### PR TITLE
pm view: match the requested range against the buffer it was parsed from

### DIFF
--- a/src/runtime/cli/pm_view_command.rs
+++ b/src/runtime/cli/pm_view_command.rs
@@ -207,11 +207,9 @@ pub(crate) fn view(
                         // Parse as semver query and find best version
                         let sliced_literal = Semver::SlicedString::init(version, version);
                         let query = Semver::query::parse(version, sliced_literal)?;
-                        // `defer query.deinit()` — handled by Drop
-                        // Use the same pattern as outdated_command: findBestVersion(query.head, string_buf)
-                        if let Some(result) =
-                            parsed_manifest.find_best_version(&query, &parsed_manifest.string_buf)
-                        {
+                        // The query's prerelease/build tags are offsets into `version`, the
+                        // buffer it was parsed from, so that is the buffer to match it with.
+                        if let Some(result) = parsed_manifest.find_best_version(&query, version) {
                             break 'brk2 result.version;
                         }
                     }

--- a/test/cli/install/bun-info.test.ts
+++ b/test/cli/install/bun-info.test.ts
@@ -1,6 +1,6 @@
 import { spawn } from "bun";
 import { describe, expect, it, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isASAN, tempDir, tempDirWithFiles } from "harness";
 import { join } from "node:path";
 
 describe.concurrent("bun info", () => {
@@ -368,6 +368,71 @@ describe.concurrent("bun info", () => {
         Published: 2016-08-23T17:56:58.976Z
         "
       `);
+    });
+  });
+});
+
+// Semver strings longer than 8 bytes are stored as offsets into the buffer they
+// were parsed from. A range given on the command line is parsed from the
+// argument, so its prerelease tags have to be read back out of the argument and
+// not out of the manifest's string buffer. The manifest buffer starts with the
+// package name, and the name is longer than any range below, so reading the
+// wrong buffer yields a piece of the name rather than the tag by coincidence.
+describe.concurrent("version ranges with prerelease tags longer than 8 bytes", () => {
+  const name = "long-prerelease-tags-pkg";
+  const published = ["1.0.0-beta.20240101", "1.0.0-beta.20240301"];
+  const packument = JSON.stringify({
+    name,
+    "dist-tags": { latest: "1.0.0-beta.20240301" },
+    versions: Object.fromEntries(
+      published.map(version => [
+        version,
+        { name, version, dist: { tarball: `http://localhost/${name}-${version}.tgz` } },
+      ]),
+    ),
+  });
+
+  async function view(subcommand: string[], spec: string) {
+    await using server = Bun.serve({
+      port: 0,
+      fetch: () => new Response(packument, { headers: { "content-type": "application/json" } }),
+    });
+    using dir = tempDir("view-long-prerelease", {
+      "package.json": JSON.stringify({ name: "test", version: "1.0.0" }),
+      "bunfig.toml": `[install]\nregistry = "http://localhost:${server.port}/"\n`,
+    });
+    await using proc = spawn({
+      cmd: [bunExe(), ...subcommand, `${name}@${spec}`, "version"],
+      cwd: String(dir),
+      env: { ...bunEnv, http_proxy: "", https_proxy: "", HTTP_PROXY: "", HTTPS_PROXY: "" },
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  describe.each([
+    ["bun info", ["info"]],
+    ["bun pm view", ["pm", "view"]],
+  ])("%s", (_, subcommand) => {
+    test.each([
+      // resolved through the `latest` dist-tag
+      [">=1.0.0-beta.20240101", "1.0.0-beta.20240301"],
+      ["~1.0.0-beta.20240301", "1.0.0-beta.20240301"],
+      // `latest` is excluded, resolved by walking the prerelease list
+      ["<1.0.0-beta.20240201", "1.0.0-beta.20240101"],
+    ])(`${name}@%s resolves to %s`, async (spec, expected) => {
+      expect(await view(subcommand, spec)).toEqual({ stdout: `${expected}\n`, stderr: "", exitCode: 0 });
+    });
+
+    test(`${name}@<1.0.0-beta.20240101 matches nothing`, async () => {
+      expect(await view(subcommand, "<1.0.0-beta.20240101")).toEqual({
+        stdout: "",
+        stderr: expect.stringContaining(`No version of "${name}" satisfying "<1.0.0-beta.20240101" found`),
+        exitCode: 1,
+      });
     });
   });
 });


### PR DESCRIPTION
### Problem
- `bun info pkg@<range>` and `bun pm view pkg@<range>` resolve the wrong version, or none, when a comparator in the range carries a prerelease tag longer than 8 bytes. Against a registry whose only versions are `1.0.0-beta.20240101` and `1.0.0-beta.20240301` (`latest` = `.20240301`), bun 1.4.0 gives:
  - `pkg@'>=1.0.0-beta.20240101'`: `error: No version of "pkg" satisfying ">=1.0.0-beta.20240101" found` (should resolve to `.20240301`)
  - `pkg@'~1.0.0-beta.20240301'`: same error (should resolve to `.20240301`)
  - `pkg@'<1.0.0-beta.20240201'`: resolves to `.20240301` (should be `.20240101`)
  - `pkg@'<1.0.0-beta.20240101'`: resolves to `.20240301` (should match nothing)
- Cause: `src/runtime/cli/pm_view_command.rs:213` parses the range out of the command line argument (`SlicedString::init(version, version)`) but then calls `find_best_version(&query, &parsed_manifest.string_buf)`, so the range's prerelease tags are read out of the manifest's string buffer. The comment on that line said it mirrors `outdated_command.rs`, but there the range comes from the lockfile and the lockfile buffer is passed, which is the matching buffer for that caller.
- Tags of 8 bytes or less are stored inline and are unaffected, and an exact version (`pkg@1.0.0-beta.20240101`) is unaffected because `find_best_version` takes the exact-version fast path, which looks the version up by tag hash. Only ranges hit the bad path.
- The Zig version of this command had the same call, so this is not a port regression.

### Fix
- Pass `version` (the argument slice the query was parsed from) as the group buffer, the same contract every other `find_best_version` / `find_best_version_with_filter` caller follows (`outdated_command.rs`, `update_interactive_command.rs`, `PackageManagerEnqueue.rs` all pass the lockfile buffer their range was parsed from).
- Correct because `find_best_version(group, group_buf)` slices the group's tags out of `group_buf` (`Group::satisfies(v, group_buf, &self.string_buf)` and `left.version.order(latest, group_buf, &self.string_buf)` in `src/install/npm.rs`), and `query::parse(version, SlicedString::init(version, version))` stores those tags as offsets into `version`.
- Test: `test/cli/install/bun-info.test.ts`, `describe("version ranges with prerelease tags longer than 8 bytes")`. A `Bun.serve` mock registry serves the two-version packument above; for both `bun info` and `bun pm view` it checks the two cases resolved through the `latest` dist-tag, the case that walks the prerelease list, and the case that must match nothing. All 8 fail on the released binary with the outputs listed under Problem and pass with this change; the whole file (28 tests) passes with the debug build.
  - The package name in the test is longer than the ranges so that, without the fix, the bytes read from the manifest buffer are part of the package name and never happen to equal the tag (with a very short name the manifest buffer would line up with the argument by accident and the test would pass either way).

### Background
- Semver values (`Version`, its prerelease/build `Tag`, range `Group`s) do not own their text. A string of up to 8 bytes is stored inline in the 8-byte `semver::String`; anything longer is stored as an offset and length into whichever buffer it was parsed from, and every `slice`/`order`/`fmt` on it has to be handed that same buffer. Passing a different buffer is bounds-checked, so it yields unrelated bytes (or an empty string) rather than a crash, which is why this shows up as a wrong answer instead of a failure.
- `bun pm view` has two such buffers in play: the command line argument the range was parsed from, and the manifest's `string_buf`, which holds everything parsed out of the registry response (it starts with the package name, followed by the version strings that have tags). `find_best_version` takes the range's buffer as a parameter and uses its own `string_buf` for the candidate versions.
- Comparing a prerelease version against a prerelease comparator (`Tag::order_pre`) compares the two tags dot-segment by dot-segment; the major/minor/patch and "has a prerelease at all" comparisons happen before that and do not touch the buffers. So the wrong buffer only matters when both the comparator and the candidate have a prerelease tag at the same major.minor.patch, which is exactly the case the test exercises.
