### PR TITLE
bunfig: keep CLI flags ahead of bunfig.toml when it is loaded after argv (bun run)

### DIFF
--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -244,7 +244,7 @@ impl<'a> Parser<'a> {
     }
 
     fn load_preload(&mut self, expr: &Expr) -> crate::Result<()> {
-        match &expr.data {
+        let mut preloads: Vec<Box<[u8]>> = match &expr.data {
             ExprData::EArray(array) => {
                 let items = array.items.slice();
                 let mut preloads: Vec<Box<[u8]>> = Vec::with_capacity(items.len());
@@ -256,18 +256,22 @@ impl<'a> Parser<'a> {
                         }
                     }
                 }
-                self.ctx.preloads = preloads;
+                preloads
             }
             ExprData::EString(s) => {
-                if s.len() > 0 {
-                    self.ctx.preloads = vec![estring_to_owned(s, self.bump)];
+                if s.len() == 0 {
+                    return Ok(());
                 }
+                vec![estring_to_owned(s, self.bump)]
             }
-            ExprData::ENull(_) => {}
-            _ => {
-                self.add_error(expr.loc, b"Expected preload to be an array")?;
-            }
-        }
+            ExprData::ENull(_) => return Ok(()),
+            _ => return self.add_error(expr.loc, b"Expected preload to be an array"),
+        };
+        // `ctx.preloads` already holds the `--preload`s when bunfig.toml is
+        // loaded after argument parsing (`bun run`); as in the other load
+        // order, the config's preloads run first and argv's follow.
+        preloads.append(&mut self.ctx.preloads);
+        self.ctx.preloads = preloads;
         Ok(())
     }
 
@@ -359,8 +363,15 @@ impl<'a> Parser<'a> {
             self.load_log_level(&expr)?;
         }
 
