### PR TITLE
libuv_sys: restore uv_translate_sys_error / uv_os_getppid (Windows build of main) and lint crate references

### DIFF
--- a/src/libuv_sys/libuv.rs
+++ b/src/libuv_sys/libuv.rs
@@ -2725,6 +2725,9 @@ unsafe extern "C" {
     pub fn uv_update_time(loop_: *mut Loop);
     pub fn uv_now(loop_: *const Loop) -> u64;
 
+    // errors
+    pub fn uv_translate_sys_error(sys_errno: c_int) -> c_int;
+
     // handle/req
     pub fn uv_handle_size(type_: uv_handle_type) -> usize;
     pub fn uv_handle_get_type(handle: *const uv_handle_t) -> uv_handle_type;
@@ -2845,6 +2848,7 @@ unsafe extern "C" {
     pub fn uv_uptime(uptime: *mut f64) -> c_int;
     pub fn uv_getrusage(rusage: *mut uv_rusage_t) -> c_int;
     pub fn uv_os_homedir(buffer: *mut u8, size: *mut usize) -> ReturnCode;
+    pub fn uv_os_getppid() -> uv_pid_t;
     pub fn uv_os_getpriority(pid: uv_pid_t, priority: *mut c_int) -> c_int;
     pub fn uv_cpu_info(cpu_infos: *mut *mut uv_cpu_info_t, count: *mut c_int) -> c_int;
     pub fn uv_free_cpu_info(cpu_infos: *mut uv_cpu_info_t, count: c_int);

--- a/test/internal/source-lints/libuv-sys-references.test.ts
+++ b/test/internal/source-lints/libuv-sys-references.test.ts
@@ -1,0 +1,110 @@
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+// bun_libuv_sys (src/libuv_sys/) is `#![cfg(windows)]`, and so is every use of
+// it in the rest of the tree. On the posix build and check lanes rustc never
+// resolves those paths, so a declaration deleted from the crate while a
+// cfg(windows) caller still names it (or a caller added for a declaration that
+// is already gone) is only found by the Windows build, ~25 minutes in. This
+// happened when #37332 dropped `uv_translate_sys_error` / `uv_os_getppid` and
+// #31829, merged in between, had started calling both.
+//
+// This lint resolves the crate-root names textually on any host: every name
+// reached through the crate from src/ must be an item the crate defines or
+// re-exports. Only root names are checked; methods, fields and signatures
+// remain rustc's job on Windows (`bun run rust:check-all`).
+//
+// Comments are handled per match (a hit preceded by `//` on its line is
+// skipped) rather than by stripping them up front: a `/*` inside a `//` comment
+// (`build/*/codegen`) would otherwise swallow real code up to the next `*/`.
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+
+function rustFiles(pattern: string): string[] {
+  return [...new Bun.Glob(pattern).scanSync({ cwd: root })].map(p => p.replaceAll("\\", "/")).sort();
+}
+
+function inLineComment(code: string, offset: number): boolean {
+  return code.slice(code.lastIndexOf("\n", offset) + 1, offset).includes("//");
+}
+
+function lineOf(code: string, offset: number): number {
+  return code.slice(0, offset).split("\n").length;
+}
+
+// Names a path into the crate can resolve to. Deliberately a superset of the
+// real crate root (impl methods and items of nested modules are collected too,
+// and every identifier of a `pub use` line counts): a name missing from this
+// set is missing everywhere, and that is the only thing this lint reports.
+function crateNames(): Set<string> {
+  const names = new Set<string>();
+  const item =
+    /\b(?:fn|struct|enum|union|type|mod|trait|macro_rules!)\s+([A-Za-z_]\w*)|\b(?:const|static)\s+(?:mut\s+)?(?!fn\b)([A-Za-z_]\w*)/g;
+  for (const file of rustFiles("src/libuv_sys/**/*.rs")) {
+    const code = readFileSync(path.join(root, file), "utf8");
+    for (const m of code.matchAll(item)) {
+      if (!inLineComment(code, m.index)) names.add(m[1] ?? m[2]);
+    }
+    for (const m of code.matchAll(/^\s*pub(?:\([^)]*\))?\s+use\b([^;]*);/gm)) {
+      for (const id of m[1].matchAll(/[A-Za-z_]\w*/g)) names.add(id[0]);
+    }
+  }
+  return names;
+}
+
+// The crate is reached by name, through bun_sys's re-export
+// (`pub use bun_libuv_sys as libuv;` in src/sys/windows/mod.rs, spelled out as
+// `bun_sys::windows::libuv::Loop` or `crate::windows::libuv::ReturnCode`), or
+// through the tree-wide aliases `use bun_libuv_sys as uv;` /
+// `use bun_sys::windows::libuv as uv;` / `use bun_sys::windows::libuv;`.
+const DIRECT = "bun_libuv_sys|windows::libuv";
+const WITH_ALIASES = `${DIRECT}|libuv|uv`;
+// The bare aliases are only followed in files with a `use` declaration naming
+// the crate or the re-export, so a file that binds `uv::` / `libuv::` to
+// something else is left alone (bun_core, which bun_libuv_sys depends on,
+// declares its own one-function `windows_sys::libuv` module).
+const importsCrate = /^\s*(?:pub(?:\([^)]*\))?\s+)?use\b[^;]*\b(?:bun_libuv_sys|libuv)\b/m;
+
+function pathRefs(prefixes: string): RegExp {
+  return new RegExp(String.raw`(?<!\w)(?:${prefixes})::([A-Za-z_]\w*)`, "g");
+}
+// `use bun_sys::windows::libuv::{a, b as _, c::{d}};` is not a path reference;
+// each entry's leading segment is a root name (one level of nesting allowed).
+function useListRefs(prefixes: string): RegExp {
+  return new RegExp(String.raw`\buse\s+(?:\w+::)*(?:${prefixes})::\{((?:[^{}]|\{[^{}]*\})*)\}`, "g");
+}
+
+test("every name referenced through bun_libuv_sys exists in src/libuv_sys", () => {
+  const names = crateNames();
+  const missing: string[] = [];
+  let referenced = 0;
+
+  for (const file of rustFiles("src/**/*.rs")) {
+    if (file.startsWith("src/libuv_sys/")) continue;
+    const bytes = readFileSync(path.join(root, file));
+    if (!bytes.includes("uv::") && !bytes.includes("bun_libuv_sys")) continue;
+    const code = bytes.toString("utf8");
+    const prefixes = importsCrate.test(code) ? WITH_ALIASES : DIRECT;
+
+    for (const m of code.matchAll(pathRefs(prefixes))) {
+      if (inLineComment(code, m.index)) continue;
+      referenced++;
+      if (!names.has(m[1])) missing.push(`${file}:${lineOf(code, m.index)}: ${m[0]}`);
+    }
+    for (const m of code.matchAll(useListRefs(prefixes))) {
+      if (inLineComment(code, m.index)) continue;
+      for (const entry of m[1].replace(/\{[^{}]*\}/g, "").split(",")) {
+        const name = /^\s*([A-Za-z_]\w*)/.exec(entry)?.[1];
+        if (name === undefined || name === "self") continue;
+        referenced++;
+        if (!names.has(name)) missing.push(`${file}:${lineOf(code, m.index)}: use ...::{${name}}`);
+      }
+    }
+  }
+
+  expect(missing).toEqual([]);
+  // Several hundred references exist today; if a change to the crate's layout
+  // or to these regexes stopped finding them, the lint would pass vacuously.
+  expect(referenced).toBeGreaterThan(200);
+});


