### PR TITLE
pack: report an error instead of panicking when --destination does not fit the path buffer

### DIFF
--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -3024,11 +3024,24 @@ fn tarball_destination<'a>(
         return (ZStr::from_buf(&dest_buf[..], tarball_name_len - 1), 0);
     } else {
         let (dir_len_trimmed, dir_len_full) = {
-            let tarball_destination_dir = resolve_path::join_abs_string_buf::<
+            let Some(tarball_destination_dir) = resolve_path::join_abs_string_buf_checked::<
                 resolve_path::platform::Auto,
             >(
                 abs_workspace_path, dest_buf, &[pack_destination]
-            );
+            ) else {
+                Output::err_generic(
+                    "archive destination name too long: \"{}/{}\"",
+                    (
+                        bstr::BStr::new(strings::without_trailing_slash(pack_destination)),
+                        fmt_tarball_filename(
+                            package_name,
+                            package_version,
+                            TarballNameStyle::Normalize,
+                        ),
+                    ),
+                );
+                Global::crash();
+            };
             (
                 strings::without_trailing_slash(tarball_destination_dir).len(),
                 tarball_destination_dir.len(),

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -2,7 +2,7 @@ import { file, spawn, write } from "bun";
 import { readTarball } from "bun:internal-for-testing";
 import { beforeEach, describe, expect, test } from "bun:test";
 import { exists, mkdir, rm } from "fs/promises";
-import { bunEnv, bunExe, pack, runBunInstall, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isWindows, pack, runBunInstall, tempDir, tmpdirSync } from "harness";
 import fs from "node:fs/promises";
 import { join } from "path";
 
@@ -395,6 +395,59 @@ describe("flags", () => {
     ]);
 
     expect(async () => await pack(packageDir, bunEnv, "--filename=test.tgz", "--destination=packed")).toThrowError();
+  });
+
+  // PATH_MAX is 4096 on Linux and 1024 on macOS, so this overflows the path buffer on both. Windows'
+  // path buffer is larger than any command line, so the overflow cannot be reached there.
+  describe.skipIf(isWindows)("--destination longer than PATH_MAX", () => {
+    const longName = Buffer.alloc(5000, "d").toString();
+    const packageJson = JSON.stringify({ name: "pack-long-dest", version: "1.0.0" });
+    const expectedError = `error: archive destination name too long: "${longName}/pack-long-dest-1.0.0.tgz"\n`;
+
+    async function packWithDestination(dir: string, destination: string, ...args: string[]) {
+      await using proc = spawn({
+        cmd: [bunExe(), "pm", "pack", ...args, `--destination=${destination}`],
+        cwd: dir,
+        stdout: "pipe",
+        stderr: "pipe",
+        stdin: "ignore",
+        env: bunEnv,
+      });
+      return await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    }
+
+    test.concurrent("is reported as an error", async () => {
+      await using dir = tempDir("pack-long-destination", { "package.json": packageJson });
+
+      const [out, err, exitCode] = await packWithDestination(dir, longName);
+
+      expect(err).toContain(expectedError);
+      expect(out).not.toContain(".tgz");
+      expect(exitCode).toBe(1);
+      expect(await exists(join(dir, "pack-long-dest-1.0.0.tgz"))).toBeFalse();
+    });
+
+    test.concurrent("is reported as an error with --dry-run", async () => {
+      await using dir = tempDir("pack-long-destination-dry-run", { "package.json": packageJson });
+
+      const [out, err, exitCode] = await packWithDestination(dir, `${longName}/`, "--dry-run");
+
+      expect(err).toContain(expectedError);
+      expect(out).not.toContain(".tgz");
+      expect(exitCode).toBe(1);
+    });
+
+    test.concurrent("packs when the path normalizes to one that fits", async () => {
+      await using dir = tempDir("pack-long-destination-normalized", { "package.json": packageJson });
+
+      // `<5000 bytes>/..` resolves back to the package directory.
+      const { out } = await pack(dir, bunEnv, `--destination=${longName}/..`);
+
+      expect(out).toContain(join(dir, "pack-long-dest-1.0.0.tgz"));
+      expect(readTarball(join(dir, "pack-long-dest-1.0.0.tgz")).entries).toMatchObject([
+        { "pathname": "package/package.json" },
+      ]);
+    });
   });
 
   test("--ignore-scripts", async () => {

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -2,7 +2,7 @@ import { file, spawn, write } from "bun";
 import { readTarball } from "bun:internal-for-testing";
 import { beforeEach, describe, expect, test } from "bun:test";
 import { exists, mkdir, rm } from "fs/promises";
-import { bunEnv, bunExe, isWindows, pack, runBunInstall, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isWindows, MAX_PATH_BYTES, pack, runBunInstall, tempDir, tmpdirSync } from "harness";
 import fs from "node:fs/promises";
 import { join } from "path";
 
@@ -397,10 +397,9 @@ describe("flags", () => {
     expect(async () => await pack(packageDir, bunEnv, "--filename=test.tgz", "--destination=packed")).toThrowError();
   });
 
-  // PATH_MAX is 4096 on Linux and 1024 on macOS, so this overflows the path buffer on both. Windows'
-  // path buffer is larger than any command line, so the overflow cannot be reached there.
-  describe.skipIf(isWindows)("--destination longer than PATH_MAX", () => {
-    const longName = Buffer.alloc(5000, "d").toString();
+  // On Windows the path buffer is larger than any command line, so the overflow cannot be reached there.
+  describe.skipIf(isWindows)("--destination longer than the path buffer", () => {
+    const longName = Buffer.alloc(MAX_PATH_BYTES + 1, "d").toString();
     const packageJson = JSON.stringify({ name: "pack-long-dest", version: "1.0.0" });
     const expectedError = `error: archive destination name too long: "${longName}/pack-long-dest-1.0.0.tgz"\n`;
 
@@ -440,7 +439,7 @@ describe("flags", () => {
     test.concurrent("packs when the path normalizes to one that fits", async () => {
       await using dir = tempDir("pack-long-destination-normalized", { "package.json": packageJson });
 
-      // `<5000 bytes>/..` resolves back to the package directory.
+      // `<over-long name>/..` resolves back to the package directory.
       const { out } = await pack(dir, bunEnv, `--destination=${longName}/..`);
 
       expect(out).toContain(join(dir, "pack-long-dest-1.0.0.tgz"));

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -24,6 +24,11 @@ export const isFreeBSD = process.platform === "freebsd";
 export const isAndroid = process.platform === "android";
 export const isPosix = isMacOS || isLinux || isFreeBSD || isAndroid;
 export const isWindows = process.platform === "win32";
+/**
+ * Size of bun's fixed path buffers (`MAX_PATH_BYTES` in `src/bun_core/util.rs`). A path longer than this does not
+ * fit in one, which code taking a path from the user has to report rather than overflow the buffer.
+ */
+export const MAX_PATH_BYTES = isWindows ? 32767 * 3 + 1 : isLinux || isAndroid ? 4096 : 1024;
 export const isIntelMacOS = isMacOS && process.arch === "x64";
 export const isArm64 = process.arch === "arm64";
 export const isDebug = Bun.version.includes("debug");


### PR DESCRIPTION
### Problem
- `bun pm pack --destination=<value longer than the path buffer>` aborts with a crash report instead of an error:
  `panic: range end index 5014 out of range for slice of length 4095` (exit 134). Same with `--dry-run`.
- Cause: `tarball_destination()` in `src/runtime/cli/pack_command.rs` joins the raw `--destination` value into a `PathBuffer` with `resolve_path::join_abs_string_buf`, which is unchecked and indexes past the buffer when the joined directory does not fit.
- The existing `archive destination name too long` error only fires in the narrow window where the directory fits but `/<name>-<version>.tgz` does not (the `write!` after the join is bounds-checked). On Linux with a 15-byte cwd that is a destination of 4060 to 4081 bytes; from 4082 up it panics. macOS has a 1024-byte buffer, so the panic starts much lower there.

### Fix
- Join with `resolve_path::join_abs_string_buf_checked`, which returns `None` instead of overflowing, and report the same `archive destination name too long: "<destination>/<name>-<version>.tgz"` error (exit 1) in that case, the way the `--filename` branch already handles an over-long `--filename`.
- The checked join is the right boundary because it decides on the normalized result: `--destination=<over-long>/..` still packs into the package directory, as it would for a short path, instead of being rejected on raw length.
- The rest of the function is unchanged: a directory that fits but leaves no room for the tarball name still hits the existing `write!` check, and the `dest_buf[dir_end]` access in `pack()` is only reached after that check, so every length now ends in one of the two errors or a packed tarball.
- `test/harness.ts` gains `MAX_PATH_BYTES` (the platform table behind `PathBuffer`); the new tests build their destination from it. #38743 and #38753 each carry a private copy of the same table and can switch to this one.
- Verified with `test/cli/install/bun-pack.test.ts` (`--destination longer than the path buffer`): the error for a normal pack and for `--dry-run` (the two call sites an over-long `--destination` can reach; `bun publish` does not accept the flag), plus the `/..` case above. The three tests fail on the current release (panic) and pass with this change; the whole file (79 tests) passes. They are skipped on Windows, whose path buffer is larger than any command line.
- Also swept destinations of 4040 to 4120 bytes against the debug build: every length exits 1 with one of the two errors.

### Relationship to the other open `tarball_destination` PRs
- This is the smallest piece and is meant to land first. #38739 (resolve relative `--destination`/`--filename` against the invoking directory, a behavior change) rewrites the whole function and contains this PR's `None` arm verbatim; once this lands, its rebase drops that duplicate and its overflow bullet. #38743 only touches the argument lists of the neighbouring error messages. Neither has a test for this overflow.
- #38753 is the same crash one command over (`bun publish <over-long tarball path>`), fixed in `publish_command.rs`.

### Background
- `PathBuffer` is a fixed `[u8; MAX_PATH_BYTES]` scratch buffer (4096 bytes on Linux, 1024 on macOS, about 96 KiB on Windows) that path helpers write into.
- `join_abs_string_buf(cwd, buf, parts)` resolves `parts` against `cwd` (like `path.resolve`) and writes the normalized result into `buf`, assuming it fits. `join_abs_string_buf_checked` is the variant documented for user-controlled parts: it normalizes into a temporary buffer when the input is long and returns `None` if the normalized result is longer than `buf`.
- `Output::err_generic` + `Global::crash()` is how this file reports fatal user errors; `Global::crash()` is `exit(1)`, not an abort.

<details>
<summary>Repro</summary>

```sh
mkdir /tmp/x && cd /tmp/x && echo '{"name":"pack-repro","version":"1.0.0"}' > package.json
bun pm pack --destination="$(head -c 5000 /dev/zero | tr '\0' d)"
# before: panic: range end index 5014 out of range for slice of length 4095 (exit 134)
# after:  error: archive destination name too long: "ddd.../pack-repro-1.0.0.tgz" (exit 1)
```
</details>

<details>
<summary>Earlier revision</summary>

The first push sized the destination with a literal 5000 bytes and had no harness change; the test was then moved onto the shared `MAX_PATH_BYTES` constant. The `pack_command.rs` hunk is unchanged since the first push.
</details>
