### PR TITLE
serve: add ServerConfig.is_node_http_server and key the node:http lifecycle paths on it

### DIFF
--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -51,9 +51,7 @@ pub struct ServerConfig {
     pub(crate) on_error: JSValue,
     pub(crate) on_request: JSValue,
     pub(crate) on_node_http_request: JSValue,
-    /// `serve()` was called with `onNodeHTTPRequest` (node:http's server).
-    /// Fixed for the server's lifetime, unlike `on_node_http_request`, which
-    /// is the current handler and can be cleared by `reload()`.
+    /// Created with `onNodeHTTPRequest`; unlike the handler above, `reload()` never clears this.
     pub(crate) is_node_http_server: bool,
 
     pub(crate) websocket: Option<WebSocketServerContext>,

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -51,6 +51,13 @@ pub struct ServerConfig {
     pub(crate) on_error: JSValue,
     pub(crate) on_request: JSValue,
     pub(crate) on_node_http_request: JSValue,
+    /// The server was created by node:http (`serve()` was called with
+    /// `onNodeHTTPRequest`). Fixed for the server's lifetime: it selects the
+    /// uWS context's node:http mode in `set_routes()` and the node:http
+    /// close/drain semantics, and `reload()` leaves it alone, whereas
+    /// `on_node_http_request` is the current handler and a reload that omits
+    /// it clears it.
+    pub(crate) is_node_http_server: bool,
 
     pub(crate) websocket: Option<WebSocketServerContext>,
 
@@ -86,6 +93,7 @@ impl Default for ServerConfig {
             on_error: JSValue::ZERO,
             on_request: JSValue::ZERO,
             on_node_http_request: JSValue::ZERO,
+            is_node_http_server: false,
             websocket: None,
             reuse_port: false,
             id: Box::default(),
@@ -272,6 +280,7 @@ impl ServerConfig {
             on_error: self.on_error,
             on_request: self.on_request,
             on_node_http_request: self.on_node_http_request,
+            is_node_http_server: self.is_node_http_server,
             websocket: self.websocket.take(),
             reuse_port: self.reuse_port,
             id: core::mem::take(&mut self.id),
@@ -1355,6 +1364,7 @@ impl ServerConfig {
                 )));
             }
             args.on_node_http_request = on_request_;
+            args.is_node_http_server = true;
         }
 
         if let Some(on_request_) = arg.get_truthy(global, "fetch")? {
@@ -1364,7 +1374,7 @@ impl ServerConfig {
             }
             args.on_request = on_request_;
         } else if args.bake.is_none()
-            && args.on_node_http_request.is_empty()
+            && !args.is_node_http_server
             && ((args.static_routes.len() + args.user_routes_to_build.len()) == 0
                 && !opts.has_user_routes)
             && opts.is_fetch_required

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -51,12 +51,9 @@ pub struct ServerConfig {
     pub(crate) on_error: JSValue,
     pub(crate) on_request: JSValue,
     pub(crate) on_node_http_request: JSValue,
-    /// The server was created by node:http (`serve()` was called with
-    /// `onNodeHTTPRequest`). Fixed for the server's lifetime: it selects the
-    /// uWS context's node:http mode in `set_routes()` and the node:http
-    /// close/drain semantics, and `reload()` leaves it alone, whereas
-    /// `on_node_http_request` is the current handler and a reload that omits
-    /// it clears it.
+    /// `serve()` was called with `onNodeHTTPRequest` (node:http's server).
+    /// Fixed for the server's lifetime, unlike `on_node_http_request`, which
+    /// is the current handler and can be cleared by `reload()`.
     pub(crate) is_node_http_server: bool,
 
     pub(crate) websocket: Option<WebSocketServerContext>,

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -2734,8 +2734,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             );
         }
 
-        // Puts the uWS context into node:http mode (needed for the Node socket
-        // callbacks even when user routes cover "/*"). Idempotent on reload.
+        // Idempotent, so re-running set_routes on reload() is fine.
         if self.config.is_node_http_server {
             ffi::NodeHTTP_assignOnNodeJSCompat(SSL, std::ptr::from_mut(app).cast::<c_void>());
         }

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -1613,7 +1613,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         self.pending_requests.get() == 0
             && !self.has_listener()
             && !self.has_active_web_sockets()
-            && (!self.config.on_node_http_request.is_empty() || !self.has_active_connections())
+            && (self.config.is_node_http_server || !self.has_active_connections())
     }
 
     /// Nothing is left that can dispatch a handler: [`Self::is_closed`] and
@@ -1765,7 +1765,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             // `closeIdleConnections()`), and a connection whose response
             // completes after `close()` stays keep-alive until its timeout
             // reaps it — verified against Node v26.
