### PR TITLE
inspector: do not pass BUN_INSPECT / BUN_INSPECT_NOTIFY on to child processes

### DIFF
--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -92,9 +92,6 @@ new!(pub BUN_GC_TIMER_INTERVAL: unsigned, "BUN_GC_TIMER_INTERVAL", {});
 new!(pub BUN_INOTIFY_COALESCE_INTERVAL: unsigned, "BUN_INOTIFY_COALESCE_INTERVAL", { default: 100_000 });
 new!(pub BUN_INSPECT: string, "BUN_INSPECT", { default: b"" });
 new!(pub BUN_INSPECT_CONNECT_TO: string, "BUN_INSPECT_CONNECT_TO", { default: b"" });
-// `unix://<path>` or `tcp://host:port` that the debugger thread connects to once
-// its inspector is listening. Set together with `BUN_INSPECT` by the VS Code
-// extension, which attaches when the connection arrives.
 new!(pub BUN_INSPECT_NOTIFY: string, "BUN_INSPECT_NOTIFY", { default: b"" });
 new!(pub BUN_INSPECT_PRELOAD: string, "BUN_INSPECT_PRELOAD", {});
 new!(pub BUN_INSTALL: string, "BUN_INSTALL", {});

--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -92,6 +92,10 @@ new!(pub BUN_GC_TIMER_INTERVAL: unsigned, "BUN_GC_TIMER_INTERVAL", {});
 new!(pub BUN_INOTIFY_COALESCE_INTERVAL: unsigned, "BUN_INOTIFY_COALESCE_INTERVAL", { default: 100_000 });
 new!(pub BUN_INSPECT: string, "BUN_INSPECT", { default: b"" });
 new!(pub BUN_INSPECT_CONNECT_TO: string, "BUN_INSPECT_CONNECT_TO", { default: b"" });
+// `unix://<path>` or `tcp://host:port` that the debugger thread connects to once
+// its inspector is listening. Set together with `BUN_INSPECT` by the VS Code
+// extension, which attaches when the connection arrives.
+new!(pub BUN_INSPECT_NOTIFY: string, "BUN_INSPECT_NOTIFY", { default: b"" });
 new!(pub BUN_INSPECT_PRELOAD: string, "BUN_INSPECT_PRELOAD", {});
 new!(pub BUN_INSTALL: string, "BUN_INSTALL", {});
 new!(pub BUN_INSTALL_BIN: string, "BUN_INSTALL_BIN", {});

