### PR TITLE
bun test: make --hot re-run tests on change by treating it as --watch

### DIFF
--- a/docs/runtime/watch-mode.mdx
+++ b/docs/runtime/watch-mode.mdx
@@ -99,6 +99,11 @@ Use `bun --hot` to enable hot reloading when executing code with Bun. Unlike `--
 bun --hot server.ts
 ```
 
+<Note>
+  `bun test` accepts `--hot` too, but treats it as `--watch`: the test runner always restarts the process when a file
+  changes.
+</Note>
+
 Starting from the entrypoint (`server.ts` in this example), Bun builds a registry of all imported source files (excluding those in `node_modules`) and watches them for changes. When a file changes, Bun performs a "soft reload". All files are re-evaluated, but global state (notably, the `globalThis` object) persists.
 
 ```ts title="server.ts" icon="/icons/typescript.svg"

--- a/docs/test/runtime-behavior.mdx
+++ b/docs/test/runtime-behavior.mdx
@@ -193,25 +193,15 @@ bun test --prefer-offline
 bun test --frozen-lockfile
 ```
 
-## Watch and Hot Reloading
+## Watch Mode
 
-### Watch Mode
-
-With the `--watch` flag, the test runner watches for file changes and re-runs tests.
+With the `--watch` flag, the test runner watches the test files and the files they import, and restarts the run whenever one of them changes.
 
 ```bash terminal icon="terminal"
 bun test --watch
 ```
 
-### Hot Reloading
-
-The `--hot` flag is similar, but more aggressive about preserving state between runs:
-
-```bash terminal icon="terminal"
-bun test --hot
-```
-
-For most tests, use `--watch`: it gives better isolation between runs.
+`bun test --hot` does the same thing. Unlike [`bun --hot`](/runtime/watch-mode#hot-mode) for scripts, the test runner has no in-process hot reloading: every change restarts the process, so no state is carried over between runs.
 
 ## Global Variables
 

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -1048,12 +1048,19 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
             }
         }
 
-        if args.flag(b"--hot") {
+        // The test runner has no in-process reload: a hot reload only
+        // re-evaluates modules, nothing runs the re-collected tests or reports
+        // them. `bun test --hot` is therefore the restart-on-change mode of
+        // `--watch`. Decided here rather than in the test command because
+        // `create_context_data` reads `hot_reload` right after parsing to
+        // become the Windows watcher manager.
+        let hot = args.flag(b"--hot");
+        if hot && cmd != CommandTag::TestCommand {
             ctx.debug.hot_reload = HotReload::Hot;
             if args.flag(b"--no-clear-screen") {
                 let _ = bun_dotenv::HAS_NO_CLEAR_SCREEN_CLI_FLAG.set(true);
             }
-        } else if args.flag(b"--watch") {
+        } else if hot || args.flag(b"--watch") {
             ctx.debug.hot_reload = HotReload::Watch;
 
             // Windows applies this to the watcher child process.

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -2634,28 +2634,17 @@ impl TestCommand {
                 ChangedFilesFilter::init_watch_trigger();
             }
 
-            match vm.hot_reload {
-                jsc::virtual_machine::HotReload::Hot => {
-                    // SAFETY: `vm` is the process-lifetime main-thread VM; it
-                    // outlives the leaked reloader.
-                    unsafe {
-                        jsc::hot_reloader::HotReloader::enable_hot_module_reloading(
-                            std::ptr::from_mut::<VirtualMachine>(vm),
-                            None,
-                        );
-                    }
+            // Argument parsing turns `bun test --hot` into `Watch` as well;
+            // the in-process `HotReloader` has nothing to re-run tests with.
+            if vm.hot_reload == jsc::virtual_machine::HotReload::Watch {
+                // SAFETY: `vm` is the process-lifetime main-thread VM; it
+                // outlives the leaked reloader.
+                unsafe {
+                    jsc::hot_reloader::WatchReloader::enable_hot_module_reloading(
+                        std::ptr::from_mut::<VirtualMachine>(vm),
+                        None,
+                    );
                 }
-                jsc::virtual_machine::HotReload::Watch => {
-                    // SAFETY: `vm` is the process-lifetime main-thread VM; it
-                    // outlives the leaked reloader.
-                    unsafe {
-                        jsc::hot_reloader::WatchReloader::enable_hot_module_reloading(
-                            std::ptr::from_mut::<VirtualMachine>(vm),
-                            None,
-                        );
-                    }
-                }
-                _ => {}
             }
         }
 

--- a/test/cli/hot/watch.test.ts
+++ b/test/cli/hot/watch.test.ts
@@ -48,3 +48,57 @@ describe.todoIf(isBroken && isWindows)("--watch works", async () => {
     });
   }
 });
