### PR TITLE
CompressionStream/DecompressionStream: emit each chunk's output in bounded steps

### DIFF
--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -93,7 +93,13 @@ declare var CompressionStream: Bun.__internal.UseLibDomIfAvailable<
   "CompressionStream",
   {
     prototype: CompressionStream;
-    new (format: Bun.CompressionFormat): CompressionStream;
+    /**
+     * @param strategy Bun extension. Its `highWaterMark` (bytes, default 64 KiB) bounds how much
+     * output one input chunk produces per step: the largest piece a reader receives per `read()`,
+     * and how far decoding runs ahead of a slow reader. A chunk larger than that may produce up to
+     * its own size per step.
+     */
+    new (format: Bun.CompressionFormat, strategy?: { highWaterMark?: number }): CompressionStream;
   }
 >;
 
@@ -102,7 +108,13 @@ declare var DecompressionStream: Bun.__internal.UseLibDomIfAvailable<
   "DecompressionStream",
   {
     prototype: DecompressionStream;
-    new (format: Bun.CompressionFormat): DecompressionStream;
+    /**
+     * @param strategy Bun extension. Its `highWaterMark` (bytes, default 64 KiB) bounds how much
+     * output one input chunk produces per step: the largest piece a reader receives per `read()`,
+     * and how far decoding runs ahead of a slow reader. A chunk larger than that may produce up to
+     * its own size per step.
+     */
+    new (format: Bun.CompressionFormat, strategy?: { highWaterMark?: number }): DecompressionStream;
   }
 >;
 

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -1017,6 +1017,7 @@ static void rsisDetachNativeTransform(JSGlobalObject* globalObject, JSReadStream
         ts->m_nativeSinkReadyPromise.clear();
         resolvePromise(globalObject, ready, jsUndefined());
     }
+    nativeCodecAbandon(globalObject, ts);
     op->m_nativeTransform.clear();
 }
 
@@ -1542,6 +1543,9 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundReadStreamIntoSinkOnReady, (JS
             ts->m_nativeSinkReadyPromise.clear();
             Bun::WebStreams::resolvePromise(globalObject, ready, jsUndefined());
             scope.assertNoException();
+        } else if (ts->m_codecPromise) {
+            Bun::WebStreams::nativeCodecContinue(globalObject, ts);
+            RETURN_IF_EXCEPTION(scope, {});
         }
     }
     if (!op->m_waitingOnSink)

--- a/src/jsc/bindings/webcore/streams/JSCompressionStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSCompressionStream.cpp
@@ -158,8 +158,10 @@ template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSCompressionStreamConst
     auto format = parseCompressionFormat(lexicalGlobalObject, callFrame->argument(0));
     RETURN_IF_EXCEPTION(scope, {});
     ASSERT(format.has_value());
+    size_t highWaterMark = parseCodecHighWaterMark(lexicalGlobalObject, callFrame->argument(1));
+    RETURN_IF_EXCEPTION(scope, {});
 
-    void* coder = CompressionStreamCoder__create(static_cast<uint8_t>(*format), false);
+    void* coder = CompressionStreamCoder__create(static_cast<uint8_t>(*format), false, highWaterMark);
     if (!coder) [[unlikely]] {
         throwTypeError(lexicalGlobalObject, scope, "failed to initialize compressor"_s);
         return {};

--- a/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.cpp
+++ b/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.cpp
@@ -4,6 +4,8 @@
 #include "ErrorCode.h"
 #include "JSCompressionStream.h"
 #include "JSDecompressionStream.h"
+#include "JSReadableStream.h"
+#include "JSReadableStreamDefaultController.h"
 #include "JSSink.h"
 #include "JSStreamsRuntime.h"
 #include "JSTransformStream.h"
@@ -21,6 +23,8 @@ namespace WebStreams {
 using namespace JSC;
 using WebCore::JSCompressionStream;
 using WebCore::JSDecompressionStream;
+using WebCore::JSReadableStreamDefaultController;
+using WebCore::JSStreamsRuntime;
 using WebCore::JSTransformStream;
 using WebCore::JSTransformStreamDefaultController;
 
@@ -89,57 +93,291 @@ static std::optional<std::span<const uint8_t>> bufferSourceBytes(JSGlobalObject*
 
 static constexpr size_t kAsyncCodecThreshold = 128 * 1024;
 
-// Runs the Rust coder and delivers the output. When a native JSSink is attached
-// (m_nativeSinkPtr), the coder writes straight to it (no JSUint8Array); otherwise
-// the result is enqueued on the readable. Abrupt completions become a rejected
-// promise — a transform algorithm must never throw synchronously into
-// ProcessWrite/ProcessClose.
-static JSPromise* codeAndEnqueue(JSGlobalObject* globalObject, JSTransformStream* stream, void* coder, JSTransformStreamDefaultController* controller, JSValue chunk, const uint8_t* input, size_t inputLen, bool finish)
+// ─── Stepping a chunk through the coder ─────────────────────────────────────
+//
+// The coder transforms a chunk (or the flush) in steps of bounded output (see
+// CompressionStreamCoder.rs). A chunk whose first step finishes it is the common case and
+// completes synchronously like any other transform arm. Otherwise the chunk stays pending
+// on the stream (m_codecPromise is its transform-algorithm promise) and is moved along
+// from later turns: the output of every step goes to the native sink or the readable, and
+// the next step runs only once that consumer has room again. While a chunk is pending the
+// coder holds its state, so ClearAlgorithms defers the coder release to the chunk's
+// terminal (settleCodecChunk / completeChunkWhenSinkDrains).
+
+static void* coderOf(JSTransformStream* stream)
+{
+    if (auto* s = dynamicDowncast<JSCompressionStream>(stream))
+        return s->m_coder;
+    if (auto* s = dynamicDowncast<JSDecompressionStream>(stream))
+        return s->m_coder;
+    return nullptr;
+}
+
+// One step, with its output already handed to the consumer.
+struct CodecStepResult {
+    // The coder stopped at its output cap; the chunk needs another step.
+    bool more { false };
+    bool sinkBackpressure { false };
+    // Codec error, or the delivery's abrupt completion. Empty on success and on VM
+    // termination (which the caller sees on its own scope).
+    JSValue thrown;
+};
+
+enum class CodecVerdict : uint8_t {
+    // The chunk is complete (or its remaining output has no consumer left).
+    Done,
+    // CodecStepResult::thrown holds the failure.
+    Failed,
+    // Complete, but the sink is under backpressure: the chunk's promise settles when the
+    // sink drains, exactly like a plain backpressured write.
+    AwaitSink,
+    // More output is pending and the consumer is full; onCodecChunkResume continues.
+    ParkOnReadable,
+    ParkOnSink,
+    // More output is pending and there is room for it.
+    Step,
+};
+
+// Whether a pending chunk's remaining output still has somewhere to go. False once the
+// readable was cancelled or errored underneath a parked chunk (that terminal already ran
+// ClearAlgorithms; the coder release waits on settleCodecChunk), or once a native-sink
+// pump finished and detached.
+static bool codecOutputWanted(JSTransformStream* stream)
+{
+    auto* readable = stream->m_readable.get();
+    if (readable->m_state != ReadableStreamState::Readable)
+        return false;
+    if (stream->m_nativeSinkPtr)
+        return true;
+    if (readable->m_controllerKind != ControllerKind::Default)
+        return false;
+    auto* controller = uncheckedDowncast<JSReadableStreamDefaultController>(readable->m_controller.get());
+    return controller && readableStreamDefaultControllerCanCloseOrEnqueue(controller);
+}
+
+static CodecVerdict verdictAfterStep(JSTransformStream* stream, const CodecStepResult& step)
+{
+    if (!step.thrown.isEmpty())
+        return CodecVerdict::Failed;
+    // A sink that detached during the write has already resolved whatever was parked on
+    // it and will not signal again; its absence surfaces through the readable instead.
+    bool sinkFull = step.sinkBackpressure && stream->m_nativeSinkPtr;
+    if (!step.more)
+        return sinkFull ? CodecVerdict::AwaitSink : CodecVerdict::Done;
+    if (sinkFull)
+        return CodecVerdict::ParkOnSink;
+    if (!codecOutputWanted(stream))
+        return CodecVerdict::Done;
+    if (!stream->m_nativeSinkPtr && stream->m_backpressure)
+        return CodecVerdict::ParkOnReadable;
+    return CodecVerdict::Step;
+}
+
+// Runs one step on this thread and delivers its output: straight into the native JSSink
+// when one is attached (no JSUint8Array), otherwise enqueued on the readable. `input` is
+// the chunk's bytes on its first step and null afterwards (the coder keeps the tail).
+static CodecStepResult runStepHere(JSGlobalObject* globalObject, JSTransformStream* stream, void* coder, const uint8_t* input, size_t inputLen, bool finish)
+{
+    auto& vm = getVM(globalObject);
+    auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    CodecStepResult step;
+    if (void* sinkPtr = stream->m_nativeSinkPtr) {
+        JSValue wrote = JSValue::decode(CompressionStreamCoder__transformInto(coder, globalObject, input, inputLen, finish, stream->m_nativeSinkId, sinkPtr, &step.more));
+        if (!catchScope.exception())
+            step.sinkBackpressure = nativeSinkWriteIsBackpressure(vm, wrote);
+    } else {
+        JSValue out = JSValue::decode(CompressionStreamCoder__transform(coder, globalObject, input, inputLen, finish, &step.more));
+        if (!catchScope.exception()) {
+            auto* view = dynamicDowncast<JSArrayBufferView>(out);
+            if (view && view->length())
+                transformStreamDefaultControllerEnqueue(globalObject, stream->m_controller.get(), out);
+        }
+    }
+    if (catchScope.exception()) [[unlikely]]
+        step.thrown = takeAbruptCompletion(globalObject, catchScope);
+    return step;
+}
+
+// Steps the chunk on this thread until it completes, fails, or has to wait; never returns
+// CodecVerdict::Step. The caller holds m_nativeStateInUse, so a terminal reached
+// re-entrantly from a delivery defers the coder release instead of freeing it under the
+// loop (the loop then stops because codecOutputWanted turns false). On VM termination the
+// return value is meaningless and the exception is pending on the VM.
+static CodecVerdict stepChunkHere(JSGlobalObject* globalObject, JSTransformStream* stream, void* coder, const uint8_t* input, size_t inputLen, bool finish, JSValue& thrown)
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
+    ASSERT(stream->m_nativeStateInUse);
+    for (;;) {
+        CodecStepResult step = runStepHere(globalObject, stream, coder, input, inputLen, finish);
+        RETURN_IF_EXCEPTION(scope, CodecVerdict::Failed);
+        CodecVerdict verdict = verdictAfterStep(stream, step);
+        if (verdict != CodecVerdict::Step) {
+            thrown = step.thrown;
+            return verdict;
+        }
+        input = nullptr;
+        inputLen = 0;
+    }
+}
 
-    if (inputLen > kAsyncCodecThreshold && coder) {
+static void dispatchStepOffThread(JSGlobalObject* globalObject, JSTransformStream* stream, void* coder, JSValue chunk, const uint8_t* input, size_t inputLen, bool finish)
+{
+    stream->m_asyncCodecInFlight = true;
+    CompressionStreamCoder__transformAsync(coder, globalObject, JSValue::encode(stream), JSValue::encode(chunk), input, inputLen, finish);
+}
+
+// Terminal of a pending chunk: frees the coder if ClearAlgorithms ran meanwhile, then
+// settles the chunk's promise (fulfilled when `thrown` is empty).
+static void settleCodecChunk(JSGlobalObject* globalObject, JSTransformStream* stream, JSValue thrown)
+{
+    auto* promise = stream->m_codecPromise.get();
+    stream->m_codecPromise.clear();
+    stream->m_codecChunkOffThread = false;
+    nativeTransformReleaseStateIfIdle(stream);
+    ASSERT(promise);
+    if (!promise) [[unlikely]]
+        return;
+    if (!thrown.isEmpty())
+        rejectPromise(globalObject, promise, thrown);
+    else
+        resolvePromise(globalObject, promise, jsUndefined());
+}
+
+// CodecVerdict::AwaitSink. The coder is idle from here on; the chunk's promise (created now for a
+// chunk that completed in its first arm) becomes m_nativeSinkReadyPromise, which the sink's
+// onReady, or detaching from the sink, resolves.
+static JSPromise* completeChunkWhenSinkDrains(JSGlobalObject* globalObject, JSTransformStream* stream)
+{
+    auto& vm = getVM(globalObject);
+    auto* promise = stream->m_codecPromise.get();
+    stream->m_codecPromise.clear();
+    stream->m_codecChunkOffThread = false;
+    if (!promise)
+        promise = JSPromise::create(vm, globalObject->promiseStructure());
+    stream->m_nativeSinkReadyPromise.set(vm, stream, promise);
+    nativeTransformReleaseStateIfIdle(stream);
+    return promise;
+}
+
+// CodecVerdict::ParkOnReadable / ParkOnSink. Leaves the chunk pending and registers
+// onCodecChunkResume on the promise the consumer resolves when it has room: the readable
+// side's [[backpressureChangePromise]] (resolved by its pull, and by the unblock-write step
+// of every error/cancel terminal), or a fresh gate in m_nativeSinkReadyPromise (resolved by
+// the sink's onReady or by detaching from the sink). Returns the chunk's promise.
+static JSPromise* parkCodecChunk(JSGlobalObject* globalObject, JSTransformStream* stream, CodecVerdict wait)
+{
+    auto& vm = getVM(globalObject);
+    if (!stream->m_codecPromise)
+        stream->m_codecPromise.set(vm, stream, JSPromise::create(vm, globalObject->promiseStructure()));
+    JSPromise* gate;
+    if (wait == CodecVerdict::ParkOnSink) {
+        ASSERT(!stream->m_nativeSinkReadyPromise);
+        gate = JSPromise::create(vm, globalObject->promiseStructure());
+        stream->m_nativeSinkReadyPromise.set(vm, stream, gate);
+    } else {
+        ASSERT(wait == CodecVerdict::ParkOnReadable);
+        ASSERT(stream->m_backpressure);
+        gate = stream->m_backpressureChangePromise.get();
+        ASSERT(gate);
+    }
+    auto* runtime = JSStreamsRuntime::from(globalObject);
+    gate->performPromiseThenWithContext(vm, globalObject, runtime->onCodecChunkResume(), jsUndefined(), jsUndefined(), stream);
+    return stream->m_codecPromise.get();
+}
+
+// Applies a step's verdict to a chunk that is already pending (m_codecPromise set).
+static void continuePendingChunk(JSGlobalObject* globalObject, JSTransformStream* stream, CodecVerdict verdict, JSValue thrown)
+{
+    switch (verdict) {
+    case CodecVerdict::Done:
+    case CodecVerdict::Failed:
+        settleCodecChunk(globalObject, stream, thrown);
+        return;
+    case CodecVerdict::AwaitSink:
+        completeChunkWhenSinkDrains(globalObject, stream);
+        return;
+    case CodecVerdict::ParkOnReadable:
+    case CodecVerdict::ParkOnSink:
+        parkCodecChunk(globalObject, stream, verdict);
+        return;
+    case CodecVerdict::Step:
+        break;
+    }
+    // Only an off-thread chunk reports Step here (stepChunkHere loops on it itself); its
+    // remaining steps go to the pool too, so a large expansion never blocks this thread.
+    ASSERT(stream->m_codecChunkOffThread);
+    dispatchStepOffThread(globalObject, stream, coderOf(stream), jsUndefined(), nullptr, 0, false);
+}
+
+// The transform / flush arm. Returns the transform-algorithm promise; abrupt completions
+// become a rejected promise, since an arm must never throw synchronously into
+// ProcessWrite/ProcessClose. Runs under runNativeArm.
+static JSPromise* transformChunk(JSGlobalObject* globalObject, JSTransformStream* stream, void* coder, JSValue chunk, const uint8_t* input, size_t inputLen, bool finish)
+{
+    auto& vm = getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    // The previous chunk's promise settled before the writable handed us this one, and
+    // ClearAlgorithms (which frees the coder) also retargets the transformer kind, so the
+    // dispatch no longer reaches this arm afterwards.
+    ASSERT(!stream->m_codecPromise);
+    ASSERT(coder);
+
+    if (inputLen > kAsyncCodecThreshold) {
         auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
-        stream->m_asyncCodecPromise.set(vm, stream, promise);
-        stream->m_asyncCodecInFlight = true;
-        CompressionStreamCoder__transformAsync(coder, globalObject, JSValue::encode(stream), JSValue::encode(chunk), input, inputLen, finish);
-        scope.assertNoException();
+        stream->m_codecPromise.set(vm, stream, promise);
+        stream->m_codecChunkOffThread = true;
+        dispatchStepOffThread(globalObject, stream, coder, chunk, input, inputLen, finish);
         return promise;
     }
 
     JSValue thrown;
-    bool sinkBackpressure = false;
-    {
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        if (void* sinkPtr = stream->m_nativeSinkPtr) {
-            JSValue wrote = JSValue::decode(CompressionStreamCoder__transformInto(coder, globalObject, input, inputLen, finish, stream->m_nativeSinkId, sinkPtr));
-            if (!catchScope.exception())
-                sinkBackpressure = nativeSinkWriteIsBackpressure(vm, wrote);
-        } else {
-            JSValue out = JSValue::decode(CompressionStreamCoder__transform(coder, globalObject, input, inputLen, finish));
-            if (!catchScope.exception()) {
-                auto* view = dynamicDowncast<JSArrayBufferView>(out);
-                if (view && view->length())
-                    transformStreamDefaultControllerEnqueue(globalObject, controller, out);
-            }
-        }
-        if (catchScope.exception()) [[unlikely]]
-            thrown = takeAbruptCompletion(globalObject, catchScope);
-    }
+    CodecVerdict verdict = stepChunkHere(globalObject, stream, coder, input, inputLen, finish, thrown);
     RETURN_IF_EXCEPTION(scope, nullptr);
-    if (!thrown.isEmpty())
+    switch (verdict) {
+    case CodecVerdict::Done:
+        RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, jsUndefined()));
+    case CodecVerdict::Failed:
         RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, thrown));
-    if (sinkBackpressure) {
-        auto* ready = JSPromise::create(vm, globalObject->promiseStructure());
-        stream->m_nativeSinkReadyPromise.set(vm, stream, ready);
-        return ready;
+    case CodecVerdict::AwaitSink:
+        RELEASE_AND_RETURN(scope, completeChunkWhenSinkDrains(globalObject, stream));
+    case CodecVerdict::ParkOnReadable:
+    case CodecVerdict::ParkOnSink:
+        RELEASE_AND_RETURN(scope, parkCodecChunk(globalObject, stream, verdict));
+    case CodecVerdict::Step:
+        break;
     }
-    RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+// The consumer a chunk was parked on has room again (or went away, which resolves the same
+// promises); see parkCodecChunk.
+static void resumeCodecChunk(JSGlobalObject* globalObject, JSTransformStream* stream)
+{
+    auto& vm = getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    if (!stream->m_codecPromise) [[unlikely]]
+        return;
+    void* coder = coderOf(stream);
+    ASSERT(coder);
+    if (!coder || !codecOutputWanted(stream)) {
+        settleCodecChunk(globalObject, stream, JSValue());
+        return;
+    }
+    if (stream->m_codecChunkOffThread) {
+        dispatchStepOffThread(globalObject, stream, coder, jsUndefined(), nullptr, 0, false);
+        return;
+    }
+    JSValue thrown;
+    stream->m_nativeStateInUse = true;
+    CodecVerdict verdict = stepChunkHere(globalObject, stream, coder, nullptr, 0, false, thrown);
+    stream->m_nativeStateInUse = false;
+    RETURN_IF_EXCEPTION(scope, void());
+    continuePendingChunk(globalObject, stream, verdict, thrown);
 }
 
 template<typename JSStream>
-static JSPromise* compressionStreamTransformImpl(JSGlobalObject* globalObject, JSStream* stream, JSTransformStreamDefaultController* controller, JSValue chunk)
+static JSPromise* compressionStreamTransformImpl(JSGlobalObject* globalObject, JSStream* stream, JSValue chunk)
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -157,58 +395,57 @@ static JSPromise* compressionStreamTransformImpl(JSGlobalObject* globalObject, J
         RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, thrown));
     if (!bytes) [[unlikely]]
         return nullptr;
-    RELEASE_AND_RETURN(scope, codeAndEnqueue(globalObject, stream, stream->m_coder, controller, chunk, bytes->data(), bytes->size(), false));
+    RELEASE_AND_RETURN(scope, transformChunk(globalObject, stream, stream->m_coder, chunk, bytes->data(), bytes->size(), false));
 }
 
-JSPromise* compressionStreamTransform(JSGlobalObject* globalObject, JSCompressionStream* stream, JSTransformStreamDefaultController* controller, JSValue chunk)
+JSPromise* compressionStreamTransform(JSGlobalObject* globalObject, JSCompressionStream* stream, JSTransformStreamDefaultController*, JSValue chunk)
 {
-    return compressionStreamTransformImpl(globalObject, stream, controller, chunk);
+    return compressionStreamTransformImpl(globalObject, stream, chunk);
 }
 
-JSPromise* compressionStreamFlush(JSGlobalObject* globalObject, JSCompressionStream* stream, JSTransformStreamDefaultController* controller)
+JSPromise* compressionStreamFlush(JSGlobalObject* globalObject, JSCompressionStream* stream, JSTransformStreamDefaultController*)
 {
-    return codeAndEnqueue(globalObject, stream, stream->m_coder, controller, jsUndefined(), nullptr, 0, true);
+    return transformChunk(globalObject, stream, stream->m_coder, jsUndefined(), nullptr, 0, true);
 }
 
-JSPromise* decompressionStreamTransform(JSGlobalObject* globalObject, JSDecompressionStream* stream, JSTransformStreamDefaultController* controller, JSValue chunk)
+JSPromise* decompressionStreamTransform(JSGlobalObject* globalObject, JSDecompressionStream* stream, JSTransformStreamDefaultController*, JSValue chunk)
 {
-    return compressionStreamTransformImpl(globalObject, stream, controller, chunk);
+    return compressionStreamTransformImpl(globalObject, stream, chunk);
 }
 
-JSPromise* decompressionStreamFlush(JSGlobalObject* globalObject, JSDecompressionStream* stream, JSTransformStreamDefaultController* controller)
+JSPromise* decompressionStreamFlush(JSGlobalObject* globalObject, JSDecompressionStream* stream, JSTransformStreamDefaultController*)
 {
-    return codeAndEnqueue(globalObject, stream, stream->m_coder, controller, jsUndefined(), nullptr, 0, true);
+    return transformChunk(globalObject, stream, stream->m_coder, jsUndefined(), nullptr, 0, true);
 }
 
