### PR TITLE
bun-types: type Subprocess.send(message, handle, options, callback) and the ipc callback's handle

### DIFF
--- a/docs/runtime/child-process.mdx
+++ b/docs/runtime/child-process.mdx
@@ -310,6 +310,55 @@ To disconnect the IPC channel from the parent process, call:
 childProc.disconnect();
 ```
 
+### Passing sockets over IPC
+
+`send()` takes an optional second argument: a listening `net.Server`, a connected `net.Socket` or a bound `dgram.Socket`. The operating system socket is duplicated into the other process, which receives its own `net.Server`, `net.Socket` or `dgram.Socket` for it as the third argument of the `ipc` handler (in the parent) or the second argument of the `"message"` listener (in the child). This is the same handle passing that `child.send()` and `process.send()` do in Node.js, and it also works when the other process is Node.js (with `serialization: "json"`, see below).
+
+```ts parent.ts icon="/icons/typescript.svg"
+import { connect, createServer, type AddressInfo } from "node:net";
+
+const server = createServer();
+
+server.listen(0, "127.0.0.1", () => {
+  const { port } = server.address() as AddressInfo;
+
+  const child = Bun.spawn(["bun", "child.ts"], {
+    ipc(message, subprocess) {
+      // The child replies once it has set up its copy of the server.
+      if (message !== "ready") return;
+      connect(port, "127.0.0.1").on("data", data => {
+        console.log(data.toString()); // "hello from the child"
+        subprocess.kill();
+      });
+    },
+  });
+
+  child.send("take over this server", server);
+  // The child now has its own copy of the listening socket. Closing the parent's
+  // copy leaves every incoming connection to the child.
+  server.close();
+});
+```
+
+```ts child.ts icon="/icons/typescript.svg"
+import { Server } from "node:net";
+
+process.on("message", (message, handle) => {
+  // `handle` is this process's own copy of the socket the parent passed to `send()`.
+  if (handle instanceof Server) {
+    handle.on("connection", socket => socket.end("hello from the child"));
+    process.send("ready");
+  }
+});
+```
+
+The full signature is `send(message, handle?, options?, callback?)`, like `child.send()` in Node.js:
+
+- A `net.Socket` is closed in the sending process once it has been handed over; pass `{ keepOpen: true }` as `options` to keep it open on both sides. `net.Server` and `dgram.Socket` handles always stay open in the sender.
+- `callback` is called with `null` once the message (and handle) has been sent, or with the error that prevented it. Without a callback, sending on a closed channel throws `ERR_IPC_CHANNEL_CLOSED`.
+- `send()` returns `true`, or `false` when messages are queuing up behind a handle the other process has not acknowledged yet (or, with a callback, when the channel is closed).
+- A handle with no open socket behind it (a server that is not listening, a socket that is not connected) is dropped and the message arrives without one. Passing anything else, including a `tls.TLSSocket`, throws `ERR_INVALID_HANDLE_TYPE`.
+
 ### IPC between Bun & Node.js
 
 To use IPC between a `bun` process and a Node.js process, set `serialization: "json"` in `Bun.spawn`. This is because Node.js and Bun use different JavaScript engines with different object serialization formats.

--- a/docs/runtime/child-process.mdx
+++ b/docs/runtime/child-process.mdx
@@ -581,7 +581,7 @@ namespace SpawnOptions {
       signalCode: number | null,
       error?: ErrorLike,
     ): void | Promise<void>;
-    ipc?(message: any, subprocess: Subprocess): void;
+    ipc?(message: any, subprocess: Subprocess, handle?: SendHandle): void;
     serialization?: "json" | "advanced";
     windowsHide?: boolean;
     windowsVerbatimArguments?: boolean;
@@ -616,6 +616,14 @@ namespace SpawnOptions {
     | Blob
     | Response
     | Request;
+
+  // A socket that can be passed along with an IPC message; the other process
+  // receives its own net.Server / net.Socket / dgram.Socket for it.
+  type SendHandle = net.Server | net.Socket | dgram.Socket;
+
+  interface SendOptions {
+    keepOpen?: boolean; // keep a sent net.Socket open in this process as well
+  }
 }
 
 interface Subprocess extends AsyncDisposable {
@@ -634,7 +642,12 @@ interface Subprocess extends AsyncDisposable {
   ref(): void;
   unref(): void;
 
-  send(message: any): void;
+  send(
+    message: any,
+    handle?: SpawnOptions.SendHandle,
+    options?: SpawnOptions.SendOptions,
+    callback?: (error: Error | null) => void,
+  ): boolean;
   disconnect(): void;
   resourceUsage(): ResourceUsage | undefined;
 }

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7155,7 +7155,15 @@ declare module "bun" {
          * The {@link Subprocess} that received the message
          */
         subprocess: Subprocess<In, Out, Err>,
-        handle?: unknown,
+        /**
+         * Set when the child passed a socket as the second argument of
+         * `process.send(message, handle)`: a listening `net.Server`, a
+         * connected `net.Socket` or a bound `dgram.Socket` wrapping this
+         * process's own copy of it. This process owns that copy and should
+         * close it when done with it. Use `instanceof` to tell the three
+         * apart. `undefined` for messages sent without a handle.
+         */
+        handle?: SendHandle,
       ): void;
 
       /**
@@ -7343,6 +7351,45 @@ declare module "bun" {
       : X extends BunFile | ArrayBufferView | Blob | Request | Response | number
         ? number
         : undefined;
+
+    /**
+     * A socket that can be sent over the IPC channel along with a message: the
+     * second argument of {@link Subprocess.send} in the parent and of
+     * `process.send()` in the child. Also works when the other process is
+     * Node.js (with `serialization: "json"`).
+     *
+     * The operating system socket is duplicated into the other process, which
+     * receives a new object of the same kind wrapping it: a listening
+     * `net.Server`, a connected `net.Socket` or a bound `dgram.Socket`. The
+     * parent receives it as the third argument of the {@link BaseOptions.ipc}
+     * callback, the child as the second argument of its `"message"` listener.
+     *
+     * A handle with no open socket behind it (a server that is not listening,
+     * a socket that is not connected or already destroyed, an unbound
+     * `dgram.Socket`) is dropped and the message arrives without a handle.
+     * Any other value, including a `tls.TLSSocket`, makes `send()` throw
+     * `ERR_INVALID_HANDLE_TYPE`.
+     */
+    type SendHandle = import("node:net").Server | import("node:net").Socket | import("node:dgram").Socket;
+
+    /**
+     * Options for {@link Subprocess.send} when sending a {@link SendHandle}.
+     */
+    interface SendOptions {
+      /**
+       * Only meaningful for a `net.Socket` handle. By default the sender's
+       * copy of the connection is closed once the socket has been handed
+       * over, leaving the receiving process as its only owner. With `true`,
+       * the sender's socket stays open too and both processes can read from
+       * and write to the same connection.
+       *
+       * `net.Server` and `dgram.Socket` handles always stay open in the
+       * sender.
+       *
+       * @default false
+       */
+      keepOpen?: boolean | undefined;
+    }
   }
 
   interface ResourceUsage {
@@ -7541,11 +7588,70 @@ declare module "bun" {
 
     /**
      * Send a message to the subprocess. This is only supported if the subprocess
-     * was created with the `ipc` option, and is another instance of `bun`.
+     * was created with the `ipc` option. The subprocess receives it through
+     * `process.on("message")`.
      *
      * Messages are serialized using the JSC serialize API, which allows for the same types that `postMessage`/`structuredClone` supports.
+     *
+     * Throws `ERR_IPC_CHANNEL_CLOSED` if the channel is closed or the process has
+     * exited, unless a `callback` is given, in which case the error is passed to
+     * the callback and `false` is returned.
+     *
+     * @param callback Called on a later tick with `null` once the message has been
+     * sent, or with the error that prevented sending it. Use it for flow control
+     * when sending many messages.
+     * @returns `true` normally. `false` if the message had to be queued because a
+     * {@link SpawnOptions.SendHandle} sent earlier is still waiting to be
+     * acknowledged by the subprocess and other messages are already queued behind
+     * it, or if the channel is closed and a `callback` was given.
      */
-    send(message: any): void;
+    send(message: any, callback?: (error: Error | null) => void): boolean;
+
+    /**
+     * Send a message together with a socket, like `child.send(message, handle)`
+     * in Node.js. The subprocess receives the message and its own copy of the
+     * socket as the two arguments of its `"message"` listener. See
+     * {@link SpawnOptions.SendHandle} for what can be sent and what arrives.
+     *
+     * A `net.Socket` is closed in this process once it has been handed over
+     * unless `{ keepOpen: true }` is passed as the third argument.
+     *
+     * @example
+     * ```ts
+     * import { createServer } from "node:net";
+     *
+     * const child = Bun.spawn(["bun", "child.ts"], { ipc(message) {} });
+     * const server = createServer();
+     *
+     * server.listen(0, () => {
+     *   // child.ts receives (message, server) in process.on("message") and can
+     *   // accept connections on the port this process bound.
+     *   child.send("take this server", server);
+     *   // Closing this process's copy leaves every connection to the child.
+     *   server.close();
+     * });
+     * ```
+     */
+    send(message: any, handle?: SpawnOptions.SendHandle, callback?: (error: Error | null) => void): boolean;
+
+    /**
+     * Send a message together with a socket, with {@link SpawnOptions.SendOptions}
+     * controlling what happens to this process's copy of the socket.
+     *
+     * @example
+     * ```ts
+     * // Both processes can now use the connection.
+     * child.send("shared", socket, { keepOpen: true }, error => {
+     *   if (error) console.error(error);
+     * });
+     * ```
+     */
+    send(
+      message: any,
+      handle?: SpawnOptions.SendHandle,
+      options?: SpawnOptions.SendOptions,
+      callback?: (error: Error | null) => void,
+    ): boolean;
 
     /**
      * Disconnect the IPC channel to the subprocess. This is only supported if the subprocess

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -400,6 +400,35 @@ describe("@types/bun integration test", () => {
     });
   });
 
+  // Also runs on debug builds: type-checks fixture/spawn.ts on its own, which covers
+  // Subprocess.send(message, handle, options, callback) and the ipc callback's handle.
+  describe("Bun.spawn", () => {
+    test("fixture/spawn.ts type-checks", async () => {
+      const checkDir = join(TEMP_DIR, "spawn-fixture-check");
+      const tsconfig = structuredClone(sourceTsconfig);
+      tsconfig.files = [join(BASE_FIXTURE_DIR, "spawn.ts")];
+      tsconfig.compilerOptions.typeRoots = [join(BASE_FIXTURE_DIR, "node_modules", "@types")];
+      await mkdir(checkDir, { recursive: true });
+      await makeTree(checkDir, {
+        "tsconfig.json": JSON.stringify(tsconfig, null, 2),
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), join(BASE_FIXTURE_DIR, "node_modules", "typescript", "bin", "tsc"), "-p", "."],
+        env: bunEnv,
+        cwd: checkDir,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr.trim()).toBe("");
+      expect(stdout.trim()).toBe("");
+      expect(exitCode).toBe(0);
+    });
+  });
+
   describe("Test Globals", () => {
     const code = `
       const test_shouldBeAFunction: Function = test;

