### PR TITLE
js_parser: keep the inferred name of lowered anonymous decorated class expressions

### DIFF
--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -123,8 +123,7 @@ fn class_copy(c: &G::Class) -> G::Class {
     }
 }
 
-/// Whether the class body defines a static member keyed `name` (`static get
-/// name()`, `static name = ...`), which replaces the constructor's own `name`.
+/// `static name`, `static get name()`, ...: the class replaces its own `.name`.
 fn defines_static_name(props: &[Property]) -> bool {
     props.iter().any(|prop| {
         prop.flags.contains(Flags::Property::IsStatic)
@@ -2412,14 +2411,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             new_properties = merged;
         }
 
-        // `_class = class {}` would infer the name "_class", so restore the one
-        // the source position inferred. It is set with `__name` instead of by
-        // naming the class binding: the bundler renames a binding that collides
-        // with the enclosing scope (`const Bar = class Bar2 {}`), and a binding
-        // would shadow the outer `Bar` inside the class body. The block goes
-        // first so static initializers left in the body observe the name. A body
-        // with its own static `name` gets no block: static methods and accessors
-        // are installed before any static block runs, so it would overwrite them.
+        // `_class = class {}` would be named "_class". A string literal, unlike a
+        // class binding, survives bundler renaming and shadows nothing in the body;
+        // the block goes first so static initializers already see the name.
         if expr_class_is_anonymous && !defines_static_name(&new_properties) {
             let this_e = p.new_expr(E::This {}, loc);
             let name_e = p.new_expr(

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -5,9 +5,8 @@ use bun_alloc::ArenaVecExt as _;
 
 use bun_collections::{HashMap, VecExt};
 
-use crate::lexer as js_lexer;
 use crate::p::P;
-use crate::parser::{ARGUMENTS_STR as arguments_str, Ref, is_eval_or_arguments};
+use crate::parser::{ARGUMENTS_STR as arguments_str, Ref};
 use bun_ast::g::{DeclList, Property, PropertyKind};
 use bun_ast::{self as js_ast, B, E, Expr, ExprNodeList, Flags, G, S, Stmt};
 
@@ -122,21 +121,6 @@ fn class_copy(c: &G::Class) -> G::Class {
         has_decorators: c.has_decorators,
         should_lower_standard_decorators: c.should_lower_standard_decorators,
     }
-}
-
-/// Whether a context-inferred name (`export default` → "default", object
-/// property keys, assignment targets) can be attached to a lowered anonymous
-/// class expression as its syntactic binding name. Class bodies are always
-/// strict mode code and the output may be a module, so reserved words
-/// ("default", "let", "await", …), `eval`/`arguments`, and non-identifier
-/// strings would turn `_class = class <name> {}` into a syntax error.
-#[inline]
-fn can_be_class_binding_name(name: &[u8]) -> bool {
-    js_lexer::is_identifier(name)
-        && js_lexer::keyword(name).is_none()
-        && !js_lexer::is_strict_mode_reserved_word(name)
-        && name != b"await"
-        && !is_eval_or_arguments(name)
 }
 
 // ── impl P ───────────────────────────────────────────────────────────────────
@@ -1142,14 +1126,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 class_name_ref = ecr;
                 class_name_loc = loc;
                 expr_class_is_anonymous = true;
-                if let Some(name) = name_from_context
-                    && can_be_class_binding_name(name)
-                {
-                    class.class_name = Some(js_ast::LocRef {
-                        ref_: p.new_sym(js_ast::symbol::Kind::Other, name),
-                        loc,
-                    });
-                }
             }
         } else {
             class_name_ref = class.class_name.as_ref().unwrap().ref_;
@@ -2420,6 +2396,26 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 merged.push(np);
             }
             new_properties = merged;
+        }
+
+        // `_class = class {}` would infer the name "_class", so restore the one
+        // the source position inferred. It is set with `__name` instead of by
+        // naming the class binding: the bundler renames a binding that collides
+        // with the enclosing scope (`const Bar = class Bar2 {}`), and a binding
+        // would shadow the outer `Bar` inside the class body. The block goes
+        // first so static initializers left in the body observe the name.
+        if expr_class_is_anonymous {
+            let this_e = p.new_expr(E::This {}, loc);
+            let name_e = p.new_expr(
+                E::EString {
+                    data: name_from_context.unwrap_or(b"").into(),
+                    ..Default::default()
+                },
+                loc,
+            );
+            let set_name = p.call_rt(loc, b"__name", &[this_e, name_e]);
+            let block = p.make_static_block(set_name, loc);
+            new_properties.insert(0, block);
         }
 
         class.properties = bun_ast::StoreSlice::new_mut(new_properties.into_bump_slice_mut());

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -123,8 +123,7 @@ fn class_copy(c: &G::Class) -> G::Class {
     }
 }
 
