### PR TITLE
Transpile each file with the tsconfig.json nearest to it at runtime

### DIFF
--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -840,9 +840,7 @@ impl<'a> Transpiler<'a> {
             return None;
         }
         self.resolver
-            .read_dir_info(dir)
-            .ok()
-            .flatten()?
+            .read_dir_info_ignore_error(dir)?
             .enclosing_tsconfig_json
     }
 

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -833,8 +833,7 @@ impl<'a> Transpiler<'a> {
         Ok(())
     }
 
-    /// The tsconfig.json nearest to `path`, as `bun build` applies it; `None` for
-    /// paths with no directory on disk. Uses the resolver, so JS thread only.
+    /// Nearest tsconfig.json to `path` (as in `bun build`). Resolver lookup, so JS thread only.
     pub fn tsconfig_for_file(&mut self, path: &[u8]) -> Option<&'static TSConfigJSON> {
         let dir = Fs::PathName::init(path).dir;
         if !bun_paths::is_absolute(dir) {
@@ -847,14 +846,12 @@ impl<'a> Transpiler<'a> {
             .enclosing_tsconfig_json
     }
 
-    /// Settings for a file governed by `tsconfig` ([`Self::tsconfig_for_file`]);
-    /// without one, the cwd tsconfig values `configure_linker` put in `options`.
+    /// Without a `tsconfig`, the cwd tsconfig values `configure_linker` put in `options` apply.
     pub fn tsconfig_parse_options(&self, tsconfig: Option<&TSConfigJSON>) -> TSConfigParseOptions {
         match tsconfig {
             Some(tsconfig) => {
                 let mut jsx = tsconfig.merge_jsx(self.options.jsx.clone());
-                // An explicit NODE_ENV (settled in `options.jsx` by `configure_defines`)
-                // outranks the tsconfig's react-jsx / react-jsxdev choice.
+                // Explicit NODE_ENV (already in `options.jsx`) outranks tsconfig's dev/prod jsx.
                 if self.options.production
                     || self.options.force_node_env != options::ForceNodeEnv::Unspecified
                 {
@@ -1029,8 +1026,7 @@ pub struct ParseOptions<'a, 'b> {
 
     pub path: bun_paths::fs::Path<'static>,
     pub loader: options::Loader,
-    /// The file-backed `options_impl::jsx::Pragma` (NOT the lib.rs shim), with
-    /// the file's tsconfig.json merged in; see [`TSConfigParseOptions`].
+    /// File-backed `options_impl::jsx::Pragma` (NOT the lib.rs shim), tsconfig already merged in.
     pub jsx: crate::options_impl::jsx::Pragma,
     pub macro_remappings: MacroRemap,
     pub macro_js_ctx: MacroJSCtx,

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -832,6 +832,69 @@ impl<'a> Transpiler<'a> {
         }
         Ok(())
     }
+
+    /// The tsconfig.json governing the file at `path`: the nearest one in its
+    /// directory or an ancestor, which is what the resolver applies to the file
+    /// when `bun build` bundles it. `None` when there is none, or when `path`
+    /// has no directory on disk (virtual modules).
+    ///
+    /// The directory was already walked to resolve the file, so this is a cache
+    /// lookup in practice. Runs on the JS thread: a cache miss reads the
+    /// directory through this transpiler's resolver.
+    pub fn tsconfig_for_file(&mut self, path: &[u8]) -> Option<&'static TSConfigJSON> {
+        let dir = Fs::PathName::init(path).dir;
+        if !bun_paths::is_absolute(dir) {
+            return None;
+        }
+        self.resolver
+            .read_dir_info(dir)
+            .ok()
+            .flatten()?
+            .enclosing_tsconfig_json
+    }
+
+    /// The [`ParseOptions`] fields that tsconfig.json controls, for a file
+    /// governed by `tsconfig` (see [`Self::tsconfig_for_file`]). A file without
+    /// one gets the values `configure_linker` took from the cwd's tsconfig.
+    pub fn tsconfig_parse_options(&self, tsconfig: Option<&TSConfigJSON>) -> TSConfigParseOptions {
+        match tsconfig {
+            Some(tsconfig) => {
+                let mut jsx = tsconfig.merge_jsx(self.options.jsx.clone());
+                // An explicit NODE_ENV outranks the tsconfig's "react-jsx" /
+                // "react-jsxdev" choice (`force_node_env`); `configure_defines`
+                // already settled it in `options.jsx` for the whole process.
+                if self.options.production
+                    || self.options.force_node_env != options::ForceNodeEnv::Unspecified
+                {
+                    jsx.development = self.options.jsx.development;
+                }
+                TSConfigParseOptions {
+                    jsx,
+                    emit_decorator_metadata: tsconfig.emit_decorator_metadata,
+                    experimental_decorators: tsconfig.experimental_decorators,
+                    use_define_for_class_fields: tsconfig
+                        .use_define_for_class_fields
+                        .unwrap_or(true),
+                }
+            }
+            None => TSConfigParseOptions {
+                jsx: self.options.jsx.clone(),
+                emit_decorator_metadata: self.options.emit_decorator_metadata,
+                experimental_decorators: self.options.experimental_decorators,
+                use_define_for_class_fields: self.options.use_define_for_class_fields,
+            },
+        }
+    }
+}
+
+/// Per-file parse settings derived from a tsconfig.json by
+/// [`Transpiler::tsconfig_parse_options`]; copied into the same-named
+/// [`ParseOptions`] fields.
+pub struct TSConfigParseOptions {
+    pub jsx: crate::options_impl::jsx::Pragma,
+    pub emit_decorator_metadata: bool,
+    pub experimental_decorators: bool,
+    pub use_define_for_class_fields: bool,
 }
 
 // ══════════════════════════════════════════════════════════════════════════
@@ -977,7 +1040,8 @@ pub struct ParseOptions<'a, 'b> {
     pub path: bun_paths::fs::Path<'static>,
     pub loader: options::Loader,
     /// `BundleOptions.jsx` — the file-backed `options_impl::jsx::Pragma`, NOT
-    /// the lib.rs shim. Callers pass `transpiler.options.jsx.clone()`.
+    /// the lib.rs shim — with the file's tsconfig.json merged in; see
+    /// [`TSConfigParseOptions`].
     pub jsx: crate::options_impl::jsx::Pragma,
     pub macro_remappings: MacroRemap,
     pub macro_js_ctx: MacroJSCtx,
@@ -985,6 +1049,7 @@ pub struct ParseOptions<'a, 'b> {
     pub replace_exports: bun_collections::StringArrayHashMap<bun_ast::runtime::ReplaceableExport>,
     pub inject_jest_globals: bool,
     pub set_breakpoint_on_first_line: bool,
+    /// These three come from the file's tsconfig.json too.
     pub emit_decorator_metadata: bool,
     pub experimental_decorators: bool,
     pub use_define_for_class_fields: bool,

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -833,14 +833,8 @@ impl<'a> Transpiler<'a> {
         Ok(())
     }
 
-    /// The tsconfig.json governing the file at `path`: the nearest one in its
-    /// directory or an ancestor, which is what the resolver applies to the file
-    /// when `bun build` bundles it. `None` when there is none, or when `path`
-    /// has no directory on disk (virtual modules).
-    ///
-    /// The directory was already walked to resolve the file, so this is a cache
-    /// lookup in practice. Runs on the JS thread: a cache miss reads the
-    /// directory through this transpiler's resolver.
+    /// The tsconfig.json nearest to `path`, as `bun build` applies it; `None` for
+    /// paths with no directory on disk. Uses the resolver, so JS thread only.
     pub fn tsconfig_for_file(&mut self, path: &[u8]) -> Option<&'static TSConfigJSON> {
         let dir = Fs::PathName::init(path).dir;
         if !bun_paths::is_absolute(dir) {
@@ -853,16 +847,14 @@ impl<'a> Transpiler<'a> {
             .enclosing_tsconfig_json
     }
 
-    /// The [`ParseOptions`] fields that tsconfig.json controls, for a file
-    /// governed by `tsconfig` (see [`Self::tsconfig_for_file`]). A file without
-    /// one gets the values `configure_linker` took from the cwd's tsconfig.
+    /// Settings for a file governed by `tsconfig` ([`Self::tsconfig_for_file`]);
+    /// without one, the cwd tsconfig values `configure_linker` put in `options`.
     pub fn tsconfig_parse_options(&self, tsconfig: Option<&TSConfigJSON>) -> TSConfigParseOptions {
         match tsconfig {
             Some(tsconfig) => {
                 let mut jsx = tsconfig.merge_jsx(self.options.jsx.clone());
-                // An explicit NODE_ENV outranks the tsconfig's "react-jsx" /
-                // "react-jsxdev" choice (`force_node_env`); `configure_defines`
-                // already settled it in `options.jsx` for the whole process.
+                // An explicit NODE_ENV (settled in `options.jsx` by `configure_defines`)
+                // outranks the tsconfig's react-jsx / react-jsxdev choice.
                 if self.options.production
                     || self.options.force_node_env != options::ForceNodeEnv::Unspecified
                 {
@@ -887,9 +879,7 @@ impl<'a> Transpiler<'a> {
     }
 }
 
-/// Per-file parse settings derived from a tsconfig.json by
-/// [`Transpiler::tsconfig_parse_options`]; copied into the same-named
-/// [`ParseOptions`] fields.
+/// The [`ParseOptions`] fields a tsconfig.json controls.
 pub struct TSConfigParseOptions {
     pub jsx: crate::options_impl::jsx::Pragma,
     pub emit_decorator_metadata: bool,
@@ -1039,9 +1029,8 @@ pub struct ParseOptions<'a, 'b> {
 
     pub path: bun_paths::fs::Path<'static>,
     pub loader: options::Loader,
-    /// `BundleOptions.jsx` — the file-backed `options_impl::jsx::Pragma`, NOT
-    /// the lib.rs shim — with the file's tsconfig.json merged in; see
-    /// [`TSConfigParseOptions`].
+    /// The file-backed `options_impl::jsx::Pragma` (NOT the lib.rs shim), with
+    /// the file's tsconfig.json merged in; see [`TSConfigParseOptions`].
     pub jsx: crate::options_impl::jsx::Pragma,
     pub macro_remappings: MacroRemap,
     pub macro_js_ctx: MacroJSCtx,
@@ -1049,7 +1038,6 @@ pub struct ParseOptions<'a, 'b> {
     pub replace_exports: bun_collections::StringArrayHashMap<bun_ast::runtime::ReplaceableExport>,
     pub inject_jest_globals: bool,
     pub set_breakpoint_on_first_line: bool,
-    /// These three come from the file's tsconfig.json too.
     pub emit_decorator_metadata: bool,
     pub experimental_decorators: bool,
     pub use_define_for_class_fields: bool,

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -22,6 +22,7 @@ use bun_js_printer::{self as js_printer, BufferPrinter, BufferWriter};
 use bun_paths;
 use bun_ptr::BackRef;
 use bun_resolve_builtins::{Alias as HardcodedAlias, Cfg as HardcodedAliasCfg};
+use bun_resolver::TSConfigJSON;
 use bun_resolver::fs as Fs;
 use bun_resolver::node_fallbacks;
 use bun_resolver::package_json::{MacroMap as MacroRemap, PackageJSON};
@@ -319,6 +320,7 @@ impl RuntimeTranspilerStore {
         referrer: String,
         loader: Loader,
         package_json: Option<&PackageJSON>,
+        tsconfig: Option<&'static TSConfigJSON>,
     ) -> *mut c_void {
         // The path text is heap-duplicated here and freed in `reset_for_pool` via
         // heap::take on `path.text`.
@@ -360,6 +362,7 @@ impl RuntimeTranspilerStore {
                 ticket: None,
                 log: bun_ast::Log::init(),
                 loader,
+                tsconfig,
                 promise: StrongOptional::create(JSValue::from_cell(promise), global_object),
                 poll_ref: KeepAlive::default(),
                 resolved_source,
@@ -406,6 +409,11 @@ pub struct TranspilerJob {
     pub(crate) non_threadsafe_input_specifier: bun_core::String,
     pub(crate) non_threadsafe_referrer: bun_core::String,
     pub(crate) loader: Loader,
+    /// The tsconfig.json governing `path` (`Transpiler::tsconfig_for_file`),
+    /// looked up on the JS thread: the worker must not touch the resolver's
+    /// directory cache through its bytewise transpiler copy. Interned for the
+    /// life of the process, so the worker reads it without synchronization.
+    pub(crate) tsconfig: Option<&'static TSConfigJSON>,
     pub(crate) promise: StrongOptional,
     // Note: struct is stored in a HiveArray and crosses to a worker thread;
     // raw pointers/BackRefs are used (BACKREF — VM owns the
@@ -786,6 +794,8 @@ impl TranspilerJob {
             _ => ModuleType::Unknown,
         };
 
+        let tsconfig_options = transpiler.tsconfig_parse_options(self.tsconfig);
+
         let mut parse_options = ParseOptions {
             arena: &arena,
             path,
@@ -798,10 +808,10 @@ impl TranspilerJob {
             file_fd_ptr: Some(unsafe { &mut *ptr::addr_of_mut!(input_file_fd) }),
             macro_remappings,
             macro_js_ctx: transpiler::default_macro_js_value(),
-            jsx: transpiler.options.jsx.clone(),
-            emit_decorator_metadata: transpiler.options.emit_decorator_metadata,
-            experimental_decorators: transpiler.options.experimental_decorators,
-            use_define_for_class_fields: transpiler.options.use_define_for_class_fields,
+            jsx: tsconfig_options.jsx,
+            emit_decorator_metadata: tsconfig_options.emit_decorator_metadata,
+            experimental_decorators: tsconfig_options.experimental_decorators,
+            use_define_for_class_fields: tsconfig_options.use_define_for_class_fields,
             virtual_source: None,
             replace_exports: Default::default(),
             dont_bundle_twice: true,

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -409,10 +409,8 @@ pub struct TranspilerJob {
     pub(crate) non_threadsafe_input_specifier: bun_core::String,
     pub(crate) non_threadsafe_referrer: bun_core::String,
     pub(crate) loader: Loader,
-    /// The tsconfig.json governing `path` (`Transpiler::tsconfig_for_file`),
-    /// looked up on the JS thread: the worker must not touch the resolver's
-    /// directory cache through its bytewise transpiler copy. Interned for the
-    /// life of the process, so the worker reads it without synchronization.
+    /// Looked up on the JS thread (the worker's transpiler copy must not use the
+    /// resolver); process-lifetime, so the worker reads it freely.
     pub(crate) tsconfig: Option<&'static TSConfigJSON>,
     pub(crate) promise: StrongOptional,
     // Note: struct is stored in a HiveArray and crosses to a worker thread;

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -409,8 +409,7 @@ pub struct TranspilerJob {
     pub(crate) non_threadsafe_input_specifier: bun_core::String,
     pub(crate) non_threadsafe_referrer: bun_core::String,
     pub(crate) loader: Loader,
-    /// Looked up on the JS thread (the worker's transpiler copy must not use the
-    /// resolver); process-lifetime, so the worker reads it freely.
+    /// Looked up on the JS thread: the worker's transpiler copy must not use the resolver.
     pub(crate) tsconfig: Option<&'static TSConfigJSON>,
     pub(crate) promise: StrongOptional,
     // Note: struct is stored in a HiveArray and crosses to a worker thread;

--- a/src/resolver/dir_info.rs
+++ b/src/resolver/dir_info.rs
@@ -109,9 +109,8 @@ pub struct DirInfo {
     // Borrows). Read sites use the `.package_json()` / `.tsconfig_json()` /
     // `.package_json_for_dependencies()` accessors.
     pub(crate) package_json_for_browser_field: Option<&'static PackageJSON>,
-    /// The tsconfig.json (or jsconfig.json) in this directory or the nearest
-    /// ancestor that has one. Per-file resolution and `bun build` apply this
-    /// one to files in the directory; `tsconfig_json` is only the directory's own.
+    /// The nearest tsconfig.json at or above this directory (`tsconfig_json` is
+    /// this directory's own).
     pub enclosing_tsconfig_json: Option<&'static TSConfigJSON>,
 
     /// package.json used for bundling

--- a/src/resolver/dir_info.rs
+++ b/src/resolver/dir_info.rs
@@ -109,8 +109,7 @@ pub struct DirInfo {
     // Borrows). Read sites use the `.package_json()` / `.tsconfig_json()` /
     // `.package_json_for_dependencies()` accessors.
     pub(crate) package_json_for_browser_field: Option<&'static PackageJSON>,
-    /// The nearest tsconfig.json at or above this directory (`tsconfig_json` is
-    /// this directory's own).
+    /// Nearest tsconfig.json at or above this directory; `tsconfig_json` is this directory's own.
     pub enclosing_tsconfig_json: Option<&'static TSConfigJSON>,
 
     /// package.json used for bundling

--- a/src/resolver/dir_info.rs
+++ b/src/resolver/dir_info.rs
@@ -109,7 +109,10 @@ pub struct DirInfo {
     // Borrows). Read sites use the `.package_json()` / `.tsconfig_json()` /
     // `.package_json_for_dependencies()` accessors.
     pub(crate) package_json_for_browser_field: Option<&'static PackageJSON>,
-    pub(crate) enclosing_tsconfig_json: Option<&'static TSConfigJSON>,
+    /// The tsconfig.json (or jsconfig.json) in this directory or the nearest
+    /// ancestor that has one. Per-file resolution and `bun build` apply this
+    /// one to files in the directory; `tsconfig_json` is only the directory's own.
+    pub enclosing_tsconfig_json: Option<&'static TSConfigJSON>,
 
     /// package.json used for bundling
     /// it's the deepest one in the hierarchy with a "name" field

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2475,6 +2475,15 @@ fn transpile_source_code_inner(
                 _ => ModuleType::Unknown,
             };
 
+            let tsconfig = match loader {
+                // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM;
+                // no borrow of `vm.transpiler` is held across this call.
+                L::Js | L::Jsx | L::Ts | L::Tsx => unsafe {
+                    (*jsc_vm).transpiler.tsconfig_for_file(path.text)
+                },
+                _ => None,
+            };
+
             let mut input_file_fd = bun_sys::Fd::INVALID;
             // The deferred fd close is independent of `give_back_arena`
             // and must fire on every exit path: parse failure, JSON early
@@ -2549,6 +2558,10 @@ fn transpile_source_code_inner(
                 use bun_ast::RuntimeTranspilerCache;
                 use bun_bundler::transpiler::{AlreadyBundled, ParseOptions, ParseResult};
                 use bun_jsc::resolved_source::Tag as ResolvedSourceTag;
+
+                // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
+                let tsconfig_options =
+                    unsafe { &(*jsc_vm).transpiler }.tsconfig_parse_options(tsconfig);
 
                 // Keep the one-shot
                 // `set_break_point_on_first_line()` last so it is only
@@ -2633,20 +2646,10 @@ fn transpile_source_code_inner(
                     // fresh `&mut` (see Note on `_fd_guard`).
                     file_fd_ptr: Some(unsafe { &mut *input_file_fd_ptr }),
                     macro_remappings,
-                    // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
-                    jsx: unsafe { &*jsc_vm }.transpiler.options.jsx.clone(),
-                    // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
-                    emit_decorator_metadata: unsafe {
-                        (*jsc_vm).transpiler.options.emit_decorator_metadata
-                    },
-                    // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
-                    experimental_decorators: unsafe {
-                        (*jsc_vm).transpiler.options.experimental_decorators
-                    },
-                    // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
-                    use_define_for_class_fields: unsafe {
-                        (*jsc_vm).transpiler.options.use_define_for_class_fields
-                    },
+                    jsx: tsconfig_options.jsx,
+                    emit_decorator_metadata: tsconfig_options.emit_decorator_metadata,
+                    experimental_decorators: tsconfig_options.experimental_decorators,
+                    use_define_for_class_fields: tsconfig_options.use_define_for_class_fields,
                     virtual_source,
                     dont_bundle_twice: true,
                     allow_commonjs: true,
@@ -4327,6 +4330,10 @@ pub unsafe extern "C" fn Bun__transpileFile(
                 }
             }
 
+            // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM and
+            // nothing borrows `vm.transpiler` across this call.
+            let tsconfig = unsafe { (*jsc_vm).transpiler.tsconfig_for_file(lr.path.text) };
+
             // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
             // `lr.path` borrows `_specifier`, which the store immediately
             // heap-duplicates inside `transpile()`.
@@ -4339,6 +4346,7 @@ pub unsafe extern "C" fn Bun__transpileFile(
                     referrer.clone(),
                     concurrent_loader,
                     lr.package_json,
+                    tsconfig,
                 )
             };
         }

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
+import path from "node:path";
 
 // ES standard decorators are used for .js files (always) and for .ts files
 // when experimentalDecorators is NOT set in tsconfig.
@@ -677,6 +678,81 @@ describe("ES Decorators", () => {
       expect(filterStderr(rawStderr)).toBe("");
       expect(stdout).toBe("class Foo\n");
       expect(exitCode).toBe(0);
+    });
+
+    // The mode of each file is decided by the tsconfig.json nearest to that
+    // file, not by the one in the directory bun was launched from. This is what
+    // tsc and `bun build` do; in a monorepo the packages commonly disagree.
+    describe("per-file tsconfig", () => {
+      // Reports how many arguments the method decorator received (legacy: 3,
+      // standard: 2) and which design:* metadata keys were emitted.
+      const probe = `
+        let arity = 0;
+        const metadata: string[] = [];
+        (Reflect as any).metadata = (key: string) => (metadata.push(key), () => {});
+        function dec(...args: unknown[]) {
+          arity = args.length;
+        }
+        class Foo {
+          @dec
+          method(a: string) {}
+        }
+        export const result = { arity, metadata };
+      `;
+      const designKeys = ["design:type", "design:paramtypes", "design:returntype"];
+      const expected = {
+        legacy: { arity: 3, metadata: [] },
+        standard: { arity: 2, metadata: [] },
+        inherited: { arity: 3, metadata: designKeys },
+      };
+      const files = {
+        "tsconfig.json": JSON.stringify({
+          compilerOptions: { experimentalDecorators: true, emitDecoratorMetadata: true },
+        }),
+        "packages/legacy/tsconfig.json": JSON.stringify({ compilerOptions: { experimentalDecorators: true } }),
+        "packages/legacy/index.ts": probe,
+        "packages/standard/tsconfig.json": JSON.stringify({ compilerOptions: {} }),
+        "packages/standard/index.ts": probe,
+        // No tsconfig of its own: governed by the root one.
+        "packages/inherited/index.ts": probe,
+        "static.ts": `
+          import { result as legacy } from "./packages/legacy/index.ts";
+          import { result as standard } from "./packages/standard/index.ts";
+          import { result as inherited } from "./packages/inherited/index.ts";
+          console.log(JSON.stringify({ legacy, standard, inherited }));
+        `,
+        // Modules imported after startup are transpiled on the thread pool,
+        // which is a separate code path from the entry point's static imports.
+        "dynamic.ts": `
+          await Promise.resolve();
+          const [legacy, standard, inherited] = await Promise.all(
+            ["legacy", "standard", "inherited"].map(async name => (await import("./packages/" + name + "/index.ts")).result),
+          );
+          console.log(JSON.stringify({ legacy, standard, inherited }));
+        `,
+      };
+
+      for (const entry of ["static.ts", "dynamic.ts"]) {
+        for (const cwd of [".", "packages/legacy", "packages/standard", "packages/inherited"]) {
+          test.concurrent(`${entry} run from ${cwd}`, async () => {
+            using dir = tempDir("es-dec-per-file-tsconfig", files);
+            await using proc = Bun.spawn({
+              cmd: [bunExe(), path.join(String(dir), entry)],
+              env: bunEnv,
+              cwd: path.join(String(dir), cwd),
+              stderr: "pipe",
+            });
+            const [stdout, rawStderr, exitCode] = await Promise.all([
+              proc.stdout.text(),
+              proc.stderr.text(),
+              proc.exited,
+            ]);
+            expect(filterStderr(rawStderr)).toBe("");
+            expect(JSON.parse(stdout)).toEqual(expected);
+            expect(exitCode).toBe(0);
+          });
+        }
+      }
     });
   });
 

--- a/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
+++ b/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
@@ -154,4 +154,61 @@ describe("tsconfig compilerOptions.jsx", () => {
     const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
     expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "prod jsx", exitCode: 0 });
   });
+
+  // A jsx field the nearest tsconfig leaves unset is filled from the same base
+  // pragma `bun build` seeds its per-file settings from (today: the cwd's
+  // tsconfig folded into the process-wide options). Only agreement between the
+  // two is asserted, so the base itself can change without touching this test.
+  test("a jsx field the nearest tsconfig leaves unset resolves like bun build", async () => {
+    const jsxRuntimePackage = (name: string) => ({
+      [`node_modules/${name}/package.json`]: JSON.stringify({
+        name,
+        version: "1.0.0",
+        type: "module",
+        exports: { "./jsx-runtime": "./rt.js", "./jsx-dev-runtime": "./rt.js" },
+      }),
+      [`node_modules/${name}/rt.js`]: `
+        export const Fragment = Symbol.for("F");
+        export const jsx = () => (console.log(${JSON.stringify(name)}), {});
+        export const jsxs = jsx;
+        export const jsxDEV = jsx;
+      `,
+    });
+    using dir = tempDir("jsx-tsconfig-merge-base", {
+      ...jsxRuntimePackage("react"),
+      ...jsxRuntimePackage("root-runtime"),
+      "tsconfig.json": JSON.stringify({ compilerOptions: { jsx: "react-jsx", jsxImportSource: "root-runtime" } }),
+      // Sets jsx but not jsxImportSource, and does not extend the root.
+      "app/tsconfig.json": JSON.stringify({ compilerOptions: { jsx: "react-jsx" } }),
+      "app/m.jsx": `export const el = <div />;`,
+    });
+
+    await using run = Bun.spawn({
+      cmd: [bunExe(), "run", "app/m.jsx"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    await using build = Bun.spawn({
+      cmd: [bunExe(), "build", "app/m.jsx", "--external", "react/*", "--external", "root-runtime/*"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const [runStdout, runExitCode, buildStdout, buildExitCode] = await Promise.all([
+      run.stdout.text(),
+      run.exited,
+      build.stdout.text(),
+      build.exited,
+    ]);
+    const buildImportSource = buildStdout.match(/from "([^"]+)\/jsx(?:-dev)?-runtime"/)?.[1];
+    expect(["react", "root-runtime"]).toContain(buildImportSource);
+    expect({ runtimeImportSource: runStdout.trim(), runExitCode, buildExitCode }).toEqual({
+      runtimeImportSource: buildImportSource!,
+      runExitCode: 0,
+      buildExitCode: 0,
+    });
+  });
 });

--- a/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
+++ b/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
@@ -131,4 +131,27 @@ describe("tsconfig compilerOptions.jsx", () => {
     const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
     expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: runStdout, exitCode: 0 });
   });
+
+  // https://github.com/oven-sh/bun/issues/28605: a workspace root with no
+  // tsconfig at all used to make every file fall back to importing from "react".
+  test("jsxImportSource of a package's tsconfig applies when run from a workspace root without one", async () => {
+    using dir = tempDir("jsx-tsconfig-workspace-root", {
+      ...shimFiles,
+      "package.json": JSON.stringify({ private: true, workspaces: ["services/connect"] }),
+      "services/connect/tsconfig.json": JSON.stringify({
+        compilerOptions: { jsx: "react-jsx", jsxImportSource: "shim" },
+      }),
+      "services/connect/src/app.ts": `import "./lib/prompt.tsx";`,
+      "services/connect/src/lib/prompt.tsx": `export const prompt = <div>hello</div>;`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "./services/connect/src/app.ts"],
+      env: { ...bunEnv, NODE_ENV: undefined, BUN_ENV: undefined },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "prod jsx", exitCode: 0 });
+  });
 });

--- a/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
+++ b/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
@@ -68,4 +68,67 @@ describe("tsconfig compilerOptions.jsx", () => {
       expect(exitCode).toBe(0);
     }
   });
+
+  test("the tsconfig nearest to the file applies, not the cwd's", async () => {
+    using dir = tempDir("jsx-tsconfig-nearest", {
+      "tsconfig.json": JSON.stringify({ compilerOptions: { jsx: "react", jsxFactory: "rootFactory" } }),
+      "app/tsconfig.json": JSON.stringify({ compilerOptions: { jsx: "react", jsxFactory: "appFactory" } }),
+      "app/m.tsx": `
+        const rootFactory = (tag: string) => "root:" + tag;
+        const appFactory = (tag: string) => "app:" + tag;
+        console.log(<div />);
+      `,
+    });
+
+    // bun run
+    {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "run", "app/m.tsx"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "inherit",
+      });
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "app:div", exitCode: 0 });
+    }
+
+    // bun build, which already picked the file's own tsconfig
+    {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build", "app/m.tsx"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "inherit",
+      });
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      expect(stdout).toContain('appFactory("div"');
+      expect(exitCode).toBe(0);
+    }
+  });
+
+  // The file's own tsconfig picks dev vs. production too, except that an
+  // explicit NODE_ENV still outranks every tsconfig (react's production
+  // jsx-dev-runtime exports no jsxDEV, so NODE_ENV=production must never emit it).
+  test.each([
+    [{}, "dev jsxDEV"],
+    [{ NODE_ENV: "production" }, "prod jsx"],
+  ])('nested "react-jsxdev" under a "react-jsx" cwd with env %o', async (env, runStdout) => {
+    using dir = tempDir("jsx-tsconfig-nearest-dev", {
+      ...shimFiles,
+      "tsconfig.json": JSON.stringify({ compilerOptions: { jsx: "react-jsx", jsxImportSource: "shim" } }),
+      "app/tsconfig.json": JSON.stringify({ compilerOptions: { jsx: "react-jsxdev", jsxImportSource: "shim" } }),
+      "app/m.jsx": shimFiles["m.jsx"],
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "app/m.jsx"],
+      env: { ...bunEnv, NODE_ENV: undefined, BUN_ENV: undefined, ...env },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: runStdout, exitCode: 0 });
+  });
 });

--- a/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
+++ b/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
+import path from "node:path";
 
 // tsconfig "jsx": "react-jsx" selects the production automatic runtime (jsx/jsxs),
 // "react-jsxdev" selects the development runtime (jsxDEV), matching TypeScript/esbuild.
@@ -209,6 +210,93 @@ describe("tsconfig compilerOptions.jsx", () => {
       runtimeImportSource: buildImportSource!,
       runExitCode: 0,
       buildExitCode: 0,
+    });
+  });
+
+  // Two packages with their own tsconfig, each with a `paths` alias and a
+  // jsxImportSource, one importing the other. `paths` was already resolved per
+  // file; jsxImportSource has to be too, so both markers agree with `bun build`
+  // from any cwd, including one that has no tsconfig of its own but whose
+  // parent does (packages/a/src).
+  describe("cross-package matrix", () => {
+    const runtime = (name: string) => ({
+      [`node_modules/${name}/package.json`]: JSON.stringify({
+        name,
+        version: "1.0.0",
+        type: "module",
+        exports: { "./jsx-runtime": "./rt.js", "./jsx-dev-runtime": "./rt.js" },
+      }),
+      [`node_modules/${name}/rt.js`]: `
+        export const Fragment = Symbol.for("F");
+        export const jsx = () => ${JSON.stringify(name)};
+        export const jsxs = jsx;
+        export const jsxDEV = jsx;
+      `,
+    });
+    const tsconfig = (jsxImportSource: string, pathsDir: string) =>
+      JSON.stringify({
+        compilerOptions: { jsx: "react-jsx", jsxImportSource, baseUrl: ".", paths: { "@m/*": [`${pathsDir}/*`] } },
+      });
+    const files = {
+      ...runtime("react"),
+      ...runtime("jsxA"),
+      ...runtime("jsxB"),
+      "tsconfig.json": tsconfig("react", "rootm"),
+      "rootm/x.ts": `export default "rootm";`,
+      "packages/a/tsconfig.json": tsconfig("jsxA", "am"),
+      "packages/a/am/x.ts": `export default "am";`,
+      "packages/a/src/x.tsx": `
+        import m from "@m/x";
+        import { y } from "../../b/src/y.tsx";
+        console.log(JSON.stringify({ a: { paths: m, jsx: <i /> }, b: y }));
+      `,
+      "packages/b/tsconfig.json": tsconfig("jsxB", "bm"),
+      "packages/b/bm/x.ts": `export default "bm";`,
+      "packages/b/src/y.tsx": `
+        import m from "@m/x";
+        export const y = { paths: m, jsx: <i /> };
+      `,
+    };
+    const expected = { a: { paths: "am", jsx: "jsxA" }, b: { paths: "bm", jsx: "jsxB" } };
+
+    test.concurrent.each([".", "packages/a", "packages/b", "packages/a/src"])("bun run from %s", async cwd => {
+      using dir = tempDir("jsx-tsconfig-matrix", files);
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "run", path.join(String(dir), "packages/a/src/x.tsx")],
+        env: bunEnv,
+        cwd: path.join(String(dir), cwd),
+        stdout: "pipe",
+        stderr: "inherit",
+      });
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      expect({ out: JSON.parse(stdout), exitCode }).toEqual({ out: expected, exitCode: 0 });
+    });
+
+    test.concurrent("bun build agrees", async () => {
+      using dir = tempDir("jsx-tsconfig-matrix-build", files);
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "build",
+          "packages/a/src/x.tsx",
+          "--external",
+          "react/*",
+          "--external",
+          "jsxA/*",
+          "--external",
+          "jsxB/*",
+        ],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "inherit",
+      });
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      expect({
+        importSources: [...stdout.matchAll(/from "(\w+)\/jsx-runtime"/g)].map(m => m[1]).sort(),
+        pathsMarkers: [...stdout.matchAll(/"(rootm|am|bm)"/g)].map(m => m[1]).sort(),
+        exitCode,
+      }).toEqual({ importSources: ["jsxA", "jsxB"], pathsMarkers: ["am", "bm"], exitCode: 0 });
     });
   });
 });

