### PR TITLE
Handle 16-bit module sources in the error preview, the new-position fix-up and the REPL

### DIFF
--- a/src/jsc/bindings/ErrorStackFrame.cpp
+++ b/src/jsc/bindings/ErrorStackFrame.cpp
@@ -8,9 +8,10 @@
 namespace Bun {
 using namespace JSC;
 
-/// Adjust a `ZigStackFramePosition` by a number of bytes. This accounts for when the adjustment
-/// crosses line boundaries, and thus requires the source code in order to properly compute
-/// the result.
+/// Adjust a `ZigStackFramePosition` by a number of code units. This accounts for when the
+/// adjustment crosses line boundaries, and thus requires the source code in order to properly
+/// compute the result. Works on 8-bit and 16-bit sources alike: offsets from JSC are code units
+/// either way.
 void adjustPositionBackwards(ZigStackFramePosition& pos, int amount, CodeBlock* code)
 {
     if (pos.byte_position - amount < 0) {
@@ -31,17 +32,6 @@ void adjustPositionBackwards(ZigStackFramePosition& pos, int amount, CodeBlock* 
         }
 
         auto source = provider->source();
-        if (!source.is8Bit()) {
-            // Debug-only assertion
-            // Bun does not yet use 16-bit sources anywhere. The transpiler ensures everything
-            // fit's into latin1 / 8-bit strings for on-average lower memory usage.
-            ASSERT_NOT_REACHED("16-bit source re-mapping is not implemented here.");
-
-            pos.line_zero_based = 0;
-            pos.column_zero_based = 0;
-            pos.byte_position = 0;
-            return;
-        }
 
         for (int i = 0; i < amount; i++) {
             if (source[pos.byte_position - i] == '\n') {

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -160,7 +160,7 @@ static void populateStackFramePosition(const JSC::StackFrame& stackFrame, BunStr
     if (flags == PopulateStackTraceFlags::OnlyPosition)
         return;
 
-    if (source_lines_count > 1 && source_lines != nullptr && sourceString.is8Bit()) {
+    if (source_lines_count > 1 && source_lines != nullptr) {
         // Search for the beginning of the line
         unsigned int lineStart = location.byte_position;
         while (lineStart > 0 && sourceString[lineStart] != '\n') {
@@ -173,8 +173,6 @@ static void populateStackFramePosition(const JSC::StackFrame& stackFrame, BunStr
         while (lineEnd < maxSearch && sourceString[lineEnd] != '\n') {
             lineEnd++;
         }
-
-        const unsigned char* bytes = sourceString.span8().data();
 
         // Most of the time, when you look at a stack trace, you want a couple lines above.
 
@@ -189,36 +187,34 @@ static void populateStackFramePosition(const JSC::StackFrame& stackFrame, BunStr
         source_line_numbers[0] = location.line();
 
         if (lineStart > 0) {
-            auto byte_offset_in_source_string = lineStart - 1;
+            auto offset_in_source_string = lineStart - 1;
             uint8_t source_line_i = 1;
             auto remaining_lines_to_grab = source_lines_count - 1;
 
             {
-                // This should probably be code points instead of newlines
-                while (byte_offset_in_source_string > 0 && bytes[byte_offset_in_source_string] != '\n') {
-                    byte_offset_in_source_string--;
+                while (offset_in_source_string > 0 && sourceString[offset_in_source_string] != '\n') {
+                    offset_in_source_string--;
                 }
 
-                byte_offset_in_source_string -= byte_offset_in_source_string > 0;
+                offset_in_source_string -= offset_in_source_string > 0;
             }
 
-            while (byte_offset_in_source_string > 0 && remaining_lines_to_grab > 0) {
-                unsigned int end_of_line_offset = byte_offset_in_source_string;
+            while (offset_in_source_string > 0 && remaining_lines_to_grab > 0) {
+                unsigned int end_of_line_offset = offset_in_source_string;
 
-                // This should probably be code points instead of newlines
-                while (byte_offset_in_source_string > 0 && bytes[byte_offset_in_source_string] != '\n') {
-                    byte_offset_in_source_string--;
+                while (offset_in_source_string > 0 && sourceString[offset_in_source_string] != '\n') {
+                    offset_in_source_string--;
                 }
 
                 // We are at the beginning of the line
-                source_lines[source_line_i] = Bun::toStringView(sourceString.substring(byte_offset_in_source_string, end_of_line_offset - byte_offset_in_source_string + 1));
+                source_lines[source_line_i] = Bun::toStringView(sourceString.substring(offset_in_source_string, end_of_line_offset - offset_in_source_string + 1));
 
                 source_line_numbers[source_line_i] = location.line().fromZeroBasedInt(location.line().zeroBasedInt() - source_line_i);
                 source_line_i++;
 
                 remaining_lines_to_grab--;
 
-                byte_offset_in_source_string -= byte_offset_in_source_string > 0;
+                offset_in_source_string -= offset_in_source_string > 0;
             }
         }
     }

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -6883,7 +6883,12 @@ extern "C" JSC::EncodedJSValue Bun__REPL__evaluate(
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
-    WTF::String source = WTF::String::fromUTF8(std::span { sourcePtr, sourceLen });
+    // Same decoder as the module loader: text the transpiler passes through
+    // verbatim (preserved comments) can be ill-formed UTF-8, which becomes U+FFFD
+    // here; WTF::String::fromUTF8 returned a null string that evaluated to nothing.
+    WTF::String source = sourceLen > 0
+        ? Zig::convertUTF8ToString(std::span { sourcePtr, sourceLen })
+        : WTF::emptyString();
     WTF::String filename = filenameLen > 0
         ? WTF::String::fromUTF8(std::span { filenamePtr, filenameLen })
         : "[repl]"_s;

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -1117,6 +1117,43 @@ error: Hello World`,
       },
     },
   });
+  // A module containing any non-ASCII text (here a preserved comment) is held
+  // by JSC as a 16-bit string. Without a source map the error preview is
+  // rendered from that string, and so is the fix-up that moves a constructor
+  // call's position back to its new keyword when the two are on different
+  // lines. Both used to give up on 16-bit sources: no preview, and a frame
+  // position of 1:1. The ASCII twin of this fixture has always printed the
+  // output asserted here.
+  itBundled("compile/NoSourceMapNonAsciiSource", {
+    target: "bun",
+    compile: true,
+    files: {
+      "/entry.ts": /* js */ `
+        /*! © café 中 */
+        function code() {
+          throw new (class Boom extends Error {
+            constructor(message: string) {
+              super(message);
+            }
+          })("boom");
+        }
+        code();
+      `,
+    },
+    run: {
+      exitCode: 1,
+      validate({ stderr }) {
+        expect(stderr).toInclude("| /*! © café 中 */\n");
+        expect(stderr).toInclude(
+          `5 |   throw new class Boom extends Error {
+            ^
+error: boom
+`,
+        );
+        expect(stderr).toMatch(/at code \(.*:5:9\)\n/);
+      },
+    },
+  });
   itBundled("compile/SourceMapBigFile", {
     target: "bun",
     compile: true,

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -431,6 +431,31 @@ describe.concurrent("Bun REPL", () => {
       expect(exitCode).toBe(0);
     });
 
+    test(".load of a file with an ill-formed byte in a preserved comment still evaluates it", async () => {
+      // The transpiler passes `/*! */` comments through verbatim, so the program
+      // handed to the evaluator can contain ill-formed UTF-8. It has to be decoded
+      // the way module sources are (the bad byte becomes U+FFFD); decoding it with
+      // WTF::String::fromUTF8 turned the whole program into a null string, so
+      // nothing in the file was defined.
+      using dir = tempDir("repl-load-ill-formed", {
+        "bad.js": Buffer.concat([
+          Buffer.from("function tagged() {\n  /*! "),
+          Buffer.from([0xe9]),
+          Buffer.from(" */\n}\nvar loadedWithComment = 1;\n"),
+        ]),
+      });
+      const filePath = path.join(String(dir), "bad.js");
+      const { outputs, stderr, exitCode } = await runRepl([
+        `.load ${filePath}`,
+        'JSON.stringify([loadedWithComment, tagged.toString().split("\\uFFFD").length])',
+        ".exit",
+      ]);
+      // `.load` echoes the value of the file's last statement.
+      expect(outputs).toEqual([`Loading ${filePath}...\n1`, '"[1,2]"']);
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    });
+
     test(".load with a nonexistent file shows the error and keeps running", async () => {
       // A relative path: Windows rejects a forward-slash absolute path with EINVAL.
       const { outputs, stderr, exitCode } = await runRepl([


### PR DESCRIPTION
First of a four PR stack split out of #33866 (1: this, 2: coverage line table, 3: disk sources decoded as UTF-8, 4: #33866 itself). Each part is a bug on main today with its own failing test; this one has no dependency on the others.

### Problem

- A module whose text contains any non-ASCII character is held by JSC as a 16-bit string. Today that happens to every `--compile` executable with a non-ASCII preserved (`/*! */`) comment and to anything else loaded through `String::clone_utf8` (plain `bun build --target=bun` output is still read as Latin-1 on main and joins them with #38714). Three readers of module text assumed 8-bit:
  - `src/jsc/bindings/ZigException.cpp`: the source preview printed under an uncaught error was only built for 8-bit sources (it read them through `span8()`), so these modules print `error: boom` with no excerpt at all.
  - `src/jsc/bindings/ErrorStackFrame.cpp`, `adjustPositionBackwards`: when moving a constructor call's position back to its `new` keyword crosses a line it has to read the source; on a 16-bit source it hit an `ASSERT_NOT_REACHED` (a no-op in release) and reset the frame to 1:1, so the stack says `at code (app:1:1)`.
  - `src/jsc/bindings/bindings.cpp`, `Bun__REPL__evaluate`: the program was decoded with `WTF::String::fromUTF8`, which returns a null string for ill-formed input. Preserved comments pass through the REPL's transpile verbatim, so one stray byte in one made `.load` silently define nothing.

### Fix

- The preview indexes the `WTF::String` (works for both widths) and no longer requires 8-bit; `adjustPositionBackwards` drops the 8-bit check, since the offsets it walks are code units in either width; the REPL decodes with the same `Bun::toString` the module loader uses, which substitutes U+FFFD.
- Verification, both fail on main and pass here:
  - `test/bundler/bundler_compile.test.ts` `compile/NoSourceMapNonAsciiSource`: a compiled fixture with a non-ASCII preserved comment and a `new (class ...)("boom")` whose argument list is four lines below `new`. On main the output is `error: boom` followed by `at code (/$bunfs/root/out:1:1)`; now it prints the excerpt (with the comment decoded) and `:5:9`, exactly what the ASCII twin of the fixture has always printed. The excerpt's context-line labels are not asserted; they are off by one for bundled modules today, independently of this change; #38244 is fixing that.
  - `test/js/bun/repl/repl.test.ts`: `.load` of a file containing `/*! <0xE9> */` inside a function. On main the file defines nothing (`ReferenceError`); now it evaluates and `Function.prototype.toString` shows the U+FFFD.
  - Also run: the rest of `bundler_compile`'s source map cases, the `.load` REPL tests, `inspect-error.test.js` (its two "minified file" cases fail on debug builds before and after this change: an extra internal frame), `stack.test.ts`, `bundler_bun.test.ts`.

### Background

- JSC strings are either 8-bit (one Latin-1 character per byte) or 16-bit (UTF-16 code units). `WTF::String::operator[]` and `length()` work on either; `span8()` is only valid for 8-bit strings. Source positions JSC reports (`divot`, columns) are code unit offsets, so the same arithmetic is correct for both widths.
- The source preview is the `N | code` excerpt Bun prints above `error: ...` for an uncaught exception when no source map is involved; it is produced from the module text JSC holds.
- JSC places the position of a `new X(...)` at the argument list or the end of the callee; Bun moves it back to the `new` keyword so stacks point where V8's would. The move only needs the source text when `new` is on an earlier line.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 18 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/repl/repl.test.ts, test/bundler/bundler_compile.test.ts

<!-- robobun:evidence:end -->
