### PR TITLE
bundler: resolve in-memory entry points when an onResolve plugin declines them

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2800,6 +2800,24 @@ pub mod bv2_impl {
             Ok(Some(source_index.get()))
         }
 
+        /// Entry points that no plugin claimed are looked up in the `files`
+        /// map before the disk, like `run_resolver` does for imports. Returns
+        /// whether the map had the entry point (it has been enqueued if so).
+        pub(crate) fn enqueue_entry_point_from_file_map(
+            &mut self,
+            entry_point: &[u8],
+            target: options::Target,
+        ) -> Result<bool, Error> {
+            let Some(file_map) = self.file_map else {
+                return Ok(false);
+            };
+            let Some(mut resolved) = file_map.resolve(self.arena(), b"", entry_point) else {
+                return Ok(false);
+            };
+            self.enqueue_entry_item(&mut resolved, true, target)?;
+            Ok(true)
+        }
+
         /// `heap` is not freed when `deinit`ing the BundleV2
         pub fn init(
             transpiler: &'a mut Transpiler<'a>,
@@ -3062,17 +3080,11 @@ pub mod bv2_impl {
                     continue;
                 }
 
-                // Check FileMap first for in-memory entry points
-                if let Some(file_map) = self.file_map {
-                    if let Some(file_map_result) = file_map.resolve(self.arena(), b"", entry_point)
-                    {
-                        let _ = self.enqueue_entry_item(
-                            &mut { file_map_result },
-                            true,
-                            self.transpiler.options.target,
-                        )?;
-                        continue;
-                    }
+                if self.enqueue_entry_point_from_file_map(
+                    entry_point,
+                    self.transpiler.options.target,
+                )? {
+                    continue;
                 }
 
                 // no plugins were matched
@@ -4654,6 +4666,13 @@ pub mod bv2_impl {
                     if resolve.import_record.namespace.as_ref() == b"file" {
                         if resolve.import_record.kind == ImportKind::EntryPointBuild {
                             let target = resolve.import_record.original_target;
+                            match this.enqueue_entry_point_from_file_map(
+                                &resolve.import_record.specifier,
+                                target,
+                            ) {
+                                Ok(false) => {}
+                                Ok(true) | Err(_) => return,
+                            }
                             let Ok(resolved) = this
                                 .transpiler_for_target(target)
                                 .resolve_entry_point(&resolve.import_record.specifier)

--- a/test/bundler/bundler_files.test.ts
+++ b/test/bundler/bundler_files.test.ts
@@ -1,5 +1,7 @@
+import type { BunPlugin, OnResolveCallback } from "bun";
 import { describe, expect, test } from "bun:test";
 import { tempDir } from "harness";
+import { basename } from "node:path";
 
 describe("bundler files option", () => {
   test("basic in-memory file bundling", async () => {
@@ -581,5 +583,127 @@ describe("bundler files option", () => {
 
     const output = await result.outputs[0].text();
     expect(output).toContain("injected by plugin");
+  });
+
+  // An onResolve filter that matches the entry point runs before the files map
+  // is consulted. When the callback declines, the entry point must still come
+  // from the files map, exactly as it does when no plugin matches it.
+  describe("onResolve plugin matching an in-memory entry point and declining", () => {
+    function decliningPlugin(
+      filter: RegExp,
+      seen: string[] = [],
+      result: ReturnType<OnResolveCallback> = undefined,
+    ): BunPlugin {
+      return {
+        name: "declining",
+        setup(build) {
+          build.onResolve({ filter }, args => {
+            seen.push(`${args.kind} ${args.path}`);
+            return result;
+          });
+        },
+      };
+    }
+
+    async function buildOutputs(entrypoint: string, files: Record<string, string>, plugins: BunPlugin[]) {
+      const result = await Bun.build({ entrypoints: [entrypoint], files, plugins, throw: false });
+      expect(result.logs.map(String)).toEqual([]);
+      expect(result.success).toBe(true);
+      return Promise.all(result.outputs.map(async output => [output.path, await output.text()]));
+    }
+
+    const byPath = ([a]: string[], [b]: string[]) => (a < b ? -1 : a > b ? 1 : 0);
+
+    const jsFiles = {
+      "/app/entry.js": `import { value } from "./lib.js"; console.log(value);`,
+      "/app/lib.js": `export const value = "js entry from files";`,
+    };
+
+    const htmlFiles = {
+      "/app/index.html": `<!doctype html><html><body><script src="./app.js"></script></body></html>`,
+      "/app/app.js": `console.log("html entry from files");`,
+    };
+
+    test("JS entry point is bundled from the files map", async () => {
+      const seen: string[] = [];
+      const outputs = await buildOutputs("/app/entry.js", jsFiles, [decliningPlugin(/.*/, seen)]);
+
+      expect(seen).toEqual(["entry-point-build /app/entry.js", "import-statement ./lib.js"]);
+      expect(outputs).toEqual([[expect.any(String), expect.stringContaining("js entry from files")]]);
+    });
+
+    test("HTML entry point is bundled from the files map", async () => {
+      const seen: string[] = [];
+      const outputs = await buildOutputs("/app/index.html", htmlFiles, [decliningPlugin(/.*/, seen)]);
+
+      expect(seen).toEqual(["entry-point-build /app/index.html", "import-statement ./app.js"]);
+      expect(outputs.sort(byPath)).toEqual([
+        [expect.stringMatching(/\.js$/), expect.stringContaining("html entry from files")],
+        [expect.stringMatching(/\.html$/), expect.stringContaining("<script")],
+      ]);
+    });
+
+    test("declining asynchronously is bundled from the files map too", async () => {
+      const outputs = await buildOutputs("/app/entry.js", jsFiles, [
+        decliningPlugin(/.*/, [], Promise.resolve(undefined)),
+      ]);
+
+      expect(outputs).toEqual([[expect.any(String), expect.stringContaining("js entry from files")]]);
+    });
+
+    // These filters match only the entry point, so the imports take the same
+    // route in both builds and the outputs have to be byte-for-byte identical.
+    test.each([
+      ["JS", "/app/entry.js", /entry\.js$/, jsFiles],
+      ["HTML", "/app/index.html", /index\.html$/, htmlFiles],
+    ])("%s build output is identical to a build without the plugin", async (_, entrypoint, filter, files) => {
+      const withPlugin = await buildOutputs(entrypoint, files, [decliningPlugin(filter)]);
+      const withoutPlugin = await buildOutputs(entrypoint, files, []);
+
+      expect(withPlugin).toEqual(withoutPlugin);
+    });
+
+    test("in-memory and on-disk entry points in one build", async () => {
+      using dir = tempDir("bundler-files-declining-plugin", {
+        "disk.js": `console.log("disk entry");`,
+      });
+
+      const result = await Bun.build({
+        entrypoints: [`${dir}/disk.js`, `${dir}/virtual.js`],
+        files: {
+          [`${dir}/virtual.js`]: `console.log("virtual entry");`,
+        },
+        plugins: [decliningPlugin(/.*/)],
+        throw: false,
+      });
+      expect(result.logs.map(String)).toEqual([]);
+      expect(result.success).toBe(true);
+
+      const outputs = await Promise.all(
+        result.outputs.map(async output => [basename(output.path), await output.text()]),
+      );
+      expect(outputs.sort(byPath)).toEqual([
+        ["disk.js", expect.stringContaining("disk entry")],
+        ["virtual.js", expect.stringContaining("virtual entry")],
+      ]);
+    });
+
+    test("entry point missing from both the files map and disk is still an error", async () => {
+      using dir = tempDir("bundler-files-declining-plugin-missing", {});
+
+      const result = await Bun.build({
+        entrypoints: [`${dir}/missing.js`],
+        files: {
+          [`${dir}/other.js`]: `console.log("other");`,
+        },
+        plugins: [decliningPlugin(/.*/)],
+        throw: false,
+      });
+
+      expect(result.logs.map(String)).toEqual([
+        expect.stringMatching(/^BuildMessage: ModuleNotFound resolving ".*missing\.js" \(entry point\)$/),
+      ]);
+      expect(result.success).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
### Problem

- `Bun.build({ entrypoints: ["/v/page.html"], files: { "/v/page.html": ..., "/v/app.js": ... } })` builds, but adding any onResolve plugin whose filter matches the entry point and whose callback returns `undefined` makes the same build fail with `ModuleNotFound resolving "/v/page.html" (entry point)`. Same for `.js` entry points; the loader is irrelevant.
- `enqueue_entry_points_normal` (`src/bundler/bundle_v2.rs`) hands an entry point to the plugins before it consults `self.file_map`. When the plugin declines, `on_resolve`'s `NoMatch` arm for `ImportKind::EntryPointBuild` (previously `bundle_v2.rs:4655`) called `resolve_entry_point` directly, i.e. disk resolution, and never looked at the `files` map. The equivalent `NoMatch` fallback for imports, `run_resolver`, does check the map first, so only entry points were affected.
- The `files` option (#25852) added its lookup to the no-plugin entry path, `run_resolver`, and `resolve_import_records`, but not to this arm, which the earlier virtual-entry-point plugin support (#22144) had added.

### Fix

- New `BundleV2::enqueue_entry_point_from_file_map`: looks the entry point up in the `files` map and, on a hit, enqueues it through `enqueue_entry_item` with the requested target. It replaces the inline lookup in `enqueue_entry_points_normal` and is called from the `NoMatch` arm before the disk fallback.
- Both entry paths now resolve identically: plugins, then the `files` map, then disk. That is already the order used for imports (plugin, then `run_resolver`'s map lookup, then the resolver), and it is what the no-plugin path did for entry points. A plugin that declines is therefore a no-op, which is the contract onResolve has for every other specifier.
- A map hit goes through the same `enqueue_entry_item` call as the no-plugin path (same target, same output naming), so the outputs are byte-identical with and without the declining plugin; a miss still falls through to the unchanged disk path and its existing error.
- The dev server and bake production paths dispatch entry points to plugins too, but never set `file_map`, so the helper is a no-op there.
- Verified with `test/bundler/bundler_files.test.ts` (new `describe` block): JS and HTML virtual entry points with a catch-all declining plugin, an asynchronously declining plugin, byte-for-byte equality with a plugin-free build, a build mixing a virtual and an on-disk entry point, and an entry point missing from both the map and disk still reporting `ModuleNotFound`. 6 of the 7 new tests fail on the released binary (`USE_SYSTEM_BUN=1`), all 30 tests in the file pass with `bun bd test`.
- Also ran `bundler_plugin.test.ts`, `bundler_plugin_chain.test.ts` and `regression/issue/bundler-plugin-onresolve-entrypoint.test.ts` with the debug build: no failures.

### Background

- `files` option / `FileMap`: `Bun.build({ files })` supplies in-memory sources keyed by path. The bundler consults this map (`FileMap::resolve`) before touching the disk wherever it resolves a specifier; a hit yields a resolver result in the `file` namespace whose contents are later read from the map instead of the filesystem.
- onResolve dispatch for entry points: when a registered onResolve filter matches an entry point, the bundler creates a `Resolve` request of kind `EntryPointBuild` and sends it to the plugin on the JS thread. The answer comes back to `BundleV2::on_resolve` as `Success` (plugin supplied a path), `Err`, or `NoMatch` (every callback returned nothing). `NoMatch` is supposed to behave as if no plugin existed.
- `enqueue_entry_item`: registers a resolved entry point in the graph (path to source index map, input file, parse task) and appends it to `graph.entry_points`; both the no-plugin path and the `NoMatch` arm end up here.

<details>
<summary>Repro</summary>

```js
const files = {
  "/v/page.html": `<!doctype html><html><body><script src="./app.js"></script></body></html>`,
  "/v/app.js": `console.log(1)`,
};
const r = await Bun.build({
  entrypoints: ["/v/page.html"],
  files,
  throw: false,
  plugins: [{ name: "p", setup(b) { b.onResolve({ filter: /.*/ }, () => undefined); } }],
});
console.log(r.success, r.logs.map(String));
// bun 1.4.0: false [ 'BuildMessage: ModuleNotFound resolving "/v/page.html" (entry point)' ]
// without `plugins`: true []
```

</details>
