### PR TITLE
shell: lex `]]` before `)`, `<` or a closing backtick as the closing token, and only inside `[[`

### DIFF
--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -2220,6 +2220,9 @@ pub struct Lexer<'bump, const ENCODING: StringEncoding> {
     pub(crate) tokens: bun_alloc::ArenaVec<'bump, Token>,
     pub(crate) delimit_quote: bool,
     pub(crate) in_subshell: Option<SubShellKind>,
+    /// Set between `[[` and its `]]`. Outside of a conditional, `]]` is
+    /// ordinary text (`echo [[x]]`).
+    pub(crate) in_cond_expr: bool,
     pub(crate) subshell_depth: u32,
     pub(crate) errors: bun_alloc::ArenaVec<'bump, LexError>,
 
@@ -2254,6 +2257,7 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
             j: 0,
             delimit_quote: false,
             in_subshell: None,
+            in_cond_expr: false,
             subshell_depth: 0,
             string_refs: strings_to_escape,
             jsobjs_len,
@@ -2296,6 +2300,7 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                 bun_alloc::ArenaVec::new_in(bump),
             ),
             in_subshell: Some(kind),
+            in_cond_expr: false,
             subshell_depth: self.subshell_depth + 1,
             word_start: self.word_start,
             j: self.j,
@@ -2458,30 +2463,20 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                                 }
                                 let state = self.make_snapshot();
                                 let _ = self.eat();
-                                'do_backtrack: {
-                                    let p2 = match self.peek() {
-                                        Some(p2) => p2,
-                                        None => {
-                                            self.break_word(true)?;
-                                            self.tokens.push(Token::DoubleBracketClose);
-                                            fell_through = true;
-                                            break 'escaped;
-                                        }
-                                    };
-                                    if p2.escaped {
-                                        break 'do_backtrack;
+                                let is_token = match self.peek() {
+                                    None => true,
+                                    Some(p2) => {
+                                        !p2.escaped
+                                            && matches!(
+                                                u8::try_from(p2.char),
+                                                Ok(b' ' | b'\r' | b'\n' | b'\t')
+                                            )
                                     }
-                                    match p2.char {
-                                        c2 if c2 == u32::from(b' ')
-                                            || c2 == u32::from(b'\r')
-                                            || c2 == u32::from(b'\n')
-                                            || c2 == u32::from(b'\t') =>
-                                        {
-                                            self.break_word(true)?;
-                                            self.tokens.push(Token::DoubleBracketOpen);
-                                        }
-                                        _ => break 'do_backtrack,
-                                    }
+                                };
+                                if is_token {
+                                    self.break_word(true)?;
+                                    self.tokens.push(Token::DoubleBracketOpen);
+                                    self.in_cond_expr = true;
                                     fell_through = true;
                                     break 'escaped;
                                 }
@@ -2493,6 +2488,7 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                             const _: () = assert!(SPECIAL_CHARS_TABLE.is_set(b']' as usize));
                             if self.chars.state == CharState::Single
                                 || self.chars.state == CharState::Double
+                                || !self.in_cond_expr
                             {
                                 break 'escaped;
                             }
@@ -2502,37 +2498,26 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                                 }
                                 let state = self.make_snapshot();
                                 let _ = self.eat();