### PR DESCRIPTION
### Problem
- main does not build on Windows (both build-bun Windows lanes). `cargo check --workspace --target x86_64-pc-windows-msvc` on main (2d3b1eed18):
  ```
  error[E0425]: cannot find function `uv_translate_sys_error` in crate `bun_libuv_sys`  --> src/runtime/node/node_cluster_binding.rs:391
  error[E0425]: cannot find function `uv_translate_sys_error` in crate `bun_libuv_sys`  --> src/runtime/node/node_util_binding.rs:75
  error[E0425]: cannot find function `uv_os_getppid` in crate `bun_libuv_sys`           --> src/runtime/ipc_host.rs:374
  error: could not compile `bun_runtime` (lib) due to 3 previous errors
  ```
- #37332 (opened Aug 10, merged Aug 14) removed the `uv_translate_sys_error` and `uv_os_getppid` declarations from `src/libuv_sys/libuv.rs`; at the time nothing called them.
- #31829 (merged Aug 11) added the three callers above, all inside `#[cfg(windows)]` blocks.
- The two PRs touch different files, so the merge had no conflict, and the posix lanes never type-check a `cfg(windows)` block, so only the Windows build noticed.

### Fix
- `src/libuv_sys/libuv.rs`: restore the two `extern "C"` declarations. Signatures match `src/jsc/bindings/libuv/uv.h` (`int uv_translate_sys_error(int)`, `uv_pid_t uv_os_getppid(void)`, `uv_pid_t` is `int` on Windows) and the three call sites; they are the lines #37332 removed.
- `test/internal/source-lints/libuv-sys-references.test.ts`: a source lint that collects every name referenced through `bun_libuv_sys` from `src/` (`bun_libuv_sys::x`, `bun_sys::windows::libuv::x`, the `uv::` / `libuv::` aliases in files that import the crate, and `use ...::{...}` lists) and requires each to be an item the crate defines or re-exports. On main it fails with exactly the three file:line pairs rustc reports above; with the restore it passes. It runs on any host in the source-lints workflow (which also runs on `merge_group`), so the same class of break is reported in seconds instead of after the Windows build. It does not replace `rust:check-all`: only crate-root names are checked, not signatures.
- Verified: `cargo check --workspace --target x86_64-pc-windows-msvc` and `--target aarch64-pc-windows-msvc` both exit 0 with this change (the x64 one reproduces the three errors without it); `bun bd test test/internal/source-lints/libuv-sys-references.test.ts` passes (~1.7s debug, ~0.1s release) and fails on main; `bun test test/internal/source-lints/` all green; `cargo fmt --check` clean.