-            if self.config.on_node_http_request.is_empty() {
+            if !self.config.is_node_http_server {
                 if let Some(app) = self.app {
                     self.deinit_running.set(true);
                     // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
@@ -2734,10 +2734,9 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             );
         }
 
-        // If onNodeHTTPRequest is configured, it might be needed for Node.js
-        // compatibility layer for specific Node API routes, even if it's not
-        // the main "/*" handler.
-        if has_node_http {
+        // Puts the uWS context into node:http mode (needed for the Node socket
+        // callbacks even when user routes cover "/*"). Idempotent on reload.
+        if self.config.is_node_http_server {
             ffi::NodeHTTP_assignOnNodeJSCompat(SSL, std::ptr::from_mut(app).cast::<c_void>());
         }
 
@@ -2985,7 +2984,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
         bun_opaque::opaque_deref_mut(app).filter(Self::on_connection_filter, this.cast::<c_void>());
 
-        if !this_ref.config.on_node_http_request.is_empty() {
+        if this_ref.config.is_node_http_server {
             // SAFETY: `this` is the live boxed server from `init()`; no other
             // borrow is live — `&mut` scoped to this call.
             unsafe { (*this).set_using_custom_expect_handler(true) };

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2277,18 +2277,20 @@ where
             );
             self.config.on_request = new_config.on_request;
         }
-        // Swap on any change, *including* clearing to ZERO when the reload
-        // config omits the handler, so subsequent `on_web_socket_upgrade` /
-        // `set_routes` stop routing through the node:http path.
+        // On a node:http server, swap on any change, *including* clearing to
+        // ZERO when the reload config omits the handler, so subsequent
+        // `on_web_socket_upgrade` / `set_routes` stop routing through the
+        // node:http path (a later reload may set it again).
         //
-        // Never the other direction: a server that was not created as a
-        // node:http server cannot become one through reload(). listen()
-        // already sized every future connection's socket ext block for this
-        // server's kind (HttpResponseData vs the bigger NodeHttpResponseData)
-        // and set_routes would swap the context onto the node:http handler
-        // instantiation under those already-sized allocations, so the node
-        // request path would construct and index past them.
-        if !self.config.on_node_http_request.is_empty()
+        // A server that was not created as a node:http server cannot become
+        // one through reload() (`is_node_http_server` is never copied from
+        // `new_config`): listen() already sized every future connection's
+        // socket ext block for this server's kind (HttpResponseData vs the
+        // bigger NodeHttpResponseData) and set_routes would swap the context
+        // onto the node:http handler instantiation under those already-sized
+        // allocations, so the node request path would construct and index past
+        // them.
+        if self.config.is_node_http_server
             && self.config.on_node_http_request != new_config.on_node_http_request
         {
             super::wrap_handler_slot(

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2277,19 +2277,17 @@ where
             );
             self.config.on_request = new_config.on_request;
         }
-        // On a node:http server, swap on any change, *including* clearing to
-        // ZERO when the reload config omits the handler, so subsequent
-        // `on_web_socket_upgrade` / `set_routes` stop routing through the
-        // node:http path (a later reload may set it again).
+        // Swap on any change, *including* clearing to ZERO when the reload
+        // config omits the handler, so subsequent `on_web_socket_upgrade` /
+        // `set_routes` stop routing through the node:http path.
         //
-        // A server that was not created as a node:http server cannot become
-        // one through reload() (`is_node_http_server` is never copied from
-        // `new_config`): listen() already sized every future connection's
-        // socket ext block for this server's kind (HttpResponseData vs the
-        // bigger NodeHttpResponseData) and set_routes would swap the context
-        // onto the node:http handler instantiation under those already-sized
-        // allocations, so the node request path would construct and index past
-        // them.
+        // Never the other direction: a server that was not created as a
+        // node:http server cannot become one through reload(). listen()
+        // already sized every future connection's socket ext block for this
+        // server's kind (HttpResponseData vs the bigger NodeHttpResponseData)
+        // and set_routes would swap the context onto the node:http handler
+        // instantiation under those already-sized allocations, so the node
+        // request path would construct and index past them.
         if self.config.is_node_http_server
             && self.config.on_node_http_request != new_config.on_node_http_request
         {

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1302,6 +1302,74 @@ it("reload() cannot turn a Bun.serve server into a node:http server", async () =
   );
 });
 
+it("reload() that drops the node:http handler keeps the server's node:http stop() semantics", async () => {
+  // The other direction of the kind invariant: a server created as a node:http
+  // one stays one. node's close() contract is that stop(false) neither sweeps
+  // idle keep-alive connections nor waits for them, and a reload() that routes
+  // requests to fetch instead of the node handler must not switch the server
+  // over to Bun.serve's drain (which closes the idle connection here).
+  using server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    // @ts-expect-error internal option used by node:http's Server
+    onNodeHTTPRequest() {
+      throw new Error("replaced by reload() before any request");
+    },
+  });
+  server.reload({ fetch: () => new Response("ok") });
+
+  let received = "";
+  let connectionClosed = false;
+  let waiter = Promise.withResolvers<void>();
+  await using connection = await Bun.connect({
+    hostname: "127.0.0.1",
+    port: server.port,
+    socket: {
+      data(_, data) {
+        received += data.toString("latin1");
+        waiter.resolve();
+      },
+      end() {
+        connectionClosed = true;
+        waiter.resolve();
+      },
+      close() {
+        connectionClosed = true;
+        waiter.resolve();
+      },
+      error() {
+        connectionClosed = true;
+        waiter.resolve();
+      },
+    },
+  });
+  // Sends a keep-alive request and returns "<status line> <body>", or "closed"
+  // if the server hung up instead of answering.
+  async function request(): Promise<string> {
+    connection.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
+    connection.flush();
+    while (true) {
+      const headEnd = received.indexOf("\r\n\r\n");
+      if (headEnd !== -1) {
+        const head = received.slice(0, headEnd);
+        const bodyEnd = headEnd + 4 + Number(/^content-length: (\d+)$/im.exec(head)?.[1] ?? 0);
+        if (received.length >= bodyEnd) {
+          const result = `${head.split("\r\n")[0]} ${received.slice(headEnd + 4, bodyEnd)}`;
+          received = received.slice(bodyEnd);
+          return result;
+        }
+      }
+      if (connectionClosed) return "closed";
+      await waiter.promise;
+      waiter = Promise.withResolvers();
+    }
+  }
+
+  expect(await request()).toBe("HTTP/1.1 200 OK ok");
+  await server.stop(false);
+  expect(await request()).toBe("HTTP/1.1 200 OK ok");
+});
+
 describe("status code text", () => {
   const fixture = {
     200: "OK",


### PR DESCRIPTION
Follow-up to the review comment on 43afad2dd4 (#38661) asking for a `config.is_node_http_server` flag.

### Problem
- Five places inferred "this is a node:http server" from `config.on_node_http_request` being set: the close/drain predicate (`is_closed`, mod.rs:1616), the graceful-stop idle sweep exemption (`stop_listening`, mod.rs:1768), the custom `Expect` handler (`listen`, mod.rs:2986), the switch of the uWS context into node:http mode (`set_routes`, mod.rs:2738) and the reload guard that keeps a Bun.serve server from adopting the handler (`on_reload_from_zig`, server_body.rs:2291).
- `on_node_http_request` is the current handler, and a `reload()` that omits it clears it on purpose (so requests route to `fetch` afterwards), while the server's kind cannot change after `listen()`: the uWS context mode and per-socket allocation size are fixed there. So a node:http server reloaded that way flipped to Bun.serve's stop semantics (`stop(false)` closed its idle keep-alive connections and waited for the rest) on a context still running in node:http mode, and could never get its handler back through a later reload.

### Fix
- `ServerConfig` gains `is_node_http_server`, set once in `ServerConfig::from_js` when `onNodeHTTPRequest` is passed (how `node:http` creates its server) and carried across `clone_for_reloading_static_routes`. `on_reload_from_zig` copies individual fields, so a reload can neither set nor clear it, which is the property the five sites above want; they now read it, as does the "fetch or routes required" check in `from_js`.
- Request routing (`negative_h1` and the `/*` fallback in `set_routes`, `on_web_socket_upgrade`) still follows the handler value, matching the reload comment in server_body.rs.
- The connection filter registered in `listen()` is left unconditional on purpose. Bun.serve has had it since #35130 (it feeds `active_connection_count`, which makes `stop(false)` wait for open connections and keeps the wrapper alive while one can still dispatch; `bun-server.test.ts`, "server.stop() drain promise counts open connections"), and #38661 added it to node:http because `is_drained` needs the same count there (`node-http-uaf.test.ts`). Gating it on the flag in either direction removes one of those two fixes; if its per connection cost matters, replacing it with a counter maintained inside uWS for every server kind is the follow-up, and it does not need this flag.
- Test: `test/js/bun/http/serve.test.ts`, "reload() that drops the node:http handler keeps the server's node:http stop() semantics", next to the two existing server-kind reload tests. It creates a server with `onNodeHTTPRequest`, reloads it over to `fetch`, parks one idle keep-alive connection, awaits `stop(false)` and sends a second request on the same connection. Without the src change the connection is closed by the sweep and the test sees `"closed"` (checked with main's src on a debug build, and with the released binary); with it the second request is answered.
- Also verified on the debug build: `node-http-uaf.test.ts` (8 pass), `node-http.test.ts` (143 pass) and `bun-server.test.ts` (75 pass); the remaining failures in the last two are `localhost` connection refusals that fail identically with the released binary in this environment.

### Background
- `node:http`'s `Server` is implemented on top of `Bun.serve()`: `_http_server.ts` passes an internal `onNodeHTTPRequest` option, and that option is what puts a server into node:http mode. `Bun.serve()` accepts it directly, which is how the tests build such a server without node:http.
- The uWS connection filter is a callback uWS invokes when an HTTP connection is accepted (after the TLS handshake for HTTPS) and when it closes or is upgraded to a WebSocket; `NewServer` uses it to maintain `active_connection_count`.
- `is_closed` is what `server.stop()`'s promise (node:http's `'close'` event) and the event loop ref wait for. Bun.serve's graceful stop also sweeps idle connections and waits for the rest; node:http's `close()` does neither, because node's JS layer sweeps idle connections itself and the rest are left to their timeouts. `is_drained` additionally requires zero open connections and is the point where the server's JS wrapper, the GC root of the handlers, may become collectible; it applies to both kinds.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/http/serve.test.ts

<!-- robobun:evidence:end -->