### PR TITLE
cli: make `bun run -e` / `bun run --print` evaluate the script

### DIFF
--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -1451,7 +1451,12 @@ pub mod command {
             }
         }
 
-        if tag == Tag::AutoCommand && !ctx.runtime_options.eval.script.is_empty() {
+        if !ctx.runtime_options.eval.script.is_empty() {
+            // `exec_eval` turns the positionals into the script's process.argv;
+            // `bun run -e code a b` must yield the same argv as `bun -e code a b`.
+            if tag == Tag::RunCommand && ctx.positionals.first().is_some_and(|p| &**p == b"run") {
+                ctx.positionals.remove(0);
+            }
             return run_command::RunCommand::exec_eval(ctx);
         }
 

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -2854,8 +2854,9 @@ impl RunCommand {
     /// Synthetic `cwd/[eval]`
     /// entry point + boot. `Arguments::parse` has already stashed the script
     /// in `ctx.runtime_options.eval.script`. Public so `Command::start` can
-    /// route the `-e`/`-p` AutoCommand path here without re-implementing the
-    /// path-buffer dance.
+    /// route `bun -e`/`-p` and `bun run -e`/`-p` here without re-implementing
+    /// the path-buffer dance. `ctx.positionals` must hold only the script's
+    /// arguments: they become `process.argv[1..]`.
     pub(crate) fn exec_eval(ctx: &mut ContextData) -> crate::Result<()> {
         // prepend positionals into the existing passthrough vec
         // (cold path, single allocation).

--- a/test/cli/run/run-eval.test.ts
+++ b/test/cli/run/run-eval.test.ts
@@ -63,6 +63,8 @@ for (const flag of ["-e", "--print"]) {
       testProcessArgv(["abc", "def"], [exe, "abc", "def"]);
       testProcessArgv(["--", "abc", "def"], [exe, "abc", "def"]);
       // testProcessArgv(["--", "abc", "--", "def"], [exe, "abc", "--", "def"]);
+      // "run" is a script argument here, not the `bun run` subcommand
+      testProcessArgv(["run"], [exe, "run"]);
     });
 
     test("process._eval", async () => {
@@ -107,6 +109,76 @@ for (const flag of ["-e", "--print"]) {
     });
   });
 }
