### PR TITLE
Lower the public fields of a class whose private members get lowered by decorator lowering

### DIFF
--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -139,6 +139,28 @@ fn can_be_class_binding_name(name: &[u8]) -> bool {
         && !is_eval_or_arguments(name)
 }
 
+/// An undecorated public field (`x = 1`, `static [k];`, `1n;`, …), i.e. an
+/// element whose key can be passed to `__publicField` as-is (a literal, or a
+/// computed key once Phase 2 has hoisted it into a temporary). The visitor also
+/// synthesizes initializer-less fields keyed by an `E::Identifier` for TypeScript
+/// parameter properties; those have nothing to evaluate and stay in the body.
+#[inline]
+fn is_public_field(prop: &Property) -> bool {
+    let Some(key) = prop.key else {
+        return false;
+    };
+    prop.kind == PropertyKind::Normal
+        && !prop.flags.contains(Flags::Property::IsMethod)
+        && prop.value.is_none()
+        && (prop.flags.contains(Flags::Property::IsComputed)
+            || matches!(
+                key.data,
+                js_ast::ExprData::EString(_)
+                    | js_ast::ExprData::ENumber(_)
+                    | js_ast::ExprData::EBigInt(_)
+            ))
+}
+
 // ── impl P ───────────────────────────────────────────────────────────────────
 
 impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
@@ -272,17 +294,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         )
     }
 
-    /// Create a static block property from a single expression.
-    fn make_static_block(&mut self, expr: Expr, l: bun_ast::Loc) -> Property {
+    /// Create a static block property from a list of statements.
+    fn make_static_block(&mut self, stmts: &[Stmt], l: bun_ast::Loc) -> Property {
         let bump = self.arena;
-        let stmt = self.s(
-            S::SExpr {
-                value: expr,
-                ..Default::default()
-            },
-            l,
-        );
-        let stmts = bump.alloc_slice_copy(&[stmt]);
+        let stmts = bump.alloc_slice_copy(stmts);
         let stmts_list = bun_alloc::AstVec::<Stmt>::from_arena_slice(stmts);
         let sb = bump.alloc(G::ClassStaticBlock {
             loc: l,
@@ -293,6 +308,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             class_static_block: Some(js_ast::StoreRef::from_bump(sb)),
             ..Default::default()
         }
+    }
+
+    fn expr_stmt(&self, value: Expr, l: bun_ast::Loc) -> Stmt {
+        self.s(
+            S::SExpr {
+                value,
+                ..Default::default()
+            },
+            l,
+        )
     }
 
     /// Build property access: target.name or target[key].
@@ -344,15 +369,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         (((5 + 2 * idx) << 1) | 1) as f64
     }
 
-    /// Emit __privateAdd for a given storage ref.
+    /// Emit `__privateAdd(this, storage[, value])` into the instance list (spliced
+    /// into the constructor) or the static list (a static block at the top of the
+    /// class body); `this` is the instance or the class respectively.
     fn emit_private_add(
         &mut self,
         is_static: bool,
         storage_ref: Ref,
         value: Option<Expr>,
         loc: bun_ast::Loc,
-        constructor_inject: &mut BumpVec<'_, Stmt>,
-        static_blocks: &mut BumpVec<'_, Property>,
+        instance_out: &mut BumpVec<'_, Stmt>,
+        static_out: &mut BumpVec<'_, Stmt>,
     ) {
         let target = self.new_expr(E::This {}, loc);
         let storage = self.use_ref(storage_ref, loc);
@@ -361,16 +388,35 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         } else {
             self.call_rt(loc, b"__privateAdd", &[target, storage])
         };
+        let stmt = self.expr_stmt(call, loc);
         if is_static {
-            static_blocks.push(self.make_static_block(call, loc));
+            static_out.push(stmt);
         } else {
-            constructor_inject.push(self.s(
-                S::SExpr {
-                    value: call,
-                    ..Default::default()
-                },
-                loc,
-            ));
+            instance_out.push(stmt);
+        }
+    }
+
+    /// Emit `__publicField(this, key[, initializer])` for an undecorated field
+    /// that leaves the class body; same placement rules as `emit_private_add`.
+    fn emit_public_field(
+        &mut self,
+        prop: &Property,
+        loc: bun_ast::Loc,
+        instance_out: &mut BumpVec<'_, Stmt>,
+        static_out: &mut BumpVec<'_, Stmt>,
+    ) {
+        let target = self.new_expr(E::This {}, loc);
+        let key = prop.key.expect("infallible: public field has a key");
+        let call = if let Some(init) = prop.initializer {
+            self.call_rt(loc, b"__publicField", &[target, key, init])
+        } else {
+            self.call_rt(loc, b"__publicField", &[target, key])
+        };
+        let stmt = self.expr_stmt(call, loc);
+        if prop.flags.contains(Flags::Property::IsStatic) {
+            static_out.push(stmt);
+        } else {
+            instance_out.push(stmt);
         }
     }
 
