### PR TITLE
sql: fix the build after #32089 × #37275 (LISTEN/NOTIFY error path)

### DIFF
--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -3105,7 +3105,7 @@ impl PostgresSQLConnection {
             return Ok(entry.js.get());
         }
         let js = bun_string_jsc::create_utf8_for_js(global, channel)
-            .map_err(|_| AnyPostgresError::JSError)?;
+            .map_err(crate::jsc::js_error_to_postgres)?;
         if self.channel_names.get().len() < Self::MAX_INTERNED_CHANNELS {
             self.channel_names.with_mut(|names| {
                 names.push(InternedChannel {
@@ -3129,7 +3129,7 @@ impl PostgresSQLConnection {
         let global = self.global();
         let channel_js = self.channel_name_js(global, channel)?;
         let payload_js = bun_string_jsc::create_utf8_for_js(global, payload)
-            .map_err(|_| AnyPostgresError::JSError)?;
+            .map_err(crate::jsc::js_error_to_postgres)?;
         self.event_loop().run_callback(
             callback,
             global,

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -3040,7 +3040,7 @@ impl PostgresSQLConnection {
             }
             MessageType::NotificationResponse => {
                 let resp = protocol::NotificationResponse::decode_internal(reader.reborrow())?;
-                self.on_notification(resp.channel.slice(), resp.payload.slice());
+                self.on_notification(resp.channel.slice(), resp.payload.slice())?;
             }
             MessageType::EmptyQueryResponse => {
                 reader.eat_message(&protocol::EMPTY_QUERY_RESPONSE)?;
@@ -3091,22 +3091,21 @@ impl PostgresSQLConnection {
 
     const MAX_INTERNED_CHANNELS: usize = 256;
 
-    fn channel_name_js(&self, global: &JSGlobalObject, channel: &[u8]) -> Option<JSValue> {
+    fn channel_name_js(
+        &self,
+        global: &JSGlobalObject,
+        channel: &[u8],
+    ) -> Result<JSValue, AnyPostgresError> {
         if let Some(entry) = self
             .channel_names
             .get()
             .iter()
             .find(|entry| entry.bytes.as_ref() == channel)
         {
-            return Some(entry.js.get());
+            return Ok(entry.js.get());
         }
-        let js = match bun_string_jsc::create_utf8_for_js(global, channel) {
-            Ok(js) => js,
-            Err(e) => {
-                global.report_active_exception_as_unhandled(e);
-                return None;
-            }
-        };
+        let js = bun_string_jsc::create_utf8_for_js(global, channel)
+            .map_err(|_| AnyPostgresError::JSError)?;
         if self.channel_names.get().len() < Self::MAX_INTERNED_CHANNELS {
             self.channel_names.with_mut(|names| {
                 names.push(InternedChannel {
@@ -3115,30 +3114,29 @@ impl PostgresSQLConnection {
                 })
             });
         }
-        Some(js)
+        Ok(js)
     }
 
-    fn on_notification(&self, channel: &[u8], payload: &[u8]) {
+    /// A conversion the VM cut short (OOM, a worker's termination) is this connection's
+    /// failure like any other in [`Self::on`]: `JSError` takes the pending exception.
+    fn on_notification(&self, channel: &[u8], payload: &[u8]) -> Result<(), AnyPostgresError> {
         let Some(this_value) = self.js_value.get().try_get() else {
-            return;
+            return Ok(());
         };
         let Some(callback) = js::onnotification_get_cached(this_value) else {
-            return;
+            return Ok(());
         };
         let global = self.global();
-        let Some(channel_js) = self.channel_name_js(global, channel) else {
-            return;
-        };
-        let payload_js = match bun_string_jsc::create_utf8_for_js(global, payload) {
-            Ok(js) => js,
-            Err(e) => return global.report_active_exception_as_unhandled(e),
-        };
+        let channel_js = self.channel_name_js(global, channel)?;
+        let payload_js = bun_string_jsc::create_utf8_for_js(global, payload)
+            .map_err(|_| AnyPostgresError::JSError)?;
         self.event_loop().run_callback(
             callback,
             global,
             JSValue::UNDEFINED,
             &[channel_js, payload_js],
         );
+        Ok(())
     }
 
     pub(crate) fn consume_on_connect_callback(


### PR DESCRIPTION
### What does this PR do?

`main` does not compile: #32089 (sql.listen/notify) calls `JSGlobalObject::report_active_exception_as_unhandled`, which #37275 removed (`bun_sql_jsc`: "no method named `report_active_exception_as_unhandled`", ×2 in `PostgresSQLConnection.rs`).

A NOTIFY channel/payload string the VM could not make (OOM, a worker's termination) is now handled the way every other JS conversion failure inside `PostgresSQLConnection::on()` is: `on_notification` returns `AnyPostgresError::JSError`, and the connection's error path takes the pending exception and fails the connection with it — which is also #37275's rule that an `Err` always leaves its exception pending for exactly one taker.

### How did you verify your code works?

`cargo check -p bun_sql_jsc` and `cargo check -p bun_bin` (full crate graph) pass. The LISTEN/NOTIFY tests need a Postgres server (CI's docker lane).