### PR TITLE
semver: record cloned prerelease/build tag offsets against the whole destination buffer

### DIFF
--- a/src/install/PackageManager/PackageManagerResolution.rs
+++ b/src/install/PackageManager/PackageManagerResolution.rs
@@ -139,23 +139,8 @@ impl PackageManager {
             if !parsed.valid || parsed.wildcard != semver::query::Wildcard::None {
                 continue;
             }
-            // not handling OOM
             // TODO: wildcard
-            let mut version = parsed.version.min();
-            let total = (version.tag.build.len() + version.tag.pre.len()) as usize;
-            if total > 0 {
-                let len_before = tags_buf.len();
-                // `clone_into` writes exactly `total` bytes (build.len + pre.len)
-                // into `available` and advances it; zero-fill the tail first so
-                // we can hand it out as a safe `&mut [u8]` instead of slicing
-                // raw spare capacity.
-                tags_buf.resize(len_before + total, 0);
-                let mut available = &mut tags_buf[len_before..];
-                let new_version = version.clone_into(name, &mut available);
-                version = new_version;
-            }
-
-            list.push(version);
+            list.push(parsed.version.min().clone_into(name, tags_buf));
         }
 
         Ok(list)

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -1480,23 +1480,16 @@ fn record_updating_package_versions(manager: &mut PackageManager) {
                 continue;
             }
 
+            // clone because don't know if lockfile buffer will reallocate
+            let mut tag_buf = Vec::new();
             // SAFETY: `original_resolution.tag == ResolutionTag::Npm` was checked
             // immediately above, so the `.npm` arm of the value union is active.
-            let mut original = original_resolution.npm().version;
-            let tag_total = original.tag.pre.len() + original.tag.build.len();
-            if tag_total > 0 {
-                // clone because don't know if lockfile buffer will reallocate
-                let mut tag_buf = vec![0u8; tag_total].into_boxed_slice();
-                let mut ptr = &mut tag_buf[..];
-                original.tag = original_resolution
-                    .npm()
-                    .version
-                    .tag
-                    .clone_into(&lockfile.buffers.string_bytes, &mut ptr);
+            let original = original_resolution
+                .npm()
+                .version
+                .clone_into(&lockfile.buffers.string_bytes, &mut tag_buf);
 
-                entry_ptr.original_version_string_buf = tag_buf;
-            }
-
+            entry_ptr.original_version_string_buf = tag_buf.into_boxed_slice();
             entry_ptr.original_version = Some(original);
         }
     }

--- a/src/semver/Version.rs
+++ b/src/semver/Version.rs
@@ -114,13 +114,16 @@ impl<T: VersionInt> VersionType<T> {
         Self::parse(SlicedString { buf: slice, slice })
     }
 
