### PR TITLE
css: keep later physical declarations ahead of compiled logical ones

### DIFF
--- a/src/css/context.rs
+++ b/src/css/context.rs
@@ -3,6 +3,7 @@ use crate::css_parser as css;
 use css::css_rules::media::MediaRule;
 
 use css::css_properties::custom::UnparsedProperty;
+use css::css_properties::text::Direction;
 use css::media_query::{MediaCondition, MediaFeature, MediaFeatureId, MediaList, MediaQuery};
 
 use bun_alloc::{Arena as Bump, ArenaPtr};
@@ -78,6 +79,16 @@ impl<'a> PropertyHandlerContext<'a> {
     pub(crate) fn add_logical_rule(&mut self, ltr: css::Property, rtl: css::Property) {
         self.ltr.push(ltr);
         self.rtl.push(rtl);
+    }
+
+    /// Adds a declaration to the rule generated for one text direction only. Used when the
+    /// declaration the other direction would get is overridden by a later physical declaration in
+    /// the rule being minified.
+    pub(crate) fn add_directional_rule(&mut self, direction: Direction, property: css::Property) {
+        match direction {
+            Direction::Ltr => self.ltr.push(property),
+            Direction::Rtl => self.rtl.push(property),
+        }
     }
 
     pub(crate) fn should_compile_logical(&self, feature: css::compat::Feature) -> bool {
@@ -157,21 +168,11 @@ impl<'a> PropertyHandlerContext<'a> {
         let mut dest: Vec<css::CssRule<T>> = Vec::new();
 
         if !self.ltr.is_empty() {
-            self.get_additional_rules_helper(
-                css::selector::parser::Direction::Ltr,
-                &self.ltr,
-                style_rule,
-                &mut dest,
-            );
+            self.get_additional_rules_helper(Direction::Ltr, &self.ltr, style_rule, &mut dest);
         }
 
         if !self.rtl.is_empty() {
-            self.get_additional_rules_helper(
-                css::selector::parser::Direction::Rtl,
-                &self.rtl,
-                style_rule,
-                &mut dest,
-            );
+            self.get_additional_rules_helper(Direction::Rtl, &self.rtl, style_rule, &mut dest);
         }
 
         if !self.dark.is_empty() {
@@ -229,7 +230,7 @@ impl<'a> PropertyHandlerContext<'a> {
     // Takes the Direction value and a borrow of the decls Vec directly.
     pub(crate) fn get_additional_rules_helper<T>(
         &self,
-        dir: css::selector::parser::Direction,
+        dir: Direction,
         decls: &[css::Property],
         sty: &css::StyleRule<T>,
         dest: &mut Vec<css::CssRule<T>>,

--- a/src/css/context.rs
+++ b/src/css/context.rs
@@ -81,9 +81,7 @@ impl<'a> PropertyHandlerContext<'a> {
         self.rtl.push(rtl);
     }
 
-    /// Adds a declaration to the rule generated for one text direction only. Used when the
-    /// declaration the other direction would get is overridden by a later physical declaration in
-    /// the rule being minified.
+    /// For a compiled logical value whose other direction a later physical declaration overrides.
     pub(crate) fn add_directional_rule(&mut self, direction: Direction, property: css::Property) {
         match direction {
             Direction::Ltr => self.ltr.push(property),

--- a/src/css/properties/border.rs
+++ b/src/css/properties/border.rs
@@ -1615,9 +1615,7 @@ mod border_handler_body {
             self.border_radius_handler.finalize(dest, context);
         }
 
-        /// Keeps compiled logical values buffered under the physical one, for
-        /// `flush_overridden_inline`. Every arm storing a physical value records the physical
-        /// category, so the reverse never happens.
+        /// Sound because every arm storing a physical value also records the physical category.
         fn keeps_logical_buffered(
             &self,
             incoming: PropertyCategory,
@@ -1648,8 +1646,7 @@ mod border_handler_body {
             declared
         }
 
-        /// Before an unparsed declaration setting `declared` is written out: inline values being
-        /// compiled away stay buffered and what was written out ahead of them is recorded instead.
+        /// For an unparsed declaration setting `declared`, which then overrides like a buffered one.
         fn flush_before_unparsed(
             &mut self,
             declared: BorderProperty,

--- a/src/css/properties/border.rs
+++ b/src/css/properties/border.rs
@@ -610,13 +610,11 @@ pub struct BorderHandler {
     border_block_end: BorderShorthand,
     border_inline_start: BorderShorthand,
     border_inline_end: BorderShorthand,
-    /// Unparsed inline logical declarations (`border-inline-start: var(--b)`), held back while
-    /// logical borders are compiled away for the same reason parsed logical values are held in
-    /// the `BorderShorthand`s above: a physical declaration following them may override one of
-    /// the directions they compile to. Written out by `flush_logical`.
+    /// Unparsed inline declarations, held back like the parsed ones while logical borders are
+    /// compiled away.
     unparsed_inline: Vec<UnparsedProperty>,
-    /// Physical left/right sub-properties written out while the inline values above stayed
-    /// buffered (see `flush_before_unparsed`). Consumed by the next `flush`.
+    /// Left/right sub-properties written out by `flush_before_unparsed` while the inline values
+    /// stayed buffered.
     declared_after_inline: BorderProperty,
     category: PropertyCategory,
     border_image_handler: BorderImageHandler,
@@ -1227,15 +1225,8 @@ mod border_handler_body {
     }};
 }
 
-    /// Runs ahead of `flush_category!` when logical borders are compiled away. Each inline value
-    /// that differs between the two sides normally becomes one declaration in the ltr rule and one
-    /// in the rtl rule (`fc_logical_prop!`); those rules are appended after the rule being
-    /// minified and override everything declared in it. `declared` holds the physical
-    /// left/right sub-properties declared after the buffered logical values (see
-    /// `BorderHandler::keeps_logical_buffered`). In the direction where an inline side maps onto
-    /// one of them, the later physical declaration is what the source resolves to, so the
-    /// affected values are taken out of the normal flush here and written out for the other
-    /// direction only.
+    /// The ltr/rtl rules are appended after this rule and override it: a value mapping onto a
+    /// later `declared` side is taken away from `flush_category!` and only gets the other one.
     #[inline(never)]
     fn flush_overridden_inline(
         f: &mut FlushContext,
@@ -1250,9 +1241,7 @@ mod border_handler_body {
                 if left_declared || right_declared {
                     match (inline_start.$key.take(), inline_end.$key.take()) {
                         (Some(start), Some(end)) if css::generic::eql(&start, &end) => {
-                            // The same value on both sides does not depend on the direction, so
-                            // it goes into the rule itself, ahead of the physical values declared
-                            // after it.
+                            // Direction independent, so it stays in this rule.
                             if !left_declared {
                                 fc_prop!(f, $Left, start);
                             }
@@ -1261,10 +1250,8 @@ mod border_handler_body {
                             }
                         }
                         (start, end) => {
-                            // inline-start is the left side in ltr text and the right side in
-                            // rtl text; inline-end the other way around. At least one of the two
-                            // sides was declared later, so each value has at most one direction
-                            // left.
+                            // inline-start is left in ltr text and right in rtl text, inline-end
+                            // the other way around; one of the two sides was declared later.
                             if let Some(value) = start {
                                 if !left_declared {
                                     ctx_add_directional_with(f.ctx, Direction::Ltr, || {
@@ -1316,9 +1303,7 @@ mod border_handler_body {
         );
     }
 
-    /// The physical properties an inline logical border property compiles to, as
-    /// `(ltr, rtl)`: inline-start is the left side in ltr text and the right side in rtl text,
-    /// inline-end the other way around.
+    /// The physical properties an inline logical property compiles to in ltr and in rtl text.
     fn compiled_inline_targets(property_id: PropertyIdTag) -> Option<(PropertyId, PropertyId)> {
         use PropertyIdTag as P;
         Some(match property_id {
@@ -1340,10 +1325,8 @@ mod border_handler_body {
         })
     }
 
-    /// Writes out an unparsed inline logical declaration held back by `flush_unparsed` into the
-    /// ltr and rtl rules, except for a direction in which everything it sets was declared again
-    /// afterwards (`declared`, see `flush_overridden_inline`). An unparsed value cannot be split,
-    /// so one that a later declaration overrides only partially is still written out whole.
+    /// As `flush_overridden_inline`, for a declaration held back by `flush_unparsed`. It cannot be
+    /// split, so a direction is only left out when everything it sets there was declared later.
     #[inline(never)]
     fn flush_unparsed_inline(
         unparsed: &UnparsedProperty,
@@ -1386,8 +1369,6 @@ mod border_handler_body {
                         self.flush(dest, context);
                     }
 
-                    // A value containing syntax that isn't supported across all targets keeps
-                    // the previous value as a fallback.
                     if let Some(existing) = &self.$key.$prop
                         && !existing.eql($val)
                         && let Some(browsers) = &context.targets.browsers
@@ -1634,13 +1615,9 @@ mod border_handler_body {
             self.border_radius_handler.finalize(dest, context);
         }
 
-        /// Whether a physical value arriving while logical ones are buffered leaves them buffered
-        /// instead of flushing them. That is done when the logical values are compiled away
-        /// anyway: `flush` then knows which physical sub-properties were declared after them and
-        /// leaves those out of the ltr/rtl rules, which would otherwise override the physical
-        /// value (see `flush_overridden_inline`). Every arm that stores a physical value records
-        /// the physical category, so a logical value arriving afterwards still flushes first and
-        /// physical values are never buffered ahead of logical ones.
+        /// Keeps compiled logical values buffered under the physical one, for
+        /// `flush_overridden_inline`. Every arm storing a physical value records the physical
+        /// category, so the reverse never happens.
         fn keeps_logical_buffered(
             &self,
             incoming: PropertyCategory,
@@ -1651,8 +1628,6 @@ mod border_handler_body {
                 && context.should_compile_logical(Feature::LogicalBorders)
         }
 
-        /// The physical left/right sub-properties currently buffered. They can only be buffered
-        /// alongside inline values that were declared before them (see `keeps_logical_buffered`).
         fn buffered_physical_inline(&self) -> BorderProperty {
             let mut declared = BorderProperty::empty();
             macro_rules! side {
@@ -1673,13 +1648,8 @@ mod border_handler_body {
             declared
         }
 
-        /// Flushes ahead of an unparsed declaration, which is written out directly instead of
-        /// being buffered; `declared` holds the properties it sets. Normally everything buffered
-        /// is flushed so that it ends up ahead of that declaration. Inline values that are
-        /// compiled away don't go into the rule itself, though, so when the declaration sets a
-        /// physical left/right property those stay buffered and the physical sub-properties
-        /// written out ahead of them are recorded instead: the declaration then overrides them
-        /// exactly like a buffered physical value does.
+        /// Before an unparsed declaration setting `declared` is written out: inline values being
+        /// compiled away stay buffered and what was written out ahead of them is recorded instead.
         fn flush_before_unparsed(
             &mut self,
             declared: BorderProperty,
@@ -1708,8 +1678,6 @@ mod border_handler_body {
             self.unparsed_inline = unparsed_inline;
             self.declared_after_inline = declared_after_inline;
             self.has_any = true;
-            // Same state as after buffering a physical value: further physical values are added
-            // to the buffer, a logical one flushes first.
             self.category = PropertyCategory::Physical;
         }
 
@@ -1721,10 +1689,8 @@ mod border_handler_body {
 
             self.has_any = false;
 
-            // Physical values are only buffered together with logical ones when they were declared
-            // after them, so the logical values go first: the block ones (and inline ones equal on
-            // both sides) land in this same rule, where source order decides. It also lets
-            // `flush_logical` see which physical values are buffered before they are taken out.
+            // Logical values first: any physical value buffered with them was declared later, and
+            // `flush_logical` needs to see it before `flush_physical` takes it.
             self.flush_logical(declared_after_inline, dest, context);
             self.flush_physical(dest, context);
 
@@ -1802,7 +1768,7 @@ mod border_handler_body {
 
             let arena = dest.bump();
 
-            // Held back before anything buffered below was declared, so they go first.
+            // Older than anything buffered below.
             for unparsed in self.unparsed_inline.drain(..) {
                 flush_unparsed_inline(&unparsed, declared, arena, context);
             }
@@ -1883,9 +1849,7 @@ mod border_handler_body {
 
             match unparsed.property_id.tag() {
                 property_id if compiled_inline_targets(property_id).is_some() => {
-                    // Held back like a parsed inline value (see `keeps_logical_buffered`); the
-                    // flush that preceded this call keeps an earlier value of the same property
-                    // ahead of it as a fallback.
+                    // The flush before this call wrote out any earlier value of the property.
                     self.unparsed_inline.push(unparsed.deep_clone(arena));
                     self.category = PropertyCategory::Logical;
                     self.has_any = true;

--- a/src/css/properties/border.rs
+++ b/src/css/properties/border.rs
@@ -610,11 +610,9 @@ pub struct BorderHandler {
     border_block_end: BorderShorthand,
     border_inline_start: BorderShorthand,
     border_inline_end: BorderShorthand,
-    /// Unparsed inline declarations, held back like the parsed ones while logical borders are
-    /// compiled away.
+    /// Unparsed inline declarations, held back like the parsed ones while logical borders compile.
     unparsed_inline: Vec<UnparsedProperty>,
-    /// Left/right sub-properties written out by `flush_before_unparsed` while the inline values
-    /// stayed buffered.
+    /// Sub-properties `flush_before_unparsed` wrote out while the inline values stayed buffered.
     declared_after_inline: BorderProperty,
     category: PropertyCategory,
     border_image_handler: BorderImageHandler,
@@ -1225,8 +1223,7 @@ mod border_handler_body {
     }};
 }
 
-    /// The ltr/rtl rules are appended after this rule and override it: a value mapping onto a
-    /// later `declared` side is taken away from `flush_category!` and only gets the other one.
+    /// The ltr/rtl rules override this rule, so the direction of a `declared` side is left out.
     #[inline(never)]
     fn flush_overridden_inline(
         f: &mut FlushContext,
@@ -1250,8 +1247,7 @@ mod border_handler_body {
                             }
                         }
                         (start, end) => {
-                            // inline-start is left in ltr text and right in rtl text, inline-end
-                            // the other way around; one of the two sides was declared later.
+                            // One side was declared later, so at most one direction is left.
                             if let Some(value) = start {
                                 if !left_declared {
                                     ctx_add_directional_with(f.ctx, Direction::Ltr, || {
@@ -1325,8 +1321,7 @@ mod border_handler_body {
         })
     }
 
-    /// As `flush_overridden_inline`, for a declaration held back by `flush_unparsed`. It cannot be
-    /// split, so a direction is only left out when everything it sets there was declared later.
+    /// Unsplittable: a direction is only left out if everything it sets there was declared later.
     #[inline(never)]
     fn flush_unparsed_inline(
         unparsed: &UnparsedProperty,
@@ -1646,7 +1641,7 @@ mod border_handler_body {
             declared
         }
 
-        /// For an unparsed declaration setting `declared`, which then overrides like a buffered one.
+        /// For an unparsed declaration setting `declared`; it then overrides like a buffered one.
         fn flush_before_unparsed(
             &mut self,
             declared: BorderProperty,
@@ -1686,8 +1681,7 @@ mod border_handler_body {
 
             self.has_any = false;
 
-            // Logical values first: any physical value buffered with them was declared later, and
-            // `flush_logical` needs to see it before `flush_physical` takes it.
+            // Logical first: the physical values came later, and `flush_logical` reads them.
             self.flush_logical(declared_after_inline, dest, context);
             self.flush_physical(dest, context);
 

--- a/src/css/properties/border.rs
+++ b/src/css/properties/border.rs
@@ -1380,24 +1380,18 @@ mod border_handler_body {
 
             macro_rules! flush_helper {
                 ($key:ident, $prop:ident, $val:expr, $category:expr) => {{
-                    // A value containing syntax that isn't supported across all targets keeps
-                    // the previous value as a fallback.
-                    let browsers = context.targets.browsers;
-                    let needs_fallback = || {
-                        browsers
-                            .as_ref()
-                            .is_some_and(|browsers| !css::generic::is_compatible($val, browsers))
-                    };
-
                     if $category != self.category
-                        && !(self.keeps_logical_buffered($category, context) && !needs_fallback())
+                        && !self.keeps_logical_buffered($category, context)
                     {
                         self.flush(dest, context);
                     }
 
+                    // A value containing syntax that isn't supported across all targets keeps
+                    // the previous value as a fallback.
                     if let Some(existing) = &self.$key.$prop
                         && !existing.eql($val)
-                        && needs_fallback()
+                        && let Some(browsers) = &context.targets.browsers
+                        && !css::generic::is_compatible($val, browsers)
                     {
                         self.flush(dest, context);
                     }

--- a/src/css/properties/border.rs
+++ b/src/css/properties/border.rs
@@ -1356,6 +1356,19 @@ mod border_handler_body {
 
             // Helper macros.
 
+            // The buffered block side that, compiled, lands on a physical side.
+            macro_rules! compiled_block_side {
+                (border_top) => {
+                    Some(&self.border_block_start)
+                };
+                (border_bottom) => {
+                    Some(&self.border_block_end)
+                };
+                ($key:ident) => {
+                    None::<&BorderShorthand>
+                };
+            }
+
             macro_rules! flush_helper {
                 ($key:ident, $prop:ident, $val:expr, $category:expr) => {{
                     if $category != self.category
@@ -1364,11 +1377,19 @@ mod border_handler_body {
                         self.flush(dest, context);
                     }
 
-                    if let Some(existing) = &self.$key.$prop
-                        && !existing.eql($val)
-                        && let Some(browsers) = &context.targets.browsers
-                        && !css::generic::is_compatible($val, browsers)
-                    {
+                    // The previous value of the property stays ahead of a value some target rejects.
+                    let previous = self.$key.$prop.as_ref().or_else(|| {
+                        compiled_block_side!($key)
+                            .filter(|_| context.should_compile_logical(Feature::LogicalBorders))
+                            .and_then(|side| side.$prop.as_ref())
+                    });
+                    let needs_fallback = previous.is_some_and(|existing| {
+                        !existing.eql($val)
+                            && context.targets.browsers.as_ref().is_some_and(|browsers| {
+                                !css::generic::is_compatible($val, browsers)
+                            })
+                    });
+                    if needs_fallback {
                         self.flush(dest, context);
                     }
                 }};

--- a/src/css/properties/border.rs
+++ b/src/css/properties/border.rs
@@ -3,6 +3,7 @@ use crate as css;
 use crate::css_properties::custom::UnparsedProperty;
 use crate::css_values::color::{ColorFallbackKind, CssColor};
 use crate::css_values::length::Length;
+use crate::properties::text::Direction;
 use crate::properties::{Property, PropertyId, PropertyIdTag};
 use crate::targets::Browsers;
 use crate::{
@@ -443,6 +444,10 @@ impl BorderShorthand {
         self.width.is_some() && self.style.is_some() && self.color.is_some()
     }
 
+    fn is_empty(&self) -> bool {
+        self.width.is_none() && self.style.is_none() && self.color.is_none()
+    }
+
     /// Generic over the `P` const param so the same `BorderShorthand` data
     /// can populate any of `BorderTop`/`BorderLeft`/.../`Border`.
     fn to_border<const P: u8>(&self, arena: &Bump) -> GenericBorder<LineStyle, P> {
@@ -605,6 +610,14 @@ pub struct BorderHandler {
     border_block_end: BorderShorthand,
     border_inline_start: BorderShorthand,
     border_inline_end: BorderShorthand,
+    /// Unparsed inline logical declarations (`border-inline-start: var(--b)`), held back while
+    /// logical borders are compiled away for the same reason parsed logical values are held in
+    /// the `BorderShorthand`s above: a physical declaration following them may override one of
+    /// the directions they compile to. Written out by `flush_logical`.
+    unparsed_inline: Vec<UnparsedProperty>,
+    /// Physical left/right sub-properties written out while the inline values above stayed
+    /// buffered (see `flush_before_unparsed`). Consumed by the next `flush`.
+    declared_after_inline: BorderProperty,
     category: PropertyCategory,
     border_image_handler: BorderImageHandler,
     border_radius_handler: BorderRadiusHandler,
@@ -636,6 +649,14 @@ mod border_handler_body {
     ) {
         let (a, b) = mk();
         ctx.add_logical_rule(a, b);
+    }
+    #[inline(never)]
+    fn ctx_add_directional_with(
+        ctx: &mut PropertyHandlerContext,
+        direction: Direction,
+        mk: impl FnOnce() -> Property,
+    ) {
+        ctx.add_directional_rule(direction, mk());
     }
 
     struct FlushContext<'a, 'bump, 'ctx> {
@@ -1206,6 +1227,144 @@ mod border_handler_body {
     }};
 }
 
+    /// Runs ahead of `flush_category!` when logical borders are compiled away. Each inline value
+    /// that differs between the two sides normally becomes one declaration in the ltr rule and one
+    /// in the rtl rule (`fc_logical_prop!`); those rules are appended after the rule being
+    /// minified and override everything declared in it. `declared` holds the physical
+    /// left/right sub-properties declared after the buffered logical values (see
+    /// `BorderHandler::keeps_logical_buffered`). In the direction where an inline side maps onto
+    /// one of them, the later physical declaration is what the source resolves to, so the
+    /// affected values are taken out of the normal flush here and written out for the other
+    /// direction only.
+    #[inline(never)]
+    fn flush_overridden_inline(
+        f: &mut FlushContext,
+        declared: BorderProperty,
+        inline_start: &mut BorderShorthand,
+        inline_end: &mut BorderShorthand,
+    ) {
+        macro_rules! split {
+            ($key:ident, $left_flag:ident, $Left:ident, $right_flag:ident, $Right:ident) => {{
+                let left_declared = declared.contains(BorderProperty::$left_flag);
+                let right_declared = declared.contains(BorderProperty::$right_flag);
+                if left_declared || right_declared {
+                    match (inline_start.$key.take(), inline_end.$key.take()) {
+                        (Some(start), Some(end)) if css::generic::eql(&start, &end) => {
+                            // The same value on both sides does not depend on the direction, so
+                            // it goes into the rule itself, ahead of the physical values declared
+                            // after it.
+                            if !left_declared {
+                                fc_prop!(f, $Left, start);
+                            }
+                            if !right_declared {
+                                fc_prop!(f, $Right, end);
+                            }
+                        }
+                        (start, end) => {
+                            // inline-start is the left side in ltr text and the right side in
+                            // rtl text; inline-end the other way around. At least one of the two
+                            // sides was declared later, so each value has at most one direction
+                            // left.
+                            if let Some(value) = start {
+                                if !left_declared {
+                                    ctx_add_directional_with(f.ctx, Direction::Ltr, || {
+                                        Property::$Left(value)
+                                    });
+                                } else if !right_declared {
+                                    ctx_add_directional_with(f.ctx, Direction::Rtl, || {
+                                        Property::$Right(value)
+                                    });
+                                }
+                            }
+                            if let Some(value) = end {
+                                if !right_declared {
+                                    ctx_add_directional_with(f.ctx, Direction::Ltr, || {
+                                        Property::$Right(value)
+                                    });
+                                } else if !left_declared {
+                                    ctx_add_directional_with(f.ctx, Direction::Rtl, || {
+                                        Property::$Left(value)
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
+            }};
+        }
+
+        split!(
+            width,
+            LEFT_WIDTH,
+            BorderLeftWidth,
+            RIGHT_WIDTH,
+            BorderRightWidth
+        );
+        split!(
+            style,
+            LEFT_STYLE,
+            BorderLeftStyle,
+            RIGHT_STYLE,
+            BorderRightStyle
+        );
+        split!(
+            color,
+            LEFT_COLOR,
+            BorderLeftColor,
+            RIGHT_COLOR,
+            BorderRightColor
+        );
+    }
+
+    /// The physical properties an inline logical border property compiles to, as
+    /// `(ltr, rtl)`: inline-start is the left side in ltr text and the right side in rtl text,
+    /// inline-end the other way around.
+    fn compiled_inline_targets(property_id: PropertyIdTag) -> Option<(PropertyId, PropertyId)> {
+        use PropertyIdTag as P;
+        Some(match property_id {
+            P::BorderInlineStart => (PropertyId::BorderLeft, PropertyId::BorderRight),
+            P::BorderInlineStartWidth => {
+                (PropertyId::BorderLeftWidth, PropertyId::BorderRightWidth)
+            }
+            P::BorderInlineStartStyle => {
+                (PropertyId::BorderLeftStyle, PropertyId::BorderRightStyle)
+            }
+            P::BorderInlineStartColor => {
+                (PropertyId::BorderLeftColor, PropertyId::BorderRightColor)
+            }
+            P::BorderInlineEnd => (PropertyId::BorderRight, PropertyId::BorderLeft),
+            P::BorderInlineEndWidth => (PropertyId::BorderRightWidth, PropertyId::BorderLeftWidth),
+            P::BorderInlineEndStyle => (PropertyId::BorderRightStyle, PropertyId::BorderLeftStyle),
+            P::BorderInlineEndColor => (PropertyId::BorderRightColor, PropertyId::BorderLeftColor),
+            _ => return None,
+        })
+    }
+
+    /// Writes out an unparsed inline logical declaration held back by `flush_unparsed` into the
+    /// ltr and rtl rules, except for a direction in which everything it sets was declared again
+    /// afterwards (`declared`, see `flush_overridden_inline`). An unparsed value cannot be split,
+    /// so one that a later declaration overrides only partially is still written out whole.
+    #[inline(never)]
+    fn flush_unparsed_inline(
+        unparsed: &UnparsedProperty,
+        declared: BorderProperty,
+        arena: &Bump,
+        context: &mut PropertyHandlerContext,
+    ) {
+        let Some((ltr, rtl)) = compiled_inline_targets(unparsed.property_id.tag()) else {
+            return;
+        };
+        for (direction, physical) in [(Direction::Ltr, ltr), (Direction::Rtl, rtl)] {
+            let sets = BorderProperty::try_from_property_id(physical.tag()).unwrap();
+            if !declared.contains(sets) {
+                context.add_directional_rule(
+                    direction,
+                    Property::Unparsed(unparsed.with_property_id(arena, physical)),
+                );
+            }
+        }
+    }
+
     impl BorderHandler {
         pub(crate) fn handle_property(
             &mut self,
@@ -1221,20 +1380,26 @@ mod border_handler_body {
 
             macro_rules! flush_helper {
                 ($key:ident, $prop:ident, $val:expr, $category:expr) => {{
-                    if $category != self.category {
+                    // A value containing syntax that isn't supported across all targets keeps
+                    // the previous value as a fallback.
+                    let browsers = context.targets.browsers;
+                    let needs_fallback = || {
+                        browsers
+                            .as_ref()
+                            .is_some_and(|browsers| !css::generic::is_compatible($val, browsers))
+                    };
+
+                    if $category != self.category
+                        && !(self.keeps_logical_buffered($category, context) && !needs_fallback())
+                    {
                         self.flush(dest, context);
                     }
 
-                    if let Some(existing) = &self.$key.$prop {
-                        if !existing.eql($val)
-                            && context.targets.browsers.is_some()
-                            && !css::generic::is_compatible(
-                                $val,
-                                &context.targets.browsers.unwrap(),
-                            )
-                        {
-                            self.flush(dest, context);
-                        }
+                    if let Some(existing) = &self.$key.$prop
+                        && !existing.eql($val)
+                        && needs_fallback()
+                    {
+                        self.flush(dest, context);
                     }
                 }};
             }
@@ -1250,7 +1415,9 @@ mod border_handler_body {
 
             macro_rules! set_border_helper {
                 ($key:ident, $val:expr, $category:expr) => {{
-                    if $category != self.category {
+                    if $category != self.category
+                        && !self.keeps_logical_buffered($category, context)
+                    {
                         self.flush(dest, context);
                     }
 
@@ -1424,11 +1591,15 @@ mod border_handler_body {
 
                     // Setting the `border` property resets `border-image`
                     self.border_image_handler.reset();
+                    self.category = Physical;
                     self.has_any = true;
                 }
                 Property::Unparsed(val) => {
-                    if is_border_property(val.property_id.tag()) {
-                        self.flush(dest, context);
+                    let property_id = val.property_id.tag();
+                    if is_border_property(property_id) {
+                        let declared =
+                            BorderProperty::try_from_property_id(property_id).unwrap_or_default();
+                        self.flush_before_unparsed(declared, dest, context);
                         self.flush_unparsed(val, dest, context);
                     } else {
                         if self.border_image_handler.will_flush(property) {
@@ -1469,15 +1640,99 @@ mod border_handler_body {
             self.border_radius_handler.finalize(dest, context);
         }
 
+        /// Whether a physical value arriving while logical ones are buffered leaves them buffered
+        /// instead of flushing them. That is done when the logical values are compiled away
+        /// anyway: `flush` then knows which physical sub-properties were declared after them and
+        /// leaves those out of the ltr/rtl rules, which would otherwise override the physical
+        /// value (see `flush_overridden_inline`). Every arm that stores a physical value records
+        /// the physical category, so a logical value arriving afterwards still flushes first and
+        /// physical values are never buffered ahead of logical ones.
+        fn keeps_logical_buffered(
+            &self,
+            incoming: PropertyCategory,
+            context: &PropertyHandlerContext,
+        ) -> bool {
+            self.category == PropertyCategory::Logical
+                && incoming == PropertyCategory::Physical
+                && context.should_compile_logical(Feature::LogicalBorders)
+        }
+
+        /// The physical left/right sub-properties currently buffered. They can only be buffered
+        /// alongside inline values that were declared before them (see `keeps_logical_buffered`).
+        fn buffered_physical_inline(&self) -> BorderProperty {
+            let mut declared = BorderProperty::empty();
+            macro_rules! side {
+                ($side:expr, $width:ident, $style:ident, $color:ident) => {{
+                    if $side.width.is_some() {
+                        declared |= BorderProperty::$width;
+                    }
+                    if $side.style.is_some() {
+                        declared |= BorderProperty::$style;
+                    }
+                    if $side.color.is_some() {
+                        declared |= BorderProperty::$color;
+                    }
+                }};
+            }
+            side!(self.border_left, LEFT_WIDTH, LEFT_STYLE, LEFT_COLOR);
+            side!(self.border_right, RIGHT_WIDTH, RIGHT_STYLE, RIGHT_COLOR);
+            declared
+        }
+
+        /// Flushes ahead of an unparsed declaration, which is written out directly instead of
+        /// being buffered; `declared` holds the properties it sets. Normally everything buffered
+        /// is flushed so that it ends up ahead of that declaration. Inline values that are
+        /// compiled away don't go into the rule itself, though, so when the declaration sets a
+        /// physical left/right property those stay buffered and the physical sub-properties
+        /// written out ahead of them are recorded instead: the declaration then overrides them
+        /// exactly like a buffered physical value does.
+        fn flush_before_unparsed(
+            &mut self,
+            declared: BorderProperty,
+            dest: &mut DeclarationList,
+            context: &mut PropertyHandlerContext,
+        ) {
+            let keep_inline = declared
+                .intersects(BorderProperty::BORDER_LEFT | BorderProperty::BORDER_RIGHT)
+                && !(self.unparsed_inline.is_empty()
+                    && self.border_inline_start.is_empty()
+                    && self.border_inline_end.is_empty())
+                && context.should_compile_logical(Feature::LogicalBorders);
+            if !keep_inline {
+                self.flush(dest, context);
+                return;
+            }
+
+            let declared_after_inline =
+                self.declared_after_inline | declared | self.buffered_physical_inline();
+            let inline_start = core::mem::take(&mut self.border_inline_start);
+            let inline_end = core::mem::take(&mut self.border_inline_end);
+            let unparsed_inline = core::mem::take(&mut self.unparsed_inline);
+            self.flush(dest, context);
+            self.border_inline_start = inline_start;
+            self.border_inline_end = inline_end;
+            self.unparsed_inline = unparsed_inline;
+            self.declared_after_inline = declared_after_inline;
+            self.has_any = true;
+            // Same state as after buffering a physical value: further physical values are added
+            // to the buffer, a logical one flushes first.
+            self.category = PropertyCategory::Physical;
+        }
+
         fn flush(&mut self, dest: &mut DeclarationList, context: &mut PropertyHandlerContext) {
+            let declared_after_inline = core::mem::take(&mut self.declared_after_inline);
             if !self.has_any {
                 return;
             }
 
             self.has_any = false;
 
+            // Physical values are only buffered together with logical ones when they were declared
+            // after them, so the logical values go first: the block ones (and inline ones equal on
+            // both sides) land in this same rule, where source order decides. It also lets
+            // `flush_logical` see which physical values are buffered before they are taken out.
+            self.flush_logical(declared_after_inline, dest, context);
             self.flush_physical(dest, context);
-            self.flush_logical(dest, context);
 
             let arena = dest.bump();
             self.border_top.reset(arena);
@@ -1541,6 +1796,7 @@ mod border_handler_body {
         #[inline(never)]
         fn flush_logical(
             &mut self,
+            declared_after_inline: BorderProperty,
             dest: &mut DeclarationList,
             context: &mut PropertyHandlerContext,
         ) {
@@ -1548,7 +1804,15 @@ mod border_handler_body {
             let logical_shorthand_supported =
                 !context.should_compile_logical(Feature::LogicalBorderShorthand);
 
+            let declared = declared_after_inline | self.buffered_physical_inline();
+
             let arena = dest.bump();
+
+            // Held back before anything buffered below was declared, so they go first.
+            for unparsed in self.unparsed_inline.drain(..) {
+                flush_unparsed_inline(&unparsed, declared, arena, context);
+            }
+
             let mut flctx = FlushContext {
                 flushed_properties: &mut self.flushed_properties,
                 dest,
@@ -1557,6 +1821,17 @@ mod border_handler_body {
                 logical_supported,
                 logical_shorthand_supported,
             };
+
+            if !logical_supported
+                && declared.intersects(BorderProperty::BORDER_LEFT | BorderProperty::BORDER_RIGHT)
+            {
+                flush_overridden_inline(
+                    &mut flctx,
+                    declared,
+                    &mut self.border_inline_start,
+                    &mut self.border_inline_end,
+                );
+            }
 
             flush_category!(
                 &mut flctx,
@@ -1612,35 +1887,14 @@ mod border_handler_body {
                 }};
             }
 
-            macro_rules! logical_prop {
-                ($ltr:ident, $rtl:ident) => {{
-                    context.add_logical_rule(
-                        Property::Unparsed(unparsed.with_property_id(arena, PropertyId::$ltr)),
-                        Property::Unparsed(unparsed.with_property_id(arena, PropertyId::$rtl)),
-                    );
-                }};
-            }
-
             match unparsed.property_id.tag() {
-                PropertyIdTag::BorderInlineStart => logical_prop!(BorderLeft, BorderRight),
-                PropertyIdTag::BorderInlineStartWidth => {
-                    logical_prop!(BorderLeftWidth, BorderRightWidth)
-                }
-                PropertyIdTag::BorderInlineStartColor => {
-                    logical_prop!(BorderLeftColor, BorderRightColor)
-                }
-                PropertyIdTag::BorderInlineStartStyle => {
-                    logical_prop!(BorderLeftStyle, BorderRightStyle)
-                }
-                PropertyIdTag::BorderInlineEnd => logical_prop!(BorderRight, BorderLeft),
-                PropertyIdTag::BorderInlineEndWidth => {
-                    logical_prop!(BorderRightWidth, BorderLeftWidth)
-                }
-                PropertyIdTag::BorderInlineEndColor => {
-                    logical_prop!(BorderRightColor, BorderLeftColor)
-                }
-                PropertyIdTag::BorderInlineEndStyle => {
-                    logical_prop!(BorderRightStyle, BorderLeftStyle)
+                property_id if compiled_inline_targets(property_id).is_some() => {
+                    // Held back like a parsed inline value (see `keeps_logical_buffered`); the
+                    // flush that preceded this call keeps an earlier value of the same property
+                    // ahead of it as a fallback.
+                    self.unparsed_inline.push(unparsed.deep_clone(arena));
+                    self.category = PropertyCategory::Logical;
+                    self.has_any = true;
                 }
                 PropertyIdTag::BorderBlockStart => prop!(BorderTop),
                 PropertyIdTag::BorderBlockStartWidth => prop!(BorderTopWidth),

--- a/src/css/properties/border_radius.rs
+++ b/src/css/properties/border_radius.rs
@@ -214,7 +214,8 @@ macro_rules! maybe_flush {
 
 macro_rules! property_helper {
     ($self:expr, $d:expr, $ctx:expr, $bump:expr, $prop:ident, $val:expr, $vp:expr) => {{
-        if $self.category != PropertyCategory::Physical && !$self.keeps_logical_buffered($ctx, $val)
+        if $self.category != PropertyCategory::Physical
+            && !BorderRadiusHandler::keeps_logical_buffered($ctx)
         {
             $self.flush($d, $ctx);
         }
@@ -492,19 +493,9 @@ impl BorderRadiusHandler {
     /// instead of flushing them. That is done when the logical corners are compiled away anyway:
     /// `flush` then knows which physical corners were declared after them and leaves those out of
     /// the ltr/rtl rules, which would otherwise override the physical corner (see
-    /// `logical_property!`). A value that needs a fallback flushes as before, so that the buffered
-    /// values are written out ahead of it.
-    fn keeps_logical_buffered(
-        &self,
-        context: &PropertyHandlerContext,
-        val: &Size2D<LengthPercentage>,
-    ) -> bool {
+    /// `logical_property!`).
+    fn keeps_logical_buffered(context: &PropertyHandlerContext) -> bool {
         context.should_compile_logical(css::compat::Feature::LogicalBorderRadius)
-            && context
-                .targets
-                .browsers
-                .as_ref()
-                .is_none_or(|browsers| size2d_lp_is_compatible(val, browsers))
     }
 
     /// Flushes ahead of an unparsed physical declaration, which is written out directly instead

--- a/src/css/properties/border_radius.rs
+++ b/src/css/properties/border_radius.rs
@@ -260,8 +260,7 @@ macro_rules! single_property {
     }};
 }
 
-// The ltr/rtl rules are appended after this rule and override it, so a direction whose physical
-// corner was declared later (`$ltr_declared` / `$rtl_declared`) gets nothing.
+// The ltr/rtl rules override this rule: a direction whose corner was declared later gets nothing.
 macro_rules! logical_property {
     (
         $d:expr, $ctx:expr, $bump:expr, $val:expr, $ltr:ident, $rtl:ident, $logical_supported:expr,

--- a/src/css/properties/border_radius.rs
+++ b/src/css/properties/border_radius.rs
@@ -149,8 +149,7 @@ pub struct BorderRadiusHandler {
     pub(crate) start_end: Option<Property>,
     pub(crate) end_end: Option<Property>,
     pub(crate) end_start: Option<Property>,
-    /// Physical corners written out while the logical corners above stayed buffered (see
-    /// `flush_before_unparsed`). Consumed by the next `flush`.
+    /// Corners written out by `flush_before_unparsed` while the logical corners stayed buffered.
     declared_after_logical: DeclaredCorners,
     // derive(Default) is sound here because
     // PropertyCategory::default() == Physical (see src/css/logical.rs).
@@ -158,7 +157,7 @@ pub struct BorderRadiusHandler {
     pub(crate) has_any: bool,
 }
 
-/// Physical corners set by declarations that came after the buffered logical corners.
+/// Physical corners declared after the buffered logical corners.
 #[derive(Copy, Clone, Default)]
 struct DeclaredCorners {
     top_left: bool,
@@ -261,11 +260,8 @@ macro_rules! single_property {
     }};
 }
 
-// When the logical corners are compiled away, each becomes one declaration in the ltr rule and
-// one in the rtl rule, which are appended after the rule being minified and therefore override
-// everything declared in it. In the direction where the corner maps onto a physical corner
-// declared after it (`$ltr_declared` / `$rtl_declared`), that later declaration is what the
-// source resolves to, so no declaration is generated for that direction.
+// The ltr/rtl rules are appended after this rule and override it, so a direction whose physical
+// corner was declared later (`$ltr_declared` / `$rtl_declared`) gets nothing.
 macro_rules! logical_property {
     (
         $d:expr, $ctx:expr, $bump:expr, $val:expr, $ltr:ident, $rtl:ident, $logical_supported:expr,
@@ -489,21 +485,13 @@ impl BorderRadiusHandler {
         self.flush(dest, context);
     }
 
-    /// Whether a physical corner arriving while logical corners are buffered leaves them buffered
-    /// instead of flushing them. That is done when the logical corners are compiled away anyway:
-    /// `flush` then knows which physical corners were declared after them and leaves those out of
-    /// the ltr/rtl rules, which would otherwise override the physical corner (see
-    /// `logical_property!`).
+    /// Keeps compiled logical corners buffered under the physical one for `logical_property!`.
     fn keeps_logical_buffered(context: &PropertyHandlerContext) -> bool {
         context.should_compile_logical(css::compat::Feature::LogicalBorderRadius)
     }
 
-    /// Flushes ahead of an unparsed physical declaration, which is written out directly instead
-    /// of being buffered; `declared` holds the corners it sets. Normally everything buffered is
-    /// flushed so that it ends up ahead of that declaration. Logical corners that are compiled
-    /// away don't go into the rule itself, though, so those stay buffered and the physical corners
-    /// written out ahead of them are recorded instead: the declaration then overrides them exactly
-    /// like a buffered physical corner does (see `keeps_logical_buffered`).
+    /// Before an unparsed declaration setting `declared` is written out: logical corners being
+    /// compiled away stay buffered and what was written out ahead of them is recorded instead.
     fn flush_before_unparsed(
         &mut self,
         declared: DeclaredCorners,
@@ -540,8 +528,6 @@ impl BorderRadiusHandler {
         self.end_start = end_start;
         self.declared_after_logical = declared_after_logical;
         self.has_any = true;
-        // Same state as after buffering a physical corner: further physical corners are added to
-        // the buffer, a logical one flushes first.
         self.category = PropertyCategory::Physical;
     }
 
@@ -562,8 +548,7 @@ impl BorderRadiusHandler {
         let end_end = self.end_end.take();
         let end_start = self.end_start.take();
 
-        // Physical corners are only buffered together with logical ones when they were declared
-        // after them (see `keeps_logical_buffered`).
+        // Any physical corner buffered alongside logical ones was declared after them.
         let declared = declared_after_logical.or(DeclaredCorners {
             top_left: top_left.is_some(),
             top_right: top_right.is_some(),
@@ -608,8 +593,7 @@ impl BorderRadiusHandler {
         single_property!(dest, context, BorderBottomRightRadius, bottom_right);
         single_property!(dest, context, BorderBottomLeftRadius, bottom_left);
 
-        // The start-* corners are at the top and the *-start corners on the left in ltr text;
-        // in rtl text the *-start corners are on the right.
+        // *-start corners are on the left in ltr text and on the right in rtl text.
         logical_property!(
             dest,
             context,

--- a/src/css/properties/border_radius.rs
+++ b/src/css/properties/border_radius.rs
@@ -490,8 +490,7 @@ impl BorderRadiusHandler {
         context.should_compile_logical(css::compat::Feature::LogicalBorderRadius)
     }
 
-    /// Before an unparsed declaration setting `declared` is written out: logical corners being
-    /// compiled away stay buffered and what was written out ahead of them is recorded instead.
+    /// For an unparsed declaration setting `declared`, which then overrides like a buffered value.
     fn flush_before_unparsed(
         &mut self,
         declared: DeclaredCorners,

--- a/src/css/properties/border_radius.rs
+++ b/src/css/properties/border_radius.rs
@@ -5,6 +5,7 @@ use crate::Printer;
 use crate::PropertyCategory;
 use crate::PropertyHandlerContext;
 use crate::VendorPrefix;
+use crate::css_properties::text::Direction;
 use crate::css_properties::{Property, PropertyId, PropertyIdTag};
 use crate::css_values::length::LengthPercentage;
 use crate::css_values::rect::Rect;
@@ -148,10 +149,33 @@ pub struct BorderRadiusHandler {
     pub(crate) start_end: Option<Property>,
     pub(crate) end_end: Option<Property>,
     pub(crate) end_start: Option<Property>,
+    /// Physical corners written out while the logical corners above stayed buffered (see
+    /// `flush_before_unparsed`). Consumed by the next `flush`.
+    declared_after_logical: DeclaredCorners,
     // derive(Default) is sound here because
     // PropertyCategory::default() == Physical (see src/css/logical.rs).
     pub(crate) category: PropertyCategory,
     pub(crate) has_any: bool,
+}
+
+/// Physical corners set by declarations that came after the buffered logical corners.
+#[derive(Copy, Clone, Default)]
+struct DeclaredCorners {
+    top_left: bool,
+    top_right: bool,
+    bottom_right: bool,
+    bottom_left: bool,
+}
+
+impl DeclaredCorners {
+    fn or(self, other: Self) -> Self {
+        Self {
+            top_left: self.top_left || other.top_left,
+            top_right: self.top_right || other.top_right,
+            bottom_right: self.bottom_right || other.bottom_right,
+            bottom_left: self.bottom_left || other.bottom_left,
+        }
+    }
 }
 
 // There is no field-by-name reflection, so these helpers are
@@ -190,7 +214,8 @@ macro_rules! maybe_flush {
 
 macro_rules! property_helper {
     ($self:expr, $d:expr, $ctx:expr, $bump:expr, $prop:ident, $val:expr, $vp:expr) => {{
-        if $self.category != PropertyCategory::Physical {
+        if $self.category != PropertyCategory::Physical && !$self.keeps_logical_buffered($ctx, $val)
+        {
             $self.flush($d, $ctx);
         }
 
@@ -235,8 +260,16 @@ macro_rules! single_property {
     }};
 }
 
+// When the logical corners are compiled away, each becomes one declaration in the ltr rule and
+// one in the rtl rule, which are appended after the rule being minified and therefore override
+// everything declared in it. In the direction where the corner maps onto a physical corner
+// declared after it (`$ltr_declared` / `$rtl_declared`), that later declaration is what the
+// source resolves to, so no declaration is generated for that direction.
 macro_rules! logical_property {
-    ($d:expr, $ctx:expr, $bump:expr, $val:expr, $ltr:ident, $rtl:ident, $logical_supported:expr) => {{
+    (
+        $d:expr, $ctx:expr, $bump:expr, $val:expr, $ltr:ident, $rtl:ident, $logical_supported:expr,
+        $ltr_declared:expr, $rtl_declared:expr
+    ) => {{
         if let Some(v) = $val {
             if $logical_supported {
                 $d.push(v);
@@ -249,20 +282,36 @@ macro_rules! logical_property {
                     | Property::BorderStartEndRadius(radius)
                     | Property::BorderEndEndRadius(radius)
                     | Property::BorderEndStartRadius(radius) => {
-                        $ctx.add_logical_rule(
-                            Property::$ltr((radius.deep_clone($bump), prefix)),
-                            Property::$rtl((radius, prefix)),
-                        );
+                        if !$ltr_declared {
+                            $ctx.add_directional_rule(
+                                Direction::Ltr,
+                                Property::$ltr((radius.deep_clone($bump), prefix)),
+                            );
+                        }
+                        if !$rtl_declared {
+                            $ctx.add_directional_rule(
+                                Direction::Rtl,
+                                Property::$rtl((radius, prefix)),
+                            );
+                        }
                     }
                     Property::Unparsed(unparsed) => {
-                        $ctx.add_logical_rule(
-                            Property::Unparsed(
-                                unparsed.with_property_id($bump, PropertyId::$ltr(prefix)),
-                            ),
-                            Property::Unparsed(
-                                unparsed.with_property_id($bump, PropertyId::$rtl(prefix)),
-                            ),
-                        );
+                        if !$ltr_declared {
+                            $ctx.add_directional_rule(
+                                Direction::Ltr,
+                                Property::Unparsed(
+                                    unparsed.with_property_id($bump, PropertyId::$ltr(prefix)),
+                                ),
+                            );
+                        }
+                        if !$rtl_declared {
+                            $ctx.add_directional_rule(
+                                Direction::Rtl,
+                                Property::Unparsed(
+                                    unparsed.with_property_id($bump, PropertyId::$rtl(prefix)),
+                                ),
+                            );
+                        }
                     }
                     _ => {}
                 }
@@ -403,8 +452,17 @@ impl BorderRadiusHandler {
                                 Property::Unparsed(unparsed.deep_clone(bump))
                             )
                         }
-                        _ => {
-                            self.flush(dest, context);
+                        physical => {
+                            let all = physical == PropertyIdTag::BorderRadius;
+                            let declared = DeclaredCorners {
+                                top_left: all || physical == PropertyIdTag::BorderTopLeftRadius,
+                                top_right: all || physical == PropertyIdTag::BorderTopRightRadius,
+                                bottom_right: all
+                                    || physical == PropertyIdTag::BorderBottomRightRadius,
+                                bottom_left: all
+                                    || physical == PropertyIdTag::BorderBottomLeftRadius,
+                            };
+                            self.flush_before_unparsed(declared, dest, context);
                             dest.push(Property::Unparsed(unparsed.get_prefixed(
                                 bump,
                                 &context.targets,
@@ -430,7 +488,74 @@ impl BorderRadiusHandler {
         self.flush(dest, context);
     }
 
+    /// Whether a physical corner arriving while logical corners are buffered leaves them buffered
+    /// instead of flushing them. That is done when the logical corners are compiled away anyway:
+    /// `flush` then knows which physical corners were declared after them and leaves those out of
+    /// the ltr/rtl rules, which would otherwise override the physical corner (see
+    /// `logical_property!`). A value that needs a fallback flushes as before, so that the buffered
+    /// values are written out ahead of it.
+    fn keeps_logical_buffered(
+        &self,
+        context: &PropertyHandlerContext,
+        val: &Size2D<LengthPercentage>,
+    ) -> bool {
+        context.should_compile_logical(css::compat::Feature::LogicalBorderRadius)
+            && context
+                .targets
+                .browsers
+                .as_ref()
+                .is_none_or(|browsers| size2d_lp_is_compatible(val, browsers))
+    }
+
+    /// Flushes ahead of an unparsed physical declaration, which is written out directly instead
+    /// of being buffered; `declared` holds the corners it sets. Normally everything buffered is
+    /// flushed so that it ends up ahead of that declaration. Logical corners that are compiled
+    /// away don't go into the rule itself, though, so those stay buffered and the physical corners
+    /// written out ahead of them are recorded instead: the declaration then overrides them exactly
+    /// like a buffered physical corner does (see `keeps_logical_buffered`).
+    fn flush_before_unparsed(
+        &mut self,
+        declared: DeclaredCorners,
+        dest: &mut DeclarationList,
+        context: &mut PropertyHandlerContext,
+    ) {
+        let keep_logical = (self.start_start.is_some()
+            || self.start_end.is_some()
+            || self.end_end.is_some()
+            || self.end_start.is_some())
+            && context.should_compile_logical(css::compat::Feature::LogicalBorderRadius);
+        if !keep_logical {
+            self.flush(dest, context);
+            return;
+        }
+
+        let declared_after_logical = self
+            .declared_after_logical
+            .or(declared)
+            .or(DeclaredCorners {
+                top_left: self.top_left.is_some(),
+                top_right: self.top_right.is_some(),
+                bottom_right: self.bottom_right.is_some(),
+                bottom_left: self.bottom_left.is_some(),
+            });
+        let start_start = self.start_start.take();
+        let start_end = self.start_end.take();
+        let end_end = self.end_end.take();
+        let end_start = self.end_start.take();
+        self.flush(dest, context);
+        self.start_start = start_start;
+        self.start_end = start_end;
+        self.end_end = end_end;
+        self.end_start = end_start;
+        self.declared_after_logical = declared_after_logical;
+        self.has_any = true;
+        // Same state as after buffering a physical corner: further physical corners are added to
+        // the buffer, a logical one flushes first.
+        self.category = PropertyCategory::Physical;
+    }
+
     fn flush(&mut self, dest: &mut DeclarationList, context: &mut PropertyHandlerContext) {
+        let declared_after_logical = core::mem::take(&mut self.declared_after_logical);
         if !self.has_any {
             return;
         }
@@ -445,6 +570,15 @@ impl BorderRadiusHandler {
         let start_end = self.start_end.take();
         let end_end = self.end_end.take();
         let end_start = self.end_start.take();
+
+        // Physical corners are only buffered together with logical ones when they were declared
+        // after them (see `keeps_logical_buffered`).
+        let declared = declared_after_logical.or(DeclaredCorners {
+            top_left: top_left.is_some(),
+            top_right: top_right.is_some(),
+            bottom_right: bottom_right.is_some(),
+            bottom_left: bottom_left.is_some(),
+        });
 
         if let (Some(tl), Some(tr), Some(br), Some(bl)) = (
             &mut top_left,
@@ -483,6 +617,8 @@ impl BorderRadiusHandler {
         single_property!(dest, context, BorderBottomRightRadius, bottom_right);
         single_property!(dest, context, BorderBottomLeftRadius, bottom_left);
 
+        // The start-* corners are at the top and the *-start corners on the left in ltr text;
+        // in rtl text the *-start corners are on the right.
         logical_property!(
             dest,
             context,
@@ -490,7 +626,9 @@ impl BorderRadiusHandler {
             start_start,
             BorderTopLeftRadius,
             BorderTopRightRadius,
-            logical_supported
+            logical_supported,
+            declared.top_left,
+            declared.top_right
         );
         logical_property!(
             dest,
@@ -499,7 +637,9 @@ impl BorderRadiusHandler {
             start_end,
             BorderTopRightRadius,
             BorderTopLeftRadius,
-            logical_supported
+            logical_supported,
+            declared.top_right,
+            declared.top_left
         );
         logical_property!(
             dest,
@@ -508,7 +648,9 @@ impl BorderRadiusHandler {
             end_end,
             BorderBottomRightRadius,
             BorderBottomLeftRadius,
-            logical_supported
+            logical_supported,
+            declared.bottom_right,
+            declared.bottom_left
         );
         logical_property!(
             dest,
@@ -517,7 +659,9 @@ impl BorderRadiusHandler {
             end_start,
             BorderBottomLeftRadius,
             BorderBottomRightRadius,
-            logical_supported
+            logical_supported,
+            declared.bottom_left,
+            declared.bottom_right
         );
     }
 }

--- a/src/css/properties/margin_padding.rs
+++ b/src/css/properties/margin_padding.rs
@@ -844,8 +844,7 @@ impl<S: SizeHandlerSpec> SizeHandler<S> {
         self.has_any = true;
     }
 
-    /// Before an unparsed declaration setting `declared` is written out: inline values being
-    /// compiled away stay buffered and what was written out ahead of them is recorded instead.
+    /// For an unparsed declaration setting `declared`, which then overrides like a buffered value.
     fn flush_before_unparsed(
         &mut self,
         declared: DeclaredSides,

--- a/src/css/properties/margin_padding.rs
+++ b/src/css/properties/margin_padding.rs
@@ -769,30 +769,22 @@ impl<S: SizeHandlerSpec> SizeHandler<S> {
     ) {
         // If the value contains syntax that isn't supported across all targets,
         // preserve the previous value as a fallback.
-        let needs_fallback = context
-            .targets
-            .browsers
-            .as_ref()
-            .is_some_and(|browsers| !val.is_compatible(browsers));
-        if needs_fallback && self.physical_slot_is_some(field) {
-            self.flush(dest, context);
-            return;
-        }
+        let needs_fallback = self.physical_slot_is_some(field)
+            && context
+                .targets
+                .browsers
+                .as_ref()
+                .is_some_and(|browsers| !val.is_compatible(browsers));
 
-        if category == self.category {
-            return;
-        }
-
-        // A physical value following logical ones. When the logical values are compiled away
-        // anyway, keep them buffered: `flush` then knows which physical sides were declared after
-        // them and leaves those out of the ltr/rtl rules, which would otherwise override this
-        // value (see `flush_compiled_inline`). A value that needs a fallback flushes as before so
-        // that the buffered values are written out ahead of it.
+        // A physical value following logical ones flushes them, unless they are compiled away
+        // anyway: then they stay buffered, so that `flush` knows which physical sides were
+        // declared after them and leaves those out of the ltr/rtl rules, which would otherwise
+        // override this value (see `flush_compiled_inline`).
         let keep_logical_buffered = category == PropertyCategory::Physical
             && self.category == PropertyCategory::Logical
-            && !needs_fallback
             && Self::compiles_logical(context);
-        if !keep_logical_buffered {
+
+        if needs_fallback || (category != self.category && !keep_logical_buffered) {
             self.flush(dest, context);
         }
     }

--- a/src/css/properties/margin_padding.rs
+++ b/src/css/properties/margin_padding.rs
@@ -2,9 +2,10 @@
 use crate::compat::Feature;
 use crate::css_values::length::LengthPercentageOrAuto;
 use crate::logical::PropertyCategory;
+use crate::properties::text::Direction;
 use crate::properties::{Property, PropertyId, PropertyIdTag};
 use crate::{DeclarationList, PropertyHandlerContext};
-use bun_alloc::ArenaVecExt as _;
+use bun_alloc::{Arena, ArenaVecExt as _};
 
 // The rect-shorthand structs
 // below are stamped out by `define_rect_shorthand!` (struct
@@ -300,6 +301,22 @@ enum LogicalSlot {
     InlineEnd,
 }
 
+/// Physical inline sides set by declarations that came after the buffered logical values.
+#[derive(Copy, Clone, Default)]
+struct DeclaredSides {
+    left: bool,
+    right: bool,
+}
+
+impl DeclaredSides {
+    fn or(self, other: Self) -> Self {
+        Self {
+            left: self.left || other.left,
+            right: self.right || other.right,
+        }
+    }
+}
+
 /// Compile-time configuration for one `SizeHandler` instantiation.
 pub trait SizeHandlerSpec {
     // ---- tag parameters ----
@@ -403,6 +420,9 @@ pub struct SizeHandler<S: SizeHandlerSpec> {
     pub(crate) block_end: Option<Property>,
     pub(crate) inline_start: Option<Property>,
     pub(crate) inline_end: Option<Property>,
+    /// Physical sides written out while the inline values above stayed buffered (see
+    /// `flush_before_unparsed`). Consumed by the next `flush`.
+    declared_after_inline: DeclaredSides,
     pub(crate) has_any: bool,
     pub(crate) category: PropertyCategory,
     _spec: core::marker::PhantomData<S>,
@@ -419,6 +439,7 @@ impl<S: SizeHandlerSpec> Default for SizeHandler<S> {
             block_end: None,
             inline_start: None,
             inline_end: None,
+            declared_after_inline: DeclaredSides::default(),
             has_any: false,
             category: PropertyCategory::default(),
             _spec: core::marker::PhantomData,
@@ -519,7 +540,11 @@ impl<S: SizeHandlerSpec> SizeHandler<S> {
                         context,
                     );
                 } else {
-                    self.flush(dest, context);
+                    let declared = DeclaredSides {
+                        left: id == S::LEFT || id == S::SHORTHAND,
+                        right: id == S::RIGHT || id == S::SHORTHAND,
+                    };
+                    self.flush_before_unparsed(declared, dest, context);
                     dest.push(Property::Unparsed(unparsed.deep_clone(bump)));
                 }
             } else {
@@ -712,6 +737,7 @@ impl<S: SizeHandlerSpec> SizeHandler<S> {
             self.block_end = None;
             self.inline_start = None;
             self.inline_end = None;
+            self.category = S::SHORTHAND_CATEGORY;
             self.has_any = true;
         } else {
             return false;
@@ -741,16 +767,41 @@ impl<S: SizeHandlerSpec> SizeHandler<S> {
         dest: &mut DeclarationList,
         context: &mut PropertyHandlerContext,
     ) {
-        // If the category changes betweet logical and physical,
-        // or if the value contains syntax that isn't supported across all targets,
+        // If the value contains syntax that isn't supported across all targets,
         // preserve the previous value as a fallback.
-        if category != self.category
-            || (self.physical_slot_is_some(field)
-                && context.targets.browsers.is_some()
-                && !val.is_compatible(&context.targets.browsers.unwrap()))
-        {
+        let needs_fallback = context
+            .targets
+            .browsers
+            .as_ref()
+            .is_some_and(|browsers| !val.is_compatible(browsers));
+        if needs_fallback && self.physical_slot_is_some(field) {
+            self.flush(dest, context);
+            return;
+        }
+
+        if category == self.category {
+            return;
+        }
+
+        // A physical value following logical ones. When the logical values are compiled away
+        // anyway, keep them buffered: `flush` then knows which physical sides were declared after
+        // them and leaves those out of the ltr/rtl rules, which would otherwise override this
+        // value (see `flush_compiled_inline`). A value that needs a fallback flushes as before so
+        // that the buffered values are written out ahead of it.
+        let keep_logical_buffered = category == PropertyCategory::Physical
+            && self.category == PropertyCategory::Logical
+            && !needs_fallback
+            && Self::compiles_logical(context);
+        if !keep_logical_buffered {
             self.flush(dest, context);
         }
+    }
+
+    /// Whether the targets lack logical properties, so that the logical longhands are written out
+    /// as physical ones: the block ones into the rule itself, the inline ones into the ltr and rtl
+    /// rules that `PropertyHandlerContext` appends after it.
+    fn compiles_logical(context: &PropertyHandlerContext) -> bool {
+        S::FEATURE.is_some_and(|feature| context.should_compile_logical(feature))
     }
 
     /// Flush helper for the four logical slots (`block_start`/.../`inline_end`).
@@ -808,7 +859,44 @@ impl<S: SizeHandlerSpec> SizeHandler<S> {
         self.has_any = true;
     }
 
+    /// Flushes ahead of an unparsed physical declaration, which is written out directly instead
+    /// of being buffered; `declared` holds the inline sides it sets. Normally everything buffered
+    /// is flushed so that it ends up ahead of that declaration. Inline values that are compiled
+    /// away don't go into the rule itself, though, so those stay buffered and the physical sides
+    /// written out ahead of them are recorded instead: the declaration then overrides them exactly
+    /// like a buffered physical value does (see `flush_helper_physical`).
+    fn flush_before_unparsed(
+        &mut self,
+        declared: DeclaredSides,
+        dest: &mut DeclarationList,
+        context: &mut PropertyHandlerContext,
+    ) {
+        let keep_inline = (declared.left || declared.right)
+            && (self.inline_start.is_some() || self.inline_end.is_some())
+            && Self::compiles_logical(context);
+        if !keep_inline {
+            self.flush(dest, context);
+            return;
+        }
+
+        let declared_after_inline = self.declared_after_inline.or(declared).or(DeclaredSides {
+            left: self.left.is_some(),
+            right: self.right.is_some(),
+        });
+        let inline_start = self.inline_start.take();
+        let inline_end = self.inline_end.take();
+        self.flush(dest, context);
+        self.inline_start = inline_start;
+        self.inline_end = inline_end;
+        self.declared_after_inline = declared_after_inline;
+        self.has_any = true;
+        // Same state as after buffering a physical value: further physical values are added to
+        // the buffer, a logical one flushes first.
+        self.category = PropertyCategory::Physical;
+    }
+
     fn flush(&mut self, dest: &mut DeclarationList, context: &mut PropertyHandlerContext) {
+        let declared_after_inline = core::mem::take(&mut self.declared_after_inline);
         if !self.has_any {
             return;
         }
@@ -819,10 +907,43 @@ impl<S: SizeHandlerSpec> SizeHandler<S> {
         let bottom = self.bottom.take();
         let left = self.left.take();
         let right = self.right.take();
-        let logical_supported = match S::FEATURE {
-            Some(feature) => !context.should_compile_logical(feature),
-            None => true,
-        };
+        let mut block_start = self.block_start.take();
+        let mut block_end = self.block_end.take();
+        let mut inline_start = self.inline_start.take();
+        let mut inline_end = self.inline_end.take();
+        let logical_supported = !Self::compiles_logical(context);
+
+        if !logical_supported {
+            // Physical values are only buffered together with logical ones when they were declared
+            // after them (see `flush_helper_physical`), so the logical values go first: the block
+            // ones land in this same rule, where source order decides.
+            Self::prop(
+                block_start.as_ref(),
+                S::BLOCK_START,
+                S::extract_block_start,
+                S::make_top,
+                S::TOP_ID,
+                dest,
+            );
+            Self::prop(
+                block_end.as_ref(),
+                S::BLOCK_END,
+                S::extract_block_end,
+                S::make_bottom,
+                S::BOTTOM_ID,
+                dest,
+            );
+            Self::flush_compiled_inline(
+                inline_start.as_ref(),
+                inline_end.as_ref(),
+                declared_after_inline.or(DeclaredSides {
+                    left: left.is_some(),
+                    right: right.is_some(),
+                }),
+                dest,
+                context,
+            );
+        }
 
         match (top, bottom, left, right) {
             (Some(top), Some(bottom), Some(left), Some(right))
@@ -846,11 +967,6 @@ impl<S: SizeHandlerSpec> SizeHandler<S> {
             }
         }
 
-        let mut block_start = self.block_start.take();
-        let mut block_end = self.block_end.take();
-        let mut inline_start = self.inline_start.take();
-        let mut inline_end = self.inline_end.take();
-
         if logical_supported {
             Self::logical_side_helper(
                 &mut block_start,
@@ -860,28 +976,6 @@ impl<S: SizeHandlerSpec> SizeHandler<S> {
                 dest,
                 context,
             );
-        } else {
-            Self::prop(
-                &mut block_start,
-                S::BLOCK_START,
-                S::extract_block_start,
-                S::make_top,
-                S::TOP_ID,
-                dest,
-                context,
-            );
-            Self::prop(
-                &mut block_end,
-                S::BLOCK_END,
-                S::extract_block_end,
-                S::make_bottom,
-                S::BOTTOM_ID,
-                dest,
-                context,
-            );
-        }
-
-        if logical_supported {
             Self::logical_side_helper(
                 &mut inline_start,
                 &mut inline_end,
@@ -890,95 +984,110 @@ impl<S: SizeHandlerSpec> SizeHandler<S> {
                 dest,
                 context,
             );
-        } else if inline_start.is_some() || inline_end.is_some() {
-            // Raw union-tag equality, which is `false` for `Unparsed`.
-            let start_matches = inline_start
-                .as_ref()
-                .map(|p| p.variant_tag() == S::INLINE_START)
-                .unwrap_or(false);
-            let end_matches = inline_end
-                .as_ref()
-                .map(|p| p.variant_tag() == S::INLINE_END)
-                .unwrap_or(false);
-            let values_equal = if start_matches && end_matches {
-                S::extract_inline_start(inline_start.as_ref().unwrap())
-                    == S::extract_inline_end(inline_end.as_ref().unwrap())
-            } else {
-                false
-            };
+        }
+    }
 
-            if start_matches && end_matches && values_equal {
-                Self::prop(
-                    &mut inline_start,
+    /// Writes out the inline longhands for targets without logical properties. Unless both sides
+    /// hold the same value, each side becomes one declaration in the ltr rule and one in the rtl
+    /// rule, which are appended after the rule being minified and therefore override everything
+    /// declared in it. `declared` holds the physical sides declared after the logical values: in
+    /// the direction where a logical side maps onto one of them, the later physical declaration
+    /// is what the source resolves to, so no declaration is generated for that direction.
+    fn flush_compiled_inline(
+        inline_start: Option<&Property>,
+        inline_end: Option<&Property>,
+        declared: DeclaredSides,
+        dest: &mut DeclarationList,
+        context: &mut PropertyHandlerContext,
+    ) {
+        // `variant_tag()` keeps `Unparsed` distinct, so only parsed values are compared.
+        let start_value = inline_start
+            .filter(|p| p.variant_tag() == S::INLINE_START)
+            .map(S::extract_inline_start);
+        let end_value = inline_end
+            .filter(|p| p.variant_tag() == S::INLINE_END)
+            .map(S::extract_inline_end);
+        if let Some(value) = start_value
+            && end_value == Some(value)
+        {
+            // The same value on both sides does not depend on the direction, so it goes into the
+            // rule itself, minus the sides declared again after it.
+            if !declared.left {
+                dest.push(S::make_left(value.clone()));
+            }
+            if !declared.right {
+                dest.push(S::make_right(value.clone()));
+            }
+            return;
+        }
+
+        let bump = dest.bump();
+        if let Some(start) = inline_start {
+            // inline-start is the left side in ltr text and the right side in rtl text.
+            let compile = |make_physical, physical| {
+                Self::to_physical(
+                    start,
                     S::INLINE_START,
                     S::extract_inline_start,
-                    S::make_left,
-                    S::LEFT_ID,
-                    dest,
-                    context,
-                );
-                Self::prop(
-                    &mut inline_end,
+                    make_physical,
+                    physical,
+                    bump,
+                )
+            };
+            if !declared.left
+                && let Some(property) = compile(S::make_left, S::LEFT_ID)
+            {
+                context.add_directional_rule(Direction::Ltr, property);
+            }
+            if !declared.right
+                && let Some(property) = compile(S::make_right, S::RIGHT_ID)
+            {
+                context.add_directional_rule(Direction::Rtl, property);
+            }
+        }
+        if let Some(end) = inline_end {
+            // inline-end is the right side in ltr text and the left side in rtl text.
+            let compile = |make_physical, physical| {
+                Self::to_physical(
+                    end,
                     S::INLINE_END,
                     S::extract_inline_end,
-                    S::make_right,
-                    S::RIGHT_ID,
-                    dest,
-                    context,
-                );
-            } else {
-                Self::logical_prop_helper(
-                    &mut inline_start,
-                    S::INLINE_START,
-                    S::extract_inline_start,
-                    S::make_left,
-                    S::LEFT_ID,
-                    S::make_right,
-                    S::RIGHT_ID,
-                    dest,
-                    context,
-                );
-                Self::logical_prop_helper(
-                    &mut inline_end,
-                    S::INLINE_END,
-                    S::extract_inline_end,
-                    S::make_right,
-                    S::RIGHT_ID,
-                    S::make_left,
-                    S::LEFT_ID,
-                    dest,
-                    context,
-                );
+                    make_physical,
+                    physical,
+                    bump,
+                )
+            };
+            if !declared.right
+                && let Some(property) = compile(S::make_right, S::RIGHT_ID)
+            {
+                context.add_directional_rule(Direction::Ltr, property);
+            }
+            if !declared.left
+                && let Some(property) = compile(S::make_left, S::LEFT_ID)
+            {
+                context.add_directional_rule(Direction::Rtl, property);
             }
         }
     }
 
-    #[inline]
-    #[allow(clippy::too_many_arguments)]
-    fn logical_prop_helper(
-        val: &mut Option<Property>,
+    /// The physical form of a buffered logical longhand, which is either the parsed `logical`
+    /// property or an unparsed one carrying its id.
+    fn to_physical(
+        value: &Property,
         logical: PropertyIdTag,
         extract_logical: fn(&Property) -> &LengthPercentageOrAuto,
-        make_ltr: fn(LengthPercentageOrAuto) -> Property,
-        ltr: PropertyId,
-        make_rtl: fn(LengthPercentageOrAuto) -> Property,
-        rtl: PropertyId,
-        dest: &mut DeclarationList,
-        context: &mut PropertyHandlerContext,
-    ) {
-        // _ = this; // autofix
-        let bump = dest.bump();
-        if let Some(v_) = val.as_ref() {
-            // Raw discriminant comparison.
-            if v_.variant_tag() == logical {
-                let v = extract_logical(v_);
-                context.add_logical_rule(make_ltr(v.clone()), make_rtl(v.clone()));
-            } else if let Property::Unparsed(v) = v_ {
-                context.add_logical_rule(
-                    Property::Unparsed(v.with_property_id(bump, ltr)),
-                    Property::Unparsed(v.with_property_id(bump, rtl)),
-                );
-            }
+        make_physical: fn(LengthPercentageOrAuto) -> Property,
+        physical: PropertyId,
+        bump: &Arena,
+    ) -> Option<Property> {
+        if value.variant_tag() == logical {
+            Some(make_physical(extract_logical(value).clone()))
+        } else if let Property::Unparsed(unparsed) = value {
+            Some(Property::Unparsed(
+                unparsed.with_property_id(bump, physical),
+            ))
+        } else {
+            None
         }
     }
 
@@ -1040,28 +1149,26 @@ impl<S: SizeHandlerSpec> SizeHandler<S> {
         }
     }
 
-    #[inline]
+    /// Writes a buffered logical longhand into the rule itself as `physical`.
     fn prop(
-        val: &mut Option<Property>,
+        value: Option<&Property>,
         logical: PropertyIdTag,
         extract_logical: fn(&Property) -> &LengthPercentageOrAuto,
         make_physical: fn(LengthPercentageOrAuto) -> Property,
         physical: PropertyId,
         dest: &mut DeclarationList,
-        context: &mut PropertyHandlerContext,
     ) {
-        // _ = this; // autofix
-        let _ = context;
-        let bump = dest.bump();
-        if let Some(v) = val.as_ref() {
-            // Raw discriminant comparison.
-            if v.variant_tag() == logical {
-                // Clone instead of moving out of `&Property`;
-                // `LengthPercentageOrAuto` is small.
-                dest.push(make_physical(extract_logical(v).clone()));
-            } else if let Property::Unparsed(u) = v {
-                dest.push(Property::Unparsed(u.with_property_id(bump, physical)));
-            }
+        if let Some(value) = value
+            && let Some(property) = Self::to_physical(
+                value,
+                logical,
+                extract_logical,
+                make_physical,
+                physical,
+                dest.bump(),
+            )
+        {
+            dest.push(property);
         }
     }
 }

--- a/src/css/properties/margin_padding.rs
+++ b/src/css/properties/margin_padding.rs
@@ -301,7 +301,7 @@ enum LogicalSlot {
     InlineEnd,
 }
 
-/// Physical inline sides set by declarations that came after the buffered logical values.
+/// Physical inline sides declared after the buffered inline values.
 #[derive(Copy, Clone, Default)]
 struct DeclaredSides {
     left: bool,
@@ -420,8 +420,7 @@ pub struct SizeHandler<S: SizeHandlerSpec> {
     pub(crate) block_end: Option<Property>,
     pub(crate) inline_start: Option<Property>,
     pub(crate) inline_end: Option<Property>,
-    /// Physical sides written out while the inline values above stayed buffered (see
-    /// `flush_before_unparsed`). Consumed by the next `flush`.
+    /// Sides written out by `flush_before_unparsed` while the inline values stayed buffered.
     declared_after_inline: DeclaredSides,
     pub(crate) has_any: bool,
     pub(crate) category: PropertyCategory,
@@ -776,10 +775,7 @@ impl<S: SizeHandlerSpec> SizeHandler<S> {
                 .as_ref()
                 .is_some_and(|browsers| !val.is_compatible(browsers));
 
-        // A physical value following logical ones flushes them, unless they are compiled away
-        // anyway: then they stay buffered, so that `flush` knows which physical sides were
-        // declared after them and leaves those out of the ltr/rtl rules, which would otherwise
-        // override this value (see `flush_compiled_inline`).
+        // Kept for `flush_compiled_inline`, which leaves out the directions this value overrides.
         let keep_logical_buffered = category == PropertyCategory::Physical
             && self.category == PropertyCategory::Logical
             && Self::compiles_logical(context);
@@ -789,9 +785,6 @@ impl<S: SizeHandlerSpec> SizeHandler<S> {
         }
     }
 
-    /// Whether the targets lack logical properties, so that the logical longhands are written out
-    /// as physical ones: the block ones into the rule itself, the inline ones into the ltr and rtl
-    /// rules that `PropertyHandlerContext` appends after it.
     fn compiles_logical(context: &PropertyHandlerContext) -> bool {
         S::FEATURE.is_some_and(|feature| context.should_compile_logical(feature))
     }
@@ -851,12 +844,8 @@ impl<S: SizeHandlerSpec> SizeHandler<S> {
         self.has_any = true;
     }
 
-    /// Flushes ahead of an unparsed physical declaration, which is written out directly instead
-    /// of being buffered; `declared` holds the inline sides it sets. Normally everything buffered
-    /// is flushed so that it ends up ahead of that declaration. Inline values that are compiled
-    /// away don't go into the rule itself, though, so those stay buffered and the physical sides
-    /// written out ahead of them are recorded instead: the declaration then overrides them exactly
-    /// like a buffered physical value does (see `flush_helper_physical`).
+    /// Before an unparsed declaration setting `declared` is written out: inline values being
+    /// compiled away stay buffered and what was written out ahead of them is recorded instead.
     fn flush_before_unparsed(
         &mut self,
         declared: DeclaredSides,
@@ -882,8 +871,6 @@ impl<S: SizeHandlerSpec> SizeHandler<S> {
         self.inline_end = inline_end;
         self.declared_after_inline = declared_after_inline;
         self.has_any = true;
-        // Same state as after buffering a physical value: further physical values are added to
-        // the buffer, a logical one flushes first.
         self.category = PropertyCategory::Physical;
     }
 
@@ -906,9 +893,7 @@ impl<S: SizeHandlerSpec> SizeHandler<S> {
         let logical_supported = !Self::compiles_logical(context);
 
         if !logical_supported {
-            // Physical values are only buffered together with logical ones when they were declared
-            // after them (see `flush_helper_physical`), so the logical values go first: the block
-            // ones land in this same rule, where source order decides.
+            // Logical values first: any physical value buffered with them was declared later.
             Self::prop(
                 block_start.as_ref(),
                 S::BLOCK_START,
@@ -979,12 +964,8 @@ impl<S: SizeHandlerSpec> SizeHandler<S> {
         }
     }
 
-    /// Writes out the inline longhands for targets without logical properties. Unless both sides
-    /// hold the same value, each side becomes one declaration in the ltr rule and one in the rtl
-    /// rule, which are appended after the rule being minified and therefore override everything
-    /// declared in it. `declared` holds the physical sides declared after the logical values: in
-    /// the direction where a logical side maps onto one of them, the later physical declaration
-    /// is what the source resolves to, so no declaration is generated for that direction.
+    /// The ltr/rtl rules are appended after this rule and override it, so a direction in which a
+    /// side maps onto one of the later `declared` sides gets nothing.
     fn flush_compiled_inline(
         inline_start: Option<&Property>,
         inline_end: Option<&Property>,
@@ -992,7 +973,6 @@ impl<S: SizeHandlerSpec> SizeHandler<S> {
         dest: &mut DeclarationList,
         context: &mut PropertyHandlerContext,
     ) {
-        // `variant_tag()` keeps `Unparsed` distinct, so only parsed values are compared.
         let start_value = inline_start
             .filter(|p| p.variant_tag() == S::INLINE_START)
             .map(S::extract_inline_start);
@@ -1002,8 +982,7 @@ impl<S: SizeHandlerSpec> SizeHandler<S> {
         if let Some(value) = start_value
             && end_value == Some(value)
         {
-            // The same value on both sides does not depend on the direction, so it goes into the
-            // rule itself, minus the sides declared again after it.
+            // Direction independent, so it stays in this rule.
             if !declared.left {
                 dest.push(S::make_left(value.clone()));
             }
@@ -1062,8 +1041,6 @@ impl<S: SizeHandlerSpec> SizeHandler<S> {
         }
     }
 
-    /// The physical form of a buffered logical longhand, which is either the parsed `logical`
-    /// property or an unparsed one carrying its id.
     fn to_physical(
         value: &Property,
         logical: PropertyIdTag,
@@ -1141,7 +1118,6 @@ impl<S: SizeHandlerSpec> SizeHandler<S> {
         }
     }
 
-    /// Writes a buffered logical longhand into the rule itself as `physical`.
     fn prop(
         value: Option<&Property>,
         logical: PropertyIdTag,

--- a/src/css/properties/margin_padding.rs
+++ b/src/css/properties/margin_padding.rs
@@ -466,6 +466,14 @@ impl<S: SizeHandlerSpec> SizeHandler<S> {
             PhysicalSlot::Right => self.right.is_some(),
         }
     }
+    /// Whether a block value is buffered that, compiled, lands on this physical side.
+    fn compiled_block_slot_is_some(&self, slot: PhysicalSlot) -> bool {
+        match slot {
+            PhysicalSlot::Top => self.block_start.is_some(),
+            PhysicalSlot::Bottom => self.block_end.is_some(),
+            PhysicalSlot::Left | PhysicalSlot::Right => false,
+        }
+    }
     fn logical_slot(&mut self, slot: LogicalSlot) -> &mut Option<Property> {
         match slot {
             LogicalSlot::BlockStart => &mut self.block_start,
@@ -768,7 +776,8 @@ impl<S: SizeHandlerSpec> SizeHandler<S> {
     ) {
         // If the value contains syntax that isn't supported across all targets,
         // preserve the previous value as a fallback.
-        let needs_fallback = self.physical_slot_is_some(field)
+        let needs_fallback = (self.physical_slot_is_some(field)
+            || (Self::compiles_logical(context) && self.compiled_block_slot_is_some(field)))
             && context
                 .targets
                 .browsers

--- a/src/css/properties/margin_padding.rs
+++ b/src/css/properties/margin_padding.rs
@@ -963,8 +963,7 @@ impl<S: SizeHandlerSpec> SizeHandler<S> {
         }
     }
 
-    /// The ltr/rtl rules are appended after this rule and override it, so a direction in which a
-    /// side maps onto one of the later `declared` sides gets nothing.
+    /// The ltr/rtl rules override this rule, so the direction of a `declared` side is left out.
     fn flush_compiled_inline(
         inline_start: Option<&Property>,
         inline_end: Option<&Property>,

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -2103,6 +2103,382 @@ describe("css tests", () => {
     );
   });
 
+  // When logical properties are compiled away for old targets, the inline ones (and the logical
+  // border-radius corners) become rules appended after the original rule, one for ltr and one for
+  // rtl text, which override everything declared in the original rule. A physical declaration that
+  // comes later in the same block than the logical one it overlaps with must therefore win over the
+  // compiled copy: the copy for the direction in which the logical value maps onto that physical
+  // side is dropped, and only the other direction is emitted.
+  describe("physical declaration after a compiled logical one", () => {
+    const targets = { safari: 8 << 16 };
+    const rtlLangs =
+      ":lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi)";
+    // The rules the compilation appends for the ltr and the rtl direction (each is emitted twice
+    // because :is() is prefixed for these targets).
+    const ltr = (decls: string) =>
+      `.foo:not(:-webkit-any(${rtlLangs})) { ${decls} } .foo:not(:is(${rtlLangs})) { ${decls} }`;
+    const rtl = (decls: string) => `.foo:-webkit-any(${rtlLangs}) { ${decls} } .foo:is(${rtlLangs}) { ${decls} }`;
+    const rule = (decls: string) => `.foo { ${decls} }`;
+    const compiled = (source: string, expected: string) => prefix_test(`.foo { ${source} }`, expected, targets);
+
+    describe.each([
+      ["margin", "margin-"],
+      ["padding", "padding-"],
+      ["inset", ""],
+    ])("%s", (shorthand, physicalPrefix) => {
+      const inlineStart = `${shorthand}-inline-start`;
+      const inlineEnd = `${shorthand}-inline-end`;
+      const blockStart = `${shorthand}-block-start`;
+      const left = `${physicalPrefix}left`;
+      const right = `${physicalPrefix}right`;
+      const top = `${physicalPrefix}top`;
+
+      // Each inline longhand maps onto left in one direction and right in the other; the direction
+      // in which it maps onto the side declared later is dropped.
+      compiled(`${inlineStart}: 3px; ${left}: 1px`, rule(`${left}: 1px;`) + rtl(`${right}: 3px;`));
+      compiled(`${inlineStart}: 3px; ${right}: 1px`, rule(`${right}: 1px;`) + ltr(`${left}: 3px;`));
+      compiled(`${inlineEnd}: 3px; ${left}: 1px`, rule(`${left}: 1px;`) + ltr(`${right}: 3px;`));
+      compiled(`${inlineEnd}: 3px; ${right}: 1px`, rule(`${right}: 1px;`) + rtl(`${left}: 3px;`));
+
+      // Both sides declared later: nothing of the logical value survives.
+      compiled(`${inlineStart}: 3px; ${left}: 1px; ${right}: 1px`, rule(`${left}: 1px; ${right}: 1px;`));
+
+      // Both inline longhands: in ltr text the right side comes from inline-end, in rtl text from
+      // inline-start; the left side is physical in both.
+      compiled(
+        `${inlineStart}: 3px; ${inlineEnd}: 4px; ${left}: 1px`,
+        rule(`${left}: 1px;`) + ltr(`${right}: 4px;`) + rtl(`${right}: 3px;`),
+      );
+      // Equal inline values don't depend on the direction and stay in the rule itself.
+      compiled(`${inlineStart}: 3px; ${inlineEnd}: 3px; ${left}: 1px`, rule(`${right}: 3px; ${left}: 1px;`));
+
+      // Later declarations of other properties don't affect it.
+      compiled(`${inlineStart}: 3px; ${top}: 1px`, rule(`${top}: 1px;`) + ltr(`${left}: 3px;`) + rtl(`${right}: 3px;`));
+      // A block longhand compiles into the rule itself and is unaffected.
+      compiled(
+        `${inlineStart}: 3px; ${blockStart}: 4px; ${left}: 1px`,
+        rule(`${top}: 4px; ${left}: 1px;`) + rtl(`${right}: 3px;`),
+      );
+      compiled(`${blockStart}: 3px; ${top}: 1px`, rule(`${top}: 3px; ${top}: 1px;`));
+
+      // The logical declaration coming last still wins.
+      compiled(
+        `${left}: 1px; ${inlineStart}: 3px`,
+        rule(`${left}: 1px;`) + ltr(`${left}: 3px;`) + rtl(`${right}: 3px;`),
+      );
+      compiled(
+        `${inlineStart}: 3px; ${left}: 1px; ${inlineStart}: 5px`,
+        rule(`${left}: 1px;`) + ltr(`${left}: 5px;`) + rtl(`${right}: 5px;`),
+      );
+      // inline-end declared after the physical left overrides it again in rtl text.
+      compiled(
+        `${inlineStart}: 3px; ${left}: 1px; ${inlineEnd}: 2px`,
+        rule(`${left}: 1px;`) + ltr(`${right}: 2px;`) + rtl(`${left}: 2px; ${right}: 3px;`),
+      );
+
+      // Unparsed values on either side.
+      compiled(`${inlineStart}: 3px; ${left}: var(--x)`, rule(`${left}: var(--x);`) + rtl(`${right}: 3px;`));
+      compiled(`${inlineStart}: var(--x); ${left}: 1px`, rule(`${left}: 1px;`) + rtl(`${right}: var(--x);`));
+      compiled(
+        `${inlineStart}: 3px; ${left}: var(--x); ${right}: var(--y)`,
+        rule(`${left}: var(--x); ${right}: var(--y);`),
+      );
+      compiled(`${inlineStart}: 3px; ${left}: 1px; ${right}: var(--y)`, rule(`${left}: 1px; ${right}: var(--y);`));
+      compiled(
+        `${inlineStart}: 3px; ${left}: var(--x); ${inlineStart}: 5px`,
+        rule(`${left}: var(--x);`) + ltr(`${left}: 5px;`) + rtl(`${right}: 5px;`),
+      );
+      compiled(
+        `${inlineStart}: 3px; ${top}: var(--t)`,
+        rule(`${top}: var(--t);`) + ltr(`${left}: 3px;`) + rtl(`${right}: 3px;`),
+      );
+
+      // The shorthand sets both sides.
+      compiled(`${inlineStart}: 3px; ${shorthand}: 0`, rule(`${shorthand}: 0;`));
+      compiled(`${inlineStart}: 3px; ${shorthand}: var(--all)`, rule(`${shorthand}: var(--all);`));
+      compiled(
+        `${inlineStart}: 3px; ${shorthand}: 0; ${inlineStart}: 5px`,
+        rule(`${shorthand}: 0;`) + ltr(`${left}: 5px;`) + rtl(`${right}: 5px;`),
+      );
+      // (`inset` itself is still emitted for these targets, which is a separate problem, so the
+      // folding into the shorthand is only checked for the others.)
+      if (shorthand !== "inset") {
+        compiled(
+          `${inlineStart}: 3px; ${top}: 1px; ${right}: 1px; ${physicalPrefix}bottom: 1px; ${left}: 1px`,
+          rule(`${shorthand}: 1px;`),
+        );
+      }
+
+      // With targets that support logical properties everything stays in the rule in source order.
+      describe("supported", () => {
+        prefix_test(`.foo { ${inlineStart}: 3px; ${left}: 1px }`, rule(`${inlineStart}: 3px; ${left}: 1px;`), {
+          chrome: 90 << 16,
+        });
+      });
+    });
+
+    // A physical value that needs the buffered values as a fallback still flushes them first.
+    compiled("margin-block-start: 3px; margin: 1dvh", rule("margin-top: 3px; margin: 1dvh;"));
+    compiled("margin-block-start: 3px; margin-top: 1dvh", rule("margin-top: 3px; margin-top: 1dvh;"));
+    compiled(
+      "margin-inline-start: 3px; margin-left: 1px; margin-left: 1dvh",
+      rule("margin-left: 1px; margin-left: 1dvh;") + rtl("margin-right: 3px;"),
+    );
+
+    describe("border", () => {
+      compiled(
+        "border-inline-start-width: 3px; border-left-width: 1px",
+        rule("border-left-width: 1px;") + rtl("border-right-width: 3px;"),
+      );
+      compiled(
+        "border-inline-start-width: 3px; border-right-width: 1px",
+        rule("border-right-width: 1px;") + ltr("border-left-width: 3px;"),
+      );
+      compiled(
+        "border-inline-end-width: 3px; border-left-width: 1px",
+        rule("border-left-width: 1px;") + ltr("border-right-width: 3px;"),
+      );
+      compiled(
+        "border-inline-end-width: 3px; border-right-width: 1px",
+        rule("border-right-width: 1px;") + rtl("border-left-width: 3px;"),
+      );
+      compiled(
+        "border-inline-start-style: dotted; border-left-style: solid",
+        rule("border-left-style: solid;") + rtl("border-right-style: dotted;"),
+      );
+      compiled(
+        "border-inline-start-color: red; border-left-color: #00f",
+        rule("border-left-color: #00f;") + rtl("border-right-color: red;"),
+      );
+      compiled(
+        "border-inline-start-width: 3px; border-left-width: 1px; border-right-width: 1px",
+        rule("border-left-width: 1px; border-right-width: 1px;"),
+      );
+      compiled(
+        "border-inline-start-width: 3px; border-inline-end-width: 4px; border-left-width: 1px",
+        rule("border-left-width: 1px;") + ltr("border-right-width: 4px;") + rtl("border-right-width: 3px;"),
+      );
+      compiled(
+        "border-inline-start-width: 3px; border-inline-end-width: 3px; border-left-width: 1px",
+        rule("border-right-width: 3px; border-left-width: 1px;"),
+      );
+
+      // Side shorthands are tracked per sub-property.
+      compiled(
+        "border-inline-start: 3px solid red; border-left: 1px solid #00f",
+        rule("border-left: 1px solid #00f;") + rtl("border-right: 3px solid red;"),
+      );
+      compiled(
+        "border-inline-start: 3px solid red; border-left-width: 1px",
+        rule("border-left-width: 1px;") +
+          ltr("border-left-style: solid; border-left-color: red;") +
+          rtl("border-right: 3px solid red;"),
+      );
+      compiled(
+        "border-inline-start: 3px solid red; border-inline-end: 4px solid red; border-left: 1px solid #00f",
+        rule("border-right-style: solid; border-right-color: red; border-left: 1px solid #00f;") +
+          ltr("border-right-width: 4px;") +
+          rtl("border-right-width: 3px;"),
+      );
+      // All four logical sides set, which otherwise folds into the `border` shorthand.
+      compiled(
+        "border-block-start: 3px solid red; border-block-end: 3px solid red; border-inline-start: 3px solid red; border-inline-end: 5px solid red; border-left-width: 1px",
+        rule(
+          "border-style: solid; border-color: red; border-top-width: 3px; border-bottom-width: 3px; border-left-width: 1px;",
+        ) +
+          ltr("border-right-width: 5px;") +
+          rtl("border-right-width: 3px;"),
+      );
+
+      // Unaffected orders and sides.
+      compiled(
+        "border-inline-start-width: 3px; border-top-width: 1px",
+        rule("border-top-width: 1px;") + ltr("border-left-width: 3px;") + rtl("border-right-width: 3px;"),
+      );
+      compiled(
+        "border-left-width: 1px; border-inline-start-width: 3px",
+        rule("border-left-width: 1px;") + ltr("border-left-width: 3px;") + rtl("border-right-width: 3px;"),
+      );
+      compiled(
+        "border-inline-start-width: 3px; border-left-width: 1px; border-inline-end-width: 2px",
+        rule("border-left-width: 1px;") +
+          ltr("border-right-width: 2px;") +
+          rtl("border-left-width: 2px; border-right-width: 3px;"),
+      );
+      compiled(
+        "border-block-start-width: 3px; border-top-width: 1px",
+        rule("border-top-width: 3px; border-top-width: 1px;"),
+      );
+
+      // Four-side shorthands set both sides.
+      compiled("border-inline-start-width: 3px; border-width: 1px", rule("border-width: 1px;"));
+      compiled(
+        "border-inline-start-width: 3px; border: 1px solid red; border-inline-start-width: 5px",
+        rule("border: 1px solid red;") + ltr("border-left-width: 5px;") + rtl("border-right-width: 5px;"),
+      );
+      compiled(
+        "border-inline-start-width: 3px; border-width: 1px; border-inline-start-width: 5px",
+        rule("border-width: 1px;") + ltr("border-left-width: 5px;") + rtl("border-right-width: 5px;"),
+      );
+
+      // Unparsed physical declarations.
+      compiled(
+        "border-inline-start-width: 3px; border-left-width: var(--w)",
+        rule("border-left-width: var(--w);") + rtl("border-right-width: 3px;"),
+      );
+      compiled(
+        "border-inline-start-width: 3px; border-left: var(--b)",
+        rule("border-left: var(--b);") + rtl("border-right-width: 3px;"),
+      );
+      compiled("border-inline-start-width: 3px; border: var(--b)", rule("border: var(--b);"));
+      compiled(
+        "border-inline-start-width: 3px; border-left-width: var(--l); border-right-width: var(--r)",
+        rule("border-left-width: var(--l); border-right-width: var(--r);"),
+      );
+      compiled(
+        "border-inline-start-width: 3px; border-left-width: 1px; border-right-width: var(--r)",
+        rule("border-left-width: 1px; border-right-width: var(--r);"),
+      );
+      compiled(
+        "border-inline-start-width: 3px; border-left-width: var(--l); border-inline-start-width: 5px",
+        rule("border-left-width: var(--l);") + ltr("border-left-width: 5px;") + rtl("border-right-width: 5px;"),
+      );
+      compiled(
+        "border-inline-start-width: 3px; border-top-width: var(--t)",
+        rule("border-top-width: var(--t);") + ltr("border-left-width: 3px;") + rtl("border-right-width: 3px;"),
+      );
+
+      // Unparsed logical declarations are held back the same way.
+      compiled(
+        "border-inline-start: var(--b); border-left: 1px solid #00f",
+        rule("border-left: 1px solid #00f;") + rtl("border-right: var(--b);"),
+      );
+      compiled(
+        "border-inline-end-width: var(--w); border-right-width: 1px",
+        rule("border-right-width: 1px;") + rtl("border-left-width: var(--w);"),
+      );
+      compiled(
+        "border-inline-start-width: var(--w); border-left-width: 1px; border-right-width: var(--r)",
+        rule("border-left-width: 1px; border-right-width: var(--r);"),
+      );
+      compiled("border-inline-start-width: var(--w); border: 1px solid red", rule("border: 1px solid red;"));
+      compiled(
+        "border-inline-start: var(--b); border-left: var(--l); border-right: var(--r)",
+        rule("border-left: var(--l); border-right: var(--r);"),
+      );
+      compiled(
+        "border-inline-start-width: var(--w); border-inline-end-width: 4px; border-left-width: 1px",
+        rule("border-left-width: 1px;") + ltr("border-right-width: 4px;") + rtl("border-right-width: var(--w);"),
+      );
+      // An unparsed value can't be split, so a later declaration that only overrides part of it
+      // leaves it in place.
+      compiled(
+        "border-inline-start: var(--b); border-left-width: 1px",
+        rule("border-left-width: 1px;") + ltr("border-left: var(--b);") + rtl("border-right: var(--b);"),
+      );
+      // Two declarations of the same logical property still both come through, in order.
+      compiled(
+        "border-inline-start-width: 3px; border-inline-start-width: var(--w)",
+        ltr("border-left-width: 3px; border-left-width: var(--w);") +
+          rtl("border-right-width: 3px; border-right-width: var(--w);"),
+      );
+      compiled(
+        "border-inline-start-width: var(--a); border-inline-start-width: var(--b)",
+        ltr("border-left-width: var(--a); border-left-width: var(--b);") +
+          rtl("border-right-width: var(--a); border-right-width: var(--b);"),
+      );
+      compiled(
+        "border-inline-start-width: var(--w); border-top-width: 1px",
+        rule("border-top-width: 1px;") + ltr("border-left-width: var(--w);") + rtl("border-right-width: var(--w);"),
+      );
+
+      describe("supported", () => {
+        prefix_test(
+          ".foo { border-inline-start-width: 3px; border-left-width: 1px }",
+          rule("border-inline-start-width: 3px; border-left-width: 1px;"),
+          { chrome: 90 << 16 },
+        );
+      });
+    });
+
+    describe("border-radius", () => {
+      // In ltr text the *-start corners are on the left, in rtl text on the right.
+      for (const [logical, ltrCorner, rtlCorner] of [
+        ["border-start-start-radius", "border-top-left-radius", "border-top-right-radius"],
+        ["border-start-end-radius", "border-top-right-radius", "border-top-left-radius"],
+        ["border-end-start-radius", "border-bottom-left-radius", "border-bottom-right-radius"],
+        ["border-end-end-radius", "border-bottom-right-radius", "border-bottom-left-radius"],
+      ]) {
+        // Physical corners are written out in a fixed order.
+        const [first, second] = [
+          "border-top-left-radius",
+          "border-top-right-radius",
+          "border-bottom-right-radius",
+          "border-bottom-left-radius",
+        ].filter(corner => corner === ltrCorner || corner === rtlCorner);
+
+        compiled(`${logical}: 3px; ${ltrCorner}: 1px`, rule(`${ltrCorner}: 1px;`) + rtl(`${rtlCorner}: 3px;`));
+        compiled(`${logical}: 3px; ${rtlCorner}: 1px`, rule(`${rtlCorner}: 1px;`) + ltr(`${ltrCorner}: 3px;`));
+        compiled(`${logical}: 3px; ${ltrCorner}: 1px; ${rtlCorner}: 1px`, rule(`${first}: 1px; ${second}: 1px;`));
+      }
+
+      compiled(
+        "border-start-start-radius: 3px; border-bottom-left-radius: 1px",
+        rule("border-bottom-left-radius: 1px;") +
+          ltr("border-top-left-radius: 3px;") +
+          rtl("border-top-right-radius: 3px;"),
+      );
+      compiled(
+        "border-top-left-radius: 1px; border-start-start-radius: 3px",
+        rule("border-top-left-radius: 1px;") +
+          ltr("border-top-left-radius: 3px;") +
+          rtl("border-top-right-radius: 3px;"),
+      );
+      compiled(
+        "border-start-start-radius: 3px; border-top-left-radius: 1px; border-start-start-radius: 5px",
+        rule("border-top-left-radius: 1px;") +
+          ltr("border-top-left-radius: 5px;") +
+          rtl("border-top-right-radius: 5px;"),
+      );
+      compiled(
+        "border-start-start-radius: 3px; border-top-left-radius: var(--r)",
+        rule("border-top-left-radius: var(--r);") + rtl("border-top-right-radius: 3px;"),
+      );
+      compiled(
+        "border-start-start-radius: var(--r); border-top-left-radius: 1px",
+        rule("border-top-left-radius: 1px;") + rtl("border-top-right-radius: var(--r);"),
+      );
+      compiled("border-start-start-radius: 3px; border-radius: var(--r)", rule("border-radius: var(--r);"));
+      compiled(
+        "border-start-start-radius: 3px; border-top-left-radius: var(--a); border-top-right-radius: var(--b)",
+        rule("border-top-left-radius: var(--a); border-top-right-radius: var(--b);"),
+      );
+      compiled(
+        "border-start-start-radius: 3px; border-top-left-radius: 1px; border-top-right-radius: var(--b)",
+        rule("border-top-left-radius: 1px; border-top-right-radius: var(--b);"),
+      );
+      compiled(
+        "border-start-start-radius: 3px; border-top-left-radius: var(--a); border-start-start-radius: 5px",
+        rule("border-top-left-radius: var(--a);") +
+          ltr("border-top-left-radius: 5px;") +
+          rtl("border-top-right-radius: 5px;"),
+      );
+      compiled("border-start-start-radius: 3px; border-radius: 1px", rule("border-radius: 1px;"));
+      compiled(
+        "border-start-start-radius: 3px; border-radius: 1px; border-start-start-radius: 5px",
+        rule("border-radius: 1px;") + ltr("border-top-left-radius: 5px;") + rtl("border-top-right-radius: 5px;"),
+      );
+
+      describe("supported", () => {
+        prefix_test(
+          ".foo { border-start-start-radius: 3px; border-top-left-radius: 1px }",
+          rule("border-start-start-radius: 3px; border-top-left-radius: 1px;"),
+          { chrome: 90 << 16 },
+        );
+      });
+    });
+  });
+
   describe("length", () => {
     const properties = [
       "margin-right",

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -2217,13 +2217,17 @@ describe("css tests", () => {
       });
     });
 
-    // A physical value that needs the buffered values as a fallback still flushes them first.
-    compiled("margin-block-start: 3px; margin: 1dvh", rule("margin-top: 3px; margin: 1dvh;"));
+    // Values with syntax the targets don't support (dvh here): a block value still ends up ahead
+    // of the later one as a fallback, since it is written into the rule first, and the existing
+    // fallback flush between two physical values still applies. An inline value is dropped for the
+    // overridden direction all the same, since keeping it would override the later value in every
+    // browser that does support the syntax.
     compiled("margin-block-start: 3px; margin-top: 1dvh", rule("margin-top: 3px; margin-top: 1dvh;"));
     compiled(
       "margin-inline-start: 3px; margin-left: 1px; margin-left: 1dvh",
       rule("margin-left: 1px; margin-left: 1dvh;") + rtl("margin-right: 3px;"),
     );
+    compiled("margin-inline-start: 3px; margin-left: 1dvh", rule("margin-left: 1dvh;") + rtl("margin-right: 3px;"));
 
     describe("border", () => {
       compiled(
@@ -2308,6 +2312,30 @@ describe("css tests", () => {
       compiled(
         "border-block-start-width: 3px; border-top-width: 1px",
         rule("border-top-width: 3px; border-top-width: 1px;"),
+      );
+
+      // Values with syntax the targets don't support, as for margin above; colors get their own
+      // fallbacks.
+      compiled(
+        "border-block-start-width: 3px; border-top-width: 1dvh",
+        rule("border-top-width: 3px; border-top-width: 1dvh;"),
+      );
+      compiled(
+        "border-inline-start-width: 3px; border-left-width: 1dvh",
+        rule("border-left-width: 1dvh;") + rtl("border-right-width: 3px;"),
+      );
+      compiled(
+        "border-inline-start: 3px solid red; border-left: 1dvh solid #00f",
+        rule("border-left: 1dvh solid #00f;") + rtl("border-right: 3px solid red;"),
+      );
+      compiled(
+        "border-inline-start-color: red; border-left-color: lab(40% 56.6 39)",
+        rule("border-left-color: #b32323; border-left-color: lab(40% 56.6 39);") + rtl("border-right-color: red;"),
+      );
+      compiled(
+        "border-inline-start-color: red; border-left: 1px solid lab(40% 56.6 39)",
+        rule("border-left: 1px solid #b32323; border-left: 1px solid lab(40% 56.6 39);") +
+          rtl("border-right-color: red;"),
       );
 
       // Four-side shorthands set both sides.
@@ -2464,6 +2492,10 @@ describe("css tests", () => {
           rtl("border-top-right-radius: 5px;"),
       );
       compiled("border-start-start-radius: 3px; border-radius: 1px", rule("border-radius: 1px;"));
+      compiled(
+        "border-start-start-radius: 3px; border-top-left-radius: 1dvh",
+        rule("border-top-left-radius: 1dvh;") + rtl("border-top-right-radius: 3px;"),
+      );
       compiled(
         "border-start-start-radius: 3px; border-radius: 1px; border-start-start-radius: 5px",
         rule("border-radius: 1px;") + ltr("border-top-left-radius: 5px;") + rtl("border-top-right-radius: 5px;"),

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -2228,6 +2228,9 @@ describe("css tests", () => {
       rule("margin-left: 1px; margin-left: 1dvh;") + rtl("margin-right: 3px;"),
     );
     compiled("margin-inline-start: 3px; margin-left: 1dvh", rule("margin-left: 1dvh;") + rtl("margin-right: 3px;"));
+    // The 4-side shorthand drops the block value it overrides, unless it is needed as a fallback.
+    compiled("margin-block-start: 3px; margin: 0", rule("margin: 0;"));
+    compiled("margin-block-start: 3px; margin: 1dvh", rule("margin-top: 3px; margin: 1dvh;"));
 
     describe("border", () => {
       compiled(
@@ -2320,6 +2323,8 @@ describe("css tests", () => {
         "border-block-start-width: 3px; border-top-width: 1dvh",
         rule("border-top-width: 3px; border-top-width: 1dvh;"),
       );
+      compiled("border-block-start-width: 3px; border-width: 1px", rule("border-width: 1px;"));
+      compiled("border-block-start-width: 3px; border-width: 1dvh", rule("border-top-width: 3px; border-width: 1dvh;"));
       compiled(
         "border-inline-start-width: 3px; border-left-width: 1dvh",
         rule("border-left-width: 1dvh;") + rtl("border-right-width: 3px;"),


### PR DESCRIPTION
### Problem
- With targets that lack logical properties, a physical longhand declared after a logical one for the same side loses to it. `.a{margin-inline-start:3px;margin-left:1px}` compiled for `safari 8` (or `chrome 60`) prints `.a{margin-left:1px}` followed by `.a:not(:is(:lang(ar), ...)){margin-left:3px}` and `.a:is(...){margin-right:3px}`, so ltr pages get `margin-left: 3px`, while the source (and any browser that understands logical properties) resolves it to `1px`. The same happens for padding, inset, every `border-inline-*` longhand and side shorthand, and the logical `border-*-radius` corners. Upstream lightningcss 1.30 prints the same thing, so this is inherited, not a regression.
- Cause: the minifier compiles an inline logical value into one declaration for an ltr rule and one for an rtl rule (`PropertyHandlerContext::add_logical_rule`, `src/css/context.rs`), and those rules are appended after the rule being minified, so they win over everything in it. The handlers flushed their buffered logical values the moment a physical value arrived (`flush_helper_physical` in `src/css/properties/margin_padding.rs`, `flush_helper!`/`set_border_helper!` in `border.rs`, `property_helper!` in `border_radius.rs`), before knowing which sides the physical declarations would set, so both direction copies were always emitted.

### Fix
- While logical values are being compiled away, a physical value arriving after buffered logical ones no longer flushes them; it is buffered alongside. The physical slots can then only hold values declared after the logical ones: a logical value still flushes a physical buffer first, and every arm that stores a physical value now records the physical category (the 4-side `margin`/`border` arms did not).
- `flush` writes the logical values out first. Block values go into the rule itself as before, so source order still decides there. For each inline value (and each logical radius corner) the direction that maps onto a physical side set in the same buffer is skipped, via a new `PropertyHandlerContext::add_directional_rule`; the other direction is still emitted. This is correct because in the skipped direction the later physical declaration is what the cascade resolves to, and the skipped copy had no effect other than overriding it; in the other direction the logical value is still the last declaration for that side. `.a{margin-inline-start:3px;margin-left:1px}` now prints `.a{margin-left:1px}` plus only the rtl rules with `margin-right:3px`; with `margin-right` also declared afterwards nothing is appended at all.
- In `border.rs` this is done per sub-property (width/style/color) in `flush_overridden_inline`, which runs before the existing `flush_category!` and takes the affected values out of it; surviving halves are pushed as longhands and the appended rules are re-minified anyway, so `border-inline-start: 3px solid red; border-left: 1px solid blue` still yields a `border-right: 3px solid red` shorthand in the rtl rules.
- Unparsed physical declarations (`margin-left: var(--x)`) are written out directly rather than buffered; `flush_before_unparsed` writes out everything that belongs in the rule itself, keeps the compiled inline values buffered and records the sides written out ahead of them (`declared_after_inline`), so any number of them behave exactly like buffered physical values. The border handler additionally holds back unparsed inline logical declarations (`border-inline-start: var(--b)`) in `unparsed_inline`, as the margin handler already did through its `Option<Property>` slots, so a later `border-left` overrides them too; a declaration that overrides only part of such a value leaves it untouched, since it cannot be split.
- Values whose syntax some target rejects (`1dvh` for these targets) keep their fallbacks: the existing flush that keeps the previous value of a property ahead of such a value now also counts a buffered logical value that compiles into the rule itself as the previous value of the physical property: a block value, or an inline pair with equal values. So `margin-block-start:3px; margin:1dvh` still prints `margin-top:3px; margin:1dvh`, and `margin-inline:3px; margin-left:1dvh` still prints `margin-left:3px; margin-right:3px; margin-left:1dvh` (the 4-side shorthand arms drop the logical values otherwise). The physical side shorthands (`border-left: 1dvh solid blue`) and the 4-side `border` shorthand get the same check for width and color, which they lacked. A logical side shorthand gets none: its fallback would go into the ltr/rtl rules, which override the rule itself where an equal inline pair lands. The 4-side `border-width`/`border-style`/`border-color` arms run every fallback check before they store a side, so a fallback for a later side no longer splits the shorthand. An unequal inline value is dropped for the overridden direction regardless of the later value's syntax: keeping it is exactly what overrides the later value in every browser that does support the syntax, and a copy that both applies only in one direction and yields to the later value cannot be expressed in the rule itself. For colors, the common case of such syntax, the generated rgb fallback covers the old targets, so `border-inline-start-color: red; border-left-color: lab(...)` now resolves to the lab color (or its fallback) on the left everywhere.
- With targets that support logical properties nothing changes: no value is buffered across the category switch, so everything is still emitted in source order.
- Verified with the new `physical declaration after a compiled logical one` block in `test/js/bun/css/css.test.ts` (margin/padding/inset, border, border-radius: every side and corner combination, both sides declared, equal inline values, unparsed values on either side and several in a row, the 4-side shorthands, a logical value declared again afterwards, unsupported syntax, and the unaffected orders): 110 of the 173 cases fail on a build without the `src/` changes (a debug build of main) and all pass with them; the remaining 63 pin output that must not change.
- `bun bd test test/js/bun/css/` and `test/bundler/css/` are otherwise unchanged (the `nested-vendor-prefix-duplication` and `nth-anplusb-ident` 5s timeouts reproduce on a debug build of main here too); `cargo clippy -p bun_css` is clean.
- Related open PRs, all compatible with this one: #38576 and #38607 change the 4-side shorthand arms (this PR covers the longhand and side-shorthand case; those arms now join the buffer the same way), #38551 adds the same category line to the shorthand arms, #38582 fixes the unparsed `border-block-*` arm of `flush_unparsed` next to the arm changed here, #38597 adds `!important` tracking to the context lists this PR pushes into.

### Background
- Compiling logical properties: for targets without `margin-inline-start` and friends, the minifier rewrites block-axis properties into the physical top/bottom ones inside the same rule, and inline-axis ones into two extra rules appended after it: one matching ltr documents (`:not(:lang(<rtl languages>))`, emitted twice because `:is()` is prefixed for such targets) with the left/right mapping for ltr text, and one matching rtl documents with the opposite mapping. `border-start-start-radius` and the other logical corners are compiled the same way, since every corner depends on the direction. The appended rules have higher specificity and come later, so any declaration in them beats the same property in the original rule.
- Property handlers: during minification each declaration block is fed to per-family handlers (`SizeHandler` for margin/padding/inset, `BorderHandler`, `BorderRadiusHandler`). A handler buffers the values of its family and writes them out ("flushes") as merged shorthands when something forces it to: the end of the block, a value that cannot be merged, or, until now, any switch between physical and logical values (`category`). Values flushed into the rule keep the order they are emitted in; values flushed into the direction rules always end up after the rule.
- Unparsed values: declarations the parser cannot fully interpret (for example ones containing `var()`) are kept as `Property::Unparsed` with the property id and the raw tokens. The margin handler buffers logical ones in its slots like parsed values; the border handler used to write them out immediately.

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 110 failed, 69 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/css/css.test.ts
bun test v1.4.3 (b52d51348)

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [10.58ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [2.25ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [2.03ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.element {
  color: var(--my-color);
  background-color: var(--my-bg);
  font-size: var(--my-font-size);
}

(pass) css tests > custom property cases > :root {
        --my-color: red;
        --my-bg: w
... (truncated)

release without fix: 15 failed, 69 skipped
bun test v1.4.3-canary.1 (0b7e8a14e)

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [0.69ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [0.04ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [0.65ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.element {
  color: var(--my-color);
  background-color: var(--my-bg);
  font-size: var(--my-font-size);
}

(pass) css tests > custom property cases > :root {
        --my-color: red;
        --my-bg: white;
        --my-font-size: 16px;
      }
      .element {
        color: var(--my-color);
        background-color: var(--my-bg);
        font-size: 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 69 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/css/css.test.ts
bun test v1.4.3 (b52d51348)

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [12.33ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [1.77ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [1.36ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.element {
  color: var(--my-color);
  background-color: var(--my-bg);
  font-size: var(--my-font-size);
}

(pass) css tests > custom property cases > :root {
        --my-color: red;
        --my-bg: w
... (truncated)

release with fix: 69 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 732ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/7] cargo bun_runtime → libbun_runtime.a
[1m[33mwarning[0m[1m: binary `bun_shim_impl` should have a kebab-case name[0m
   [1m[94m|[0m
[1m[94m 1[0m [1m[94m|[0m /workspace/bun/build/release/rust-target/.../bun_shim_impl
   [1m[94m|[0m                                              [1m[33m^^^^^^^^^^^^^[0m
   [1m[94m|[0m
   [1m[94m= [0m[1mnote[0m: `cargo::non_kebab_case_bins` is set to `warn` by default
[1m[96mhelp[0m: to change the binary name to `bun-shim-impl`, convert `bin.name`
  [1m[94m--> [0msrc/install/windows-shim/Cargo.toml:41:8
   [1m[94m|[0m
[1m[94m41[0m [91m- [0mname = [91m"bun_shim_impl"[0m
[1m[94m41[0m [92m+ [0mname = [92m"bun-shim-impl"[0m
   [1m[94m|[0m
[1m[33mwarning[0m: `bun_shim_impl` (manifest) generated 1 warning
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   C
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/css/context.rs                   |  25 +-
 src/css/properties/border.rs         | 410 ++++++++++++++++++++++------
 src/css/properties/border_radius.rs  | 157 +++++++++--
 src/css/properties/margin_padding.rs | 363 +++++++++++++++----------
 test/js/bun/css/css.test.ts          | 501 +++++++++++++++++++++++++++++++++++
 5 files changed, 1209 insertions(+), 247 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/css/context.rs                        0      0     27
src/css/properties/border.rs              9     15     27
src/css/properties/border_radius.rs       0      0     27
src/css/properties/margin_padding.rs      2      5     27
test/js/bun/css/css.test.ts               5      8     27
```

</details>

<!-- robobun:evidence:end -->