### PR TITLE
node:buffer: make Buffer.prototype.parent/offset enumerable and non-configurable like Node

### DIFF
--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -3148,8 +3148,10 @@ static const HashTableValue JSBufferPrototypeTableValues[]
           { "lastIndexOf"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsBufferPrototypeFunction_lastIndexOf, 3 } },
           { "latin1Slice"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsBufferPrototypeFunction_latin1Slice, 2 } },
           { "latin1Write"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsBufferPrototypeFunction_latin1Write, 3 } },
-          { "offset"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::Accessor | JSC::PropertyAttribute::Builtin), NoIntrinsic, { HashTableValue::BuiltinAccessorType, jsBufferPrototypeOffsetCodeGenerator, 0 } },
-          { "parent"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::Accessor | JSC::PropertyAttribute::Builtin), NoIntrinsic, { HashTableValue::BuiltinAccessorType, jsBufferPrototypeParentCodeGenerator, 0 } },
+          // Enumerable and non-configurable, as Node defines them:
+          // https://github.com/nodejs/node/blob/v26.3.0/lib/buffer.js#L876-L892
+          { "offset"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontDelete | JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::Accessor | JSC::PropertyAttribute::Builtin), NoIntrinsic, { HashTableValue::BuiltinAccessorType, jsBufferPrototypeOffsetCodeGenerator, 0 } },
+          { "parent"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontDelete | JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::Accessor | JSC::PropertyAttribute::Builtin), NoIntrinsic, { HashTableValue::BuiltinAccessorType, jsBufferPrototypeParentCodeGenerator, 0 } },
           { "readBigInt64"_s, static_cast<unsigned>(JSC::PropertyAttribute::Builtin), NoIntrinsic, { HashTableValue::BuiltinGeneratorType, jsBufferPrototypeReadBigInt64LECodeGenerator, 1 } },
           { "readBigInt64BE"_s, static_cast<unsigned>(JSC::PropertyAttribute::Builtin), NoIntrinsic, { HashTableValue::BuiltinGeneratorType, jsBufferPrototypeReadBigInt64BECodeGenerator, 1 } },
           { "readBigInt64LE"_s, static_cast<unsigned>(JSC::PropertyAttribute::Builtin), NoIntrinsic, { HashTableValue::BuiltinGeneratorType, jsBufferPrototypeReadBigInt64LECodeGenerator, 1 } },

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -4746,3 +4746,45 @@ it.skipIf(os.totalmem() < 10 * 1024 ** 3)(
     expect(exitCode).toBe(0);
   },
 );
+
+describe("Buffer.prototype.parent and Buffer.prototype.offset", () => {
+  // Node defines both legacy getters with ObjectDefineProperty(Buffer.prototype, name, { enumerable: true, get() {...} }),
+  // so they are enumerable and, like every defineProperty default, non-configurable.
+  it.each(["parent", "offset"])("%s is an enumerable, non-configurable getter", name => {
+    const desc = Object.getOwnPropertyDescriptor(Buffer.prototype, name);
+    expect({ ...desc, get: typeof desc.get }).toEqual({
+      get: "function",
+      set: undefined,
+      enumerable: true,
+      configurable: false,
+    });
+
+    expect(Reflect.deleteProperty(Buffer.prototype, name)).toBe(false);
+    // This file is an ES module, so this `delete` runs in strict mode and must throw rather than remove the property.
+    expect(() => delete Buffer.prototype[name]).toThrow(TypeError);
+    expect(Object.getOwnPropertyDescriptor(Buffer.prototype, name)).toEqual(desc);
+  });
+
+  it("are listed by for...in and Object.keys(Buffer.prototype)", () => {
+    const forInKeys = [];
+    for (const key in Buffer.alloc(2)) forInKeys.push(key);
+    expect(forInKeys.filter(key => key === "parent" || key === "offset").sort()).toEqual(["offset", "parent"]);
+    expect(Object.keys(Buffer.prototype)).toEqual(expect.arrayContaining(["parent", "offset"]));
+  });
+
+  it("still resolve to buffer/byteOffset on a Buffer and to undefined on a plain Uint8Array", () => {
+    const buf = Buffer.from(new ArrayBuffer(8), 2, 4);
+    expect(buf.parent).toBe(buf.buffer);
+    expect(buf.offset).toBe(2);
+
+    const { get: getParent } = Object.getOwnPropertyDescriptor(Buffer.prototype, "parent");
+    const { get: getOffset } = Object.getOwnPropertyDescriptor(Buffer.prototype, "offset");
+    const u8 = new Uint8Array(new ArrayBuffer(8), 2, 4);
+    expect([
+      getParent.call(u8),
+      getOffset.call(u8),
+      getParent.call(Buffer.prototype),
+      getOffset.call(Buffer.prototype),
+    ]).toEqual([undefined, undefined, undefined, undefined]);
+  });
+});


