### PR TITLE
install: reject dependency names containing control characters

### DIFF
--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -3326,6 +3326,50 @@ fn escape_powershell_impl(str: &[u8], writer: &mut impl fmt::Write) -> fmt::Resu
     write_bytes(writer, remain)
 }
 
+// ───────────────────────────────────────────────────────────────────────────
+// escapeControlChars
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Renders the wrapped `Display` with C0 controls, DEL and C1 controls spelled
+/// out (`\n`, `\x1b`, `\x7f`, `\u009b`) instead of written raw, for text a
+/// registry or a package authored; everything else passes through unchanged.
+pub struct EscapeControlChars<T>(pub T);
+
+/// [`EscapeControlChars`] over raw bytes; invalid UTF-8 renders as U+FFFD.
+pub fn escape_control_chars(text: &[u8]) -> EscapeControlChars<&bstr::BStr> {
+    EscapeControlChars(bstr::BStr::new(text))
+}
+
+impl<T: Display> Display for EscapeControlChars<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let mut writer = EscapeControlCharsWriter(f);
+        write!(writer, "{}", self.0)
+    }
+}
+
+struct EscapeControlCharsWriter<'a, 'f>(&'a mut Formatter<'f>);
+
+impl fmt::Write for EscapeControlCharsWriter<'_, '_> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        let mut start = 0;
+        for (i, c) in s.char_indices() {
+            if !matches!(c, '\0'..='\x1f' | '\x7f' | '\u{80}'..='\u{9f}') {
+                continue;
+            }
+            self.0.write_str(&s[start..i])?;
+            match c {
+                '\n' => self.0.write_str("\\n")?,
+                '\r' => self.0.write_str("\\r")?,
+                '\t' => self.0.write_str("\\t")?,
+                c if c.is_ascii() => write!(self.0, "\\x{:02x}", c as u32)?,
+                c => write!(self.0, "\\u{:04x}", c as u32)?,
+            }
+            start = i + c.len_utf8();
+        }
+        self.0.write_str(&s[start..])
+    }
+}
+
 // js_bindings (fmtString for highlighter.test.ts) lives in src/jsc/fmt_jsc.rs
 // alongside fmt_jsc.bind.ts; bun_core/ stays JSC-free.
 

--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -3330,9 +3330,9 @@ fn escape_powershell_impl(str: &[u8], writer: &mut impl fmt::Write) -> fmt::Resu
 // escapeControlChars
 // ───────────────────────────────────────────────────────────────────────────
 
-/// Renders the wrapped `Display` with C0 controls, DEL and C1 controls spelled
-/// out (`\n`, `\x1b`, `\x7f`, `\u009b`) instead of written raw, for text a
-/// registry or a package authored; everything else passes through unchanged.
+/// Renders the wrapped `Display` with C0 controls and DEL spelled out (`\n`,
+/// `\x1b`, `\x7f`) and C1 controls as `\u` escapes instead of written raw, for
+/// text a registry or a package authored; everything else passes through.
 pub struct EscapeControlChars<T>(pub T);
 
 /// [`EscapeControlChars`] over raw bytes; invalid UTF-8 renders as U+FFFD.
