### PR TITLE
bench: homepage benchmark harness + express/websocket/postgres bench fixes

### DIFF
--- a/bench/express/README.md
+++ b/bench/express/README.md
@@ -26,10 +26,18 @@ To run in Deno:
 deno run -A ./express.mjs
 ```
 
+To run the same server over HTTPS (`express-tls.mjs`), generate a self-signed certificate first:
+
+```sh
+openssl req -x509 -newkey rsa:2048 -nodes -keyout key.pem -out cert.pem -days 365 -subj "/CN=localhost"
+bun ./express-tls.mjs   # or node / deno run -A; TLS_CERT / TLS_KEY override the file paths
+```
+
 To benchmark each runtime:
 
 ```bash
 oha http://localhost:3000 -n 500000 -H "Accept-Encoding: identity"
+bombardier -k -c 50 -d 5s -l -H "Accept-Encoding: identity" https://localhost:3443
 ```
 
 We recommend using `oha` or `bombardier` for benchmarking. We do not recommend using `ab`, as it uses HTTP/1.0 which stopped being used by web browsers in the early 2000s. We also do not recommend using autocannon, as the node:http client is not performant enough to measure the throughput of Bun's HTTP server.

--- a/bench/express/express-tls.mjs
+++ b/bench/express/express-tls.mjs
@@ -1,0 +1,19 @@
+// Same hello world as express.mjs, served over HTTPS (see the README.md for how to generate cert.pem/key.pem)
+import express from "express";
+import fs from "fs";
+import https from "https";
+
+const app = express();
+const port = Number(process.env.PORT || 3443);
+const cert = fs.readFileSync(process.env.TLS_CERT || "cert.pem");
+const key = fs.readFileSync(process.env.TLS_KEY || "key.pem");
+let i = 0;
+
+app.get("/", (req, res) => {
+  res.send("Hello World! (request number: " + i++ + ")");
+});
+
+const server = https.createServer({ cert, key }, app);
+server.listen(port, () => {
+  console.log(`Express HTTPS server listening on port ${server.address().port}`);
+});

--- a/bench/express/express.mjs
+++ b/bench/express/express.mjs
@@ -2,13 +2,13 @@
 import express from "express";
 
 const app = express();
-const port = process.env.PORT || 3000;
+const port = Number(process.env.PORT || 3000);
 let i = 0;
 
 app.get("/", (req, res) => {
   res.send("Hello World! (request number: " + i++ + ")");
 });
 
-app.listen(port, () => {
-  console.log(`Express server listening on port ${port}`);
+const server = app.listen(port, () => {
+  console.log(`Express server listening on port ${server.address().port}`);
 });

--- a/bench/postgres/index.mjs
+++ b/bench/postgres/index.mjs
@@ -43,3 +43,6 @@ for (let i = 0; i < 100_000; i++) {
 }
 await Promise.all(promises);
 console.timeEnd(type);
+
+// postgres.js keeps the process alive through its connection pool; Bun.sql does not.
+await sql.end?.();

--- a/bench/site/README.md
+++ b/bench/site/README.md
@@ -1,0 +1,87 @@
+# bun.com homepage benchmarks
+
+This directory is the reproducible source for the benchmark numbers shown on [bun.com](https://bun.com): the bundler,
+HTTP server, WebSocket, Postgres and `bun install` cards. It runs the benchmark sources that already live in `bench/`
+(`bench/express`, `bench/websocket-server`, `bench/postgres`, `bench/install`) plus the
+[rolldown/benchmarks](https://github.com/rolldown/benchmarks) bundler harness, against pinned versions of every
+runtime and package manager, and writes one results directory per run.
+
+Linux x64 only (it reads `/proc`, uses GNU `time`, `lscpu` and `free`).
+
+## Running it
+
+```sh
+bench/site/setup-toolchains.sh                      # node, deno, pnpm/yarn/npm, bun release + canary -> $SITEBENCH_HOME/toolchains
+bench/site/setup-repos.sh                           # rolldown/benchmarks clone + deps of bench/express, bench/websocket-server, bench/postgres
+BUN=/abs/path/to/bun bench/site/run-all.sh          # everything: bundler http ws postgres install (~30 min with RUNS=3)
+BUN=/abs/path/to/bun bench/site/run-all.sh http ws  # a subset
+RUNS=1 BUN=... bench/site/run-all.sh                # quick smoke run
+```
+
+- `BUN` (required) is the Bun binary under test. The fixed comparison row is always `toolchains/bun-release/bun`.
+- `SITEBENCH_HOME` (default `~/sitebench`) holds toolchains, the rolldown/benchmarks clone, per-PM caches, the Postgres
+  data dir, scratch files and `results/`. Nothing is installed system-wide; `bombardier`, `hyperfine`, `openssl` and a
+  PostgreSQL server binary (`pg_ctl`/`initdb`, or `SITEBENCH_PG_EXTERNAL=1` + `PG*` variables for a running server) must
+  already be on `PATH`.
+- `RUNS` (default 3) is the number of repetitions for http, ws, postgres and install. The bundler harness always does
+  hyperfine's 10 runs per tool.
+
+Results land in `$SITEBENCH_HOME/results/<UTC stamp>-<dir of $BUN>-<bun version>/` (symlinked as `results/latest`):
+
+| file                                                                            | contents                                                                                                      |
+| ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `versions.txt`                                                                  | machine (CPU model, cores, RAM, kernel) and the exact version of every runtime, package manager and tool used |
+| `timings.txt`                                                                   | `<bench> <exit code> <wall seconds>` per benchmark                                                            |
+| `bundler-10000.json`, `bundler-10000-bun-release.json`, `bundler-10000-rss.txt` | hyperfine JSON per bundler, the bun-release row, peak RSS per bundler                                         |
+| `http.txt`                                                                      | req/s per run, server CPU %, peak RSS per server                                                              |
+| `ws.txt`                                                                        | msgs/s, server CPU %, peak RSS per server and repetition                                                      |
+| `postgres.txt`                                                                  | wall ms, driver-reported ms, peak RSS per run                                                                 |
+| `install.txt`                                                                   | `<pm> <scenario> r<N> <ms> peak_rss rc` for every package manager and scenario                                |
+| `*.log`                                                                         | full stdout/stderr of each benchmark script                                                                   |
+
+## What is measured
+
+**bundler.sh** - `node bench.mjs --app apps/10000` from rolldown/benchmarks: a 10,000-component React app (~19k modules)
+built for production with sourcemaps by vite, rsbuild, rspack, rollup, rolldown, esbuild and `bun build`, hyperfine 10
+runs each. `bun` on `PATH` is a shim symlink to `$BUN`. Then the same `bun build` command under bun-release, and one build
+per tool under GNU `time` for peak RSS. The harness has no warmup, so the first vite run is a cold outlier.
+
+**http.sh** - `bench/express/express-tls.mjs` (Express 5 hello world over HTTPS with a self-signed cert generated into
+`$SITEBENCH_HOME/certs`) under `$BUN`, bun-release, node and `deno run -A`; 3 s warmup, then
+`bombardier -k -c 50 -d 5s -l -H "Accept-Encoding: identity"` x RUNS. Plaintext `express.mjs` and the native servers in
+`servers/` (`Bun.serve`, `node:https`/`node:http`, `Deno.serve`) over TLS and plaintext are recorded as context. Server
+CPU is the `/proc` utime+stime delta over the measured window; peak RSS is `VmHWM`. HTTPS is used because that is what
+the site publishes and what production servers terminate.
+
+**ws.sh** - `bench/websocket-server`: a chat room with 32 clients where every message is echoed to every client. The
+clients are split across `K=4` client processes (`CLIENTS_COUNT=8 TOTAL_CLIENTS=32`, always run under bun-release), so the
+client side is not the bottleneck and every server gets the identical bounded workload. Rows: `$BUN` with
+`ws.publish()` (`chat-server.bun.js`), `$BUN` broadcasting with a `ws.send()` loop (`servers/chat-server.bun-send.js`,
+the same shape as the node and Deno servers), bun-release, node `ws`, `Deno.upgradeWebSocket`. msgs/s is the sum over
+client processes of the per-second samples 2-10; server CPU over an 8 s window; peak RSS.
+
+**postgres.sh** - `bench/postgres/index.mjs`: 100,000 `SELECT * FROM users_bun_bench LIMIT 100` queries with 100 in
+flight, `Bun.sql` under `$BUN` and bun-release, `postgres.js` under node and deno, against a PostgreSQL server the script
+starts from `$SITEBENCH_HOME/pgdata` (trust auth on 127.0.0.1) and stops afterwards. Wall time around the process,
+the driver-reported `console.time`, peak RSS via GNU `time`.
+
+**install.sh** - `bench/install` (a create-t3-app Next.js app: 25 direct dependencies, ~220 resolved packages) installed
+by `$BUN`, `$BUN --linker=isolated`, bun-release, pnpm, yarn 1 and npm. Every package manager gets a private cache/store
+under `$SITEBENCH_HOME/caches` (`BUN_INSTALL_CACHE_DIR`, `npm_config_cache`, `YARN_CACHE_FOLDER`,
+`--store-dir`/`--cache-dir` for pnpm) so "cold" only ever wipes our own cache; pnpm and yarn run with `--prefer-offline`,
+npm with `--prefer-offline --no-audit --no-fund`. Six scenarios x RUNS each, wall ms around the process and peak RSS:
+`clean` (no cache, lockfile or node_modules), `cache` (warm cache only), `ci-cold` (lockfile only), `ci-cache`
+(lockfile + warm cache), `nm-lock` (lockfile + node_modules, cold cache), `uptodate` (everything present).
+
+## How the published numbers were produced
+
+- Machine: a dedicated AWS EC2 instance, AMD EPYC 9R14, 64 vCPUs, 128 GB RAM, Amazon Linux 2023 (kernel 6.1), otherwise
+  idle. Client and server run on the same machine.
+- `RUNS=3`; every repetition is recorded and the published number is the median repetition, labelled with the versions
+  from `versions.txt`.
+- Versions pinned in `setup-toolchains.sh` / `setup-repos.sh`: Node v26.7.0, Deno 2.9.5, pnpm 11.21.0, yarn 1.22.22,
+  npm 12.0.2, Bun 1.3.14 as the release row, rolldown/benchmarks at `257a5850` (esbuild 0.28.2, rolldown 1.2.3,
+  rspack 2.1.8, rsbuild 2.1.10, rollup 4.62.4, vite 8.2.1), Express 5.2.1, ws 8.13.0, postgres.js 3.4.9,
+  PostgreSQL 18.3, bombardier, hyperfine 1.19.0.
+- The Bun under test is a release or canary build from GitHub releases (PR builds are produced without the symbol
+  order file, so only release/canary artifacts are comparable to the release row).

--- a/bench/site/README.md
+++ b/bench/site/README.md
@@ -79,9 +79,10 @@ npm with `--prefer-offline --no-audit --no-fund`. Six scenarios x RUNS each, wal
   idle. Client and server run on the same machine.
 - `RUNS=3`; every repetition is recorded and the published number is the median repetition, labelled with the versions
   from `versions.txt`.
-- Versions pinned in `setup-toolchains.sh` / `setup-repos.sh`: Node v26.7.0, Deno 2.9.5, pnpm 11.21.0, yarn 1.22.22,
-  npm 12.0.2, Bun 1.3.14 as the release row, rolldown/benchmarks at `257a5850` (esbuild 0.28.2, rolldown 1.2.3,
-  rspack 2.1.8, rsbuild 2.1.10, rollup 4.62.4, vite 8.2.1), Express 5.2.1, ws 8.13.0, postgres.js 3.4.9,
-  PostgreSQL 18.3, bombardier, hyperfine 1.19.0.
+- Versions pinned in `setup-toolchains.sh` / `setup-repos.sh` / the `bench/*/package.json` files: Node v26.7.0,
+  Deno 2.9.5, pnpm 11.21.0, yarn 1.22.22, npm 12.0.2, Bun 1.3.14 as the release row, rolldown/benchmarks at `257a5850`
+  with its bundlers bumped to npm `latest` as of 2026-08-14 (esbuild 0.28.2, rolldown 1.2.4, rspack 2.1.10,
+  rsbuild 2.1.13, rollup 4.62.4, vite 8.2.1), Express 5.2.1, ws 8.21.3 (bufferutil 4.1.0, utf-8-validate 6.0.6),
+  postgres.js 3.4.9, PostgreSQL 18.3, bombardier, hyperfine 1.19.0.
 - The Bun under test is a release or canary build from GitHub releases (PR builds are produced without the symbol
   order file, so only release/canary artifacts are comparable to the release row).

--- a/bench/site/README.md
+++ b/bench/site/README.md
@@ -24,7 +24,7 @@ RUNS=1 BUN=... bench/site/run-all.sh                # quick smoke run
   PostgreSQL server binary (`pg_ctl`/`initdb`, or `SITEBENCH_PG_EXTERNAL=1` + `PG*` variables for a running server) must
   already be on `PATH`.
 - `RUNS` (default 3) is the number of repetitions for http, ws, postgres and install. The bundler harness always does
-  hyperfine's 10 runs per tool.
+  hyperfine's 10 runs per tool. Each benchmark script is killed after `BENCH_TIMEOUT` seconds (default 3600).
 
 Results land in `$SITEBENCH_HOME/results/<UTC stamp>-<dir of $BUN>-<bun version>/` (symlinked as `results/latest`):
 

--- a/bench/site/bench/bundler.sh
+++ b/bench/site/bench/bundler.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# rolldown/benchmarks harness on apps/10000 (10k React components / ~19k modules): vite, rsbuild, rspack, rollup, rolldown, esbuild, bun.
+# The harness runs `bun build` via `bun` on PATH, so a shim dir pointing at $BUN goes first on PATH.
+source "$(dirname "${BASH_SOURCE[0]}")/../env.sh"
+APP=${APP:-apps/10000}
+SHIM=$S/bin; mkdir -p "$SHIM"; ln -sf "$BUN" "$SHIM/bun"; export PATH=$SHIM:$PATH
+cd "$S/benchmarks"
+echo "bun=$(bun --version) ($BUN) node=$($NODE --version) hyperfine=$(hyperfine --version)"
+$NODE bench.mjs --app "$APP" --json "$OUT/bundler-$(basename "$APP").json"
+echo "--- release-bun row (same command as the harness's build:bun, run alone):"
+(cd "$APP" && hyperfine --export-json "$OUT/bundler-$(basename "$APP")-bun-release.json" -n "$BUN_RELEASE_LABEL" "$BUN_RELEASE build --outdir=dist-bun --production --sourcemap ./src/index.jsx")
+echo "--- peak RSS per bundler (one build each under GNU time; output size in the harness json):"
+cd "$APP"
+for t in bun rolldown esbuild rspack rollup vite rsbuild; do
+  $GNU_TIME -f "%M" -o "$TMP/rss.txt" $NODE --run build:$t > /dev/null 2>&1 || echo "  (build:$t exited non-zero)"
+  echo "peak_rss $t $(( $(tail -1 "$TMP/rss.txt") / 1024 ))MB"
+done | tee "$OUT/bundler-$(basename "$APP")-rss.txt"
+echo BUNDLER_DONE

--- a/bench/site/bench/http.sh
+++ b/bench/site/bench/http.sh
@@ -11,6 +11,7 @@ RES=$OUT/http.txt; : > "$RES"
 DUR=${DUR:-5s}
 # run <label> <scheme> <cwd> <cmd...>   -- the server must print "... port <n>" once listening
 run() { local label=$1 scheme=$2 dir=$3; shift 3
+  : > "$TMP/http.log"
   ( cd "$dir" && PORT=0 "$@" > "$TMP/http.log" 2>&1 ) & local SRV=$!
   local PORT=""; for i in $(seq 1 60); do PORT=$(sed -nE 's/.* port ([0-9]+).*/\1/p' "$TMP/http.log" | head -1); [ -n "$PORT" ] && [ "$PORT" != 0 ] && break; sleep 0.25; done
   # the subshell above is $SRV; the runtime is its child, which is what /proc accounting must look at

