### PR TITLE
install: stamp lockfileVersion 1 on new bun.lock files

### DIFF
--- a/docs/pm/catalogs.mdx
+++ b/docs/pm/catalogs.mdx
@@ -257,7 +257,7 @@ Bun's lockfile tracks catalog versions, so installs are consistent across enviro
 
 ```json bun.lock(excerpt) icon="file-json"
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "workspaces": {
     "": {
       "name": "react-monorepo",

--- a/docs/pm/lockfile.mdx
+++ b/docs/pm/lockfile.mdx
@@ -56,7 +56,7 @@ For more on the format, see [the blog post](https://bun.com/blog/bun-lock-text-l
 
 #### `lockfileVersion`
 
-The `lockfileVersion` field at the top of `bun.lock` records its format version. A new `bun.lock` is written as `lockfileVersion` 1, which every Bun release since v1.2 can read, and re-saving an existing lockfile keeps the version it already has. The one exception is [nested or version-scoped overrides](/pm/overrides#limitations): a lockfile containing those is written as `lockfileVersion` 3, which requires Bun v1.4 or later.
+The `lockfileVersion` field at the top of `bun.lock` records its format version. A new `bun.lock` is written as `lockfileVersion` 1, which every Bun release since v1.2 can read, and re-saving a `lockfileVersion` 1 or 2 lockfile keeps its version. The exception is [nested or version-scoped overrides](/pm/overrides#limitations): while a lockfile contains those it is written as `lockfileVersion` 3, which requires Bun v1.4 or later, and it goes back to 1 once they are removed.
 
 #### Automatic lockfile migration
 

--- a/docs/pm/lockfile.mdx
+++ b/docs/pm/lockfile.mdx
@@ -54,6 +54,10 @@ Bun v1.2 changed the default lockfile format to the text-based `bun.lock`. To mi
 
 For more on the format, see [the blog post](https://bun.com/blog/bun-lock-text-lockfile).
 
+#### `lockfileVersion`
+
+The `lockfileVersion` field at the top of `bun.lock` records its format version. A new `bun.lock` is written as `lockfileVersion` 1, which every Bun release since v1.2 can read, and re-saving an existing lockfile keeps the version it already has. The one exception is [nested or version-scoped overrides](/pm/overrides#limitations): a lockfile containing those is written as `lockfileVersion` 3, which requires Bun v1.4 or later.
+
 #### Automatic lockfile migration
 
 When you run `bun install` in a project without a `bun.lock`, Bun automatically migrates existing lockfiles:

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -115,9 +115,7 @@ pub enum Version {
     ///   check on a `github` tag is enforced at every version, since its
     ///   download path has no checkout-time re-validation)
     ///
-    /// Same content as v1. Only preserved on a lockfile that was loaded at v2;
-    /// a new lockfile is stamped v1 so Bun releases that predate v2 can read it
-    /// (see `Stringifier::version_to_write`).
+    /// Same content as v1; only ever preserved, never stamped on a new lockfile.
     V2 = 2,
 
     /// `overrides` values may be objects holding scoped rules (parent-scoped or `name@range` targets); stamped while such rules exist and the package walk in `Stringifier::version_to_write` is v2-clean (object rows themselves parse at every version)
@@ -184,46 +182,25 @@ impl Stringifier {
         Self::save_from_binary_inner(lockfile, load_result, options, writer)
     }
 
-    /// Pick the `lockfileVersion` to stamp. The stamp is the lowest version whose
-    /// readers understand the content being written, so a `bun.lock` keeps
-    /// loading in every Bun release that can read it:
-    ///
-    /// - A lockfile loaded as v1 or v2 keeps its version. v1→v2 only added
-    ///   parse-time strictness on identical content, so neither is upgraded or
-    ///   downgraded on re-save.
-    /// - A lockfile with no prior version is stamped v1. `text_lockfile_version`
-    ///   holds the parsed version when the lockfile was loaded from text and is
-    ///   left at `Version::CURRENT` otherwise (a fresh install, or a migration
-    ///   from another lockfile format); both land in the v3 arm below. Stamping
-    ///   v2 there would lock out the releases that predate v2 without changing a
-    ///   byte of content.
-    /// - v0 is floored to v1: v0→v1 changed the content (v1 stopped listing a
-    ///   workspace package's dependencies as a trailing object) and the writer
-    ///   only emits the v1+ single-element `["name@workspace:path"]` form, which
-    ///   a v0 stamp would make the next parse reject ("Missing dependencies
-    ///   object").
-    /// - Scoped overrides (parent-scoped or `name@range` rules) are content an
-    ///   older reader would silently ignore, so while any exist the lockfile is
-    ///   stamped v3 whatever version was loaded; once they are gone a v3 lockfile
-    ///   drops back to v1 like a fresh one.
-    ///
-    /// v3 implies the v2 parse checks, and the parser evaluates the integrity
-    /// check against the *reader's* registries, so before stamping v3 the package
-    /// tree is walked the same way the writer serializes it (only packages that
-    /// reach the written `packages` object count; migration can leave
-    /// unreferenced entries in `pkg_resolutions`). A row some reader could reject
-    /// at v2+ (an off-registry npm tarball without a supported integrity, an
-    /// unsafe git `.bun-tag`) holds the lockfile at v1 with the override objects
-    /// written as-is: the parser reads those at every version, so the file still
-    /// round-trips everywhere instead of depending on the writer's `~/.npmrc`.
+    /// The lowest `lockfileVersion` whose readers understand the content being
+    /// written: v1 and v2 are the same content and pre-v2 readers reject the v2
+    /// stamp, so a new lockfile is v1; v3 is stamped only while scoped overrides
+    /// (which older readers would silently drop) exist.
     fn version_to_write(lockfile: &BinaryLockfile) -> Version {
         if !lockfile.overrides.has_scoped() {
             return match lockfile.text_lockfile_version {
                 loaded @ (Version::V1 | Version::V2) => loaded,
+                // v0: the writer only emits the v1+ workspace entry shape. v3: a
+                // lockfile that was never loaded sits at `Version::CURRENT`.
                 Version::V0 | Version::V3 => Version::V1,
             };
         }
 
+        // v3 implies the v2 parse checks, which a reader evaluates against its
+        // own registry config. Any serialized row that some reader could reject
+        // holds the file at v1 instead; the override objects parse at every
+        // version. Walk the tree rather than `pkg_resolutions`, which migration
+        // can leave holding entries the writer never emits.
         let buf = lockfile.buffers.string_bytes.as_slice();
         let deps_buf = lockfile.buffers.dependencies.as_slice();
         let resolution_buf = lockfile.buffers.resolutions.as_slice();
@@ -251,29 +228,19 @@ impl Stringifier {
                         if pkg_metas[i].integrity.tag.is_supported() {
                             continue;
                         }
-                        // No supported integrity: only v2-clean if the tarball
-                        // URL is under the *default* registry, the one case the
-                        // writer normalizes to `""` (see the npm URL
-                        // serialization in `save_from_binary_inner`). An empty
-                        // URL never sets the parser's `npm_url_needs_integrity`,
-                        // so that round-trips for any reader. A URL under a
-                        // configured-but-not-default scope is written verbatim,
-                        // and the parser's integrity check is evaluated against
-                        // the *reader's* scope config, so it is not
-                        // config-independent: a writer with a private `@scope`
-                        // registry could stamp v3 on a lockfile a teammate
-                        // without that scope then fails to parse. Stay at v1 for
-                        // those so the file keeps loading everywhere.
+                        // Only a default-registry URL is config-independent: the
+                        // writer serializes it as `""`, which never trips the
+                        // parser's `npm_url_needs_integrity`. A URL under one of
+                        // the writer's own scopes is written verbatim and a reader
+                        // without that scope would reject it.
                         let url = res.npm().url.slice(buf);
                         if !url_is_under_registry(url, Npm::Registry::DEFAULT_URL.as_bytes()) {
                             return Version::V1;
                         }
                     }
                     ResolutionTag::Git => {
-                        // An unsafe git `.bun-tag` is only rejected at v2+, so
-                        // staying at v1 keeps it loading. (A `github` tag is
-                        // rejected at every version, so no lockfile version can
-                        // round-trip an unsafe one — nothing to gate here.)
+                        // A `github` tag is rejected at every version, so there is
+                        // nothing to gate for it.
                         if !crate::repository::is_safe_resolved_tag(
                             res.repository().resolved.slice(buf),
                         ) {

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -114,6 +114,10 @@ pub enum Version {
     /// - a git `.bun-tag` must be a safe path/checkout component (the same
     ///   check on a `github` tag is enforced at every version, since its
     ///   download path has no checkout-time re-validation)
+    ///
+    /// Same content as v1. Only preserved on a lockfile that was loaded at v2;
+    /// a new lockfile is stamped v1 so Bun releases that predate v2 can read it
+    /// (see `Stringifier::version_to_write`).
     V2 = 2,
 
     /// `overrides` values may be objects holding scoped rules (parent-scoped or `name@range` targets); stamped while such rules exist and the package walk in `Stringifier::version_to_write` is v2-clean (object rows themselves parse at every version)
@@ -180,46 +184,43 @@ impl Stringifier {
         Self::save_from_binary_inner(lockfile, load_result, options, writer)
     }
 
-    /// Pick the `lockfileVersion` to stamp. A lockfile loaded from disk keeps
-    /// the version it already carried — re-saving never silently upgrades an
-    /// existing `bun.lock` to a newer format. `text_lockfile_version` holds the
-    /// parsed version when the lockfile was loaded from text, and defaults to
-    /// `Version::CURRENT` otherwise (a fresh install, or a migration from
-    /// another lockfile format), the "no version previously" case whose stamp
-    /// is decided by the walk below.
+    /// Pick the `lockfileVersion` to stamp. The stamp is the lowest version whose
+    /// readers understand the content being written, so a `bun.lock` keeps
+    /// loading in every Bun release that can read it:
     ///
-    /// The one version that is *not* preserved is v0: v0→v1 was a content-format
-    /// change (v1 stopped listing a workspace package's dependencies as a
-    /// trailing object), and the writer only ever emits the v1+ single-element
-    /// `["name@workspace:path"]` form. Stamping v0 on that output would make the
-    /// next parse fail ("Missing dependencies object"), so a v0 lockfile is
-    /// floored to v1 — the lowest version whose content matches what we write.
-    /// v1→v2, by contrast, only added parse-time strictness on identical
-    /// content, so v1 is preserved as-is.
+    /// - A lockfile loaded as v1 or v2 keeps its version. v1→v2 only added
+    ///   parse-time strictness on identical content, so neither is upgraded or
+    ///   downgraded on re-save.
+    /// - A lockfile with no prior version is stamped v1. `text_lockfile_version`
+    ///   holds the parsed version when the lockfile was loaded from text and is
+    ///   left at `Version::CURRENT` otherwise (a fresh install, or a migration
+    ///   from another lockfile format); both land in the v3 arm below. Stamping
+    ///   v2 there would lock out the releases that predate v2 without changing a
+    ///   byte of content.
+    /// - v0 is floored to v1: v0→v1 changed the content (v1 stopped listing a
+    ///   workspace package's dependencies as a trailing object) and the writer
+    ///   only emits the v1+ single-element `["name@workspace:path"]` form, which
+    ///   a v0 stamp would make the next parse reject ("Missing dependencies
+    ///   object").
+    /// - Scoped overrides (parent-scoped or `name@range` rules) are content an
+    ///   older reader would silently ignore, so while any exist the lockfile is
+    ///   stamped v3 whatever version was loaded; once they are gone a v3 lockfile
+    ///   drops back to v1 like a fresh one.
     ///
-    /// Scoped overrides (parent-scoped or `name@range` rules) are stamped v3, but
-    /// only after the same walk: a lockfile the walk holds at v1 stays v1 with the
-    /// override objects written as-is, since the parser reads those at every
-    /// version while its v2+ integrity check is evaluated against the *reader's*
-    /// registries — stamping 3 there would make the file config-dependent again.
-    /// A walk-clean lockfile with scoped rules is stamped v3 whatever version was
-    /// loaded. Without scoped rules a lockfile keeps its loaded v1/v2, and a fresh
-    /// or v3-loaded one is walked down to v2, or to v1 on a v2-invariant violation
-    /// (off-registry npm tarball without a supported integrity, unsafe git
-    /// `.bun-tag`); that decision must not depend on the writer's `~/.npmrc`.
-    ///
-    /// Walks the package tree the same way the writer does — only packages that
-    /// are actually serialized are considered, not every entry in the in-memory
-    /// `pkg_resolutions` buffer (migration can leave pruned/unreferenced entries
-    /// there that never reach the written `packages` object).
+    /// v3 implies the v2 parse checks, and the parser evaluates the integrity
+    /// check against the *reader's* registries, so before stamping v3 the package
+    /// tree is walked the same way the writer serializes it (only packages that
+    /// reach the written `packages` object count; migration can leave
+    /// unreferenced entries in `pkg_resolutions`). A row some reader could reject
+    /// at v2+ (an off-registry npm tarball without a supported integrity, an
+    /// unsafe git `.bun-tag`) holds the lockfile at v1 with the override objects
+    /// written as-is: the parser reads those at every version, so the file still
+    /// round-trips everywhere instead of depending on the writer's `~/.npmrc`.
     fn version_to_write(lockfile: &BinaryLockfile) -> Version {
-        let loaded = lockfile.text_lockfile_version;
-        let has_scoped = lockfile.overrides.has_scoped();
-        if !has_scoped && !loaded.at_least(Version::V3) {
-            return if loaded.at_least(Version::V1) {
-                loaded
-            } else {
-                Version::V1
+        if !lockfile.overrides.has_scoped() {
+            return match lockfile.text_lockfile_version {
+                loaded @ (Version::V1 | Version::V2) => loaded,
+                Version::V0 | Version::V3 => Version::V1,
             };
         }
 
@@ -260,7 +261,7 @@ impl Stringifier {
                         // and the parser's integrity check is evaluated against
                         // the *reader's* scope config, so it is not
                         // config-independent: a writer with a private `@scope`
-                        // registry could stamp v2 on a lockfile a teammate
+                        // registry could stamp v3 on a lockfile a teammate
                         // without that scope then fails to parse. Stay at v1 for
                         // those so the file keeps loading everywhere.
                         let url = res.npm().url.slice(buf);
@@ -269,7 +270,7 @@ impl Stringifier {
                         }
                     }
                     ResolutionTag::Git => {
-                        // An unsafe git `.bun-tag` is only rejected at v2, so
+                        // An unsafe git `.bun-tag` is only rejected at v2+, so
                         // staying at v1 keeps it loading. (A `github` tag is
                         // rejected at every version, so no lockfile version can
                         // round-trip an unsafe one — nothing to gate here.)
@@ -283,7 +284,7 @@ impl Stringifier {
                 }
             }
         }
-        if has_scoped { Version::V3 } else { Version::V2 }
+        Version::V3
     }
 
     fn save_from_binary_inner(

--- a/test/cli/install/__snapshots__/bun-install-registry.test.ts.snap
+++ b/test/cli/install/__snapshots__/bun-install-registry.test.ts.snap
@@ -10,7 +10,7 @@ exports[`auto-install symlinks (and junctions) are created correctly in the inst
 
 exports[`text lockfile workspace sorting 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -45,7 +45,7 @@ exports[`text lockfile workspace sorting 1`] = `
 
 exports[`text lockfile workspace sorting 2`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -88,7 +88,7 @@ exports[`text lockfile workspace sorting 2`] = `
 
 exports[`text lockfile --frozen-lockfile 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -120,7 +120,7 @@ exports[`text lockfile --frozen-lockfile 1`] = `
 
 exports[`binaries each type of binary serializes correctly to text lockfile 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -170,7 +170,7 @@ exports[`binaries root resolution bins 1`] = `
 
 exports[`hoisting text lockfile is hoisted 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -280,7 +280,7 @@ exports[`outdated NO_COLOR works 1`] = `
 
 exports[`it should ignore peerDependencies within workspaces 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {

--- a/test/cli/install/__snapshots__/bun-lock.test.ts.snap
+++ b/test/cli/install/__snapshots__/bun-lock.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`should write plaintext lockfiles 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -21,7 +21,7 @@ exports[`should write plaintext lockfiles 1`] = `
 
 exports[`should escape names 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -48,7 +48,7 @@ exports[`should escape names 1`] = `
 
 exports[`should be the default save format 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -67,7 +67,7 @@ exports[`should be the default save format 1`] = `
 
 exports[`should be the default save format 2`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -89,7 +89,7 @@ exports[`should be the default save format 2`] = `
 
 exports[`should save the lockfile if --save-text-lockfile and --frozen-lockfile are used 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -108,7 +108,7 @@ exports[`should save the lockfile if --save-text-lockfile and --frozen-lockfile 
 
 exports[`should save the lockfile if --save-text-lockfile and --frozen-lockfile are used 2`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -130,7 +130,7 @@ exports[`should save the lockfile if --save-text-lockfile and --frozen-lockfile 
 
 exports[`should convert a binary lockfile with invalid optional peers 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 0,
   "workspaces": {
     "": {
@@ -300,7 +300,7 @@ exports[`should not deduplicate bundled packages with un-bundled packages 2`] = 
 
 exports[`should not change formatting unexpectedly 2`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -400,7 +400,7 @@ exports[`should not change formatting unexpectedly 2`] = `
 
 exports[`should sort overrides before comparing 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -438,7 +438,7 @@ exports[`should sort overrides before comparing 1`] = `
 
 exports[`should include unused resolutions in the lockfile 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {

--- a/test/cli/install/__snapshots__/catalogs.test.ts.snap
+++ b/test/cli/install/__snapshots__/catalogs.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`basic detect changes (bun.lock) 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -37,7 +37,7 @@ exports[`basic detect changes (bun.lock) 1`] = `
 
 exports[`basic detect changes (bun.lock) 2`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -72,7 +72,7 @@ exports[`basic detect changes (bun.lock) 2`] = `
 
 exports[`basic detect changes (bun.lock) 3`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -9449,7 +9449,7 @@ describe.concurrent("bun-install", () => {
       expect(await exists(join(ctx.package_dir, "bun.lockb"))).toBeFalse();
       expect(await file(join(ctx.package_dir, "bun.lock")).text()).toMatchInlineSnapshot(`
       "{
-        "lockfileVersion": 2,
+        "lockfileVersion": 1,
         "configVersion": 1,
         "workspaces": {
           "": {
@@ -10251,7 +10251,7 @@ it("installs file: dependencies that depend on each other", async () => {
   using dir = tempDir("file-dep-cycle", fileDepCycleFixture);
   expect(await installFileDepCycle(String(dir))).toMatchInlineSnapshot(`
     "{
-      "lockfileVersion": 2,
+      "lockfileVersion": 1,
       "configVersion": 1,
       "workspaces": {
         "": {

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -2464,7 +2464,7 @@ test("matching workspace devDependency and npm peerDependency", async () => {
   expect((await file(join(packageDir, "bun.lock")).text()).replaceAll(/localhost:\d+/g, "localhost:1234"))
     .toMatchInlineSnapshot(`
     "{
-      "lockfileVersion": 2,
+      "lockfileVersion": 1,
       "configVersion": 1,
       "workspaces": {
         "": {

--- a/test/cli/install/config-version.test.ts
+++ b/test/cli/install/config-version.test.ts
@@ -55,7 +55,7 @@ describe.concurrent("configVersion", () => {
 
     expect(await file(join(packageDir, "bun.lock")).text()).toMatchInlineSnapshot(`
       "{
-        "lockfileVersion": 2,
+        "lockfileVersion": 1,
         "configVersion": 1,
         "workspaces": {
           "": {
@@ -108,7 +108,7 @@ describe.concurrent("configVersion", () => {
 
     expect(await file(join(packageDir, "bun.lock")).text()).toMatchInlineSnapshot(`
       "{
-        "lockfileVersion": 2,
+        "lockfileVersion": 1,
         "configVersion": 1,
         "workspaces": {
           "": {

--- a/test/cli/install/lockfile-version-2.test.ts
+++ b/test/cli/install/lockfile-version-2.test.ts
@@ -4,13 +4,18 @@ import { exists } from "fs/promises";
 import { bunExe, bunEnv as env, tempDir } from "harness";
 import { join } from "path";
 
-// These tests cover the text lockfile bump to version 2 and the parse-time
-// checks gated behind it. They run fully offline — using `file:` deps or
-// loopback/unreachable endpoints — so no external network or registry is
-// required.
+// These tests cover text lockfile version 2 (parse-time checks on v1's
+// content) and which version the writer stamps. They run fully offline — using
+// `file:` deps or loopback/unreachable endpoints — so no external network or
+// registry is required.
 
-it("a freshly written text lockfile defaults to version 2", async () => {
-  using dir = tempDir("lockfile-v2-default", {
+// v1 and v2 have identical content, and Bun releases before v2 existed reject
+// `lockfileVersion: 2` outright ("Unknown lockfile version"), so a lockfile
+// written from scratch is stamped v1: the first `bun install` of a project
+// must produce a file that a teammate or CI image on an older Bun can still
+// install from with `--frozen-lockfile`.
+it("a freshly written text lockfile is stamped version 1", async () => {
+  using dir = tempDir("lockfile-fresh-v1", {
     "package.json": JSON.stringify({ name: "root", dependencies: { dep: "file:./dep" } }),
     "dep/package.json": JSON.stringify({ name: "dep", version: "1.0.0" }),
   });
@@ -26,15 +31,53 @@ it("a freshly written text lockfile defaults to version 2", async () => {
 
   const lockfile = await file(join(String(dir), "bun.lock")).text();
   expect(err).not.toContain("error:");
-  expect(lockfile).toContain(`"lockfileVersion": 2,`);
+  expect(lockfile).toContain(`"lockfileVersion": 1,`);
+  expect(exitCode).toBe(0);
+});
+
+// An existing v2 lockfile is left alone: the writer neither upgrades nor
+// downgrades a version it loaded, it only avoids introducing v2 on new files.
+it("re-saving a v2 lockfile keeps it at version 2", async () => {
+  const v2Lockfile =
+    JSON.stringify(
+      {
+        lockfileVersion: 2,
+        configVersion: 1,
+        workspaces: { "": { name: "root", dependencies: { a: "file:./a" } } },
+        packages: { a: ["a@file:a", {}] },
+      },
+      null,
+      2,
+    ) + "\n";
+
+  using dir = tempDir("lockfile-v2-preserved", {
+    // package.json asks for a second `file:` dep the lockfile doesn't have yet,
+    // forcing a real re-save (not a no-op skip).
+    "package.json": JSON.stringify({ name: "root", dependencies: { a: "file:./a", b: "file:./b" } }),
+    "a/package.json": JSON.stringify({ name: "a", version: "1.0.0" }),
+    "b/package.json": JSON.stringify({ name: "b", version: "1.0.0" }),
+    "bun.lock": v2Lockfile,
+  });
+
+  await using proc = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: String(dir),
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const after = await file(join(String(dir), "bun.lock")).text();
+  expect(err).not.toContain("error:");
+  expect(after).toContain(`"b": ["b@file:b"`);
+  expect(after).toContain(`"lockfileVersion": 2,`);
   expect(exitCode).toBe(0);
 });
 
 // Re-saving an existing lockfile must never bump its version. A v1 `bun.lock`
 // that is rewritten — here because a new dependency is added — keeps
 // `lockfileVersion: 1`, even though every entry would satisfy the v2 invariants.
-// Only a lockfile with no prior version (fresh install / migration) is written
-// at the current version.
 it("re-saving a v1 lockfile keeps it at version 1 even after adding a dependency", async () => {
   const v1Lockfile =
     JSON.stringify(

--- a/test/cli/install/migration/__snapshots__/migrate.test.ts.snap
+++ b/test/cli/install/migration/__snapshots__/migrate.test.ts.snap
@@ -6,7 +6,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 0
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -1169,7 +1169,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 0
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -1192,7 +1192,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 0
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -2703,7 +2703,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 1
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -2730,7 +2730,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 0
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -2998,7 +2998,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 0
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -3023,7 +3023,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 0
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -3051,7 +3051,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 0
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -3078,7 +3078,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 0
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -3574,7 +3574,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 1
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -3621,7 +3621,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 0
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -3669,7 +3669,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 1
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -3710,7 +3710,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 1
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -3743,7 +3743,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 1
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -3768,7 +3768,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 0
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -3835,7 +3835,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 0
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -3867,7 +3867,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 0
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -3889,7 +3889,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 0
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -3913,7 +3913,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 0
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -3944,7 +3944,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 1
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -3967,7 +3967,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 1
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -3990,7 +3990,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 0
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -4013,7 +4013,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 1
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -4036,7 +4036,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 1
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -4061,7 +4061,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 0
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -4090,7 +4090,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 0
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -4118,7 +4118,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 0
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -4218,7 +4218,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 1
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {},
@@ -4259,7 +4259,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 0
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -4282,7 +4282,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 0
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -4313,7 +4313,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 0
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -4345,7 +4345,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 0
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -4409,7 +4409,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 0
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -4552,7 +4552,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 0
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -4574,7 +4574,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 1
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {},
@@ -4596,7 +4596,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 0
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -4641,7 +4641,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 0
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -4670,7 +4670,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 0
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -4704,7 +4704,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 0
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -4753,7 +4753,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 0
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -4786,7 +4786,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 0
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -4842,7 +4842,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 0
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -4875,7 +4875,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 0
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -4902,7 +4902,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 0
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -4933,7 +4933,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 0
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -4968,7 +4968,7 @@ bun pm migrate exit code: 0
 bun install --frozen-lockfile exit code: 0
 
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {

--- a/test/cli/install/migration/__snapshots__/pnpm-comprehensive.test.ts.snap
+++ b/test/cli/install/migration/__snapshots__/pnpm-comprehensive.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`pnpm comprehensive migration tests large single package with many dependencies: large-single-package 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -100,7 +100,7 @@ exports[`pnpm comprehensive migration tests large single package with many depen
 
 exports[`pnpm comprehensive migration tests complex monorepo with cross-dependencies: complex-monorepo 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -295,7 +295,7 @@ exports[`pnpm comprehensive migration tests pnpm with patches and overrides: pat
 
 exports[`pnpm comprehensive migration tests pnpm with peer dependencies and auto-install-peers: peer-deps-auto-install 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {

--- a/test/cli/install/migration/__snapshots__/pnpm-lock-migration.test.ts.snap
+++ b/test/cli/install/migration/__snapshots__/pnpm-lock-migration.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`pnpm-lock.yaml migration simple pnpm lockfile migration produces correct bun.lock: simple-pnpm-migration 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -24,7 +24,7 @@ exports[`pnpm-lock.yaml migration simple pnpm lockfile migration produces correc
 
 exports[`pnpm-lock.yaml migration pnpm workspace lockfile migration: workspace-pnpm-migration 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -86,7 +86,7 @@ exports[`pnpm-lock.yaml migration pnpm workspace lockfile migration: workspace-p
 
 exports[`pnpm-lock.yaml migration pnpm with npm protocol aliases: npm-aliases-pnpm-migration 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {

--- a/test/cli/install/migration/__snapshots__/pnpm-lock-v9.test.ts.snap
+++ b/test/cli/install/migration/__snapshots__/pnpm-lock-v9.test.ts.snap
@@ -29,7 +29,7 @@ exports[`pnpm-lock.yaml v9 v9 git and userinfo-tarball references migrate: bun.l
 
 exports[`pnpm-lock.yaml v9 snapshot alias whose dep-path version is a file: directory or tarball: bun.lock 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {

--- a/test/cli/install/migration/__snapshots__/pnpm-migration-complete.test.ts.snap
+++ b/test/cli/install/migration/__snapshots__/pnpm-migration-complete.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with all edge cases: basic-dependencies 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -33,7 +33,7 @@ exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with al
 
 exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with all edge cases: canary-versions 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -58,7 +58,7 @@ exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with al
 
 exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with all edge cases: monorepo-workspaces 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -112,7 +112,7 @@ exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with al
 
 exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with all edge cases: patches-overrides 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -137,7 +137,7 @@ exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with al
 
 exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with all edge cases: file-link-deps 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -159,7 +159,7 @@ exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with al
 
 exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with all edge cases: custom-registries 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -181,7 +181,7 @@ exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with al
 
 exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with all edge cases: peer-dependencies 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -210,7 +210,7 @@ exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with al
 
 exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with all edge cases: duplicate-packages 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -242,7 +242,7 @@ exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with al
 
 exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with all edge cases: catalogs 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -276,7 +276,7 @@ exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with al
 
 exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with all edge cases: integrity-hashes 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -298,7 +298,7 @@ exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with al
 
 exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with all edge cases: version-zero 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -317,7 +317,7 @@ exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with al
 
 exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with all edge cases: mixed-dependency-types 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -352,7 +352,7 @@ exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with al
 
 exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with all edge cases: circular-workspaces 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {

--- a/test/cli/install/migration/__snapshots__/pnpm-migration.test.ts.snap
+++ b/test/cli/install/migration/__snapshots__/pnpm-migration.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`basic: bun.lock 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {

--- a/test/cli/install/migration/__snapshots__/yarn-lock-migration.test.ts.snap
+++ b/test/cli/install/migration/__snapshots__/yarn-lock-migration.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`yarn.lock migration basic simple yarn.lock migration produces correct bun.lock: simple-yarn-migration 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -21,7 +21,7 @@ exports[`yarn.lock migration basic simple yarn.lock migration produces correct b
 
 exports[`yarn.lock migration basic complex yarn.lock with multiple dependencies and versions: complex-yarn-migration 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -169,7 +169,7 @@ exports[`yarn.lock migration basic complex yarn.lock with multiple dependencies 
 
 exports[`yarn.lock migration basic yarn.lock with npm aliases: aliases-yarn-migration 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -222,7 +222,7 @@ exports[`yarn.lock migration basic yarn.lock with resolutions: resolutions-yarn-
 
 exports[`yarn.lock migration basic yarn.lock with workspace dependencies: workspace-yarn-migration 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -241,7 +241,7 @@ exports[`yarn.lock migration basic yarn.lock with workspace dependencies: worksp
 
 exports[`yarn.lock migration basic yarn.lock with scoped packages and parent/child relationships: scoped-yarn-migration 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -269,7 +269,7 @@ exports[`yarn.lock migration basic yarn.lock with scoped packages and parent/chi
 
 exports[`yarn.lock migration basic migration with realistic complex yarn.lock: complex-realistic-yarn-migration 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -324,7 +324,7 @@ exports[`yarn.lock migration basic migration with realistic complex yarn.lock: c
 
 exports[`bun pm migrate for existing yarn.lock yarn-cli-repo: yarn-cli-repo 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -3069,7 +3069,7 @@ exports[`bun pm migrate for existing yarn.lock yarn-cli-repo: yarn-cli-repo 1`] 
 
 exports[`bun pm migrate for existing yarn.lock yarn-lock-mkdirp: yarn-lock-mkdirp 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -3087,7 +3087,7 @@ exports[`bun pm migrate for existing yarn.lock yarn-lock-mkdirp: yarn-lock-mkdir
 
 exports[`bun pm migrate for existing yarn.lock yarn-lock-mkdirp-file-dep: yarn-lock-mkdirp-file-dep 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -3105,7 +3105,7 @@ exports[`bun pm migrate for existing yarn.lock yarn-lock-mkdirp-file-dep: yarn-l
 
 exports[`bun pm migrate for existing yarn.lock yarn-lock-mkdirp-no-resolved: yarn-lock-mkdirp-no-resolved 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -3166,7 +3166,7 @@ exports[`bun pm migrate for existing yarn.lock yarn-stuff: yarn-stuff 1`] = `
 
 exports[`bun pm migrate for existing yarn.lock yarn-stuff/abbrev-link-target: yarn-stuff/abbrev-link-target 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -3180,7 +3180,7 @@ exports[`bun pm migrate for existing yarn.lock yarn-stuff/abbrev-link-target: ya
 
 exports[`bun pm migrate for existing yarn.lock yarn.lock with packages that have os/cpu requirements: os-cpu-yarn-migration 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {

--- a/test/cli/install/nested-overrides.test.ts
+++ b/test/cli/install/nested-overrides.test.ts
@@ -1126,7 +1126,7 @@ describe.concurrent("lockfile", () => {
     ]);
     await Promise.all([installOk(x), installOk(y), installOk(z)]);
     const xLock = await lock(x);
-    expect(xLock).toContain('"lockfileVersion": 2');
+    expect(xLock).toContain('"lockfileVersion": 1');
     expect(xLock).toContain('\n    "no-deps": "1.0.0",\n');
     expect(await lock(y)).toContain('"lockfileVersion": 3');
     expect(await lock(z)).toContain('"lockfileVersion": 3');
@@ -1144,10 +1144,10 @@ describe.concurrent("lockfile", () => {
     const dir = await project({ dependencies: walkFallbackDeps });
     await installOk(dir);
     const text = await lock(dir);
-    expect(text).toContain('"lockfileVersion": 2');
+    expect(text).toContain('"lockfileVersion": 1');
     expect(text).toContain('one-dep-1.0.0.tgz", ');
     const stripped = text
-      .replace('"lockfileVersion": 2', `"lockfileVersion": ${stampVersion}`)
+      .replace('"lockfileVersion": 1', `"lockfileVersion": ${stampVersion}`)
       .replace(/, "sha512-[^"]*"\]/g, ', ""]');
     expect(stripped).not.toContain("sha512-");
     await write(join(dir, "bun.lock"), stripped);
@@ -1286,7 +1286,7 @@ describe.concurrent("lockfile", () => {
     const after = await lock(dir);
     expect(after).not.toContain('"overrides"');
     expect(after).not.toContain("no-deps@2.0.0");
-    expect(after).toContain('"lockfileVersion": 2');
+    expect(after).toContain('"lockfileVersion": 1');
     await installOk(dir, "--frozen-lockfile");
   });
 


### PR DESCRIPTION
### Problem
- Every `bun.lock` that current main writes from scratch (`bun install` with no lockfile, `bun init -y`, first `bun add`, `rm bun.lock && bun install`, package-lock/yarn/pnpm migration, `bun.lockb` conversion) is stamped `"lockfileVersion": 2`.
- Bun 1.3.14 and earlier only know versions 0 and 1. On such a file, `bun install --frozen-lockfile` / `bun ci` on an older Bun exits 1 (`error: Unknown lockfile version`, `UnknownLockfileVersion: failed to parse lockfile: 'bun.lock'`), and a plain `bun install` prints `warn: Ignoring lockfile`, re-resolves from `package.json` and rewrites the file as v1, dropping the pins. One teammate creating a lockfile on 1.4 breaks every CI image and Docker base still on 1.3.
- v2 has byte-identical content to v1. It only turns on two parse-time rejections (`bun.lock.rs`, the `at_least(Version::V2)` checks: off-registry npm tarball without integrity, unsafe git `.bun-tag`), and since they are keyed on the digit in the file, a tampered lockfile bypasses them by saying `1`. Stamping 2 on new files costs the compatibility without buying enforcement.
- Cause: `Stringifier::version_to_write` in `src/install/lockfile/bun.lock.rs` walked a fresh lockfile (no prior version) down to v2 when it passed the v2 checks. Introduced by #31539; not in any 1.3 release. Every release since 1.2.0 has otherwise written lockfiles the previous release could read; existing v1 files are already preserved on re-save (#31602), so this only affects newly created lockfiles.

### Fix
- `version_to_write` stamps v1 on a lockfile that has no prior version. A lockfile loaded as v1 or v2 keeps its version (no upgrade, no downgrade); v0 is still floored to v1; scoped overrides still stamp v3 after the same package walk as before, and a v3 lockfile whose scoped rules were removed now drops to v1 instead of v2.
- The parser is untouched: a lockfile that already says 2 (written by a canary build, or by hand) still gets the v2 checks, and the "Unsupported lockfile version" message still reports 3 as the maximum.
- v3 is unaffected on purpose: nested / version-scoped overrides are content a 1.3 reader would silently ignore (it warns and drops them), so refusing the file there is the correct outcome, and `docs/pm/overrides.mdx` already documents it.
- Verified:
  - `test/cli/install/lockfile-version-2.test.ts`: "a freshly written text lockfile is stamped version 1" fails on a build without this change (writes 2) and passes with it; added "re-saving a v2 lockfile keeps it at version 2" to pin the preserve behavior. 13 pass.
  - `nested-overrides.test.ts`, `bun-lock.test.ts`, `catalogs.test.ts`, `bun-workspaces.test.ts`, `config-version.test.ts`, `migration/*.test.ts`: snapshots of freshly written lockfiles flipped from 2 to 1 (every flipped line is followed by `configVersion`, i.e. a written `bun.lock`; npm `package-lock.json` fixtures with their own `lockfileVersion: 2` are untouched). All pass with the debug build.
  - `bun-install.test.ts` and `bun-install-registry.test.ts`: the tests owning the flipped snapshots (`-t`) pass with the debug build.
- Docs: `docs/pm/lockfile.mdx` gets a short `lockfileVersion` section (new files are v1, existing versions are kept, scoped overrides need v3 / Bun 1.4); the `catalogs.mdx` example goes back to `1`.
- If this lands, the `lockfileVersion: 2` entries in #28792 and the upgrade guide in #36463 can be dropped, and #36464 (bunfig cap) becomes unnecessary for the 1.3 case.

### Background
- `bun.lock` starts with `"lockfileVersion": N`. The parser maps N to `Version` (`bun.lock.rs`) and rejects anything it does not know, so the digit is a hard compatibility gate for older readers; the content of v0 differs (workspace entries carried a trailing object), while v1, v2 and v3 share the same content.
- `Version::CURRENT` (3) is the newest version this build can read. A freshly created in-memory lockfile has `text_lockfile_version == CURRENT` because nothing was loaded, which is why the "no prior version" case and the "loaded v3" case share an arm in `version_to_write`.
- The package walk in `version_to_write` exists because the v2+ integrity check is evaluated against the reader's registry configuration: a row that some reader could reject is held at v1 so the file loads the same everywhere. With this change the walk only runs when a v3 stamp is being considered.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install.test.ts

<!-- robobun:evidence:end -->