### PR TITLE
paths: compute the common path of 9+ inputs with the same loop as fewer

### DIFF
--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -99,11 +99,17 @@ fn get_if_exists_longest_common_path_generic<'a, P: PlatformT>(
     let is_path_separator = P::P.get_separator_func();
 
     let nql_at_index_fn: fn(usize, usize, &[&[u8]]) -> bool = match P::P {
-        Platform::Windows => |n, i, inp| nql_at_index_case_insensitive_dyn(n, i, inp),
-        _ => |n, i, inp| nql_at_index_dyn(n, i, inp),
+        Platform::Windows => nql_at_index_case_insensitive_dyn,
+        _ => nql_at_index_dyn,
     };
     // PERF: uses a runtime `n` (no per-count unrolling). Profile if it shows
     // up on a hot path.
+
+    let string_count = match input.len() {
+        0 => return Some(b""),
+        1 => return Some(input[0]),
+        n => n,
+    };
 
     let mut min_length: usize = usize::MAX;
     for str in input {
@@ -113,47 +119,15 @@ fn get_if_exists_longest_common_path_generic<'a, P: PlatformT>(
     let mut index: usize = 0;
     let mut last_common_separator: Option<usize> = None;
 
-    match input.len() {
-        0 => return Some(b""),
-        1 => return Some(input[0]),
-        n @ 2..=8 => {
-            while index < min_length {
-                if nql_at_index_fn(n, index, input) {
-                    last_common_separator?;
-                    break;
-                }
-                if is_path_separator(input[0][index]) {
-                    last_common_separator = Some(index);
-                }
-                index += 1;
-            }
+    while index < min_length {
+        if nql_at_index_fn(string_count, index, input) {
+            last_common_separator?;
+            break;
         }
-        _ => {
-            let mut string_index: usize = 1;
-            while string_index < input.len() {
-                while index < min_length {
-                    if P::P == Platform::Windows {
-                        if !input[0][index].eq_ignore_ascii_case(&input[string_index][index]) {
-                            last_common_separator?;
-                            break;
-                        }
-                    } else {
-                        if input[0][index] != input[string_index][index] {
-                            last_common_separator?;
-                            break;
-                        }
-                    }
-                    index += 1;
-                }
-                if index == min_length {
-                    index -= 1;
-                }
-                if is_path_separator(input[0][index]) {
-                    last_common_separator = Some(index);
-                }
-                string_index += 1;
-            }
+        if is_path_separator(input[0][index]) {
+            last_common_separator = Some(index);
         }
+        index += 1;
     }
 
     if index == 0 {
@@ -216,6 +190,23 @@ fn longest_common_path_generic<'a, P: PlatformT>(input: &[&'a [u8]]) -> &'a [u8]
     };
     // PERF: no per-count unrolling — profile if hot
 
+    let string_count = match input.len() {
+        0 => return b"",
+        1 => return input[0],
+        n => n,
+    };
+
+    // If volume IDs do not match on windows, we can't have a common path
+    if P::P == Platform::Windows {
+        let first_root = windows_filesystem_root(input[0]);
+        for str in &input[1..] {
+            let root = windows_filesystem_root(str);
+            if !strings::eql_case_insensitive_ascii_check_length(first_root, root) {
+                return b"";
+            }
+        }
+    }
+
     let mut min_length: usize = usize::MAX;
     for str in input {
         min_length = str.len().min(min_length);
@@ -224,70 +215,14 @@ fn longest_common_path_generic<'a, P: PlatformT>(input: &[&'a [u8]]) -> &'a [u8]
     let mut index: usize = 0;
     let mut last_common_separator: usize = 0;
 
-    match input.len() {
-        0 => return b"",
-        1 => return input[0],
-        n @ 2..=8 => {
-            // If volume IDs do not match on windows, we can't have a common path
-            if P::P == Platform::Windows {
-                let first_root = windows_filesystem_root(input[0]);
-                let mut i = 1;
-                while i < n {
-                    let root = windows_filesystem_root(input[i]);
-                    if !strings::eql_case_insensitive_ascii_check_length(first_root, root) {
-                        return b"";
-                    }
-                    i += 1;
-                }
-            }
-
-            while index < min_length {
-                if nql_at_index_fn(n, index, input) {
-                    break;
-                }
-                if is_path_separator(input[0][index]) {
-                    last_common_separator = index;
-                }
-                index += 1;
-            }
+    while index < min_length {
+        if nql_at_index_fn(string_count, index, input) {
+            break;
         }
-        _ => {
-            // If volume IDs do not match on windows, we can't have a common path
-            if P::P == Platform::Windows {
-                let first_root = windows_filesystem_root(input[0]);
-                let mut i: usize = 1;
-                while i < input.len() {
-                    let root = windows_filesystem_root(input[i]);
-                    if !strings::eql_case_insensitive_ascii_check_length(first_root, root) {
-                        return b"";
-                    }
-                    i += 1;
-                }
-            }
-
-            let mut string_index: usize = 1;
-            while string_index < input.len() {
-                while index < min_length {
-                    if P::P == Platform::Windows {
-                        if !input[0][index].eq_ignore_ascii_case(&input[string_index][index]) {
-                            break;
-                        }
-                    } else {
-                        if input[0][index] != input[string_index][index] {
-                            break;
-                        }
-                    }
-                    index += 1;
-                }
-                if index == min_length {
-                    index -= 1;
-                }
-                if is_path_separator(input[0][index]) {
-                    last_common_separator = index;
-                }
-                string_index += 1;
-            }
+        if is_path_separator(input[0][index]) {
+            last_common_separator = index;
         }
+        index += 1;
     }
 
     if index == 0 {
@@ -2508,6 +2443,86 @@ mod tests {
         text.iter()
             .position(|b| chars.contains(b))
             .unwrap_or(text_len)
+    }
+
+    fn entries(count: usize) -> Vec<Vec<u8>> {
+        (0..count)
+            .map(|i| format!("/app/pages/page{i}.ts").into_bytes())
+            .collect()
+    }
+
+    fn borrow(owned: &[Vec<u8>]) -> Vec<&[u8]> {
+        owned.iter().map(Vec::as_slice).collect()
+    }
+
+    #[test]
+    fn longest_common_path_does_not_depend_on_the_input_count() {
+        for count in 2..=20 {
+            let owned = entries(count);
+            let input = borrow(&owned);
+            assert_eq!(
+                get_if_exists_longest_common_path(&input),
+                Some(b"/app/pages/".as_slice()),
+                "{count} inputs"
+            );
+            assert_eq!(
+                longest_common_path(&input),
+                b"/app/pages/",
+                "{count} inputs"
+            );
+        }
+    }
+
+    #[test]
+    fn longest_common_path_of_many_inputs_detects_a_directory_that_is_itself_an_input() {
+        let mut owned = entries(9);
+        owned.push(b"/app/pages".to_vec());
+        let input = borrow(&owned);
+        assert_eq!(
+            get_if_exists_longest_common_path(&input),
+            Some(b"/app/pages/".as_slice())
+        );
+        assert_eq!(longest_common_path(&input), b"/app/pages/");
+    }
+
+    #[test]
+    fn longest_common_path_of_many_unrelated_inputs_matches_the_two_input_answer() {
+        let mut owned = entries(9);
+        owned.push(b"lib/other.ts".to_vec());
+        let input = borrow(&owned);
+        assert_eq!(
+            get_if_exists_longest_common_path(&input),
+            get_if_exists_longest_common_path(&input[8..])
+        );
+        assert_eq!(
+            longest_common_path(&input),
+            longest_common_path(&input[8..])
+        );
+    }
+
+    #[test]
+    fn longest_common_path_tolerates_an_empty_input_among_many() {
+        let mut owned = entries(9);
+        owned.push(Vec::new());
+        let input = borrow(&owned);
+        assert_eq!(
+            get_if_exists_longest_common_path(&input),
+            get_if_exists_longest_common_path(&input[8..])
+        );
+        assert_eq!(
+            longest_common_path(&input),
+            longest_common_path(&input[8..])
+        );
+
+        let empties = [b"".as_slice(); 9];
+        assert_eq!(
+            get_if_exists_longest_common_path(&empties),
+            get_if_exists_longest_common_path(&empties[..2])
+        );
+        assert_eq!(
+            longest_common_path(&empties),
+            longest_common_path(&empties[..2])
+        );
     }
 
     #[test]

--- a/test/bundler/bundler_naming.test.ts
+++ b/test/bundler/bundler_naming.test.ts
@@ -73,6 +73,20 @@ describe("bundler", () => {
       },
     ],
   });
+  // The implicit root is the entry points' common ancestor, `pages/` here.
+  // With more than 8 entry points it used to fall back to the cwd, so the
+  // same build wrote `/out/pages/*.js` instead.
+  const manyEntryNames = Array.from({ length: 9 }, (_, i) => `page${i}.js`);
+  for (const backend of ["api", "cli"] as const) {
+    itBundled(`naming/ImplicitOutbaseManyEntryPoints/${backend}`, {
+      backend,
+      files: Object.fromEntries(manyEntryNames.map((name, i) => [`/pages/${name}`, `console.log(${i});`])),
+      entryPoints: manyEntryNames.map(name => `/pages/${name}`),
+      onAfterBundle(api) {
+        expect(readdirSync(api.outdir).sort()).toEqual(manyEntryNames);
+      },
+    });
+  }
   itBundled("naming/EntryNamingTemplate1", {
     files: {
       "/a/hello/entry.js": /* js */ `

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -799,6 +799,35 @@ describe.concurrent("--no-bundle with --outdir", () => {
   });
 });
 
+test("an empty entry point is reported the same way past 8 entry points", async () => {
+  // The implicit root is derived from all entry point paths before anything is
+  // resolved; with more than 8 of them an empty path used to crash there. What
+  // it is reported as differs by platform, so compare against the 2 entry run.
+  // --no-bundle keeps both runs on the single-threaded transform path: the
+  // bundler's error exit has a teardown race of its own.
+  const entries = Array.from({ length: 8 }, (_, i) => `e${i}.ts`);
+  using dir = tempDir(
+    "build-many-entries-empty-entry",
+    Object.fromEntries(entries.map((name, i) => [name, `console.log(${i});`])),
+  );
+
+  async function build(entryPoints: string[], outdir: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--no-bundle", `--outdir=${outdir}`, ...entryPoints, ""],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    return { firstStderrLine: stderr.split("\n")[0], exitCode };
+  }
+
+  const [two, nine] = await Promise.all([build(entries.slice(0, 1), "dist-2"), build(entries, "dist-9")]);
+  expect(two.firstStderrLine).not.toBe("");
+  expect(nine).toEqual(two);
+});
+
 describe("CLI argument error messages", () => {
   test("--format with an unrecognized value echoes the value back", async () => {
     using dir = tempDir("build-format-err", { "in.js": "console.log(1)" });


### PR DESCRIPTION
### Problem
- `bun build` and `Bun.build()` derive the implicit root from the entry points with `resolve_path::get_if_exists_longest_common_path`. With 9 or more entry points it returns `None` for practically any input, so the root falls back to the cwd: 8 files in `pages/` build to `out/page0.js`, the same build with 9 files writes `out/pages/page0.js`. docs/bundler/index.mdx (the `root` option) documents the flat layout.
- The same code path aborts when one of 9+ entry points is empty: `bun build --outdir=out e0.ts ... e7.ts ""` dies with `panic: index out of bounds: the len is 5 but the index is 18446744073709551615` (debug build: `attempt to subtract with overflow` at src/paths/resolve_path.rs:282) instead of `error: ModuleNotFound resolving "" (entry point)`, which is what the same command with 2 entry points prints.
- Before #35644 landed, `bun build --no-bundle --outdir=dir` with 9+ entry points crashed the same way through `longest_common_path` (src/runtime/cli/build_command.rs:833), because every transform-only output had an empty `dest_path`. #35644 gives those outputs names (and fixes the `ENOENT: failed to write file '""'` seen with 1 to 8 entries); this PR fixes the function itself, which any caller with an empty or 9th input still hits.
- Cause, src/paths/resolve_path.rs: both functions match on `input.len()`. The `2..=8` arm runs one loop that compares every input at each byte and records the last separator it passed. The `_` arm (9+) compares `input[0]` against each other input in turn and only checks for a separator at the byte where the two diverge, so at the first mismatch `last_common_separator` is still unset (`get_if_exists` returns `None`; `longest_common_path` returns a one byte prefix), and when the shortest input is empty it executes `index -= 1` with `index == 0`. The Zig version had the same two arms; this is not a port regression.

### Fix
- Delete the 9+ arm in both functions. The 2..=8 loop already takes the input count as a runtime argument (`nql_at_index_dyn`), so it now runs for every count of 2 or more; the Windows volume check in `longest_common_path` becomes one loop over the inputs.
- Correct because the remaining loop is the one that has been producing the answers for up to 8 inputs; the result no longer depends on how many inputs there are. An empty input now gives the same answer it gives with 2 inputs (the separator, meaning nothing in common), and the command then fails the way it already does with 2 entries: the entry is reported as unresolvable on Linux and macOS, while Windows fails opening `/` as the root directory.
- The 2-input case used by `relative()` is unchanged except that the volume check now runs before the length scan.
- Verified with:
  - test/bundler/bundler_naming.test.ts `naming/ImplicitOutbaseManyEntryPoints/{api,cli}`: 9 entry points in `pages/` land directly in `out/`. On the released build both fail with `Bundle was not written to disk: .../out/page0.js`.
  - test/bundler/cli.test.ts `an empty entry point is reported the same way past 8 entry points`: runs `bun build --no-bundle --outdir` with 1 + 1 and with 8 + 1 entry points and expects the same first stderr line and exit code, so it holds on every platform. On the released build the 9 entry run exits 134 with the crash banner instead. It uses `--no-bundle` because the bundler's error exit still has the teardown race #37480 fixes; the first version of this test went through the bundler and hit that race as a segfault on one CI lane.
  - Unit tests in src/paths/resolve_path.rs (`cargo test -p bun_paths`): same answer for 2 through 20 inputs, a directory that is itself one of the inputs, unrelated inputs, an empty input. Against the previous implementation three of the four fail (`None`, `"."`, `attempt to subtract with overflow`).
  - Also run with the change: the rest of bundler_naming.test.ts and cli.test.ts, bun-build-api.test.ts, bundler_html.test.ts, bundler_splitting.test.ts, the node:path relative/resolve tests, `cargo clippy -p bun_paths`.
  - Rebased over #35644 (the only conflict was both changes adding tests at the same spot in cli.test.ts); its `--no-bundle with --outdir` tests and the tests above all pass on the rebased tree.

### Background
- The implicit root (esbuild calls it outbase) is the directory that output paths are computed relative to when `--root` / `root` is not given. It is derived from the entry point strings before anything is resolved (src/runtime/cli/build_command.rs:406, src/runtime/api/JSBundler.rs:902), which is why an unresolvable entry point reaches this code at all.
- `get_if_exists_longest_common_path` returns the directory prefix shared by all of its inputs, or `None` when they diverge before the first directory boundary (the callers then fall back to `.`). `longest_common_path` is the same scan but always returns something: the separator when nothing is shared. `relative()` calls the latter with two inputs, so the 2-input loop is the heavily exercised one.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 13 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/cli.test.ts

<!-- robobun:evidence:end -->
