### PR TITLE
node:string_decoder: make end(buf) accept what write(buf) accepts

### DIFF
--- a/src/jsc/bindings/JSStringDecoder.cpp
+++ b/src/jsc/bindings/JSStringDecoder.cpp
@@ -403,45 +403,50 @@ JSC::GCClient::IsoSubspace* JSStringDecoder::subspaceForImpl(JSC::VM& vm)
 
 STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(JSStringDecoderPrototype, JSStringDecoderPrototype::Base);
 
+// Node's end(buf) is write(buf) followed by the flush, so both accept the same `buf`: a string is
+// passed through (the callers handle that first) and anything else must be an ArrayBufferView.
+// https://github.com/nodejs/node/blob/v26.3.0/lib/string_decoder.js#L76-L101
+static JSC::JSArrayBufferView* bufArgument(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, JSC::JSValue buffer)
+{
+    JSC::JSArrayBufferView* view = dynamicDowncast<JSC::JSArrayBufferView>(buffer);
+    if (!view || view->isDetached()) [[unlikely]] {
+        Bun::ERR::INVALID_ARG_TYPE(throwScope, globalObject, "buf"_s, "Buffer, TypedArray, or DataView"_s, buffer);
+        return nullptr;
+    }
+    return view;
+}
+
 static inline JSC::EncodedJSValue jsStringDecoderPrototypeFunction_writeBody(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, JSStringDecoder* castedThis)
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
-    if (callFrame->argumentCount() < 1) {
-        throwVMError(lexicalGlobalObject, throwScope, createNotEnoughArgumentsError(lexicalGlobalObject));
-        return {};
-    }
+    JSValue buffer = callFrame->argument(0);
+    if (buffer.isString())
+        return JSC::JSValue::encode(buffer);
 
-    auto buffer = callFrame->uncheckedArgument(0);
-    JSC::JSArrayBufferView* view = dynamicDowncast<JSC::JSArrayBufferView>(buffer);
-    if (!view || view->isDetached()) [[unlikely]] {
-        // What node does:
-        // StringDecoder.prototype.write = function write(buf) {
-        // if (typeof buf === 'string')
-        //     return buf;
-        if (buffer.isString()) {
-            return JSC::JSValue::encode(buffer);
-        }
-
-        return Bun::ERR::INVALID_ARG_TYPE(throwScope, lexicalGlobalObject, "buf"_s, "Buffer, TypedArray, or DataView"_s, buffer);
-    }
+    JSC::JSArrayBufferView* view = bufArgument(throwScope, lexicalGlobalObject, buffer);
+    RETURN_IF_EXCEPTION(throwScope, {});
     RELEASE_AND_RETURN(throwScope, JSC::JSValue::encode(castedThis->write(vm, lexicalGlobalObject, reinterpret_cast<uint8_t*>(view->vector()), view->byteLength())));
 }
 static inline JSC::EncodedJSValue jsStringDecoderPrototypeFunction_endBody(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, JSStringDecoder* castedThis)
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
-    if (callFrame->argumentCount() < 1) {
+    JSValue buffer = callFrame->argument(0);
+    if (buffer.isUndefined())
         RELEASE_AND_RETURN(throwScope, JSC::JSValue::encode(castedThis->end(vm, lexicalGlobalObject, nullptr, 0)));
+
+    if (!buffer.isString()) {
+        JSC::JSArrayBufferView* view = bufArgument(throwScope, lexicalGlobalObject, buffer);
+        RETURN_IF_EXCEPTION(throwScope, {});
+        RELEASE_AND_RETURN(throwScope, JSC::JSValue::encode(castedThis->end(vm, lexicalGlobalObject, reinterpret_cast<uint8_t*>(view->vector()), view->byteLength())));
     }
 
-    auto buffer = callFrame->uncheckedArgument(0);
-    JSC::JSArrayBufferView* view = dynamicDowncast<JSC::JSArrayBufferView>(buffer);
-    if (!view || view->isDetached()) [[unlikely]] {
-        throwVMTypeError(lexicalGlobalObject, throwScope, "Expected Uint8Array"_s);
-        return {};
-    }
-    RELEASE_AND_RETURN(throwScope, JSC::JSValue::encode(castedThis->end(vm, lexicalGlobalObject, reinterpret_cast<uint8_t*>(view->vector()), view->byteLength())));
+    JSC::JSString* flushed = castedThis->end(vm, lexicalGlobalObject, nullptr, 0);
+    RETURN_IF_EXCEPTION(throwScope, {});
+    if (flushed->length() == 0)
+        return JSC::JSValue::encode(buffer);
+    RELEASE_AND_RETURN(throwScope, JSC::JSValue::encode(JSC::jsString(lexicalGlobalObject, asString(buffer), flushed)));
 }
 static inline JSC::EncodedJSValue jsStringDecoderPrototypeFunction_textBody(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, JSStringDecoder* castedThis)
 {

--- a/test/js/node/string_decoder/string-decoder.test.js
+++ b/test/js/node/string_decoder/string-decoder.test.js
@@ -310,6 +310,115 @@ describe("lastNeed/lastTotal/lastChar state matches Node after completing a spli
   });
 });
 
