### PR TITLE
test(css): build every css-fuzz generator input instead of mis-indexing the tables

### DIFF
--- a/test/js/bun/css/css-fuzz.test.ts
+++ b/test/js/bun/css/css-fuzz.test.ts
@@ -1,22 +1,27 @@
-import { expect, test } from "bun:test";
-import { isCI, isDebug } from "harness";
-
-interface InvalidFuzzOptions {
-  maxLength: number;
-  strategy: "syntax" | "structure" | "encoding" | "memory" | "all";
-  iterations: number;
-}
+import { describe, expect, test } from "bun:test";
+import { isASAN, isCI, isDebug } from "harness";
 
 const shutup = process.env.CSS_FUZZ_SHUTUP === "1";
 const log = shutup ? () => {} : console.log;
 
-// Collection of invalid CSS generation strategies
+// Virtual path of the fuzzed stylesheet, handed to Bun.build through `files` instead of being
+// written to disk. It has to be absolute: the bundler asserts that entry points are absolute.
+const entrypoint = "/css-fuzz/invalid.css";
+
+// Every generator returns the full list of inputs it contributes; the tables are flattened before
+// anything picks from them, so generators are free to contribute any number of inputs.
+//
+// Inputs are byte strings: each char is one byte of the stylesheet (see expectBuildToFinish). That is
+// what lets the encoding strategy feed the parser real invalid UTF-8 rather than the U+FFFD that
+// decoding it into a JS string would turn it into.
 const invalidGenerators = {
   // Syntax errors
   syntax: {
-    unclosedRules: () => `
+    unclosedRules: () => [
+      `
       .test { color: red
       .another { padding: 10px }`,
+    ],
     invalidSelectors: () => [
       "}{color:red}",
       "&*#@.class{color:red}",
@@ -36,7 +41,7 @@ const invalidGenerators = {
       ".test{color:red} /* unclosed",
       "/**//**//* .test{color:red}",
     ],
-  } as const,
+  },
 
   // Structural errors
   structure: {
@@ -47,57 +52,80 @@ const invalidGenerators = {
     ],
     malformedAtRules: () => ["@media ;", "@import url('test.css'", "@{color:red}", "@media screen and and {color:red}"],
     invalidImports: () => ["@import 'file' 'screen';", "@import url(;", "@import url('test.css') print"],
-  } as const,
+  },
 
   // Encoding and character issues
   encoding: {
+    // Overlong encodings of U+0000: the lead byte announces 2, 3 and 4 byte sequences.
     invalidUTF8: () => [
-      `.test{content:"${Buffer.from([0xc0, 0x80]).toString()}"}`,
-      `.test{content:"${Buffer.from([0xe0, 0x80, 0x80]).toString()}"}`,
-      `.test{content:"${Buffer.from([0xf0, 0x80, 0x80, 0x80]).toString()}"}`,
+      '.test{content:"\xc0\x80"}',
+      '.test{content:"\xe0\x80\x80"}',
+      '.test{content:"\xf0\x80\x80\x80"}',
     ],
-    nullBytes: () => [`.test{color:red${"\0"};}`, `.te${"\0"}st{color:red}`, `${"\0"}.test{color:red}`],
-    controlCharacters: () => {
-      const controls = Array.from({ length: 32 }, (_, i) => String.fromCharCode(i));
-      return controls.map(char => `.test{color:${char}red}`);
-    },
-  } as const,
+    nullBytes: () => [".test{color:red\0;}", ".te\0st{color:red}", "\0.test{color:red}"],
+    controlCharacters: () => Array.from({ length: 32 }, (_, i) => `.test{color:${String.fromCharCode(i)}red}`),
+  },
 
   // Memory and resource stress
   memory: {
-    deepNesting: (depth: number = 300) => {
-      let css = "";
-      for (let i = 0; i < depth; i++) {
-        css += "@media screen {";
-      }
-      css += ".test{color:red}";
-      for (let i = 0; i < depth; i++) {
-        css += "}";
-      }
-      return css;
-    },
-    longSelectors: (length: number = 100000) => {
-      const selector = ".test".repeat(length);
-      return `${selector}{color:red}`;
-    },
-    manyProperties: (count: number = 10000) => {
-      const properties = Array(count).fill("color:red;").join("\n");
-      return `.test{${properties}}`;
-    },
-  } as const,
-} as const;
+    deepNesting: () => ["@media screen {".repeat(300) + ".test{color:red}" + "}".repeat(300)],
+    longSelectors: () => [`${".test".repeat(100000)}{color:red}`],
+    manyProperties: () => [`.test{${Array(10000).fill("color:red;").join("\n")}}`],
+  },
+} satisfies Record<string, Record<string, () => string[]>>;
+
+type Strategy = keyof typeof invalidGenerators;
+
+// The memory inputs only run on plain release builds: the 300-deep @media input overflows the parser
+// thread's stack under ASAN, and the 500 KB selector takes over a second per build on a debug build.
+const strategies = (Object.keys(invalidGenerators) as Strategy[]).filter(
+  strategy => strategy !== "memory" || !(isDebug || isASAN),
+);
+
+function inputsOf(strategy: Strategy): { label: string; css: string }[] {
+  return Object.entries(invalidGenerators[strategy]).flatMap(([name, generate]) =>
+    generate().map((css, i) => ({ label: `${name}[${i}]`, css })),
+  );
+}
+
+function describeInput(css: string): string {
+  const limit = 100;
+  const shown = JSON.stringify(css.slice(0, limit)).replace(
+    /[\x7f-\xff]/g,
+    byte => `\\x${byte.charCodeAt(0).toString(16)}`,
+  );
+  return css.length > limit ? `${shown}... (${css.length} bytes)` : shown;
+}
+
+// The parser has to finish on every input, either with the one output a single entrypoint produces
+// or with a reported error. A crash takes the process down, and a JS exception escaping Bun.build
+// rejects even with `throw: false`; both fail the test.
+async function expectBuildToFinish(css: string): Promise<"built" | "rejected"> {
+  const result = await Bun.build({
+    entrypoints: [entrypoint],
+    // latin1 maps every char of the byte string to the byte it stands for.
+    files: { [entrypoint]: Buffer.from(css, "latin1") },
+    throw: false,
+  });
+  if (result.success) {
+    expect(result.outputs).toHaveLength(1);
+    return "built";
+  }
+  expect(result.logs).not.toBeEmpty();
+  return "rejected";
+}
 
 // Helper to randomly corrupt CSS
 function corruptCSS(css: string): string {
   const corruptions = [
-    (s: string) => (s + "").replace(/{/g, "}"),
-    (s: string) => (s + "").replace(/}/g, "{"),
-    (s: string) => (s + "").replace(/:/g, ";"),
-    (s: string) => (s + "").replace(/;/g, ":"),
-    (s: string) => (s + "").slice(Math.floor(Math.random() * (s + "").length)),
-    (s: string) => s + "" + "}}".repeat(Math.floor(Math.random() * 5)),
-    (s: string) => (s + "").split("").reverse().join(""),
-    (s: string) => (s + "").replace(/[a-z]/g, c => String.fromCharCode(97 + Math.floor(Math.random() * 26))),
+    (s: string) => s.replace(/{/g, "}"),
+    (s: string) => s.replace(/}/g, "{"),
+    (s: string) => s.replace(/:/g, ";"),
+    (s: string) => s.replace(/;/g, ":"),
+    (s: string) => s.slice(Math.floor(Math.random() * s.length)),
+    (s: string) => s + "}}".repeat(Math.floor(Math.random() * 5)),
+    (s: string) => s.split("").reverse().join(""),
+    (s: string) => s.replace(/[a-z]/g, () => String.fromCharCode(97 + Math.floor(Math.random() * 26))),
   ];
 
   const numCorruptions = Math.floor(Math.random() * 3) + 1;
@@ -111,144 +139,62 @@ function corruptCSS(css: string): string {
   return corrupted;
 }
 
-// TODO:
+// Every generated input as written, built once each. Unlike the random corruptions below these are
+// fixed inputs, so they also run in CI.
+describe.each(strategies)("CSS Parser Invalid Input - %s", strategy => {
+  test.each(inputsOf(strategy).map(({ label, css }) => [`${label} ${describeInput(css)}`, css]))(
+    "%s",
+    async (_label, css) => {
+      await expectBuildToFinish(css);
+    },
+  );
+});
+
 if (!isCI) {
-  // Main fuzzing test suite for invalid inputs
-  test.each(
-    [["syntax", 1000], ["structure", 1000], ["encoding", 500], !isDebug ? ["memory", 100] : []].filter(
-      xs => xs.length > 0,
-    ),
-  )(
+  // Every iteration is one Bun.build call: about 1ms on a release build and about 50ms on a debug
+  // build, where the release counts would run past the test timeout.
+  const releaseIterations: Record<Strategy, number> = { syntax: 1000, structure: 1000, encoding: 500, memory: 100 };
+
+  test.each(strategies.map(strategy => [strategy, isDebug ? 50 : releaseIterations[strategy]] as const))(
     "CSS Parser Invalid Input Fuzzing - %s (%d iterations)",
     async (strategy, iterations) => {
-      const options: InvalidFuzzOptions = {
-        maxLength: 10000,
-        strategy: strategy as any,
-        iterations,
-      };
-
-      let crashCount = 0;
-      let errorCount = 0;
+      const inputs = inputsOf(strategy);
+      const outcomes = { built: 0, rejected: 0 };
       const startTime = performance.now();
 
-      for (let i = 0; i < options.iterations; i++) {
-        let invalidCSS = "";
-
-        switch (strategy) {
-          case "syntax":
-            invalidCSS =
-              invalidGenerators.syntax[
-                Object.keys(invalidGenerators.syntax)[
-                  Math.floor(Math.random() * Object.keys(invalidGenerators.syntax).length)
-                ]
-              ]()[Math.floor(Math.random() * 5)];
-            break;
-
-          case "structure":
-            invalidCSS =
-              invalidGenerators.structure[
-                Object.keys(invalidGenerators.structure)[
-                  Math.floor(Math.random() * Object.keys(invalidGenerators.structure).length)
-                ]
-              ]()[Math.floor(Math.random() * 3)];
-            break;
-
-          case "encoding":
-            invalidCSS =
-              invalidGenerators.encoding[
-                Object.keys(invalidGenerators.encoding)[
-                  Math.floor(Math.random() * Object.keys(invalidGenerators.encoding).length)
-                ]
-              ]()[0];
-            break;
-
-          case "memory":
-            const memoryFuncs = Object.keys(invalidGenerators.memory);
-            const selectedFunc = memoryFuncs[Math.floor(Math.random() * memoryFuncs.length)];
-            invalidCSS = invalidGenerators.memory[selectedFunc]();
-            break;
-        }
-
-        // Further corrupt the CSS randomly
-        if (Math.random() < 0.3) {
-          invalidCSS = corruptCSS(invalidCSS);
-        }
-
-        log("--- CSS Fuzz ---");
-        invalidCSS = invalidCSS + "";
-        log(JSON.stringify(invalidCSS, null, 2));
-        await Bun.write("invalid.css", invalidCSS);
-
-        try {
-          const result = await Bun.build({
-            entrypoints: ["invalid.css"],
-          });
-
-          // We expect the parser to either throw an error or return a valid result
-          // If it returns undefined/null, that's a potential issue
-          if (result === undefined || result === null) {
-            crashCount++;
-            console.error(`Parser returned ${result} for input:\n${invalidCSS.slice(0, 100)}...`);
-          }
-        } catch (error) {
-          // Expected behavior for invalid CSS
-          errorCount++;
-
-          // Check for specific error types we want to track
-          if (error instanceof RangeError || error instanceof TypeError) {
-            console.warn(`Unexpected error type: ${error.constructor.name} for input:\n${invalidCSS.slice(0, 100)}...`);
-          }
-        }
-
-        // Memory check every 100 iterations
-        if (i % 100 === 0) {
-          const heapUsed = process.memoryUsage().heapUsed / 1024 / 1024;
-          expect(heapUsed).toBeLessThan(500); // Alert if memory usage exceeds 500MB
-        }
+      for (let i = 0; i < iterations; i++) {
+        const { label, css } = inputs[Math.floor(Math.random() * inputs.length)];
+        const corrupted = corruptCSS(css);
+        // Logged before the build so that a crash can be traced back to its input.
+        log(`--- CSS Fuzz: ${strategy} ${label} ---\n${describeInput(corrupted)}`);
+        outcomes[await expectBuildToFinish(corrupted)]++;
       }
 
-      const endTime = performance.now();
-      const duration = endTime - startTime;
-
+      const duration = performance.now() - startTime;
       console.log(`
     Strategy: ${strategy}
     Total iterations: ${iterations}
-    Crashes: ${crashCount}
-    Expected errors: ${errorCount}
+    Built: ${outcomes.built}
+    Rejected: ${outcomes.rejected}
     Duration: ${duration.toFixed(2)}ms
     Average time per test: ${(duration / iterations).toFixed(2)}ms
   `);
-
-      // We expect some errors for invalid input, but no crashes
-      expect(crashCount).toBe(0);
-      expect(errorCount).toBeGreaterThan(0);
     },
-    10 * 1000,
   );
 
   // Additional test for mixed valid/invalid input
   test("CSS Parser Mixed Input Fuzzing", async () => {
     const validCSS = ".test{color:red}";
 
-    for (let i = 0; i < 100; i++) {
+    for (let i = 0; i < (isDebug ? 10 : 100); i++) {
       const mixedCSS = `
       ${validCSS}
       ${corruptCSS(validCSS)}
       ${validCSS}
     `;
 
-      console.log("--- Mixed CSS ---");
-      console.log(JSON.stringify(mixedCSS, null, 2));
-      await Bun.write("invalid.css", mixedCSS);
-
-      try {
-        await Bun.build({
-          entrypoints: ["invalid.css"],
-        });
-      } catch (error) {
-        // Expected to throw, but shouldn't crash
-        expect(error).toBeDefined();
-      }
+      log(`--- Mixed CSS ---\n${describeInput(mixedCSS)}`);
+      await expectBuildToFinish(mixedCSS);
     }
   });
 }


### PR DESCRIPTION
### Problem
- `test/js/bun/css/css-fuzz.test.ts` builds far fewer inputs than its generator tables contain, because the strategy switch (css-fuzz.test.ts:138-163 on main) indexes each generator's result with a fixed range that does not match the generators:
  - `syntax` indexes with `Math.random() * 5`, but `unclosedRules` returns a string (so the "input" is one character of it, a space or newline) and `unclosedComments` has 3 entries (indices 3 and 4 give `undefined`, which `invalidCSS + ""` turns into the stylesheet `undefined`). Measured over 100k picks: 13 of the 14 intended inputs, the whole `unclosedRules` sheet never, plus `" "` 20% of the time, `"undefined"` 10%, `"\n"` 5%.
  - `structure` indexes with `Math.random() * 3`, but `malformedAtRules` has 4 entries: `@media screen and and {color:red}` is never built (9 of 10).
  - `encoding` always takes `[0]`: 3 of its 38 inputs are built; 31 of the 32 `controlCharacters` variants never are.
- The assertions the file ends with do not check anything: `crashCount` (:189) only increments when an awaited `Bun.build` resolves to `null`/`undefined`, which it never does, so `expect(crashCount).toBe(0)` cannot fail, and the `heapUsed < 500 MB` check (:205) reads the JS heap while the bundler's work is native memory (it stays around 1 MB).
- `invalidUTF8` (:54) runs its bytes through `Buffer#toString()`, so the parser receives U+FFFD replacement characters, which are valid UTF-8.
- The file is wrapped in `if (!isCI)`, so none of its inputs run in CI.

### Fix
- Every generator returns an array and the tables are flattened (`inputsOf`), so a generator's entry count no longer has to match a hard-coded index range. The file is typed `satisfies Record<string, Record<string, () => string[]>>` so a generator returning a bare string again fails to typecheck.
- Each generated input gets its own test (`describe.each` over strategies, `test.each` over the flattened inputs, named `generator[i] <input>`), and these run in CI: they are fixed inputs, so a failure is a deterministic parser regression. 62 tests, plus the 3 memory inputs on plain release builds; about 0.3s on release and 6s on a debug build. The random corruption loops pick from the same flattened lists and stay behind `!isCI` as before; they now always corrupt, since the uncorrupted inputs are covered by the table.
- `expectBuildToFinish` replaces `crashCount` and the heap check: every build runs with `throw: false` and has to end with exactly one output or with a non-empty `logs`. A parser crash takes the process down and a JS-level exception rejects the promise, so both still fail the test, and the check is one that can actually fail. The per-strategy `errorCount > 0` assertion is gone with it: it was only ever a plumbing check, and the table checks every input's outcome individually.
- Inputs are byte strings and reach `Bun.build` via `files` as `Buffer.from(css, "latin1")`, so the three `invalidUTF8` inputs are now the overlong sequences they claim to be (`C0 80`, `E0 80 80`, `F0 80 80 80`), all other inputs are ASCII and unaffected, and the string corruptions keep working on bytes. Test names escape bytes >= 0x7f as `\xNN`.
- Why this is safe to turn on in CI: all 65 inputs finish on both the release binary and a debug (ASAN) build at this base; so do 1174 enumerated corruption variants of the encoding inputs on both (every single corruption of all 38 inputs and every pair of corruptions of the three byte inputs, with every slice position enumerated rather than sampled). The memory strategy is gated on `!isDebug && !isASAN` (it was `!isDebug`): its 300-deep `@media` input overflows the parser thread's stack under ASAN (pre-existing, being fixed separately), which would otherwise hit the release ASAN lane now that the table runs in CI. That lane also runs this file without LeakSanitizer (it is already listed in `test/no-validate-leaksan.txt`), so only a crash or a failed assertion can turn it red, not a leak report. The file is part of the `js/bun/css` parallel batch; the table takes about 0.3s on a release build.
- Overlaps with #38491 (pass the sheet through `files` instead of writing `invalid.css` into the cwd) and #38500 (fewer iterations on debug builds): this rewrite of the loop ends up including both, since the build call and the iteration table are the lines it replaces. Whichever lands second needs a trivial rebase; if this lands first the other two become no-ops.
- Test-only change, so there is no src diff to prove against; the evidence is the before/after on the same binaries:
  - `USE_SYSTEM_BUN=1 bun test test/js/bun/css/css-fuzz.test.ts`: 70 pass in 4.6s (10 runs in a row), versus 5 pass on main with the coverage above and a stray `invalid.css` left in the checkout.
  - `bun bd test test/js/bun/css/css-fuzz.test.ts`: 66 pass in 14s; main's file fails 4/4 on a debug build (timeouts, as described in #38500).
  - `CI=1` with both binaries: 65 pass (release, 0.3s) and 62 pass (debug, 6s); only the table runs.
  - Random loops on the debug build, 8 runs: no failures.

### Background
- `Bun.build({ files })` is an in-memory file map; an entrypoint whose path matches a key is bundled from the map instead of the disk, and values may be strings or byte arrays. The bundler asserts entry points are absolute, hence the fixed `/css-fuzz/invalid.css` key. `throw: false` makes a failed build resolve to `{ success: false, logs }` instead of rejecting.
- The CSS tokenizer works on the raw bytes of the source, so invalid UTF-8 can only be exercised by handing it bytes; a JS string is always encoded to valid UTF-8 on the way in. `Buffer.from(s, "latin1")` maps each char U+0000..U+00FF of `s` to that single byte, which is how an ordinary string literal like `"\xc0\x80"` becomes the bytes `C0 80`.
- `isASAN` (test/harness.ts) is true for `bun bd` builds and for CI's release ASAN lane; `isDebug` only for the former.

<details>
<summary>Measurement of the old selection code</summary>

Replicating the three `case` bodies from main verbatim and counting distinct results over 100,000 picks per strategy (corruption step excluded):

```
=== syntax ===
intended base inputs: 14
distinct inputs actually built: 16 (13 of them are intended inputs)
intended inputs never built (1):
    "\n      .test { color: red\n      .another { padding: 10px }"
non-intended junk built:
    " " -> 20.0%
    "undefined" -> 10.0%
    "\n" -> 4.9%

=== structure ===
intended base inputs: 10
distinct inputs actually built: 9 (9 of them are intended inputs)
intended inputs never built (1):
    "@media screen and and {color:red}"

=== encoding ===
intended base inputs: 38
distinct inputs actually built: 3 (3 of them are intended inputs)
intended inputs never built (35): invalidUTF8[1..2], nullBytes[1..2], controlCharacters[1..31]
```

Outcome of the 65 uncorrupted inputs, identical on the release binary and the debug build: 15 rejected (unclosedRules, the 5 invalidSelectors, `.test{:red}`, `@keyframes { @keyframes { } }`, the 4 malformedAtRules, the 3 invalidImports), 50 built. None of the encoding or memory inputs is rejected, which is why the old `errorCount > 0` for those strategies was only ever satisfied by the random corruptions (see #38500).

</details>
