### PR TITLE
inspector: unlink ws+unix:// socket files before a --watch reload

### DIFF
--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -4381,8 +4381,10 @@ pub fn maybe_handle_panic_during_process_reload() {
 }
 
 /// Port of `bun.reloadProcess`. `may_return == true` → returns on failure; `false` → panics.
-/// `on_before_reload_process_posix` clears CLOEXEC on stdio/IPC and resets caught signal
-/// dispositions on all POSIX; the close_range sweep is Linux/BSD only.
+/// `BunDebugger__willReloadProcess` removes the inspector's unix socket file, which the
+/// reloaded process binds again. `on_before_reload_process_posix` clears CLOEXEC on
+/// stdio/IPC and resets caught signal dispositions on all POSIX; the close_range sweep is
+/// Linux/BSD only.
 pub fn reload_process(clear_terminal: bool, may_return: bool) {
     // Exactly one thread may perform the reload: the JS thread and the watcher's grace-window
     // fallback can both reach here, and concurrent execve prep crashes on musl. The swap elects a
@@ -4407,6 +4409,13 @@ pub fn reload_process(clear_terminal: bool, may_return: bool) {
         crate::output::reset_terminal_all();
     }
     crate::output::stdio::restore();
+
+    {
+        unsafe extern "C" {
+            safe fn BunDebugger__willReloadProcess();
+        }
+        BunDebugger__willReloadProcess();
+    }
 
     #[cfg(windows)]
     {

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -4381,7 +4381,7 @@ pub fn maybe_handle_panic_during_process_reload() {
 }
 
 /// Port of `bun.reloadProcess`. `may_return == true` → returns on failure; `false` → panics.
-/// `BunDebugger__willReloadProcess` removes the inspector's unix socket file, which the
+/// `BunDebugger__willReloadProcess` removes the inspector's unix socket files, which the
 /// reloaded process binds again. `on_before_reload_process_posix` clears CLOEXEC on
 /// stdio/IPC and resets caught signal dispositions on all POSIX; the close_range sweep is
 /// Linux/BSD only.

--- a/src/js/internal/debugger.ts
+++ b/src/js/internal/debugger.ts
@@ -388,8 +388,7 @@ class Debugger {
         fetch: this.#fetch.bind(this),
         websocket: this.#websocket,
       });
-      // A --watch reload execs over this process and would otherwise find this
-      // socket file still on disk when it binds the same path again.
+      // Unlinked by a --watch reload, which execs over this process and binds it again.
       addInspectorUnixSocketPath(pathname);
       return;
     }

--- a/src/js/internal/debugger.ts
+++ b/src/js/internal/debugger.ts
@@ -96,6 +96,8 @@ type CreateBackendFn = (
   receive: (...messages: string[]) => void,
 ) => unknown;
 
+const addInspectorUnixSocketPath = $newCppFunction("BunDebugger.cpp", "jsFunction_addInspectorUnixSocketPath", 1);
+
 // CDP translation is only needed for node:inspector servers, so load it lazily.
 let lazyInspectorCDPAdapter: any;
 function cdpAdapterConstructor() {
@@ -386,6 +388,9 @@ class Debugger {
         fetch: this.#fetch.bind(this),
         websocket: this.#websocket,
       });
+      // A --watch reload execs over this process and would otherwise find this
+      // socket file still on disk when it binds the same path again.
+      addInspectorUnixSocketPath(pathname);
       return;
     }
 

--- a/src/jsc/bindings/BunDebugger.cpp
+++ b/src/jsc/bindings/BunDebugger.cpp
@@ -683,9 +683,8 @@ extern "C" void BunDebugger__willHotReload()
     });
 }
 
