### PR TITLE
Diagnostics: identify the double close behind the async Closer EBADF assertion on the asan lane

### DIFF
--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -2234,6 +2234,10 @@ pub mod closer {
     pub struct Closer {
         pub(crate) fd: Fd,
         task: WorkPoolTask,
+        #[cfg(all(debug_assertions, any(target_os = "linux", target_os = "android")))]
+        scheduled_from: std::backtrace::Backtrace,
+        #[cfg(all(debug_assertions, any(target_os = "linux", target_os = "android")))]
+        scheduled_on: String,
     }
 
     #[cfg(not(windows))]
@@ -2243,6 +2247,28 @@ pub mod closer {
     unsafe impl bun_threading::work_pool::OwnedTask for Closer {
         fn run(self: Box<Self>) {
             use bun_sys::FdExt;
+            #[cfg(all(debug_assertions, any(target_os = "linux", target_os = "android")))]
+            {
+                #[allow(clippy::print_stderr)]
+                if let Some(err) = self.fd.close_allowing_bad_file_descriptor(None) {
+                    if err.errno == bun_sys::E::EBADF as _ {
+                        std::eprintln!(
+                            "\n==================== Closer: close({}) = EBADF ====================\n\
+                             this Closer was scheduled on thread {} from:\n{}\n\
+                             ======================================================================\n",
+                            self.fd.native(),
+                            self.scheduled_on,
+                            self.scheduled_from,
+                        );
+                        panic!(
+                            "Closer: fd {} was already closed when the async close ran (see report above)",
+                            self.fd.native()
+                        );
+                    }
+                }
+                return;
+            }
+            #[allow(unreachable_code)]
             self.fd.close();
         }
     }
@@ -2257,6 +2283,16 @@ pub mod closer {
                 task: WorkPoolTask {
                     node: Default::default(),
                     callback: <Self as bun_threading::work_pool::OwnedTask>::__callback,
+                },
+                #[cfg(all(debug_assertions, any(target_os = "linux", target_os = "android")))]
+                scheduled_from: std::backtrace::Backtrace::force_capture(),
+                #[cfg(all(debug_assertions, any(target_os = "linux", target_os = "android")))]
+                scheduled_on: {
+                    let t = std::thread::current();
+                    match t.name() {
+                        Some(name) => std::format!("{name} ({:?})", t.id()),
+                        None => std::format!("{:?}", t.id()),
+                    }
                 },
             }));
         }

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -2235,9 +2235,9 @@ pub mod closer {
         pub(crate) fd: Fd,
         task: WorkPoolTask,
         #[cfg(all(debug_assertions, any(target_os = "linux", target_os = "android")))]
-        scheduled_from: std::backtrace::Backtrace,
+        scheduled_from: bun_core::StoredTrace,
         #[cfg(all(debug_assertions, any(target_os = "linux", target_os = "android")))]
-        scheduled_on: String,
+        scheduled_on_tid: i64,
     }
 
     #[cfg(not(windows))]
@@ -2253,12 +2253,19 @@ pub mod closer {
                 if let Some(err) = self.fd.close_allowing_bad_file_descriptor(None) {
                     if err.errno == bun_sys::E::EBADF as _ {
                         std::eprintln!(
-                            "\n==================== Closer: close({}) = EBADF ====================\n\
-                             this Closer was scheduled on thread {} from:\n{}\n\
-                             ======================================================================\n",
-                            self.fd.native(),
-                            self.scheduled_on,
-                            self.scheduled_from,
+                            "\n==================== Closer: close({}) = EBADF ====================",
+                            self.fd.native()
+                        );
+                        std::eprintln!(
+                            "this Closer was scheduled on tid {} at:",
+                            self.scheduled_on_tid
+                        );
+                        bun_core::dump_stack_trace(
+                            &self.scheduled_from.trace(),
+                            bun_core::DumpStackTraceOptions::default(),
+                        );
+                        std::eprintln!(
+                            "======================================================================\n"
                         );
                         panic!(
                             "Closer: fd {} was already closed when the async close ran (see report above)",
@@ -2285,15 +2292,9 @@ pub mod closer {
                     callback: <Self as bun_threading::work_pool::OwnedTask>::__callback,
                 },
                 #[cfg(all(debug_assertions, any(target_os = "linux", target_os = "android")))]
-                scheduled_from: std::backtrace::Backtrace::force_capture(),
+                scheduled_from: bun_core::StoredTrace::capture(None),
                 #[cfg(all(debug_assertions, any(target_os = "linux", target_os = "android")))]
-                scheduled_on: {
-                    let t = std::thread::current();
-                    match t.name() {
-                        Some(name) => std::format!("{name} ({:?})", t.id()),
-                        None => std::format!("{:?}", t.id()),
-                    }
-                },
+                scheduled_on_tid: bun_sys::close_ledger::current_tid(),
             }));
         }
     }

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -2238,6 +2238,10 @@ pub mod closer {
         scheduled_from: bun_core::StoredTrace,
         #[cfg(all(debug_assertions, any(target_os = "linux", target_os = "android")))]
         scheduled_on_tid: i64,
+        /// What the fd pointed at when the close was scheduled (empty if it
+        /// was already closed by then).
+        #[cfg(all(debug_assertions, any(target_os = "linux", target_os = "android")))]
+        scheduled_description: bun_sys::close_ledger::FdDescription,
     }
 
     #[cfg(not(windows))]
