### PR TITLE
Let a decorated class body observe the class its decorators return

### DIFF
--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -156,6 +156,15 @@ fn has_private_key(prop: &Property) -> bool {
     matches!(prop.key, Some(key) if matches!(key.data, js_ast::ExprData::EPrivateIdentifier(_)))
 }
 
+/// Undecorated private static field or static auto-accessor: initialized outside step 7's order.
+#[inline]
+fn is_unordered_static_initializer(prop: &Property) -> bool {
+    prop.flags.contains(Flags::Property::IsStatic)
+        && !prop.flags.contains(Flags::Property::IsMethod)
+        && prop.ts_decorators.len_u32() == 0
+        && (has_private_key(prop) || prop.kind == PropertyKind::AutoAccessor)
+}
+
 /// Shapes `rewrite_expr` walks fully; never `super`, `new.target`, `#names`, functions or classes.
 fn can_leave_class_body(expr: &Expr) -> bool {
     use js_ast::ExprData as D;
@@ -1284,8 +1293,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // All or nothing (keys are pre-evaluated in Phase 2), so static members keep their order.
         let relocate_static_fields = class_decorators_len > 0
             && class.properties.slice().iter().all(|prop| {
-                (!prop.flags.contains(Flags::Property::IsComputed)
-                    || prop.key.is_none_or(|key| can_leave_class_body(&key)))
+                !is_unordered_static_initializer(prop)
+                    && (!prop.flags.contains(Flags::Property::IsComputed)
+                        || prop.key.is_none_or(|key| can_leave_class_body(&key)))
                     && (!is_plain_static_field(prop)
                         || prop
                             .initializer

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -156,13 +156,20 @@ fn has_private_key(prop: &Property) -> bool {
     matches!(prop.key, Some(key) if matches!(key.data, js_ast::ExprData::EPrivateIdentifier(_)))
 }
 
-/// Undecorated private static field or static auto-accessor: initialized outside step 7's order.
+/// Its storage is initialized before the class decorator runs, outside step 7's source order.
 #[inline]
-fn is_unordered_static_initializer(prop: &Property) -> bool {
-    prop.flags.contains(Flags::Property::IsStatic)
-        && !prop.flags.contains(Flags::Property::IsMethod)
+fn is_undecorated_static_accessor(prop: &Property) -> bool {
+    prop.kind == PropertyKind::AutoAccessor
+        && prop.flags.contains(Flags::Property::IsStatic)
         && prop.ts_decorators.len_u32() == 0
-        && (has_private_key(prop) || prop.kind == PropertyKind::AutoAccessor)
+}
+
+fn has_private_static_member(class: &G::Class) -> bool {
+    class
+        .properties
+        .slice()
+        .iter()
+        .any(|prop| prop.flags.contains(Flags::Property::IsStatic) && has_private_key(prop))
 }
 
 /// Shapes `rewrite_expr` walks fully; never `super`, `new.target`, `#names`, functions or classes.
@@ -220,11 +227,7 @@ fn can_leave_class_body(expr: &Expr) -> bool {
 pub(crate) fn wants_inner_class_binding(class: &G::Class) -> bool {
     class.should_lower_standard_decorators
         && class.ts_decorators.len_u32() > 0
-        && !class
-            .properties
-            .slice()
-            .iter()
-            .any(|prop| prop.flags.contains(Flags::Property::IsStatic) && has_private_key(prop))
+        && !has_private_static_member(class)
 }
 
 // ── impl P ───────────────────────────────────────────────────────────────────
@@ -1272,7 +1275,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             class_name_loc = class.class_name.as_ref().unwrap().loc;
         }
 
-        // Class expressions keep their per-evaluation name binding; see `relocated_name_rewrite`.
+        // Class expressions keep their own name binding (see `body_names_class_as_written`).
         let inner_class_ref: Ref = if is_expr {
             class_name_ref
         } else if visited_inner_class_ref.is_symbol() {
@@ -1290,10 +1293,18 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             bun_alloc::AstAlloc::take(&mut class.ts_decorators);
         let class_decorators_len = class_decorators.len_u32() as usize;
 
+        // Relocated fields land on the decorated class; a body naming the original would miss them.
+        let body_names_class_as_written = if is_expr {
+            !expr_class_is_anonymous
+                && p.symbols[class_name_ref.inner_index() as usize].use_count_estimate > 0
+        } else {
+            has_private_static_member(class)
+        };
         // All or nothing (keys are pre-evaluated in Phase 2), so static members keep their order.
         let relocate_static_fields = class_decorators_len > 0
+            && !body_names_class_as_written
             && class.properties.slice().iter().all(|prop| {
-                !is_unordered_static_initializer(prop)
+                !is_undecorated_static_accessor(prop)
                     && (!prop.flags.contains(Flags::Property::IsComputed)
                         || prop.key.is_none_or(|key| can_leave_class_body(&key)))
                     && (!is_plain_static_field(prop)
@@ -1452,9 +1463,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 .set(class_name_ref);
         }
 
-        // For named class expressions: swap to expr_class_ref for suffix ops and relocated code
+        // For named class expressions: swap to expr_class_ref for suffix ops
         let mut original_class_name_for_decorator: Option<&'a [u8]> = None;
-        let mut relocated_name_rewrite: Option<RewriteKind> = None;
         if is_expr
             && !expr_class_is_anonymous
             && let Some(ecr) = expr_class_ref
@@ -1465,10 +1475,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     .original_name
                     .slice(),
             );
-            relocated_name_rewrite = Some(RewriteKind::ReplaceRef {
-                old: class_name_ref,
-                new: ecr,
-            });
             class_name_ref = ecr;
             class_name_loc = loc;
         }
@@ -2368,9 +2374,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                         loc: class_name_loc,
                                     },
                                 );
-                                if let Some(rewrite) = relocated_name_rewrite {
-                                    p.rewrite_expr(init, rewrite);
-                                }
                                 let init = *init;
                                 suffix_exprs.push(p.call_rt(
                                     key.loc,

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -1281,11 +1281,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             bun_alloc::AstAlloc::take(&mut class.ts_decorators);
         let class_decorators_len = class_decorators.len_u32() as usize;
 
-        // Relocating pre-evaluates every computed key (Phase 2) to keep them in source order.
+        // All or nothing (keys are pre-evaluated in Phase 2), so static members keep their order.
         let relocate_static_fields = class_decorators_len > 0
             && class.properties.slice().iter().all(|prop| {
-                !prop.flags.contains(Flags::Property::IsComputed)
-                    || prop.key.is_none_or(|key| can_leave_class_body(&key))
+                (!prop.flags.contains(Flags::Property::IsComputed)
+                    || prop.key.is_none_or(|key| can_leave_class_body(&key)))
+                    && (!is_plain_static_field(prop)
+                        || prop
+                            .initializer
+                            .is_none_or(|init| can_leave_class_body(&init)))
             });
 
         let init_ref = p.new_sym(js_ast::symbol::Kind::Other, b"_init");
@@ -1790,12 +1794,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     }
                     continue;
                 }
-                if relocate_static_fields
-                    && is_plain_static_field(prop)
-                    && prop
-                        .initializer
-                        .is_none_or(|init| can_leave_class_body(&init))
-                {
+                if relocate_static_fields && is_plain_static_field(prop) {
                     static_element_order.push(StaticElement {
                         kind: StaticElementKind::PlainField,
                         index: relocated_static_fields.len(),

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -52,7 +52,8 @@ enum StaticElementKind {
     Block,
     FieldOrAccessor,
     /// Undecorated public static field moved out of the body of a class that
-    /// has class decorators (index into `relocated_static_fields`).
+    /// has class decorators (index into `relocated_static_fields`); see
+    /// `can_leave_class_body`.
     PlainField,
 }
 
@@ -144,7 +145,8 @@ fn can_be_class_binding_name(name: &[u8]) -> bool {
 
 /// `static x = 1` / `static x;` with no decorators. When the class itself is
 /// decorated these are initialized after the class decorators run (on whatever
-/// class they returned), so they cannot stay in the class body.
+/// class they returned), so they are moved out of the class body, provided
+/// `can_leave_class_body` holds for the initializer.
 #[inline]
 fn is_plain_static_field(prop: &Property) -> bool {
     prop.kind == PropertyKind::Normal
@@ -158,6 +160,63 @@ fn is_plain_static_field(prop: &Property) -> bool {
 #[inline]
 fn has_private_key(prop: &Property) -> bool {
     matches!(prop.key, Some(key) if matches!(key.data, js_ast::ExprData::EPrivateIdentifier(_)))
+}
+
+/// Whether an undecorated static field initializer or computed key may be
+/// printed outside the class body. Accepts only the shapes `rewrite_expr`
+/// walks completely, so every `this` in them gets redirected, and none of
+/// the syntax that only means something inside the body: `super`,
+/// `new.target`, `#names`, and anything creating a function or class, whose
+/// parameters, keys and heritage the rewriter does not visit. Everything else
+/// stays in the class body and keeps behaving as it did before.
+fn can_leave_class_body(expr: &Expr) -> bool {
+    use js_ast::ExprData as D;
+    match &expr.data {
+        D::EThis(_)
+        | D::EIdentifier(_)
+        | D::EImportIdentifier(_)
+        | D::EString(_)
+        | D::ENumber(_)
+        | D::EBigInt(_)
+        | D::EBoolean(_)
+        | D::ENull(_)
+        | D::EUndefined(_)
+        | D::ERegExp(_)
+        | D::EInlinedEnum(_)
+        | D::ERequireString(_)
+        | D::ERequireResolveString(_)
+        | D::EImportMeta(_)
+        | D::EMissing(_) => true,
+        D::EBinary(e) => can_leave_class_body(&e.left) && can_leave_class_body(&e.right),
+        D::ECall(e) => {
+            can_leave_class_body(&e.target) && e.args.slice().iter().all(can_leave_class_body)
+        }
+        D::ENew(e) => {
+            can_leave_class_body(&e.target) && e.args.slice().iter().all(can_leave_class_body)
+        }
+        D::EIndex(e) => can_leave_class_body(&e.target) && can_leave_class_body(&e.index),
+        D::EDot(e) => can_leave_class_body(&e.target),
+        D::ESpread(e) => can_leave_class_body(&e.value),
+        D::EUnary(e) => can_leave_class_body(&e.value),
+        D::EIf(e) => {
+            can_leave_class_body(&e.test)
+                && can_leave_class_body(&e.yes)
+                && can_leave_class_body(&e.no)
+        }
+        D::EArray(e) => e.items.slice().iter().all(can_leave_class_body),
+        D::EObject(e) => e.properties.slice().iter().all(|prop| {
+            !prop.flags.contains(Flags::Property::IsComputed)
+                && prop.initializer.is_none()
+                && prop.value.is_some_and(|value| can_leave_class_body(&value))
+        }),
+        D::ETemplate(e) => {
+            e.tag.is_none_or(|tag| can_leave_class_body(&tag))
+                && e.parts()
+                    .iter()
+                    .all(|part| can_leave_class_body(&part.value))
+        }
+        _ => false,
+    }
 }
 
 /// Whether a class statement with class decorators gets a binding of its own
@@ -1250,11 +1309,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             bun_alloc::AstAlloc::take(&mut class.ts_decorators);
         let class_decorators_len = class_decorators.len_u32() as usize;
 
-        // Relocated initializers are printed outside the class body, where a
-        // `#name` access would be a syntax error, so a class with private
-        // members keeps its static fields in place.
-        let has_private_members = class.properties.slice().iter().any(has_private_key);
-        let relocate_static_fields = class_decorators_len > 0 && !has_private_members;
+        // Relocating a static field moves its key's evaluation ahead of the
+        // class, so to keep the keys in source order every computed key in the
+        // class is pre-evaluated along with it (Phase 2), which all of them
+        // must be able to take.
+        let relocate_static_fields = class_decorators_len > 0
+            && class.properties.slice().iter().all(|prop| {
+                !prop.flags.contains(Flags::Property::IsComputed)
+                    || prop.key.is_none_or(|key| can_leave_class_body(&key))
+            });
 
         let init_ref = p.new_sym(js_ast::symbol::Kind::Other, b"_init");
         if is_expr {
@@ -1349,8 +1412,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
             if prop.flags.contains(Flags::Property::IsComputed)
                 && prop.key.is_some()
-                && (prop.ts_decorators.len_u32() > 0
-                    || (relocate_static_fields && is_plain_static_field(prop)))
+                && (prop.ts_decorators.len_u32() > 0 || relocate_static_fields)
             {
                 computed_key_counter += 1;
                 let key_name: &'a [u8] = if computed_key_counter == 1 {
@@ -1762,7 +1824,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     }
                     continue;
                 }
-                if relocate_static_fields && is_plain_static_field(prop) {
+                if relocate_static_fields
+                    && is_plain_static_field(prop)
+                    && prop
+                        .initializer
+                        .is_none_or(|init| can_leave_class_body(&init))
+                {
                     static_element_order.push(StaticElement {
                         kind: StaticElementKind::PlainField,
                         index: relocated_static_fields.len(),
@@ -2573,7 +2640,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
 
         // `static { _Foo = this }`: static initializers left in the body (see
-        // `relocate_static_fields`) read the binding while the class is still
+        // `can_leave_class_body`) read the binding while the class is still
         // being defined, before the suffix can assign it.
         if inner_binding_used {
             let this_e = p.new_expr(E::This {}, class_name_loc);

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -51,9 +51,7 @@ struct FieldInitEntry {
 enum StaticElementKind {
     Block,
     FieldOrAccessor,
-    /// Undecorated public static field moved out of the body of a class that
-    /// has class decorators (index into `relocated_static_fields`); see
-    /// `can_leave_class_body`.
+    /// Undecorated static field (`relocated_static_fields`).
     PlainField,
 }
 
@@ -143,10 +141,6 @@ fn can_be_class_binding_name(name: &[u8]) -> bool {
         && !is_eval_or_arguments(name)
 }
 
-/// `static x = 1` / `static x;` with no decorators. When the class itself is
-/// decorated these are initialized after the class decorators run (on whatever
-/// class they returned), so they are moved out of the class body, provided
-/// `can_leave_class_body` holds for the initializer.
 #[inline]
 fn is_plain_static_field(prop: &Property) -> bool {
     prop.kind == PropertyKind::Normal
@@ -162,13 +156,7 @@ fn has_private_key(prop: &Property) -> bool {
     matches!(prop.key, Some(key) if matches!(key.data, js_ast::ExprData::EPrivateIdentifier(_)))
 }
 
-/// Whether an undecorated static field initializer or computed key may be
-/// printed outside the class body. Accepts only the shapes `rewrite_expr`
-/// walks completely, so every `this` in them gets redirected, and none of
-/// the syntax that only means something inside the body: `super`,
-/// `new.target`, `#names`, and anything creating a function or class, whose
-/// parameters, keys and heritage the rewriter does not visit. Everything else
-/// stays in the class body and keeps behaving as it did before.
+/// Shapes `rewrite_expr` walks fully; never `super`, `new.target`, `#names`, functions or classes.
 fn can_leave_class_body(expr: &Expr) -> bool {
     use js_ast::ExprData as D;
     match &expr.data {
@@ -219,13 +207,7 @@ fn can_leave_class_body(expr: &Expr) -> bool {
     }
 }
 
-/// Whether a class statement with class decorators gets a binding of its own
-/// for the body's references to its name (see `declare_inner_class_binding`).
-///
-/// Private static members stay installed on the class as written, so a body
-/// that reaches them through the class name (`Foo.#count`) has to keep naming
-/// that class; pointing the name at a replacement returned by a decorator would
-/// turn every such access into a brand-check TypeError.
+/// Private statics stay on the class as written, so `Foo.#x` in the body must keep naming it.
 pub(crate) fn wants_inner_class_binding(class: &G::Class) -> bool {
     class.should_lower_standard_decorators
         && class.ts_decorators.len_u32() > 0
@@ -269,14 +251,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         ref_
     }
 
-    /// `_Foo`: what `class Foo`'s body refers to by its own name once lowered.
-    /// The name binding a class declaration creates for its body is immutable,
-    /// so after `Foo = __decorateElement(...)` it would still hold the
-    /// undecorated class; `lower_impl` instead declares this symbol (`let _Foo;`)
-    /// in the scope the class statement is in, which must be the current scope
-    /// here, and reassigns it along with `Foo`. Element decorator and computed
-    /// key expressions are evaluated before that declaration and so hit the TDZ
-    /// the spec gives them.
+    /// `_Foo`, the body's name for `class Foo`: the binding the class itself provides is immutable.
     pub(crate) fn declare_inner_class_binding(&mut self, class_name_ref: Ref) -> Ref {
         let class_name: &'a [u8] = self.symbols[class_name_ref.inner_index() as usize]
             .original_name
@@ -1177,9 +1152,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     // ── Public API ───────────────────────────────────────
 
-    /// `inner_class_ref` is the binding `visit_class` resolved the body's
-    /// references to the class name to (see `declare_inner_class_binding`), or
-    /// `Ref::NONE` when it left them on the class name itself.
+    /// `inner_class_ref`: what `visit_class` returned for this class.
     pub(crate) fn lower_standard_decorators_stmt(
         &mut self,
         stmt: Stmt,
@@ -1290,8 +1263,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             class_name_loc = class.class_name.as_ref().unwrap().loc;
         }
 
-        // Statement mode only; class expressions keep their own (per-evaluation)
-        // name binding and redirect relocated code to `_class` instead.
+        // Class expressions keep their per-evaluation name binding; see `relocated_name_rewrite`.
         let inner_class_ref: Ref = if is_expr {
             class_name_ref
         } else if visited_inner_class_ref.is_symbol() {
@@ -1309,10 +1281,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             bun_alloc::AstAlloc::take(&mut class.ts_decorators);
         let class_decorators_len = class_decorators.len_u32() as usize;
 
-        // Relocating a static field moves its key's evaluation ahead of the
-        // class, so to keep the keys in source order every computed key in the
-        // class is pre-evaluated along with it (Phase 2), which all of them
-        // must be able to take.
+        // Relocating pre-evaluates every computed key (Phase 2) to keep them in source order.
         let relocate_static_fields = class_decorators_len > 0
             && class.properties.slice().iter().all(|prop| {
                 !prop.flags.contains(Flags::Property::IsComputed)
@@ -1459,20 +1428,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
 
-        // Must be read before the lowering itself starts referencing the binding.
+        // Read before the lowering itself references the binding.
         let inner_binding_used =
             !is_expr && p.symbols[inner_class_ref.inner_index() as usize].use_count_estimate > 0;
         if !is_expr && !inner_binding_used {
-            // Either declared below or merged into the class name, so the symbol
-            // never prints as an undeclared `_Foo`.
+            // Not declared below, so merge it into the class name instead.
             p.symbols[inner_class_ref.inner_index() as usize]
                 .link
                 .set(class_name_ref);
         }
 
-        // For named class expressions: swap to expr_class_ref for suffix ops.
-        // Code relocated out of the body can no longer see the expression's own
-        // name binding, so it is redirected to `_class` as well.
+        // For named class expressions: swap to expr_class_ref for suffix ops and relocated code
         let mut original_class_name_for_decorator: Option<&'a [u8]> = None;
         let mut relocated_name_rewrite: Option<RewriteKind> = None;
         if is_expr
@@ -2380,9 +2346,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         suffix_exprs.push(p.call_rt(loc, b"__runInitializers", &[i_e, n_e, c_e]));
                     }
                     StaticElementKind::PlainField => {
-                        // `__publicField(Foo, "x", init)` keeps the field syntax's
-                        // [[Define]] semantics; a plain assignment would invoke
-                        // inherited setters.
+                        // __publicField defines; an assignment would run inherited setters.
                         let field = &mut relocated_static_fields[elem.index];
                         let key = field.key.expect("infallible: prop has key");
                         let target = p.use_ref(class_name_ref, class_name_loc);
@@ -2639,9 +2603,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             new_properties = merged;
         }
 
-        // `static { _Foo = this }`: static initializers left in the body (see
-        // `can_leave_class_body`) read the binding while the class is still
-        // being defined, before the suffix can assign it.
+        // `static { _Foo = this }`: initializers left in the body run before the suffix assigns it.
         if inner_binding_used {
             let this_e = p.new_expr(E::This {}, class_name_loc);
             let capture = p.assign_to(inner_class_ref, this_e, class_name_loc);
@@ -2779,11 +2741,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
         out.extend_from_slice(&pre_eval_stmts);
         out.extend_from_slice(&prefix_stmts);
-        // `let _Foo;` comes after the pre-evaluated element decorators and
-        // computed keys (which must still hit its TDZ) and before the class
-        // statement whose leading static block assigns it. `let` rather than
-        // `var` so that a class statement in a loop body or function gets a
-        // fresh binding per evaluation, like the class binding itself.
+        // After the pre-evaluated keys and decorators (TDZ); `let` so loops get fresh bindings.
         if inner_binding_used {
             p.record_declared_symbol(inner_class_ref);
             let binding = p.b(

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -51,6 +51,9 @@ struct FieldInitEntry {
 enum StaticElementKind {
     Block,
     FieldOrAccessor,
+    /// Undecorated public static field moved out of the body of a class that
+    /// has class decorators (index into `relocated_static_fields`).
+    PlainField,
 }
 
 #[derive(Clone, Copy)]
@@ -139,6 +142,41 @@ fn can_be_class_binding_name(name: &[u8]) -> bool {
         && !is_eval_or_arguments(name)
 }
 
+/// `static x = 1` / `static x;` with no decorators. When the class itself is
+/// decorated these are initialized after the class decorators run (on whatever
+/// class they returned), so they cannot stay in the class body.
+#[inline]
+fn is_plain_static_field(prop: &Property) -> bool {
+    prop.kind == PropertyKind::Normal
+        && prop.flags.contains(Flags::Property::IsStatic)
+        && !prop.flags.contains(Flags::Property::IsMethod)
+        && prop.ts_decorators.len_u32() == 0
+        && prop.key.is_some()
+        && !has_private_key(prop)
+}
+
+#[inline]
+fn has_private_key(prop: &Property) -> bool {
+    matches!(prop.key, Some(key) if matches!(key.data, js_ast::ExprData::EPrivateIdentifier(_)))
+}
+
+/// Whether a class statement with class decorators gets a binding of its own
+/// for the body's references to its name (see `declare_inner_class_binding`).
+///
+/// Private static members stay installed on the class as written, so a body
+/// that reaches them through the class name (`Foo.#count`) has to keep naming
+/// that class; pointing the name at a replacement returned by a decorator would
+/// turn every such access into a brand-check TypeError.
+pub(crate) fn wants_inner_class_binding(class: &G::Class) -> bool {
+    class.should_lower_standard_decorators
+        && class.ts_decorators.len_u32() > 0
+        && !class
+            .properties
+            .slice()
+            .iter()
+            .any(|prop| prop.flags.contains(Flags::Property::IsStatic) && has_private_key(prop))
+}
+
 // ── impl P ───────────────────────────────────────────────────────────────────
 
 impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
@@ -170,6 +208,22 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let ref_ = self.new_symbol(kind, name);
         VecExt::append(&mut self.current_scope_mut().generated, ref_);
         ref_
+    }
+
+    /// `_Foo`: what `class Foo`'s body refers to by its own name once lowered.
+    /// The name binding a class declaration creates for its body is immutable,
+    /// so after `Foo = __decorateElement(...)` it would still hold the
+    /// undecorated class; `lower_impl` instead declares this symbol (`let _Foo;`)
+    /// in the scope the class statement is in, which must be the current scope
+    /// here, and reassigns it along with `Foo`. Element decorator and computed
+    /// key expressions are evaluated before that declaration and so hit the TDZ
+    /// the spec gives them.
+    pub(crate) fn declare_inner_class_binding(&mut self, class_name_ref: Ref) -> Ref {
+        let class_name: &'a [u8] = self.symbols[class_name_ref.inner_index() as usize]
+            .original_name
+            .slice();
+        let name = self.bump_name2(b"_", class_name);
+        self.new_sym(js_ast::symbol::Kind::Other, name)
     }
 
     /// Single var declaration statement.
@@ -1064,9 +1118,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     // ── Public API ───────────────────────────────────────
 
+    /// `inner_class_ref` is the binding `visit_class` resolved the body's
+    /// references to the class name to (see `declare_inner_class_binding`), or
+    /// `Ref::NONE` when it left them on the class name itself.
     pub(crate) fn lower_standard_decorators_stmt(
         &mut self,
         stmt: Stmt,
+        inner_class_ref: Ref,
         out: &mut BumpVec<'a, Stmt>,
     ) {
         // Every call site is the visitStmt `s_class` branch. `Stmt` and the
@@ -1078,7 +1136,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             js_ast::StmtData::SClass(c) => c,
             _ => unreachable!(),
         };
-        self.lower_impl(&mut s_class.class, stmt.loc, None, false, Some(stmt), out);
+        self.lower_impl(
+            &mut s_class.class,
+            stmt.loc,
+            None,
+            false,
+            Some(stmt),
+            inner_class_ref,
+            out,
+        );
     }
 
     pub(crate) fn lower_standard_decorators_expr(
@@ -1089,7 +1155,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     ) -> Expr {
         let bump = self.arena;
         let mut out = BumpVec::<Stmt>::new_in(bump);
-        self.lower_impl(class, loc, name_from_context, true, None, &mut out);
+        self.lower_impl(
+            class,
+            loc,
+            name_from_context,
+            true,
+            None,
+            Ref::NONE,
+            &mut out,
+        );
         if out.is_empty() {
             return self.new_expr(E::Missing {}, loc);
         }
@@ -1109,6 +1183,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         name_from_context: Option<&'a [u8]>,
         is_expr: bool,
         original_stmt: Option<Stmt>,
+        visited_inner_class_ref: Ref,
         out: &mut BumpVec<'a, Stmt>,
     ) {
         let p = self;
@@ -1156,15 +1231,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             class_name_loc = class.class_name.as_ref().unwrap().loc;
         }
 
-        let mut inner_class_ref: Ref = class_name_ref;
-        if !is_expr {
-            // SAFETY: original_name is arena-owned for 'a.
-            let cns: &'a [u8] = p.symbols[class_name_ref.inner_index() as usize]
-                .original_name
-                .slice();
-            let name = p.bump_name2(b"_", cns);
-            inner_class_ref = p.new_sym(js_ast::symbol::Kind::Other, name);
-        }
+        // Statement mode only; class expressions keep their own (per-evaluation)
+        // name binding and redirect relocated code to `_class` instead.
+        let inner_class_ref: Ref = if is_expr {
+            class_name_ref
+        } else if visited_inner_class_ref.is_symbol() {
+            visited_inner_class_ref
+        } else {
+            p.declare_inner_class_binding(class_name_ref)
+        };
 
         // `ExprNodeList = Vec<Expr>` owns its
         // buffer, so this MUST be a real ownership transfer; the previous
@@ -1174,6 +1249,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let mut class_decorators: ExprNodeList =
             bun_alloc::AstAlloc::take(&mut class.ts_decorators);
         let class_decorators_len = class_decorators.len_u32() as usize;
+
+        // Relocated initializers are printed outside the class body, where a
+        // `#name` access would be a syntax error, so a class with private
+        // members keeps its static fields in place.
+        let has_private_members = class.properties.slice().iter().any(has_private_key);
+        let relocate_static_fields = class_decorators_len > 0 && !has_private_members;
 
         let init_ref = p.new_sym(js_ast::symbol::Kind::Other, b"_init");
         if is_expr {
@@ -1268,7 +1349,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
             if prop.flags.contains(Flags::Property::IsComputed)
                 && prop.key.is_some()
-                && prop.ts_decorators.len_u32() > 0
+                && (prop.ts_decorators.len_u32() > 0
+                    || (relocate_static_fields && is_plain_static_field(prop)))
             {
                 computed_key_counter += 1;
                 let key_name: &'a [u8] = if computed_key_counter == 1 {
@@ -1315,8 +1397,22 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
 
-        // For named class expressions: swap to expr_class_ref for suffix ops
+        // Must be read before the lowering itself starts referencing the binding.
+        let inner_binding_used =
+            !is_expr && p.symbols[inner_class_ref.inner_index() as usize].use_count_estimate > 0;
+        if !is_expr && !inner_binding_used {
+            // Either declared below or merged into the class name, so the symbol
+            // never prints as an undeclared `_Foo`.
+            p.symbols[inner_class_ref.inner_index() as usize]
+                .link
+                .set(class_name_ref);
+        }
+
+        // For named class expressions: swap to expr_class_ref for suffix ops.
+        // Code relocated out of the body can no longer see the expression's own
+        // name binding, so it is redirected to `_class` as well.
         let mut original_class_name_for_decorator: Option<&'a [u8]> = None;
+        let mut relocated_name_rewrite: Option<RewriteKind> = None;
         if is_expr
             && !expr_class_is_anonymous
             && let Some(ecr) = expr_class_ref
@@ -1327,6 +1423,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     .original_name
                     .slice(),
             );
+            relocated_name_rewrite = Some(RewriteKind::ReplaceRef {
+                old: class_name_ref,
+                new: ecr,
+            });
             class_name_ref = ecr;
             class_name_loc = loc;
         }
@@ -1385,6 +1485,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let mut static_init_entries = BumpVec::<FieldInitEntry>::new_in(bump);
         let mut instance_init_entries = BumpVec::<FieldInitEntry>::new_in(bump);
         let mut static_element_order = BumpVec::<StaticElement>::new_in(bump);
+        let mut relocated_static_fields = BumpVec::<Property>::new_in(bump);
         let mut extracted_static_blocks =
             BumpVec::<js_ast::StoreRef<G::ClassStaticBlock>>::new_in(bump);
         let mut prefix_stmts = BumpVec::<Stmt>::new_in(bump);
@@ -1659,6 +1760,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         });
                         extracted_static_blocks.push(sb);
                     }
+                    continue;
+                }
+                if relocate_static_fields && is_plain_static_field(prop) {
+                    static_element_order.push(StaticElement {
+                        kind: StaticElementKind::PlainField,
+                        index: relocated_static_fields.len(),
+                    });
+                    relocated_static_fields.push(prop_copy(prop));
                     continue;
                 }
                 new_properties.push(prop_full_copy(prop));
@@ -2086,7 +2195,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
             let cls_dec_list = ExprNodeList::from_bump_vec(cls_dec_args);
             let dec_call = p.call_runtime(loc, b"__decorateElement", cls_dec_list);
-            suffix_exprs.push(p.assign_to(class_name_ref, dec_call, class_name_loc));
+            // `Foo = _Foo = __decorateElement(...)`
+            let decorated = if inner_binding_used {
+                p.assign_to(inner_class_ref, dec_call, class_name_loc)
+            } else {
+                dec_call
+            };
+            suffix_exprs.push(p.assign_to(class_name_ref, decorated, class_name_loc));
         }
 
         // 6: Static method extra initializers
@@ -2196,6 +2311,41 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         let n_e = p.new_expr(E::Number::new(Self::extra_init_flag(field_idx)), loc);
                         let c_e = p.use_ref(class_name_ref, class_name_loc);
                         suffix_exprs.push(p.call_rt(loc, b"__runInitializers", &[i_e, n_e, c_e]));
+                    }
+                    StaticElementKind::PlainField => {
+                        // `__publicField(Foo, "x", init)` keeps the field syntax's
+                        // [[Define]] semantics; a plain assignment would invoke
+                        // inherited setters.
+                        let field = &mut relocated_static_fields[elem.index];
+                        let key = field.key.expect("infallible: prop has key");
+                        let target = p.use_ref(class_name_ref, class_name_loc);
+                        match field.initializer.as_mut() {
+                            Some(init) => {
+                                p.rewrite_expr(
+                                    init,
+                                    RewriteKind::ReplaceThis {
+                                        ref_: class_name_ref,
+                                        loc: class_name_loc,
+                                    },
+                                );
+                                if let Some(rewrite) = relocated_name_rewrite {
+                                    p.rewrite_expr(init, rewrite);
+                                }
+                                let init = *init;
+                                suffix_exprs.push(p.call_rt(
+                                    key.loc,
+                                    b"__publicField",
+                                    &[target, key, init],
+                                ));
+                            }
+                            None => {
+                                suffix_exprs.push(p.call_rt(
+                                    key.loc,
+                                    b"__publicField",
+                                    &[target, key],
+                                ));
+                            }
+                        }
                     }
                 }
             }
@@ -2422,6 +2572,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             new_properties = merged;
         }
 
+        // `static { _Foo = this }`: static initializers left in the body (see
+        // `relocate_static_fields`) read the binding while the class is still
+        // being defined, before the suffix can assign it.
+        if inner_binding_used {
+            let this_e = p.new_expr(E::This {}, class_name_loc);
+            let capture = p.assign_to(inner_class_ref, this_e, class_name_loc);
+            let block = p.make_static_block(capture, class_name_loc);
+            new_properties.insert(0, block);
+        }
+
         class.properties = bun_ast::StoreSlice::new_mut(new_properties.into_bump_slice_mut());
         class.has_decorators = false;
         class.should_lower_standard_decorators = false;
@@ -2552,6 +2712,32 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
         out.extend_from_slice(&pre_eval_stmts);
         out.extend_from_slice(&prefix_stmts);
+        // `let _Foo;` comes after the pre-evaluated element decorators and
+        // computed keys (which must still hit its TDZ) and before the class
+        // statement whose leading static block assigns it. `let` rather than
+        // `var` so that a class statement in a loop body or function gets a
+        // fresh binding per evaluation, like the class binding itself.
+        if inner_binding_used {
+            p.record_declared_symbol(inner_class_ref);
+            let binding = p.b(
+                B::Identifier {
+                    r#ref: inner_class_ref,
+                },
+                class_name_loc,
+            );
+            let decls = DeclList::from_slice(&[G::Decl {
+                binding,
+                value: None,
+            }]);
+            out.push(p.s(
+                S::Local {
+                    kind: S::Kind::KLet,
+                    decls,
+                    ..Default::default()
+                },
+                loc,
+            ));
+        }
         out.push(init_decl_stmt);
         out.push(original_stmt.unwrap());
         for expr in suffix_exprs.iter() {
@@ -2561,32 +2747,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     ..Default::default()
                 },
                 expr.loc,
-            ));
-        }
-        // Inner class binding: let _Foo = Foo
-        if !inner_class_ref.eql(class_name_ref) {
-            p.record_usage(class_name_ref);
-            let binding = p.b(
-                B::Identifier {
-                    r#ref: inner_class_ref,
-                },
-                loc,
-            );
-            let value = Some(p.new_expr(
-                E::Identifier {
-                    ref_: class_name_ref,
-                    ..Default::default()
-                },
-                class_name_loc,
-            ));
-            let decls = DeclList::from_slice(&[G::Decl { binding, value }]);
-            out.push(p.s(
-                S::Local {
-                    kind: S::Kind::KLet,
-                    decls,
-                    ..Default::default()
-                },
-                loc,
             ));
         }
     }

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -1275,7 +1275,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             class_name_loc = class.class_name.as_ref().unwrap().loc;
         }
 
-        // Class expressions keep their own name binding (see `body_names_class_as_written`).
+        // Class expressions keep their own name binding (see `keep_static_fields_in_body`).
         let inner_class_ref: Ref = if is_expr {
             class_name_ref
         } else if visited_inner_class_ref.is_symbol() {
@@ -1293,16 +1293,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             bun_alloc::AstAlloc::take(&mut class.ts_decorators);
         let class_decorators_len = class_decorators.len_u32() as usize;
 
-        // Relocated fields land on the decorated class; a body naming the original would miss them.
-        let body_names_class_as_written = if is_expr {
-            !expr_class_is_anonymous
-                && p.symbols[class_name_ref.inner_index() as usize].use_count_estimate > 0
-        } else {
-            has_private_static_member(class)
-        };
+        // Private statics stay in the body; an expression body using its name means the original.
+        let keep_static_fields_in_body = has_private_static_member(class)
+            || (is_expr
+                && !expr_class_is_anonymous
+                && p.symbols[class_name_ref.inner_index() as usize].use_count_estimate > 0);
         // All or nothing (keys are pre-evaluated in Phase 2), so static members keep their order.
         let relocate_static_fields = class_decorators_len > 0
-            && !body_names_class_as_written
+            && !keep_static_fields_in_body
             && class.properties.slice().iter().all(|prop| {
                 !is_undecorated_static_accessor(prop)
                     && (!prop.flags.contains(Flags::Property::IsComputed)

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -6336,7 +6336,12 @@ fn path_package_name<'a>(path: &fs::Path<'a>) -> Option<&'a [u8]> {
 }
 
 impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
-    pub(crate) fn lower_class(&mut self, stmtorexpr: js_ast::StmtOrExpr) -> &'a mut [Stmt] {
+    /// `inner_class_ref` is what `visit_class` returned for this class.
+    pub(crate) fn lower_class(
+        &mut self,
+        stmtorexpr: js_ast::StmtOrExpr,
+        inner_class_ref: Ref,
+    ) -> &'a mut [Stmt] {
         use js_ast::g::PropertyKind;
         match stmtorexpr {
             js_ast::StmtOrExpr::Stmt(stmt) => {
@@ -6351,7 +6356,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     // `lower_standard_decorators_stmt` takes an out-param Vec; wrap to
                     // keep this function's slice contract.
                     let mut out = BumpVec::<Stmt>::new_in(self.arena);
-                    self.lower_standard_decorators_stmt(stmt, &mut out);
+                    self.lower_standard_decorators_stmt(stmt, inner_class_ref, &mut out);
                     return out.into_bump_slice_mut();
                 }
 

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod visit_expr;
 pub(crate) mod visit_stmt;
 
 use crate::lexer as js_lexer;
+use crate::lower::lower_decorators::wants_inner_class_binding;
 use crate::p::{LowerUsingDeclarationsContext, P};
 use crate::parser::{
     ExprIn, FnOnlyDataVisit, FnOrArrowDataVisit, ImportItemForNamespaceMap, PrependTempRefsOpts,
@@ -776,11 +777,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         self.stmts_to_single_stmt(stmt.loc, stmts.into_bump_slice_mut())
     }
 
+    /// Returns the `declare_inner_class_binding` the body resolved to (for `lower_class`) or NONE.
     pub(crate) fn visit_class(
         &mut self,
         name_scope_loc: bun_ast::Loc,
         class: &mut G::Class,
         default_name_ref: Ref,
+        is_stmt: bool,
     ) -> Ref {
         debug_assert!(
             !SCAN_ONLY,
@@ -792,6 +795,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if let Some(name) = class.class_name {
             self.record_declared_symbol(name.ref_);
         }
+
+        // Created in the enclosing scope, where the lowering declares it.
+        let inner_class_ref = match class.class_name {
+            Some(name) if is_stmt && wants_inner_class_binding(class) => {
+                self.declare_inner_class_binding(name.ref_)
+            }
+            _ => Ref::NONE,
+        };
 
         self.push_scope_for_visit_pass(ScopeKind::ClassName, name_scope_loc)
             .expect("unreachable");
@@ -807,17 +818,23 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // must be the original value of the name, not the re-assigned value.
         // Use "const" for this symbol to match JavaScript run-time semantics. You
         // are not allowed to assign to this symbol (it throws a TypeError).
-        let mut shadow_ref = if let Some(name) = class.class_name {
+        // With lowered class decorators the body resolves to `inner_class_ref` instead.
+        let shadow_ref = if let Some(name) = class.class_name {
             let name_ref = name.ref_;
             let original_name: &'a [u8] = self.symbols[name_ref.inner_index() as usize]
                 .original_name
                 .slice();
+            let body_ref = if inner_class_ref.is_symbol() {
+                inner_class_ref
+            } else {
+                name_ref
+            };
             self.vis_scope()
                 .members
                 .put(
                     original_name,
                     ScopeMember {
-                        ref_: name.ref_,
+                        ref_: body_ref,
                         loc: name.loc,
                     },
                 )
@@ -1243,12 +1260,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             self.enclosing_class_keyword = old_enclosing_class_keyword;
         }
 
-        if self.symbols[shadow_ref.inner_index() as usize].use_count_estimate == 0 {
-            // If there was originally no class name but something inside needed one
-            // (e.g. there was a static property initializer that referenced "this"),
-            // store our generated name so the class expression ends up with a name.
-            shadow_ref = Ref::NONE;
-        } else if class.class_name.is_none() {
+        // An anonymous class whose body used the generated name keeps it as its name.
+        if class.class_name.is_none()
+            && self.symbols[shadow_ref.inner_index() as usize].use_count_estimate > 0
+        {
             class.class_name = Some(LocRef {
                 ref_: shadow_ref,
                 loc: name_scope_loc,
@@ -1259,7 +1274,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // class name scope
         self.pop_scope();
 
-        shadow_ref
+        inner_class_ref
     }
 
     // Try separating the list for appending, so that it's not a pointer.

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -2622,7 +2622,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let decorator_name_from_context = p.decorator_class_name;
         p.decorator_class_name = None;
 
-        let _ = p.visit_class(expr.loc, &mut e_, Ref::NONE);
+        let _ = p.visit_class(expr.loc, &mut e_, Ref::NONE, false);
 
         // Lower standard decorators for class expressions
         if e_.should_lower_standard_decorators {

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -773,7 +773,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     }
                     StmtData::SClass(mut class_ref) => {
                         let class: &mut S::Class = &mut *class_ref;
-                        let _ = p.visit_class(s2_loc, &mut class.class, data.default_name.ref_);
+                        let inner_class_ref =
+                            p.visit_class(s2_loc, &mut class.class, data.default_name.ref_, true);
 
                         if p.is_control_flow_dead {
                             restore_dead!();
@@ -828,7 +829,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         // Lower the class (handles both TS legacy and standard decorators).
                         // Standard decorator lowering may produce prefix statements
                         // (variable declarations) before the class statement.
-                        let class_stmts = p.lower_class(js_ast::StmtOrExpr::Stmt(s2_copy));
+                        let class_stmts =
+                            p.lower_class(js_ast::StmtOrExpr::Stmt(s2_copy), inner_class_ref);
 
                         // Find the s_class statement in the returned list
                         let mut class_stmt_idx: usize = 0;
@@ -1054,7 +1056,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             p.is_control_flow_dead = true;
         }
 
-        let _ = p.visit_class(stmt.loc, &mut data.class, Ref::NONE);
+        let inner_class_ref = p.visit_class(stmt.loc, &mut data.class, Ref::NONE, true);
 
         // Remove the export flag inside a namespace
         let was_export_inside_namespace = data.is_export && p.enclosing_namespace_arg_ref.is_some();
@@ -1063,7 +1065,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
 
         // Lower class field syntax for browsers that don't support it
-        let lowered = p.lower_class(js_ast::StmtOrExpr::Stmt(*stmt));
+        let lowered = p.lower_class(js_ast::StmtOrExpr::Stmt(*stmt), inner_class_ref);
 
         if !mark_as_dead || was_export_inside_namespace {
             // Lower class field syntax for browsers that don't support it

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -369,7 +369,18 @@ describe("ES Decorators", () => {
           values: [WithAccessor.first, WithAccessor.second, WithAccessor.third],
           keys: Object.keys(WithAccessor),
         };
-        console.log(JSON.stringify({ withPrivate, withAccessor }));
+        const Expression = @wrap class {
+          static first = (log.push("first"), 1);
+          static #second = (log.push("second"), this.first + 1);
+          static get second() { return original.#second; }
+        };
+        const expression = {
+          log: log.splice(0),
+          second: Expression.second,
+          originalKeys: Object.keys(original),
+          replacementKeys: Object.keys(Expression),
+        };
+        console.log(JSON.stringify({ withPrivate, withAccessor, expression }));
       `);
       expect(stderr).toBe("");
       expect(JSON.parse(stdout)).toEqual({
@@ -384,6 +395,12 @@ describe("ES Decorators", () => {
           log: ["first", "third", "second", "decorator"],
           values: [1, 2, 3],
           keys: ["first", "third"],
+        },
+        expression: {
+          log: ["first", "second", "decorator"],
+          second: 2,
+          originalKeys: ["first"],
+          replacementKeys: [],
         },
       });
       expect(exitCode).toBe(0);

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -546,28 +546,64 @@ describe("ES Decorators", () => {
           static make() { return new Bar(); }
           id() { return this.#id; }
         }
+        // A private static method is enough to keep the name on the class as
+        // written, so the static fields that name reaches must stay there too.
+        @wrap class Store {
+          static instances = [];
+          static #register(instance) { Store.instances.push(instance); }
+          constructor() { Store.#register(this); }
+        }
+        const store = new Store();
         Foo.create();
         Foo.create();
-        console.log(JSON.stringify([tag(Foo), Foo.instances, Bar.make().id(), Bar.make().id(), Bar.made]));
+        console.log(JSON.stringify([
+          tag(Foo),
+          Foo.instances,
+          Bar.make().id(),
+          Bar.make().id(),
+          Bar.made,
+          Store.instances.length === 1 && Store.instances[0] === store,
+          Object.hasOwn(Store, "instances"),
+        ]));
       `);
       expect(stderr).toBe("");
-      expect(JSON.parse(stdout)).toEqual(["wrapped", 2, 1, 2, 0]);
+      expect(JSON.parse(stdout)).toEqual(["wrapped", 2, 1, 2, 0, true, false]);
       expect(exitCode).toBe(0);
     });
 
-    test("class expression: static fields are initialized on the replacement", async () => {
+    test("class expressions: static fields move unless the body uses the expression's own name", async () => {
       const { stdout, stderr, exitCode } = await runDecorator(`
         ${wrap}
         const receivers = [];
-        const Foo = @wrap class Inner {
-          static self = Inner;
+        const Anonymous = @wrap class {
           static viaThis = (receivers.push(this), 1);
           static plain;
         };
-        console.log(JSON.stringify([tag(Foo), tag(Foo.self), receivers[0] === Foo, Object.keys(Foo)]));
+        const Registry = @wrap class Inner {
+          static entries = [];
+          static add(entry) { Inner.entries.push(entry); return Inner.entries.length; }
+        };
+        console.log(JSON.stringify([
+          tag(Anonymous),
+          receivers[0] === Anonymous,
+          Object.keys(Anonymous),
+          tag(Registry),
+          Registry.add("a"),
+          Object.keys(Registry),
+          Registry.entries,
+        ]));
       `);
       expect(stderr).toBe("");
-      expect(JSON.parse(stdout)).toEqual(["wrapped", "wrapped", true, ["tag", "self", "viaThis", "plain"]]);
+      expect(JSON.parse(stdout)).toEqual([
+        "wrapped",
+        true,
+        ["tag", "viaThis", "plain"],
+        "wrapped",
+        1,
+        // Inner's body means the class as written, so entries stays there and is inherited.
+        ["tag"],
+        ["a"],
+      ]);
       expect(exitCode).toBe(0);
     });
 

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -546,12 +546,18 @@ describe("ES Decorators", () => {
           static make() { return new Bar(); }
           id() { return this.#id; }
         }
-        // A private static method is enough to keep the name on the class as
-        // written, so the static fields that name reaches must stay there too.
+        // Any private static member (a method, or a decorated one) is enough to
+        // keep the name on the class as written, so the static fields that name
+        // reaches must stay there too.
         @wrap class Store {
           static instances = [];
           static #register(instance) { Store.instances.push(instance); }
           constructor() { Store.#register(this); }
+        }
+        @wrap class Keyed {
+          static registry = [];
+          @keep static #key = "k";
+          lookup() { return Keyed.registry; }
         }
         const store = new Store();
         Foo.create();
@@ -564,10 +570,12 @@ describe("ES Decorators", () => {
           Bar.made,
           Store.instances.length === 1 && Store.instances[0] === store,
           Object.hasOwn(Store, "instances"),
+          new Keyed().lookup(),
+          Object.hasOwn(Keyed, "registry"),
         ]));
       `);
       expect(stderr).toBe("");
-      expect(JSON.parse(stdout)).toEqual(["wrapped", 2, 1, 2, 0, true, false]);
+      expect(JSON.parse(stdout)).toEqual(["wrapped", 2, 1, 2, 0, true, false, [], false]);
       expect(exitCode).toBe(0);
     });
 

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -194,22 +194,96 @@ describe("ES Decorators", () => {
         @wrap class Foo {
           static [key("first")] = 1;
           @methodDec() method() {}
+          [key("instance field")] = 0;
           static [key("second")] = 2;
+          [key("instance method")]() {}
           static 0 = "zero";
           static "quoted key" = "quoted";
         }
-        console.log(JSON.stringify([log, Object.keys(Foo), Foo.first, Foo.second, Foo[0], Foo["quoted key"]]));
+        console.log(JSON.stringify([
+          log,
+          Object.keys(Foo),
+          Object.keys(new Foo()),
+          typeof Foo.prototype["instance method"],
+          Foo.first,
+          Foo.second,
+          Foo[0],
+          Foo["quoted key"],
+        ]));
       `);
       expect(stderr).toBe("");
       expect(JSON.parse(stdout)).toEqual([
-        ["first", "decorator expression", "second", "decorator applied"],
+        ["first", "decorator expression", "instance field", "second", "instance method", "decorator applied"],
         // "tag" is Wrapped's own static field; the relocated fields follow it.
         ["0", "tag", "first", "second", "quoted key"],
+        ["instance field"],
+        "function",
         1,
         2,
         "zero",
         "quoted",
       ]);
+      expect(exitCode).toBe(0);
+    });
+
+    test("initializers that only work inside the class body stay there", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        let original;
+        function wrap(cls, ctx) {
+          original = cls;
+          return class Wrapped extends cls {};
+        }
+        class Base {
+          static defaults = { limit: 10 };
+        }
+        @wrap class Foo extends Base {
+          static fromSuper = { ...super.defaults, limit: 20 };
+          static newTarget = new.target;
+          static thisInParameter = (value = this) => value;
+          static thisInComputedKey = { [this.name]: true };
+          static relocated = { limit: 30, tags: ["a", \`b\${1}\`], self: Foo };
+          static instance = new Foo();
+        }
+        const own = name => (Object.hasOwn(Foo, name) ? "replacement" : Object.hasOwn(original, name) ? "original" : "none");
+        console.log(JSON.stringify({
+          fromSuper: [own("fromSuper"), Foo.fromSuper],
+          newTarget: [own("newTarget"), typeof Foo.newTarget],
+          thisInParameter: [own("thisInParameter"), Foo.thisInParameter() === original],
+          thisInComputedKey: [own("thisInComputedKey"), Foo.thisInComputedKey],
+          relocated: [own("relocated"), Foo.relocated.limit, Foo.relocated.tags, Foo.relocated.self === Foo],
+          instance: [own("instance"), Foo.instance instanceof Foo],
+        }));
+      `);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual({
+        fromSuper: ["original", { limit: 20 }],
+        newTarget: ["original", "undefined"],
+        thisInParameter: ["original", true],
+        thisInComputedKey: ["original", { Foo: true }],
+        relocated: ["replacement", 30, ["a", "b1"], true],
+        instance: ["replacement", true],
+      });
+      expect(exitCode).toBe(0);
+    });
+
+    test("a computed key that cannot be pre-evaluated keeps every static field in place", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        let original;
+        function wrap(cls, ctx) {
+          original = cls;
+          return class Wrapped extends cls {};
+        }
+        const log = [];
+        const key = name => (log.push(name), name);
+        @wrap class Foo {
+          static [key("first")] = 1;
+          [key("instance")] = 2;
+          static [(() => key("second"))()] = 3;
+        }
+        console.log(JSON.stringify([log, Object.keys(Foo), Object.keys(original)]));
+      `);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual([["first", "instance", "second"], [], ["first", "second"]]);
       expect(exitCode).toBe(0);
     });
 
@@ -261,7 +335,7 @@ describe("ES Decorators", () => {
       expect(exitCode).toBe(0);
     });
 
-    test("element decorator expressions see the TDZ, then the decorated class", async () => {
+    test("heritage, element decorator and computed key expressions see the TDZ, then the decorated class", async () => {
       const { stdout, stderr, exitCode } = await runDecorator(`
         ${wrap}
         const captured = [];
@@ -271,42 +345,66 @@ describe("ES Decorators", () => {
           captured.push({ fn, threw });
           return () => {};
         }
-        @wrap class Foo {
+        class Base {}
+        @wrap class Foo extends (capture(() => Foo), Base) {
           @(capture(() => Foo)) method() {}
           @(capture(() => Foo)) static [(capture(() => Foo), "computed")]() {}
         }
-        console.log(JSON.stringify(captured.map(({ fn, threw }) => [threw, tag(fn())])));
+        // Relocating Bar's static field pre-evaluates every computed key, so
+        // the undecorated method's key still observes the TDZ too.
+        let undecoratedKey = "did not throw";
+        try {
+          @wrap class Bar {
+            [String(Bar)]() {}
+            static field = 1;
+          }
+        } catch (e) {
+          undecoratedKey = e.constructor.name;
+        }
+        console.log(JSON.stringify({
+          captured: captured.map(({ fn, threw }) => [threw, tag(fn())]),
+          undecoratedKey,
+        }));
       `);
       expect(stderr).toBe("");
-      expect(JSON.parse(stdout)).toEqual([
-        ["ReferenceError", "wrapped"],
-        ["ReferenceError", "wrapped"],
-        ["ReferenceError", "wrapped"],
-      ]);
+      expect(JSON.parse(stdout)).toEqual({
+        captured: [
+          ["ReferenceError", "wrapped"],
+          ["ReferenceError", "wrapped"],
+          ["ReferenceError", "wrapped"],
+          ["ReferenceError", "wrapped"],
+        ],
+        undecoratedKey: "ReferenceError",
+      });
       expect(exitCode).toBe(0);
     });
 
-    test("class with instance private members: body sees the replacement, static fields stay in the body", async () => {
-      // Static initializers may use the private names, which only exist inside
-      // the body, so they are not relocated; they still observe the class
-      // (as written) through its name.
+    test("class with instance private members: initializers using them stay in the body", async () => {
       const { stdout, stderr, exitCode } = await runDecorator(`
-        ${wrap}
+        let original;
+        function wrap(cls, ctx) {
+          original = cls;
+          return class Wrapped extends cls {};
+        }
         @wrap class Foo {
           #secret = 42;
           static create() { return new Foo(); }
           static peek = foo => foo.#secret;
+          static hasSecret = #secret in Foo;
           static self = Foo;
         }
         console.log(JSON.stringify([
-          tag(Foo),
-          tag(Foo.create().constructor),
+          Foo.create() instanceof Foo,
           Foo.peek(Foo.create()),
-          typeof Foo.self,
+          Foo.hasSecret,
+          Object.hasOwn(original, "peek"),
+          Object.hasOwn(original, "hasSecret"),
+          Object.hasOwn(Foo, "self"),
+          Foo.self === Foo,
         ]));
       `);
       expect(stderr).toBe("");
-      expect(JSON.parse(stdout)).toEqual(["wrapped", "wrapped", 42, "function"]);
+      expect(JSON.parse(stdout)).toEqual([true, 42, false, true, true, true, true]);
       expect(exitCode).toBe(0);
     });
 
@@ -360,12 +458,14 @@ describe("ES Decorators", () => {
           export function wrap(cls, ctx) {
             return class Wrapped extends cls {};
           }
+          export const marker = Symbol("marker");
         `,
         "named.js": `
-          import { wrap } from "./wrap.js";
+          import { wrap, marker } from "./wrap.js";
           @wrap export class Named {
             static create() { return new Named(); }
             static self = Named;
+            static fromImport = [marker];
           }
         `,
         "default.js": `

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -98,6 +98,370 @@ describe("ES Decorators", () => {
     });
   });
 
+  // A class decorator that returns a replacement class rebinds the class name
+  // inside the class body too (tsc: `_classThis`), and the class's static
+  // fields are initialized afterwards, on the replacement.
+  describe.concurrent("class body observes the class returned by a class decorator", () => {
+    const wrap = `
+      function wrap(cls, ctx) {
+        return class Wrapped extends cls { static tag = "wrapped"; };
+      }
+      const tag = x => x.tag ?? "original";
+    `;
+
+    test("methods, getters, instance fields and static fields see the replacement", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        ${wrap}
+        @wrap class Foo {
+          static create() { return new Foo(); }
+          static self = Foo;
+          static viaThis = this;
+          static tagWhenInitialized = String(Foo.tag);
+          whoAmI() { return Foo; }
+          get ctor() { return Foo; }
+          field = Foo;
+        }
+        console.log(JSON.stringify({
+          outer: tag(Foo),
+          create: tag(Foo.create().constructor),
+          whoAmI: tag(new Foo().whoAmI()),
+          getter: tag(new Foo().ctor),
+          field: tag(new Foo().field),
+          self: tag(Foo.self),
+          viaThis: tag(Foo.viaThis),
+          tagWhenInitialized: Foo.tagWhenInitialized,
+        }));
+      `);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual({
+        outer: "wrapped",
+        create: "wrapped",
+        whoAmI: "wrapped",
+        getter: "wrapped",
+        field: "wrapped",
+        self: "wrapped",
+        viaThis: "wrapped",
+        tagWhenInitialized: "wrapped",
+      });
+      expect(exitCode).toBe(0);
+    });
+
+    test("static fields are initialized after the class decorator, in order, on the replacement", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        const log = [];
+        let original;
+        function wrap(cls, ctx) {
+          log.push("decorator");
+          original = cls;
+          return class Wrapped extends cls {};
+        }
+        const receivers = [];
+        @wrap class Foo {
+          static a = (log.push("a"), 1);
+          static { log.push("static block"); }
+          static b = (receivers.push(this), 2);
+          static c;
+        }
+        log.push("after class");
+        console.log(JSON.stringify({
+          log,
+          ownKeys: Object.keys(Foo),
+          originalKeys: Object.keys(original),
+          receiverIsReplacement: receivers[0] === Foo && receivers[0] !== original,
+          values: [Foo.a, Foo.b, Foo.c],
+        }));
+      `);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual({
+        log: ["decorator", "a", "static block", "after class"],
+        ownKeys: ["a", "b", "c"],
+        originalKeys: [],
+        receiverIsReplacement: true,
+        values: [1, 2, null],
+      });
+      expect(exitCode).toBe(0);
+    });
+
+    test("relocated static fields keep their keys, evaluated once and in source order", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        ${wrap}
+        const log = [];
+        const key = name => (log.push(name), name);
+        const methodDec = () => {
+          log.push("decorator expression");
+          return (fn, ctx) => { log.push("decorator applied"); };
+        };
+        @wrap class Foo {
+          static [key("first")] = 1;
+          @methodDec() method() {}
+          static [key("second")] = 2;
+          static 0 = "zero";
+          static "quoted key" = "quoted";
+        }
+        console.log(JSON.stringify([log, Object.keys(Foo), Foo.first, Foo.second, Foo[0], Foo["quoted key"]]));
+      `);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual([
+        ["first", "decorator expression", "second", "decorator applied"],
+        // "tag" is Wrapped's own static field; the relocated fields follow it.
+        ["0", "tag", "first", "second", "quoted key"],
+        1,
+        2,
+        "zero",
+        "quoted",
+      ]);
+      expect(exitCode).toBe(0);
+    });
+
+    test("relocated static fields define properties instead of invoking inherited setters", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        ${wrap}
+        const setterCalls = [];
+        class Base {
+          static set limit(value) { setterCalls.push(value); }
+        }
+        @wrap class Foo extends Base {
+          static limit = 10;
+        }
+        console.log(JSON.stringify([setterCalls, Object.getOwnPropertyDescriptor(Foo, "limit")]));
+      `);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual([[], { value: 10, writable: true, enumerable: true, configurable: true }]);
+      expect(exitCode).toBe(0);
+    });
+
+    test("each evaluation of a class statement gets its own binding", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        ${wrap}
+        function make() {
+          @wrap class Foo {
+            static create() { return new Foo(); }
+          }
+          return Foo;
+        }
+        const first = make();
+        const second = make();
+        const fromLoop = [];
+        for (let i = 0; i < 2; i++) {
+          @wrap class Bar {
+            static create() { return new Bar(); }
+          }
+          fromLoop.push(Bar);
+        }
+        console.log(JSON.stringify([
+          first.create() instanceof first,
+          second.create() instanceof second,
+          first.create() instanceof second,
+          fromLoop[0].create() instanceof fromLoop[0],
+          fromLoop[0].create() instanceof fromLoop[1],
+        ]));
+      `);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual([true, true, false, true, false]);
+      expect(exitCode).toBe(0);
+    });
+
+    test("element decorator expressions see the TDZ, then the decorated class", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        ${wrap}
+        const captured = [];
+        function capture(fn) {
+          let threw = "did not throw";
+          try { fn(); } catch (e) { threw = e.constructor.name; }
+          captured.push({ fn, threw });
+          return () => {};
+        }
+        @wrap class Foo {
+          @(capture(() => Foo)) method() {}
+          @(capture(() => Foo)) static [(capture(() => Foo), "computed")]() {}
+        }
+        console.log(JSON.stringify(captured.map(({ fn, threw }) => [threw, tag(fn())])));
+      `);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual([
+        ["ReferenceError", "wrapped"],
+        ["ReferenceError", "wrapped"],
+        ["ReferenceError", "wrapped"],
+      ]);
+      expect(exitCode).toBe(0);
+    });
+
+    test("class with instance private members: body sees the replacement, static fields stay in the body", async () => {
+      // Static initializers may use the private names, which only exist inside
+      // the body, so they are not relocated; they still observe the class
+      // (as written) through its name.
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        ${wrap}
+        @wrap class Foo {
+          #secret = 42;
+          static create() { return new Foo(); }
+          static peek = foo => foo.#secret;
+          static self = Foo;
+        }
+        console.log(JSON.stringify([
+          tag(Foo),
+          tag(Foo.create().constructor),
+          Foo.peek(Foo.create()),
+          typeof Foo.self,
+        ]));
+      `);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual(["wrapped", "wrapped", 42, "function"]);
+      expect(exitCode).toBe(0);
+    });
+
+    test("class with private static members keeps name-based private access working", async () => {
+      // Private statics are installed on the class as written, so in this case
+      // the name keeps referring to that class (esbuild's behavior): pointing
+      // it at the replacement would make `Foo.#instances` throw.
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        ${wrap}
+        function keep(cls, ctx) {}
+        @wrap class Foo {
+          static #instances = 0;
+          static create() { Foo.#instances++; return new Foo(); }
+          static get instances() { return Foo.#instances; }
+        }
+        @keep class Bar {
+          static #count = 0;
+          #id = ++Bar.#count;
+          static made = Bar.#count;
+          static make() { return new Bar(); }
+          id() { return this.#id; }
+        }
+        Foo.create();
+        Foo.create();
+        console.log(JSON.stringify([tag(Foo), Foo.instances, Bar.make().id(), Bar.make().id(), Bar.made]));
+      `);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual(["wrapped", 2, 1, 2, 0]);
+      expect(exitCode).toBe(0);
+    });
+
+    test("class expression: static fields are initialized on the replacement", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        ${wrap}
+        const receivers = [];
+        const Foo = @wrap class Inner {
+          static self = Inner;
+          static viaThis = (receivers.push(this), 1);
+          static plain;
+        };
+        console.log(JSON.stringify([tag(Foo), tag(Foo.self), receivers[0] === Foo, Object.keys(Foo)]));
+      `);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual(["wrapped", "wrapped", true, ["tag", "self", "viaThis", "plain"]]);
+      expect(exitCode).toBe(0);
+    });
+
+    test("exported and default-exported classes", async () => {
+      using dir = tempDir("es-dec-replacement-exports", {
+        "wrap.js": `
+          export function wrap(cls, ctx) {
+            return class Wrapped extends cls {};
+          }
+        `,
+        "named.js": `
+          import { wrap } from "./wrap.js";
+          @wrap export class Named {
+            static create() { return new Named(); }
+            static self = Named;
+          }
+        `,
+        "default.js": `
+          import { wrap } from "./wrap.js";
+          @wrap export default class Default {
+            static create() { return new Default(); }
+            static self = Default;
+          }
+        `,
+        "entry.js": `
+          import { Named } from "./named.js";
+          import Default from "./default.js";
+          console.log(JSON.stringify([
+            Named.create() instanceof Named,
+            Named.self === Named,
+            Default.create() instanceof Default,
+            Default.self === Default,
+          ]));
+        `,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "entry.js"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+
+      const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(filterStderr(rawStderr)).toBe("");
+      expect(JSON.parse(stdout)).toEqual([true, true, true, true]);
+      expect(exitCode).toBe(0);
+    });
+
+    test("Bun.build keeps the bindings of same-named classes from different files apart", async () => {
+      using dir = tempDir("es-dec-replacement-bundle", {
+        "wrap.js": `
+          export const wrap = label => (cls, ctx) => class Wrapped extends cls { static label = label; };
+        `,
+        "a.js": `
+          import { wrap } from "./wrap.js";
+          @wrap("a") export class Service {
+            static create() { return new Service(); }
+          }
+        `,
+        "b.js": `
+          import { wrap } from "./wrap.js";
+          @wrap("b") export class Service {
+            static create() { return new Service(); }
+          }
+        `,
+        "entry.js": `
+          import { Service as A } from "./a.js";
+          import { Service as B } from "./b.js";
+          console.log(JSON.stringify([A.create().constructor.label, B.create().constructor.label]));
+        `,
+        "build.js": `
+          for (const minify of [false, true]) {
+            const result = await Bun.build({
+              entrypoints: ["./entry.js"],
+              outdir: "./out-" + minify,
+              target: "bun",
+              minify,
+            });
+            if (!result.success) throw new AggregateError(result.logs, "build failed");
+            await import(result.outputs[0].path);
+          }
+        `,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build.js"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+
+      const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(filterStderr(rawStderr)).toBe("");
+      expect(stdout).toBe('["a","b"]\n["a","b"]\n');
+      expect(exitCode).toBe(0);
+    });
+
+    test("a class that never names itself gets no extra binding", () => {
+      const transpiler = new Bun.Transpiler({ loader: "js", target: "bun" });
+      const output = transpiler.transformSync(`
+        @dec class Foo {
+          static create() { return new this(); }
+          method() {}
+        }
+      `);
+      expect(output).toContain("__decorateElement");
+      expect(output).not.toContain("_Foo");
+    });
+  });
+
   describe("method decorators", () => {
     test("instance method decorator", async () => {
       const { stdout, stderr, exitCode } = await runDecorator(`

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -334,6 +334,61 @@ describe("ES Decorators", () => {
       expect(exitCode).toBe(0);
     });
 
+    test("a private static field or a static accessor keeps every static field in place", async () => {
+      // Neither is initialized through the ordered part of the lowering, so
+      // relocating their siblings would move those out from under them.
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        const log = [];
+        let original;
+        function wrap(cls, ctx) {
+          log.push("decorator");
+          original = cls;
+          return class Wrapped extends cls {};
+        }
+        function keep(cls, ctx) {
+          log.push("decorator");
+        }
+        @wrap class WithPrivate {
+          static first = (log.push("first"), 1);
+          static #second = (log.push("second"), WithPrivate.first + 1);
+          static get second() { return WithPrivate.#second; }
+        }
+        const withPrivate = {
+          log: log.splice(0),
+          second: WithPrivate.second,
+          originalKeys: Object.keys(original),
+          replacementKeys: Object.keys(WithPrivate),
+        };
+        @keep class WithAccessor {
+          static first = (log.push("first"), 1);
+          static accessor second = (log.push("second"), 2);
+          static third = (log.push("third"), WithAccessor.first + 2);
+        }
+        const withAccessor = {
+          log: log.splice(0),
+          values: [WithAccessor.first, WithAccessor.second, WithAccessor.third],
+          keys: Object.keys(WithAccessor),
+        };
+        console.log(JSON.stringify({ withPrivate, withAccessor }));
+      `);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual({
+        withPrivate: {
+          log: ["first", "second", "decorator"],
+          second: 2,
+          originalKeys: ["first"],
+          replacementKeys: [],
+        },
+        withAccessor: {
+          // The accessor's storage is set up by the lowering after the body runs; unchanged by this change.
+          log: ["first", "third", "second", "decorator"],
+          values: [1, 2, 3],
+          keys: ["first", "third"],
+        },
+      });
+      expect(exitCode).toBe(0);
+    });
+
     test("relocated static fields define properties instead of invoking inherited setters", async () => {
       const { stdout, stderr, exitCode } = await runDecorator(`
         ${wrap}

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -226,10 +226,12 @@ describe("ES Decorators", () => {
       expect(exitCode).toBe(0);
     });
 
-    test("initializers that only work inside the class body stay there", async () => {
+    test("an initializer that only works inside the class body keeps every static field there, in order", async () => {
       const { stdout, stderr, exitCode } = await runDecorator(`
+        const log = [];
         let original;
         function wrap(cls, ctx) {
+          log.push("decorator");
           original = cls;
           return class Wrapped extends cls {};
         }
@@ -237,31 +239,76 @@ describe("ES Decorators", () => {
           static defaults = { limit: 10 };
         }
         @wrap class Foo extends Base {
-          static fromSuper = { ...super.defaults, limit: 20 };
+          static first = (log.push("first"), 1);
+          static fromSuper = (log.push("fromSuper"), { ...super.defaults, limit: 20 });
+          static second = (log.push("second"), Foo.first + 1);
           static newTarget = new.target;
           static thisInParameter = (value = this) => value;
           static thisInComputedKey = { [this.name]: true };
-          static relocated = { limit: 30, tags: ["a", \`b\${1}\`], self: Foo };
-          static instance = new Foo();
+          static create = () => new Foo();
         }
-        const own = name => (Object.hasOwn(Foo, name) ? "replacement" : Object.hasOwn(original, name) ? "original" : "none");
         console.log(JSON.stringify({
-          fromSuper: [own("fromSuper"), Foo.fromSuper],
-          newTarget: [own("newTarget"), typeof Foo.newTarget],
-          thisInParameter: [own("thisInParameter"), Foo.thisInParameter() === original],
-          thisInComputedKey: [own("thisInComputedKey"), Foo.thisInComputedKey],
-          relocated: [own("relocated"), Foo.relocated.limit, Foo.relocated.tags, Foo.relocated.self === Foo],
-          instance: [own("instance"), Foo.instance instanceof Foo],
+          log,
+          originalKeys: Object.keys(original),
+          replacementKeys: Object.keys(Foo),
+          fromSuper: Foo.fromSuper,
+          second: Foo.second,
+          newTarget: typeof Foo.newTarget,
+          thisInParameter: Foo.thisInParameter() === original,
+          thisInComputedKey: Foo.thisInComputedKey,
+          created: Foo.create() instanceof Foo,
         }));
       `);
       expect(stderr).toBe("");
       expect(JSON.parse(stdout)).toEqual({
-        fromSuper: ["original", { limit: 20 }],
-        newTarget: ["original", "undefined"],
-        thisInParameter: ["original", true],
-        thisInComputedKey: ["original", { Foo: true }],
-        relocated: ["replacement", 30, ["a", "b1"], true],
-        instance: ["replacement", true],
+        log: ["first", "fromSuper", "second", "decorator"],
+        originalKeys: ["first", "fromSuper", "second", "newTarget", "thisInParameter", "thisInComputedKey", "create"],
+        replacementKeys: [],
+        fromSuper: { limit: 20 },
+        second: 2,
+        newTarget: "undefined",
+        thisInParameter: true,
+        thisInComputedKey: { Foo: true },
+        // Lazy initializers still pick up the decorated class through the body's binding.
+        created: true,
+      });
+      expect(exitCode).toBe(0);
+    });
+
+    test("eagerly evaluated initializers of every common shape are relocated together", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        let original;
+        function wrap(cls, ctx) {
+          original = cls;
+          return class Wrapped extends cls {};
+        }
+        const label = "label";
+        @wrap class Foo {
+          static singleton = new Foo();
+          static registry = new Map([[label, Foo]]);
+          static config = { self: Foo, owner: this, nested: [1, ...[2], \`\${label}:\${Foo.name}\`], ...{ extra: true } };
+          static flag = typeof Foo === "function" && this === Foo ? "decorated" : "undecorated";
+          static declaredOnly;
+        }
+        console.log(JSON.stringify({
+          originalKeys: Object.keys(original),
+          replacementKeys: Object.keys(Foo),
+          singleton: Foo.singleton instanceof Foo,
+          registry: Foo.registry.get("label") === Foo,
+          config: [Foo.config.self === Foo, Foo.config.owner === Foo, Foo.config.nested, Foo.config.extra],
+          flag: Foo.flag,
+          declaredOnly: Object.hasOwn(Foo, "declaredOnly") && Foo.declaredOnly === undefined,
+        }));
+      `);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual({
+        originalKeys: [],
+        replacementKeys: ["singleton", "registry", "config", "flag", "declaredOnly"],
+        singleton: true,
+        registry: true,
+        config: [true, true, [1, 2, "label:Wrapped"], true],
+        flag: "decorated",
+        declaredOnly: true,
       });
       expect(exitCode).toBe(0);
     });
@@ -379,32 +426,49 @@ describe("ES Decorators", () => {
       expect(exitCode).toBe(0);
     });
 
-    test("class with instance private members: initializers using them stay in the body", async () => {
+    test("instance private members: the body sees the replacement; initializers naming them stay put", async () => {
       const { stdout, stderr, exitCode } = await runDecorator(`
-        let original;
+        const originals = [];
         function wrap(cls, ctx) {
-          original = cls;
+          originals.push(cls);
           return class Wrapped extends cls {};
         }
-        @wrap class Foo {
+        @wrap class UsesPrivateNames {
           #secret = 42;
-          static create() { return new Foo(); }
+          static create() { return new UsesPrivateNames(); }
           static peek = foo => foo.#secret;
-          static hasSecret = #secret in Foo;
-          static self = Foo;
+          static hasSecret = #secret in UsesPrivateNames;
+          static self = UsesPrivateNames;
         }
-        console.log(JSON.stringify([
-          Foo.create() instanceof Foo,
-          Foo.peek(Foo.create()),
-          Foo.hasSecret,
-          Object.hasOwn(original, "peek"),
-          Object.hasOwn(original, "hasSecret"),
-          Object.hasOwn(Foo, "self"),
-          Foo.self === Foo,
-        ]));
+        @wrap class PlainInitializers {
+          #secret = 42;
+          static create() { return new PlainInitializers(); }
+          static self = PlainInitializers;
+          reveal() { return this.#secret; }
+        }
+        console.log(JSON.stringify({
+          usesPrivateNames: [
+            UsesPrivateNames.create() instanceof UsesPrivateNames,
+            UsesPrivateNames.peek(UsesPrivateNames.create()),
+            UsesPrivateNames.hasSecret,
+            Object.keys(originals[0]),
+            Object.keys(UsesPrivateNames),
+            UsesPrivateNames.self === originals[0],
+          ],
+          plainInitializers: [
+            PlainInitializers.create() instanceof PlainInitializers,
+            PlainInitializers.create().reveal(),
+            Object.keys(originals[1]),
+            Object.keys(PlainInitializers),
+            PlainInitializers.self === PlainInitializers,
+          ],
+        }));
       `);
       expect(stderr).toBe("");
-      expect(JSON.parse(stdout)).toEqual([true, 42, false, true, true, true, true]);
+      expect(JSON.parse(stdout)).toEqual({
+        usesPrivateNames: [true, 42, false, ["peek", "hasSecret", "self"], [], true],
+        plainInitializers: [true, 42, [], ["self"], true],
+      });
       expect(exitCode).toBe(0);
     });
 


### PR DESCRIPTION
### Problem

- With standard (TC39) decorators, references to the class name inside a decorated class declaration still see the undecorated class after a class decorator returns a replacement:
  ```ts
  function wrap(value, ctx) { return class W extends value { static tag = "W" } }
  @wrap class C {
    static create() { return new C() }
    whoAmI() { return C }
    static selfRef = C;
  }
  // bun 1.4.0:  [t(C), t(C.create().constructor), t(new C().whoAmI()), t(C.selfRef)] -> ["W","orig","orig","orig"]
  // tsc / spec:                                                                       -> ["W","W","W","W"]
  ```
  So a factory such as `static create()` under a class-replacing decorator (DI / mixin decorators) builds undecorated instances.
- Cause, part 1: `visit_class` (`src/js_parser/visit/mod.rs`) resolves the body's `C` to the same symbol as the outer `C`, so the printed `class C { ... new C ... }` binds to the class's own immutable inner binding. The lowering (`src/js_parser/lower/lower_decorators.rs`, step 5) only reassigns the outer binding: `C = __decorateElement(...)`. The `let _C = C` it appended after everything only served the TDZ emulation for element decorator expressions.
- Cause, part 2: undecorated static fields were left in the class body, so `static selfRef = C` ran while the class was being defined, i.e. before the class decorator was even called, and landed on the undecorated class. Per spec (and tsc's emit) static fields are initialized after the class decorators, on the class they returned, and `this` in their initializers is that class.
- esbuild 0.25 has the same two deviations; tsc is the reference here.

### Fix

- `visit_class`: for a class statement that has class decorators, the body's references to the class name now resolve to a separate symbol (`_C`), created in the scope containing the statement and handed to `lower_class`. Ordinary name resolution does the rewriting, so every position in the body (nested functions, shadowing, etc.) is covered.
- `lower_impl`, statement mode, when that symbol is referenced:
  - emits `let _C;` after the pre-evaluated element decorators / computed keys (they still hit the TDZ the spec gives them; the esbuild conformance test "Class binding" keeps passing) and before the class statement; `let`, so a class statement in a loop body or function gets a fresh binding per evaluation;
  - injects `static { _C = this }` as the first element, so anything still evaluated inside the body sees the class while it is being defined;
  - step 5 becomes `C = _C = __decorateElement(...)`;
  - records the symbol as declared so the bundler renames it per file (previously two files declaring a decorated `class C` produced two top-level `let _C` in one bundle, a SyntaxError).
- When the body never names the class, the symbol is merged into the class name and nothing extra is emitted. This also removes the unconditional `let _C = C;` that every lowered class statement used to end with.
- Classes with private static members keep the old resolution (`wants_inner_class_binding`): those members stay installed on the class as written, so `C.#count` inside the body has to keep naming that class; pointing it at the replacement would turn such accesses into brand-check TypeErrors. esbuild behaves the same way for these.
- Static fields: undecorated public static fields of a class with class decorators are now moved out of the body like decorated ones already were, and emitted in source order with the static blocks and decorated fields as `__publicField(C, key, init)` after the class decorators are applied (`__publicField` keeps [[Define]] semantics). `this` in the initializer is rewritten to the decorated class and, for class expressions, the class's own name to `_class`, with the existing `rewrite_expr` walker.
  - This happens all or nothing per class, and only when every static field initializer and every computed key in the class is made of shapes the walker covers completely (`can_leave_class_body`: literals, identifiers, `this`, calls, `new`, member access, operators, arrays, objects without computed keys, templates). If one of them is not, in particular `super.x`, `new.target`, private names, or an arrow / function / class (whose parameter defaults, keys and heritage the walker does not visit), or if the class has any private static member (for statements the body then keeps naming the class as written, see above; and a private static field is initialized in the body, so moving its siblings would reorder them) or an undecorated static auto-accessor (its storage is initialized outside the source-ordered part of the suffix), every static field stays in the class body, in source order, and behaves exactly as before; arrows are lazy anyway, so `static create = () => new C()` still picks up the decorated class through `_C`.
  - When fields are relocated, every computed key in the class is pre-evaluated in source order (members that stay in the body get the `_computedKey` temp, as decorated members already did), so key evaluation keeps its source order and undecorated members' keys observe the class binding's TDZ as well.
- Not changed: the inner name binding of decorated class *expressions*. Their lowering has no per-evaluation binding to reassign (`_class` is a hoisted temp shared by every evaluation), so a named class expression's body still sees the undecorated class, same as esbuild. For the same reason their static fields are only relocated when the body never uses the expression's name (anonymous expressions being the common case); otherwise they stay with the class the body names, as before.
- Verification:
  - `test/bundler/transpiler/es-decorators.test.ts`, new `class body observes the class returned by a class decorator` block (16 tests): the report's repro plus getters / instance fields / `this`, initialization order and ownership of relocated statics, computed keys interleaved with in-body members (plus the bail-out), numeric / quoted keys, a class with one `super` / `new.target` / arrow initializer keeping all of its fields in the body in order (and its arrow still seeing the decorated class), the same for a class statement or expression with a private static field, or a static accessor, the common eager shapes all relocating together, [[Define]] vs inherited setter, per-evaluation bindings (function and loop), TDZ for heritage / element decorators / computed keys, instance-private and private-static classes (including a private static method next to a public static field the body reads), anonymous and self-referencing class expressions, `export` / `export default` (with an imported value in an initializer), a two-file `Bun.build` (plain and minified), and that a class which never names itself gets no extra binding. 12 fail on the released bun (the TDZ, private-static and the two bail-out ones are regression guards), all pass with this build.
  - `es-decorators-esbuild.test.ts` (esbuild's 147 conformance tests), `es-decorators.test.ts`, `decorators.test.ts`, `decorator-metadata.test.ts`, `bundler_decorator_metadata.test.ts`, `ts-use-define-for-class-fields.test.ts`, `regression/issue/27575.test.ts`, `transpiler.test.js`, `esbuild/ts.test.ts`, `runtime-transpiler.test.ts`: all pass.
  - `cargo clippy -p bun_js_parser` clean.

### Background

- Standard decorator lowering (`lower_decorators.rs`) is modeled on esbuild's: the class is printed mostly as written, followed by a suffix of `__decorateElement(...)` calls that apply the decorators; a class decorator's result is assigned back to the class binding. Static blocks and decorated static fields are moved into that suffix so they run after decoration, with `this` rewritten to the class binding by `rewrite_expr`.
- A class declaration creates two bindings for its name: a mutable one in the enclosing scope, and an immutable one visible only inside the class body (`class C { m() { return C } }; C = 1; new ...m()` still returns the class). A class decorator that returns a replacement only ever updates the outer one, which is why the body needs its own reassignable binding. tsc solves the same problem by printing the class as an anonymous expression and rewriting body references to a `_classThis` variable.
- The TC39 proposal initializes the body's binding to the decorated class right after applying class decorators and runs static field initializers / static blocks afterwards with `this` being that class; heritage, element decorator expressions and computed keys are evaluated before that, while the binding is in its TDZ.
- `__publicField(obj, key, value)` (runtime.js) defines a data property the way field syntax does, instead of a `[[Set]]` that would run inherited setters.
- Related open work on the same lowering, not overlapping with this change: #31922 (`this` / class name in the already-relocated decorated initializers of class expressions, and widening `rewrite_expr`; `can_leave_class_body` can grow with it), #31930 (collisions between the generated `_init` / `_dec` / `_C` names and user identifiers; this PR keeps the existing naming scheme), #35537 (`__publicField` for decorated fields), #38730 (`super.x` in already-relocated static code).

<details>
<summary>Emitted code for the repro, before and after</summary>

Before:

```js
var _dec = [wrap];
var _init = __decoratorStart(undefined);
class C {
  static create() { return new C; }
  whoAmI() { return C; }
  static selfRef = C;
}
C = __decorateElement(_init, 0, "C", _dec, C);
__runInitializers(_init, 1, C);
__decoratorMetadata(_init, C);
let _C = C;
```

After:

```js
var _dec = [wrap];
let _C;
var _init = __decoratorStart(undefined);
class C {
  static { _C = this; }
  static create() { return new _C; }
  whoAmI() { return _C; }
}
C = _C = __decorateElement(_init, 0, "C", _dec, C);
__publicField(C, "selfRef", _C);
__runInitializers(_init, 1, C);
__decoratorMetadata(_init, C);
```

</details>

<details>
<summary>Behavior matrix (this build vs bun 1.4.0)</summary>

| case | 1.4.0 | this PR |
| --- | --- | --- |
| methods / getters / instance fields naming the class | undecorated class | replacement |
| static fields with plain initializers (`C`, `this.x`, `new C()`, literals, objects, templates...) | initialized before the decorator runs, on the undecorated class | initialized after decoration, own properties of the replacement, `this` is the replacement |
| a class with one static field whose initializer uses `super`, `new.target`, `#names`, an arrow, function or class, a computed key that cannot be pre-evaluated, a private static member, or a static accessor | all static fields stay in the body | unchanged (arrow / function bodies still see the replacement through `_C`) |
| private static members (fields or methods) | undecorated class | unchanged |
| member decorators only, no class decorator | unchanged | unchanged (minus the trailing unused `let _C = C`) |
| class expression | undecorated class | anonymous, or name unused in the body: static fields on the replacement; body using the name: unchanged |
| heritage / element decorator / computed key expressions naming the class | ReferenceError during evaluation | same (computed keys of undecorated members included when fields are relocated) |
| two files each declaring a decorated, self-referencing `class C`, bundled | SyntaxError (`let _C` twice) | renamed `_C` / `_C2` |

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 12 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/es-decorators.test.ts
bun test v1.4.0 (6e906e468)

test/bundler/transpiler/es-decorators.test.ts:
(pass) ES Decorators > class decorators > basic class decorator [344.37ms]
(pass) ES Decorators > class decorators > class decorator receives correct context [310.19ms]
(pass) ES Decorators > class decorators > class decorator can replace class [317.17ms]
(pass) ES Decorators > class decorators > multiple class decorators apply in reverse order [306.49ms]
131 |           viaThis: tag(Foo.viaThis),
132 |           tagWhenInitialized: Foo.tagWhenInitialized,
133 |         }));
134 |       `);
135 |       expect(stderr).toBe("");
136 |       expect(JSON.parse(stdout)).toEqual({
                                       ^
error: expect(received).toEqual(expected)

  {
-   "create": "wrapped",
-   "field": "wrapped",
-   "getter": "wrapped",
+   "create": "original",
+   "field": "original",
+   "getter": "original",
    "outer": "wrapped",
-   "self": "wrapped",
-   "tagWhenInitialized": "wrapped",
-   "viaThis": "wrapped"
... (truncated)

release without fix: 12 FAILED
bun test v1.4.0-canary.1 (6e906e468)

test/bundler/transpiler/es-decorators.test.ts:
(pass) ES Decorators > class decorators > basic class decorator [9.73ms]
(pass) ES Decorators > class decorators > class decorator receives correct context [8.72ms]
(pass) ES Decorators > class decorators > class decorator can replace class [8.41ms]
(pass) ES Decorators > class decorators > multiple class decorators apply in reverse order [8.59ms]
736 |           static create() { return new this(); }
737 |           method() {}
738 |         }
739 |       `);
740 |       expect(output).toContain("__decorateElement");
741 |       expect(output).not.toContain("_Foo");
                               ^
error: expect(received).not.toContain(expected)

Expected to not contain: "_Foo"
Received: "import { __decorateElement as __decorateElement_ggs2dd8p, __decoratorMetadata as __decoratorMetadata_0rk0ydtx, __decoratorStart as __decoratorStart_x73frcn4, __runInitializers as __runInitializers_cst8seht } from \"bun:wrap\";\nvar _dec = [\n  dec\n], _init = __decoratorStart_x73frcn4(void 0);\n\nclass Foo {\n  static create() {\n    return new this;\n  }\n  method() {}\n}\nFoo = __decorateElement
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/es-decorators.test.ts
bun test v1.4.0 (6e906e468)

test/bundler/transpiler/es-decorators.test.ts:
(pass) ES Decorators > class decorators > basic class decorator [369.39ms]
(pass) ES Decorators > class decorators > class decorator receives correct context [316.02ms]
(pass) ES Decorators > class decorators > class decorator can replace class [334.14ms]
(pass) ES Decorators > class decorators > multiple class decorators apply in reverse order [317.29ms]
(pass) ES Decorators > class body observes the class returned by a class decorator > methods, getters, instance fields and static fields see the replacement [352.35ms]
(pass) ES Decorators > class body observes the class returned by a class decorator > static fields are initialized after the class decorator, in order, on the replacement [365.26ms]
(pass) ES Decorators > class body observes the class returned by a class decorator > relocated static fields keep their keys, evaluated once and in source order [364.63ms]
(pass) ES Decorators > class body observes the cl
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 683ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compili
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/lower/lower_decorators.rs       | 267 +++++++++--
 src/js_parser/p.rs                            |   9 +-
 src/js_parser/visit/mod.rs                    |  33 +-
 src/js_parser/visit/visit_expr.rs             |   2 +-
 src/js_parser/visit/visit_stmt.rs             |  10 +-
 test/bundler/transpiler/es-decorators.test.ts | 644 ++++++++++++++++++++++++++
 6 files changed, 913 insertions(+), 52 deletions(-)
```

</details>

**gate history** · 5 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
src/js_parser/lower/lower_decorators.rs           39     67      0
src/js_parser/p.rs                                 6      1      0
src/js_parser/visit/mod.rs                        10     18      0
src/js_parser/visit/visit_expr.rs                  2      2      0
src/js_parser/visit/visit_stmt.rs                  2      4      0
test/bundler/transpiler/es-decorators.test.ts     10     17      0
```

</details>

<!-- robobun:evidence:end -->


