### PR TITLE
watch: re-raise signals queued for JS listeners before the reload execve

### DIFF
--- a/src/jsc/PosixSignalHandle.rs
+++ b/src/jsc/PosixSignalHandle.rs
@@ -70,27 +70,34 @@ impl PosixSignalHandle {
         true
     }
 
-    /// Called by the main thread (single consumer).
-    /// Returns `None` if the ring is empty, or the next signal otherwise.
+    /// Called by the main thread (the consumer); also by whichever thread is
+    /// about to execve, via `Bun__takeQueuedPosixSignal`. Returns `None` if the
+    /// ring is empty, or the next signal otherwise.
     #[allow(dead_code)]
     pub(crate) fn dequeue(&self) -> Option<u8> {
-        // Read the current head and tail.
-        let old_head = self.head.load(Ordering::Acquire);
-        let tail_val = self.tail.load(Ordering::Acquire);
+        loop {
+            // Read the current head and tail.
+            let old_head = self.head.load(Ordering::Acquire);
+            let tail_val = self.tail.load(Ordering::Acquire);
 
-        // If head == tail, the ring is empty.
-        if old_head == tail_val {
-            return None; // No available items
+            // If head == tail, the ring is empty.
+            if old_head == tail_val {
+                return None; // No available items
+            }
+
+            let slot_index = (old_head % BUFFER_SIZE) as usize;
+            // Acquire load of the stored signal to get the item.
+            let signal = self.signals[slot_index].swap(0, Ordering::AcqRel);
+
+            // Publish the updated head (Release).
+            self.head.store(old_head.wrapping_add(1), Ordering::Release);
+
+            // A zeroed slot was taken by the exec-time consumer racing this one
+            // (or vice versa); signal numbers start at 1, so skip it.
+            if signal != 0 {
+                return Some(signal);
+            }
         }
-
-        let slot_index = (old_head % BUFFER_SIZE) as usize;
-        // Acquire load of the stored signal to get the item.
-        let signal = self.signals[slot_index].swap(0, Ordering::AcqRel);
-
-        // Publish the updated head (Release).
-        self.head.store(old_head.wrapping_add(1), Ordering::Release);
-
-        Some(signal)
     }
 
     /// Drain as many signals as possible and enqueue them as tasks in the event loop.
@@ -141,6 +148,29 @@ extern "C" fn Bun__onPosixSignal(number: i32) {
     }
     #[cfg(not(unix))]
     let _ = number;
+}
+
+/// Called by `on_before_reload_process_posix` (from whichever thread is doing
+/// the reload) once every caught disposition is back to SIG_DFL: returns the
+/// next signal `Bun__onPosixSignal` queued for a JS listener, or 0 once the
+/// ring is empty. Nothing still queued at that point can reach JS before the
+/// execve discards it (the JS thread is running the pre-reload kill-signal
+/// handlers, is wedged, or is not the reloading thread), so the caller
+/// re-raises it and it takes its default action, like a signal arriving after
+/// the reset. Racing the main thread's `drain` is harmless: each signal ends
+/// up either dispatched to JS in the dying image or re-raised.
+#[cfg(unix)]
+#[unsafe(no_mangle)]
+extern "C" fn Bun__takeQueuedPosixSignal() -> i32 {
+    let Some(vm) = VirtualMachine::get_main_thread_vm() else {
+        return 0;
+    };
+    // SAFETY: same projection as `Bun__onPosixSignal`: the VM and its event
+    // loop live for the process and only the `signal_handler` slot is read.
+    let handler = unsafe { (*(*vm).event_loop()).signal_handler };
+    handler
+        .and_then(|handler| handler.dequeue())
+        .map_or(0, i32::from)
 }
 
 pub struct PosixSignalTask;

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -298,6 +298,9 @@ static void unset_cloexec(int fd)
     fcntl(fd, F_SETFD, flags);
 }
 
+// PosixSignalHandle.rs: pops one signal the process.on() handler queued for the JS thread; 0 when empty.
+extern "C" int Bun__takeQueuedPosixSignal();
+
 extern "C" void on_before_reload_process_posix()
 {
     unset_cloexec(STDIN_FILENO);
@@ -349,6 +352,32 @@ extern "C" void on_before_reload_process_posix()
     sigset_t signal_set;
     sigemptyset(&signal_set);
     sigprocmask(SIG_SETMASK, &signal_set, nullptr);
+
+    // A SIGTERM that arrived before the reset was caught by the process.on() handler, which only
+    // queues it for the JS thread; that thread never ticks again before execve (it is running the
+    // --watch-kill-signal listeners, or another thread is doing the reload), so the signal would
+    // vanish with the old image. Re-raise the queue now that those dispositions are SIG_DFL: the
+    // outcome is the one a signal arriving after the reset gets. Emptying the queue first and
+    // skipping anything the loop above left caught keeps a re-raise from refilling the queue.
+    sigset_t queued;
+    sigemptyset(&queued);
+    bool any_queued = false;
+    while (int s = Bun__takeQueuedPosixSignal()) {
+        if (s > 0 && s < NSIG) {
+            sigaddset(&queued, s);
+            any_queued = true;
+        }
+    }
+    if (!any_queued)
+        return;
+    for (int s = 1; s < NSIG; s++) {
+        if (!sigismember(&queued, s))
+            continue;
+        struct sigaction current {};
+        if (sigaction(s, nullptr, &current) != 0 || current.sa_handler != SIG_DFL)
+            continue;
+        raise(s);
+    }
 }
 
 #endif // !OS(WINDOWS)

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -1,6 +1,6 @@
 import type { Subprocess } from "bun";
 import { spawn } from "bun";
