### PR TITLE
hot: report a reloaded generation's error while a beforeExit listener keeps the loop alive

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1583,6 +1583,19 @@ impl VirtualMachine {
     }
 
     pub fn on_before_exit(&mut self) {
+        self.on_before_exit_with(|_| {});
+    }
+
+    /// Dispatches 'beforeExit', then drains whatever the listeners scheduled,
+    /// re-dispatching each time the loop empties again (node's semantics).
+    ///
+    /// `after_tick` runs after every tick of that drain. A listener that
+    /// re-arms the loop on each dispatch keeps the process in here for good,
+    /// so per-tick work the caller does in its own run loop has to be passed
+    /// in: `bun run --hot` passes
+    /// [`Self::report_exception_in_hot_reloaded_module_if_needed`], because
+    /// the ticks here run reload tasks too.
+    pub fn on_before_exit_with(&mut self, mut after_tick: impl FnMut(&mut Self)) {
         // Node only emits 'beforeExit' on a natural drain; a fatal uncaught
         // exception that brought us here is an implicit process.exit(1). Arm
         // the hard-exit flag ourselves since we're skipping the dispatch that
@@ -1597,6 +1610,7 @@ impl VirtualMachine {
         loop {
             while self.is_event_loop_alive() {
                 self.tick();
+                after_tick(self);
                 self.auto_tick_active();
                 dispatch = true;
             }

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1477,7 +1477,9 @@ impl Run<'_> {
                     vm.report_exception_in_hot_reloaded_module_if_needed();
                     vm.auto_tick_active();
                 }
-                vm.on_before_exit();
+                vm.on_before_exit_with(
+                    VirtualMachine::report_exception_in_hot_reloaded_module_if_needed,
+                );
                 vm.report_exception_in_hot_reloaded_module_if_needed();
                 // SAFETY: `event_loop` is a self-pointer into this VM; uniquely
                 // accessed here. Watcher arm keeps the process alive across

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -624,6 +624,94 @@ ${Buffer.alloc(counter * 2, " ").toString()}throw new Error('${counter}');`,
 );
 
 it(
+  "should report a reloaded module's error while a beforeExit listener keeps re-arming the event loop",
+  async () => {
+    const root = join(cwd, "hot-before-exit-keepalive.js");
+    // The keep-alive idiom: every 'beforeExit' schedules more work, so once the
+    // first one fires the process stays inside the beforeExit drain for good and
+    // every reload below lands there. The generations log to stderr, where --hot
+    // reports errors, so one stream shows the order of the listener's lines and
+    // the error report.
+    const gen1 = `console.error("gen1");
+if (!globalThis.armed) {
+  globalThis.armed = true;
+  process.on("beforeExit", () => {
+    console.error("beforeExit");
+    setTimeout(() => {}, 10);
+  });
+}
+`;
+    const gen2 = `console.error("gen2");\nthrow new Error("boom");\n`;
+    const gen3 = `console.error("gen3 fine");\n`;
+
+    let current = gen1;
+    writeFileSync(root, gen1);
+    await using runner = spawn({
+      cmd: [bunExe(), "--hot", "run", root],
+      env: bunEnv,
+      cwd,
+      stdout: "ignore",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+
+    let output = "";
+    let exited = false;
+    const waiters: Array<() => void> = [];
+    const notify = () => {
+      for (const wake of waiters.splice(0)) wake();
+    };
+    (async () => {
+      for await (const chunk of runner.stderr) {
+        output += new TextDecoder().decode(chunk);
+        notify();
+      }
+    })();
+    runner.exited.then(() => {
+      exited = true;
+      notify();
+    });
+    const waitFor = async (pred: () => boolean, what: string) => {
+      while (!pred()) {
+        if (exited) throw new Error(`--hot process exited before "${what}"\nstderr:\n${output}`);
+        await new Promise<void>(resolve => waiters.push(resolve));
+      }
+    };
+    const count = (haystack: string, needle: string) => haystack.split(needle).length - 1;
+    const beforeExitsSince = (marker: string) => {
+      const at = output.indexOf(marker);
+      return at === -1 ? 0 : count(output.slice(at), "beforeExit");
+    };
+    const save = (content: string) => writeHotFileAtomicSync(root, (current = content));
+    // In case the watcher coalesced or missed a save, re-save the current generation.
+    const resave = setInterval(() => save(current), 1000);
+
+    try {
+      // With the listener re-arming the loop, every dispatch after the first
+      // comes from inside the drain, so the reloads below are handled there.
+      await waitFor(
+        () => output.includes("gen1") && count(output, "beforeExit") >= 2,
+        "gen1 inside the beforeExit drain",
+      );
+
+      save(gen2);
+      // The error has to be reported as soon as the generation rejects, not
+      // once the drain ends (it never does here). If the drain keeps cycling
+      // past the rejected generation without reporting it, stop waiting.
+      await waitFor(() => output.includes("error: boom") || beforeExitsSince("gen2") >= 20, "gen2's error");
+      expect(output).toContain("error: boom");
+
+      // The unreported rejection would also have made every later reload defer forever.
+      save(gen3);
+      await waitFor(() => output.includes("gen3 fine"), "gen3 after the failed generation");
+    } finally {
+      clearInterval(resave);
+    }
+  },
+  timeout,
+);
+
+it(
   "should work with sourcemap loading",
   async () => {
     let bundleIn = join(cwd, "bundle_in.ts");


### PR DESCRIPTION
### Problem
- Under `bun --hot`, a program using the keep-alive idiom `process.on("beforeExit", () => setTimeout(...))` loses error reporting for reloads: when a saved generation throws at top level, nothing is printed, and every save after that one is ignored for the rest of the process (reproduced on 1.4.0 and main, probe below). The same saves work when the program is kept alive by a `setInterval` instead.
- With that idiom the process lives inside the drain loop of `VirtualMachine::on_before_exit` (src/jsc/VirtualMachine.rs): each `beforeExit` dispatch arms a timer, the timer drains, `beforeExit` is dispatched again, and the function never returns. The ticks in that loop do run the watcher's reload tasks, so the new generation is evaluated there.
- `report_exception_in_hot_reloaded_module_if_needed()` is what prints a reloaded generation's rejection (and runs a reload that `reload()` deferred). It was only called from the watcher arm of the run loop in `Run::start` (src/runtime/cli/run_command.rs), between that loop's own ticks and once after `on_before_exit()` returns. While `on_before_exit()` keeps draining, neither point is reached, so the rejection is never reported.
- `reload()` defers whenever the current generation rejected and has not been reported yet (`pending_internal_promise_reported_at != hot_reload_counter`, from #29740), and the deferred reload is retried by the same reporting function. After one unreported rejection every later reload defers and nothing retries it.

### Fix
- `on_before_exit()` now delegates to `on_before_exit_with(after_tick)`, which calls `after_tick` after every tick of the drain loop. The `--hot`/`--watch` run loop passes `report_exception_in_hot_reloaded_module_if_needed`; `on_before_exit()` itself passes a no-op, so `bun run` without a watcher, `bun test`, the REPL and workers are unchanged.
- Why this is the right shape: the drain inside `on_before_exit` is a continuation of the caller's run loop (same `tick(); auto_tick_active();` turn), and the run command already polls after each of its own ticks. The poll is passed in by the run command rather than keyed on the watcher inside `on_before_exit` because the state it reads (`pending_internal_promise_reported_at`, the deferred reload, re-watching the entry file) is only maintained by the run command: `bun test --watch` installs the same watcher and sets the same `hot_reload` field, but reports a rejected test file itself and leaves `reported_at` untouched, so the poll would report that file again if it ran there (today it would only be spared by `bun test` returning before its own `on_before_exit()` call for such a file).
- The `beforeExit` semantics are untouched: the dispatch, the re-dispatch-only-after-work rule and both `unhandled_error_counter` guards are the same code, with one extra call in the loop body. When the poll reports an error the counter becomes nonzero, so the drain stops and no further `beforeExit` is dispatched for the failed generation, which is what already happens when a generation fails outside the drain.
- Test: `test/cli/hot/hot.test.ts`, "should report a reloaded module's error while a beforeExit listener keeps re-arming the event loop". Generation 1 installs the idiom and the test waits for the second `beforeExit` line (only dispatched from inside the drain); generation 2 throws and the test expects `error: boom`; generation 3 must then load. Everything the generations print goes to stderr, where the error is reported too, so the `beforeExit` lines after `gen2` double as the bound for the unfixed case: the test stops waiting once the drain has cycled 20 more times without a report, instead of running into the timeout.
  - Without the `src/` change (release 1.4.0, and a debug build with `src/` stashed): fails in under a second with the output `gen1, beforeExit x2, gen2, beforeExit x20` and no error. With it: passes (five runs, 0.6 to 0.8s on the debug build; the error is reported before any further `beforeExit` line).
- Also run on the debug build: the rest of `test/cli/hot/hot.test.ts`, `test/cli/hot/watch.test.ts`, the `process.onBeforeExit` block of `test/js/node/process/process.test.js`, the node `test-process-beforeexit*`, `test-beforeexit-event-exit`, `test-process-exit-from-before-exit`, `test-timers-unrefed-in-beforeexit` and `test-worker-beforeexit-throw-exit` / `test-worker-ref` / `test-worker-voluntarily-exit-*` files, the `-e` and exit tests of `test/js/bun/repl/repl.test.ts`, and the `process.on('exit')` block of `test/cli/test/bun-test.test.ts`. `cargo fmt --all -- --check` is clean.
- Nearby open PRs, none of which add this poll: #38206 and #34657 change what happens to `unhandled_error_counter` after an error is reported (with #38206 the drain keeps going after the report, which the test allows); #38613 changes when `reload()` defers on a pending generation; #34645 adds termination checks to the same drain loop for workers and will need a one-line rebase onto `on_before_exit_with` (or the other way round).

### Background
- `--hot` keeps one process and one `process` object across reloads: on a file change the watcher thread posts a reload task to the event loop, and running it (`VirtualMachine::reload`) clears the module registry and re-evaluates the entry point. Listeners registered by an earlier generation, such as the `beforeExit` listener here, stay installed.
- `pending_internal_promise` is the promise for the entry point's evaluation in the current generation. The initial load waits for it and reports a rejection directly; a reload does not wait, which is why the run loop polls `report_exception_in_hot_reloaded_module_if_needed()` after every tick. The function prints the rejection once per generation, keyed on `hot_reload_counter`, then retries a deferred reload, then re-adds the entry file to the watcher.
- `beforeExit`: node emits it when the event loop drains; if a listener schedules more work, the loop runs again and `beforeExit` is emitted again when it drains. `on_before_exit` implements this as dispatch, drain, re-dispatch if the drain did any work. A listener that always schedules work therefore keeps the drain going indefinitely; under `--hot` this is the process's steady state.

<details>
<summary>Probe on the released build (1.4.0, linux x64)</summary>

```
$ printf 'console.log("gen1");\nprocess.on("beforeExit", () => setTimeout(() => {}, 20));\n' > app.ts
$ bun --hot --no-clear-screen app.ts &
$ sleep 1; printf 'console.log("gen2");\nthrow new Error("boom");\n' > app.ts
$ sleep 1; printf 'console.log("gen3 fine");\n' > app.ts; sleep 1
gen1
gen2
# nothing else; the process is still alive, and gen3 never loads.

# Control, same sequence with `setInterval(() => {}, 1e6)` in place of the listener:
gen1
gen2
1 | console.log("gen2");
2 | throw new Error("boom");
              ^
error: boom
      at /tmp/hotrepro/app.ts:2:11
gen3 fine
```
</details>