### PR DESCRIPTION
### Problem
- `Object.getOwnPropertyDescriptor(Buffer.prototype, "parent")` (and `"offset"`) reports `enumerable: false, configurable: true` in Bun; Node reports `enumerable: true, configurable: false`.
- Observable differences: `for...in` over a Buffer (and `Object.keys(Buffer.prototype)`) skips `parent`/`offset` in Bun and lists them in Node; `delete Buffer.prototype.parent` removes the getter in Bun and fails (throws in strict code) in Node.
- Cause: the two entries in the `JSBufferPrototypeTableValues` static table in `src/jsc/bindings/JSBuffer.cpp` (line 3151) carry `PropertyAttribute::DontEnum` and no `DontDelete`. `JSBufferPrototype::finishCreation` reifies the table as-is, so those become the JS-visible attributes.
- The getters themselves already match Node (return `buffer`/`byteOffset` for a Buffer, `undefined` for any other receiver); only the attributes differ.

### Fix
- Replace `DontEnum` with `DontDelete` on the `offset` and `parent` table entries. That is the whole change; the rest of the diff is the test.
- Why this is right: Node defines both with `ObjectDefineProperty(Buffer.prototype, name, { enumerable: true, get() {...} })` (https://github.com/nodejs/node/blob/v26.3.0/lib/buffer.js#L876-L892); `defineProperty` defaults `configurable` to `false`, so the Node contract is exactly "enumerable, non-configurable accessor", which is what the new attribute set reifies to. Property attributes are part of the compat surface (a `for (k in buf)` loop visits these keys in Node, and code cannot delete or redefine them).
- Everything else Bun builds on top of Buffers is unaffected, checked against this build: `Bun.inspect`/`util.inspect` of a Buffer, `JSON.stringify`, `{...buf}`/`Object.assign`, `Object.entries`, `Bun.deepEquals`, `assert.deepStrictEqual`, `structuredClone`, and the `for (op in Buffer.prototype)` mocking pattern already covered in `buffer.test.js` all produce the same output as before (and as Node); they only look at own properties.
- Verified:
  - `test/js/node/buffer.test.js`, new `describe("Buffer.prototype.parent and Buffer.prototype.offset")`: 3 of the 4 tests fail on the released binary (descriptor mismatch for both names, empty `for...in` result) and all pass with this change; the whole file passes (622 pass, 1 pre-existing skip).
  - The same assertions run as a plain script under Node v26.3.0 produce the values the test expects.
  - Vendored `test-buffer-{parent-property,inheritance,fakes,inspect,prototype-inspect,alloc,arraybuffer,new,slow,tojson}.js` still pass.
- Out of scope, noted for completeness: Bun's prototype also carries some Bun-only enumerable aliases (`readDouble`, `writeUInt16`, `utf16leSlice`, ...) that Node does not have, and the enumeration order of the prototype is alphabetical rather than Node's definition order. Neither is touched here.

### Background
- `Buffer.prototype.parent` / `.offset` are legacy (pre-`Uint8Array`) names for `buf.buffer` and `buf.byteOffset`; Node keeps them as getters on the prototype for backwards compatibility.
- `JSBufferPrototypeTableValues` is a JSC static property table (`HashTableValue[]`). Each entry's `PropertyAttribute` bits are the property's attributes: `DontEnum` is `enumerable: false`, `DontDelete` is `configurable: false`, `ReadOnly` is `writable: false` (ignored by JSC for accessors), `Accessor | Builtin` means the entry is a getter implemented by a JS builtin (`src/js/builtins/JSBufferPrototype.ts`). Bits at 8 and above (`Builtin`, `Function`) only tell the table how to materialize the value and are masked off before they reach the object.
- `reifyStaticProperties` (called from `JSBufferPrototype::finishCreation`) walks that table once and defines every entry directly on the prototype object, so the table bits are exactly what `getOwnPropertyDescriptor`, `for...in` and `delete` later observe.

<details>
<summary>Repro (released Bun vs Node)</summary>

```js
const d = n => { const x = Object.getOwnPropertyDescriptor(Buffer.prototype, n); return [x.enumerable, x.configurable]; };
console.log(d("parent"), d("offset"));
const keys = []; for (const k in Buffer.alloc(1)) keys.push(k);
console.log(keys.includes("parent"), keys.includes("offset"));
console.log(Reflect.deleteProperty(Buffer.prototype, "parent"), "parent" in Buffer.prototype);
```

```
node v26.3.0:  [ true, false ] [ true, false ]   / true true   / false true
bun 1.4.0:     [ false, true ] [ false, true ]   / false false / true false
this branch:   [ true, false ] [ true, false ]   / true true   / false true
```
</details>
