### PR TITLE
install: do not resolve an exact version from an abbreviated manifest under minimum-release-age

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1045,9 +1045,18 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                         loaded_manifest = Some(manifest.clone());
 
                                         // If it's an exact package version already living in the cache
-                                        // We can skip the network request, even if it's beyond the caching period
+                                        // We can skip the network request, even if it's beyond the caching period.
+                                        // Except when minimum-release-age needs publish times and the cached
+                                        // manifest is abbreviated: its timestamps are all 0, so the age check
+                                        // below would pass any version. Fall through and fetch the extended one.
                                         if version.tag == dependency::version::Tag::Npm
                                             && version.npm().version.is_exact()
+                                            && (!needs_extended_manifest
+                                                || loaded_manifest
+                                                    .as_ref()
+                                                    .unwrap()
+                                                    .pkg
+                                                    .has_extended_manifest)
                                         {
                                             if let Some(find_result) =
                                                 loaded_manifest.as_ref().unwrap().find_by_version(

--- a/test/cli/install/minimum-release-age.test.ts
+++ b/test/cli/install/minimum-release-age.test.ts
@@ -15,6 +15,9 @@ setDefaultTimeout(1000 * 60 * 5);
 describe("minimum-release-age", () => {
   let mockRegistryServer: Server;
   let mockRegistryUrl: string;
+  // Every request the mock registry served, so tests can assert which manifests
+  // were fetched and whether the abbreviated or the full document was requested.
+  const registryRequests: { pathname: string; accept: string | null }[] = [];
   const currentTime = Date.now();
   const SECONDS_PER_DAY = 24 * 60 * 60;
   const MS_PER_SECOND = 1000;
@@ -85,6 +88,7 @@ describe("minimum-release-age", () => {
       port: 0,
       async fetch(req) {
         const url = new URL(req.url);
+        registryRequests.push({ pathname: url.pathname, accept: req.headers.get("accept") });
 
         // Special timestamp helpers for edge case packages
         const futureTime = new Date(currentTime + 7 * DAY_MS).toISOString();
@@ -936,6 +940,124 @@ describe("minimum-release-age", () => {
       expect(stderr.toLowerCase()).toMatch(
         /blocked.*npm.*minimal.*age.*gate|blocked.*minimum.*release.*age|too.*recent/,
       );
+    });
+  });
+
+  describe("exact version with a cached manifest", () => {
+    // An exact version can be resolved from a cached manifest without asking the
+    // registry again. An install without an age gate caches the abbreviated
+    // manifest, which (from the real registry as well as from this mock) has no
+    // publish times, so an age-gated install must not resolve from it. Each test
+    // uses its own cache directory and reads which manifest flavor was requested
+    // off the Accept header.
+    const minAgeArgs = ["--minimum-release-age", `${5 * SECONDS_PER_DAY}`];
+    const blockedMessage = /blocked by minimum-release-age|minimum release age/;
+
+    const project = (dependencies: Record<string, string>) => ({
+      "package.json": JSON.stringify({ name: "app", dependencies }),
+      ".npmrc": `registry=${mockRegistryUrl}`,
+    });
+
+    async function runWithCache(cwd: string, cacheDir: string, args: string[], { stale = false } = {}) {
+      const firstRequest = registryRequests.length;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), ...args, "--no-verify"],
+        cwd,
+        env: {
+          ...bunEnv,
+          BUN_INSTALL_CACHE_DIR: cacheDir,
+          // BUN_MANIFEST_CACHE=1 treats every cached manifest as past its
+          // freshness window, which is the state the exact-version shortcut
+          // exists for.
+          ...(stale && { BUN_MANIFEST_CACHE: "1" }),
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const manifestRequests = registryRequests
+        .slice(firstRequest)
+        .filter(({ pathname }) => pathname === "/regular-package")
+        .map(({ accept }) => (accept?.includes("application/vnd.npm.install-v1+json") ? "abbreviated" : "full"));
+      return { stdout, stderr, exitCode, manifestRequests };
+    }
+
+    test("too-recent exact version is blocked when only the abbreviated manifest is cached", async () => {
+      using cache = tempDir("abbreviated-cache", {});
+      using ungated = tempDir("abbreviated-ungated", project({ "regular-package": "3.0.0" }));
+      using gated = tempDir("abbreviated-gated", project({ "regular-package": "3.0.0" }));
+
+      const first = await runWithCache(String(ungated), String(cache), ["install"]);
+      expect(first.manifestRequests).toEqual(["abbreviated"]);
+      expect(first.exitCode).toBe(0);
+
+      const second = await runWithCache(String(gated), String(cache), ["install", ...minAgeArgs]);
+      expect(second.stderr).toMatch(blockedMessage);
+      expect(second.manifestRequests).toEqual(["full"]);
+      expect(await Bun.file(`${gated}/node_modules/regular-package/package.json`).exists()).toBe(false);
+      expect(second.exitCode).toBe(1);
+    });
+
+    test("old enough exact version installs after the full manifest is fetched", async () => {
+      using cache = tempDir("abbreviated-cache-old", {});
+      using ungated = tempDir("abbreviated-ungated-old", project({ "regular-package": "1.0.0" }));
+      using gated = tempDir("abbreviated-gated-old", project({ "regular-package": "1.0.0" }));
+
+      const first = await runWithCache(String(ungated), String(cache), ["install"]);
+      expect(first.manifestRequests).toEqual(["abbreviated"]);
+      expect(first.exitCode).toBe(0);
+
+      const second = await runWithCache(String(gated), String(cache), ["install", ...minAgeArgs]);
+      expect(second.manifestRequests).toEqual(["full"]);
+      expect(await Bun.file(`${gated}/bun.lock`).text()).toContain("regular-package@1.0.0");
+      expect(second.exitCode).toBe(0);
+    });
+
+    test("bun add of a too-recent exact version is blocked when only the abbreviated manifest is cached", async () => {
+      using cache = tempDir("abbreviated-cache-add", {});
+      using ungated = tempDir("abbreviated-ungated-add", project({ "regular-package": "3.0.0" }));
+      using gated = tempDir("abbreviated-gated-add", project({}));
+
+      const first = await runWithCache(String(ungated), String(cache), ["install"]);
+      expect(first.manifestRequests).toEqual(["abbreviated"]);
+      expect(first.exitCode).toBe(0);
+
+      const second = await runWithCache(String(gated), String(cache), ["add", "regular-package@3.0.0", ...minAgeArgs]);
+      expect(second.stderr).toMatch(blockedMessage);
+      expect(second.manifestRequests).toEqual(["full"]);
+      expect(await Bun.file(`${gated}/package.json`).json()).toEqual({ name: "app", dependencies: {} });
+      expect(second.exitCode).toBe(1);
+    });
+
+    test("old enough exact version still resolves from a stale full manifest without a request", async () => {
+      using cache = tempDir("full-cache", {});
+      using first = tempDir("full-first", project({ "regular-package": "1.0.0" }));
+      using second = tempDir("full-second", project({ "regular-package": "1.0.0" }));
+
+      const populate = await runWithCache(String(first), String(cache), ["install", ...minAgeArgs]);
+      expect(populate.manifestRequests).toEqual(["full"]);
+      expect(populate.exitCode).toBe(0);
+
+      const fromCache = await runWithCache(String(second), String(cache), ["install", ...minAgeArgs], { stale: true });
+      expect(fromCache.manifestRequests).toEqual([]);
+      expect(await Bun.file(`${second}/bun.lock`).text()).toContain("regular-package@1.0.0");
+      expect(fromCache.exitCode).toBe(0);
+    });
+
+    test("too-recent exact version is still blocked by a stale full manifest without a request", async () => {
+      using cache = tempDir("full-cache-blocked", {});
+      using first = tempDir("full-first-blocked", project({ "regular-package": "1.0.0" }));
+      using second = tempDir("full-second-blocked", project({ "regular-package": "3.0.0" }));
+
+      const populate = await runWithCache(String(first), String(cache), ["install", ...minAgeArgs]);
+      expect(populate.manifestRequests).toEqual(["full"]);
+      expect(populate.exitCode).toBe(0);
+
+      const fromCache = await runWithCache(String(second), String(cache), ["install", ...minAgeArgs], { stale: true });
+      expect(fromCache.stderr).toMatch(blockedMessage);
+      expect(fromCache.manifestRequests).toEqual([]);
+      expect(await Bun.file(`${second}/node_modules/regular-package/package.json`).exists()).toBe(false);
+      expect(fromCache.exitCode).toBe(1);
     });
   });
 


### PR DESCRIPTION
### Problem
- `bun install --minimum-release-age N` (or `install.minimumReleaseAge` in bunfig) installs a version younger than N when package.json pins an exact version and the package's abbreviated manifest is already in the install cache (for example from an earlier `bun install` without the setting, in any project sharing the cache). `bun add pkg@x.y.z` takes the same path.
- No request is made to the registry at all, so the full manifest that carries publish times is never fetched and the age gate never runs.
- Cause, in the npm branch of `enqueue_dependency_with_main_and_success_fn` (`src/install/PackageManager/PackageManagerEnqueue.rs:1035-1110` on main):
  - `by_name_hash_allow_expired` hands back the cached manifest even when an age gate is set and the manifest is abbreviated; it only marks it expired (`src/install/PackageManifestMap.rs:186` and `:217`). That is deliberate: the manifest's ETag is needed for the network request further down.
  - The exact-version shortcut right after it (`:1049`) does not check which flavor it got. An abbreviated manifest has `publish_timestamp_ms == 0` for every version (`src/install/npm.rs:764`), so `is_package_version_too_recent` (`npm.rs:1558`) is false and the pin is resolved from the cache.
- The regular resolution path is not affected: `get_or_put_resolved_package` uses `by_name_hash` (`PackageManagerEnqueue.rs:2424`), which refuses an abbreviated manifest when an age gate is set. Only the exact-version shortcut bypasses it. The same structure existed before the Rust port, so this is not a regression.

### Fix
- The shortcut now also requires `!needs_extended_manifest || manifest.pkg.has_extended_manifest`. With an age gate and an abbreviated manifest, the code falls through to the network request it would have made for any non-exact specifier.
- Correct because that request already handles this exact state: `NetworkTask::for_manifest` asks for the full manifest and skips the conditional headers when the loaded manifest is abbreviated (`src/install/NetworkTask.rs:567`), so the registry returns the full document, and the re-enqueued dependency is then resolved (or rejected) by the regular path with real publish times. The condition is the same one `PackageManifestMap` and `for_manifest` already use to decide whether a manifest is good enough under an age gate.
- Without an age gate, `needs_extended_manifest` is false and the shortcut behaves exactly as before. With an age gate and a full manifest in the cache (even a stale one), the shortcut is still taken and still applies its own age check; two of the new tests pin that down.
- Packages listed in `minimumReleaseAgeExcludes` with an exact pin now also refetch the full manifest once, like they already did for non-exact specifiers.
- Verified with `test/cli/install/minimum-release-age.test.ts`, new `exact version with a cached manifest` block (5 tests):
  - The three abbreviated-manifest tests (`bun install` on a too-recent pin, `bun install` on an old enough pin, `bun add` on a too-recent pin) fail on the released binary: the too-recent pins install with zero registry requests, and the old enough pin resolves without the full-manifest request.
  - The two full-manifest tests pass before and after; they use `BUN_MANIFEST_CACHE=1` so the cached manifest counts as stale and the shortcut is the path taken (confirmed by its distinct error message).
  - All 54 tests in the file pass with `bun bd test`.
  - The mock registry now records each request's path and Accept header; the new tests use that to assert whether the abbreviated or the full manifest was requested.

### Background
- Abbreviated vs full manifest: the registry serves two documents for a package. With `Accept: application/vnd.npm.install-v1+json` it returns the abbreviated one (versions and tarballs, no `time` field); with `Accept: application/json` it returns the full one, including `time` with a publish date per version. Bun asks for the full one only when a minimum release age is configured (`needs_extended_manifest`), and records which one it parsed in `pkg.has_extended_manifest`. Both are written to the same cache file, so a later process can load either flavor.
- Exact-version shortcut: when package.json pins `pkg@1.2.3` and a cached manifest (even one past its freshness window) contains that version, bun resolves it from the cache instead of re-requesting the manifest, since a published version does not change. The network request below the shortcut is what every other specifier uses when the cached manifest cannot be used.
- `BUN_MANIFEST_CACHE=1` (used by two tests): keep reading the manifest cache but treat every cached manifest as past its freshness window, which is the state the shortcut exists for.
