### PR TITLE
test/bundler: fail the file when itBundled registration throws anything but an auto-skip

### DIFF
--- a/test/bundler/bundler_jsx.test.ts
+++ b/test/bundler/bundler_jsx.test.ts
@@ -115,8 +115,9 @@ function itBundledDevAndProd(
     prodTodo?: boolean;
   },
 ) {
-  const { devStdout, prodStdout, ...rest } = opts;
+  const { devStdout, prodStdout, devTodo, prodTodo, ...rest } = opts;
   itBundled(id + "Dev", {
+    todo: devTodo,
     ...rest,
     env: {
       NODE_ENV: "development",
@@ -129,6 +130,7 @@ function itBundledDevAndProd(
       : rest.run,
   });
   itBundled(id + "Prod", {
+    todo: prodTodo,
     ...rest,
     env: {
       NODE_ENV: "production",

--- a/test/bundler/esbuild/default.test.ts
+++ b/test/bundler/esbuild/default.test.ts
@@ -234,7 +234,6 @@ describe.concurrent("bundler", () => {
       "/e.js": "export default class Foo {}",
     },
     entryPoints: ["/a.js", "/b.js", "/c.js", "/d.js", "/e.js"],
-    mode: "bundle",
     bundling: false,
     runtimeFiles: {
       "./out/f.js": /* js */ `
@@ -4859,7 +4858,7 @@ describe.concurrent("bundler", () => {
       "/is-main.js": `module.exports = require.main === module`,
     },
     format: "cjs",
-    platform: "node",
+    target: "node",
   });
   itBundled("default/ExternalES6ConvertedToCommonJS", {
     todo: true,

--- a/test/bundler/esbuild/lower.test.ts
+++ b/test/bundler/esbuild/lower.test.ts
@@ -1544,7 +1544,7 @@ describe.todo("bundler", () => {
         console.log(new Foo().bar === 123)
       `,
     },
-    mode: "passthrough",
+    bundling: false,
   });
   itBundled("lower/LowerPrivateClassMethodOrder", {
     // GENERATED
@@ -1557,7 +1557,7 @@ describe.todo("bundler", () => {
         console.log(new Foo().bar === 123)
       `,
     },
-    mode: "passthrough",
+    bundling: false,
   });
   itBundled("lower/LowerPrivateClassAccessorOrder", {
     // GENERATED
@@ -1570,7 +1570,7 @@ describe.todo("bundler", () => {
         console.log(new Foo().bar === 123)
       `,
     },
-    mode: "passthrough",
+    bundling: false,
   });
   itBundled("lower/LowerPrivateClassStaticFieldOrder", {
     // GENERATED
@@ -1589,7 +1589,7 @@ describe.todo("bundler", () => {
         console.log(FooThis.bar === 123)
       `,
     },
-    mode: "passthrough",
+    bundling: false,
   });
   itBundled("lower/LowerPrivateClassStaticMethodOrder", {
     // GENERATED
@@ -1608,7 +1608,7 @@ describe.todo("bundler", () => {
         console.log(FooThis.bar === 123)
       `,
     },
-    mode: "passthrough",
+    bundling: false,
   });
   itBundled("lower/LowerPrivateClassStaticAccessorOrder", {
     // GENERATED
@@ -1627,7 +1627,7 @@ describe.todo("bundler", () => {
         console.log(FooThis.bar === 123)
       `,
     },
-    mode: "passthrough",
+    bundling: false,
   });
   itBundled("lower/LowerPrivateClassBrandCheckUnsupported", {
     // GENERATED
@@ -1646,7 +1646,7 @@ describe.todo("bundler", () => {
         }
       `,
     },
-    mode: "passthrough",
+    bundling: false,
   });
   itBundled("lower/LowerPrivateClassBrandCheckSupported", {
     // GENERATED
@@ -1665,7 +1665,7 @@ describe.todo("bundler", () => {
         }
       `,
     },
-    mode: "passthrough",
+    bundling: false,
   });
   itBundled("lower/LowerTemplateObject", {
     // GENERATED
@@ -1675,7 +1675,7 @@ describe.todo("bundler", () => {
           tag\` + "\`x\`" +
       `,
     },
-    mode: "passthrough",
+    bundling: false,
   });
   itBundled("lower/LowerPrivateClassFieldStaticESBuildIssue1424", {
     // GENERATED
@@ -1774,7 +1774,7 @@ describe.todo("bundler", () => {
         ]
       `,
     },
-    mode: "passthrough",
+    bundling: false,
   });
   itBundled("lower/LowerForAwait2015", {
     // GENERATED
@@ -1788,7 +1788,7 @@ describe.todo("bundler", () => {
         ]
       `,
     },
-    mode: "passthrough",
+    bundling: false,
   });
   itBundled("lower/LowerNestedFunctionDirectEval", {
     // GENERATED
@@ -1803,6 +1803,6 @@ describe.todo("bundler", () => {
       "/8.js": `'use strict'; if (foo) { eval(''); function x() {} }`,
     },
     entryPoints: ["/1.js", "/2.js", "/3.js", "/4.js", "/5.js", "/6.js", "/7.js", "/8.js"],
-    mode: "passthrough",
+    bundling: false,
   });
 });

--- a/test/bundler/expectBundled.md
+++ b/test/bundler/expectBundled.md
@@ -14,7 +14,7 @@ In addition to comparing the bundle outputs against snapshots, **most test cases
 
 On top of `expectBundled`, there is also `itBundled` which wraps `expectBundled` and `it` together, which is what we mostly use in our tests.
 
-These two functions have many options you can pass to it, check the examples below for some common use cases, then look at the `BundlerTestInput` for a complete set of options. Not all of the options are implemented; these tests get auto-skipped.
+These two functions have many options you can pass to it, check the examples below for some common use cases, then look at the `BundlerTestInput` for a complete set of options. Not all of the options are implemented; tests that use one of those (or a combination the current backend cannot run) get auto-skipped: `itBundled` registers nothing for them. An option that `BundlerTestInput` does not declare at all is treated as a typo and fails the test file while it is being loaded.
 
 ## Running tests
 

--- a/test/bundler/expectBundled.test.ts
+++ b/test/bundler/expectBundled.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isCI, isDebug, isWindows } from "harness";
+import { itBundled } from "./expectBundled";
+
+// The itBundled registrations under test must not land in this file's own run, so the file doubles as
+// its own fixture: spawned with EXPECT_BUNDLED_TEST_CASE set it registers that case and nothing else,
+// and the tests below spawn it that way and assert on what the child printed.
+const CASE = "EXPECT_BUNDLED_TEST_CASE";
+const files = { "/entry.js": /* js */ `console.log("hi");` };
+// Each child loads expectBundled.ts and maybe bundles one file, which takes a while in a debug build.
+// In CI the runner's --timeout applies, as it does to the itBundled tests themselves.
+const childTimeout = isCI ? undefined : isDebug ? Infinity : 30_000;
+
+switch (process.env[CASE]) {
+  case "unknown options":
+    describe("an option BundlerTestInput does not declare", () => {
+      itBundled("harness/Typo", {
+        files,
+        // @ts-expect-error the typo is the point
+        bundeling: false,
+      });
+    });
+    describe("next to an option the harness skips the test for", () => {
+      itBundled("harness/TypoAndUnimplemented", {
+        files,
+        mangleProps: /_$/,
+        // @ts-expect-error esbuild's name for `target`
+        platform: "node",
+      });
+    });
+    describe("on a todo test", () => {
+      itBundled("harness/TypoOnTodo", {
+        todo: true,
+        files,
+        // @ts-expect-error esbuild's name for `bundling`
+        mode: "passthrough",
+      });
+    });
+    break;
+
+  case "skipped options":
+    describe("bundler", () => {
+      itBundled("harness/Registers", { files });
+      // Implemented for the esbuild backend only.
+      itBundled("harness/EsbuildOnlyOption", { files, legalComments: "none" });
+      // Declared in BundlerTestInput, passed to neither backend.
+      itBundled("harness/UnimplementedOption", { files, mangleProps: /_$/ });
+      // Combination bun build does not support yet.
+      itBundled("harness/NoBundleTwoEntryPoints", {
+        files: { "/a.js": ``, "/b.js": `` },
+        entryPoints: ["/a.js", "/b.js"],
+        bundling: false,
+      });
+    });
+    break;
+
+  default:
+    describe.concurrent("itBundled registration", () => {
+      test(
+        "a test passing an option the harness does not know fails the file instead of disappearing",
+        async () => {
+          const { output, exitCode } = await runBunTest({ [CASE]: "unknown options" });
+          expect(output.match(/^error: expectBundled\(.*$/gm)).toEqual([
+            'error: expectBundled("harness/Typo", ...) received unknown options: bundeling',
+            'error: expectBundled("harness/TypoAndUnimplemented", ...) received unknown options: platform',
+            'error: expectBundled("harness/TypoOnTodo", ...) received unknown options: mode',
+          ]);
+          expect(exitCode).toBe(1);
+        },
+        childTimeout,
+      );
+
+      // itBundled registers nothing on Windows for now (see the isWindows return in it), so there is
+      // nothing to tell apart there.
+      test.skipIf(isWindows)(
+        "tests the current backend or the harness cannot run register nothing, the rest still register",
+        async () => {
+          const { output, exitCode } = await runBunTest({ [CASE]: "skipped options" });
+          expect(registeredIds(output)).toEqual(["harness/Registers"]);
+          expect(output).toContain("1 pass");
+          expect(exitCode).toBe(0);
+        },
+        childTimeout,
+      );
+    });
+}
+
+/** The ids the child reported a result for, in any state (pass, fail, skip, todo). */
+function registeredIds(output: string) {
+  return [...output.matchAll(/^\((?:pass|fail|skip|todo)\) .*?(harness\/\w+)/gm)].map(m => m[1]);
+}
+
+async function runBunTest(env: Record<string, string>) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", import.meta.path],
+    cwd: import.meta.dir,
+    env: {
+      ...bunEnv,
+      // A developer's shell may carry these; they would change what the child registers.
+      BUN_BUNDLER_TEST_FILTER: undefined,
+      BUN_BUNDLER_TEST_USE_ESBUILD: undefined,
+      BUN_BUNDLER_TEST_DEBUG: undefined,
+      BUN_BUNDLER_TEST_HIDE_SKIP: undefined,
+      ...env,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { output: stdout + stderr, exitCode };
+}

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -16,7 +16,7 @@ import {
   rmSync,
   writeFileSync,
 } from "fs";
-import { bunEnv, bunExe, isCI, isDebug } from "harness";
+import { bunEnv, bunExe, isCI, isDebug, isWindows } from "harness";
 import { tmpdir } from "os";
 import path from "path";
 import { SourceMapConsumer } from "source-map";
@@ -463,18 +463,36 @@ function testRef(id: string, options: BundlerTestInput): BundlerTestRef {
   return { id, options };
 }
 
+/**
+ * Thrown by the option checks at the top of `expectBundled` when a test, as written, cannot run on
+ * the current backend or uses an option the harness does not implement. `itBundled` registers
+ * nothing for such a test (expectBundled.md: "these tests get auto-skipped"). Anything else thrown
+ * while a test is being registered is a mistake in the test and fails the file.
+ */
+class NotImplementedError extends Error {}
+
+/**
+ * Declared in `BundlerTestInput` but not passed to either backend: a test that sets one is skipped.
+ * An option that is not declared at all is a typo and fails the file.
+ */
+const unimplementedOptions: ReadonlySet<string> = new Set([
+  "alias",
+  "entryPointsAdvanced",
+  "extensionOrder",
+  "mangleProps",
+  "mangleQuoted",
+  "nodePaths",
+  "skipIfWeDidNotImplementWildcardSideEffects",
+  "stdin",
+  "targetFromAPI",
+] satisfies (keyof BundlerTestInput)[]);
+
 function expectBundled(
   id: string,
   opts: BundlerTestInput,
   dryRun = false,
   ignoreFilter = false,
 ): Promise<BundlerTestRef> | BundlerTestRef {
-  if (!new Error().stack!.includes("test/bundler/")) {
-    throw new Error(
-      `All bundler tests must be placed in ./test/bundler/ so that regressions can be quickly detected locally via the 'bun test bundler' command`,
-    );
-  }
-
   var { expect, it, test } = testForFile(currentFile ?? callerSourceOrigin());
   if (!ignoreFilter && FILTER && !filterMatches(id)) return testRef(id, opts);
 
@@ -553,6 +571,8 @@ function expectBundled(
     generateOutput = true,
     onAfterApiBundle,
     throw: _throw = false,
+    // Read by itBundled when it registers the test.
+    timeoutScale: _timeoutScale,
     ...unknownProps
   } = opts;
 
@@ -560,9 +580,12 @@ function expectBundled(
     splitting = true;
   }
 
-  // TODO: Remove this check once all options have been implemented
+  const unknownOptions = Object.keys(unknownProps).filter(option => !unimplementedOptions.has(option));
+  if (unknownOptions.length > 0) {
+    throw new Error(`expectBundled("${id}", ...) received unknown options: ${unknownOptions.join(", ")}`);
+  }
   if (Object.keys(unknownProps).length > 0) {
-    throw new Error("expectBundled received unexpected options: " + Object.keys(unknownProps).join(", "));
+    throw new NotImplementedError(`${Object.keys(unknownProps).join(", ")} not implemented in expectBundled`);
   }
 
   // This is a sanity check that protects against bad copy pasting.
@@ -597,46 +620,47 @@ function expectBundled(
           : entryPoints.length === 1;
 
   if (bundling === false && entryPoints.length > 1) {
-    throw new Error("bundling:false only supports a single entry point");
+    // Several entry points need --outdir, which `bun build --no-bundle` does not write to yet (#9859).
+    throw new NotImplementedError("bundling:false only supports a single entry point");
   }
 
   if (!ESBUILD && legalComments) {
-    throw new Error("legalComments not implemented in bun build");
+    throw new NotImplementedError("legalComments not implemented in bun build");
   }
   if (!ESBUILD && unsupportedJSFeatures && unsupportedJSFeatures.length) {
-    throw new Error("unsupportedJSFeatures not implemented in bun build");
+    throw new NotImplementedError("unsupportedJSFeatures not implemented in bun build");
   }
   if (!ESBUILD && unsupportedCSSFeatures && unsupportedCSSFeatures.length) {
-    throw new Error("unsupportedCSSFeatures not implemented in bun build");
+    throw new NotImplementedError("unsupportedCSSFeatures not implemented in bun build");
   }
   if (!ESBUILD && mainFields) {
-    throw new Error("mainFields not implemented in bun build");
+    throw new NotImplementedError("mainFields not implemented in bun build");
   }
   if (!ESBUILD && inject) {
-    throw new Error("inject not implemented in bun build");
+    throw new NotImplementedError("inject not implemented in bun build");
   }
   if (!ESBUILD && loader) {
     const loaderValues = [...new Set(Object.values(loader))];
     const supportedLoaderTypes = ["js", "jsx", "ts", "tsx", "css", "json", "text", "file", "wtf", "toml"];
     const unsupportedLoaderTypes = loaderValues.filter(x => !supportedLoaderTypes.includes(x));
     if (unsupportedLoaderTypes.length > 0) {
-      throw new Error(`loader '${unsupportedLoaderTypes.join("', '")}' not implemented in bun build`);
+      throw new NotImplementedError(`loader '${unsupportedLoaderTypes.join("', '")}' not implemented in bun build`);
     }
   }
   if (ESBUILD && bytecode) {
-    throw new Error("bytecode not implemented in esbuild");
+    throw new NotImplementedError("bytecode not implemented in esbuild");
   }
   if (ESBUILD && skipOnEsbuild) {
     return testRef(id, opts);
   }
   if (ESBUILD && dotenv) {
-    throw new Error("dotenv not implemented in esbuild");
+    throw new NotImplementedError("dotenv not implemented in esbuild");
   }
   if (ESBUILD && _throw) {
-    throw new Error("throw not implemented in esbuild");
+    throw new NotImplementedError("throw not implemented in esbuild");
   }
   if (ESBUILD && allowUnresolved !== undefined) {
-    throw new Error("allowUnresolved not possible in esbuild backend");
+    throw new NotImplementedError("allowUnresolved not possible in esbuild backend");
   }
   if (dryRun) {
     return testRef(id, opts);
@@ -1898,8 +1922,12 @@ export function itBundled(
     try {
       expectBundled(id, opts, true);
     } catch (error) {
-      return ref;
+      if (error instanceof NotImplementedError) return ref;
+      throw error;
     }
+    // itBundled tests have not been registered on Windows since #15181 (the dry run threw on every one
+    // of them there) and about 55 of them fail on it now. #34552 fixes or gates those and deletes this line.
+    if (isWindows) return ref;
   }
 
   if (opts.todo && !FILTER) {


### PR DESCRIPTION
### Problem
- `itBundled()` dry-runs `expectBundled()` while the test file is being collected, inside `try { expectBundled(id, opts, true); } catch (error) { return ref; }` (`test/bundler/expectBundled.ts:1899` on main).
- Only the `... not implemented in bun build` / `... in esbuild` throws in that dry run are meant to skip the test (expectBundled.md: "these tests get auto-skipped"). The catch is bare, so every other throw also ends as a test that is never registered: no skip or todo line, `bun test` exits 0.
- Repro with the released bun: a file under `test/bundler/` with `itBundled("x", { files: { "/a.js": "" }, bogusOption: 1 })` reports `Ran 0 tests` and exits 0. The `expectBundled received unexpected options: bogusOption` thrown at `expectBundled.ts:565` is never seen.
- Logging what the catch swallows during a registration-only run (`bun test bundler -t '^$'`): 136 registrations. 86 are backend auto-skips and 25 set options `BundlerTestInput` declares but the harness never wires up (`mangleProps`, `alias`, `nodePaths`, `skipIfWeDidNotImplementWildcardSideEffects`); both intended. The other 25 are dead tests nobody knew about:
  - 16 pass an option that does not exist: esbuild's `mode` (13 tests), esbuild's `platform` (1), `prodTodo` (2).
  - 7 hit the `bundling:false only supports a single entry point` check.
  - 2 set `timeoutScale` (#34542).
- #34552 (every `itBundled` test on Windows) is this same catch swallowing yet another throw.

### Fix
- The auto-skip throws in `expectBundled` now throw a module-private `NotImplementedError`. `itBundled` returns without registering for that class and rethrows everything else.
- Why that is right: a rethrown error leaves the `describe` callback that called `itBundled`, and `bun test` already reports that and exits 1, as it does for any other error while collecting a file. The message names the test id and the stack points at the `itBundled` call. The catch was the only thing exempting `itBundled` from the behavior every other registration-time mistake gets.
- Options `BundlerTestInput` declares but the harness does not pass to either backend are listed in `unimplementedOptions` (typed against `keyof BundlerTestInput`) and still skip. Whatever else is left after the destructure is undeclared and throws a plain `Error`; that is checked first, so a test with both still fails.
- `timeoutScale` is destructured because `itBundled` reads it (same hunk as #34542). `edgecase/AwsCdkLib` and `plugin/ResolveManySegfault` register again and pass.
- The `bundling:false` + several entry points check becomes a skip too: several entry points need `--outdir`, which `bun build --no-bundle` does not write to (#9859), so it is a backend limitation like the others. Lifting it when #9859 is fixed brings those tests back.
- The 16 tests with nonexistent options now say what they meant:
  - 12 `lower/*` tests: `mode: "passthrough"` becomes `bundling: false`, as in the 29 other tests in that file. The file is `describe.todo`, so 11 register as todo; `LowerNestedFunctionDirectEval` has 8 entry points and skips.
  - `default/ExportFormsWithMinifyIdentifiersAndNoBundle`: drops the leftover `mode: "bundle"` next to its `bundling: false`; it has 5 entry points, so it now skips on the check above.
  - `default/RequireMainCacheCommonJS`: `platform: "node"` becomes `target: "node"`; passes.
  - `bundler_jsx.test.ts`: `itBundledDevAndProd` maps its `devTodo`/`prodTodo` flags to `todo` instead of passing them through. `jsx/ImportSourceDev` registers and passes, `jsx/ImportSourceProd` registers as todo, which is what its `prodTodo: true` has asked for since #3052.
- The location check at the top of `expectBundled` is removed. The `Error` it inspects is created inside `test/bundler/`, so on posix it never fired; on Windows the stack has backslashes, so it fired for every test and this catch swallowed it, which is what has dropped every `itBundled` test there since #15181. With the catch narrowed it would fail every bundler file on Windows instead.
- Deleting it would start registering those tests on Windows, where about 55 fail (measured in #34552 and #38499). So `itBundled` keeps Windows where it is today with an explicit `if (isWindows) return ref;` after the dry run; the option checks still run there, so a broken test fails the file on Windows as well. #34552 fixes or gates those tests and deletes that line (its hunk on the location check becomes this deletion).
- Result for the same registration-only run: 120 registrations skip, all through `NotImplementedError`; the 16 above register; all 102 files load with both backends (`BUN_BUNDLER_TEST_USE_ESBUILD=1` included).
- Windows (Server 2019 x64, released bun): the same registration-only run over `test/bundler` registers nothing from `itBundled` on main and on this branch alike (`bundler_banner.test.ts` reports `Ran 0 tests` both times) and every file loads; `expectBundled.test.ts` there passes the unknown-options case and skips the other one.
- Test: `test/bundler/expectBundled.test.ts`. The file is its own fixture: spawned with `EXPECT_BUNDLED_TEST_CASE` set it registers that case and nothing else.
  - `"unknown options"`: a test with a typo, one with a typo next to `mangleProps`, and a `todo` test with esbuild's `mode`. Asserts the child prints exactly the three `error: expectBundled("harness/...", ...) received unknown options: ...` lines and exits 1. With main's `expectBundled.ts` in place the child prints no error and exits 0, so the test fails.
  - `"skipped options"`: a plain test next to one with an esbuild-only option, one with `mangleProps` and one with `bundling: false` and two entry points. Asserts the child reports exactly `harness/Registers` and exits 0. Skipped on Windows, where the return above registers nothing.
  - The change is entirely under `test/`, so the automated check that stashes `src/` cannot see a before state; stashing `expectBundled.ts` is the equivalent and is where the failing run above comes from.
- Other runs (`bun bd test`): `esbuild/default.test.ts` 152 pass / 5 skip / 36 todo (193 registered, was 192); `bundler_jsx.test.ts` + `esbuild/lower.test.ts` 49 pass / 30 todo; `test/regression/issue/27465.test.ts` and `bundler-plugin-onresolve-entrypoint.test.ts`, the two files outside `test/bundler/` that register through `itBundled`, still pass.
- Open neighbours: #34542 is contained in this (its harness hunk). #34552 deletes the `isWindows` line here instead of normalizing the location check. #38471 creates the same `expectBundled.test.ts` with the same `EXPECT_BUNDLED_TEST_CASE` shape; whichever lands second moves its cases into the other's `switch`. #38454 is in an unrelated part of the file.

### Background
- `itBundled(id, opts)` is the bundler test helper. While a file is collected it calls `expectBundled(id, opts, /* dryRun */ true)`, which checks the options and returns before bundling anything, then registers `it(id, () => expectBundled(id, opts))`, which writes `opts.files` to a temp dir, bundles them and checks the output.
- The suite has two backends: `bun build` by default, esbuild when `BUN_BUNDLER_TEST_USE_ESBUILD` is set (to check the ported esbuild tests against esbuild itself). Some options exist on only one of them; a test setting such an option is "auto-skipped" on the other, which has always meant "the dry run throws and `itBundled` registers nothing". A skip still looks like that; what changes is which throws count as one.
- `bun test` collects a file by running it and its `describe` callbacks. An error thrown during that is reported against the file and makes the run exit 1 whether or not anything registered; a file that registers nothing and throws nothing exits 0, which is why a swallowed throw is invisible.
