### PR TITLE
docs: restore the Remix guide (for Remix 3) and the blob.stream chunk-size sections

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -385,6 +385,7 @@
               "/guides/ecosystem/prisma-postgres",
               "/guides/ecosystem/qwik",
               "/guides/ecosystem/react",
+              "/guides/ecosystem/remix",
               "/guides/ecosystem/tanstack-start",
               "/guides/ecosystem/sentry",
               "/guides/ecosystem/solidstart",

--- a/docs/guides/binary/buffer-to-readablestream.mdx
+++ b/docs/guides/binary/buffer-to-readablestream.mdx
@@ -28,20 +28,14 @@ const stream = blob.stream();
 
 ---
 
-To control the chunk size, split the `Buffer` into chunks and enqueue each one individually.
+Pass a number to `.stream()` to set the chunk size.
 
 ```ts
 const buf = Buffer.from("hello world");
-const chunkSize = 1024;
+const blob = new Blob([buf]);
 
-const stream = new ReadableStream({
-  start(controller) {
-    for (let i = 0; i < buf.length; i += chunkSize) {
-      controller.enqueue(buf.subarray(i, i + chunkSize));
-    }
-    controller.close();
-  },
-});
+// set chunk size of 1024 bytes
+const stream = blob.stream(1024);
 ```
 
 ---

--- a/docs/guides/binary/typedarray-to-readablestream.mdx
+++ b/docs/guides/binary/typedarray-to-readablestream.mdx
@@ -28,20 +28,14 @@ const stream = blob.stream();
 
 ---
 
-To control the chunk size, split the `Uint8Array` into chunks and enqueue each one individually.
+Pass a number to `.stream()` to set the chunk size.
 
 ```ts
 const arr = new Uint8Array(64);
-const chunkSize = 1024;
+const blob = new Blob([arr]);
 
-const stream = new ReadableStream({
-  start(controller) {
-    for (let i = 0; i < arr.length; i += chunkSize) {
-      controller.enqueue(arr.slice(i, i + chunkSize));
-    }
-    controller.close();
-  },
-});
+// set chunk size of 1024 bytes
+const stream = blob.stream(1024);
 ```
 
 ---

