### PR TITLE
Bump WebKit (oven-sh/WebKit#434 preview): correct stack positions after an arrow function ending in a multi-line template literal

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "e2f13c6aa1cdaa885722c0cb55e609334a717d13";
+export const WEBKIT_VERSION = "autobuild-preview-pr-434-3b56d328";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/jsc-stress/fixtures/template-literal-line-terminators-after-cached-arrow-function.js
+++ b/test/js/bun/jsc-stress/fixtures/template-literal-line-terminators-after-cached-arrow-function.js
@@ -1,0 +1,151 @@
+// @bun
+// While the code around a function is parsed, every function nested in it is parsed once and gets a
+// SourceProviderCache entry; when the enclosing function is compiled on its first call, its body is parsed
+// again and each nested function is skipped by resuming the lexer after the nested function's last token.
+// For an arrow function with an expression body that last token is the body's last token, and a template
+// literal (or a string literal with line continuations) there can span several lines. The cache entry only
+// knew the line the token started on, so after the arrow function the lexer continued on that line: every
+// position after the arrow function was reported too many lines up, by the number of line terminators inside
+// the token, and positions on the token's last line were measured from the wrong line start.
+//
+// Each body below ends in a statement that creates an Error. The body is run once as eval code (parsed once,
+// which is the reference) and then as the body of functions that are called, which is the parse that goes
+// through the cache; both have to report the Error at the same place.
+
+const cases = [
+    // The token the arrow function body ends in spans lines; the next statement is on the following line.
+    { name: "template with one line terminator", line: 3,
+      body: "var f = (a) => `x\ny`;\nresult = new Error();" },
+    { name: "template with three line terminators", line: 5,
+      body: "var f = (a) => `x\n\n\ny`;\nresult = new Error();" },
+    { name: "template with CR, CRLF, LS and PS line terminators", line: 6,
+      body: "var f = (a) => `x\ry\r\nz\u2028w\u2029v`;\nresult = new Error();" },
+    { name: "template with an escaped line terminator", line: 3,
+      body: "var f = (a) => `x\\\ny`;\nresult = new Error();" },
+    { name: "template tail after a substitution", line: 3,
+      body: "var f = (a) => `${a}\ny`;\nresult = new Error();" },
+    { name: "tagged template", line: 3,
+      body: "var f = (a) => String.raw`x\ny`;\nresult = new Error();" },
+    { name: "string with a line continuation", line: 3,
+      body: "var f = (a) => 'x\\\ny';\nresult = new Error();" },
+
+    // Other arrow function shapes whose body ends in such a token.
+    { name: "single identifier parameter", line: 3,
+      body: "var f = a => `x\ny`;\nresult = new Error();" },
+    { name: "async arrow function", line: 3,
+      body: "var f = async (a) => `x\ny`;\nresult = new Error();" },
+    { name: "assignment expression as the body", line: 3,
+      body: "var f = (a) => a.p = `x\ny`;\nresult = new Error();" },
+    { name: "arrow function returning an arrow function", line: 3,
+      body: "var f = (a) => (b) => `x\ny`;\nresult = new Error();" },
+    { name: "arrow function as a call argument", line: 3,
+      body: "[].map((a) => `x\ny`);\nresult = new Error();" },
+    { name: "arrow function ended by automatic semicolon insertion", line: 3,
+      body: "var f = (a) => `x\ny`\nresult = new Error()" },
+    { name: "two such arrow functions in one statement", line: 4,
+      body: "var f = (a) => `x\ny`, g = (a) => `x\ny`;\nresult = new Error();" },
+    // Functions declared after the arrow function are recorded as starting on the line the lexer believes it is
+    // on, and every position inside them is computed from that line when they are compiled.
+    { name: "function declared after such an arrow function", line: 3,
+      body: "var f = (a) => `x\ny`;\nfunction g() { result = new Error(); }\ng();" },
+    { name: "method declared after such an arrow function class field", line: 4,
+      body: "class C {\n  a = () => `x\ny`;\n  m() { result = new Error(); }\n}\nnew C().m();" },
+
+    // In these shapes the eval run takes a cache hit as well, so for them the check of the eval run against the
+    // line given here is the one that matters: a class field initializer and a function's parameters are parsed
+    // again when the class's initializer function or the function is compiled, and an assignment pattern is first
+    // parsed as an expression and then again as a pattern. (The Error is created in a function declared after the
+    // arrow function because the jsc shell reports no position for the field initializer itself.)
+    { name: "class field initializer continuing after such an arrow function", line: 3,
+      body: "class C {\n  a = [() => `x\ny`, () => { result = new Error(); }];\n}\nnew C().a[1]();" },
+    { name: "static class field initializer continuing after such an arrow function", line: 3,
+      body: "class C {\n  static a = [() => `x\ny`, () => { result = new Error(); }];\n}\nC.a[1]();" },
+    { name: "function body after such an arrow function as a parameter default value", line: 2,
+      body: "function g(a = () => `x\ny`) { result = new Error(); }\ng();" },
+    { name: "arrow function body after such an arrow function as a parameter default value", line: 2,
+      body: "var g = (a = () => `x\ny`) => { result = new Error(); };\ng();" },
+    { name: "assignment pattern with such an arrow function as a default value", line: 4,
+      body: "var a;\n[a = () => `x\ny`] = [];\nresult = new Error();" },
+
+    // The next statement is on the line the token ends on, so its column depends on where that line starts.
+    { name: "next statement on the template's last line", line: 2,
+      body: "var f = (a) => `x\ny`; result = new Error();" },
+    { name: "next statement on the string's last line", line: 2,
+      body: "var f = (a) => 'x\\\ny'; result = new Error();" },
+
+    // Shapes whose positions were already right.
+    { name: "single-line template", line: 2,
+      body: "var f = (a) => `xy`;\nresult = new Error();" },
+    { name: "single-line template, next statement on the same line", line: 1,
+      body: "var f = (a) => `xy`; result = new Error();" },
+    { name: "parenthesized template", line: 3,
+      body: "var f = (a) => (`x\ny`);\nresult = new Error();" },
+    { name: "block body", line: 3,
+      body: "var f = (a) => { return `x\ny`; };\nresult = new Error();" },
+    { name: "function expression", line: 3,
+      body: "var f = function (a) { return `x\ny`; };\nresult = new Error();" },
+    { name: "template outside of any function", line: 3,
+      body: "var t = `x\ny`;\nresult = new Error();" },
+];
+
+// A global property rather than a top-level var: the functions made by new Function() below live in the global
+// scope, so this keeps working when this file itself is run as a module.
+globalThis.result = null;
+
+function positionInEval(body)
+{
+    result = null;
+    eval(body);
+    return { line: result.line, column: result.column };
+}
+
+// The function expression's body is parsed (and the functions in it cached) while the eval code is parsed,
+// and parsed again, through the cache, when the function is called.
+function positionInCalledFunction(wrapperStart, wrapperEnd, body)
+{
+    result = null;
+    eval(wrapperStart + body + wrapperEnd)();
+    return { line: result.line, column: result.column };
+}
+
+// new Function() parses its synthesized source once to check it and again when the function is called.
+function positionInFunctionConstructorFunction(body)
+{
+    result = null;
+    new Function(body)();
+    return { line: result.line, column: result.column };
+}
+
+const functionConstructorHeaderLines = positionInFunctionConstructorFunction("result = new Error();").line - 1;
+const firstLineWrapperStart = "(function () { ";
+
+const failures = [];
+function check(description, actual, expected)
+{
+    if (actual.line !== expected.line || actual.column !== expected.column)
+        failures.push(`${description}: expected ${expected.line}:${expected.column}, got ${actual.line}:${actual.column}`);
+}
+
+for (const { name, line, body } of cases) {
+    const reference = positionInEval(body);
+    check(`${name}, in eval code`, reference, { line, column: reference.column });
+
+    // The body starts on the line after the function's first line, so it keeps its line structure and columns.
+    check(`${name}, in a function whose body starts on the next line`,
+        positionInCalledFunction("(function () {\n", "\n})", body),
+        { line: reference.line + 1, column: reference.column });
+
+    // The body starts on the function's first line. An arrow function on the body's first line then starts on
+    // the line the enclosing function starts on, which the cache handles specially because that line's start is
+    // recorded differently by the two parses. The Error's column only shifts if it is on that line as well.
+    check(`${name}, in a function whose body starts on the function's first line`,
+        positionInCalledFunction(firstLineWrapperStart, "\n})", body),
+        { line: reference.line, column: reference.column + (reference.line === 1 ? firstLineWrapperStart.length : 0) });
+
+    check(`${name}, in a function created by the Function constructor`,
+        positionInFunctionConstructorFunction(body),
+        { line: reference.line + functionConstructorHeaderLines, column: reference.column });
+}
+
+if (failures.length)
+    throw new Error(`FAIL:\n${failures.join("\n")}`);

--- a/test/js/bun/jsc-stress/jsc-stress.test.ts
+++ b/test/js/bun/jsc-stress/jsc-stress.test.ts
@@ -121,6 +121,8 @@ const jsFixtures = [
   "varargs-inlined-simple-exit.js",
   "loop-unrolling.js",
   "licm-no-pre-header.js",
+  // Parser
+  "template-literal-line-terminators-after-cached-arrow-function.js",
 ];
 
 const wasmFixtures = [

--- a/test/js/bun/test/stack.test.ts
+++ b/test/js/bun/test/stack.test.ts
@@ -1,6 +1,6 @@
 import { $ } from "bun";
-import { expect, test } from "bun:test";
-import { bunEnv, bunExe, bunRun, normalizeBunSnapshot } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, bunRun, normalizeBunSnapshot, tempDir } from "harness";
 import { join } from "node:path";
 
 test("name property is used for function calls in Error.stack", () => {
@@ -148,4 +148,180 @@ test("Async functions frame should be included in stack trace", async () => {
         at async foo (file:NN:NN)
         at async <anonymous> (file:NN:NN)"
   `);
+});
+
+// JSC skips a function it has already seen (a nested function while the enclosing code is reparsed on first
+// call, or anything when the same source is parsed twice) by resuming the lexer after the function's last
+// token. For an arrow function with an expression body that token is the body's last token; when it is a
+// template literal with line breaks inside it, the lexer used to resume on the line the token started on, so
+// everything after the arrow function was reported that many lines too early, including the recorded start
+// line of every function declared afterwards. The transpiler prints "\n" inside a string literal as a template
+// literal with a real line break, so `s => s + "\n"` is enough to trigger it in Bun.
+describe.concurrent("stack positions after an arrow function whose body ends in a multi-line template literal", () => {
+  async function run(dir: string, file: string, env: Record<string, string> = {}) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), file],
+      env: { ...bunEnv, ...env },
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return stdout;
+  }
+
+  // One source line per array element, so the expected line numbers below can be read off the indices.
+  const fixture = (vmModule: string) =>
+    [
+      /*  1 */ vmModule,
+      /*  2 */ "const lineOf = (error) => +error.stack.match(/^\\s+at .*:(\\d+):\\d+\\)?$/m)[1];",
+      /*  3 */ "const results = {};",
+      /*  4 */ 'const newline = (s) => s + "\\n";',
+      /*  5 */ "results.afterStringArrow = lineOf(new Error());",
+      // Declared right after the arrow function: its recorded start line is what the positions inside it are
+      // computed from. (Skipping any block-bodied function in between would have resynchronized the line.)
+      /*  6 */ "function declaredAfterwards() {",
+      /*  7 */ "  results.inFunctionDeclaredAfterwards = lineOf(new Error());",
+      /*  8 */ "}",
+      /*  9 */ "declaredAfterwards();",
+      /* 10 */ "const template = () => `a",
+      /* 11 */ "b`;",
+      /* 12 */ "results.afterTemplateArrow = lineOf(new Error());",
+      /* 13 */ "function containing() {",
+      /* 14 */ '  const inner = (s) => s + "\\n";',
+      /* 15 */ "  results.inFunction = lineOf(new Error());",
+      /* 16 */ "}",
+      /* 17 */ "containing();",
+      // The method's start line is recorded while the class body is parsed, right after the field's arrow
+      // function; the start line of the arrow function in handlers is recorded while that field initializer is
+      // parsed on its own when the instance is created, again right after an arrow function. (The bodies are on
+      // their own lines because a one-line drift inside a construct the printer spreads over several lines
+      // would map back to the same source line.)
+      /* 18 */ "class K {",
+      /* 19 */ '  newline = (s) => s + "\\n";',
+      /* 20 */ "  fail() {",
+      /* 21 */ "    return lineOf(new Error());",
+      /* 22 */ "  }",
+      /* 23 */ "  handlers = {",
+      /* 24 */ '    newline: (s) => s + "\\n",',
+      /* 25 */ "    fail: () => {",
+      /* 26 */ "      return lineOf(new Error());",
+      /* 27 */ "    },",
+      /* 28 */ "  };",
+      /* 29 */ "}",
+      /* 30 */ "const k = new K();",
+      /* 31 */ "results.inMethodAfterFieldArrow = k.fail();",
+      /* 32 */ "results.inArrowAfterFieldInitializerArrow = k.handlers.fail();",
+      // The Function constructor puts the body on line 3 of "function anonymous(lineOf\n) {\n...", and
+      // vm.Script gets the source as is; neither goes through the transpiler.
+      /* 33 */ 'results.inFunctionConstructor = new Function("lineOf", "const f = () => `a\\nb`;\\nreturn lineOf(new Error());")(lineOf);',
+      /* 34 */ 'results.inVmScript = lineOf(new vm.Script("const g = () => `a\\nb`;\\nnew Error();", { filename: "script.js" }).runInThisContext());',
+      /* 35 */ "console.log(JSON.stringify(results));",
+    ].join("\n");
+
+  const expected = {
+    afterStringArrow: 5,
+    inFunctionDeclaredAfterwards: 7,
+    afterTemplateArrow: 12,
+    inFunction: 15,
+    inMethodAfterFieldArrow: 21,
+    inArrowAfterFieldInitializerArrow: 26,
+    inFunctionConstructor: 5,
+    inVmScript: 3,
+  };
+
+  test("CommonJS module", async () => {
+    using dir = tempDir("stack-after-multiline-arrow", { "fixture.cjs": fixture('const vm = require("node:vm");') });
+    expect(JSON.parse(await run(String(dir), "fixture.cjs"))).toEqual(expected);
+  });
+
+  test("ES module", async () => {
+    using dir = tempDir("stack-after-multiline-arrow", { "fixture.mjs": fixture('import vm from "node:vm";') });
+    expect(JSON.parse(await run(String(dir), "fixture.mjs"))).toEqual(expected);
+  });
+
+  test("TypeScript enum with a line break in a member name", async () => {
+    // The source contains no arrow function, but the enum is lowered to one, (E) => E[E[name] = 1] = name, where
+    // name is printed as a template literal containing the line break, so the body ends in one.
+    using dir = tempDir("stack-after-multiline-arrow", {
+      "fixture.ts": [
+        /* 1 */ "enum E {",
+        /* 2 */ '  "a\\nb" = 1,',
+        /* 3 */ "}",
+        /* 4 */ "const afterEnum = new Error();",
+        /* 5 */ "console.log(JSON.stringify({ afterEnum: +afterEnum.stack.match(/^\\s+at .*:(\\d+):\\d+\\)?$/m)[1], members: Object.keys(E) }));",
+      ].join("\n"),
+    });
+    expect(JSON.parse(await run(String(dir), "fixture.ts"))).toEqual({ afterEnum: 4, members: ["1", "a\nb"] });
+  });
+
+  // The tests above pin absolute positions for a handful of shapes. This one covers the whole class of bug
+  // without expected values: with BUN_JSC_useSourceProviderCache=false every function is parsed again instead
+  // of being skipped, so whatever positions that run reports, the default run has to report the same ones, for
+  // every kind of line-spanning token in every shape in which a function can follow the arrow function.
+  test("positions are the same with JSC's SourceProviderCache disabled", async () => {
+    const tokens = {
+      "template": "`x\ny`",
+      "template with CRLF": "`x\r\ny`",
+      "template with LS": "`x\u2028y`",
+      "template with an escaped line break": "`x\\\ny`",
+      "template tail": "`${0}\ny`",
+      "tagged template": "String.raw`x\ny`",
+      "string with a line continuation": "'x\\\ny'",
+      "single-line template": "`xy`",
+    };
+    // TOKEN is the arrow function body; `result` receives the Error created somewhere after the arrow function.
+    const shapes = {
+      "next statement": "var f = (a) => TOKEN;\nresult = new Error();",
+      "same line": "var f = (a) => TOKEN; result = new Error();",
+      "automatic semicolon insertion": "var f = (a) => TOKEN\nresult = new Error()",
+      "call argument": "[].map((a) => TOKEN);\nresult = new Error();",
+      "nested arrow functions": "var f = (a) => (b) => TOKEN;\nresult = new Error();",
+      "async arrow function": "var f = async (a) => TOKEN;\nresult = new Error();",
+      "function declared after it": "var f = (a) => TOKEN;\nfunction g() { result = new Error(); }\ng();",
+      "async function declared after it": "var f = (a) => TOKEN;\nasync function g() { result = new Error(); }\ng();",
+      "method after a field": "class C {\n  a = () => TOKEN;\n  m() { result = new Error(); }\n}\nnew C().m();",
+      "static block after a field": "class C {\n  a = () => TOKEN;\n  static { result = new Error(); }\n}",
+      "field initializer": "class C {\n  a = [() => TOKEN, () => { result = new Error(); }];\n}\nnew C().a[1]();",
+      "static field initializer":
+        "class C {\n  static a = [() => TOKEN, () => { result = new Error(); }];\n}\nC.a[1]();",
+      "parameter default value": "function g(a = () => TOKEN) { result = new Error(); }\ng();",
+      "arrow function parameter default value": "var g = (a = () => TOKEN) => { result = new Error(); };\ng();",
+      "assignment pattern default value": "var a;\n[a = () => TOKEN] = [];\nresult = new Error();",
+      "declaration pattern default value": "var [a = () => TOKEN] = [];\nresult = new Error();",
+    };
+    const corpus = [
+      "globalThis.result = null;",
+      `const tokens = ${JSON.stringify(tokens)};`,
+      `const shapes = ${JSON.stringify(shapes)};`,
+      "const lines = [];",
+      "function record(name, run) {",
+      "  result = null;",
+      "  run();",
+      "  lines.push(`${name}: ${result.line}:${result.column}`);",
+      "}",
+      "for (const [tokenName, token] of Object.entries(tokens)) {",
+      "  for (const [shapeName, shape] of Object.entries(shapes)) {",
+      '    const body = shape.replaceAll("TOKEN", token);',
+      "    const name = `${shapeName}, ${tokenName}`;",
+      "    record(`${name}, eval`, () => eval(body));",
+      '    record(`${name}, function`, () => eval("(function () {\\n" + body + "\\n})")());',
+      '    record(`${name}, function starting on the same line`, () => eval("(function () { " + body + "\\n})")());',
+      "    record(`${name}, new Function`, () => new Function(body)());",
+      "  }",
+      "}",
+      'console.log(lines.join("\\n"));',
+    ].join("\n");
+    using dir = tempDir("stack-after-multiline-arrow", { "corpus.js": corpus });
+
+    const [withCache, withoutCache] = await Promise.all([
+      run(String(dir), "corpus.js"),
+      run(String(dir), "corpus.js", { BUN_JSC_useSourceProviderCache: "false" }),
+    ]);
+    const positions = withCache.trimEnd().split("\n");
+    expect(positions).toHaveLength(Object.keys(tokens).length * Object.keys(shapes).length * 4);
+    expect(positions).toEqual(withoutCache.trimEnd().split("\n"));
+  });
 });


### PR DESCRIPTION
### Problem

- Every stack frame position after an arrow function whose expression body ends in a template literal with line breaks inside it is reported too far up in the file, by the number of line breaks in that template, and every function declared after it is recorded as starting on the wrong line, so positions inside those functions are off too:
  ```js
  const f = () => `a
  b`;
  console.log(new Error().stack);   // bun: line 1 (node: line 3)
  ```
- In Bun this does not need a multi-line template in the source. The transpiler prints `"\n"` inside a string literal as a template literal with a real line break, so `const nl = s => s + "\n";` shifts the stack traces of everything after it in the module; `enum E { "a\nb" = 1 }` is lowered to an arrow function of the same shape. `new Function` and `vm.Script` sources containing such an arrow function are affected as well, and so is the `// @bun` fixture, so source maps are not involved.
- Cause: JSC parses a nested function once while parsing the code around it and records it in its SourceProviderCache; when the enclosing function is compiled on first call (or the same source is parsed again, which is what happens to Bun's module top level, `new Function` and `vm.Script`) the nested function is skipped by moving the lexer to the end of its last token. `Parser::parseFunctionInfo()` did that with the token's end offset but the line number and line start of the line the token *starts* on (`vendor/WebKit/Source/JavaScriptCore/parser/Parser.cpp:2663` at the current pin), because that is all the cache item recorded. For a block body the last token is the `}`, so it never mattered; for an expression body it is the body's last token, and a template literal is one token however many lines it spans (a string literal with a `\`-newline continuation is the other such token). Code that is parsed only once (eval) is right, which is why this shows up as wrong stack traces rather than as a parse error. Upstream WebKit has the same code.

### Fix

- oven-sh/WebKit#434: the parser remembers the position right after the last token it consumed, the cache item stores that token's end line and end line start, and the restore path positions the lexer from those. This PR pins that PR's preview build, `autobuild-preview-pr-434-3b56d328`, which is the current pin (`e2f13c6a`, the fork's main) plus that one change. The WebKit PR's head has since gained test cases only (`Source/` is identical to the preview); the fixture here is a copy of the head's test. There is no `src/` change because Bun links the prebuilt engine.
- Why it is right: lexing resumes at the token's end offset, so the line information handed to the lexer has to describe that same point. For a single-line last token (every block body and every arrow body that was already fine) the new values are equal to the old ones, so only functions whose last token spans lines change behavior. The one subtle spot is the existing special case for a last token on the function's first line, whose recorded line start differs between the two parses: it is applied to the end position too when the token also ends on that line and not otherwise, because any later line starts at the same offset in every parse. The fixture exercises both branches.
- Before this can merge, oven-sh/WebKit#434 has to land and `WEBKIT_VERSION` has to move to the resulting main sha (the preview release goes away when the WebKit PR merges); I will push that when it happens.
- Tests:
  - `test/js/bun/jsc-stress/fixtures/template-literal-line-terminators-after-cached-arrow-function.js` (the engine test, verbatim plus the `// @bun` pragma; registered in `jsc-stress.test.ts`): 29 bodies, each run as eval code and as the body of two kinds of called function and of a `new Function` function; all four have to put an Error created after the arrow function on the same line and column, and the eval run is also checked against the line it is on. Covers LF / CR / CRLF / LS / PS / escaped line terminators, template tails, tagged templates, string continuations, the arrow shapes, a function and a method declared after the arrow, the column on the token's last line, shapes where even a single parse takes the cache hit (class field and static field initializers, parameter defaults, an assignment pattern default) and six shapes that were already right.
  - `test/js/bun/test/stack.test.ts`, new describe block: what users see, read out of stack strings. One program run as CommonJS and as an ES module with the `"\n"` arrow at the top level, before a function declaration, inside a function, as a class field before a method and inside a field initializer, plus an explicit multi-line template, `new Function` and `vm.Script`; a TypeScript enum with a line break in a member name; and a differential test that generates 8 token kinds x 16 shapes, runs each through 4 evaluators and requires the 512 reported positions to be identical with `BUN_JSC_useSourceProviderCache=false` (every function parsed again instead of skipped), which covers the class of bug without hand-written expectations.
- Verified:
  - Against the current pin (`bun bd --webkit-version=e2f13c6a...`) and with `USE_SYSTEM_BUN=1` on 1.4.0: the fixture fails 59 of its 116 checks (every affected shape in each cached path, plus the eval run of the five single-parse shapes; the other eval runs and the already-right shapes pass, same as the prebuilt `jsc` shell); all 8 program positions are wrong (4, 6, 10, 14, 20, 25, 4, 2 instead of 5, 7, 12, 15, 21, 26, 5, 3); the enum reports line 1 instead of 4; 371 of the 512 differential lines differ (53 for each line-spanning token kind, 0 for the single-line control), and that run's cache-off output is correct, which is what makes it a usable oracle.
  - Against the preview: both files pass (`jsc-stress.test.ts` as a whole is 116/116; the differential has 0 differing lines), and `node/vm/vm.test.ts`, `bun/jsc/bun-jsc.test.ts`, `node/module/sourcemap.test.js`, `bun/sourcemap/` pass. `inspect-error.test.js`'s two "Error inside minified file" tests fail identically on the current pin with a debug build (an extra `at require (51:24)` frame), unrelated to this.
  - Engine side (details in the WebKit PR): the test passes on the preview's debug+ASAN `jsc` shell; 342 neighbouring stress tests are unchanged; TypeScript's `typescript.js` runs on an assertions-enabled build.

### Background

- Bun does not build JavaScriptCore from source: `scripts/build/deps/webkit.ts` pins a release of the oven-sh/WebKit fork and the build downloads its prebuilt libraries. Engine fixes land in the fork and reach Bun by moving that pin. A PR against the fork gets a prerelease tagged `autobuild-preview-pr-<n>-<sha8>` that Bun CI can build against; a merge to the fork's main produces the permanent `autobuild-<sha>` release.
- SourceProviderCache: while JSC parses a piece of code it also parses every function nested in it (to report syntax errors up front) and records, per function, where it ends and which variables it uses. When a function is compiled later, its body is parsed again and each nested function is skipped using that record. The record is keyed by the function's offset in the source, so it is also used when the same source text is parsed twice; `BUN_JSC_useSourceProviderCache=false` turns the skipping off, which is what the differential test compares against.
- Arrow function bodies: `x => expr` has no closing token of its own; the function ends where `expr`'s last token ends, and a template literal (or, after a substitution, its tail from `}` to the closing backtick) is a single token that can contain line terminators.
- `test/js/bun/jsc-stress/` runs WebKit `JSTests/stress`-style files through Bun with a preload providing the jsc shell globals; the `// @bun` first line makes Bun hand the file to JSC without transpiling it.
