### PR TITLE
require(): retry a module that threw, as Node does for CommonJS

### DIFF
--- a/src/jsc/bindings/JSCommonJSExtensions.cpp
+++ b/src/jsc/bindings/JSCommonJSExtensions.cpp
@@ -264,6 +264,8 @@ JSC::EncodedJSValue builtinLoader(JSC::JSGlobalObject* globalObject, JSC::CallFr
     res.success = false;
     memset(&res.result, 0, sizeof res.result);
 
+    evictFailedModuleRegistryEntry(global, specifierWtfString);
+
     JSValue result = fetchCommonJSModuleNonBuiltin<true>(
         global->bunVM(),
         vm,

--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -29,6 +29,7 @@
 
 #include <JavaScriptCore/JSModuleLoader.h>
 #include <JavaScriptCore/ModuleRegistryEntry.h>
+#include <JavaScriptCore/CyclicModuleRecord.h>
 #include <JavaScriptCore/Completion.h>
 #include <JavaScriptCore/JSModuleNamespaceObject.h>
 #include <JavaScriptCore/JSMap.h>
@@ -655,6 +656,46 @@ void evaluateCommonJSCustomExtension(
     RETURN_IF_EXCEPTION(scope, );
 }
 
+static bool moduleRegistryEntryFailed(JSC::ModuleRegistryEntry* entry)
+{
+    switch (entry->status()) {
+    case JSC::ModuleRegistryEntry::Status::FetchFailed:
+    case JSC::ModuleRegistryEntry::Status::InstantiationFailed:
+    case JSC::ModuleRegistryEntry::Status::EvaluationFailed:
+        return true;
+    default:
+        break;
+    }
+    // A module that threw while being evaluated as a dependency of some other
+    // module's graph keeps Status::Fetched; the error is recorded on its record.
+    auto* record = dynamicDowncast<JSC::CyclicModuleRecord>(entry->record());
+    return record && record->evaluationError();
+}
+
+// A require() that throws removes the module from the require map
+// (finishRequireWithError, the catch blocks in CommonJS.ts) so that, as in Node,
+// the next require() runs the file again. If that load went through the module
+// registry (a file the transpiler classified as ESM, a CommonJS file first
+// reached via import(), a plugin module), the registry still holds the entry
+// with the error stored on it, and JSModuleLoader::loadModule settles every
+// later load of that key with the stored error without running anything. Only
+// failed entries are dropped: an entry that is still loading or loaded fine may
+// belong to an in-flight import(), and dropping it would evaluate that module
+// twice.
+void evictFailedModuleRegistryEntry(Zig::GlobalObject* globalObject, const WTF::String& specifier)
+{
+    auto* moduleLoader = globalObject->moduleLoader();
+    auto key = JSC::Identifier::fromString(globalObject->vm(), specifier);
+    auto* entry = moduleLoader->registryEntry(key);
+    if (!entry || !moduleRegistryEntryFailed(entry))
+        return;
+
+    // JSModuleLoader::visitChildrenImpl iterates these maps on the GC thread
+    // under cellLock(); take the same lock so the removal can't race it.
+    WTF::Locker locker { moduleLoader->cellLock() };
+    moduleLoader->removeEntry(key);
+}
+
 JSValue fetchCommonJSModule(
     Zig::GlobalObject* globalObject,
     JSCommonJSModule* target,
@@ -674,6 +715,8 @@ JSValue fetchCommonJSModule(
     ResolvedSourceCodeHolder sourceCodeHolder(res);
 
     BunString specifier = Bun::toString(specifierWtfString);
+
+    evictFailedModuleRegistryEntry(globalObject, specifierWtfString);
 
     bool wasModuleMock = false;
 

--- a/src/jsc/bindings/ModuleLoader.h
+++ b/src/jsc/bindings/ModuleLoader.h
@@ -105,6 +105,11 @@ JSValue fetchCommonJSModule(
     BunString* referrer,
     BunString* typeAttribute);
 
+// Call before loading a module on behalf of require(): drops the module
+// registry entry for `specifier` if an earlier load of it failed, so the module
+// is evaluated again instead of rethrowing the stored error.
+void evictFailedModuleRegistryEntry(Zig::GlobalObject* globalObject, const WTF::String& specifier);
+
 template<bool isExtension>
 JSValue fetchCommonJSModuleNonBuiltin(
     void* bunVM,

--- a/test/cli/test/isolation.test.ts
+++ b/test/cli/test/isolation.test.ts
@@ -995,3 +995,42 @@ test.concurrent("--isolate: require(esm) caches a BunTranspiledModule SourceProv
     expect(exitCode, `run ${run}`).toBe(0);
   }
 });
+
+// A module that throws while being evaluated is retried by the next require().
+// Under --isolate the first attempt leaves its SourceProvider in the cache, so
+// the retry is served from there; it still has to get rid of the failed module
+// registry entry the first attempt left behind, or it rethrows the stored error.
+test.concurrent("--isolate: require() retries a cached module that threw", async () => {
+  using dir = tempDir("isolate-require-retry", {
+    // No CommonJS or ES module syntax on purpose: such files load through the
+    // module registry.
+    "flaky.js": `
+      globalThis.evaluations = (globalThis.evaluations ?? 0) + 1;
+      if (globalThis.evaluations === 1) throw new Error("fail " + globalThis.evaluations);
+    `,
+    "a.test.ts": `
+      import { test, expect } from "bun:test";
+      import { isolatedModuleCacheSourceType } from "bun:internal-for-testing";
+
+      test("second require() evaluates the module again", () => {
+        const path = require.resolve("./flaky.js");
+        expect(() => require("./flaky.js")).toThrow("fail 1");
+        expect(isolatedModuleCacheSourceType(path)).not.toBeNull();
+        require("./flaky.js");
+        expect(globalThis.evaluations).toBe(2);
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--isolate", "./a.test.ts"],
+    env: { ...bunEnv, BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING: "1" },
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toContain("1 pass");
+  expect(stderr).toContain("0 fail");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/resolve/require.test.ts
+++ b/test/js/bun/resolve/require.test.ts
@@ -1,4 +1,4 @@
-import { bunRun, tempDirWithFiles } from "harness";
+import { bunRun, tempDir, tempDirWithFiles } from "harness";
 import fs from "node:fs";
 import path from "node:path";
 const fixture = (...segs: string[]): string => path.join(import.meta.dirname, "fixtures", "require", ...segs);
@@ -43,6 +43,187 @@ describe("require(specifier)", () => {
     it.todo("require('*.html') synchronously produces a string");
     it.todo("require('*.wasm') produces a WebAssembly.Module");
     it.todo("require('*.db') wraps a sqlite file in a Database object and exports it");
+  });
+
+  // Like Node, a module that throws while it is being evaluated is dropped from
+  // the cache, and the next require() of it runs the file again. The fixtures
+  // below have no CommonJS or ES module syntax on purpose: Bun loads such files
+  // through the ES module registry, which also holds CommonJS files that were
+  // first reached via import() and modules provided by plugins. A failed entry
+  // in that registry used to make every later require() rethrow the stored
+  // error without running the module again.
+  describe.concurrent("when the module throws while being evaluated", () => {
+    // Throws the first `failures` times it is evaluated and succeeds afterwards.
+    const flakyModule = (failures: number) => /* js */ `
+      globalThis.evaluations = (globalThis.evaluations ?? 0) + 1;
+      if (globalThis.evaluations <= ${failures}) throw new Error("fail " + globalThis.evaluations);
+    `;
+
+    async function runEntry(files: Record<string, string>) {
+      using dir = tempDir("require-throwing-module", files);
+      const { stdout, stderr, exitCode } = await bunRun(path.join(String(dir), "entry.js"));
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+      return JSON.parse(stdout);
+    }
+
+    it("the next require() evaluates it again until it succeeds", async () => {
+      const result = await runEntry({
+        "flaky.js": flakyModule(2),
+        "entry.js": /* js */ `
+          const id = require.resolve("./flaky.js");
+          const attempts = [];
+          for (let i = 0; i < 4; i++) {
+            let outcome;
+            try {
+              require("./flaky.js");
+              outcome = "ok";
+            } catch (e) {
+              outcome = e.message;
+            }
+            attempts.push({ outcome, cached: id in require.cache });
+          }
+          console.log(JSON.stringify({ attempts, evaluations: globalThis.evaluations }));
+        `,
+      });
+      expect(result).toEqual({
+        attempts: [
+          { outcome: "fail 1", cached: false },
+          { outcome: "fail 2", cached: false },
+          { outcome: "ok", cached: true },
+          { outcome: "ok", cached: true },
+        ],
+        evaluations: 3,
+      });
+    });
+
+    it("require() evaluates a CommonJS module again after import() of it failed", async () => {
+      const result = await runEntry({
+        "flaky.js": flakyModule(1) + `module.exports = { attempt: globalThis.evaluations };`,
+        "entry.js": /* js */ `
+          (async () => {
+            let importOutcome, requireOutcome;
+            try {
+              await import("./flaky.js");
+              importOutcome = "ok";
+            } catch (e) {
+              importOutcome = e.message;
+            }
+            try {
+              requireOutcome = require("./flaky.js");
+            } catch (e) {
+              requireOutcome = e.message;
+            }
+            console.log(JSON.stringify({ importOutcome, requireOutcome, evaluations: globalThis.evaluations }));
+          })();
+        `,
+      });
+      expect(result).toEqual({ importOutcome: "fail 1", requireOutcome: { attempt: 2 }, evaluations: 2 });
+    });
+
+    it("require() evaluates it again after it threw as a dependency of an imported module", async () => {
+      const result = await runEntry({
+        "flaky.js": flakyModule(1),
+        "parent.mjs": `import "./flaky.js";`,
+        "entry.js": /* js */ `
+          (async () => {
+            let importOutcome, requireOutcome;
+            try {
+              await import("./parent.mjs");
+              importOutcome = "ok";
+            } catch (e) {
+              importOutcome = e.message;
+            }
+            try {
+              require("./flaky.js");
+              requireOutcome = "ok";
+            } catch (e) {
+              requireOutcome = e.message;
+            }
+            console.log(JSON.stringify({ importOutcome, requireOutcome, evaluations: globalThis.evaluations }));
+          })();
+        `,
+      });
+      expect(result).toEqual({ importOutcome: "fail 1", requireOutcome: "ok", evaluations: 2 });
+    });
+
+    it("a module provided by a plugin is evaluated again by the next require()", async () => {
+      const result = await runEntry({
+        "entry.js": /* js */ `
+          Bun.plugin({
+            name: "flaky virtual module",
+            setup(build) {
+              build.module("virtual:flaky", () => ({
+                loader: "js",
+                contents: ${JSON.stringify(flakyModule(1) + `export const attempt = globalThis.evaluations;`)},
+              }));
+            },
+          });
+          const attempts = [];
+          for (let i = 0; i < 2; i++) {
+            try {
+              attempts.push(require("virtual:flaky").attempt);
+            } catch (e) {
+              attempts.push(e.message);
+            }
+          }
+          console.log(JSON.stringify({ attempts, evaluations: globalThis.evaluations }));
+        `,
+      });
+      expect(result).toEqual({ attempts: ["fail 1", 2], evaluations: 2 });
+    });
+
+    it("calling require.extensions['.js'] directly evaluates it again", async () => {
+      const result = await runEntry({
+        "flaky.js": flakyModule(1),
+        "entry.js": /* js */ `
+          const Module = require("node:module");
+          const filename = require.resolve("./flaky.js");
+          const attempts = [];
+          for (let i = 0; i < 2; i++) {
+            const mod = new Module(filename);
+            mod.filename = filename;
+            try {
+              require.extensions[".js"](mod, filename);
+              attempts.push("ok");
+            } catch (e) {
+              attempts.push(e.message);
+            }
+          }
+          console.log(JSON.stringify({ attempts, evaluations: globalThis.evaluations }));
+        `,
+      });
+      expect(result).toEqual({ attempts: ["fail 1", "ok"], evaluations: 2 });
+    });
+
+    // Only require() retries. An ES module that failed stays failed for
+    // import(), which rejects with the error the module threw, as in Node.
+    it("import() of an ES module that failed under require() still rejects with the original error", async () => {
+      const result = await runEntry({
+        "bad.mjs": flakyModule(Infinity),
+        "entry.js": /* js */ `
+          (async () => {
+            let requireError, importError;
+            try {
+              require("./bad.mjs");
+            } catch (e) {
+              requireError = e;
+            }
+            try {
+              await import("./bad.mjs");
+            } catch (e) {
+              importError = e;
+            }
+            console.log(JSON.stringify({
+              requireError: requireError.message,
+              importRejectsWithSameError: importError === requireError,
+              evaluations: globalThis.evaluations,
+            }));
+          })();
+        `,
+      });
+      expect(result).toEqual({ requireError: "fail 1", importRejectsWithSameError: true, evaluations: 1 });
+    });
   });
 
   describe("require.main", () => {


### PR DESCRIPTION
### Problem

- `require()` of a module that threw while it was evaluated never runs it again. Every later `require()` rethrows the first exception object, though `require.cache` no longer lists the module. Node evaluates the file again on each `require()` until one succeeds.
- Affected: every `require()` that goes through the module registry: a file with no module syntax at all (ESM to Bun, CommonJS to Node), a CommonJS file whose first load was a failed `import()`, a `Bun.plugin` module.
- Cause: the failure path only cleans the require map. The `ModuleRegistryEntry` keeps the error, and `JSModuleLoader::loadModule` replays it on every later load.

### Fix

- `evictFailedModuleRegistryEntry()` in `src/jsc/bindings/ModuleLoader.cpp` runs before a `require()` load. It removes the entry when the module threw (status `EvaluationFailed`, or `evaluationError()` on its record) and Node would run it as CommonJS: not `.mjs`/`.mts`, not under a `"type": "module"` package.json (`Bun__isESModuleByPathOrPackage` asks the resolver), no import, export, top-level await or import.meta, or no `JSModuleRecord` at all.
- An ES module that threw keeps its error, as in Node. A pending or loaded entry is never removed: it may belong to an in-flight `import()`, and removing it would evaluate the module twice (why #27288 was reverted).
- The `--isolate` source cache entry for the key is dropped with the registry entry, as `delete require.cache[key]` does. So the retry reads the file from disk again in every mode.
- Verified: `test/js/bun/resolve/require.test.ts` (9 of 15 new tests fail on main) and `test/cli/test/isolation.test.ts`. 70 of 77 cases equal Node v26.3.0 (main: 53), none is worse than main. Also the `resolve`, `plugin` and `node/module` suites.

### Background

- Require map: the map behind `require.cache`. `require()` inserts the module before it evaluates it and removes it again if evaluation throws.
- Module registry: JSC's map from specifier to `ModuleRegistryEntry`. Bun routes `require()` through it for everything that is not plain CommonJS. A record that failed is never evaluated again (ES spec).
- Module classification: a file with no `module`, `exports` or `require` and no `import`/`export` is ESM in Bun and CommonJS in Node.

<details><summary>Notes</summary>

Repro:

```sh
printf 'console.log("evaluating t2");\nthrow new Error("x2");\n' > t2.js
cat > twice.js <<'EOF'
function a() { try { require("./t2.js"); } catch (e) { console.log("a:", e.stack.split("\n")[1]); } }
function b() { try { require("./t2.js"); } catch (e) { console.log("b:", e.stack.split("\n")[1]); } }
a(); b();
console.log("cached?", Object.keys(require.cache).filter(k => k.includes("t2.js")));
EOF
bun twice.js
```

bun 1.4.0 prints `evaluating t2` once and both `a:` and `b:` show `at a (...)`. Node, and bun with this change, print it twice and `b:` shows `at b (...)`.

`removeEntry()` takes the loader's cell lock itself since the WebKit upgrade. An earlier revision held that lock around the call and the second `require()` never returned.

Earlier shape of this PR: it also evicted `FetchFailed` and `InstantiationFailed` entries and did not check for ES module syntax, so `require()` of a real `.mjs` that threw was retried too. That is gone. A `FetchFailed` entry is dropped by the loader itself, and the `ModuleLoadTopRejected` reaction one microtask after a top-level `import()` failure looks the key up again, so evicting in that window would poison the retry's entry (#39204). The check for ES module syntax reads the `JSModuleRecord` that JSC already parsed, so no new information has to travel from the transpiler.

Comparison with Node v26.3.0, one child process per case: 11 file kinds (no module syntax `.js`/`.ts`, `export` in `.js`/`.mjs`/`.ts`, CommonJS `.js`/`.cjs`, JSON, a syntax error, a file with no module syntax as a dependency of a CommonJS parent and of an `.mjs` parent) times 7 load sequences (`require()` fails then `require()`, with and without a fix on disk or `delete require.cache[path]` in between, `import()` fails then `require()`, `require()` succeeds then the file changes, `require()` fails then `import()`). main equals Node in 53 of 77 cases, this branch in 70. The 17 that changed are the cases this PR is about. The 7 left are identical on main: `delete require.cache[path]` of a real ES module (4), `import()` after a failed `require()` of a file with no module syntax (2), one JSON case.

Classification order, as in Node: the extension (`.mjs`, `.mts`, with a `?query` stripped), then the nearest package.json `"type"` of a `.js`/`.ts` file (`Bun__isESModuleByPathOrPackage` in `jsc_hooks.rs` runs the resolver's `read_dir_info` walk and reads `package_json_for_module_type`, the nearest package.json named or not, as the bundler does), then the record's syntax. The provider's `ResolvedSourceTag` is not used: the runtime transpiler cache-hit and watcher branches do not set it, and a record parsed from a Bake provider is not a `Zig::SourceProvider`.

Known limit of the syntax check: a `.js` file whose only module syntax does not reach the record is retried here where Node keeps the error. That is `export {}`, a type-only import, or a top-level `let`/`const`/`class` named `require`, `module`, `exports`, `__dirname` or `__filename` (Node counts that redeclaration as ES module syntax). Telling it apart needs one more bit from the transpiler, carried through the runtime transpiler cache. An import that the transpiler injects (the automatic JSX runtime) has the opposite effect: the record looks like an ES module, so such a file keeps the stale error, as on main. A bundled `require()` (`bun build`, `--compile`) does not go through the runtime registry and is unchanged.

Known window: `ModuleLoadTopRejected` runs one microtask after a top-level `import()` fails and looks the key up by name. A `require()` of the same key inside that window runs the file again and gets a fresh entry, which the reaction then marks with the first error. Closing it needs a pending set on the loader. Left as is.

`import()` after a failed `require()`: still rejects with the stored error for an ES module. For a file Node runs as CommonJS, a later `require()` that succeeds makes a following `import()` resolve to that namespace. Node keeps rejecting there because its ESM cache keeps the failed job.

Other suites run with the debug build: `test/regression/issue/{24387,22743,23139,30493}.test.ts`, `test/js/bun/resolve/require-esm-transitive-tla.test.ts` and Node's `test-require-exceptions.js`. No new failures.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 2 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 failed, 3 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/cli/test/isolation.test.ts test/js/bun/resolve/require.test.ts
bun test v1.4.3 (367d939d9)

test/cli/test/isolation.test.ts:
(pass) bun test --isolate > without --isolate, leaked global is visible to next file [430.33ms]
(pass) bun test --isolate > with --isolate, each file gets a fresh global [382.41ms]
(pass) bun test --isolate > with --isolate, --preload re-runs in each file's fresh global [390.74ms]
(pass) bun test --isolate > without --isolate, --preload still runs once (regression) [459.88ms]
(pass) bun test --isolate > with --isolate, module state is not shared between files [418.85ms]
(pass) bun test --isolate > with --isolate, a file's process.env writes with native side effects are undone before the next file [1445.27ms]
(pass) bun test --isolate > with --isolate, a file's process.chdir() is undone before the next file [1500.30ms]
(pass) bun test --isolate > cached module records keep the namespace a plugin onResolve gives an import (--isolate) [716.28ms]
(pass) bun test --isolate > with --isolate, cached module records k
... (truncated)

release without fix: 4 failed, 3 skipped
bun test v1.4.3-canary.1 (db728c77f)

test/cli/test/isolation.test.ts:
(pass) bun test --isolate > without --isolate, leaked global is visible to next file [66.73ms]
(pass) bun test --isolate > with --isolate, each file gets a fresh global [66.62ms]
(pass) bun test --isolate > without --isolate, --preload still runs once (regression) [58.49ms]
(pass) bun test --isolate > with --isolate, module state is not shared between files [61.86ms]
(pass) bun test --isolate > with --isolate, --preload re-runs in each file's fresh global [69.71ms]
(pass) bun test --isolate > cached module records keep the namespace a plugin onResolve gives an import (--isolate) [65.75ms]
(pass) bun test --isolate > with --isolate, cached module records keep short, Latin-1 and UTF-16 names [74.12ms]
(pass) bun test --isolate > cached module records keep the namespace a plugin onResolve gives an import (--parallel worker) [71.83ms]
(pass) bun test --isolate > with --isolate, what a leaked listener's close handler opens is closed before next file [74.00ms]
(pass) bun test --isolate > with --isolate, the default DNS resolver answers in every file, not only the first [73.55ms]
(pass) bun test --isola
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 3 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/cli/test/isolation.test.ts test/js/bun/resolve/require.test.ts
bun test v1.4.3 (367d939d9)

test/cli/test/isolation.test.ts:
(pass) bun test --isolate > without --isolate, leaked global is visible to next file [417.16ms]
(pass) bun test --isolate > with --isolate, each file gets a fresh global [358.91ms]
(pass) bun test --isolate > with --isolate, --preload re-runs in each file's fresh global [374.51ms]
(pass) bun test --isolate > without --isolate, --preload still runs once (regression) [534.88ms]
(pass) bun test --isolate > with --isolate, module state is not shared between files [311.10ms]
(pass) bun test --isolate > cached module records keep the namespace a plugin onResolve gives an import (--isolate) [579.64ms]
(pass) bun test --isolate > with --isolate, a file's process.chdir() is undone before the next file [1585.18ms]
(pass) bun test --isolate > with --isolate, a file's process.env writes with native side effects are undone before the next file [1583.86ms]
(pass) bun test --isolate > with --isolate, cached module records k
... (truncated)

release with fix: 3 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 694ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/10] cxx obj/unified/UnifiedSource-src_jsc_bindings-2.cpp.o
[2/10] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[3/10] gen generated_host_exports.rs
generated_host_exports.rs: 121 exports (host=5, lazy=10, generic=106, rust=0); 245 extern-C blocks audited
[4/10] gen cpp.rs (cppbind)
[4/10] cargo bun_runtime → libbun_runtime.a
[1m[33mwarning[0m[1m: binary `bun_shim_impl` should have a kebab-case name[0m
   [1m[94m|[0m
[1m[94m 1[0m [1m[94m|[0m /workspace/bun/build/release/rust-target/.../bun_shim_impl
   [1m[94m|[0m                                              [1m[33m^^^^^^^^^^^^^[0m
   [1m[94m|[0m
   [1m[94m= [0m[1mnote[0m: `cargo::non_kebab_case_bins` is set to `warn` by default
[1m[96mhelp[0m: to change the binary name to `bun-shim-impl`, convert `bin.name`
  [1m[94m--> [0msrc/install/windows-shim/Cargo.toml:41:8
   [1m[94m|[0m
[1m[94m41[0m [91m- [0mname = [91m"bun_shim_impl"[0m
[1m[94m41[0m [92m+ [0mname = [92m"bun-shim-impl"[0m
   [1m[94
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/ModuleLoader.cpp   |  50 +++++++
 src/runtime/jsc_hooks.rs            |  37 +++++
 test/cli/test/isolation.test.ts     |  39 +++++
 test/js/bun/resolve/require.test.ts | 286 +++++++++++++++++++++++++++++++++++-
 4 files changed, 411 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 3 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/jsc/bindings/ModuleLoader.cpp        5      7     33
src/runtime/jsc_hooks.rs                 1      1     32
test/cli/test/isolation.test.ts          1      1     14
test/js/bun/resolve/require.test.ts      1      2     27
```

</details>

**root cause** · written by the author bot

When a CommonJS module threw during evaluation, Bun left the failed entry in the JSC module registry, so subsequent require() calls returned the cached error instead of re-evaluating the file as Node does. The fix makes the CommonJS load paths evict a registry entry that carries an evaluation error before loading, but only when the module is classified as CommonJS by extension and by the nearest package.json "type" field via the resolver. Failed ES module entries are preserved, so import() semantics and in-flight imports are unaffected while require() of a fixed CommonJS module now retries …

<!-- robobun:evidence:end -->





