### PR TITLE
ci: trigger a bun.com deploy when docs, bun-types or install scripts change

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -24,7 +24,9 @@ concurrency:
 
 jobs:
   deploy:
+    if: github.repository == 'oven-sh/bun'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Trigger Vercel deployment
         env:
@@ -34,5 +36,8 @@ jobs:
             echo "::error::SITE_VERCEL_DEPLOY_HOOK secret is not set"
             exit 1
           fi
-          curl --fail --silent --show-error -X POST "$VERCEL_DEPLOY_HOOK"
+          curl --fail --silent --show-error \
+            --connect-timeout 10 \
+            --max-time 60 \
+            -X POST "$VERCEL_DEPLOY_HOOK"
           echo "Vercel deployment triggered"

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -1,0 +1,38 @@
+name: Deploy bun.com
+
+# bun.com (oven-sh/site) bakes a slice of this repository into its build:
+# docs/** and guides (rendered natively), packages/bun-types (API reference),
+# and the install scripts. Nothing on the site side watches this repo, so a
+# push that only touches those paths would otherwise sit unpublished until the
+# next unrelated site deploy. Poke the site's Vercel deploy hook instead.
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - "packages/bun-types/**"
+      - "src/runtime/cli/install.sh"
+      - "src/runtime/cli/install.ps1"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: deploy-site
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Vercel deployment
+        env:
+          VERCEL_DEPLOY_HOOK: ${{ secrets.SITE_VERCEL_DEPLOY_HOOK }}
+        run: |
+          if [ -z "$VERCEL_DEPLOY_HOOK" ]; then
+            echo "::error::SITE_VERCEL_DEPLOY_HOOK secret is not set"
+            exit 1
+          fi
+          curl --fail --silent --show-error -X POST "$VERCEL_DEPLOY_HOOK"
+          echo "Vercel deployment triggered"


### PR DESCRIPTION
bun.com now renders `docs/**` and `guides/**` itself (Mintlify no longer serves them), and its build also bakes in `packages/bun-types` and `src/runtime/cli/install.{sh,ps1}` from a sparse clone of this repo. Nothing tells the site to rebuild when those change, so a docs-only push to `main` sits unpublished until the next unrelated site deploy.

This adds a workflow that POSTs the site's Vercel deploy hook on pushes to `main` touching those paths (plus `workflow_dispatch` for a manual poke). No actions are used, so nothing to SHA-pin. Concurrent runs collapse to the latest.

**Setup before merge:** add the repo secret `SITE_VERCEL_DEPLOY_HOOK` (the same hook `oven-sh/site` already uses in its `update-releases` cron). The job fails loudly if it is missing.

**Testing:** not runnable from a branch since it only fires on `main`. After merge, run it once via `workflow_dispatch` and confirm a deployment appears in the site's Vercel project.