--- a/bench/site/bench/http.sh
+++ b/bench/site/bench/http.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Express hello world over HTTPS (bench/express/express-tls.mjs; bombardier -k -c 50 -d 5s x RUNS after a 3s warmup) for
+# bun / bun-release / node / deno, plus plaintext express and the native servers (Bun.serve, node:https, Deno.serve) over
+# TLS and plaintext as context. Server CPU = /proc utime+stime over the measured window; peak RSS = VmHWM.
+source "$(dirname "${BASH_SOURCE[0]}")/../env.sh"
+CERTS=$S/certs; mkdir -p "$CERTS"
+[ -f "$CERTS/cert.pem" ] || openssl req -x509 -newkey rsa:2048 -nodes -keyout "$CERTS/key.pem" -out "$CERTS/cert.pem" -days 365 -subj "/CN=localhost" 2>/dev/null
+export TLS_CERT=$CERTS/cert.pem TLS_KEY=$CERTS/key.pem
+EX=$BENCH_DIR/express; SV=$SITE_DIR/servers
+RES=$OUT/http.txt; : > "$RES"
+DUR=${DUR:-5s}
+# run <label> <scheme> <cwd> <cmd...>   -- the server must print "... port <n>" once listening
+run() { local label=$1 scheme=$2 dir=$3; shift 3
+  ( cd "$dir" && PORT=0 "$@" > "$TMP/http.log" 2>&1 ) & local SRV=$!
+  local PORT=""; for i in $(seq 1 60); do PORT=$(sed -nE 's/.* port ([0-9]+).*/\1/p' "$TMP/http.log" | head -1); [ -n "$PORT" ] && [ "$PORT" != 0 ] && break; sleep 0.25; done
+  # the subshell above is $SRV; the runtime is its child, which is what /proc accounting must look at
+  local PID=$(pgrep -P $SRV | head -1); [ -z "$PID" ] && PID=$SRV
+  if [ -z "$PORT" ] || [ "$PORT" = 0 ]; then echo "$label $scheme FAILED_TO_START: $(head -3 "$TMP/http.log" | tr '\n' ' ')" | tee -a "$RES"; kill $SRV 2>/dev/null; wait $SRV 2>/dev/null; return; fi
+  local KFLAG=""; [ $scheme = https ] && KFLAG=-k
+  bombardier $KFLAG -c 50 -d 3s -l $scheme://localhost:$PORT > /dev/null 2>&1
+  local c0=$(cpu_ticks $PID) t0=$(date +%s.%N) res=""
+  for r in $(seq 1 $RUNS); do
+    res="$res $(bombardier $KFLAG -c 50 -d $DUR -l -H "Accept-Encoding: identity" $scheme://localhost:$PORT 2>&1 | grep -oE "Reqs/sec +[0-9.]+" | awk '{printf "%d", $2}')"
+  done
+  local c1=$(cpu_ticks $PID) t1=$(date +%s.%N)
+  local cpu=$(awk -v a=$c0 -v b=$c1 -v t0=$t0 -v t1=$t1 'BEGIN{printf "%.0f", (b-a)/100/(t1-t0)*100}')
+  printf "%-34s %-5s req/s:%s   server_cpu=%s%%   peak_rss=%sMB\n" "$label" "$scheme" "$res" "$cpu" "$(peak_rss_mb $PID)" | tee -a "$RES"
+  kill $PID $SRV 2>/dev/null; wait $SRV 2>/dev/null; sleep 1
+}
+echo "############ EXPRESS (HTTPS)" | tee -a "$RES"
+run "express $BUN_LABEL"          https "$EX" $BUN ./express-tls.mjs
+run "express $BUN_RELEASE_LABEL"  https "$EX" $BUN_RELEASE ./express-tls.mjs
+run "express $NODE_LABEL"         https "$EX" $NODE ./express-tls.mjs
+run "express $DENO_LABEL"         https "$EX" $DENO run -A ./express-tls.mjs
+echo "############ EXPRESS (plaintext, context)" | tee -a "$RES"
+run "express $BUN_LABEL"          http  "$EX" $BUN ./express.mjs
+run "express $NODE_LABEL"         http  "$EX" $NODE ./express.mjs
+run "express $DENO_LABEL"         http  "$EX" $DENO run -A ./express.mjs
+echo "############ NATIVE SERVERS (TLS)" | tee -a "$RES"
+run "Bun.serve $BUN_LABEL"          https "$SV" $BUN bunserve-tls.js
+run "Bun.serve $BUN_RELEASE_LABEL"  https "$SV" $BUN_RELEASE bunserve-tls.js
+run "node:https $NODE_LABEL"        https "$SV" $NODE nodehttps.js
+run "Deno.serve $DENO_LABEL"        https "$SV" $DENO run -A denoserve-tls.js
+echo "############ NATIVE SERVERS (plaintext, context)" | tee -a "$RES"
+run "Bun.serve $BUN_LABEL"          http  "$SV" $BUN bunserve.js
+run "Bun.serve $BUN_RELEASE_LABEL"  http  "$SV" $BUN_RELEASE bunserve.js
+run "node:http $NODE_LABEL"         http  "$SV" $NODE nodehttp.js
+run "Deno.serve $DENO_LABEL"        http  "$SV" $DENO run -A denoserve.js
+echo HTTP_DONE | tee -a "$RES"

