### PR TITLE
node: pass ERR_INVALID_ARG_TYPE expected types as lists so fs streams, zlib and diagnostics_channel messages match node

### DIFF
--- a/src/js/internal/fs/streams.ts
+++ b/src/js/internal/fs/streams.ts
@@ -170,7 +170,7 @@ function ReadStream(this: FSStream, path, options): void {
     fd[kRef]();
     fd.on("close", this.close.bind(this));
   } else {
-    throw $ERR_INVALID_ARG_TYPE("options.fd", "number or FileHandle", fd);
+    throw $ERR_INVALID_ARG_TYPE("options.fd", ["number", "FileHandle"], fd);
   }
 
   if (customFs) {
@@ -415,7 +415,7 @@ function WriteStream(this: FSStream, path: string | null, options?: any): void {
     fd.on("close", this.close.bind(this));
     this.fd = fd = fd[kFd];
   } else {
-    throw $ERR_INVALID_ARG_TYPE("options.fd", "number or FileHandle", fd);
+    throw $ERR_INVALID_ARG_TYPE("options.fd", ["number", "FileHandle"], fd);
   }
 
   const autoDestroy = (autoClose = options.autoDestroy = autoClose === undefined ? true : autoClose);

--- a/src/js/node/diagnostics_channel.ts
+++ b/src/js/node/diagnostics_channel.ts
@@ -219,7 +219,7 @@ function channel(name) {
   if (channel) return channel;
 
   if (typeof name !== "string" && typeof name !== "symbol") {
-    throw $ERR_INVALID_ARG_TYPE("channel", "string or symbol", name);
+    throw $ERR_INVALID_ARG_TYPE("channel", ["string", "symbol"], name);
   }
 
   return new Channel(name);
@@ -277,7 +277,8 @@ class TracingChannel {
       this.asyncEnd = asyncEnd;
       this.error = error;
     } else {
-      throw $ERR_INVALID_ARG_TYPE("nameOrChannels", ["string, object, or Channel"], nameOrChannels);
+      // https://github.com/nodejs/node/blob/v26.3.0/lib/diagnostics_channel.js#L315-L317
+      throw $ERR_INVALID_ARG_TYPE("nameOrChannels", ["string", "object", "TracingChannel"], nameOrChannels);
     }
   }
 

--- a/src/js/node/fs.ts
+++ b/src/js/node/fs.ts
@@ -1022,7 +1022,8 @@ function _toUnixTimestamp(time: any, name = "time") {
     // Convert to 123.456 UNIX timestamp
     return time.getTime() / 1000;
   }
-  throw $ERR_INVALID_ARG_TYPE(name, "number or Date", time);
+  // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/fs/utils.js#L795
+  throw $ERR_INVALID_ARG_TYPE(name, ["Date", "Time in seconds"], time);
 }
 
 function onOpendirStatFulfilled(callback, path, result, stats) {

--- a/src/js/node/zlib.ts
+++ b/src/js/node/zlib.ts
@@ -114,7 +114,7 @@ function zlibBufferSync(engine, buffer) {
     if (isAnyArrayBuffer(buffer)) {
       buffer = Buffer.from(buffer);
     } else {
-      throw $ERR_INVALID_ARG_TYPE("buffer", "string, Buffer, TypedArray, DataView, or ArrayBuffer", buffer);
+      throw $ERR_INVALID_ARG_TYPE("buffer", ["string", "Buffer", "TypedArray", "DataView", "ArrayBuffer"], buffer);
     }
   }
   buffer = processChunkSync(engine, buffer, engine._finishFlushFlag);

--- a/test/js/node/diagnostics_channel/diagnostics_channel.test.ts
+++ b/test/js/node/diagnostics_channel/diagnostics_channel.test.ts
@@ -1,7 +1,7 @@
 import { gc } from "bun";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { AsyncLocalStorage } from "node:async_hooks";
-import { channel, Channel, hasSubscribers, subscribe, unsubscribe } from "node:diagnostics_channel";
+import { channel, Channel, hasSubscribers, subscribe, tracingChannel, unsubscribe } from "node:diagnostics_channel";
 
 describe("Channel", () => {
   // test-diagnostics-channel-has-subscribers.js
@@ -40,7 +40,12 @@ describe("Channel", () => {
     expect(() => {
       // @ts-expect-error
       channel(null);
-    }).toThrow(/"channel" argument must be of type string or symbol/);
+    }).toThrow(
+      expect.objectContaining({
+        code: "ERR_INVALID_ARG_TYPE",
+        message: 'The "channel" argument must be one of type string or symbol. Received null',
+      }),
+    );
 
     checkCalls();
   });
@@ -154,9 +159,29 @@ describe("Channel", () => {
     expect(() => {
       // @ts-expect-error
       subscribe(null);
-    }).toThrow(/"channel" argument must be of type/);
+    }).toThrow(
+      expect.objectContaining({
+        code: "ERR_INVALID_ARG_TYPE",
+        message: 'The "channel" argument must be one of type string or symbol. Received null',
+      }),
+    );
 
     checkCalls();
+  });
+
+  test("rejects a channel name that is neither a string nor a symbol with node's message", () => {
+    expect(() => channel(123 as any)).toThrow(
+      expect.objectContaining({
+        code: "ERR_INVALID_ARG_TYPE",
+        message: 'The "channel" argument must be one of type string or symbol. Received type number (123)',
+      }),
+    );
+    expect(() => unsubscribe({} as any, () => {})).toThrow(
+      expect.objectContaining({
+        code: "ERR_INVALID_ARG_TYPE",
+        message: 'The "channel" argument must be one of type string or symbol. Received an instance of Object',
+      }),
+    );
   });
 
   // test-diagnostics-channel-safe-subscriber-errors.js