@@ -3351,20 +3351,33 @@ struct EscapeControlCharsWriter<'a, 'f>(&'a mut Formatter<'f>);
 
 impl fmt::Write for EscapeControlCharsWriter<'_, '_> {
     fn write_str(&mut self, s: &str) -> fmt::Result {
+        let bytes = s.as_bytes();
         let mut start = 0;
-        for (i, c) in s.char_indices() {
-            if !matches!(c, '\0'..='\x1f' | '\x7f' | '\u{80}'..='\u{9f}') {
-                continue;
-            }
+        let mut cursor = 0;
+        // `\` doubles as the quote char so the scan stops at nothing else extra.
+        while let Some(offset) =
+            strings::index_of_needs_escape_for_java_script_string(&bytes[cursor..], b'\\')
+        {
+            let i = cursor + offset as usize;
+            let (code_point, len) = match bytes[i] {
+                byte @ (0x00..=0x1F | 0x7F) => (byte as u32, 1),
+                0xC2 if matches!(bytes.get(i + 1), Some(0x80..=0x9F)) => (bytes[i + 1] as u32, 2),
+                byte => {
+                    let char_len = strings::wtf8_byte_sequence_length(byte) as usize;
+                    cursor = (i + char_len).min(bytes.len());
+                    continue;
+                }
+            };
             self.0.write_str(&s[start..i])?;
-            match c {
-                '\n' => self.0.write_str("\\n")?,
-                '\r' => self.0.write_str("\\r")?,
-                '\t' => self.0.write_str("\\t")?,
-                c if c.is_ascii() => write!(self.0, "\\x{:02x}", c as u32)?,
-                c => write!(self.0, "\\u{:04x}", c as u32)?,
+            match code_point {
+                0x0A => self.0.write_str("\\n")?,
+                0x0D => self.0.write_str("\\r")?,
+                0x09 => self.0.write_str("\\t")?,
+                0x00..=0x7F => write!(self.0, "\\x{:02x}", code_point)?,
+                _ => write!(self.0, "\\u{:04x}", code_point)?,
             }
-            start = i + c.len_utf8();
+            start = i + len;
+            cursor = start;
         }
         self.0.write_str(&s[start..])
     }

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -360,24 +360,15 @@ fn abs_node_modules_path(
     abs
 }
 
-/// A dependency alias becomes the install destination inside `node_modules`
-/// (the existing entry is renamed aside, deleted, and re-created). Reject
-/// anything that could escape `node_modules`: empty names, `.`/`..`
-/// components, absolute paths, drive letters, backslashes, NUL bytes, and any
-/// separator other than the single `/` in a scoped name (`@scope/name`).
+/// The alias is the install destination inside `node_modules` (renamed aside,
+/// deleted and re-created), so on top of `is_safe_install_folder_name` it must
+/// be a single path component, or two for a scoped name.
 pub(crate) fn alias_is_safe_install_target(alias: &[u8]) -> bool {
-    if alias.is_empty() || alias.len() >= MAX_PATH_BYTES || strings::contains_any(alias, b"\\:\0") {
+    if alias.len() >= MAX_PATH_BYTES || !crate::dependency::is_safe_install_folder_name(alias) {
         return false;
     }
 
-    let mut component_count = 0usize;
-    for component in strings::split(alias, b"/") {
-        component_count += 1;
-        if component.is_empty() || component == b"." || component == b".." {
-            return false;
-        }
-    }
-
+    let component_count = strings::split(alias, b"/").count();
     component_count == 1 || (component_count == 2 && alias[0] == b'@')
 }
 
@@ -1251,7 +1242,7 @@ impl<'a> PackageInstaller<'a> {
             if log_level != Options::LogLevel::Silent {
                 bun_core::pretty_errorln!(
                     "<r><red>error<r>: refusing to install dependency with unsafe name <b>{}<r>",
-                    bstr::BStr::new(alias.slice(string_buf!())),
+                    bun_core::fmt::escape_control_chars(alias.slice(string_buf!())),
                 );
             }
             self.summary.fail += 1;

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -770,6 +770,55 @@ pub fn enqueue_dependency_with_main_and_success_fn(
         version_was_replaced = false;
         break 'version dependency.version.clone();
     };
+
+    // Refuse an unsafe alias (the future `node_modules/` folder) or registry
+    // name (the request and the package name) here, before either is fetched
+    // or printed. Empty names are tolerated, as in the tree builder.
+    let invalid_name = {
+        let alias = this.lockfile.str(&dependency.name);
+        let alias_is_safe = if alias == this.lockfile.str(&dependency.version.literal) {
+            // `bun add <specifier>` uses the specifier as the alias until
+            // `assign_resolution` names it: never a folder, but still printed.
+            !dependency::contains_control_character(alias)
+        } else {
+            alias.is_empty() || dependency::is_safe_install_folder_name(alias)
+        };
+        if !alias_is_safe {
+            Some(alias)
+        } else {
+            match version.tag {
+                dependency::version::Tag::Npm | dependency::version::Tag::DistTag => {
+                    let registry_name = this.lockfile.str(&name);
+                    (!registry_name.is_empty()
+                        && !dependency::is_safe_install_folder_name(registry_name))
+                    .then_some(registry_name)
+                }
+                _ => None,
+            }
+        }
+    };
+    if let Some(invalid_name) = invalid_name {
+        if let Some(fail) = fail_fn {
+            fail(this, dependency, id, crate::Error::InvalidDependencyName);
+            return Ok(());
+        }
+        let name = bun_fmt::escape_control_chars(invalid_name);
+        if dependency.behavior.is_required() {
+            this.log_mut().add_error_fmt(
+                None,
+                bun_ast::Loc::EMPTY,
+                format_args!("Invalid dependency name \"{name}\""),
+            );
+        } else {
+            this.log_mut().add_warning_fmt(
+                None,
+                bun_ast::Loc::EMPTY,
+                format_args!("Invalid dependency name \"{name}\""),
+            );
+        }
+        return Ok(());
+    }
+
     let mut loaded_manifest: Option<Npm::PackageManifest> = None;
 
     match version.tag {

--- a/src/install/PackageManager/PackageManagerResolution.rs
+++ b/src/install/PackageManager/PackageManagerResolution.rs
@@ -390,14 +390,20 @@ impl PackageManager {
                     {
                         Output::err_generic(
                             "<b>{}<r><d> failed to resolve<r>",
-                            (failed_dep.version.literal.fmt(string_buf),),
+                            (bun_core::fmt::escape_control_chars(
+                                failed_dep.version.literal.slice(string_buf),
+                            ),),
                         );
                     } else {
                         Output::err_generic(
                             "<b>{}<r><d>@<b>{}<r><d> failed to resolve<r>",
                             (
-                                bstr::BStr::new(failed_dep.name.slice(string_buf)),
-                                failed_dep.version.literal.fmt(string_buf),
+                                bun_core::fmt::escape_control_chars(
+                                    failed_dep.name.slice(string_buf),
+                                ),
+                                bun_core::fmt::escape_control_chars(
+                                    failed_dep.version.literal.slice(string_buf),
+                                ),
                             ),
                         );
                     }

--- a/src/install/PackageManager/PackageManagerResolution.rs
+++ b/src/install/PackageManager/PackageManagerResolution.rs
@@ -348,8 +348,11 @@ impl PackageManager {
                         Output::flush();
                     }
                     if failed_dep.version.tag == dependency::Tag::Catalog {
-                        let name = bstr::BStr::new(failed_dep.name.slice(string_buf));
-                        let literal = failed_dep.version.literal.fmt(string_buf);
+                        let name =
+                            bun_core::fmt::escape_control_chars(failed_dep.name.slice(string_buf));
+                        let literal = bun_core::fmt::escape_control_chars(
+                            failed_dep.version.literal.slice(string_buf),
+                        );
                         let catalog_name = failed_dep.version.catalog().slice(string_buf);
                         let is_default = catalog_name.is_empty() || catalog_name == b"default";
                         let catalog_exists = is_default
@@ -359,25 +362,26 @@ impl PackageManager {
                                 .keys()
                                 .iter()
                                 .any(|k| k.slice(string_buf) == catalog_name);
+                        let catalog_name = bun_core::fmt::escape_control_chars(catalog_name);
                         if !catalog_exists {
                             Output::err_generic(
                                 "<b>{}@{}<r>: there is no catalog named \"{}\" in the root package.json",
-                                (name, literal, bstr::BStr::new(catalog_name)),
+                                (&name, &literal, &catalog_name),
                             );
                         } else if is_default {
                             Output::err_generic(
                                 "<b>{}@{}<r> is not in the catalog",
-                                (name, literal),
+                                (&name, &literal),
                             );
                             bun_core::pretty_errorln!("  bun add --catalog {}", name);
                         } else {
                             Output::err_generic(
                                 "<b>{}@{}<r> is not in catalog \"{}\"",
-                                (name, literal, bstr::BStr::new(catalog_name)),
+                                (&name, &literal, &catalog_name),
                             );
                             bun_core::pretty_errorln!(
                                 "  bun add --catalog={} {}",
-                                bstr::BStr::new(catalog_name),
+                                catalog_name,
                                 name
                             );
                         }

--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -1090,7 +1090,7 @@ impl TarballStream {
                         bun_ast::Loc::EMPTY,
                         format_args!(
                             "Refusing to install package with invalid name \"{}\"",
-                            bun_fmt::s(tarball.name_and_basename().0),
+                            bun_fmt::escape_control_chars(tarball.name_and_basename().0),
                         ),
                     );
                 } else {

--- a/src/install/dependency.rs
+++ b/src/install/dependency.rs
@@ -514,11 +514,11 @@ pub fn is_scoped_package_name(name: &[u8]) -> Result<bool, PackageNameError> {
     Err(PackageNameError::InvalidPackageName)
 }
 
-/// A dependency name/alias becomes a directory under `node_modules/`. Names
-/// come from untrusted `package.json` / manifest keys, so reject anything that
-/// could resolve outside that directory. `@scope/name` stays valid.
+/// Names come from untrusted `package.json` / manifest keys and end up as
+/// `node_modules/` directories and in progress and error output, so reject path
+/// escapes and terminal control characters. `@scope/name` stays valid.
 pub(crate) fn is_safe_install_folder_name(name: &[u8]) -> bool {
-    if name.is_empty() {
+    if name.is_empty() || contains_control_character(name) {
         return false;
     }
 
@@ -526,12 +526,24 @@ pub(crate) fn is_safe_install_folder_name(name: &[u8]) -> bool {
         if component.is_empty() || component == b"." || component == b".." {
             return false;
         }
-        if strings::contains_any(component, b"\\:\0") {
+        if strings::contains_any(component, b"\\:") {
             return false;
         }
     }
 
     true
+}
+
+/// C0 controls and DEL, plus UTF-8 encoded C1 controls (`C2 80`..`C2 9F`,
+/// U+0080..=U+009F), which terminals interpret too.
+pub(crate) fn contains_control_character(name: &[u8]) -> bool {
+    name.iter().enumerate().any(|(i, &byte)| {
+        byte.is_ascii_control()
+            || (byte == 0xC2
+                && name
+                    .get(i + 1)
+                    .is_some_and(|next| (0x80..=0x9F).contains(next)))
+    })
 }
 
 /// assumes version is valid

--- a/src/install/error.rs
+++ b/src/install/error.rs
@@ -68,6 +68,8 @@ pub enum Error {
     Failed,
     #[error("UnrecognizedDependencyFormat")]
     UnrecognizedDependencyFormat,
+    #[error("InvalidDependencyName")]
+    InvalidDependencyName,
     #[error("No global directory found")]
     NoGlobalDirectoryFound,
     #[error("InvalidPackageID")]
@@ -275,6 +277,7 @@ impl Error {
             Self::HTTPError => "HTTPError",
             Self::Failed => "Failed",
             Self::UnrecognizedDependencyFormat => "UnrecognizedDependencyFormat",
+            Self::InvalidDependencyName => "InvalidDependencyName",
             Self::NoGlobalDirectoryFound => "No global directory found",
             Self::InvalidPackageID => "InvalidPackageID",
             Self::PartialInstallFailed => "PartialInstallFailed",

--- a/src/install/extract_tarball.rs
+++ b/src/install/extract_tarball.rs
@@ -247,7 +247,7 @@ impl ExtractTarball {
                     bun_ast::Loc::EMPTY,
                     format_args!(
                         "Refusing to install package with invalid name \"{}\"",
-                        bun_fmt::s(name),
+                        bun_fmt::escape_control_chars(name),
                     ),
                 );
                 return Err(crate::Error::InstallFailed);
@@ -466,7 +466,7 @@ impl ExtractTarball {
                             bun_ast::Loc::EMPTY,
                             format_args!(
                                 "Refusing to install package with invalid name \"{}\"",
-                                bun_fmt::s(name),
+                                bun_fmt::escape_control_chars(name),
                             ),
                         );
                         return Err(crate::Error::InstallFailed);

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -2146,7 +2146,7 @@ pub(crate) fn install_isolated_packages(
                 if let Some(name) = unsafe_folder_name {
                     Output::err_generic(
                         "\"{}\" is not a valid install folder name",
-                        (BStr::new(name),),
+                        (bun_core::fmt::escape_control_chars(name),),
                     );
                     Output::flush();
                     Global::exit(1);

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -370,7 +370,7 @@ pub(crate) fn relative_path_and_depth<'b, const PATH_STYLE: IteratorPathStyle>(
             if !folder_name_is_safe(name) {
                 Output::err_generic(
                     "Lockfile is malformed (dependency name \"{}\" is not a valid folder name)",
-                    (bstr::BStr::new(name),),
+                    (bun_core::fmt::escape_control_chars(name),),
                 );
                 bun_core::Global::crash();
             }
@@ -743,17 +743,18 @@ impl Tree {
             // don't treat it as unsafe — match the lockfile parser and isolated
             // installer (`bun.lock.rs`, `isolated_install.rs`) which guard
             // `!name.is_empty()` here rather than failing the whole install.
+            // Neither does an unresolved dependency, and if its name is why it
+            // did not resolve, enqueue already reported it.
             let dependency_name = dependency
                 .name
                 .slice(lockfile.buffers.string_bytes.as_slice());
-            if !dependency_name.is_empty()
+            if pkg_id != invalid_package_id
+                && !dependency_name.is_empty()
                 && !crate::dependency::is_safe_install_folder_name(dependency_name)
             {
                 builder.maybe_report_error(format_args!(
                     "Invalid dependency name \"{}\"",
-                    dependency
-                        .name
-                        .fmt(lockfile.buffers.string_bytes.as_slice()),
+                    bun_core::fmt::escape_control_chars(dependency_name),
                 ));
                 continue 'dep;
             }

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -3496,8 +3496,8 @@ fn dependency_resolution_failure(
             format_args!(
                 "Failed to resolve {} dependency '{}' for package '{}'",
                 behavior_str,
-                bstr::BStr::new(dep.name.slice(buf)),
-                bstr::BStr::new(path),
+                bun_core::fmt::escape_control_chars(dep.name.slice(buf)),
+                bun_core::fmt::escape_control_chars(path),
             ),
         );
     } else {
@@ -3507,7 +3507,7 @@ fn dependency_resolution_failure(
             format_args!(
                 "Failed to resolve root {} dependency '{}'",
                 behavior_str,
-                bstr::BStr::new(dep.name.slice(buf)),
+                bun_core::fmt::escape_control_chars(dep.name.slice(buf)),
             ),
         );
     }

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -2665,6 +2665,35 @@ it("should not add duplicate package.json entries when installing the same tarba
   });
 });
 
+it("reports a tarball URL that fails to download once, as unresolved", async () => {
+  using server = Bun.serve({
+    port: 0,
+    fetch() {
+      return new Response("not found", { status: 404 });
+    },
+  });
+  const tarball_url = `${server.url.href.replace(/\/+$/, "")}/baz-0.0.3.tgz`;
+  setHandler(dummyRegistry([]));
+  await writeFile(join(package_dir, "package.json"), JSON.stringify({ name: "foo", version: "0.0.1" }));
+
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "add", tarball_url],
+    cwd: package_dir,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  const [err, , exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
+
+  expect(err).toContain(`error: ${tarball_url} failed to resolve`);
+  // Until the tarball resolves, the URL itself stands in as the dependency's
+  // name. The tree builder must not complain about that placeholder being an
+  // unusable folder name on top of the download failure.
+  expect(err).not.toContain("Invalid dependency name");
+  expect(exitCode).toBe(1);
+});
+
 it("should add multiple dependencies specified on command line", async () => {
   expect(check_npm_auth_type.check).toBe(true);
   using server = Bun.serve({

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -9371,8 +9371,10 @@ test("rejects npm aliases whose manifest URL resolves to a different host than t
   const err = await stderr.text();
   await stdout.text();
 
-  // The manifest request must be refused with a clear error...
-  expect(err).toContain("is not on registry");
+  // The manifest request must be refused with a clear error (today the name is
+  // already refused while resolving, before a URL is built; the URL check stays
+  // behind it as a second line of defense)...
+  expect(err).toMatch(/Invalid dependency name|is not on registry/);
   // ...and no request (carrying the registry Authorization header) may reach
   // a host other than the configured registry.
   expect(received).toEqual([]);

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -9779,9 +9779,12 @@ describe.concurrent("bun-install", () => {
       });
 
       it("still refuses a name that joins to a URL outside the registry directory", async () => {
+        // A literal `..` is refused as a folder name before a URL is built; the
+        // percent-encoded spelling is a fine folder name, but the URL parser
+        // still treats it as a dot segment, so only the URL check can catch it.
         const { result, origin } = await installNoDeps(origin => ({
           "bunfig.toml": Bun.TOML.stringify({ install: { registry: { url: `${singleColon(origin)}/npm/`, token } } }),
-          "package.json": JSON.stringify({ name: "app", version: "1.0.0", dependencies: { "..": "1.0.0" } }),
+          "package.json": JSON.stringify({ name: "app", version: "1.0.0", dependencies: { "%2e%2e": "1.0.0" } }),
         }));
         expect(result).toEqual({
           requests: [],
@@ -10200,10 +10203,228 @@ it("does not extract a tarball for a dependency alias containing '..' path segme
     expect(await readdirSorted(zone)).toEqual(["a"]);
     expect(await readdirSorted(join(zone, "a"))).toEqual(["b"]);
     expect(await readdirSorted(join(zone, "a", "b"))).toEqual(["c"]);
-    // The unsafe alias is reported as an error and nothing is installed.
-    expect(err).toContain("Refusing to install package with invalid name");
+    // The unsafe alias is reported as an error before the tarball is even
+    // requested, and nothing is installed.
+    expect(err).toContain('Invalid dependency name "x/../../../.."');
+    expect(urls).toEqual([]);
     expect(out).not.toContain("1 package installed");
     expect(exitCode).not.toBe(0);
+  });
+});
+
+describe("dependency names containing terminal control characters", () => {
+  // OSC 52 (write to the clipboard) followed by CSI 2J (clear the screen). A
+  // registry serves it as an ordinary JSON string (`"ev\u001b]52;..."`), so it
+  // reaches bun like any other dependency name.
+  const controlName = "ev\x1b]52;c;aGkK\x07\x1b[2Jil";
+  // How bun reports it: with the control characters spelled out.
+  const escapedName = String.raw`ev\x1b]52;c;aGkK\x07\x1b[2Jil`;
+  // Forces the progress line, which echoes the name of every manifest being
+  // fetched, even though stderr is a pipe here.
+  const progressEnv = { ...env, BUN_INSTALL_PROGRESS: "1" };
+
+  /**
+   * The dummy registry, which has a manifest for every name asked of it, plus:
+   * the control-character package really is installable (its tarball is
+   * bar's) and `bar@0.0.2` declares `barDeps`.
+   */
+  function registry(ctx: TestContext, urls: string[], barDeps: object = {}) {
+    const dummy = dummyRegistryForContext(ctx, urls);
+    return async (req: Request) => {
+      const name = decodeURIComponent(new URL(req.url).pathname.slice(`/${ctx.id}/`.length));
+      if (name.endsWith(".tgz") && name.includes(controlName)) {
+        urls.push(req.url);
+        return new Response(file(join(import.meta.dir, "bar-0.0.2.tgz")));
+      }
+      const res = await dummy(req);
+      if (name !== "bar") return res;
+      const manifest = await res.json();
+      Object.assign(manifest.versions["0.0.2"], barDeps);
+      return Response.json(manifest);
+    };
+  }
+
+  function assertNameNeverLeaked(out: string, err: string, urls: string[]) {
+    expect(out).not.toContain(controlName);
+    expect(err).not.toContain(controlName);
+    expect(err).not.toContain("\x1b]52;");
+    expect(urls.filter(url => url.includes("%1B") || url.includes("\x1b"))).toEqual([]);
+  }
+
+  /** Entries of node_modules other than the cache this registry setup (`cache = false`) puts there. */
+  async function installed(ctx: TestContext) {
+    const entries = await readdirSorted(join(ctx.package_dir, "node_modules")).catch(() => []);
+    return entries.filter(entry => entry !== ".cache");
+  }
+
+  // A dependency whose key repeats its specifier is how `bun add <specifier>`
+  // records a dependency it has not named yet, so such a key is exempt from the
+  // folder name rules, but not from this one: git tasks put it on the progress
+  // line as-is.
+  const gitSpecifier = `git+https://127.0.0.1:9/${controlName}.git`;
+  const escapedGitSpecifier = `git+https://127.0.0.1:9/${escapedName}.git`;
+  const manifestCases: [string, object, string][] = [
+    ["a dependency name", { dependencies: { [controlName]: "0.0.2" } }, escapedName],
+    ["an unnamed git dependency", { dependencies: { [gitSpecifier]: gitSpecifier } }, escapedGitSpecifier],
+  ];
+  for (const [description, barDeps, expectedName] of manifestCases) {
+    it(`rejects ${description} declared by a package manifest before requesting or printing it`, async () => {
+      await withContext(defaultOpts, async ctx => {
+        const urls: string[] = [];
+        setContextHandler(ctx, registry(ctx, urls, barDeps));
+        await writeFile(
+          join(ctx.package_dir, "package.json"),
+          JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { bar: "0.0.2" } }),
+        );
+
+        const { stdout, stderr, exited } = spawn({
+          cmd: [bunExe(), "install"],
+          cwd: ctx.package_dir,
+          stdout: "pipe",
+          stderr: "pipe",
+          env: progressEnv,
+        });
+        const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+
+        expect(err).toContain(`error: Invalid dependency name "${expectedName}"`);
+        assertNameNeverLeaked(out, err, urls);
+        expect(urls).toContain(`${ctx.registry_url}bar`);
+        expect(await installed(ctx)).toEqual([]);
+        expect(exitCode).toBe(1);
+      });
+    });
+  }
+
+  it("keeps the unnamed form for specifiers without control characters", async () => {
+    await withContext(defaultOpts, async ctx => {
+      const urls: string[] = [];
+      setContextHandler(ctx, registry(ctx, urls));
+      await writeFile(join(ctx.package_dir, "package.json"), JSON.stringify({ name: "foo", version: "0.0.1" }));
+
+      // The alias of this dependency is the specifier until the tarball has
+      // been resolved: full of characters a folder name may not contain.
+      const { stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "add", `${ctx.registry_url}bar-0.0.2.tgz`],
+        cwd: ctx.package_dir,
+        stdout: "pipe",
+        stderr: "pipe",
+        env,
+      });
+      const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+
+      expect(err).not.toContain("Invalid dependency name");
+      expect(out).toContain("installed bar@");
+      expect(await installed(ctx)).toEqual(["bar"]);
+      expect(exitCode).toBe(0);
+    });
+  });
+
+  it("only warns when the name is declared as an optional dependency", async () => {
+    await withContext(defaultOpts, async ctx => {
+      const urls: string[] = [];
+      setContextHandler(ctx, registry(ctx, urls, { optionalDependencies: { [controlName]: "0.0.2" } }));
+      await writeFile(
+        join(ctx.package_dir, "package.json"),
+        JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { bar: "0.0.2" } }),
+      );
+
+      const { stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: ctx.package_dir,
+        stdout: "pipe",
+        stderr: "pipe",
+        env: progressEnv,
+      });
+      const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+
+      expect(err).toContain(`warn: Invalid dependency name "${escapedName}"`);
+      assertNameNeverLeaked(out, err, urls);
+      expect(await installed(ctx)).toEqual(["bar"]);
+      expect(out).toContain("1 package installed");
+      expect(exitCode).toBe(0);
+    });
+  });
+
+  // [description, root dependencies, how the unresolved dependency is summarized]
+  const aliasCases: [string, Record<string, string>, string][] = [
+    ["as the alias of a dependency", { [controlName]: "npm:bar@0.0.2" }, `${escapedName}@npm:bar@0.0.2`],
+    [
+      "as the target of an npm: alias",
+      { "safe-alias": `npm:${controlName}@0.0.2` },
+      `safe-alias@npm:${escapedName}@0.0.2`,
+    ],
+  ];
+  for (const [description, dependencies, summary] of aliasCases) {
+    it(`rejects a name used ${description}`, async () => {
+      await withContext(defaultOpts, async ctx => {
+        const urls: string[] = [];
+        setContextHandler(ctx, registry(ctx, urls));
+        await writeFile(
+          join(ctx.package_dir, "package.json"),
+          JSON.stringify({ name: "foo", version: "0.0.1", dependencies }),
+        );
+
+        const { stdout, stderr, exited } = spawn({
+          cmd: [bunExe(), "install"],
+          cwd: ctx.package_dir,
+          stdout: "pipe",
+          stderr: "pipe",
+          env,
+        });
+        const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+
+        expect(err).toContain(`error: Invalid dependency name "${escapedName}"`);
+        expect(err).toContain(`error: ${summary} failed to resolve`);
+        assertNameNeverLeaked(out, err, urls);
+        expect(await installed(ctx)).toEqual([]);
+        expect(exitCode).toBe(1);
+      });
+    });
+  }
+
+  it("rejects a package name found in bun.lock instead of installing or listing it", async () => {
+    await withContext(defaultOpts, async ctx => {
+      const urls: string[] = [];
+      setContextHandler(ctx, registry(ctx, urls));
+      await Promise.all([
+        writeFile(
+          join(ctx.package_dir, "package.json"),
+          JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { [controlName]: "0.0.2" } }),
+        ),
+        writeFile(
+          join(ctx.package_dir, "bun.lock"),
+          textLockfile(1, {
+            workspaces: { "": { name: "foo", dependencies: { [controlName]: "0.0.2" } } },
+            packages: { [controlName]: [`${controlName}@0.0.2`, `${ctx.registry_url}bar-0.0.2.tgz`, {}, ""] },
+          }),
+        ),
+      ]);
+
+      // `bun pm ls` prints straight from the lockfile, so it runs first, before
+      // `bun install` gets a chance to touch it.
+      const commands: [string[], string][] = [
+        [["pm", "ls", "--all"], "failed to parse lockfile: InvalidLockfile"],
+        [["install"], "Invalid package name"],
+      ];
+      for (const [args, expectedError] of commands) {
+        const { stdout, stderr, exited } = spawn({
+          cmd: [bunExe(), ...args],
+          cwd: ctx.package_dir,
+          stdout: "pipe",
+          stderr: "pipe",
+          env,
+        });
+        const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+
+        expect(err).toContain(expectedError);
+        assertNameNeverLeaked(out, err, urls);
+        expect(exitCode).toBe(1);
+      }
+      // Ignoring the rejected lockfile must not make `bun install` fall back to
+      // resolving the same name from package.json either.
+      expect(urls).toEqual([]);
+      expect(await installed(ctx)).toEqual([]);
+    });
   });
 });
 

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -10345,13 +10345,22 @@ describe("dependency names containing terminal control characters", () => {
     });
   });
 
-  // [description, root dependencies, how the unresolved dependency is summarized]
-  const aliasCases: [string, Record<string, string>, string][] = [
-    ["as the alias of a dependency", { [controlName]: "npm:bar@0.0.2" }, `${escapedName}@npm:bar@0.0.2`],
+  // [description, root dependencies, how the unresolved dependency is summarized afterwards]
+  const aliasCases: [string, Record<string, string>, string[]][] = [
+    [
+      "as the alias of a dependency",
+      { [controlName]: "npm:bar@0.0.2" },
+      [`error: ${escapedName}@npm:bar@0.0.2 failed to resolve`],
+    ],
     [
       "as the target of an npm: alias",
       { "safe-alias": `npm:${controlName}@0.0.2` },
-      `safe-alias@npm:${escapedName}@0.0.2`,
+      [`error: safe-alias@npm:${escapedName}@0.0.2 failed to resolve`],
+    ],
+    [
+      "as the alias of a catalog dependency",
+      { [controlName]: "catalog:" },
+      [`error: ${escapedName}@catalog: is not in the catalog`, `bun add --catalog ${escapedName}`],
     ],
   ];
   for (const [description, dependencies, summary] of aliasCases) {
@@ -10374,7 +10383,7 @@ describe("dependency names containing terminal control characters", () => {
         const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
 
         expect(err).toContain(`error: Invalid dependency name "${escapedName}"`);
-        expect(err).toContain(`error: ${summary} failed to resolve`);
+        for (const line of summary) expect(err).toContain(line);
         assertNameNeverLeaked(out, err, urls);
         expect(await installed(ctx)).toEqual([]);
         expect(exitCode).toBe(1);

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -3351,7 +3351,8 @@ test("rejects dependency aliases that traverse outside node_modules", async () =
   // A (transitively) malicious package.json can use an arbitrary string as a
   // dependency alias. The alias becomes a `node_modules/<alias>` path
   // component in the isolated store layout, so a `..` segment lets it plant
-  // symlinks outside of node_modules.
+  // symlinks outside of node_modules. Such an alias is refused while resolving
+  // (the installer has its own check as well, see the next test).
   await write(
     packageJson,
     JSON.stringify({
@@ -3371,7 +3372,7 @@ test("rejects dependency aliases that traverse outside node_modules", async () =
   });
   const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
-  expect(stderr).toContain("is not a valid install folder name");
+  expect(stderr).toContain('Invalid dependency name "../pwned-by-alias"');
   // Nothing may be created outside of node_modules. `lstatSync` instead of
   // `existsSync` because the escaped artifact would be a dangling symlink.
   expect(() => lstatSync(join(packageDir, "pwned-by-alias"))).toThrow();


### PR DESCRIPTION
### Problem
- A registry manifest can list a dependency whose name contains terminal control characters (served as an ordinary JSON string whose key spells ESC and BEL with JSON unicode escapes; the name used below is `ev` + OSC 52 "write to the clipboard" + CSI 2J "clear the screen" + `il`). `bun install` accepts it: the name is requested from the registry, written raw onto the progress line (`ev<ESC>]52;c;aGkK<BEL><ESC>[2Jil [9/8]`), printed raw in `error: InvalidURL downloading tarball <name>@1.0.0` and in the `<name>@1.0.0 failed to resolve` summary, stored in bun.lock, and `node_modules/ev<ESC>]52;...il/` is created; `bun pm ls` and `bun why` then print the raw bytes again on every run. A hand-edited bun.lock with such a package name behaves the same.
- Cause: nothing validates dependency names between parsing them and using them. `enqueue_dependency_with_main_and_success_fn` (`src/install/PackageManager/PackageManagerEnqueue.rs`) turns the name into the manifest request and later the package name without looking at it; `is_safe_install_folder_name` (`src/install/dependency.rs`), which the tree builder, the installers and the bun.lock parser apply to folder names, only knows about path rules (`..`, `\`, `:`); and the messages that report a bad or unresolvable name (`Tree.rs`, `isolated_install.rs`, `PackageInstaller.rs`, `extract_tarball.rs`, `TarballStream.rs`, `PackageManagerResolution.rs::verify_resolutions`, `bun.lock.rs::dependency_resolution_failure`) all wrote the name through `BStr`/`fmt::s`, i.e. raw.

### Fix
- `is_safe_install_folder_name` additionally rejects names containing C0 controls, DEL, or a UTF-8 encoded C1 control (`C2 80`..`C2 9F`, which some terminals also execute). This covers every place that already used it: the hoisted tree builder, the hoisted and isolated installers (`alias_is_safe_install_target` now delegates to it instead of duplicating its rules), package names read from bun.lock (so `bun pm ls` / `bun install` refuse a hostile lockfile instead of printing or installing from it), bin names, and tarball extraction.
- `enqueue_dependency_with_main_and_success_fn` validates the dependency before resolving it, which is before anything is requested, shown on the progress line or turned into a package: the alias (the future `node_modules/` folder) with the full validator, and for npm / dist-tag dependencies also the resolved registry name (`npm:` alias targets, overrides and catalog replacements included). The placeholder alias `bun add <specifier>` creates (alias == version literal, replaced by `assign_resolution` once the package is known) is only checked for control characters, since it is printed by the git tasks but never becomes a folder. A required dependency is reported as `error: Invalid dependency name "..."` (the install fails, as the tree builder's check already did for `..` names), an optional one as a warning and skipped, matching how an unresolvable dependency is reported today. Auto-install callers get a new `Error::InvalidDependencyName` through their `fail_fn`.
- The tree builder's own check now skips dependencies that did not resolve: they get no folder, and when the reason is the name, enqueue already reported it, so the error is not printed twice. Resolved dependencies (lockfile-loaded) are still checked there.
- New `bun_core::fmt::escape_control_chars` renders text with C0/DEL/C1 spelled out (`\x1b`, `\n`, and a four-digit backslash-u spelling for C1 code points), everything else verbatim; it scans for the next byte that needs a look with `strings::index_of_needs_escape_for_java_script_string` and only decodes there (the body is the copy reviewed on #38631). All the rejection messages above and every arm of the `verify_resolutions` summary (including the catalog arm main added in the meantime) use it, so reporting a rejected name is byte-identical to before for ordinary names and cannot replay a hostile one. The same helper (same name, table and shape) is being added by #38525, #38536 and #38557 for other commands, and #38631 (which escapes the non-name strings: resolutions, specifiers, bin names, registry error text) reuses it; whichever lands first, the others reduce to dropping their copy.
- Because invalid names are now refused while resolving, three existing tests observe the earlier layer and were updated to its message: `does not extract a tarball for a dependency alias containing '..'` (the tarball is no longer even requested), the isolated `rejects dependency aliases that traverse outside node_modules` (the next test still exercises the installer's own check), and the registry host-pinning test, whose assertion now accepts either layer and still checks that no request reaches the other host.
- Rebased onto current main (the conflict was the dead-code removal next to `alias_is_safe_install_target`). Two tests that main added or reworded since were adapted: `bun pm ls` on a rejected lockfile now prints `failed to parse lockfile: InvalidLockfile`, and the Registry URLs test `still refuses a name that joins to a URL outside the registry directory` used a dependency literally named `..`, which this PR refuses as a folder name before a URL exists; it now uses `%2e%2e`, which the folder validator accepts but the URL parser still treats as a dot segment, so it keeps exercising the URL check (and shows why that check stays behind this one).
- Verified:
  - `test/cli/install/bun-install.test.ts`, `describe("dependency names containing terminal control characters")`: manifest-declared name (with `BUN_INSTALL_PROGRESS=1`, so the progress line is captured), unnamed git dependency in a manifest, `bun add <tarball url>` placeholder still allowed, optional dependency only warns, alias of a dependency, `npm:` alias target, alias of a `catalog:` dependency (the catalog arm of the summary), package name in bun.lock (`bun pm ls` and `bun install`). Each asserts the escaped message, that the raw name appears in neither stream, that nothing with that name was requested or installed, and the exit code. All 8 fail on a build without the `src/` changes (the progress line shows the raw bytes, the package installs, `bun pm ls` prints it) and pass with it.
  - `test/cli/install/bun-add.test.ts`, `reports a tarball URL that fails to download once, as unresolved`: pins the tree builder skipping unresolved dependencies. On main, `bun add` of a URL that 404s also printed `Invalid dependency name "<the url>"` for the URL standing in as the alias (echoing any credentials in it); with this change only `failed to resolve` is printed.
  - Manually checked a U+009B (C1) name is rejected and rendered as its four-digit backslash-u spelling, and that a non-ASCII name whose UTF-8 contains a `0x80` continuation byte (`okĀname`) still passes and prints verbatim.
  - `bun-install.test.ts` (remaining failures need network), `bun-install-registry.test.ts`, `isolated-install.test.ts`, `bun-add.test.ts`, `bun-workspaces.test.ts`, `overrides.test.ts`, `catalogs.test.ts`, `bun-lock.test.ts`, `bun-update.test.ts`, `bun-pm*.test.ts`, `migration/migrate.test.ts`, `bunx.test.ts`, `test/regression/issue/31652.test.ts` (empty-name optional dependency stays tolerated), `cargo clippy -p bun_core -p bun_install`, `test/internal/source-lints`.
- Out of scope, tracked separately: the progress-line buffer overflow for names longer than 768 bytes (#38558); rejecting names outside npm's URL-safe set (#34737 does that at the same spot, and composes with this: this PR is about what gets printed and created, that one about registry routing); and a git/tarball dependency whose own package.json `name` is invalid, where bun currently writes a bun.lock entry that the parser then refuses (pre-existing for `:`/`\` names, now also for control characters).

### Background
- A dependency has two names. The alias is the key in `dependencies` and becomes the `node_modules/<alias>` folder. The registry name is what is fetched and becomes the package's name in the lockfile; it equals the alias except for `npm:` aliases, overrides and catalogs, where it comes out of the version string. Both come out of whatever manifest declared the dependency, so a transitive package controls both.
- Resolution flows through `enqueue_dependency_with_main_and_success_fn` for every dependency of every source (package.json, fetched manifests, lockfiles); a dependency left unresolved there is reported by `verify_resolutions` and skipped by the tree builder. Folder creation happens later from the lockfile, which is why the folder validator stays in the tree builder, both installers and the bun.lock parser as the second line of defense for lockfiles that never go through resolution.
- `bun add ./x.tgz` / `bun add github:o/r` store the specifier itself as the alias until the package is known (`assign_resolution` swaps in the package name when alias == version literal); that is why such an alias must not be held to the folder rules.
- C1 controls are U+0080..U+009F; in UTF-8 they are the two bytes `C2 80`..`C2 9F`, and e.g. U+009B is an alternative spelling of `ESC [`. The check is sequence-based because bytes `0x80..0x9F` also occur as continuation bytes of ordinary non-ASCII names.

<details>
<summary>Before / after output</summary>

Unfixed build, manifest-declared name, stderr bytes (`BUN_INSTALL_PROGRESS=1`):

```
Resolving [1/1]
ev\x1b]52;c;aGkK\x07\x1b[2Jil [9/8]        <- raw ESC / BEL bytes
Saving lockfile...
$ ls node_modules | od -c
e   v 033   ]   5   2   ;   c   ;   a   G   k   K  \a 033   [   2   J   i   l
```

Fixed build:

```
error: Invalid dependency name "ev\x1b]52;c;aGkK\x07\x1b[2Jil"      <- literal backslashes
error: ev\x1b]52;c;aGkK\x07\x1b[2Jil@1.0.0 failed to resolve
```

Fixed build, `bun pm ls` on a bun.lock carrying such a package name:

```
error: Error loading lockfile: InvalidLockfile
```
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-add.test.ts test/cli/install/bun-install-registry.test.ts test/cli/install/bun-install.test.ts test/cli/install/isolated-install.test.ts

<!-- robobun:evidence:end -->


