### PR TITLE
css modules: report a composes property conflict at the declarations involved

### DIFF
--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -1367,8 +1367,8 @@ impl<'a> ExportStarContext<'a> {
 // ──────────────────────────────────────────────────────────────────────────
 mod __css_validation {
     use super::*;
+    use crate::bun_css::BundlerStyleSheet;
     use crate::bun_css::css_properties::css_modules::Specifier;
-    use crate::bun_css::{BundlerStyleSheet, PropertyIdTag};
     use bun_ast::Log;
     use bun_collections::{ArrayHashMap, StringArrayHashMap};
 
@@ -1446,8 +1446,9 @@ mod __css_validation {
     ///
     /// Specfically, composing two classes that both define the same property is undefined behavior.
     ///
-    /// We check this by recording, at parse time, properties that classes use in the `PropertyUsage` struct.
-    /// Then here, we compare the properties of the two classes to ensure that there are no conflicts.
+    /// We check this by recording, at parse time, the declarations of each class in `local_properties`
+    /// (see `bun_css::DeclaredProperty`). Then here, we compare the properties of the two classes to
+    /// ensure that there are no conflicts, reporting a conflict at the declarations involved.
     ///
     /// There is one case we skip, which is checking the properties of composing from the global scope (`composes: X from global`).
     ///
@@ -1532,7 +1533,7 @@ mod __css_validation {
                                 ),
                                 entry.value_ptr.range,
                                 bun_ast::alloc_print(format_args!(
-                                    "The first definition of {} is in this style rule:",
+                                    "The first definition of {} is here:",
                                     bstr::BStr::new(property_name)
                                 )),
                             ),
@@ -1624,36 +1625,12 @@ mod __css_validation {
                     }
                 }
 
-                let Some(property_usage) = ast.local_properties.get(&r#ref) else {
+                let Some(declarations) = ast.local_properties.get(&r#ref) else {
                     return;
                 };
                 // Warn about cross-file composition with the same CSS properties
-                let mut iter = property_usage.bitset.iter_set();
-                while let Some(property_tag) = iter.next() {
-                    let property_id_tag: PropertyIdTag =
-                        // SAFETY: `PropertyBitset` is only ever populated via
-                        // `bitset.set(tag as u16 as usize)` where `tag: PropertyIdTag`
-                        // (see `bun_css::fill_property_bit_set`), so every set index is a
-                        // valid `#[repr(u16)]` discriminant. `PropertyIdTag` lives in
-                        // `bun_css` (generated) and exposes no `from_repr`; once it does,
-                        // replace this transmute with that accessor.
-                        unsafe {
-                            core::mem::transmute::<u16, PropertyIdTag>(
-                                u16::try_from(property_tag).expect("int cast"),
-                            )
-                        };
-                    debug_assert!(property_id_tag != PropertyIdTag::Custom);
-                    debug_assert!(property_id_tag != PropertyIdTag::Unparsed);
-                    self.add_property_or_warn(
-                        r#ref,
-                        property_id_tag.name(),
-                        idx,
-                        property_usage.range,
-                    );
-                }
-
-                for property in property_usage.custom_properties.iter() {
-                    self.add_property_or_warn(r#ref, property, idx, property_usage.range);
+                for declaration in declarations.iter() {
+                    self.add_property_or_warn(r#ref, declaration.name, idx, declaration.range);
                 }
             }
         }

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -8,7 +8,6 @@ use core::fmt;
 
 use bun_alloc::Arena as Bump;
 use bun_ast::Log;
-use bun_collections::bit_set::{ArrayBitSet, num_masks_for};
 use bun_collections::{ArrayHashMap, StringArrayHashMap, VecExt};
 use bun_core::strings;
 
@@ -1035,6 +1034,9 @@ pub enum ComposesState {
 pub trait ComposesCtx {
     fn composes_state(&self) -> ComposesState;
     fn record_composes(&mut self, composes: &mut Composes);
+    /// Records a declaration other than `composes` of a class whose state is
+    /// `ComposesState::Allow`, for the bundler's composes conflict check.
+    fn record_property(&mut self, property: &Property);
 }
 /// Unit `ComposesCtx` for callers that don't track `composes:`.
 pub struct NoComposesCtx;
@@ -1045,6 +1047,8 @@ impl ComposesCtx for NoComposesCtx {
     }
     #[inline]
     fn record_composes(&mut self, _: &mut Composes) {}
+    #[inline]
+    fn record_property(&mut self, _: &Property) {}
 }
 
 pub struct NestedRuleParser<'a, T: CustomAtRuleParser> {
@@ -1084,9 +1088,12 @@ impl<'a, T: CustomAtRuleParser> NestedRuleParser<'a, T> {
 
 pub trait DeclarationParser {
     type Declaration;
+    /// `start` is the state at the declaration's property name; `input` is
+    /// positioned after the colon.
     fn parse_value(
         this: &mut Self,
         name: &[u8],
+        start: &ParserState,
         input: &mut Parser,
     ) -> CssResult<Self::Declaration>;
 }
@@ -1174,13 +1181,16 @@ mod rule_parsers {
 
     // The borrow checker forbids passing `&mut *this` while also borrowing
     // `this.declarations` / `this.important_declarations`, so split-borrow the
-    // three composes fields into a small adaptor that implements the
-    // `ComposesCtx` dispatch trait.
+    // composes fields into a small adaptor that implements the `ComposesCtx`
+    // dispatch trait.
     struct NestedComposesCtx<'a> {
         state: ComposesState,
+        /// The property name of the declaration being parsed.
+        name_range: bun_ast::Range,
         arena: &'a Bump,
         composes: &'a mut ComposesMap,
         composes_refs: &'a mut SmallList<ast::Ref, 2>,
+        local_properties: &'a mut LocalPropertyUsage,
     }
     impl<'a> ComposesCtx for NestedComposesCtx<'a> {
         #[inline]
@@ -1191,6 +1201,14 @@ mod rule_parsers {
             for ref_ in self.composes_refs.slice() {
                 let entry = self.composes.entry(*ref_).or_default();
                 entry.composes.push(composes.deep_clone(self.arena));
+            }
+        }
+        fn record_property(&mut self, property: &Property) {
+            for ref_ in self.composes_refs.slice() {
+                self.local_properties
+                    .entry(*ref_)
+                    .or_default()
+                    .push(DeclaredProperty::new(property, self.name_range));
             }
         }
     }
@@ -2071,35 +2089,10 @@ mod rule_parsers {
                     });
                 }
             }
-            let location = input.position();
+            // While `composes_state` is `Allow`, the declarations of the block are
+            // recorded in `local_properties` as they are parsed (see
+            // `NestedComposesCtx::record_property`).
             let (declarations, rules) = this.parse_nested(input, true)?;
-
-            // We parsed a style rule with the `composes` property. Track which
-            // properties it used so we can validate it later.
-            if matches!(this.composes_state, ComposesState::Allow(_)) {
-                let len = input.position() - location;
-                let mut usage = PropertyBitset::init_empty();
-                let mut custom_properties: Vec<&'static [u8]> = Vec::new();
-                fill_property_bit_set(&mut usage, &declarations, &mut custom_properties);
-
-                let custom_properties_slice = custom_properties.slice();
-
-                for ref_ in this.composes_refs.slice() {
-                    let entry =
-                        this.local_properties
-                            .entry(*ref_)
-                            .or_insert_with(|| PropertyUsage {
-                                range: bun_ast::Range {
-                                    loc: bun_ast::Loc {
-                                        start: i32::try_from(location).expect("int cast"),
-                                    },
-                                    len: i32::try_from(len).expect("int cast"),
-                                },
-                                ..Default::default()
-                            });
-                    entry.fill(&usage, custom_properties_slice);
-                }
-            }
 
             this.rules.v.push(CssRule::Style(StyleRule {
                 selectors,
@@ -2125,7 +2118,12 @@ mod rule_parsers {
     impl<'a, T: CustomAtRuleParser> DeclarationParser for NestedRuleParser<'a, T> {
         type Declaration = ();
 
-        fn parse_value(this: &mut Self, name: &[u8], input: &mut Parser) -> CssResult<()> {
+        fn parse_value(
+            this: &mut Self,
+            name: &[u8],
+            start: &ParserState,
+            input: &mut Parser,
+        ) -> CssResult<()> {
             // Note: split-borrow — see `NestedComposesCtx` above.
             // SAFETY: `input.arena()` re-borrows the parser arena through `&self`;
             // detach that borrow so `input` can be re-borrowed mutably below. The
@@ -2133,9 +2131,16 @@ mod rule_parsers {
             let arena: &Bump = unsafe { bun_ptr::detach_lifetime_ref(input.arena()) };
             let mut ctx = NestedComposesCtx {
                 state: this.composes_state,
+                name_range: bun_ast::Range {
+                    loc: bun_ast::Loc {
+                        start: i32::try_from(start.position).expect("int cast"),
+                    },
+                    len: i32::try_from(name.len()).expect("int cast"),
+                },
                 arena,
                 composes: &mut *this.composes,
                 composes_refs: &mut *this.composes_refs,
+                local_properties: &mut *this.local_properties,
             };
             declaration::parse_declaration_impl(
                 name,
@@ -2247,7 +2252,10 @@ pub type LocalScope = StringArrayHashMap<LocalEntry>;
 pub type LocalsResultsMap = ast::MangledProps;
 /// Using `compose` and having conflicting properties is undefined behavior
 /// according to the css modules spec. We should warn the user about this.
-pub type LocalPropertyUsage = ArrayHashMap<bun_ast::Ref, PropertyUsage>;
+///
+/// Maps each class that may use `composes` (see `ComposesState::Allow`) to the
+/// declarations of all of its style rules, in source order.
+pub type LocalPropertyUsage = ArrayHashMap<bun_ast::Ref, Vec<DeclaredProperty>>;
 pub type ComposesMap = ArrayHashMap<bun_ast::Ref, ComposesEntry>;
 
 #[derive(Default)]
@@ -2255,75 +2263,28 @@ pub struct ComposesEntry {
     pub composes: Vec<Composes>,
 }
 
-pub struct PropertyUsage {
-    pub bitset: PropertyBitset,
-    pub custom_properties: Box<[&'static [u8]]>, // TODO: lifetime — arena slices
+/// One declaration of a class tracked in `LocalPropertyUsage`.
+pub struct DeclaredProperty {
+    /// The name the bundler compares declarations by: the unprefixed name of a
+    /// known property, or the name as written of a custom or unknown one (an
+    /// arena slice with the lifetime erased, like `Token` payloads; see
+    /// `src_str`).
+    pub name: &'static [u8],
+    /// The property name in the source, where the bundler reports a conflict
+    /// with a composed class.
     pub range: bun_ast::Range,
 }
 
-impl Default for PropertyUsage {
-    fn default() -> Self {
-        Self {
-            bitset: PropertyBitset::init_empty(),
-            custom_properties: Box::default(),
-            range: bun_ast::Range::default(),
-        }
-    }
-}
-
-impl PropertyUsage {
-    #[inline]
-    pub(crate) fn fill(&mut self, used: &PropertyBitset, custom_properties: &[&'static [u8]]) {
-        self.bitset.set_union(used);
-        // TODO: lifetime — box for now.
-        self.custom_properties = custom_properties.to_vec().into_boxed_slice();
-    }
-}
-
-// `PropertyIdTag` is a dense `repr(u16)` enum with no
-// explicit discriminants whose last variant is `Custom`, so the variant count
-// is `Custom + 1`.
-pub const PROPERTY_BITSET_BITS: usize = (PropertyIdTag::Custom as usize + 1).next_power_of_two();
-pub type PropertyBitset =
-    ArrayBitSet<PROPERTY_BITSET_BITS, { num_masks_for(PROPERTY_BITSET_BITS) }>;
-
-pub(crate) fn fill_property_bit_set(
-    bitset: &mut PropertyBitset,
-    block: &DeclarationBlock<'_>,
-    custom_properties: &mut Vec<&'static [u8]>,
-) {
-    for prop in block.declarations.iter() {
-        let tag = match prop {
-            Property::Custom(c) => {
-                // SAFETY: `'bump`-erasure — `CustomPropertyName` stores an
-                // arena-owned `*const [u8]`; detach from `block`'s borrow so
-                // callers can move `block` afterwards. Re-thread once
-                // `PropertyUsage` carries the arena lifetime (TODO at field def).
-                let name: &'static [u8] = unsafe { src_str(c.name.as_str()) };
-                custom_properties.push(name);
-                continue;
-            }
-            Property::Unparsed(u) => u.property_id.tag(),
-            Property::Composes(_) => continue,
-            _ => prop.property_id().tag(),
+impl DeclaredProperty {
+    pub(crate) fn new(property: &Property, range: bun_ast::Range) -> DeclaredProperty {
+        let name: &'static [u8] = match property {
+            // SAFETY: `CustomPropertyName` points into the parser source or
+            // arena, which outlive the style sheet the entry is stored in (see
+            // `src_str`).
+            Property::Custom(c) => unsafe { src_str(c.name.as_str()) },
+            _ => property.property_id().tag().name(),
         };
-        let int: u16 = tag as u16;
-        bitset.set(int as usize);
-    }
-    for prop in block.important_declarations.iter() {
-        let tag = match prop {
-            Property::Custom(c) => {
-                // SAFETY: see above.
-                let name: &'static [u8] = unsafe { src_str(c.name.as_str()) };
-                custom_properties.push(name);
-                continue;
-            }
-            Property::Unparsed(u) => u.property_id.tag(),
-            Property::Composes(_) => continue,
-            _ => prop.property_id().tag(),
-        };
-        let int: u16 = tag as u16;
-        bitset.set(int as usize);
+        DeclaredProperty { name, range }
     }
 }
 
@@ -2869,10 +2830,10 @@ where
                                 self.input,
                                 Delimiters::SEMICOLON,
                                 error_behavior,
-                                (&mut *self.parser, name),
-                                |(parser, name), input| {
+                                (&mut *self.parser, name, &start),
+                                |(parser, name, start), input| {
                                     input.expect_colon()?;
-                                    P::parse_value(parser, name, input)
+                                    P::parse_value(parser, name, start, input)
                                 },
                             )
                         };

--- a/src/css/declaration.rs
+++ b/src/css/declaration.rs
@@ -270,6 +270,7 @@ impl<'a, 'bump> css::DeclarationParser for PropertyDeclarationParser<'a, 'bump> 
     fn parse_value(
         this: &mut Self,
         name: &[u8],
+        _start: &css::ParserState,
         input: &mut css::Parser,
     ) -> Result<Self::Declaration> {
         parse_declaration(
@@ -375,6 +376,8 @@ where
                     );
                 }
             }
+        } else if let css::ComposesState::Allow(_) = composes_ctx.composes_state() {
+            composes_ctx.record_property(&property);
         }
     }
     if important {

--- a/src/css/lib.rs
+++ b/src/css/lib.rs
@@ -204,8 +204,7 @@ pub use targets::{Browsers, Features, Targets};
 
 // Bundler-facing surface (`bun_bundler::Chunk` / `scanImportsAndExports`
 // reach for these via `bun_css::*`).
-pub use css_parser::BundlerStyleSheet;
-pub use properties::PropertyIdTag;
+pub use css_parser::{BundlerStyleSheet, DeclaredProperty};
 pub use rules::import::ImportConditions;
 
 // ───────────────────────────── VendorPrefix ─────────────────────────────

--- a/src/css/rules/font_face.rs
+++ b/src/css/rules/font_face.rs
@@ -734,6 +734,7 @@ const _: () = {
         fn parse_value(
             _this: &mut Self,
             name: &[u8],
+            _start: &ParserState,
             input: &mut Parser,
         ) -> Result<Self::Declaration> {
             let state = input.state();

--- a/src/css/rules/font_palette_values.rs
+++ b/src/css/rules/font_palette_values.rs
@@ -243,6 +243,7 @@ const _: () = {
         fn parse_value(
             _this: &mut Self,
             name: &[u8],
+            _start: &ParserState,
             input: &mut Parser,
         ) -> Result<Self::Declaration> {
             let state = input.state();

--- a/src/css/rules/keyframes.rs
+++ b/src/css/rules/keyframes.rs
@@ -328,6 +328,7 @@ const _: () = {
         fn parse_value(
             _this: &mut Self,
             name: &[u8],
+            _start: &ParserState,
             input: &mut Parser,
         ) -> Result<Self::Declaration> {
             // SAFETY: `name` is a sub-slice of the parser input arena; see `src_str`.

--- a/src/css/rules/page.rs
+++ b/src/css/rules/page.rs
@@ -318,6 +318,7 @@ const _: () = {
         fn parse_value(
             this: &mut Self,
             name: &[u8],
+            _start: &ParserState,
             input: &mut Parser,
         ) -> Result<Self::Declaration> {
             css::declaration::parse_declaration(

--- a/src/css/rules/property.rs
+++ b/src/css/rules/property.rs
@@ -174,6 +174,7 @@ const _: () = {
         fn parse_value(
             this: &mut Self,
             name: &[u8],
+            _start: &ParserState,
             input: &mut Parser,
         ) -> Result<Self::Declaration> {
             crate::match_ignore_ascii_case! { name, {

--- a/test/bundler/css/css-modules.test.ts
+++ b/test/bundler/css/css-modules.test.ts
@@ -1,3 +1,6 @@
+import { describe, expect, test } from "bun:test";
+import { tempDir } from "harness";
+import { basename, join } from "node:path";
 import { itBundled } from "../expectBundled";
 
 describe("css", () => {
@@ -211,5 +214,174 @@ describe("css", () => {
       const betaOwn = beta![1].split(" ").find(name => name.startsWith("betaGamma_"))!;
       expect(css).toContain(`.${betaOwn}`);
     },
+  });
+
+  // Composing a class from another file that declares one of the composing
+  // class's properties is reported at the two declarations of that property
+  // (like esbuild), whichever rule of either class declares it.
+  describe("composes conflict locations", () => {
+    function where(position: BuildMessage["position"]) {
+      const { file, line, column, length, lineText } = position!;
+      return { file: basename(file), line, column, length, lineText };
+    }
+
+    async function composesConflicts(styles: string[], other: string[]) {
+      using dir = tempDir("css-modules-composes-conflict", {
+        "entry.js": `import styles from "./styles.module.css"; console.log(styles);`,
+        "styles.module.css": styles.join("\n"),
+        "other.module.css": other.join("\n"),
+      });
+      const build = await Bun.build({ entrypoints: [join(String(dir), "entry.js")], throw: false });
+      return build.logs.map(log => {
+        const [firstDefinition] = (log as BuildMessage & { notes: BuildMessage[] }).notes;
+        return {
+          message: log.message,
+          at: where(log.position),
+          note: firstDefinition.message,
+          noteAt: where(firstDefinition.position),
+        };
+      });
+    }
+
+    test.concurrent("custom property declared by a later rule of the composing class", async () => {
+      expect(
+        await composesConflicts(
+          [`.button { composes: other from "./other.module.css" }`, `.button { --x: 3 }`],
+          [`.other { --x: 1 }`],
+        ),
+      ).toEqual([
+        {
+          message: "The value of --x in the class button is undefined.",
+          at: { file: "styles.module.css", line: 2, column: 11, length: 3, lineText: ".button { --x: 3 }" },
+          note: "The first definition of --x is here:",
+          noteAt: { file: "other.module.css", line: 1, column: 10, length: 3, lineText: ".other { --x: 1 }" },
+        },
+      ]);
+    });
+
+    test.concurrent("known property declared by a later rule of the composing class", async () => {
+      expect(
+        await composesConflicts(
+          [`.button { composes: other from "./other.module.css" }`, `.button { color: red }`],
+          [`.other { color: blue }`],
+        ),
+      ).toEqual([
+        {
+          message: "The value of color in the class button is undefined.",
+          at: { file: "styles.module.css", line: 2, column: 11, length: 5, lineText: ".button { color: red }" },
+          note: "The first definition of color is here:",
+          noteAt: { file: "other.module.css", line: 1, column: 10, length: 5, lineText: ".other { color: blue }" },
+        },
+      ]);
+    });
+
+    test.concurrent("!important declarations", async () => {
+      expect(
+        await composesConflicts(
+          [`.button { composes: other from "./other.module.css" }`, `.button { color: red !important }`],
+          [`.other { color: blue !important }`],
+        ),
+      ).toEqual([
+        {
+          message: "The value of color in the class button is undefined.",
+          at: {
+            file: "styles.module.css",
+            line: 2,
+            column: 11,
+            length: 5,
+            lineText: ".button { color: red !important }",
+          },
+          note: "The first definition of color is here:",
+          noteAt: {
+            file: "other.module.css",
+            line: 1,
+            column: 10,
+            length: 5,
+            lineText: ".other { color: blue !important }",
+          },
+        },
+      ]);
+    });
+
+    test.concurrent("the declaration's own line inside a multi-line rule", async () => {
+      expect(
+        await composesConflicts(
+          [`.button {`, `  composes: other from "./other.module.css";`, `  margin: 0;`, `  --x: 3;`, `}`],
+          [`.other {`, `  color: red;`, `  --x: 1;`, `}`],
+        ),
+      ).toEqual([
+        {
+          message: "The value of --x in the class button is undefined.",
+          at: { file: "styles.module.css", line: 4, column: 3, length: 3, lineText: "  --x: 3;" },
+          note: "The first definition of --x is here:",
+          noteAt: { file: "other.module.css", line: 3, column: 3, length: 3, lineText: "  --x: 1;" },
+        },
+      ]);
+    });
+
+    test.concurrent("the note points at the rule of the composed class that declares the property", async () => {
+      expect(
+        await composesConflicts(
+          [`.button { --x: 3; composes: other from "./other.module.css" }`],
+          [`.other { color: red }`, `.other { --x: 1 }`],
+        ),
+      ).toEqual([
+        {
+          message: "The value of --x in the class button is undefined.",
+          at: {
+            file: "styles.module.css",
+            line: 1,
+            column: 11,
+            length: 3,
+            lineText: `.button { --x: 3; composes: other from "./other.module.css" }`,
+          },
+          note: "The first definition of --x is here:",
+          noteAt: { file: "other.module.css", line: 2, column: 10, length: 3, lineText: ".other { --x: 1 }" },
+        },
+      ]);
+    });
+
+    test.concurrent("each conflicting property is reported at its own declaration", async () => {
+      expect(
+        await composesConflicts(
+          [`.button { composes: other from "./other.module.css" }`, `.button { --x: 3 }`, `.button { color: red }`],
+          [`.other { --x: 1; color: blue }`],
+        ),
+      ).toEqual([
+        {
+          message: "The value of --x in the class button is undefined.",
+          at: { file: "styles.module.css", line: 2, column: 11, length: 3, lineText: ".button { --x: 3 }" },
+          note: "The first definition of --x is here:",
+          noteAt: {
+            file: "other.module.css",
+            line: 1,
+            column: 10,
+            length: 3,
+            lineText: ".other { --x: 1; color: blue }",
+          },
+        },
+        {
+          message: "The value of color in the class button is undefined.",
+          at: { file: "styles.module.css", line: 3, column: 11, length: 5, lineText: ".button { color: red }" },
+          note: "The first definition of color is here:",
+          noteAt: {
+            file: "other.module.css",
+            line: 1,
+            column: 18,
+            length: 5,
+            lineText: ".other { --x: 1; color: blue }",
+          },
+        },
+      ]);
+    });
+
+    test.concurrent("classes without a shared property", async () => {
+      expect(
+        await composesConflicts(
+          [`.button { composes: other from "./other.module.css" }`, `.button { --x: 3 }`],
+          [`.other { --y: 1 }`, `.other { color: red }`],
+        ),
+      ).toEqual([]);
+    });
   });
 });


### PR DESCRIPTION
### Problem

- `The value of --x in the class button is undefined.` (the CSS modules composes conflict) is reported at the first style rule of the class, not at the rule that declares `--x`. With `styles.module.css` being `.button { composes: other from "./other.module.css" }` on line 1 and `.button { --x: 3 }` on line 2, the error points at line 1. The note `The first definition of --x is in this style rule:` has the same problem for the composed class, and both point at the start of a block rather than at a declaration, so in a multi-line rule they point at the `{` line.
- Cause: `PropertyUsage` (src/css/css_parser.rs) holds one `range` per class. `parse_block` creates it with the range of the first rule of the class (`or_insert_with`) and later rules only `fill` the property set, so the range is never updated. `validate_composes_from_properties` (src/bundler/linker_context/scanImportsAndExports.rs) uses that one range for both the error and the note.
- Same structure, second symptom: `PropertyUsage::fill` replaced `custom_properties` instead of appending, so a class written as several rules only kept the custom properties of the rule parsed last and conflicts on the other rules' custom properties were not reported at all (#38523 fixes this symptom on its own; this PR covers it as well).
- Reproduces on 1.4.0 and main. Reported by another session while working on #38523.

### Fix

- `local_properties` now maps a class to a list of `DeclaredProperty { name, range }`, one per declaration of every style rule of the class, where `range` is the property name in the source. The linker reports each conflict at the declaration in the composing file and the note (`The first definition of --x is here:`) at the declaration in the composed file. This is what esbuild reports (it keeps a property name to declaration location map per class and reports both locations from it).
- To get the declaration's range, `DeclarationParser::parse_value` receives the parser state at the start of the declaration (`RuleBodyParser` already has it; this mirrors the `declaration_start` parameter of the same method in cssparser, and the `start: &ParserState` the `parse_block` methods of this file already take). The other implementors ignore it.
- The declarations are recorded as they are parsed, through the existing `ComposesCtx` adaptor in `parse_declaration_impl`, which already records `composes` declarations against the same class refs. A declaration is recorded exactly when a `composes` in the same block would be, so the set of tracked declarations is the same as before except that every rule of a class now contributes. The per-class property bitset, `fill_property_bit_set` and the `transmute` back to `PropertyIdTag` in the linker go away; properties are compared by the same names as before (`PropertyIdTag::name()` for known properties, the name as written for custom and unknown ones).
- Because `add_property_or_warn` keeps the first entry per file, the locations reported are the first declaration of the property in each of the two files.
- Not changed: whether the diagnostic is an error or a warning (#38537), and declarations written after a nested rule in the same block, which are still not tracked because the nested rule clears the class refs (#38520 restructures that; rebased on this PR it makes those declarations tracked too).
- Verified with test/bundler/css/css-modules.test.ts (`composes conflict locations`): custom and known properties declared by a later rule of the composing class, `!important` declarations, the declaration's own line in a multi-line rule, the note pointing at the declaring rule of the composed class, two conflicts reported at two different rules, and no report without a shared property. The tests assert line, column, length and line text of the error and of the note and do not depend on the diagnostic's level. They fail on the current binary (`USE_SYSTEM_BUN=1`) and pass with `bun bd test`.
- Also run: test/bundler/esbuild/css.test.ts, test/js/bun/css/css.test.ts, css-loader, doesnt_crash and the other test/bundler/css files (they cover the `@font-face`, `@page`, `@property`, `@font-palette-values` and keyframes declaration parsers that got the new parameter), `cargo clippy -p bun_css -p bun_bundler`, `cargo fmt --check`.

### Background

- CSS modules `composes`: `.button { composes: other from "./other.module.css" }` makes the generated `button` class name also include `other`'s class name. The spec leaves the result undefined when the two classes set the same property from different files, which is what this diagnostic reports.
- `local_properties`: a per-stylesheet map filled by the CSS parser for every top-level rule whose selector is a single class (`ComposesState::Allow`), whether or not the rule uses `composes`; the linker's `validate_composes_from_properties` walks the classes reachable through `composes` and compares these maps across files.
- `ComposesCtx` / `NestedComposesCtx`: the small adaptor `parse_declaration_impl` calls back into while parsing one declaration; it carries the class refs of the enclosing rule so that what the declaration means for CSS modules can be recorded without borrowing the whole rule parser.
- `bun_ast::Range`: a byte offset plus a length into the source; `Log` turns it into the file, line, column and line text shown in the CLI and in `BuildMessage.position`.

<details>
<summary>Before and after, on the repro above</summary>

Before (1.4.0):

```
1 | .button { composes: other from "./other.module.css" }
             ^
error: The value of --x in the class button is undefined.
    at styles.module.css:1:10

1 | .other { --x: 1 }
            ^
note: The first definition of --x is in this style rule:
   at other.module.css:1:9
```

After:

```
2 | .button { --x: 3 }
              ^
error: The value of --x in the class button is undefined.
    at styles.module.css:2:11

1 | .other { --x: 1 }
             ^
note: The first definition of --x is here:
   at other.module.css:1:10
```

</details>
