### PR TITLE
node errors: render -0 and constructor-less objects in determineSpecificType like node

### DIFF
--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -372,6 +372,60 @@ void JSValueToStringSafe(JSC::JSGlobalObject* globalObject, WTF::StringBuilder& 
     builder.append(Bun__inspect_singleline(globalObject, arg).transferToWTFString());
 }
 
+// Port of the `object` arm of Node's determineSpecificType:
+//   if (value.constructor && 'name' in value.constructor) return `an instance of ${value.constructor.name}`;
+//   return inspect(value, { depth: -1 });
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/errors.js#L1038-L1041
+static void appendSpecificTypeOfObject(JSC::VM& vm, JSC::JSGlobalObject* globalObject, WTF::StringBuilder& builder, JSC::JSObject* object)
+{
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue constructor = object->get(globalObject, vm.propertyNames->constructor);
+    RETURN_IF_EXCEPTION(scope, );
+    if (constructor.toBoolean(globalObject)) {
+        JSObject* constructorObject = constructor.getObject();
+        if (!constructorObject) {
+            // `'name' in <primitive>` throws, so node's message builder throws too (worded as V8 words it).
+            String description;
+            if (constructor.isSymbol())
+                description = asSymbol(constructor)->tryGetDescriptiveString().value_or("Symbol()"_s);
+            else
+                description = constructor.toWTFString(globalObject);
+            RETURN_IF_EXCEPTION(scope, );
+            throwTypeError(globalObject, scope, makeString("Cannot use 'in' operator to search for 'name' in "_s, description));
+            return;
+        }
+        JSValue name = constructorObject->getIfPropertyExists(globalObject, vm.propertyNames->name);
+        RETURN_IF_EXCEPTION(scope, );
+        if (name) {
+            auto* nameString = name.toString(globalObject);
+            RETURN_IF_EXCEPTION(scope, );
+            auto nameView = nameString->view(globalObject);
+            RETURN_IF_EXCEPTION(scope, );
+            builder.append("an instance of "_s);
+            builder.append(nameView);
+            return;
+        }
+    }
+
+    JSFunction* utilInspect = defaultGlobalObject(globalObject)->utilInspectFunction();
+    RETURN_IF_EXCEPTION(scope, );
+    JSObject* options = constructEmptyObject(globalObject);
+    options->putDirect(vm, Identifier::fromString(vm, "depth"_s), jsNumber(-1), 0);
+    auto callData = JSC::getCallData(utilInspect);
+    MarkedArgumentBuffer arguments;
+    arguments.append(object);
+    arguments.append(options);
+    ASSERT(!arguments.hasOverflowed());
+    JSValue inspected = JSC::profiledCall(globalObject, ProfilingReason::API, utilInspect, callData, jsUndefined(), arguments);
+    RETURN_IF_EXCEPTION(scope, );
+    auto* inspectedString = inspected.toString(globalObject);
+    RETURN_IF_EXCEPTION(scope, );
+    auto inspectedView = inspectedString->view(globalObject);
+    RETURN_IF_EXCEPTION(scope, );
+    builder.append(inspectedView);
+}
+
 void determineSpecificType(JSC::VM& vm, JSC::JSGlobalObject* globalObject, WTF::StringBuilder& builder, JSValue value)
 {
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
@@ -392,6 +446,9 @@ void determineSpecificType(JSC::VM& vm, JSC::JSGlobalObject* globalObject, WTF::
         if (d != d) return builder.append("type number (NaN)"_s);
         if (d == infinity) return builder.append("type number (Infinity)"_s);
         if (d == -infinity) return builder.append("type number (-Infinity)"_s);
+        // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/errors.js#L1021-L1022
+        // Number-to-string drops the sign of -0, so node special-cases it.
+        if (d == 0 && std::signbit(d)) return builder.append("type number (-0)"_s);
         builder.append("type number ("_s);
         builder.append(d);
         builder.append(')');
@@ -490,19 +547,9 @@ void determineSpecificType(JSC::VM& vm, JSC::JSGlobalObject* globalObject, WTF::
         return;
     }
     if (cell->isObject()) {
-        auto constructor = value.get(globalObject, vm.propertyNames->constructor);
-        RETURN_IF_EXCEPTION(scope, void());
-        if (constructor.toBoolean(globalObject)) {
-            auto name = constructor.get(globalObject, vm.propertyNames->name);
-            RETURN_IF_EXCEPTION(scope, void());
-            auto str = name.toString(globalObject);
-            RETURN_IF_EXCEPTION(scope, void());
-            builder.append("an instance of "_s);
-            auto view = str->view(globalObject);
-            RETURN_IF_EXCEPTION(scope, );
-            builder.append(view);
-            return;
-        }
+        appendSpecificTypeOfObject(vm, globalObject, builder, cell->getObject());
+        RETURN_IF_EXCEPTION(scope, );
+        return;
     }
 
     //       value = lazyInternalUtilInspect().inspect(value, { colors: false });

--- a/test/js/node/errors/invalid-arg-type-received.test.ts
+++ b/test/js/node/errors/invalid-arg-type-received.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, test } from "bun:test";
+import EventEmitter from "node:events";
+import { SocketAddress } from "node:net";
+
+// The "Received ..." suffix of ERR_INVALID_ARG_TYPE is rendered by determineSpecificType() in
+// src/jsc/bindings/ErrorCode.cpp, a port of node's lib/internal/errors.js determineSpecificType().
+// Native classes also use it for the "but received ..." suffix of ERR_INVALID_THIS. The entry
+// points below reach it from a C++ validator, from the JS builtins' $ERR_INVALID_ARG_TYPE, from
+// Rust's determine_specific_type, and from createInvalidThisError. Every rendering and every
+// thrown message asserted here is what node v26.3.0 prints for the same value through the three
+// ERR_INVALID_ARG_TYPE entry points.
+const entryPoints: [label: string, code: string, prefix: string, throwWith: (value: unknown) => unknown][] = [
+  [
+    "C++ validator (process.chdir)",
+    "ERR_INVALID_ARG_TYPE",
+    'The "directory" argument must be of type string. Received ',
+    value => process.chdir(value as any),
+  ],
+  [
+    "$ERR_INVALID_ARG_TYPE (EventEmitter#on)",
+    "ERR_INVALID_ARG_TYPE",
+    'The "listener" argument must be of type function. Received ',
+    value => new EventEmitter().on("event", value as any),
+  ],
+  [
+    "Rust determine_specific_type (SocketAddress.parse)",
+    "ERR_INVALID_ARG_TYPE",
+    'The "input" argument must be of type string. Received ',
+    value => SocketAddress.parse(value as any),
+  ],
+  [
+    "createInvalidThisError (CryptoHasher#update)",
+    "ERR_INVALID_THIS",
+    "Expected this to be instanceof CryptoHasher, but received ",
+    value => Bun.CryptoHasher.prototype.update.call(value, "x"),
+  ],
+];
+
+const inspectCustom = Symbol.for("nodejs.util.inspect.custom");
+
+const cases: [label: string, make: () => unknown, rendered: string][] = [
+  // Number.prototype.toString drops the sign of -0; node special-cases it.
+  ["negative zero", () => -0, "type number (-0)"],
+  ["zero", () => 0, "type number (0)"],
+  ["negative fraction", () => -1.5, "type number (-1.5)"],
+
+  // `value.constructor && 'name' in value.constructor` -> `an instance of ${value.constructor.name}`
+  ["plain object", () => ({}), "an instance of Object"],
+  ["array", () => [], "an instance of Array"],
+  ["instance of an anonymous class", () => new (class {})(), "an instance of "],
+  ["non-function constructor with a name", () => ({ constructor: { name: "Custom" } }), "an instance of Custom"],
+  ["constructor whose name is undefined", () => ({ constructor: { name: undefined } }), "an instance of undefined"],
+  [
+    "constructor that inherits its name",
+    () => ({ constructor: Object.create({ name: "Inherited" }) }),
+    "an instance of Inherited",
+  ],
+
+  // Otherwise node falls back to util.inspect(value, { depth: -1 }), which collapses the value to
+  // its constructor name in brackets instead of printing its contents.
+  ["constructor without a name", () => ({ constructor: {} }), "[Object]"],
+  ["constructor is null", () => ({ constructor: null }), "[Object]"],
+  ["constructor is a falsy primitive", () => ({ constructor: "" }), "[Object]"],
+  [
+    "constructor whose has trap hides name",
+    () => ({ constructor: new Proxy({ name: "Hidden" }, { has: () => false }) }),
+    "[Object]",
+  ],
+  [
+    "class instance shadowing its constructor with a nameless one",
+    () => Object.assign(new (class Foo {})(), { constructor: {} }),
+    "[Foo]",
+  ],
+  ["Map with a null constructor", () => Object.assign(new Map([[1, 2]]), { constructor: null }), "[Map]"],
+  ["empty null-prototype object", () => Object.create(null), "[Object: null prototype] {}"],
+  [
+    "null-prototype object with properties",
+    () => Object.assign(Object.create(null), { a: 1 }),
+    "[Object: null prototype]",
+  ],
+  [
+    "custom inspect function receives depth -1",
+    () => ({ constructor: null, [inspectCustom]: (depth: number) => `custom depth=${depth}` }),
+    "custom depth=-1",
+  ],
+];
+
+// `'name' in value.constructor` throws when the constructor is a truthy primitive, so node's
+// message builder throws a plain TypeError instead of producing ERR_INVALID_ARG_TYPE.
+const primitiveConstructors: [label: string, constructor: unknown, rendered: string][] = [
+  ["number", 1, "1"],
+  ["string", "abc", "abc"],
+  ["boolean", true, "true"],
+  ["symbol", Symbol("desc"), "Symbol(desc)"],
+  ["bigint", 1n, "1"],
+];
+
+function thrownBy(fn: () => unknown): any {
+  try {
+    fn();
+  } catch (e) {
+    return e;
+  }
+  throw new Error("expected the call to throw");
+}
+
+describe.each(entryPoints)("determineSpecificType via %s", (_label, code, prefix, throwWith) => {
+  test("renders -0 and objects like node", () => {
+    const messages = cases.map(([label, make]) => {
+      const error = thrownBy(() => throwWith(make()));
+      return [label, error.code, error.message];
+    });
+    expect(messages).toEqual(cases.map(([label, , rendered]) => [label, code, prefix + rendered]));
+  });
+
+  test("a truthy primitive constructor throws the `in` operator's TypeError", () => {
+    const errors = primitiveConstructors.map(([label, constructor]) => {
+      const error = thrownBy(() => throwWith({ constructor }));
+      return [label, error instanceof TypeError, error.code, error.message];
+    });
+    expect(errors).toEqual(
+      primitiveConstructors.map(([label, , rendered]) => [
+        label,
+        true,
+        undefined,
+        `Cannot use 'in' operator to search for 'name' in ${rendered}`,
+      ]),
+    );
+  });
+
+  test("an exception thrown while rendering the value replaces the error being built", () => {
+    const constructorBoom = new RangeError("constructor getter");
+    const hasBoom = new RangeError("has trap");
+    const nameBoom = new RangeError("name getter");
+    const inspectBoom = new RangeError("custom inspect");
+
+    expect(
+      thrownBy(() =>
+        throwWith({
+          get constructor() {
+            throw constructorBoom;
+          },
+        }),
+      ),
+    ).toBe(constructorBoom);
+    expect(
+      thrownBy(() =>
+        throwWith({
+          constructor: new Proxy(
+            {},
+            {
+              has() {
+                throw hasBoom;
+              },
+            },
+          ),
+        }),
+      ),
+    ).toBe(hasBoom);
+    expect(
+      thrownBy(() =>
+        throwWith({
+          constructor: {
+            get name() {
+              throw nameBoom;
+            },
+          },
+        }),
+      ),
+    ).toBe(nameBoom);
+    expect(
+      thrownBy(() =>
+        throwWith({
+          constructor: null,
+          [inspectCustom]() {
+            throw inspectBoom;
+          },
+        }),
+      ),
+    ).toBe(inspectBoom);
+  });
+});


### PR DESCRIPTION
### Problem

`determineSpecificType()` in `src/jsc/bindings/ErrorCode.cpp` renders the `Received ...` part of every `ERR_INVALID_ARG_TYPE` message (C++ validators, the JS builtins' `$ERR_INVALID_ARG_TYPE`, Rust's `determine_specific_type`, and the `but received ...` suffix of the `ERR_INVALID_THIS` that native classes throw). Two arms of it diverge from node's `lib/internal/errors.js` `determineSpecificType()`:

- Number arm (`ErrorCode.cpp:389`): `process.chdir(-0)` says `Received type number (0)`; node says `type number (-0)`. `StringBuilder::append(double)` drops the sign like `Number#toString` does, and node special-cases it.
- Object arm (`ErrorCode.cpp:492`): bun only checks that `value.constructor` is truthy and then prints `.constructor.name`, node checks `'name' in value.constructor` and otherwise falls back to `util.inspect(value, { depth: -1 })`. Measured on bun 1.4.0 vs node v26.3.0 through `process.chdir(v)`:
  - `{ constructor: {} }`: bun `an instance of undefined`, node `[Object]`
  - `{ constructor: null }`: bun `{}`, node `[Object]` (bun's fallback was the native formatter at unlimited depth)
  - `Object.assign(Object.create(null), { a: 1 })`: bun `[Object: null prototype] { a: 1 }`, node `[Object: null prototype]`
  - `{ constructor: 1 }`: bun `an instance of undefined`, node throws `TypeError: Cannot use 'in' operator to search for 'name' in 1` (the `in` on a primitive propagates out of the message builder)

### Fix

- Number arm: `-0` renders as `type number (-0)`.
- Object arm moves into `appendSpecificTypeOfObject()`, a line by line port of node's arm: `getIfPropertyExists(name)` is the `'name' in ctor` check plus the read (it goes through the same `[[HasProperty]]` walk, so Proxy `has` traps and inherited names behave as in node); a truthy primitive constructor throws a TypeError with the text node prints for it; everything else calls `util.inspect(value, { depth: -1 })` the way the BroadcastChannel / URLSearchParams / web streams inspect code already calls it from C++. Bun's `util.inspect` is a port of node's, so the collapsed renderings (`[Object]`, `[Foo]`, `[Map]`, `[Object: null prototype]`, custom inspect functions called with depth -1) come out identical; the fallback runs only for values whose constructor is missing or nameless, so the common `an instance of X` path is unchanged apart from using `getIfPropertyExists`.
- The helper has its own `ThrowScope` because it throws; `determineSpecificType()` keeps its `TopExceptionScope`, so its contract towards callers (exception left pending, callers check) is unchanged. The same shape already happens today when a `constructor` getter throws, which is why every caller, including `createInvalidThisError`, already copes with it.
- Why this is the right behavior: it is what node does, verbatim (permalinks in the code comments), and bun's ported node tests compare these messages as text.
- Verified with `test/js/node/errors/invalid-arg-type-received.test.ts`: 4 entry points (C++ `process.chdir`, JS `EventEmitter#on`, Rust `SocketAddress.parse`, generated-class `CryptoHasher#update` invalid `this`) x 18 renderings, the 5 primitive-constructor throws, and propagation of exceptions thrown from the constructor getter, a `has` trap, the name getter, and a custom inspect function. All 12 tests fail on bun 1.4.0 (only the intended rows differ, see below) and pass on this build, also with `BUN_JSC_validateExceptionChecks=1`.
- The renderings and thrown messages asserted by the test were replayed against node v26.3.0 with the test's own data (script output below): 0 mismatches across the three `ERR_INVALID_ARG_TYPE` entry points.
- Independent of #38473, which fixes the callable arm of the same function; the hunks do not overlap and #38473's object-branch test passes on this build.

### Background

- `determineSpecificType` (node `lib/internal/errors.js`): turns the offending value into the `Received ...` text of `ERR_INVALID_ARG_TYPE`: primitives as `type number (5)`, objects as `an instance of <constructor name>`, and anything without a usable constructor name through `util.inspect` with `depth: -1`, which prints a value as just its bracketed constructor name instead of its contents.
- `'name' in x`: `[[HasProperty]]`, i.e. it looks up the prototype chain and asks a Proxy's `has` trap, and it throws a TypeError when `x` is a primitive. JSC's `JSObject::getIfPropertyExists` does that lookup and returns the value, or an empty `JSValue` when the property does not exist.
- Exception scopes: JSC code that throws needs a `ThrowScope`; a `TopExceptionScope` (what `determineSpecificType` uses) can only observe exceptions that callees threw. Under `BUN_JSC_validateExceptionChecks=1` (CI's ASAN lanes) every call that may throw has to be followed by a check, hence the `RETURN_IF_EXCEPTION` after the new helper.
- `utilInspectFunction()` on the global object lazily loads `node:util` and returns its `inspect`, the same function users call; `defaultGlobalObject()` maps a non-Bun global (a `node:vm` context) to the Bun global that owns it.
- Pre-existing and unchanged by this PR: if the exception left pending while rendering is a primitive (for example a `constructor` getter that does `throw 7`), `ErrorCodeCache::createError` asserts in debug builds on the `createInvalidThisError` path. It reproduces on main without this change and is being fixed separately.

<details>
<summary>Rows that differ on bun 1.4.0 (process.chdir entry point; the other three entry points differ identically)</summary>

```
expected                                                   bun 1.4.0
type number (-0)                                           type number (0)
[Object]          ({ constructor: {} })                    an instance of undefined
[Object]          ({ constructor: null })                  {}
[Object]          ({ constructor: "" })                    {}
[Object]          (has trap hides name)                    an instance of Hidden
[Foo]             (Foo instance, own constructor: {})      an instance of undefined
[Map]             (Map, constructor: null)                 Map(1) { 1: 2 }
[Object: null prototype]   (null proto with keys)          [Object: null prototype] { a: 1 }
custom depth=-1   (inspect.custom, constructor: null)      custom depth=65535
Cannot use 'in' operator to search for 'name' in 1 ...     ERR_INVALID_ARG_TYPE "an instance of undefined" (x5 primitives)
has trap throws -> trap's error propagates                 ERR_INVALID_ARG_TYPE "an instance of undefined"
```

</details>

<details>
<summary>Node v26.3.0 replay of the test's data (excerpt, 0 mismatches over 81 checks)</summary>

```
ok   [process.chdir] negative zero => "type number (-0)"
ok   [process.chdir] zero => "type number (0)"
ok   [process.chdir] constructor without a name => "[Object]"
ok   [process.chdir] constructor is null => "[Object]"
ok   [process.chdir] constructor is a falsy primitive => "[Object]"
ok   [process.chdir] constructor whose has trap hides name => "[Object]"
ok   [process.chdir] class instance shadowing its constructor with a nameless one => "[Foo]"
ok   [process.chdir] Map with a null constructor => "[Map]"
ok   [process.chdir] empty null-prototype object => "[Object: null prototype] {}"
ok   [process.chdir] null-prototype object with properties => "[Object: null prototype]"
ok   [process.chdir] custom inspect function receives depth -1 => "custom depth=-1"
ok   [process.chdir] primitive constructor number => "Cannot use 'in' operator to search for 'name' in 1"
ok   [process.chdir] primitive constructor string => "Cannot use 'in' operator to search for 'name' in abc"
ok   [process.chdir] primitive constructor boolean => "Cannot use 'in' operator to search for 'name' in true"
ok   [process.chdir] primitive constructor symbol => "Cannot use 'in' operator to search for 'name' in Symbol(desc)"
ok   [process.chdir] primitive constructor bigint => "Cannot use 'in' operator to search for 'name' in 1"
ok   [process.chdir] constructor getter throws => same error propagated
ok   [process.chdir] has trap throws => same error propagated
ok   [process.chdir] name getter throws => same error propagated
ok   [process.chdir] custom inspect throws => same error propagated
(same for EventEmitter#on and SocketAddress.parse)
v26.3.0 mismatches: 0
```

</details>