-import { afterEach, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, isBroken, isLinux, isWindows, tempDir, tmpdirSync } from "harness";
 import { readdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
@@ -127,6 +127,91 @@ setInterval(() => {}, 1000);
   },
   10000,
 );
+
+// Spawns `bun --watch --watch-kill-signal SIGINT <entry>`, touches the entry once
+// its first boot prints "started", then waits for whichever comes first: the
+// process exiting, or a second "started" (the execve reload went through).
+// Returns how many boots were seen; the caller asserts on the exit.
+async function touchOnceAndAwaitExitOrReboot(dir: string, entry: string): Promise<number> {
+  const path = join(dir, entry);
+  watchee = spawn({
+    cwd: dir,
+    cmd: [bunExe(), "--watch", "--watch-kill-signal", "SIGINT", entry],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "inherit",
+    stdin: "ignore",
+  });
+  const rebooted = Promise.withResolvers<void>();
+  let starts = 0;
+  const pump = (async () => {
+    const decoder = new TextDecoder();
+    let buffered = "";
+    for await (const chunk of watchee.stdout) {
+      buffered += decoder.decode(chunk, { stream: true });
+      let newline;
+      while ((newline = buffered.indexOf("\n")) !== -1) {
+        const line = buffered.slice(0, newline);
+        buffered = buffered.slice(newline + 1);
+        if (!line.includes("started")) continue;
+        if (++starts === 1) {
+          await Bun.write(path, (await Bun.file(path).text()) + "\n// touched\n");
+        } else {
+          rebooted.resolve();
+        }
+      }
+    }
+  })();
+  await Promise.race([watchee.exited, rebooted.promise]);
+  if (starts === 1) await pump;
+  return starts;
+}
+
+// The signal handler installed for process.on(<signal>) only queues the signal
+// for the JS thread. Once a watch reload is under way that thread never ticks
+// again, so a SIGTERM that lands during the reload used to be discarded by the
+// execve and the process came back up instead of dying (the parent in
+// test-watch-mode-kill-signal-override.mjs kills the watcher exactly then).
+// The reload must deliver whatever is still queued with the default
+// disposition: here the process has to die of the SIGTERM instead of rebooting.
+describe.skipIf(isWindows)("a signal caught during a --watch reload is not lost", () => {
+  // The kill-signal listener runs synchronously before the execve; the SIGTERM
+  // it sends itself is queued behind it and must still terminate the process.
+  it("when it arrives while the kill-signal listeners run on the JS thread", async () => {
+    using dir = tempDir("watch-signal-during-kill-signal-emit", {
+      "app.js": `process.on("SIGTERM", () => {});
+process.on("SIGINT", () => {
+  process.kill(process.pid, "SIGTERM");
+  process.exit(0);
+});
+console.log("started");
+setInterval(() => {}, 1000);
+`,
+    });
+    const starts = await touchOnceAndAwaitExitOrReboot(String(dir), "app.js");
+    expect(starts).toBe(1);
+    expect(watchee.signalCode).toBe("SIGTERM");
+  }, 10000);
+
+  // No listener for the kill signal, so the watcher thread execve's on its own
+  // while the JS thread is still spinning with the SIGTERM sitting in its queue.
+  it("when it is queued and the watcher thread reloads around a busy JS thread", async () => {
+    using dir = tempDir("watch-signal-queued-busy", {
+      "busy.js": `process.on("SIGTERM", () => {});
+console.log("started");
+process.kill(process.pid, "SIGTERM");
+// Self-limiting spin, like the wedge fixtures further down: long enough for
+// the watcher thread to reload around it, bounded so a leaked process exits on its own.
+const end = Date.now() + 30_000;
+while (Date.now() < end) {}
+process.exit(1);
+`,
+    });
+    const starts = await touchOnceAndAwaitExitOrReboot(String(dir), "busy.js");
+    expect(starts).toBe(1);
+    expect(watchee.signalCode).toBe("SIGTERM");
+  }, 10000);
+});
 
 // Watcher::start() must propagate a failed thread spawn as an Err through its
 // Result return instead of aborting inside start() with `.expect()`. An


