### PR TITLE
bundler: create the HTML import manifest on the plugin and in-memory resolution paths

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2287,11 +2287,12 @@ pub mod bv2_impl {
                         // For virtual files, use the path text as-is (no relative path computation needed).
                         path_primary.pretty = self.arena().alloc_slice_copy(path_primary.text);
                         if self.is_server_html_import(loader, target) {
-                            // Fills the map slot reserved by `get_or_put` above with the
-                            // manifest module; `value_ptr` is not used on this path.
                             let manifest_source_index = self
                                 .enqueue_server_html_import(&file_map_result, &path_primary, target)
                                 .expect("oom");
+                            // SAFETY: see `value_ptr` note above; only the browser graph's map
+                            // was touched since.
+                            unsafe { *value_ptr = manifest_source_index };
                             let record: &mut ImportRecord =
                                 &mut self.graph.ast.items_import_records_mut()
                                     [import_record.importer_source_index as usize]
@@ -2548,6 +2549,9 @@ pub mod bv2_impl {
                 if self.is_server_html_import(loader, target) {
                     let manifest_source_index = self
                         .enqueue_server_html_import(&resolve_result, &path, target)
+                        .expect("oom");
+                    self.path_to_source_index_map(target)
+                        .put(path.text, manifest_source_index)
                         .expect("oom");
                     let record: &mut ImportRecord = &mut self.graph.ast.items_import_records_mut()
                         [import_record.importer_source_index as usize]
@@ -4817,8 +4821,6 @@ pub mod bv2_impl {
                                     },
                                     ..Default::default()
                                 };
-                                // Fills the map slot reserved by `get_or_put` above with
-                                // the manifest module; `value_ptr` is not used on this path.
                                 let manifest_source_index = this
                                     .enqueue_server_html_import(
                                         &resolve_result,
@@ -4826,6 +4828,9 @@ pub mod bv2_impl {
                                         resolve.import_record.original_target,
                                     )
                                     .expect("oom");
+                                // SAFETY: map slot from `get_or_put` above; only the browser
+                                // graph's map was touched since.
+                                unsafe { *value_ptr = manifest_source_index };
                                 out_source_index = Some(Index::init(manifest_source_index));
                                 is_html_manifest = true;
                             } else {
@@ -6223,8 +6228,7 @@ pub mod bv2_impl {
                 // SAFETY: see note above — raw `*mut Transpiler` lives for `'a`.
                 let transpiler: &mut Transpiler<'a> = unsafe { &mut *transpiler_ptr };
 
-                // Check the FileMap first for in-memory files. A hit takes the place of
-                // the resolver's result and is handled like a file on disk from there on.
+                // An in-memory file stands in for the resolver's result from here on.
                 let in_memory_result: Option<_resolver::Result> =
                     self.file_map.and_then(|file_map| {
                         file_map.resolve(self.arena(), source.path.text, import_record.path.text)
@@ -6233,8 +6237,7 @@ pub mod bv2_impl {
                 let mut had_busted_dir_cache = false;
                 let resolve_result: _resolver::Result = 'inner: loop {
                     if let Some(mut result) = in_memory_result {
-                        // The resolver fills this in from the transpiler (and tsconfig.json);
-                        // an in-memory file has no tsconfig.json.
+                        // No tsconfig.json to take these from.
                         result.jsx = transpiler.options.jsx.clone();
                         break result;
                     }
@@ -6620,10 +6623,13 @@ pub mod bv2_impl {
                 }
 
                 if is_html_entrypoint {
-                    import_record.source_index = Index::init(
-                        self.generate_server_html_module(path, target)
-                            .expect("unreachable"),
-                    );
+                    let manifest_source_index = self
+                        .generate_server_html_module(path, target)
+                        .expect("unreachable");
+                    self.path_to_source_index_map(target)
+                        .put(path.text, manifest_source_index)
+                        .expect("oom");
+                    import_record.source_index = Index::init(manifest_source_index);
                 }
             }
 
@@ -6850,12 +6856,10 @@ pub mod bv2_impl {
             }
         }
 
-        /// Creates the module a server-side import of the HTML file at `path`
-        /// binds to, and registers it under `path` in `target`'s graph. Its AST
-        /// is a lazy export of a unique key that the linker replaces with the
-        /// manifest of the HTML entry point's outputs (see `HTMLImportManifest`);
-        /// the HTML file itself is bundled separately, as an entry point of the
-        /// browser graph. Returns the new module's source index.
+        /// Creates the module a server-side import of the HTML file at `path` binds
+        /// to: a lazy export of a placeholder the linker replaces with the manifest
+        /// of the page's browser build (see `HTMLImportManifest`). Returns its source
+        /// index; the caller registers it in `target`'s path map.
         fn generate_server_html_module(
             &mut self,
             path: &Fs::Path,
@@ -6935,8 +6939,6 @@ pub mod bv2_impl {
             self.graph.input_files.append(fake_input_file)?;
             let _ = self.graph.ast.append(ast_for_html_entrypoint); // OOM/capacity: fire-and-forget
 
-            self.path_to_source_index_map(target)
-                .put(path.text, fake_source_index.0)?;
             self.graph
                 .html_imports
                 .server_source_indices
@@ -6945,22 +6947,17 @@ pub mod bv2_impl {
             Ok(fake_source_index.0)
         }
 
-        /// Whether an import record resolving to a file bundled with `loader`
-        /// from a graph targeting `target` is an HTML import in the sense of
-        /// [`Self::generate_server_html_module`]. Under the dev server, HTML
-        /// files are routes it owns, never modules of the server graph.
+        /// Whether an import of a file bundled with `loader` from a `target` graph
+        /// binds to a [`Self::generate_server_html_module`] (the dev server serves
+        /// HTML files as routes instead).
         fn is_server_html_import(&self, loader: Loader, target: options::Target) -> bool {
             loader == Loader::Html && target.is_server_side() && self.dev_server.is_none()
         }
 
-        /// The counterpart of what `resolve_import_records` + `process_resolve_queue`
-        /// do for an HTML import on the bulk resolution path, for the paths that
-        /// enqueue a resolved import record one at a time (`run_resolver` and
-        /// `on_resolve`): the server graph gets the manifest module, and the HTML
-        /// file is parsed once as a browser entry point, however many server files
-        /// import it and whether or not it is also a user-specified entry point.
-        /// `path` must already have its `pretty` initialized. Returns the manifest
-        /// module's source index, which is what the import record binds to.
+        /// What `resolve_import_records` + `process_resolve_queue` do for an HTML
+        /// import, for the paths that enqueue one resolved import at a time: creates
+        /// the manifest module (returned; the caller registers and binds it) and
+        /// parses the HTML file as a browser entry point unless that graph has it.
         fn enqueue_server_html_import(
             &mut self,
             resolve_result: &_resolver::Result,

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -6856,10 +6856,9 @@ pub mod bv2_impl {
             }
         }
 
-        /// Creates the module a server-side import of the HTML file at `path` binds
-        /// to: a lazy export of a placeholder the linker replaces with the manifest
-        /// of the page's browser build (see `HTMLImportManifest`). Returns its source
-        /// index; the caller registers it in `target`'s path map.
+        /// The module a server-side import of `path` binds to: a placeholder export the
+        /// linker replaces with the page's manifest. The caller registers the returned
+        /// index in `target`'s path map.
         fn generate_server_html_module(
             &mut self,
             path: &Fs::Path,
@@ -6947,17 +6946,15 @@ pub mod bv2_impl {
             Ok(fake_source_index.0)
         }
 
-        /// Whether an import of a file bundled with `loader` from a `target` graph
-        /// binds to a [`Self::generate_server_html_module`] (the dev server serves
-        /// HTML files as routes instead).
+        /// Whether an import resolved with `loader` from a `target` graph binds to a
+        /// manifest module. The dev server serves HTML files as routes instead.
         fn is_server_html_import(&self, loader: Loader, target: options::Target) -> bool {
             loader == Loader::Html && target.is_server_side() && self.dev_server.is_none()
         }
 
-        /// What `resolve_import_records` + `process_resolve_queue` do for an HTML
-        /// import, for the paths that enqueue one resolved import at a time: creates
-        /// the manifest module (returned; the caller registers and binds it) and
-        /// parses the HTML file as a browser entry point unless that graph has it.
+        /// HTML import resolved outside the bulk pass: creates the manifest module (the
+        /// caller registers and binds the returned index) and parses the page as a
+        /// browser entry point unless that graph already has it.
         fn enqueue_server_html_import(
             &mut self,
             resolve_result: &_resolver::Result,

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -6223,96 +6223,21 @@ pub mod bv2_impl {
                 // SAFETY: see note above — raw `*mut Transpiler` lives for `'a`.
                 let transpiler: &mut Transpiler<'a> = unsafe { &mut *transpiler_ptr };
 
-                // Check the FileMap first for in-memory files
-                if let Some(file_map) = self.file_map {
-                    if let Some(_file_map_result) =
+                // Check the FileMap first for in-memory files. A hit takes the place of
+                // the resolver's result and is handled like a file on disk from there on.
+                let in_memory_result: Option<_resolver::Result> =
+                    self.file_map.and_then(|file_map| {
                         file_map.resolve(self.arena(), source.path.text, import_record.path.text)
-                    {
-                        let mut file_map_result = _file_map_result;
-                        let mut path_primary = file_map_result.path_pair.primary;
-                        let import_record_loader = import_record.loader.unwrap_or_else(|| {
-                            Fs::Path::init(path_primary.text)
-                                .loader(&transpiler.options.loaders)
-                                .unwrap_or(Loader::File)
-                        });
-                        import_record.loader = Some(import_record_loader);
-
-                        if let Some(id) =
-                            self.path_to_source_index_map(target).get(path_primary.text)
-                        {
-                            import_record.source_index = Index::init(id);
-                            continue;
-                        }
-
-                        let is_html_entrypoint =
-                            self.is_server_html_import(import_record_loader, target);
-                        if is_html_entrypoint {
-                            import_record.kind = ImportKind::HtmlManifest;
-                        }
-
-                        let resolve_entry =
-                            resolve_queue.get_or_put(path_primary.text).expect("oom");
-                        if resolve_entry.found_existing {
-                            // SAFETY: arena-allocated `ParseTask` stored in the queue; arena outlives the pass.
-                            import_record.path =
-                                path_as_static(&unsafe { &**resolve_entry.value_ptr }.path);
-                            continue;
-                        }
-
-                        // For virtual files, use the path text as-is (no relative path computation needed).
-                        // SAFETY: arena outlives the bundle pass; raw-pointer detour erases the
-                        // `&self` lifetime so the resulting `&'static [u8]` doesn't pin `self`
-                        // (otherwise `path_primary: Path<'static>` forces `&self: 'static`,
-                        // cascading borrow conflicts into every `&mut self` call below).
-                        path_primary.pretty = unsafe {
-                            bun_ptr::detach_lifetime(
-                                self.arena().alloc_slice_copy(path_primary.text),
-                            )
-                        };
-                        import_record.path = path_as_static(&path_primary);
-                        let _ = path_primary.text; // key already interned by get_or_put
-                        bun_core::scoped_log!(
-                            Bundle,
-                            "created ParseTask from FileMap: {}",
-                            bstr::BStr::new(&path_primary.text)
-                        );
-                        file_map_result.path_pair.primary = path_primary;
-                        // Arena-owned.
-                        let resolve_task_val =
-                            ParseTask::init(&file_map_result, bun_ast::Index::INVALID, self);
-                        // SAFETY: arena outlives the bundle pass.
-                        let resolve_task: &mut ParseTask = self.arena_create(resolve_task_val);
-                        resolve_task.known_target = if is_html_entrypoint {
-                            Target::Browser
-                        } else {
-                            target
-                        };
-                        // Use transpiler JSX options, applying force_node_env like the disk path does
-                        resolve_task.jsx = transpiler.options.jsx.clone();
-                        resolve_task.jsx.development = match transpiler.options.force_node_env {
-                            options::ForceNodeEnv::Development => true,
-                            options::ForceNodeEnv::Production => false,
-                            options::ForceNodeEnv::Unspecified => {
-                                transpiler.options.jsx.development
-                            }
-                        };
-                        resolve_task.loader = Some(import_record_loader);
-                        resolve_task.tree_shaking = transpiler.options.tree_shaking;
-                        resolve_task.side_effects = bun_ast::SideEffects::HasSideEffects;
-                        *resolve_entry.value_ptr = resolve_task;
-
-                        if is_html_entrypoint {
-                            import_record.source_index = Index::init(
-                                self.generate_server_html_module(&path_primary, target)
-                                    .expect("unreachable"),
-                            );
-                        }
-                        continue;
-                    }
-                }
-
+                    });
+                let is_in_memory = in_memory_result.is_some();
                 let mut had_busted_dir_cache = false;
                 let resolve_result: _resolver::Result = 'inner: loop {
+                    if let Some(mut result) = in_memory_result {
+                        // The resolver fills this in from the transpiler (and tsconfig.json);
+                        // an in-memory file has no tsconfig.json.
+                        result.jsx = transpiler.options.jsx.clone();
+                        break result;
+                    }
                     match transpiler.resolver.resolve_with_framework(
                         source_dir,
                         import_record.path.text,
@@ -6647,9 +6572,18 @@ pub mod bv2_impl {
                     continue;
                 }
 
-                *path = self
-                    .path_with_pretty_initialized(path, target)
-                    .expect("oom");
+                if is_in_memory {
+                    // For virtual files, use the path text as-is (no relative path computation needed).
+                    // SAFETY: arena outlives the bundle pass; raw-pointer detour erases the
+                    // `&self` lifetime so the resulting `&'static [u8]` doesn't pin `self`.
+                    path.pretty = unsafe {
+                        bun_ptr::detach_lifetime(self.arena().alloc_slice_copy(path.text))
+                    };
+                } else {
+                    *path = self
+                        .path_with_pretty_initialized(path, target)
+                        .expect("oom");
+                }
 
                 import_record.path = path_as_static(path);
                 // key already interned by get_or_put — no key_ptr on StringHashMapGetOrPut

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2286,6 +2286,21 @@ pub mod bv2_impl {
                         };
                         // For virtual files, use the path text as-is (no relative path computation needed).
                         path_primary.pretty = self.arena().alloc_slice_copy(path_primary.text);
+                        if self.is_server_html_import(loader, target) {
+                            // Fills the map slot reserved by `get_or_put` above with the
+                            // manifest module; `value_ptr` is not used on this path.
+                            let manifest_source_index = self
+                                .enqueue_server_html_import(&file_map_result, &path_primary, target)
+                                .expect("oom");
+                            let record: &mut ImportRecord =
+                                &mut self.graph.ast.items_import_records_mut()
+                                    [import_record.importer_source_index as usize]
+                                    .as_mut_slice()
+                                    [import_record.import_record_index as usize];
+                            record.source_index = Index::init(manifest_source_index);
+                            record.kind = ImportKind::HtmlManifest;
+                            return;
+                        }
                         let mut tmp_source = bun_ast::Source {
                             path: path_as_static(&path_primary),
                             contents: std::borrow::Cow::Borrowed(&b""[..]),
@@ -2529,8 +2544,18 @@ pub mod bv2_impl {
                     break 'brk path
                         .loader(unsafe { &(*transpiler).options.loaders })
                         .unwrap_or(Loader::File);
-                    // HTML is only allowed at the entry point.
                 };
+                if self.is_server_html_import(loader, target) {
+                    let manifest_source_index = self
+                        .enqueue_server_html_import(&resolve_result, &path, target)
+                        .expect("oom");
+                    let record: &mut ImportRecord = &mut self.graph.ast.items_import_records_mut()
+                        [import_record.importer_source_index as usize]
+                        .as_mut_slice()[import_record.import_record_index as usize];
+                    record.source_index = Index::init(manifest_source_index);
+                    record.kind = ImportKind::HtmlManifest;
+                    return;
+                }
                 let mut tmp_source = bun_ast::Source {
                     path: path_as_static(&path.dupe_alloc(self.arena()).expect("oom")),
                     contents: std::borrow::Cow::Borrowed(&b""[..]),
@@ -4724,6 +4749,7 @@ pub mod bv2_impl {
                 }
                 jsc_api::JSBundler::ResolveValue::Success(result) => {
                     let mut out_source_index: Option<Index> = None;
+                    let mut is_html_manifest = false;
                     if !result.external {
                         // SAFETY: `result.{path,namespace}` are `Box<[u8]>` whose heap
                         // allocations are moved into `this.free_list` below (in the
@@ -4774,84 +4800,116 @@ pub mod bv2_impl {
                                 .expect("oom");
                             // `GetOrPutResult` has no `key_ptr` — `get_or_put` already
                             // duped the key into the map (see PathToSourceIndexMap.rs).
-
-                            // We need to parse this
-                            let source_index =
-                                Index::init(u32::try_from(this.graph.ast.len()).expect("int cast"));
-                            // SAFETY: map slot from `get_or_put` above; map not mutated since.
-                            unsafe { *value_ptr = source_index.get() };
-                            out_source_index = Some(source_index);
-                            let _ = this.graph.ast.append(JSAst::empty_in(this.graph.heap)); // OOM/capacity: fire-and-forget
                             let loader = path
                                 .loader(&this.transpiler.options.loaders)
                                 .unwrap_or(Loader::File);
 
-                            this.graph
-                                .input_files
-                                .append(crate::Graph::InputFile {
-                                    source: bun_ast::Source {
-                                        // Shim to the field-identical `bun_paths::fs::Path<'static>`.
-                                        path: path_as_static(&path),
-                                        contents: std::borrow::Cow::Borrowed(&b""[..]),
-                                        index: bun_ast::Index(source_index.get()),
+                            if resolve.import_record.kind != ImportKind::EntryPointBuild
+                                && this.is_server_html_import(
+                                    loader,
+                                    resolve.import_record.original_target,
+                                )
+                            {
+                                let resolve_result = _resolver::Result {
+                                    path_pair: _resolver::PathPair {
+                                        primary: path,
                                         ..Default::default()
                                     },
-                                    loader,
-                                    side_effects: bun_ast::SideEffects::HasSideEffects,
                                     ..Default::default()
-                                })
-                                .expect("unreachable");
-                            let task_val = ParseTask {
-                                // SAFETY: `from_mut(this)` is the live bundle (write provenance);
-                                // outlives the task.
-                                ctx: Some(unsafe {
-                                    bun_ptr::ParentRef::from_raw_mut(
-                                        std::ptr::from_mut::<BundleV2>(this)
-                                            .cast::<BundleV2<'static>>(),
+                                };
+                                // Fills the map slot reserved by `get_or_put` above with
+                                // the manifest module; `value_ptr` is not used on this path.
+                                let manifest_source_index = this
+                                    .enqueue_server_html_import(
+                                        &resolve_result,
+                                        &path,
+                                        resolve.import_record.original_target,
                                     )
-                                }),
-                                path,
-                                // unknown at this point:
-                                contents_or_fd: parse_task::ContentsOrFd::Fd {
-                                    dir: bun_sys::Fd::INVALID,
-                                    file: bun_sys::Fd::INVALID,
-                                },
-                                side_effects: bun_ast::SideEffects::HasSideEffects,
-                                jsx: this
-                                    .transpiler_for_target(resolve.import_record.original_target)
-                                    .options
-                                    .jsx
-                                    .clone(),
-                                source_index: bun_ast::Index::init(source_index.get()),
-                                module_type: options::ModuleType::Unknown,
-                                loader: Some(loader),
-                                tree_shaking: this.linker.options.tree_shaking,
-                                known_target: resolve.import_record.original_target,
-                                ..Default::default()
-                            };
-                            // Arena-owned.
-                            // SAFETY: arena outlives the bundle pass.
-                            let task: &mut ParseTask = this.arena_create(task_val);
-                            task.task.node.next = core::ptr::null_mut();
-                            task.io_task.node.next = core::ptr::null_mut();
-                            this.increment_scan_counter();
+                                    .expect("oom");
+                                out_source_index = Some(Index::init(manifest_source_index));
+                                is_html_manifest = true;
+                            } else {
+                                // We need to parse this
+                                let source_index = Index::init(
+                                    u32::try_from(this.graph.ast.len()).expect("int cast"),
+                                );
+                                // SAFETY: map slot from `get_or_put` above; map not mutated since.
+                                unsafe { *value_ptr = source_index.get() };
+                                out_source_index = Some(source_index);
+                                let _ = this.graph.ast.append(JSAst::empty_in(this.graph.heap)); // OOM/capacity: fire-and-forget
 
-                            if !this.enqueue_on_load_plugin_if_needed(task) {
-                                if loader.should_copy_for_bundling() {
-                                    let additional_files: &mut bun_alloc::AstVec<
-                                        crate::AdditionalFile,
-                                    > = &mut this.graph.input_files.items_additional_files_mut()
-                                        [source_index.get() as usize];
-                                    additional_files.push(crate::AdditionalFile::SourceIndex(
-                                        task.source_index.get(),
-                                    ));
-                                    this.graph.input_files.items_side_effects_mut()
-                                        [source_index.get() as usize] =
-                                        bun_ast::SideEffects::NoSideEffectsPureData;
-                                    this.graph.estimated_file_loader_count += 1;
+                                this.graph
+                                    .input_files
+                                    .append(crate::Graph::InputFile {
+                                        source: bun_ast::Source {
+                                            // Shim to the field-identical `bun_paths::fs::Path<'static>`.
+                                            path: path_as_static(&path),
+                                            contents: std::borrow::Cow::Borrowed(&b""[..]),
+                                            index: bun_ast::Index(source_index.get()),
+                                            ..Default::default()
+                                        },
+                                        loader,
+                                        side_effects: bun_ast::SideEffects::HasSideEffects,
+                                        ..Default::default()
+                                    })
+                                    .expect("unreachable");
+                                let task_val = ParseTask {
+                                    // SAFETY: `from_mut(this)` is the live bundle (write provenance);
+                                    // outlives the task.
+                                    ctx: Some(unsafe {
+                                        bun_ptr::ParentRef::from_raw_mut(
+                                            std::ptr::from_mut::<BundleV2>(this)
+                                                .cast::<BundleV2<'static>>(),
+                                        )
+                                    }),
+                                    path,
+                                    // unknown at this point:
+                                    contents_or_fd: parse_task::ContentsOrFd::Fd {
+                                        dir: bun_sys::Fd::INVALID,
+                                        file: bun_sys::Fd::INVALID,
+                                    },
+                                    side_effects: bun_ast::SideEffects::HasSideEffects,
+                                    jsx: this
+                                        .transpiler_for_target(
+                                            resolve.import_record.original_target,
+                                        )
+                                        .options
+                                        .jsx
+                                        .clone(),
+                                    source_index: bun_ast::Index::init(source_index.get()),
+                                    module_type: options::ModuleType::Unknown,
+                                    loader: Some(loader),
+                                    tree_shaking: this.linker.options.tree_shaking,
+                                    known_target: resolve.import_record.original_target,
+                                    ..Default::default()
+                                };
+                                // Arena-owned.
+                                // SAFETY: arena outlives the bundle pass.
+                                let task: &mut ParseTask = this.arena_create(task_val);
+                                task.task.node.next = core::ptr::null_mut();
+                                task.io_task.node.next = core::ptr::null_mut();
+                                this.increment_scan_counter();
+
+                                if !this.enqueue_on_load_plugin_if_needed(task) {
+                                    if loader.should_copy_for_bundling() {
+                                        let additional_files: &mut bun_alloc::AstVec<
+                                            crate::AdditionalFile,
+                                        > = &mut this
+                                            .graph
+                                            .input_files
+                                            .items_additional_files_mut()
+                                            [source_index.get() as usize];
+                                        additional_files.push(crate::AdditionalFile::SourceIndex(
+                                            task.source_index.get(),
+                                        ));
+                                        this.graph.input_files.items_side_effects_mut()
+                                            [source_index.get() as usize] =
+                                            bun_ast::SideEffects::NoSideEffectsPureData;
+                                        this.graph.estimated_file_loader_count += 1;
+                                    }
+
+                                    this.graph.pool().schedule(task);
                                 }
-
-                                this.graph.pool().schedule(task);
                             }
                         } else {
                             // SAFETY: map slot from `get_or_put` above; map not mutated since.
@@ -4899,6 +4957,9 @@ pub mod bv2_impl {
                                     .as_mut_slice()
                                     [resolve.import_record.import_record_index as usize];
                                 import_record.source_index = source_index;
+                                if is_html_manifest {
+                                    import_record.kind = ImportKind::HtmlManifest;
+                                }
                             }
                         }
                     }
@@ -6183,6 +6244,12 @@ pub mod bv2_impl {
                             continue;
                         }
 
+                        let is_html_entrypoint =
+                            self.is_server_html_import(import_record_loader, target);
+                        if is_html_entrypoint {
+                            import_record.kind = ImportKind::HtmlManifest;
+                        }
+
                         let resolve_entry =
                             resolve_queue.get_or_put(path_primary.text).expect("oom");
                         if resolve_entry.found_existing {
@@ -6215,7 +6282,11 @@ pub mod bv2_impl {
                             ParseTask::init(&file_map_result, bun_ast::Index::INVALID, self);
                         // SAFETY: arena outlives the bundle pass.
                         let resolve_task: &mut ParseTask = self.arena_create(resolve_task_val);
-                        resolve_task.known_target = target;
+                        resolve_task.known_target = if is_html_entrypoint {
+                            Target::Browser
+                        } else {
+                            target
+                        };
                         // Use transpiler JSX options, applying force_node_env like the disk path does
                         resolve_task.jsx = transpiler.options.jsx.clone();
                         resolve_task.jsx.development = match transpiler.options.force_node_env {
@@ -6229,6 +6300,13 @@ pub mod bv2_impl {
                         resolve_task.tree_shaking = transpiler.options.tree_shaking;
                         resolve_task.side_effects = bun_ast::SideEffects::HasSideEffects;
                         *resolve_entry.value_ptr = resolve_task;
+
+                        if is_html_entrypoint {
+                            import_record.source_index = Index::init(
+                                self.generate_server_html_module(&path_primary, target)
+                                    .expect("unreachable"),
+                            );
+                        }
                         continue;
                     }
                 }
@@ -6545,9 +6623,7 @@ pub mod bv2_impl {
                 };
                 import_record.loader = Some(import_record_loader);
 
-                let is_html_entrypoint = import_record_loader == Loader::Html
-                    && target.is_server_side()
-                    && self.dev_server.is_none();
+                let is_html_entrypoint = self.is_server_html_import(import_record_loader, target);
 
                 if let Some(id) = self.path_to_source_index_map(target).get(path.text) {
                     if self.dev_server.is_some() && loader != Loader::Html {
@@ -6610,8 +6686,10 @@ pub mod bv2_impl {
                 }
 
                 if is_html_entrypoint {
-                    self.generate_server_html_module(path, target, import_record, path.text)
-                        .expect("unreachable");
+                    import_record.source_index = Index::init(
+                        self.generate_server_html_module(path, target)
+                            .expect("unreachable"),
+                    );
                 }
             }
 
@@ -6632,8 +6710,8 @@ pub mod bv2_impl {
             let mut diff: i32 = 0;
             // reshaped for borrowck — `graph` and the
             // path map are both needed across the loop body. We (a) capture a raw self ptr for
-            // ParseTask.ctx, (b) hoist dev_server check, and (c) scope the map
-            // borrow to the get_or_put so later `self.graph.*` writes don't overlap.
+            // ParseTask.ctx and (b) scope the map borrow to the get_or_put so later
+            // `self.graph.*` writes don't overlap.
             // SAFETY: write provenance from `ptr::from_mut`; outlives every ParseTask.
             let self_ptr: Option<bun_ptr::ParentRef<BundleV2<'static>, bun_ptr::Mut>> =
                 Some(unsafe {
@@ -6641,7 +6719,6 @@ pub mod bv2_impl {
                         std::ptr::from_mut::<Self>(self).cast::<BundleV2<'static>>(),
                     )
                 });
-            let dev_server_is_none = self.dev_server.is_none();
             for (key, value) in resolve_queue.iter() {
                 let value: *mut ParseTask = *value;
                 // SAFETY: ParseTask was arena-allocated in `resolve_import_records`;
@@ -6653,8 +6730,7 @@ pub mod bv2_impl {
                         .loader(&self.transpiler.options.loaders)
                         .unwrap_or(Loader::File)
                 });
-                let is_html_entrypoint =
-                    loader == Loader::Html && target.is_server_side() && dev_server_is_none;
+                let is_html_entrypoint = self.is_server_html_import(loader, target);
                 // Select map and perform get_or_put, capturing the slot as a raw ptr
                 // so the &mut on self.graph is released before we touch other fields.
                 let (found_existing, value_ptr): (bool, *mut IndexInt) = {
@@ -6840,16 +6916,17 @@ pub mod bv2_impl {
             }
         }
 
+        /// Creates the module a server-side import of the HTML file at `path`
+        /// binds to, and registers it under `path` in `target`'s graph. Its AST
+        /// is a lazy export of a unique key that the linker replaces with the
+        /// manifest of the HTML entry point's outputs (see `HTMLImportManifest`);
+        /// the HTML file itself is bundled separately, as an entry point of the
+        /// browser graph. Returns the new module's source index.
         fn generate_server_html_module(
             &mut self,
             path: &Fs::Path,
             target: options::Target,
-            import_record: &mut ImportRecord,
-            path_text: &[u8],
-        ) -> Result<(), Error> {
-            // 1. Create the ast right here
-            // 2. Create a separate "virutal" module that becomes the manifest later on.
-            // 3. Add it to the graph
+        ) -> Result<IndexInt, Error> {
             // Re-borrow `self.graph`
             // at each use so the `self.*` method calls below don't conflict.
             let heap = self.graph.heap;
@@ -6924,16 +7001,64 @@ pub mod bv2_impl {
             self.graph.input_files.append(fake_input_file)?;
             let _ = self.graph.ast.append(ast_for_html_entrypoint); // OOM/capacity: fire-and-forget
 
-            import_record.source_index = Index::init(fake_source_index.0);
-            let _ = self
-                .path_to_source_index_map(target)
-                .put(path_text, fake_source_index.0); // OOM-only Result
+            self.path_to_source_index_map(target)
+                .put(path.text, fake_source_index.0)?;
             self.graph
                 .html_imports
                 .server_source_indices
                 .push(fake_source_index.0);
             self.ensure_client_transpiler();
-            Ok(())
+            Ok(fake_source_index.0)
+        }
+
+        /// Whether an import record resolving to a file bundled with `loader`
+        /// from a graph targeting `target` is an HTML import in the sense of
+        /// [`Self::generate_server_html_module`]. Under the dev server, HTML
+        /// files are routes it owns, never modules of the server graph.
+        fn is_server_html_import(&self, loader: Loader, target: options::Target) -> bool {
+            loader == Loader::Html && target.is_server_side() && self.dev_server.is_none()
+        }
+
+        /// The counterpart of what `resolve_import_records` + `process_resolve_queue`
+        /// do for an HTML import on the bulk resolution path, for the paths that
+        /// enqueue a resolved import record one at a time (`run_resolver` and
+        /// `on_resolve`): the server graph gets the manifest module, and the HTML
+        /// file is parsed once as a browser entry point, however many server files
+        /// import it and whether or not it is also a user-specified entry point.
+        /// `path` must already have its `pretty` initialized. Returns the manifest
+        /// module's source index, which is what the import record binds to.
+        fn enqueue_server_html_import(
+            &mut self,
+            resolve_result: &_resolver::Result,
+            path: &Fs::Path,
+            target: options::Target,
+        ) -> Result<IndexInt, Error> {
+            let manifest_source_index = self.generate_server_html_module(path, target)?;
+
+            if self
+                .path_to_source_index_map(Target::Browser)
+                .get(path.text)
+                .is_none()
+            {
+                let mut html_source = bun_ast::Source {
+                    path: path_as_static(path),
+                    contents: std::borrow::Cow::Borrowed(&b""[..]),
+                    ..Default::default()
+                };
+                let html_source_index = self.enqueue_parse_task(
+                    resolve_result,
+                    &mut html_source,
+                    Loader::Html,
+                    Target::Browser,
+                )?;
+                self.path_to_source_index_map(Target::Browser)
+                    .put(path.text, html_source_index)?;
+                self.graph
+                    .entry_points
+                    .push(bun_ast::Index(html_source_index));
+            }
+
+            Ok(manifest_source_index)
         }
     }
 

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2286,36 +2286,25 @@ pub mod bv2_impl {
                         };
                         // For virtual files, use the path text as-is (no relative path computation needed).
                         path_primary.pretty = self.arena().alloc_slice_copy(path_primary.text);
-                        if self.is_server_html_import(loader, target) {
-                            let manifest_source_index = self
-                                .enqueue_server_html_import(&file_map_result, &path_primary, target)
-                                .expect("oom");
-                            // SAFETY: see `value_ptr` note above; only the browser graph's map
-                            // was touched since.
-                            unsafe { *value_ptr = manifest_source_index };
-                            let record: &mut ImportRecord =
-                                &mut self.graph.ast.items_import_records_mut()
-                                    [import_record.importer_source_index as usize]
-                                    .as_mut_slice()
-                                    [import_record.import_record_index as usize];
-                            record.source_index = Index::init(manifest_source_index);
-                            record.kind = ImportKind::HtmlManifest;
-                            return;
-                        }
-                        let mut tmp_source = bun_ast::Source {
-                            path: path_as_static(&path_primary),
-                            contents: std::borrow::Cow::Borrowed(&b""[..]),
-                            ..Default::default()
-                        };
-                        let idx = self
-                            .enqueue_parse_task(
+                        let idx = if self.is_server_html_import(loader, target) {
+                            self.enqueue_server_html_import(&file_map_result, &path_primary, target)
+                                .expect("oom")
+                        } else {
+                            let mut tmp_source = bun_ast::Source {
+                                path: path_as_static(&path_primary),
+                                contents: std::borrow::Cow::Borrowed(&b""[..]),
+                                ..Default::default()
+                            };
+                            self.enqueue_parse_task(
                                 &file_map_result,
                                 &mut tmp_source,
                                 loader,
                                 import_record.original_target,
                             )
-                            .expect("oom");
-                        // SAFETY: see `value_ptr` note above.
+                            .expect("oom")
+                        };
+                        // SAFETY: see `value_ptr` note above; the HTML branch only touches the
+                        // browser graph's map.
                         unsafe { *value_ptr = idx };
                         let record: &mut ImportRecord =
                             &mut self.graph.ast.items_import_records_mut()
@@ -2557,7 +2546,6 @@ pub mod bv2_impl {
                         [import_record.importer_source_index as usize]
                         .as_mut_slice()[import_record.import_record_index as usize];
                     record.source_index = Index::init(manifest_source_index);
-                    record.kind = ImportKind::HtmlManifest;
                     return;
                 }
                 let mut tmp_source = bun_ast::Source {
@@ -4753,7 +4741,6 @@ pub mod bv2_impl {
                 }
                 jsc_api::JSBundler::ResolveValue::Success(result) => {
                     let mut out_source_index: Option<Index> = None;
-                    let mut is_html_manifest = false;
                     if !result.external {
                         // SAFETY: `result.{path,namespace}` are `Box<[u8]>` whose heap
                         // allocations are moved into `this.free_list` below (in the
@@ -4832,7 +4819,6 @@ pub mod bv2_impl {
                                 // graph's map was touched since.
                                 unsafe { *value_ptr = manifest_source_index };
                                 out_source_index = Some(Index::init(manifest_source_index));
-                                is_html_manifest = true;
                             } else {
                                 // We need to parse this
                                 let source_index = Index::init(
@@ -4962,9 +4948,6 @@ pub mod bv2_impl {
                                     .as_mut_slice()
                                     [resolve.import_record.import_record_index as usize];
                                 import_record.source_index = source_index;
-                                if is_html_manifest {
-                                    import_record.kind = ImportKind::HtmlManifest;
-                                }
                             }
                         }
                     }

--- a/test/bundler/bundler_files.test.ts
+++ b/test/bundler/bundler_files.test.ts
@@ -1,5 +1,7 @@
+import type { BunPlugin } from "bun";
 import { describe, expect, test } from "bun:test";
 import { tempDir } from "harness";
+import { basename } from "node:path";
 
 describe("bundler files option", () => {
   test("basic in-memory file bundling", async () => {
@@ -581,5 +583,78 @@ describe("bundler files option", () => {
 
     const output = await result.outputs[0].text();
     expect(output).toContain("injected by plugin");
+  });
+
+  // A server-side build importing an in-memory HTML file gets a manifest of the
+  // HTML's browser bundle, just like it does for an HTML file on disk. Each
+  // case below resolves the import on a different path: the bulk resolution
+  // pass, the one-at-a-time resolver behind a declining onResolve callback,
+  // and a path returned by onResolve.
+  describe("HTML import from a server-side build", () => {
+    const htmlImportFiles = {
+      "/page.html": `<!DOCTYPE html><html><head><script src="./page.js"></script></head><body></body></html>`,
+      "/page.js": `console.log("page script");`,
+    };
+
+    async function buildHtmlImport(specifier: string, plugins: BunPlugin[]) {
+      const result = await Bun.build({
+        entrypoints: ["/server.js"],
+        target: "bun",
+        files: {
+          ...htmlImportFiles,
+          "/server.js": `import manifest from "${specifier}"; console.log(manifest.index);`,
+        },
+        plugins,
+        throw: false,
+      });
+      expect(result.logs).toEqual([]);
+      expect(result.success).toBe(true);
+
+      const outputNames = result.outputs.map(output => basename(output.path));
+      expect(outputNames.filter(name => name.endsWith(".html"))).toEqual(["page.html"]);
+
+      const serverOutput = await result.outputs.find(output => basename(output.path) === "server.js")!.text();
+      // The import is replaced by the inlined manifest, not left for the runtime to resolve.
+      expect(serverOutput).not.toContain("import manifest");
+      const manifests = [...serverOutput.matchAll(/__jsonParse\("(.+?)"\)/gs)].map(match =>
+        JSON.parse(JSON.parse('"' + match[1] + '"')),
+      );
+      expect(manifests).toHaveLength(1);
+      const [manifest] = manifests;
+      expect(basename(manifest.index)).toBe("page.html");
+      expect(manifest.files.map((file: any) => file.loader).sort()).toEqual(["html", "js"]);
+
+      // The HTML's script is bundled for the browser, not for the server target.
+      const scriptPath = manifest.files.find((file: any) => file.loader === "js").path;
+      const scriptOutput = await result.outputs.find(output => basename(output.path) === basename(scriptPath))!.text();
+      expect(scriptOutput).toContain("page script");
+      expect(scriptOutput).not.toContain("// @bun");
+    }
+
+    test("without plugins", async () => {
+      await buildHtmlImport("./page.html", []);
+    });
+
+    test("with an onResolve plugin that declines the import", async () => {
+      await buildHtmlImport("./page.html", [
+        {
+          name: "decline-relative-imports",
+          setup(build) {
+            build.onResolve({ filter: /^\.\// }, () => undefined);
+          },
+        },
+      ]);
+    });
+
+    test("with an onResolve plugin that resolves to the in-memory HTML file", async () => {
+      await buildHtmlImport("app:page", [
+        {
+          name: "resolve-to-html",
+          setup(build) {
+            build.onResolve({ filter: /^app:page$/ }, () => ({ path: "/page.html" }));
+          },
+        },
+      ]);
+    });
   });
 });

--- a/test/bundler/bundler_files.test.ts
+++ b/test/bundler/bundler_files.test.ts
@@ -1,7 +1,6 @@
 import type { BunPlugin } from "bun";
 import { describe, expect, test } from "bun:test";
 import { tempDir } from "harness";
-import { basename } from "node:path";
 
 describe("bundler files option", () => {
   test("basic in-memory file bundling", async () => {
@@ -585,76 +584,222 @@ describe("bundler files option", () => {
     expect(output).toContain("injected by plugin");
   });
 
-  // A server-side build importing an in-memory HTML file gets a manifest of the
-  // HTML's browser bundle, just like it does for an HTML file on disk. Each
-  // case below resolves the import on a different path: the bulk resolution
-  // pass, the one-at-a-time resolver behind a declining onResolve callback,
-  // and a path returned by onResolve.
-  describe("HTML import from a server-side build", () => {
-    const htmlImportFiles = {
-      "/page.html": `<!DOCTYPE html><html><head><script src="./page.js"></script></head><body></body></html>`,
-      "/page.js": `console.log("page script");`,
+  test("in-memory imports are parsed with the build's jsx options", async () => {
+    const result = await Bun.build({
+      entrypoints: ["/app/entry.js"],
+      files: {
+        "/app/entry.js": `import "./child.jsx";`,
+        "/app/child.jsx": `console.log(<div>child</div>);`,
+      },
+      jsx: { runtime: "classic", factory: "myFactory", fragment: "MyFragment" },
+    });
+
+    const output = await result.outputs[0].text();
+    expect(output).toContain(`myFactory("div", null, "child")`);
+    // In-memory files are labelled by their key, not by a path relative to cwd.
+    expect(output).toContain("// /app/child.jsx");
+  });
+
+  describe("HTML imports", () => {
+    type Manifest = {
+      index: string;
+      files: Array<{ input: string; path: string; loader: string; isEntry: boolean; headers: Record<string, string> }>;
     };
 
-    async function buildHtmlImport(specifier: string, plugins: BunPlugin[]) {
-      const result = await Bun.build({
-        entrypoints: ["/server.js"],
-        target: "bun",
-        files: {
-          ...htmlImportFiles,
-          "/server.js": `import manifest from "${specifier}"; console.log(manifest.index);`,
-        },
-        plugins,
-        throw: false,
-      });
-      expect(result.logs).toEqual([]);
-      expect(result.success).toBe(true);
-
-      const outputNames = result.outputs.map(output => basename(output.path));
-      expect(outputNames.filter(name => name.endsWith(".html"))).toEqual(["page.html"]);
-
-      const serverOutput = await result.outputs.find(output => basename(output.path) === "server.js")!.text();
-      // The import is replaced by the inlined manifest, not left for the runtime to resolve.
-      expect(serverOutput).not.toContain("import manifest");
-      const manifests = [...serverOutput.matchAll(/__jsonParse\("(.+?)"\)/gs)].map(match =>
-        JSON.parse(JSON.parse('"' + match[1] + '"')),
-      );
-      expect(manifests).toHaveLength(1);
-      const [manifest] = manifests;
-      expect(basename(manifest.index)).toBe("page.html");
-      expect(manifest.files.map((file: any) => file.loader).sort()).toEqual(["html", "js"]);
-
-      // The HTML's script is bundled for the browser, not for the server target.
-      const scriptPath = manifest.files.find((file: any) => file.loader === "js").path;
-      const scriptOutput = await result.outputs.find(output => basename(output.path) === basename(scriptPath))!.text();
-      expect(scriptOutput).toContain("page script");
-      expect(scriptOutput).not.toContain("// @bun");
+    // Importing an .html file into a server build replaces the import with a
+    // `__jsonParse("<manifest json>")` module describing the browser build of that page.
+    function manifestsIn(serverCode: string): Manifest[] {
+      return [...serverCode.matchAll(/__jsonParse\("(.+?)"\)/gs)].map(m => JSON.parse(JSON.parse(`"${m[1]}"`)));
     }
 
-    test("without plugins", async () => {
-      await buildHtmlImport("./page.html", []);
-    });
+    const basename = (path: string) => path.split(/[\\/]/).pop()!;
 
-    test("with an onResolve plugin that declines the import", async () => {
-      await buildHtmlImport("./page.html", [
+    function outputText(result: Awaited<ReturnType<typeof Bun.build>>, path: string) {
+      const output = result.outputs.find(o => basename(o.path) === basename(path));
+      if (!output) throw new Error(`no output named ${basename(path)} in ${result.outputs.map(o => o.path)}`);
+      return output.text();
+    }
+
+    const pageHtml = `<!DOCTYPE html><html><head><link rel="stylesheet" href="./page.css"></head><body><script src="./client.js"></script></body></html>`;
+    const pageCss = `body { color: red }`;
+    const clientJs = `document.title = "client";`;
+
+    test("server build importing an in-memory .html file gets a manifest and a browser bundle", async () => {
+      const result = await Bun.build({
+        entrypoints: ["/app/server.js"],
+        target: "bun",
+        files: {
+          "/app/server.js": `import page from "./page.html"; export default page;`,
+          "/app/page.html": pageHtml,
+          "/app/page.css": pageCss,
+          "/app/client.js": clientJs,
+        },
+      });
+
+      const server = await outputText(result, "server.js");
+      expect(server).toStartWith("// @bun\n");
+      expect(server).not.toMatch(/from "[^"]*page\.html"/);
+
+      const [manifest, ...extra] = manifestsIn(server);
+      expect(extra).toBeEmpty();
+      expect(manifest.index).toMatch(/page\.html$/);
+      expect(manifest.files.toSorted((a, b) => a.loader.localeCompare(b.loader))).toEqual([
         {
-          name: "decline-relative-imports",
-          setup(build) {
-            build.onResolve({ filter: /^\.\// }, () => undefined);
-          },
+          input: expect.stringContaining("page.html"),
+          path: expect.stringMatching(/\.css$/),
+          loader: "css",
+          isEntry: true,
+          headers: { "etag": expect.any(String), "content-type": "text/css;charset=utf-8" },
+        },
+        {
+          input: expect.stringContaining("page.html"),
+          path: manifest.index,
+          loader: "html",
+          isEntry: true,
+          headers: { "etag": expect.any(String), "content-type": "text/html;charset=utf-8" },
+        },
+        {
+          input: expect.stringContaining("page.html"),
+          path: expect.stringMatching(/\.js$/),
+          loader: "js",
+          isEntry: true,
+          headers: { "etag": expect.any(String), "content-type": "text/javascript;charset=utf-8" },
         },
       ]);
+
+      const { path: cssPath } = manifest.files.find(f => f.loader === "css")!;
+      const { path: jsPath } = manifest.files.find(f => f.loader === "js")!;
+      const html = await outputText(result, manifest.index);
+      expect(html).toContain(basename(cssPath));
+      expect(html).toContain(basename(jsPath));
+
+      // The page's script is bundled for the browser even though the build targets bun.
+      const client = await outputText(result, jsPath);
+      expect(client).toContain(clientJs);
+      expect(client).not.toContain("// @bun");
+      expect(await outputText(result, cssPath)).toContain("color: red");
     });
 
-    test("with an onResolve plugin that resolves to the in-memory HTML file", async () => {
-      await buildHtmlImport("app:page", [
-        {
-          name: "resolve-to-html",
-          setup(build) {
-            build.onResolve({ filter: /^app:page$/ }, () => ({ path: "/page.html" }));
-          },
+    test("file on disk importing an in-memory .html file", async () => {
+      using dir = tempDir("bundler-files-html-import", {
+        "server.js": `import page from "./page.html"; export default page;`,
+      });
+
+      const result = await Bun.build({
+        entrypoints: [`${dir}/server.js`],
+        target: "bun",
+        files: {
+          [`${dir}/page.html`]: pageHtml,
+          [`${dir}/page.css`]: pageCss,
+          [`${dir}/client.js`]: clientJs,
         },
-      ]);
+      });
+
+      const [manifest, ...extra] = manifestsIn(await outputText(result, "server.js"));
+      expect(extra).toBeEmpty();
+      expect(manifest.index).toMatch(/page\.html$/);
+      expect(manifest.files.map(f => f.loader).toSorted()).toEqual(["css", "html", "js"]);
+      const { path: jsPath } = manifest.files.find(f => f.loader === "js")!;
+      expect(await outputText(result, manifest.index)).toContain(basename(jsPath));
+      expect(await outputText(result, jsPath)).toContain(clientJs);
+    });
+
+    test("each in-memory .html file gets one manifest, however often it is imported", async () => {
+      const result = await Bun.build({
+        entrypoints: ["/app/server.js"],
+        target: "bun",
+        files: {
+          "/app/server.js": `
+            import home from "./home.html";
+            import about from "./about.html";
+            import { home as homeAgain } from "./routes.js";
+            export default { home, about, homeAgain };
+          `,
+          "/app/routes.js": `export { default as home } from "./home.html";`,
+          "/app/home.html": `<!DOCTYPE html><script src="./home.js"></script>`,
+          "/app/about.html": `<!DOCTYPE html><script src="./about.js"></script>`,
+          "/app/home.js": `console.log("home");`,
+          "/app/about.js": `console.log("about");`,
+        },
+      });
+
+      const server = await outputText(result, "server.js");
+      expect(server).not.toMatch(/from "[^"]*\.html"/);
+
+      const manifests = manifestsIn(server).toSorted((a, b) => a.index.localeCompare(b.index));
+      expect(manifests.map(m => basename(m.index))).toEqual(["about.html", "home.html"]);
+      for (const manifest of manifests) {
+        expect(manifest.files.map(f => f.loader).toSorted()).toEqual(["html", "js"]);
+        const { path: jsPath } = manifest.files.find(f => f.loader === "js")!;
+        const pageName = basename(manifest.index).replace(".html", "");
+        expect(await outputText(result, jsPath)).toContain(`console.log("${pageName}")`);
+      }
+    });
+
+    // With an onResolve plugin registered, imports matching its filter are resolved one at a
+    // time (by the plugin, or by the regular resolver when the plugin declines) instead of by
+    // the bulk pass the tests above go through. The in-memory page has to become a manifest
+    // on those paths as well.
+    async function expectManifestWithPlugin(specifier: string, plugin: BunPlugin) {
+      const result = await Bun.build({
+        entrypoints: ["/app/server.js"],
+        target: "bun",
+        files: {
+          "/app/server.js": `import page from "${specifier}"; export default page;`,
+          "/app/page.html": pageHtml,
+          "/app/page.css": pageCss,
+          "/app/client.js": clientJs,
+        },
+        plugins: [plugin],
+      });
+
+      const server = await outputText(result, "server.js");
+      expect(server).not.toContain(`from "${specifier}"`);
+      const [manifest, ...extra] = manifestsIn(server);
+      expect(extra).toBeEmpty();
+      expect(manifest.index).toMatch(/page\.html$/);
+      expect(manifest.files.map(f => f.loader).toSorted()).toEqual(["css", "html", "js"]);
+      expect(result.outputs.filter(o => o.path.endsWith(".html"))).toHaveLength(1);
+
+      const { path: jsPath } = manifest.files.find(f => f.loader === "js")!;
+      const client = await outputText(result, jsPath);
+      expect(client).toContain(clientJs);
+      expect(client).not.toContain("// @bun");
+    }
+
+    test("imported through an onResolve plugin that declines the import", async () => {
+      await expectManifestWithPlugin("./page.html", {
+        name: "decline-relative-imports",
+        setup(build) {
+          build.onResolve({ filter: /^\.\// }, () => undefined);
+        },
+      });
+    });
+
+    test("imported through an onResolve plugin that returns the in-memory file's path", async () => {
+      await expectManifestWithPlugin("app:page", {
+        name: "resolve-to-in-memory-page",
+        setup(build) {
+          build.onResolve({ filter: /^app:page$/ }, () => ({ path: "/app/page.html" }));
+        },
+      });
+    });
+
+    test("assets referenced by an in-memory .html file are copied to the output", async () => {
+      const result = await Bun.build({
+        entrypoints: ["/app/index.html"],
+        files: {
+          "/app/index.html": `<!DOCTYPE html><link rel="manifest" href="./manifest.json">`,
+          "/app/manifest.json": `{"name":"app"}`,
+        },
+      });
+
+      const html = await outputText(result, "index.html");
+      expect(html).toMatch(/href="[^"]*manifest-[a-zA-Z0-9]+\.json"/);
+
+      const asset = result.outputs.find(o => o.kind === "asset");
+      expect(asset?.path).toMatch(/manifest-[a-zA-Z0-9]+\.json$/);
+      expect(await asset!.text()).toBe(`{"name":"app"}`);
     });
   });
 });

--- a/test/bundler/html-import-manifest.test.ts
+++ b/test/bundler/html-import-manifest.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { tempDir } from "harness";
 import { readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { SourceMapConsumer } from "source-map";
 import { itBundled } from "./expectBundled";
 
@@ -522,6 +522,178 @@ console.log("✓ Both import types work correctly");
       expect(entryCode).toContain('__jsonParse("');
       expect(entryCode).toContain('\\\"index\\\":\\\"./index.html\\\"');
       expect(entryCode).toContain('\\\"files\\\":[');
+    },
+  });
+
+  // With an onResolve plugin registered, import records that match its filter
+  // are resolved one at a time by the plugin callback (and by the regular
+  // resolver when the callback declines) instead of by the bulk resolution
+  // pass. A server-side import of an HTML file has to produce the same
+  // manifest module and browser entry point on those paths too.
+  const pluginResolvedHtmlFiles = {
+    "/page.html": `
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" href="./page.css">
+    <script src="./page.js"></script>
+  </head>
+  <body>
+    <h1>Page</h1>
+  </body>
+</html>`,
+    "/page.css": `body { margin: 0; }`,
+    "/page.js": `console.log("page script");`,
+  };
+
+  const printManifest = /* js */ `
+console.log(JSON.stringify({ index: manifest.index.split("/").pop(), loaders: manifest.files.map(f => f.loader).sort() }));
+`;
+  const expectedManifestSummary = `{"index":"page.html","loaders":["css","html","js"]}`;
+
+  function readManifests(api: { readFile(file: string): string }, file: string) {
+    return [...api.readFile(file).matchAll(/__jsonParse\("(.+?)"\)/gs)].map(match =>
+      JSON.parse(JSON.parse('"' + match[1] + '"')),
+    );
+  }
+
+  function expectSingleHtmlOutput(build: { outputs: { path: string }[] }) {
+    const htmlOutputs = build.outputs.map(output => basename(output.path)).filter(file => file.endsWith(".html"));
+    expect(htmlOutputs).toEqual(["page.html"]);
+  }
+
+  itBundled("html-import/onresolve-fallthrough", {
+    outdir: "out/",
+    metafile: true,
+    files: {
+      ...pluginResolvedHtmlFiles,
+      "/server.js": `
+import manifest from "./page.html";
+import { manifest as importedByOtherModule } from "./other.js";
+console.log(manifest === importedByOtherModule);
+${printManifest}`,
+      "/other.js": `export { default as manifest } from "./page.html";`,
+    },
+    entryPoints: ["/server.js"],
+    target: "bun",
+    plugins(builder) {
+      builder.onResolve({ filter: /.*/ }, () => undefined);
+    },
+    run: {
+      stdout: `true\n${expectedManifestSummary}`,
+    },
+    onAfterApiBundle: expectSingleHtmlOutput,
+    onAfterBundle(api) {
+      const manifests = readManifests(api, "out/server.js");
+      expect(manifests).toHaveLength(1);
+
+      // The HTML file's scripts were bundled for the browser, not for the
+      // server target of the graph that imported it.
+      const script = manifests[0].files.find((file: any) => file.loader === "js");
+      const scriptCode = api.readFile("out/" + script.path);
+      expect(scriptCode).toContain("page script");
+      expect(scriptCode).not.toContain("// @bun");
+
+      const metafile = JSON.parse(api.readFile("metafile.json"));
+      expect(metafile.inputs["server.js"].imports).toContainEqual(
+        expect.objectContaining({ path: "page.html", kind: "html_manifest" }),
+      );
+    },
+  });
+
+  // Unlike an import statement, a require() of the HTML file used to build
+  // without an error on this path and evaluate to an empty module.
+  itBundled("html-import/onresolve-fallthrough-require", {
+    outdir: "out/",
+    files: {
+      ...pluginResolvedHtmlFiles,
+      "/server.js": `
+const required = require("./page.html");
+const manifest = required.default ?? required;
+${printManifest}`,
+    },
+    entryPoints: ["/server.js"],
+    target: "bun",
+    plugins(builder) {
+      builder.onResolve({ filter: /.*/ }, () => undefined);
+    },
+    run: {
+      stdout: expectedManifestSummary,
+    },
+    onAfterApiBundle: expectSingleHtmlOutput,
+    onAfterBundle(api) {
+      expect(readManifests(api, "out/server.js")).toHaveLength(1);
+    },
+  });
+
+  itBundled("html-import/onresolve-returns-html-path", ({ root }) => ({
+    outdir: "out/",
+    files: {
+      ...pluginResolvedHtmlFiles,
+      "/server.js": `
+import manifest from "app:page";
+${printManifest}`,
+    },
+    entryPoints: ["/server.js"],
+    target: "bun",
+    plugins(builder) {
+      builder.onResolve({ filter: /^app:page$/ }, () => ({ path: join(root, "page.html") }));
+    },
+    run: {
+      stdout: expectedManifestSummary,
+    },
+    onAfterApiBundle: expectSingleHtmlOutput,
+    onAfterBundle(api) {
+      expect(readManifests(api, "out/server.js")).toHaveLength(1);
+    },
+  }));
+
+  // page.html is an entry point of its own (resolved without the plugin, whose
+  // filter only matches relative specifiers) and imported by server.js
+  // (resolved through the plugin). It must be bundled once and the import must
+  // still get a manifest for it.
+  itBundled("html-import/onresolve-fallthrough-html-is-also-an-entry-point", {
+    outdir: "out/",
+    files: {
+      ...pluginResolvedHtmlFiles,
+      "/server.js": `
+import manifest from "./page.html";
+${printManifest}`,
+    },
+    entryPoints: ["/server.js", "/page.html"],
+    target: "bun",
+    plugins(builder) {
+      builder.onResolve({ filter: /^\.\// }, () => undefined);
+    },
+    run: {
+      file: "out/server.js",
+      stdout: expectedManifestSummary,
+    },
+    onAfterApiBundle: expectSingleHtmlOutput,
+    onAfterBundle(api) {
+      expect(readManifests(api, "out/server.js")).toHaveLength(1);
+    },
+  });
+
+  itBundled("html-import/onresolve-fallthrough-keeps-type-file-attribute", {
+    outdir: "out/",
+    files: {
+      ...pluginResolvedHtmlFiles,
+      "/server.js": `
+import url from "./page.html" with { type: "file" };
+console.log(typeof url, url.endsWith(".html"));
+`,
+    },
+    entryPoints: ["/server.js"],
+    target: "bun",
+    plugins(builder) {
+      builder.onResolve({ filter: /.*/ }, () => undefined);
+    },
+    run: {
+      stdout: "string true",
+    },
+    onAfterBundle(api) {
+      expect(readManifests(api, "out/server.js")).toHaveLength(0);
     },
   });
 });

--- a/test/bundler/html-import-manifest.test.ts
+++ b/test/bundler/html-import-manifest.test.ts
@@ -594,9 +594,10 @@ ${printManifest}`,
       expect(scriptCode).toContain("page script");
       expect(scriptCode).not.toContain("// @bun");
 
+      // The import record keeps its own kind; only its target changes.
       const metafile = JSON.parse(api.readFile("metafile.json"));
       expect(metafile.inputs["server.js"].imports).toContainEqual(
-        expect.objectContaining({ path: "page.html", kind: "html_manifest" }),
+        expect.objectContaining({ path: "page.html", kind: "import-statement" }),
       );
     },
   });


### PR DESCRIPTION
### Problem
- `import page from "./page.html"` in a `target: "bun"` (or `node`) build works, but the same build fails with `No matching export in "page.html" for import "default"` as soon as any onResolve plugin matches the import, even one that returns `undefined` for everything. A plugin that returns the path of an `.html` file fails the same way.
- `require("./page.html")` on those paths builds without an error but evaluates to an empty module, and an HTML file supplied through the `files:` option is never turned into a manifest either: the output keeps a literal `import page from "/page.html" with { type: "html" }` and the page's scripts are bundled for the server target.
- Cause: the HTML-import handling (manifest module, HTML parsed as a browser entry point, record kind `html_manifest`) existed only on the bulk resolution path for files on disk, in `resolve_import_records` and `process_resolve_queue` (`src/bundler/bundle_v2.rs`). Every other place that binds a resolved import record to a module bundled the HTML file as an ordinary module of the server graph, which exports nothing:
  - `on_resolve` `NoMatch` -> `run_resolver`, both its disk branch and its `files:` branch,
  - `on_resolve` `Success` (plugin returned a path),
  - the `files:` branch of `resolve_import_records`, a copy of the disk branch's tail that had drifted from it (it also skipped the loader override that copies url assets referenced from an HTML file, so an in-memory page with `<link rel="manifest" href="./manifest.json">` bundled the JSON instead of emitting the asset).

### Fix
- `is_server_html_import` is the one definition of "this import binds to a manifest module" (HTML loader, server-side target, no dev server); the bulk path's two inline copies use it too.
- `generate_server_html_module` now only creates the manifest module and returns its source index. Each call site registers that index in its graph's path map and binds the record the same way it does for any other module (`put` on the get-then-put sites, the reserved `get_or_put` slot on the other two), so the record can live inside `graph.ast`, as it does on the plugin paths.
- `enqueue_server_html_import` is the one-at-a-time counterpart of the bulk path, used by `run_resolver` (both branches) and `on_resolve`'s `Success` arm: create the manifest module, and parse the HTML file as a `Target::Browser` entry point unless the browser graph already has it (a second importer never gets here, it finds the manifest in the server graph's map; an HTML file that is also a user entry point is parsed once). The callers bind the record to it and leave the record's kind alone: rewriting it to `HtmlManifest`, as the bulk path currently does, is what breaks `import()` and `require()` of HTML files (the linker wraps a module and the printer emits the import based on the record's `Dynamic` / `Require` kind), and the manifest wiring does not depend on it. #38621 removes that rewrite on the bulk path; this PR does not add it to the new ones. The `Success` arm skips all of this for `EntryPointBuild` records, which are entry points rather than imports (#38594 handles those).
- In `resolve_import_records`, a `files:` hit now stands in for the resolver's result and goes through the shared tail instead of its own copy of it; the only virtual-file specifics left are that `jsx` comes from the transpiler (no tsconfig.json to consult) and that the display path is the map key as-is. This is what makes the in-memory HTML import a manifest and also fixes the url-asset case above. (Taken from a parallel attempt at the `files:` half of this bug, see the comment below.)
- Why this is right: the linker (`process_html_import_files`, `HTMLImportManifest`) needs the manifest module in `html_imports.server_source_indices` and the HTML file under the same path in the browser graph's map, and nothing else; every path now produces exactly that. Building the same inputs with no plugin, with a declining plugin and with a path-returning plugin yields byte-identical outputs; the metafiles differ only in the import's kind label (`html_manifest` on the bulk path until #38621 lands, the real kind on the new paths), and `import()` of an HTML file already works on the new paths.
- Verified with `test/bundler/html-import-manifest.test.ts` (onresolve-fallthrough, -require, -returns-html-path, -html-is-also-an-entry-point, plus a guard that `with { type: "file" }` still wins on the fall-through path) and `test/bundler/bundler_files.test.ts` ("HTML imports": bulk path, importer on disk, one manifest per page however often it is imported, declining plugin, path-returning plugin, url asset; plus a guard for the jsx options of in-memory files). Everything except the two guards fails on bun 1.4.0 and passes with this branch. Existing `html-import-manifest`, `bundler_files`, `bundler_html`, `bundler_html_server`, `bundler_plugin`, `css/doesnt_crash` (the other user of `files:`), `bun-serve-html-manifest`, `bake/dev/html` and `bake/dev/plugins` tests pass.

### Background
- HTML import manifest: when server-side code imports an HTML file, the bundler bundles the page (with its scripts and styles) as a separate browser build and replaces the import with a JSON object listing the files that build produced (`index`, `files[]` with paths, loaders and headers); `Bun.serve` routes consume it. Internally the import binds to a generated "manifest module" whose AST is a lazy export of a placeholder string that the linker replaces once output paths are known.
- Path maps: `BundleV2` keeps one path -> source index map per target graph. For an HTML import, the server graph's map holds the manifest module and the browser graph's map holds the real HTML file under the same path; `process_html_import_files` joins the two by that path.
- Resolution paths: import records are normally resolved in bulk right after their file is parsed (`resolve_import_records`, then `process_resolve_queue` creates the parse tasks). A record that matches an onResolve filter is handed to the plugin instead and comes back later through `on_resolve`, which either uses the plugin's answer (`Success`) or runs the regular resolver itself (`NoMatch` -> `run_resolver`); both create the module for the record directly. `files:` (`FileMap`) is the in-memory file map of `Bun.build({ files })`, consulted before the resolver on both kinds of path.

<details>
<summary>Probes and adjacent findings</summary>

Repro on 1.4.0 (`server.ts` imports `./page.html`, `target: "bun"`):

```
no plugin                        true  []
onResolve -> undefined           false ["No matching export in \"page.html\" for import \"default\""]
onResolve -> {path}              false ["No matching export in \"page.html\" for import \"default\""]
target node + onResolve          false ["No matching export in \"page.html\" for import \"default\""]
onLoad only                      true  []     (onLoad does not change how the record is resolved)
files: virtual html, no plugin   true  []     but the output still contains `import page from "/virtual/page.html" with { type: "html" }`
```

With this branch all of the above build, and comparing the three disk builds (no plugin, declining plugin, path-returning plugin) gives identical output files (one manifest per import, the page's script chunk compiled for the browser, i.e. without the `// @bun` pragma); the metafiles differ only in the kind label described above.

Related, pre-existing on the plugin-less path as well, and handled elsewhere: HTML entry points (not imports) bundled under the server target when a plugin or `files:` is involved (#38594); `files:` entry points failing when a plugin declines them (#38600; the `files:` tests here use a filter that does not match the entry point for that reason); `import("./page.html")` from server code on the bulk path emitting a call to an undefined `require_page` wrapper (#38621, whose analysis is why the new paths here do not rewrite the kind); the import attribute loader being ignored when a plugin returns a path (#37476, which is also why the `Success` arm here still derives the loader from the extension); and the manifest's `index` reading `././page.html` under an explicit `[dir]/[name].[ext]` entry naming, which is why the tests compare the basename of `index`.
</details>
