### PR TITLE
bundler: compute [dir] for entries whose directory does not exist on disk without re-joining the cwd

### DIFF
--- a/src/bundler/linker_context/computeChunks.rs
+++ b/src/bundler/linker_context/computeChunks.rs
@@ -651,10 +651,10 @@ pub(crate) fn compute_chunks(
                     bun_sys::O::PATH | bun_sys::O::DIRECTORY,
                     0,
                 ) else {
-                    break 'dir &*resolve_path::normalize_buf::<bun_paths::platform::Auto>(
-                        dir_path,
-                        &mut real_path_buf.0,
-                    );
+                    // The directory only exists in memory (`files:` entry, plugin-resolved
+                    // path). `relative_alloc` normalizes the path itself; `normalize_buf`
+                    // would drop the leading `/` (or `..`) and make it cwd-relative.
+                    break 'dir dir_path;
                 };
 
                 match dir_file.get_path(&mut real_path_buf) {

--- a/test/bundler/bundler_files.test.ts
+++ b/test/bundler/bundler_files.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { tempDir } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 describe("bundler files option", () => {
   test("basic in-memory file bundling", async () => {
@@ -581,5 +581,125 @@ describe("bundler files option", () => {
 
     const output = await result.outputs[0].text();
     expect(output).toContain("injected by plugin");
+  });
+
+  // `[dir]` in the output path is the entry's directory relative to `root`. An in-memory
+  // directory cannot be opened on disk, so it must come out the same as one that exists.
+  describe.concurrent("[dir] of an entry whose directory does not exist on disk", () => {
+    function outputPaths(result: Awaited<ReturnType<typeof Bun.build>>) {
+      expect(result.logs).toBeEmpty();
+      return result.outputs.map(output => output.path).sort();
+    }
+
+    test("absolute in-memory entries inside root", async () => {
+      using dir = tempDir("bundler-files-dir-placeholder", {
+        "src/.keep": "",
+      });
+
+      const result = await Bun.build({
+        root: String(dir),
+        entrypoints: [
+          `${dir}/src/on-disk-dir.js`,
+          `${dir}/missing/entry.js`,
+          `${dir}/missing/deeply/nested/entry.js`,
+          `${dir}/missing/../src/dot-dot.js`,
+        ],
+        files: {
+          [`${dir}/src/on-disk-dir.js`]: `console.log("a");`,
+          [`${dir}/missing/entry.js`]: `console.log("b");`,
+          [`${dir}/missing/deeply/nested/entry.js`]: `console.log("c");`,
+          [`${dir}/missing/../src/dot-dot.js`]: `console.log("d");`,
+        },
+      });
+
+      expect(outputPaths(result)).toEqual([
+        "missing/deeply/nested/entry.js",
+        "missing/entry.js",
+        "src/dot-dot.js",
+        "src/on-disk-dir.js",
+      ]);
+    });
+
+    test("absolute in-memory entries outside root", async () => {
+      using dir = tempDir("bundler-files-dir-placeholder-outside", {
+        "root/.keep": "",
+        "outside-on-disk/.keep": "",
+      });
+
+      const result = await Bun.build({
+        root: `${dir}/root`,
+        entrypoints: [`${dir}/outside-on-disk/entry.js`, `${dir}/outside-missing/entry.js`],
+        files: {
+          [`${dir}/outside-on-disk/entry.js`]: `console.log("a");`,
+          [`${dir}/outside-missing/entry.js`]: `console.log("b");`,
+        },
+      });
+
+      expect(outputPaths(result)).toEqual(["_.._/outside-missing/entry.js", "_.._/outside-on-disk/entry.js"]);
+    });
+
+    test("entries resolved by an onResolve plugin", async () => {
+      using dir = tempDir("bundler-files-dir-placeholder-plugin", {
+        "src/.keep": "",
+      });
+
+      const result = await Bun.build({
+        root: String(dir),
+        entrypoints: [`${dir}/src/on-disk-dir.js`, `${dir}/virtual/entry.js`],
+        plugins: [
+          {
+            name: "virtual-entries",
+            setup(build) {
+              build.onResolve({ filter: /\.js$/ }, args => ({ path: args.path, namespace: "virtual" }));
+              build.onLoad({ filter: /./, namespace: "virtual" }, args => ({
+                contents: `console.log(${JSON.stringify(args.path)});`,
+                loader: "js",
+              }));
+            },
+          },
+        ],
+      });
+
+      expect(outputPaths(result)).toEqual(["src/on-disk-dir.js", "virtual/entry.js"]);
+    });
+
+    // Relative entry names are relative to the cwd, so this one runs in a subprocess.
+    test("relative plugin-resolved entries that leave the cwd", async () => {
+      using dir = tempDir("bundler-files-dir-placeholder-relative", {
+        "sibling-on-disk/.keep": "",
+        "cwd/build.fixture.js": `
+          const result = await Bun.build({
+            root: ".",
+            entrypoints: ["../sibling-on-disk/entry.js", "../sibling-missing/entry.js"],
+            plugins: [
+              {
+                name: "virtual-entries",
+                setup(build) {
+                  build.onResolve({ filter: /\\.js$/ }, args => ({ path: args.path, namespace: "virtual" }));
+                  build.onLoad({ filter: /./, namespace: "virtual" }, args => ({
+                    contents: "console.log(" + JSON.stringify(args.path) + ");",
+                    loader: "js",
+                  }));
+                },
+              },
+            ],
+          });
+          console.log(JSON.stringify(result.outputs.map(output => output.path).sort()));
+        `,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build.fixture.js"],
+        cwd: `${dir}/cwd`,
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual(["_.._/sibling-missing/entry.js", "_.._/sibling-on-disk/entry.js"]);
+      expect(exitCode).toBe(0);
+    });
   });
 });


### PR DESCRIPTION
### Problem

- `Bun.build()` gives an entry point whose directory does not exist on disk an output path that repeats the cwd's own components. With cwd `/tmp/app`, a `files:` entry `/tmp/app/missing/a.js` is emitted as `tmp/app/missing/a.js`; the same entry in a directory that exists (`/tmp/app/src/a.js`) is emitted as `src/a.js`.
- The same happens for an entry point an `onResolve` plugin resolves to a virtual namespace: its output path is computed from the name passed in `entrypoints`, and that directory usually does not exist either. A relative name that leaves the cwd (`../lib/a.js`) loses its `..` and is emitted as `lib/a.js` instead of `_.._/lib/a.js`.
- Cause: `src/bundler/linker_context/computeChunks.rs:654`. When `openat` of the entry's directory fails, the `[dir]` code falls back to `resolve_path::normalize_buf` before calling `relative_alloc(root_dir, dir)`. `normalize_buf` (`normalize_string_generic_tz`, `src/paths/resolve_path.rs:907`) does not write the leading separator of a POSIX absolute path, and drops the leading `..` of a relative one, so `/tmp/app/missing` becomes `tmp/app/missing`. `relative_platform_buf` (`resolve_path.rs:695`) then sees a relative path and joins it onto the cwd, giving `/tmp/app/tmp/app/missing`, and the output path is computed from that.
- The result also depends on unrelated disk state: `/src/entry.js` from the `files:` map is emitted as `src/entry.js` on a machine without a `/src` directory and as a path outside root on a machine that has one.

### Fix

- When the directory cannot be opened, pass it to `relative_alloc` unchanged instead of pre-normalizing it.
- This is correct because `relative_alloc` normalizes both arguments itself (`relative_platform_buf`): an absolute path is normalized and keeps its root, a relative one is normalized with `..` kept and then resolved against the cwd, which is the same directory the `openat` that just failed was relative to. The pre-normalization added nothing and only lost the root. A directory that does exist still goes through `openat` + `get_path` as before, so resolved paths, symlink handling and the outside-root `_.._` rewriting are unchanged; an in-memory directory now produces the same `[dir]` as an on-disk one at the same path.
- Tests: `test/bundler/bundler_files.test.ts`, describe `[dir] of an entry whose directory does not exist on disk`. Each test pairs a directory that exists with one that does not and checks both output paths: absolute `files:` entries inside root (including a `..` segment in the key, showing normalization still happens), absolute `files:` entries outside root, plugin-resolved absolute entries, and plugin-resolved relative entries that leave the cwd (a subprocess, since relative names resolve against the cwd).
  - `bun bd test test/bundler/bundler_files.test.ts`: 27 pass.
  - `USE_SYSTEM_BUN=1 bun test test/bundler/bundler_files.test.ts -t "does not exist on disk"` (1.4.0): the 4 new tests fail with the paths described above.
  - `bun bd test test/bundler/bundler_naming.test.ts test/bundler/bundler_plugin_chain.test.ts test/bundler/bundler_plugin.test.ts test/bundler/bun-build-api.test.ts test/bundler/bundler_edgecase.test.ts`: all pass.
- Relative `files:` keys are not used in the tests because a relative key still trips `Path::assert_file_path_is_absolute` on debug builds; #38650 covers that separately. #34558, #35660 and #38365 rewrite this block for other reasons (asset `[dir]` canonicalization, symlink spelling, removing `get_fd_path`) and would make the source change here moot if they land first; the tests still apply to them.

### Background

- `[dir]` is the placeholder in the `naming` templates (default entry template `[dir]/[name].[ext]`) that stands for the entry's directory relative to the build root. For a directory outside the root the relative path starts with `..`, which `PathTemplate::print` rewrites to `_.._` so the output cannot escape the outdir.
- The build root (`root_dir`) is the `root` option, or for a build whose entry points all come from `files:` the cwd; `JSBundler` canonicalizes it with `get_fd_path`.
- `files:` is the `Bun.build` option that supplies in-memory sources. Its keys are used verbatim as source paths, so a key's directory need not exist on disk. A plugin-resolved entry point keeps the name given in `entrypoints` as its output path (`entry_point_original_names`), which reaches the same code.
- `resolve_path::normalize_buf` collapses `.`/`..`/duplicate separators in place. On POSIX the underlying normalizer emits only the path components, never the leading `/`; callers that need an absolute result add it back themselves (`relative_platform_buf` does exactly this with `buf[1..]`). `relative_alloc` is `path.relative()` over two paths that it first normalizes and makes absolute against `FileSystem::top_level_dir` (the cwd).
