### PR TITLE
hot/watch: dispatch beforeExit once per drain, not once per event loop wakeup

### DIFF
--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1471,13 +1471,30 @@ impl Run<'_> {
         // ── core run-loop ──────────────────────────────────────────────────
         if vm.is_watcher_enabled() {
             vm.report_exception_in_hot_reloaded_module_if_needed();
+            // 'beforeExit' is dispatched when a generation's work drains: once
+            // for the initial evaluation, again whenever the loop had work and
+            // ran out of it, and again for a reload (which, for an entry with
+            // nothing to transpile off-thread, is evaluated entirely inside the
+            // wakeup that delivered it, without the loop ever being alive).
+            // `tick_possibly_forever()` also returns for its bounded wait, a
+            // signal, or an unref'd poll; none of those is a drain.
+            let mut dispatch_before_exit = true;
+            let mut generation = vm.hot_reload_counter;
             loop {
                 while vm.is_event_loop_alive() {
                     vm.tick();
                     vm.report_exception_in_hot_reloaded_module_if_needed();
                     vm.auto_tick_active();
+                    dispatch_before_exit = true;
                 }
-                vm.on_before_exit();
+                if generation != vm.hot_reload_counter {
+                    generation = vm.hot_reload_counter;
+                    dispatch_before_exit = true;
+                }
+                if dispatch_before_exit {
+                    dispatch_before_exit = false;
+                    vm.on_before_exit();
+                }
                 vm.report_exception_in_hot_reloaded_module_if_needed();
                 // SAFETY: `event_loop` is a self-pointer into this VM; uniquely
                 // accessed here. Watcher arm keeps the process alive across

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -1,7 +1,7 @@
 import { spawn } from "bun";
 import { beforeEach, expect, it } from "bun:test";
 import { copyFileSync, cpSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, isDebug, isWindows, tmpdirSync, waitForFileToExist } from "harness";
+import { bunEnv, bunExe, forEachLine, isDebug, isWindows, tempDir, tmpdirSync, waitForFileToExist } from "harness";
 import { join } from "path";
 
 const timeout = isDebug ? Infinity : 10_000;
@@ -775,4 +775,55 @@ ${Buffer.alloc(counter * 2, " ").toString()}throw new Error(${counter});`,
     // TODO: bun has a memory leak when --hot is used on very large files
   },
   longTimeout,
+);
+
+// With a watcher installed the process never exits, so the run loop parks and
+// wakes up again for things that are not a drain of the event loop (its bounded
+// wait, a signal). 'beforeExit' is only for a drain: once after the entry is
+// evaluated and once more after a reload. A signal listener runs without keeping
+// the loop alive, which makes it a wakeup that must not re-emit; it is also why
+// this is POSIX-only, the run loop itself is the same on every platform.
+it.skipIf(isWindows).each(["--hot", "--watch"])(
+  "%s emits beforeExit once per generation, not once per event loop wakeup",
+  async flag => {
+    const source = `console.log("start");
+// Under --hot a reload re-evaluates this file on the same process object.
+if (!globalThis.listening) {
+  globalThis.listening = true;
+  process.on("beforeExit", () => console.log("beforeExit"));
+  process.on("SIGUSR2", () => console.log("signal"));
+}
+`;
+    using dir = tempDir("hot-before-exit", { "entry.js": source });
+    const entry = join(String(dir), "entry.js");
+    await using runner = spawn({
+      cmd: [bunExe(), flag, entry],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "inherit",
+      stdin: "ignore",
+    });
+    const lines = forEachLine(runner.stdout);
+    const nextLine = async () => (await lines.next()).value;
+
+    expect(await nextLine()).toBe("start");
+    expect(await nextLine()).toBe("beforeExit");
+
+    for (let i = 0; i < 3; i++) {
+      runner.kill("SIGUSR2");
+      expect(await nextLine()).toBe("signal");
+    }
+
+    // A reload is a new generation (re-evaluated in-process under --hot,
+    // re-executed under --watch), so it drains, and announces it, once more.
+    // One save can reach the watcher as more than one event; a second reload
+    // that runs before the first one's drain is announced drains with it.
+    writeHotFileAtomicSync(entry, `${source}// reloaded\n`);
+    expect(await nextLine()).toBe("start");
+    let line = await nextLine();
+    while (line === "start") line = await nextLine();
+    expect(line).toBe("beforeExit");
+  },
+  timeout,
 );


### PR DESCRIPTION
### Problem
- Under `bun --hot` and `bun --watch`, `process.on("beforeExit", ...)` fires again about once per second while the script is idle, and in a tight loop whenever some fd the loop polls is ready. Plain `bun` and node (with or without `--watch`) emit it once when the loop drains. Reproduces on 1.4.0 and main (probes below).
- Cause: the watcher arm of the run loop in `Run::start` (src/runtime/cli/run_command.rs, the `loop` after `// core run-loop`) calls `vm.on_before_exit()` on every iteration, and one iteration is one return from `tick_possibly_forever()` (src/jsc/event_loop.rs), which returns on every wakeup: its one second bounded wait, a signal, a ready one-shot poll. Nothing checked whether the loop had done any work since the previous dispatch.
- Not new: the Zig version of this loop made the same unconditional call, but its park was only interrupted by a 4 minute keep-alive timer (and fd wakeups); the one second bounded wait the Rust `tick_possibly_forever()` uses is what makes the idle case visible.