+        // Keys with a command-line counterpart are still validated but only
+        // applied when that flag was not given: see `CliOverrides`.
+        let cli = self.ctx.cli_overrides;
+
         if let Some(expr) = json.get(b"define") {
-            self.ctx.args.define = Some(self.parse_define_map(&expr)?);
+            let define = self.parse_define_map(&expr)?;
+            if !cli.define {
+                self.ctx.args.define = Some(define);
+            }
         }
 
         if let Some(expr) = json.get(b"origin") {
@@ -723,9 +734,9 @@ impl<'a> Parser<'a> {
                 }
 
                 if let Some(auto_install_expr) = install_obj.get(b"auto") {
-                    if let ExprData::EString(_) = &auto_install_expr.data {
+                    let auto_install = if let ExprData::EString(_) = &auto_install_expr.data {
                         let key = auto_install_expr.as_string(self.bump).unwrap_or(b"");
-                        self.ctx.debug.global_cache = match GlobalCache::MAP.get(key) {
+                        match GlobalCache::MAP.get(key) {
                             Some(v) => *v,
                             None => {
                                 self.add_error(
@@ -734,19 +745,22 @@ impl<'a> Parser<'a> {
                                 )?;
                                 return Ok(());
                             }
-                        };
+                        }
                     } else if let ExprData::EBoolean(b) = auto_install_expr.data {
-                        self.ctx.debug.global_cache = if b.value {
+                        if b.value {
                             GlobalCache::allow_install
                         } else {
                             GlobalCache::disable
-                        };
+                        }
                     } else {
                         self.add_error(
                             auto_install_expr.loc,
                             b"Invalid auto install setting, must be one of true, false, or \"force\" \"fallback\" \"disable\"",
                         )?;
                         return Ok(());
+                    };
+                    if !cli.auto_install {
+                        self.ctx.debug.global_cache = auto_install;
                     }
                 }
 
@@ -827,13 +841,15 @@ impl<'a> Parser<'a> {
             if let Some(console_expr) = json.get(b"console") {
                 if let Some(depth) = console_expr.get(b"depth") {
                     if let Some(n) = depth.as_number() {
-                        let depth_value = n as u16;
-                        // Treat depth=0 as maxInt(u16) for infinite depth
-                        self.ctx.runtime_options.console_depth = Some(if depth_value == 0 {
-                            u16::MAX
-                        } else {
-                            depth_value
-                        });
+                        if !cli.console_depth {
+                            let depth_value = n as u16;
+                            // Treat depth=0 as maxInt(u16) for infinite depth
+                            self.ctx.runtime_options.console_depth = Some(if depth_value == 0 {
+                                u16::MAX
+                            } else {
+                                depth_value
+                            });
+                        }
                     } else {
                         self.add_error(depth.loc, b"Expected number")?;
                     }
@@ -987,16 +1003,18 @@ impl<'a> Parser<'a> {
         }
         {
             if let Some(jsx) = self.ctx.args.jsx.as_mut() {
-                if !jsx_factory.is_empty() {
+                if !jsx_factory.is_empty() && !cli.jsx_factory {
                     jsx.factory = jsx_factory;
                 }
-                if !jsx_fragment.is_empty() {
+                if !jsx_fragment.is_empty() && !cli.jsx_fragment {
                     jsx.fragment = jsx_fragment;
                 }
-                if !jsx_import_source.is_empty() {
+                if !jsx_import_source.is_empty() && !cli.jsx_import_source {
                     jsx.import_source = jsx_import_source;
                 }
-                jsx.runtime = jsx_runtime;
+                if !cli.jsx_runtime {
+                    jsx.runtime = jsx_runtime;
+                }
                 jsx.development = jsx_dev;
             } else {
                 self.ctx.args.jsx = Some(api::Jsx {
@@ -1020,12 +1038,14 @@ impl<'a> Parser<'a> {
 
         if let Some(expr) = json.get(b"macros") {
             if let ExprData::EBoolean(b) = expr.data {
-                if !b.value {
+                if !b.value && !cli.macros {
                     self.ctx.debug.macros = MacroOptions::Disable;
                 }
             } else {
-                self.ctx.debug.macros =
-                    MacroOptions::Map(parse_macros_json(&expr, self.log, self.source, self.bump));
+                let remaps = parse_macros_json(&expr, self.log, self.source, self.bump);
+                if !cli.macros {
+                    self.ctx.debug.macros = MacroOptions::Map(remaps);
+                }
             }
             bun_analytics::features::macros.fetch_add(1, Ordering::Relaxed);
         }
@@ -1084,10 +1104,12 @@ impl<'a> Parser<'a> {
                 loader_names.push(key.into());
                 loader_values.push(loader.to_api());
             }
-            self.ctx.args.loaders = Some(api::LoaderMap {
-                extensions: loader_names,
-                loaders: loader_values,
-            });
+            if !cli.loaders {
+                self.ctx.args.loaders = Some(api::LoaderMap {
+                    extensions: loader_names,
+                    loaders: loader_values,
+                });
+            }
         }
 
         Ok(())

--- a/src/options_types/context.rs
+++ b/src/options_types/context.rs
@@ -44,6 +44,36 @@ pub struct ContextData {
 
     pub preloads: Vec<Box<[u8]>>,
     pub has_loaded_global_config: bool,
+    pub cli_overrides: CliOverrides,
+}
+
+/// Settings that were given on the command line.
+///
+/// bunfig.toml is usually parsed before argv is applied, so argv simply
+/// overwrites it. `bun run <target>`, the `node` shim, `bun repl` and
+/// standalone executables only load it afterwards (the `loaded_bunfig`
+/// checks in run_command.rs and repl_command.rs); the bunfig parser skips the
+/// keys recorded here so the command line wins in that order too.
+#[derive(Clone, Copy, Default)]
+pub struct CliOverrides {
+    /// `--define`
+    pub define: bool,
+    /// `--loader`
+    pub loaders: bool,
+    /// `--jsx-runtime`
+    pub jsx_runtime: bool,
+    /// `--jsx-factory`
+    pub jsx_factory: bool,
+    /// `--jsx-fragment`
+    pub jsx_fragment: bool,
+    /// `--jsx-import-source`
+    pub jsx_import_source: bool,
+    /// `--console-depth`
+    pub console_depth: bool,
+    /// `--install`, `-i` or `--no-install`
+    pub auto_install: bool,
+    /// `--no-macros`
+    pub macros: bool,
 }
 
 impl Default for ContextData {
@@ -84,6 +114,7 @@ impl Default for ContextData {
             no_exit_on_error: false,
             preloads: Vec::new(),
             has_loaded_global_config: false,
+            cli_overrides: CliOverrides::default(),
         }
     }
 }

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -926,6 +926,7 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
     let defines_tuple = DefineColonList::resolve(args.options(b"--define"))?;
 
     if !defines_tuple.keys.is_empty() {
+        ctx.cli_overrides.define = true;
         opts.define = Some(api::StringMap {
             keys: defines_tuple
                 .keys
@@ -955,6 +956,7 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
     };
 
     if !loader_tuple.keys.is_empty() {
+        ctx.cli_overrides.loaders = true;
         opts.loaders = Some(api::LoaderMap {
             extensions: loader_tuple
                 .keys
@@ -1179,19 +1181,19 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
             bun_options_types::offline_mode::OfflineMode::Online
         });
 
-        if args.flag(b"--no-install") {
-            ctx.debug.global_cache = options::GlobalCache::disable;
+        let auto_install = if args.flag(b"--no-install") {
+            Some(options::GlobalCache::disable)
         } else if args.flag(b"-i") && cmd != CommandTag::RunAsNodeCommand {
             // Under node emulation `-i` is node's --interactive alias, not
             // --install=fallback (auto-install is meaningless there).
-            ctx.debug.global_cache = options::GlobalCache::fallback;
+            Some(options::GlobalCache::fallback)
         } else if let Some(enum_value) = args.option(b"--install") {
             // -i=auto --install=force, --install=disable
             if let Some(result) = options::GlobalCache::MAP.get(enum_value) {
-                ctx.debug.global_cache = *result;
+                Some(*result)
             // -i, --install
             } else if enum_value.is_empty() {
-                ctx.debug.global_cache = options::GlobalCache::force;
+                Some(options::GlobalCache::force)
             } else {
                 Output::err_generic(
                     "Invalid value for --install: \"{}\". Must be either \"auto\", \"fallback\", \"force\", or \"disable\"\n",
@@ -1199,6 +1201,12 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
                 );
                 Global::exit(1);
             }
+        } else {
+            None
+        };
+        if let Some(auto_install) = auto_install {
+            ctx.debug.global_cache = auto_install;
+            ctx.cli_overrides.auto_install = true;
         }
 
         if let Some(script) = args.option(b"--print") {
@@ -1239,6 +1247,7 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
             };
             // Treat depth=0 as maxInt(u16) for infinite depth
             ctx.runtime_options.console_depth = Some(if depth == 0 { u16::MAX } else { depth });
+            ctx.cli_overrides.console_depth = true;
         }
 
         if let Some(order) = args.option(b"--dns-result-order") {
@@ -1602,6 +1611,10 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
         || jsx_import_source.is_some()
         || jsx_runtime.is_some()
     {
+        ctx.cli_overrides.jsx_factory = jsx_factory.is_some();
+        ctx.cli_overrides.jsx_fragment = jsx_fragment.is_some();
+        ctx.cli_overrides.jsx_import_source = jsx_import_source.is_some();
+        ctx.cli_overrides.jsx_runtime = jsx_runtime.is_some();
         let default_factory: &[u8] = b"";
         let default_fragment: &[u8] = b"";
         let default_import_source: &[u8] = b"";
@@ -1686,6 +1699,7 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
 
     if args.flag(b"--no-macros") {
         ctx.debug.macros = MacroOptions::Disable;
+        ctx.cli_overrides.macros = true;
     }
 
     opts.output_dir = output_dir.map(Box::<[u8]>::from);

--- a/test/config/bunfig/cli-flags-override-bunfig.test.ts
+++ b/test/config/bunfig/cli-flags-override-bunfig.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "node:path";
+
+// `bun <file>` parses bunfig.toml before it applies argv; `bun run <file>` (and
+// everything else that boots through RunCommand) parses it after argv. A key
+// with a command-line counterpart has to lose to the flag in both orders and
+// still apply when the flag is absent.
+
+async function run(cwd: string, args: string[], env: Record<string, string | undefined> = bunEnv) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), ...args],
+    cwd,
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+type Expected = { stdout: unknown; stderr: unknown; exitCode: number };
+const ok = (stdout: string): Expected => ({ stdout, stderr: "", exitCode: 0 });
+
+// An import source for the automatic runtime, so nothing is fetched from a
+// registry. The dev and prod entry points report the same thing so the tests do
+// not depend on how `development` is derived.
+function jsxImportSource(name: string, output: string) {
+  return {
+    [`node_modules/${name}/package.json`]: JSON.stringify({ name }),
+    [`node_modules/${name}/jsx-runtime/index.js`]: `exports.jsx = exports.jsxs = () => ${JSON.stringify(output)};`,
+    [`node_modules/${name}/jsx-dev-runtime/index.js`]: `exports.jsxDEV = () => ${JSON.stringify(output)};`,
+  };
+}
+
+const settings: {
+  name: string;
+  files: Record<string, string>;
+  entry: string;
+  flags: string[];
+  withFlag: Expected;
+  withoutFlag: Expected;
+}[] = [
+  {
+    name: "[define] / --define",
+    files: {
+      "bunfig.toml": `[define]\nTAG = '"bunfig"'\n`,
+      "index.js": `console.log(TAG);\n`,
+    },
+    entry: "index.js",
+    flags: ["--define", 'TAG="cli"'],
+    withFlag: ok("cli\n"),
+    withoutFlag: ok("bunfig\n"),
+  },
+  {
+    name: "[loader] / --loader",
+    files: {
+      "bunfig.toml": `[loader]\n".data" = "text"\n`,
+      "payload.data": `{"loaded": true}`,
+      "index.js": `import payload from "./payload.data";\nconsole.log(typeof payload);\n`,
+    },
+    entry: "index.js",
+    flags: ["--loader", ".data:json"],
+    withFlag: ok("object\n"),
+    withoutFlag: ok("string\n"),
+  },
+  {
+    name: "[console] depth / --console-depth",
+    files: {
+      "bunfig.toml": `[console]\ndepth = 1\n`,
+      "index.js": `console.log({ a: { b: { c: 1 } } });\n`,
+    },
+    entry: "index.js",
+    flags: ["--console-depth", "5"],
+    withFlag: ok("{\n  a: {\n    b: {\n      c: 1,\n    },\n  },\n}\n"),
+    withoutFlag: ok("{\n  a: {\n    b: [Object ...],\n  },\n}\n"),
+  },
+  {
+    name: "jsx / --jsx-runtime",
+    files: {
+      ...jsxImportSource("react", "runtime:bunfig"),
+      "bunfig.toml": `jsx = "react-jsx"\n`,
+      "index.jsx": `globalThis.React = { createElement: () => "runtime:cli" };\nconsole.log(<div />);\n`,
+    },
+    entry: "index.jsx",
+    flags: ["--jsx-runtime", "classic"],
+    withFlag: ok("runtime:cli\n"),
+    withoutFlag: ok("runtime:bunfig\n"),
+  },
+  {
+    // The runtime still comes from bunfig.toml here; only the factory is
+    // taken from the command line.
+    name: "jsxFactory / --jsx-factory",
+    files: {
+      "bunfig.toml": `jsx = "react"\njsxFactory = "bunfigFactory"\n`,
+      "index.jsx": [
+        `globalThis.bunfigFactory = () => "factory:bunfig";`,
+        `globalThis.cliFactory = () => "factory:cli";`,
+        `console.log(<div />);`,
+        ``,
+      ].join("\n"),
+    },
+    entry: "index.jsx",
+    flags: ["--jsx-factory", "cliFactory"],
+    withFlag: ok("factory:cli\n"),
+    withoutFlag: ok("factory:bunfig\n"),
+  },
+  {
+    name: "jsxFragment / --jsx-fragment",
+    files: {
+      "bunfig.toml": `jsx = "react"\njsxFragment = "BunfigFragment"\n`,
+      "index.jsx": [
+        `globalThis.React = { createElement: fragment => "fragment:" + fragment };`,
+        `globalThis.BunfigFragment = "bunfig";`,
+        `globalThis.CliFragment = "cli";`,
+        `console.log(<></>);`,
+        ``,
+      ].join("\n"),
+    },
+    entry: "index.jsx",
+    flags: ["--jsx-fragment", "CliFragment"],
+    withFlag: ok("fragment:cli\n"),
+    withoutFlag: ok("fragment:bunfig\n"),
+  },
+  {
+    name: "jsxImportSource / --jsx-import-source",
+    files: {
+      ...jsxImportSource("bunfig-source", "source:bunfig"),
+      ...jsxImportSource("cli-source", "source:cli"),
+      "bunfig.toml": `jsx = "react-jsx"\njsxImportSource = "bunfig-source"\n`,
+      "index.jsx": `console.log(<div />);\n`,
+    },
+    entry: "index.jsx",
+    flags: ["--jsx-import-source", "cli-source"],
+    withFlag: ok("source:cli\n"),
+    withoutFlag: ok("source:bunfig\n"),
+  },
+  {
+    // Any `[macros]` remap table turns macros back on.
+    name: "[macros] / --no-macros",
+    files: {
+      "bunfig.toml": `[macros]\n"some-package" = { "value" = "./macro.ts" }\n`,
+      "macro.ts": `export function value() {\n  return "ran";\n}\n`,
+      "index.ts": `import { value } from "./macro.ts" with { type: "macro" };\nconsole.log("macro:" + value());\n`,
+    },
+    entry: "index.ts",
+    flags: ["--no-macros"],
+    withFlag: { stdout: "", stderr: expect.stringContaining("error: Macros are disabled"), exitCode: 1 },
+    // Debug builds log "[macro] call value" to stdout before the script runs.
+    withoutFlag: { stdout: expect.stringMatching(/(^|\n)macro:ran\n$/), stderr: "", exitCode: 0 },
+  },
+];
+
+describe.each(settings)("$name", ({ files, entry, flags, withFlag, withoutFlag }) => {
+  test.concurrent("bun <flags> <file>: the flag wins", async () => {
+    using dir = tempDir("bunfig-cli-early", files);
+    expect(await run(String(dir), [...flags, entry])).toEqual(withFlag);
+  });
+
+  test.concurrent("bun run <flags> <file>: the flag still wins when bunfig.toml is parsed after argv", async () => {
+    using dir = tempDir("bunfig-cli-late", files);
+    expect(await run(String(dir), ["run", ...flags, entry])).toEqual(withFlag);
+  });
+
+  test.concurrent("bun run <file>: bunfig.toml applies when the flag is absent", async () => {
+    using dir = tempDir("bunfig-only", files);
+    expect(await run(String(dir), ["run", entry])).toEqual(withoutFlag);
+  });
+});
+
+describe("[install] auto / --install", () => {
+  // Auto-install is observable as a manifest request, so point bunfig.toml at
+  // a registry stub that only records what was asked for.
+  function registryStub() {
+    const requests: string[] = [];
+    const server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        requests.push(new URL(req.url).pathname);
+        return new Response("not found", { status: 404 });
+      },
+    });
+    return { requests, server, [Symbol.dispose]: () => server.stop(true) };
+  }
+
+  function project(auto: string, registryPort: number) {
+    return tempDir("bunfig-install-auto", {
+      "bunfig.toml": `[install]\nauto = ${auto}\nregistry = "http://localhost:${registryPort}/"\n`,
+      "index.js": `import "package-that-is-not-installed";\n`,
+    });
+  }
+
+  async function runProject(dir: string, args: string[]) {
+    const result = await run(dir, args, { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(dir, ".bun-cache") });
+    expect(result.stderr).toContain("Cannot find package 'package-that-is-not-installed'");
+    expect(result.exitCode).toBe(1);
+  }
+
+  test.concurrent.each(["--no-install index.js", "run --no-install index.js"])(
+    'bun %s: --no-install wins over auto = "fallback"',
+    async args => {
+      using registry = registryStub();
+      using dir = project(`"fallback"`, registry.server.port);
+      await runProject(String(dir), args.split(" "));
+      expect(registry.requests).toEqual([]);
+    },
+  );
+
+  test.concurrent('bun run <file>: auto = "fallback" applies when no flag is given', async () => {
+    using registry = registryStub();
+    using dir = project(`"fallback"`, registry.server.port);
+    await runProject(String(dir), ["run", "index.js"]);
+    expect(registry.requests).toEqual(["/package-that-is-not-installed"]);
+  });
+
+  test.concurrent("bun run -i <file>: -i wins over auto = false", async () => {
+    using registry = registryStub();
+    using dir = project("false", registry.server.port);
+    await runProject(String(dir), ["run", "-i", "index.js"]);
+    expect(registry.requests).toEqual(["/package-that-is-not-installed"]);
+  });
+});

--- a/test/config/bunfig/preload.test.ts
+++ b/test/config/bunfig/preload.test.ts
@@ -1,5 +1,5 @@
 import type { SpawnOptions } from "bun";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, fakeNodeRun } from "harness";
 import { join, resolve } from "path";
 
 const fixturePath = (...segs: string[]) => resolve(import.meta.dirname, "fixtures", "preload", ...segs);
@@ -91,16 +91,24 @@ describe("Given a `bunfig.toml` with a list of preloads", () => {
     //
     "--preload ./preload3.ts",
     "--preload=./preload3.ts",
-    // FIXME: Tests are failing due to active bugs
+    // `bun run` loads bunfig.toml after argv has been applied.
+    "--preload=./preload3.ts run",
+    "run --preload ./preload3.ts",
+    "run --preload=./preload3.ts",
+    // FIXME: `bun --preload ./preload3.ts run cli-merge.ts` takes `./preload3.ts` for the subcommand
+    // name, so it runs as `bun run` with no target and only prints the usage text.
     // "--preload ./preload3.ts run",
-    // "--preload=./preload3.ts run",
-    // "run --preload ./preload3.ts",
-    // "run --preload=./preload3.ts",
   ])("When `bun %s cli-merge.ts` is run, `--preload` adds the target file to the list of preloads", async args => {
     const [out, err, code] = await run("cli-merge.ts", { args: args.split(" "), cwd: dir });
     expect(err).toBeEmpty();
     expect(out).toBeEmpty();
     expect(code).toBe(0);
+  });
+
+  // The `node` shim loads bunfig.toml the same way `bun run` does.
+  it("When run as `node -r ./preload3.ts cli-merge.ts`, the preload is added after the ones from bunfig.toml", () => {
+    // fakeNodeRun throws, with the assertion message from cli-merge.ts, when the list is wrong.
+    expect(fakeNodeRun(dir, ["-r", "./preload3.ts", "cli-merge.ts"])).toEqual({ stdout: "", stderr: "" });
   });
 }); // </given a `bunfig.toml` with a list of preloads>
 


### PR DESCRIPTION
### Problem

- With a `bunfig.toml` in the cwd, `bun run --define X=4 file.mjs` runs with bunfig's `[define]` value; `bun --define X=3 file.mjs` and `bun test --define ...` use the flag. Reproduces on 1.4.0 and main.
- The same inversion applies to every other key the bunfig parser writes over a value a flag had set: `[loader]` vs `--loader`, `[console] depth` vs `--console-depth` (the docs promise the flag wins), `jsx`/`jsxFactory`/`jsxFragment`/`jsxImportSource` vs `--jsx-*` (any bunfig.toml at all, even one without jsx keys, undid `--jsx-runtime classic`), `[install] auto` vs `--no-install`/`-i`/`--install` (`bun run --no-install` still asked the registry), and a `[macros]` table vs `--no-macros` (macros ran anyway). A `preload` key dropped the `--preload`/`--require`/`--import` list entirely; `test/config/bunfig/preload.test.ts` had these cases commented out as a FIXME.
- Cause: `bun <file>` and `bun test` load bunfig.toml inside `Arguments::parse` (`src/runtime/cli/Arguments.rs`, `load_config_with_cmd_args`) before the flags are applied, so flags overwrite it. `bun run <target>` is not in `ALWAYS_LOADS_CONFIG`, so it, the `node` shim (both boot through `RunCommand::boot`, `src/runtime/cli/run_command.rs`), `RunCommand::exec_with_cfg`, `boot_standalone` and `bun repl` load bunfig.toml after argv, and `Bunfig::parse` (`src/bunfig/bunfig.rs`) assigned each key unconditionally.

### Fix

- `ContextData` gets `cli_overrides: CliOverrides` (`src/options_types/context.rs`), one bool per setting; `Arguments::parse` sets the bool where it applies the flag. `Bunfig::parse` still parses and validates each of these keys (so diagnostics do not depend on which flags were passed) but skips the assignment when the flag was given.
- `load_preload` prepends the config's preloads to whatever is already in `ctx.preloads` instead of replacing it. In the early order that list is empty, so nothing changes; in the late order it yields config preloads followed by argv preloads, which is what `Arguments::parse` builds in the early order (and what the existing `cli-merge.ts` fixture asserts).
- The `--no-install`/`-i`/`--install` chain in `Arguments::parse` is reshaped to compute one `Option<GlobalCache>` so the override is recorded in one place; the accepted values and the error are unchanged.
- Why this shape: it makes the parser correct in either load order, so it also covers the `node` shim, `bun repl` and standalone executables without touching each late-load site, and it only changes behavior when a flag and its bunfig key are both present (the buggy combination). It is the pattern `test.pathIgnorePatterns` already uses (`path_ignore_patterns_from_cli`). Moving the `bun run` load earlier instead would change error handling for malformed configs, start applying bunfig to `--filter`/`--parallel` runs, and still leave the node shim on the late path.
- For `jsx`, only `runtime` is guarded by `--jsx-runtime`; `development` keeps following the bunfig `jsx` key as it does today, since no flag sets it (this is also the behavior #36209 gives the early order).
- Intentionally not covered here: the `[run]` keys (#33198 adds the same guards for those), `origin`/`serve.port` (nothing at runtime reads them; `vm.origin` is never set from options), and `smol`/`install.prefer`, which `Arguments::parse` overwrites unconditionally even in the early order, so they need a different fix (reported separately).
- Verification:
  - `test/config/bunfig/cli-flags-override-bunfig.test.ts` (new: the precedence matrix spans eight settings and two load orders, which no existing file covers): for each key, `bun <flag> file`, `bun run <flag> file` and `bun run file`; `[install] auto` uses a local registry stub and checks in both directions. With the released binary exactly the ten `bun run <flag>` cases fail; all 28 pass with this change.
  - `test/config/bunfig/preload.test.ts`: the three `run` forms from the FIXME list are enabled, plus `node -r ./preload3.ts` through `fakeNodeRun`; these four fail on the released binary and pass here. The remaining commented form (`bun --preload x run file`) is a different bug, the subcommand detection problem #36644 is about, and the comment now says so.
  - Also run locally: `test/cli/console-depth.test.ts`, `test/config/bunfig/bunfig-errors.test.ts`, `test/cli/install/bun-run-bunfig.test.ts`, `test/cli/run/as-node.test.ts`, `test/cli/run/run-autoinstall.test.ts`, `test/bundler/transpiler/macro-test.test.ts`, `test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts`, `test/js/bun/resolve/resolve-error.test.ts`; `cargo clippy` on the three crates is clean.

### Background

- `ContextData` (`ctx`) is the process-wide bag of parsed CLI state: `ctx.args` (`TransformOptions`: define, loaders, jsx, ...), `ctx.debug` (auto-install mode, macros), `ctx.runtime_options` (console depth), `ctx.preloads`. Both `Arguments::parse` and `Bunfig::parse` write into it; whichever runs second wins a field.
- `ALWAYS_LOADS_CONFIG` (`src/options_types/command_tag.rs`) lists the subcommands whose bunfig.toml is loaded during `Arguments::parse`. `bun run` was deliberately left out and loads it later in `RunCommand` (#16664), which is why the two orders exist.
- Auto-install modes (`GlobalCache`): `--no-install` disables resolving missing packages from the registry; `fallback` (`-i`) fetches only packages that are not found locally. A manifest request to the configured registry is therefore the observable difference the install test uses.

<details>
<summary>Probe matrix on the released 1.4.0 binary</summary>

```
$ cat bunfig.toml
preload = ["./pre-bunfig.js"]
[loader]
".foo" = "text"
[console]
depth = 1

$ bun --preload ./pre-cli.js --loader .foo:json --console-depth 5 main.mjs
preload:bunfig
preload:cli
loader:object
{ a: { b: { c: { d: 1 } } } }          # printed at depth 5

$ bun run --preload ./pre-cli.js --loader .foo:json --console-depth 5 main.mjs
preload:bunfig                          # --preload dropped
loader:string                           # bunfig [loader] won
{ a: { b: [Object ...] } }              # bunfig depth won

$ echo 'logLevel = "warn"' > bunfig.toml          # no jsx keys at all
$ bun --jsx-runtime classic main.jsx              -> classic:div
$ bun run --jsx-runtime classic main.jsx          -> automatic runtime used

$ printf '[macros]\n"p" = { "x" = "./macro.ts" }\n' > bunfig.toml
$ bun --no-macros main.ts                         -> error: Macros are disabled
$ bun run --no-macros main.ts                     -> macro=42

$ printf '[install]\nauto = "fallback"\nregistry = "http://localhost:<stub>/"\n' > bunfig.toml
$ bun --no-install main.mjs                       -> registry requests: []
$ bun run --no-install main.mjs                   -> registry requests: ["/zz-missing-pkg"]
```

</details>
