### PR TITLE
Bun.inspect: clear exceptions left behind by property lookups while walking an object

### DIFF
--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -320,9 +320,6 @@ static JSValue defaultBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, vm.propertyNames->defaultKeyword));
 }
@@ -332,9 +329,6 @@ static JSValue constructBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     auto clientData = WebCore::clientData(vm);
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, clientData->builtinNames().SQLPublicName()));

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5625,10 +5625,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
-                // Ignore exceptions from "Get" proxy traps.
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
+                // Ignore exceptions from "Get" proxy traps and lazy property initializers.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto
@@ -5700,7 +5701,12 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue prototype = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototypeOf" traps.
+            CLEAR_IF_EXCEPTION(scope);
+            if (!prototype) [[unlikely]]
+                break;
+            iterating = prototype.getObject();
         }
     }
 

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -2077,7 +2077,10 @@ extern "C" napi_status napi_get_all_property_names(
             if (key_mode == napi_key_include_prototypes) {
                 // Climb up the prototype chain to find inherited properties
                 while (!owner->getOwnPropertyDescriptor(globalObject, propKey, desc)) {
-                    JSObject* proto = owner->getPrototype(globalObject).getObject();
+                    NAPI_RETURN_IF_EXCEPTION(env);
+                    JSValue prototype = owner->getPrototype(globalObject);
+                    NAPI_RETURN_IF_EXCEPTION(env);
+                    JSObject* proto = prototype.getObject();
                     if (!proto) {
                         break;
                     }
@@ -2085,6 +2088,7 @@ extern "C" napi_status napi_get_all_property_names(
                 }
             } else {
                 owner->getOwnPropertyDescriptor(globalObject, propKey, desc);
+                NAPI_RETURN_IF_EXCEPTION(env);
             }
 
             // V8 never applies ONLY_WRITABLE/ONLY_CONFIGURABLE to Proxy keys

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -942,7 +942,7 @@ describe("exceptions thrown while walking properties", () => {
   }
 
   it.concurrent("a throwing Proxy get trap in the prototype chain skips that property", async () => {
-    const { stdout, exitCode } = await run(`
+    const result = await run(`
       const proto = new Proxy(
         { a: 1, b: 2, c: 3 },
         {
@@ -954,12 +954,11 @@ describe("exceptions thrown while walking properties", () => {
       );
       console.log(Bun.inspect(Object.create(proto)));
     `);
-    expect(stdout).toBe("{\n  c: 3,\n}\n");
-    expect(exitCode).toBe(0);
+    expect(result).toEqual({ stdout: "{\n  c: 3,\n}\n", stderr: "", exitCode: 0 });
   });
 
   it.concurrent("a throwing Proxy getPrototypeOf trap in the prototype chain stops the walk", async () => {
-    const { stdout, exitCode } = await run(`
+    const result = await run(`
       const proto = new Proxy(
         { a: 1 },
         {
@@ -970,15 +969,18 @@ describe("exceptions thrown while walking properties", () => {
       );
       console.log(Bun.inspect(Object.create(proto)));
     `);
-    expect(stdout).toBe("{\n  a: 1,\n}\n");
-    expect(exitCode).toBe(0);
+    expect(result).toEqual({ stdout: "{\n  a: 1,\n}\n", stderr: "", exitCode: 0 });
   });
 
   // Bun.$ is a lazy property whose initializer calls into JS. Inspecting the Bun
   // object right after a stack overflow makes that initializer throw; the
   // properties after it must still be visited.
-  it.concurrent("a lazy property initializer that throws does not hide the remaining properties", async () => {
-    const { stdout, exitCode } = await run(`
+  //
+  // On Windows, reading Bun.$ (or Bun.sql) at the stack limit kills the process
+  // with STATUS_STACK_BUFFER_OVERRUN instead of throwing, independently of the
+  // property walk being tested here.
+  it.concurrent.skipIf(isWindows)("a throwing lazy property initializer does not hide later properties", async () => {
+    const result = await run(`
       let result;
       function recurse() {
         try {
@@ -993,7 +995,6 @@ describe("exceptions thrown while walking properties", () => {
       recurse();
       console.log(result.includes("Archive: [class Archive]"));
     `);
-    expect(stdout).toBe("true\n");
-    expect(exitCode).toBe(0);
+    expect(result).toEqual({ stdout: "true\n", stderr: "", exitCode: 0 });
   });
 });

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -928,3 +928,72 @@ describe.skipIf(!isASAN)("object mutated while being formatted", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+describe("exceptions thrown while walking properties", () => {
+  async function run(code) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  it.concurrent("a throwing Proxy get trap in the prototype chain skips that property", async () => {
+    const { stdout, exitCode } = await run(`
+      const proto = new Proxy(
+        { a: 1, b: 2, c: 3 },
+        {
+          get(target, key, receiver) {
+            if (key === "a" || key === "b") throw new Error("no " + key);
+            return Reflect.get(target, key, receiver);
+          },
+        },
+      );
+      console.log(Bun.inspect(Object.create(proto)));
+    `);
+    expect(stdout).toBe("{\n  c: 3,\n}\n");
+    expect(exitCode).toBe(0);
+  });
+
+  it.concurrent("a throwing Proxy getPrototypeOf trap in the prototype chain stops the walk", async () => {
+    const { stdout, exitCode } = await run(`
+      const proto = new Proxy(
+        { a: 1 },
+        {
+          getPrototypeOf() {
+            throw new Error("no prototype");
+          },
+        },
+      );
+      console.log(Bun.inspect(Object.create(proto)));
+    `);
+    expect(stdout).toBe("{\n  a: 1,\n}\n");
+    expect(exitCode).toBe(0);
+  });
+
+  // Bun.$ is a lazy property whose initializer calls into JS. Inspecting the Bun
+  // object right after a stack overflow makes that initializer throw; the
+  // properties after it must still be visited.
+  it.concurrent("a lazy property initializer that throws does not hide the remaining properties", async () => {
+    const { stdout, exitCode } = await run(`
+      let result;
+      function recurse() {
+        try {
+          recurse();
+        } catch {}
+        if (result === undefined) {
+          try {
+            result = Bun.inspect(Bun);
+          } catch {}
+        }
+      }
+      recurse();
+      console.log(result.includes("Archive: [class Archive]"));
+    `);
+    expect(stdout).toBe("true\n");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -321,6 +321,65 @@ nativeTests.test_get_all_property_names_proxy_and_string_wrapper = () => {
   show("frozen writable:", apn(Object.freeze({ a: 1, b: 2 }), napi_key_writable));
 };
 
+// Applying an attribute filter looks up the descriptor of every collected key,
+// which runs Proxy traps. A trap that throws must surface as the pending
+// exception rather than being ignored.
+nativeTests.test_get_all_property_names_throwing_traps = () => {
+  const napi_key_include_prototypes = 0;
+  const napi_key_own_only = 1;
+  const napi_key_enumerable = 1 << 1;
+  const napi_key_keep_numbers = 0;
+
+  const apn = (label, obj, mode) => {
+    try {
+      const { status } = nativeTests.get_all_property_names(obj, mode, napi_key_enumerable, napi_key_keep_numbers);
+      console.log(label, "status=" + status);
+    } catch (e) {
+      console.log(label, "threw:", e.message);
+    }
+  };
+
+  const throwingDescriptors = {
+    getOwnPropertyDescriptor() {
+      throw new Error("getOwnPropertyDescriptor trap");
+    },
+  };
+  apn("own_only:", new Proxy({ x: 1 }, throwingDescriptors), napi_key_own_only);
+  apn("include_prototypes:", Object.create(new Proxy({ x: 1 }, throwingDescriptors)), napi_key_include_prototypes);
+};
+
+// Bun looks up the prototype chain a second time while filtering, so a
+// getPrototypeOf trap that only throws after key collection is reached there.
+// Node only invokes the trap once and returns the keys, so this is not
+// compared against Node.
+nativeTests.test_get_all_property_names_get_prototype_of_throws_while_filtering = () => {
+  const napi_key_include_prototypes = 0;
+  const napi_key_enumerable = 1 << 1;
+  const napi_key_keep_numbers = 0;
+
+  let calls = 0;
+  const proxy = new Proxy(
+    {},
+    {
+      getPrototypeOf(target) {
+        if (calls++ > 0) throw new Error("getPrototypeOf trap");
+        return Reflect.getPrototypeOf(target);
+      },
+    },
+  );
+  try {
+    const { status } = nativeTests.get_all_property_names(
+      Object.create(proxy),
+      napi_key_include_prototypes,
+      napi_key_enumerable,
+      napi_key_keep_numbers,
+    );
+    console.log("status=" + status);
+  } catch (e) {
+    console.log("threw:", e.message);
+  }
+};
+
 nativeTests.test_set_property = () => {
   const objects = [
     {},

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -880,6 +880,15 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
       expect(output).toContain(`plain writable: status=0 keys=["w","nc"]`);
       expect(output).toContain(`frozen writable: status=0 keys=[]`);
     });
+    it("propagates exceptions thrown by Proxy traps while filtering", async () => {
+      const output = await checkSameOutput("test_get_all_property_names_throwing_traps", []);
+      expect(output).toContain("own_only: threw: getOwnPropertyDescriptor trap");
+      expect(output).toContain("include_prototypes: threw: getOwnPropertyDescriptor trap");
+    });
+    it("propagates an exception from getPrototypeOf thrown while filtering", async () => {
+      const output = await runOn(bunExe(), "test_get_all_property_names_get_prototype_of_throws_while_filtering", []);
+      expect(output.replaceAll(/^\[\w+\].+$/gm, "").trim()).toBe("threw: getPrototypeOf trap");
+    });
   });
 
   describe("napi_value <=> integer conversion", () => {


### PR DESCRIPTION
### What does this PR do?

Found by fuzzing (`Bun.inspect(Bun)` right after a caught stack overflow aborted a debug build with `ASSERTION FAILED: Unexpected exception observed ... Maximum call stack size exceeded`).

`JSC__JSValue__forEachPropertyImpl` (the walk behind `Bun.inspect` / `console.log` for objects that can't take the fast structure walk) had two exception handling holes in its slow path, in `src/jsc/bindings/bindings.cpp`:

1. When `getPropertySlot` returned false it did `continue` before `CLEAR_IF_EXCEPTION`, so a lookup that failed by throwing left the exception pending for the rest of the walk. That happens for a throwing Proxy `get` trap in the prototype chain, and for a lazy property whose initializer throws (`Bun.$` calls into JS to build the shell object, so it throws when the stack is nearly exhausted; `setUpStaticFunctionSlot` then reports the slot as not found). With the exception still pending, `setUpStaticFunctionSlot` reports every following static property as missing too, so `Bun.inspect(Bun)` silently dropped everything from `$` up to the first already reified property. In debug builds the next lazy callback (`Archive`) hit the assertion in `to_js_host_call` instead. The fix is to clear before deciding whether to skip the property, which is what `JSC__JSValue__forEachPropertyOrdered` already does.

2. `iterating = iterating->getPrototype(globalObject).getObject()` when walking up the chain. `getPrototype` returns an empty `JSValue` when a Proxy `getPrototypeOf` trap throws (or, before fix 1, whenever an exception was already pending), and `JSValue().getObject()` is a null `JSCell` deref. Release builds segfault at address 0x5 on `Bun.inspect(Object.create(new Proxy({}, { getPrototypeOf() { throw 1 } })))`. Now the walk stops there.

With 1 fixed, the fuzzer's script got further and tripped a second debug-only assertion: the `#if BUN_DEBUG` blocks in `defaultBunSQLObject` / `constructBunSQLObject` call `reportUncaughtExceptionAtEventLoop` while the exception is still pending in the VM (every other caller clears first). The uncaught exception handler then looks up properties on `process`, whose own lazy properties get reified but reported as missing because of the pending exception, and `JSObject::getPropertySlot` asserts on the stale structure. The exception already propagates to whoever touched `Bun.sql`, so the blocks are removed rather than patched.

Second commit, from review: the attribute filter loop in `napi_get_all_property_names` (`src/jsc/bindings/napi.cpp`) had the same two holes. It called `getOwnPropertyDescriptor` and `getPrototype` on each object in the chain without checking for exceptions, so a throwing Proxy trap was ignored (the call then returned `napi_ok` with the exception still pending, which debug builds assert on in `NAPI_RETURN_SUCCESS`) or, once `getPrototype` came back empty, hit the same null deref. It now returns `napi_pending_exception`, as the key collection step right above it already does, which is also what Node returns there. The other `getPrototype` callers in `src/jsc/bindings` (deep equals, REPL completions, `ObjectBindings.cpp`, `WebStreamsInspectCustom.cpp`, the two fast-path sites in this same function) already check the result or only run on objects that cannot have traps.

### How did you verify your code works?

Added three tests to `test/js/bun/util/inspect.test.js` ("exceptions thrown while walking properties"). Before this change all three fail on a release build (the two Proxy cases crash the child process, the lazy property case prints `false` because `Archive` is missing from the output), and the lazy property case aborts a debug build with the assertion above. All pass with the patched debug build, and the rest of `inspect.test.js`, `test/js/bun/console/`, and the node `util.inspect` proxy/getter suites still pass. The lazy property case is skipped on Windows: there, reading `Bun.$` or `Bun.sql` at the stack limit kills the process with `STATUS_STACK_BUFFER_OVERRUN` on an unpatched main build as well (verified on Windows Server 2019 with the canary; generic native to JS reentry like a `JSON.parse` reviver throws RangeError as expected there), so the scenario cannot run before reaching the code under test. That crash is tracked separately. The two Proxy cases run on Windows too; on the unpatched canary the `get` trap case prints `{}` there instead of crashing.

For napi, added two cases to `test/napi/napi-app/module.js` wired up in `test/napi/napi.test.ts`. The throwing `getOwnPropertyDescriptor` trap case is compared against Node's output (both print `threw: getOwnPropertyDescriptor trap` for own_only and include_prototypes); before the fix the debug build aborted on the `NAPI_RETURN_SUCCESS` assertion. The `getPrototypeOf` trap that throws on its second call is Bun only, since Node invokes the trap once during collection and returns the keys; before the fix it died in `JSValue::getObject()` on the empty value. `test/napi/napi.test.ts` and Node's `test_object` suite under `test/napi/node-napi-tests` pass with the patched build.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/inspect.test.js test/napi/napi.test.ts

<!-- robobun:evidence:end -->
