### PR TITLE
css: keep !important in the rules generated for logical properties and color-scheme

### DIFF
--- a/src/css/context.rs
+++ b/src/css/context.rs
@@ -8,10 +8,36 @@ use css::media_query::{MediaCondition, MediaFeature, MediaFeatureId, MediaList, 
 use bun_alloc::{Arena as Bump, ArenaPtr};
 use bun_collections::ArrayHashMap;
 
+/// Declarations staged for one of the rules generated next to the style rule
+/// being minified, split by importance like the `DeclarationBlock` they become.
+#[derive(Default)]
+pub struct StagedDeclarations {
+    declarations: Vec<css::Property>,
+    important_declarations: Vec<css::Property>,
+}
+
+impl StagedDeclarations {
+    fn push(&mut self, property: css::Property, important: bool) {
+        if important {
+            self.important_declarations.push(property);
+        } else {
+            self.declarations.push(property);
+        }
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.declarations.is_empty() && self.important_declarations.is_empty()
+    }
+
+    fn clear(&mut self) {
+        self.declarations.clear();
+        self.important_declarations.clear();
+    }
+}
+
 pub struct SupportsEntry {
     pub(crate) condition: css::SupportsCondition,
-    pub(crate) declarations: Vec<css::Property>,
-    pub(crate) important_declarations: Vec<css::Property>,
+    pub(crate) declarations: StagedDeclarations,
 }
 
 // No explicit deinit — all fields own their storage and drop automatically.
@@ -29,11 +55,13 @@ pub struct PropertyHandlerContext<'a> {
     // minified; bound to `'a` alongside the other borrowed inputs.
     pub(crate) arena: &'a Bump,
     pub(crate) targets: css::targets::Targets,
+    /// Whether the declarations currently being handled are `!important`;
+    /// staged declarations inherit it. Set by `DeclarationBlock::minify`.
     pub(crate) is_important: bool,
     pub(crate) supports: Vec<SupportsEntry>,
-    pub(crate) ltr: Vec<css::Property>,
-    pub(crate) rtl: Vec<css::Property>,
-    pub(crate) dark: Vec<css::Property>,
+    pub(crate) ltr: StagedDeclarations,
+    pub(crate) rtl: StagedDeclarations,
+    pub(crate) dark: StagedDeclarations,
     pub(crate) context: DeclarationContext,
     pub(crate) unused_symbols: &'a ArrayHashMap<Box<[u8]>, ()>,
 }
@@ -49,9 +77,9 @@ impl<'a> PropertyHandlerContext<'a> {
             targets: *targets,
             is_important: false,
             supports: Vec::new(),
-            ltr: Vec::new(),
-            rtl: Vec::new(),
-            dark: Vec::new(),
+            ltr: StagedDeclarations::default(),
+            rtl: StagedDeclarations::default(),
+            dark: StagedDeclarations::default(),
             context: DeclarationContext::None,
             unused_symbols,
         }
