### PR TITLE
pack: fill every placeholder in multi-argument error messages

### DIFF
--- a/src/bun_core/output.rs
+++ b/src/bun_core/output.rs
@@ -1876,8 +1876,8 @@ impl_fmt_tuple!(0 A, 1 B, 2 C, 3 D, 4 E, 5 F, 6 G);
 impl_fmt_tuple!(0 A, 1 B, 2 C, 3 D, 4 E, 5 F, 6 G, 7 H);
 
 /// Substitute `{}` / `{s}` / `{d}` / `{any}` / `{f}` placeholders in `template`
-/// with successive entries from `args`; the spec inside the braces is ignored.
-/// `{{` / `}}` are emitted as literal braces.
+/// with successive entries from `args`. `{{` / `}}` are emitted as literal
+/// braces. The spec inside any other `{...}` is ignored.
 fn substitute_template(
     template: &[u8],
     args: &impl FmtTuple,

--- a/src/bun_core/output.rs
+++ b/src/bun_core/output.rs
@@ -1797,7 +1797,7 @@ impl fmt::Display for PrettyBuf {
 /// Positional-argument bundle for runtime template substitution.
 pub trait FmtTuple {
     /// Write the `idx`-th positional into `f`. Returns `false` if `idx` is out
-    /// of range (caller emits the literal `{}` then).
+    /// of range.
     fn write_nth(&self, idx: usize, f: &mut dyn fmt::Write) -> Result<bool, fmt::Error>;
     fn len(&self) -> usize;
 }
@@ -1877,7 +1877,10 @@ impl_fmt_tuple!(0 A, 1 B, 2 C, 3 D, 4 E, 5 F, 6 G, 7 H);
 
 /// Substitute `{}` / `{s}` / `{d}` / `{any}` / `{f}` placeholders in `template`
 /// with successive entries from `args`. `{{` / `}}` are emitted as literal
-/// braces. Unrecognised specs are passed through verbatim.
+/// braces. Every other `{...}` consumes an entry, whatever the spec says; a
+/// placeholder with no entry left renders as nothing (and fails a debug
+/// assertion, since it means the call site packed several values into one
+/// `format_args!` instead of passing a tuple).
 fn substitute_template(
     template: &[u8],
     args: &impl FmtTuple,
@@ -1901,7 +1904,14 @@ fn substitute_template(
             }
             if j < t.len() {
                 // consume placeholder
-                if args.write_nth(argi, f)? {
+                let filled = args.write_nth(argi, f)?;
+                debug_assert!(
+                    filled,
+                    "template has more placeholders than the {} arg(s) passed for it: {:?}",
+                    args.len(),
+                    bstr::BStr::new(t),
+                );
+                if filled {
                     argi += 1;
                 }
                 i = j + 1;

--- a/src/bun_core/output.rs
+++ b/src/bun_core/output.rs
@@ -1876,11 +1876,8 @@ impl_fmt_tuple!(0 A, 1 B, 2 C, 3 D, 4 E, 5 F, 6 G);
 impl_fmt_tuple!(0 A, 1 B, 2 C, 3 D, 4 E, 5 F, 6 G, 7 H);
 
 /// Substitute `{}` / `{s}` / `{d}` / `{any}` / `{f}` placeholders in `template`
-/// with successive entries from `args`. `{{` / `}}` are emitted as literal
-/// braces. Every other `{...}` consumes an entry, whatever the spec says; a
-/// placeholder with no entry left renders as nothing (and fails a debug
-/// assertion, since it means the call site packed several values into one
-/// `format_args!` instead of passing a tuple).
+/// with successive entries from `args`; the spec inside the braces is ignored.
+/// `{{` / `}}` are emitted as literal braces.
 fn substitute_template(
     template: &[u8],
     args: &impl FmtTuple,
@@ -1907,7 +1904,7 @@ fn substitute_template(
                 let filled = args.write_nth(argi, f)?;
                 debug_assert!(
                     filled,
-                    "template has more placeholders than the {} arg(s) passed for it: {:?}",
+                    "template has more placeholders than the {} arg(s) passed with it (a format_args! counts as one; pass a tuple): {:?}",
                     args.len(),
                     bstr::BStr::new(t),
                 );

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -2713,7 +2713,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
                     Output::err(
                         err,
                         "failed to stat file: \"{}\"",
-                        format_args!("{}", file.handle),
+                        format_args!("{}", bstr::BStr::new(item.path.as_bytes())),
                     );
                     Global::crash();
                 }
@@ -3000,8 +3000,7 @@ fn tarball_destination<'a>(
     if !pack_filename.is_empty() && !pack_destination.is_empty() {
         Output::err_generic(
             "cannot use both filename and destination at the same time with tarball: filename \"{}\" and destination \"{}\"",
-            format_args!(
-                "{} {}",
+            (
                 bstr::BStr::new(strings::without_trailing_slash(pack_filename)),
                 bstr::BStr::new(strings::without_trailing_slash(pack_destination)),
             ),
@@ -3045,13 +3044,12 @@ fn tarball_destination<'a>(
         if res.is_err() {
             Output::err_generic(
                 "archive destination name too long: \"{}/{}\"",
-                format_args!(
-                    "{}/{}",
+                (
                     bstr::BStr::new(strings::without_trailing_slash(&dest_buf[..dir_len_full])),
                     fmt_tarball_filename(
                         package_name,
                         package_version,
-                        TarballNameStyle::Normalize
+                        TarballNameStyle::Normalize,
                     ),
                 ),
             );
@@ -3654,8 +3652,7 @@ impl IgnorePatterns {
         Output::err(
             err,
             "failed to {} {} at: \"{}{}{}\"",
-            format_args!(
-                "{} {} {}{}{}",
+            (
                 <&str>::from(reason),
                 <&str>::from(ignore_kind),
                 bstr::BStr::new(strings::without_trailing_slash(dir_path)),

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -2,7 +2,7 @@ import { file, spawn, write } from "bun";
 import { readTarball } from "bun:internal-for-testing";
 import { beforeEach, describe, expect, test } from "bun:test";
 import { exists, mkdir, rm } from "fs/promises";
-import { bunEnv, bunExe, pack, runBunInstall, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isLinux, isWindows, pack, runBunInstall, tempDir, tmpdirSync } from "harness";
 import fs from "node:fs/promises";
 import { join } from "path";
 
@@ -331,6 +331,28 @@ describe("flags", () => {
     });
   }
 
+  // The destination directory itself still fits in the path buffer, but appending
+  // "/<name>-<version>.tgz" to it does not. Windows command lines cannot carry an
+  // argument anywhere near its path buffer size.
+  test.skipIf(isWindows)("--destination with no room left for the tarball name", async () => {
+    const name = `pack-dest-too-long-${Buffer.alloc(180, "n").toString()}`;
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name,
+          version: "1.0.0",
+        }),
+      ),
+      write(join(packageDir, "index.js"), "console.log('hello ./index.js')"),
+    ]);
+
+    const pathMax = isLinux ? 4096 : 1024;
+    const dest = join(packageDir, Buffer.alloc(pathMax - 100 - packageDir.length - 1, "d").toString());
+    const { err } = await packExpectError(packageDir, bunEnv, `--destination=${dest}`);
+    expect(err).toContain(`error: archive destination name too long: "${dest}/${name}-1.0.0.tgz"\n`);
+  });
+
   const filenameTests = [
     {
       filename: "test.tgz",
@@ -394,7 +416,12 @@ describe("flags", () => {
       write(join(packageDir, "index.js"), "console.log('hello ./index.js')"),
     ]);
 
-    expect(async () => await pack(packageDir, bunEnv, "--filename=test.tgz", "--destination=packed")).toThrowError();
+    const { err } = await packExpectError(packageDir, bunEnv, "--filename=test.tgz", "--destination=packed");
+    expect(err).toContain(
+      'error: cannot use both filename and destination at the same time with tarball: filename "test.tgz" and destination "packed"',
+    );
+    expect(await exists(join(packageDir, "test.tgz"))).toBeFalse();
+    expect(await exists(join(packageDir, "packed"))).toBeFalse();
   });
 
   test("--ignore-scripts", async () => {
@@ -1402,6 +1429,26 @@ describe(".gitignore/.npmignore", () => {
       await pack(packageDir, bunEnv);
       const tarball3 = readTarball(join(packageDir, "pack-ignore-1-0.0.0.tgz"));
       expect(tarball3.entries).toMatchObject([{ "pathname": "package/package.json" }]);
+    });
+  }
+
+  for (const ignoreFile of [".gitignore", ".npmignore"]) {
+    test(`reports which ${ignoreFile} could not be read`, async () => {
+      await Promise.all([
+        write(
+          join(packageDir, "package.json"),
+          JSON.stringify({
+            name: "pack-ignore-unreadable",
+            version: "1.0.0",
+          }),
+        ),
+        write(join(packageDir, "subdir", "index.js"), "console.log('hello ./subdir/index.js')"),
+        // a directory where the ignore file is expected: opening it succeeds, reading it fails
+        mkdir(join(packageDir, "subdir", ignoreFile), { recursive: true }),
+      ]);
+
+      const { err } = await packExpectError(packageDir, bunEnv);
+      expect(err).toContain(`EISDIR: failed to read ${ignoreFile} at: "${join(packageDir, "subdir", ignoreFile)}"\n`);
     });
   }
 

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -331,11 +331,13 @@ describe("flags", () => {
     });
   }
 
-  // The destination directory itself still fits in the path buffer, but appending
-  // "/<name>-<version>.tgz" to it does not. Windows command lines cannot carry an
-  // argument anywhere near its path buffer size.
+  // The destination directory ends `headroom` bytes short of the path buffer, so it still fits,
+  // but the longer "/<name>-<version>.tgz" appended to it does not. Windows command lines cannot
+  // carry an argument anywhere near its path buffer size.
   test.skipIf(isWindows)("--destination with no room left for the tarball name", async () => {
-    const name = `pack-dest-too-long-${Buffer.alloc(180, "n").toString()}`;
+    const pathMax = isLinux ? 4096 : 1024;
+    const headroom = 100;
+    const name = `pack-dest-too-long-${Buffer.alloc(2 * headroom, "n").toString()}`;
     await Promise.all([
       write(
         join(packageDir, "package.json"),
@@ -347,8 +349,9 @@ describe("flags", () => {
       write(join(packageDir, "index.js"), "console.log('hello ./index.js')"),
     ]);
 
-    const pathMax = isLinux ? 4096 : 1024;
-    const dest = join(packageDir, Buffer.alloc(pathMax - 100 - packageDir.length - 1, "d").toString());
+    // packageDir + "/" + filler is `headroom` bytes short of the buffer
+    const filler = Buffer.alloc(pathMax - headroom - Buffer.byteLength(packageDir) - 1, "d").toString();
+    const dest = join(packageDir, filler);
     const { err } = await packExpectError(packageDir, bunEnv, `--destination=${dest}`);
     expect(err).toContain(`error: archive destination name too long: "${dest}/${name}-1.0.0.tgz"\n`);
   });


### PR DESCRIPTION
### Problem
- `bun pm pack --filename=a.tgz --destination=out` prints `error: cannot use both filename and destination at the same time with tarball: filename "a.tgz out" and destination ""`: both values land in the first quoted slot and the second is empty.
- The "archive destination name too long" error prints the path with a stray trailing slash (`".../pkg-1.0.0.tgz/"`) for the same reason.
- An ignore file that cannot be read prints `EISDIR: failed to read .npmignore /pkg/sub/.npmignore  at: ""` instead of `EISDIR: failed to read .npmignore at: "/pkg/sub/.npmignore"`.
- Cause: these three sites in `src/runtime/cli/pack_command.rs` (`tarball_destination`, twice, and `IgnorePatterns::ignore_file_fail`) hand `Output::err_generic` / `Output::err` one `format_args!` holding every value, while the template has two (or five) placeholders. A `fmt::Arguments` counts as a single positional (`src/bun_core/output.rs`, `impl FmtTuple for fmt::Arguments`), so placeholder 0 receives everything and `substitute_template` renders the remaining placeholders as nothing.
- Unrelated to formatting but in the same function: the `bundledDependencies` entry loop in `pack()` puts `file.handle` into its "failed to stat file" error, so it would read `failed to stat file: "7"` (a file descriptor) instead of naming the file. The entry loop directly above it prints the path.

### Fix
- The three sites pass a tuple, as the other multi-argument messages in this file (`edit_root_package_json`) already do. The bundled loop's stat error prints `item.path` like the loop above it.
- `substitute_template` now fails a `debug_assert!` when it reaches a placeholder after the arguments have run out. Release builds are unchanged (`debug_assert!`); debug builds, which is what the test suite runs, crash at the offending call site instead of printing a plausible-looking message.
- Safe to add: a scan of all 570 `Output::err` / `err_generic` call sites in `src/` (placeholders in the template literal against the arity of the argument) found these three as the only ones with more placeholders than arguments, so the assertion only fires on a new instance.
- Checked that it catches this class: rebuilt with only the `output.rs` hunk, and `bun pm pack --filename=a.tgz --destination=out` panics with `template has more placeholders than the 1 arg(s) passed for it: "cannot use both filename and destination ..."`. With the whole change it prints the correct message.
- The bundled loop's `fstat` failure cannot be provoked from a test (the file was opened a moment earlier), so that one line is untested.
- Verified with `test/cli/install/bun-pack.test.ts`. `--filename and --destination` now asserts the message; new: `--destination with no room left for the tarball name` (POSIX only, it sizes the destination against PATH_MAX, which a Windows command line cannot reach) and `reports which .gitignore/.npmignore could not be read` (a directory where the ignore file is expected, inside a subdirectory so the directory part of the message is exercised; the current release prints the same EISDIR/read message on Windows, so the assertion is not platform-gated). These 4 fail on the current release and pass with this change; the whole file (79 tests) passes with it.
- Overlap: #38739 (relative `--destination` / `--filename`) also switches the two `tarball_destination` messages to tuples. Those hunks are identical, so `pack_command.rs` merges cleanly in either order (checked with `git merge-tree`). Both PRs rewrite the `--filename and --destination` test the same way; the one textual conflict is that #38739 adds its tests directly below it.

### Background
- `Output::err(name, template, args)` and `Output::err_generic(template, args)` in `src/bun_core/output.rs` take a template string with `{}` placeholders and an `impl FmtTuple`: `()`, a tuple of up to eight `Display` values, or one `fmt::Arguments`. `substitute_template` walks the template at runtime and fills each placeholder with the next entry. The `fmt::Arguments` form exists for the common one-placeholder message (`format_args!("{}", bstr::BStr::new(path))`); it is one entry no matter how many values went into it.
- Unlike the `pretty!` family of macros, which expand to `format_args!` and so are checked by the compiler, this path has no compile-time check that the template and the arguments agree. The new assertion is its debug-time equivalent.
- `pack()` writes entries in two loops: the package's own files, then the files of its `bundledDependencies`. The second loop opens files through the `Dir` API and so holds a `File` (whose `handle` is the descriptor) rather than a path-carrying error, which is how the descriptor ended up in the message.
