### PR TITLE
css: do not add transition entries the declaration already lists

### DIFF
--- a/src/css/properties/transition.rs
+++ b/src/css/properties/transition.rs
@@ -17,6 +17,7 @@ use crate::css_values::time::Time;
 use crate::VendorPrefix;
 use crate::compat;
 use crate::prefixes::Feature;
+use crate::targets::Targets;
 
 /// A value for the [transition](https://www.w3.org/TR/2018/WD-css-transitions-1-20181011/#transition-shorthand-property) property.
 #[derive(Clone, PartialEq)]
@@ -510,6 +511,10 @@ mod transition_handler_body {
             }
         }
 
+        // Entries the declaration already spells out (`-webkit-transform, transform`,
+        // which is also what this handler's own output looks like when a merged rule
+        // is minified again) must not be generated a second time below.
+        let as_written: SmallList<PropertyId, 4> = properties.iter().copied().collect();
         let mut rtl_properties: Option<SmallList<PropertyId, 1>> = None;
         let mut i: u32 = 0;
 
@@ -543,38 +548,23 @@ mod transition_handler_body {
                 }
                 _ => {
                     let index = i;
-                    // Expand vendor prefixes for targets.
-                    properties.slice_mut()[index as usize]
-                        .set_prefixes_for_targets(&context.targets);
-
-                    // Expand mask properties, which use different vendor-prefixed names.
+                    let targets = &context.targets;
+                    expand_prefixes(properties.r#mut(index), &as_written, targets);
                     if let Some(property_id) =
-                        masking::get_webkit_mask_property(properties.at(index))
+                        webkit_mask_property_to_insert(properties.at(index), &as_written, targets)
                     {
-                        if context
-                            .targets
-                            .prefixes(VendorPrefix::NONE, Feature::MaskBorder)
-                            .contains(VendorPrefix::WEBKIT)
-                        {
-                            properties.insert(index, property_id);
-                            i += 1;
-                        }
+                        properties.insert(index, property_id);
+                        i += 1;
                     }
 
                     if let Some(rtl_props) = &mut rtl_properties {
-                        rtl_props.slice_mut()[index as usize]
-                            .set_prefixes_for_targets(&context.targets);
-
-                        if let Some(property_id) =
-                            masking::get_webkit_mask_property(rtl_props.at(index))
-                        {
-                            if context
-                                .targets
-                                .prefixes(VendorPrefix::NONE, Feature::MaskBorder)
-                                .contains(VendorPrefix::WEBKIT)
-                            {
-                                rtl_props.insert(index, property_id);
-                            }
+                        expand_prefixes(rtl_props.r#mut(index), &as_written, targets);
+                        if let Some(property_id) = webkit_mask_property_to_insert(
+                            rtl_props.at(index),
+                            &as_written,
+                            targets,
+                        ) {
+                            rtl_props.insert(index, property_id);
                         }
                     }
                     i += 1;
@@ -583,6 +573,40 @@ mod transition_handler_body {
         }
 
         rtl_properties
+    }
+
+    /// Expands the vendor prefixes of `property_id` for the targets, minus the
+    /// prefixes that other entries of the same property in `as_written` already
+    /// carry: `-webkit-transform, transform` expands `transform` to the remaining
+    /// prefixes only, so each entry keeps its own duration, delay and timing function.
+    fn expand_prefixes(property_id: &mut PropertyId, as_written: &[PropertyId], targets: &Targets) {
+        let written = property_id.prefix();
+        property_id.set_prefixes_for_targets(targets);
+        let added = property_id.prefix().difference(written);
+        if added.is_empty() {
+            return;
+        }
+
+        let listed = as_written
+            .iter()
+            .filter(|p| p.tag() == property_id.tag())
+            .fold(VendorPrefix::empty(), |listed, p| listed | p.prefix());
+        *property_id = property_id.with_prefix(property_id.prefix().difference(added & listed));
+    }
+
+    /// The `-webkit-` mask property that animates alongside `property_id` for the
+    /// targets (`mask-border` -> `-webkit-mask-box-image`, which has a different
+    /// name rather than a prefix), unless the declaration already lists it.
+    fn webkit_mask_property_to_insert(
+        property_id: &PropertyId,
+        as_written: &[PropertyId],
+        targets: &Targets,
+    ) -> Option<PropertyId> {
+        let webkit = masking::get_webkit_mask_property(property_id)?;
+        let needed = targets
+            .prefixes(VendorPrefix::NONE, Feature::MaskBorder)
+            .contains(VendorPrefix::WEBKIT);
+        (needed && !as_written.contains(&webkit)).then_some(webkit)
     }
 
     enum LogicalPropertyId {

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -6981,6 +6981,292 @@ describe("css tests", () => {
       },
     );
 
+    // A prefixed entry the list already spells out is not generated again. This is what
+    // the handler's own output looks like when a block runs through it a second time
+    // (merged rules below, the generated :lang() rules further down), and also what
+    // already-autoprefixed stylesheets look like.
+    prefix_test(
+      `
+      .foo {
+        transition: -webkit-transform .3s, transform .3s, opacity .2s;
+      }
+    `,
+      `
+      .foo {
+        -webkit-transition: -webkit-transform .3s, transform .3s, opacity .2s;
+        transition: -webkit-transform .3s, transform .3s, opacity .2s;
+      }
+    `,
+      {
+        safari: Some(6 << 16),
+      },
+    );
+
+    // Each entry keeps its own duration.
+    prefix_test(
+      `
+      .foo {
+        transition: -webkit-transform 2s, transform 1s;
+      }
+    `,
+      `
+      .foo {
+        -webkit-transition: -webkit-transform 2s, transform 1s;
+        transition: -webkit-transform 2s, transform 1s;
+      }
+    `,
+      {
+        safari: Some(6 << 16),
+      },
+    );
+
+    prefix_test(
+      `
+      .foo {
+        transition: transform 1s, -webkit-transform 1s;
+      }
+    `,
+      `
+      .foo {
+        -webkit-transition: transform 1s, -webkit-transform 1s;
+        transition: transform 1s, -webkit-transform 1s;
+      }
+    `,
+      {
+        safari: Some(6 << 16),
+      },
+    );
+
+    prefix_test(
+      `
+      .foo {
+        transition-property: -webkit-transform, transform;
+      }
+    `,
+      `
+      .foo {
+        -webkit-transition-property: -webkit-transform, transform;
+        transition-property: -webkit-transform, transform;
+      }
+    `,
+      {
+        safari: Some(6 << 16),
+      },
+    );
+
+    // Only the prefixes are deduplicated. Listing the same property twice is meaningful
+    // (the last entry wins), so both entries are still expanded.
+    prefix_test(
+      `
+      .foo {
+        transition: transform 1s, transform 2s;
+      }
+    `,
+      `
+      .foo {
+        -webkit-transition: -webkit-transform 1s, transform 1s, -webkit-transform 2s, transform 2s;
+        transition: -webkit-transform 1s, transform 1s, -webkit-transform 2s, transform 2s;
+      }
+    `,
+      {
+        safari: Some(6 << 16),
+      },
+    );
+
+    // Merging the two .foo rules minifies the merged block again.
+    prefix_test(
+      `
+      .foo {
+        color: red;
+      }
+
+      .foo {
+        transition: opacity .2s, transform .2s;
+      }
+    `,
+      `
+      .foo {
+        color: red;
+        -webkit-transition: opacity .2s, -webkit-transform .2s, transform .2s;
+        transition: opacity .2s, -webkit-transform .2s, transform .2s;
+      }
+    `,
+      {
+        safari: Some(6 << 16),
+      },
+    );
+
+    // Every @media rule merged into the first one minifies the merged body again.
+    prefix_test(
+      `
+      @media (min-width: 100px) {
+        .foo {
+          transition: transform .2s;
+        }
+      }
+
+      @media (min-width: 100px) {
+        .bar {
+          color: red;
+        }
+      }
+
+      @media (min-width: 100px) {
+        .baz {
+          color: green;
+        }
+      }
+    `,
+      `
+      @media (min-width: 100px) {
+        .foo {
+          -webkit-transition: -webkit-transform .2s, transform .2s;
+          transition: -webkit-transform .2s, transform .2s;
+        }
+
+        .bar {
+          color: red;
+        }
+
+        .baz {
+          color: green;
+        }
+      }
+    `,
+      {
+        safari: Some(6 << 16),
+      },
+    );
+
+    // The rules generated for a logical property are minified again as well.
+    prefix_test(
+      `
+      .foo {
+        transition: margin-inline-start .2s, transform .2s;
+      }
+    `,
+      `
+      .foo:not(:-webkit-any(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi))) {
+        transition: margin-left .2s, -webkit-transform .2s, transform .2s;
+      }
+
+      .foo:not(:is(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi))) {
+        transition: margin-left .2s, -webkit-transform .2s, transform .2s;
+      }
+
+      .foo:-webkit-any(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi)) {
+        transition: margin-right .2s, -webkit-transform .2s, transform .2s;
+      }
+
+      .foo:is(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi)) {
+        transition: margin-right .2s, -webkit-transform .2s, transform .2s;
+      }
+    `,
+      {
+        safari: Some(8 << 16),
+      },
+    );
+
+    // For targets that need it, mask-border gets -webkit-mask-box-image inserted in front of
+    // it (a different name, not a prefix); that entry is not inserted again when it is
+    // already listed.
+    prefix_test(
+      `
+      .foo {
+        transition: mask-border .2s;
+      }
+    `,
+      `
+      .foo {
+        transition: -webkit-mask-box-image .2s, mask-border .2s;
+      }
+    `,
+      {
+        safari: Some(15 << 16),
+      },
+    );
+
+    prefix_test(
+      `
+      .foo {
+        transition: mask-border .2s;
+      }
+    `,
+      `
+      .foo {
+        transition: mask-border .2s;
+      }
+    `,
+      {
+        safari: Some(16 << 16),
+      },
+    );
+
+    prefix_test(
+      `
+      .foo {
+        transition: -webkit-mask-box-image .2s, mask-border .2s;
+      }
+    `,
+      `
+      .foo {
+        transition: -webkit-mask-box-image .2s, mask-border .2s;
+      }
+    `,
+      {
+        safari: Some(15 << 16),
+      },
+    );
+
+    prefix_test(
+      `
+      .foo {
+        color: red;
+      }
+
+      .foo {
+        transition: mask-border .2s;
+      }
+    `,
+      `
+      .foo {
+        color: red;
+        transition: -webkit-mask-box-image .2s, mask-border .2s;
+      }
+    `,
+      {
+        safari: Some(15 << 16),
+      },
+    );
+
+    prefix_test(
+      `
+      .foo {
+        transition: margin-inline-start .2s, mask-border .2s;
+      }
+    `,
+      `
+      .foo:not(:-webkit-any(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi))) {
+        transition: margin-left .2s, -webkit-mask-box-image .2s, mask-border .2s;
+      }
+
+      .foo:not(:is(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi))) {
+        transition: margin-left .2s, -webkit-mask-box-image .2s, mask-border .2s;
+      }
+
+      .foo:-webkit-any(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi)) {
+        transition: margin-right .2s, -webkit-mask-box-image .2s, mask-border .2s;
+      }
+
+      .foo:is(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi)) {
+        transition: margin-right .2s, -webkit-mask-box-image .2s, mask-border .2s;
+      }
+    `,
+      {
+        safari: Some(8 << 16),
+      },
+    );
+
     prefix_test(
       `
       .foo {


### PR DESCRIPTION
### Problem

- With CSS targets that need vendor prefixes (this includes `bun build`'s default `browser` target, whose safari 14 entry still prefixes the `mask-*` properties), transition lists come out with duplicated prefixed entries:
  - `.a{color:red} .a{transition: mask-size .3s}` -> `transition: -webkit-mask-size .3s, -webkit-mask-size .3s, mask-size .3s` (plain `bun build a.css`)
  - a run of same-query `@media` rules merged into one gains one more copy per merged rule: three rules give `-webkit-mask-size .3s, -webkit-mask-size .3s, -webkit-mask-size .3s, mask-size .3s`
  - `transition: margin-inline-start .2s, transform .2s` (safari 8) duplicates `-webkit-transform` inside every generated `:lang()` rule, without any rule merging
  - already autoprefixed input does it in a single pass: `transition: -webkit-transform .3s, transform .3s, opacity .2s` (safari 6) -> `-webkit-transform .3s, -webkit-transform .3s, transform .3s, opacity .2s`; same for `transition-property: -webkit-transform, transform`
  - the same for the `-webkit-mask-box-image` entry inserted for `mask-border`: a merged rule or `transition: -webkit-mask-box-image .2s, mask-border .2s` ends up with it twice
- Cause: `expand_properties` in `src/css/properties/transition.rs` expands every unprefixed entry to the full prefix set for the targets (`set_prefixes_for_targets`) and inserts the mask-box-image counterpart of a `mask-border*` entry unconditionally, without looking at what the rest of the list already says. The handler's own output lists every prefix as a separate entry, so each pass over a block adds the expansion again, and rule merging (`flush_pending_style_merge` and the `CssRule::Media` arm in `src/css/rules/mod.rs`) as well as `add_logical_rule` all run a block through the handlers more than once.
- lightningcss 1.30.2 prints each of the inputs above with a single prefixed entry.

### Fix

- `expand_properties` keeps a copy of the list as written. When an entry is expanded for the targets, the prefixes the expansion added that another entry of the same property already carries are dropped again (`expand_prefixes`), and the `-webkit-mask-box-image*` entry is only inserted when the list does not contain it yet (`webkit_mask_property_to_insert`). Both helpers replace the previously duplicated ltr/rtl blocks.
- Why this is the right shape:
  - Only bits the expansion added are ever removed, and no entry is removed or reordered. Each entry therefore keeps its own duration, delay and timing function (in `flush` those lists are paired with the property list by position), and author-written repeats such as `transform 1s, transform 2s` still expand both entries, since the unprefixed bit is never something the expansion added.
  - The handler's output is now a fixed point of the handler: every prefix it generated is present as an explicit entry of the same property, so a second pass adds nothing, and the output no longer depends on how many rules were merged into a block. The merged and `:lang()` outputs now match lightningcss.
  - Upstream handles the explicit-prefix case with `merge_properties()`, which folds later entries of the same property into the first one and drops them while leaving the duration/delay/timing lists alone, so every later entry is paired with the wrong values: lightningcss 1.30.2 turns `transition: -webkit-transform .3s, transform .3s, opacity .2s` into `..., opacity .3s`, also without targets. Bun gets that input right today, so that function is deliberately not ported. Subtracting from the expansion instead gives upstream's output whenever the merged entries have the same values (every re-minify case) and keeps the author's values otherwise.
  - Upstream does not dedupe the mask-box-image insertion either (it duplicates it on a merged rule too); it is covered here because it is the same fixed-point requirement in the same function.
- Verified:
  - `test/js/bun/css/css.test.ts`, `transition` block: 13 new `prefix_test`s (explicit prefixed entry before and after the unprefixed one, different durations per entry, `transition-property`, repeated unprefixed entries, merged same-selector rules, a run of three merged `@media` rules, the `:lang()` rules for a logical property, and mask-border: insertion for safari 15, no insertion for safari 16, explicit entry, merged rule, logical rules). 10 of them fail on the unfixed build with the duplicated entries, the other 3 pin the unchanged behavior they build on; all pass with the fix, along with the rest of the file.
  - `bun bd test test/bundler/css/ test/bundler/esbuild/css.test.ts`: pass.
  - `bun build` on the stylesheet below produces the single-entry output with the fix.

### Background

- Minifying a stylesheet runs every declaration block through the property handlers (`DeclarationHandler`); handlers such as `TransitionHandler` buffer the related declarations and write a minimal form in `finalize`/`flush`. When `CssRuleList::minify` merges a rule into an earlier one with the same selector, or an `@media` rule into the previous one with the same query, the merged block is minified again, and the `:lang()` rules a handler emits through `add_logical_rule` are minified as new rules. So a handler sees its own output as input, and its output has to be stable under that.
- A `PropertyId` of a prefixable property carries a `VendorPrefix` bit set. `Targets::prefixes` replaces a set that contains the unprefixed bit with the full set the browser targets need and returns an explicitly prefixed set unchanged; that is what `set_prefixes_for_targets` applies to each list entry. `flush` then turns a multi-bit entry of a `transition` shorthand into one transition per bit (`get_transitions`), which is why the handler's own output comes back as separate single-prefix entries; a `transition-property` list prints a multi-bit entry as one name per bit.
- `mask-border` and its longhands have no prefixed spelling; WebKit's equivalent is `-webkit-mask-box-image`, a different property, so `masking::get_webkit_mask_property` returns a separate `PropertyId` that the handler inserts in front of the entry instead of setting a prefix bit.

<details>
<summary><code>bun build</code> repro (default targets)</summary>

```css
.a { color: red }
.a { transition: mask-size .3s }
.b { transition: -webkit-mask-size .3s, mask-size .3s, opacity .2s }
@media (min-width: 1px) { .e { transition: mask-size .3s } }
@media (min-width: 1px) { .f { color: blue } }
@media (min-width: 1px) { .g { color: green } }
```

bun 1.4.0 / main:

```css
.a { color: red; transition: -webkit-mask-size .3s, -webkit-mask-size .3s, mask-size .3s; }
.b { transition: -webkit-mask-size .3s, -webkit-mask-size .3s, mask-size .3s, opacity .2s; }
@media (min-width: 1px) {
  .e { transition: -webkit-mask-size .3s, -webkit-mask-size .3s, -webkit-mask-size .3s, mask-size .3s; }
  ...
}
```

with this change:

```css
.a { color: red; transition: -webkit-mask-size .3s, mask-size .3s; }
.b { transition: -webkit-mask-size .3s, mask-size .3s, opacity .2s; }
@media (min-width: 1px) {
  .e { transition: -webkit-mask-size .3s, mask-size .3s; }
  ...
}
```

</details>

<details>
<summary>Comparison with lightningcss 1.30.2 (targets chrome 20, firefox 20, safari 5, ie 9, ios_saf 6, android 4 unless noted)</summary>

| input | bun before | bun after | lightningcss |
| --- | --- | --- | --- |
| `.a{font-weight:bold}.a{transition: opacity 1s, transform 1s}` | `opacity 1s,-webkit-transform 1s,-ms-transform 1s,-webkit-transform 1s,-ms-transform 1s,transform 1s` | `opacity 1s,-webkit-transform 1s,-ms-transform 1s,transform 1s` | same as after |
| three merged `@media (x:1)` rules, first with `transition: opacity 1s, transform 1s` | three copies of `-webkit-transform 1s,-ms-transform 1s` | one | same as after |
| `.a{transition: opacity 1s, -webkit-transform 1s, transform 1s}` | `-webkit-transform` twice | `opacity 1s,-webkit-transform 1s,-ms-transform 1s,transform 1s` | same as after |
| `.a{transition-property: opacity, -webkit-transform, transform}` | `-webkit-transform` twice | `opacity,-webkit-transform,-ms-transform,transform` | same as after |
| `.a{transition: -webkit-transform .3s, transform .3s, opacity .2s}` (safari 6) | `-webkit-transform` twice, `opacity .2s` | `-webkit-transform .3s,transform .3s,opacity .2s` | `-webkit-transform .3s,transform .3s,opacity .3s` |
| `.a{transition: transform 1s, -webkit-transform 1s}` (safari 6) | `-webkit-transform 1s,transform 1s,-webkit-transform 1s` | `transform 1s,-webkit-transform 1s` | `-webkit-transform 1s,transform 1s` |
| `.a{font-weight:bold}.a{transition: mask-border 1s}` | `-webkit-mask-box-image` twice | `-webkit-mask-box-image 1s,mask-border 1s` | `-webkit-mask-box-image` twice |

</details>
