### PR TITLE
serve: reload() refuses a config that would leave the server with no handler

### DIFF
--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1461,7 +1461,8 @@ fn serve(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSVa
             crate::server::server_config::FromJSOptions {
                 allow_bake_config: bun_core::FeatureFlags::bake(),
                 is_fetch_required: true,
-                has_user_routes: false,
+                previous_fetch: false,
+                previous_routes: false,
             },
         )?;
 

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -1650,11 +1650,12 @@ impl ServerConfig {
 pub struct FromJSOptions {
     pub(crate) allow_bake_config: bool,
     pub(crate) is_fetch_required: bool,
-    /// `reload()` keeps the running server's `fetch` (or node handler) when
-    /// the new config omits it, and its routes when the new config has no
-    /// `routes` object at all; a `routes` object replaces them. So a reload
-    /// that names no handler is fine on the strength of these, except
-    /// `routes: {}` on a server whose only handler was its routes.
+    /// What the running server keeps answering with when a `reload()` config
+    /// names no handler, as `on_reload_from_zig` applies it: `fetch` stays
+    /// unless the new config replaces it, and callback routes stay as long as
+    /// the new config has no `routes` object at all (`routes: {}` replaces
+    /// them). Static routes and the node:http handler are replaced on every
+    /// reload, so they count for nothing here. Both are false for `Bun.serve()`.
     pub(crate) previous_fetch: bool,
     pub(crate) previous_routes: bool,
 }

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -1370,8 +1370,9 @@ impl ServerConfig {
             args.on_request = on_request_;
         } else if args.bake.is_none()
             && !args.is_node_http_server
-            && ((args.static_routes.len() + args.user_routes_to_build.len()) == 0
-                && !opts.has_user_routes)
+            && (args.static_routes.len() + args.user_routes_to_build.len()) == 0
+            && !opts.previous_fetch
+            && !(opts.previous_routes && !args.had_routes_object)
             && opts.is_fetch_required
         {
             if global.has_exception() {
@@ -1649,7 +1650,13 @@ impl ServerConfig {
 pub struct FromJSOptions {
     pub(crate) allow_bake_config: bool,
     pub(crate) is_fetch_required: bool,
-    pub(crate) has_user_routes: bool,
+    /// `reload()` keeps the running server's `fetch` (or node handler) when
+    /// the new config omits it, and its routes when the new config has no
+    /// `routes` object at all; a `routes` object replaces them. So a reload
+    /// that names no handler is fine on the strength of these, except
+    /// `routes: {}` on a server whose only handler was its routes.
+    pub(crate) previous_fetch: bool,
+    pub(crate) previous_routes: bool,
 }
 
 impl Default for FromJSOptions {
@@ -1657,7 +1664,8 @@ impl Default for FromJSOptions {
         Self {
             allow_bake_config: true,
             is_fetch_required: true,
-            has_user_routes: false,
+            previous_fetch: false,
+            previous_routes: false,
         }
     }
 }

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2395,7 +2395,10 @@ where
             server_config::FromJSOptions {
                 allow_bake_config: false,
                 is_fetch_required: true,
-                has_user_routes: !self.user_routes.is_empty(),
+                previous_fetch: !self.config.on_request.is_empty_or_undefined_or_null()
+                    || !self.config.on_node_http_request.is_empty(),
+                previous_routes: !self.user_routes.is_empty()
+                    || !self.config.static_routes.is_empty(),
             },
         )?;
         if global.has_exception() {

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2395,10 +2395,8 @@ where
             server_config::FromJSOptions {
                 allow_bake_config: false,
                 is_fetch_required: true,
-                previous_fetch: !self.config.on_request.is_empty_or_undefined_or_null()
-                    || !self.config.on_node_http_request.is_empty(),
-                previous_routes: !self.user_routes.is_empty()
-                    || !self.config.static_routes.is_empty(),
+                previous_fetch: !self.config.on_request.is_empty_or_undefined_or_null(),
+                previous_routes: !self.user_routes.is_empty(),
             },
         )?;
         if global.has_exception() {

--- a/test/js/bun/http/bun-serve-routes.test.ts
+++ b/test/js/bun/http/bun-serve-routes.test.ts
@@ -618,6 +618,39 @@ describe("route reloading", () => {
   });
 });
 
+describe("reload() keeps the server able to answer", () => {
+  it("rejects routes: {} on a routes-only server, and keeps serving the old routes", async () => {
+    using server = Bun.serve({
+      port: 0,
+      routes: { "/": () => new Response("routes") },
+    });
+    // The routes are the only handler; taking them away without adding a fetch
+    // would leave nothing to answer requests, which is what the same check
+    // refuses at Bun.serve() time.
+    expect(() => server.reload({ routes: {} } as ServeOptions)).toThrow("Bun.serve() needs either:");
+    expect(await (await fetch(server.url)).text()).toBe("routes");
+  });
+
+  it("allows routes: {} when the server keeps its fetch handler", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch: () => new Response("fetch"),
+      routes: { "/": () => new Response("routes") },
+    });
+    server.reload({ routes: {} } as ServeOptions);
+    expect(await (await fetch(server.url)).text()).toBe("fetch");
+  });
+
+  it("allows a reload that names no handler at all on a routes-only server", async () => {
+    using server = Bun.serve({
+      port: 0,
+      routes: { "/": () => new Response("routes") },
+    });
+    server.reload({ development: false } as ServeOptions);
+    expect(await (await fetch(server.url)).text()).toBe("routes");
+  });
+});
+
 describe("many route params", () => {
   let server: Server;
 

--- a/test/js/bun/http/bun-serve-routes.test.ts
+++ b/test/js/bun/http/bun-serve-routes.test.ts
@@ -649,6 +649,36 @@ describe("reload() keeps the server able to answer", () => {
     server.reload({ development: false } as ServeOptions);
     expect(await (await fetch(server.url)).text()).toBe("routes");
   });
+
+  it("allows a reload that names no handler at all on a fetch-only server", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch: () => new Response("fetch"),
+    });
+    server.reload({ error: _err => new Response("error") } as ServeOptions);
+    expect(await (await fetch(server.url)).text()).toBe("fetch");
+  });
+
+  // Unlike callback routes, static routes are replaced by every reload, even
+  // one without a routes object, so they cannot stand in for a missing handler.
+  it("rejects a reload that names no handler on a server whose only routes are static", async () => {
+    using server = Bun.serve({
+      port: 0,
+      routes: { "/": new Response("static") },
+    });
+    expect(() => server.reload({ development: false } as ServeOptions)).toThrow("Bun.serve() needs either:");
+    expect(await (await fetch(server.url)).text()).toBe("static");
+  });
+
+  // Same for node:http's request handler: a reload that omits it clears it.
+  it("rejects a reload that names no handler on a server whose only handler is onNodeHTTPRequest", () => {
+    using server = Bun.serve({
+      port: 0,
+      // @ts-expect-error internal option used by node:http's Server
+      onNodeHTTPRequest() {},
+    });
+    expect(() => server.reload({ development: false } as ServeOptions)).toThrow("Bun.serve() needs either:");
+  });
 });
 
 describe("many route params", () => {


### PR DESCRIPTION
Bun.serve() refuses a config with no fetch, no node handler and no routes. reload() ran the same check but told it "the server has routes" based on the routes it was about to replace, so on a server whose only handler was its routes, reload({ routes: {} }) went through and every request got a 404 from then on.

The check now hears two things about the running server, matching what on_reload_from_zig carries over when the new config leaves them out: whether it has a fetch handler (kept unless the new config replaces it), and whether it has callback routes (kept only when the new config has no routes object at all; routes: {} replaces them). Static routes are replaced on every reload and the node:http handler is cleared when omitted, so neither counts; a reload that names no handler on a server that only has those still throws, as it does today. Same error message as at serve time; on a rejected reload the server keeps answering with its old config.

Left alone on purpose: a reload that passes the internal onNodeHTTPRequest option to a server not created by node:http still gets credit for it in this check even though the handler is ignored (serve.test.ts pins the ignoring). Same as main, only reachable with an undocumented option, and counting it right would need another flag, so it is not part of this change.

Side effect worth calling out: reload({ error }) or reload({ websocket }) on a fetch-only server used to throw this error too, and now goes through with fetch kept.

Tests in bun-serve-routes.test.ts ("reload() keeps the server able to answer"): the routes: {} case and the fetch-only case fail on the release binary; the static-only and node-handler-only cases pin that those are not counted.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-routes.test.ts
bun test v1.4.0 (7a79e9682)

test/js/bun/http/bun-serve-routes.test.ts:
(pass) path parameters > handles single parameter [22.92ms]
RequestParams {
  postId: "456",
  commentId: "789",
}
(pass) path parameters > handles multiple parameters [10.58ms]
(pass) path parameters > handles encoded parameters [7.76ms]
(pass) path parameters > handles unicode parameters [7.82ms]
(pass) path parameters > decodes raw valid UTF-8 bytes in a parameter segment [343.09ms]
(pass) path parameters > decodes raw an invalid UTF-8 byte in a parameter segment [33.88ms]
(pass) HTTP methods > GET request [31.09ms]
(pass) HTTP methods > POST request [5.92ms]
(pass) HTTP methods > PUT request [4.24ms]
(pass) HTTP methods > DELETE request [3.84ms]
(pass) HTTP methods > PATCH request [4.54ms]
(pass) HTTP methods > OPTIONS request [4.54ms]
(pass) HTTP methods > HEAD request [5.07ms]
(pass) implicit HEAD for per-method route objects > HEAD is served by the GET handler when no HEAD handler is declared [49.87ms]
(pass) implici
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (4517879aa)

test/js/bun/http/bun-serve-routes.test.ts:
(pass) path parameters > handles single parameter [2.73ms]
RequestParams {
  postId: "456",
  commentId: "789",
}
(pass) path parameters > handles multiple parameters [0.73ms]
(pass) path parameters > handles encoded parameters [0.70ms]
(pass) path parameters > handles unicode parameters [0.24ms]
(pass) path parameters > decodes raw valid UTF-8 bytes in a parameter segment [7.62ms]
(pass) path parameters > decodes raw an invalid UTF-8 byte in a parameter segment [0.98ms]
(pass) HTTP methods > GET request [1.88ms]
(pass) HTTP methods > POST request [0.19ms]
(pass) HTTP methods > PUT request [0.13ms]
(pass) HTTP methods > DELETE request [0.10ms]
(pass) HTTP methods > PATCH request [0.10ms]
(pass) HTTP methods > OPTIONS request [0.09ms]
(pass) HTTP methods > HEAD request [0.09ms]
(pass) implicit HEAD for per-method route objects > HEAD is served by the GET handler when no HEAD handler is declared [1.67ms]
(pass) implicit HEAD for per-method route objects > HEAD does not 404 when there is no later route to fall through to [1.39ms]
(pass) implicit HEAD for per-method route objects > the GET 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-routes.test.ts
bun test v1.4.0 (7a79e9682)

test/js/bun/http/bun-serve-routes.test.ts:
(pass) path parameters > handles single parameter [22.34ms]
RequestParams {
  postId: "456",
  commentId: "789",
}
(pass) path parameters > handles multiple parameters [11.38ms]
(pass) path parameters > handles encoded parameters [8.15ms]
(pass) path parameters > handles unicode parameters [8.25ms]
(pass) path parameters > decodes raw valid UTF-8 bytes in a parameter segment [351.18ms]
(pass) path parameters > decodes raw an invalid UTF-8 byte in a parameter segment [28.86ms]
(pass) HTTP methods > GET request [33.64ms]
(pass) HTTP methods > POST request [5.05ms]
(pass) HTTP methods > PUT request [4.28ms]
(pass) HTTP methods > DELETE request [3.63ms]
(pass) HTTP methods > PATCH request [4.52ms]
(pass) HTTP methods > OPTIONS request [4.04ms]
(pass) HTTP methods > HEAD request [4.58ms]
(pass) implicit HEAD for per-method route objects > HEAD is served by the GET handler when no HEAD handler is declared [53.18ms]
(pass) implici
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 706ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/134] gen ErrorCode+*.h
[2/134] gen .bind.ts → GeneratedBindings.cpp
[3/134] gen NodeModuleModule.lut.h
Generating /workspace/bun/build/release/codegen/NodeModuleModule.lut.h from /workspace/bun/src/jsc/modules/NodeModuleModule.cpp
[4/134] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[5/134] gen cpp.rs (cppbind)
[6/134] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fiel
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/BunObject.rs              |  3 +-
 src/runtime/server/ServerConfig.rs        | 17 +++++++--
 src/runtime/server/server_body.rs         |  3 +-
 test/js/bun/http/bun-serve-routes.test.ts | 63 +++++++++++++++++++++++++++++++
 4 files changed, 80 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/runtime/api/BunObject.rs                   1      0      0
src/runtime/server/ServerConfig.rs             3      1      0
src/runtime/server/server_body.rs              1      1      0
test/js/bun/http/bun-serve-routes.test.ts      1      2      0
```

</details>

<!-- robobun:evidence:end -->
