### PR TITLE
bundler: apply the jsx option to entry points that come from files:

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -922,9 +922,15 @@ pub mod bv2_impl {
                 /// `bun_resolver::Result`'s `Path<'static>` borrows arena memory
                 /// (lives for the entire build pass) instead of the map's key
                 /// storage.
+                ///
+                /// `jsx` is the configured pragma of the transpiler the file is
+                /// bundled with. The resolver fills `Result.jsx` from its options
+                /// for on-disk files and `ParseTask::init` parses with whatever the
+                /// `Result` carries, so a virtual file has to carry it too.
                 pub(crate) fn resolve(
                     &self,
                     arena: &bun_alloc::Arena,
+                    jsx: &crate::options::jsx::Pragma,
                     source_file: &[u8],
                     specifier: &[u8],
                 ) -> Option<bun_resolver::Result> {
@@ -946,7 +952,7 @@ pub mod bv2_impl {
                     // key, not the parameter).
                     #[cfg(not(windows))]
                     if let Some((key, _)) = self.map.get_key_value(specifier) {
-                        return Some(Self::result_for_key(dupe(key.as_ref())));
+                        return Some(Self::result_for_key(dupe(key.as_ref()), jsx));
                     }
                     #[cfg(windows)]
                     {
@@ -954,7 +960,7 @@ pub mod bv2_impl {
                         let normalized =
                             bun_paths::resolve_path::path_to_posix_buf(specifier, &mut **buf);
                         if let Some((key, _)) = self.map.get_key_value(normalized) {
-                            return Some(Self::result_for_key(dupe(key.as_ref())));
+                            return Some(Self::result_for_key(dupe(key.as_ref()), jsx));
                         }
                     }
 
@@ -1017,7 +1023,7 @@ pub mod bv2_impl {
                         }
                         let joined = &buf[0..joined_len];
                         if let Some((key, _)) = self.map.get_key_value(joined) {
-                            return Some(Self::result_for_key(dupe(key.as_ref())));
+                            return Some(Self::result_for_key(dupe(key.as_ref()), jsx));
                         }
                     }
 
@@ -1030,12 +1036,16 @@ pub mod bv2_impl {
                 /// the resulting `Path<'static>` borrows arena memory rather than
                 /// forging a `'static` from a map borrow.
                 #[inline]
-                fn result_for_key(key: &'static [u8]) -> bun_resolver::Result {
+                fn result_for_key(
+                    key: &'static [u8],
+                    jsx: &crate::options::jsx::Pragma,
+                ) -> bun_resolver::Result {
                     bun_resolver::Result {
                         path_pair: bun_resolver::PathPair {
                             primary: crate::bun_fs::Path::init_with_namespace(key, b"file"),
                             ..Default::default()
                         },
+                        jsx: jsx.clone(),
                         module_type: crate::options::ModuleType::Unknown,
                         ..Default::default()
                     }
@@ -2250,6 +2260,8 @@ pub mod bv2_impl {
             if let Some(file_map) = self.file_map {
                 if let Some(_file_map_result) = file_map.resolve(
                     self.arena(),
+                    // SAFETY: see `transpiler` note above.
+                    unsafe { &(*transpiler).options.jsx },
                     &import_record.source_file,
                     &import_record.specifier,
                 ) {
@@ -3064,8 +3076,12 @@ pub mod bv2_impl {
 
                 // Check FileMap first for in-memory entry points
                 if let Some(file_map) = self.file_map {
-                    if let Some(file_map_result) = file_map.resolve(self.arena(), b"", entry_point)
-                    {
+                    if let Some(file_map_result) = file_map.resolve(
+                        self.arena(),
+                        &self.transpiler.options.jsx,
+                        b"",
+                        entry_point,
+                    ) {
                         let _ = self.enqueue_entry_item(
                             &mut { file_map_result },
                             true,
@@ -6164,9 +6180,12 @@ pub mod bv2_impl {
 
                 // Check the FileMap first for in-memory files
                 if let Some(file_map) = self.file_map {
-                    if let Some(_file_map_result) =
-                        file_map.resolve(self.arena(), source.path.text, import_record.path.text)
-                    {
+                    if let Some(_file_map_result) = file_map.resolve(
+                        self.arena(),
+                        &transpiler.options.jsx,
+                        source.path.text,
+                        import_record.path.text,
+                    ) {
                         let mut file_map_result = _file_map_result;
                         let mut path_primary = file_map_result.path_pair.primary;
                         let import_record_loader = import_record.loader.unwrap_or_else(|| {

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -923,10 +923,8 @@ pub mod bv2_impl {
                 /// (lives for the entire build pass) instead of the map's key
                 /// storage.
                 ///
-                /// `jsx` is the configured pragma of the transpiler the file is
-                /// bundled with. The resolver fills `Result.jsx` from its options
-                /// for on-disk files and `ParseTask::init` parses with whatever the
-                /// `Result` carries, so a virtual file has to carry it too.
+                /// `jsx` becomes the result's `Result.jsx`, which `ParseTask::init`
+                /// parses with (the resolver fills it from its options for disk files).
                 pub(crate) fn resolve(
                     &self,
                     arena: &bun_alloc::Arena,

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -922,9 +922,6 @@ pub mod bv2_impl {
                 /// `bun_resolver::Result`'s `Path<'static>` borrows arena memory
                 /// (lives for the entire build pass) instead of the map's key
                 /// storage.
-                ///
-                /// `jsx` becomes the result's `Result.jsx`, which `ParseTask::init`
-                /// parses with (the resolver fills it from its options for disk files).
                 pub(crate) fn resolve(
                     &self,
                     arena: &bun_alloc::Arena,

--- a/test/bundler/bundler_files.test.ts
+++ b/test/bundler/bundler_files.test.ts
@@ -200,7 +200,99 @@ describe("bundler files option", () => {
     expect(result.outputs.length).toBe(1);
 
     const output = await result.outputs[0].text();
-    expect(output).toContain("Hello JSX");
+    expect(output).toContain('h("div", null, "Hello JSX")');
+    expect(output).not.toContain("jsxDEV");
+  });
+
+  test("jsx option applies to an in-memory entry point, not only to in-memory imports", async () => {
+    const result = await Bun.build({
+      entrypoints: ["/entry.jsx"],
+      files: {
+        "/entry.jsx": `
+          import { child, childFragment } from "./child.jsx";
+          export const entry = <div>{child}{childFragment}</div>;
+          export const entryFragment = <>entry</>;
+        `,
+        "/child.jsx": `
+          export const child = <span>child</span>;
+          export const childFragment = <>child</>;
+        `,
+      },
+      jsx: {
+        runtime: "classic",
+        factory: "myFactory",
+        fragment: "MyFragment",
+      },
+    });
+
+    expect(result.success).toBe(true);
+    const output = await result.outputs[0].text();
+    // imported in-memory file
+    expect(output).toContain('myFactory("span", null, "child")');
+    expect(output).toContain('myFactory(MyFragment, null, "child")');
+    // in-memory entry point itself
+    expect(output).toContain('myFactory("div", null, child, childFragment)');
+    expect(output).toContain('myFactory(MyFragment, null, "entry")');
+    expect(output).not.toContain("jsxDEV");
+    expect(output).not.toContain("jsx-dev-runtime");
+  });
+
+  test("jsx.importSource and jsx.development apply to an in-memory entry point", async () => {
+    const files = {
+      "/entry.jsx": `export const entry = <div>entry</div>;`,
+    };
+
+    const dev = await Bun.build({
+      entrypoints: ["/entry.jsx"],
+      files,
+      jsx: { runtime: "automatic", importSource: "my-jsx-lib" },
+      external: ["my-jsx-lib/*"],
+    });
+    expect(dev.success).toBe(true);
+    expect(await dev.outputs[0].text()).toContain('import { jsxDEV } from "my-jsx-lib/jsx-dev-runtime";');
+
+    const prod = await Bun.build({
+      entrypoints: ["/entry.jsx"],
+      files,
+      jsx: { runtime: "automatic", importSource: "my-jsx-lib", development: false },
+      external: ["my-jsx-lib/*"],
+    });
+    expect(prod.success).toBe(true);
+    expect(await prod.outputs[0].text()).toContain('import { jsx } from "my-jsx-lib/jsx-runtime";');
+  });
+
+  test("jsx option applies to an in-memory import that an onResolve plugin declined", async () => {
+    let resolveCalled = false;
+
+    const result = await Bun.build({
+      entrypoints: ["/entry.js"],
+      files: {
+        "/entry.js": `export { child } from "./child.jsx";`,
+        "/child.jsx": `export const child = <span>child</span>;`,
+      },
+      jsx: {
+        runtime: "classic",
+        factory: "myFactory",
+        fragment: "MyFragment",
+      },
+      plugins: [
+        {
+          name: "decline",
+          setup(build) {
+            build.onResolve({ filter: /child\.jsx$/ }, () => {
+              resolveCalled = true;
+              return undefined;
+            });
+          },
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    expect(resolveCalled).toBe(true);
+    const output = await result.outputs[0].text();
+    expect(output).toContain('myFactory("span", null, "child")');
+    expect(output).not.toContain("jsxDEV");
   });
 
   test("in-memory file with Blob content", async () => {


### PR DESCRIPTION
### Problem

- `Bun.build({ entrypoints: ["/v/entry.jsx"], files: { "/v/entry.jsx": ... }, jsx: { runtime: "classic", factory: "myH" } })` ignores the `jsx` option for the entry point: the file is transpiled with the default automatic React runtime, so the build either fails with `ResolveMessage: Could not resolve: "react/jsx-dev-runtime"` or, when react happens to be installed, silently bundles react. `jsx.importSource` and `jsx.development` are dropped the same way.
- The same file honors the option when it is imported from another in-memory file, or when the entry point is on disk.
- Cause: `FileMap::result_for_key` (src/bundler/bundle_v2.rs:1039) fabricates the `bun_resolver::Result` for an in-memory file with `..Default::default()`, so `Result.jsx` is `jsx::Pragma::default()`. `enqueue_entry_points_normal` (bundle_v2.rs:3078) hands that result to `enqueue_entry_item`, and `ParseTask::init` (src/bundler/ParseTask.rs:261) parses with `resolve_result.jsx`; `enqueue_entry_item` only patches `jsx.development` afterwards.
- The two import paths did not show the bug because they overwrite the task's pragma from the transpiler options after `ParseTask::init` (`enqueue_parse_task`, bundle_v2.rs:3622, and the FileMap branch of `resolve_import_records`, bundle_v2.rs:6239).

### Fix

- `FileMap::resolve` takes the pragma of the transpiler the file is bundled with and `result_for_key` stores it in the `Result` it builds. The three callers pass `transpiler.options.jsx` for their target.
- This is what the resolver does for on-disk files: it seeds `Result.jsx` from its options (src/resolver/resolver.rs:1200) before merging the nearest tsconfig. The consumers (`enqueue_entry_item`, `ParseTask::init`) are correct to trust `Result.jsx`, since for disk files it holds the per-file tsconfig-merged value, so the fix belongs where the in-memory result is built rather than in another consumer-side override. The `jsx.development` handling in `enqueue_entry_item` is unchanged and now applies on top of the configured pragma, exactly as it does for disk entry points. For `Bun.build` the transpiler options are the merged result of the `jsx` option, the root tsconfig and `NODE_ENV`, which is the value the import paths already used, so entry points and imports now agree.
- The existing overrides on the import paths are left in place; they now assign the same value the result already carries.
- Verified with test/bundler/bundler_files.test.ts: the strengthened "in-memory file with JSX" test and two new entry point tests (classic factory/fragment, automatic `importSource` with `development` true and false) fail on the released build and pass with the fix; a fourth new test pins the plugin-declined import path (`run_resolver`), which is the third caller of `FileMap::resolve`.
- Also ran test/bundler/bundler_jsx.test.ts, test/bundler/bun-build-api.test.ts and test/bundler/html-import-manifest.test.ts with the debug build: green.

### Background

- `files:` (the `FileMap`) lets `Bun.build` bundle sources that are not on disk. When a specifier matches a key of the map, the bundler skips the resolver and fabricates the `bun_resolver::Result` itself in `FileMap::resolve`; the file's contents are read from the map later, in `ParseTask`.
- `bun_resolver::Result` is the resolver's per-file answer. Besides the path it carries per-file transpile settings, among them the JSX pragma (`jsx`: runtime, factory, fragment, import source, development flag), because the nearest tsconfig.json can change them per directory. `ParseTask::init` copies these settings into the parse task, and the parser uses the task's copy only.
- An entry point from `files:` goes through `enqueue_entry_item`, the same function disk entry points use, while an import of a `files:` entry goes through `resolve_import_records` (or `run_resolver` when an onResolve plugin declined it), which have their own code for virtual files. That is why only the entry point was affected.
