### PR TITLE
bundler: default the build target to bun from entry point hashbangs

### DIFF
--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -366,7 +366,7 @@ For bundles that run in the Bun runtime. In many cases, it isn't necessary to bu
 
 All bundles generated with `target: "bun"` are marked with a `// @bun` pragma, which tells the Bun runtime that there's no need to re-transpile the file before execution.
 
-If any entrypoint contains a Bun shebang (`#!/usr/bin/env bun`), the bundler defaults to `target: "bun"` instead of `"browser"`.
+If `target` is not set and any entrypoint starts with a Bun shebang (`#!/usr/bin/env bun`), the bundler defaults to `target: "bun"` instead of `"browser"`. An explicit `target` is always used as given.
 
 When using `target: "bun"` and `format: "cjs"` together, the `// @bun @bun-cjs` pragma is added and the CommonJS wrapper function is not compatible with Node.js.
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2800,6 +2800,11 @@ declare module "bun" {
     entrypoints: string[];
 
     /**
+     * The environment the bundle will run in.
+     *
+     * When not set, defaults to `"bun"` if any entrypoint starts with a
+     * `#!/usr/bin/env bun` shebang, and to `"browser"` otherwise.
+     *
      * @default "browser"
      */
     target?: Target; // default: "browser"

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -35,7 +35,7 @@ use crate::cache::{Entry as CacheEntry, ExternalFreeFunction};
 use crate::html_scanner::HTMLScanner;
 use crate::options::{self, Loader};
 use crate::transpiler::Transpiler;
-use crate::{ContentHasher, UseDirective, perf, target_from_hashbang};
+use crate::{ContentHasher, UseDirective, perf};
 use bun_resolver::fs::PathResolverExt as _;
 use bun_resolver::{self as _resolver, Resolver};
 
@@ -2400,27 +2400,20 @@ pub mod parse_worker {
             ..Default::default()
         });
 
-        let target = (if task.source_index.get() == 1 {
-            target_from_hashbang(entry_contents)
+        let target = if task.known_target == options::Target::ServerComponentsSsr
+            && topts
+                .framework
+                .as_ref()
+                .unwrap()
+                .server_components
+                .as_ref()
+                .unwrap()
+                .separate_ssr_graph
+        {
+            options::Target::ServerComponentsSsr
         } else {
-            None
-        })
-        .unwrap_or_else(|| {
-            if task.known_target == options::Target::ServerComponentsSsr
-                && topts
-                    .framework
-                    .as_ref()
-                    .unwrap()
-                    .server_components
-                    .as_ref()
-                    .unwrap()
-                    .separate_ssr_graph
-            {
-                options::Target::ServerComponentsSsr
-            } else {
-                topts.target
-            }
-        });
+            topts.target
+        };
 
         let output_format = topts.output_format;
 

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -18,7 +18,6 @@ pub use bv2_impl::dispatch;
 pub use bv2_impl::{
     CompileResult, CompileResultForSourceMap, CompileResultForSourceMapColumns, ContentHasher,
     EventLoop, ImportTracker, PartRange, StableRef, WrapKind, generic_path_with_pretty_initialized,
-    target_from_hashbang,
 };
 pub use bv2_impl::{DevServerInput, DevServerOutput, ImportTrackerIterator, ImportTrackerStatus};
 // Flatten the impl-body module into this file's namespace so external callers
@@ -913,9 +912,7 @@ pub mod bv2_impl {
                     }
                 }
                 /// Returns a `resolver::Result` for a file in the map, or `None` if
-                /// not found. Handles direct key matches and relative specifiers
-                /// joined against `dirname(source_file)` (with Windows
-                /// drive-letter / separator normalization).
+                /// not found (see [`Self::lookup`] for what matches).
                 ///
                 /// `arena` is the build's bump arena (`BundleV2::arena()`);
                 /// the matched key is copied into it so the returned
