### PR TITLE
js_parser: accept a JSX element or fragment as an unbraced attribute value

### DIFF
--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -393,14 +393,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             p.lexer.next_inside_jsx_element()?;
             Ok(expr)
         } else if p.lexer.token == T::TLessThan {
-            // <a b=<c/> /> and <a b=<>..</> />: JSXAttributeValue also allows a bare
-            // JSXElement or JSXFragment (https://facebook.github.io/jsx/)
+            // <a b=<c /> /> or <a b=<>..</> />
             let loc = p.lexer.loc();
             p.lexer.next_inside_jsx_element()?;
             let value = p.parse_jsx_element(loc)?;
 
-            // parse_jsx_element() leaves the element's final ">" as the current token.
-            // What follows is the rest of the enclosing tag's attribute list.
+            // parse_jsx_element() leaves the closing ">" unconsumed; more attributes follow it
             p.lexer.next_inside_jsx_element()?;
             Ok(value)
         } else {

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -392,6 +392,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
             p.lexer.next_inside_jsx_element()?;
             Ok(expr)
+        } else if p.lexer.token == T::TLessThan {
+            // <a b=<c/> /> and <a b=<>..</> />: JSXAttributeValue also allows a bare
+            // JSXElement or JSXFragment (https://facebook.github.io/jsx/)
+            let loc = p.lexer.loc();
+            p.lexer.next_inside_jsx_element()?;
+            let value = p.parse_jsx_element(loc)?;
+
+            // parse_jsx_element() leaves the element's final ">" as the current token.
+            // What follows is the rest of the enclosing tag's attribute list.
+            p.lexer.next_inside_jsx_element()?;
+            Ok(value)
         } else {
             // Use Expect() not ExpectInsideJSXElement() so we can parse expression tokens
             p.lexer.expect(T::TOpenBrace)?;

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2481,6 +2481,66 @@ console.log(<div {...obj} key="after" />);`),
     );
   });
 
+  // JSXAttributeValue is a string, `{expr}`, or a bare JSXElement / JSXFragment
+  // (https://facebook.github.io/jsx/), so `<a b=<c /> />` means `<a b={<c />} />`.
+  // Babel, TypeScript and esbuild accept the bare form; Bun used to fail with
+  // 'Expected "{" but found "<"'.
+  describe("JSX element or fragment as an unbraced attribute value", () => {
+    const jsx = new Bun.Transpiler({
+      loader: "jsx",
+      define: { "process.env.NODE_ENV": JSON.stringify("development") },
+    });
+    const tsx = new Bun.Transpiler({
+      loader: "tsx",
+      define: { "process.env.NODE_ENV": JSON.stringify("development") },
+    });
+
+    it("self-closing element", () => {
+      expect(jsx.transformSync("export var x = <a b=<c /> />")).toBe(
+        `export var x = jsxDEV_7x81h0kn("a", {
+  b: jsxDEV_7x81h0kn("c", {}, undefined, false, undefined, this)
+}, undefined, false, undefined, this);
+`,
+      );
+    });
+
+    it("fragment", () => {
+      expect(jsx.transformSync("export var x = <Trans values=<>x</> />")).toBe(
+        `export var x = jsxDEV_7x81h0kn(Trans, {
+  values: jsxDEV_7x81h0kn(Fragment_8vg9x3sq, {
+    children: "x"
+  }, undefined, false, undefined, this)
+}, undefined, false, undefined, this);
+`,
+      );
+    });
+
+    it.each([
+      ["<a b=<c/>/>", "<a b={<c/>}/>"],
+      ["<a b=<></> />", "<a b={<></>} />"],
+      ["<a b=<c>hi</c>>child</a>", "<a b={<c>hi</c>}>child</a>"],
+      ["<a b=<c/>>child</a>", "<a b={<c/>}>child</a>"],
+      ['<a b=<c d=<e /> /> f="1" g />', '<a b={<c d={<e />} />} f="1" g />'],
+      ["<a b=<c d={1} {...e}>{f}<g /></c> />", "<a b={<c d={1} {...e}>{f}<g /></c>} />"],
+      ["<A b=<C.D /> />", "<A b={<C.D />} />"],
+      ["<a key=<c /> />", "<a key={<c />} />"],
+    ])("%s transpiles like %s", (unbraced, braced) => {
+      expect(jsx.transformSync(`export var x = ${unbraced}`)).toBe(jsx.transformSync(`export var x = ${braced}`));
+    });
+
+    it("tsx: tags with type arguments", () => {
+      expect(tsx.transformSync("export var x = <A<T> b=<C<U> /> />")).toBe(
+        tsx.transformSync("export var x = <A<T> b={<C<U> />} />"),
+      );
+    });
+
+    it("the value is parsed as a regular element, so its tags must still match", () => {
+      expect(() => jsx.transformSync("export var x = <a b=<c></d> />")).toThrow(
+        'Expected closing JSX tag to match opening tag "<c>"',
+      );
+    });
+  });
+
   it("JSX tag names containing '-' or ':' are string tags regardless of case", () => {
     // Matches esbuild/Babel/TypeScript: a dashed (custom element) or namespaced
     // name is never a component reference, even when it starts uppercase.


### PR DESCRIPTION
### Problem
- A JSX element or fragment written directly as an attribute value is rejected: `<a t=<b/> />` and `<Trans values=<>x</> />` fail with `error: Expected "{" but found "<"`. The braced spelling `t={<b/>}` works.
- The JSX grammar (https://facebook.github.io/jsx/) defines `JSXAttributeValue` as a string, `{ AssignmentExpression }`, a `JSXElement`, or a `JSXFragment`. Babel, TypeScript and esbuild accept the bare element form.
- `parse_jsx_prop_value_identifier` (`src/js_parser/parse/mod.rs:377`) only handles the string literal case and otherwise does `expect(TOpenBrace)`, so the last two grammar alternatives were missing.

### Fix
- After `=`, when the next token is `<`, call `parse_jsx_element` (the same routine used for top-level elements and child elements; it also handles fragments and TS type arguments), then advance with `next_inside_jsx_element` because what follows is the rest of the enclosing tag's attribute list. This is the same shape as esbuild's handling of this case.
- The value is the same `E::JSXElement` node the braced form produces, so everything downstream (visitor, classic/automatic runtime lowering, printer, `key` handling) is unchanged. Inputs that parsed before take exactly the same path as before; the new branch is only reached on input that used to be a syntax error.
- Recursion through attribute values goes through the stack guard at the top of `parse_jsx_element`; a 50k-deep `<a b=<a b=...` input reports "Maximum call stack size exceeded" instead of crashing.
- Verified with `test/bundler/transpiler/transpiler.test.js` ("JSX element or fragment as an unbraced attribute value"): 12 tests fail on the released 1.4.0 (`USE_SYSTEM_BUN=1`), pass with this change. The tests assert that the bare form transpiles byte for byte like the braced form for self-closing elements, fragments, elements with children, nested bare values, following attributes, member-expression tags, `key`, and TSX type arguments, plus that a mismatched closing tag inside the value still produces the normal error.
- Also ran the rest of `transpiler.test.js` (200 pass) and `test/bundler/bundler_jsx.test.ts` (48 pass).

### Background
- Bun's lexer has several "next token" functions because JSX needs different tokenization depending on where it is: `next_inside_jsx_element` is used between a tag's attributes (it lexes JSX string literals and single-character `<` `>` `/` tokens), `next_jsx_element_child` is used for text between tags, and plain `next` is used inside `{...}` expressions. `parse_jsx_element` deliberately does not consume the element's closing `>` because only the caller knows which of these modes the following source is in; the top-level caller uses `next`, the child-element caller uses `next_jsx_element_child`, and this new caller uses `next_inside_jsx_element`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 12 failed, 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
bun test v1.4.0 (f316154f7)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [5.55ms]
(pass) Bun.Transpiler > normalizes \r\n [6.50ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [4.18ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [7.69ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.91ms]
(pass) Bun.Transpiler > property access inlining > works [2.44ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.78ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [47.99ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [21.86ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [331.73ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional
... (truncated)

release without fix: 12 failed, 22 skipped
bun test v1.4.0-canary.1 (b7a043103)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [0.11ms]
(pass) Bun.Transpiler > normalizes \r\n [0.13ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [0.08ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.11ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.03ms]
(pass) Bun.Transpiler > property access inlining > works [0.03ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.02ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [0.55ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [0.30ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [10.42ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [0.42ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [0.05ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly whe
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
bun test v1.4.0 (f316154f7)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [6.47ms]
(pass) Bun.Transpiler > normalizes \r\n [7.28ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [5.39ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [9.21ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [3.54ms]
(pass) Bun.Transpiler > property access inlining > works [3.02ms]
(pass) Bun.Transpiler > property access inlining > works nested [3.45ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [51.44ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [25.76ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [332.86ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional
... (truncated)

release with fix: 22 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 717ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[9
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/parse/mod.rs                 |  9 +++++
 test/bundler/transpiler/transpiler.test.js | 60 ++++++++++++++++++++++++++++++
 2 files changed, 69 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/js_parser/parse/mod.rs                      2      3      0
test/bundler/transpiler/transpiler.test.js      1      1      0
```

</details>

<!-- robobun:evidence:end -->