### PR TITLE
node:http2: throw getUnpackedSettings/respondWithFD ERR_INVALID_ARG_TYPE through the shared error machinery

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -284,20 +284,9 @@ function getPackedSettings(settings?: any): Buffer {
   return buf;
 }
 
-function getUnpackedSettings(buf?: any, options?: any): any {
-  if (buf === undefined) {
-    return { ...kDefaultSettings };
-  }
-
-  if (!Buffer.isBuffer(buf) && !isTypedArray(buf)) {
-    {
-      // node renders this as instance-of (class names), not of-type.
-      const err = new TypeError(
-        `The "buf" argument must be an instance of Buffer or TypedArray. Received ` + receivedValueLabel(buf),
-      );
-      err.code = "ERR_INVALID_ARG_TYPE";
-      throw err;
-    }
+function getUnpackedSettings(buf: any, options?: any): any {
+  if (!isTypedArray(buf)) {
+    throw $ERR_INVALID_ARG_TYPE("buf", ["Buffer", "TypedArray"], buf);
   }
 
   if (buf.length % 6 !== 0) {
@@ -3564,18 +3553,10 @@ class ServerHttp2Stream extends Http2Stream {
     fs.open(path, "r", afterOpen.bind(this, options || {}, headers));
   }
   respondWithFD(fd, headers, options) {
-    if (typeof fd !== "number") {
-      // node accepts a FileHandle too; unwrap its descriptor.
-      if (fd !== null && typeof fd === "object" && typeof fd.fd === "number") {
-        fd = fd.fd;
-      } else {
-        const err = new TypeError(
-          `The "fd" argument must be of type number or an instance of FileHandle.` +
-            ` Received ${receivedValueLabel(fd)}`,
-        );
-        err.code = "ERR_INVALID_ARG_TYPE";
-        throw err;
-      }
+    if (fd instanceof FileHandle) {
+      fd = fd.fd;
+    } else if (typeof fd !== "number") {
+      throw $ERR_INVALID_ARG_TYPE("fd", ["number", "FileHandle"], fd);
     }
     if (this.destroyed) {
       throw $ERR_HTTP2_INVALID_STREAM();
@@ -3628,11 +3609,7 @@ class ServerHttp2Stream extends Http2Stream {
       // stream.end() right after it is a no-op instead of ending the stream before the file.
       closeWritableForFileResponse(this);
     }
-    if (fd instanceof FileHandle) {
-      fs.fstat(fd.fd, doSendFileFD.bind(this, options, fd, headers));
-    } else {
-      fs.fstat(fd, doSendFileFD.bind(this, options, fd, headers));
-    }
+    fs.fstat(fd, doSendFileFD.bind(this, options, fd, headers));
   }
   additionalHeaders(headers) {
     if (this.destroyed || this.closed || this.session === undefined) {
@@ -4033,17 +4010,6 @@ function assertSingleValueHeaders(headers) {
     if (seen === null) seen = new SafeSet();
     seen.add(lower);
   }
-}
-
-// Renders a received value the way node's determineSpecificType does for error messages.
-function receivedValueLabel(value) {
-  if (value === null) return "null";
-  if (typeof value === "object") return "an instance of " + (value.constructor?.name || "Object");
-  if (typeof value === "function") return `function ${value.name}`;
-  if (typeof value === "string") return `type string ('${value}')`;
-  if (typeof value === "symbol") return `type symbol (${String(value)})`;
-  if (typeof value === "number") return `type number (${String(value)})`;
-  return `type ${typeof value} (${JSON.stringify(value)})`;
 }
 
 function buildSensitiveNames(headers, sensitives) {
@@ -6860,9 +6826,8 @@ function performServerHandshake(socket, options = {}) {
   options = initializeOptions(options);
   return new ServerHttp2Session(socket, options, undefined);
 }
-function getDefaultSettings() {
-  // return default settings
-  return getUnpackedSettings();
+function getDefaultSettings(): any {
+  return { ...kDefaultSettings };
 }
 
 Object.defineProperty(connect, promisify.custom, {

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4116,20 +4116,27 @@ it("http2 stream.respondWithFD() reports a bad fd argument like node and accepts
     errors = collectInvalidArgTypeErrors(cases, value => stream.respondWithFD(value));
     stream.respondWithFD(fileHandle, { "content-type": "text/plain" });
   });
-  await new Promise(resolve => server.listen(0, resolve));
-  const client = http2.connect(`http://localhost:${server.address().port}`);
+  let client;
 
   try {
-    const req = client.request({ ":path": "/" });
-    const response = await new Promise((resolve, reject) => {
-      req.on("error", reject);
-      req.on("response", resolve);
-      req.end();
+    await new Promise((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, resolve);
     });
+    client = http2.connect(`http://localhost:${server.address().port}`);
+
+    const { promise: finished, resolve, reject } = Promise.withResolvers();
+    client.on("error", reject);
+    const req = client.request({ ":path": "/" });
+    req.on("error", reject);
+    let response;
+    req.on("response", headers => (response = headers));
     let body = "";
     req.setEncoding("utf8");
     req.on("data", chunk => (body += chunk));
-    await new Promise(resolve => req.on("end", resolve));
+    req.on("end", resolve);
+    req.end();
+    await finished;
 
     expect(errors).toEqual(
       cases.map(([, received]) => ({
@@ -4141,7 +4148,7 @@ it("http2 stream.respondWithFD() reports a bad fd argument like node and accepts
     expect(response[":status"]).toBe(200);
     expect(body).toBe("served from a FileHandle");
   } finally {
-    client.close();
+    client?.close();
     server.close();
     await fileHandle.close();
   }

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -1,4 +1,4 @@
-import { bunEnv, bunExe, isASAN, isCI, isDebug, nodeExe } from "harness";
+import { bunEnv, bunExe, isASAN, isCI, isDebug, nodeExe, tempDir } from "harness";
 import { createTest } from "node-harness";
 import { AsyncLocalStorage } from "node:async_hooks";
 import dc from "node:diagnostics_channel";
@@ -4070,6 +4070,83 @@ it("http2 stream.respond accepts raw-headers arrays; respondWithFD/respondWithFi
     server.close();
   }
 });
+
+// Rejected values paired with how node v26.3.0's ERR_INVALID_ARG_TYPE describes each of them.
+const invalidArgTypeCases = [
+  [1n, "type bigint (1n)"],
+  ["a".repeat(40), "type string ('aaaaaaaaaaaaaaaaaaaaaaaaa...')"],
+  ["it's", `type string ("it's")`],
+  [Object.create(null), "[Object: null prototype] {}"],
+  [undefined, "undefined"],
+  [null, "null"],
+  [true, "type boolean (true)"],
+  [{}, "an instance of Object"],
+  [new DataView(new ArrayBuffer(6)), "an instance of DataView"],
+];
+
+function collectInvalidArgTypeErrors(cases, invoke) {
+  return cases.map(([value]) => {
+    try {
+      invoke(value);
+      return "did not throw";
+    } catch (err) {
+      return { name: err.constructor.name, code: err.code, message: err.message };
+    }
+  });
+}
+
+it("http2 getUnpackedSettings() reports a bad buf argument like node", () => {
+  expect(collectInvalidArgTypeErrors(invalidArgTypeCases, value => http2.getUnpackedSettings(value))).toEqual(
+    invalidArgTypeCases.map(([, received]) => ({
+      name: "TypeError",
+      code: "ERR_INVALID_ARG_TYPE",
+      message: `The "buf" argument must be an instance of Buffer or TypedArray. Received ${received}`,
+    })),
+  );
+});
+
+it("http2 stream.respondWithFD() reports a bad fd argument like node and accepts a FileHandle", async () => {
+  using dir = tempDir("http2-respond-with-fd", { "body.txt": "served from a FileHandle" });
+  const fileHandle = await fs.promises.open(path.join(String(dir), "body.txt"), "r");
+  // Only a real FileHandle stands in for a number; node rejects other objects carrying an fd property.
+  const cases = [...invalidArgTypeCases, [{ fd: fileHandle.fd }, "an instance of Object"]];
+  let errors;
+  const server = http2.createServer();
+  server.on("stream", stream => {
+    errors = collectInvalidArgTypeErrors(cases, value => stream.respondWithFD(value));
+    stream.respondWithFD(fileHandle, { "content-type": "text/plain" });
+  });
+  await new Promise(resolve => server.listen(0, resolve));
+  const client = http2.connect(`http://localhost:${server.address().port}`);
+
+  try {
+    const req = client.request({ ":path": "/" });
+    const response = await new Promise((resolve, reject) => {
+      req.on("error", reject);
+      req.on("response", resolve);
+      req.end();
+    });
+    let body = "";
+    req.setEncoding("utf8");
+    req.on("data", chunk => (body += chunk));
+    await new Promise(resolve => req.on("end", resolve));
+
+    expect(errors).toEqual(
+      cases.map(([, received]) => ({
+        name: "TypeError",
+        code: "ERR_INVALID_ARG_TYPE",
+        message: `The "fd" argument must be of type number or an instance of FileHandle. Received ${received}`,
+      })),
+    );
+    expect(response[":status"]).toBe(200);
+    expect(body).toBe("served from a FileHandle");
+  } finally {
+    client.close();
+    server.close();
+    await fileHandle.close();
+  }
+});
+
 it("http2 client.request() on a destroyed or closed session uses the right error codes", async () => {
   // Node: destroyed session -> ERR_HTTP2_INVALID_SESSION,
   // closed (GOAWAY-pending) session -> ERR_HTTP2_GOAWAY_SESSION.


### PR DESCRIPTION
### Problem

- `require("node:http2").getUnpackedSettings(1n)` throws a plain `TypeError: JSON.stringify cannot serialize BigInt.` with no `code`; node throws `ERR_INVALID_ARG_TYPE` (`... Received type bigint (1n)`). `Http2Stream#respondWithFD(1n)` does the same.
- The other `Received ...` renderings at those two sites also diverge from node v26.3.0:

  | input | bun 1.4.0 | node v26.3.0 |
  | --- | --- | --- |
  | `"a".repeat(40)` | all 40 characters | `type string ('aaaaaaaaaaaaaaaaaaaaaaaaa...')` |
  | `"it's"` | `type string ('it's')` | `type string ("it's")` |
  | `Object.create(null)` | `an instance of Object` | `[Object: null prototype] {}` |
  | `undefined` (respondWithFD) | `type undefined (undefined)` | `undefined` |
  | `undefined` (getUnpackedSettings) | returns the default settings | throws `ERR_INVALID_ARG_TYPE` |

- Cause: `src/js/node/http2.ts` builds these two messages by hand (`new TypeError(...)` + `err.code = ...`) through a private `receivedValueLabel()` helper (`http2.ts:4039` on main) that approximates node's `determineSpecificType`. The helper was added in #31584 because at the time the shared `$ERR_INVALID_ARG_TYPE` rendered an expected-type array as `of type Buffer or TypedArray`; #32626 taught the native array overload node's grouping a week later, so the helper has only been a source of divergence since.
- `respondWithFD()` also accepted any object with a numeric `fd` property in place of a `FileHandle` (node checks `instanceof FileHandle`), and the `fd instanceof FileHandle` branch further down the method was unreachable because the descriptor is unwrapped at the top.

### Fix

- `getUnpackedSettings()` throws `$ERR_INVALID_ARG_TYPE("buf", ["Buffer", "TypedArray"], buf)` and `respondWithFD()` throws `$ERR_INVALID_ARG_TYPE("fd", ["number", "FileHandle"], fd)`: the same argument lists node's `lib/internal/http2/core.js` passes to its `ERR_INVALID_ARG_TYPE`. `receivedValueLabel()` is deleted.
- Correct because the message now comes from the same renderer every other node-style validator in bun uses: the array overload in `ErrorCode.cpp` produces node's `must be an instance of Buffer or TypedArray` / `must be of type number or an instance of FileHandle` wording, and `determineSpecificType` produces node's `Received ...` suffix (bigint, truncation, quote switching, null-prototype inspect fallback, `undefined`). With this change the output of both sites matches node v26.3.0 for every value I tried except `-0` and an object whose `constructor` has no `name`, which are rows inside the native renderer itself and are being fixed there, not in http2.
- `getUnpackedSettings(undefined)` now throws like node; `getDefaultSettings()` (the only caller that relied on the shortcut) returns `{ ...kDefaultSettings }` directly, so its result is unchanged (the existing `getDefaultSettings` test pins it).
- `respondWithFD()` unwraps `fd` only when it is a real `FileHandle` (`instanceof`, as node does); other objects now get the `ERR_INVALID_ARG_TYPE` above. The now-dead second `instanceof` branch is removed; `fd` is always a number by that point. The `FileHandle` class was already imported for that branch.
- Verified with the two tests added to `test/js/node/http2/node-http2.test.js` (`getUnpackedSettings() reports a bad buf argument like node`, `respondWithFD() reports a bad fd argument like node and accepts a FileHandle`): both fail on the released binary (`USE_SYSTEM_BUN=1`) and pass with `bun bd test`. Expected strings are node v26.3.0's output; the second test also serves a file through a `fs.promises` `FileHandle` to cover the accept path.
- Also ran with the debug build: the vendored `test-http2-getpackedsettings.js`, `test-http2-respond-file-fd*.js` (5 files), `test-http2-respond-file-filehandle.js`, `test-http2-util-asserts.js`, and the 15 vendored http2 tests that read `getDefaultSettings`/`localSettings`/`remoteSettings`, all passing; the rest of `node-http2.test.js` passes apart from the pre-existing `DATA payload survives ...` block, whose 9 concurrent subprocess cases sit at the 5s default timeout on a loaded debug+ASAN machine and fail identically with this change stashed.

### Background

- `$ERR_INVALID_ARG_TYPE(name, expected, value)` is the builtin-JS entry point to bun's shared node-error machinery (`src/jsc/bindings/ErrorCode.cpp`). It creates the `TypeError` with `code` set, and when `expected` is an array it ports node's list rendering: entries that are primitive type names become `of type a or b`, capitalized names become `an instance of X or Y`, and the two groups are joined with `or`.
- `determineSpecificType` is bun's native port of the node helper of the same name that produces the `Received ...` part of these messages (`type bigint (1n)`, `an instance of Array`, a 25-character string prefix plus `...`, double quotes when the string contains a single quote, a `util.inspect` fallback for objects without a usable constructor). Every validator in bun that goes through the shared machinery gets it for free; the deleted helper was a second, partial implementation of it.
- `FileHandle` is the object `fs.promises.open()` resolves to; `node:fs/promises` exposes the class to other builtins through its private `$data` export, which is how `http2.ts` already imported it.

<details>
<summary>Probe output (bun 1.4.0 vs node v26.3.0, both sites)</summary>

Values: `1n`, `"a".repeat(40)`, `"it's"`, `Object.create(null)`, `{ constructor: {} }`, `undefined`, `null`, `true`, `""`, `[]`, `{}`, `Symbol("s")`, named and anonymous functions, a `DataView`, a `Map`, `{ fd: "3" }`, `-0`, `1`.

Before, rows differing from node (same at both sites): `1n` (`undefined: JSON.stringify cannot serialize BigInt.`), the 40-character string (not truncated), `"it's"` (single-quoted), `Object.create(null)` and `{ constructor: {} }` (`an instance of Object`), `undefined` (`type undefined (undefined)` for `respondWithFD`, no throw for `getUnpackedSettings`), `-0` (`type number (0)`).

After: only `{ constructor: {} }` (`an instance of undefined`) and `-0` (`type number (0)`) still differ; both come from the native renderer and are outside this change.

</details>
