### PR TITLE
pack: skip bins reached through symlinks; publish: do not read the readme through a symlink

### DIFF
--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -1528,6 +1528,35 @@ fn bin_path_escapes_root(p: &[u8]) -> bool {
     path::is_absolute_loose(p) || p == b".." || p.starts_with(b"../")
 }
 
+/// Bins are added to the pack queue directly instead of being found by the
+/// tree walk, which never packs symlinks (like npm-packlist). Apply the same
+/// rule here: a bin reached through a symlink in any path component would
+/// otherwise be packed with the contents of whatever the link points at,
+/// possibly outside the package. Returns `Unknown` if the path does not
+/// exist or a parent component is not a real directory.
+fn bin_kind_without_following_symlinks(root_dir: &Dir, bin_path: &[u8]) -> bun_sys::FileKind {
+    // A trailing slash would make `lstat` resolve a symlink to a directory.
+    let bin_path = strings::without_trailing_slash(bin_path);
+    let mut end = 0;
+    loop {
+        end += match strings::index_of_char_usize(&bin_path[end..], b'/') {
+            Some(i) => i,
+            None => bin_path.len() - end,
+        };
+        let kind = match bun_sys::lstatat(root_dir, &ZBox::from_bytes(&bin_path[..end])) {
+            Ok(stat) => bun_sys::kind_from_mode(stat.st_mode as bun_sys::Mode),
+            Err(_) => return bun_sys::FileKind::Unknown,
+        };
+        if end == bin_path.len() {
+            return kind;
+        }
+        if kind != bun_sys::FileKind::Directory {
+            return bun_sys::FileKind::Unknown;
+        }
+        end += 1;
+    }
+}
+
 fn is_package_bin(bins: &[BinInfo], maybe_bin_path: &[u8]) -> bool {
     for bin in bins {
         match bin.ty {
@@ -2268,6 +2297,14 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
     let bins = get_package_bins(&json.root)?;
 
     for bin in &bins {
+        let expected_kind = match bin.ty {
+            BinType::File => bun_sys::FileKind::File,
+            BinType::Dir => bun_sys::FileKind::Directory,
+        };
+        if bin_kind_without_following_symlinks(&root_dir, bin.path.as_bytes()) != expected_kind {
+            continue;
+        }
+
         match bin.ty {
             BinType::File => {
                 pack_queue.add(PackQueueItem {

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -1528,9 +1528,7 @@ fn bin_path_escapes_root(p: &[u8]) -> bool {
     path::is_absolute_loose(p) || p == b".." || p.starts_with(b"../")
 }
 
-/// `lstat` kind of `bin_path`, or `Unknown` if it is missing or a parent
-/// component is not a real directory. Bins skip the tree walk, which packs
-/// nothing reached through a symlink, so they get the same check here.
+/// `Unknown` if `bin_path` is missing or a parent component is not a real directory.
 fn bin_kind_without_following_symlinks(root_dir: &Dir, bin_path: &[u8]) -> bun_sys::FileKind {
     // A trailing slash would make `lstat` resolve a symlink to a directory.
     let bin_path = strings::without_trailing_slash(bin_path);

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -1528,17 +1528,27 @@ fn bin_path_escapes_root(p: &[u8]) -> bool {
     path::is_absolute_loose(p) || p == b".." || p.starts_with(b"../")
 }
 
-/// `Unknown` if `bin_path` is missing or a parent component is not a real directory.
-fn bin_kind_without_following_symlinks(root_dir: &Dir, bin_path: &[u8]) -> bun_sys::FileKind {
+/// `lstat` kind of `bin_path` (relative to the package root, `/`-separated), or
+/// `Unknown` if it is missing or a parent component is not a real directory.
+fn bin_kind_without_following_symlinks(
+    abs_workspace_path: &[u8],
+    bin_path: &[u8],
+) -> bun_sys::FileKind {
     // A trailing slash would make `lstat` resolve a symlink to a directory.
     let bin_path = strings::without_trailing_slash(bin_path);
+    // By absolute path: on Windows `lstatat` reports a reparse point as its target's kind.
+    let mut spill: Vec<u8> = Vec::new();
     let mut end = 0;
     loop {
         end += match strings::index_of_char_usize(&bin_path[end..], b'/') {
             Some(i) => i,
             None => bin_path.len() - end,
         };
-        let kind = match bun_sys::lstatat(root_dir, &ZBox::from_bytes(&bin_path[..end])) {
+        let abs_path = resolve_path::join_z_spill::<resolve_path::platform::Auto>(
+            &mut spill,
+            &[abs_workspace_path, &bin_path[..end]],
+        );
+        let kind = match bun_sys::lstat(abs_path) {
             Ok(stat) => bun_sys::kind_from_mode(stat.st_mode as bun_sys::Mode),
             Err(_) => return bun_sys::FileKind::Unknown,
         };
@@ -2296,7 +2306,9 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
             BinType::File => bun_sys::FileKind::File,
             BinType::Dir => bun_sys::FileKind::Directory,
         };
-        if bin_kind_without_following_symlinks(&root_dir, bin.path.as_bytes()) != expected_kind {
+        if bin_kind_without_following_symlinks(abs_workspace_path, bin.path.as_bytes())
+            != expected_kind
+        {
             continue;
         }
 

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -1528,8 +1528,7 @@ fn bin_path_escapes_root(p: &[u8]) -> bool {
     path::is_absolute_loose(p) || p == b".." || p.starts_with(b"../")
 }
 
-/// `lstat` kind of `bin_path` (relative to the package root, `/`-separated), or
-/// `Unknown` if it is missing or a parent component is not a real directory.
+/// `Unknown` if `bin_path` is missing or a parent component is not a real directory.
 fn bin_kind_without_following_symlinks(
     abs_workspace_path: &[u8],
     bin_path: &[u8],

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -1528,12 +1528,9 @@ fn bin_path_escapes_root(p: &[u8]) -> bool {
     path::is_absolute_loose(p) || p == b".." || p.starts_with(b"../")
 }
 
-/// Bins are added to the pack queue directly instead of being found by the
-/// tree walk, which never packs symlinks (like npm-packlist). Apply the same
-/// rule here: a bin reached through a symlink in any path component would
-/// otherwise be packed with the contents of whatever the link points at,
-/// possibly outside the package. Returns `Unknown` if the path does not
-/// exist or a parent component is not a real directory.
+/// `lstat` kind of `bin_path`, or `Unknown` if it is missing or a parent
+/// component is not a real directory. Bins skip the tree walk, which packs
+/// nothing reached through a symlink, so they get the same check here.
 fn bin_kind_without_following_symlinks(root_dir: &Dir, bin_path: &[u8]) -> bun_sys::FileKind {
     // A trailing slash would make `lstat` resolve a symlink to a directory.
     let bin_path = strings::without_trailing_slash(bin_path);

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -1589,8 +1589,7 @@ impl PublishCommand {
 
         let mut iter = DirIterator::iterate(workspace_dir);
         while let Some(entry) = iter.next().ok().flatten() {
-            // Same rule as the tarball: a README that is a symlink is not packed,
-            // so it must not be published as the readme either.
+            // Symlinks are not packed, so a symlinked README is not the readme either.
             if entry.kind != bun_sys::EntryKind::File {
                 continue;
             }

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -1589,7 +1589,9 @@ impl PublishCommand {
 
         let mut iter = DirIterator::iterate(workspace_dir);
         while let Some(entry) = iter.next().ok().flatten() {
-            if entry.kind == bun_sys::EntryKind::Directory {
+            // Same rule as the tarball: a README that is a symlink is not packed,
+            // so it must not be published as the readme either.
+            if entry.kind != bun_sys::EntryKind::File {
                 continue;
             }
             // Entry names are UTF-8 on every platform.

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -1,8 +1,8 @@
 import { file, spawn, write } from "bun";
 import { readTarball } from "bun:internal-for-testing";
 import { beforeEach, describe, expect, test } from "bun:test";
-import { exists, mkdir, rm } from "fs/promises";
-import { bunEnv, bunExe, pack, runBunInstall, tempDir, tmpdirSync } from "harness";
+import { exists, mkdir, rm, symlink } from "fs/promises";
+import { bunEnv, bunExe, isWindows, pack, runBunInstall, tempDir, tmpdirSync } from "harness";
 import fs from "node:fs/promises";
 import { join } from "path";
 
@@ -1596,6 +1596,93 @@ describe("bins", () => {
         pathname: "package/dist/hi.js",
       },
     ]);
+  });
+
+  test("pointing at a directory is ignored", async () => {
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "pack-bins-dir-as-file",
+          version: "1.0.0",
+          bin: "lib",
+        }),
+      ),
+      write(join(packageDir, "index.js"), "console.log('index')"),
+      write(join(packageDir, "lib", "a.js"), "console.log('a')"),
+    ]);
+
+    await pack(packageDir, bunEnv);
+
+    const tarball = readTarball(join(packageDir, "pack-bins-dir-as-file-1.0.0.tgz"));
+    expect(tarball.entries).toMatchObject([
+      { pathname: "package/package.json" },
+      { pathname: "package/index.js" },
+      { pathname: "package/lib/a.js" },
+    ]);
+  });
+
+  // Symlinks are never packed (same as npm). Bins are no exception: packing one
+  // would copy the link target, which may live outside the package.
+  test.skipIf(isWindows)("that are symlinks, or behind a symlinked directory, are not packed", async () => {
+    const pkgDir = join(packageDir, "pkg");
+    await Promise.all([
+      write(join(packageDir, "outside", "secret.js"), "console.log('outside the package')"),
+      write(join(packageDir, "outside", "nested", "inner.js"), "console.log('outside the package')"),
+      write(
+        join(pkgDir, "package.json"),
+        JSON.stringify({
+          name: "pack-bins-symlink",
+          version: "1.0.0",
+          files: ["index.js"],
+          bin: {
+            "real": "real-bin.js",
+            "linked": "linked-bin.js",
+            "through-link": "linked-dir/inner.js",
+          },
+        }),
+      ),
+      write(join(pkgDir, "index.js"), "console.log('index')"),
+      write(join(pkgDir, "real-bin.js"), "console.log('real bin')"),
+    ]);
+    await Promise.all([
+      symlink("../outside/secret.js", join(pkgDir, "linked-bin.js")),
+      symlink("../outside/nested", join(pkgDir, "linked-dir")),
+    ]);
+
+    await pack(pkgDir, bunEnv);
+
+    const tarball = readTarball(join(pkgDir, "pack-bins-symlink-1.0.0.tgz"));
+    expect(tarball.entries).toMatchObject([
+      { pathname: "package/package.json" },
+      { pathname: "package/index.js" },
+      { pathname: "package/real-bin.js" },
+    ]);
+  });
+
+  test.skipIf(isWindows)('"directories.bin" that is a symlink is not packed', async () => {
+    const pkgDir = join(packageDir, "pkg");
+    await Promise.all([
+      write(join(packageDir, "outside", "bins", "a.js"), "console.log('outside the package')"),
+      write(join(packageDir, "outside", "bins", "b.js"), "console.log('outside the package')"),
+      write(
+        join(pkgDir, "package.json"),
+        JSON.stringify({
+          name: "pack-bins-dir-symlink",
+          version: "1.0.0",
+          directories: {
+            bin: "bins",
+          },
+        }),
+      ),
+      write(join(pkgDir, "index.js"), "console.log('index')"),
+    ]);
+    await symlink("../outside/bins", join(pkgDir, "bins"));
+
+    await pack(pkgDir, bunEnv);
+
+    const tarball = readTarball(join(pkgDir, "pack-bins-dir-symlink-1.0.0.tgz"));
+    expect(tarball.entries).toMatchObject([{ pathname: "package/package.json" }, { pathname: "package/index.js" }]);
   });
 });
 

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -1652,6 +1652,8 @@ describe("bins", () => {
             "absolute-link": "absolute-link.js",
             "link-inside-package": "link-to-real.js",
             "through-linked-dir": "linked-dir/inner.js",
+            // bin paths are normalized to `/` before they are checked
+            "through-linked-dir-backslash": "linked-dir\\inner.js",
           },
         }),
       ),

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -2,7 +2,7 @@ import { file, spawn, write } from "bun";
 import { readTarball } from "bun:internal-for-testing";
 import { beforeEach, describe, expect, test } from "bun:test";
 import { exists, mkdir, rm, symlink } from "fs/promises";
-import { bunEnv, bunExe, isWindows, pack, runBunInstall, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, pack, runBunInstall, tempDir, tmpdirSync } from "harness";
 import fs from "node:fs/promises";
 import { join } from "path";
 
@@ -1598,47 +1598,60 @@ describe("bins", () => {
     ]);
   });
 
-  test("pointing at a directory is ignored", async () => {
+  test("that are not regular files are ignored", async () => {
     await Promise.all([
       write(
         join(packageDir, "package.json"),
         JSON.stringify({
-          name: "pack-bins-dir-as-file",
+          name: "pack-bins-not-files",
           version: "1.0.0",
-          bin: "lib",
+          bin: {
+            "a-directory": "lib",
+            "empty": "",
+            "real": "real-bin.js",
+          },
         }),
       ),
       write(join(packageDir, "index.js"), "console.log('index')"),
       write(join(packageDir, "lib", "a.js"), "console.log('a')"),
+      write(join(packageDir, "real-bin.js"), "console.log('real bin')"),
     ]);
 
     await pack(packageDir, bunEnv);
 
-    const tarball = readTarball(join(packageDir, "pack-bins-dir-as-file-1.0.0.tgz"));
-    expect(tarball.entries).toMatchObject([
-      { pathname: "package/package.json" },
-      { pathname: "package/index.js" },
-      { pathname: "package/lib/a.js" },
+    const tarball = readTarball(join(packageDir, "pack-bins-not-files-1.0.0.tgz"));
+    expect(tarball.entries.map(({ pathname }) => pathname)).toEqual([
+      "package/package.json",
+      "package/index.js",
+      "package/lib/a.js",
+      "package/real-bin.js",
     ]);
+    expect(tarball.entries[3].perm & 0o111).toBe(0o111);
   });
 
   // Symlinks are never packed (same as npm). Bins are no exception: packing one
   // would copy the link target, which may live outside the package.
-  test.skipIf(isWindows)("that are symlinks, or behind a symlinked directory, are not packed", async () => {
+  const OUTSIDE = "console.log('outside the package')";
+
+  async function writeSymlinkedBins() {
+    const outside = join(packageDir, "outside");
     const pkgDir = join(packageDir, "pkg");
     await Promise.all([
-      write(join(packageDir, "outside", "secret.js"), "console.log('outside the package')"),
-      write(join(packageDir, "outside", "nested", "inner.js"), "console.log('outside the package')"),
+      write(join(outside, "secret.js"), OUTSIDE),
+      write(join(outside, "nested", "inner.js"), OUTSIDE),
       write(
         join(pkgDir, "package.json"),
         JSON.stringify({
           name: "pack-bins-symlink",
           version: "1.0.0",
+          // `files` leaves out every bin so that only the bin handling can add them.
           files: ["index.js"],
           bin: {
             "real": "real-bin.js",
-            "linked": "linked-bin.js",
-            "through-link": "linked-dir/inner.js",
+            "relative-link": "relative-link.js",
+            "absolute-link": "absolute-link.js",
+            "link-inside-package": "link-to-real.js",
+            "through-linked-dir": "linked-dir/inner.js",
           },
         }),
       ),
@@ -1646,43 +1659,69 @@ describe("bins", () => {
       write(join(pkgDir, "real-bin.js"), "console.log('real bin')"),
     ]);
     await Promise.all([
-      symlink("../outside/secret.js", join(pkgDir, "linked-bin.js")),
-      symlink("../outside/nested", join(pkgDir, "linked-dir")),
+      symlink(join("..", "outside", "secret.js"), join(pkgDir, "relative-link.js"), "file"),
+      symlink(join(outside, "secret.js"), join(pkgDir, "absolute-link.js"), "file"),
+      symlink("real-bin.js", join(pkgDir, "link-to-real.js"), "file"),
+      symlink(join("..", "outside", "nested"), join(pkgDir, "linked-dir"), "dir"),
     ]);
+    return pkgDir;
+  }
+
+  test("that are symlinks, or behind a symlinked directory, are not packed", async () => {
+    const pkgDir = await writeSymlinkedBins();
 
     await pack(pkgDir, bunEnv);
 
     const tarball = readTarball(join(pkgDir, "pack-bins-symlink-1.0.0.tgz"));
-    expect(tarball.entries).toMatchObject([
-      { pathname: "package/package.json" },
-      { pathname: "package/index.js" },
-      { pathname: "package/real-bin.js" },
+    expect(tarball.entries.map(({ pathname }) => pathname)).toEqual([
+      "package/package.json",
+      "package/index.js",
+      "package/real-bin.js",
     ]);
+    for (const entry of tarball.entries) {
+      expect(entry.contents).not.toContain(OUTSIDE);
+    }
+    expect(tarball.entries[2].perm & 0o111).toBe(0o111);
   });
 
-  test.skipIf(isWindows)('"directories.bin" that is a symlink is not packed', async () => {
+  test("that are symlinks are not listed by --dry-run", async () => {
+    const pkgDir = await writeSymlinkedBins();
+
+    const { out } = await pack(pkgDir, bunEnv, "--dry-run");
+
+    const packed = out
+      .split("\n")
+      .filter(line => line.startsWith("packed "))
+      .map(line => line.split(" ").at(-1));
+    expect(packed).toEqual(["package.json", "index.js", "real-bin.js"]);
+    expect(out).toContain("Total files: 3");
+  });
+
+  test('"directories.bin" that is a symlink is not packed', async () => {
+    const outside = join(packageDir, "outside");
     const pkgDir = join(packageDir, "pkg");
     await Promise.all([
-      write(join(packageDir, "outside", "bins", "a.js"), "console.log('outside the package')"),
-      write(join(packageDir, "outside", "bins", "b.js"), "console.log('outside the package')"),
+      write(join(outside, "bins", "a.js"), OUTSIDE),
+      write(join(outside, "bins", "b.js"), OUTSIDE),
       write(
         join(pkgDir, "package.json"),
         JSON.stringify({
           name: "pack-bins-dir-symlink",
           version: "1.0.0",
           directories: {
-            bin: "bins",
+            bin: "./bins/",
           },
         }),
       ),
       write(join(pkgDir, "index.js"), "console.log('index')"),
     ]);
-    await symlink("../outside/bins", join(pkgDir, "bins"));
+    // A junction on Windows, where "junction" is ignored elsewhere and makes a plain symlink.
+    await symlink(join(outside, "bins"), join(pkgDir, "bins"), "junction");
 
     await pack(pkgDir, bunEnv);
 
     const tarball = readTarball(join(pkgDir, "pack-bins-dir-symlink-1.0.0.tgz"));
-    expect(tarball.entries).toMatchObject([{ pathname: "package/package.json" }, { pathname: "package/index.js" }]);
+    expect(tarball.entries.map(({ pathname }) => pathname)).toEqual(["package/package.json", "package/index.js"]);
   });
 });
 

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -1,7 +1,7 @@
 import { file, spawn, write } from "bun";
 import { afterAll, beforeAll, describe, expect, it, test } from "bun:test";
 import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
-import { exists, rm } from "fs/promises";
+import { exists, rm, symlink } from "fs/promises";
 import {
   VerdaccioRegistry,
   bunExe,
@@ -1204,6 +1204,44 @@ describe("readme", () => {
       readme: readmeContents,
       readmeFilename: "README.md",
     });
+  });
+
+  // A README that is a symlink is not packed (symlinks never are), so its
+  // target must not be published as the readme either.
+  test.skipIf(isWindows)("a README that is a symlink is not sent as readme", async () => {
+    let captured: any = null;
+    using mock = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        if (req.method === "PUT") captured = await req.json();
+        return new Response("OK", { status: 200 });
+      },
+    });
+
+    const dir = tmpdirSync();
+    const packageDir = join(dir, "pkg");
+    await Promise.all([
+      write(join(dir, "outside", "README.md"), "# outside the package"),
+      write(
+        join(packageDir, "bunfig.toml"),
+        Bun.TOML.stringify({
+          install: {
+            cache: false,
+            registry: { url: `http://localhost:${mock.port}`, token: "unused" },
+          },
+        }),
+      ),
+      write(join(packageDir, "package.json"), JSON.stringify({ name: "readme-pkg-3", version: "3.0.0" })),
+      write(join(packageDir, "index.js"), "module.exports = 3;"),
+    ]);
+    await symlink("../outside/README.md", join(packageDir, "README.md"));
+
+    const { err, exitCode } = await publish(env, packageDir);
+    expect(err).not.toContain("error:");
+    expect(exitCode).toBe(0);
+
+    expect(captured.versions["3.0.0"]).not.toContainAnyKeys(["readme", "readmeFilename"]);
+    expect(JSON.stringify(captured)).not.toContain("outside the package");
   });
 });
 

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -1208,7 +1208,7 @@ describe("readme", () => {
 
   // A README that is a symlink is not packed (symlinks never are), so its
   // target must not be published as the readme either.
-  test.skipIf(isWindows)("a README that is a symlink is not sent as readme", async () => {
+  test("a README that is a symlink is not sent as readme", async () => {
     let captured: any = null;
     using mock = Bun.serve({
       port: 0,
@@ -1234,7 +1234,7 @@ describe("readme", () => {
       write(join(packageDir, "package.json"), JSON.stringify({ name: "readme-pkg-3", version: "3.0.0" })),
       write(join(packageDir, "index.js"), "module.exports = 3;"),
     ]);
-    await symlink("../outside/README.md", join(packageDir, "README.md"));
+    await symlink(join("..", "outside", "README.md"), join(packageDir, "README.md"), "file");
 
     const { err, exitCode } = await publish(env, packageDir);
     expect(err).not.toContain("error:");


### PR DESCRIPTION
### Problem
- `bun pm pack` / `bun publish` never pack symlinks (the tree walk only takes regular files and directories, same as npm-packlist), but `bin` / `directories.bin` entries bypass the walk: `pack()` adds each bin path to the pack queue directly (src/runtime/cli/pack_command.rs, the `for bin in &bins` loop) and later `openat()`s it, which follows symlinks.
- So a bin that is a symlink, a bin under a symlinked directory (`"bin": "sub/cli.js"` with `sub -> ../elsewhere`), or a symlinked `directories.bin` is packed with the contents of the link target, which can be anything outside the package. npm 11 (npm-packlist 10) omits all three; its `onstat` drops every lstat result that is not a file or directory, bins included.
- A `bin` entry that names a directory (or is `""`, which normalizes to `.`) failed the whole pack with `EISDIR: failed to read file: "lib"` and left a truncated `.tgz` behind. npm ignores it.
- `bun publish` has the same hole for the readme: `find_workspace_readme` (src/runtime/cli/publish_command.rs) only skipped directory entries, so a `README.md` symlink was read through and its target sent to the registry as the `readme` / `readmeFilename` metadata, while the tarball itself (correctly) omitted the README.

### Fix
- `bin_kind_without_following_symlinks()` lstats every component of a bin path; a bin is only force-added when it is a regular file (or, for `directories.bin`, a real directory) reached through real directories. Anything else is skipped and the normal tree walk decides what gets packed, which gives the npm behavior for the symlink cases and for a bin that names a directory.
- The components are stat'ed by absolute path (`join(abs_workspace_path, prefix)` + `bun_sys::lstat`) rather than `lstatat(root_dir, ..)`: on Windows `lstatat` reports a reparse point as its target's kind (the same thing `install/prune.rs` works around), while `lstat` reports symlinks and junctions as links, so the check works on every platform. This part is folded in from the independent branch linked in the comments below.
- The trailing slash that `directories.bin` values commonly carry is stripped before the lstat, since `lstat("bins/")` would follow a symlinked directory.
- `find_workspace_readme` now requires a regular file entry, the same test the tarball applies, so the published readme is always the README that is actually in the tarball. Publishing from an existing tarball already did this. (#38716 additionally resolves `Unknown` entry kinds in all of these loops; whichever lands second adapts this one line.)
- Verified:
  - `test/cli/install/bun-pack.test.ts` (`bins` block): symlinked bin (relative and absolute target, and a link inside the package), bin behind a symlinked directory, the same through `--dry-run`, a junction/symlink as `directories.bin` (spelled `./bins/`), and bins naming a directory or `""`. The four new tests fail on the current release and pass with this change; the whole file passes (80 tests).
  - `test/cli/install/bun-publish.test.ts` (`readme` block): symlinked README is not sent as readme. Fails before, passes after; whole file passes (40 tests).
  - Windows x64 debug build: the four pack tests fail with the test changes alone and pass with the fix; the readme tests pass.
  - The same fixtures run through `npm pack --dry-run` (npm 11.16.0) produce the file lists the tests expect.
  - `cargo check -p bun_runtime` for `x86_64-pc-windows-msvc` and `aarch64-apple-darwin`.

### Background
- `bin` (string or object of name -> path) and `directories.bin` (a directory whose files all become bins) in package.json name executables that must end up in the tarball even when `files` or `.npmignore` would exclude them. That is why pack handles them separately from the tree walk: bin files are pushed onto the pack queue before the walk, and the walk skips them to avoid duplicates; a `directories.bin` directory is walked on its own. The `files: ["index.js"]` in the test fixture is there so that only this bin handling can add the bins.
- `lstat` returns the kind of the path itself rather than of what a symlink points at; checking each prefix of the path is what makes a symlink in the middle of the path (`sub -> ../elsewhere`) visible, since an `lstat` of the full path would only look at the last component. Bin paths are normalized to `/` separators by `get_package_bins` on every platform, so splitting on `/` is enough.
- `readme` / `readmeFilename` are fields `npm publish` puts in the version metadata it sends to the registry; registries render them as the package page. Bun fills them from the first README it finds in the package directory when publishing from a directory, or from the README inside the archive when publishing an existing tarball.

<details>
<summary>Repro on the current release (1.4.0-canary)</summary>

```sh
mkdir -p outside pkg && echo 'SECRET' > outside/secret.js && mkdir outside/bins && echo x > outside/bins/a.js
cd pkg
printf '{"name":"symbin","version":"1.0.0","bin":{"cli":"cli.js","cli2":"sub/cli2.js"},"files":["index.js"]}' > package.json
echo 'module.exports=1' > index.js
ln -s ../outside/secret.js cli.js
ln -s ../outside sub
bun pm pack && tar -tzf symbin-1.0.0.tgz
# package/package.json
# package/cli.js          <- contents of ../outside/secret.js
# package/index.js
# package/sub/cli2.js     <- if ../outside/cli2.js exists
npm pack --dry-run       # index.js, package.json only
```

`directories.bin` pointing at a symlink to `../outside/bins` packs `bins/a.js` the same way. For the publish side, a `README.md -> ../outside/README.md` link produces a PUT whose `versions[v].readme` is the target's contents although the tarball has no README entry.

Earlier revision of this PR: the bin check used `lstatat` relative to the package root, which is correct on POSIX but not on Windows until `lstatat` there reports reparse points (#38365), so the symlink tests were skipped on Windows. Superseded by the absolute-path lstat above.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-publish.test.ts

<!-- robobun:evidence:end -->