### PR TITLE
Restore BUN_DUMP_STATE_ON_CRASH: dump the DevServer graph when bun crashes

### DIFF
--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -255,6 +255,9 @@ pub mod feature_flag {
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE, "BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE", {});
     new_feature_flag!(pub BUN_DISABLE_TRANSPILED_SOURCE_CODE_PREVIEW, "BUN_DISABLE_TRANSPILED_SOURCE_CODE_PREVIEW", {});
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_UV_FS_COPYFILE, "BUN_FEATURE_FLAG_DISABLE_UV_FS_COPYFILE", {});
+    // Canary/debug builds only: a crashing bake DevServer writes its incremental
+    // graph to `incremental-graph-crash-dump.<timestamp>.html` in the cwd
+    // (`DevServer::dump_state_due_to_crash`). test/bake/bake-harness.ts sets it.
     new_feature_flag!(pub BUN_DUMP_STATE_ON_CRASH, "BUN_DUMP_STATE_ON_CRASH", {});
     new_feature_flag!(pub BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS, "BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS", {});
     new_feature_flag!(pub BUN_FEATURE_FLAG_EXPERIMENTAL_BAKE, "BUN_FEATURE_FLAG_EXPERIMENTAL_BAKE", {});

--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -255,9 +255,8 @@ pub mod feature_flag {
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE, "BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE", {});
     new_feature_flag!(pub BUN_DISABLE_TRANSPILED_SOURCE_CODE_PREVIEW, "BUN_DISABLE_TRANSPILED_SOURCE_CODE_PREVIEW", {});
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_UV_FS_COPYFILE, "BUN_FEATURE_FLAG_DISABLE_UV_FS_COPYFILE", {});
-    // Canary/debug builds only: a crashing bake DevServer writes its incremental
-    // graph to `incremental-graph-crash-dump.<timestamp>.html` in the cwd
-    // (`DevServer::dump_state_due_to_crash`). test/bake/bake-harness.ts sets it.
+    // Canary/debug builds: a crashing bake DevServer dumps its incremental graph
+    // to the cwd (`DevServer::dump_state_due_to_crash`). Set by test/bake/bake-harness.ts.
     new_feature_flag!(pub BUN_DUMP_STATE_ON_CRASH, "BUN_DUMP_STATE_ON_CRASH", {});
     new_feature_flag!(pub BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS, "BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS", {});
     new_feature_flag!(pub BUN_FEATURE_FLAG_EXPERIMENTAL_BAKE, "BUN_FEATURE_FLAG_EXPERIMENTAL_BAKE", {});

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -456,13 +456,11 @@ impl Write for StderrWriter {
 mod draft {
 
     use core::cell::Cell;
-    use core::ffi::c_char;
     #[cfg(not(windows))]
     use core::ffi::c_int;
     #[cfg(windows)]
     use core::ffi::c_long;
-    #[cfg(not(windows))]
-    use core::ffi::c_void;
+    use core::ffi::{c_char, c_void};
     use core::fmt;
     // D101: `core::fmt::Write` intentionally NOT in scope here — `bun_io::Write`
     // (via `super::Write`) supplies `write_fmt` for `BoundedArray<u8,N>`; importing
@@ -613,6 +611,89 @@ mod draft {
     /// abort the process. Overrides BUN_CRASH_REPORT_URL, BUN_ENABLE_CRASH_REPORTING, and all other
     /// things that affect crash reporting. See suppressReporting() for intended usage.
     static SUPPRESS_REPORTING: AtomicBool = AtomicBool::new(false);
+
+    /// Implemented by long-lived subsystems whose state is worth writing to disk
+    /// when the process crashes (bake's `DevServer` dumps its incremental graph
+    /// when `BUN_DUMP_STATE_ON_CRASH` is set). Registered with
+    /// [`append_pre_crash_handler`].
+    pub trait PreCrashHandler {
+        /// Runs on the crashing thread, after the crash report has been printed
+        /// (so crashing again in here cannot hide the original report) and before
+        /// the process is torn down. The crash may have interrupted a mutation of
+        /// `self` on any thread: only read, and expect inconsistent state.
+        fn on_crash(&self);
+    }
+
+    struct PreCrashHandlerEntry {
+        handler: *const c_void,
+        /// `run_pre_crash_handler::<T>` for the `T` that `handler` points to.
+        run: unsafe fn(*const c_void),
+    }
+
+    // SAFETY: `handler` is only dereferenced by `run`, on the crashing thread, and
+    // the registrant keeps it live until `remove_pre_crash_handler` (the
+    // `append_pre_crash_handler` contract); every other access just compares the address.
+    unsafe impl Send for PreCrashHandlerEntry {}
+
+    static PRE_CRASH_HANDLERS: bun_threading::Guarded<Vec<PreCrashHandlerEntry>> =
+        bun_threading::Guarded::new(Vec::new());
+
+    /// # Safety
+    /// `handler` must be a pointer registered through `append_pre_crash_handler::<T>`
+    /// whose pointee is still live.
+    unsafe fn run_pre_crash_handler<T: PreCrashHandler>(handler: *const c_void) {
+        // SAFETY: per fn contract.
+        unsafe { (*handler.cast::<T>()).on_crash() }
+    }
+
+    /// Registers `handler` to run if the process crashes. This is best effort:
+    /// handlers are skipped when the crash happens while another one is being
+    /// registered or removed, and whatever they do, the process still dies.
+    ///
+    /// # Safety
+    /// `*handler` must stay live at this address until it is passed to
+    /// [`remove_pre_crash_handler`].
+    pub unsafe fn append_pre_crash_handler<T: PreCrashHandler>(handler: *const T) {
+        PRE_CRASH_HANDLERS.lock().push(PreCrashHandlerEntry {
+            handler: handler.cast(),
+            run: run_pre_crash_handler::<T>,
+        });
+    }
+
+    /// Unregisters a handler passed to [`append_pre_crash_handler`]. Does nothing
+    /// if it is not registered.
+    pub fn remove_pre_crash_handler<T: PreCrashHandler>(handler: *const T) {
+        let handler: *const c_void = handler.cast();
+        let mut handlers = PRE_CRASH_HANDLERS.lock();
+        if let Some(index) = handlers.iter().position(|entry| entry.handler == handler) {
+            handlers.remove(index);
+        }
+    }
+
+    /// Called by both crash entry points (`crash_handler` and `rust_panic_hook`)
+    /// once the report is printed; runs the handlers at most once per process.
+    fn run_pre_crash_handlers() {
+        static RAN: AtomicBool = AtomicBool::new(false);
+        if RAN.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        // The crash may have happened while this thread held the lock, so never block on it.
+        let Some(handlers) = PRE_CRASH_HANDLERS.try_lock() else {
+            return;
+        };
+        if handlers.is_empty() {
+            return;
+        }
+        for entry in handlers.iter() {
+            // SAFETY: `entry.run` was instantiated for the type `entry.handler` points
+            // to, and the registrant keeps the pointee live until it removes the entry
+            // (see `append_pre_crash_handler`).
+            unsafe { (entry.run)(entry.handler) };
+        }
+        // Handlers say where they wrote to through the buffered `Output` writers,
+        // and nothing flushes those between here and the abort.
+        Output::flush();
+    }
 
     /// This structure and formatter must be kept in sync with `bun.report`'s decoder implementation.
     #[derive(Clone, Copy)]
@@ -1184,6 +1265,8 @@ mod draft {
                 // Be aware that this function only lets one thread return from it.
                 // This is important so that we do not try to run the following reload logic twice.
                 wait_for_other_thread_to_finish_panicking();
+
+                run_pre_crash_handlers();
 
                 report(trace_str_buf.const_slice());
 
@@ -1864,6 +1947,8 @@ mod draft {
                 let _ = writer.write_all(b"\n");
             }
         }
+
+        run_pre_crash_handlers();
 
         report(trace_str_buf.const_slice());
 

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -612,15 +612,11 @@ mod draft {
     /// things that affect crash reporting. See suppressReporting() for intended usage.
     static SUPPRESS_REPORTING: AtomicBool = AtomicBool::new(false);
 
-    /// Implemented by long-lived subsystems whose state is worth writing to disk
-    /// when the process crashes (bake's `DevServer` dumps its incremental graph
-    /// when `BUN_DUMP_STATE_ON_CRASH` is set). Registered with
-    /// [`append_pre_crash_handler`].
+    /// Dumps state to disk when the process crashes (bake's `DevServer` with
+    /// `BUN_DUMP_STATE_ON_CRASH`). See [`append_pre_crash_handler`].
     pub trait PreCrashHandler {
-        /// Runs on the crashing thread, after the crash report has been printed
-        /// (so crashing again in here cannot hide the original report) and before
-        /// the process is torn down. The crash may have interrupted a mutation of
-        /// `self` on any thread: only read, and expect inconsistent state.
+        /// Runs on the crashing thread after the crash report has been printed.
+        /// `self` may be mid-mutation on another thread: only read, trust nothing.
         fn on_crash(&self);
     }
 
@@ -630,29 +626,25 @@ mod draft {
         run: unsafe fn(*const c_void),
     }
 
-    // SAFETY: `handler` is only dereferenced by `run`, on the crashing thread, and
-    // the registrant keeps it live until `remove_pre_crash_handler` (the
-    // `append_pre_crash_handler` contract); every other access just compares the address.
+    // SAFETY: `handler` is only dereferenced by `run`, and stays live until
+    // `remove_pre_crash_handler` (the `append_pre_crash_handler` contract).
     unsafe impl Send for PreCrashHandlerEntry {}
 
     static PRE_CRASH_HANDLERS: bun_threading::Guarded<Vec<PreCrashHandlerEntry>> =
         bun_threading::Guarded::new(Vec::new());
 
     /// # Safety
-    /// `handler` must be a pointer registered through `append_pre_crash_handler::<T>`
-    /// whose pointee is still live.
+    /// `handler` must be the live `*const T` passed to `append_pre_crash_handler::<T>`.
     unsafe fn run_pre_crash_handler<T: PreCrashHandler>(handler: *const c_void) {
         // SAFETY: per fn contract.
         unsafe { (*handler.cast::<T>()).on_crash() }
     }
 
-    /// Registers `handler` to run if the process crashes. This is best effort:
-    /// handlers are skipped when the crash happens while another one is being
-    /// registered or removed, and whatever they do, the process still dies.
+    /// Registers `handler` to run if the process crashes. Best effort: it is
+    /// skipped if the crash happens while the list itself is being modified.
     ///
     /// # Safety
-    /// `*handler` must stay live at this address until it is passed to
-    /// [`remove_pre_crash_handler`].
+    /// `*handler` must stay live at this address until [`remove_pre_crash_handler`].
     pub unsafe fn append_pre_crash_handler<T: PreCrashHandler>(handler: *const T) {
         PRE_CRASH_HANDLERS.lock().push(PreCrashHandlerEntry {
             handler: handler.cast(),
@@ -660,8 +652,7 @@ mod draft {
         });
     }
 
-    /// Unregisters a handler passed to [`append_pre_crash_handler`]. Does nothing
-    /// if it is not registered.
+    /// No-op if `handler` is not registered.
     pub fn remove_pre_crash_handler<T: PreCrashHandler>(handler: *const T) {
         let handler: *const c_void = handler.cast();
         let mut handlers = PRE_CRASH_HANDLERS.lock();
@@ -670,14 +661,13 @@ mod draft {
         }
     }
 
-    /// Called by both crash entry points (`crash_handler` and `rust_panic_hook`)
-    /// once the report is printed; runs the handlers at most once per process.
+    /// Called once the report is printed, by `crash_handler` and `rust_panic_hook`.
     fn run_pre_crash_handlers() {
         static RAN: AtomicBool = AtomicBool::new(false);
         if RAN.swap(true, Ordering::AcqRel) {
             return;
         }
-        // The crash may have happened while this thread held the lock, so never block on it.
+        // The crashing thread may be the one holding the lock.
         let Some(handlers) = PRE_CRASH_HANDLERS.try_lock() else {
             return;
         };
@@ -685,13 +675,11 @@ mod draft {
             return;
         }
         for entry in handlers.iter() {
-            // SAFETY: `entry.run` was instantiated for the type `entry.handler` points
-            // to, and the registrant keeps the pointee live until it removes the entry
-            // (see `append_pre_crash_handler`).
+            // SAFETY: `run` was instantiated for the type `handler` points to, and
+            // `handler` is live until removed (`append_pre_crash_handler` contract).
             unsafe { (entry.run)(entry.handler) };
         }
-        // Handlers say where they wrote to through the buffered `Output` writers,
-        // and nothing flushes those between here and the abort.
+        // The handlers' `note!`/`warn!` output is buffered; the callers abort without flushing.
         Output::flush();
     }
 

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -120,6 +120,8 @@ export const crash_handler = $rust("crash_handler.rs", "js_bindings.generate") a
   getMachOImageZeroOffset: () => number;
   segfault: () => void;
   panic: () => void;
+  /** A `panic!()` in Rust code, which reaches the crash handler through the panic hook rather than directly. */
+  rustPanic: () => void;
   rootError: () => void;
   outOfMemory: () => void;
   abort: () => void;

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -24,6 +24,7 @@ pub(crate) mod js_bindings {
             ("segfault", __jsc_host_js_segfault),
             ("segfaultInDll", __jsc_host_js_segfault_in_dll),
             ("panic", __jsc_host_js_panic),
+            ("rustPanic", __jsc_host_js_rust_panic),
             ("rootError", __jsc_host_js_root_error),
             ("outOfMemory", __jsc_host_js_out_of_memory),
             ("abort", __jsc_host_js_abort),
@@ -130,6 +131,15 @@ pub(crate) mod js_bindings {
     fn js_panic(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
         crash_handler::suppress_core_dumps_if_necessary();
         crash_handler::panic_impl(b"invoked crashByPanic() handler", None, None);
+    }
+
+    /// Unlike `panic` above, which enters `crash_handler()` directly, this takes
+    /// the route a failed `assert!`/`unwrap()` takes: `std::panic` → the panic
+    /// hook the crash handler installs.
+    #[bun_jsc::host_fn]
+    fn js_rust_panic(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
+        crash_handler::suppress_core_dumps_if_necessary();
+        panic!("invoked crashByRustPanic() handler");
     }
 
     #[bun_jsc::host_fn]

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -133,9 +133,8 @@ pub(crate) mod js_bindings {
         crash_handler::panic_impl(b"invoked crashByPanic() handler", None, None);
     }
 
-    /// Unlike `panic` above, which enters `crash_handler()` directly, this takes
-    /// the route a failed `assert!`/`unwrap()` takes: `std::panic` → the panic
-    /// hook the crash handler installs.
+    /// Reaches the crash handler through the std panic hook, like a failed
+    /// `assert!` does; `panic` above calls into it directly.
     #[bun_jsc::host_fn]
     fn js_rust_panic(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
         crash_handler::suppress_core_dumps_if_necessary();

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -422,9 +422,7 @@ pub struct DevServer {
     /// Reference count to number of active sockets with the memory_visualizer enabled.
     pub(crate) emit_memory_visualizer_events: u32,
     pub(crate) memory_visualizer_timer: EventLoopTimer,
-    /// `BUN_DUMP_STATE_ON_CRASH`: this DevServer is registered with the crash
-    /// handler, which calls `dump_state_due_to_crash` if the process crashes.
-    /// Set once `init` has registered it; `Drop` unregisters it.
+    /// Registered with `bun_crash_handler` (`BUN_DUMP_STATE_ON_CRASH`); `Drop` unregisters.
     pub(crate) has_pre_crash_handler: bool,
 
     pub(crate) assume_perfect_incremental_bundling: bool,
@@ -5539,38 +5537,37 @@ impl DevServer {
         Ok(())
     }
 
-    /// Serializes both incremental graphs as a `MessageId::Visualizer` message,
-    /// the format `incremental_visualizer.html` decodes (see its `decodeAndUpdate`):
-    /// the client and server file lists, then the client and server edge lists.
+    /// The `MessageId::Visualizer` format decoded by `incremental_visualizer.html`.
+    /// Runs from the crash handler, where the graphs may be mid-mutation: counts are
+    /// written after their entries, and the path buffer pool (a `RefCell`) is not used.
     fn write_visualizer_message(&self, payload: &mut Vec<u8>) {
         payload.push(MessageId::Visualizer.char());
-        self.write_visualizer_files(&self.client_graph, payload);
-        self.write_visualizer_files(&self.server_graph, payload);
+        let mut buf = Box::new(PathBuffer::ZEROED);
+        self.write_visualizer_files(&self.client_graph, payload, &mut buf);
+        self.write_visualizer_files(&self.server_graph, payload, &mut buf);
         write_visualizer_edges(&self.client_graph, payload);
         write_visualizer_edges(&self.server_graph, payload);
     }
 
-    /// - `u32`: number of files. For each:
-    ///   - `u32`: length of the path, relative to the root. Zero for a deleted
-    ///     file, in which case no other fields follow.
-    ///   - `[n]u8`: the path
-    ///   - `u8` each: stale, server (RSC), SSR, route, special framework file,
-    ///     boundary (client component boundary / HMR root). The flags that only
-    ///     exist on one side are zero on the other.
+    /// `u32` count, then per file: `u32` path length (0 = deleted file, nothing
+    /// follows), the path, and six `u8` flags: stale, RSC, SSR, route,
+    /// framework file, boundary (client side: HMR root).
     fn write_visualizer_files<const SIDE: bake::Side>(
         &self,
         graph: &IncrementalGraph<SIDE>,
         payload: &mut Vec<u8>,
+        buf: &mut PathBuffer,
     ) {
+        let count_at = reserve_visualizer_count(payload);
+        let mut count = 0u32;
         let keys = graph.bundled_files.keys();
-        payload.extend_from_slice(&u32::try_from(keys.len()).expect("int cast").to_le_bytes());
-        let mut buf = paths::path_buffer_pool::get();
         for (i, (key, file)) in keys.iter().zip(graph.bundled_files.values()).enumerate() {
+            count += 1;
             if key.is_empty() {
                 payload.extend_from_slice(&0u32.to_le_bytes());
                 continue;
             }
-            let path = self.relative_path(&mut *buf, key);
+            let path = self.relative_path(buf, key);
             payload.extend_from_slice(&u32::try_from(path.len()).expect("int cast").to_le_bytes());
             payload.extend_from_slice(path);
             let stale = graph.stale_files.is_set_allow_out_of_bound(i, true) || file.failed;
@@ -5594,15 +5591,14 @@ impl DevServer {
             };
             payload.extend_from_slice(&flags.map(u8::from));
         }
+        set_visualizer_count(payload, count_at, count);
     }
 
-    /// `BUN_DUMP_STATE_ON_CRASH`: writes `incremental_visualizer.html` to the
-    /// working directory with the current graphs inlined in place of its
-    /// WebSocket feed, so the page works offline, after the process is gone.
+    /// `BUN_DUMP_STATE_ON_CRASH`: writes `incremental_visualizer.html` to the cwd
+    /// with the graphs inlined, so it works without the (dead) dev server.
     fn dump_state_due_to_crash(&self) -> sys::Maybe<()> {
         const VISUALIZER: &[u8] = include_bytes!("incremental_visualizer.html");
-        // The page's own script starts at the last `<script>` tag; `inlinedData`
-        // has to be defined before it runs.
+        // `inlinedData` goes at the top of the page's own (last) script.
         let script_start = strings::last_index_of(VISUALIZER, b"<script>")
             .expect("incremental_visualizer.html has an inline <script>")
             + b"<script>".len();
@@ -5615,8 +5611,7 @@ impl DevServer {
 
         file.write_all(head)?;
         file.write_all(b"\nlet inlinedData = Uint8Array.from(atob(\"")?;
-        // A multiple of 3 input bytes encodes without padding, so the chunks
-        // concatenate into one valid base64 string.
+        // Multiple of 3: no `=` padding between chunks, which `atob` rejects.
         const CHUNK: usize = 3 * 1024;
         let mut encoded = [0u8; bun_core::base64::standard_encoder_calc_size(CHUNK)];
         for chunk in payload.chunks(CHUNK) {
@@ -5633,10 +5628,8 @@ impl DevServer {
     }
 }
 
-/// Creates `incremental-graph-crash-dump.<unix seconds>.html` in the working
-/// directory, or the first of `.1.html`, `.2.html`, ... that does not exist
-/// yet: every DevServer in the process dumps during the same crash, and a
-/// process that restarts on crash may crash again within the second.
+/// `incremental-graph-crash-dump.<unix seconds>[.N].html` in the cwd; `N` keeps
+/// several DevServers (or a crash-restart loop) from overwriting each other.
 fn create_crash_dump_file() -> sys::Maybe<(sys::File, String)> {
     const MAX_DUMPS_PER_SECOND: u32 = 100;
     let timestamp = bun_core::time::timestamp();
@@ -5662,26 +5655,42 @@ fn create_crash_dump_file() -> sys::Maybe<(sys::File, String)> {
     }
 }
 
-/// - `u32`: number of edges. For each:
-///   - `u32`: index of the file containing the import
-///   - `u32`: index of the imported file
+/// `u32` count, then per live edge: `u32` importer index, `u32` imported index.
 fn write_visualizer_edges<const SIDE: bake::Side>(
     graph: &IncrementalGraph<SIDE>,
     payload: &mut Vec<u8>,
 ) {
-    let live_edges = graph.edges.len() - graph.edges_free_list.len();
-    payload.extend_from_slice(&u32::try_from(live_edges).expect("int cast").to_le_bytes());
-    for (i, edge) in graph.edges.iter().enumerate() {
-        if graph
-            .edges_free_list
-            .iter()
-            .any(|free| free.get() as usize == i)
-        {
-            continue;
+    let mut freed = vec![false; graph.edges.len()];
+    for free in &graph.edges_free_list {
+        if let Some(slot) = freed.get_mut(free.get() as usize) {
+            *slot = true;
         }
+    }
+    let count_at = reserve_visualizer_count(payload);
+    let mut count = 0u32;
+    for (edge, _) in graph
+        .edges
+        .iter()
+        .zip(freed)
+        .filter(|(_, is_freed)| !is_freed)
+    {
+        count += 1;
         payload.extend_from_slice(&edge.dependency.get().to_le_bytes());
         payload.extend_from_slice(&edge.imported.get().to_le_bytes());
     }
+    set_visualizer_count(payload, count_at, count);
+}
+
+/// Leaves room for a list's `u32` count, filled in by `set_visualizer_count`
+/// once the number of entries actually written is known.
+fn reserve_visualizer_count(payload: &mut Vec<u8>) -> usize {
+    let at = payload.len();
+    payload.extend_from_slice(&0u32.to_le_bytes());
+    at
+}
+
+fn set_visualizer_count(payload: &mut [u8], at: usize, count: u32) {
+    payload[at..at + 4].copy_from_slice(&count.to_le_bytes());
 }
 
 impl bun_crash_handler::PreCrashHandler for DevServer {

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -422,6 +422,10 @@ pub struct DevServer {
     /// Reference count to number of active sockets with the memory_visualizer enabled.
     pub(crate) emit_memory_visualizer_events: u32,
     pub(crate) memory_visualizer_timer: EventLoopTimer,
+    /// `BUN_DUMP_STATE_ON_CRASH`: this DevServer is registered with the crash
+    /// handler, which calls `dump_state_due_to_crash` if the process crashes.
+    /// Set once `init` has registered it; `Drop` unregisters it.
+    pub(crate) has_pre_crash_handler: bool,
 
     pub(crate) assume_perfect_incremental_bundling: bool,
 
@@ -535,6 +539,7 @@ pub(crate) fn init(options: Options) -> JsResult<Box<DevServer>> {
             memory_visualizer_timer,
             EventLoopTimer::init_paused(EventLoopTimerTag::DevServerMemoryVisualizerTick)
         );
+        w!(has_pre_crash_handler, false);
         // `dev.frontend_only = dev.framework.file_system_router_types.len == 0`
         w!(
             frontend_only,
@@ -1000,6 +1005,17 @@ pub(crate) fn init(options: Options) -> JsResult<Box<DevServer>> {
     // after that line.
     dev.scan_initial_routes()?;
 
+    if bun_core::feature_flags::BAKE_DEBUGGING_FEATURES
+        && bun_core::env_var::feature_flag::BUN_DUMP_STATE_ON_CRASH
+            .get()
+            .unwrap_or(false)
+    {
+        // SAFETY: `dev` is boxed, so this address stays valid until the box is
+        // freed, and `Drop for DevServer` unregisters it before that.
+        unsafe { bun_crash_handler::append_pre_crash_handler::<DevServer>(&raw const *dev) };
+        dev.has_pre_crash_handler = true;
+    }
+
     debug_assert!(dev.magic == Magic::Valid);
 
     Ok(dev)
@@ -1063,9 +1079,15 @@ impl Drop for DevServer {
                 emit_incremental_visualizer_events: _,
                 emit_memory_visualizer_events: _,
                 memory_visualizer_timer: _,
+                has_pre_crash_handler: _,
                 assume_perfect_incremental_bundling: _,
                 broadcast_console_log_from_browser_to_server: _,
             } = &*self;
+        }
+
+        // First, so that a crash anywhere below does not dump a half-destroyed graph.
+        if self.has_pre_crash_handler {
+            bun_crash_handler::remove_pre_crash_handler::<DevServer>(std::ptr::from_ref(self));
         }
 
         // WebSockets should be deinitialized before other parts.
@@ -5515,6 +5537,133 @@ impl DevServer {
             }
         }
         Ok(())
+    }
+
+    /// Serializes both incremental graphs as a `MessageId::Visualizer` message,
+    /// the format `incremental_visualizer.html` decodes (see its `decodeAndUpdate`):
+    /// the client and server file lists, then the client and server edge lists.
+    fn write_visualizer_message(&self, payload: &mut Vec<u8>) {
+        payload.push(MessageId::Visualizer.char());
+        self.write_visualizer_files(&self.client_graph, payload);
+        self.write_visualizer_files(&self.server_graph, payload);
+        write_visualizer_edges(&self.client_graph, payload);
+        write_visualizer_edges(&self.server_graph, payload);
+    }
+
+    /// - `u32`: number of files. For each:
+    ///   - `u32`: length of the path, relative to the root. Zero for a deleted
+    ///     file, in which case no other fields follow.
+    ///   - `[n]u8`: the path
+    ///   - `u8` each: stale, server (RSC), SSR, route, special framework file,
+    ///     boundary (client component boundary / HMR root). The flags that only
+    ///     exist on one side are zero on the other.
+    fn write_visualizer_files<const SIDE: bake::Side>(
+        &self,
+        graph: &IncrementalGraph<SIDE>,
+        payload: &mut Vec<u8>,
+    ) {
+        let keys = graph.bundled_files.keys();
+        payload.extend_from_slice(&u32::try_from(keys.len()).expect("int cast").to_le_bytes());
+        let mut buf = paths::path_buffer_pool::get();
+        for (i, (key, file)) in keys.iter().zip(graph.bundled_files.values()).enumerate() {
+            if key.is_empty() {
+                payload.extend_from_slice(&0u32.to_le_bytes());
+                continue;
+            }
+            let path = self.relative_path(&mut *buf, key);
+            payload.extend_from_slice(&u32::try_from(path.len()).expect("int cast").to_le_bytes());
+            payload.extend_from_slice(path);
+            let stale = graph.stale_files.is_set_allow_out_of_bound(i, true) || file.failed;
+            let flags: [bool; 6] = match SIDE {
+                bake::Side::Client => [
+                    stale,
+                    false,
+                    false,
+                    file.html_route_bundle_index.is_some(),
+                    file.is_special_framework_file,
+                    file.is_hmr_root,
+                ],
+                bake::Side::Server => [
+                    stale,
+                    file.is_rsc,
+                    file.is_ssr,
+                    file.is_route,
+                    false,
+                    file.is_client_component_boundary,
+                ],
+            };
+            payload.extend_from_slice(&flags.map(u8::from));
+        }
+    }
+
+    /// `BUN_DUMP_STATE_ON_CRASH`: writes `incremental_visualizer.html` to the
+    /// working directory with the current graphs inlined in place of its
+    /// WebSocket feed, so the page works offline, after the process is gone.
+    fn dump_state_due_to_crash(&self) -> sys::Maybe<()> {
+        const VISUALIZER: &[u8] = include_bytes!("incremental_visualizer.html");
+        // The page's own script starts at the last `<script>` tag; `inlinedData`
+        // has to be defined before it runs.
+        let script_start = strings::last_index_of(VISUALIZER, b"<script>")
+            .expect("incremental_visualizer.html has an inline <script>")
+            + b"<script>".len();
+        let (head, script) = VISUALIZER.split_at(script_start);
+
+        let file_name = format!(
+            "incremental-graph-crash-dump.{}.html",
+            bun_core::time::timestamp()
+        );
+        let file = sys::File::create(sys::Fd::cwd(), file_name.as_bytes(), true)?;
+
+        let mut payload: Vec<u8> = Vec::new();
+        self.write_visualizer_message(&mut payload);
+
+        file.write_all(head)?;
+        file.write_all(b"\nlet inlinedData = Uint8Array.from(atob(\"")?;
+        // A multiple of 3 input bytes encodes without padding, so the chunks
+        // concatenate into one valid base64 string.
+        const CHUNK: usize = 3 * 1024;
+        let mut encoded = [0u8; bun_core::base64::standard_encoder_calc_size(CHUNK)];
+        for chunk in payload.chunks(CHUNK) {
+            file.write_all(bun_core::base64::standard_encode(&mut encoded, chunk))?;
+        }
+        file.write_all(b"\"), c => c.charCodeAt(0));\n")?;
+        file.write_all(script)?;
+
+        bun_core::note!(
+            "Dumped incremental bundler graph to {}",
+            bun_core::fmt::quote(file_name.as_bytes())
+        );
+        Ok(())
+    }
+}
+
+/// - `u32`: number of edges. For each:
+///   - `u32`: index of the file containing the import
+///   - `u32`: index of the imported file
+fn write_visualizer_edges<const SIDE: bake::Side>(
+    graph: &IncrementalGraph<SIDE>,
+    payload: &mut Vec<u8>,
+) {
+    let live_edges = graph.edges.len() - graph.edges_free_list.len();
+    payload.extend_from_slice(&u32::try_from(live_edges).expect("int cast").to_le_bytes());
+    for (i, edge) in graph.edges.iter().enumerate() {
+        if graph
+            .edges_free_list
+            .iter()
+            .any(|free| free.get() as usize == i)
+        {
+            continue;
+        }
+        payload.extend_from_slice(&edge.dependency.get().to_le_bytes());
+        payload.extend_from_slice(&edge.imported.get().to_le_bytes());
+    }
+}
+
+impl bun_crash_handler::PreCrashHandler for DevServer {
+    fn on_crash(&self) {
+        if let Err(err) = self.dump_state_due_to_crash() {
+            bun_core::warn!("Could not dump incremental bundler graph: {}", err);
+        }
     }
 }
 

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -5608,11 +5608,7 @@ impl DevServer {
             + b"<script>".len();
         let (head, script) = VISUALIZER.split_at(script_start);
 
-        let file_name = format!(
-            "incremental-graph-crash-dump.{}.html",
-            bun_core::time::timestamp()
-        );
-        let file = sys::File::create(sys::Fd::cwd(), file_name.as_bytes(), true)?;
+        let (file, file_name) = create_crash_dump_file()?;
 
         let mut payload: Vec<u8> = Vec::new();
         self.write_visualizer_message(&mut payload);
@@ -5634,6 +5630,35 @@ impl DevServer {
             bun_core::fmt::quote(file_name.as_bytes())
         );
         Ok(())
+    }
+}
+
+/// Creates `incremental-graph-crash-dump.<unix seconds>.html` in the working
+/// directory, or the first of `.1.html`, `.2.html`, ... that does not exist
+/// yet: every DevServer in the process dumps during the same crash, and a
+/// process that restarts on crash may crash again within the second.
+fn create_crash_dump_file() -> sys::Maybe<(sys::File, String)> {
+    const MAX_DUMPS_PER_SECOND: u32 = 100;
+    let timestamp = bun_core::time::timestamp();
+    let mut attempt = 0u32;
+    loop {
+        let file_name = if attempt == 0 {
+            format!("incremental-graph-crash-dump.{timestamp}.html")
+        } else {
+            format!("incremental-graph-crash-dump.{timestamp}.{attempt}.html")
+        };
+        match sys::File::openat(
+            sys::Fd::cwd(),
+            file_name.as_bytes(),
+            sys::O::WRONLY | sys::O::CREAT | sys::O::EXCL | sys::O::CLOEXEC,
+            0o666,
+        ) {
+            Ok(file) => return Ok((file, file_name)),
+            Err(err) if err.get_errno() == sys::E::EEXIST && attempt < MAX_DUMPS_PER_SECOND => {
+                attempt += 1;
+            }
+            Err(err) => return Err(err),
+        }
     }
 }
 

--- a/src/runtime/bake/dev_server/memory_cost.rs
+++ b/src/runtime/bake/dev_server/memory_cost.rs
@@ -84,6 +84,7 @@ pub(crate) fn memory_cost_detailed(dev: &DevServer) -> MemoryCost {
             emit_incremental_visualizer_events: _,
             emit_memory_visualizer_events: _,
             memory_visualizer_timer: _,
+            has_pre_crash_handler: _,
             assume_perfect_incremental_bundling: _,
             broadcast_console_log_from_browser_to_server: _,
         } = dev;
@@ -101,6 +102,7 @@ pub(crate) fn memory_cost_detailed(dev: &DevServer) -> MemoryCost {
     //   .frontend_only
     //   .generation
     //   .graph_safety_lock
+    //   .has_pre_crash_handler
     //   .magic
     //   .memory_visualizer_timer
     //   .plugin_state

--- a/src/threading/Mutex.rs
+++ b/src/threading/Mutex.rs
@@ -49,7 +49,6 @@ impl Mutex {
     /// Tries to acquire the mutex without blocking the caller's thread.
     /// Returns `false` if the calling thread would have to block to acquire it.
     /// Otherwise, returns `true` and the caller should `unlock()` the Mutex to release it.
-    #[cfg(debug_assertions)]
     pub fn try_lock(&self) -> bool {
         self.impl_.try_lock()
     }
@@ -234,7 +233,6 @@ unsafe impl Send for WindowsImpl {}
 unsafe extern "system" {
     safe fn AcquireSRWLockExclusive(lock: &core::cell::UnsafeCell<bun_sys::windows::SRWLOCK>);
     // Returns BOOLEAN (u8), not BOOL — compare against 0, not the i32 `FALSE`.
-    #[cfg(debug_assertions)]
     safe fn TryAcquireSRWLockExclusive(
         lock: &core::cell::UnsafeCell<bun_sys::windows::SRWLOCK>,
     ) -> u8;
@@ -248,7 +246,6 @@ impl WindowsImpl {
         }
     }
 
-    #[cfg(debug_assertions)]
     fn try_lock(&self) -> bool {
         TryAcquireSRWLockExclusive(&self.srwlock) != 0
     }
@@ -299,7 +296,6 @@ pub(crate) struct OsUnfairLock {
 // `os_unfair_lock_unlock` takes the address instead: see `Mutex::unlock_raw`.
 #[cfg(target_vendor = "apple")]
 unsafe extern "C" {
-    #[cfg(debug_assertions)]
     safe fn os_unfair_lock_trylock(lock: &core::cell::UnsafeCell<OsUnfairLock>) -> bool;
     safe fn os_unfair_lock_lock(lock: &core::cell::UnsafeCell<OsUnfairLock>);
     fn os_unfair_lock_unlock(lock: *mut OsUnfairLock);
@@ -313,7 +309,6 @@ impl DarwinImpl {
         }
     }
 
-    #[cfg(debug_assertions)]
     fn try_lock(&self) -> bool {
         os_unfair_lock_trylock(&self.oul)
     }

--- a/src/threading/guarded.rs
+++ b/src/threading/guarded.rs
@@ -54,6 +54,21 @@ impl<Value> GuardedBy<Value, Mutex> {
             mutex: Mutex::new(),
         }
     }
+
+    /// Attempts to acquire the mutex without blocking. Returns the guard on
+    /// success, `None` if another thread holds the lock.
+    ///
+    /// Parity with `parking_lot::Mutex::try_lock`. Only provided for the real
+    /// [`Mutex`] backend (not generic `M`) because [`RawMutex`] intentionally
+    /// stays `lock`/`unlock`-only.
+    #[inline]
+    pub fn try_lock(&self) -> Option<GuardedLock<'_, Value, Mutex>> {
+        if self.mutex.try_lock() {
+            Some(GuardedLock { guarded: self })
+        } else {
+            None
+        }
+    }
 }
 
 impl<Value, M: RawMutex> GuardedBy<Value, M> {

--- a/src/threading/guarded.rs
+++ b/src/threading/guarded.rs
@@ -55,12 +55,8 @@ impl<Value> GuardedBy<Value, Mutex> {
         }
     }
 
-    /// Attempts to acquire the mutex without blocking. Returns the guard on
-    /// success, `None` if another thread holds the lock.
-    ///
-    /// Parity with `parking_lot::Mutex::try_lock`. Only provided for the real
-    /// [`Mutex`] backend (not generic `M`) because [`RawMutex`] intentionally
-    /// stays `lock`/`unlock`-only.
+    /// `None` if the lock is held. Only for the [`Mutex`] backend: [`RawMutex`]
+    /// is deliberately `lock`/`unlock`-only.
     #[inline]
     pub fn try_lock(&self) -> Option<GuardedLock<'_, Value, Mutex>> {
         if self.mutex.try_lock() {

--- a/test/bake/dump-state-on-crash.test.ts
+++ b/test/bake/dump-state-on-crash.test.ts
@@ -1,0 +1,215 @@
+// BUN_DUMP_STATE_ON_CRASH=1 (bake-harness.ts sets it for every dev server it
+// spawns) makes a crashing DevServer write its incremental graph to
+// `incremental-graph-crash-dump.<timestamp>.html` in the working directory: a
+// self-contained copy of `src/runtime/bake/incremental_visualizer.html`.
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isDebug, tempDir } from "harness";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// DevServer debugging features only exist in canary and debug builds
+// (`bun_core::feature_flags::BAKE_DEBUGGING_FEATURES`). Canary builds report
+// themselves as e.g. "v1.4.0-canary.1 (b7a04310)".
+const hasBakeDebuggingFeatures = isDebug || Bun.version_with_sha.includes("-canary.");
+
+// Enough files, with long enough names, that the serialized graph is several
+// KiB and its base64 is written to the dump in more than one chunk.
+const padding = Buffer.alloc(40, "x").toString();
+const leaves = Array.from({ length: 48 }, (_, i) => `modules/leaf-${String(i).padStart(2, "0")}-${padding}.ts`);
+
+const fixture = {
+  "index.html": `<!DOCTYPE html><html><head><script type="module" src="./entry.ts"></script></head><body></body></html>`,
+  "entry.ts":
+    leaves.map((leaf, i) => `import { v as v${i} } from "./${leaf}";`).join("\n") +
+    `\nconsole.log(${leaves.map((_, i) => `v${i}`).join(" + ")});\n`,
+  ...Object.fromEntries(leaves.map((leaf, i) => [leaf, `export const v = ${i};\n`])),
+  "fixture.ts": `
+    import { crash_handler, getDevServerDeinitCount } from "bun:internal-for-testing";
+    import html from "./index.html";
+
+    const mode = process.argv[2];
+    const deinitsBefore = getDevServerDeinitCount();
+    let server: ReturnType<typeof Bun.serve> | null = Bun.serve({
+      port: 0,
+      development: true,
+      routes: { "/": html },
+    });
+
+    // Bundling the route is what populates the incremental graph.
+    const response = await fetch(server.url);
+    if (response.status !== 200) throw new Error("unexpected status " + response.status);
+    await response.text();
+
+    if (mode === "after-deinit") {
+      server.stop(true);
+      server = null;
+      for (let attempts = 0; getDevServerDeinitCount() === deinitsBefore; attempts++) {
+        if (attempts > 200) throw new Error("DevServer was not deinitialized");
+        Bun.gc(true);
+        await Bun.sleep(10);
+      }
+    }
+
+    if (mode === "rust-panic") {
+      crash_handler.rustPanic();
+    } else {
+      crash_handler.panic();
+    }
+    throw new Error("unreachable: the crash handler returned");
+  `,
+};
+
+const dumpFileName = /^incremental-graph-crash-dump\.\d+\.html$/;
+
+async function crash(mode: "crash-handler" | "rust-panic" | "after-deinit", dumpStateOnCrash: "0" | "1") {
+  using dir = tempDir("dump-state-on-crash", fixture);
+  await using proc = Bun.spawn({
+    // The flag makes debug builds print the trace string instead of spawning a symbolizer.
+    cmd: [bunExe(), "fixture.ts", mode, "--debug-crash-handler-use-trace-string"],
+    cwd: String(dir),
+    env: {
+      ...bunEnv,
+      BUN_DUMP_STATE_ON_CRASH: dumpStateOnCrash,
+      // These crashes are deliberate; never report them.
+      BUN_CRASH_REPORT_URL: "",
+      BUN_ENABLE_CRASH_REPORTING: "0",
+    },
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  expect(stderr).toContain(
+    mode === "rust-panic" ? "invoked crashByRustPanic() handler" : "invoked crashByPanic() handler",
+  );
+  expect(exitCode).not.toBe(0);
+
+  const dumps = readdirSync(String(dir)).filter(name => dumpFileName.test(name));
+  return {
+    stderr,
+    dumps,
+    contents: dumps.map(name => readFileSync(join(String(dir), name), "utf8")),
+  };
+}
+
+interface DumpedFile {
+  name: string;
+  stale: boolean;
+  route: boolean;
+}
+
+type Edge = [dependency: number, imported: number];
+
+/** Reads the payload the way the `decodeAndUpdate` function in incremental_visualizer.html does. */
+function decodeDump(html: string) {
+  const inlined = /\nlet inlinedData = Uint8Array\.from\(atob\("([^"]*)"\), c => c\.charCodeAt\(0\)\);\n/.exec(html);
+  if (!inlined) throw new Error("the dump does not inline a graph payload");
+  // Like the browser, `atob` rejects base64 with padding in the middle of the string.
+  const bytes = Uint8Array.from(atob(inlined[1]), c => c.charCodeAt(0));
+  const view = new DataView(bytes.buffer);
+  let offset = 1;
+  const u32 = () => {
+    const value = view.getUint32(offset, true);
+    offset += 4;
+    return value;
+  };
+  const readFiles = () => {
+    const count = u32();
+    const files: (DumpedFile | null)[] = [];
+    for (let i = 0; i < count; i++) {
+      const nameLength = u32();
+      if (nameLength === 0) {
+        files.push(null); // deleted file
+        continue;
+      }
+      const name = new TextDecoder().decode(bytes.subarray(offset, offset + nameLength));
+      offset += nameLength;
+      // stale, server (rsc), ssr, route, framework, boundary
+      const [stale, , , route] = bytes.subarray(offset, offset + 6);
+      offset += 6;
+      files.push({ name, stale: stale === 1, route: route === 1 });
+    }
+    return files;
+  };
+  const readEdges = () => {
+    const count = u32();
+    const edges: Edge[] = [];
+    for (let i = 0; i < count; i++) edges.push([u32(), u32()]);
+    return edges;
+  };
+
+  expect(bytes[0]).toBe("v".charCodeAt(0));
+  const clientFiles = readFiles();
+  const serverFiles = readFiles();
+  const clientEdges = readEdges();
+  const serverEdges = readEdges();
+  expect(offset).toBe(bytes.length);
+  return {
+    client: { files: clientFiles, edges: clientEdges },
+    server: { files: serverFiles, edges: serverEdges },
+  };
+}
+
+const byIndex = (a: Edge, b: Edge) => a[0] - b[0] || a[1] - b[1];
+
+function expectDumpToDescribeTheFixture(html: string) {
+  expect(html).toStartWith("<!doctype html>");
+  expect(html).toContain("<title>IncrementalGraph Visualization</title>");
+  expect(html.trimEnd()).toEndWith("</html>");
+
+  const { client, server } = decodeDump(html);
+  expect(server).toEqual({ files: [], edges: [] });
+
+  // Names are relative to the DevServer root.
+  const fileIndex = (relativePath: string) => {
+    const index = client.files.findIndex(
+      file => file?.name === relativePath || file?.name.endsWith("/" + relativePath),
+    );
+    if (index === -1) throw new Error(`${relativePath} is missing from the dump`);
+    return index;
+  };
+  const flags = (relativePath: string) => {
+    const { stale, route } = client.files[fileIndex(relativePath)]!;
+    return { stale, route };
+  };
+
+  expect(flags("index.html")).toEqual({ stale: false, route: true });
+  expect(flags("entry.ts")).toEqual({ stale: false, route: false });
+  expect(leaves.map(flags)).toEqual(leaves.map(() => ({ stale: false, route: false })));
+
+  const entry = fileIndex("entry.ts");
+  const expectedEdges: Edge[] = [
+    [fileIndex("index.html"), entry],
+    ...leaves.map((leaf): Edge => [entry, fileIndex(leaf)]),
+  ];
+  expect(client.edges.sort(byIndex)).toEqual(expectedEdges.sort(byIndex));
+}
+
+// Not concurrent: in debug builds each child spends about two seconds just
+// loading bun:internal-for-testing, and running the four side by side made
+// each of them take over four seconds, close to the default per-test timeout.
+describe.skipIf(!hasBakeDebuggingFeatures)("BUN_DUMP_STATE_ON_CRASH", () => {
+  test("dumps the incremental graph when the crash goes through the crash handler", async () => {
+    const { stderr, dumps, contents } = await crash("crash-handler", "1");
+    expect(dumps).toHaveLength(1);
+    expect(stderr).toContain(`Dumped incremental bundler graph to "${dumps[0]}"`);
+    expectDumpToDescribeTheFixture(contents[0]);
+  });
+
+  test("dumps the incremental graph when the crash is a Rust panic", async () => {
+    const { stderr, dumps, contents } = await crash("rust-panic", "1");
+    expect(dumps).toHaveLength(1);
+    expect(stderr).toContain(`Dumped incremental bundler graph to "${dumps[0]}"`);
+    expectDumpToDescribeTheFixture(contents[0]);
+  });
+
+  test("does nothing unless the variable is set", async () => {
+    const { stderr, dumps } = await crash("crash-handler", "0");
+    expect(stderr).not.toContain("Dumped incremental bundler graph");
+    expect(dumps).toEqual([]);
+  });
+
+  test("does not dump a DevServer that was already freed", async () => {
+    const { stderr, dumps } = await crash("after-deinit", "1");
+    expect(stderr).not.toContain("Dumped incremental bundler graph");
+    expect(dumps).toEqual([]);
+  });
+});

--- a/test/bake/dump-state-on-crash.test.ts
+++ b/test/bake/dump-state-on-crash.test.ts
@@ -48,6 +48,10 @@ const fixture = {
         Bun.gc(true);
         await Bun.sleep(10);
       }
+    } else if (mode === "two-servers") {
+      // A second DevServer that never bundled anything, so its dump is
+      // distinguishable from the first one's.
+      Bun.serve({ port: 0, development: true, routes: { "/": html } });
     }
 
     if (mode === "rust-panic") {
@@ -59,9 +63,13 @@ const fixture = {
   `,
 };
 
-const dumpFileName = /^incremental-graph-crash-dump\.\d+\.html$/;
+// The second and later dumps written in the same second get a counter suffix.
+const dumpFileName = /^incremental-graph-crash-dump\.\d+(\.\d+)?\.html$/;
 
-async function crash(mode: "crash-handler" | "rust-panic" | "after-deinit", dumpStateOnCrash: "0" | "1") {
+async function crash(
+  mode: "crash-handler" | "rust-panic" | "after-deinit" | "two-servers",
+  dumpStateOnCrash: "0" | "1",
+) {
   using dir = tempDir("dump-state-on-crash", fixture);
   await using proc = Bun.spawn({
     // The flag makes debug builds print the trace string instead of spawning a symbolizer.
@@ -184,8 +192,8 @@ function expectDumpToDescribeTheFixture(html: string) {
 }
 
 // Not concurrent: in debug builds each child spends about two seconds just
-// loading bun:internal-for-testing, and running the four side by side made
-// each of them take over four seconds, close to the default per-test timeout.
+// loading bun:internal-for-testing, and running these side by side made each
+// of them take over four seconds, close to the default per-test timeout.
 describe.skipIf(!hasBakeDebuggingFeatures)("BUN_DUMP_STATE_ON_CRASH", () => {
   test("dumps the incremental graph when the crash goes through the crash handler", async () => {
     const { stderr, dumps, contents } = await crash("crash-handler", "1");
@@ -199,6 +207,19 @@ describe.skipIf(!hasBakeDebuggingFeatures)("BUN_DUMP_STATE_ON_CRASH", () => {
     expect(dumps).toHaveLength(1);
     expect(stderr).toContain(`Dumped incremental bundler graph to "${dumps[0]}"`);
     expectDumpToDescribeTheFixture(contents[0]);
+  });
+
+  test("every DevServer in the process gets its own dump", async () => {
+    const { stderr, dumps, contents } = await crash("two-servers", "1");
+    expect(dumps).toHaveLength(2);
+    for (const dump of dumps) {
+      expect(stderr).toContain(`Dumped incremental bundler graph to "${dump}"`);
+    }
+    const [bundled, untouched] = contents.sort(
+      (a, b) => decodeDump(b).client.files.length - decodeDump(a).client.files.length,
+    );
+    expectDumpToDescribeTheFixture(bundled);
+    expect(decodeDump(untouched)).toEqual({ client: { files: [], edges: [] }, server: { files: [], edges: [] } });
   });
 
   test("does nothing unless the variable is set", async () => {


### PR DESCRIPTION
### Problem
- `BUN_DUMP_STATE_ON_CRASH=1` does nothing. `test/bake/bake-harness.ts:1971` sets it for every dev server it spawns so that a crashing DevServer leaves a dump of its incremental graph behind, but the only reference to the variable in `src/` is its declaration (`src/bun_core/env_var.rs:258`).
- Cause: the Rust port put the DevServer debugging code (this dump included) behind `#[cfg(feature = "bake_debugging_features")]`, a cargo feature that was never declared (the file carried `#![allow(unexpected_cfgs)]` for it), so it never compiled. #36184 then deleted it as provably dead, together with its only dependencies: the crash handler's pre-crash handler list, `Guarded::try_lock`, and the release-build `Mutex::try_lock` (which it gated to debug builds). The Zig version was gated on `bake_debugging_features` (canary or debug builds); the Rust equivalent, `bun_core::feature_flags::BAKE_DEBUGGING_FEATURES`, exists and is what `dev_server/hmr_socket.rs` already uses.
- #37454 (open) takes the other option and deletes the declaration, noting it would drop that hunk if the feature is wanted back. Whichever of the two lands second needs to drop or rebase that hunk.

### Fix
- `bun_crash_handler`: a `PreCrashHandler` trait with `append_pre_crash_handler` / `remove_pre_crash_handler`, and `run_pre_crash_handlers()`, which runs the registered handlers once per process.
  - It is called from both crash entry points. In the Rust port a DevServer assertion (`debug_assert!`, `unwrap()`, `Output::panic`) reaches the crash handler through the std panic hook (`rust_panic_hook`), while `crash_handler()` itself only sees signals, OOM and the `panic()` test binding. Hooking only `crash_handler()`, as the Zig port had, would skip the crashes the dump exists for.
  - It runs after the report is printed (the Zig version ran hooks first). A handler reads state the crash may have left inconsistent, possibly from another thread; if it crashes too, the re-entrant path prints "panicked during a panic" under the original report instead of replacing it.
  - It takes the list's lock with `try_lock`: the crashing thread may be the one holding it.
- `bun_threading`: `Guarded::try_lock` is restored and `Mutex::try_lock` (plus the two platform externs behind it) is available in release builds again. These are the hunks #36184 removed or gated when the list went away.
- `DevServer`: registers itself in `init` when `BAKE_DEBUGGING_FEATURES` and the variable are set, and unregisters as the first step of `Drop`, so a crash during teardown or after the server is freed never reaches a dead `DevServer`. `has_pre_crash_handler` is only set after registration succeeds, so every `remove` matches an `append`, including on `init`'s error paths.
- `dump_state_due_to_crash` writes `incremental_visualizer.html` to the cwd with `let inlinedData = ...` inserted after the page's inline `<script>` tag, and prints a `note:` naming the file. The file is created with `O_EXCL` as `incremental-graph-crash-dump.<unix seconds>.html`, falling back to a `.1`, `.2`, ... suffix, so several DevServers in one process (they all dump during the same crash) or a restart-on-crash loop do not truncate each other's dumps.
- `write_visualizer_message` ports the serializer for the `'v'` message, written to survive the state a crash can leave behind: each list's count is filled in after its entries are written rather than derived up front (`edges.len() - edges_free_list.len()` could underflow or disagree with what the loop emits), the free list is marked into a per-edge table instead of being rescanned per edge, deleted files are written as a zero-length name as the page expects, and the path scratch buffer is a plain `Box` rather than the thread-local path buffer pool, whose `RefCell` the crash may have interrupted while borrowed.
- The payload is base64-encoded in 3 KiB pieces. Both the Zig code and the deleted port used 4096-byte pieces; 4096 is not a multiple of 3, so each piece ended in `=` padding and `atob` in the page rejects the concatenation of any payload over 4 KiB. The pieces now encode without padding, so they concatenate into one valid string.
- `bun:internal-for-testing` gains `crash_handler.rustPanic()` (a plain `panic!`) so the panic-hook path can be exercised; the existing `panic()` enters `crash_handler()` directly.
- Test: `test/bake/dump-state-on-crash.test.ts`. A fixture starts `Bun.serve` with an HTML route importing 48 modules, fetches it, then crashes through `panic()` or `rustPanic()`. The test decodes the dump the way the page does (`atob`, then the binary format, checking that the payload is consumed exactly) and checks the file set, the route flag on `index.html`, the exact edge set and an empty server graph. Three more cases check that two dev servers in one process produce two distinct dumps (one with the fixture's graph, one empty), and that nothing is written when the variable is `0` or when the DevServer was freed before the crash. The fixture is large enough that the base64 spans several pieces. On the unfixed build the three positive cases fail (no file; `rustPanic` missing) and the two negative ones pass. The freed-edge and half-updated-graph branches of the serializer are not covered: producing them needs a hot reload, or a crash in the middle of a graph update, neither of which this fixture can trigger deterministically. The test is skipped on non-canary release builds, where `BAKE_DEBUGGING_FEATURES` is false (CI builds are canary, `scripts/build/config.ts:892`).
- Other runs: `test/cli/run/run-crash-handler.test.ts` (14 pass, 9 skipped as before); `test/bake/deinitialization.test.ts`; `test/bake/dev/incremental-graph-edge-deletion.test.ts` and `test/bake/dev/vfile.test.ts`, which go through `bake-harness.ts` and therefore now register and unregister the handler; `test/internal/source-lints/`; `cargo clippy` for `bun_runtime`, `bun_crash_handler`, `bun_threading`; `cargo check --release -p bun_threading -p bun_crash_handler` for `x86_64-pc-windows-msvc` and `aarch64-apple-darwin`, which is where the un-gated `try_lock` code is.

### Background
- The bake DevServer is the bundler behind `Bun.serve` in development mode. It keeps every bundled file as a node in two `IncrementalGraph`s (client side and server side) with an edge per import, and updates them incrementally on every change; the dump is a snapshot of those graphs. Removed edges leave their slot in `edges` and go on `edges_free_list`, which is why the serializer has to skip freed slots.
- `src/runtime/bake/incremental_visualizer.html` renders a `'v'` (`MessageId::Visualizer`) message: per side, a list of files (relative path plus six flags) and a list of `(importer, imported)` index pairs. Served from a dev server it subscribes to those messages over the HMR WebSocket; if a global `inlinedData` exists it renders that instead, which is what the crash dump relies on. Nothing has referenced the file since #36184.
- `BAKE_DEBUGGING_FEATURES` (`src/bun_core/feature_flags.rs:135`) is a const that is true in canary and debug builds; it gates the DevServer debugging features, which need further opt-in flags such as this variable.
- Bun has two crash entry points. `crash_handler()` in `src/crash_handler/lib.rs` handles signals, OOM and explicit `panic_impl` calls; `rust_panic_hook` is the `std::panic::set_hook` hook that every Rust `panic!` goes through. Both track a per-thread stage counter, and a crash while the stage is already set prints "panicked during a panic" and aborts.
- `bun_threading::Guarded<T>` is the crate's mutex-plus-value type (the equivalent of `parking_lot::Mutex<T>`); the crash handler already uses one for the report itself. `bun_paths::path_buffer_pool` hands out path-sized scratch buffers from a thread-local `RefCell<Vec<...>>`, which panics if re-entered while borrowed.
