### PR TITLE
install: keep trustedDependencies and patchedDependencies order in bun.lock

### DIFF
--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -165,14 +165,10 @@ impl<'a> TreeDepsSortCtx<'a> {
     }
 }
 
-/// Hash context for the maps `trustedDependencies` and `patchedDependencies`
-/// are collected in. Both sections are written in map iteration order, so the
-/// slot layout is part of the on-disk format: every bun.lock written so far
-/// has them in `std.AutoHashMap(u64, ...)` order, i.e. wyhash over the key's
-/// bytes in the linear-probe layout `HashMap` still has. `AutoHashContext`
-/// hashes integers differently; writing in its order reorders both sections
-/// of a lockfile an earlier version wrote on the next save, even though
-/// nothing in them changed.
+/// `std.AutoHashMap(u64)`'s hash. `trustedDependencies` and
+/// `patchedDependencies` are written in the iteration order of the maps they
+/// are collected in, so every existing bun.lock has them in this hash's slot
+/// order; `AutoHashContext` hashes integers differently and would reorder them.
 struct WrittenOrderContext;
 
 impl HashContext<u64> for WrittenOrderContext {
@@ -185,10 +181,6 @@ impl HashContext<u64> for WrittenOrderContext {
         a == b
     }
 }
-
-/// Keyed by the hash the lockfile already has for the entry
-/// (`Dependency.name_hash`, `PackageNameAndVersionHash`).
-type WrittenOrderMap<V> = HashMap<u64, V, WrittenOrderContext>;
 
 pub(crate) struct Stringifier;
 
@@ -331,15 +323,15 @@ impl Stringifier {
 
         let mut temp_buf: Vec<u8> = Vec::new();
 
-        // The `reserve` calls also fix the written order: the capacity they
-        // pick decides which slot each entry lands in (see `WrittenOrderContext`).
-        let mut found_trusted_dependencies: WrittenOrderMap<String> = WrittenOrderMap::default();
+        // The reserved capacity is part of the written order too (`WrittenOrderContext`).
+        let mut found_trusted_dependencies: HashMap<u64, String, WrittenOrderContext> =
+            HashMap::default();
         if let Some(trusted_dependencies) = &lockfile.trusted_dependencies {
             found_trusted_dependencies.reserve(trusted_dependencies.count());
         }
 
-        let mut found_patched_dependencies: WrittenOrderMap<(Box<[u8]>, String)> =
-            WrittenOrderMap::default();
+        let mut found_patched_dependencies: HashMap<u64, (Box<[u8]>, String), WrittenOrderContext> =
+            HashMap::default();
         found_patched_dependencies.reserve(lockfile.patched_dependencies.count());
 
         let mut optional_peers_buf: Vec<String> = Vec::new();

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -4,7 +4,7 @@ use core::fmt::Write as _;
 
 use crate::bun_json as JSON;
 use bun_ast::{Expr, expr::Data as ExprData};
-use bun_collections::{HashMap, StringHashMap};
+use bun_collections::{HashContext, HashMap, StringHashMap};
 use bun_core::strings;
 use bun_core::{self};
 use bun_paths::PathBuffer;
@@ -165,6 +165,31 @@ impl<'a> TreeDepsSortCtx<'a> {
     }
 }
 
