### PR TITLE
PipeReader: don't re-deliver streamed bytes after a re-entrant read

### DIFF
--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -827,7 +827,7 @@ impl PosixBufferedReader {
             let mut got_retry = false;
 
             // SAFETY: caller contract; borrow ends at `;`.
-            let unbuffered = scratch.is_some() && unsafe { (*this)._buffer.capacity() == 0 };
+            let unbuffered = scratch.is_some() && unsafe { (*this)._buffer.is_empty() };
             if unbuffered {
                 // Use stack buffer for streaming — per-loop scratch buffer;
                 // single-threaded event loop (see `EventLoopCtx::pipe_read_buffer_mut`).
@@ -952,11 +952,11 @@ impl PosixBufferedReader {
                                     ReadState::Progress
                                 },
                             );
-                            // Reinstall; anything re-entry buffered lands after
-                            // the bytes it was delivered.
+                            // Delivered bytes are consumed by `on_read_chunk`; keep only what re-entry buffered.
                             // SAFETY: caller contract; borrows end at the block.
                             unsafe {
                                 let mut buffer = buffer;
+                                buffer.clear();
                                 buffer.extend_from_slice(&(*this)._buffer);
                                 (*this)._buffer = buffer;
                             }
@@ -1070,7 +1070,7 @@ impl PosixBufferedReader {
             let event_loop = vtable.event_loop();
             let stack_buffer_len = event_loop.pipe_read_buffer_mut().len();
             // SAFETY: caller contract; borrow ends at the loop test.
-            while unsafe { (*this)._buffer.capacity() == 0 } {
+            while unsafe { (*this)._buffer.is_empty() } {
                 let stack_buffer_cutoff = stack_buffer_len / 2;
                 let mut head_start = 0usize; // index into stack_buffer where the unwritten head begins
                 while stack_buffer_len - head_start > 16 * 1024 {

--- a/test/js/node/process/process-stdin.test.ts
+++ b/test/js/node/process/process-stdin.test.ts
@@ -531,3 +531,20 @@ describe.skipIf(isWindows)("pipe backpressure", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+test.skipIf(isWindows)("process.stdin over an anonymous pipe delivers each byte exactly once", async () => {
+  const total = 10 * 1024 * 1024;
+  const writer = `const chunk = Buffer.alloc(65536); let left = ${total}; (function pump() { while (left > 0) { left -= chunk.length; if (!process.stdout.write(chunk)) return process.stdout.once("drain", pump); } })();`;
+  const reader = `const h = new Bun.CryptoHasher("sha1"); let n = 0; process.stdin.on("data", d => { n += d.length; h.update(d); }); process.stdin.on("close", () => process.stdout.write(n + " " + h.digest("hex")));`;
+  await using proc = Bun.spawn({
+    cmd: ["sh", "-c", `"$BUN" -e "$WRITER" | "$BUN" -e "$READER"`],
+    env: { ...bunEnv, BUN: bunExe(), WRITER: writer, READER: reader },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const expected = new Bun.CryptoHasher("sha1").update(Buffer.alloc(total)).digest("hex");
+  expect(stdout).toBe(`${total} ${expected}`);
+  expect(exitCode).toBe(0);
+});

--- a/test/js/node/process/process-stdin.test.ts
+++ b/test/js/node/process/process-stdin.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isDebug, isWindows } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, isWindows, tempDir } from "harness";
+import { exec } from "node:child_process";
 
 test.concurrent("pipe does the right thing", async () => {
   // Note: Bun.spawnSync uses memfd_create on Linux for pipe, which means we see
@@ -532,19 +533,19 @@ describe.skipIf(isWindows)("pipe backpressure", () => {
   });
 });
 
-test.skipIf(isWindows)("process.stdin over an anonymous pipe delivers each byte exactly once", async () => {
+test("process.stdin over an anonymous pipe delivers each byte exactly once", async () => {
   const total = 10 * 1024 * 1024;
-  const writer = `const chunk = Buffer.alloc(65536); let left = ${total}; (function pump() { while (left > 0) { left -= chunk.length; if (!process.stdout.write(chunk)) return process.stdout.once("drain", pump); } })();`;
-  const reader = `const h = new Bun.CryptoHasher("sha1"); let n = 0; process.stdin.on("data", d => { n += d.length; h.update(d); }); process.stdin.on("close", () => process.stdout.write(n + " " + h.digest("hex")));`;
-  await using proc = Bun.spawn({
-    cmd: ["sh", "-c", `"$BUN" -e "$WRITER" | "$BUN" -e "$READER"`],
-    env: { ...bunEnv, BUN: bunExe(), WRITER: writer, READER: reader },
-    stdout: "pipe",
-    stderr: "pipe",
+  using dir = tempDir("stdin-pipe-exactly-once", {
+    "writer.js": `const chunk = Buffer.alloc(65536); let left = ${total}; (function pump() { while (left > 0) { left -= chunk.length; if (!process.stdout.write(chunk)) return process.stdout.once("drain", pump); } })();`,
+    "reader.js": `const h = new Bun.CryptoHasher("sha1"); let n = 0; process.stdin.on("data", d => { n += d.length; h.update(d); }); process.stdin.on("close", () => process.stdout.write(n + " " + h.digest("hex")));`,
   });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const { promise, resolve } = Promise.withResolvers<{ err: Error | null; stdout: string; stderr: string }>();
+  exec(`"${bunExe()}" writer.js | "${bunExe()}" reader.js`, { cwd: String(dir), env: bunEnv }, (err, stdout, stderr) =>
+    resolve({ err, stdout, stderr }),
+  );
+  const { err, stdout, stderr } = await promise;
   expect(stderr).toBe("");
   const expected = new Bun.CryptoHasher("sha1").update(Buffer.alloc(total)).digest("hex");
   expect(stdout).toBe(`${total} ${expected}`);
-  expect(exitCode).toBe(0);
+  expect(err).toBeNull();
 });


### PR DESCRIPTION
### What does this PR do?

Fixes `process.stdin` (and any streaming `FileReader` over a real pipe) delivering some chunks twice, which made `test/js/node/test/parallel/test-http-chunk-problem.js` fail on Linux after #38656.

`FileReader.on_pull` can re-enter `PosixBufferedReader::read` on the same reader while an outer read loop is inside `on_read_chunk`. Since #38656 that nested frame can't claim the per-loop scratch buffer, so `read_blocking_pipe` takes its `_buffer` branch. That branch dispatched only the newest slice but reinstalled the whole buffer, delivered bytes included, and because `_buffer` kept its capacity every later top-level read was demoted to the same branch. On the final HUP drain (several reads then EOF in one frame) `on_reader_done` handed the retained bytes to the stream a second time.

Now the branch keeps only what re-entry appended after a dispatch, and the scratch/`_buffer` choice keys on `is_empty()` rather than `capacity() == 0` so one nested pull doesn't permanently drop a reader from 256 KB scratch reads to 16 KB buffered ones.

### How did you verify your code works?

Added a `process-stdin.test.ts` case that pipes 10 MiB through `sh -c 'bun | bun'` and checks byte count + sha1. Against the #38656 release build it fails 5/5 on macOS (reader sees 10.6–10.8 MB); with this change it passes, and `bun bd test/js/node/test/parallel/test-http-chunk-problem.js` exits 0.