@@ -1197,6 +1243,30 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
 
+        // With a private and a decorated member, every private member is lowered
+        // to WeakMap/WeakSet storage and its initializer moves into the
+        // constructor / a static block. The public fields move along: a field left
+        // in the body would initialize before all of them, i.e. out of source
+        // order and before the storage its rewritten initializer reads exists.
+        let lower_all_private = {
+            let mut has_any_private = false;
+            let mut has_any_decorated = false;
+            for cprop in class.properties.slice().iter() {
+                if cprop.kind == PropertyKind::ClassStaticBlock {
+                    continue;
+                }
+                has_any_private |= matches!(
+                    cprop.key,
+                    Some(key) if matches!(key.data, js_ast::ExprData::EPrivateIdentifier(_))
+                );
+                has_any_decorated |= cprop.ts_decorators.len_u32() > 0;
+                if has_any_private && has_any_decorated {
+                    break;
+                }
+            }
+            has_any_private && has_any_decorated
+        };
+
         // ── Phase 2: Pre-evaluate decorators/keys ────────
         let mut dec_counter: usize = 0;
         let mut class_dec_ref: Option<Ref> = None;
@@ -1266,9 +1336,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 );
                 pre_eval_stmts.push(p.var_decl(dec_ref, Some(arr), loc));
             }