--- a/bench/site/bench/install.sh
+++ b/bench/site/bench/install.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# `install` on bench/install (create-t3-app Next.js app: 25 direct deps, ~220 resolved packages) for bun (default linker),
+# bun --linker=isolated, bun-release, pnpm, yarn 1, npm. Six scenarios x RUNS runs each; every PM uses a private cache/store
+# under $SITEBENCH_HOME/caches so "cold" only wipes our own cache. Wall time in ms around the process; peak RSS via GNU time.
+#   clean     : no cache, no lockfile, no node_modules
+#   cache     : warm cache, no lockfile, no node_modules
+#   ci-cold   : lockfile only (cold cache, no node_modules)
+#   ci-cache  : lockfile + warm cache, no node_modules
+#   nm-lock   : lockfile + node_modules, cold cache
+#   uptodate  : everything present (no-op install)
+source "$(dirname "${BASH_SOURCE[0]}")/../env.sh"
+B=$S/install; C=$S/caches; mkdir -p "$B" "$C"
+export BUN_INSTALL_CACHE_DIR=$C/bun npm_config_cache=$C/npm YARN_CACHE_FOLDER=$C/yarn
+PMS=${PMS:-bun bun-isolated bun-release pnpm yarn npm}
+lock() { case $1 in bun*) echo bun.lock;; yarn) echo yarn.lock;; pnpm) echo pnpm-lock.yaml;; npm) echo package-lock.json;; esac; }
+cmd() { case $1 in
+  bun)          echo "$BUN install";;
+  bun-isolated) echo "$BUN install --linker=isolated";;
+  bun-release)  echo "$BUN_RELEASE install";;
+  pnpm)         echo "$PNPM install --prefer-offline --config.strict-dep-builds=false --store-dir $C/pnpm-store --cache-dir $C/pnpm-cache";;
+  yarn)         echo "$YARN install --prefer-offline --non-interactive";;
+  npm)          echo "$NPM install --prefer-offline --no-audit --no-fund";;
+esac; }
+label() { case $1 in bun) echo "$BUN_LABEL";; bun-isolated) echo "$BUN_LABEL --linker=isolated";; bun-release) echo "$BUN_RELEASE_LABEL";; pnpm) echo "pnpm-$($PNPM --version)";; yarn) echo "yarn-$($YARN --version)";; npm) echo "npm-$($NPM --version)";; esac; }
+clr_cache() { case $1 in bun*) rm -rf "$C/bun";; yarn) rm -rf "$C/yarn";; pnpm) rm -rf "$C/pnpm-store" "$C/pnpm-cache";; npm) rm -rf "$C/npm";; esac; }
+RES=$OUT/install.txt; : > "$RES"
+for pm in $PMS; do
+  D=$B/$pm; rm -rf "$D"; mkdir -p "$D"; cp "$BENCH_DIR/install/package.json" "$D/"
+  case $pm in bun*) cp "$BENCH_DIR/install/bun.lock" "$D/";; esac
+  cd "$D"
+  # baseline: one real install to warm the cache and produce this PM's lockfile + node_modules
+  t0=$(date +%s%N); $(cmd $pm) > "$TMP/inst.log" 2>&1; rc=$?; t1=$(date +%s%N)
+  echo "$pm baseline-install rc=$rc $(( (t1-t0)/1000000 ))ms $(tail -1 "$TMP/inst.log" | sed 's/\x1b\[[0-9;?]*[a-zA-Z]//g')"
+  [ $rc = 0 ] || { echo "$pm BASELINE_FAILED" | tee -a "$RES"; tail -5 "$TMP/inst.log"; continue; }
+  L=$(lock $pm); cp $L .lock_keep; rm -rf .nm_keep; cp -al node_modules .nm_keep
+  # run <scenario> <cache 0/1> <lockfile 0/1> <node_modules 0/1>
+  run() { local scen=$1 c=$2 l=$3 nm=$4
+    for r in $(seq 1 $RUNS); do
+      if [ $nm = 1 ]; then [ -d node_modules ] || cp -al .nm_keep node_modules; else rm -rf node_modules; fi
+      if [ $l = 1 ]; then cp .lock_keep $L; else rm -f $L; fi
+      [ $c = 0 ] && clr_cache $pm
+      sync; sleep 1
+      local t0=$(date +%s%N)
+      $GNU_TIME -f "%M" -o "$TMP/inst-rss.txt" $(cmd $pm) > "$TMP/inst.log" 2>&1; local rc=$?
+      local t1=$(date +%s%N)
+      printf "%-40s %-9s r%s  %7d ms   peak_rss=%4d MB   rc=%s\n" "$(label $pm)" "$scen" "$r" "$(( (t1-t0)/1000000 ))" "$(( $(tail -1 "$TMP/inst-rss.txt") / 1024 ))" "$rc" | tee -a "$RES"
+      [ $rc = 0 ] || tail -3 "$TMP/inst.log"
+    done
+    cp .lock_keep $L
+  }
+  run clean    0 0 0
+  run cache    1 0 0
+  run ci-cold  0 1 0
+  run ci-cache 1 1 0
+  run nm-lock  0 1 1
+  run uptodate 1 1 1
+done
+echo INSTALL_DONE | tee -a "$RES"

