### PR TITLE
node:fs: use node's ERR_INVALID_ARG_TYPE message for invalid utimes/lutimes/futimes times

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -163,7 +163,7 @@ pub use super::types::PathOrFileDescriptor;
 /// Local alias for the many `node::foo` call sites below, routing to `super::*`.
 mod node {
     pub(super) use super::super::statfs::StatFS;
-    pub(super) use super::super::time_like::from_js as time_like_from_js;
+    pub(super) use super::super::time_like::from_js_required as time_like_from_js_required;
     pub(super) use super::super::types::SliceWithUnderlyingString;
     pub(super) use super::super::{gid_t, uid_t};
 
@@ -2879,28 +2879,12 @@ pub mod args {
     impl Lutimes {
         pub fn from_js(ctx: &JSGlobalObject, arguments: &mut ArgumentsSlice) -> JsResult<Lutimes> {
             // `Drop for PathLike` covers the
-            // `time_like_from_js` throws below.
+            // `time_like_from_js_required` throws below.
             let path = PathLike::from_js_required(ctx, arguments, "path")?;
-            let atime = node::time_like_from_js(
-                ctx,
-                arguments.next().ok_or_else(|| {
-                    ctx.throw_invalid_arguments(format_args!("atime is required"))
-                })?,
-            )?
-            .ok_or_else(|| {
-                ctx.throw_invalid_arguments(format_args!("atime must be a number or a Date"))
-            })?;
-            arguments.eat();
-            let mtime = node::time_like_from_js(
-                ctx,
-                arguments.next().ok_or_else(|| {
-                    ctx.throw_invalid_arguments(format_args!("mtime is required"))
-                })?,
-            )?
-            .ok_or_else(|| {
-                ctx.throw_invalid_arguments(format_args!("mtime must be a number or a Date"))
-            })?;
-            arguments.eat();
+            // Node's utimes/lutimes report both timestamps as "time"; only
+            // futimes names them "atime"/"mtime".
+            let atime = node::time_like_from_js_required(ctx, arguments, "time")?;
+            let mtime = node::time_like_from_js_required(ctx, arguments, "time")?;
             Ok(Lutimes { path, atime, mtime })
         }
     }
@@ -3577,26 +3561,8 @@ pub mod args {
         pub(crate) fn to_thread_safe(&self) {}
         pub fn from_js(ctx: &JSGlobalObject, arguments: &mut ArgumentsSlice) -> JsResult<Futimes> {
             let fd = FD::from_js_required(ctx, arguments)?;
-            let atime = node::time_like_from_js(
-                ctx,
-                arguments.next().ok_or_else(|| {
-                    ctx.throw_invalid_arguments(format_args!("atime is required"))
-                })?,
-            )?
-            .ok_or_else(|| {
-                ctx.throw_invalid_arguments(format_args!("atime must be a number or a Date"))
-            })?;
-            arguments.eat();
-            let mtime = node::time_like_from_js(
-                ctx,
-                arguments.next().ok_or_else(|| {
-                    ctx.throw_invalid_arguments(format_args!("mtime is required"))
-                })?,
-            )?
-            .ok_or_else(|| {
-                ctx.throw_invalid_arguments(format_args!("mtime must be a number or a Date"))
-            })?;
-            arguments.eat();
+            let atime = node::time_like_from_js_required(ctx, arguments, "atime")?;
+            let mtime = node::time_like_from_js_required(ctx, arguments, "mtime")?;
             Ok(Futimes { fd, atime, mtime })
         }
     }

--- a/src/runtime/node/time_like.rs
+++ b/src/runtime/node/time_like.rs
@@ -1,4 +1,4 @@
-use bun_jsc::{JSGlobalObject, JSType as JsType, JSValue, JsResult};
+use bun_jsc::{ArgumentsSlice, JSGlobalObject, JSType as JsType, JSValue, JsResult};
 
 /// On windows, this is what libuv expects
 /// On unix it is what the utimens api expects
@@ -47,6 +47,25 @@ pub fn from_js(global_object: &JSGlobalObject, value: JSValue) -> JsResult<Optio
         }
     }
     Ok(None)
