### PR TITLE
test(install): normalize the registry URL, not the bare port, in the lockb print snapshot

### DIFF
--- a/test/cli/install/__snapshots__/bun-install-registry.test.ts.snap
+++ b/test/cli/install/__snapshots__/bun-install-registry.test.ts.snap
@@ -315,17 +315,17 @@ exports[`duplicate dependency in optionalDependencies maintains sort order 1`] =
 
 "@types/is-number@>=1.0.0":
   version "2.0.0"
-  resolved "http://localhost:4873/@types/is-number/-/is-number-2.0.0.tgz"
+  resolved "http://localhost:1234/@types/is-number/-/is-number-2.0.0.tgz"
   integrity sha512-GEeIxCB+NpM1NrDBqmkYPeU8bI//i+xPzdOY4E1YHet51IcFmz4js6k57m69fLl/cbn7sOR7wj9RNNw53X8AiA==
 
 a-dep@1.0.1:
   version "1.0.1"
-  resolved "http://localhost:4873/a-dep/-/a-dep-1.0.1.tgz"
+  resolved "http://localhost:1234/a-dep/-/a-dep-1.0.1.tgz"
   integrity sha512-6nmTaPgO2U/uOODqOhbjbnaB4xHuZ+UB7AjKUA3g2dT4WRWeNxgp0dC8Db4swXSnO5/uLLUdFmUJKINNBO/3wg==
 
 duplicate-optional@1.0.1:
   version "1.0.1"
-  resolved "http://localhost:4873/duplicate-optional/-/duplicate-optional-1.0.1.tgz"
+  resolved "http://localhost:1234/duplicate-optional/-/duplicate-optional-1.0.1.tgz"
   integrity sha512-tL28+yJiTPehPLq7QnOu9jbRBpRgfBkyTVveaJojKcyae2khKuLaPRvsiX5gXv+iNGpYiYcNnV1eDBLXS+L85A==
   dependencies:
     a-dep "1.0.1"
@@ -335,12 +335,12 @@ duplicate-optional@1.0.1:
 
 no-deps@1.0.1, no-deps@^1.0.0:
   version "1.0.1"
-  resolved "http://localhost:4873/no-deps/-/no-deps-1.0.1.tgz"
+  resolved "http://localhost:1234/no-deps/-/no-deps-1.0.1.tgz"
   integrity sha512-3X6cn4+UJdXJuLPu11v8i/fGLe2PdI6v1yKTELam04lY5esCAFdG/qQts6N6rLrL6g1YRq+MKBAwxbmUQk355A==
 
 two-range-deps@1.0.0:
   version "1.0.0"
-  resolved "http://localhost:4873/two-range-deps/-/two-range-deps-1.0.0.tgz"
+  resolved "http://localhost:1234/two-range-deps/-/two-range-deps-1.0.0.tgz"
   integrity sha512-N+6kPy/GxuMncNz/EKuIrwdoYbh1qmvHDnw1UbM3sQE184kBn+6qAQgtf1wgT9dJnt6X+tWcTzSmfDvtJikVBA==
   dependencies:
     no-deps "^1.0.0"
@@ -348,7 +348,7 @@ two-range-deps@1.0.0:
 
 what-bin@1.0.0:
   version "1.0.0"
