### PR TITLE
bundler: list tree-shaken files in the metafile inputs so import edges resolve

### DIFF
--- a/src/bundler/linker_context/MetafileBuilder.rs
+++ b/src/bundler/linker_context/MetafileBuilder.rs
@@ -216,17 +216,14 @@ pub(crate) fn generate(c: &mut LinkerContext, chunks: &mut [Chunk]) -> crate::Re
     let loaders = parse_graph.input_files.items_loader();
     let import_records_list = parse_graph.ast.items_import_records();
 
-    // Iterate through all files in chunks to collect unique source indices
+    // Every reachable file is an input, not just the files that made it into a chunk:
+    // tree shaking drops whole files (a `sideEffects: false` module with no used
+    // exports, a module only reached from dead code), but the import records written
+    // below still point at them, so they must be keys of "inputs". Which files each
+    // output was built from is `outputs[].inputs`, which stays chunk-based.
     let mut seen_sources = DynamicBitSet::init_empty(sources.len())?;
-    // defer seen_sources.deinit() — handled by Drop
-
-    // Mark all files that appear in chunks
-    for chunk in chunks.iter() {
-        for &source_index in chunk.files_with_parts_in_chunk.keys() {
-            if (source_index as usize) < sources.len() {
-                seen_sources.set(source_index as usize);
-            }
-        }
+    for source_index in c.graph.reachable_files.slice() {
+        seen_sources.set(source_index.get() as usize);
     }
 
     // Write inputs

--- a/test/bundler/metafile.test.ts
+++ b/test/bundler/metafile.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { tempDir } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 // Type definitions for metafile structure
 interface MetafileImport {
@@ -534,6 +534,84 @@ describe("bundler metafile", () => {
     }
   });
 
+  // Builds entry.js from inside the fixture directory, so the input keys are the
+  // fixture's relative file names.
+  async function buildMetafileInDir(dir: string): Promise<Metafile> {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "entry.js", "--outdir=out", "--metafile=meta.json"],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return await Bun.file(`${dir}/meta.json`).json();
+  }
+
+  test("metafile lists a sideEffects: false module that tree shaking dropped from the output", async () => {
+    const files = {
+      "entry.js": `import { x } from "pkg";\nconsole.log("hi");\n`,
+      "node_modules/pkg/package.json": JSON.stringify({ name: "pkg", main: "index.js", sideEffects: false }),
+      // `x` is unused and the package has no side effects, so nothing of this file is
+      // bundled. It is still an input, and the one entry.js's import points at.
+      "node_modules/pkg/index.js": `export const x = 1;\n`,
+    };
+    using dir = tempDir("metafile-tree-shaken-package", files);
+
+    const metafile = await buildMetafileInDir(String(dir));
+
+    expect(metafile.inputs).toEqual({
+      "entry.js": {
+        bytes: files["entry.js"].length,
+        imports: [{ path: "node_modules/pkg/index.js", kind: "import-statement", original: "pkg" }],
+        format: "esm",
+      },
+      "node_modules/pkg/index.js": {
+        bytes: files["node_modules/pkg/index.js"].length,
+        imports: [],
+        format: "esm",
+      },
+    });
+
+    // The outputs side still only lists what was bundled into each output, as in esbuild.
+    expect(Object.values(metafile.outputs).map(output => Object.keys(output.inputs))).toEqual([["entry.js"]]);
+  });
+
+  test("metafile lists modules only reached from tree-shaken code, and what they import", async () => {
+    const files = {
+      // `unused` is dead code, so lazy.js and everything below it is bundled into
+      // nothing. No sideEffects flag is involved.
+      "entry.js": `function unused() { return require("./lazy.js"); }\nconsole.log("hi");\n`,
+      "lazy.js": `import "./effect.js";\nmodule.exports = 1;\n`,
+      "effect.js": `console.log("effect");\n`,
+    };
+    using dir = tempDir("metafile-tree-shaken-require", files);
+
+    const metafile = await buildMetafileInDir(String(dir));
+
+    expect(metafile.inputs).toEqual({
+      "entry.js": {
+        bytes: files["entry.js"].length,
+        imports: [{ path: "lazy.js", kind: "require-call", original: "./lazy.js" }],
+        format: "cjs",
+      },
+      "lazy.js": {
+        bytes: files["lazy.js"].length,
+        imports: [{ path: "effect.js", kind: "import-statement", original: "./effect.js" }],
+        format: "cjs",
+      },
+      "effect.js": {
+        bytes: files["effect.js"].length,
+        imports: [],
+        format: "esm",
+      },
+    });
+
+    expect(Object.values(metafile.outputs).map(output => Object.keys(output.inputs))).toEqual([["entry.js"]]);
+  });
+
   test("metafile import paths are deterministic across repeated builds", async () => {
     const N = 30;
     const files: Record<string, string> = { "b/shared.js": `export const s = 1;` };
@@ -800,8 +878,6 @@ describe("Bun.build metafile option variants", () => {
 });
 
 // CLI tests for --metafile-md
-import { bunEnv, bunExe } from "harness";
-
 describe("bun build --metafile-md", () => {
   test("generates markdown metafile with default name", async () => {
     using dir = tempDir("metafile-md-test", {
@@ -1214,6 +1290,32 @@ describe("bun build --metafile-md", () => {
 
     // helper.js is imported by main.js
     expect(content).toMatch(/\[IMPORTED_BY: .*helper\.js <- main\.js\]/);
+  });
+
+  test("markdown lists a module that tree shaking dropped from the output", async () => {
+    using dir = tempDir("metafile-md-tree-shaken", {
+      "entry.js": `import { x } from "pkg";\nconsole.log("hi");\n`,
+      "node_modules/pkg/package.json": JSON.stringify({ name: "pkg", main: "index.js", sideEffects: false }),
+      "node_modules/pkg/index.js": `export const x = 1;\n`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "entry.js", "--metafile-md", "--outdir=dist"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+
+    const content = await Bun.file(`${dir}/meta.md`).text();
+    expect(content).toContain("| Input modules | 2 |");
+    expect(content).toContain("[MODULE: node_modules/pkg/index.js]");
+    expect(content).toContain("[IMPORT: entry.js -> node_modules/pkg/index.js]");
+    expect(content).toContain("[IMPORTED_BY: node_modules/pkg/index.js <- entry.js]");
   });
 
   test("markdown includes entry point markers", async () => {

--- a/test/bundler/metafile.test.ts
+++ b/test/bundler/metafile.test.ts
@@ -550,7 +550,7 @@ describe("bundler metafile", () => {
     return await Bun.file(`${dir}/meta.json`).json();
   }
 
-  test("metafile lists a sideEffects: false module that tree shaking dropped from the output", async () => {
+  test.concurrent("metafile lists a sideEffects: false module that tree shaking dropped from the output", async () => {
     const files = {
       "entry.js": `import { x } from "pkg";\nconsole.log("hi");\n`,
       "node_modules/pkg/package.json": JSON.stringify({ name: "pkg", main: "index.js", sideEffects: false }),
@@ -579,7 +579,7 @@ describe("bundler metafile", () => {
     expect(Object.values(metafile.outputs).map(output => Object.keys(output.inputs))).toEqual([["entry.js"]]);
   });
 
-  test("metafile lists modules only reached from tree-shaken code, and what they import", async () => {
+  test.concurrent("metafile lists modules only reached from tree-shaken code, and what they import", async () => {
     const files = {
       // `unused` is dead code, so lazy.js and everything below it is bundled into
       // nothing. No sideEffects flag is involved.
@@ -1292,7 +1292,7 @@ describe("bun build --metafile-md", () => {
     expect(content).toMatch(/\[IMPORTED_BY: .*helper\.js <- main\.js\]/);
   });
 
-  test("markdown lists a module that tree shaking dropped from the output", async () => {
+  test.concurrent("markdown lists a module that tree shaking dropped from the output", async () => {
     using dir = tempDir("metafile-md-tree-shaken", {
       "entry.js": `import { x } from "pkg";\nconsole.log("hi");\n`,
       "node_modules/pkg/package.json": JSON.stringify({ name: "pkg", main: "index.js", sideEffects: false }),


### PR DESCRIPTION
### Problem
- With `--metafile`, a file that tree shaking removes entirely is missing from `inputs`, while the `imports[]` of the file that imports it still points at it: the edge has no target and is not marked `external`. Consumers that walk `inputs` edges (esbuild's analyzer, `--metafile-md`) hit a dangling edge. Reproduces on bun 1.4.0 and main.
- Two ways to get there, repro in the details block below:
  - `import { x } from "pkg"` where `pkg` has `"sideEffects": false` and `x` is unused: `inputs` has only `entry.js`, whose imports list `node_modules/pkg/index.js`.
  - `function unused() { return require("./lazy.js") }` (no `sideEffects` field anywhere): `lazy.js` and the `effect.js` it imports are both missing, `entry.js` still lists `lazy.js`.
- esbuild lists these files in `inputs` (with their own `imports`) and leaves them out of `outputs[].inputs`, so the edges resolve. `bun build` itself already counts them ("Bundled 2 modules" for the first repro).
- Cause: `generate` in src/bundler/linker_context/MetafileBuilder.rs seeds the set of inputs to write from `chunk.files_with_parts_in_chunk` of every chunk (lines 223-230 on main). That map is filled in src/bundler/linker_context/computeChunks.rs:291-292 from the reachable files that are also in `files_live`, so it only holds files that survived tree shaking. The per-input `imports` are written from the importer's import records (MetafileBuilder.rs:299-312), whose `source_index` still points at the removed file.

### Fix
- `generate` seeds the inputs from `c.graph.reachable_files` instead of chunk membership. Nothing else changes: the per-input fields, the index-order emission, and `outputs[].inputs` (still derived from `files_with_parts_in_chunk`) are as before.
- Why this is the right set: `reachable_files` is the closure of the entry points over import records with a valid `source_index`, computed before tree shaking (`find_reachable_files`, src/bundler/bundle_v2.rs). The import records written into `imports[]` are exactly the edges that traversal followed, so every bundled import edge now lands on an `inputs` key. Conversely every file that was in a chunk is reachable (the chunk maps are filled from `reachable_files`, see above), so nothing that was listed before disappears. It is the set esbuild writes as well (checked against esbuild 0.25.12 on both repros) and the one the "Bundled N modules" summary counts (`reachable_files_count` in bundle_v2.rs).
- `outputs[].inputs` is deliberately left chunk-based: a removed file contributed nothing to any output, and esbuild omits it there too (covered by the tests).
- Verified with test/bundler/metafile.test.ts: `metafile lists a sideEffects: false module that tree shaking dropped from the output`, `metafile lists modules only reached from tree-shaken code, and what they import` (also checks the removed module's own import edge and that outputs are unchanged), and `markdown lists a module that tree shaking dropped from the output` (`--metafile-md` module list and reverse dependency). All three fail on the released build (`USE_SYSTEM_BUN=1`, the only diff being the missing entries) and pass with `bun bd test`; the rest of the file (47 tests), test/bundler/esbuild/metafile.test.ts and `css/MetafileCSSBundleTwoToOne` pass with the debug build. `cargo clippy -p bun_bundler --no-deps` and `cargo fmt --check` are clean.
- Side effect worth knowing: a CSS entry point's stylesheets (which have no JS chunk and an empty CSS chunk map today) now show up in `inputs` as well; the `outputs` half of that is #38341 (its source merges cleanly with this; the test file conflicts only on adjacent import lines). #38337 adds document assets to the same seeding loop; those assets are reachable, so this change covers its metafile part and that hunk can be dropped when the two meet. #38465 builds a map inside the loop this removes and needs a small rebase. #36974 (input ordering) merges cleanly.

### Background
- Metafile: esbuild's build report format. `inputs` maps each source file to its size and the imports found in it (edges between source files, or `external: true`); `outputs` maps each emitted file to the inputs it was built from (`bytesInOutput`) and the chunks it imports. Bun writes `outputs` per chunk during chunk generation and assembles `inputs` afterwards in `metafile_builder::generate`.
- Reachable files: before linking, the bundler walks import records from the entry points and records every file it reaches (`graph.reachable_files`). This is the set of files that were parsed into the build.
- Tree shaking: the linker then marks files and parts live starting from the entry points. A file with no used exports whose package declares `"sideEffects": false`, or one only referenced from code that is itself dead, is never marked live. `compute_chunks` places only live files into chunks, and a chunk's `files_with_parts_in_chunk` is what `outputs[].inputs` and, until this change, `inputs` were generated from.

<details>
<summary>Repro</summary>

```sh
mkdir -p d/node_modules/pkg && cd d
printf 'import { x } from "pkg";\nconsole.log("hi");\n' > entry.js
printf '{"name":"pkg","main":"index.js","sideEffects":false}\n' > node_modules/pkg/package.json
printf 'export const x = 1;\n' > node_modules/pkg/index.js
bun build entry.js --outdir out --metafile=meta.json
```

Before (bun 1.4.0 and main), `inputs`:

```json
{
  "entry.js": {
    "bytes": 44,
    "imports": [{ "path": "node_modules/pkg/index.js", "kind": "import-statement", "original": "pkg" }],
    "format": "esm"
  }
}
```

After (same as esbuild's `inputs` for this project):

```json
{
  "entry.js": {
    "bytes": 44,
    "imports": [{ "path": "node_modules/pkg/index.js", "kind": "import-statement", "original": "pkg" }],
    "format": "esm"
  },
  "node_modules/pkg/index.js": { "bytes": 20, "imports": [], "format": "esm" }
}
```

`outputs["./entry.js"].inputs` is `{ "entry.js": { "bytesInOutput": 19 } }` before and after.

Second shape, without any `sideEffects` field:

```sh
printf 'function unused() { return require("./lazy.js"); }\nconsole.log("hi");\n' > entry.js
printf 'import "./effect.js";\nmodule.exports = 1;\n' > lazy.js
printf 'console.log("effect");\n' > effect.js
bun build entry.js --outdir out --metafile=meta.json
```

Before, `inputs` keys: `["entry.js"]`, with `entry.js` importing `lazy.js`. After: `["entry.js", "lazy.js", "effect.js"]`, with `lazy.js` importing `effect.js`. esbuild lists the same three.

`--metafile-md` for the first repro, before: `| Input modules | 1 |` and an `[IMPORT: entry.js -> node_modules/pkg/index.js]` line with no matching `[MODULE: ...]` or `[IMPORTED_BY: ...]`. After: `| Input modules | 2 |`, `[MODULE: node_modules/pkg/index.js]`, `[IMPORTED_BY: node_modules/pkg/index.js <- entry.js]`.

Also checked with the fixed build: an HTML entry point (scripts, stylesheet, `<img>`, `url()` asset), a JS entry importing CSS, a `sideEffects: false` barrel with an unused re-export, and the first repro under `--splitting` all produce the same `inputs` as before plus, where applicable, the removed modules; a CSS entry point now lists its stylesheets (see the last Fix bullet).
</details>
