### PR TITLE
bundler: fix panic relativizing a source path close to MAX_PATH_BYTES

### DIFF
--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -689,8 +689,8 @@ impl IntermediateOutput {
         let additional_files = graph.input_files.items_additional_files();
         let unique_key_for_additional_files =
             graph.input_files.items_unique_key_for_additional_file();
-        let mut relative_platform_buf = bun_paths::path_buffer_pool::get();
-        let mut file_path_buf = bun_paths::path_buffer_pool::get();
+        let mut relative_spill: Vec<u8> = Vec::new();
+        let mut file_path_posix: Vec<u8> = Vec::new();
         match self {
             IntermediateOutput::Pieces(pieces) => {
                 let entry_point_chunks_for_scb = linker_graph.files.items_entry_point_chunk_index();
@@ -808,11 +808,10 @@ impl IntermediateOutput {
                                 if use_outdir_relative_path {
                                     file_path
                                 } else {
-                                    bun_paths::resolve_path::relative_platform_buf::<
+                                    bun_paths::resolve_path::relative_platform_spill::<
                                         bun_paths::platform::Posix,
-                                        false,
                                     >(
-                                        &mut relative_platform_buf[..], from_chunk_dir, file_path
+                                        &mut relative_spill, from_chunk_dir, file_path
                                     )
                                 },
                             );
@@ -978,28 +977,26 @@ impl IntermediateOutput {
                                 _ => unreachable!(),
                             };
 
-                            // normalize windows paths to '/'
-                            // The source slices are reachable only
-                            // through `&Graph` / `&[Chunk]` here; materialising `&mut` from a
-                            // shared-provenance pointer is UB regardless of whether the write
-                            // happens. Copy into a pooled scratch buffer and normalise that.
+                            // normalize windows paths to '/', in a scratch copy: the
+                            // source slices are only reachable through `&Graph` /
+                            // `&[Chunk]` here, so they cannot be normalized in place.
                             let file_path: &[u8] = {
-                                let n = file_path.len();
-                                let dst = &mut file_path_buf[..n];
-                                dst.copy_from_slice(file_path);
-                                bun_paths::resolve_path::platform_to_posix_in_place::<u8>(dst);
-                                dst
+                                file_path_posix.clear();
+                                file_path_posix.extend_from_slice(file_path);
+                                bun_paths::resolve_path::platform_to_posix_in_place::<u8>(
+                                    &mut file_path_posix,
+                                );
+                                &file_path_posix
                             };
                             let cheap_normalizer = cheap_prefix_normalizer(
                                 import_prefix,
                                 if use_outdir_relative_path {
                                     file_path
                                 } else {
-                                    bun_paths::resolve_path::relative_platform_buf::<
+                                    bun_paths::resolve_path::relative_platform_spill::<
                                         bun_paths::platform::Posix,
-                                        false,
                                     >(
-                                        &mut relative_platform_buf[..], from_chunk_dir, file_path
+                                        &mut relative_spill, from_chunk_dir, file_path
                                     )
                                 },
                             );

--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -803,6 +803,16 @@ impl IntermediateOutput {
                                 QueryKind::None => unreachable!(),
                             };
 
+                            // Normalize exactly like the write pass below, so
+                            // the counted and the written lengths agree.
+                            let file_path: &[u8] = {
+                                file_path_posix.clear();
+                                file_path_posix.extend_from_slice(file_path);
+                                bun_paths::resolve_path::platform_to_posix_in_place::<u8>(
+                                    &mut file_path_posix,
+                                );
+                                &file_path_posix
+                            };
                             let cheap_normalizer = cheap_prefix_normalizer(
                                 import_prefix,
                                 if use_outdir_relative_path {

--- a/src/bundler/HTMLImportManifest.rs
+++ b/src/bundler/HTMLImportManifest.rs
@@ -42,7 +42,7 @@ use bun_collections::VecExt;
 use bun_core::strings;
 use bun_io::{FmtAdapter, Write};
 use bun_js_printer::Encoding;
-use bun_paths::resolve_path::relative_normalized;
+use bun_paths::resolve_path::relative_normalized_spill;
 use bun_resolver::fs::FileSystem;
 
 use crate::Graph::Graph;
@@ -197,6 +197,7 @@ pub(crate) fn write<W: Write + ?Sized>(
     // Use the server-side public path here.
     let public_path: &[u8] = &options.public_path;
     let mut temp_buffer: Vec<u8> = Vec::new();
+    let mut relative_spill: Vec<u8> = Vec::new();
 
     for ch in chunks.iter() {
         if ch.entry_point.source_index() == browser_source_index && ch.entry_point.is_entry_point()
@@ -253,7 +254,8 @@ pub(crate) fn write<W: Write + ?Sized>(
             let input: &[u8] = if !ch.entry_point.is_entry_point() {
                 b""
             } else {
-                let path_for_key = relative_normalized::<bun_paths::platform::Posix, false>(
+                let path_for_key = relative_normalized_spill::<bun_paths::platform::Posix>(
+                    &mut relative_spill,
                     root_dir,
                     sources[ch.entry_point.source_index() as usize].path.text,
                 );
@@ -308,7 +310,8 @@ pub(crate) fn write<W: Write + ?Sized>(
                 }
                 first = false;
 
-                let path_for_key = relative_normalized::<bun_paths::platform::Posix, false>(
+                let path_for_key = relative_normalized_spill::<bun_paths::platform::Posix>(
+                    &mut relative_spill,
                     root_dir,
                     sources[source_index.get() as usize].path.text,
                 );

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2485,10 +2485,10 @@ impl<'a> LinkerContext<'a> {
                                 let path = &parse_graph.additional_output_files
                                     [*output_file_id as usize]
                                     .dest_path;
-                                hash.write(bun_paths::resolve_path::relative_platform::<
+                                let mut spill = Vec::new();
+                                hash.write(bun_paths::resolve_path::relative_platform_spill::<
                                     bun_paths::resolve_path::platform::Posix,
-                                    false,
-                                >(from_chunk_dir, path));
+                                >(&mut spill, from_chunk_dir, path));
                             }
                         }
                         crate::chunk::QueryKind::Chunk => out.push(piece.query.index()),

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2488,7 +2488,9 @@ impl<'a> LinkerContext<'a> {
                                 let mut spill = Vec::new();
                                 hash.write(bun_paths::resolve_path::relative_platform_spill::<
                                     bun_paths::resolve_path::platform::Posix,
-                                >(&mut spill, from_chunk_dir, path));
+                                >(
+                                    &mut spill, from_chunk_dir, path
+                                ));
                             }
                         }
                         crate::chunk::QueryKind::Chunk => out.push(piece.query.index()),

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -6570,12 +6570,6 @@ pub mod bv2_impl {
                         import_record.source_index = Index::INVALID;
 
                         if let Some(entry) = dev_server.is_file_cached(path.text, bake_graph) {
-                            let rel = bun_paths::resolve_path::relative_platform::<
-                                bun_paths::resolve_path::platform::Loose,
-                                false,
-                            >(
-                                self.transpiler.fs().top_level_dir, path.text
-                            );
                             if loader == Loader::Html && entry.kind == bake_types::CacheKind::Asset
                             {
                                 // Overload `path.text` to point to the final URL
@@ -6601,8 +6595,6 @@ pub mod bv2_impl {
                                 };
                                 import_record.path.is_disabled = false;
                             } else {
-                                import_record.path.text = path.text;
-                                import_record.path.pretty = rel;
                                 import_record.path = path_as_static(
                                     &self
                                         .path_with_pretty_initialized(path, target)
@@ -7700,10 +7692,8 @@ pub mod bv2_impl {
             return Ok(*path);
         }
 
-        // `pretty` is a display path that is never handed to the filesystem, so
-        // unlike `text` it is not bounded by MAX_PATH_BYTES: relativizing adds a
-        // `..` per level of `top_level_dir`, and the other forms add a prefix.
-        // `dupe_alloc_fix_pretty` copies whatever is built here into `bump`.
+        // `pretty` is a display path never handed to the filesystem, so it is
+        // not bounded by MAX_PATH_BYTES; `dupe_alloc_fix_pretty` copies it into `bump`.
         let ssr_prefix: &[u8] = if target == options::Target::ServerComponentsSsr {
             b"ssr:"
         } else {

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2525,11 +2525,13 @@ pub mod bv2_impl {
 
             if path.pretty.as_ptr() == path.text.as_ptr() {
                 // TODO: outbase
-                let rel = bun_paths::resolve_path::relative_platform::<
+                let mut spill = Vec::new();
+                let rel = bun_paths::resolve_path::relative_platform_spill::<
                     bun_paths::resolve_path::platform::Loose,
-                    false,
                 >(
-                    bun_resolver::fs::FileSystem::get().top_level_dir, path.text
+                    &mut spill,
+                    bun_resolver::fs::FileSystem::get().top_level_dir,
+                    path.text,
                 );
                 // SAFETY: arena outlives the bundle pass; raw-pointer detour erases the
                 // `&self` lifetime so the resulting `&'static [u8]` doesn't pin `self`.
@@ -4297,14 +4299,16 @@ pub mod bv2_impl {
 
                         let output_path: Box<[u8]> = {
                             // TODO: outbase
-                            let pathname =
-                                Fs::PathName::init(bun_paths::resolve_path::relative_platform::<
+                            let mut spill = Vec::new();
+                            let pathname = Fs::PathName::init(
+                                bun_paths::resolve_path::relative_platform_spill::<
                                     bun_paths::resolve_path::platform::Loose,
-                                    false,
                                 >(
+                                    &mut spill,
                                     &self.transpiler.options.root_dir,
                                     source.path.text,
-                                ));
+                                ),
+                            );
 
                             template.placeholder.name = pathname.base.to_vec().into_boxed_slice();
                             template.placeholder.dir = pathname.dir.to_vec().into_boxed_slice();
@@ -7687,9 +7691,6 @@ pub mod bv2_impl {
     ) -> crate::Result<bun_paths::fs::Path<'static>> {
         use crate::bun_fs::PathResolverExt as _;
         use crate::bun_node_fallbacks;
-        use bun_io::Write as _;
-
-        let mut buf = bun_paths::path_buffer_pool::get();
 
         let is_node = path.namespace == b"node";
         if is_node
@@ -7699,49 +7700,47 @@ pub mod bv2_impl {
             return Ok(*path);
         }
 
-        if path.is_file() || is_node {
-            let mut buf2 = bun_paths::path_buffer_pool::get();
-            let rel = bun_paths::resolve_path::relative_platform_buf::<
-                bun_paths::resolve_path::platform::Loose,
-                false,
-            >(&mut **buf2, top_level_dir, path.text);
-            let mut path_clone: crate::bun_fs::Path<'_> = *path;
-            if target == options::Target::ServerComponentsSsr {
-                let mut fbs = bun_io::FixedBufferStream::new_mut(&mut buf.0[..]);
-                let _ = fbs.write_all(b"ssr:");
-                let _ = fbs.write_all(rel);
-                let written = fbs.pos;
-                path_clone.pretty = &buf.0[..written];
-            } else {
-                path_clone.pretty = rel;
-            }
-            path_clone.dupe_alloc_fix_pretty(bump).map_err(Into::into)
+        // `pretty` is a display path that is never handed to the filesystem, so
+        // unlike `text` it is not bounded by MAX_PATH_BYTES: relativizing adds a
+        // `..` per level of `top_level_dir`, and the other forms add a prefix.
+        // `dupe_alloc_fix_pretty` copies whatever is built here into `bump`.
+        let ssr_prefix: &[u8] = if target == options::Target::ServerComponentsSsr {
+            b"ssr:"
         } else {
-            let mut path_clone: crate::bun_fs::Path<'_> = *path;
-            let mut fbs = bun_io::FixedBufferStream::new_mut(&mut buf.0[..]);
-            if target == options::Target::ServerComponentsSsr {
-                let _ = fbs.write_all(b"ssr:");
+            b""
+        };
+        let mut spill = Vec::new();
+        let mut prefixed = Vec::new();
+        let mut path_clone: crate::bun_fs::Path<'_> = *path;
+        path_clone.pretty = if path.is_file() || is_node {
+            let rel = bun_paths::resolve_path::relative_platform_spill::<
+                bun_paths::resolve_path::platform::Loose,
+            >(&mut spill, top_level_dir, path.text);
+            if ssr_prefix.is_empty() {
+                rel
+            } else {
+                prefixed = [ssr_prefix, rel].concat();
+                &prefixed
             }
-            let _ = write_escaped_namespace(&mut fbs, path_clone.namespace);
-            let _ = fbs.write_all(b":");
-            let _ = fbs.write_all(path_clone.text);
-            let written = fbs.pos;
-            path_clone.pretty = &buf.0[..written];
-            path_clone.dupe_alloc_fix_pretty(bump).map_err(Into::into)
-        }
+        } else {
+            prefixed.reserve(ssr_prefix.len() + path.namespace.len() + 1 + path.text.len());
+            prefixed.extend_from_slice(ssr_prefix);
+            push_escaped_namespace(&mut prefixed, path.namespace);
+            prefixed.extend_from_slice(b":");
+            prefixed.extend_from_slice(path.text);
+            &prefixed
+        };
+        path_clone.dupe_alloc_fix_pretty(bump).map_err(Into::into)
     }
 
-    fn write_escaped_namespace<W: bun_io::Write + ?Sized>(
-        w: &mut W,
-        slice: &[u8],
-    ) -> bun_io::Result {
-        let mut rest = slice;
+    fn push_escaped_namespace(out: &mut Vec<u8>, namespace: &[u8]) {
+        let mut rest = namespace;
         while let Some(i) = strings::index_of_char(rest, b':') {
-            w.write_all(&rest[..i as usize])?;
-            w.write_all(b"::")?;
+            out.extend_from_slice(&rest[..i as usize]);
+            out.extend_from_slice(b"::");
             rest = &rest[i as usize + 1..];
         }
-        w.write_all(rest)
+        out.extend_from_slice(rest);
     }
 
     #[repr(u8)]

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -715,7 +715,7 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                         // so the sourceMappingURL resolves relative to the HTML
                         // file rather than a JS file next to the .map. Point at
                         // the .map path relative to the HTML chunk's directory.
-                        let mut relative_platform_buf = path::path_buffer_pool::get();
+                        let mut relative_spill: Vec<u8> = Vec::new();
                         let [a, b]: [&[u8]; 2] = if !c.options.public_path.is_empty() {
                             cheap_prefix_normalizer(
                                 c.options.public_path,
@@ -743,11 +743,10 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                                 if html_dir.is_empty() {
                                     &source_map_final_rel_path
                                 } else {
-                                    path::resolve_path::relative_platform_buf::<
+                                    path::resolve_path::relative_platform_spill::<
                                         path::platform::Posix,
-                                        false,
                                     >(
-                                        &mut relative_platform_buf[..],
+                                        &mut relative_spill,
                                         html_dir,
                                         &source_map_final_rel_path,
                                     )

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -746,9 +746,7 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                                     path::resolve_path::relative_platform_spill::<
                                         path::platform::Posix,
                                     >(
-                                        &mut relative_spill,
-                                        html_dir,
-                                        &source_map_final_rel_path,
+                                        &mut relative_spill, html_dir, &source_map_final_rel_path
                                     )
                                 },
                             )

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -2631,7 +2631,10 @@ impl<'a> Transpiler<'a> {
             return crate::linker::dupe(_entry);
         }
 
-        let entry = fs.relative_to(entry);
+        let mut rel_spill = Vec::new();
+        let entry = bun_paths::resolve_path::relative_platform_spill::<
+            bun_paths::resolve_path::platform::Auto,
+        >(&mut rel_spill, fs.top_level_dir, entry);
 
         if !strings::starts_with(entry, b"./") {
             // Entry point paths without a leading "./" are interpreted as package
@@ -2898,7 +2901,10 @@ impl<'a> Transpiler<'a> {
         let mut file_path = Fs::Path::init(file_path_text);
 
         let top_level_dir = self.fs().top_level_dir;
-        let rel = bun_paths::resolve_path::relative(top_level_dir, file_path_text);
+        let mut rel_spill = Vec::new();
+        let rel = bun_paths::resolve_path::relative_platform_spill::<
+            bun_paths::resolve_path::platform::Auto,
+        >(&mut rel_spill, top_level_dir, file_path_text);
         file_path.pretty = crate::linker::dupe(rel);
 
         let mut output_file = options::OutputFile::zero_value();
@@ -3069,10 +3075,10 @@ impl<'a> Transpiler<'a> {
         loader: options::Loader,
         output: &[u8],
     ) -> Box<[u8]> {
-        let rel_to_root = bun_paths::resolve_path::relative_platform::<
+        let mut rel_spill = Vec::new();
+        let rel_to_root = bun_paths::resolve_path::relative_platform_spill::<
             bun_paths::resolve_path::platform::Loose,
-            false,
-        >(&self.options.root_dir, file_path_text);
+        >(&mut rel_spill, &self.options.root_dir, file_path_text);
         let pathname = Fs::PathName::init(rel_to_root);
 
         let ext: &[u8] = if loader == options::Loader::Css {

--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -653,85 +653,129 @@ pub fn relative_buf_z<'a>(buf: &'a mut [u8], from: &[u8], to: &[u8]) -> &'a ZStr
     ZStr::from_buf(&buf[..], len)
 }
 
+/// Normalizes both inputs of a `relative` computation into `from_buf` and
+/// `to_buf`, resolving a non-absolute input against the top-level dir first
+/// (`to_scratch` holds the intermediate normalization of a non-absolute `to`).
+/// Each of the three buffers must hold [`relative_scratch_len`] bytes. The
+/// results borrow only `from_buf` and `to_buf`, so `to_scratch` is free again
+/// once this returns.
+fn relative_normalize_inputs<'f, 't, P: PlatformT>(
+    from_buf: &'f mut [u8],
+    to_buf: &'t mut [u8],
+    to_scratch: &mut [u8],
+    from: &[u8],
+    to: &[u8],
+) -> (&'f [u8], &'t [u8]) {
+    let normalized_from: &'f [u8] = if P::P.is_absolute(from) {
+        'brk: {
+            if P::P == Platform::Loose && cfg!(windows) {
+                // we want to invoke the windows resolution behavior but end up with a
+                // string with forward slashes.
+                let normalized =
+                    normalize_string_buf::<true, platform::Windows, true>(from, &mut from_buf[1..]);
+                platform_to_posix_in_place::<u8>(normalized);
+                break 'brk &*normalized;
+            }
+            // reshaped for borrowck — capture len, drop inner &mut, re-slice
+            let path_len = normalize_string_buf::<true, P, true>(from, &mut from_buf[1..]).len();
+            if P::P == Platform::Windows {
+                break 'brk &from_buf[1..1 + path_len];
+            }
+            from_buf[0] = P::P.separator();
+            break 'brk &from_buf[0..path_len + 1];
+        }
+    } else {
+        // Avoid aliasing from_buf as both input (normalize result) and output
+        // (join target): normalize into to_buf as scratch, then join into
+        // from_buf. Safe because normalized_to is computed afterwards
+        // (overwrites to_buf anyway).
+        let norm_len = normalize_string_buf::<true, P, true>(from, &mut to_buf[..]).len();
+        join_abs_string_buf::<P>(
+            Fs::FileSystem::instance().top_level_dir(),
+            from_buf,
+            &[&to_buf[..norm_len]],
+        )
+    };
+
+    let normalized_to: &'t [u8] = if P::P.is_absolute(to) {
+        'brk: {
+            if P::P == Platform::Loose && cfg!(windows) {
+                let normalized =
+                    normalize_string_buf::<true, platform::Windows, true>(to, &mut to_buf[1..]);
+                platform_to_posix_in_place::<u8>(normalized);
+                break 'brk &*normalized;
+            }
+            // reshaped for borrowck — capture len, drop inner &mut, re-slice
+            let path_len = normalize_string_buf::<true, P, true>(to, &mut to_buf[1..]).len();
+            if P::P == Platform::Windows {
+                break 'brk &to_buf[1..1 + path_len];
+            }
+            to_buf[0] = P::P.separator();
+            break 'brk &to_buf[0..path_len + 1];
+        }
+    } else {
+        // Same aliasing concern as above: normalize into to_scratch, then join
+        // into to_buf.
+        let norm_len = normalize_string_buf::<true, P, true>(to, to_scratch).len();
+        join_abs_string_buf::<P>(
+            Fs::FileSystem::instance().top_level_dir(),
+            to_buf,
+            &[&to_scratch[..norm_len]],
+        )
+    };
+
+    (normalized_from, normalized_to)
+}
+
+/// Bytes each buffer handed to [`relative_normalize_inputs`] must hold: an
+/// input (joined onto the top-level dir when it is not absolute, which adds
+/// that dir and a separator) plus the leading separator slot and the one byte
+/// normalization can add (see [`normalize_string_spill`]), for both the
+/// intermediate and the final normalization.
+fn relative_scratch_len<P: PlatformT>(from: &[u8], to: &[u8]) -> usize {
+    let cwd_len = if P::P.is_absolute(from) && P::P.is_absolute(to) {
+        0
+    } else {
+        Fs::FileSystem::instance().top_level_dir().len()
+    };
+    cwd_len + from.len().max(to.len()) + 4
+}
+
+/// Upper bound on what [`relative_normalized_buf`] writes for these inputs:
+/// at most one `..` per component of `from` (three bytes each, counting its
+/// separator), one joining separator, then a suffix of `to`. Counting both
+/// separator styles over-approximates the component count on every platform.
+fn relative_max_len(normalized_from: &[u8], normalized_to: &[u8]) -> usize {
+    let from_components = strings::count_char(normalized_from, SEP_POSIX)
+        + strings::count_char(normalized_from, SEP_WINDOWS)
+        + 1;
+    3 * from_components + 1 + normalized_to.len()
+}
+
+/// `from` and `to` must each fit in a `PathBuffer` and the result must fit in
+/// `buf`. The result is not bounded by the inputs: it is the tail of `to` plus
+/// one `..` per level of `from` outside their common prefix, so a `to` that
+/// fits in a `PathBuffer` can still relativize to something that does not.
+/// Use [`relative_platform_spill`] when that is possible.
 pub fn relative_platform_buf<'a, P: PlatformT, const ALWAYS_COPY: bool>(
     buf: &'a mut [u8],
     from: &[u8],
     to: &[u8],
 ) -> &'a [u8] {
     // RELATIVE_FROM_BUF and RELATIVE_TO_BUF are independent allocations so the
-    // two `&mut` borrows below are disjoint.
-    let relative_from_buf = RELATIVE_FROM_BUF.with(lazy_path_buf);
-    let relative_to_buf = RELATIVE_TO_BUF.with(lazy_path_buf);
-
-    let normalized_from: &[u8] = if P::P.is_absolute(from) {
-        'brk: {
-            if P::P == Platform::Loose && cfg!(windows) {
-                // we want to invoke the windows resolution behavior but end up with a
-                // string with forward slashes.
-                let normalized = normalize_string_buf::<true, platform::Windows, true>(
-                    from,
-                    &mut relative_from_buf[1..],
-                );
-                platform_to_posix_in_place::<u8>(normalized);
-                break 'brk &*normalized;
-            }
-            // reshaped for borrowck — capture len, drop inner &mut, re-slice
-            let path_len =
-                normalize_string_buf::<true, P, true>(from, &mut relative_from_buf[1..]).len();
-            if P::P == Platform::Windows {
-                break 'brk &relative_from_buf[1..1 + path_len];
-            }
-            relative_from_buf[0] = P::P.separator();
-            break 'brk &relative_from_buf[0..path_len + 1];
-        }
-    } else {
-        // Avoid aliasing relative_from_buf as both input (normalize result)
-        // and output (join target): normalize into relative_to_buf scratch,
-        // then join into relative_from_buf. Safe because normalized_to is computed
-        // afterwards (overwrites relative_to_buf anyway).
-        let norm_len = normalize_string_buf::<true, P, true>(from, &mut relative_to_buf[..]).len();
-        join_abs_string_buf::<P>(
-            Fs::FileSystem::instance().top_level_dir(),
-            relative_from_buf,
-            &[&relative_to_buf[..norm_len]],
-        )
-    };
-
-    let normalized_to: &[u8] = if P::P.is_absolute(to) {
-        'brk: {
-            if P::P == Platform::Loose && cfg!(windows) {
-                let normalized = normalize_string_buf::<true, platform::Windows, true>(
-                    to,
-                    &mut relative_to_buf[1..],
-                );
-                platform_to_posix_in_place::<u8>(normalized);
-                break 'brk &*normalized;
-            }
-            // reshaped for borrowck — capture len, drop inner &mut, re-slice
-            let path_len =
-                normalize_string_buf::<true, P, true>(to, &mut relative_to_buf[1..]).len();
-            if P::P == Platform::Windows {
-                break 'brk &relative_to_buf[1..1 + path_len];
-            }
-            relative_to_buf[0] = P::P.separator();
-            break 'brk &relative_to_buf[0..path_len + 1];
-        }
-    } else {
-        // Avoid aliasing relative_to_buf as both input (normalize result)
-        // and output (join target): normalize into `buf` scratch (caller
-        // output buffer, untouched until the final relative_normalized_buf call
-        // and disjoint from both threadlocals), then join into relative_to_buf.
-        let norm_len = normalize_string_buf::<true, P, true>(to, buf).len();
-        join_abs_string_buf::<P>(
-            Fs::FileSystem::instance().top_level_dir(),
-            relative_to_buf,
-            &[&buf[..norm_len]],
-        )
-    };
-
+    // two `&mut` borrows below are disjoint. `buf` serves as the scratch for a
+    // non-absolute `to`; that use ends before the result is written into it.
+    let (normalized_from, normalized_to) = relative_normalize_inputs::<P>(
+        RELATIVE_FROM_BUF.with(lazy_path_buf),
+        RELATIVE_TO_BUF.with(lazy_path_buf),
+        buf,
+        from,
+        to,
+    );
     relative_normalized_buf::<P, ALWAYS_COPY>(buf, normalized_from, normalized_to)
 }
 
+/// See [`relative_platform_buf`] for the length limits.
 pub fn relative_platform<P: PlatformT, const ALWAYS_COPY: bool>(
     from: &[u8],
     to: &[u8],
@@ -744,8 +788,59 @@ pub fn relative_platform<P: PlatformT, const ALWAYS_COPY: bool>(
     )
 }
 
+/// [`relative_platform`] without its length limits: the inputs and the result
+/// use the thread-local buffers when they fit, and otherwise heap scratch and
+/// `spill` (grown as needed) respectively. `spill` is untouched in the common
+/// case. Like `relative_platform`, the result is valid until the next
+/// `relative*` call on this thread.
+pub fn relative_platform_spill<'a, P: PlatformT>(
+    spill: &'a mut Vec<u8>,
+    from: &[u8],
+    to: &[u8],
+) -> &'a [u8] {
+    let scratch_len = relative_scratch_len::<P>(from, to);
+    let mut heap: Vec<u8>;
+    let (from_buf, to_buf, to_scratch): (&mut [u8], &mut [u8], &mut [u8]) =
+        if scratch_len <= MAX_PATH_BYTES {
+            // SAFETY: thread-local scratch; single live borrow per thread.
+            (
+                RELATIVE_FROM_BUF.with(lazy_path_buf).as_mut_slice(),
+                RELATIVE_TO_BUF.with(lazy_path_buf).as_mut_slice(),
+                RELATIVE_TO_COMMON_PATH_BUF
+                    .with(lazy_path_buf)
+                    .as_mut_slice(),
+            )
+        } else {
+            heap = vec![0u8; scratch_len * 3];
+            let (from_buf, rest) = heap.split_at_mut(scratch_len);
+            let (to_buf, to_scratch) = rest.split_at_mut(scratch_len);
+            (from_buf, to_buf, to_scratch)
+        };
+    let (normalized_from, normalized_to) =
+        relative_normalize_inputs::<P>(from_buf, to_buf, to_scratch, from, to);
+
+    let needed = relative_max_len(normalized_from, normalized_to);
+    let out: &'a mut [u8] = if needed <= MAX_PATH_BYTES {
+        // The scratch use of this buffer above (if any) is over: the normalized
+        // inputs live in the from/to buffers.
+        RELATIVE_TO_COMMON_PATH_BUF
+            .with(lazy_path_buf)
+            .as_mut_slice()
+    } else {
+        if spill.len() < needed {
+            spill.resize(needed, 0);
+        }
+        spill.as_mut_slice()
+    };
+    // ALWAYS_COPY, so that the result never aliases the (possibly heap) input
+    // scratch; it is a prefix of `out`, or empty.
+    let len = relative_normalized_buf::<P, true>(out, normalized_from, normalized_to).len();
+    &out[..len]
+}
+
 pub fn relative_alloc(from: &[u8], to: &[u8]) -> Result<Box<[u8]>, bun_alloc::AllocError> {
-    let result = relative_platform::<platform::Auto, false>(from, to);
+    let mut spill = Vec::new();
+    let result = relative_platform_spill::<platform::Auto>(&mut spill, from, to);
     Ok(Box::<[u8]>::from(result))
 }
 
@@ -2534,6 +2629,59 @@ mod tests {
             .unwrap_or(text_len)
     }
 
+    /// Returns `haystack_len` when `needle` does not occur, like the kernel.
+    #[unsafe(no_mangle)]
+    unsafe extern "C" fn highway_last_index_of_char(
+        haystack: *const u8,
+        haystack_len: usize,
+        needle: u8,
+    ) -> usize {
+        // SAFETY: test stub; callers pass a valid (ptr, len) pair.
+        let haystack = unsafe { core::slice::from_raw_parts(haystack, haystack_len) };
+        haystack
+            .iter()
+            .rposition(|&b| b == needle)
+            .unwrap_or(haystack_len)
+    }
+
+    #[unsafe(no_mangle)]
+    unsafe extern "C" fn highway_count_char(
+        haystack: *const u8,
+        haystack_len: usize,
+        needle: u8,
+    ) -> usize {
+        // SAFETY: test stub; callers pass a valid (ptr, len) pair.
+        let haystack = unsafe { core::slice::from_raw_parts(haystack, haystack_len) };
+        haystack.iter().filter(|&&b| b == needle).count()
+    }
+
+    /// Only linked, never reached: `strings::last_index_of_char_t::<u8>` (used
+    /// by `relative`) also names the `u16` kernel. Returns `usize::MAX` when
+    /// `needle` does not occur, like the kernel.
+    #[cfg(not(miri))]
+    #[unsafe(no_mangle)]
+    unsafe extern "C" fn highway_memrmem16(
+        haystack: *const u16,
+        haystack_len: usize,
+        needle: *const u16,
+        needle_len: usize,
+    ) -> usize {
+        // SAFETY: test stub; callers pass valid (ptr, len) pairs.
+        let (haystack, needle) = unsafe {
+            (
+                core::slice::from_raw_parts(haystack, haystack_len),
+                core::slice::from_raw_parts(needle, needle_len),
+            )
+        };
+        if needle.is_empty() {
+            return haystack_len;
+        }
+        (0..haystack_len.saturating_sub(needle_len - 1))
+            .rev()
+            .find(|&i| haystack[i..].starts_with(needle))
+            .unwrap_or(usize::MAX)
+    }
+
     #[test]
     fn normalize_string_spill_leaves_spill_untouched_when_the_input_fits() {
         let mut spill = Vec::new();
@@ -2709,5 +2857,98 @@ mod tests {
             join_string_buf_w_same::<platform::Windows>(&mut out, &[&long, &rest]),
             &expected[..]
         );
+    }
+
+    /// A single-component absolute path of exactly `len` bytes.
+    fn abs_path(len: usize, fill: u8) -> Vec<u8> {
+        let mut path = b"/".to_vec();
+        path.resize(len, fill);
+        path
+    }
+
+    #[test]
+    fn relative_spill_leaves_spill_untouched_when_the_result_fits() {
+        let mut spill = Vec::new();
+        assert_eq!(
+            relative_platform_spill::<platform::Posix>(&mut spill, b"/a/b", b"/a/c/d.js"),
+            b"../c/d.js"
+        );
+        assert_eq!(
+            relative_platform_spill::<platform::Posix>(&mut spill, b"/a/b", b"/a/b/c.js"),
+            b"c.js"
+        );
+        assert_eq!(
+            relative_platform_spill::<platform::Posix>(&mut spill, b"/a/b", b"/a/b"),
+            b""
+        );
+        assert!(spill.is_empty());
+    }
+
+    #[test]
+    fn relative_spill_spills_a_result_longer_than_a_path_buffer() {
+        // `to` fits in a PathBuffer; the added `..` levels push the result past one.
+        let to = abs_path(MAX_PATH_BYTES - 1, b'f');
+        let mut expected = b"../../../".to_vec();
+        expected.extend_from_slice(&to[1..]);
+        assert!(expected.len() > MAX_PATH_BYTES);
+
+        let mut spill = Vec::new();
+        assert_eq!(
+            relative_platform_spill::<platform::Posix>(&mut spill, b"/x/y/z", &to),
+            &expected[..]
+        );
+        assert!(!spill.is_empty());
+
+        // A shorter result after a longer one must not include the previous tail.
+        let to = abs_path(MAX_PATH_BYTES - 4, b'g');
+        let mut expected = b"../../../".to_vec();
+        expected.extend_from_slice(&to[1..]);
+        assert!(expected.len() > MAX_PATH_BYTES);
+        assert_eq!(
+            relative_platform_spill::<platform::Posix>(&mut spill, b"/x/y/z", &to),
+            &expected[..]
+        );
+    }
+
+    #[test]
+    fn relative_spill_accepts_inputs_longer_than_a_path_buffer() {
+        let mut spill = Vec::new();
+
+        let to = abs_path(MAX_PATH_BYTES * 2, b'h');
+        let mut expected = b"../".to_vec();
+        expected.extend_from_slice(&to[1..]);
+        assert_eq!(
+            relative_platform_spill::<platform::Posix>(&mut spill, b"/x", &to),
+            &expected[..]
+        );
+
+        // Every component of a long `from` becomes a `..`.
+        let components = MAX_PATH_BYTES;
+        let from = b"/d".repeat(components);
+        let mut expected = b"..".to_vec();
+        expected.extend_from_slice(&b"/..".repeat(components - 1));
+        expected.extend_from_slice(b"/e.js");
+        assert_eq!(
+            relative_platform_spill::<platform::Posix>(&mut spill, &from, b"/e.js"),
+            &expected[..]
+        );
+
+        // A short result must be copied out of the heap input scratch.
+        let dir = abs_path(MAX_PATH_BYTES + 1, b'k');
+        let mut file = dir.clone();
+        file.extend_from_slice(b"/e.js");
+        assert_eq!(
+            relative_platform_spill::<platform::Posix>(&mut spill, &dir, &file),
+            b"e.js"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn relative_alloc_handles_a_result_longer_than_a_path_buffer() {
+        let to = abs_path(MAX_PATH_BYTES - 1, b'm');
+        let mut expected = b"../../../".to_vec();
+        expected.extend_from_slice(&to[1..]);
+        assert_eq!(&*relative_alloc(b"/x/y/z", &to).unwrap(), &expected[..]);
     }
 }

--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -653,12 +653,9 @@ pub fn relative_buf_z<'a>(buf: &'a mut [u8], from: &[u8], to: &[u8]) -> &'a ZStr
     ZStr::from_buf(&buf[..], len)
 }
 
-/// Normalizes both inputs of a `relative` computation into `from_buf` and
-/// `to_buf`, resolving a non-absolute input against the top-level dir first
-/// (`to_scratch` holds the intermediate normalization of a non-absolute `to`).
-/// Each of the three buffers must hold [`relative_scratch_len`] bytes. The
-/// results borrow only `from_buf` and `to_buf`, so `to_scratch` is free again
-/// once this returns.
+/// Normalizes `from` and `to` into `from_buf` and `to_buf` (each
+/// [`relative_scratch_len`] bytes), resolving a non-absolute input against the
+/// top-level dir; `to_scratch` is intermediate space for a non-absolute `to`.
 fn relative_normalize_inputs<'f, 't, P: PlatformT>(
     from_buf: &'f mut [u8],
     to_buf: &'t mut [u8],
@@ -685,10 +682,8 @@ fn relative_normalize_inputs<'f, 't, P: PlatformT>(
             break 'brk &from_buf[0..path_len + 1];
         }
     } else {
-        // Avoid aliasing from_buf as both input (normalize result) and output
-        // (join target): normalize into to_buf as scratch, then join into
-        // from_buf. Safe because normalized_to is computed afterwards
-        // (overwrites to_buf anyway).
+        // Normalize into to_buf (overwritten below anyway), then join into
+        // from_buf, so from_buf is not both input and output.
         let norm_len = normalize_string_buf::<true, P, true>(from, &mut to_buf[..]).len();
         join_abs_string_buf::<P>(
             Fs::FileSystem::instance().top_level_dir(),
@@ -714,8 +709,7 @@ fn relative_normalize_inputs<'f, 't, P: PlatformT>(
             break 'brk &to_buf[0..path_len + 1];
         }
     } else {
-        // Same aliasing concern as above: normalize into to_scratch, then join
-        // into to_buf.
+        // As above: normalize into to_scratch, then join into to_buf.
         let norm_len = normalize_string_buf::<true, P, true>(to, to_scratch).len();
         join_abs_string_buf::<P>(
             Fs::FileSystem::instance().top_level_dir(),
@@ -727,11 +721,9 @@ fn relative_normalize_inputs<'f, 't, P: PlatformT>(
     (normalized_from, normalized_to)
 }
 
-/// Bytes each buffer handed to [`relative_normalize_inputs`] must hold: an
-/// input (joined onto the top-level dir when it is not absolute, which adds
-/// that dir and a separator) plus the leading separator slot and the one byte
-/// normalization can add (see [`normalize_string_spill`]), for both the
-/// intermediate and the final normalization.
+/// Bytes each [`relative_normalize_inputs`] buffer must hold: an input, the
+/// top-level dir it may be joined onto, a separator slot, and the byte
+/// normalization can add (see [`normalize_string_spill`]).
 fn relative_scratch_len<P: PlatformT>(from: &[u8], to: &[u8]) -> usize {
     let cwd_len = if P::P.is_absolute(from) && P::P.is_absolute(to) {
         0
@@ -741,10 +733,9 @@ fn relative_scratch_len<P: PlatformT>(from: &[u8], to: &[u8]) -> usize {
     cwd_len + from.len().max(to.len()) + 4
 }
 
-/// Upper bound on what [`relative_normalized_buf`] writes for these inputs:
-/// at most one `..` per component of `from` (three bytes each, counting its
-/// separator), one joining separator, then a suffix of `to`. Counting both
-/// separator styles over-approximates the component count on every platform.
+/// Upper bound on what [`relative_normalized_buf`] writes: one `..` per
+/// component of `from` (counting both separator styles over-approximates),
+/// one joining separator, then a suffix of `to`.
 fn relative_max_len(normalized_from: &[u8], normalized_to: &[u8]) -> usize {
     let from_components = strings::count_char(normalized_from, SEP_POSIX)
         + strings::count_char(normalized_from, SEP_WINDOWS)
@@ -752,19 +743,16 @@ fn relative_max_len(normalized_from: &[u8], normalized_to: &[u8]) -> usize {
     3 * from_components + 1 + normalized_to.len()
 }
 
-/// `from` and `to` must each fit in a `PathBuffer` and the result must fit in
-/// `buf`. The result is not bounded by the inputs: it is the tail of `to` plus
-/// one `..` per level of `from` outside their common prefix, so a `to` that
-/// fits in a `PathBuffer` can still relativize to something that does not.
-/// Use [`relative_platform_spill`] when that is possible.
+/// `from`, `to` and the result must each fit in a `PathBuffer`. The result can
+/// outgrow both inputs (a `..` per level of `from` outside the common prefix);
+/// use [`relative_platform_spill`] when that is possible.
 pub fn relative_platform_buf<'a, P: PlatformT, const ALWAYS_COPY: bool>(
     buf: &'a mut [u8],
     from: &[u8],
     to: &[u8],
 ) -> &'a [u8] {
-    // RELATIVE_FROM_BUF and RELATIVE_TO_BUF are independent allocations so the
-    // two `&mut` borrows below are disjoint. `buf` serves as the scratch for a
-    // non-absolute `to`; that use ends before the result is written into it.
+    // The thread-local bufs are independent allocations; `buf` is only scratch
+    // for a non-absolute `to`, and that use ends before the final write.
     let (normalized_from, normalized_to) = relative_normalize_inputs::<P>(
         RELATIVE_FROM_BUF.with(lazy_path_buf),
         RELATIVE_TO_BUF.with(lazy_path_buf),
@@ -788,11 +776,33 @@ pub fn relative_platform<P: PlatformT, const ALWAYS_COPY: bool>(
     )
 }
 
+/// [`relative_normalized`] without its length limit: the result uses the
+/// thread-local buffer when it fits and `spill` (grown as needed) otherwise.
+pub fn relative_normalized_spill<'a, P: PlatformT>(
+    spill: &'a mut Vec<u8>,
+    normalized_from: &[u8],
+    normalized_to: &[u8],
+) -> &'a [u8] {
+    let needed = relative_max_len(normalized_from, normalized_to);
+    let out: &'a mut [u8] = if needed <= MAX_PATH_BYTES {
+        // SAFETY: thread-local scratch; single live borrow per thread.
+        RELATIVE_TO_COMMON_PATH_BUF.with(lazy_path_buf)
+    } else {
+        if spill.len() < needed {
+            spill.resize(needed, 0);
+        }
+        spill.as_mut_slice()
+    };
+    // ALWAYS_COPY: the result must be a prefix of `out`, never a view into
+    // the caller's (possibly temporary) inputs.
+    let len = relative_normalized_buf::<P, true>(out, normalized_from, normalized_to).len();
+    &out[..len]
+}
+
 /// [`relative_platform`] without its length limits: the inputs and the result
 /// use the thread-local buffers when they fit, and otherwise heap scratch and
-/// `spill` (grown as needed) respectively. `spill` is untouched in the common
-/// case. Like `relative_platform`, the result is valid until the next
-/// `relative*` call on this thread.
+/// `spill` respectively. The result is valid until the next `relative*` call
+/// on this thread.
 pub fn relative_platform_spill<'a, P: PlatformT>(
     spill: &'a mut Vec<u8>,
     from: &[u8],
@@ -802,7 +812,9 @@ pub fn relative_platform_spill<'a, P: PlatformT>(
     let mut heap: Vec<u8>;
     let (from_buf, to_buf, to_scratch): (&mut [u8], &mut [u8], &mut [u8]) =
         if scratch_len <= MAX_PATH_BYTES {
-            // SAFETY: thread-local scratch; single live borrow per thread.
+            // SAFETY: thread-local scratch; single live borrow per thread. The
+            // common-path buf is only scratch here; its borrow ends before
+            // `relative_normalized_spill` reuses it for the result.
             (
                 RELATIVE_FROM_BUF.with(lazy_path_buf).as_mut_slice(),
                 RELATIVE_TO_BUF.with(lazy_path_buf).as_mut_slice(),
@@ -818,24 +830,7 @@ pub fn relative_platform_spill<'a, P: PlatformT>(
         };
     let (normalized_from, normalized_to) =
         relative_normalize_inputs::<P>(from_buf, to_buf, to_scratch, from, to);
-
-    let needed = relative_max_len(normalized_from, normalized_to);
-    let out: &'a mut [u8] = if needed <= MAX_PATH_BYTES {
-        // The scratch use of this buffer above (if any) is over: the normalized
-        // inputs live in the from/to buffers.
-        RELATIVE_TO_COMMON_PATH_BUF
-            .with(lazy_path_buf)
-            .as_mut_slice()
-    } else {
-        if spill.len() < needed {
-            spill.resize(needed, 0);
-        }
-        spill.as_mut_slice()
-    };
-    // ALWAYS_COPY, so that the result never aliases the (possibly heap) input
-    // scratch; it is a prefix of `out`, or empty.
-    let len = relative_normalized_buf::<P, true>(out, normalized_from, normalized_to).len();
-    &out[..len]
+    relative_normalized_spill::<P>(spill, normalized_from, normalized_to)
 }
 
 pub fn relative_alloc(from: &[u8], to: &[u8]) -> Result<Box<[u8]>, bun_alloc::AllocError> {
@@ -2655,9 +2650,8 @@ mod tests {
         haystack.iter().filter(|&&b| b == needle).count()
     }
 
-    /// Only linked, never reached: `strings::last_index_of_char_t::<u8>` (used
-    /// by `relative`) also names the `u16` kernel. Returns `usize::MAX` when
-    /// `needle` does not occur, like the kernel.
+    /// Only linked, never reached: `strings::last_index_of_char_t::<u8>` also
+    /// names the `u16` kernel.
     #[cfg(not(miri))]
     #[unsafe(no_mangle)]
     unsafe extern "C" fn highway_memrmem16(

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -7,6 +7,7 @@ import {
   bunRun,
   isASAN,
   isDebug,
+  isLinux,
   isMacOS,
   isWindows,
   tempDir,
@@ -1992,3 +1993,80 @@ test.skipIf(isWindows)(
   },
   30_000,
 );
+
+describe.concurrent("source whose path is close to the path buffer size", () => {
+  // Bun's fixed path buffer (MAX_PATH_BYTES): PATH_MAX on Linux and macOS, the
+  // UTF-8 worst case of a 32767-character path on Windows.
+  const MAX_PATH_BYTES = isWindows ? 32767 * 3 + 1 : isLinux ? 4096 : 1024;
+  // The path itself fits in the buffer (and, on Linux and macOS, on disk); the
+  // paths derived from it by relativizing against the cwd below do not.
+  const PATH_LENGTH = MAX_PATH_BYTES - 32;
+
+  async function bundle(mode: string) {
+    using dir = tempDir("bun-build-long-source-path", {});
+    // Relativizing against the cwd adds `../` per level of the cwd outside the
+    // common prefix, so a cwd this deep puts the relative form of the long
+    // path past MAX_PATH_BYTES however long the temp dir itself is.
+    const depth = Math.ceil((String(dir).length + 64) / 3);
+    const cwd = join(String(dir), "cwd", ...Array(depth).fill("a"));
+    mkdirSync(cwd, { recursive: true });
+
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        join(import.meta.dir, "fixtures", "long-source-path-fixture.ts"),
+        mode,
+        String(PATH_LENGTH),
+        String(dir),
+      ],
+      env: bunEnv,
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // The bug was a panic, which shows up here as a non-zero exit and the
+    // crash report on stderr.
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+
+    const result = JSON.parse(stdout);
+    expect(result.path).toHaveLength(PATH_LENGTH);
+    // The display form Bun derives from the path, as node computes it.
+    const relativePath = path.relative(result.cwd, result.path).replaceAll("\\", "/");
+    expect(relativePath.length).toBeGreaterThan(MAX_PATH_BYTES);
+    expect(result.logs).toEqual([]);
+    expect(result.success).toBe(true);
+    return { ...result, relativePath };
+  }
+
+  test("as an in-memory entry point", async () => {
+    const { inputs, sources, relativePath } = await bundle("entry");
+    expect(inputs).toEqual([relativePath]);
+    expect(sources).toEqual([relativePath]);
+  });
+
+  test("as an in-memory asset", async () => {
+    const { outputs } = await bundle("asset");
+    expect(outputs).toEqual([
+      expect.stringMatching(/(^|\/)entry\.js$/),
+      expect.stringMatching(/(^|\/)entry\.js\.map$/),
+      expect.stringMatching(/(^|\/)e*image-[a-z0-9]+\.png$/),
+    ]);
+  });
+
+  // A real path can only get close to the buffer size where the buffer is
+  // sized after PATH_MAX; the Windows buffer is far larger than any path the
+  // filesystem accepts.
+  test.skipIf(isWindows)("as an imported file on disk", async () => {
+    const { inputs, sources, relativePath } = await bundle("import");
+    expect(inputs).toEqual(["entry.js", relativePath]);
+    expect(sources).toEqual([relativePath, "entry.js"]);
+  });
+
+  test.skipIf(isWindows)("as an imported file on disk, with an onResolve plugin that declines it", async () => {
+    const { inputs, sources, relativePath } = await bundle("import-plugin");
+    expect(inputs).toEqual(["entry.js", relativePath]);
+    expect(sources).toEqual([relativePath, "entry.js"]);
+  });
+});

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -2064,6 +2064,35 @@ describe.concurrent("source whose path is close to or beyond the path buffer siz
     ]);
   });
 
+  test("as an in-memory asset named with a [dir] template", async () => {
+    const { outputs, relativePath } = await bundle("asset-dir");
+    // [dir] is the asset's directory relative to the root (the cwd here), with
+    // each `..` level written as `_.._`, so the output path is even longer than
+    // the source path. It is relativized again when chunks refer to it.
+    const relativeDir = relativePath.slice(0, relativePath.lastIndexOf("/"));
+    const [, , asset] = outputs;
+    expect(outputs).toEqual([
+      expect.stringMatching(/(^|[\\/])entry\.js$/),
+      expect.stringMatching(/(^|[\\/])entry\.js\.map$/),
+      expect.stringMatching(/(^|[\\/])e*image-[a-z0-9]+\.png$/),
+    ]);
+    expect(asset.replaceAll("\\", "/")).toStartWith(`./${relativeDir.replaceAll("..", "_.._")}/`);
+    expect(asset.length).toBeGreaterThan(MAX_PATH_BYTES);
+  });
+
+  test("as a dynamically imported in-memory module, with chunks named with a [dir] template", async () => {
+    const { outputs, path: modulePath } = await bundle("chunk-dir");
+    // The module's chunk keeps the module's directory, so the relative path
+    // from the importing chunk to it, written into the import(), is about as
+    // long as the source path itself.
+    const chunks = outputs.filter(output => /lazy-[a-z0-9]+\.js(\.map)?$/.test(output));
+    expect(chunks).toEqual([
+      expect.stringMatching(/(^|[\\/])e*lazy-[a-z0-9]+\.js$/),
+      expect.stringMatching(/(^|[\\/])e*lazy-[a-z0-9]+\.js\.map$/),
+    ]);
+    expect(chunks[0].length).toBeGreaterThan(modulePath.length);
+  });
+
   // A real path can only get close to the buffer size where the buffer is
   // sized after PATH_MAX; the Windows buffer is far larger than any path the
   // filesystem accepts.

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -2102,6 +2102,12 @@ describe.concurrent("source whose path is close to or beyond the path buffer siz
     expect(sources).toEqual([relativePath, "entry.js"]);
   });
 
+  test.skipIf(isWindows)("as a bun build --no-bundle entry point on disk", async () => {
+    // The transform-only path relativizes the entry for its display path and
+    // for the entry naming placeholders.
+    await bundle("no-bundle");
+  });
+
   test.skipIf(isWindows)("as an HTML file on disk imported by a server-target entry point", async () => {
     // The HTML import manifest embedded in the server chunk keys its entries
     // by the cwd-relative source path.

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -1994,15 +1994,18 @@ test.skipIf(isWindows)(
   30_000,
 );
 
-describe.concurrent("source whose path is close to the path buffer size", () => {
+describe.concurrent("source whose path is close to or beyond the path buffer size", () => {
   // Bun's fixed path buffer (MAX_PATH_BYTES): PATH_MAX on Linux and macOS, the
   // UTF-8 worst case of a 32767-character path on Windows.
   const MAX_PATH_BYTES = isWindows ? 32767 * 3 + 1 : isLinux ? 4096 : 1024;
   // The path itself fits in the buffer (and, on Linux and macOS, on disk); the
   // paths derived from it by relativizing against the cwd below do not.
   const PATH_LENGTH = MAX_PATH_BYTES - 32;
+  // Not even the path itself fits. Only a plugin can hand the bundler one of
+  // these: nothing on disk can be this long.
+  const OVERSIZED_PATH_LENGTH = MAX_PATH_BYTES * 2;
 
-  async function bundle(mode: string) {
+  async function build(mode: string, length: number) {
     using dir = tempDir("bun-build-long-source-path", {});
     // Relativizing against the cwd adds `../` per level of the cwd outside the
     // common prefix, so a cwd this deep puts the relative form of the long
@@ -2016,7 +2019,7 @@ describe.concurrent("source whose path is close to the path buffer size", () => 
         bunExe(),
         join(import.meta.dir, "fixtures", "long-source-path-fixture.ts"),
         mode,
-        String(PATH_LENGTH),
+        String(length),
         String(dir),
       ],
       env: bunEnv,
@@ -2031,13 +2034,18 @@ describe.concurrent("source whose path is close to the path buffer size", () => 
     expect(exitCode).toBe(0);
 
     const result = JSON.parse(stdout);
-    expect(result.path).toHaveLength(PATH_LENGTH);
+    expect(result.path).toHaveLength(length);
     // The display form Bun derives from the path, as node computes it.
     const relativePath = path.relative(result.cwd, result.path).replaceAll("\\", "/");
     expect(relativePath.length).toBeGreaterThan(MAX_PATH_BYTES);
+    return { ...result, relativePath };
+  }
+
+  async function bundle(mode: string, length = PATH_LENGTH) {
+    const result = await build(mode, length);
     expect(result.logs).toEqual([]);
     expect(result.success).toBe(true);
-    return { ...result, relativePath };
+    return result;
   }
 
   test("as an in-memory entry point", async () => {
@@ -2048,10 +2056,11 @@ describe.concurrent("source whose path is close to the path buffer size", () => 
 
   test("as an in-memory asset", async () => {
     const { outputs } = await bundle("asset");
+    // Output paths use either separator on Windows (`./entry.js` next to `.\image.png`).
     expect(outputs).toEqual([
-      expect.stringMatching(/(^|\/)entry\.js$/),
-      expect.stringMatching(/(^|\/)entry\.js\.map$/),
-      expect.stringMatching(/(^|\/)e*image-[a-z0-9]+\.png$/),
+      expect.stringMatching(/(^|[\\/])entry\.js$/),
+      expect.stringMatching(/(^|[\\/])entry\.js\.map$/),
+      expect.stringMatching(/(^|[\\/])e*image-[a-z0-9]+\.png$/),
     ]);
   });
 
@@ -2069,4 +2078,25 @@ describe.concurrent("source whose path is close to the path buffer size", () => 
     expect(inputs).toEqual(["entry.js", relativePath]);
     expect(sources).toEqual([relativePath, "entry.js"]);
   });
+
+  for (const [description, length] of [
+    ["close to the path buffer size", PATH_LENGTH],
+    ["longer than the path buffer", OVERSIZED_PATH_LENGTH],
+  ] as const) {
+    test(`as a path ${description} returned by an onResolve plugin and loaded by an onLoad plugin`, async () => {
+      const { inputs, sources, relativePath } = await bundle("load-plugin", length);
+      expect(inputs).toEqual(["entry.js", relativePath]);
+      expect(sources).toEqual([relativePath, "entry.js"]);
+    });
+
+    test(`as a path ${description} returned by an onResolve plugin that does not exist on disk`, async () => {
+      const { success, logs, path: resolvedPath } = await build("resolve-plugin", length);
+      // Reading it fails (ENOENT, or ENAMETOOLONG once it is longer than the
+      // filesystem allows) and is reported like any other unreadable import.
+      expect(logs).toHaveLength(1);
+      expect(logs[0]).toMatch(/^BuildMessage: (File not found|\w+ reading file:) "/);
+      expect(logs[0]).toContain(`"${resolvedPath}"`);
+      expect(success).toBe(false);
+    });
+  }
 });

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -2073,6 +2073,13 @@ describe.concurrent("source whose path is close to or beyond the path buffer siz
     expect(sources).toEqual([relativePath, "entry.js"]);
   });
 
+  test.skipIf(isWindows)("as an HTML file on disk imported by a server-target entry point", async () => {
+    // The HTML import manifest embedded in the server chunk keys its entries
+    // by the cwd-relative source path.
+    const { inputs, relativePath } = await bundle("html-import");
+    expect(inputs).toContain(relativePath);
+  });
+
   test.skipIf(isWindows)("as an imported file on disk, with an onResolve plugin that declines it", async () => {
     const { inputs, sources, relativePath } = await bundle("import-plugin");
     expect(inputs).toEqual(["entry.js", relativePath]);

--- a/test/bundler/fixtures/long-source-path-fixture.ts
+++ b/test/bundler/fixtures/long-source-path-fixture.ts
@@ -1,0 +1,86 @@
+// Bundles a source whose absolute path is `length` bytes long, from whatever
+// cwd the test picked, and reports what the build said about it. Spawned as a
+// separate process because the bug this covers was a crash.
+//
+//   bun long-source-path-fixture.ts <mode> <length> <dir>
+//
+// Modes:
+//   entry          in-memory (`files`) entry point at the long path
+//   asset          in-memory entry point importing an in-memory image at the long path
+//   import         entry point on disk importing a file on disk at the long path
+//   import-plugin  like `import`, with an onResolve plugin that declines every path
+//                  (imports then reach the resolver through the plugin code path)
+import type { BuildConfig } from "bun";
+import { mkdirSync, realpathSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+
+const [mode, lengthArg, dir] = process.argv.slice(2);
+const length = Number(lengthArg);
+
+// `<prefix>/<directory segments, each well under NAME_MAX>/<padding><basename>`,
+// exactly `length` bytes long.
+function longPath(prefix: string, basename: string): string {
+  const segment = Buffer.alloc(200, "d").toString();
+  let path = prefix;
+  while (path.length + 1 + segment.length + 1 + basename.length <= length) {
+    path += "/" + segment;
+  }
+  const padding = length - (path.length + 1 + basename.length);
+  if (padding < 0) throw new Error(`${prefix} leaves no room for a ${length} byte path`);
+  return `${path}/${Buffer.alloc(padding, "e")}${basename}`;
+}
+
+// The filesystem root, without its trailing separator (`""` on POSIX, the
+// cwd's drive on Windows), so that the in-memory paths are absolute everywhere.
+const root = resolve("/").slice(0, -1);
+
+let path: string;
+let options: BuildConfig;
+
+switch (mode) {
+  case "entry": {
+    path = longPath(root, "entry.js");
+    options = { entrypoints: [path], files: { [path]: "console.log(1);" } };
+    break;
+  }
+  case "asset": {
+    path = longPath(root, "image.png");
+    const entry = join(process.cwd(), "entry.js");
+    options = {
+      entrypoints: [entry],
+      files: { [entry]: `import url from ${JSON.stringify(path)}; console.log(url);`, [path]: "not really a png" },
+    };
+    break;
+  }
+  case "import":
+  case "import-plugin": {
+    path = longPath(realpathSync(dir), "dep.js");
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, "export default 42;");
+    writeFileSync("entry.js", `import value from ${JSON.stringify(path)}; console.log(value);`);
+    options = {
+      entrypoints: ["./entry.js"],
+      plugins:
+        mode === "import-plugin"
+          ? [{ name: "declines everything", setup: build => build.onResolve({ filter: /.*/ }, () => undefined) }]
+          : [],
+    };
+    break;
+  }
+  default:
+    throw new Error(`unknown mode ${mode}`);
+}
+
+const result = await Bun.build({ ...options, metafile: true, sourcemap: "external", throw: false });
+const map = result.outputs.find(output => output.path.endsWith(".map"));
+console.log(
+  JSON.stringify({
+    success: result.success,
+    logs: result.logs.map(String),
+    cwd: process.cwd(),
+    path,
+    inputs: result.metafile ? Object.keys(result.metafile.inputs) : null,
+    sources: map ? JSON.parse(await map.text()).sources : null,
+    outputs: result.outputs.map(output => output.path),
+  }),
+);

--- a/test/bundler/fixtures/long-source-path-fixture.ts
+++ b/test/bundler/fixtures/long-source-path-fixture.ts
@@ -10,6 +10,12 @@
 //   import         entry point on disk importing a file on disk at the long path
 //   import-plugin  like `import`, with an onResolve plugin that declines every path
 //                  (imports then reach the resolver through the plugin code path)
+//   resolve-plugin entry point on disk whose import an onResolve plugin resolves to the
+//                  long path; nothing exists there, so the build reports the failed read
+//   load-plugin    like `resolve-plugin`, with an onLoad plugin supplying the contents
+//
+// A plugin can return a path of any length, so the last two modes are the
+// ones that accept a `length` beyond the path buffer.
 import type { BuildConfig } from "bun";
 import { mkdirSync, realpathSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
@@ -64,6 +70,26 @@ switch (mode) {
         mode === "import-plugin"
           ? [{ name: "declines everything", setup: build => build.onResolve({ filter: /.*/ }, () => undefined) }]
           : [],
+    };
+    break;
+  }
+  case "resolve-plugin":
+  case "load-plugin": {
+    path = longPath(root, "dep.js");
+    writeFileSync("entry.js", `import value from "./dep.js"; console.log(value);`);
+    options = {
+      entrypoints: ["./entry.js"],
+      plugins: [
+        {
+          name: "resolves to the long path",
+          setup(build) {
+            build.onResolve({ filter: /^\.\/dep\.js$/ }, () => ({ path }));
+            if (mode === "load-plugin") {
+              build.onLoad({ filter: /dep\.js$/ }, () => ({ contents: "export default 42;", loader: "js" }));
+            }
+          },
+        },
+      ],
     };
     break;
   }

--- a/test/bundler/fixtures/long-source-path-fixture.ts
+++ b/test/bundler/fixtures/long-source-path-fixture.ts
@@ -7,6 +7,11 @@
 // Modes:
 //   entry          in-memory (`files`) entry point at the long path
 //   asset          in-memory entry point importing an in-memory image at the long path
+//   asset-dir      like `asset`, with an asset naming template that starts with [dir]
+//                  (the asset's output path then contains the long directory too)
+//   chunk-dir      in-memory entry point dynamically importing an in-memory module at the
+//                  long path, with splitting and a chunk naming template that starts with
+//                  [dir] (the module's chunk is emitted under the long directory)
 //   import         entry point on disk importing a file on disk at the long path
 //   import-plugin  like `import`, with an onResolve plugin that declines every path
 //                  (imports then reach the resolver through the plugin code path)
@@ -51,12 +56,28 @@ switch (mode) {
     options = { entrypoints: [path], files: { [path]: "console.log(1);" } };
     break;
   }
-  case "asset": {
+  case "asset":
+  case "asset-dir": {
     path = longPath(root, "image.png");
     const entry = join(process.cwd(), "entry.js");
     options = {
       entrypoints: [entry],
       files: { [entry]: `import url from ${JSON.stringify(path)}; console.log(url);`, [path]: "not really a png" },
+      naming: mode === "asset-dir" ? { asset: "[dir]/[name]-[hash].[ext]" } : undefined,
+    };
+    break;
+  }
+  case "chunk-dir": {
+    path = longPath(root, "lazy.js");
+    const entry = join(process.cwd(), "entry.js");
+    options = {
+      entrypoints: [entry],
+      files: { [entry]: `import(${JSON.stringify(path)}).then(console.log);`, [path]: "export default 42;" },
+      // Without this the root would be the common ancestor of both modules,
+      // the filesystem root, and [dir] would not contain the cwd's `..` levels.
+      root: process.cwd(),
+      splitting: true,
+      naming: { chunk: "[dir]/[name]-[hash].[ext]" },
     };
     break;
   }

--- a/test/bundler/fixtures/long-source-path-fixture.ts
+++ b/test/bundler/fixtures/long-source-path-fixture.ts
@@ -10,6 +10,8 @@
 //   import         entry point on disk importing a file on disk at the long path
 //   import-plugin  like `import`, with an onResolve plugin that declines every path
 //                  (imports then reach the resolver through the plugin code path)
+//   html-import    server-target entry point on disk importing an HTML file on disk at
+//                  the long path (its path becomes a key in the HTML import manifest)
 //   resolve-plugin entry point on disk whose import an onResolve plugin resolves to the
 //                  long path; nothing exists there, so the build reports the failed read
 //   load-plugin    like `resolve-plugin`, with an onLoad plugin supplying the contents
@@ -71,6 +73,15 @@ switch (mode) {
           ? [{ name: "declines everything", setup: build => build.onResolve({ filter: /.*/ }, () => undefined) }]
           : [],
     };
+    break;
+  }
+  case "html-import": {
+    path = longPath(realpathSync(dir), "index.html");
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, `<!DOCTYPE html><html><head></head><body><script src="./app.js"></script></body></html>`);
+    writeFileSync(join(dirname(path), "app.js"), "console.log(1);");
+    writeFileSync("entry.js", `import index from ${JSON.stringify(path)}; console.log(typeof index);`);
+    options = { entrypoints: ["./entry.js"], target: "bun" };
     break;
   }
   case "resolve-plugin":

--- a/test/bundler/fixtures/long-source-path-fixture.ts
+++ b/test/bundler/fixtures/long-source-path-fixture.ts
@@ -17,6 +17,8 @@
 //                  (imports then reach the resolver through the plugin code path)
 //   html-import    server-target entry point on disk importing an HTML file on disk at
 //                  the long path (its path becomes a key in the HTML import manifest)
+//   no-bundle      `bun build --no-bundle` of an entry point on disk at the long path
+//                  (the transform-only path relativizes it for `pretty` and naming)
 //   resolve-plugin entry point on disk whose import an onResolve plugin resolves to the
 //                  long path; nothing exists there, so the build reports the failed read
 //   load-plugin    like `resolve-plugin`, with an onLoad plugin supplying the contents
@@ -51,6 +53,28 @@ let path: string;
 let options: BuildConfig;
 
 switch (mode) {
+  case "no-bundle": {
+    path = longPath(realpathSync(dir), "entry.js");
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, "console.log(1);");
+    const child = Bun.spawnSync({
+      cmd: [process.execPath, "build", "--no-bundle", path],
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    console.log(
+      JSON.stringify({
+        success: child.exitCode === 0,
+        logs: child.exitCode === 0 ? [] : [child.stderr.toString()],
+        cwd: process.cwd(),
+        path,
+        inputs: null,
+        sources: null,
+        outputs: null,
+      }),
+    );
+    process.exit(0);
+  }
   case "entry": {
     path = longPath(root, "entry.js");
     options = { entrypoints: [path], files: { [path]: "console.log(1);" } };


### PR DESCRIPTION
### Problem

- Bundling a source whose absolute path is close to `MAX_PATH_BYTES` (4096 on Linux, 1024 on macOS) aborts the process instead of building or reporting an error:
  ```
  panic: range end index 4130 out of range for slice of length 4096
  ```
  Top frames: `resolve_path::relative_to_common_path` <- `relative_normalized_buf` <- `relative_platform_buf` <- `bundle_v2::generic_path_with_pretty_initialized`.
- The path itself fits in a `PathBuffer` (and, on Linux and macOS, on disk). What does not fit is its relative form: `relative(cwd, path)` is the tail of `path` plus a `../` for every level of `cwd` outside the common prefix, so it is longer than `path` whenever the cwd is a few levels deep. `relative_platform_buf` (`src/paths/resolve_path.rs`) writes that into a fixed `PathBuffer` with no length check.
- The bundler relativizes every source path against the cwd, so one long path reaches this several times. Each of these aborts on current main:
  - `generic_path_with_pretty_initialized` (`bundle_v2.rs`): the display path (`Path.pretty`, used for metafile keys and messages) of every entry point and import; reached from `enqueue_entry_item`, `resolve_import_records` and the onResolve plugin paths.
  - `run_resolver` (`bundle_v2.rs`): same computation for imports when an onResolve plugin declined the path.
  - `process_files_to_copy` (`bundle_v2.rs`): the name of a `file`-loader asset.
  - `relative_alloc`, used by `computeChunks` for the `[dir]` placeholder and by `LinkerContext::source_map_relative_path` for the sourcemap `sources` entries. With only the first site fixed, the entry-point and import cases above still abort here (verified by temporarily reverting just that part).
  - Review pointed at the HTML import manifest (`HTMLImportManifest.rs`), which keys its entries by the same relative path; exercising that (a server-target build importing an HTML file at a long path) showed the output names derived from the long path also reach the chunk piece URL substitution: `Chunk.rs` `code_standalone` (both the size-counting and the writing pass), the isolated-hash mixing in `LinkerContext.rs`, and the linked-sourcemap URL in `generateChunksInParallel.rs`.
  - Review also pointed at the transform-only path (`bun build --no-bundle`, `transpiler.rs`), which relativizes the entry three times: entry normalization in `normalize_entry_point_path`, the `pretty` display path, and the entry naming placeholders in `transform_only_dest_path`. Confirmed: the same abort on 1.4.0.
- Supersedes #35853, which addressed the first site only (for paths returned by onResolve plugins) and has been conflicting with main since July. This PR covers the same overflow plus the sites the same input hits next.
- Overlaps textually with two other open PRs that add spill helpers for other symptoms: #38392 (`relative_alloc` in `resolve_path.rs`, for `_nodeModulePaths` and the runtime linker) and #37502 (the rendering of naming templates, touching the same `Chunk.rs`, `LinkerContext.rs` and `generateChunksInParallel.rs` sites). Merging either of them together with this branch conflicts in those files, so whichever lands second needs a rebase onto the other's helpers; none of the three fixes another's case.

### Fix

- `src/paths/resolve_path.rs`: split the input normalization out of `relative_platform_buf` (unchanged behavior, it still uses the thread-local buffers) and add `relative_platform_spill`: it sizes the scratch from the inputs and the result from `relative_max_len` (a bound derived from the component count of `from` and the length of `to`), and uses the thread-local buffers when those fit, otherwise heap scratch and a caller-owned `Vec`. Same shape as the existing `normalize_string_spill` / `join_spill` (#37526). Its result-sizing half is exposed as `relative_normalized_spill` for callers whose inputs are already normalized. `relative_alloc` now goes through it; it returns an owned box anyway, so no caller is affected.
- `src/bundler/bundle_v2.rs`: the three sites above use `relative_platform_spill`. `generic_path_with_pretty_initialized` also no longer assembles the result in a `PathBuffer`: the `ssr:` and `namespace:` forms were written with `FixedBufferStream` and errors ignored, which silently truncated them once the relative part could be long. `dupe_alloc` copies the display path into the bundle arena regardless of how it was built. The dev-server cached-file branch computed the same relative path into fields that the next statement overwrote; that dead computation is removed rather than converted.
- `src/bundler/HTMLImportManifest.rs`, `LinkerContext.rs`, `Chunk.rs`, `linker_context/generateChunksInParallel.rs`: the manifest keys, the chunk content hash, the piece URL substitution (including its posix-normalization scratch copy, previously also a fixed `PathBuffer`), and the linked-sourcemap URL use the spill helpers. Rebase note: #40518 replaced the recursive isolated-hash walk with `final_chunk_hashes`; the spill conversion of its asset-path arm carried over to the new function unchanged.
- `src/bundler/transpiler.rs`: the three transform-only relativizations use `relative_platform_spill`.
- Why this is correct: `pretty`, asset names, `[dir]`, manifest keys, substituted URLs and sourcemap `sources` are display strings and output names; unlike `Path.text` they are never passed to the filesystem, so there is no `PATH_MAX` for them to respect. The only thing bounding them to `MAX_PATH_BYTES` was the scratch buffer. The common case is unchanged: the bound is a length check plus two `count_char` calls over the cwd, and the `Vec`s stay unallocated unless something spills.
- Verified:
  - `test/bundler/bun-build-api.test.ts`, `"source whose path is close to or beyond the path buffer size"`: 12 subprocess builds driven by `test/bundler/fixtures/long-source-path-fixture.ts`, each from a cwd deep enough that the relative form of the long path is longer than `MAX_PATH_BYTES` (asserted): an in-memory entry point; an in-memory `file`-loader asset, with the default naming and with a `[dir]` template (its output path then contains the `_.._` levels and is itself longer than a buffer); a module reached through `import()` with `splitting` and a `[dir]` chunk template; a file on disk near `PATH_MAX`, imported directly and through a declining onResolve plugin; a `bun build --no-bundle` entry on disk; a server-target entry importing an HTML file on disk; and an onResolve plugin returning a path close to the buffer size or twice it, each with an onLoad plugin serving it (build succeeds) and without (the build reports the unreadable file). The successful cases check the metafile keys, sourcemap `sources` or output names. Every case aborts on 1.4.0, with the panic above or its `slice of length 4095` variant (an input rather than the result outgrowing a buffer), and passes with this change on Linux and Windows x64; the two `[dir]` cases also abort with only the `Chunk.rs` and `LinkerContext.rs` parts of this change reverted. The on-disk modes are skipped on Windows, where no real path gets near the 98302-byte buffer.
  - `cargo test -p bun_paths` (4 new unit tests: fast path leaves the spill untouched, result longer than a buffer, inputs longer than a buffer including a short result that must be copied out of the heap scratch, and `relative_alloc` itself, which panics on the old code) and `bun run rust:miri -p bun_paths`, since `bun_paths` is in the Miri CI set.
  - `bun bd test` on `bun-build-api`, `bundler_files`, `metafile`, `bundler_naming`, `bundler_plugin`, `bundler_loader`, `bundler_splitting`, `bundler_edgecase`, `bundler_html`, `bundler_npm`, `bundler_compile`, `node/path` and `install/bun-link`, `bun-workspaces`: no new failures (`bun-link`'s "without crashing" case, the 400-builds stress test in `bun-build-api` and `bundler_compile`'s `HelloWorldWithProcessVersionsBun` fail the same way without this change on a debug build here).
  - `cargo clippy -p bun_paths -p bun_bundler`, `cargo check` of both crates for `x86_64-pc-windows-msvc`.

### Background

- `PathBuffer` / `MAX_PATH_BYTES`: Bun's fixed-size path scratch buffer (`[u8; 4096]` on Linux, 1024 on macOS, 98302 on Windows). Most of `resolve_path` writes into one of these, or into a thread-local one, and relies on the inputs being real paths, which the OS already limits to that size.
- `Path.text` vs `Path.pretty`: `text` is the canonical absolute path a source was read from; `pretty` is the cwd-relative display form shown in messages and used as the metafile key. `generic_path_with_pretty_initialized` computes `pretty` once per source when it enters the graph.
- `*_spill` helpers: the convention in `resolve_path.rs` for inputs of unbounded length. The helper computes the space it needs, uses its usual fixed buffer when that fits, and otherwise grows a `Vec` the caller passes in, so the fast path allocates nothing.
- `relative_alloc`: the owned-result variant of `relative`, used where the result is stored rather than consumed immediately (chunk templates, sourcemaps).
- HTML imports: a server-target build can `import index from "./index.html"`; the bundler then emits browser chunks for the page and embeds a JSON manifest (the HTML import manifest) into the server chunk, keyed by each source's cwd-relative path.
- Chunk pieces: chunk contents are assembled from pieces separated by placeholders; each placeholder is replaced by the path from the importing chunk to the referenced chunk or asset, which is where the piece URL substitution computes relative paths.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bun-build-api.test.ts

<!-- robobun:evidence:end -->


