### PR TITLE
bundler: name the node target in the Bun builtin resolution error

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -6335,7 +6335,12 @@ pub mod bv2_impl {
                                                 Some(source),
                                                 import_record.range,
                                                 format_args!(
-                                                    "Browser build cannot {} Bun builtin: \"{}\"{}",
+                                                    "{} build cannot {} Bun builtin: \"{}\"{}",
+                                                    if ctx.target.is_node() {
+                                                        "Node.js"
+                                                    } else {
+                                                        "Browser"
+                                                    },
                                                     bstr::BStr::new(
                                                         import_record.kind.error_label()
                                                     ),

--- a/test/bundler/bundler_browser.test.ts
+++ b/test/bundler/bundler_browser.test.ts
@@ -436,6 +436,50 @@ describe("bundler", () => {
     },
   });
 
+  const targetNodeImportBunFiles = {
+    "/entry.js": `
+      import { file } from "bun";
+      const { serve } = require("bun");
+      const dynamic = import("bun");
+      console.log(file, serve, dynamic);
+    `,
+  };
+  const targetNodeImportBunErrors = {
+    "/entry.js": ["import", "require()", "import()"].map(
+      label => `Node.js build cannot ${label} Bun builtin: "bun". When bundling for Bun, set target to 'bun'`,
+    ),
+  };
+  itBundled("browser/TargetNodeImportBunError", {
+    skipOnEsbuild: true,
+    files: targetNodeImportBunFiles,
+    target: "node",
+    backend: "api",
+    bundleErrors: targetNodeImportBunErrors,
+  });
+  itBundled("browser/TargetNodeImportBunErrorCLI", {
+    skipOnEsbuild: true,
+    files: targetNodeImportBunFiles,
+    target: "node",
+    backend: "cli",
+    bundleErrors: targetNodeImportBunErrors,
+  });
+  // Unlike the bare "bun" specifier, "bun:*" is left external when targeting node.
+  itBundled("browser/TargetNodeBunPrefixedBuiltinShouldBeExternal", {
+    skipOnEsbuild: true,
+    files: {
+      "/entry.js": `
+        import { Database } from "bun:sqlite";
+        console.log(Database);
+      `,
+    },
+    target: "node",
+    onAfterBundle(api) {
+      expect(new Bun.Transpiler().scanImports(api.readFile("out.js"))).toStrictEqual([
+        { kind: "import-statement", path: "bun:sqlite" },
+      ]);
+    },
+  });
+
   // not implemented right now
   itBundled("browser/BunPolyfillExternal", {
     skipOnEsbuild: true,


### PR DESCRIPTION
### Problem
- `bun build ./entry.js --target=node` with `import { file } from "bun"` fails with `error: Browser build cannot import Bun builtin: "bun". When bundling for Bun, set target to 'bun'`. The build is a node build; the message names the wrong target.
- Same wording for `require("bun")` and `import("bun")`, and for `Bun.build({ target: "node" })`. Reproduced on 1.4.0 and main.
- Cause: in `resolve_import_records` (src/bundler/bundle_v2.rs:6329), the branch is guarded by `!ctx.target.is_bun()`, which covers both the browser and the node target, but the format string was hard-coded to `"Browser build cannot ..."`. The sibling Node.js builtin branch right above it is guarded by `ctx.target == Target::Browser`, so it is not affected.

### Fix
- The message takes its first word from `ctx.target`: `Node.js build cannot ...` for the node target, `Browser build cannot ...` for the browser target. The `When bundling for Bun, set target to 'bun'` hint is unchanged, since that is still the only way to bundle an import of `"bun"`.
- `!is_bun()` leaves exactly two targets, `Node` and `Browser`, so `is_node()` is sufficient to tell them apart. Browser-target output is byte for byte what it was, so the existing assertions on it (`browser/ImportBunError`, the dev server test `importing bun on the client`) still pass unchanged.
- Only the bare `"bun"` specifier reaches this branch under the node target: `"bun:*"` specifiers are marked external by the resolver for node and bun targets (`mark_builtins_as_external`, set in `BundleV2::init`), while `"bun"` itself is only a builtin alias for bun targets and therefore falls through to filesystem resolution and fails. The handoff that reported this mentioned `bun:sqlite` as also affected; it is not, and the new external test pins that.
- Tests (test/bundler/bundler_browser.test.ts):
  - `browser/TargetNodeImportBunError` (`Bun.build`) and `browser/TargetNodeImportBunErrorCLI` (`bun build`) assert the `Node.js build cannot import / require() / import() Bun builtin: "bun"` messages. Both fail on the released binary with the `Browser build` wording and pass with this change.
  - `browser/TargetNodeBunPrefixedBuiltinShouldBeExternal` pins that `bun:sqlite` is left as an external import under the node target (passes before and after; it documents why the error tests only cover `"bun"`).
  - `bun bd test test/bundler/bundler_browser.test.ts` passes (19 pass, 1 skip, 1 todo), as does the `importing bun on the client` case in test/bake/dev/bundle.test.ts.

### Background
- The bundler's `Target` is one of `Browser`, `Node`, `Bun`, `BunMacro`, `ServerComponentsSsr`; `Target::is_bun()` is true for the last three, so `!is_bun()` means browser or node.
- For bun targets, `"bun"` and `"bun:*"` imports are handled before resolution (kept as runtime imports). For the node target, the resolver externalizes `"node:*"` and `"bun:*"` specifiers, and everything else, including the bare `"bun"` specifier, goes through normal package resolution; when that fails, `resolve_import_records` picks one of the "Could not resolve" style messages, which is where this text lives.
- `itBundled` runs a bundle through `Bun.build` by default; `backend: "cli"` runs the same case through `bun build`. `bundleErrors` matches each expected message as a substring of an emitted error, and every emitted error has to be matched.
