### PR TITLE
lexer: keep whitespace in JSX attribute strings that contain an ampersand or non-ASCII

### DIFF
--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -2991,8 +2991,6 @@ lexer_impl_header! {
             debug_assert!(self.temp_buffer_u16.is_empty());
             let mut tmp = core::mem::take(&mut self.temp_buffer_u16);
             tmp.reserve(raw_content_slice.len());
-            // Attribute strings keep their whitespace verbatim; only JSX children
-            // text (next_jsx_element_child) gets the line trimming/joining.
             let res = self.decode_jsx_entities(raw_content_slice, &mut tmp);
             if let Err(e) = res {
                 tmp.clear();

--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -2991,8 +2991,9 @@ lexer_impl_header! {
             debug_assert!(self.temp_buffer_u16.is_empty());
             let mut tmp = core::mem::take(&mut self.temp_buffer_u16);
             tmp.reserve(raw_content_slice.len());
-            let res = self
-                .fix_whitespace_and_decode_jsx_entities(raw_content_slice, &mut tmp);
+            // Attribute strings keep their whitespace verbatim; only JSX children
+            // text (next_jsx_element_child) gets the line trimming/joining.
+            let res = self.decode_jsx_entities(raw_content_slice, &mut tmp);
             if let Err(e) = res {
                 tmp.clear();
                 self.temp_buffer_u16 = tmp;

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2531,12 +2531,13 @@ console.log(<div {...obj} key="after" />);`),
   });
 
   // A JSX attribute string keeps its whitespace verbatim and only has its
-  // entities decoded (esbuild, Babel and TypeScript all agree). Only JSX
-  // children text gets its lines trimmed and joined with a single space.
-  // The lexer's slow path for attribute strings, taken when the string
-  // contains an entity or a non-ASCII character, used to apply the children
-  // rules, so `title="a&amp;\n b"` became "a& b" while `title="a\n b"` was
-  // kept as is.
+  // entities decoded, as in esbuild and TypeScript. (Babel differs: it turns a
+  // newline plus indentation inside an attribute into one space. Bun follows
+  // esbuild here, and its fast path always has.) Only JSX children text gets
+  // its lines trimmed and joined with a single space. The lexer's slow path for
+  // attribute strings, taken when the string contains an `&`, a non-ASCII
+  // character or a `\u`, used to apply the children rules, so
+  // `title="a&amp;\n b"` became "a& b" while `title="a\n b"` was kept as is.
   describe("JSX attribute strings keep their whitespace when they need decoding", () => {
     const bun = new Bun.Transpiler({
       loader: "jsx",
@@ -2562,14 +2563,17 @@ console.log(<div {...obj} key="after" />);`),
       ["whitespace-only lines", `<p title="&amp;\n   \n"/>`, "&\n   \n"],
       ["leading and trailing whitespace", `<p title="  &amp; \n "/>`, "  & \n "],
       ["numeric entity", `<p title="&#65;\n\tb"/>`, "A\n\tb"],
+      // Any `&` takes the slow path, not only ones that turn out to be entities.
+      ["ampersand that is not an entity", `<a title="?a=1&b=2\n  x"/>`, "?a=1&b=2\n  x"],
+      ["ampersand with a `;` on a later line", `<p title="Tom &\n Jerry; friends"/>`, "Tom &\n Jerry; friends"],
       // Non-ASCII characters that the children rules themselves treat as
       // whitespace or as line breaks.
       ["no-break spaces", `<p title="1\n\u00a0\u00a0z"/>`, "1\n\u00a0\u00a0z"],
       ["U+2028", `<p title="p\u2028q"/>`, "p\u2028q"],
       ["U+2029", `<p title="p\u2029q"/>`, "p\u2029q"],
       // JSX strings have no escapes; a `\u` is kept literally, but it is the
-      // third thing (besides entities and non-ASCII) that sends the lexer
-      // down the decoding path.
+      // third thing (besides `&` and non-ASCII) that sends the lexer down the
+      // decoding path.
       ["backslash u", `<p title="\\u0041\n   b"/>`, "\\u0041\n   b"],
     ])("%s", (_, element, title) => {
       expect(propsOf(element)).toEqual({ title });

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2562,6 +2562,11 @@ console.log(<div {...obj} key="after" />);`),
       ["whitespace-only lines", `<p title="&amp;\n   \n"/>`, "&\n   \n"],
       ["leading and trailing whitespace", `<p title="  &amp; \n "/>`, "  & \n "],
       ["numeric entity", `<p title="&#65;\n\tb"/>`, "A\n\tb"],
+      // Non-ASCII characters that the children rules themselves treat as
+      // whitespace or as line breaks.
+      ["no-break spaces", `<p title="1\n\u00a0\u00a0z"/>`, "1\n\u00a0\u00a0z"],
+      ["U+2028", `<p title="p\u2028q"/>`, "p\u2028q"],
+      ["U+2029", `<p title="p\u2029q"/>`, "p\u2029q"],
       // JSX strings have no escapes; a `\u` is kept literally, but it is the
       // third thing (besides entities and non-ASCII) that sends the lexer
       // down the decoding path.

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2530,6 +2530,52 @@ console.log(<div {...obj} key="after" />);`),
     });
   });
 
