### PR TITLE
install: import pnpm-workspace.yaml even without a migratable pnpm-lock.yaml

### DIFF
--- a/docs/pm/cli/install.mdx
+++ b/docs/pm/cli/install.mdx
@@ -531,7 +531,7 @@ The migration process handles:
 
 ### Workspace Configuration
 
-When a `pnpm-workspace.yaml` file exists, Bun migrates workspace settings to your root `package.json`:
+When a `pnpm-workspace.yaml` file exists, Bun migrates workspace settings to your root `package.json`. This happens together with the lockfile migration, and also when there is no `pnpm-lock.yaml` to migrate (it was never committed, or it is too old to convert), as long as `bun.lock` does not exist yet and the root `package.json` has no `workspaces` field of its own:
 
 ```yaml pnpm-workspace.yaml icon="file-code"
 packages:
@@ -596,7 +596,7 @@ Bun migrates the following pnpm configuration from both `pnpm-lock.yaml` and `pn
 - All catalog entries referenced by dependencies must exist in the catalogs definition
 - Every workspace in `pnpm-lock.yaml` must have its `package.json` on disk (in Docker, copy them in before `bun install`)
 - Relative `link:` dependencies and git dependencies with a sub-directory (`resolution.path`) are not supported
-- If migration fails for any of these reasons, Bun prints why and resolves from scratch instead
+- If migration fails for any of these reasons, Bun prints why and resolves from scratch instead. The `pnpm-workspace.yaml` settings above are still migrated, so workspaces, catalogs and overrides are not lost
 
 After migration, you can safely remove `pnpm-lock.yaml` and `pnpm-workspace.yaml` files.
 

--- a/docs/pm/isolated-installs.mdx
+++ b/docs/pm/isolated-installs.mdx
@@ -207,12 +207,14 @@ bun install --linker isolated
 Isolated installs are conceptually similar to pnpm, so migration is direct:
 
 ```bash terminal icon="terminal"
-# Remove pnpm files
-rm -rf node_modules pnpm-lock.yaml
+# Remove pnpm's node_modules
+rm -rf node_modules
 
 # Install with Bun's isolated linker
 bun install --linker isolated
 ```