--- a/docs/guides/ecosystem/remix.mdx
+++ b/docs/guides/ecosystem/remix.mdx
@@ -1,0 +1,98 @@
+---
+title: Build an app with Remix and Bun
+sidebarTitle: Remix with Bun
+mode: center
+---
+
+[Remix 3](https://github.com/remix-run/remix) is a web framework built from standalone packages (a router, HTML rendering, sessions, form parsing, and more) that are distributed together as the `remix` package. It is published under the `next` tag on npm while it is in beta, and its server runs on Bun as-is.
+
+<Note>This guide covers Remix 3. Remix 2 projects are created with `create-remix` instead.</Note>
+
+---
+
+Scaffold a new project with the Remix CLI.
+
+```sh terminal icon="terminal"
+bunx remix@next new my-remix-app
+```
+
+```txt
+• Prepare target directory...
+✓ Prepare target directory
+• Generate scaffold files...
+✓ Generate scaffold files
+• Finalize package.json...
+✓ Finalize package.json
+
+Created My Remix App at my-remix-app
+```
+
+Then install its dependencies.
+
+```sh terminal icon="terminal"
+cd my-remix-app
+bun install
+```
+
+---
+
+The generated `server.ts` creates a `node:http` server that hands every request to the app's router. Bun runs it directly; pass `--watch` to restart the server whenever a file it imports changes.
+
+```sh terminal icon="terminal"
+bun --watch server.ts
+```
+
+```txt
+Server listening on http://localhost:44100
+```
+
+Open [http://localhost:44100](http://localhost:44100) to see the starter page. The routes live in `app/routes.ts` and `app/router.ts`, and the starter home page is rendered by `app/actions/home-page.tsx`.
+
+---
+
+The `scripts` generated in `package.json` run the server with Node.js and the `remix/node-tsx` TypeScript loader. Bun runs TypeScript itself, so point the scripts at `bun` instead.
+
+```json package.json icon="file-json"
+{
+  "scripts": {
+    "dev": "NODE_ENV=development node --watch --import remix/node-tsx server.ts", // [!code --]
+    "dev": "bun --watch server.ts", // [!code ++]
+    "start": "NODE_ENV=production node --import remix/node-tsx server.ts", // [!code --]
+    "start": "NODE_ENV=production bun server.ts" // [!code ++]
+  }
+}
+```
+
+```sh terminal icon="terminal"
+bun run dev
+```
+
+```txt
+$ bun --watch server.ts
+Server listening on http://localhost:44100
+```
+
+<Note>
+  The generated `hmr` script (`hmr.ts`) also loads `remix/node-tsx`, which relies on `module.registerHooks()`. Bun does
+  not implement that API yet (see [Node.js compatibility](/runtime/nodejs-compat#node-module)), so the script fails
+  under Bun; `bun --watch` restarts the server on changes instead.
+</Note>
+
+---
+
+The router is a `fetch` handler, so the app can also be served with [`Bun.serve()`](/runtime/http/server) instead of `node:http`.
+
+```ts server.ts icon="/icons/typescript.svg"
+import { router } from "./app/router.ts";
+
+const server = Bun.serve({
+  port: 44100,
+  fetch: request => router.fetch(request),
+});
+
+console.log(`Server listening on ${server.url}`);
+```
+
+---
+
+See the Remix [documentation](https://github.com/remix-run/remix/tree/main/docs) to learn more.

--- a/docs/snippets/guides.jsx
+++ b/docs/snippets/guides.jsx
@@ -134,6 +134,7 @@ export const GuidesList = () => {
           { title: "Build an app with Nuxt and Bun", href: "/guides/ecosystem/nuxt" },
           { title: "Build an app with Qwik and Bun", href: "/guides/ecosystem/qwik" },
           { title: "Build an app with Astro and Bun", href: "/guides/ecosystem/astro" },
+          { title: "Build an app with Remix and Bun", href: "/guides/ecosystem/remix" },
           { title: "Use TanStack Start with Bun", href: "/guides/ecosystem/tanstack-start" },
           { title: "Run Bun as a daemon with systemd", href: "/guides/ecosystem/systemd" },
           { title: "Build an app with Next.js and Bun", href: "/guides/ecosystem/nextjs" },


### PR DESCRIPTION
Follow-up to #38441, requested by @alii: keep the Remix guide (updated) rather than removing it, and keep the `blob.stream(chunkSize)` sections.

### Problem
- #38441 removed `guides/ecosystem/remix` because the page documented the Remix v2 `create-remix` flow while the Remix name now refers to Remix 3. The right outcome is a guide for creating a current Remix app, not no guide.
- #38441 also removed the "pass a number to `.stream()` to set the chunk size" paragraphs from `binary/typedarray-to-readablestream` and `binary/buffer-to-readablestream` because the argument has no effect when run. The argument is real API (`Blob.rs` parses it and `ByteBlobLoader` stores it; `on_pull` just never uses it), so that is a runtime bug, and the docs should describe the intended behavior.

### Fix
- `guides/ecosystem/remix` is back, rewritten for Remix 3 (`remix@3.0.0-beta.6`, the `next` dist-tag): `bunx remix@next new`, `bun install`, running the generated `server.ts` with `bun --watch`, switching the generated `package.json` scripts from `node --import remix/node-tsx` to `bun`, and a `Bun.serve()` variant since the router is a `fetch` handler. It also notes that the generated `hmr` script fails under Bun because `remix/node-tsx` needs `module.registerHooks()`, which the compatibility page lists as missing. Every command and output on the page was run: the scaffold, `bun install`, `bun --watch server.ts` (including a restart on edit), `bun run dev` / `bun run start` with the replaced scripts, the `Bun.serve()` server (home page and the `/assets/...` script both return 200), and the `hmr` failure.
- The page's entries in `docs/docs.json` and `docs/snippets/guides.jsx` are restored at their previous positions (190 guide files, 190 nav entries).
- The two binary guides are restored to their pre-#38441 text. The runtime bug (chunk size ignored for in-memory and file-backed blobs, and `stream()` declared without the parameter in `bun-types`) has been handed off and is being fixed separately.
- Verified with `prettier`, a fence/internal-link check on the new page, and the nav cross-check.

### Background
- Remix 3 is distributed as the single `remix` package, whose CLI (`remix new`) scaffolds a project with a `server.ts` that builds a `node:http` server from `remix/node-fetch-server` and an `app/` directory holding the router; `node:http` works in Bun, which is why the generated server runs unmodified. The template's npm scripts exist to give Node.js a TypeScript loader, which Bun does not need.
- Guides are listed in two places besides their own file (sidebar navigation in `docs/docs.json`, guides index in `docs/snippets/guides.jsx`), which is why restoring one touches three files.