### PR DESCRIPTION
### Problem
- A signal sent to a `bun --watch` process while it is restarting is silently dropped: `kill <pid>` (SIGTERM) during a restart leaves the process running on the new image, with the same pid.
- Seen in CI as `test/js/node/test/parallel/test-watch-mode-kill-signal-override.mjs` timing out (debian 13 x64-asan lane of an unrelated PR, passed on retry): the parent sends SIGTERM the moment it sees `__SIGINT received__`, and the log then shows `script ready <same pid>` again and the test waits forever.
- Cause: the handler installed for `process.on(<signal>)` (`forwardSignal` in `src/jsc/bindings/BunProcess.cpp`) only pushes the signal onto the `PosixSignalHandle` ring for the JS thread to dispatch. Once a watch reload is under way the JS thread never ticks again: `VirtualMachine::reload` runs the `--watch-kill-signal` listeners synchronously and goes straight into `reload_process` (`src/jsc/VirtualMachine.rs`, `src/runtime/node/node_process.rs`), and when there are no kill-signal listeners the watcher thread calls `reload_process` itself (`src/jsc/hot_reloader.rs`). `on_before_reload_process_posix` (`src/jsc/bindings/c-bindings.cpp`) resets the dispositions to SIG_DFL, which only covers signals arriving after that point; anything already in the ring is discarded by the execve.

### Fix
- `on_before_reload_process_posix` drains the ring after the disposition reset and `raise()`s each queued signal whose disposition is now SIG_DFL. The ring is emptied before anything is raised, and signals the reset loop leaves caught (SIGSEGV/SIGBUS, JSC's suspend signal, RT signals) are skipped, so a re-raise cannot refill the ring.
- `PosixSignalHandle.rs` exports `Bun__takeQueuedPosixSignal` for that, and `dequeue` skips zeroed slots: the reloading thread may be the watcher thread racing the main thread's own drain, and the loser of that race sees a slot the other side already emptied.
- Why this is correct: by the time the ring is drained the process is committed to replacing its image, so the JS listener the signal was queued for can never run. Re-raising with SIG_DFL gives the signal exactly the outcome it gets if it arrives a moment later, after the reset: SIGTERM/SIGINT/SIGHUP terminate the process, ignore-by-default signals are dropped (as execve would have done anyway). This also matches node, where a SIGTERM/SIGINT to the watcher while it restarts the child exits the watcher.
- Verified with `test/cli/watch/watch.test.ts` ("a signal caught during a --watch reload is not lost", 2 tests): each makes the watched script send itself a SIGTERM it has a listener for, so the signal is deterministically sitting in the ring when the reload happens. One covers the JS-thread path (the kill-signal listener sends it, then calls `process.exit()`), the other the watcher-thread path (no kill-signal listener, JS thread spinning). Both fail on the current release (a second boot is observed) and pass with this change (the process dies of SIGTERM); 10 consecutive runs on the debug build pass.
- Also run: the rest of `test/cli/watch/watch.test.ts`, `test/cli/hot/watch.test.ts`, the three vendored `test-watch-mode-kill-signal-*.mjs` (override 8 times in a row, one boot each), `process-signal-listener-count.test.ts`, the `signal` tests in `test/js/node/process/process.test.js`, and the vendored `test-signal-*.js` / `test-process-remove-all-signal-listeners.js`.

### Background
- `bun --watch` restarts by `execve`-ing itself in the same process (node uses a separate watcher process that kills and respawns the child). `reload_process` (`src/bun_core/util.rs`) is the single exit for every restart: the watcher thread's immediate reload, the JS thread after emitting the kill-signal listeners, the grace timer that forces a reload around a wedged JS thread, and auto-reload on crash.
- `--watch-kill-signal` (default SIGTERM) names the signal node would send the child; bun emulates it by running that signal's JS listeners synchronously right before the execve, which is why the JS thread cannot dispatch anything else at that point.
- `PosixSignalHandle` is a lock-free ring written by the signal handler and drained by the main thread at the top of each event loop tick into `PosixSignalTask`s; a caught signal lives there between delivery and its JS listener running. Pending (blocked, undelivered) signals survive an execve, but a signal that was already delivered to a handler does not.

<details>
<summary>What this does not cover</summary>

A SIGTERM that arrives after the execve is handled by the new image normally (it dies, or its freshly registered listener runs); that is a different, much narrower window than the one fixed here, which spanned the whole `process.exit()` -> compile-cache flush -> fd cleanup -> sigaction reset sequence on an ASAN build. The residual race in the vendored test would need the parent to react more slowly than a full bun re-exec and script boot.

</details>
