### PR TITLE
shell(cp): reject copying a directory into itself; walk cp trees without recursion

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -2024,7 +2024,7 @@ mod _async_tasks {
             let dest = unsafe { OSPathSliceZ::from_raw(dest_buf.as_ptr(), dest_dir_len as usize) };
 
             #[cfg(target_os = "macos")]
-            {
+            'try_with_clonefile: {
                 // CLONE_NOFOLLOW: `src` was classified as a directory via lstat, so
                 // mirror the O_NOFOLLOW directory open below instead of dereferencing.
                 if let Some(err) = Maybe::<ret::Cp>::errno_sys_p(
@@ -2034,6 +2034,11 @@ mod _async_tasks {
                 ) {
                     match err.get_errno() {
                         E::EACCES | E::ENAMETOOLONG | E::EROFS | E::EPERM | E::EINVAL => {
+                            if matches!(err.get_errno(), E::EACCES | E::EPERM)
+                                && this_ref.args.flags.force
+                            {
+                                break 'try_with_clonefile;
+                            }
                             // `errno_sys_p`
                             // already boxed `src.as_bytes()` into `err.path`, so just forward.
                             return err;

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -503,13 +503,17 @@ impl CpPendingDirs {
     }
 
     /// Writes the next directory's NUL-terminated src/dest paths into the
-    /// buffers and returns their lengths.
+    /// buffers and their lengths into `src_len`/`dest_len`; false once empty.
     fn pop_into(
         &mut self,
         src_buf: &mut OSPathBuffer,
+        src_len: &mut PathInt,
         dest_buf: &mut OSPathBuffer,
-    ) -> Option<(PathInt, PathInt)> {
-        let dir = self.dirs.pop()?;
+        dest_len: &mut PathInt,
+    ) -> bool {
+        let Some(dir) = self.dirs.pop() else {
+            return false;
+        };
         let name = &self.names[dir.name_start as usize..];
         let sd = dir.parent_src_len as usize;
         let dd = dir.parent_dest_len as usize;
@@ -519,12 +523,10 @@ impl CpPendingDirs {
         dest_buf[dd] = paths::SEP as OSPathChar;
         dest_buf[dd + 1..dd + 1 + name.len()].copy_from_slice(name);
         dest_buf[dd + 1 + name.len()] = 0;
-        let lens = (
-            (sd + 1 + name.len()) as PathInt,
-            (dd + 1 + name.len()) as PathInt,
-        );
+        *src_len = (sd + 1 + name.len()) as PathInt;
+        *dest_len = (dd + 1 + name.len()) as PathInt;
         self.names.truncate(dir.name_start as usize);
-        Some(lens)
+        true
     }
 }
 
@@ -1991,9 +1993,8 @@ mod _async_tasks {
                     dest_dir_len,
                     &mut pending,
                 )?;
-                match pending.pop_into(src_buf, dest_buf) {
-                    Some((sd, dd)) => (src_dir_len, dest_dir_len) = (sd, dd),
-                    None => return Ok(()),
+                if !pending.pop_into(src_buf, &mut src_dir_len, dest_buf, &mut dest_dir_len) {
+                    return Ok(());
                 }
             }
         }
@@ -8373,9 +8374,8 @@ impl NodeFS {
                 args,
                 &mut pending,
             )?;
-            match pending.pop_into(src_buf, dest_buf) {
-                Some((sd, dd)) => (src_dir_len, dest_dir_len) = (sd, dd),
-                None => return Ok(()),
+            if !pending.pop_into(src_buf, &mut src_dir_len, dest_buf, &mut dest_dir_len) {
+                return Ok(());
             }
         }
     }

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -519,7 +519,10 @@ impl CpPendingDirs {
         dest_buf[dd] = paths::SEP as OSPathChar;
         dest_buf[dd + 1..dd + 1 + name.len()].copy_from_slice(name);
         dest_buf[dd + 1 + name.len()] = 0;
-        let lens = ((sd + 1 + name.len()) as PathInt, (dd + 1 + name.len()) as PathInt);
+        let lens = (
+            (sd + 1 + name.len()) as PathInt,
+            (dd + 1 + name.len()) as PathInt,
+        );
         self.names.truncate(dir.name_start as usize);
         Some(lens)
     }

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -475,6 +475,56 @@ pub(crate) const DEFAULT_PERMISSION: Mode = 0;
 // `&AbortSignal` inherent methods — the former `AbortSignalRefExt` shim with
 // per-call `unsafe { self.as_ref() }` is gone. `unref()` is handled by `Drop`.
 
+/// Subdirectories a recursive `cp` walk has seen but not yet entered. The sync
+/// and async walkers share one src/dest buffer pair for the whole tree, so an
+/// entry is its parent's lengths in those buffers plus the name to append; LIFO
+/// order guarantees the parent prefix is still in place when an entry is popped.
+#[derive(Default)]
+struct CpPendingDirs {
+    names: Vec<OSPathChar>,
+    dirs: Vec<CpPendingDir>,
+}
+
+struct CpPendingDir {
+    parent_src_len: PathInt,
+    parent_dest_len: PathInt,
+    name_start: u32,
+}
+
+impl CpPendingDirs {
+    /// The caller has checked that `name` fits both buffers after its parent.
+    fn push(&mut self, parent_src_len: PathInt, parent_dest_len: PathInt, name: &[OSPathChar]) {
+        self.dirs.push(CpPendingDir {
+            parent_src_len,
+            parent_dest_len,
+            name_start: self.names.len() as u32,
+        });
+        self.names.extend_from_slice(name);
+    }
+
+    /// Writes the next directory's NUL-terminated src/dest paths into the
+    /// buffers and returns their lengths.
+    fn pop_into(
+        &mut self,
+        src_buf: &mut OSPathBuffer,
+        dest_buf: &mut OSPathBuffer,
+    ) -> Option<(PathInt, PathInt)> {
+        let dir = self.dirs.pop()?;
+        let name = &self.names[dir.name_start as usize..];
+        let sd = dir.parent_src_len as usize;
+        let dd = dir.parent_dest_len as usize;
+        src_buf[sd] = paths::SEP as OSPathChar;
+        src_buf[sd + 1..sd + 1 + name.len()].copy_from_slice(name);
+        src_buf[sd + 1 + name.len()] = 0;
+        dest_buf[dd] = paths::SEP as OSPathChar;
+        dest_buf[dd + 1..dd + 1 + name.len()].copy_from_slice(name);
+        dest_buf[dd + 1 + name.len()] = 0;
+        let lens = ((sd + 1 + name.len()) as PathInt, (dd + 1 + name.len()) as PathInt);
+        self.names.truncate(dir.name_start as usize);
+        Some(lens)
+    }
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // Async task type aliases
 // ──────────────────────────────────────────────────────────────────────────
@@ -1902,9 +1952,8 @@ mod _async_tasks {
             // are slices into `src_buf`/`dest_buf` and must end their borrow first.
             let src_len = PathInt::try_from(src.len()).expect("int cast");
             let dest_len = PathInt::try_from(dest.len()).expect("int cast");
-            let _ = Self::cp_async_directory(
+            if let Err(err) = Self::cp_async_directory(
                 nodefs,
-                args.flags,
                 // Pass the raw `*mut Self` (Box::leak provenance) so spawned
                 // `CpSingleTask`s store a pointer that may later be promoted to
                 // `&mut` in `on_subtask_done`.
@@ -1913,19 +1962,50 @@ mod _async_tasks {
                 src_len,
                 &mut dest_buf,
                 dest_len,
-            );
+            ) {
+                this.finish_concurrently(Err(err));
+            }
         }
 
-        // returns boolean `should_continue`
+        /// Walks the tree with an explicit work list: this runs on a pool
+        /// thread, and a call frame per level overflowed its stack on deep trees.
         fn cp_async_directory(
             nodefs: &mut NodeFS,
-            args: args::CpFlags,
             this: *mut Self,
             src_buf: &mut OSPathBuffer,
-            src_dir_len: PathInt,
+            mut src_dir_len: PathInt,
             dest_buf: &mut OSPathBuffer,
+            mut dest_dir_len: PathInt,
+        ) -> Maybe<()> {
+            let mut pending = CpPendingDirs::default();
+            loop {
+                Self::cp_async_one_directory(
+                    nodefs,
+                    this,
+                    src_buf,
+                    src_dir_len,
+                    dest_buf,
+                    dest_dir_len,
+                    &mut pending,
+                )?;
+                match pending.pop_into(src_buf, dest_buf) {
+                    Some((sd, dd)) => (src_dir_len, dest_dir_len) = (sd, dd),
+                    None => return Ok(()),
+                }
+            }
+        }
+
+        /// Creates `dest`, dispatches a `CpSingleTask` per non-directory entry
+        /// of `src` and queues its subdirectories on `pending`.
+        fn cp_async_one_directory(
+            nodefs: &mut NodeFS,
+            this: *mut Self,
+            src_buf: &OSPathBuffer,
+            src_dir_len: PathInt,
+            dest_buf: &OSPathBuffer,
             dest_dir_len: PathInt,
-        ) -> bool {
+            pending: &mut CpPendingDirs,
+        ) -> Maybe<()> {
             // SAFETY: `this` is the live Box-leaked task. Shared borrow only — spawned
             // `CpSingleTask`s on other workpool threads may concurrently hold `&Self`.
             // The raw `*mut` is threaded through (instead of `&Self`) so that the
@@ -1952,34 +2032,26 @@ mod _async_tasks {
                         E::EACCES | E::ENAMETOOLONG | E::EROFS | E::EPERM | E::EINVAL => {
                             // `errno_sys_p`
                             // already boxed `src.as_bytes()` into `err.path`, so just forward.
-                            this_ref.finish_concurrently(err);
-                            return false;
+                            return err;
                         }
                         // Other errors may be due to clonefile() not being supported
                         // We'll fall back to other implementations
                         _ => {}
                     }
                 } else {
-                    return true;
+                    return Ok(());
                 }
             }
 
             let open_flags = sys::O::DIRECTORY | sys::O::RDONLY | sys::O::NOFOLLOW;
-            let fd = match openat_os_path(FD::cwd(), src, open_flags, 0) {
-                Err(err) => {
-                    this_ref.finish_concurrently(Err(
-                        err.with_path(nodefs.os_path_into_sync_error_buf(src))
-                    ));
-                    return false;
-                }
-                Ok(fd_) => fd_,
-            };
+            let fd = openat_os_path(FD::cwd(), src, open_flags, 0)
+                .map_err(|err| err.with_path(nodefs.os_path_into_sync_error_buf(src)))?;
             let _close = scopeguard::guard(fd, |fd| fd.close());
 
             #[cfg(windows)]
-            let mut buf = OSPathBuffer::uninit();
+            let mut buf = bun_paths::os_path_buffer_pool::get();
             #[cfg(windows)]
-            let normdest: &OSPathSliceZ = match sys::normalize_path_windows_opts(
+            let normdest: &OSPathSliceZ = sys::normalize_path_windows_opts(
                 FD::INVALID,
                 dest.as_slice(),
                 &mut buf[..],
@@ -1989,26 +2061,12 @@ mod _async_tasks {
                 sys::NormalizePathWindowsOpts {
                     add_nt_prefix: false,
                 },
-            ) {
-                Err(err) => {
-                    this_ref.finish_concurrently(Err(err));
-                    return false;
-                }
-                Ok(n) => n,
-            };
+            )?;
             #[cfg(not(windows))]
             let normdest: &OSPathSliceZ = dest;
 
-            let mkdir_ = nodefs.mkdir_recursive_os_path(normdest, args::Mkdir::DEFAULT_MODE, false);
-            match mkdir_ {
-                Err(err) => {
-                    this_ref.finish_concurrently(Err(err));
-                    return false;
-                }
-                Ok(_) => {
-                    this_ref.on_copy(src, normdest);
-                }
-            }
+            nodefs.mkdir_recursive_os_path(normdest, args::Mkdir::DEFAULT_MODE, false)?;
+            this_ref.on_copy(src, normdest);
 
             // On POSIX directory entries are always UTF-8, so monomorphise the
             // const-generic path type on `U8` and let the Windows branch (gated
@@ -2017,19 +2075,13 @@ mod _async_tasks {
             let mut iterator = DirIterator::iterate::<true>(fd);
             #[cfg(not(windows))]
             let mut iterator = DirIterator::iterate::<false>(fd);
-            let mut entry = iterator.next();
             loop {
-                let current = match entry {
+                let current = match iterator.next() {
                     Err(err) => {
-                        this_ref.finish_concurrently(Err(
-                            err.with_path(nodefs.os_path_into_sync_error_buf(src))
-                        ));
-                        return false;
+                        return Err(err.with_path(nodefs.os_path_into_sync_error_buf(src)));
                     }
-                    Ok(ent) => match ent {
-                        Some(e) => e,
-                        None => break,
-                    },
+                    Ok(Some(e)) => e,
+                    Ok(None) => break,
                 };
                 let cname = current.name.slice();
 
@@ -2039,40 +2091,19 @@ mod _async_tasks {
                 if (src_dir_len as usize) + 1 + cname.len() >= src_buf.len()
                     || (dest_dir_len as usize) + 1 + cname.len() >= dest_buf.len()
                 {
-                    this_ref.finish_concurrently(Err(sys::Error {
+                    return Err(sys::Error {
                         errno: E::ENAMETOOLONG as _,
                         syscall: sys::Tag::copyfile,
                         path: nodefs
                             .os_path_into_sync_error_buf(&src_buf[..src_dir_len as usize])
                             .into(),
                         ..Default::default()
-                    }));
-                    return false;
+                    });
                 }
 
                 match current.kind {
                     crate::node::dirent::Kind::Directory => {
-                        let sd = src_dir_len as usize;
-                        let dd = dest_dir_len as usize;
-                        src_buf[sd + 1..sd + 1 + cname.len()].copy_from_slice(cname);
-                        src_buf[sd] = paths::SEP as OSPathChar;
-                        src_buf[sd + 1 + cname.len()] = 0;
-                        dest_buf[dd + 1..dd + 1 + cname.len()].copy_from_slice(cname);
-                        dest_buf[dd] = paths::SEP as OSPathChar;
-                        dest_buf[dd + 1 + cname.len()] = 0;
-
-                        let should_continue = Self::cp_async_directory(
-                            nodefs,
-                            args,
-                            this,
-                            src_buf,
-                            (sd + 1 + cname.len()) as PathInt,
-                            dest_buf,
-                            (dd + 1 + cname.len()) as PathInt,
-                        );
-                        if !should_continue {
-                            return false;
-                        }
+                        pending.push(src_dir_len, dest_dir_len, cname);
                     }
                     _ => {
                         this_ref.subtask_count.fetch_add(1, Ordering::Relaxed);
@@ -2102,10 +2133,9 @@ mod _async_tasks {
                         );
                     }
                 }
-                entry = iterator.next();
             }
 
-            true
+            Ok(())
         }
     }
 
@@ -8327,6 +8357,45 @@ impl NodeFS {
             });
         }
 
+        // An explicit work list: a call frame per level overflowed the stack on
+        // deep trees.
+        let mut pending = CpPendingDirs::default();
+        let (mut src_dir_len, mut dest_dir_len) = (src_dir_len, dest_dir_len);
+        loop {
+            self.cp_sync_one_directory(
+                src_buf,
+                src_dir_len,
+                dest_buf,
+                dest_dir_len,
+                args,
+                &mut pending,
+            )?;
+            match pending.pop_into(src_buf, dest_buf) {
+                Some((sd, dd)) => (src_dir_len, dest_dir_len) = (sd, dd),
+                None => return Ok(()),
+            }
+        }
+    }
+
+    /// Creates `dest`, copies every non-directory entry of `src` into it and
+    /// queues the subdirectories on `pending`.
+    fn cp_sync_one_directory(
+        &mut self,
+        src_buf: &mut OSPathBuffer,
+        src_dir_len: PathInt,
+        dest_buf: &mut OSPathBuffer,
+        dest_dir_len: PathInt,
+        args: &args::Cp,
+        pending: &mut CpPendingDirs,
+    ) -> Maybe<ret::Cp> {
+        let cp_flags = &args.flags;
+        let sd = src_dir_len as usize;
+        let dd = dest_dir_len as usize;
+        // SAFETY: the caller NUL-terminated both buffers at `sd`/`dd`.
+        let src = unsafe { OSPathSliceZ::from_raw(src_buf.as_ptr(), sd) };
+        // SAFETY: see `src` above.
+        let dest = unsafe { OSPathSliceZ::from_raw(dest_buf.as_ptr(), dd) };
+
         #[cfg(target_os = "macos")]
         'try_with_clonefile: {
             // CLONE_NOFOLLOW: `src` was classified as a directory via lstat, so
@@ -8401,26 +8470,19 @@ impl NodeFS {
                 });
             }
 
-            src_buf[sd + 1..sd + 1 + name_slice.len()].copy_from_slice(name_slice);
-            src_buf[sd] = paths::SEP as OSPathChar;
-            src_buf[sd + 1 + name_slice.len()] = 0;
-
-            dest_buf[dd + 1..dd + 1 + name_slice.len()].copy_from_slice(name_slice);
-            dest_buf[dd] = paths::SEP as OSPathChar;
-            dest_buf[dd + 1 + name_slice.len()] = 0;
-
             match current.kind {
                 sys::FileKind::Directory => {
-                    let r = self.cp_sync_inner(
-                        src_buf,
-                        (sd + 1 + name_slice.len()) as PathInt,
-                        dest_buf,
-                        (dd + 1 + name_slice.len()) as PathInt,
-                        args,
-                    );
-                    r?;
+                    pending.push(src_dir_len, dest_dir_len, name_slice);
                 }
                 _ => {
+                    src_buf[sd + 1..sd + 1 + name_slice.len()].copy_from_slice(name_slice);
+                    src_buf[sd] = paths::SEP as OSPathChar;
+                    src_buf[sd + 1 + name_slice.len()] = 0;
+
+                    dest_buf[dd + 1..dd + 1 + name_slice.len()].copy_from_slice(name_slice);
+                    dest_buf[dd] = paths::SEP as OSPathChar;
+                    dest_buf[dd + 1 + name_slice.len()] = 0;
+
                     // NUL written at [len] above; `from_buf` debug-asserts it.
                     let src_z = OSPathSliceZ::from_buf(&src_buf[..], sd + 1 + name_slice.len());
                     let dest_z = OSPathSliceZ::from_buf(&dest_buf[..], dd + 1 + name_slice.len());

--- a/src/runtime/shell/builtin/cp.rs
+++ b/src/runtime/shell/builtin/cp.rs
@@ -587,6 +587,100 @@ impl ShellCpTask {
         }
     }
 
+    fn same_inode(a: &bun_sys::Stat, b: &bun_sys::Stat) -> bool {
+        // An inode number of 0 means the filesystem reports no identity.
+        a.st_ino != 0 && a.st_ino == b.st_ino && a.st_dev == b.st_dev
+    }
+
+    /// The up-front src/dest validation `fs.cp` does (node's `checkPaths` and
+    /// `checkParentPaths`) for the final absolute pair, so a copy that cannot
+    /// succeed — notably a directory into itself, which would otherwise nest
+    /// until ENAMETOOLONG — is refused before anything is created. `appended`
+    /// is the source basename when it was joined onto the target operand.
+    fn check_paths(
+        &self,
+        src: &bun_core::ZStr,
+        tgt: &bun_core::ZStr,
+        appended: Option<&[u8]>,
+    ) -> Option<ShellErr> {
+        use bun_sys::S;
+        use resolve_path::Platform;
+
+        let custom = |msg: String| Some(ShellErr::Custom(msg.into_bytes().into_boxed_slice()));
+        let src_shown = bstr::BStr::new(&self.src);
+        let tgt_shown = || -> Vec<u8> {
+            let mut shown = self.tgt.clone();
+            if let Some(basename) = appended {
+                if !Self::has_trailing_sep(&shown) {
+                    shown.push(bun_paths::SEP);
+                }
+                shown.extend_from_slice(basename);
+            }
+            shown
+        };
+
+        // Anything this cannot see is left for the copy itself to report.
+        let Ok(src_stat) = bun_sys::lstat(src) else {
+            return None;
+        };
+        // lstat, so a symlink to a directory — copied as a link — is not one.
+        let src_is_dir = S::ISDIR(src_stat.st_mode as _);
+        if let Ok(tgt_stat) = bun_sys::lstat(tgt) {
+            if Self::same_inode(&src_stat, &tgt_stat) || src.as_bytes() == tgt.as_bytes() {
+                return custom(format!(
+                    "{src_shown} and {} are identical (not copied)",
+                    bstr::BStr::new(&tgt_shown()),
+                ));
+            }
+            let tgt_is_dir = S::ISDIR(tgt_stat.st_mode as _);
+            if src_is_dir && !tgt_is_dir {
+                return custom(format!(
+                    "cannot overwrite non-directory {} with directory {src_shown}",
+                    bstr::BStr::new(&tgt_shown()),
+                ));
+            }
+            if !src_is_dir && tgt_is_dir {
+                return custom(format!(
+                    "cannot overwrite directory {} with non-directory {src_shown}",
+                    bstr::BStr::new(&tgt_shown()),
+                ));
+            }
+        }
+
+        if !src_is_dir {
+            return None;
+        }
+        let into_itself = || {
+            custom(format!(
+                "cannot copy a directory, '{src_shown}', into itself, '{}'",
+                bstr::BStr::new(&tgt_shown()),
+            ))
+        };
+        let (s, t) = (src.as_bytes(), tgt.as_bytes());
+        if t.len() > s.len() && t.starts_with(s) && Platform::AUTO.is_separator(t[s.len()]) {
+            return into_itself();
+        }
+        // The same relationship through symlinks (or any other second name for
+        // `src`): is an ancestor of `tgt` the source directory itself?
+        let src_parent = bun_paths::dirname(s);
+        let mut path = bun_paths::path_buffer_pool::get();
+        let mut ancestor = t;
+        while let Some(parent) = bun_paths::dirname(ancestor) {
+            if Some(parent) == src_parent {
+                break;
+            }
+            path[..parent.len()].copy_from_slice(parent);
+            path[parent.len()] = 0;
+            if let Ok(stat) = bun_sys::stat(bun_core::ZStr::from_buf(&path[..], parent.len())) {
+                if Self::same_inode(&src_stat, &stat) {
+                    return into_itself();
+                }
+            }
+            ancestor = parent;
+        }
+        None
+    }
+
     /// Resolves src/tgt to absolute paths, classifies them per the three
     /// POSIX `cp` synopses
     /// (<https://man7.org/linux/man-pages/man1/cp.1p.html>), then hands off to
@@ -639,17 +733,6 @@ impl ShellCpTask {
             ));
         }
 
-        if !src_is_dir && src.as_bytes() == tgt.as_bytes() {
-            return Some(ShellErr::Custom(
-                format!(
-                    "{0} and {0} are identical (not copied)",
-                    bstr::BStr::new(&self.src)
-                )
-                .into_bytes()
-                .into_boxed_slice(),
-            ));
-        }
-
         let (tgt_is_dir, tgt_exists) = match Self::is_dir(tgt) {
             Ok(is_dir) => (is_dir, true),
             Err(e) if e.get_errno() == bun_sys::E::ENOENT => {
@@ -660,6 +743,8 @@ impl ShellCpTask {
         };
 
         let mut _copying_many = false;
+        // The source basename, once joined onto `tgt`.
+        let mut appended: Option<&[u8]> = None;
 
         // The following logic is based on the POSIX spec.
         if !src_is_dir && !tgt_is_dir && self.operands == 2 {
@@ -672,6 +757,7 @@ impl ShellCpTask {
                     buf3.as_mut_slice(),
                     &[tgt.as_bytes(), basename],
                 );
+                appended = Some(basename);
             } else if self.operands == 2 {
                 // source_dir -> new_target_dir.
             } else {
@@ -703,7 +789,12 @@ impl ShellCpTask {
                 buf3.as_mut_slice(),
                 &[tgt.as_bytes(), basename],
             );
+            appended = Some(basename);
             _copying_many = true;
+        }
+
+        if let Some(err) = self.check_paths(src, tgt, appended) {
+            return Some(err);
         }
 
         self.src_absolute = Some(src.as_bytes().to_vec());

--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -1,7 +1,9 @@
 import { $ } from "bun";
 import { shellInternals } from "bun:internal-for-testing";
-import { describe, expect } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, isMacOS, isWindows, tempDir, tempDirWithFiles } from "harness";
+import { mkdirSync, readdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { join, sep } from "node:path";
 import { bunExe, createTestBuilder } from "../test_builder";
 import { sortedShellOutput } from "../util";
 const { builtinDisabled } = shellInternals;
@@ -170,6 +172,132 @@ describe.if(!builtinDisabled("cp"))("bunshell cp", async () => {
       .fileEquals(TEST_COPY_TO_FOLDER_NEW_FILE, "Hello, World!")
       .testMini({ cwd: mini_tmpdir })
       .runAsTest("cp_recurse");
+  });
+});
+
+// These spawn a child with the builtin force-enabled so they also run on POSIX,
+// where `cp` otherwise falls through to the system binary.
+describe.concurrent("bunshell cp src/dest validation", () => {
+  async function cp(cwd: string, command: string) {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const r = await Bun.$\`${command}\`.nothrow().quiet(); process.stdout.write(r.stderr); process.exit(r.exitCode);`,
+      ],
+      cwd,
+      env: { ...bunEnv, BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1" },
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    return { stderr, exitCode };
+  }
+
+  const tree = { d: { f: "hi", sub: {} }, e: { g: "there" }, file: "x" };
+  const list = (dir: string, sub: string) => readdirSync(join(dir, sub)).sort();
+
+  test("cp -R dir dir/sub is refused and creates nothing", async () => {
+    using dir = tempDir("cp-self", tree);
+    expect(await cp(String(dir), "cp -R d d/sub")).toEqual({
+      stderr: `cp: cannot copy a directory, 'd', into itself, 'd/sub${sep}d'\n`,
+      exitCode: 1,
+    });
+    expect(list(dir, "d/sub")).toEqual([]);
+  });
+
+  test("cp -R dir dir is refused", async () => {
+    using dir = tempDir("cp-self", tree);
+    expect(await cp(String(dir), "cp -R d d")).toEqual({
+      stderr: `cp: cannot copy a directory, 'd', into itself, 'd${sep}d'\n`,
+      exitCode: 1,
+    });
+    expect(list(dir, "d")).toEqual(["f", "sub"]);
+  });
+
+  test("cp -R dir dir/new is refused", async () => {
+    using dir = tempDir("cp-self", tree);
+    expect(await cp(String(dir), "cp -R d d/sub/new")).toEqual({
+      stderr: `cp: cannot copy a directory, 'd', into itself, 'd/sub/new'\n`,
+      exitCode: 1,
+    });
+    expect(list(dir, "d/sub")).toEqual([]);
+  });
+
+  test("cp -R dir . onto itself is refused", async () => {
+    using dir = tempDir("cp-self", tree);
+    expect(await cp(String(dir), "cp -R d .")).toEqual({
+      stderr: `cp: d and .${sep}d are identical (not copied)\n`,
+      exitCode: 1,
+    });
+    expect(list(dir, "d")).toEqual(["f", "sub"]);
+  });
+
+  // Directory symlinks need extra privileges on Windows.
+  test.skipIf(isWindows)("cp -R dir link-to-dir is refused", async () => {
+    using dir = tempDir("cp-self", tree);
+    symlinkSync("d", join(String(dir), "link"));
+    expect(await cp(String(dir), "cp -R d link")).toEqual({
+      stderr: `cp: cannot copy a directory, 'd', into itself, 'link/d'\n`,
+      exitCode: 1,
+    });
+    expect(list(dir, "d")).toEqual(["f", "sub"]);
+  });
+
+  test("other sources are still copied", async () => {
+    using dir = tempDir("cp-self", tree);
+    expect(await cp(String(dir), "cp -R e d d/sub")).toEqual({
+      stderr: `cp: cannot copy a directory, 'd', into itself, 'd/sub${sep}d'\n`,
+      exitCode: 1,
+    });
+    expect(list(dir, "d/sub")).toEqual(["e"]);
+    expect(list(dir, "d/sub/e")).toEqual(["g"]);
+  });
+
+  test("directory onto an existing non-directory is refused", async () => {
+    using dir = tempDir("cp-self", { ...tree, out: { d: "not a dir" } });
+    expect(await cp(String(dir), "cp -R d out")).toEqual({
+      stderr: `cp: cannot overwrite non-directory out${sep}d with directory d\n`,
+      exitCode: 1,
+    });
+    expect(readFileSync(join(String(dir), "out/d"), "utf8")).toBe("not a dir");
+  });
+
+  test("file onto an existing directory is refused", async () => {
+    using dir = tempDir("cp-self", { ...tree, out: { file: {} } });
+    expect(await cp(String(dir), "cp file out")).toEqual({
+      stderr: `cp: cannot overwrite directory out${sep}file with non-directory file\n`,
+      exitCode: 1,
+    });
+    expect(list(dir, "out/file")).toEqual([]);
+  });
+
+  test("a sibling whose name has the source as a prefix is not itself", async () => {
+    using dir = tempDir("cp-self", tree);
+    expect(await cp(String(dir), "cp -R d d2")).toEqual({ stderr: "", exitCode: 0 });
+    expect(list(dir, "d2")).toEqual(["f", "sub"]);
+  });
+
+  // Deeper than the pool thread's stack could take when the walk used a call
+  // frame per level. macOS cannot hold a path this long (PATH_MAX is 1024) and
+  // Windows fails to create it well before this depth.
+  test.skipIf(isMacOS || isWindows)("a very deep tree is copied", async () => {
+    const depth = 800;
+    using dir = tempDir("cp-self", {});
+    const levels = [""];
+    for (let i = 0; i < depth; i++) levels.push(join(levels[i], "a"));
+    const at = (root: string, level: number) => join(String(dir), root, levels[level]);
+    mkdirSync(at("deep", depth), { recursive: true });
+    writeFileSync(join(at("deep", depth), "leaf"), "leaf");
+    try {
+      expect(await cp(String(dir), "cp -R deep out")).toEqual({ stderr: "", exitCode: 0 });
+      expect(readFileSync(join(at("out", depth), "leaf"), "utf8")).toBe("leaf");
+    } finally {
+      // Bottom-up, so disposing `dir` does not have to walk chains this deep.
+      for (const root of ["deep", "out"]) {
+        for (let i = depth; i >= 0; i--) rmSync(at(root, i), { recursive: true, force: true });
+      }
+    }
   });
 });
 

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -301,6 +301,25 @@ for (const [name, copy] of impls) {
       });
     });
 
