### PR TITLE
Lower super in static blocks and static initializers relocated by decorator lowering (stacked on #38769)

### DIFF
--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -76,6 +76,33 @@ struct SuperLowering<'r> {
     is_static: bool,
 }
 
+/// Static blocks and static initializers emitted after the class: `this` is the class and
+/// `super.x` is a static `super` access. Every site that moves such code out of the body
+/// goes through `rewrite_relocated_static_*`.
+#[derive(Clone, Copy)]
+struct RelocatedStatic<'r> {
+    home: &'r Cell<Option<Ref>>,
+    class_ref: Ref,
+    class_loc: bun_ast::Loc,
+}
+
+impl<'r> RelocatedStatic<'r> {
+    /// `LowerSuper` first: the `this` receivers it emits are replaced together with the
+    /// user's own `this` by the class binding, which class decorators may have reassigned.
+    fn kinds(self) -> [RewriteKind<'r>; 2] {
+        [
+            RewriteKind::LowerSuper(SuperLowering {
+                class_ref: self.home,
+                is_static: true,
+            }),
+            RewriteKind::ReplaceThis {
+                ref_: self.class_ref,
+                loc: self.class_loc,
+            },
+        ]
+    }
+}
+
 // ── Shallow-copy helpers (Property / Class are not `Clone` because they hold
 //    raw arena pointers; copying the raw pointers is intentional). ──
 
@@ -621,6 +648,18 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let kind = RewriteKind::LowerSuper(ctx);
         self.rewrite_args(func.func.args.slice_mut(), kind);
         self.rewrite_stmts(func.func.body.stmts.slice_mut(), kind);
+    }
+
+    fn rewrite_relocated_static_expr(&mut self, expr: &mut Expr, ctx: RelocatedStatic<'_>) {
+        for kind in ctx.kinds() {
+            self.rewrite_expr(expr, kind);
+        }
+    }
+
+    fn rewrite_relocated_static_stmts(&mut self, stmts: &mut [Stmt], ctx: RelocatedStatic<'_>) {
+        for kind in ctx.kinds() {
+            self.rewrite_stmts(stmts, kind);
+        }
     }
 
     /// The key of `super.name` / `super[expr]`; `None` for any other expression.
@@ -1772,6 +1811,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let mut emitted_private_adds: HashMap<u32, ()> = HashMap::default();
         let mut static_private_add_blocks = BumpVec::<Property>::new_in(bump);
         let super_home_ref: Cell<Option<Ref>> = Cell::new(None);
+        let relocated_static = RelocatedStatic {
+            home: &super_home_ref,
+            class_ref: class_name_ref,
+            class_loc: class_name_loc,
+        };
 
         // Pre-scan: determine if all private members need lowering
         let mut lower_all_private = false;
@@ -2012,7 +2056,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         ..Default::default()
                     });
 