@@ -928,33 +925,50 @@ pub mod bv2_impl {
                     source_file: &[u8],
                     specifier: &[u8],
                 ) -> Option<bun_resolver::Result> {
-                    if self.map.is_empty() {
-                        return None;
-                    }
-
+                    let (key, _) = self.lookup(source_file, specifier)?;
                     // SAFETY: ARENA — `arena` is the build-pass bump arena
                     // (never freed before the `Result` is consumed); detaching the
                     // borrow lifetime matches the established `Path<'static>`
                     // convention used throughout `bun_resolver` (PORTING.md
                     // §Lifetimes: ARENA → `&'bump T`).
-                    let dupe = |key: &[u8]| -> &'static [u8] {
-                        // SAFETY: see ARENA note above — bytes live in the build-pass arena.
-                        unsafe { bun_ptr::detach_lifetime(arena.alloc_slice_copy(key)) }
-                    };
+                    let key: &'static [u8] =
+                        unsafe { bun_ptr::detach_lifetime(arena.alloc_slice_copy(key)) };
+                    Some(bun_resolver::Result {
+                        path_pair: bun_resolver::PathPair {
+                            primary: crate::bun_fs::Path::init_with_namespace(key, b"file"),
+                            ..Default::default()
+                        },
+                        module_type: crate::options::ModuleType::Unknown,
+                        ..Default::default()
+                    })
+                }
 
-                    // Direct key match (must use `getKey` to return the map-owned
-                    // key, not the parameter).
+                /// Finds the file `specifier` denotes when imported from
+                /// `source_file` (`b""` for an entry point): a direct key match, or a
+                /// relative specifier joined against `dirname(source_file)` (with
+                /// Windows drive-letter / separator normalization). Returns the
+                /// map-owned key and the file's contents.
+                pub(crate) fn lookup(
+                    &self,
+                    source_file: &[u8],
+                    specifier: &[u8],
+                ) -> Option<(&[u8], &[u8])> {
+                    if self.map.is_empty() {
+                        return None;
+                    }
+
+                    // Direct key match.
                     #[cfg(not(windows))]
-                    if let Some((key, _)) = self.map.get_key_value(specifier) {
-                        return Some(Self::result_for_key(dupe(key.as_ref())));
+                    if let Some(found) = self.entry(specifier) {
+                        return Some(found);
                     }
                     #[cfg(windows)]
                     {
                         let mut buf = bun_paths::path_buffer_pool::get();
                         let normalized =
                             bun_paths::resolve_path::path_to_posix_buf(specifier, &mut **buf);
-                        if let Some((key, _)) = self.map.get_key_value(normalized) {
-                            return Some(Self::result_for_key(dupe(key.as_ref())));
+                        if let Some(found) = self.entry(normalized) {
+                            return Some(found);
                         }
                     }
 
@@ -1015,30 +1029,18 @@ pub mod bv2_impl {
                                 &mut buf[0..joined_len],
                             );
                         }
-                        let joined = &buf[0..joined_len];
-                        if let Some((key, _)) = self.map.get_key_value(joined) {
-                            return Some(Self::result_for_key(dupe(key.as_ref())));
-                        }
+                        return self.entry(&buf[0..joined_len]);
                     }
 
                     None
                 }
 
-                /// Build a `bun_resolver::Result` for a matched key. `key` must
-                /// already satisfy `'static` — see [`resolve`], which copies the
-                /// map-owned key into the build's bump arena before calling here so
-                /// the resulting `Path<'static>` borrows arena memory rather than
-                /// forging a `'static` from a map borrow.
-                #[inline]
-                fn result_for_key(key: &'static [u8]) -> bun_resolver::Result {
-                    bun_resolver::Result {
-                        path_pair: bun_resolver::PathPair {
-                            primary: crate::bun_fs::Path::init_with_namespace(key, b"file"),
-                            ..Default::default()
-                        },
-                        module_type: crate::options::ModuleType::Unknown,
-                        ..Default::default()
-                    }
+                /// `get_key_value` rather than `get`: callers need the map-owned
+                /// key (it outlives the specifier they looked up).
+                fn entry(&self, key: &[u8]) -> Option<(&[u8], &[u8])> {
+                    self.map
+                        .get_key_value(key)
+                        .map(|(key, contents)| (key.as_ref(), &contents[..]))
                 }
             }
 