+    // root reads through mode 000, so there is nothing to refuse.
+    test.skipIf(isWindows || process.getuid?.() === 0)(
+      "recursive - an unreadable file inside the tree is reported by its own path",
+      async () => {
+        await using basename = tempDir("cp", {
+          "from/a.txt": "a",
+          "from/sub/secret.txt": "s",
+        });
+        const secret = join(basename, "from", "sub", "secret.txt");
+        fs.chmodSync(secret, 0o000);
+        try {
+          const e = await copyShouldThrow(join(basename, "from"), join(basename, "result"), { recursive: true });
+          expect({ code: e.code, path: e.path }).toEqual({ code: "EACCES", path: secret });
+        } finally {
+          fs.chmodSync(secret, 0o600);
+        }
+      },
+    );
+
     test.skipIf(isWindows)("recursive - FIFO inside the tree is rejected with ERR_FS_CP_FIFO_PIPE", async () => {
       await using basename = tempDir("cp", {
         "from/a.txt": "a",


### PR DESCRIPTION
### What does this PR do?

`Bun.$` cp (the builtin, default on Windows, `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1` elsewhere) crashed the process on `cp -R d d/sub`: it handed the copy straight to the native recursive walker, which kept nesting `d/sub/d/sub/...` until the pool thread's 4 MB stack overflowed in the per-directory recursion (SIGSEGV on Linux, ~490 nested dirs left behind).

Two changes:

- **shell cp validates src/dest up front**, mirroring the checks `fs.cp` already does in JS (node's `checkPaths`/`checkParentPaths`) on the final absolute pair: same inode, directory onto an existing non-directory (and vice versa), and destination equal to or below the source directory — by path prefix and by walking the destination's ancestors' inodes so symlinked spellings are caught. Each prints a normal `cp: ...` error (GNU wording for the into-itself case), exits 1, and creates nothing; other sources in the same command still copy.
- **The sync and async native directory walkers are iterative.** Instead of a call frame per level (each with an 8 KB dirent buffer and an open fd), they keep a LIFO of pending subdirectory names over the shared path buffers and re-enter one loop. Depth is still bounded by the existing ENAMETOOLONG check, but a deep tree now costs a few bytes of heap per level rather than a worker/pool thread stack.

Supersedes #37927.

### How did you verify your code works?

New tests in `test/js/bun/shell/commands/cp.test.ts` (spawned with the builtin force-enabled so they run on POSIX too): into-sub/self/new/`.`/through-symlink refusals with the tree left untouched, dir↔non-dir refusals, prefix-named sibling still copies, and an 800-level tree copy (Linux). Ran them and `test/js/node/fs/cp.test.ts` on macOS arm64 and Linux x64 debug builds; on Linux the release binary segfaults on both the self-copy and the 800-level tree while the patched build refuses / copies. Also drove `fs.cpSync`, `fs.promises.cp` and shell `cp -R` over a 460-level tree on an HFS+ volume (no clonefile, so the macOS walkers actually run) and compared trees. Windows x64 debug build: `test/js/bun/shell/commands/cp.test.ts` 38 pass / 2 skip (the POSIX-symlink and Linux-only deep-tree cases) / 0 fail.

Also, while in the async walker: on macOS it returned the `clonefile` EACCES/EPERM error for the whole directory even with `force` set, where `cpSync` falls back to the per-entry walk and reports the entry that is actually unreadable. The async path now takes the same fallback; covered for both impls in `test/js/node/fs/cp.test.ts`.