-// JS-thread completion for the off-thread codec dispatched by codeAndEnqueue. `out[..outLen]`
-// borrows the coder's reusable output buffer, so the bytes are consumed (sink-write or
-// controller-enqueue) BEFORE `m_asyncCodecInFlight` is cleared and any deferred coder release
-// runs. The transform-algorithm promise to settle is read from `m_asyncCodecPromise`.
-extern "C" void Bun__CompressionStream__deliverAsync(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue streamCell, const uint8_t* out, size_t outLen, JSC::EncodedJSValue error)
+// JS-thread completion of an off-thread step (dispatchStepOffThread). `out[..outLen]`
+// borrows the coder's reusable output buffer, so it is consumed (sink write or enqueue)
+// BEFORE m_asyncCodecInFlight is cleared: only then may the chunk's verdict release the
+// coder or hand it to the pool again.
+extern "C" void Bun__CompressionStream__deliverAsync(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue streamCell, const uint8_t* out, size_t outLen, bool more, JSC::EncodedJSValue error)
 {
     auto& vm = getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
     auto* stream = dynamicDowncast<JSTransformStream>(JSValue::decode(streamCell));
     ASSERT(stream);
     if (!stream) [[unlikely]]
         return;
-    auto* promise = stream->m_asyncCodecPromise.get();
-    stream->m_asyncCodecPromise.clear();
-    ASSERT(promise);
+    ASSERT(stream->m_asyncCodecInFlight);
 
-    JSValue thrown;
-    bool sinkBackpressure = false;
-    if (!error) {
+    CodecStepResult step;
+    step.more = more;
+    if (error) {
+        step.thrown = JSValue::decode(error);
+    } else if (outLen) {
         auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
         if (void* sinkPtr = stream->m_nativeSinkPtr) {
-            if (outLen) {
-                JSValue wrote = JSValue::decode(Bun__NativeTransformSink__writeBytes(stream->m_nativeSinkId, sinkPtr, globalObject, out, outLen));
-                if (!catchScope.exception())
-                    sinkBackpressure = nativeSinkWriteIsBackpressure(vm, wrote);
-            }
-        } else if (outLen) {
+            JSValue wrote = JSValue::decode(Bun__NativeTransformSink__writeBytes(stream->m_nativeSinkId, sinkPtr, globalObject, out, outLen));
+            if (!catchScope.exception())
+                step.sinkBackpressure = nativeSinkWriteIsBackpressure(vm, wrote);
+        } else {
             auto copied = JSC::ArrayBuffer::tryCreate(std::span<const uint8_t>(out, outLen));
             if (!copied) [[unlikely]] {
-                thrown = JSC::createOutOfMemoryError(globalObject);
+                step.thrown = JSC::createOutOfMemoryError(globalObject);
             } else {
                 auto* view = JSC::JSUint8Array::create(globalObject, globalObject->typedArrayStructure(JSC::TypeUint8, false), WTF::move(copied), 0, outLen);
                 if (!catchScope.exception())
@@ -216,29 +453,31 @@ extern "C" void Bun__CompressionStream__deliverAsync(JSC::JSGlobalObject* global
             }
         }
         if (catchScope.exception()) [[unlikely]]
-            thrown = takeAbruptCompletion(globalObject, catchScope);
+            step.thrown = takeAbruptCompletion(globalObject, catchScope);
     }
 
     stream->m_asyncCodecInFlight = false;
-    if (stream->m_nativeStateReleasePending && !stream->m_nativeStateInUse) [[unlikely]]
-        nativeTransformReleaseState(stream);
-
-    if (!promise) [[unlikely]]
-        return;
-    if (error) {
-        rejectPromise(globalObject, promise, JSValue::decode(error));
-        return;
-    }
-    if (!thrown.isEmpty()) {
-        rejectPromise(globalObject, promise, thrown);
-        return;
-    }
-    if (sinkBackpressure) {
-        stream->m_nativeSinkReadyPromise.set(vm, stream, promise);
-        return;
-    }
-    resolvePromise(globalObject, promise, jsUndefined());
+    // VM termination: the chunk stays pending; teardown's finalizer releases the coder.
+    RETURN_IF_EXCEPTION(scope, void());
+    continuePendingChunk(globalObject, stream, verdictAfterStep(stream, step), step.thrown);
 }
 
 } // namespace WebStreams
 } // namespace Bun
+
+namespace WebCore {
+
+using namespace JSC;
+
+// [reaction-convention] _CODEC group; context = the JSCompressionStream / JSDecompressionStream.
+JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onCodecChunkResume, (JSGlobalObject * globalObject, CallFrame* callFrame))
+{
+    auto& vm = getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto* stream = uncheckedDowncast<JSTransformStream>(callFrame->argument(1));
+    Bun::WebStreams::resumeCodecChunk(globalObject, stream);
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSValue::encode(jsUndefined());
+}
+
+} // namespace WebCore

--- a/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.cpp
+++ b/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.cpp
@@ -309,6 +309,7 @@ static JSPromise* transformChunk(JSGlobalObject* globalObject, JSTransformStream
         stream->m_codecPromise.set(vm, stream, promise);
         stream->m_codecChunkOffThread = true;
         dispatchStepOffThread(globalObject, stream, coder, chunk, input, inputLen, finish);
+        scope.assertNoException();
         return promise;
     }
 
@@ -340,20 +341,16 @@ static void resumeCodecChunk(JSGlobalObject* globalObject, JSTransformStream* st
         return;
     void* coder = coderOf(stream);
     ASSERT(coder);
-    if (!coder || !codecOutputWanted(stream)) {
-        settleCodecChunk(globalObject, stream, JSValue());
-        return;
-    }
-    if (stream->m_codecChunkOffThread) {
-        dispatchStepOffThread(globalObject, stream, coder, jsUndefined(), nullptr, 0, false);
-        return;
-    }
+    if (!coder || !codecOutputWanted(stream))
+        RELEASE_AND_RETURN(scope, settleCodecChunk(globalObject, stream, JSValue()));
+    if (stream->m_codecChunkOffThread)
+        RELEASE_AND_RETURN(scope, dispatchStepOffThread(globalObject, stream, coder, jsUndefined(), nullptr, 0, false));
     JSValue thrown;
     stream->m_nativeStateInUse = true;
     CodecVerdict verdict = stepChunkHere(globalObject, stream, coder, nullptr, 0, false, thrown);
     stream->m_nativeStateInUse = false;
     RETURN_IF_EXCEPTION(scope, void());
-    continuePendingChunk(globalObject, stream, verdict, thrown);
+    RELEASE_AND_RETURN(scope, continuePendingChunk(globalObject, stream, verdict, thrown));
 }
 
 template<typename JSStream>
@@ -400,11 +397,11 @@ JSPromise* decompressionStreamFlush(JSGlobalObject* globalObject, JSDecompressio
 
 // JS-thread completion of an off-thread step. `out` borrows the coder's buffer, so it is
 // consumed BEFORE m_asyncCodecInFlight is cleared and the verdict may release or re-dispatch
-// the coder.
+// the coder. Returns into Rust, so this is an exception boundary rather than a throw scope.
 extern "C" void Bun__CompressionStream__deliverAsync(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue streamCell, const uint8_t* out, size_t outLen, bool more, JSC::EncodedJSValue error)
 {
     auto& vm = getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     auto* stream = dynamicDowncast<JSTransformStream>(JSValue::decode(streamCell));
     ASSERT(stream);
     if (!stream) [[unlikely]]
@@ -416,10 +413,9 @@ extern "C" void Bun__CompressionStream__deliverAsync(JSC::JSGlobalObject* global
     if (error) {
         step.thrown = JSValue::decode(error);
     } else if (outLen) {
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
         if (void* sinkPtr = stream->m_nativeSinkPtr) {
             JSValue wrote = JSValue::decode(Bun__NativeTransformSink__writeBytes(stream->m_nativeSinkId, sinkPtr, globalObject, out, outLen));
-            if (!catchScope.exception())
+            if (!scope.exception())
                 step.sinkBackpressure = nativeSinkWriteIsBackpressure(vm, wrote);
         } else {
             auto copied = JSC::ArrayBuffer::tryCreate(std::span<const uint8_t>(out, outLen));
@@ -427,18 +423,23 @@ extern "C" void Bun__CompressionStream__deliverAsync(JSC::JSGlobalObject* global
                 step.thrown = JSC::createOutOfMemoryError(globalObject);
             } else {
                 auto* view = JSC::JSUint8Array::create(globalObject, globalObject->typedArrayStructure(JSC::TypeUint8, false), WTF::move(copied), 0, outLen);
-                if (!catchScope.exception())
+                if (!scope.exception())
                     transformStreamDefaultControllerEnqueue(globalObject, stream->m_controller.get(), JSValue(view));
             }
         }
-        if (catchScope.exception()) [[unlikely]]
-            step.thrown = takeAbruptCompletion(globalObject, catchScope);
+        if (scope.exception()) [[unlikely]] {
+            step.thrown = takeAbruptCompletion(globalObject, scope);
+            if (step.thrown.isEmpty()) {
+                // VM termination: the chunk stays pending; teardown's finalizer releases the coder.
+                stream->m_asyncCodecInFlight = false;
+                return;
+            }
+        }
     }
 
     stream->m_asyncCodecInFlight = false;
-    // VM termination: the chunk stays pending; teardown's finalizer releases the coder.
-    RETURN_IF_EXCEPTION(scope, void());
     continuePendingChunk(globalObject, stream, verdictAfterStep(stream, step), step.thrown);
+    scope.assertNoException();
 }
 
 } // namespace WebStreams

--- a/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.cpp
+++ b/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.cpp
@@ -292,7 +292,13 @@ static void continuePendingChunk(JSGlobalObject* globalObject, JSTransformStream
     }
     // stepChunkHere loops on Step itself; an off-thread chunk's next step goes to the pool too.
     ASSERT(stream->m_codecChunkOffThread);
-    dispatchStepOffThread(globalObject, stream, coderOf(stream), jsUndefined(), nullptr, 0, false);
+    void* coder = coderOf(stream);
+    ASSERT(coder);
+    if (!coder) [[unlikely]] {
+        settleCodecChunk(globalObject, stream, JSValue());
+        return;
+    }
+    dispatchStepOffThread(globalObject, stream, coder, jsUndefined(), nullptr, 0, false);
 }
 
 // The transform / flush arm (under runNativeArm). Abrupt completions become a rejected

--- a/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.cpp
+++ b/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.cpp
@@ -115,9 +115,11 @@ static constexpr size_t kAsyncCodecThreshold = 128 * 1024;
 // any other arm. Otherwise its transform promise (m_codecPromise) stays pending, which keeps
 // the write in flight and so the producer waiting, and the consumer drives the remaining
 // steps: the readable's pull algorithm and the native sink's onReady call nativeCodecContinue;
