### PR TITLE
bundler: write metafile chunk references as the chunk's outputs key

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -3982,10 +3982,7 @@ pub mod bv2_impl {
 
                 // Generate metafile if requested (the CLI build command writes the files)
                 let metafile: Option<Box<[u8]>> = if this.linker.options.metafile {
-                    match crate::linker_context::metafile_builder::generate(
-                        &mut this.linker,
-                        &mut chunks,
-                    ) {
+                    match crate::linker_context::metafile_builder::generate(&this.linker, &chunks) {
                         Ok(m) => Some(m),
                         Err(err) => {
                             bun_core::warn!("Failed to generate metafile: {}", err);
@@ -5097,10 +5094,7 @@ pub mod bv2_impl {
 
             // Generate metafile if requested
             let metafile: Option<Box<[u8]>> = if self.linker.options.metafile {
-                match crate::linker_context::metafile_builder::generate(
-                    &mut self.linker,
-                    &mut chunks,
-                ) {
+                match crate::linker_context::metafile_builder::generate(&self.linker, &chunks) {
                     Ok(m) => Some(m),
                     Err(err) => {
                         bun_core::warn!("Failed to generate metafile: {}", err.name());

--- a/src/bundler/linker_context/MetafileBuilder.rs
+++ b/src/bundler/linker_context/MetafileBuilder.rs
@@ -202,8 +202,7 @@ pub(crate) fn generate_chunk_json(
 /// Called after all chunks have been generated in parallel.
 /// Chunk references (unique_keys) are resolved to their final output paths.
 /// The caller is responsible for freeing the returned slice.
-pub(crate) fn generate(c: &mut LinkerContext, chunks: &mut [Chunk]) -> crate::Result<Box<[u8]>> {
-    // Use StringJoiner so we can use breakOutputIntoPieces to resolve chunk references
+pub(crate) fn generate(c: &LinkerContext, chunks: &[Chunk]) -> crate::Result<Box<[u8]>> {
     let mut j = StringJoiner::default();
     // errdefer j.deinit() — handled by Drop
 
@@ -220,12 +219,18 @@ pub(crate) fn generate(c: &mut LinkerContext, chunks: &mut [Chunk]) -> crate::Re
     let mut seen_sources = DynamicBitSet::init_empty(sources.len())?;
     // defer seen_sources.deinit() — handled by Drop
 
+    // compute_cross_chunk_dependencies points a split dynamic import at its chunk by unique key.
+    let mut chunk_index_by_unique_key: StringHashMap<usize> = StringHashMap::default();
+
     // Mark all files that appear in chunks
-    for chunk in chunks.iter() {
+    for (chunk_index, chunk) in chunks.iter().enumerate() {
         for &source_index in chunk.files_with_parts_in_chunk.keys() {
             if (source_index as usize) < sources.len() {
                 seen_sources.set(source_index as usize);
             }
+        }
+        if !chunk.unique_key.is_empty() {
+            chunk_index_by_unique_key.put_static_key(chunk.unique_key, chunk_index)?;
         }
     }
 
@@ -295,7 +300,7 @@ pub(crate) fn generate(c: &mut LinkerContext, chunks: &mut [Chunk]) -> crate::Re
                 j.push_static(b"\n        {\n          \"path\": ");
                 // Bundled imports use the target source's pretty path (same string as the
                 // "inputs" key). `record.path.text` is unreliable here: dedup can set
-                // `source_index` without rewriting the path. Externals/chunk refs fall through.
+                // `source_index` without rewriting the path. Chunk refs use the "outputs" key.
                 let import_path: &[u8] = 'path: {
                     if record.source_index.is_valid()
                         && record.source_index.get() != Index::RUNTIME.get()
@@ -307,6 +312,9 @@ pub(crate) fn generate(c: &mut LinkerContext, chunks: &mut [Chunk]) -> crate::Re
                                 break 'path pretty;
                             }
                         }
+                    }
+                    if let Some(&chunk_index) = chunk_index_by_unique_key.get(record.path.text) {
+                        break 'path &chunks[chunk_index].final_rel_path;
                     }
                     record.path.text
                 };
@@ -418,40 +426,7 @@ pub(crate) fn generate(c: &mut LinkerContext, chunks: &mut [Chunk]) -> crate::Re
 
     j.push_static(b"\n  }\n}\n");
 
-    // If no chunks, there are no chunk references to resolve, so just return the joined string
-    if chunks.is_empty() {
-        return Ok(j.done()?);
-    }
-
-    // Break output into pieces and resolve chunk references to final paths
-    let alloc = c.arena();
-    // SAFETY: every borrowed node in `j` points into `chunk.metafile_chunk_json`,
-    // parse-graph data (import-record kind labels), or `'static` literals, all of
-    // which outlive `intermediate` — it is consumed by `code()` below while `chunks`
-    // and `c` are still alive.
-    let mut j = unsafe { j.detach_lifetime() };
-    let mut intermediate = c.break_output_into_pieces(
-        alloc,
-        &mut j,
-        u32::try_from(chunks.len()).expect("int cast"),
-    )?;
-
-    // Get final output with all chunk references resolved.
-    // `code()` takes the dummy chunk and the full slice as `&`, so pass
-    // `&chunks[0]` directly — overlapping shared borrows are fine.
-    let code_result = intermediate.code(
-        None,
-        parse_graph,
-        &c.graph,
-        b"", // no import prefix for metafile
-        &chunks[0],
-        chunks,
-        None,  // no display size
-        false, // not force absolute path
-        false, // no source map shifts
-    )?;
-
-    Ok(code_result.buffer)
+    Ok(j.done()?)
 }
 
 fn write_json_string(writer: &mut impl Write, str: &[u8]) -> std::io::Result<()> {

--- a/test/bundler/metafile.test.ts
+++ b/test/bundler/metafile.test.ts
@@ -458,6 +458,77 @@ describe("bundler metafile", () => {
     expect(outputPaths).toContain(dynamicImport!.path);
   });
 
+  // A dynamic import that splitting turned into a chunk of its own is reported in "inputs"
+  // by the chunk's output path, which is relative to the outdir like every "outputs" key.
+  // Both layouts below used to produce a path that matched no "outputs" key: the first
+  // because the paths were made relative to the directory of the first chunk, the second
+  // because they were run through the import specifier normalizer ("./pages/b.js" for an
+  // output keyed "pages/b.js").
+  describe("chunk references in inputs are keyed like outputs", () => {
+    function chunkReference(metafile: Metafile, importer: string, imported: string) {
+      const inputKeys = Object.keys(metafile.inputs);
+      const importerKey = inputKeys.find(k => k.replaceAll("\\", "/").endsWith(importer))!;
+      const importedKey = inputKeys.find(k => k.replaceAll("\\", "/").endsWith(imported))!;
+      // The "outputs" key of the chunk each entry point was written to.
+      const [importedChunk, importerChunk] = [importedKey, importerKey].map(
+        entryPoint => Object.entries(metafile.outputs).find(([, output]) => output.entryPoint === entryPoint)![0],
+      );
+      return {
+        importedChunk,
+        inputImports: metafile.inputs[importerKey].imports.map(imp => ({ path: imp.path, kind: imp.kind })),
+        outputImports: metafile.outputs[importerChunk].imports.filter(imp => imp.kind === "dynamic-import"),
+      };
+    }
+
+    test("entry point in a subdirectory of the outdir", async () => {
+      using dir = tempDir("metafile-nested-entry-chunk-ref", {
+        "src/pages/entry.js": `import("../dyn.js").then(m => console.log(m.v));`,
+        "src/dyn.js": `export const v = 1;`,
+      });
+
+      const result = await Bun.build({
+        entrypoints: [`${dir}/src/pages/entry.js`],
+        root: `${dir}/src`,
+        outdir: `${dir}/out`,
+        splitting: true,
+        metafile: true,
+      });
+      expect(result.success).toBe(true);
+
+      const { importedChunk, inputImports, outputImports } = chunkReference(
+        result.metafile as Metafile,
+        "src/pages/entry.js",
+        "src/dyn.js",
+      );
+      expect(inputImports).toEqual([{ path: importedChunk, kind: "dynamic-import" }]);
+      expect(outputImports).toEqual([{ path: importedChunk, kind: "dynamic-import" }]);
+    });
+
+    test("imported entry point in a subdirectory of the outdir", async () => {
+      using dir = tempDir("metafile-nested-target-chunk-ref", {
+        "src/entry.js": `import("./pages/b.js").then(m => console.log(m.v));`,
+        "src/pages/b.js": `export const v = 2;`,
+      });
+
+      const result = await Bun.build({
+        entrypoints: [`${dir}/src/entry.js`, `${dir}/src/pages/b.js`],
+        root: `${dir}/src`,
+        outdir: `${dir}/out`,
+        splitting: true,
+        metafile: true,
+      });
+      expect(result.success).toBe(true);
+
+      const { importedChunk, inputImports, outputImports } = chunkReference(
+        result.metafile as Metafile,
+        "src/entry.js",
+        "src/pages/b.js",
+      );
+      expect(inputImports).toEqual([{ path: importedChunk, kind: "dynamic-import" }]);
+      expect(outputImports).toEqual([{ path: importedChunk, kind: "dynamic-import" }]);
+    });
+  });
+
   test("metafile includes cssBundle for CSS outputs", async () => {
     using dir = tempDir("metafile-css-bundle-test", {
       "entry.js": `import "./styles.css"; console.log("styled");`,


### PR DESCRIPTION
### Problem
- With `--splitting`, a chunk referenced from the metafile's `inputs` section (a dynamic import that got a chunk of its own) is written with a path that matches no `outputs` key, so the two halves of the metafile disagree. Two shapes of it:
  - Entry point in a subdirectory of the outdir (`bun build src/pages/entry.js --root src --splitting --outdir out --metafile=meta.json`): `inputs["src/pages/entry.js"].imports[0].path` is `"../dyn-7kv0c31x.js"`, while the chunk is keyed `"./dyn-7kv0c31x.js"` in `outputs` and listed as `"./dyn-7kv0c31x.js"` in `outputs["pages/entry.js"].imports`.
  - Imported entry point in a subdirectory (`entry.js` does `import("./pages/b.js")`, both are entry points): `inputs` says `"./pages/b.js"`, the `outputs` key is `"pages/b.js"`.
- Cause: `metafile_builder::generate` (src/bundler/linker_context/MetafileBuilder.rs, end of the function) left the chunks' unique keys in the JSON and ran the whole document through `IntermediateOutput::code`, the routine that splices chunk paths into a chunk's source code, with `&chunks[0]` standing in for the importing chunk. That routine formats import specifiers: relative to the importing chunk's directory when it has one (first shape), otherwise normalized with a `./` prefix by `cheap_prefix_normalizer` (second shape). Neither is the string `outputs` is keyed by. Both shapes are the same defect; which one you get depends on where the first chunk happens to live.

### Fix
- `generate` builds a map from each chunk's unique key to its index and, when an import record's path is a unique key, writes that chunk's `final_rel_path`. That is the same string `generate_chunk_json` writes as the chunk's `outputs` key and into `outputs[*].imports`, so the reference matches by construction, whatever the layout or naming template.
- The splice pass at the end of `generate` is removed, along with the `chunks[0]` stand-in and the `detach_lifetime` unsafe block it needed; `generate` now takes `&LinkerContext` and `&[Chunk]`. The splitting rewrite in `compute_cross_chunk_dependencies` is the only thing that puts a unique key into an import record's path (the other placeholder users, file loader strings, HTML import manifests and server component references, live in AST string literals, not in record paths or source paths), and every chunk gets a unique key in `compute_chunks`, so the map resolves every reference the pass used to resolve.
- Everything else in the record is written as before (`kind`, `original`, `external: true` for the cleared source index), and the emitted JavaScript is unchanged: chunk code still goes through `IntermediateOutput::code`, whose importer-relative paths are correct there.
- Related: #38465 proposes reporting these imports as the imported input file instead (esbuild's format). The two changes are independent; if both land, this PR is what formats any chunk reference that still reaches `inputs`. #38366 changes when output keys carry a `./` prefix; this PR copies the key, so it is unaffected.
- Verified with test/bundler/metafile.test.ts: the two new cases under "chunk references in inputs are keyed like outputs" fail on the released build (`../chunk-rr3a4n40.js` vs `./chunk-rr3a4n40.js`, and `./pages/b.js` vs `pages/b.js`) and pass with this change; 46/46 in the file pass.
  - test/bundler/esbuild/metafile.test.ts (12/12) and test/bundler/bundler_splitting.test.ts (11/11) pass.
  - Checked the CLI repro above, the two entry point variant, and a build with `--public-path`, `--chunk-naming "chunks/[name]-[hash].[ext]"` and `--entry-naming "nested/[name].[ext]"`: `inputs` now names each chunk by its `outputs` key, and the code emitted for the chunks is byte-identical to before.

### Background
- Metafile: the esbuild-format build report (`--metafile` / `metafile: true`). `inputs` maps each source file to the imports found in it; `outputs` maps each emitted file (keyed by its outdir-relative path) to what it contains and which other outputs it imports. Bun writes each chunk's `outputs` entry during parallel chunk generation (`generate_chunk_json`) and assembles `inputs` afterwards in `generate`.
- Unique key: a per-build random placeholder every chunk gets in `compute_chunks` before its output path is known. Chunk code is printed with placeholders, and once the final paths exist `IntermediateOutput::code` splices the real paths in, formatted as import specifiers for the chunk being written. With splitting, `compute_cross_chunk_dependencies` also stores the target chunk's unique key in the import record of a dynamic import, which is how the metafile came to contain placeholders.
- `final_rel_path`: a chunk's output path relative to the outdir, rendered from the naming template (so it carries a `./` prefix or not depending on the template). It is the `outputs` key.

<details>
<summary>Repro</summary>

```sh
mkdir -p src/pages
printf 'import("../dyn.js").then(m => console.log(m.v));\n' > src/pages/entry.js
printf 'export const v = 1;\n' > src/dyn.js
bun build ./src/pages/entry.js --root src --splitting --outdir out --metafile=meta.json
```

bun 1.4.0: `outputs` keys are `pages/entry.js`, `./entry-c3taa3cg.js`, `./dyn-7kv0c31x.js`; `inputs["src/pages/entry.js"].imports[0].path` is `"../dyn-7kv0c31x.js"`.

With this change it is `"./dyn-7kv0c31x.js"`.

Second shape:

```sh
printf 'import("./pages/b.js").then(m => console.log(m.v));\n' > src/entry.js
printf 'export const v = 2;\n' > src/pages/b.js
bun build ./src/entry.js ./src/pages/b.js --root src --splitting --outdir out --metafile=meta.json
```

bun 1.4.0: `inputs["src/entry.js"].imports[0].path` is `"./pages/b.js"`, the `outputs` key is `"pages/b.js"`. With this change it is `"pages/b.js"`.
</details>
