### PR TITLE
node:zlib: throw when a zstd dictionary fails to load instead of returning empty output

### DIFF
--- a/src/runtime/node/node_zlib_binding.rs
+++ b/src/runtime/node/node_zlib_binding.rs
@@ -786,7 +786,7 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
         Ok(JSValue::UNDEFINED)
     }
 
-    fn close_internal(this: &T) {
+    pub(crate) fn close_internal(this: &T) {
         if this.write_in_progress().get() {
             this.pending_close().set(true);
             return;

--- a/src/runtime/node/zlib/NativeZstd.rs
+++ b/src/runtime/node/zlib/NativeZstd.rs
@@ -235,8 +235,7 @@ mod _impl {
                 .stream
                 .with_mut(|s| s.init(pledged_src_size, dictionary));
             if err.is_error() {
-                CompressionStream::<Self>::emit_error(self, global, this_value, err);
-                return Ok(JSValue::FALSE);
+                return Err(self.throw_initialization_failed(global, err));
             }
 
             let Some(mut params_) = init_params_array_value.as_array_buffer(global) else {
@@ -261,22 +260,32 @@ mod _impl {
                     .stream
                     .with_mut(|s| s.set_params(c_uint::try_from(i).expect("int cast"), x));
                 if err_.is_error() {
-                    self.stream.with_mut(|s| s.close());
-                    // The Context is torn down (`mode` is `NONE`); reject any
-                    // further operation the way `close()` does.
-                    self.closed.set(true);
-                    // SAFETY: is_error() ⇔ msg is non-null; it points at a NUL-terminated C string.
-                    let msg = unsafe { bun_core::ffi::cstr(err_.msg) }.to_bytes();
-                    return Err(global
-                        .err(
-                            jsc::ErrorCode::ZLIB_INITIALIZATION_FAILED,
-                            format_args!("{}", bstr::BStr::new(msg)),
-                        )
-                        .throw());
+                    return Err(self.throw_initialization_failed(global, err_));
                 }
             }
 
             Ok(JSValue::TRUE)
+        }
+
+        /// `zlib.ts` installs `onerror` only after `init()` returns, so an
+        /// error raised here can only reach the caller as an exception
+        /// (node's `ZstdStream::Init` throws `ERR_ZLIB_INITIALIZATION_FAILED`
+        /// with the context's message for both a failed `Init()` and a failed
+        /// `SetParameter()`). Otherwise the handle would be left with no
+        /// context and every later write would silently produce no output.
+        fn throw_initialization_failed(&self, global: &JSGlobalObject, err: Error) -> jsc::JsError {
+            self.stream.with_mut(|s| s.close());
+            // The Context is torn down (`mode` is `NONE`); reject any
+            // further operation the way `close()` does.
+            self.closed.set(true);
+            // SAFETY: is_error() ⇔ msg is non-null; it points at a NUL-terminated C string.
+            let msg = unsafe { bun_core::ffi::cstr(err.msg) }.to_bytes();
+            global
+                .err(
+                    jsc::ErrorCode::ZLIB_INITIALIZATION_FAILED,
+                    format_args!("{}", bstr::BStr::new(msg)),
+                )
+                .throw()
         }
 
         #[bun_jsc::host_fn(method)]

--- a/src/runtime/node/zlib/NativeZstd.rs
+++ b/src/runtime/node/zlib/NativeZstd.rs
@@ -267,17 +267,10 @@ mod _impl {
             Ok(JSValue::TRUE)
         }
 
-        /// `zlib.ts` installs `onerror` only after `init()` returns, so an
-        /// error raised here can only reach the caller as an exception
-        /// (node's `ZstdStream::Init` throws `ERR_ZLIB_INITIALIZATION_FAILED`
-        /// with the context's message for both a failed `Init()` and a failed
-        /// `SetParameter()`). Otherwise the handle would be left with no
-        /// context and every later write would silently produce no output.
+        /// Thrown rather than emitted because `zlib.ts` installs `onerror` only
+        /// after `init()` returns; node's `ZstdStream::Init` throws the same way.
         fn throw_initialization_failed(&self, global: &JSGlobalObject, err: Error) -> jsc::JsError {
-            self.stream.with_mut(|s| s.close());
-            // The Context is torn down (`mode` is `NONE`); reject any
-            // further operation the way `close()` does.
-            self.closed.set(true);
+            CompressionStream::<Self>::close_internal(self);
             // SAFETY: is_error() ⇔ msg is non-null; it points at a NUL-terminated C string.
             let msg = unsafe { bun_core::ffi::cstr(err.msg) }.to_bytes();
             global

--- a/src/runtime/node/zlib/NativeZstd.rs
+++ b/src/runtime/node/zlib/NativeZstd.rs
@@ -267,8 +267,7 @@ mod _impl {
             Ok(JSValue::TRUE)
         }
 
-        /// Thrown rather than emitted because `zlib.ts` installs `onerror` only
-        /// after `init()` returns; node's `ZstdStream::Init` throws the same way.
+        /// `zlib.ts` installs `onerror` only after `init()` returns, so init errors are thrown.
         fn throw_initialization_failed(&self, global: &JSGlobalObject, err: Error) -> jsc::JsError {
             CompressionStream::<Self>::close_internal(self);
             // SAFETY: is_error() ⇔ msg is non-null; it points at a NUL-terminated C string.

--- a/test/js/node/zlib/zlib.test.js
+++ b/test/js/node/zlib/zlib.test.js
@@ -1,5 +1,5 @@
 import { deflateSync, gunzipSync, gzipSync, inflateSync } from "bun";
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, jest } from "bun:test";
 import { tmpdirSync } from "harness";
 import * as buffer from "node:buffer";
 import { randomFillSync } from "node:crypto";
@@ -577,6 +577,44 @@ describe("zlib.zstd", () => {
     const f1 = zlib.zstdCompressSync(Buffer.from("first\n"));
     const f2 = zlib.zstdCompressSync(Buffer.from("second\n"));
     expect(zlib.zstdDecompressSync(Buffer.concat([f1, f2])).toString()).toBe("first\nsecond\n");
+  });
+
+  describe("dictionary that fails to load", () => {
+    // Starts with the zstd dictionary magic (0xEC30A437) but carries no valid
+    // entropy tables, so ZSTD_DCtx_loadDictionary rejects it. A buffer without
+    // the magic is treated as a raw content dictionary and always loads.
+    const malformedDictionary = Buffer.from([0x37, 0xa4, 0x30, 0xec, 1, 2, 3, 4, 5, 6, 7, 8]);
+    const expectedError = {
+      name: "Error",
+      code: "ERR_ZLIB_INITIALIZATION_FAILED",
+      message: "Failed to load zstd dictionary",
+    };
+
+    it("zstdDecompressSync throws instead of returning an empty buffer", () => {
+      expect(() => zlib.zstdDecompressSync(compressedBuffer, { dictionary: malformedDictionary })).toThrow(
+        expect.objectContaining(expectedError),
+      );
+    });
+
+    it("zstdDecompress throws synchronously like node", () => {
+      const callback = jest.fn();
+      expect(() => zlib.zstdDecompress(compressedBuffer, { dictionary: malformedDictionary }, callback)).toThrow(
+        expect.objectContaining(expectedError),
+      );
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it("createZstdDecompress throws from the constructor", () => {
+      expect(() => zlib.createZstdDecompress({ dictionary: malformedDictionary })).toThrow(
+        expect.objectContaining(expectedError),
+      );
+    });
+
+    it("a raw content dictionary still round-trips", () => {
+      const dictionary = Buffer.from(inputString.slice(0, 64));
+      const compressed = zlib.zstdCompressSync(inputString, { dictionary });
+      expect(zlib.zstdDecompressSync(compressed, { dictionary }).toString()).toBe(inputString);
+    });
   });
 
   it("can compress streaming", async () => {


### PR DESCRIPTION
### Problem
- `zlib.zstdDecompressSync(data, { dictionary })` with a dictionary that zstd refuses to load returns an empty `Buffer`; `zlib.zstdDecompress` hands that empty buffer to the callback; `zlib.createZstdDecompress({ dictionary })` returns a stream that consumes its input and ends without emitting anything. No error is raised anywhere.
- node v26.3.0 throws `ERR_ZLIB_INITIALIZATION_FAILED: Failed to load zstd dictionary` from all three (`ZstdStream::Init` in `src/node_zlib.cc` throws `ERR_ZLIB_INITIALIZATION_FAILED` with the context's message).
- Cause: `NativeZstd::init` (`src/runtime/node/zlib/NativeZstd.rs:237`) reported a failed `Context::init` through `emit_error`, i.e. the handle's `onerror` callback. `zlib.ts` installs `onerror` in `ZlibBase`, which the `Zstd` constructor only reaches after `handle.init()` returns, so the callback does not exist yet and the error is dropped. The failed init leaves the context with no `ZSTD_DCtx`, and `Context::do_work` returns early on a missing context, so every later write completes with zero output.
- The parameter-setting loop a few lines below already handled its failure by throwing, so only the context-init failure (the dictionary path added with dictionary support, plus `ZSTD_create*Ctx` returning null) was silent.

### Fix
- Both failure sites in `init` now go through one helper that closes the context, marks the handle closed, and throws `ERR_ZLIB_INITIALIZATION_FAILED` carrying the context's message, which is what node does for both.
- Verified with `test/js/node/zlib/zlib.test.js` (new `dictionary that fails to load` block): the three throwing cases fail on the released `bun` 1.4.0 (empty buffer / constructed stream) and pass with this build; the whole file passes (391 tests).
- `test/js/node/test/parallel/test-zlib-zstd*.js`, `test-zlib-brotli.js`, `test-zlib-dictionary-fail.js` pass; the other handle-level files in `test/js/node/zlib/` pass.
- The same differential script run against node v26.3.0 and this build now prints identical results for `zstdCompressSync`, `zstdDecompressSync`, `createZstdCompress`, `createZstdDecompress`, `zstdCompress` and `zstdDecompress` with the malformed dictionary (the compress side is unchanged: zstd defers dictionary parsing on the compression side, and both runtimes report `ZSTD_error_memory_allocation` at compress time).

### Background
- `node:zlib` streams are a JS `Transform` (`src/js/node/zlib.ts`) wrapping a native handle (`NativeZstd` here). The JS constructor creates the handle, calls `handle.init(params, pledgedSrcSize, writeState, callback, dictionary)`, and only then runs the shared `ZlibBase` setup that assigns `handle.onerror`. Errors during a write are delivered through `onerror`; errors during `init` can only be delivered by throwing, which is why node's native `Init` throws.
- A zstd dictionary is either a "raw content" dictionary (arbitrary bytes, always loads) or a formatted one starting with the magic `0xEC30A437` followed by entropy tables. The test uses the magic followed by junk, which `ZSTD_DCtx_loadDictionary` rejects.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/zlib/zlib.test.js
bun test v1.4.0 (c756081ec)

test/js/node/zlib/zlib.test.js:
(pass) prototype and name and constructor > Gzip > Gzip.prototype should be instanceof Gzip.__proto__ [2.08ms]
(pass) prototype and name and constructor > Gzip > Gzip.prototype.constructor should be Gzip [1.53ms]
(pass) prototype and name and constructor > Gzip > Gzip.name should be Gzip [1.43ms]
(pass) prototype and name and constructor > Gzip > Gzip.prototype.__proto__.constructor.name should be Zlib [1.50ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype should be instanceof Gunzip.__proto__ [0.45ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.constructor should be Gunzip [0.27ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.name should be Gunzip [0.27ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.__proto__.constructor.name should be Zlib [0.33ms]
(pass) prototype and name and constructor > Deflate > Deflate.prototype should be instanceof Deflate.__prot
... (truncated)

release without fix: 3 failed, 2 skipped
bun test v1.4.0-canary.1 (b7a043103)

test/js/node/zlib/zlib.test.js:
(pass) prototype and name and constructor > Gzip > Gzip.prototype should be instanceof Gzip.__proto__ [0.03ms]
(pass) prototype and name and constructor > Gzip > Gzip.prototype.constructor should be Gzip [0.01ms]
(pass) prototype and name and constructor > Gzip > Gzip.name should be Gzip
(pass) prototype and name and constructor > Gzip > Gzip.prototype.__proto__.constructor.name should be Zlib [0.01ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype should be instanceof Gunzip.__proto__
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.constructor should be Gunzip
(pass) prototype and name and constructor > Gunzip > Gunzip.name should be Gunzip
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.__proto__.constructor.name should be Zlib
(pass) prototype and name and constructor > Deflate > Deflate.prototype should be instanceof Deflate.__proto__
(pass) prototype and name and constructor > Deflate > Deflate.prototype.constructor should be Deflate
(pass) prototype and name and constructor > Deflate > Deflate.name should be Deflate
(pass) pr
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/zlib/zlib.test.js
bun test v1.4.0 (c756081ec)

test/js/node/zlib/zlib.test.js:
(pass) prototype and name and constructor > Gzip > Gzip.prototype should be instanceof Gzip.__proto__ [2.06ms]
(pass) prototype and name and constructor > Gzip > Gzip.prototype.constructor should be Gzip [1.55ms]
(pass) prototype and name and constructor > Gzip > Gzip.name should be Gzip [1.15ms]
(pass) prototype and name and constructor > Gzip > Gzip.prototype.__proto__.constructor.name should be Zlib [1.86ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype should be instanceof Gunzip.__proto__ [0.53ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.constructor should be Gunzip [0.29ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.name should be Gunzip [0.31ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.__proto__.constructor.name should be Zlib [0.29ms]
(pass) prototype and name and constructor > Deflate > Deflate.prototype should be instanceof Deflate.__prot
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 678ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/130] gen NodeModuleModule.lut.h
Generating /workspace/bun/build/release/codegen/NodeModuleModule.lut.h from /workspace/bun/src/jsc/modules/NodeModuleModule.cpp
[2/130] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 240 extern-C blocks audited
[3/130] gen cpp.rs (cppbind)
[4/130] gen JS modules (bundle-modules)
Preprocess modules (8311ms)
Bundle modules (48ms)
Postprocesss modules (244ms)
Bundle Functions (750ms)
Generate Code (31ms)

[9.40s] Bundled "src/js" for production
  2637 kb
  197 internal modules
  13 native modules
  91 internal functions across 17 files
[4/129] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_simdutf_sys v0.0.0 (/workspace/bun/src/simdutf_sys)
[1m[92m   Compiling[0m bun_libuv_sys v0.0.0 (/work
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/node/node_zlib_binding.rs |  2 +-
 src/runtime/node/zlib/NativeZstd.rs   | 29 +++++++++++++------------
 test/js/node/zlib/zlib.test.js        | 40 ++++++++++++++++++++++++++++++++++-
 3 files changed, 55 insertions(+), 16 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/runtime/node/node_zlib_binding.rs      2      1      0
src/runtime/node/zlib/NativeZstd.rs        2      4      0
test/js/node/zlib/zlib.test.js             1      2      0
```

</details>

<!-- robobun:evidence:end -->