### PR TITLE
Build the coverage line table in UTF-16 code units

### DIFF
--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1590,8 +1590,8 @@ impl CommandLineReporter {
         // SAFETY: thread-local Box pinned for the thread; sole `&mut` for the
         // collection loop below (single-threaded CLI report path).
         let map = unsafe { &mut *map.as_ptr() };
-        // `ByteRangeMapping` owns a `MultiArrayList` and is not `Copy`, so
-        // collect mutable borrows into the thread-local map instead — no
+        // `ByteRangeMapping` owns its line table and is not `Copy`, so collect
+        // mutable borrows into the thread-local map instead; there is no
         // double-free risk.
         let mut byte_ranges: Vec<&mut ByteRangeMapping> = Vec::with_capacity(map.len());
         for entry in map.values_mut() {

--- a/src/sourcemap_jsc/CodeCoverage.rs
+++ b/src/sourcemap_jsc/CodeCoverage.rs
@@ -5,11 +5,10 @@ use core::ptr::NonNull;
 use bun_ast::Loc;
 use bun_collections::VecExt;
 use bun_collections::bit_set::DynamicBitSet;
-use bun_core::{self, Utf8Bytes};
+use bun_core::{self, Utf8Bytes, strings};
 use bun_jsc::{JSGlobalObject, JSValue, VM, bun_string_jsc};
 use bun_sourcemap::{
     LineOffsetTable, LineOffsetTableColumns as _, Ordinal, ParsedSourceMap, internal_source_map,
-    line_offset_table,
 };
 
 type LinesHits = Vec<u32>;
@@ -409,7 +408,10 @@ pub struct BasicBlockRange {
 }
 
 pub struct ByteRangeMapping {
-    pub(crate) line_offset_table: line_offset_table::List,
+    /// Offset of the start of each line, in UTF-16 code units: the unit JSC
+    /// reports `BasicBlockRange` offsets in. Equal to the byte offset only
+    /// while the source text is pure ASCII.
+    pub(crate) line_starts: Box<[u32]>,
     pub(crate) source_id: i32,
     pub source_url: Utf8Bytes<'static>,
 }
@@ -475,7 +477,7 @@ impl ByteRangeMapping {
         ignore_sourcemap: bool,
     ) -> Result<Report<'_>, bun_alloc::AllocError> {
         let source_url = self.source_url.slice();
-        let line_starts = self.line_offset_table.items_byte_offset_to_start_of_line();
+        let line_starts = &*self.line_starts;
 
         let mut executable_lines: Bitset;
         let mut lines_which_have_executed: Bitset;
@@ -800,9 +802,36 @@ impl ByteRangeMapping {
         source_id: i32,
         source_url: Utf8Bytes<'static>,
     ) -> ByteRangeMapping {
+        let mut line_offset_table = LineOffsetTable::generate(source_contents, 0)
+            .unwrap_or_else(|_| bun_alloc::out_of_memory());
+        let byte_starts = line_offset_table.items_byte_offset_to_start_of_line();
+
+        let line_starts: Box<[u32]> = if strings::is_all_ascii(source_contents) {
+            Box::from(byte_starts)
+        } else {
+            // `source_contents` is the UTF-8 form of the string JSC holds
+            // (8-bit or 16-bit), and JSC's offsets count that string's code
+            // units, so re-measure each line in those.
+            let mut previous_byte_start: usize = 0;
+            let mut code_units: u32 = 0;
+            byte_starts
+                .iter()
+                .map(|&byte_start| {
+                    let byte_start = byte_start as usize;
+                    let line = &source_contents[previous_byte_start..byte_start];
+                    code_units += u32::try_from(strings::element_length_utf8_into_utf16(line))
+                        .expect("int cast");
+                    previous_byte_start = byte_start;
+                    code_units
+                })
+                .collect()
+        };
+        // `MultiArrayList`'s own `Drop` frees the slab only; this drops each
+        // row's `columns_for_non_ascii` box.
+        line_offset_table.drop_elements();
+
         ByteRangeMapping {
-            line_offset_table: LineOffsetTable::generate(source_contents, 0)
-                .unwrap_or_else(|_| bun_alloc::out_of_memory()),
+            line_starts,
             source_id,
             source_url,
         }

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -641,3 +641,87 @@ test("only imports the function", () => {
   expect(stderr).toMatch(/ subject\.ts +\| +100\.00 +\| +100\.00 +\| +\n/);
   expect(exitCode).toBe(0);
 });
+
+// JSC reports the offsets of executed and unexecuted blocks in UTF-16 code
+// units of the source text it holds, and the line table those offsets are
+// looked up in was built in bytes, so line attribution drifted after any
+// non-ASCII text. Each non-ASCII variant below has exactly the same number of
+// code units on every line as the ASCII twin (an astral character is two code
+// units and four bytes), so its lcov record must be identical to the twin's;
+// counting bytes or code points shifts it.
+//
+// Both lengths are in UTF-16 code units.
+const coverageBannerUnits = 30;
+const coverageTextUnits = 40;
+function coverageDemo(banner: string, text: string) {
+  return `/*! ${banner} */
+export const raw = String.raw\`${text}\`;
+export const re = /${text}/u;
+export function covered() {
+  return raw.length + re.source.length;
+}
+export function uncovered() {
+  return 1;
+}
+export function alsoUncovered() {
+  return 2;
+}
+`;
+}
+const coverageDemoTest = `
+import { expect, test } from "bun:test";
+import { covered } from "./demo";
+
+test("source text has the expected length", () => {
+  expect(covered()).toBe(${2 * coverageTextUnits});
+});
+`;
+function repeatUnits(piece: string, units: number) {
+  return Buffer.alloc((Buffer.byteLength(piece) * units) / piece.length, piece).toString();
+}
+
+// lcov records of `demo.ts` for each variant, in order.
+async function coverageRecords(variants: Record<string, string>) {
+  using dir = tempDir(
+    "cov-non-ascii",
+    Object.fromEntries(
+      Object.entries(variants).flatMap(([name, source]) => [
+        [`${name}/demo.ts`, source],
+        [`${name}/demo.test.ts`, coverageDemoTest],
+      ]),
+    ),
+  );
+  // `await` here keeps `dir` alive until the processes have finished.
+  return await Promise.all(
+    Object.keys(variants).map(async variant => {
+      const cwd = path.join(String(dir), variant);
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", "--coverage", "--coverage-reporter=lcov", "./demo.test.ts"],
+        cwd,
+        env: bunEnv,
+        stdout: "ignore",
+        stderr: "pipe",
+      });
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain(" 1 pass\n");
+      expect(exitCode).toBe(0);
+      const record = readFileSync(path.join(cwd, "coverage", "lcov.info"), "utf8")
+        .split("end_of_record")
+        .find(record => record.includes("\nSF:demo.ts\n"));
+      expect(record).toBeDefined();
+      return record!;
+    }),
+  );
+}
+
+test("a non-ASCII preserved comment does not shift coverage lines", async () => {
+  const asciiText = repeatUnits("x", coverageTextUnits);
+  const [ascii, legalComment] = await coverageRecords({
+    ascii: coverageDemo(repeatUnits("x", coverageBannerUnits), asciiText),
+    legalComment: coverageDemo(repeatUnits("©🐰", coverageBannerUnits), asciiText),
+  });
+  // `uncovered` and `alsoUncovered` start on lines 7 and 10.
+  expect(ascii).toContain("\nDA:7,0\n");
+  expect(ascii).toContain("\nDA:10,0\n");
+  expect(legalComment).toBe(ascii);
+});


### PR DESCRIPTION
Second of the four PR stack split out of #33866, based on #38708 (1: #38708, 2: this, 3: disk sources decoded as UTF-8, 4: #33866). The diff against #38708 is `src/sourcemap_jsc/CodeCoverage.rs` and `test/cli/test/coverage.test.ts`, plus a one-line comment update in `src/runtime/cli/test_command.rs` that referred to the removed field; nothing here depends on #38708, it is only stacked for ordering.

### Problem

- `bun test --coverage` misattributes lines in any file whose module text contains non-ASCII characters. Today a non-ASCII preserved comment (`/*! © ... */`, the usual license banner) is enough: in the new test's fixture every line after the banner is shifted, the two functions that never run disappear from the lcov record, and unrelated lines are reported as unexecuted (full diff in the test output on main: `DA:7,0` / `DA:10,0` become `DA:4,0` / `DA:5,0` / `DA:6,0`).
- Cause: JSC reports block ranges as offsets in code units of the source string it holds. `ByteRangeMapping` (`src/sourcemap_jsc/CodeCoverage.rs`) receives the UTF-8 form of that string (`ByteRangeMapping__generate` calls `to_utf8()`), builds a table of byte offsets of line starts from it, and looks the code unit offsets up in that table. The two agree only while the text is ASCII.

### Fix

- The mapping stores the start of each line in code units: the byte offsets are used as-is for ASCII text, otherwise each line is re-measured with `element_length_utf8_into_utf16`. This is correct for both kinds of string JSC can hold (an 8-bit string with characters above 0x7F, which is what the runtime produces for such a comment today, and a 16-bit string), because the code unit count of the UTF-8 re-encoding of either equals the offsets JSC uses.
- The line offset table's per-line column tables were never used here; they are now freed right after the line starts are taken instead of living as long as the mapping.
- The `byte_offset` locals in the report loops and the `ByteRangeMapping` name itself follow JSC's own "byte range" terminology for these offsets and are left as they are; the unit is documented on the field they are compared against.
- Verification: `test/cli/test/coverage.test.ts` "a non-ASCII preserved comment does not shift coverage lines" runs the same module twice, once with an ASCII banner and once with a `©🐰` banner of the same length in code units (astral characters make code units differ from both bytes and code points), and requires identical lcov records, after checking the ASCII one reports the two unexecuted functions on lines 7 and 10. Fails on main as described above; passes here along with the rest of the file. The helper is shaped so the regex / tagged template variant, which needs #33866, can be added there as a second test.

### Background

- lcov `DA:<line>,<count>` records are what `--coverage-reporter=lcov` writes per line; comparing records of two files that differ only in text is a direct check of line attribution.
- JSC strings are 8-bit (one Latin-1 character per byte) or 16-bit (UTF-16 code units); offsets it reports are indices into whichever it holds. `to_utf8()` re-encodes either into UTF-8, which is longer than the string's unit count as soon as there is a character above 0x7F.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 18 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/test/coverage.test.ts
bun test v1.4.1 (861e9ae04)

test/cli/test/coverage.test.ts:
bun test v1.4.1 (861e9ae04)

demo.test.ts:
--------------|---------|---------|-------------------
File          | % Funcs | % Lines | Uncovered Line #s
--------------|---------|---------|-------------------
All files     |    0.00 |   66.67 |
 demo.test.ts |    0.00 |   66.67 | 
--------------|---------|---------|-------------------

 0 pass
 0 fail
Ran 0 tests across 1 file. [215.00ms]
(pass) coverage crash [323.38ms]
bun test v1.4.1 (861e9ae04)

demo2.ts:

 0 pass
 0 fail
Ran 0 tests across 1 file. [228.00ms]
(pass) lcov coverage reporter [281.45ms]
(pass) coverage excludes node_modules directory [269.85ms]
(pass) coveragePathIgnorePatterns - single pattern string [374.41ms]
(pass) coveragePathIgnorePatterns - partial coverage without nan [357.18ms]
(pass) coveragePathIgnorePatterns - array of patterns [402.83ms]
(pass) coveragePathIgnorePatterns - glob patterns [384.15ms]
(pass) coveragePathIgnorePatterns - lcov reporter [296.44ms]
(pass) cov
... (truncated)

release without fix: 1 FAILED
bun test v1.4.1-canary.1 (861e9ae04)

test/cli/test/coverage.test.ts:
bun test v1.4.1-canary.1 (861e9ae04)

demo.test.ts:

 0 pass
 0 fail
Ran 0 tests across 1 file. [12.00ms]
(pass) coverage crash [32.44ms]
bun test v1.4.1-canary.1 (861e9ae04)

demo2.ts:

 0 pass
 0 fail
Ran 0 tests across 1 file. [5.00ms]
(pass) lcov coverage reporter [51.65ms]
(pass) coverage excludes node_modules directory [49.43ms]
(pass) coveragePathIgnorePatterns - single pattern string [49.06ms]
(pass) coveragePathIgnorePatterns - partial coverage without nan [40.96ms]
(pass) coveragePathIgnorePatterns - array of patterns [40.10ms]
(pass) coveragePathIgnorePatterns - glob patterns [16.61ms]
(pass) coveragePathIgnorePatterns - lcov reporter [23.55ms]
(pass) coveragePathIgnorePatterns - invalid config type [12.29ms]
(pass) coveragePathIgnorePatterns - invalid array item [2.65ms]
(pass) coveragePathIgnorePatterns - empty array [52.16ms]
(pass) coveragePathIgnorePatterns - ignore all files [18.12ms]
(pass) --parallel merges line coverage across workers [129.41ms]
721 |     legalComment: coverageDemo(repeatUnits("©🐰", coverageBannerUnits), asciiText),
722 |   });
723 |   // `uncovered` and `a
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/test/coverage.test.ts
bun test v1.4.1 (861e9ae04)