### Fix
- The watcher arm dispatches `beforeExit` only when something drained: once for the initial evaluation, again after its `while vm.is_event_loop_alive()` body ran (the loop had work and ran out of it), and again when `vm.hot_reload_counter` moved (a reload happened). A wakeup that did none of these goes straight back to parking.
- The counter check is needed, not just the "body ran" flag: the entry file is transpiled on the JS thread (`transpile_file` in src/runtime/jsc_hooks.rs skips the concurrent store for `is_main`), so a reload of an entry without imports is evaluated entirely inside the tick of the wakeup that delivered the reload task, and the loop is never alive for it. Verified by building without the counter check: the `--hot` test below then fails because the reloaded generation never gets its `beforeExit`.
- Why this is correct: it is the rule node and the non-watcher arm right below already follow (emit when the loop drains; emit again only if a listener re-armed it), applied to a process that is kept alive by the watcher instead of exiting. The re-arm case itself is unchanged, it is handled inside `VirtualMachine::on_before_exit()`. A listener that schedules a timer once still gets `start, beforeExit, timer, beforeExit` under `--hot`, the same as plain `bun`. Two reloads that land in the same tick drain together and are announced once.
- Everything else the loop did per iteration (`report_exception_in_hot_reloaded_module_if_needed()`, which reports a reloaded generation's rejection, retries a deferred reload and re-arms the watcher on the entry) still runs on every iteration; only the dispatch is gated.
- Test: test/cli/hot/hot.test.ts, `--hot` and `--watch` variants of "emits beforeExit once per generation, not once per event loop wakeup". The wake source is `SIGUSR2`: a signal listener runs without keeping the loop alive, so after each `signal` line nothing else may be printed. The test then saves the entry and expects the new generation to print `start` and exactly one more `beforeExit`. Signals are what make the test POSIX-only; the run loop is shared by all platforms.
  - Unfixed (1.4.0 via `USE_SYSTEM_BUN=1`, and the previous debug build): both variants fail within 100ms with `expected "signal", received "beforeExit"`. Fixed: pass, 40/40 with `--rerun-each=20` on the debug (ASAN) build.
  - Also green on the debug build: the rest of test/cli/hot/hot.test.ts, test/cli/hot/watch.test.ts, test/cli/watch/watch.test.ts, test/cli/watch/watcher-trace.test.ts, test/cli/hot/watch-many-dirs.test.ts, test/js/bun/cron/in-process-cron.test.ts, test/js/bun/resolve/bun-main-entry-point.test.ts, test/regression/issue/29524.test.ts, and the `beforeExit` tests in test/js/node/process/process.test.js.
- Not in scope: `console.write()` (a `FileSink` write + flush) inside a `beforeExit` listener still re-fires forever, with or without a watcher, because the flushed write leaves its poll registered and ref'd, so the loop reads as alive and `on_before_exit()`'s own re-dispatch rule fires; that is a `FileSink` keep-alive bug being fixed separately. Once it is, this change is what stops the same scenario from looping under `--hot` (the poll still wakes the loop, but no longer counts as a drain).
- Nearby open PRs touch the same line and compose with this one: #38638 replaces the `on_before_exit()` call with `on_before_exit_with(...)` (the call simply moves inside the new `if`), #38206 and #34657 change the error counters the dispatch is already guarded on, #38613 changes when a reload defers.

### Background
- `beforeExit` is node's "the event loop is empty" event: emitted when the loop drains; if a listener schedules more work, the loop runs again and the event is emitted again when it drains; if not, the process exits. `VirtualMachine::on_before_exit()` implements exactly that (dispatch, drain, re-dispatch only if the drain did work).
- With `--hot` or `--watch` the process must not exit, so `Run::start` takes a different arm: drive the loop while `is_event_loop_alive()`, dispatch `beforeExit`, then park in `tick_possibly_forever()` until something wakes the loop. `--hot` handles a file change by posting a task that re-evaluates the entry in the same process (one "generation" per evaluation; `hot_reload_counter` is incremented by each reload, and `globalThis` and `process` listeners survive it); `--watch` re-executes the process, so each generation starts from the top of this function.
- `is_event_loop_alive()` counts ref'd handles, queued tasks and in-flight module loads. Signal listeners and unref'd handles do not count, so their callbacks run on a wakeup without the loop ever being alive.

<details>
<summary>Probes (1.4.0, linux x64)</summary>

```
$ cat log.js
process.on("beforeExit", () => console.log("beforeExit"));
$ timeout 3 bun log.js | wc -l          # 1
$ timeout 3 bun --hot log.js | wc -l    # 3, one per second of idling
$ timeout 3 bun --watch log.js | wc -l  # 3

$ cat entry.js
console.log("start");
if (!globalThis.listening) {
  globalThis.listening = true;
  process.on("beforeExit", () => console.log("beforeExit"));
  process.on("SIGUSR2", () => console.log("signal"));
}
# bun --hot entry.js, then three kill -USR2, then save the file:
start, beforeExit, signal, beforeExit, signal, beforeExit, signal, beforeExit, start, beforeExit
# same with --watch. With this change (debug build), both modes:
start, beforeExit, signal, signal, signal, start, beforeExit
```
</details>