-// ws+unix:// paths internal/debugger.ts is listening on (--inspect and BUN_INSPECT can
-// each add one). Appended by the debugger thread, read by whichever thread reloads the
-// process (possibly the crash handler): atomic head, entries are never freed.
+// Appended by the debugger thread (one per --inspect / BUN_INSPECT ws+unix:// URL), walked by
+// whichever thread reloads the process, possibly the crash handler; entries are never freed.
 struct InspectorUnixSocket {
     CString path;
     InspectorUnixSocket* next;
@@ -706,10 +705,8 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_addInspectorUnixSocketPath, (JSGlobalObject 
     return JSValue::encode(jsUndefined());
 }
 
-// The reload execs over this process, which closes the sockets but not their files, and
-// the reloaded process binds the same paths again (the unlink Server.stop() would do).
-// A bind still in flight on the debugger thread is not waited for: a reload in that
-// startup window fails with EADDRINUSE as every reload did before this existed.
+// exec closes the sockets but leaves their files, and the reloaded process binds the same paths.
+// A bind still in flight on the debugger thread is not waited for; that reload fails as before.
 extern "C" void BunDebugger__willReloadProcess()
 {
     for (auto* socket = inspectorUnixSockets.load(); socket; socket = socket->next)

--- a/src/jsc/bindings/BunDebugger.cpp
+++ b/src/jsc/bindings/BunDebugger.cpp
@@ -683,11 +683,9 @@ extern "C" void BunDebugger__willHotReload()
     });
 }
 
-// Paths of the unix sockets internal/debugger.ts is listening on: one per
-// ws+unix:// URL, and --inspect and BUN_INSPECT can each supply one. Only the
-// debugger thread appends; the list is read by whichever thread replaces the
-// process (the file watcher, the JS thread, or the crash handler), so the head is
-// published through an atomic and entries are never freed.
+// ws+unix:// paths internal/debugger.ts is listening on (--inspect and BUN_INSPECT can
+// each add one). Appended by the debugger thread, read by whichever thread reloads the
+// process (possibly the crash handler): atomic head, entries are never freed.
 struct InspectorUnixSocket {
     CString path;
     InspectorUnixSocket* next;
@@ -708,15 +706,10 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_addInspectorUnixSocketPath, (JSGlobalObject 
     return JSValue::encode(jsUndefined());
 }
 
-// A watch-mode reload execs over this process: that closes the listening sockets
-// but leaves their files behind, and the reloaded process inherits the same
-// --inspect / BUN_INSPECT values, so it would bind the same paths and fail with
-// EADDRINUSE. Same cleanup Server.stop() does for a unix listener.
-//
-// Not synchronized with a bind in progress on the debugger thread: a reload landing
-// in the microseconds between that bind and its registration (startup only) leaves
-// that file behind and that one reload fails as before. Waiting for that thread here
-// is not worth it, and this also runs from the crash handler.
+// The reload execs over this process, which closes the sockets but not their files, and
+// the reloaded process binds the same paths again (the unlink Server.stop() would do).
+// A bind still in flight on the debugger thread is not waited for: a reload in that
+// startup window fails with EADDRINUSE as every reload did before this existed.
 extern "C" void BunDebugger__willReloadProcess()
 {
     for (auto* socket = inspectorUnixSockets.load(); socket; socket = socket->next)

--- a/src/jsc/bindings/BunDebugger.cpp
+++ b/src/jsc/bindings/BunDebugger.cpp
@@ -683,6 +683,41 @@ extern "C" void BunDebugger__willHotReload()
     });
 }
 