--- a/bench/site/bench/postgres.sh
+++ b/bench/site/bench/postgres.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# bench/postgres/index.mjs (100k `SELECT ... LIMIT 100` queries, 100 in flight) for bun / bun-release / node / deno.
+# Starts a private PostgreSQL from $SITEBENCH_PGDATA (default $SITEBENCH_HOME/pgdata, trust auth, 127.0.0.1:$PGPORT) and
+# stops it afterwards; set SITEBENCH_PG_EXTERNAL=1 to use an already-running server via the PG* variables instead.
+# Reports wall time, the driver-reported time, and peak RSS.
+source "$(dirname "${BASH_SOURCE[0]}")/../env.sh"
+export PGHOST=${PGHOST:-127.0.0.1} PGPORT=${PGPORT:-5432} PGUSER=${PGUSER:-$USER} PGDATABASE=${PGDATABASE:-postgres}
+export DATABASE_URL=postgres://$PGUSER@$PGHOST:$PGPORT/$PGDATABASE
+if [ "${SITEBENCH_PG_EXTERNAL:-}" != 1 ]; then
+  PG_BIN=${PG_BIN:-$(dirname "$(command -v pg_ctl)")}
+  PGDATA=${SITEBENCH_PGDATA:-$S/pgdata}
+  [ -f "$PGDATA/PG_VERSION" ] || "$PG_BIN/initdb" -D "$PGDATA" -U "$PGUSER" --auth=trust > "$S/pg-initdb.log" 2>&1
+  "$PG_BIN/pg_ctl" -D "$PGDATA" -o "-p $PGPORT -k $TMP -c listen_addresses=$PGHOST -c max_connections=200" -l "$S/pg.log" start > /dev/null
+  trap '"$PG_BIN/pg_ctl" -D "$PGDATA" stop -m fast > /dev/null 2>&1' EXIT
+fi
+for i in $(seq 1 40); do pg_isready -h "$PGHOST" -p "$PGPORT" -q && break; sleep 0.25; done
+psql -c "select version()" -tA
+cd "$BENCH_DIR/postgres"
+RES=$OUT/postgres.txt; : > "$RES"
+run() { local name="$1"; shift
+  for r in $(seq 1 $RUNS); do
+    local t0=$(date +%s%N)
+    $GNU_TIME -f "%M" -o "$TMP/pg-rss.txt" "$@" index.mjs > "$TMP/pg.log" 2>&1; local rc=$?
+    local t1=$(date +%s%N)
+    printf "%-32s r%s wall=%sms  %s  peak_rss=%sMB  rc=%s\n" "$name" "$r" "$(( (t1-t0)/1000000 ))" "$(grep -E "Bun.sql|postgres:" "$TMP/pg.log" | tail -1 | tr -d '\n')" "$(( $(tail -1 "$TMP/pg-rss.txt") / 1024 ))" "$rc" | tee -a "$RES"
+    [ $rc = 0 ] || tail -3 "$TMP/pg.log"
+  done
+}
+run "$BUN_LABEL Bun.sql"          $BUN
+run "$BUN_RELEASE_LABEL Bun.sql"  $BUN_RELEASE
+run "$NODE_LABEL postgres.js"     $NODE
+run "$DENO_LABEL postgres.js"     $DENO run -A
+echo POSTGRES_DONE | tee -a "$RES"

--- a/bench/site/bench/ws.sh
+++ b/bench/site/bench/ws.sh
@@ -7,14 +7,19 @@ source "$(dirname "${BASH_SOURCE[0]}")/../env.sh"
 W=$BENCH_DIR/websocket-server; cd "$W"
 K=${K:-4}; TOTAL=32; PER=$((TOTAL/K))
 RES=$OUT/ws.txt; : > "$RES"
