### PR TITLE
node: pass ERR_INVALID_ARG_TYPE expected types as lists in the C++ bindings

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -2243,7 +2243,8 @@ JSValue Process::emitWarning(JSC::JSGlobalObject* lexicalGlobalObject, JSValue w
     } else if (warning.isCell() && warning.asCell()->type() == ErrorInstanceType) {
         errorInstance = warning.getObject();
     } else {
-        return JSValue::decode(Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "warning"_s, "string or Error"_s, warning));
+        static constexpr ASCIILiteral warningTypes[] = { "Error"_s, "string"_s };
+        return JSValue::decode(Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "warning"_s, warningTypes, warning));
     }
 
     if (!code.isUndefined()) errorInstance->putDirect(vm, builtinNames(vm).codePublicName(), code, JSC::PropertyAttribute::DontEnum | 0);
@@ -3270,9 +3271,12 @@ JSC_DEFINE_HOST_FUNCTION(Process_functiongetgroups, (JSGlobalObject * globalObje
     return JSValue::encode(groups);
 }
 
+// Node's validateId(), shared by the set*id, setgroups, and initgroups arguments.
+static constexpr ASCIILiteral idTypes[] = { "number"_s, "string"_s };
+
 static JSValue maybe_uid_by_name(JSC::ThrowScope& throwScope, JSGlobalObject* globalObject, JSValue value)
 {
-    if (!value.isNumber() && !value.isString()) return JSValue::decode(Bun::ERR::INVALID_ARG_TYPE(throwScope, globalObject, "id"_s, "number or string"_s, value));
+    if (!value.isNumber() && !value.isString()) return JSValue::decode(Bun::ERR::INVALID_ARG_TYPE(throwScope, globalObject, "id"_s, idTypes, value));
     if (!value.isString()) return value;
 
     auto str = value.getString(globalObject);
@@ -3294,7 +3298,7 @@ static JSValue maybe_uid_by_name(JSC::ThrowScope& throwScope, JSGlobalObject* gl
 
 static JSValue maybe_gid_by_name(JSC::ThrowScope& throwScope, JSGlobalObject* globalObject, JSValue value)
 {
-    if (!value.isNumber() && !value.isString()) return JSValue::decode(Bun::ERR::INVALID_ARG_TYPE(throwScope, globalObject, "id"_s, "number or string"_s, value));
+    if (!value.isNumber() && !value.isString()) return JSValue::decode(Bun::ERR::INVALID_ARG_TYPE(throwScope, globalObject, "id"_s, idTypes, value));
     if (!value.isString()) return value;
 
     auto str = value.getString(globalObject);
@@ -3430,7 +3434,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionsetgroups, (JSGlobalObject * globalObje
             groupsStack[i] = item.toUInt32(globalObject);
             continue;
         }
-        return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, name, "number or string"_s, item);
+        return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, name, idTypes, item);
     }
 
     auto result = callWithoutThreadSuspension([&] { return setgroups(count, groupsStack); });
@@ -3438,10 +3442,6 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionsetgroups, (JSGlobalObject * globalObje
     RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(jsNumber(result));
 }
-
-// Node reports initgroups argument-type failures as
-// "must be one of type number or string".
-static constexpr ASCIILiteral initgroupsIdTypes[] = { "number"_s, "string"_s };
 
 JSC_DEFINE_HOST_FUNCTION(Process_functioninitgroups, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
@@ -3455,13 +3455,13 @@ JSC_DEFINE_HOST_FUNCTION(Process_functioninitgroups, (JSGlobalObject * globalObj
     // negatives, and non-integers fail deterministically instead of being
     // coerced into an unrelated uid/gid by toUInt32().
     if (!user.isNumber() && !user.isString())
-        return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "user"_s, std::span<const ASCIILiteral> { initgroupsIdTypes }, user);
+        return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "user"_s, idTypes, user);
     if (user.isNumber()) {
         Bun::V::validateUint32(scope, globalObject, user, "user"_s, jsUndefined());
         RETURN_IF_EXCEPTION(scope, {});
     }
     if (!extraGroup.isNumber() && !extraGroup.isString())
-        return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "extraGroup"_s, std::span<const ASCIILiteral> { initgroupsIdTypes }, extraGroup);
+        return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "extraGroup"_s, idTypes, extraGroup);
     if (extraGroup.isNumber()) {
         Bun::V::validateUint32(scope, globalObject, extraGroup, "extraGroup"_s, jsUndefined());
         RETURN_IF_EXCEPTION(scope, {});

--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -840,7 +840,7 @@ JSC::EncodedJSValue INVALID_ARG_TYPE(JSC::ThrowScope& throwScope, JSC::JSGlobalO
     return {};
 }
 
-JSC::EncodedJSValue INVALID_ARG_TYPE(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, WTF::ASCIILiteral arg_name, std::span<const WTF::ASCIILiteral> expected_types, JSC::JSValue val_actual_value)
+JSC::EncodedJSValue INVALID_ARG_TYPE(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, const WTF::String& arg_name, std::span<const WTF::ASCIILiteral> expected_types, JSC::JSValue val_actual_value)
 {
     auto& vm = JSC::getVM(globalObject);
     JSC::MarkedArgumentBuffer types;

--- a/src/jsc/bindings/ErrorCode.h
+++ b/src/jsc/bindings/ErrorCode.h
@@ -88,8 +88,9 @@ namespace ERR {
 JSC::EncodedJSValue INVALID_ARG_TYPE(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, ASCIILiteral message);
 JSC::EncodedJSValue INVALID_ARG_TYPE(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, const WTF::String& arg_name, const WTF::String& expected_type, JSC::JSValue val_actual_value);
 JSC::EncodedJSValue INVALID_ARG_TYPE(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, JSC::JSValue arg_name, const WTF::String& expected_type, JSC::JSValue val_actual_value);
-// Renders Node's multi-type list ("must be one of type number or string").
-JSC::EncodedJSValue INVALID_ARG_TYPE(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, WTF::ASCIILiteral arg_name, std::span<const WTF::ASCIILiteral> expected_types, JSC::JSValue val_actual_value);
+// Takes the list Node passes to ERR_INVALID_ARG_TYPE and renders it the way Node does
+// ("one of type number or string or an instance of Buffer or DataView").
+JSC::EncodedJSValue INVALID_ARG_TYPE(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, const WTF::String& arg_name, std::span<const WTF::ASCIILiteral> expected_types, JSC::JSValue val_actual_value);
 JSC::EncodedJSValue INVALID_ARG_INSTANCE(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, const WTF::String& arg_name, const WTF::String& expected_type, JSC::JSValue val_actual_value);
 JSC::EncodedJSValue INVALID_ARG_TYPE_INSTANCE(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, WTF::ASCIILiteral arg_name, WTF::ASCIILiteral expected_type, WTF::ASCIILiteral expected_instance_types, JSC::JSValue val_actual_value);
 JSC::EncodedJSValue INVALID_ARG_TYPE_INSTANCE(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, WTF::ASCIILiteral arg_name, WTF::ASCIILiteral expected_instance_types, JSC::JSValue val_actual_value);

--- a/src/jsc/bindings/JSStringDecoder.cpp
+++ b/src/jsc/bindings/JSStringDecoder.cpp
@@ -423,7 +423,7 @@ static inline JSC::EncodedJSValue jsStringDecoderPrototypeFunction_writeBody(JSC
             return JSC::JSValue::encode(buffer);
         }
 
-        return Bun::ERR::INVALID_ARG_TYPE(throwScope, lexicalGlobalObject, "buf"_s, "Buffer, TypedArray, or DataView"_s, buffer);
+        return Bun::ERR::INVALID_ARG_INSTANCE(throwScope, lexicalGlobalObject, "buf"_s, "Buffer, TypedArray, or DataView"_s, buffer);
     }
     RELEASE_AND_RETURN(throwScope, JSC::JSValue::encode(castedThis->write(vm, lexicalGlobalObject, reinterpret_cast<uint8_t*>(view->vector()), view->byteLength())));
 }

--- a/src/jsc/bindings/node/crypto/CryptoGenDhKeyPair.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoGenDhKeyPair.cpp
@@ -156,7 +156,7 @@ std::optional<DhKeyPairJobCtx> DhKeyPairJobCtx::fromJS(JSGlobalObject* globalObj
                 return std::nullopt;
             }
         } else {
-            ERR::INVALID_ARG_TYPE(scope, globalObject, "options.prime"_s, "Buffer, TypedArray, or DataView"_s, primeValue);
+            ERR::INVALID_ARG_INSTANCE(scope, globalObject, "options.prime"_s, "Buffer, TypedArray, or DataView"_s, primeValue);
             return std::nullopt;
         }
     } else if (!primeLengthValue.isUndefinedOrNull()) {

--- a/src/jsc/bindings/node/crypto/CryptoHkdf.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoHkdf.cpp
@@ -176,7 +176,8 @@ void copyBufferOrString(JSGlobalObject* lexicalGlobalObject, ThrowScope& scope, 
     } else if (auto* buf = dynamicDowncast<JSArrayBuffer>(value)) {
         buffer.append(buf->impl()->span());
     } else {
-        ERR::INVALID_ARG_TYPE(scope, lexicalGlobalObject, name, "string, ArrayBuffer, TypedArray, Buffer"_s, value);
+        static constexpr ASCIILiteral byteSourceTypes[] = { "string"_s, "ArrayBuffer"_s, "TypedArray"_s, "DataView"_s, "Buffer"_s };
+        ERR::INVALID_ARG_TYPE(scope, lexicalGlobalObject, name, byteSourceTypes, value);
     }
 }
 