-                    let init_val = prop
+                    let mut init_val = prop
                         .initializer
                         .unwrap_or_else(|| p.new_expr(E::Undefined {}, loc));
                     if !prop.flags.contains(Flags::Property::IsStatic) {
@@ -2027,6 +2071,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             loc,
                         ));
                     } else {
+                        p.rewrite_relocated_static_expr(&mut init_val, relocated_static);
                         let cn_e = p.use_ref(class_name_ref, class_name_loc);
                         let wm_e3 = p.use_ref(wm_ref, loc);
                         suffix_exprs.push(p.call_rt(
@@ -2039,7 +2084,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
                 // Static blocks → extract to suffix
                 if prop.kind == PropertyKind::ClassStaticBlock {
-                    if let Some(sb) = prop.class_static_block {
+                    if let Some(mut sb) = prop.class_static_block {
+                        p.rewrite_relocated_static_stmts(sb.stmts.slice_mut(), relocated_static);
                         static_element_order.push(StaticElement {
                             kind: StaticElementKind::Block,
                             index: extracted_static_blocks.len(),
@@ -2305,13 +2351,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
 
                 let is_accessor = k == 4;
-                let init_entry = FieldInitEntry {
+                let mut init_entry = FieldInitEntry {
                     prop: prop_shallow,
                     is_private,
                     is_accessor,
                 };
 
                 if prop.flags.contains(Flags::Property::IsStatic) {
+                    if let Some(init) = &mut init_entry.prop.initializer {
+                        p.rewrite_relocated_static_expr(init, relocated_static);
+                    }
                     if is_accessor {
                         static_non_field_elements.push(element);
                         static_accessor_count += 1;
@@ -2509,13 +2558,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         // `StoreRef::DerefMut` — arena-owned, safe under the StoreRef invariant.
                         let sb = &mut *extracted_static_blocks[elem.index];
                         let stmts_slice = sb.stmts.slice_mut();
-                        p.rewrite_stmts(
-                            stmts_slice,
-                            RewriteKind::ReplaceThis {
-                                ref_: class_name_ref,
-                                loc: class_name_loc,
-                            },
-                        );
 
                         let all_exprs = stmts_slice
                             .iter()

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -76,9 +76,7 @@ struct SuperLowering<'r> {
     is_static: bool,
 }
 
-/// Static blocks and static initializers emitted after the class: `this` is the class and
-/// `super.x` is a static `super` access. Every site that moves such code out of the body
-/// goes through `rewrite_relocated_static_*`.
+/// Static code emitted after the class. Every relocation site uses `rewrite_relocated_static_*`.
 #[derive(Clone, Copy)]
 struct RelocatedStatic<'r> {
     home: &'r Cell<Option<Ref>>,
@@ -87,8 +85,7 @@ struct RelocatedStatic<'r> {
 }
 
 impl<'r> RelocatedStatic<'r> {
-    /// `LowerSuper` first: the `this` receivers it emits are replaced together with the
-    /// user's own `this` by the class binding, which class decorators may have reassigned.
+    /// `LowerSuper` first, so the `this` receivers it emits are replaced along with the user's own.
     fn kinds(self) -> [RewriteKind<'r>; 2] {
         [
             RewriteKind::LowerSuper(SuperLowering {

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1833,7 +1833,7 @@ describe("ES Decorators", () => {
       expect(statement).toContain("_home = this;");
       expect(statement).toMatch(/__superGet\w*\(_home, C, "x"\)/);
       expect(statement).toMatch(/__superGet\w*\(_home, C, "m"\)\.call\(C, 1\)/);
-      expect(statement).not.toContain("super.");
+      expect(statement).not.toMatch(/\bsuper\b/);
 
       const expression = transpiler.transformSync(`
         function dec() {}
@@ -1842,7 +1842,7 @@ describe("ES Decorators", () => {
         };
       `);
       expect(expression).toMatch(/__superGet\w*\(_home, _class, key\)/);
-      expect(expression).not.toContain("super.");
+      expect(expression).not.toMatch(/\bsuper\b/);
 
       const withoutSuper = transpiler.transformSync(`
         function dec() {}

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1510,6 +1510,353 @@ describe("ES Decorators", () => {
     });
   });
 
+  // The lowering also moves static blocks and the initializers of lowered static
+  // fields/accessors out of the class body. The expected output of each program
+  // is what the same class prints without the lowering (checked with node; the
+  // class decorator case against tsc's emit), which pins the receiver as well as
+  // the object the lookup starts from.
+  describe.concurrent("super property access in relocated static code", () => {
+    const base = `
+      class Base {
+        static x = 1;
+        static named = "named";
+        static get who() { return "who:" + this.name; }
+        static set tap(v) { this.tapped = this.name + "=" + v; }
+        static m(...args) { return "m:" + this.name + ":" + args.join(","); }
+        static tag(strings, ...values) { return "tag:" + this.name + ":" + strings.join("|") + ":" + values.join(","); }
+      }
+    `;
+
+    test("static block reads, computed keys and calls keep the class as receiver", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        ${base}
+        function dec() {}
+        const prop = "named";
+        const method = "m";
+        class C extends Base {
+          @dec static decorated;
+          static {
+            console.log(super.x, super[prop], super.who);
+            console.log(super.m(1, 2), super[method](3));
+            console.log(super.m?.(4), super.missing?.(5));
+            console.log(super.tag\`a\${super.x}b\`);
+            console.log((() => super.x + 1)());
+          }
+        }
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe(["1 named who:C", "m:C:1,2 m:C:3", "m:C:4 undefined", "tag:C:a|b:1", "2"].join("\n") + "\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("awaited super accesses inside an async arrow in a static block", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        ${base}
+        function dec() {}
+        class C extends Base {
+          @dec static decorated;
+          static {
+            (async () => {
+              console.log(await super.m("async"), (await super.x) + 1);
+            })();
+          }
+        }
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("m:C:async 2\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("static block assignments invoke inherited setters and define on the class", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        ${base}
+        function dec() {}
+        const key = "viaIndex";
+        class C extends Base {
+          @dec static decorated;
+          static {
+            super.tap = "t";
+            super.plain = "p";
+            super[key] = "i";
+            super.a = 1, super.b = 2;
+            if (super.x) super.c = 3;
+          }
+        }
+        console.log(C.tapped, Object.hasOwn(Base, "tapped"));
+        console.log(C.plain, C.viaIndex, Object.hasOwn(Base, "plain"), Object.hasOwn(Base, "viaIndex"));
+        console.log(C.a, C.b, C.c);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("C=t false\np i false false\n1 2 3\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("every write form prints what the undecorated class prints", async () => {
+      // Reads go to the parent and writes land on the class, so e.g. super.n++
+      // after super.n += 5 still reads the parent's 1.
+      const body = `
+        static out = [];
+        static {
+          super.n += 5;
+          this.out.push(["plusEq", this.n, Base.n, Object.hasOwn(this, "n")]);
+          super[key] *= 3;
+          this.out.push(["computedMulEq", this.computed, Base.computed]);
+          const post = super.n++;
+          this.out.push(["postInc", post, this.n]);
+          this.out.push(["preDec", --super.n]);
+          super.missing ??= "filled";
+          super.n ||= "never";
+          this.out.push(["logical", this.missing, this.n]);
+          const assigned = (super.acc = "v");
+          this.out.push(["assignValue", assigned, this.backing]);
+          [super.first, super.second = "dflt"] = ["f"];
+          ({ s: super.third } = { s: "t" });
+          this.out.push(["destructure", this.first, this.second, this.third]);
+          let threw = "no";
+          try { delete super.n; } catch (e) { threw = e.constructor.name; }
+          this.out.push(["delete", threw]);
+          this.out.push(["call", super.m()]);
+        }
+      `;
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() {}
+        const key = "computed";
+        function makeBase() {
+          return class {
+            static n = 1;
+            static computed = 10;
+            static get acc() { return this.backing; }
+            static set acc(v) { this.backing = "set:" + v; }
+            static m() { return "m:" + this.name; }
+          };
+        }
+        const native = (() => { const Base = makeBase(); class C extends Base { ${body} } return JSON.stringify(C.out); })();
+        const lowered = (() => { const Base = makeBase(); class C extends Base { @dec static decorated; ${body} } return JSON.stringify(C.out); })();
+        console.log(native === lowered);
+        console.log(lowered);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe(
+        "true\n" +
+          JSON.stringify([
+            ["plusEq", 6, 1, true],
+            ["computedMulEq", 30, 10],
+            ["postInc", 1, 2],
+            ["preDec", 0],
+            ["logical", "filled", 0],
+            ["assignValue", "v", "set:v"],
+            ["destructure", "f", "dflt", "t"],
+            ["delete", "ReferenceError"],
+            ["call", "m:C"],
+          ]) +
+          "\n",
+      );
+      expect(exitCode).toBe(0);
+    });
+
+    test("static block with declarations (wrapped in an IIFE) still sees super", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        ${base}
+        function dec() {}
+        class C extends Base {
+          @dec static decorated;
+          static {
+            const doubled = super.x * 2;
+            let calls = "";
+            for (let i = 0; i < 2; i++) calls += super.m(i);
+            let destructured;
+            [destructured] = [super.named];
+            console.log(doubled, calls, destructured);
+          }
+        }
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("2 m:C:0m:C:1 named\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("decorated static field, accessor and private field initializers", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        ${base}
+        function dec() {}
+        const key = "x";
+        class C extends Base {
+          @dec static field = super.x + 10;
+          @dec static computed = super[key] + 20;
+          @dec static called = super.m("init");
+          @dec static got = super.who;
+          @dec static self = this === C && this.field;
+          @dec static accessor acc = super.x + 30;
+          @dec static #priv = super.x + 40;
+          static get priv() { return C.#priv; }
+        }
+        console.log(C.field, C.computed, C.called, C.got, C.self, C.acc, C.priv);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("11 21 m:C:init who:C 11 31 41\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("undecorated static accessor initializer in a decorated class", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        ${base}
+        function dec() {}
+        class C extends Base {
+          @dec static decorated;
+          static accessor acc = super.m(super.x) + "/" + this.name;
+        }
+        console.log(C.acc);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("m:C:1/C\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("static accessor initializer in a class with no decorators at all", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        ${base}
+        class C extends Base {
+          static accessor acc = super.x + 5;
+        }
+        console.log(C.acc);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("6\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("class without an extends clause looks up Function.prototype", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() {}
+        class C {
+          @dec static decorated;
+          static { console.log(super.call === Function.prototype.call); }
+          @dec static ctor = super.constructor === Function;
+        }
+        console.log(C.ctor);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("true\ntrue\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("class replaced by a class decorator is the receiver, lookup still starts at the parent", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        ${base}
+        function dec() {}
+        function replace(cls) {
+          return class Replaced extends cls { static x = "shadowed"; };
+        }
+        @replace class C extends Base {
+          static { console.log(super.x, super.who, this.name); }
+          @dec static field = super.m(super.x);
+        }
+        console.log(C.name, C.field);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("1 who:Replaced Replaced\nReplaced m:Replaced:1\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("class expressions", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        ${base}
+        function dec() {}
+        const Anon = class extends Base {
+          @dec static field = super.x + 1;
+          static { console.log(super.m("anon")); }
+        };
+        const Named = class Inner extends Base {
+          @dec static field = super.x + 2;
+          static { console.log(super.m("named")); }
+        };
+        console.log(Anon.field, Named.field);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("m:Anon:anon\nm:Inner:named\n2 3\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("decorated class inside a method binds super to its own parent", async () => {
+      // Without the rewrite this is not even a syntax error: the relocated
+      // super.x lands inside Outer's method and silently reads OuterBase.
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() {}
+        class OuterBase { static x = "outer"; }
+        class InnerBase { static x = "inner"; }
+        class Outer extends OuterBase {
+          static make() {
+            class Inner extends InnerBase {
+              @dec static fromInit = super.x;
+              static { this.fromBlock = super.x; }
+            }
+            return Inner;
+          }
+        }
+        const Inner = Outer.make();
+        console.log(Inner.fromInit, Inner.fromBlock);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("inner inner\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("super inside nested methods and classes is left alone", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        ${base}
+        function dec() {}
+        class C extends Base {
+          @dec static decorated;
+          static {
+            const proto = { m() { return "proto:" + this.tagName; } };
+            const obj = { tagName: "obj", m() { return super.m() + "," + this.tagName; } };
+            Object.setPrototypeOf(obj, proto);
+            class Inner extends Base { static { this.fromInner = super.m("inner"); } }
+            console.log(obj.m(), Inner.fromInner, super.m("outer"));
+          }
+        }
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("proto:obj,obj m:Inner:inner m:C:outer\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("Bun.Transpiler output uses the captured class with the class binding as receiver", () => {
+      const transpiler = new Bun.Transpiler({ loader: "js" });
+      const statement = transpiler.transformSync(`
+        function dec() {}
+        class C extends Base {
+          @dec static field = super.x;
+          static { super.m(1); }
+        }
+      `);
+      expect(statement).toContain("_home = this;");
+      expect(statement).toMatch(/__superGet\w*\(_home, C, "x"\)/);
+      expect(statement).toMatch(/__superGet\w*\(_home, C, "m"\)\.call\(C, 1\)/);
+      expect(statement).not.toContain("super.");
+
+      const expression = transpiler.transformSync(`
+        function dec() {}
+        const C = class extends Base {
+          @dec static field = super[key];
+        };
+      `);
+      expect(expression).toMatch(/__superGet\w*\(_home, _class, key\)/);
+      expect(expression).not.toContain("super.");
+
+      const withoutSuper = transpiler.transformSync(`
+        function dec() {}
+        class C extends Base {
+          @dec static field = this.x;
+          static { this.y = 2; }
+          static inBody = super.x;
+        }
+      `);
+      expect(withoutSuper).not.toContain("_home");
+      expect(withoutSuper).toContain("static inBody = super.x;");
+    });
+  });
+
   describe("accessor with TypeScript annotations", () => {
     test("accessor with definite assignment assertion (!)", async () => {
       using dir = tempDir("es-dec-accessor-bang", {


### PR DESCRIPTION
Stacked on #38769: this PR's base is that PR's branch, so the diff shown here is only the static-site change, and it retargets to `main` when #38769 merges. Intended merge order: #31930, #38769, then this.

### Problem

- The standard (TC39) decorator lowering moves class static blocks and the initializers of lowered static fields/accessors out of the class body and emits them after the class. A `super.x` in that code was copied verbatim (`lower_impl` in `src/js_parser/lower/lower_decorators.rs`: the static block extraction and the `static_init_entries` push in the property loop, plus the undecorated static `accessor` initializer, which triggers the lowering without any decorator).
- At module or function level that is `SyntaxError: super is not valid in this context.` and the file fails to load. When the decorated class is declared inside a method of another class it is worse: the relocated `super.x` now sits inside that method, is valid there, and silently reads the enclosing class's parent (bun 1.4.0 prints `outer` for the `decorated class inside a method` test below).

```ts
function dec(v: any, c: any) {}
class Base { static x = 1; }
class C extends Base {
  @dec static y = 2;
  static { console.log("block super.x =", super.x); }
  @dec static z = super.x + 10;
}
console.log(C.z); // expected: "block super.x = 1" then 11 (tsc, esbuild, native decorators)
```

### Fix

- #38769 adds the `super` lowering for private method bodies that leave the class body (`RewriteKind::LowerSuper`, emitting `__superGet` / `__superSet` / `__superWrapper` against a `_home` temporary that a leading static block binds to the class). This PR runs that pass over the three static relocation sites as well, followed by the `ReplaceThis` pass that extracted static blocks already had, through one helper (`RelocatedStatic`, `rewrite_relocated_static_expr` / `_stmts`) that every relocation site calls. About 40 lines in the lowering, no new mechanism.
- The order inside the helper is the one non-obvious point: `LowerSuper` emits `__superGet(_home, this, key)`, and `ReplaceThis` afterwards turns that `this` (together with the user's own) into the class binding. That is the receiver the spec wants, the class as possibly reassigned by class decorators, while `_home` keeps the lookup starting at the original class's parent (`class replaced by a class decorator ...` test).
- The rewrites run when each piece is extracted in the property loop instead of in step 7, because `_home` is declared and its capture block emitted right after that loop. The private-access rewriting that runs in between does not care: `this.#x` lowers the same whether the receiver is `this` or `C`.
- The decorated static initializer and undecorated static accessor sites thereby also get `this` replaced, which they lacked before (pinned by `@dec static self = this === C` and `static accessor a = ... + this.name`); that is the `this` half of #31922 for these two sites.
- Why not the first revision of this PR (standalone inline `Reflect.get(_base, key, C)`): review found that `_base` is spelled the same for every class in a file, so a closure escaping from relocated code in one class read the next decorated class's base, silently wrong where today's code fails loudly, and that it was a second mechanism next to #38769's. `_home` has the same spelling problem until #31930 lands (it bites when two classes in one file both use relocated `super` and one stores a closure; #38769's method bodies depend on #31930 in the same way), hence the merge order above.
- Not covered here: #38731 adds a fourth relocation site (undecorated static fields of class-decorated classes); whichever of the two lands second adds the one `rewrite_relocated_static_expr` call there. #31926 / #35708 stop relocating the undecorated accessor initializer, at which point that call site disappears with it. The positions the shared walker still skips (object literal computed keys, arrow parameter defaults, nested class `extends` clauses) are #31922's.
- Verification: new `super property access in relocated static code` block in `test/bundler/transpiler/es-decorators.test.ts`, 14 tests. With this PR's `src/` change removed (so on #38769 alone) all 14 fail; with it all 14 pass. Expected outputs are what the same classes print without the lowering: `every write form ...` runs the identical static block natively and lowered in one program and prints whether the two agree (compound and logical assignment, `++` / `--`, assignment used as a value, destructuring targets with a default, `delete` throwing, computed keys); the other programs were run through node (tsc's emit for the class decorator case). Also covered: reads, calls, `?.()`, tagged templates, `await` in an async arrow, IIFE-wrapped blocks, decorated field / accessor / private field initializers, an undecorated accessor in a decorated class and in a class with no decorators, no `extends` clause, class expressions, the method-scoped class, nested object methods and classes keeping their own `super`, and the emitted shape.
- Suites run on this stack: `es-decorators` (including #38769's block), `es-decorators-esbuild`, `decorators`, `decorator-metadata`, `bundler_decorator_metadata`, `ts-use-define-for-class-fields`, `esbuild/ts`, `transpiler.test.js`, `bundler_edgecase`: green. A probe with every read, call and write form matched node's output for the unlowered class through `bun run`, `bun build` and `--minify`.

### Background

- Standard decorator lowering: a class with TC39 decorators (or an `accessor` member) is printed as a plain class followed by `__decorateElement` / `__runInitializers` calls. Static blocks and the initializers of lowered static members must run after those calls, so they are moved out of the body too; `ReplaceThis` is the existing pass that turns their `this` into the class binding.
- `super.x` in a static block or static initializer means: look `x` up on the [[Prototype]] of the class being defined (its home object), with the class as receiver. With class decorators the receiver is the replacement class but the home object is still the original one. `__superGet(home, receiver, key)` is `Reflect.get(Object.getPrototypeOf(home), key, receiver)`; `_home` is bound to the original class by the static block #38769 puts first in the body.
- Lowering temporaries (`_home`, `_init`, `_base`, ...) are printed by spelling; the runtime transpiler has no rename pass, so two classes in one file share one `var` of each name. Reads made while the class is being defined are fine; reads from closures or method bodies that run later see the last class's value. #31930 gives the temporaries file-unique names.

<details>
<summary>First revision of this PR, superseded</summary>

The initial version rewrote the same three sites to inline `Reflect.get(_base, key, C)` / `Reflect.set(...)` (tsc's emit shape) and left compound writes, destructuring targets and classes without `extends` as syntax errors. It was replaced by the stacked version above after review; its behaviour tests carried over.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 14 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/es-decorators.test.ts
bun test v1.4.0 (40a07eab0)

test/bundler/transpiler/es-decorators.test.ts:
(pass) ES Decorators > class decorators > basic class decorator [447.64ms]
(pass) ES Decorators > class decorators > class decorator receives correct context [398.94ms]
(pass) ES Decorators > class decorators > class decorator can replace class [447.05ms]
(pass) ES Decorators > class decorators > multiple class decorators apply in reverse order [471.23ms]
(pass) ES Decorators > method decorators > instance method decorator [448.68ms]
(pass) ES Decorators > method decorators > static method decorator [383.26ms]
(pass) ES Decorators > method decorators > method decorator context has correct access [358.63ms]
(pass) ES Decorators > getter decorators > getter decorator [393.64ms]
(pass) ES Decorators > setter decorators > setter decorator [368.73ms]
(pass) ES Decorators > field decorators > field decorator receives undefined value [487.83ms]
(pass) ES Decorators > field decorators > multiple field decorators [394.07ms]

... (truncated)

release without fix: 25 FAILED
bun test v1.4.0-canary.1 (b7a043103)

test/bundler/transpiler/es-decorators.test.ts:
(pass) ES Decorators > class decorators > basic class decorator [49.25ms]
(pass) ES Decorators > class decorators > class decorator receives correct context [13.62ms]
(pass) ES Decorators > class decorators > class decorator can replace class [21.88ms]
(pass) ES Decorators > class decorators > multiple class decorators apply in reverse order [19.20ms]
(pass) ES Decorators > method decorators > instance method decorator [15.15ms]
(pass) ES Decorators > method decorators > static method decorator [14.17ms]
(pass) ES Decorators > method decorators > method decorator context has correct access [12.68ms]
(pass) ES Decorators > getter decorators > getter decorator [23.30ms]
(pass) ES Decorators > setter decorators > setter decorator [23.28ms]
(pass) ES Decorators > field decorators > field decorator receives undefined value [25.74ms]
(pass) ES Decorators > field decorators > multiple field decorators [20.34ms]
(pass) ES Decorators > field decorators > static field decorator [17.60ms]
(pass) ES Decorators > non-ASCII string-literal keys > Bun.Transpiler output preserves the key [0.76ms]
(p
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/es-decorators.test.ts
bun test v1.4.0 (40a07eab0)

test/bundler/transpiler/es-decorators.test.ts:
(pass) ES Decorators > class decorators > basic class decorator [413.31ms]
(pass) ES Decorators > class decorators > class decorator receives correct context [356.64ms]
(pass) ES Decorators > class decorators > class decorator can replace class [390.80ms]
(pass) ES Decorators > class decorators > multiple class decorators apply in reverse order [452.83ms]
(pass) ES Decorators > method decorators > instance method decorator [569.10ms]
(pass) ES Decorators > method decorators > static method decorator [398.51ms]
(pass) ES Decorators > method decorators > method decorator context has correct access [464.89ms]
(pass) ES Decorators > getter decorators > getter decorator [504.64ms]
(pass) ES Decorators > setter decorators > setter decorator [503.95ms]
(pass) ES Decorators > field decorators > field decorator receives undefined value [405.55ms]
(pass) ES Decorators > field decorators > multiple field decorators [440.35ms]

... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     40a07eab02
  features     baseline

22 deps, 123 codegen, 1176 objects in 1350ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] gen ErrorCode+*.h
[2/1238] fetch tinycc
[tinycc] up to date
[3/1237] gen bindgenv2
[4/1237] fetch zlib
[zlib] up to date
[5/1237] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1237] gen .bind.ts → GeneratedBindings.cpp
[7/1237] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[8/1237] gen ProcessBindingBuffer.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingBuffer.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingBuffer.cpp
[9/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[10/1237] gen ZigGlobalObject.lut.h
Generating /workspace/bun/build/release/codegen/ZigGlobalObject.lut.h from /workspace/bu
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/lower/lower_decorators.rs       |  59 ++++-
 test/bundler/transpiler/es-decorators.test.ts | 347 ++++++++++++++++++++++++++
 2 files changed, 396 insertions(+), 10 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
src/js_parser/lower/lower_decorators.rs           33     41      0
test/bundler/transpiler/es-decorators.test.ts     10     12      0
```

</details>

<!-- robobun:evidence:end -->