### PR TITLE
bunfig: honor smol and install.prefer for bun file.js / bun test, and let the flags override them for bun run

### DIFF
--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -404,7 +404,10 @@ impl<'a> Parser<'a> {
         if cmd == CommandTag::RunCommand || cmd == CommandTag::AutoCommand {
             if let Some(expr) = json.get(b"smol") {
                 self.expect(&expr, ExprTag::EBoolean)?;
-                self.ctx.runtime_options.smol = expr.as_bool().expect("infallible: type checked");
+                if !self.ctx.cli_overrides.smol {
+                    self.ctx.runtime_options.smol =
+                        expr.as_bool().expect("infallible: type checked");
+                }
             }
         }
 
@@ -420,8 +423,10 @@ impl<'a> Parser<'a> {
 
                 if let Some(expr) = test.get(b"smol") {
                     self.expect(&expr, ExprTag::EBoolean)?;
-                    self.ctx.runtime_options.smol =
-                        expr.as_bool().expect("infallible: type checked");
+                    if !self.ctx.cli_overrides.smol {
+                        self.ctx.runtime_options.smol =
+                            expr.as_bool().expect("infallible: type checked");
+                    }
                 }
 
                 if let Some(expr) = test.get(b"coverage") {
@@ -754,7 +759,9 @@ impl<'a> Parser<'a> {
                     self.expect_string(&prefer_expr)?;
                     let key = prefer_expr.as_string(self.bump).unwrap_or(b"");
                     if let Some(setting) = OFFLINE_PREFER.get(key) {
-                        self.ctx.debug.offline_mode_setting = Some(*setting);
+                        if !self.ctx.cli_overrides.install_prefer {
+                            self.ctx.debug.offline_mode_setting = Some(*setting);
+                        }
                     } else {
                         self.add_error(
                             prefer_expr.loc,

--- a/src/options_types/context.rs
+++ b/src/options_types/context.rs
@@ -44,6 +44,22 @@ pub struct ContextData {
 
     pub preloads: Vec<Box<[u8]>>,
     pub has_loaded_global_config: bool,
+    pub cli_overrides: CliOverrides,
+}
+
+/// Settings that were given on the command line.
+///
+/// `Arguments::parse` loads bunfig.toml before it applies the flags for
+/// `bun file.js` / `bun -e` / `bun test`, but `bun run <target>` (and the
+/// `node` shim, `bun repl`) only load it afterwards, from `RunCommand`; the
+/// bunfig parser skips the keys recorded here so the flag wins in that order
+/// too.
+#[derive(Clone, Copy, Default)]
+pub struct CliOverrides {
+    /// `--smol`
+    pub smol: bool,
+    /// `--prefer-offline` or `--prefer-latest`
+    pub install_prefer: bool,
 }
 
 impl Default for ContextData {
@@ -84,6 +100,7 @@ impl Default for ContextData {
             no_exit_on_error: false,
             preloads: Vec::new(),
             has_loaded_global_config: false,
+            cli_overrides: CliOverrides::default(),
         }
     }
 }

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -1171,13 +1171,19 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
             let _ = bun_http::OVERRIDDEN_DEFAULT_USER_AGENT.set(user_agent);
         }
 
-        ctx.debug.offline_mode_setting = Some(if args.flag(b"--prefer-offline") {
-            bun_options_types::offline_mode::OfflineMode::Offline
+        // "install.prefer" in bunfig.toml; without a flag, leave whatever
+        // bunfig.toml set (None reads as online).
+        let prefer = if args.flag(b"--prefer-offline") {
+            Some(bun_options_types::offline_mode::OfflineMode::Offline)
         } else if args.flag(b"--prefer-latest") {
-            bun_options_types::offline_mode::OfflineMode::Latest
+            Some(bun_options_types::offline_mode::OfflineMode::Latest)
         } else {
-            bun_options_types::offline_mode::OfflineMode::Online
-        });
+            None
+        };
+        if let Some(prefer) = prefer {
+            ctx.debug.offline_mode_setting = Some(prefer);
+            ctx.cli_overrides.install_prefer = true;
+        }
 
         if args.flag(b"--no-install") {
             ctx.debug.global_cache = options::GlobalCache::disable;
@@ -1208,7 +1214,12 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
             ctx.runtime_options.eval.script = script.into();
         }
         ctx.runtime_options.if_present = args.flag(b"--if-present");
-        ctx.runtime_options.smol = args.flag(b"--smol");
+        // "smol" / "test.smol" in bunfig.toml; without the flag, leave
+        // whatever bunfig.toml set.
+        if args.flag(b"--smol") {
+            ctx.runtime_options.smol = true;
+            ctx.cli_overrides.smol = true;
+        }
         // node's `-i` is an alias for --interactive; elsewhere `-i` is --install=fallback.
         ctx.runtime_options.interactive = args.flag(b"--interactive")
             || (cmd == CommandTag::RunAsNodeCommand && args.flag(b"-i"));

--- a/test/config/bunfig/smol.test.ts
+++ b/test/config/bunfig/smol.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux, tempDir } from "harness";
+
+// Nothing in JS reports smol mode directly. On Linux it lowers the size at
+// which a Blob is backed by a memfd (LinuxMemFdAllocator::should_use: 1 MiB in
+// smol mode, 8 MiB otherwise), and the memfd is visible in /proc/self/fd while
+// the Blob is alive, so a 2 MiB Blob tells the two modes apart.
+const probe = /* js */ `
+  const { readdirSync, readlinkSync } = require("node:fs");
+  const blob = new Blob([new Uint8Array(2 * 1024 * 1024)]);
+  const memfd = readdirSync("/proc/self/fd").some(fd => {
+    try {
+      return readlinkSync("/proc/self/fd/" + fd).startsWith("/memfd:memfd-num-");
+    } catch {
+      return false;
+    }
+  });
+  console.log("mode:" + (memfd ? "smol" : "normal") + ":" + blob.size);
+`;
+
+// Stands in for the probe source in argv so test names stay readable.
+const PROBE = "<probe>";
+
+type Case = [bunfig: string, argv: string[], expected: "smol" | "normal"];
+
+async function runCase([bunfig, argv, expected]: Case, files: Record<string, string>) {
+  if (bunfig) files["bunfig.toml"] = bunfig + "\n";
+  using dir = tempDir("bunfig-smol", files);
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), ...argv.map(arg => (arg === PROBE ? probe : arg))],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout.match(/^mode:(\w+):2097152$/m)?.[1], stderr).toBe(expected);
+  expect(exitCode, stderr).toBe(0);
+}
+
+describe.skipIf(!isLinux).concurrent("bunfig.toml smol", () => {
+  const cases: Case[] = [
+    ["", ["index.js"], "normal"],
+    ["smol = false", ["index.js"], "normal"],
+    ["[test]\nsmol = true", ["index.js"], "normal"],
+    // bunfig.toml is read while argv is being parsed for these.
+    ["smol = true", ["index.js"], "smol"],
+    ["smol = true", ["-e", PROBE], "smol"],
+    // `bun run` reads bunfig.toml after argv has been applied.
+    ["smol = true", ["run", "index.js"], "smol"],
+    // The flag wins over the file in either order.
+    ["smol = false", ["--smol", "index.js"], "smol"],
+    ["smol = false", ["run", "--smol", "index.js"], "smol"],
+    ["smol = false", ["--smol", "run", "index.js"], "smol"],
+  ];
+
+  test.each(cases)("%j + bun %j -> %s", (bunfig, argv, expected) =>
+    runCase([bunfig, argv, expected], { "index.js": probe }),
+  );
+});
+
+describe.skipIf(!isLinux).concurrent("bunfig.toml test.smol", () => {
+  const testFile = `import { test } from "bun:test";\ntest("probe", () => {${probe}});\n`;
+
+  const cases: Case[] = [
+    ["", ["test", "probe.test.js"], "normal"],
+    ["[test]\nsmol = true", ["test", "probe.test.js"], "smol"],
+    ["[test]\nsmol = false", ["test", "--smol", "probe.test.js"], "smol"],
+    ["[test]\nsmol = false", ["--smol", "test", "probe.test.js"], "smol"],
+  ];
+
+  test.each(cases)("%j + bun %j -> %s", (bunfig, argv, expected) =>
+    runCase([bunfig, argv, expected], { "probe.test.js": testFile }),
+  );
+});