--- a/src/jsc/bindings/node/crypto/CryptoPrimes.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoPrimes.cpp
@@ -264,6 +264,8 @@ JSValue GeneratePrimeJob::result(JSGlobalObject* globalObject, JSC::ThrowScope& 
     return JSArrayBuffer::create(vm, globalObject->arrayBufferStructure(), WTF::move(buf));
 }
 
+static constexpr ASCIILiteral addRemTypes[] = { "ArrayBuffer"_s, "TypedArray"_s, "Buffer"_s, "DataView"_s, "bigint"_s };
+
 JSC_DEFINE_HOST_FUNCTION(jsGeneratePrime, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
 {
     auto& vm = lexicalGlobalObject->vm();
@@ -327,7 +329,7 @@ JSC_DEFINE_HOST_FUNCTION(jsGeneratePrime, (JSC::JSGlobalObject * lexicalGlobalOb
         }
         auto* addView = dynamicDowncast<JSC::JSArrayBufferView>(addValue);
         if (!addView) {
-            return ERR::INVALID_ARG_TYPE(scope, lexicalGlobalObject, "options.add"_s, "ArrayBuffer, Buffer, TypedArray, DataView, or bigint"_s, addValue);
+            return ERR::INVALID_ARG_TYPE(scope, lexicalGlobalObject, "options.add"_s, addRemTypes, addValue);
         }
         add.reset(reinterpret_cast<const uint8_t*>(addView->vector()), addView->byteLength());
         if (!add) {
@@ -343,7 +345,7 @@ JSC_DEFINE_HOST_FUNCTION(jsGeneratePrime, (JSC::JSGlobalObject * lexicalGlobalOb
         }
         auto* remView = dynamicDowncast<JSC::JSArrayBufferView>(remValue);
         if (!remView) {
-            return ERR::INVALID_ARG_TYPE(scope, lexicalGlobalObject, "options.rem"_s, "ArrayBuffer, Buffer, TypedArray, DataView, or bigint"_s, remValue);
+            return ERR::INVALID_ARG_TYPE(scope, lexicalGlobalObject, "options.rem"_s, addRemTypes, remValue);
         }
         rem.reset(reinterpret_cast<const uint8_t*>(remView->vector()), remView->byteLength());
         if (!rem) {
@@ -428,7 +430,7 @@ JSC_DEFINE_HOST_FUNCTION(jsGeneratePrimeSync, (JSC::JSGlobalObject * lexicalGlob
         }
         auto* addView = dynamicDowncast<JSC::JSArrayBufferView>(addValue);
         if (!addView) {
-            return ERR::INVALID_ARG_TYPE(scope, lexicalGlobalObject, "options.add"_s, "ArrayBuffer, Buffer, TypedArray, DataView, or bigint"_s, addValue);
+            return ERR::INVALID_ARG_TYPE(scope, lexicalGlobalObject, "options.add"_s, addRemTypes, addValue);
         }
         add.reset(reinterpret_cast<const uint8_t*>(addView->vector()), addView->byteLength());
         if (!add) {
@@ -444,7 +446,7 @@ JSC_DEFINE_HOST_FUNCTION(jsGeneratePrimeSync, (JSC::JSGlobalObject * lexicalGlob
         }
         auto* remView = dynamicDowncast<JSC::JSArrayBufferView>(remValue);
         if (!remView) {
-            return ERR::INVALID_ARG_TYPE(scope, lexicalGlobalObject, "options.rem"_s, "ArrayBuffer, Buffer, TypedArray, DataView, or bigint"_s, remValue);
+            return ERR::INVALID_ARG_TYPE(scope, lexicalGlobalObject, "options.rem"_s, addRemTypes, remValue);
         }
         rem.reset(reinterpret_cast<const uint8_t*>(remView->vector()), remView->byteLength());
         if (!rem) {

--- a/src/jsc/bindings/node/crypto/JSDiffieHellmanConstructor.cpp
+++ b/src/jsc/bindings/node/crypto/JSDiffieHellmanConstructor.cpp
@@ -29,6 +29,8 @@ JSC_DEFINE_HOST_FUNCTION(callDiffieHellman, (JSC::JSGlobalObject * lexicalGlobal
     return JSValue::encode(result);
 }
 
+static constexpr ASCIILiteral dhKeyTypes[] = { "number"_s, "string"_s, "ArrayBuffer"_s, "Buffer"_s, "TypedArray"_s, "DataView"_s };
+
 JSC_DEFINE_HOST_FUNCTION(constructDiffieHellman, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     JSC::VM& vm = globalObject->vm();
@@ -37,7 +39,7 @@ JSC_DEFINE_HOST_FUNCTION(constructDiffieHellman, (JSC::JSGlobalObject * globalOb
     JSValue sizeOrKey = callFrame->argument(0);
 
     if (!sizeOrKey.isNumber() && !sizeOrKey.isString() && !isArrayBufferOrView(sizeOrKey)) {
-        return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "sizeOrKey"_s, "number, string, ArrayBuffer, Buffer, TypedArray, or DataView"_s, sizeOrKey);
+        return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "sizeOrKey"_s, dhKeyTypes, sizeOrKey);
     }
 
     if (sizeOrKey.isNumber()) {
@@ -77,7 +79,7 @@ JSC_DEFINE_HOST_FUNCTION(constructDiffieHellman, (JSC::JSGlobalObject * globalOb
         Bun::V::validateInt32(scope, globalObject, generatorValue, "generator"_s, jsUndefined(), jsUndefined());
         RETURN_IF_EXCEPTION(scope, {});
     } else if (!generatorValue.isString() && !isArrayBufferOrView(generatorValue)) {
-        return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "generator"_s, "number, string, ArrayBuffer, Buffer, TypedArray, or DataView"_s, generatorValue);
+        return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "generator"_s, dhKeyTypes, generatorValue);
     }
 
     ncrypto::DHPointer dh;

--- a/src/jsc/bindings/node/crypto/JSSign.cpp
+++ b/src/jsc/bindings/node/crypto/JSSign.cpp
@@ -431,7 +431,9 @@ JSC_DEFINE_HOST_FUNCTION(jsSignProtoFuncSign, (JSC::JSGlobalObject * lexicalGlob
     }
 
     if (!options.isCell()) {
-        return Bun::ERR::INVALID_ARG_TYPE(scope, lexicalGlobalObject, "key"_s, "ArrayBuffer, Buffer, TypedArray, DataView, string, KeyObject, or CryptoKey"_s, options);
+        // Node: preparePrivateKey(privateKey, 'privateKey') with getKeyTypes(true).
+        static constexpr ASCIILiteral keyTypes[] = { "ArrayBuffer"_s, "Buffer"_s, "TypedArray"_s, "DataView"_s, "string"_s, "KeyObject"_s, "CryptoKey"_s };
+        return Bun::ERR::INVALID_ARG_TYPE(scope, lexicalGlobalObject, "privateKey"_s, keyTypes, options);
     }
 
     JSValue outputEncodingValue = callFrame->argument(1);

--- a/src/jsc/bindings/node/crypto/node_crypto_binding.cpp
+++ b/src/jsc/bindings/node/crypto/node_crypto_binding.cpp
@@ -215,7 +215,8 @@ JSC_DEFINE_HOST_FUNCTION(jsGetCipherInfo, (JSC::JSGlobalObject * lexicalGlobalOb
         Bun::V::validateInt32(scope, lexicalGlobalObject, nameOrNid, "nameOrNid"_s, jsUndefined(), jsUndefined());
         RETURN_IF_EXCEPTION(scope, {});
     } else if (!nameOrNid.isString()) {
-        return Bun::ERR::INVALID_ARG_TYPE(scope, lexicalGlobalObject, "nameOrNid"_s, "string or number"_s, nameOrNid);
+        static constexpr ASCIILiteral nameOrNidTypes[] = { "string"_s, "number"_s };
+        return Bun::ERR::INVALID_ARG_TYPE(scope, lexicalGlobalObject, "nameOrNid"_s, nameOrNidTypes, nameOrNid);
     }
 
     JSValue options = callFrame->argument(1);

--- a/src/jsc/bindings/webcrypto/JSSubtleCrypto.cpp
+++ b/src/jsc/bindings/webcrypto/JSSubtleCrypto.cpp
@@ -376,7 +376,7 @@ static inline JSC::EncodedJSValue jsSubtleCryptoPrototypeFunction_digestBody(JSC
     auto data = convert<IDLUnion<IDLArrayBufferView, IDLArrayBuffer>>(*lexicalGlobalObject, argument1.value());
     if (throwScope.exception()) [[unlikely]] {
         (void)throwScope.tryClearException();
-        return Bun::ERR::INVALID_ARG_TYPE(throwScope, lexicalGlobalObject, "data"_s, "ArrayBuffer, Buffer, TypedArray, or DataView"_s, argument1.value());
+        return Bun::throwError(lexicalGlobalObject, throwScope, Bun::ErrorCode::ERR_INVALID_ARG_TYPE, "Failed to execute 'digest' on 'SubtleCrypto': 2nd argument is not instance of ArrayBuffer, Buffer, TypedArray, or DataView."_s);
     }
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLPromise<IDLAny>>(*lexicalGlobalObject, *castedThis->globalObject(), throwScope, [&]() -> decltype(auto) { return impl.digest(*uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject), WTF::move(algorithm), WTF::move(data), WTF::move(promise)); })));
 }

--- a/test/js/node/crypto/node-crypto.test.js
+++ b/test/js/node/crypto/node-crypto.test.js
@@ -1223,3 +1223,101 @@ describe("Certificate spkac argument validation", () => {
     expect(new crypto.Certificate().verifySpkac("not a spkac", "utf8")).toBe(false);
   });
 });
+
+// These native entry points used to hand ERR_INVALID_ARG_TYPE an already flattened
+// "A, B, or C" string, which always rendered as "must be of type A, B, or C". Node
+// passes a list and groups it into "one of type ..." (primitives) and "an instance
+// of ..." (classes); the messages below are Node v26.3.0's verbatim.
+describe("ERR_INVALID_ARG_TYPE messages group accepted types like Node", () => {
+  const dhTypes =
+    "must be one of type number or string or an instance of ArrayBuffer, Buffer, TypedArray, or DataView.";
+  const addRemTypes = "must be of type bigint or an instance of ArrayBuffer, TypedArray, Buffer, or DataView.";
+  const byteSourceTypes = "must be of type string or an instance of ArrayBuffer, TypedArray, DataView, or Buffer.";
+  const keyTypes =
+    "must be of type string or an instance of ArrayBuffer, Buffer, TypedArray, DataView, KeyObject, or CryptoKey.";
+
+  it.each([
+    [
+      "createDiffieHellman(sizeOrKey)",
+      () => crypto.createDiffieHellman({}),
+      `The "sizeOrKey" argument ${dhTypes} Received an instance of Object`,
+    ],
+    [
+      "new DiffieHellman(sizeOrKey)",
+      () => new crypto.DiffieHellman(true),
+      `The "sizeOrKey" argument ${dhTypes} Received type boolean (true)`,
+    ],
+    [
+      "createDiffieHellman(prime, generator)",
+      () => crypto.createDiffieHellman(Buffer.from("abcd", "hex"), {}),
+      `The "generator" argument ${dhTypes} Received an instance of Object`,
+    ],
+    [
+      "getCipherInfo(nameOrNid)",
+      () => crypto.getCipherInfo({}),
+      'The "nameOrNid" argument must be one of type string or number. Received an instance of Object',
+    ],
+    [
+      "generatePrimeSync options.add",
+      () => crypto.generatePrimeSync(8, { add: {} }),
+      `The "options.add" property ${addRemTypes} Received an instance of Object`,
+    ],
+    [
+      "generatePrimeSync options.rem",
+      () => crypto.generatePrimeSync(8, { rem: "x" }),
+      `The "options.rem" property ${addRemTypes} Received type string ('x')`,
+    ],
+    [
+      "generatePrime options.add",
+      () => crypto.generatePrime(8, { add: {} }, () => {}),
+      `The "options.add" property ${addRemTypes} Received an instance of Object`,
+    ],
+    [
+      "generatePrime options.rem",
+      () => crypto.generatePrime(8, { rem: 1 }, () => {}),
+      `The "options.rem" property ${addRemTypes} Received type number (1)`,
+    ],
+    [
+      "hkdfSync salt",
+      () => crypto.hkdfSync("sha256", "key", {}, "info", 16),
+      `The "salt" argument ${byteSourceTypes} Received an instance of Object`,
+    ],
+    [
+      "hkdfSync info",
+      () => crypto.hkdfSync("sha256", "key", "salt", 123, 16),
+      `The "info" argument ${byteSourceTypes} Received type number (123)`,
+    ],
+    [
+      "hkdf salt",
+      () => crypto.hkdf("sha256", "key", 123, "info", 16, () => {}),
+      `The "salt" argument ${byteSourceTypes} Received type number (123)`,
+    ],
+    [
+      "hkdf info",
+      () => crypto.hkdf("sha256", "key", "salt", {}, 16, () => {}),
+      `The "info" argument ${byteSourceTypes} Received an instance of Object`,
+    ],
+    [
+      "generateKeyPairSync dh options.prime",
+      () => crypto.generateKeyPairSync("dh", { prime: "x" }),
+      "The \"options.prime\" property must be an instance of Buffer, TypedArray, or DataView. Received type string ('x')",
+    ],
+    [
+      "generateKeyPair dh options.prime",
+      () => crypto.generateKeyPair("dh", { prime: {} }, () => {}),
+      'The "options.prime" property must be an instance of Buffer, TypedArray, or DataView. Received an instance of Object',
+    ],
+    [
+      "Sign#sign(privateKey)",
+      () => crypto.createSign("SHA256").update("data").sign(123),
+      `The "privateKey" argument ${keyTypes} Received type number (123)`,
+    ],
+    [
+      "Sign#sign(privateKey) boolean",
+      () => crypto.createSign("SHA256").update("data").sign(true),
+      `The "privateKey" argument ${keyTypes} Received type boolean (true)`,
+    ],
+  ])("%s", (_label, fn, message) => {
+    expect(fn).toThrow(expect.objectContaining({ name: "TypeError", code: "ERR_INVALID_ARG_TYPE", message }));
+  });
+});

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -2365,6 +2365,43 @@ it.skipIf(isWindows)("process.initgroups pre-resolves a numeric uid through pass
   expect(err?.message).toContain("User identifier does not exist: 2147483646");
 });
 
+// Node validates all of these ids with validateId(), which passes ['number', 'string'] to
+// ERR_INVALID_ARG_TYPE; a list of primitives renders as "one of type ...". Every call below
+// fails validation before any syscall, so this runs fine as an unprivileged user.
+describe.skipIf(isWindows)("credential setters report invalid ids with Node's message", () => {
+  const idMessage = (name, received) =>
+    `The "${name}" argument must be one of type number or string. Received ${received}`;
+
+  it.each([
+    ["setuid", () => process.setuid({}), idMessage("id", "an instance of Object")],
+    ["seteuid", () => process.seteuid(true), idMessage("id", "type boolean (true)")],
+    ["setgid", () => process.setgid([]), idMessage("id", "an instance of Array")],
+    ["setegid", () => process.setegid(null), idMessage("id", "null")],
+    ["setgroups", () => process.setgroups([1, true]), idMessage("groups[1]", "type boolean (true)")],
+    ["initgroups user", () => process.initgroups({}, 1), idMessage("user", "an instance of Object")],
+    ["initgroups extraGroup", () => process.initgroups("root", {}), idMessage("extraGroup", "an instance of Object")],
+  ])("process.%s", (_name, fn, message) => {
+    expect(fn).toThrow(expect.objectContaining({ name: "TypeError", code: "ERR_INVALID_ARG_TYPE", message }));
+  });
+});
+
+it("process.emitWarning reports a non-string, non-Error warning with Node's message", () => {
+  // Node passes ['Error', 'string'], which renders as "of type string or an instance of Error".
+  for (const [warning, received] of [
+    [123, "type number (123)"],
+    [{}, "an instance of Object"],
+    [undefined, "undefined"],
+  ]) {
+    expect(() => process.emitWarning(warning)).toThrow(
+      expect.objectContaining({
+        name: "TypeError",
+        code: "ERR_INVALID_ARG_TYPE",
+        message: `The "warning" argument must be of type string or an instance of Error. Received ${received}`,
+      }),
+    );
+  }
+});
+
 it("process.finalization.register does not validate that fn is a function", async () => {
   // Node only validates the ref (obj); a non-callable fn is stored and only
   // fails at exit time. Run in a subprocess so registration doesn't leak into

--- a/test/js/node/string_decoder/string-decoder.test.js
+++ b/test/js/node/string_decoder/string-decoder.test.js
@@ -338,6 +338,24 @@ it("invalid utf-8 at end of stream can sometimes produce more than one replaceme
   expect(decoder.end(Buffer.from("9c", "hex"))).toEqual("\uFFFD\uFFFD");
 });
 
+it("write() rejects a non-buffer with Node's ERR_INVALID_ARG_TYPE message", () => {
+  // Node passes ['Buffer', 'TypedArray', 'DataView'], which renders as "an instance of".
+  const cases = [
+    [123, "type number (123)"],
+    [{}, "an instance of Object"],
+    [null, "null"],
+  ];
+  for (const [input, received] of cases) {
+    expect(() => new RealStringDecoder("utf8").write(input)).toThrow(
+      expect.objectContaining({
+        name: "TypeError",
+        code: "ERR_INVALID_ARG_TYPE",
+        message: `The "buf" argument must be an instance of Buffer, TypedArray, or DataView. Received ${received}`,
+      }),
+    );
+  }
+});
+
 // When the input buffer is too large to be represented as a JS string,
 // write()/end() should throw ERR_STRING_TOO_LONG instead of segfaulting.
 // Previously, Bun__encoding__toString would throw and return an empty JSValue,

--- a/test/js/node/test/parallel/test-process-euid-egid.js
+++ b/test/js/node/test/parallel/test-process-euid-egid.js
@@ -18,7 +18,7 @@ assert.throws(() => {
   process.seteuid({});
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
-  message: 'The "id" argument must be of type number or string. ' +
+  message: 'The "id" argument must be one of type number or string. ' +
     'Received an instance of Object'
 });
 

--- a/test/js/node/test/parallel/test-process-setgroups.js
+++ b/test/js/node/test/parallel/test-process-setgroups.js
@@ -41,7 +41,7 @@ assert.throws(
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
       message: 'The "groups[0]" argument must be ' +
-               'of type number or string.' +
+               'one of type number or string.' +
                common.invalidArgTypeHelper(val)
     }
   );

--- a/test/js/node/test/parallel/test-process-uid-gid.js
+++ b/test/js/node/test/parallel/test-process-uid-gid.js
@@ -40,7 +40,7 @@ assert.throws(() => {
   process.setuid({});
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
-  message: 'The "id" argument must be of type ' +
+  message: 'The "id" argument must be one of type ' +
     'number or string. Received an instance of Object'
 });
 

--- a/test/js/node/test/parallel/test-string-decoder.js
+++ b/test/js/node/test/parallel/test-string-decoder.js
@@ -196,7 +196,7 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "buf" argument must be of type Buffer, TypedArray,' +
+    message: 'The "buf" argument must be an instance of Buffer, TypedArray,' +
       ' or DataView. Received null'
   }
 );

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -106,6 +106,25 @@ describe("Web Crypto", () => {
     expect(isSigValid).toBe(true);
   });
 
+  it("digest with non-buffer data rejects with Node's ERR_INVALID_ARG_TYPE", async () => {
+    // Same webidl-style message node's BufferSource converter produces (and that
+    // importKey already uses below for its buffer formats).
+    for (const data of [123, {}, "abc", null]) {
+      let err: any;
+      try {
+        await crypto.subtle.digest("SHA-256", data as any);
+      } catch (e) {
+        err = e;
+      }
+      expect(err).toBeInstanceOf(TypeError);
+      expect({ code: err.code, message: err.message }).toEqual({
+        code: "ERR_INVALID_ARG_TYPE",
+        message:
+          "Failed to execute 'digest' on 'SubtleCrypto': 2nd argument is not instance of ArrayBuffer, Buffer, TypedArray, or DataView.",
+      });
+    }
+  });
+
   describe("unwrapKey JWK error handling", () => {
     // Setup: AES-GCM key that can encrypt arbitrary bytes and also unwrap keys.
     // We encrypt payloads that decrypt to invalid JWK data so the JWK parse path


### PR DESCRIPTION
### Problem
- Several native (C++) entry points throw `ERR_INVALID_ARG_TYPE` with a different message than Node for the same input, for example:
  - `new StringDecoder().write(123)`: Bun `The "buf" argument must be of type Buffer, TypedArray, or DataView.`, Node `... must be an instance of Buffer, TypedArray, or DataView.`
  - `process.setuid({})`: Bun `The "id" argument must be of type number or string.`, Node `... must be one of type number or string.`
  - `crypto.createDiffieHellman({})`: Bun `... must be of type number, string, ArrayBuffer, Buffer, TypedArray, or DataView.`, Node `... must be one of type number or string or an instance of ArrayBuffer, Buffer, TypedArray, or DataView.`
  - `process.emitWarning(123)`: Bun `... must be of type string or Error.`, Node `... must be of type string or an instance of Error.`
- Cause: these call sites pass one pre-flattened string (`"number or string"_s`, `"Buffer, TypedArray, or DataView"_s`, ...) to the single-string overload of `Bun::ERR::INVALID_ARG_TYPE`, which always emits `"of type " + string` (`src/jsc/bindings/ErrorCode.cpp`, `Message::ERR_INVALID_ARG_TYPE`). Node's `lib/internal/errors.js` receives a list and groups it into primitive names and class names.
- The list renderer already exists (`Message::ERR_INVALID_ARG_TYPE(..., ArgList, ...)`, exposed as the `std::span<const ASCIILiteral>` overload of `ERR::INVALID_ARG_TYPE`); `process.initgroups` was its only caller.
- Affected sites (verified one by one against Node v26.3.0, full table in the details block): `StringDecoder#write`, `subtle.digest`, `createDiffieHellman` (`sizeOrKey`, `generator`), `getCipherInfo`, `generatePrime`/`generatePrimeSync` (`options.add`, `options.rem`), `hkdf`/`hkdfSync` (`salt`, `info`), `generateKeyPair("dh")` `options.prime`, `Sign#sign`, `process.emitWarning`, `process.setuid`/`seteuid`/`setgid`/`setegid`, `process.setgroups`.
- Four vendored Node tests (`test-string-decoder`, `test-process-uid-gid`, `test-process-euid-egid`, `test-process-setgroups`) had been edited when they were vendored so that they expect Bun's wording.

### Fix
- Each site now passes the list Node's own source passes (`static constexpr ASCIILiteral xs[] = {...}`) through the span overload, so the grouping is computed by the same renderer Node uses instead of being hand-written per site. The two class-only lists (`StringDecoder#write`, dh `options.prime`) use the existing `ERR::INVALID_ARG_INSTANCE`, the same helper `validateBuffer` uses for this exact list.
- The span overload's `arg_name` parameter is widened from `ASCIILiteral` to `const WTF::String&` so `setgroups` can pass its computed `groups[i]` name; `ASCIILiteral` callers convert implicitly and the existing overloads stay unambiguous (no other overload accepts an array or a span as the expected type).
- `BunProcess.cpp`: the `initgroups` list becomes a shared `idTypes` used by every site that corresponds to Node's `validateId()` (set*id, setgroups, initgroups), so all seven ids render identically.
- `subtle.digest()`: Node's message here comes from its webidl `BufferSource` converter, not from the list renderer, so this site uses the literal webidl message that `importKey()` in the same file already emits.
- `Sign#sign()`: besides the list, the argument is named `privateKey` as in Node's `sig.js` (`preparePrivateKey(privateKey, 'privateKey')`).
- `CryptoHkdf.cpp`: the old string also omitted `DataView` and had no "or"; the list is Node's `validateByteSource` list.
- The four vendored tests are restored to their upstream v26.3.0 text (one line each); they fail on the released binary and pass with this change.
- Why this is correct: every expected message in the added tests is Node v26.3.0's verbatim output for the same call (each table was executed against `node` v26.3.0 before being committed), and the error codes, error classes and accepted inputs are unchanged; only the wording differs.
- Verification:
  - `bun bd test test/js/node/crypto/node-crypto.test.js` (new `describe`, 16 cases: all fail on Bun 1.4.0, pass with this change)
  - `bun bd test test/js/node/process/process.test.js` (new id and emitWarning tests: 6 of 8 cases fail on 1.4.0, the 2 `initgroups` cases document the already-correct site; the one pre-existing failure in that file, `process.env.USER` being unset in the container, is unrelated)
  - `bun bd test test/js/node/string_decoder/string-decoder.test.js`, `bun bd test test/js/web/crypto/web-crypto.test.ts` (one new test each, fail on 1.4.0, pass now)
  - `bun bd test/js/node/test/parallel/<file>.js` for the 4 restored tests plus `test-process-initgroups`, `test-process-emitwarning`, `test-crypto-dh`, `test-crypto-dh-errors`, `test-crypto-hkdf`, `test-crypto-prime`, `test-crypto-getcipherinfo`, `test-crypto-sign-verify`, `test-crypto-keygen-dh-classic`, `test-webcrypto-digest`, `test-process-exception-capture-errors`: all exit 0
  - A probe of 57 calls across these APIs went from 42 messages differing from Node to 9; the remaining 9 are the histogram site owned by #33585 plus different bugs (listed in the details block) that are tracked separately.
- Deliberately not changed here:
  - `KeyObject.cpp` (`createPrivateKey`, raw key formats): #38431.
  - `perf_hooks` `histogram.record()`: #33585 already makes the same change.
  - `process.setUncaughtExceptionCaptureCallback` (`"function or null"`): already renders exactly like Node, since Node's list is `['Function', 'null']`.
  - `process.kill()` signal type check: Node throws `ERR_UNKNOWN_SIGNAL` there rather than a differently worded `ERR_INVALID_ARG_TYPE`, so that is a separate fix.
  - The equivalent JS and Rust callers are #38657 and #38663.

### Background
- `ERR_INVALID_ARG_TYPE` rendering in Node: `expected` is an array; each entry that is one of Node's primitive type names (`string`, `number`, `bigint`, `Function`, `Object`, ...) goes into a "types" bucket rendered as `of type X` (or `one of type X or Y` for several), each entry matching `/^[A-Z][a-zA-Z0-9]*$/` goes into an "instances" bucket rendered as `an instance of A, B, or C`, and the buckets are joined with `or`. So the order of the list does not matter, but which bucket each entry lands in does.
- `Bun::ERR::INVALID_ARG_TYPE` overloads (`src/jsc/bindings/ErrorCode.h`): the `(name, const String& expected, value)` overload is for a single type and prints `of type <expected>` verbatim; the `(name, std::span<const ASCIILiteral>, value)` overload is the port of Node's bucketing above; `INVALID_ARG_INSTANCE(name, "A, B, or C", value)` prints `an instance of ...` for lists that are classes only. `addParameter` picks `argument` or `property` depending on whether the name contains a dot, which is why `options.add` renders as a property.
- `subtle.digest` is a WebCrypto method; Node validates its arguments with its own webidl layer, whose failures are `TypeError`s with `code: 'ERR_INVALID_ARG_TYPE'` and a `Failed to execute '<method>' on 'SubtleCrypto': <n>th argument ...` message, which is why that one site does not use the list renderer.

<details>
<summary>Before/after for every changed site (Node v26.3.0 is the "after" text)</summary>

| Call | Bun before | Now (= Node v26.3.0) |
| --- | --- | --- |
| `new StringDecoder().write(123)` | `The "buf" argument must be of type Buffer, TypedArray, or DataView. Received type number (123)` | `The "buf" argument must be an instance of Buffer, TypedArray, or DataView. Received type number (123)` |
| `crypto.subtle.digest("SHA-256", 123)` | `The "data" argument must be of type ArrayBuffer, Buffer, TypedArray, or DataView. Received type number (123)` | `Failed to execute 'digest' on 'SubtleCrypto': 2nd argument is not instance of ArrayBuffer, Buffer, TypedArray, or DataView.` |
| `createDiffieHellman({})` | `The "sizeOrKey" argument must be of type number, string, ArrayBuffer, Buffer, TypedArray, or DataView. Received an instance of Object` | `The "sizeOrKey" argument must be one of type number or string or an instance of ArrayBuffer, Buffer, TypedArray, or DataView. Received an instance of Object` |
| `createDiffieHellman(prime, {})` | same shape for `"generator"` | same shape for `"generator"` |
| `getCipherInfo({})` | `The "nameOrNid" argument must be of type string or number. Received an instance of Object` | `The "nameOrNid" argument must be one of type string or number. Received an instance of Object` |
| `generatePrimeSync(8, { add: {} })` (also `rem`, also async `generatePrime`) | `The "options.add" property must be of type ArrayBuffer, Buffer, TypedArray, DataView, or bigint. Received an instance of Object` | `The "options.add" property must be of type bigint or an instance of ArrayBuffer, TypedArray, Buffer, or DataView. Received an instance of Object` |
| `hkdfSync("sha256", "key", {}, "info", 16)` (also `info`, also async `hkdf`) | `The "salt" argument must be of type string, ArrayBuffer, TypedArray, Buffer. Received an instance of Object` | `The "salt" argument must be of type string or an instance of ArrayBuffer, TypedArray, DataView, or Buffer. Received an instance of Object` |
| `generateKeyPairSync("dh", { prime: "x" })` | `The "options.prime" property must be of type Buffer, TypedArray, or DataView. Received type string ('x')` | `The "options.prime" property must be an instance of Buffer, TypedArray, or DataView. Received type string ('x')` |
| `createSign("SHA256").sign(123)` | `The "key" argument must be of type ArrayBuffer, Buffer, TypedArray, DataView, string, KeyObject, or CryptoKey. Received type number (123)` | `The "privateKey" argument must be of type string or an instance of ArrayBuffer, Buffer, TypedArray, DataView, KeyObject, or CryptoKey. Received type number (123)` |
| `process.emitWarning(123)` | `The "warning" argument must be of type string or Error. Received type number (123)` | `The "warning" argument must be of type string or an instance of Error. Received type number (123)` |
| `process.setuid({})` (also `seteuid`, `setgid`, `setegid`) | `The "id" argument must be of type number or string. Received an instance of Object` | `The "id" argument must be one of type number or string. Received an instance of Object` |
| `process.setgroups([1, true])` | `The "groups[1]" argument must be of type number or string. Received type boolean (true)` | `The "groups[1]" argument must be one of type number or string. Received type boolean (true)` |

Remaining differences from the probe: `histogram.record("x")` (#33585), and, each a separate bug, `StringDecoder#end(123)` throws a plain `Expected Uint8Array` TypeError; `Sign#sign({ key: 123 })` and `privateDecrypt(123, ...)` say `key`/`key.key` where Node says `privateKey`/`privateKey.key` (the name is not threaded through `KeyObject::prepareAsymmetricKey`); `process.kill(pid, {})` throws `ERR_INVALID_ARG_TYPE` where Node throws `ERR_UNKNOWN_SIGNAL`; and the `kill EINVAL` errno message uses Bun's general system-error format.
</details>