@@ -7582,17 +7584,6 @@ pub mod bv2_impl {
         None = 0,
         Cjs,
         Esm,
-    }
-
-    pub fn target_from_hashbang(buffer: &[u8]) -> Option<options::Target> {
-        const HB: &[u8] = b"#!/usr/bin/env bun";
-        if buffer.len() > HB.len() && buffer.starts_with(HB) {
-            match buffer[HB.len()] {
-                b'\n' | b' ' => return Some(options::Target::Bun),
-                _ => {}
-            }
-        }
-        None
     }
 
     pub fn generic_path_with_pretty_initialized(

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -943,11 +943,8 @@ pub mod bv2_impl {
                     })
                 }
 
-                /// Finds the file `specifier` denotes when imported from
-                /// `source_file` (`b""` for an entry point): a direct key match, or a
-                /// relative specifier joined against `dirname(source_file)` (with
-                /// Windows drive-letter / separator normalization). Returns the
-                /// map-owned key and the file's contents.
+                /// Returns the map-owned key and contents of `specifier` as imported
+                /// from `source_file` (`b""` for an entry point).
                 pub(crate) fn lookup(
                     &self,
                     source_file: &[u8],
@@ -957,7 +954,6 @@ pub mod bv2_impl {
                         return None;
                     }
 
-                    // Direct key match.
                     #[cfg(not(windows))]
                     if let Some(found) = self.entry(specifier) {
                         return Some(found);
@@ -1035,8 +1031,6 @@ pub mod bv2_impl {
                     None
                 }
 
-                /// `get_key_value` rather than `get`: callers need the map-owned
-                /// key (it outlives the specifier they looked up).
                 fn entry(&self, key: &[u8]) -> Option<(&[u8], &[u8])> {
                     self.map
                         .get_key_value(key)

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -943,8 +943,7 @@ pub mod bv2_impl {
                     })
                 }
 
-                /// Returns the map-owned key and contents of `specifier` as imported
-                /// from `source_file` (`b""` for an entry point).
+                /// Map-owned key and contents; `source_file` is `b""` for an entry point.
                 pub(crate) fn lookup(
                     &self,
                     source_file: &[u8],

--- a/src/bundler/lib.rs
+++ b/src/bundler/lib.rs
@@ -47,7 +47,7 @@ pub use HTMLImportManifest::html_import_manifest;
 pub use bun_core::cheap_prefix_normalizer;
 pub use bundle_v2::{
     CompileResult, CompileResultForSourceMap, ContentHasher, EventLoop, ImportTracker, PartRange,
-    StableRef, WrapKind, generic_path_with_pretty_initialized, target_from_hashbang,
+    StableRef, WrapKind, generic_path_with_pretty_initialized,
 };
 pub use chunk::{
     CrossChunkImport, CrossChunkImportItem, CrossChunkImportItemList, bun_renamer,

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -326,12 +326,8 @@ impl TargetExt for Target {
 
 const BUN_HASHBANG: &[u8] = b"#!/usr/bin/env bun";
 
-/// `bun build` / `Bun.build()` without an explicit `target` default to
-/// `Target::Bun` when an entry point starts with `#!/usr/bin/env bun`
-/// (docs/bundler/index.mdx, "target"). Entry points are looked up in
-/// `file_map` first, then read from disk relative to the working directory;
-/// anything that is not a readable file (a bare specifier, a path only a
-/// plugin resolves) does not count.
+/// Decides the documented `target` default (docs/bundler/index.mdx): a build
+/// without an explicit target is built for Bun when an entry point has this hashbang.
 pub fn any_entry_point_has_bun_hashbang(
     entry_points: &[Box<[u8]>],
     file_map: Option<&crate::bundle_v2::FileMap>,
@@ -347,8 +343,6 @@ pub fn any_entry_point_has_bun_hashbang(
     })
 }
 
-/// `contents` need only hold one byte past the hashbang: that byte tells
-/// `bun` (line ends at LF / CRLF / EOF, or arguments follow) apart from `bunx`.
 fn has_bun_hashbang(contents: &[u8]) -> bool {
     contents.starts_with(BUN_HASHBANG)
         && matches!(

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -324,6 +324,39 @@ impl TargetExt for Target {
     }
 }
 
+const BUN_HASHBANG: &[u8] = b"#!/usr/bin/env bun";
+
+/// `bun build` / `Bun.build()` without an explicit `target` default to
+/// `Target::Bun` when an entry point starts with `#!/usr/bin/env bun`
+/// (docs/bundler/index.mdx, "target"). Entry points are looked up in
+/// `file_map` first, then read from disk relative to the working directory;
+/// anything that is not a readable file (a bare specifier, a path only a
+/// plugin resolves) does not count.
+pub fn any_entry_point_has_bun_hashbang(
+    entry_points: &[Box<[u8]>],
+    file_map: Option<&crate::bundle_v2::FileMap>,
+) -> bool {
+    entry_points.iter().any(|entry_point| {
+        if let Some((_, contents)) = file_map.and_then(|files| files.lookup(b"", entry_point)) {
+            return has_bun_hashbang(contents);
+        }
+        let mut first_bytes = [0u8; BUN_HASHBANG.len() + 1];
+        bun_sys::File::openat(bun_sys::Fd::cwd(), entry_point, bun_sys::O::RDONLY, 0)
+            .and_then(|file| file.read_all(&mut first_bytes))
+            .is_ok_and(|len| has_bun_hashbang(&first_bytes[..len]))
+    })
+}
+
+/// `contents` need only hold one byte past the hashbang: that byte tells
+/// `bun` (line ends at LF / CRLF / EOF, or arguments follow) apart from `bunx`.
+fn has_bun_hashbang(contents: &[u8]) -> bool {
+    contents.starts_with(BUN_HASHBANG)
+        && matches!(
+            contents.get(BUN_HASHBANG.len()),
+            None | Some(b'\n' | b'\r' | b' ' | b'\t')
+        )
+}
+
 pub use bun_options_types::Format;
 pub use bun_options_types::WindowsOptions;
 

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -326,8 +326,7 @@ impl TargetExt for Target {
 
 const BUN_HASHBANG: &[u8] = b"#!/usr/bin/env bun";
 
-/// Decides the documented `target` default (docs/bundler/index.mdx): a build
-/// without an explicit target is built for Bun when an entry point has this hashbang.
+/// The `target` default documented in docs/bundler/index.mdx; callers apply it only when no target was given.
 pub fn any_entry_point_has_bun_hashbang(
     entry_points: &[Box<[u8]>],
     file_map: Option<&crate::bundle_v2::FileMap>,

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -830,6 +830,16 @@ pub mod js_bundler {
                 this.files = file_map_from_js(global_this, JSValue::from_cell(files_obj))?;
             }
 
+            if !did_set_target
+                && this.target != Target::Bun
+                && options::any_entry_point_has_bun_hashbang(
+                    this.entry_points.keys(),
+                    Some(&this.files),
+                )
+            {
+                this.target = Target::Bun;
+            }
+
             if let Some(flag) = config.get_boolean_loose(global_this, "emitDCEAnnotations")? {
                 this.emit_dce_annotations = Some(flag);
             }

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -77,6 +77,12 @@ impl BuildCommand {
             return crate::bake::production::build_command(ctx);
         }
 
+        if ctx.args.target.is_none()
+            && options::any_entry_point_has_bun_hashbang(&ctx.args.entry_points, None)
+        {
+            ctx.args.target = Some(api::Target::Bun);
+        }
+
         if fetcher.is_some() {
             ctx.args.packages = Some(api::PackagesMode::External);
             ctx.bundler_options.compile = false;

--- a/test/bundler/bundler_bun.test.ts
+++ b/test/bundler/bundler_bun.test.ts
@@ -1,5 +1,7 @@
 import { Database } from "bun:sqlite";
-import { describe, expect } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, bunRun, tempDir } from "harness";
+import { join } from "path";
 import { itBundled } from "./expectBundled";
 
 describe("bundler", () => {
@@ -183,4 +185,132 @@ error: Hello World`,
       });
     }
   }
+});
+
+// docs/bundler/index.mdx ("target"): a build with no explicit target defaults to
+// target "bun" when an entry point starts with `#!/usr/bin/env bun`.
+describe.concurrent("bundler hashbang target default", () => {
+  const hashbang = "#!/usr/bin/env bun";
+  const backends = ["api", "cli"] as const;
+
+  // Imports node:fs so the selected target is observable at runtime: the bun
+  // target keeps the import, the browser target replaces it with an empty stub.
+  const usesNodeFs = (firstLine: string) =>
+    `${firstLine}import { readFileSync } from "node:fs";\nconsole.log(typeof readFileSync);\n`;
+
+  /** Builds `entries` (relative to `dir`) into `dir/out` and returns each entry's output text. */
+  async function build(
+    backend: (typeof backends)[number],
+    dir: string,
+    entries: string[],
+    target?: "node" | "browser",
+  ): Promise<string[]> {
+    if (backend === "api") {
+      const result = await Bun.build({
+        entrypoints: entries.map(entry => join(dir, entry)),
+        outdir: join(dir, "out"),
+        ...(target ? { target } : {}),
+      });
+      expect(result.success).toBe(true);
+    } else {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build", ...entries, "--outdir", "out", ...(target ? [`--target=${target}`] : [])],
+        cwd: dir,
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
+      expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+    }
+    return Promise.all(entries.map(entry => Bun.file(join(dir, "out", entry)).text()));
+  }
+
+  const firstLines = [
+    { name: "LF", source: `${hashbang}\n`, bun: true },
+    { name: "CRLF", source: `${hashbang}\r\n`, bun: true },
+    { name: "flags", source: `${hashbang} --smol\n`, bun: true },
+    { name: "node", source: `#!/usr/bin/env node\n`, bun: false },
+    { name: "bunx", source: `${hashbang}x\n`, bun: false },
+  ];
+
+  for (const backend of backends) {
+    test.each(firstLines)(`${backend}: $name hashbang`, async ({ source, bun }) => {
+      using dir = tempDir("hashbang-target", { "cli.js": usesNodeFs(source) });
+      const [output] = await build(backend, String(dir), ["cli.js"]);
+      const hashbangLine = source.split(/\r?\n/)[0];
+      if (bun) {
+        expect(output).toStartWith(`${hashbangLine}\n// @bun\n`);
+      } else {
+        expect(output).toStartWith(`${hashbangLine}\n`);
+        expect(output).not.toContain("// @bun");
+      }
+      expect(await bunRun(join(String(dir), "out", "cli.js"))).toSpawn(bun ? "function" : "undefined");
+    });
+
+    test(`${backend}: a file containing only the hashbang`, async () => {
+      using dir = tempDir("hashbang-target", { "cli.js": hashbang });
+      const [output] = await build(backend, String(dir), ["cli.js"]);
+      expect(output).toStartWith(`${hashbang}\n// @bun\n`);
+    });
+
+    test(`${backend}: dependencies of the hashbang entry are built for bun too`, async () => {
+      using dir = tempDir("hashbang-target", {
+        "cli.js": `${hashbang}\nimport { depHasFs } from "./dep.js";\nconsole.log(depHasFs);\n`,
+        "dep.js": `import { readFileSync } from "node:fs";\nexport const depHasFs = typeof readFileSync;\n`,
+      });
+      const [output] = await build(backend, String(dir), ["cli.js"]);
+      expect(output).toStartWith(`${hashbang}\n// @bun\n`);
+      expect(await bunRun(join(String(dir), "out", "cli.js"))).toSpawn("function");
+    });
+
+    test(`${backend}: a hashbang on a later entry point applies to the whole build`, async () => {
+      using dir = tempDir("hashbang-target", {
+        "lib.js": usesNodeFs(""),
+        "cli.js": usesNodeFs(`${hashbang}\n`),
+      });
+      const [lib, cli] = await build(backend, String(dir), ["lib.js", "cli.js"]);
+      expect(lib).toStartWith("// @bun\n");
+      expect(cli).toStartWith(`${hashbang}\n// @bun\n`);
+      expect(await bunRun(join(String(dir), "out", "lib.js"))).toSpawn("function");
+    });
+
+    test.each(["node", "browser"] as const)(
+      `${backend}: an explicit --target=%s wins over the hashbang`,
+      async target => {
+        using dir = tempDir("hashbang-target", {
+          "cli.js": `${hashbang}\nimport { Shared } from "./shared.js";\nimport { ReExported } from "./reexport.js";\nconsole.log(Shared === ReExported);\n`,
+          "shared.js": `export class Shared {}\n`,
+          "reexport.js": `import { Shared } from "./shared.js";\nexport const ReExported = Shared;\n`,
+        });
+        const [output] = await build(backend, String(dir), ["cli.js"], target);
+        expect(output).toStartWith(`${hashbang}\n`);
+        expect(output).not.toContain("// @bun");
+        // The whole build shares one target, so shared.js is bundled exactly once.
+        expect(output.split("class Shared").length - 1).toBe(1);
+        expect(await bunRun(join(String(dir), "out", "cli.js"))).toSpawn("true");
+      },
+    );
+  }
+
+  test("api: an in-memory `files` entry is checked instead of the file on disk", async () => {
+    using dir = tempDir("hashbang-target", {
+      "plain.js": usesNodeFs(""),
+      "cli.js": usesNodeFs(`${hashbang}\n`),
+    });
+    const plain = join(String(dir), "plain.js");
+    const cli = join(String(dir), "cli.js");
+
+    const inMemoryHashbang = await Bun.build({
+      entrypoints: [plain],
+      files: { [plain]: usesNodeFs(`${hashbang}\n`) },
+    });
+    expect(await inMemoryHashbang.outputs[0].text()).toStartWith(`${hashbang}\n// @bun\n`);
+
+    const inMemoryPlain = await Bun.build({
+      entrypoints: [cli],
+      files: { [cli]: usesNodeFs("") },
+    });
+    expect(await inMemoryPlain.outputs[0].text()).not.toContain("// @bun");
+  });
 });

--- a/test/bundler/bundler_bun.test.ts
+++ b/test/bundler/bundler_bun.test.ts
@@ -203,18 +203,27 @@ describe.concurrent("bundler hashbang target default", () => {
     backend: (typeof backends)[number],
     dir: string,
     entries: string[],
-    target?: "node" | "browser",
+    { target, format }: { target?: "node" | "browser"; format?: "cjs" } = {},
   ): Promise<string[]> {
     if (backend === "api") {
       const result = await Bun.build({
         entrypoints: entries.map(entry => join(dir, entry)),
         outdir: join(dir, "out"),
         ...(target ? { target } : {}),
+        ...(format ? { format } : {}),
       });
       expect(result.success).toBe(true);
     } else {
       await using proc = Bun.spawn({
-        cmd: [bunExe(), "build", ...entries, "--outdir", "out", ...(target ? [`--target=${target}`] : [])],
+        cmd: [
+          bunExe(),
+          "build",
+          ...entries,
+          "--outdir",
+          "out",
+          ...(target ? [`--target=${target}`] : []),
+          ...(format ? [`--format=${format}`] : []),
+        ],
         cwd: dir,
         env: bunEnv,
         stdout: "pipe",
@@ -283,7 +292,7 @@ describe.concurrent("bundler hashbang target default", () => {
           "shared.js": `export class Shared {}\n`,
           "reexport.js": `import { Shared } from "./shared.js";\nexport const ReExported = Shared;\n`,
         });
-        const [output] = await build(backend, String(dir), ["cli.js"], target);
+        const [output] = await build(backend, String(dir), ["cli.js"], { target });
         expect(output).toStartWith(`${hashbang}\n`);
         expect(output).not.toContain("// @bun");
         // The whole build shares one target, so shared.js is bundled exactly once.
@@ -291,6 +300,14 @@ describe.concurrent("bundler hashbang target default", () => {
         expect(await bunRun(join(String(dir), "out", "cli.js"))).toSpawn("true");
       },
     );
+
+    // Only an explicit target disables the default; format: "cjs" alone does not.
+    test(`${backend}: the hashbang still selects bun with format cjs`, async () => {
+      using dir = tempDir("hashbang-target", { "cli.js": `${hashbang}\nconsole.log("cjs");\n` });
+      const [output] = await build(backend, String(dir), ["cli.js"], { format: "cjs" });
+      expect(output).toStartWith(`${hashbang}\n// @bun @bun-cjs\n`);
+      expect(await bunRun(join(String(dir), "out", "cli.js"))).toSpawn("cjs");
+    });
   }
 
   test("api: an in-memory `files` entry is checked instead of the file on disk", async () => {


### PR DESCRIPTION
### Problem

- docs/bundler/index.mdx ("target") says: if any entrypoint contains a `#!/usr/bin/env bun` shebang, the bundler defaults to `target: "bun"`. The implementation did something narrower, and the parts it did do were only half applied:
  - `target_from_hashbang` (`src/bundler/bundle_v2.rs`) only accepted `\n` or a space after `#!/usr/bin/env bun`, so a CRLF file (or a file that is only the hashbang line) was built for the browser. `bun build ./crlf.js` produced no `// @bun` pragma while the same file with LF endings did.
  - `ParseTask.rs` only consulted it for source index 1, i.e. the first entry point. `bun build plain.js cli.js` ignored the hashbang in `cli.js`.
  - What it did apply was a per-file target: only the entry file's own AST was marked `Target::Bun`. Its dependencies were still resolved and printed for the configured target (browser by default), so for a script with a bun shebang and no `--target`:
    - `import { readFileSync } from "node:fs"` in a dependency became the browser stub (`typeof readFileSync` is `undefined` at runtime), while the same import in the entry file worked.
    - `import "bun"` in a dependency failed with `Browser build cannot import Bun builtin: "bun"`.
    - The output still carried the `// @bun` pragma, which promises Bun the whole file was printed for Bun.
  - The per-file target also overrode an explicit `--target=node` / `--target=browser` for that one file. That is the trigger behind #33859 (`// @bun` / `@bun-cjs` wrapper emitted into a node or browser build) and #33862 (the entry registers its imports in the `Target::Bun` dedup graph while dependencies use the configured target's graph, so a module imported by both is bundled twice and `Shared === ReExported` is `false`).

### Fix

- `options::any_entry_point_has_bun_hashbang` (`src/bundler/options.rs`) reads the first 19 bytes of each entry point (the `Bun.build` `files` map is consulted first, then disk) and accepts LF, CRLF, EOF, or arguments after `bun`.
- `bun build` (`build_command.rs`) and `Bun.build()` (`JSBundler.rs`) call it when the user gave no target and set the build target to bun. `--compile`, `--bytecode` and an explicit target are untouched: an explicit setting wins over the inferred one. Nothing else disables it; in particular `--format=cjs` / `format: "cjs"` on a hashbang entry still gives a bun build (`// @bun @bun-cjs`) on both paths, as it did before, and a test pins that. (The documented cjs to node CLI default is not applied on main today, `Arguments.rs` writes it into a copy of the args that `parse()` discards; that is tracked separately and, when fixed, needs to keep running after this check.)
- The per-file override in `ParseTask.rs` and `target_from_hashbang` are removed. With the default applied at the options layer it is redundant when no target is given (the whole build is already bun) and only harmful when one is (it was the trigger for #33859 and #33862; both of their repros pass with this change, see the tests below). This does not change `known_target` handling or the server-components branch.
- `FileMap::resolve` is split into `lookup` (returns the matched key and contents) plus a thin `resolve`, so the hashbang check matches entry points against `files` exactly the way the bundler itself does.
- Why this is the right contract: it is the one the docs (and the `BuildConfig` JSDoc, updated here) describe, it applies the target to the whole graph instead of one file, and it makes the CLI and the JS API behave the same. The cost is one small read per entry point, only when no target was given.
- Behavior changes to be aware of: a bun-shebang entry built with an explicit non-bun target is now built purely for that target (no `// @bun` pragma, no `@bun-cjs` wrapper). The entry path is read as written, so an entry that only exists through resolution (`bun build ./cli` without an extension, `./cli.js` naming a `cli.ts`, a package name) does not trigger the default; the removed override read the parsed file, but only for the first entry. Only the documented `#!/usr/bin/env bun` spelling is recognized, as before; `env -S bun` and absolute interpreter paths are not.
- Verified with `test/bundler/bundler_bun.test.ts` (`bundler hashbang target default`), run through both `bun build` and `Bun.build()`: LF / CRLF / hashbang-only / `bun --flags` files select bun and `#!/usr/bin/env node` / `bunx` do not; a dependency's `node:fs` import survives; a hashbang on the second entry point applies to the build; `--target=node` and `--target=browser` are honored with the shared module bundled once and identity preserved; `format: "cjs"` alone keeps the bun default; a `files` entry is checked instead of the file on disk. 12 of the 23 cases fail on the released binary (CRLF, hashbang-only, dependency, later entry, and both explicit-target cases, on both backends); all pass with this change.
- Also run: `bundler_banner`, `bundler_files`, `bundler_plugin`, `bundler_naming`, `bundler_browser`, `bundler_edgecase`, `bundler_cjs`, `bun-build-api`, `cli`, `html-import-manifest`, `bundler_html_server`, `bake/dev/bundle`, `bake/dev-and-prod`, `integration/bun-types`, `cargo clippy` on `bun_bundler` and `bun_runtime`, `cargo check` of `bun_bundler` for `x86_64-pc-windows-msvc` (the `FileMap` change has a Windows-only branch).

### Background

- Build target: `browser` / `bun` / `node`. It selects package.json export conditions, whether `node:*` and `bun` imports are kept or stubbed, the runtime helpers, and how files are printed. It is fixed when the options are built (`BundleOptions::from_api`), before any file is parsed, which is why this check has to happen in the two option-building entry points rather than in the parser.
- `// @bun` pragma: the first comment of a bun-target bundle; it tells Bun to load the file without transpiling it again. It is emitted when the entry file's per-file target is bun, so it was the visible symptom of the old per-file override.
- Per-file target (`ast.target`): the bundler keeps one path-to-module map per target so that, for example, a server build can also bundle browser code. A file whose target differs from its importers' therefore lives in a different map, which is how the removed override duplicated modules (#33862).
- `Bun.build({ files })`: in-memory files that can be used as entry points or imports and shadow files on disk with the same path; the hashbang check has to read those instead of the disk.
