### PR TITLE
Parse TS class modifiers followed by a newline as field names

### DIFF
--- a/src/js_parser/parse/parse_property.rs
+++ b/src/js_parser/parse/parse_property.rs
@@ -480,8 +480,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                     | PropertyModifierKeyword::PPublic
                                     | PropertyModifierKeyword::PReadonly
                                     | PropertyModifierKeyword::POverride => {
-                                        // Skip over TypeScript keywords ("public\n x" is a field
-                                        // named "public", like "declare" but unlike "static")
+                                        // Skip over TypeScript keywords
                                         if opts.is_class
                                             && Self::IS_TYPESCRIPT_ENABLED
                                             && !p.lexer.has_newline_before

--- a/src/js_parser/parse/parse_property.rs
+++ b/src/js_parser/parse/parse_property.rs
@@ -480,10 +480,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                     | PropertyModifierKeyword::PPublic
                                     | PropertyModifierKeyword::PReadonly
                                     | PropertyModifierKeyword::POverride => {
-                                        // Skip over TypeScript keywords. As with "declare" and
-                                        // "abstract" (but not "static"), tsc only treats these as
-                                        // modifiers when the member name is on the same line;
-                                        // "public\n x" is a field named "public" followed by "x".
+                                        // Skip over TypeScript keywords ("public\n x" is a field
+                                        // named "public", like "declare" but unlike "static")
                                         if opts.is_class
                                             && Self::IS_TYPESCRIPT_ENABLED
                                             && !p.lexer.has_newline_before

--- a/src/js_parser/parse/parse_property.rs
+++ b/src/js_parser/parse/parse_property.rs
@@ -480,9 +480,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                     | PropertyModifierKeyword::PPublic
                                     | PropertyModifierKeyword::PReadonly
                                     | PropertyModifierKeyword::POverride => {
-                                        // Skip over TypeScript keywords
+                                        // Skip over TypeScript keywords. As with "declare" and
+                                        // "abstract" (but not "static"), tsc only treats these as
+                                        // modifiers when the member name is on the same line;
+                                        // "public\n x" is a field named "public" followed by "x".
                                         if opts.is_class
                                             && Self::IS_TYPESCRIPT_ENABLED
+                                            && !p.lexer.has_newline_before
                                             && PropertyModifierKeyword::find(raw) == Some(keyword)
                                         {
                                             errors = None;

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -357,6 +357,30 @@ describe("Bun.Transpiler", () => {
       // Class body "accessor": a newline makes it a field named "accessor" followed by a field.
       exp("class A { accessor\n x = 1 }\nnew A", "class A {\n  accessor;\n  x = 1;\n}\nnew A;\n");
 
+      // Class body "public"/"private"/"protected"/"readonly"/"override": same rule as tsc, a newline
+      // makes each of them a field of that name instead of a modifier of the next member.
+      exp("class A { public\n x = 1 }\nnew A", "class A {\n  public;\n  x = 1;\n}\nnew A;\n");
+      exp("class A { private\n x = 1 }\nnew A", "class A {\n  private;\n  x = 1;\n}\nnew A;\n");
+      exp("class A { protected\n x = 1 }\nnew A", "class A {\n  protected;\n  x = 1;\n}\nnew A;\n");
+      exp("class A { readonly\n x = 1 }\nnew A", "class A {\n  readonly;\n  x = 1;\n}\nnew A;\n");
+      exp("class A extends B { override\n x = 1 }\nnew A", "class A extends B {\n  override;\n  x = 1;\n}\nnew A;\n");
+      exp(
+        "class A { public\n m() { return 1 } }\nnew A().m()",
+        "class A {\n  public;\n  m() {\n    return 1;\n  }\n}\nnew A().m();\n",
+      );
+      exp("class A { readonly\n [k] = 1 }\nnew A", "class A {\n  readonly;\n  [k] = 1;\n}\nnew A;\n");
+      exp("class A { public\n #x = 1 }\nnew A", "class A {\n  public;\n  #x = 1;\n}\nnew A;\n");
+      // "static" still binds across a newline, so only the word on the other side of it is split off.
+      exp("class A { public\n static\n x = 1 }\nnew A", "class A {\n  public;\n  static x = 1;\n}\nnew A;\n");
+      exp("class A { static\n public\n x = 1 }\nnew A", "class A {\n  static public;\n  x = 1;\n}\nnew A;\n");
+      // On the same line they are still modifiers and get erased.
+      exp(
+        "class A extends B { public x = 1; private readonly y = 2; protected override z() {} }",
+        "class A extends B {\n  x = 1;\n  y = 2;\n  z() {}\n}",
+      );
+      exp("class A { public static\n x = 1 }\nnew A", "class A {\n  static x = 1;\n}\nnew A;\n");
+      exp("class A { readonly [key: string]: number }\nnew A", "class A {\n}\nnew A;\n");
+
       // Class body "get"/"set" followed by "*": the asterisk starts a generator; the prior word is a field.
       exp("class A { get\n *x() {} }\nnew A", "class A {\n  get;\n  *x() {}\n}\nnew A;\n");
       exp("class A { set\n *x() {} }\nnew A", "class A {\n  set;\n  *x() {}\n}\nnew A;\n");


### PR DESCRIPTION
### Problem
- In a `.ts` class body, `public`, `private`, `protected`, `readonly` or `override` written on its own line is dropped, and the member on the next line is emitted without it:
  ```ts
  class C {
    public
    a = 1
    readonly
    b = 2
  }
  Object.keys(new C()) // bun 1.4.0: ["a","b"]   tsc 6.0.2 / node --strip-types (swc): ["public","a","readonly","b"]
  ```
- tsc's grammar (`nextTokenIsOnSameLineAndCanFollowModifier`) only accepts these words as modifiers when the member name is on the same line; otherwise each one is a field named `public`, `readonly`, etc. `static`, `get` and `set` are the exceptions and do bind across a newline.
- Cause: the `PPrivate | PProtected | PPublic | PReadonly | POverride` arm in `src/js_parser/parse/parse_property.rs:478` skips the keyword without checking `p.lexer.has_newline_before`. The neighbouring `declare`, `abstract`, `accessor` and `async` arms already check it. (esbuild, which this code descends from, has the same divergence from tsc.)

### Fix
- Add `!p.lexer.has_newline_before` to that arm. With a newline after the word it now falls through to the normal key path, becomes a field of that name, and the class-field code ends it via ASI, so the next line is parsed as its own member. `static` is unchanged.
- Output for the snippet above is now the same member list tsc emits (`public; a = 1; readonly; b = 2;`), including mixed forms: `public⏎static⏎x` gives `public; static x;`, `static⏎public⏎x` gives `static public; x;`, and `public static⏎x` still gives `static x;`.
- Verified:
  - `test/bundler/transpiler/transpiler.test.js` ("contextual keywords followed by a newline ..."): 13 new cases, 10 of which fail on bun 1.4.0 and all pass with this change; every expectation was cross-checked against tsc 6.0.2 `transpileModule`.
  - `bun bd test` on `test/bundler/transpiler/transpiler.test.js`, `test/bundler/esbuild/ts.test.ts`, `decorators`, `decorator-metadata`, `es-decorators`, `es-decorators-esbuild`, `property` and `ts-use-define-for-class-fields` tests: all green.
  - Running the snippet above with the debug build prints `["public","a","readonly","b"]`.

### Background
- `parse_property` reads one identifier, advances the lexer, and if the following token could itself be a property key, checks whether the identifier was a modifier keyword; a modifier sets some state and restarts the loop on the next token. Falling through instead makes the identifier the property key.
- `p.lexer.has_newline_before` is true when a line terminator sits between the previous token and the current one; after the `next()` above it describes the gap between the candidate modifier and the following token, which is exactly what tsc's same-line rule looks at. It is also what `expect_or_insert_semicolon` uses for ASI, which is why the keyword-turned-field terminates cleanly without a `;`.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 3 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
bun test v1.4.0 (4550863a7)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [5.19ms]
(pass) Bun.Transpiler > normalizes \r\n [7.59ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [4.34ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [8.13ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.44ms]
(pass) Bun.Transpiler > property access inlining > works [2.59ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.64ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [46.90ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [33.82ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [350.34ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional
... (truncated)

release without fix: 1 failed, 22 skipped
bun test v1.4.0-canary.1 (b7a043103)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [0.10ms]
(pass) Bun.Transpiler > normalizes \r\n [0.15ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [0.08ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.10ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.03ms]
(pass) Bun.Transpiler > property access inlining > works [0.03ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.02ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [0.82ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [0.35ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [12.77ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [0.52ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [0.05ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly whe
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
bun test v1.4.0 (4550863a7)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [5.55ms]
(pass) Bun.Transpiler > normalizes \r\n [7.54ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [4.70ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [8.02ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.57ms]
(pass) Bun.Transpiler > property access inlining > works [2.71ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.80ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [47.39ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [22.71ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [370.07ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional
... (truncated)

release with fix: 22 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     4550863a77
  features     baseline

22 deps, 123 codegen, 1176 objects in 918ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] gen ErrorCode+*.h
[2/1238] gen bindgenv2
[3/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[4/1238] install /workspace/bun
bun install v1.4.0-canary.1 (b7a043103)

Checked 107 installs across 153 packages (no changes) [79.00ms]
[5/1238] fetch zlib
[zlib] up to date
[6/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (b7a043103)

Checked 1 install across 2 packages (no changes) [1.00ms]
[7/1238] fetch tinycc
[tinycc] up to date
[8/1237] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (b7a043103)

Checked 129 installs across 147 packages (no changes) [33.00ms]
[9/1237] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[10/1237] gen .bind.ts → GeneratedBindings.cpp
[11/1237] gen ProcessBindingBuffer.lut.h
Gen
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/parse/parse_property.rs      |  1 +
 test/bundler/transpiler/transpiler.test.js | 24 ++++++++++++++++++++++++
 2 files changed, 25 insertions(+)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/js_parser/parse/parse_property.rs           5      4      0
test/bundler/transpiler/transpiler.test.js      2      1      0
```

</details>

<!-- robobun:evidence:end -->