+
+// `bun run` accepts the same -e / -p flags as `bun` (they are listed in `bun run --help`);
+// it used to parse them and then print the `bun run` usage text instead of evaluating.
+// https://github.com/oven-sh/bun/issues/23631
+describe("bun run -e / --print", () => {
+  const exe = isWindows ? bunExe().replaceAll("/", "\\") : bunExe();
+
+  async function bunRun(...args: string[]) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", ...args],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  const evalSpellings: [args: string[], stdout: string][] = [
+    [["-e", 'console.log("hello world")'], "hello world\n"],
+    [["--eval", 'console.log("hello world")'], "hello world\n"],
+    [["--eval=console.log(1 + 2)"], "3\n"],
+    [["-p", "1 + 2"], "3\n"],
+    [["--print", "1 + 2"], "3\n"],
+    [["--print=1 + 2"], "3\n"],
+    // flags that belong to `bun run` still parse alongside the script
+    [["--silent", "-p", "1 + 2"], "3\n"],
+  ];
+  for (const [args, stdout] of evalSpellings) {
+    test.concurrent(`bun run ${args.join(" ")}`, async () => {
+      expect(await bunRun(...args)).toEqual({ stdout, stderr: "", exitCode: 0 });
+    });
+  }
+
+  for (const flag of ["-e", "-p"]) {
+    const argvCode = flag === "-p" ? "JSON.stringify(process.argv)" : "console.log(JSON.stringify(process.argv))";
+    const argvCases = [
+      { extraArgs: [], argv: [exe] },
+      { extraArgs: ["abc", "def"], argv: [exe, "abc", "def"] },
+      { extraArgs: ["--", "abc", "def"], argv: [exe, "abc", "def"] },
+      // only the `run` subcommand keyword is dropped, not a script argument that happens to be "run"
+      { extraArgs: ["run", "abc"], argv: [exe, "run", "abc"] },
+    ];
+    for (const { extraArgs, argv } of argvCases) {
+      test.concurrent(`process.argv: bun run ${flag} <code> ${extraArgs.join(" ")}`, async () => {
+        const { stdout, stderr, exitCode } = await bunRun(flag, argvCode, ...extraArgs);
+        expect(stderr).toBe("");
+        expect(JSON.parse(stdout)).toEqual(argv);
+        expect(exitCode).toBe(0);
+      });
+    }
+
+    test.concurrent(`bun run ${flag}: [eval] entry point and process._eval`, async () => {
+      const expr = "JSON.stringify([import.meta.path, process._eval])";
+      const code = flag === "-p" ? expr : `console.log(${expr})`;
+      const { stdout, stderr, exitCode } = await bunRun(flag, code);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual([join(process.cwd(), "[eval]"), code]);
+      expect(exitCode).toBe(0);
+    });
+  }
+
+  test.concurrent("uncaught error exits 1 with the [eval] location", async () => {
+    const { stdout, stderr, exitCode } = await bunRun("-e", 'throw new Error("run-eval-uncaught")');
+    expect(stderr).toContain("run-eval-uncaught");
+    expect(stderr).toContain("[eval]");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+});
 
 describe("--print for cjs/esm", () => {
   test("eval result between esm imports", async () => {

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1545,7 +1545,8 @@ it("process.execArgv", async () => {
   const fixtures = [
     ["index.ts --bun -a -b -c", [], ["--bun", "-a", "-b", "-c"]],
     ["--bun index.ts index.ts", ["--bun"], ["index.ts"]],
-    ["run -e bruh -b index.ts foo -a -b -c", ["-e", "bruh", "-b"], ["foo", "-a", "-b", "-c"]],
+    // `-d` takes a value, so "bruh:1" belongs to execArgv and is not the script name.
+    ["run -d bruh:1 -b index.ts foo -a -b -c", ["-d", "bruh:1", "-b"], ["foo", "-a", "-b", "-c"]],
   ];
 
   for (const [cmd, execArgv, argv] of fixtures) {


### PR DESCRIPTION
### Problem
- `bun run -e 'console.log(1)'`, `bun run --eval ...`, `bun run -p 5` and `bun run --print=5` print the `bun run` usage text and exit 0 instead of evaluating the script. `bun -e` / `bun -p` work. Second half of #23631 (the first half, `bun --print x` dispatching to bunx, is #38578).
- `bun run --help` and docs/snippets/cli/run.mdx list `-e/--eval` and `-p/--print` as `bun run` flags, and Arguments.rs parses them into `ctx.runtime_options.eval` for RunCommand exactly as it does for AutoCommand.
- Cause: the eval dispatch in `exec_auto_or_run` (src/runtime/cli/mod.rs:1454) was `if tag == Tag::AutoCommand && !eval.script.is_empty()`. Under RunCommand the parsed script is dropped and execution falls through to `RunCommand::exec_with_cfg` with `positionals == ["run"]`, whose empty-target branch prints the usage text.
- Present since `-e` was added (the Zig `.RunCommand` arm never had the eval branch), so not a regression; reproduces on 1.3.0 and 1.4.0.

### Fix
- Dispatch to `RunCommand::exec_eval` for both tags. Before doing so, under RunCommand, drop the leading `"run"` positional: `exec_eval` prepends the positionals to `ctx.passthrough`, which becomes `process.argv[1..]`, and `run` is the subcommand keyword, not a script argument.
- Why this is right: `bun run -e code a b` now behaves exactly like `bun -e code a b` (same `[eval]` entry point, `process._eval`, `process.argv` and `process.execArgv`), which is also what `node -e code a b` does. When both `-e` and a positional are given, the code is evaluated and the positional becomes an argument, as with `bun -e` and `node -e`.
- Only one `run` is dropped, and only under RunCommand, so `bun run -e code run abc` gives `argv == [exe, "run", "abc"]` and `bun -e code run` still gives `[exe, "run"]`. This mirrors how `exec_with_cfg`, `multi_run` and `process.execArgv` already treat the keyword.
- `bun run` with no target is unchanged (still lists package.json scripts), as is the `--interactive` check above the gate, which already handled both tags.
- test/js/node/process/process.test.js: the `process.execArgv` fixture `bun run -e bruh -b <file> ...` used `-e` as an example of a value-taking flag and relied on `bun run` ignoring it (with this change it evaluates `bruh`). It now uses `-d bruh:1`, which keeps the short-flag-with-value coverage the fixture exists for and passes before and after this change. (#38577 edits the same fixture list, so one of the two will need a trivial rebase.)
- Verified:
  - test/cli/run/run-eval.test.ts: new `bun run -e / --print` block (every spelling, `process.argv` with no args / args / `--` / a literal `run` arg, `[eval]` entry point + `process._eval`, uncaught error exit code) plus a `bun -e code run` argv case. 18 new tests fail on the released 1.4.0 (usage text, exit 0) and pass with `bun bd test`.
  - `bun bd test test/js/node/process/process.test.js -t execArgv`, test/cli/install/bun-run.test.ts, test/cli/run/{run_command,as-node,multi-run,if-present}.test.ts, test/cli/bun.test.ts: pass.

### Background
- `Tag::AutoCommand` vs `Tag::RunCommand`: `which()` classifies `bun <anything>` as AutoCommand and `bun run ...` as RunCommand; both are executed by `exec_auto_or_run` in src/runtime/cli/mod.rs. They share the flag table for `-e`/`-p`, but RunCommand's argv parse keeps the `run` keyword as `positionals[0]` (and stops collecting positionals one token later), so every RunCommand consumer of positionals strips that keyword itself.
- `ctx.positionals` / `ctx.passthrough`: the positionals clap collected before it stopped, and the untouched remainder of argv. `RunCommand::exec_eval` concatenates them into `vm.argv`; `process.argv` is `[execPath, ...vm.argv]` because the synthetic `<cwd>/[eval]` main module is omitted from argv (src/runtime/node/node_process.rs).
