### PR TITLE
bun build: reject --sourcemap=linked without --outdir or --outfile

### DIFF
--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -175,6 +175,17 @@ impl BuildCommand {
             && outfile.is_empty()
             && ctx.bundler_options.outdir.is_empty();
 
+        // Without this, the bundle and its .map are written next to the entry
+        // point, overwriting a .js entry.
+        if output_to_stdout
+            && this_transpiler.options.source_map == options::SourceMapOption::Linked
+        {
+            bun_core::pretty_errorln!(
+                "<r><red>error<r><d>:<r> cannot use a linked source map without --outdir or --outfile"
+            );
+            Global::exit(1);
+        }
+
         this_transpiler.options.supports_multiple_outputs =
             !(output_to_stdout || !outfile.is_empty());
 

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -351,6 +351,82 @@ test("you can use --outfile=... and --sourcemap", async () => {
   `);
 });
 
+describe.concurrent("--sourcemap without --outdir or --outfile", () => {
+  // A linked map used to be written next to the entry point along with the
+  // bundle, which replaced `entry.js` itself and put a stray `entry.js` next
+  // to `entry.ts`.
+  const src = {
+    "dep.js": `module.exports = 1;\n`,
+    "entry.js": `const dep = require("./dep.js");\nmodule.exports = dep;\n`,
+    "entry.ts": `const dep: number = require("./dep.js");\nexport default dep;\n`,
+  };
+  const fixture = Object.fromEntries(Object.entries(src).map(([name, contents]) => [`src/${name}`, contents]));
+
+  function srcTree(dir: string) {
+    return Object.fromEntries(
+      fs
+        .readdirSync(join(dir, "src"))
+        .sort()
+        .map(name => [name, fs.readFileSync(join(dir, "src", name), "utf8")]),
+    );
+  }
+
+  async function build(dir: string, args: string[]) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", ...args],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  const linked = "error: cannot use a linked source map without --outdir or --outfile\n";
+  const external = "error: cannot use an external source map without --outdir\n";
+
+  test.each([
+    ["src/entry.js --sourcemap", linked],
+    ["src/entry.js --sourcemap=linked", linked],
+    ["src/entry.ts --sourcemap", linked],
+    ["--no-bundle src/entry.js --sourcemap", linked],
+    ["src/entry.js --sourcemap=external", external],
+  ])("bun build %s fails instead of writing next to the entry point", async (args, error) => {
+    using dir = tempDir("build-sourcemap-no-output", fixture);
+
+    expect(await build(String(dir), args.split(" "))).toEqual({ stdout: "", stderr: error, exitCode: 1 });
+
+    expect(srcTree(String(dir))).toEqual(src);
+    expect(fs.readdirSync(String(dir))).toEqual(["src"]);
+  });
+
+  test("--sourcemap=inline prints the bundle to stdout", async () => {
+    using dir = tempDir("build-sourcemap-inline-stdout", fixture);
+
+    const { stdout, stderr, exitCode } = await build(String(dir), ["src/entry.js", "--sourcemap=inline"]);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("module.exports = 1;");
+    expect(stdout).toContain("//# sourceMappingURL=data:application/json;base64,");
+    expect(exitCode).toBe(0);
+
+    expect(srcTree(String(dir))).toEqual(src);
+    expect(fs.readdirSync(String(dir))).toEqual(["src"]);
+  });
+
+  test("--sourcemap with --outdir writes the bundle and its map there", async () => {
+    using dir = tempDir("build-sourcemap-outdir", fixture);
+
+    const { stdout, stderr, exitCode } = await build(String(dir), ["src/entry.js", "--sourcemap", "--outdir=dist"]);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("entry.js.map");
+    expect(exitCode).toBe(0);
+
+    expect(fs.readdirSync(join(String(dir), "dist")).sort()).toEqual(["entry.js", "entry.js.map"]);
+    expect(srcTree(String(dir))).toEqual(src);
+  });
+});
+
 test("some log cases", async () => {
   const tmpdir = tmpdirSync();
   const inputFile = path.join(tmpdir, "input.js");


### PR DESCRIPTION
### Problem
- `bun build src/entry.js --sourcemap` (or `--sourcemap=linked`) with neither `--outdir` nor `--outfile` does not print the bundle to stdout. It writes the bundle over `src/entry.js`, writes `src/entry.js.map` next to it, prints the usual summary and exits 0. With a `.ts` entry it leaves a stray `entry.js` and `entry.js.map` next to the source.
- Cause: a linked map is a second output file. The stdout path in `BuildCommand::exec` (src/runtime/cli/build_command.rs, `output_files.len() == 1` in the `'dump` block) is skipped, and the writer below it has no output directory, so it falls back to `dirname(entry_points[0])` and writes both files there.
- `--sourcemap=external` in the same situation is already rejected up front (`cannot use an external source map without --outdir`, same file); `--sourcemap=inline` prints to stdout as expected. Linked was the gap.

### Fix
- Reject `--sourcemap=linked` when the build would otherwise print to stdout (no `--outdir`, no `--outfile`, not `--compile`), next to the existing external check: `error: cannot use a linked source map without --outdir or --outfile`.
- Why an error rather than printing the bundle and dropping the map: the flag asks for a `.map` file and there is nowhere to write one. This is what the docs for `linked` already say ("Requires `--outdir` to be set"), what the external check already does, and what esbuild and rollup do when writing to stdout (esbuild: "Cannot use an external source map without an output path"). `--sourcemap=inline` remains the way to get a map on stdout.
- The check keys off `output_to_stdout`, so it applies to `--no-bundle` as well, where the flag is currently a silent no-op in this situation; #38651 adds the same error with the same message inside its transform-mode block, so whichever of the two lands second can drop its copy. `--compile` is unaffected (`output_to_stdout` is false; the map goes next to the executable), and `Bun.build()` is unaffected (without `outdir` it returns the map as an artifact, which is valid there).
- Not changed here: `--outfile x.js --sourcemap` still writes next to the entry instead of into the outfile's directory; that is #30884, which also covers `--compile --target=browser --sourcemap` on an HTML entry without `--outdir` (the default outfile takes the same path). The `dirname(entry)` fallback in the writer is left in place for the same reason.
- Tests: `--sourcemap without --outdir or --outfile` in test/bundler/cli.test.ts. Bare `--sourcemap` and `--sourcemap=linked` on a `.js` entry, `--sourcemap` on a `.ts` entry, and `--no-bundle --sourcemap` all exit 1 with exactly the new error on stderr and nothing on stdout, and the source directory is byte-for-byte what the fixture created (the four rows that fail on the released 1.4.0, where they exit 0 and modify the directory); `--sourcemap=external` pins the existing error; `--sourcemap=inline` still prints the bundle with a `data:` map comment and writes nothing; `--sourcemap --outdir=dist` still writes `entry.js` and `entry.js.map` into `dist`. The `--outfile` case is the existing `you can use --outfile=... and --sourcemap` test in the same file; `--compile --sourcemap` without `--outfile` is the existing `does not crash` test in test/bundler/bundler_compile.test.ts.
- Also run with the change: the rest of test/bundler/cli.test.ts, the `sourcemaps` tests in test/bundler/standalone.test.ts, test/bundler/bundler_promiseall_deadcode.test.ts.

### Background
- `bun build` with a single entry point and no `--outdir`/`--outfile` prints the one output file to stdout. Anything that produces more than one output file (assets, `--bytecode`, HTML entries) is rejected by the bundler with `cannot write multiple output files without an output directory`; that check does not count source maps, because `--outfile` is single-output from its point of view but still gets a `.map` next to it, so the CLI has to check source maps itself, as it already did for `external`.
- `--sourcemap` with no value means `linked`: the bundle gets a `//# sourceMappingURL=<name>.map` comment and the map is a separate file. `inline` embeds the map in the bundle as a `data:` URL; `external` writes the separate file without the comment.
