### PR TITLE
node errors: render functions in ERR_INVALID_ARG_VALUE messages like util.inspect

### DIFF
--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -12,6 +12,8 @@
 #include "helpers.h"
 #include "JavaScriptCore/JSCJSValue.h"
 #include "JavaScriptCore/ErrorInstance.h"
+#include "JavaScriptCore/FunctionExecutable.h"
+#include "JavaScriptCore/JSFunction.h"
 #include "JavaScriptCore/JSString.h"
 #include "JavaScriptCore/JSType.h"
 #include "JavaScriptCore/Symbol.h"
@@ -307,6 +309,81 @@ static void appendEscapedQuotedChar(WTF::StringBuilder& builder, CharType c, cha
     }
 }
 
+// util.inspect's rendering of a function (getFunctionBase / getClassBase in
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/util/inspect.js, without the trailing
+// own-property listing): the kind comes from how the function was defined and the name is an
+// ordinary `.name` read, so a bound function is "[Function: bound f]", an async function
+// "[AsyncFunction: f]" and a class "[class Foo extends Base]". Bun.inspect intentionally differs here
+// ("[Function]" for an anonymous function, "[class Array]" for a native constructor), so callables
+// cannot share the Bun__inspect_singleline fallback that other objects take.
+static void appendFunctionLikeInspect(JSC::JSGlobalObject* globalObject, WTF::StringBuilder& builder, JSC::JSObject* function)
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    bool isClass = false;
+    ASCIILiteral kind = "Function"_s;
+    auto* jsFunction = dynamicDowncast<JSC::JSFunction>(function);
+    if (jsFunction && !jsFunction->isHostFunction()) {
+        auto* executable = jsFunction->jsExecutable();
+        isClass = executable->isClassConstructorFunction();
+        bool isGenerator = executable->isGenerator() || executable->isAsyncGenerator();
+        if (JSC::isAsyncFunctionParseMode(executable->parseMode()))
+            kind = isGenerator ? "AsyncGeneratorFunction"_s : "AsyncFunction"_s;
+        else if (isGenerator)
+            kind = "GeneratorFunction"_s;
+    }
+
+    JSValue nameValue = function->get(globalObject, vm.propertyNames->name);
+    RETURN_IF_EXCEPTION(scope, );
+    // A name that was redefined to a non-string (Object.defineProperty(f, "name", { value: 42 }))
+    // is inspected, like node's formatValue does: "[Function: 42]".
+    WTF::String name = nameValue.isString()
+        ? nameValue.toWTFString(globalObject)
+        : Bun__inspect_singleline(globalObject, nameValue).transferToWTFString();
+    RETURN_IF_EXCEPTION(scope, );
+
+    // A JSFunction or InternalFunction is an ordinary object (a callable Proxy has its own JSType and
+    // never gets here), so reading its [[Prototype]] directly is unobservable.
+    JSValue prototype = function->getPrototypeDirect();
+
+    if (!isClass) {
+        builder.append('[');
+        builder.append(kind);
+        if (prototype.isNull())
+            builder.append(" (null prototype)"_s);
+        if (name.isEmpty()) {
+            builder.append(" (anonymous)"_s);
+        } else {
+            builder.append(": "_s);
+            builder.append(name);
+        }
+        builder.append(']');
+        return;
+    }
+
+    builder.append("[class "_s);
+    if (name.isEmpty())
+        builder.append("(anonymous)"_s);
+    else
+        builder.append(name);
+    if (prototype.isNull()) {
+        builder.append(" extends [null prototype]"_s);
+    } else {
+        JSValue superNameValue = prototype.get(globalObject, vm.propertyNames->name);
+        RETURN_IF_EXCEPTION(scope, );
+        if (superNameValue.isString()) {
+            WTF::String superName = superNameValue.toWTFString(globalObject);
+            RETURN_IF_EXCEPTION(scope, );
+            if (!superName.isEmpty()) {
+                builder.append(" extends "_s);
+                builder.append(superName);
+            }
+        }
+    }
+    builder.append(']');
+}
+
 void JSValueToStringSafe(JSC::JSGlobalObject* globalObject, WTF::StringBuilder& builder, JSValue arg, bool quotesLikeInspect = false)
 {
     ASSERT(!arg.isEmpty());
@@ -349,19 +426,9 @@ void JSValueToStringSafe(JSC::JSGlobalObject* globalObject, WTF::StringBuilder& 
         return;
     }
     case JSC::JSType::InternalFunctionType:
-    case JSC::JSType::JSFunctionType: {
-        auto& vm = JSC::getVM(globalObject);
-        auto name = Zig::functionName(vm, globalObject, cell->getObject());
-
-        if (!name.isEmpty()) {
-            builder.append("[Function: "_s);
-            builder.append(name);
-            builder.append(']');
-        } else {
-            builder.append("[Function (anonymous)]"_s);
-        }
+    case JSC::JSType::JSFunctionType:
+        appendFunctionLikeInspect(globalObject, builder, cell->getObject());
         return;
-    }
 
     default: {
         break;

--- a/test/js/node/errors/invalid-arg-value-received-function.test.ts
+++ b/test/js/node/errors/invalid-arg-value-received-function.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import http from "node:http";
+
+// ERR_INVALID_ARG_VALUE's "Received ..." is built by JSValueToStringSafe() in src/jsc/bindings/ErrorCode.cpp.
+// Node renders the value with util.inspect, which for a callable means the function's kind plus an
+// ordinary read of its `name`: "[Function: bound f]", "[AsyncFunction: f]", "[class Foo extends Base]".
+// The entry points below reach the renderer from Rust (inspect_for_error_message), from two of the
+// C++ INVALID_ARG_VALUE overloads (validateOneOf's and the plain one) and from the JS builtins'
+// $ERR_INVALID_ARG_VALUE. Node prints these exact messages (prefix included) for the same calls.
+const entryPoints: [label: string, prefix: string, throwWith: (value: unknown) => unknown][] = [
+  [
+    "Rust (fs.readFileSync flag)",
+    "The argument 'flags' is invalid. Received ",
+    value => fs.readFileSync(import.meta.path, { flag: value as any }),
+  ],
+  [
+    "C++ validateOneOf (http.Agent scheduling)",
+    "The argument 'scheduling' must be one of: 'fifo', 'lifo'. Received ",
+    value => new http.Agent({ scheduling: value as any }),
+  ],
+  [
+    "C++ INVALID_ARG_VALUE (require.resolve paths)",
+    "The property 'options.paths' is invalid. Received ",
+    value => require.resolve("./unused", { paths: value as any }),
+  ],
+  [
+    "$ERR_INVALID_ARG_VALUE (fs.opendirSync encoding)",
+    "The argument 'encoding' is invalid encoding. Received ",
+    value => fs.opendirSync(".", { encoding: value as any }),
+  ],
+];
+
+class Base {}
+function Parent() {}
+// The arrow takes its name from the property key. It lives here rather than inline in its case
+// because the transpiler folds `({ aa: <arrow> }).aa` down to the bare arrow, which has no name.
+const arrows = { aa: async () => {} };
+
+// The cases build their values per call: JSC materializes a function's `name` property lazily, and
+// the old renderer's output for e.g. a bound function depended on whether that had already happened.
+const cases: [label: string, make: () => unknown, rendered: string][] = [
+  ["bound function", () => function b() {}.bind(null), "[Function: bound b]"],
+  ["bound anonymous function", () => [function () {}][0].bind(null), "[Function: bound ]"],
+  ["bound class", () => class BC {}.bind(null), "[Function: bound BC]"],
+  ["class", () => class Foo {}, "[class Foo]"],
+  ["anonymous class", () => [class {}][0], "[class (anonymous)]"],
+  ["class extending a class", () => class Derived extends Base {}, "[class Derived extends Base]"],
+  ["class extending a function", () => class D extends Parent {}, "[class D extends Parent]"],
+  [
+    "class whose name was redefined",
+    () => Object.defineProperty(class K {}, "name", { value: "Renamed" }),
+    "[class Renamed]",
+  ],
+  [
+    "class with a null prototype",
+    () => Object.setPrototypeOf(class NP {}, null),
+    "[class NP extends [null prototype]]",
+  ],
+  ["async function", () => async function af() {}, "[AsyncFunction: af]"],
+  ["async arrow function", () => arrows.aa, "[AsyncFunction: aa]"],
+  ["async method", () => ({ async m() {} }).m, "[AsyncFunction: m]"],
+  ["generator function", () => function* gen() {}, "[GeneratorFunction: gen]"],
+  ["async generator function", () => async function* agen() {}, "[AsyncGeneratorFunction: agen]"],
+  ["getter", () => Object.getOwnPropertyDescriptor({ get x() {} }, "x")!.get, "[Function: get x]"],
+  [
+    "name redefined as a getter",
+    () => Object.defineProperty(function f() {}, "name", { get: () => "fromGetter" }),
+    "[Function: fromGetter]",
+  ],
+  ["name redefined as a number", () => Object.defineProperty(function f() {}, "name", { value: 42 }), "[Function: 42]"],
+  [
+    "name deleted (falls back to Function.prototype.name)",
+    () => {
+      function f() {}
+      delete (f as any).name;
+      return f;
+    },
+    "[Function (anonymous)]",
+  ],
+  [
+    "function with a null prototype",
+    () => Object.setPrototypeOf(function np() {}, null),
+    "[Function (null prototype): np]",
+  ],
+  // Renderings the old code already got right, pinned so the rewrite keeps them.
+  ["named function", () => function named() {}, "[Function: named]"],
+  ["anonymous function", () => [function () {}][0], "[Function (anonymous)]"],
+  [
+    "name redefined as a string",
+    () => Object.defineProperty(function f() {}, "name", { value: "renamed" }),
+    "[Function: renamed]",
+  ],
+  ["symbol-keyed method", () => ({ [Symbol.iterator]() {} })[Symbol.iterator], "[Function: [Symbol.iterator]]"],
+  ["native constructor", () => Array, "[Function: Array]"],
+  ["native function", () => Math.max, "[Function: max]"],
+];
+
+function thrownBy(fn: () => unknown): any {
+  try {
+    fn();
+  } catch (e) {
+    return e;
+  }
+  throw new Error("expected the call to throw");
+}
+
+describe.each(entryPoints)("ERR_INVALID_ARG_VALUE renders a callable like node: %s", (_label, prefix, throwWith) => {
+  test("kind and name", () => {
+    const messages = cases.map(([label, make]) => {
+      const error = thrownBy(() => throwWith(make()));
+      return [label, error.code, error.message];
+    });
+    expect(messages).toEqual(cases.map(([label, , rendered]) => [label, "ERR_INVALID_ARG_VALUE", prefix + rendered]));
+  });
+
+  test("an exception thrown while reading a name replaces the error being built", () => {
+    const getterBoom = new RangeError("getter boom");
+    const throwingName = Object.defineProperty(function f() {}, "name", {
+      get() {
+        throw getterBoom;
+      },
+    });
+    expect(thrownBy(() => throwWith(throwingName))).toBe(getterBoom);
+
+    const parentBoom = new RangeError("parent boom");
+    const throwingParent = Object.defineProperty(function P() {}, "name", {
+      get() {
+        throw parentBoom;
+      },
+    });
+    expect(thrownBy(() => throwWith(class D extends throwingParent {}))).toBe(parentBoom);
+  });
+});


### PR DESCRIPTION
### Problem
- The `Received ...` part of `ERR_INVALID_ARG_VALUE` (and the other messages built by `JSValueToStringSafe`) renders every callable as `[Function: <name>]`, so it diverges from node, which renders the value with `util.inspect`. With `fs.readFileSync(f, { flag: v })` on bun 1.4.0 vs node v26.3.0:

  | value | bun | node |
  |---|---|---|
  | `function b(){}.bind(null)` | `[Function: b]` | `[Function: bound b]` |
  | `class Foo {}` | `[Function: Foo]` | `[class Foo]` |
  | `async function af(){}` | `[Function: af]` | `[AsyncFunction: af]` |
  | `function* gen(){}` | `[Function: gen]` | `[GeneratorFunction: gen]` |
  | `Object.defineProperty(function f(){}, "name", { get: () => "g" })` | `[Function: f]` | `[Function: g]` |

- Cause: the `JSFunctionType` / `InternalFunctionType` arm of `JSValueToStringSafe` (`src/jsc/bindings/ErrorCode.cpp`) builds the string from `Zig::functionName`, the stack-trace name heuristic (`ErrorStackTrace.cpp`). It reads the function's internal name state, so it misses the `bound ` prefix until `.name` has been materialized, ignores `name` accessors, and knows nothing about class, async or generator kinds.
- Deleting the arm (so callables take the `Bun__inspect_singleline` fallback like other objects) does not work: that fallback is `Bun.inspect`, not `util.inspect`, and `Bun.inspect` prints `[Function]` for an anonymous function and `[class Array]` for a native constructor (both pinned by `test/js/bun/util/inspect.test.js` and `test/regression/issue/29225.test.ts`), and also drops the `bound ` prefix. Node prints `[Function (anonymous)]` and `[Function: Array]`, which the current arm already gets right, so removing it would trade one set of divergences for another.

### Fix
- The arm now renders the same form as node's `getFunctionBase` / `getClassBase` (`lib/internal/util/inspect.js`), in a new `appendFunctionLikeInspect` helper:
  - kind from the function's `FunctionExecutable` (`isClassConstructorFunction`, `isAsyncFunctionParseMode`, `isGenerator` / `isAsyncGenerator`); host functions, bound functions and `InternalFunction`s are plain `Function`, as in node;
  - name via an ordinary `[[Get]]` of `name`, which is what node reads: gives `bound f`, `get x`, redefined names and accessor results, and `(anonymous)` when empty; a non-string name is inspected (`[Function: 42]`); an accessor that throws propagates, replacing the error being built, as in node;
  - `[class X extends Base]` from the constructor's `[[Prototype]]`'s `name`, and node's `(null prototype)` / `extends [null prototype]` forms.
- Why this is right: `ERR_INVALID_ARG_VALUE` and `ERR_OUT_OF_RANGE` are specified by node as `inspect(value)`, and this makes the callable case print what node prints (table below: 27 checks x 4 entry points are byte-identical to node v26.3.0). The arm keeps existing for the same reason the `StringType` arm above it exists: node's rendering and `Bun.inspect`'s intentionally differ for these types, so the message has to be built here.
- Every caller already does `RETURN_IF_EXCEPTION` after `JSValueToStringSafe` (objects could already throw through the inspect fallback), so the new `[[Get]]` needs no caller changes; `BUN_JSC_validateExceptionChecks=1` is clean on the probe below.
- Not changed: the suffixes node appends after this base form (own enumerable properties `{ x: 1 }`, a `Symbol.toStringTag`, a constructor that differs from the kind such as `[Function: bound af] AsyncFunction`), and callable Proxies, which have their own `JSType` and still go through the inspect fallback. Node detects classes from `Function.prototype.toString` text while this uses JSC's flag; the only difference is heritage expressions containing parentheses (`class D extends (function P() {}) {}` is `[Function: D]` in node).
- Callers where node uses `${value}` rather than inspect (`ERR_UNKNOWN_ENCODING`, `ERR_UNKNOWN_SIGNAL`, ...) matched node neither before nor after; they now print the same form `util.inspect` would.
- Verified:
  - `test/js/node/errors/invalid-arg-value-received-function.test.ts`: 25 values through four bridges into the renderer (Rust `inspect_for_error_message` via `fs.readFileSync` flag, the C++ validateOneOf overload via `http.Agent`, the plain C++ overload via `require.resolve` paths, and `$ERR_INVALID_ARG_VALUE` via `fs.opendirSync`), plus the throwing-accessor propagation. Node prints the expected messages (prefix included) for the identical calls, checked by running the same table under node v26.3.0. The directory follows #38473 / #38435 / #38402, which add tests for neighbouring arms of this renderer there.
  - `USE_SYSTEM_BUN=1 bun test <file>`: 8 fail (84 of the 108 message checks differ; the 24 that already pass are the pinned unchanged renderings). `bun bd test <file>`: 8 pass.
  - Also ran with the debug build: `test/js/node/fs/fs.test.ts`, `test/js/node/buffer.test.js`, `yaml.test.ts`, `histogram.test.ts`, `test-assert.js`, `test-assert-class.js`, `test-webstream-readable-from.js`, `test-string-decoder.js`, `test-buffer-alloc.js`, `test-crypto-keygen.js` and the other vendored tests that mention these error codes: no failures besides the pre-existing `readdirSync ... x 100` 10s throughput timeout under ASAN.

### Background
- `JSValueToStringSafe` is the shared "render this value into an error message" routine in `ErrorCode.cpp`. Strings and symbols have hand-written arms; everything else falls through to `Bun__inspect_singleline`, which is `Bun.inspect` (the native formatter in `ConsoleObject`) in single-line mode. `util.inspect` in bun is a separate JS port of node's implementation (`src/js/internal/util/inspect.js`) and is not what error messages use.
- `Zig::functionName` is the name lookup used for stack frames: it reads an already-materialized own `name` slot or JSC's calculated display name, never runs user code, and returns only a bare name.
- JSC creates a function's `name` property lazily; `[[Get]]` (`JSObject::get`) materializes it, which for a bound function is where the `bound ` prefix is produced.
- A `FunctionExecutable`'s parse mode records how a JS function was written (plain, arrow, async, generator, async generator, class constructor); host (native) functions and bound functions have no `FunctionExecutable`, which is why they render as plain `Function`, matching node's `isAsyncFunction` / class detection on such values.
- A callable Proxy has `ProxyObjectType`, not `JSFunctionType`, so it never enters this arm; a `JSFunction` or `InternalFunction` has an ordinary `[[GetPrototypeOf]]`, which is why `getPrototypeDirect()` is safe to use for the `extends` / null-prototype checks.

<details>
<summary>Probe: node v26.3.0 vs this branch on edge cases (fs.readFileSync flag)</summary>

```
value                                node                                     this branch
name getter throws                   throws the getter's error                same
name redefined to a function itself  RangeError: Maximum call stack           [Function: [Function: f]]
name = 42                            [Function: 42]                           same
name = Symbol("sym")                 [Function: Symbol(sym)]                  same
name = undefined                     [Function: undefined]                    same
class with name = 42                 [class 42]                               same
class with name deleted              [class (anonymous)]                      same
class with name getter "G"           [class G]                                same
setPrototypeOf(fn, null)             [Function (null prototype): np]          same
setPrototypeOf(class NP {}, null)    [class NP extends [null prototype]]      same
class EN extends null {}             [class EN]                               same
class D extends P (P a function)     [class D extends P]                      same
parent name getter                   [class D extends PG]                     same
parent name getter throws            throws the getter's error                same
async / generator / async gen method [AsyncFunction: m] / [GeneratorFunction: g] / [AsyncGeneratorFunction: ag]   same
getter function                      [Function: get x]                        same
f.bind().bind()                      [Function: bound bound f]                same
class BC {}.bind(null)               [Function: bound BC]                     same
Array / Math.max / Function          [Function: Array] / [Function: max] / [Function: Function]   same
({ [Symbol.iterator]() {} })[...]    [Function: [Symbol.iterator]]            same
async fn .bind(null)                 [Function: bound af] AsyncFunction       [Function: bound af]
fn with Symbol.toStringTag           [Function: tagged] [MyTag]               [Function: tagged]
fn with own props / class w/ static  [Function: withProps] { x: 1 } / [class S] { y: 2 }   [Function: withProps] / [class S]
new Proxy(function pf() {}, {})      Proxy([Function: pf])                    [Function: pf]   (unchanged)
revoked proxy                        <Revoked Proxy>                          same (unchanged)
```

Before this change every line above rendered as `[Function: <bare name>]`.
</details>