+/// Hash context for the maps `trustedDependencies` and `patchedDependencies`
+/// are collected in. Both sections are written in map iteration order, so the
+/// slot layout is part of the on-disk format: every bun.lock written so far
+/// has them in `std.AutoHashMap(u64, ...)` order, i.e. wyhash over the key's
+/// bytes in the linear-probe layout `HashMap` still has. `AutoHashContext`
+/// hashes integers differently; writing in its order reorders both sections
+/// of a lockfile an earlier version wrote on the next save, even though
+/// nothing in them changed.
+struct WrittenOrderContext;
+
+impl HashContext<u64> for WrittenOrderContext {
+    #[inline]
+    fn ctx_hash(key: &u64) -> u64 {
+        bun_wyhash::hash(&key.to_le_bytes())
+    }
+    #[inline]
+    fn ctx_eql(a: &u64, b: &u64) -> bool {
+        a == b
+    }
+}
+
+/// Keyed by the hash the lockfile already has for the entry
+/// (`Dependency.name_hash`, `PackageNameAndVersionHash`).
+type WrittenOrderMap<V> = HashMap<u64, V, WrittenOrderContext>;
+
 pub(crate) struct Stringifier;
 
 impl Stringifier {
@@ -306,12 +331,15 @@ impl Stringifier {
 
         let mut temp_buf: Vec<u8> = Vec::new();
 
-        let mut found_trusted_dependencies: HashMap<u64, String> = HashMap::default();
+        // The `reserve` calls also fix the written order: the capacity they
+        // pick decides which slot each entry lands in (see `WrittenOrderContext`).
+        let mut found_trusted_dependencies: WrittenOrderMap<String> = WrittenOrderMap::default();
         if let Some(trusted_dependencies) = &lockfile.trusted_dependencies {
             found_trusted_dependencies.reserve(trusted_dependencies.count());
         }
 
-        let mut found_patched_dependencies: HashMap<u64, (Box<[u8]>, String)> = HashMap::default();
+        let mut found_patched_dependencies: WrittenOrderMap<(Box<[u8]>, String)> =
+            WrittenOrderMap::default();
         found_patched_dependencies.reserve(lockfile.patched_dependencies.count());
 
         let mut optional_peers_buf: Vec<String> = Vec::new();

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -165,10 +165,8 @@ impl<'a> TreeDepsSortCtx<'a> {
     }
 }
 
-/// `std.AutoHashMap(u64)`'s hash. `trustedDependencies` and
-/// `patchedDependencies` are written in the iteration order of the maps they
-/// are collected in, so every existing bun.lock has them in this hash's slot
-/// order; `AutoHashContext` hashes integers differently and would reorder them.
+/// The slot order every existing bun.lock has its `trustedDependencies` and
+/// `patchedDependencies` in (`std.AutoHashMap(u64)`'s hash).
 struct WrittenOrderContext;
 
 impl HashContext<u64> for WrittenOrderContext {
@@ -323,7 +321,7 @@ impl Stringifier {
 
         let mut temp_buf: Vec<u8> = Vec::new();
 
-        // The reserved capacity is part of the written order too (`WrittenOrderContext`).
+        // Written out in iteration order, which the hash and the reserved capacity decide.
         let mut found_trusted_dependencies: HashMap<u64, String, WrittenOrderContext> =
             HashMap::default();
         if let Some(trusted_dependencies) = &lockfile.trusted_dependencies {

--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -523,40 +523,20 @@ index d156130662798530e852e1afaec5b1c03d429cdc..b4ddf35975a952fdaed99f2b14236519
   );
 });
 
-it("writes trustedDependencies and patchedDependencies in the order earlier versions wrote them", async () => {
+describe("writes trustedDependencies and patchedDependencies in the order earlier versions wrote them", () => {
   // Neither section is sorted: each is written in the iteration order of the
   // map that collects it, so that order is part of the format. The expected
-  // blocks below are what bun 1.3.14 writes for this package.json. Writing a
-  // different order would reorder both sections in every existing bun.lock on
-  // the next `bun add`/`bun remove`, and the older version would flip them back.
-  const trusted = ["esbuild", "sharp", "@prisma/client", "prisma", "bcrypt", "core-js", "@prisma/engines"];
-  const patched = ["esbuild", "sharp", "prisma", "bcrypt", "core-js"];
-  const patch = `diff --git a/index.js b/index.js
-new file mode 100644
-index 0000000..e69de29
-`;
-
-  const files: Record<string, string> = {
-    "package.json": JSON.stringify({
-      name: "trusted-and-patched-order",
-      version: "1.0.0",
-      workspaces: ["packages/*", "packages/@prisma/*"],
-      trustedDependencies: trusted,
-      patchedDependencies: Object.fromEntries(patched.map(name => [`${name}@1.0.0`, `patches/${name}.patch`])),
-    }),
-  };
-  for (const name of trusted) {
-    files[`packages/${name}/package.json`] = JSON.stringify({ name, version: "1.0.0" });
-  }
-  for (const name of patched) {
-    files[`patches/${name}.patch`] = patch;
-  }
-
-  const { packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "hoisted" }, files });
-
-  const trustedAndPatchedSections = (lockfile: string) =>
-    lockfile.slice(lockfile.indexOf('  "trustedDependencies"'), lockfile.indexOf('  "packages"'));
-  const expected = `  "trustedDependencies": [
+  // blocks below are what bun 1.3.14 writes for these package.json files.
+  // Writing a different order would reorder both sections in every existing
+  // bun.lock on the next `bun add`/`bun remove`, and the older version would
+  // flip them back. The second shape uses a larger trusted map (13 entries
+  // instead of 7) and fills the patched map up to its growth threshold (6 of
+  // 8 slots), so a change to how the maps size themselves shows up here too.
+  const shapes = [
+    {
+      trusted: ["esbuild", "sharp", "@prisma/client", "prisma", "bcrypt", "core-js", "@prisma/engines"],
+      patched: ["esbuild", "sharp", "prisma", "bcrypt", "core-js"],
+      expected: `  "trustedDependencies": [
     "bcrypt",
     "esbuild",
     "sharp",
@@ -572,21 +552,92 @@ index 0000000..e69de29
     "esbuild@1.0.0": "patches/esbuild.patch",
     "sharp@1.0.0": "patches/sharp.patch",
   },
+`,
+    },
+    {
+      trusted: [
+        "esbuild",
+        "sharp",
+        "@prisma/client",
+        "prisma",
+        "bcrypt",
+        "core-js",
+        "@prisma/engines",
+        "puppeteer",
+        "playwright",
+        "electron",
+        "better-sqlite3",
+        "fsevents",
+        "@swc/core",
+      ],
+      patched: ["esbuild", "sharp", "prisma", "bcrypt", "core-js", "puppeteer"],
+      expected: `  "trustedDependencies": [
+    "bcrypt",
+    "@swc/core",
+    "core-js",
+    "playwright",
+    "esbuild",
+    "sharp",
+    "@prisma/engines",
+    "fsevents",
+    "@prisma/client",
+    "electron",
+    "better-sqlite3",
+    "prisma",
+    "puppeteer",
+  ],
+  "patchedDependencies": {
+    "prisma@1.0.0": "patches/prisma.patch",
+    "bcrypt@1.0.0": "patches/bcrypt.patch",
+    "core-js@1.0.0": "patches/core-js.patch",
+    "esbuild@1.0.0": "patches/esbuild.patch",
+    "puppeteer@1.0.0": "patches/puppeteer.patch",
+    "sharp@1.0.0": "patches/sharp.patch",
+  },
+`,
+    },
+  ];
+
+  const trustedAndPatchedSections = (lockfile: string) =>
+    lockfile.slice(lockfile.indexOf('  "trustedDependencies"'), lockfile.indexOf('  "packages"'));
+
+  it.each(shapes)("$trusted.length trusted, $patched.length patched", async ({ trusted, patched, expected }) => {
+    const scopes = new Set(trusted.filter(name => name.startsWith("@")).map(name => name.split("/")[0]));
+    const files: Record<string, string> = {
+      "package.json": JSON.stringify({
+        name: "trusted-and-patched-order",
+        version: "1.0.0",
+        workspaces: ["packages/*", ...Array.from(scopes, scope => `packages/${scope}/*`)],
+        trustedDependencies: trusted,
+        patchedDependencies: Object.fromEntries(patched.map(name => [`${name}@1.0.0`, `patches/${name}.patch`])),
+      }),
+    };
+    for (const name of trusted) {
+      files[`packages/${name}/package.json`] = JSON.stringify({ name, version: "1.0.0" });
+    }
+    for (const name of patched) {
+      files[`patches/${name}.patch`] = `diff --git a/index.js b/index.js
+new file mode 100644
+index 0000000..e69de29
 `;
+    }
 
-  await runBunInstall(env, packageDir);
-  expect(trustedAndPatchedSections(await file(join(packageDir, "bun.lock")).text())).toBe(expected);
+    const { packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "hoisted" }, files });
 
-  // Re-saving the lockfile because something else changed must leave both
-  // sections untouched.
-  await write(
-    join(packageDir, "packages", "left-pad", "package.json"),
-    JSON.stringify({ name: "left-pad", version: "1.0.0" }),
-  );
-  await runBunInstall(env, packageDir);
-  const resaved = await file(join(packageDir, "bun.lock")).text();
-  expect(resaved).toContain('"left-pad": ["left-pad@workspace:packages/left-pad"]');
-  expect(trustedAndPatchedSections(resaved)).toBe(expected);
+    await runBunInstall(env, packageDir);
+    expect(trustedAndPatchedSections(await file(join(packageDir, "bun.lock")).text())).toBe(expected);
+
+    // Re-saving the lockfile because something else changed must leave both
+    // sections untouched.
+    await write(
+      join(packageDir, "packages", "left-pad", "package.json"),
+      JSON.stringify({ name: "left-pad", version: "1.0.0" }),
+    );
+    await runBunInstall(env, packageDir);
+    const resaved = await file(join(packageDir, "bun.lock")).text();
+    expect(resaved).toContain('"left-pad": ["left-pad@workspace:packages/left-pad"]');
+    expect(trustedAndPatchedSections(resaved)).toBe(expected);
+  });
 });
 
 it("should sort overrides before comparing", async () => {

--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -523,6 +523,72 @@ index d156130662798530e852e1afaec5b1c03d429cdc..b4ddf35975a952fdaed99f2b14236519
   );
 });
 
+it("writes trustedDependencies and patchedDependencies in the order earlier versions wrote them", async () => {
+  // Neither section is sorted: each is written in the iteration order of the
+  // map that collects it, so that order is part of the format. The expected
+  // blocks below are what bun 1.3.14 writes for this package.json. Writing a
+  // different order would reorder both sections in every existing bun.lock on
+  // the next `bun add`/`bun remove`, and the older version would flip them back.
+  const trusted = ["esbuild", "sharp", "@prisma/client", "prisma", "bcrypt", "core-js", "@prisma/engines"];
+  const patched = ["esbuild", "sharp", "prisma", "bcrypt", "core-js"];
+  const patch = `diff --git a/index.js b/index.js
+new file mode 100644
+index 0000000..e69de29
+`;
+
+  const files: Record<string, string> = {
+    "package.json": JSON.stringify({
+      name: "trusted-and-patched-order",
+      version: "1.0.0",
+      workspaces: ["packages/*", "packages/@prisma/*"],
+      trustedDependencies: trusted,
+      patchedDependencies: Object.fromEntries(patched.map(name => [`${name}@1.0.0`, `patches/${name}.patch`])),
+    }),
+  };
+  for (const name of trusted) {
+    files[`packages/${name}/package.json`] = JSON.stringify({ name, version: "1.0.0" });
+  }
+  for (const name of patched) {
+    files[`patches/${name}.patch`] = patch;
+  }
+
+  const { packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "hoisted" }, files });
+
+  const trustedAndPatchedSections = (lockfile: string) =>
+    lockfile.slice(lockfile.indexOf('  "trustedDependencies"'), lockfile.indexOf('  "packages"'));
+  const expected = `  "trustedDependencies": [
+    "bcrypt",
+    "esbuild",
+    "sharp",
+    "@prisma/engines",
+    "@prisma/client",
+    "core-js",
+    "prisma",
+  ],
+  "patchedDependencies": {
+    "prisma@1.0.0": "patches/prisma.patch",
+    "bcrypt@1.0.0": "patches/bcrypt.patch",
+    "core-js@1.0.0": "patches/core-js.patch",
+    "esbuild@1.0.0": "patches/esbuild.patch",
+    "sharp@1.0.0": "patches/sharp.patch",
+  },
+`;
+
+  await runBunInstall(env, packageDir);
+  expect(trustedAndPatchedSections(await file(join(packageDir, "bun.lock")).text())).toBe(expected);
+
+  // Re-saving the lockfile because something else changed must leave both
+  // sections untouched.
+  await write(
+    join(packageDir, "packages", "left-pad", "package.json"),
+    JSON.stringify({ name: "left-pad", version: "1.0.0" }),
+  );
+  await runBunInstall(env, packageDir);
+  const resaved = await file(join(packageDir, "bun.lock")).text();
+  expect(resaved).toContain('"left-pad": ["left-pad@workspace:packages/left-pad"]');
+  expect(trustedAndPatchedSections(resaved)).toBe(expected);
+});
+
 it("should sort overrides before comparing", async () => {
   const { packageDir, packageJson } = await registry.createTestDir();
 


### PR DESCRIPTION
### Problem
- The first `bun add` / `bun remove` / `bun update <pkg>` run by a 1.4 build on a bun.lock written by 1.3.x rewrites the `trustedDependencies` array (and the `patchedDependencies` object) in a different order. Nothing in either section changed, so this is an unrelated hunk in every dependency PR, and a 1.3.x build doing the next add/remove reorders it back.
- Both sections are written in the iteration order of the map they are collected in (`src/install/lockfile/bun.lock.rs`, `found_trusted_dependencies` / `found_patched_dependencies`, written at the `"trustedDependencies"` / `"patchedDependencies"` loops in `save_from_binary_inner`). That order has never been sorted, so it is effectively part of the file format.
- The Zig writer collected them in a `std.AutoHashMapUnmanaged(u64, ...)`: slot index = wyhash of the key's 8 bytes, masked by a capacity derived from the `trustedDependencies` / `patchedDependencies` count. `bun_collections::HashMap` is a port of that layout (`src/collections/zig_hash_map.rs`), but its `AutoHashContext` hashes integer keys through `OneShotHasher::write_u64` (a single `mum` multiply, `src/wyhash/lib.rs`), so the same keys land in different slots and the sections come out permuted.
- Reproduced with 1.3.14 and a 1.4 canary on the same package.json (7 trusted names, 5 patched): 1.3.14 writes `bcrypt, esbuild, sharp, @prisma/engines, @prisma/client, core-js, prisma` (the order reported), the 1.4 build writes `bcrypt, esbuild, prisma, @prisma/engines, core-js, @prisma/client, sharp`, and `patchedDependencies` swaps two entries.

### Fix
- Adds a `HashContext` for those two maps that hashes the key as wyhash over its little-endian bytes (`bun_wyhash::hash` is the same wyhash `std.hash.Wyhash` implements), so with the unchanged map layout and the unchanged `reserve` counts the slots, and therefore the written order, are the ones every earlier version produced. No other caller of the map is affected.
- Restoring the old order rather than sorting: sorting would still rewrite both sections once in every existing lockfile and would still ping-pong against 1.3.x, so it would need to be tied to a `lockfileVersion` bump to be churn-free. This change makes 1.3.x and 1.4 agree byte for byte.
- Test: `test/cli/install/bun-lock.test.ts`, "writes trustedDependencies and patchedDependencies in the order earlier versions wrote them". Two shapes, each installed as a workspace and compared against the text bun 1.3.14 writes for that package.json: the reported 7 trusted / 5 patched set, and a 13 trusted / 6 patched set that puts the trusted map in the next capacity and fills the patched map to its growth threshold, so a change to the hash or to how the maps size themselves shows up. Each shape is re-saved after adding a package and checked again. Both fail on current main (the first with the same two hunks as the report) and pass with this change.
- Also checked: 1.3.14-written lockfile, `bun add` with this build produces only the added lines, and `bun remove` with 1.3.14 afterwards restores a byte-identical file; a differential run of 60 random workspace layouts (1 to 24 packages, so map capacities 8 through 32, some trusted names absent from the tree) writes identical sections with 1.3.14 and this build, while the unfixed build differs in 11 of 12; the rest of `bun-lock.test.ts` passes unchanged.

### Background
- bun.lock is the text lockfile. `trustedDependencies` lists the packages whose lifecycle scripts may run, `patchedDependencies` maps `name@version` to a patch file; the writer only emits the entries that are actually in the resolved tree, which is why they are collected into a map during the tree walk instead of being copied from package.json.
- `bun_collections::HashMap` is an open-addressing table with linear probing whose iteration order is its slot order, which is determined by the hash function, the capacity, and insertion order on collisions. A `HashContext` is the type parameter that supplies the hash function for a given map, so one map can use a different hash than the default without touching the others.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-lock.test.ts

<!-- robobun:evidence:end -->