### PR DESCRIPTION
### Problem
- `smol = true` in bunfig.toml is ignored by `bun file.js` and `bun -e`, and `[test] smol = true` is ignored by `bun test`. Only `bun run file.js` honors it.
- In the other direction, `bun run --smol file.js` with `smol = false` in bunfig.toml runs without smol mode: the file overrides the flag, although the bunfig docs say CLI flags override bunfig.toml.
- `install.prefer` (`--prefer-offline` / `--prefer-latest`) has the same two problems.
- Cause: `Arguments::parse` (`src/runtime/cli/Arguments.rs`) assigns `ctx.runtime_options.smol = args.flag("--smol")` and `ctx.debug.offline_mode_setting = Some(...)` unconditionally. For `bun file.js`, `bun -e` and `bun test` it has already applied bunfig.toml at that point (`load_config_with_cmd_args`), so with no flag on the command line both assignments reset what the file set (`src/bunfig/bunfig.rs`: top-level `smol`, `[test] smol`, `install.prefer`).
- `bun run <target>` loads bunfig.toml later, from `RunCommand`, and the bunfig parser assigned the keys unconditionally, so there the file overwrote a flag that was given.

### Fix
- `Arguments::parse` only writes the two settings when the flag is present. Without a flag `offline_mode_setting` stays `None`, which all three readers (`RunCommand`, `bun repl`, `bun build --app`) already map to online, so the default is unchanged.
- A flag that is present is also recorded in `ctx.cli_overrides` (new `CliOverrides` in `src/options_types/context.rs`), and the bunfig parser skips the assignment for a recorded key (the key is still type-checked). This is the mechanism `test.pathIgnorePatterns` already uses (`path_ignore_patterns_from_cli`), and it gives the same result in both load orders without touching the late-load sites.
- #38599 adds the same `cli_overrides` struct for the keys that were only broken in the `bun run` order; it leaves `smol` and `install.prefer` to this PR. The struct and field are named the same here so whichever lands second only has to merge the field lists.
- Test: `test/config/bunfig/smol.test.ts`. Smol mode has no direct JS reflection; on Linux it lowers the size at which a Blob is backed by a memfd from 8 MiB to 1 MiB (`LinuxMemFdAllocator::should_use`), so a 2 MiB Blob plus a look at `/proc/self/fd` tells the two modes apart with an unmodified binary. The cases cover `bun file.js`, `bun -e`, `bun run file.js`, `bun test`, and `--smol` beating `smol = false` / `[test] smol = false` with the flag before and after the subcommand. Linux only because of the probe; the code under test is not platform specific.
  - On the release build of main, 5 of the 13 cases fail (`smol = true` with `bun index.js` and with `bun -e`, `[test] smol = true` with `bun test`, `smol = false` with `bun run --smol` and with `bun --smol run`); with this change all 13 pass.
