### PR TITLE
css: wrap a one-argument min()/max() sum or product in calc()

### DIFF
--- a/src/css/values/calc.rs
+++ b/src/css/values/calc.rs
@@ -351,28 +351,15 @@ impl<V: CalcValue> Calc<V> {
                 Ok(Calc::Function(Box::new(MathFunction::Calc(calc))))
             }
             CalcUnit::Min => {
-                let mut reduced = input.parse_nested_block(|i| {
-                    i.parse_comma_separated(|i| Self::parse_sum(i, ctx, parse_ident))
-                })?;
-                // PERF(alloc): i don't like this additional allocation
-                // can we use stack fallback here if the common case is that there will be 1 argument?
-                Self::reduce_args(&mut reduced, Ordering::Less);
-                if reduced.len() == 1 {
-                    return Ok(reduced.swap_remove(0));
-                }
-                Ok(Calc::Function(Box::new(MathFunction::Min(reduced))))
+                Self::parse_min_max(input, Ordering::Less, MathFunction::Min, ctx, parse_ident)
             }
-            CalcUnit::Max => {
-                let mut reduced = input.parse_nested_block(|i| {
-                    i.parse_comma_separated(|i| Self::parse_sum(i, ctx, parse_ident))
-                })?;
-                // PERF: i don't like this additional allocation
-                Self::reduce_args(&mut reduced, Ordering::Greater);
-                if reduced.len() == 1 {
-                    return Ok(reduced.remove(0));
-                }
-                Ok(Calc::Function(Box::new(MathFunction::Max(reduced))))
-            }
+            CalcUnit::Max => Self::parse_min_max(
+                input,
+                Ordering::Greater,
+                MathFunction::Max,
+                ctx,
+                parse_ident,
+            ),
             CalcUnit::Clamp => {
                 let (mut min, mut center, mut max) = input.parse_nested_block(|i| {
                     let min = Self::parse_sum(i, ctx, parse_ident)?;
@@ -544,6 +531,27 @@ impl<V: CalcValue> Calc<V> {
                 Ok(Calc::Function(Box::new(MathFunction::Sign(v))))
             }),
         }
+    }
+
+    fn parse_min_max<C: Copy>(
+        input: &mut css::Parser,
+        order: Ordering,
+        function: fn(Vec<Self>) -> MathFunction<V>,
+        ctx: C,
+        parse_ident: impl Fn(C, &[u8]) -> Option<Self> + Copy,
+    ) -> CssResult<Self> {
+        let mut args = input.parse_nested_block(|i| {
+            i.parse_comma_separated(|i| Self::parse_sum(i, ctx, parse_ident))
+        })?;
+        Self::reduce_args(&mut args, order);
+        if args.len() == 1 {
+            // min(x) and max(x) are x, but a bare sum or product is only valid inside a math function.
+            return Ok(match args.swap_remove(0) {
+                arg @ (Calc::Value(_) | Calc::Number(_) | Calc::Function(_)) => arg,
+                arg => Calc::Function(Box::new(MathFunction::Calc(arg))),
+            });
+        }
+        Ok(Calc::Function(Box::new(function(args))))
     }
 
     pub(crate) fn parse_numeric_fn<C: Copy>(

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -191,6 +191,52 @@ describe("css tests", () => {
     ); // ideally -400% - 8vh + 3ic
     minify_test(`a { top: calc(100% - 1 * 2 - 8 * 2); }`, `a{top:calc(100% - 2 - 16)}`); // ideally 100% - 18
   });