+
+Keep `pnpm-lock.yaml` around for this first install: Bun converts it to `bun.lock`, so you keep the versions pnpm had resolved. The workspace list, catalogs and overrides in `pnpm-workspace.yaml` are moved into the root `package.json` whether or not a `pnpm-lock.yaml` is present. See [pnpm migration](/pm/cli/install#pnpm-migration) for what is converted.
 
 The main difference is that Bun uses symlinks in `node_modules` while pnpm uses a global store with symlinks.
 

--- a/docs/pm/isolated-installs.mdx
+++ b/docs/pm/isolated-installs.mdx
@@ -214,7 +214,7 @@ rm -rf node_modules
 bun install --linker isolated
 ```
 
-Keep `pnpm-lock.yaml` around for this first install: Bun converts it to `bun.lock`, so you keep the versions pnpm had resolved. The workspace list, catalogs and overrides in `pnpm-workspace.yaml` are moved into the root `package.json` whether or not a `pnpm-lock.yaml` is present. See [pnpm migration](/pm/cli/install#pnpm-migration) for what is converted.
+Keep `pnpm-lock.yaml` around for this first install: Bun converts it to `bun.lock`, so you keep the versions pnpm had resolved. The same first install (no `bun.lock` yet, no `workspaces` field in the root `package.json`) also moves the workspace list, catalogs and overrides from `pnpm-workspace.yaml` into the root `package.json`, with or without a `pnpm-lock.yaml`. See [pnpm migration](/pm/cli/install#pnpm-migration) for what is converted.
 
 The main difference is that Bun uses symlinks in `node_modules` while pnpm uses a global store with symlinks.
 

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -1937,9 +1937,7 @@ fn create_new_lockfile_and_enqueue(
         Global::crash();
     }
 
-    // A loaded lockfile already describes the project (a migrated
-    // pnpm-lock.yaml imports pnpm-workspace.yaml itself); without one, the
-    // package.json read below is all the install has to go on.
+    // A loaded lockfile already describes the project; a migrated pnpm-lock.yaml imports the yaml itself.
     if !matches!(load_result, lockfile::LoadResult::Ok { .. }) {
         crate::pnpm::migrate_pnpm_workspace_config(manager)?;
     }

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -1937,6 +1937,13 @@ fn create_new_lockfile_and_enqueue(
         Global::crash();
     }
 
+    // A loaded lockfile already describes the project (a migrated
+    // pnpm-lock.yaml imports pnpm-workspace.yaml itself); without one, the
+    // package.json read below is all the install has to go on.
+    if !matches!(load_result, lockfile::LoadResult::Ok { .. }) {
+        crate::pnpm::migrate_pnpm_workspace_config(manager)?;
+    }
+
     // SAFETY: `manager.log` is a non-null backref to the CLI log set at init().
     let root_package_json_entry = match manager.workspace_package_json_cache.get_with_path(
         manager.log_mut(),

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -486,12 +486,12 @@ fn update_package_json_and_install_with_manager_with_updates(
     // The Smarter™ approach is you resolve ahead of time and write to disk once!
     // But, turns out that's slower in any case where more than one package has to be resolved (most of the time!)
     // Concurrent network requests are faster than doing one and then waiting until the next batch
-    let new_package_json_source: Vec<u8> = package_json_writer
-        .ctx
-        .written_without_trailing_zero()
-        .to_vec();
-    // The cache entry (`Cow<'static, [u8]>`) outlives this stack frame, so it needs its own copy.
-    current_package_json.source.contents = Cow::Owned(new_package_json_source.clone());
+    current_package_json.source.contents = Cow::Owned(
+        package_json_writer
+            .ctx
+            .written_without_trailing_zero()
+            .to_vec(),
+    );
     // The edits above went into a promoted copy
     // (`current_package_json_root`), so re-parse the
     // printed source so the cached AST (consumed by `FolderResolver` for workspace
@@ -664,40 +664,36 @@ fn update_package_json_and_install_with_manager_with_updates(
     }
 
     if manager.options.do_.contains(Do::WRITE_PACKAGE_JSON) {
-        let (source, path): (&[u8], &ZStr) =
-            if matches!(manager.options.patch_features, PatchFeatures::Commit { .. }) {
-                'source_and_path: {
-                    let root_package_json_entry = match manager
-                        .workspace_package_json_cache
-                        .get_with_path(
-                            manager.log_mut(),
-                            root_package_json_path.as_bytes(),
-                            GetJSONOptions::default(),
-                        )
-                        .unwrap()
-                    {
-                        Ok(e) => e,
-                        Err(err) => {
-                            Output::err(
-                                err,
-                                "failed to read/parse package.json at '{s}'",
-                                (BStr::new(root_package_json_path.as_bytes()),),
-                            );
-                            Global::exit(1);
-                        }
-                    };
-
-                    break 'source_and_path (
-                        &root_package_json_entry.source.contents,
-                        root_package_json_path,
-                    );
-                }
-            } else {
-                (
-                    &new_package_json_source,
-                    manager.original_package_json_path.as_zstr(),
-                )
-            };
+        // `bun patch --commit` records the patch in the root package.json even
+        // when run from a workspace member; everything else edited the cwd's.
+        let path: &ZStr = if matches!(manager.options.patch_features, PatchFeatures::Commit { .. })
+        {
+            root_package_json_path
+        } else {
+            manager.original_package_json_path.as_zstr()
+        };
+        // The cache entry, not the text printed before the install: a pnpm
+        // migration during `install_with_manager` edits the root entry too.
+        let entry = match manager
+            .workspace_package_json_cache
+            .get_with_path(
+                manager.log_mut(),
+                path.as_bytes(),
+                GetJSONOptions::default(),
+            )
+            .unwrap()
+        {
+            Ok(entry) => entry,
+            Err(err) => {
+                Output::err(
+                    err,
+                    "failed to read/parse package.json at '{s}'",
+                    (BStr::new(path.as_bytes()),),
+                );
+                Global::exit(1);
+            }
+        };
+        let source: &[u8] = &entry.source.contents;
 
         // Now that we've run the install step
         // We can save our in-memory package.json to disk

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -287,9 +287,18 @@ fn update_package_json_and_install_with_manager_with_updates(
 
     add_catalog::prepare(manager, &updates);
 
+    // Loads the lockfile, and migrating one rewrites the cached root package.json: do it before reading the entry.
+    let patch_commit: Option<PatchCommitResult> =
+        if matches!(manager.options.patch_features, PatchFeatures::Commit { .. }) {
+            let mut pathbuf = PathBuffer::uninit();
+            patch_package::do_patch_commit(manager, &mut pathbuf, log_level)?
+        } else {
+            None
+        };
+
     // reshaped for borrowck — `get_with_path` returns `&mut MapEntry`
     // borrowed from `manager.workspace_package_json_cache`, but we then need
-    // `&mut *manager` for `PackageJSONEditor::edit` / `do_patch_commit` while still
+    // `&mut *manager` for `PackageJSONEditor::edit` while still
     // holding the entry. Demote to `*mut MapEntry` and re-
     // borrow at point of use. The cache map is not mutated again until the
     // next `get_with_path` call below, so the pointer remains valid.
@@ -329,8 +338,7 @@ fn update_package_json_and_install_with_manager_with_updates(
         };
     // SAFETY: see note above — pointer into `manager.workspace_package_json_cache`,
     // valid until the next `get_with_path`. No `&mut manager.workspace_package_json_cache`
-    // is taken across this borrow; `PackageJSONEditor` and `do_patch_commit` touch only
-    // disjoint manager fields.
+    // is taken across this borrow; `PackageJSONEditor` touches only disjoint manager fields.
     let current_package_json: &mut MapEntry = unsafe { &mut *current_package_json_ptr };
     let mut current_package_json_root: bun_ast::Expr = current_package_json.root;
     let current_package_json_indent = current_package_json.indentation;
@@ -428,23 +436,17 @@ fn update_package_json_and_install_with_manager_with_updates(
             }
         }
         _ => {
-            if matches!(manager.options.patch_features, PatchFeatures::Commit { .. }) {
-                let mut pathbuf = PathBuffer::uninit();
-                if let Some(stuff) =
-                    patch_package::do_patch_commit(manager, &mut pathbuf, log_level)?
-                {
-                    // we're inside a workspace package, we need to edit the
-                    // root json, not the `current_package_json`
-                    if stuff.not_in_workspace_root {
-                        not_in_workspace_root = Some(stuff);
-                    } else {
-                        PackageJSONEditor::edit_patched_dependencies(
-                            manager,
-                            &mut current_package_json_root,
-                            &stuff.patch_key,
-                            &stuff.patchfile_path,
-                        )?;
-                    }
+            if let Some(stuff) = patch_commit {
+                // Inside a workspace package the root package.json is edited below, not `current_package_json`.
+                if stuff.not_in_workspace_root {
+                    not_in_workspace_root = Some(stuff);
+                } else {
+                    PackageJSONEditor::edit_patched_dependencies(
+                        manager,
+                        &mut current_package_json_root,
+                        &stuff.patch_key,
+                        &stuff.patchfile_path,
+                    )?;
                 }
             }
         }

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -664,16 +664,14 @@ fn update_package_json_and_install_with_manager_with_updates(
     }
 
     if manager.options.do_.contains(Do::WRITE_PACKAGE_JSON) {
-        // `bun patch --commit` records the patch in the root package.json even
-        // when run from a workspace member; everything else edited the cwd's.
+        // `bun patch --commit` records the patch in the root package.json, even when run from a workspace.
         let path: &ZStr = if matches!(manager.options.patch_features, PatchFeatures::Commit { .. })
         {
             root_package_json_path
         } else {
             manager.original_package_json_path.as_zstr()
         };
-        // The cache entry, not the text printed before the install: a pnpm
-        // migration during `install_with_manager` edits the root entry too.
+        // Written from the cache entry: a pnpm migration inside `install_with_manager` may have edited it since.
         let entry = match manager
             .workspace_package_json_cache
             .get_with_path(

--- a/src/install/pnpm.rs
+++ b/src/install/pnpm.rs
@@ -2349,10 +2349,7 @@ fn rewrite_bare_patch_keys(
     Ok(())
 }
 
-/// Without a pnpm-lock.yaml to migrate (never committed, or older than
-/// `migrate_pnpm_lockfile` accepts) the install resolves from package.json
-/// alone, which turns a pnpm monorepo into a single package. A root
-/// package.json that already declares `workspaces` is treated as migrated.
+/// Imports pnpm-workspace.yaml when no pnpm-lock.yaml was migrated; a root `workspaces` field means it already was.
 pub(crate) fn migrate_pnpm_workspace_config(
     manager: &mut PackageManager,
 ) -> Result<(), AllocError> {
@@ -2369,11 +2366,7 @@ pub(crate) fn migrate_pnpm_workspace_config(
     update_package_json_after_migration(manager, log, Fd::cwd(), &StringArrayHashMap::new())
 }
 
-/// Moves the configuration pnpm reads from package.json's `pnpm` field and
-/// from pnpm-workspace.yaml (workspace globs, catalogs, overrides, patched
-/// dependencies) into the package.json fields `bun install` reads.
-/// `patches` maps the bare `name` patch keys the lockfile resolved to their
-/// versions; it is empty when there is no lockfile.
+/// Moves the settings pnpm reads from package.json `pnpm.*` and pnpm-workspace.yaml into the fields bun reads.
 fn update_package_json_after_migration(
     manager: &mut PackageManager,
     log: &mut bun_ast::Log,
@@ -2538,9 +2531,7 @@ fn update_package_json_after_migration(
 
     match sys::File::read_from(Fd::cwd(), b"pnpm-workspace.yaml") {
         Ok(contents) => 'read_pnpm_workspace_yaml: {
-            // The yaml `Expr`s spliced into `json` below borrow the source text
-            // (plain scalars) and the parse arena (quoted and block scalars), so
-            // both live in `bump` until `json` has been printed.
+            // Quoted and block scalars are copied into the parse arena, so it has to outlive the print below.
             let contents: &[u8] = bump.alloc_slice_copy(&contents);
             let yaml_source = bun_ast::Source::init_path_string(b"pnpm-workspace.yaml", contents);
             let Ok(ws_root) = bun_parsers::yaml::YAML::parse(
@@ -2732,9 +2723,7 @@ fn update_package_json_after_migration(
         return Ok(());
     }
 
-    // The nodes spliced into `json` above live in `bump` and the thread-local
-    // AST store; re-parsing the printed source leaves the cache entry owning
-    // everything it points at, as the rest of the install expects.
+    // The spliced-in nodes live in `bump` and the AST store; re-parse so the cache entry owns its tree.
     print_package_json_into_cache_entry(root_pkg_json, json);
     if let Err(err) = root_pkg_json.reparse_root(log) {
         bun_core::pretty_errorln!("package.json failed to parse due to error {}", err.name());
@@ -2742,8 +2731,7 @@ fn update_package_json_after_migration(
     }
 
     let moved = moved.join(", ");
-    // The install that follows resolves from the updated entry, so a bun.lock
-    // saved after a failed write here would not match the package.json on disk.
+    // Continuing would save a bun.lock that does not match the package.json left on disk.
     if let Err(err) = sys::File::write_file(
         dir,
         bun_core::zstr!("package.json"),

--- a/src/install/pnpm.rs
+++ b/src/install/pnpm.rs
@@ -6,7 +6,7 @@ use bun_alloc::AllocError;
 use bun_collections::StringArrayHashMap;
 
 use bun_ast::{self, self as js_ast, E, Expr, ExprData, G};
-use bun_core::{Global, strings};
+use bun_core::{Global, Output, strings};
 use bun_semver as semver;
 use bun_semver::{ExternalString, String};
 use bun_sys::{self as sys, Fd};
@@ -2741,16 +2741,19 @@ fn update_package_json_after_migration(
         Global::crash();
     }
 
-    if sys::File::write_file(
+    let moved = moved.join(", ");
+    // The install that follows resolves from the updated entry, so a bun.lock
+    // saved after a failed write here would not match the package.json on disk.
+    if let Err(err) = sys::File::write_file(
         dir,
         bun_core::zstr!("package.json"),
         root_pkg_json.source.contents(),
-    )
-    .is_ok()
-        && !moved.is_empty()
-        && !silent
-    {
-        bun_core::pretty_errorln!("<d>moved {} in <r><green>package.json<r>", moved.join(", "));
+    ) {
+        Output::err(err, "failed to move {} in package.json", (&moved,));
+        Global::crash();
+    }
+    if !silent {
+        bun_core::pretty_errorln!("<d>moved {} in <r><green>package.json<r>", moved);
     }
 
     Ok(())

--- a/src/install/pnpm.rs
+++ b/src/install/pnpm.rs
@@ -6,7 +6,7 @@ use bun_alloc::AllocError;
 use bun_collections::StringArrayHashMap;
 
 use bun_ast::{self, self as js_ast, E, Expr, ExprData, G};
-use bun_core::strings;
+use bun_core::{Global, strings};
 use bun_semver as semver;
 use bun_semver::{ExternalString, String};
 use bun_sys::{self as sys, Fd};
@@ -17,6 +17,7 @@ use crate::external_slice::ExternalSlice;
 use crate::integrity::Integrity;
 use crate::lockfile::{self, LoadResult, LoadResultOk, Lockfile};
 use crate::npm::{self};
+use crate::package_manager_real::update_package_json_and_install::print_package_json_into_cache_entry;
 use crate::repository::Repository;
 use crate::resolution::{self, Resolution, TaggedValue};
 use crate::{DependencyID, INVALID_PACKAGE_ID, PackageID, PackageManager};
@@ -175,6 +176,25 @@ fn collect_patch_paths(
     Ok(())
 }
 
+fn root_package_json<'a>(
+    manager: &'a mut PackageManager,
+    log: &mut bun_ast::Log,
+) -> Option<&'a mut crate::WorkspacePackageJsonCacheEntry> {
+    let mut pkg_json_path = bun_paths::AutoAbsPath::init_top_level_dir();
+    let _ = pkg_json_path.append(b"package.json"); // OOM/capacity error is non-actionable here
+    match manager.workspace_package_json_cache.get_with_path(
+        log,
+        pkg_json_path.slice(),
+        crate::GetJsonOptions {
+            guess_indentation: true,
+            ..Default::default()
+        },
+    ) {
+        crate::GetJsonResult::Entry(entry) => Some(entry),
+        crate::GetJsonResult::ReadErr(_) | crate::GetJsonResult::ParseErr(_) => None,
+    }
+}
+
 /// Current pnpm records only the patch hash in the lockfile; the patch file path lives in the config.
 fn read_config_patch_paths(
     manager: &mut PackageManager,
@@ -182,12 +202,7 @@ fn read_config_patch_paths(
 ) -> Result<StringArrayHashMap<Box<[u8]>>, AllocError> {
     let mut paths: StringArrayHashMap<Box<[u8]>> = StringArrayHashMap::new();
 
-    let mut pkg_json_path = bun_paths::AutoAbsPath::init_top_level_dir();
-    let _ = pkg_json_path.append(b"package.json");
-    if let crate::GetJsonResult::Entry(pkg_json) = manager
-        .workspace_package_json_cache
-        .get_with_path(log, pkg_json_path.slice(), Default::default())
-    {
+    if let Some(pkg_json) = root_package_json(manager, log) {
         if let Some(patched) = pkg_json
             .root
             .get(b"pnpm")
@@ -2327,40 +2342,49 @@ fn rewrite_bare_patch_keys(
             bstr::BStr::new(&**res_str)
         )
         .map_err(|_| AllocError)?;
-        // Interned into the DATA_STORE backing the cached package.json Expr tree, which outlives this fn.
+        // Lives in the AST store like the key node below; nothing resets it before the caller prints the tree.
         let interned: &[u8] = js_ast::data_store_dupe_str(join_buf.as_slice());
         prop.key = Some(Expr::init(E::EString::init(interned), bun_ast::Loc::EMPTY));
     }
     Ok(())
 }
 
-/// Updates package.json with workspace and catalog information after migration
+/// Without a pnpm-lock.yaml to migrate (never committed, or older than
+/// `migrate_pnpm_lockfile` accepts) the install resolves from package.json
+/// alone, which turns a pnpm monorepo into a single package. A root
+/// package.json that already declares `workspaces` is treated as migrated.
+pub(crate) fn migrate_pnpm_workspace_config(
+    manager: &mut PackageManager,
+) -> Result<(), AllocError> {
+    if !sys::exists_z(bun_core::zstr!("pnpm-workspace.yaml")) {
+        return Ok(());
+    }
+    let log = manager.log_mut();
+    let Some(root_pkg_json) = root_package_json(manager, log) else {
+        return Ok(());
+    };
+    if root_pkg_json.root.get(b"workspaces").is_some() {
+        return Ok(());
+    }
+    update_package_json_after_migration(manager, log, Fd::cwd(), &StringArrayHashMap::new())
+}
+
+/// Moves the configuration pnpm reads from package.json's `pnpm` field and
+/// from pnpm-workspace.yaml (workspace globs, catalogs, overrides, patched
+/// dependencies) into the package.json fields `bun install` reads.
+/// `patches` maps the bare `name` patch keys the lockfile resolved to their
+/// versions; it is empty when there is no lockfile.
 fn update_package_json_after_migration(
     manager: &mut PackageManager,
     log: &mut bun_ast::Log,
     dir: Fd,
     patches: &StringArrayHashMap<Box<[u8]>>,
 ) -> Result<(), AllocError> {
-    let mut pkg_json_path = bun_paths::AutoAbsPath::init_top_level_dir();
-    let _ = pkg_json_path.append(b"package.json"); // OOM/capacity error is non-actionable here
-
     let bump = bun_alloc::Arena::new();
     let silent = manager.options.log_level.is_silent();
 
-    let root_pkg_json = match manager
-        .workspace_package_json_cache
-        .get_with_path(
-            log,
-            pkg_json_path.slice(),
-            crate::GetJsonOptions {
-                guess_indentation: true,
-                ..Default::default()
-            },
-        )
-        .unwrap()
-    {
-        Ok(j) => j,
-        Err(_) => return Ok(()),
+    let Some(root_pkg_json) = root_package_json(manager, log) else {
+        return Ok(());
     };
 
     let mut json = root_pkg_json.root;
@@ -2506,10 +2530,7 @@ fn update_package_json_after_migration(
         }
     }
 
-    // Each `&'static [u8]` here is interned into the thread-local `DATA_STORE`
-    // (see `data_store_dupe_str` below) so it shares the lifetime of the
-    // `Expr` nodes it ends up backing inside the cached `root_pkg_json.root`.
-    let mut workspace_paths: Option<Vec<&'static [u8]>> = None;
+    let mut workspace_paths: Option<Vec<&[u8]>> = None;
     let mut catalog_obj: Option<Expr> = None;
     let mut catalogs_obj: Option<Expr> = None;
     let mut workspace_overrides_obj: Option<Expr> = None;
@@ -2517,20 +2538,15 @@ fn update_package_json_after_migration(
 
     match sys::File::read_from(Fd::cwd(), b"pnpm-workspace.yaml") {
         Ok(contents) => 'read_pnpm_workspace_yaml: {
-            // The `Vec<u8>` would drop at the end of this arm while the
-            // `Expr`s it backs (catalog/catalogs/overrides/patchedDependencies
-            // below) escape into `json` and the
-            // `workspace_package_json_cache`. Intern the bytes into the same
-            // thread-local `DATA_STORE` that owns the surrounding `Expr`
-            // nodes — arena ownership, not a leak (bulk-freed on
-            // `Expr::data_store_reset`).
-            let contents: &'static [u8] = js_ast::data_store_dupe_str(&contents);
+            // The yaml `Expr`s spliced into `json` below borrow the source text
+            // (plain scalars) and the parse arena (quoted and block scalars), so
+            // both live in `bump` until `json` has been printed.
+            let contents: &[u8] = bump.alloc_slice_copy(&contents);
             let yaml_source = bun_ast::Source::init_path_string(b"pnpm-workspace.yaml", contents);
-            let arena = bun_alloc::Arena::new();
             let Ok(ws_root) = bun_parsers::yaml::YAML::parse(
                 &yaml_source,
                 log,
-                &arena,
+                &bump,
                 bun_parsers::yaml::CyclicAliases::Reject,
             ) else {
                 break 'read_pnpm_workspace_yaml;
@@ -2538,16 +2554,10 @@ fn update_package_json_after_migration(
 
             if let Some(packages_expr) = ws_root.get(b"packages") {
                 if let Some(mut packages) = packages_expr.as_array() {
-                    let mut paths: Vec<&'static [u8]> = Vec::new();
+                    let mut paths: Vec<&[u8]> = Vec::new();
                     while let Some(package_path) = packages.next() {
                         if let Some(package_path_str) = as_string(&package_path) {
-                            // Intern (vs. the prior `Box<[u8]>`) so the
-                            // `EString` nodes built from these paths below do
-                            // not dangle once this function returns and the
-                            // boxes drop — they are stored into
-                            // `root_pkg_json.root` which is cached in
-                            // `manager.workspace_package_json_cache`.
-                            paths.push(js_ast::data_store_dupe_str(package_path_str));
+                            paths.push(package_path_str);
                         }
                     }
                     workspace_paths = Some(paths);
@@ -2718,50 +2728,29 @@ fn update_package_json_after_migration(
         }
     }
 
-    if needs_update {
-        let mut buffer_writer = bun_js_printer::BufferWriter::init();
-        buffer_writer.append_newline = !root_pkg_json.source.contents().is_empty()
-            && root_pkg_json.source.contents()[root_pkg_json.source.contents().len() - 1] == b'\n';
-        let mut package_json_writer = bun_js_printer::BufferPrinter::init(buffer_writer);
+    if !needs_update {
+        return Ok(());
+    }
 
-        if bun_js_printer::print_json(
-            &mut package_json_writer,
-            json,
-            &root_pkg_json.source,
-            bun_js_printer::PrintJsonOptions {
-                indent: root_pkg_json.indentation,
-                mangled_props: None,
-                ..Default::default()
-            },
-        )
-        .is_err()
-        {
-            return Ok(());
-        }
+    // The nodes spliced into `json` above live in `bump` and the thread-local
+    // AST store; re-parsing the printed source leaves the cache entry owning
+    // everything it points at, as the rest of the install expects.
+    print_package_json_into_cache_entry(root_pkg_json, json);
+    if let Err(err) = root_pkg_json.reparse_root(log) {
+        bun_core::pretty_errorln!("package.json failed to parse due to error {}", err.name());
+        Global::crash();
+    }
 
-        if package_json_writer.flush().is_err() {
-            return Err(AllocError);
-        }
-
-        root_pkg_json.source.contents = std::borrow::Cow::Owned(
-            package_json_writer
-                .ctx
-                .written_without_trailing_zero()
-                .to_vec(),
-        );
-
-        // Write the updated package.json
-        if sys::File::write_file(
-            dir,
-            bun_core::zstr!("package.json"),
-            root_pkg_json.source.contents(),
-        )
-        .is_ok()
-            && !moved.is_empty()
-            && !silent
-        {
-            bun_core::pretty_errorln!("<d>moved {} in <r><green>package.json<r>", moved.join(", "));
-        }
+    if sys::File::write_file(
+        dir,
+        bun_core::zstr!("package.json"),
+        root_pkg_json.source.contents(),
+    )
+    .is_ok()
+        && !moved.is_empty()
+        && !silent
+    {
+        bun_core::pretty_errorln!("<d>moved {} in <r><green>package.json<r>", moved.join(", "));
     }
 
     Ok(())
@@ -2771,7 +2760,7 @@ fn is_non_empty_object(expr: &Expr) -> bool {
     matches!(&expr.data, ExprData::EObject(o) if !o.properties.is_empty())
 }
 
-fn paths_array(paths: &[&'static [u8]]) -> Expr {
+fn paths_array(paths: &[&[u8]]) -> Expr {
     let mut items = js_ast::ExprNodeList::init_capacity(paths.len());
     for path in paths {
         VecExt::append(

--- a/test/cli/install/migration/pnpm-lock-migration.test.ts
+++ b/test/cli/install/migration/pnpm-lock-migration.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { join } from "path";
 
 describe("pnpm-lock.yaml migration", () => {
@@ -635,5 +635,46 @@ importers:
 
     expect(readPackageJson(dir)).toEqual(single);
     expect(fs.readFileSync(join(dir, "bun.lock"), "utf8")).not.toContain("@w/a");
+  });
+
+  // A 0444 package.json does not stop root from writing it, and the mode bits mean something else on Windows.
+  test.skipIf(isWindows || process.getuid?.() === 0).each([
+    ["without a lockfile", {}],
+    [
+      "while migrating pnpm-lock.yaml",
+      {
+        "pnpm-lock.yaml": `lockfileVersion: '9.0'
+
+importers:
+
+  .: {}
+
+  packages/a: {}
+
+  packages/b:
+    dependencies:
+      '@w/a':
+        specifier: workspace:*
+        version: link:../a
+`,
+      },
+    ],
+  ])("and the install fails when package.json cannot be written back, %s", async (_, lockfile) => {
+    const original = JSON.stringify(rootPackageJson);
+    await using dir = tempDir("pnpm-workspace-yaml-readonly", {
+      "package.json": original,
+      "pnpm-workspace.yaml": workspaceYaml,
+      ...workspacePackages,
+      ...lockfile,
+    });
+    fs.chmodSync(join(dir, "package.json"), 0o444);
+
+    const { stderr, exitCode } = await runBun(dir, "install");
+    expect(stderr).toContain("failed to move pnpm-workspace.yaml to workspaces in package.json");
+    expect(stderr).not.toContain("moved pnpm");
+    expect(exitCode).toBe(1);
+
+    expect(fs.readFileSync(join(dir, "package.json"), "utf8")).toBe(original);
+    expect(fs.existsSync(join(dir, "bun.lock"))).toBe(false);
   });
 });

--- a/test/cli/install/migration/pnpm-lock-migration.test.ts
+++ b/test/cli/install/migration/pnpm-lock-migration.test.ts
@@ -402,3 +402,238 @@ snapshots:
     expect(stderr).not.toContain("migrated lockfile from pnpm-lock.yaml");
   });
 });
+
+// Everything below resolves only workspace packages, so it never touches a registry.
+describe.concurrent("pnpm-workspace.yaml is imported into package.json", () => {
+  const rootPackageJson = { name: "root", private: true };
+  const workspaceYaml = `packages:\n  - "packages/*"\n`;
+  const workspacePackages = {
+    "packages/a/package.json": JSON.stringify({ name: "@w/a", version: "1.2.3" }),
+    "packages/b/package.json": JSON.stringify({
+      name: "@w/b",
+      version: "0.0.1",
+      dependencies: { "@w/a": "workspace:*" },
+    }),
+  };
+  const movedWorkspaces = "moved pnpm-workspace.yaml to workspaces in package.json";
+
+  async function runBun(cwd: string, ...args: string[]) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), ...args],
+      cwd,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  function readPackageJson(dir: string) {
+    return JSON.parse(fs.readFileSync(join(dir, "package.json"), "utf8"));
+  }
+
+  // `@w/b` can only see `@w/a` if the install knew `packages/*` were workspaces.
+  async function versionOfAResolvedFromB(dir: string) {
+    const { stdout, stderr, exitCode } = await runBun(
+      join(dir, "packages/b"),
+      "-e",
+      `console.log(require("@w/a/package.json").version)`,
+    );
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "1.2.3\n", stderr: "", exitCode: 0 });
+  }
+
+  // Quoted yaml scalars are stored differently from plain ones by the parser; cover both.
+  const catalogFixture = {
+    "package.json": JSON.stringify({ ...rootPackageJson, pnpm: { overrides: { "from-package-json": "1.0.0" } } }),
+    "pnpm-workspace.yaml": `packages:
+  - 'packages/*'
+catalog:
+  "@w/a": "workspace:*"
+  left-pad: ^1.3.0
+catalogs:
+  build:
+    '@scope/quoted': '~2.0.0'
+overrides:
+  "@scope/quoted": "2.0.1"
+  plain: 3.0.0
+`,
+    ...workspacePackages,
+    "packages/b/package.json": JSON.stringify({
+      name: "@w/b",
+      version: "0.0.1",
+      dependencies: { "@w/a": "catalog:" },
+    }),
+  };
+  const catalogFixtureMoved =
+    "moved pnpm.overrides to overrides, pnpm-workspace.yaml to workspaces, pnpm-workspace.yaml overrides to overrides in package.json";
+  const catalogFixtureImported = {
+    ...rootPackageJson,
+    workspaces: {
+      packages: ["packages/*"],
+      catalog: { "@w/a": "workspace:*", "left-pad": "^1.3.0" },
+      catalogs: { build: { "@scope/quoted": "~2.0.0" } },
+    },
+    overrides: { "from-package-json": "1.0.0", "@scope/quoted": "2.0.1", plain: "3.0.0" },
+  };
+
+  test("by bun install when there is no lockfile at all", async () => {
+    await using dir = tempDir("pnpm-workspace-yaml-no-lockfile", {
+      "package.json": JSON.stringify(rootPackageJson, null, 2) + "\n",
+      "pnpm-workspace.yaml": workspaceYaml,
+      ...workspacePackages,
+    });
+
+    const first = await runBun(dir, "install");
+    expect(first.stderr).toContain(movedWorkspaces);
+    expect(first.exitCode).toBe(0);
+
+    expect(readPackageJson(dir)).toEqual({ ...rootPackageJson, workspaces: ["packages/*"] });
+    const lockfile = fs.readFileSync(join(dir, "bun.lock"), "utf8");
+    expect(lockfile).toContain(`"@w/a": ["@w/a@workspace:packages/a"]`);
+    expect(lockfile).toContain(`"@w/b": ["@w/b@workspace:packages/b"]`);
+    await versionOfAResolvedFromB(dir);
+
+    // package.json now declares the workspaces and bun.lock exists: nothing left to import.
+    const second = await runBun(dir, "install");
+    expect(second.stderr).not.toContain("moved pnpm");
+    expect(second.exitCode).toBe(0);
+    expect(readPackageJson(dir)).toEqual({ ...rootPackageJson, workspaces: ["packages/*"] });
+  });
+
+  test("with its catalogs and overrides when there is no lockfile", async () => {
+    await using dir = tempDir("pnpm-workspace-yaml-catalog", catalogFixture);
+
+    const { stderr, exitCode } = await runBun(dir, "install");
+    expect(stderr).toContain(catalogFixtureMoved);
+    expect(exitCode).toBe(0);
+
+    expect(readPackageJson(dir)).toEqual(catalogFixtureImported);
+    expect(fs.readFileSync(join(dir, "bun.lock"), "utf8")).toContain(`"@w/b": ["@w/b@workspace:packages/b"]`);
+    await versionOfAResolvedFromB(dir);
+  });
+
+  test("with its catalogs and overrides while migrating pnpm-lock.yaml", async () => {
+    await using dir = tempDir("pnpm-workspace-yaml-catalog-lockfile", {
+      ...catalogFixture,
+      "pnpm-lock.yaml": `lockfileVersion: '9.0'
+
+catalogs:
+  default:
+    '@w/a':
+      specifier: workspace:*
+      version: link:packages/a
+
+importers:
+
+  .: {}
+
+  packages/a: {}
+
+  packages/b:
+    dependencies:
+      '@w/a':
+        specifier: 'catalog:'
+        version: link:../a
+`,
+    });
+
+    const { stderr, exitCode } = await runBun(dir, "install");
+    expect(stderr).toContain(catalogFixtureMoved);
+    expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
+    expect(exitCode).toBe(0);
+
+    expect(readPackageJson(dir)).toEqual(catalogFixtureImported);
+    await versionOfAResolvedFromB(dir);
+  });
+
+  test("when pnpm-lock.yaml is too old to migrate", async () => {
+    await using dir = tempDir("pnpm-workspace-yaml-old-lockfile", {
+      "package.json": JSON.stringify(rootPackageJson),
+      "pnpm-workspace.yaml": workspaceYaml,
+      "pnpm-lock.yaml": `lockfileVersion: '6.0'\n\nimporters:\n\n  .: {}\n`,
+      ...workspacePackages,
+    });
+
+    const { stderr, exitCode } = await runBun(dir, "install");
+    expect(stderr).toContain("pnpm-lock.yaml is lockfileVersion 6.0, which bun cannot migrate");
+    expect(stderr).toContain(movedWorkspaces);
+    expect(exitCode).toBe(0);
+
+    expect(readPackageJson(dir)).toEqual({ ...rootPackageJson, workspaces: ["packages/*"] });
+    await versionOfAResolvedFromB(dir);
+  });
+
+  test("by bun add, alongside the added dependency", async () => {
+    await using dir = tempDir("pnpm-workspace-yaml-add", {
+      "package.json": JSON.stringify(rootPackageJson),
+      "pnpm-workspace.yaml": workspaceYaml,
+      "lib/c/package.json": JSON.stringify({ name: "c", version: "0.0.1" }),
+      ...workspacePackages,
+    });
+
+    const { stderr, exitCode } = await runBun(dir, "add", "file:lib/c");
+    expect(stderr).toContain(movedWorkspaces);
+    expect(exitCode).toBe(0);
+
+    expect(readPackageJson(dir)).toEqual({
+      ...rootPackageJson,
+      dependencies: { c: "file:lib/c" },
+      workspaces: ["packages/*"],
+    });
+    await versionOfAResolvedFromB(dir);
+  });
+
+  test("by bun remove, surviving its package.json write-back", async () => {
+    await using dir = tempDir("pnpm-workspace-yaml-remove", {
+      "package.json": JSON.stringify({ ...rootPackageJson, dependencies: { c: "file:lib/c" } }),
+      "pnpm-workspace.yaml": workspaceYaml,
+      "lib/c/package.json": JSON.stringify({ name: "c", version: "0.0.1" }),
+      ...workspacePackages,
+    });
+
+    const { stderr, exitCode } = await runBun(dir, "remove", "c");
+    expect(stderr).toContain(movedWorkspaces);
+    expect(exitCode).toBe(0);
+
+    expect(readPackageJson(dir)).toEqual({ ...rootPackageJson, workspaces: ["packages/*"] });
+    await versionOfAResolvedFromB(dir);
+  });
+
+  test("not when package.json already declares workspaces", async () => {
+    const declared = { ...rootPackageJson, workspaces: ["packages/a"] };
+    await using dir = tempDir("pnpm-workspace-yaml-declared", {
+      "package.json": JSON.stringify(declared),
+      "pnpm-workspace.yaml": workspaceYaml,
+      ...workspacePackages,
+    });
+
+    const { stderr, exitCode } = await runBun(dir, "install");
+    expect(stderr).not.toContain("moved pnpm");
+    expect(exitCode).toBe(0);
+
+    expect(readPackageJson(dir)).toEqual(declared);
+    const lockfile = fs.readFileSync(join(dir, "bun.lock"), "utf8");
+    expect(lockfile).toContain(`"@w/a": ["@w/a@workspace:packages/a"]`);
+    expect(lockfile).not.toContain("@w/b");
+  });
+
+  test("not when a bun.lock exists", async () => {
+    const single = { ...rootPackageJson, dependencies: { c: "file:lib/c" } };
+    await using dir = tempDir("pnpm-workspace-yaml-has-bun-lock", {
+      "package.json": JSON.stringify(single),
+      "lib/c/package.json": JSON.stringify({ name: "c", version: "0.0.1" }),
+      ...workspacePackages,
+    });
+    expect((await runBun(dir, "install")).exitCode).toBe(0);
+    expect(fs.existsSync(join(dir, "bun.lock"))).toBe(true);
+
+    fs.writeFileSync(join(dir, "pnpm-workspace.yaml"), workspaceYaml);
+    const { stderr, exitCode } = await runBun(dir, "install");
+    expect(stderr).not.toContain("moved pnpm");
+    expect(exitCode).toBe(0);
+
+    expect(readPackageJson(dir)).toEqual(single);
+    expect(fs.readFileSync(join(dir, "bun.lock"), "utf8")).not.toContain("@w/a");
+  });
+});

--- a/test/cli/install/migration/pnpm-lock-v9.test.ts
+++ b/test/cli/install/migration/pnpm-lock-v9.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { existsSync, readdirSync, realpathSync, rmSync } from "fs";
+import { appendFileSync, existsSync, readdirSync, realpathSync, rmSync, writeFileSync } from "fs";
 import { bunEnv, bunExe, nodeModulesPackages, tempDir, VerdaccioRegistry } from "harness";
 import { dirname, join } from "path";
 
@@ -948,6 +948,63 @@ snapshots:
         );
       },
     );
+
+    // `bun patch --commit` loads the lockfile before it edits package.json, so the migration's rewrite of
+    // package.json (and of its cache entry) happens underneath the command.
+    test("bun patch --commit that has to migrate the lockfile keeps the migration's package.json edits", async () => {
+      const packageJson = { name: "patch-commit-migrates", dependencies: { "no-deps": "^1.0.0" } };
+      const { packageDir } = await verdaccio.createTestDir({
+        bunfigOpts: { linker: "hoisted" },
+        files: {
+          "package.json": JSON.stringify(packageJson),
+          "pnpm-workspace.yaml": "packages:\n  - 'packages/*'\n",
+          "packages/a/package.json": JSON.stringify({ name: "a", version: "1.0.0" }),
+          "pnpm-lock.yaml": `lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    dependencies:
+      no-deps:
+        specifier: ^1.0.0
+        version: 1.0.1
+
+  packages/a: {}
+
+packages:
+
+  no-deps@1.0.1:
+    resolution: {integrity: ${NO_DEPS_1_0_1_INTEGRITY}}
+
+snapshots:
+
+  no-deps@1.0.1: {}
+`,
+        },
+      });
+
+      // `bun patch` installs and unlinks node_modules/no-deps from the cache copy that `--commit` diffs against;
+      // the repo is then put back to how it was checked out, so `--commit` is the command that migrates.
+      expect((await run(packageDir, "patch", "no-deps")).exitCode).toBe(0);
+      rmSync(join(packageDir, "bun.lock"));
+      writeFileSync(join(packageDir, "package.json"), JSON.stringify(packageJson));
+      appendFileSync(join(packageDir, "node_modules/no-deps/index.js"), "globalThis.patchedAtCommit = true;\n");
+
+      const { stderr, exitCode } = await run(packageDir, "patch", "--commit", "node_modules/no-deps");
+      expect(stderr).toContain("moved pnpm-workspace.yaml to workspaces in package.json");
+      expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
+      expect(exitCode).toBe(0);
+
+      expect(await Bun.file(join(packageDir, "package.json")).json()).toEqual({
+        ...packageJson,
+        workspaces: ["packages/*"],
+        patchedDependencies: { "no-deps@1.0.1": "patches/no-deps@1.0.1.patch" },
+      });
+      expect(await Bun.file(join(packageDir, "patches/no-deps@1.0.1.patch")).text()).toContain(
+        "+globalThis.patchedAtCommit = true;",
+      );
+      expect(await bunLockOf(packageDir)).toContain(`"no-deps@1.0.1": "patches/no-deps@1.0.1.patch"`);
+    });
   });
 
   test("catalog:default is the default catalog", async () => {


### PR DESCRIPTION
### Problem
- In a pnpm monorepo whose `pnpm-lock.yaml` is not present (never committed, or `rm`'d as the isolated-installs docs told people to do) or is a pnpm 8 lockfile (`lockfileVersion: '6.0'`, which bun does not migrate), `bun install` prints `No packages! Deleted empty lockfile`, exits 0, and installs the root as a single package: no workspace is linked, `catalog:` references never resolve, and the yaml `overrides:` / `patchedDependencies:` are not applied.
- Cause: `pnpm-workspace.yaml` is only read by `update_package_json_after_migration` (`src/install/pnpm.rs`), which `migrate_pnpm_lockfile` calls after it has successfully converted a `pnpm-lock.yaml`. Every other path resolves the root `package.json` as-is, and that file has no `workspaces` field in a pnpm repo.
- Same shared function, found while extending it: the yaml was parsed into a block-local `Arena` that is destroyed at the end of the block, and the `catalog` / `overrides` / `patchedDependencies` objects taken from that tree were printed into `package.json` afterwards. Quoted and block yaml scalars (`'@scope/pkg': '^1.0.0'`) are stored in that arena, so they were read after free. ASAN reports it as `use-after-poison` in `bun_js_printer::write_pre_quoted_string_inner` under `print_json` when the freed pages are not reused first.

### Fix
- `pnpm::migrate_pnpm_workspace_config` (new): when `pnpm-workspace.yaml` exists and the root `package.json` has no `workspaces` field, run the existing `update_package_json_after_migration` with an empty patch map. `create_new_lockfile_and_enqueue` calls it right before it parses the root `package.json`, and only when no lockfile was loaded (`LoadResult::NotFound` or `Err`, which covers the too-old lockfile; a loaded `bun.lock` or a migrated lockfile is left authoritative, and a migrated `pnpm-lock.yaml` already ran the import). The `workspaces` guard is what makes a second install, and a repo that maintains `package.json` for bun by hand, a no-op.
- The import is the same one the lockfile migration performs, so the output and the `moved ... in package.json` notice are identical on both paths. The only difference is that bare `name` keys in `patchedDependencies` stay bare, since the version they resolve to is only known from a lockfile.
- `update_package_json_after_migration` now parses the yaml into its function-scoped `bump` arena (the fix for the read-after-free: the tree must outlive the `print_json` at the end of the function), and after printing re-parses the result into the cache entry with the existing `print_package_json_into_cache_entry` + `reparse_root` idiom, so the entry owns what it points at instead of referencing nodes in the thread-local AST store that the next `initialize_store()` resets. The three root `package.json` lookups in the file share a new `root_package_json` helper.
- `update_package_json_and_install_with_manager` (`bun remove` / `bun unlink` / `bun patch --commit`) writes back the cache entry instead of the text it printed before the install. Previously `bun remove` as the first bun command in a pnpm repo threw away the `workspaces` the migration had just written; this was already true on the lockfile path.
- `bun patch --commit` now loads the lockfile (`do_patch_commit`) before this function reads the cwd `package.json` entry, next to where it already loads it for `bun update -r`. With no `bun.lock` that load migrates `pnpm-lock.yaml`, which rewrites the root entry (and, for a monorepo, inserts the workspace package.jsons into the cache map), so an entry pointer or `Expr` taken earlier was stale: store-allocated nodes reset inside `do_patch_commit` before this PR, the re-parsed tree's old arena with it. Found in review.
- A failed write of the rewritten `package.json` (read-only file, full disk) now prints the error and exits 1, like a failed `bun.lock` save. Both entry points used to continue from the in-memory copy and save a `bun.lock` that did not match the `package.json` on disk.
- Docs: `docs/pm/cli/install.mdx` states when the yaml import happens; `docs/pm/isolated-installs.mdx` no longer tells pnpm users to delete `pnpm-lock.yaml` before their first `bun install`.
- Verified: `test/cli/install/migration/pnpm-lock-migration.test.ts`, new `describe` block (10 tests, offline, workspace-only). With `src/` stashed, 5 of them fail with the symptom above (`No packages! Deleted empty lockfile`), the `bun remove` one additionally fails without the write-back change, and the two `cannot be written back` cases (0444 `package.json`; skipped as root and on Windows, run here as an unprivileged user) fail without the write-error change. With only the arena line reverted, the catalog test fails under ASAN with the `use-after-poison` above. The remaining ones pin the negative contract (declared `workspaces` or an existing `bun.lock` win) and the lockfile path with quoted scalars.
- `test/cli/install/migration/pnpm-lock-v9.test.ts` gains the `bun patch --commit` case above (needs the verdaccio fixture registry). It fails on the base commit, fails on the previous head of this PR with `AddressSanitizer: use-after-poison` on the root object's property list in `update_package_json_and_install_with_manager_with_updates`, and passes now with both `workspaces` and `patchedDependencies` in the final `package.json`.
- Also run: `test/cli/install/migration/pnpm-migration.test.ts`, `pnpm-lock-v9.test.ts` (80 pass), `bun-remove.test.ts`, `bun-patch.test.ts`, `bun-link.test.ts` (one pre-existing debug-only failure in `bun-link`, which expects release output on an install failure).

### Background
- `bun install` has no notion of `pnpm-workspace.yaml` at resolve time. Migration from pnpm works by rewriting the root `package.json` once (yaml `packages`/`catalog`/`catalogs` become the `workspaces` field, yaml and `pnpm.*` overrides and patches become the top-level fields) and then letting the normal install read `package.json`. The migration only runs while `bun.lock` does not exist, which is the rule this change keeps.
- `LoadResult` is what `Lockfile::load_from_cwd` returns: `Ok` with a `bun.lock`/`bun.lockb` or a lockfile migrated from npm/yarn/pnpm, `NotFound`, or `Err` (unreadable, or a migration that failed, such as a pnpm 8 lockfile). `install_with_manager` builds a fresh lockfile from `package.json` in the last two cases, which is where the import now runs.
- `workspace_package_json_cache` holds each parsed `package.json` (`MapEntry`: source text plus an AST cloned into an arena the entry owns). The install flow, and the add/remove write-back after it, read the root entry again later, so an editor has to leave `root == parse(source)` with entry-owned memory; `print_package_json_into_cache_entry` + `reparse_root` is how the other editors in `PackageManager/` do that.

<details>
<summary>Manual runs against the debug build</summary>

Repro from the report (no lockfile):

```
$ bun install
moved pnpm-workspace.yaml to workspaces in package.json
Saved lockfile
Checked 4 installs across 3 packages (no changes)
$ ls -l packages/b/node_modules/@w/a
packages/b/node_modules/@w/a -> ../../../a
$ bun install          # second run: silent, package.json untouched
```

pnpm 8 lockfile present:

```
warn: pnpm-lock.yaml is lockfileVersion 6.0, which bun cannot migrate; resolving from package.json instead
note: pnpm install --lockfile-only
moved pnpm-workspace.yaml to workspaces in package.json
```

Unchanged: `package.json` already has `workspaces`; `bun.lock` exists; a yaml with only `namedRegistries:` (nothing to move, no message, file not rewritten).

An unrelated pre-existing bug seen while probing (a root `file:` dependency on a workspace folder produces a `bun.lock` with a duplicate `packages` key on the second install) is already tracked separately; the tests here avoid that layout.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/migration/pnpm-lock-migration.test.ts

<!-- robobun:evidence:end -->