-            if prop.flags.contains(Flags::Property::IsComputed)
-                && prop.key.is_some()
-                && prop.ts_decorators.len_u32() > 0
+            // Elements that leave the class body must have their computed key
+            // evaluated here, once, at class definition time.
+            let leaves_body =
+                prop.ts_decorators.len_u32() > 0 || (lower_all_private && is_public_field(prop));
+            if prop.flags.contains(Flags::Property::IsComputed) && prop.key.is_some() && leaves_body
             {
                 computed_key_counter += 1;
                 let key_name: &'a [u8] = if computed_key_counter == 1 {
@@ -1372,7 +1444,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         // ── Phase 4: Property loop ───────────────────────
         let mut suffix_exprs = BumpVec::<Expr>::new_in(bump);
-        let mut constructor_inject_stmts = BumpVec::<Stmt>::new_in(bump);
         let mut new_properties = BumpVec::<Property>::new_in(bump);
         let mut static_non_field_elements = BumpVec::<Expr>::new_in(bump);
         let mut instance_non_field_elements = BumpVec::<Expr>::new_in(bump);
@@ -1391,43 +1462,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let mut private_lowered_map: PrivateLoweredMap = PrivateLoweredMap::default();
         let mut accessor_storage_counter: usize = 0;
         let mut emitted_private_adds: HashMap<u32, ()> = HashMap::default();
-        let mut static_private_add_blocks = BumpVec::<Property>::new_in(bump);
-
-        // Pre-scan: determine if all private members need lowering
-        let mut lower_all_private = false;
-        {
-            let mut has_any_private = false;
-            let mut has_any_decorated = false;
-            let cprops: &[Property] = class.properties.slice();
-            for cprop in cprops.iter() {
-                if cprop.kind == PropertyKind::ClassStaticBlock {
-                    continue;
-                }
-                if cprop.ts_decorators.len_u32() > 0 {
-                    has_any_decorated = true;
-                    if cprop.key.is_some()
-                        && matches!(
-                            cprop.key.unwrap().data,
-                            js_ast::ExprData::EPrivateIdentifier(_)
-                        )
-                    {
-                        lower_all_private = true;
-                        break;
-                    }
-                }
-                if cprop.key.is_some()
-                    && matches!(
-                        cprop.key.unwrap().data,
-                        js_ast::ExprData::EPrivateIdentifier(_)
-                    )
-                {
-                    has_any_private = true;
-                }
-            }
-            if !lower_all_private && has_any_private && has_any_decorated {
-                lower_all_private = true;
-            }
-        }
+        // Method `__privateAdd`s run before the field initializers, which stay in
+        // source order. Instance lists are spliced into the constructor in Phase 7,
+        // static lists become a static block.
+        let mut instance_private_method_adds = BumpVec::<Stmt>::new_in(bump);
+        let mut static_private_method_adds = BumpVec::<Stmt>::new_in(bump);
+        let mut instance_field_inits = BumpVec::<Stmt>::new_in(bump);
+        let mut static_field_inits = BumpVec::<Stmt>::new_in(bump);
 
         let props_slice2: &mut [Property] = class.properties.slice_mut();
         for (prop_idx, prop) in props_slice2.iter_mut().enumerate() {
@@ -1506,8 +1547,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 ws_ref,
                                 None,
                                 loc,
-                                &mut constructor_inject_stmts,
-                                &mut static_private_add_blocks,
+                                &mut instance_private_method_adds,
+                                &mut static_private_method_adds,
                             );
                         }
                         continue;
@@ -1522,20 +1563,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         let init_val = prop
                             .initializer
                             .unwrap_or_else(|| p.new_expr(E::Undefined {}, loc));
-                        let this_e = p.new_expr(E::This {}, loc);
-                        let wm_e = p.use_ref(wm_ref, loc);
-                        let call = p.call_rt(loc, b"__privateAdd", &[this_e, wm_e, init_val]);
-                        if !prop.flags.contains(Flags::Property::IsStatic) {
-                            constructor_inject_stmts.push(p.s(
-                                S::SExpr {
-                                    value: call,
-                                    ..Default::default()
-                                },
-                                loc,
-                            ));
-                        } else {
-                            static_private_add_blocks.push(p.make_static_block(call, loc));
-                        }
+                        p.emit_private_add(
+                            prop.flags.contains(Flags::Property::IsStatic),
+                            wm_ref,
+                            Some(init_val),
+                            loc,
+                            &mut instance_field_inits,
+                            &mut static_field_inits,
+                        );
                         continue;
                     }
                 }
@@ -1628,18 +1663,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     let init_val = prop
                         .initializer
                         .unwrap_or_else(|| p.new_expr(E::Undefined {}, loc));
-                    if !prop.flags.contains(Flags::Property::IsStatic) {
-                        let this_e3 = p.new_expr(E::This {}, loc);
-                        let wm_e3 = p.use_ref(wm_ref, loc);
-                        let call = p.call_rt(loc, b"__privateAdd", &[this_e3, wm_e3, init_val]);
-                        constructor_inject_stmts.push(p.s(
-                            S::SExpr {
-                                value: call,
-                                ..Default::default()
-                            },
-                            loc,
-                        ));
-                    } else {
+                    let is_static = prop.flags.contains(Flags::Property::IsStatic);
+                    if is_static && !lower_all_private {
+                        // The public static fields stay in the body, so there is no
+                        // ordered static sequence to join; initialize after the class.
                         let cn_e = p.use_ref(class_name_ref, class_name_loc);
                         let wm_e3 = p.use_ref(wm_ref, loc);
                         suffix_exprs.push(p.call_rt(
@@ -1647,6 +1674,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             b"__privateAdd",
                             &[cn_e, wm_e3, init_val],
                         ));
+                    } else {
+                        p.emit_private_add(
+                            is_static,
+                            wm_ref,
+                            Some(init_val),
+                            loc,
+                            &mut instance_field_inits,
+                            &mut static_field_inits,
+                        );
                     }
                     continue;
                 }
