### PR TITLE
http: escape control characters in the verbose request/response trace

### DIFF
--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -257,8 +257,11 @@ impl Display for RedactedNpmUrlFormatter<'_> {
             }
 
             // Emit the run of bytes up to the next position where a uuid/npm
-            // secret could possibly start, so multi-byte UTF-8 sequences are
-            // written intact (raw bytes, not Latin-1→UTF-8 chars).
+            // secret could possibly start. Runs split only at ASCII bytes, so
+            // multi-byte sequences stay intact; `BStr` turns invalid UTF-8 (the
+            // URL is package metadata, not guaranteed UTF-8) into U+FFFD instead
+            // of handing a bogus `&str` to a `Display` wrapper such as
+            // [`EscapeControlChars`].
             let mut next = i + 1;
             while next < self.url.len() {
                 let b = self.url[next];
@@ -271,7 +274,7 @@ impl Display for RedactedNpmUrlFormatter<'_> {
                 }
                 next += 1;
             }
-            write_bytes(f, &self.url[i..next])?;
+            write!(f, "{}", bstr::BStr::new(&self.url[i..next]))?;
             i = next;
         }
         Ok(())
@@ -3323,6 +3326,50 @@ fn escape_powershell_impl(str: &[u8], writer: &mut impl fmt::Write) -> fmt::Resu
         remain = &remain[i + 1..];
     }
     write_bytes(writer, remain)
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// escapeControlChars
+// ───────────────────────────────────────────────────────────────────────────
+
+/// `Display` adapter that spells out C0 controls, DEL and C1 controls
+/// (`\n`, `\x1b`, `\x7f`, `\u009b`, ...) so text authored by a dependency
+/// cannot erase, repaint or forge lines of terminal output when printed.
+pub struct EscapeControlChars<T>(pub T);
+
+/// [`EscapeControlChars`] over raw bytes; invalid UTF-8 renders as U+FFFD.
+pub fn escape_control_chars(text: &[u8]) -> EscapeControlChars<&bstr::BStr> {
+    EscapeControlChars(bstr::BStr::new(text))
+}
+
+impl<T: Display> Display for EscapeControlChars<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let mut writer = EscapeControlCharsWriter(f);
+        write!(writer, "{}", self.0)
+    }
+}
+
+struct EscapeControlCharsWriter<'a, 'f>(&'a mut Formatter<'f>);
+
+impl fmt::Write for EscapeControlCharsWriter<'_, '_> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        let mut start = 0;
+        for (i, c) in s.char_indices() {
+            if !matches!(c, '\0'..='\x1f' | '\x7f' | '\u{80}'..='\u{9f}') {
+                continue;
+            }
+            self.0.write_str(&s[start..i])?;
+            match c {
+                '\n' => self.0.write_str("\\n")?,
+                '\r' => self.0.write_str("\\r")?,
+                '\t' => self.0.write_str("\\t")?,
+                c if c.is_ascii() => write!(self.0, "\\x{:02x}", c as u32)?,
+                c => write!(self.0, "\\u{:04x}", c as u32)?,
+            }
+            start = i + c.len_utf8();
+        }
+        self.0.write_str(&s[start..])
+    }
 }
 
 // js_bindings (fmtString for highlighter.test.ts) lives in src/jsc/fmt_jsc.rs

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -999,6 +999,7 @@ use bstr::BStr;
 use bun_boringssl as boringssl;
 use bun_collections::{ArrayHashMap, VecExt};
 use bun_core::StringBuilder;
+use bun_core::fmt::{EscapeControlChars, escape_control_chars};
 use bun_core::{FeatureFlags, Global, Output};
 use bun_core::{OwnedString, String as BunString, Tag as BunStringTag, strings};
 use bun_http_types::ETag::StringPointer;
