### PR TITLE
HTMLRewriter: don't read a streamed input ahead of its reader

### DIFF
--- a/docs/runtime/html-rewriter.mdx
+++ b/docs/runtime/html-rewriter.mdx
@@ -126,13 +126,15 @@ rewriter.on("div", {
 });
 ```
 
-`transform(response)` returns immediately and you read the result off the
-returned `Response`. A streamed input (a file, a `fetch()` response, a
-`ReadableStream`) is pulled through the rewriter as that result is consumed, so
-only a small amount of output is buffered ahead of the reader and the remaining
-handlers run while you read. Because the rewrite outlives `transform()`, an
-error thrown by an async handler (or a Promise it returns that rejects) rejects
-the response body instead of throwing from `transform()`:
+`transform(response)` returns immediately; the rewrite continues in the
+background and you read the result off the returned `Response`. Reading it
+paces the rewrite: a streamed input (a file, a `fetch()` response, a
+`ReadableStream`) is pulled through only as fast as the returned body is
+consumed, so a slow reader does not accumulate the whole document in memory. If
+nothing reads the body, the rewrite still runs every handler to the end of the
+document and buffers the output until it is read. Because the rewrite outlives
+`transform()`, an error thrown by an async handler (or a Promise it returns that
+rejects) rejects the response body instead of throwing from `transform()`:
 
 ```ts
 try {

--- a/docs/runtime/html-rewriter.mdx
+++ b/docs/runtime/html-rewriter.mdx
@@ -126,11 +126,13 @@ rewriter.on("div", {
 });
 ```
 
-`transform(response)` returns immediately; the rewrite continues in the
-background and you read the result off the returned `Response`. Because the
-rewrite outlives `transform()`, an error thrown by an async handler (or a
-Promise it returns that rejects) rejects the response body instead of throwing
-from `transform()`:
+`transform(response)` returns immediately and you read the result off the
+returned `Response`. A streamed input (a file, a `fetch()` response, a
+`ReadableStream`) is pulled through the rewriter as that result is consumed, so
+only a small amount of output is buffered ahead of the reader and the remaining
+handlers run while you read. Because the rewrite outlives `transform()`, an
+error thrown by an async handler (or a Promise it returns that rejects) rejects
+the response body instead of throwing from `transform()`:
 
 ```ts
 try {

--- a/packages/bun-types/html-rewriter.d.ts
+++ b/packages/bun-types/html-rewriter.d.ts
@@ -164,11 +164,13 @@ declare class HTMLRewriter {
   /**
    * Transform HTML content
    *
-   * Returns immediately. A streamed input (a file, a `fetch()` response, a
-   * `ReadableStream`) is pulled through the rewriter as the returned
-   * response's body is consumed, so the remaining handlers run while it is
-   * read. An error thrown by a content handler (or a Promise it returns that
-   * rejects) rejects that body rather than throwing from `transform()`.
+   * Returns immediately; the rewrite continues in the background. Reading
+   * the returned response's body paces it — a streamed input (a file, a
+   * `fetch()` response, a `ReadableStream`) is pulled through only as fast
+   * as that body is consumed — and an unread body still runs every handler
+   * and buffers the output. An error thrown by a content handler (or a
+   * Promise it returns that rejects) rejects that body rather than throwing
+   * from `transform()`.
    *
    * @param input - The HTML to transform
    * @returns A new {@link Response} with the transformed HTML

--- a/packages/bun-types/html-rewriter.d.ts
+++ b/packages/bun-types/html-rewriter.d.ts
@@ -164,9 +164,11 @@ declare class HTMLRewriter {
   /**
    * Transform HTML content
    *
-   * Returns immediately; the rewrite continues in the background. An error
-   * thrown by a content handler (or a Promise it returns that rejects) rejects
-   * the returned response's body rather than throwing from `transform()`.
+   * Returns immediately. A streamed input (a file, a `fetch()` response, a
+   * `ReadableStream`) is pulled through the rewriter as the returned
+   * response's body is consumed, so the remaining handlers run while it is
+   * read. An error thrown by a content handler (or a Promise it returns that
+   * rejects) rejects that body rather than throwing from `transform()`.
    *
    * @param input - The HTML to transform
    * @returns A new {@link Response} with the transformed HTML

--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -148,6 +148,30 @@ impl Drop for ParentKeepAlive {
     }
 }
 
+// The per-loop `pipe_read_buffer` scratch is handed to `on_read_chunk` as the
+// chunk itself, and a consumer may keep parsing it while running user code
+// that starts a *second* reader synchronously (HTMLRewriter handlers do). A
+// nested read loop must not refill the scratch under the outer one, so only
+// the outermost loop on the thread borrows it; nested ones read into their
+// own `_buffer`.
+thread_local! {
+    static READ_SCRATCH_IN_USE: core::cell::Cell<bool> = const { core::cell::Cell::new(false) };
+}
+
+struct ReadScratchClaim;
+
+impl ReadScratchClaim {
+    fn try_claim() -> Option<Self> {
+        READ_SCRATCH_IN_USE.with(|in_use| (!in_use.replace(true)).then_some(Self))
+    }
+}
+
+impl Drop for ReadScratchClaim {
+    fn drop(&mut self) {
+        READ_SCRATCH_IN_USE.with(|in_use| in_use.set(false));
+    }
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // PosixBufferedReader
 // ──────────────────────────────────────────────────────────────────────────
@@ -568,17 +592,22 @@ impl PosixBufferedReader {
     /// spanning that re-entry is exactly the aliasing this API avoids.
     pub unsafe fn read(this: *mut Self) {
         // SAFETY: caller contract — `this` is live; borrows end at each `;`.
-        let (paused, fd, file_type) = unsafe {
+        let (paused, fd, file_type, vtable) = unsafe {
             (
                 (*this).flags.contains(PosixFlags::IS_PAUSED),
                 (*this).get_fd(),
                 (*this).get_file_type(),
+                (*this).vtable,
             )
         };
         // Don't initiate new reads if paused
         if paused {
             return;
         }
+        // As in `on_poll`: the synchronous read loops below dispatch
+        // `on_read_chunk` and touch `*this` afterwards, so the parent (which
+        // embeds this reader) must outlive them.
+        let _parent = vtable.ref_parent();
 
         match file_type {
             FileType::NonblockingPipe => {
@@ -792,12 +821,13 @@ impl PosixBufferedReader {
         // SAFETY: caller contract — `this` is live.
         let vtable = unsafe { (*this).vtable };
         let mut received_hup = received_hup_initially;
+        let scratch = ReadScratchClaim::try_claim();
         loop {
             let streaming = vtable.is_streaming_enabled();
             let mut got_retry = false;
 
             // SAFETY: caller contract; borrow ends at `;`.
-            let unbuffered = unsafe { (*this)._buffer.capacity() == 0 };
+            let unbuffered = scratch.is_some() && unsafe { (*this)._buffer.capacity() == 0 };
             if unbuffered {
                 // Use stack buffer for streaming — per-loop scratch buffer;
                 // single-threaded event loop (see `EventLoopCtx::pipe_read_buffer_mut`).
@@ -1032,8 +1062,9 @@ impl PosixBufferedReader {
         // SAFETY: caller contract — `this` is live.
         let vtable = unsafe { (*this).vtable };
         let streaming = vtable.is_streaming_enabled();
+        let scratch = ReadScratchClaim::try_claim();
 
-        if streaming {
+        if streaming && scratch.is_some() {
             // Per-loop scratch buffer; single-threaded event loop (see
             // `EventLoopCtx::pipe_read_buffer_mut`).
             let event_loop = vtable.event_loop();
@@ -1178,8 +1209,9 @@ impl PosixBufferedReader {
             }
         } else {
             // SAFETY: caller contract; borrows end at `;`.
-            let take_stack_path =
-                unsafe { (*this)._buffer.capacity() == 0 && (*this)._offset == 0 };
+            let take_stack_path = !streaming
+                && scratch.is_some()
+                && unsafe { (*this)._buffer.capacity() == 0 && (*this)._offset == 0 };
             if take_stack_path {
                 // Avoid a 16 KB dynamic memory allocation when the buffer might very well be empty.
                 // Per-loop scratch buffer; single-threaded event loop (see

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -959,8 +959,9 @@ impl RewriterPipe {
         }
         let cell = self.cell.get();
         cell.is_cell()
-            && js_HTMLRewriterTransform::output_stream_get_cached(cell)
-                .is_some_and(|stream| webcore::readable_stream::is_locked_value(stream, &self.global))
+            && js_HTMLRewriterTransform::output_stream_get_cached(cell).is_some_and(|stream| {
+                webcore::readable_stream::is_locked_value(stream, &self.global)
+            })
     }
 
     /// An observed reader has fallen behind: hold the input until its drain
@@ -1297,10 +1298,11 @@ impl RewriterPipe {
             cell.protect();
         }
         self.ref_();
-        vm.as_mut().enqueue_task(bun_jsc::ManagedTask::ManagedTask::new(
-            core::ptr::from_ref(self).cast_mut(),
-            Self::run_background_pull,
-        ));
+        vm.as_mut()
+            .enqueue_task(bun_jsc::ManagedTask::ManagedTask::new(
+                core::ptr::from_ref(self).cast_mut(),
+                Self::run_background_pull,
+            ));
     }
 
     fn run_background_pull(pipe: *mut RewriterPipe) -> bun_event_loop::JsResult<()> {
@@ -1800,7 +1802,9 @@ impl lol_html::OutputSink for PipeOutput {
         if chunk.is_empty() {
             return;
         }
-        self.0.output_buffer.with_mut(|v| v.extend_from_slice(chunk));
+        self.0
+            .output_buffer
+            .with_mut(|v| v.extend_from_slice(chunk));
     }
 }
 

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -729,8 +729,14 @@ pub struct RewriterPipe {
     /// `.body` on the output Response. Kept alive by the cell's `outputStream`
     /// slot.
     output: Cell<Option<bun_ptr::BackRef<ByteStream>>>,
-    /// lol-html output buffered before the output ByteStream exists.
+    /// lol-html output buffered before the output ByteStream exists. Bounded
+    /// by `high_water_mark` (the input is held meanwhile) unless
+    /// `buffer_all_output` is set.
     output_buffer: JsCell<Vec<u8>>,
+    /// A buffered consumer (`.text()`, `Bun.write`, … via
+    /// [`Self::on_start_buffering`]) wants the whole output in
+    /// `output_buffer`.
+    buffer_all_output: Cell<bool>,
     /// Output Response. The pipe holds a native `+1` (released in `Drop`) so
     /// the body stays reachable on the abandon-suspension path after the
     /// Response JS wrapper has been swept alongside the Transform cell.
@@ -907,10 +913,12 @@ impl RewriterPipe {
             }
             return out.buffer.get().len() as BlobSizeType > self.high_water_mark.get();
         }
-        // No output ByteStream yet: the pre-stream buffer has no drain signal
-        // (only `on_start_streaming`/`finish` consume it), so backpressuring
-        // the input here would deadlock the body-mixin (`.text()` etc.) path.
-        false
+        // No output ByteStream yet: hold the input once the pre-stream buffer
+        // passes the high-water mark. Reading `.body` hands the buffer to a
+        // ByteStream whose drain calls `resume()`; buffered consumers lift the
+        // bound through `on_start_buffering`.
+        !self.buffer_all_output.get()
+            && self.output_buffer.get().len() as BlobSizeType > self.high_water_mark.get()
     }
 
     fn init(
@@ -931,6 +939,7 @@ impl RewriterPipe {
             high_water_mark: Cell::new(16384),
             output: Cell::new(None),
             output_buffer: JsCell::new(Vec::new()),
+            buffer_all_output: Cell::new(false),
             response: Cell::new(None),
             phase: Cell::new(RewritePhase::WritePending),
             sync_only_noun: Cell::new(sync_only_noun),
@@ -946,8 +955,6 @@ impl RewriterPipe {
         // `BackRef` is sound across the re-entrant lol-html calls below.
         let this = BackRef::from(pipe);
 
-        let input_size = original.get_body_len();
-
         // The handler closures point into `Box`es owned by `(*pipe).context`,
         // which `pipe` keeps alive for the rewriter's whole lifetime.
         let (element_content_handlers, document_content_handlers) =
@@ -957,15 +964,13 @@ impl RewriterPipe {
                 element_content_handlers,
                 document_content_handlers,
                 encoding: lol_html::AsciiCompatibleEncoding::utf_8(),
+                // The parsing buffer only ever holds the unparsed tail of one
+                // chunk (a token split across writes) and grows on demand, so
+                // its size is unrelated to the input length; keep lol_html's
+                // default preallocation rather than reserving the whole body.
                 memory_settings: lol_html::MemorySettings {
-                    preallocated_parsing_buffer_size: if input_size as u64
-                        == webcore::blob::MAX_SIZE
-                    {
-                        1024
-                    } else {
-                        input_size.max(1024) as usize
-                    },
                     max_allowed_memory_usage: u32::MAX as usize,
+                    ..lol_html::MemorySettings::new()
                 },
                 strict: false,
                 enable_esi_tags: false,
@@ -986,6 +991,7 @@ impl RewriterPipe {
             webcore::Body::new({
                 let mut pv = webcore::body::PendingValue::new(global);
                 pv.task = Some(pipe.cast::<c_void>());
+                pv.on_start_buffering = Some(RewriterPipe::on_start_buffering);
                 pv.on_start_streaming = Some(RewriterPipe::on_start_streaming);
                 pv.on_readable_stream_available = Some(RewriterPipe::on_readable_stream_available);
                 pv.producer = SourceHandle::HTMLRewriter(this);
@@ -1188,6 +1194,17 @@ impl RewriterPipe {
         // undefined/null: the stream drained synchronously inside
         // assignToStream.
         this.end_from_stream(None);
+    }
+
+    /// `PendingValue::on_start_buffering` — `.text()`/`.json()`/`Bun.write`
+    /// want the whole output: stop bounding the pre-stream buffer and pull the
+    /// rest of the input. May complete the rewrite (and resolve the body)
+    /// before returning, so consumers install their state before signalling.
+    fn on_start_buffering(ctx: NonNull<c_void>) {
+        // Same liveness argument as `on_start_streaming`.
+        let this = bun_ptr::BackRef::from(ctx.cast::<RewriterPipe>());
+        this.buffer_all_output.set(true);
+        this.resume();
     }
 
     /// `PendingValue::on_start_streaming` — the output Response's body is
@@ -1439,11 +1456,16 @@ impl RewriterPipe {
         if self.done.get() || self.phase.get() == RewritePhase::Done {
             return;
         }
-        if self.is_suspended() || self.output_backpressured() {
+        if self.is_suspended() {
             return;
         }
+        // Output backpressure only gates pulling more input; once the input
+        // is exhausted, finishing frees the parser and settles the body.
         if self.input_ended.get() {
             self.end_rewrite();
+            return;
+        }
+        if self.output_backpressured() {
             return;
         }
         // `ready()` may re-enter and write `input_source` (sink → feed →

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -694,6 +694,14 @@ pub type HTMLRewriterTransform = RewriterPipe;
 /// when a content handler returns a pending Promise), and emits output either
 /// into a pre-stream buffer or — once JS reads `.body` — a [`ByteStream`]
 /// whose `producer` is [`SourceHandle::HTMLRewriter`].
+///
+/// Flow control follows the output's reader. While something is positioned
+/// to drain the output ([`Self::output_observed`]) the input is held whenever
+/// that reader falls a high-water mark behind, and its drain signal resumes
+/// it. While nothing is, the rewrite still runs to completion — its handlers
+/// are side effects callers rely on — but one upstream chunk per event-loop
+/// turn ([`Self::schedule_background_pull`]), so a synchronous source such as
+/// a regular file is never read through inside a single call.
 #[derive(bun_ptr::CellRefCounted)]
 pub struct RewriterPipe {
     pub(crate) global: GlobalRef,
@@ -722,21 +730,25 @@ pub struct RewriterPipe {
     js_pump_reaction_pending: Cell<bool>,
     /// Bytes accepted from the input while suspended or output-backpressured.
     pending_input: JsCell<Vec<u8>>,
-    high_water_mark: Cell<BlobSizeType>,
+    /// A [`Self::run_background_pull`] task is in the event-loop queue.
+    background_pull_queued: Cell<bool>,
+    /// That task should pull the input when it runs; cleared when a reader
+    /// attaches and drives the input itself first.
+    background_pull_armed: Cell<bool>,
 
     // ── output side ──────────────────────────────────────────────────────
     /// Set by [`Self::on_readable_stream_available`]; `None` until JS reads
     /// `.body` on the output Response. Kept alive by the cell's `outputStream`
     /// slot.
     output: Cell<Option<bun_ptr::BackRef<ByteStream>>>,
-    /// lol-html output buffered before the output ByteStream exists. Bounded
-    /// by `high_water_mark` (the input is held meanwhile) unless
-    /// `buffer_all_output` is set.
+    /// lol-html output of the current `write`/`end`/`resume` call; flushed to
+    /// `output` when the call returns, or kept here until the output stream
+    /// exists (`on_start_streaming`) or the rewrite finishes.
     output_buffer: JsCell<Vec<u8>>,
-    /// A buffered consumer (`.text()`, `Bun.write`, … via
-    /// [`Self::on_start_buffering`]) wants the whole output in
-    /// `output_buffer`.
-    buffer_all_output: Cell<bool>,
+    /// A consumer is waiting on the pending body as a whole (`.text()`,
+    /// `Bun.write`, … via [`Self::on_start_buffering`]): the output is
+    /// observed and never backpressured.
+    buffered_consumer: Cell<bool>,
     /// Output Response. The pipe holds a native `+1` (released in `Drop`) so
     /// the body stays reachable on the abandon-suspension path after the
     /// Response JS wrapper has been swept alongside the Transform cell.
@@ -776,6 +788,11 @@ pub struct RewriterPipe {
 }
 
 impl RewriterPipe {
+    /// How far the output may run ahead of its reader before the input is
+    /// held (or, unobserved, before the turn is yielded). The same distance
+    /// `fetch()` lets a request-body stream run ahead of the socket.
+    const HIGH_WATER_MARK: BlobSizeType = 16384;
+
     /// `JSHTMLRewriterTransform` finalizer. Runs during GC sweep: nothing
     /// here may touch other GC cells, and the other ref holders may still
     /// dispatch into the pipe after this cell is swept. So only release the
@@ -857,22 +874,16 @@ impl RewriterPipe {
     }
 
     /// Sever the wired input source: null the upstream's raw `sink` backref
-    /// so it can no longer dispatch into this pipe, and clear its `sinkOwner`
-    /// slot so I/O no longer roots the Transform cell through it. With
-    /// `cancel_upstream`, also close a native producer afterwards, so a
-    /// failed or cancelled rewrite stops a fetch mid-download and closes a
-    /// file fd instead of draining to upstream EOF; EOF paths pass `false`.
-    /// Only called from terminal paths on the JS thread, where the source is
-    /// still alive (it is rooted by the cell's `inputStream` slot until the
-    /// handle is dropped here). Idempotent: the handle is `None` after the
-    /// first call.
-    fn detach_input_source(&self, cancel_upstream: bool) {
+    /// so it can no longer dispatch into this pipe. With `cancel_upstream`,
+    /// also close a native producer afterwards, so a failed or cancelled
+    /// rewrite stops a fetch mid-download and closes a file fd instead of
+    /// draining to upstream EOF; EOF paths pass `false`. Only called from
+    /// terminal paths on the JS thread. Idempotent: the handle is `None`
+    /// after the first call. Returns the severed handle for
+    /// [`Self::release_input_roots`], which the caller runs after its
+    /// terminal work.
+    fn detach_input_source(&self, cancel_upstream: bool) -> SourceHandle {
         let mut src = self.input_source.replace(SourceHandle::None);
-        match &src {
-            SourceHandle::ByteStream(bs) => bs.parent_const().set_sink_owner(JSValue::UNDEFINED),
-            SourceHandle::FileReader(fr) => fr.parent_const().set_sink_owner(JSValue::UNDEFINED),
-            _ => {}
-        }
         let mut upstream = src;
         JSSink::<RewriterPipe>::detach(&mut src, &self.global);
         if cancel_upstream {
@@ -883,6 +894,29 @@ impl RewriterPipe {
                 _ => {}
             }
         }
+        upstream
+    }
+
+    /// Drop the GC edges between the Transform cell and its (severed) input:
+    /// the source's `sinkOwner` slot, through which I/O rooted the cell, and
+    /// the cell's `inputStream` slot, which rooted the source. Terminal paths
+    /// run this last, after end handlers, body resolution and error
+    /// construction, because those allocate while the source's own frames may
+    /// still be on the stack below (a file's read loop delivering EOF, an
+    /// upstream pipe delivering `Done`) and while this cell may be reachable
+    /// only through that source.
+    fn release_input_roots(&self, src: SourceHandle) {
+        let cell = self.cell.get();
+        if !cell.is_cell() {
+            // Swept together with everything these edges pointed at.
+            return;
+        }
+        match src {
+            SourceHandle::ByteStream(bs) => bs.parent_const().set_sink_owner(JSValue::UNDEFINED),
+            SourceHandle::FileReader(fr) => fr.parent_const().set_sink_owner(JSValue::UNDEFINED),
+            _ => {}
+        }
+        js_HTMLRewriterTransform::input_stream_set_cached(cell, &self.global, JSValue::UNDEFINED);
     }
 
     /// Sever the output `ByteStream`'s `SourceHandle::HTMLRewriter` backref
@@ -901,7 +935,36 @@ impl RewriterPipe {
         self.suspended_wrapper.get().is_some() || self.pending_suspension.take_peek().is_some()
     }
 
-    #[inline]
+    /// Output emitted but not yet taken by a reader.
+    fn unread_output(&self) -> BlobSizeType {
+        let staged = self.output_buffer.get().len();
+        let queued = self.output.get().map_or(0, |out| out.buffer.get().len());
+        (staged + queued) as BlobSizeType
+    }
+
+    /// Whether anything is positioned to drain the output: a native sink or a
+    /// buffered collector on the output stream, a parked or possible
+    /// (`locked`) JS read on it, or a consumer waiting on the pending body.
+    /// The same test `fetch()` applies to its own body stream before letting
+    /// it hold the connection.
+    fn output_observed(&self) -> bool {
+        let Some(out) = self.output.get() else {
+            return self.buffered_consumer.get();
+        };
+        if out.sink.get().is_some()
+            || out.buffer_action.get().is_some()
+            || out.pending.get().state == streams::PendingState::Pending
+        {
+            return true;
+        }
+        let cell = self.cell.get();
+        cell.is_cell()
+            && js_HTMLRewriterTransform::output_stream_get_cached(cell)
+                .is_some_and(|stream| webcore::readable_stream::is_locked_value(stream, &self.global))
+    }
+
+    /// An observed reader has fallen behind: hold the input until its drain
+    /// signal (`resume()`).
     fn output_backpressured(&self) -> bool {
         if let Some(out) = self.output.get() {
             if out.sink_paused.get() {
@@ -911,14 +974,15 @@ impl RewriterPipe {
             if out.buffer_action.get().is_some() {
                 return false;
             }
-            return out.buffer.get().len() as BlobSizeType > self.high_water_mark.get();
+        } else if self.buffered_consumer.get() {
+            return false;
         }
-        // No output ByteStream yet: hold the input once the pre-stream buffer
-        // passes the high-water mark. Reading `.body` hands the buffer to a
-        // ByteStream whose drain calls `resume()`; buffered consumers lift the
-        // bound through `on_start_buffering`.
-        !self.buffer_all_output.get()
-            && self.output_buffer.get().len() as BlobSizeType > self.high_water_mark.get()
+        self.output_observed() && self.unread_output() > Self::HIGH_WATER_MARK
+    }
+
+    /// Nobody is draining the output: keep going, but not within this turn.
+    fn should_yield(&self) -> bool {
+        !self.output_observed() && self.unread_output() > Self::HIGH_WATER_MARK
     }
 
     fn init(
@@ -936,10 +1000,11 @@ impl RewriterPipe {
             input_ended: Cell::new(false),
             js_pump_reaction_pending: Cell::new(false),
             pending_input: JsCell::new(Vec::new()),
-            high_water_mark: Cell::new(16384),
+            background_pull_queued: Cell::new(false),
+            background_pull_armed: Cell::new(false),
             output: Cell::new(None),
             output_buffer: JsCell::new(Vec::new()),
-            buffer_all_output: Cell::new(false),
+            buffered_consumer: Cell::new(false),
             response: Cell::new(None),
             phase: Cell::new(RewritePhase::WritePending),
             sync_only_noun: Cell::new(sync_only_noun),
@@ -964,10 +1029,8 @@ impl RewriterPipe {
                 element_content_handlers,
                 document_content_handlers,
                 encoding: lol_html::AsciiCompatibleEncoding::utf_8(),
-                // The parsing buffer only ever holds the unparsed tail of one
-                // chunk (a token split across writes) and grows on demand, so
-                // its size is unrelated to the input length; keep lol_html's
-                // default preallocation rather than reserving the whole body.
+                // Default parsing-buffer preallocation: it only ever holds the
+                // unparsed tail of one write (a token split across chunks).
                 memory_settings: lol_html::MemorySettings {
                     max_allowed_memory_usage: u32::MAX as usize,
                     ..lol_html::MemorySettings::new()
@@ -1197,14 +1260,71 @@ impl RewriterPipe {
     }
 
     /// `PendingValue::on_start_buffering` — `.text()`/`.json()`/`Bun.write`
-    /// want the whole output: stop bounding the pre-stream buffer and pull the
-    /// rest of the input. May complete the rewrite (and resolve the body)
-    /// before returning, so consumers install their state before signalling.
+    /// want the whole output: pull the rest of the input now, unbounded.
     fn on_start_buffering(ctx: NonNull<c_void>) {
         // Same liveness argument as `on_start_streaming`.
         let this = bun_ptr::BackRef::from(ctx.cast::<RewriterPipe>());
-        this.buffer_all_output.set(true);
+        this.buffered_consumer.set(true);
         this.resume();
+    }
+
+    /// Hold a ref on the pipe across an externally-entered call whose work
+    /// (user handlers, body resolution) can drop the last GC path to the
+    /// Transform cell and sweep it, releasing the cell's ref mid-call.
+    fn pin(&self) -> bun_ptr::ScopedRef<Self> {
+        // SAFETY: `self` is live; the guard's own ref keeps the allocation
+        // valid until it drops.
+        unsafe { bun_ptr::ScopedRef::new(core::ptr::from_ref(self).cast_mut()) }
+    }
+
+    /// Nothing is draining the output, so nothing will signal `resume()`:
+    /// continue the rewrite from the event loop instead, one upstream chunk
+    /// per turn. The queued task holds a pipe ref and protects the cell, which
+    /// roots the Response, both streams and the handlers until it runs — an
+    /// unobserved rewrite is otherwise reachable from nothing.
+    fn schedule_background_pull(&self) {
+        self.background_pull_armed.set(true);
+        if self.background_pull_queued.replace(true) {
+            return;
+        }
+        let vm = self.global.bun_vm();
+        if vm.is_shutting_down() {
+            self.background_pull_queued.set(false);
+            return;
+        }
+        let cell = self.cell.get();
+        if cell.is_cell() {
+            cell.protect();
+        }
+        self.ref_();
+        vm.as_mut().enqueue_task(bun_jsc::ManagedTask::ManagedTask::new(
+            core::ptr::from_ref(self).cast_mut(),
+            Self::run_background_pull,
+        ));
+    }
+
+    fn run_background_pull(pipe: *mut RewriterPipe) -> bun_event_loop::JsResult<()> {
+        // SAFETY: the task's ref (taken in `schedule_background_pull`) keeps
+        // the allocation live until the `deref_nn` below.
+        let this = BackRef::from(unsafe { NonNull::new_unchecked(pipe) });
+        let cell = this.cell.get();
+        this.background_pull_queued.set(false);
+        if this.background_pull_armed.replace(false)
+            && !this.done.get()
+            && this.phase.get() != RewritePhase::Done
+            && !this.driving.get()
+            && !this.is_suspended()
+            && !this.output_backpressured()
+        {
+            this.drain_pending_input(PullPacing::AlreadyYielded);
+        }
+        // The cell cannot have been swept while protected, so this balances
+        // the `protect()` exactly.
+        if cell.is_cell() {
+            cell.unprotect();
+        }
+        Self::deref_nn(this.into());
+        Ok(())
     }
 
     /// `PendingValue::on_start_streaming` — the output Response's body is
@@ -1263,14 +1383,30 @@ impl RewriterPipe {
 
     /// `SinkHandle::write` entry — input bytes arrived.
     pub fn write(&self, data: &StreamResult) -> Writable {
+        let _pin = self.pin();
         let bytes = data.slice();
         let len = bytes.len() as BlobSizeType;
+        // A chunk that carries EOF is never answered with `Backpressure`: there
+        // is no further input to hold back, and the source follows any other
+        // answer with `end()`, which is what lets a document that arrived in
+        // one piece finish inside `transform()`.
+        let held = |len| {
+            if data.is_done() {
+                Writable::Owned(len)
+            } else {
+                Writable::Backpressure(len)
+            }
+        };
         if self.done.get() || self.phase.get() == RewritePhase::Done {
             return Writable::Done;
         }
-        if self.driving.get() || self.is_suspended() || self.output_backpressured() {
+        if self.driving.get()
+            || self.is_suspended()
+            || self.output_backpressured()
+            || self.background_pull_armed.get()
+        {
             self.pending_input.with_mut(|v| v.extend_from_slice(bytes));
-            return Writable::Backpressure(len);
+            return held(len);
         }
         let fed = self.feed(bytes);
         // `feed` ran user JS; a handler may have cancelled the output reader
@@ -1283,11 +1419,18 @@ impl RewriterPipe {
             // `feed` returns false for both a handler suspension and a fatal
             // error. Only the latter should detach the upstream sink.
             if self.is_suspended() {
-                return Writable::Backpressure(len);
+                return held(len);
             }
             return Writable::Done;
         }
+        if data.is_done() {
+            return Writable::Owned(len);
+        }
         if self.is_suspended() || self.output_backpressured() {
+            return Writable::Backpressure(len);
+        }
+        if self.should_yield() {
+            self.schedule_background_pull();
             return Writable::Backpressure(len);
         }
         Writable::Owned(len)
@@ -1295,12 +1438,13 @@ impl RewriterPipe {
 
     /// `SinkHandle::end` entry — input EOF or terminal upstream error.
     pub fn end_from_stream(&self, err: Option<StreamError>) {
+        let _pin = self.pin();
         // Detach via `detach_input_source` (not a bare `.set(None)`) so a
         // `JSController`'s `m_sinkPtr` is nulled before any path can free the
         // pipe; otherwise the controller's destructor would later dispatch
         // `__controllerDetached`/`__finalize` on freed memory. The upstream
         // already ended, so there is nothing to cancel.
-        self.detach_input_source(false);
+        let src = self.detach_input_source(false);
 
         if self.js_pump_reaction_pending.get() {
             // The pump-promise `.then()` reaction is the single terminal
@@ -1312,15 +1456,8 @@ impl RewriterPipe {
             return;
         }
 
-        js_HTMLRewriterTransform::input_stream_set_cached(
-            self.cell.get(),
-            &self.global,
-            JSValue::UNDEFINED,
-        );
         if self.done.get() || self.phase.get() == RewritePhase::Done {
-            return;
-        }
-        if let Some(err) = err {
+        } else if let Some(err) = err {
             let value_error = match err {
                 StreamError::JSValue(v) => webcore::body::ValueError::JSValue(v),
                 StreamError::Error(e) => {
@@ -1329,13 +1466,13 @@ impl RewriterPipe {
                 StreamError::AbortReason(r) => webcore::body::ValueError::AbortReason(r),
             };
             self.fail(value_error);
-            return;
-        }
-        if self.driving.get() || self.is_suspended() || !self.pending_input.get().is_empty() {
+        } else if self.driving.get() || self.is_suspended() || !self.pending_input.get().is_empty()
+        {
             self.input_ended.set(true);
-            return;
+        } else {
+            self.end_rewrite();
         }
-        self.end_rewrite();
+        self.release_input_roots(src);
     }
 
     /// `SourceHandle::on_ready` entry — the output ByteStream drained.
@@ -1348,24 +1485,22 @@ impl RewriterPipe {
         {
             return;
         }
-        self.drain_pending_input();
+        let _pin = self.pin();
+        self.drain_pending_input(PullPacing::YieldIfUnobserved);
     }
 
     /// `SourceHandle::on_close` entry — the output reader cancelled.
     pub fn cancel_from_output(&self, _err: Option<SysError>) {
+        let _pin = self.pin();
         self.detach_output();
-        self.detach_input_source(true);
-        js_HTMLRewriterTransform::input_stream_set_cached(
-            self.cell.get(),
-            &self.global,
-            JSValue::UNDEFINED,
-        );
+        let src = self.detach_input_source(true);
         self.phase.set(RewritePhase::Done);
         self.done.set(true);
         self.pending.with_mut(|p| {
             p.result = Writable::Done;
             p.run();
         });
+        self.release_input_roots(src);
     }
 
     /// Run one lol-html `write`/`end_mut`/`resume` call under the
@@ -1380,8 +1515,23 @@ impl RewriterPipe {
         let _active = ActiveSinkGuard::enter(self);
         self.driving.set(true);
         let res = self.rewriter.with_mut(|r| r.as_deref_mut().map(f));
+        // Hand this call's output to the stream as one chunk: lol-html emits a
+        // fragment per token piece, and each `on_data` may be a socket write
+        // or a downstream rewriter's `write`. Still under `driving`, so the
+        // stream's re-entrant drain signal defers as it did per fragment.
+        self.flush_output();
         self.driving.set(false);
         res
+    }
+
+    fn flush_output(&self) {
+        let Some(out) = self.output.get() else {
+            return;
+        };
+        if self.output_buffer.get().is_empty() {
+            return;
+        }
+        out.on_data(StreamResult::Owned(self.output_buffer.replace(Vec::new())));
     }
 
     /// Feed `bytes` through lol-html once. Returns `true` if the write
@@ -1432,6 +1582,8 @@ impl RewriterPipe {
         let Some(response) = self.response.get() else {
             return;
         };
+        // For a waiting `.blob()`'s content type.
+        let headers = response.get_fetch_headers().map(NonNull::from);
         let body_value = response.get_body_value();
         let bytes = self.output_buffer.replace(Vec::new());
         let mut prev_value = core::mem::replace(
@@ -1441,12 +1593,12 @@ impl RewriterPipe {
                 was_string: false,
             }),
         );
-        let _ = webcore::body::Value::resolve(&mut prev_value, body_value, &self.global, None);
+        let _ = webcore::body::Value::resolve(&mut prev_value, body_value, &self.global, headers);
     }
 
     /// Feed the accumulated `pending_input` once unblocked, then maybe end,
     /// then signal the upstream source to resume.
-    fn drain_pending_input(&self) {
+    fn drain_pending_input(&self, pacing: PullPacing) {
         let pending = self.pending_input.replace(Vec::new());
         if !pending.is_empty() && !self.feed(&pending) {
             return;
@@ -1468,6 +1620,12 @@ impl RewriterPipe {
         if self.output_backpressured() {
             return;
         }
+        if pacing == PullPacing::YieldIfUnobserved && self.should_yield() {
+            self.schedule_background_pull();
+            return;
+        }
+        // Pulling now; a queued background pull has nothing left to do.
+        self.background_pull_armed.set(false);
         // `ready()` may re-enter and write `input_source` (sink → feed →
         // fail/end_from_stream), so copy the handle out instead of holding a
         // `with_mut` borrow across the call.
@@ -1489,7 +1647,7 @@ impl RewriterPipe {
             return self.on_rewriting_error(&e);
         }
         match self.phase.get() {
-            RewritePhase::WritePending => self.drain_pending_input(),
+            RewritePhase::WritePending => self.drain_pending_input(PullPacing::YieldIfUnobserved),
             RewritePhase::EndPending => self.finish(),
             RewritePhase::Done => {}
         }
@@ -1585,17 +1743,10 @@ impl RewriterPipe {
 
     /// Put `err` on the output `Response`'s body / ByteStream.
     fn fail(&self, err: webcore::body::ValueError) {
+        let _pin = self.pin();
         self.phase.set(RewritePhase::Done);
         self.done.set(true);
-        self.detach_input_source(true);
-        let cell = self.cell.get();
-        if cell.is_cell() {
-            js_HTMLRewriterTransform::input_stream_set_cached(
-                cell,
-                &self.global,
-                JSValue::UNDEFINED,
-            );
-        }
+        let src = self.detach_input_source(true);
         // Settle any `flush(true)`/`write()` promise a direct-stream `pull()`
         // is parked on so the pump promise can settle (mirrors
         // `cancel_from_output`).
@@ -1605,32 +1756,43 @@ impl RewriterPipe {
         });
 
         if let Some(out) = self.output.get() {
+            // Output emitted before the failure still precedes the error.
+            self.flush_output();
             let mut err = err;
             out.on_data(StreamResult::Err(err.to_stream_error(&self.global)));
             self.detach_output();
-            return;
+        } else if let Some(response) = self.response.get() {
+            let body_value = response.get_body_value();
+            let has_readable = match body_value {
+                webcore::body::Value::Locked(l) => l.readable.has(),
+                _ => false,
+            };
+            if !has_readable
+                && matches!(body_value, webcore::body::Value::Locked(l)
+                    if l.promise.is_none() && l.on_receive_value.is_none())
+            {
+                *body_value = webcore::body::Value::Empty;
+            }
+            let _ = body_value.to_error_instance(err, &self.global);
         }
-        let Some(response) = self.response.get() else {
-            return;
-        };
-        let body_value = response.get_body_value();
-        let has_readable = match body_value {
-            webcore::body::Value::Locked(l) => l.readable.has(),
-            _ => false,
-        };
-        if !has_readable
-            && matches!(body_value, webcore::body::Value::Locked(l)
-                if l.promise.is_none() && l.on_receive_value.is_none())
-        {
-            *body_value = webcore::body::Value::Empty;
-        }
-        let _ = body_value.to_error_instance(err, &self.global);
+        self.release_input_roots(src);
     }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum PullPacing {
+    /// Entered from a reader's drain signal or a settled handler: if nobody is
+    /// reading and the output is already a high-water mark ahead, defer the
+    /// pull to the event loop.
+    YieldIfUnobserved,
+    /// Entered from that deferred task: this is the next turn, pull now.
+    AlreadyYielded,
 }
 
 /// `lol_html::OutputSink` for the rewriter built in [`RewriterPipe::init`].
 /// The pipe owns the `Box<LolRewriter>` that owns this `PipeOutput`, so the
 /// back-reference invariant (pointee outlives holder) is structurally upheld.
+/// Output is staged in `output_buffer`; `drive_rewriter` forwards it.
 pub struct PipeOutput(BackRef<RewriterPipe>);
 
 impl lol_html::OutputSink for PipeOutput {
@@ -1638,12 +1800,7 @@ impl lol_html::OutputSink for PipeOutput {
         if chunk.is_empty() {
             return;
         }
-        let pipe = &*self.0;
-        if let Some(out) = pipe.output.get() {
-            out.on_data(StreamResult::Temporary(RawSlice::new(chunk)));
-        } else {
-            pipe.output_buffer.with_mut(|v| v.extend_from_slice(chunk));
-        }
+        self.0.output_buffer.with_mut(|v| v.extend_from_slice(chunk));
     }
 }
 
@@ -1726,7 +1883,12 @@ impl crate::webcore::sink::JsSinkType for RewriterPipe {
                 JSValue::js_number(0.0),
             ));
         }
-        if wait && (self.driving.get() || self.is_suspended() || self.output_backpressured()) {
+        if wait
+            && (self.driving.get()
+                || self.is_suspended()
+                || self.output_backpressured()
+                || self.background_pull_armed.get())
+        {
             let prom = self.pending.with_mut(|p| {
                 p.result = Writable::Owned(0);
                 p.promise(global)
@@ -1740,12 +1902,7 @@ impl crate::webcore::sink::JsSinkType for RewriterPipe {
             JSValue::js_number(0.0),
         ))
     }
-    fn start(&mut self, config: Start) -> bun_sys::Result<()> {
-        if let Start::ChunkSize(chunk_size) = config {
-            if chunk_size > 0 {
-                self.high_water_mark.set(chunk_size);
-            }
-        }
+    fn start(&mut self, _config: Start) -> bun_sys::Result<()> {
         bun_sys::Result::Ok(())
     }
     fn source(&mut self) -> Option<&mut SourceHandle> {

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5164,15 +5164,19 @@ pub(crate) fn write_file_internal(
                         let BodyValue::Locked(locked) = (unsafe { &mut *body_value }) else {
                             unreachable!()
                         };
-                        if let (Some(on_start_buffering), Some(orig_task)) =
-                            (locked.on_start_buffering.take(), locked.task)
-                        {
-                            on_start_buffering(orig_task);
-                        }
+                        let producer_hook = locked.on_start_buffering.take().zip(locked.task);
                         locked.task = Some(NonNull::new(task).unwrap().cast::<c_void>());
                         locked.on_receive_value = Some(WriteFileWaitFromLockedValueTask::then_wrap);
                         // SAFETY: `task` was just heap-allocated; consumed in `then_wrap`.
-                        Ok(ControlFlow::Break(unsafe { (*task).promise.value() }))
+                        let promise = unsafe { (*task).promise.value() };
+                        // Signalled last: a producer may resolve the body from
+                        // inside this call, which runs `then_wrap` and replaces
+                        // `*body_value`, so neither `locked` nor `task` may be
+                        // touched afterwards.
+                        if let Some((on_start_buffering, producer_task)) = producer_hook {
+                            on_start_buffering(producer_task);
+                        }
+                        Ok(ControlFlow::Break(promise))
                     }
                 }
             };

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5169,10 +5169,8 @@ pub(crate) fn write_file_internal(
                         locked.on_receive_value = Some(WriteFileWaitFromLockedValueTask::then_wrap);
                         // SAFETY: `task` was just heap-allocated; consumed in `then_wrap`.
                         let promise = unsafe { (*task).promise.value() };
-                        // Signalled last: a producer may resolve the body from
-                        // inside this call, which runs `then_wrap` and replaces
-                        // `*body_value`, so neither `locked` nor `task` may be
-                        // touched afterwards.
+                        // Signalled last (see `PendingValue::on_start_buffering`):
+                        // `then_wrap` may run and `*body_value` be replaced inside.
                         if let Some((on_start_buffering, producer_task)) = producer_hook {
                             on_start_buffering(producer_task);
                         }

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -226,8 +226,13 @@ pub struct PendingValue {
     /// runs after the data is available.
     pub(crate) on_receive_value: Option<fn(ctx: NonNull<c_void>, value: &mut Value)>,
 
-    /// conditionally runs when requesting data
-    /// used in HTTP server to ignore request bodies unless asked for it
+    /// A consumer that wants the whole body (`.text()`/`.json()`/…,
+    /// `Bun.write`) has started waiting on it without realising a stream.
+    /// Producers use it to stop holding data back (the server ignores request
+    /// bodies until asked; HTMLRewriter stops pacing its input). The producer
+    /// may resolve or fail this body synchronously from inside the call —
+    /// replacing the `Value` this `PendingValue` lives in — so callers install
+    /// their `promise`/`on_receive_value` first and touch nothing afterwards.
     pub(crate) on_start_buffering: Option<fn(ctx: NonNull<c_void>)>,
     pub(crate) on_start_streaming: Option<fn(ctx: NonNull<c_void>) -> DrainResult>,
     pub(crate) on_readable_stream_available:
@@ -420,9 +425,10 @@ impl PendingValue {
             promise_value.protect();
 
             if let Some(on_start_buffering) = self.on_start_buffering.take() {
-                // `task` is the live request-ctx pointer registered alongside
-                // this callback in `prepare_js_request_context`.
-                on_start_buffering(self.task.unwrap());
+                // Last use of `self`: the producer may settle the body (and so
+                // replace `*self`) before this returns.
+                let task = self.task.unwrap();
+                on_start_buffering(task);
             }
             Ok(promise_value)
         }

--- a/src/runtime/webcore/ByteStream.rs
+++ b/src/runtime/webcore/ByteStream.rs
@@ -690,11 +690,15 @@ impl ByteStream {
     }
 
     pub(crate) fn drain(&self) -> Vec<u8> {
-        if !self.buffer.get().is_empty() {
-            self.signal_drained();
-            return Vec::<u8>::move_from_list(self.buffer.replace(Vec::new()));
+        if self.buffer.get().is_empty() {
+            return Vec::<u8>::default();
         }
-        Vec::<u8>::default()
+        let drained = Vec::<u8>::move_from_list(self.buffer.replace(Vec::new()));
+        // Signal after taking, as `on_pull` does: a backpressure-gated
+        // producer checks `buffer.len()` to decide whether to resume, and
+        // anything it emits inline lands in the fresh buffer for the next pull.
+        self.signal_drained();
+        drained
     }
 
     /// Take a pre-attach `StreamResult::Err` stashed by [`Self::append`].

--- a/src/runtime/webcore/ByteStream.rs
+++ b/src/runtime/webcore/ByteStream.rs
@@ -227,11 +227,16 @@ impl ByteStream {
         self.parent_const().producer.get().ready(None, None);
     }
 
-    /// Take the buffered bytes without signalling the producer; the caller
-    /// writes them to the sink before [`Self::signal_drained`].
+    /// Take the unread buffered bytes (`buffer[offset..]`) without signalling
+    /// the producer; the caller writes them to the sink before
+    /// [`Self::signal_drained`].
     pub(crate) fn take_buffer(&self) -> Vec<u8> {
-        self.offset.set(0);
-        Vec::<u8>::move_from_list(self.buffer.replace(Vec::new()))
+        let consumed = self.offset.replace(0);
+        let mut list = self.buffer.replace(Vec::new());
+        if consumed > 0 {
+            list.drain(..consumed);
+        }
+        Vec::<u8>::move_from_list(list)
     }
 
     /// Called by native fast-paths after wiring `self.sink`. Restores
@@ -690,14 +695,13 @@ impl ByteStream {
     }
 
     pub(crate) fn drain(&self) -> Vec<u8> {
-        if self.buffer.get().is_empty() {
-            return Vec::<u8>::default();
+        let drained = self.take_buffer();
+        if !drained.is_empty() {
+            // After taking, as in `on_pull`: the producer decides whether to
+            // resume from `buffer.len()`, and anything it emits inline queues
+            // behind these bytes for the next pull.
+            self.signal_drained();
         }
-        let drained = Vec::<u8>::move_from_list(self.buffer.replace(Vec::new()));
-        // Signal after taking, as `on_pull` does: a backpressure-gated
-        // producer checks `buffer.len()` to decide whether to resume, and
-        // anything it emits inline lands in the fresh buffer for the next pull.
-        self.signal_drained();
         drained
     }
 

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -561,10 +561,24 @@ impl FileReader {
         if !self.sink_paused.replace(false) {
             return;
         }
-        let sink = *self.sink.get();
-        if sink.is_none() {
+        if self.sink.get().is_none() {
             return;
         }
+        // The sink receives bytes synchronously below (a regular file's whole
+        // read loop runs inside `read`) and may respond by dropping the last
+        // root of this stream — HTMLRewriter clears its `inputStream` slot on
+        // EOF — and then allocating, so pin the source until this returns.
+        let parent = self.parent();
+        // SAFETY: see `parent()`.
+        unsafe { (*parent).increment_count() };
+        self.push_to_sink();
+        // SAFETY: balances the increment above; may free `self`, which is not
+        // touched afterwards.
+        let _ = unsafe { Source::decrement_count(parent) };
+    }
+
+    fn push_to_sink(&self) {
+        let sink = *self.sink.get();
         let reader_done = self.reader().is_done();
         let buffered = self.drain();
         if !buffered.is_empty() {

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -304,6 +304,12 @@ bun_io::impl_buffered_reader_parent! {
         #[cfg(not(windows))] { ev.r#loop() }
     };
     event_loop = |this| (&*this).event_loop.get().as_event_loop_ctx();
+    // A read delivers to `on_read_chunk` consumers (JS, or a native sink such
+    // as HTMLRewriter) that can drop this stream's last GC root and allocate
+    // before the read loop's frames unwind, so the reader pins its parent —
+    // and, through `increment_count`, the JS wrapper — for the duration.
+    ref_  = |this| (*(&*this).parent()).increment_count();
+    deref = |this| { let _ = Source::decrement_count((&*this).parent()); };
 }
 
 impl FileReader {
@@ -561,24 +567,10 @@ impl FileReader {
         if !self.sink_paused.replace(false) {
             return;
         }
-        if self.sink.get().is_none() {
+        let sink = *self.sink.get();
+        if sink.is_none() {
             return;
         }
-        // The sink receives bytes synchronously below (a regular file's whole
-        // read loop runs inside `read`) and may respond by dropping the last
-        // root of this stream — HTMLRewriter clears its `inputStream` slot on
-        // EOF — and then allocating, so pin the source until this returns.
-        let parent = self.parent();
-        // SAFETY: see `parent()`.
-        unsafe { (*parent).increment_count() };
-        self.push_to_sink();
-        // SAFETY: balances the increment above; may free `self`, which is not
-        // touched afterwards.
-        let _ = unsafe { Source::decrement_count(parent) };
-    }
-
-    fn push_to_sink(&self) {
-        let sink = *self.sink.get();
         let reader_done = self.reader().is_done();
         let buffered = self.drain();
         if !buffered.is_empty() {
@@ -590,6 +582,7 @@ impl FileReader {
             match sink.write(&chunk) {
                 streams::Writable::Backpressure(_) => {
                     self.sink_paused.set(true);
+                    self.reader().pause();
                     return;
                 }
                 streams::Writable::Err(e) => {
@@ -726,7 +719,12 @@ impl FileReader {
                 }
                 match wrote {
                     streams::Writable::Backpressure(_) => {
+                        // Returning `false` ends a synchronous read loop; an
+                        // event-driven reader (Windows, pollable fds) has to
+                        // be paused, or its next completion lands here again
+                        // and piles into the sink. `pull_into_sink` unpauses.
                         self.sink_paused.set(true);
+                        self.reader().pause();
                         close_if_needed!();
                         return false;
                     }

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -632,6 +632,10 @@ pub(crate) fn is_disturbed_value(value: JSValue, global_object: &JSGlobalObject)
     ReadableStream__isDisturbed(value, global_object)
 }
 
+pub(crate) fn is_locked_value(value: JSValue, global_object: &JSGlobalObject) -> bool {
+    ReadableStream__isLocked(value, global_object)
+}
+
 // ─── Tag / Source ────────────────────────────────────────────────────────────
 
 #[repr(i32)]

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -1,7 +1,18 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { once } from "events";
 import fs from "fs";
-import { bunEnv, bunExe, gcTick, isASAN, isDebug, isWindows, tempDir, tls, tmpdirSync } from "harness";
+import {
+  bunEnv,
+  bunExe,
+  gcTick,
+  isASAN,
+  isDebug,
+  isWindows,
+  tempDir,
+  tempDirWithFiles,
+  tls,
+  tmpdirSync,
+} from "harness";
 import { createServer as createTcpServer } from "net";
 import path, { join } from "path";
 import { setImmediate as setImmediatePromise } from "timers/promises";
@@ -1874,24 +1885,20 @@ describe("output ByteStream backpressured when a native sink is wired", () => {
   });
 });
 
-// A streamed input is pulled through the rewriter only as fast as its output is
-// consumed: `transform()` returns once the unread output passes the pipe's
-// high-water mark, with the rest of the input still unread, and whichever
-// consumer later attaches to the pending body drives the rewrite to the end.
-describe("streamed input is held until the output is consumed", () => {
+// A streamed input (file, fetch body, ReadableStream) is paced by the output's
+// reader: `transform()` itself feeds at most one upstream chunk, a reader that
+// falls behind holds the input, and with no reader at all the rewrite still
+// runs to completion from the event loop, one chunk per turn.
+describe("streamed input pacing", () => {
   const text = Buffer.alloc(1000, "a").toString();
   const piece = `<p>${text}</p>`;
   const count = 2500; // ~2.4 MB of input: many upstream chunks
   const input = Buffer.alloc(piece.length * count, piece).toString();
   const rewritten = Buffer.alloc((piece.length + 6) * count, `<p x="1">${text}</p>`).toString();
-  let dir, file;
-  beforeAll(() => {
-    dir = tempDir("hr-held-input", { "in.html": input });
-    file = path.join(String(dir), "in.html");
-  });
-  afterAll(() => dir?.[Symbol.dispose]());
+  const dir = tempDirWithFiles("hr-pacing", { "in.html": input });
+  const file = path.join(dir, "in.html");
 
-  function transformFile() {
+  function transformInput(body = Bun.file(file)) {
     let seen = 0;
     const res = new HTMLRewriter()
       .on("p", {
@@ -1900,135 +1907,193 @@ describe("streamed input is held until the output is consumed", () => {
           e.setAttribute("x", "1");
         },
       })
-      .transform(new Response(Bun.file(file)));
+      .transform(new Response(body));
     return { res, seen: () => seen };
   }
 
-  it("transform() returns before the whole input has been read", async () => {
-    const { res, seen } = transformFile();
-    // Regular-file reads complete asynchronously on Windows, so wait for the
-    // first chunk to be fed before checking that the rest is still held.
-    while (seen() === 0) await setImmediatePromise();
+  async function readAll(body) {
+    const reader = body.getReader();
+    const chunks = [];
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+    }
+    return Buffer.concat(chunks).toString();
+  }
+
+  it("transform() feeds at most one upstream chunk before returning", async () => {
+    const { res, seen } = transformInput();
     expect(seen()).toBeLessThan(count);
     expect(await res.text()).toBe(rewritten);
     expect(seen()).toBe(count);
   });
 
-  it(".arrayBuffer()", async () => {
-    const { res } = transformFile();
-    expect(Buffer.from(await res.arrayBuffer()).toString()).toBe(rewritten);
-  });
-
-  it(".body read after transform() returned, then .text()", async () => {
-    const { res } = transformFile();
-    res.body;
-    expect(await res.text()).toBe(rewritten);
-  });
-
-  it("JS reader", async () => {
-    const { res, seen } = transformFile();
-    const reader = res.body.getReader();
-    let total = 0;
-    for (;;) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      total += value.length;
-    }
-    expect(total).toBe(rewritten.length);
+  // Each consumer that can attach to the still-pending body drives the held
+  // input to the end and gets every byte.
+  const consumers = {
+    ".text()": res => res.text(),
+    ".arrayBuffer()": async res => Buffer.from(await res.arrayBuffer()).toString(),
+    ".blob()": async res => (await res.blob()).text(),
+    ".bytes()": async res => Buffer.from(await res.bytes()).toString(),
+    ".body touched, then .text()": res => (res.body, res.text()),
+    "JS reader": res => readAll(res.body),
+    "for await": async res => {
+      const chunks = [];
+      for await (const chunk of res.body) chunks.push(chunk);
+      return Buffer.concat(chunks).toString();
+    },
+    "textStream()": async res => {
+      let out = "";
+      for await (const s of res.textStream()) out += s;
+      return out;
+    },
+    "new Response(res.body).text()": res => new Response(res.body).text(),
+    "second HTMLRewriter": res => new HTMLRewriter().transform(res).text(),
+    ".clone()": async res => {
+      const clone = res.clone();
+      const [a, b] = await Promise.all([clone.text(), res.text()]);
+      expect(a).toBe(b);
+      return b;
+    },
+    "Bun.write(file, res)": async res => {
+      const out = path.join(dir, `out-${Math.random().toString(36).slice(2)}.html`);
+      await Bun.write(out, res);
+      return Bun.file(out).text();
+    },
+    "returned from Bun.serve": async res => {
+      await using server = Bun.serve({ port: 0, fetch: () => res });
+      return await (await fetch(server.url)).text();
+    },
+    "res.body returned from Bun.serve": async res => {
+      await using server = Bun.serve({ port: 0, fetch: () => new Response(res.body) });
+      return await (await fetch(server.url)).text();
+    },
+    "Bun.spawn stdin": async res => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", "process.stdin.pipe(process.stdout)"],
+        env: bunEnv,
+        stdin: res,
+        stdout: "pipe",
+      });
+      return await proc.stdout.text();
+    },
+  };
+  it.each(Object.keys(consumers))("held file input completes via %s", async name => {
+    const { res, seen } = transformInput();
+    expect(await consumers[name](res)).toBe(rewritten);
     expect(seen()).toBe(count);
   });
 
-  it("for await", async () => {
-    const { res } = transformFile();
-    let total = 0;
-    for await (const chunk of res.body) total += chunk.length;
-    expect(total).toBe(rewritten.length);
-  });
-
-  it("new Response(res.body).text()", async () => {
-    const { res } = transformFile();
-    expect(await new Response(res.body).text()).toBe(rewritten);
-  });
-
-  it("second HTMLRewriter", async () => {
-    const { res } = transformFile();
-    expect(await new HTMLRewriter().transform(res).text()).toBe(rewritten);
-  });
-
-  it(".clone()", async () => {
-    const { res } = transformFile();
-    const clone = res.clone();
-    const [a, b] = await Promise.all([clone.text(), res.text()]);
-    expect(a).toBe(rewritten);
-    expect(b).toBe(rewritten);
-  });
-
-  it("Bun.write(file, res)", async () => {
-    const { res } = transformFile();
-    const out = path.join(String(dir), "out.html");
-    expect(await Bun.write(out, res)).toBe(rewritten.length);
-    expect(await Bun.file(out).text()).toBe(rewritten);
-  });
-
-  it("returned from Bun.serve", async () => {
-    await using server = Bun.serve({ port: 0, fetch: () => transformFile().res });
-    expect(await (await fetch(server.url)).text()).toBe(rewritten);
-  });
-
-  it("res.body returned from Bun.serve", async () => {
-    await using server = Bun.serve({ port: 0, fetch: () => new Response(transformFile().res.body) });
-    expect(await (await fetch(server.url)).text()).toBe(rewritten);
-  });
-
-  it("fetch() input read with a JS reader", async () => {
+  it("held fetch() input completes via a JS reader", async () => {
     await using server = Bun.serve({ port: 0, fetch: () => new Response(Bun.file(file)) });
-    let seen = 0;
+    const { res, seen } = transformInput((await fetch(server.url)).body);
+    expect(await readAll(res.body)).toBe(rewritten);
+    expect(seen()).toBe(count);
+  });
+
+  it("a locked but idle reader holds the input", async () => {
+    const { res, seen } = transformInput();
+    const reader = res.body.getReader();
+    for (let i = 0; i < 5; i++) await setImmediatePromise();
+    const held = seen();
+    expect(held).toBeLessThan(count);
+    for (let i = 0; i < 5; i++) await setImmediatePromise();
+    expect(seen()).toBe(held);
+    reader.releaseLock();
+    expect(await readAll(res.body)).toBe(rewritten);
+  });
+
+  // With nothing reading the output the rewrite is a side effect the caller is
+  // waiting on: it must still run every handler, finish, and let the process
+  // exit — for a file (paced from the event loop) and for a fetch() body
+  // (whose connection must not be parked forever).
+  it.each(["file", "fetch", "fetch, .body touched"])("an unread transform over a %s runs to completion", async kind => {
+    await using server = Bun.serve({ port: 0, fetch: () => new Response(Bun.file(file)) });
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `let n = 0, ended = false;
+         const input = ${kind === "file"} ? Bun.file(process.argv[1]) : (await fetch(process.argv[2])).body;
+         const res = new HTMLRewriter().on("p", { element() { n++; } }).onDocument({ end() { ended = true; } }).transform(new Response(input));
+         if (${kind === "fetch, .body touched"}) res.body;
+         const fed = n;
+         process.on("exit", () => console.log(JSON.stringify({ heldAtReturn: fed < ${count}, n, ended })));`,
+        file,
+        server.url.href,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(JSON.parse(stdout)).toEqual({ heldAtReturn: true, n: count, ended: true });
+    expect(exitCode).toBe(0);
+  });
+
+  // The whole document arrives in the first read: it finishes inside
+  // `transform()` however large its output, so the body is already materialized
+  // for consumers that need that (Content-Length, static routes).
+  it("a document that arrives in one chunk finishes inside transform()", async () => {
+    const small = path.join(dir, "small.html");
+    await Bun.write(small, Buffer.alloc(12 * 4000, "<p>hello</p>").toString());
+    let ended = false;
     const res = new HTMLRewriter()
+      .on("p", { element: e => void e.setAttribute("x", "1") })
+      .onDocument({ end: () => void (ended = true) })
+      .transform(new Response(Bun.file(small)));
+    expect(ended).toBe(true);
+    await using server = Bun.serve({ port: 0, fetch: () => res });
+    const served = await fetch(server.url);
+    expect(served.headers.get("content-length")).toBe(String(18 * 4000));
+    expect(await served.text()).toBe(Buffer.alloc(18 * 4000, '<p x="1">hello</p>').toString());
+  });
+
+  it(".blob() keeps the response's content type", async () => {
+    const res = new HTMLRewriter().transform(
+      new Response(Bun.file(file), { headers: { "content-type": "text/html" } }),
+    );
+    expect((await res.blob()).type).toBe("text/html;charset=utf-8");
+  });
+
+  // The outer document is being parsed out of the read buffer when the handler
+  // starts a second file read; the two must not share it.
+  it("a handler may consume another held transform", async () => {
+    const other = transformInput().res;
+    let inner;
+    const outer = new HTMLRewriter()
       .on("p", {
         element(e) {
-          seen++;
           e.setAttribute("x", "1");
+          inner ??= other.text();
         },
       })
-      .transform(await fetch(server.url));
-    const reader = res.body.getReader();
-    let total = 0;
-    for (;;) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      total += value.length;
-    }
-    expect(total).toBe(rewritten.length);
-    expect(seen).toBe(count);
+      .transform(new Response(Bun.file(file)));
+    expect(await outer.text()).toBe(rewritten);
+    expect(await inner).toBe(rewritten);
   });
 
-  // Regular-file reads are synchronous on POSIX, so an unbounded pre-stream
-  // buffer shows up as `transform()` itself reading (and buffering the rewrite
-  // of) the entire file. Sparse files keep these cheap.
+  // Regular-file reads are synchronous on POSIX, so reading ahead of the
+  // consumer would show up as `transform()` itself reading (and buffering the
+  // rewrite of) the entire file. Sparse files keep these cheap.
   describe.skipIf(isWindows)("large sparse file", () => {
-    function sparse(dir, name, size) {
-      const file = path.join(String(dir), name);
-      const fd = fs.openSync(file, "w");
-      fs.ftruncateSync(fd, size);
-      fs.closeSync(fd);
-      return file;
-    }
-
     // 5 GiB: a body size that does not fit lol_html's `u32::MAX` memory limit.
     it.concurrent.each([256 * 1024 * 1024, 5 * 1024 * 1024 * 1024])(
-      "of %d bytes: transform() does not read it before the body is consumed",
+      "of %d bytes: transform() does not read ahead",
       async size => {
-        using dir = tempDir("hr-sparse", {});
-        const file = sparse(dir, "in.html", size);
+        using dir = tempDir("hr-sparse", { "in.html": "" });
+        const file = path.join(String(dir), "in.html");
+        fs.truncateSync(file, size);
         await using proc = Bun.spawn({
           cmd: [
             bunExe(),
             "-e",
             `const before = process.memoryUsage.rss();
-           const res = new HTMLRewriter().on("a", { element() {} }).transform(new Response(Bun.file(process.argv[1])));
-           const delta = process.memoryUsage.rss() - before;
-           await res.body.cancel();
-           console.log(Math.round(delta / 1024 / 1024));`,
+             const res = new HTMLRewriter().on("a", { element() {} }).transform(new Response(Bun.file(process.argv[1])));
+             const delta = process.memoryUsage.rss() - before;
+             await res.body.cancel();
+             console.log(Math.round(delta / 1024 / 1024));`,
             file,
           ],
           env: bunEnv,
@@ -2036,9 +2101,8 @@ describe("streamed input is held until the output is consumed", () => {
           stderr: "inherit",
         });
         const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-        // RSS growth across transform(), in MB. Unfixed, it exceeded the file
-        // size (the whole rewritten output was buffered); fixed, it is one
-        // upstream chunk.
+        // RSS growth across transform(), in MB: one upstream chunk and its
+        // rewrite, where reading ahead cost more than the file size.
         expect(parseInt(stdout)).toBeLessThan(isDebug || isASAN ? 96 : 48);
         expect(exitCode).toBe(0);
       },

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { once } from "events";
 import fs from "fs";
-import { bunEnv, bunExe, gcTick, tempDir, tls, tmpdirSync } from "harness";
+import { bunEnv, bunExe, gcTick, isASAN, isDebug, isWindows, tempDir, tls, tmpdirSync } from "harness";
 import { createServer as createTcpServer } from "net";
 import path, { join } from "path";
 import { setImmediate as setImmediatePromise } from "timers/promises";
@@ -1859,6 +1859,185 @@ describe("output ByteStream backpressured when a native sink is wired", () => {
   it("completes with a streaming input (.text())", async () => {
     const { body } = await makeParkedStreaming();
     expect(await new Response(body).text()).toBe(streamed);
+  });
+
+  it("completes when read with a JS reader", async () => {
+    const { body } = await makeParked();
+    const reader = body.getReader();
+    const chunks = [];
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+    }
+    expect(Buffer.concat(chunks).toString()).toBe(out);
+  });
+});
+
+// A streamed input is pulled through the rewriter only as fast as its output is
+// consumed: `transform()` returns once the unread output passes the pipe's
+// high-water mark, with the rest of the input still unread, and whichever
+// consumer later attaches to the pending body drives the rewrite to the end.
+describe("streamed input is held until the output is consumed", () => {
+  const text = Buffer.alloc(1000, "a").toString();
+  const piece = `<p>${text}</p>`;
+  const count = 2500; // ~2.4 MB of input: many upstream chunks
+  const input = Buffer.alloc(piece.length * count, piece).toString();
+  const rewritten = Buffer.alloc((piece.length + 6) * count, `<p x="1">${text}</p>`).toString();
+  let dir, file;
+  beforeAll(() => {
+    dir = tempDir("hr-held-input", { "in.html": input });
+    file = path.join(String(dir), "in.html");
+  });
+  afterAll(() => dir?.[Symbol.dispose]());
+
+  function transformFile() {
+    let seen = 0;
+    const res = new HTMLRewriter()
+      .on("p", {
+        element(e) {
+          seen++;
+          e.setAttribute("x", "1");
+        },
+      })
+      .transform(new Response(Bun.file(file)));
+    return { res, seen: () => seen };
+  }
+
+  it("transform() returns before the whole input has been read", async () => {
+    const { res, seen } = transformFile();
+    expect(seen()).toBeGreaterThan(0);
+    expect(seen()).toBeLessThan(count);
+    expect(await res.text()).toBe(rewritten);
+    expect(seen()).toBe(count);
+  });
+
+  it(".arrayBuffer()", async () => {
+    const { res } = transformFile();
+    expect(Buffer.from(await res.arrayBuffer()).toString()).toBe(rewritten);
+  });
+
+  it(".body read after transform() returned, then .text()", async () => {
+    const { res } = transformFile();
+    res.body;
+    expect(await res.text()).toBe(rewritten);
+  });
+
+  it("JS reader", async () => {
+    const { res, seen } = transformFile();
+    const reader = res.body.getReader();
+    let total = 0;
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.length;
+    }
+    expect(total).toBe(rewritten.length);
+    expect(seen()).toBe(count);
+  });
+
+  it("for await", async () => {
+    const { res } = transformFile();
+    let total = 0;
+    for await (const chunk of res.body) total += chunk.length;
+    expect(total).toBe(rewritten.length);
+  });
+
+  it("new Response(res.body).text()", async () => {
+    const { res } = transformFile();
+    expect(await new Response(res.body).text()).toBe(rewritten);
+  });
+
+  it("second HTMLRewriter", async () => {
+    const { res } = transformFile();
+    expect(await new HTMLRewriter().transform(res).text()).toBe(rewritten);
+  });
+
+  it(".clone()", async () => {
+    const { res } = transformFile();
+    const clone = res.clone();
+    const [a, b] = await Promise.all([clone.text(), res.text()]);
+    expect(a).toBe(rewritten);
+    expect(b).toBe(rewritten);
+  });
+
+  it("Bun.write(file, res)", async () => {
+    const { res } = transformFile();
+    const out = path.join(String(dir), "out.html");
+    expect(await Bun.write(out, res)).toBe(rewritten.length);
+    expect(await Bun.file(out).text()).toBe(rewritten);
+  });
+
+  it("returned from Bun.serve", async () => {
+    await using server = Bun.serve({ port: 0, fetch: () => transformFile().res });
+    expect(await (await fetch(server.url)).text()).toBe(rewritten);
+  });
+
+  it("res.body returned from Bun.serve", async () => {
+    await using server = Bun.serve({ port: 0, fetch: () => new Response(transformFile().res.body) });
+    expect(await (await fetch(server.url)).text()).toBe(rewritten);
+  });
+
+  it("fetch() input read with a JS reader", async () => {
+    await using server = Bun.serve({ port: 0, fetch: () => new Response(Bun.file(file)) });
+    let seen = 0;
+    const res = new HTMLRewriter()
+      .on("p", {
+        element(e) {
+          seen++;
+          e.setAttribute("x", "1");
+        },
+      })
+      .transform(await fetch(server.url));
+    const reader = res.body.getReader();
+    let total = 0;
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.length;
+    }
+    expect(total).toBe(rewritten.length);
+    expect(seen).toBe(count);
+  });
+
+  // Regular-file reads are synchronous on POSIX, so an unbounded pre-stream
+  // buffer shows up as `transform()` itself reading (and buffering the rewrite
+  // of) the entire file. Sparse files keep these cheap.
+  describe.skipIf(isWindows)("large sparse file", () => {
+    function sparse(dir, name, size) {
+      const file = path.join(String(dir), name);
+      const fd = fs.openSync(file, "w");
+      fs.ftruncateSync(fd, size);
+      fs.closeSync(fd);
+      return file;
+    }
+
+    // 5 GiB: a body size that does not fit lol_html's `u32::MAX` memory limit.
+    it.concurrent.each([256 * 1024 * 1024, 5 * 1024 * 1024 * 1024])("of %d bytes: transform() does not read it before the body is consumed", async size => {
+      using dir = tempDir("hr-sparse", {});
+      const file = sparse(dir, "in.html", size);
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const before = process.memoryUsage.rss();
+           const res = new HTMLRewriter().on("a", { element() {} }).transform(new Response(Bun.file(process.argv[1])));
+           const delta = process.memoryUsage.rss() - before;
+           await res.body.cancel();
+           console.log(Math.round(delta / 1024 / 1024));`,
+          file,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "inherit",
+      });
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      // RSS growth across transform(), in MB. Unfixed, it exceeded the file
+      // size (the whole rewritten output was buffered); fixed, it is one
+      // upstream chunk.
+      expect(parseInt(stdout)).toBeLessThan(isDebug || isASAN ? 96 : 48);
+      expect(exitCode).toBe(0);
+    });
   });
 });
 

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -1906,7 +1906,9 @@ describe("streamed input is held until the output is consumed", () => {
 
   it("transform() returns before the whole input has been read", async () => {
     const { res, seen } = transformFile();
-    expect(seen()).toBeGreaterThan(0);
+    // Regular-file reads complete asynchronously on Windows, so wait for the
+    // first chunk to be fed before checking that the rest is still held.
+    while (seen() === 0) await setImmediatePromise();
     expect(seen()).toBeLessThan(count);
     expect(await res.text()).toBe(rewritten);
     expect(seen()).toBe(count);

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -2013,31 +2013,34 @@ describe("streamed input is held until the output is consumed", () => {
     }
 
     // 5 GiB: a body size that does not fit lol_html's `u32::MAX` memory limit.
-    it.concurrent.each([256 * 1024 * 1024, 5 * 1024 * 1024 * 1024])("of %d bytes: transform() does not read it before the body is consumed", async size => {
-      using dir = tempDir("hr-sparse", {});
-      const file = sparse(dir, "in.html", size);
-      await using proc = Bun.spawn({
-        cmd: [
-          bunExe(),
-          "-e",
-          `const before = process.memoryUsage.rss();
+    it.concurrent.each([256 * 1024 * 1024, 5 * 1024 * 1024 * 1024])(
+      "of %d bytes: transform() does not read it before the body is consumed",
+      async size => {
+        using dir = tempDir("hr-sparse", {});
+        const file = sparse(dir, "in.html", size);
+        await using proc = Bun.spawn({
+          cmd: [
+            bunExe(),
+            "-e",
+            `const before = process.memoryUsage.rss();
            const res = new HTMLRewriter().on("a", { element() {} }).transform(new Response(Bun.file(process.argv[1])));
            const delta = process.memoryUsage.rss() - before;
            await res.body.cancel();
            console.log(Math.round(delta / 1024 / 1024));`,
-          file,
-        ],
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "inherit",
-      });
-      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-      // RSS growth across transform(), in MB. Unfixed, it exceeded the file
-      // size (the whole rewritten output was buffered); fixed, it is one
-      // upstream chunk.
-      expect(parseInt(stdout)).toBeLessThan(isDebug || isASAN ? 96 : 48);
-      expect(exitCode).toBe(0);
-    });
+            file,
+          ],
+          env: bunEnv,
+          stdout: "pipe",
+          stderr: "inherit",
+        });
+        const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+        // RSS growth across transform(), in MB. Unfixed, it exceeded the file
+        // size (the whole rewritten output was buffered); fixed, it is one
+        // upstream chunk.
+        expect(parseInt(stdout)).toBeLessThan(isDebug || isASAN ? 96 : 48);
+        expect(exitCode).toBe(0);
+      },
+    );
   });
 });
 

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -2032,10 +2032,12 @@ describe("streamed input pacing", () => {
     expect(exitCode).toBe(0);
   });
 
-  // The whole document arrives in the first read: it finishes inside
-  // `transform()` however large its output, so the body is already materialized
-  // for consumers that need that (Content-Length, static routes).
-  it("a document that arrives in one chunk finishes inside transform()", async () => {
+  // The whole document arrives in the first read: it finishes with that read
+  // however large its output — inside `transform()` where regular-file reads
+  // are synchronous (POSIX), on the read's completion otherwise — so the body
+  // is already materialized for consumers that need that (Content-Length,
+  // static routes) without anything reading it.
+  it("a document that arrives in one chunk finishes with that chunk", async () => {
     const small = path.join(dir, "small.html");
     await Bun.write(small, Buffer.alloc(12 * 4000, "<p>hello</p>").toString());
     let ended = false;
@@ -2043,7 +2045,8 @@ describe("streamed input pacing", () => {
       .on("p", { element: e => void e.setAttribute("x", "1") })
       .onDocument({ end: () => void (ended = true) })
       .transform(new Response(Bun.file(small)));
-    expect(ended).toBe(true);
+    if (!isWindows) expect(ended).toBe(true);
+    while (!ended) await setImmediatePromise();
     await using server = Bun.serve({ port: 0, fetch: () => res });
     const served = await fetch(server.url);
     expect(served.headers.get("content-length")).toBe(String(18 * 4000));


### PR DESCRIPTION
### What does this PR do?

`new HTMLRewriter().transform(new Response(Bun.file(f)))` no longer reads the whole file inside `transform()`. A streamed input (file, `fetch()` body, `ReadableStream`) is now paced by whoever reads the output, the way `fetch()` paces its own body stream:

- `transform()` feeds at most one upstream chunk before returning (a document that arrives in one chunk still finishes inside the call, so small pages keep `Content-Length` and work as static routes).
- While something is positioned to read the output — a native sink (`Bun.serve`, a second rewriter, spawn stdin), a JS reader, or a `.text()`/`.arrayBuffer()`/`Bun.write` consumer — the input is held once that reader is 16 KiB behind and resumed by its drain signal, so a slow reader never accumulates the document.
- While nothing is, the rewrite still runs every handler to the end (from the event loop, one chunk per turn) and buffers the output until read, as it always has — an unread transform is a side effect callers rely on, and a `fetch()` input must not sit on a paused connection forever.

Two things sized memory to the input before. lol_html's `preallocated_parsing_buffer_size` was set to the body length; that buffer only holds the unparsed tail of one write and grows on demand, so this reserved the whole body up front, ate most of the `u32::MAX` memory budget, and for bodies ≥ 4 GiB tripped lol_html's `debug_assert!` (which is why only debug/ASAN builds panicked and release canaries "worked"). It now uses lol_html's default. And since the streaming rewrite (#36733) nothing paced the input before the output stream existed, while regular-file reads are synchronous on POSIX — so `transform()` read the entire file and buffered its rewritten output before returning (~6.5 GB RSS for a 4.2 GB file).

Fixes the new steady state depends on: output is handed to the stream once per lol_html call rather than per fragment; `finish()` passes the response headers to `Value::resolve` (`.blob().type`); terminal paths drop the input's GC edges after their end handlers/body resolution rather than before, and pipe entry points hold a ref across their work; `FileReader` pins its parent for the duration of a read (buffered-reader ref hooks) and pauses the reader on backpressure; the per-loop read scratch buffer is only lent to the outermost read loop (a nested file read started from a handler no longer corrupts the outer document); `ByteStream::drain`/`take_buffer` honour `offset` (`textStream()` re-delivered a consumed prefix); `Bun.write` installs its consumer before signalling `on_start_buffering`.

### How did you verify your code works?

`test/js/workerd/html-rewriter.test.js` gains a "streamed input pacing" block: one consumer table (15 consumers, byte-exact) over a held file input, held `fetch()` input, an idle locked reader, unread transforms over file/fetch inputs running to completion in a child that must exit, single-chunk `Content-Length`, blob type, `textStream()`, a handler consuming another held transform, and sparse 256 MiB / 5 GiB files whose `transform()` must not move RSS. Seven of those fail with `USE_SYSTEM_BUN=1` (the read-ahead ones, plus the `.body`-touched-but-unread hang and JS-reader stall that already existed). Ran that file (also under `BUN_JSC_collectContinuously`), html-rewriter-leak/end-error/doctype, bun-write, body-stream, fetch.stream, stream-fast-path, streams, shell pipe tests on a debug+ASAN build; `cargo check` for `x86_64-pc-windows-msvc`.
