### PR TITLE
publish: resolve a relative tarball path against the invoking directory

### DIFF
--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -17,7 +17,6 @@ use bun_libarchive::lib::{Archive, ArchiveIterator, IteratorResult as ArchiveIte
 use bun_parsers::json as json_mod;
 use bun_paths::resolve_path::{join_abs_string_buf_z, normalize_buf, normalize_buf_z};
 use bun_paths::{self as path, PathBuffer};
-use bun_resolver::fs::FileSystem;
 use bun_sha_hmac as sha;
 use bun_simdutf_sys::simdutf;
 use bun_sys::dir_iterator as DirIterator;
@@ -135,14 +134,18 @@ pub(crate) type FromWorkspaceError = pack::PackError<true>;
 
 impl<'a, const DIRECTORY_PUBLISH: bool> Context<'a, DIRECTORY_PUBLISH> {
     /// Retrieve information for publishing from a tarball path, `bun publish path/to/tarball.tgz`
+    ///
+    /// `original_cwd` is the directory the command was run from. `PackageManager::init` has
+    /// already chdir'd to the package root, which may be an ancestor of it.
     pub(crate) fn from_tarball_path(
         ctx: Command::Context<'a>,
         manager: &'a mut PackageManager,
+        original_cwd: &[u8],
         tarball_path: &[u8],
     ) -> Result<Context<'a, DIRECTORY_PUBLISH>, FromTarballError> {
         let mut abs_buf = PathBuffer::uninit();
         let abs_tarball_path = join_abs_string_buf_z::<path::platform::Auto>(
-            FileSystem::instance().top_level_dir,
+            original_cwd,
             &mut abs_buf,
             &[tarball_path],
         );
@@ -549,13 +552,13 @@ impl PublishCommand {
                     Global::crash();
                 }
             };
-        drop(original_cwd);
         let manager_ptr: *mut PackageManager = manager;
 
         if cli.positionals.len() > 1 {
             let context = match Context::<false>::from_tarball_path(
                 ctx,
                 manager,
+                &original_cwd,
                 cli.positionals[1],
             ) {
                 Ok(c) => c,

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -134,9 +134,6 @@ pub(crate) type FromWorkspaceError = pack::PackError<true>;
 
 impl<'a, const DIRECTORY_PUBLISH: bool> Context<'a, DIRECTORY_PUBLISH> {
     /// Retrieve information for publishing from a tarball path, `bun publish path/to/tarball.tgz`
-    ///
-    /// `original_cwd` is the directory the command was run from. `PackageManager::init` has
-    /// already chdir'd to the package root, which may be an ancestor of it.
     pub(crate) fn from_tarball_path(
         ctx: Command::Context<'a>,
         manager: &'a mut PackageManager,

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -551,6 +551,68 @@ test("can publish from a tarball", async () => {
   await runBunInstall(env, packageDir, { savesLockfile: false });
   expect(await file(join(packageDir, "node_modules", "publish-pkg-2", "package.json")).json()).toEqual(json);
 });
+describe("relative tarball path", () => {
+  // `bun publish` chdirs to the package root (or the workspace root) before it reads the tarball.
+  // The path on the command line still has to be resolved against the directory the command ran from.
+  // --dry-run never talks to the registry, so a bogus one with auth in the url is enough.
+  const dryRunEnv = { ...env, npm_config_registry: "http://someuser:hunter2@127.0.0.1:1/" };
+
+  test.concurrent("is resolved against the cwd, not the package root above it", async () => {
+    using dir = tempDir("publish-tarball-cwd", {
+      "package.json": JSON.stringify({ name: "publish-tarball-cwd-root", version: "0.0.0" }),
+      "stale-src/package.json": JSON.stringify({ name: "publish-tarball-cwd-stale", version: "0.0.1" }),
+      "dist-src/package.json": JSON.stringify({ name: "publish-tarball-cwd-dist", version: "9.9.9" }),
+      "dist": {},
+    });
+    // a same-named tarball in the package root, and the one we actually mean in ./dist
+    await pack(join(String(dir), "stale-src"), env, "--filename", join(String(dir), "rel.tgz"));
+    await pack(join(String(dir), "dist-src"), env, "--filename", join(String(dir), "dist", "rel.tgz"));
+
+    const { out, err, exitCode } = await publish(dryRunEnv, join(String(dir), "dist"), "./rel.tgz", "--dry-run");
+    expect(err).not.toContain("error:");
+    expect(out).toContain(" + publish-tarball-cwd-dist@9.9.9");
+    expect(out).not.toContain("publish-tarball-cwd-stale");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("is found when the cwd is a subdirectory of the package root", async () => {
+    using dir = tempDir("publish-tarball-subdir", {
+      "package.json": JSON.stringify({ name: "publish-tarball-subdir-root", version: "0.0.0" }),
+      "dist-src/package.json": JSON.stringify({ name: "publish-tarball-subdir-dist", version: "1.0.0" }),
+      "dist": {},
+    });
+    await pack(join(String(dir), "dist-src"), env, "--filename", join(String(dir), "dist", "pkg.tgz"));
+
+    const { out, err, exitCode } = await publish(dryRunEnv, join(String(dir), "dist"), "pkg.tgz", "--dry-run");
+    expect(err).not.toContain("ENOENT");
+    expect(out).toContain(" + publish-tarball-subdir-dist@1.0.0");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("is found when the cwd is a workspace package", async () => {
+    using dir = tempDir("publish-tarball-workspace", {
+      "package.json": JSON.stringify({
+        name: "publish-tarball-workspace-root",
+        version: "0.0.0",
+        workspaces: ["packages/*"],
+      }),
+      "packages/member/package.json": JSON.stringify({ name: "publish-tarball-workspace-member", version: "1.2.3" }),
+    });
+    const memberDir = join(String(dir), "packages", "member");
+    await pack(memberDir, env);
+    expect(await exists(join(memberDir, "publish-tarball-workspace-member-1.2.3.tgz"))).toBeTrue();
+
+    const { out, err, exitCode } = await publish(
+      dryRunEnv,
+      memberDir,
+      "./publish-tarball-workspace-member-1.2.3.tgz",
+      "--dry-run",
+    );
+    expect(err).not.toContain("ENOENT");
+    expect(out).toContain(" + publish-tarball-workspace-member@1.2.3");
+    expect(exitCode).toBe(0);
+  });
+});
 test("can publish scoped packages", async () => {
   const { packageDir, packageJson } = await registry.createTestDir();
   const bunfig = await registry.authBunfig("scoped-pkg");


### PR DESCRIPTION
### Problem
- `bun publish ./pkg.tgz` resolves the tarball path against the wrong directory whenever the package root is not the directory the command was run from:
  - from a workspace member: `cd packages/foo && bun pm pack && bun publish ./foo-1.2.3.tgz` fails with `ENOENT: No such file or directory: failed to read tarball: './foo-1.2.3.tgz' (open)` even though the file is right there.
  - from a subdirectory of a project (`<repo>/dist`, the usual build-then-publish layout): same ENOENT, or, if a same-named tarball happens to sit in `<repo>/`, that stale tarball is published instead, silently. An absolute path works.
- Cause: `Context::from_tarball_path` (`src/runtime/cli/publish_command.rs:144`) joins the argument onto `FileSystem::instance().top_level_dir`. By then `PackageManager::init` has walked up to the nearest package.json (or the workspace root), set `top_level_dir` to it and `chdir`'d there. `init` returns the directory the command was actually run from as its second tuple element, and `PublishCommand::exec` was dropping it on the next line.
- Not a regression: the same join was in the Zig version.

### Fix
- `from_tarball_path` takes `original_cwd` and joins the argument onto that instead of `top_level_dir`; `exec` passes the value `PackageManager::init` returns. Absolute arguments are unaffected (`join_abs_string_buf_z` ignores the base), and when the cwd is the package root nothing changes.
- Same pattern the other install commands already use for user-supplied relative paths (`add_remove_with_filter.rs` joins `bun add ./dir` onto `original_cwd`).
- Project discovery is kept for the tarball form on purpose: it is what loads the project's `bunfig.toml` / `.npmrc` (registry, token), which the existing tarball publish tests depend on.
- Verified: `test/cli/install/bun-publish.test.ts`, new `relative tarball path` describe block (three tests: stale root tarball must not win, subdirectory of a project, workspace member). All three fail on the released bun (`USE_SYSTEM_BUN=1`: first one publishes `publish-tarball-cwd-stale@0.0.1`, the other two hit ENOENT) and pass with `bun bd test`; the whole file passes (42 tests).

### Background
- `PackageManager::init` is shared by every install subcommand. It starts from the process cwd, walks up to the nearest `package.json`, and if that package is a member of a workspace continues up to the workspace root; it then `chdir`s into that directory and makes it `top_level_dir`, so the rest of the package manager can work with root-relative paths. It hands the pre-walk cwd back to the caller (`original_cwd`) precisely for command-line arguments that the user typed relative to where they were standing.
- `bun publish <tarball>` is the two-step flow documented in `docs/pm/cli/publish.mdx` (`bun pm pack`, then `bun publish ./package.tgz`): it reads an existing tarball, takes name/version from the `package.json` inside it, and uploads it; nothing about it needs the project root except configuration.