### Background
- `bun_libuv_sys` (`src/libuv_sys/`) is bun's hand-written Rust FFI surface for libuv, and it is compiled only on Windows (`#![cfg(windows)]` at the top of `libuv.rs`). Other crates reach it either directly, through `bun_sys::windows::libuv` (a `pub use bun_libuv_sys as libuv;` re-export), or via the conventional `use ... as uv;` alias.
- Every caller is behind `#[cfg(windows)]` as well. rustc drops cfg'd-out code before name resolution, so a Linux or macOS `cargo check` / `bun bd` cannot tell whether a path into this crate still resolves; CLAUDE.md asks for `bun run rust:check-all` (a `cargo check` per CI target) when touching platform-gated code for this reason. That check was run for #37332, but against the main of the time, before #31829 added the callers.
- `test/internal/source-lints/` holds tests that only read the source tree. They run in a GitHub Actions workflow against a released bun on every `src/**/*.rs` change and on merge groups, and are excluded from the Buildkite shards, which is what makes a textual check useful here even though rustc on Windows is the authority.

<details>
<summary>cargo check on the Windows targets, before and after</summary>

Before (main, x86_64-pc-windows-msvc, `--keep-going`):

```
src/runtime/node/node_cluster_binding.rs:391:50: error[E0425]: cannot find function `uv_translate_sys_error` in crate `bun_libuv_sys`: not found in `bun_libuv_sys`
src/runtime/node/node_util_binding.rs:75:46: error[E0425]: cannot find function `uv_translate_sys_error` in crate `bun_libuv_sys`: not found in `bun_libuv_sys`
src/runtime/ipc_host.rs:374:37: error[E0425]: cannot find function `uv_os_getppid` in crate `bun_libuv_sys`: not found in `bun_libuv_sys`
error: could not compile `bun_runtime` (lib) due to 3 previous errors
```

After (this branch):

```
x86_64-pc-windows-msvc:  Finished `dev` profile [unoptimized + debuginfo] target(s) in 46.23s   (exit 0, no warnings)
aarch64-pc-windows-msvc: Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 09s   (exit 0, no warnings)
```

Lint on main (`git stash push -- src/ && bun bd test test/internal/source-lints/libuv-sys-references.test.ts`):

```
+   "src/runtime/ipc_host.rs:374: bun_libuv_sys::uv_os_getppid",
+   "src/runtime/node/node_cluster_binding.rs:391: bun_libuv_sys::uv_translate_sys_error",
+   "src/runtime/node/node_util_binding.rs:75: bun_libuv_sys::uv_translate_sys_error",
```

The lint currently resolves 645 references against 559 crate names. Comments are skipped per match (a hit preceded by `//` on its line) rather than by stripping them first: `src/runtime/api/bun/subprocess.rs:205` has `build/*/codegen` inside a `//` comment, and a stripping pass treats that `/*` as opening a block comment that hides real code down to line 1529, including a real libuv reference at line 1266.
</details>