@@ -1440,7 +1441,7 @@ pub(crate) fn print_request(
         "> {} {} {}",
         ver,
         BStr::new(request.method),
-        bun_core::fmt::redacted_npm_url(url),
+        EscapeControlChars(bun_core::fmt::redacted_npm_url(url)),
     );
     for header in request.headers {
         let name = header.name();
@@ -1451,8 +1452,8 @@ pub(crate) fn print_request(
             let scheme_len = strings::index_of_char_usize(value, b' ').map_or(0, |i| i + 1);
             bun_core::pretty_errorln!(
                 "> <r><cyan>{}<r><d>: <r>{}<d>[redacted]<r>",
-                BStr::new(name),
-                BStr::new(&value[..scheme_len]),
+                escape_control_chars(name),
+                escape_control_chars(&value[..scheme_len]),
             );
         } else {
             bun_core::pretty_errorln!("> {}", header);

--- a/src/picohttp/lib.rs
+++ b/src/picohttp/lib.rs
@@ -4,6 +4,7 @@ use core::fmt;
 
 use bstr::BStr;
 
+use bun_core::fmt::escape_control_chars;
 use bun_core::output::enable_ansi_colors_stderr;
 use bun_core::pretty_fmt;
 
@@ -155,19 +156,29 @@ impl Header {
     }
 }
 
+// The `Display` impls in this file (except `Headers`, which is wire format)
+// render the `fetch(..., { verbose: true })` / `bun install --verbose` trace.
+// Names, values, status text and URLs are peer-supplied, so they go through
+// `escape_control_chars`: HTTP/1.1 admits HT and any byte >= 0x80 (so UTF-8
+// encoded C1 controls such as U+009B, CSI) in a field value or reason phrase,
+// and HPACK/QPACK only reject NUL, CR and LF.
 impl fmt::Display for Header {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // NOTE: pretty_fmt! is the compile-time ANSI-tag expander (`<r><cyan>` → escape
         // codes).
         if enable_ansi_colors_stderr() {
             if self.is_multiline() {
-                write!(f, pretty_fmt!("<r><cyan>{}", true), BStr::new(self.value()))
+                write!(
+                    f,
+                    pretty_fmt!("<r><cyan>{}", true),
+                    escape_control_chars(self.value())
+                )
             } else {
                 write!(
                     f,
                     pretty_fmt!("<r><cyan>{}<r><d>: <r>{}", true),
-                    BStr::new(self.name()),
-                    BStr::new(self.value()),
+                    escape_control_chars(self.name()),
+                    escape_control_chars(self.value()),
                 )
             }
         } else {
@@ -175,14 +186,14 @@ impl fmt::Display for Header {
                 write!(
                     f,
                     pretty_fmt!("<r><cyan>{}", false),
-                    BStr::new(self.value())
+                    escape_control_chars(self.value())
                 )
             } else {
                 write!(
                     f,
                     pretty_fmt!("<r><cyan>{}<r><d>: <r>{}", false),
-                    BStr::new(self.name()),
-                    BStr::new(self.value()),
+                    escape_control_chars(self.name()),
+                    escape_control_chars(self.value()),
                 )
             }
         }
@@ -203,11 +214,11 @@ impl fmt::Display for HeaderCurlFormatter<'_> {
             write!(
                 f,
                 "-H \"{}: {}\"",
-                BStr::new(header.name()),
-                BStr::new(header.value())
+                escape_control_chars(header.name()),
+                escape_control_chars(header.value())
             )
         } else {
-            write!(f, "-H \"{}\"", BStr::new(header.name()))
+            write!(f, "-H \"{}\"", escape_control_chars(header.name()))
         }
     }
 }
@@ -307,7 +318,7 @@ impl fmt::Display for Request<'_> {
             f,
             "> HTTP/1.1 {} {}",
             BStr::new(self.method),