--- a/test/integration/bun-types/fixture/spawn.ts
+++ b/test/integration/bun-types/fixture/spawn.ts
@@ -226,3 +226,57 @@ tsd.expectAssignable<SyncSubprocess<Bun.SpawnOptions.Readable, Bun.SpawnOptions.
   Bun.spawnSync({ cmd: ["echo", "hello"], stdout: "pipe", stderr: "pipe", lazy: true,
   });
 }
+
+// IPC: Subprocess.send() takes the same (message, handle, options, callback) shapes as process.send(),
+// and the ipc callback receives the handle the child sent.
+import * as dgram from "node:dgram";
+import * as net from "node:net";
+
+{
+  const proc = Bun.spawn(["bun", "child.ts"], {
+    ipc(message, subprocess, handle) {
+      tsd.expectType(subprocess).is<Bun.Subprocess<"ignore", "pipe", "inherit">>();
+      tsd.expectType(handle).is<Bun.Spawn.SendHandle | undefined>();
+      if (handle instanceof net.Server) tsd.expectType(handle).is<net.Server>();
+      else if (handle instanceof net.Socket) tsd.expectType(handle).is<net.Socket>();
+      else if (handle instanceof dgram.Socket) tsd.expectType(handle).is<dgram.Socket>();
+      else tsd.expectType(handle).is<undefined>();
+    },
+  });
+
+  const server = net.createServer();
+  const socket = net.connect(0);
+  const udp = dgram.createSocket("udp4");
+  const onSent = (error: Error | null) => {};
+
+  tsd.expectType(proc.send("message")).is<boolean>();
+  tsd.expectType(proc.send({ some: "object" }, onSent)).is<boolean>();
+
+  tsd.expectType(proc.send("server", server)).is<boolean>();
+  tsd.expectType(proc.send("socket", socket)).is<boolean>();
+  tsd.expectType(proc.send("udp", udp)).is<boolean>();
+  tsd.expectType(proc.send("socket", socket, onSent)).is<boolean>();
+  tsd.expectType(proc.send("socket", socket, { keepOpen: true })).is<boolean>();
+  tsd.expectType(proc.send("socket", socket, { keepOpen: true }, onSent)).is<boolean>();
+  tsd.expectType(proc.send("no handle", undefined, {}, onSent)).is<boolean>();
+
+  const handle: Bun.Spawn.SendHandle = Math.random() > 0.5 ? server : socket;
+  proc.send("either", handle);
+  proc.send("either", handle, { keepOpen: false } satisfies Bun.Spawn.SendOptions);
+  proc.send("either", handle, undefined, onSent);
+
+  // Anything child_process.ChildProcess.send() accepts as a handle can be passed here too.
+  const nodeHandle = null as unknown as import("node:child_process").SendHandle;
+  tsd.expectAssignable<Bun.Spawn.SendHandle | undefined>(nodeHandle);
+
+  const bunListener = Bun.listen({ hostname: "localhost", port: 0, socket: { data() {} } });
+
+  // @ts-expect-error only net.Server, net.Socket and dgram.Socket can be sent
+  proc.send("fd", { fd: 3 });
+  // @ts-expect-error Bun.listen() listeners are not node:net servers and cannot be sent
+  proc.send("bun listener", bunListener);
+  // @ts-expect-error keepOpen is the only option
+  proc.send("socket", socket, { keepAlive: true });
+  // @ts-expect-error the callback receives an error or null
+  proc.send("socket", socket, undefined, (sent: boolean) => {});
+}