+// Paths of the unix sockets internal/debugger.ts is listening on: one per
+// ws+unix:// URL, and --inspect and BUN_INSPECT can each supply one. Only the
+// debugger thread appends; the list is read by whichever thread replaces the
+// process (the file watcher, the JS thread, or the crash handler), so the head is
+// published through an atomic and entries are never freed.
+struct InspectorUnixSocket {
+    CString path;
+    InspectorUnixSocket* next;
+};
+static std::atomic<InspectorUnixSocket*> inspectorUnixSockets { nullptr };
+
+extern "C" void Bun__unlink(const char*, size_t);
+
+JSC_DEFINE_HOST_FUNCTION(jsFunction_addInspectorUnixSocketPath, (JSGlobalObject * globalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    String path = callFrame->argument(0).toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    inspectorUnixSockets.store(new InspectorUnixSocket { path.utf8(), inspectorUnixSockets.load() });
+    return JSValue::encode(jsUndefined());
+}
+
+// A watch-mode reload execs over this process: that closes the listening sockets
+// but leaves their files behind, and the reloaded process inherits the same
+// --inspect / BUN_INSPECT values, so it would bind the same paths and fail with
+// EADDRINUSE. Same cleanup Server.stop() does for a unix listener.
+extern "C" void BunDebugger__willReloadProcess()
+{
+    for (auto* socket = inspectorUnixSockets.load(); socket; socket = socket->next)
+        Bun__unlink(socket->path.data(), socket->path.length());
+}
+
 JSC_DEFINE_HOST_FUNCTION(jsFunctionCreateConnection, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     auto* debuggerGlobalObject = dynamicDowncast<Zig::GlobalObject>(globalObject);

--- a/src/jsc/bindings/BunDebugger.cpp
+++ b/src/jsc/bindings/BunDebugger.cpp
@@ -712,6 +712,11 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_addInspectorUnixSocketPath, (JSGlobalObject 
 // but leaves their files behind, and the reloaded process inherits the same
 // --inspect / BUN_INSPECT values, so it would bind the same paths and fail with
 // EADDRINUSE. Same cleanup Server.stop() does for a unix listener.
+//
+// Not synchronized with a bind in progress on the debugger thread: a reload landing
+// in the microseconds between that bind and its registration (startup only) leaves
+// that file behind and that one reload fails as before. Waiting for that thread here
+// is not worth it, and this also runs from the crash handler.
 extern "C" void BunDebugger__willReloadProcess()
 {
     for (auto* socket = inspectorUnixSockets.load(); socket; socket = socket->next)

--- a/src/jsc/bindings/BunDebugger.h
+++ b/src/jsc/bindings/BunDebugger.h
@@ -12,4 +12,8 @@ JSC_DECLARE_HOST_FUNCTION(jsFunction_waitForNodeInspectorConnection);
 JSC_DECLARE_HOST_FUNCTION(jsFunction_postNodeInspectorControl);
 JSC_DECLARE_HOST_FUNCTION(jsFunction_closeNodeInspector);
 
+// Called by src/js/internal/debugger.ts once it is listening on a ws+unix://
+// socket, so a watch-mode reload can remove the socket file before exec'ing.
+JSC_DECLARE_HOST_FUNCTION(jsFunction_addInspectorUnixSocketPath);
+
 } // namespace Bun

--- a/src/jsc/bindings/BunDebugger.h
+++ b/src/jsc/bindings/BunDebugger.h
@@ -12,8 +12,7 @@ JSC_DECLARE_HOST_FUNCTION(jsFunction_waitForNodeInspectorConnection);
 JSC_DECLARE_HOST_FUNCTION(jsFunction_postNodeInspectorControl);
 JSC_DECLARE_HOST_FUNCTION(jsFunction_closeNodeInspector);
 
-// Called by src/js/internal/debugger.ts once it is listening on a ws+unix://
-// socket, so a watch-mode reload can remove the socket file before exec'ing.
+// internal/debugger.ts registers each ws+unix:// socket it listens on; a --watch reload unlinks them.
 JSC_DECLARE_HOST_FUNCTION(jsFunction_addInspectorUnixSocketPath);
 
 } // namespace Bun

--- a/test/cli/inspect/inspect.test.ts
+++ b/test/cli/inspect/inspect.test.ts
@@ -1,7 +1,7 @@
 import { Subprocess, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, isPosix, randomPort, tempDir } from "harness";
+import { bunEnv, bunExe, isPosix, isWindows, randomPort, tempDir } from "harness";
 import { join } from "node:path";
 import stripAnsi from "strip-ansi";
 import { WebSocket } from "ws";
@@ -455,6 +455,108 @@ describe("unix domain socket without websocket", () => {
       await runTest(path, [], { ...bunEnv, BUN_INSPECT: "unix:" + path });
     });
   }
+});
+
+// The debug adapter (packages/bun-debug-adapter-protocol) launches `bun --watch` with
+// BUN_INSPECT=ws+unix://<socket> and BUN_INSPECT_NOTIFY=unix://<socket> on POSIX. A watch
+// reload execs over the process with the same argv and environment, so every incarnation
+// has to bind the same socket path and connect to the notify socket again. On Windows the
+// adapter uses TCP and --watch restarts through a parent process instead of exec.
+describe.skipIf(isWindows).concurrent("ws+unix:// inspector under --watch", () => {
+  // stdout only closes because the process is gone, and `exited` rejects with the exit code
+  // and stderr when it is, which is the useful failure to report.
+  function stdoutWaiter(stream: ReadableStream<Uint8Array>, exited: Promise<never>) {
+    const reader = stream.getReader();
+    const decoder = new TextDecoder();
+    let output = "";
+    return async (needle: string) => {
+      while (!output.includes(needle)) {
+        const { value, done } = await reader.read();
+        if (done) return exited;
+        output += decoder.decode(value, { stream: true });
+      }
+    };
+  }
+
+  // `sockets` are the paths the inspector must be listening on; each case names them relative
+  // to the temporary directory.
+  test.each([
+    [
+      "BUN_INSPECT=ws+unix://",
+      (dir: string) => ({ args: [], env: { BUN_INSPECT: `ws+unix://${dir}/env.sock` }, sockets: ["env.sock"] }),
+    ],
+    [
+      "--inspect=ws+unix://",
+      (dir: string) => ({ args: [`--inspect=ws+unix://${dir}/flag.sock`], env: {}, sockets: ["flag.sock"] }),
+    ],
+    [
+      "BUN_INSPECT=ws+unix:// together with --inspect=ws+unix://",
+      (dir: string) => ({
+        args: [`--inspect=ws+unix://${dir}/flag.sock`],
+        env: { BUN_INSPECT: `ws+unix://${dir}/env.sock` },
+        sockets: ["env.sock", "flag.sock"],
+      }),
+    ],
+  ])("%s listens on the same socket again after a reload", async (_, configure) => {
+    const script = (generation: number) => `console.log("generation ${generation}");\nsetInterval(() => {}, 1000);\n`;
+    using dir = tempDir("inspect-watch", { "watchee.js": script(1) });
+    const notifySocket = join(String(dir), "notify.sock");
+    const { args, env, sockets } = configure(String(dir));
+
+    // One connection per incarnation, made once its inspector servers are listening (a process
+    // with both an environment and a flag inspector notifies once, after both are up).
+    const listening = [Promise.withResolvers<void>(), Promise.withResolvers<void>()];
+    let incarnation = 0;
+    using notify = Bun.listen({
+      unix: notifySocket,
+      socket: {
+        open(socket) {
+          listening[incarnation++]?.resolve();
+          socket.end();
+        },
+        data() {},
+      },
+    });
+
+    await using watchee = spawn({
+      cmd: [bunExe(), "--watch", "--no-clear-screen", ...args, "watchee.js"],
+      cwd: String(dir),
+      env: { ...bunEnv, ...env, BUN_INSPECT_NOTIFY: `unix://${notifySocket}` },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const stderr = watchee.stderr.text();
+    const exited = watchee.exited.then(async code => {
+      throw new Error(`bun --watch exited with code ${code}:\n${await stderr}`);
+    });
+    exited.catch(() => {});
+    const stdoutIncludes = stdoutWaiter(watchee.stdout, exited);
+    // The notify connection is made as soon as an incarnation's first inspector is listening,
+    // so with two inspectors the second one may still be binding: retry until each accepts.
+    async function inspectorStatus(socket: string): Promise<number> {
+      while (true) {
+        try {
+          return (await fetch("http://localhost/json/version", { unix: join(String(dir), socket) })).status;
+        } catch (error) {
+          if ((error as { code?: string }).code !== "FailedToOpenSocket") throw error;
+        }
+        await Promise.race([Bun.sleep(10), exited]);
+      }
+    }
+    const inspectorStatuses = () => Promise.all(sockets.map(inspectorStatus));
+
+    await Promise.race([Promise.all([stdoutIncludes("generation 1"), listening[0].promise]), exited]);
+    const beforeReload = await inspectorStatuses();
+
+    // The reload unlinks the old socket files before exec, so once the new incarnation has
+    // notified, anything answering on these paths was bound by the new incarnation.
+    await Bun.write(join(String(dir), "watchee.js"), script(2));
+    await Promise.race([Promise.all([stdoutIncludes("generation 2"), listening[1].promise]), exited]);
+    const afterReload = await inspectorStatuses();
+
+    const allListening = sockets.map(() => 200);
+    expect({ beforeReload, afterReload }).toEqual({ beforeReload: allListening, afterReload: allListening });
+  });
 });
 
 /// TODO: this test is flaky because the inspect may not send all messages before the process exit

--- a/test/cli/inspect/inspect.test.ts
+++ b/test/cli/inspect/inspect.test.ts
@@ -503,8 +503,8 @@ describe.skipIf(isWindows).concurrent("ws+unix:// inspector under --watch", () =
     const notifySocket = join(String(dir), "notify.sock");
     const { args, env, sockets } = configure(String(dir));
 
-    // One connection per incarnation, made once its inspector servers are listening (a process
-    // with both an environment and a flag inspector notifies once, after both are up).
+    // One connection per incarnation: the first inspector to come up notifies and clears the
+    // variable for the second one.
     const listening = [Promise.withResolvers<void>(), Promise.withResolvers<void>()];
     let incarnation = 0;
     using notify = Bun.listen({


### PR DESCRIPTION
### Problem

- `BUN_INSPECT=ws+unix:///tmp/x.sock bun --watch app.js` (what the VS Code extension / `bun-debug-adapter-protocol` launches for `watchMode` on POSIX) debugs the first run only. On the first file change the reloaded program prints `Failed to start inspector:` plus an `internal:debugger` source dump and `EADDRINUSE: address already in use, listen '/tmp/x.sock'`, and exits with code 1. `--inspect=ws+unix://...` together with `--watch` fails the same way.
- Cause: a watch reload goes through `bun_core::reload_process` (`src/bun_core/util.rs:4388`), which execs over the current process. That closes the inspector's listening socket but leaves its file on disk, and the new process gets the same environment and argv, so `internal/debugger.ts` binds the same path again (`src/js/internal/debugger.ts:385`). Nothing unlinked the file: the only unlink for a unix listener is in `Server.stop()` (`src/runtime/server/mod.rs:1726`), which a reload never calls, and bind itself does not unlink (`packages/bun-usockets/src/bsd.c`, `internal_bsd_create_listen_socket_unix`). The listen failure is fatal (`debugger.ts:227`).
- The same thing happens on the crash auto-restart that `--watch` enables, which also ends in `reload_process` (`src/crash_handler/lib.rs:1212`).
- Distinct from #38596, which is about child processes inheriting `BUN_INSPECT`; this is the same process exec'ing itself, and the real environment is deliberately kept across the exec so the reloaded program is debugged again.

### Fix

- `internal/debugger.ts` reports each `ws+unix://` path it has started listening on to `jsFunction_addInspectorUnixSocketPath` (`src/jsc/bindings/BunDebugger.cpp:697`), which keeps the paths in a process-wide list.
- `reload_process` calls `BunDebugger__willReloadProcess` (`BunDebugger.cpp:713`) before replacing the process; it unlinks every recorded path. The fixing line is that call in `util.rs:4417`.
- Why this is the right place: the reload is the moment this process stops serving those sockets, so it removes the files it created, exactly what `Server.stop()` does for a unix listener (it also unlinks while still bound). Every reload path funnels through `reload_process` (file change on the watcher thread, `--watch-kill-signal` listeners on the JS thread, the grace timer, `process.exit()` inside a kill-signal handler, crash auto-restart), so all of them are covered by one call. Nothing is removed that this process did not bind, so a path that is genuinely owned by another process still fails with `EADDRINUSE` as before.
- Why a list and not one slot: `BUN_INSPECT` and `--inspect` each start their own server when both are given, so two `ws+unix://` paths can be live at once; a single slot would leave one of them broken after a reload.
- Why the list is an atomic head with entries that are never freed: only the debugger thread appends (both servers are started from `Debugger::start` on that thread), but the reader is whichever thread happens to reload, including the crash handler, so there is no lock to take and no buffer that could be freed under a reader. At most two small entries exist per process.
- Known and accepted: a reload is not synchronized with a bind that is in flight on the debugger thread. A reload landing in the microseconds between `Bun.serve()` returning and the registration call, or a bind landing between the list walk and `execve`, leaves that file behind and that one reload fails with `EADDRINUSE`, which is the pre-existing behavior. A bind happens once per incarnation during startup, so this is a microsecond window per restart; closing it would need an in-flight bind count held across `Bun.serve()` plus a bounded wait in `reload_process`, which also runs from the crash handler. Documented at `BunDebugger__willReloadProcess`.
- Rejected alternative: unlinking a stale file before bind in `debugger.ts`. That would also make a second process handed the same path silently take it over from a live one (today it fails loudly), and it changes the semantics of the bind rather than cleaning up after the reload.
- Out of scope: a user's own `Bun.serve({ unix })` under `--watch` hits the same `EADDRINUSE` after a reload, but Node's `--watch` with `net.Server.listen(path)` behaves the same way (checked with v26.3.0, see details), so that is left as is; the inspector socket is Bun's own, and its launcher protocol expects the reloaded process to bind it again and re-notify.
- Tests: `test/cli/inspect/inspect.test.ts`, `ws+unix:// inspector under --watch`, three cases: `BUN_INSPECT=ws+unix://`, `--inspect=ws+unix://`, and both at once. Each launches `bun --watch` with `BUN_INSPECT_NOTIFY`, waits for the first incarnation to run and notify, checks `/json/version` over every socket, edits the file, waits for the second incarnation to run and notify, and checks every socket again. The reload unlinks the old files before exec, so anything answering after the second notification was bound by the new incarnation. All three fail on the unmodified binary with `bun --watch exited with code 1: ... EADDRINUSE` and pass with this change (12/12 runs of the debug build). Skipped on Windows: the adapter uses TCP there and `--watch` restarts through a parent process instead of exec.
- Also run: `test/cli/watch/watch.test.ts` (8/8) and the rest of `inspect.test.ts`; the crash auto-restart path was checked by hand (details below).
- `BunDebugger__willReloadProcess` is called on Windows too (it goes through `Bun__unlink`, which is cross-platform), but the Windows reload is a `TerminateProcess` followed by a respawn from the parent, and the adapter does not use `ws+unix://` there, so only the POSIX behavior is tested.

### Background

- `--watch` reload: on POSIX Bun does not restart a child; the running process `execve`s its own executable with its original argv and the live `environ` (`reload_process`). File descriptors are close-on-exec, so listening sockets close, but a unix socket's filesystem entry is only removed by an explicit `unlink`; binding a path whose entry exists fails with `EADDRINUSE` whether or not anything is listening behind it.
- Debugger thread: `--inspect` / `BUN_INSPECT` run `src/js/internal/debugger.ts` on a second JS VM in its own thread. For a `ws+unix://` URL it calls `Bun.serve({ unix })` there; `BunDebugger.cpp` holds the native state shared between that thread and the rest of the process, which is why the path list lives there.
- Launcher protocol: the debug adapter sets `BUN_INSPECT=ws+unix://<tmp path>?wait=1` and `BUN_INSPECT_NOTIFY=unix://<signal path>`; Bun listens on the first and connects to the second once it is listening, and the adapter attaches on every notification. After a reload the new incarnation notifies again, which is how the adapter re-attaches; the stale socket file was the only broken link, and the test drives exactly this handshake.
- `RareData.listening_sockets_for_watch_mode` looks related but is not: it tracks fds of the main VM's servers and nothing drains it on a reload (its Zig-era consumer was behind an always-false `comptime` check and was removed as dead code in #35002); it never knew about the debugger VM's server or about paths.

<details>
<summary>Repro on the unmodified binary and the manual checks</summary>

Stock bun 1.4.0, Linux x64:

```
$ printf 'console.log("v1", process.pid); setInterval(()=>{},1000);\n' > watchme.js
$ BUN_INSPECT=ws+unix:///tmp/w.sock bun --watch --no-clear-screen watchme.js &
$ sed -i s/v1/v2/ watchme.js
v1 527
v2 527
Failed to start inspector:
...
EADDRINUSE: address already in use, listen '/tmp/w.sock'
    path: "/tmp/w.sock",
 syscall: "listen",
   errno: -98,
    code: "EADDRINUSE"
      at #listen (internal:debugger:237:16)
```

Crash auto-restart, unmodified binary (`crashy.js` segfaults 700ms after start via `bun:internal-for-testing`):

```
boot
panic(main thread): Segmentation fault at address 0xDEADBEEF
--- Bun is auto-restarting due to crash ---
boot
Failed to start inspector:
EADDRINUSE: address already in use, listen '/tmp/crashreload/i.sock'
exit: 1
```

Same script with this change (debug build, 40 seconds): 7 boots, 6 auto-restarts, no `Failed to start inspector`.

Node 26.3.0 for comparison, `node --watch` with `net.createServer().listen("/tmp/napp.sock")`, then editing the file:

```
listening v1
Restarting 'nsrv.js'
error: EADDRINUSE
```

</details>
