### PR TITLE
install: only open package.json for writing in the commands that rewrite it

### DIFF
--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -538,10 +538,8 @@ impl Subcommand {
         !matches!(self, Self::Link)
     }
 
-    /// `init` opens package.json for writing for these, so a read-only file is reported
-    /// before any work is done. `bun install <pkg>` and `bun link <pkg>` are `bun add`.
-    /// Commands that only write in some modes (`pm trust`, `pm version`, `pm pkg set`,
-    /// `audit fix`) open package.json themselves.
+    /// `init` opens package.json read-write for these so a read-only file fails before any work is
+    /// done; `bun install <pkg>`/`bun link <pkg>` are `bun add`. `pm trust` etc. open it themselves.
     pub(crate) fn writes_package_json(self, has_package_args: bool) -> bool {
         match self {
             Self::Add | Self::Remove | Self::Update | Self::Patch | Self::PatchCommit => true,

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -538,8 +538,7 @@ impl Subcommand {
         !matches!(self, Self::Link)
     }
 
-    /// `init` opens package.json read-write for these so a read-only file fails before any work is
-    /// done; `bun install <pkg>`/`bun link <pkg>` are `bun add`. `pm trust` etc. open it themselves.
+    /// `init` opens package.json read-write for these so a read-only file fails before any work.
     pub(crate) fn writes_package_json(self, has_package_args: bool) -> bool {
         match self {
             Self::Add | Self::Remove | Self::Update | Self::Patch | Self::PatchCommit => true,

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1579,7 +1579,10 @@ pub fn init(
         let mut this_cwd: &[u8] = original_cwd;
         let mut created_package_json = false;
         let child_json: bun_sys::File = 'child: {
-            let need_write = subcommand.writes_package_json(cli.positionals.len() > 1);
+            // --dry-run and --no-save clear `Do::WRITE_PACKAGE_JSON` once the options load.
+            let need_write = subcommand.writes_package_json(cli.positionals.len() > 1)
+                && !cli.dry_run
+                && !cli.no_save;
 
             loop {
                 let mut package_json_path_buf = PathBuffer::uninit();

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -337,8 +337,6 @@ pub struct PackageManager {
     /// Only set in `bun pm`
     pub root_package_json_name_at_time_of_init: Box<[u8]>,
 
-    pub root_package_json_file: bun_sys::File,
-
     /// The package id corresponding to the workspace the install is happening in. Could be root, or
     /// could be any of the workspaces.
     pub root_package_id: RootPackageId,
@@ -538,6 +536,27 @@ impl Subcommand {
     // TODO: make all subcommands find root and chdir
     pub(crate) fn should_chdir_to_root(self) -> bool {
         !matches!(self, Self::Link)
+    }
+
+    /// `init` opens package.json for writing for these, so a read-only file is reported
+    /// before any work is done. `bun install <pkg>` and `bun link <pkg>` are `bun add`.
+    /// Commands that only write in some modes (`pm trust`, `pm version`, `pm pkg set`,
+    /// `audit fix`) open package.json themselves.
+    pub(crate) fn writes_package_json(self, has_package_args: bool) -> bool {
+        match self {
+            Self::Add | Self::Remove | Self::Update | Self::Patch | Self::PatchCommit => true,
+            Self::Install | Self::Link => has_package_args,
+            Self::Pm
+            | Self::Unlink
+            | Self::Outdated
+            | Self::Pack
+            | Self::Publish
+            | Self::Audit
+            | Self::Info
+            | Self::Why
+            | Self::Dedupe
+            | Self::Prune => false,
+        }
     }
 }
 
@@ -1563,14 +1582,7 @@ pub fn init(
         let mut this_cwd: &[u8] = original_cwd;
         let mut created_package_json = false;
         let child_json: bun_sys::File = 'child: {
-            // if we are only doing `bun install` (no args), then we can open as read_only
-            // in all other cases we will need to write new data later.
-            // this is relevant because it allows us to succeed an install if package.json
-            // is readable but not writable
-            //
-            // probably wont matter as if package.json isn't writable, it's likely that
-            // the underlying directory and node_modules isn't either.
-            let need_write = subcommand != Subcommand::Install || cli.positionals.len() > 1;
+            let need_write = subcommand.writes_package_json(cli.positionals.len() > 1);
 
             loop {
                 let mut package_json_path_buf = PathBuffer::uninit();
@@ -1674,11 +1686,12 @@ pub fn init(
                     parent_path_buf[parent_without_trailing_slash.len() + b"/package.json".len()] =
                         0;
 
+                    // Finding the workspace root must not depend on its package.json being writable.
                     let json_file = match bun_sys::File::openat(
                         bun_sys::Fd::cwd(),
                         &parent_path_buf
                             [..parent_without_trailing_slash.len() + b"/package.json".len()],
-                        bun_sys::O::RDWR | bun_sys::O::CLOEXEC,
+                        bun_sys::O::RDONLY | bun_sys::O::CLOEXEC,
                         0,
                     ) {
                         Ok(f) => f,
@@ -1802,10 +1815,6 @@ pub fn init(
                                 // process-lifetime (`set_top_level_dir` requires `'static`).
                                 fs.set_top_level_dir(fs.dirname_store().append(parent)?);
                                 let _ = child_json.close();
-                                #[cfg(windows)]
-                                {
-                                    json_file.seek_to(0)?;
-                                }
                                 workspace_name_hash =
                                     Some(Semver::string::Builder::string_hash(&entry.name));
                                 break 'root_package_json_file json_file;
@@ -1854,6 +1863,8 @@ pub fn init(
         root_buf[plen] = 0;
         ROOT_PACKAGE_JSON_PATH.write(ZStr::from_raw(root_buf.as_ptr(), plen));
     }
+    // From here on package.json is read (and, by the commands that do, written) by path.
+    let _ = root_package_json_file.close();
 
     // Returns the resolver's BSSMap-owned
     // `*EntriesOption` slot.
@@ -2046,7 +2057,6 @@ pub fn init(
         // zero-bit pattern is UB; allocate the real (empty) lockfile here directly.
         // `Lockfile::default()` ≡ `Lockfile::init_empty()`.
         wr!(lockfile, Box::new(Lockfile::default()));
-        wr!(root_package_json_file, root_package_json_file);
         // .progress
         wr!(event_loop, AnyEventLoop::init());
         wr!(
@@ -2486,13 +2496,6 @@ fn init_with_runtime_once(
         // `Lockfile` holds `HashMap`/`Vec`/`NonNull` (zero-bit pattern is
         // UB), so allocate the real empty lockfile here directly instead of a zeroed placeholder.
         wr!(lockfile, Box::new(Lockfile::default()));
-        // `.root_package_json_file` is never read in the runtime
-        // path. Use the explicit invalid-fd sentinel rather than `mem::zeroed()` —
-        // on posix `Fd(0)` is stdin, not the invalid marker.
-        wr!(
-            root_package_json_file,
-            bun_sys::File::from_fd(Fd::invalid())
-        );
         // erased *mut () set by tier-6; `js_current()` resolves the per-thread JS
         // event loop via `bun_io::__bun_get_vm_ctx` (link-time, definer in bun_runtime).
         wr!(event_loop, AnyEventLoop::js_current());

--- a/src/install/pnpm.rs
+++ b/src/install/pnpm.rs
@@ -2750,17 +2750,28 @@ fn update_package_json_after_migration(
                 .to_vec(),
         );
 
-        // Write the updated package.json
-        if sys::File::write_file(
+        let written = sys::File::write_file(
             dir,
             bun_core::zstr!("package.json"),
             root_pkg_json.source.contents(),
-        )
-        .is_ok()
-            && !moved.is_empty()
-            && !silent
-        {
-            bun_core::pretty_errorln!("<d>moved {} in <r><green>package.json<r>", moved.join(", "));
+        );
+        if silent || moved.is_empty() {
+            return Ok(());
+        }
+        match written {
+            Ok(()) => {
+                bun_core::pretty_errorln!(
+                    "<d>moved {} in <r><green>package.json<r>",
+                    moved.join(", ")
+                );
+            }
+            Err(err) => {
+                bun_core::warn!(
+                    "failed to write package.json ({}): {} not moved",
+                    bstr::BStr::new(err.name()),
+                    moved.join(", ")
+                );
+            }
         }
     }
 

--- a/src/runtime/cli/pm_trusted_command.rs
+++ b/src/runtime/cli/pm_trusted_command.rs
@@ -439,6 +439,31 @@ impl TrustCommand {
             Global::crash();
         }
 
+        // Opened before any script runs: package.json is rewritten at the end, and a script
+        // whose trust cannot be recorded must not run.
+        // SAFETY: `ROOT_PACKAGE_JSON_PATH` is set during `PackageManager::init`
+        // (single-threaded startup) and immutable thereafter.
+        let root_package_json_path = unsafe { ROOT_PACKAGE_JSON_PATH.read() };
+        let root_file = match bun_sys::File::openat(
+            bun_sys::Fd::cwd(),
+            root_package_json_path.as_bytes(),
+            bun_sys::O::RDWR | bun_sys::O::CLOEXEC,
+            0,
+        ) {
+            Ok(file) => file,
+            Err(err) => {
+                Output::err(
+                    &err,
+                    "could not open \"{s}\" for writing",
+                    (bstr::BStr::new(root_package_json_path.as_bytes()),),
+                );
+                bun_core::note!(
+                    "bun pm trust adds the packages to trustedDependencies in package.json"
+                );
+                Global::crash();
+            }
+        };
+
         let mut scripts_node: Progress::Node;
         // SAFETY: `pm_raw` singleton; `progress` is owned inline.
         let show_progress = unsafe { (*pm_raw).options.log_level.show_progress() };
@@ -533,20 +558,10 @@ impl TrustCommand {
             }
         }
 
-        // SAFETY: `pm_raw` singleton; this scope takes over the descriptor
-        // (the original `pm.root_package_json_file` is replaced with INVALID so
-        // its eventual drop is a no-op).
-        let root_file = unsafe {
-            let fd = (*pm_raw).root_package_json_file.handle;
-            (*pm_raw).root_package_json_file.handle = bun_core::Fd::INVALID;
-            bun_sys::File::from_fd(fd)
-        };
         let package_json_contents = root_file.read_to_end().map_err(crate::Error::from)?;
 
-        // SAFETY: `ROOT_PACKAGE_JSON_PATH` is set during `PackageManager::init`
-        // (single-threaded startup) and immutable thereafter.
         let package_json_source = bun_ast::Source::init_path_string(
-            unsafe { ROOT_PACKAGE_JSON_PATH.read() }.as_bytes(),
+            root_package_json_path.as_bytes(),
             package_json_contents.as_slice(),
         );
 

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -2,7 +2,7 @@ import { file, spawn, write } from "bun";
 import { readTarball } from "bun:internal-for-testing";
 import { beforeEach, describe, expect, test } from "bun:test";
 import { exists, mkdir, rm } from "fs/promises";
-import { bunEnv, bunExe, pack, runBunInstall, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isWindows, pack, runBunInstall, tempDir, tmpdirSync, unprivilegedSpawnOptions } from "harness";
 import fs from "node:fs/promises";
 import { join } from "path";
 
@@ -48,6 +48,35 @@ test("basic", async () => {
   await pack(packageDir, bunEnv);
 
   const tarball = readTarball(join(packageDir, "pack-basic-1.2.3.tgz"));
+  expect(tarball.entries).toMatchObject([{ "pathname": "package/package.json" }, { "pathname": "package/index.js" }]);
+});
+
+// pack only reads package.json, so a file that is readable but not writable (a read-only
+// checkout, a file owned by another user) must not stop it.
+test.skipIf(isWindows)("read-only package.json", async () => {
+  using dir = tempDir("pack-read-only", {
+    "package.json": JSON.stringify({ name: "pack-read-only", version: "1.2.3" }),
+    "index.js": "console.log('hello ./index.js')",
+  });
+  await fs.chmod(join(String(dir), "package.json"), 0o444);
+  using unprivileged = unprivilegedSpawnOptions(String(dir));
+
+  await using proc = spawn({
+    cmd: [bunExe(), "pm", "pack"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+    ...unprivileged,
+  });
+  const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(err).toBe("");
+  expect(out).toContain("pack-read-only-1.2.3.tgz");
+  expect(exitCode).toBe(0);
+
+  const tarball = readTarball(join(String(dir), "pack-read-only-1.2.3.tgz"));
   expect(tarball.entries).toMatchObject([{ "pathname": "package/package.json" }, { "pathname": "package/index.js" }]);
 });
 

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -976,11 +976,7 @@ describe.skipIf(isWindows)("read-only package.json", () => {
       }),
     });
     const unprivileged = unprivilegedSpawnOptions(String(dir));
-    const [, err, exitCode] = await run(String(dir), unprivileged, "install");
-    expect(err).toContain("Saved lockfile");
-    expect(exitCode).toBe(0);
-    await chmod(join(String(dir), "package.json"), 0o444);
-    return {
+    const project = {
       dir: String(dir),
       run: (...args: string[]) => run(String(dir), unprivileged, ...args),
       [Symbol.dispose]() {
@@ -988,6 +984,16 @@ describe.skipIf(isWindows)("read-only package.json", () => {
         dir[Symbol.dispose]();
       },
     };
+    try {
+      const [, err, exitCode] = await project.run("install");
+      expect(err).toContain("Saved lockfile");
+      expect(exitCode).toBe(0);
+      await chmod(join(project.dir, "package.json"), 0o444);
+    } catch (e) {
+      project[Symbol.dispose]();
+      throw e;
+    }
+    return project;
   }
 
   test("commands that only read package.json work", async () => {

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -965,7 +965,8 @@ describe.skipIf(isWindows)("read-only package.json", () => {
   }
 
   // An installed project whose package.json was made read-only afterwards. `dep` is a
-  // local dependency whose postinstall was blocked, so there is something to trust.
+  // local dependency whose postinstall was blocked, so there is something to trust; `other`
+  // is a local package that is not a dependency yet, so there is something to add.
   async function installedProject() {
     const dir = tempDir("pm-read-only-package-json", {
       "package.json": JSON.stringify({ name: "read-only", version: "1.0.0", dependencies: { dep: "file:./dep" } }),
@@ -974,6 +975,7 @@ describe.skipIf(isWindows)("read-only package.json", () => {
         version: "1.0.0",
         scripts: { postinstall: "echo ran > ran.txt" },
       }),
+      "other/package.json": JSON.stringify({ name: "other", version: "1.0.0" }),
     });
     const unprivileged = unprivilegedSpawnOptions(String(dir));
     const project = {
@@ -1047,7 +1049,7 @@ describe.skipIf(isWindows)("read-only package.json", () => {
     using project = await installedProject();
 
     const results: { args: string[]; out: string; err: string; exitCode: number }[] = [];
-    for (const args of [["add", "other"], ["remove", "dep"], ["update"]]) {
+    for (const args of [["add", "./other"], ["remove", "dep"], ["update"]]) {
       const [out, err, exitCode] = await project.run(...args);
       results.push({ args, out, err, exitCode });
     }
@@ -1060,10 +1062,36 @@ describe.skipIf(isWindows)("read-only package.json", () => {
       exitCode: 1,
     };
     expect(results).toEqual([
-      { args: ["add", "other"], ...refused },
+      { args: ["add", "./other"], ...refused },
       { args: ["remove", "dep"], ...refused },
       { args: ["update"], ...refused },
     ]);
+  });
+
+  // --dry-run and --no-save turn the same commands into readers of package.json.
+  test("--dry-run and --no-save do not need a writable package.json", async () => {
+    using project = await installedProject();
+    const packageJson = join(project.dir, "package.json");
+    const packageJsonBefore = await Bun.file(packageJson).text();
+
+    const results: { args: string[]; err: string; exitCode: number }[] = [];
+    for (const args of [
+      ["add", "./other", "--dry-run"],
+      ["remove", "dep", "--dry-run"],
+      ["update", "--dry-run"],
+      ["add", "./other", "--no-save"],
+    ]) {
+      const [, err, exitCode] = await project.run(...args);
+      results.push({ args, err, exitCode });
+    }
+
+    expect(results).toEqual([
+      { args: ["add", "./other", "--dry-run"], err: "", exitCode: 0 },
+      { args: ["remove", "dep", "--dry-run"], err: "", exitCode: 0 },
+      { args: ["update", "--dry-run"], err: "", exitCode: 0 },
+      { args: ["add", "./other", "--no-save"], err: "", exitCode: 0 },
+    ]);
+    expect(await Bun.file(packageJson).text()).toBe(packageJsonBefore);
   });
 
   test("a read-only root package.json is still found from a workspace member", async () => {

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -1,7 +1,16 @@
 import { spawn } from "bun";
-import { afterAll, afterEach, beforeAll, beforeEach, expect, it, test } from "bun:test";
-import { exists, mkdir, writeFile } from "fs/promises";
-import { bunEnv, bunExe, bunEnv as env, readdirSorted, tempDir, tmpdirSync } from "harness";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, test } from "bun:test";
+import { chmod, exists, mkdir, writeFile } from "fs/promises";
+import {
+  bunEnv,
+  bunExe,
+  bunEnv as env,
+  isWindows,
+  readdirSorted,
+  tempDir,
+  tmpdirSync,
+  unprivilegedSpawnOptions,
+} from "harness";
 import { cpSync } from "node:fs";
 import { join } from "path";
 import {
@@ -935,4 +944,134 @@ test("bun pm cache rm does not create the directory named by a project-local .en
   expect(stdout).toInclude("Cleared 'bun install' cache");
   expect(stderr).not.toContain("error");
   expect(exitCode).toBe(0);
+});
+
+// A package.json that is readable but not writable (a read-only checkout, a file owned by
+// another user) must only stop the commands that actually rewrite it.
+describe.skipIf(isWindows)("read-only package.json", () => {
+  // Nothing here may reach a registry.
+  const offlineEnv = { ...env, npm_config_registry: "http://127.0.0.1:1/" };
+
+  function run(cwd: string, unprivileged: ReturnType<typeof unprivilegedSpawnOptions>, ...args: string[]) {
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), ...args],
+      cwd,
+      env: offlineEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      ...unprivileged,
+    });
+    return Promise.all([stdout.text(), stderr.text(), exited]);
+  }
+
+  // An installed project whose package.json was made read-only afterwards. `dep` is a
+  // local dependency whose postinstall was blocked, so there is something to trust.
+  async function installedProject() {
+    const dir = tempDir("pm-read-only-package-json", {
+      "package.json": JSON.stringify({ name: "read-only", version: "1.0.0", dependencies: { dep: "file:./dep" } }),
+      "dep/package.json": JSON.stringify({
+        name: "dep",
+        version: "1.0.0",
+        scripts: { postinstall: "echo ran > ran.txt" },
+      }),
+    });
+    const unprivileged = unprivilegedSpawnOptions(String(dir));
+    const [, err, exitCode] = await run(String(dir), unprivileged, "install");
+    expect(err).toContain("Saved lockfile");
+    expect(exitCode).toBe(0);
+    await chmod(join(String(dir), "package.json"), 0o444);
+    return {
+      dir: String(dir),
+      run: (...args: string[]) => run(String(dir), unprivileged, ...args),
+      [Symbol.dispose]() {
+        unprivileged[Symbol.dispose]();
+        dir[Symbol.dispose]();
+      },
+    };
+  }
+
+  test("commands that only read package.json work", async () => {
+    using project = await installedProject();
+
+    const results: { args: string[]; out: string; err: string; exitCode: number }[] = [];
+    for (const args of [["pm", "bin"], ["pm", "ls"], ["pm", "pkg", "get", "name"], ["why", "dep"], ["outdated"]]) {
+      const [out, err, exitCode] = await project.run(...args);
+      results.push({ args, out, err, exitCode });
+    }
+
+    expect(results).toEqual([
+      { args: ["pm", "bin"], out: join(project.dir, "node_modules", ".bin") + "\n", err: "", exitCode: 0 },
+      { args: ["pm", "ls"], out: expect.stringContaining("dep@dep"), err: "", exitCode: 0 },
+      { args: ["pm", "pkg", "get", "name"], out: '"read-only"\n', err: "", exitCode: 0 },
+      { args: ["why", "dep"], out: expect.stringContaining("dep@dep"), err: "", exitCode: 0 },
+      { args: ["outdated"], out: expect.stringMatching(/^bun outdated v/), err: "", exitCode: 0 },
+    ]);
+  });
+
+  test("bun pm trust refuses before running any script", async () => {
+    using project = await installedProject();
+    const packageJson = join(project.dir, "package.json");
+    const lockfile = join(project.dir, "bun.lock");
+    const ranMarker = join(project.dir, "node_modules", "dep", "ran.txt");
+    const lockfileBefore = await Bun.file(lockfile).text();
+
+    {
+      const [out, err, exitCode] = await project.run("pm", "trust", "dep");
+      expect(err).toContain(`EACCES: Permission denied: could not open "${packageJson}" for writing`);
+      expect(out).toBe("");
+      expect(exitCode).toBe(1);
+      expect(await exists(ranMarker)).toBeFalse();
+      expect(await Bun.file(lockfile).text()).toBe(lockfileBefore);
+    }
+
+    // Once package.json is writable again the same command runs the script and records the trust.
+    await chmod(packageJson, 0o644);
+    {
+      const [out, err, exitCode] = await project.run("pm", "trust", "dep");
+      expect(err).not.toContain("error");
+      expect(out).toContain("1 script ran across 1 package");
+      expect(exitCode).toBe(0);
+      expect(await exists(ranMarker)).toBeTrue();
+      expect(await Bun.file(packageJson).json()).toMatchObject({ trustedDependencies: ["dep"] });
+      expect(await Bun.file(lockfile).text()).toContain("trustedDependencies");
+    }
+  });
+
+  test("commands that rewrite package.json still refuse up front", async () => {
+    using project = await installedProject();
+
+    const results: { args: string[]; out: string; err: string; exitCode: number }[] = [];
+    for (const args of [["add", "other"], ["remove", "dep"], ["update"]]) {
+      const [out, err, exitCode] = await project.run(...args);
+      results.push({ args, out, err, exitCode });
+    }
+
+    const refused = {
+      out: "",
+      err: expect.stringContaining(
+        `EACCES: Permission denied while opening "${join(project.dir, "package.json")}"\nnote: package.json must be writable`,
+      ),
+      exitCode: 1,
+    };
+    expect(results).toEqual([
+      { args: ["add", "other"], ...refused },
+      { args: ["remove", "dep"], ...refused },
+      { args: ["update"], ...refused },
+    ]);
+  });
+
+  test("a read-only root package.json is still found from a workspace member", async () => {
+    using dir = tempDir("pm-read-only-workspace-root", {
+      "package.json": JSON.stringify({ name: "root", workspaces: ["packages/*"] }),
+      "packages/member/package.json": JSON.stringify({ name: "member", version: "1.0.0" }),
+    });
+    await chmod(join(String(dir), "package.json"), 0o444);
+    using unprivileged = unprivilegedSpawnOptions(String(dir));
+
+    const [out, err, exitCode] = await run(join(String(dir), "packages", "member"), unprivileged, "pm", "bin");
+
+    expect(err).toBe("");
+    expect(out).toBe(join(String(dir), "node_modules", ".bin") + "\n");
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -12,6 +12,7 @@ import {
   runBunInstall,
   tempDir,
   tmpdirSync,
+  unprivilegedSpawnOptions,
 } from "harness";
 import { delimiter, join } from "path";
 
@@ -803,6 +804,31 @@ describe("--dry-run", async () => {
     expect(out).not.toContain("someuser");
     expect(out).not.toContain("hunter2");
     expect(err).not.toContain("hunter2");
+    expect(exitCode).toBe(0);
+  });
+  // publish only reads package.json, so a file that is readable but not writable (a
+  // read-only checkout, a file owned by another user) must not stop it.
+  test.skipIf(isWindows)("read-only package.json", async () => {
+    using dir = tempDir("publish-read-only", {
+      "package.json": JSON.stringify({ name: "dry-run-read-only", version: "4.4.4" }),
+      "index.js": "",
+    });
+    chmodSync(join(String(dir), "package.json"), 0o444);
+    using unprivileged = unprivilegedSpawnOptions(String(dir));
+
+    await using proc = spawn({
+      cmd: [bunExe(), "publish", "--dry-run"],
+      cwd: String(dir),
+      // Credentials in the URL satisfy the auth check; --dry-run stops before any request.
+      env: { ...env, npm_config_registry: "http://someuser:hunter2@127.0.0.1:1/" },
+      stdout: "pipe",
+      stderr: "pipe",
+      ...unprivileged,
+    });
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(err).toBe("");
+    expect(out).toContain(" + dry-run-read-only@4.4.4 (dry-run)");
     expect(exitCode).toBe(0);
   });
 });

--- a/test/cli/install/migration/pnpm-lock-v9.test.ts
+++ b/test/cli/install/migration/pnpm-lock-v9.test.ts
@@ -2604,10 +2604,11 @@ importers:
         stderr: "pipe",
         ...unprivileged,
       });
-      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
       expect(stderr).toContain("warn: failed to write package.json (EACCES): pnpm.overrides to overrides not moved");
       expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
+      expect(stdout).toBe("");
       expect(exitCode).toBe(0);
       expect(await Bun.file(join(String(dir), "package.json")).text()).toBe(packageJson);
       expect(overridesSection(await bunLockOf(String(dir)))).toMatchInlineSnapshot(`

--- a/test/cli/install/migration/pnpm-lock-v9.test.ts
+++ b/test/cli/install/migration/pnpm-lock-v9.test.ts
@@ -1,6 +1,14 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { existsSync, readdirSync, realpathSync, rmSync } from "fs";
-import { bunEnv, bunExe, nodeModulesPackages, tempDir, VerdaccioRegistry } from "harness";
+import { chmodSync, existsSync, readdirSync, realpathSync, rmSync } from "fs";
+import {
+  bunEnv,
+  bunExe,
+  isWindows,
+  nodeModulesPackages,
+  tempDir,
+  unprivilegedSpawnOptions,
+  VerdaccioRegistry,
+} from "harness";
 import { dirname, join } from "path";
 
 const verdaccio = new VerdaccioRegistry();
@@ -2576,6 +2584,37 @@ importers:
       expect(stderr).toContain("pnpm-lock.yaml override 'foo' must be a string");
       expect(exitCode).toBe(1);
       expect(existsSync(join(String(dir), "bun.lock"))).toBe(false);
+    });
+
+    // A read-only checkout still gets its bun.lock; the fields that could not be moved are named.
+    test.concurrent.skipIf(isWindows)("a read-only package.json keeps its fields and is reported", async () => {
+      const packageJson = JSON.stringify({ name: "overrides-read-only", pnpm: { overrides: { plain: "1.0.0" } } });
+      using dir = tempDir("pnpm-v9-overrides-read-only", {
+        "package.json": packageJson,
+        "pnpm-lock.yaml": overridesLockfile("  plain: 1.0.0"),
+      });
+      chmodSync(join(String(dir), "package.json"), 0o444);
+      using unprivileged = unprivilegedSpawnOptions(String(dir));
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "pm", "migrate"],
+        cwd: String(dir),
+        env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache") },
+        stdout: "pipe",
+        stderr: "pipe",
+        ...unprivileged,
+      });
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+      expect(stderr).toContain("warn: failed to write package.json (EACCES): pnpm.overrides to overrides not moved");
+      expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
+      expect(exitCode).toBe(0);
+      expect(await Bun.file(join(String(dir), "package.json")).text()).toBe(packageJson);
+      expect(overridesSection(await bunLockOf(String(dir)))).toMatchInlineSnapshot(`
+        "  "overrides": {
+            "plain": "1.0.0",
+          },"
+      `);
     });
   });
 

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -486,6 +486,50 @@ export function tempDirWithFilesAnon(filesOrAbsolutePathToCopyFolderFrom: Direct
   return base;
 }
 
+/**
+ * `Bun.spawn` options for a child that must be subject to file permission bits,
+ * for tests where e.g. a `chmod 444` file has to be unwritable.
+ *
+ * Root bypasses permission bits, so when the tests run as root the child is
+ * run as uid/gid 65534 ("nobody" on Linux and macOS): `dir` is handed over to
+ * that user, and every ancestor it could not traverse (CI points TMPDIR at a
+ * mode 0700 directory) gets `o+x` until the returned value is disposed. When
+ * the tests already run unprivileged, the child runs as the current user and
+ * nothing is changed. POSIX only.
+ *
+ * @example
+ * ```ts
+ * using dir = tempDir("read-only", { "package.json": "{}" });
+ * fs.chmodSync(join(String(dir), "package.json"), 0o444);
+ * using unprivileged = unprivilegedSpawnOptions(String(dir));
+ * await using proc = Bun.spawn({ cmd: [bunExe(), "pm", "pack"], cwd: String(dir), env: bunEnv, ...unprivileged });
+ * ```
+ */
+export function unprivilegedSpawnOptions(dir: string): { uid?: number; gid?: number } & Disposable {
+  const restoreModes: [path: string, mode: number][] = [];
+  const options: { uid?: number; gid?: number } & Disposable = {
+    [Symbol.dispose]() {
+      for (const [path, mode] of restoreModes) fs.chmodSync(path, mode);
+    },
+  };
+  if (isWindows || process.getuid!() !== 0) return options;
+
+  const NOBODY = 65534;
+  fs.chownSync(dir, NOBODY, NOBODY);
+  for (const entry of fs.readdirSync(dir, { recursive: true, encoding: "utf8" })) {
+    fs.lchownSync(join(dir, entry), NOBODY, NOBODY);
+  }
+  for (let parent = dirname(dir); parent !== dirname(parent); parent = dirname(parent)) {
+    const mode = fs.statSync(parent).mode & 0o7777;
+    if (mode & 0o001) continue;
+    fs.chmodSync(parent, mode | 0o001);
+    restoreModes.push([parent, mode]);
+  }
+  options.uid = NOBODY;
+  options.gid = NOBODY;
+  return options;
+}
+
 export interface BunRunResult {
   stdout: string;
   stderr: string;

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -515,15 +515,20 @@ export function unprivilegedSpawnOptions(dir: string): { uid?: number; gid?: num
   if (isWindows || process.getuid!() !== 0) return options;
 
   const NOBODY = 65534;
-  fs.chownSync(dir, NOBODY, NOBODY);
-  for (const entry of fs.readdirSync(dir, { recursive: true, encoding: "utf8" })) {
-    fs.lchownSync(join(dir, entry), NOBODY, NOBODY);
-  }
-  for (let parent = dirname(dir); parent !== dirname(parent); parent = dirname(parent)) {
-    const mode = fs.statSync(parent).mode & 0o7777;
-    if (mode & 0o001) continue;
-    fs.chmodSync(parent, mode | 0o001);
-    restoreModes.push([parent, mode]);
+  try {
+    fs.chownSync(dir, NOBODY, NOBODY);
+    for (const entry of fs.readdirSync(dir, { recursive: true, encoding: "utf8" })) {
+      fs.lchownSync(join(dir, entry), NOBODY, NOBODY);
+    }
+    for (let parent = dirname(dir); parent !== dirname(parent); parent = dirname(parent)) {
+      const mode = fs.statSync(parent).mode & 0o7777;
+      if (mode & 0o001) continue;
+      fs.chmodSync(parent, mode | 0o001);
+      restoreModes.push([parent, mode]);
+    }
+  } catch (e) {
+    options[Symbol.dispose]();
+    throw e;
   }
   options.uid = NOBODY;
   options.gid = NOBODY;


### PR DESCRIPTION
### Problem
- `bun pm pack`, `bun publish`, `bun outdated`, `bun pm ls`, `bun pm bin`, `bun pm cache`, `bun audit`, `bun info`, `bun why`, ... exit 1 when package.json is readable but not writable (`chmod 444 package.json`, a checkout owned by another user, a read-only mount):
  ```
  EACCES: Permission denied while opening "/work/ro/package.json"
  note: package.json must be writable to add packages
  ```
  None of these commands write package.json; `npm pack` / `npm publish` work on the same directory.
- Cause: `PackageManager::init` opens the nearest package.json `O_RDWR` for every subcommand except a bare `bun install` (`src/install/PackageManager.rs:1573` before this change, `need_write = subcommand != Install || positionals.len() > 1`). The early read-write open exists so that `bun add` / `bun remove` fail before doing any work, but it was applied to every other command too.
- Second instance of the same thing: the walk that looks for a workspace root opens each parent package.json `O_RDWR` as well and treats any failure as "not a workspace root" (`PackageManager.rs:1681-1686` before this change). With a read-only root package.json, every command run from a workspace member, including a bare `bun install`, silently treats the member as a standalone package (`bun pm bin` prints `packages/a/node_modules/.bin`, `bun install` ignores the workspace).
- Reproduced with bun 1.4.0 and a debug build of main, running as a non-root user (root bypasses the mode bits). The read-write open dates from #7550, which fixed #4936 (Docker `--mount=type=bind`, read-only by default) for a bare `bun install` only; #20722 later tried to exempt pack and publish the same way and was not merged.

### Fix
- `Subcommand::writes_package_json` (`PackageManager.rs:545`) names the commands that rewrite the nearest package.json unconditionally and therefore keep the early read-write check: `add`, `remove`, `update`, `patch`, `patch-commit`, plus `install`/`link` when they are given packages (that is `bun add`). The match is exhaustive, so a new subcommand has to pick a side. Everything else opens package.json read-only.
- The check is also skipped under `--dry-run` and `--no-save`, the two flags that clear `Do::WRITE_PACKAGE_JSON` once the options load, so `bun add x --dry-run`, `bun remove x --dry-run`, `bun update --dry-run` and `bun add x --no-save` work on a read-only package.json too. `bun link <pkg>` defaults to `--no-save` (it only edits package.json with `--save`), so it is covered by the same condition.
- The workspace root walk always opens the parent package.json read-only: whether a directory is the workspace root does not depend on being able to write its package.json. Commands that do edit the root package.json from a member (`patch-commit`, `audit fix`) already open it by path when they write and report that failure.
- `bun pm trust` was the only code that used the descriptor `init` kept open (`root_package_json_file`), reading and rewriting the root package.json through it, so with `pm` opening read-only it has to open the file itself. It now opens `ROOT_PACKAGE_JSON_PATH` read-write before running any script (`pm_trusted_command.rs:447`), so a read-only package.json is still reported up front instead of after the scripts ran and the lockfile was saved. With no remaining reader, the descriptor field is removed and `init` closes the file once it has derived `ROOT_PACKAGE_JSON_PATH` from it (this also removes the Windows `seek_to(0)` that only existed for `pm trust`).
- `pm version`, `pm pkg set/delete/fix` and `audit fix` are unaffected: they already open package.json by path when they write and print their own error on failure.
- pnpm migration also writes package.json by path (it moves `pnpm.overrides` / `pnpm.patchedDependencies` and the pnpm-workspace.yaml fields into it) and ignored a failed write, leaving bun.lock with the moved fields and package.json without them, silently. A bare `bun install` always reached this (it was already read-only at init); `bun pm migrate` now reaches it too instead of being rejected up front. `update_package_json_after_migration` (`src/install/pnpm.rs`) now warns `failed to write package.json (EACCES): pnpm.overrides to overrides not moved`; the lockfile is still written and the exit code is unchanged, as for `bun install` before.
- Why this is correct: the early read-write open is only an optimization of the error (fail before network and install work); the command's real write still opens the file by path. Limiting it to the invocations that actually write changes nothing for them, and the ones that only read package.json never needed write access. npm behaves this way for pack/publish/outdated/ls.
- Kept the check in `init` rather than moving it next to the write in `update_package_json_and_install_with_manager`: `bun update -i` reaches that function only after fetching manifests and prompting, so the check would have needed a second call site there, and the classification is two lines either way.
- Tests (all skipped on Windows like the existing chmod tests; when the suite runs as root the child bun is run as uid 65534 via a new `unprivilegedSpawnOptions` harness helper, since root ignores the mode bits and the existing chmod tests simply skip there. The helper hands the fixture to that uid and adds `o+x` to any ancestor it could not traverse until the test ends, which is what the root-only fs.watch subtree test in `test/js/node/watch/fs.watch.test.ts` already does, because the CI runner points `TMPDIR` at a mode 0700 directory):
  - `test/cli/install/bun-pack.test.ts` "read-only package.json": `bun pm pack` on a 0444 package.json produces the tarball.
  - `test/cli/install/bun-publish.test.ts` "--dry-run > read-only package.json": `bun publish --dry-run` succeeds.
  - `test/cli/install/bun-pm.test.ts` "read-only package.json": `pm bin`, `pm ls`, `pm pkg get`, `why`, `outdated` work on an installed project with a 0444 package.json; `pm trust` refuses without running the script or touching bun.lock and then works once the file is writable again; `add` / `remove` / `update` still fail up front with the existing message while their `--dry-run` / `--no-save` forms exit 0 and leave the file alone; `pm bin` from a workspace member finds the root whose package.json is 0444.
  - `test/cli/install/migration/pnpm-lock-v9.test.ts` "a read-only package.json keeps its fields and is reported": `bun pm migrate` on a 0444 package.json writes bun.lock with the overrides, leaves package.json as it was, prints the warning and exits 0.
  - Before the fix (`USE_SYSTEM_BUN=1`): pack, publish, the migration test and four of the five bun-pm tests fail; the `add`/`remove`/`update` refusal test passes both ways by design.
  - `bun bd test` on bun-pm, bun-pack, bun-publish, pnpm-lock-v9 (78), bun-workspaces, bad-workspace, bun-pm-why, bun-dedupe, bun-info, bun-remove, bun-audit, bun-prune, bun-patch, and the `trust` tests of bun-install-lifecycle-scripts (68) all pass. Also ran the bun-pm tests as root with `TMPDIR` pointing at a mode 0700 directory to mirror the CI runner.

### Background
- `PackageManager::init` is shared by every `bun install`-family command. It locates the nearest package.json by walking up from the cwd, then walks further up looking for a package.json whose `workspaces` field lists the directory it found, and chdirs to that root. Both steps open the files; the nearest one's descriptor used to be stored on the manager as `root_package_json_file`, and `ROOT_PACKAGE_JSON_PATH` is derived from it.
- `bun pm trust <pkg>` runs the lifecycle scripts that `bun install` blocked for untrusted dependencies and then records the names in `trustedDependencies` in both bun.lock and the root package.json, which is why it is the one `pm` subcommand that writes the file `init` opened.
- `bun pm <x>`, `bun whoami` and `bun list` all enter `init` as `Subcommand::Pm` before the `pm` subcommand is known, so the `pm` family can only be classified as a whole; its writing members open package.json themselves.


