### PR TITLE
crypto: accept ArrayBuffer and SharedArrayBuffer for generatePrime options.add/rem

### DIFF
--- a/src/jsc/bindings/node/crypto/CryptoPrimes.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoPrimes.cpp
@@ -264,6 +264,33 @@ JSValue GeneratePrimeJob::result(JSGlobalObject* globalObject, JSC::ThrowScope& 
     return JSArrayBuffer::create(vm, globalObject->arrayBufferStructure(), WTF::move(buf));
 }
 
+// options.add / options.rem: a bigint, an ArrayBuffer or SharedArrayBuffer, or any ArrayBufferView
+// (node: isAnyArrayBuffer(x) || isArrayBufferView(x)), read as a big-endian unsigned integer.
+static ncrypto::BignumPointer primeOptionToBignum(JSGlobalObject* globalObject, ThrowScope& scope, JSValue value, ASCIILiteral name)
+{
+    if (value.isBigInt()) {
+        value = unsignedBigIntToBuffer(globalObject, scope, value, name);
+        RETURN_IF_EXCEPTION(scope, {});
+    }
+
+    std::span<const uint8_t> bytes;
+    if (auto* view = dynamicDowncast<JSArrayBufferView>(value)) {
+        bytes = view->span();
+    } else if (auto* arrayBuffer = dynamicDowncast<JSArrayBuffer>(value)) {
+        bytes = arrayBuffer->impl()->span();
+    } else {
+        ERR::INVALID_ARG_TYPE(scope, globalObject, name, "ArrayBuffer, Buffer, TypedArray, DataView, or bigint"_s, value);
+        return {};
+    }
+
+    ncrypto::BignumPointer result(bytes.data(), bytes.size());
+    if (!result) {
+        ERR::CRYPTO_OPERATION_FAILED(scope, globalObject, "could not generate prime"_s);
+        return {};
+    }
+    return result;
+}
+
 JSC_DEFINE_HOST_FUNCTION(jsGeneratePrime, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
 {
     auto& vm = lexicalGlobalObject->vm();
@@ -321,34 +348,14 @@ JSC_DEFINE_HOST_FUNCTION(jsGeneratePrime, (JSC::JSGlobalObject * lexicalGlobalOb
 
     ncrypto::BignumPointer add;
     if (!addValue.isUndefined()) {
-        if (addValue.isBigInt()) {
-            addValue = unsignedBigIntToBuffer(lexicalGlobalObject, scope, addValue, "options.add"_s);
-            RETURN_IF_EXCEPTION(scope, {});
-        }
-        auto* addView = dynamicDowncast<JSC::JSArrayBufferView>(addValue);
-        if (!addView) {
-            return ERR::INVALID_ARG_TYPE(scope, lexicalGlobalObject, "options.add"_s, "ArrayBuffer, Buffer, TypedArray, DataView, or bigint"_s, addValue);
-        }
-        add.reset(reinterpret_cast<const uint8_t*>(addView->vector()), addView->byteLength());
-        if (!add) {
-            return ERR::CRYPTO_OPERATION_FAILED(scope, lexicalGlobalObject, "could not generate prime"_s);
-        }
+        add = primeOptionToBignum(lexicalGlobalObject, scope, addValue, "options.add"_s);
+        RETURN_IF_EXCEPTION(scope, {});
     }
 
     ncrypto::BignumPointer rem;
     if (!remValue.isUndefined()) {
-        if (remValue.isBigInt()) {
-            remValue = unsignedBigIntToBuffer(lexicalGlobalObject, scope, remValue, "options.rem"_s);
-            RETURN_IF_EXCEPTION(scope, {});
-        }
-        auto* remView = dynamicDowncast<JSC::JSArrayBufferView>(remValue);
-        if (!remView) {
-            return ERR::INVALID_ARG_TYPE(scope, lexicalGlobalObject, "options.rem"_s, "ArrayBuffer, Buffer, TypedArray, DataView, or bigint"_s, remValue);
-        }
-        rem.reset(reinterpret_cast<const uint8_t*>(remView->vector()), remView->byteLength());
-        if (!rem) {
-            return ERR::CRYPTO_OPERATION_FAILED(scope, lexicalGlobalObject, "could not generate prime"_s);
-        }
+        rem = primeOptionToBignum(lexicalGlobalObject, scope, remValue, "options.rem"_s);
+        RETURN_IF_EXCEPTION(scope, {});
     }
 
     if (add) {
@@ -422,34 +429,14 @@ JSC_DEFINE_HOST_FUNCTION(jsGeneratePrimeSync, (JSC::JSGlobalObject * lexicalGlob
 
     ncrypto::BignumPointer add;
     if (!addValue.isUndefined()) {
-        if (addValue.isBigInt()) {
-            addValue = unsignedBigIntToBuffer(lexicalGlobalObject, scope, addValue, "options.add"_s);
-            RETURN_IF_EXCEPTION(scope, {});
-        }
-        auto* addView = dynamicDowncast<JSC::JSArrayBufferView>(addValue);
-        if (!addView) {
-            return ERR::INVALID_ARG_TYPE(scope, lexicalGlobalObject, "options.add"_s, "ArrayBuffer, Buffer, TypedArray, DataView, or bigint"_s, addValue);
-        }
-        add.reset(reinterpret_cast<const uint8_t*>(addView->vector()), addView->byteLength());
-        if (!add) {
-            return ERR::CRYPTO_OPERATION_FAILED(scope, lexicalGlobalObject, "could not generate prime"_s);
-        }
+        add = primeOptionToBignum(lexicalGlobalObject, scope, addValue, "options.add"_s);
+        RETURN_IF_EXCEPTION(scope, {});
     }
 
     ncrypto::BignumPointer rem;
     if (!remValue.isUndefined()) {
-        if (remValue.isBigInt()) {
-            remValue = unsignedBigIntToBuffer(lexicalGlobalObject, scope, remValue, "options.rem"_s);
-            RETURN_IF_EXCEPTION(scope, {});
-        }
-        auto* remView = dynamicDowncast<JSC::JSArrayBufferView>(remValue);
-        if (!remView) {
-            return ERR::INVALID_ARG_TYPE(scope, lexicalGlobalObject, "options.rem"_s, "ArrayBuffer, Buffer, TypedArray, DataView, or bigint"_s, remValue);
-        }
-        rem.reset(reinterpret_cast<const uint8_t*>(remView->vector()), remView->byteLength());
-        if (!rem) {
-            return ERR::CRYPTO_OPERATION_FAILED(scope, lexicalGlobalObject, "could not generate prime"_s);
-        }
+        rem = primeOptionToBignum(lexicalGlobalObject, scope, remValue, "options.rem"_s);
+        RETURN_IF_EXCEPTION(scope, {});
     }
 
     if (add) {

--- a/test/js/node/crypto/crypto-random.test.ts
+++ b/test/js/node/crypto/crypto-random.test.ts
@@ -1,5 +1,14 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { checkPrime, checkPrimeSync, randomBytes, randomFill, randomFillSync, randomInt } from "crypto";
+import {
+  checkPrime,
+  checkPrimeSync,
+  generatePrime,
+  generatePrimeSync,
+  randomBytes,
+  randomFill,
+  randomFillSync,
+  randomInt,
+} from "crypto";
 import { bunEnv, bunExe, isLinux, isMacOS, isMusl, tempDir } from "harness";
 import { join } from "path";
 
@@ -256,6 +265,121 @@ describe("checkPrime candidate handling", () => {
     const result = await promise;
     expect(checksReads).toBe(1);
     expect(result).toBe(true);
+  });
+});
+
+// Node accepts a bigint, an ArrayBuffer, a SharedArrayBuffer, or any ArrayBufferView for
+// options.add and options.rem. Bun used to reject the two buffer kinds with ERR_INVALID_ARG_TYPE.
+describe("generatePrime options.add / options.rem buffer kinds", () => {
+  // add = 256 and rem = 255, spelled as big-endian bytes. Two bytes each so a byte-order mistake
+  // would show up in the residue; a power-of-two add keeps generation fast.
+  const ADD = 256n;
+  const REM = 255n;
+  const ADD_BYTES = [0x01, 0x00];
+  const REM_BYTES = [0x00, 0xff];
+
+  function arrayBuffer(bytes: number[]): ArrayBuffer {
+    return new Uint8Array(bytes).buffer;
+  }
+  function sharedArrayBuffer(bytes: number[]): SharedArrayBuffer {
+    const sab = new SharedArrayBuffer(bytes.length);
+    new Uint8Array(sab).set(bytes);
+    return sab;
+  }
+
+  type PrimeOptions = { add?: unknown; rem?: unknown; bigint?: boolean };
+  function generatePrimeAsync(size: number, options: PrimeOptions): Promise<unknown> {
+    const { promise, resolve, reject } = Promise.withResolvers<unknown>();
+    generatePrime(size, options as any, (err, prime) => (err ? reject(err) : resolve(prime)));
+    return promise;
+  }
+
+  function expectPrimeCongruent(prime: unknown) {
+    expect(typeof prime).toBe("bigint");
+    expect((prime as bigint) % ADD).toBe(REM);
+    expect(checkPrimeSync(prime as bigint)).toBe(true);
+  }
+
+  describe.each<[string, (bytes: number[]) => ArrayBuffer | SharedArrayBuffer]>([
+    ["ArrayBuffer", arrayBuffer],
+    ["SharedArrayBuffer", sharedArrayBuffer],
+  ])("%s", (_, make) => {
+    it("generatePrimeSync accepts it for add and rem", () => {
+      expectPrimeCongruent(generatePrimeSync(32, { add: make(ADD_BYTES), rem: make(REM_BYTES), bigint: true }));
+    });
+
+    it("generatePrime accepts it for add and rem", async () => {
+      expectPrimeCongruent(await generatePrimeAsync(32, { add: make(ADD_BYTES), rem: make(REM_BYTES), bigint: true }));
+    });
+
+    it("can be combined with a bigint or a view for the other option", async () => {
+      expectPrimeCongruent(generatePrimeSync(32, { add: make(ADD_BYTES), rem: REM, bigint: true }));
+      expectPrimeCongruent(generatePrimeSync(32, { add: Buffer.from(ADD_BYTES), rem: make(REM_BYTES), bigint: true }));
+      expectPrimeCongruent(await generatePrimeAsync(32, { add: ADD, rem: make(REM_BYTES), bigint: true }));
+      expectPrimeCongruent(
+        await generatePrimeAsync(32, { add: make(ADD_BYTES), rem: Buffer.from(REM_BYTES), bigint: true }),
+      );
+    });
+
+    it("is copied before the async job starts", async () => {
+      const add = make(ADD_BYTES);
+      const rem = make(REM_BYTES);
+      const pending = generatePrimeAsync(32, { add, rem, bigint: true });
+      new Uint8Array(add).fill(0);
+      new Uint8Array(rem).fill(0);
+      expectPrimeCongruent(await pending);
+    });
+  });
+
+  it("returns an ArrayBuffer when bigint is not requested", () => {
+    const prime = generatePrimeSync(32, { add: arrayBuffer(ADD_BYTES), rem: arrayBuffer(REM_BYTES) });
+    expect(prime).toBeInstanceOf(ArrayBuffer);
+    expectPrimeCongruent(BigInt("0x" + Buffer.from(prime).toString("hex")));
+  });
+
+  it("range-checks values given as ArrayBuffers", () => {
+    const invalidAdd = expect.objectContaining({ code: "ERR_OUT_OF_RANGE", message: "invalid options.add" });
+    const invalidRem = expect.objectContaining({ code: "ERR_OUT_OF_RANGE", message: "invalid options.rem" });
+
+    // add (9 bits) is wider than the requested prime.
+    expect(() => generatePrimeSync(8, { add: arrayBuffer(ADD_BYTES) })).toThrow(invalidAdd);
+    expect(() => generatePrime(8, { add: arrayBuffer(ADD_BYTES) }, () => {})).toThrow(invalidAdd);
+
+    // rem >= add.
+    expect(() => generatePrimeSync(32, { add: arrayBuffer(REM_BYTES), rem: arrayBuffer(ADD_BYTES) })).toThrow(
+      invalidRem,
+    );
+    expect(() => generatePrime(32, { add: arrayBuffer(REM_BYTES), rem: arrayBuffer(ADD_BYTES) }, () => {})).toThrow(
+      invalidRem,
+    );
+
+    // A detached ArrayBuffer has byteLength 0 and reads as 0, as in node, so it fails the rem >= add check.
+    const detached = new ArrayBuffer(2);
+    structuredClone(detached, { transfer: [detached] });
+    expect(detached.byteLength).toBe(0);
+    expect(() => generatePrimeSync(32, { add: detached, rem: 1n })).toThrow(invalidRem);
+    expect(() => generatePrime(32, { add: detached, rem: 1n }, () => {})).toThrow(invalidRem);
+  });
+
+  it.each([
+    ["a string", "256"],
+    ["a number", 256],
+    ["a plain object", {}],
+    ["an array of bytes", ADD_BYTES],
+    ["null", null],
+  ])("still rejects %s", (_, value) => {
+    const invalidAdd = expect.objectContaining({
+      code: "ERR_INVALID_ARG_TYPE",
+      message: expect.stringContaining('"options.add"'),
+    });
+    const invalidRem = expect.objectContaining({
+      code: "ERR_INVALID_ARG_TYPE",
+      message: expect.stringContaining('"options.rem"'),
+    });
+    expect(() => generatePrimeSync(32, { add: value as any })).toThrow(invalidAdd);
+    expect(() => generatePrimeSync(32, { add: ADD, rem: value as any })).toThrow(invalidRem);
+    expect(() => generatePrime(32, { add: value as any }, () => {})).toThrow(invalidAdd);
+    expect(() => generatePrime(32, { add: ADD, rem: value as any }, () => {})).toThrow(invalidRem);
   });
 });
 


### PR DESCRIPTION
### Problem
- `crypto.generatePrime()` and `crypto.generatePrimeSync()` throw when `options.add` or `options.rem` is an `ArrayBuffer` or `SharedArrayBuffer`:
  `ERR_INVALID_ARG_TYPE: The "options.add" property must be of type ArrayBuffer, Buffer, TypedArray, DataView, or bigint. Received an instance of ArrayBuffer`
- Node accepts these: `lib/internal/crypto/random.js` checks `isAnyArrayBuffer(add) || isArrayBufferView(add)` (same for `rem`), and the error message above already claims `ArrayBuffer` is accepted.
- Cause: the four add/rem blocks in `src/jsc/bindings/node/crypto/CryptoPrimes.cpp` (two per entry point) only try `dynamicDowncast<JSArrayBufferView>`, so a `JSArrayBuffer` falls through to the type error.

Repro (node prints a prime, bun throws):

```js
const { generatePrimeSync } = require("crypto");
generatePrimeSync(32, { add: new Uint8Array([12]).buffer, rem: new Uint8Array([11]).buffer, bigint: true });
```

### Fix
- Replaces the four copies of the add/rem parsing with one helper, `primeOptionToBignum`, that converts a bigint via the existing `unsignedBigIntToBuffer`, then takes the bytes of either a `JSArrayBufferView` or a `JSArrayBuffer` and copies them into a `BignumPointer`. Everything after that (the `ERR_OUT_OF_RANGE` checks, scheduling, result encoding) is unchanged.
- Why this is correct:
  - Matches node's accepted set: in JSC a `SharedArrayBuffer` is also a `JSArrayBuffer` (shared `ArrayBuffer` impl), so the one downcast covers node's `isAnyArrayBuffer`; the view downcast covers `isArrayBufferView`; bigint is handled as before. Strings, numbers, plain objects and arrays still fail with the same `ERR_INVALID_ARG_TYPE`.
  - Same value semantics as the existing view path: the bytes are read big-endian by `BN_bin2bn` and copied on the JS thread before the job is scheduled, so the async job never touches JS memory (relevant for `SharedArrayBuffer`). A detached buffer has a 0-length span and reads as 0, which is also what node's `ArrayBufferOrViewContents` produces.
  - The error message text is left as is; how the type list in that message is rendered is a separate issue.
- Verified:
  - `test/js/node/crypto/crypto-random.test.ts`, new `generatePrime options.add / options.rem buffer kinds` block: `ArrayBuffer` and `SharedArrayBuffer` for add and rem, sync and async, mixed with bigint/Buffer for the other option, bytes copied before the async job runs, `ArrayBuffer` result when `bigint` is not set, `ERR_OUT_OF_RANGE` checks still applied to buffer inputs (including a detached buffer), and the invalid types still rejected. 10 of the 15 tests fail on the current release, all pass with this change.
  - `test/js/node/test/parallel/test-crypto-prime.js` (bigint/Buffer add/rem and the range error paths, which now go through the helper) passes with the debug build.
  - The new tests also pass under `BUN_JSC_validateExceptionChecks=1` and 15 repeated runs.
- The tests use add = 256 / rem = 255 at 32 bits and assert primality and the residue rather than the bit length; the oversized results and hangs for some add/rem inputs are a separate ncrypto bug (#37963) and are not touched here.

### Background
- `options.add` / `options.rem` in `generatePrime` ask for a prime `p` with `p % add == rem`; both are passed as big-endian unsigned byte strings (or bigints), and the binding turns them into OpenSSL `BIGNUM`s (`BignumPointer`, a wrapper around `BN_bin2bn`, which copies the bytes).
- `JSArrayBufferView` is JSC's base class for typed arrays, `Buffer` and `DataView`; `JSArrayBuffer` is the wrapper for both `ArrayBuffer` and `SharedArrayBuffer`, whose backing `ArrayBuffer` impl exposes the bytes as a span (empty once detached).