+# every server prints "Waiting for <n> clients to connect" once it is listening
 run() { local name="$1"; shift
+  : > "$TMP/ws-srv.log"
   CLIENTS_COUNT=$TOTAL "$@" > "$TMP/ws-srv.log" 2>&1 & local SRV=$!
-  sleep 3
-  local CP=""; for i in $(seq 1 $K); do CLIENTS_COUNT=$PER TOTAL_CLIENTS=$TOTAL $BUN_RELEASE ./chat-client.mjs > "$TMP/ws-c$i.log" 2>&1 & CP="$CP $!"; done
+  local up=""; for i in $(seq 1 60); do grep -q "Waiting for" "$TMP/ws-srv.log" && up=1 && break; kill -0 $SRV 2>/dev/null || break; sleep 0.25; done
+  if [ -z "$up" ]; then echo "$name FAILED_TO_START: $(head -3 "$TMP/ws-srv.log" | tr '\n' ' ')" | tee -a "$RES"; kill $SRV 2>/dev/null; wait $SRV 2>/dev/null; return; fi
+  sleep 1
+  local CP=""; for i in $(seq 1 $K); do CLIENTS_COUNT=$PER TOTAL_CLIENTS=$TOTAL timeout 120 $BUN_RELEASE ./chat-client.mjs > "$TMP/ws-c$i.log" 2>&1 & CP="$CP $!"; done
   sleep 2
   local c0=$(cpu_ticks $SRV) t0=$(date +%s.%N); sleep 8; local c1=$(cpu_ticks $SRV) t1=$(date +%s.%N)
   local cpu=$(awk -v a=$c0 -v b=$c1 -v t0=$t0 -v t1=$t1 'BEGIN{printf "%.0f", (b-a)/100/(t1-t0)*100}')
-  for p in $CP; do wait $p 2>/dev/null; done
+  local timed_out=""; for p in $CP; do wait $p 2>/dev/null; [ $? = 124 ] && timed_out=1; done
+  [ -n "$timed_out" ] && echo "$name CLIENTS_TIMED_OUT (server: $(tail -1 "$TMP/ws-srv.log"))" | tee -a "$RES"
   local hwm=$(peak_rss_mb $SRV) sum=0 n=0
   for i in $(seq 1 $K); do m=$(sed -n "s/ messages per second.*//p" "$TMP/ws-c$i.log" | sed -n "2,10p" | awk '{s+=$1;n++} END {if(n) printf "%d", s/n; else print 0}'); sum=$((sum+m)); n=$((n+$(sed -n "s/ messages per second.*//p" "$TMP/ws-c$i.log" | wc -l))); done
   printf "%-40s msgs/s=%9d   server_cpu=%3s%%   peak_rss=%sMB   (client_samples=%s)\n" "$name" "$sum" "$cpu" "$hwm" "$n" | tee -a "$RES"

--- a/bench/site/bench/ws.sh
+++ b/bench/site/bench/ws.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# WebSocket chat (bench/websocket-server), closed loop: 32 sockets split across K client processes (always run under
+# bun-release), every server offered the identical bounded workload. Reports msgs/s summed over the client processes
+# (samples 2-10), server CPU (/proc utime+stime over an 8s window) and peak RSS.
+# Rows: bun publish(), bun send()-loop (servers/chat-server.bun-send.js), bun-release publish(), node ws, Deno.
+source "$(dirname "${BASH_SOURCE[0]}")/../env.sh"
+W=$BENCH_DIR/websocket-server; cd "$W"
+K=${K:-4}; TOTAL=32; PER=$((TOTAL/K))
+RES=$OUT/ws.txt; : > "$RES"
+run() { local name="$1"; shift
+  CLIENTS_COUNT=$TOTAL "$@" > "$TMP/ws-srv.log" 2>&1 & local SRV=$!
+  sleep 3
+  local CP=""; for i in $(seq 1 $K); do CLIENTS_COUNT=$PER TOTAL_CLIENTS=$TOTAL $BUN_RELEASE ./chat-client.mjs > "$TMP/ws-c$i.log" 2>&1 & CP="$CP $!"; done
+  sleep 2
+  local c0=$(cpu_ticks $SRV) t0=$(date +%s.%N); sleep 8; local c1=$(cpu_ticks $SRV) t1=$(date +%s.%N)
+  local cpu=$(awk -v a=$c0 -v b=$c1 -v t0=$t0 -v t1=$t1 'BEGIN{printf "%.0f", (b-a)/100/(t1-t0)*100}')
+  for p in $CP; do wait $p 2>/dev/null; done
+  local hwm=$(peak_rss_mb $SRV) sum=0 n=0
+  for i in $(seq 1 $K); do m=$(sed -n "s/ messages per second.*//p" "$TMP/ws-c$i.log" | sed -n "2,10p" | awk '{s+=$1;n++} END {if(n) printf "%d", s/n; else print 0}'); sum=$((sum+m)); n=$((n+$(sed -n "s/ messages per second.*//p" "$TMP/ws-c$i.log" | wc -l))); done
+  printf "%-40s msgs/s=%9d   server_cpu=%3s%%   peak_rss=%sMB   (client_samples=%s)\n" "$name" "$sum" "$cpu" "$hwm" "$n" | tee -a "$RES"
+  kill $SRV 2>/dev/null; wait $SRV 2>/dev/null; pkill -f "chat-client.mjs" 2>/dev/null; sleep 1
+}
+for rep in $(seq 1 $RUNS); do
+  echo "== rep $rep" | tee -a "$RES"
+  run "$BUN_LABEL publish()"              $BUN ./chat-server.bun.js
+  run "$BUN_LABEL send()-loop"            $BUN "$SITE_DIR/servers/chat-server.bun-send.js"
+  run "$BUN_RELEASE_LABEL publish()"      $BUN_RELEASE ./chat-server.bun.js
+  run "$NODE_LABEL ws"                    $NODE ./chat-server.node.mjs
+  run "$DENO_LABEL Deno.upgradeWebSocket" $DENO run -A ./chat-server.deno.mjs
+done
+echo WS_DONE | tee -a "$RES"

--- a/bench/site/env.sh
+++ b/bench/site/env.sh
@@ -1,0 +1,25 @@
+# Sourced by every script in bench/site. Bench sources come from this checkout; toolchains, caches, results and
+# scratch state live under $SITEBENCH_HOME (default ~/sitebench). The Bun under test is $BUN.
+SITE_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+BENCH_DIR=$(cd "$SITE_DIR/.." && pwd)
+S=${SITEBENCH_HOME:-$HOME/sitebench}; T=$S/toolchains
+NODE=${NODE:-$T/node/bin/node}
+DENO=${DENO:-$T/deno/deno}
+PNPM=${PNPM:-$T/npm-global/bin/pnpm}
+YARN=${YARN:-$T/npm-global/bin/yarn}
+NPM=${NPM:-$T/npm-global/bin/npm}
+BUN_RELEASE=${BUN_RELEASE:-$T/bun-release/bun}
+BUN=${BUN:?set BUN=/abs/path/to/bun (the Bun binary under test)}
+[ -x "$BUN" ] || { echo "BUN=$BUN is not executable" >&2; exit 2; }
+GNU_TIME=${GNU_TIME:-/usr/bin/time}
+export PATH=$T/npm-global/bin:$T/node/bin:$PATH
+export NO_COLOR=1
+BUN_LABEL="bun-$($BUN --version)+$($BUN --revision | sed 's/.*+//')"
+BUN_RELEASE_LABEL="bun-$($BUN_RELEASE --version)"
+NODE_LABEL="node-$($NODE --version | tr -d v)"
+DENO_LABEL="deno-$($DENO --version | head -1 | awk '{print $2}')"
+OUT=${OUT:-$S/results/latest}; mkdir -p "$OUT"
+TMP=$S/tmp; rm -rf "$TMP"; mkdir -p "$TMP"
+RUNS=${RUNS:-3}
+cpu_ticks() { awk '{print $14+$15}' /proc/$1/stat 2>/dev/null || echo 0; }
+peak_rss_mb() { echo $(( $(awk '/VmHWM/{print $2}' /proc/$1/status 2>/dev/null || echo 0) / 1024 )); }

--- a/bench/site/run-all.sh
+++ b/bench/site/run-all.sh
@@ -10,6 +10,7 @@ mkdir -p "$OUT"; ln -sfn "$OUT" "$S/results/latest"
 export BUN
 source "$(dirname "${BASH_SOURCE[0]}")/env.sh"
 BENCHES=${@:-bundler http ws postgres install}
+cd "$S"
 {
   echo "date_utc=$STAMP host=$(hostname) cpu=\"$(lscpu | sed -n 's/Model name: *//p')\" cores=$(nproc) mem_gb=$(free -g | awk '/Mem/{print $2}') kernel=$(uname -r)"
   echo "BUN=$BUN version=$($BUN --version) revision=$($BUN --revision)"
@@ -23,7 +24,8 @@ cat "$OUT/versions.txt"
 for b in $BENCHES; do
   echo "############ $b  $(date -u +%H:%M:%S)"
   t0=$(date +%s)
-  bash "$SITE_DIR/bench/$b.sh" > "$OUT/$b.log" 2>&1; rc=$?
+  timeout -k 30 "${BENCH_TIMEOUT:-3600}" bash "$SITE_DIR/bench/$b.sh" > "$OUT/$b.log" 2>&1; rc=$?
+  [ $rc = 124 ] && echo "$b TIMED_OUT after ${BENCH_TIMEOUT:-3600}s" | tee -a "$OUT/$b.log"
   t1=$(date +%s)
   echo "$b  ${rc}  $((t1-t0))s" | tee -a "$OUT/timings.txt"
 done

--- a/bench/site/run-all.sh
+++ b/bench/site/run-all.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Usage: BUN=/abs/path/to/bun bench/site/run-all.sh [bundler] [http] [ws] [postgres] [install]
+# Results: $SITEBENCH_HOME/results/<UTC stamp>-<bun label>/  (also symlinked as results/latest)
+set -u
+BUN=${BUN:?set BUN=/abs/path/to/bun}
+STAMP=$(date -u +%Y%m%d-%H%M%S)
+S=${SITEBENCH_HOME:-$HOME/sitebench}
+export OUT=$S/results/$STAMP-$(basename "$(dirname "$BUN")")-$("$BUN" --version)
+mkdir -p "$OUT"; ln -sfn "$OUT" "$S/results/latest"
+export BUN
+source "$(dirname "${BASH_SOURCE[0]}")/env.sh"
+BENCHES=${@:-bundler http ws postgres install}
+{
+  echo "date_utc=$STAMP host=$(hostname) cpu=\"$(lscpu | sed -n 's/Model name: *//p')\" cores=$(nproc) mem_gb=$(free -g | awk '/Mem/{print $2}') kernel=$(uname -r)"
+  echo "BUN=$BUN version=$($BUN --version) revision=$($BUN --revision)"
+  echo "bun_release=$($BUN_RELEASE --version) node=$($NODE --version) deno=$($DENO --version | head -1) pnpm=$($PNPM --version) yarn=$($YARN --version) npm=$($NPM --version)"
+  echo "bombardier=$(bombardier --version 2>&1 | head -1) hyperfine=$(hyperfine --version) postgres=$(postgres --version 2>/dev/null || echo n/a)"
+  (cd "$S/benchmarks" && echo "rolldown_benchmarks=$(git rev-parse --short HEAD) $($NODE -e 'for (const p of ["esbuild","rolldown","@rspack/core","@rsbuild/core","rollup","vite"]) process.stdout.write(p+"="+require(p+"/package.json").version+" ")')")
+  (cd "$BENCH_DIR" && echo "bun_bench=$(git rev-parse --short HEAD) express=$($NODE -p 'require("./express/node_modules/express/package.json").version') ws=$($NODE -p 'require("./websocket-server/node_modules/ws/package.json").version') postgres_js=$($NODE -p 'require("./postgres/node_modules/postgres/package.json").version')")
+} > "$OUT/versions.txt"
+cat "$OUT/versions.txt"
+: > "$OUT/timings.txt"
+for b in $BENCHES; do
+  echo "############ $b  $(date -u +%H:%M:%S)"
+  t0=$(date +%s)
+  bash "$SITE_DIR/bench/$b.sh" > "$OUT/$b.log" 2>&1; rc=$?
+  t1=$(date +%s)
+  echo "$b  ${rc}  $((t1-t0))s" | tee -a "$OUT/timings.txt"
+done
+echo "############ ALLDONE $(date -u +%H:%M:%S)  results in $OUT"

--- a/bench/site/servers/bunserve-tls.js
+++ b/bench/site/servers/bunserve-tls.js
@@ -1,0 +1,8 @@
+const server = Bun.serve({
+  port: 0,
+  tls: { cert: Bun.file(process.env.TLS_CERT || "cert.pem"), key: Bun.file(process.env.TLS_KEY || "key.pem") },
+  fetch() {
+    return new Response("Hello World!");
+  },
+});
+console.log(`Bun.serve listening on port ${server.port}`);

--- a/bench/site/servers/bunserve.js
+++ b/bench/site/servers/bunserve.js
@@ -1,0 +1,7 @@
+const server = Bun.serve({
+  port: 0,
+  fetch() {
+    return new Response("Hello World!");
+  },
+});
+console.log(`Bun.serve listening on port ${server.port}`);

--- a/bench/site/servers/chat-server.bun-send.js
+++ b/bench/site/servers/chat-server.bun-send.js
@@ -31,3 +31,4 @@ Bun.serve({
     return new Response("Error");
   },
 });
+console.log(`Waiting for ${CLIENTS_TO_WAIT_FOR} clients to connect...`);

--- a/bench/site/servers/chat-server.bun-send.js
+++ b/bench/site/servers/chat-server.bun-send.js
@@ -1,0 +1,33 @@
+// bench/websocket-server chat server without publish/subscribe: broadcasts by looping ws.send(), like the node "ws" and Deno servers.
+const CLIENTS_TO_WAIT_FOR = parseInt(process.env.CLIENTS_COUNT || "", 10) || 32;
+var remainingClients = CLIENTS_TO_WAIT_FOR;
+const port = process.env.PORT || 4001;
+const clients = new Set();
+
+Bun.serve({
+  port,
+  websocket: {
+    open(ws) {
+      clients.add(ws);
+      remainingClients--;
+      if (remainingClients === 0) {
+        setTimeout(() => {
+          for (const c of clients) c.send("ready");
+        }, 100);
+      }
+    },
+    message(ws, msg) {
+      const out = `${ws.data.name}: ${msg}`;
+      for (const c of clients) c.send(out);
+    },
+    close(ws) {
+      clients.delete(ws);
+      remainingClients++;
+    },
+    perMessageDeflate: false,
+  },
+  fetch(req, server) {
+    if (server.upgrade(req, { data: { name: new URL(req.url).searchParams.get("name") } })) return;
+    return new Response("Error");
+  },
+});

--- a/bench/site/servers/denoserve-tls.js
+++ b/bench/site/servers/denoserve-tls.js
@@ -1,0 +1,11 @@
+Deno.serve(
+  {
+    port: 0,
+    cert: Deno.readTextFileSync(Deno.env.get("TLS_CERT") || "cert.pem"),
+    key: Deno.readTextFileSync(Deno.env.get("TLS_KEY") || "key.pem"),
+    onListen({ port }) {
+      console.log(`Deno.serve listening on port ${port}`);
+    },
+  },
+  () => new Response("Hello World!"),
+);

--- a/bench/site/servers/denoserve.js
+++ b/bench/site/servers/denoserve.js
@@ -1,0 +1,9 @@
+Deno.serve(
+  {
+    port: 0,
+    onListen({ port }) {
+      console.log(`Deno.serve listening on port ${port}`);
+    },
+  },
+  () => new Response("Hello World!"),
+);

--- a/bench/site/servers/nodehttp.js
+++ b/bench/site/servers/nodehttp.js
@@ -1,0 +1,6 @@
+const http = require("http");
+const server = http.createServer((req, res) => {
+  res.setHeader("Content-Type", "text/plain");
+  res.end("Hello World!");
+});
+server.listen(0, () => console.log(`node:http listening on port ${server.address().port}`));

--- a/bench/site/servers/nodehttps.js
+++ b/bench/site/servers/nodehttps.js
@@ -1,0 +1,10 @@
+const https = require("https");
+const fs = require("fs");
+const server = https.createServer(
+  { cert: fs.readFileSync(process.env.TLS_CERT || "cert.pem"), key: fs.readFileSync(process.env.TLS_KEY || "key.pem") },
+  (req, res) => {
+    res.setHeader("Content-Type", "text/plain");
+    res.end("Hello World!");
+  },
+);
+server.listen(0, () => console.log(`node:https listening on port ${server.address().port}`));

--- a/bench/site/setup-repos.sh
+++ b/bench/site/setup-repos.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Clones rolldown/benchmarks (bundler benchmark) under $SITEBENCH_HOME and installs the deps of the bench/ sources in this
+# checkout (express, websocket-server, postgres). Idempotent. Run setup-toolchains.sh first.
+set -euo pipefail
+SITE_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd); BENCH_DIR=$(cd "$SITE_DIR/.." && pwd)
+S=${SITEBENCH_HOME:-$HOME/sitebench}; T=$S/toolchains
+ROLLDOWN_BENCH_REV=${ROLLDOWN_BENCH_REV:-257a585028663a339641e72e0c2d9ea6a0aa2752}
+export PATH=$T/npm-global/bin:$T/node/bin:$PATH
+mkdir -p "$S"; cd "$S"
+[ -d benchmarks ] || git clone --depth 1 https://github.com/rolldown/benchmarks.git
+(cd benchmarks && git fetch -q --depth 1 origin "$ROLLDOWN_BENCH_REV" && git checkout -q FETCH_HEAD && git log -1 --format="rolldown/benchmarks at %h %ci")
+echo "--- rolldown/benchmarks pnpm install"; (cd benchmarks && pnpm install --frozen-lockfile --config.strict-dep-builds=false 2>&1 | tail -3)
+for d in express websocket-server postgres; do
+  echo "--- bench/$d"; (cd "$BENCH_DIR/$d" && "$T/bun-release/bun" install 2>&1 | tail -2)
+done
+echo "--- deno warms (express + postgres)"
+(cd "$BENCH_DIR/express" && "$T/deno/deno" install --allow-scripts >/dev/null 2>&1 || true)
+(cd "$BENCH_DIR/postgres" && "$T/deno/deno" install --allow-scripts >/dev/null 2>&1 || true)
+echo REPOS_DONE