@@ -2255,6 +2259,10 @@ pub mod closer {
                         std::eprintln!(
                             "\n==================== Closer: close({}) = EBADF ====================",
                             self.fd.native()
+                        );
+                        std::eprintln!(
+                            "when this Closer was scheduled the fd was \"{}\" (empty = already closed at that point)",
+                            self.scheduled_description.as_str()
                         );
                         std::eprintln!(
                             "this Closer was scheduled on tid {} at:",
@@ -2295,6 +2303,8 @@ pub mod closer {
                 scheduled_from: bun_core::StoredTrace::capture(None),
                 #[cfg(all(debug_assertions, any(target_os = "linux", target_os = "android")))]
                 scheduled_on_tid: bun_sys::close_ledger::current_tid(),
+                #[cfg(all(debug_assertions, any(target_os = "linux", target_os = "android")))]
+                scheduled_description: bun_sys::close_ledger::FdDescription::of(fd.native()),
             }));
         }
     }

--- a/src/io/pipes.rs
+++ b/src/io/pipes.rs
@@ -62,6 +62,18 @@ impl PollOrFd {
         #[cfg(windows)]
         let _ = close_fd;
         let fd = self.get_fd();
+        #[cfg(all(debug_assertions, any(target_os = "linux", target_os = "android")))]
+        if fd != Fd::INVALID {
+            bun_sys::close_ledger::record_registration_event(
+                match (self.tag_name(), close_fd) {
+                    ("poll", true) => "close_impl(poll, close_fd)",
+                    ("poll", false) => "close_impl(poll, keep fd)",
+                    (_, true) => "close_impl(bare fd, close_fd)",
+                    (_, false) => "close_impl(bare fd, keep fd)",
+                },
+                fd.native(),
+            );
+        }
         #[cfg(target_os = "macos")]
         let mut close_async = true;
         #[cfg(all(not(target_os = "macos"), not(windows)))]

--- a/src/io/posix_event_loop.rs
+++ b/src/io/posix_event_loop.rs
@@ -671,7 +671,11 @@ impl FilePoll {
                 {
                     let what = std::format!(
                         "epoll_ctl({}, fd {}, {}) failed: {} (poll flags before: {})",
-                        if op == EPOLL::CTL_MOD { "CTL_MOD" } else { "CTL_ADD" },
+                        if op == EPOLL::CTL_MOD {
+                            "CTL_MOD"
+                        } else {
+                            "CTL_ADD"
+                        },
                         fd.native(),
                         <&'static str>::from(flag),
                         errno

--- a/src/io/posix_event_loop.rs
+++ b/src/io/posix_event_loop.rs
@@ -953,7 +953,11 @@ impl FilePoll {
         {
             #[cfg(all(debug_assertions, any(target_os = "linux", target_os = "android")))]
             sys::close_ledger::record_registration_event(
-                if force_unregister { "DEL skipped(force): no poll flags" } else { "DEL skipped: no poll flags" },
+                if force_unregister {
+                    "DEL skipped(force): no poll flags"
+                } else {
+                    "DEL skipped: no poll flags"
+                },
                 fd.native(),
             );
             // no-op
@@ -1025,13 +1029,20 @@ impl FilePoll {
                 e if deregistration_already_gone(e) => {
                     #[cfg(debug_assertions)]
                     sys::close_ledger::record_registration_event(
-                        if e == sys::E::EBADF { "DEL -> EBADF (fd already closed)" } else { "DEL -> ENOENT (not registered)" },
+                        if e == sys::E::EBADF {
+                            "DEL -> EBADF (fd already closed)"
+                        } else {
+                            "DEL -> ENOENT (not registered)"
+                        },
                         fd.native(),
                     );
                 }
                 e => {
                     #[cfg(debug_assertions)]
-                    sys::close_ledger::record_registration_event("DEL failed (other errno)", fd.native());
+                    sys::close_ledger::record_registration_event(
+                        "DEL failed (other errno)",
+                        fd.native(),
+                    );
                     return sys::Result::Err(sys::Error::from_code(e, sys::Tag::epoll_ctl));
                 }
             }

--- a/src/io/posix_event_loop.rs
+++ b/src/io/posix_event_loop.rs
@@ -690,6 +690,14 @@ impl FilePoll {
                 self.deactivate(loop_);
                 return errno;
             }
+            #[cfg(debug_assertions)]
+            {
+                // Only ADDs create kernel registrations; MODs are noise here.
+                if op == EPOLL::CTL_ADD {
+                    let what = std::format!("ADD ok ({})", <&'static str>::from(flag));
+                    sys::close_ledger::record_registration_event(&what, fd.native());
+                }
+            }
         }
         #[cfg(target_os = "macos")]
         {
@@ -943,6 +951,11 @@ impl FilePoll {
             || self.flags.contains(Flags::PollMachport)
             || self.flags.contains(Flags::PollMemoryPressure))
         {
+            #[cfg(all(debug_assertions, any(target_os = "linux", target_os = "android")))]
+            sys::close_ledger::record_registration_event(
+                if force_unregister { "DEL skipped(force): no poll flags" } else { "DEL skipped: no poll flags" },
+                fd.native(),
+            );
             // no-op
             return sys::Result::Ok(());
         }
@@ -981,6 +994,8 @@ impl FilePoll {
             self.flags.remove(Flags::PollWritable);
             self.flags.remove(Flags::PollMachport);
             self.flags.remove(Flags::PollMemoryPressure);
+            #[cfg(all(debug_assertions, any(target_os = "linux", target_os = "android")))]
+            sys::close_ledger::record_registration_event("DEL skipped: needs_rearm", fd.native());
             return sys::Result::Ok(());
         }
 
@@ -1003,9 +1018,22 @@ impl FilePoll {
             };
 
             match sys::get_errno(ctl) {
-                sys::E::SUCCESS => {}
-                e if deregistration_already_gone(e) => {}
-                e => return sys::Result::Err(sys::Error::from_code(e, sys::Tag::epoll_ctl)),
+                sys::E::SUCCESS => {
+                    #[cfg(debug_assertions)]
+                    sys::close_ledger::record_registration_event("DEL ok", fd.native());
+                }
+                e if deregistration_already_gone(e) => {
+                    #[cfg(debug_assertions)]
+                    sys::close_ledger::record_registration_event(
+                        if e == sys::E::EBADF { "DEL -> EBADF (fd already closed)" } else { "DEL -> ENOENT (not registered)" },
+                        fd.native(),
+                    );
+                }
+                e => {
+                    #[cfg(debug_assertions)]
+                    sys::close_ledger::record_registration_event("DEL failed (other errno)", fd.native());
+                    return sys::Result::Err(sys::Error::from_code(e, sys::Tag::epoll_ctl));
+                }
             }
         }
         #[cfg(target_os = "macos")]

--- a/src/io/posix_event_loop.rs
+++ b/src/io/posix_event_loop.rs
@@ -667,6 +667,22 @@ impl FilePoll {
             let ctl = unsafe { linux::epoll_ctl(watcher_fd, op, fd.native(), &raw mut event) };
             self.flags.insert(Flags::WasEverRegistered);
             if let Some(errno) = errno_sys(ctl, sys::Tag::epoll_ctl) {
+                #[cfg(debug_assertions)]
+                {
+                    let what = std::format!(
+                        "epoll_ctl({}, fd {}, {}) failed: {} (poll flags before: {})",
+                        if op == EPOLL::CTL_MOD { "CTL_MOD" } else { "CTL_ADD" },
+                        fd.native(),
+                        <&'static str>::from(flag),
+                        errno
+                            .as_ref()
+                            .err()
+                            .and_then(|e| core::str::from_utf8(e.name()).ok())
+                            .unwrap_or("?"),
+                        FlagsFormatter(self.flags),
+                    );
+                    sys::close_ledger::report_fd_event(&what, fd.native());
+                }
                 self.deactivate(loop_);
                 return errno;
             }

--- a/src/sys/close_ledger.rs
+++ b/src/sys/close_ledger.rs
@@ -1,0 +1,84 @@
+//! Debug-only (`debug_assertions`) diagnostics for double closes.
+//!
+//! Every successful `close(2)` issued through `bun_sys` records the calling
+//! thread and a backtrace, keyed by fd number. When a later close of the same
+//! number fails with `EBADF` (a use-after-close, or a second owner closing a
+//! descriptor it does not own), the reporter can name the code path that
+//! closed it first.
+#![allow(clippy::print_stderr)]
+
+use std::backtrace::Backtrace;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+struct Entry {
+    seq: u64,
+    thread: String,
+    backtrace: Backtrace,
+}
+
+const MAX_TRACKED_FD: usize = 8192;
+
+static LEDGER: Mutex<Vec<Option<Entry>>> = Mutex::new(Vec::new());
+static SEQ: AtomicU64 = AtomicU64::new(0);
+
+fn thread_label() -> String {
+    let t = std::thread::current();
+    match t.name() {
+        Some(name) => format!("{name} ({:?})", t.id()),
+        None => format!("{:?}", t.id()),
+    }
+}
+
+/// Record that `fd` was just closed successfully by the current thread.
+pub fn record_closed(fd: i32) {
+    if fd < 0 || fd as usize >= MAX_TRACKED_FD {
+        return;
+    }
+    let entry = Entry {
+        seq: SEQ.fetch_add(1, Ordering::Relaxed),
+        thread: thread_label(),
+        backtrace: Backtrace::force_capture(),
+    };
+    let mut ledger = match LEDGER.lock() {
+        Ok(l) => l,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    let idx = fd as usize;
+    if ledger.len() <= idx {
+        ledger.resize_with(idx + 1, || None);
+    }
+    ledger[idx] = Some(entry);
+}
+
+/// Human-readable description of the most recent successful close of `fd`.
+pub fn describe_last_close(fd: i32) -> String {
+    if fd < 0 || fd as usize >= MAX_TRACKED_FD {
+        return format!("fd {fd}: out of ledger range");
+    }
+    let ledger = match LEDGER.lock() {
+        Ok(l) => l,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    match ledger.get(fd as usize).and_then(|e| e.as_ref()) {
+        Some(entry) => format!(
+            "fd {fd} was last closed successfully (close #{}) on thread {}:\n{}",
+            entry.seq, entry.thread, entry.backtrace
+        ),
+        None => format!("fd {fd}: no successful close recorded through bun_sys (closed by C/C++ code, or never closed)"),
+    }
+}
+
+/// Print an EBADF report for a close attempt of `fd` made by `what`.
+pub fn report_ebadf(what: &str, fd: i32) {
+    let now = Backtrace::force_capture();
+    eprintln!(
+        "\n==================== close({fd}) = EBADF ({what}) ====================\n\
+         current thread: {}\n\
+         this close attempt came from:\n{now}\n\
+         {}\n\
+         ======================================================================\n",
+        thread_label(),
+        describe_last_close(fd),
+    );
+}

--- a/src/sys/close_ledger.rs
+++ b/src/sys/close_ledger.rs
@@ -65,7 +65,9 @@ pub fn describe_last_close(fd: i32) -> String {
             "fd {fd} was last closed successfully (close #{}) on thread {}:\n{}",
             entry.seq, entry.thread, entry.backtrace
         ),
-        None => format!("fd {fd}: no successful close recorded through bun_sys (closed by C/C++ code, or never closed)"),
+        None => format!(
+            "fd {fd}: no successful close recorded through bun_sys (closed by C/C++ code, or never closed)"
+        ),
     }
 }
 

--- a/src/sys/close_ledger.rs
+++ b/src/sys/close_ledger.rs
@@ -211,7 +211,11 @@ fn dump_registration_events(fd: i32) {
         return;
     }
     for slot in history.iter().filter(|s| s.seq != 0) {
-        let len = slot.kind.iter().position(|&b| b == 0).unwrap_or(slot.kind.len());
+        let len = slot
+            .kind
+            .iter()
+            .position(|&b| b == 0)
+            .unwrap_or(slot.kind.len());
         eprintln!(
             "fd {fd} registration event #{}: {} (fd was \"{}\") on tid {} at:",
             slot.seq,

--- a/src/sys/close_ledger.rs
+++ b/src/sys/close_ledger.rs
@@ -1,11 +1,12 @@
 //! Debug-only (`debug_assertions`) diagnostics for double closes.
 //!
 //! Every successful `close(2)` issued through `bun_sys` records the calling
-//! thread and a frame-pointer stack trace, keyed by fd number. When a later
-//! close of the same number fails with `EBADF` (a use-after-close, or a second
-//! owner closing a descriptor it does not own), the reporter prints the code
-//! path that closed it first. Traces are printed as raw return addresses
-//! (symbolize them against the binary with llvm-symbolizer).
+//! thread, what the descriptor pointed at (`/proc/self/fd/N`), and a
+//! frame-pointer stack trace, keyed by fd number (the last few closes of each
+//! number are kept). When a later close of the same number fails with `EBADF`
+//! (a use-after-close, or a second owner closing a descriptor it does not
+//! own), the reporter prints that history. Traces are printed as raw return
+//! addresses (symbolize them against the binary with llvm-symbolizer).
 #![allow(clippy::print_stderr)]
 
 use std::sync::Mutex;
@@ -13,11 +14,51 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use bun_core::{DumpStackTraceOptions, StoredTrace};
 
+/// `readlink("/proc/self/fd/N")`, truncated to a fixed buffer.
+#[derive(Clone, Copy)]
+pub struct FdDescription {
+    len: u8,
+    bytes: [u8; 63],
+}
+
+impl FdDescription {
+    pub const UNKNOWN: FdDescription = FdDescription {
+        len: 0,
+        bytes: [0; 63],
+    };
+
+    /// Describe a currently-open descriptor. Call this *before* closing it.
+    pub fn of(fd: i32) -> FdDescription {
+        let mut out = FdDescription::UNKNOWN;
+        if fd < 0 {
+            return out;
+        }
+        let path = format!("/proc/self/fd/{fd}\0");
+        // SAFETY: `path` is NUL-terminated; `bytes` is valid for `bytes.len()` writes.
+        let n = unsafe {
+            libc::readlink(
+                path.as_ptr().cast(),
+                out.bytes.as_mut_ptr().cast(),
+                out.bytes.len(),
+            )
+        };
+        if n > 0 {
+            out.len = n as u8;
+        }
+        out
+    }
+
+    pub fn as_str(&self) -> &str {
+        core::str::from_utf8(&self.bytes[..self.len as usize]).unwrap_or("<non-utf8>")
+    }
+}
+
 #[derive(Clone, Copy)]
 struct Slot {
     /// 0 = never recorded.
     seq: u64,
     tid: i64,
+    description: FdDescription,
     trace: StoredTrace,
 }
 
@@ -25,13 +66,16 @@ impl Slot {
     const EMPTY: Slot = Slot {
         seq: 0,
         tid: 0,
+        description: FdDescription::UNKNOWN,
         trace: StoredTrace::EMPTY,
     };
 }
 
 const MAX_TRACKED_FD: usize = 4096;
+const HISTORY: usize = 3;
 
-static LEDGER: Mutex<[Slot; MAX_TRACKED_FD]> = Mutex::new([Slot::EMPTY; MAX_TRACKED_FD]);
+static LEDGER: Mutex<[[Slot; HISTORY]; MAX_TRACKED_FD]> =
+    Mutex::new([[Slot::EMPTY; HISTORY]; MAX_TRACKED_FD]);
 static SEQ: AtomicU64 = AtomicU64::new(1);
 
 pub fn current_tid() -> i64 {
@@ -39,53 +83,83 @@ pub fn current_tid() -> i64 {
     unsafe { libc::syscall(libc::SYS_gettid) as i64 }
 }
 
-/// Record that `fd` was just closed successfully by the current thread.
-pub fn record_closed(fd: i32) {
+/// Record that `fd` (which pointed at `description` before the call) was just
+/// closed successfully by the current thread.
+pub fn record_closed(fd: i32, description: FdDescription) {
     if fd < 0 || fd as usize >= MAX_TRACKED_FD {
         return;
     }
     let slot = Slot {
         seq: SEQ.fetch_add(1, Ordering::Relaxed),
         tid: current_tid(),
+        description,
         trace: StoredTrace::capture(None),
     };
     let mut ledger = match LEDGER.lock() {
         Ok(l) => l,
         Err(poisoned) => poisoned.into_inner(),
     };
-    ledger[fd as usize] = slot;
+    let history = &mut ledger[fd as usize];
+    history.copy_within(0..HISTORY - 1, 1);
+    history[0] = slot;
 }
 
-fn last_close(fd: i32) -> Option<Slot> {
+fn history_of(fd: i32) -> [Slot; HISTORY] {
     if fd < 0 || fd as usize >= MAX_TRACKED_FD {
-        return None;
+        return [Slot::EMPTY; HISTORY];
     }
     let ledger = match LEDGER.lock() {
         Ok(l) => l,
         Err(poisoned) => poisoned.into_inner(),
     };
-    let slot = ledger[fd as usize];
-    (slot.seq != 0).then_some(slot)
+    ledger[fd as usize]
+}
+
+/// Print the recorded close history of `fd`, newest first.
+pub fn dump_history(fd: i32) {
+    let history = history_of(fd);
+    if history[0].seq == 0 {
+        eprintln!(
+            "fd {fd}: no successful close recorded through bun_sys (closed by C/C++ code, or never closed)"
+        );
+        return;
+    }
+    for slot in history.iter().filter(|s| s.seq != 0) {
+        eprintln!(
+            "fd {fd} was closed successfully (close #{}, it was \"{}\") on tid {} at:",
+            slot.seq,
+            slot.description.as_str(),
+            slot.tid
+        );
+        bun_core::dump_stack_trace(&slot.trace.trace(), DumpStackTraceOptions::default());
+    }
 }
 
 /// Print an EBADF report for a close attempt of `fd` made by `what`: the
-/// current stack, then the stack that closed `fd` last.
+/// current stack, then the close history of `fd`.
 pub fn report_ebadf(what: &str, fd: i32) {
     let now = StoredTrace::capture(None);
     eprintln!("\n==================== close({fd}) = EBADF ({what}) ====================");
     eprintln!("this close attempt is on tid {} at:", current_tid());
     bun_core::dump_stack_trace(&now.trace(), DumpStackTraceOptions::default());
-    match last_close(fd) {
-        Some(slot) => {
-            eprintln!(
-                "fd {fd} was last closed successfully (close #{}) on tid {} at:",
-                slot.seq, slot.tid
-            );
-            bun_core::dump_stack_trace(&slot.trace.trace(), DumpStackTraceOptions::default());
-        }
-        None => eprintln!(
-            "fd {fd}: no successful close recorded through bun_sys (closed by C/C++ code, or never closed)"
-        ),
-    }
+    dump_history(fd);
+    eprintln!("======================================================================\n");
+}
+
+/// Print the current stack plus what `fd`, stdout and stderr point at. Used to
+/// report failures to register `fd` with the event loop.
+pub fn report_fd_event(what: &str, fd: i32) {
+    let now = StoredTrace::capture(None);
+    eprintln!("\n==================== {what} ====================");
+    eprintln!(
+        "fd {fd} is \"{}\"; fd 1 is \"{}\"; fd 2 is \"{}\"; tid {}",
+        FdDescription::of(fd).as_str(),
+        FdDescription::of(1).as_str(),
+        FdDescription::of(2).as_str(),
+        current_tid()
+    );
+    eprintln!("at:");
+    bun_core::dump_stack_trace(&now.trace(), DumpStackTraceOptions::default());
+    dump_history(fd);
     eprintln!("======================================================================\n");
 }

--- a/src/sys/close_ledger.rs
+++ b/src/sys/close_ledger.rs
@@ -1,33 +1,42 @@
 //! Debug-only (`debug_assertions`) diagnostics for double closes.
 //!
 //! Every successful `close(2)` issued through `bun_sys` records the calling
-//! thread and a backtrace, keyed by fd number. When a later close of the same
-//! number fails with `EBADF` (a use-after-close, or a second owner closing a
-//! descriptor it does not own), the reporter can name the code path that
-//! closed it first.
+//! thread and a frame-pointer stack trace, keyed by fd number. When a later
+//! close of the same number fails with `EBADF` (a use-after-close, or a second
+//! owner closing a descriptor it does not own), the reporter prints the code
+//! path that closed it first. Traces are printed as raw return addresses
+//! (symbolize them against the binary with llvm-symbolizer).
 #![allow(clippy::print_stderr)]
 
-use std::backtrace::Backtrace;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-struct Entry {
+use bun_core::{DumpStackTraceOptions, StoredTrace};
+
+#[derive(Clone, Copy)]
+struct Slot {
+    /// 0 = never recorded.
     seq: u64,
-    thread: String,
-    backtrace: Backtrace,
+    tid: i64,
+    trace: StoredTrace,
 }
 
-const MAX_TRACKED_FD: usize = 8192;
+impl Slot {
+    const EMPTY: Slot = Slot {
+        seq: 0,
+        tid: 0,
+        trace: StoredTrace::EMPTY,
+    };
+}
 
-static LEDGER: Mutex<Vec<Option<Entry>>> = Mutex::new(Vec::new());
-static SEQ: AtomicU64 = AtomicU64::new(0);
+const MAX_TRACKED_FD: usize = 4096;
 
-fn thread_label() -> String {
-    let t = std::thread::current();
-    match t.name() {
-        Some(name) => format!("{name} ({:?})", t.id()),
-        None => format!("{:?}", t.id()),
-    }
+static LEDGER: Mutex<[Slot; MAX_TRACKED_FD]> = Mutex::new([Slot::EMPTY; MAX_TRACKED_FD]);
+static SEQ: AtomicU64 = AtomicU64::new(1);
+
+pub fn current_tid() -> i64 {
+    // SAFETY: SYS_gettid takes no arguments and cannot fail.
+    unsafe { libc::syscall(libc::SYS_gettid) as i64 }
 }
 
 /// Record that `fd` was just closed successfully by the current thread.
@@ -35,52 +44,48 @@ pub fn record_closed(fd: i32) {
     if fd < 0 || fd as usize >= MAX_TRACKED_FD {
         return;
     }
-    let entry = Entry {
+    let slot = Slot {
         seq: SEQ.fetch_add(1, Ordering::Relaxed),
-        thread: thread_label(),
-        backtrace: Backtrace::force_capture(),
+        tid: current_tid(),
+        trace: StoredTrace::capture(None),
     };
     let mut ledger = match LEDGER.lock() {
         Ok(l) => l,
         Err(poisoned) => poisoned.into_inner(),
     };
-    let idx = fd as usize;
-    if ledger.len() <= idx {
-        ledger.resize_with(idx + 1, || None);
-    }
-    ledger[idx] = Some(entry);
+    ledger[fd as usize] = slot;
 }
 
-/// Human-readable description of the most recent successful close of `fd`.
-pub fn describe_last_close(fd: i32) -> String {
+fn last_close(fd: i32) -> Option<Slot> {
     if fd < 0 || fd as usize >= MAX_TRACKED_FD {
-        return format!("fd {fd}: out of ledger range");
+        return None;
     }
     let ledger = match LEDGER.lock() {
         Ok(l) => l,
         Err(poisoned) => poisoned.into_inner(),
     };
-    match ledger.get(fd as usize).and_then(|e| e.as_ref()) {
-        Some(entry) => format!(
-            "fd {fd} was last closed successfully (close #{}) on thread {}:\n{}",
-            entry.seq, entry.thread, entry.backtrace
-        ),
-        None => format!(
+    let slot = ledger[fd as usize];
+    (slot.seq != 0).then_some(slot)
+}
+
+/// Print an EBADF report for a close attempt of `fd` made by `what`: the
+/// current stack, then the stack that closed `fd` last.
+pub fn report_ebadf(what: &str, fd: i32) {
+    let now = StoredTrace::capture(None);
+    eprintln!("\n==================== close({fd}) = EBADF ({what}) ====================");
+    eprintln!("this close attempt is on tid {} at:", current_tid());
+    bun_core::dump_stack_trace(&now.trace(), DumpStackTraceOptions::default());
+    match last_close(fd) {
+        Some(slot) => {
+            eprintln!(
+                "fd {fd} was last closed successfully (close #{}) on tid {} at:",
+                slot.seq, slot.tid
+            );
+            bun_core::dump_stack_trace(&slot.trace.trace(), DumpStackTraceOptions::default());
+        }
+        None => eprintln!(
             "fd {fd}: no successful close recorded through bun_sys (closed by C/C++ code, or never closed)"
         ),
     }
-}
-
-/// Print an EBADF report for a close attempt of `fd` made by `what`.
-pub fn report_ebadf(what: &str, fd: i32) {
-    let now = Backtrace::force_capture();
-    eprintln!(
-        "\n==================== close({fd}) = EBADF ({what}) ====================\n\
-         current thread: {}\n\
-         this close attempt came from:\n{now}\n\
-         {}\n\
-         ======================================================================\n",
-        thread_label(),
-        describe_last_close(fd),
-    );
+    eprintln!("======================================================================\n");
 }

--- a/src/sys/close_ledger.rs
+++ b/src/sys/close_ledger.rs
@@ -146,7 +146,85 @@ pub fn report_ebadf(what: &str, fd: i32) {
     eprintln!("======================================================================\n");
 }
 
-/// Print the current stack plus what `fd`, stdout and stderr point at. Used to
+/// Event-loop registration events (epoll add/del) per fd, same shape as the
+/// close ledger. `kind` is a free-form label supplied by the event loop.
+#[derive(Clone, Copy)]
+struct RegSlot {
+    seq: u64,
+    tid: i64,
+    kind: [u8; 32],
+    description: FdDescription,
+    trace: StoredTrace,
+}
+
+impl RegSlot {
+    const EMPTY: RegSlot = RegSlot {
+        seq: 0,
+        tid: 0,
+        kind: [0; 32],
+        description: FdDescription::UNKNOWN,
+        trace: StoredTrace::EMPTY,
+    };
+}
+
+const REG_HISTORY: usize = 6;
+
+static REGISTRATIONS: Mutex<[[RegSlot; REG_HISTORY]; MAX_TRACKED_FD]> =
+    Mutex::new([[RegSlot::EMPTY; REG_HISTORY]; MAX_TRACKED_FD]);
+
+/// Record an event-loop registration event for `fd` (`kind` is truncated to 32 bytes).
+pub fn record_registration_event(kind: &str, fd: i32) {
+    if fd < 0 || fd as usize >= MAX_TRACKED_FD {
+        return;
+    }
+    let mut slot = RegSlot {
+        seq: SEQ.fetch_add(1, Ordering::Relaxed),
+        tid: current_tid(),
+        kind: [0; 32],
+        description: FdDescription::of(fd),
+        trace: StoredTrace::capture(None),
+    };
+    let n = kind.len().min(32);
+    slot.kind[..n].copy_from_slice(&kind.as_bytes()[..n]);
+    let mut table = match REGISTRATIONS.lock() {
+        Ok(t) => t,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    let history = &mut table[fd as usize];
+    history.copy_within(0..REG_HISTORY - 1, 1);
+    history[0] = slot;
+}
+
+fn dump_registration_events(fd: i32) {
+    if fd < 0 || fd as usize >= MAX_TRACKED_FD {
+        return;
+    }
+    let history = {
+        let table = match REGISTRATIONS.lock() {
+            Ok(t) => t,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        table[fd as usize]
+    };
+    if history[0].seq == 0 {
+        eprintln!("fd {fd}: no event-loop registration events recorded");
+        return;
+    }
+    for slot in history.iter().filter(|s| s.seq != 0) {
+        let len = slot.kind.iter().position(|&b| b == 0).unwrap_or(slot.kind.len());
+        eprintln!(
+            "fd {fd} registration event #{}: {} (fd was \"{}\") on tid {} at:",
+            slot.seq,
+            core::str::from_utf8(&slot.kind[..len]).unwrap_or("?"),
+            slot.description.as_str(),
+            slot.tid
+        );
+        bun_core::dump_stack_trace(&slot.trace.trace(), DumpStackTraceOptions::default());
+    }
+}
+
+/// Print the current stack plus what `fd`, stdout and stderr point at, the
+/// registration events recorded for `fd`, and its close history. Used to
 /// report failures to register `fd` with the event loop.
 pub fn report_fd_event(what: &str, fd: i32) {
     let now = StoredTrace::capture(None);
@@ -160,6 +238,7 @@ pub fn report_fd_event(what: &str, fd: i32) {
     );
     eprintln!("at:");
     bun_core::dump_stack_trace(&now.trace(), DumpStackTraceOptions::default());
+    dump_registration_events(fd);
     dump_history(fd);
     eprintln!("======================================================================\n");
 }

--- a/src/sys/fd.rs
+++ b/src/sys/fd.rs
@@ -101,6 +101,9 @@ impl FdExt for Fd {
             &fd_fmt_buf[..len]
         };
 
+        #[cfg(all(debug_assertions, any(target_os = "linux", target_os = "android")))]
+        let description = sys::close_ledger::FdDescription::of(self.native());
+
         let result: Option<sys::Error> = {
             #[cfg(any(target_os = "linux", target_os = "android"))]
             {
@@ -201,7 +204,7 @@ impl FdExt for Fd {
                     sys::close_ledger::report_ebadf("FdExt::close", self.native());
                 }
                 Some(_) => {}
-                None => sys::close_ledger::record_closed(self.native()),
+                None => sys::close_ledger::record_closed(self.native(), description),
             }
             if let Some(ref err) = result {
                 if err.errno == sys::E::EBADF as _ {

--- a/src/sys/fd.rs
+++ b/src/sys/fd.rs
@@ -195,6 +195,14 @@ impl FdExt for Fd {
 
         #[cfg(debug_assertions)]
         {
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            match result {
+                Some(ref err) if err.errno == sys::E::EBADF as _ => {
+                    sys::close_ledger::report_ebadf("FdExt::close", self.native());
+                }
+                Some(_) => {}
+                None => sys::close_ledger::record_closed(self.native()),
+            }
             if let Some(ref err) = result {
                 if err.errno == sys::E::EBADF as _ {
                     bun_core::debug_warn!(

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -2009,6 +2009,8 @@ mod posix_impl {
         // Darwin uses `close$NOCANCEL` (avoid pthread cancellation point).
         #[cfg(any(target_os = "linux", target_os = "android"))]
         {
+            #[cfg(debug_assertions)]
+            let description = crate::close_ledger::FdDescription::of(fd.native());
             return match super::linux_syscall::close(fd.native()) {
                 Err(e) if e == libc::EBADF => {
                     #[cfg(debug_assertions)]
@@ -2017,7 +2019,7 @@ mod posix_impl {
                 }
                 _ => {
                     #[cfg(debug_assertions)]
-                    crate::close_ledger::record_closed(fd.native());
+                    crate::close_ledger::record_closed(fd.native(), description);
                     Ok(())
                 }
             };

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -17,6 +17,8 @@ pub extern crate bun_core as bun_str;
 pub extern crate bun_libuv_sys;
 pub mod fd;
 pub use fd::{ErrorCase, FdExt, MakeLibUvOwnedError, RawFd};
+#[cfg(all(debug_assertions, any(target_os = "linux", target_os = "android")))]
+pub mod close_ledger;
 #[path = "Error.rs"]
 mod error;
 pub use error::Error;
@@ -2009,9 +2011,15 @@ mod posix_impl {
         {
             return match super::linux_syscall::close(fd.native()) {
                 Err(e) if e == libc::EBADF => {
+                    #[cfg(debug_assertions)]
+                    crate::close_ledger::report_ebadf("bun_sys::close", fd.native());
                     Err(Error::from_code_int(libc::EBADF, Tag::close).with_fd(fd))
                 }
-                _ => Ok(()),
+                _ => {
+                    #[cfg(debug_assertions)]
+                    crate::close_ledger::record_closed(fd.native());
+                    Ok(())
+                }
             };
         }
         #[cfg(not(any(target_os = "linux", target_os = "android")))]


### PR DESCRIPTION
### Diagnostics only, do not merge

The x64-asan test lane intermittently aborts a `bun test --test-worker --isolate` process with:

```
panic: assertion failed: err.is_none()
  src/sys/fd.rs:73      FdExt::close            (debug_assert: "use after close!")
  src/io/lib.rs:2246    closer::Closer::run     (async close on the work pool)
  src/threading/work_pool.rs:66
```

i.e. by the time the async `Closer` ran, the fd it was handed had already been closed by something else. The crash report does not say which fd or which object scheduled the close, and it has not reproduced locally with a debug build (the same 52-file batch passes under `--isolate` and `--parallel=N`). It reproduces on the asan lane in most builds (seen in builds 95992, 95993, 95999, 96000 x2, 96094 x2, usually attributed to the file that just finished running, e.g. `test/cli/test/concurrent-test-glob.test.ts`, `test/js/node/events/event-emitter.test.ts`, `test/js/node/readline/stdin-pause-pty.test.ts`).

This PR adds `debug_assertions`-only instrumentation (Linux) so the next occurrence names both sides of the double close:

- `bun_sys::close_ledger`: every successful close issued through `bun_sys` records a backtrace keyed by fd number; an `EBADF` close prints the attempt's backtrace plus the recorded first closer.
- `Closer` captures a backtrace when it is scheduled and prints it before panicking if its close comes back `EBADF`.

The instrumentation will be removed; the real fix goes in a separate PR once the CI output identifies the owner.