-    pub fn clone_into(self, slice: &[u8], buf: &mut &mut [u8]) -> Self {
+    /// Copies the pre/build tag strings out of `buf` (the buffer `self` was
+    /// parsed against) onto the end of `dest`. The returned version slices
+    /// against the whole of `dest`.
+    pub fn clone_into(self, buf: &[u8], dest: &mut Vec<u8>) -> Self {
         Self {
             major: self.major,
             minor: self.minor,
             patch: self.patch,
             _tag_padding: Default::default(),
-            tag: self.tag.clone_into(slice, buf),
+            tag: self.tag.clone_into(buf, dest),
         }
     }
 
@@ -1016,39 +1019,21 @@ impl Tag {
         self.pre.order(&rhs.pre, lhs_buf, rhs_buf)
     }
 
-    pub fn clone_into(self, slice: &[u8], buf: &mut &mut [u8]) -> Tag {
-        let pre: SemverString;
-        let build: SemverString;
-
-        if self.pre.is_inline() {
-            pre = self.pre.value;
-        } else {
-            let pre_slice = self.pre.slice(slice);
-            buf[..pre_slice.len()].copy_from_slice(pre_slice);
-            // reshaped for borrowck —
-            // capture the init args before advancing `buf`.
-            pre = SemverString::init(buf, &buf[0..pre_slice.len()]);
-            *buf = &mut core::mem::take(buf)[pre_slice.len()..];
-        }
-
-        if self.build.is_inline() {
-            build = self.build.value;
-        } else {
-            let build_slice = self.build.slice(slice);
-            buf[..build_slice.len()].copy_from_slice(build_slice);
-            build = SemverString::init(buf, &buf[0..build_slice.len()]);
-            *buf = &mut core::mem::take(buf)[build_slice.len()..];
-        }
-
+    /// See `VersionType::clone_into`.
+    pub(crate) fn clone_into(self, buf: &[u8], dest: &mut Vec<u8>) -> Tag {
         Tag {
-            pre: ExternalString {
-                value: pre,
-                hash: self.pre.hash,
-            },
-            build: ExternalString {
-                value: build,
-                hash: self.build.hash,
-            },
+            pre: Self::clone_string_into(self.pre, buf, dest),
+            build: Self::clone_string_into(self.build, buf, dest),
+        }
+    }
+
+    fn clone_string_into(str: ExternalString, buf: &[u8], dest: &mut Vec<u8>) -> ExternalString {
+        if str.is_inline() {
+            return str;
+        }
+        ExternalString {
+            value: bun_core::handle_oom(SemverString::init_append_if_needed(dest, str.slice(buf))),
+            hash: str.hash,
         }
     }
 

--- a/test/cli/install/bun-update.test.ts
+++ b/test/cli/install/bun-update.test.ts
@@ -1331,6 +1331,26 @@ it("should print UTF-8 arrows correctly with colors enabled", async () => {
   expect(await exited2).toBe(0);
 });
 
+// The previous version in the "^ name old -> new" line is copied out of the old
+// lockfile before it is rebuilt. Tags longer than 8 bytes are stored as offsets
+// into that copy, so use a prerelease tag and a build tag that are both longer.
+it("should print the previous prerelease and build tags in the update summary", async () => {
+  const urls: string[] = [];
+  const oldVersion = "1.0.0-canary.20240101+build.20240101";
+  const newVersion = "1.0.0-canary.20240102+build.20240102";
+  // `as` serves the existing baz tarballs for these versions.
+  setHandler(dummyRegistry(urls, { [oldVersion]: { as: "0.0.3" }, latest: oldVersion }));
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({ name: "foo", dependencies: { baz: "^1.0.0-canary.20240101" } }),
+  );
+  expect(await runInPackageDir("install", "--linker=hoisted")).toContain(`+ baz@${oldVersion}`);
+
+  setHandler(dummyRegistry(urls, { [oldVersion]: { as: "0.0.3" }, [newVersion]: { as: "0.0.5" }, latest: newVersion }));
+  const out = await runInPackageDir("update", "--linker=hoisted");
+  expect(out).toContain(`^ baz ${oldVersion} -> ${newVersion}`);
+});
+
 // Unlike `dummyRegistry`, this serves a distinct manifest per package name,
 // packing a real tarball for each version into `tgzDir`.
 async function perNameRegistry(


### PR DESCRIPTION
### Problem

- `bun update` prints the previous version of an updated package with the wrong build tag when both its prerelease tag and its build tag are longer than 8 bytes. With `baz@1.0.0-canary.20240101+build.20240101` in the lockfile:
  ```
  ^ baz 1.0.0-canary.20240101+canary.2024010 -> 1.0.0-canary.20240102+build.20240102
  ```
  (reproduced on bun 1.4.0-canary.1; the `+` part is the first 14 bytes of the prerelease tag).
- Cause: `Tag::clone_into` (src/semver/Version.rs:1019 before this change) copies the tag strings into a caller-provided window and builds each `String` handle relative to the window, then advances the window past the prerelease tag. The build tag is therefore stored as offset 0 of the advanced window, and when several versions are cloned into one buffer every version after the first is too. Both callers slice the results against the whole buffer:
  - `record_updating_package_versions` (src/install/PackageManager/install_with_manager.rs:1483), whose copy is what `print_updated_package` in tree_printer.rs formats for the line above.
  - `get_installed_versions_from_disk_cache` (src/install/PackageManager/PackageManagerResolution.rs:144), which clones every cached version of a package into one `tags_buf` and then sorts and range-matches against it. Only the first entry scanned is read correctly. This path is `--prefer-offline` auto-install and is not observable on main (see details), so it is only adapted here.

### Fix

- `Version::clone_into` / `Tag::clone_into` take the destination `Vec<u8>` and append through the existing `String::init_append_if_needed`, which records offsets from the start of that buffer. The callee no longer sees a window, so there is nothing to be relative to except the buffer the callers slice with.
- `record_updating_package_versions` clones into a `Vec` and boxes it; the disk cache scan passes `tags_buf` directly. Behaviour for inline (8 bytes or shorter) tags is unchanged: those are copied by value as before.
- `Tag::clone_into` becomes `pub(crate)`; its only remaining caller is `Version::clone_into`.
- Verified with the new test in `test/cli/install/bun-update.test.ts` ("should print the previous prerelease and build tags in the update summary"): fails on the released binary with the output above, passes with `bun bd`. The whole file passes with `bun bd test` (39 tests). `cargo fmt --check` is clean.

### Background

- `bun_semver::String` is an 8-byte handle: strings of up to 8 bytes are stored inline in the handle, longer ones as an (offset, length) pair into whatever buffer was passed when the handle was created. Reading one back (`slice(buf)`, `fmt(buf)`, `order`, `satisfies`) needs that same buffer; with another buffer it returns unrelated bytes, or an empty slice if out of range. A semver `Tag` is two such strings (`pre`, `build`) plus their hashes.
- `bun update` keeps the pre-update version of each package being updated (`PackageUpdateInfo.original_version` + `original_version_string_buf`) so the summary can print `old -> new` after the lockfile has been rebuilt. `clone_into` is how that version's tag strings are copied out of the old lockfile's string buffer.

<details>
<summary>Related sites from the same audit, and the disk cache probe</summary>

This came out of an audit of semver values sliced against a buffer other than the one they were parsed from. The other sites in the auto-install path are owned by open PRs and are intentionally not touched here:

- #36776 rewrites `resolve_from_disk_cache` and removes the `tags_buf` code entirely (it skips prerelease/build entries, whose tags are stored as hashes in the cache index names). On main that function cannot resolve anything: index entries are named `<version>@@@<cache version>`, which the semver parser rejects for release versions, and prerelease entries reconstruct to a path that does not exist. This PR's change there is just the call-site adaptation and will fall away if #36776 lands first.
- #38198 adds the `version_buf` parameter to `Lockfile::resolve_package_from_name_and_version` / `AutoInstaller::lockfile_resolve`.
- #38688 fixes the remaining wrong-buffer read in this file, `DiffFormatter` printing a build tag with `other_buf` (colored `bun outdated` / `bun update -i` output). Different hunk of Version.rs, no overlap with this change.

Probe of the disk cache caller with a debug build, a fake cache index containing three prerelease entries for `pkg`, and `bun --prefer-offline` importing each of them by exact version (`bun_core::debug!` output shown; `ENOENT` here means the entry matched and path reconstruction failed, as it always does on main):

```
unfixed: only one of the three queries reaches "error getting path for cached npm path: ENOENT"
         (the entry that happened to be scanned first; the other two read its bytes)
fixed:   all three queries reach it
```
</details>