-  resolved "http://localhost:4873/what-bin/-/what-bin-1.0.0.tgz"
+  resolved "http://localhost:1234/what-bin/-/what-bin-1.0.0.tgz"
   integrity sha512-sa99On1k5aDqCvpni/TQ6rLzYprUWBlb8fNwWOzbjDlM24fRr7FKDOuaBO/Y9WEIcZuzoPkCW5EkBCpflj8REQ==
 "
 `;

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -6249,7 +6249,7 @@ test("duplicate dependency in optionalDependencies maintains sort order", async 
   });
 
   const out = await stdout.text();
-  expect(out.replaceAll(`${port}`, "4873")).toMatchSnapshot();
+  expect(out.replaceAll(/localhost:\d+/g, "localhost:1234")).toMatchSnapshot();
   expect(await exited).toBe(0);
 });
 


### PR DESCRIPTION
### Problem
- `test/cli/install/bun-install-registry.test.ts`, test `duplicate dependency in optionalDependencies maintains sort order`, flakes on main depending on which random port verdaccio was started on. Seen on the Windows x64 lane in main build 95598 (passed on retry); the port that run got was 7280 and the snapshot diff was:
  ```
  - # bun ./bun.lockb --hash: A1A17280329F8383-20d6659d9c0623de-94508CB3B7915517-4b22a59b37f2f4f6
  + # bun ./bun.lockb --hash: A1A14873329F8383-20d6659d9c0623de-94508CB3B7915517-4b22a59b37f2f4f6
  ```
- Cause: the test prints the binary lockfile with `bun bun.lockb` and normalizes the port with `out.replaceAll(`${port}`, "4873")` (bun-install-registry.test.ts:6252). The bare digits are replaced everywhere in the output, not only in the `resolved` URLs, so any port whose digits occur in the deterministic `--hash:` header line corrupts that line before it is compared with the snapshot.
- Enumerating every port `randomPort()` can return (1024 to 65534) against the committed snapshot: 15 ports break the old assertion (1551, 1728, 2803, 4508, 5517, 6659, 7280, 7915, 8032, 8383, 9155, 9450, 15517, 17280, 28032), all of them through the hash line. About 0.023% of runs of this file, every platform.
- This is the only bare-port normalization left in `test/`; every other lockfile snapshot in this file and its siblings already uses `replaceAll(/localhost:\d+/g, "localhost:1234")`.

### Fix
- Replace only the `localhost:<port>` URLs, using the same regex and `localhost:1234` placeholder as the other lockfile snapshots in the file, and update the six `resolved` URLs in the snapshot entry accordingly. The hash line in the snapshot is unchanged (it never depended on the port, which is why the test passes for the other 64496 ports).
- Correct because the port can only legitimately appear in the output as part of a registry URL; anything else in the output that happens to contain the same digits (the content hash, integrity strings) must be compared as-is.
- Verified:
  - `bun bd test test/cli/install/bun-install-registry.test.ts -t "duplicate dependency in optionalDependencies maintains sort order"` passes (snapshot matched, not rewritten).
  - Fail-before: with `registry.port` forced to 7280 and the original assertion and snapshot, the same command fails with the exact diff above, on both the debug build and the release `bun` on PATH. With this change and the port forced to 7280, 8383 and 1728 it passes.
  - Port enumeration script (below) reports 15 failing ports for the old assertion and 0 for the new one.
- Test-only change, so there is no `src/` diff to stash for a mechanical before/after; the forced-port runs above are the before/after.

### Background
- `VerdaccioRegistry` (test/harness.ts) starts the fixture npm registry on `randomPort()`, so every `resolved` URL that `bun install` writes into the lockfile contains a different port on each run. Snapshot tests of lockfile contents therefore have to normalize the port before comparing.
- `bun <path>.lockb` prints a binary lockfile in yarn v1 lockfile format. Its header includes `# bun ./bun.lockb --hash: <hex>` (src/install/lockfile/printer/Yarn.rs:46), the lockfile's meta hash. `generate_meta_hash` (src/install/lockfile.rs:2924) hashes `name@resolution` lines plus lifecycle scripts, and for npm packages the resolution formats as the bare version (src/install/resolution.rs:767), so the hash never contains the registry port: it is stable across runs and belongs in the snapshot as-is, which is exactly what the old normalization broke.

<details>
<summary>Port enumeration</summary>

Takes the committed snapshot as the expected normalized output, substitutes each candidate port into its URLs to reconstruct what `bun bun.lockb` would print, then applies the old and new normalizations.

```ts
const snap = await Bun.file("test/cli/install/__snapshots__/bun-install-registry.test.ts.snap").text();
const key = "exports[`duplicate dependency in optionalDependencies maintains sort order 1`] = `\n";
const start = snap.indexOf(key) + key.length;
const expectedOld = snap.slice(start, snap.indexOf("\n`;", start)).replace(/^"/, "").replace(/"$/, "");
// snapshot as it was before this PR used localhost:4873; the new one uses localhost:1234
const expectedNew = expectedOld.replaceAll("localhost:4873", "localhost:1234");
const badOld: number[] = []; let badNew = 0;
for (let p = 1024; p <= 65534; p++) {
  const out = expectedOld.replaceAll("localhost:4873", `localhost:${p}`);
  if (out.replaceAll(`${p}`, "4873") !== expectedOld) badOld.push(p);
  if (out.replaceAll(/localhost:\d+/g, "localhost:1234") !== expectedNew) badNew++;
}
console.log(badOld.length, badOld.join(","), badNew);
```

Output against the pre-PR snapshot:

```
ports tried: 64511 (1024..65534)
old assertion fails for 15 ports (0.023%)
  1551, 1728, 2803, 4508, 5517, 6659, 7280, 7915, 8032, 8383, 9155, 9450, 15517, 17280, 28032
new assertion fails for 0 ports
  15 ports hit line 3: # bun ./bun.lockb --hash: A1A17280329F8383-20d6659d9c0623de-94508CB3B7915517-4b22a59b37f2f4f6
```
</details>
