### PR TITLE
Decode module text that comes from disk or bundler output as UTF-8

### DIFF
--- a/src/bundler/OutputFile.rs
+++ b/src/bundler/OutputFile.rs
@@ -119,8 +119,7 @@ impl Value {
     }
 
     /// ASCII output aliases `bytes` (an external string with a no-op free;
-    /// `self` must outlive it), non-ASCII output is transcoded. Both return
-    /// one owned reference: release it with `transferToWTFString()`.
+    /// `self` must outlive it), non-ASCII output is transcoded.
     pub fn to_bun_string_ref(&self) -> BunString {
         match self {
             Value::Noop => BunString::EMPTY,

--- a/src/bundler/OutputFile.rs
+++ b/src/bundler/OutputFile.rs
@@ -118,20 +118,18 @@ impl Value {
         }
     }
 
-    /// Borrowing variant of [`Self::to_bun_string`]: wraps the buffer in a
-    /// `WTF::ExternalStringImpl` that aliases `bytes` with a **no-op** free
-    /// callback (zero-copy). Caller guarantees `self` outlives every use of the
-    /// returned string.
-    ///
-    /// `PerThread.bundled_outputs` owns the bytes for the entire prerender
-    /// phase. The consuming [`Self::to_bun_string`] cannot be used there
-    /// because the `Vec<OutputFile>` is only borrowed.
+    /// ASCII output aliases `bytes` (an external string with a no-op free;
+    /// `self` must outlive it), non-ASCII output is transcoded. Both return
+    /// one owned reference: release it with `transferToWTFString()`.
     pub fn to_bun_string_ref(&self) -> BunString {
         match self {
             Value::Noop => BunString::EMPTY,
             Value::Buffer { bytes } => {
                 if bytes.is_empty() {
                     return BunString::EMPTY;
+                }
+                if !bun_core::strings::is_all_ascii(bytes) {
+                    return BunString::clone_utf8(bytes);
                 }
                 extern "C" fn noop(_: *mut c_void, _: *mut c_void, _: usize) {}
                 // latin1 = true.

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -982,7 +982,7 @@ impl TranspilerJob {
             let bytecode_cache =
                 crate::resolved_source::Bytecode::owned(already_bundled.into_bytecode());
             self.resolved_source = ResolvedSource {
-                source_code: String::clone_latin1(&parse_result.source.contents),
+                source_code: String::clone_utf8(&parse_result.source.contents),
                 already_bundled: true,
                 bytecode_cache,
                 is_commonjs_module,

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -4283,7 +4283,7 @@ pub(super) fn finalize_bundle(
                 }
             }
         } else {
-            match c::bake_load_server_hmr_patch(global, BunString::clone_latin1(&server_bundle)) {
+            match c::bake_load_server_hmr_patch(global, BunString::clone_utf8(&server_bundle)) {
                 Ok(v) => v,
                 Err(err) => {
                     // SAFETY: vm is JSC_BORROW — valid for DevServer lifetime;

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -1598,8 +1598,9 @@ extern "C" fn BakeProdLoad(pt: *mut PerThread, key: &BunString) -> BunString {
     log!("BakeProdLoad: {}\n", BStr::new(utf8.slice()));
     if let Some(value) = pt.module_map.get(utf8.slice()) {
         log!("  found in module_map: {}\n", BStr::new(utf8.slice()));
-        // Zero-copy: alias the chunk bytes; `pt.bundled_outputs` owns them for
-        // the lifetime of the attached `PerThread` (see `Value::to_bun_string_ref`).
+        // ASCII chunks are aliased, not copied; `pt.bundled_outputs` owns the
+        // bytes for the lifetime of the attached `PerThread` (see
+        // `Value::to_bun_string_ref`).
         return pt.bundled_outputs[value.get() as usize]
             .value
             .to_bun_string_ref();

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2867,7 +2867,7 @@ fn transpile_source_code_inner(
                     let is_commonjs_module = already_bundled.is_common_js();
                     let bytecode_cache = Bytecode::owned(already_bundled.into_bytecode());
                     return Ok(ResolvedSource {
-                        source_code: bun_core::String::clone_latin1(&source.contents),
+                        source_code: bun_core::String::clone_utf8(&source.contents),
                         source_url: input_specifier.create_if_different(path.text),
                         already_bundled: true,
                         bytecode_cache,

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -136,6 +136,36 @@ export default function TestPage() {
     expect(hasApiPath).toBe(true);
   });
 
+  // The server chunks are handed to the prerender VM straight from the
+  // in-memory build output (OutputFile::to_bun_string_ref). They are UTF-8,
+  // and a preserved comment is text the bundler keeps as written, so loading
+  // them as Latin-1 shows up in anything the page reads back out of one.
+  test("non-ASCII text in a server chunk survives prerendering", async () => {
+    const dir = await tempDirWithBakeDeps("bake-production-non-ascii", {
+      "src/index.tsx": `export default { app: { framework: "react" } };`,
+      "pages/index.tsx": `
+function banner() {
+  /*! © café-中-🐰 */
+}
+
+export default function IndexPage() {
+  const text = banner.toString().split("/*! ")[1].split(" */")[0];
+  return <div id="probe">{[text, text.length].join("|")}</div>;
+}
+`,
+    });
+
+    const build = await Bun.$`${bunExe()} build --app ./src/index.tsx --outdir ./dist`
+      .cwd(dir)
+      .env(bunEnv)
+      .throws(false);
+    expect(build.stderr.toString()).not.toContain("error");
+    expect(build.exitCode).toBe(0);
+
+    const indexHtml = await Bun.file(path.join(dir, "dist", "index.html")).text();
+    expect(indexHtml).toContain(`<div id="probe">© café-中-🐰|11</div>`);
+  });
+
   test("import.meta properties are inlined in catch-all routes during production build", async () => {
     const dir = await tempDirWithBakeDeps("bake-production-catch-all", {
       "src/index.tsx": `export default { 

--- a/test/bundler/transpiler/runtime-transpiler.test.ts
+++ b/test/bundler/transpiler/runtime-transpiler.test.ts
@@ -48,6 +48,40 @@ describe("// @bun", () => {
     expect(stdout.toString()).toBe("Hello world!\n");
     expect(exitCode).toBe(0);
   });
+
+  // https://github.com/oven-sh/bun/issues/37161
+  const nonAscii = "\u2014\u00b7\u2713 K\u00e4ufer";
+  test("raw utf-8 decodes as utf-8, not latin-1 (import)", async () => {
+    using dir = tempDir("bun-pragma-utf8-import", {
+      "pragma.js": `// @bun\nexport const text = "${nonAscii}";\n`,
+    });
+    const { text } = await import(`${dir}/pragma.js`);
+    expect(text).toBe(nonAscii);
+  });
+
+  test("raw utf-8 decodes as utf-8, not latin-1 (require)", async () => {
+    using dir = tempDir("bun-pragma-utf8-require", {
+      "pragma.js": `// @bun\nexport const text = "${nonAscii}";\n`,
+    });
+    const { text } = require(`${dir}/pragma.js`);
+    expect(text).toBe(nonAscii);
+  });
+
+  test("raw utf-8 decodes as utf-8, not latin-1 (entry point)", async () => {
+    using dir = tempDir("bun-pragma-utf8-entry", {
+      "pragma.js": `// @bun\nconst DASH = "\u2014";\nconsole.log([...DASH].map(c => c.codePointAt(0).toString(16)).join(" "));\n`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "pragma.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("2014\n");
+    expect(exitCode).toBe(0);
+  });
 });
 
 describe("json imports", () => {


### PR DESCRIPTION
Fixes #37161

Third of the four PR stack split out of #33866, based on #38710 (1: #38708, 2: #38710, 3: this, 4: #33866). The diff against #38710 is four source files and two test files. Supersedes #37162, whose decoding commit and tests are carried here.

### Problem

- Module text that comes from disk or from the bundler's in-memory output is UTF-8, and three places handed it to JSC wrapped as Latin-1, which is only correct for ASCII:
  - files carrying the `// @bun` pragma (what `bun build --target=bun` writes) skip the transpiler; both the sync loader (`src/runtime/jsc_hooks.rs`, already-bundled branch) and the async one (`src/jsc/RuntimeTranspilerStore.rs`) used `clone_latin1`, so every non-ASCII string literal in such a bundle is mojibake at runtime (#37161: `"Käufer"` comes back as `KÃ¤ufer`, and the issue's `\u2014` and `\u2713` each become three characters);
  - `bun build --app` prerendering loads server chunks straight from the build output through `OutputFile::to_bun_string_ref` (`src/bundler/OutputFile.rs`), which always wrapped the bytes; a preserved comment is enough to see it: the new test's page renders `Â© cafÃ©-ä¸­-ð°|17` on main instead of `© café-中-🐰|11`;
  - the dev server's server HMR patch load without a source map (`src/runtime/bake/DevServer.rs`) did the same, although in practice every JS chunk carries at least a line-count map and takes the other branch, which already decoded; it is switched for consistency only and has no test.

### Fix

- `clone_latin1` -> `clone_utf8` at the two `// @bun` sites and in the dev server branch; `clone_utf8` keeps the 8-bit fast path for ASCII input and only transcodes otherwise. `to_bun_string_ref` keeps the zero-copy wrapper for ASCII output and decodes anything else; either way it returns one owned reference, which the C++ entry points take over with `transferToWTFString()` (they did so since #40238; an earlier revision of this PR carried that change).
- For a `// @bun` bundle with non-ASCII text and a `.jsc` bytecode sidecar, the sidecar was generated from the Latin-1 reading and now fails JSC's source check, so JSC silently parses instead; before this change the bytecode was accepted for a program whose strings were wrong. #33866 makes the generators decode the same way and restores the cache hit. `--compile` already loaded non-ASCII bundles as UTF-8 and is unaffected.
- Verification (all fail on main, pass here):
  - `test/bundler/transpiler/runtime-transpiler.test.ts`: a `// @bun` module with a non-ASCII string literal loaded via `import` (async path), `require` (sync path) and as the entry point (from #37162).
  - `test/bake/dev/production.test.ts` "non-ASCII text in a server chunk survives prerendering": a page that renders the text of a preserved comment read back through `Function.prototype.toString`, so it exercises the prerender handoff without depending on #33866.
  - Also run on this build: the rest of `production.test.ts` and `test/bake/dev/server-sourcemap.test.ts`, which load server patches through `BakeLoadServerHmrPatchWithSourceMap` repeatedly and tear the providers down at exit (the entry point without a map is unreachable, as noted above, so its change is covered by reading only).

### Background

- JSC strings are 8-bit (one Latin-1 character per byte) or 16-bit. `clone_latin1` wraps bytes as the former without looking at them; `clone_utf8` scans and, for non-ASCII input, transcodes to 16-bit.
- `// @bun` pragma: marks a file as already transpiled by Bun, so the runtime hands its bytes to JSC directly.
- Prerendering (`bun build --app`): after bundling, the server chunks are executed in a VM inside the build process to produce static HTML; `BakeProdLoad` serves those chunks from the in-memory `OutputFile`s.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 18 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bake/dev/production.test.ts

<!-- robobun:evidence:end -->