test/cli/test/coverage.test.ts:
bun test v1.4.1 (861e9ae04)

demo.test.ts:
--------------|---------|---------|-------------------
File          | % Funcs | % Lines | Uncovered Line #s
--------------|---------|---------|-------------------
All files     |    0.00 |   66.67 |
 demo.test.ts |    0.00 |   66.67 | 
--------------|---------|---------|-------------------

 0 pass
 0 fail
Ran 0 tests across 1 file. [212.00ms]
(pass) coverage crash [311.76ms]
bun test v1.4.1 (861e9ae04)

demo2.ts:

 0 pass
 0 fail
Ran 0 tests across 1 file. [333.00ms]
(pass) lcov coverage reporter [396.28ms]
(pass) coverage excludes node_modules directory [357.51ms]
(pass) coveragePathIgnorePatterns - single pattern string [291.31ms]
(pass) coveragePathIgnorePatterns - partial coverage without nan [310.18ms]
(pass) coveragePathIgnorePatterns - array of patterns [296.72ms]
(pass) coveragePathIgnorePatterns - glob patterns [310.62ms]
(pass) coveragePathIgnorePatterns - lcov reporter [302.01ms]
(pass) cov
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     fabdf83a01
  features     baseline

23 deps, 129 codegen, 1172 objects in 662ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (861e9ae04)

Checked 26 installs across 63 packages (no changes) [3.00ms]
[2/1244] gen ErrorCode+*.h
[3/1244] gen bindgenv2
[4/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (861e9ae04)

Checked 1 install across 2 packages (no changes) [1.00ms]
[5/1244] gen .bind.ts → GeneratedBindings.cpp
[6/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1217] fetch zlib
[zlib] up to date
[8/1217] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (861e9ae04)

Checked 111 installs across 104 packages (no changes) [12.00ms]
[9/1217] fetch tinycc
[tinycc] up to date
[10/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[11/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 6ms

  react-refresh.js  4.81 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/cli/test_command.rs   |  4 +-
 src/sourcemap_jsc/CodeCoverage.rs | 41 ++++++++++++++++---
 test/cli/test/coverage.test.ts    | 84 +++++++++++++++++++++++++++++++++++++++
 3 files changed, 121 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 18

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/runtime/cli/test_command.rs        0      0      0
src/sourcemap_jsc/CodeCoverage.rs      3      3      0
test/cli/test/coverage.test.ts         4      4      0
```

</details>

<!-- robobun:evidence:end -->
