### PR TITLE
Remove dead code from bun_core, bun_css, bun_jsc, and the FFI crates

### DIFF
--- a/src/ast/symbol.rs
+++ b/src/ast/symbol.rs
@@ -545,14 +545,6 @@ impl Map {
         })
     }
 
-    pub fn init(source_count: usize) -> Map {
-        let mut v: NestedList = Vec::with_capacity(source_count);
-        v.resize_with(source_count, Vec::new);
-        Map {
-            symbols_for_source: v,
-        }
-    }
-
     // Takes ownership of `list` and boxes it into a one-element NestedList.
     // PERF: one extra allocation — profile if needed (single caller is the
     // printer one-shot, cold).

--- a/src/boringssl_sys/boringssl.rs
+++ b/src/boringssl_sys/boringssl.rs
@@ -331,10 +331,6 @@ impl GeneralNames {
         unsafe { sk_num(self.0.as_ptr().cast::<OPENSSL_STACK>()) }
     }
 
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
     /// Borrows the `i`th entry; `None` past the end.
     pub(crate) fn get(&self, i: usize) -> Option<&GENERAL_NAME> {
         if i >= self.len() {
@@ -1098,10 +1094,6 @@ opaque!(
 
 /// `TLS1_3_VERSION` (`openssl/tls1.h`).
 pub const TLS1_3_VERSION: u16 = 0x0304;
-/// `X509_V_OK` (`openssl/x509.h`).
-pub const X509_V_OK: c_long = 0;
-/// `SSL_SESS_CACHE_CLIENT` (`openssl/ssl.h`).
-pub const SSL_SESS_CACHE_CLIENT: c_int = 1;
 
 unsafe extern "C" {
     pub safe fn TLS_method() -> *const SSL_METHOD;

--- a/src/bun_alloc/lib.rs
+++ b/src/bun_alloc/lib.rs
@@ -592,13 +592,6 @@ impl Default for Mutex {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AllocError;
 
-impl AllocError {
-    #[inline]
-    pub const fn name(self) -> &'static str {
-        "OutOfMemory"
-    }
-}
-
 impl core::fmt::Display for AllocError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.write_str("OutOfMemory")
@@ -696,13 +689,6 @@ pub unsafe fn realloc_raw(
         return Err(AllocError);
     }
     Ok(new_ptr.cast::<u8>())
-}
-
-/// `mi_usable_size` — actual allocated size for a mimalloc-owned ptr.
-#[inline]
-pub fn usable_size(ptr: *const u8) -> usize {
-    // SAFETY: `mi_usable_size` is null-safe (returns 0).
-    unsafe { mimalloc::mi_usable_size(ptr.cast()) }
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -1453,7 +1439,7 @@ macro_rules! bss_singleton {
 
 /// Heap-allocate a fresh `T` via mimalloc and run its in-place `init_at` initializer.
 ///
-/// Shared body of the `BSSList`/`BSSStringList`/`BSSMapInner` `init()` shims.
+/// Shared body of the `BSSStringList`/`BSSMapInner` `init()` shims.
 /// The once-guard is the *caller's* responsibility; use the `bss_*!` macros
 /// for the canonical per-monomorphization singleton.
 #[doc(hidden)] // Public only for the `bss_singleton!` macro expansion in dependent crates.
@@ -2020,9 +2006,7 @@ impl<ValueType, const COUNT: usize> BSSList<ValueType, COUNT> {
     // Rust cannot define generic statics, so the per-monomorphization storage is
     // emitted at the *declare site* via `bss_list! { name: T, N }` (see macro
     // below), which owns a `SyncUnsafeCell<MaybeUninit<Self>>` + `Once` and
-    // calls `init_at` on first access. `init()` is kept for callers that manage
-    // their own once-guard (e.g. `dir_info::hash_map_instance`); it heap-allocs
-    // a fresh instance each call.
+    // calls `init_at` on first access.
 
     /// In-place field initialization into demand-zero storage.
     ///
@@ -2048,13 +2032,6 @@ impl<ValueType, const COUNT: usize> BSSList<ValueType, COUNT> {
         }
     }
 
-    /// Heap-allocate and initialize a fresh instance. The once-guard is the
-    /// *caller's* responsibility — use `bss_list!` for
-    /// the canonical per-monomorphization singleton.
-    pub fn init() -> NonNull<Self> {
-        bss_heap_init(Self::init_at)
-    }
-
     // Singleton teardown belongs to the `bss_list!` singleton wrapper;
     // Drop only frees the heap-allocated head chain.
 
@@ -2066,7 +2043,7 @@ impl<ValueType, const COUNT: usize> BSSList<ValueType, COUNT> {
         &mut self,
     ) -> core::result::Result<*mut MaybeUninit<ValueType>, AllocError> {
         self.used += 1;
-        // SAFETY: head is always non-null after init() (points at self.tail or heap block).
+        // SAFETY: head is always non-null after init_at() (points at self.tail or heap block).
         let mut head_ptr = self.head.unwrap();
         // Check capacity first, allocate the new block if
         // needed, then reserve exactly one slot. Safe under `self.mutex`.

--- a/src/bun_core/bounded_array.rs
+++ b/src/bun_core/bounded_array.rs
@@ -125,14 +125,6 @@ impl<T, const BUFFER_CAPACITY: usize> BoundedArrayAligned<T, BUFFER_CAPACITY> {
     // If a non-`Copy` caller
     // appears, add a `from_slice_clone` or use `ptr::copy_nonoverlapping`.
 
-    /// Return the element at index `i` of the slice.
-    pub fn get(&self, i: usize) -> T
-    where
-        T: Copy,
-    {
-        self.const_slice()[i]
-    }
-
     /// Check that the slice can hold at least `additional_count` items.
     pub(crate) fn ensure_unused_capacity(
         &self,

--- a/src/bun_core/external_shared.rs
+++ b/src/bun_core/external_shared.rs
@@ -39,13 +39,6 @@ impl<T: ExternalSharedDescriptor> ExternalShared<T> {
         self.ptr.as_ptr()
     }
 
-    /// Alias of [`Self::get`] — provided so call sites that previously used a
-    /// hand-rolled `NonNull` wrapper (e.g. `AbortSignalRef`) keep compiling.
-    #[inline]
-    pub fn as_ptr(&self) -> *mut T {
-        self.ptr.as_ptr()
-    }
-
     /// # Safety
     /// `raw` must be a valid pointer managed by the external refcount.
     pub unsafe fn clone_from_raw(raw: *mut T) -> Self {
@@ -110,10 +103,6 @@ impl<T: ExternalSharedDescriptor> ExternalSharedOptional<T> {
         Self {
             ptr: NonNull::new(incremented_raw),
         }
-    }
-
-    pub fn get(&self) -> Option<*mut T> {
-        self.ptr.map(|p| p.as_ptr())
     }
 }
 

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -129,16 +129,6 @@ impl<T> RawSlice<T> {
     pub const fn new(s: &[T]) -> Self {
         RawSlice(core::ptr::from_ref(s))
     }
-    /// Wrap a raw slice pointer.
-    ///
-    /// # Safety
-    /// `p` must either be a (dangling, len 0) empty slice or point to `len`
-    /// initialized `T` that remain live and stable for the lifetime of every
-    /// `RawSlice` copied from the result.
-    #[inline]
-    pub const unsafe fn from_raw(p: *const [T]) -> Self {
-        RawSlice(p)
-    }
     #[inline]
     pub const fn as_ptr(self) -> *const [T] {
         self.0
@@ -933,13 +923,6 @@ pub fn concat_boxed<T: Copy>(parts: &[&[T]]) -> Box<[T]> {
         v.extend_from_slice(p);
     }
     v.into_boxed_slice()
-}
-
-/// Back-compat alias for the original `u8`-only buffer-concat. New code should
-/// call [`concat_into`] directly.
-#[inline]
-pub fn concat<'b>(buf: &'b mut [u8], parts: &[&[u8]]) -> &'b [u8] {
-    concat_into(buf, parts)
 }
 
 /// Tagged-union field projection — `data.file`, `chunk.content.javascript`.

--- a/src/bun_core/string/mod.rs
+++ b/src/bun_core/string/mod.rs
@@ -1835,17 +1835,6 @@ impl SliceWithUnderlyingString {
         }
     }
 
-    /// `fromUTF8` — wrap a borrowed UTF-8 slice (caller keeps it alive).
-    #[inline]
-    pub fn from_utf8(utf8: &[u8]) -> SliceWithUnderlyingString {
-        SliceWithUnderlyingString {
-            utf8: ZigStringSlice::from_utf8_never_free(utf8),
-            underlying: String::DEAD,
-            #[cfg(debug_assertions)]
-            did_report_extra_memory_debug: false,
-        }
-    }
-
     /// `slice` — the UTF-8 byte view.
     #[inline]
     pub fn slice(&self) -> &[u8] {

--- a/src/bun_core/string/write.rs
+++ b/src/bun_core/string/write.rs
@@ -11,7 +11,4 @@
 //! (`FixedBufferStream`, `BufWriter`, `FmtAdapter`, `DiscardingWriter`) on top,
 //! so the existing `bun_io::Write` importers are unaffected.
 
-/// `Result<T>` over `core::fmt::Error` so `?` composes everywhere.
-pub type Result<T = ()> = core::result::Result<T, core::fmt::Error>;
-
 pub use crate::io::{IntLe, Write};

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -38,11 +38,6 @@ pub struct Unaligned<T: Copy>(T);
 
 impl<T: Copy> Unaligned<T> {
     #[inline(always)]
-    pub const fn new(value: T) -> Self {
-        Self(value)
-    }
-
-    #[inline(always)]
     pub fn get(self) -> T {
         // `self` is by-value (already moved into an aligned local), so a plain
         // field read is fine; the `packed` repr only affects in-place borrows.
@@ -601,8 +596,7 @@ macro_rules! opaque_extern {
 // `bun_threading::Guarded` / `bun_threading::RwLock` directly.
 //
 // API parity with the previous `parking_lot` aliases: `const fn new(T)`,
-// `.lock()` → guard (no `Result`), `.try_lock()` → `Option`, `.get_mut()`,
-// `Default`.
+// `.lock()` → guard (no `Result`), `.try_lock()` → `Option`, `Default`.
 
 /// Poison-free `std::sync::Mutex<T>` wrapper. See module note above for why
 /// this is not `bun_threading::Guarded<T>`.
@@ -635,13 +629,6 @@ impl<T> Mutex<T> {
             Err(std::sync::TryLockError::WouldBlock) => None,
         }
     }
-
-    #[inline]
-    pub fn get_mut(&mut self) -> &mut T {
-        self.0
-            .get_mut()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-    }
 }
 
 impl<T: Default> Default for Mutex<T> {
@@ -673,13 +660,6 @@ impl<T> RwLock<T> {
     pub fn write(&self) -> RwLockWriteGuard<'_, T> {
         self.0
             .write()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-    }
-
-    #[inline]
-    pub fn get_mut(&mut self) -> &mut T {
-        self.0
-            .get_mut()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 }
@@ -3356,12 +3336,6 @@ impl<I: GenericIndexInt, M> GenericIndex<I, M> {
         GenericIndexOptional(self.0, core::marker::PhantomData)
     }
 }
-impl<I: GenericIndexInt, M> GenericIndexOptional<I, M> {
-    #[inline]
-    pub fn is_some(self) -> bool {
-        !self.is_none()
-    }
-}
 
 /// `GenericIndex::Optional` — `MAX` is `none`.
 #[repr(transparent)]
@@ -3386,18 +3360,7 @@ impl<I: core::fmt::Debug, M> core::fmt::Debug for GenericIndexOptional<I, M> {
     }
 }
 impl<I: GenericIndexInt, M> GenericIndexOptional<I, M> {
-    #[inline]
-    pub fn is_none(self) -> bool {
-        self.0 == I::NULL_VALUE
-    }
-
     pub const NONE: Self = Self(I::NULL_VALUE, core::marker::PhantomData);
-    /// Alias for `unwrap()` matching the local-newtype API that pre-existed in
-    /// `bun_bundler::output_file::IndexOptional`.
-    #[inline]
-    pub fn get(self) -> Option<GenericIndex<I, M>> {
-        self.unwrap()
-    }
     #[inline]
     pub fn unwrap(self) -> Option<GenericIndex<I, M>> {
         if self.0 == I::NULL_VALUE {
@@ -4918,11 +4881,6 @@ impl Timespec {
     pub const EPOCH: Timespec = Timespec { sec: 0, nsec: 0 };
     const NS_PER_S: i64 = crate::time::NS_PER_S as i64;
     const NS_PER_MS: i64 = crate::time::NS_PER_MS as i64;
-
-    #[inline]
-    pub const fn new(sec: i64, nsec: i64) -> Self {
-        Self { sec, nsec }
-    }
 
     #[inline]
     pub fn eql(&self, other: &Timespec) -> bool {

--- a/src/cares_sys/c_ares.rs
+++ b/src/cares_sys/c_ares.rs
@@ -671,12 +671,6 @@ pub struct AddrInfo_hints {
 // SAFETY: four `c_int` fields; all-zero is a valid hints value (S021).
 unsafe impl bun_core::ffi::Zeroable for AddrInfo_hints {}
 
-impl AddrInfo_hints {
-    pub fn is_empty(&self) -> bool {
-        self.ai_flags == 0 && self.ai_family == 0 && self.ai_socktype == 0 && self.ai_protocol == 0
-    }
-}
-
 #[derive(Copy, Clone, Default)]
 pub struct ChannelOptions {
     pub timeout: Option<i32>,

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -625,12 +625,6 @@ pub trait QualifiedRuleParser {
 #[derive(Default, Clone, Copy, crate::DeepClone)]
 pub struct DefaultAtRule;
 
-impl DefaultAtRule {
-    pub fn to_css(self, dest: &mut Printer) -> Result<(), PrintErr> {
-        dest.new_error(PrinterErrorKind::fmt_error, None)
-    }
-}
-
 /// Same as `AtRuleParser` but modified to provide parser options.
 /// Also added: `on_import_rule` to handle `@import` rules.
 pub trait CustomAtRuleParser {
@@ -5257,11 +5251,6 @@ pub enum TokenKind {
 pub use crate::Token;
 
 impl Token {
-    pub fn eql(lhs: &Token, rhs: &Token) -> bool {
-        // TODO: derive PartialEq once payload lifetimes settle.
-        generic::implement_eql(lhs, rhs)
-    }
-
     /// Return whether this token represents a parse error.
     pub(crate) fn is_parse_error(&self) -> bool {
         matches!(
@@ -5506,22 +5495,16 @@ pub use bun_io::Write as WriteAll;
 // Num/Dimension data layouts hoisted at crate root (lib.rs).
 pub use crate::{Dimension, Num};
 
-// Num/Dimension eql/hash gated until generics::CssEql/CssHash blanket impls
+// Num/Dimension hash gated until generics::CssHash blanket impls
 // cover the float/slice payloads.
 
 impl Num {
-    pub fn eql(lhs: &Num, rhs: &Num) -> bool {
-        generic::implement_eql(lhs, rhs)
-    }
     pub(crate) fn hash(&self, hasher: &mut bun_wyhash::Wyhash) {
         generic::implement_hash(self, hasher)
     }
 }
 
 impl Dimension {
-    pub fn eql(lhs: &Self, rhs: &Self) -> bool {
-        generic::implement_eql(lhs, rhs)
-    }
     pub(crate) fn hash(&self, hasher: &mut bun_wyhash::Wyhash) {
         generic::implement_hash(self, hasher)
     }

--- a/src/css/generics.rs
+++ b/src/css/generics.rs
@@ -191,11 +191,6 @@ pub trait CssEql {
 pub use bun_css_derive::CssEql;
 
 #[inline]
-pub fn implement_eql<T: CssEql>(this: &T, other: &T) -> bool {
-    this.eql(other)
-}
-
-#[inline]
 pub(crate) fn eql<T: CssEql>(lhs: &T, rhs: &T) -> bool {
     lhs.eql(rhs)
 }
@@ -1203,11 +1198,6 @@ pub fn parse_with_options<T: ParseWithOptions>(
     options: &ParserOptions,
 ) -> CssResult<T> {
     T::parse_with_options(input, options)
-}
-
-#[inline]
-pub fn parse<T: Parse>(input: &mut Parser) -> CssResult<T> {
-    T::parse(input)
 }
 
 // ── container / primitive Parse impls ────────────────────────────────────────

--- a/src/css/lib.rs
+++ b/src/css/lib.rs
@@ -340,7 +340,7 @@ pub struct Dimension {
 }
 
 /// CSS lexer token. Data-only definition hoisted out of `css_parser.rs`; the
-/// `to_css*`/`eql`/`hash` impls stay in `css_parser.rs` since they depend on
+/// `to_css*`/`hash` impls stay in `css_parser.rs` since they depend on
 /// `serializer::*` and `generics`.
 // Every `&'static [u8]` payload actually borrows the parser arena/source text and
 // must not outlive the arena; `&'static` is the crate-wide placeholder until the

--- a/src/css/properties/custom.rs
+++ b/src/css/properties/custom.rs
@@ -1,6 +1,6 @@
 //! CSS custom properties / `var()` / `env()` / unparsed token lists.
 //
-// `TokenList::{parse, parse_into, parse_with_options, to_css, to_css_raw}`,
+// `TokenList::{parse, parse_into, to_css, to_css_raw}`,
 // `UnresolvedColor::{parse, to_css}`, `Variable::{parse, to_css}`,
 // `EnvironmentVariable::{parse, parse_nested, to_css}`,
 // `EnvironmentVariableName::{parse, to_css}`, `Function::to_css`,
@@ -162,7 +162,7 @@ mod ext {
 
 // ─── Token protocol impls ──────────────────────────────────────────────────
 // `Token` / `Num` / `Dimension` are defined data-only at crate root (lib.rs);
-// their `eql`/`hash` bodies in css_parser.rs forward to `generic::implement_*`
+// their `hash` bodies in css_parser.rs forward to `generic::implement_*`
 // which bound on these traits — provide them here so the cycle closes and
 // `#[derive(CssEql/CssHash/DeepClone)]` on `TokenOrValue` resolves the
 // `Token(Token)` arm. Hand-written (not derived) because `Token` carries
@@ -478,10 +478,6 @@ impl TokenList {
         }
 
         Ok(TokenList { v: tokens })
-    }
-
-    pub fn parse_with_options(input: &mut Parser, options: &ParserOptions) -> Result<TokenList> {
-        Self::parse(input, options, 0)
     }
 
     pub(crate) fn parse_raw(

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -58,10 +58,9 @@ macro_rules! css_rule_variants {
                 match self {
                     $( CssRule::$Variant(x) => x.to_css(dest), )+
                     CssRule::Unknown(x) => x.to_css(dest),
-                    // The only concrete `R` is `DefaultAtRule` (whose `to_css`
-                    // errors unconditionally), so erroring here is correct for
-                    // every `R` that is actually instantiated. If another `R`
-                    // is ever added, thread a `ToCss`-style bound
+                    // The only concrete `R` is `DefaultAtRule`, so erroring here
+                    // is correct for every `R` that is actually instantiated. If
+                    // another `R` is ever added, thread a `ToCss`-style bound
                     // (or per-`R` vtable) so `Custom(x)` dispatches to
                     // `x.to_css(dest)` and only the error path maps through
                     // `add_fmt_error()`; that bound cascades through every nested

--- a/src/css/selectors/parser.rs
+++ b/src/css/selectors/parser.rs
@@ -112,10 +112,10 @@ pub(crate) const SELECTOR_WHITESPACE: &[u8] = &[b' ', b'\t', b'\n', b'\r', 0x0C]
 /// by `impl_::Selectors` in `bun_css::selector::impl_`.
 // `PartialEq + Clone` bounds dropped — the concrete assoc types
 // (`values::ident::{Ident,IdentOrRef}`, `*const [u8]`) implement structural
-// equality via the `CssEql` protocol (`generics::implement_eql`), not
-// `core::cmp::PartialEq`. Every `eql`/`deep_clone`/`hash` callsite in this
-// module forwards through `css::implement_*` which bound on `CssEql`/
-// `DeepClone`/`CssHash`, so the std bounds were never load-bearing.
+// equality via the `CssEql` protocol, not `core::cmp::PartialEq`. Every
+// `eql`/`deep_clone`/`hash` callsite in this module forwards through
+// `css::implement_*` which bound on `CssEql`/`DeepClone`/`CssHash`, so the
+// std bounds were never load-bearing.
 pub trait SelectorImpl: Sized {
     type AttrValue: Clone;
     type Identifier: Clone;
@@ -1613,13 +1613,6 @@ impl<Impl: BunSelectorImpl> GenericSelectorList<Impl> {
         true
     }
 
-    /// Do not call this! Use `serializer::serialize_selector_list()` or
-    /// `tocss_servo::to_css_selector_list()` instead.
-    #[deprecated = "use serializer::serialize_selector_list()"]
-    pub fn to_css(&self, _dest: &mut Printer) -> Result<(), PrintErr> {
-        unreachable!("use serializer::serialize_selector_list()");
-    }
-
     pub fn parse(
         parser: &mut SelectorParser,
         input: &mut CssParser,
@@ -1828,13 +1821,6 @@ impl<Impl: BunSelectorImpl> GenericSelector<Impl> {
     pub fn parse(parser: &mut SelectorParser, input: &mut CssParser) -> CResult<Self> {
         let mut state = SelectorParsingState::empty();
         parse_selector::<Impl>(parser, input, &mut state, NestingRequirement::None)
-    }
-
-    /// Do not call this! Use `serializer::serialize_selector()` or
-    /// `tocss_servo::to_css_selector()` instead.
-    #[deprecated = "use serializer::serialize_selector()"]
-    pub fn to_css(&self, _dest: &mut Printer) -> Result<(), PrintErr> {
-        unreachable!("use serializer::serialize_selector()");
     }
 
     pub(crate) fn append(&mut self, component: GenericComponent<Impl>) {
@@ -2284,13 +2270,6 @@ impl<Impl: BunSelectorImpl> GenericComponent<Impl> {
     /// Returns true if this is a combinator.
     pub(crate) fn is_combinator(&self) -> bool {
         matches!(self, Self::Combinator(_))
-    }
-
-    /// Do not call this! Use `serializer::serialize_component()` or
-    /// `tocss_servo::to_css_component()` instead.
-    #[deprecated = "use serializer::serialize_component()"]
-    pub fn to_css(&self, _dest: &mut Printer) -> Result<(), PrintErr> {
-        unreachable!("use serializer::serialize_component()");
     }
 
     pub(crate) fn hash(&self, hasher: &mut Wyhash) {
@@ -2821,13 +2800,6 @@ pub enum Combinator {
 
 impl Combinator {
     // hash — via `#[derive(CssHash)]`.
-
-    /// Do not call this! Use `serializer::serialize_combinator()` or
-    /// `tocss_servo::to_css_combinator()` instead.
-    #[deprecated = "use serializer::serialize_combinator()"]
-    pub fn to_css(self, _dest: &mut Printer) -> Result<(), PrintErr> {
-        unreachable!("use serializer::serialize_combinator()");
-    }
 
     pub(crate) fn is_tree_combinator(self) -> bool {
         matches!(

--- a/src/css/values/angle.rs
+++ b/src/css/values/angle.rs
@@ -178,10 +178,6 @@ impl Angle {
         Some(Angle::Deg(self.to_degrees() + rhs.to_degrees()))
     }
 
-    pub(crate) fn eql(self, rhs: Angle) -> bool {
-        self.to_degrees() == rhs.to_degrees()
-    }
-
     pub(crate) fn mul_f32(self, other: f32) -> Angle {
         // return Angle.op(&this, &other, Angle.mulF32);
         match self {

--- a/src/css/values/calc.rs
+++ b/src/css/values/calc.rs
@@ -141,7 +141,6 @@ pub trait CalcValue:
     fn into_calc(self) -> Calc<Self>;
     /// Convert a `Calc<Self>` into `Self` if representable.
     fn from_calc(c: Calc<Self>, input: &mut css::Parser) -> CssResult<Self>;
-    fn eql(&self, other: &Self) -> bool;
 }
 
 impl<V: Clone> Clone for Calc<V> {
@@ -152,8 +151,7 @@ impl<V: Clone> Clone for Calc<V> {
 
 // Structural equality decoupled from `CalcValue` so `derive(PartialEq)` on
 // `Length` / `DimensionPercentage<D>` consumers can compare through
-// `Box<Calc<V>>` without pulling in the full behavior bound. `Calc::eql`
-// (below) keeps its `V: CalcValue` bound for callers that already have it.
+// `Box<Calc<V>>` without pulling in the full behavior bound.
 impl<V: PartialEq + Clone> PartialEq for Calc<V> {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
@@ -217,38 +215,6 @@ impl<V> Calc<V> {
 
     // Cleanup is handled by Drop on Box<V>/Box<Calc<V>>/
     // Box<MathFunction<V>>. No explicit Drop impl needed.
-
-    pub fn eql(&self, other: &Self) -> bool
-    where
-        V: CalcValue,
-    {
-        match (self, other) {
-            (Calc::Value(a), Calc::Value(b)) => a.eql(b),
-            (Calc::Number(a), Calc::Number(b)) => *a == *b,
-            (
-                Calc::Sum {
-                    left: al,
-                    right: ar,
-                },
-                Calc::Sum {
-                    left: bl,
-                    right: br,
-                },
-            ) => al.eql(bl) && ar.eql(br),
-            (
-                Calc::Product {
-                    number: an,
-                    expression: ae,
-                },
-                Calc::Product {
-                    number: bn,
-                    expression: be,
-                },
-            ) => an == bn && ae.eql(be),
-            (Calc::Function(a), Calc::Function(b)) => a.eql(b),
-            _ => false,
-        }
-    }
 }
 
 // `PartialEq for Calc<V>` is provided above with the looser `V: PartialEq +
@@ -1204,8 +1170,8 @@ pub enum MathFunction<V> {
 
 impl<V: PartialEq + Clone> PartialEq for MathFunction<V> {
     fn eq(&self, other: &Self) -> bool {
-        // Mirrors `MathFunction::eql` but bounds only on `V: PartialEq` so
-        // `Calc<V>: PartialEq` (above) closes without `CalcValue`.
+        // Bounds only on `V: PartialEq` so `Calc<V>: PartialEq` (above)
+        // closes without `CalcValue`.
         match (self, other) {
             (MathFunction::Calc(a), MathFunction::Calc(b)) => a == b,
             (MathFunction::Min(a), MathFunction::Min(b)) => a == b,
@@ -1262,78 +1228,7 @@ impl<V: PartialEq + Clone> PartialEq for MathFunction<V> {
     }
 }
 
-fn eql_calc_list<V: CalcValue>(a: &[Calc<V>], b: &[Calc<V>]) -> bool {
-    if a.len() != b.len() {
-        return false;
-    }
-    for (l, r) in a.iter().zip(b.iter()) {
-        if !l.eql(r) {
-            return false;
-        }
-    }
-    true
-}
-
 impl<V> MathFunction<V> {
-    pub fn eql(&self, other: &Self) -> bool
-    where
-        V: CalcValue,
-    {
-        match (self, other) {
-            (MathFunction::Calc(a), MathFunction::Calc(b)) => a.eql(b),
-            (MathFunction::Min(a), MathFunction::Min(b)) => eql_calc_list(a, b),
-            (MathFunction::Max(a), MathFunction::Max(b)) => eql_calc_list(a, b),
-            (
-                MathFunction::Clamp {
-                    min: a0,
-                    center: a1,
-                    max: a2,
-                },
-                MathFunction::Clamp {
-                    min: b0,
-                    center: b1,
-                    max: b2,
-                },
-            ) => a0.eql(b0) && a1.eql(b1) && a2.eql(b2),
-            (
-                MathFunction::Round {
-                    strategy: as_,
-                    value: av,
-                    interval: ai,
-                },
-                MathFunction::Round {
-                    strategy: bs,
-                    value: bv,
-                    interval: bi,
-                },
-            ) => as_ == bs && av.eql(bv) && ai.eql(bi),
-            (
-                MathFunction::Rem {
-                    dividend: ad,
-                    divisor: av,
-                },
-                MathFunction::Rem {
-                    dividend: bd,
-                    divisor: bv,
-                },
-            ) => ad.eql(bd) && av.eql(bv),
-            (
-                MathFunction::Mod {
-                    dividend: ad,
-                    divisor: av,
-                },
-                MathFunction::Mod {
-                    dividend: bd,
-                    divisor: bv,
-                },
-            ) => ad.eql(bd) && av.eql(bv),
-            (MathFunction::Abs(a), MathFunction::Abs(b)) => a.eql(b),
-            (MathFunction::Sign(a), MathFunction::Sign(b)) => a.eql(b),
-            (MathFunction::Hypot(a), MathFunction::Hypot(b)) => eql_calc_list(a, b),
-            _ => false,
-        }
-    }
-
     pub(crate) fn deep_clone(&self) -> Self
     where
         V: Clone,
@@ -1615,10 +1510,6 @@ impl CalcValue for CSSNumber {
             _ => Err(input.new_custom_error(css::ParserError::invalid_value)),
         }
     }
-    #[inline]
-    fn eql(&self, other: &Self) -> bool {
-        *self == *other
-    }
 }
 
 impl CalcValue for Angle {
@@ -1635,10 +1526,6 @@ impl CalcValue for Angle {
             Calc::Value(v) => Ok(*v),
             _ => Err(input.new_custom_error(css::ParserError::invalid_value)),
         }
-    }
-    #[inline]
-    fn eql(&self, other: &Self) -> bool {
-        Angle::eql(*self, *other)
     }
 }
 
@@ -1777,10 +1664,6 @@ impl CalcValue for Percentage {
             _ => Ok(Percentage { v: f32::NAN }),
         }
     }
-    #[inline]
-    fn eql(&self, other: &Self) -> bool {
-        Percentage::eql(*self, *other)
-    }
 }
 
 calc_protocol_forwarders!(Time {
@@ -1823,10 +1706,6 @@ impl CalcValue for Time {
             _ => Err(input.new_custom_error(css::ParserError::invalid_value)),
         }
     }
-    #[inline]
-    fn eql(&self, other: &Self) -> bool {
-        Time::eql(*self, *other)
-    }
 }
 
 calc_protocol_forwarders!(Length {
@@ -1863,10 +1742,6 @@ impl CalcValue for Length {
     }
     fn from_calc(c: Calc<Self>, _input: &mut css::Parser) -> CssResult<Self> {
         Ok(Length::Calc(Box::new(c)))
-    }
-    #[inline]
-    fn eql(&self, other: &Self) -> bool {
-        self == other
     }
 }
 
@@ -1916,7 +1791,6 @@ macro_rules! dim_pct_protocol {
             fn from_calc(c: Calc<Self>, _input: &mut css::Parser) -> CssResult<Self> {
                 Ok(DimensionPercentage::Calc(Box::new(c)))
             }
-            #[inline] fn eql(&self, other: &Self) -> bool { self == other }
         }
     };
 }

--- a/src/css/values/css_string.rs
+++ b/src/css/values/css_string.rs
@@ -1,5 +1,4 @@
 pub use crate::css_parser as css;
-pub use css::CssResult as Result;
 pub use css::PrintErr;
 pub use css::Printer;
 
@@ -15,11 +14,6 @@ pub type CssString = *const [u8];
 
 pub struct CssStringFns;
 impl CssStringFns {
-    pub fn parse(input: &mut css::Parser) -> Result<CssString> {
-        // No lifetime laundering: capture the arena slice as a raw pointer.
-        input.expect_string().map(std::ptr::from_ref::<[u8]>)
-    }
-
     pub fn to_css(this: &CssString, dest: &mut Printer) -> core::result::Result<(), PrintErr> {
         // SAFETY: per the `CssString` invariant above, the pointee borrows the
         // parser arena which outlives the `Printer` it is being written to.

--- a/src/css/values/time.rs
+++ b/src/css/values/time.rs
@@ -28,13 +28,6 @@ pub enum Time {
 impl Time {
     // css.implementDeepClone / css.implementEql / css.implementHash — provided
     // by `#[derive(DeepClone, CssEql, CssHash)]` above (POD f32 payload).
-    // Kept as an inherent assoc fn for `protocol::CalcValue` callers that
-    // forward via UFCS (`Time::eql(a, b)`) — does not conflict with the
-    // derived trait method (that one has a `&self` receiver).
-    #[inline]
-    pub fn eql(lhs: Self, rhs: Self) -> bool {
-        lhs == rhs
-    }
 
     pub fn parse(input: &mut css::Parser) -> Result<Time> {
         match input.try_parse(Calc::<Time>::parse) {

--- a/src/css_derive/lib.rs
+++ b/src/css_derive/lib.rs
@@ -1153,8 +1153,8 @@ fn expand_derive_parse(input: &DeriveInput) -> syn::Result<TokenStream2> {
         }
     };
 
-    // Emit the body in the **trait** impl so `css::generic::parse[_with_options]`
-    // (bounded on `T: generics::Parse[WithOptions]`) resolves. An inherent
+    // Emit the body in the **trait** impl so `css::generic::parse_with_options`
+    // (bounded on `T: generics::ParseWithOptions`) resolves. An inherent
     // `parse` is kept as a thin forwarder for call sites that don't import the
     // trait. `ParseWithOptions` ignores options — types that
     // genuinely consume options hand-write their own impl instead of deriving.

--- a/src/install/windows-shim/main.rs
+++ b/src/install/windows-shim/main.rs
@@ -288,9 +288,7 @@ pub mod compat {
     // ── kernel32 surface (bun_sys::windows::kernel32 layers extras on top
     //    of bun_windows_sys::kernel32; mirror just what the shim calls) ──
     pub mod kernel32 {
-        pub use bun_windows_sys::externs::{
-            GetConsoleMode, GetExitCodeProcess, SetConsoleMode, WaitForSingleObject,
-        };
+        pub use bun_windows_sys::externs::{GetConsoleMode, GetExitCodeProcess, SetConsoleMode};
         pub use bun_windows_sys::kernel32::*;
     }
 }

--- a/src/jsc/AbortSignal.rs
+++ b/src/jsc/AbortSignal.rs
@@ -2,10 +2,7 @@ use core::ffi::c_void;
 use core::ptr::NonNull;
 use core::sync::atomic::Ordering;
 
-use crate::{
-    CommonAbortReason, CommonAbortReasonExt as _, JSGlobalObject, JSValue,
-    VirtualMachineRef as VirtualMachine,
-};
+use crate::{CommonAbortReason, JSGlobalObject, JSValue, VirtualMachineRef as VirtualMachine};
 use bun_event_loop::EventLoopTimer::{
     EventLoopTimer, InHeap, IntrusiveField, State as TimerState, Tag as TimerTag, TimerFlags,
     Timespec as ElTimespec,
@@ -260,15 +257,6 @@ impl AbortSignal {
 pub enum AbortReason {
     Common(CommonAbortReason),
     Js(JSValue),
-}
-
-impl AbortReason {
-    pub fn to_js(self, global: &JSGlobalObject) -> JSValue {
-        match self {
-            AbortReason::Common(reason) => reason.to_js(global),
-            AbortReason::Js(value) => value,
-        }
-    }
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -1996,12 +1996,6 @@ pub mod formatter {
     }
 
     impl TagPayload {
-        /// The constructor lives here as well as on the bare
-        /// discriminant `Tag`. Callers in sibling modules use either name.
-        #[inline]
-        pub fn get(value: JSValue, global_this: &JSGlobalObject) -> JsResult<TagResult> {
-            Tag::get(value, global_this)
-        }
         pub(crate) fn is_primitive(self) -> bool {
             self.tag().is_primitive()
         }

--- a/src/jsc/ErrorCode.rs
+++ b/src/jsc/ErrorCode.rs
@@ -138,11 +138,6 @@ pub struct ErrorBuilder<'a, G: GlobalObjectRef + ?Sized = JSGlobalObject> {
 }
 
 impl<'a, G: GlobalObjectRef + ?Sized> ErrorBuilder<'a, G> {
-    #[inline]
-    pub fn new(global: &'a G, code: ErrorCode, args: Arguments<'a>) -> Self {
-        Self { global, code, args }
-    }
-
     /// Throw this error as a JS exception.
     #[inline]
     pub fn throw(self) -> JsError {

--- a/src/jsc/JSCell.rs
+++ b/src/jsc/JSCell.rs
@@ -1,6 +1,6 @@
+use crate::JSType;
 use crate::custom_getter_setter::CustomGetterSetter;
 use crate::getter_setter::GetterSetter;
-use crate::{JSType, JSValue};
 
 bun_opaque::opaque_ffi! {
     /// Opaque FFI handle for `JSC::JSCell`.
@@ -14,10 +14,6 @@ impl JSCell {
         // `JSType` is a `#[repr(transparent)]` newtype over `u8`, so any byte
         // returned by the extern is a valid value (see the extern's NOTE).
         JSType(JSC__JSCell__getType(self))
-    }
-
-    pub fn to_js(&self) -> JSValue {
-        JSValue::from_cell(std::ptr::from_ref::<JSCell>(self))
     }
 
     pub(crate) fn get_getter_setter(&self) -> &GetterSetter {

--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -379,10 +379,6 @@ impl JSGlobalObject {
         .to_js()
     }
 
-    pub fn to_js<T: Into<JSValue>>(&self, value: T) -> JsResult<JSValue> {
-        Ok(value.into())
-    }
-
     /// "Expected {field} to be a {typename} for '{name}'."
     pub fn throw_invalid_argument_type(
         &self,
@@ -927,15 +923,6 @@ impl JSGlobalObject {
         let str = ZigString::init_utf8(&buffer);
         let err_value = str.to_error_instance(self);
         self.throw_value(err_value)
-    }
-
-    // TODO: delete these two fns
-    pub fn ref_(&self) -> &JSGlobalObject {
-        self
-    }
-    #[inline]
-    pub fn ctx(&self) -> &JSGlobalObject {
-        self.ref_()
     }
 
     pub fn create_aggregate_error(

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -181,12 +181,6 @@ impl JSValue {
     ) {
         self.then2(global, ctx, resolve, reject)
     }
-
-    /// Reinterpret a raw pointer's address as a JSValue bit-pattern.
-    #[inline]
-    pub fn cast<T>(ptr: *const T) -> JSValue {
-        JSValue(ptr as usize, PhantomData)
-    }
 }
 
 // `pub fn format(...) !void { @compileError(...) }` — intentionally NOT

--- a/src/jsc/Task.rs
+++ b/src/jsc/Task.rs
@@ -21,14 +21,6 @@ use crate::{JSGlobalObject, JsError};
 // `bun_jsc::Task` / `bun_jsc::Taskable` without reaching down a tier.
 pub use bun_event_loop::{Task, TaskTag, Taskable, task_tag};
 
-/// `Task::new<T: Taskable>(ptr)` — typed constructor. Kept as a free fn for
-/// back-compat with existing call sites; equivalent to [`Task::init`].
-/// The tag comes from the [`Taskable`] impl.
-#[inline]
-pub fn new<T: Taskable>(ptr: *mut T) -> Task {
-    Task::init(ptr)
-}
-
 // ─── run_tasks dispatch ─────────────────────────────────────────────────────
 // The per-tick dispatch entry point is `bun_jsc::event_loop::tick_queue_with_
 // count` (declares `__bun_tick_queue_with_count`, defined in

--- a/src/jsc/TopExceptionScope.rs
+++ b/src/jsc/TopExceptionScope.rs
@@ -171,19 +171,6 @@ impl Drop for TopExceptionScopeGuard<'_> {
 }
 
 impl TopExceptionScope {
-    /// Convenience alias of [`init`](Self::init) accepting an explicit caller `Location`.
-    /// The inner C++ scope only consumes file/line, which `init` already recovers via
-    /// `#[track_caller]`; `_src` is accepted for API symmetry with
-    /// `ExceptionValidationScope::new` so call sites can pass `Location::caller()` uniformly.
-    #[track_caller]
-    pub fn new<'a>(
-        storage: &'a mut core::mem::MaybeUninit<Self>,
-        global: &JSGlobalObject,
-        _src: &'static core::panic::Location<'static>,
-    ) -> &'a mut Self {
-        Self::init(storage, global)
-    }
-
     /// Construct in caller-owned storage. The C++ `ExceptionScope` ctor stores
     /// `&bytes` into `vm.m_topExceptionScope`, so the storage address must be
     /// stable from before this call until [`destroy`](Self::destroy) — which
@@ -443,20 +430,6 @@ impl Drop for ExceptionValidationScopeGuard<'_> {
 }
 
 impl ExceptionValidationScope {
-    /// See [`TopExceptionScope::init`] for the storage-passing rationale.
-    /// `src` is currently advisory (forwarded to the C++ scope when `ci_assert`
-    /// is enabled via `init_in_place` callers); kept in the signature so call
-    /// sites can pass `core::panic::Location::caller()` today and the value
-    /// flows through once the C++ side consumes it.
-    #[track_caller]
-    pub fn new<'a>(
-        storage: &'a mut core::mem::MaybeUninit<Self>,
-        global: &JSGlobalObject,
-        _src: &'static core::panic::Location<'static>,
-    ) -> &'a mut Self {
-        Self::init(storage, global)
-    }
-
     /// See [`TopExceptionScope::init`] for the storage-passing rationale.
     #[track_caller]
     pub(crate) fn init<'a>(

--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -445,8 +445,7 @@ impl ArrayBuffer {
                     self.byte_len,
                     Some(MarkedArrayBuffer_deallocator),
                     // The deallocator ignores its ctx (mi_free needs no ctx). Any non-null
-                    // sentinel would do; pass the data ptr itself for symmetry with
-                    // `MarkedArrayBuffer::to_js`.
+                    // sentinel would do; pass the data ptr itself.
                     self.ptr.cast(),
                 )
             };
@@ -918,42 +917,6 @@ impl MarkedArrayBuffer {
         self.owns_buffer = false;
         let mut buf = self.buffer;
         JSValue::create_buffer(global, buf.byte_slice_mut())
-    }
-
-    /// Ownership of the bytes moves to JSC (freed by `MarkedArrayBuffer_deallocator`).
-    pub fn to_js(&mut self, global: &JSGlobalObject) -> JsResult<JSValue> {
-        if !self.buffer.value.is_empty_or_undefined_or_null() {
-            return Ok(self.buffer.value);
-        }
-        self.owns_buffer = false;
-        if self.buffer.byte_len == 0 {
-            // SAFETY: null `ptr` with `len == 0` and no deallocator — every
-            // obligation of the callee's contract holds trivially.
-            return unsafe {
-                make_typed_array_with_bytes_no_copy(
-                    global,
-                    self.buffer.typed_array_type.to_typed_array_type(),
-                    ptr::null_mut(),
-                    0,
-                    None,
-                    ptr::null_mut(),
-                )
-            };
-        }
-        // SAFETY: this type's contract: `buffer.ptr` is the live backing
-        // allocation of `byte_len` bytes, mimalloc-owned (`from_string`/
-        // `from_bytes`); ownership moves to JSC, which frees it exactly once
-        // via `MarkedArrayBuffer_deallocator` (`mi_free`, ctx ignored).
-        unsafe {
-            make_typed_array_with_bytes_no_copy(
-                global,
-                self.buffer.typed_array_type.to_typed_array_type(),
-                self.buffer.ptr.cast(),
-                self.buffer.byte_len,
-                Some(MarkedArrayBuffer_deallocator),
-                self.buffer.ptr.cast(),
-            )
-        }
     }
 }
 

--- a/src/jsc/job.rs
+++ b/src/jsc/job.rs
@@ -13,7 +13,7 @@
 //! [`JobContext::Js`] is the completion's JS-thread state (promise, callback,
 //! wrapper refs, pins, protected buffers) and is only ever touched on the JS
 //! thread. JS-backed memory the body reads in place is reachable through
-//! [`JsPtr`], dereferenceable only with the job's ticket or a [`JsThread`].
+//! [`JsPtr`], dereferenceable only with the job's ticket.
 //!
 //! Node's equivalent is `ThreadPoolWork` + `req_wrap`; WebCore's is
 //! `WorkerRunLoop::postTask` with `ActiveDOMObject`-owned completions.
@@ -32,10 +32,9 @@ use crate::{JSGlobalObject, JsResult};
 
 // ── tokens ────────────────────────────────────────────────────────────────
 
-/// Proof that the holder is on `global`'s JS thread with its heap alive: what
-/// it takes to dereference a [`JsPtr`] outside a pool body. Host functions and
-/// event-loop dispatch have one by construction ([`JSGlobalObject::js_thread`]).
-/// Not `Send`.
+/// Proof that the holder is on `global`'s JS thread with its heap alive. Host
+/// functions and event-loop dispatch have one by construction
+/// ([`JSGlobalObject::js_thread`]). Not `Send`.
 pub struct JsThread<'a> {
     global: &'a JSGlobalObject,
     _not_send: PhantomData<*mut ()>,
@@ -141,10 +140,10 @@ impl Drop for Protected {
 /// A pointer into JS-owned memory (an ArrayBuffer's bytes, a pinned cell, the
 /// creating global) that a job carries off-thread. It can be *passed around*
 /// anywhere but dereferenced only with proof the VM is alive: the job's
-/// [`Ticket`] or a [`JsThread`].
+/// [`Ticket`].
 #[repr(transparent)]
 pub struct JsPtr<T: ?Sized>(NonNull<T>);
-// SAFETY: dereferenceable only under a Ticket/JsThread (see type doc).
+// SAFETY: dereferenceable only under a Ticket (see type doc).
 unsafe impl<T: ?Sized> Send for JsPtr<T> {}
 impl<T: ?Sized> Clone for JsPtr<T> {
     fn clone(&self) -> Self {
@@ -173,14 +172,6 @@ impl<T: ?Sized> JsPtr<T> {
         // SAFETY: ticket held ⇒ VM alive ⇒ pointee alive (type contract); aliasing per fn contract.
         unsafe { &mut *self.0.as_ptr() }
     }
-    /// # Safety
-    /// No other live reference aliases the pointee for `'b`.
-    #[inline]
-    #[allow(clippy::mut_from_ref)] // the `&JsThread` is a thread witness, not the pointee
-    pub unsafe fn on_js_thread<'b>(self, _: &'b JsThread<'_>) -> &'b mut T {
-        // SAFETY: JS thread with heap alive; aliasing per fn contract.
-        unsafe { &mut *self.0.as_ptr() }
-    }
 }
 
 // ── Job ───────────────────────────────────────────────────────────────────
@@ -202,9 +193,7 @@ pub trait JobContext: Sized + 'static {
     /// job's ticket: proof the VM is alive (for [`JsPtr::under_ticket`]), and
     /// `script_allowed()` on it says whether the result still has a consumer.
     /// `off` borrows the job, which the JS thread may free the moment
-    /// [`Completion::finish`] queues it: do not touch it after finishing (work
-    /// that continues past `run` reaches its state through
-    /// [`Completion::off_thread`]).
+    /// [`Completion::finish`] queues it: do not touch it after finishing.
     fn run(off: &mut Self::OffThread, done: Completion<Self>) -> Option<Completion<Self>>;
 
     /// JS thread, VM still running script: the completion. Both halves are
@@ -425,14 +414,6 @@ impl<C: JobContext> Completion<C> {
     #[inline]
     pub fn ticket(&self) -> &Ticket {
         &self.ticket
-    }
-    /// The job's off-thread part, for work that continues after `run` returned.
-    ///
-    /// # Safety
-    /// No other reference to it is live (the pool callback has returned).
-    pub unsafe fn off_thread(&self) -> *mut C::OffThread {
-        // SAFETY: live job.
-        unsafe { &raw mut (*self.job.as_ptr()).off }
     }
 }
 impl<C: JobContext> Drop for Completion<C> {

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -944,39 +944,6 @@ impl BuiltinName {
     pub const Error: Self = Self::error;
     pub const Encoding: Self = Self::encoding;
     pub const Type: Self = Self::type_;
-
-    pub fn get(property: &[u8]) -> Option<BuiltinName> {
-        BUILTIN_NAME_MAP.get(property).copied()
-    }
-}
-
-bun_core::comptime_string_map! {
-    static BUILTIN_NAME_MAP: BuiltinName = {
-        b"method" => BuiltinName::method,
-        b"headers" => BuiltinName::headers,
-        b"status" => BuiltinName::status,
-        b"statusText" => BuiltinName::statusText,
-        b"url" => BuiltinName::url,
-        b"body" => BuiltinName::body,
-        b"data" => BuiltinName::data,
-        b"toString" => BuiltinName::toString,
-        b"redirect" => BuiltinName::redirect,
-        b"inspectCustom" => BuiltinName::inspectCustom,
-        b"highWaterMark" => BuiltinName::highWaterMark,
-        b"path" => BuiltinName::path,
-        b"stream" => BuiltinName::stream,
-        b"asyncIterator" => BuiltinName::asyncIterator,
-        b"name" => BuiltinName::name,
-        b"message" => BuiltinName::message,
-        b"error" => BuiltinName::error,
-        b"default" => BuiltinName::default,
-        b"encoding" => BuiltinName::encoding,
-        b"fatal" => BuiltinName::fatal,
-        b"ignoreBOM" => BuiltinName::ignoreBOM,
-        b"type" => BuiltinName::type_,
-        b"signal" => BuiltinName::signal,
-        b"cmd" => BuiltinName::cmd,
-    };
 }
 
 /// RAII guard that keeps a `JSValue` reachable across an FFI call by emitting

--- a/src/jsc/uuid.rs
+++ b/src/jsc/uuid.rs
@@ -63,11 +63,6 @@ impl UUID {
 
         Ok(uuid)
     }
-
-    // Zero UUID
-    pub const ZERO: UUID = UUID { bytes: [0u8; 16] };
-
-    // Convenience function to return a new v4 UUID.
 }
 
 // Indices in the UUID string representation for each byte.

--- a/src/ptr/lib.rs
+++ b/src/ptr/lib.rs
@@ -156,11 +156,6 @@ impl<T: ?Sized> BackRef<T, Mut> {
         // liveness/alignment; `Mut` records write provenance.
         unsafe { self.0.as_mut() }
     }
-
-    #[inline]
-    pub const fn shared(self) -> BackRef<T, Shared> {
-        BackRef(self.0, core::marker::PhantomData)
-    }
 }
 
 impl<T, P> BackRef<T, P> {
@@ -709,12 +704,6 @@ impl<T> DetachablePtr<T> {
     #[inline]
     pub fn is_detached(&self) -> bool {
         self.0.get().is_null()
-    }
-
-    /// Recover the raw pointer (for forwarding / identity checks).
-    #[inline]
-    pub fn as_ptr(&self) -> *mut T {
-        self.0.get()
     }
 
     /// Load the parked `&mut T`, or `None` if detached.

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -3575,12 +3575,8 @@ impl TimeLike {
 }
 #[cfg(unix)]
 pub const UTIME_NOW: i64 = libc::UTIME_NOW;
-#[cfg(unix)]
-pub const UTIME_OMIT: i64 = libc::UTIME_OMIT;
 #[cfg(windows)]
 pub const UTIME_NOW: i64 = -1;
-#[cfg(windows)]
-pub const UTIME_OMIT: i64 = -2;
 
 #[cfg(windows)]
 #[path = "sys_uv.rs"]
@@ -5115,7 +5111,7 @@ pub mod c {
         pub safe fn getgid() -> libc::gid_t;
     }
     #[cfg(unix)]
-    pub use super::{UTIME_NOW, UTIME_OMIT};
+    pub use super::UTIME_NOW;
     #[cfg(any(
         target_os = "macos",
         target_os = "ios",
@@ -5213,9 +5209,8 @@ pub mod c {
         vm_statistics64,
         vm_statistics64_data_t,
     };
-    // `UTIME_NOW`/`UTIME_OMIT` — already re-exported via
-    // `pub use super::{UTIME_NOW, UTIME_OMIT}` above (top-level `#[cfg(unix)]`
-    // consts cast `libc::UTIME_NOW`/`_OMIT` to i64).
+    // `UTIME_NOW` — already re-exported via `pub use super::UTIME_NOW` above
+    // (top-level `#[cfg(unix)]` const casts `libc::UTIME_NOW` to i64).
     /// Safe rc-returning `clonefile(2)` — callers that want their own
     /// `sys::Tag` / path boxing (`errno_sys_p`) take the raw `c_int` instead
     /// of the `Maybe<()>`-shaped [`super::clonefile`].
@@ -6211,10 +6206,6 @@ impl DynLib {
         }
         // Windows: FreeLibrary via windows mod; intentionally leaked here
         // (close is a no-op on Windows in our usage).
-    }
-    #[inline]
-    pub fn handle(&self) -> *mut c_void {
-        self.handle
     }
 }
 
@@ -7990,7 +7981,7 @@ pub(crate) fn make_path_w(dir: Fd, sub_path: &[u16]) -> Maybe<()> {
 // `std.posix` — wider surface than `bun_errno::posix` (which only has
 // mode_t/E/S/errno). Dependents (`bun_resolver`, `bun_md`, `bun_crash`,
 // `bun_threading`) reach for `Sigaction`, `getrlimit`, `tcgetattr`, raw
-// `read`/`write`/`poll`, `dl_iterate_phdr` etc. We re-export the errno stub
+// `write`/`poll`, `dl_iterate_phdr` etc. We re-export the errno stub
 // and layer the libc bits on top so `bun_sys::posix::*` is the single import.
 // ──────────────────────────────────────────────────────────────────────────
 pub mod posix {
@@ -8236,20 +8227,6 @@ pub mod posix {
     }
 
     // ── raw I/O (no `Maybe` wrapping) ──
-    #[cfg(unix)]
-    #[inline]
-    pub unsafe fn read(fd: c_int, buf: *mut u8, count: usize) -> isize {
-        #[cfg(any(target_os = "linux", target_os = "android"))]
-        {
-            // SAFETY: caller contract — `buf` points to `count` writable bytes.
-            unsafe { super::linux_syscall::read_raw(fd, buf, count) }
-        }
-        #[cfg(not(any(target_os = "linux", target_os = "android")))]
-        {
-            // SAFETY: caller contract — `buf` points to `count` writable bytes.
-            unsafe { libc::read(fd, buf.cast(), count) }
-        }
-    }
     #[cfg(unix)]
     #[inline]
     pub unsafe fn write(fd: c_int, buf: *const u8, count: usize) -> isize {

--- a/src/sys/linux_syscall.rs
+++ b/src/sys/linux_syscall.rs
@@ -385,7 +385,7 @@ pub(crate) unsafe fn pwritev(
 // `-errno` returns, which callers decode via `GetErrno for isize`.
 // ──────────────────────────────────────────────────────────────────────────
 
-/// Raw `read(2)` — libc-convention return (for `linux::read` / `posix::read`).
+/// Raw `read(2)` — libc-convention return (for `linux::read`).
 ///
 /// This is a libc-convention thunk: callers may pass `fd == -1` (expecting
 /// EBADF), `buf == NULL` with `count == 0` (expecting `0`), or an

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -1654,8 +1654,7 @@ pub fn become_watcher_manager() -> ! {
             bun_core::Output::panic(format_args!("Failed to spawn process: {}\n", err));
         }
         // `kernel32::WaitForSingleObject` is the local `safe fn` re-decl
-        // (by-value `HANDLE`/`DWORD` only); avoid the `bun_windows_sys`
-        // `unsafe fn` Result-wrapper and check `WAIT_FAILED` inline.
+        // (by-value `HANDLE`/`DWORD` only); check `WAIT_FAILED` inline.
         if kernel32::WaitForSingleObject(procinfo.hProcess, win32::INFINITE) == externs::WAIT_FAILED
         {
             let err = Win32Error::get();

--- a/src/tcc_sys/lib.rs
+++ b/src/tcc_sys/lib.rs
@@ -2,6 +2,5 @@
 #![warn(unused_must_use)]
 pub mod tcc;
 pub use tcc::{
-    Config, ConfigErr, Error, ErrorFunc, OutputFormat, State, Symbol, SymbolCallback, TCCErrorFunc,
-    TCCState,
+    Config, ConfigErr, Error, ErrorFunc, OutputFormat, State, Symbol, TCCErrorFunc, TCCState,
 };

--- a/src/tcc_sys/tcc.rs
+++ b/src/tcc_sys/tcc.rs
@@ -123,9 +123,6 @@ pub enum OutputFormat {
 // allowing for interop with other APIs taking `*mut c_void` pointers.
 bun_opaque::opaque_ffi! { pub struct Symbol; }
 
-pub type SymbolCallback =
-    unsafe extern "C" fn(ctx: *mut c_void, name: *const c_char, val: *const Symbol);
-
 bun_opaque::opaque_ffi! {
     /// Opaque TinyCC compilation state. Always handled via `*mut State` / `&mut State`.
     pub struct State;

--- a/src/uws_sys/Loop.rs
+++ b/src/uws_sys/Loop.rs
@@ -248,11 +248,6 @@ impl PosixLoop {
         unsafe { c::us_wakeup_loop(self) };
     }
 
-    #[inline]
-    pub fn wake(&mut self) {
-        self.wakeup();
-    }
-
     pub fn tick(&mut self) {
         // SAFETY: self is a valid loop pointer
         unsafe { c::us_loop_run_bun_tick(self, core::ptr::null(), NOW_NS_UNKNOWN) };
@@ -339,11 +334,6 @@ impl PosixLoop {
         // SAFETY: `this` is the live C-allocated loop pointer per fn contract.
         unsafe { c::uws_loop_addPreHandler(this, ctx, callback) };
         Handler { loop_: this }
-    }
-
-    pub fn run(&mut self) {
-        // SAFETY: self is a valid loop pointer
-        unsafe { c::us_loop_run(self) };
     }
 
     pub fn should_enable_date_header_timer(&self) -> bool {

--- a/src/uws_sys/Response.rs
+++ b/src/uws_sys/Response.rs
@@ -779,15 +779,6 @@ impl AnyResponse {
         any_dispatch!(self, |r| r.state())
     }
 
-    // Thin alias for the `From` impls below.
-    #[inline]
-    pub fn init<T>(response: T) -> AnyResponse
-    where
-        AnyResponse: From<T>,
-    {
-        AnyResponse::from(response)
-    }
-
     pub fn timeout(self, seconds: u8) {
         any_dispatch!(self, |r| r.timeout(seconds))
     }

--- a/src/uws_sys/SocketGroup.rs
+++ b/src/uws_sys/SocketGroup.rs
@@ -146,13 +146,6 @@ impl SocketGroup {
         self.ext.cast::<T>()
     }
 
-    pub fn is_empty(&self) -> bool {
-        self.head_sockets.is_null()
-            && self.head_connecting_sockets.is_null()
-            && self.head_listen_sockets.is_null()
-            && self.low_prio_count == 0
-    }
-
     pub fn listen(
         &mut self,
         kind: SocketKind,

--- a/src/uws_sys/lib.rs
+++ b/src/uws_sys/lib.rs
@@ -139,7 +139,6 @@ pub struct Opcode(pub i32);
 impl Opcode {
     pub const Text: Opcode = Opcode(1);
     pub const Binary: Opcode = Opcode(2);
-    pub const Close: Opcode = Opcode(8);
     pub const Ping: Opcode = Opcode(9);
     pub const Pong: Opcode = Opcode(10);
     // Upper-case aliases for callers that use the screaming-snake names
@@ -471,7 +470,6 @@ pub mod fault_inject {
 }
 pub use socket::{
     AnySocket, ConnectError, InternalSocket, NewSocketHandler, SocketHandler, SocketTCP, SocketTLS,
-    SocketTcp, SocketTls,
 };
 
 // ───────────────────────────── re-exports ────────────────────────────────────
@@ -483,8 +481,7 @@ pub use loop_::{Loop, NOW_NS_UNKNOWN, PosixLoop};
 pub use socket_kind::SocketKind;
 #[cfg(windows)]
 pub use timer::Timer;
-#[cfg(not(windows))]
-pub type WindowsLoop = loop_::PosixLoop; // unified on non-Windows
+
 pub use body_reader_mixin::BodyReaderMixin;
 pub use connecting_socket::ConnectingSocket;
 pub use listen_socket::ListenSocket;

--- a/src/uws_sys/socket.rs
+++ b/src/uws_sys/socket.rs
@@ -197,9 +197,6 @@ pub struct NewSocketHandler<const IS_SSL: bool> {
 
 pub type SocketTCP = NewSocketHandler<false>;
 pub type SocketTLS = NewSocketHandler<true>;
-/// snake-case aliases (match `AnySocket` variant names).
-pub type SocketTcp = NewSocketHandler<false>;
-pub type SocketTls = NewSocketHandler<true>;
 /// Alias used by `http`, `ipc`, `websocket_client` — same type, less ceremony.
 pub type SocketHandler<const SSL: bool> = NewSocketHandler<SSL>;
 
@@ -612,7 +609,7 @@ impl<const IS_SSL: bool> NewSocketHandler<IS_SSL> {
         }
     }
 
-    // ── ext / group / fd ────────────────────────────────────────────────────
+    // ── ext / fd ────────────────────────────────────────────────────────────
 
     /// Typed ext storage. `None` for non-uSockets transports.
     pub fn ext<T>(&self) -> Option<*mut T> {
@@ -623,17 +620,6 @@ impl<const IS_SSL: bool> NewSocketHandler<IS_SSL> {
             InternalSocket::Connecting(s) => {
                 Some(crate::connecting_socket::us_connecting_socket_ext(conn(s)).cast::<T>())
             }
-            _ => None,
-        }
-    }
-
-    /// Group this socket is linked into. `None` for non-uSockets transports.
-    pub fn group(&self) -> Option<*mut SocketGroup> {
-        match self.socket {
-            InternalSocket::Connected(s) => {
-                Some(std::ptr::from_mut::<SocketGroup>(sock(s).group()))
-            }
-            InternalSocket::Connecting(s) => Some(conn(s).group()),
             _ => None,
         }
     }
@@ -939,14 +925,6 @@ impl AnySocket {
             AnySocket::SocketTcp(s) => &s.socket,
             AnySocket::SocketTls(s) => &s.socket,
         }
-    }
-    #[inline]
-    pub fn group(&self) -> *mut SocketGroup {
-        match self {
-            AnySocket::SocketTcp(s) => s.group(),
-            AnySocket::SocketTls(s) => s.group(),
-        }
-        .unwrap()
     }
 
     any_socket_forward! {

--- a/src/windows_sys/externs.rs
+++ b/src/windows_sys/externs.rs
@@ -999,23 +999,6 @@ pub const INFINITE: DWORD = 0xFFFF_FFFF;
 pub const WAIT_FAILED: DWORD = 0xFFFF_FFFF;
 pub const STARTF_USESTDHANDLES: DWORD = 0x0000_0100;
 
-#[cfg_attr(windows, link(name = "kernel32"))]
-unsafe extern "system" {
-    #[link_name = "WaitForSingleObject"]
-    fn WaitForSingleObject_raw(hHandle: HANDLE, dwMilliseconds: DWORD) -> DWORD;
-}
-/// SAFETY: `handle` must be a valid waitable kernel object.
-pub unsafe fn WaitForSingleObject(handle: HANDLE, ms: DWORD) -> Result<DWORD, Win32Error> {
-    // SAFETY: caller contract guarantees `handle` is a valid waitable kernel
-    // object; `ms` is a by-value DWORD with no pointer preconditions.
-    let rc = unsafe { WaitForSingleObject_raw(handle, ms) };
-    if rc == WAIT_FAILED {
-        Err(Win32Error::get())
-    } else {
-        Ok(rc)
-    }
-}
-
 // ──────────────────────────────────────────────────────────────────────────
 // NTSTATUS — a transparent newtype so unmapped codes round-trip.
 // ──────────────────────────────────────────────────────────────────────────
@@ -1061,10 +1044,6 @@ impl NTSTATUS {
     #[inline]
     pub const fn from_raw(raw: u32) -> Self {
         NTSTATUS(raw)
-    }
-    #[inline]
-    pub const fn raw(self) -> u32 {
-        self.0
     }
 }
 

--- a/src/zlib_sys/posix.rs
+++ b/src/zlib_sys/posix.rs
@@ -3,8 +3,8 @@
 use core::ffi::{c_char, c_int};
 
 pub use crate::shared::{
-    DataType, FlushValue, ReturnCode, alloc_func, free_func, struct_internal_state, z_alloc_fn,
-    z_free_fn, z_stream, z_streamp, zStream_struct,
+    DataType, FlushValue, ReturnCode, alloc_func, free_func, struct_internal_state, z_stream,
+    z_streamp, zStream_struct,
 };
 
 unsafe extern "C" {

--- a/src/zlib_sys/shared.rs
+++ b/src/zlib_sys/shared.rs
@@ -76,10 +76,8 @@ use core::ffi::{c_char, c_uint, c_ulong, c_void};
 // typedef void   (*free_func) (voidpf opaque, voidpf address);
 pub type alloc_func = Option<unsafe extern "C" fn(*mut c_void, c_uint, c_uint) -> *mut c_void>;
 pub type free_func = Option<unsafe extern "C" fn(*mut c_void, *mut c_void)>;
-// Legacy spellings the per-platform modules exported; keep both so downstream
-// `pub use` re-exports stay source-compatible.
-pub type z_alloc_fn = alloc_func;
-pub type z_free_fn = free_func;
+// Legacy spellings win32.rs exports; kept so its `pub use` re-export stays
+// source-compatible.
 pub type z_alloc_func = alloc_func;
 pub type z_free_func = free_func;
 
@@ -91,7 +89,6 @@ pub type z_free_func = free_func;
 // target Bun ships; `uLong` = `unsigned long` (4B on LLP64 Windows, 8B on LP64
 // Unix) for the same reason zStream_struct above uses `c_ulong` directly.
 // ---------------------------------------------------------------------------
-pub type Byte = u8;
 pub type Bytef = u8;
 pub type uInt = c_uint;
 pub type uLong = c_ulong;

--- a/test/internal/source-lints/dead-symbols-cross-crate-sweep.test.ts
+++ b/test/internal/source-lints/dead-symbols-cross-crate-sweep.test.ts
@@ -1,0 +1,139 @@
+// Guards against reintroduction of `pub` items removed after a cross-crate
+// reachability pass over the Rust workspace. Every entry below was unreachable
+// from the shipped roots on all six analyzed targets (linux-gnu, linux-musl,
+// android, freebsd, darwin, windows-msvc) with test targets included, had no
+// textual references under src/, src/codegen/ or the regenerated
+// build/debug/codegen/ output, and the removal was validated with
+// `cargo check --workspace` on all ten CI triples plus a full `bun bd` build.
+//
+// This is a source-tree lint (it only reads src/), so it lives in
+// test/internal/source-lints/ per the README there.
+
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const repoRoot = path.resolve(import.meta.dir, "..", "..", "..");
+
+/**
+ * `[file, item]` fails when `item` matches anywhere in the file.
+ * `[file, block, item]` fails when `item` matches inside the first match of
+ * `block` (used where a same-named item legitimately exists on another type in
+ * the same file). A block that no longer exists at all counts as clean.
+ */
+type Check = [file: string, item: RegExp] | [file: string, block: RegExp, item: RegExp];
+
+function resurrected(checks: Check[]): string[] {
+  const out: string[] = [];
+  for (const check of checks) {
+    const source = readFileSync(path.join(repoRoot, check[0]), "utf8");
+    if (check.length === 2) {
+      if (check[1].test(source)) out.push(`${check[0]}: ${check[1].source}`);
+      continue;
+    }
+    const block = check[1].exec(source);
+    if (block && check[2].test(block[0])) out.push(`${check[0]}: ${check[1].source} :: ${check[2].source}`);
+  }
+  return out;
+}
+
+test("dead bun_core / bun_alloc / bun_ast / bun_ptr items do not reappear", () => {
+  expect(
+    resurrected([
+      ["src/bun_core/bounded_array.rs", /\bpub fn get\(&self, i: usize\)/],
+      ["src/bun_core/external_shared.rs", /\bfn as_ptr\b/],
+      ["src/bun_core/lib.rs", /\bfn from_raw\(p: \*const \[T\]\)/],
+      ["src/bun_core/lib.rs", /\bpub fn concat<'b>\(buf: &'b mut \[u8\]/],
+      ["src/bun_core/string/mod.rs", /\bfn from_utf8\(utf8: &\[u8\]\) -> SliceWithUnderlyingString\b/],
+      ["src/bun_core/string/write.rs", /\bpub type Result\b/],
+      ["src/bun_core/util.rs", /^impl<T: Copy> Unaligned<T> \{[^]*?\n\}/m, /\bpub const fn new\b/],
+      ["src/bun_core/util.rs", /\bfn get_mut\(&mut self\) -> &mut T\b/],
+      ["src/bun_core/util.rs", /\bfn is_some\(self\)/],
+      ["src/bun_core/util.rs", /\bfn is_none\(self\)/],
+      ["src/bun_core/util.rs", /\bfn get\(self\) -> Option<GenericIndex<I, M>>/],
+      ["src/bun_core/util.rs", /\bfn new\(sec: i64, nsec: i64\)/],
+      ["src/bun_alloc/lib.rs", /^impl AllocError \{/m],
+      ["src/bun_alloc/lib.rs", /^pub fn usable_size\b/m],
+      [
+        "src/bun_alloc/lib.rs",
+        /^impl<ValueType, const COUNT: usize> BSSList<ValueType, COUNT> \{[^]*?\n\}/m,
+        /\bpub fn init\(\)/,
+      ],
+      ["src/ast/symbol.rs", /\bfn init\(source_count: usize\) -> Map\b/],
+      ["src/ptr/lib.rs", /\bfn shared\(self\) -> BackRef<T, Shared>/],
+      ["src/ptr/lib.rs", /^impl<T> DetachablePtr<T> \{[^]*?\n\}/m, /\bpub fn as_ptr\b/],
+    ]),
+  ).toEqual([]);
+});
+
+test("dead bun_css items do not reappear", () => {
+  expect(
+    resurrected([
+      // Inherent eql / to_css / parse forwarders whose callers all go through
+      // the CssEql / ToCss / Parse trait impls.
+      ["src/css/css_parser.rs", /^impl DefaultAtRule \{/m],
+      ["src/css/css_parser.rs", /\bfn eql\(lhs: &Token, rhs: &Token\)/],
+      ["src/css/css_parser.rs", /\bfn eql\(lhs: &Num, rhs: &Num\)/],
+      ["src/css/generics.rs", /\bfn implement_eql\b/],
+      ["src/css/generics.rs", /^pub fn parse<T: Parse>/m],
+      ["src/css/properties/custom.rs", /\bfn parse_with_options\b/],
+      ["src/css/selectors/parser.rs", /\bfn to_css\(&self, _dest: &mut Printer\)/],
+      ["src/css/selectors/parser.rs", /\bfn to_css\(self, _dest: &mut Printer\)/],
+      ["src/css/values/calc.rs", /\bfn eql\b/],
+      ["src/css/values/calc.rs", /\bfn eql_calc_list\b/],
+      ["src/css/values/css_string.rs", /\bfn parse\(input: &mut css::Parser\) -> Result<CssString>/],
+      ["src/css/values/angle.rs", /\bpub\(crate\) fn eql\b/],
+      ["src/css/values/time.rs", /\bpub fn eql\b/],
+    ]),
+  ).toEqual([]);
+});
+
+test("dead bun_jsc items do not reappear", () => {
+  expect(
+    resurrected([
+      ["src/jsc/AbortSignal.rs", /^impl AbortReason \{/m],
+      ["src/jsc/ConsoleObject.rs", /^    impl TagPayload \{[^]*?\n    \}/m, /\bpub fn get\b/],
+      ["src/jsc/ErrorCode.rs", /\bfn new\(global: &'a G, code: ErrorCode, args: Arguments<'a>\)/],
+      ["src/jsc/JSCell.rs", /\bfn to_js\b/],
+      ["src/jsc/JSGlobalObject.rs", /\bpub fn to_js<T: Into<JSValue>>/],
+      ["src/jsc/JSGlobalObject.rs", /\bpub fn ref_\b/],
+      ["src/jsc/JSGlobalObject.rs", /\bpub fn ctx\b/],
+      ["src/jsc/JSValue.rs", /\bpub fn cast<T>\(ptr: \*const T\) -> JSValue\b/],
+      ["src/jsc/Task.rs", /\bpub fn new<T: Taskable>/],
+      ["src/jsc/TopExceptionScope.rs", /\bpub fn new\b/],
+      ["src/jsc/array_buffer.rs", /\bpub fn to_js\(&mut self, global: &JSGlobalObject\)/],
+      ["src/jsc/job.rs", /\bfn on_js_thread\b/],
+      ["src/jsc/job.rs", /\bfn off_thread\b/],
+      ["src/jsc/lib.rs", /\bBUILTIN_NAME_MAP\b/],
+      ["src/jsc/uuid.rs", /\bconst ZERO\b/],
+    ]),
+  ).toEqual([]);
+});
+
+test("dead FFI-crate items do not reappear", () => {
+  expect(
+    resurrected([
+      ["src/boringssl_sys/boringssl.rs", /\bX509_V_OK\b/],
+      ["src/boringssl_sys/boringssl.rs", /\bSSL_SESS_CACHE_CLIENT\b/],
+      ["src/boringssl_sys/boringssl.rs", /^impl GeneralNames \{[^]*?\n\}/m, /\bfn is_empty\b/],
+      ["src/cares_sys/c_ares.rs", /^impl AddrInfo_hints \{/m],
+      ["src/sys/lib.rs", /\bUTIME_OMIT\b/],
+      ["src/sys/lib.rs", /\bfn handle\(&self\) -> \*mut c_void\b/],
+      ["src/tcc_sys/tcc.rs", /\bSymbolCallback\b/],
+      ["src/uws_sys/Loop.rs", /^impl PosixLoop \{[^]*?\n\}/m, /\bpub fn wake\b/],
+      ["src/uws_sys/Loop.rs", /^impl PosixLoop \{[^]*?\n\}/m, /\bpub fn run\b/],
+      ["src/uws_sys/Response.rs", /\bpub fn init<T>\(response: T\) -> AnyResponse\b/],
+      ["src/uws_sys/SocketGroup.rs", /\bfn is_empty\b/],
+      ["src/uws_sys/lib.rs", /\bconst Close: Opcode\b/],
+      ["src/uws_sys/lib.rs", /\bpub type WindowsLoop\b/],
+      ["src/uws_sys/socket.rs", /\bpub type SocketTcp\b/],
+      ["src/uws_sys/socket.rs", /\bpub type SocketTls\b/],
+      ["src/uws_sys/socket.rs", /\bpub fn group\b/],
+      ["src/windows_sys/externs.rs", /\bWaitForSingleObject_raw\b/],
+      ["src/windows_sys/externs.rs", /\bpub unsafe fn WaitForSingleObject\b/],
+      ["src/windows_sys/externs.rs", /\bpub const fn raw\(self\) -> u32\b/],
+      ["src/zlib_sys/shared.rs", /\bz_alloc_fn\b|\bz_free_fn\b/],
+      ["src/zlib_sys/shared.rs", /\bpub type Byte\b/],
+    ]),
+  ).toEqual([]);
+});


### PR DESCRIPTION
Net -631 lines of Rust source (49 files), plus a 139-line source lint that keeps the symbols from coming back.

Method: ran the repo's hawk setup (`tools/hawk/`, `dead_public` only) once per target for linux-gnu, linux-musl, android, freebsd, darwin and windows-msvc, and kept only the items reported unreachable on every target (test targets included). Items whose file is touched by one of the currently open dead-code PRs were dropped if that PR removes the same symbol (checked against each PR's diff), so nothing here duplicates an open PR. Every remaining item was then re-checked by hand with `rg` over `src/`, `src/codegen/` and freshly regenerated `build/debug/codegen/` before deletion; that pass caught a few hawk false positives, listed at the bottom.

## bun_css (-203)

The inherent `eql` / `to_css` / `parse` forwarders that predate the `CssEql` / `ToCss` / `Parse` trait impls; every caller already goes through the traits.

- `Calc::eql`, `MathFunction::eql` and the private `eql_calc_list` they shared (values/calc.rs)
- `CalcValue::eql` trait hook and its six impls: its only caller was `Calc::eql`. That in turn made the UFCS-only inherent `Time::eql` and `Angle::eql` dead (`Angle::eql` is `pub(crate)`, so rustc flagged it once the trait hook was gone); both removed
- `Token::eql`, `Num::eql`, `Dimension::eql` (css_parser.rs) and `generics::implement_eql`, which only they called
- `generics::parse<T: Parse>` free function
- `DefaultAtRule::to_css` (whole impl block)
- `GenericSelectorList::to_css`, `GenericSelector::to_css`, `GenericComponent::to_css`, `Combinator::to_css`: `#[deprecated]` tombstones that unconditionally `unreachable!()`
- `TokenList::parse_with_options`, `CssStringFns::parse` (and the `css::CssResult as Result` import only it used)

## bun_jsc (-175)

- `BuiltinName::get` and the private `BUILTIN_NAME_MAP` comptime map that only it read (lib.rs)
- `MarkedArrayBuffer::to_js` (every holder goes through `to_node_buffer` / `destroy`)
- `TopExceptionScope::new`, `ExceptionValidationScope::new` (all construction goes through `init` / `init_guard*`)
- `JSGlobalObject::to_js`, `JSGlobalObject::ref_`, `JSGlobalObject::ctx` (the latter two were already marked for deletion in a comment)
- `AbortReason::to_js` (whole impl block, plus the `CommonAbortReasonExt` import only it used), `JSCell::to_js`, `JSValue::cast`, `ErrorBuilder::new` (values are built with a struct literal), `TagPayload::get`, `task::new`, `JsPtr::on_js_thread`, `Completion::off_thread`, `UUID::ZERO`

## bun_core, bun_alloc, bun_ast, bun_ptr (-134)

- bun_core: `RawSlice::from_raw`, the buffer `concat` in lib.rs (callers use `strings::concat`), `SliceWithUnderlyingString::from_utf8`, `BoundedArrayAligned::get`, `ExternalShared::as_ptr`, `ExternalSharedOptional::get`, `Unaligned::new`, `Mutex::get_mut`, `RwLock::get_mut`, `GenericIndexOptional::{is_some, is_none, get}`, `Timespec::new`, and the `write::Result` alias (bun_io defines its own)
- bun_alloc: `impl AllocError { name }` (wrapping error types hardcode the string), the top-level `usable_size` (the `default_alloc::usable_size` everyone calls stays), `BSSList::init` (`bss_singleton!` uses `init_at`)
- bun_ast: `symbol::Map::init`
- bun_ptr: `BackRef::shared`, `DetachablePtr::as_ptr`

## sys crates (-119)

- bun_sys: both cfg variants of `UTIME_OMIT` and its `c::` re-export, the raw `posix::read` wrapper, `DynLib::handle`
- bun_uws_sys: `NewSocketHandler::group` and `AnySocket::group`, the `SocketTcp` / `SocketTls` type aliases and their re-exports (the same-named `AnySocket` variants are what everything uses), `AnyResponse::init`, `SocketGroup::is_empty`, `PosixLoop::wake`, `PosixLoop::run`, `Opcode::Close` (the `Opcode::Close` in bun_http is a different type), and the non-Windows `WindowsLoop` stub alias (its only users are `#[cfg(windows)]`)
- bun_windows_sys: the `WaitForSingleObject` Result wrapper and its raw extern (bun_sys and the install shim each declare their own; the shim's dead re-export of it is dropped too), `NTSTATUS::raw`
- bun_boringssl_sys: `GeneralNames::is_empty`, `X509_V_OK`, `SSL_SESS_CACHE_CLIENT`
- bun_cares_sys: `impl AddrInfo_hints { is_empty }`
- bun_zlib_sys: the `z_alloc_fn` / `z_free_fn` legacy aliases and their re-export, `Byte`
- bun_tcc_sys: `SymbolCallback` alias and its re-export

Comment lines that named a removed item were trimmed; no comments were added.

## Verification

- `cargo check --workspace` on all ten CI triples (`bun run rust:check-all`), plus `--cfg bun_debug --cfg bun_asan` and `--cfg bun_codegen_embed --all-targets` on linux: clean, so no `dead_code` / `unused_imports` fallout is left behind
- `cargo fmt --check` clean; full `bun bd` builds
- `bun bd test` on `test/js/bun/css/{css,color}.test.ts`, `test/bundler/css/css-modules.test.ts`, `test/js/web/abort/abort.test.ts`, `test/js/bun/util/inspect.test.js`, `test/js/node/zlib/deflate-streaming.test.ts`, `test/js/bun/net/localhost-loopback-contract.test.ts`: all pass
- `test/internal/source-lints/dead-symbols-cross-crate-sweep.test.ts`: every one of its 67 entries fires against the pre-PR sources and none fire after

## Found dead but deliberately left alone

- `CssModuleReference::eql`: dead on main, but #36225 (`handle_composes`) starts calling it, so it stays
- `StoredTrace::from`: only caller is under `#[cfg(bun_debug)]` (hawk ran without that cfg); live
- `host_fn::host_fn_this_value`: `generate-classes.ts` can still emit calls to it
- `strings::{split_once, rsplit_once, rsplit_once_char}`: no callers, but `clippy.toml` points people at them as the sanctioned replacements for the std versions; removing them means rewording those entries
- hawk reports constants used only in const-generic / array-length / `const _:` assertion positions as dead (`Kind::ABS`/`REL`, `PROPERTY_BITSET_BITS`, `CALLBACK_COUNT`, `DeferredRequest::MAX_PREALLOCATED`, `native_promise_context::Tag::COUNT`, `MAX_CID_LEN`, `ARES_EDESTRUCTION` as an enum discriminant); all live, all kept. Its `module` findings are also not "module unused" (`ffi::ffi`, `udp::raw`, `bake::jsc` are all used), so none were acted on
- Single unused entries of otherwise-complete flag/code tables (`O::{NOATIME, DSYNC, SYMLINK, NOFOLLOW_ANY}`, `posix::R_OK`, `posix::POLL_OUT`, `TCSA` / `RlimitResource` variants) were left for table completeness, matching the overrides already in `hawk.toml`
- ~300 never-read `pub` fields and ~25 never-constructed variants are reported on every target as well; those need per-field judgment (repr(C) layouts, liveness anchors, generated accessors) and are left for a separate pass
- The rest of the all-target findings (~730 lines, mostly simdutf/lsquic/uws/zlib/windows_sys bindings and a few runtime items) are already deleted by the open dead-code PRs #38439, #38213, #37181, #37332, #38005, #37149, #37062, #36237, #37012, #36115 and #37272, so they are intentionally not repeated here