-/// A static method or accessor keyed `name` is installed before any static block runs.
-/// (A `static name` field is initialized after them and replaces the name by itself.)
+/// Installed before static blocks run; a `static name` field instead wins on its own.
 fn defines_static_name_method(props: &[Property]) -> bool {
     props.iter().any(|prop| {
         prop.flags.contains(Flags::Property::IsStatic)

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -123,10 +123,13 @@ fn class_copy(c: &G::Class) -> G::Class {
     }
 }
 
-/// `static name`, `static get name()`, ...: the class replaces its own `.name`.
-fn defines_static_name(props: &[Property]) -> bool {
+/// A static method or accessor keyed `name` is installed before any static block runs.
+/// (A `static name` field is initialized after them and replaces the name by itself.)
+fn defines_static_name_method(props: &[Property]) -> bool {
     props.iter().any(|prop| {
         prop.flags.contains(Flags::Property::IsStatic)
+            && (prop.flags.contains(Flags::Property::IsMethod)
+                || prop.kind == PropertyKind::AutoAccessor)
             && match &prop.key {
                 Some(key) => {
                     matches!(&key.data, js_ast::ExprData::EString(s) if s.eql_comptime(b"name"))
@@ -1144,6 +1147,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             class_name_ref = class.class_name.as_ref().unwrap().ref_;
             class_name_loc = class.class_name.as_ref().unwrap().loc;
         }
+        // Decided before Phase 2 replaces decorated computed keys with temporaries.
+        let restore_inferred_name =
+            expr_class_is_anonymous && !defines_static_name_method(class.properties.slice());
 
         let mut inner_class_ref: Ref = class_name_ref;
         if !is_expr {
@@ -2412,7 +2418,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
 
         // A string literal, unlike a class binding, survives the bundler's renaming.
-        if expr_class_is_anonymous && !defines_static_name(&new_properties) {
+        if restore_inferred_name {
             let this_e = p.new_expr(E::This {}, loc);
             let name_e = p.new_expr(
                 E::EString {

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -2411,9 +2411,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             new_properties = merged;
         }
 
-        // `_class = class {}` would be named "_class". A string literal, unlike a
-        // class binding, survives bundler renaming and shadows nothing in the body;
-        // the block goes first so static initializers already see the name.
+        // A string literal, unlike a class binding, survives the bundler's renaming.
         if expr_class_is_anonymous && !defines_static_name(&new_properties) {
             let this_e = p.new_expr(E::This {}, loc);
             let name_e = p.new_expr(

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -128,7 +128,8 @@ fn defines_static_name_method(props: &[Property]) -> bool {
     props.iter().any(|prop| {
         prop.flags.contains(Flags::Property::IsStatic)
             && (prop.flags.contains(Flags::Property::IsMethod)
-                || prop.kind == PropertyKind::AutoAccessor)
+                // A decorated accessor is installed from the suffix instead.
+                || (prop.kind == PropertyKind::AutoAccessor && prop.ts_decorators.len_u32() == 0))
             && match &prop.key {
                 Some(key) => {
                     matches!(&key.data, js_ast::ExprData::EString(s) if s.eql_comptime(b"name"))

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -123,6 +123,20 @@ fn class_copy(c: &G::Class) -> G::Class {
     }
 }
 
+/// Whether the class body defines a static member keyed `name` (`static get
+/// name()`, `static name = ...`), which replaces the constructor's own `name`.
+fn defines_static_name(props: &[Property]) -> bool {
+    props.iter().any(|prop| {
+        prop.flags.contains(Flags::Property::IsStatic)
+            && match &prop.key {
+                Some(key) => {
+                    matches!(&key.data, js_ast::ExprData::EString(s) if s.eql_comptime(b"name"))
+                }
+                None => false,
+            }
+    })
+}
+
 // ── impl P ───────────────────────────────────────────────────────────────────
 
 impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
@@ -2403,8 +2417,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // naming the class binding: the bundler renames a binding that collides
         // with the enclosing scope (`const Bar = class Bar2 {}`), and a binding
         // would shadow the outer `Bar` inside the class body. The block goes
-        // first so static initializers left in the body observe the name.
-        if expr_class_is_anonymous {
+        // first so static initializers left in the body observe the name. A body
+        // with its own static `name` gets no block: static methods and accessors
+        // are installed before any static block runs, so it would overwrite them.
+        if expr_class_is_anonymous && !defines_static_name(&new_properties) {
             let this_e = p.new_expr(E::This {}, loc);
             let name_e = p.new_expr(
                 E::EString {

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -130,10 +130,11 @@ fn defines_static_name_method(props: &[Property]) -> bool {
             && (prop.flags.contains(Flags::Property::IsMethod)
                 // A decorated accessor is installed from the suffix instead.
                 || (prop.kind == PropertyKind::AutoAccessor && prop.ts_decorators.len_u32() == 0))
-            && match &prop.key {
-                Some(key) => {
-                    matches!(&key.data, js_ast::ExprData::EString(s) if s.eql_comptime(b"name"))
-                }
+            && match prop.key {
+                Some(key) => matches!(
+                    key.unwrap_inlined().data,
+                    js_ast::ExprData::EString(s) if s.eql_comptime(b"name")
+                ),
                 None => false,
             }
     })

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -3170,6 +3170,51 @@ describe("bundler", () => {
     },
     run: { stdout: "try:false" },
   });
+  // Standard-decorator lowering rewrites `const Bar = class { ... }` into
+  // `_class = class { ... }`, so the class no longer infers its name from the
+  // binding. The name the lowering attaches instead has to survive the
+  // bundler's renaming of symbols that collide in the enclosing scope (the
+  // function-local `Bar` here, the CommonJS-wrapped module scope below) and
+  // identifier minification.
+  const decoratedAnonymousClassNames = /* js */ `
+    function dec() {}
+    function f() {
+      const Bar = class { @dec m() {} };
+      const Baz = class { accessor x; };
+      let Qux; Qux = class { @dec static s() {} };
+      const obj = { "not-an-identifier": class { @dec m() {} } };
+      return [Bar.name, Baz.name, Qux.name, obj["not-an-identifier"].name];
+    }
+    console.log(JSON.stringify(f()));
+  `;
+  itBundled("edgecase/DecoratedAnonymousClassExprKeepsInferredName", {
+    files: {
+      "/entry.js": decoratedAnonymousClassNames,
+    },
+    run: { stdout: '["Bar","Baz","Qux","not-an-identifier"]' },
+  });
+  itBundled("edgecase/DecoratedAnonymousClassExprKeepsInferredNameMinified", {
+    files: {
+      "/entry.js": decoratedAnonymousClassNames,
+    },
+    minifyIdentifiers: true,
+    minifySyntax: true,
+    minifyWhitespace: true,
+    run: { stdout: '["Bar","Baz","Qux","not-an-identifier"]' },
+  });
+  itBundled("edgecase/DecoratedAnonymousClassExprKeepsInferredNameInCJSWrapper", {
+    files: {
+      "/entry.js": /* js */ `
+        console.log(require("./mod.cjs").name);
+      `,
+      "/mod.cjs": /* js */ `
+        function dec() {}
+        const Bar = class { @dec m() {} };
+        module.exports = Bar;
+      `,
+    },
+    run: { stdout: "Bar" },
+  });
 });
 
 for (const backend of ["api", "cli"] as const) {

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1104,6 +1104,20 @@ describe("ES Decorators", () => {
       );
       expect(exitCode).toBe(0);
     });
+
+    test.concurrent("a decorated static accessor named `name` is installed after the body runs", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() {}
+        const Foo = class {
+          static seenBefore = this.name;
+          @dec static accessor name = "from accessor";
+        };
+        console.log(JSON.stringify([Foo.seenBefore, Foo.name]));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe('["Foo","from accessor"]\n');
+      expect(exitCode).toBe(0);
+    });
   });
 
   describe("private member calls in lowered classes", () => {

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1072,6 +1072,33 @@ describe("ES Decorators", () => {
       expect(stdout).toBe("static block: Bar\nBar Bar Bar\nBaz Baz\n");
       expect(exitCode).toBe(0);
     });
+
+    test.concurrent("a static member named `name` declared by the class wins", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() {}
+        const Getter = class { static get name() { return "from getter"; } @dec m() {} };
+        const Setter = class { static set name(v) {} @dec m() {} };
+        const Method = class { static name() {} @dec m() {} };
+        const DecoratedMethod = class { @dec static name() {} };
+        const Accessor = class { static accessor name = "from accessor"; @dec m() {} };
+        const Field = class { static name = "from field"; @dec m() {} };
+        const Uninitialized = class { static name; @dec m() {} };
+        const Instance = class { name = "instance"; @dec m() {} };
+        console.log(JSON.stringify([
+          Getter.name,
+          Setter.name,
+          typeof Method.name,
+          typeof DecoratedMethod.name,
+          Accessor.name,
+          Field.name,
+          Uninitialized.name,
+          Instance.name,
+        ]));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe('["from getter",null,"function","function","from accessor","from field",null,"Instance"]\n');
+      expect(exitCode).toBe(0);
+    });
   });
 
   describe("private member calls in lowered classes", () => {

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1080,8 +1080,9 @@ describe("ES Decorators", () => {
         const Setter = class { static set name(v) {} @dec m() {} };
         const Method = class { static name() {} @dec m() {} };
         const DecoratedMethod = class { @dec static name() {} };
+        const DecoratedComputed = class { @dec static ["name"]() {} };
         const Accessor = class { static accessor name = "from accessor"; @dec m() {} };
-        const Field = class { static name = "from field"; @dec m() {} };
+        const Field = class { static seenBefore = this.name; static name = "from field"; @dec m() {} };
         const Uninitialized = class { static name; @dec m() {} };
         const Instance = class { name = "instance"; @dec m() {} };
         console.log(JSON.stringify([
@@ -1089,14 +1090,18 @@ describe("ES Decorators", () => {
           Setter.name,
           typeof Method.name,
           typeof DecoratedMethod.name,
+          typeof DecoratedComputed.name,
           Accessor.name,
+          Field.seenBefore,
           Field.name,
           Uninitialized.name,
           Instance.name,
         ]));
       `);
       expect(stderr).toBe("");
-      expect(stdout).toBe('["from getter",null,"function","function","from accessor","from field",null,"Instance"]\n');
+      expect(stdout).toBe(
+        '["from getter",null,"function","function","function","from accessor","Field","from field",null,"Instance"]\n',
+      );
       expect(exitCode).toBe(0);
     });
   });

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -845,6 +845,7 @@ describe("ES Decorators", () => {
           import Cls from "./mod.js";
           const c = new Cls();
           console.log(c.foo());
+          console.log(Cls.name);
         `,
         "mod.js": `
           function dec(fn, ctx) { console.log("decorated", ctx.name); return fn; }
@@ -863,7 +864,7 @@ describe("ES Decorators", () => {
 
       const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(filterStderr(rawStderr)).toBe("");
-      expect(stdout).toBe("decorated foo\n42\n");
+      expect(stdout).toBe("decorated foo\n42\ndefault\n");
       expect(exitCode).toBe(0);
     });
 
@@ -979,6 +980,97 @@ describe("ES Decorators", () => {
       expect(output).not.toContain("class default");
       // the lowered output must still be valid syntax
       expect(() => new Bun.Transpiler({ loader: "js" }).transformSync(output)).not.toThrow();
+    });
+  });
+
+  describe("inferred names of lowered anonymous class expressions", () => {
+    // Lowering turns `const Bar = class { ... }` into `_class = class { ... }`,
+    // which would otherwise make the class infer the name "_class". The name
+    // the source position would have inferred must be restored without adding
+    // a class binding: a binding can only hold identifier names, shadows the
+    // outer variable inside the class body, and is renamed by the bundler.
+    test.concurrent("names that are not valid identifiers", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() {}
+        const obj = {
+          "foo-bar": class { @dec m() {} },
+          "": class { @dec m() {} },
+          default: class { @dec m() {} },
+          "with space": class { accessor x; },
+        };
+        console.log(JSON.stringify([obj["foo-bar"].name, obj[""].name, obj.default.name, obj["with space"].name]));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe('["foo-bar","","default","with space"]\n');
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("every naming context", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() {}
+        const A = class { @dec m() {} };
+        let B; B = class { @dec m() {} };
+        const { C = class { @dec m() {} } } = {};
+        const [D = class { @dec m() {} }] = [];
+        const obj = { E: class { @dec m() {} } };
+        class Holder {
+          static F = class { @dec m() {} };
+          G = class { @dec m() {} };
+        }
+        const H = @dec class {};
+        console.log(JSON.stringify([A.name, B.name, C.name, D.name, obj.E.name, Holder.F.name, new Holder().G.name, H.name]));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe('["A","B","C","D","E","F","G","H"]\n');
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("no naming context leaves the name empty", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() {}
+        const id = x => x;
+        console.log(JSON.stringify([id(class { @dec m() {} }).name, id(@dec class {}).name, id(class { accessor x; }).name]));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe('["","",""]\n');
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("class body still refers to the outer binding", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() {}
+        let Bar = class {
+          @dec m() { return Bar; }
+          static s() { return Bar; }
+        };
+        const Original = Bar;
+        Bar = "reassigned";
+        console.log(Original.name, new Original().m(), Original.s());
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("Bar reassigned reassigned\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("name is set before static initializers run", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() {}
+        const Bar = class {
+          static field = this.name;
+          static #priv = this.name;
+          static priv() { return this.#priv; }
+          static { console.log("static block:", this.name); }
+          @dec m() {}
+        };
+        console.log(Bar.name, Bar.field, Bar.priv());
+        const Baz = @dec class {
+          static field = this.name;
+        };
+        console.log(Baz.name, Baz.field);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("static block: Bar\nBar Bar Bar\nBaz Baz\n");
+      expect(exitCode).toBe(0);
     });
   });
 

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1141,6 +1141,31 @@ describe("ES Decorators", () => {
       expect(stdout).toBe('["Foo","from accessor"]\n');
       expect(exitCode).toBe(0);
     });
+
+    test.concurrent("a static `name` method keyed by an inlined TypeScript enum member wins too", async () => {
+      using dir = tempDir("es-dec-enum-name-key", {
+        "tsconfig.json": JSON.stringify({ compilerOptions: {} }),
+        "test.ts": `
+          enum Key { Name = "name" }
+          function dec() {}
+          const Foo = class {
+            static [Key.Name]() { return "method"; }
+            @dec m() {}
+          };
+          console.log(typeof Foo.name);
+        `,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(filterStderr(rawStderr)).toBe("");
+      expect(stdout).toBe("function\n");
+      expect(exitCode).toBe(0);
+    });
   });
 
   describe("private member calls in lowered classes", () => {

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1005,6 +1005,29 @@ describe("ES Decorators", () => {
       expect(exitCode).toBe(0);
     });
 
+    test.concurrent("console.log and Bun.inspect show the inferred name", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() {}
+        const Item = class { accessor id; };
+        const Decorated = class { @dec m() {} };
+        class Child extends Item {}
+        console.log(Item, Bun.inspect(new Item(), { compact: true }), Bun.inspect({ item: new Item() }, { compact: true }));
+        console.log(Decorated, Bun.inspect(new Decorated(), { compact: true }), Child);
+        const id = x => x;
+        const Nameless = id(class { @dec m() {} });
+        console.log(Nameless, Bun.inspect(new Nameless(), { compact: true }));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe(
+        [
+          "[class Item] Item { id: [Getter/Setter] } { item: Item { id: [Getter/Setter] } }",
+          "[class Decorated] Decorated { m: [Function: m] } [class Child extends Item]",
+          "[class (anonymous)] { m: [Function: m] }",
+        ].join("\n") + "\n",
+      );
+      expect(exitCode).toBe(0);
+    });
+
     test.concurrent("every naming context", async () => {
       const { stdout, stderr, exitCode } = await runDecorator(`
         function dec() {}


### PR DESCRIPTION
Stacked on #38922 (this PR's base branch): the formatter change there is what keeps `console.log` of these classes printing `[class Bar]` once the binding is gone (see Fix). Merge #38922 first; GitHub retargets this one to main.

### Problem

- With standard (TC39) decorators, an anonymous class expression whose name comes from its position gets the wrong `.name` once the module is bundled:
  ```js
  function dec() {}
  function f() {
    const Bar = class { @dec m() {} };
    console.log(Bar.name);
  }
  f();
  ```
  `bun repro.js` prints `Bar`; `bun build repro.js` prints `Bar2` (the output contains `_class = class Bar2 {`), and `--minify` prints a one-letter name. The same happens at the top level of a CommonJS-wrapped module, and for `accessor` members, which use the same lowering. It does not happen with a class decorator only because `__decorateElement(_init, 0, "Bar", ...)` re-applies the name at runtime.
- Cause: `lower_impl` in `src/js_parser/lower/lower_decorators.rs` rewrites the expression to `_class = class {}`, which would infer the name `"_class"`, and compensated by creating a symbol named after the context (`Bar`) and making it the class's own binding name. That symbol lands in the scope that also declares the user's `const Bar`, and the bundler's renamer (`assign_names_in_scope` in `src/js_printer/renamer.rs`) renames the second `Bar` it meets in a scope; declaring it in the class's own scope would not help, since the renamer also renames bindings that shadow an enclosing name (`bun build` turns an explicit `const Bar = class Bar {}` into `class Bar2` today).
- The same mechanism has two more visible effects in unbundled code:
  - names that cannot be a binding fall back to `"_class"`: `{ "foo-bar": class { @dec m() {} } }`, `{ default: ... }`, `{ "": ... }`, `export default (class { @dec m() {} })` (node: `"foo-bar"`, `"default"`, `""`, `"default"`), and a class with no naming context at all is named `"_class"` instead of `""`;
  - the synthesized binding shadows the outer variable inside the class body: in `let Bar = class { m() { return Bar } ... }; Bar = 1`, `m()` returns the class instead of `1`.

### Fix

- The lowering no longer gives the class a binding. Instead the class body starts with `static { __name(this, "Bar") }` (`"Bar"` being the context name, or `""` when there is none); the class decorator path still passes the same name to `__decorateElement` as before.
- Correct because the name is now a string literal rather than an identifier, so neither the bundler's renamer nor the minifier can alter it, any string works, and the class body keeps resolving `Bar` to the outer variable exactly as the source did. A static block runs during class definition, before the static field initializers the lowering leaves in the body (`static x = this.name`) and before the generated `__privateAdd` blocks, so everything that could observe the name still sees it; putting the `__name` call after the class expression would not. This is the shape esbuild emits for the same situation under `--keep-names`.
- No block is emitted when the class declares a static method, getter, setter or undecorated `accessor` keyed `name` (`defines_static_name_method`, checked on the source properties before decorated computed keys are replaced by temporaries, so `@dec static ["name"]() {}` counts, and looking through the wrapper same-file enum inlining leaves on a key, so `static [Key.Name]() {}` with `Name = "name"` counts too): those are installed from the class body before static blocks run, so the block would overwrite them, which a class binding never did. Members the lowering installs from the suffix (a `static name` field, decorated or not, and a decorated `accessor`) do not suppress the block: they replace the name after it, and static initializers before them still have to read the inferred name. Known limitation: a computed key that only evaluates to `"name"` at runtime (`static [k]() {}`) is not detected and the block overwrites that member, as esbuild's `--keep-names` also does; suppressing the block for every computed static key would instead drop the name for classes with `static [Symbol.iterator]()` and the like.
- Display: `console.log`, `Bun.inspect` and bun:test name a class from its executable, which for the lowered class is the `_class` temporary, so with the binding gone they printed `[class _class]` / `_class {}` where 1.4.0 printed `[class Bar]` / `Bar {}` (`.name` itself was right). #38922, the base of this PR, makes them use a `name` set with `Object.defineProperty`, which is also what tsc-compiled decorated classes need today; the new `console.log and Bun.inspect show the inferred name` test pins `[class Item] Item { ... }`, `[class Child extends Item]` and, for a class with no naming context, `[class (anonymous)]` for this PR's output.
- `__name` is an existing `runtime.js` helper (`__decorateElement` already calls it for class decorators), so bundled and unbundled output both have it; `can_be_class_binding_name` (the identifier filter for the old binding) is removed with the binding.
- Verification:
  - `test/bundler/bundler_edgecase.test.ts`: `DecoratedAnonymousClassExprKeepsInferredName` (function scope: `const`, `accessor`-only class, assignment, non-identifier key), the same input with `minifyIdentifiers`/`minifySyntax`/`minifyWhitespace`, and a CommonJS-wrapped module. On the unfixed build they print `["Bar2","Baz2","Qux2","_class4"]`, `["e","x","q","y"]` and `Bar2`.
  - `test/bundler/transpiler/es-decorators.test.ts`, new `inferred names of lowered anonymous class expressions` block: non-identifier names, every naming context (`const`, assignment, destructuring defaults, object key, static and instance class field, class decorator), no context gives `""`, the class body still sees the outer binding after reassignment, and the name is visible to inline static fields, a static private field initializer and a static block, with and without a class decorator. The `export default (class { @dec foo() {} })` test now also checks `.name === "default"`. A further test covers classes declaring their own static `name` getter, setter, method, decorated method, decorated computed `["name"]` method, a method keyed by an inlined TypeScript enum member (`.ts` file), `accessor`, and a field or decorated `accessor` preceded by an initializer that reads `this.name`. Expectations were cross-checked against node on the same code with the decorators removed. 4 of these fail on the unfixed build; the naming-context, static-initializer and static-`name` tests are regression guards for dropping the binding.
  - Existing suites pass: `es-decorators-esbuild.test.ts` (esbuild's 147 conformance tests), `es-decorators.test.ts`, `decorators.test.ts`, `decorator-metadata.test.ts`, `bundler_decorator_metadata.test.ts`, `ts-use-define-for-class-fields.test.ts`, `regression/issue/27575.test.ts`, `transpiler.test.js`, `esbuild/ts.test.ts`, `esbuild/default.test.ts`, `bundler_edgecase.test.ts`, `bundler_minify.test.ts`, `bundler_naming.test.ts`; `cargo clippy -p bun_js_parser` is clean.

### Background

- Name inference: an anonymous class or function expression takes its `.name` from where it appears (`const Bar = class {}`, `{ Bar: class {} }`, `Bar = class {}`, a default value in a destructuring pattern, `export default`). It only applies when the expression is directly in that position; once the lowering wraps it in `_class = class {}, ...` the inferred name becomes `_class`. The parser records the position's name in `decorator_class_name` and passes it to the lowering as `name_from_context`.
- Standard decorator lowering prints the class mostly as written, assigned to a hoisted `_class` temporary, followed by a comma list of `__decorateElement(...)` calls. Decorated and relocated static elements run in that suffix, but undecorated static fields stay in the class body and are evaluated while the class is being defined.
- Class static blocks (`static { ... }`) run in source order with the static field initializers during class definition, with `this` bound to the class, so a block placed first runs before any other static initializer.
- The bundler renames symbols with `NumberRenamer`: it walks each scope, keeps the first symbol with a given name, and renames later ones and ones that shadow a name from an enclosing scope by appending a number. It never sees string literals. `__name(target, name)` in `src/runtime.js` defines the `name` property on a function, the same helper the class decorator path uses.
- Related open work on this file: #38734 (unique temporary names; deliberately leaves this symbol alone), #38731 (a class statement's body observing the decorated class, which injects a static block of its own for statements only; this change is expression-only, so the two do not interact).
- #38758, opened a minute after this PR, removes the same binding but emits `__name(_class, ...)` after the class expression, and additionally fixes the `export default class { @dec m() {} }` statement form. Built at 50085c0, `const Bar = class { static x = this.name; @dec m() {} }` gives `Bar.x === "_class"` there (`"Bar"` on 1.4.0, node and this PR), because the class body has already run by then; that is what the static-block placement here is for. The statement-form fix is independent of this PR and can land on top of it.

<details>
<summary>Emitted code for the repro, before and after</summary>

Before (`bun build`):

```js
function f() {
  var _class, _init, _dec, _dec;
  const Bar = (_dec = [dec], _init = __decoratorStart(undefined), _class = class Bar2 {
    constructor() { __runInitializers(_init, 5, this); }
    m() {}
  }, __decorateElement(_init, 1, "m", _dec, _class), __decoratorMetadata(_init, _class), _class);
  console.log(Bar.name);
}
```

After:

```js
function f() {
  var _class, _init, _dec, _dec;
  const Bar = (_dec = [dec], _init = __decoratorStart(undefined), _class = class {
    static {
      __name(this, "Bar");
    }
    constructor() { __runInitializers(_init, 5, this); }
    m() {}
  }, __decorateElement(_init, 1, "m", _dec, _class), __decoratorMetadata(_init, _class), _class);
  console.log(Bar.name);
}
```

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bundler_edgecase.test.ts

<!-- robobun:evidence:end -->