### PR TITLE
compile: do not inline NODE_ENV into runtime-transpiled files when .env autoload is off

### DIFF
--- a/src/bun.js.rs
+++ b/src/bun.js.rs
@@ -16,13 +16,13 @@ pub(crate) fn apply_standalone_runtime_flags(
     graph: &StandaloneModuleGraph,
 ) {
     use bun_options_types::schema::api::DotEnvBehavior;
-    let disable_env = graph.flags.contains(GraphFlags::DISABLE_DEFAULT_ENV_FILES);
-    b.options.env.disable_default_env_files = disable_env;
-    b.options.env.behavior = if disable_env {
-        DotEnvBehavior::disable
-    } else {
-        DotEnvBehavior::LoadAllWithoutInlining
-    };
+    b.options.env.disable_default_env_files =
+        graph.flags.contains(GraphFlags::DISABLE_DEFAULT_ENV_FILES);
+    // Not `disable` when .env autoload is off: every behavior other than this
+    // one makes `defines_from_transform_options` inline `process.env.NODE_ENV`,
+    // `BUN_ENV` and `process.browser` into the files transpiled at runtime.
+    // `disable_default_env_files` alone skips the .env files (as `--no-env-file`).
+    b.options.env.behavior = DotEnvBehavior::LoadAllWithoutInlining;
 
     b.resolver.opts.load_tsconfig_json =
         !graph.flags.contains(GraphFlags::DISABLE_AUTOLOAD_TSCONFIG);

--- a/test/bundler/bundler_compile_autoload.test.ts
+++ b/test/bundler/bundler_compile_autoload.test.ts
@@ -206,6 +206,62 @@ console.log("PRELOAD");
     },
   });
 
