### PR TITLE
bun-types: declare Subprocess.connected

### DIFF
--- a/docs/runtime/child-process.mdx
+++ b/docs/runtime/child-process.mdx
@@ -304,6 +304,14 @@ The `serialization` option controls the underlying communication format between 
 - `advanced`: (default) Messages are serialized using the JSC `serialize` API, which supports cloning [everything `structuredClone` supports](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm). This does not support transferring ownership of objects.
 - `json`: Messages are serialized using `JSON.stringify` and `JSON.parse`, which does not support as many object types as `advanced` does.
 
+`childProc.connected` reports whether the IPC channel is still open. It is `true` from the time the process is spawned with `ipc` until either side disconnects or the child exits, and always `false` for a process spawned without `ipc`. Calling `.send()` once it is `false` throws `ERR_IPC_CHANNEL_CLOSED`, so check it before sending to a child that may have gone away:
+
+```ts
+if (childProc.connected) {
+  childProc.send("still there?");
+}
+```
+
 To disconnect the IPC channel from the parent process, call:
 
 ```ts
@@ -580,6 +588,7 @@ interface Subprocess extends AsyncDisposable {
   readonly exitCode: number | null;
   readonly signalCode: NodeJS.Signals | null;
   readonly killed: boolean;
+  readonly connected: boolean;
 
   kill(exitCode?: number | NodeJS.Signals): void;
   ref(): void;

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7519,6 +7519,31 @@ declare module "bun" {
     readonly killed: boolean;
 
     /**
+     * Whether the IPC channel to the subprocess is open.
+     *
+     * `true` from the moment a process is spawned with the `ipc` option until the
+     * channel closes. It becomes `false` synchronously when {@link disconnect} is
+     * called (even if queued messages are still being flushed), and once the
+     * subprocess has called `process.disconnect()` or exited. It is always `false`
+     * for a process spawned without the `ipc` option.
+     *
+     * Once this is `false`, {@link send} fails with `ERR_IPC_CHANNEL_CLOSED`. To be
+     * notified when the channel closes, pass an `onDisconnect` callback to {@link Bun.spawn}.
+     *
+     * This is the same value `child_process.ChildProcess` exposes as `subprocess.connected`.
+     *
+     * @example
+     * ```ts
+     * const child = Bun.spawn(["bun", "child.ts"], { ipc(message) {} });
+     * child.connected; // true
+     *
+     * child.disconnect();
+     * child.connected; // false
+     * ```
+     */
+    readonly connected: boolean;
+
+    /**
      * Kill the process
      * @param exitCode Exit code or signal to send to the process
      */

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -400,6 +400,35 @@ describe("@types/bun integration test", () => {
     });
   });
 
+  // Also runs on debug builds, where the in-process typeTest cases (which cover the whole
+  // fixture directory) are skipped: checks fixture/spawn.ts alone against the packed bun-types.
+  describe("Bun.spawn", () => {
+    test("fixture/spawn.ts type-checks", async () => {
+      const checkDir = join(TEMP_DIR, "spawn-fixture-check");
+      const tsconfig = structuredClone(sourceTsconfig);
+      tsconfig.files = [join(BASE_FIXTURE_DIR, "spawn.ts")];
+      tsconfig.compilerOptions.typeRoots = [join(BASE_FIXTURE_DIR, "node_modules", "@types")];
+      await mkdir(checkDir, { recursive: true });
+      await makeTree(checkDir, {
+        "tsconfig.json": JSON.stringify(tsconfig, null, 2),
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), join(BASE_FIXTURE_DIR, "node_modules", "typescript", "bin", "tsc"), "-p", "."],
+        env: bunEnv,
+        cwd: checkDir,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr.trim()).toBe("");
+      expect(stdout.trim()).toBe("");
+      expect(exitCode).toBe(0);
+    });
+  });
+
   describe("Test Globals", () => {
     const code = `
       const test_shouldBeAFunction: Function = test;

