### PR TITLE
node: render the Rust validators' ERR_INVALID_ARG_TYPE messages like Node

### DIFF
--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -541,6 +541,7 @@ impl JSGlobalObject {
     }
 
     /// "The {argname} argument must be of type {typename}. Received {value}"
+    /// (a dotted `argname` is a "property", see `InvalidArgTypeName`).
     ///
     /// Accepts `&str`, `&[u8]`, or `b"..."` for `argname`/`typename`.
     pub fn throw_invalid_argument_type_value(
@@ -556,8 +557,8 @@ impl JSGlobalObject {
         self.err(
             JscError::INVALID_ARG_TYPE,
             format_args!(
-                "The \"{}\" argument must be of type {}. Received {}",
-                bstr::BStr::new(argname.as_ref()),
+                "The {} must be of type {}. Received {}",
+                InvalidArgTypeName(argname.as_ref()),
                 bstr::BStr::new(typename.as_ref()),
                 actual_string_value
             ),
@@ -565,6 +566,8 @@ impl JSGlobalObject {
         .throw()
     }
 
+    /// Like [`Self::throw_invalid_argument_type_value`], but `typename` is the whole
+    /// phrase after "must be" (e.g. `"an instance of Array"`).
     pub fn throw_invalid_argument_type_value2(
         &self,
         argname: impl AsRef<[u8]>,
@@ -578,8 +581,8 @@ impl JSGlobalObject {
         self.err(
             JscError::INVALID_ARG_TYPE,
             format_args!(
-                "The \"{}\" argument must be {}. Received {}",
-                bstr::BStr::new(argname.as_ref()),
+                "The {} must be {}. Received {}",
+                InvalidArgTypeName(argname.as_ref()),
                 bstr::BStr::new(typename.as_ref()),
                 actual_string_value
             ),
@@ -587,7 +590,6 @@ impl JSGlobalObject {
         .throw()
     }
 
-    /// `validators.throwErrInvalidArgType` —
     /// `The "<name>" property must be of type <expected>, got <actual>`
     /// where `<actual>` is the JS `typeof` (or `"array"` for arrays).
     pub(crate) fn throw_invalid_property_type(
@@ -627,8 +629,8 @@ impl JSGlobalObject {
         self.err(
             JscError::INVALID_ARG_TYPE,
             format_args!(
-                "The \"{}\" argument must be one of type {}. Received {}",
-                bstr::BStr::new(argname.as_ref()),
+                "The {} must be one of type {}. Received {}",
+                InvalidArgTypeName(argname.as_ref()),
                 bstr::BStr::new(typename.as_ref()),
                 actual_string_value
             ),
@@ -1378,6 +1380,26 @@ pub struct SysErrOptions {
     pub code: NodeErrorCode,
     pub errno: Option<i32>,
     pub name: Option<&'static [u8]>,
+}
+
+/// The subject of Node's `ERR_INVALID_ARG_TYPE` message: `"name" argument`,
+/// `"options.name" property` for a dotted name, or the name verbatim when it
+/// already ends in ` argument` ("first argument"). Same rule as
+/// `Bun::Message::addParameter` in ErrorCode.cpp.
+/// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/errors.js#L1407-L1414
+struct InvalidArgTypeName<'a>(&'a [u8]);
+
+impl core::fmt::Display for InvalidArgTypeName<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let name = bstr::BStr::new(self.0);
+        if self.0.ends_with(b" argument") {
+            write!(f, "{name}")
+        } else if strings::contains_char(self.0, b'.') {
+            write!(f, "\"{name}\" property")
+        } else {
+            write!(f, "\"{name}\" argument")
+        }
+    }
 }
 
 // Unified with the crate-root definitions (lib.rs) — re-exported here so

--- a/src/runtime/node/path.rs
+++ b/src/runtime/node/path.rs
@@ -576,7 +576,7 @@ pub(crate) fn basename(
     };
 
     if let Some(_suffix_ptr) = suffix_ptr {
-        validate_string(global_object, _suffix_ptr, format_args!("ext"))?;
+        validate_string(global_object, _suffix_ptr, format_args!("suffix"))?;
     }
 
     let path_ptr: JSValue = if args_len > 0 {
@@ -1561,18 +1561,10 @@ pub(crate) fn join(
     // allocating; only non-ASCII triggers a transcode allocation.
     let mut owned: SmallVec<[ZigStringSlice; 8]> = SmallVec::with_capacity(args_len);
 
-    for (i, &path_ptr) in args.iter().enumerate() {
-        // Inline the `is_string` fast path; only build `format_args!("paths[{i}]")`
-        // on the cold error branch (it materialises a 48-byte `fmt::Arguments`
-        // every iteration otherwise).
-        if !path_ptr.is_string() {
-            #[cold]
-            #[inline(never)]
-            fn not_a_string(g: &JSGlobalObject, v: JSValue, i: usize) -> crate::jsc::JsError {
-                validate_string(g, v, format_args!("paths[{}]", i)).unwrap_err()
-            }
-            return Err(not_a_string(global_object, path_ptr, i));
-        }
+    for &path_ptr in args {
+        // Node's join() reports every argument as "path" (resolve() is the one
+        // that uses `paths[i]`).
+        validate_string(global_object, path_ptr, "path")?;
         let path_zstr = path_ptr.get_zig_string(global_object)?;
         if path_zstr.len == 0 {
             continue;

--- a/src/runtime/node/util/parse_args_utils.rs
+++ b/src/runtime/node/util/parse_args_utils.rs
@@ -19,7 +19,7 @@ impl From<OptionValueType> for &'static str {
 }
 
 impl super::validators::StringEnum for OptionValueType {
-    const VALUES_INFO: &'static str = "boolean|string";
+    const VALUES_INFO: &'static str = "string|boolean";
     fn from_bun_string(s: &String) -> Option<Self> {
         if s.eql_comptime(b"boolean") {
             Some(Self::Boolean)

--- a/src/runtime/node/util/validators.rs
+++ b/src/runtime/node/util/validators.rs
@@ -1,17 +1,6 @@
 use core::fmt;
 
-use bun_core::ZigString;
 use bun_jsc::{self as jsc, JSGlobalObject, JSValue, JsError, JsResult};
-
-fn get_type_name(global_object: &JSGlobalObject, value: JSValue) -> ZigString {
-    let js_type = value.js_type();
-    if js_type.is_array() {
-        return ZigString::static_("array");
-    }
-    value
-        .js_type_string(global_object)
-        .get_zig_string(global_object)
-}
 
 #[cold]
 pub(crate) fn throw_err_invalid_arg_value(
@@ -33,9 +22,9 @@ pub(crate) fn throw_err_invalid_arg_type_with_message(
         .throw()
 }
 
-// Callers pass the
-// already-formatted name as anything `Display`-able (e.g. `&str` or
-// `format_args!(...)`) and we embed it via `{}`.
+/// Node's `ERR_INVALID_ARG_TYPE(name, type, value)`. `name` is anything
+/// `Display`-able (`&str` or `format_args!("options.{}", key)`); it is only
+/// rendered on this cold path.
 #[cold]
 pub(crate) fn throw_err_invalid_arg_type(
     global_this: &JSGlobalObject,
@@ -43,14 +32,7 @@ pub(crate) fn throw_err_invalid_arg_type(
     expected_type: &str,
     value: JSValue,
 ) -> JsError {
-    let actual_type = get_type_name(global_this, value);
-    throw_err_invalid_arg_type_with_message(
-        global_this,
-        format_args!(
-            "The \"{}\" property must be of type {}, got {}",
-            name, expected_type, actual_type
-        ),
-    )
+    global_this.throw_invalid_argument_type_value(name.to_string(), expected_type, value)
 }
 
 #[cold]
@@ -395,13 +377,10 @@ pub(crate) fn validate_array(
     min_length: Option<i32>,
 ) -> JsResult<()> {
     if !value.js_type().is_array() {
-        let actual_type = get_type_name(global_this, value);
-        return Err(throw_err_invalid_arg_type_with_message(
-            global_this,
-            format_args!(
-                "The \"{}\" property must be an instance of Array, got {}",
-                name, actual_type
-            ),
+        return Err(global_this.throw_invalid_argument_type_value2(
+            name.to_string(),
+            "an instance of Array",
+            value,
         ));
     }
     if let Some(min_length) = min_length {
@@ -429,7 +408,7 @@ pub(crate) fn validate_string_array(
                 global_this,
                 format_args!("{}[{}]", name, i),
                 "string",
-                value,
+                item,
             ));
         }
         i += 1;
@@ -451,7 +430,7 @@ pub(crate) fn validate_boolean_array(
                 global_this,
                 format_args!("{}[{}]", name, i),
                 "boolean",
-                value,
+                item,
             ));
         }
         i += 1;
@@ -474,12 +453,14 @@ pub(crate) fn validate_function(
 /// Implementors should typically `#[derive(strum::EnumString, strum::VariantNames)]`
 /// and provide `VALUES_INFO` as the `|`-joined variant names.
 pub(crate) trait StringEnum: Sized {
-    /// `|`-joined list of variant names.
+    /// `|`-joined list of variant names, in the order Node lists the union.
     const VALUES_INFO: &'static str;
     /// Match `s` against variant names exactly.
     fn from_bun_string(s: &bun_core::String) -> Option<Self>;
 }
 
+/// Node's `validateUnion(value, name, [...])`, whose error renders the union as
+/// `must be ('a|b')`.
 pub(crate) fn validate_string_enum<T: StringEnum>(
     global_this: &JSGlobalObject,
     value: JSValue,
@@ -492,8 +473,9 @@ pub(crate) fn validate_string_enum<T: StringEnum>(
         return Ok(v);
     }
 
-    Err(throw_err_invalid_arg_type_with_message(
-        global_this,
-        format_args!("{} must be one of: {}", name, T::VALUES_INFO),
+    Err(global_this.throw_invalid_argument_type_value2(
+        name.to_string(),
+        format!("('{}')", T::VALUES_INFO),
+        value,
     ))
 }

--- a/test/js/node/crypto/scrypt.test.ts
+++ b/test/js/node/crypto/scrypt.test.ts
@@ -90,3 +90,23 @@ test("scryptSync reads its buffers only after every argument has been coerced", 
   expect(passwordBytes.byteLength).toBe(0);
   expect(key).toStrictEqual(scryptSync("", "salt", 16, { N: 1024 }));
 });
+
+test.each([
+  [
+    "keylen",
+    () => scryptSync("password", "salt", "x" as any),
+    `The "keylen" argument must be of type number. Received type string ('x')`,
+  ],
+  [
+    "N",
+    () => scryptSync("password", "salt", 16, { N: "x" as any }),
+    `The "N" argument must be of type number. Received type string ('x')`,
+  ],
+  [
+    "cost",
+    () => scryptSync("password", "salt", 16, { cost: 1n as any }),
+    `The "cost" argument must be of type number. Received type bigint (1n)`,
+  ],
+])("scryptSync reports a non-numeric %s with node's ERR_INVALID_ARG_TYPE message", (_, fn, message) => {
+  expect(fn).toThrow(expect.objectContaining({ name: "TypeError", code: "ERR_INVALID_ARG_TYPE", message }));
+});

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -2686,6 +2686,21 @@ describe("open/mkdir mode string validation matches node", () => {
     expect(() => fs.chmodSync(d, new String("755") as any)).toThrowWithCode(TypeError, "ERR_INVALID_ARG_TYPE");
   });
 
+  it("chmodSync/fchmodSync without a mode report it the way node does", () => {
+    using dir = tempDir("fs-mode-missing", { "f.txt": "" });
+    const file = join(String(dir), "f.txt");
+    const fd = openSync(file, "r");
+    try {
+      const message = 'The "mode" argument must be of type number. Received undefined';
+      // @ts-expect-error -- mode is required
+      expect(() => fs.chmodSync(file)).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE", message }));
+      // @ts-expect-error -- mode is required
+      expect(() => fs.fchmodSync(fd)).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE", message }));
+    } finally {
+      closeSync(fd);
+    }
+  });
+
   it("mkdirSync treats a String wrapper as an options bag, like node", () => {
     // `typeof new String` is "object", so Node treats the wrapper as an options
     // bag and applies the default mode rather than parsing it as "700". Compare
@@ -3102,6 +3117,24 @@ describe("rm", () => {
     expect(existsSync(path)).toBe(true);
     rmSync(join(path, "../../"), { recursive: true });
     expect(existsSync(path)).toBe(false);
+  });
+
+  it("reports a mistyped retry option as a property, like node", () => {
+    using dir = tempDir("fs-rm-options", { "f.txt": "" });
+    const file = join(String(dir), "f.txt");
+    expect(() => rmSync(file, { maxRetries: "a" as any })).toThrow(
+      expect.objectContaining({
+        code: "ERR_INVALID_ARG_TYPE",
+        message: `The "options.maxRetries" property must be of type number. Received type string ('a')`,
+      }),
+    );
+    expect(() => rmSync(file, { retryDelay: {} as any })).toThrow(
+      expect.objectContaining({
+        code: "ERR_INVALID_ARG_TYPE",
+        message: 'The "options.retryDelay" property must be of type number. Received an instance of Object',
+      }),
+    );
+    expect(existsSync(file)).toBe(true);
   });
 
   // On Windows a leading-separator, drive-less path like "/foo/bar" is

--- a/test/js/node/net/socketaddress.spec.ts
+++ b/test/js/node/net/socketaddress.spec.ts
@@ -91,6 +91,19 @@ describe("SocketAddress constructor", () => {
     },
   );
 
+  // Node calls a dotted option name a "property" in ERR_INVALID_ARG_TYPE.
+  it.each([
+    [{ address: 1 }, `The "options.address" property must be of type string. Received type number (1)`],
+    [
+      { family: "ipv6", flowlabel: "x" },
+      `The "options.flowlabel" property must be of type number. Received type string ('x')`,
+    ],
+  ] as [any, string][])("new SocketAddress(%o) throws node's ERR_INVALID_ARG_TYPE message", (options, message) => {
+    expect(() => new SocketAddress(options)).toThrow(
+      expect.objectContaining({ name: "TypeError", code: "ERR_INVALID_ARG_TYPE", message }),
+    );
+  });
+
   // ===========================================================================
   // ============================= LEAK DETECTION ==============================
   // ===========================================================================

--- a/test/js/node/path/parse-format.test.js
+++ b/test/js/node/path/parse-format.test.js
@@ -191,7 +191,14 @@ describe("path.parse", () => {
         assert.strictEqual(path.format(element), expect);
       });
 
-      [null, undefined, 1, true, false, "string"].forEach(pathObject => {
+      [
+        [null, "null"],
+        [undefined, "undefined"],
+        [1, "type number (1)"],
+        [true, "type boolean (true)"],
+        [false, "type boolean (false)"],
+        ["string", "type string ('string')"],
+      ].forEach(([pathObject, received]) => {
         assert.throws(
           () => {
             path.format(pathObject);
@@ -199,19 +206,7 @@ describe("path.parse", () => {
           {
             code: "ERR_INVALID_ARG_TYPE",
             name: "TypeError",
-            // TODO: Make our error messages use util.inspect like Node:
-            // https://github.com/nodejs/node/blob/68885d512640556ba95b18f5ab2e0b9e76013399/lib/internal/errors.js#L1370-L1440
-            // https://github.com/nodejs/node/blob/68885d512640556ba95b18f5ab2e0b9e76013399/test/common/index.js#L815
-            //
-            // Node's error message template is:
-            //  `The "pathObject" argument must be of type object. Received ${inspect(input, { depth: -1 })}`
-            //
-            // For example, when we throw for path.format(null) our error message is:
-            //   The "pathObject" property must be of type object, got object
-            //
-            // While Node's error message is:
-            //   The "pathObject" argument must be of type object. Received null
-            message: `The "pathObject" property must be of type object, got ${typeof pathObject}`,
+            message: `The "pathObject" argument must be of type object. Received ${received}`,
           },
         );
       });

--- a/test/js/node/path/path.test.js
+++ b/test/js/node/path/path.test.js
@@ -40,6 +40,54 @@ describe("path", () => {
     }
   });
 
+  test("error messages match Node", () => {
+    // Node v26.3.0 output for the same calls: join() names every argument
+    // "path", resolve() uses paths[i], basename()'s second argument is "suffix".
+    const received = [
+      [1, "type number (1)"],
+      [2n, "type bigint (2n)"],
+      [true, "type boolean (true)"],
+      [null, "null"],
+      [undefined, "undefined"],
+      [{}, "an instance of Object"],
+      [[], "an instance of Array"],
+    ];
+
+    function expectThrows(fn, name, expected, specific) {
+      assert.throws(fn, {
+        code: "ERR_INVALID_ARG_TYPE",
+        name: "TypeError",
+        message: `The "${name}" argument must be ${expected}. Received ${specific}`,
+      });
+    }
+
+    for (const namespace of [path.posix, path.win32]) {
+      for (const [value, specific] of received) {
+        const string = (fn, name) => expectThrows(fn, name, "of type string", specific);
+        string(() => namespace.join(value), "path");
+        string(() => namespace.join("foo", value), "path");
+        string(() => namespace.resolve(value), "paths[0]");
+        string(() => namespace.resolve("foo", value), "paths[1]");
+        string(() => namespace.normalize(value), "path");
+        string(() => namespace.isAbsolute(value), "path");
+        string(() => namespace.dirname(value), "path");
+        string(() => namespace.basename(value), "path");
+        string(() => namespace.extname(value), "path");
+        string(() => namespace.parse(value), "path");
+        string(() => namespace.relative(value, "foo"), "from");
+        string(() => namespace.relative("foo", value), "to");
+        // Undefined is a valid value as the second argument to basename
+        if (value !== undefined) {
+          string(() => namespace.basename("foo", value), "suffix");
+        }
+        // {} is a valid pathObject
+        if (typeof value !== "object" || value === null || Array.isArray(value)) {
+          expectThrows(() => namespace.format(value), "pathObject", "of type object", specific);
+        }
+      }
+    }
+  });
+
   test("path.sep", () => {
     // path.sep tests
     // windows

--- a/test/js/node/path/resolve.test.js
+++ b/test/js/node/path/resolve.test.js
@@ -170,7 +170,7 @@ describe("path.resolve", () => {
   test("undefined argument are ignored if absolute path comes first (reverse loop through args)", () => {
     expect(() => {
       return path.posix.resolve(undefined, "hi");
-    }).toThrow('The "paths[0]" property must be of type string, got undefined');
+    }).toThrow('The "paths[0]" argument must be of type string. Received undefined');
     expect(() => {
       return path.posix.resolve(undefined, "/hi");
     }).not.toThrow();

--- a/test/js/node/util/parse_args/parse-args.test.mjs
+++ b/test/js/node/util/parse_args/parse-args.test.mjs
@@ -309,6 +309,78 @@ describe("parseArgs", () => {
     );
   });
 
+  describe("ERR_INVALID_ARG_TYPE messages match Node", () => {
+    // Expected messages are Node v26.3.0's. Top-level config keys are
+    // "arguments", dotted option paths are "properties", and a bad array
+    // element reports the element, not the array.
+    test.each([
+      ["args", { args: "x" }, `The "args" argument must be an instance of Array. Received type string ('x')`],
+      [
+        "strict",
+        { args: [], strict: "yes" },
+        `The "strict" argument must be of type boolean. Received type string ('yes')`,
+      ],
+      ["options", { args: [], options: 1 }, `The "options" argument must be of type object. Received type number (1)`],
+      [
+        "options (array)",
+        { args: [], options: [] },
+        `The "options" argument must be of type object. Received an instance of Array`,
+      ],
+      [
+        "options.alpha",
+        { args: [], options: { alpha: 1 } },
+        `The "options.alpha" property must be of type object. Received type number (1)`,
+      ],
+      [
+        "options.alpha.type (missing)",
+        { args: [], options: { alpha: {} } },
+        `The "options.alpha.type" property must be ('string|boolean'). Received undefined`,
+      ],
+      [
+        "options.alpha.type (unknown)",
+        { args: [], options: { alpha: { type: "nope" } } },
+        `The "options.alpha.type" property must be ('string|boolean'). Received type string ('nope')`,
+      ],
+      [
+        "options.alpha.short",
+        { args: [], options: { alpha: { type: "string", short: 1 } } },
+        `The "options.alpha.short" property must be of type string. Received type number (1)`,
+      ],
+      [
+        "options.alpha.multiple",
+        { args: [], options: { alpha: { type: "string", multiple: "yes" } } },
+        `The "options.alpha.multiple" property must be of type boolean. Received type string ('yes')`,
+      ],
+      [
+        "options.alpha.default (boolean)",
+        { args: [], options: { alpha: { type: "boolean", default: "x" } } },
+        `The "options.alpha.default" property must be of type boolean. Received type string ('x')`,
+      ],
+      [
+        "options.alpha.default (string)",
+        { args: [], options: { alpha: { type: "string", default: null } } },
+        `The "options.alpha.default" property must be of type string. Received null`,
+      ],
+      [
+        "options.alpha.default (array expected)",
+        { args: [], options: { alpha: { type: "string", multiple: true, default: "x" } } },
+        `The "options.alpha.default" property must be an instance of Array. Received type string ('x')`,
+      ],
+      [
+        "options.alpha.default[1] (string element)",
+        { args: [], options: { alpha: { type: "string", multiple: true, default: ["a", 1] } } },
+        `The "options.alpha.default[1]" property must be of type string. Received type number (1)`,
+      ],
+      [
+        "options.alpha.default[1] (boolean element)",
+        { args: [], options: { alpha: { type: "boolean", multiple: true, default: [true, "no"] } } },
+        `The "options.alpha.default[1]" property must be of type boolean. Received type string ('no')`,
+      ],
+    ])("%s", (_, config, message) => {
+      expectToThrowErrorMatching(() => parseArgs(config), { name: "TypeError", code: "ERR_INVALID_ARG_TYPE", message });
+    });
+  });
+
   // Test strict mode
 
   test("unknown long option --bar", () => {


### PR DESCRIPTION
### Problem

- Every argument type error thrown by the Rust port of Node's validators has a Bun-specific message. `path.join(1)` throws `The "paths[0]" property must be of type string, got number`; Node v26.3.0 throws `The "path" argument must be of type string. Received type number (1)`. The `code` (`ERR_INVALID_ARG_TYPE`) is right, only the message differs.
- Cause: `throw_err_invalid_arg_type` in `src/runtime/node/util/validators.rs` formats the message by hand (`"property"`, `, got <typeof>`) instead of using the shared renderer. It is behind `validate_string`, `validate_int32`, `validate_uint32`, `validate_boolean`, `validate_object`, the string/boolean array validators, and the `mode` errors of `fs.chmod`/`fs.fchmod`, so `node:path`, `util.parseArgs`, `net.BlockList`, `crypto.scrypt` and others all produce the Bun wording. `validate_array` (`must be an instance of Array, got ...`) and `validate_string_enum` (`options.x.type must be one of: boolean|string`) hand-format their messages the same way.
- Three smaller mismatches in the same area: the string/boolean array validators pass the array instead of the offending element to the error, `path.join()` names its argument `paths[i]` (Node's `join()` uses `path`; only `resolve()` uses `paths[i]`), and `path.basename()` names its second argument `ext` (Node: `suffix`).
- The shared Rust renderer itself (`JSGlobalObject::throw_invalid_argument_type_value`) always says `argument`. Node says `property` when the name is dotted, so `fs.rmSync(p, { maxRetries: "a" })` and `new SocketAddress({ address: 1 })` said `The "options.maxRetries" argument ...` where Node says `property`.

### Fix

- `validators.rs`: `throw_err_invalid_arg_type` delegates to `throw_invalid_argument_type_value`; `validate_array` and `validate_string_enum` go through `throw_invalid_argument_type_value2` with Node's phrases (`an instance of Array`, `('string|boolean')`); the array validators report the element; `get_type_name` (the only remaining user of the old wording) is deleted. `OptionValueType::VALUES_INFO` is reordered to `string|boolean`, the order Node passes to `validateUnion`.
- `JSGlobalObject.rs`: the three `throw_invalid_argument_type_value*` renderers format the name through a small `Display` type that applies Node's rule (`"x" argument`, `"a.b" property`, a name ending in ` argument` verbatim). This is the same rule `Bun::Message::addParameter` already applies for C++ callers, so Rust and C++ errors now agree.
- `path.rs`: `join()` validates each argument as `path`; `basename()` validates the suffix as `suffix`.
- Why this is right: every message in this PR is byte-identical to Node v26.3.0 (the version `process.versions.node` reports). A 196-call matrix over `path.{posix,win32}` x 14 functions x 7 bad values, plus the `parseArgs`, `fs`, `scrypt`, `BlockList` and `SocketAddress` cases below, diffs clean against a real `node` binary; 192 of the 196 path lines differed before.
- Intentionally left alone: `JSGlobalObject::throw_invalid_property_type` (the `JSValue` option getters behind `fs.mkdir`'s `recursive` and Bun's own option bags) still uses the old wording; that is a different helper with mostly Bun-API callers and needs dotted-name plumbing (`options.recursive`) to match Node. `parseArgs`'s `ERR_INVALID_ARG_VALUE` messages and `fs.rm`'s hand-written `recursive`/`force` messages are different templates and are not touched. Section 1 of the draft #35423 (and the renderer change in #35429) covers the message shape part of this; this PR is the focused version and also fixes the array element, `join`, `basename` and `validateUnion` mismatches, which those drafts do not.
- Tests (all fail on the current release, pass with this change):
  - `test/js/node/path/path.test.js`: exact messages for every `path` function on both namespaces (`path`, `paths[i]`, `from`/`to`, `suffix`, `pathObject`).
  - `test/js/node/path/parse-format.test.js`, `resolve.test.js`: existing assertions on the old wording updated (the former carried a TODO describing this divergence).
  - `test/js/node/util/parse_args/parse-args.test.mjs`: `validate_array`, `validate_boolean`, `validate_object`, `validate_string`, `validate_string_enum`, the array element validators, and argument vs property naming.
  - `test/js/node/fs/fs.test.ts`: `chmodSync`/`fchmodSync` without a mode (direct `throw_err_invalid_arg_type` callers); `rmSync` retry options (dotted name through the shared renderer).
  - `test/js/node/crypto/scrypt.test.ts`: `validate_int32` (`keylen`) and `validate_uint32` (`N`, `cost`).
  - `test/js/node/net/socketaddress.spec.ts`: dotted name from a direct caller of the shared renderer.
  - The 35 vendored Node tests for path, parseArgs, BlockList, SocketAddress, scrypt, chmod, rm and zlib constructors still pass; `grep` for the old `must be of type ..., got` wording finds no remaining assertions that this change affects (the leftovers are the `throw_invalid_property_type` callers above).

### Background

- `ERR_INVALID_ARG_TYPE(name, expected, actual)` in Node's `lib/internal/errors.js` renders `The <subject> must be <expected>. Received <determineSpecificType(actual)>`. The subject is `"name" argument`, or `"name" property` when the name contains a `.` (it is then an option path like `options.foo`). `expected` renders as `of type string` for a primitive type name, `an instance of Array` for a class name, and verbatim for anything else (`validateUnion` passes `('string|boolean')`).
- `determineSpecificType` is Node's description of the received value: `type number (1)`, `type string ('x')`, `an instance of Object`, `null`, `undefined`. Bun implements it once in C++ (`ErrorCode.cpp`) and exposes it to Rust as `JSGlobalObject::determine_specific_type`, which the shared renderers already used.
- `src/runtime/node/util/validators.rs` is the Rust port of Node's `lib/internal/validators.js`, used by the natively implemented parts of `node:path`, `util.parseArgs`, `net.BlockList`, `crypto.scrypt`, `dgram` and `zlib`.

<details>
<summary>Before / after for a few of the calls (right column is also Node v26.3.0's output)</summary>

| call | before | after |
| --- | --- | --- |
| `path.join(1)` | `The "paths[0]" property must be of type string, got number` | `The "path" argument must be of type string. Received type number (1)` |
| `path.join("a", 2n)` | `The "paths[1]" property must be of type string, got bigint` | `The "path" argument must be of type string. Received type bigint (2n)` |
| `path.resolve("a", null)` | `The "paths[1]" property must be of type string, got object` | `The "paths[1]" argument must be of type string. Received null` |
| `path.basename("a", 1)` | `The "ext" property must be of type string, got number` | `The "suffix" argument must be of type string. Received type number (1)` |
| `path.format([])` | `The "pathObject" property must be of type object, got array` | `The "pathObject" argument must be of type object. Received an instance of Array` |
| `parseArgs({ args: "x" })` | `The "args" property must be an instance of Array, got string` | `The "args" argument must be an instance of Array. Received type string ('x')` |
| `parseArgs(... default: ["a", 1])` | `The "options.alpha.default[1]" property must be of type string, got array` | `The "options.alpha.default[1]" property must be of type string. Received type number (1)` |
| `parseArgs(... type: "nope")` | `options.alpha.type must be one of: boolean\|string` | `The "options.alpha.type" property must be ('string\|boolean'). Received type string ('nope')` |
| `fs.chmodSync(p)` | `The "mode" property must be of type number, got undefined` | `The "mode" argument must be of type number. Received undefined` |
| `fs.rmSync(p, { maxRetries: "a" })` | `The "options.maxRetries" argument must be of type number. Received type string ('a')` | `The "options.maxRetries" property must be of type number. Received type string ('a')` |
| `new BlockList().addSubnet("1.1.1.1", "x")` | `The "prefix" property must be of type number, got string` | `The "prefix" argument must be of type number. Received type string ('x')` |
| `scryptSync("p", "s", "x")` | `The "keylen" property must be of type number, got string` | `The "keylen" argument must be of type number. Received type string ('x')` |

</details>
