### PR TITLE
css: drop the logical border longhands a border-width/style/color shorthand overrides instead of flushing them

### DIFF
--- a/src/css/properties/border.rs
+++ b/src/css/properties/border.rs
@@ -1260,6 +1260,35 @@ mod border_handler_body {
                 }};
             }
 
+            // `border-width` / `border-style` / `border-color` set all four physical sides,
+            // so the buffered logical values of that component are dead in every writing
+            // mode, except for a target that rejects the whole declaration (same condition
+            // as the fallback flush in `flush_helper!`). They have to go before the first
+            // `property_helper!`: if the buffer holds logical values, it flushes them, and
+            // when logical properties are compiled away the inline sides come out as
+            // `:lang()` rules after this block, where they would win over the shorthand.
+            macro_rules! rect_shorthand_helper {
+                ($prop:ident, $val:expr) => {{
+                    let rejected_by_a_target = match context.targets.browsers {
+                        Some(browsers) => [&$val.top, &$val.right, &$val.bottom, &$val.left]
+                            .into_iter()
+                            .any(|side| !css::generic::is_compatible(side, &browsers)),
+                        None => false,
+                    };
+                    if !rejected_by_a_target {
+                        self.border_block_start.$prop = None;
+                        self.border_block_end.$prop = None;
+                        self.border_inline_start.$prop = None;
+                        self.border_inline_end.$prop = None;
+                    }
+
+                    property_helper!(border_top, $prop, &$val.top, Physical);
+                    property_helper!(border_right, $prop, &$val.right, Physical);
+                    property_helper!(border_bottom, $prop, &$val.bottom, Physical);
+                    property_helper!(border_left, $prop, &$val.left, Physical);
+                }};
+            }
+
             use PropertyCategory::{Logical, Physical};
 
             match property {
@@ -1375,42 +1404,9 @@ mod border_handler_body {
                     set_border_helper!(border_inline_start, val, Logical);
                     set_border_helper!(border_inline_end, val, Logical);
                 }
-                Property::BorderWidth(val) => {
-                    property_helper!(border_top, width, &val.top, Physical);
-                    property_helper!(border_right, width, &val.right, Physical);
-                    property_helper!(border_bottom, width, &val.bottom, Physical);
-                    property_helper!(border_left, width, &val.left, Physical);
-
-                    self.border_block_start.width = None;
-                    self.border_block_end.width = None;
-                    self.border_inline_start.width = None;
-                    self.border_inline_end.width = None;
-                    self.has_any = true;
-                }
-                Property::BorderStyle(val) => {
-                    property_helper!(border_top, style, &val.top, Physical);
-                    property_helper!(border_right, style, &val.right, Physical);
-                    property_helper!(border_bottom, style, &val.bottom, Physical);
-                    property_helper!(border_left, style, &val.left, Physical);
-
-                    self.border_block_start.style = None;
-                    self.border_block_end.style = None;
-                    self.border_inline_start.style = None;
-                    self.border_inline_end.style = None;
-                    self.has_any = true;
-                }
-                Property::BorderColor(val) => {
-                    property_helper!(border_top, color, &val.top, Physical);
-                    property_helper!(border_right, color, &val.right, Physical);
-                    property_helper!(border_bottom, color, &val.bottom, Physical);
-                    property_helper!(border_left, color, &val.left, Physical);
-
-                    self.border_block_start.color = None;
-                    self.border_block_end.color = None;
-                    self.border_inline_start.color = None;
-                    self.border_inline_end.color = None;
-                    self.has_any = true;
-                }
+                Property::BorderWidth(val) => rect_shorthand_helper!(width, val),
+                Property::BorderStyle(val) => rect_shorthand_helper!(style, val),
+                Property::BorderColor(val) => rect_shorthand_helper!(color, val),
                 Property::Border(val) => {
                     self.border_top.set_border(arena, val);
                     self.border_bottom.set_border(arena, val);

--- a/src/css/properties/border.rs
+++ b/src/css/properties/border.rs
@@ -1260,12 +1260,9 @@ mod border_handler_body {
                 }};
             }
 
