### PR TITLE
Point the caller frame of a throwing require() at the require call in stack traces

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -1041,7 +1041,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     ) -> Expr {
         // The argument must be a string
         if matches!(arg.data, js_ast::ExprData::EString(_)) {
-            return self.transpose_require_resolve_known_string(arg);
+            return self.transpose_require_resolve_known_string(arg, require_resolve_ref.loc);
         }
 
         if self.options.warn_about_unbundled_modules {
@@ -1065,19 +1065,25 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 args: ExprNodeList::init_one(arg),
                 ..Default::default()
             },
-            arg.loc,
+            require_resolve_ref.loc,
         )
     }
 
+    /// `loc` is the call target of the `require.resolve(...)` being replaced; the
+    /// replacement is attributed to it (see `transpose_require`).
     #[inline]
-    pub(crate) fn transpose_require_resolve_known_string(&mut self, arg: Expr) -> Expr {
+    pub(crate) fn transpose_require_resolve_known_string(
+        &mut self,
+        arg: Expr,
+        loc: bun_ast::Loc,
+    ) -> Expr {
         debug_assert!(matches!(arg.data, js_ast::ExprData::EString(_)));
 
         // Ignore calls to import() if the control flow is provably dead here.
         // We don't want to spend time scanning the required files if they will
         // never be used.
         if self.is_control_flow_dead {
-            return self.new_expr(E::Null {}, arg.loc);
+            return self.new_expr(E::Null {}, loc);
         }
 
         let import_record_index = self.add_import_record(
@@ -1103,19 +1109,25 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 import_record_index,
                 // .leading_interior_comments = arg.getString().
             },
-            arg.loc,
+            loc,
         )
     }
 
     pub(crate) fn transpose_require(&mut self, arg: Expr, state: &TransposeState) -> Expr {
+        // Whatever replaces the `require(...)` call is attributed to the call target
+        // (`state.loc`: the `require` token), not to the argument. The printer emits
+        // that location as the call's source mapping, so a stack frame for the call
+        // remaps to `require(` the way it does for any other call's callee.
+        let loc = state.loc;
+
         if !self.options.features.allow_runtime {
             return self.new_expr(
                 E::Call {
-                    target: self.value_for_require(arg.loc),
+                    target: self.value_for_require(loc),
                     args: ExprNodeList::init_one(arg),
                     ..Default::default()
                 },
-                arg.loc,
+                loc,
             );
         }
 
@@ -1127,7 +1139,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 if self.is_control_flow_dead {
                     return Expr {
                         data: null_expr_data(),
-                        loc: arg.loc,
+                        loc,
                     };
                 }
 
@@ -1196,7 +1208,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 ref_: namespace_ref,
                                 ..Default::default()
                             },
-                            arg.loc,
+                            loc,
                         );
                     }
 
@@ -1208,7 +1220,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             )
                             .expect("int cast"),
                         },
-                        arg.loc,
+                        loc,
                     );
                 }
 
@@ -1231,7 +1243,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         import_record_index,
                         ..Default::default()
                     },
-                    arg.loc,
+                    loc,
                 )
             }
             _ => {
@@ -1239,11 +1251,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 self.record_usage_of_runtime_require();
                 self.new_expr(
                     E::Call {
-                        target: self.value_for_require(arg.loc),
+                        target: self.value_for_require(loc),
                         args: ExprNodeList::init_one(arg),
                         ..Default::default()
                     },
-                    arg.loc,
+                    loc,
                 )
             }
         }

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -1069,13 +1069,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         )
     }
 
