### PR TITLE
install: link bins whose target has a trailing slash

### DIFF
--- a/src/install/bin.rs
+++ b/src/install/bin.rs
@@ -750,10 +750,7 @@ fn normalized_bin_name(name: &[u8]) -> &[u8] {
     name
 }
 
-/// npm resolves the target with `path.resolve`, which drops trailing separators
-/// (`"bin": { "x": "cli.js/" }` links `cli.js`). `join_abs_string_z` keeps them,
-/// and `<package_dir>/cli.js/` would then fail the exists check in
-/// `link_bin_or_create_shim`.
+/// npm `path.resolve`s bin targets, dropping trailing separators; our join keeps them.
 fn normalized_bin_target(target: &[u8]) -> &[u8] {
     strings::without_trailing_slash(target)
 }

--- a/src/install/bin.rs
+++ b/src/install/bin.rs
@@ -750,6 +750,14 @@ fn normalized_bin_name(name: &[u8]) -> &[u8] {
     name
 }
 
+/// npm resolves the target with `path.resolve`, which drops trailing separators
+/// (`"bin": { "x": "cli.js/" }` links `cli.js`). `join_abs_string_z` keeps them,
+/// and `<package_dir>/cli.js/` would then fail the exists check in
+/// `link_bin_or_create_shim`.
+fn normalized_bin_target(target: &[u8]) -> &[u8] {
+    strings::without_trailing_slash(target)
+}
+
 /// True when a `bin` entry's target value would resolve outside the package
 /// directory (absolute path or `..` traversal). The bin *value* is taken
 /// verbatim from package.json, so without this check a malicious package could
