### PR TITLE
docs(sql): onconnect/onclose receive an error argument, not a client

### DIFF
--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -660,16 +660,13 @@ const sql = new SQL({
   //   cert: "path/to/cert.pem",
   // },
 
-  // Callbacks
-  onconnect: client => {
-    console.log("Connected to MySQL");
+  // Callbacks (see "Connection callbacks" below)
+  onconnect: err => {
+    if (!err) console.log("Connected to MySQL");
   },
-  onclose: (client, err) => {
-    if (err) {
-      console.error("MySQL connection error:", err);
-    } else {
-      console.log("MySQL connection closed");
-    }
+  onclose: err => {
+    // err.code is e.g. ERR_MYSQL_CONNECTION_CLOSED or ERR_MYSQL_IDLE_TIMEOUT
+    console.log("MySQL connection closed:", err);
   },
 });
 ```
@@ -709,12 +706,13 @@ const sql = new SQL({
   //   },
   // },
 
-  // Callbacks
-  onconnect: client => {
-    console.log("Connected to PostgreSQL");
+  // Callbacks (see "Connection callbacks" below)
+  onconnect: err => {
+    if (!err) console.log("Connected to PostgreSQL");
   },
-  onclose: client => {
-    console.log("PostgreSQL connection closed");
+  onclose: err => {
+    // err.code is e.g. ERR_POSTGRES_CONNECTION_CLOSED or ERR_POSTGRES_IDLE_TIMEOUT
+    console.log("PostgreSQL connection closed:", err);
   },
 });
 ```
@@ -738,12 +736,16 @@ const sql = new SQL({
   strict: true, // Enable strict mode for better type safety
   safeIntegers: false, // Use BigInt for integers exceeding JS number range
 
-  // Callbacks
-  onconnect: client => {
-    console.log("SQLite database opened");
+  // Callbacks (see "Connection callbacks" below)
+  onconnect: err => {
+    if (err) {
+      console.error("Failed to open SQLite database:", err);
+    } else {
+      console.log("SQLite database opened");
+    }
   },
-  onclose: client => {
-    console.log("SQLite database closed");
+  onclose: err => {
+    console.log("SQLite database closed:", err);
   },
 });
 ```
@@ -756,6 +758,13 @@ const sql = new SQL({
 - **Memory Databases**: Using `:memory:` creates a temporary database that exists only for the connection lifetime.
 
 </Accordion>
+
+### Connection callbacks
+
+`onconnect` and `onclose` each receive a single argument, `err`, which is an `Error` or `null`. Neither callback receives the connection.
+
+- `onconnect` is called once for each connection that is opened, with `null`. SQLite passes the error instead when the database could not be opened. PostgreSQL and MySQL report a failed connection attempt through `onclose`, not `onconnect`.
+- `onclose` is called once for each connection that closes, with the error describing why it closed. `err` is set even when you closed the connection yourself: `sql.close()` passes `ERR_POSTGRES_CONNECTION_CLOSED` / `ERR_MYSQL_CONNECTION_CLOSED` (for SQLite, an `Error` with the message `"Connection closed"`), `idleTimeout` passes `ERR_POSTGRES_IDLE_TIMEOUT` / `ERR_MYSQL_IDLE_TIMEOUT`, and a failed connection attempt passes the connection error, such as `ERR_POSTGRES_CONNECTION_REFUSED`.
 
 ---
 


### PR DESCRIPTION
### Problem
- The MySQL, PostgreSQL and SQLite blocks under "Connection Options" in `docs/runtime/sql.mdx` show `onconnect: client => ...` and (MySQL) `onclose: (client, err) => ...`.
- Both callbacks are called with exactly one argument, the error or `null`: `src/js/internal/sql/shared.ts` (`connectionInfo.onconnect(err)` in `handleConnected`, `connectionInfo.onclose(err)` in `#finishClose`) and `src/js/internal/sql/sqlite.ts` (`onconnect(null)` / `onconnect(error)`, `onclose(this.storedError)`). `packages/bun-types/sql.d.ts` declares both as `(err: Error | null) => void`.
- Following the MySQL example, `client` is actually the error and `err` is always `undefined`, so the example's `if (err)` branch never runs. The old MySQL snippet also fails to compile against bun-types (`Target signature provides too few arguments`).
- The MySQL example's `else` branch implied a deliberate close passes no error. It does: `sql.close()` calls `onclose` with `ERR_POSTGRES_CONNECTION_CLOSED` / `ERR_MYSQL_CONNECTION_CLOSED`, and SQLite passes `new Error("Connection closed")`.

### Fix
- Rewrite the three examples with the real signature (`onconnect: err => ...`, `onclose: err => ...`) and drop the misleading branching.
- Add a short "Connection callbacks" subsection stating what each callback receives: one `err` argument, `null` to `onconnect` on success (SQLite passes the open error on failure; PostgreSQL/MySQL report failed attempts via `onclose`), and always an error to `onclose`, including for `sql.close()` and `idleTimeout`.
- Correct because it matches the runtime and the published types; every statement in the new text is also pinned by existing tests (`test/js/sql/sql-onconnect-onclose-throw.test.ts` expects `onconnect: null` and `onclose: Connection closed` around `sql.end()` for postgres and mysql; `test/js/sql/sql-mysql.test.ts` "Connection timeout works" expects `onconnect` not called and `onclose` called once on a failed attempt, and "Idle timeout works at start" expects `ERR_MYSQL_IDLE_TIMEOUT` in `onclose`).
- Docs only, no runtime or type change, so there is no new test. Verification:
  - Extracted the three updated code blocks from the page and type-checked them as written against `packages/bun-types` with `strict` + `exactOptionalPropertyTypes` (passes; the previous MySQL block fails with the error quoted above).
  - Ran the same three blocks against local PostgreSQL, MariaDB and an in-memory SQLite with only the connection details substituted: each prints its "Connected"/"opened" line, then `onclose` receives `PostgresError ERR_POSTGRES_CONNECTION_CLOSED`, `MySQLError ERR_MYSQL_CONNECTION_CLOSED`, and `Error: Connection closed` respectively.
  - Probed the other claims with the released binary: `onconnect`/`onclose` are invoked with `arguments.length === 1` on all three adapters; `idleTimeout: 1` delivers `ERR_POSTGRES_IDLE_TIMEOUT` / `ERR_MYSQL_IDLE_TIMEOUT`; a bad role / refused port on postgres and mysql calls `onclose` (with `ERR_POSTGRES_SERVER_ERROR`, `ERR_POSTGRES_CONNECTION_REFUSED`, `ERR_MYSQL_SERVER_ERROR`) and never `onconnect`; SQLite with `create: false` on a missing file calls `onconnect` with `SQLITE_CANTOPEN`; a `max: 2` pool fires each callback twice.
  - `prettier --check docs/runtime/sql.mdx` passes.

### Background
- `onconnect` / `onclose` are per-connection hooks passed in the `SQL` constructor options. For PostgreSQL and MySQL the pool creates up to `max` connections and the hooks fire once for each of them; the native connection reports to an internal handler in `shared.ts`, which then calls the user's hook with just the error. For SQLite there is a single connection and `sqlite.ts` calls the hooks directly.
- The `ERR_*_CONNECTION_CLOSED`, `ERR_*_IDLE_TIMEOUT` and `ERR_*_CONNECTION_REFUSED` codes referenced in the new text are the existing `code` values on `SQL.PostgresError` / `SQL.MySQLError`, already listed in the page's "Error Handling" section.
