### PR TITLE
install: format versions with the string buffer they were parsed from (bun outdated table, minimum-release-age messages)

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1082,7 +1082,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                                             format_args!(
                                                                 "Version \"{}@{}\" was published within minimum release age of {} seconds",
                                                                 bstr::BStr::new(package_name),
-                                                                find_result.version.fmt(this.lockfile.buffers.string_bytes.as_slice()),
+                                                                find_result.version.fmt(&loaded_manifest.as_ref().unwrap().string_buf),
                                                                 min_age_seconds,
                                                             ),
                                                         );
@@ -2498,7 +2498,10 @@ fn get_or_put_resolved_package(
                                 }
                                 dependency::version::Tag::Npm => {
                                     // SAFETY: `version.tag == Npm`.
-                                    let version_str = &version.npm().version.fmt(manifest_buf);
+                                    let version_str = &version
+                                        .npm()
+                                        .version
+                                        .fmt(this.lockfile.buffers.string_bytes.as_slice());
                                     bun_core::pretty_errorln!(
                                         "<d>[minimum-release-age]<r> <b>{}<r>@{}<r> selected <green>{}<r> instead of <yellow>{}<r> due to {}-second filter",
                                         bstr::BStr::new(package_name),

--- a/src/runtime/cli/outdated_command.rs
+++ b/src/runtime/cli/outdated_command.rs
@@ -473,7 +473,7 @@ impl OutdatedCommand {
                     write!(version_buf, "{}", uv.version.fmt(&manifest.string_buf))
                         .expect("OOM writing version");
                 } else {
-                    write!(version_buf, "{}", current_version.fmt(&manifest.string_buf))
+                    write!(version_buf, "{}", current_version.fmt(string_buf))
                         .expect("OOM writing version");
                 }
                 let update_version_len =
@@ -487,7 +487,7 @@ impl OutdatedCommand {
                     write!(version_buf, "{}", lv.version.fmt(&manifest.string_buf))
                         .expect("OOM writing version");
                 } else {
-                    write!(version_buf, "{}", current_version.fmt(&manifest.string_buf))
+                    write!(version_buf, "{}", current_version.fmt(string_buf))
                         .expect("OOM writing version");
                 }
                 let latest_version_len =

--- a/test/cli/install/minimum-release-age.test.ts
+++ b/test/cli/install/minimum-release-age.test.ts
@@ -793,6 +793,78 @@ describe("minimum-release-age", () => {
           return Response.json(packageData);
         }
 
+        // TEST PACKAGE 14: snapshot-package (prerelease tag longer than the 8 bytes a
+        // semver string stores inline; every published version is younger than the
+        // filters used in the tests, so nothing can be selected)
+        if (url.pathname === "/snapshot-package") {
+          const packageData = {
+            name: "snapshot-package",
+            "dist-tags": {
+              latest: "1.0.0",
+              snapshot: "1.0.0-snapshot.20240101",
+            },
+            versions: {
+              "1.0.0-snapshot.20240101": {
+                name: "snapshot-package",
+                version: "1.0.0-snapshot.20240101",
+                dist: {
+                  tarball: `${mockRegistryUrl}/snapshot-package/-/snapshot-package-1.0.0-snapshot.20240101.tgz`,
+                  integrity: "sha512-snapshot==",
+                },
+              },
+              "1.0.0": {
+                name: "snapshot-package",
+                version: "1.0.0",
+                dist: {
+                  tarball: `${mockRegistryUrl}/snapshot-package/-/snapshot-package-1.0.0.tgz`,
+                  integrity: "sha512-stable==",
+                },
+              },
+            },
+            time: {
+              "1.0.0-snapshot.20240101": daysAgo(2),
+              "1.0.0": daysAgo(1),
+            },
+          };
+
+          return Response.json(packageData);
+        }
+
+        // TEST PACKAGE 15: nightly-package (prerelease tags longer than the inline
+        // limit; the older nightly passes a 5 day filter, the newer one does not)
+        if (url.pathname === "/nightly-package") {
+          const packageData = {
+            name: "nightly-package",
+            "dist-tags": {
+              latest: "1.0.0-nightly.20240102",
+            },
+            versions: {
+              "1.0.0-nightly.20240101": {
+                name: "nightly-package",
+                version: "1.0.0-nightly.20240101",
+                dist: {
+                  tarball: `${mockRegistryUrl}/nightly-package/-/nightly-package-1.0.0-nightly.20240101.tgz`,
+                  integrity: "sha512-nightly1==",
+                },
+              },
+              "1.0.0-nightly.20240102": {
+                name: "nightly-package",
+                version: "1.0.0-nightly.20240102",
+                dist: {
+                  tarball: `${mockRegistryUrl}/nightly-package/-/nightly-package-1.0.0-nightly.20240102.tgz`,
+                  integrity: "sha512-nightly2==",
+                },
+              },
+            },
+            time: {
+              "1.0.0-nightly.20240101": daysAgo(30),
+              "1.0.0-nightly.20240102": daysAgo(1),
+            },
+          };
+
+          return Response.json(packageData);
+        }
+
         // TEST PACKAGE: many-versions-package (large version count, time entries
         // in reverse order relative to versions). Exercises the publish-time
         // index built during manifest parse.
@@ -1759,6 +1831,123 @@ describe("minimum-release-age", () => {
       expect(stdout).not.toContain("3.0.0");
       // Should show note about minimum release age
       expect(stdout.toLowerCase()).toContain("minimum release age");
+    });
+  });
+
+  // Semver strings longer than 8 bytes are not stored inline: they are offsets into
+  // the string buffer they were parsed from, and the lockfile and each package
+  // manifest have their own buffer. The prerelease tags of snapshot-package and
+  // nightly-package are long enough to live in those buffers, so these tests
+  // notice when a version is printed through the other side's buffer.
+  describe("prerelease tags longer than an inline semver string", () => {
+    const minimumReleaseAge = `${5 * SECONDS_PER_DAY}`;
+
+    async function run(cmd: string[], cwd: string, env: NodeJS.Dict<string> = bunEnv) {
+      await using proc = Bun.spawn({ cmd, cwd, env, stdout: "pipe", stderr: "pipe" });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { stdout, stderr, exitCode };
+    }
+
+    test("bun outdated sizes the Update and Latest columns by the current version when nothing passes the filter", async () => {
+      using dir = tempDir("outdated-long-prerelease", {
+        "package.json": JSON.stringify({
+          dependencies: {
+            // Already on their latest versions, so they stay out of the table. They
+            // sort before snapshot-package in bun.lock, so their names and tarball
+            // URLs fill the lockfile string buffer first and snapshot-package's
+            // prerelease tag ends up at an offset past the end of its (much smaller)
+            // manifest buffer. Closer to the start of the buffer, a read through the
+            // wrong buffer returns wrong bytes of the right length and the table
+            // lines up by accident.
+            "bugfix-package": "1.0.3",
+            "exact-threshold-package": "2.0.0",
+            "regular-package": "3.0.0",
+            "snapshot-package": "snapshot",
+          },
+        }),
+        ".npmrc": `registry=${mockRegistryUrl}`,
+      });
+
+      // Installed without the filter: the snapshot is only two days old.
+      const install = await run([bunExe(), "install", "--no-verify"], String(dir));
+      expect(install).toMatchObject({ exitCode: 0 });
+
+      // With the filter, neither the `snapshot` tag nor `latest` has a version old
+      // enough, so both columns fall back to showing the current version.
+      const { stdout, exitCode } = await run(
+        [bunExe(), "outdated", "--minimum-release-age", minimumReleaseAge],
+        String(dir),
+      );
+      const table = stdout.slice(stdout.indexOf("\n") + 1);
+      expect(table).toMatchInlineSnapshot(`
+        "|----------------------------------------------------------------------------------------------------|
+        | Package          | Current                 | Update                    | Latest                    |
+        |------------------|-------------------------|---------------------------|---------------------------|
+        | snapshot-package | 1.0.0-snapshot.20240101 | 1.0.0-snapshot.20240101 * | 1.0.0-snapshot.20240101 * |
+        |----------------------------------------------------------------------------------------------------|
+        Note: The * indicates that version isn't true latest due to minimum release age
+        "
+      `);
+      const widths = table
+        .split("\n")
+        .filter(line => line.startsWith("|"))
+        .map(line => line.length);
+      expect(new Set(widths).size).toBe(1);
+      expect(exitCode).toBe(0);
+    });
+
+    test("--verbose prints the dependency's range from the lockfile", async () => {
+      using dir = tempDir("verbose-long-prerelease", {
+        "package.json": JSON.stringify({
+          dependencies: { "nightly-package": "^1.0.0-nightly.20240101" },
+        }),
+        ".npmrc": `registry=${mockRegistryUrl}`,
+      });
+
+      const { stderr, exitCode } = await run(
+        [bunExe(), "install", "--minimum-release-age", minimumReleaseAge, "--no-verify", "--verbose"],
+        String(dir),
+      );
+      expect(stderr.split("\n").filter(line => line.includes("[minimum-release-age]"))).toEqual([
+        "[minimum-release-age] nightly-package@>=1.0.0-nightly.20240101 <2.0.0 selected 1.0.0-nightly.20240101 instead of 1.0.0-nightly.20240102 due to 432000-second filter",
+      ]);
+      expect(exitCode).toBe(0);
+    });
+
+    test("an exact pin rejected from a cached manifest is reported with the manifest's version", async () => {
+      using dir = tempDir("cached-manifest-long-prerelease", {
+        "package.json": JSON.stringify({
+          dependencies: { "nightly-package": "^1.0.0-nightly.20240101" },
+        }),
+        ".npmrc": `registry=${mockRegistryUrl}`,
+      });
+
+      // Puts nightly-package's manifest, including publish times, in the cache.
+      const first = await run(
+        [bunExe(), "install", "--minimum-release-age", minimumReleaseAge, "--no-verify"],
+        String(dir),
+      );
+      expect(first).toMatchObject({ exitCode: 0 });
+
+      await Bun.write(
+        `${dir}/package.json`,
+        JSON.stringify({ dependencies: { "nightly-package": "1.0.0-nightly.20240102" } }),
+      );
+      // BUN_MANIFEST_CACHE=1 treats every cached manifest as stale, which is how a
+      // manifest cached more than a few minutes ago looks. Exact pins are then
+      // checked against the cached manifest instead of a fresh download, and that
+      // check is what reports the rejected version.
+      const second = await run(
+        [bunExe(), "install", "--minimum-release-age", minimumReleaseAge, "--no-verify"],
+        String(dir),
+        { ...bunEnv, BUN_MANIFEST_CACHE: "1" },
+      );
+      expect(second.stderr).toMatchInlineSnapshot(`
+        "error: Version "nightly-package@1.0.0-nightly.20240102" was published within minimum release age of 432000 seconds
+        error: nightly-package@1.0.0-nightly.20240102 failed to resolve
+        "
+      `);
+      expect(second.exitCode).toBe(1);
     });
   });
 


### PR DESCRIPTION
### Problem
- `bun outdated --minimum-release-age` (or with `install.minimumReleaseAge` configured) prints a misaligned table when the installed version has a prerelease tag longer than 8 bytes (`1.0.0-snapshot.20240101`) and nothing passes the filter: the `Update`/`Latest` header cells are sized for `1.0.0- *` while the row prints `1.0.0-snapshot.20240101 *`, so the row overflows the table.
- Cause: the column width pass in `src/runtime/cli/outdated_command.rs:476` and `:490` formats `current_version`, which comes from the lockfile, against `manifest.string_buf`. The print pass (`:696`, `:727`) and the `Current` column (`:465`) use the lockfile buffer. Reading the tag out of the wrong buffer returns an empty slice once the offset is past the end of the manifest buffer (or unrelated bytes before that), so the width is computed from the wrong text.
- The same mistake exists in two other minimum-release-age messages:
  - `src/install/PackageManager/PackageManagerEnqueue.rs:2501`: the `--verbose` line `[minimum-release-age] pkg@<range> selected X instead of Y` formats the dependency's range (lockfile) against the manifest buffer. Observed: `nightly-package@>=1.0.0-ightly.20240101h <2.0.0`.
  - `src/install/PackageManager/PackageManagerEnqueue.rs:1085`: `Version "pkg@<version>" was published within minimum release age of N seconds` formats the manifest's version against the lockfile buffer. Observed: `Version "nightly-package@1.0.0-htly.20240101.tg"`.
- All three were like this in the Zig code as well; this is not a port regression.

### Fix
- Pass each value the buffer it was parsed from: the lockfile buffer for the current version and the dependency range, the manifest's `string_buf` for the manifest's version. No other logic changes.
- Correct because these are the buffers the same values are already formatted with a few lines away (`outdated_command.rs:465/696/727`, and `PackageManagerEnqueue.rs:2465-2467` passes the lockfile buffer for the same range when matching), so the fixed sites now agree with their neighbours.
- Tests: `test/cli/install/minimum-release-age.test.ts`, new `describe("prerelease tags longer than an inline semver string")`, one test per site. All three fail on the unfixed binary (misaligned table, `>=1.0.0-ightly.20240101h`, `1.0.0-htly.20240101.tg`) and pass with the fix; the whole file passes (52 tests) with the debug build.
  - The `bun outdated` test installs three up-to-date packages next to `snapshot-package` so that the prerelease tag's lockfile offset lies past the end of `snapshot-package`'s manifest buffer; with a nearly empty lockfile the wrong buffer yields wrong bytes of the right length and the table lines up by accident. The test asserts the exact table.
  - The cached-manifest test runs the second install with `BUN_MANIFEST_CACHE=1`, which makes bun treat the cached manifest as stale (the state any manifest is in five minutes after it was fetched) and take the exact-pin-from-cache path that prints the message.

### Background
- Semver values (`Version`, prerelease/build tags, `Group` ranges) do not own their text. Strings of up to 8 bytes are stored inline; longer ones are an offset and length into the string buffer they were parsed from, and every `.fmt(buf)` / `.slice(buf)` call has to be given that buffer.
- There are two buffers in these code paths: the lockfile's `buffers.string_bytes` (everything read from `bun.lock`/`package.json`: installed versions, dependency ranges) and each package manifest's `string_buf` (everything read from the registry: candidate versions). `slice` is bounds-checked, so a wrong buffer produces garbage or an empty string rather than a crash, which is why this only shows up as misaligned or mangled output.
- `minimum-release-age` is what makes the `bun outdated` fallback branches reachable: without it, `latest` always resolves and `update` only fails when the installed version was unpublished.

<details>
<summary>Related sites found while grepping for the same pattern, intentionally not in this PR</summary>

These have different triggers and need their own fixtures, so they are being tracked separately rather than bundled here:

- `src/semver/Version.rs:845`: `DiffFormatter` prints its own build tag with `other_buf` when colours are on and the other version has no build tag (affects `bun outdated` with build metadata in the registry version).
- `src/runtime/cli/pm_view_command.rs:213`: `bun pm view` / `bun info` passes the manifest buffer as the buffer for a range parsed from the CLI argument.
- Auto-install's disk-cache resolution (`PackageManagerResolution.rs:152-202`, `Tag::clone_into`) records tag offsets relative to a sub-slice of `tags_buf` and later slices against the whole buffer.
- While reproducing the `PackageManagerEnqueue.rs:1085` message: the exact-pin-from-cached-manifest path does not check that the cached manifest actually has publish times, so an abbreviated manifest cached by an earlier install lets an exact pin bypass `--minimum-release-age`. Handed off separately as its own bug.
</details>
