### PR TITLE
bun test --isolate: kill module-scope subprocesses of every file at the isolation swap

### DIFF
--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -570,7 +570,11 @@ impl Execution {
 
     fn on_group_completed(global_this: &JSGlobalObject) {
         // SAFETY: bun_vm() returns the live per-thread VM.
-        global_this.bun_vm().as_mut().auto_killer.disable();
+        let vm = global_this.bun_vm().as_mut();
+        // Under --isolate the swap between files kills and clears the tracked set.
+        if !vm.test_isolation_enabled {
+            vm.auto_killer.disable();
+        }
     }
 
     fn on_sequence_started(sequence: &mut ExecutionSequence) {

--- a/test/cli/test/isolation.test.ts
+++ b/test/cli/test/isolation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, setDefaultTimeout, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, normalizeBunSnapshot, tempDir } from "harness";
 import fs from "node:fs";
 import net from "node:net";
+import { join } from "node:path";
 
 // Every case spawns at least one full `bun test --isolate` child; the heavy
 // ones (8-file leak fixtures, 500-2000-export module_info modules) exceed the
@@ -410,6 +411,67 @@ describe.concurrent("bun test --isolate", () => {
     expect(normalizeBunSnapshot(stderr, dir)).toContain("3 pass");
     expect(normalizeBunSnapshot(stderr, dir)).toContain("0 fail");
     expect(exitCode).toBe(0);
+  });
+
+  // Every file spawns a sleeper at module scope (outside any test or hook),
+  // appends its pid to a shared log, and its test asserts that the sleepers
+  // logged by the files that ran before it are gone. The first file's sleeper
+  // is always killed; the third file is what proves the second file's
+  // module-scope sleeper was killed at its isolation swap too. Holds in any
+  // file order, so the same fixture covers a --parallel worker running
+  // several files.
+  const moduleScopeSpawnFile = `
+    import { test, expect } from "bun:test";
+    import fs from "node:fs";
+    const log = process.env.PID_LOG!;
+    const earlier = fs.readFileSync(log, "utf8").split("\\n").filter(Boolean).map(Number);
+    const child = Bun.spawn({ cmd: [process.execPath, "-e", "setInterval(()=>{}, 1e6)"], stdout: "ignore", stderr: "ignore" });
+    fs.appendFileSync(log, child.pid + "\\n");
+    const isAlive = (pid: number) => { try { process.kill(pid, 0); return true; } catch { return false; } };
+    test("module-scope sleepers of the files before this one were killed", async () => {
+      // The swap sends SIGTERM; the sleeper may still be getting reaped.
+      const deadline = Date.now() + 2_000;
+      while (earlier.some(isAlive) && Date.now() < deadline) await Bun.sleep(10);
+      expect(earlier.filter(isAlive)).toEqual([]);
+    });
+  `;
+
+  test.each([
+    ["--isolate", ["--isolate"], {}],
+    // One worker takes all three files (scale-up gated), so the worker's
+    // per-file swap is what has to kill the second and third sleepers.
+    ["--parallel worker", ["--parallel=2"], { BUN_TEST_PARALLEL_SCALE_MS: "60000" }],
+  ])("module-scope subprocesses are killed for every isolated file, not just the first (%s)", async (_, args, env) => {
+    using dir = tempDir("isolate-module-scope-subprocess", {
+      "a.test.ts": moduleScopeSpawnFile,
+      "b.test.ts": moduleScopeSpawnFile,
+      "c.test.ts": moduleScopeSpawnFile,
+      "pids.txt": "",
+    });
+    const log = join(String(dir), "pids.txt");
+    const loggedPids = () => fs.readFileSync(log, "utf8").split("\n").filter(Boolean);
+    try {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", ...args, "./a.test.ts", "./b.test.ts", "./c.test.ts"],
+        env: { ...bunEnv, ...env, PID_LOG: log },
+        cwd: String(dir),
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(normalizeBunSnapshot(stderr, dir)).toContain("3 pass");
+      expect(normalizeBunSnapshot(stderr, dir)).toContain("0 fail");
+      expect(loggedPids()).toHaveLength(3);
+      expect(exitCode).toBe(0);
+    } finally {
+      // Nothing swaps after the last file of a serial run, so its sleeper is
+      // ours to kill, as is anything an unfixed runner leaked.
+      for (const pid of loggedPids()) {
+        try {
+          process.kill(Number(pid));
+        } catch {}
+      }
+    }
   });
 });
 


