### PR TITLE
publish: report ENAMETOOLONG for a tarball path that does not fit the path buffer

### DIFF
--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -15,7 +15,7 @@ use bun_install::lockfile::{LoadResult, LoadStep};
 use bun_install::{self as install, Lockfile, Npm, PackageManager, Subcommand};
 use bun_libarchive::lib::{Archive, ArchiveIterator, IteratorResult as ArchiveIterResult};
 use bun_parsers::json as json_mod;
-use bun_paths::resolve_path::{join_abs_string_buf_z, normalize_buf, normalize_buf_z};
+use bun_paths::resolve_path::{join_abs_string_buf_checked, normalize_buf, normalize_buf_z};
 use bun_paths::{self as path, PathBuffer};
 use bun_resolver::fs::FileSystem;
 use bun_sha_hmac as sha;
@@ -141,11 +141,18 @@ impl<'a, const DIRECTORY_PUBLISH: bool> Context<'a, DIRECTORY_PUBLISH> {
         tarball_path: &[u8],
     ) -> Result<Context<'a, DIRECTORY_PUBLISH>, FromTarballError> {
         let mut abs_buf = PathBuffer::uninit();
-        let abs_tarball_path = join_abs_string_buf_z::<path::platform::Auto>(
+        let Some(abs_tarball_path) = join_abs_string_buf_checked::<path::platform::Auto>(
             FileSystem::instance().top_level_dir,
             &mut abs_buf,
             &[tarball_path],
-        );
+        ) else {
+            Output::err(
+                bun_sys::Error::from_code(bun_sys::E::ENAMETOOLONG, bun_sys::Tag::open),
+                "failed to read tarball: '{}'",
+                (bstr::BStr::new(tarball_path),),
+            );
+            Global::crash();
+        };
 
         let tarball_bytes = match File::read_from(Fd::cwd(), abs_tarball_path) {
             Ok(b) => b,
@@ -438,7 +445,7 @@ impl<'a, const DIRECTORY_PUBLISH: bool> Context<'a, DIRECTORY_PUBLISH> {
             command_ctx: ctx,
             package_name,
             package_version,
-            abs_tarball_path: ZStr::boxed(abs_tarball_path.as_bytes()),
+            abs_tarball_path: ZStr::boxed(abs_tarball_path),
             tarball_bytes: tarball_bytes.into(),
             uses_workspaces: false,
             normalized_pkg_info,

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -812,34 +812,62 @@ describe.concurrent("tarball path", () => {
   // for the auth check and the closed port guarantees nothing is contacted.
   const dryRunEnv = { ...env, npm_config_registry: "http://someuser:hunter2@127.0.0.1:1/" };
 
-  function packageDir(name: string) {
-    return tempDir(name, { "package.json": JSON.stringify({ name, version: "1.0.0" }) });
+  function packageDir(dirName: string, packageName: string) {
+    return tempDir(dirName, { "package.json": JSON.stringify({ name: packageName, version: "1.0.0" }) });
   }
 
   // The tarball path is resolved against the package directory (`${dir}/${tarballPath}`) into a
-  // buffer of MAX_PATH_BYTES: 4096 bytes on Linux, 1024 on macOS. On Windows the buffer holds more
-  // than the longest command line the OS accepts, so an argument cannot overflow it.
-  const PATH_BUFFER_BYTES = isLinux ? 4096 : 1024;
-  const tarballPathBytes: [string, (dir: string) => number][] = [
-    ["longer than the path buffer", () => 5000],
-    ["one byte longer than the path buffer once resolved", dir => PATH_BUFFER_BYTES + 1 - Buffer.byteLength(dir + "/")],
-    // Fills the buffer, so it leaves no room for the terminating NUL and is refused when opened.
-    ["as long as the path buffer once resolved", dir => PATH_BUFFER_BYTES - Buffer.byteLength(dir + "/")],
-  ];
+  // buffer of MAX_PATH_BYTES (src/bun_core/util.rs): 4096 bytes on Linux, 1024 on macOS and, on
+  // Windows, the longest possible command line (32767 UTF-16 units) at three UTF-8 bytes per unit.
+  const PATH_BUFFER_BYTES = isWindows ? 32767 * 3 + 1 : isLinux ? 4096 : 1024;
 
-  test.skipIf(isWindows).each(tarballPathBytes)("%s fails with ENAMETOOLONG", async (_, bytes) => {
-    using dir = packageDir("publish-tarball-path-too-long");
-    const tarballPath = Buffer.alloc(bytes(String(dir)), "d").toString();
+  // So on Windows the resolved path only gets that long when it is made of three byte characters.
+  // That goes for the directory too: the argument shares the command line with bun.exe and the
+  // other arguments, and every byte the directory contributes is one the argument does not need.
+  // 150 characters keep the directory within MAX_PATH (260 units), the longest a process can be
+  // started in, and leave about 140 units of the command line for the path of bun.exe.
+  const FILLER = isWindows ? "\u4e00" : "d";
+  const TOO_LONG_DIR = isWindows ? Buffer.alloc(150 * 3, FILLER).toString() : "publish-tarball-path-too-long";
+
+  function nameOfBytes(bytes: number) {
+    const remainder = bytes % Buffer.byteLength(FILLER);
+    return Buffer.alloc(bytes - remainder, FILLER).toString() + Buffer.alloc(remainder, "d").toString();
+  }
+
+  function nameResolvingTo(resolvedBytes: number, dir: string) {
+    return nameOfBytes(resolvedBytes - Buffer.byteLength(dir) - 1);
+  }
+
+  async function expectTooLong(tarballPathFor: (dir: string) => string) {
+    using dir = packageDir(TOO_LONG_DIR, "publish-tarball-path-too-long");
+    const tarballPath = tarballPathFor(String(dir));
+    if (isWindows) {
+      // CreateProcess takes command lines of up to 32767 units, terminating NUL included.
+      expect(`"${bunExe()}" publish ${tarballPath} --dry-run\0`.length).toBeLessThanOrEqual(32767);
+    }
 
     const { err, exitCode } = await publish(dryRunEnv, String(dir), tarballPath, "--dry-run");
 
     expect(err).toContain(`ENAMETOOLONG: File name too long: failed to read tarball: '${tarballPath}'`);
     expect(exitCode).toBe(1);
-  });
+  }
+
+  test("one byte longer than the path buffer once resolved fails with ENAMETOOLONG", () =>
+    expectTooLong(dir => nameResolvingTo(PATH_BUFFER_BYTES + 1, dir)));
+
+  // Neither of these works on Windows: an argument longer than the whole buffer does not fit in a
+  // command line, and a path that fills the buffer exactly is refused by the open rather than the
+  // join, which on Windows currently reports it as ENOSYS (it takes ENAMETOOLONG's number from the
+  // C runtime, where it is a different one than in bun's errno table).
+  test.skipIf(isWindows).each([
+    ["longer than the path buffer", () => nameOfBytes(5000)],
+    // Leaves no room for the terminating NUL.
+    ["as long as the path buffer once resolved", (dir: string) => nameResolvingTo(PATH_BUFFER_BYTES, dir)],
+  ])("%s fails with ENAMETOOLONG", (_, tarballPathFor) => expectTooLong(tarballPathFor));
 
   // What has to fit the buffer is the resolved path, not the argument as written.
   test("that only fits the path buffer once resolved is read", async () => {
-    using dir = packageDir("publish-tarball-path-resolved");
+    using dir = packageDir("publish-tarball-path-resolved", "publish-tarball-path-resolved");
     await pack(String(dir), env);
     const tarballPath = Buffer.alloc(5000, "x/../").toString() + "publish-tarball-path-resolved-1.0.0.tgz";
 

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -807,6 +807,50 @@ describe("--dry-run", async () => {
   });
 });
 
+describe.concurrent("tarball path", () => {
+  // --dry-run stops before the first request, so credentials in the registry url are enough
+  // for the auth check and the closed port guarantees nothing is contacted.
+  const dryRunEnv = { ...env, npm_config_registry: "http://someuser:hunter2@127.0.0.1:1/" };
+
+  function packageDir(name: string) {
+    return tempDir(name, { "package.json": JSON.stringify({ name, version: "1.0.0" }) });
+  }
+
+  // The tarball path is resolved against the package directory (`${dir}/${tarballPath}`) into a
+  // buffer of MAX_PATH_BYTES: 4096 bytes on Linux, 1024 on macOS. On Windows the buffer holds more
+  // than the longest command line the OS accepts, so an argument cannot overflow it.
+  const PATH_BUFFER_BYTES = isLinux ? 4096 : 1024;
+  const tarballPathBytes: [string, (dir: string) => number][] = [
+    ["longer than the path buffer", () => 5000],
+    ["one byte longer than the path buffer once resolved", dir => PATH_BUFFER_BYTES + 1 - Buffer.byteLength(dir + "/")],
+    // Fills the buffer, so it leaves no room for the terminating NUL and is refused when opened.
+    ["as long as the path buffer once resolved", dir => PATH_BUFFER_BYTES - Buffer.byteLength(dir + "/")],
+  ];
+
+  test.skipIf(isWindows).each(tarballPathBytes)("%s fails with ENAMETOOLONG", async (_, bytes) => {
+    using dir = packageDir("publish-tarball-path-too-long");
+    const tarballPath = Buffer.alloc(bytes(String(dir)), "d").toString();
+
+    const { err, exitCode } = await publish(dryRunEnv, String(dir), tarballPath, "--dry-run");
+
+    expect(err).toContain(`ENAMETOOLONG: File name too long: failed to read tarball: '${tarballPath}'`);
+    expect(exitCode).toBe(1);
+  });
+
+  // What has to fit the buffer is the resolved path, not the argument as written.
+  test("that only fits the path buffer once resolved is read", async () => {
+    using dir = packageDir("publish-tarball-path-resolved");
+    await pack(String(dir), env);
+    const tarballPath = Buffer.alloc(5000, "x/../").toString() + "publish-tarball-path-resolved-1.0.0.tgz";
+
+    const { out, err, exitCode } = await publish(dryRunEnv, String(dir), tarballPath, "--dry-run");
+
+    expect(err).not.toContain("error:");
+    expect(out).toContain(" + publish-tarball-path-resolved@1.0.0 (dry-run)");
+    expect(exitCode).toBe(0);
+  });
+});
+
 describe("lifecycle scripts", async () => {
   const script = `const fs = require("fs");
     fs.writeFileSync(process.argv[2] + ".txt", \`


### PR DESCRIPTION
### Problem
- `bun publish <tarball>` aborts with a crash report when the tarball argument does not fit the path buffer. `bun publish "$(head -c 5000 /dev/zero | tr '\0' d).tgz" --dry-run` prints `panic: range end index 5017 out of range for slice of length 4095` and exits 134.
- An argument whose resolved path is exactly the buffer size panics one line later instead, on the NUL terminator write: `panic: index out of bounds: the len is 4096 but the index is 4096`.
- Cause: `Context::from_tarball_path` (src/runtime/cli/publish_command.rs:144) resolves the raw positional with `join_abs_string_buf_z` into a `PathBuffer`. That helper assumes the result fits and indexes past the buffer when it does not.
- Found by reading the code while looking at the neighbouring pack code; there is no issue or crash report for it that I know of. The site has been like this since `bun publish` was added. It is reachable on every platform: on Windows the buffer is sized for the longest command line as UTF-8, so an argument of three byte characters overflows it as well (`panic: range end index 98303 out of range for slice of length 98302`, exit code 3, reproduced on Windows Server 2019 with the current canary).
- One byte shorter than the buffer already fails cleanly today, because the open wrapper rejects it: `ENAMETOOLONG: File name too long: failed to read tarball: '...' (open)`, exit 1. Only the lengths past that point crash.

### Fix
- Resolve the argument with `join_abs_string_buf_checked`, which returns `None` when the normalized result does not fit, and in that case report `ENAMETOOLONG` through the existing `failed to read tarball` error and exit 1.
- Correct because the join buffer and the open wrapper's limit are the same constant (`MAX_PATH_BYTES`): a resolved path that does not fit the buffer is exactly a path `File::read_from` would have refused with `ENAMETOOLONG` (`bun_sys::openat_a` synthesizes that errno for `len >= MAX_PATH_BYTES` before calling the OS). Reporting it one layer earlier gives the same message the lengths that already fail today get, so what the user sees no longer depends on which layer happened to catch the overflow. `build_command.rs` builds the same error for an over-long asset path.
- The checked helper bounds the normalized path, not the argument as written, so `x/../x/../.../pkg.tgz` longer than the buffer still resolves and publishes (as before). The test pins that, so a plain length check on the argument is not an acceptable fix.
- `File::read_from` takes `&[u8]` and the context stores a `ZStr::boxed` copy, so nothing needed the NUL-terminated `_z` flavour; the unchecked join was the only thing providing it.
- Relation to the open PRs in this area: #35863 bounds the unchecked primitive itself and makes it return an empty path on overflow, which this site would then report as `ENOENT` for an empty path; this change keeps `ENAMETOOLONG` for it, so the two are complementary and either order works. #38704 (resolve against the invoking directory) and #38784 (bin and files entries) touch the same import line and the same test file; the conflicts are textual. #38749 adds a shared `MAX_PATH_BYTES` to the test harness; this test keeps a local constant rather than adding a competing export, and can switch once that lands.
- Verified with test/cli/install/bun-publish.test.ts, `describe("tarball path")`:
  - a resolved path one byte longer than the buffer reports `ENAMETOOLONG ... failed to read tarball` and exits 1 on every platform. On Windows the argument and the directory it is resolved against are made of three byte characters; the test asserts the command line stays within the 32767 units CreateProcess accepts (about 140 units are left for the path of bun.exe).
  - a 5000 byte argument and a resolved path exactly the buffer size do the same; POSIX only, because an argument longer than the Windows buffer does not fit in a command line, and the exact fit case is refused by the open wrapper, which on Windows reports it as `ENOSYS` today (it takes the errno number from the C runtime, whose numbering differs from bun's table; pre-existing and reported separately, this change uses bun's own constant and is not affected).
  - an over-long argument that normalizes down is read and dry-run published (passes before and after).
  - Linux: the three error cases fail on the unfixed binary with the panics quoted above (output below) and pass with the fix. Windows Server 2019 x64: the shared case fails on the current canary with the panic quoted above and passes with this branch built there; the two POSIX cases skip.
- The rest of the file passes with the debug build, apart from the pre-existing lifecycle scripts test hitting the 5 s default timeout on this machine (six debug bun spawns at about 1.1 s each) and taking verdaccio down for the tests after it; unrelated to this change.

### Background
- `PathBuffer` / `MAX_PATH_BYTES`: bun resolves paths into fixed stack buffers (4096 bytes on Linux, 1024 on macOS, 32767 * 3 + 1 on Windows, i.e. the longest UTF-16 command line at three UTF-8 bytes per unit) instead of allocating. The unchecked `join_abs_string_buf*` helpers are for parts known to fit; `join_abs_string_buf_checked` is the variant documented for user-controlled parts of arbitrary length. It normalizes into a heap scratch when the concatenation is too big and only then checks whether the result fits, which is why `..` segments still work. When the input would have fit anyway it takes the same path as the unchecked helper.
- `bun_sys::openat_a` copies a `&[u8]` path into a `PathBuffer` to NUL terminate it and returns a synthesized `ENAMETOOLONG` with syscall tag `open` when `len >= MAX_PATH_BYTES`. `Output::err` prints a `bun_sys::Error` as `<errno>: <description>: <message> (<syscall>)`, which is the format the tests match.
- `Global::crash()` is the CLI's print-an-error-and-exit-1 helper used by every other error path in `from_tarball_path`.

<details>
<summary>New tests on the unfixed binary (Linux)</summary>

```
(fail) tarball path > longer than the path buffer fails with ENAMETOOLONG
  panic: range end index 5041 out of range for slice of length 4095
(fail) tarball path > one byte longer than the path buffer once resolved fails with ENAMETOOLONG
  panic: range end index 4096 out of range for slice of length 4095
(fail) tarball path > as long as the path buffer once resolved fails with ENAMETOOLONG
  panic: index out of bounds: the len is 4096 but the index is 4096
(pass) tarball path > that only fits the path buffer once resolved is read
```

5041 rather than the 5017 in the report above because the test resolves against a longer temporary directory.

</details>

<details>
<summary>Shared case on Windows Server 2019 x64</summary>

Directory: 195 UTF-16 units, 495 bytes. Argument: 32603 units, 97807 bytes. Resolved path: 98303 bytes against a 98302 byte buffer.

```
canary 1.4.0-canary.1 (39fb3c103):
  panic: range end index 98303 out of range for slice of length 98302   (exit code 3)
this branch (debug build):
  ENAMETOOLONG: File name too long: failed to read tarball: '...' (open)   (exit code 1)
same argument one character shorter (resolved path exactly 98302 bytes), this branch:
  ENOSYS: Function not implemented: failed to read tarball: '...' (open)   (the open wrapper's pre-existing errno mix-up, not covered by the test)
```

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-publish.test.ts

<!-- robobun:evidence:end -->