### PR TITLE
websocket client: honor a negotiated client_max_window_bits=8 instead of closing with 1011

### DIFF
--- a/src/http_jsc/error.rs
+++ b/src/http_jsc/error.rs
@@ -4,10 +4,6 @@ pub enum Error {
     InvalidOptions,
     #[error("ConnectionClosed")]
     ConnectionClosed,
-    #[error("DeflateInitFailed")]
-    DeflateInitFailed,
-    #[error("InflateInitFailed")]
-    InflateInitFailed,
 }
 
 impl Error {
@@ -16,8 +12,6 @@ impl Error {
         match self {
             Self::InvalidOptions => "InvalidOptions",
             Self::ConnectionClosed => "ConnectionClosed",
-            Self::DeflateInitFailed => "DeflateInitFailed",
-            Self::InflateInitFailed => "InflateInitFailed",
         }
     }
 }

--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -1416,9 +1416,7 @@ impl<const SSL: bool> WebSocket<SSL> {
             payload_length_frame_bytes: Cell::new([0u8; 8]),
             payload_length_frame_len: Cell::new(0),
             pending_initial_task: Cell::new(None),
-            deflate: RefCell::new(
-                deflate_params.and_then(|params| WebSocketDeflate::init(*params).ok()),
-            ),
+            deflate: RefCell::new(deflate_params.map(|params| WebSocketDeflate::init(*params))),
             receiving_compressed: Cell::new(false),
             message_is_compressed: Cell::new(false),
             secure: Cell::new(secure),

--- a/src/http_jsc/websocket_client/WebSocketDeflate.rs
+++ b/src/http_jsc/websocket_client/WebSocketDeflate.rs
@@ -2,7 +2,7 @@
 
 use core::ffi::c_int;
 
-use bun_core::feature_flag;
+use bun_core::{feature_flag, handle_oom};
 use bun_libdeflate_sys::libdeflate as libdeflate_sys;
 use bun_zlib as zlib;
 
@@ -52,6 +52,9 @@ const Z_DEFAULT_COMPRESSION: c_int = 6;
 const Z_DEFAULT_STRATEGY: c_int = 0;
 const Z_DEFAULT_MEM_LEVEL: c_int = 8;
 
+/// Still decodable by an 8-bit peer: deflate's match distances stay <= 512 - MIN_LOOKAHEAD = 250.
+const ZLIB_MIN_RAW_DEFLATE_WINDOW_BITS: u8 = 9;
+
 // Buffer size for compression/decompression operations
 const COMPRESSION_BUFFER_SIZE: usize = 4096;
 
@@ -85,27 +88,26 @@ pub enum CompressError {
 }
 
 impl PerMessageDeflate {
-    pub(crate) fn init(params: Params) -> crate::Result<Box<Self>> {
-        // Initialize compressor (deflate)
-        // We use negative window bits for raw DEFLATE, as required by RFC 7692.
-        let compress_stream = zlib::DeflateEncoder::new(
+    pub(crate) fn init(params: Params) -> Box<Self> {
+        // Negative window bits select raw DEFLATE, as required by RFC 7692.
+        let compress_window_bits = params
+            .client_max_window_bits
+            .max(ZLIB_MIN_RAW_DEFLATE_WINDOW_BITS);
+        let compress_stream = handle_oom(zlib::DeflateEncoder::new(
             Z_DEFAULT_COMPRESSION,
-            -(params.client_max_window_bits as c_int),
+            -(compress_window_bits as c_int),
             Z_DEFAULT_MEM_LEVEL,
             Z_DEFAULT_STRATEGY,
-        )
-        .map_err(|_| crate::Error::DeflateInitFailed)?;
+        ));
+        let decompress_stream = handle_oom(zlib::InflateDecoder::new(
+            -(params.server_max_window_bits as c_int),
+        ));
 
-        // Initialize decompressor (inflate)
-        let decompress_stream =
-            zlib::InflateDecoder::new(-(params.server_max_window_bits as c_int))
-                .map_err(|_| crate::Error::InflateInitFailed)?;
-
-        Ok(Box::new(Self {
+        Box::new(Self {
             params,
             compress_stream,
             decompress_stream,
-        }))
+        })
     }
 
     fn can_use_libdeflate(len: usize) -> bool {

--- a/test/js/web/websocket/websocket-permessage-deflate-edge-cases.test.ts
+++ b/test/js/web/websocket/websocket-permessage-deflate-edge-cases.test.ts
@@ -2,7 +2,7 @@ import { serve } from "bun";
 import { expect, setDefaultTimeout, test } from "bun:test";
 import crypto from "node:crypto";
 import net from "node:net";
-import { deflateRawSync, constants as zc } from "node:zlib";
+import { deflateRawSync, inflateRawSync, constants as zc } from "node:zlib";
 
 // The decompression bomb test needs extra time to compress 150MB of test data
 setDefaultTimeout(30_000);
@@ -570,3 +570,122 @@ test.each([false, true])(
     }
   },
 );
+
+const DEFLATE_TRAILER = Buffer.from([0x00, 0x00, 0xff, 0xff]);
+
+/** Unmask one client -> server frame; `null` until all of it has arrived. */
+function parseClientFrame(bytes: Buffer): { fin: boolean; rsv1: boolean; opcode: number; payload: Buffer } | null {
+  if (bytes.length < 2) return null;
+  if (!(bytes[1] & 0x80)) throw new Error("client frame is not masked");
+  let length = bytes[1] & 0x7f;
+  let offset = 2;
+  if (length === 126) {
+    if (bytes.length < 4) return null;
+    length = bytes.readUInt16BE(2);
+    offset = 4;
+  } else if (length === 127) {
+    if (bytes.length < 10) return null;
+    length = Number(bytes.readBigUInt64BE(2));
+    offset = 10;
+  }
+  if (bytes.length < offset + 4 + length) return null;
+  const mask = bytes.subarray(offset, offset + 4);
+  const payload = Buffer.from(bytes.subarray(offset + 4, offset + 4 + length));
+  for (let i = 0; i < payload.length; i++) payload[i] ^= mask[i & 3];
+  return { fin: (bytes[0] & 0x80) !== 0, rsv1: (bytes[0] & 0x40) !== 0, opcode: bytes[0] & 0x0f, payload };
+}
+
+// RFC 7692 §7.1.2.2: the client offers `client_max_window_bits` without a
+// value, so the server may answer with any window from 8 to 15 bits. zlib
+// refuses to create a raw deflater with an 8-bit window, which used to leave
+// the negotiated extension without a codec: the client still reported it in
+// `extensions`, sent uncompressed, and closed with 1011 on the first compressed
+// server message. It has to compress with a 9-bit window instead, whose output
+// (back-references of at most 250 bytes) a server holding the negotiated
+// 256-byte window can still inflate.
+test("WebSocket client honors client_max_window_bits=8", async () => {
+  // The same 300 bytes repeated: a compressor using a larger window than
+  // negotiated would encode the repeats as back-references that an 8-bit
+  // window cannot resolve.
+  const block = Buffer.alloc(300);
+  let x = 12345;
+  for (let i = 0; i < block.length; i++) {
+    x = (Math.imul(x, 1103515245) + 12345) | 0;
+    block[i] = 0x20 + ((x >>> 16) % 0x5e);
+  }
+  const clientMessage = Buffer.concat(Array(6).fill(block)).toString("latin1");
+
+  const serverDeflated = deflateRawSync(Buffer.from("hello from the server"), { finishFlush: zc.Z_SYNC_FLUSH });
+  const serverFrame = frame(OPCODE_TEXT, serverDeflated.subarray(0, serverDeflated.length - 4), { rsv1: true });
+
+  // Rejected if the connection fails before the events below arrive; every
+  // await below races against it.
+  const failed = Promise.withResolvers<never>();
+  const clientFrame = Promise.withResolvers<NonNullable<ReturnType<typeof parseClientFrame>>>();
+  let fromClient = Buffer.alloc(0);
+  let handshakeComplete = false;
+  const server = Bun.listen({
+    hostname: "127.0.0.1",
+    port: 0,
+    socket: {
+      error(_, error) {
+        failed.reject(error);
+      },
+      data(socket, data) {
+        fromClient = Buffer.concat([fromClient, data]);
+        if (!handshakeComplete) {
+          const end = fromClient.indexOf("\r\n\r\n");
+          if (end < 0) return;
+          const key = /Sec-WebSocket-Key:\s*(\S+)/i.exec(fromClient.subarray(0, end).toString("latin1"));
+          if (!key) throw new Error("client did not send Sec-WebSocket-Key");
+          const accept = new Bun.CryptoHasher("sha1").update(key[1] + WEBSOCKET_GUID).digest("base64");
+          handshakeComplete = true;
+          fromClient = fromClient.subarray(end + 4);
+          socket.write(
+            "HTTP/1.1 101 Switching Protocols\r\n" +
+              "Upgrade: websocket\r\n" +
+              "Connection: Upgrade\r\n" +
+              `Sec-WebSocket-Accept: ${accept}\r\n` +
+              "Sec-WebSocket-Extensions: permessage-deflate; client_max_window_bits=8\r\n" +
+              "\r\n",
+          );
+          socket.write(serverFrame);
+          socket.flush();
+        }
+        const parsed = parseClientFrame(fromClient);
+        if (parsed) clientFrame.resolve(parsed);
+      },
+    },
+  });
+
+  const opened = Promise.withResolvers<void>();
+  const serverMessage = Promise.withResolvers<string>();
+  const ws = new WebSocket(`ws://127.0.0.1:${server.port}/`);
+  ws.onopen = () => opened.resolve();
+  ws.onmessage = event => serverMessage.resolve(event.data);
+  ws.onclose = event => failed.reject(new Error(`closed: code=${event.code} reason=${event.reason}`));
+
+  try {
+    await Promise.race([opened.promise, failed.promise]);
+    expect(ws.extensions).toBe("permessage-deflate; client_max_window_bits=8");
+    ws.send(clientMessage);
+
+    expect(await Promise.race([serverMessage.promise, failed.promise])).toBe("hello from the server");
+
+    const { payload, ...header } = await Promise.race([clientFrame.promise, failed.promise]);
+    expect(header).toEqual({ fin: true, rsv1: true, opcode: OPCODE_TEXT });
+    // Inflate with the window the server negotiated. The small chunkSize makes
+    // zlib resolve back-references through that 256-byte window rather than
+    // through the output buffer, so a longer distance fails here as it would on
+    // a real server.
+    const inflated = inflateRawSync(Buffer.concat([payload, DEFLATE_TRAILER]), {
+      windowBits: 8,
+      chunkSize: 64,
+      finishFlush: zc.Z_SYNC_FLUSH,
+    });
+    expect(inflated.toString("latin1")).toBe(clientMessage);
+  } finally {
+    ws.close();
+    server.stop(true);
+  }
+});


### PR DESCRIPTION
### Problem
- `new WebSocket()` offers `permessage-deflate; client_max_window_bits` (no value), which per RFC 7692 section 7.1.2.2 lets the server pick any client window from 8 to 15 bits.
- When a server answers `client_max_window_bits=8`, the connection opens and `ws.extensions` reports `permessage-deflate; client_max_window_bits=8`, but the first compressed (RSV1) message from the server closes the socket with `1011 "Compression not implemented yet"` (`wasClean: true`, no `error` event). Values 9 through 15 work. Node (`undici`, `ws`) delivers the message.
- Cause, in two parts:
  - `PerMessageDeflate::init` (`src/http_jsc/websocket_client/WebSocketDeflate.rs`) passed `-8` to `deflateInit2`, and zlib rejects a raw deflate window of 8 bits (`vendor/zlib/deflate.c:279`, `windowBits == 8 && wrap != 1` returns `Z_STREAM_ERROR`). The inflate side accepts 8 bits, which is why `server_max_window_bits=8` already worked.
  - `WebSocket::new_raw` (`src/http_jsc/websocket_client.rs`) did `WebSocketDeflate::init(..).ok()`, turning that failure into `deflate: None` after the extension had already been accepted and reported, so the client sent uncompressed and `recv_failed(CompressionUnsupported)` fired on the server's first RSV1 frame.

### Fix
- `init` floors the compressor's window at `ZLIB_MIN_RAW_DEFLATE_WINDOW_BITS` (9); the negotiated `Params` and the inflater are unchanged.
- This still honors the 8-bit negotiation: zlib never emits a match distance above `w_size - MIN_LOOKAHEAD`, which is 512 - 262 = 250 bytes for a 9-bit window, so the output inflates under the peer's 256-byte window. It is the same substitution node's `zlib.DeflateRaw` makes (and Bun's own `node:zlib`, `src/js/node/zlib.ts:635`), so this is what the `ws` client has always sent for this negotiation.
- `init` is now infallible. The upgrade client range-checks both window values to 8..=15 and the deflate side is floored at 9, so allocation is the only thing zlib can still refuse; `init` routes that through `bun_core::handle_oom` like the buffer reservations in `finish_init`, and `new_raw` no longer has a failure to swallow. The `DeflateInitFailed` / `InflateInitFailed` variants of the crate error, whose only producer this was, are removed.
- Verified:
  - `test/js/web/websocket/websocket-permessage-deflate-edge-cases.test.ts`, new test `WebSocket client honors client_max_window_bits=8`: a raw server negotiates `=8` and immediately sends a compressed frame; the client must deliver it, and the client's own message (1800 bytes of a 300-byte block repeated, so a larger window would produce back-references an 8-bit window cannot resolve) must arrive with RSV1 set and inflate under `windowBits: 8` with `chunkSize: 64`, which forces zlib to resolve back-references through the real 256-byte window (15-bit deflate output of the same message fails that inflate with "invalid distance too far back").
  - Fails on the current release with `closed: code=1011 reason=Compression not implemented yet`; passes with this change.
  - The rest of that file, `websocket-permessage-deflate.test.ts`, `websocket-permessage-deflate-simple.test.ts`, `websocket-proxy.test.ts`, `websocket-upgrade.test.ts`, `websocket-client.test.ts`, and regression tests 24593 and 29684 pass with the debug build.
  - The reporter's standalone repro delivers the message for window sizes 8, 9, 10 and 15 with the debug build.

### Background
- permessage-deflate (RFC 7692) compresses each WebSocket message as a raw DEFLATE stream. `client_max_window_bits` / `server_max_window_bits` are the base-2 log of the LZ77 window each side may use when compressing, 8 to 15; the receiver only needs to keep that much history to inflate. A message's first frame sets the RSV1 bit to mark it as compressed.
- zlib's raw deflate (negative `windowBits`) cannot be created with an 8-bit window: its compressor with a 256-byte window could emit distances slightly over 256 (the "256-byte window bug" noted in `deflate.c`), so zlib either refuses (raw) or silently uses 9 bits (zlib-wrapped). A 9-bit window is safe for 8-bit receivers because of the 250-byte distance cap above.
- `ws.extensions` is built by the C++ side from the negotiated `Params` (`WebSocket::setExtensionsFromDeflateParams`), independent of whether the Rust side managed to create the codecs, which is why the old behavior looked like a successful negotiation from JS.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/websocket/websocket-permessage-deflate-edge-cases.test.ts
bun test v1.4.1 (65362b53b)

test/js/web/websocket/websocket-permessage-deflate-edge-cases.test.ts:
(pass) WebSocket client handles compressed continuation frames correctly [133.34ms]
(pass) WebSocket client doesn't compress small messages [51.87ms]
(pass) WebSocket client rejects messages exceeding size limit [54.58ms]
(pass) WebSocket client handles compression errors gracefully [30.75ms]
(pass) WebSocket client rejects decompression bombs [3601.44ms]
(pass) WebSocket client fails the connection on RSV1 set on a continuation frame [58.10ms]
(pass) WebSocket client fails the connection on RSV1 set on a continuation frame without deflate [11.45ms]
(pass) WebSocket client fails the connection on RSV1 set on a control frame [10.17ms]
(pass) WebSocket client accepts RSV1 on the first frame of a fragmented compressed message [15.95ms]
(pass) WebSocket client resets inflater after BFINAL (server_no_context_takeover=false) [244.35ms]
(pass) WebSocket client resets inflater
... (truncated)

release without fix: 1 FAILED
bun test v1.4.1-canary.1 (65362b53b)

test/js/web/websocket/websocket-permessage-deflate-edge-cases.test.ts:
(pass) WebSocket client handles compressed continuation frames correctly [4.43ms]
(pass) WebSocket client doesn't compress small messages [2.31ms]
(pass) WebSocket client rejects messages exceeding size limit [4.64ms]
(pass) WebSocket client handles compression errors gracefully [1.11ms]
(pass) WebSocket client rejects decompression bombs [638.45ms]
(pass) WebSocket client fails the connection on RSV1 set on a continuation frame [3.07ms]
(pass) WebSocket client fails the connection on RSV1 set on a continuation frame without deflate [0.34ms]
(pass) WebSocket client fails the connection on RSV1 set on a control frame [0.29ms]
(pass) WebSocket client accepts RSV1 on the first frame of a fragmented compressed message [0.45ms]
(pass) WebSocket client resets inflater after BFINAL (server_no_context_takeover=false) [30.04ms]
(pass) WebSocket client resets inflater after BFINAL (server_no_context_takeover=true) [18.32ms]
661 |   const opened = Promise.withResolvers<void>();
662 |   const serverMessage = Promise.withResolvers<string>();
663 |   const ws = new WebSock
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/websocket/websocket-permessage-deflate-edge-cases.test.ts
bun test v1.4.1 (65362b53b)

test/js/web/websocket/websocket-permessage-deflate-edge-cases.test.ts:
(pass) WebSocket client handles compressed continuation frames correctly [97.91ms]
(pass) WebSocket client doesn't compress small messages [29.91ms]
(pass) WebSocket client rejects messages exceeding size limit [52.40ms]
(pass) WebSocket client handles compression errors gracefully [28.53ms]
(pass) WebSocket client rejects decompression bombs [3244.59ms]
(pass) WebSocket client fails the connection on RSV1 set on a continuation frame [58.01ms]
(pass) WebSocket client fails the connection on RSV1 set on a continuation frame without deflate [15.83ms]
(pass) WebSocket client fails the connection on RSV1 set on a control frame [9.60ms]
(pass) WebSocket client accepts RSV1 on the first frame of a fragmented compressed message [22.16ms]
(pass) WebSocket client resets inflater after BFINAL (server_no_context_takeover=false) [251.12ms]
(pass) WebSocket client resets inflater a
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     0e6517378b
  features     baseline

23 deps, 131 codegen, 1172 objects in 840ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (65362b53b)

Checked 26 installs across 63 packages (no changes) [25.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (65362b53b)

Checked 1 install across 2 packages (no changes) [7.00ms]
[3/1244] gen ErrorCode+*.h
[4/1244] fetch zlib
[zlib] up to date
[5/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (65362b53b)

Checked 111 installs across 104 packages (no changes) [19.00ms]
[6/1244] gen bindgenv2
[7/1244] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[8/1244] fetch tinycc
[tinycc] up to date
[9/1243] gen node-fallbacks/react-refresh.js
Bundled 1 module in 8ms

  react-refresh.js  4.81 KB  (entry point)

[10/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[11/1216] gen .bind.ts → Ge
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/http_jsc/error.rs                              |   6 -
 src/http_jsc/websocket_client.rs                   |   4 +-
 src/http_jsc/websocket_client/WebSocketDeflate.rs  |  32 +++---
 ...websocket-permessage-deflate-edge-cases.test.ts | 121 ++++++++++++++++++++-
 4 files changed, 138 insertions(+), 25 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/http_jsc/error.rs                                         1      2      0
src/http_jsc/websocket_client.rs                              8      6      0
src/http_jsc/websocket_client/WebSocketDeflate.rs             7     12      0
…bsocket/websocket-permessage-deflate-edge-cases.test.ts      3      3      0
```

</details>

<!-- robobun:evidence:end -->