### PR TITLE
Blob: return only the slice when consuming a slice's stream after the Blobs were collected

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -6382,17 +6382,26 @@ impl Any {
 
 impl Any {
     fn to_internal_blob_if_possible(&mut self) {
-        if let Any::Blob(blob) = self {
-            if let Some(s) = blob.store.get() {
-                if matches!(s.data, store::Data::Bytes(_)) && s.has_one_ref() {
-                    // `StoreRef` exposes interior-mutable `data_mut()` (no DerefMut).
-                    let internal = s.data_mut().as_bytes_mut().to_internal_blob();
-                    // StoreRef::drop on the replace below releases the store ref.
-                    *self = Any::InternalBlob(internal);
-                    return;
-                }
-            }
+        let Any::Blob(blob) = self else {
+            return;
+        };
+        let Some(s) = blob.store.get() else {
+            return;
+        };
+        let store::Data::Bytes(bytes) = &s.data else {
+            return;
+        };
+        // `to_internal_blob` moves the store's whole buffer out, so the Blob
+        // must view all of it: a `slice()` shares its parent's store and only
+        // narrows `offset`/`size`, and it can be the store's last reference
+        // once the parent has been collected.
+        if !s.has_one_ref() || blob.offset.get() != 0 || blob.size.get() < bytes.len() {
+            return;
         }
+        // `StoreRef` exposes interior-mutable `data_mut()` (no DerefMut).
+        let internal = s.data_mut().as_bytes_mut().to_internal_blob();
+        // StoreRef::drop on the replace below releases the store ref.
+        *self = Any::InternalBlob(internal);
     }
 
     pub(crate) fn to_action_value(

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, tempDir } from "harness";
+import { bunEnv, bunExe, gcTick, isASAN, tempDir } from "harness";
 import type { BlobOptions } from "node:buffer";
 import type { BinaryLike } from "node:crypto";
 import path from "node:path";
@@ -597,6 +597,120 @@ describe("slice bounds are respected when streaming and serving", () => {
     const get = await fetch(`http://localhost:${server.port}/`);
     expect(get.headers.get("content-length")).toBe("4");
     expect(await get.text()).toBe("3456");
+  });
+});
+
+// A slice shares its parent's backing store. Once the parent and the slice
+// objects have been collected, a stream made from the slice holds the only
+// reference to that store, and the buffered consumers (Bun.readableStreamTo*,
+// stream.text(), Response.text() after .body was materialized) take a fast
+// path that hands the store itself to JS. That path used to ignore the slice's
+// offset and size and return every byte in the store.
+describe("consuming a slice's stream after the Blobs were collected", () => {
+  // Bytes on both sides of the slice, non-ASCII after it. The slice is valid
+  // JSON so that every consumer can be checked against the same fixture.
+  const parts = ["xx", '"abc"', "héllo wörld ✓"];
+  const start = 2;
+  const end = 7;
+  const sliced = '"abc"';
+
+  // Resolves once every Blob passed to `track` has been finalized, which is
+  // when it releases its reference on the store.
+  async function afterBlobsAreCollected<T>(make: (track: (blob: Blob) => Blob) => T): Promise<T> {
+    let tracked = 0;
+    let collected = 0;
+    const registry = new FinalizationRegistry(() => collected++);
+    const result = make(blob => {
+      tracked++;
+      registry.register(blob, undefined);
+      return blob;
+    });
+    while (collected < tracked) await gcTick();
+    return result;
+  }
+
+  function collectedSliceStream(makeStream: (slice: Blob) => ReadableStream) {
+    return afterBlobsAreCollected(track => {
+      const parent = track(new Blob(parts));
+      const slice = track(parent.slice(start, end));
+      return makeStream(slice);
+    });
+  }
+
+  const sources: [string, (slice: Blob) => ReadableStream][] = [
+    ["slice.stream()", slice => slice.stream()],
+    ["new Response(slice).body", slice => new Response(slice).body!],
+  ];
+
+  const consumers: [string, (stream: ReadableStream) => Promise<unknown>, unknown][] = [
+    ["Bun.readableStreamToText", stream => Bun.readableStreamToText(stream), sliced],
+    [
+      "Bun.readableStreamToBytes",
+      async stream => Buffer.from(await Bun.readableStreamToBytes(stream)).toString(),
+      sliced,
+    ],
+    [
+      "Bun.readableStreamToArrayBuffer",
+      async stream => Buffer.from(await Bun.readableStreamToArrayBuffer(stream)).toString(),
+      sliced,
+    ],
+    ["Bun.readableStreamToJSON", stream => Bun.readableStreamToJSON(stream), "abc"],
+    [
+      "Bun.readableStreamToBlob",
+      async stream => {
+        const blob = await Bun.readableStreamToBlob(stream);
+        return [blob.size, await blob.text()];
+      },
+      [sliced.length, sliced],
+    ],
+    ["stream.text()", stream => stream.text(), sliced],
+    ["stream.json()", stream => stream.json(), "abc"],
+    ["stream.bytes()", async stream => Buffer.from(await stream.bytes()).toString(), sliced],
+  ];
+
+  describe.each(sources)("%s", (_, makeStream) => {
+    test.each(consumers)("%s", async (_, consume, expected) => {
+      const stream = await collectedSliceStream(makeStream);
+      expect(await consume(stream)).toEqual(expected);
+    });
+  });
+
+  test("Response.text() after .body was accessed", async () => {
+    const response = await afterBlobsAreCollected(track => {
+      const parent = track(new Blob(parts));
+      const response = new Response(track(parent.slice(start, end)));
+      expect(response.body).toBeInstanceOf(ReadableStream);
+      return response;
+    });
+    expect(await response.text()).toBe(sliced);
+  });
+
+  test("slice of a slice", async () => {
+    const stream = await afterBlobsAreCollected(track => {
+      const parent = track(new Blob(parts));
+      const outer = track(parent.slice(1));
+      return track(outer.slice(start - 1, end - 1)).stream();
+    });
+    expect(await Bun.readableStreamToText(stream)).toBe(sliced);
+  });
+
+  test("empty slice", async () => {
+    const stream = await afterBlobsAreCollected(track => {
+      const parent = track(new Blob(parts));
+      return track(parent.slice(start, start)).stream();
+    });
+    expect(await Bun.readableStreamToBytes(stream)).toHaveLength(0);
+  });
+
+  // An unsliced Blob views its whole store, so handing the store over is fine.
+  // A type makes the stream go through the same code a slice does, with a
+  // view that happens to cover the store.
+  test.each([
+    ["untyped", undefined],
+    ["typed", { type: "text/plain" }],
+  ])("%s unsliced Blob still yields everything", async (_, options) => {
+    const stream = await afterBlobsAreCollected(track => track(new Blob(parts, options)).stream());
+    expect(await Bun.readableStreamToText(stream)).toBe(parts.join(""));
   });
 });
 


### PR DESCRIPTION
### Problem

- `Bun.readableStreamToText(blob.slice(0, 3).stream())` resolves to all of `blob`, not the 3-byte slice, once the `blob` and slice objects have been garbage collected. Same for `readableStreamToBytes` / `ToArrayBuffer` / `ToJSON` (parses the whole parent, so it rejects), `stream.text()` / `.json()` / `.bytes()`, `new Response(slice).body`, and `response.text()` on a Response whose `.body` was accessed first. Bytes before the slice come back too: `new Response(parent.slice(3, 6)).body` yields `"0123456789"` instead of `"345"`, and an empty slice yields the whole parent.
- While the parent is still reachable the same calls return the slice, so what a program sees depends on GC timing. Reproduces on the released 1.4.0; the condition is unchanged from the pre-port Zig.
- Cause: `Any::to_internal_blob_if_possible` (src/runtime/webcore/Blob.rs:6384), run by `Any::to_action_value` for every buffered action except `blob()`, converts any `Any::Blob` whose bytes store has a single reference into an `InternalBlob` via `Bytes::to_internal_blob` (src/runtime/webcore/blob/Store.rs:497). That takes the store's entire buffer and never looks at the Blob's `offset`/`size`.
- The only producer of an `Any::Blob` on this path is `ByteBlobLoader::to_any_blob` (src/runtime/webcore/ByteBlobLoader.rs:145), which does check the window and hands back a windowed `Any::Blob` on purpose when the stream does not cover the store. The store's other references were the parent and slice objects; once they are collected the conversion's refcount guard passes and the window is lost.

### Fix

- `to_internal_blob_if_possible` also requires `offset == 0 && size >= store length`. A windowed Blob stays an `Any::Blob`, and the existing `Any::Blob` arms of `to_action_value` read it through `Blob::to_string` / `to_json` / `to_array_buffer_view`, which apply the window (`shared_view_raw`). That is the code `slice.text()` uses, and the code these consumers already run whenever the parent is still alive.
- Why this is correct: an `Any::Blob` stands for `store[offset..offset + size]`, while `to_internal_blob` yields the whole buffer, so the conversion preserves the value only when the window is the whole buffer. The refcount check answers a different question (may the buffer be taken at all), and both are needed. Blobs that cover their store (every unsliced Blob, `slice(0)`) convert exactly as before. `>=` rather than `==` because `shared_view` clamps an oversized `size` to the store, so such a Blob also views all of it.
- Cost: a windowed, uniquely owned store is now copied (or, for all-ASCII text, referenced) instead of adopted; the store is released when the stream detaches its `Any` right afterwards, as before.
- Verified with test/js/web/fetch/blob.test.ts, `describe("consuming a slice's stream after the Blobs were collected")`: 2 sources (`slice.stream()`, `new Response(slice).body`) x 8 consumers, plus `Response.text()` after `.body`, a slice of a slice, an empty slice, and unsliced typed/untyped Blobs as controls. 17 of the 21 fail on 1.4.0 (`USE_SYSTEM_BUN=1`, same 17 across 12 runs; the 4 that pass are the `readableStreamToBlob` cases, which skip the conversion, and the two controls). All 21 pass with this build.
- Also run on this build: the rest of blob.test.ts, streams.test.js, readable-stream-blob-consumed, stream-fast-path, direct-readable-stream, body, body-clone, body-stream, body-mixin-errors, blob-cow, blob-array-fast-path, node's test-stream-consumers.js, all passing. The probe below returns the slice on every line.

### Background

- A Blob's in-memory bytes live in a refcounted `Blob.Store`. `blob.slice()` does not copy: the new Blob shares the store and only sets its own `offset`/`size`. Each Blob's JS wrapper holds one store reference and releases it when the wrapper is finalized.
- `blob.stream()` and `new Response(blob).body` are backed by a `ByteBlobLoader`, which holds its own store reference plus the window it is going to read.
- `Bun.readableStreamTo*()`, Bun's `ReadableStream.prototype.text()/json()/bytes()/blob()`, and `Response.text()` on a body whose stream has been materialized share one fast path: when the stream is native and untouched they ask the source for the finished value instead of pumping chunks. For a Blob-backed stream that is `ByteBlobLoader::to_buffered_value` -> `Any::to_action_value`.
- `blob::Any` is the value those consumers operate on: `Any::Blob` is a view into a shared store, `Any::InternalBlob` an owned `Vec<u8>` that can be handed to JS without a copy. `to_internal_blob_if_possible` is the optimization that turns the former into the latter when nothing else references the store.
- The test waits on a `FinalizationRegistry` for the parent and slice objects, since their finalizers are what bring the store down to one reference.

<details>
<summary>Probe: 17 cases on released 1.4.0 (all 17 pass with this build)</summary>

```
FAIL readableStreamToText prefix slice: "abchéllo wörld ✓" expected "abc"
FAIL readableStreamToBytes Response(slice).body: [48,...,57] expected [51,52,53]
FAIL readableStreamToArrayBuffer: "0123456789" expected "345"
FAIL readableStreamToJSON: threw "Failed to parse JSON" expected {"a":1}
ok   readableStreamToBlob: [3,"345"]
FAIL stream.text(): "0123456789" expected "345"
FAIL node:stream/consumers text(): "0123456789" expected "345"
FAIL empty slice(4,4): "0123456789" expected ""
FAIL empty slice(0,0): "0123456789" expected ""
FAIL nested slice: "0123456789" expected "34"
ok   whole blob: "abchéllo wörld ✓"
ok   whole typed blob: "abchéllo wörld ✓"
ok   slice(0): "abchéllo wörld ✓"
ok   control, parent kept alive: "345"
ok   new Response(sliceStream).text(): "345"
FAIL res.body; res.text(): "0123456789" expected "345"
ok   spawn stdin from the slice stream: "345"
```

`new Response(sliceStream).text()` was already correct because `Body` unwraps a Blob-backed stream back into a windowed Blob value rather than using the consumer fast path; spawn stdin writes the `Any` through its windowed view.

</details>
