### PR TITLE
install: drop the duplicated warn: label from the verbose tarball retry notice

### DIFF
--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -674,7 +674,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                                 manager.log_mut(),
                                 None,
                                 bun_ast::Loc::EMPTY,
-                                "<r><yellow>warn:<r> {} downloading tarball <b>{}@{}<r>. Retrying {}/{}...",
+                                "{} downloading tarball <b>{}@{}<r>. Retrying {}/{}...",
                                 bstr::BStr::new(err.name().as_bytes()),
                                 bstr::BStr::new(extract.name.slice()),
                                 extract

--- a/test/cli/install/bun-install-retry.test.ts
+++ b/test/cli/install/bun-install-retry.test.ts
@@ -232,6 +232,48 @@ it("retries a tarball whose redirect target 500s once", async () => {
   });
 });
 
+// The retry notice is added to the log as a warning, and the log printer
+// prefixes it with `warn: ` when it prints it. The message itself used to carry
+// a second `warn: `, so every retry printed as `warn: warn: ...`.
+it("prints each verbose tarball retry as a single warn: line", async () => {
+  setHandler(async request => {
+    const { pathname } = new URL(request.url);
+    if (pathname === "/BaR") {
+      return Response.json({
+        name: "BaR",
+        "dist-tags": { latest: "0.0.2" },
+        versions: {
+          "0.0.2": { name: "BaR", version: "0.0.2", dist: { tarball: `${root_url}/BaR-0.0.2.tgz` } },
+        },
+      });
+    }
+    if (pathname === "/BaR-0.0.2.tgz") {
+      return new Response("no", { status: 500 });
+    }
+    return new Response("unexpected", { status: 404 });
+  });
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { BaR: "0.0.2" } }),
+  );
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "install", "--verbose", "--no-progress", "--ignore-scripts"],
+    cwd: package_dir,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env: { ...env, BUN_CONFIG_HTTP_RETRY_COUNT: "2" },
+  });
+  const [err, out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
+  expect(err.split(/\r?\n/).filter(line => line.includes("downloading tarball"))).toEqual([
+    "warn: TarballFailedToDownload downloading tarball BaR@0.0.2. Retrying 1/2...",
+    "warn: TarballFailedToDownload downloading tarball BaR@0.0.2. Retrying 2/2...",
+  ]);
+  expect(err).toContain(`error: GET ${root_url}/BaR-0.0.2.tgz - 500`);
+  expect(out).not.toContain("installed");
+  expect(exitCode).toBe(1);
+});
+
 it("retries on 500", async () => {
   const urls: string[] = [];
   setHandler(dummyRegistry(urls, undefined, 4));


### PR DESCRIPTION
### Problem
- `bun install --verbose` prints every tarball download retry with the label doubled: `warn: warn: TarballFailedToDownload downloading tarball BaR@0.0.2. Retrying 1/5...` (one such line per retry).
- The notice is added with `add_warning_pretty!` in `src/install/PackageManager/runTasks.rs:677`, and its template starts with `<r><yellow>warn:<r> `. The log printer (`Msg::write_format` in `src/ast/lib.rs`) already writes `warn: ` in front of every warning it prints, so the label comes out twice.
- Both retry notices were added with the inline label in #2536. #9143 removed it from the manifest one (that one prints correctly today: `warn: HTTPError downloading package manifest BaR. Retry 1/5...`); the tarball one was missed and the Rust port kept it.

### Fix
- Remove the leading `<r><yellow>warn:<r> ` from the tarball retry template. The rest of the message and its arguments are unchanged.
- The label belongs to the printer, which adds it for every message: this was the only message in `src/` passed to `add_warning_pretty!`/`add_error_pretty!` with a label of its own, and it now matches the manifest retry notice and the non-retry tarball warning/error a few lines below it.
- Test: `test/cli/install/bun-install-retry.test.ts`, "prints each verbose tarball retry as a single warn: line". The registry answers the tarball with a 500, `BUN_CONFIG_HTTP_RETRY_COUNT=2` keeps it to two retries, and the two `downloading tarball` lines on stderr are compared exactly. It fails on the released build (both lines start with `warn: warn:`) and passes with this change.
- The rest of the file still passes with the debug build (11 tests).

### Background
- Package manager diagnostics are not printed where they are produced. They are added to a `bun_ast::Log` as messages with a kind (`error`, `warn`, `note`) and printed later by `Msg::write_format`, which writes `<kind>: ` and then the message text. Message text is therefore written without a label.
- `add_warning_pretty!` is the call-site macro that converts the `<b>`/`<r>` color markup in a literal and adds the result to the log as a warning.
- The retry notice only exists under `--verbose`. The failure reported after the last retry (`error: GET <url> - 500`) is a separate message and is unchanged.
