### PR TITLE
sourcemap: make the debugId tail spell "bun!bun!"

### DIFF
--- a/src/sourcemap/lib.rs
+++ b/src/sourcemap/lib.rs
@@ -321,11 +321,15 @@ pub struct DebugIDFormatter {
     pub id: u64,
 }
 
+impl DebugIDFormatter {
+    /// The RFC asks for a UUID (128 bits / 32 hex chars). Our hashes are 64
+    /// bits; the other 64 are this constant.
+    const TAIL: u64 = u64::from_be_bytes(*b"bun!bun!");
+}
+
 impl core::fmt::Display for DebugIDFormatter {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        // The RFC asks for a UUID (128 bits / 32 hex chars). Our hashes are 64
-        // bits; the tail is "bun!bun!" hex-encoded.
-        write!(f, "{:016X}64756E2164756E21", self.id)
+        write!(f, "{:016X}{:016X}", self.id, Self::TAIL)
     }
 }
 

--- a/test/bundler/bundler_promiseall_deadcode.test.ts
+++ b/test/bundler/bundler_promiseall_deadcode.test.ts
@@ -164,7 +164,7 @@ describe("bundler", () => {
         var { AsyncEntryPoint: AsyncEntryPoint2 } = await Promise.resolve().then(() => exports_AsyncEntryPoint);
         AsyncEntryPoint2();
 
-        //# debugId=19FD1E5354FE6B6564756E2164756E21
+        //# debugId=19FD1E5354FE6B6562756E2162756E21
         //# sourceMappingURL=out.js.map
         "
       `);
@@ -410,7 +410,7 @@ describe("bundler", () => {
         var { AsyncEntryPoint: AsyncEntryPoint2 } = await Promise.resolve().then(() => exports_AsyncEntryPoint);
         AsyncEntryPoint2();
 
-        //# debugId=EA1AA30E1BD7B08E64756E2164756E21
+        //# debugId=EA1AA30E1BD7B08E62756E2162756E21
         //# sourceMappingURL=out.js.map
         "
       `);

--- a/test/bundler/esbuild/default.test.ts
+++ b/test/bundler/esbuild/default.test.ts
@@ -1164,9 +1164,9 @@ describe.concurrent("bundler", () => {
       const json = JSON.parse(api.readFile("/Users/user/project/out/entry.js.map"));
       api.expectFile("/Users/user/project/out/entry.js").not.toContain(`//# sourceMappingURL`);
       api.expectFile("/Users/user/project/out/entry.js").toContain(`//# debugId=${json.debugId}`);
-      // see src/sourcemap/sourcemap.zig DebugIDFormatter for more info
+      // see src/sourcemap/lib.rs DebugIDFormatter for more info
       expect(json.debugId).toMatch(/^[A-F0-9]{32}$/);
-      expect(json.debugId.endsWith("64756e2164756e21"));
+      expect(Buffer.from(json.debugId.slice(16), "hex").toString()).toBe("bun!bun!");
     },
     run: {
       stdout: "hi",
@@ -1187,9 +1187,9 @@ describe.concurrent("bundler", () => {
       const json = JSON.parse(api.readFile("/Users/user/project/out/entry.js.map"));
       api.expectFile("/Users/user/project/out/entry.js").toContain(`//# sourceMappingURL=entry.js.map`);
       api.expectFile("/Users/user/project/out/entry.js").toContain(`//# debugId=${json.debugId}`);
-      // see src/sourcemap/sourcemap.zig DebugIDFormatter for more info
+      // see src/sourcemap/lib.rs DebugIDFormatter for more info
       expect(json.debugId).toMatch(/^[A-F0-9]{32}$/);
-      expect(json.debugId.endsWith("64756e2164756e21"));
+      expect(Buffer.from(json.debugId.slice(16), "hex").toString()).toBe("bun!bun!");
     },
     run: {
       stdout: "hi",
@@ -1207,9 +1207,12 @@ describe.concurrent("bundler", () => {
     outdir: "/Users/user/project/out",
     sourceMap: "inline",
     onAfterBundle(api) {
-      api
-        .expectFile("/Users/user/project/out/entry.js")
-        .toContain(`//# sourceMappingURL=data:application/json;base64,`);
+      const code = api.readFile("/Users/user/project/out/entry.js");
+      expect(code).toContain(`//# sourceMappingURL=data:application/json;base64,`);
+      const json = JSON.parse(atob(code.slice(code.lastIndexOf("base64,") + "base64,".length).trim()));
+      expect(code).toContain(`//# debugId=${json.debugId}`);
+      expect(json.debugId).toMatch(/^[A-F0-9]{32}$/);
+      expect(Buffer.from(json.debugId.slice(16), "hex").toString()).toBe("bun!bun!");
     },
     run: {
       stdout: "hi",

--- a/test/js/bun/http/bun-serve-html.test.ts
+++ b/test/js/bun/http/bun-serve-html.test.ts
@@ -210,7 +210,7 @@ console.log("How...dashing?");
           "import './script.js';\\n      // Additional dashboard-specific code could go here\\n      console.log(\\"How...dashing?\\")"
         ],
         "mappings": ";AACM,IAAI,QAAQ;AACZ,IAAM,SAAS,SAAS,eAAe,SAAS;AAChD,OAAO,iBAAiB,SAAS,MAAM;AAAA,EACrC;AAAA,EACA,OAAO,cAAc,aAAa;AAAA,CACnC;;;ACHD,QAAQ,IAAI,gBAAgB;",
-        "debugId": "DEEF3F05D4E944CA64756E2164756E21",
+        "debugId": "DEEF3F05D4E944CA62756E2162756E21",
         "names": []
       }"
     `);

--- a/test/regression/issue/cyclic-imports-async-bundler.test.js
+++ b/test/regression/issue/cyclic-imports-async-bundler.test.js
@@ -180,7 +180,7 @@ test("cyclic imports with async dependencies should generate async wrappers", as
     var { AsyncEntryPoint: AsyncEntryPoint2 } = await Promise.resolve().then(() => exports_AsyncEntryPoint);
     AsyncEntryPoint2();
 
-    //# debugId=66236CFF39257E1264756E2164756E21
+    //# debugId=66236CFF39257E1262756E2162756E21
     //# sourceMappingURL=entryBuild.js.map
     "
   `);


### PR DESCRIPTION
### Problem

- Every debug ID bun writes (the `//# debugId=` footer of a JS chunk and the `debugId` field of its source map) ends in the constant `64756E2164756E21`. Those bytes decode to `dun!dun!`. The comment above `DebugIDFormatter` in `src/sourcemap/lib.rs:326` says the tail is `"bun!bun!"`, which would be `62756E2162756E21`.
- The literal has been off since it was introduced: #2890 describes it as `hex encoded "bun!bun!"` and ships the `64` (`d`) bytes, #11983 uppercased it, and the Rust port kept both the literal and the comment.
- Repro on bun 1.4.0: `bun build entry.js --outdir out --sourcemap=external`, then `Buffer.from(debugId.slice(16), "hex").toString()` on either the footer or the `.map` field prints `dun!dun!`. Same for `linked` and `inline`.

### Fix

- `DebugIDFormatter` formats `u64::from_be_bytes(*b"bun!bun!")` as the low 64 bits instead of a hand-written hex literal, so the tail is derived from the string it is documented to be and the two cannot drift apart again. IDs now end in `62756E2162756E21`.
- Why changing the bytes (rather than the comment) is right: the tail carries no information. It exists to pad bun's 64-bit chunk hash to the 128 bits the debug ID proposal asks for (#2890), and the value was meant to be `bun!bun!`. Both writers (the footer in `src/bundler/Chunk.rs`, the map field in `src/bundler/LinkerContext.rs`) go through this one formatter, so a bundle and its map still agree; nothing in bun reads the tail back (the only `DebugIDFormatter` users are those two writers); and #11983 already changed the constant once (casing) without anything depending on it. A GitHub code search for the old constant outside bun forks finds only committed build output.
- The hash half of every ID is unchanged. `isolated_hash` is computed before the source map or footer exist (`postProcessJSChunk.rs`), and the `[hash]` in output names and the ETag `Bun.serve` puts on HTML-route chunks are built from those hashes, not from the final bytes. In the four updated snapshots only the last 16 characters move; the `serve html` snapshot that also pins the chunk's ETag still passes.
- Tests, `test/bundler/esbuild/default.test.ts`: `default/SourceMap`, `default/SourceMapLinked` and `default/SourceMapInline` now decode the tail of the map's `debugId` and assert it is `bun!bun!`, after checking that the footer carries the same ID. The first two previously had a matcher-less `expect(json.debugId.endsWith("64756e2164756e21"))`, which asserted nothing (and names lowercase hex that #11983 removed); the inline test previously only checked that a `data:` URL was present, so the inline map's `debugId` was unpinned. On the released 1.4.0 all three fail with `Expected: "bun!bun!"` / `Received: "dun!dun!"`; with this change they pass.
- Snapshots updated to the new tail: `test/bundler/bundler_promiseall_deadcode.test.ts` (2), `test/regression/issue/cyclic-imports-async-bundler.test.js`, `test/js/bun/http/bun-serve-html.test.ts`. All pass on the debug build; with the released binary each fails with a diff confined to the tail.
- Also checked on the debug build: `bun build` via the CLI in all three sourcemap modes and `--compile --sourcemap=external` all emit the new tail; `bun-build-api`, `bundler_html`, `html-import-manifest`, `bun-build-compile-sourcemap`, `compile-sourcemap-internal` and the `test/js/bun/sourcemap` files pass (two timeouts in the first and fourth are debug-build slowness of tests that do not look at debug IDs; their sibling cases pass).
- #38646 (open) touches the same two `default.test.ts` lines to pin the old tail; whichever of the two lands second needs a two-line rebase. #38651 does not touch the tail.

### Background

- Debug IDs (the Sentry source map proposal linked above the formatter): a bundler writes one 32-hex-character ID both as a `//# debugId=` comment at the end of a JS file and as a `debugId` field in that file's source map, so tooling can pair the two without trusting file names. The proposal sizes the ID like a UUID; bun has a 64-bit per-chunk hash, so the other 64 bits are a fixed filler, and that filler is what this PR changes.
- `isolated_hash`: bun's per-chunk content hash (`generate_isolated_hash`, over the chunk's code and its mappings). It is the first 16 characters of the debug ID, and, mixed with the hashes of imported chunks, the `[hash]` in output file names and the chunk ETag for `Bun.serve` HTML routes. It is computed before the debug ID is written anywhere, which is why none of those move here.
