### PR TITLE
websocket: drop the write-only ProxyTlsHandshake state

### DIFF
--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -89,12 +89,13 @@ pub(crate) struct DeflateNegotiationResult {
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum State {
     Initializing,
+    /// Socket connecting/open, waiting for the upgrade response. Through a
+    /// proxy this is re-entered once CONNECT succeeds; for wss:// it also
+    /// spans the tunnel's TLS handshake (bytes route by `proxy.get_tunnel()`).
     Reading,
     Failed,
     /// Sent CONNECT, waiting for 200
     ProxyHandshake,
-    /// TLS inside tunnel (for wss:// through proxy)
-    ProxyTlsHandshake,
     /// WebSocket upgrade complete, forwarding data through tunnel
     Done,
 }
@@ -1187,7 +1188,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
         };
         p.set_tunnel(Some(tunnel));
         // SAFETY: scoped write; `p` is dead.
-        unsafe { (*this).state = State::ProxyTlsHandshake };
+        unsafe { (*this).state = State::Reading };
     }
 
     /// Called by WebSocketProxyTunnel when TLS handshake completes successfully

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -89,9 +89,6 @@ pub(crate) struct DeflateNegotiationResult {
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum State {
     Initializing,
-    /// Socket connecting/open, waiting for the upgrade response. Through a
-    /// proxy this is re-entered once CONNECT succeeds; for wss:// it also
-    /// spans the tunnel's TLS handshake (bytes route by `proxy.get_tunnel()`).
     Reading,
     Failed,
     /// Sent CONNECT, waiting for 200


### PR DESCRIPTION
The upgrade client's State had a ProxyTlsHandshake variant that was written once and never read: while the tunnel's TLS handshake runs, incoming bytes are routed by the proxy having a tunnel, which is set at the same moment. What the write does do is leave ProxyHandshake, so the ServerHello is not parsed as a CONNECT response; setting Reading does that too and is what the ws:// path already does after CONNECT succeeds. Every reader of state in that window sees the same answer as before (the only one comparing against Reading is the connect-error handler, which cannot fire on an open socket).

No behavior change. The websocket proxy tests (38 pass, docker cases skipped) and a wss-through-CONNECT-proxy script pass on the debug build.