-    /// `loc` is the call target of the `require.resolve(...)` being replaced; the
-    /// replacement is attributed to it (see `transpose_require`).
     #[inline]
     pub(crate) fn transpose_require_resolve_known_string(
         &mut self,
         arg: Expr,
-        loc: bun_ast::Loc,
+        call_target_loc: bun_ast::Loc,
     ) -> Expr {
         debug_assert!(matches!(arg.data, js_ast::ExprData::EString(_)));
 
@@ -1083,7 +1081,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // We don't want to spend time scanning the required files if they will
         // never be used.
         if self.is_control_flow_dead {
-            return self.new_expr(E::Null {}, loc);
+            return self.new_expr(E::Null {}, call_target_loc);
         }
 
         let import_record_index = self.add_import_record(
@@ -1109,25 +1107,23 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 import_record_index,
                 // .leading_interior_comments = arg.getString().
             },
-            loc,
+            call_target_loc,
         )
     }
 
     pub(crate) fn transpose_require(&mut self, arg: Expr, state: &TransposeState) -> Expr {
-        // Whatever replaces the `require(...)` call is attributed to the call target
-        // (`state.loc`: the `require` token), not to the argument. The printer emits
-        // that location as the call's source mapping, so a stack frame for the call
-        // remaps to `require(` the way it does for any other call's callee.
-        let loc = state.loc;
+        // Stack frames for a call are mapped at its callee, so the replacement
+        // takes the `require` token's location rather than the argument's.
+        let call_target_loc = state.loc;
 
         if !self.options.features.allow_runtime {
             return self.new_expr(
                 E::Call {
-                    target: self.value_for_require(loc),
+                    target: self.value_for_require(call_target_loc),
                     args: ExprNodeList::init_one(arg),
                     ..Default::default()
                 },
-                loc,
+                call_target_loc,
             );
         }
 
@@ -1139,7 +1135,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 if self.is_control_flow_dead {
                     return Expr {
                         data: null_expr_data(),
-                        loc,
+                        loc: call_target_loc,
                     };
                 }
 
@@ -1208,7 +1204,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 ref_: namespace_ref,
                                 ..Default::default()
                             },
-                            loc,
+                            call_target_loc,
                         );
                     }
 
@@ -1220,7 +1216,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             )
                             .expect("int cast"),
                         },
-                        loc,
+                        call_target_loc,
                     );
                 }
 
@@ -1243,7 +1239,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         import_record_index,
                         ..Default::default()
                     },
