### PR TITLE
test(css): run the selector-list recovery cases through one child process

### DIFF
--- a/test/js/bun/css/selector-list-error-recovery.test.ts
+++ b/test/js/bun/css/selector-list-error-recovery.test.ts
@@ -20,20 +20,76 @@ const { minifyTest } = cssInternals;
 //    selectors at all parsed as a valid empty selector. That let
 //    `:nth-child(2n of)`, ` { color: red }`, and `.a, , .b { }` through too.
 
-// An unfixed build asserts on the empty of-list in the serializer, so run each
-// input through a child process to keep the test runner alive either way.
-// Returns the single line the child prints, `ok: <minified>` or `error: <message>`,
-// plus stderr filtered to real diagnostics so a crash shows up in the failure diff.
-async function minifyInChild(css: string): Promise<{ stdout: string; stderr: string; exitCode: number | null }> {
+function rejected(message: string) {
+  return `error: parsing failed: ${message}`;
+}
+
+function minified(output: string) {
+  return `ok: ${output}`;
+}
+
+const cases: [css: string, expected: string][] = [
+  // --- :nth-child(An+B of <selectors>) ---
+
+  // An of-list made only of invalid selectors invalidates the rule: a
+  // pseudo-element, a lexically invalid selector, a bad-string token.
+  ["a:nth-child(2n of ::before) { color: red }", rejected("Invalid selector. Token is not allowed in this state")],
+  ["a:nth-child(2n of %bad) { color: red }", rejected("Invalid selector. Empty selector is not allowed")],
+  [
+    'div:nth-child(2n of [q="x\n]) { color: red }',
+    rejected("Invalid selector. Invalid value in attribute selector: x"),
+  ],
+  // Non-forgiving means one invalid selector invalidates the whole list, even
+  // when another selector in it is valid on its own.
+  [
+    "a:nth-child(2n of .valid, ::before) { color: red }",
+    rejected("Invalid selector. Token is not allowed in this state"),
+  ],
+  // :nth-last-child takes the same of-list grammar.
+  ["a:nth-last-child(2n of ::before) { color: red }", rejected("Invalid selector. Token is not allowed in this state")],
+  // An empty of-list, or an empty selector before a comma in one.
+  ["a:nth-child(2n of) { color: red }", rejected("Invalid selector. Empty selector is not allowed")],
+  ["a:nth-child(2n of , .x) { color: red }", rejected("Invalid selector. Empty selector is not allowed")],
+  // Valid of-lists still parse and minify.
+  [":nth-child(even of li.important) {width: 20px}", minified(":nth-child(2n of li.important){width:20px}")],
+  [
+    ":nth-last-child(2n of li.important, .other) {width: 20px}",
+    minified(":nth-last-child(2n of li.important, .other){width:20px}"),
+  ],
+  ["a:nth-child(2n of *) { color: red }", minified("a:nth-child(2n of *){color:red}")],
+
+  // --- :has(<relative-selector-list>) ---
+
+  // A list made only of a lexically invalid selector, or of a lone comma,
+  // invalidates the rule.
+  ["a:has(%bad) { color: red }", rejected("Invalid selector. Empty selector is not allowed")],
+  ["a:has(,) { color: red }", rejected("Unexpected end of input")],
+  // A valid selector does not rescue a list with an invalid one.
+  ["a:has(> .x, %bad) { color: red }", rejected("Invalid selector. Empty selector is not allowed")],
+  // Valid lists still parse and minify.
+  ["a:has(.x) { color: red }", minified("a:has(.x){color:red}")],
+  ["a:has(> .x, ~ .y) { color: red }", minified("a:has(>.x,~.y){color:red}")],
+];
+
+// An unfixed build asserts on the empty of-list in the serializer, so the inputs
+// run in a child process to keep the test runner alive either way. One child for
+// all of them: a debug build takes a couple of seconds to start, so a child per
+// input does not fit in the per-test timeout. The child prints a `[css, result]`
+// line per input, so if it crashes the diff still shows how far it got.
+test("of-lists and :has() lists are parsed non-forgivingly", async () => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
       "-e",
       `const { minifyTest } = require("bun:internal-for-testing").cssInternals;
-try {
-  console.log("ok: " + minifyTest(${JSON.stringify(css)}, ""));
-} catch (e) {
-  console.log("error: " + e.message);
+for (const css of ${JSON.stringify(cases.map(([css]) => css))}) {
+  let result;
+  try {
+    result = "ok: " + minifyTest(css, "");
+  } catch (e) {
+    result = "error: " + e.message;
+  }
+  console.log(JSON.stringify([css, result]));
 }`,
     ],
     env: bunEnv,
@@ -41,100 +97,12 @@ try {
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  return {
-    stdout: stdout.trim(),
-    stderr: stderr.includes("error") || stderr.includes("panic") ? stderr.trim() : "",
-    exitCode,
-  };
-}
+  const results = stdout
+    .split("\n")
+    .filter(line => line !== "")
+    .map(line => JSON.parse(line));
 
-function rejected(message: string) {
-  return { stdout: `error: parsing failed: ${message}`, stderr: "", exitCode: 0 };
-}
-
-function minified(output: string) {
-  return { stdout: `ok: ${output}`, stderr: "", exitCode: 0 };
-}
-
-// --- :nth-child(An+B of <selectors>) ---
-
-test.concurrent("an of-list made only of a pseudo-element invalidates the rule", async () => {
-  expect(await minifyInChild("a:nth-child(2n of ::before) { color: red }")).toEqual(
-    rejected("Invalid selector. Token is not allowed in this state"),
-  );
-});
-
-test.concurrent("an of-list made only of a lexically invalid selector invalidates the rule", async () => {
-  expect(await minifyInChild("a:nth-child(2n of %bad) { color: red }")).toEqual(
-    rejected("Invalid selector. Empty selector is not allowed"),
-  );
-});
-
-test.concurrent("an of-list made only of a bad-string token invalidates the rule", async () => {
-  expect(await minifyInChild('div:nth-child(2n of [q="x\n]) { color: red }')).toEqual(
-    rejected("Invalid selector. Invalid value in attribute selector: x"),
-  );
-});
-
-// Non-forgiving means one invalid selector invalidates the whole list, even when
-// another selector in it is valid on its own.
-test.concurrent("a valid selector does not rescue an of-list with an invalid one", async () => {
-  expect(await minifyInChild("a:nth-child(2n of .valid, ::before) { color: red }")).toEqual(
-    rejected("Invalid selector. Token is not allowed in this state"),
-  );
-});
-
-test.concurrent(":nth-last-child takes the same of-list grammar", async () => {
-  expect(await minifyInChild("a:nth-last-child(2n of ::before) { color: red }")).toEqual(
-    rejected("Invalid selector. Token is not allowed in this state"),
-  );
-});
-
-test.concurrent("an empty of-list invalidates the rule", async () => {
-  expect(await minifyInChild("a:nth-child(2n of) { color: red }")).toEqual(
-    rejected("Invalid selector. Empty selector is not allowed"),
-  );
-});
-
-test.concurrent("an empty selector before a comma invalidates the of-list", async () => {
-  expect(await minifyInChild("a:nth-child(2n of , .x) { color: red }")).toEqual(
-    rejected("Invalid selector. Empty selector is not allowed"),
-  );
-});
-
-test.concurrent("valid of-lists still parse and minify", async () => {
-  expect(await minifyInChild(":nth-child(even of li.important) {width: 20px}")).toEqual(
-    minified(":nth-child(2n of li.important){width:20px}"),
-  );
-  expect(await minifyInChild(":nth-last-child(2n of li.important, .other) {width: 20px}")).toEqual(
-    minified(":nth-last-child(2n of li.important, .other){width:20px}"),
-  );
-  expect(await minifyInChild("a:nth-child(2n of *) { color: red }")).toEqual(
-    minified("a:nth-child(2n of *){color:red}"),
-  );
-});
-
-// --- :has(<relative-selector-list>) ---
-
-test.concurrent("a :has() list made only of a lexically invalid selector invalidates the rule", async () => {
-  expect(await minifyInChild("a:has(%bad) { color: red }")).toEqual(
-    rejected("Invalid selector. Empty selector is not allowed"),
-  );
-});
-
-test.concurrent("a lone comma in :has() invalidates the rule", async () => {
-  expect(await minifyInChild("a:has(,) { color: red }")).toEqual(rejected("Unexpected end of input"));
-});
-
-test.concurrent("a valid selector does not rescue a :has() list with an invalid one", async () => {
-  expect(await minifyInChild("a:has(> .x, %bad) { color: red }")).toEqual(
-    rejected("Invalid selector. Empty selector is not allowed"),
-  );
-});
-
-test.concurrent("valid :has() lists still parse and minify", async () => {
-  expect(await minifyInChild("a:has(.x) { color: red }")).toEqual(minified("a:has(.x){color:red}"));
-  expect(await minifyInChild("a:has(> .x, ~ .y) { color: red }")).toEqual(minified("a:has(>.x,~.y){color:red}"));
+  expect({ results, stderr, exitCode }).toEqual({ results: cases, stderr: "", exitCode: 0 });
 });
 
 // --- empty selectors ---


### PR DESCRIPTION
### Problem
- `bun bd test test/js/bun/css/selector-list-error-recovery.test.ts` fails on a debug+ASAN build with `this test timed out after 5000ms`: 6 of 14 tests on an 8 core machine (file takes 20s), and on 16 cores still the two tests that await several children in a row (`valid of-lists still parse and minify`, `valid :has() lists still parse and minify`).
- Cause: every case goes through `minifyInChild`, which spawns its own `bun -e` child, and all twelve tests are `test.concurrent`, so 15 debug children start at once against the same 5s per-test clock. One child costs about 2s of CPU on a debug+ASAN build, so they starve each other.
- The CSS code under test is fine; this is test structure only. CI is not affected because the CI runner passes a much larger `--timeout`, so this bites local debug runs of the file.

### Fix
- Move the inputs and expected lines into a `cases` table and feed all of them to one child process, which prints a `[css, result]` JSON line per input. The test compares the parsed lines, stderr and exit code against the table in a single `toEqual`. Same shape as the neighboring `angle-serialization-hang.test.ts` and `shell/brace.test.ts`.
- Why one child rather than splitting or `Promise.all`: the cost is the number of simultaneous debug children, not how they are grouped into tests. Single-spawn tests were already timing out on 8 cores, so any layout with one child per input stays CPU bound. One child also keeps the reason the file used children in the first place (an unfixed build trips a serializer assertion on the empty of-list, which would take the test runner down).
- Why one `toEqual` over lines + stderr + exit code: if the child crashes, the failure shows the panic text, the exit code and the inputs that had completed, so the crashing input is visible (verified by making the child abort on one input; the diff stops right before it). A wrong expectation shows the input next to the divergent result.
- stderr is now asserted to be exactly empty rather than filtered for `error`/`panic`; the two neighboring tests above already assert that on a debug child, and it held here under the CI ASAN lane environment (`detect_leaks=1`, `BUN_DESTRUCT_VM_ON_EXIT=1`, `BUN_JSC_validateExceptionChecks=1`).
- Every input and expected output from the previous version is carried over unchanged; the two in-process empty-selector tests at the bottom are untouched.
- Verified: `bun bd test test/js/bun/css/selector-list-error-recovery.test.ts` passes, child test 2.2 to 2.5s, whole file about 5.5s on the same debug+ASAN build that failed before (3 runs under the CI ASAN env: 3.4s, 2.8s, 2.4s for the child test). `USE_SYSTEM_BUN=1 bun test` on the same file passes in 44ms.

### Background
- `bun bd` builds a debug binary with ASAN; starting one and loading `bun:internal-for-testing` takes about 2s of CPU on it, versus a few ms on a release build, which is why a spawn-per-case layout only shows up as a problem on debug builds.
- `test.concurrent` starts every such test at the same time, and each test's default 5s timeout starts when the test starts, so concurrent tests that all spawn children share one wall-clock budget.
- `cssInternals.minifyTest(css, "")` (from `bun:internal-for-testing`) minifies a stylesheet in-process and throws on a parse error; the child turns each call into an `ok: <minified>` or `error: <message>` string so that both outcomes can sit in the same table.

<details>
<summary>Before (unmodified file, debug+ASAN, 8 cores, warm cache)</summary>

```
(pass) an of-list made only of a pseudo-element invalidates the rule [3931.19ms]
(pass) an of-list made only of a bad-string token invalidates the rule [4821.15ms]
(pass) an of-list made only of a lexically invalid selector invalidates the rule [4899.83ms]
(fail) a valid selector does not rescue an of-list with an invalid one [5028.78ms]
(fail) :nth-last-child takes the same of-list grammar [5014.57ms]
(pass) an empty of-list invalidates the rule [5001.75ms]
(fail) an empty selector before a comma invalidates the of-list [5000.96ms]
(fail) valid of-lists still parse and minify [5000.23ms]
(pass) a :has() list made only of a lexically invalid selector invalidates the rule [4875.44ms]
(fail) a lone comma in :has() invalidates the rule [5000.23ms]
(pass) a valid selector does not rescue a :has() list with an invalid one [3475.24ms]
(fail) valid :has() lists still parse and minify [5007.10ms]
(pass) an empty selector in a style rule prelude is rejected [24.48ms]
(pass) a forgiving list drops an empty selector instead of keeping it [6.57ms]
 8 pass
 6 fail
Ran 14 tests across 1 file. [20.21s]
```

A single child in isolation on the same build: `real 2.07s / 2.64s / 2.47s` over three runs, about 1.8s user CPU each.

</details>

<details>
<summary>After (same build)</summary>

```
(pass) of-lists and :has() lists are parsed non-forgivingly [2249.44ms]
(pass) an empty selector in a style rule prelude is rejected [13.28ms]
(pass) a forgiving list drops an empty selector instead of keeping it [6.03ms]
 3 pass
 0 fail
Ran 3 tests across 1 file. [5.52s]
```

</details>