@@ -343,6 +368,23 @@ describe("TracingChannel", () => {
   // Port tests from:
   // https://github.com/search?q=repo%3Anodejs%2Fnode+test-diagnostics-channel+AND+%2Ftracing%2F&type=code
   test.todo("TODO");
+
+  test("rejects a nameOrChannels argument that is neither a string nor an object with node's message", () => {
+    expect(() => tracingChannel(123 as any)).toThrow(
+      expect.objectContaining({
+        code: "ERR_INVALID_ARG_TYPE",
+        message:
+          'The "nameOrChannels" argument must be of type string or an instance of TracingChannel or Object. Received type number (123)',
+      }),
+    );
+    expect(() => tracingChannel(undefined as any)).toThrow(
+      expect.objectContaining({
+        code: "ERR_INVALID_ARG_TYPE",
+        message:
+          'The "nameOrChannels" argument must be of type string or an instance of TracingChannel or Object. Received undefined',
+      }),
+    );
+  });
 });
 
 const mocks = new Map();

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -3790,6 +3790,30 @@ describe("fs.ReadStream", () => {
   });
 });
 
+describe.each([
+  ["createReadStream", (options: any) => createReadStream(null as any, options)],
+  ["createWriteStream", (options: any) => createWriteStream(null as any, options)],
+  ["new fs.ReadStream", (options: any) => new fs.ReadStream(null as any, options)],
+  ["new fs.WriteStream", (options: any) => new fs.WriteStream(null as any, options)],
+])("%s with an invalid options.fd", (_, construct) => {
+  const expected = 'The "options.fd" property must be of type number or an instance of FileHandle.';
+
+  it.each([
+    ["3", "Received type string ('3')"],
+    [true, "Received type boolean (true)"],
+    [3n, "Received type bigint (3n)"],
+    [{}, "Received an instance of Object"],
+  ])("rejects fd: %p with node's message", (fd, received) => {
+    expect(() => construct({ fd })).toThrow(
+      expect.objectContaining({
+        name: "TypeError",
+        code: "ERR_INVALID_ARG_TYPE",
+        message: `${expected} ${received}`,
+      }),
+    );
+  });
+});
+
 describe("createWriteStream", () => {
   it.todoIf(isBroken && isWindows)("simple write stream finishes", async () => {
     const streamPath = join(tmpdirSync(), "create-write-stream.txt");
@@ -4605,6 +4629,26 @@ it("existsSync with invalid path doesn't throw", () => {
   expect(existsSync(123 as any)).toBe(false);
   expect(existsSync(undefined as any)).toBe(false);
   expect(existsSync({ invalid: 1 } as any)).toBe(false);
+});
+
+describe("fs._toUnixTimestamp", () => {
+  // Node passes ["Date", "Time in seconds"] as the expected types, so its
+  // message really does read "an Time in seconds".
+  it.each([
+    ["x", undefined, '"time"', "Received type string ('x')"],
+    [NaN, undefined, '"time"', "Received type number (NaN)"],
+    [{}, undefined, '"time"', "Received an instance of Object"],
+    [Infinity, "atime", '"atime"', "Received type number (Infinity)"],
+    [undefined, "mtime", '"mtime"', "Received undefined"],
+  ])("rejects %p (name: %p) with node's message", (time, name, label, received) => {
+    expect(() => (fs as any)._toUnixTimestamp(time, name)).toThrow(
+      expect.objectContaining({
+        name: "TypeError",
+        code: "ERR_INVALID_ARG_TYPE",
+        message: `The ${label} argument must be an instance of Date or an Time in seconds. ${received}`,
+      }),
+    );
+  });
 });
 
 describe("utimesSync", () => {

--- a/test/js/node/test/parallel/test-zlib-not-string-or-buffer.js
+++ b/test/js/node/test/parallel/test-zlib-not-string-or-buffer.js
@@ -22,8 +22,8 @@ const zlib = require('zlib');
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "buffer" argument must be of type string, ' +
-               'Buffer, TypedArray, DataView, or ArrayBuffer.' +
+      message: 'The "buffer" argument must be of type string or an instance ' +
+               'of Buffer, TypedArray, DataView, or ArrayBuffer.' +
                common.invalidArgTypeHelper(input)
     }
   );

--- a/test/js/node/zlib/zlib.test.js
+++ b/test/js/node/zlib/zlib.test.js
@@ -788,3 +788,24 @@ describe("crc32", () => {
     expect(zlib.crc32("hello")).toBe(zlib.crc32("hello", 0));
   });
 });
+
+describe("sync convenience methods reject non-buffer input with node's message", () => {
+  const expected =
+    'The "buffer" argument must be of type string or an instance of Buffer, TypedArray, DataView, or ArrayBuffer.';
+
+  it.each([
+    ["deflateSync", 123, "Received type number (123)"],
+    ["gunzipSync", {}, "Received an instance of Object"],
+    ["brotliCompressSync", [1, 2, 3], "Received an instance of Array"],
+    ["zstdDecompressSync", null, "Received null"],
+    ["inflateRawSync", undefined, "Received undefined"],
+  ])("%s(%p)", (method, input, received) => {
+    expect(() => zlib[method](input)).toThrow(
+      expect.objectContaining({
+        name: "TypeError",
+        code: "ERR_INVALID_ARG_TYPE",
+        message: `${expected} ${received}`,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
### Problem
- Several `ERR_INVALID_ARG_TYPE` messages thrown from the TypeScript builtins do not match node's text. `fs.createReadStream(null, { fd: "x" })` says `The "options.fd" property must be of type number or FileHandle. Received type string ('x')`; node v26.3.0 says `... must be of type number or an instance of FileHandle. ...`.
- Same defect at four more sites, verified against node v26.3.0 (outputs in the details block below):
  - `zlib.*Sync(notABuffer)`: bun `of type string, Buffer, TypedArray, DataView, or ArrayBuffer`, node `of type string or an instance of Buffer, TypedArray, DataView, or ArrayBuffer`
  - `diagnostics_channel.channel(123)` (also `subscribe`/`unsubscribe`): bun `of type string or symbol`, node `one of type string or symbol`
  - `diagnostics_channel.tracingChannel(123)`: bun `must be an string, object, or Channel`, node `must be of type string or an instance of TracingChannel or Object`
  - `fs._toUnixTimestamp("x")`: bun `of type number or Date`, node `an instance of Date or an Time in seconds`
- Cause: these call sites pass the expected types as one pre-joined string (`"number or FileHandle"`, or `["string, object, or Channel"]`), so they hit the single-string overload of the message builder (`src/jsc/bindings/ErrorCode.cpp:631`), which prints `of type ` + the string verbatim. Node passes an array (`['number', 'FileHandle']`) and groups the entries. Sites: `src/js/internal/fs/streams.ts:173` and `:418`, `src/js/node/zlib.ts:117`, `src/js/node/diagnostics_channel.ts:222` and `:280`, `src/js/node/fs.ts:1025`.

### Fix
- Pass the same arrays node passes at each of the six sites. No error-builder change: the array overload (`ErrorCode.cpp:690`) is already a port of node's grouping and is what the other ~70 array call sites in `src/js` use, so the output is node's text byte for byte, including node's `an Time in seconds` (`lib/internal/fs/utils.js#L795`) and the `TracingChannel` entry (`lib/diagnostics_channel.js#L315-L317`), which are cited at the two sites where the list looks odd.
- Correct because for `node:*` modules node's observed output is the contract; every new assertion below is the string real node v26.3.0 prints for the same call.
- These are the only remaining list-as-string sites in `src/js` (scanned all 232 `$ERR_INVALID_ARG_TYPE` calls). The two other joined strings (`_http_client.ts:72`, `tls.ts:1778`) already render node's text and are untouched. The `"path"` site next to the fixed ones in `streams.ts` is left alone because its real problem is that Buffer paths are rejected, which #35981 fixes.
- Overlap note: the `zlib.ts` line and the vendored test restore below are also contained in #35429; they are one line each and rebase cleanly whichever lands first.
- Verified:
  - `test/js/node/fs/fs.test.ts`: new `options.fd` cases for `createReadStream`, `createWriteStream`, `new fs.ReadStream`, `new fs.WriteStream` (primitive, bigint and object values) and `fs._toUnixTimestamp` cases (default and explicit `name`). 21 new tests fail on the unfixed build, pass with the fix; the whole file passes (532 pass, 0 fail).
  - `test/js/node/zlib/zlib.test.js`: new cases across deflate/gunzip/brotli/zstd/inflateRaw sync methods; fail before, pass after; file passes (392 pass).
  - `test/js/node/diagnostics_channel/diagnostics_channel.test.ts`: the two existing regexes for the old wording are replaced with node's exact text, plus `channel`/`unsubscribe`/`tracingChannel` cases; 4 fail before, all pass after.
  - `test/js/node/test/parallel/test-zlib-not-string-or-buffer.js`: restored to the upstream v26.3.0 file byte for byte (it had been edited to bun's wording); exits 1 on the unfixed build, 0 with the fix, 0 under real node.
  - All 35 vendored `test-diagnostics-channel-*.js`, `test-fs-timestamp-parsing-error.js`, `test-fs-utimes.js` and the fd/FileHandle stream tests still exit 0.
- The same pattern exists in C++ callers of `ERR::INVALID_ARG_TYPE` (string_decoder, process, crypto); that is a separate change, not touched here.

### Background
- `ERR_INVALID_ARG_TYPE` message shape: node's `lib/internal/errors.js` takes the expected types as an array and splits it into primitive type names (`of type string`, or `one of type string or symbol` when there are several), class names (`an instance of A, B, or C`) and free-form phrases, joined with ` or `. A primitive and a class together therefore read `of type number or an instance of FileHandle`.
- `$ERR_INVALID_ARG_TYPE(name, expected, value)` in `src/js` compiles to a call into `src/jsc/bindings/ErrorCode.cpp`. If `expected` is a JS array it goes to the grouping overload described above; if it is a string, the string is printed as-is after `of type ` (or after `an ` when it is a single capitalized phrase). So a list joined in JS skips the grouping, which is the whole bug.

<details>
<summary>bun 1.4.0 vs node v26.3.0 for the affected calls</summary>

```
fs.createReadStream(null, { fd: "x" })
  bun:  The "options.fd" property must be of type number or FileHandle. Received type string ('x')
  node: The "options.fd" property must be of type number or an instance of FileHandle. Received type string ('x')
fs.createWriteStream(null, { fd: {} })
  bun:  The "options.fd" property must be of type number or FileHandle. Received an instance of Object
  node: The "options.fd" property must be of type number or an instance of FileHandle. Received an instance of Object
zlib.gzipSync(123)
  bun:  The "buffer" argument must be of type string, Buffer, TypedArray, DataView, or ArrayBuffer. Received type number (123)
  node: The "buffer" argument must be of type string or an instance of Buffer, TypedArray, DataView, or ArrayBuffer. Received type number (123)
dc.channel(123)
  bun:  The "channel" argument must be of type string or symbol. Received type number (123)
  node: The "channel" argument must be one of type string or symbol. Received type number (123)
dc.tracingChannel(123)
  bun:  The "nameOrChannels" argument must be an string, object, or Channel. Received type number (123)
  node: The "nameOrChannels" argument must be of type string or an instance of TracingChannel or Object. Received type number (123)
fs._toUnixTimestamp("x")
  bun:  The "time" argument must be of type number or Date. Received type string ('x')
  node: The "time" argument must be an instance of Date or an Time in seconds. Received type string ('x')
```

With this change every bun line above is identical to the node line.
</details>
