### PR TITLE
http: restore the "> " and "[fetch] " prefixes on verbose trace request lines

### DIFF
--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -1436,8 +1436,11 @@ pub(crate) fn print_request(
         Protocol::Http2 => "HTTP/2",
         Protocol::Http3 => "HTTP/3",
     };
+    // The templates escape `>`: the pretty formatter drops a bare one as a tag terminator.
+    let prefix = picohttp::trace_line_prefix();
     bun_core::pretty_errorln!(
-        "> {} {} {}",
+        "{}\\> {} {} {}",
+        prefix,
         ver,
         BStr::new(request.method),
         bun_core::fmt::redacted_npm_url(url),
@@ -1450,12 +1453,13 @@ pub(crate) fn print_request(
             let value = header.value();
             let scheme_len = strings::index_of_char_usize(value, b' ').map_or(0, |i| i + 1);
             bun_core::pretty_errorln!(
-                "> <r><cyan>{}<r><d>: <r>{}<d>[redacted]<r>",
+                "{}\\> <r><cyan>{}<r><d>: <r>{}<d>[redacted]<r>",
+                prefix,
                 BStr::new(name),
                 BStr::new(&value[..scheme_len]),
             );
         } else {
-            bun_core::pretty_errorln!("> {}", header);
+            bun_core::pretty_errorln!("{}\\> {}", prefix, header);
         }
     }
     Output::flush();

--- a/src/picohttp/lib.rs
+++ b/src/picohttp/lib.rs
@@ -155,6 +155,17 @@ impl Header {
     }
 }
 
+/// Start of every line of the verbose request/response trace (`[fetch] > ...`,
+/// `[fetch] < ...`). The tag is only shown when stderr has colors; plain output
+/// starts at the `>` / `<`.
+pub fn trace_line_prefix() -> &'static str {
+    if enable_ansi_colors_stderr() {
+        pretty_fmt!("<r><d>[fetch]<r> ", true)
+    } else {
+        ""
+    }
+}
+
 impl fmt::Display for Header {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // NOTE: pretty_fmt! is the compile-time ANSI-tag expander (`<r><cyan>` → escape
@@ -295,28 +306,6 @@ impl<'a> Request<'a> {
             headers: unsafe { &*core::ptr::from_ref::<[Header]>(self.headers) },
             bytes_read: self.bytes_read,
         }
-    }
-}
-
-impl fmt::Display for Request<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if enable_ansi_colors_stderr() {
-            f.write_str(pretty_fmt!("<r><d>[fetch]<r> ", true))?;
-        }
-        writeln!(
-            f,
-            "> HTTP/1.1 {} {}",
-            BStr::new(self.method),
-            BStr::new(self.path)
-        )?;
-        for header in self.headers {
-            if enable_ansi_colors_stderr() {
-                f.write_str(pretty_fmt!("<r><d>[fetch]<r> ", true))?;
-            }
-            f.write_str("> ")?;
-            writeln!(f, "{}", header)?;
-        }
-        Ok(())
     }
 }
 