--- a/src/js/internal/debugger.ts
+++ b/src/js/internal/debugger.ts
@@ -112,9 +112,7 @@ export default function (
   urlIsServer: boolean,
   isNodeInspector: boolean,
   reportNodeInspectorServerStarted: (url: string, controlCallback?: (message: string) => void, error?: string) => void,
-  // BUN_INSPECT_NOTIFY as read by the inspected thread at startup. It is passed
-  // in because that thread removes the launcher variables from the environment
-  // process.env is built from. Empty when unset or already delivered.
+  // BUN_INSPECT_NOTIFY; passed in because the inspected thread strips it from the env process.env is built from.
   notifyUrl: string,
 ): void {
   if (urlIsServer) {

--- a/src/js/internal/debugger.ts
+++ b/src/js/internal/debugger.ts
@@ -112,6 +112,10 @@ export default function (
   urlIsServer: boolean,
   isNodeInspector: boolean,
   reportNodeInspectorServerStarted: (url: string, controlCallback?: (message: string) => void, error?: string) => void,
+  // BUN_INSPECT_NOTIFY as read by the inspected thread at startup. It is passed
+  // in because that thread removes the launcher variables from the environment
+  // process.env is built from. Empty when unset or already delivered.
+  notifyUrl: string,
 ): void {
   if (urlIsServer) {
     connectToUnixServer(executionContextId, url, createBackend, send, close);
@@ -246,11 +250,7 @@ export default function (
     }
   }
 
-  const notifyUrl = process.env["BUN_INSPECT_NOTIFY"] || "";
   if (notifyUrl) {
-    // Only send this once.
-    process.env["BUN_INSPECT_NOTIFY"] = "";
-
     if (notifyUrl.startsWith("unix://")) {
       const path = require("node:path");
       notify({

--- a/src/jsc/Debugger.rs
+++ b/src/jsc/Debugger.rs
@@ -116,13 +116,7 @@ pub struct Debugger {
     // `'static` is genuine: borrowed from process-lifetime env-var storage;
     // default `""`.
     pub from_environment_variable: &'static [u8],
-    /// `BUN_INSPECT_NOTIFY` — where the debugger thread reports that its
-    /// inspector is listening (see `internal/debugger.ts`). Carried here rather
-    /// than read back out of `process.env` on the debugger thread because the
-    /// launcher variables are removed from the VM's environment before that
-    /// thread starts (`VirtualMachine::load_extra_env_and_source_code_printer`).
-    /// Same `'static` env-var storage as `from_environment_variable`; `""` when
-    /// unset.
+    /// `BUN_INSPECT_NOTIFY` (`""` if unset); gone from the env map by the time it is needed.
     pub notify: &'static [u8],
     pub script_execution_context_id: u32,
     pub next_debugger_id: u64,

--- a/src/jsc/Debugger.rs
+++ b/src/jsc/Debugger.rs
@@ -116,6 +116,14 @@ pub struct Debugger {
     // `'static` is genuine: borrowed from process-lifetime env-var storage;
     // default `""`.
     pub from_environment_variable: &'static [u8],
+    /// `BUN_INSPECT_NOTIFY` — where the debugger thread reports that its
+    /// inspector is listening (see `internal/debugger.ts`). Carried here rather
+    /// than read back out of `process.env` on the debugger thread because the
+    /// launcher variables are removed from the VM's environment before that
+    /// thread starts (`VirtualMachine::load_extra_env_and_source_code_printer`).
+    /// Same `'static` env-var storage as `from_environment_variable`; `""` when
+    /// unset.
+    pub notify: &'static [u8],
     pub script_execution_context_id: u32,
     pub next_debugger_id: u64,
     pub poll_ref: KeepAlive,
@@ -139,6 +147,7 @@ impl Default for Debugger {
         Self {
             path_or_port: None,
             from_environment_variable: b"",
+            notify: b"",
             script_execution_context_id: 0,
             next_debugger_id: 1,
             poll_ref: KeepAlive::default(),
@@ -168,6 +177,7 @@ unsafe extern "C" {
         from_env: c_int,
         is_connect: bool,
         is_node_inspector: bool,
+        notify: &BunString,
     );
 }
 
@@ -183,6 +193,7 @@ struct DebuggerThreadInit {
     is_node_inspector: bool,
     from_env: &'static [u8],
     path_or_port: Option<&'static [u8]>,
+    notify: &'static [u8],
 }
 
 impl Debugger {
@@ -406,6 +417,7 @@ impl Debugger {
                 is_node_inspector: dbg.protocol == Protocol::NodeInspector,
                 from_env: dbg.from_environment_variable,
                 path_or_port: dbg.path_or_port,
+                notify: dbg.notify,
             };
             // Rust's `std::thread` default stack (2 MiB) is too small to run
             // a full `VirtualMachine::init` + JS module load on this thread,
@@ -484,18 +496,30 @@ impl Debugger {
             is_node_inspector,
             from_env,
             path_or_port,
+            mut notify,
         } = init;
 
         if !from_env.is_empty() {
             let url = BunString::borrow_utf8(from_env);
+            // The launcher is told once, by whichever server comes up first.
+            let notify_url = BunString::borrow_utf8(core::mem::take(&mut notify));
             let _scope = this.enter_event_loop_scope();
-            Bun__startJSDebuggerThread(global, ctx_id, &url, 1, is_connect, false);
+            Bun__startJSDebuggerThread(global, ctx_id, &url, 1, is_connect, false, &notify_url);
         }
 
         if let Some(path_or_port) = path_or_port {
             let url = BunString::borrow_utf8(path_or_port);
+            let notify_url = BunString::borrow_utf8(core::mem::take(&mut notify));
             let _scope = this.enter_event_loop_scope();
-            Bun__startJSDebuggerThread(global, ctx_id, &url, 0, is_connect, is_node_inspector);
+            Bun__startJSDebuggerThread(
+                global,
+                ctx_id,
+                &url,
+                0,
+                is_connect,
+                is_node_inspector,
+                &notify_url,
+            );
         }
 
         let _ = this.global().handle_rejected_promises();

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -3563,23 +3563,9 @@ impl VirtualMachine {
             self.transpiler_store.enabled = false;
         }
 
-        // `BUN_INSPECT` / `BUN_INSPECT_NOTIFY` are addressed to this one process
-        // (`configure_debugger` consumed them at VM init), like `NODE_CHANNEL_FD`
-        // below. Left in the map they reach `process.env` and every child's
-        // environment, and each child `bun` then brings up a second inspector on
-        // the same socket/port (EADDRINUSE, exit 1) or waits for a frontend that
-        // never comes. Done per VM because a worker's loader re-reads the process
-        // environment. `BUN_INSPECT_CONNECT_TO` is different: it is set on a whole
-        // terminal and means every bun process should connect, children included.
-        if bun_core::env_var::BUN_INSPECT.get_not_empty().is_some() {
-            map.remove(b"BUN_INSPECT");
-        }
-        if bun_core::env_var::BUN_INSPECT_NOTIFY
-            .get_not_empty()
-            .is_some()
-        {
-            map.remove(b"BUN_INSPECT_NOTIFY");
-        }
+        // Consumed by `configure_debugger`; a child inheriting them starts a second inspector.
+        map.remove(b"BUN_INSPECT");
+        map.remove(b"BUN_INSPECT_NOTIFY");
 
         if let Some(idx) = map.map.get_index(b"NODE_CHANNEL_FD") {
             let (_, kv) = map.map.swap_remove_at(idx);

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -3563,6 +3563,24 @@ impl VirtualMachine {
             self.transpiler_store.enabled = false;
         }
 
+        // `BUN_INSPECT` / `BUN_INSPECT_NOTIFY` are addressed to this one process
+        // (`configure_debugger` consumed them at VM init), like `NODE_CHANNEL_FD`
+        // below. Left in the map they reach `process.env` and every child's
+        // environment, and each child `bun` then brings up a second inspector on
+        // the same socket/port (EADDRINUSE, exit 1) or waits for a frontend that
+        // never comes. Done per VM because a worker's loader re-reads the process
+        // environment. `BUN_INSPECT_CONNECT_TO` is different: it is set on a whole
+        // terminal and means every bun process should connect, children included.
+        if bun_core::env_var::BUN_INSPECT.get_not_empty().is_some() {
+            map.remove(b"BUN_INSPECT");
+        }
+        if bun_core::env_var::BUN_INSPECT_NOTIFY
+            .get_not_empty()
+            .is_some()
+        {
+            map.remove(b"BUN_INSPECT_NOTIFY");
+        }
+
         if let Some(idx) = map.map.get_index(b"NODE_CHANNEL_FD") {
             let (_, kv) = map.map.swap_remove_at(idx);
             let fd_s = kv.value;

--- a/src/jsc/bindings/BunDebugger.cpp
+++ b/src/jsc/bindings/BunDebugger.cpp
@@ -951,7 +951,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_closeNodeInspector, (JSGlobalObject*, CallFr
     return JSValue::encode(jsUndefined());
 }
 
-extern "C" void Bun__startJSDebuggerThread(Zig::GlobalObject* debuggerGlobalObject, ScriptExecutionContextIdentifier scriptId, const BunString* portOrPathString, int isAutomatic, bool isUrlServer, bool isNodeInspector)
+extern "C" void Bun__startJSDebuggerThread(Zig::GlobalObject* debuggerGlobalObject, ScriptExecutionContextIdentifier scriptId, const BunString* portOrPathString, int isAutomatic, bool isUrlServer, bool isNodeInspector, const BunString* notifyUrlString)
 {
     if (!debuggerScriptExecutionContext)
         debuggerScriptExecutionContext = debuggerGlobalObject->scriptExecutionContext();
@@ -970,6 +970,10 @@ extern "C" void Bun__startJSDebuggerThread(Zig::GlobalObject* debuggerGlobalObje
         return;
     }
     arguments.append(portOrPathJS);
+    auto* notifyUrlJS = Bun::toJS(debuggerGlobalObject, *notifyUrlString);
+    if (!notifyUrlJS) [[unlikely]] {
+        return;
+    }
     arguments.append(JSFunction::create(vm, debuggerGlobalObject, 3, String(), jsFunctionCreateConnection, ImplementationVisibility::Public));
     arguments.append(JSFunction::create(vm, debuggerGlobalObject, 1, String("send"_s), jsFunctionSend, ImplementationVisibility::Public));
     arguments.append(JSFunction::create(vm, debuggerGlobalObject, 0, String("disconnect"_s), jsFunctionDisconnect, ImplementationVisibility::Public));
@@ -977,6 +981,7 @@ extern "C" void Bun__startJSDebuggerThread(Zig::GlobalObject* debuggerGlobalObje
     arguments.append(jsBoolean(isUrlServer));
     arguments.append(jsBoolean(isNodeInspector));
     arguments.append(JSFunction::create(vm, debuggerGlobalObject, 3, String("reportNodeInspectorServerStarted"_s), jsFunctionReportNodeInspectorServerStarted, ImplementationVisibility::Public));
+    arguments.append(notifyUrlJS);
 
     JSC::call(debuggerGlobalObject, debuggerDefaultFn, arguments, "Bun__initJSDebuggerThread - debuggerDefaultFn"_s);
     scope.assertNoException();

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -590,6 +590,7 @@ unsafe fn configure_debugger(
 
     let unix: &'static [u8] = env_var::BUN_INSPECT.get().unwrap_or(b"");
     let connect_to: &'static [u8] = env_var::BUN_INSPECT_CONNECT_TO.get().unwrap_or(b"");
+    let notify: &'static [u8] = env_var::BUN_INSPECT_NOTIFY.get().unwrap_or(b"");
 
     let set_breakpoint_on_first_line = !unix.is_empty() && unix.ends_with(b"?break=1");
     let wait_for_debugger = !unix.is_empty() && unix.ends_with(b"?wait=1");
@@ -606,6 +607,7 @@ unsafe fn configure_debugger(
                 Some(Debugger {
                     path_or_port: None,
                     from_environment_variable: unix,
+                    notify,
                     wait_for_connection,
                     set_breakpoint_on_first_line,
                     ..Default::default()
@@ -630,6 +632,7 @@ unsafe fn configure_debugger(
             Some(Debugger {
                 path_or_port: Some(path_or_port),
                 from_environment_variable: unix,
+                notify,
                 wait_for_connection: if enable.wait_for_connection {
                     Wait::Forever
                 } else {

--- a/test/cli/inspect/inspect-launcher-env.test.ts
+++ b/test/cli/inspect/inspect-launcher-env.test.ts
@@ -1,0 +1,121 @@
+import { spawn } from "bun";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isPosix, tempDir } from "harness";
+import { join } from "node:path";
+
+// A debugger frontend (the VS Code extension, bun-debug-adapter-protocol)
+// launches a program with BUN_INSPECT pointing at the socket it should listen
+// on and BUN_INSPECT_NOTIFY pointing at where to say that it is listening. Both
+// are addressed to that one process: anything the program spawns must not see
+// them, or every child `bun` tries to bring up an inspector on the same address.
+// BUN_INSPECT_CONNECT_TO is different: it is set on a whole terminal and every
+// bun process started in it, children included, is meant to connect.
+const fixture = join(import.meta.dir, "launcher-env-fixture.ts");
+
+function expectedReport(connectTo: string) {
+  const env = { BUN_INSPECT: null, BUN_INSPECT_NOTIFY: null, BUN_INSPECT_CONNECT_TO: connectTo };
+  return {
+    self: env,
+    worker: env,
+    "node:child_process": { exitCode: 0, env },
+    "Bun.spawn": { exitCode: 0, env },
+  };
+}
+
+// Nothing listens here, so whatever is told to connect to it fails at once.
+function unusedTcpAddress(): string {
+  using probe = Bun.listen({ hostname: "127.0.0.1", port: 0, socket: { data() {} } });
+  return `tcp://127.0.0.1:${probe.port}`;
+}
+
+describe.concurrent("BUN_INSPECT launch environment", () => {
+  test("BUN_INSPECT and BUN_INSPECT_NOTIFY stop at the launched program; BUN_INSPECT_CONNECT_TO is passed on", async () => {
+    const connectTo = unusedTcpAddress();
+    await using proc = spawn({
+      cmd: [bunExe(), fixture],
+      env: {
+        ...bunEnv,
+        BUN_INSPECT: `ws://127.0.0.1:0/${crypto.randomUUID()}`,
+        BUN_INSPECT_NOTIFY: unusedTcpAddress(),
+        BUN_INSPECT_CONNECT_TO: connectTo,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual(expectedReport(connectTo));
+    expect(exitCode).toBe(0);
+  });
+
+  // The full launch sequence as the extension runs it on POSIX: the program
+  // listens on the unix socket named by BUN_INSPECT and waits, reports to
+  // BUN_INSPECT_NOTIFY, we attach, and only then does the program run. A child
+  // inheriting BUN_INSPECT here would try to listen on the very socket we are
+  // attached to and die with EADDRINUSE before running a line of its own code.
+  test.skipIf(!isPosix).each(["unix", "tcp"])(
+    "children of a program launched by a debugger run undebugged (notified over %s)",
+    async notifyTransport => {
+      using dir = tempDir("inspect-launch", {});
+      const inspectorSocket = join(String(dir), "inspector.sock");
+      const notifySocket = join(String(dir), "notify.sock");
+
+      const notified = Promise.withResolvers<string>();
+      const socket = {
+        data(_socket: unknown, data: Buffer) {
+          notified.resolve(data.toString());
+        },
+        error(_socket: unknown, error: Error) {
+          notified.reject(error);
+        },
+      };
+      using signal =
+        notifyTransport === "unix"
+          ? Bun.listen({ unix: notifySocket, socket })
+          : Bun.listen({ hostname: "127.0.0.1", port: 0, socket });
+      const notifyUrl = notifyTransport === "unix" ? `unix://${notifySocket}` : `tcp://127.0.0.1:${signal.port}`;
+
+      const connectTo = unusedTcpAddress();
+      await using proc = spawn({
+        cmd: [bunExe(), fixture],
+        env: {
+          ...bunEnv,
+          BUN_INSPECT: `ws+unix://${inspectorSocket}?wait=1`,
+          BUN_INSPECT_NOTIFY: notifyUrl,
+          BUN_INSPECT_CONNECT_TO: connectTo,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const exitedEarly = proc.exited.then(code => {
+        throw new Error(`program exited with ${code} before a frontend attached`);
+      });
+      exitedEarly.catch(() => {});
+
+      expect(await Promise.race([notified.promise, exitedEarly])).toBe("1");
+
+      const frontend = new globalThis.WebSocket(`ws+unix://${inspectorSocket}`);
+      try {
+        await Promise.race([
+          new Promise<void>((resolve, reject) => {
+            frontend.onopen = () => resolve();
+            frontend.onerror = event => reject(new Error("could not attach", { cause: event }));
+            frontend.onclose = event => reject(new Error(`inspector closed the connection: ${event.code}`));
+          }),
+          exitedEarly,
+        ]);
+        frontend.send(JSON.stringify({ id: 1, method: "Inspector.enable" }));
+        frontend.send(JSON.stringify({ id: 2, method: "Inspector.initialized" }));
+
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+        expect(stderr).toBe("");
+        expect(JSON.parse(stdout)).toEqual(expectedReport(connectTo));
+        expect(exitCode).toBe(0);
+      } finally {
+        frontend.close();
+      }
+    },
+  );
+});

--- a/test/cli/inspect/inspect-launcher-env.test.ts
+++ b/test/cli/inspect/inspect-launcher-env.test.ts
@@ -1,4 +1,4 @@
-import { spawn } from "bun";
+import { spawn, type Subprocess } from "bun";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isPosix, tempDir } from "harness";
 import { join } from "node:path";
@@ -28,6 +28,80 @@ function unusedTcpAddress(): string {
   return `tcp://127.0.0.1:${probe.port}`;
 }
 
+// The BUN_INSPECT_NOTIFY side of the launcher: collects what connects to it.
+function notifyListener(address: { unix: string } | { tcp: true }) {
+  const first = Promise.withResolvers<string>();
+  const received: string[] = [];
+  const socket = {
+    data(_socket: unknown, data: Buffer) {
+      received.push(data.toString());
+      first.resolve(received[0]);
+    },
+    error(_socket: unknown, error: Error) {
+      first.reject(error);
+    },
+  };
+  const listener =
+    "unix" in address
+      ? Bun.listen({ unix: address.unix, socket })
+      : Bun.listen({ hostname: "127.0.0.1", port: 0, socket });
+  return {
+    url: "unix" in address ? `unix://${address.unix}` : `tcp://127.0.0.1:${listener.port}`,
+    first: first.promise,
+    received,
+    [Symbol.dispose]() {
+      listener.stop(true);
+    },
+  };
+}
+
+// Rejects as soon as the program exits; raced against things it must do first.
+function exitsTooEarly(proc: Subprocess): Promise<never> {
+  const exited = proc.exited.then(code => {
+    throw new Error(`program exited with ${code} first`);
+  });
+  exited.catch(() => {});
+  return exited;
+}
+
+// Attach to a program started in wait mode and let it run.
+async function attach(url: string, proc: Subprocess): Promise<WebSocket> {
+  const frontend = new WebSocket(url);
+  try {
+    await Promise.race([
+      new Promise<void>((resolve, reject) => {
+        frontend.onopen = () => resolve();
+        frontend.onerror = event => reject(new Error("could not attach", { cause: event }));
+        frontend.onclose = event => reject(new Error(`inspector closed the connection: ${event.code}`));
+      }),
+      exitsTooEarly(proc),
+    ]);
+  } catch (error) {
+    frontend.close();
+    throw error;
+  }
+  frontend.send(JSON.stringify({ id: 1, method: "Inspector.enable" }));
+  frontend.send(JSON.stringify({ id: 2, method: "Inspector.initialized" }));
+  return frontend;
+}
+
+// `--inspect-wait` prints the URL it is serving on; BUN_INSPECT does not.
+function printedInspectorUrl(proc: Subprocess<"ignore", "pipe", "pipe">) {
+  const url = Promise.withResolvers<string>();
+  const decoder = new TextDecoder();
+  let text = "";
+  const stderr = (async () => {
+    for await (const chunk of proc.stderr) {
+      text += decoder.decode(chunk, { stream: true });
+      const line = text.split("\n").find(line => line.trimStart().startsWith("ws://"));
+      if (line) url.resolve(line.trim());
+    }
+    url.reject(new Error(`no inspector URL in stderr:\n${text}`));
+    return text;
+  })();
+  return { url: url.promise, stderr };
+}
+
 describe.concurrent("BUN_INSPECT launch environment", () => {
   test("BUN_INSPECT and BUN_INSPECT_NOTIFY stop at the launched program; BUN_INSPECT_CONNECT_TO is passed on", async () => {
     const connectTo = unusedTcpAddress();
@@ -49,65 +123,36 @@ describe.concurrent("BUN_INSPECT launch environment", () => {
     expect(exitCode).toBe(0);
   });
 
-  // The full launch sequence as the extension runs it on POSIX: the program
-  // listens on the unix socket named by BUN_INSPECT and waits, reports to
+  // The launch sequence as the extension runs it on POSIX: the program listens
+  // on the unix socket named by BUN_INSPECT and waits, reports to
   // BUN_INSPECT_NOTIFY, we attach, and only then does the program run. A child
-  // inheriting BUN_INSPECT here would try to listen on the very socket we are
-  // attached to and die with EADDRINUSE before running a line of its own code.
-  test.skipIf(!isPosix).each(["unix", "tcp"])(
+  // inheriting BUN_INSPECT here tries to listen on the very socket we are
+  // attached to and dies with EADDRINUSE before running a line of its own code.
+  test.skipIf(!isPosix).each(["unix", "tcp"] as const)(
     "children of a program launched by a debugger run undebugged (notified over %s)",
     async notifyTransport => {
       using dir = tempDir("inspect-launch", {});
       const inspectorSocket = join(String(dir), "inspector.sock");
-      const notifySocket = join(String(dir), "notify.sock");
-
-      const notified = Promise.withResolvers<string>();
-      const socket = {
-        data(_socket: unknown, data: Buffer) {
-          notified.resolve(data.toString());
-        },
-        error(_socket: unknown, error: Error) {
-          notified.reject(error);
-        },
-      };
-      using signal =
-        notifyTransport === "unix"
-          ? Bun.listen({ unix: notifySocket, socket })
-          : Bun.listen({ hostname: "127.0.0.1", port: 0, socket });
-      const notifyUrl = notifyTransport === "unix" ? `unix://${notifySocket}` : `tcp://127.0.0.1:${signal.port}`;
-
+      using notify = notifyListener(
+        notifyTransport === "unix" ? { unix: join(String(dir), "notify.sock") } : { tcp: true },
+      );
       const connectTo = unusedTcpAddress();
+
       await using proc = spawn({
         cmd: [bunExe(), fixture],
         env: {
           ...bunEnv,
           BUN_INSPECT: `ws+unix://${inspectorSocket}?wait=1`,
-          BUN_INSPECT_NOTIFY: notifyUrl,
+          BUN_INSPECT_NOTIFY: notify.url,
           BUN_INSPECT_CONNECT_TO: connectTo,
         },
         stdout: "pipe",
         stderr: "pipe",
       });
-      const exitedEarly = proc.exited.then(code => {
-        throw new Error(`program exited with ${code} before a frontend attached`);
-      });
-      exitedEarly.catch(() => {});
+      expect(await Promise.race([notify.first, exitsTooEarly(proc)])).toBe("1");
 
-      expect(await Promise.race([notified.promise, exitedEarly])).toBe("1");
-
-      const frontend = new globalThis.WebSocket(`ws+unix://${inspectorSocket}`);
+      const frontend = await attach(`ws+unix://${inspectorSocket}`, proc);
       try {
-        await Promise.race([
-          new Promise<void>((resolve, reject) => {
-            frontend.onopen = () => resolve();
-            frontend.onerror = event => reject(new Error("could not attach", { cause: event }));
-            frontend.onclose = event => reject(new Error(`inspector closed the connection: ${event.code}`));
-          }),
-          exitedEarly,
-        ]);
-        frontend.send(JSON.stringify({ id: 1, method: "Inspector.enable" }));
-        frontend.send(JSON.stringify({ id: 2, method: "Inspector.initialized" }));
-
         const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
         expect(stderr).toBe("");
@@ -118,4 +163,40 @@ describe.concurrent("BUN_INSPECT launch environment", () => {
       }
     },
   );
+
+  // The notification is also sent for an inspector started from the command
+  // line, and once when both are configured (BUN_INSPECT's server starts first
+  // and is the one that reports).
+  test.each([
+    ["--inspect-wait", {}],
+    ["--inspect-wait together with BUN_INSPECT", { BUN_INSPECT: `ws://127.0.0.1:0/${crypto.randomUUID()}` }],
+  ])("%s reports to BUN_INSPECT_NOTIFY once", async (_, inspectEnv) => {
+    using notify = notifyListener({ tcp: true });
+    await using proc = spawn({
+      cmd: [
+        bunExe(),
+        "--inspect-wait=127.0.0.1:0",
+        "-e",
+        `Bun.write(Bun.stdout, "ran\\n").then(() => process.exit(0))`,
+      ],
+      env: { ...bunEnv, ...inspectEnv, BUN_INSPECT_NOTIFY: notify.url },
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const printed = printedInspectorUrl(proc);
+    const url = await Promise.race([printed.url, exitsTooEarly(proc)]);
+    expect(await Promise.race([notify.first, exitsTooEarly(proc)])).toBe("1");
+
+    const frontend = await attach(url, proc);
+    try {
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited, printed.stderr]);
+
+      expect(stdout).toBe("ran\n");
+      expect(exitCode).toBe(0);
+      expect(notify.received).toEqual(["1"]);
+    } finally {
+      frontend.close();
+    }
+  });
 });

--- a/test/cli/inspect/inspect-launcher-env.test.ts
+++ b/test/cli/inspect/inspect-launcher-env.test.ts
@@ -93,7 +93,11 @@ function printedInspectorUrl(proc: Subprocess<"ignore", "pipe", "pipe">) {
   const stderr = (async () => {
     for await (const chunk of proc.stderr) {
       text += decoder.decode(chunk, { stream: true });
-      const line = text.split("\n").find(line => line.trimStart().startsWith("ws://"));
+      // Only complete lines: the last element is whatever follows the final newline so far.
+      const line = text
+        .split("\n")
+        .slice(0, -1)
+        .find(line => line.trimStart().startsWith("ws://"));
       if (line) url.resolve(line.trim());
     }
     url.reject(new Error(`no inspector URL in stderr:\n${text}`));

--- a/test/cli/inspect/launcher-env-fixture.ts
+++ b/test/cli/inspect/launcher-env-fixture.ts
@@ -20,8 +20,9 @@ if (!Bun.isMainThread) {
   }
 
   const worker = new Worker(import.meta.url);
-  const fromWorker = await new Promise(resolve => {
+  const fromWorker = await new Promise((resolve, reject) => {
     worker.onmessage = event => resolve(event.data);
+    worker.onerror = event => reject(event.error ?? new Error(event.message));
   });
   worker.terminate();
 

--- a/test/cli/inspect/launcher-env-fixture.ts
+++ b/test/cli/inspect/launcher-env-fixture.ts
@@ -1,0 +1,44 @@
+// Launched with BUN_INSPECT (and BUN_INSPECT_NOTIFY) set, the way a debugger
+// frontend launches the program it wants to debug. Reports whether those
+// variables are still visible to the program itself, to a worker it starts, and
+// to bun processes it spawns through node:child_process and Bun.spawn.
+import { spawnSync } from "node:child_process";
+
+const KEYS = ["BUN_INSPECT", "BUN_INSPECT_NOTIFY", "BUN_INSPECT_CONNECT_TO"];
+const visible = () => Object.fromEntries(KEYS.map(key => [key, process.env[key] ?? null]));
+
+if (!Bun.isMainThread) {
+  postMessage(visible());
+} else {
+  const grandchildArgs = [
+    "-e",
+    `console.log(JSON.stringify(Object.fromEntries(${JSON.stringify(KEYS)}.map(key => [key, process.env[key] ?? null]))))`,
+  ];
+
+  function report(exitCode: number | null, stdout: string, stderr: string) {
+    return exitCode === 0 ? { exitCode, env: JSON.parse(stdout) } : { exitCode, stderr: stderr.split("\n", 1)[0] };
+  }
+
+  const worker = new Worker(import.meta.url);
+  const fromWorker = await new Promise(resolve => {
+    worker.onmessage = event => resolve(event.data);
+  });
+  worker.terminate();
+
+  // No `env` option on either call: each child gets whatever this process hands
+  // to children by default.
+  const viaChildProcess = spawnSync(process.execPath, grandchildArgs, { encoding: "utf8", timeout: 30_000 });
+  const viaBunSpawn = Bun.spawnSync({ cmd: [process.execPath, ...grandchildArgs], timeout: 30_000 });
+
+  await Bun.write(
+    Bun.stdout,
+    JSON.stringify({
+      self: visible(),
+      worker: fromWorker,
+      "node:child_process": report(viaChildProcess.status, viaChildProcess.stdout, viaChildProcess.stderr),
+      "Bun.spawn": report(viaBunSpawn.exitCode, viaBunSpawn.stdout.toString(), viaBunSpawn.stderr.toString()),
+    }) + "\n",
+  );
+  // An attached frontend keeps the event loop alive, so end explicitly.
+  process.exit(0);
+}

--- a/test/regression/issue/test_env_loader_threading.test.ts
+++ b/test/regression/issue/test_env_loader_threading.test.ts
@@ -62,10 +62,10 @@ test("env_loader should not have allocator threading issues with BUN_INSPECT_CON
 // environment as it is: not parse it again (the define setup JSON-parses NODE_ENV and fails on a value
 // that is not valid JSON) and not load .env files of its own into the process.
 //
-// Once that VM is up, the debugger thread connects to BUN_INSPECT_NOTIFY (src/js/internal/debugger.ts)
-// through its own process.env. The fixtures wait for stdin, which is closed after that notification,
-// so what they print was observed after the debugger thread finished its setup. A debugger thread
-// that aborts takes the process down before the notification instead.
+// Once that VM is up, the debugger thread connects to BUN_INSPECT_NOTIFY (src/js/internal/debugger.ts).
+// The fixtures wait for stdin, which is closed after that notification, so what they print was
+// observed after the debugger thread finished its setup. A debugger thread that aborts takes the
+// process down before the notification instead.
 async function runUnderInspector(cmd: string[], cwd: string, env: Record<string, string | undefined>) {
   const { promise: notified, resolve: onNotified } = Promise.withResolvers<string>();
   using listener = Bun.listen({


### PR DESCRIPTION
### Problem

- A program launched under the debugger (VS Code extension, `bun-debug-adapter-protocol`: `BUN_INSPECT=ws+unix://<tmp>/<id>.sock?wait=1` on POSIX, `ws://127.0.0.1:<port>/<id>?wait=1` on Windows, plus `BUN_INSPECT_NOTIFY`) passes both variables on to every `bun` process it spawns. Each child brings up its own inspector on the same address and dies before running any of its code: `Failed to start inspector:` followed by an `internal:debugger` source dump and `EADDRINUSE: address already in use, listen '<sock>'`, exit code 1. With a port of 0 in the URL the child instead binds a port nobody knows about and, with `?wait=1`, waits forever.
- Cause: `configure_debugger` (`src/runtime/jsc_hooks.rs:585`) reads the variables from the process environment at VM init, but they are also copied into the VM's env map by `load_process()`, and that map is what `process.env` (`node:child_process`), `Bun.spawn`'s default environment and the shell build a child's environment from. Nothing removed them. `internal/debugger.ts` cleared `process.env.BUN_INSPECT_NOTIFY`, but on the debugger thread's own `process.env`, which no child is built from.

### Fix

- `VirtualMachine::load_extra_env_and_source_code_printer` (`src/jsc/VirtualMachine.rs`) removes `BUN_INSPECT` and `BUN_INSPECT_NOTIFY` from the env map, where `NODE_CHANNEL_FD` is already removed for the same reason (`bunx bun-repl` strips the same variables the same way). Unconditional like those two: bun only ever acts on the values found in the process environment, so a copy that came from a `.env` file was inert for the program itself and now is for its children as well. It runs for every VM, so a worker (whose loader re-reads the process environment into its own map) does not hand them out either. The real process environment is untouched: `--watch` re-execs with it, and the reloaded program is meant to be debugged again (checked: a `--watch` program under `BUN_INSPECT` still notifies once per incarnation).
- `BUN_INSPECT_CONNECT_TO` is deliberately left in place. The extension sets it on the whole terminal and every bun process started there, children included, is supposed to connect (`packages/bun-vscode/src/features/diagnostics/diagnostics.ts`; `test/harness.ts` strips it from `bunEnv` for the same reason).
- The debugger thread's VM is built from a copy of the main VM's env map (#39996), taken after this removal, so it can no longer find `BUN_INSPECT_NOTIFY` in its `process.env`. `configure_debugger` now captures it next to `BUN_INSPECT` (new `Debugger.notify`, `bun_core::env_var::BUN_INSPECT_NOTIFY`), `Debugger::start` hands it to `Bun__startJSDebuggerThread`, and `internal/debugger.ts` receives it as an argument. It is passed with the first server started and cleared for the second, which keeps the existing "notify once" behavior when `--inspect` and `BUN_INSPECT` are both given. Compared with the release binary across the five start modes (CLI flag, env, both, `BUN_INSPECT_CONNECT_TO`, none): the notification arrives in the same three and stays absent in the same two.
- `test/cli/inspect/inspect-launcher-env.test.ts` (+ `launcher-env-fixture.ts`), five cases. One launches the fixture with all three variables and checks what the program, a worker, a `node:child_process` child and a `Bun.spawn` child see. Two (POSIX) run the real launch sequence: listen on a unix socket and wait, notify (over `unix://` and over `tcp://`), attach over WebSocket, `Inspector.initialized`, then the program spawns children. Two pin the notify plumbing for the CLI path: `--inspect-wait`, alone and together with `BUN_INSPECT`, must report to `BUN_INSPECT_NOTIFY` exactly once. On an unmodified release binary the first three fail, the launch-sequence ones with both children reporting `exitCode: 1, stderr: "Failed to start inspector:"`, and the two notify cases pass (they guard existing behavior); with this change all five pass, and stay green across 10 runs including 4 copies in parallel. Also run: the rest of `test/cli/inspect`, `test/js/node/inspector`, `test/regression/issue/test_env_loader_threading.test.ts`, `28159.test.ts`, `spawn-env.test.ts`, `bun-ipc-inherit.test.ts`, the source lints; clippy and formatting on the touched crates.
- The test is in its own file rather than in `inspect.test.ts` because that file's `localhost` cases fail in this environment on the release binary too (`localhost` resolution), which would hide whether the new cases pass; `test/cli/inspect` is already split into one file per topic.

### Background

- Env map: each VM owns a map of environment variables, filled from the process environment (`load_process()`) and then from `.env` files. `process.env` is created from it on first access, and `Bun.spawn` without `env` serializes it for the child, so it is the single place where a variable can be kept from children. The real C environment is separate and only matters for code that reads it directly, such as the `--watch` re-exec.
- Launch protocol: a frontend sets `BUN_INSPECT` to the address the program should serve the inspector on (`?wait=1` makes it block until a frontend attaches) and `BUN_INSPECT_NOTIFY` to a socket the program connects to once the inspector is up; the frontend attaches when that connection arrives. `BUN_INSPECT_CONNECT_TO` is the reverse mode: the program connects out to a socket the frontend is already listening on, which works for any number of processes at once.
- Debugger thread: with an inspector configured, bun runs the inspector server (`internal/debugger.ts`) on a second VM in its own thread. Since #39996 that VM gets its own loader holding a copy of the main VM's env map, made in `Debugger::create`. After this change the thread reads nothing from any environment; it gets the notify address as an argument.
- Related: the fatal listen failure itself (the child could instead run undebugged, as node does) is a separate item and unchanged here. While checking `--watch` I found that a `ws+unix://` `BUN_INSPECT` program dies with the same `EADDRINUSE` on its first reload because its own previous socket file is still on disk; that is also separate and has been filed on its own.

<details>
<summary>Test output on the unmodified release binary</summary>

```
(fail) BUN_INSPECT launch environment > BUN_INSPECT and BUN_INSPECT_NOTIFY stop at the launched program; BUN_INSPECT_CONNECT_TO is passed on
    "self": {
-     "BUN_INSPECT": null,
+     "BUN_INSPECT": "ws://127.0.0.1:0/cd2e5357-00a3-47ea-a15b-e7495a2f2034",
      "BUN_INSPECT_CONNECT_TO": "tcp://127.0.0.1:40209",
-     "BUN_INSPECT_NOTIFY": null,
+     "BUN_INSPECT_NOTIFY": "tcp://127.0.0.1:38845",
    (same for "worker", and for the "env" of both children)

(fail) BUN_INSPECT launch environment > children of a program launched by a debugger run undebugged (notified over unix)
    "Bun.spawn": {
-     "env": { ... },
-     "exitCode": 0,
+     "exitCode": 1,
+     "stderr": "Failed to start inspector:",
    },
    "node:child_process": {
-     "env": { ... },
-     "exitCode": 0,
+     "exitCode": 1,
+     "stderr": "Failed to start inspector:",
    },
    "self": {
-     "BUN_INSPECT": null,
+     "BUN_INSPECT": "ws+unix:///tmp/inspect-launch_nzDniT/inspector.sock?wait=1",
      "BUN_INSPECT_CONNECT_TO": "tcp://127.0.0.1:32921",
-     "BUN_INSPECT_NOTIFY": null,
+     "BUN_INSPECT_NOTIFY": "unix:///tmp/inspect-launch_nzDniT/notify.sock",
    },
    "worker": { same as "self" }
```

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 5 · 9 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/inspect/inspect-launcher-env.test.ts test/regression/issue/test_env_loader_threading.test.ts
bun test v1.4.1 (4448a2e21)

test/regression/issue/test_env_loader_threading.test.ts:
(pass) env_loader should not have allocator threading issues with BUN_INSPECT_CONNECT_TO [591.36ms]
(pass) --inspect starts when BUN_ENV holds a value that is not valid JSON [444.93ms]
(pass) --inspect starts when NODE_ENV holds a value that is not valid JSON [487.47ms]
(pass) the debugger thread does not load .env files into a bun test process [737.08ms]
(pass) inspector.open() starts when BUN_ENV holds a value that is not valid JSON [1472.98ms]
(pass) inspector.open() starts when NODE_ENV holds a value that is not valid JSON [1500.24ms]

test/cli/inspect/inspect-launcher-env.test.ts:
(pass) BUN_INSPECT launch environment > --inspect-wait reports to BUN_INSPECT_NOTIFY once [504.25ms]
(pass) BUN_INSPECT launch environment > --inspect-wait together with BUN_INSPECT reports to BUN_INSPECT_NOTIFY once [482.96ms]
121 |       stderr: "pipe",
122 |     });

... (truncated)

release without fix: all passed
bun test v1.4.1-canary.1 (518db30db)

test/regression/issue/test_env_loader_threading.test.ts:
(pass) env_loader should not have allocator threading issues with BUN_INSPECT_CONNECT_TO [11.99ms]
(pass) --inspect starts when NODE_ENV holds a value that is not valid JSON [10.50ms]
(pass) --inspect starts when BUN_ENV holds a value that is not valid JSON [9.34ms]
(pass) the debugger thread does not load .env files into a bun test process [14.38ms]
(pass) inspector.open() starts when NODE_ENV holds a value that is not valid JSON [23.56ms]
(pass) inspector.open() starts when BUN_ENV holds a value that is not valid JSON [23.29ms]

test/cli/inspect/inspect-launcher-env.test.ts:
(pass) BUN_INSPECT launch environment > --inspect-wait reports to BUN_INSPECT_NOTIFY once [10.62ms]
(pass) BUN_INSPECT launch environment > --inspect-wait together with BUN_INSPECT reports to BUN_INSPECT_NOTIFY once [10.06ms]
(pass) BUN_INSPECT launch environment > BUN_INSPECT and BUN_INSPECT_NOTIFY stop at the launched program; BUN_INSPECT_CONNECT_TO is passed on [25.51ms]
(pass) BUN_INSPECT launch environment > children of a program launched by a debugger run undebugged (notified over unix) [29.40m
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/inspect/inspect-launcher-env.test.ts test/regression/issue/test_env_loader_threading.test.ts
bun test v1.4.1 (4448a2e21)

test/regression/issue/test_env_loader_threading.test.ts:
(pass) env_loader should not have allocator threading issues with BUN_INSPECT_CONNECT_TO [583.45ms]
(pass) --inspect starts when NODE_ENV holds a value that is not valid JSON [477.92ms]
(pass) --inspect starts when BUN_ENV holds a value that is not valid JSON [444.99ms]
(pass) the debugger thread does not load .env files into a bun test process [731.98ms]
(pass) inspector.open() starts when NODE_ENV holds a value that is not valid JSON [1491.41ms]
(pass) inspector.open() starts when BUN_ENV holds a value that is not valid JSON [1482.97ms]

test/cli/inspect/inspect-launcher-env.test.ts:
(pass) BUN_INSPECT launch environment > --inspect-wait reports to BUN_INSPECT_NOTIFY once [510.67ms]
(pass) BUN_INSPECT launch environment > --inspect-wait together with BUN_INSPECT reports to BUN_INSPECT_NOTIFY once [489.61ms]
(pass) BUN_INSPECT launch environment > BU
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 640ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/23] gen generated_host_exports.rs
generated_host_exports.rs: 120 exports (host=5, lazy=10, generic=105, rust=0); 243 extern-C blocks audited
[2/23] gen cpp.rs (cppbind)
[3/23] gen JS modules (bundle-modules)
Preprocess modules (7420ms)
Bundle modules (64ms)
Postprocesss modules (276ms)
Bundle Functions (492ms)
Generate Code (40ms)

[8.30s] Bundled "src/js" for production
  2593 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/9] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)

... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bun_core/env_var.rs                            |   1 +
 src/js/internal/debugger.ts                        |   6 +-
 src/jsc/Debugger.rs                                |  22 ++-
 src/jsc/VirtualMachine.rs                          |   4 +
 src/jsc/bindings/BunDebugger.cpp                   |   7 +-
 src/runtime/jsc_hooks.rs                           |   3 +
 test/cli/inspect/inspect-launcher-env.test.ts      | 206 +++++++++++++++++++++
 test/cli/inspect/launcher-env-fixture.ts           |  45 +++++
 .../issue/test_env_loader_threading.test.ts        |   8 +-
 9 files changed, 291 insertions(+), 11 deletions(-)
```

</details>

**gate history** · 5 passed · 0 rejected · iteration 5

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/bun_core/env_var.rs                                      4      4      0
src/js/internal/debugger.ts                                  3      6      0
src/jsc/Debugger.rs                                          5     11      0
src/jsc/VirtualMachine.rs                                    3      5      0
src/jsc/bindings/BunDebugger.cpp                             7      7      0
src/runtime/jsc_hooks.rs                                     3      3      0
test/cli/inspect/inspect-launcher-env.test.ts                1      4      0
test/cli/inspect/launcher-env-fixture.ts                     0      3      0
test/regression/issue/test_env_loader_threading.test.ts      2      1      0
```

</details>

<!-- robobun:evidence:end -->