+  // autoloadDotenv: false only opts out of the .env files. Code the executable
+  // transpiles at runtime (here a package loaded from the cwd's node_modules)
+  // must still read process.env.NODE_ENV / BUN_ENV / process.browser live, as it
+  // does under `bun run` and in an executable built with autoloadDotenv on.
+  // It used to get the values from the launch environment inlined instead, on
+  // the main thread and in workers alike.
+  itBundled("compile/AutoloadDotenvDisabledDoesNotInlineNodeEnvCLI", {
+    compile: {
+      autoloadDotenv: false,
+    },
+    backend: "cli",
+    files: {
+      "/entry.ts": /* js */ `
+        process.env.NODE_ENV = "set-by-main";
+        process.env.BUN_ENV = "set-by-main";
+        process.browser = "set-by-main";
+        const imp = x => import(x);
+        const { read } = await imp("runtime-only");
+        console.log(JSON.stringify(read()));
+
+        const worker = new Worker("./worker.ts");
+        console.log(JSON.stringify(await new Promise(resolve => {
+          worker.onmessage = event => resolve(event.data);
+        })));
+        worker.terminate();
+      `,
+      "/worker.ts": /* js */ `
+        process.env.NODE_ENV = "set-by-worker";
+        process.env.BUN_ENV = "set-by-worker";
+        process.browser = "set-by-worker";
+        const imp = x => import(x);
+        const { read } = await imp("runtime-only");
+        postMessage(read());
+      `,
+      "/node_modules/runtime-only/index.js": `throw new Error("Must be loaded at runtime, not bundled.");`,
+    },
+    entryPointsRaw: ["./entry.ts", "./worker.ts"],
+    outfile: "dist/out",
+    runtimeFiles: {
+      "/node_modules/runtime-only/index.js": /* js */ `
+        export function read() {
+          return [process.env.NODE_ENV, process.env.BUN_ENV, process.browser];
+        }
+      `,
+    },
+    run: {
+      file: "dist/out",
+      setCwd: true,
+      env: {
+        NODE_ENV: "from-launch-env",
+        BUN_ENV: "from-launch-env",
+      },
+      stdout: `["set-by-main","set-by-main","set-by-main"]\n["set-by-worker","set-by-worker","set-by-worker"]`,
+    },
+  });
+
   // Test CLI backend with autoloadDotenv: true
   itBundled("compile/AutoloadDotenvEnabledCLI", {
     compile: {


### PR DESCRIPTION
### Problem
- A `bun build --compile` executable built with `--no-compile-autoload-dotenv` (`compile.autoloadDotenv: false`) inlines `process.env.NODE_ENV`, `process.env.BUN_ENV` and `process.browser` into every file it transpiles at runtime (anything imported from disk rather than embedded in the binary). The values are the ones in the environment at launch, or `"development"` when unset, and `process.browser` becomes the literal `false`.
- `bun run` and the same executable built with autoload on (the default) leave these as live reads, so in the autoload-off executable a later `process.env.NODE_ENV = ...` is invisible to disk-loaded files, and the `"development"` default gets baked in when `NODE_ENV` is unset. The same happens on the main thread and in workers.
- Cause: `apply_standalone_runtime_flags` (src/bun.js.rs:21) switches `options.env.behavior` to `DotEnvBehavior::disable` when the executable carries the `DISABLE_DEFAULT_ENV_FILES` flag. `defines_from_transform_options` (src/bundler/options.rs:887) adds the `NODE_ENV` / `BUN_ENV` / `process.browser` defines for every behavior except `LoadAllWithoutInlining`; `disable` only skips the copy of the other env vars. `disable` is the bundler's `--env=disable` setting; whether the bundler should keep inlining `NODE_ENV` under it is a separate open question (#20183, #22820, #35952, with #35954 and #32851 proposing changes to the shared function) that this PR does not touch: the runtime inside an executable should not be running with a bundler setting in the first place, and no other runtime path does.
- Repro (bun 1.4.0): `entry.ts` sets `process.env.NODE_ENV = "changed"` and dynamically imports a file from the cwd that prints `process.env.NODE_ENV`; `bun run` and the default executable print `changed`, the `--no-compile-autoload-dotenv` executable prints `development`.

### Fix
- `apply_standalone_runtime_flags` always keeps `LoadAllWithoutInlining` and only sets `disable_default_env_files` from the flag. `run_env_loader` passes that flag to `Loader::load`, which then skips the default `.env` files; process env vars are still loaded, and `NODE_ENV=production` still switches production mode, exactly as before.
- Correct because this is the combination `bun --no-env-file` already runs with (src/runtime/cli/Arguments.rs:986 sets the same field, `boot` in run_command.rs sets the same behavior), so an autoload-off executable now behaves like `bun --no-env-file <entry>`, and identically to an autoload-on executable apart from the `.env` files. For executables built with autoload on (flag clear) the function produces the same values as before, so they are unaffected.
- One consequence of the same alignment: an autoload-off executable given an explicit `--env-file=...` at runtime (via `BUN_OPTIONS` or `--compile-exec-argv`) now loads that file, as `bun --no-env-file --env-file=...` and autoload-on executables do; previously the `disable` branch ignored it. The autoloaded `.env*` files stay skipped.
- Main thread and workers share `apply_standalone_runtime_flags`, so both are fixed by the one change.
- Verified: `test/bundler/bundler_compile_autoload.test.ts` gets `compile/AutoloadDotenvDisabledDoesNotInlineNodeEnvCLI`, which builds one autoload-off executable whose main thread and worker each assign the three values and then import a package from the cwd's `node_modules` that reads them back. It fails on bun 1.4.0 (prints `["from-launch-env","from-launch-env",false]` twice) and passes with this change; the same program with autoload on already passes on 1.4.0, which is the parity the test pins.
- The rest of `bundler_compile_autoload.test.ts` (24 tests, including the autoload-off `.env` and worker cases that guard the opt-out itself) passes on the debug build. `test/regression/issue/27431.test.ts` covers the autoload-off worker configuration on Windows and runs in CI.

### Background
- Standalone executables embed the bundled entry points, but still carry the full runtime: files imported from disk at runtime (`node_modules` next to the cwd, dynamic imports of absolute paths) go through the runtime transpiler like they would under `bun run`.
- `DotEnvBehavior` is the transpiler's env setting, shared between `bun build` and the runtime. `LoadAll` / `prefix` inline env vars into the code (bundler `--env=inline`, `--env=PREFIX_*`), `disable` inlines nothing except the `NODE_ENV` / `BUN_ENV` / `process.browser` defaults (bundler `--env=disable`, also the struct default), and `LoadAllWithoutInlining` is the runtime setting: load env files into `process.env`, inline nothing. The runtime (`bun run`, `bun test`, workers, executables) always uses the last one.
- `disable_default_env_files` is a separate option that only controls whether `Loader::load` reads the automatic `.env`, `.env.local`, `.env.{development,production,test}` files. It is what `--no-env-file` and bunfig `env = false` set; the executable's `DISABLE_DEFAULT_ENV_FILES` flag is the compiled-in form of it.
- `apply_standalone_runtime_flags` is called once per VM in an executable, for the main thread (`RunCommand::boot_standalone`) and for each worker (`WebWorker::start_vm`), right before `configure_defines` builds the define table from these options.
- Related: #38590 keys the shared on-disk transpiler cache on the define table, which is where these entries were noticed; it does not change what gets inlined. #34211 fixes a different inlining bug in non-standalone workers. #35954 and #32851 change what `bun build` inlines; even with either of them, an autoload-off executable would still run with the bundler setting (still inlining `process.browser` with #35954, still ignoring `--env-file`), so this change is needed independently of them.