--- a/bench/site/setup-repos.sh
+++ b/bench/site/setup-repos.sh
@@ -1,19 +1,33 @@
 #!/bin/bash
 # Clones rolldown/benchmarks (bundler benchmark) under $SITEBENCH_HOME and installs the deps of the bench/ sources in this
 # checkout (express, websocket-server, postgres). Idempotent. Run setup-toolchains.sh first.
+# rolldown/benchmarks pins older rolldown/rspack/rsbuild than npm `latest`; the versions below are what the published
+# numbers used (npm `latest` on 2026-08-14). Override any of them via the environment.
 set -euo pipefail
 SITE_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd); BENCH_DIR=$(cd "$SITE_DIR/.." && pwd)
 S=${SITEBENCH_HOME:-$HOME/sitebench}; T=$S/toolchains
 ROLLDOWN_BENCH_REV=${ROLLDOWN_BENCH_REV:-257a585028663a339641e72e0c2d9ea6a0aa2752}
+ROLLDOWN_VER=${ROLLDOWN_VER:-1.2.4} RSPACK_VER=${RSPACK_VER:-2.1.10} RSBUILD_VER=${RSBUILD_VER:-2.1.13}
 export PATH=$T/npm-global/bin:$T/node/bin:$PATH
 mkdir -p "$S"; cd "$S"
 [ -d benchmarks ] || git clone --depth 1 https://github.com/rolldown/benchmarks.git