+
+// The test runner has no in-process reload, so `bun test --hot` restarts the
+// run on change exactly like `--watch` does (it used to run the suite once and
+// exit).
+describe.todoIf(isBroken && isWindows)("bun test re-runs on file change", () => {
+  const testFile = (version: string) =>
+    `import { test } from "bun:test";\ntest("a", () => { console.error("RAN ${version}"); });\n`;
+
+  for (const args of [
+    ["test", "--watch"],
+    ["test", "--hot"],
+    ["--hot", "test"],
+  ]) {
+    test.concurrent(`bun ${args.join(" ")}`, async () => {
+      using dir = tempDir("test-rerun", { "a.test.ts": testFile("v1") });
+      await using proc = spawn({
+        cmd: [bunExe(), ...args, "--no-clear-screen"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdio: ["ignore", "ignore", "pipe"],
+      });
+
+      const reader = proc.stderr.getReader();
+      const decoder = new TextDecoder();
+      let buf = "";
+      async function waitFor(needle: string, from = 0) {
+        while (!buf.slice(from).includes(needle)) {
+          const { value, done } = await reader.read();
+          if (done) {
+            throw new Error(
+              `bun exited with code ${await proc.exited} before printing ${JSON.stringify(needle)}. stderr:\n${buf}`,
+            );
+          }
+          buf += decoder.decode(value, { stream: true });
+        }
+      }
+
+      await waitFor("RAN v1");
+      // The summary is printed after the file was loaded, i.e. after it was
+      // registered with the watcher, so a write from here on is observed.
+      await waitFor("Ran 1 test across 1 file");
+
+      const firstRun = buf.length;
+      await writeFile(join(String(dir), "a.test.ts"), testFile("v2"));
+      await waitFor("RAN v2", firstRun);
+      await waitFor("Ran 1 test across 1 file", firstRun);
+      expect(buf.slice(firstRun)).not.toContain("RAN v1");
+
+      reader.releaseLock();
+      proc.kill();
+      await proc.exited;
+    });
+  }
+});


### PR DESCRIPTION
### Problem
- `bun test --hot` (and `bun --hot test`) runs the suite once and exits 0. The docs (`docs/test/runtime-behavior.mdx`, "Hot Reloading") describe it as re-running tests on save while preserving state; `bun test --watch` on the same files re-runs on every save.
- Cause: `src/runtime/cli/test_command.rs:2637` installs the in-process `HotReloader` for `HotReload::Hot`, but only `HotReload::Watch` keeps the runner alive after the run (`run_event_loop_for_watch`, `test_command.rs:3018`), so the process exits before the watcher can fire.
- Even if it were kept alive, a hot reload ends in `VirtualMachine::reload()` (`src/jsc/VirtualMachine.rs:3804`), which re-evaluates the last loaded module; nothing collects or runs the tests again or prints a summary. The Zig code before the Rust rewrite had the same shape, so this has never worked.

### Fix
- `src/runtime/cli/Arguments.rs`: when the command is `bun test`, `--hot` sets `HotReload::Watch` instead of `HotReload::Hot`. Every other command keeps the existing behavior, including `--hot` winning over `--watch` when both are passed.
- This is done at parse time rather than in the test command because `create_context_data` (`src/runtime/cli/mod.rs`) reads `hot_reload` right after parsing to turn the process into the Windows watcher manager, and the parser is also where crash auto-restart is armed for watch mode. Mapping it there gives `bun test --hot` exactly the `--watch` code path on every platform.
- `src/runtime/cli/test_command.rs`: the `HotReload::Hot` arm is now unreachable for the test command and is removed; only `WatchReloader` is installed.
- Why this rather than a real in-process mode: the test runner has no way to re-run a collected suite and re-print a summary from a reload callback (reporter totals, snapshot state, JUnit, coverage and `--changed` would all need resetting), and a `bun --hot` reload already re-evaluates every module including dependencies, so the only thing an in-process mode could preserve is `globalThis`, which is the opposite of what a test run wants. The flag's own help text ("Enable auto reload in the ... test runner") and the user-visible promise (re-run on save) are both satisfied by the restart mode.
- Docs: `docs/test/runtime-behavior.mdx` no longer describes `--hot` as a separate state-preserving mode; `docs/runtime/watch-mode.mdx` notes that `bun test` treats `--hot` as `--watch`.
- Test: `test/cli/hot/watch.test.ts`, "bun test re-runs on file change", covers `bun test --hot`, `bun --hot test` and `bun test --watch` as a control. It waits for the first run's summary, rewrites the test file, and waits for the new file's output. Both `--hot` cases fail on the unfixed build (`bun exited with code 0 before printing "RAN v2"`) and pass with this change; the `--watch` control passes on both.
- Also run with the change: `test/cli/hot/hot.test.ts`, `test/cli/hot/watch-many-dirs.test.ts`, `test/cli/watch/watch.test.ts`, `test/cli/test/test-changed.test.ts` (includes `--changed --watch`), `test/regression/issue/29524.test.ts`, `test/js/bun/resolve/bun-main-entry-point.test.ts`; all green.
- Behavior change to be aware of: `bun test --hot` used to exit after one run; it now stays up like `--watch`, which is what the flag and docs have always claimed.

### Background
- `HotReload` (`src/options_types/context.rs`) is the runtime's reload mode, set from `--hot` / `--watch` during argument parsing and copied onto the VM. `Watch` restarts the whole process (execve on POSIX; on Windows a parent "watcher manager" process respawns a child) when a watched file changes. `Hot` keeps the process and re-evaluates the entry point through `VirtualMachine::reload()`; it is what `bun --hot server.ts` uses.
- `HotReloader` / `WatchReloader` (`src/jsc/hot_reloader.rs`) are the two flavors of the file watcher thread: both register every loaded module with the OS watcher; on change the first posts a reload task to the JS event loop, the second restarts the process directly.
- The test runner loads each test file as a module and runs the tests it collected right after loading (`TestCommand::run`), so "re-running on change" for tests means loading the files again, which the restart mode does by construction.

<details>
<summary>Repro on the unfixed build</summary>

```sh
mkdir t && cd t
printf 'import { test } from "bun:test";\ntest("a", () => console.log("RAN v1"));\n' > a.test.ts
timeout 10 bun test --hot; echo "exit=$?"      # prints RAN v1, exits 0 immediately
timeout 10 bun test --watch; echo "exit=$?"    # prints RAN v1, killed by timeout (124): stays up and re-runs on save
```

</details>