@@ -556,10 +545,7 @@ impl<'a> Response<'a> {
 
 impl fmt::Display for Response<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if enable_ansi_colors_stderr() {
-            f.write_str(pretty_fmt!("<r><d>[fetch]<r> ", true))?;
-        }
-
+        f.write_str(trace_line_prefix())?;
         writeln!(
             f,
             "< {} {}",
@@ -569,10 +555,7 @@ impl fmt::Display for Response<'_> {
             BStr::new(self.status),
         )?;
         for header in self.headers.list {
-            if enable_ansi_colors_stderr() {
-                f.write_str(pretty_fmt!("<r><d>[fetch]<r> ", true))?;
-            }
-
+            f.write_str(trace_line_prefix())?;
             f.write_str("< ")?;
             writeln!(f, "{}", header)?;
         }

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -3592,10 +3592,88 @@ it("verbose fetch logging prints [redacted] in place of Authorization credential
 
   expect(stdout).toBe("Bearer sekret-token\n");
   const authorizationLines = stderr.split(/\r?\n/).flatMap(line => {
-    const match = /^(?:\[fetch\])?\s*>?\s*authorization:(.*)$/i.exec(line);
+    const match = /^> authorization:(.*)$/i.exec(line);
     return match ? [match[1].trim()] : [];
   });
   expect(authorizationLines).toEqual(["Bearer [redacted]"]);
   expect(stderr).not.toContain("sekret-token");
   expect(exitCode).toBe(0);
+});
+
+describe.concurrent("verbose fetch logging line prefixes", () => {
+  // Every line of the trace starts with "> " (request) or "< " (response). On a
+  // color terminal each line is additionally tagged with a dim "[fetch] ".
+  const fetchTag = "\x1b[0m\x1b[2m[fetch]\x1b[0m ";
+
+  async function traceLines(env: Record<string, string | undefined>) {
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response("ok", { headers: { "x-response-header": "yes" } });
+      },
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const init = { headers: { "Authorization": "Bearer sekret-token", "x-request-header": "yes" } };
+         if (process.env.FETCH_VERBOSE) init.verbose = true;
+         const res = await fetch(process.env.SERVER_URL, init);
+         console.log(await res.text());`,
+      ],
+      env: { ...bunEnv, SERVER_URL: server.url.href, ...env },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("ok\n");
+    expect(exitCode).toBe(0);
+    return { url: server.url.href, lines: stderr.split(/\r?\n/).filter(line => line.length > 0) };
+  }
+
+  it("verbose: true prints > request lines and < response lines", async () => {
+    const { url, lines } = await traceLines({ FETCH_VERBOSE: "1" });
+
+    expect(lines.filter(line => !/^[<>] /.test(line))).toEqual([]);
+    expect(lines[0]).toBe(`> HTTP/1.1 GET ${url}`);
+    expect(lines).toContain("> Authorization: Bearer [redacted]");
+    expect(lines).toContain("> x-request-header: yes");
+    expect(lines).toContain("< 200 OK");
+    expect(lines).toContain("< x-response-header: yes");
+  });
+
+  it("BUN_CONFIG_VERBOSE_FETCH=1 prints > request lines and < response lines", async () => {
+    const { url, lines } = await traceLines({ BUN_CONFIG_VERBOSE_FETCH: "1" });
+
+    expect(lines.filter(line => !/^[<>] /.test(line))).toEqual([]);
+    expect(lines[0]).toBe(`> HTTP/1.1 GET ${url}`);
+    expect(lines).toContain("> x-request-header: yes");
+    expect(lines).toContain("< 200 OK");
+  });
+
+  it("BUN_CONFIG_VERBOSE_FETCH=curl prints the curl line, then > request lines", async () => {
+    const { url, lines } = await traceLines({ BUN_CONFIG_VERBOSE_FETCH: "curl" });
+
+    expect(lines[0]).toStartWith(`curl --http1.1 "${url}"`);
+    expect(lines.slice(1).filter(line => !/^[<>] /.test(line))).toEqual([]);
+    expect(lines[1]).toBe(`> HTTP/1.1 GET ${url}`);
+    expect(lines).toContain("> x-request-header: yes");
+    expect(lines).toContain("< 200 OK");
+  });
+
+  it("with colors, request lines get the same [fetch] tag as response lines", async () => {
+    const { url, lines } = await traceLines({ FETCH_VERBOSE: "1", NO_COLOR: undefined, FORCE_COLOR: "1" });
+
+    expect(lines.filter(line => !line.startsWith(fetchTag))).toEqual([]);
+    expect(lines[0]).toBe(`${fetchTag}> HTTP/1.1 GET ${url}`);
+
+    const plain = lines.map(line => Bun.stripANSI(line));
+    expect(plain.filter(line => !/^\[fetch\] [<>] /.test(line))).toEqual([]);
+    expect(plain).toContain("[fetch] > Authorization: Bearer [redacted]");
+    expect(plain).toContain("[fetch] > x-request-header: yes");
+    expect(plain).toContain("[fetch] < 200 OK");
+    expect(plain).toContain("[fetch] < x-response-header: yes");
+  });
 });


### PR DESCRIPTION
### Problem

- The verbose HTTP client trace (`fetch(url, { verbose: true })`, `BUN_CONFIG_VERBOSE_FETCH=1|curl`, `bun install --verbose`) is documented (docs/runtime/networking/fetch.mdx, docs/runtime/debugger.mdx) as printing request lines as `[fetch] > HTTP/1.1 GET http://example.com/` / `[fetch] > Connection: keep-alive` and response lines as `[fetch] < 200 OK`.
- Since the Rust port, request lines print without their prefix. Released 1.4.0, `NO_COLOR=1`:
  ```
   HTTP/1.1 GET http://localhost:35399/
   Authorization: Bearer [redacted]
   Connection: keep-alive
  < 200 OK
  < Content-Length: 2
  ```
  With colors (`FORCE_COLOR=1` or a terminal) the response lines also carry the dim `[fetch] ` tag and the request lines still carry nothing.
- Cause, `print_request` in `src/http/lib.rs:1439-1459`: the three templates passed to `pretty_errorln!` start with a bare `> `. In the pretty template language a bare `>` is a tag terminator (`<cyan>`'s closing character) and is dropped (`src/bun_core_macros/lib.rs:112`, mirrored by `pretty_fmt_runtime` in `src/bun_core/output.rs`); a literal `>` has to be written `\\>`. The response side is unaffected because `picohttp::Response`'s `Display` writes `< ` through `write_str`, not through a template.
- The `[fetch] ` tag was dropped by the same port: the Zig `printRequest` wrote the tag plus `> ` through the raw error writer, and the port replaced that with the templates above (the original port left a `TODO(port)` about the missing prefix, later removed without restoring it).

### Fix

- `src/http/lib.rs` `print_request`: the three templates escape the `>` (`"{}\\> ..."`), and each line starts with `picohttp::trace_line_prefix()`.
- `src/picohttp/lib.rs`: new `trace_line_prefix()` returns the `<r><d>[fetch]<r> ` expansion when stderr has colors and `""` otherwise, and `Response`'s `Display` now uses it in place of its two inline copies of that condition and literal (same condition, same literal, so response output is byte for byte unchanged). The unused `impl Display for picohttp::Request` (a second, stale copy of the request format: hardcoded `HTTP/1.1`, no credential redaction, no callers since the port) is deleted rather than updated.
- Why this is the right output: `\\>` is the established spelling of a literal `>` in these templates (`src/install/lockfile/printer/tree_printer.rs` `-\\>`, `src/runtime/test_runner/expect/toHaveBeenCalled.rs` `\\>=`, the `\\<cmd\\>` help texts), and taking the tag from the same function the response lines use makes the two halves of the trace line up the way the docs and the pre-port code had them; the tag staying color-only keeps plain (piped) output identical in shape to the response lines, which already behave that way.
- Other templates in the tree with an unescaped `>` (the `->` arrows in some `bun install --verbose` and bin-linker messages, etc.) are unrelated output and are not touched here.
- Overlaps with #38673 (control-character escaping in the same trace): the two changes are independent and both touch `print_request`'s argument lists, `Response`'s `Display` and the end of `fetch.test.ts`, so whichever lands second needs a trivial rebase.
- Verified with `test/js/web/fetch/fetch.test.ts`:
  - new `verbose fetch logging line prefixes` block: `verbose: true`, `BUN_CONFIG_VERBOSE_FETCH=1` and `=curl` (plain output: every trace line starts with `> ` or `< `, exact first line `> HTTP/1.1 GET <url>`, the redacted `Authorization` line, a custom header, `< 200 OK`), and `FORCE_COLOR=1` (every line starts with the exact `\x1b[0m\x1b[2m[fetch]\x1b[0m ` bytes, and after `Bun.stripANSI` every line matches `[fetch] > ` / `[fetch] < `).
  - the existing `[redacted]` test now requires the `> ` prefix instead of tolerating its absence (`>?`), which is how this went unnoticed.
  - All five fail on the released binary (request lines start with a space) and pass with this branch; `test/regression/issue/12042.test.ts` (curl trace) still passes. The rest of `fetch.test.ts` has the same set of `localhost`/IPv6 and root-permission failures here with and without this change.
  - `cargo check -p bun_picohttp -p bun_http` and `cargo fmt` are clean.

### Background

- Pretty templates: `pretty_errorln!` and friends take a template in which `<cyan>`, `<d>` (dim), `<r>` (reset) and so on are rewritten at compile time into ANSI escapes, or stripped when the destination has no colors (`bun_core::pretty_fmt!`). Only the template is rewritten; `{}` arguments are substituted afterwards and are never scanned for tags, which is why header values containing `>` were always printed intact and only the template's own `>` went missing.
- `HTTPVerboseLevel::Headers` prints the `>` / `<` lines; `Curl` additionally prints a copy-pasteable `curl` command first. HTTP/1.1, h2 and h3 all call the same `print_request`, so the three protocols share this fix; `print_response` formats the response through `picohttp::Response`'s `Display`.
- `FORCE_COLOR=1` makes `Output` enable colors on a piped stderr (and overrides `NO_COLOR`), which is how the color case is exercised from a test.
