### PR TITLE
prune: open a workspace's tree at the workspace path, not through node_modules/<name>

### DIFF
--- a/src/install/prune.rs
+++ b/src/install/prune.rs
@@ -640,7 +640,6 @@ struct HoistedTree<'a> {
     folders: Vec<TreeFolder>,
     paths: Vec<u8>,
     expected: Vec<(&'a [u8], PackageID)>,
-    workspace_names: &'a [Box<[u8]>],
     quiet: bool,
     kept_mismatched: Cell<bool>,
     checked: RefCell<DynamicBitSet>,
@@ -656,11 +655,7 @@ enum Installed {
 }
 
 impl<'a> HoistedTree<'a> {
-    fn init(
-        lockfile: &'a Lockfile,
-        workspace_names: &'a [Box<[u8]>],
-        quiet: bool,
-    ) -> HoistedTree<'a> {
+    fn init(lockfile: &'a Lockfile, quiet: bool) -> HoistedTree<'a> {
         let trees = lockfile.buffers.trees.as_slice();
         let deps = lockfile.buffers.dependencies.as_slice();
         let resolutions = lockfile.buffers.resolutions.as_slice();
@@ -711,7 +706,6 @@ impl<'a> HoistedTree<'a> {
             folders,
             paths,
             expected,
-            workspace_names,
             quiet,
             kept_mismatched: Cell::new(false),
             checked: RefCell::new(checked),
@@ -811,7 +805,6 @@ impl<'a> HoistedTree<'a> {
 
     fn installed(&self, tree_id: tree::Id, alias: &[u8], pkg_id: PackageID) -> Installed {
         let buf = self.lockfile.buffers.string_bytes.as_slice();
-        let deps = self.lockfile.buffers.dependencies.as_slice();
         let Some(res) = self
             .lockfile
             .packages
@@ -820,8 +813,7 @@ impl<'a> HoistedTree<'a> {
         else {
             return Installed::Mismatch;
         };
-        let Some(folder) = open_tree_folder(self.trees, deps, buf, tree_id, self.workspace_names)
-        else {
+        let Some(folder) = open_tree_folder(self.lockfile, tree_id) else {
             return Installed::Missing;
         };
         let kind = entry_kind_of(&folder, alias);
@@ -839,7 +831,7 @@ impl<'a> HoistedTree<'a> {
             ResolutionTag::Folder if kind == EntryKind::SymLink => return Installed::Matches,
             _ => {}
         }
-        let Some(package) = descend(&folder, alias, false) else {
+        let Some(package) = descend(&folder, alias) else {
             return Installed::Mismatch;
         };
         let expected_name = self.lockfile.packages.items_name()[pkg_id as usize].slice(buf);
@@ -913,7 +905,7 @@ fn plan_hoisted(
 
     let quiet = manager.options.log_level == LogLevel::Silent;
     let lockfile: &Lockfile = &manager.lockfile;
-    let hoisted = HoistedTree::init(lockfile, workspace_names, quiet);
+    let hoisted = HoistedTree::init(lockfile, quiet);
     let buf = lockfile.buffers.string_bytes.as_slice();
     let deps = lockfile.buffers.dependencies.as_slice();
     let trees = lockfile.buffers.trees.as_slice();
@@ -957,7 +949,7 @@ fn plan_hoisted(
 
         let expected = hoisted.expected(tree_idx);
 
-        let Some(dir) = open_tree_folder(trees, deps, buf, tree_id, workspace_names) else {
+        let Some(dir) = open_tree_folder(lockfile, tree_id) else {
             continue;
         };
 
@@ -978,7 +970,7 @@ fn plan_hoisted(
             if !extracted || has_bundled_deps(lockfile, pkg_id) {
                 continue;
             }
-            let Some(nested) = descend(&dir, alias, false)
+            let Some(nested) = descend(&dir, alias)
                 .and_then(|package| open_real_subdir(&package, b"node_modules"))
             else {
                 continue;
@@ -1019,19 +1011,16 @@ fn plan_hoisted(
             scan_folder(dir, b"node_modules", false, &keep_workspaces, plan);
         }
     }
-    for (pkg_id, res) in pkg_res.iter().enumerate() {
+    for pkg_id in 0..pkg_res.len() {
+        let Some(folder_path) = workspace_node_modules(lockfile, pkg_id as PackageID) else {
+            continue;
+        };
         if visited.is_set(pkg_id)
-            || res.tag != ResolutionTag::Workspace
             || selection.is_some_and(|sel| !sel.selected.is_set(pkg_id))
             || is_pruned_workspace(&*manager, pkg_id)
         {
             continue;
         }
-        let path = strings::without_trailing_slash(res.workspace().slice(buf));
-        if path.is_empty() {
-            continue;
-        }
-        let folder_path = join(path, b"node_modules");
         if let Ok(dir) = Dir::open(&folder_path) {
             scan_folder(
                 dir,
@@ -1100,8 +1089,8 @@ pub(crate) fn remove_collapsed_copies(manager: &PackageManager, before: &Lockfil
         return;
     }
     let quiet = manager.options.log_level == LogLevel::Silent;
-    let old = HoistedTree::init(before, &workspace_names, true);
-    let new = HoistedTree::init(after, &workspace_names, quiet);
+    let old = HoistedTree::init(before, true);
+    let new = HoistedTree::init(after, quiet);
     let targets = manager.filtered_link_targets.as_ref();
     let selected: Option<Vec<PackageID>> = targets.map(|targets| targets.package_ids(before));
     let importers = selected.as_ref().map(|_| tree_importers(before));
@@ -1149,13 +1138,7 @@ pub(crate) fn remove_collapsed_copies(manager: &PackageManager, before: &Lockfil
         {
             continue;
         }
-        let Some(dir) = open_tree_folder(
-            old.trees,
-            old_deps,
-            old_buf,
-            old_idx as tree::Id,
-            &workspace_names,
-        ) else {
+        let Some(dir) = open_tree_folder(before, old_idx as tree::Id) else {
             continue;
         };
         let folder_idx = plan.push_folder(old_path, FolderKind::NodeModules);
@@ -1198,20 +1181,16 @@ pub(crate) fn remove_collapsed_copies(manager: &PackageManager, before: &Lockfil
     let selected_after: Option<Vec<PackageID>> = targets.map(|targets| targets.package_ids(after));
     let buf = after.buffers.string_bytes.as_slice();
     let pkg_names = after.packages.items_name();
-    let pkg_res = after.packages.items_resolution();
-    for pkg_id in 0..pkg_res.len() {
-        let res = &pkg_res[pkg_id];
-        if res.tag != ResolutionTag::Workspace
-            || is_pruned_workspace(manager, pkg_id)
+    for pkg_id in 0..after.packages.len() {
+        let Some(folder_path) = workspace_node_modules(after, pkg_id as PackageID) else {
+            continue;
+        };
+        if is_pruned_workspace(manager, pkg_id)
             || selected_after
                 .as_ref()
                 .is_some_and(|sel| sel.binary_search(&(pkg_id as PackageID)).is_err())
             || has_bundled_deps(after, pkg_id as PackageID)
         {
-            continue;
-        }
-        let path = strings::without_trailing_slash(res.workspace().slice(buf));
-        if path.is_empty() {
             continue;
         }
         let tree_path = join(
@@ -1223,7 +1202,6 @@ pub(crate) fn remove_collapsed_copies(manager: &PackageManager, before: &Lockfil
             None => &[],
         };
         let surviving = tree_at(&new_paths, &tree_path);
-        let folder_path = join(path, b"node_modules");
         let Ok(dir) = Dir::open(&folder_path) else {
             continue;
         };
@@ -1273,13 +1251,12 @@ fn tree_at(paths: &[(&[u8], tree::Id)], path: &[u8]) -> Option<tree::Id> {
         .map(|i| paths[i].1)
 }
 
-fn open_tree_folder(
-    trees: &[tree::Tree],
-    deps: &[crate::Dependency],
-    buf: &[u8],
-    tree_id: tree::Id,
-    workspace_names: &[Box<[u8]>],
-) -> Option<Dir> {
+// A workspace's tree is installed into the workspace folder itself; `node_modules/<name>` is only a link to it,
+// and `bun link` can point that link at another checkout. Nothing below the root folder is ever followed.
+fn open_tree_folder(lockfile: &Lockfile, tree_id: tree::Id) -> Option<Dir> {
+    let trees = lockfile.buffers.trees.as_slice();
+    let deps = lockfile.buffers.dependencies.as_slice();
+    let buf = lockfile.buffers.string_bytes.as_slice();
     let mut chain: Vec<tree::Id> = Vec::new();
     let mut id = tree_id;
     while id != 0 && (id as usize) < trees.len() {
@@ -1288,14 +1265,30 @@ fn open_tree_folder(
     }
     let mut dir = Dir::open(b"node_modules").ok()?;
     while let Some(id) = chain.pop() {
-        let alias = trees[id as usize].folder_name(deps, buf);
-        let package = descend(&dir, alias, contains(workspace_names, alias))?;
+        if let Some(folder) = workspace_node_modules(lockfile, tree_owner(lockfile, id as usize)) {
+            dir = Dir::open(&folder).ok()?;
+            continue;
+        }
+        let package = descend(&dir, trees[id as usize].folder_name(deps, buf))?;
         dir = open_real_subdir(&package, b"node_modules")?;
     }
     Some(dir)
 }
 
-fn descend(dir: &Dir, alias: &[u8], follow: bool) -> Option<Dir> {
+fn workspace_node_modules(lockfile: &Lockfile, pkg_id: PackageID) -> Option<Box<[u8]>> {
+    let res = lockfile.packages.items_resolution().get(pkg_id as usize)?;
+    if res.tag != ResolutionTag::Workspace {
+        return None;
+    }
+    let buf = lockfile.buffers.string_bytes.as_slice();
+    let path = strings::without_trailing_slash(res.workspace().slice(buf));
+    if path.is_empty() {
+        return None;
+    }
+    Some(join(path, b"node_modules"))
+}
+
+fn descend(dir: &Dir, alias: &[u8]) -> Option<Dir> {
     let (scope, name) = match strings::split_once_char(alias, b'/') {
         Some(split) if alias.first() == Some(&b'@') => (Some(split.0), split.1),
         _ => (None, alias),
@@ -1304,12 +1297,7 @@ fn descend(dir: &Dir, alias: &[u8], follow: bool) -> Option<Dir> {
         Some(scope) => Some(open_real_subdir(dir, scope)?),
         None => None,
     };
-    let parent = scope_dir.as_ref().unwrap_or(dir);
-    if follow {
-        parent.open_at(name).ok()
-    } else {
-        open_real_subdir(parent, name)
-    }
+    open_real_subdir(scope_dir.as_ref().unwrap_or(dir), name)
 }
 
 fn entry_kind_of(dir: &Dir, alias: &[u8]) -> EntryKind {

--- a/src/install/prune.rs
+++ b/src/install/prune.rs
@@ -1251,8 +1251,6 @@ fn tree_at(paths: &[(&[u8], tree::Id)], path: &[u8]) -> Option<tree::Id> {
         .map(|i| paths[i].1)
 }
 
-// A workspace's tree is installed into the workspace folder itself; `node_modules/<name>` is only a link to it,
-// and `bun link` can point that link at another checkout. Nothing below the root folder is ever followed.
 fn open_tree_folder(lockfile: &Lockfile, tree_id: tree::Id) -> Option<Dir> {
     let trees = lockfile.buffers.trees.as_slice();
     let deps = lockfile.buffers.dependencies.as_slice();
@@ -1265,6 +1263,7 @@ fn open_tree_folder(lockfile: &Lockfile, tree_id: tree::Id) -> Option<Dir> {
     }
     let mut dir = Dir::open(b"node_modules").ok()?;
     while let Some(id) = chain.pop() {
+        // `node_modules/<workspace>` is a link `bun link` may point anywhere; the tree lives in the workspace folder.
         if let Some(folder) = workspace_node_modules(lockfile, tree_owner(lockfile, id as usize)) {
             dir = Dir::open(&folder).ok()?;
             continue;

--- a/test/cli/install/bun-prune.test.ts
+++ b/test/cli/install/bun-prune.test.ts
@@ -840,6 +840,53 @@ test.concurrent("hoisted: a symlinked scope dir is unlinked, not followed", asyn
   expect(existsSync(join(nm, "@real"))).toBeFalse();
 });
 
+test.concurrent(
+  "hoisted: a workspace's nested folder is pruned where bun.lock says the workspace is, not through node_modules/<name>",
+  async () => {
+    const dir = await setupWorkspaces("hoisted", {
+      root: { dependencies: { "no-deps": "2.0.0" } },
+      packages: { a: { dependencies: { "no-deps": "1.0.0" } } },
+    });
+    const link = join(dir, "node_modules", "a");
+    const workspaceNoDeps = join(dir, "packages", "a", "node_modules", "no-deps", "package.json");
+    expect(isSymlink(link)).toBeTrue();
+    expect(existsSync(workspaceNoDeps)).toBeTrue();
+    const junk = plant(dir, "packages/a/node_modules/junk");
+
+    // `bun link a` run from another checkout leaves node_modules/a pointing at that checkout, which has a node_modules of its own.
+    rmSync(link);
+    const other = linkOutside(dir, "node_modules/a", {
+      "package.json": JSON.stringify({ name: "a", version: "1.0.0" }),
+    });
+    const victim = plant(other, "node_modules/victim");
+    const otherNoDeps = plant(other, "node_modules/no-deps");
+
+    const dryRun = await prune(dir, "--dry-run", "--linker", "hoisted");
+    expect(out(dryRun.stdout)).toMatchInlineSnapshot(`
+      "bun prune <version> (<revision>)
+
+      - junk (node_modules/a/node_modules)
+      1 package can be removed (checked 4)
+        bun prune --linker hoisted"
+    `);
+    expect(dryRun.exitCode).toBe(0);
+
+    const { stdout, exitCode } = await prune(dir, "--linker", "hoisted");
+    expect(out(stdout)).toMatchInlineSnapshot(`
+      "bun prune <version> (<revision>)
+
+      - junk (node_modules/a/node_modules)
+      1 package removed (checked 4)"
+    `);
+    expect(exitCode).toBe(0);
+    expect(existsSync(junk)).toBeFalse();
+    expect(existsSync(workspaceNoDeps)).toBeTrue();
+    expect(existsSync(join(victim, "package.json"))).toBeTrue();
+    expect(existsSync(join(otherNoDeps, "package.json"))).toBeTrue();
+    expect(isSymlink(link)).toBeTrue();
+  },
+);
+
 test.concurrent.skipIf(isWindows)("a symlinked .bin directory is never cleaned through", async () => {
   const dir = await setup({ name: "foo", dependencies: { "no-deps": "1.0.0" } });
   const nm = join(dir, "node_modules");

--- a/test/cli/install/bun-prune.test.ts
+++ b/test/cli/install/bun-prune.test.ts
@@ -871,7 +871,8 @@ test.concurrent(
     `);
     expect(dryRun.exitCode).toBe(0);
 
-    const { stdout, exitCode } = await prune(dir, "--linker", "hoisted");
+    // bun.lock records workspace folders relative to the root; prune chdirs there first, so running it from inside a workspace resolves them the same way.
+    const { stdout, exitCode } = await prune({ dir, cwd: join(dir, "packages", "a") }, "--linker", "hoisted");
     expect(out(stdout)).toMatchInlineSnapshot(`
       "bun prune <version> (<revision>)
 


### PR DESCRIPTION
### Problem
- `bun prune` (hoisted linker) can delete outside the project. With `node_modules/<workspace name>` pointing at another checkout of the workspace (what `bun link` or a hand-made link leaves), prune plans the workspace's tree against that checkout's `node_modules` and removes from it: `- victim (node_modules/a/node_modules)`, and `<other checkout>/node_modules/victim/` is gone. The real `packages/a/node_modules` is not pruned at all in that state. docs/pm/cli/prune.mdx promises prune never removes anything outside the project's `node_modules` folders.
- Cause: `open_tree_folder` in `src/install/prune.rs` reaches every tree folder by descending from the root `node_modules`. Each step uses `O_NOFOLLOW` except when the entry name is a workspace name, where `descend(&dir, alias, contains(workspace_names, alias))` (`prune.rs:1292` on main) opened the entry with a plain `openat`, following the link. A workspace's entry in `node_modules` is only ever a link, so the tree's folder was wherever the link happened to point.
- Reported by the install fuzz ledger against main at ada2a67ef (`bun prune` landed in #38333). No user-facing issue yet.

### Fix
- `open_tree_folder` now takes the lockfile. For a tree owned by a workspace package it opens `<workspace path from bun.lock>/node_modules` directly (the same path the planner's separate workspace pass already uses); every other level is still an `O_NOFOLLOW` descent. The `follow` parameter of `descend` is gone, so no tree walk can follow a link any more.
- The path computation shared by the two hoisted workspace passes moved into `workspace_node_modules`, and `HoistedTree` no longer carries `workspace_names`, which it only used for the removed `follow` decision.
- Correct because the hoisted installer installs a workspace's tree into `node_modules/<name>/node_modules` through the link that `bun install` itself created, which is `<workspace path>/node_modules`; bun.lock's workspace path is the authoritative location, the link is not.
- Side effect: a workspace's folder is now also pruned when its `node_modules/<name>` link is missing. Before, a missing link made the tree unopenable and the workspace was skipped (its owner had already been marked visited).
- Rows keep printing the tree path (`- junk (node_modules/a/node_modules)`), as the existing tests expect; only where prune opens changed.
- Verified:
  - `test/cli/install/bun-prune.test.ts`, new case "hoisted: a workspace's nested folder is pruned where bun.lock says the workspace is ...": fails on main (`- victim (node_modules/a/node_modules)` in the plan, `junk` kept), passes with the fix (`junk` removed, the other checkout untouched, the link left alone).
  - `bun-prune.test.ts` (110 tests), `bun-dedupe.test.ts`, `bun-update.test.ts`, `bun-update-transitive.test.ts`, `bun-audit.test.ts` pass with the debug build; the last four exercise `remove_collapsed_copies`, the other caller of `open_tree_folder`.

### Background
- Hoisted linker: every package is a real directory inside some `node_modules` folder. Workspace packages are the exception: `node_modules/<name>` is a symlink (junction on Windows) to the workspace's source folder, e.g. `packages/a`.
- Lockfile tree: bun.lock's hoisting result is a list of trees, one per `node_modules` folder. Tree 0 is the root folder; a child tree named `a` is the folder `node_modules/a/node_modules`, holding the dependencies of `a` that could not be hoisted (here `no-deps@1.0.0`, because the root has `no-deps@2.0.0`). For a workspace that folder physically lives at `packages/a/node_modules`, since the installer writes through the link.
- `bun prune` plans removals by opening each tree's folder and comparing its entries against what the tree is expected to contain. Removals are executed relative to the opened directory handle, so whichever directory gets opened is the one that is modified.
- `tree_owner` maps a tree to the package installed at that folder (already used by the planner for the bundled-dependency and `--filter` checks); `Resolution::workspace()` is that package's folder relative to the project root.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-prune.test.ts

<!-- robobun:evidence:end -->