@@ -1603,7 +1611,7 @@ impl<'a> Linker<'a> {
                 Tag::None => {}
                 Tag::File => {
                     let file = self.bin.value.file;
-                    let target = file.slice(self.string_buf);
+                    let target = normalized_bin_target(file.slice(self.string_buf));
                     if target.is_empty() || bin_target_escapes_package_dir(target) {
                         return;
                     }
@@ -1655,7 +1663,7 @@ impl<'a> Linker<'a> {
                     let named = self.bin.value.named_file;
                     let name = named[0].slice(self.string_buf);
                     let normalized_name = normalized_bin_name(name);
-                    let target = named[1].slice(self.string_buf);
+                    let target = normalized_bin_target(named[1].slice(self.string_buf));
                     if normalized_name.is_empty()
                         || target.is_empty()
                         || bin_target_escapes_package_dir(target)
@@ -1707,8 +1715,9 @@ impl<'a> Linker<'a> {
                     while i < end {
                         let bin_dest = self.extern_string_buf[i as usize].slice(self.string_buf);
                         let normalized_bin_dest = normalized_bin_name(bin_dest);
-                        let bin_target =
-                            self.extern_string_buf[(i + 1) as usize].slice(self.string_buf);
+                        let bin_target = normalized_bin_target(
+                            self.extern_string_buf[(i + 1) as usize].slice(self.string_buf),
+                        );
                         if bin_target.is_empty()
                             || normalized_bin_dest.is_empty()
                             || bin_target_escapes_package_dir(bin_target)

--- a/src/install/bin.rs
+++ b/src/install/bin.rs
@@ -750,11 +750,6 @@ fn normalized_bin_name(name: &[u8]) -> &[u8] {
     name
 }
 
-/// npm `path.resolve`s bin targets, dropping trailing separators; our join keeps them.
-fn normalized_bin_target(target: &[u8]) -> &[u8] {
-    strings::without_trailing_slash(target)
-}
-
 /// True when a `bin` entry's target value would resolve outside the package
 /// directory (absolute path or `..` traversal). The bin *value* is taken
 /// verbatim from package.json, so without this check a malicious package could
@@ -1479,6 +1474,9 @@ impl<'a> Linker<'a> {
         target: &[u8],
         bin_name: &[u8],
     ) -> &'b ZStr {
+        // npm `path.resolve`s the target, dropping trailing separators; our join keeps them, and a
+        // trailing separator also makes the kernel follow a symlinked target despite `lchmod`.
+        let target = strings::without_trailing_slash(target);
         let primary = resolve_path::join_abs_string_z::<PlatformAuto>(package_dir, &[target]);
 
         if !is_native_binlink_redirect {
@@ -1608,7 +1606,7 @@ impl<'a> Linker<'a> {
                 Tag::None => {}
                 Tag::File => {
                     let file = self.bin.value.file;
-                    let target = normalized_bin_target(file.slice(self.string_buf));
+                    let target = file.slice(self.string_buf);
                     if target.is_empty() || bin_target_escapes_package_dir(target) {
                         return;
                     }
@@ -1660,7 +1658,7 @@ impl<'a> Linker<'a> {
                     let named = self.bin.value.named_file;
                     let name = named[0].slice(self.string_buf);
                     let normalized_name = normalized_bin_name(name);
-                    let target = normalized_bin_target(named[1].slice(self.string_buf));
+                    let target = named[1].slice(self.string_buf);
                     if normalized_name.is_empty()
                         || target.is_empty()
                         || bin_target_escapes_package_dir(target)
@@ -1712,9 +1710,8 @@ impl<'a> Linker<'a> {
                     while i < end {
                         let bin_dest = self.extern_string_buf[i as usize].slice(self.string_buf);
                         let normalized_bin_dest = normalized_bin_name(bin_dest);
-                        let bin_target = normalized_bin_target(
-                            self.extern_string_buf[(i + 1) as usize].slice(self.string_buf),
-                        );
+                        let bin_target =
+                            self.extern_string_buf[(i + 1) as usize].slice(self.string_buf);
                         if bin_target.is_empty()
                             || normalized_bin_dest.is_empty()
                             || bin_target_escapes_package_dir(bin_target)

--- a/src/install/bin.rs
+++ b/src/install/bin.rs
@@ -1474,8 +1474,7 @@ impl<'a> Linker<'a> {
         target: &[u8],
         bin_name: &[u8],
     ) -> &'b ZStr {
-        // npm `path.resolve`s the target, dropping trailing separators; our join keeps them, and a
-        // trailing separator also makes the kernel follow a symlinked target despite `lchmod`.
+        // A trailing separator would make `lchmod` follow a symlinked target; npm drops it too.
         let target = strings::without_trailing_slash(target);
         let primary = resolve_path::join_abs_string_z::<PlatformAuto>(package_dir, &[target]);
 

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -3083,6 +3083,72 @@ describe("binaries", () => {
     );
   });
 
+  test("bin targets with a trailing slash are linked", async () => {
+    // npm resolves each target with path.resolve, which drops trailing separators,
+    // so all of these link the file. Covers the string, single-entry and multi-entry
+    // forms of "bin" since each is linked by a separate code path.
+    const script = (name: string) => `#!/usr/bin/env node\nconsole.log("${name}")`;
+    await Promise.all([
+      write(
+        packageJson,
+        JSON.stringify({
+          name: "foo",
+          dependencies: {
+            "file-bin": "./file-bin",
+            "named-file-bin": "./named-file-bin",
+            "map-bin": "./map-bin",
+          },
+        }),
+      ),
+      write(
+        join(packageDir, "file-bin", "package.json"),
+        JSON.stringify({ name: "file-bin", version: "1.0.0", bin: "file-bin.js/" }),
+      ),
+      write(join(packageDir, "file-bin", "file-bin.js"), script("file-bin")),
+      write(
+        join(packageDir, "named-file-bin", "package.json"),
+        JSON.stringify({
+          name: "named-file-bin",
+          version: "1.0.0",
+          bin: { "named-file-bin": "./bin/named-file-bin.js/" },
+        }),
+      ),
+      write(join(packageDir, "named-file-bin", "bin", "named-file-bin.js"), script("named-file-bin")),
+      write(
+        join(packageDir, "map-bin", "package.json"),
+        JSON.stringify({
+          name: "map-bin",
+          version: "1.0.0",
+          bin: {
+            "map-bin-1": "map-bin-1.js//",
+            "map-bin-2": "map-bin-2.js\\",
+            "map-bin-3": "map-bin-3.js",
+          },
+        }),
+      ),
+      write(join(packageDir, "map-bin", "map-bin-1.js"), script("map-bin-1")),
+      write(join(packageDir, "map-bin", "map-bin-2.js"), script("map-bin-2")),
+      write(join(packageDir, "map-bin", "map-bin-3.js"), script("map-bin-3")),
+    ]);
+
+    const expectBins = () => {
+      const bin = (name: string) => join(packageDir, "node_modules", ".bin", name);
+      expect(bin("file-bin")).toBeValidBin(join("..", "file-bin", "file-bin.js"));
+      expect(bin("named-file-bin")).toBeValidBin(join("..", "named-file-bin", "bin", "named-file-bin.js"));
+      expect(bin("map-bin-1")).toBeValidBin(join("..", "map-bin", "map-bin-1.js"));
+      expect(bin("map-bin-2")).toBeValidBin(join("..", "map-bin", "map-bin-2.js"));
+      expect(bin("map-bin-3")).toBeValidBin(join("..", "map-bin", "map-bin-3.js"));
+    };
+
+    await runBunInstall(env, packageDir);
+    expectBins();
+
+    // The lockfile keeps the targets as written, so linking from it has to normalize them as well.
+    await rm(join(packageDir, "node_modules", ".bin"), { recursive: true, force: true });
+    await runBunInstall(env, packageDir, { savesLockfile: false });
+    expectBins();
+  });
+
   test("root resolution bins", async () => {
     // As of writing this test, the only way to get a root resolution
     // is to migrate a package-lock.json with a root resolution. For now,

--- a/test/cli/install/symlink-path-traversal.test.ts
+++ b/test/cli/install/symlink-path-traversal.test.ts
@@ -817,6 +817,58 @@ it.skipIf(isWindows)(
 );
 
 it.skipIf(isWindows)(
+  "does not change permissions of a directory reached through a symlinked bin target with a trailing slash",
+  async () => {
+    // Same as above, but the bin target is written as "payload/". The kernel
+    // follows a symlink named with a trailing slash even when chmod is told not
+    // to follow symlinks, so the installer has to drop the slash before it
+    // stats, links and chmods the target.
+    using dir = tempDir("bin-target-symlink-trailing-slash-test", {
+      "bunfig.toml": `[install]\nlinker = "hoisted"\n`,
+      "package.json": JSON.stringify({
+        name: "bin-target-symlink-slash-app",
+        version: "1.0.0",
+        workspaces: ["packages/*"],
+      }),
+      "packages/dep/package.json": JSON.stringify({
+        name: "dep-with-symlinked-dir-bin",
+        version: "1.0.0",
+        bin: { "dep-with-symlinked-dir-bin": "./payload/" },
+      }),
+      "victim-dir/keep": "",
+    });
+    const installDir = String(dir);
+
+    const victimDir = join(installDir, "victim-dir");
+    await chmod(victimDir, 0o700);
+    await symlink(join("..", "..", "victim-dir"), join(installDir, "packages", "dep", "payload"));
+
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: installDir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect((await stat(victimDir)).mode & 0o777).toBe(0o700);
+
+    // Without the slash this target links (see above), so with it the result is the same.
+    const binLink = join(installDir, "node_modules", ".bin", "dep-with-symlinked-dir-bin");
+    expect(await readlink(binLink)).toBe(join("..", "dep-with-symlinked-dir-bin", "payload"));
+
+    if (exitCode !== 0) {
+      console.error("Install failed with exit code:", exitCode);
+      console.error("stdout:", stdout);
+      console.error("stderr:", stderr);
+    }
+    expect(exitCode).toBe(0);
+  },
+  60000,
+);
+
+it.skipIf(isWindows)(
   "skips a package bin entry whose name contains a NUL byte and links the remaining entries",
   async () => {
     using dir = tempDir("bin-name-nul-test", {


### PR DESCRIPTION
### Problem
- A `bin` target that ends in a path separator is never linked. With `"bin": { "depcli": "cli.js/" }` in a dependency, `bun install` succeeds, prints nothing, and `node_modules/.bin/depcli` does not exist; `"cli.js"` links fine. Debug builds abort instead: `panic: assertion failed: abs_target.as_bytes()[abs_target.as_bytes().len() - 1] != SEP` in `link_bin_or_create_shim` (src/install/bin.rs:896 on main).
- The same trailing separator gets around the chmod hardening from #31339. For `"bin": { "x": "payload/" }` where `payload` is a symlink the package ships, pointing at a directory outside the package, the hardened `lchmod` in `chmod_on_ok` still changes that outside directory's mode (700 becomes 755 in the repro below), because the kernel follows a symlink whose path ends in a slash regardless of `AT_SYMLINK_NOFOLLOW`. Without the slash the same package leaves the directory alone.
- Cause of both: `resolve_bin_target` (bin.rs:1477 on main) joins the target onto the package directory with `join_abs_string_z`, which keeps a trailing separator, so every later step (`exists`, the containment check, `symlink`, `lchmod`) runs on `.../payload/` instead of `.../payload`. For a file target `exists` fails with ENOTDIR and the entry is skipped as a missing bin; for a symlinked directory target everything succeeds, through the symlink.
- npm links the file: bin-links resolves each target with `path.resolve(pkgDir, target)` (`bin-links/lib/link-bins.js`), which drops trailing separators.
- Found by reading the code while working on `bun pm pack`'s bin handling, not from a user report.

### Fix
- `resolve_bin_target` strips trailing `/` and `\` from the target (`strings::without_trailing_slash`) before joining it, so the path that is stat'ed, checked, linked and chmodded names the entry itself. Two lines in src/install/bin.rs.
- Correct for the linking case because it is exactly what npm's `path.resolve` does to the same value; correct for the chmod case because the kernel's follow-the-slash rule only applies to paths ending in a separator, so once the separator is gone `lchmod` refuses to follow the symlink as #31339 intended.
- It cannot weaken the checks that run on the raw value in `Linker::link`: `bin_target_escapes_package_dir` and `bin_target_needs_resolved_containment_check` ignore empty path components, and `without_trailing_slash` never strips a lone separator, so `"../"`, `"/"`, `"//"` and `"C:/"` are rejected exactly as before. Directory targets such as `"sub/"` were already linked by release builds and still are.
- `resolve_bin_target` is the one place every `Bin` source (package.json, registry manifests, bun.lock, bun.lockb, migrated lockfiles) and every caller (hoisted and isolated installers, global installs, `bun link`) goes through, so existing lockfiles with such a value are covered, the lockfile keeps storing the value as written, and the extra caller that open PR #37150 adds to this function is covered whichever lands first. `directories.bin` (the `Dir` arm) does not use this function; it opens the directory, where a trailing slash is valid.
- Scope: values only. Bin names (the keys) are normalized separately by `normalized_bin_name` and are unchanged by this PR.
- Tests:
  - `test/cli/install/bun-install-registry.test.ts`, "bin targets with a trailing slash are linked": the string, single-entry and multi-entry forms of `bin` with `x/`, `./bin/x/`, `x//` and `x\` targets, linked from package.json and again from the lockfile. Fails on the current release (link missing) and on a current debug build (the assertion above).
  - `test/cli/install/symlink-path-traversal.test.ts`, "does not change permissions of a directory reached through a symlinked bin target with a trailing slash": a workspace package with `"./payload/"` pointing at a 700 directory outside the package. On the current release it fails with the directory at 755; on a current debug build it fails because the install aborts.
- Also ran with the debug build: all of bun-install-registry.test.ts, symlink-path-traversal.test.ts and bun-install-native-binlink.test.ts; the first repro also links with `--linker isolated`.

### Background
- Bin linking: for each entry of a package's `bin` field, `bun install` creates `node_modules/.bin/<name>` as a relative symlink (a `.bunx` plus `.exe` shim on Windows) pointing at `<package dir>/<target>`, then chmods the target so it is executable. `Linker::link` in src/install/bin.rs handles the three shapes `bin` has after parsing (a string, a one-entry object, a larger object); each shape calls `resolve_bin_target` to turn the target into an absolute path.
- #31339 changed that chmod to `lchmod` (`fchmodat2`, falling back to `fchmodat`, with `AT_SYMLINK_NOFOLLOW` on Linux) so a package cannot ship a symlink as its bin target and have the installer change the mode of whatever it points at. POSIX path resolution has an exception that matters here: a path ending in `/` must resolve to a directory, so the kernel follows a final symlink anyway, and the no-follow flag has nothing left to act on.
- `link_bin_or_create_shim` skips a target that does not exist on disk (so a dangling link cannot break a postinstall script) and prints nothing when it does, which is why the first symptom has no output.

<details>
<summary>Repro of the chmod symptom, release 1.4.0-canary (b7a043103, includes #31339) vs. this branch</summary>

```
mkdir -p packages/dep victim-dir && chmod 700 victim-dir
printf '[install]\nlinker = "hoisted"\n' > bunfig.toml
echo '{"name":"app","workspaces":["packages/*"]}' > package.json
echo '{"name":"dep","version":"1.0.0","bin":{"dep-bin":"payload/"}}' > packages/dep/package.json
ln -s ../../victim-dir packages/dep/payload
bun install && stat -c %a victim-dir
```

| target | release (unfixed) | this branch |
| --- | --- | --- |
| `payload/` or `./payload/` | victim-dir becomes 755, `.bin/dep-bin -> ../dep/payload` | victim-dir stays 700, same link |
| `payload` or `./payload` | victim-dir stays 700, same link | unchanged |

</details>

<details>
<summary>Other target shapes, unfixed release vs. this branch (hoisted install of a <code>file:</code> dependency, <code>readlink node_modules/.bin/x</code>)</summary>

| target | release (unfixed) | this branch |
| --- | --- | --- |
| `cli.js/` | not linked | `../dep/cli.js` |
| `cli.js/.` | `../dep/cli.js` | `../dep/cli.js` |
| `missing.js/` | not linked | not linked |
| `sub/` (a directory) | `../dep/sub` | `../dep/sub` |
| `sub` | `../dep/sub` | `../dep/sub` |
| `.` / `./` | not linked | not linked |
| `/` / `//` / `../` | not linked | not linked |

</details>

<details>
<summary>Earlier shape of this PR</summary>

The first revision applied the same strip in each of the three arms of `Linker::link` through a small helper and only described the linking symptom. Review pointed out that the join being fixed lives in `resolve_bin_target`, that stripping there also covers the caller #37150 adds, and that the chmod symptom above was being fixed without being stated or tested; this revision addresses all three.

</details>