-// the error and cancel terminals and a sink detach call nativeCodecAbandon. The coder holds a
-// pending chunk's state, so ClearAlgorithms defers the coder release meanwhile (the close
-// algorithm clears algorithms while a multi-step flush is still being drained).
+// nativeCodecAbandon is called once the chunk can no longer finish, from whichever side goes
+// away first: the writable starting to error with the write in flight (abort, transform
+// errors), the readable being cancelled, or the sink detaching. The coder holds a pending
+// chunk's state, so ClearAlgorithms defers the coder release meanwhile (the close algorithm
+// clears algorithms while a multi-step flush is still being drained).
 
 static void* coderOf(JSTransformStream* stream)
 {

--- a/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.cpp
+++ b/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.cpp
@@ -95,14 +95,11 @@ static constexpr size_t kAsyncCodecThreshold = 128 * 1024;
 
 // ─── Stepping a chunk through the coder ─────────────────────────────────────
 //
-// The coder transforms a chunk (or the flush) in steps of bounded output (see
-// CompressionStreamCoder.rs). A chunk whose first step finishes it is the common case and
-// completes synchronously like any other transform arm. Otherwise the chunk stays pending
-// on the stream (m_codecPromise is its transform-algorithm promise) and is moved along
-// from later turns: the output of every step goes to the native sink or the readable, and
-// the next step runs only once that consumer has room again. While a chunk is pending the
-// coder holds its state, so ClearAlgorithms defers the coder release to the chunk's
-// terminal (settleCodecChunk / completeChunkWhenSinkDrains).
+// The coder emits a chunk (or the flush) in steps of bounded output (CompressionStreamCoder.rs).
+// A chunk its first step finishes completes synchronously like any other arm; otherwise it
+// stays pending on the stream (m_codecPromise) and is stepped again from later turns, once
+// the readable or the native sink has room for more. The coder holds a pending chunk's state,
+// so ClearAlgorithms defers the coder release to the chunk's terminal.
 
 static void* coderOf(JSTransformStream* stream)
 {
@@ -118,30 +115,25 @@ struct CodecStepResult {
     // The coder stopped at its output cap; the chunk needs another step.
     bool more { false };
     bool sinkBackpressure { false };
-    // Codec error, or the delivery's abrupt completion. Empty on success and on VM
-    // termination (which the caller sees on its own scope).
+    // Codec error or failed delivery; empty on success (and on VM termination).
     JSValue thrown;
 };
 
 enum class CodecVerdict : uint8_t {
-    // The chunk is complete (or its remaining output has no consumer left).
+    // Complete, or the rest of its output has no consumer left.
     Done,
-    // CodecStepResult::thrown holds the failure.
     Failed,
-    // Complete, but the sink is under backpressure: the chunk's promise settles when the
-    // sink drains, exactly like a plain backpressured write.
+    // Complete, but the sink is full: the chunk's promise settles when the sink drains.
     AwaitSink,
-    // More output is pending and the consumer is full; onCodecChunkResume continues.
+    // More output pending and the consumer is full; onCodecChunkResume continues it.
     ParkOnReadable,
     ParkOnSink,
-    // More output is pending and there is room for it.
+    // More output pending and room for it.
     Step,
 };
 
-// Whether a pending chunk's remaining output still has somewhere to go. False once the
-// readable was cancelled or errored underneath a parked chunk (that terminal already ran
-// ClearAlgorithms; the coder release waits on settleCodecChunk), or once a native-sink
-// pump finished and detached.
+// Whether the rest of a pending chunk's output still has somewhere to go (false once the
+// readable was cancelled or errored under it, or its native-sink pump finished and detached).
 static bool codecOutputWanted(JSTransformStream* stream)
 {
     auto* readable = stream->m_readable.get();
@@ -159,8 +151,7 @@ static CodecVerdict verdictAfterStep(JSTransformStream* stream, const CodecStepR
 {
     if (!step.thrown.isEmpty())
         return CodecVerdict::Failed;
-    // A sink that detached during the write has already resolved whatever was parked on
-    // it and will not signal again; its absence surfaces through the readable instead.
+    // A sink that detached during the write will not signal again.
     bool sinkFull = step.sinkBackpressure && stream->m_nativeSinkPtr;
     if (!step.more)
         return sinkFull ? CodecVerdict::AwaitSink : CodecVerdict::Done;
@@ -173,9 +164,8 @@ static CodecVerdict verdictAfterStep(JSTransformStream* stream, const CodecStepR
     return CodecVerdict::Step;
 }
 
-// Runs one step on this thread and delivers its output: straight into the native JSSink
-// when one is attached (no JSUint8Array), otherwise enqueued on the readable. `input` is
-// the chunk's bytes on its first step and null afterwards (the coder keeps the tail).
+// One step on this thread, delivered straight into the native JSSink when one is attached
+// (no JSUint8Array), otherwise enqueued. `input` is only passed on a chunk's first step.
 static CodecStepResult runStepHere(JSGlobalObject* globalObject, JSTransformStream* stream, void* coder, const uint8_t* input, size_t inputLen, bool finish)
 {
     auto& vm = getVM(globalObject);
@@ -198,11 +188,9 @@ static CodecStepResult runStepHere(JSGlobalObject* globalObject, JSTransformStre
     return step;
 }
 
-// Steps the chunk on this thread until it completes, fails, or has to wait; never returns
-// CodecVerdict::Step. The caller holds m_nativeStateInUse, so a terminal reached
-// re-entrantly from a delivery defers the coder release instead of freeing it under the
-// loop (the loop then stops because codecOutputWanted turns false). On VM termination the
-// return value is meaningless and the exception is pending on the VM.
+// Steps the chunk on this thread until it completes, fails, or has to wait (never returns
+// Step). The caller holds m_nativeStateInUse: a terminal reached from inside a delivery then
+// defers the coder release and the loop stops via codecOutputWanted instead.
 static CodecVerdict stepChunkHere(JSGlobalObject* globalObject, JSTransformStream* stream, void* coder, const uint8_t* input, size_t inputLen, bool finish, JSValue& thrown)
 {
     auto& vm = getVM(globalObject);
@@ -227,8 +215,7 @@ static void dispatchStepOffThread(JSGlobalObject* globalObject, JSTransformStrea
     CompressionStreamCoder__transformAsync(coder, globalObject, JSValue::encode(stream), JSValue::encode(chunk), input, inputLen, finish);
 }
 
-// Terminal of a pending chunk: frees the coder if ClearAlgorithms ran meanwhile, then
-// settles the chunk's promise (fulfilled when `thrown` is empty).
+// Terminal of a pending chunk; `thrown` empty means fulfilled.
 static void settleCodecChunk(JSGlobalObject* globalObject, JSTransformStream* stream, JSValue thrown)
 {
     auto* promise = stream->m_codecPromise.get();
@@ -244,9 +231,8 @@ static void settleCodecChunk(JSGlobalObject* globalObject, JSTransformStream* st
         resolvePromise(globalObject, promise, jsUndefined());
 }
 
-// CodecVerdict::AwaitSink. The coder is idle from here on; the chunk's promise (created now for a
-// chunk that completed in its first arm) becomes m_nativeSinkReadyPromise, which the sink's
-// onReady, or detaching from the sink, resolves.
+// CodecVerdict::AwaitSink: the chunk's promise becomes m_nativeSinkReadyPromise, which the
+// sink's onReady (or detaching from the sink) resolves. The coder is idle from here on.
 static JSPromise* completeChunkWhenSinkDrains(JSGlobalObject* globalObject, JSTransformStream* stream)
 {
     auto& vm = getVM(globalObject);
@@ -260,14 +246,11 @@ static JSPromise* completeChunkWhenSinkDrains(JSGlobalObject* globalObject, JSTr
     return promise;
 }
 
-// CodecVerdict::ParkOnReadable / ParkOnSink. Leaves the chunk pending and registers
-// onCodecChunkResume on the promise the consumer resolves when it has room: the readable
-// side's [[backpressureChangePromise]], or a fresh gate in m_nativeSinkReadyPromise (resolved
-// by the sink's onReady or by detaching from the sink). Besides the readable's pull, every
-// terminal resolves the former through transformStreamUnblockWrite: the error path, the
-// cancel reaction, and (Bun addition, for a flush parked here) the cancel that arrives while
-// a close is already in flight, see transformStreamDefaultSourceCancelAlgorithm. Returns the
-// chunk's promise.
+// CodecVerdict::ParkOnReadable / ParkOnSink: registers onCodecChunkResume on the readable's
+// [[backpressureChangePromise]] (resolved by its pull and, via transformStreamUnblockWrite, by
+// every error/cancel terminal, including the cancel-after-close branch of
+// transformStreamDefaultSourceCancelAlgorithm) or on a gate in m_nativeSinkReadyPromise
+// (resolved by the sink's onReady or by detaching from it). Returns the chunk's promise.
 static JSPromise* parkCodecChunk(JSGlobalObject* globalObject, JSTransformStream* stream, CodecVerdict wait)
 {
     auto& vm = getVM(globalObject);
@@ -307,22 +290,17 @@ static void continuePendingChunk(JSGlobalObject* globalObject, JSTransformStream
     case CodecVerdict::Step:
         break;
     }
-    // Only an off-thread chunk reports Step here (stepChunkHere loops on it itself); its
-    // remaining steps go to the pool too, so a large expansion never blocks this thread.
+    // stepChunkHere loops on Step itself; an off-thread chunk's next step goes to the pool too.
     ASSERT(stream->m_codecChunkOffThread);
     dispatchStepOffThread(globalObject, stream, coderOf(stream), jsUndefined(), nullptr, 0, false);
 }
 
-// The transform / flush arm. Returns the transform-algorithm promise; abrupt completions
-// become a rejected promise, since an arm must never throw synchronously into
-// ProcessWrite/ProcessClose. Runs under runNativeArm.
+// The transform / flush arm (under runNativeArm). Abrupt completions become a rejected
+// promise: an arm must never throw synchronously into ProcessWrite/ProcessClose.
 static JSPromise* transformChunk(JSGlobalObject* globalObject, JSTransformStream* stream, void* coder, JSValue chunk, const uint8_t* input, size_t inputLen, bool finish)
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    // The previous chunk's promise settled before the writable handed us this one, and
-    // ClearAlgorithms (which frees the coder) also retargets the transformer kind, so the
-    // dispatch no longer reaches this arm afterwards.
     ASSERT(!stream->m_codecPromise);
     ASSERT(coder);
 
@@ -353,8 +331,7 @@ static JSPromise* transformChunk(JSGlobalObject* globalObject, JSTransformStream
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-// The consumer a chunk was parked on has room again (or went away, which resolves the same
-// promises); see parkCodecChunk.
+// The consumer a chunk was parked on has room again, or went away (see parkCodecChunk).
 static void resumeCodecChunk(JSGlobalObject* globalObject, JSTransformStream* stream)
 {
     auto& vm = getVM(globalObject);
@@ -421,10 +398,9 @@ JSPromise* decompressionStreamFlush(JSGlobalObject* globalObject, JSDecompressio
     return transformChunk(globalObject, stream, stream->m_coder, jsUndefined(), nullptr, 0, true);
 }
 
-// JS-thread completion of an off-thread step (dispatchStepOffThread). `out[..outLen]`
-// borrows the coder's reusable output buffer, so it is consumed (sink write or enqueue)
-// BEFORE m_asyncCodecInFlight is cleared: only then may the chunk's verdict release the
-// coder or hand it to the pool again.
+// JS-thread completion of an off-thread step. `out` borrows the coder's buffer, so it is
+// consumed BEFORE m_asyncCodecInFlight is cleared and the verdict may release or re-dispatch
+// the coder.
 extern "C" void Bun__CompressionStream__deliverAsync(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue streamCell, const uint8_t* out, size_t outLen, bool more, JSC::EncodedJSValue error)
 {
     auto& vm = getVM(globalObject);

--- a/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.cpp
+++ b/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.cpp
@@ -4,8 +4,6 @@
 #include "ErrorCode.h"
 #include "JSCompressionStream.h"
 #include "JSDecompressionStream.h"
-#include "JSReadableStream.h"
-#include "JSReadableStreamDefaultController.h"
 #include "JSSink.h"
 #include "JSStreamsRuntime.h"
 #include "JSTransformStream.h"
@@ -16,6 +14,7 @@
 #include <JavaScriptCore/JSArrayBufferView.h>
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/TopExceptionScope.h>
+#include <limits>
 
 namespace Bun {
 namespace WebStreams {
@@ -23,8 +22,6 @@ namespace WebStreams {
 using namespace JSC;
 using WebCore::JSCompressionStream;
 using WebCore::JSDecompressionStream;
-using WebCore::JSReadableStreamDefaultController;
-using WebCore::JSStreamsRuntime;
 using WebCore::JSTransformStream;
 using WebCore::JSTransformStreamDefaultController;
 
@@ -46,6 +43,24 @@ std::optional<CompressionFormat> parseCompressionFormat(JSGlobalObject* globalOb
         return CompressionFormat::Zstd;
     Bun::ERR::INVALID_ARG_VALUE(scope, globalObject, "format"_s, formatValue, "must be one of: deflate, deflate-raw, gzip, brotli, zstd"_s);
     return std::nullopt;
+}
+
+// Default for the optional second constructor argument; the same default output size as the
+// node:zlib stream adapter (src/js/internal/streams/iter/transform.ts).
+static constexpr double kDefaultCodecHighWaterMark = 64 * 1024;
+
+size_t parseCodecHighWaterMark(JSGlobalObject* globalObject, JSValue strategy)
+{
+    auto& vm = getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    QueuingStrategyDict dict = convertQueuingStrategyDict(globalObject, strategy);
+    RETURN_IF_EXCEPTION(scope, 0);
+    double highWaterMark = extractHighWaterMark(globalObject, dict, kDefaultCodecHighWaterMark);
+    RETURN_IF_EXCEPTION(scope, 0);
+    // +Infinity (spec-legal) means "never split a chunk's output"; the coder floors at one byte.
+    if (highWaterMark >= static_cast<double>(std::numeric_limits<size_t>::max()))
+        return std::numeric_limits<size_t>::max();
+    return static_cast<size_t>(highWaterMark);
 }
 
 // BufferSource → (ptr, len). `scratch` owns the bytes when `chunk` is a string
@@ -95,11 +110,14 @@ static constexpr size_t kAsyncCodecThreshold = 128 * 1024;
 
 // ─── Stepping a chunk through the coder ─────────────────────────────────────
 //
-// The coder emits a chunk (or the flush) in steps of bounded output (CompressionStreamCoder.rs).
-// A chunk its first step finishes completes synchronously like any other arm; otherwise it
-// stays pending on the stream (m_codecPromise) and is stepped again from later turns, once
-// the readable or the native sink has room for more. The coder holds a pending chunk's state,
-// so ClearAlgorithms defers the coder release to the chunk's terminal.
+// The coder emits a chunk (or the flush) in steps of at most the stream's highWaterMark
+// (CompressionStreamCoder.rs). A chunk its first step finishes completes synchronously like
+// any other arm. Otherwise its transform promise (m_codecPromise) stays pending, which keeps
+// the write in flight and so the producer waiting, and the consumer drives the remaining
+// steps: the readable's pull algorithm and the native sink's onReady call nativeCodecContinue;
+// the error and cancel terminals and a sink detach call nativeCodecAbandon. The coder holds a
+// pending chunk's state, so ClearAlgorithms defers the coder release meanwhile (the close
+// algorithm clears algorithms while a multi-step flush is still being drained).
 
 static void* coderOf(JSTransformStream* stream)
 {
@@ -112,57 +130,12 @@ static void* coderOf(JSTransformStream* stream)
 
 // One step, with its output already handed to the consumer.
 struct CodecStepResult {
-    // The coder stopped at its output cap; the chunk needs another step.
+    // The coder stopped at its output bound; the chunk needs another step.
     bool more { false };
     bool sinkBackpressure { false };
     // Codec error or failed delivery; empty on success (and on VM termination).
     JSValue thrown;
 };
-
-enum class CodecVerdict : uint8_t {
-    // Complete, or the rest of its output has no consumer left.
-    Done,
-    Failed,
-    // Complete, but the sink is full: the chunk's promise settles when the sink drains.
-    AwaitSink,
-    // More output pending and the consumer is full; onCodecChunkResume continues it.
-    ParkOnReadable,
-    ParkOnSink,
-    // More output pending and room for it.
-    Step,
-};
-
-// Whether the rest of a pending chunk's output still has somewhere to go (false once the
-// readable was cancelled or errored under it, or its native-sink pump finished and detached).
-static bool codecOutputWanted(JSTransformStream* stream)
-{
-    auto* readable = stream->m_readable.get();
-    if (readable->m_state != ReadableStreamState::Readable)
-        return false;
-    if (stream->m_nativeSinkPtr)
-        return true;
-    if (readable->m_controllerKind != ControllerKind::Default)
-        return false;
-    auto* controller = uncheckedDowncast<JSReadableStreamDefaultController>(readable->m_controller.get());
-    return controller && readableStreamDefaultControllerCanCloseOrEnqueue(controller);
-}
-
-static CodecVerdict verdictAfterStep(JSTransformStream* stream, const CodecStepResult& step)
-{
-    if (!step.thrown.isEmpty())
-        return CodecVerdict::Failed;
-    // A sink that detached during the write will not signal again.
-    bool sinkFull = step.sinkBackpressure && stream->m_nativeSinkPtr;
-    if (!step.more)
-        return sinkFull ? CodecVerdict::AwaitSink : CodecVerdict::Done;
-    if (sinkFull)
-        return CodecVerdict::ParkOnSink;
-    if (!codecOutputWanted(stream))
-        return CodecVerdict::Done;
-    if (!stream->m_nativeSinkPtr && stream->m_backpressure)
-        return CodecVerdict::ParkOnReadable;
-    return CodecVerdict::Step;
-}
 
 // One step on this thread, delivered straight into the native JSSink when one is attached
 // (no JSUint8Array), otherwise enqueued. `input` is only passed on a chunk's first step.
@@ -188,22 +161,45 @@ static CodecStepResult runStepHere(JSGlobalObject* globalObject, JSTransformStre
     return step;
 }
 
-// Steps the chunk on this thread until it completes, fails, or has to wait (never returns
-// Step). The caller holds m_nativeStateInUse: a terminal reached from inside a delivery then
-// defers the coder release and the loop stops via codecOutputWanted instead.
-static CodecVerdict stepChunkHere(JSGlobalObject* globalObject, JSTransformStream* stream, void* coder, const uint8_t* input, size_t inputLen, bool finish, JSValue& thrown)
+enum class CodecOutcome : uint8_t {
+    Done,
+    // Done, but its last write left the sink full: the transform promise becomes
+    // m_nativeSinkReadyPromise and settles when the sink drains, as any backpressured write.
+    DoneSinkFull,
+    Failed,
+    // Nothing to settle: output is still pending and the consumer is full (it will continue
+    // the chunk), or a terminal reached from inside a delivery already abandoned it.
+    Pending,
+};
+
+static bool consumerFull(JSTransformStream* stream, const CodecStepResult& step)
+{
+    return stream->m_nativeSinkPtr ? step.sinkBackpressure : stream->m_backpressure;
+}
+
+// Steps on this thread until the chunk completes, fails, or its consumer is full. `input` is
+// only fed on the first step. The caller holds m_nativeStateInUse, so a terminal reached from
+// inside a delivery defers the coder release instead of freeing it under the loop.
+static CodecOutcome stepChunkHere(JSGlobalObject* globalObject, JSTransformStream* stream, void* coder, const uint8_t* input, size_t inputLen, bool finish, JSValue& thrown)
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     ASSERT(stream->m_nativeStateInUse);
+    bool continuation = !!stream->m_codecPromise;
     for (;;) {
         CodecStepResult step = runStepHere(globalObject, stream, coder, input, inputLen, finish);
-        RETURN_IF_EXCEPTION(scope, CodecVerdict::Failed);
-        CodecVerdict verdict = verdictAfterStep(stream, step);
-        if (verdict != CodecVerdict::Step) {
+        RETURN_IF_EXCEPTION(scope, CodecOutcome::Failed);
+        if (continuation && !stream->m_codecPromise)
+            return CodecOutcome::Pending;
+        if (!step.thrown.isEmpty()) {
             thrown = step.thrown;
-            return verdict;
+            return CodecOutcome::Failed;
         }
+        bool full = consumerFull(stream, step);
+        if (!step.more)
+            return full && stream->m_nativeSinkPtr ? CodecOutcome::DoneSinkFull : CodecOutcome::Done;
+        if (full)
+            return CodecOutcome::Pending;
         input = nullptr;
         inputLen = 0;
     }
@@ -215,13 +211,20 @@ static void dispatchStepOffThread(JSGlobalObject* globalObject, JSTransformStrea
     CompressionStreamCoder__transformAsync(coder, globalObject, JSValue::encode(stream), JSValue::encode(chunk), input, inputLen, finish);
 }
 
-// Terminal of a pending chunk; `thrown` empty means fulfilled.
-static void settleCodecChunk(JSGlobalObject* globalObject, JSTransformStream* stream, JSValue thrown)
+// Takes the pending chunk's promise off the stream; the coder is idle again, so a deferred
+// release can go ahead.
+static JSPromise* takeCodecPromise(JSTransformStream* stream)
 {
     auto* promise = stream->m_codecPromise.get();
     stream->m_codecPromise.clear();
     stream->m_codecChunkOffThread = false;
     nativeTransformReleaseStateIfIdle(stream);
+    return promise;
+}
+
+static void settleCodecChunk(JSGlobalObject* globalObject, JSTransformStream* stream, JSValue thrown)
+{
+    auto* promise = takeCodecPromise(stream);
     ASSERT(promise);
     if (!promise) [[unlikely]]
         return;
@@ -231,74 +234,24 @@ static void settleCodecChunk(JSGlobalObject* globalObject, JSTransformStream* st
         resolvePromise(globalObject, promise, jsUndefined());
 }
 
-// CodecVerdict::AwaitSink: the chunk's promise becomes m_nativeSinkReadyPromise, which the
-// sink's onReady (or detaching from the sink) resolves. The coder is idle from here on.
-static JSPromise* completeChunkWhenSinkDrains(JSGlobalObject* globalObject, JSTransformStream* stream)
+// Applies the outcome of a step that ran from a later turn to the pending chunk.
+static void settlePendingChunk(JSGlobalObject* globalObject, JSTransformStream* stream, CodecOutcome outcome, JSValue thrown)
 {
     auto& vm = getVM(globalObject);
-    auto* promise = stream->m_codecPromise.get();
-    stream->m_codecPromise.clear();
-    stream->m_codecChunkOffThread = false;
-    if (!promise)
-        promise = JSPromise::create(vm, globalObject->promiseStructure());
-    stream->m_nativeSinkReadyPromise.set(vm, stream, promise);
-    nativeTransformReleaseStateIfIdle(stream);
-    return promise;
-}
-
-// CodecVerdict::ParkOnReadable / ParkOnSink: registers onCodecChunkResume on the readable's
-// [[backpressureChangePromise]] (resolved by its pull and, via transformStreamUnblockWrite, by
-// every error/cancel terminal, including the cancel-after-close branch of
-// transformStreamDefaultSourceCancelAlgorithm) or on a gate in m_nativeSinkReadyPromise
-// (resolved by the sink's onReady or by detaching from it). Returns the chunk's promise.
-static JSPromise* parkCodecChunk(JSGlobalObject* globalObject, JSTransformStream* stream, CodecVerdict wait)
-{
-    auto& vm = getVM(globalObject);
-    if (!stream->m_codecPromise)
-        stream->m_codecPromise.set(vm, stream, JSPromise::create(vm, globalObject->promiseStructure()));
-    JSPromise* gate;
-    if (wait == CodecVerdict::ParkOnSink) {
-        ASSERT(!stream->m_nativeSinkReadyPromise);
-        gate = JSPromise::create(vm, globalObject->promiseStructure());
-        stream->m_nativeSinkReadyPromise.set(vm, stream, gate);
-    } else {
-        ASSERT(wait == CodecVerdict::ParkOnReadable);
-        ASSERT(stream->m_backpressure);
-        gate = stream->m_backpressureChangePromise.get();
-        ASSERT(gate);
-    }
-    auto* runtime = JSStreamsRuntime::from(globalObject);
-    gate->performPromiseThenWithContext(vm, globalObject, runtime->onCodecChunkResume(), jsUndefined(), jsUndefined(), stream);
-    return stream->m_codecPromise.get();
-}
-
-// Applies a step's verdict to a chunk that is already pending (m_codecPromise set).
-static void continuePendingChunk(JSGlobalObject* globalObject, JSTransformStream* stream, CodecVerdict verdict, JSValue thrown)
-{
-    switch (verdict) {
-    case CodecVerdict::Done:
-    case CodecVerdict::Failed:
-        settleCodecChunk(globalObject, stream, thrown);
-        return;
-    case CodecVerdict::AwaitSink:
-        completeChunkWhenSinkDrains(globalObject, stream);
-        return;
-    case CodecVerdict::ParkOnReadable:
-    case CodecVerdict::ParkOnSink:
-        parkCodecChunk(globalObject, stream, verdict);
-        return;
-    case CodecVerdict::Step:
-        break;
-    }
-    // stepChunkHere loops on Step itself; an off-thread chunk's next step goes to the pool too.
-    ASSERT(stream->m_codecChunkOffThread);
-    void* coder = coderOf(stream);
-    ASSERT(coder);
-    if (!coder) [[unlikely]] {
+    switch (outcome) {
+    case CodecOutcome::Done:
         settleCodecChunk(globalObject, stream, JSValue());
         return;
+    case CodecOutcome::Failed:
+        settleCodecChunk(globalObject, stream, thrown);
+        return;
+    case CodecOutcome::DoneSinkFull:
+        if (auto* promise = takeCodecPromise(stream))
+            stream->m_nativeSinkReadyPromise.set(vm, stream, promise);
+        return;
+    case CodecOutcome::Pending:
+        return;
     }
-    dispatchStepOffThread(globalObject, stream, coder, jsUndefined(), nullptr, 0, false);
 }
 
 // The transform / flush arm (under runNativeArm). Abrupt completions become a rejected
@@ -320,43 +273,59 @@ static JSPromise* transformChunk(JSGlobalObject* globalObject, JSTransformStream
     }
 
     JSValue thrown;
-    CodecVerdict verdict = stepChunkHere(globalObject, stream, coder, input, inputLen, finish, thrown);
+    CodecOutcome outcome = stepChunkHere(globalObject, stream, coder, input, inputLen, finish, thrown);
     RETURN_IF_EXCEPTION(scope, nullptr);
-    switch (verdict) {
-    case CodecVerdict::Done:
+    switch (outcome) {
+    case CodecOutcome::Done:
         RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, jsUndefined()));
-    case CodecVerdict::Failed:
+    case CodecOutcome::Failed:
         RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, thrown));
-    case CodecVerdict::AwaitSink:
-        RELEASE_AND_RETURN(scope, completeChunkWhenSinkDrains(globalObject, stream));
-    case CodecVerdict::ParkOnReadable:
-    case CodecVerdict::ParkOnSink:
-        RELEASE_AND_RETURN(scope, parkCodecChunk(globalObject, stream, verdict));
-    case CodecVerdict::Step:
-        break;
+    case CodecOutcome::DoneSinkFull: {
+        auto* ready = JSPromise::create(vm, globalObject->promiseStructure());
+        stream->m_nativeSinkReadyPromise.set(vm, stream, ready);
+        return ready;
+    }
+    case CodecOutcome::Pending: {
+        auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
+        stream->m_codecPromise.set(vm, stream, promise);
+        return promise;
+    }
     }
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-// The consumer a chunk was parked on has room again, or went away (see parkCodecChunk).
-static void resumeCodecChunk(JSGlobalObject* globalObject, JSTransformStream* stream)
+void nativeCodecContinue(JSGlobalObject* globalObject, JSTransformStream* stream)
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    if (!stream->m_codecPromise) [[unlikely]]
-        return;
+    ASSERT(stream->m_codecPromise);
     void* coder = coderOf(stream);
     ASSERT(coder);
-    if (!coder || !codecOutputWanted(stream))
+    if (!coder) [[unlikely]]
         RELEASE_AND_RETURN(scope, settleCodecChunk(globalObject, stream, JSValue()));
-    if (stream->m_codecChunkOffThread)
+    if (stream->m_codecChunkOffThread) {
+        // A step already on the pool re-dispatches itself from deliverAsync while there is room.
+        if (stream->m_asyncCodecInFlight)
+            return;
         RELEASE_AND_RETURN(scope, dispatchStepOffThread(globalObject, stream, coder, jsUndefined(), nullptr, 0, false));
+    }
     JSValue thrown;
     stream->m_nativeStateInUse = true;
-    CodecVerdict verdict = stepChunkHere(globalObject, stream, coder, nullptr, 0, false, thrown);
+    CodecOutcome outcome = stepChunkHere(globalObject, stream, coder, nullptr, 0, false, thrown);
     stream->m_nativeStateInUse = false;
     RETURN_IF_EXCEPTION(scope, void());
-    RELEASE_AND_RETURN(scope, continuePendingChunk(globalObject, stream, verdict, thrown));
+    settlePendingChunk(globalObject, stream, outcome, thrown);
+    // An abandon from inside the loop deferred its release to here.
+    RELEASE_AND_RETURN(scope, nativeTransformReleaseStateIfIdle(stream));
+}
+
+void nativeCodecAbandon(JSGlobalObject* globalObject, JSTransformStream* stream)
+{
+    if (!stream->m_codecPromise)
+        return;
+    // The in-flight write this chunk holds must still finish for the writable to reach its
+    // own terminal; the output that was never consumed is dropped with the coder.
+    settleCodecChunk(globalObject, stream, JSValue());
 }
 
 template<typename JSStream>
@@ -402,8 +371,8 @@ JSPromise* decompressionStreamFlush(JSGlobalObject* globalObject, JSDecompressio
 }
 
 // JS-thread completion of an off-thread step. `out` borrows the coder's buffer, so it is
-// consumed BEFORE m_asyncCodecInFlight is cleared and the verdict may release or re-dispatch
-// the coder. Returns into Rust, so this is an exception boundary rather than a throw scope.
+// consumed BEFORE m_asyncCodecInFlight is cleared and the coder may be released or
+// re-dispatched. Returns into Rust, so this is an exception boundary rather than a throw scope.
 extern "C" void Bun__CompressionStream__deliverAsync(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue streamCell, const uint8_t* out, size_t outLen, bool more, JSC::EncodedJSValue error)
 {
     auto& vm = getVM(globalObject);
@@ -416,9 +385,10 @@ extern "C" void Bun__CompressionStream__deliverAsync(JSC::JSGlobalObject* global
 
     CodecStepResult step;
     step.more = more;
+    bool abandoned = !stream->m_codecPromise;
     if (error) {
         step.thrown = JSValue::decode(error);
-    } else if (outLen) {
+    } else if (outLen && !abandoned) {
         if (void* sinkPtr = stream->m_nativeSinkPtr) {
             JSValue wrote = JSValue::decode(Bun__NativeTransformSink__writeBytes(stream->m_nativeSinkId, sinkPtr, globalObject, out, outLen));
             if (!scope.exception())
@@ -444,26 +414,24 @@ extern "C" void Bun__CompressionStream__deliverAsync(JSC::JSGlobalObject* global
     }
 
     stream->m_asyncCodecInFlight = false;
-    continuePendingChunk(globalObject, stream, verdictAfterStep(stream, step), step.thrown);
+    // A terminal abandoned the chunk while this step ran (the delivery above may have been it).
+    if (!stream->m_codecPromise) {
+        nativeTransformReleaseStateIfIdle(stream);
+        return;
+    }
+    if (!step.thrown.isEmpty())
+        settleCodecChunk(globalObject, stream, step.thrown);
+    else if (!step.more)
+        settlePendingChunk(globalObject, stream, consumerFull(stream, step) && stream->m_nativeSinkPtr ? CodecOutcome::DoneSinkFull : CodecOutcome::Done, JSValue());
+    else if (!consumerFull(stream, step)) {
+        if (void* coder = coderOf(stream)) [[likely]]
+            dispatchStepOffThread(globalObject, stream, coder, jsUndefined(), nullptr, 0, false);
+        else
+            settleCodecChunk(globalObject, stream, JSValue());
+    }
+    // Otherwise the consumer continues the chunk once it has room.
     scope.assertNoException();
 }
 
 } // namespace WebStreams
 } // namespace Bun
-
-namespace WebCore {
-
-using namespace JSC;
-
-// [reaction-convention] _CODEC group; context = the JSCompressionStream / JSDecompressionStream.
-JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onCodecChunkResume, (JSGlobalObject * globalObject, CallFrame* callFrame))
-{
-    auto& vm = getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* stream = uncheckedDowncast<JSTransformStream>(callFrame->argument(1));
-    Bun::WebStreams::resumeCodecChunk(globalObject, stream);
-    RETURN_IF_EXCEPTION(scope, {});
-    return JSValue::encode(jsUndefined());
-}
-
-} // namespace WebCore

--- a/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.cpp
+++ b/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.cpp
@@ -262,9 +262,12 @@ static JSPromise* completeChunkWhenSinkDrains(JSGlobalObject* globalObject, JSTr
 
 // CodecVerdict::ParkOnReadable / ParkOnSink. Leaves the chunk pending and registers
 // onCodecChunkResume on the promise the consumer resolves when it has room: the readable
-// side's [[backpressureChangePromise]] (resolved by its pull, and by the unblock-write step
-// of every error/cancel terminal), or a fresh gate in m_nativeSinkReadyPromise (resolved by
-// the sink's onReady or by detaching from the sink). Returns the chunk's promise.
+// side's [[backpressureChangePromise]], or a fresh gate in m_nativeSinkReadyPromise (resolved
+// by the sink's onReady or by detaching from the sink). Besides the readable's pull, every
+// terminal resolves the former through transformStreamUnblockWrite: the error path, the
+// cancel reaction, and (Bun addition, for a flush parked here) the cancel that arrives while
+// a close is already in flight, see transformStreamDefaultSourceCancelAlgorithm. Returns the
+// chunk's promise.
 static JSPromise* parkCodecChunk(JSGlobalObject* globalObject, JSTransformStream* stream, CodecVerdict wait)
 {
     auto& vm = getVM(globalObject);

--- a/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.h
+++ b/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.h
@@ -5,17 +5,14 @@
 #include "root.h"
 #include "StreamsForward.h"
 
-// CompressionStreamCoder.rs. A chunk (or the flush) is transformed in steps of bounded
-// output: each call below runs one step and reports through `more` whether the coder
-// stopped at its cap, in which case it must be stepped again (with no input; it keeps the
-// chunk's unconsumed tail) before the next chunk is fed.
+// CompressionStreamCoder.rs. Each transform call runs one bounded step; `more` means the coder
+// must be stepped again (with no input, it kept the tail) before the next chunk is fed.
 extern "C" void* CompressionStreamCoder__create(uint8_t format, bool decompress);
 // Releases the cell's reference (in-flight off-thread steps hold their own).
 extern "C" void CompressionStreamCoder__destroy(void* coder);
 extern "C" JSC::EncodedJSValue CompressionStreamCoder__transform(void* coder, JSC::JSGlobalObject* global, const uint8_t* input, size_t input_len, bool finish, bool* more);
 extern "C" JSC::EncodedJSValue CompressionStreamCoder__transformInto(void* coder, JSC::JSGlobalObject* global, const uint8_t* input, size_t input_len, bool finish, uint8_t sinkId, void* sinkPtr, bool* more);
-// Off-thread step; completes through Bun__CompressionStream__deliverAsync. A continuation
-// step passes an undefined chunk and no input.
+// Off-thread step, completed by Bun__CompressionStream__deliverAsync.
 extern "C" void CompressionStreamCoder__transformAsync(void* coder, JSC::JSGlobalObject* global, JSC::EncodedJSValue streamCell, JSC::EncodedJSValue chunk, const uint8_t* input, size_t inputLen, bool finish);
 
 namespace Bun {

--- a/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.h
+++ b/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.h
@@ -5,12 +5,17 @@
 #include "root.h"
 #include "StreamsForward.h"
 
-// CompressionStreamCoder.rs
+// CompressionStreamCoder.rs. A chunk (or the flush) is transformed in steps of bounded
+// output: each call below runs one step and reports through `more` whether the coder
+// stopped at its cap, in which case it must be stepped again (with no input; it keeps the
+// chunk's unconsumed tail) before the next chunk is fed.
 extern "C" void* CompressionStreamCoder__create(uint8_t format, bool decompress);
-// Releases the cell's reference (in-flight async transforms hold their own).
+// Releases the cell's reference (in-flight off-thread steps hold their own).
 extern "C" void CompressionStreamCoder__destroy(void* coder);
-extern "C" JSC::EncodedJSValue CompressionStreamCoder__transform(void* coder, JSC::JSGlobalObject* global, const uint8_t* input, size_t input_len, bool finish);
-extern "C" JSC::EncodedJSValue CompressionStreamCoder__transformInto(void* coder, JSC::JSGlobalObject* global, const uint8_t* input, size_t input_len, bool finish, uint8_t sinkId, void* sinkPtr);
+extern "C" JSC::EncodedJSValue CompressionStreamCoder__transform(void* coder, JSC::JSGlobalObject* global, const uint8_t* input, size_t input_len, bool finish, bool* more);
+extern "C" JSC::EncodedJSValue CompressionStreamCoder__transformInto(void* coder, JSC::JSGlobalObject* global, const uint8_t* input, size_t input_len, bool finish, uint8_t sinkId, void* sinkPtr, bool* more);
+// Off-thread step; completes through Bun__CompressionStream__deliverAsync. A continuation
+// step passes an undefined chunk and no input.
 extern "C" void CompressionStreamCoder__transformAsync(void* coder, JSC::JSGlobalObject* global, JSC::EncodedJSValue streamCell, JSC::EncodedJSValue chunk, const uint8_t* input, size_t inputLen, bool finish);
 
 namespace Bun {

--- a/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.h
+++ b/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.h
@@ -7,7 +7,7 @@
 
 // CompressionStreamCoder.rs. Each transform call runs one bounded step; `more` means the coder
 // must be stepped again (with no input, it kept the tail) before the next chunk is fed.
-extern "C" void* CompressionStreamCoder__create(uint8_t format, bool decompress);
+extern "C" void* CompressionStreamCoder__create(uint8_t format, bool decompress, size_t highWaterMark);
 // Releases the cell's reference (in-flight off-thread steps hold their own).
 extern "C" void CompressionStreamCoder__destroy(void* coder);
 extern "C" JSC::EncodedJSValue CompressionStreamCoder__transform(void* coder, JSC::JSGlobalObject* global, const uint8_t* input, size_t input_len, bool finish, bool* more);
@@ -19,6 +19,11 @@ namespace Bun {
 namespace WebStreams {
 
 std::optional<CompressionFormat> parseCompressionFormat(JSC::JSGlobalObject*, JSC::JSValue formatValue);
+// The optional second constructor argument, read like a queuing strategy: its highWaterMark (bytes,
+// default 64 KiB) is the output bound of one codec step, i.e. the largest piece a consumer gets per
+// read() and how far the coder runs ahead of a slow consumer. Throws RangeError / TypeError as
+// ExtractHighWaterMark does; `size` is ignored.
+size_t parseCodecHighWaterMark(JSC::JSGlobalObject*, JSC::JSValue strategy);
 
 } // namespace WebStreams
 } // namespace Bun

--- a/src/jsc/bindings/webcore/streams/JSDecompressionStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSDecompressionStream.cpp
@@ -158,8 +158,10 @@ template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSDecompressionStreamCon
     auto format = parseCompressionFormat(lexicalGlobalObject, callFrame->argument(0));
     RETURN_IF_EXCEPTION(scope, {});
     ASSERT(format.has_value());
+    size_t highWaterMark = parseCodecHighWaterMark(lexicalGlobalObject, callFrame->argument(1));
+    RETURN_IF_EXCEPTION(scope, {});
 
-    void* coder = CompressionStreamCoder__create(static_cast<uint8_t>(*format), true);
+    void* coder = CompressionStreamCoder__create(static_cast<uint8_t>(*format), true, highWaterMark);
     if (!coder) [[unlikely]] {
         throwTypeError(lexicalGlobalObject, scope, "failed to initialize decompressor"_s);
         return {};

--- a/src/jsc/bindings/webcore/streams/JSStreamsRuntime.h
+++ b/src/jsc/bindings/webcore/streams/JSStreamsRuntime.h
@@ -148,8 +148,7 @@ namespace WebCore {
     V(onTSPerformTransformRejected)
 
 // owner: JSCompressionStreamShared.cpp. context = the JSCompressionStream / JSDecompressionStream
-// (a JSTransformStream) whose codec chunk parked mid-way; registered on the readable side's
-// backpressureChangePromise or on the native sink's ready promise.
+// whose codec chunk is parked.
 #define FOR_EACH_WEB_STREAMS_REACTION_HANDLER_CODEC(V) \
     V(onCodecChunkResume)
 

--- a/src/jsc/bindings/webcore/streams/JSStreamsRuntime.h
+++ b/src/jsc/bindings/webcore/streams/JSStreamsRuntime.h
@@ -147,11 +147,6 @@ namespace WebCore {
 #define FOR_EACH_WEB_STREAMS_REACTION_HANDLER_TS_CONTROLLER(V) \
     V(onTSPerformTransformRejected)
 
-// owner: JSCompressionStreamShared.cpp. context = the JSCompressionStream / JSDecompressionStream
-// whose codec chunk is parked.
-#define FOR_EACH_WEB_STREAMS_REACTION_HANDLER_CODEC(V) \
-    V(onCodecChunkResume)
-
 // owner: CrossRealmTransform.cpp (transferable streams are not implemented; the handler may
 // assert-not-reached). context = the JSCrossRealmTransformState.
 #define FOR_EACH_WEB_STREAMS_REACTION_HANDLER_CROSS_REALM(V) \
@@ -232,7 +227,6 @@ namespace WebCore {
     FOR_EACH_WEB_STREAMS_REACTION_HANDLER_WS_CONTROLLER(V)         \
     FOR_EACH_WEB_STREAMS_REACTION_HANDLER_TS_OPERATIONS(V)         \
     FOR_EACH_WEB_STREAMS_REACTION_HANDLER_TS_CONTROLLER(V)         \
-    FOR_EACH_WEB_STREAMS_REACTION_HANDLER_CODEC(V)                 \
     FOR_EACH_WEB_STREAMS_REACTION_HANDLER_CROSS_REALM(V)           \
     FOR_EACH_WEB_STREAMS_REACTION_HANDLER_BUN_SOURCE(V)            \
     FOR_EACH_WEB_STREAMS_REACTION_HANDLER_DIRECT_CONTROLLER(V)     \

--- a/src/jsc/bindings/webcore/streams/JSStreamsRuntime.h
+++ b/src/jsc/bindings/webcore/streams/JSStreamsRuntime.h
@@ -147,6 +147,12 @@ namespace WebCore {
 #define FOR_EACH_WEB_STREAMS_REACTION_HANDLER_TS_CONTROLLER(V) \
     V(onTSPerformTransformRejected)
 
+// owner: JSCompressionStreamShared.cpp. context = the JSCompressionStream / JSDecompressionStream
+// (a JSTransformStream) whose codec chunk parked mid-way; registered on the readable side's
+// backpressureChangePromise or on the native sink's ready promise.
+#define FOR_EACH_WEB_STREAMS_REACTION_HANDLER_CODEC(V) \
+    V(onCodecChunkResume)
+
 // owner: CrossRealmTransform.cpp (transferable streams are not implemented; the handler may
 // assert-not-reached). context = the JSCrossRealmTransformState.
 #define FOR_EACH_WEB_STREAMS_REACTION_HANDLER_CROSS_REALM(V) \
@@ -227,6 +233,7 @@ namespace WebCore {
     FOR_EACH_WEB_STREAMS_REACTION_HANDLER_WS_CONTROLLER(V)         \
     FOR_EACH_WEB_STREAMS_REACTION_HANDLER_TS_OPERATIONS(V)         \
     FOR_EACH_WEB_STREAMS_REACTION_HANDLER_TS_CONTROLLER(V)         \
+    FOR_EACH_WEB_STREAMS_REACTION_HANDLER_CODEC(V)                 \
     FOR_EACH_WEB_STREAMS_REACTION_HANDLER_CROSS_REALM(V)           \
     FOR_EACH_WEB_STREAMS_REACTION_HANDLER_BUN_SOURCE(V)            \
     FOR_EACH_WEB_STREAMS_REACTION_HANDLER_DIRECT_CONTROLLER(V)     \

--- a/src/jsc/bindings/webcore/streams/JSTransformStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTransformStream.cpp
@@ -284,7 +284,7 @@ void JSTransformStream::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     visitor.appendHidden(thisObject->m_pendingWriteChunk);
     visitor.appendHidden(thisObject->m_nativeSinkCell);
     visitor.appendHidden(thisObject->m_nativeSinkReadyPromise);
-    visitor.appendHidden(thisObject->m_asyncCodecPromise);
+    visitor.appendHidden(thisObject->m_codecPromise);
 }
 
 void JSTransformStream::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
@@ -299,7 +299,7 @@ void JSTransformStream::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
     analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_pendingWriteChunk, "pendingWriteChunk"_s);
     analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_nativeSinkCell, "nativeSinkCell"_s);
     analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_nativeSinkReadyPromise, "nativeSinkReadyPromise"_s);
-    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_asyncCodecPromise, "asyncCodecPromise"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_codecPromise, "codecPromise"_s);
 }
 
 // Prototype host functions

--- a/src/jsc/bindings/webcore/streams/JSTransformStream.h
+++ b/src/jsc/bindings/webcore/streams/JSTransformStream.h
@@ -70,13 +70,14 @@ public:
     // output straight to `m_nativeSinkPtr` via the Rust SinkHandle dispatcher
     // (Bun__NativeTransformSink__writeBytes) instead of wrapping it in a
     // JSUint8Array and enqueueing on the readable.
-    // `m_nativeSinkReadyPromise` is the promise an arm parked on sink backpressure;
-    // the sink's onReady (or detaching from the sink) resolves it.
+    // `m_nativeSinkReadyPromise` is the transform-algorithm result returned on
+    // sink backpressure; the sink's onReady resolves it.
     JSC::WriteBarrier<JSC::JSObject> m_nativeSinkCell;
     JSC::WriteBarrier<JSC::JSPromise> m_nativeSinkReadyPromise;
     // Compression/Decompression only: transform-algorithm promise of a chunk whose codec
-    // steps span turns (off-thread, or parked at the output cap). While set, the coder holds
-    // that chunk's state and ClearAlgorithms defers the coder release to the chunk's terminal.
+    // steps span turns (off-thread, or waiting for the consumer to take the output so far);
+    // the consumer drives it on (WebStreamsInternals.h: nativeCodecContinue / Abandon). While
+    // set, the coder holds that chunk's state and ClearAlgorithms defers the coder release.
     JSC::WriteBarrier<JSC::JSPromise> m_codecPromise;
     void* m_nativeSinkPtr { nullptr };
     uint8_t m_nativeSinkId { 0 };

--- a/src/jsc/bindings/webcore/streams/JSTransformStream.h
+++ b/src/jsc/bindings/webcore/streams/JSTransformStream.h
@@ -59,23 +59,29 @@ public:
     // ClearAlgorithms defers the eager free to the arm's epilogue instead.
     bool m_nativeStateInUse : 1 { false };
     bool m_nativeStateReleasePending : 1 { false };
-    // An off-thread codec task holds the coder; ClearAlgorithms / runNativeArm must defer
-    // the free until the task's JS-thread completion clears this.
+    // An off-thread codec step holds the coder; ClearAlgorithms / runNativeArm must defer
+    // the free until the step's JS-thread completion clears this.
     bool m_asyncCodecInFlight : 1 { false };
+    // Compression/Decompression only: the chunk behind m_codecPromise started on the thread
+    // pool, so its remaining steps are dispatched there too (never run on this thread).
+    bool m_codecChunkOffThread : 1 { false };
 
     // Native byte-producing subclasses only: when `readStreamIntoSink` attaches a
     // native JSSink controller to this transform, the transform arms write coder
     // output straight to `m_nativeSinkPtr` via the Rust SinkHandle dispatcher
     // (Bun__NativeTransformSink__writeBytes) instead of wrapping it in a
     // JSUint8Array and enqueueing on the readable.
-    // `m_nativeSinkReadyPromise` is the transform-algorithm result returned on
-    // sink backpressure; the sink's onReady resolves it.
+    // `m_nativeSinkReadyPromise` is whatever promise the arm parked on sink
+    // backpressure (the transform-algorithm result itself, or a codec chunk's
+    // resume gate); the sink's onReady (or detaching from the sink) resolves it.
     JSC::WriteBarrier<JSC::JSObject> m_nativeSinkCell;
     JSC::WriteBarrier<JSC::JSPromise> m_nativeSinkReadyPromise;
-    // Pending transform-algorithm promise for the off-thread codec step; the
-    // WorkTask's single `Strong` roots this cell and this barrier keeps the
-    // promise alive until deliverAsync settles it.
-    JSC::WriteBarrier<JSC::JSPromise> m_asyncCodecPromise;
+    // Compression/Decompression only: the transform-algorithm promise of a chunk (or
+    // flush) whose codec steps span turns, because a step ran off-thread or stopped at
+    // the coder's output cap and is parked until the consumer has room. Set means the
+    // coder still holds that chunk's state, so ClearAlgorithms defers the coder release
+    // to the chunk's terminal (JSCompressionStreamShared.cpp).
+    JSC::WriteBarrier<JSC::JSPromise> m_codecPromise;
     void* m_nativeSinkPtr { nullptr };
     uint8_t m_nativeSinkId { 0 };
 

--- a/src/jsc/bindings/webcore/streams/JSTransformStream.h
+++ b/src/jsc/bindings/webcore/streams/JSTransformStream.h
@@ -62,8 +62,7 @@ public:
     // An off-thread codec step holds the coder; ClearAlgorithms / runNativeArm must defer
     // the free until the step's JS-thread completion clears this.
     bool m_asyncCodecInFlight : 1 { false };
-    // Compression/Decompression only: the chunk behind m_codecPromise started on the thread
-    // pool, so its remaining steps are dispatched there too (never run on this thread).
+    // The chunk behind m_codecPromise runs its steps on the thread pool.
     bool m_codecChunkOffThread : 1 { false };
 
     // Native byte-producing subclasses only: when `readStreamIntoSink` attaches a
@@ -71,16 +70,13 @@ public:
     // output straight to `m_nativeSinkPtr` via the Rust SinkHandle dispatcher
     // (Bun__NativeTransformSink__writeBytes) instead of wrapping it in a
     // JSUint8Array and enqueueing on the readable.
-    // `m_nativeSinkReadyPromise` is whatever promise the arm parked on sink
-    // backpressure (the transform-algorithm result itself, or a codec chunk's
-    // resume gate); the sink's onReady (or detaching from the sink) resolves it.
+    // `m_nativeSinkReadyPromise` is the promise an arm parked on sink backpressure;
+    // the sink's onReady (or detaching from the sink) resolves it.
     JSC::WriteBarrier<JSC::JSObject> m_nativeSinkCell;
     JSC::WriteBarrier<JSC::JSPromise> m_nativeSinkReadyPromise;
-    // Compression/Decompression only: the transform-algorithm promise of a chunk (or
-    // flush) whose codec steps span turns, because a step ran off-thread or stopped at
-    // the coder's output cap and is parked until the consumer has room. Set means the
-    // coder still holds that chunk's state, so ClearAlgorithms defers the coder release
-    // to the chunk's terminal (JSCompressionStreamShared.cpp).
+    // Compression/Decompression only: transform-algorithm promise of a chunk whose codec
+    // steps span turns (off-thread, or parked at the output cap). While set, the coder holds
+    // that chunk's state and ClearAlgorithms defers the coder release to the chunk's terminal.
     JSC::WriteBarrier<JSC::JSPromise> m_codecPromise;
     void* m_nativeSinkPtr { nullptr };
     uint8_t m_nativeSinkId { 0 };

--- a/src/jsc/bindings/webcore/streams/JSTransformStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTransformStreamDefaultController.cpp
@@ -401,20 +401,26 @@ void nativeTransformReleaseState(JSTransformStream* stream)
         TextDecoder__destroyForStream(std::exchange(s->m_decoder, nullptr));
 }
 
-// ClearAlgorithms is the one shared terminal (post-flush, error, cancel), but a
-// re-entrant reader.cancel() from user JS inside a native arm's chunk coercion reaches
-// it while the coder is still in use on the stack. Defer when m_nativeStateInUse; the
-// runNativeArm epilogue frees it once control unwinds.
+void nativeTransformReleaseStateIfIdle(JSTransformStream* stream)
+{
+    if (!stream->m_nativeStateReleasePending || stream->m_nativeStateInUse || stream->m_asyncCodecInFlight || stream->m_codecPromise)
+        return;
+    nativeTransformReleaseState(stream);
+}
+
+// ClearAlgorithms is the one shared terminal (post-flush, error, cancel), but it can reach
+// a coder that is still busy: a re-entrant reader.cancel() from user JS inside a native arm
+// (m_nativeStateInUse), an off-thread codec step (m_asyncCodecInFlight), or a codec chunk
+// whose steps are still pending across turns (m_codecPromise; the close algorithm clears
+// algorithms as soon as the flush arm returns, while a large flush may still be parked
+// mid-way). Defer; whoever finishes that work runs nativeTransformReleaseStateIfIdle.
 static void nativeTransformReleaseStateOrDefer(JSTransformStreamDefaultController* controller)
 {
     auto* stream = dynamicDowncast<JSTransformStream>(controller->m_algorithmContext.get());
     if (!stream)
         return;
-    if (stream->m_nativeStateInUse || stream->m_asyncCodecInFlight) {
-        stream->m_nativeStateReleasePending = true;
-        return;
-    }
-    nativeTransformReleaseState(stream);
+    stream->m_nativeStateReleasePending = true;
+    nativeTransformReleaseStateIfIdle(stream);
 }
 
 void transformStreamDefaultControllerClearAlgorithms(JSTransformStreamDefaultController* controller)

--- a/src/jsc/bindings/webcore/streams/JSTransformStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTransformStreamDefaultController.cpp
@@ -408,12 +408,9 @@ void nativeTransformReleaseStateIfIdle(JSTransformStream* stream)
     nativeTransformReleaseState(stream);
 }
 
-// ClearAlgorithms is the one shared terminal (post-flush, error, cancel), but it can reach
-// a coder that is still busy: a re-entrant reader.cancel() from user JS inside a native arm
-// (m_nativeStateInUse), an off-thread codec step (m_asyncCodecInFlight), or a codec chunk
-// whose steps are still pending across turns (m_codecPromise; the close algorithm clears
-// algorithms as soon as the flush arm returns, while a large flush may still be parked
-// mid-way). Defer; whoever finishes that work runs nativeTransformReleaseStateIfIdle.
+// ClearAlgorithms (post-flush, error, cancel) can reach a coder that is still busy: an arm on
+// the stack, an off-thread step, or a chunk parked across turns (the close algorithm clears
+// algorithms as soon as the flush arm returns). Whoever finishes that work releases it.
 static void nativeTransformReleaseStateOrDefer(JSTransformStreamDefaultController* controller)
 {
     auto* stream = dynamicDowncast<JSTransformStream>(controller->m_algorithmContext.get());

--- a/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultController.cpp
@@ -564,10 +564,8 @@ void writableStreamDefaultControllerError(JSGlobalObject* globalObject, JSWritab
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* stream = controller->m_stream.get();
     ASSERT(stream->m_state == WritableStreamState::Writable);
-    // Cleared after StartErroring rather than before as in the spec: StartErroring reaches a
-    // native codec chunk still in flight through the algorithms, and nothing else it does uses
-    // them (a Writable stream has no pending abort request, so it cannot get to the abort steps).
     writableStreamStartErroring(globalObject, stream, error);
+    // After StartErroring, not before as in the spec: it reaches an in-flight codec chunk through the algorithms.
     writableStreamDefaultControllerClearAlgorithms(controller);
     RETURN_IF_EXCEPTION(scope, );
 }

--- a/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultController.cpp
@@ -564,8 +564,12 @@ void writableStreamDefaultControllerError(JSGlobalObject* globalObject, JSWritab
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* stream = controller->m_stream.get();
     ASSERT(stream->m_state == WritableStreamState::Writable);
+    // Cleared after StartErroring rather than before as in the spec: StartErroring reaches a
+    // native codec chunk still in flight through the algorithms, and nothing else it does uses
+    // them (a Writable stream has no pending abort request, so it cannot get to the abort steps).
+    writableStreamStartErroring(globalObject, stream, error);
     writableStreamDefaultControllerClearAlgorithms(controller);
-    RELEASE_AND_RETURN(scope, writableStreamStartErroring(globalObject, stream, error));
+    RETURN_IF_EXCEPTION(scope, );
 }
 
 void writableStreamDefaultControllerErrorIfNeeded(JSGlobalObject* globalObject, JSWritableStreamDefaultController* controller, JSValue error)

--- a/src/jsc/bindings/webcore/streams/TransformStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/TransformStreamOperations.cpp
@@ -283,6 +283,7 @@ JSPromise* transformStreamDefaultSourceCancelAlgorithm(JSGlobalObject* globalObj
         // as the readable this cancel just closed will never pull again. Nothing else waits on
         // that promise once a close has started.
         transformStreamUnblockWrite(globalObject, stream);
+        RETURN_IF_EXCEPTION(scope, nullptr);
         return finishPromise;
     }
     auto* finishPromise = JSPromise::create(vm, globalObject->promiseStructure());

--- a/src/jsc/bindings/webcore/streams/TransformStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/TransformStreamOperations.cpp
@@ -278,12 +278,10 @@ JSPromise* transformStreamDefaultSourceCancelAlgorithm(JSGlobalObject* globalObj
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* controller = stream->m_controller.get();
     if (auto* finishPromise = controller->m_finishPromise.get()) {
-        // A close is already in flight, so the spec just hands back its finish promise and the
-        // unblock-write step of the reaction below never runs. That step is what wakes a native
-        // codec flush parked on [[backpressureChangePromise]] (JSCompressionStreamShared.cpp),
-        // and the readable, closed by this cancel, will never pull again, so perform it here.
-        // Nothing else can be waiting on that promise: a close or abort only starts once no
-        // write is in flight.
+        // The spec skips the reaction below (and its unblock-write step) while a close is in
+        // flight; a native codec flush parked on [[backpressureChangePromise]] still needs it,
+        // as the readable this cancel just closed will never pull again. Nothing else waits on
+        // that promise once a close has started.
         transformStreamUnblockWrite(globalObject, stream);
         return finishPromise;
     }

--- a/src/jsc/bindings/webcore/streams/TransformStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/TransformStreamOperations.cpp
@@ -161,6 +161,7 @@ void transformStreamErrorWritableAndUnblockWrite(JSGlobalObject* globalObject, J
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
+    nativeCodecAbandon(globalObject, stream);
     transformStreamDefaultControllerClearAlgorithms(stream->m_controller.get());
     writableStreamDefaultControllerErrorIfNeeded(globalObject, stream->m_writable->m_controller.get(), error);
     RETURN_IF_EXCEPTION(scope, void());
@@ -277,15 +278,11 @@ JSPromise* transformStreamDefaultSourceCancelAlgorithm(JSGlobalObject* globalObj
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* controller = stream->m_controller.get();
-    if (auto* finishPromise = controller->m_finishPromise.get()) {
-        // The spec skips the reaction below (and its unblock-write step) while a close is in
-        // flight; a native codec flush parked on [[backpressureChangePromise]] still needs it,
-        // as the readable this cancel just closed will never pull again. Nothing else waits on
-        // that promise once a close has started.
-        transformStreamUnblockWrite(globalObject, stream);
-        RETURN_IF_EXCEPTION(scope, nullptr);
+    // The readable is closed: a codec chunk (or, with a close in flight, flush) still being
+    // drained into it can no longer finish.
+    nativeCodecAbandon(globalObject, stream);
+    if (auto* finishPromise = controller->m_finishPromise.get())
         return finishPromise;
-    }
     auto* finishPromise = JSPromise::create(vm, globalObject->promiseStructure());
     controller->m_finishPromise.set(vm, controller, finishPromise);
 
@@ -301,9 +298,21 @@ JSPromise* transformStreamDefaultSourceCancelAlgorithm(JSGlobalObject* globalObj
 
 JSPromise* transformStreamDefaultSourcePullAlgorithm(JSGlobalObject* globalObject, JSTransformStream* stream)
 {
+    auto& vm = getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
     ASSERT(stream->m_backpressure);
     ASSERT(stream->m_backpressureChangePromise);
     transformStreamSetBackpressure(globalObject, stream, false);
+    scope.assertNoException();
+    if (stream->m_codecPromise) [[unlikely]] {
+        // The readable is asking for the next piece of a native codec chunk. Its enqueues may
+        // set [[backpressure]] again right here; a null result (pull done) keeps the next pull
+        // valid in that case, and otherwise the usual promise does.
+        nativeCodecContinue(globalObject, stream);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        if (stream->m_backpressure)
+            return nullptr;
+    }
     return stream->m_backpressureChangePromise.get();
 }
 

--- a/src/jsc/bindings/webcore/streams/TransformStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/TransformStreamOperations.cpp
@@ -161,7 +161,6 @@ void transformStreamErrorWritableAndUnblockWrite(JSGlobalObject* globalObject, J
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    nativeCodecAbandon(globalObject, stream);
     transformStreamDefaultControllerClearAlgorithms(stream->m_controller.get());
     writableStreamDefaultControllerErrorIfNeeded(globalObject, stream->m_writable->m_controller.get(), error);
     RETURN_IF_EXCEPTION(scope, void());

--- a/src/jsc/bindings/webcore/streams/TransformStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/TransformStreamOperations.cpp
@@ -277,8 +277,16 @@ JSPromise* transformStreamDefaultSourceCancelAlgorithm(JSGlobalObject* globalObj
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* controller = stream->m_controller.get();
-    if (auto* finishPromise = controller->m_finishPromise.get())
+    if (auto* finishPromise = controller->m_finishPromise.get()) {
+        // A close is already in flight, so the spec just hands back its finish promise and the
+        // unblock-write step of the reaction below never runs. That step is what wakes a native
+        // codec flush parked on [[backpressureChangePromise]] (JSCompressionStreamShared.cpp),
+        // and the readable, closed by this cancel, will never pull again, so perform it here.
+        // Nothing else can be waiting on that promise: a close or abort only starts once no
+        // write is in flight.
+        transformStreamUnblockWrite(globalObject, stream);
         return finishPromise;
+    }
     auto* finishPromise = JSPromise::create(vm, globalObject->promiseStructure());
     controller->m_finishPromise.set(vm, controller, finishPromise);
 

--- a/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
@@ -513,6 +513,11 @@ JSC::JSPromise* compressionStreamTransform(JSC::JSGlobalObject*, JSCompressionSt
 JSC::JSPromise* compressionStreamFlush(JSC::JSGlobalObject*, JSCompressionStream*, JSTransformStreamDefaultController*); // userJS: yes — JSCompressionStreamShared.cpp
 JSC::JSPromise* decompressionStreamTransform(JSC::JSGlobalObject*, JSDecompressionStream*, JSTransformStreamDefaultController*, JSC::JSValue chunk); // userJS: yes — JSCompressionStreamShared.cpp
 JSC::JSPromise* decompressionStreamFlush(JSC::JSGlobalObject*, JSDecompressionStream*, JSTransformStreamDefaultController*); // userJS: yes — JSCompressionStreamShared.cpp
+// A codec chunk whose output is still pending (stream->m_codecPromise set) is driven by its
+// consumer: the readable's pull algorithm / the native sink's onReady continue it; the
+// error and cancel terminals and a sink detach abandon it (no-ops when nothing is pending).
+void nativeCodecContinue(JSC::JSGlobalObject*, JSTransformStream*); // userJS: no — JSCompressionStreamShared.cpp
+void nativeCodecAbandon(JSC::JSGlobalObject*, JSTransformStream*); // userJS: no — JSCompressionStreamShared.cpp
 
 // CrossRealmTransform.cpp — transferable streams are NOT implemented. These signatures are
 // FROZEN, but the .cpp may be a stub whose entry points assert / throw; the per-class

--- a/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
@@ -463,9 +463,7 @@ void transformStreamDefaultControllerClearAlgorithms(JSTransformStreamDefaultCon
 // completion, errors the writable, then throws stream.[[readable]].[[storedError]]).
 void transformStreamDefaultControllerEnqueue(JSC::JSGlobalObject*, JSTransformStreamDefaultController*, JSC::JSValue chunk); // userJS: yes; throws — JSTransformStreamDefaultController.cpp
 void nativeTransformReleaseState(JSTransformStream*); // userJS: no — JSTransformStreamDefaultController.cpp
-// Performs the release ClearAlgorithms deferred (m_nativeStateReleasePending), provided nothing
-// holds the native state any more: no arm on the stack, no off-thread codec step, no codec
-// chunk pending across turns. No-op otherwise.
+// Performs a release ClearAlgorithms deferred, once nothing holds the native state any more.
 void nativeTransformReleaseStateIfIdle(JSTransformStream*); // userJS: no — JSTransformStreamDefaultController.cpp
 
 // Rust-side single dispatch for the native-transform → native-JSSink byte write, routed

--- a/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
@@ -463,6 +463,10 @@ void transformStreamDefaultControllerClearAlgorithms(JSTransformStreamDefaultCon
 // completion, errors the writable, then throws stream.[[readable]].[[storedError]]).
 void transformStreamDefaultControllerEnqueue(JSC::JSGlobalObject*, JSTransformStreamDefaultController*, JSC::JSValue chunk); // userJS: yes; throws — JSTransformStreamDefaultController.cpp
 void nativeTransformReleaseState(JSTransformStream*); // userJS: no — JSTransformStreamDefaultController.cpp
+// Performs the release ClearAlgorithms deferred (m_nativeStateReleasePending), provided nothing
+// holds the native state any more: no arm on the stack, no off-thread codec step, no codec
+// chunk pending across turns. No-op otherwise.
+void nativeTransformReleaseStateIfIdle(JSTransformStream*); // userJS: no — JSTransformStreamDefaultController.cpp
 
 // Rust-side single dispatch for the native-transform → native-JSSink byte write, routed
 // through SinkHandle::write (src/runtime/webcore/Sink.rs). Returns a negative number for
@@ -482,8 +486,8 @@ JSC::JSPromise* runNativeArm(JSC::JSCell* context, Arm&& arm)
     stream->m_nativeStateInUse = true;
     JSC::JSPromise* result = arm(stream);
     stream->m_nativeStateInUse = false;
-    if (stream->m_nativeStateReleasePending && !stream->m_asyncCodecInFlight) [[unlikely]]
-        nativeTransformReleaseState(stream);
+    if (stream->m_nativeStateReleasePending) [[unlikely]]
+        nativeTransformReleaseStateIfIdle(stream);
     return result;
 }
 void transformStreamDefaultControllerError(JSC::JSGlobalObject*, JSTransformStreamDefaultController*, JSC::JSValue error); // userJS: yes — JSTransformStreamDefaultController.cpp

--- a/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
@@ -454,7 +454,7 @@ JSC::JSPromise* transformStreamDefaultSinkWriteAlgorithm(JSC::JSGlobalObject*, J
 JSC::JSPromise* transformStreamDefaultSinkAbortAlgorithm(JSC::JSGlobalObject*, JSTransformStream*, JSC::JSValue reason); // userJS: yes — TransformStreamOperations.cpp
 JSC::JSPromise* transformStreamDefaultSinkCloseAlgorithm(JSC::JSGlobalObject*, JSTransformStream*); // userJS: yes (user flush) — TransformStreamOperations.cpp
 JSC::JSPromise* transformStreamDefaultSourceCancelAlgorithm(JSC::JSGlobalObject*, JSTransformStream*, JSC::JSValue reason); // userJS: yes — TransformStreamOperations.cpp
-JSC::JSPromise* transformStreamDefaultSourcePullAlgorithm(JSC::JSGlobalObject*, JSTransformStream*); // userJS: no — TransformStreamOperations.cpp
+JSC::JSPromise* transformStreamDefaultSourcePullAlgorithm(JSC::JSGlobalObject*, JSTransformStream*); // userJS: yes (steps a pending codec chunk, whose enqueue fulfills read requests) — TransformStreamOperations.cpp
 
 // JSTransformStreamDefaultController.cpp
 
@@ -516,7 +516,7 @@ JSC::JSPromise* decompressionStreamFlush(JSC::JSGlobalObject*, JSDecompressionSt
 // A codec chunk whose output is still pending (stream->m_codecPromise set) is driven by its
 // consumer: the readable's pull algorithm / the native sink's onReady continue it; the
 // error and cancel terminals and a sink detach abandon it (no-ops when nothing is pending).
-void nativeCodecContinue(JSC::JSGlobalObject*, JSTransformStream*); // userJS: no — JSCompressionStreamShared.cpp
+void nativeCodecContinue(JSC::JSGlobalObject*, JSTransformStream*); // userJS: yes (enqueues) — JSCompressionStreamShared.cpp
 void nativeCodecAbandon(JSC::JSGlobalObject*, JSTransformStream*); // userJS: no — JSCompressionStreamShared.cpp
 
 // CrossRealmTransform.cpp — transferable streams are NOT implemented. These signatures are

--- a/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
@@ -514,8 +514,9 @@ JSC::JSPromise* compressionStreamFlush(JSC::JSGlobalObject*, JSCompressionStream
 JSC::JSPromise* decompressionStreamTransform(JSC::JSGlobalObject*, JSDecompressionStream*, JSTransformStreamDefaultController*, JSC::JSValue chunk); // userJS: yes — JSCompressionStreamShared.cpp
 JSC::JSPromise* decompressionStreamFlush(JSC::JSGlobalObject*, JSDecompressionStream*, JSTransformStreamDefaultController*); // userJS: yes — JSCompressionStreamShared.cpp
 // A codec chunk whose output is still pending (stream->m_codecPromise set) is driven by its
-// consumer: the readable's pull algorithm / the native sink's onReady continue it; the
-// error and cancel terminals and a sink detach abandon it (no-ops when nothing is pending).
+// consumer: the readable's pull algorithm / the native sink's onReady continue it; the writable
+// starting to error with the write in flight, a readable cancel, or a sink detach abandon it
+// (no-ops when nothing is pending).
 void nativeCodecContinue(JSC::JSGlobalObject*, JSTransformStream*); // userJS: yes (enqueues) — JSCompressionStreamShared.cpp
 void nativeCodecAbandon(JSC::JSGlobalObject*, JSTransformStream*); // userJS: no — JSCompressionStreamShared.cpp
 

--- a/src/jsc/bindings/webcore/streams/WritableStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/WritableStreamOperations.cpp
@@ -7,6 +7,7 @@
 #include "JSDOMGlobalObject.h"
 #include "JSDOMWrapperCache.h"
 #include "JSStreamsRuntime.h"
+#include "JSTransformStream.h"
 #include "JSWritableStream.h"
 #include "JSWritableStreamDefaultController.h"
 #include "JSWritableStreamDefaultWriter.h"
@@ -310,6 +311,11 @@ void writableStreamStartErroring(JSGlobalObject* globalObject, JSWritableStream*
         writableStreamDefaultWriterEnsureReadyPromiseRejected(globalObject, writer, reason);
         RETURN_IF_EXCEPTION(scope, );
     }
+    // The in-flight write may be a native codec chunk still being drained into the readable,
+    // which nothing on this side would ever finish; give it up so the erroring can complete.
+    // An in-flight close (a flush) is left to finish: a close in progress wins over the abort.
+    if (controller->m_algorithms.kind == SinkKind::Transform && stream->m_inFlightWriteRequest)
+        nativeCodecAbandon(globalObject, uncheckedDowncast<JSTransformStream>(controller->m_algorithms.algorithmContext.get()));
     if (!writableStreamHasOperationMarkedInFlight(stream) && controller->m_started)
         RELEASE_AND_RETURN(scope, writableStreamFinishErroring(globalObject, stream));
 }

--- a/src/jsc/rare_data.rs
+++ b/src/jsc/rare_data.rs
@@ -270,6 +270,8 @@ pub struct RareData {
 
     /// `node:http2` PADDED DATA scratch; see [`Self::take_h2_padded_frame_buffer`].
     h2_padded_frame_buffer: Option<Box<H2PaddedFrameBuffer>>,
+    /// Output scratch for one JS-thread `CompressionStream` step; see [`Self::take_compression_scratch`].
+    compression_scratch: Option<Vec<u8>>,
 
     // There is intentionally no `aws_signature_cache` field — storage lives in
     // `bun_s3_signing::credentials::AWS_SIGNATURE_CACHE` (process static; it
@@ -330,6 +332,7 @@ impl Default for RareData {
             listening_sockets_for_watch_mode: Mutex::new(Vec::new()),
             temp_pipe_read_buffer: None,
             h2_padded_frame_buffer: None,
+            compression_scratch: None,
             s3_default_client: Strong::empty(),
             node_quic_callbacks: Strong::empty(),
             default_csrf_secret: Box::default(),
@@ -680,6 +683,20 @@ impl RareData {
     /// Hand a taken buffer back; the slot keeps the first one returned.
     pub fn put_back_h2_padded_frame_buffer(&mut self, buffer: Box<H2PaddedFrameBuffer>) {
         self.h2_padded_frame_buffer.get_or_insert(buffer);
+    }
+
+    /// Empty `Vec` with whatever capacity the last step left behind.
+    pub fn take_compression_scratch(&mut self) -> Vec<u8> {
+        self.compression_scratch.take().unwrap_or_default()
+    }
+
+    /// Hand a taken buffer back; the slot keeps the first one returned and lets an oversized one go.
+    pub fn put_back_compression_scratch(&mut self, mut buffer: Vec<u8>) {
+        const KEEP: usize = 256 * 1024;
+        if self.compression_scratch.is_none() && buffer.capacity() <= KEEP {
+            buffer.clear();
+            self.compression_scratch = Some(buffer);
+        }
     }
 
     pub fn boring_engine(&mut self) -> *mut boring::ENGINE {

--- a/src/runtime/webcore/CompressionStreamCoder.rs
+++ b/src/runtime/webcore/CompressionStreamCoder.rs
@@ -131,8 +131,6 @@ pub struct CompressionStreamCoder {
     high_water_mark: usize,
     /// Set while a chunk's transform spans steps; `None` between chunks.
     pending: Option<Pending>,
-    /// Output of the latest `step`, which clears it on entry.
-    out: Vec<u8>,
 }
 
 // SAFETY: the z_stream / Brotli*Instance / ZSTD_*Ctx handles are single-owner
@@ -258,7 +256,6 @@ impl CompressionStreamCoder {
             zstd_head_len: 0,
             high_water_mark,
             pending: None,
-            out: Vec::new(),
         }))
     }
 
@@ -277,11 +274,11 @@ impl CompressionStreamCoder {
     }
 
     /// One step of the chunk (or, with `finish`, the final flush) in progress:
-    /// collects at most `max(high_water_mark, chunk length)` bytes into `self.out` and
+    /// collects at most `max(high_water_mark, chunk length)` bytes into `out` and
     /// returns `true` if the codec stopped at that cap, in which case the caller
     /// must step again (with no input) before feeding the next chunk.
-    fn step(&mut self, input: &[u8], finish: bool) -> Result<bool, CodecError> {
-        self.out.clear();
+    fn step(&mut self, input: &[u8], finish: bool, out: &mut Vec<u8>) -> Result<bool, CodecError> {
+        out.clear();
         if let Some(mut pending) = self.pending.take() {
             debug_assert!(input.is_empty());
             return match self.run(
@@ -289,6 +286,7 @@ impl CompressionStreamCoder {
                 pending.finish,
                 true,
                 pending.cap,
+                out,
             )? {
                 Progress::Done => Ok(false),
                 Progress::More { consumed } => {
@@ -308,7 +306,7 @@ impl CompressionStreamCoder {
             input
         };
         let cap = self.high_water_mark.max(input.len());
-        match self.run(bytes, finish, false, cap)? {
+        match self.run(bytes, finish, false, cap, out)? {
             Progress::Done => Ok(false),
             Progress::More { consumed } => {
                 self.pending = Some(Pending {
@@ -322,7 +320,7 @@ impl CompressionStreamCoder {
         }
     }
 
-    /// Drives the codec until the chunk is done or `self.out` holds `cap` bytes.
+    /// Drives the codec until the chunk is done or `out` holds `cap` bytes.
     /// A `continuing` step (not the chunk's first) calls the codec even with no
     /// input left, to drain the output it is holding.
     fn run(
@@ -331,8 +329,8 @@ impl CompressionStreamCoder {
         finish: bool,
         continuing: bool,
         cap: usize,
+        out: &mut Vec<u8>,
     ) -> Result<Progress, CodecError> {
-        let out = &mut self.out;
         match &mut self.backend {
             Backend::Deflate(s) => {
                 // `avail_in` is `uInt`; clamp and refill so a ≥4 GiB chunk
@@ -793,18 +791,18 @@ pub extern "C" fn CompressionStreamCoder__transform(
         // escape this call (`step` copies whatever it leaves unconsumed).
         unsafe { core::slice::from_raw_parts(input, input_len) }
     };
+    let rare = global.bun_vm().as_mut().rare_data();
+    let mut out = rare.take_compression_scratch();
     // SAFETY: `this` is the live coder owned by the calling JS cell; it is
     // only driven from the JS thread, so the call-scoped `&mut *this` has no
-    // alias. No JS runs between `step` and `take` below.
-    match unsafe { (*this).step(slice, finish) } {
+    // alias.
+    let result = match unsafe { (*this).step(slice, finish, &mut out) } {
         Ok(has_more) => {
             *more = has_more;
-            // SAFETY: as above.
-            let out = unsafe { core::mem::take(&mut (*this).out) };
             if out.is_empty() {
                 JSUint8Array::create_empty(global)
             } else {
-                JSUint8Array::from_bytes(global, out.into())
+                JSUint8Array::from_bytes_copy(global, &out)
             }
         }
         Err(e) => {
@@ -812,7 +810,9 @@ pub extern "C" fn CompressionStreamCoder__transform(
             throw_codec_error(global, e);
             JSValue::ZERO
         }
-    }
+    };
+    rare.put_back_compression_scratch(out);
+    result
 }
 
 fn codec_error_to_js(global: &JSGlobalObject, e: &CodecError) -> JSValue {
@@ -862,36 +862,38 @@ pub extern "C" fn CompressionStreamCoder__transformInto(
         // SAFETY: as in `CompressionStreamCoder__transform`.
         unsafe { core::slice::from_raw_parts(input, input_len) }
     };
+    let rare = global.bun_vm().as_mut().rare_data();
+    let mut out = rare.take_compression_scratch();
     // SAFETY: as in `CompressionStreamCoder__transform`.
-    match unsafe { (*this).step(slice, finish) } {
+    let result = match unsafe { (*this).step(slice, finish, &mut out) } {
         Ok(has_more) => {
             *more = has_more;
-            // SAFETY: as above; the sink copies before returning.
-            let out = unsafe { &(*this).out };
-            if out.is_empty() {
-                return JSValue::UNDEFINED;
+            'write: {
+                let Some(sink_ptr) = NonNull::new(sink_ptr).filter(|_| !out.is_empty()) else {
+                    break 'write JSValue::UNDEFINED;
+                };
+                // SAFETY: `sink_ptr` is a live JSSink of type `sink_id`; the sink
+                // copies what it needs before returning.
+                let handle =
+                    unsafe { crate::webcore::sink::sink_handle_from_id(sink_id, sink_ptr) };
+                if handle.is_none() {
+                    break 'write JSValue::UNDEFINED;
+                }
+                handle
+                    .write(&crate::webcore::streams::Result::Temporary(
+                        bun_ptr::RawSlice::new(&out),
+                    ))
+                    .to_js(global)
             }
-            let Some(sink_ptr) = NonNull::new(sink_ptr) else {
-                return JSValue::UNDEFINED;
-            };
-            // SAFETY: `sink_ptr` is a live JSSink of type `sink_id`; the sink
-            // copies what it needs before returning.
-            let handle = unsafe { crate::webcore::sink::sink_handle_from_id(sink_id, sink_ptr) };
-            if handle.is_none() {
-                return JSValue::UNDEFINED;
-            }
-            handle
-                .write(&crate::webcore::streams::Result::Temporary(
-                    bun_ptr::RawSlice::new(out),
-                ))
-                .to_js(global)
         }
         Err(e) => {
             *more = false;
             throw_codec_error(global, e);
             JSValue::ZERO
         }
-    }
+    };
+    rare.put_back_compression_scratch(out);
+    result
 }
 
 // ─── off-thread path (chunks > kAsyncCodecThreshold) ───────────────────────
@@ -919,6 +921,7 @@ pub struct CompressionAsyncCtx {
     /// Empty on a continuation step: the coder holds the chunk's tail.
     input: AsyncInput,
     finish: bool,
+    out: Vec<u8>,
     more: bool,
     error: Option<CodecError>,
 }
@@ -953,7 +956,7 @@ impl bun_jsc::JobContext for CompressionAsyncCtx {
     fn run(this: &mut Self, done: bun_jsc::Completion<Self>) -> Option<bun_jsc::Completion<Self>> {
         // SAFETY: `coder` is kept alive by the reference this ctx holds (the
         // cell's finalizer only releases its own); see the field doc.
-        match unsafe { (*this.coder).step(this.input.slice(), this.finish) } {
+        match unsafe { (*this.coder).step(this.input.slice(), this.finish, &mut this.out) } {
             Ok(more) => this.more = more,
             Err(e) => this.error = Some(e),
         }
@@ -967,12 +970,7 @@ impl bun_jsc::JobContext for CompressionAsyncCtx {
     ) -> bun_jsc::JsResult<()> {
         let global = cx.global();
         let (out, out_len, err) = match &this.error {
-            None => {
-                // SAFETY: `this` holds a coder reference until the end of this fn,
-                // and `deliverAsync` copies `out` before it can re-dispatch the coder.
-                let coder = unsafe { &*this.coder };
-                (coder.out.as_ptr(), coder.out.len(), JSValue::ZERO)
-            }
+            None => (this.out.as_ptr(), this.out.len(), JSValue::ZERO),
             Some(e) => (core::ptr::null(), 0, codec_error_to_js(global, e)),
         };
         // SAFETY: FFI into `JSCompressionStreamShared.cpp`; see above.
@@ -1021,6 +1019,7 @@ pub extern "C" fn CompressionStreamCoder__transformAsync(
             coder: this,
             input,
             finish,
+            out: Vec::new(),
             more: false,
             error: None,
         },

--- a/src/runtime/webcore/CompressionStreamCoder.rs
+++ b/src/runtime/webcore/CompressionStreamCoder.rs
@@ -5,9 +5,19 @@
 //! `TransformStream` whose transform step feeds bytes into a codec and
 //! enqueues whatever comes out. The C++ `JSCompressionStream` /
 //! `JSDecompressionStream` cells own one `CompressionStreamCoder` via a
-//! `void*` and drive it per chunk through the three `extern "C"` fns at the
-//! bottom of this file; the TransformStream machinery already handles
-//! backpressure, so this layer is a pure `bytes in → bytes out` pump.
+//! `void*` and drive it through the `extern "C"` fns at the bottom of this
+//! file.
+//!
+//! TransformStream backpressure only applies between input chunks, and one
+//! chunk can expand without bound (a few hundred bytes of brotli or zstd
+//! decode to gigabytes), so a chunk is transformed in *steps*: each step
+//! collects at most [`STEP_OUTPUT`] (or [`STEP_OUTPUT_OFF_THREAD`]) bytes, or
+//! the chunk's own size if that is larger, and reports whether the codec
+//! stopped short. The C++ arm
+//! (`JSCompressionStreamShared.cpp`) delivers each step's output and steps
+//! again only once the readable side or native sink has room, so a chunk's
+//! expansion is never materialized at once; between steps the coder holds the
+//! chunk's unconsumed input itself ([`Pending`]).
 
 use core::ffi::c_int;
 use core::ptr::{self, NonNull};
@@ -53,7 +63,48 @@ impl Format {
     }
 }
 
+/// Granularity in which a step's output buffer grows.
 const CHUNK: usize = 16 * 1024;
+
+/// Output bound of one step on the JS thread, and so the largest piece a
+/// consumer of the readable side sees per `read()` for ordinary chunk sizes.
+/// A chunk larger than this may produce up to its own size per step (see
+/// [`CompressionStreamCoder::step`]): the bound is on *expansion*, and a big
+/// chunk's caller has already materialized that much.
+pub const STEP_OUTPUT: usize = 64 * 1024;
+/// The same bound for steps run on the thread pool (chunks over the C++
+/// `kAsyncCodecThreshold`): every step there costs a pool round trip, so each
+/// one is allowed to do more work.
+pub const STEP_OUTPUT_OFF_THREAD: usize = 1024 * 1024;
+
+/// Spare room for one codec call: grows `out` by up to [`CHUNK`] but never
+/// lets the step pass `cap`. The caller has checked `out.len() < cap`.
+fn spare(out: &mut Vec<u8>, cap: usize) -> &mut [core::mem::MaybeUninit<u8>] {
+    let budget = cap - out.len();
+    out.reserve(budget.min(CHUNK));
+    let spare = out.spare_capacity_mut();
+    let len = spare.len().min(budget);
+    &mut spare[..len]
+}
+
+/// The rest of a chunk (or flush) whose last step stopped at the output cap.
+/// The unconsumed input is copied rather than borrowed: user code runs between
+/// steps (the consumer's reads) and may detach or resize the chunk's buffer.
+struct Pending {
+    input: Vec<u8>,
+    pos: usize,
+    finish: bool,
+    /// The chunk's per-step output bound, fixed by its first step.
+    cap: usize,
+}
+
+enum Progress {
+    /// The chunk (or flush) has been fully transformed.
+    Done,
+    /// Stopped at the output cap with the codec mid-chunk; the first
+    /// `consumed` bytes of this step's input are no longer needed.
+    More { consumed: usize },
+}
 
 enum Backend {
     Deflate(Box<zlib::z_stream>),
@@ -89,8 +140,10 @@ pub struct CompressionStreamCoder {
     /// ends with <4 bytes after frame-complete we cannot tell which yet.
     zstd_head: [u8; 4],
     zstd_head_len: u8,
-    /// Output buffer for `transform`. Reused across chunks; `transform` clears
-    /// it on entry.
+    /// Set while a chunk's transform spans steps; `None` between chunks.
+    pending: Option<Pending>,
+    /// Output of the latest `step`. Reused across steps; `step` clears it on
+    /// entry.
     out: Vec<u8>,
 }
 
@@ -211,6 +264,7 @@ impl CompressionStreamCoder {
             ended: false,
             zstd_head: [0; 4],
             zstd_head_len: 0,
+            pending: None,
             out: Vec::new(),
         }))
     }
@@ -229,19 +283,80 @@ impl CompressionStreamCoder {
                     .all(|(a, b)| *a == b))
     }
 
-    /// Feed one chunk (or the final empty flush) and collect every byte the
-    /// codec produces into `self.out` (cleared on entry). `finish` drives the
-    /// codec to completion and performs the "unexpected end of file" /
-    /// "trailing junk" checks.
-    fn transform(&mut self, input: &[u8], finish: bool) -> Result<(), CodecError> {
+    /// Runs one step of the chunk (or final empty flush, `finish`) being
+    /// transformed, collecting at most `max(min_cap, chunk length)` bytes into
+    /// `self.out` (cleared on entry). Returns `true` when the codec stopped at
+    /// that cap: the caller delivers `out` and, once there is room for more,
+    /// steps again with no input; only then may the next chunk be fed.
+    /// `input` / `finish` / `min_cap` are read on a chunk's first step only.
+    /// `finish` drives the codec to completion and performs the "unexpected
+    /// end of file" / "trailing junk" checks.
+    fn step(&mut self, input: &[u8], finish: bool, min_cap: usize) -> Result<bool, CodecError> {
+        self.out.clear();
+        if let Some(mut pending) = self.pending.take() {
+            debug_assert!(input.is_empty());
+            return match self.run(
+                &pending.input[pending.pos..],
+                pending.finish,
+                true,
+                pending.cap,
+            )? {
+                Progress::Done => Ok(false),
+                Progress::More { consumed } => {
+                    pending.pos += consumed;
+                    self.pending = Some(pending);
+                    Ok(true)
+                }
+            };
+        }
+        // Zstd decode: the frame-magic bytes the previous chunk ended inside of
+        // (`zstd_head`) belong in front of this one.
+        let joined;
+        let bytes: &[u8] = if self.zstd_head_len > 0 {
+            joined = [&self.zstd_head[..self.zstd_head_len as usize], input].concat();
+            self.zstd_head_len = 0;
+            &joined
+        } else {
+            input
+        };
+        let cap = min_cap.max(input.len());
+        match self.run(bytes, finish, false, cap)? {
+            Progress::Done => Ok(false),
+            Progress::More { consumed } => {
+                self.pending = Some(Pending {
+                    input: bytes[consumed..].to_vec(),
+                    pos: 0,
+                    finish,
+                    cap,
+                });
+                Ok(true)
+            }
+        }
+    }
+
+    /// Drives the codec over `input` until the chunk is done or `self.out`
+    /// holds `cap` bytes. `continuing` is set for every step of a chunk after
+    /// its first: the codec is then mid-chunk and must be called even with no
+    /// input left, to drain the output it is holding.
+    fn run(
+        &mut self,
+        input: &[u8],
+        finish: bool,
+        continuing: bool,
+        cap: usize,
+    ) -> Result<Progress, CodecError> {
         let out = &mut self.out;
-        out.clear();
         match &mut self.backend {
             Backend::Deflate(s) => {
                 // `avail_in` is `uInt`; clamp and refill so a ≥4 GiB chunk
                 // isn't silently truncated by the `as u32` cast.
                 let mut remaining = input;
                 loop {
+                    if out.len() >= cap {
+                        return Ok(Progress::More {
+                            consumed: input.len() - remaining.len(),
+                        });
+                    }
                     let take = remaining.len().min(u32::MAX as usize);
                     let tail = remaining.len() > take;
                     let flush = if finish && !tail {
@@ -251,8 +366,7 @@ impl CompressionStreamCoder {
                     };
                     s.next_in = remaining.as_ptr();
                     s.avail_in = take as u32;
-                    out.reserve(CHUNK);
-                    let spare = out.spare_capacity_mut();
+                    let spare = spare(out, cap);
                     s.next_out = spare.as_mut_ptr().cast();
                     s.avail_out = spare.len().min(u32::MAX as usize) as u32;
                     let before = s.avail_out;
@@ -267,34 +381,41 @@ impl CompressionStreamCoder {
                     remaining = &remaining[consumed..];
                     match rc {
                         zlib::ReturnCode::Ok | zlib::ReturnCode::BufError => {}
-                        zlib::ReturnCode::StreamEnd => break,
+                        zlib::ReturnCode::StreamEnd => return Ok(Progress::Done),
                         _ => return Err(CodecError::Message("deflate failed")),
                     }
                     if s.avail_out != 0 && remaining.is_empty() {
-                        break;
+                        return Ok(Progress::Done);
                     }
                 }
             }
             Backend::Inflate { state: s, gzip } => {
                 let gzip = *gzip;
-                // `self.ended` = "the last inflate returned StreamEnd" = "at a
-                // member boundary". For gzip, a following chunk starts the next
-                // member; for deflate/deflate-raw it is trailing junk.
-                if self.ended && !input.is_empty() {
-                    if !gzip {
-                        return Err(CodecError::TrailingJunk);
+                if !continuing {
+                    // `self.ended` = "the last inflate returned StreamEnd" = "at
+                    // a member boundary". For gzip, a following chunk starts the
+                    // next member; for deflate/deflate-raw it is trailing junk.
+                    if self.ended && !input.is_empty() {
+                        if !gzip {
+                            return Err(CodecError::TrailingJunk);
+                        }
+                        // SAFETY: `s` is an initialized inflate stream.
+                        if unsafe { zlib::inflateReset(&raw mut **s) } != zlib::ReturnCode::Ok {
+                            return Err(CodecError::Message("inflate failed"));
+                        }
+                        self.ended = false;
                     }
-                    // SAFETY: `s` is an initialized inflate stream.
-                    if unsafe { zlib::inflateReset(&raw mut **s) } != zlib::ReturnCode::Ok {
-                        return Err(CodecError::Message("inflate failed"));
+                    if input.is_empty() && (self.ended || !finish) {
+                        return Ok(Progress::Done);
                     }
-                    self.ended = false;
-                }
-                if input.is_empty() && (self.ended || !finish) {
-                    return Ok(());
                 }
                 let mut remaining = input;
                 loop {
+                    if out.len() >= cap {
+                        return Ok(Progress::More {
+                            consumed: input.len() - remaining.len(),
+                        });
+                    }
                     let take = remaining.len().min(u32::MAX as usize);
                     let tail = remaining.len() > take;
                     let flush = if finish && !tail {
@@ -304,8 +425,7 @@ impl CompressionStreamCoder {
                     };
                     s.next_in = remaining.as_ptr();
                     s.avail_in = take as u32;
-                    out.reserve(CHUNK);
-                    let spare = out.spare_capacity_mut();
+                    let spare = spare(out, cap);
                     s.next_out = spare.as_mut_ptr().cast();
                     s.avail_out = spare.len().min(u32::MAX as usize) as u32;
                     let before = s.avail_out;
@@ -326,20 +446,18 @@ impl CompressionStreamCoder {
                         }
                         zlib::ReturnCode::StreamEnd => {
                             self.ended = true;
-                            if !remaining.is_empty() {
-                                if gzip {
-                                    // SAFETY: `s` is an initialized inflate stream.
-                                    if unsafe { zlib::inflateReset(&raw mut **s) }
-                                        != zlib::ReturnCode::Ok
-                                    {
-                                        return Err(CodecError::Message("inflate failed"));
-                                    }
-                                    self.ended = false;
-                                    continue;
-                                }
+                            if remaining.is_empty() {
+                                return Ok(Progress::Done);
+                            }
+                            if !gzip {
                                 return Err(CodecError::TrailingJunk);
                             }
-                            break;
+                            // SAFETY: `s` is an initialized inflate stream.
+                            if unsafe { zlib::inflateReset(&raw mut **s) } != zlib::ReturnCode::Ok {
+                                return Err(CodecError::Message("inflate failed"));
+                            }
+                            self.ended = false;
+                            continue;
                         }
                         zlib::ReturnCode::NeedDict => {
                             return Err(CodecError::Message("Missing dictionary"));
@@ -350,7 +468,7 @@ impl CompressionStreamCoder {
                         if finish && !self.ended {
                             return Err(CodecError::Message("unexpected end of file"));
                         }
-                        break;
+                        return Ok(Progress::Done);
                     }
                 }
             }
@@ -363,8 +481,12 @@ impl CompressionStreamCoder {
                 let mut next_in: *const u8 = input.as_ptr();
                 let mut avail_in: usize = input.len();
                 loop {
-                    out.reserve(CHUNK);
-                    let spare = out.spare_capacity_mut();
+                    if out.len() >= cap {
+                        return Ok(Progress::More {
+                            consumed: input.len() - avail_in,
+                        });
+                    }
+                    let spare = spare(out, cap);
                     let mut next_out: *mut u8 = spare.as_mut_ptr().cast();
                     let mut avail_out: usize = spare.len();
                     let before = avail_out;
@@ -388,7 +510,7 @@ impl CompressionStreamCoder {
                         return Err(CodecError::Message("brotli encode failed"));
                     }
                     if avail_in == 0 && avail_out != 0 {
-                        break;
+                        return Ok(Progress::Done);
                     }
                 }
             }
@@ -397,13 +519,17 @@ impl CompressionStreamCoder {
                     if !input.is_empty() {
                         return Err(CodecError::TrailingJunk);
                     }
-                    return Ok(());
+                    return Ok(Progress::Done);
                 }
                 let mut next_in: *const u8 = input.as_ptr();
                 let mut avail_in: usize = input.len();
                 loop {
-                    out.reserve(CHUNK);
-                    let spare = out.spare_capacity_mut();
+                    if out.len() >= cap {
+                        return Ok(Progress::More {
+                            consumed: input.len() - avail_in,
+                        });
+                    }
+                    let spare = spare(out, cap);
                     let mut next_out: *mut u8 = spare.as_mut_ptr().cast();
                     let mut avail_out: usize = spare.len();
                     let before = avail_out;
@@ -427,15 +553,15 @@ impl CompressionStreamCoder {
                             if avail_in != 0 {
                                 return Err(CodecError::TrailingJunk);
                             }
-                            break;
+                            return Ok(Progress::Done);
                         }
                         brotli::BrotliDecoderResult::needs_more_input => {
                             if finish {
                                 return Err(CodecError::Message("unexpected end of file"));
                             }
-                            break;
+                            return Ok(Progress::Done);
                         }
-                        brotli::BrotliDecoderResult::needs_more_output => continue,
+                        brotli::BrotliDecoderResult::needs_more_output => {}
                         brotli::BrotliDecoderResult::err => {
                             // SAFETY: `p` is a live decoder; the error string is a
                             // static C string owned by the brotli library.
@@ -459,8 +585,12 @@ impl CompressionStreamCoder {
                     pos: 0,
                 };
                 loop {
-                    out.reserve(CHUNK);
-                    let spare = out.spare_capacity_mut();
+                    if out.len() >= cap {
+                        return Ok(Progress::More {
+                            consumed: input_buf.pos,
+                        });
+                    }
+                    let spare = spare(out, cap);
                     let mut output_buf = zstd::ZSTD_outBuffer {
                         dst: spare.as_mut_ptr().cast(),
                         size: spare.len(),
@@ -483,33 +613,26 @@ impl CompressionStreamCoder {
                         return Err(CodecError::Message("zstd encode failed"));
                     }
                     if input_buf.pos == input_buf.size && (!finish || remaining == 0) {
-                        break;
+                        return Ok(Progress::Done);
                     }
                 }
             }
             Backend::ZstdDecode(p) => {
                 // A zstd stream is one or more concatenated frames (RFC 8878
                 // §3.1, including skippable frames). After a frame completes,
-                // the next bytes must be another frame magic; a chunk boundary
-                // may fall inside that 4-byte magic, which `zstd_head` carries.
-                let joined;
-                let bytes: &[u8] = if self.zstd_head_len > 0 {
-                    joined = [&self.zstd_head[..self.zstd_head_len as usize], input].concat();
-                    self.zstd_head_len = 0;
-                    &joined
-                } else {
-                    input
-                };
+                // the next bytes must be another frame magic; a chunk may end
+                // inside that 4-byte magic, which `zstd_head` carries over to
+                // the next chunk (`step` joins it back on).
                 let mut input_buf = zstd::ZSTD_inBuffer {
-                    src: bytes.as_ptr().cast(),
-                    size: bytes.len(),
+                    src: input.as_ptr().cast(),
+                    size: input.len(),
                     pos: 0,
                 };
                 loop {
                     if self.ended {
-                        let rest = &bytes[input_buf.pos..];
+                        let rest = &input[input_buf.pos..];
                         if rest.is_empty() {
-                            break;
+                            return Ok(Progress::Done);
                         }
                         let head = &rest[..rest.len().min(4)];
                         if !Self::is_zstd_frame_prefix(head) {
@@ -521,7 +644,7 @@ impl CompressionStreamCoder {
                             }
                             self.zstd_head[..head.len()].copy_from_slice(head);
                             self.zstd_head_len = head.len() as u8;
-                            break;
+                            return Ok(Progress::Done);
                         }
                         // SAFETY: `p` is a live DCtx.
                         unsafe {
@@ -532,8 +655,12 @@ impl CompressionStreamCoder {
                         };
                         self.ended = false;
                     }
-                    out.reserve(CHUNK);
-                    let spare = out.spare_capacity_mut();
+                    if out.len() >= cap {
+                        return Ok(Progress::More {
+                            consumed: input_buf.pos,
+                        });
+                    }
+                    let spare = spare(out, cap);
                     let mut output_buf = zstd::ZSTD_outBuffer {
                         dst: spare.as_mut_ptr().cast(),
                         size: spare.len(),
@@ -562,12 +689,11 @@ impl CompressionStreamCoder {
                         if finish {
                             return Err(CodecError::Message("unexpected end of file"));
                         }
-                        break;
+                        return Ok(Progress::Done);
                     }
                 }
             }
         }
-        Ok(())
     }
 }
 
@@ -662,9 +788,12 @@ pub extern "C" fn CompressionStreamCoder__destroy(this: *mut CompressionStreamCo
     }
 }
 
-/// Runs one transform step. Returns a fresh `Uint8Array` on success, or
-/// `JSValue::zero` with a `TypeError` thrown on `global` on failure.
-/// `input` may be null iff `input_len == 0`.
+/// Runs one step (see [`CompressionStreamCoder::step`]) on the JS thread.
+/// Returns a fresh `Uint8Array` (possibly empty) on success, setting `more`
+/// when the coder stopped at the cap and must be stepped again with no input;
+/// or `JSValue::zero` with a `TypeError` thrown on `global` on failure.
+/// `input` may be null iff `input_len == 0`, and is ignored on a continuation
+/// step.
 #[unsafe(no_mangle)]
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub extern "C" fn CompressionStreamCoder__transform(
@@ -673,19 +802,21 @@ pub extern "C" fn CompressionStreamCoder__transform(
     input: *const u8,
     input_len: usize,
     finish: bool,
+    more: &mut bool,
 ) -> JSValue {
     let slice = if input.is_null() {
         &[][..]
     } else {
         // SAFETY: the caller passes a BufferSource's bytes; `slice` does not
-        // escape this call.
+        // escape this call (`step` copies whatever it leaves unconsumed).
         unsafe { core::slice::from_raw_parts(input, input_len) }
     };
     // SAFETY: `this` is the live coder owned by the calling JS cell; it is
     // only driven from the JS thread, so the call-scoped `&mut *this` has no
-    // alias. No JS runs between `transform` and `take` below.
-    match unsafe { (*this).transform(slice, finish) } {
-        Ok(()) => {
+    // alias. No JS runs between `step` and `take` below.
+    match unsafe { (*this).step(slice, finish, STEP_OUTPUT) } {
+        Ok(has_more) => {
+            *more = has_more;
             // SAFETY: as above.
             let out = unsafe { core::mem::take(&mut (*this).out) };
             if out.is_empty() {
@@ -695,6 +826,7 @@ pub extern "C" fn CompressionStreamCoder__transform(
             }
         }
         Err(e) => {
+            *more = false;
             throw_codec_error(global, e);
             JSValue::ZERO
         }
@@ -727,10 +859,10 @@ fn throw_codec_error(global: &JSGlobalObject, e: CodecError) {
     let _ = global.throw_value(codec_error_to_js(global, &e));
 }
 
-/// Runs one transform step and writes the output straight to a native JSSink
-/// (`m_sinkPtr`), so the chunk never becomes a `JSUint8Array`. Returns the
-/// sink's `write_bytes` result (see nativeSinkWriteIsBackpressure for the
-/// backpressure-signal shapes), `undefined` for an empty output, or
+/// [`CompressionStreamCoder__transform`], but the step's output goes straight
+/// to a native JSSink (`m_sinkPtr`) instead of becoming a `JSUint8Array`.
+/// Returns the sink's `write_bytes` result (see nativeSinkWriteIsBackpressure
+/// for the backpressure-signal shapes), `undefined` for an empty output, or
 /// `JSValue::zero` with an exception pending on `global` on codec failure.
 #[unsafe(no_mangle)]
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
@@ -742,6 +874,7 @@ pub extern "C" fn CompressionStreamCoder__transformInto(
     finish: bool,
     sink_id: u8,
     sink_ptr: *mut core::ffi::c_void,
+    more: &mut bool,
 ) -> JSValue {
     let slice = if input.is_null() {
         &[][..]
@@ -750,8 +883,9 @@ pub extern "C" fn CompressionStreamCoder__transformInto(
         unsafe { core::slice::from_raw_parts(input, input_len) }
     };
     // SAFETY: as in `CompressionStreamCoder__transform`.
-    match unsafe { (*this).transform(slice, finish) } {
-        Ok(()) => {
+    match unsafe { (*this).step(slice, finish, STEP_OUTPUT) } {
+        Ok(has_more) => {
+            *more = has_more;
             // SAFETY: as above; the sink copies before returning.
             let out = unsafe { &(*this).out };
             if out.is_empty() {
@@ -773,6 +907,7 @@ pub extern "C" fn CompressionStreamCoder__transformInto(
                 .to_js(global)
         }
         Err(e) => {
+            *more = false;
             throw_codec_error(global, e);
             JSValue::ZERO
         }
@@ -784,26 +919,31 @@ pub extern "C" fn CompressionStreamCoder__transformInto(
 unsafe extern "C" {
     /// JS-thread completion hook in `JSCompressionStreamShared.cpp`. Copies
     /// `out[..out_len]` into the sink / a fresh Uint8Array before it clears
-    /// `m_asyncCodecInFlight` (so a deferred coder release cannot free the
-    /// bytes under it), then settles the stream's `m_asyncCodecPromise`.
+    /// `m_asyncCodecInFlight`, then either settles the stream's
+    /// `m_codecPromise` or, when `more` is set, arranges the chunk's next step
+    /// (another `CompressionStreamCoder__transformAsync` with no input, once
+    /// the consumer has room).
     fn Bun__CompressionStream__deliverAsync(
         global: &JSGlobalObject,
         stream_cell: JSValue,
         out: *const u8,
         out_len: usize,
+        more: bool,
         error: JSValue,
     );
 }
 
-/// One large `CompressionStream`/`DecompressionStream` chunk transformed off
-/// the JS thread.
+/// One step of a large `CompressionStream`/`DecompressionStream` chunk, run
+/// off the JS thread.
 pub struct CompressionAsyncCtx {
     /// Holds one coder reference (taken in `CompressionStreamCoder__transformAsync`,
     /// released by `Drop`); see [`CompressionStreamCoder::ref_count`]. TransformStream
     /// serializes writes, so nothing else touches it while the pool has it.
     coder: *mut CompressionStreamCoder,
+    /// Empty on a continuation step: the coder holds the chunk's tail.
     input: AsyncInput,
     finish: bool,
+    more: bool,
     error: Option<CodecError>,
 }
 
@@ -824,7 +964,7 @@ unsafe impl Send for CompressionAsyncCtx {}
 pub struct CompressionAsyncJs {
     /// GC root for the `JSTransformStream` cell; its `m_asyncCodecInFlight`
     /// flag defers the eager ClearAlgorithms release while this task holds it,
-    /// and its `m_asyncCodecPromise` WriteBarrier keeps the pending
+    /// and its `m_codecPromise` WriteBarrier keeps the pending
     /// transform-algorithm promise alive.
     stream: Strong,
     _pin: Option<PinnedChunk>,
@@ -837,7 +977,11 @@ impl bun_jsc::JobContext for CompressionAsyncCtx {
     fn run(this: &mut Self, done: bun_jsc::Completion<Self>) -> Option<bun_jsc::Completion<Self>> {
         // SAFETY: `coder` is kept alive by the reference this ctx holds (the
         // cell's finalizer only releases its own); see the field doc.
-        this.error = unsafe { (*this.coder).transform(this.input.slice(), this.finish) }.err();
+        match unsafe { (*this.coder).step(this.input.slice(), this.finish, STEP_OUTPUT_OFF_THREAD) }
+        {
+            Ok(more) => this.more = more,
+            Err(e) => this.error = Some(e),
+        }
         Some(done)
     }
 
@@ -851,19 +995,32 @@ impl bun_jsc::JobContext for CompressionAsyncCtx {
             None => {
                 // SAFETY: `this` holds a coder reference until it drops at the
                 // end of this fn, so `coder` (and its `out` buffer) stay live
-                // while `Bun__CompressionStream__deliverAsync` copies.
+                // while `Bun__CompressionStream__deliverAsync` copies; it copies
+                // before it can schedule the next step, which is what would
+                // touch `out` again.
                 let coder = unsafe { &*this.coder };
                 (coder.out.as_ptr(), coder.out.len(), JSValue::ZERO)
             }
             Some(e) => (core::ptr::null(), 0, codec_error_to_js(global, e)),
         };
-        // SAFETY: FFI into `JSCompressionStreamShared.cpp`; the callee copies
-        // `out[..out_len]` before releasing the coder.
-        unsafe { Bun__CompressionStream__deliverAsync(global, js.stream.get(), out, out_len, err) };
+        // SAFETY: FFI into `JSCompressionStreamShared.cpp`; see above.
+        unsafe {
+            Bun__CompressionStream__deliverAsync(
+                global,
+                js.stream.get(),
+                out,
+                out_len,
+                this.more,
+                err,
+            )
+        };
         Ok(())
     }
 }
 
+/// Schedules one off-thread step. The first step of a chunk gets the chunk's
+/// bytes; a continuation step (the previous one stopped at the cap) is called
+/// with no chunk and no input, and the coder works from the tail it kept.
 #[unsafe(no_mangle)]
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub extern "C" fn CompressionStreamCoder__transformAsync(
@@ -893,6 +1050,7 @@ pub extern "C" fn CompressionStreamCoder__transformAsync(
             coder: this,
             input,
             finish,
+            more: false,
             error: None,
         },
         CompressionAsyncJs {

--- a/src/runtime/webcore/CompressionStreamCoder.rs
+++ b/src/runtime/webcore/CompressionStreamCoder.rs
@@ -8,16 +8,13 @@
 //! `void*` and drive it through the `extern "C"` fns at the bottom of this
 //! file.
 //!
-//! TransformStream backpressure only applies between input chunks, and one
-//! chunk can expand without bound (a few hundred bytes of brotli or zstd
-//! decode to gigabytes), so a chunk is transformed in *steps*: each step
-//! collects at most [`STEP_OUTPUT`] (or [`STEP_OUTPUT_OFF_THREAD`]) bytes, or
-//! the chunk's own size if that is larger, and reports whether the codec
-//! stopped short. The C++ arm
+//! TransformStream backpressure only applies between chunks, and one chunk can
+//! expand without bound (a few hundred bytes of brotli decode to gigabytes), so
+//! a chunk is transformed in steps of bounded output
+//! ([`CompressionStreamCoder::step`]). The C++ arm
 //! (`JSCompressionStreamShared.cpp`) delivers each step's output and steps
-//! again only once the readable side or native sink has room, so a chunk's
-//! expansion is never materialized at once; between steps the coder holds the
-//! chunk's unconsumed input itself ([`Pending`]).
+//! again once the consumer has room; in between, the coder keeps the chunk's
+//! unconsumed input ([`Pending`]).
 
 use core::ffi::c_int;
 use core::ptr::{self, NonNull};
@@ -63,23 +60,18 @@ impl Format {
     }
 }
 
-/// Granularity in which a step's output buffer grows.
+/// Growth granularity of a step's output buffer.
 const CHUNK: usize = 16 * 1024;
 
-/// Output bound of one step on the JS thread, and so the largest piece a
-/// consumer of the readable side sees per `read()` for ordinary chunk sizes.
-/// A chunk larger than this may produce up to its own size per step (see
-/// [`CompressionStreamCoder::step`]): the bound is on *expansion*, and a big
-/// chunk's caller has already materialized that much.
+/// Output bound of a step on the JS thread (a chunk larger than this may
+/// produce up to its own size per step: the bound is on expansion).
 pub const STEP_OUTPUT: usize = 64 * 1024;
-/// The same bound for steps run on the thread pool (chunks over the C++
-/// `kAsyncCodecThreshold`): every step there costs a pool round trip, so each
-/// one is allowed to do more work.
+/// Output bound of a step on the thread pool, where every step is a round trip.
 pub const STEP_OUTPUT_OFF_THREAD: usize = 1024 * 1024;
 
-/// Spare room for one codec call: grows `out` by up to [`CHUNK`] but never
-/// lets the step pass `cap`. The caller has checked `out.len() < cap`.
+/// Room for one codec call: grows `out` by up to [`CHUNK`], clamped to `cap`.
 fn spare(out: &mut Vec<u8>, cap: usize) -> &mut [core::mem::MaybeUninit<u8>] {
+    debug_assert!(out.len() < cap);
     let budget = cap - out.len();
     out.reserve(budget.min(CHUNK));
     let spare = out.spare_capacity_mut();
@@ -88,22 +80,21 @@ fn spare(out: &mut Vec<u8>, cap: usize) -> &mut [core::mem::MaybeUninit<u8>] {
 }
 
 /// The rest of a chunk (or flush) whose last step stopped at the output cap.
-/// The unconsumed input is copied rather than borrowed: user code runs between
-/// steps (the consumer's reads) and may detach or resize the chunk's buffer.
+/// Copied, not borrowed: user code runs between steps and may detach the chunk.
 struct Pending {
     input: Vec<u8>,
     pos: usize,
     finish: bool,
-    /// The chunk's per-step output bound, fixed by its first step.
+    /// Per-step output bound, fixed by the chunk's first step.
     cap: usize,
 }
 
 enum Progress {
-    /// The chunk (or flush) has been fully transformed.
     Done,
-    /// Stopped at the output cap with the codec mid-chunk; the first
-    /// `consumed` bytes of this step's input are no longer needed.
-    More { consumed: usize },
+    /// Stopped at the output cap; `consumed` bytes of this step's input are used up.
+    More {
+        consumed: usize,
+    },
 }
 
 enum Backend {
@@ -142,8 +133,7 @@ pub struct CompressionStreamCoder {
     zstd_head_len: u8,
     /// Set while a chunk's transform spans steps; `None` between chunks.
     pending: Option<Pending>,
-    /// Output of the latest `step`. Reused across steps; `step` clears it on
-    /// entry.
+    /// Output of the latest `step`, which clears it on entry.
     out: Vec<u8>,
 }
 
@@ -283,14 +273,10 @@ impl CompressionStreamCoder {
                     .all(|(a, b)| *a == b))
     }
 
-    /// Runs one step of the chunk (or final empty flush, `finish`) being
-    /// transformed, collecting at most `max(min_cap, chunk length)` bytes into
-    /// `self.out` (cleared on entry). Returns `true` when the codec stopped at
-    /// that cap: the caller delivers `out` and, once there is room for more,
-    /// steps again with no input; only then may the next chunk be fed.
-    /// `input` / `finish` / `min_cap` are read on a chunk's first step only.
-    /// `finish` drives the codec to completion and performs the "unexpected
-    /// end of file" / "trailing junk" checks.
+    /// One step of the chunk (or, with `finish`, the final flush) in progress:
+    /// collects at most `max(min_cap, chunk length)` bytes into `self.out` and
+    /// returns `true` if the codec stopped at that cap, in which case the caller
+    /// must step again (with no input) before feeding the next chunk.
     fn step(&mut self, input: &[u8], finish: bool, min_cap: usize) -> Result<bool, CodecError> {
         self.out.clear();
         if let Some(mut pending) = self.pending.take() {
@@ -309,8 +295,7 @@ impl CompressionStreamCoder {
                 }
             };
         }
-        // Zstd decode: the frame-magic bytes the previous chunk ended inside of
-        // (`zstd_head`) belong in front of this one.
+        // Zstd decode: re-attach the frame magic the previous chunk ended inside of.
         let joined;
         let bytes: &[u8] = if self.zstd_head_len > 0 {
             joined = [&self.zstd_head[..self.zstd_head_len as usize], input].concat();
@@ -334,9 +319,8 @@ impl CompressionStreamCoder {
         }
     }
 
-    /// Drives the codec over `input` until the chunk is done or `self.out`
-    /// holds `cap` bytes. `continuing` is set for every step of a chunk after
-    /// its first: the codec is then mid-chunk and must be called even with no
+    /// Drives the codec until the chunk is done or `self.out` holds `cap` bytes.
+    /// A `continuing` step (not the chunk's first) calls the codec even with no
     /// input left, to drain the output it is holding.
     fn run(
         &mut self,
@@ -618,11 +602,8 @@ impl CompressionStreamCoder {
                 }
             }
             Backend::ZstdDecode(p) => {
-                // A zstd stream is one or more concatenated frames (RFC 8878
-                // §3.1, including skippable frames). After a frame completes,
-                // the next bytes must be another frame magic; a chunk may end
-                // inside that 4-byte magic, which `zstd_head` carries over to
-                // the next chunk (`step` joins it back on).
+                // After a frame completes, whatever follows must be another frame
+                // magic (see `zstd_head`); `step` has already re-attached a split one.
                 let mut input_buf = zstd::ZSTD_inBuffer {
                     src: input.as_ptr().cast(),
                     size: input.len(),
@@ -788,12 +769,9 @@ pub extern "C" fn CompressionStreamCoder__destroy(this: *mut CompressionStreamCo
     }
 }
 
-/// Runs one step (see [`CompressionStreamCoder::step`]) on the JS thread.
-/// Returns a fresh `Uint8Array` (possibly empty) on success, setting `more`
-/// when the coder stopped at the cap and must be stepped again with no input;
-/// or `JSValue::zero` with a `TypeError` thrown on `global` on failure.
-/// `input` may be null iff `input_len == 0`, and is ignored on a continuation
-/// step.
+/// One JS-thread [`step`](CompressionStreamCoder::step): returns its output as
+/// a fresh (possibly empty) `Uint8Array` and sets `more` if the coder must be
+/// stepped again (with `input` null), or throws a `TypeError` and returns zero.
 #[unsafe(no_mangle)]
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub extern "C" fn CompressionStreamCoder__transform(
@@ -859,11 +837,9 @@ fn throw_codec_error(global: &JSGlobalObject, e: CodecError) {
     let _ = global.throw_value(codec_error_to_js(global, &e));
 }
 
-/// [`CompressionStreamCoder__transform`], but the step's output goes straight
-/// to a native JSSink (`m_sinkPtr`) instead of becoming a `JSUint8Array`.
-/// Returns the sink's `write_bytes` result (see nativeSinkWriteIsBackpressure
-/// for the backpressure-signal shapes), `undefined` for an empty output, or
-/// `JSValue::zero` with an exception pending on `global` on codec failure.
+/// [`CompressionStreamCoder__transform`], but the output is written to the
+/// native JSSink `sink_ptr`: returns the sink's `write` result (see
+/// nativeSinkWriteIsBackpressure), `undefined` when there was no output.
 #[unsafe(no_mangle)]
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub extern "C" fn CompressionStreamCoder__transformInto(
@@ -917,12 +893,8 @@ pub extern "C" fn CompressionStreamCoder__transformInto(
 // ─── off-thread path (chunks > kAsyncCodecThreshold) ───────────────────────
 
 unsafe extern "C" {
-    /// JS-thread completion hook in `JSCompressionStreamShared.cpp`. Copies
-    /// `out[..out_len]` into the sink / a fresh Uint8Array before it clears
-    /// `m_asyncCodecInFlight`, then either settles the stream's
-    /// `m_codecPromise` or, when `more` is set, arranges the chunk's next step
-    /// (another `CompressionStreamCoder__transformAsync` with no input, once
-    /// the consumer has room).
+    /// JS-thread completion in `JSCompressionStreamShared.cpp`: consumes
+    /// `out[..out_len]` before anything may release or re-dispatch the coder.
     fn Bun__CompressionStream__deliverAsync(
         global: &JSGlobalObject,
         stream_cell: JSValue,
@@ -993,11 +965,8 @@ impl bun_jsc::JobContext for CompressionAsyncCtx {
         let global = cx.global();
         let (out, out_len, err) = match &this.error {
             None => {
-                // SAFETY: `this` holds a coder reference until it drops at the
-                // end of this fn, so `coder` (and its `out` buffer) stay live
-                // while `Bun__CompressionStream__deliverAsync` copies; it copies
-                // before it can schedule the next step, which is what would
-                // touch `out` again.
+                // SAFETY: `this` holds a coder reference until the end of this fn,
+                // and `deliverAsync` copies `out` before it can re-dispatch the coder.
                 let coder = unsafe { &*this.coder };
                 (coder.out.as_ptr(), coder.out.len(), JSValue::ZERO)
             }
@@ -1018,9 +987,8 @@ impl bun_jsc::JobContext for CompressionAsyncCtx {
     }
 }
 
-/// Schedules one off-thread step. The first step of a chunk gets the chunk's
-/// bytes; a continuation step (the previous one stopped at the cap) is called
-/// with no chunk and no input, and the coder works from the tail it kept.
+/// Schedules one off-thread step; a continuation step passes no chunk and no
+/// input (the coder kept the tail).
 #[unsafe(no_mangle)]
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub extern "C" fn CompressionStreamCoder__transformAsync(

--- a/src/runtime/webcore/CompressionStreamCoder.rs
+++ b/src/runtime/webcore/CompressionStreamCoder.rs
@@ -63,12 +63,6 @@ impl Format {
 /// Growth granularity of a step's output buffer.
 const CHUNK: usize = 16 * 1024;
 
-/// Output bound of a step on the JS thread (a chunk larger than this may
-/// produce up to its own size per step: the bound is on expansion).
-pub const STEP_OUTPUT: usize = 64 * 1024;
-/// Output bound of a step on the thread pool, where every step is a round trip.
-pub const STEP_OUTPUT_OFF_THREAD: usize = 1024 * 1024;
-
 /// Room for one codec call: grows `out` by up to [`CHUNK`], clamped to `cap`.
 fn spare(out: &mut Vec<u8>, cap: usize) -> &mut [core::mem::MaybeUninit<u8>] {
     debug_assert!(out.len() < cap);
@@ -131,6 +125,10 @@ pub struct CompressionStreamCoder {
     /// ends with <4 bytes after frame-complete we cannot tell which yet.
     zstd_head: [u8; 4],
     zstd_head_len: u8,
+    /// The stream's `highWaterMark`: output bound of one step. A chunk larger
+    /// than this may produce up to its own size per step (the bound is on
+    /// expansion), so a big chunk still finishes in a step or two.
+    high_water_mark: usize,
     /// Set while a chunk's transform spans steps; `None` between chunks.
     pending: Option<Pending>,
     /// Output of the latest `step`, which clears it on entry.
@@ -178,7 +176,11 @@ enum CodecError {
 }
 
 impl CompressionStreamCoder {
-    fn new(format: Format, decompress: bool) -> Result<Box<Self>, CodecError> {
+    fn new(
+        format: Format,
+        decompress: bool,
+        high_water_mark: usize,
+    ) -> Result<Box<Self>, CodecError> {
         let backend = match (format, decompress) {
             (Format::Deflate | Format::DeflateRaw | Format::Gzip, false) => {
                 let mut s = Box::new(bun_core::ffi::zeroed::<zlib::z_stream>());
@@ -254,6 +256,7 @@ impl CompressionStreamCoder {
             ended: false,
             zstd_head: [0; 4],
             zstd_head_len: 0,
+            high_water_mark,
             pending: None,
             out: Vec::new(),
         }))
@@ -274,10 +277,10 @@ impl CompressionStreamCoder {
     }
 
     /// One step of the chunk (or, with `finish`, the final flush) in progress:
-    /// collects at most `max(min_cap, chunk length)` bytes into `self.out` and
+    /// collects at most `max(high_water_mark, chunk length)` bytes into `self.out` and
     /// returns `true` if the codec stopped at that cap, in which case the caller
     /// must step again (with no input) before feeding the next chunk.
-    fn step(&mut self, input: &[u8], finish: bool, min_cap: usize) -> Result<bool, CodecError> {
+    fn step(&mut self, input: &[u8], finish: bool) -> Result<bool, CodecError> {
         self.out.clear();
         if let Some(mut pending) = self.pending.take() {
             debug_assert!(input.is_empty());
@@ -304,7 +307,7 @@ impl CompressionStreamCoder {
         } else {
             input
         };
-        let cap = min_cap.max(input.len());
+        let cap = self.high_water_mark.max(input.len());
         match self.run(bytes, finish, false, cap)? {
             Progress::Done => Ok(false),
             Progress::More { consumed } => {
@@ -748,11 +751,12 @@ impl AsyncInput {
 pub extern "C" fn CompressionStreamCoder__create(
     format: u8,
     decompress: bool,
+    high_water_mark: usize,
 ) -> *mut CompressionStreamCoder {
     let Some(format) = Format::from_u8(format) else {
         return ptr::null_mut();
     };
-    match CompressionStreamCoder::new(format, decompress) {
+    match CompressionStreamCoder::new(format, decompress, high_water_mark.max(1)) {
         Ok(b) => Box::into_raw(b),
         Err(_) => ptr::null_mut(),
     }
@@ -792,7 +796,7 @@ pub extern "C" fn CompressionStreamCoder__transform(
     // SAFETY: `this` is the live coder owned by the calling JS cell; it is
     // only driven from the JS thread, so the call-scoped `&mut *this` has no
     // alias. No JS runs between `step` and `take` below.
-    match unsafe { (*this).step(slice, finish, STEP_OUTPUT) } {
+    match unsafe { (*this).step(slice, finish) } {
         Ok(has_more) => {
             *more = has_more;
             // SAFETY: as above.
@@ -859,7 +863,7 @@ pub extern "C" fn CompressionStreamCoder__transformInto(
         unsafe { core::slice::from_raw_parts(input, input_len) }
     };
     // SAFETY: as in `CompressionStreamCoder__transform`.
-    match unsafe { (*this).step(slice, finish, STEP_OUTPUT) } {
+    match unsafe { (*this).step(slice, finish) } {
         Ok(has_more) => {
             *more = has_more;
             // SAFETY: as above; the sink copies before returning.
@@ -949,8 +953,7 @@ impl bun_jsc::JobContext for CompressionAsyncCtx {
     fn run(this: &mut Self, done: bun_jsc::Completion<Self>) -> Option<bun_jsc::Completion<Self>> {
         // SAFETY: `coder` is kept alive by the reference this ctx holds (the
         // cell's finalizer only releases its own); see the field doc.
-        match unsafe { (*this.coder).step(this.input.slice(), this.finish, STEP_OUTPUT_OFF_THREAD) }
-        {
+        match unsafe { (*this.coder).step(this.input.slice(), this.finish) } {
             Ok(more) => this.more = more,
             Err(e) => this.error = Some(e),
         }

--- a/test/js/web/streams/compression.test.ts
+++ b/test/js/web/streams/compression.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN } from "harness";
+import { addAbortSignal } from "node:stream";
 import zlib from "node:zlib";
 
 // CompressionStream et al are C++ subclasses of JSTransformStream so that
@@ -831,6 +832,24 @@ describe("bounded output per input chunk", () => {
     await expect(writer.closed).rejects.toThrow("stop");
     // The abort algorithm errored the readable (dropping the piece it still held).
     await expect(reader.read()).rejects.toThrow("stop");
+  });
+
+  // node:stream's addAbortSignal() errors the writable through its controller, the
+  // other route into the erroring state (it clears the sink's algorithms on the way).
+  test("addAbortSignal() on the writable mid-expansion settles the write", async () => {
+    const ds = new DecompressionStream("brotli");
+    const writer = ds.writable.getWriter();
+    const reader = ds.readable.getReader();
+    const write = writer.write(bombs.brotli());
+
+    const first = await reader.read();
+    expect(first.value!.byteLength).toBeLessThanOrEqual(kDefaultHighWaterMark);
+
+    const controller = new AbortController();
+    addAbortSignal(controller.signal, ds.writable);
+    controller.abort();
+    expect(await write).toBeUndefined();
+    await expect(writer.closed).rejects.toMatchObject({ name: "AbortError" });
   });
 
   // An abort during close() is different: the close in progress wins, so a flush

--- a/test/js/web/streams/compression.test.ts
+++ b/test/js/web/streams/compression.test.ts
@@ -716,16 +716,15 @@ describe("CompressionStream chunk handling (Node v26 semantics)", () => {
 });
 
 // One input chunk can expand enormously (a few hundred bytes of brotli or zstd
-// decode to gigabytes), so the coder emits its output in bounded steps: at most
-// kStepOutput bytes per step on the JS thread (kStepOutputOffThread for the
-// >128 KiB chunks that run on the thread pool), or the chunk's own size if that
-// is larger, parking between steps while the readable side (or the native sink)
-// is full. A consumer that enforces a size limit in its read loop, or simply
-// reads slowly, sees the expansion one piece at a time, and the write() that
-// carried the chunk settles only once the whole expansion has been pulled.
+// decode to gigabytes), so the coder emits its output in steps of at most the
+// stream's highWaterMark (64 KiB unless passed to the constructor), or the
+// chunk's own size if that is larger, and waits between steps while the readable
+// side (or the native sink) is full. A consumer that enforces a size limit in
+// its read loop, or simply reads slowly, sees the expansion one piece at a time,
+// and the write() that carried the chunk settles only once the whole expansion
+// has been pulled.
 describe("bounded output per input chunk", () => {
-  const kStepOutput = 64 * 1024;
-  const kStepOutputOffThread = 1024 * 1024;
+  const kDefaultHighWaterMark = 64 * 1024;
   const EXPANDED = 4 * 1024 * 1024;
   const expanded = Buffer.alloc(EXPANDED, 0x41);
   const bombs = {
@@ -775,7 +774,7 @@ describe("bounded output per input chunk", () => {
     async format => {
       const bomb = bombs[format]();
       // The whole expansion arrives in one write, well under the thread-pool threshold.
-      expect(bomb.byteLength).toBeLessThan(kStepOutput);
+      expect(bomb.byteLength).toBeLessThan(kDefaultHighWaterMark);
 
       const ds = new DecompressionStream(format);
       const writer = ds.writable.getWriter();
@@ -784,13 +783,13 @@ describe("bounded output per input chunk", () => {
 
       const first = await reader.read();
       expect(first.done).toBe(false);
-      expect(first.value!.byteLength).toBeLessThanOrEqual(kStepOutput);
+      expect(first.value!.byteLength).toBeLessThanOrEqual(kDefaultHighWaterMark);
       // The readable holds one piece, so the coder is now parked with the rest of
       // the expansion still undecoded and the write that carried it still in flight.
       expect(await Promise.race([write.then(() => "settled"), Bun.sleep(0).then(() => "pending")])).toBe("pending");
 
       const rest = await readExactly(reader, EXPANDED - first.value!.byteLength);
-      expect(largest(rest)).toBeLessThanOrEqual(kStepOutput);
+      expect(largest(rest)).toBeLessThanOrEqual(kDefaultHighWaterMark);
       expect(Buffer.concat([first.value!, ...rest]).equals(expanded)).toBe(true);
 
       await write;
@@ -806,7 +805,7 @@ describe("bounded output per input chunk", () => {
     const write = writer.write(bombs.brotli());
 
     const first = await reader.read();
-    expect(first.value!.byteLength).toBeLessThanOrEqual(kStepOutput);
+    expect(first.value!.byteLength).toBeLessThanOrEqual(kDefaultHighWaterMark);
 
     await reader.cancel(new Error("too large"));
     // The readable will never pull again; the parked chunk is abandoned rather
@@ -840,9 +839,9 @@ describe("bounded output per input chunk", () => {
     const res = await fetch(server.url, { method: "POST", body: bombs.brotli() });
     expect(res.status).toBe(413);
     const { total, largestPiece } = (await res.json()) as { total: number; largestPiece: number };
-    expect(largestPiece).toBeLessThanOrEqual(kStepOutput);
+    expect(largestPiece).toBeLessThanOrEqual(kDefaultHighWaterMark);
     // The guard fires on the step that crosses the limit; nothing beyond it was decoded.
-    expect(total).toBeLessThanOrEqual(limit + kStepOutput);
+    expect(total).toBeLessThanOrEqual(limit + kDefaultHighWaterMark);
   });
 
   test("DecompressionStream -> native HTTP response sink delivers a large expansion in steps", async () => {
@@ -865,12 +864,11 @@ describe("bounded output per input chunk", () => {
 
   test("a >128 KiB compressed chunk (thread-pool path) is also delivered in bounded steps", async () => {
     // Incompressible prefix to push the compressed chunk over the thread-pool
-    // threshold (while staying under the off-thread step size, so that is the
-    // bound in effect), followed by a highly compressible expansion.
+    // threshold, followed by a highly compressible expansion. A chunk bigger than
+    // the high water mark may produce up to its own size per step.
     const plain = Buffer.concat([randomBytes(160 * 1024), expanded]);
     const compressed = zlib.gzipSync(plain);
     expect(compressed.byteLength).toBeGreaterThan(128 * 1024);
-    expect(compressed.byteLength).toBeLessThan(kStepOutputOffThread);
 
     const ds = new DecompressionStream("gzip");
     const writer = ds.writable.getWriter();
@@ -879,7 +877,7 @@ describe("bounded output per input chunk", () => {
 
     const pieces = await readExactly(reader, plain.byteLength);
     expect(pieces.length).toBeGreaterThanOrEqual(2);
-    expect(largest(pieces)).toBeLessThanOrEqual(kStepOutputOffThread);
+    expect(largest(pieces)).toBeLessThanOrEqual(compressed.byteLength);
     expect(Buffer.concat(pieces).equals(plain)).toBe(true);
 
     await write;
@@ -903,12 +901,101 @@ describe("bounded output per input chunk", () => {
     expect(writeError).toBe(readError);
   });
 
+  test.each([16 * 1024, 1024 * 1024])(
+    "the constructor's highWaterMark (%i) sets the step size",
+    async highWaterMark => {
+      const ds = new DecompressionStream("brotli", { highWaterMark });
+      const writer = ds.writable.getWriter();
+      const reader = ds.readable.getReader();
+      const write = writer.write(bombs.brotli());
+
+      const pieces = await readExactly(reader, EXPANDED);
+      expect(largest(pieces)).toBe(highWaterMark);
+      expect(Buffer.concat(pieces).equals(expanded)).toBe(true);
+
+      await write;
+      await writer.close();
+    },
+  );
+
+  test("highWaterMark: Infinity turns the splitting off", async () => {
+    const ds = new DecompressionStream("zstd", { highWaterMark: Infinity });
+    const writer = ds.writable.getWriter();
+    const reader = ds.readable.getReader();
+    const write = writer.write(bombs.zstd());
+
+    const first = await reader.read();
+    expect(first.value!.byteLength).toBe(EXPANDED);
+    await write;
+    await writer.close();
+  });
+
+  test("CompressionStream takes the same option", async () => {
+    // zstd holds these back and emits them all from the flush, whose input is
+    // empty, so the high water mark alone bounds the pieces (64 KiB by default).
+    const highWaterMark = 8 * 1024;
+    const chunks = Array.from({ length: 8 }, () => randomBytes(highWaterMark));
+    const cs = new CompressionStream("zstd", { highWaterMark });
+    const writer = cs.writable.getWriter();
+    const written = (async () => {
+      for (const chunk of chunks) await writer.write(chunk);
+      await writer.close();
+    })();
+
+    const pieces = await Array.fromAsync(cs.readable);
+    await written;
+    expect(largest(pieces)).toBeLessThanOrEqual(highWaterMark);
+    expect(pieces.length).toBeGreaterThanOrEqual(8);
+    expect(zlib.zstdDecompressSync(Buffer.concat(pieces)).equals(Buffer.concat(chunks))).toBe(true);
+  });
+
+  test("the second argument is validated like a queuing strategy", () => {
+    expect(() => new DecompressionStream("gzip", { highWaterMark: -1 })).toThrow(RangeError);
+    expect(() => new CompressionStream("gzip", { highWaterMark: NaN })).toThrow(RangeError);
+    expect(() => new DecompressionStream("gzip", 4096 as any)).toThrow(TypeError);
+    expect(new DecompressionStream("gzip", {})).toBeInstanceOf(DecompressionStream);
+    expect(new DecompressionStream("gzip", undefined)).toBeInstanceOf(DecompressionStream);
+  });
+
+  // A client that goes away mid-expansion closes the response sink under the
+  // transform. The chunk being drained into it has to be given up so the
+  // transform's writable can finish erroring, which is what lets pipeThrough
+  // cancel the source; otherwise the source is never told and the handler's
+  // pipeline stays pending forever.
+  test("a client disconnecting mid-expansion propagates back to the source of the pipeline", async () => {
+    const sourceCancelled = Promise.withResolvers<unknown>();
+    await using server = Bun.serve({
+      port: 0,
+      fetch() {
+        const source = new ReadableStream({
+          start(controller) {
+            controller.enqueue(new Uint8Array(bombs.brotli()));
+          },
+          cancel(reason) {
+            sourceCancelled.resolve(reason);
+          },
+        });
+        return new Response(source.pipeThrough(new DecompressionStream("brotli")));
+      },
+    });
+
+    const res = await fetch(server.url);
+    const reader = res.body!.getReader();
+    expect((await reader.read()).done).toBe(false);
+    await reader.cancel();
+    await sourceCancelled.promise;
+  });
+
   // The encoders are stepped the same way. Incompressible input comes out
-  // slightly larger than it went in, so kStepOutput-sized chunks overflow a
+  // slightly larger than it went in, so highWaterMark-sized chunks overflow a
   // step by a few bytes; brotli and zstd hold everything back until the flush,
   // which then spans several steps.
   test.each(formats)("CompressionStream(%s): output larger than one step is emitted in pieces", async format => {
-    const chunks = [randomBytes(kStepOutput), randomBytes(kStepOutput), randomBytes(kStepOutput)];
+    const chunks = [
+      randomBytes(kDefaultHighWaterMark),
+      randomBytes(kDefaultHighWaterMark),
+      randomBytes(kDefaultHighWaterMark),
+    ];
     const cs = new CompressionStream(format);
     const writer = cs.writable.getWriter();
     const written = (async () => {
@@ -918,7 +1005,7 @@ describe("bounded output per input chunk", () => {
 
     const pieces = await Array.fromAsync(cs.readable);
     await written;
-    expect(largest(pieces)).toBeLessThanOrEqual(kStepOutput);
+    expect(largest(pieces)).toBeLessThanOrEqual(kDefaultHighWaterMark);
     expect(inflaters[format](Buffer.concat(pieces)).equals(Buffer.concat(chunks))).toBe(true);
   });
 
@@ -966,7 +1053,7 @@ describe("bounded output per input chunk", () => {
       for (let i = 0; i < readsBeforeCancel; i++) {
         const { value, done } = await reader.read();
         expect(done).toBe(false);
-        expect(value!.byteLength).toBeLessThanOrEqual(kStepOutput);
+        expect(value!.byteLength).toBeLessThanOrEqual(kDefaultHighWaterMark);
       }
       const cancelled = reader.cancel();
       // close() and cancel() share the transform's finish promise; the abandoned

--- a/test/js/web/streams/compression.test.ts
+++ b/test/js/web/streams/compression.test.ts
@@ -887,6 +887,22 @@ describe("bounded output per input chunk", () => {
     expect(await reader.read()).toEqual({ value: undefined, done: true });
   });
 
+  test("a >128 KiB chunk that is not valid input errors both sides through the thread-pool path", async () => {
+    const ds = new DecompressionStream("gzip");
+    const writer = ds.writable.getWriter();
+    const readAll = new Response(ds.readable).arrayBuffer().then(
+      () => null,
+      e => e,
+    );
+    const write = writer.write(randomBytes(200 * 1024)).then(
+      () => null,
+      e => e,
+    );
+    const [readError, writeError] = await Promise.all([readAll, write]);
+    expect(readError).toBeInstanceOf(TypeError);
+    expect(writeError).toBe(readError);
+  });
+
   // The encoders are stepped the same way. Incompressible input comes out
   // slightly larger than it went in, so kStepOutput-sized chunks overflow a
   // step by a few bytes; brotli and zstd hold everything back until the flush,

--- a/test/js/web/streams/compression.test.ts
+++ b/test/js/web/streams/compression.test.ts
@@ -715,6 +715,234 @@ describe("CompressionStream chunk handling (Node v26 semantics)", () => {
   });
 });
 
+// One input chunk can expand enormously (a few hundred bytes of brotli or zstd
+// decode to gigabytes), so the coder emits its output in bounded steps: at most
+// kStepOutput bytes per step on the JS thread (kStepOutputOffThread for the
+// >128 KiB chunks that run on the thread pool), or the chunk's own size if that
+// is larger, parking between steps while the readable side (or the native sink)
+// is full. A consumer that enforces a size limit in its read loop, or simply
+// reads slowly, sees the expansion one piece at a time, and the write() that
+// carried the chunk settles only once the whole expansion has been pulled.
+describe("bounded output per input chunk", () => {
+  const kStepOutput = 64 * 1024;
+  const kStepOutputOffThread = 1024 * 1024;
+  const EXPANDED = 4 * 1024 * 1024;
+  const expanded = Buffer.alloc(EXPANDED, 0x41);
+  const bombs = {
+    gzip: (plain: Buffer = expanded) => zlib.gzipSync(plain),
+    deflate: (plain: Buffer = expanded) => zlib.deflateSync(plain),
+    "deflate-raw": (plain: Buffer = expanded) => zlib.deflateRawSync(plain),
+    brotli: (plain: Buffer = expanded) =>
+      zlib.brotliCompressSync(plain, { params: { [zlib.constants.BROTLI_PARAM_QUALITY]: 5 } }),
+    zstd: (plain: Buffer = expanded) => zlib.zstdCompressSync(plain),
+  };
+  const inflaters = {
+    gzip: zlib.gunzipSync,
+    deflate: zlib.inflateSync,
+    "deflate-raw": zlib.inflateRawSync,
+    brotli: zlib.brotliDecompressSync,
+    zstd: zlib.zstdDecompressSync,
+  };
+  const formats = Object.keys(bombs) as (keyof typeof bombs)[];
+
+  function randomBytes(len: number) {
+    const out = Buffer.alloc(len);
+    for (let off = 0; off < len; off += 65536) crypto.getRandomValues(out.subarray(off, Math.min(off + 65536, len)));
+    return out;
+  }
+
+  function largest(pieces: Uint8Array[]) {
+    return pieces.reduce((max, piece) => Math.max(max, piece.byteLength), 0);
+  }
+
+  // Reads until `length` bytes have arrived; every piece is returned so callers
+  // can check how the expansion was split up.
+  async function readExactly(reader: ReadableStreamDefaultReader<Uint8Array>, length: number) {
+    const pieces: Uint8Array[] = [];
+    let total = 0;
+    while (total < length) {
+      const { value, done } = await reader.read();
+      expect(done).toBe(false);
+      pieces.push(value!);
+      total += value!.byteLength;
+    }
+    expect(total).toBe(length);
+    return pieces;
+  }
+
+  test.each(formats)(
+    "DecompressionStream(%s): one small chunk expands step by step as the reader pulls",
+    async format => {
+      const bomb = bombs[format]();
+      // The whole expansion arrives in one write, well under the thread-pool threshold.
+      expect(bomb.byteLength).toBeLessThan(kStepOutput);
+
+      const ds = new DecompressionStream(format);
+      const writer = ds.writable.getWriter();
+      const reader = ds.readable.getReader();
+      const write = writer.write(bomb);
+
+      const first = await reader.read();
+      expect(first.done).toBe(false);
+      expect(first.value!.byteLength).toBeLessThanOrEqual(kStepOutput);
+      // The readable holds one piece, so the coder is now parked with the rest of
+      // the expansion still undecoded and the write that carried it still in flight.
+      expect(await Promise.race([write.then(() => "settled"), Bun.sleep(0).then(() => "pending")])).toBe("pending");
+
+      const rest = await readExactly(reader, EXPANDED - first.value!.byteLength);
+      expect(largest(rest)).toBeLessThanOrEqual(kStepOutput);
+      expect(Buffer.concat([first.value!, ...rest]).equals(expanded)).toBe(true);
+
+      await write;
+      await writer.close();
+      expect(await reader.read()).toEqual({ value: undefined, done: true });
+    },
+  );
+
+  test("cancelling the readable mid-expansion settles the in-flight write instead of hanging it", async () => {
+    const ds = new DecompressionStream("brotli");
+    const writer = ds.writable.getWriter();
+    const reader = ds.readable.getReader();
+    const write = writer.write(bombs.brotli());
+
+    const first = await reader.read();
+    expect(first.value!.byteLength).toBeLessThanOrEqual(kStepOutput);
+
+    await reader.cancel(new Error("too large"));
+    // The readable will never pull again; the parked chunk is abandoned rather
+    // than left pending forever (which would also hang the erroring writable).
+    expect(await write).toBeUndefined();
+    await expect(writer.closed).rejects.toThrow("too large");
+  });
+
+  test("a request body bomb trips a streaming size guard after one step, not after the whole expansion", async () => {
+    const limit = 256 * 1024;
+    await using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const reader = req.body!.pipeThrough(new DecompressionStream("brotli")).getReader();
+        let total = 0;
+        let largestPiece = 0;
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          total += value.byteLength;
+          largestPiece = Math.max(largestPiece, value.byteLength);
+          if (total > limit) {
+            await reader.cancel();
+            break;
+          }
+        }
+        return Response.json({ total, largestPiece }, { status: total > limit ? 413 : 200 });
+      },
+    });
+
+    const res = await fetch(server.url, { method: "POST", body: bombs.brotli() });
+    expect(res.status).toBe(413);
+    const { total, largestPiece } = (await res.json()) as { total: number; largestPiece: number };
+    expect(largestPiece).toBeLessThanOrEqual(kStepOutput);
+    // The guard fires on the step that crosses the limit; nothing beyond it was decoded.
+    expect(total).toBeLessThanOrEqual(limit + kStepOutput);
+  });
+
+  test("DecompressionStream -> native HTTP response sink delivers a large expansion in steps", async () => {
+    const plain = Buffer.alloc(16 * 1024 * 1024, 0x5a);
+    const bomb = bombs.zstd(plain);
+    await using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response(new Blob([bomb]).stream().pipeThrough(new DecompressionStream("zstd")));
+      },
+    });
+
+    // The server pushes into the socket until the sink reports backpressure and
+    // parks mid-chunk; draining the body then resumes it step by step.
+    const res = await fetch(server.url);
+    const body = Buffer.from(await res.arrayBuffer());
+    expect(body.byteLength).toBe(plain.byteLength);
+    expect(body.equals(plain)).toBe(true);
+  });
+
+  test("a >128 KiB compressed chunk (thread-pool path) is also delivered in bounded steps", async () => {
+    // Incompressible prefix to push the compressed chunk over the thread-pool
+    // threshold (while staying under the off-thread step size, so that is the
+    // bound in effect), followed by a highly compressible expansion.
+    const plain = Buffer.concat([randomBytes(160 * 1024), expanded]);
+    const compressed = zlib.gzipSync(plain);
+    expect(compressed.byteLength).toBeGreaterThan(128 * 1024);
+    expect(compressed.byteLength).toBeLessThan(kStepOutputOffThread);
+
+    const ds = new DecompressionStream("gzip");
+    const writer = ds.writable.getWriter();
+    const reader = ds.readable.getReader();
+    const write = writer.write(compressed);
+
+    const pieces = await readExactly(reader, plain.byteLength);
+    expect(pieces.length).toBeGreaterThanOrEqual(2);
+    expect(largest(pieces)).toBeLessThanOrEqual(kStepOutputOffThread);
+    expect(Buffer.concat(pieces).equals(plain)).toBe(true);
+
+    await write;
+    await writer.close();
+    expect(await reader.read()).toEqual({ value: undefined, done: true });
+  });
+
+  // The encoders are stepped the same way. Incompressible input comes out
+  // slightly larger than it went in, so kStepOutput-sized chunks overflow a
+  // step by a few bytes; brotli and zstd hold everything back until the flush,
+  // which then spans several steps.
+  test.each(formats)("CompressionStream(%s): output larger than one step is emitted in pieces", async format => {
+    const chunks = [randomBytes(kStepOutput), randomBytes(kStepOutput), randomBytes(kStepOutput)];
+    const cs = new CompressionStream(format);
+    const writer = cs.writable.getWriter();
+    const written = (async () => {
+      for (const chunk of chunks) await writer.write(chunk);
+      await writer.close();
+    })();
+
+    const pieces = await Array.fromAsync(cs.readable);
+    await written;
+    expect(largest(pieces)).toBeLessThanOrEqual(kStepOutput);
+    expect(inflaters[format](Buffer.concat(pieces)).equals(Buffer.concat(chunks))).toBe(true);
+  });
+
+  // The close algorithm clears the transform's algorithms (which normally frees
+  // the coder) as soon as the flush arm returns, while a flush this large is
+  // still parked part-way through. The coder has to survive until the flush has
+  // actually been drained, here into the native response sink.
+  test.each(["zstd", "brotli"] as const)(
+    "CompressionStream(%s) -> native HTTP response sink: a flush spanning several steps is delivered in full",
+    async format => {
+      const input = randomBytes(200 * 1024);
+      await using server = Bun.serve({
+        port: 0,
+        fetch() {
+          return new Response(new Blob([input]).stream().pipeThrough(new CompressionStream(format)));
+        },
+      });
+
+      const body = Buffer.from(await (await fetch(server.url)).arrayBuffer());
+      expect(inflaters[format](body).equals(input)).toBe(true);
+    },
+  );
+
+  test("cancelling the readable while the flush is parked settles close()", async () => {
+    const cs = new CompressionStream("zstd");
+    const writer = cs.writable.getWriter();
+    const reader = cs.readable.getReader();
+    // zstd holds all of this back until the flush, which then needs two steps.
+    await writer.write(randomBytes(100 * 1024));
+    const closed = writer.close();
+
+    const first = await reader.read();
+    expect(first.value!.byteLength).toBeLessThanOrEqual(kStepOutput);
+    await reader.cancel();
+    // close() shares the transform's finish promise with cancel(): the abandoned
+    // flush resolves it instead of leaving both pending forever.
+    expect(await closed).toBeUndefined();
+  });
+});
+
 // The native coder (a gzip deflate context is ~280 KiB of zlib state) must be
 // released eagerly at the transform's terminal (ClearAlgorithms: post-flush,
 // error, cancel), not left to the cell's finalizer. Finalizers run late, so a

--- a/test/js/web/streams/compression.test.ts
+++ b/test/js/web/streams/compression.test.ts
@@ -926,21 +926,38 @@ describe("bounded output per input chunk", () => {
     },
   );
 
-  test("cancelling the readable while the flush is parked settles close()", async () => {
-    const cs = new CompressionStream("zstd");
-    const writer = cs.writable.getWriter();
-    const reader = cs.readable.getReader();
-    // zstd holds all of this back until the flush, which then needs two steps.
-    await writer.write(randomBytes(100 * 1024));
-    const closed = writer.close();
+  // reader.cancel() after writer.close() is the one terminal that does not go
+  // through the transform's cancel reaction (the close already owns the finish
+  // promise, so the source cancel algorithm just returns it), and the cancelled
+  // readable will never pull again. A flush parked between steps at that point
+  // still has to be woken up, or close() and cancel() both stay pending forever.
+  // Both encoders hold incompressible input back until the flush: zstd's ~100 KiB
+  // flush takes two steps (parked after the first, cancelled with no read in
+  // between), and brotli's ~200 KiB one takes four (the second read is served by
+  // the resumed flush, which then parks again before the cancel lands).
+  test.each([
+    { format: "zstd", writes: [100 * 1024], readsBeforeCancel: 0 },
+    { format: "brotli", writes: [100 * 1024, 100 * 1024], readsBeforeCancel: 2 },
+  ] as const)(
+    "reader.cancel() after writer.close() settles both while a $format flush is parked (reads first: $readsBeforeCancel)",
+    async ({ format, writes, readsBeforeCancel }) => {
+      const cs = new CompressionStream(format);
+      const writer = cs.writable.getWriter();
+      const reader = cs.readable.getReader();
+      for (const size of writes) await writer.write(randomBytes(size));
+      const closed = writer.close();
 
-    const first = await reader.read();
-    expect(first.value!.byteLength).toBeLessThanOrEqual(kStepOutput);
-    await reader.cancel();
-    // close() shares the transform's finish promise with cancel(): the abandoned
-    // flush resolves it instead of leaving both pending forever.
-    expect(await closed).toBeUndefined();
-  });
+      for (let i = 0; i < readsBeforeCancel; i++) {
+        const { value, done } = await reader.read();
+        expect(done).toBe(false);
+        expect(value!.byteLength).toBeLessThanOrEqual(kStepOutput);
+      }
+      const cancelled = reader.cancel();
+      // close() and cancel() share the transform's finish promise; the abandoned
+      // flush resolves it rather than leaving both pending forever.
+      expect(await Promise.all([closed, cancelled])).toEqual([undefined, undefined]);
+    },
+  );
 });
 
 // The native coder (a gzip deflate context is ~280 KiB of zlib state) must be

--- a/test/js/web/streams/compression.test.ts
+++ b/test/js/web/streams/compression.test.ts
@@ -814,6 +814,49 @@ describe("bounded output per input chunk", () => {
     await expect(writer.closed).rejects.toThrow("too large");
   });
 
+  // The producer giving up is the other way a pending chunk can end: the abort
+  // has to wait for the in-flight write, so the chunk is given up when the
+  // writable starts erroring, even though nobody is reading.
+  test("writer.abort() mid-expansion settles and errors the readable", async () => {
+    const ds = new DecompressionStream("brotli");
+    const writer = ds.writable.getWriter();
+    const reader = ds.readable.getReader();
+    const write = writer.write(bombs.brotli());
+
+    const first = await reader.read();
+    expect(first.value!.byteLength).toBeLessThanOrEqual(kDefaultHighWaterMark);
+
+    await writer.abort(new Error("stop"));
+    expect(await write).toBeUndefined();
+    await expect(writer.closed).rejects.toThrow("stop");
+    // The abort algorithm errored the readable (dropping the piece it still held).
+    await expect(reader.read()).rejects.toThrow("stop");
+  });
+
+  // An abort during close() is different: the close in progress wins, so a flush
+  // being drained keeps going and the reader still gets all of it.
+  test("writer.abort() during a multi-step flush does not truncate it", async () => {
+    const input = randomBytes(100 * 1024);
+    const cs = new CompressionStream("zstd");
+    const writer = cs.writable.getWriter();
+    const reader = cs.readable.getReader();
+    await writer.write(input);
+    const closed = writer.close();
+
+    const first = await reader.read();
+    expect(first.value!.byteLength).toBe(kDefaultHighWaterMark);
+    const aborted = writer.abort(new Error("stop"));
+
+    const pieces = [first.value!];
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      pieces.push(value);
+    }
+    expect(zlib.zstdDecompressSync(Buffer.concat(pieces)).equals(input)).toBe(true);
+    expect(await Promise.all([closed, aborted])).toEqual([undefined, undefined]);
+  });
+
   test("a request body bomb trips a streaming size guard after one step, not after the whole expansion", async () => {
     const limit = 256 * 1024;
     await using server = Bun.serve({


### PR DESCRIPTION
### Problem
- `DecompressionStream` (all five formats; `CompressionStream` has the same structure) materializes the entire expansion of one input chunk as one output chunk before the consumer's first `read()` resolves. A 203-byte brotli chunk comes out of the first `read()` as a single 268,435,456-byte `Uint8Array`; a 4 KiB brotli request body expanding to 5 GiB OOM-kills a server whose handler enforces a 10 MiB limit in its read loop, because the limit is checked after the expansion exists.
- Cause: `CompressionStreamCoder::transform` (src/runtime/webcore/CompressionStreamCoder.rs) loops the codec until the chunk is fully consumed, collecting everything into one buffer, and the arm in `JSCompressionStreamShared.cpp` enqueues it once. TransformStream backpressure only applies between input chunks, so nothing between the codec and the consumer can stop one chunk's expansion.
- Node's `DecompressionStream` inflates lazily per `read()`; the same guard there trips after the first 16 KiB.

### Fix
- Rust: `transform` becomes `step`. A step collects at most the stream's `highWaterMark` bytes of output, or the chunk's own size if that is larger (the bound is on expansion; a big chunk still finishes in a step or two), and reports whether the codec stopped short. When it did, the coder copies the chunk's unconsumed tail into itself (`Pending`), so later steps take no input and do not depend on the JS buffer staying intact while user code runs in between. The per-format loops are unchanged apart from the cap check; the zstd split-magic join moves up into `step` so the tail offset is uniform.
- The bound is a per-stream option: `new DecompressionStream("gzip", { highWaterMark })` (also `CompressionStream`), read like a queuing strategy (`size` is ignored; NaN/negative is a RangeError, a non-object is a TypeError, `Infinity` disables the splitting), default 64 KiB, the same default output size as the node:zlib stream adapter. It is stored in the coder at creation; there are no step-size constants left. Declared in bun-types.
- C++: the arm runs steps in a loop until the chunk completes or its consumer is full (readable queue at its high water mark, or the native sink reporting backpressure). A chunk whose first call completes it returns the same settled promise as before. Otherwise its transform-algorithm promise is created and kept in `m_codecPromise` (renamed from `m_asyncCodecPromise`, which served the same purpose for the thread-pool path only): a pending transform promise is what keeps the write in flight, so the producer waits too. No other promise is involved: the consumer drives the rest through two functions, `nativeCodecContinue`, called from the readable's pull algorithm and from the native sink's onReady, and `nativeCodecAbandon`, called from whichever side goes away first: the writable starting to error while the chunk's write is in flight (`writer.abort()`, an aborted `pipeTo`, a transform error, node:stream's `addAbortSignal()`; all routes go through `writableStreamStartErroring`, and `writableStreamDefaultControllerError` now clears the sink algorithms after calling it rather than before so the check there still sees the transform; an in-flight close, that is a flush, is left to finish, since a close in progress wins over the abort), the readable's cancel algorithm (before its early return, so cancelling after `close()` with a flush in progress is covered), and a sink detach. Chunks that started on the thread pool keep stepping there; `deliverAsync` re-dispatches while the consumer has room and drops the output of a step whose chunk was abandoned meanwhile.
- The pull algorithm, after its usual flip of `[[backpressure]]`, steps the pending chunk and returns null (pull complete) when the enqueues set backpressure again, otherwise the usual promise; either way the next pull still finds the state the spec algorithm expects. JS transforms take the existing path.
- `transformStreamDefaultControllerClearAlgorithms` defers the coder release while `m_codecPromise` is set (`nativeTransformReleaseStateIfIdle`), and the chunk's terminal releases it. The close algorithm clears algorithms as soon as the flush arm returns, so a brotli/zstd flush of more than one step depends on this.
- Observable semantics: a chunk's `write()` settles once its expansion has been consumed rather than once it has been produced (Node behaves the same for output beyond its buffer); a single write whose output fits in one step still completes without a reader, as before. Pieces are at most `highWaterMark` (or the chunk's size) bytes; readers that concatenate are unaffected.
- Verified: `test/js/web/streams/compression.test.ts`, `bounded output per input chunk` block (28 tests: per-format piece size and pending `write()`, `reader.cancel()`, `writer.abort()` and `addAbortSignal()` mid-expansion, `writer.abort()` during a multi-step flush leaving the output intact, request-body guard, native response sink, thread-pool path and its error path, the option on both classes and its validation, `Infinity`, encoder side, multi-step flush into the sink, `reader.cancel()` after `writer.close()` in both the no-read and re-parked variants, and a client disconnecting mid-expansion propagating back to the pipeline's source); 21 of them fail on the unfixed build, the whole file (65 tests) passes with the fix; the `writer.abort()` and `addAbortSignal()` tests additionally hang with, respectively, the `writableStreamStartErroring` hook removed and the `writableStreamDefaultControllerError` order restored, which are the hangs they guard against. All of it, plus the vendored WPT streams suite (which exercises the modified pull and cancel algorithms), `streams.test.js`, the TextEncoderStream/TextDecoderStream tests (they share `runNativeArm` and the release deferral), the node webstreams compression tests and the bun-types test, pass locally, the stream suites under `BUN_JSC_validateExceptionChecks=1`.
- The report's repro (`http` server, brotli body, 10 MiB guard) on a debug build: a 1 GiB bomb goes from `firstChunk: 1073741824`, +1013 MB RSS to `firstChunk: 65536`, +58 MB; the 5 GiB / 4041-byte case that was OOM-killed reports `firstChunk: 65536`, +53 MB.

### Background
- A native `CompressionStream`/`DecompressionStream` is a `JSTransformStream` subclass whose transform and flush algorithms are C++ arms driving a Rust coder (one zlib/brotli/zstd context plus an output buffer) through `extern "C"` calls. Chunks over 128 KiB run the coder on the thread pool and complete through `Bun__CompressionStream__deliverAsync`. The readable side queues one piece at a time (count-based high water mark of 1, as in Node and Chromium), so the option here is a byte bound on the pieces, not a queue length.
- TransformStream backpressure: an enqueue that fills the readable's queue sets the transform's `[[backpressure]]` flag; the readable's pull algorithm clears it when the consumer wants more, and a pending write waits for that. The pull algorithm is therefore exactly the "consumer has room" event, which is why a pending chunk is stepped from it. The transform algorithm's own promise is what keeps the writable's in-flight write pending.
- Native sink: when a byte-producing transform is consumed by `readStreamIntoSink` (for example as a `Response` body in `Bun.serve`), the arm writes coder output straight into the sink, which reports backpressure from the write and later calls onReady; the pump detaches the sink from the transform when it finishes. Those two callbacks are the sink-side equivalents of pull and cancel.
- Coder release: `ClearAlgorithms` is the shared terminal (after flush, on error, on cancel) and frees the coder eagerly instead of waiting for the cell's finalizer, deferring while an arm is on the stack or a pool step holds it; this change adds "a chunk is pending across turns" to that list.

<details>
<summary>Earlier revision</summary>

The first revision registered a promise reaction on the readable's `backpressureChangePromise` (or a gate promise in the sink-ready slot) to resume a pending chunk, which needed a reaction handler, the gate, and an extra unblock-write step in the cancel algorithm's early-return branch; the step sizes were constants (64 KiB on the JS thread, 1 MiB on the pool). Review asked for a configurable bound and less machinery, hence the current shape.

</details>


