### PR TITLE
node errors: render a single class name in ERR_INVALID_ARG_TYPE as "an instance of" like node

### DIFF
--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -641,6 +641,16 @@ void addParameter(WTF::StringBuilder& result, const StringView& arg_name)
     }
 }
 
+static bool isPrimitiveTypeName(StringView type);
+static bool isClassName(StringView type);
+
+// Node treats a string `expected` as a one-entry list, so a single entry is
+// classified the same way the list overload below classifies each of its
+// entries: kTypes names render "of type x", class names "an instance of X".
+// Callers of this overload also pass pre-rendered lists ("string or an
+// instance of Buffer"), which Node never sees; those keep the verbatim
+// "of type ..." rendering.
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/errors.js#L1404
 WTF::String ERR_INVALID_ARG_TYPE(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, const StringView& arg_name, const StringView& expected_type, JSValue actual_value)
 {
     WTF::StringBuilder result;
@@ -648,27 +658,35 @@ WTF::String ERR_INVALID_ARG_TYPE(JSC::ThrowScope& scope, JSC::JSGlobalObject* gl
     addParameter(result, arg_name);
     result.append(" must be "_s);
 
-    // Node categorizes a free-form phrase like "Array of unique strings"
-    // (spaces, but not a flattened "X, Y, or Z" list) as neither a primitive
-    // type name nor a class name: it renders "must be an Array of unique
-    // strings", not "must be of type ...". Flattened lists keep the legacy
-    // "of type" rendering.
-    bool isPhrase = expected_type.contains(' ') && !expected_type.contains(", "_s) && !expected_type.contains(" or "_s);
-    if (isPhrase) {
-        bool hasUppercase = false;
-        for (unsigned i = 0; i < expected_type.length(); i++) {
-            if (isASCIIUpper(expected_type[i])) {
-                hasUppercase = true;
-                break;
-            }
-        }
-        if (hasUppercase)
-            result.append("an "_s);
-    } else {
+    if (isPrimitiveTypeName(expected_type)) {
         result.append("of type "_s);
+        result.append(expected_type.convertToASCIILowercase());
+    } else if (isClassName(expected_type)) {
+        result.append("an instance of "_s);
+        result.append(expected_type);
+    } else {
+        // Node categorizes a free-form phrase like "Array of unique strings"
+        // (spaces, but not a flattened "X, Y, or Z" list) as neither a primitive
+        // type name nor a class name: it renders "must be an Array of unique
+        // strings", not "must be of type ...". Flattened lists keep the legacy
+        // "of type" rendering.
+        bool isPhrase = expected_type.contains(' ') && !expected_type.contains(", "_s) && !expected_type.contains(" or "_s);
+        if (isPhrase) {
+            bool hasUppercase = false;
+            for (unsigned i = 0; i < expected_type.length(); i++) {
+                if (isASCIIUpper(expected_type[i])) {
+                    hasUppercase = true;
+                    break;
+                }
+            }
+            if (hasUppercase)
+                result.append("an "_s);
+        } else {
+            result.append("of type "_s);
+        }
+        result.append(expected_type);
     }
 
-    result.append(expected_type);
     result.append(". Received "_s);
     determineSpecificType(JSC::getVM(globalObject), globalObject, result, actual_value);
     RETURN_IF_EXCEPTION(scope, {});
@@ -677,7 +695,7 @@ WTF::String ERR_INVALID_ARG_TYPE(JSC::ThrowScope& scope, JSC::JSGlobalObject* gl
 
 // Matches Node's kTypes list: primitive type names accepted by ERR_INVALID_ARG_TYPE.
 // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/errors.js#L72
-static bool isPrimitiveTypeName(const WTF::String& type)
+static bool isPrimitiveTypeName(StringView type)
 {
     return type == "string"_s || type == "function"_s || type == "number"_s
         || type == "object"_s || type == "Function"_s || type == "Object"_s
@@ -685,7 +703,7 @@ static bool isPrimitiveTypeName(const WTF::String& type)
 }
 
 // Matches Node's classRegExp /^[A-Z][a-zA-Z0-9]*$/.
-static bool isClassName(const WTF::String& type)
+static bool isClassName(StringView type)
 {
     if (type.isEmpty() || !isASCIIUpper(type[0]))
         return false;
@@ -889,7 +907,9 @@ JSC::EncodedJSValue INVALID_ARG_TYPE_INSTANCE(JSC::ThrowScope& throwScope, JSC::
     return {};
 }
 
-// When you want INVALID_ARG_TYPE to say "The argument must be an instance of X. Received Y." instead of "The argument must be of type X. Received Y."
+// Renders "must be an instance of <expected_type>" verbatim, so it also takes a
+// pre-rendered list like "Buffer, TypedArray, or DataView". INVALID_ARG_TYPE
+// produces the same text when given a single class name.
 JSC::EncodedJSValue INVALID_ARG_INSTANCE(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, const WTF::String& arg_name, const WTF::String& expected_type, JSC::JSValue val_actual_value)
 {
     auto& vm = JSC::getVM(globalObject);

--- a/src/jsc/bindings/ErrorCode.h
+++ b/src/jsc/bindings/ErrorCode.h
@@ -86,6 +86,10 @@ enum Bound {
 namespace ERR {
 
 JSC::EncodedJSValue INVALID_ARG_TYPE(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, ASCIILiteral message);
+// `expected_type` is classified like a one-entry Node list: a primitive type name renders
+// "must be of type string", a class name "must be an instance of KeyObject", a phrase
+// "must be an Array of unique strings". A pre-rendered list such as "string or an instance of
+// Buffer" is printed as written after "must be of type ".
 JSC::EncodedJSValue INVALID_ARG_TYPE(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, const WTF::String& arg_name, const WTF::String& expected_type, JSC::JSValue val_actual_value);
 JSC::EncodedJSValue INVALID_ARG_TYPE(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, JSC::JSValue arg_name, const WTF::String& expected_type, JSC::JSValue val_actual_value);
 // Renders Node's multi-type list ("must be one of type number or string").

--- a/src/jsc/bindings/JSNodePerformanceHooksHistogramPrototype.cpp
+++ b/src/jsc/bindings/JSNodePerformanceHooksHistogramPrototype.cpp
@@ -119,7 +119,7 @@ JSC_DEFINE_HOST_FUNCTION(jsNodePerformanceHooksHistogramProtoFuncAdd, (JSGlobalO
     JSValue otherArg = callFrame->uncheckedArgument(0);
     JSNodePerformanceHooksHistogram* otherHistogram = dynamicDowncast<JSNodePerformanceHooksHistogram>(otherArg);
     if (!otherHistogram) [[unlikely]] {
-        Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "argument"_s, "Histogram"_s, otherArg);
+        Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "other"_s, "RecordableHistogram"_s, otherArg);
         return {};
     }
 

--- a/src/jsc/bindings/JSX509CertificatePrototype.cpp
+++ b/src/jsc/bindings/JSX509CertificatePrototype.cpp
@@ -328,10 +328,10 @@ JSC_DEFINE_HOST_FUNCTION(jsX509CertificateProtoFuncCheckIssued, (JSGlobalObject 
     if (!thisObject) [[unlikely]]
         return throwVMError(globalObject, scope, createError(globalObject, ErrorCode::ERR_INVALID_THIS, "checkIssued called on incompatible receiver"_s));
 
-    JSX509Certificate* issuer = dynamicDowncast<JSX509Certificate>(callFrame->argument(0));
+    JSValue otherCertValue = callFrame->argument(0);
+    JSX509Certificate* issuer = dynamicDowncast<JSX509Certificate>(otherCertValue);
     if (!issuer) {
-        Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_TYPE, "issuer must be a JSX509Certificate"_s);
-        return {};
+        return ERR::INVALID_ARG_TYPE(scope, globalObject, "otherCert"_s, "X509Certificate"_s, otherCertValue);
     }
 
     auto check = thisObject->checkIssued(globalObject, issuer);

--- a/test/js/bun/perf_hooks/histogram.test.ts
+++ b/test/js/bun/perf_hooks/histogram.test.ts
@@ -99,6 +99,23 @@ describe("Histogram", () => {
     assert.strictEqual(h1.max, 4);
   });
 
+  // Messages verified against node v26.3.0.
+  test("add() rejects a non-histogram with Node's argument name and class name", () => {
+    const h = createHistogram();
+
+    assert.throws(() => h.add(1), {
+      name: "TypeError",
+      code: "ERR_INVALID_ARG_TYPE",
+      message: 'The "other" argument must be an instance of RecordableHistogram. Received type number (1)',
+    });
+    assert.throws(() => h.add({}), {
+      name: "TypeError",
+      code: "ERR_INVALID_ARG_TYPE",
+      message: 'The "other" argument must be an instance of RecordableHistogram. Received an instance of Object',
+    });
+    assert.strictEqual(h.count, 0);
+  });
+
   test("reset functionality", () => {
     const h = createHistogram();
 

--- a/test/js/node/crypto/x509-subclass.test.ts
+++ b/test/js/node/crypto/x509-subclass.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { X509Certificate } from "node:crypto";
+import { createPrivateKey, createPublicKey, X509Certificate } from "node:crypto";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 
@@ -124,8 +124,56 @@ describe("X509Certificate#checkIssued", () => {
     expect(result).toBe(false);
   });
 
+  // Messages verified against node v26.3.0.
   test("throws ERR_INVALID_ARG_TYPE when the argument is not an X509Certificate", () => {
-    expect(() => agent1.checkIssued({} as any)).toThrow();
-    expect(() => agent1.checkIssued("" as any)).toThrow();
+    expect(() => agent1.checkIssued({} as any)).toThrow(
+      expect.objectContaining({
+        name: "TypeError",
+        code: "ERR_INVALID_ARG_TYPE",
+        message: 'The "otherCert" argument must be an instance of X509Certificate. Received an instance of Object',
+      }),
+    );
+    expect(() => agent1.checkIssued("" as any)).toThrow(
+      expect.objectContaining({
+        name: "TypeError",
+        code: "ERR_INVALID_ARG_TYPE",
+        message: `The "otherCert" argument must be an instance of X509Certificate. Received type string ('')`,
+      }),
+    );
+  });
+});
+
+// Messages verified against node v26.3.0.
+describe("X509Certificate#checkPrivateKey and #verify argument validation", () => {
+  const agent1 = new X509Certificate(certPem);
+  const privateKey = createPrivateKey(readFileSync(path.join(keysDir, "agent1-key.pem")));
+  const publicKey = createPublicKey(privateKey);
+
+  test.each([
+    [1, "type number (1)"],
+    [{}, "an instance of Object"],
+    [undefined, "undefined"],
+    [null, "null"],
+    ["pem", "type string ('pem')"],
+  ])("%p is rejected with an instance-of KeyObject message", (value, received) => {
+    const expected = expect.objectContaining({
+      name: "TypeError",
+      code: "ERR_INVALID_ARG_TYPE",
+      message: `The "pkey" argument must be an instance of KeyObject. Received ${received}`,
+    });
+    expect(() => agent1.checkPrivateKey(value as any)).toThrow(expected);
+    expect(() => agent1.verify(value as any)).toThrow(expected);
+  });
+
+  test("a KeyObject of the wrong type is still ERR_INVALID_ARG_VALUE", () => {
+    expect(() => agent1.checkPrivateKey(publicKey)).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE" }));
+    expect(() => agent1.verify(privateKey)).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE" }));
+  });
+
+  test("matching keys are accepted", () => {
+    expect(agent1.checkPrivateKey(privateKey)).toBe(true);
+    // agent1 is signed by ca1, not by its own key.
+    expect(agent1.verify(publicKey)).toBe(false);
+    expect(agent1.verify(new X509Certificate(ca1Pem).publicKey)).toBe(true);
   });
 });

--- a/test/js/node/errors/invalid-arg-type-expected.test.ts
+++ b/test/js/node/errors/invalid-arg-type-expected.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { EventEmitter, addAbortListener, on, once } from "node:events";
+import { Session } from "node:inspector";
+import { timerify } from "node:perf_hooks";
+import { Duplex, Readable, Writable, addAbortSignal } from "node:stream";
+import { SyntheticModule } from "node:vm";
+
+// The "must be ..." half of an ERR_INVALID_ARG_TYPE message is rendered by
+// Message::ERR_INVALID_ARG_TYPE in src/jsc/bindings/ErrorCode.cpp. Node's
+// lib/internal/errors.js treats a string `expected` as a one-entry list and
+// classifies the entry: a kTypes name renders "of type x" (lower-cased), a name
+// matching /^[A-Z][a-zA-Z0-9]*$/ renders "an instance of X", anything else is
+// printed as written. The same formatter is reached from C++ callers that pass a
+// C++ argument name, from C++ validators that receive the name from JS, and from
+// the builtins' $ERR_INVALID_ARG_TYPE(name, "X", value). Every message below is
+// what node v26.3.0 prints for the same call.
+
+function caught(fn: () => unknown) {
+  try {
+    fn();
+  } catch (error: any) {
+    return { name: error.name, code: error.code, message: error.message };
+  }
+  throw new Error("expected the call to throw");
+}
+
+type Case = [label: string, call: () => unknown, message: string];
+
+describe("ERR_INVALID_ARG_TYPE with a single class name renders 'an instance of'", () => {
+  const cases: Case[] = [
+    // C++ caller with a C++ argument name (JSBuffer.cpp copyBytesFrom).
+    [
+      "Buffer.copyBytesFrom(1)",
+      () => Buffer.copyBytesFrom(1 as any),
+      'The "view" argument must be an instance of TypedArray. Received type number (1)',
+    ],
+    [
+      "Buffer.copyBytesFrom({})",
+      () => Buffer.copyBytesFrom({} as any),
+      'The "view" argument must be an instance of TypedArray. Received an instance of Object',
+    ],
+
+    // C++ validator whose argument name comes from JS (NodeValidator.cpp
+    // validateAbortSignal); a dotted name is a "property".
+    [
+      "events.on() with a primitive signal",
+      () => on(new EventEmitter(), "x", { signal: 1 as any }),
+      'The "options.signal" property must be an instance of AbortSignal. Received type number (1)',
+    ],
+    [
+      "events.on() with an object that is not a signal",
+      () => on(new EventEmitter(), "x", { signal: {} as any }),
+      'The "options.signal" property must be an instance of AbortSignal. Received an instance of Object',
+    ],
+    [
+      "events.on() with a null signal",
+      () => on(new EventEmitter(), "x", { signal: null as any }),
+      'The "options.signal" property must be an instance of AbortSignal. Received null',
+    ],
+
+    // Builtins calling $ERR_INVALID_ARG_TYPE(name, "ClassName", value).
+    [
+      "events.addAbortListener(1)",
+      () => addAbortListener(1 as any, () => {}),
+      'The "signal" argument must be an instance of AbortSignal. Received type number (1)',
+    ],
+    [
+      "stream.addAbortSignal(1)",
+      () => addAbortSignal(1 as any, new Readable()),
+      'The "signal" argument must be an instance of AbortSignal. Received type number (1)',
+    ],
+    [
+      "new Readable({ signal: 'abc' })",
+      () => new Readable({ signal: "abc" as any }),
+      `The "signal" argument must be an instance of AbortSignal. Received type string ('abc')`,
+    ],
+    [
+      "Readable.fromWeb(1)",
+      () => Readable.fromWeb(1 as any),
+      'The "readableStream" argument must be an instance of ReadableStream. Received type number (1)',
+    ],
+    [
+      "Writable.fromWeb(1)",
+      () => Writable.fromWeb(1 as any),
+      'The "writableStream" argument must be an instance of WritableStream. Received type number (1)',
+    ],
+    [
+      "Duplex.fromWeb({ readable: 1 })",
+      () => Duplex.fromWeb({ readable: 1, writable: 1 } as any),
+      'The "pair.readable" property must be an instance of ReadableStream. Received type number (1)',
+    ],
+    [
+      "perf_hooks.timerify(fn, { histogram: 1 })",
+      () => timerify(() => {}, { histogram: 1 as any }),
+      'The "options.histogram" property must be an instance of RecordableHistogram. Received type number (1)',
+    ],
+  ];
+
+  test.each(cases)("%s", (_label, call, message) => {
+    expect(caught(call)).toEqual({ name: "TypeError", code: "ERR_INVALID_ARG_TYPE", message });
+  });
+
+  test("events.once(1) rejects with the same rendering", async () => {
+    const error: any = await once(1 as any, "x").then(
+      () => {
+        throw new Error("expected once() to reject");
+      },
+      error => error,
+    );
+    expect({ name: error.name, code: error.code, message: error.message }).toEqual({
+      name: "TypeError",
+      code: "ERR_INVALID_ARG_TYPE",
+      message: 'The "emitter" argument must be an instance of EventEmitter. Received type number (1)',
+    });
+  });
+});
+
+test("a kTypes name spelled with a capital renders lower-cased like node", () => {
+  // inspector.ts passes "Object"; node's validateObject prints "object".
+  expect(caught(() => new Session().post("Runtime.evaluate", 1 as any))).toEqual({
+    name: "TypeError",
+    code: "ERR_INVALID_ARG_TYPE",
+    message: 'The "params" argument must be of type object. Received type number (1)',
+  });
+});
+
+describe("renderings that do not involve a class name are unchanged", () => {
+  const cases: Case[] = [
+    [
+      "primitive type name (process.chdir)",
+      () => process.chdir(1 as any),
+      'The "directory" argument must be of type string. Received type number (1)',
+    ],
+    [
+      "pre-rendered list (Hash#update)",
+      () => createHash("sha256").update(1 as any),
+      'The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received type number (1)',
+    ],
+    [
+      "free-form phrase (vm.SyntheticModule)",
+      () => new SyntheticModule(1 as any, () => {}),
+      'The "exportNames" argument must be an Array of unique strings. Received type number (1)',
+    ],
+  ];
+
+  test.each(cases)("%s", (_label, call, message) => {
+    expect(caught(call)).toEqual({ name: "TypeError", code: "ERR_INVALID_ARG_TYPE", message });
+  });
+});

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -2333,6 +2333,36 @@ describe("Bun.readableStreamTo* on an already used stream", () => {
   });
 });
 
+describe("Bun.readableStreamTo* with something that is not a ReadableStream", () => {
+  const consumers = [
+    "readableStreamToText",
+    "readableStreamToArrayBuffer",
+    "readableStreamToBytes",
+    "readableStreamToJSON",
+    "readableStreamToArray",
+    "readableStreamToBlob",
+    "readableStreamToFormData",
+  ];
+
+  for (const consumer of consumers) {
+    test(`${consumer} throws ERR_INVALID_ARG_TYPE naming the ReadableStream class`, () => {
+      expect(() => Bun[consumer](1)).toThrow(
+        expect.objectContaining({
+          name: "TypeError",
+          code: "ERR_INVALID_ARG_TYPE",
+          message: 'The "stream" argument must be an instance of ReadableStream. Received type number (1)',
+        }),
+      );
+      expect(() => Bun[consumer]({})).toThrow(
+        expect.objectContaining({
+          code: "ERR_INVALID_ARG_TYPE",
+          message: 'The "stream" argument must be an instance of ReadableStream. Received an instance of Object',
+        }),
+      );
+    });
+  }
+});
+
 // Text assembly past the string limit must throw a catchable out-of-memory error, never
 // abort the process. The synthetic allocation limit makes the path testable without
 // multi-gigabyte inputs; a subprocess isolates the lowered limit.


### PR DESCRIPTION
### Problem
- `ERR_INVALID_ARG_TYPE` messages whose expected type is a single class name say `must be of type X`; node says `must be an instance of X`. For example `events.on(ee, "x", { signal: 1 })` throws `The "options.signal" property must be of type AbortSignal. Received type number (1)`; node v26.3.0 throws `... must be an instance of AbortSignal. ...`.
- Cause: the single-string formatter `Message::ERR_INVALID_ARG_TYPE` (`src/jsc/bindings/ErrorCode.cpp:644` on main) prints `of type ` + the string for anything that is not a phrase with spaces. Node's `lib/internal/errors.js` turns a string `expected` into a one-entry list and classifies the entry (kTypes name, class name, other) the same way it classifies list entries; the list overload a few lines below already ports that classification, the single-string one never did.
- Every single-string caller is affected: the 21 C++ `ERR::INVALID_ARG_TYPE(..., "ClassName"_s, ...)` sites (validateAbortSignal, `Buffer.copyBytesFrom`, `X509Certificate#checkPrivateKey`/`#verify`, `Histogram#add`, the `Bun.readableStreamTo*` consumers, ...) and the 26 builtin `$ERR_INVALID_ARG_TYPE(name, "ClassName", value)` sites, which compile to the same formatter (`ErrorCode.cpp:1673`): `stream.addAbortSignal`, `Readable`/`Writable`/`Duplex.fromWeb`, `events.addAbortListener`, `events.once`, `perf_hooks.timerify`, `new Readable({ signal })`, and so on. The two builtin sites that pass `"Object"` (`inspector.Session#post` and the internal zlib transform params check) render `of type Object` where node lower-cases to `of type object`, same cause.
- Two of the C++ sites also use the wrong names: `Histogram#add` reports `The "argument" argument ... Histogram` (node: `"other"` / `RecordableHistogram`), and `X509Certificate#checkIssued` throws a hand-written `issuer must be a JSX509Certificate` (node: `The "otherCert" argument must be an instance of X509Certificate. Received ...`).

### Fix
- `Message::ERR_INVALID_ARG_TYPE` (single-string overload) now classifies its argument like one node list entry, reusing the list overload's `isPrimitiveTypeName`/`isClassName`: a kTypes name renders `of type ` + lower-cased name, a class name renders `an instance of X`. The existing phrase handling and the verbatim `of type ...` fallback for pre-rendered lists (`"string or an instance of Buffer, ..."`) are unchanged, so callers passing a lower-case primitive name or a pre-rendered list produce byte-identical output.
- `Histogram#add` passes `"other"` / `"RecordableHistogram"`; `X509Certificate#checkIssued` goes through `ERR::INVALID_ARG_TYPE` with `"otherCert"` / `"X509Certificate"`. Nothing else at the call sites changes; the other 19 C++ sites and all builtin sites are fixed by the formatter. (`Buffer.copyBytesFrom` is deliberately left alone so this does not collide with #35239, which switches that line to `INVALID_ARG_INSTANCE` for a different reason; either order of landing gives the same text.) Pre-rendered list sites are a separate change (#38690, #38657).
- Why this is correct: for `node:*` APIs node's output is the contract, and node's classification is exactly the one-entry case of the list port that already exists in this file. Every assertion added below is the string node v26.3.0 prints for the same call; the three Bun-only sites whose text changes as a side effect (`Bun.readableStreamTo*`, `CompressionStream`/`TextDecoderStream` chunk errors, the `$checkBufferRead` guard) go from `of type ReadableStream` to `an instance of ReadableStream`, which is the wording the rest of the tree already uses for class checks via `INVALID_ARG_INSTANCE`. No test in the tree pinned any of the old strings.
- Verified:
  - `test/js/node/errors/invalid-arg-type-expected.test.ts` (new): 17 cases covering the three routes into the formatter (C++ name, JS-supplied dotted name via validateAbortSignal, builtin `$ERR_INVALID_ARG_TYPE` including an async rejection), the `"Object"` lower-casing, and three unchanged renderings (primitive, pre-rendered list, phrase). 14 fail on the unfixed build, 17 pass with the fix.
  - `test/js/bun/perf_hooks/histogram.test.ts`: `add()` name and class name (fails before, passes after).
  - `test/js/node/crypto/x509-subclass.test.ts`: `checkIssued`, `checkPrivateKey` and `verify` messages for five non-KeyObject values, plus wrong-key-type and success paths (6 fail before, 19 pass after).
  - `test/js/web/streams/streams.test.js`: the seven `Bun.readableStreamTo*` consumers (7 fail before, pass after).
  - A 20-call probe script diffed against real node v26.3.0 is identical with the fix; `buffer.test.js`, `event-emitter.test.ts`, `node-stream.test.js`, `perf_hooks.test.ts`, `inspector.test.ts`, `compression.test.ts`, `text-decoder-stream.test.ts`, `x509.test.ts`, all of `streams.test.js`, and 17 vendored node tests for the affected APIs (`test-stream-add-abort-signal`, `test-events-once`, `test-events-on-async-iterator`, `test-crypto-x509`, `test-buffer-from`, the five `test-whatwg-webstreams-adapters-*`, ...) pass on the debug build.

### Background
- `ERR_INVALID_ARG_TYPE` message shape: `The "<name>" argument|property must be <expected>. Received <value>`. Node builds `<expected>` from a list: entries in its `kTypes` list (`string`, `number`, `object`, `Function`, ...) become `of type x` (lower-cased), entries matching `/^[A-Z][a-zA-Z0-9]*$/` become `an instance of X`, anything else is printed as written. A string `expected` is wrapped into a one-entry list first, so `'AbortSignal'` and `['AbortSignal']` render identically.
- Bun has two formatter overloads in `ErrorCode.cpp`: the list overload (used when a caller passes an array or a `std::span`) is a port of the grouping above; the single-string overload is reached by C++ callers passing one `WTF::String` and by `$ERR_INVALID_ARG_TYPE` when its second argument is a string. Some C++ callers pass the single-string overload a list they already rendered by hand (`"string or an instance of Buffer"`); node has no equivalent, which is why that overload keeps a verbatim fallback instead of delegating to the list renderer outright.
- `INVALID_ARG_INSTANCE` is the existing helper that always prints `an instance of <text>`; it stays, since it also takes pre-rendered instance lists. After this change passing a bare class name to `INVALID_ARG_TYPE` produces the same text, so callers no longer have to know about it.

<details>
<summary>bun 1.4.0 vs node v26.3.0 for the calls asserted in the tests</summary>

```
Buffer.copyBytesFrom(1)
  bun:  The "view" argument must be of type TypedArray. Received type number (1)
  node: The "view" argument must be an instance of TypedArray. Received type number (1)
events.on(ee, "x", { signal: {} })
  bun:  The "options.signal" property must be of type AbortSignal. Received an instance of Object
  node: The "options.signal" property must be an instance of AbortSignal. Received an instance of Object
stream.addAbortSignal(1, readable)
  bun:  The "signal" argument must be of type AbortSignal. Received type number (1)
  node: The "signal" argument must be an instance of AbortSignal. Received type number (1)
Readable.fromWeb(1)
  bun:  The "readableStream" argument must be of type ReadableStream. Received type number (1)
  node: The "readableStream" argument must be an instance of ReadableStream. Received type number (1)
Duplex.fromWeb({ readable: 1, writable: 1 })
  bun:  The "pair.readable" property must be of type ReadableStream. Received type number (1)
  node: The "pair.readable" property must be an instance of ReadableStream. Received type number (1)
perf_hooks.timerify(fn, { histogram: 1 })
  bun:  The "options.histogram" property must be of type RecordableHistogram. Received type number (1)
  node: The "options.histogram" property must be an instance of RecordableHistogram. Received type number (1)
createHistogram().add(1)
  bun:  The "argument" argument must be of type Histogram. Received type number (1)
  node: The "other" argument must be an instance of RecordableHistogram. Received type number (1)
events.once(1, "x")  (rejects)
  bun:  The "emitter" argument must be of type EventEmitter. Received type number (1)
  node: The "emitter" argument must be an instance of EventEmitter. Received type number (1)
new inspector.Session().post("Runtime.evaluate", 1)
  bun:  The "params" argument must be of type Object. Received type number (1)
  node: The "params" argument must be of type object. Received type number (1)
cert.checkPrivateKey(1) / cert.verify(1)
  bun:  The "pkey" argument must be of type KeyObject. Received type number (1)
  node: The "pkey" argument must be an instance of KeyObject. Received type number (1)
cert.checkIssued({})
  bun:  issuer must be a JSX509Certificate
  node: The "otherCert" argument must be an instance of X509Certificate. Received an instance of Object
unchanged (already identical): process.chdir(1), createHash("sha256").update(1), new vm.SyntheticModule(1, fn)
```

With this change every bun line above is identical to the node line.
</details>