+  // A JSX attribute string keeps its whitespace verbatim and only has its
+  // entities decoded (esbuild, Babel and TypeScript all agree). Only JSX
+  // children text gets its lines trimmed and joined with a single space.
+  // The lexer's slow path for attribute strings, taken when the string
+  // contains an entity or a non-ASCII character, used to apply the children
+  // rules, so `title="a&amp;\n b"` became "a& b" while `title="a\n b"` was
+  // kept as is.
+  describe("JSX attribute strings keep their whitespace when they need decoding", () => {
+    const bun = new Bun.Transpiler({
+      loader: "jsx",
+      define: { "process.env.NODE_ENV": JSON.stringify("development") },
+    });
+
+    // Evaluates the transpiled element with a stand-in jsxDEV that returns the
+    // props, so the assertions are about the runtime string values and not
+    // about which quotes the printer picked.
+    function propsOf(element) {
+      const code = bun.transformSync(`export default ${element};`);
+      expect(code).toStartWith("export default jsxDEV_7x81h0kn(");
+      const expression = code.slice("export default ".length);
+      return new Function("jsxDEV_7x81h0kn", `return ${expression}`)((type, props) => props);
+    }
+
+    it.each([
+      ["plain ASCII (fast path)", `<p title="a\n   b  \n c"/>`, "a\n   b  \n c"],
+      ["entity", `<p title="a&amp;\n   b  \n c"/>`, "a&\n   b  \n c"],
+      ["non-ASCII", `<p title="é\n   b  \n c"/>`, "é\n   b  \n c"],
+      ["single quotes", `<p title='a&amp;\n   b  \n c'/>`, "a&\n   b  \n c"],
+      ["CRLF", `<p title="a&amp;\r\n  b"/>`, "a&\r\n  b"],
+      ["whitespace-only lines", `<p title="&amp;\n   \n"/>`, "&\n   \n"],
+      ["leading and trailing whitespace", `<p title="  &amp; \n "/>`, "  & \n "],
+      ["numeric entity", `<p title="&#65;\n\tb"/>`, "A\n\tb"],
+      // JSX strings have no escapes; a `\u` is kept literally, but it is the
+      // third thing (besides entities and non-ASCII) that sends the lexer
+      // down the decoding path.
+      ["backslash u", `<p title="\\u0041\n   b"/>`, "\\u0041\n   b"],
+    ])("%s", (_, element, title) => {
+      expect(propsOf(element)).toEqual({ title });
+    });
+
+    it("children text still collapses whitespace", () => {
+      expect(propsOf(`<p>a&amp;\n   b  \n c</p>`)).toEqual({ children: "a& b c" });
+      expect(propsOf(`<p>é\n   b  \n c</p>`)).toEqual({ children: "é b c" });
+    });
+  });
+
   it("require with a dynamic non-string expression", () => {
     var nodeTranspiler = new Bun.Transpiler({ platform: "node" });
     expect(nodeTranspiler.transformSync("require('hi' + bar)")).toBe('require("hi" + bar);\n');


### PR DESCRIPTION
### Problem
- A JSX attribute string loses its newlines and per-line whitespace as soon as it contains an `&` (entity or not), a non-ASCII character, or a `\u`: `<p title="a&amp;\n   b  \n c"/>` transpiles to `title: "a& b c"`, and `href="?a=1&b=2\n  x"` to `"?a=1&b=2 x"`.
- The same attribute without one of those (`title="a\n   b  \n c"`) is kept verbatim, so the value a user gets depends on whether the string also happened to contain an `&` or an `é`.
- Cause: `parse_jsx_string_literal` in `src/js_parser/lexer.rs` (the `needs_decode` slow path, line 2994 on main) calls `fix_whitespace_and_decode_jsx_entities`, which is the children-text routine: it drops whitespace-only lines, trims the others and joins them with a single space. Attribute strings only need `decode_jsx_entities`.
- Regression from #15009 (bun v1.1.35): before that refactor the attribute path called `decodeJSXEntities`; the refactor switched it to the children routine while changing how the lexer stores decoded strings.

### Fix
- `parse_jsx_string_literal` calls `decode_jsx_entities` on its slow path. `next_jsx_element_child` (children text) still uses `fix_whitespace_and_decode_jsx_entities`, so child text is still collapsed.
- Why this is the right behavior: the trim-and-join rule is a JSX children rule; an attribute value is an ordinary string whose only JSX-specific processing is entity decoding. Bun's JSX lexer is a port of esbuild's, which uses `decodeJSXEntities` for attribute strings and the whitespace-fixing variant only for children; TypeScript keeps attribute strings verbatim as well. Bun's own fast path (attribute strings with none of the three triggers) has always kept them verbatim, and the slow path did too before v1.1.35, so this makes the two paths agree again. The collapsed output matched no tool: Babel does collapse newline+indentation in attributes, but differently (`"a& b   c"` for the example above), and Bun's fast path never followed Babel.
- Only the slow path changes. Strings without a line terminator (CR, LF, U+2028, U+2029) are unaffected either way; the old routine only altered strings containing one.
- One knock-on effect: `maybe_decode_jsx_entity` now looks for the closing `;` in the whole attribute string instead of within one trimmed line (esbuild's `decodeJSXEntities` searches the whole string too). Valid entities and bare `&` are unaffected (covered by the `;`-on-a-later-line row), but a malformed reference such as `&#` + newline + `65;` now raises the existing "Invalid JSX entity escape" error, the same error `&#zz;` already raises on one line, where 1.4.0 produced the collapsed `"&# 65;"`. #38725 turns that error into literal text, which is also what esbuild emits; the two PRs touch different hunks of `lexer.rs` but adjacent blocks of `transpiler.test.js`, so whichever lands second needs a trivial rebase.
- Test: `test/bundler/transpiler/transpiler.test.js`, "JSX attribute strings keep their whitespace when they need decoding". It evaluates the transpiled element with a stand-in `jsxDEV` and checks the runtime prop value for each of the three slow-path triggers (named and numeric entities, a bare `&` with and without a `;` later in the string, non-ASCII, `\u`), both quote styles, CRLF, whitespace-only lines, leading/trailing whitespace, and the non-ASCII characters the children routine itself treats as whitespace or line breaks (U+00A0, U+2028, U+2029), plus controls showing the fast path is unchanged and children text still collapses. 13 of the 15 cases fail on bun 1.4.0 and on main, all pass with this change. esbuild 0.18.6 and TypeScript 6.0.2 (from `test/node_modules`) produce the expected value for every attribute row.
- Also ran `transpiler.test.js` (198 pass), `bundler_jsx.test.ts`, `jsx-production.test.ts`, `jsx-tsconfig-react-jsx.test.ts`, `jsx-namespaced-attributes.test.ts` against the debug build: all green.

### Background
- JSX entities: `&amp;`, `&#65;`, `&#x41;` etc. are the only escape mechanism in JSX strings (a backslash is a literal character). Both attribute strings and children text decode them; an `&` that does not form a known entity is kept as is.
- JSX children whitespace rule: in `<p>` text, lines are trimmed, whitespace-only lines are dropped and the remaining lines are joined with a single space. The lexer implements this in `fix_whitespace_and_decode_jsx_entities`, used by `next_jsx_element_child`.
- The JSX attribute string scanner has a fast path that hands the source bytes straight to the AST and a slow path that builds a decoded UTF-16 copy. The slow path is taken when the string contains any `&`, a byte >= 0x80, or a backslash followed by `u` (or a few control characters). The bug was only visible on the slow path.

<details>
<summary>Before / after on the three repro files</summary>

```
$ bun build --no-bundle x.jsx        # export const e = <p title="..."/>;

title="a\n   b  \n c"          1.4.0: `a\n   b  \n c`   fixed: same (fast path, unchanged)
title="a&amp;\n   b  \n c"     1.4.0: "a& b c"          fixed: `a&\n   b  \n c`
title="é\n   b  \n c"          1.4.0: "é b c"           fixed: `é\n   b  \n c`
```

For the same inputs, esbuild 0.18.6 and TypeScript 6.0.2 emit `"a&\n   b  \n c"` / `"é\n   b  \n c"`; @babel/plugin-transform-react-jsx 8.0.1 emits `"a& b   c"` / `"é b   c"` (it applies `value.replace(/\n\s+/g, " ")` to attribute string literals, with or without an entity, so it also differs from Bun's fast path on the first input).
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 13 failed, 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
bun test v1.4.0 (b3df70249)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [5.60ms]
(pass) Bun.Transpiler > normalizes \r\n [6.85ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [4.41ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [8.27ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [3.08ms]
(pass) Bun.Transpiler > property access inlining > works [2.48ms]
(pass) Bun.Transpiler > property access inlining > works nested [3.47ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [46.35ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [21.63ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [390.66ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional
... (truncated)

release without fix: 13 failed, 22 skipped
bun test v1.4.0-canary.1 (b7a043103)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [0.16ms]
(pass) Bun.Transpiler > normalizes \r\n [0.25ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [0.13ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.19ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.06ms]
(pass) Bun.Transpiler > property access inlining > works [0.05ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.05ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [1.06ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [0.55ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [10.20ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [0.66ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [0.09ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly whe
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
bun test v1.4.0 (b3df70249)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [5.90ms]
(pass) Bun.Transpiler > normalizes \r\n [6.53ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [4.69ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [8.44ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [3.18ms]
(pass) Bun.Transpiler > property access inlining > works [2.86ms]
(pass) Bun.Transpiler > property access inlining > works nested [3.28ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [49.21ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [23.13ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [352.37ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional
... (truncated)

release with fix: 22 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     b3df702494
  features     baseline

22 deps, 123 codegen, 1176 objects in 3440ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] gen ErrorCode+*.h
[2/1238] gen bindgenv2
[3/1238] fetch zlib
[zlib] up to date
[4/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[5/1238] fetch tinycc
[tinycc] up to date
[6/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[7/1237] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[8/1237] subst deps/zlib/zlib.h
[9/1237] gen JSEvent.lut.h
Generating /workspace/bun/build/release/codegen/JSEvent.lut.h from /workspace/bun/src/jsc/bindings/webcore/JSEvent.cpp
[10/1237] gen ProcessBindingHTTPParser.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingHTTPParser.lut.h from /workspace/bun/src/jsc/bindings/ProcessBin
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/lexer.rs                     |  3 +-
 test/bundler/transpiler/transpiler.test.js | 55 ++++++++++++++++++++++++++++++
 2 files changed, 56 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/js_parser/lexer.rs                          3      2      0
test/bundler/transpiler/transpiler.test.js      6      8      0
```

</details>

<!-- robobun:evidence:end -->