+// Node's end(buf) is `(buf === undefined ? "" : this.write(buf))` followed by the flushed partial
+// character (https://github.com/nodejs/node/blob/v26.3.0/lib/string_decoder.js#L96-L101), so
+// end() takes exactly what write() takes: undefined only flushes, a string is returned as-is ahead
+// of the flushed bytes, and anything that is not an ArrayBufferView throws write()'s error.
+describe("end(buf) handles its argument like write(buf)", () => {
+  const encodings = ["utf8", "utf16le", "base64", "base64url", "hex", "latin1", "ascii"];
+
+  // [encoding, bytes that stay buffered as an incomplete character, what end() flushes for them]
+  const partials = [
+    ["utf8", [0xe2, 0x82], "\ufffd"],
+    ["utf16le", [0x3d, 0xd8], "\ud83d"],
+    // A lone trailing byte of a utf16le code unit is dropped by the flush.
+    ["utf16le", [0x61], ""],
+    ["base64", [0x61, 0x62], "YWI="],
+    ["base64url", [0x61, 0x62], "YWI"],
+  ];
+
+  // [label, value] pairs that neither write() nor end() accept.
+  const rejected = [
+    ["null", null],
+    ["a number", 123],
+    ["a boolean", true],
+    ["a bigint", 123n],
+    ["a symbol", Symbol("buf")],
+    ["a plain object", {}],
+    ["an array", [0x61]],
+    ["an ArrayBuffer", new ArrayBuffer(2)],
+    ["a String object", new String("abc")],
+    ["a function", () => {}],
+  ];
+
+  function thrownBy(fn) {
+    try {
+      fn();
+    } catch (e) {
+      return { isTypeError: e instanceof TypeError, name: e.name, code: e.code, message: e.message };
+    }
+    return "did not throw";
+  }
+
+  it.each(encodings)('%s: end(undefined) is "" and end(string) is the string when nothing is buffered', encoding => {
+    const results = {
+      undefined: new RealStringDecoder(encoding).end(undefined),
+      string: new RealStringDecoder(encoding).end("abc"),
+      emptyString: new RealStringDecoder(encoding).end(""),
+    };
+    expect(results).toEqual({ undefined: "", string: "abc", emptyString: "" });
+  });
+
+  it.each(partials)("%s: end(undefined) flushes the buffered partial like end()", (encoding, bytes, flushed) => {
+    const decoder = new RealStringDecoder(encoding);
+    expect(decoder.write(Buffer.from(bytes))).toBe("");
+    expect(decoder.end(undefined)).toBe(flushed);
+    expect(decoder.end()).toBe("");
+  });
+
+  it.each(partials)(
+    "%s: end(string) returns the string followed by the buffered partial",
+    (encoding, bytes, flushed) => {
+      const decoder = new RealStringDecoder(encoding);
+      expect(decoder.write(Buffer.from(bytes))).toBe("");
+      expect(decoder.end("abc")).toBe("abc" + flushed);
+      // The partial was consumed and the decoder is reusable, as after end().
+      expect({ again: decoder.end(), lastNeed: decoder.lastNeed, lastTotal: decoder.lastTotal }).toEqual({
+        again: "",
+        lastNeed: 0,
+        lastTotal: 0,
+      });
+    },
+  );
+
+  it.each(rejected)("end() of %s throws the ERR_INVALID_ARG_TYPE that write() throws", (_label, value) => {
+    const fromWrite = thrownBy(() => new RealStringDecoder().write(value));
+    expect(fromWrite).toMatchObject({ isTypeError: true, name: "TypeError", code: "ERR_INVALID_ARG_TYPE" });
+    expect(thrownBy(() => new RealStringDecoder().end(value))).toEqual(fromWrite);
+  });
+
+  it("the error names the argument and the value it received", () => {
+    const { message } = thrownBy(() => new RealStringDecoder().end(123));
+    expect(message).toStartWith('The "buf" argument must be ');
+    expect(message).toEndWith(". Received type number (123)");
+  });
+
+  it("a rejected end(buf) leaves the buffered partial for the next end()", () => {
+    const decoder = new RealStringDecoder("utf8");
+    expect(decoder.write(Buffer.from([0xe2, 0x82]))).toBe("");
+    expect(thrownBy(() => decoder.end(123))).toMatchObject({ code: "ERR_INVALID_ARG_TYPE" });
+    expect(decoder.end()).toBe("\ufffd");
+  });
+
+  it("write() with no argument throws what write(undefined) throws", () => {
+    const fromUndefined = thrownBy(() => new RealStringDecoder().write(undefined));
+    expect(fromUndefined).toMatchObject({ isTypeError: true, code: "ERR_INVALID_ARG_TYPE" });
+    expect(fromUndefined.message).toEndWith(". Received undefined");
+    expect(thrownBy(() => new RealStringDecoder().write())).toEqual(fromUndefined);
+  });
+
+  it("end(view) still decodes any ArrayBufferView and then flushes", () => {
+    // 0xe2 0x82 0xac is "€"; the trailing 0xe2 starts a new character that end() flushes.
+    const utf8 = new RealStringDecoder("utf8");
+    expect(utf8.write(Buffer.from([0xe2]))).toBe("");
+    expect(utf8.end(new DataView(Uint8Array.of(0x82, 0xac, 0xe2).buffer))).toBe("€\ufffd");
+
+    // "a" followed by a lone high surrogate, which end() flushes on its own.
+    const utf16le = new RealStringDecoder("utf16le");
+    expect(utf16le.end(new DataView(Uint8Array.of(0x61, 0x00, 0x3d, 0xd8).buffer))).toBe("a\ud83d");
+  });
+});
+
 it("invalid utf-8 input, pr #3562", () => {
   const decoder = new RealStringDecoder("utf-8");
   let output = "";


### PR DESCRIPTION
### Problem
- `new StringDecoder().end(undefined)`, `.end("abc")` and `.end(123)` all throw `TypeError: Expected Uint8Array` (no `.code`). Node returns `""`, `"abc"`, and throws `TypeError [ERR_INVALID_ARG_TYPE]: The "buf" argument must be ... Received type number (123)` respectively.
- With a partial character buffered, Node's `end("abc")` returns `"abc\ufffd"`; Bun throws, and the partial stays buffered.
- Cause: `jsStringDecoderPrototypeFunction_endBody` (src/jsc/bindings/JSStringDecoder.cpp:430) has its own argument check that only accepts an `ArrayBufferView` when an argument is present, while `writeBody` right above it already implements Node's string pass-through and `ERR_INVALID_ARG_TYPE`. In Node, `end(buf)` is `(buf === undefined ? "" : this.write(buf))` plus the flush (https://github.com/nodejs/node/blob/v26.3.0/lib/string_decoder.js#L96-L101), so it accepts exactly what `write()` accepts. `@types/node` declares `end(buffer?: string | ArrayBufferView)` accordingly, so this compiles and then throws at runtime on Bun.

### Fix
- `write()` and `end()` resolve `buf` through one helper (`bufArgument`), which throws the `ERR_INVALID_ARG_TYPE` `write()` already threw; `end()` no longer has its own error.
- `end()` now mirrors Node's three outcomes: `undefined` (explicit or omitted) only flushes; a string is returned followed by whatever the flush produces; any other non-view throws before the decoder state is touched, so the buffered partial is still returned by the next `end()` (also Node's behavior, since `write()` throws before the flush runs).
- `write()` reads its argument with `callFrame->argument(0)`, so `write()` with no argument now throws Node's `ERR_INVALID_ARG_TYPE` (`Received undefined`) instead of `ERR_MISSING_ARGS`.
- Why this is correct: matches Node. Every expected value in the new tests was checked against Node v26.3.0 with the same scenarios written in `node:assert` (output below); the only remaining difference is the `must be of type` vs `must be an instance of` wording of the shared message, which `test/js/node/test/parallel/test-string-decoder.js` currently pins to Bun's wording and which this PR deliberately leaves alone so `write()` and `end()` keep throwing the identical message.
- Intentionally unchanged: detached views are still rejected by both methods (Node decodes them as empty), and the legacy `text(buf, offset)` keeps its own check, because Node's `text()` is `write(buf.slice(offset))` and fails with a plain `TypeError` from `.slice`, not with `write()`'s error.
- Tests: `test/js/node/string_decoder/string-decoder.test.js`, new `describe("end(buf) handles its argument like write(buf)")`: 30 of the 31 new cases fail on the released Bun (`USE_SYSTEM_BUN=1`), all 126 in the file pass with this build. The one case that passes both ways (`end(view)` decodes and flushes) guards the path the refactor kept.
- Also run on this build: `test/js/node/test/parallel/test-string-decoder.js`, `test-string-decoder-end.js`, `test-string-decoder-fuzz.js` (exit 0), and the new cases under `BUN_JSC_validateExceptionChecks=1`.

### Background
- `StringDecoder` decodes a byte stream that may split multi-byte characters across chunks: `write(chunk)` returns the complete characters and keeps the trailing incomplete bytes; `end()` flushes those (as U+FFFD for utf8, a lone surrogate for utf16le, padding for base64) and resets the decoder. Bun implements it natively in `JSStringDecoder.cpp`; `JSStringDecoder::end(ptr, len)` decodes `len` bytes and then flushes, so `end(nullptr, 0)` is a pure flush.
- `ERR_INVALID_ARG_TYPE` is Node's error for a wrongly typed argument; `Bun::ERR::INVALID_ARG_TYPE` (src/jsc/bindings/ErrorCode.cpp) builds the same `The "name" argument must be ... Received ...` message with Node's rendering of the received value and sets `.code`. Callers pass the `ThrowScope` in and check `RETURN_IF_EXCEPTION` afterwards, which is the pattern the new helper follows.

<details>
<summary>Node v26.3.0 vs Bun 1.4.0 for the reported calls</summary>

```
$ node repro.js
end()                -> ""
end(undefined)       -> ""
end('abc')           -> "abc"
partial + end('abc') -> "abc\ufffd"
end(123)             -> TypeError ERR_INVALID_ARG_TYPE: The "buf" argument must be an instance of Buffer, TypedArray, or DataView. Received type number (123)
write()              -> TypeError ERR_INVALID_ARG_TYPE: The "buf" argument must be an instance of Buffer, TypedArray, or DataView. Received undefined

$ USE_SYSTEM_BUN=1 bun repro.js
end()                -> ""
end(undefined)       -> TypeError: Expected Uint8Array   (code undefined)
end('abc')           -> TypeError: Expected Uint8Array   (code undefined)
partial + end('abc') -> TypeError: Expected Uint8Array   (code undefined)
end(123)             -> TypeError: Expected Uint8Array   (code undefined)
write()              -> TypeError ERR_MISSING_ARGS: Not enough arguments

$ bun bd repro.js   (this branch)
end()                -> ""
end(undefined)       -> ""
end('abc')           -> "abc"
partial + end('abc') -> "abc\ufffd"
end(123)             -> TypeError ERR_INVALID_ARG_TYPE: The "buf" argument must be of type Buffer, TypedArray, or DataView. Received type number (123)
write()              -> TypeError ERR_INVALID_ARG_TYPE: The "buf" argument must be of type Buffer, TypedArray, or DataView. Received undefined
```

The new test's scenarios rewritten with `node:assert` pass under Node v26.3.0 and under this build (`all scenarios agree`); the released Bun fails at the first `end(undefined)`.
</details>