--- a/test/bundler/transpiler/ts-use-define-for-class-fields.test.ts
+++ b/test/bundler/transpiler/ts-use-define-for-class-fields.test.ts
@@ -229,6 +229,24 @@ describe("tsconfig compilerOptions.useDefineForClassFields", () => {
     expect(exitCode).toBe(0);
   });
 
+  test.concurrent("comes from the tsconfig nearest to the file, not the cwd's", async () => {
+    using dir = tempDir("udfcf-nearest", {
+      "tsconfig.json": JSON.stringify({ compilerOptions: {} }),
+      "lib/tsconfig.json": JSON.stringify({ compilerOptions: { useDefineForClassFields: false } }),
+      // [[Define]] semantics would re-declare x as undefined; under
+      // useDefineForClassFields: false the bare declaration is dropped.
+      "lib/index.ts": `
+        class Base { x = 1; }
+        class Derived extends Base { x; }
+        console.log(new Derived().x);
+      `,
+    });
+    const { stdout, stderr, exitCode } = await run(String(dir), "lib/index.ts");
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("1");
+    expect(exitCode).toBe(0);
+  });
+
   test.concurrent("false: Bun.Transpiler honors the option", async () => {
     const t = new Bun.Transpiler({
       loader: "ts",


### PR DESCRIPTION
Fixes #28605

### Problem
- `bun run` transpiles every file with the `compilerOptions` of the tsconfig.json sitting in the cwd. The same `proj/sub/a.ts` gets legacy `(target, key, descriptor)` decorators when run from `proj/` and TC39 `(value, context)` decorators when run from `proj/sub/` or from above `proj/` (repro below). `emitDecoratorMetadata`, `useDefineForClassFields` and the `jsx*` settings flip the same way.
- `bun build`, tsc and editors apply the tsconfig.json nearest to each file, so in a monorepo `bun run` both disagrees with `bun build` of the same file and gives every package the config of whichever package you happen to be in. #28605 is the `jsxImportSource` form of this (workspace root without a tsconfig, so every package's `.tsx` falls back to `react/jsx-dev-runtime`); #28606 fixed it the same way against the Zig sources and was closed when those were removed.
- Cause: `configure_linker_with_auto_jsx` (`src/bundler/transpiler.rs:700`) copies the cwd tsconfig into `transpiler.options`, and both runtime parse sites read those process-wide values for every module: `src/runtime/jsc_hooks.rs:2719` (entry point, `require()`, static imports) and `src/jsc/RuntimeTranspilerStore.rs:852` (imports transpiled on the thread pool). The bundler instead uses the per-file `ResolveResult` flags that `Resolver::finalize_result` (`src/resolver/resolver.rs:1644`) fills from `DirInfo.enclosing_tsconfig_json`.

### Fix
- `Transpiler::tsconfig_for_file` returns the file's `enclosing_tsconfig_json` from the resolver's `DirInfo` cache (the directory was already walked to resolve the file, so this is a cache hit; it runs on the JS thread, and the thread-pool job carries the interned pointer because the worker's bytewise transpiler copy must not touch the resolver).
- `Transpiler::tsconfig_parse_options` derives the four tsconfig-controlled `ParseOptions` fields from that tsconfig exactly as `finalize_result` and `Bun.Transpiler({ tsconfig })` already do: decorator flags straight from it, `useDefineForClassFields` defaulting to true, `jsx` merged over the process-wide pragma (`options.jsx`, the same base `bun build` seeds `resolver.opts.jsx` from, so a field a nested tsconfig leaves unset comes out the same in both; that base currently includes the cwd tsconfig in both tools, which is a separate, pre-existing question, see the review thread). A file with no enclosing tsconfig (and virtual modules) keeps getting the cwd-derived values, so nothing changes for them.
- Dev vs production JSX runtime: after the merge, an explicit `NODE_ENV` (`options.production` / `force_node_env`) still wins over a tsconfig's `react-jsx` / `react-jsxdev`, which is the precedence `Pragma::development` documents and the bundler applies per parse task (`bundle_v2.rs:2663`). Without it, `NODE_ENV=production` plus a nested `react-jsxdev` tsconfig emits `jsxDEV`, which react's production `jsx-dev-runtime` exports as `undefined` (caught by the existing `jsx-production.test.ts`).
- The runtime transpiler cache already hashes all four settings (`hash_for_runtime_transpiler`), so byte-identical files under different tsconfigs transpile differently; verified with the on-disk cache enabled.
- `DirInfo.enclosing_tsconfig_json` becomes `pub`, like its sibling `enclosing_package_json`, which the module loader already reads.
- Also makes `--tsconfig-override` apply to on-disk files, since the resolver attaches the override as every directory's enclosing tsconfig; #38584 fixes the same flag through the cwd path and is complementary.
- Tests (each fails on bun 1.4.0, passes with this change, except the two guards noted):
  - `test/bundler/transpiler/es-decorators.test.ts` "per-file tsconfig": three identical modules under different tsconfigs (own legacy, own empty, inherited root with metadata), loaded both by static import and by `import()` after startup (the thread-pool path), run from four cwds, must all print the same result.
  - `test/bundler/transpiler/ts-use-define-for-class-fields.test.ts`: nested `useDefineForClassFields: false` applied from the parent cwd.
  - `test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts`: nested `jsxFactory` (run and build agree), nested `react-jsxdev` under a `react-jsx` cwd, the same with `NODE_ENV=production` still selecting the production runtime (guard: also passes on 1.4.0), the #28605 layout (package tsconfig with `jsxImportSource`, run from a workspace root that has no tsconfig; 1.4.0 fails it with the issue's exact error), and a guard that a jsx field the nearest tsconfig leaves unset resolves to the same import source in `bun run` and `bun build`, whatever the shared base is. Also a cross-package matrix: two packages with their own `paths` alias and `jsxImportSource`, one importing the other, run from four cwds (repo root, each package, and a `src/` dir that has no tsconfig of its own but whose parent does) and compared with `bun build`. On 1.4.x `paths` is already per file while `jsxImportSource` follows the cwd, so every cwd prints a different pair; with this change all four match `bun build` (`am/jsxA`, `bm/jsxB`).
- Also ran with this change: `decorators`, `decorator-metadata`, `es-decorators-esbuild`, `jsx-production`, `test/cli/run/tsconfig-override.test.ts`, `test/cli/test/bun-test.test.ts -t tsconfig`, `test/regression/issue/27526`, `27575`, `test/js/bun/resolve/*` (resolve, resolve-ts, require, esModule, import-meta, custom conditions, tsconfig-extends-leak), `test/js/bun/plugin/*`, `run-eval`, `preload-test`, `run-cjs`, `run-extensionless`, `env`, `type-export`: all pass. `cargo fmt` and `cargo clippy` on the four touched crates are clean.
- Note for the repo's own suite: test files now get `test/tsconfig.json` (which extends `tsconfig.base.json`: same decorator flags as the root tsconfig, plus `jsx: react-jsx`) instead of the root `tsconfig.json`. The only in-tree fixtures whose transform this changes are the `jsx-production` ones, which pass.

### Background
- `DirInfo` is the resolver's cached record for one directory. `tsconfig_json` is the tsconfig found in that directory itself; `enclosing_tsconfig_json` is the nearest one at or above it, copied down when a child directory is first read (`dir_info_uncached`). Per-file `paths` resolution at runtime and the bundler both already use the enclosing one; only the runtime's transpile settings used the cwd's own.
- The runtime has two parse sites. `transpile_source_code_inner` (jsc_hooks.rs) runs synchronously on the JS thread for the entry point, `require()` and imports made before startup finishes. `RuntimeTranspilerStore` transpiles later imports on the work pool: `transpile()` creates a job on the JS thread, and `run()` on a worker parses using a bytewise copy of the VM's `Transpiler`, whose resolver caches are not safe to use from there, hence the lookup happens at job creation.
- `TSConfigJSON` objects are interned for the life of the process (only the intermediate configs of an `extends` chain are freed), which is why `DirInfo` holds them as `&'static` and the job can carry one across threads.
- `force_node_env` / `set_production` record an explicit `NODE_ENV=development` / `production`; `configure_defines` folds that into `options.jsx.development` at startup. When neither was given, tsconfig's `react-jsx` (production `jsx`) vs `react-jsxdev` (`jsxDEV`) decides.

<details>
<summary>Repro</summary>

```sh
mkdir -p proj/sub && cd proj
echo '{ "compilerOptions": { "experimentalDecorators": true } }' > tsconfig.json
cat > sub/a.ts <<'EOF'
function d(...a: any[]) { (globalThis as any).ar = a.length }
class C { @d m() {} }
console.log((globalThis as any).ar === 3 ? "legacy" : "standard");
EOF

bun run sub/a.ts          # legacy
(cd sub && bun run a.ts)  # standard   (before: cwd has no tsconfig of its own)
(cd .. && bun run proj/sub/a.ts)   # standard   (before)
bun build sub/a.ts | grep __legacyDecorateClassTS   # the bundler applies proj/tsconfig.json from any cwd
```

With this change all three `bun run` invocations print `legacy`. The `Internal error: directory mismatch` line `--tsconfig-override` prints on stderr is #34980, and `experimentalDecorators` set in a tsconfig that `extends` another is lost in the extends merge independently of this (fixed in #34496).
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 12 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/es-decorators.test.ts test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts test/bundler/transpiler/ts-use-define-for-class-fields.test.ts
bun test v1.4.1 (4448a2e21)

test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts:
(pass) tsconfig compilerOptions.jsx > "react-jsx" selects the matching automatic runtime [668.00ms]
(pass) tsconfig compilerOptions.jsx > "react-jsxdev" selects the matching automatic runtime [592.06ms]
88 |         cwd: String(dir),
89 |         stdout: "pipe",
90 |         stderr: "inherit",
91 |       });
92 |       const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
93 |       expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "app:div", exitCode: 0 });
                                                       ^
error: expect(received).toEqual(expected)

  {
    "exitCode": 0,
-   "stdout": "app:div",
+   "stdout": "root:div",
  }

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/bundler/transpiler/jsx-tsconfig-react-jsx.test
... (truncated)

release without fix: 12 FAILED
bun test v1.4.0-canary.1 (4448a2e21)

test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts:
(pass) tsconfig compilerOptions.jsx > "react-jsx" selects the matching automatic runtime [16.33ms]
(pass) tsconfig compilerOptions.jsx > "react-jsxdev" selects the matching automatic runtime [13.25ms]
88 |         cwd: String(dir),
89 |         stdout: "pipe",
90 |         stderr: "inherit",
91 |       });
92 |       const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
93 |       expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "app:div", exitCode: 0 });
                                                       ^