@@ -1659,6 +1695,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         });
                         extracted_static_blocks.push(sb);
                     }
+                    continue;
+                }
+                if lower_all_private && is_public_field(prop) {
+                    p.emit_public_field(
+                        prop,
+                        loc,
+                        &mut instance_field_inits,
+                        &mut static_field_inits,
+                    );
                     continue;
                 }
                 new_properties.push(prop_full_copy(prop));
@@ -1950,8 +1995,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         private_storage_ref.unwrap(),
                         None,
                         loc,
-                        &mut constructor_inject_stmts,
-                        &mut static_private_add_blocks,
+                        &mut instance_private_method_adds,
+                        &mut static_private_method_adds,
                     );
                 }
                 if prop.flags.contains(Flags::Property::IsStatic) {
@@ -1974,7 +2019,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         // ── Phase 5: Rewrite private accesses ────────────
         if !private_lowered_map.is_empty() {
+            // Only `lower_all_private` classes get here, so every field initializer
+            // is in `*_field_inits` or `*_init_entries`, none in the body or suffix.
+            debug_assert!(lower_all_private);
+            debug_assert!(suffix_exprs.is_empty());
             for nprop in new_properties.iter_mut() {
+                debug_assert!(nprop.initializer.is_none());
                 if let Some(v) = &mut nprop.value {
                     p.rewrite_private_accesses_in_expr(v, &private_lowered_map);
                 }
@@ -1982,6 +2032,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     p.rewrite_private_accesses_in_stmts(sb.stmts.slice_mut(), &private_lowered_map);
                 }
             }
+            p.rewrite_private_accesses_in_stmts(&mut instance_field_inits, &private_lowered_map);
+            p.rewrite_private_accesses_in_stmts(&mut static_field_inits, &private_lowered_map);
             for entry in instance_init_entries.iter_mut() {
                 if let Some(ini) = &mut entry.prop.initializer {
                     p.rewrite_private_accesses_in_expr(ini, &private_lowered_map);
@@ -2217,21 +2269,19 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
 
         // ── Phase 7: Constructor injection ───────────────
+        // Private methods are installed first, then the extra initializers added
+        // by method/accessor decorators run, then the fields initialize in order.
+        let mut constructor_inject_stmts = instance_private_method_adds;
         if !instance_non_field_elements.is_empty() || has_instance_private_methods {
             let i_e = p.use_ref(init_ref, loc);
             let n_e = p.new_expr(E::Number::new(5.0), loc);
             let t_e = p.new_expr(E::This {}, loc);
             let call = p.call_rt(loc, b"__runInitializers", &[i_e, n_e, t_e]);
-            constructor_inject_stmts.push(p.s(
-                S::SExpr {
-                    value: call,
-                    ..Default::default()
-                },
-                loc,
-            ));
+            constructor_inject_stmts.push(p.expr_stmt(call, loc));
         }
+        constructor_inject_stmts.extend_from_slice(&instance_field_inits);
 
-        // Instance field/accessor init + extra-init
+        // Decorated instance field/accessor init + extra-init
         {
             let mut i_accessor_idx: usize = 0;
             let mut i_field_idx: usize = 0;
@@ -2407,19 +2457,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
 
-        // Static private __privateAdd blocks at beginning
-        if !static_private_add_blocks.is_empty() {
-            let mut merged = BumpVec::<Property>::with_capacity_in(
-                static_private_add_blocks.len() + new_properties.len(),
-                bump,
-            );
-            for sp in static_private_add_blocks.drain(..) {
-                merged.push(sp);
-            }
-            for np in new_properties.drain(..) {
-                merged.push(np);
-            }
-            new_properties = merged;
+        // Same order as the constructor, as a single static block.
+        let mut static_inits = static_private_method_adds;
+        static_inits.extend_from_slice(&static_field_inits);
+        if !static_inits.is_empty() {
+            let block = p.make_static_block(&static_inits, loc);
+            new_properties.insert(0, block);
         }
 
         class.properties = bun_ast::StoreSlice::new_mut(new_properties.into_bump_slice_mut());

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -31,6 +31,21 @@ async function runDecorator(code: string) {
   return { stdout, stderr: filterStderr(rawStderr), exitCode };
 }
 
+async function runDecoratorTS(code: string) {
+  using dir = tempDir("es-dec-ts", {
+    "tsconfig.json": JSON.stringify({ compilerOptions: {} }),
+    "test.ts": code,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr: filterStderr(rawStderr), exitCode };
+}
+
 describe("ES Decorators", () => {
   describe("class decorators", () => {
     test("basic class decorator", async () => {
@@ -390,21 +405,6 @@ describe("ES Decorators", () => {
       expect(stdout).toBe("hello bar\ndone\n");
       expect(exitCode).toBe(0);
     });
-
-    async function runDecoratorTS(code: string) {
-      using dir = tempDir("es-dec-ts", {
-        "tsconfig.json": JSON.stringify({ compilerOptions: {} }),
-        "test.ts": code,
-      });
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "test.ts"],
-        env: bunEnv,
-        cwd: String(dir),
-        stderr: "pipe",
-      });
-      const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      return { stdout, stderr: filterStderr(rawStderr), exitCode };
-    }
 
     test("non-null assertion in decorator member expression", async () => {
       const { stdout, stderr, exitCode } = await runDecoratorTS(`
@@ -1151,6 +1151,309 @@ describe("ES Decorators", () => {
       expect(stderr).toBe("");
       expect(stdout).toBe("i0 b 1 1\n");
       expect(exitCode).toBe(0);
+    });
+  });
+
+  // A class with a private member and a decorated member has all of its private
+  // members lowered to WeakMap/WeakSet storage, so their initializers move into
+  // the constructor (or a static block). The undecorated public fields have to
+  // move with them: their initializers must be rewritten too (`this.#p` no
+  // longer exists), and they must keep initializing in source order relative to
+  // the private fields. Expected outputs were checked against esbuild's lowering.
+  describe("fields in classes with lowered private members", () => {
+    test("public field initializers can read lowered private fields", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(v, ctx) {}
+        class C {
+          #p = 1;
+          @dec m() {}
+          x = this.#p + 1;
+          static #sp = 5;
+          static sx = C.#sp + 1;
+        }
+        console.log(new C().x, C.sx);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("2 6\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("private field initializers can read other lowered private fields", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(v, ctx) { return v; }
+        class Broken {
+          @dec accessor label = "";
+          #name = "hello";
+          #callback = () => this.#name;
+          #read = function () { return this.#name + "!"; };
+          run() { return this.#callback() + " " + this.#read(); }
+        }
+        console.log(new Broken().run());
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("hello hello!\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("static private fields and undecorated accessors can read lowered private fields", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(v, ctx) {}
+        class S {
+          static #a = 1;
+          static #b = S.#a + 1;
+          static accessor acc = S.#b + 1;
+          static sum = S.#a + S.#b + S.acc;
+          @dec m() {}
+        }
+        class I {
+          #a = 1;
+          accessor acc = this.#a + 1;
+          sum = this.#a + this.acc;
+          @dec m() {}
+        }
+        console.log(S.sum, new I().sum);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("6 3\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("instance fields initialize in source order with computed keys evaluated once", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        const log = [];
+        function dec(v, ctx) {}
+        const sym = Symbol("sym");
+        let keys = 0;
+        class C {
+          a = log.push("a");
+          #p = log.push("#p");
+          b;
+          accessor c = log.push("c");
+          [(keys++, "d")] = log.push("d");
+          [sym] = log.push("sym");
+          1 = log.push("1");
+          "e-f" = log.push("e-f");
+          @dec m() {}
+          g = this.#p;
+        }
+        new C();
+        const c = new C();
+        console.log(log.join(","));
+        console.log(Object.keys(c).join(","), keys);
+        console.log(c.b, c.c, c.d, c[sym], c[1], c["e-f"], c.g);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout.split("\n")).toEqual([
+        "a,#p,c,d,sym,1,e-f,a,#p,c,d,sym,1,e-f",
+        "1,a,b,d,e-f,g 1",
+        "undefined 10 11 12 13 14 9",
+        "",
+      ]);
+      expect(exitCode).toBe(0);
+    });
+
+    test("static fields initialize in source order", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        const log = [];
+        function dec(v, ctx) {}
+        const sym = Symbol("sym");
+        class C {
+          static a = log.push("a");
+          static #p = log.push("#p");
+          static b;
+          static accessor c = log.push("c");
+          static [("d")] = log.push("d");
+          static [sym] = log.push("sym");
+          static g = C.#p;
+          @dec m() {}
+          static h = log.push("h");
+        }
+        console.log(log.join(","));
+        console.log(Object.keys(C).join(","));
+        console.log(C.b, C.c, C.d, C[sym], C.g, C.h);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout.split("\n")).toEqual(["a,#p,c,d,sym,h", "a,b,d,g,h", "undefined 3 4 5 2 6", ""]);
+      expect(exitCode).toBe(0);
+    });
+
+    test("private field initializers see public fields declared before them", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(v, ctx) {}
+        class O {
+          static pub = 3;
+          static #spriv = O.pub * 2;
+          static get spriv() { return O.#spriv; }
+          pub = 5;
+          #ipriv = this.pub * 2;
+          get ipriv() { return this.#ipriv; }
+          @dec m() {}
+        }
+        console.log(O.spriv, new O().ipriv);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("6 10\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("private methods are installed before any field initializer runs", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(v, ctx) {}
+        class C {
+          x = this.#m();
+          #p = this.#m() + 1;
+          static sx = C.#sm();
+          static #sp = C.#sm() + 1;
+          @dec n() {}
+          #m() { return 10; }
+          static #sm() { return 20; }
+          get p() { return this.#p; }
+          static get sp() { return C.#sp; }
+        }
+        const c = new C();
+        console.log(c.x, c.p, C.sx, C.sp);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("10 11 20 21\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("method extra initializers run before field initializers", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function tag(v, ctx) {
+          ctx.addInitializer(function () { this.tagged = ctx.name; });
+        }
+        class C {
+          seen = this.tagged;
+          @tag #m() {}
+        }
+        console.log(new C().seen);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("#m\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("moved public fields keep [[Define]] semantics", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(v, ctx) {}
+        class Base {
+          set x(v) { throw new Error("setter invoked with " + v); }
+          get x() { return "getter"; }
+          static set s(v) { throw new Error("static setter invoked with " + v); }
+          static get s() { return "static getter"; }
+        }
+        class C extends Base {
+          #p = 1;
+          x = 1;
+          static s = 2;
+          @dec m() {}
+        }
+        const c = new C();
+        console.log(c.x, Object.hasOwn(c, "x"), C.s, Object.hasOwn(C, "s"));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("1 true 2 true\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("class expressions and `this` in static initializers", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(v, ctx) {}
+        const C = class {
+          #p = 1;
+          x = this.#p + 1;
+          static #sp = 2;
+          static sx = this.#sp + 1;
+          @dec m() {}
+        };
+        console.log(new C().x, C.sx);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("2 3\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("derived classes initialize moved fields right after super()", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(v, ctx) {}
+        const log = [];
+        class Base { constructor() { log.push("base"); } }
+        class A extends Base {
+          #p = log.push("#p");
+          x = log.push("x");
+          @dec m() {}
+        }
+        class B extends Base {
+          #p = log.push("#p");
+          x = this.#p;
+          constructor() {
+            log.push("before-super");
+            super();
+            log.push("x=" + this.x);
+          }
+          @dec m() {}
+        }
+        new A();
+        new B();
+        console.log(log.join(","));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("base,#p,x,before-super,base,#p,x=6\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("private method calls in moved initializers evaluate their receiver once", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(v, ctx) {}
+        let calls = 0;
+        function obj(o) { calls++; return o; }
+        class C {
+          #m() { return this.v; }
+          static #sm() { return this.sv; }
+          v = 1;
+          static sv = 2;
+          x = obj(this).#m();
+          static sx = obj(C).#sm();
+          @dec n() {}
+        }
+        console.log(new C().x, C.sx, calls);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("1 2 2\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("TypeScript parameter properties stay ahead of the moved fields", async () => {
+      const { stdout, stderr, exitCode } = await runDecoratorTS(`
+        function dec(v: any, ctx: any) {}
+        class A {
+          #p = 1;
+          x = this.#p;
+          constructor(public a: number) {}
+          @dec m() {}
+        }
+        const a = new A(5);
+        console.log(a.a, a.x, Object.keys(a).join(","));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("5 1 a,x\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("no private name survives in the output", () => {
+      const source = `class C {
+        #p = 1;
+        static #sp = 2;
+        @dec m() {}
+        x = this.#p;
+        static sx = C.#sp;
+        static accessor acc = C.#sp;
+      }`;
+      const output = new Bun.Transpiler({ loader: "js", target: "bun" }).transformSync(source);
+      expect(output).not.toContain("#p");
+      expect(output).not.toContain("#sp");
+      expect(() => new Bun.Transpiler({ loader: "js" }).transformSync(output)).not.toThrow();
     });
   });
 


### PR DESCRIPTION
Closes #28118

### Problem

- With standard (TC39) decorators, a class that has a private member and a decorated member fails to load as soon as a field initializer mentions a private name:
  ```ts
  function dec(v, c) {}
  class C {
    #p = 1;
    @dec m() {}
    x = this.#p + 1;
    static #sp = 5;
    static sx = C.#sp + 1;
  }
  console.log(new C().x, C.sx);   // tsc / esbuild: 2 6
  ```
  bun 1.4.0: `SyntaxError: Cannot reference undeclared private names: "#sp"` (`"#p"` without the static pair). Same failure for the shapes in #28118, where the initializer that mentions the private name is itself a private field (`#callback = () => this.#name`, `static #m = ...` used from a field).
- Cause: `lower_impl` in `src/js_parser/lower/lower_decorators.rs` lowers every private member of such a class (`lower_all_private`) to WeakMap/WeakSet storage, so the `#name` declarations disappear from the class body, but
  - undecorated public fields stayed in the body with their initializers as written (Phase 4 pushed them to `new_properties`, Phase 5 rewrote `value`, which fields do not use), and
  - the `__privateAdd(this, _p, <initializer>)` calls Phase 4 built for private fields and undecorated accessors (`constructor_inject_stmts`, `static_private_add_blocks`, `suffix_exprs`) were not passed through the Phase 5 rewrite at all.
- Rewriting the in-body initializers alone (what #28120 and #31405 did) is not enough: a field left in the body initializes before the constructor body runs, so `x = __privateGet(this, _p)` would throw a TypeError because `__privateAdd(this, _p, 1)` has not happened yet. Ordering is already observable today without any `#name` in an initializer: `static pub = 3; static #priv = O.pub * 2` gives `NaN`, because the private adds run from a static block at the top of the body, before the public statics.

### Fix

- When `lower_all_private` is set, undecorated public fields leave the body too, as `__publicField(this, key[, init])` statements emitted in source order into the same lists as the private field adds (`instance_field_inits` / `static_field_inits`); undecorated static accessors join the static list instead of the suffix in this case. Initializer-less fields still get defined (`__publicField(this, "y")`), so own-property order is kept. Computed keys of these fields are pre-evaluated once in Phase 2 exactly like decorated members' keys, so they are not re-evaluated per construction. The initializer-less fields the visitor synthesizes for TypeScript parameter properties (identifier key) are left in the body, where they already come first, matching tsc's order.
- Private method `__privateAdd`s are collected separately and emitted first (`*_private_method_adds`), so a field may call a private method declared later in the class, as it can natively. Assembly order per side is: method adds, `__runInitializers(_init, 5, this)` (method extra initializers, which the spec runs before fields), undecorated fields in source order, then the decorated fields Phase 7 already appended. Statics become one static block at the top of the body instead of one block per private member.
- Phase 5 runs the private access rewrite over the two field lists. With every field gone from the body this is the complete set (`debug_assert`s pin that no `initializer` is left in `new_properties` and that Phase 4 put nothing in `suffix_exprs`), and each initializer is rewritten exactly once.
- Why this is right: it is esbuild's rule for lowering private fields ("when any field of a kind is lowered, lower all of them, or evaluation order changes"), and the emitted shape matches esbuild's for the same input: `__runInitializers(_init, 5, this); __privateAdd(this, _p, 1); __publicField(this, "x", __privateGet(this, _p) + 1)`. `__publicField` keeps the [[Define]] semantics the fields had as native fields (an inherited setter is not invoked), and `this` is still the instance / class in the constructor / static block, so initializers need no other rewriting. Classes without `lower_all_private` are untouched; in classes with it, fields that did not mention a private name were already being constructed through the injected constructor, so the only behavior change for them is the order fix. The gating is disjoint from #38731, which relocates the statics of class-decorated classes without private members.
- Verification:
  - `test/bundler/transpiler/es-decorators.test.ts`, new block `fields in classes with lowered private members` (14 tests): the repro, the #28118 shapes, static private fields and accessors, instance and static initialization order with computed / symbol / numeric / quoted keys, private-before-public dependencies, private methods declared after their use, method extra initializers before fields, [[Define]] semantics, class expressions with `this` in static initializers, derived classes with and without an explicit `super()` call, receiver capture temps in moved initializers, TypeScript parameter properties, and a reparse check that no `#name` survives in the output. Every expected output was produced by running esbuild's lowering of the same source; 13 fail on bun 1.4.0 (the [[Define]] one is a guard for the `__publicField` choice), all pass with this build. `runDecoratorTS` was hoisted to module scope so the parameter-property test can use it.
  - `es-decorators-esbuild.test.ts` (esbuild's 147 conformance tests), `es-decorators.test.ts`, `decorators.test.ts`, `decorator-metadata.test.ts`, `bundler_decorator_metadata.test.ts`, `regression/issue/27575.test.ts`, `regression/issue/27526.test.ts`, `transpiler.test.js`, `esbuild/ts.test.ts`, `esbuild/lower.test.ts`, `esbuild/default.test.ts`, `esbuild/dce.test.ts`: all pass with the debug build. `cargo clippy -p bun_js_parser` and `cargo fmt --check` clean.
- Not changed (pre-existing, independent of private lowering): decorated fields still initialize after all undecorated ones rather than interleaved, static blocks and decorated static fields still run after the class, and classes that are not `lower_all_private` keep their fields in the body.

### Background

- Standard decorator lowering (`lower_decorators.rs`) prints the class mostly as written and appends `__decorateElement(...)` calls after it. Private members cannot be decorated that way, so a class with private and decorated members has all private members lowered the way esbuild lowers them for old targets: a `var _p = new WeakMap` per field (a `WeakSet` per method), `__privateAdd(this, _p, init)` where the field used to be initialized, and every `obj.#p` read / write rewritten to `__privateGet` / `__privateSet` (Phase 5 of `lower_impl`, `rewrite_private_accesses_in_*`).
- Native instance fields are initialized by the engine before the constructor body runs (right after `super()` returns in a derived class); static fields and static blocks run in source order while the class is being defined. Anything the lowering moves into the constructor therefore runs after every field that stays in the body, which is why the body cannot keep some fields once others have been moved.
- `__publicField(obj, key, value)` (already in `src/runtime.js`, also used by #35537 and #38731) defines an own data property with the same semantics as a class field declaration; `obj.key = value` would instead invoke an inherited setter.
