### PR TITLE
util.inspect: print proxies as Proxy(...) and unwrap nested proxies like node v26

### DIFF
--- a/src/js/internal/test/binding.ts
+++ b/src/js/internal/test/binding.ts
@@ -91,7 +91,9 @@ function internalBinding(name: string) {
     case "tcp_wrap":
       return { TCP: TestTCPWrap, constants: { SOCKET: 0, SERVER: 1 } };
     case "util":
-      return { isInsideNodeModules };
+      // getProxyDetails is the function util.inspect itself formats proxies with
+      // (test-util-inspect-proxy.js checks it directly).
+      return { isInsideNodeModules, getProxyDetails: require("internal/util/inspect").getProxyDetails };
     case "cares_wrap":
       // Only the pure IP-normalizer the vendored tls/dns tests reach for; the
       // resolver surface lives in node:dns.

--- a/src/js/internal/util/inspect.js
+++ b/src/js/internal/util/inspect.js
@@ -1391,17 +1391,28 @@ function formatValue(ctx, value, recurseTimes, typedArray) {
 
   // Memorize the context for custom inspection on proxies.
   const context = value;
+  let proxies = 0;
   // Always check for proxies to prevent side effects and to prevent triggering
   // any proxy handlers.
-  const proxy = getProxyDetails(value, !!ctx.showProxy);
+  let proxy = getProxyDetails(value, !!ctx.showProxy);
   if (proxy !== undefined) {
-    if (proxy === null || proxy[0] === null) {
-      return ctx.stylize("<Revoked Proxy>", "special");
-    }
     if (ctx.showProxy) {
+      if (proxy[0] === null) {
+        return ctx.stylize("<Revoked Proxy>", "special");
+      }
       return formatProxy(ctx, proxy, recurseTimes);
     }
-    value = proxy;
+    // A target can itself be a proxy (possibly revoked after it was wrapped), so
+    // unwrap every layer here; each one becomes a `Proxy(...)` around the result.
+    // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/util/inspect.js#L1121-L1144
+    do {
+      if (proxy === null) {
+        return wrapInProxy(ctx, ctx.stylize("<Revoked Proxy>", "special"), proxies);
+      }
+      value = proxy;
+      proxy = getProxyDetails(value, false);
+      proxies += 1;
+    } while (proxy !== undefined);
   }
 
   // Provide a hook for user-specified inspect functions.
@@ -1418,7 +1429,7 @@ function formatValue(ctx, value, recurseTimes, typedArray) {
       // This makes sure the recurseTimes are reported as before while using
       // a counter internally.
       const depth = ctx.depth === null ? null : ctx.depth - recurseTimes;
-      const isCrossContext = proxy !== undefined || !(context instanceof Object);
+      const isCrossContext = proxies !== 0 || !(context instanceof Object);
       const ret = maybeCustom.$call(context, depth, getUserOptions(ctx, isCrossContext), inspect);
       // If the custom inspection method returned `this`, don't go into infinite recursion.
       if (ret !== context) {
@@ -1447,7 +1458,14 @@ function formatValue(ctx, value, recurseTimes, typedArray) {
     return ctx.stylize(`[Circular *${index}]`, "special");
   }
 
-  return formatRaw(ctx, value, recurseTimes, typedArray);
+  return wrapInProxy(ctx, formatRaw(ctx, value, recurseTimes, typedArray), proxies);
+}
+
+function wrapInProxy(ctx, formatted, proxies) {
+  for (let i = 0; i < proxies; i++) {
+    formatted = `${ctx.stylize("Proxy(", "special")}${formatted}${ctx.stylize(")", "special")}`;
+  }
+  return formatted;
 }
 
 function formatRaw(ctx, value, recurseTimes, typedArray) {
@@ -3008,4 +3026,5 @@ export default {
   formatWithOptions,
   getStringWidth,
   stripVTControlCharacters,
+  getProxyDetails,
 };

--- a/test/js/node/test/parallel/test-util-inspect-proxy.js
+++ b/test/js/node/test/parallel/test-util-inspect-proxy.js
@@ -1,13 +1,11 @@
 // Flags: --expose-internals
 'use strict';
 
-// tests testing proxy internals are skipped, as getProxyDetails is not available in bun
-
 require('../common');
 const assert = require('assert');
 const util = require('util');
-// const { internalBinding } = require('internal/test/binding');
-// const processUtil = internalBinding('util');
+const { internalBinding } = require('internal/test/binding');
+const processUtil = internalBinding('util');
 const opts = { showProxy: true };
 
 let proxyObj;
@@ -44,33 +42,37 @@ proxyObj = new Proxy(target, handler);
 util.inspect(proxyObj, opts);
 
 // Make sure inspecting object does not trigger any proxy traps.
-util.format('%s', proxyObj);
+// %i%f%d use Symbol.toPrimitive to convert the value to a string.
+// %j uses JSON.stringify, accessing the value's toJSON and toString method.
+util.format('%s%o%O%c', proxyObj, proxyObj, proxyObj, proxyObj);
+const nestedProxy = new Proxy(new Proxy({}, handler), {});
+util.format('%s%o%O%c', nestedProxy, nestedProxy, nestedProxy, nestedProxy);
 
 // getProxyDetails is an internal method, not intended for public use.
 // This is here to test that the internals are working correctly.
-// let details = processUtil.getProxyDetails(proxyObj, true);
-// assert.strictEqual(target, details[0]);
-// assert.strictEqual(handler, details[1]);
+let details = processUtil.getProxyDetails(proxyObj, true);
+assert.strictEqual(target, details[0]);
+assert.strictEqual(handler, details[1]);
 
-// details = processUtil.getProxyDetails(proxyObj);
-// assert.strictEqual(target, details[0]);
-// assert.strictEqual(handler, details[1]);
+details = processUtil.getProxyDetails(proxyObj);
+assert.strictEqual(target, details[0]);
+assert.strictEqual(handler, details[1]);
 
-// details = processUtil.getProxyDetails(proxyObj, false);
-// assert.strictEqual(target, details);
+details = processUtil.getProxyDetails(proxyObj, false);
+assert.strictEqual(target, details);
 
-// details = processUtil.getProxyDetails({}, true);
-// assert.strictEqual(details, undefined);
+details = processUtil.getProxyDetails({}, true);
+assert.strictEqual(details, undefined);
 
 const r = Proxy.revocable({}, {});
 r.revoke();
 
-// details = processUtil.getProxyDetails(r.proxy, true);
-// assert.strictEqual(details[0], null);
-// assert.strictEqual(details[1], null);
+details = processUtil.getProxyDetails(r.proxy, true);
+assert.strictEqual(details[0], null);
+assert.strictEqual(details[1], null);
 
-// details = processUtil.getProxyDetails(r.proxy, false);
-// assert.strictEqual(details, null);
+details = processUtil.getProxyDetails(r.proxy, false);
+assert.strictEqual(details, null);
 
 assert.strictEqual(util.inspect(r.proxy), '<Revoked Proxy>');
 assert.strictEqual(
@@ -102,8 +104,8 @@ assert.strictEqual(
   ']'
 );
 
-// // Using getProxyDetails with non-proxy returns undefined
-// assert.strictEqual(processUtil.getProxyDetails({}), undefined);
+// Using getProxyDetails with non-proxy returns undefined
+assert.strictEqual(processUtil.getProxyDetails({}), undefined);
 
 // Inspecting a proxy without the showProxy option set to true should not
 // trigger any proxy handlers.
@@ -118,7 +120,7 @@ const proxy3 = new Proxy(proxy2, proxy1);
 const proxy4 = new Proxy(proxy1, proxy2);
 const proxy5 = new Proxy(proxy3, proxy4);
 const proxy6 = new Proxy(proxy5, proxy5);
-const expected0 = '{}';
+const expected0 = 'Proxy({})';
 const expected1 = 'Proxy [ {}, {} ]';
 const expected2 = 'Proxy [ Proxy [ {}, {} ], {} ]';
 const expected3 = 'Proxy [ Proxy [ Proxy [ {}, {} ], {} ], Proxy [ {}, {} ] ]';
@@ -137,6 +139,10 @@ const expected6 = 'Proxy [\n' +
                   '    Proxy [ Proxy [Array], Proxy [Array] ]\n' +
                   '  ]\n' +
                   ']';
+const expected2NoShowProxy = 'Proxy(Proxy({}))';
+const expected3NoShowProxy = 'Proxy(Proxy(Proxy({})))';
+const expected4NoShowProxy = 'Proxy(Proxy(Proxy(Proxy({}))))';
+const expected5NoShowProxy = 'Proxy(Proxy(Proxy(Proxy(Proxy({})))))';
 assert.strictEqual(
   util.inspect(proxy1, { showProxy: 1, depth: null }),
   expected1);
@@ -146,17 +152,17 @@ assert.strictEqual(util.inspect(proxy4, opts), expected4);
 assert.strictEqual(util.inspect(proxy5, opts), expected5);
 assert.strictEqual(util.inspect(proxy6, opts), expected6);
 assert.strictEqual(util.inspect(proxy1), expected0);
-assert.strictEqual(util.inspect(proxy2), expected0);
-assert.strictEqual(util.inspect(proxy3), expected0);
-assert.strictEqual(util.inspect(proxy4), expected0);
-assert.strictEqual(util.inspect(proxy5), expected0);
-assert.strictEqual(util.inspect(proxy6), expected0);
+assert.strictEqual(util.inspect(proxy2), expected2NoShowProxy);
+assert.strictEqual(util.inspect(proxy3), expected3NoShowProxy);
+assert.strictEqual(util.inspect(proxy4), expected2NoShowProxy);
+assert.strictEqual(util.inspect(proxy5), expected4NoShowProxy);
+assert.strictEqual(util.inspect(proxy6), expected5NoShowProxy);
 
 // Just for fun, let's create a Proxy using Arrays.
 const proxy7 = new Proxy([], []);
 const expected7 = 'Proxy [ [], [] ]';
 assert.strictEqual(util.inspect(proxy7, opts), expected7);
-assert.strictEqual(util.inspect(proxy7), '[]');
+assert.strictEqual(util.inspect(proxy7), 'Proxy([])');
 
 // Now we're just getting silly, right?
 const proxy8 = new Proxy(Date, []);
@@ -165,8 +171,8 @@ const expected8 = 'Proxy [ [Function: Date], [] ]';
 const expected9 = 'Proxy [ [Function: Date], [Function: String] ]';
 assert.strictEqual(util.inspect(proxy8, opts), expected8);
 assert.strictEqual(util.inspect(proxy9, opts), expected9);
-assert.strictEqual(util.inspect(proxy8), '[Function: Date]');
-assert.strictEqual(util.inspect(proxy9), '[Function: Date]');
+assert.strictEqual(util.inspect(proxy8), 'Proxy([Function: Date])');
+assert.strictEqual(util.inspect(proxy9), 'Proxy([Function: Date])');
 
 const proxy10 = new Proxy(() => {}, {});
 const proxy11 = new Proxy(() => {}, {
@@ -177,7 +183,37 @@ const proxy11 = new Proxy(() => {}, {
     return proxy11;
   }
 });
-const expected10 = '[Function (anonymous)]';
-const expected11 = '[Function (anonymous)]';
+const expected10 = 'Proxy([Function (anonymous)])';
+const expected11 = 'Proxy([Function (anonymous)])';
 assert.strictEqual(util.inspect(proxy10), expected10);
 assert.strictEqual(util.inspect(proxy11), expected11);
+
+const proxy12 = new Proxy([1, 2, 3], proxy5);
+assert.strictEqual(
+  util.inspect(proxy12, { colors: true, breakLength: 1 }),
+  '\x1B[36mProxy(\x1B[39m' +
+    '[\n  \x1B[33m1\x1B[39m,\n  \x1B[33m2\x1B[39m,\n  \x1B[33m3\x1B[39m\n]\x1B[36m' +
+    ')\x1B[39m'
+);
+assert.strictEqual(util.format('%s', proxy12), 'Proxy([ 1, 2, 3 ])');
+
+{
+  // Nested proxies should not trigger any proxy handlers.
+  const nestedProxy = new Proxy(new Proxy(new Proxy({}, handler), {}), {});
+
+  assert.strictEqual(
+    util.inspect(nestedProxy, { showProxy: true }),
+    'Proxy [ Proxy [ Proxy [ {}, [Object] ], {} ], {} ]'
+  );
+  assert.strictEqual(util.inspect(nestedProxy, { showProxy: false }), expected3NoShowProxy);
+}
+
+{
+  // Nested revoked proxies should work as expected as well as custom inspection functions.
+  const revocable = Proxy.revocable({}, handler);
+  revocable.revoke();
+  const nestedProxy = new Proxy(revocable.proxy, {});
+
+  assert.strictEqual(util.inspect(nestedProxy, { showProxy: true }), 'Proxy [ <Revoked Proxy>, {} ]');
+  assert.strictEqual(util.inspect(nestedProxy, { showProxy: false }), 'Proxy(<Revoked Proxy>)');
+}

--- a/test/js/node/util/node-inspect-tests/internal-inspect.test.js
+++ b/test/js/node/util/node-inspect-tests/internal-inspect.test.js
@@ -1,4 +1,6 @@
 import assert from "assert";
+import { Console } from "console";
+import { Writable } from "stream";
 import util from "util";
 
 test("no assertion failures", () => {
@@ -11,7 +13,7 @@ test("no assertion failures", () => {
       },
     },
   );
-  assert.strictEqual(util.format(obj), "{ x: 5 }");
+  assert.strictEqual(util.format(obj), "Proxy({ x: 5 })");
 
   assert.strictEqual(util.formatWithOptions({ numericSeparator: true }, "%d", 4000), "4_000");
 
@@ -23,6 +25,117 @@ test("no assertion failures", () => {
   const cause = new Error("cause");
   const e2 = new Error("wrapper", { cause });
   assert.match(util.inspect(e2), /\[cause\]: Error: cause\n/);
+});
+
+// Proxies are formatted as their (innermost) target wrapped in `Proxy(...)`,
+// one layer per proxy, without invoking any handler trap
+// (nodejs/node#61029 and nodejs/node#61077, in node v26.3.0).
+test("proxies are marked as such unless showProxy is set", () => {
+  const proxy = new Proxy({ a: 1 }, {});
+  assert.strictEqual(util.inspect(proxy), "Proxy({ a: 1 })");
+  assert.strictEqual(util.inspect(proxy, { depth: -1 }), "Proxy([Object])");
+  assert.strictEqual(util.inspect({ p: proxy }), "{ p: Proxy({ a: 1 }) }");
+  assert.strictEqual(util.inspect([proxy, proxy]), "[ Proxy({ a: 1 }), Proxy({ a: 1 }) ]");
+  assert.strictEqual(util.inspect(new Map([[proxy, 1]])), "Map(1) { Proxy({ a: 1 }) => 1 }");
+  assert.strictEqual(util.inspect(new Proxy(function f() {}, {})), "Proxy([Function: f])");
+  assert.strictEqual(util.inspect(new Proxy(new Map([[1, 2]]), {})), "Proxy(Map(1) { 1 => 2 })");
+  class Foo {
+    x = 1;
+  }
+  assert.strictEqual(util.inspect(new Proxy(new Foo(), {})), "Proxy(Foo { x: 1 })");
+  const xs = Buffer.alloc(30, "x").toString();
+  const ys = Buffer.alloc(30, "y").toString();
+  assert.strictEqual(
+    util.inspect({ k: new Proxy({ first: xs, second: ys }, {}) }),
+    `{\n  k: Proxy({\n    first: '${xs}',\n    second: '${ys}'\n  })\n}`,
+  );
+  assert.strictEqual(
+    util.inspect(proxy, { colors: true }),
+    "\x1B[36mProxy(\x1B[39m{ a: \x1B[33m1\x1B[39m }\x1B[36m)\x1B[39m",
+  );
+
+  // Only `showProxy` (and `%o`, which implies it) shows the target/handler pair.
+  assert.strictEqual(util.inspect(proxy, { showProxy: true }), "Proxy [ { a: 1 }, {} ]");
+  assert.strictEqual(util.format("%o", proxy), "Proxy [ { a: 1 }, {} ]");
+  assert.strictEqual(util.format("%O", proxy), "Proxy({ a: 1 })");
+  assert.strictEqual(util.format("%s", proxy), "Proxy({ a: 1 })");
+  assert.strictEqual(util.format("%j", proxy), '{"a":1}');
+  assert.strictEqual(util.format(proxy), "Proxy({ a: 1 })");
+
+  // A target revoked after being wrapped.
+  const revocable = Proxy.revocable({ a: 1 }, {});
+  const wrapped = new Proxy(revocable.proxy, {});
+  assert.strictEqual(util.inspect(wrapped), "Proxy(Proxy({ a: 1 }))");
+  revocable.revoke();
+  assert.strictEqual(util.inspect(revocable.proxy), "<Revoked Proxy>");
+  assert.strictEqual(util.inspect(wrapped), "Proxy(<Revoked Proxy>)");
+  assert.strictEqual(util.inspect(new Proxy(wrapped, {})), "Proxy(Proxy(<Revoked Proxy>))");
+  assert.strictEqual(util.inspect(wrapped, { showProxy: true }), "Proxy [ <Revoked Proxy>, {} ]");
+
+  // The custom inspect function is looked up on the innermost target without
+  // going through any handler, invoked with the proxy as `this`, and its
+  // result is used as-is.
+  const throwingHandler = new Proxy(
+    {},
+    {
+      get(_, trap) {
+        throw new Error(`trap ${String(trap)} was invoked`);
+      },
+    },
+  );
+  let receiver;
+  const target = {
+    [util.inspect.custom](depth, options) {
+      receiver = this;
+      return `custom(${depth}, showProxy=${options.showProxy})`;
+    },
+  };
+  const nested = new Proxy(new Proxy(target, throwingHandler), {});
+  assert.strictEqual(util.inspect(nested), "custom(2, showProxy=false)");
+  assert.strictEqual(receiver, nested);
+  assert.strictEqual(util.inspect({ nested }), "{ nested: custom(1, showProxy=false) }");
+  assert.strictEqual(util.inspect(new Proxy({ z: 1 }, throwingHandler)), "Proxy({ z: 1 })");
+
+  // A custom inspect function returning `this` falls through to the regular formatting.
+  const returnsThis = {
+    [util.inspect.custom]() {
+      return this;
+    },
+  };
+  assert.strictEqual(
+    util.inspect(new Proxy(returnsThis, {})),
+    "Proxy({\n  Symbol(nodejs.util.inspect.custom): [Function: [nodejs.util.inspect.custom]]\n})",
+  );
+
+  // A proxy around an object already being formatted is a circular reference to its target.
+  const self = { name: "self" };
+  self.proxy = new Proxy(self, {});
+  assert.strictEqual(util.inspect(self), "<ref *1> { name: 'self', proxy: [Circular *1] }");
+
+  // node:console and node:assert format values through the same code.
+  let written = "";
+  const stream = new Writable({
+    write(chunk, _encoding, callback) {
+      written += chunk;
+      callback();
+    },
+  });
+  new Console(stream).log(proxy, wrapped);
+  assert.strictEqual(written, "Proxy({ a: 1 }) Proxy(<Revoked Proxy>)\n");
+
+  assert.throws(() => assert.deepStrictEqual(new Proxy([1, 2], {}), [1, 2, 3]), {
+    message:
+      "Expected values to be strictly deep-equal:\n" +
+      "+ actual - expected\n" +
+      "\n" +
+      "+ Proxy([\n" +
+      "- [\n" +
+      "    1,\n" +
+      "    2,\n" +
+      "+ ])\n" +
+      "-   3\n" +
+      "- ]\n",
+  });
 });
 
 test("boxed BigInt/Symbol with no prototype are still formatted as boxed primitives", () => {

--- a/test/js/node/util/node-inspect-tests/parallel/util-inspect-proxy.test.js
+++ b/test/js/node/util/node-inspect-tests/parallel/util-inspect-proxy.test.js
@@ -63,7 +63,11 @@ test("no assertion failures", () => {
   util.inspect(proxyObj, opts);
 
   // Make sure inspecting object does not trigger any proxy traps.
-  util.format("%s", proxyObj);
+  // %i%f%d use Symbol.toPrimitive to convert the value to a string.
+  // %j uses JSON.stringify, accessing the value's toJSON and toString method.
+  util.format("%s%o%O%c", proxyObj, proxyObj, proxyObj, proxyObj);
+  const nestedProxy = new Proxy(new Proxy({}, handler), {});
+  util.format("%s%o%O%c", nestedProxy, nestedProxy, nestedProxy, nestedProxy);
 
   const r = Proxy.revocable({}, {});
   r.revoke();
@@ -111,7 +115,7 @@ test("no assertion failures", () => {
   const proxy4 = new Proxy(proxy1, proxy2);
   const proxy5 = new Proxy(proxy3, proxy4);
   const proxy6 = new Proxy(proxy5, proxy5);
-  const expected0 = "{}";
+  const expected0 = "Proxy({})";
   const expected1 = "Proxy [ {}, {} ]";
   const expected2 = "Proxy [ Proxy [ {}, {} ], {} ]";
   const expected3 = "Proxy [ Proxy [ Proxy [ {}, {} ], {} ], Proxy [ {}, {} ] ]";
@@ -132,6 +136,10 @@ test("no assertion failures", () => {
     "    Proxy [ Proxy [Array], Proxy [Array] ]\n" +
     "  ]\n" +
     "]";
+  const expected2NoShowProxy = "Proxy(Proxy({}))";
+  const expected3NoShowProxy = "Proxy(Proxy(Proxy({})))";
+  const expected4NoShowProxy = "Proxy(Proxy(Proxy(Proxy({}))))";
+  const expected5NoShowProxy = "Proxy(Proxy(Proxy(Proxy(Proxy({})))))";
   assert.strictEqual(util.inspect(proxy1, { showProxy: 1, depth: null }), expected1);
   assert.strictEqual(util.inspect(proxy2, opts), expected2);
   assert.strictEqual(util.inspect(proxy3, opts), expected3);
@@ -139,17 +147,17 @@ test("no assertion failures", () => {
   assert.strictEqual(util.inspect(proxy5, opts), expected5);
   assert.strictEqual(util.inspect(proxy6, opts), expected6);
   assert.strictEqual(util.inspect(proxy1), expected0);
-  assert.strictEqual(util.inspect(proxy2), expected0);
-  assert.strictEqual(util.inspect(proxy3), expected0);
-  assert.strictEqual(util.inspect(proxy4), expected0);
-  assert.strictEqual(util.inspect(proxy5), expected0);
-  assert.strictEqual(util.inspect(proxy6), expected0);
+  assert.strictEqual(util.inspect(proxy2), expected2NoShowProxy);
+  assert.strictEqual(util.inspect(proxy3), expected3NoShowProxy);
+  assert.strictEqual(util.inspect(proxy4), expected2NoShowProxy);
+  assert.strictEqual(util.inspect(proxy5), expected4NoShowProxy);
+  assert.strictEqual(util.inspect(proxy6), expected5NoShowProxy);
 
   // Just for fun, let's create a Proxy using Arrays.
   const proxy7 = new Proxy([], []);
   const expected7 = "Proxy [ [], [] ]";
   assert.strictEqual(util.inspect(proxy7, opts), expected7);
-  assert.strictEqual(util.inspect(proxy7), "[]");
+  assert.strictEqual(util.inspect(proxy7), "Proxy([])");
 
   // Now we're just getting silly, right?
   const proxy8 = new Proxy(Date, []);
@@ -158,8 +166,8 @@ test("no assertion failures", () => {
   const expected9 = "Proxy [ [Function: Date], [Function: String] ]";
   assert.strictEqual(util.inspect(proxy8, opts), expected8);
   assert.strictEqual(util.inspect(proxy9, opts), expected9);
-  assert.strictEqual(util.inspect(proxy8), "[Function: Date]");
-  assert.strictEqual(util.inspect(proxy9), "[Function: Date]");
+  assert.strictEqual(util.inspect(proxy8), "Proxy([Function: Date])");
+  assert.strictEqual(util.inspect(proxy9), "Proxy([Function: Date])");
 
   const proxy10 = new Proxy(() => {}, {});
   const proxy11 = new Proxy(() => {}, {
@@ -170,8 +178,38 @@ test("no assertion failures", () => {
       return proxy11;
     },
   });
-  const expected10 = "[Function (anonymous)]";
-  const expected11 = "[Function (anonymous)]";
+  const expected10 = "Proxy([Function (anonymous)])";
+  const expected11 = "Proxy([Function (anonymous)])";
   assert.strictEqual(util.inspect(proxy10), expected10);
   assert.strictEqual(util.inspect(proxy11), expected11);
+
+  const proxy12 = new Proxy([1, 2, 3], proxy5);
+  assert.strictEqual(
+    util.inspect(proxy12, { colors: true, breakLength: 1 }),
+    "\x1B[36mProxy(\x1B[39m" +
+      "[\n  \x1B[33m1\x1B[39m,\n  \x1B[33m2\x1B[39m,\n  \x1B[33m3\x1B[39m\n]\x1B[36m" +
+      ")\x1B[39m",
+  );
+  assert.strictEqual(util.format("%s", proxy12), "Proxy([ 1, 2, 3 ])");
+
+  {
+    // Nested proxies should not trigger any proxy handlers.
+    const nestedProxy = new Proxy(new Proxy(new Proxy({}, handler), {}), {});
+
+    assert.strictEqual(
+      util.inspect(nestedProxy, { showProxy: true }),
+      "Proxy [ Proxy [ Proxy [ {}, [Object] ], {} ], {} ]",
+    );
+    assert.strictEqual(util.inspect(nestedProxy, { showProxy: false }), expected3NoShowProxy);
+  }
+
+  {
+    // Nested revoked proxies should work as expected as well as custom inspection functions.
+    const revocable = Proxy.revocable({}, handler);
+    revocable.revoke();
+    const nestedProxy = new Proxy(revocable.proxy, {});
+
+    assert.strictEqual(util.inspect(nestedProxy, { showProxy: true }), "Proxy [ <Revoked Proxy>, {} ]");
+    assert.strictEqual(util.inspect(nestedProxy, { showProxy: false }), "Proxy(<Revoked Proxy>)");
+  }
 });


### PR DESCRIPTION
### Problem
- `util.inspect(new Proxy({ a: 1 }, {}))` prints `{ a: 1 }`; node v26.3.0 (the version Bun reports) prints `Proxy({ a: 1 })`. Same for `util.format` (`%s`, `%O`, bare args), `new console.Console(...)`, and `assert` diff messages, which all format through this code.
- A proxy whose target is itself a proxy is worse than mislabeled: `util.inspect(new Proxy(new Proxy({}, throwingHandler), {}))` invokes the inner handler's traps and throws, and `util.inspect(new Proxy(revokedProxy, {}))` throws `TypeError: Proxy has already been revoked`. Node prints `Proxy(Proxy({}))` and `Proxy(<Revoked Proxy>)`.
- Cause: `formatValue` in `src/js/internal/util/inspect.js` (formerly lines 1396-1404) still has the pre-v26 logic: with `showProxy` off it replaces `value` with the proxy's target exactly once and formats that as if it were a plain value, so the target's own proxy-ness is never checked and nothing marks the output.

### Fix
- Port the `formatValue` proxy block from node v26.3.0 (nodejs/node#61029 wraps the output in `Proxy(...)`, nodejs/node#61077 unwraps nested proxies): with `showProxy` off, unwrap layer by layer through the proxy internal fields, counting layers, then wrap the formatted innermost target (or `<Revoked Proxy>`) in one `Proxy(`/`)` pair per layer, stylized as `special` like node. `isCrossContext` now keys off the layer count, since `proxy` is always `undefined` after the loop.
- Why this is right: for `node:util` node's observed output is the spec, and the output here is now byte-identical to node v26.3.0 for every case tried (table below). The ordering also matches node: a custom inspect function found on the innermost target is still called with the outer proxy as `this` and its result is returned unwrapped; a target already on the `seen` stack still prints as `[Circular *n]`; `showProxy: true` and `%o` keep printing `Proxy [ target, handler ]`; top-level revoked proxies still print `<Revoked Proxy>`. No trap is ever invoked, because every layer is read through `$getProxyInternalField`.
- `internalBinding('util')` (test-only shim in `src/js/internal/test/binding.ts`) now exposes `getProxyDetails`, the same function `inspect` uses, so `test-util-inspect-proxy.js` can be vendored byte-for-byte from node v26.3.0 instead of the hand-edited older copy that encoded the old output.
- Out of scope, deliberately: the global `console.log` and `Bun.inspect` use the native formatter (`src/jsc/ConsoleObject.rs` `print_proxy`), which also prints the bare target. Node's `console.log` prints `Proxy(...)` too, but Bun's native formatter has its own format and changing it is a separate decision; this PR only changes `node:util` and the modules built on it.
- Verified:
  - `test/js/node/util/node-inspect-tests/internal-inspect.test.js` (new case covering nesting inside objects/arrays/Map keys, `depth`, `colors`, multi-line indentation, every `util.format` specifier, a target revoked after being wrapped, custom inspect on the innermost target through a trapping handler, custom inspect returning `this`, circular through a proxy, `console.Console`, and the `assert.deepStrictEqual` message) and `test/js/node/util/node-inspect-tests/parallel/util-inspect-proxy.test.js` (updated with the same hunks upstream applied): fail on the unfixed build (3 tests), pass with the fix. Both files also pass unmodified under real node v26.3.0.
  - `test/js/node/test/parallel/test-util-inspect-proxy.js`: now identical to upstream v26.3.0; passes with `bun bd --expose-internals`, fails on the unfixed build at the nested-proxy `util.format` line.
  - `test/js/node/util/`, `test/js/node/assert/`, `test/js/node/console/`, `test-console-issue-43095.js`, `test-common-must-not-call.js`, `test-repl-completion-on-getters-disabled.js`: no new failures (the only failures are pre-existing 5s timeouts under the local debug+ASAN build, identical on an unfixed build).

### Background
- `showProxy` is a `util.inspect` option (default `false`). When on, a proxy prints as `Proxy [ target, handler ]` via `formatProxy`; `%o` turns it on. This PR only changes the default (off) path.
- `getProxyDetails(value, withHandler)` is inspect's helper over JSC's `$isProxyObject` / `$getProxyInternalField`: `undefined` for a non-proxy, `[target, handler]` (or `target`) for a proxy, and `null` / `[null, null]` for a revoked one. Reading the internal fields never invokes handler traps, which is the whole reason inspect must not fall back to ordinary property access on a proxy. Node has the same function as a native binding, which is what the upstream test calls through `internalBinding('util')`.
- A proxy may wrap another proxy (`new Proxy(proxyA, {})`), and the inner one can be revoked at any time (including after being wrapped), so a single unwrap step can hand the formatter a live proxy or a revoked one.
- `ctx.stylize(str, "special")` is how inspect colors markers such as `[Circular *1]` (cyan when `colors: true`); node uses it for the `Proxy(` and `)` tokens.

<details>
<summary>node v26.3.0 vs Bun, before and after (node:util)</summary>

| input | node 26.3.0 / Bun with this PR | Bun before |
| --- | --- | --- |
| `inspect(new Proxy({ a: 1 }, {}))` | `Proxy({ a: 1 })` | `{ a: 1 }` |
| `inspect(p, { depth: -1 })` | `Proxy([Object])` | `[Object]` |
| `inspect({ p })` | `{ p: Proxy({ a: 1 }) }` | `{ p: { a: 1 } }` |
| `inspect(new Proxy(function f() {}, {}))` | `Proxy([Function: f])` | `[Function: f]` |
| `inspect(new Proxy(new Proxy({}, {}), {}))` | `Proxy(Proxy({}))` | `{}` |
| `inspect(new Proxy(revoked, {}))` | `Proxy(<Revoked Proxy>)` | throws `TypeError: Proxy has already been revoked` |
| `inspect(new Proxy(new Proxy({}, throwing), {}))` | `Proxy(Proxy({}))` | throws from the `get` trap |
| `inspect(p, { colors: true })` | `\x1b[36mProxy(\x1b[39m{ a: \x1b[33m1\x1b[39m }\x1b[36m)\x1b[39m` | no wrapper |
| `format("%s", p)`, `format("%O", p)`, `format(p)` | `Proxy({ a: 1 })` | `{ a: 1 }` |
| `format("%o", p)`, `inspect(p, { showProxy: true })` | `Proxy [ { a: 1 }, {} ]` | same (unchanged) |
| `inspect(revoked)` | `<Revoked Proxy>` | same (unchanged) |
| target with `[inspect.custom]` returning `"x"` | `x` (called with the proxy as `this`) | same (unchanged) |
| `o.self = new Proxy(o, {}); inspect(o)` | `<ref *1> { name: 'o', self: [Circular *1] }` | same (unchanged) |
| `assert.deepStrictEqual(new Proxy([1, 2], {}), [1, 2, 3])` message | `+ Proxy([` / `- [` ... (matches upstream test-assert-deep.js) | `  [` ... |

A 36-line comparison script exercising these produced identical output under node v26.3.0 and the patched debug build.
</details>
