### PR TITLE
bake: provide every runtime helper from the dev server's bun:wrap module

### DIFF
--- a/src/runtime/bake/bake.private.d.ts
+++ b/src/runtime/bake/bake.private.d.ts
@@ -144,14 +144,3 @@ declare module "react-dom/server.node" {
     options: RenderToPipeableStreamOptions,
   ): PipeableStream<Uint8Array>;
 }
-
-declare module "bun:wrap" {
-  export const __name: unique symbol;
-  export const __legacyDecorateClassTS: unique symbol;
-  export const __legacyDecorateParamTS: unique symbol;
-  export const __legacyMetadataTS: unique symbol;
-  export const __using: unique symbol;
-  export const __callDispose: unique symbol;
-  export const __MEMO_CACHE_SENTINEL: unique symbol;
-  export const __EARLY_RETURN_SENTINEL: unique symbol;
-}

--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -935,9 +935,8 @@ declare global {
   }
 }
 
-// bun:bake/server, bun:bake/client, and bun:wrap are provided by this file
-// instead of the bundler. Transpiled output imports whichever lowering helpers
-// it uses from bun:wrap, so it gets all of runtime.bun.js, like `bun run`.
+// bun:bake/server, bun:bake/client, and bun:wrap are
+// provided by this file instead of the bundler
 registerSynthetic("bun:wrap", runtimeHelpers);
 
 if (side === "server") {

--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -935,13 +935,9 @@ declare global {
   }
 }
 