-(cd benchmarks && git fetch -q --depth 1 origin "$ROLLDOWN_BENCH_REV" && git checkout -q FETCH_HEAD && git log -1 --format="rolldown/benchmarks at %h %ci")
-echo "--- rolldown/benchmarks pnpm install"; (cd benchmarks && pnpm install --frozen-lockfile --config.strict-dep-builds=false 2>&1 | tail -3)
+(cd benchmarks && git fetch -q --depth 1 origin "$ROLLDOWN_BENCH_REV" && git checkout -q -f FETCH_HEAD && git log -1 --format="rolldown/benchmarks at %h %ci")
+echo "--- rolldown/benchmarks pins: rolldown=$ROLLDOWN_VER rspack=$RSPACK_VER rsbuild=$RSBUILD_VER"
+(cd benchmarks && node -e '
+const fs = require("fs"); const p = JSON.parse(fs.readFileSync("package.json", "utf8")); const [rd, rs, rb] = process.argv.slice(1);
+p.devDependencies.rolldown = rd; p.devDependencies["@rspack/core"] = rs; p.devDependencies["@rspack/cli"] = rs; p.devDependencies["@rsbuild/core"] = rb;
+fs.writeFileSync("package.json", JSON.stringify(p, null, "\t") + "\n");' "$ROLLDOWN_VER" "$RSPACK_VER" "$RSBUILD_VER")
+echo "--- rolldown/benchmarks pnpm install"
+(cd benchmarks && pnpm install --no-frozen-lockfile --config.strict-dep-builds=false 2>&1 | tail -3; git checkout -q -- pnpm-workspace.yaml 2>/dev/null || true)
+# a stale bun.lock keeps node-gyp-build < 4.8, which does not find bufferutil 4.1's prebuild and silently falls back to JS
+(cd "$BENCH_DIR/websocket-server" && rm -rf node_modules bun.lock)
 for d in express websocket-server postgres; do
   echo "--- bench/$d"; (cd "$BENCH_DIR/$d" && "$T/bun-release/bun" install 2>&1 | tail -2)
 done
 echo "--- deno warms (express + postgres)"
 (cd "$BENCH_DIR/express" && "$T/deno/deno" install --allow-scripts >/dev/null 2>&1 || true)
 (cd "$BENCH_DIR/postgres" && "$T/deno/deno" install --allow-scripts >/dev/null 2>&1 || true)
+echo "--- resolved versions"
+(cd benchmarks && node -e 'for (const p of ["rolldown","@rspack/core","@rspack/cli","@rsbuild/core","esbuild","rollup","vite"]) console.log("  " + p, require(p + "/package.json").version)')
+(cd "$BENCH_DIR/websocket-server" && node -e 'for (const p of ["ws","bufferutil","utf-8-validate"]) console.log("  " + p, require(p + "/package.json").version); console.log("  bufferutil native:", require("node-gyp-build").path(process.cwd() + "/node_modules/bufferutil"))')
 echo REPOS_DONE

--- a/bench/site/setup-toolchains.sh
+++ b/bench/site/setup-toolchains.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Installs every runtime/tool the site benchmarks need under $SITEBENCH_HOME/toolchains (Linux x64, no system changes).
+# The versions below are the ones the published numbers were produced with; override any of them via the environment.
+set -euo pipefail
+S=${SITEBENCH_HOME:-$HOME/sitebench}; T=$S/toolchains; mkdir -p "$T"; cd "$T"
+NODE_VER=${NODE_VER:-v26.7.0}
+DENO_VER=${DENO_VER:-v2.9.5}
+BUN_REL=${BUN_REL:-1.3.14}
+PNPM_VER=${PNPM_VER:-11.21.0}
+YARN_VER=${YARN_VER:-1.22.22}
+NPM_VER=${NPM_VER:-12.0.2}
+echo "node=$NODE_VER deno=$DENO_VER bun-release=$BUN_REL pnpm=$PNPM_VER yarn=$YARN_VER npm=$NPM_VER"
+if [ ! -x "$T/node/bin/node" ] || [ "$("$T/node/bin/node" --version)" != "$NODE_VER" ]; then
+  rm -rf "$T/node"; curl -fsSL "https://nodejs.org/dist/$NODE_VER/node-$NODE_VER-linux-x64.tar.xz" | tar xJ && mv "node-$NODE_VER-linux-x64" node
+fi
+export PATH=$T/node/bin:$PATH
+mkdir -p "$T/npm-global"
+npm_config_prefix=$T/npm-global npm install -g "pnpm@$PNPM_VER" "yarn@$YARN_VER" "npm@$NPM_VER" >/dev/null 2>&1
+if [ ! -x "$T/deno/deno" ] || ! "$T/deno/deno" --version | head -1 | grep -q "${DENO_VER#v}"; then
+  rm -rf "$T/deno"; mkdir -p "$T/deno"; curl -fsSL -o "$T/deno.zip" "https://dl.deno.land/release/$DENO_VER/deno-x86_64-unknown-linux-gnu.zip" && unzip -oq "$T/deno.zip" -d "$T/deno" && rm -f "$T/deno.zip"
+fi
+if [ ! -x "$T/bun-release/bun" ] || [ "$("$T/bun-release/bun" --version)" != "$BUN_REL" ]; then
+  rm -rf "$T/bun-release" "$T/bunrel"; mkdir -p "$T/bun-release"
+  curl -fsSL -o "$T/bunrel.zip" "https://github.com/oven-sh/bun/releases/download/bun-v$BUN_REL/bun-linux-x64.zip" && unzip -oq "$T/bunrel.zip" -d "$T/bunrel" && mv "$T/bunrel/bun-linux-x64/bun" "$T/bun-release/bun" && rm -rf "$T/bunrel" "$T/bunrel.zip"
+fi
+# the Bun under test is whatever $BUN points at; the current canary is downloaded as a convenient default
+if [ "${SKIP_CANARY:-}" != 1 ]; then
+  rm -rf "$T/bun-canary" "$T/buncan"; mkdir -p "$T/bun-canary"
+  curl -fsSL -o "$T/buncan.zip" https://github.com/oven-sh/bun/releases/download/canary/bun-linux-x64.zip && unzip -oq "$T/buncan.zip" -d "$T/buncan" && mv "$T/buncan/bun-linux-x64/bun" "$T/bun-canary/bun" && rm -rf "$T/buncan" "$T/buncan.zip"
+fi
+for tool in bombardier hyperfine pg_ctl; do command -v $tool >/dev/null || echo "warning: $tool not found on PATH (install it before running the $tool-based benchmarks)"; done
+echo TOOLCHAINS_DONE

--- a/bench/websocket-server/README.md
+++ b/bench/websocket-server/README.md
@@ -34,4 +34,13 @@ For example, when the client sends `"foo"`, the server sends back `"John: foo"` 
 
 The client script waits until it receives all the messages for each client before sending the next batch of messages.
 
+A single client process can become the bottleneck for fast servers. To spread the 32 clients across several processes, start
+each one with `CLIENTS_COUNT` set to its share and `TOTAL_CLIENTS` set to the total the server was started with, so every
+process expects the echoes of all senders:
+
+```bash
+CLIENTS_COUNT=32 bun ./chat-server.bun.js &
+for i in 1 2 3 4; do CLIENTS_COUNT=8 TOTAL_CLIENTS=32 bun ./chat-client.mjs & done; wait
+```
+
 This project was created using `bun init` in bun v0.2.1. [Bun](https://bun.com) is a fast all-in-one JavaScript runtime.

--- a/bench/websocket-server/bun.lock
+++ b/bench/websocket-server/bun.lock
@@ -1,22 +1,23 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "websocket-server",
       "dependencies": {
-        "bufferutil": "4.0.7",
-        "utf-8-validate": "6.0.3",
-        "ws": "8.13.0",
+        "bufferutil": "4.1.0",
+        "utf-8-validate": "6.0.6",
+        "ws": "8.21.3",
       },
     },
   },
   "packages": {
-    "bufferutil": ["bufferutil@4.0.7", "", { "dependencies": { "node-gyp-build": "^4.3.0" } }, "sha512-kukuqc39WOHtdxtw4UScxF/WVnMFVSQVKhtx3AjZJzhd0RGZZldcrfSEbVsWWe6KNH253574cq5F+wpv0G9pJw=="],
+    "bufferutil": ["bufferutil@4.1.0", "", { "dependencies": { "node-gyp-build": "^4.3.0" } }, "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw=="],
 
-    "node-gyp-build": ["node-gyp-build@4.6.0", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ=="],
+    "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
 
-    "utf-8-validate": ["utf-8-validate@6.0.3", "", { "dependencies": { "node-gyp-build": "^4.3.0" } }, "sha512-uIuGf9TWQ/y+0Lp+KGZCMuJWc3N9BHA+l/UmHd/oUHwJJDeysyTRxNQVkbzsIWfGFbRe3OcgML/i0mvVRPOyDA=="],
+    "utf-8-validate": ["utf-8-validate@6.0.6", "", { "dependencies": { "node-gyp-build": "^4.3.0" } }, "sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA=="],
 
-    "ws": ["ws@8.13.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["utf-8-validate"] }, "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA=="],
+    "ws": ["ws@8.21.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw=="],
   }
 }

--- a/bench/websocket-server/chat-client.mjs
+++ b/bench/websocket-server/chat-client.mjs
@@ -4,6 +4,8 @@ const SERVER = env.SERVER || "ws://0.0.0.0:4001";
 const WebSocket = globalThis.WebSocket || (await import("ws")).WebSocket;
 const LOG_MESSAGES = env.LOG_MESSAGES === "1";
 const CLIENTS_TO_WAIT_FOR = parseInt(env.CLIENTS_COUNT || "", 10) || 32;
+// Total number of clients across every client process (see README); each echo fans out to all of them.
+const TOTAL_CLIENTS = parseInt(env.TOTAL_CLIENTS || "", 10) || CLIENTS_TO_WAIT_FOR;
 const DELAY = 64;
 const MESSAGES_TO_SEND = Array.from({ length: 32 }, () => [
   "Hello World!",
@@ -128,16 +130,8 @@ for (let i = 0; i < CLIENTS_TO_WAIT_FOR; i++) {
   };
 }
 
-// each message is supposed to be received
-// by each client
-// so its an extra loop
-for (let i = 0; i < CLIENTS_TO_WAIT_FOR; i++) {
-  for (let j = 0; j < MESSAGES_TO_SEND.length; j++) {
-    for (let k = 0; k < CLIENTS_TO_WAIT_FOR; k++) {
-      total++;
-    }
-  }
-}
+// every message sent by any of the TOTAL_CLIENTS senders is echoed to each of this process's clients
+total = CLIENTS_TO_WAIT_FOR * MESSAGES_TO_SEND.length * TOTAL_CLIENTS;
 remaining = total;
 
 function restart() {

--- a/bench/websocket-server/chat-server.bun.js
+++ b/bench/websocket-server/chat-server.bun.js
@@ -2,7 +2,7 @@
 const CLIENTS_TO_WAIT_FOR = parseInt(process.env.CLIENTS_COUNT || "", 10) || 32;
 var remainingClients = CLIENTS_TO_WAIT_FOR;
 const COMPRESS = process.env.COMPRESS === "1";
-const port = process.PORT || 4001;
+const port = process.env.PORT || 4001;
 
 const server = Bun.serve({
   port: port,
@@ -23,7 +23,8 @@ const server = Bun.serve({
     },
     message(ws, msg) {
       const out = `${ws.data.name}: ${msg}`;
-      if (ws.publishText("room", out) !== out.length) {
+      // publishText returns -1 when the message is queued behind backpressure, 0 when it is dropped.
+      if (ws.publishText("room", out) === 0) {
         throw new Error("Failed to publish message");
       }
     },

--- a/bench/websocket-server/package.json
+++ b/bench/websocket-server/package.json
@@ -3,8 +3,8 @@
   "module": "index.ts",
   "type": "module",
   "dependencies": {
-    "bufferutil": "4.0.7",
-    "utf-8-validate": "6.0.3",
-    "ws": "8.13.0"
+    "bufferutil": "4.1.0",
+    "utf-8-validate": "6.0.6",
+    "ws": "8.21.3"
   }
 }


### PR DESCRIPTION
### What does this PR do?

Adds `bench/site/`, the harness that produces the benchmark numbers on the bun.com homepage, so anyone can reproduce them from this repository, and fixes three things in the existing `bench/` sources that the harness (and anyone else running them) needs.

**The harness** (`bench/site/README.md` has the full description): `setup-toolchains.sh` installs pinned versions of Node, Deno, pnpm, yarn, npm and the Bun release row under `$SITEBENCH_HOME` (default `~/sitebench`, nothing system-wide); `setup-repos.sh` pins rolldown/benchmarks and installs the deps of `bench/express`, `bench/websocket-server`, `bench/postgres`; `run-all.sh` runs bundler / http / ws / postgres / install against `$BUN` and writes `versions.txt`, `timings.txt` and per-benchmark result files (req/s, msgs/s, wall ms, server CPU from `/proc`, peak RSS) into one results directory. Linux x64 only.

**Bench source fixes**

- `bench/postgres/index.mjs`: `await sql.end?.()` at the end. postgres.js keeps node and deno alive through its connection pool, so the script never exited under those runtimes; `Bun.sql` does not hold the event loop, so Bun is unaffected either way.
- `bench/websocket-server/chat-client.mjs`: new optional `TOTAL_CLIENTS` env var so the 32 clients can be split across several client processes and each process still expects the echoes of all senders. A single client process was the bottleneck for fast servers, which made the published msgs/s a client number rather than a server number. Default behaviour (`TOTAL_CLIENTS` unset) is unchanged.
- `bench/websocket-server/chat-server.bun.js`: `publishText()` returns `-1` when the message is queued behind backpressure, which is normal at saturation; the server threw on anything other than the byte count. It now only throws on `0` (dropped). Also `process.PORT` -> `process.env.PORT`.
- `bench/express/express-tls.mjs`: the same hello world over HTTPS (this is what the site measures), reading `cert.pem`/`key.pem` or `TLS_CERT`/`TLS_KEY`; `express.mjs` now prints the port it actually bound so `PORT=0` works.

Servers used only as context rows (`Bun.serve`, `node:http(s)`, `Deno.serve`, and a `ws.send()`-loop variant of the Bun chat server) live in `bench/site/servers/`.

### How did you verify your code works?

Ran every changed JS file with the current Bun, Node 25 and Deno: `postgres/index.mjs` now exits under all three against a local PostgreSQL; `chat-server.bun.js` with 4 fan-out clients (`CLIENTS_COUNT=8 TOTAL_CLIENTS=32`) completes 10 samples per client without throwing; `express-tls.mjs`, `express.mjs` and each file in `bench/site/servers/` start with `PORT=0`, print their port and answer a request. `bash -n` on all shell scripts. `run-all.sh ws http postgres install` was then run end to end from a fresh sparse clone of this branch on the benchmark machine (results and versions in the comment below); `bundler` was not part of that run.