--- a/test/integration/bun-types/fixture/spawn.ts
+++ b/test/integration/bun-types/fixture/spawn.ts
@@ -127,6 +127,26 @@ function depromise<T>(_promise: Promise<T>): T {
 }
 
 {
+  const proc = Bun.spawn(["bun", "child.ts"], {
+    ipc(message, subprocess) {
+      tsd.expectType(subprocess.connected).is<boolean>();
+    },
+  });
+
+  tsd.expectType(proc.connected).is<boolean>();
+  if (proc.connected) proc.disconnect();
+
+  // @ts-expect-error connected is a read-only getter
+  proc.connected = false;
+}
+
+{
+  // connected exists whether or not the process was spawned with `ipc` (it is false without it).
+  const proc = Bun.spawn(["echo", "hello"]);
+  tsd.expectType(proc.connected).is<boolean>();
+}
+
+{
   const proc = Bun.spawn(["echo", "hello"], {
     stdio: ["pipe", "pipe", "pipe"],
   });


### PR DESCRIPTION
### Problem

- `Bun.spawn(cmd, { ipc() {} }).connected` fails to type-check: `error TS2339: Property 'connected' does not exist on type 'Subprocess<"ignore", "pipe", "inherit">'`.
- The property exists at runtime: `src/runtime/api/BunObject.classes.ts:103` puts a `connected` getter on the Subprocess prototype, implemented by `get_connected` in `src/runtime/api/bun/subprocess.rs:860`, and `node:child_process` implements `ChildProcess#connected` by reading it (`src/js/node/child_process.ts:1343`).
- `interface Subprocess` in `packages/bun-types/bun.d.ts` never declared it, so TypeScript users have to cast to reach it.

### Fix

- Declares `readonly connected: boolean` on `interface Subprocess`, with JSDoc describing when it is true and false.
- The declaration mirrors the runtime: the getter returns a plain boolean (`true` while the IPC channel is open, `false` after `disconnect()`, after the child disconnected or exited, and always `false` without the `ipc` option), and it has no setter. Every statement in the JSDoc and the docs paragraph was checked by running it, see the transcript below; the `send()` claim comes from `do_send` in `src/runtime/ipc_host.rs:117`, which gates on the same `is_connected()` predicate as the getter and throws `ERR_IPC_CHANNEL_CLOSED` when it is false.
- Documents the property in `docs/runtime/child-process.mdx` (IPC section and the Reference block).
- Test: `test/integration/bun-types/fixture/spawn.ts` asserts `proc.connected` is a `boolean` on a process spawned with and without `ipc`, on the `ipc` callback's subprocess argument, and that assigning to it is an error. `test/integration/bun-types/bun-types.test.ts` gets a `Bun.spawn > fixture/spawn.ts type-checks` case that runs `tsc` over that fixture alone; it fails without the `bun.d.ts` change (4 x TS2339, on both release and debug builds) and passes with it.
- Verified: `bun bd test test/integration/bun-types/bun-types.test.ts` (4 pass, 12 skipped as debug-only skips), and the same file under a release build, where the in-process cases also run (16 pass, including the `lib.dom.d.ts` variant and tsgo).
- Not touched: the runtime `Subprocess.prototype` also has an undeclared `writable` getter (alias of `stdin`, returning a `FileSink`). It has been left out of bun-types since the package's first commit, presumably because it is not a `WritableStream`, so this PR leaves it alone. `send()`'s signature is being extended separately in #38662; this PR does not touch it.

### Background

- `Bun.spawn` with the `ipc` option opens a message channel (a socket pair) between the parent and a child `bun`/`node` process. `subprocess.send()` writes to it, the `ipc` callback receives from it, and either side can close it with `disconnect()`; it also closes when the child exits. `connected` is the parent's view of whether that channel is still open.
- `packages/bun-types` is the published `bun-types` package; `interface Subprocess` in `bun.d.ts` is the type of the object `Bun.spawn` returns, so a runtime property missing from it is invisible to TypeScript users.
- `test/integration/bun-types/` packs `bun-types` and type-checks the `fixture/` directory against it. Those in-process checks are skipped on debug builds (they drive the TypeScript language service and are very slow there), which is why this PR adds a case that spawns `tsc` on the one fixture file instead, following the existing `Bun.mmap` case in the same file.

<details>
<summary>Runtime behavior the declaration and docs describe (release build)</summary>

```ts
const noIpc = Bun.spawn([process.execPath, "-e", "0"]);
console.log("no ipc:", noIpc.connected, typeof noIpc.connected);

const p = Bun.spawn([process.execPath, "-e", "process.on('disconnect', () => process.exit(0)); setInterval(() => {}, 1000)"], { ipc() {} });
console.log("connected:", p.connected);
p.disconnect();
console.log("connected after disconnect():", p.connected);
try { p.send("x"); } catch (e) { console.log("send after disconnect:", e.code, "-", e.message); }
await p.exited;
console.log("connected after exit:", p.connected);
```

```
no ipc: false boolean
connected: true
connected after disconnect(): false
send after disconnect: ERR_IPC_CHANNEL_CLOSED - Subprocess.send() can only be used if an IPC channel is open.
connected after exit: false
```

A child that calls `process.disconnect()` itself also flips the parent's `connected` to `false` (observed after `onDisconnect` fired).

</details>

<details>
<summary>Failure without the bun.d.ts change</summary>

```
(fail) @types/bun integration test > Bun.spawn > fixture/spawn.ts type-checks
../base-fixture/spawn.ts(132,33): error TS2339: Property 'connected' does not exist on type 'Subprocess<"ignore", "pipe", "inherit">'.
../base-fixture/spawn.ts(136,23): error TS2339: Property 'connected' does not exist on type 'Subprocess<"ignore", "pipe", "inherit">'.
../base-fixture/spawn.ts(137,12): error TS2339: Property 'connected' does not exist on type 'Subprocess<"ignore", "pipe", "inherit">'.
../base-fixture/spawn.ts(146,23): error TS2339: Property 'connected' does not exist on type 'Subprocess<"ignore", "pipe", "inherit">'.
```

</details>