-            BStr::new(self.path)
+            escape_control_chars(self.path)
         )?;
         for header in self.headers {
             if enable_ansi_colors_stderr() {
@@ -348,10 +359,14 @@ impl fmt::Display for RequestCurlFormatter<'_> {
             write!(
                 f,
                 pretty_fmt!("<b><cyan>curl<r> <d>--http1.1<r> <b>\"{}\"<r>", true),
-                BStr::new(request.path),
+                escape_control_chars(request.path),
             )?;
         } else {
-            write!(f, "curl --http1.1 \"{}\"", BStr::new(request.path))?;
+            write!(
+                f,
+                "curl --http1.1 \"{}\"",
+                escape_control_chars(request.path)
+            )?;
         }
 
         if request.method != b"GET" {
@@ -566,7 +581,7 @@ impl fmt::Display for Response<'_> {
             StatusCodeFormatter {
                 code: self.status_code as usize
             },
-            BStr::new(self.status),
+            escape_control_chars(self.status),
         )?;
         for header in self.headers.list {
             if enable_ansi_colors_stderr() {

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -872,6 +872,54 @@ describe.concurrent("bun-install", () => {
     expect(exitCode).toBe(0);
   });
 
+  it("--verbose escapes control characters in the tarball URL and response headers it traces", async () => {
+    // U+009B is the one-byte form of ESC [ (CSI), so "\u009b31m" written to a terminal as-is turns the
+    // rest of the line red. Header values are byte strings: the two Latin-1 characters below go out as
+    // the bytes C2 9B, the UTF-8 encoding of U+009B.
+    await using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch() {
+        return new Response("not found", { status: 404, headers: { "x-evil": "a\u00c2\u009b31mb" } });
+      },
+    });
+
+    const origin = `http://127.0.0.1:${server.port}`;
+    using dir = tempDir("install-verbose-escape", {
+      "package.json": Buffer.concat([
+        Buffer.from(`{"name":"app","dependencies":{"csi":"${origin}/csi-\u009b31m.tgz","latin1":"${origin}/latin1-`),
+        // A Latin-1 encoded package.json: a lone 0x9B (the 8-bit CSI) and a stray continuation byte,
+        // neither of which is valid UTF-8.
+        Buffer.from([0x82, 0x41, 0x9b, 0x41]),
+        Buffer.from(`.tgz"}}`),
+      ]),
+    });
+
+    await using proc = spawn({
+      cmd: [bunExe(), "install", "--verbose"],
+      cwd: String(dir),
+      env: { ...env, BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache") },
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+    const [stderrBytes, exitCode] = await Promise.all([proc.stderr.bytes(), proc.exited]);
+    const stderr = new TextDecoder().decode(stderrBytes);
+
+    const requestedUrls = stderr.split(/\r?\n/).flatMap(line => {
+      const match = /^\s*>?\s*HTTP\/1\.1 GET (.*)$/.exec(line);
+      return match ? [match[1]] : [];
+    });
+    expect(requestedUrls.sort()).toEqual([`${origin}/csi-\\u009b31m.tgz`, `${origin}/latin1-\ufffdA\ufffdA.tgz`]);
+    expect(stderr.split(/\r?\n/).filter(line => line.startsWith("< x-evil:"))).toEqual([
+      "< x-evil: a\\u009b31mb",
+      "< x-evil: a\\u009b31mb",
+    ]);
+    // The lenient decode above also shows U+FFFD for the raw Latin-1 bytes themselves, so check
+    // separately that they were not copied to stderr as-is.
+    expect(() => new TextDecoder("utf-8", { fatal: true }).decode(stderrBytes)).not.toThrow();
+    expect(exitCode).toBe(1);
+  });
+
   it("fails cleanly for a git dependency specifier longer than the path buffer", async () => {
     const longPath = Buffer.alloc(isWindows ? 100_000 : 8192, "a").toString();
     using dir = tempDir("long-git-dep", {

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -3599,3 +3599,59 @@ it("verbose fetch logging prints [redacted] in place of Authorization credential
   expect(stderr).not.toContain("sekret-token");
   expect(exitCode).toBe(0);
 });
+
+it("verbose fetch logging escapes control characters coming from the peer", async () => {
+  // U+009B is the one-byte form of ESC [ (CSI), so "\u009b31m" written to a terminal as-is turns
+  // the rest of the line red. HTTP/1.1 lets a server put any byte >= 0x80 in a reason phrase or
+  // header value, which includes the UTF-8 encoding of U+009B.
+  let request = "";
+  using listener = Bun.listen({
+    hostname: "127.0.0.1",
+    port: 0,
+    socket: {
+      data(socket, chunk) {
+        request += chunk.toString("latin1");
+        if (!request.includes("\r\n\r\n")) return;
+        socket.end(
+          Buffer.from(
+            "HTTP/1.1 500 Server \u009bError\r\n" +
+              "x-evil: a\u009b31mb\r\n" +
+              "content-length: 0\r\n" +
+              "connection: close\r\n" +
+              "\r\n",
+          ),
+        );
+      },
+    },
+  });
+
+  // Header values are byte strings, so the two Latin-1 characters "\u00c2\u009b" are sent as the
+  // bytes C2 9B, i.e. the same UTF-8 encoded U+009B the server sends back.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const res = await fetch(process.env.SERVER_URL, {
+         verbose: "curl",
+         headers: { "x-req": "v\\u00c2\\u009b31mq", authorization: "Bea\\u00c2\\u009brer sekret-token" },
+       });
+       console.log(res.status);`,
+    ],
+    env: { ...bunEnv, SERVER_URL: `http://127.0.0.1:${listener.port}/` },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe("500\n");
+  // The request line and the response status line are printed on their own lines; header lines
+  // are printed once per header in the "name: value" trace and once more in the curl command.
+  expect(stderr).toMatch(/^.*x-req: v\\u009b31mq$/im);
+  expect(stderr).toMatch(/^.*authorization: Bea\\u009brer \[redacted\]$/im);
+  expect(stderr).toMatch(/^< 500 Server \\u009bError$/m);
+  expect(stderr).toMatch(/^< x-evil: a\\u009b31mb$/m);
+  expect(stderr).toContain(`-H "x-req: v\\u009b31mq"`);
+  expect(stderr).not.toMatch(/[\x80-\x9f]/);
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### Problem

- The HTTP client's verbose trace (`fetch(url, { verbose: true | "curl" })`, `BUN_CONFIG_VERBOSE_FETCH`, `bun install --verbose`) writes the request URL, every request and response header name and value, and the response status text to stderr byte for byte: `print_request` in `src/http/lib.rs:1439-1459` and the `Display` impls for `Header`, `HeaderCurlFormatter`, `RequestCurlFormatter` and `Response` in `src/picohttp/lib.rs`.
- Those bytes are chosen by the peer or by a dependency:
  - HTTP/1.1 header values and the reason phrase may contain HT and any byte >= 0x80 (picohttpparser only rejects the other C0 bytes and DEL), which includes the UTF-8 encoding of the C1 controls; HPACK/QPACK values on h2/h3 may contain anything except NUL, CR and LF (`is_malformed_response_value`), so ESC gets through there too.
  - `bun install` passes the tarball URL from a dependency's `package.json` / registry manifest to the trace unmodified.
- Example (released bun, `bun install --verbose` with `"dep": "http://127.0.0.1:PORT/dep-\u009b31m.tgz"`): stderr receives ` HTTP/1.1 GET http://127.0.0.1:PORT/dep-<U+009B>31m.tgz`; a 404 response with `x-evil: a<C2 9B>31mb` prints `< x-evil: a<U+009B>31mb`. U+009B is the one-byte CSI, so `<U+009B>31m` is a colour change when a terminal reads it, and CSI/OSC sequences in general can erase or repaint the lines around them.
- The install commands' own output for the same strings is being escaped in #38631 (and #38525, #38536, #38557, #38615 for other commands); this PR covers the HTTP trace those strings also flow through.

### Fix

- Adds `bun_core::fmt::escape_control_chars` / `EscapeControlChars` (the same hunk as #38631, #38525 and #38615, so whichever lands first the others merge cleanly) and prints every peer- or dependency-supplied field of the trace through it: the request URL, header names and values in both the `>`/`<` lines and the `curl` line, the redacted `Authorization` scheme, and the response status text. `Headers` (used to build the WebSocket upgrade request) and the method (a `Method` enum name) are untouched.
- Escaping happens inside the `Display` impls rather than around them, because those impls also emit bun's own ANSI colour codes when stderr is a TTY; only the data is escaped (checked by hand with `FORCE_COLOR=1`).
- The request line keeps its secret redaction and wraps it: `EscapeControlChars(redacted_npm_url(url))`, so redaction runs on the real bytes and escaping on the result. For that to be sound `RedactedNpmUrlFormatter` now writes its runs through `BStr` instead of `write_bytes` (`from_utf8_unchecked`): `bun install` hands the trace whatever bytes the `package.json` contained, and a Latin-1 file gets bytes that are not UTF-8 (verified: a dependency URL containing `82 41 9B 41` reaches `print_request` as-is). Runs only ever split at ASCII bytes, so valid UTF-8 renders exactly as before; invalid sequences now render as U+FFFD, which is how the package manager's own error lines already print them.
- Why this is the right output: the trace exists to show what went over the wire, so the bytes are spelled out (`\u009b`, `\x1b`, `\r`) rather than dropped, matching the convention the sibling PRs establish for the rest of the install output. The request body in the `curl` line is already a JSON string literal (C0 controls escaped) and is the caller's own data, so it is left alone.
- Verified with:
  - `test/js/web/fetch/fetch.test.ts` "verbose fetch logging escapes control characters coming from the peer": raw TCP server sends a reason phrase and a header value containing U+009B, the client sends `x-req` and `Authorization` values containing it, `verbose: "curl"`. Covers the `>` header lines, the redacted `Authorization` branch, the `curl` line and the `<` status and header lines. Fails on the released binary (the raw U+009B is printed in all five places), passes with this branch.
  - `test/cli/install/bun-install.test.ts` "--verbose escapes control characters in the tarball URL and response headers it traces": `package.json` with one tarball URL containing U+009B and one containing raw non-UTF-8 bytes, against a local 404 server. Covers the request-line URL path (which `fetch()` cannot reach, since it percent-encodes the path) and the non-UTF-8 rendering. Fails on the released binary, passes with this branch.
  - `bun bd test test/regression/issue/12042.test.ts` (curl trace body) and `test/cli/install/redacted-config-logs.test.ts` (URL redaction) still pass; the remaining failures when running the two edited files in full here are `localhost`/internet-dependent tests that fail identically with the released binary.

### Background

- The verbose trace is printed from the HTTP client thread by `print_request` (HTTP/1.1, h2 and h3 all call it) and `print_response` in `src/http/lib.rs`; the line formatting for headers and the response lives in the `Display` impls of the `bun_picohttp` crate. `HTTPVerboseLevel::Headers` prints the `>`/`<` lines, `HTTPVerboseLevel::Curl` additionally prints a copy-pasteable `curl` command first; `bun install --verbose` uses `Headers`.
- C1 controls are U+0080..U+009F. Terminals treat several of them as one-byte forms of two-byte ESC sequences (U+009B = `ESC [`, CSI; U+009D = `ESC ]`, OSC), and in UTF-8 mode xterm and others recognise them when they arrive UTF-8 encoded (`C2 9B`), which is the form that passes through an HTTP/1.1 parser.
- `bstr::BStr`'s `Display` writes bytes as UTF-8 and substitutes U+FFFD for invalid sequences, which is what the rest of the trace already used; `escape_control_chars(bytes)` builds on it, and `EscapeControlChars<T: Display>` escapes whatever the inner `Display` writes, so it must only ever be fed valid `&str` chunks (the reason for the `RedactedNpmUrlFormatter` change).
- `redacted_npm_url` replaces URL passwords, UUIDs and `npm_` tokens with `***`; it is the existing formatter for printing registry/tarball URLs.