+}
+
+/// Eats the next argument (a missing one is `undefined`, as in Node) and
+/// throws Node's `toUnixTimestamp` error when [`from_js`] rejects it.
+pub fn from_js_required(
+    global_object: &JSGlobalObject,
+    arguments: &mut ArgumentsSlice,
+    name: &str,
+) -> JsResult<TimeLike> {
+    let value = arguments.next_eat().unwrap_or(JSValue::UNDEFINED);
+    from_js(global_object, value)?.ok_or_else(|| {
+        // Node passes `["Date", "Time in seconds"]` as the expected types and its
+        // ERR_INVALID_ARG_TYPE list renderer prints that as "an Time in seconds".
+        global_object.throw_invalid_argument_type_value2(
+            name,
+            "an instance of Date or an Time in seconds",
+            value,
+        )
+    })
 }
 
 #[cfg(windows)]

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it, spyOn } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it, spyOn } from "bun:test";
 import {
   bunEnv,
   bunExe,
@@ -4757,6 +4757,127 @@ describe("utimesSync", () => {
 
     expect(newStats.mtime.getTime() / 1000).toEqual(mtime);
     expect(newStats.atime.getTime() / 1000).toEqual(atime);
+  });
+});
+
+describe("utimes/lutimes/futimes reject an invalid time with node's message", () => {
+  // Node's toUnixTimestamp() passes ["Date", "Time in seconds"] as the expected
+  // types, so its message really does say "an Time in seconds". utimes and
+  // lutimes validate both timestamps under toUnixTimestamp's default name
+  // "time"; only futimes (and so FileHandle.utimes) says "atime"/"mtime".
+  const invalidTime = (name: "time" | "atime" | "mtime", received: string) => ({
+    name: "TypeError",
+    code: "ERR_INVALID_ARG_TYPE",
+    message: `The "${name}" argument must be an instance of Date or an Time in seconds. Received ${received}`,
+  });
+  const pick = ({ name, code, message }: any) => ({ name, code, message });
+  const thrownBy = (fn: () => unknown) => {
+    try {
+      fn();
+    } catch (e) {
+      return pick(e);
+    }
+    throw new Error("expected to throw");
+  };
+  const rejectedBy = async (fn: () => Promise<unknown>) => {
+    try {
+      await fn();
+    } catch (e) {
+      return pick(e);
+    }
+    throw new Error("expected to reject");
+  };
+  const mustNotCall = () => {
+    throw new Error("callback must not be called");
+  };
+
+  const file = join(tempDirWithFiles("fs-utimes-invalid-time", { "f.txt": "x" }), "f.txt");
+  let fd: number;
+  beforeAll(() => {
+    fd = openSync(file, "r");
+  });
+  afterAll(() => closeSync(fd));
+
+  it.each([
+    ["bad", "type string ('bad')"],
+    [{}, "an instance of Object"],
+    [[1], "an instance of Array"],
+    [null, "null"],
+    [undefined, "undefined"],
+    [NaN, "type number (NaN)"],
+    [Infinity, "type number (Infinity)"],
+    [-Infinity, "type number (-Infinity)"],
+    [true, "type boolean (true)"],
+    [1n, "type bigint (1n)"],
+  ] as [time: any, received: string][])("sync forms, time = %p", (time, received) => {
+    expect({
+      utimesAtime: thrownBy(() => fs.utimesSync(file, time, 1)),
+      utimesMtime: thrownBy(() => fs.utimesSync(file, 1, time)),
+      lutimesAtime: thrownBy(() => fs.lutimesSync(file, time, 1)),
+      lutimesMtime: thrownBy(() => fs.lutimesSync(file, 1, time)),
+      futimesAtime: thrownBy(() => fs.futimesSync(fd, time, 1)),
+      futimesMtime: thrownBy(() => fs.futimesSync(fd, 1, time)),
+    }).toEqual({
+      utimesAtime: invalidTime("time", received),
+      utimesMtime: invalidTime("time", received),
+      lutimesAtime: invalidTime("time", received),
+      lutimesMtime: invalidTime("time", received),
+      futimesAtime: invalidTime("atime", received),
+      futimesMtime: invalidTime("mtime", received),
+    });
+  });
+
+  it("callback forms throw synchronously, as in node", () => {
+    expect({
+      utimes: thrownBy(() => fs.utimes(file, "bad", 1, mustNotCall)),
+      lutimes: thrownBy(() => fs.lutimes(file, 1, {} as any, mustNotCall)),
+      futimesAtime: thrownBy(() => fs.futimes(fd, "bad", 1, mustNotCall)),
+      futimesMtime: thrownBy(() => fs.futimes(fd, 1, {} as any, mustNotCall)),
+    }).toEqual({
+      utimes: invalidTime("time", "type string ('bad')"),
+      lutimes: invalidTime("time", "an instance of Object"),
+      futimesAtime: invalidTime("atime", "type string ('bad')"),
+      futimesMtime: invalidTime("mtime", "an instance of Object"),
+    });
+  });
+
+  it("fs/promises forms and FileHandle.utimes reject", async () => {
+    await using handle = await promises.open(file, "r");
+    expect({
+      utimesAtime: await rejectedBy(() => promises.utimes(file, "bad", 1)),
+      utimesMtime: await rejectedBy(() => promises.utimes(file, 1, {} as any)),
+      lutimesAtime: await rejectedBy(() => promises.lutimes(file, "bad", 1)),
+      lutimesMtime: await rejectedBy(() => promises.lutimes(file, 1, {} as any)),
+      handleAtime: await rejectedBy(() => handle.utimes("bad", 1)),
+      handleMtime: await rejectedBy(() => handle.utimes(1, {} as any)),
+    }).toEqual({
+      utimesAtime: invalidTime("time", "type string ('bad')"),
+      utimesMtime: invalidTime("time", "an instance of Object"),
+      lutimesAtime: invalidTime("time", "type string ('bad')"),
+      lutimesMtime: invalidTime("time", "an instance of Object"),
+      handleAtime: invalidTime("atime", "type string ('bad')"),
+      handleMtime: invalidTime("mtime", "an instance of Object"),
+    });
+  });
+
+  it("a missing time is reported as undefined, as in node", () => {
+    expect({
+      utimesNone: thrownBy(() => (fs.utimesSync as any)(file)),
+      utimesOne: thrownBy(() => (fs.utimesSync as any)(file, 1)),
+      lutimesNone: thrownBy(() => (fs.lutimesSync as any)(file)),
+      futimesNone: thrownBy(() => (fs.futimesSync as any)(fd)),
+      futimesOne: thrownBy(() => (fs.futimesSync as any)(fd, 1)),
+    }).toEqual({
+      utimesNone: invalidTime("time", "undefined"),
+      utimesOne: invalidTime("time", "undefined"),
+      lutimesNone: invalidTime("time", "undefined"),
+      futimesNone: invalidTime("atime", "undefined"),
+      futimesOne: invalidTime("mtime", "undefined"),
+    });
+  });
+
+  it("futimes reports atime before looking at mtime", () => {
+    expect(thrownBy(() => fs.futimesSync(fd, "bad", {} as any))).toEqual(invalidTime("atime", "type string ('bad')"));
   });
 });
 


