### PR TITLE
install: reject tarball, folder and git packages whose package.json name is invalid

### DIFF
--- a/src/install/PackageManager/processDependencyList.rs
+++ b/src/install/PackageManager/processDependencyList.rs
@@ -167,7 +167,7 @@ impl PackageManager {
                                     format_args!("{}", resolution.fmt_url(string_buf)),
                                 );
                             }
-                            Global::crash();
+                            self.crash();
                         }
 
                         let has_scripts = pkg.scripts.has_any() || {
@@ -264,7 +264,7 @@ impl PackageManager {
                             err.name(),
                         );
                     }
-                    Global::crash();
+                    self.crash();
                 }
 
                 let has_scripts = package.scripts.has_any() || {

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -2064,6 +2064,16 @@ impl Package<u64> {
             if let Some(name_q) = json.as_property(b"name") {
                 if let Some(name) = name_q.expr.as_utf8(&bump) {
                     if !name.is_empty() {
+                        // Non-root names become bun.lock `packages` entries, which the
+                        // lockfile parser rejects with the same check (see bun.lock.rs).
+                        if !FEATURES.is_main && !dependency::is_safe_install_folder_name(name) {
+                            log.add_error_fmt(
+                                source,
+                                value_loc_of(source, name_q.loc),
+                                format_args!("Invalid package name {}", bun_core::fmt::quote(name)),
+                            );
+                            return Err(crate::Error::InvalidPackageJSON);
+                        }
                         string_builder.count(name);
                         break 'name;
                     }

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -9696,6 +9696,149 @@ it("does not install transitive file: dependencies that point outside their pack
   expect(exitCode).toBe(1);
 });
 
+describe.concurrent("a dependency whose own package.json has an invalid name", () => {
+  // The name inside a tarball, folder or git dependency's package.json is written
+  // to bun.lock as `name@resolution`, and the bun.lock parser rejects names that
+  // are not safe install folder names. Saving such a name used to succeed and
+  // leave behind a lockfile that every later `bun install` ignored, so the
+  // install has to fail before the lockfile is saved.
+  async function install(root: string, ...args: string[]) {
+    await using proc = spawn({
+      cmd: [bunExe(), "install", ...args],
+      cwd: join(root, "project"),
+      env: { ...env, BUN_INSTALL_CACHE_DIR: join(root, "cache") },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { out, err, exitCode };
+  }
+
+  async function expectRejected(root: string, quotedName: string) {
+    const { out, err, exitCode } = await install(root);
+    expect(err).toContain(`error: Invalid package name ${quotedName}`);
+    expect(out).not.toContain("1 package installed");
+    expect(await exists(join(root, "project", "bun.lock"))).toBe(false);
+    expect(await exists(join(root, "project", "node_modules", "dep"))).toBe(false);
+    expect(exitCode).toBe(1);
+    return err;
+  }
+
+  it("fails to install a local tarball", async () => {
+    using dir = tempDir("invalid-name-tarball", {
+      "project/package.json": JSON.stringify({
+        name: "foo",
+        version: "0.0.1",
+        dependencies: { dep: "file:../dep.tgz" },
+      }),
+    });
+    await Bun.Archive.write(
+      join(String(dir), "dep.tgz"),
+      { "package/package.json": JSON.stringify({ name: "a:b", version: "1.0.0" }) },
+      { compress: "gzip" },
+    );
+
+    await expectRejected(String(dir), '"a:b"');
+  });
+
+  it("fails to install a file: folder and points at the offending package.json", async () => {
+    using dir = tempDir("invalid-name-folder", {
+      "project/package.json": JSON.stringify({
+        name: "foo",
+        version: "0.0.1",
+        dependencies: { dep: "file:../lib" },
+      }),
+      "lib/package.json": JSON.stringify({ name: "lib/..", version: "1.0.0" }),
+    });
+
+    const err = await expectRejected(String(dir), '"lib/.."');
+    expect(err).toMatch(/ at .*lib[\\/]package\.json:1:9\s/);
+  });
+
+  it("escapes the rejected name in the error message", async () => {
+    using dir = tempDir("invalid-name-escaped", {
+      "project/package.json": JSON.stringify({
+        name: "foo",
+        version: "0.0.1",
+        dependencies: { dep: "file:../lib" },
+      }),
+      "lib/package.json": JSON.stringify({ name: "a\0b", version: "1.0.0" }),
+    });
+
+    await expectRejected(String(dir), '"a\\u0000b"');
+  });
+
+  it("fails to install a git dependency", async () => {
+    using dir = tempDir("invalid-name-git", {
+      "work/package.json": JSON.stringify({ name: "a\\b", version: "1.0.0" }),
+    });
+    await createDumbHttpGitRepo(String(dir), {});
+    using server = serveDirectory(String(dir));
+    await write(
+      join(String(dir), "project", "package.json"),
+      JSON.stringify({
+        name: "foo",
+        version: "0.0.1",
+        dependencies: { dep: `git+http://localhost:${server.port}/repo.git` },
+      }),
+    );
+
+    await expectRejected(String(dir), '"a\\b"');
+  });
+
+  it("still installs scoped names and writes a lockfile the next install loads", async () => {
+    using dir = tempDir("valid-scoped-name-tarball", {
+      "project/package.json": JSON.stringify({
+        name: "foo",
+        version: "0.0.1",
+        dependencies: { dep: "file:../dep.tgz" },
+      }),
+    });
+    await Bun.Archive.write(
+      join(String(dir), "dep.tgz"),
+      { "package/package.json": JSON.stringify({ name: "@scope/dep", version: "1.0.0" }) },
+      { compress: "gzip" },
+    );
+
+    const first = await install(String(dir));
+    expect(first.err).not.toContain("error:");
+    expect(first.out).toContain("1 package installed");
+    expect(first.exitCode).toBe(0);
+    expect(await file(join(String(dir), "project", "bun.lock")).text()).toContain('"dep": ["@scope/dep@../dep.tgz"');
+
+    const second = await install(String(dir), "--frozen-lockfile");
+    expect(second.err).not.toContain("Ignoring lockfile");
+    expect(second.err).not.toContain("error:");
+    expect(second.exitCode).toBe(0);
+  });
+
+  it("does not apply to the root package's own name", async () => {
+    // The root is not a bun.lock `packages` entry; its name only appears in the
+    // `workspaces` section, which accepts it as-is.
+    using dir = tempDir("invalid-name-root", {
+      "project/package.json": JSON.stringify({
+        name: "a:b",
+        version: "0.0.1",
+        dependencies: { dep: "file:../lib" },
+      }),
+      "lib/package.json": JSON.stringify({ name: "lib", version: "1.0.0" }),
+    });
+
+    const first = await install(String(dir));
+    expect(first.err).not.toContain("error:");
+    expect(first.out).toContain("1 package installed");
+    expect(first.exitCode).toBe(0);
+    const lockfile = await file(join(String(dir), "project", "bun.lock")).text();
+    expect(lockfile).toContain('"name": "a:b"');
+    expect(lockfile).toContain('"dep": ["lib@file:../lib", {}]');
+
+    const second = await install(String(dir), "--frozen-lockfile");
+    expect(second.err).not.toContain("Ignoring lockfile");
+    expect(second.err).not.toContain("error:");
+    expect(second.exitCode).toBe(0);
+  });
+});
+
 it("does not install transitive file: dependencies with overlong folder targets", async () => {
   const overlongTarget = "file:./" + Buffer.alloc(120000, "a").toString();
   using dir = tempDir("transitive-file-dep-overlong", {


### PR DESCRIPTION
### Problem
- A `file:` tarball, `file:` folder, git or workspace dependency whose own `package.json` has a name such as `"a:b"` installs fine, and `bun install` writes `"x": ["a:b@../evil.tgz", ...]` into bun.lock.
- The bun.lock parser rejects that entry (`error: Invalid package name`, `src/install/lockfile/bun.lock.rs` line 2357), so every following `bun install` prints `warn: Ignoring lockfile`, re-resolves and writes the same lockfile again, `bun install --frozen-lockfile` always fails with `lockfile had changes, but lockfile is frozen`, and `bun pm ls` fails with `error: Error loading lockfile: InvalidLockfile`.
- Cause: `Package::parse_with_json_impl` (`src/install/lockfile/Package.rs`, the `'name:` block near line 2064) copies any non-empty `name` out of the package's package.json. Nothing applies the check the lockfile parser applies on reload. Registry packages are not affected because their name is the requested, already validated name; this only concerns names read out of tarball, folder, git and workspace packages.
- In the same situation the isolated linker already refuses the package (`"a:b" is not a valid install folder name`, the name is a store folder there), so only the hoisted linker got as far as saving the lockfile.

### Fix
- `Package::parse_with_json_impl` runs `dependency::is_safe_install_folder_name` on the name of every non-root package. On failure it logs `Invalid package name "<name>"` pointing at the `name` value in that package.json and returns `InvalidPackageJSON`, the error this function already uses for package.json contents it refuses, so the install fails before a lockfile is saved.
- This is the same predicate the bun.lock parser uses, so whatever bun saves it can load again; and since #38615 extends that predicate to control characters, those get rejected here as well once it lands. The rejected name is echoed through `bun_core::fmt::quote`, which JSON-escapes control characters and quotes.
- Failing instead of inventing a name: these names are already rejected by the isolated linker and by the lockfile, and npm's own name rules reject them too (`:`/`\`, `.`/`..` segments, empty segments), so no package produced by normal tooling is affected. A substituted name would also never match the installed package.json, so `bun install` would reinstall the package every run.
- The root package is exempt (`FEATURES.is_main`): its name is only written to the `workspaces` section, which accepts it, and a root named `"a:b"` installs and reloads fine today.
- The git and tarball arms of `process_extracted_tarball_package` (`src/install/PackageManager/processDependencyList.rs`) now exit through `PackageManager::crash()` instead of `Global::crash()`, so the logged reason is printed; without that, the new error (like any `InvalidPackageJSON` from a tarball today) would only show up as `expected package.json in ../evil.tgz to be a JSON file: InvalidPackageJSON`. The folder and workspace paths already printed the log. The npm arm of that match is not on this path and is unchanged.
- Out of scope: a tarball/folder package with no name at all (`"x": ["@file:../dir", {}]`) and names containing `@` also produce a lockfile that does not load back, but that is a problem of the `name@resolution` encoding rather than of name validation, and is left for a separate change.
- Verified: `test/cli/install/bun-install.test.ts`, describe `a dependency whose own package.json has an invalid name`: local tarball, `file:` folder (asserts the error location), escaping of the echoed name, git dependency (local dumb-http repo), plus two controls that must keep passing: a scoped `@scope/dep` tarball still installs and the saved bun.lock loads under `--frozen-lockfile`, and an invalid root name is still accepted. The four rejection tests fail on the released binary and pass with this change; the controls pass on both.
- Also ran with the debug build: the rest of `bun-install.test.ts` (remaining failures are the bitbucket/gitlab network tests and two tests that fail identically without this change in this environment), `bun-workspaces`, `bun-add`, `bun-patch`, `isolated-install`, `migration/migrate`, and the folder/tarball/workspace/git subset of `bun-install-registry`; all green.

### Background
- bun.lock stores each installed package as `"<path>": ["<name>@<resolution>", ...]`. On load, the name is split back out and checked with `is_safe_install_folder_name`, because package names from the lockfile become folder names: the npm cache folder for registry packages and the `node_modules/.bun/<name>@...` store folder for isolated installs. A name failing the check makes the whole lockfile unloadable, which bun reports as `Ignoring lockfile` and treats as "no lockfile".
- `is_safe_install_folder_name` (`src/install/dependency.rs`) rejects empty names, `.`/`..` or empty `/`-separated segments, and segments containing `\`, `:` or NUL; `@scope/name` passes.
- `Package::parse_with_json_impl` is the one function that turns a package.json into a lockfile `Package` for everything that is not a registry manifest: the root (`Features::MAIN`, the only caller with `is_main`), workspace members, `file:` folders, `link:` targets, and the package.json extracted from tarball and git dependencies. That is why the check lives there.
- `PackageManager::crash()` prints the accumulated install log to stderr (unless `--silent`) and exits 1; `Global::crash()` just exits 1.
