### PR TITLE
Bun.inspect: don't leave an exception pending when a property lookup fails

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5616,10 +5616,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
-                // Ignore exceptions from "Get" proxy traps.
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
+                // Ignore exceptions from "Get" proxy traps and lazy property initializers.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto
@@ -5691,7 +5692,12 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue proto = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototypeOf" traps.
+            CLEAR_IF_EXCEPTION(scope);
+            if (!proto)
+                break;
+            iterating = proto.getObject();
         }
     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -579,6 +579,59 @@ it("Bun.inspect huge sparse array summarizes holes without iterating them", asyn
   });
 });
 
+describe("Bun.inspect with a Proxy in the prototype chain", () => {
+  it("skips properties whose get trap throws", () => {
+    const proto = new Proxy(
+      { a: 1, b: 2 },
+      {
+        get(target, key, receiver) {
+          if (key === "a" || key === "b") throw new Error("get trap");
+          return Reflect.get(target, key, receiver);
+        },
+      },
+    );
+    expect(Bun.inspect(Object.create(proto))).toBe("{}");
+    expect(Bun.inspect(Object.assign(Object.create(proto), { own: 3 }))).toBe("{\n  own: 3,\n}");
+  });
+
+  it("stops walking the prototype chain when the getPrototypeOf trap throws", () => {
+    const proto = new Proxy(
+      { a: 1 },
+      {
+        getPrototypeOf() {
+          throw new Error("getPrototypeOf trap");
+        },
+      },
+    );
+    expect(Bun.inspect(Object.create(proto))).toBe("{\n  a: 1,\n}");
+    expect(Bun.inspect(Object.create(Object.create(proto)))).toBe("{\n  a: 1,\n}");
+  });
+});
+
+// Bun.$ is built lazily and reads the global `process` while doing so, so clobbering
+// `process` makes that property throw while Bun.inspect enumerates the Bun object. The
+// exception used to stay pending while the next lazy property (Archive) was built, which
+// dropped it from the output in release builds and tripped an assertion in debug builds.
+it("Bun.inspect keeps going when a lazily built property throws", async () => {
+  const code = `
+    globalThis.process = undefined;
+    const out = Bun.inspect(Bun);
+    console.log(typeof out, out.includes("Archive:"), out.includes("version:"));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, exitCode }).toEqual({
+    stdout: "string true true\n",
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
 describe("console.logging function displays async and generator names", async () => {
   const cases = [
     function () {},


### PR DESCRIPTION
### What does this PR do?

`JSC__JSValue__forEachPropertyImpl` (the property walk behind `Bun.inspect` / `console.log`) skipped a property as soon as `getPropertySlot` returned false. Two lookups can return false with an exception still pending: a lazily built static property (`PropertyCallback`) whose initializer throws, and a Proxy `get` trap that throws. The `continue` ran before the existing `CLEAR_IF_EXCEPTION`, so the exception stayed set while the next property was looked up.

What that did:

* For the Bun object, the next lazy property (`Archive`) was built with the stale exception pending. In release builds `setUpStaticFunctionSlot` then reported it as missing and it vanished from the output; in debug builds the exception scope assertion fired (`releaseAssertNoException`, the crash this PR started from, found by fuzzing: a script that broke `Bun.$`'s initializer and then called `Bun.inspect(Bun)`).
* With a Proxy in the prototype chain, the later `iterating->getPrototype(globalObject)` bailed out on the pending exception and returned an empty `JSValue`, and `.getObject()` on it segfaulted (`Segmentation fault at address 0x5` on the current canary).

The same `getPrototype` line also crashed on its own whenever a Proxy `getPrototypeOf` trap throws, since the empty return value was never checked.

The fix is the two hunks in `bindings.cpp`: clear the exception right after `getPropertySlot` regardless of its result (this is what `forEachPropertyOrdered` already does), and stop the prototype walk when `getPrototype` returns empty instead of dereferencing it. Exceptions from these lookups were already being swallowed at the end of the function, so the output for the non-crashing cases is unchanged.

Repros that crash the current release build and pass with this change:

```js
const proto = new Proxy({ a: 1 }, { get(t, k, r) { if (k === "a") throw new Error("x"); return Reflect.get(t, k, r); } });
Bun.inspect(Object.create(proto)); // segfault, now "{}"

const proto2 = new Proxy({ a: 1 }, { getPrototypeOf() { throw new Error("x"); } });
Bun.inspect(Object.create(proto2)); // segfault, now "{\n  a: 1,\n}"
```

### How did you verify your code works?

Added three tests to `test/js/bun/util/inspect.test.js`. On the unfixed build the two Proxy tests segfault (release) or trip UBSan (debug), and the lazy property test fails with `Archive` missing from the output (release) or the exception scope assertion in the child process (debug). All three pass with `bun bd test test/js/bun/util/inspect.test.js`, along with the rest of that file and the console tests.
