### PR TITLE
bun build --no-bundle: exit 1 when an entry point does not resolve

### DIFF
--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -459,14 +459,6 @@ impl<'a> Transpiler<'a> {
     pub fn resolve_entry_point(&mut self, entry_point: &[u8]) -> crate::Result<resolver::Result> {
         match self._resolve_entry_point(entry_point) {
             Ok(r) => Ok(r),
-            // Nothing that long names a directory whose cache could be stale
-            // (and the join below has a PathBuffer to fit `top_level_dir/entry/..` in).
-            Err(err)
-                if self.fs().top_level_dir.len() + entry_point.len() + 4
-                    > bun_paths::MAX_PATH_BYTES =>
-            {
-                Err(err)
-            }
             Err(err) => {
                 let mut cache_bust_buf = bun_paths::PathBuffer::uninit();
 
@@ -477,6 +469,14 @@ impl<'a> Transpiler<'a> {
                 // disjoint mutable borrows of `cache_bust_buf` across `break`,
                 // so compute `busted` directly instead.
                 let busted: bool = 'name: {
+                    // Nothing that long names a directory whose cache could be stale
+                    // (and the join below has a PathBuffer to fit `top_level_dir/entry/..` in).
+                    if self.fs().top_level_dir.len() + entry_point.len() + 4
+                        > bun_paths::MAX_PATH_BYTES
+                    {
+                        break 'name false;
+                    }
+
                     if bun_paths::is_absolute(entry_point) {
                         let dir = bun_paths::resolve_path::dirname::<bun_paths::platform::Auto>(
                             entry_point,

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -469,8 +469,7 @@ impl<'a> Transpiler<'a> {
                 // disjoint mutable borrows of `cache_bust_buf` across `break`,
                 // so compute `busted` directly instead.
                 let busted: bool = 'name: {
-                    // Nothing that long names a directory whose cache could be stale
-                    // (and the join below has a PathBuffer to fit `top_level_dir/entry/..` in).
+                    // `cache_bust_buf` has to fit `top_level_dir/entry_point/..`.
                     if self.fs().top_level_dir.len() + entry_point.len() + 4
                         > bun_paths::MAX_PATH_BYTES
                     {
@@ -2653,8 +2652,6 @@ impl<'a> Transpiler<'a> {
 
             let _reset = bun_ast::StoreResetGuard::new();
 
-            // Failures have to reach the log, not just stderr: `BuildCommand`
-            // decides the exit code from `log.errors`.
             let Ok(result) = self.resolve_entry_point(entry) else {
                 continue;
             };

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -459,6 +459,14 @@ impl<'a> Transpiler<'a> {
     pub fn resolve_entry_point(&mut self, entry_point: &[u8]) -> crate::Result<resolver::Result> {
         match self._resolve_entry_point(entry_point) {
             Ok(r) => Ok(r),
+            // Nothing that long names a directory whose cache could be stale
+            // (and the join below has a PathBuffer to fit `top_level_dir/entry/..` in).
+            Err(err)
+                if self.fs().top_level_dir.len() + entry_point.len() + 4
+                    > bun_paths::MAX_PATH_BYTES =>
+            {
+                Err(err)
+            }
             Err(err) => {
                 let mut cache_bust_buf = bun_paths::PathBuffer::uninit();
 
@@ -469,13 +477,6 @@ impl<'a> Transpiler<'a> {
                 // disjoint mutable borrows of `cache_bust_buf` across `break`,
                 // so compute `busted` directly instead.
                 let busted: bool = 'name: {
-                    // `cache_bust_buf` has to fit `top_level_dir/entry_point/..`.
-                    if self.fs().top_level_dir.len() + entry_point.len() + 4
-                        > bun_paths::MAX_PATH_BYTES
-                    {
-                        break 'name false;
-                    }
-
                     if bun_paths::is_absolute(entry_point) {
                         let dir = bun_paths::resolve_path::dirname::<bun_paths::platform::Auto>(
                             entry_point,
@@ -2661,7 +2662,7 @@ impl<'a> Transpiler<'a> {
                     None,
                     bun_ast::Loc::EMPTY,
                     format_args!(
-                        "\"{}\" is disabled due to \"browser\" field in package.json",
+                        "\"{}\" is disabled due to \"browser\" field in package.json (entry point)",
                         bstr::BStr::new(entry),
                     ),
                 );

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -2643,7 +2643,6 @@ impl<'a> Transpiler<'a> {
         // snapshot entry points so the `&mut self` resolver call
         // does not conflict with the `&self.options` borrow.
         let entries: Vec<Box<[u8]>> = self.options.entry_points.to_vec();
-        let top_level_dir = self.fs().top_level_dir;
 
         for _entry in entries.iter() {
             let entry: &[u8] = if NORMALIZE_ENTRY_POINT {
@@ -2654,26 +2653,20 @@ impl<'a> Transpiler<'a> {
 
             let _reset = bun_ast::StoreResetGuard::new();
 
-            let result = match self.resolver.resolve(
-                top_level_dir,
-                entry,
-                bun_ast::ImportKind::EntryPointBuild,
-            ) {
-                Ok(r) => r,
-                Err(err) => {
-                    bun_core::pretty_error!(
-                        "Error resolving \"{}\": {}\n",
-                        bstr::BStr::new(entry),
-                        err.name(),
-                    );
-                    continue;
-                }
+            // Failures have to reach the log, not just stderr: `BuildCommand`
+            // decides the exit code from `log.errors`.
+            let Ok(result) = self.resolve_entry_point(entry) else {
+                continue;
             };
 
             if result.path_const().is_none() {
-                bun_core::pretty_error!(
-                    "\"{}\" is disabled due to \"browser\" field in package.json.\n",
-                    bstr::BStr::new(entry),
+                self.log_mut().add_error_fmt(
+                    None,
+                    bun_ast::Loc::EMPTY,
+                    format_args!(
+                        "\"{}\" is disabled due to \"browser\" field in package.json",
+                        bstr::BStr::new(entry),
+                    ),
                 );
                 continue;
             }

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -580,10 +580,13 @@ describe.concurrent("modules that fail to print", () => {
   });
 });
 
-describe.concurrent("bun build with an entry point that cannot be resolved", () => {
+// --no-bundle resolves its entry points the same way a bundling build does.
+// It used to print a resolve failure without recording it as a build error,
+// so it still reported "Transpiled file" and exited 0.
+describe.concurrent("bun build --no-bundle entry point resolution", () => {
   async function build(dir: string, ...args: string[]) {
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "build", ...args],
+      cmd: [bunExe(), "build", "--no-bundle", ...args],
       env: bunEnv,
       cwd: dir,
       stdout: "pipe",
@@ -599,51 +602,45 @@ describe.concurrent("bun build with an entry point that cannot be resolved", () 
     exitCode: 1,
   };
 
-  // --no-bundle used to print the resolve failure without recording it as a
-  // build error, so it still reported "Transpiled file" and exited 0.
-  test("--no-bundle exits 1 when the entry point does not exist", async () => {
+  test("exits 1 when the entry point does not exist", async () => {
     using dir = tempDir("build-no-bundle-missing", {});
-    expect(await build(String(dir), "--no-bundle", "missing.ts")).toEqual(missingEntryFailure);
+    expect(await build(String(dir), "missing.ts")).toEqual(missingEntryFailure);
   });
 
-  test("--no-bundle --outfile exits 1 and does not create the output file", async () => {
+  test("--outfile: exits 1 and does not create the output file", async () => {
     using dir = tempDir("build-no-bundle-missing-outfile", {});
-    expect(await build(String(dir), "--no-bundle", "missing.ts", "--outfile", "out.js")).toEqual(missingEntryFailure);
+    expect(await build(String(dir), "missing.ts", "--outfile", "out.js")).toEqual(missingEntryFailure);
     expect(fs.existsSync(path.join(String(dir), "out.js"))).toBe(false);
   });
 
-  test("--no-bundle --outdir: one missing entry point fails the whole build, like bundling does", async () => {
+  test("--outdir: one missing entry point fails the whole build, like bundling does", async () => {
     using dir = tempDir("build-no-bundle-missing-outdir", {
       "present.ts": "export const present: number = 1;\n",
     });
-    expect(await build(String(dir), "--no-bundle", "present.ts", "missing.ts", "--outdir", "out")).toEqual(
-      missingEntryFailure,
-    );
+    expect(await build(String(dir), "present.ts", "missing.ts", "--outdir", "out")).toEqual(missingEntryFailure);
     expect(fs.existsSync(path.join(String(dir), "out", "present.js"))).toBe(false);
   });
 
-  test("--no-bundle exits 1 when the entry point is disabled by the package.json browser field", async () => {
+  test("exits 1 when the entry point is disabled by the package.json browser field", async () => {
     using dir = tempDir("build-no-bundle-browser-disabled", {
       "package.json": JSON.stringify({ name: "pkg", browser: { "./entry.ts": false } }),
       "entry.ts": "export const entry: number = 1;\n",
     });
-    expect(await build(String(dir), "--no-bundle", "--target=browser", "entry.ts")).toEqual({
+    expect(await build(String(dir), "--target=browser", "entry.ts")).toEqual({
       stdout: "",
-      stderr: expect.stringContaining('entry.ts" is disabled due to "browser" field in package.json'),
+      stderr: expect.stringContaining('entry.ts" is disabled due to "browser" field in package.json (entry point)'),
       exitCode: 1,
     });
   });
 
-  // Entry points longer than a path can be skip the retry after busting the
-  // directory cache; that used to skip reporting the failure as well, and the
-  // bundle then crashed with no entry points.
-  test("reports an entry point that is longer than a path can be", async () => {
-    using dir = tempDir("build-long-entry", {});
-    const name = Buffer.alloc(5000, "a").toString() + ".ts";
-    expect(await build(String(dir), name)).toEqual({
-      stdout: "",
-      stderr: expect.stringContaining(`error: ModuleNotFound resolving "${name}" (entry point)`),
-      exitCode: 1,
+  test("resolves an entry point without its extension, like bundling does", async () => {
+    using dir = tempDir("build-no-bundle-extensionless", {
+      "entry.ts": "export const entry: number = 1;\n",
+    });
+    expect(await build(String(dir), "entry")).toEqual({
+      stdout: "export const entry = 1;\n",
+      stderr: "",
+      exitCode: 0,
     });
   });
 });

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -579,3 +579,58 @@ describe.concurrent("modules that fail to print", () => {
     expect(exitCode).toBe(1);
   });
 });
+
+describe.concurrent("bun build --no-bundle with an entry point that cannot be resolved", () => {
+  // The resolve failure used to be printed straight to stderr without being
+  // recorded as a build error, so the command still reported
+  // "Transpiled file" and exited 0.
+  async function build(dir: string, ...args: string[]) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--no-bundle", ...args],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  // Same error line as `bun build missing.ts` without --no-bundle.
+  const missingEntryFailure = {
+    stdout: "",
+    stderr: expect.stringContaining('error: ModuleNotFound resolving "missing.ts" (entry point)'),
+    exitCode: 1,
+  };
+
+  test("exits 1 when the entry point does not exist", async () => {
+    using dir = tempDir("build-no-bundle-missing", {});
+    expect(await build(String(dir), "missing.ts")).toEqual(missingEntryFailure);
+  });
+
+  test("--outfile: exits 1 and does not create the output file", async () => {
+    using dir = tempDir("build-no-bundle-missing-outfile", {});
+    expect(await build(String(dir), "missing.ts", "--outfile", "out.js")).toEqual(missingEntryFailure);
+    expect(fs.existsSync(path.join(String(dir), "out.js"))).toBe(false);
+  });
+
+  test("--outdir: one missing entry point fails the whole build, like bundling does", async () => {
+    using dir = tempDir("build-no-bundle-missing-outdir", {
+      "present.ts": "export const present: number = 1;\n",
+    });
+    expect(await build(String(dir), "present.ts", "missing.ts", "--outdir", "out")).toEqual(missingEntryFailure);
+    expect(fs.existsSync(path.join(String(dir), "out", "present.js"))).toBe(false);
+  });
+
+  test("exits 1 when the entry point is disabled by the package.json browser field", async () => {
+    using dir = tempDir("build-no-bundle-browser-disabled", {
+      "package.json": JSON.stringify({ name: "pkg", browser: { "./entry.ts": false } }),
+      "entry.ts": "export const entry: number = 1;\n",
+    });
+    expect(await build(String(dir), "--target=browser", "entry.ts")).toEqual({
+      stdout: "",
+      stderr: expect.stringContaining('entry.ts" is disabled due to "browser" field in package.json'),
+      exitCode: 1,
+    });
+  });
+});

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -580,13 +580,10 @@ describe.concurrent("modules that fail to print", () => {
   });
 });
 
-describe.concurrent("bun build --no-bundle with an entry point that cannot be resolved", () => {
-  // The resolve failure used to be printed straight to stderr without being
-  // recorded as a build error, so the command still reported
-  // "Transpiled file" and exited 0.
+describe.concurrent("bun build with an entry point that cannot be resolved", () => {
   async function build(dir: string, ...args: string[]) {
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "build", "--no-bundle", ...args],
+      cmd: [bunExe(), "build", ...args],
       env: bunEnv,
       cwd: dir,
       stdout: "pipe",
@@ -596,40 +593,56 @@ describe.concurrent("bun build --no-bundle with an entry point that cannot be re
     return { stdout, stderr, exitCode };
   }
 
-  // Same error line as `bun build missing.ts` without --no-bundle.
   const missingEntryFailure = {
     stdout: "",
     stderr: expect.stringContaining('error: ModuleNotFound resolving "missing.ts" (entry point)'),
     exitCode: 1,
   };
 
-  test("exits 1 when the entry point does not exist", async () => {
+  // --no-bundle used to print the resolve failure without recording it as a
+  // build error, so it still reported "Transpiled file" and exited 0.
+  test("--no-bundle exits 1 when the entry point does not exist", async () => {
     using dir = tempDir("build-no-bundle-missing", {});
-    expect(await build(String(dir), "missing.ts")).toEqual(missingEntryFailure);
+    expect(await build(String(dir), "--no-bundle", "missing.ts")).toEqual(missingEntryFailure);
   });
 
-  test("--outfile: exits 1 and does not create the output file", async () => {
+  test("--no-bundle --outfile exits 1 and does not create the output file", async () => {
     using dir = tempDir("build-no-bundle-missing-outfile", {});
-    expect(await build(String(dir), "missing.ts", "--outfile", "out.js")).toEqual(missingEntryFailure);
+    expect(await build(String(dir), "--no-bundle", "missing.ts", "--outfile", "out.js")).toEqual(missingEntryFailure);
     expect(fs.existsSync(path.join(String(dir), "out.js"))).toBe(false);
   });
 
-  test("--outdir: one missing entry point fails the whole build, like bundling does", async () => {
+  test("--no-bundle --outdir: one missing entry point fails the whole build, like bundling does", async () => {
     using dir = tempDir("build-no-bundle-missing-outdir", {
       "present.ts": "export const present: number = 1;\n",
     });
-    expect(await build(String(dir), "present.ts", "missing.ts", "--outdir", "out")).toEqual(missingEntryFailure);
+    expect(await build(String(dir), "--no-bundle", "present.ts", "missing.ts", "--outdir", "out")).toEqual(
+      missingEntryFailure,
+    );
     expect(fs.existsSync(path.join(String(dir), "out", "present.js"))).toBe(false);
   });
 
-  test("exits 1 when the entry point is disabled by the package.json browser field", async () => {
+  test("--no-bundle exits 1 when the entry point is disabled by the package.json browser field", async () => {
     using dir = tempDir("build-no-bundle-browser-disabled", {
       "package.json": JSON.stringify({ name: "pkg", browser: { "./entry.ts": false } }),
       "entry.ts": "export const entry: number = 1;\n",
     });
-    expect(await build(String(dir), "--target=browser", "entry.ts")).toEqual({
+    expect(await build(String(dir), "--no-bundle", "--target=browser", "entry.ts")).toEqual({
       stdout: "",
       stderr: expect.stringContaining('entry.ts" is disabled due to "browser" field in package.json'),
+      exitCode: 1,
+    });
+  });
+
+  // Entry points longer than a path can be skip the retry after busting the
+  // directory cache; that used to skip reporting the failure as well, and the
+  // bundle then crashed with no entry points.
+  test("reports an entry point that is longer than a path can be", async () => {
+    using dir = tempDir("build-long-entry", {});
+    const name = Buffer.alloc(5000, "a").toString() + ".ts";
+    expect(await build(String(dir), name)).toEqual({
+      stdout: "",
+      stderr: expect.stringContaining(`error: ModuleNotFound resolving "${name}" (entry point)`),
       exitCode: 1,
     });
   });

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -369,6 +369,23 @@ describe("web worker", () => {
       expect(err.message).toBe("5");
       expect(err.error).toBe(null);
     });
+
+    test("names an entry point that does not resolve", async () => {
+      const worker = new Worker("./worker-fixture-does-not-exist.js");
+      const [err] = await once(worker, "error");
+      expect(err.message).toBe(
+        'BuildMessage: ModuleNotFound resolving "./worker-fixture-does-not-exist.js" (entry point)',
+      );
+    });
+
+    // A specifier longer than a path can be skips the retry after busting the
+    // directory cache; that used to skip the report too ("BuildMessage: undefined").
+    test("names an entry point that is longer than a path can be", async () => {
+      const name = Buffer.alloc(5000, "a").toString() + ".js";
+      const worker = new Worker(name);
+      const [err] = await once(worker, "error");
+      expect(err.message).toBe(`BuildMessage: ModuleNotFound resolving "${name}" (entry point)`);
+    });
   });
 
   describe("terminate() races and lifecycle edges", () => {

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -369,23 +369,6 @@ describe("web worker", () => {
       expect(err.message).toBe("5");
       expect(err.error).toBe(null);
     });
-
-    test("names an entry point that does not resolve", async () => {
-      const worker = new Worker("./worker-fixture-does-not-exist.js");
-      const [err] = await once(worker, "error");
-      expect(err.message).toBe(
-        'BuildMessage: ModuleNotFound resolving "./worker-fixture-does-not-exist.js" (entry point)',
-      );
-    });
-
-    // A specifier longer than a path can be skips the retry after busting the
-    // directory cache; that used to skip the report too ("BuildMessage: undefined").
-    test("names an entry point that is longer than a path can be", async () => {
-      const name = Buffer.alloc(5000, "a").toString() + ".js";
-      const worker = new Worker(name);
-      const [err] = await once(worker, "error");
-      expect(err.message).toBe(`BuildMessage: ModuleNotFound resolving "${name}" (entry point)`);
-    });
   });
 
   describe("terminate() races and lifecycle edges", () => {


### PR DESCRIPTION
### Problem
- `bun build --no-bundle missing.ts` prints `Error resolving "missing.ts": ModuleNotFound`, then `Transpiled file in 1ms`, and exits 0. Same with `--outfile` (nothing is written) and with `--outdir` and several entries. Scripts running `bun build --no-bundle` over a file list cannot detect a bad path.
- `bun build missing.ts` (bundling) prints `error: ModuleNotFound resolving "missing.ts" (entry point)` and exits 1.
- Cause: `Transpiler::enqueue_entry_points` (src/bundler/transpiler.rs) resolves each entry point with a bare `resolver.resolve` call and, on failure, writes to stderr with `pretty_error!` and `continue`s without adding anything to the log. The `--no-bundle` branch of `BuildCommand::exec` (src/runtime/cli/build_command.rs, `if log_ref.has_errors()`) only exits 1 when the log has errors, so the build is reported as successful.
- The `"..." is disabled due to "browser" field in package.json` arm a few lines below has the same problem: an entry point disabled by the browser field also exited 0.
- The bare `resolver.resolve` call is also less capable than bundling mode's entry point resolution: `bun build --no-bundle entry` (or `entry.js` for an `entry.ts`, or `lib/util`) fails with the same silent exit 0, while `bun build entry` resolves it.

### Fix
- `enqueue_entry_points` resolves each entry point with `Transpiler::resolve_entry_point`, the helper bundling mode (`BundleV2::enqueue_entry_points_normal`) uses. It records the failure in the log, so the existing `has_errors()` check in `BuildCommand` prints it and exits 1, and the error line is the same in both modes. Because it also retries with a `./` prefix before giving up, extension-less and extension-remapped entries now transpile under `--no-bundle` exactly as they bundle without it.
- The browser-field arm is recorded in the log with `add_error_fmt`, with the same `(entry point)` suffix the other entry point errors carry.
- Why this is the right place: the exit code of `bun build` is derived from the log in both modes. An error that only goes to stderr is invisible to that check, so any failure this path wants to fail the build on has to be logged (same shape as #37036, which did this for print failures one step later in the same path). Logging instead of adding a second exit-code source in `BuildCommand` also keeps the mixed case consistent with bundling: with one good and one missing entry, nothing is written and the command exits 1 in both modes.
- Blast radius: `enqueue_entry_points` is only reached from `Transpiler::transform`, whose only caller is the `--no-bundle` branch of `BuildCommand`. `resolve_entry_point` itself is not modified here. Relative to the replaced call, the only success-path difference is the `./` retry described above; everything else differs only after the first resolve has failed.
- Related open PRs, all of which this one merges independently of: #38391 makes `resolve_entry_point` log for specifiers too long for a path buffer (an earlier revision of this PR carried the same change; dropped in favour of that PR, whose tests also cover Windows and `Bun.build`). #38778 makes `resolve_entry_point` itself reject browser-field-disabled entry points with the message used here; once both are in, the browser-field arm in `enqueue_entry_points` is unreachable and whichever PR lands second deletes it. #35644 makes `--no-bundle --outdir` write files at all; the `--outdir` test here asserts on the exit taken before the write loop, so it holds with and without it.
- Tests: `test/bundler/cli.test.ts`, five cases: missing entry to stdout, with `--outfile`, with `--outdir` plus an existing second entry (nothing written), an entry disabled by the browser field, and `entry` resolving to `entry.ts`. All five fail on the released binary (exit 0 or no output) and pass with the debug build.
- Also run with the debug build: the rest of `test/bundler/cli.test.ts`, `test/regression/issue/{23569,29242,31401}.test.ts`, `test/bundler/transpiler/transpiler-stack-overflow.test.ts`, and the itBundled suites that contain `bundling: false` cases (`esbuild/{default,lower,ts,dce,loader,importstar,importstar_ts}.test.ts`, `bundler_jsx`, `bundler_string`, `bundler_minify_symbol_for`; these pass absolute entry paths through the changed code): 0 failures.

### Background
- `--no-bundle` makes `bun build` transpile each entry point on its own instead of bundling. It takes a separate code path: `Transpiler::transform` in src/bundler/transpiler.rs (resolve the entry points, transpile each one, collect `OutputFile`s), while bundling goes through `BundleV2`.
- The log (`bun_ast::Log`) is the list of build messages shared by the resolver, parser, and printer. `BuildCommand` prints it at the end and uses `log.errors` to decide the exit code; output written straight to stderr is not part of it.
- `Transpiler::resolve_entry_point` resolves an entry point specifier, retries with a `./` prefix if it did not resolve as a package, busts the resolver's directory cache and retries once more, and logs `<error> resolving "<entry>" (entry point)` if it still fails. Bundling mode has used it for entry points all along.
- The package.json `browser` field can map a file to `false`, which tells the resolver the module is disabled for browser targets; the resolver then returns a result with no path.

<details>
<summary>Before / after, and neighbouring bugs not changed here</summary>

```
$ bun build --no-bundle missing.ts; echo exit=$?
Error resolving "missing.ts": ModuleNotFound
Transpiled file in 1ms

exit=0

$ bun build --no-bundle a.ts missing.ts --outdir out; echo exit=$?    # with this change
error: ModuleNotFound resolving "missing.ts" (entry point)
exit=1

$ bun build a.ts missing.ts --outdir out; echo exit=$?                # bundling, unchanged
error: ModuleNotFound resolving "missing.ts" (entry point)
exit=1

$ bun build --no-bundle a; echo exit=$?                               # a.ts exists; with this change
export const a = 1;
exit=0
```

Neighbouring bugs noticed on the way, each owned elsewhere:
- Bundling mode with a browser-field-disabled entry point crashes with zero entry points: #38778.
- `resolve_entry_point` returns without logging for specifiers too long for a path buffer: #38391.
- `bun build --no-bundle <5000-byte name>` panics before reaching the resolver, in `normalize_entry_point_path` -> `fs.abs()`, on main as well: the join primitive is being bounded in #35863, after which this PR's routing makes that case exit 1 too.
- `--no-bundle --outdir` writes nothing at all (`ENOENT: failed to write file '""'`): #35644.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/cli.test.ts

<!-- robobun:evidence:end -->