### PR TITLE
css: fold one-argument hypot() to the absolute value of its argument

### DIFF
--- a/src/css/values/calc.rs
+++ b/src/css/values/calc.rs
@@ -1094,20 +1094,19 @@ impl<V: CalcValue> Calc<V> {
 
         for arg in args.iter_mut() {
             let mut found: Option<Option<usize>> = None;
-            if let Calc::Value(val) = &*arg {
-                for (idx, b) in reduced.iter().enumerate() {
-                    if let Calc::Value(v) = b {
-                        let result = protocol::PartialCmp::partial_cmp(&**val, &**v);
-                        if result.is_some() {
-                            if result == Some(order) {
-                                found = Some(Some(idx));
-                                break;
-                            } else {
-                                found = Some(None);
-                                break;
-                            }
-                        }
+            for (idx, b) in reduced.iter().enumerate() {
+                let result = match (&*arg, b) {
+                    (Calc::Value(val), Calc::Value(v)) => {
+                        protocol::PartialCmp::partial_cmp(&**val, &**v)
                     }
+                    (Calc::Number(val), Calc::Number(v)) => {
+                        protocol::PartialCmp::partial_cmp(val, v)
+                    }
+                    _ => None,
+                };
+                if let Some(result) = result {
+                    found = Some((result == order).then_some(idx));
+                    break;
                 }
             }
 
@@ -1771,10 +1770,10 @@ impl CalcValue for Percentage {
     fn into_calc(self) -> Calc<Self> {
         Calc::Value(Box::new(self))
     }
-    fn from_calc(c: Calc<Self>, _input: &mut css::Parser) -> CssResult<Self> {
+    fn from_calc(c: Calc<Self>, input: &mut css::Parser) -> CssResult<Self> {
         match c {
             Calc::Value(v) => Ok(*v),
-            _ => Ok(Percentage { v: f32::NAN }),
+            _ => Err(input.new_custom_error(css::ParserError::invalid_value)),
         }
     }
     #[inline]

--- a/src/css/values/calc.rs
+++ b/src/css/values/calc.rs
@@ -510,8 +510,8 @@ impl<V: CalcValue> Calc<V> {
             CalcUnit::Sqrt => Self::parse_numeric_fn(input, NumericFnOp::Sqrt, ctx, parse_ident),
             CalcUnit::Exp => Self::parse_numeric_fn(input, NumericFnOp::Exp, ctx, parse_ident),
             CalcUnit::Hypot => input.parse_nested_block(|i| {
-                let mut args = i.parse_comma_separated(|i| Self::parse_sum(i, ctx, parse_ident))?;
-                let val = Self::parse_hypot(&mut args)?;
+                let args = i.parse_comma_separated(|i| Self::parse_sum(i, ctx, parse_ident))?;
+                let val = Self::parse_hypot(&args)?;
                 if let Some(v) = val {
                     return Ok(v);
                 }
@@ -918,10 +918,10 @@ impl<V: CalcValue> Calc<V> {
         Ok(val)
     }
 
-    pub(crate) fn parse_hypot(args: &mut [Self]) -> CssResult<Option<Self>> {
+    pub(crate) fn parse_hypot(args: &[Self]) -> CssResult<Option<Self>> {
         if args.len() == 1 {
-            let v = core::mem::replace(&mut args[0], Calc::Number(0.0));
-            return Ok(Some(v));
+            // hypot(A) is sqrt(A * A), i.e. abs(A): it folds exactly when abs() would.
+            return Ok(Self::apply_map(&args[0], absf));
         }
 
         if args.len() == 2 {

--- a/src/css/values/color.rs
+++ b/src/css/values/color.rs
@@ -2127,9 +2127,7 @@ impl RelativeComponentParser {
             return Ok(NumberOrPercentage::Percentage { unit_value: value });
         }
 
-        // A channel keyword is a <number>, so `calc(r * 50%)` is a <percentage>.
-        // Wrapping it in a Percentage here would make that a percentage times a
-        // percentage, which calc() rejects.
+        // The keyword is a <number>: `r * 50%` is a number times a percentage.
         if let Ok(value) = input.try_parse(|i| {
             match Calc::<Percentage>::parse_with(i, this, |ctx, ident| {
                 let v = ctx.get_ident(ident, allowed)?;

--- a/src/css/values/color.rs
+++ b/src/css/values/color.rs
@@ -2127,13 +2127,13 @@ impl RelativeComponentParser {
             return Ok(NumberOrPercentage::Percentage { unit_value: value });
         }
 
+        // A channel keyword is a <number>, so `calc(r * 50%)` is a <percentage>.
+        // Wrapping it in a Percentage here would make that a percentage times a
+        // percentage, which calc() rejects.
         if let Ok(value) = input.try_parse(|i| {
             match Calc::<Percentage>::parse_with(i, this, |ctx, ident| {
                 let v = ctx.get_ident(ident, allowed)?;
-                // value variant is a *Percentage
-                // but we immediately dereference it and discard the pointer
-                // so using a field on this closure struct instead of making a gratuitous allocation
-                Some(Calc::Value(Box::new(Percentage { v })))
+                Some(Calc::Number(v))
             }) {
                 Ok(Calc::Value(v)) => Ok(*v),
                 _ => Err(i.new_custom_error(css::ParserError::invalid_value)),

--- a/test/js/bun/css/color.test.ts
+++ b/test/js/bun/css/color.test.ts
@@ -551,8 +551,9 @@ describe("css string output parses back to the same color", () => {
 });
 
 // https://drafts.csswg.org/css-color-5/#relative-colors
-// Inside calc() a channel keyword is a <number>, so multiplying it by a
-// <percentage> gives a <percentage>, while adding one to it is a type error.
+// Inside a math function a channel keyword is a <number>, so multiplying it by
+// a <percentage> gives a <percentage>, while adding or comparing it to one is a
+// type error.
 describe("relative color calc() with percentages", () => {
   const origin = "color(srgb .8 .4 .2)";
 
@@ -567,6 +568,9 @@ describe("relative color calc() with percentages", () => {
     ["calc((r + g) * 50%)", ".6"],
     ["min(r * 50%, 30%)", ".3"],
     ["max(r * 50%, 30%)", ".4"],
+    ["round(r * 100%, 30%)", ".9"],
+    ["mod(r * 100%, 30%)", ".2"],
+    ["hypot(r * 100%, 30%)", ".8544"],
   ])("%s is a percentage of the channel", (expr, expected) => {
     expect(color(`color(from ${origin} srgb ${expr} g b)`, "css")).toBe(`color(srgb ${expected} .4 .2)`);
   });
@@ -623,13 +627,22 @@ describe("relative color calc() with percentages", () => {
     expect(color("lch(from lch(50% 20 30) l c min(h, 10))", "css")).toBe("lch(50% 20 10)");
   });
 
+  // A bare keyword is a <number>, and a <number> only combines with a <percentage>
+  // through * and /. lightningcss leaves every one of these unparsed as well.
   test.each([
     "color(from color(srgb .8 .4 .2) srgb calc(r + 50%) g b)",
     "color(from color(srgb .8 .4 .2) srgb calc(50% + r) g b)",
     "color(from color(srgb .8 .4 .2) srgb calc(r * 50% + .1) g b)",
     "color(from color(srgb .8 .4 .2) srgb calc(r * 50% - g) g b)",
+    "color(from color(srgb .8 .4 .2) srgb min(r, 50%) g b)",
+    "color(from color(srgb .8 .4 .2) srgb max(50%, r) g b)",
+    "color(from color(srgb .8 .4 .2) srgb round(r, 30%) g b)",
+    "color(from color(srgb .8 .4 .2) srgb hypot(r, 30%) g b)",
     "color(from color(srgb .8 .4 .2 / .5) srgb r g b / calc(alpha + 10%))",
+    "color(from color(srgb .8 .4 .2 / .5) srgb r g b / max(alpha, 30%))",
     "rgb(from rgb(200 100 50 / .5) r g b / calc(alpha + 10%))",
+    "rgb(from rgb(200 100 50 / .5) r g b / calc(alpha - 20%))",
+    "rgb(from rgb(200 100 50 / .5) r g b / min(alpha, 30%))",
     // The same type error outside relative color syntax (not a `none` channel).
     "color(srgb calc(1 + 50%) 0 0)",
     "color(srgb calc(50% + 1) 0 0)",

--- a/test/js/bun/css/color.test.ts
+++ b/test/js/bun/css/color.test.ts
@@ -550,6 +550,95 @@ describe("css string output parses back to the same color", () => {
   });
 });
 
+// https://drafts.csswg.org/css-color-5/#relative-colors
+// Inside calc() a channel keyword is a <number>, so multiplying it by a
+// <percentage> gives a <percentage>, while adding one to it is a type error.
+describe("relative color calc() with percentages", () => {
+  const origin = "color(srgb .8 .4 .2)";
+
+  test.each([
+    ["calc(r * 50%)", ".4"],
+    ["calc(50% * r)", ".4"],
+    ["calc(r * -50%)", "-.4"],
+    ["calc(r * 50% + 10%)", ".5"],
+    ["calc(50% - r * 25%)", ".3"],
+    ["calc(r / 2 * 100%)", ".4"],
+    ["calc(r * g * 50%)", ".16"],
+    ["calc((r + g) * 50%)", ".6"],
+    ["min(r * 50%, 30%)", ".3"],
+    ["max(r * 50%, 30%)", ".4"],
+  ])("%s is a percentage of the channel", (expr, expected) => {
+    expect(color(`color(from ${origin} srgb ${expr} g b)`, "css")).toBe(`color(srgb ${expected} .4 .2)`);
+  });
+
+  const spaces: [space: string, channels: string, printed?: string][] = [
+    ["srgb", "g b"],
+    ["srgb-linear", "g b"],
+    ["display-p3", "g b"],
+    ["prophoto-rgb", "g b"],
+    ["rec2020", "g b"],
+    ["xyz-d50", "y z"],
+    ["xyz-d65", "y z", "xyz"],
+    ["xyz", "y z"],
+  ];
+  test.each(spaces)("color(from ... %s calc(<channel> * <percentage>))", (space, channels, printed = space) => {
+    const [b, c] = channels.split(" ");
+    expect(color(`color(from color(${space} .8 .4 .2) ${space} ${b} calc(${b} * 50%) calc(50% * ${c}))`, "css")).toBe(
+      `color(${printed} .4 .2 .1)`,
+    );
+  });
+
+  test.each([
+    ["color(from color(srgb .8 .4 .2 / .5) srgb r g b / calc(alpha * 50%))", "color(srgb .8 .4 .2 / .25)"],
+    ["rgb(from rgb(200 100 50 / .5) r g b / calc(alpha * 50%))", "#c8643240"],
+    ["hsl(from hsl(30 50% 50% / .5) h s l / calc(50% * alpha))", "#bf804040"],
+    ["hwb(from hwb(30 20% 40% / .5) h w b / calc(alpha * 50%))", "#99663340"],
+    ["lab(from lab(50% 20 30 / .5) l a b / calc(alpha * 50%))", "lab(50% 20 30 / .25)"],
+    ["lch(from lch(50% 20 30 / .5) l c h / calc(alpha * 50%))", "lch(50% 20 30 / .25)"],
+    ["oklab(from oklab(50% .1 .1 / .5) l a b / calc(alpha * 50%))", "oklab(50% .1 .1 / .25)"],
+    ["oklch(from oklch(50% .1 30 / .5) l c h / calc(alpha * 50%))", "oklch(50% .1 30 / .25)"],
+  ])("%s", (input, expected) => {
+    expect(color(input, "css")).toBe(expected);
+  });
+
+  // min()/max() fold channel keywords whether or not a literal number is mixed in.
+  test.each([
+    ["min(r, g)", ".4"],
+    ["max(r, g)", ".8"],
+    ["min(r, g, b)", ".2"],
+    ["min(r, .5)", ".5"],
+    ["min(.5, r)", ".5"],
+    ["max(r, .5)", ".8"],
+    ["min(r, g, .3)", ".3"],
+    ["max(g, .3, b)", ".4"],
+    ["calc(r * .5)", ".4"],
+    ["round(r, .5)", "1"],
+  ])("%s folds to a number", (expr, expected) => {
+    expect(color(`color(from ${origin} srgb ${expr} g b)`, "css")).toBe(`color(srgb ${expected} .4 .2)`);
+  });
+
+  test("min()/max() fold in the number and hue channels too", () => {
+    expect(color("lab(from lab(50% 20 30) l max(a, b) b)", "css")).toBe("lab(50% 30 30)");
+    expect(color("lab(from lab(50% 20 30) l min(a, 10) b)", "css")).toBe("lab(50% 10 30)");
+    expect(color("lch(from lch(50% 20 30) l c min(h, 10))", "css")).toBe("lch(50% 20 10)");
+  });
+
+  test.each([
+    "color(from color(srgb .8 .4 .2) srgb calc(r + 50%) g b)",
+    "color(from color(srgb .8 .4 .2) srgb calc(50% + r) g b)",
+    "color(from color(srgb .8 .4 .2) srgb calc(r * 50% + .1) g b)",
+    "color(from color(srgb .8 .4 .2) srgb calc(r * 50% - g) g b)",
+    "color(from color(srgb .8 .4 .2 / .5) srgb r g b / calc(alpha + 10%))",
+    "rgb(from rgb(200 100 50 / .5) r g b / calc(alpha + 10%))",
+    // The same type error outside relative color syntax (not a `none` channel).
+    "color(srgb calc(1 + 50%) 0 0)",
+    "color(srgb calc(50% + 1) 0 0)",
+    "hsl(120 calc(50% + 1) 40%)",
+  ])("%s mixes a number and a percentage and does not parse", input => {
+    expect(color(input, "css")).toBeNull();
+  });
+});
+
 describe("input forms", () => {
   test.each([
     ["a named color", "red"],

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -180,6 +180,81 @@ describe("css tests", () => {
     minify_test(`a { opacity: calc(NaN) }`, `a{opacity:0}`);
     minify_test(`a { rotate: calc(NaN * 1deg) }`, `a{rotate:0deg}`);
     minify_test(`a { transition-duration: calc(NaN * 1s) }`, `a{transition-duration:0s}`);
+
+    // min()/max() of plain numbers fold like min()/max() of dimensions do.
+    minify_test(`a { line-height: min(1.5, 1.2) }`, `a{line-height:1.2}`);
+    minify_test(`a { line-height: max(1.2, 2, 1.5) }`, `a{line-height:2}`);
+    minify_test(`a { line-height: calc(min(1.5, 1.2) * 2) }`, `a{line-height:2.4}`);
+    minify_test(`a { width: calc(min(1.5, 1.2) * 10px) }`, `a{width:12px}`);
+    minify_test(`a { opacity: min(.5, .7) }`, `a{opacity:.5}`);
+    minify_test(`a { opacity: max(50%, 70%) }`, `a{opacity:.7}`);
+    minify_test(`a { opacity: min(NaN, .5) }`, `a{opacity:min(NaN,.5)}`);
+    minify_test(`a { width: min(10px, 1.5) }`, `a{width:min(10px,1.5)}`);
+
+    // A <number> and a <percentage> cannot be added: the declaration is invalid and
+    // is left as written, not evaluated to NaN and serialized as 0.
+    minify_test(`a { opacity: calc(50% + 1) }`, `a{opacity:calc(50% + 1)}`);
+    minify_test(`a { opacity: calc(1 - 50%) }`, `a{opacity:calc(1 - 50%)}`);
+    minify_test(`a { opacity: calc(50% + 25%) }`, `a{opacity:.75}`);
+    minify_test(`a { opacity: calc(50% * 1.5) }`, `a{opacity:.75}`);
+  });
+
+  describe("relative color calc() with percentages", () => {
+    // https://drafts.csswg.org/css-color-5/#relative-colors: a channel keyword is
+    // a <number>, so `calc(r * 50%)` is a <percentage> and `calc(r + 50%)` is invalid.
+    minify_test(
+      ".foo { color: color(from color(srgb .8 .4 .2) srgb calc(r * 50%) calc(50% * g) b) }",
+      ".foo{color:color(srgb .4 .2 .2)}",
+    );
+    minify_test(
+      ".foo { color: color(from color(display-p3 .8 .4 .2) display-p3 r calc(g * 50% + 10%) calc(50% - b * 50%)) }",
+      ".foo{color:color(display-p3 .8 .3 .4)}",
+    );
+    minify_test(
+      ".foo { color: color(from color(srgb .8 .4 .2) srgb min(r * 50%, 30%) max(g * 50%, 30%) b) }",
+      ".foo{color:color(srgb .3 .3 .2)}",
+    );
+    minify_test(
+      ".foo { color: color(from color(srgb .8 .4 .2 / .5) srgb r g b / calc(alpha * 50%)) }",
+      ".foo{color:color(srgb .8 .4 .2/.25)}",
+    );
+    minify_test(".foo { color: rgb(from rgb(200 100 50 / .5) r g b / calc(alpha * 50%)) }", ".foo{color:#c8643240}");
+    // Not `rgb(255 0 0/calc(alpha*50%))`, which no browser accepts.
+    minify_test(".foo { color: rgb(from red r g b / calc(alpha * 50%)) }", ".foo{color:#ff000080}");
+    minify_test(".foo { color: hsl(from hsl(30 50% 50% / .5) h s l / calc(50% * alpha)) }", ".foo{color:#bf804040}");
+    minify_test(
+      ".foo { color: oklch(from oklch(50% .1 30 / .5) l c h / calc(alpha * 50%)) }",
+      ".foo{color:oklch(50% .1 30/.25)}",
+    );
+
+    // min()/max() fold over channel keywords, with or without a literal number
+    // among the arguments.
+    minify_test(
+      ".foo { color: color(from color(srgb .8 .4 .2) srgb min(r, g) max(g, b) b) }",
+      ".foo{color:color(srgb .4 .4 .2)}",
+    );
+    minify_test(
+      ".foo { color: color(from color(srgb .8 .4 .2) srgb min(r, .5) max(g, .5) b) }",
+      ".foo{color:color(srgb .5 .5 .2)}",
+    );
+    minify_test(".foo { color: lab(from lab(50% 20 30) l max(a, b) min(b, 10)) }", ".foo{color:lab(50% 30 10)}");
+
+    minify_test(
+      ".foo { color: color(from red srgb calc(r + 50%) g b) }",
+      ".foo{color:color(from red srgb calc(r + 50%)g b)}",
+    );
+    minify_test(
+      ".foo { color: color(from red srgb r g b / calc(alpha + 10%)) }",
+      ".foo{color:color(from red srgb r g b/calc(alpha + 10%))}",
+    );
+    // rgb()/hsl() with an alpha that does not parse resolve the channels and keep
+    // the alpha as written (the `/ var(--alpha)` path); same output as lightningcss.
+    // The point is that the invalid alpha is not folded into `red`.
+    minify_test(
+      ".foo { color: rgb(from red r g b / calc(alpha + 10%)) }",
+      ".foo{color:rgb(255 0 0/calc(alpha + 10%))}",
+    );
+    minify_test(".foo { color: color(srgb calc(1 + 50%) 0 0) }", ".foo{color:color(srgb calc(1 + 50%)0 0)}");
   });
   describe("calc stack overflow", () => {
     // https://github.com/oven-sh/bun/issues/20128

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -277,6 +277,58 @@ describe("css tests", () => {
     ); // ideally -400% - 8vh + 3ic
     minify_test(`a { top: calc(100% - 1 * 2 - 8 * 2); }`, `a{top:calc(100% - 2 - 16)}`); // ideally 100% - 18
   });
+  describe("hypot() with one argument", () => {
+    // hypot(A) is sqrt(A * A), i.e. abs(A) (CSS Values 4), so it folds exactly like
+    // abs(A) does. It used to be returned as its argument, unchanged.
+    minify_test(`a { margin-left: hypot(-3px) }`, `a{margin-left:3px}`);
+    minify_test(`a { margin-left: hypot(3px) }`, `a{margin-left:3px}`);
+    minify_test(`a { margin-left: hypot(calc(-3px)) }`, `a{margin-left:3px}`);
+    minify_test(`a { margin-left: hypot(-1in) }`, `a{margin-left:1in}`);
+    minify_test(`a { border-spacing: hypot(-3px) }`, `a{border-spacing:3px}`);
+    minify_test(`a { rotate: hypot(-90deg) }`, `a{rotate:90deg}`);
+    minify_test(
+      `a { background: conic-gradient(red hypot(-0.25turn), blue) }`,
+      `a{background:conic-gradient(red .25turn,#00f)}`,
+    );
+    minify_test(`a { transition-delay: hypot(-2s) }`, `a{transition-delay:2s}`);
+    minify_test(`a { line-height: hypot(-3) }`, `a{line-height:3}`);
+    minify_test(`a { opacity: hypot(-0.5) }`, `a{opacity:.5}`);
+    minify_test(`a { color: rgb(255 0 0 / hypot(-0.5)) }`, `a{color:#ff000080}`);
+    // The folded value takes part in the calculation around it.
+    minify_test(`a { margin-left: calc(hypot(-3px) + 1px) }`, `a{margin-left:4px}`);
+    minify_test(`a { width: calc(100% - hypot(-3px)) }`, `a{width:calc(100% - 3px)}`);
+    minify_test(`a { opacity: calc(1 - hypot(-0.25)) }`, `a{opacity:.75}`);
+    // Two arguments still fold the way they did before.
+    minify_test(`a { margin-left: hypot(-3px, 4px) }`, `a{margin-left:5px}`);
+
+    // Whatever abs() leaves unevaluated (a percentage, a sum, a function that did not
+    // fold), hypot() leaves unevaluated too, and it stays wrapped in hypot(): the
+    // argument on its own would have the wrong sign, and a bare sum or product
+    // outside of a math function is not valid CSS.
+    minify_test(`a { margin-left: hypot(-30%) }`, `a{margin-left:hypot(-30%)}`);
+    minify_test(`a { margin-left: abs(-30%) }`, `a{margin-left:abs(-30%)}`);
+    minify_test(`a { margin-left: hypot(1px + 10%) }`, `a{margin-left:hypot(1px + 10%)}`);
+    minify_test(`a { margin-left: abs(1px + 10%) }`, `a{margin-left:abs(1px + 10%)}`);
+    minify_test(`a { margin-left: hypot(2 * min(1px, 1em)) }`, `a{margin-left:hypot(2*min(1px,1em))}`);
+    minify_test(`a { margin-left: hypot(1px + min(1px, 1em)) }`, `a{margin-left:hypot(1px + min(1px,1em))}`);
+    minify_test(`a { margin-left: hypot(min(-1px, -1em)) }`, `a{margin-left:hypot(min(-1px,-1em))}`);
+    minify_test(`a { border-spacing: hypot(min(-1px, -1em)) }`, `a{border-spacing:hypot(min(-1px,-1em))}`);
+    minify_test(
+      `a { background: conic-gradient(red hypot(-30%), blue) }`,
+      `a{background:conic-gradient(red hypot(-30%),#00f)}`,
+    );
+    minify_test(`a { margin-left: calc(1px + hypot(1px + 10%)) }`, `a{margin-left:calc(1px + hypot(1px + 10%))}`);
+    minify_test(`a { width: calc(100% - hypot(1px + 10%)) }`, `a{width:calc(100% + -1*hypot(1px + 10%))}`);
+    // A bare <percentage> (opacity, an alpha channel) is not folded by abs() either,
+    // so hypot() of one is kept as written, whether on its own or inside a sum. The
+    // sums used to be evaluated as if hypot() were not there (.6 and #f009).
+    minify_test(`a { opacity: hypot(-50%) }`, `a{opacity:hypot(-50%)}`);
+    minify_test(`a { opacity: hypot(50%) }`, `a{opacity:hypot(50%)}`);
+    minify_test(`a { opacity: abs(50%) }`, `a{opacity:abs(50%)}`);
+    minify_test(`a { opacity: calc(10% + hypot(50%)) }`, `a{opacity:calc(10% + hypot(50%))}`);
+    minify_test(`a { color: rgb(255 0 0 / hypot(50%)) }`, `a{color:rgb(255 0 0/hypot(50%))}`);
+    minify_test(`a { color: rgb(255 0 0 / calc(hypot(50%) + 10%)) }`, `a{color:rgb(255 0 0/calc(hypot(50%) + 10%))}`);
+  });
   describe("border_spacing", () => {
     minify_test(
       `

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -215,6 +215,10 @@ describe("css tests", () => {
       ".foo{color:color(srgb .3 .3 .2)}",
     );
     minify_test(
+      ".foo { color: color(from color(srgb .8 .4 .2) srgb round(r * 100%, 30%) g b) }",
+      ".foo{color:color(srgb .9 .4 .2)}",
+    );
+    minify_test(
       ".foo { color: color(from color(srgb .8 .4 .2 / .5) srgb r g b / calc(alpha * 50%)) }",
       ".foo{color:color(srgb .8 .4 .2/.25)}",
     );
@@ -239,9 +243,15 @@ describe("css tests", () => {
     );
     minify_test(".foo { color: lab(from lab(50% 20 30) l max(a, b) min(b, 10)) }", ".foo{color:lab(50% 30 10)}");
 
+    // A bare keyword is a <number>, which only combines with a <percentage>
+    // through * and /; these are invalid and stay as written, as in lightningcss.
     minify_test(
       ".foo { color: color(from red srgb calc(r + 50%) g b) }",
       ".foo{color:color(from red srgb calc(r + 50%)g b)}",
+    );
+    minify_test(
+      ".foo { color: color(from red srgb min(r, 50%) g b) }",
+      ".foo{color:color(from red srgb min(r,50%)g b)}",
     );
     minify_test(
       ".foo { color: color(from red srgb r g b / calc(alpha + 10%)) }",
@@ -249,11 +259,12 @@ describe("css tests", () => {
     );
     // rgb()/hsl() with an alpha that does not parse resolve the channels and keep
     // the alpha as written (the `/ var(--alpha)` path); same output as lightningcss.
-    // The point is that the invalid alpha is not folded into `red`.
+    // The point is that the invalid alpha is not folded into `red` / `#ff00004d`.
     minify_test(
       ".foo { color: rgb(from red r g b / calc(alpha + 10%)) }",
       ".foo{color:rgb(255 0 0/calc(alpha + 10%))}",
     );
+    minify_test(".foo { color: rgb(from red r g b / min(alpha, 30%)) }", ".foo{color:rgb(255 0 0/min(alpha,30%))}");
     minify_test(".foo { color: color(srgb calc(1 + 50%) 0 0) }", ".foo{color:color(srgb calc(1 + 50%)0 0)}");
   });
   describe("calc stack overflow", () => {


### PR DESCRIPTION
### Problem
- `hypot()` with a single argument minifies to that argument unchanged. `margin-left: hypot(-3px)` becomes `-3px`, `rotate: hypot(-90deg)` becomes `-90deg`, `transition-delay: hypot(-2s)` becomes `-2s`, `line-height: hypot(-3)` becomes `-3`. CSS Values 4 defines `hypot(A)` as the square root of the sum of the squares of its arguments, so `hypot(A)` is `abs(A)` and all of these should lose the sign. The wrong value also flows into surrounding arithmetic: `calc(100% - hypot(-3px))` becomes `calc(100% + 3px)`.
- When the argument is not a plain value, the function itself disappears: `hypot(1px + 10%)` becomes the bare `1px + 10%` and `hypot(2 * min(1px, 1em))` becomes `2*min(1px,1em)`, neither of which is valid CSS outside a math function. `hypot(min(-1px, -1em))` becomes `min(-1px,-1em)`, which has the wrong sign.
- Cause: `Calc::parse_hypot` (`src/css/values/calc.rs:921`) special-cases `args.len() == 1` by moving the argument out and returning it as parsed. Nothing applies the absolute value, and because a value is returned the caller never reaches its `MathFunction::Hypot(args)` fallback. lightningcss has the same shortcut, so upstream output is not the reference here; the spec is.
- Reproduced on bun 1.4.0 and on main with `bun build --minify` (table below).

### Fix
- The one-argument branch returns `Calc::apply_map(&args[0], absf)`, which is the same step the `abs()` arm directly below the `hypot()` arm already uses. `parse_hypot` no longer needs `&mut`, so it takes `&[Self]`.
- A value folds to its absolute value (`hypot(-3px)` is `3px`, `hypot(-1in)` is `1in`, `hypot(-90deg)` is `90deg`, `hypot(-2s)` is `2s`, `hypot(-3)` is `3`, `calc(100% - hypot(-3px))` is `calc(100% - 3px)`).
- When `apply_map` returns `None` (a percentage, a sum, a product, a function that did not evaluate) the existing caller fallback keeps `hypot(...)` in the output as written, so `hypot(1px + 10%)`, `hypot(2*min(1px,1em))`, `hypot(min(-1px,-1em))` and `hypot(-30%)` now print exactly that. This is byte for byte what `abs()` of the same arguments prints today, and the tests pin a few of the `abs()` forms next to the `hypot()` ones.
- Why this is right: `hypot(A)` and `abs(A)` are the same function of one argument, so giving them the same folding rule makes `hypot()` correct in every case where `abs()` is, and leaves it unevaluated (rather than wrong) in exactly the cases where `abs()` is left unevaluated. Keeping the function as `hypot()` rather than rewriting it to `abs()` means the output only ever uses functions the input used, which is what the rest of this file does for everything it cannot fold (and what `is_compatible` reports on).
- Stacked on #38513 (this PR's base is that branch): `hypot(50%)` in a bare `<percentage>` context is now a `MathFunction` instead of a value, and on main `Percentage::from_calc` turns any non-value operand of a sum into NaN, which prints as `0`. Without #38513 this change would therefore turn the currently correct `opacity: calc(10% + hypot(50%))` (`.6`) into `opacity:0`, the same thing `opacity: calc(10% + abs(50%))` prints on 1.4.0 today. With #38513 the declaration is kept as written, and the last block of tests pins that for `opacity` and an `rgb()` alpha. Not duplicating that one-line change here; the PR retargets to main once #38513 merges.
- #38501 (three or more arguments) rewrites the rest of `parse_hypot`; the two changes touch adjacent lines and whichever lands second is a one-line rebase.
- Verified with `bun bd test test/js/bun/css/css.test.ts` (new `hypot() with one argument` block, 32 cases covering every `Calc<V>` instantiation: length, length-percentage, angle, angle-percentage in a `conic-gradient()` stop, time, number, bare percentage in `opacity` and in an `rgb()` alpha, plus `hypot()` nested in `calc()` and the unchanged two-argument form). 27 of the 32 fail on the released 1.4.0 (`USE_SYSTEM_BUN=1`); the other 5 are the `hypot(3px)`, two-argument and `abs()` control cases.
- Also ran `test/js/bun/css/css.test.ts` and `color.test.ts` in full with the change (2253 pass, 0 fail).

### Background
- `Calc<V>` is the parsed form of a math function over values of type `V` (a length, an angle, a bare percentage, ...). `Calc::Value` / `Calc::Number` are things that were fully evaluated at parse time; `Calc::Sum` / `Calc::Product` are partially evaluated trees; `Calc::Function` is a math function kept for the output because it could not be evaluated.
- `Calc::apply_map(arg, f)` applies a unary `f32 -> f32` to a `Calc::Number` or, through the value type's `try_map`, to a `Calc::Value`, and returns `None` for anything else. `Percentage::try_map` always returns `None` because a percentage's sign is only known once it is resolved against something; this is why `abs(-30%)` (and now `hypot(-30%)`) is kept as written.
- The serializer prints a `Calc::Sum` as `a + b` with no wrapper, relying on whatever owns it at the top of a property value to be a `Calc::Function` (`calc(...)`, `min(...)`, ...). Returning a `Sum` straight out of a math function, as the old one-argument branch did, is how the bare `1px + 10%` got emitted.
- `Percentage::from_calc` is how a `calc()` sum in a bare `<percentage>` property (`opacity`, a color's alpha) converts a non-value operand back into a `Percentage`. On main it produces NaN for anything that is not a plain value; #38513 makes it a parse error, which keeps the declaration verbatim.

<details>
<summary>bun build --minify before (1.4.0 / main) and after this PR</summary>

```
input                                           before                      after
margin-left: hypot(-3px)                        -3px                        3px
margin-left: hypot(calc(-3px))                  -3px                        3px
border-spacing: hypot(-3px)                     -3px                        3px
rotate: hypot(-90deg)                           -90deg                      90deg
conic-gradient(red hypot(-0.25turn), blue)      red -.25turn                red .25turn
transition-delay: hypot(-2s)                    -2s                         2s
line-height: hypot(-3)                          -3                          3
opacity: hypot(-0.5)                            -.5                         .5
margin-left: calc(hypot(-3px) + 1px)            -2px                        4px
width: calc(100% - hypot(-3px))                 calc(100% + 3px)            calc(100% - 3px)
opacity: calc(1 - hypot(-0.25))                 1.25                        .75
margin-left: hypot(-30%)                        -30%                        hypot(-30%)
margin-left: hypot(1px + 10%)                   1px + 10%        (invalid)  hypot(1px + 10%)
margin-left: hypot(2 * min(1px, 1em))           2*min(1px,1em)   (invalid)  hypot(2*min(1px,1em))
margin-left: hypot(min(-1px, -1em))             min(-1px,-1em)              hypot(min(-1px,-1em))
margin-left: calc(1px + hypot(1px + 10%))       calc(2px + 10%)             calc(1px + hypot(1px + 10%))
width: calc(100% - hypot(1px + 10%))            calc(90% - 1px)             calc(100% + -1*hypot(1px + 10%))
opacity: hypot(-50%)                            -.5                         hypot(-50%)
opacity: calc(10% + hypot(50%))                 .6                          calc(10% + hypot(50%))   (0 without #38513)
rgb(255 0 0 / calc(hypot(50%) + 10%))           #f009                       rgb(255 0 0/calc(hypot(50%) + 10%))
margin-left: hypot(-3px, 4px)                   5px                         5px   (unchanged)
```

</details>
