### PR TITLE
Key the runtime transpiler cache on macro mode

### DIFF
--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -362,7 +362,7 @@ pub mod Runtime {
         pub(crate) fn hash_for_runtime_transpiler(&self, hasher: &mut Wyhash) {
             debug_assert!(self.runtime_transpiler_cache.is_some());
 
-            let bools: [bool; 17] = [
+            let bools: [bool; 18] = [
                 self.top_level_await,
                 self.auto_import_jsx,
                 self.allow_runtime,
@@ -380,6 +380,11 @@ pub mod Runtime {
                 self.standard_decorators,
                 self.lower_using,
                 self.repl_mode,
+                // Modules loaded while a macro is being evaluated are transpiled for
+                // Target::BunMacro: their own macro calls are left unexpanded (and so
+                // don't trip the macro_call_count opt-out), so that output must not be
+                // served to a normal import of the same file.
+                self.is_macro_runtime,
                 // note that we do not include .inject_jest_globals, as we bail out of the cache entirely if this is true
             ];
 

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -51,7 +51,10 @@ bun_core::declare_scope!(cache, visible);
 /// Version 25: Every ModuleInfo record carries a trailing FetchParameters slot
 /// so ImportEntry/ExportEntry/StarExportEntry moduleRequestType matches JSC's
 /// after WebKit 90b2ecf79ae3 keyed m_loadedModules on (specifier, type).
-const EXPECTED_VERSION: u32 = 25;
+/// Version 26: `is_macro_runtime` participates in the features hash. Entries written
+/// while a macro was being evaluated (macro calls unexpanded, printed for
+/// Target::BunMacro) were stored under the same key as a normal transpile of the file.
+const EXPECTED_VERSION: u32 = 26;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -292,6 +292,98 @@ describe("transpiler cache", () => {
       expect(newCacheCount()).toBe(0);
     });
   });
+
+  // While a macro is being evaluated, every module it loads is transpiled in
+  // macro mode (is_macro_runtime, target bun_macro), whose output differs from
+  // a normal transpile of the same file. The mode is part of the features hash
+  // so a normal import never gets an entry written by a macro-mode load.
+  describe("macro mode", () => {
+    // Padding so lib.ts clears MINIMUM_CACHE_SIZE (4 KiB).
+    const filler = "\n//" + Buffer.alloc(5 * 1024, "f").toString();
+
+    // use-macro.ts evaluates outer() at transpile time, which loads lib.ts in
+    // macro mode; outer() only looks at the export, so nothing inside lib.ts
+    // runs during the evaluation. use-lib.ts imports the same lib.ts normally
+    // and prints what getAnswer() returns and the code it was transpiled to.
+    function writeFixtures(libSource: string) {
+      writeFileSync(join(temp_dir, "lib.ts"), libSource + filler);
+      writeFileSync(
+        join(temp_dir, "outer-macro.ts"),
+        `import { getAnswer } from "./lib.ts";
+         export function outer() { return typeof getAnswer; }`,
+      );
+      writeFileSync(
+        join(temp_dir, "use-macro.ts"),
+        `import { outer } from "./outer-macro.ts" with { type: "macro" };
+         console.log(outer());`,
+      );
+      writeFileSync(
+        join(temp_dir, "use-lib.ts"),
+        `import { getAnswer } from "./lib.ts";
+         console.log(getAnswer(), "|", getAnswer.toString().replace(/\\s+/g, " "));`,
+      );
+    }
+
+    // Debug builds print "[macro] call outer" to stdout while the macro runs,
+    // so only the script's own (last) line of output is compared.
+    async function run(file: string) {
+      const { stdout, stderr, exitCode } = await bunRun(join(temp_dir, file), env);
+      return { lastLine: stdout.split("\n").pop(), stderr, exitCode };
+    }
+    const printed = (lastLine: string) => ({ lastLine, stderr: "", exitCode: 0 });
+
+    test("a file that uses a macro is expanded by a normal import after a macro-mode load", async () => {
+      writeFileSync(join(temp_dir, "answer-macro.ts"), `export function answer() { return 42; }`);
+      writeFixtures(
+        `import { answer } from "./answer-macro.ts" with { type: "macro" };
+         export function getAnswer() { return answer(); }`,
+      );
+
+      // Macro mode does not expand answer(), so the macro_call_count opt-out does
+      // not apply and the unexpanded output is written to the cache.
+      expect(await run("use-macro.ts")).toEqual(printed("function"));
+      expect(newCacheCount()).toBe(1);
+
+      // Served from that entry this prints `return answer();` (and the call
+      // throws). A normal transpile inlines the macro, and files that expand
+      // macros are never cached, so the macro-mode entry is deleted and not replaced.
+      expect(await run("use-lib.ts")).toEqual(printed("42 | function getAnswer() { return 42; }"));
+      expect(newCacheCount()).toBe(-1);
+    });
+
+    test("a file that uses require() works in a normal import after a macro-mode load", async () => {
+      // Nothing macro-related in the file itself: the macro-mode output differs
+      // only in how the printer handles the target (the `require` binding for ESM
+      // is only emitted for the regular bun target).
+      writeFixtures(`export function getAnswer() { return typeof require("node:path").join; }`);
+
+      expect(await run("use-macro.ts")).toEqual(printed("function"));
+      expect(newCacheCount()).toBe(1);
+
+      // Served from the macro-mode entry this throws "require is not defined".
+      // The normal transpile replaces the entry (delete + write).
+      expect(await run("use-lib.ts")).toEqual(
+        printed('function | function getAnswer() { return typeof require("node:path").join; }'),
+      );
+      expect(newCacheCount()).toBe(0);
+    });
+
+    test("macro-mode loads still use the cache, and switching modes replaces the entry", async () => {
+      writeFixtures(`export function getAnswer() { return 42; }`);
+
+      expect(await run("use-macro.ts")).toEqual(printed("function"));
+      expect(newCacheCount()).toBe(1);
+      expect(await run("use-macro.ts")).toEqual(printed("function"));
+      expect(newCacheCount()).toBe(0);
+
+      // The other mode has a different features_hash, so the entry is deleted and
+      // rewritten (net 0) instead of reused, and both modes keep working.
+      expect(await run("use-lib.ts")).toEqual(printed("42 | function getAnswer() { return 42; }"));
+      expect(newCacheCount()).toBe(0);
+      expect(await run("use-macro.ts")).toEqual(printed("function"));
+      expect(newCacheCount()).toBe(0);
+    });
+  });
 });
 
 test("rejects cached module records containing out-of-range string indices", () => {


### PR DESCRIPTION
### Problem
- A module that is loaded while a macro is being evaluated is transpiled in macro mode, and that output is written to the runtime transpiler cache under the same key as a normal transpile. A later normal import of the same file (in another process, or after `bun build` evaluated the macro) is served the macro-mode output.
- Symptoms on the normal import: `ReferenceError: answer is not defined` when the file uses a macro itself (the macro call was never inlined), or `ReferenceError: require is not defined` when an ES module calls `require()` (the `var {require}=import.meta;` line is missing).
- Cause: `VirtualMachine::enable_macro_mode` (src/jsc/VirtualMachine.rs:1299) switches the transpiler target to `BunMacro`, which `src/bundler/transpiler.rs:1631` turns into `features.is_macro_runtime`. With it set, `visit_expr` skips macro expansion (src/js_parser/visit/visit_expr.rs:723, :2126), and the printer skips the ESM `require` binding (src/js_printer/lib.rs:7489, `target == Target::Bun`). Neither is reflected in the cache key: `is_macro_runtime` is not in `Features::hash_for_runtime_transpiler` (src/js_parser/parser.rs:362), and the existing opt-out in src/js_parser/parse/parse_entry.rs:2117 only fires when a macro was actually expanded (`macro_call_count != 0`), which never happens in macro mode. Macro mode also disables the async transpiler store, so these loads go through the sync path in src/runtime/jsc_hooks.rs:2734, which always attaches the cache.

### Fix
- `is_macro_runtime` joins the bools hashed by `Features::hash_for_runtime_transpiler`, so macro-mode and normal-mode transpiles of the same file have different features hashes and never satisfy each other's lookups. `EXPECTED_VERSION` goes to 26 so entries already written by older versions are discarded instead of staying poisoned (the cache directory is shared across Bun versions).
- Keying on the mode is the right fix because the mode really is a different transpiler configuration: it changes both the parser output and the printer output (the two differences above are just the ones that exist today), and the features hash is exactly where every other output-affecting switch is keyed. Checking for "did this file touch macros" in the parser would miss the printer difference, and disabling the cache in macro mode would stop caching every module a macro imports.
- Cost: a file loaded in one mode by one command and in the other mode by another (for example `bun build` evaluating a macro that imports it, then `bun run` importing it) is re-transpiled once per switch, the same delete-and-rewrite that already happens when `--feature` flags change between runs. Within one process a module is only transpiled once, so the common case is unaffected. Macro-mode loads keep getting cache hits.
- Verified with the new `macro mode` block in test/cli/run/transpiler-cache.test.ts. The first two tests fail on the released build (`bun test` with `USE_SYSTEM_BUN=1`: `answer is not defined` and `require is not defined`) and pass with this change; the third test pins that macro-mode loads still hit the cache and that switching modes replaces the entry. The rest of transpiler-cache.test.ts, macro-test.test.ts, the macro regression tests (03830, 22656, 26360), 28159, 30887 and test/cli/test/isolation.test.ts pass on the debug build.
- Related open PRs: #38590 also bumps `EXPECTED_VERSION` to 26 for unrelated hash inputs, so whichever of the two lands second renumbers to 27. #35162 (nested macro imports) carries a different mitigation for this as a side change (not attaching the cache in macro mode, untested there); if this lands first that part can be dropped on its rebase. The missing `require` binding in macro mode is a separate printer bug that this PR does not change; here it only matters as a second way the two outputs differ.

### Background
- Runtime transpiler cache: `bun run` stores the transpiled output of source files of at least 4 KiB on disk (`RuntimeTranspilerCache.rs`). The file name is a hash of the source bytes; the entry also stores a `features_hash` of the transpiler options that affect output (`ParserOptions::hash_for_runtime_transpiler` plus `Features::hash_for_runtime_transpiler`). A lookup whose `features_hash` differs deletes the entry and re-transpiles. `EXPECTED_VERSION` is a header field; entries with another version are discarded.
- Macros: `import { f } from "./m.ts" with { type: "macro" }` makes the transpiler run `f()` at transpile time and inline the result. To do so it loads `m.ts`, and everything `m.ts` imports, through the regular module loader while the VM is in macro mode. Files that expanded a macro are never cached, because their output depends on what the macro returned.
- Macro mode: during that evaluation the transpiler target is `BunMacro`, and the modules being loaded are transpiled with `features.is_macro_runtime`. In this mode the parser does not expand macros used by those modules (so macros do not recursively run macros), and the printer does not emit the `require` binding it emits for the `bun` target.

<details>
<summary>Manual repro on bun 1.4.0 (two processes sharing BUN_RUNTIME_TRANSPILER_CACHE_PATH)</summary>

```ts
// inner-macro.ts
export function answer() { return 42; }
// lib.ts (padded with comments past 4 KiB)
import { answer } from "./inner-macro.ts" with { type: "macro" };
export function getAnswer() { return answer(); }
// outer-macro.ts
import { getAnswer } from "./lib.ts";
export function outer() { return typeof getAnswer; }
// use-macro.ts
import { outer } from "./outer-macro.ts" with { type: "macro" };
console.log("macro says:", outer());
// use-lib.ts
import { getAnswer } from "./lib.ts";
console.log("lib says:", getAnswer());
```

```console
$ export BUN_RUNTIME_TRANSPILER_CACHE_PATH=$PWD/.cache
$ bun use-macro.ts
macro says: function
$ bun use-lib.ts
2 | export function getAnswer() { return answer(); }
                                         ^
ReferenceError: answer is not defined
      at getAnswer (lib.ts:2:38)
$ rm -rf .cache && bun use-lib.ts
lib says: 42
```

With `export function load() { return typeof require("node:path").join; }` as the shared module instead, the second process fails with `ReferenceError: require is not defined`.

With this change, the debug build logs `get("lib.ts") = MismatchedFeatureHash` on the second process and prints 42.
</details>
