### PR TITLE
release: check GitHub API quota before uploading and report usage after

### DIFF
--- a/.buildkite/scripts/upload-release.sh
+++ b/.buildkite/scripts/upload-release.sh
@@ -183,6 +183,49 @@ function assert_buildkite_secret() {
   export "$key"="$value"
 }
 
+# The rate_limit endpoint itself does not count against the quota.
+function github_quota_remaining() {
+  gh api rate_limit --jq '.resources.core.remaining' 2> /dev/null || true
+}
+
+# Every push to main re-uploads the full canary asset set (~70 API calls with
+# --clobber), so fail before touching the release when the remaining quota
+# cannot cover it, rather than dying midway with assets partially clobbered.
+GITHUB_QUOTA_FLOOR=200
+
+function assert_github_quota() {
+  GITHUB_QUOTA_BEFORE="$(github_quota_remaining)"
+  if ! [[ "$GITHUB_QUOTA_BEFORE" =~ ^[0-9]+$ ]]; then
+    echo "warn: Cannot read GitHub API rate limit, skipping quota check"
+    GITHUB_QUOTA_BEFORE=""
+    return
+  fi
+  echo "GitHub API quota remaining before release: $GITHUB_QUOTA_BEFORE"
+  if [ "$GITHUB_QUOTA_BEFORE" -lt "$GITHUB_QUOTA_FLOOR" ]; then
+    echo "error: GitHub API quota is too low to complete the release (remaining: $GITHUB_QUOTA_BEFORE, required: $GITHUB_QUOTA_FLOOR)"
+    local reset
+    reset="$(gh api rate_limit --jq '.resources.core.reset' 2> /dev/null || true)"
+    if [[ "$reset" =~ ^[0-9]+$ ]]; then
+      echo "error: Quota resets in $((reset - $(date +%s))) seconds"
+    fi
+    exit 1
+  fi
+}
+
+function report_github_quota() {
+  local after
+  after="$(github_quota_remaining)"
+  if ! [[ "$after" =~ ^[0-9]+$ ]]; then
+    echo "warn: Cannot read GitHub API rate limit, skipping usage report"
+    return
+  fi
+  if [[ "$GITHUB_QUOTA_BEFORE" =~ ^[0-9]+$ ]] && [ "$after" -le "$GITHUB_QUOTA_BEFORE" ]; then
+    echo "GitHub API calls used by this release: $((GITHUB_QUOTA_BEFORE - after)) (remaining: $after)"
+  else
+    echo "GitHub API quota remaining after release: $after (quota window reset mid-release)"
+  fi
+}
+
 function release_tag() {
   local version="$1"
   if [ "$version" == "canary" ]; then
@@ -303,6 +346,7 @@ function create_release() {
   assert_github
   assert_aws
   assert_sentry
+  assert_github_quota
 
   local tag="$1" # 'canary' or 'x.y.z'
   local artifacts=(
@@ -396,6 +440,7 @@ function create_release() {
   create_sentry_release "$tag"
   send_discord_announcement "$tag"
   upload_s3_files "$tag" "${files[@]}"
+  report_github_quota
 }
 
 function assert_canary() {

--- a/.buildkite/scripts/upload-release.sh
+++ b/.buildkite/scripts/upload-release.sh
@@ -219,10 +219,14 @@ function report_github_quota() {
     echo "warn: Cannot read GitHub API rate limit, skipping usage report"
     return
   fi
-  if [[ "$GITHUB_QUOTA_BEFORE" =~ ^[0-9]+$ ]] && [ "$after" -le "$GITHUB_QUOTA_BEFORE" ]; then
-    echo "GitHub API calls used by this release: $((GITHUB_QUOTA_BEFORE - after)) (remaining: $after)"
+  if [[ "$GITHUB_QUOTA_BEFORE" =~ ^[0-9]+$ ]]; then
+    if [ "$after" -le "$GITHUB_QUOTA_BEFORE" ]; then
+      echo "GitHub API calls used by this release: $((GITHUB_QUOTA_BEFORE - after)) (remaining: $after)"
+    else
+      echo "GitHub API quota remaining after release: $after (quota window reset mid-release)"
+    fi
   else
-    echo "GitHub API quota remaining after release: $after (quota window reset mid-release)"
+    echo "GitHub API quota remaining after release: $after"
   fi
 }
 
@@ -347,6 +351,10 @@ function create_release() {
   assert_aws
   assert_sentry
   assert_github_quota
+  # The EXIT trap is the `set -e` equivalent of `if: always()`: it reports
+  # usage even when the release dies midway, which is when the number of
+  # calls already burned matters most.
+  trap report_github_quota EXIT
 
   local tag="$1" # 'canary' or 'x.y.z'
   local artifacts=(
@@ -440,7 +448,6 @@ function create_release() {
   create_sentry_release "$tag"
   send_discord_announcement "$tag"
   upload_s3_files "$tag" "${files[@]}"
-  report_github_quota
 }
 
 function assert_canary() {

--- a/.github/actions/github-rate-limit/action.yml
+++ b/.github/actions/github-rate-limit/action.yml
@@ -1,0 +1,63 @@
+name: GitHub API rate limit
+description: "Check the remaining GitHub API quota before a release job, or report how much the job used after it."
+
+inputs:
+  mode:
+    type: string
+    description: "'check' records the remaining quota and fails when it is below 'floor'; 'report' prints the calls used since 'check'."
+    required: true
+  floor:
+    type: string
+    description: "Minimum remaining API calls 'check' requires before letting the job proceed."
+    default: "200"
+    required: false
+  token:
+    type: string
+    description: "Token whose quota is checked."
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: GitHub API quota (${{ inputs.mode }})
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        MODE: ${{ inputs.mode }}
+        FLOOR: ${{ inputs.floor }}
+      # The rate_limit endpoint itself does not count against the quota.
+      run: |
+        remaining="$(gh api rate_limit --jq '.resources.core.remaining' 2> /dev/null || true)"
+        if ! [[ "$remaining" =~ ^[0-9]+$ ]]; then
+          echo "warning: Cannot read GitHub API rate limit, skipping quota $MODE"
+          exit 0
+        fi
+        case "$MODE" in
+          check)
+            echo "GitHub API quota remaining before this job: $remaining"
+            echo "GITHUB_QUOTA_BEFORE=$remaining" >> "$GITHUB_ENV"
+            if [ "$remaining" -lt "$FLOOR" ]; then
+              echo "error: GitHub API quota is too low to complete this job (remaining: $remaining, required: $FLOOR)"
+              reset="$(gh api rate_limit --jq '.resources.core.reset' 2> /dev/null || true)"
+              if [[ "$reset" =~ ^[0-9]+$ ]]; then
+                echo "error: Quota resets in $((reset - $(date +%s))) seconds"
+              fi
+              exit 1
+            fi
+            ;;
+          report)
+            if [[ "${GITHUB_QUOTA_BEFORE:-}" =~ ^[0-9]+$ ]]; then
+              if [ "$remaining" -le "$GITHUB_QUOTA_BEFORE" ]; then
+                echo "GitHub API calls used by this job: $((GITHUB_QUOTA_BEFORE - remaining)) (remaining: $remaining)"
+              else
+                echo "GitHub API quota remaining after this job: $remaining (quota window reset mid-job)"
+              fi
+            else
+              echo "GitHub API quota remaining after this job: $remaining"
+            fi
+            ;;
+          *)
+            echo "error: Unknown mode: $MODE"
+            exit 1
+            ;;
+        esac

--- a/.github/actions/github-rate-limit/action.yml
+++ b/.github/actions/github-rate-limit/action.yml
@@ -3,16 +3,13 @@ description: "Check the remaining GitHub API quota before a release job, or repo
 
 inputs:
   mode:
-    type: string
     description: "'check' records the remaining quota and fails when it is below 'floor'; 'report' prints the calls used since 'check'."
     required: true
   floor:
-    type: string
     description: "Minimum remaining API calls 'check' requires before letting the job proceed."
     default: "200"
     required: false
   token:
-    type: string
     description: "Token whose quota is checked."
     required: true
 
@@ -27,6 +24,16 @@ runs:
         FLOOR: ${{ inputs.floor }}
       # The rate_limit endpoint itself does not count against the quota.
       run: |
+        # Inputs are validated before the API read so a misconfigured step
+        # fails loudly instead of riding the cannot-read-quota warning path.
+        if [[ "$MODE" != "check" && "$MODE" != "report" ]]; then
+          echo "error: Unknown mode: $MODE"
+          exit 1
+        fi
+        if ! [[ "$FLOOR" =~ ^[0-9]+$ ]]; then
+          echo "error: floor must be a non-negative integer, got: $FLOOR"
+          exit 1
+        fi
         remaining="$(gh api rate_limit --jq '.resources.core.remaining' 2> /dev/null || true)"
         if ! [[ "$remaining" =~ ^[0-9]+$ ]]; then
           echo "warning: Cannot read GitHub API rate limit, skipping quota $MODE"
@@ -55,9 +62,5 @@ runs:
             else
               echo "GitHub API quota remaining after this job: $remaining"
             fi
-            ;;
-          *)
-            echo "error: Unknown mode: $MODE"
-            exit 1
             ;;
         esac

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,12 +78,23 @@ jobs:
           bun-version: "1.3.14"
       - name: Install Dependencies
         run: bun install
+      - name: Check GitHub API quota
+        uses: ./.github/actions/github-rate-limit
+        with:
+          mode: check
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Sign Release
         run: |
           echo "$GPG_PASSPHRASE" | bun upload-assets -- "$BUN_VERSION"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Report GitHub API usage
+        if: ${{ always() }}
+        uses: ./.github/actions/github-rate-limit
+        with:
+          mode: report
+          token: ${{ secrets.GITHUB_TOKEN }}
   npm:
     name: Release to NPM
     runs-on: ubuntu-latest
@@ -107,11 +118,22 @@ jobs:
           bun-version: "1.3.14"
       - name: Install Dependencies
         run: bun install
+      - name: Check GitHub API quota
+        uses: ./.github/actions/github-rate-limit
+        with:
+          mode: check
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Release
         run: bun upload-npm -- "$BUN_VERSION" publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Report GitHub API usage
+        if: ${{ always() }}
+        uses: ./.github/actions/github-rate-limit
+        with:
+          mode: report
+          token: ${{ secrets.GITHUB_TOKEN }}
   npm-types:
     name: Release types to NPM
     runs-on: ubuntu-latest
@@ -336,6 +358,11 @@ jobs:
           bun-version: "1.3.14"
       - name: Install Dependencies
         run: bun install
+      - name: Check GitHub API quota
+        uses: ./.github/actions/github-rate-limit
+        with:
+          mode: check
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Release
         run: bun upload-s3 -- "$BUN_VERSION"
         env:
@@ -344,6 +371,12 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
           AWS_ENDPOINT: ${{ secrets.AWS_ENDPOINT }}
           AWS_BUCKET: bun
+      - name: Report GitHub API usage
+        if: ${{ always() }}
+        uses: ./.github/actions/github-rate-limit
+        with:
+          mode: report
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   notify-sentry:
     name: Notify Sentry
@@ -361,4 +394,3 @@ jobs:
           ignore_empty: true
           version: ${{ env.BUN_VERSION }}
           environment: production
-


### PR DESCRIPTION
Closes #38712. Follow-up from the review discussion on #28932.

### Problem
- The release pipeline makes no rate-limit check: on a busy day a canary upload can run out of GitHub API quota midway, leaving the release with assets partially clobbered.
- There is no visibility into how many API calls a release actually uses, so a regression back to per-asset call patterns would go unnoticed.

### Fix
- `.buildkite/scripts/upload-release.sh`: `assert_github_quota` runs with the other preflight asserts and fails the step before any asset is touched when fewer than 200 core API calls remain (a canary uses roughly 70 with `--clobber`), printing seconds until the quota resets. `report_github_quota` is armed as an EXIT trap once the quota check passes, so it logs calls used (before minus after) and the remaining budget.
- `.github/workflows/release.yml`: the three jobs that hit the GitHub API (sign, npm, s3) get the same pair of steps via a new `.github/actions/github-rate-limit` composite action: a `check` step before the main work and a `report` step with `if: always()` so usage is logged even when the job fails mid-release.
- Both degrade to a warning when the rate limit cannot be read, so a transient API hiccup never blocks a release on its own. The `rate_limit` endpoint itself does not count against the quota, and the window-reset case (remaining went up mid-job) is reported as such instead of as a negative count.

### Verification
- `bash -n` on the edited script, plus the new functions exercised against the live API: normal path, simulated low-quota floor (fails with reset countdown), and `gh` unavailable (warns, continues).
- The composite action's script block extracted and run in all modes: check, report with and without a recorded before-value, low floor, and unknown mode.
- `release.yml` and `action.yml` parse as YAML and pass `prettier --check` (the workflow's pre-existing trailing blank line is fixed in passing).

### Background
- The canary release is uploaded by a Buildkite step (`upload-release.sh`) on every push to main; the `release.yml` GitHub Actions workflow then signs assets and publishes to npm/S3/Docker/Homebrew. The sign, npm, and s3 jobs authenticate to the GitHub API with the ephemeral Actions token, which has its own per-repository quota separate from the Buildkite step's token.
- `GITHUB_QUOTA_BEFORE` is shared between the action's check and report invocations through `$GITHUB_ENV`, the standard mechanism for passing values between steps in one job.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 10 · build/CI scripts only; test-proof not applicable

<!-- robobun:evidence:end -->
