### PR TITLE
types(sql): document what onconnect/onclose receive for each adapter

### DIFF
--- a/packages/bun-types/sql.d.ts
+++ b/packages/bun-types/sql.d.ts
@@ -185,14 +185,16 @@ declare module "bun" {
       filename?: URL | ":memory:" | (string & {}) | undefined;
 
       /**
-       * Called when a connection attempt completes.
-       * Receives an `Error` on failure, or `null` on success.
+       * SQLite: called once opening the database has been attempted, with
+       * `null` when it opened or with the `Error` that prevented it from
+       * opening (for example `SQLITE_CANTOPEN`).
        */
       onconnect?: ((err: Error | null) => void) | undefined;
 
       /**
-       * Called when a connection is closed.
-       * Receives the closing `Error`, or `null`.
+       * SQLite: called when the database is closed with {@link SQL.close}.
+       * Passes an `Error` (message `"Connection closed"`) rather than `null`,
+       * even though the close was requested.
        */
       onclose?: ((err: Error | null) => void) | undefined;
     }
@@ -363,14 +365,21 @@ declare module "bun" {
       path?: string | undefined;
 
       /**
-       * Called when a connection attempt completes.
-       * Receives an `Error` on failure, or `null` on success.
+       * PostgreSQL and MySQL: called once for each connection the pool
+       * establishes, always with `null`. A connection attempt that fails is
+       * reported to {@link onclose} instead; `onconnect` is not called for it.
        */
       onconnect?: ((err: Error | null) => void) | undefined;
 
       /**
-       * Called when a connection is closed.
-       * Receives the closing `Error`, or `null`.
+       * PostgreSQL and MySQL: called once for each pooled connection that
+       * closes or fails to connect, with the `Error` describing why. Closing
+       * on purpose also passes an error rather than `null`: {@link SQL.close}
+       * passes `ERR_POSTGRES_CONNECTION_CLOSED` / `ERR_MYSQL_CONNECTION_CLOSED`,
+       * and {@link idleTimeout} passes `ERR_POSTGRES_IDLE_TIMEOUT` /
+       * `ERR_MYSQL_IDLE_TIMEOUT`. A failed connection attempt passes its
+       * error, for example `ERR_POSTGRES_CONNECTION_REFUSED` or the server's
+       * authentication error.
        */
       onclose?: ((err: Error | null) => void) | undefined;
 


### PR DESCRIPTION
### Problem
- `packages/bun-types/sql.d.ts` documents `PostgresOrMySQLOptions.onconnect` as "Receives an `Error` on failure, or `null` on success". The postgres and mysql drivers never call it with an error: the native side only invokes the connected callback with `null` (`src/sql_jsc/postgres/PostgresSQLConnection.rs:646`, `src/sql_jsc/mysql/JSMySQLConnection.rs:762`), and every connect failure goes through the driver's `fail_with_js_value`, which invokes the close callback, so the user sees `onclose(err)` and `onconnect` is never called. A password function that throws, or a `createConnection` that throws synchronously, is routed to `onclose` by the JS layer as well (`src/js/internal/sql/shared.ts:907-911`).
- The same text is on `SQLiteOptions.onconnect`, where it is true (`src/js/internal/sql/sqlite.ts:334`, `:352`), so the two identical docs describe two different behaviors. When `adapter` is not specified in the options literal, editors show both docs concatenated and nothing tells them apart.
- Both `onclose` docs say "the closing `Error`, or `null`", but every adapter passes an error even for a close the user asked for: `sql.close()` passes `ERR_POSTGRES_CONNECTION_CLOSED` / `ERR_MYSQL_CONNECTION_CLOSED` (SQLite: a plain `Error("Connection closed")`, `sqlite.ts:464-475`), `idleTimeout` passes `ERR_*_IDLE_TIMEOUT`. Code written to the current doc (`if (err) reportFailure(err)`) reports every normal close as a failure.
- Verified against bun 1.4.0 with a local postgres and mariadb (output below): bad role, refused port, throwing `password()` and `idleTimeout` all fire only `onclose`; `onconnect` only ever gets `null`. Only SQLite reports an open failure through `onconnect`.

### Fix
- Rewrites the four JSDoc blocks so each states its adapter and what the callback is actually passed: postgres/mysql `onconnect` is always `null` and failed attempts go to `onclose`; `onclose` names the codes a deliberate close passes; the SQLite pair says an open failure is delivered to `onconnect` and that `onclose` also gets an error.
- Correct because it describes what the runtime does today, and that behavior is already pinned by tests: `test/js/sql/sql.test.ts:756-803` and `test/js/sql/sql-mysql.test.ts:248-288` (connect failure: `onconnect` not called, `onclose` once; idle timeout: `onclose` with `ERR_*_IDLE_TIMEOUT`), `test/js/sql/sql-onconnect-onclose-throw.test.ts` (`onconnect: null` on success, `onclose` on `sql.end()`, on a refused port and on a throwing password function), `test/js/sql/sqlite-sql.test.ts:63-110` (SQLite `onconnect(null)` / `onconnect(Error)` / `onclose(Error)`). The adapter prefixes exist because TypeScript shows both members' docs for a property of the `SQLiteOptions | PostgresOrMySQLOptions` union (checked with the language service, see below).
- The signatures are left as `(err: Error | null) => void` on purpose. Narrowing postgres/mysql `onconnect` to `(err: null)` turns the `if (err) use(err.message)` pattern the old doc encouraged into TS2339 (`err` narrows to `never`). Narrowing `onclose` to `(err: Error)` would compile for existing callers, but it would commit the types to the always-an-error behavior that the JS layer still treats as optional (`shared.ts:1787`), which is a design call rather than a doc fix; happy to do it in a follow-up if wanted.
- No test is added: the change is comment-only in a `.d.ts`, so there is nothing for `tsc` or the runtime to observe. Verification: `bun test test/integration/bun-types/bun-types.test.ts` (15 pass), `prettier --check` on the file, and the runtime probe below.
- `docs/runtime/sql.mdx` is covered separately by #38625; this PR is only the `.d.ts`, which is what editors show.

### Background
- `Bun.SQL.Options` is `SQLiteOptions | PostgresOrMySQLOptions`. Both members declare `onconnect` and `onclose`; a property that exists on every member of a union shows the docs of all of its declarations in completion, so each member's doc has to say which adapter it is about.
- For postgres and mysql, `onconnect` / `onclose` are per pooled connection, not per `SQL` instance: `BasePooledConnection.handleConnected` (`shared.ts:655`) calls the user's `onconnect` with whatever the driver passed (always `null`), and `#finishClose` (`shared.ts:759`) calls `onclose` with the error the connection died with, once per connection (backoff retries do not fire it per attempt). The SQLite adapter has no pool: it opens the file in its constructor and calls `onconnect` synchronously with `null` or the open error, and `onclose` from `close()`.

<details>
<summary>Runtime probe, bun 1.4.0, local postgres 5432 and mariadb 3306</summary>

```
## postgres: success then close()
   onconnect -> null
   onclose -> ERR_POSTGRES_CONNECTION_CLOSED: Connection closed
## postgres: bad role
   onclose -> ERR_POSTGRES_SERVER_ERROR: role "no_such_role_xyz" does not exist
## postgres: refused
   onclose -> ERR_POSTGRES_CONNECTION_REFUSED: Failed to connect
## postgres: idleTimeout: 1
   onconnect -> null
   onclose -> ERR_POSTGRES_IDLE_TIMEOUT: Idle timeout reached after 1s
## postgres: password() throws
   onclose -> Error: no password for you

## mysql: success then close()
   onconnect -> null
   onclose -> ERR_MYSQL_CONNECTION_CLOSED: Connection closed
## mysql: bad password
   onclose -> ERR_MYSQL_SERVER_ERROR: Access denied for user 'probe'@'localhost' (using password: YES)
## mysql: refused
   onclose -> ERR_MYSQL_CONNECTION_REFUSED: Failed to connect
## mysql: idleTimeout: 1
   onconnect -> null
   onclose -> ERR_MYSQL_IDLE_TIMEOUT: Idle timeout reached after 1s

## sqlite: success then close()
   onconnect -> null
   onclose -> Error: Connection closed
## sqlite: create: false on a missing file
   onconnect -> SQLITE_CANTOPEN: unable to open database file
   onclose -> Error: Connection closed
```

`onconnect` lines are absent wherever the callback did not fire.

</details>

<details>
<summary>What editors show (TypeScript language service against this branch)</summary>

Completion for `onconnect` inside `new SQL({ url: "postgres://...", | })` (union not narrowed) shows both docs back to back:

```
SQLite: called once opening the database has been attempted, with
`null` when it opened or with the `Error` that prevented it from
opening (for example `SQLITE_CANTOPEN`).
PostgreSQL and MySQL: called once for each connection the pool
establishes, always with `null`. A connection attempt that fails is
reported to {@link onclose} instead; `onconnect` is not called for it.
```

With `adapter: "postgres"` or `adapter: "sqlite"` in the literal, hover shows only the matching one. Before this change both positions showed the same "Receives an `Error` on failure" text.

</details>