@@ -63,21 +91,21 @@ impl<'a> PropertyHandlerContext<'a> {
             targets: self.targets,
             is_important: false,
             supports: Vec::new(),
-            ltr: Vec::new(),
-            rtl: Vec::new(),
-            dark: Vec::new(),
+            ltr: StagedDeclarations::default(),
+            rtl: StagedDeclarations::default(),
+            dark: StagedDeclarations::default(),
             context,
             unused_symbols: self.unused_symbols,
         }
     }
 
     pub(crate) fn add_dark_rule(&mut self, property: css::Property) {
-        self.dark.push(property);
+        self.dark.push(property, self.is_important);
     }
 
     pub(crate) fn add_logical_rule(&mut self, ltr: css::Property, rtl: css::Property) {
-        self.ltr.push(ltr);
-        self.rtl.push(rtl);
+        self.ltr.push(ltr, self.is_important);
+        self.rtl.push(rtl, self.is_important);
     }
 
     pub(crate) fn should_compile_logical(&self, feature: css::compat::Feature) -> bool {
@@ -117,6 +145,13 @@ impl<'a> PropertyHandlerContext<'a> {
         bun_alloc::vec_from_iter_in(list.iter().map(|p| p.deep_clone(bump)), bump)
     }
 
+    fn clone_block(&self, staged: &StagedDeclarations) -> css::DeclarationBlock<'static> {
+        css::DeclarationBlock {
+            declarations: self.clone_decls(&staged.declarations),
+            important_declarations: self.clone_decls(&staged.important_declarations),
+        }
+    }
+
     pub(crate) fn get_supports_rules<T>(
         &self,
         style_rule: &css::StyleRule<T>,
@@ -134,10 +169,7 @@ impl<'a> PropertyHandlerContext<'a> {
                     v: vec![css::CssRule::Style(css::StyleRule {
                         selectors: style_rule.selectors.deep_clone(),
                         vendor_prefix: css::VendorPrefix::NONE,
-                        declarations: css::DeclarationBlock {
-                            declarations: self.clone_decls(&entry.declarations),
-                            important_declarations: self.clone_decls(&entry.important_declarations),
-                        },
+                        declarations: self.clone_block(&entry.declarations),
                         rules: css::CssRuleList::default(),
                         loc: style_rule.loc,
                     })],
@@ -207,12 +239,7 @@ impl<'a> PropertyHandlerContext<'a> {
                     list.v.push(css::CssRule::Style(css::StyleRule {
                         selectors: style_rule.selectors.deep_clone(),
                         vendor_prefix: css::VendorPrefix::NONE,
-                        declarations: css::DeclarationBlock {
-                            declarations: self.clone_decls(&self.dark),
-                            important_declarations: css::DeclarationList::new_in(
-                                self.bump_static(),
-                            ),
-                        },
+                        declarations: self.clone_block(&self.dark),
                         rules: css::CssRuleList::default(),
                         loc: style_rule.loc,
                     }));
@@ -226,11 +253,10 @@ impl<'a> PropertyHandlerContext<'a> {
         dest
     }
 
-    // Takes the Direction value and a borrow of the decls Vec directly.
     pub(crate) fn get_additional_rules_helper<T>(
         &self,
         dir: css::selector::parser::Direction,
-        decls: &[css::Property],
+        decls: &StagedDeclarations,
         sty: &css::StyleRule<T>,
         dest: &mut Vec<css::CssRule<T>>,
     ) {
@@ -244,10 +270,7 @@ impl<'a> PropertyHandlerContext<'a> {
         let rule = css::StyleRule {
             selectors,
             vendor_prefix: css::VendorPrefix::NONE,
-            declarations: css::DeclarationBlock {
-                declarations: self.clone_decls(decls),
-                important_declarations: css::DeclarationList::new_in(self.bump_static()),
-            },
+            declarations: self.clone_block(decls),
             rules: css::CssRuleList::default(),
             loc: sty.loc,
         };
@@ -287,23 +310,13 @@ impl<'a> PropertyHandlerContext<'a> {
         };
 
         if let Some(entry) = found {
-            if self.is_important {
-                entry.important_declarations.push(property);
-            } else {
-                entry.declarations.push(property);
-            }
+            entry.declarations.push(property, self.is_important);
         } else {
-            let mut important_declarations: Vec<css::Property> = Vec::new();
-            let mut declarations: Vec<css::Property> = Vec::new();
-            if self.is_important {
-                important_declarations.push(property);
-            } else {
-                declarations.push(property);
-            }
+            let mut declarations = StagedDeclarations::default();
+            declarations.push(property, self.is_important);
             self.supports.push(SupportsEntry {
                 condition,
                 declarations,
-                important_declarations,
             });
         }
     }

--- a/src/css/declaration.rs
+++ b/src/css/declaration.rs
@@ -72,9 +72,8 @@ impl<'bump> DeclarationBlock<'bump> {
             hndlr: &mut DeclarationHandler<'bump>,
             important: bool,
         ) {
+            ctx.is_important = important;
             for prop in decls.iter_mut() {
-                ctx.is_important = important;
-
                 let handled = hndlr.handle_property(prop, ctx);
 
                 if !handled {
@@ -96,7 +95,11 @@ impl<'bump> DeclarationBlock<'bump> {
         );
         handle(&mut self.declarations, context, handler, false);
 
+        // Flushing in `finalize` stages logical-property rules too, so the flag
+        // has to follow the handler being finalized.
+        context.is_important = false;
         handler.finalize(context);
+        context.is_important = true;
         important_handler.finalize(context);
         // The old bumpalo Vecs drop implicitly on overwrite (arena reclaims
         // on reset).

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -2103,6 +2103,179 @@ describe("css tests", () => {
     );
   });
 
+  // The rules generated when a logical property (or color-scheme) is compiled
+  // away must keep the declaration's !important, or they lose to rules the
+  // original declaration would have beaten.
+  describe("!important in generated fallback rules", () => {
+    const rtl = ":lang(ae, ar, arc, bcc, bqi, ckb, dv, fa, glk, he, ku, mzn, nqo, pnb, ps, sd, ug, ur, yi)";
+    const safari12 = { safari: 12 << 16 };
+
+    prefix_test(
+      ".foo { margin-inline-start: 2px !important; }",
+      `
+      .foo:not(${rtl}) {
+        margin-left: 2px !important;
+      }
+
+      .foo${rtl} {
+        margin-right: 2px !important;
+      }
+    `,
+      safari12,
+    );
+
+    // Important and normal declarations of the same rule land in the same
+    // generated rules, each keeping its own importance.
+    prefix_test(
+      ".foo { margin-inline-start: 2px !important; margin-inline-end: 4px; }",
+      `
+      .foo:not(${rtl}) {
+        margin-right: 4px;
+        margin-left: 2px !important;
+      }
+
+      .foo${rtl} {
+        margin-left: 4px;
+        margin-right: 2px !important;
+      }
+    `,
+      safari12,
+    );
+
+    // The logical rules are staged while the important declarations are
+    // finalized, after the normal declarations were handled.
+    prefix_test(
+      ".foo { margin-inline-start: 2px !important; color: red; }",
+      `
+      .foo {
+        color: red;
+      }
+
+      .foo:not(${rtl}) {
+        margin-left: 2px !important;
+      }
+
+      .foo${rtl} {
+        margin-right: 2px !important;
+      }
+    `,
+      safari12,
+    );
+
+    prefix_test(
+      ".foo { margin-block-start: 2px !important; }",
+      `
+      .foo {
+        margin-top: 2px !important;
+      }
+    `,
+      safari12,
+    );
+
+    prefix_test(
+      ".foo { inset-inline-start: 2px !important; }",
+      `
+      .foo:not(${rtl}) {
+        left: 2px !important;
+      }
+
+      .foo${rtl} {
+        right: 2px !important;
+      }
+    `,
+      safari12,
+    );
+
+    prefix_test(
+      ".foo { border-inline-start: 2px solid red !important; }",
+      `
+      .foo:not(${rtl}) {
+        border-left: 2px solid red !important;
+      }
+
+      .foo${rtl} {
+        border-right: 2px solid red !important;
+      }
+    `,
+      safari12,
+    );
+
+    // The generated rules are minified again, so the @supports fallbacks split
+    // out of them must stay important as well.
+    prefix_test(
+      ".foo { border-inline-end: var(--border-width) solid lab(40% 56.6 39) !important; }",
+      `
+      .foo:not(${rtl}) {
+        border-right: var(--border-width) solid color(display-p3 .643308 .192455 .167712) !important;
+      }
+
+      @supports (color: lab(0% 0 0)) {
+        .foo:not(${rtl}) {
+          border-right: var(--border-width) solid lab(40% 56.6 39) !important;
+        }
+      }
+
+      .foo${rtl} {
+        border-left: var(--border-width) solid color(display-p3 .643308 .192455 .167712) !important;
+      }
+
+      @supports (color: lab(0% 0 0)) {
+        .foo${rtl} {
+          border-left: var(--border-width) solid lab(40% 56.6 39) !important;
+        }
+      }
+    `,
+      safari12,
+    );
+
+    prefix_test(
+      ".foo { border-start-start-radius: 2px !important; }",
+      `
+      .foo:not(${rtl}) {
+        border-top-left-radius: 2px !important;
+      }
+
+      .foo${rtl} {
+        border-top-right-radius: 2px !important;
+      }
+    `,
+      safari12,
+    );
+
+    prefix_test(
+      ".foo { transition-property: margin-inline-start !important; }",
+      `
+      .foo:not(${rtl}) {
+        transition-property: margin-left !important;
+      }
+
+      .foo${rtl} {
+        transition-property: margin-right !important;
+      }
+    `,
+      safari12,
+    );
+
+    prefix_test(
+      ".foo { color-scheme: light dark !important; }",
+      `
+      .foo {
+        --buncss-light: initial !important;
+        --buncss-dark: !important;
+        color-scheme: light dark !important;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .foo {
+          --buncss-light: !important;
+          --buncss-dark: initial !important;
+        }
+      }
+    `,
+      { chrome: 90 << 16 },
+    );
+  });
+
   describe("length", () => {
     const properties = [
       "margin-right",


### PR DESCRIPTION
### Problem

- When a logical inline property is declared with `!important` and the targets require compiling logical properties away, the generated direction rules drop the `!important`. `.foo { margin-inline-start: 2px !important }` with `safari: 12` comes out as `.foo:not(:lang(...)) { margin-left: 2px }` and `.foo:lang(...) { margin-right: 2px }`.
- The compiled output therefore loses to any rule setting the physical property with `!important`, and the rtl rule also loses to a later plain rule of higher specificity, while the source declaration would have won. Block-axis properties are unaffected because they are compiled into the original rule, which keeps the importance.
- Same class: `color-scheme: light dark !important` emits the light variables with `!important` in the rule itself, but the `@media (prefers-color-scheme: dark)` override without it, so the dark override can never apply.
- The `@supports` fallbacks split out of the generated rules inherit the same loss, since they are derived from declarations that were already staged as normal ones.
- Cause: `PropertyHandlerContext` (`src/css/context.rs`) stages the `ltr` / `rtl` / `dark` declarations as a single `Vec<Property>` each and builds the generated rules with an empty `important_declarations` list. The `@supports` entries next to them already keep two lists and honor `is_important`.
- Second half of the cause: the handlers stage most of these rules while flushing in `finalize()`, and `DeclarationBlock::minify` (`src/css/declaration.rs`) left `context.is_important` at whatever the last handled list set, so the important handler was finalized with the flag describing the normal declarations whenever the rule had any.
- Upstream lightningcss 1.30.2 produces the same output for these inputs, so this is inherited rather than a porting error; the expected output follows from the cascade.

### Fix

- `StagedDeclarations` holds a normal and an important list; `ltr`, `rtl`, `dark` and the `@supports` entries all use it, `add_logical_rule` / `add_dark_rule` / `add_conditional_property` route on `is_important`, and one `clone_block` helper builds every generated rule's `DeclarationBlock` from both lists.
- `DeclarationBlock::minify` sets `is_important` explicitly before finalizing each handler, so declarations staged during `finalize()` are attributed to the handler that staged them.
- Correct because each generated rule is a rewrite of the source declarations under a narrower selector (or media query); keeping each declaration's importance is what makes it rank the same way in the cascade as the declaration it replaces. The generated rules are minified again after this, and `DeclarationBlock::minify` already keeps the two lists apart, so `!important` flows through to their `@supports` fallbacks as well.
- No change for declarations that are not important: they still land in `declarations`, and `reset()` and the pending-merge check in `rules/mod.rs` (which calls `is_empty()` on the staged lists) see both lists.
- Tests: `test/js/bun/css/css.test.ts`, `describe("!important in generated fallback rules")`, one case per staging site (margin/padding/inset handler, border, border-radius, transition, color-scheme), plus a mixed important/normal rule, an important declaration followed by a normal one (the stale flag case), an unparsed `var()` + `lab()` value whose `@supports` fallback must stay important, and a block-axis case as the unchanged contrast. 9 of the 10 fail on the current build, all pass with the fix.
- `bun bd test test/js/bun/css/` passes apart from six pre-existing timeouts (css-fuzz and two subprocess tests) that fail identically on a build without this diff in the same container; `test/bundler/css/` and the css regression tests pass; `cargo clippy -p bun_css` is clean.

### Background

- Compiling logical properties: for targets that lack e.g. `margin-inline-start`, the minifier rewrites the declaration into physical properties. Block-axis properties map to a fixed physical side and stay in the rule. Inline-axis properties depend on the text direction, so the minifier removes them from the rule and emits two extra rules, one with `:dir(ltr)` and one with `:dir(rtl)` appended to the selectors (later compiled to `:lang()` lists), each holding the physical declaration for that direction. `color-scheme` works the same way, emitting a `@media (prefers-color-scheme: dark)` rule that overrides the variables set in the main rule.
- `PropertyHandlerContext` is where the property handlers stage these extra declarations while a rule's declarations are minified; `minify_style_arm` in `rules/mod.rs` turns them into rules after the rule is done and then calls `reset()`.
- `DeclarationBlock` stores normal and `!important` declarations as two separate lists instead of a flag per declaration, and `minify` runs two independent sets of handlers over them (`handler` and `important_handler`). `context.is_important` is the only thing telling the context which set is currently running.
- `finalize()` is the end-of-block flush of a handler: handlers such as margin buffer the sides they have seen and only decide what to emit (and what to stage) once the whole block has been handled.

<details>
<summary>Output before and after for the repro</summary>

```
.foo { margin-inline-start: 2px !important; margin-inline-end: 4px; }   (targets: safari 12)

before:
.foo:not(:lang(...)) { margin-left: 2px; margin-right: 4px; }
.foo:lang(...)       { margin-left: 4px; margin-right: 2px; }

after:
.foo:not(:lang(...)) { margin-right: 4px; margin-left: 2px !important; }
.foo:lang(...)       { margin-left: 4px; margin-right: 2px !important; }

.foo { color-scheme: light dark !important; }   (targets: chrome 90)

before:
@media (prefers-color-scheme: dark) { .foo { --buncss-light: ; --buncss-dark: initial; } }

after:
@media (prefers-color-scheme: dark) { .foo { --buncss-light: !important; --buncss-dark: initial !important; } }
```

</details>
