### PR TITLE
sql: run onconnect/onclose in the async context the SQL instance was created in

### DIFF
--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -6,6 +6,7 @@ const {
   SQLQueryFlags,
   symbols: { _strings, _values },
 } = require("internal/sql/query");
+const AsyncContextFrame = require("internal/async_context_frame");
 
 declare global {
   interface NumberConstructor {
@@ -660,7 +661,7 @@ abstract class BasePooledConnection<ConnectionHandle extends { close(): void; fl
     try {
       // user code; a throw must not abort the pool bookkeeping below
       if (connectionInfo?.onconnect) {
-        connectionInfo.onconnect(err);
+        AsyncContextFrame.run(this.adapter.callbackAsyncContext, connectionInfo.onconnect, connectionInfo, err);
       }
     } finally {
       this.storedError = err;
@@ -761,7 +762,7 @@ abstract class BasePooledConnection<ConnectionHandle extends { close(): void; fl
     try {
       // user code; a throw must not abort the pool bookkeeping below
       if (connectionInfo?.onclose) {
-        connectionInfo.onclose(err);
+        AsyncContextFrame.run(this.adapter.callbackAsyncContext, connectionInfo.onclose, connectionInfo, err);
       }
     } finally {
       this.state = PooledConnectionState.closed;
@@ -927,9 +928,15 @@ abstract class BaseSQLAdapter<PooledConnection extends BasePooledConnection, Con
   public closed: boolean = false;
   public totalQueries: number = 0;
   public onAllQueriesFinished: (() => void) | null = null;
+  /// AsyncLocalStorage context the SQL instance was created in. onconnect/onclose run
+  /// inside it rather than in whatever context the native callback happens to fire in
+  /// (none for a socket event, the close() caller's when the socket closes synchronously).
+  public readonly callbackAsyncContext: unknown;
 
   constructor(connectionInfo: Bun.SQL.__internal.DefinedPostgresOrMySQLOptions) {
     this.connectionInfo = connectionInfo;
+    this.callbackAsyncContext =
+      connectionInfo.onconnect || connectionInfo.onclose ? AsyncContextFrame.current() : undefined;
     // Slots are filled one at a time in connect()'s pool-start loop, and
     // createPooledConnection can synchronously run user code (for example a
     // function-valued `password`) that re-enters methods scanning this array,

--- a/test/js/sql/sql-onconnect-onclose-throw.test.ts
+++ b/test/js/sql/sql-onconnect-onclose-throw.test.ts
@@ -11,10 +11,17 @@
 // port and the synchronous-failure scenario never dials, so those run
 // everywhere. Each scenario runs in a subprocess because the throwing
 // callback is reported as a process-level uncaughtException.
+//
+// The AsyncLocalStorage section at the end of the file covers the other
+// property of the same two callback invocations: they run in the async
+// context the SQL instance was created in (see that section's comment).
 
+import { SQL } from "bun";
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, describeWithContainer, isDockerEnabled, tempDir } from "harness";
+import { AsyncLocalStorage } from "node:async_hooks";
 import path from "node:path";
+import { closedPort } from "./wire-frames";
 
 // Fixtures that need closedPort() / neverAnsweringServer() run them in the
 // spawned subprocess (not the test process) by importing ./wire-frames via
@@ -275,6 +282,110 @@ for (const [adapter, closedCode] of [
         `onclose: ${closedCode}\nuncaught: boom from onclose\nclosed\nquery rejected: ${closedCode}\n`,
       );
       expect(exitCode).toBe(0);
+    },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// AsyncLocalStorage. onconnect/onclose used to run in whatever context the
+// native callback happened to fire in: none for a socket event (onconnect, a
+// refused or dropped connection), or the close() caller's when a plaintext
+// connection closes synchronously inside close(). They now run in the context
+// the SQL instance was created in: pool connections are opened by whichever
+// query happens to need one (and re-opened on retry) and closed by close(),
+// idle timeouts or the server, so no other context is well defined. Every
+// pool below is driven from a context other than the one it was created in,
+// so an implementation that inherits the caller's context fails these too.
+// ---------------------------------------------------------------------------
+
+const als = new AsyncLocalStorage<string>();
+
+type HookEvent = [hook: "onconnect" | "onclose", store: string | undefined];
+
+/**
+ * `new SQL(...)` inside `als.run(createdIn)` (outside any store when `createdIn` is
+ * undefined), recording the store each hook observes when it fires.
+ */
+function poolCreatedIn(createdIn: string | undefined, url: string) {
+  const events: HookEvent[] = [];
+  const options = {
+    url,
+    max: 1,
+    onconnect() {
+      events.push(["onconnect", als.getStore()]);
+    },
+    onclose() {
+      events.push(["onclose", als.getStore()]);
+    },
+  };
+  const create = () => new SQL(options);
+  const sql = createdIn === undefined ? als.exit(create) : als.run(createdIn, create);
+  return { sql, events };
+}
+
+// describeWithContainer skips itself when no postgres service is reachable, so
+// this block needs no isDockerEnabled() guard.
+describeWithContainer("postgres: AsyncLocalStorage", { image: "postgres_plain" }, container => {
+  test("onconnect and onclose observe the store each pool was created in, not the caller's", async () => {
+    await container.ready;
+    const url = `postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`;
+    const a = poolCreatedIn("created-a", url);
+    const b = poolCreatedIn("created-b", url);
+    try {
+      await als.run("caller", () => Promise.all([a.sql.connect(), b.sql.connect()]));
+    } finally {
+      await als.run("caller", () => Promise.all([a.sql.close(), b.sql.close()]));
+    }
+    expect({ a: a.events, b: b.events }).toStrictEqual({
+      a: [
+        ["onconnect", "created-a"],
+        ["onclose", "created-a"],
+      ],
+      b: [
+        ["onconnect", "created-b"],
+        ["onclose", "created-b"],
+      ],
+    });
+  });
+
+  test("a pool created outside any store does not inherit the caller's store", async () => {
+    await container.ready;
+    const url = `postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`;
+    const { sql, events } = poolCreatedIn(undefined, url);
+    try {
+      await als.run("caller", () => sql.connect());
+    } finally {
+      await als.run("caller", () => sql.close());
+    }
+    expect(events).toStrictEqual([
+      ["onconnect", undefined],
+      ["onclose", undefined],
+    ]);
+  });
+});
+
+// Fault-injection test (a refused connection), see the DO NOT COPY THIS PATTERN
+// note above: anything a real server can produce belongs in describeWithContainer.
+// A refused connection reaches onclose through the connect-failure path rather
+// than through close(), and since nothing has to be listening it also covers
+// the mysql adapter.
+for (const [adapter, scheme, refusedCode] of [
+  ["postgres", "postgres://postgres@127.0.0.1:", "ERR_POSTGRES_CONNECTION_REFUSED"],
+  ["mysql", "mysql://root@127.0.0.1:", "ERR_MYSQL_CONNECTION_REFUSED"],
+] as const) {
+  test.concurrent(
+    `${adapter}: onclose for a refused connection observes the store the pool was created in`,
+    async () => {
+      const { sql, events } = poolCreatedIn("created-in", `${scheme}${await closedPort()}/db`);
+      let code: string | undefined;
+      try {
+        await als.run("caller", () => sql.connect());
+      } catch (err) {
+        code = (err as { code?: string }).code;
+      } finally {
+        await sql.close();
+      }
+      expect({ code, events }).toStrictEqual({ code: refusedCode, events: [["onclose", "created-in"]] });
     },
   );
 }


### PR DESCRIPTION
### Problem
- The `onconnect` / `onclose` options of `new SQL(...)` (postgres and mysql adapters) do not see the `AsyncLocalStorage` store that was active when the instance was created: `onconnect` always runs with `als.getStore() === undefined`, and `onclose` runs with the store of whoever happened to be on the stack when the native callback fired (undefined for a refused or server-closed connection, the `close()` caller's store when a plaintext socket closes synchronously inside `close()`). Awaited query results keep their context; only these two callbacks lose it.
- Cause: `BasePooledConnection.handleConnected` and `#finishClose` in `src/js/internal/sql/shared.ts` call `connectionInfo.onconnect(err)` / `connectionInfo.onclose(err)` directly. Both are reached from the native connection's connect/close callbacks (`PostgresSQLConnection.rs` delivers connect through `queue_microtask`, close through `run_callback`; `JSMySQLConnection.rs` does the same), and nothing on that path carries the user's context.
- Same bug class as #38453 (RedisClient), which leaves `Bun.SQL` out because these callbacks are plain JS options rather than natively stored functions.

### Fix
- `BaseSQLAdapter` (one per `SQL` instance, constructed synchronously inside `new SQL()`) snapshots the current async context frame when `onconnect` or `onclose` is configured; the two call sites invoke the callback through `internal/async_context_frame`'s `run()` with that frame. Arguments and `this` (`sql.options`, as before) are unchanged, and the existing try/finally pool bookkeeping around the calls is untouched.
- Why the creation context: it is the one the callbacks were registered in, which is where every other Bun API that takes a callback option captures (`Bun.spawn`'s `onExit`, timers, `Bun.serve` handlers, and the RedisClient fix in #38453). No other context is well defined for these callbacks: pool connections are opened by whichever query happens to need one and re-opened by retries, and closed by `close()`, idle/lifetime timeouts or the server; before this change the context `onclose` saw even differed between plaintext and TLS connections of the same pool.
- Zero cost when `AsyncLocalStorage` is not in use: the snapshot is `undefined` and `run()` takes its `frame === current` fast path. Nothing is captured at all when neither callback is configured, so a pool without callbacks does not keep the creating request's stores alive.
- Intentionally excluded: the sqlite adapter. Its `onconnect` runs synchronously inside the constructor, so it already observes the creation context, and its `onclose` runs synchronously inside the user's own `close()` call, where no context is lost.
- Verified with the new `AsyncLocalStorage` section of `test/js/sql/sql-onconnect-onclose-throw.test.ts` (the file that already covers these two call sites): two pools created in different stores and driven from a third store each see their own store in both callbacks (real postgres), a pool created outside any store does not pick up the `close()` caller's store (real postgres), and `onclose` for a refused connection sees the creation store for both the postgres and mysql adapters (no server needed, so this part also runs where the containers are not available). With `src/` stashed, the 4 new tests fail (`onconnect` sees `undefined`, `onclose` sees `undefined` or `"caller"`); with the fix, all 9 tests in the file pass.
- Also ran the reporter's script (output below), the neighbouring pool tests (`sql-close-pending-connection`, `sql-connect-error-reporting`, `postgres-failed-connection-resurrection`, `sql-prepare-false`, `postgres-datestyle`, `postgres-simple-query-pipeline`, `wire-frames`, `sqlite-sql`: 279 pass), and a `mock()`-based check that both callbacks still receive the same arguments and `this` as on the release build.

### Background
- Bun implements `AsyncLocalStorage` on top of a single engine slot holding the current context (an array of `[storage, value, ...]` pairs, or `undefined` when no store is active). Promise continuations, timers and native APIs that accept callbacks snapshot this slot when the work is scheduled and reinstall it around the callback. A callback invoked from a native event without such a snapshot runs with whatever the slot contains at that moment, which at the top of an event loop turn is `undefined`.
- `internal/async_context_frame` is the JS-side helper for built-ins that need to do the same thing by hand: `current()` reads the slot, and `run(frame, fn, thisArg, ...args)` installs `frame`, calls `fn`, and restores the previous value (including on throw). `node:http` and `node:http2` already use it the same way for socket-driven callbacks.
- A `Bun.SQL` instance owns one adapter (`PostgresAdapter` / `MySQLAdapter`, both extending `BaseSQLAdapter`), which owns the pool. Pooled connections are created lazily, so the adapter constructor is the only point that runs synchronously inside `new SQL()` and is therefore where the context is captured.

<details>
<summary>Reporter's script, before and after</summary>

```js
import { AsyncLocalStorage } from "node:async_hooks";
import { SQL } from "bun";
const als = new AsyncLocalStorage();
const seen = {};
const sql = await als.run({ tenant: "T1" }, async () => {
  const sql = new SQL(process.argv[2], {
    max: 1,
    onconnect: () => { seen.onconnect = String(JSON.stringify(als.getStore())); },
    onclose: () => { seen.onclose = String(JSON.stringify(als.getStore())); },
  });
  await sql`select 1`;
  seen.afterAwaitQuery = als.getStore();
  return sql;
});
await sql.close();
console.log(JSON.stringify(seen));
```

```
$ bun repro.mjs postgres://...        # 1.4.0
{"onconnect":"undefined","afterAwaitQuery":{"tenant":"T1"},"onclose":"undefined"}

$ bun-debug repro.mjs postgres://...  # this branch
{"onconnect":"{\"tenant\":\"T1\"}","afterAwaitQuery":{"tenant":"T1"},"onclose":"{\"tenant\":\"T1\"}"}
```

The stores are stringified inside the callbacks so that "fired with an empty store" is distinguishable from "never fired".
</details>
