### PR TITLE
install: stop leaking the displaced cache folder when a tarball is re-extracted

### DIFF
--- a/src/install/PackageManager/patchPackage.rs
+++ b/src/install/PackageManager/patchPackage.rs
@@ -344,6 +344,7 @@ pub fn do_patch_commit(
                 random_tempdir.as_bytes(),
                 sys::RenameOptions {
                     move_fallback: true,
+                    ..Default::default()
                 },
             )
             .is_err()
@@ -399,6 +400,7 @@ pub fn do_patch_commit(
                 patch_tag_tmpname.as_bytes(),
                 sys::RenameOptions {
                     move_fallback: true,
+                    ..Default::default()
                 },
             ) {
                 bun_core::warn!(
@@ -431,7 +433,7 @@ pub fn do_patch_commit(
                         random_tempdir.as_bytes(),
                         new_folder_handle.fd,
                         b"node_modules",
-                        sys::RenameOptions { move_fallback: true },
+                        sys::RenameOptions { move_fallback: true, ..Default::default() },
                     ) {
                         bun_core::warn!("failed renaming nested node_modules folder, this may cause issues: {}", e);
                     }
@@ -443,7 +445,7 @@ pub fn do_patch_commit(
                         patch_tag_tmpname.as_bytes(),
                         new_folder_handle.fd,
                         patch_tag,
-                        sys::RenameOptions { move_fallback: true },
+                        sys::RenameOptions { move_fallback: true, ..Default::default() },
                     ) {
                         bun_core::warn!("failed renaming the bun patch tag, this may cause issues: {}", e);
                     }
@@ -588,6 +590,7 @@ pub fn do_patch_commit(
         path_in_patches_dir,
         sys::RenameOptions {
             move_fallback: true,
+            ..Default::default()
         },
     ) {
         Output::err(e, "failed renaming patch file to patches dir", ());

--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -133,6 +133,8 @@ pub struct TarballStream {
     /// Owned copy of the temp-directory name.
     // `ZBox` is the owned NUL-terminated counterpart of `&ZStr`.
     tmpname: ZBox,
+    /// Captured in `init`, before the first byte is extracted.
+    cache_publish: CachePublish,
 
     /// Incremental SHA over the *compressed* bytes, matching
     /// `Integrity.verify` / `Integrity.forBytes` in the buffered path.
@@ -230,6 +232,7 @@ impl TarballStream {
             },
             compute_if_missing,
         );
+        let cache_publish = tarball.cache_publish();
 
         // bun.TrivialNew(@This()) → heap::alloc(Box::new(...)). Pointer is
         // recovered via `container_of` from the thread-pool callback and
@@ -254,6 +257,7 @@ impl TarballStream {
             entry_final_offset: 0,
             dest: None,
             tmpname: ZBox::from_bytes(b""),
+            cache_publish,
             hasher,
             resolved_github_dirname: b"",
             want_first_dirname,
@@ -1159,6 +1163,7 @@ impl TarballStream {
                 name,
                 basename,
                 self.resolved_github_dirname,
+                self.cache_publish,
             ) {
                 Ok(r) => r,
                 Err(err) => {
@@ -1452,5 +1457,6 @@ fn tokenize_rest_after_first(s: &[OSPathChar]) -> &[OSPathChar] {
 
 // Resolved Phase-B paths: Resolution::Tag is the real npm/git/tarball
 // discriminant; Data/Status live on PackageManagerTask.
+use crate::extract_tarball::CachePublish;
 use crate::package_manager_task::{Data as TaskData, Status as TaskStatus};
 use crate::resolution::Tag as ResolutionTag;

--- a/src/install/extract_tarball.rs
+++ b/src/install/extract_tarball.rs
@@ -181,30 +181,23 @@ pub(crate) fn uses_streaming_extraction() -> bool {
         .unwrap_or(false)
 }
 
-/// What `move_to_cache_directory` does when the cache already has a folder
-/// under the name being published. Decided by `cache_publish()` before
-/// extraction starts; by the time the extracted tree is renamed into place,
-/// a folder that was there all along and one a concurrent install published
-/// in the meantime look the same.
+/// How `move_to_cache_directory` treats a cache folder that already has the
+/// name being published. Decided before extracting: afterwards a pre-existing
+/// folder and one a concurrent install published meanwhile look the same.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CachePublish {
-    /// Swap the fresh copy in and leave the one swapped out in the temp
-    /// directory: it may have been published by a concurrent install that is
-    /// still installing from it. npm and GitHub folders are published this way.
+    /// npm and GitHub: swap the fresh copy in. The swapped-out folder is left
+    /// in the temp dir, as a concurrent install may still be reading it.
     Replace,
-    /// The folder was already there when this tarball's task started, so this
-    /// is a re-extraction of the same tarball path or URL (no lockfile, or the
-    /// tarball behind it changed): swap the fresh copy in and delete the one
-    /// swapped out.
+    /// Tarball re-extracted over its own folder: swap the fresh copy in and
+    /// delete the swapped-out folder.
     Supersede,
-    /// The folder was missing when this tarball's task started. If it exists
-    /// now, a concurrent install extracted the same tarball first: keep its
-    /// copy and delete ours, which nothing else can have opened.
+    /// Tarball whose folder did not exist yet: if one exists by now, a
+    /// concurrent install extracted the same tarball, so keep it and drop ours.
     KeepExisting,
 }
 
 impl ExtractTarball {
-    /// See [`CachePublish`]. Must run before anything is extracted.
     pub(crate) fn cache_publish(&self) -> CachePublish {
         if !self.resolution.tag.is_tarball() {
             return CachePublish::Replace;
@@ -708,8 +701,6 @@ impl ExtractTarball {
                     }
                 }
 
-                // An existing folder is normally swapped out atomically (see
-                // `renameat_concurrently`); `KeepExisting` leaves it alone.
                 match sys::renameat_concurrently_a(
                     tmpdir.fd(),
                     tmpname.as_bytes(),
@@ -738,10 +729,8 @@ impl ExtractTarball {
                 }
             };
 
-            // Whatever is left under the temp name is either our own copy (the
-            // move failed, or a concurrent install published first) or the
-            // folder we superseded. `Replace` leaves a swapped-out folder
-            // alone, see `CachePublish`.
+            // The temp name now holds our own copy (failed or lost), the
+            // superseded folder, or a `Replace` swap-out (see `CachePublish`).
             if moved.is_err() || publish != CachePublish::Replace {
                 let _ = tmpdir.delete_tree(tmpname.as_bytes());
             }

--- a/src/install/extract_tarball.rs
+++ b/src/install/extract_tarball.rs
@@ -181,7 +181,49 @@ pub(crate) fn uses_streaming_extraction() -> bool {
         .unwrap_or(false)
 }
 
+/// What `move_to_cache_directory` does when the cache already has a folder
+/// under the name being published. Decided by `cache_publish()` before
+/// extraction starts; by the time the extracted tree is renamed into place,
+/// a folder that was there all along and one a concurrent install published
+/// in the meantime look the same.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CachePublish {
+    /// Swap the fresh copy in and leave the one swapped out in the temp
+    /// directory: it may have been published by a concurrent install that is
+    /// still installing from it. npm and GitHub folders are published this way.
+    Replace,
+    /// The folder was already there when this tarball's task started, so this
+    /// is a re-extraction of the same tarball path or URL (no lockfile, or the
+    /// tarball behind it changed): swap the fresh copy in and delete the one
+    /// swapped out.
+    Supersede,
+    /// The folder was missing when this tarball's task started. If it exists
+    /// now, a concurrent install extracted the same tarball first: keep its
+    /// copy and delete ours, which nothing else can have opened.
+    KeepExisting,
+}
+
 impl ExtractTarball {
+    /// See [`CachePublish`]. Must run before anything is extracted.
+    pub(crate) fn cache_publish(&self) -> CachePublish {
+        if !self.resolution.tag.is_tarball() {
+            return CachePublish::Replace;
+        }
+        let name_taken = TL_BUFS.with_borrow_mut(|bufs| {
+            let folder_name = directories::cached_tarball_folder_name_print(
+                &mut bufs.folder_name_buf,
+                self.url.slice(),
+                None,
+            );
+            sys::exists_at_type(self.cache_dir, folder_name).is_ok()
+        });
+        if name_taken {
+            CachePublish::Supersede
+        } else {
+            CachePublish::KeepExisting
+        }
+    }
+
     /// Derive the display name and a filesystem-safe basename for this
     /// package. Shared by the buffered `extract()` path below and the
     /// streaming extractor in `TarballStream.rs` so both pick identical
@@ -256,6 +298,7 @@ impl ExtractTarball {
         let mut resolved: &'static [u8] = b"";
         let tmpname =
             FileSystem::tmpname(tmpname_suffix, &mut tmpname_buf.0, bun_core::fast_random())?;
+        let publish = self.cache_publish();
         {
             let extract_destination = match bun_sys::make_path::make_open_path(
                 tmpdir,
@@ -439,7 +482,7 @@ impl ExtractTarball {
             }
         }
 
-        self.move_to_cache_directory(log, tmpname, name, basename, resolved)
+        self.move_to_cache_directory(log, tmpname, name, basename, resolved, publish)
     }
 
     /// Rename the freshly-extracted temp directory into the cache, read
@@ -452,6 +495,7 @@ impl ExtractTarball {
         name: &[u8],
         basename: &[u8],
         resolved: &[u8],
+        publish: CachePublish,
     ) -> Result<ExtractData, Error> {
         let package_manager = self.package_manager.get();
 
@@ -521,7 +565,7 @@ impl ExtractTarball {
 
             // Now that we've extracted the archive, we rename.
             #[cfg(windows)]
-            {
+            let moved: Result<(), Error> = 'moved: {
                 // Windows EBUSY/SHARING_VIOLATION on `NtSetInformationFile` is
                 // transient when a concurrent process (another `bun install`
                 // sharing the cache, AV, the Search Indexer) is closing its
@@ -537,6 +581,10 @@ impl ExtractTarball {
                 }
 
                 let path_to_use = path2;
+                let mut folder_name_z_buf = PathBuffer::uninit();
+                folder_name_z_buf[0..folder_name.len()].copy_from_slice(folder_name);
+                folder_name_z_buf[folder_name.len()] = 0;
+                let folder_name_z = ZStr::from_buf(&folder_name_z_buf, folder_name.len());
 
                 loop {
                     let dir_to_move = match sys::open_dir_at_windows_a(
@@ -562,7 +610,7 @@ impl ExtractTarball {
                                     bun_fmt::s(folder_name),
                                 ),
                             );
-                            return Err(crate::Error::InstallFailed);
+                            break 'moved Err(crate::Error::InstallFailed);
                         }
                     };
 
@@ -582,6 +630,16 @@ impl ExtractTarball {
                                         // before we attempt to delete the destination, let's close the source dir.
                                         let _ = sys::close(dir_to_move);
 
+                                        if publish == CachePublish::KeepExisting
+                                            && sys::directory_exists_at(
+                                                cache_dir.fd(),
+                                                folder_name_z,
+                                            )
+                                            .unwrap_or(false)
+                                        {
+                                            break;
+                                        }
+
                                         // We tried to move the folder over
                                         // but it didn't work!
                                         // so instead of just simply deleting the folder
@@ -595,12 +653,6 @@ impl ExtractTarball {
                                             .copy_from_slice(&[b't', b'm', b'p', 0]);
                                         let tempdest =
                                             ZStr::from_buf(&tempdest_buf, tmpname.len() + 3);
-                                        let mut folder_name_z_buf = PathBuffer::uninit();
-                                        folder_name_z_buf[0..folder_name.len()]
-                                            .copy_from_slice(folder_name);
-                                        folder_name_z_buf[folder_name.len()] = 0;
-                                        let folder_name_z =
-                                            ZStr::from_buf(&folder_name_z_buf, folder_name.len());
                                         match sys::renameat(
                                             Fd::from_std_dir(cache_dir),
                                             folder_name_z,
@@ -637,7 +689,7 @@ impl ExtractTarball {
                                     bun_fmt::s(folder_name),
                                 ),
                             );
-                            return Err(crate::Error::InstallFailed);
+                            break 'moved Err(crate::Error::InstallFailed);
                         }
                         bun_sys::Result::Ok(_) => {
                             let _ = sys::close(dir_to_move);
@@ -646,47 +698,54 @@ impl ExtractTarball {
 
                     break;
                 }
-            }
+                Ok(())
+            };
             #[cfg(not(windows))]
-            {
-                // Attempt to gracefully handle duplicate concurrent `bun install` calls
-                //
-                // By:
-                // 1. Rename from temporary directory to cache directory and fail if it already exists
-                // 2a. If the rename fails, swap the cache directory with the temporary directory version
-                // 2b. Delete the temporary directory version ONLY if we're not using a provided temporary directory
-                // 3. If rename still fails, fallback to racily deleting the cache directory version and then renaming the temporary directory version again.
-                //
-
+            let moved: Result<(), Error> = {
                 if create_subdir {
                     if let Some(folder) = bun_paths::Dirname::dirname(folder_name) {
                         let _ = bun_sys::make_path::make_path(cache_dir, folder);
                     }
                 }
 
-                if let Err(err) = sys::renameat_concurrently_a(
+                // An existing folder is normally swapped out atomically (see
+                // `renameat_concurrently`); `KeepExisting` leaves it alone.
+                match sys::renameat_concurrently_a(
                     tmpdir.fd(),
                     tmpname.as_bytes(),
                     cache_dir.fd(),
                     folder_name,
                     sys::RenameatConcurrentlyOptions {
                         move_fallback: true,
+                        keep_existing_destination: publish == CachePublish::KeepExisting,
                     },
                 ) {
-                    log.add_error_fmt(
-                        None,
-                        bun_ast::Loc::EMPTY,
-                        format_args!(
-                            "moving \"{}\" to cache dir failed: {}\n  From: {}\n    To: {}",
-                            bun_fmt::s(name),
-                            err,
-                            bun_fmt::s(tmpname.as_bytes()),
-                            bun_fmt::s(folder_name),
-                        ),
-                    );
-                    return Err(crate::Error::InstallFailed);
+                    Ok(()) => Ok(()),
+                    Err(err) => {
+                        log.add_error_fmt(
+                            None,
+                            bun_ast::Loc::EMPTY,
+                            format_args!(
+                                "moving \"{}\" to cache dir failed: {}\n  From: {}\n    To: {}",
+                                bun_fmt::s(name),
+                                err,
+                                bun_fmt::s(tmpname.as_bytes()),
+                                bun_fmt::s(folder_name),
+                            ),
+                        );
+                        Err(crate::Error::InstallFailed)
+                    }
                 }
+            };
+
+            // Whatever is left under the temp name is either our own copy (the
+            // move failed, or a concurrent install published first) or the
+            // folder we superseded. `Replace` leaves a swapped-out folder
+            // alone, see `CachePublish`.
+            if moved.is_err() || publish != CachePublish::Replace {
+                let _ = tmpdir.delete_tree(tmpname.as_bytes());
             }
+            moved?;
 
             // We return a resolved absolute absolute file path to the cache dir.
             // To get that directory, we open the directory again.

--- a/src/install/repository.rs
+++ b/src/install/repository.rs
@@ -468,9 +468,7 @@ impl CacheStaging {
             self.tmp_name(),
             self.cache_dir,
             folder_name,
-            bun_sys::RenameatConcurrentlyOptions {
-                move_fallback: false,
-            },
+            bun_sys::RenameatConcurrentlyOptions::default(),
         );
         // After an exchange the temporary name holds the folder that was replaced.
         self.discard();

--- a/src/install/resolution.rs
+++ b/src/install/resolution.rs
@@ -965,6 +965,13 @@ impl Tag {
         self == Tag::Git || self == Tag::Github
     }
 
+    /// A tarball addressed by path or URL. Its cache folder is named after
+    /// that address, not the contents, so the same folder can hold different
+    /// versions of the tarball over time.
+    pub(crate) fn is_tarball(self) -> bool {
+        self == Tag::LocalTarball || self == Tag::RemoteTarball
+    }
+
     pub(crate) fn can_enqueue_install_task(self) -> bool {
         self == Tag::Npm
             || self == Tag::LocalTarball

--- a/src/install/resolution.rs
+++ b/src/install/resolution.rs
@@ -965,9 +965,8 @@ impl Tag {
         self == Tag::Git || self == Tag::Github
     }
 
-    /// A tarball addressed by path or URL. Its cache folder is named after
-    /// that address, not the contents, so the same folder can hold different
-    /// versions of the tarball over time.
+    /// Cached under a hash of the path or URL, so the folder's contents can
+    /// change from one extraction to the next.
     pub(crate) fn is_tarball(self) -> bool {
         self == Tag::LocalTarball || self == Tag::RemoteTarball
     }

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -9197,7 +9197,13 @@ pub fn exists(path: &[u8]) -> bool {
 /// retries; on EXDEV falls back to the slow open+copy path. Only opens the
 /// source inside the EXDEV branch.
 pub fn move_file_z(from_dir: Fd, filename: &ZStr, to_dir: Fd, destination: &ZStr) -> Maybe<()> {
-    match renameat_concurrently_without_fallback(from_dir, filename, to_dir, destination) {
+    match renameat_concurrently_without_fallback(
+        from_dir,
+        filename,
+        to_dir,
+        destination,
+        RenameatConcurrentlyOptions::default(),
+    ) {
         Ok(()) => Ok(()),
         // allow over-writing an empty directory
         Err(e) if e.get_errno() == E::EISDIR => {
@@ -9278,6 +9284,11 @@ pub fn renameat_z(from_dir: impl AsFd, from: &ZStr, to_dir: impl AsFd, to: &ZStr
 #[derive(Default, Clone, Copy)]
 pub struct RenameatConcurrentlyOptions {
     pub move_fallback: bool,
+    /// When `to` already exists, leave it in place and delete `from` instead
+    /// of replacing it. For a shared cache this is the "another process
+    /// published the same thing first" outcome: the existing tree may already
+    /// have readers, while nothing else can have found `from` yet.
+    pub keep_existing_destination: bool,
 }
 /// Alias: `bun_install` call sites spell this `RenameOptions`.
 pub type RenameOptions = RenameatConcurrentlyOptions;
@@ -9296,7 +9307,12 @@ pub(crate) fn move_file_z_slow_maybe(
 
 /// `renameatConcurrently`. Tries an atomic NOREPLACE rename,
 /// then EXCHANGE, then a racy delete-tree + rename. With `move_fallback` set,
-/// an EXDEV result falls through to a slow open/copy.
+/// an EXDEV result falls through to a slow open/copy. With
+/// `keep_existing_destination` set, an existing `to` wins and `from` is
+/// deleted instead.
+///
+/// After a successful EXCHANGE, `from` names the tree that used to be at
+/// `to`; callers that do not want to keep it have to delete it themselves.
 pub fn renameat_concurrently(
     from_dir_fd: Fd,
     from: &ZStr,
@@ -9304,7 +9320,7 @@ pub fn renameat_concurrently(
     to: &ZStr,
     opts: RenameatConcurrentlyOptions,
 ) -> Maybe<()> {
-    match renameat_concurrently_without_fallback(from_dir_fd, from, to_dir_fd, to) {
+    match renameat_concurrently_without_fallback(from_dir_fd, from, to_dir_fd, to, opts) {
         Ok(()) => Ok(()),
         Err(e) => {
             if opts.move_fallback && e.get_errno() == E::EXDEV {
@@ -9324,6 +9340,7 @@ pub(crate) fn renameat_concurrently_without_fallback(
     from: &ZStr,
     to_dir_fd: Fd,
     to: &ZStr,
+    opts: RenameatConcurrentlyOptions,
 ) -> Maybe<()> {
     'attempt: {
         {
@@ -9348,6 +9365,27 @@ pub(crate) fn renameat_concurrently_without_fallback(
                 }
                 Ok(()) => break 'attempt,
             };
+
+            // The errno alone does not say whether `to` exists (Windows and
+            // filesystems without RENAME_NOREPLACE fail differently), so look.
+            if opts.keep_existing_destination
+                && exists_at_type(
+                    if to_dir_fd.is_valid() {
+                        to_dir_fd
+                    } else {
+                        Fd::cwd()
+                    },
+                    to,
+                )
+                .is_ok()
+            {
+                if from_dir_fd.is_valid() {
+                    let _ = Dir::borrow(&from_dir_fd).delete_tree(from.as_bytes());
+                } else {
+                    let _ = delete_tree_absolute(from.as_bytes());
+                }
+                break 'attempt;
+            }
 
             // Windows doesn't have any equivalent of renameat with swap
             #[cfg(not(windows))]
@@ -9711,6 +9749,7 @@ mod owned_handle_tests {
             b"sub",
             RenameatConcurrentlyOptions {
                 move_fallback: true,
+                ..Default::default()
             },
         )
         .expect("rename");
@@ -9722,6 +9761,48 @@ mod owned_handle_tests {
         );
 
         // Cleanup.
+        let _ = close(to_dir);
+        let _ = close(root);
+        let _ = Dir::open(&tmp).map(|d| d.delete_tree(b"."));
+    }
+
+    #[test]
+    fn renameat_concurrently_keep_existing_destination() {
+        let _g = crate::file::tests::FD_TEST_LOCK.lock();
+        let mut tmp = std::env::temp_dir().as_os_str().as_encoded_bytes().to_vec();
+        tmp.extend_from_slice(b"/bun_sys_renameat_keep_existing_test");
+        let _ = Dir::open(&tmp).map(|d| d.delete_tree(b"."));
+        let _ = mkdir_recursive_at(Fd::cwd(), &tmp);
+        let root = open_dir_at(Fd::cwd(), &tmp).expect("open root");
+        let _ = mkdir_recursive_at(root, b"from/sub");
+        let _ = mkdir_recursive_at(root, b"to/sub");
+        File::write_file(root, ZStr::from_static(b"from/sub/loser\0"), b"").expect("loser");
+        File::write_file(root, ZStr::from_static(b"to/sub/winner\0"), b"").expect("winner");
+        let to_dir = open_dir_at(root, b"to").expect("open to");
+
+        let opts = RenameatConcurrentlyOptions {
+            keep_existing_destination: true,
+            ..Default::default()
+        };
+
+        // Destination taken: it is kept as-is and the source goes away.
+        renameat_concurrently_a(root, b"from/sub", to_dir, b"sub", opts).expect("rename");
+        assert!(matches!(
+            exists_at_type(root, ZStr::from_static(b"to/sub/winner\0")),
+            Ok(ExistsAtType::File)
+        ));
+        assert!(exists_at_type(root, ZStr::from_static(b"to/sub/loser\0")).is_err());
+        assert!(exists_at_type(root, ZStr::from_static(b"from/sub\0")).is_err());
+
+        // Destination free: a plain rename.
+        let _ = mkdir_recursive_at(root, b"from/other");
+        renameat_concurrently_a(root, b"from/other", to_dir, b"other", opts).expect("rename");
+        assert!(matches!(
+            exists_at_type(root, ZStr::from_static(b"to/other\0")),
+            Ok(ExistsAtType::Directory)
+        ));
+        assert!(exists_at_type(root, ZStr::from_static(b"from/other\0")).is_err());
+
         let _ = close(to_dir);
         let _ = close(root);
         let _ = Dir::open(&tmp).map(|d| d.delete_tree(b"."));

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -9284,10 +9284,8 @@ pub fn renameat_z(from_dir: impl AsFd, from: &ZStr, to_dir: impl AsFd, to: &ZStr
 #[derive(Default, Clone, Copy)]
 pub struct RenameatConcurrentlyOptions {
     pub move_fallback: bool,
-    /// When `to` already exists, leave it in place and delete `from` instead
-    /// of replacing it. For a shared cache this is the "another process
-    /// published the same thing first" outcome: the existing tree may already
-    /// have readers, while nothing else can have found `from` yet.
+    /// If `to` already exists (another process published it first and may be
+    /// reading it), keep it and delete `from` instead of replacing it.
     pub keep_existing_destination: bool,
 }
 /// Alias: `bun_install` call sites spell this `RenameOptions`.
@@ -9307,12 +9305,9 @@ pub(crate) fn move_file_z_slow_maybe(
 
 /// `renameatConcurrently`. Tries an atomic NOREPLACE rename,
 /// then EXCHANGE, then a racy delete-tree + rename. With `move_fallback` set,
-/// an EXDEV result falls through to a slow open/copy. With
-/// `keep_existing_destination` set, an existing `to` wins and `from` is
-/// deleted instead.
-///
-/// After a successful EXCHANGE, `from` names the tree that used to be at
-/// `to`; callers that do not want to keep it have to delete it themselves.
+/// an EXDEV result falls through to a slow open/copy; see
+/// [`RenameatConcurrentlyOptions`] for `keep_existing_destination`.
+/// After an EXCHANGE, `from` holds the tree that was at `to`.
 pub fn renameat_concurrently(
     from_dir_fd: Fd,
     from: &ZStr,
@@ -9366,8 +9361,8 @@ pub(crate) fn renameat_concurrently_without_fallback(
                 Ok(()) => break 'attempt,
             };
 
-            // The errno alone does not say whether `to` exists (Windows and
-            // filesystems without RENAME_NOREPLACE fail differently), so look.
+            // Not keyed on the errno: Windows and filesystems without
+            // RENAME_NOREPLACE report an existing `to` differently.
             if opts.keep_existing_destination
                 && exists_at_type(
                     if to_dir_fd.is_valid() {

--- a/test/cli/install/bun-install-tarball-integrity.test.ts
+++ b/test/cli/install/bun-install-tarball-integrity.test.ts
@@ -2,7 +2,7 @@ import { file, spawn } from "bun";
 import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
 import { rm, writeFile } from "fs/promises";
 import { bunExe, bunEnv as env, readdirSorted, tempDir } from "harness";
-import { createHash } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import { gzipSync } from "node:zlib";
 import { join } from "path";
 import {
@@ -38,6 +38,33 @@ async function withContext(
 
 // Default context options for most tests
 const defaultOpts = { linker: "hoisted" as const };
+
+/** A .tgz with the given files under the usual `package/` root. */
+function tarball(files: Record<string, Buffer>): Buffer {
+  function octal(n: number, width: number) {
+    return n.toString(8).padStart(width - 1, "0") + "\0";
+  }
+  const blocks: Buffer[] = [];
+  for (const [name, body] of Object.entries(files)) {
+    const header = Buffer.alloc(512, 0);
+    header.write(`package/${name}`, 0, 100, "utf8");
+    header.write(octal(0o644, 8), 100);
+    header.write(octal(0, 8), 108);
+    header.write(octal(0, 8), 116);
+    header.write(octal(body.length, 12), 124);
+    header.write(octal(0, 12), 136);
+    header.fill(" ", 148, 156);
+    header.write("0", 156);
+    header.write("ustar\0", 257);
+    header.write("00", 263);
+    let sum = 0;
+    for (let i = 0; i < 512; i++) sum += header[i];
+    header.write(octal(sum, 8), 148);
+    blocks.push(header, body, Buffer.alloc((512 - (body.length % 512)) % 512, 0));
+  }
+  blocks.push(Buffer.alloc(1024, 0));
+  return gzipSync(Buffer.concat(blocks));
+}
 
 describe.concurrent("tarball integrity", () => {
   it("should store integrity hash for tarball URL in text lockfile", async () => {
@@ -506,37 +533,8 @@ describe.concurrent.each(["hoisted", "isolated"] as const)("tarball integrity mi
   // callback is the void `onPackageDownloadError = {}` — i.e. the branch the
   // fix in runTasks.zig now cleans up.
   it("should fail (not hang) when tarball bytes don't match manifest SHA-512", { timeout: 60_000 }, async () => {
-    function octal(n: number, width: number) {
-      return n.toString(8).padStart(width - 1, "0") + "\0";
-    }
-    function tarHeader(name: string, size: number) {
-      const buf = Buffer.alloc(512, 0);
-      buf.write(name, 0, 100, "utf8");
-      buf.write(octal(0o644, 8), 100);
-      buf.write(octal(0, 8), 108);
-      buf.write(octal(0, 8), 116);
-      buf.write(octal(size, 12), 124);
-      buf.write(octal(0, 12), 136);
-      buf.fill(" ", 148, 156);
-      buf.write("0", 156);
-      buf.write("ustar\0", 257);
-      buf.write("00", 263);
-      let sum = 0;
-      for (let i = 0; i < 512; i++) sum += buf[i];
-      buf.write(octal(sum, 8), 148);
-      return buf;
-    }
-    function pad512(len: number) {
-      return Buffer.alloc((512 - (len % 512)) % 512, 0);
-    }
     function buildTarball(body: Buffer) {
-      const tar = Buffer.concat([
-        tarHeader("package/package.json", body.length),
-        body,
-        pad512(body.length),
-        Buffer.alloc(1024, 0),
-      ]);
-      const tgz = gzipSync(tar);
+      const tgz = tarball({ "package.json": body });
       return { tgz, integrity: "sha512-" + createHash("sha512").update(tgz).digest("base64") };
     }
 
@@ -617,34 +615,8 @@ describe.concurrent.each(["hoisted", "isolated"] as const)("tarball integrity mi
 });
 
 describe.concurrent("tarball integrity metadata forms", () => {
-  function octal(n: number, width: number) {
-    return n.toString(8).padStart(width - 1, "0") + "\0";
-  }
-  function tarHeader(name: string, size: number) {
-    const buf = Buffer.alloc(512, 0);
-    buf.write(name, 0, 100, "utf8");
-    buf.write(octal(0o644, 8), 100);
-    buf.write(octal(0, 8), 108);
-    buf.write(octal(0, 8), 116);
-    buf.write(octal(size, 12), 124);
-    buf.write(octal(0, 12), 136);
-    buf.fill(" ", 148, 156);
-    buf.write("0", 156);
-    buf.write("ustar\0", 257);
-    buf.write("00", 263);
-    let sum = 0;
-    for (let i = 0; i < 512; i++) sum += buf[i];
-    buf.write(octal(sum, 8), 148);
-    return buf;
-  }
   function buildTarball(body: Buffer) {
-    const tar = Buffer.concat([
-      tarHeader("package/package.json", body.length),
-      body,
-      Buffer.alloc((512 - (body.length % 512)) % 512, 0),
-      Buffer.alloc(1024, 0),
-    ]);
-    const tgz = gzipSync(tar);
+    const tgz = tarball({ "package.json": body });
     return {
       tgz,
       sha512: "sha512-" + createHash("sha512").update(tgz).digest("base64"),
@@ -852,5 +824,99 @@ describe.concurrent.each(["hoisted", "isolated"] as const)("tarball download fai
         expect(exitCode).not.toBe(0);
       }
     });
+  });
+});
+
+// A `file:` or URL tarball is cached under a folder named after its path or
+// URL, so installing without a lockfile extracts it again over the folder from
+// the previous install. The fresh copy must win (the tarball may have been
+// repacked) and the copy it displaces must not be left behind in the temp dir,
+// which used to grow by one extracted tarball per install.
+describe.concurrent("tarball re-extraction over an existing cache folder", () => {
+  function tarballOfVersion(version: string, padding: Record<string, Buffer> = {}) {
+    return tarball({ "package.json": Buffer.from(JSON.stringify({ name: "pkg", version }) + "\n"), ...padding });
+  }
+
+  function project(name: string, spec: string) {
+    return tempDir(name, {
+      "app/package.json": JSON.stringify({ name: "app", dependencies: { pkg: spec } }),
+      // The install extracts into tmp/ and renames into cache/; both are inside
+      // the test directory, so anything left in tmp/ after an install is a leak.
+      cache: {},
+      tmp: {},
+    });
+  }
+
+  /** `bun install` from scratch (no node_modules, no lockfile); returns the installed version of `pkg`. */
+  async function installFresh(dir: string) {
+    const app = join(dir, "app");
+    await Promise.all([
+      rm(join(app, "node_modules"), { recursive: true, force: true }),
+      rm(join(app, "bun.lock"), { force: true }),
+    ]);
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: app,
+      env: { ...env, BUN_INSTALL_CACHE_DIR: join(dir, "cache"), BUN_TMPDIR: join(dir, "tmp") },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect({ stderr, exitCode }).toMatchObject({ exitCode: 0 });
+    const { version } = await file(join(app, "node_modules", "pkg", "package.json")).json();
+    return version as string;
+  }
+
+  async function cacheState(dir: string) {
+    const [tmp, cache] = await Promise.all([readdirSorted(join(dir, "tmp")), readdirSorted(join(dir, "cache"))]);
+    return { tmp, tarballFolders: cache.filter(name => name.startsWith("@T@")).length };
+  }
+
+  it("file: tarball", async () => {
+    using dir = project("tarball-reextract-file", "file:../pkg.tgz");
+    await writeFile(join(String(dir), "pkg.tgz"), tarballOfVersion("1.0.0"));
+
+    expect(await installFresh(String(dir))).toBe("1.0.0");
+    expect(await installFresh(String(dir))).toBe("1.0.0");
+    expect(await installFresh(String(dir))).toBe("1.0.0");
+    expect(await cacheState(String(dir))).toEqual({ tmp: [], tarballFolders: 1 });
+
+    await writeFile(join(String(dir), "pkg.tgz"), tarballOfVersion("2.0.0"));
+    expect(await installFresh(String(dir))).toBe("2.0.0");
+    expect(await cacheState(String(dir))).toEqual({ tmp: [], tarballFolders: 1 });
+  });
+
+  it("tarball URL", async () => {
+    // Incompressible padding, served without a Content-Length in several
+    // chunks, makes the download take the streaming extractor rather than
+    // being buffered and extracted in one go.
+    const padding = { "blob.bin": randomBytes(256 * 1024) };
+    let tgz = tarballOfVersion("1.0.0", padding);
+    await using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch() {
+        let offset = 0;
+        return new Response(
+          new ReadableStream({
+            pull(controller) {
+              if (offset >= tgz.length) return controller.close();
+              controller.enqueue(tgz.subarray(offset, offset + 64 * 1024));
+              offset += 64 * 1024;
+            },
+          }),
+        );
+      },
+    });
+    using dir = project("tarball-reextract-url", `${server.url}pkg.tgz`);
+
+    expect(await installFresh(String(dir))).toBe("1.0.0");
+    expect(await installFresh(String(dir))).toBe("1.0.0");
+    expect(await installFresh(String(dir))).toBe("1.0.0");
+    expect(await cacheState(String(dir))).toEqual({ tmp: [], tarballFolders: 1 });
+
+    tgz = tarballOfVersion("2.0.0", padding);
+    expect(await installFresh(String(dir))).toBe("2.0.0");
+    expect(await cacheState(String(dir))).toEqual({ tmp: [], tarballFolders: 1 });
   });
 });

--- a/test/cli/install/bun-install-tarball-integrity.test.ts
+++ b/test/cli/install/bun-install-tarball-integrity.test.ts
@@ -861,8 +861,8 @@ describe.concurrent("tarball re-extraction over an existing cache folder", () =>
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-    expect({ stderr, exitCode }).toMatchObject({ exitCode: 0 });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toMatchObject({ exitCode: 0 });
     const { version } = await file(join(app, "node_modules", "pkg", "package.json")).json();
     return version as string;
   }


### PR DESCRIPTION
### Problem
- Every `bun install` without a lockfile that has a `file:` or URL tarball dependency already in the cache leaves one fully extracted copy of that tarball behind in the install temp dir (`<cache>/.tmp/.<hex>-1.<name>/`, or `$TMPDIR` when that is on the cache's filesystem). N installs leave N-1 copies; the install exits 0.
- Without a lockfile the tarball is always re-extracted (its `package.json` is what resolves it). `move_to_cache_directory` (`src/install/extract_tarball.rs`) publishes the staging dir with `renameat_concurrently`: `RENAME_NOREPLACE` fails because the folder exists, so it falls back to `RENAME_EXCHANGE`, which swaps the old folder out under the staging name. Nothing deletes it. The step "2b" described in the comment there never had code behind it (the line that was meant to do it in #9738 ran before the rename, against a variable that was still `false`).
- The same happens for `https://` tarballs, through both the buffered and the streaming extractor, since both end in `move_to_cache_directory`.

### Fix
- `ExtractTarball::cache_publish()` decides, before extraction starts, how the result will be published, and the buffered path (`extract`) and the streaming path (`TarballStream::init`) pass that decision to `move_to_cache_directory` as `CachePublish`:
  - `Supersede`: the folder name was already taken when the task started, so this is a re-extraction of the tarball. The fresh copy is swapped in as before, and the folder it displaced is deleted from the temp dir. This is the case in the report, and it keeps the current behaviour that a repacked tarball wins once the lockfile is removed.
  - `KeepExisting`: the name was free when the task started. If it is taken by the time the rename happens, a concurrent install extracted the same tarball first; its folder may already be copied from, so it is kept and our staging copy is deleted. `renameat_concurrently` gets a `keep_existing_destination` option for this, and the Windows arm of `move_to_cache_directory` does the equivalent on its existing-destination errors. Previously this case replaced the other install's folder (POSIX: swap and leak it; Windows: delete it, which is #28062).
  - `Replace`: npm and GitHub folders, unchanged. Their swapped-out folder is still left alone because nothing there can tell a race from a re-extraction; the open PRs listed below deal with those.
- The decision has to be made before extracting because the only thing distinguishing the two cases is whether the folder predates this extraction. A tarball folder is named after the hash of its path or URL (`@T@<hash>@@@1`), not its contents, so the contents of an existing folder say nothing (`Tag::is_tarball` documents this).
- After the move, anything still under the staging name is deleted whenever it is safe to do so: the superseded folder, or our own copy after a lost race or a failed move. A swapped-out folder in `Replace` mode is the one thing that is not.
- Verified with:
  - `test/cli/install/bun-install-tarball-integrity.test.ts`, two new tests (`file:` tarball, tarball URL): three installs without a lockfile must leave the temp dir empty and one `@T@` folder, and a repacked tarball must be the version installed afterwards. On the current build both fail with two `.<hex>-1.pkg` dirs left in the temp dir. The URL test serves a 256 KiB tarball in chunks without a Content-Length, and `--verbose` shows `Streamed` for all of its installs, so it covers the streaming extractor's half of the plumbing.
  - The reproduction from the report (below) with the debug build: 5 installs, 0 dirs left.
  - New `bun_sys` unit test for `keep_existing_destination` (destination kept, source removed; free destination renames normally).
  - `bun-install-streaming-extract`, `bun-add`, `bun-patch`, `bun-install-patch`, `bun-install-git-deps`, the tarball/github/cache subset of `bun-install.test.ts` (one test in it needs network access and fails identically without this change), and the rest of `bun-install-tarball-integrity` pass with the debug build. `cargo check` for `bun_sys`/`bun_install` passes on Linux and `x86_64-pc-windows-msvc`; clippy is clean.
- `RenameatConcurrentlyOptions` gained a field, so the struct literals in `patchPackage.rs` and `repository.rs` now spell out the defaults; their behaviour is unchanged.

### Related open PRs
- #33979 and #36229 make the publish step keep an existing folder for every package kind (to fix the concurrent-install leak and the NFS race). Applied to `file:`/URL tarballs that is the `Supersede` case above: a repacked tarball reinstalled without a lockfile would keep serving the old extraction while the new sha512 is written to the lockfile. `CachePublish` is the information those changes need to keep the existing folder only on a race; this PR does not change npm or GitHub publishing itself.
- #33884 (Windows, #28062) accepts an existing tarball folder whenever the directory exists. Same interaction: it should accept only in `KeepExisting` mode. The Windows branch added here is the small version of that and will be superseded by it.
- #35576 records the tarball's integrity in the cache folder. Once that exists, `Supersede` could additionally be skipped when the integrity matches; without it the folder has to be replaced to pick up a changed tarball.
- #31868 (re-download tarballs under `--force`) adds the same predicate as `Tag::is_tarball` under another name, and every re-download it adds is a `Supersede` publish, so it would leak one copy per forced install without this change.

### Background
- Cache publishing: a tarball is extracted into a randomly named staging dir in the install temp dir (chosen to be on the same filesystem as the cache) and then renamed onto its final cache folder, so a cache folder is either absent or complete.
- `renameat_concurrently` (`src/sys/lib.rs`): tries `renameat2(RENAME_NOREPLACE)`, then `RENAME_EXCHANGE` (atomically swaps source and destination, leaving the old destination under the source name), then `delete_tree` + `rename`. Since #9738 the exchange is what makes two installs sharing a cache not fail each other; the swapped-out folder is left because the other install may still be reading it.
- `@T@` folders: `file:` and URL tarballs are cached under a hash of the path or URL string (`cached_tarball_folder_name_print`), so the same folder holds whatever was last extracted from that path. npm folders (`name@version`) and GitHub folders (resolved commit) are keyed by content identity instead, which is why the race-oriented PRs above can treat an existing folder as equivalent for those but not for tarballs.
- Streaming extractor (`TarballStream.rs`): for larger or chunked downloads the tarball is extracted while it downloads; it shares `move_to_cache_directory` with the buffered path, which is why the publish decision is captured in `TarballStream::init` (on the main thread, when the download is queued) and in `extract` for the buffered path.

<details>
<summary>Reproduction from the report</summary>

```sh
d=$(mktemp -d); cd "$d"; export BUN_INSTALL_CACHE_DIR="$d/cache"
mkdir -p pkg app
printf '{"name":"tdep","version":"0.0.1","main":"i.js"}' > pkg/package.json; echo 'module.exports=1' > pkg/i.js
head -c 3000000 /dev/urandom > pkg/big.bin
tar czf tdep.tgz --transform 's,^pkg,package,' pkg
printf '{"name":"app","dependencies":{"tdep":"file:../tdep.tgz"}}' > app/package.json
cd app
for i in 1 2 3 4 5; do
  rm -rf node_modules bun.lock; bun install >/dev/null 2>&1
  echo "install #$i: $(ls -A ../cache/.tmp 2>/dev/null | wc -l) staging dirs"
done
```

Before (1.4.0-canary, `b7a043103`): 0, 1, 2, 3, 4 staging dirs (in `$TMPDIR` when it shares a filesystem with the cache, otherwise `cache/.tmp`). After: 0 every time, and the `@T@` folder holds the latest extraction.

The leaked dir holds the previous cache contents, not the new extraction: repack `tdep.tgz` between two lockfile-less installs and the leaked copy has the old files while the cache folder has the new ones.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-install-tarball-integrity.test.ts
bun test v1.4.0 (0613908c0)

test/cli/install/bun-install-tarball-integrity.test.ts:
(pass) tarball integrity > should store integrity hash for local tarball in text lockfile [300.04ms]
(pass) tarball integrity > should store integrity hash for tarball URL in text lockfile [389.67ms]
(pass) tarball integrity > should install successfully from text lockfile without integrity hash (backward compat) [395.62ms]
(pass) tarball integrity > should add integrity hash to lockfile when re-resolving tarball dep [206.05ms]
(pass) tarball integrity > should fail integrity check when tarball URL content changes [554.78ms]
(pass) tarball integrity > should store consistent integrity hash for tarball URL across reinstalls [726.04ms]
(pass) tarball integrity > should install successfully from text lockfile without integrity hash for local tarball (backward compat) [274.54ms]
(pass) tarball integrity mismatch (hoisted) > should fail (not hang) when tarball bytes don't match manifest SHA-512 [414.04m
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (b7a043103)

test/cli/install/bun-install-tarball-integrity.test.ts:
(pass) tarball integrity > should store integrity hash for local tarball in text lockfile [59.82ms]
(pass) tarball integrity mismatch (hoisted) > should fail (not hang) when tarball bytes don't match manifest SHA-512 [66.65ms]
(pass) tarball integrity metadata forms > verifies the tarball when the integrity entry carries an option suffix [51.72ms]
(pass) tarball integrity metadata forms > verifies the tarball against the strongest entry of a multi-hash integrity string [59.91ms]
(pass) tarball integrity mismatch (isolated) > should fail (not hang) when tarball bytes don't match manifest SHA-512 [63.55ms]
(pass) tarball integrity > should add integrity hash to lockfile when re-resolving tarball dep [74.78ms]
(pass) tarball integrity > should store integrity hash for tarball URL in text lockfile [79.84ms]
(pass) tarball integrity metadata forms > records the strongest entry of a multi-hash integrity string in the lockfile [57.99ms]
(pass) tarball integrity > should install successfully from text lockfile without integrity hash (backward compat) [74.99ms]
(pass) tarball integr
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-install-tarball-integrity.test.ts
bun test v1.4.0 (0613908c0)

test/cli/install/bun-install-tarball-integrity.test.ts:
(pass) tarball integrity > should store integrity hash for local tarball in text lockfile [307.36ms]
(pass) tarball integrity > should store integrity hash for tarball URL in text lockfile [370.21ms]
(pass) tarball integrity > should install successfully from text lockfile without integrity hash (backward compat) [380.74ms]
(pass) tarball integrity > should add integrity hash to lockfile when re-resolving tarball dep [184.72ms]
(pass) tarball integrity > should fail integrity check when tarball URL content changes [517.92ms]
(pass) tarball integrity > should install successfully from text lockfile without integrity hash for local tarball (backward compat) [199.20ms]
(pass) tarball integrity > should store consistent integrity hash for tarball URL across reinstalls [733.56ms]
(pass) tarball integrity > should store consistent integrity hash for local tarball across reinstalls [501.27ms]
(pass) tarba
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     0613908c0f
  features     baseline

22 deps, 123 codegen, 1176 objects in 1159ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] gen ErrorCode+*.h
[2/1238] install /workspace/bun
bun install v1.4.0-canary.1 (b7a043103)

Checked 107 installs across 153 packages (no changes) [13.00ms]
[3/1238] gen bindgenv2
[4/1238] fetch tinycc
[tinycc] up to date
[5/1237] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (b7a043103)

Checked 1 install across 2 packages (no changes) [1.00ms]
[6/1237] fetch zlib
[zlib] up to date
[7/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[8/1237] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (b7a043103)

Checked 129 installs across 147 packages (no changes) [20.00ms]
[9/1237] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[10/1237] gen JSBuffer.lut.h
Generating /worksp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/install/PackageManager/patchPackage.rs         |   7 +-
 src/install/TarballStream.rs                       |   6 +
 src/install/extract_tarball.rs                     | 116 +++++++++----
 src/install/repository.rs                          |   4 +-
 src/install/resolution.rs                          |   6 +
 src/sys/lib.rs                                     |  82 +++++++++-
 .../install/bun-install-tarball-integrity.test.ts  | 182 ++++++++++++++-------
 7 files changed, 303 insertions(+), 100 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
src/install/PackageManager/patchPackage.rs                  1      0      0
src/install/TarballStream.rs                                4      6      0
src/install/extract_tarball.rs                              5      9      0
src/install/repository.rs                                   2      1      0
src/install/resolution.rs                                   2      3      0
src/sys/lib.rs                                              4      9      0
test/cli/install/bun-install-tarball-integrity.test.ts      6      9      0
```

</details>

<!-- robobun:evidence:end -->