### PR TITLE
Keep malformed numeric JSX entities as literal text

### DIFF
--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -2808,10 +2808,7 @@ impl<'a> Lexer<'a> {
                 } else {
                     self.add_error(
                         self.start,
-                        format_args!(
-                            "JSX entity escape is too big: {}",
-                            bstr::BStr::new(entity)
-                        ),
+                        format_args!("JSX entity escape is too big: {}", bstr::BStr::new(entity)),
                     );
                     strings::UNICODE_REPLACEMENT as CodePoint
                 };

--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -2803,8 +2803,6 @@ impl<'a> Lexer<'a> {
                     return;
                 };
 
-                // Values outside the Unicode range would trip `push_codepoint_utf16`
-                // (release builds silently encode garbage surrogate pairs).
                 cursor.c = if value <= 0x10FFFF {
                     value as CodePoint
                 } else {
@@ -3387,10 +3385,8 @@ pub(crate) fn latin1_identifier_continue_length_scalar(name: &[u8]) -> usize {
     name.len()
 }
 
-/// `text` is what sits between `&#` and `;`. As in Babel and TypeScript, only
-/// `[0-9]+` and `x[0-9a-fA-F]+` are character references; anything else
-/// (`X41`, `+65`, `6_5`, empty) is `None` and stays literal text. The value
-/// saturates so the caller still reports an overlong reference as too big.
+/// `text` follows `&#`. Like Babel and TypeScript this takes only `[0-9]+` / `x[0-9a-fA-F]+`
+/// (hence not `parse_int`, which allows a sign and `_`); `None` leaves the reference as text.
 fn jsx_numeric_entity_value(text: &[u8]) -> Option<u32> {
     let (digits, radix) = match text.strip_prefix(b"x") {
         Some(hex) => (hex, 16u32),

--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -3385,8 +3385,7 @@ pub(crate) fn latin1_identifier_continue_length_scalar(name: &[u8]) -> usize {
     name.len()
 }
 
-/// `text` follows `&#`. Like Babel and TypeScript this takes only `[0-9]+` / `x[0-9a-fA-F]+`
-/// (hence not `parse_int`, which allows a sign and `_`); `None` leaves the reference as text.
+/// Only `[0-9]+` / `x[0-9a-fA-F]+` decode, as in Babel and TypeScript; `None` keeps the text.
 fn jsx_numeric_entity_value(text: &[u8]) -> Option<u32> {
     let (digits, radix) = match text.strip_prefix(b"x") {
         Some(hex) => (hex, 16u32),

--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -7,7 +7,7 @@ use bun_ast as js_ast;
 use bun_ast::lexer_tables as tables;
 use bun_ast::{LexerLog, Loc, Log, Range, Source};
 use bun_core::Environment;
-use bun_core::fmt::hex_digit_value_u32;
+use bun_core::fmt::{hex_digit_value, hex_digit_value_u32};
 use bun_core::strings;
 use bun_core::strings::CodepointIterator;
 use identifier as js_identifier;
@@ -2799,54 +2799,23 @@ impl<'a> Lexer<'a> {
                 return;
             }
             if entity[0] == b'#' {
-                let mut number = &entity[1..entity.len()];
-                let mut base: u8 = 10;
-                if number.len() > 1 && number[0] == b'x' {
-                    number = &number[1..number.len()];
-                    base = 16;
-                }
+                let Some(value) = jsx_numeric_entity_value(&entity[1..]) else {
+                    return;
+                };
 
-                // Note: bytes-based integer parse — source bytes are
-                // not guaranteed UTF-8 so we never round-trip through &str (PORTING.md §Strings).
-                // Also reject values outside the Unicode range (0..=0x10FFFF); otherwise
-                // `push_codepoint_utf16` hits `debug_assert`s in `u16_lead`/`u16_trail`
-                // (release builds would silently encode garbage surrogate pairs).
-                cursor.c = match bun_core::parse_int::<i32>(number, base) {
-                    Ok(v) if (0..=0x10FFFF).contains(&v) => v,
-                    Ok(_) => {
-                        self.add_error(
-                            self.start,
-                            format_args!(
-                                "JSX entity escape is too big: {}",
-                                bstr::BStr::new(entity)
-                            ),
-                        );
-                        strings::UNICODE_REPLACEMENT as CodePoint
-                    }
-                    Err(err) => {
-                        match err {
-                            strings::ParseIntError::InvalidCharacter => {
-                                self.add_error(
-                                    self.start,
-                                    format_args!(
-                                        "Invalid JSX entity escape: {}",
-                                        bstr::BStr::new(entity)
-                                    ),
-                                );
-                            }
-                            strings::ParseIntError::Overflow => {
-                                self.add_error(
-                                    self.start,
-                                    format_args!(
-                                        "JSX entity escape is too big: {}",
-                                        bstr::BStr::new(entity)
-                                    ),
-                                );
-                            }
-                        }
-
-                        strings::UNICODE_REPLACEMENT as CodePoint
-                    }
+                // Values outside the Unicode range would trip `push_codepoint_utf16`
+                // (release builds silently encode garbage surrogate pairs).
+                cursor.c = if value <= 0x10FFFF {
+                    value as CodePoint
+                } else {
+                    self.add_error(
+                        self.start,
+                        format_args!(
+                            "JSX entity escape is too big: {}",
+                            bstr::BStr::new(entity)
+                        ),
+                    );
+                    strings::UNICODE_REPLACEMENT as CodePoint
                 };
 
                 cursor.i += u32::try_from(length).expect("int cast") + 1;
@@ -3416,6 +3385,33 @@ pub(crate) fn latin1_identifier_continue_length_scalar(name: &[u8]) -> usize {
     }
 
     name.len()
+}
+
+/// `text` is what sits between `&#` and `;`. As in Babel and TypeScript, only
+/// `[0-9]+` and `x[0-9a-fA-F]+` are character references; anything else
+/// (`X41`, `+65`, `6_5`, empty) is `None` and stays literal text. The value
+/// saturates so the caller still reports an overlong reference as too big.
+fn jsx_numeric_entity_value(text: &[u8]) -> Option<u32> {
+    let (digits, radix) = match text.strip_prefix(b"x") {
+        Some(hex) => (hex, 16u32),
+        None => (text, 10u32),
+    };
+    if digits.is_empty() {
+        return None;
+    }
+
+    let mut value: u32 = 0;
+    for &c in digits {
+        let digit = if radix == 16 {
+            hex_digit_value(c)?
+        } else if c.is_ascii_digit() {
+            c - b'0'
+        } else {
+            return None;
+        };
+        value = value.saturating_mul(radix).saturating_add(digit as u32);
+    }
+    Some(value)
 }
 
 pub struct PragmaArg;

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2508,25 +2508,80 @@ console.log(<div {...obj} key="after" />);`),
   // A numeric JSX entity outside the Unicode range (0..=0x10FFFF) used to
   // trip a debug_assert in u16_lead (src/bun_core/lib.rs) when the lexer
   // encoded the value as a UTF-16 surrogate pair. The lexer must reject the
-  // entity with the same "JSX entity escape is too big" diagnostic it emits
-  // for i32-overflow, instead of forwarding an invalid code point.
+  // entity with a "JSX entity escape is too big" diagnostic instead of
+  // forwarding an invalid code point.
   describe("rejects out-of-range numeric JSX entities without panicking", () => {
     const bun = new Bun.Transpiler({
       loader: "jsx",
       define: { "process.env.NODE_ENV": JSON.stringify("development") },
     });
 
-    // Covers: the original fuzzer input (0x76B22B), max+1, i32::MAX, and the
-    // negative-i32 path — parse_int::<i32> accepts a leading '-' so `&#-1;`
-    // lands as a negative CodePoint that must be rejected before it reaches
-    // the u32 cast in push_codepoint_utf16.
-    it.each(["&#7777707;", "&#x110000;", "&#2147483647;", "&#-1;"])("%s is rejected", entity => {
-      expect(() => bun.transformSync(`export var x = <div>${entity}</div>`)).toThrow(/JSX entity escape is too big/);
-    });
+    // Covers: the original fuzzer input (0x76B22B), max+1, i32::MAX, and digit
+    // strings wider than u32 (the lexer saturates instead of wrapping). The
+    // issue's `&#-1;` is not a numeric reference at all and is covered as
+    // literal text in the next describe block.
+    it.each(["&#7777707;", "&#x110000;", "&#2147483647;", "&#99999999999999999999;", "&#xFFFFFFFFFF;"])(
+      "%s is rejected",
+      entity => {
+        expect(() => bun.transformSync(`export var x = <div>${entity}</div>`)).toThrow(/JSX entity escape is too big/);
+      },
+    );
 
     // Boundary: 0x10FFFF is the maximum valid code point and must still work.
     it("&#x10FFFF; (max valid) still transpiles", () => {
       expect(bun.transformSync("export var x = <div>&#x10FFFF;</div>")).toContain("jsxDEV_");
+    });
+  });
+
+  // Babel and TypeScript only decode `&#[0-9]+;` and `&#x[0-9a-fA-F]+;` (plus
+  // the named entities); any other `&#...;` is ordinary text. Bun used to fail
+  // the whole module with "Invalid JSX entity escape" instead.
+  describe("malformed numeric JSX entities are literal text", () => {
+    const bun = new Bun.Transpiler({
+      loader: "jsx",
+      define: { "process.env.NODE_ENV": JSON.stringify("development") },
+    });
+    const child = text =>
+      `export var x = jsxDEV_7x81h0kn("div", {\n  children: ${text}\n}, undefined, false, undefined, this);\n`;
+    const attr = text =>
+      `export var x = jsxDEV_7x81h0kn("div", {\n  title: ${text}\n}, undefined, false, undefined, this);\n`;
+
+    it.each([
+      // uppercase X is HTML, not JSX
+      ["&#X41;", '"&#X41;"'],
+      ["&#abc;", '"&#abc;"'],
+      ["&#;", '"&#;"'],
+      ["&#x;", '"&#x;"'],
+      ["&#+65;", '"&#+65;"'],
+      ["&#-65;", '"&#-65;"'],
+      ["&#-1;", '"&#-1;"'],
+      ["&#6_5;", '"&#6_5;"'],
+      ["&#x6_5;", '"&#x6_5;"'],
+      ["&#x4G;", '"&#x4G;"'],
+      // a failed reference must not swallow the text up to the next ';'
+      ["&#65 &#xZZ;", '"&#65 &#xZZ;"'],
+      ["&#65;&#X41;&#x41;", '"A&#X41;A"'],
+    ])("<div>%s</div>", (entity, expected) => {
+      expect(bun.transformSync(`export var x = <div>${entity}</div>`)).toBe(child(expected));
+    });
+
+    it.each([
+      ["&#65;", '"A"'],
+      ["&#x41;", '"A"'],
+      ["&#x4a;", '"J"'],
+      ["&#x4A;", '"J"'],
+      ["&#0;", '"\\x00"'],
+    ])("<div>%s</div> still decodes", (entity, expected) => {
+      expect(bun.transformSync(`export var x = <div>${entity}</div>`)).toBe(child(expected));
+    });
+
+    it.each([
+      ["&#X41;", '"&#X41;"'],
+      ["&#abc;", '"&#abc;"'],
+      ["&#+65;", '"&#+65;"'],
+      ["&#65;", '"A"'],
+    ])('<div title="%s" />', (entity, expected) => {
+      expect(bun.transformSync(`export var x = <div title="${entity}" />`)).toBe(attr(expected));
     });
   });
 

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2527,9 +2527,12 @@ console.log(<div {...obj} key="after" />);`),
       },
     );
 
-    // Boundary: 0x10FFFF is the maximum valid code point and must still work.
-    it("&#x10FFFF; (max valid) still transpiles", () => {
-      expect(bun.transformSync("export var x = <div>&#x10FFFF;</div>")).toContain("jsxDEV_");
+    // Boundary: 0x10FFFF is the maximum valid code point and must still decode
+    // (printed as its surrogate pair).
+    it.each(["&#x10FFFF;", "&#1114111;"])("%s (max valid) decodes to U+10FFFF", entity => {
+      expect(bun.transformSync(`export var x = <div>${entity}</div>`)).toBe(
+        `export var x = jsxDEV_7x81h0kn("div", {\n  children: "\\uDBFF\\uDFFF"\n}, undefined, false, undefined, this);\n`,
+      );
     });
   });
 


### PR DESCRIPTION
### Problem
- Any `&#...;` in JSX text or a JSX attribute string that is not a parseable number fails the whole module: `error: Invalid JSX entity escape: #X41` (same for `&#abc;`, `&#;`, `&#x;`; `&#-65;` reports `JSX entity escape is too big: #-65`).
- `&#+65;` and `&#6_5;` silently decode to `"A"`, because `bun_core::parse_int` accepts a sign and skips `_` separators.
- Babel, TypeScript and esbuild only decode `&#[0-9]+;` and `&#x[0-9a-fA-F]+;` (plus the named entities) and otherwise keep the source text as-is, so JSX that compiles everywhere else (HTML pasted with `&#X..;`, prose that mentions `&#...;`) does not compile under bun.
- Cause: `maybe_decode_jsx_entity` in `src/js_parser/lexer.rs` routed every `parse_int` failure to `add_error`. The named-entity miss two lines below already falls through and leaves the text literal; the numeric path was the odd one out (the esbuild original falls through in both cases).

### Fix
- New `jsx_numeric_entity_value` accepts exactly `[0-9]+` / `x[0-9a-fA-F]+` and returns `None` for anything else; `maybe_decode_jsx_entity` then returns without consuming, so the `&` and the text after it are emitted unchanged (and later `&...;` sequences on the same text are still decoded, e.g. `&#65;&#X41;&#x41;` becomes `A&#X41;A`).
- A well-formed reference above U+10FFFF still reports `JSX entity escape is too big` (Babel and tsc throw a RangeError there, and the range check is what keeps `push_codepoint_utf16` from encoding an invalid code point, #30958). The accumulator saturates, so overlong digit strings such as `&#99999999999999999999;` land on that path too.
- The "Invalid JSX entity escape" diagnostic has no remaining producers and is removed.
- Verified:
  - `test/bundler/transpiler/transpiler.test.js`: new `malformed numeric JSX entities are literal text` block (21 cases covering children and attributes, plus well-formed references that must still decode); 15 of them fail on the released binary, all pass with this change.
  - The existing #30958 block keeps its out-of-range inputs and gains the two saturating cases; its `&#-1;` input moved to the literal-text block since it is no longer a numeric reference.
  - Whole `transpiler.test.js` (210 pass), `bundler_jsx.test.ts`, the `jsx-bracket-in-text` react-compiler fixture, and the `source-lints` byte-search lint pass with the debug build; `cargo clippy -p bun_js_parser` is clean.

### Background
- JSX text and attribute strings support HTML-style character references: named (`&amp;`) and numeric (`&#65;` decimal, `&#x41;` hex). The lexer decodes them while producing the string literal; in JSX, unlike HTML, a reference that does not match is not an error, it is just text.
- `maybe_decode_jsx_entity` is called whenever the lexer sees `&` in JSX text. It looks for the next `;`, and on a hit advances the cursor past the reference and replaces the current code point; if it returns without touching the cursor, the `&` is emitted as itself and scanning continues with the next character.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 15 failed, 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
bun test v1.4.1 (65362b53b)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [4.67ms]
(pass) Bun.Transpiler > normalizes \r\n [6.04ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [3.90ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [7.34ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.73ms]
(pass) Bun.Transpiler > property access inlining > works [2.29ms]
(pass) Bun.Transpiler > property access inlining > works nested [3.60ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [49.45ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [21.86ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [304.47ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional
... (truncated)

release without fix: 15 failed, 22 skipped
bun test v1.4.1-canary.1 (65362b53b)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [0.08ms]
(pass) Bun.Transpiler > normalizes \r\n [0.12ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [0.08ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.10ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.05ms]
(pass) Bun.Transpiler > property access inlining > works [0.03ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.03ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [0.94ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [0.27ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [7.56ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [0.45ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [0.09ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
bun test v1.4.1 (65362b53b)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [4.88ms]
(pass) Bun.Transpiler > normalizes \r\n [6.16ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [4.02ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [8.08ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.90ms]
(pass) Bun.Transpiler > property access inlining > works [2.52ms]
(pass) Bun.Transpiler > property access inlining > works nested [4.52ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [49.23ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [22.54ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [310.61ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional
... (truncated)

release with fix: 22 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     7bc64782ba
  features     baseline

23 deps, 129 codegen, 1172 objects in 794ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (65362b53b)

Checked 26 installs across 63 packages (no changes) [9.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (65362b53b)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1244] gen bindgenv2
[4/1244] gen ErrorCode+*.h
[5/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (65362b53b)

Checked 111 installs across 104 packages (no changes) [7.00ms]
[6/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1217] fetch tinycc
[tinycc] up to date
[8/1216] gen .bind.ts → GeneratedBindings.cpp
[9/1216] fetch zlib
[zlib] up to date
[10/1216] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[11
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/lexer.rs                     | 84 +++++++++++++-----------------
 test/bundler/transpiler/transpiler.test.js | 80 ++++++++++++++++++++++++----
 2 files changed, 105 insertions(+), 59 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/js_parser/lexer.rs                         10     10      0
test/bundler/transpiler/transpiler.test.js      3      4      0
```

</details>

<!-- robobun:evidence:end -->