### PR TITLE
pm ls --all: stop panicking on resolutions longer than 512 bytes

### DIFF
--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -749,7 +749,6 @@ fn print_node_modules_folder_structure(
             }
         }
 
-        let mut resolution_buf = [0u8; 512];
         if let Some(id) = directory_package_id {
             let mut path: &[u8] = directory.relative_path.as_bytes();
 
@@ -761,25 +760,15 @@ fn print_node_modules_folder_structure(
                     }
                 }
             }
-            let directory_version = buf_print(
-                &mut resolution_buf,
-                format_args!(
-                    "{}",
-                    resolutions[id as usize].fmt(string_bytes, PathSep::Auto)
-                ),
-            );
+            let directory_version = resolutions[id as usize].fmt(string_bytes, PathSep::Auto);
             if let Some(j) = strings::index_of(path, b"node_modules") {
                 bun_core::prettyln!(
                     "{}<d>@{}<r>",
                     bstr::BStr::new(&path[0..j - 1]),
-                    bstr::BStr::new(directory_version),
+                    directory_version,
                 );
             } else {
-                bun_core::prettyln!(
-                    "{}<d>@{}<r>",
-                    bstr::BStr::new(path),
-                    bstr::BStr::new(directory_version),
-                );
+                bun_core::prettyln!("{}<d>@{}<r>", bstr::BStr::new(path), directory_version);
             }
         } else {
             let mut cwd_buf = PathBuffer::uninit();
@@ -886,18 +875,10 @@ fn print_node_modules_folder_structure(
             bun_core::pretty!("<d>└──<r> ");
         }
 
-        let mut resolution_buf = [0u8; 512];
-        let package_version = buf_print(
-            &mut resolution_buf,
-            format_args!(
-                "{}",
-                resolutions[package_id as usize].fmt(string_bytes, PathSep::Auto)
-            ),
-        );
         bun_core::prettyln!(
             "{}<d>@{}<r>",
             bstr::BStr::new(package_name),
-            bstr::BStr::new(package_version),
+            resolutions[package_id as usize].fmt(string_bytes, PathSep::Auto),
         );
     }
 
@@ -979,5 +960,3 @@ fn print_trusted_dependencies_flat(
         }
     }
 }
-
-use bun_core::fmt::buf_print_infallible as buf_print;

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -140,6 +140,60 @@ it("should list all dependencies", async () => {
   expect(requested).toBe(2);
 });
 
+// A tarball package's label is the URL it was installed from, which has no length
+// limit. `--all` prints a label in two places: the header of a package that has its own
+// nested node_modules (moo, whose bar/baz conflict with the root's), and the line of a
+// package that has none (bar).
+it("should list all dependencies when a resolution is longer than 512 bytes", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.2": {}, "0.0.3": {}, "0.0.5": {}, latest: "0.0.3" }));
+  const barUrl = `${root_url}/${Buffer.alloc(600, "a").toString()}/bar-0.0.2.tgz`;
+  const mooUrl = `${root_url}/${Buffer.alloc(600, "b").toString()}/moo-0.1.0.tgz`;
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "foo",
+      version: "0.0.1",
+      dependencies: {
+        bar: barUrl,
+        baz: "0.0.5",
+        // moo-0.1.0.tgz depends on bar@0.0.2 and baz@latest
+        moo: mooUrl,
+      },
+    }),
+  );
+  {
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(err).not.toContain("error:");
+    expect(err).toContain("Saved lockfile");
+    expect(exitCode).toBe(0);
+  }
+  await using proc = spawn({
+    cmd: [bunExe(), "pm", "ls", "--all"],
+    cwd: package_dir,
+    stdout: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe(`${package_dir} node_modules
+├── bar@${barUrl}
+├── baz@0.0.5
+└── moo@${mooUrl}
+    ├── bar@0.0.2
+    └── baz@0.0.3
+`);
+  expect(exitCode).toBe(0);
+});
+
 it("should list top-level aliased dependency", async () => {
   const urls: string[] = [];
   setHandler(dummyRegistry(urls));


### PR DESCRIPTION
### Problem

- `bun pm ls --all` (and `bun list --all`) aborts with `panic: buf_print: buffer too small` (exit 134) as soon as it reaches a package whose resolution is longer than 512 bytes, for example a dependency installed from a tarball URL with a ~600 character path. Plain `bun pm ls` prints the same package fine.
- Reproduced with bun 1.4.0-canary.1 and main: serve a `.tgz` from a local `Bun.serve`, depend on it as `http://127.0.0.1:PORT/aaaa...(600 chars)/bar-0.0.2.tgz`, `bun install` (succeeds), `bun pm ls --all` prints the root line and `├── ` and panics.
- Cause: the `--all` tree printer (`print_node_modules_folder_structure`, `src/runtime/cli/package_manager_command.rs`) formatted each resolution into `let mut resolution_buf = [0u8; 512]` with `buf_print_infallible`, which panics on overflow. Two sites: the header line of a package that owns a nested `node_modules` folder (formerly line 764) and the line of every other package (formerly line 890).
- A tarball, folder or git resolution repeats the user supplied spec verbatim, so there is no length a stack buffer can be sized to. #37469 fixed the same class of panic in the installer and `bun patch`; this printer was left out.

### Fix

- Pass the resolution's `Display` formatter (`resolutions[id].fmt(string_bytes, PathSep::Auto)`) straight to `prettyln!` at both sites and delete the buffer and the now unused `buf_print_infallible` import.
- Correct because the formatted bytes were only ever printed: the buffer added no information, and removing it removes the only length limit on the path.
- Output is unchanged for every label that used to fit. The old code formatted the same `Display` impl into the buffer and re-printed it through `BStr`, and `BStr` prints the valid UTF-8 that `Display` produces byte for byte, so the only observable difference is on labels that used to panic.
- This is already how the other two `pm ls` paths print the label: the top-level listing (`bun pm ls`) and `--all --trusted` (`print_trusted_dependencies_flat`) both pass the formatter directly, which is why they never had the problem.
- Verified with `test/cli/install/bun-pm.test.ts`, "should list all dependencies when a resolution is longer than 512 bytes": the root depends on two tarballs with ~620 byte URLs plus `baz@0.0.5`; one tarball (`moo`) depends on versions of `bar` and `baz` that conflict with the root's, so it owns a nested `node_modules` and its label goes through the header site, while the other tarball (`bar`) goes through the per-package site. The test asserts the full tree. It fails on the unfixed binary with the panic above and passes with the fix; the rest of `bun-pm.test.ts` and `test/regression/issue/24502/bun-pm-ls-all-invalid-package-id.test.ts` still pass. `cargo fmt --check` and `cargo clippy -p bun_runtime` are clean.

### Background

- A package's resolution is the lockfile's record of what it was installed from: a version for registry packages, otherwise the spec itself (tarball URL or path, folder path, git reference). `Resolution::fmt` returns a `Display` formatter that renders it as the `@...` label `bun pm ls` prints after each package name.
- `bun pm ls --all` walks the lockfile's hoisted tree one `node_modules` folder at a time. Each folder's header names the package that owns it, and each package inside the folder that does not own a folder of its own gets a line of its own; those are the two print sites.
- `buf_print_infallible` (`src/bun_core/fmt.rs`) formats into a caller supplied slice and panics if the output does not fit; it is meant for buffers whose contents have a known bound. The Zig version of this code used `std.fmt.bufPrint` with `try`, so the same overflow used to surface as an error instead of a panic, but `--all` failed either way.
