### PR TITLE
bundler: give files imports the same display path as disk files

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -1727,10 +1727,10 @@ impl<'a> LinkerContext<'a> {
                                 .path_with_pretty_initialized(&source.path, arena)
                                 .expect("OOM");
                         }
-                        // Note: `Path::assert_pretty_is_valid` lives on the
-                        // resolver-side `Path<'a>`; the logger `Path` has no
-                        // such debug hook yet.
-                        debug_assert!(source.path.text.as_ptr() != source.path.pretty.as_ptr());
+                        // `pretty` may legitimately alias `text` here: a relative path
+                        // (such as a bare `files` key) relativizes to itself, and
+                        // `dupe_alloc` re-slices it out of `text`.
+                        source.path.assert_pretty_is_valid();
 
                         break 'brk source.path.pretty;
                     } else {

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2253,8 +2253,8 @@ pub mod bv2_impl {
                     &import_record.source_file,
                     &import_record.specifier,
                 ) {
-                    let file_map_result = _file_map_result;
-                    let mut path_primary = file_map_result.path_pair.primary;
+                    let mut file_map_result = _file_map_result;
+                    let path_primary = file_map_result.path_pair.primary;
                     // reshaped for borrowck — `get_or_put` borrows `*self` mutably via
                     // `self.graph`; capture the slot as `*mut u32` so subsequent `self.*` calls
                     // type-check. SAFETY: `path_to_source_index_map(target)` is not mutated again
@@ -2284,8 +2284,13 @@ pub mod bv2_impl {
                                 .loader(unsafe { &(*transpiler).options.loaders })
                                 .unwrap_or(Loader::File);
                         };
-                        // For virtual files, use the path text as-is (no relative path computation needed).
-                        path_primary.pretty = self.arena().alloc_slice_copy(path_primary.text);
+                        // Same display path as `resolve_import_records` gives this file when
+                        // no plugin runs, and as disk files get. `ParseTask::init` reads the
+                        // path back out of `file_map_result`, so write it back there too.
+                        let path_primary = self
+                            .path_with_pretty_initialized(&path_primary, target)
+                            .expect("oom");
+                        file_map_result.path_pair.primary = path_primary;
                         let mut tmp_source = bun_ast::Source {
                             path: path_as_static(&path_primary),
                             contents: std::borrow::Cow::Borrowed(&b""[..]),
@@ -6192,18 +6197,13 @@ pub mod bv2_impl {
                             continue;
                         }
 
-                        // For virtual files, use the path text as-is (no relative path computation needed).
-                        // SAFETY: arena outlives the bundle pass; raw-pointer detour erases the
-                        // `&self` lifetime so the resulting `&'static [u8]` doesn't pin `self`
-                        // (otherwise `path_primary: Path<'static>` forces `&self: 'static`,
-                        // cascading borrow conflicts into every `&mut self` call below).
-                        path_primary.pretty = unsafe {
-                            bun_ptr::detach_lifetime(
-                                self.arena().alloc_slice_copy(path_primary.text),
-                            )
-                        };
+                        // Same display path as a disk file (and as `run_resolver` gives this
+                        // file when a plugin declines it).
+                        path_primary = self
+                            .path_with_pretty_initialized(&path_primary, target)
+                            .expect("oom");
                         import_record.path = path_as_static(&path_primary);
-                        let _ = path_primary.text; // key already interned by get_or_put
+                        // key already interned by get_or_put
                         bun_core::scoped_log!(
                             Bundle,
                             "created ParseTask from FileMap: {}",

--- a/test/bundler/bundler_files.test.ts
+++ b/test/bundler/bundler_files.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, test } from "bun:test";
 import { tempDir } from "harness";
+import { join } from "node:path";
+
+async function buildSummary(result: Awaited<ReturnType<typeof Bun.build>>) {
+  expect(result.success).toBe(true);
+  return {
+    outputs: await Promise.all(result.outputs.map(async output => [output.path, await output.text()])),
+    inputs: result.metafile!.inputs,
+  };
+}
 
 describe("bundler files option", () => {
   test("basic in-memory file bundling", async () => {
@@ -552,6 +561,131 @@ describe("bundler files option", () => {
 
     const output = await result.outputs[0].text();
     expect(output).toContain("from actual-data");
+  });
+
+  test("in-memory import is displayed the same way no matter how it was resolved", async () => {
+    using dir = tempDir("bundler-files-display-path", {
+      "entry.js": `import { x } from "./lib.js"; console.log(x);`,
+    });
+    const libPath = join(String(dir), "lib.js");
+
+    const build = (plugins: Bun.BunPlugin[]) =>
+      Bun.build({
+        entrypoints: [join(String(dir), "entry.js")],
+        files: { [libPath]: `export const x = "lib from memory";` },
+        plugins,
+        metafile: true,
+        naming: "[name]-[hash].[ext]",
+      }).then(buildSummary);
+
+    // Three ways for the import to reach the `files` entry: the bundler's own
+    // resolver, an onResolve plugin that matched the import but declined it,
+    // and an onResolve plugin that returned the key itself.
+    const withoutPlugin = await build([]);
+    const declined = await build([
+      {
+        name: "decline",
+        setup(builder) {
+          builder.onResolve({ filter: /lib\.js$/ }, () => undefined);
+        },
+      },
+    ]);
+    const redirected = await build([
+      {
+        name: "redirect",
+        setup(builder) {
+          builder.onResolve({ filter: /lib\.js$/ }, () => ({ path: libPath, namespace: "file" }));
+        },
+      },
+    ]);
+
+    expect(withoutPlugin.outputs[0][1]).toContain("lib from memory");
+    expect(declined).toEqual(withoutPlugin);
+    expect(redirected).toEqual(withoutPlugin);
+  });
+
+  test("in-memory imports with relative keys are displayed the same way with and without a declining plugin", async () => {
+    using dir = tempDir("bundler-files-relative-key-display-path", {
+      "entry.js": `
+        import { x } from "bare-key.js";
+        import { y } from "./dot-slash-key.js";
+        console.log(x, y);
+      `,
+    });
+
+    const build = (plugins: Bun.BunPlugin[]) =>
+      Bun.build({
+        entrypoints: [join(String(dir), "entry.js")],
+        files: {
+          "bare-key.js": `export const x = "bare";`,
+          "./dot-slash-key.js": `export const y = "dot slash";`,
+        },
+        plugins,
+        metafile: true,
+        naming: "[name]-[hash].[ext]",
+      }).then(buildSummary);
+
+    const withoutPlugin = await build([]);
+    const declined = await build([
+      {
+        name: "decline",
+        setup(builder) {
+          builder.onResolve({ filter: /key\.js$/ }, () => undefined);
+        },
+      },
+    ]);
+
+    expect(withoutPlugin.outputs[0][1]).toContain("dot slash");
+    expect(Object.keys(withoutPlugin.inputs)).toHaveLength(3);
+    expect(declined).toEqual(withoutPlugin);
+  });
+
+  test("overriding a disk file in memory produces the same output as the disk file", async () => {
+    using dir = tempDir("bundler-files-override-output", {
+      "entry.js": `import { x } from "./lib.js"; console.log(x);`,
+      "lib.js": `export const x = "same contents on disk and in memory";`,
+    });
+    const entryPath = join(String(dir), "entry.js");
+    const libPath = join(String(dir), "lib.js");
+    const libContents = await Bun.file(libPath).text();
+
+    const fromDisk = await Bun.build({
+      entrypoints: [entryPath],
+      metafile: true,
+      naming: "[name]-[hash].[ext]",
+    }).then(buildSummary);
+    const fromMemory = await Bun.build({
+      entrypoints: [entryPath],
+      files: { [libPath]: libContents },
+      metafile: true,
+      naming: "[name]-[hash].[ext]",
+    }).then(buildSummary);
+
+    expect(fromDisk.outputs[0][1]).toContain("same contents on disk and in memory");
+    expect(fromMemory).toEqual(fromDisk);
+  });
+
+  test("in-memory import uses the same display path convention as its in-memory entry point", async () => {
+    using dir = tempDir("bundler-files-virtual-metafile", {});
+    const entryPath = join(String(dir), "entry.js");
+    const libPath = join(String(dir), "lib.js");
+
+    const result = await Bun.build({
+      entrypoints: [entryPath],
+      files: {
+        [entryPath]: `import { x } from "./lib.js"; console.log(x);`,
+        [libPath]: `export const x = 1;`,
+      },
+      metafile: true,
+    });
+    expect(result.success).toBe(true);
+
+    const inputs = result.metafile!.inputs;
+    const [entryKey] = Object.keys(inputs).filter(key => key.endsWith("/entry.js"));
+    expect(entryKey).toBeDefined();
+    const libKey = entryKey.replace(/entry\.js$/, "lib.js");
+    expect(Object.keys(inputs).sort()).toEqual([entryKey, libKey].sort());
+    expect(inputs[entryKey].imports.map(record => record.path)).toEqual([libKey]);
   });
 
   test("plugin can provide content for in-memory file via onLoad", async () => {


### PR DESCRIPTION
### Problem

- A module supplied through `Bun.build({ files })` and reached through an `import` is displayed under three different names depending on how the import was resolved. The display name is what ends up in the `// path` comment above the module, in the `metafile` input key and `imports[].path`, and in the chunk's isolated hash, so the hashed output filename changes with it:
  - no plugin involved: the absolute `files` key (`// /tmp/proj/lib.js`, metafile key `/tmp/proj/lib.js`)
  - an `onResolve` plugin matched the import and returned `undefined`: comment still absolute, but the metafile key is relativized and the chunk hash differs from the no-plugin build. Declining is supposed to be a no-op.
  - an `onResolve` plugin returned the key itself, the same file used as an entry point, or the same file read from disk: relative to the working directory (`proj/lib.js`), like every other file.
- So a fully in-memory build lists `../app/entry.js` and `/app/lib.js` side by side in one metafile, and overriding a disk file through `files` changes the output bytes and the hashed filename even when the contents are identical, because the absolute path of the build machine is printed into the bundle.
- Cause: the two FileMap import branches in `src/bundler/bundle_v2.rs` set up `pretty` by hand instead of calling `path_with_pretty_initialized` like the disk, entry point and plugin paths do.
  - `resolve_import_records` (no plugin) copies the absolute key into `pretty`.
  - `run_resolver` (plugin declined) does the same on a local copy of the path and never writes it back into the `resolver::Result`, and `ParseTask::init` reads the path from that result. The parsed source therefore has `pretty` aliasing `text`, which `LinkerContext::generate_isolated_hash` treats as "not initialized" and relativizes in place, after the filename comment was already printed. That is where the hash and metafile key diverge from the no-plugin build.

### Fix

- Both branches now call `path_with_pretty_initialized`, and `run_resolver` writes the result back into the `resolver::Result` that `ParseTask::init` reads. A `files` module gets the same display path as a disk file at the same location, whichever way the import reached it, and no absolute path of the build machine is written into the output.
- This is the convention everything else already follows: `Path::pretty` is documented as the cwd-relative display path, `files` entry points (`enqueue_entry_item`), plugin-resolved paths (`on_resolve`) and disk imports all go through the same function, and `generate_isolated_hash` hashes `pretty` precisely because it is supposed to be location independent. The `files` option keeps working as an override of disk files only if the override is invisible in the output. Builds that did not use a plugin will see the metafile key and filename comment of `files` imports change from the absolute key to the relative form their entry points already used.
- `generate_isolated_hash` asserted `pretty.ptr != text.ptr` after initializing the path. That is not an invariant: a relative `files` key such as `"bare-key.js"` relativizes to itself and `dupe_alloc` re-slices `pretty` out of `text`, so once relative keys take this path too, debug builds tripped the assertion (release builds were unaffected; the recomputation is idempotent). The assertion is replaced with `assert_pretty_is_valid()`, which is the check this code had before the port. #32716 relaxes the same assertion for the entry point version of this situation; its `enqueue_entry_item` change is independent of this PR.
- Tests, in `test/bundler/bundler_files.test.ts`:
  - the same `files` import built with no plugin, with a declining `onResolve` plugin, and with a plugin returning the key produces identical output text, hashed filenames and metafile
  - the same comparison for a bare key and a `./` key (this one also exercises the assertion in debug builds)
  - overriding a disk file through `files` with identical contents produces byte-identical output, filename and metafile to the plain disk build
  - in a fully in-memory build, the import's metafile key sits next to its entry point's key and `imports[].path` matches it
- All four fail on the released build (see below) and pass with this change. `metafile.test.ts`, `bun-build-api.test.ts` and `bundler-plugin-onresolve-entrypoint.test.ts` still pass.

### Background

- `Path` in the bundler carries two strings: `text`, the canonical location used as the identity of the module (for `files`, the map key), and `pretty`, the display form. `pretty` is what is printed in filename comments, used as metafile keys, and hashed into chunk names; for `file`-namespace paths it is made relative to the working directory with forward slashes by `path_with_pretty_initialized`.
- A freshly constructed `Path` has `pretty` pointing at the same bytes as `text`. Several places use that pointer equality as "display path not computed yet" and compute it on the spot, which is why the plugin-declined build ended up relativized late instead of never.
- `FileMap` is the `files` option. `FileMap::resolve` returns a `resolver::Result` for a key, and `ParseTask::init` takes its path from that result, so any display path set up for the module has to be stored back into it.

<details>
<summary>Probe on the released build (1.4.0), same inputs, three ways to reach the import</summary>

```
=== JS entry on disk, lib.js from files ===
no plugin        -> [ "./entry-tzeagbbb.js" ]  inputs: [ "p-FDpfUu/entry.js", "/tmp/p-FDpfUu/lib.js" ]
   comments: // /tmp/p-FDpfUu/lib.js | // p-FDpfUu/entry.js
declining plugin -> [ "./entry-sgda3ws2.js" ]  inputs: [ "p-FDpfUu/entry.js", "p-FDpfUu/lib.js" ]
   comments: // /tmp/p-FDpfUu/lib.js | // p-FDpfUu/entry.js
resolving plugin -> [ "./entry-eyf9vzsd.js" ]  inputs: [ "p-FDpfUu/entry.js", "p-FDpfUu/lib.js" ]
   comments: // p-FDpfUu/lib.js | // p-FDpfUu/entry.js

=== entry and lib both from files ===
no plugin        -> inputs: [ "../app/entry.js", "/app/lib.js" ]
declining plugin -> inputs: [ "../app/entry.js", "../app/lib.js" ]
```

With this change all of the above print `// p-FDpfUu/lib.js`, key the module as `p-FDpfUu/lib.js`, and produce the same hashed filename.

</details>

<details>
<summary>New tests on the released build</summary>

```
(fail) bundler files option > in-memory import is displayed the same way no matter how it was resolved
(fail) bundler files option > in-memory imports with relative keys are displayed the same way with and without a declining plugin
(fail) bundler files option > overriding a disk file in memory produces the same output as the disk file
(fail) bundler files option > in-memory import uses the same display path convention as its in-memory entry point
 23 pass
 4 fail
```

</details>