error: expect(received).toEqual(expected)

  {
    "exitCode": 0,
-   "stdout": "app:div",
+   "stdout": "root:div",
  }

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts:93:51)
(fail) tsconfig compilerOptions.jsx > the tsconfig nearest to the file applies, not the cwd's [7.13ms]
127 |       cwd: String(dir),
128 |       stdout: "pipe",
129 |       stderr: "inherit",
130 |     });
131 |     const [stdout, exitCode] = await Promise.all([proc.stdout.text(
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/es-decorators.test.ts test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts test/bundler/transpiler/ts-use-define-for-class-fields.test.ts
bun test v1.4.1 (4448a2e21)

test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts:
(pass) tsconfig compilerOptions.jsx > "react-jsx" selects the matching automatic runtime [647.04ms]
(pass) tsconfig compilerOptions.jsx > "react-jsxdev" selects the matching automatic runtime [636.45ms]
(pass) tsconfig compilerOptions.jsx > the tsconfig nearest to the file applies, not the cwd's [609.75ms]
(pass) tsconfig compilerOptions.jsx > nested "react-jsxdev" under a "react-jsx" cwd with env {} [291.85ms]
(pass) tsconfig compilerOptions.jsx > nested "react-jsxdev" under a "react-jsx" cwd with env {"NODE_ENV":"production"} [283.56ms]
(pass) tsconfig compilerOptions.jsx > jsxImportSource of a package's tsconfig applies when run from a workspace root without one [299.98ms]
(pass) tsconfig compilerOptions.jsx > a jsx field the nearest tsconfig leaves unset resolves like bun build [307.05ms
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 740ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 120 exports (host=5, lazy=10, generic=105, rust=0); 243 extern-C blocks audited
[1/6] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

^[[1m^[[92m   Compiling^[[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
^[[1m^[[92m   Compiling^[[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
^[[1m^[[92m   Compiling^[[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
^[[1m^[[92m   Compiling^[[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
^[[1m^[[92m   Compiling^[[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
^[[1m^[[92m   Compiling^[[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
^[[1m^[[92m   Compiling^[[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
^[[1m^[[92m   Compiling^[[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
^[[1m^[[92m   Compiling^[[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
^[[1m^[[92m   Compiling^[[0m bun_pic
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/transpiler.rs                          |  51 +++++++-
 src/jsc/RuntimeTranspilerStore.rs                  |  15 ++-
 src/resolver/dir_info.rs                           |   3 +-
 src/runtime/jsc_hooks.rs                           |  36 ++++--
 test/bundler/transpiler/es-decorators.test.ts      |  76 +++++++++++
 .../transpiler/jsx-tsconfig-react-jsx.test.ts      | 143 +++++++++++++++++++++
 .../ts-use-define-for-class-fields.test.ts         |  18 +++
 7 files changed, 321 insertions(+), 21 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/bundler/transpiler.rs                                    11     16      0
src/jsc/RuntimeTranspilerStore.rs                             7      9      0
src/resolver/dir_info.rs                                      3      3      0
src/runtime/jsc_hooks.rs                                     10      9      0
test/bundler/transpiler/es-decorators.test.ts                 1      2      0
test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts        4      5      0
…ndler/transpiler/ts-use-define-for-class-fields.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->