-// bun:bake/server, bun:bake/client, and bun:wrap are
-// provided by this file instead of the bundler.
-//
-// Transpiled modules import the helpers their lowered syntax needs (legacy and
-// standard decorators, `using`, React Compiler sentinels, ...) from "bun:wrap",
-// which `bun build` resolves to runtime.js. Exposing that module as a whole
-// keeps this copy complete when helpers are added, instead of listing them here.
+// bun:bake/server, bun:bake/client, and bun:wrap are provided by this file
+// instead of the bundler. Transpiled output imports whichever lowering helpers
+// it uses from bun:wrap, so it gets all of runtime.bun.js, like `bun run`.
 registerSynthetic("bun:wrap", runtimeHelpers);
 
 if (side === "server") {

--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -6,16 +6,7 @@
 // Some build failures from the bundler surface as runtime errors here, such as
 // `require` on a module with transitive top-level await, or a missing export.
 // This was done to make incremental updates as isolated as possible.
-import {
-  __callDispose,
-  __EARLY_RETURN_SENTINEL,
-  __legacyDecorateClassTS,
-  __legacyDecorateParamTS,
-  __legacyMetadataTS,
-  __MEMO_CACHE_SENTINEL,
-  __name,
-  __using,
-} from "../../runtime.bun";
+import * as runtimeHelpers from "../../runtime.bun";
 // This import is different based on client vs server side.
 // On the server, remapping is done automatically.
 import { type SourceMapURL, derefMapping } from "#stack-trace";
@@ -945,17 +936,13 @@ declare global {
 }
 
 // bun:bake/server, bun:bake/client, and bun:wrap are
-// provided by this file instead of the bundler
-registerSynthetic("bun:wrap", {
-  __name,
-  __legacyDecorateClassTS,
-  __legacyDecorateParamTS,
-  __legacyMetadataTS,
-  __using,
-  __callDispose,
-  __MEMO_CACHE_SENTINEL,
-  __EARLY_RETURN_SENTINEL,
-});
+// provided by this file instead of the bundler.
+//
+// Transpiled modules import the helpers their lowered syntax needs (legacy and
+// standard decorators, `using`, React Compiler sentinels, ...) from "bun:wrap",
+// which `bun build` resolves to runtime.js. Exposing that module as a whole
+// keeps this copy complete when helpers are added, instead of listing them here.
+registerSynthetic("bun:wrap", runtimeHelpers);
 
 if (side === "server") {
   registerSynthetic("bun:bake/server", {

--- a/test/bake/dev-and-prod.test.ts
+++ b/test/bake/dev-and-prod.test.ts
@@ -1,6 +1,6 @@
 // Tests which apply to both dev and prod. They are run twice.
 import { writeFileSync } from "node:fs";
-import { devAndProductionTest, devTest, emptyHtmlFile, WAIT_MULTIPLIER } from "./bake-harness";
+import { devAndProductionTest, devTest, emptyHtmlFile, minimalFramework, WAIT_MULTIPLIER } from "./bake-harness";
 
 const hmrSelfAcceptingModule = (label: string) => `
   console.log(${JSON.stringify(label)});
@@ -200,6 +200,71 @@ devTest("using runtime import", {
           ]
         : []),
     );
+  },
+});
+// Standard (TC39) decorators, `accessor` fields, and the `#private` members of a
+// decorated class are lowered into calls to helpers imported from "bun:wrap"
+// (__decoratorStart, __decorateElement, __runInitializers, __decoratorMetadata,
+// __privateAdd, __privateGet, __privateSet, __privateIn, __privateMethod). The
+// dev server does not bundle runtime.js; its HMR runtime provides "bun:wrap"
+// itself, so it has to export everything the production runtime does. This
+// class imports all nine helpers.
+const standardDecoratorsSource = `
+  const applied: string[] = [];
+  function dec(_value: unknown, ctx: DecoratorContext) {
+    applied.push(ctx.kind + ":" + String(ctx.name));
+  }
+  @dec
+  class Foo {
+    @dec static s = 1;
+    @dec #p = 2;
+    @dec accessor x = 3;
+    @dec m() {}
+    @dec get g() { return this.#p; }
+    @dec #pm() { return 5; }
+    accessor y = 4;
+    has(o: object) { return #p in o; }
+    pm() { return this.#pm(); }
+  }
+  const foo = new Foo();
+  foo.x += 10;
+  foo.y += 10;
+  export const decorated = applied.sort().join(",");
+  export const values = [Foo.s, foo.x, foo.y, foo.g, foo.pm(), foo.has(foo), foo.has({})].join(",");
+`;
+const expectedDecorated = "accessor:x,class:Foo,field:#p,field:s,getter:g,method:#pm,method:m";
+const expectedValues = "1,13,14,2,5,true,false";
+devAndProductionTest("standard decorators runtime import", {
+  files: {
+    "index.html": emptyHtmlFile({
+      styles: [],
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import { decorated, values } from "./decorated";
+      console.log(decorated);
+      console.log(values);
+    `,
+    "decorated.ts": standardDecoratorsSource,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage(expectedDecorated, expectedValues);
+  },
+});
+devTest("standard decorators runtime import on the server", {
+  framework: minimalFramework,
+  files: {
+    "decorated.ts": standardDecoratorsSource,
+    "routes/index.ts": `
+      import { decorated, values } from "../decorated";
+      export default function (req, meta) {
+        return new Response(decorated + "\\n" + values);
+      }
+    `,
+  },
+  async test(dev) {
+    await dev.fetch("/").equals(expectedDecorated + "\n" + expectedValues);
   },
 });
 devTest("hmr handles rapid consecutive edits", {


### PR DESCRIPTION
### Problem
- In the dev server (`Bun.serve` with an HTML route in development, or a Bake app), any module containing a TC39 standard decorator, or just an undecorated `accessor` field, fails to evaluate: `TypeError: import_bun_wrap.__decoratorStart is not a function`. In the browser this is a runtime error overlay; in a server route it is a 500. `bun build` and `bun run` handle the same source.
- The transpiler lowers that syntax into calls to helpers it imports from `"bun:wrap"`: `__decoratorStart`, `__decorateElement`, `__runInitializers`, `__decoratorMetadata`, `__privateAdd`, `__privateGet`, `__privateSet`, `__privateIn`, `__privateMethod` (`src/js_parser/lower/lower_decorators.rs`). In dev-server output that import becomes `hmr.require("bun:wrap")` (`src/bundler/linker_context/convertStmtsForChunkForDevServer.rs:123`), so the only implementation of `"bun:wrap"` is the synthetic module the HMR runtime registers.
- Cause: `src/runtime/bake/hmr-module.ts:949` built that module from a hand-written object of eight helpers (`__name`, the three legacy TS decorator helpers, `__using`, `__callDispose`, the two React Compiler sentinels). The ES decorator helpers were added to `runtime.js` and to the parser's import table (`Imports::ALL` in `src/ast/runtime.rs`) in #26436 but never to this list, so the list has been incomplete since standard decorators shipped.

### Fix
- `hmr-module.ts` imports `runtime.bun.js` as a namespace and registers that namespace as `"bun:wrap"`, replacing the eight-name object and its matching import list.
- Why this is correct: `runtime.bun.js` is `runtime.js` plus the Bun-flavored `using` helpers, and it is already what `bun run` serves for `import ... from "bun:wrap"` (`HardcodedModule::BunWrap` in `src/runtime/jsc_hooks.rs` returns the bundled `runtime.out.js` of that file). The dev server now hands out the same 30 exports, which cover every name in `Imports::ALL` except `__require`. `__require` is only imported when `auto_polyfill_require` is set, and `ParseTask.rs` turns that off for dev-server output (`require` is printed as `hmr.require` there; the existing "using runtime import" test pins this). Helpers added to `runtime.js` later are picked up with no list to keep in sync.
- The ambient `declare module "bun:wrap"` in `bake.private.d.ts` was a third copy of the old list; nothing in the bake sources imports from `"bun:wrap"`, so it is removed.
- Cost: the dev runtimes grow by about 4.4 KB minified each (`bake.client.js` 48.5 KB to 53.0 KB, `bake.server.js` 11.0 KB to 15.4 KB). An explicit list of the 26 helpers would have been 3.3 KB; the extra 1.1 KB is `__toESM`, `__toCommonJS`, `__commonJS` and `__esm`, which the parser never emits but `bun run` and `bun build` also expose under this specifier.
- Verified with `test/bake/dev-and-prod.test.ts`: a module whose decorated class imports all nine helpers, loaded through an HTML route in the browser (dev and production) and through a `minimalFramework` server route (dev). Without the src change the two dev tests fail with the error above and the production test passes; with it all of `dev-and-prod.test.ts` (15), `test/bake/dev/esm.test.ts` and `test/bake/dev/bundle.test.ts` (38) pass on the debug build. `tsc` on the bake project reports nothing for `hmr-module.ts` or `bake.private.d.ts`.

### Background
- `runtime.js` holds the helper functions the transpiler's lowerings call (`__toESM`, `__legacyDecorateClassTS`, `__decorateElement`, ...). The parser records which helpers a file uses and emits a single `import { ... } from "bun:wrap"` for them; `Imports::ALL` is the table of names it can emit. `bun build` resolves that import to `runtime.js` and bundles the used helpers in; `bun run` resolves it to a module built from `runtime.bun.js`.
- The dev server bundles each file separately in its own module format (`internal_bake_dev`) and evaluates them with a small module loader, the HMR runtime (`hmr-module.ts`, built into `bake.client.js` and `bake.server.js` by `src/codegen/bake-codegen.ts`). Builtins and `"bun:wrap"` are not bundled in that format; they are looked up in the loader's registry at evaluation time, and `registerSynthetic` is how the runtime pre-populates that registry with modules it implements itself.

<details>
<summary>Export set of the generated synthetic module vs <code>Imports::ALL</code></summary>

Cross-checking the `__export(exports_runtime_bun, {...})` block in the regenerated `bake.client.js` / `bake.server.js` against `Imports::ALL` in `src/ast/runtime.rs`:

```
bake.client.js | Imports::ALL: 27 | exported: 30
  missing from synthetic bun:wrap: [ "__require" ]
  runtime exports not in Imports::ALL: [ "__commonJS", "__esm", "__toCommonJS", "__toESM" ]
bake.server.js | Imports::ALL: 27 | exported: 30
  missing from synthetic bun:wrap: [ "__require" ]
  runtime exports not in Imports::ALL: [ "__commonJS", "__esm", "__toCommonJS", "__toESM" ]
```

The 30 names are the same set `build/debug/codegen/runtime.out.js` (the `bun run` module for `bun:wrap`) exports.

Failure without the fix, from the new tests on the released binary:

```
web| [E] TypeError: import_bun_wrap.__decoratorStart is not a function
     at decorated.ts (http://localhost:33927/_bun/client/index-00000000f07e7e3f.js:72:33)
...
dev| TypeError: import_bun_wrap.__decoratorStart is not a function. (In 'import_bun_wrap.__decoratorStart(undefined)', 'import_bun_wrap.__decoratorStart' is undefined)
dev|       at <anonymous> (/tmp/bun-dev-test-v3GEDN/dev-and-prod14/decorated.ts:6:1)
dev| GET - http://localhost:39261/ failed
error: Expected response to be ok, but got 500 Internal Server Error
```
</details>