-                    loc,
+                    call_target_loc,
                 )
             }
             _ => {
@@ -1251,11 +1247,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 self.record_usage_of_runtime_require();
                 self.new_expr(
                     E::Call {
-                        target: self.value_for_require(loc),
+                        target: self.value_for_require(call_target_loc),
                         args: ExprNodeList::init_one(arg),
                         ..Default::default()
                     },
-                    loc,
+                    call_target_loc,
                 )
             }
         }

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -1112,8 +1112,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     pub(crate) fn transpose_require(&mut self, arg: Expr, state: &TransposeState) -> Expr {
-        // Stack frames for a call are mapped at its callee, so the replacement
-        // takes the `require` token's location rather than the argument's.
+        // Stack frames map a call at its callee, so this lives at `require`, not at the argument.
         let call_target_loc = state.loc;
 
         if !self.options.features.allow_runtime {

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -2021,6 +2021,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 let state = TransposeState {
                     is_require_immediately_assigned_to_decl: in_.is_immediately_assigned_to_decl
                         && matches!(first.data, Data::EString(..)),
+                    loc: e_.target.loc,
                     ..Default::default()
                 };
                 match &first.data {
@@ -2082,7 +2083,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     Data::EString(..) => {
                         // require.resolve(FOO) => require.resolve(FOO)
                         // (this will register dependencies)
-                        *e = p.transpose_require_resolve_known_string(first);
+                        *e = p.transpose_require_resolve_known_string(first, e_.target.loc);
                         return;
                     }
                     Data::EIf(..) => {

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -3313,6 +3313,7 @@ pub(crate) mod __gated_printer {
                     }
                 }
                 ExprData::ERequireString(e) => {
+                    self.add_source_mapping(expr.loc);
                     self.print_require_or_import_expr(
                         e.import_record_index,
                         e.unwrapped_id != u32::MAX,
@@ -3329,6 +3330,7 @@ pub(crate) mod __gated_printer {
                     }
 
                     self.print_space_before_identifier();
+                    self.add_source_mapping(expr.loc);
 
                     if let Some(require_ref) = self.options.require_ref {
                         self.print_symbol(require_ref);

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -51,7 +51,10 @@ bun_core::declare_scope!(cache, visible);
 /// Version 25: Every ModuleInfo record carries a trailing FetchParameters slot
 /// so ImportEntry/ExportEntry/StarExportEntry moduleRequestType matches JSC's
 /// after WebKit 90b2ecf79ae3 keyed m_loadedModules on (specifier, type).
-const EXPECTED_VERSION: u32 = 25;
+/// Version 26: The sourcemap gains a mapping for each `require("...")` /
+/// `require.resolve("...")` call, at the call target. Cached maps without it
+/// attribute stack frames at such calls to the previous mapped token.
+const EXPECTED_VERSION: u32 = 26;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -51,9 +51,8 @@ bun_core::declare_scope!(cache, visible);
 /// Version 25: Every ModuleInfo record carries a trailing FetchParameters slot
 /// so ImportEntry/ExportEntry/StarExportEntry moduleRequestType matches JSC's
 /// after WebKit 90b2ecf79ae3 keyed m_loadedModules on (specifier, type).
-/// Version 26: The sourcemap gains a mapping for each `require("...")` /
-/// `require.resolve("...")` call, at the call target. Cached maps without it
-/// attribute stack frames at such calls to the previous mapped token.
+/// Version 26: The sourcemap maps `require("...")` / `require.resolve("...")`
+/// calls; older maps attribute frames at such calls to the preceding token.
 const EXPECTED_VERSION: u32 = 26;
 
 /// Source files smaller than this are not written to / read from the on-disk

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -51,8 +51,7 @@ bun_core::declare_scope!(cache, visible);
 /// Version 25: Every ModuleInfo record carries a trailing FetchParameters slot
 /// so ImportEntry/ExportEntry/StarExportEntry moduleRequestType matches JSC's
 /// after WebKit 90b2ecf79ae3 keyed m_loadedModules on (specifier, type).
-/// Version 26: The sourcemap maps `require("...")` / `require.resolve("...")`
-/// calls; older maps attribute frames at such calls to the preceding token.
+/// Version 26: Sourcemaps gain a mapping for each `require("...")` / `require.resolve("...")` call.
 const EXPECTED_VERSION: u32 = 26;
 
 /// Source files smaller than this are not written to / read from the on-disk

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isBroken, isWindows, tempDir } from "harness";
 import { readdirSync, writeFileSync } from "node:fs";
+import { SourceMap } from "node:module";
 import { join } from "node:path";
 import { decodeSourceMappingsLine, itBundled } from "./expectBundled";
 
@@ -1330,6 +1331,51 @@ describe("bundler", () => {
       const keepCol = js.split("\n")[0].indexOf("keep=[");
       expect(keepCol).toBeGreaterThan(0);
       expect(line1).toContainEqual({ gen: keepCol, src: 0, ol: 3, oc: 6 });
+    },
+  });
+  // The parser folds `require("./x")` and `require.resolve("./x")` into single
+  // nodes, which the printer emitted without a mapping of their own. Whatever
+  // they print as (here the `require_dep()` wrapper call and a rewritten
+  // `require.resolve`) then resolved to the previous token on the line, so a
+  // stack frame for a require() that throws pointed at `return`, `{`, etc.
+  itBundled("edgecase/SourceMapRequireCallMapsToItsCallee", {
+    files: {
+      "/entry.js": /* js */ `
+        function load() {
+          try {
+            return require("./dep.js");
+          } catch {}
+          return require.resolve("./dep.js");
+        }
+        module.exports = load;
+      `,
+      "/dep.js": /* js */ `module.exports = 1;`,
+    },
+    target: "node",
+    format: "cjs",
+    outdir: "/out",
+    sourceMap: "external",
+    onAfterBundle(api) {
+      const source = api.readFile("/entry.js").split("\n");
+      const generated = api.readFile("/out/entry.js").split("\n");
+      const map = new SourceMap(JSON.parse(api.readFile("/out/entry.js.map")));
+
+      // Original position (1-based "line:col") that the generated `token` maps to.
+      const mapsTo = (token: string) => {
+        const line = generated.findIndex(text => text.includes(token));
+        expect(line).not.toBe(-1);
+        const entry = map.findEntry(line, generated[line].indexOf(token));
+        expect(entry.originalSource).toEndWith("entry.js");
+        return `${entry.originalLine + 1}:${entry.originalColumn + 1}`;
+      };
+      // Position of the `require` token on the source line containing `text`.
+      const requireTokenOf = (text: string) => {
+        const line = source.findIndex(sourceLine => sourceLine.includes(text));
+        return `${line + 1}:${source[line].indexOf("require") + 1}`;
+      };
+
+      expect(mapsTo("require_dep()")).toBe(requireTokenOf('require("./dep.js")'));
+      expect(mapsTo("require.resolve(")).toBe(requireTokenOf('require.resolve("./dep.js")'));
     },
   });
   itBundled("edgecase/NoUselessConstructorTS", {

--- a/test/js/bun/sourcemap/internal-sourcemap.test.ts
+++ b/test/js/bun/sourcemap/internal-sourcemap.test.ts
@@ -85,6 +85,64 @@ describe("InternalSourceMap", () => {
     expect(exited).toBe(0);
   });
 
+  // `require("./x")` is printed from its own AST node (the parser folds the call
+  // into one), so it needs its own mapping: without one the caller's frame
+  // remapped to whatever was mapped last, usually the `{` opening the enclosing
+  // function or try block. Node reports the `require` token of the call.
+  test("the caller frame of a require() whose module throws points at the require call", async () => {
+    const lines = [
+      /*  1 */ `function stmt() {`,
+      /*  2 */ `  require("./t1.js");`,
+      /*  3 */ `}`,
+      /*  4 */ `function inTry() {`,
+      /*  5 */ `  try {`,
+      /*  6 */ `    require("./t2.js");`,
+      /*  7 */ `  } finally {`,
+      /*  8 */ `  }`,
+      /*  9 */ `}`,
+      /* 10 */ `function decl() {`,
+      /* 11 */ `  const m = require("./t3.js");`,
+      /* 12 */ `  return m;`,
+      /* 13 */ `}`,
+      /* 14 */ `function arg() {`,
+      /* 15 */ `  console.log(1, require("./t4.js"));`,
+      /* 16 */ `}`,
+      /* 17 */ `function ternary(flag: boolean) {`,
+      /* 18 */ `  require(flag ? "./t5.js" : "./t1.js");`,
+      /* 19 */ `}`,
+      /* 20 */ `function viaModule() {`,
+      /* 21 */ `  module.require("./t6.js");`,
+      /* 22 */ `}`,
+      /* 23 */ `for (const fn of [stmt, inTry, decl, arg, () => ternary(true), viaModule]) {`,
+      /* 24 */ `  try {`,
+      /* 25 */ `    fn();`,
+      /* 26 */ `  } catch (e) {`,
+      /* 27 */ `    console.log((e as Error).stack);`,
+      /* 28 */ `  }`,
+      /* 29 */ `}`,
+      ``,
+    ];
+    // One module per call site: a module that threw while loading is not
+    // evaluated again by the next require() of it, which would rethrow the
+    // first call site's error.
+    const files: Record<string, string> = { "index.ts": lines.join("\n") };
+    for (let i = 1; i <= 6; i++) files[`t${i}.js`] = `throw new Error("t${i}");\n`;
+
+    const { stdout, stderr, exited } = await run(files);
+
+    expect(stderr).toBe("");
+    const frames = [...stdout.matchAll(/at (\w+) \(.*index\.ts:(\d+):(\d+)\)/g)].map(m => `${m[1]} ${m[2]}:${m[3]}`);
+    expect(frames).toEqual([
+      "stmt 2:3",
+      "inTry 6:5",
+      "decl 11:13",
+      "arg 15:18",
+      "ternary 18:3",
+      "viaModule 21:10", // the `require` of `module.require`, as for any other method call
+    ]);
+    expect(exited).toBe(0);
+  });
+
   // Source-map columns count UTF-16 code units. A non-ASCII character earlier
   // on the line (Latin-1, astral, CJK) must not shift the remapped columns of
   // the tokens that follow it.

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -72,20 +72,13 @@ note: "duplicateConstDecl" was originally declared here
 });
 
 const normalizeError = str => {
-  // remove debug-only stack trace frames
-  // like "at require (:1:21)"
-  if (str.includes(" (:")) {
-    const splits = str.split("\n");
-    for (let i = 0; i < splits.length; i++) {
-      if (splits[i].includes(" (:")) {
-        splits.splice(i, 1);
-        i--;
-      }
-    }
-    return splits.join("\n");
-  }
-
-  return str;
+  // remove debug-only stack trace frames (bun's own builtins, which have a
+  // position but no file) like "at require (51:24)" or "at require (:1:21)"
+  const debugOnlyFrame = /^\s*at .*\((?:native)?:?\d+(?::\d+)?\)$/;
+  return str
+    .split("\n")
+    .filter(line => !debugOnlyFrame.test(line))
+    .join("\n");
 };
 
 test("Error inside minified file (no color) ", () => {
@@ -111,7 +104,7 @@ test("Error inside minified file (no color) ", () => {
       error: error inside long minified file!
             at <anonymous> ([dir]/inspect-error-fixture.min.js:26:2850)
             at <anonymous> ([dir]/inspect-error-fixture.min.js:26:2890)
-            at <anonymous> ([dir]/inspect-error.test.js:92:7)"
+            at <anonymous> ([dir]/inspect-error.test.js:86:5)"
     `);
   }
 });
@@ -140,7 +133,7 @@ test("Error inside minified file (color) ", () => {
       error: error inside long minified file!
             at <anonymous> ([dir]/inspect-error-fixture.min.js:26:2850)
             at <anonymous> ([dir]/inspect-error-fixture.min.js:26:2890)
-            at <anonymous> ([dir]/inspect-error.test.js:120:7)"
+            at <anonymous> ([dir]/inspect-error.test.js:114:5)"
     `);
   }
 });
@@ -154,7 +147,7 @@ test("Inserted originalLine and originalColumn do not appear in node:util.inspec
       .replaceAll(import.meta.path.replaceAll("\\", "/"), "[file]"),
   ).toMatchInlineSnapshot(`
 "Error: my message
-    at <anonymous> ([file]:149:19)"
+    at <anonymous> ([file]:142:19)"
 `);
 });
 


### PR DESCRIPTION
### Problem
- When a module loaded with `require()` throws while evaluating, the caller's frame in `error.stack` (and in `Bun.inspect(error)`) points at the `{` opening the enclosing function or `try` block, not at the `require()` call. Node points at the call:
  ```
  function f() {
    const x = 1;
    require("./throws.js");
  }
  // bun:   at f (/tmp/pos/notry.js:1:14)     <- the `{` of f's body
  // node:  at f (/tmp/pos/notry.js:3:3)      <- the require() call
  ```
- Other shapes are off too: `const m = require("./x")` reports the `return` that follows it, `console.log(1, require("./x"))` reports the `1`, `require(flag ? "./a" : "./b")` reports `flag`.
- Stack capture is not involved: JSC reports the right position in the transpiled source. The gap is in the source map bun generates when it transpiles the file. The parser folds a `require("...")` call into one `E.RequireString` node (`require.resolve("...")` into `E.RequireResolveString`), and the printer emitted those nodes without a source mapping (`src/js_printer/lib.rs`, the `ERequireString` / `ERequireResolveString` arms), unlike every other callee expression. Remapping a position resolves to the closest mapping before it on the generated line, so the frame landed on whatever token happened to be mapped last.
- The folded nodes also carried the location of the string argument (`transpose_require` in `src/js_parser/p.rs` used `arg.loc`), so a mapping at that location would still have pointed at `"./throws.js"` rather than at `require`.

### Fix
- `src/js_printer/lib.rs`: emit `add_source_mapping(expr.loc)` for `ERequireString` and `ERequireResolveString`, as the sibling `ERequireCallTarget` / `ERequireResolveCallTarget` / `ERequireMain` arms already do.
- `src/js_parser`: the `require()` transposer receives the call target's location (through the existing `TransposeState.loc` field, which the require path left unset) and gives it to every expression that replaces the call; `require.resolve()`'s transposer takes the same location as a parameter. The import record keeps the argument's range, so resolution errors still point at the specifier.
- `src/jsc/RuntimeTranspilerCache.rs`: `EXPECTED_VERSION` 25 -> 26. The on-disk runtime transpiler cache stores the source map next to the transpiled output and is keyed by input hash + parser features, not by bun version, so entries written by an older bun would hand this build the old map and keep the bug for every cached file (`src/js_parser/parser.rs` asks for this bump on parser fixes).
- Why this is right: bun derives a call's reported position from the mapping of its callee, which for `foo()` is `foo` and for `a.b()` is `b`, i.e. V8's convention. The folded require nodes are the callee and the call in one node, so mapping them at the call target makes `require(...)` behave like any other call; the six shapes in the test now match Node's positions exactly (including `module.require("x")`, which the parser also folds and which now reports the `require` property like any other method call).
- Blast radius: `require`/`require.resolve` with a string literal gain one mapping each in runtime transpiles and in `bun build` output. The bundler's own synthesized `E.RequireString` nodes (import statements lowered to `require_x()` calls) share their location with the binding printed just before them and are deduplicated by `add_source_mapping`, so their maps are unchanged (`bundler_edgecase` `mappingsExactMatch` tests still pass). Printed code is unchanged.
- Verified:
  - `test/js/bun/sourcemap/internal-sourcemap.test.ts`: new test runs six require shapes (statement, inside `try`, `const` initializer, argument, ternary specifier, `module.require`) and checks the caller frame of each; fails on the current release (`1:17`, `5:7`, `12:3`, ...) and passes with the fix.
  - `test/bundler/bundler_edgecase.test.ts`: new test checks the `bun build` source map maps the `require_dep()` wrapper call and the rewritten `require.resolve(...)` back to their `require` tokens; fails before (`3:5` / `5:3`, the `return`s), passes after.
  - `test/js/bun/util/inspect-error.test.js`: the two minified-file snapshots encoded the bug (`at ... inspect-error.test.js:92:7`, the `try {` line) and now point at the `require(...)` line. While there, `normalizeError` is updated to strip the debug-build-only `at require (51:24)` frame whose format changed, so the file also passes on debug builds.
  - `test/bundler/transpiler/transpiler.test.js` (+ `function-tostring-require`, `runtime-transpiler`), `bundler_edgecase`, `bundler_cjs`, `bundler_cjs2esm`, `bundler_npm`, `bundler_allow_unresolved`, `bun-build-api`: pass (one pre-existing 180 s stress test in `bun-build-api` times out on this debug build regardless of the change).
  - `cargo fmt --check`, `cargo clippy -p bun_js_parser -p bun_js_printer`: clean.

### Background
- Bun transpiles every file it runs and records a source map for it. Positions JSC reports (stack frames, error locations) refer to the transpiled text and are remapped through that map before being shown.
- A source mapping is a point `(generated line:column -> original line:column)` that the printer adds while emitting a token. Looking up a generated position returns the closest mapping at or before it on the same generated line, so any token without a mapping of its own is attributed to the nearest mapped token before it.
- `E.RequireString` / `E.RequireResolveString` are the parser's replacements for `require("literal")` / `require.resolve("literal")`. They exist so the bundler can resolve the specifier at build time; at runtime the printer prints them back out as the call, in the bundler as the target module's wrapper call (`require_dep()`), `__toESM(...)`, etc.
- JSC places a call's position at its `(`; V8 (and Node's stack traces) report the callee, so bun's printer maps each callee token and the remap of the `(` position lands on it.

<details>
<summary>Positions before / after for the shapes in the test, against Node</summary>

| shape | bun before | bun after | node |
|---|---|---|---|
| `require("./t1.js");` | 1:17 (`{` of the function) | 2:3 | 2:3 |
| inside `try {` | 5:7 (`{` of the try) | 6:5 | 6:5 |
| `const m = require(...)` | 12:3 (the following `return`) | 11:13 | 11:13 |
| `console.log(1, require(...))` | 15:15 (the `1`) | 15:18 | 15:18 |
| `require(flag ? "a" : "b")` | 18:11 (`flag`) | 18:3 | 18:3 |
| `module.require(...)` | 20:22 (`{` of the function) | 21:10 | 21:10 |

</details>