- `install.prefer` gets the same code change but no behavioural test: on main, `--prefer-offline` itself has no observable effect on auto-install (the disk cache lookup it enables never matches; #36776 fixes that, and I confirmed the flag changes nothing on main with that PR's scenario), so neither the flag nor the key can be distinguished from the default yet. Once #36776 lands, its `--prefer-offline` test with `prefer = "offline"` in bunfig.toml covers this path.
- Also ran `test/config/bunfig/`, `test/cli/run/run-autoinstall.test.ts`, `test/cli/run/autoinstall-cached-manifest.test.ts`, `test/regression/issue/24387.test.ts`, the `execArgv` tests in `test/js/node/worker_threads/worker_threads.test.ts` and `test/bundler/compile-argv.test.ts` (standalone executables parse their `execArgv` through the same function): all pass. `cargo fmt --check` is clean.

### Background
- `ContextData` (`ctx`, `src/options_types/context.rs`) is the process-wide record of parsed CLI state. Both `Arguments::parse` and the bunfig parser write into it, and the commands read from it afterwards (`RunCommand::boot`, `bun test`, the REPL, the parallel test runner); whichever writer runs second owns a field.
- bunfig.toml is loaded at one of two points. `bun test`, `bun -e`, and `bun file.js` with a known extension load it inside `Arguments::parse`, before the runtime flags are applied. `bun run <target>`, `bun <script>`, the `node` shim and `bun repl` skip that and load it once argv parsing is done (the `loaded_bunfig` checks in `run_command.rs` / `repl_command.rs`). A setting that both argv and the file can set has to come out the same either way.
- `smol` (`--smol`) makes `RunCommand` / `bun test` / the REPL create the JSC VM with a small heap and makes a few native caches release memory eagerly; the memfd threshold the test observes is one of those knobs.
- `install.prefer` / `--prefer-offline` / `--prefer-latest` set `ctx.debug.offline_mode_setting`, which becomes the runtime auto-installer's `install_preference`.
