### PR TITLE
hot: replace a generation stuck on a top-level await instead of deferring every later reload

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2879,9 +2879,6 @@ impl VirtualMachine {
                 };
                 // SAFETY: see above.
                 if crate::JSPromise::status_ptr(p) == crate::js_promise::Status::Pending {
-                    // The tick may have taken the entry from loading to
-                    // executing (and stopped on a top-level await); a reload
-                    // deferred while it was loading can go ahead now.
                     self.retry_deferred_hot_reload();
                     self.auto_tick();
                 }
@@ -3744,8 +3741,7 @@ impl VirtualMachine {
         (self.on_unhandled_rejection)(self, global_object, reason);
     }
 
-    /// After a hot reload, surfaces the entry-point promise's rejection (if any), runs any reload
-    /// that [`reload`] deferred, and re-arms the watcher.
+    /// Per watch-mode tick: reports the entry promise's rejection, retries a deferred reload, re-arms the watcher.
     pub fn report_exception_in_hot_reloaded_module_if_needed(&mut self) {
         let promise = match self.pending_internal_promise {
             Some(p) => p,
@@ -3779,9 +3775,7 @@ impl VirtualMachine {
         self.add_main_to_watcher_if_needed();
     }
 
-    /// Re-attempts a reload that [`reload`] deferred. Called after ticks during
-    /// which the pending entry load may have settled or begun executing, either
-    /// of which lets the reload go ahead.
+    /// Runs a reload [`reload`] deferred; it defers itself again while the entry load is still in flight.
     fn retry_deferred_hot_reload(&mut self) {
         if self.hot_reload_deferred {
             self.reload(None);
@@ -3844,9 +3838,7 @@ impl VirtualMachine {
         }
     }
 
-    /// Performs a hot reload: re-evaluates the entry point, unless the current
-    /// entry-point load is still in flight, in which case the reload is
-    /// deferred to [`retry_deferred_hot_reload`].
+    /// Re-evaluates the entry point, or defers to [`retry_deferred_hot_reload`] while its load is in flight.
     pub(crate) fn reload(&mut self, _: Option<&mut crate::hot_reloader::HotReloadTask>) {
         if self.hot_reload == HotReload::Watch {
             // Watch reload replaces the process: never defer on a pending
@@ -3868,11 +3860,8 @@ impl VirtualMachine {
             // SAFETY: `p` is a live JSC heap cell tracked by the VM.
             match crate::JSPromise::status_ptr(p) {
                 crate::js_promise::Status::Pending => {
-                    // While the graph is still being fetched and linked, a
-                    // second load would share the module registry with the
-                    // one in flight. Once it is executing, what keeps the
-                    // promise pending is a top-level await, which may never
-                    // settle; that generation is replaced like any other.
+                    // Still loading: a second load would share the module registry with it.
+                    // Executing: only a top-level await is pending, and it may never settle.
                     if !crate::cpp::Bun__entryRootIsEvaluating(self.global()) {
                         self.hot_reload_deferred = true;
                         return;

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -3860,8 +3860,7 @@ impl VirtualMachine {
             // SAFETY: `p` is a live JSC heap cell tracked by the VM.
             match crate::JSPromise::status_ptr(p) {
                 crate::js_promise::Status::Pending => {
-                    // Still loading: a second load would share the module registry with it.
-                    // Executing: only a top-level await is pending, and it may never settle.
+                    // A load still in flight would share the registry with a new one; a pending top-level await would not.
                     if !crate::cpp::Bun__entryRootIsEvaluating(self.global()) {
                         self.hot_reload_deferred = true;
                         return;

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2879,6 +2879,10 @@ impl VirtualMachine {
                 };
                 // SAFETY: see above.
                 if crate::JSPromise::status_ptr(p) == crate::js_promise::Status::Pending {
+                    // The tick may have taken the entry from loading to
+                    // executing (and stopped on a top-level await); a reload
+                    // deferred while it was loading can go ahead now.
+                    self.retry_deferred_hot_reload();
                     self.auto_tick();
                 }
             }
@@ -3740,7 +3744,8 @@ impl VirtualMachine {
         (self.on_unhandled_rejection)(self, global_object, reason);
     }
 
-    /// After a hot reload, surfaces the entry-point promise's rejection (if any) and re-arms the watcher.
+    /// After a hot reload, surfaces the entry-point promise's rejection (if any), runs any reload
+    /// that [`reload`] deferred, and re-arms the watcher.
     pub fn report_exception_in_hot_reloaded_module_if_needed(&mut self) {
         let promise = match self.pending_internal_promise {
             Some(p) => p,
@@ -3751,10 +3756,7 @@ impl VirtualMachine {
         };
         // SAFETY: `promise` is a live JSC heap cell tracked by the VM.
         match crate::JSPromise::status_ptr(promise) {
-            crate::js_promise::Status::Pending => {
-                self.add_main_to_watcher_if_needed();
-                return;
-            }
+            crate::js_promise::Status::Pending => {}
             crate::js_promise::Status::Rejected => {
                 if self.pending_internal_promise_reported_at != self.hot_reload_counter {
                     self.pending_internal_promise_reported_at = self.hot_reload_counter;
@@ -3773,10 +3775,17 @@ impl VirtualMachine {
             crate::js_promise::Status::Fulfilled => {}
         }
 
+        self.retry_deferred_hot_reload();
+        self.add_main_to_watcher_if_needed();
+    }
+
+    /// Re-attempts a reload that [`reload`] deferred. Called after ticks during
+    /// which the pending entry load may have settled or begun executing, either
+    /// of which lets the reload go ahead.
+    fn retry_deferred_hot_reload(&mut self) {
         if self.hot_reload_deferred {
             self.reload(None);
         }
-        self.add_main_to_watcher_if_needed();
     }
 
     /// Adds the main entry point to the file watcher when watch mode is enabled.
@@ -3835,7 +3844,9 @@ impl VirtualMachine {
         }
     }
 
-    /// Performs a hot reload: re-evaluates the entry point once any pending entry-point load settles.
+    /// Performs a hot reload: re-evaluates the entry point, unless the current
+    /// entry-point load is still in flight, in which case the reload is
+    /// deferred to [`retry_deferred_hot_reload`].
     pub(crate) fn reload(&mut self, _: Option<&mut crate::hot_reloader::HotReloadTask>) {
         if self.hot_reload == HotReload::Watch {
             // Watch reload replaces the process: never defer on a pending
@@ -3857,8 +3868,15 @@ impl VirtualMachine {
             // SAFETY: `p` is a live JSC heap cell tracked by the VM.
             match crate::JSPromise::status_ptr(p) {
                 crate::js_promise::Status::Pending => {
-                    self.hot_reload_deferred = true;
-                    return;
+                    // While the graph is still being fetched and linked, a
+                    // second load would share the module registry with the
+                    // one in flight. Once it is executing, what keeps the
+                    // promise pending is a top-level await, which may never
+                    // settle; that generation is replaced like any other.
+                    if !crate::cpp::Bun__entryRootIsEvaluating(self.global()) {
+                        self.hot_reload_deferred = true;
+                        return;
+                    }
                 }
                 crate::js_promise::Status::Rejected => {
                     if self.pending_internal_promise_reported_at != self.hot_reload_counter {

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3655,8 +3655,7 @@ extern "C" [[ZIG_EXPORT(nothrow)]] bool Bun__entryRootIsEvaluating(Zig::GlobalOb
     return entryRootIsEvaluating(globalObject, globalObject->moduleLoader());
 }
 
-// A module body is about to run. Before the root is Evaluating it belongs to some other root, such as a
-// preload's un-awaited import() finishing while the entry is still fetching, so it does not count.
+// A body running before the root is Evaluating belongs to another root (a preload's un-awaited import()).
 static void noteModuleEvaluation(Zig::GlobalObject* globalObject, JSModuleLoader* moduleLoader)
 {
     void* bunVM = globalObject->bunVM();

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3638,8 +3638,7 @@ extern "C" bool Bun__VM__entryEvaluationStarted(void*);
 extern "C" BunString Bun__VM__entryRootKey(void*);
 extern "C" void Bun__VM__noteEntryEvaluationStarted(void*);
 
-// The entry root's record is Evaluating (or beyond) from the moment linkAndEvaluateModule() enters it:
-// its graph is fetched and linked, and whatever is still pending on the entry promise is a top-level await.
+// Evaluating or beyond: the entry's graph is fetched and linked, and anything still pending is a top-level await.
 static bool entryRootIsEvaluating(Zig::GlobalObject* globalObject, JSModuleLoader* moduleLoader)
 {
     BunString rootKey = Bun__VM__entryRootKey(globalObject->bunVM());
@@ -3656,10 +3655,8 @@ extern "C" [[ZIG_EXPORT(nothrow)]] bool Bun__entryRootIsEvaluating(Zig::GlobalOb
     return entryRootIsEvaluating(globalObject, globalObject->moduleLoader());
 }
 
-// A module body is about to run. That means "the entry's graph is linked and executing" only if it is
-// part of the entry root's own evaluation, whose dependencies run inside it (post-order). A module that
-// evaluates before the root is Evaluating belongs to some other root: a preload's un-awaited import()
-// finishing while the entry is still fetching.
+// A module body is about to run. Before the root is Evaluating it belongs to some other root, such as a
+// preload's un-awaited import() finishing while the entry is still fetching, so it does not count.
 static void noteModuleEvaluation(Zig::GlobalObject* globalObject, JSModuleLoader* moduleLoader)
 {
     void* bunVM = globalObject->bunVM();

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3638,24 +3638,35 @@ extern "C" bool Bun__VM__entryEvaluationStarted(void*);
 extern "C" BunString Bun__VM__entryRootKey(void*);
 extern "C" void Bun__VM__noteEntryEvaluationStarted(void*);
 
+// The entry root's record is Evaluating (or beyond) from the moment linkAndEvaluateModule() enters it:
+// its graph is fetched and linked, and whatever is still pending on the entry promise is a top-level await.
+static bool entryRootIsEvaluating(Zig::GlobalObject* globalObject, JSModuleLoader* moduleLoader)
+{
+    BunString rootKey = Bun__VM__entryRootKey(globalObject->bunVM());
+    auto* entry = moduleLoader->registryEntry(JSC::Identifier::fromString(globalObject->vm(), rootKey.toWTFString(BunString::ZeroCopy)));
+    if (!entry)
+        return false;
+    auto* cyclic = dynamicDowncast<JSC::CyclicModuleRecord>(entry->record());
+    return cyclic && cyclic->status() >= JSC::CyclicModuleRecord::Status::Evaluating;
+}
+
+// Asked by a --hot reload that finds the entry promise still pending (VirtualMachine::reload).
+extern "C" [[ZIG_EXPORT(nothrow)]] bool Bun__entryRootIsEvaluating(Zig::GlobalObject* globalObject)
+{
+    return entryRootIsEvaluating(globalObject, globalObject->moduleLoader());
+}
+
 // A module body is about to run. That means "the entry's graph is linked and executing" only if it is
-// part of the entry root's own evaluation — the root's record is Evaluating (or beyond) from the moment
-// linkAndEvaluateModule() enters it, and its dependencies run inside that (post-order). A module that
-// evaluates before then is some other root: a preload's un-awaited import() finishing while the entry is
-// still fetching.
+// part of the entry root's own evaluation, whose dependencies run inside it (post-order). A module that
+// evaluates before the root is Evaluating belongs to some other root: a preload's un-awaited import()
+// finishing while the entry is still fetching.
 static void noteModuleEvaluation(Zig::GlobalObject* globalObject, JSModuleLoader* moduleLoader)
 {
     void* bunVM = globalObject->bunVM();
     if (Bun__VM__entryEvaluationStarted(bunVM))
         return;
-    BunString rootKey = Bun__VM__entryRootKey(bunVM);
-    auto* entry = moduleLoader->registryEntry(JSC::Identifier::fromString(globalObject->vm(), rootKey.toWTFString(BunString::ZeroCopy)));
-    if (!entry)
-        return;
-    auto* cyclic = dynamicDowncast<JSC::CyclicModuleRecord>(entry->record());
-    if (!cyclic || cyclic->status() < JSC::CyclicModuleRecord::Status::Evaluating)
-        return;
-    Bun__VM__noteEntryEvaluationStarted(bunVM);
+    if (entryRootIsEvaluating(globalObject, moduleLoader))
+        Bun__VM__noteEntryEvaluationStarted(bunVM);
 }
 
 JSC::JSValue GlobalObject::moduleLoaderEvaluate(JSGlobalObject* lexicalGlobalObject,

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -912,7 +912,7 @@ describe.concurrent("a generation whose top-level await never settles", () => {
                 while (readFileSync(entry, "utf8") === entryBefore) await Bun.sleep(5);
                 // A deferred reload is not observable; give the save's watcher
                 // event time to reach the still-loading generation.
-                await Bun.sleep(300);
+                await Bun.sleep(${isDebug ? 1_000 : 300});
                 return { contents, loader: "ts" };
               });
             },

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -884,30 +884,35 @@ describe.concurrent("a generation whose top-level await never settles", () => {
   );
 
   // A save that lands while a generation is still being loaded is applied once
-  // that generation has loaded, even though it then hangs. The plugin keeps the
-  // load of a `// HOLD` generation open until the save has landed, then lets
-  // the stale contents evaluate. Covered twice: for the first generation, while
-  // the process is still in its initial load, and for a later one, once it is
-  // in its run loop.
+  // that generation has loaded, even though it then hangs. The entry imports
+  // dep.ts, whose load the plugin holds open until entry.ts has been saved
+  // over; dep.ts then evaluates and hangs. The save goes to entry.ts because it
+  // was transpiled, and so watched, before dep.ts started loading; a file the
+  // plugin provides is not watched on every platform until its generation is
+  // up. Covered twice: for the first generation, while the process is still in
+  // its initial load, and for a later one, once it is in its run loop.
   it(
     "still lets a save that landed while it was loading reload it",
     async () => {
+      const importsDep = `import "./dep.ts";\n`;
       using dir = tempDir("hot-tla-held", {
-        "entry.ts": "// HOLD\n" + hangs("[#!tla] 1 stale hung"),
+        "entry.ts": importsDep,
+        "dep.ts": hangs("[#!tla] dep hung"),
         "hold-plugin.ts": `
           import { readFileSync } from "fs";
+          import { join } from "path";
+          const entry = join(import.meta.dir, "entry.ts");
           Bun.plugin({
             name: "hold",
             setup(build) {
-              build.onLoad({ filter: /entry[.]ts$/ }, async ({ path }) => {
+              build.onLoad({ filter: /dep[.]ts$/ }, async ({ path }) => {
                 const contents = readFileSync(path, "utf8");
-                if (contents.startsWith("// HOLD")) {
-                  console.write("[#!tla] holding\\n");
-                  while (readFileSync(path, "utf8") === contents) await Bun.sleep(5);
-                  // A deferred reload is not observable; give the save's watcher
-                  // event time to be seen by the still-loading generation.
-                  await Bun.sleep(300);
-                }
+                const entryBefore = readFileSync(entry, "utf8");
+                console.write("[#!tla] holding dep\\n");
+                while (readFileSync(entry, "utf8") === entryBefore) await Bun.sleep(5);
+                // A deferred reload is not observable; give the save's watcher
+                // event time to reach the still-loading generation.
+                await Bun.sleep(300);
                 return { contents, loader: "ts" };
               });
             },
@@ -918,22 +923,22 @@ describe.concurrent("a generation whose top-level await never settles", () => {
       await using runner = spawnHot(String(dir), `--preload=${join(String(dir), "hold-plugin.ts")}`);
       const markers = stdoutMarkers(runner);
 
-      await markers.next("[#!tla] holding");
+      await markers.next("[#!tla] holding dep");
       // Only the run loop emits beforeExit: once it has, the next generation is
       // held while the process is in its run loop, not still in its initial load.
       writeFileSync(
         entry,
-        finishes("[#!tla] 2 ok") + `process.on("beforeExit", () => console.log("[#!tla] 2 idle"));\n`,
+        finishes("[#!tla] save 1 applied") + `process.on("beforeExit", () => console.log("[#!tla] idle"));\n`,
       );
-      await markers.next("[#!tla] 1 stale hung");
-      await markers.next("[#!tla] 2 ok");
-      await markers.next("[#!tla] 2 idle");
+      await markers.next("[#!tla] dep hung");
+      await markers.next("[#!tla] save 1 applied");
+      await markers.next("[#!tla] idle");
 
-      writeFileSync(entry, "// HOLD\n" + hangs("[#!tla] 3 stale hung"));
-      await markers.next("[#!tla] holding");
-      writeFileSync(entry, finishes("[#!tla] 4 ok"));
-      await markers.next("[#!tla] 3 stale hung");
-      await markers.next("[#!tla] 4 ok");
+      writeFileSync(entry, importsDep);
+      await markers.next("[#!tla] holding dep");
+      writeFileSync(entry, finishes("[#!tla] save 2 applied"));
+      await markers.next("[#!tla] dep hung");
+      await markers.next("[#!tla] save 2 applied");
     },
     timeout,
   );

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -1,7 +1,7 @@
 import { spawn } from "bun";
-import { beforeEach, expect, it } from "bun:test";
+import { beforeEach, describe, expect, it } from "bun:test";
 import { copyFileSync, cpSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, isDebug, isWindows, tmpdirSync, waitForFileToExist } from "harness";
+import { bunEnv, bunExe, isDebug, isWindows, tempDir, tmpdirSync, waitForFileToExist } from "harness";
 import { join } from "path";
 
 const timeout = isDebug ? Infinity : 10_000;
@@ -776,3 +776,165 @@ ${Buffer.alloc(counter * 2, " ").toString()}throw new Error(${counter});`,
   },
   longTimeout,
 );
+
+// Bounds how long a build that never performs the awaited reload keeps a test
+// waiting; the reload itself is awaited, never timed.
+const reloadDeadline = isDebug ? 20_000 : 5_000;
+
+/**
+ * Awaits markers a --hot child writes to stdout, in order: each `next()`
+ * searches only past the previous match, so a marker printed before the save
+ * that was supposed to produce it does not count.
+ */
+function stdoutMarkers(runner: ReturnType<typeof spawn>) {
+  const decoder = new TextDecoder();
+  let output = "";
+  let ended: string | undefined;
+  let cursor = 0;
+  let wake = () => {};
+  (async () => {
+    try {
+      for await (const chunk of runner.stdout as ReadableStream<Uint8Array>) {
+        output += decoder.decode(chunk, { stream: true });
+        wake();
+      }
+      ended = "child closed stdout";
+    } catch (error) {
+      ended = `reading stdout failed: ${error}`;
+    }
+    wake();
+  })();
+  return {
+    async next(marker: string) {
+      const line = `${marker}\n`;
+      let expired = false;
+      const { promise: expiry, resolve: expire } = Promise.withResolvers<void>();
+      const timer = setTimeout(() => {
+        expired = true;
+        expire();
+      }, reloadDeadline);
+      try {
+        while (true) {
+          const index = output.indexOf(line, cursor);
+          if (index !== -1) {
+            cursor = index + line.length;
+            return;
+          }
+          if (ended) throw new Error(`${ended} before printing ${JSON.stringify(marker)}; stdout so far:\n${output}`);
+          if (expired) throw new Error(`${JSON.stringify(marker)} was never printed; stdout so far:\n${output}`);
+          await Promise.race([new Promise<void>(resolve => (wake = resolve)), expiry]);
+        }
+      } finally {
+        clearTimeout(timer);
+      }
+    },
+  };
+}
+
+// Entry-file contents for the tests below: a generation that prints `marker`
+// and finishes, or prints it and then never settles its top-level await.
+const finishes = (marker: string) => `console.write(${JSON.stringify(marker + "\n")});\n`;
+const hangs = (marker: string) => `${finishes(marker)}await new Promise(() => {});\n`;
+
+function spawnHot(dir: string, ...args: string[]) {
+  return spawn({
+    cmd: [bunExe(), "--hot", "run", ...args, join(dir, "entry.ts")],
+    env: bunEnv,
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "inherit",
+    stdin: "ignore",
+  });
+}
+
+describe.concurrent("a generation whose top-level await never settles", () => {
+  it(
+    "is replaced by the next save of the entry",
+    async () => {
+      using dir = tempDir("hot-tla", { "entry.ts": finishes("[#!tla] 1 ok") });
+      await using runner = spawnHot(String(dir));
+      const markers = stdoutMarkers(runner);
+      await markers.next("[#!tla] 1 ok");
+
+      writeFileSync(join(String(dir), "entry.ts"), hangs("[#!tla] 2 hung"));
+      await markers.next("[#!tla] 2 hung");
+
+      writeFileSync(join(String(dir), "entry.ts"), finishes("[#!tla] 3 ok"));
+      await markers.next("[#!tla] 3 ok");
+    },
+    timeout,
+  );
+
+  it(
+    "is replaced even when it is the first generation and the await is in an import that keeps the loop busy",
+    async () => {
+      using dir = tempDir("hot-tla-import", {
+        "entry.ts": `import "./dep.ts";\n${finishes("[#!tla] entry ran")}`,
+        "dep.ts": `setInterval(() => {}, 1_000_000);\n${hangs("[#!tla] dep hung")}`,
+      });
+      await using runner = spawnHot(String(dir));
+      const markers = stdoutMarkers(runner);
+      await markers.next("[#!tla] dep hung");
+
+      writeFileSync(join(String(dir), "dep.ts"), finishes("[#!tla] dep ok"));
+      await markers.next("[#!tla] dep ok");
+      await markers.next("[#!tla] entry ran");
+    },
+    timeout,
+  );
+
+  // A save that lands while a generation is still being loaded is applied once
+  // that generation has loaded, even though it then hangs. The plugin keeps the
+  // load of a `// HOLD` generation open until the save has landed, then lets
+  // the stale contents evaluate. Covered twice: for the first generation, while
+  // the process is still in its initial load, and for a later one, once it is
+  // in its run loop.
+  it(
+    "still lets a save that landed while it was loading reload it",
+    async () => {
+      using dir = tempDir("hot-tla-held", {
+        "entry.ts": "// HOLD\n" + hangs("[#!tla] 1 stale hung"),
+        "hold-plugin.ts": `
+          import { readFileSync } from "fs";
+          Bun.plugin({
+            name: "hold",
+            setup(build) {
+              build.onLoad({ filter: /entry[.]ts$/ }, async ({ path }) => {
+                const contents = readFileSync(path, "utf8");
+                if (contents.startsWith("// HOLD")) {
+                  console.write("[#!tla] holding\\n");
+                  while (readFileSync(path, "utf8") === contents) await Bun.sleep(5);
+                  // A deferred reload is not observable; give the save's watcher
+                  // event time to be seen by the still-loading generation.
+                  await Bun.sleep(300);
+                }
+                return { contents, loader: "ts" };
+              });
+            },
+          });
+        `,
+      });
+      const entry = join(String(dir), "entry.ts");
+      await using runner = spawnHot(String(dir), `--preload=${join(String(dir), "hold-plugin.ts")}`);
+      const markers = stdoutMarkers(runner);
+
+      await markers.next("[#!tla] holding");
+      // Only the run loop emits beforeExit: once it has, the next generation is
+      // held while the process is in its run loop, not still in its initial load.
+      writeFileSync(
+        entry,
+        finishes("[#!tla] 2 ok") + `process.on("beforeExit", () => console.log("[#!tla] 2 idle"));\n`,
+      );
+      await markers.next("[#!tla] 1 stale hung");
+      await markers.next("[#!tla] 2 ok");
+      await markers.next("[#!tla] 2 idle");
+
+      writeFileSync(entry, "// HOLD\n" + hangs("[#!tla] 3 stale hung"));
+      await markers.next("[#!tla] holding");
+      writeFileSync(entry, finishes("[#!tla] 4 ok"));
+      await markers.next("[#!tla] 3 stale hung");
+      await markers.next("[#!tla] 4 ok");
+    },
+    timeout,
+  );
+});


### PR DESCRIPTION
### Problem
- `bun --hot`: after any generation whose entry top-level `await` never settles (hung `fetch()`, `for await (const line of console)` on an idle stdin, `await once(emitter, "ready")` that misses, `await new Promise(() => {})`), every later save is silently ignored for the rest of the process, including the save that fixes the hang. Also happens when the very first generation is the one that hangs. Reproduces on 1.4.0; `--watch` restarts fine on the same sequence.
- Cause: `VirtualMachine::reload()` (`src/jsc/VirtualMachine.rs`) defers whenever `pending_internal_promise` is still pending, and the only place that retries a deferred reload is `report_exception_in_hot_reloaded_module_if_needed()`, which returned early on the same pending promise. A promise held pending by a top-level await keeps both of them waiting forever.
- The deferral was added with the module-loader rewrite (#29393) for a real reason: a second `clearAll()` + load while the first load is still fetching and linking would let two loads share one registry. It just did not distinguish that state from "loaded, executing, parked on an `await`".

### Fix
- `reload()` on a pending promise now asks the module loader whether the entry root's record has reached `Evaluating` (new `Bun__entryRootIsEvaluating`, `ZigGlobalObject.cpp`). Still fetching/linking: defer as before. Executing: what keeps the promise pending is a top-level await, so the generation is replaced like a settled one. This is the line that fixes the report.
- The check is the same lookup the worker startup probe (`noteModuleEvaluation`) already does, factored into one `entryRootIsEvaluating()` used by both; the worker path is otherwise unchanged. Nothing runs on any hot path: the lookup happens only when a reload request finds the promise pending.
- A reload deferred while a generation was still loading is retried by the new `retry_deferred_hot_reload()` from both loops that tick while the entry is pending: the run loop (`report_exception_in_hot_reloaded_module_if_needed` no longer returns early on Pending) and the initial-load loop in `load_entry_point` (a first generation that loads and then hangs). `reload()` re-checks, so the retry is a no-op until the generation is executing or settled. The Rejected-but-unreported deferral from #29740 is untouched.
- Behaviour change to be aware of: a save that lands while a generation is inside a top-level await that would eventually have settled is now applied immediately instead of after the await. The replaced generation's continuation still runs later, as any other callback of an old generation does under `--hot`; this is how `--hot` behaved before #29393. If that await later rejects, nothing is printed: the loader had already marked the replaced generation's promises handled, so it neither reports nor crashes (checked by hand; current main prints that error once the await settles, with a source preview taken from the file as rewritten by the save). The wait-for-the-await behaviour cannot be kept without either ignoring a save or inventing a timeout, since a hung await and a slow one look identical.
- Intentionally not changed: `load_entry_point_for_test_runner` has the same loop (`bun test --hot` currently does nothing after the first run regardless; reported separately), and `on_before_exit()`'s internal drain has neither the error report nor the retry (pre-existing, also hits error reporting; reported separately).
- Verified with `test/cli/hot/hot.test.ts`, `describe("a generation whose top-level await never settles")`, three tests:
  - entry hangs in a later generation (the report's shape), next save reloads;
  - the first generation hangs inside an import that also keeps the loop busy, a save of that import reloads;
  - a save lands while a generation is still loading (a preload plugin holds an import's load open until the entry has been saved over, then lets the import evaluate and hang), once while the process is still in its initial load and once after it has reached the run loop (gated on `beforeExit`), and is applied afterwards. The plugin keeps the load open for 300 ms (1 s on debug builds) after the save so the save's watcher event reaches the generation while it is still loading; a window that turned out too short would only let the test pass through the plain `reload()` path, never fail it. The save goes to the entry, which is transpiled and therefore watched before the import starts loading; a file the plugin provides is only watched once its generation is up, and on Windows only watched files reload, which is what the first CI run caught.
  - All three fail on 1.4.0 (`USE_SYSTEM_BUN=1`, each in about 5 s with the captured output in the error) and pass with `bun bd test` on Linux and Windows x64. Removing the `load_entry_point` retry fails the third test's first half 3/3; removing the run-loop retry fails its second half 3/3.
  - `bun bd test test/cli/hot/hot.test.ts` (15 pass), `test/cli/hot/watch.test.ts`, `test/js/node/worker_threads/worker-top-level-await.test.ts`, the worker preload/entry-evaluation tests in `test/js/web/workers/worker.test.ts`, `test/js/bun/resolve/bun-main-entry-point.test.ts`, `test/js/bun/cron/in-process-cron.test.ts`, `test/regression/issue/29524.test.ts` pass on the debug (ASAN) build; a manual run where the replaced generation's await settles later and re-runs the generated server wrapper is ASAN-clean.

### Background
- Under `--hot`, a "generation" is one evaluation of the entry through the generated `bun:main` wrapper module. A reload clears the module registry (`GlobalObject::reload()` -> `JSModuleLoader::clearAll()`) and loads `bun:main` again; `pending_internal_promise` is the promise returned by that load, which settles when the whole graph has been evaluated.
- Loading a module graph goes through fetch (Bun reads and transpiles each file, asynchronously), link, then evaluate. JSC records the phase on the root's `CyclicModuleRecord`: its status becomes `Evaluating` when evaluation starts and `EvaluatingAsync` while it waits on a top-level await somewhere in the graph, so "status >= Evaluating" is exactly "fetch and link are finished". The registry entry for the root is looked up by the key `reload_entry_point` loaded (`bun:main`, or the entry path without transpilation; `Bun__VM__entryRootKey`). HTML entries and preload loads never register that key and keep today's behaviour.
- The watcher thread turns file changes into a `HotReloadTask` on the event loop; that task calls `reload()`. The run loop (`run_command.rs`) calls `report_exception_in_hot_reloaded_module_if_needed()` after every tick, which is how a deferred reload and a generation's rejection get picked up; the initial load spins its own loop in `load_entry_point` until the first generation settles, which is why the retry is needed in both.

<details>
<summary>Repro used</summary>

```sh
printf 'console.log("gen A ok");\nsetInterval(()=>{},1e6);\n' > app.ts
bun --hot app.ts &                                   # gen A ok
sleep 1.5
printf 'console.log("gen B hung TLA");\nawait new Promise(()=>{});\n' > app.ts
sleep 1.5                                             # gen B hung TLA
for v in 1 2 3; do printf 'console.log("gen C%s fixed");\nsetInterval(()=>{},1e6);\n' $v > app.ts; sleep 1; done
# 1.4.0: output ends at "gen B hung TLA". Fixed: gen C1/C2/C3 fixed.
# Same result on 1.4.0 when gen A itself is the hung one.
```
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 6 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/hot/hot.test.ts

<!-- robobun:evidence:end -->