### PR DESCRIPTION
### Problem
- `subprocess.send("msg", server)` on a `Bun.spawn()` subprocess fails to type-check with `TS2554: Expected 1 arguments, but got 2`, although it works at runtime.
- Since IPC handle passing landed (#31829), `Subprocess.send` is `do_send` in `src/runtime/ipc_host.rs:97`: it reads `[message, handle, options, callback]` exactly like `process.send()` and returns a boolean. `node:child_process`'s `child.send(msg, handle)` is built on it (`src/js/node/child_process.ts:1535`).
- `packages/bun-types/bun.d.ts` still declared `send(message: any): void`, and the `ipc` callback's third parameter was an undocumented `handle?: unknown`.
- `docs/runtime/child-process.mdx` did not mention handle passing.

### Fix
- `Subprocess.send` gets the three overloads `@types/node` declares for `ChildProcess.send`: `(message, callback?)`, `(message, handle?, callback?)`, `(message, handle?, options?, callback?)`, each returning `boolean`.
- Adds `Bun.Spawn.SendHandle` (`net.Server | net.Socket | dgram.Socket`) and `Bun.Spawn.SendOptions` (`{ keepOpen?: boolean }`), and types the `ipc` callback's third parameter as `SendHandle | undefined`.
- Adds a "Passing sockets over IPC" section to `child-process.mdx`; its `parent.ts`/`child.ts` example was run as written on a release build of main.
- The runtime is untouched; `message` stays `any`.
- Why these exact declarations (each point checked against the runtime, transcript below):
  - Three call shapes: `do_send` takes a callable in the handle or options slot as the callback (`ipc_host.rs:102-106`).
  - Exactly those three handle classes: `serialize` in `src/js/builtins/Ipc.ts` throws `ERR_INVALID_HANDLE_TYPE` for anything else. `tls.TLSSocket` extends `net.Socket`, so the type cannot exclude it; the JSDoc says it throws.
  - `keepOpen` is the only option read on the user path; the cluster-internal `internal` flag stays undeclared.
  - `boolean` return and `callback(Error | null)` come from `serialize_and_send` and `do_send_err`.
  - The union is spelled out instead of aliasing `child_process.SendHandle` because bun-types depends on `@types/node: "*"` and older versions of that alias lack `dgram.Socket`, which Bun accepts. The fixture still asserts `@types/node`'s `SendHandle` is assignable to ours, so the two cannot drift apart silently.
- Test: `test/integration/bun-types/fixture/spawn.ts` calls every accepted shape and `@ts-expect-error`s four rejected ones (a non-handle object, a `Bun.listen()` listener, an unknown option, a wrongly typed callback); each rejected line was checked to fail for that reason alone.
- `bun test test/integration/bun-types/bun-types.test.ts` (release build: both tsconfigs and tsgo): 16 pass. With `packages/` stashed the fixture fails with the `TS2554` above plus the missing `Spawn.SendHandle`/`SendOptions` names.
- The existing type-check cases in that file are skipped on debug builds, so it gets a `Bun.spawn` case, same shape as the `Bun.mmap` one, that runs `tsc` over `fixture/spawn.ts` alone: 1.5s under a debug build, passes with the fix, fails without it.

### Background
- `Bun.spawn({ ipc })` opens an IPC channel: the parent sends with `subprocess.send()` and receives in the `ipc` callback; the child uses `process.send()` and `process.on("message")`.
- Handle passing: `send(message, handle)` duplicates the handle's OS socket into the other process (`SCM_RIGHTS` on POSIX, `WSADuplicateSocket` on Windows), which wraps it in a new listening `net.Server`, connected `net.Socket` or bound `dgram.Socket` and passes that to the message listener next to the message.
- `keepOpen`: a sent `net.Socket` is closed in the sender once handed over unless this is set; servers and dgram sockets stay open on both sides. A handle with no live socket behind it (server not listening, socket not connected, dgram not bound) is dropped and the message arrives alone.
- Return value: `false` when a previously sent handle is still waiting for the receiver's acknowledgement and messages are already queued behind it (the backpressure signal Node documents for `send()`), or, with a callback, when the channel is closed; without a callback a closed channel throws `ERR_IPC_CHANNEL_CLOSED`.
- `bun-types.test.ts` packs `packages/bun-types`, installs it into a copy of `fixture/` and type-checks the fixture through the TypeScript LanguageService; those cases are `skipIf(isDebug)`, which is why a types change also needs a spawned-`tsc` case to be exercised on debug builds.
- #38494 (docs only) rewrites the serialization sentences in the same two JSDoc blocks and leaves the signature alone; whichever lands second has a one-line conflict.

<details>
<summary>Runtime probe on a release build of main (what the declarations mirror)</summary>

```
send(msg)                                     -> true, child gets (msg, undefined)
send(msg, cb)                                 -> true, cb(null)
send(msg, net.Server)                         -> true, child gets a net.Server
send(msg, net.Socket)                         -> true, child gets a net.Socket, sender's copy closed
send(msg, net.Socket, { keepOpen: true }, cb) -> true, cb(null), sender's socket still usable
send(msg, dgram.Socket, cb)                   -> true, cb(null), child gets a dgram.Socket
send(msg, {})                                 -> throws ERR_INVALID_HANDLE_TYPE
send(msg, tls.TLSSocket)                      -> throws ERR_INVALID_HANDLE_TYPE
send(msg, non-listening or closed net.Server) -> true, child gets (msg, undefined)
send(msg, unconnected or destroyed net.Socket)-> true, child gets (msg, undefined)
send(msg, unbound dgram.Socket)               -> true, child gets (msg, undefined)
send(undefined)                               -> throws ERR_MISSING_ARGS
send(msg) after the channel closed            -> throws ERR_IPC_CHANNEL_CLOSED
send(msg, cb) after the channel closed        -> false, cb(ERR_IPC_CHANNEL_CLOSED)
Bun.spawn({ serialization: "json" }).send(msg, server) to a node v26 child -> the child serves the port
child process.send(msg, server | dgram | socket) -> parent ipc(message, subprocess, handle) receives a
  listening net.Server / bound dgram.Socket / connected net.Socket; undefined for a plain message
```

</details>