-                                'do_backtrack: {
-                                    let p2 = match self.peek() {
-                                        Some(p2) => p2,
-                                        None => {
-                                            self.break_word(true)?;
-                                            self.tokens.push(Token::DoubleBracketClose);
-                                            fell_through = true;
-                                            break 'escaped;
+                                // `]]` closes the conditional only as a whole word, i.e.
+                                // when what follows would end a word anyway.
+                                let is_token = match self.peek() {
+                                    None => true,
+                                    Some(p2) if p2.escaped => false,
+                                    Some(p2) => match u8::try_from(p2.char) {
+                                        Ok(
+                                            b' ' | b'\r' | b'\n' | b'\t' | b';' | b'&' | b'|'
+                                            | b'>' | b'<' | b'(' | b')',
+                                        ) => true,
+                                        Ok(b'`') => {
+                                            self.in_subshell == Some(SubShellKind::Backtick)
                                         }
-                                    };
-                                    if p2.escaped {
-                                        break 'do_backtrack;
-                                    }
-                                    match p2.char {
-                                        c2 if matches!(
-                                            u8::try_from(c2),
-                                            Ok(b' '
-                                                | b'\r'
-                                                | b'\n'
-                                                | b'\t'
-                                                | b';'
-                                                | b'&'
-                                                | b'|'
-                                                | b'>')
-                                        ) =>
-                                        {
-                                            self.break_word(true)?;
-                                            self.tokens.push(Token::DoubleBracketClose);
-                                        }
-                                        _ => break 'do_backtrack,
-                                    }
+                                        _ => false,
+                                    },
+                                };
+                                if is_token {
+                                    self.break_word(true)?;
+                                    self.tokens.push(Token::DoubleBracketClose);
+                                    self.in_cond_expr = false;
                                     fell_through = true;
                                     break 'escaped;
                                 }

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -2393,6 +2393,27 @@ describe("condexprs", () => {
   TestBuilder.command`LOL=; [[ $LOl == $LOL ]] && echo yes!`.stdout("yes!\n").runAsTest("== empty");
   TestBuilder.command`LOL=; [[ $LOl != $LOL ]] && echo yes!`.exitCode(1).runAsTest("!= empty");
 
+  // The `$([[ ... ]])` and backtick forms are covered at the token level in
+  // lex.test.ts; running them also depends on how the substitution is closed (#38479).
+  describe("]] directly before the ) of a subshell", () => {
+    TestBuilder.command`([[ -n x ]]) && echo yes!`.stdout("yes!\n").runAsTest("unary operator");
+    TestBuilder.command`([[ foo == bar ]]) || echo no`.stdout("no\n").runAsTest("binary operator");
+  });
+
+  describe("]] outside of a conditional is an ordinary word", () => {
+    TestBuilder.command`echo ]]`.stdout("]]\n").runAsTest("on its own");
+    TestBuilder.command`echo [[x]] a]]`.stdout("[[x]] a]]\n").runAsTest("at the end of a word");
+    TestBuilder.command`[[ -n x ]] && echo ]]`.stdout("]]\n").runAsTest("after a conditional");
+    TestBuilder.command`echo $(echo [[x]])`.stdout("[[x]]\n").runAsTest("right before the ) of a command substitution");
+    TestBuilder.command`[[ $(echo ]] ) == "]]" ]] && echo yes!`
+      .stdout("yes!\n")
+      .runAsTest("inside a command substitution that is inside a conditional");
+  });
+
+  TestBuilder.command`[[`
+    .error("Expected a conditional expression operand, but got: EOF")
+    .runAsTest("[[ at end of input");
+
   describe.todo("ported from GNU bash", () => {
     TestBuilder.command`
     [[ foo > bar && $PWD -ef . ]]

--- a/test/js/bun/shell/lex.test.ts
+++ b/test/js/bun/shell/lex.test.ts
@@ -706,6 +706,138 @@ describe("lex shell", () => {
     expect(JSON.parse(result)).toEqual(expected);
   });
 
+  // Tokens of `[[ -n x ]]`
+  const cond = [
+    { DoubleBracketOpen: {} },
+    { Text: "-n" },
+    { Delimit: {} },
+    { Text: "x" },
+    { Delimit: {} },
+    { DoubleBracketClose: {} },
+  ];
+  const BACKTICK = { raw: "`" };
+
+  describe("double brackets", () => {
+    test("]] directly before the ) of a subshell", () => {
+      expect(JSON.parse(lex`([[ -n x ]])`)).toEqual([{ OpenParen: {} }, ...cond, { CloseParen: {} }, { Eof: {} }]);
+    });
+
+    // Whether a Delimit is emitted in front of CmdSubstEnd is decided by the
+    // arm that closes the substitution (#38479 changes it), so these two
+    // compare the token stream without Delimits.
+    const dropDelimits = (tokens: object[]) => tokens.filter(tok => !("Delimit" in tok));
+    const condInSubst = [{ CmdSubstBegin: {} }, ...dropDelimits(cond), { CmdSubstEnd: {} }, { Eof: {} }];
+
+    test("]] directly before the ) of a command substitution", () => {
+      expect(dropDelimits(JSON.parse(lex`$([[ -n x ]])`))).toEqual(condInSubst);
+    });
+
+    test("]] directly before the closing backtick", () => {
+      expect(dropDelimits(JSON.parse(lex`${BACKTICK}[[ -n x ]]${BACKTICK}`))).toEqual(condInSubst);
+    });
+
+    test("]] directly before a redirect", () => {
+      expect(JSON.parse(lex`[[ -n x ]]<in`)).toEqual([
+        ...cond,
+        { Redirect: redirect({ stdin: true }) },
+        { Text: "in" },
+        { Delimit: {} },
+        { Eof: {} },
+      ]);
+      expect(JSON.parse(lex`[[ -n x ]]>out`)).toEqual([
+        ...cond,
+        { Redirect: redirect({ stdout: true }) },
+        { Text: "out" },
+        { Delimit: {} },
+        { Eof: {} },
+      ]);
+    });
+
+    test("]] directly before an operator or a paren", () => {
+      expect(JSON.parse(lex`[[ -n x ]]&&echo`)).toEqual([
+        ...cond,
+        { DoubleAmpersand: {} },
+        { Text: "echo" },
+        { Delimit: {} },
+        { Eof: {} },
+      ]);
+      expect(JSON.parse(lex`[[ -n x ]];`)).toEqual([...cond, { Semicolon: {} }, { Eof: {} }]);
+      expect(JSON.parse(lex`[[ -n x ]]()`)).toEqual([...cond, { OpenParen: {} }, { CloseParen: {} }, { Eof: {} }]);
+    });
+
+    test("]] glued to the next word is part of the word", () => {
+      expect(JSON.parse(lex`[[ -n x ]]y`)).toEqual([
+        { DoubleBracketOpen: {} },
+        { Text: "-n" },
+        { Delimit: {} },
+        { Text: "x" },
+        { Delimit: {} },
+        { Text: "]]y" },
+        { Delimit: {} },
+        { Eof: {} },
+      ]);
+    });
+
+    test("]] outside of [[ is text", () => {
+      expect(JSON.parse(lex`echo ]]`)).toEqual([
+        { Text: "echo" },
+        { Delimit: {} },
+        { Text: "]]" },
+        { Delimit: {} },
+        { Eof: {} },
+      ]);
+      expect(JSON.parse(lex`echo [[x]]`)).toEqual([
+        { Text: "echo" },
+        { Delimit: {} },
+        { Text: "[[x]]" },
+        { Delimit: {} },
+        { Eof: {} },
+      ]);
+      expect(JSON.parse(lex`$(echo ]])`)).toEqual([
+        { CmdSubstBegin: {} },
+        { Text: "echo" },
+        { Delimit: {} },
+        { Text: "]]" },
+        { Delimit: {} },
+        { CmdSubstEnd: {} },
+        { Eof: {} },
+      ]);
+    });
+
+    test("]] after the conditional was closed is text", () => {
+      expect(JSON.parse(lex`[[ -n x ]] && echo ]]`)).toEqual([
+        ...cond,
+        { DoubleAmpersand: {} },
+        { Text: "echo" },
+        { Delimit: {} },
+        { Text: "]]" },
+        { Delimit: {} },
+        { Eof: {} },
+      ]);
+    });
+
+    test("a command substitution inside the conditional starts outside of it", () => {
+      expect(JSON.parse(lex`[[ -n $(echo ]] ) ]]`)).toEqual([
+        { DoubleBracketOpen: {} },
+        { Text: "-n" },
+        { Delimit: {} },
+        { CmdSubstBegin: {} },
+        { Text: "echo" },
+        { Delimit: {} },
+        { Text: "]]" },
+        { Delimit: {} },
+        { CmdSubstEnd: {} },
+        { Delimit: {} },
+        { DoubleBracketClose: {} },
+        { Eof: {} },
+      ]);
+    });
+
+    test("[[ at the end of the input", () => {
+      expect(JSON.parse(lex`[[`)).toEqual([{ DoubleBracketOpen: {} }, { Eof: {} }]);
+    });
+  });
+
   describe("errors", async () => {
     // This is disallowed because the js object references get turned into special vars: $__bun_0, $__bun_1, etc.
     // this will break things inside of a quote.


### PR DESCRIPTION
### Problem
- `([[ -n x ]])`, `$([[ -n x ]])`, the backtick form and `[[ -n x ]]</dev/null` all throw `Expected "]]" but got: ]]`. bash accepts every one of them; with a space in front of the `)` Bun does too.
- Cause: the `]` arm of the lexer (`src/shell_parser/parse.rs`, `c if c == u32::from(b']')`) only emits `DoubleBracketClose` when the byte after `]]` is whitespace, `;`, `&`, `|`, `>` or the end of the input. `)`, `<`, `(` and the backtick that closes a substitution are not in the list, so the lexer backtracks and the `]]` ends up in a `Text` word (`shellInternals.lex` shows `... Text("]]") Delimit CloseParen`), which `parse_cond_expr` then rejects.
- The same arm recognizes `]]` anywhere, not only inside a `[[`, so `echo ]]`, `echo [[x]]` and `[[ -n x ]] && echo ]]` fail with `expected a command or assignment but got: "DoubleBracketClose"` (bash prints the text). `echo $(echo [[x]])` works today only because of the gap above, so adding `)` to the list on its own would have broken it.
- `[[` at the end of the input emits `DoubleBracketClose` (copy/paste in the `[` arm), so `[[` reports `expected a command or assignment but got: "DoubleBracketClose"` while `[[ ` reports the conditional-expression error.
- Same behavior in the original Zig lexer; not a regression.

### Fix
- `]]` is emitted as the closing token when the byte after it ends a word anyway: whitespace, `;`, `&`, `|`, `<`, `>`, `(`, `)`, the end of the input, or a backtick while the body of a backtick substitution is being lexed (there it is the end of the input for that body; anywhere else a backtick starts a substitution glued onto the word, and bash also rejects ``[[ -n x ]]`cmd` ``). This is the rule bash applies: `]]` counts only as a whole word.
- New `Lexer::in_cond_expr` flag, set when `[[` is emitted and cleared when `]]` is. The `]` arm does nothing while it is unset, so `]]` outside a conditional stays text whatever follows it. Sub-lexers (`$(...)`, backticks, `( ... )`) start with it unset, so a `]]` inside a substitution inside a conditional is text and the parent's `]]` still closes the conditional (`[[ $(echo ]] ) == "]]" ]]`). This is what makes widening the list above safe.
- Why the lexer and not `parse_cond_expr`: both decisions need the bytes around the `]]`, which are gone once it has been tokenized. Today `echo x]]` and `echo x ]]` lex to the identical stream (`Text("x") Delimit DoubleBracketClose`), so the parser cannot tell a literal `]]` from a closing one, and in the `]])` case the `]]` has already been merged into a `Text` token by the time the parser runs. A parser-side fix would have to special-case `Text("]]")` and re-glue words.
- Both bracket arms are reduced to one decision plus one push; the `[[`-at-end-of-input path now pushes `DoubleBracketOpen`, so `[[` gets the same error as `[[ `.
- Unchanged on purpose: `[[` still has to be followed by whitespace, `[[ -n x]]` is still accepted (bash rejects it, but it worked before and is unrelated), and the parser is not touched. The only inputs whose meaning changes are a conditional directly followed by one of the new characters (now parses) and a literal `]]` outside a conditional (now text instead of a parse error).
- `$([[ -n x ]])` and the backtick form now lex to the same token stream as their spaced forms. Running them end to end also needs #38479, which removes the `Delimit` the closing `)`/backtick emits after `]]`; the two changes are independent and compatible, and `([[ ... ]])` runs with this PR alone.
- Verified:
  - `test/js/bun/shell/lex.test.ts`, "double brackets": token streams for `]]` before `)` (subshell and substitution), a closing backtick, `<` and `>`, `&&` / `;` / `(`, a glued `]]y`, literal `]]` outside a conditional, after one, and inside a substitution nested in one, and `[[` at the end of the input. 9 of the 10 fail on the released bun; the glued case is a control.
  - `test/js/bun/shell/bunshell.test.ts`, `condexprs`: `([[ ... ]])` with a unary and with a binary operator, the literal `]]` cases end to end, and the error message for `[[`. 7 of the 8 fail on the released bun; `echo $(echo [[x]])` is the control that has to keep working.
  - `bun bd test` on `bunshell`, `parse`, `lex`, `pipeline_stack`, `bunshell-instance`, `shell-seq-condexpr` and `brace`: no failures. `cargo clippy -p bun_shell_parser` is clean.

### Background
- The shell lexer produces a flat token stream. Words are built from `Text` / `Var` / quoted tokens and ended by a `Delimit`; `[[` and `]]` are separate tokens (`DoubleBracketOpen` / `DoubleBracketClose`) that `parse_cond_expr` expects around a conditional expression. The lexer decides whether a `[[` or `]]` is such a token by peeking at the byte after it and backtracking to plain text when it does not qualify.
- In bash, `[[` and `]]` are reserved words: they are recognized only as whole words (bounded by whitespace or an operator character such as `)`, `;`, `<`), and `]]` has a meaning only inside a `[[` command; anywhere else it is an ordinary word.
- Command substitutions and subshells are lexed by a sub-lexer appending to the same token stream. For a backtick substitution the body ends at the next unescaped backtick, so for a `]]` inside it that backtick is the end of the input.