-            // A 4-side shorthand overrides the logical values of its component in every
-            // writing mode, so drop them before `property_helper!` flushes the buffer.
-            // A target that rejects the shorthand still applies them: keep those as
-            // fallbacks, the same way `flush_helper!` does for physical values.
             macro_rules! rect_shorthand_helper {
                 ($prop:ident, $val:expr) => {{
+                    // Buffered logical values stay live only for a target that rejects the shorthand.
                     let rejected_by_a_target = match context.targets.browsers {
                         Some(browsers) => [&$val.top, &$val.right, &$val.bottom, &$val.left]
                             .into_iter()
@@ -1273,6 +1270,7 @@ mod border_handler_body {
                         None => false,
                     };
                     if !rejected_by_a_target {
+                        // Dead in every writing mode; clear before `property_helper!` flushes them.
                         self.border_block_start.$prop = None;
                         self.border_block_end.$prop = None;
                         self.border_inline_start.$prop = None;

--- a/src/css/properties/border.rs
+++ b/src/css/properties/border.rs
@@ -1260,13 +1260,10 @@ mod border_handler_body {
                 }};
             }
 
-            // `border-width` / `border-style` / `border-color` set all four physical sides,
-            // so the buffered logical values of that component are dead in every writing
-            // mode, except for a target that rejects the whole declaration (same condition
-            // as the fallback flush in `flush_helper!`). They have to go before the first
-            // `property_helper!`: if the buffer holds logical values, it flushes them, and
-            // when logical properties are compiled away the inline sides come out as
-            // `:lang()` rules after this block, where they would win over the shorthand.
+            // A 4-side shorthand overrides the logical values of its component in every
+            // writing mode, so drop them before `property_helper!` flushes the buffer.
+            // A target that rejects the shorthand still applies them: keep those as
+            // fallbacks, the same way `flush_helper!` does for physical values.
             macro_rules! rect_shorthand_helper {
                 ($prop:ident, $val:expr) => {{
                     let rejected_by_a_target = match context.targets.browsers {

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -1676,6 +1676,104 @@ describe("css tests", () => {
         chrome: 99 << 16,
       },
     );
+
+    // border-width / border-style / border-color set all four physical sides, so a logical longhand for
+    // the same component declared earlier in the block is overridden in every writing mode and must not
+    // be emitted. For targets that compile logical properties away it used to come out as :lang() rules
+    // after the block, where it won over the shorthand.
+    describe("4-side shorthand after a logical longhand in the same block", () => {
+      const rtlLangs =
+        ":lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi)";
+      // What safari 8 targets get for an inline side: prefixed and unprefixed rules for ltr, then for rtl.
+      const directionRules = (ltr: string, rtl: string) => `
+        .a:not(:-webkit-any(${rtlLangs})) { ${ltr} }
+        .a:not(:is(${rtlLangs})) { ${ltr} }
+        .a:-webkit-any(${rtlLangs}) { ${rtl} }
+        .a:is(${rtlLangs}) { ${rtl} }
+      `;
+
+      for (const [logical, shorthand] of [
+        ["border-inline-start-width:3px", "border-width:0"],
+        ["border-inline-end-width:3px", "border-width:0"],
+        ["border-inline-width:3px", "border-width:0"],
+        ["border-block-start-width:3px", "border-width:0"],
+        ["border-inline-start-style:dotted", "border-style:solid"],
+        ["border-inline-start-color:red", "border-color:#00f"],
+        ["border-inline-color:red", "border-color:#00f"],
+      ]) {
+        minify_test(`.a{${logical};${shorthand}}`, `.a{${shorthand}}`);
+        prefix_test(`.a{${logical};${shorthand}}`, `.a{${shorthand};}`, { safari: 8 << 16 });
+      }
+
+      // Only the overridden component goes away; the rest of the logical value is still live.
+      minify_test(
+        ".a{border-inline-start:3px solid red;border-width:0}",
+        ".a{border-inline-start-style:solid;border-inline-start-color:red;border-width:0}",
+      );
+      prefix_test(
+        ".a{border-inline-start:3px solid red;border-width:0}",
+        `
+        .a { border-width: 0; }
+        ${directionRules(
+          "border-left-style: solid; border-left-color: red;",
+          "border-right-style: solid; border-right-color: red;",
+        )}
+        `,
+        { safari: 8 << 16 },
+      );
+
+      // A different component is not touched.
+      minify_test(
+        ".a{border-inline-start-width:3px;border-color:red}",
+        ".a{border-inline-start-width:3px;border-color:red}",
+      );
+
+      // A target that rejects the shorthand's value (no container query units in safari 14, no color() in
+      // chrome 99) still applies the longhand, so it stays as a fallback, the same as for a physical one.
+      prefix_test(
+        ".a{border-inline-start-width:3px;border-width:max(2cqw,22px)}",
+        ".a{border-inline-start-width:3px;border-width:max(2cqw,22px);}",
+        { safari: 14 << 16 },
+      );
+      prefix_test(".a{border-inline-start-width:3px;border-width:max(2cqw,22px)}", ".a{border-width:max(2cqw,22px);}", {
+        safari: 16 << 16,
+      });
+      prefix_test(
+        ".a{border-inline-start-color:red;border-color:color(display-p3 0 .5 1)}",
+        ".a{border-inline-start-color:red;border-color:#0085f8;border-color:color(display-p3 0 .5 1);}",
+        { chrome: 99 << 16 },
+      );
+      prefix_test(
+        ".a{border-inline-start-color:red;border-color:color(display-p3 0 .5 1)}",
+        ".a{border-color:color(display-p3 0 .5 1);}",
+        { safari: 16 << 16 },
+      );
+
+      // The other order overrides the shorthand and is kept.
+      minify_test(
+        ".a{border-width:0;border-inline-start-width:3px}",
+        ".a{border-width:0;border-inline-start-width:3px}",
+      );
+      prefix_test(
+        ".a{border-width:0;border-inline-start-width:3px}",
+        `
+        .a { border-width: 0; }
+        ${directionRules("border-left-width: 3px;", "border-right-width: 3px;")}
+        `,
+        { safari: 8 << 16 },
+      );
+
+      // !important declarations go through their own handler: a normal shorthand does not override an
+      // important longhand, an important shorthand does.
+      minify_test(
+        ".a{border-inline-start-width:3px!important;border-width:0}",
+        ".a{border-width:0;border-inline-start-width:3px!important}",
+      );
+      minify_test(
+        ".a{border-inline-start-width:3px!important;border-width:0!important}",
+        ".a{border-width:0!important}",
+      );
+    });
   });
 
   describe("box-shadow", () => {

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -1697,9 +1697,12 @@ describe("css tests", () => {
         ["border-inline-end-width:3px", "border-width:0"],
         ["border-inline-width:3px", "border-width:0"],
         ["border-block-start-width:3px", "border-width:0"],
+        ["border-block-end-width:3px", "border-width:0"],
         ["border-inline-start-style:dotted", "border-style:solid"],
+        ["border-block-end-style:dotted", "border-style:solid"],
         ["border-inline-start-color:red", "border-color:#00f"],
         ["border-inline-color:red", "border-color:#00f"],
+        ["border-block-end-color:red", "border-color:#00f"],
       ]) {
         minify_test(`.a{${logical};${shorthand}}`, `.a{${shorthand}}`);
         prefix_test(`.a{${logical};${shorthand}}`, `.a{${shorthand};}`, { safari: 8 << 16 });


### PR DESCRIPTION
### Problem

- When the targets make the CSS minifier compile logical properties away, a `border-width`, `border-style` or `border-color` shorthand that overrides an earlier `border-inline-*` longhand in the same rule still gets the dead longhand compiled into `:lang()` fallback rules. Those rules are emitted after the rule, so they win the cascade and the output no longer matches the source (bun 1.4.0 and main):
  ```
  .a{border-inline-start-width:3px;border-width:0}
  -> .a{border-width:0}  .a:not(:lang(ae), ...){border-left-width:3px}  ...  .a:lang(ae), ...{border-right-width:3px}
  ```
  The source gives every side width `0`; the output gives LTR pages `border-left-width: 3px`. Same for `border-inline-end-*`, `border-inline-*`, and the style and color families (`border-inline-start-color:red;border-color:blue` keeps `red`).
- With logical properties supported, the same inputs are only under-minified: `bun build --minify` keeps `.a{border-inline-start-width:3px;border-width:0}` as written (now `.a{border-width:0}`). Targets old enough to compile logical properties are not reachable from the `bun build` CLI today, so the wrong-cascade output shows up through the internal API `test/js/bun/css` uses, and the under-minification is what users see.
- Cause: `BorderHandler::handle_property`, `Property::BorderWidth` / `BorderStyle` / `BorderColor` arms (`src/css/properties/border.rs:1378-1413`). Each arm buffers the four physical sides through `property_helper!`, and that helper flushes the whole buffer when the category changes (`flush_helper!`, border.rs:1224), which it does after a logical longhand. `flush_logical` turns buffered inline sides into `context.add_logical_rule(...)` rules when the targets lack logical properties. Only after that flush did the arm clear the overridden component of the four logical sides, so the clears never removed anything.
- Upstream lightningcss 1.30.2 produces the same output for these inputs (same arm shape), so this is inherited rather than a porting error. The full `border:` arm is not affected: it replaces everything without flushing.

### Fix

- The three arms share a new `rect_shorthand_helper!` that clears the component on the four logical sides before the `property_helper!` calls, so the category-change flush writes out only what the shorthand leaves live (nothing for a plain longhand; the style and color of `border-inline-start: 3px solid red` when `border-width` follows).
- The clear is skipped when one of the shorthand's four values is rejected by a target (`is_compatible`), because such a target drops the whole declaration and the buffered longhands still apply there; they are then flushed as fallbacks, which is the existing behavior and the same condition `flush_helper!` uses to keep a physical value as a fallback. This is also the rule #38576 applies to the margin/padding shorthands.
- Why this is correct: the 4-side shorthand sets all four physical longhands of its component, and a logical longhand of that component resolves to one of those four in every writing mode, so a browser that applies the shorthand can never observe the earlier longhand. Other components are untouched, physical sides still go through `property_helper!` unchanged, and the reverse order (`border-width:0;border-inline-start-width:3px`) still hits the category flush, so its output is unchanged. Every output this changes is one where the removed declaration was dead for every target.
- Verified with `test/js/bun/css/css.test.ts`, new "4-side shorthand after a logical longhand in the same block" block under `border`: inline-start, inline-end, `border-inline-*`, block-start and block-end, across width, style and color, each minified and compiled for safari 8; the partial override (`border-inline-start: 3px solid red; border-width: 0`) in both modes; a different component; the fallback condition (`max(2cqw, 22px)` with safari 14 vs 16, `color(display-p3 ...)` with chrome 99 vs safari 16); the reverse order in both modes; and the two `!important` cases. 25 of the 31 cases fail on bun 1.4.0 (`USE_SYSTEM_BUN=1`), all 31 pass with the fix.
- `bun bd test test/js/bun/css/css.test.ts`: 1173 pass. `doesnt_crash`, `css-loader`, `test/bundler/css/css-modules.test.ts`, `test/bundler/esbuild/css.test.ts`: 125 pass.
- Open PRs touching `border.rs` (#38551 `Border` arm, #38582 `flush_unparsed`, #38592 `flush_category!`) change different lines and do not cover these arms; #38576 is the same fix for `margin_padding.rs`. A physical longhand declared after a compiled inline longhand (`border-inline-start-color:red;border-left-color:blue`) loses to the appended rules in the same way; that needs a different fix and is tracked separately.

### Background

- The minifier runs each declaration block through property handlers. `BorderHandler` buffers the block's border declarations as eight sides (four physical, four logical), each holding an optional width, style and color, and `flush()` writes them out merged into the shortest shorthands. A declaration for a slot that is already buffered replaces it; that is how `border-top-width:1px;border-width:0` becomes `border-width:0`.
- Logical sides (`border-inline-start`, ...) resolve to a physical side based on the element's writing mode, so the handler cannot merge them with physical values. It buffers one category at a time (`self.category`) and flushes the buffer when a declaration of the other category arrives, which keeps source order between two groups that are both live. `property_helper!` does this flush for every longhand it buffers.
- The same flush doubles as fallback handling: if a new value uses syntax some target rejects (`is_compatible` against the targets), the value it would replace is flushed first so that target still gets the old declaration.
- When the targets lack logical properties, `flush()` converts block sides into `border-top-*`/`border-bottom-*` inside the rule, but inline sides depend on text direction, so `context.add_logical_rule()` emits them as extra `:lang()`-selected rules placed after the rule. Anything emitted that way outranks the rule itself, which is why flushing a dead inline longhand changes the result while flushing a dead block longhand only costs bytes.

<details>
<summary>Outputs before and after (safari 8 targets unless noted, <code>:lang()</code> lists abbreviated)</summary>

```
.a{border-inline-start-width:3px;border-width:0}
  before: .a{border-width:0} + :lang rules {border-left-width:3px} / {border-right-width:3px}
  after:  .a{border-width:0}

.a{border-inline-start:3px solid red;border-width:0}
  before: .a{border-width:0} + :lang rules {border-left:3px solid red} / {border-right:3px solid red}
  after:  .a{border-width:0} + :lang rules {border-left-style:solid;border-left-color:red} / {border-right-...}

.a{border-inline-width:3px;border-width:0}
  before: .a{border-left-width:3px;border-right-width:3px;border-width:0}
  after:  .a{border-width:0}

.a{border-inline-start-width:3px;border-width:max(2cqw,22px)}   (safari 14: rejects cqw)
  before and after: .a{border-inline-start-width:3px;border-width:max(2cqw,22px)}
.a{border-inline-start-width:3px;border-width:max(2cqw,22px)}   (safari 16)
  before: .a{border-inline-start-width:3px;border-width:max(2cqw,22px)}
  after:  .a{border-width:max(2cqw,22px)}

.a{border-width:0;border-inline-start-width:3px}
  before and after: .a{border-width:0} + :lang rules {border-left-width:3px} / {border-right-width:3px}

bun build --minify (no compilation of logical properties):
  .a{border-inline-start-width:3px;border-width:0}.b{border-inline-start-color:red;border-color:blue}
  before: .a{border-inline-start-width:3px;border-width:0}.b{border-inline-start-color:red;border-color:#00f}
  after:  .a{border-width:0}.b{border-color:#00f}
```
</details>