### PR DESCRIPTION
### Problem
- `bun test --isolate` (and every `--parallel` worker) kills the subprocesses a file left running when it swaps globals between files, but a subprocess spawned at module scope (top level of the file, outside any test or hook) is only killed for the first file of the run. The same spawn in the second and later files outlives the swap and leaks out of the run.
- The killer only registers spawns while `auto_killer.enabled` is set. `--isolate` sets it once at startup (`src/runtime/cli/test_command.rs:2316`; `--parallel` workers do the same in `src/runtime/cli/test/parallel/runner.rs:637`), which is why the first file's module scope is tracked. `Execution::on_group_completed` (`src/runtime/test_runner/Execution.rs:571`) then calls `disable()` after every group of tests, and nothing turns tracking back on until the next group starts, so it is off while the next file's module scope runs. `swap_global_for_test_isolation` (`src/jsc/VirtualMachine.rs:5057`) kills and clears the tracked set, but those spawns were never in it.
- The comment next to the per-file cleanup in `test_command.rs` ("under --isolate ... we need tracking to remain enabled and populated until then") describes the intended behavior; the per-group `disable()` has defeated it since `--isolate` was added in #29354.

### Fix
- `Execution::on_group_completed` leaves the killer enabled when `vm.test_isolation_enabled` is set. Under `--isolate` tracking is then on for the whole run and the swap's kill + clear covers every spawn the file made, at module scope or inside a test. Without `--isolate` nothing changes: tracking is still per group and the set is still cleared per file.
- Correct because it is the documented contract of `--isolate` (docs/test/parallel.mdx: between files Bun closes "subprocesses the file left open") and it is already how the first file of every run behaves; the change makes the later files match it. The swap is the only place that kills the set between files, so keeping the set populated until then has no other consumer.
- Side effect, stated explicitly: a test timeout under `--isolate` kills everything tracked (`Execution::handle_timeout`), so in files 2+ it now also kills that file's module-scope spawns, as it already did in file 1. #38774 makes the timeout kill per group; once both land a timeout no longer kills module-scope spawns in any file and the swap still kills everything. The two diffs touch adjacent functions and do not conflict.
- Module-scope `spawnSync` calls under `--isolate` now wait on the event loop in every file instead of only the first (the blocking fast path in `js_bun_spawn_bindings.rs:1049` is gated on the killer being off); that is the path every `spawnSync` inside a test already takes.
- Considered and not done here: registering subprocesses with the `ActiveHandle` sweep that runs before the swap (`src/runtime/jsc_hooks.rs`), which would let the killer go back to being timeout-only. The swap has used the killer for subprocesses since #29354 and #38774 is reworking the killer's internals, so this PR keeps the one-line policy change and leaves that reshape as a follow-up.
- Test: `test/cli/test/isolation.test.ts`, "module-scope subprocesses are killed for every isolated file, not just the first", run once for serial `--isolate` and once for a single `--parallel` worker running all three files. Each fixture file spawns a sleeper at module scope and logs its pid; its test asserts the sleepers of the files that ran before it are dead, so the third file to run observes the second file's leak. Both variants fail on the unfixed build (one surviving pid, the second file's) and pass with the fix; the existing in-test spawn case and `test-timeout-behavior.test.ts` still pass.

### Background
- `ProcessAutoKiller` (`src/jsc/ProcessAutoKiller.rs`) is a per-VM set of live `Bun.spawn` processes. `Bun.spawn` adds a process to it only while `enabled` is true, exits remove it, and `kill()` SIGTERMs and empties it. `bun test` uses it in two places: a test timeout kills whatever is in the set, and the `--isolate` swap kills the set to clean up after a file.
- An execution group is the unit `bun:test` runs at a time (a test with its hooks, or a batch of concurrent tests). Without `--isolate`, tracking is turned on and off around each group so a timeout only kills processes spawned while tests were running, and the set is cleared at the end of each file.
- The isolation swap (`swap_global_for_test_isolation`) runs after every file under `--isolate`, and after every file inside a `--parallel` worker (workers always isolate). A file's module scope is evaluated before any of its groups start, which is the window in which tracking was off.

<details>
<summary>Earlier revision</summary>

The first push also switched the two startup sites from `auto_killer.enabled = true` to `auto_killer.enable()` so that `ever_enabled` was set before the first group. The only effect was pruning a first-file module-scope process that exits before any test runs slightly earlier (the swap releases it anyway), so those hunks were dropped after self-review and the diff is now the `on_group_completed` change plus the test.
</details>