+  describe("min() and max() with a single remaining argument", () => {
+    // min(x) and max(x) evaluate to x. When x does not fold to a single value it
+    // is a sum or a product, which is only valid CSS inside a math function, so
+    // it has to come out wrapped in calc() rather than bare.
+    minify_test(`a { width: min(1px + 10%) }`, `a{width:calc(1px + 10%)}`);
+    minify_test(`a { width: max(1px + 10%) }`, `a{width:calc(1px + 10%)}`);
+    minify_test(`a { width: min(-1px - 10%) }`, `a{width:calc(-1px - 10%)}`);
+    minify_test(`a { width: min(2 * min(1px, 1em)) }`, `a{width:calc(2*min(1px,1em))}`);
+    minify_test(`a { width: max(max(1px, 1em) / 2) }`, `a{width:calc(max(1px,1em)/2)}`);
+    minify_test(`a { width: max(2 * (1px + 10%)) }`, `a{width:calc(2px + 20%)}`);
+    minify_test(`a { margin: min(1px + 10%) auto }`, `a{margin:calc(1px + 10%) auto}`);
+    minify_test(`a { inset: max(1px + 10%) }`, `a{inset:calc(1px + 10%)}`);
+    // A nested calc() or one-argument min()/max() is unwrapped while parsing the
+    // outer function's argument; the outer function has to wrap the result again.
+    minify_test(`a { width: min(calc(1px + 10%)) }`, `a{width:calc(1px + 10%)}`);
+    minify_test(`a { width: min(max(1px + 10%)) }`, `a{width:calc(1px + 10%)}`);
+    // <length> (border-spacing) and <angle-percentage> (conic-gradient color stop)
+    // store an unevaluated expression the same way <length-percentage> does.
+    minify_test(`a { border-spacing: max(1px + 1em) }`, `a{border-spacing:calc(1px + 1em)}`);
+    minify_test(`a { border-spacing: min(2 * max(1px, 1em)) }`, `a{border-spacing:calc(2*max(1px,1em))}`);
+    minify_test(
+      `a { background: conic-gradient(red min(10deg + 10%), blue) }`,
+      `a{background:conic-gradient(red calc(10deg + 10%),#00f)}`,
+    );
+    minify_test(
+      `a { background: conic-gradient(red max(2 * max(10deg, 10%)), blue) }`,
+      `a{background:conic-gradient(red calc(2*max(10deg,10%)),#00f)}`,
+    );
+    // An argument that folds to a value, or is itself a math function, is returned as is.
+    minify_test(`a { width: min(5px) }`, `a{width:5px}`);
+    minify_test(`a { width: min(1px + 2px) }`, `a{width:3px}`);
+    minify_test(`a { width: max(10% + 5%) }`, `a{width:15%}`);
+    minify_test(`a { width: min(3px, 5px) }`, `a{width:3px}`);
+    minify_test(`a { width: max(3px, 5px) }`, `a{width:5px}`);
+    minify_test(`a { width: max(min(1px, 1em)) }`, `a{width:min(1px,1em)}`);
+    minify_test(`a { line-height: min(1 + 2) }`, `a{line-height:3}`);
+    minify_test(`a { opacity: max(10% + 20%) }`, `a{opacity:.3}`);
+    minify_test(`a { transition-duration: min(1s + 500ms) }`, `a{transition-duration:1.5s}`);
+    minify_test(`a { rotate: max(90deg + 0.25turn) }`, `a{rotate:180deg}`);
+    // With more than one argument left, or nested inside another expression, nothing changes.
+    minify_test(`a { width: min(1px + 10%, 1em + 5%) }`, `a{width:min(1px + 10%,1em + 5%)}`);
+    minify_test(`a { width: max(3px, 1px + 10%) }`, `a{width:max(3px,1px + 10%)}`);
+    minify_test(`a { width: min(max(1px + 10%), 1em) }`, `a{width:min(1px + 10%,1em)}`);
+    minify_test(`a { width: calc(min(1px + 10%) * 2) }`, `a{width:calc(2px + 20%)}`);
+    minify_test(`a { width: calc(min(1px + 10%) + 5px) }`, `a{width:calc(6px + 10%)}`);
+  });
   describe("border_spacing", () => {
     minify_test(
       `


### PR DESCRIPTION
### Problem
- The CSS minifier (`bun build` on a `.css` file, `Bun.build`) turns a `min()` or `max()` whose only argument is a sum or a product into that bare expression, which browsers reject because a sum or product is only valid inside a math function:
  - `width: min(1px + 10%)` prints `width:1px + 10%`
  - `width: max(1px + 10%)` prints `width:1px + 10%`
  - `width: min(2 * min(1px, 1em))` prints `width:2*min(1px,1em)`
  - same for `<length>` (`border-spacing: max(1px + 1em)` prints `1px + 1em`) and `<angle-percentage>` (`conic-gradient(red min(10deg + 10%), blue)` prints `red 10deg + 10%`)
- Cause: the `Min` / `Max` arms of `Calc::parse_with` (`src/css/values/calc.rs:360` and `:371` before this change) return the one remaining argument as is. That is right for a value or a nested math function, but `1px + 10%` parses to a `Calc::Sum` and `2 * min(...)` to a `Calc::Product`, and `DimensionPercentage::parse` (`percentage.rs:167`) / `Length::parse` (`length.rs:422`) store whatever non-value calc they get and print it with `Calc::to_css`, which writes a `Sum` / `Product` without any function around it (`calc.rs:1002-1029`). The `calc()` arm right above (`calc.rs:346-351`) already wraps such a result in `MathFunction::Calc`, and every other arm either folds to a value or keeps its own function around an argument it could not fold; the arms that hand an argument back unwrapped are `min()` / `max()` (this PR) and one-argument `hypot()` (#38639, see below).
- Reproduces on bun 1.4.0 and on main. lightningcss 1.30.2 (and its current master) print the same invalid output, so matching upstream is not the goal here; valid output is.

### Fix
- The `Min` and `Max` arms now go through one `parse_min_max` helper (they were the same block twice). The behavior change is its last match: a single remaining `Calc::Value` / `Calc::Number` / `Calc::Function` is still returned unchanged, a `Calc::Sum` / `Calc::Product` is wrapped in `MathFunction::Calc`, so `min(1px + 10%)` prints as `calc(1px + 10%)` and `min(2 * min(1px, 1em))` as `calc(2*min(1px,1em))`.
- Why this is correct: `min(x)` and `max(x)` are `x` by definition (CSS Values 4), and `calc(x)` is the one form of a top-level sum or product that is valid CSS. It is also the representation the rest of the code already produces and expects for the same expression written as `calc(1px + 10%)` (the `calc()` arm, `Length::add`), so `min(1px + 10%)` and `calc(1px + 10%)` now serialize identically.
- Nested uses are byte-for-byte unchanged: when `min()` / `max()` appears inside another math function, `parse_value` (`calc.rs:676`) strips a `MathFunction::Calc` wrapper again, so `calc(min(1px + 10%) * 2)` still folds to `calc(2px + 20%)` and `min(max(1px + 10%), 1em)` still prints `min(1px + 10%,1em)`. Contexts that only accept a fully folded value (`<number>`, `<percentage>`, `<angle>`, `<time>`, relative color channels) rejected a non-value result before and still do.
- Not changed here: one-argument `hypot()` has the same bare-sum symptom, but `hypot(x)` is `abs(x)`, not `x`, so wrapping its argument in `calc()` would be wrong; #38639 handles it by keeping `hypot(...)` when the argument does not fold. The two `PERF` notes on the old arms are dropped with the arms; `reduce_args`' own doc comment says the same thing.
- Test: `test/js/bun/css/css.test.ts`, new `min() and max() with a single remaining argument` block (29 cases): the sum / product / negated sum / nested `calc()` / nested one-argument `max()` forms in `<length-percentage>`, `<length>` and `<angle-percentage>` properties and in shorthands, plus the unchanged cases (arguments that fold to a value, a math function as the argument, `<number>` / `<percentage>` / `<time>` / `<angle>` contexts, two or more remaining arguments, and `min()` nested inside `calc()`).
  - without the `src/` change (bun 1.4.0 via `USE_SYSTEM_BUN=1`): 14 of the 29 fail with the bare output above, 15 pass
  - with it (`bun bd test`): 29 pass; full `css.test.ts`: 1171 pass, 0 fail; `color.test.ts` 993 pass; `doesnt_crash.test.ts` 61 pass
  - `cargo clippy -p bun_css` and `cargo fmt --check` are clean

### Background
- `Calc<V>` (`src/css/values/calc.rs`) is the parsed form of a math expression: `Value` (a folded `1px`, `10%`, ...), `Number`, `Sum`, `Product` (a number times an expression that could not be folded into it), or `Function` (a `MathFunction`: `calc()`, `min()`, `max()`, `clamp()`, ...). Anything that can be folded while parsing is folded, so `1px + 2px` becomes a `Value` and only expressions mixing incompatible units (`1px + 10%`, `2 * min(1px, 1em)`) stay as a `Sum` / `Product`.
- `Calc::parse_with` parses one math function token and returns the `Calc` it stands for. Its result either gets stored by a value type that can hold an unevaluated expression (`DimensionPercentage::Calc` for `<length-percentage>` / `<angle-percentage>`, `Length::Calc` for `<length>`) and is later printed by `Calc::to_css`, or, when the function was nested inside another one, goes back through `parse_value`, which unwraps a `calc()` so the surrounding expression can keep folding.
- `Calc::to_css` prints a `Sum` as `a + b` and a `Product` as `n*x` / `x/n` with no function around them; the function name is only printed by `MathFunction::to_css`. A stored top-level `Calc` therefore has to be a `Value`, a `Number`, or a `Function` to print valid CSS, which is what the `calc()` arm's wrapping guarantees and what this change makes `min()` / `max()` guarantee too.
- `reduce_args` drops the arguments of `min()` / `max()` that a comparable argument makes redundant (`min(1px, 2px, 1em)` becomes `min(1px, 1em)`). It only compares values, so a sum or product can only be the single remaining argument when it was the only argument written (possibly through nesting, as in `min(max(1px + 10%))`).

<details>
<summary>Before / after for the inputs in the test</summary>

```
input                                                   bun 1.4.0 / main                          this PR
width: min(1px + 10%)                                   width:1px + 10%                           width:calc(1px + 10%)
width: max(1px + 10%)                                   width:1px + 10%                           width:calc(1px + 10%)
width: min(-1px - 10%)                                  width:-1px - 10%                          width:calc(-1px - 10%)
width: min(2 * min(1px, 1em))                           width:2*min(1px,1em)                      width:calc(2*min(1px,1em))
width: max(max(1px, 1em) / 2)                           width:max(1px,1em)/2                      width:calc(max(1px,1em)/2)
width: max(2 * (1px + 10%))                             width:2px + 20%                           width:calc(2px + 20%)
margin: min(1px + 10%) auto                             margin:1px + 10% auto                     margin:calc(1px + 10%) auto
inset: max(1px + 10%)                                   inset:1px + 10%                           inset:calc(1px + 10%)
width: min(calc(1px + 10%))                             width:1px + 10%                           width:calc(1px + 10%)
width: min(max(1px + 10%))                              width:1px + 10%                           width:calc(1px + 10%)
border-spacing: max(1px + 1em)                          border-spacing:1px + 1em                  border-spacing:calc(1px + 1em)
border-spacing: min(2 * max(1px, 1em))                  border-spacing:2*max(1px,1em)             border-spacing:calc(2*max(1px,1em))
conic-gradient(red min(10deg + 10%), blue)              red 10deg + 10%,#00f                      red calc(10deg + 10%),#00f
conic-gradient(red max(2 * max(10deg, 10%)), blue)      red 2*max(10deg,10%),#00f                 red calc(2*max(10deg,10%)),#00f

unchanged:
width: min(5px)                                         5px                                       5px
width: min(1px + 2px)                                   3px                                       3px
width: max(10% + 5%)                                    15%                                       15%
width: min(3px, 5px) / max(3px, 5px)                    3px / 5px                                 3px / 5px
width: max(min(1px, 1em))                               min(1px,1em)                              min(1px,1em)
line-height: min(1 + 2)                                 3                                         3
opacity: max(10% + 20%)                                 .3                                        .3
transition-duration: min(1s + 500ms)                    1.5s                                      1.5s
rotate: max(90deg + 0.25turn)                           180deg                                    180deg
width: min(1px + 10%, 1em + 5%)                         min(1px + 10%,1em + 5%)                   min(1px + 10%,1em + 5%)
width: max(3px, 1px + 10%)                              max(3px,1px + 10%)                        max(3px,1px + 10%)
width: min(max(1px + 10%), 1em)                         min(1px + 10%,1em)                        min(1px + 10%,1em)
width: calc(min(1px + 10%) * 2)                         calc(2px + 20%)                           calc(2px + 20%)
width: calc(min(1px + 10%) + 5px)                       calc(6px + 10%)                           calc(6px + 10%)
```
</details>