### PR DESCRIPTION
### Problem
- `fs.utimesSync(file, "bad", 1)` throws `TypeError [ERR_INVALID_ARG_TYPE]: atime must be a number or a Date`. Node v26.3.0 throws `The "time" argument must be an instance of Date or an Time in seconds. Received type string ('bad')`. Class and `code` already match; only the message differs.
- It differs in every form: `utimes`, `lutimes` and `futimes`, sync, callback, `fs/promises` and `FileHandle.utimes`, for `atime` and for `mtime`. A missing argument says `atime is required` where node says the same message with `Received undefined`.
- The argument name is also wrong: node says `"time"` in `utimes`/`lutimes` and `"atime"`/`"mtime"` only in `futimes` (and therefore `FileHandle.utimes`); bun said `atime`/`mtime` everywhere.
- Cause: `args::Lutimes::from_js` (also used for utimes, `args::Utimes` is an alias of it) and `args::Futimes::from_js` in `src/runtime/node/node_fs.rs` format their own text with `throw_invalid_arguments` instead of building the `ERR_INVALID_ARG_TYPE` message with the received value.

### Fix
- Adds `time_like::from_js_required(ctx, arguments, name)` in `src/runtime/node/time_like.rs`: eats the next argument (`undefined` when it is missing, which is what node's validator sees too) and, when the existing `time_like::from_js` rejects it, throws through `JSGlobalObject::throw_invalid_argument_type_value2` with node's expected-type phrase. The four sites in `node_fs.rs` call it; utimes/lutimes pass `"time"`, futimes passes `"atime"` and `"mtime"`.
- Why this is right: it matches node. Node's `toUnixTimestamp` throws `ERR_INVALID_ARG_TYPE(name, ['Date', 'Time in seconds'], time)`, and node's list renderer prints that array as `an instance of Date or an Time in seconds`; the `an Time` is node's own output and is reproduced on purpose (same approach as the `an Promise` message in `src/runtime/webcore/wasm_streaming.rs`). The `Received ...` half comes from the same `determineSpecificType` port that every other `ERR_INVALID_ARG_TYPE` in bun uses, so it already matches node for strings, objects, `null`, `undefined`, `NaN`, bigints and so on.
- Accepted inputs do not change: `time_like::from_js` is untouched, only its rejection is reported differently.
- Verified:
  - `test/js/node/fs/fs.test.ts`, new `describe("utimes/lutimes/futimes reject an invalid time with node's message")`: ten invalid values across utimes/lutimes/futimes for both atime and mtime, the callback forms, `fs/promises` and `FileHandle.utimes`, missing arguments, and atime being reported before mtime. All 14 tests fail on bun 1.4.0 and pass with this change. Every expected string is what node v26.3.0 prints for the same call (see the details block).
  - Whole `fs.test.ts` with the debug build: 524 pass. The one failure is the `readdirSync ... x 100` test hitting its 10s timeout under the debug build here; it does not touch this code.
  - Vendored `test-fs-utimes.js`, `test-fs-timestamp-parsing-error.js`, `test-fs-utimes-y2K38.js`, `test-fs-promises.js` and the four `test-fs-cp-*-preserve-timestamps*` tests still exit 0 (they cover the accepted inputs).
- Related: #38657 fixes the same wording in the JS helper `fs._toUnixTimestamp` (`src/js/node/fs.ts`). The real `fs.utimes*` functions validate in `node_fs.rs`, which is what this PR changes; the two do not touch the same lines.

### Background
- `ERR_INVALID_ARG_TYPE` message shape: node renders `The "<name>" argument must be <expected>. Received <value>`. `<expected>` is built from an array of entries: class names become `an instance of X`, any other phrase is printed as written with `an ` in front when it starts with a capital, and the groups are joined with ` or `. `<value>` comes from `determineSpecificType`, e.g. `type string ('bad')`, `an instance of Object`, `undefined`. Bun ports both in `src/jsc/bindings/ErrorCode.cpp`; from Rust, `throw_invalid_argument_type_value2(name, phrase, value)` takes the already rendered `<expected>` phrase and renders `<value>` through that port.
- `toUnixTimestamp(time, name = 'time')` in node's `lib/internal/fs/utils.js` turns a finite number, a numeric string or a `Date` into seconds and throws the error above for anything else. `fs.utimes` and `fs.lutimes` call it with the default name; `fs.futimes` passes `'atime'` and `'mtime'`; `FileHandle.utimes` is implemented with futimes. Bun's equivalent is `time_like::from_js`, called from the `args::*::from_js` argument parsers that the sync, callback and promise forms of a `node:fs` function share, which is why one change covers every form.

<details>
<summary>bun 1.4.0 vs node v26.3.0 (same output for the callback and promise forms)</summary>

```
fs.utimesSync(f, "bad", 1)
  bun:  atime must be a number or a Date
  node: The "time" argument must be an instance of Date or an Time in seconds. Received type string ('bad')
fs.utimesSync(f, 1, {})
  bun:  mtime must be a number or a Date
  node: The "time" argument must be an instance of Date or an Time in seconds. Received an instance of Object
fs.lutimesSync(f, null, 1)
  bun:  atime must be a number or a Date
  node: The "time" argument must be an instance of Date or an Time in seconds. Received null
fs.futimesSync(fd, "bad", 1)
  bun:  atime must be a number or a Date
  node: The "atime" argument must be an instance of Date or an Time in seconds. Received type string ('bad')
fs.futimesSync(fd, 1, NaN)
  bun:  mtime must be a number or a Date
  node: The "mtime" argument must be an instance of Date or an Time in seconds. Received type number (NaN)
fs.utimesSync(f, 1)
  bun:  mtime is required
  node: The "time" argument must be an instance of Date or an Time in seconds. Received undefined
handle.utimes("bad", 1)   (FileHandle)
  bun:  atime must be a number or a Date
  node: The "atime" argument must be an instance of Date or an Time in seconds. Received type string ('bad')
```

A script exercising the six functions (sync, callback, promises, FileHandle) with 18 different invalid values prints identical output under this build and under node, with one pre-existing exception that this PR leaves alone: for an invalid `Date` (`new Date(NaN)`) node passes NaN through to the binding and leaves the timestamp untouched, while bun rejects it (now with the message above, `Received an instance of Date`). That is a question of whether to throw, not of the message, so it is not covered by the new tests.
</details>
