### PR TITLE
js_parser: name an anonymous decorated export default class "default"

### DIFF
--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -123,8 +123,7 @@ fn class_copy(c: &G::Class) -> G::Class {
     }
 }
 
-/// Whether the class body defines a static member keyed `name` (`static get
-/// name()`, `static name = ...`), which replaces the constructor's own `name`.
+/// `static name`, `static get name()`, ...: the class replaces its own `.name`.
 fn defines_static_name(props: &[Property]) -> bool {
     props.iter().any(|prop| {
         prop.flags.contains(Flags::Property::IsStatic)
@@ -2412,14 +2411,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             new_properties = merged;
         }
 
-        // `_class = class {}` would infer the name "_class", so restore the one
-        // the source position inferred. It is set with `__name` instead of by
-        // naming the class binding: the bundler renames a binding that collides
-        // with the enclosing scope (`const Bar = class Bar2 {}`), and a binding
-        // would shadow the outer `Bar` inside the class body. The block goes
-        // first so static initializers left in the body observe the name. A body
-        // with its own static `name` gets no block: static methods and accessors
-        // are installed before any static block runs, so it would overwrite them.
+        // `_class = class {}` would be named "_class". A string literal, unlike a
+        // class binding, survives bundler renaming and shadows nothing in the body;
+        // the block goes first so static initializers already see the name.
         if expr_class_is_anonymous && !defines_static_name(&new_properties) {
             let this_e = p.new_expr(E::This {}, loc);
             let name_e = p.new_expr(

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -5,9 +5,8 @@ use bun_alloc::ArenaVecExt as _;
 
 use bun_collections::{HashMap, VecExt};
 
-use crate::lexer as js_lexer;
 use crate::p::P;
-use crate::parser::{ARGUMENTS_STR as arguments_str, Ref, is_eval_or_arguments};
+use crate::parser::{ARGUMENTS_STR as arguments_str, Ref};
 use bun_ast::g::{DeclList, Property, PropertyKind};
 use bun_ast::{self as js_ast, B, E, Expr, ExprNodeList, Flags, G, S, Stmt};
 
@@ -122,21 +121,6 @@ fn class_copy(c: &G::Class) -> G::Class {
         has_decorators: c.has_decorators,
         should_lower_standard_decorators: c.should_lower_standard_decorators,
     }
-}
-
-/// Whether a context-inferred name (`export default` → "default", object
-/// property keys, assignment targets) can be attached to a lowered anonymous
-/// class expression as its syntactic binding name. Class bodies are always
-/// strict mode code and the output may be a module, so reserved words
-/// ("default", "let", "await", …), `eval`/`arguments`, and non-identifier
-/// strings would turn `_class = class <name> {}` into a syntax error.
-#[inline]
-fn can_be_class_binding_name(name: &[u8]) -> bool {
-    js_lexer::is_identifier(name)
-        && js_lexer::keyword(name).is_none()
-        && !js_lexer::is_strict_mode_reserved_word(name)
-        && name != b"await"
-        && !is_eval_or_arguments(name)
 }
 
 // ── impl P ───────────────────────────────────────────────────────────────────
@@ -1142,14 +1126,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 class_name_ref = ecr;
                 class_name_loc = loc;
                 expr_class_is_anonymous = true;
-                if let Some(name) = name_from_context
-                    && can_be_class_binding_name(name)
-                {
-                    class.class_name = Some(js_ast::LocRef {
-                        ref_: p.new_sym(js_ast::symbol::Kind::Other, name),
-                        loc,
-                    });
-                }
             }
         } else {
             class_name_ref = class.class_name.as_ref().unwrap().ref_;
@@ -2420,6 +2396,26 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 merged.push(np);
             }
             new_properties = merged;
+        }
+
+        // `_class = class {}` would infer the name "_class", so restore the one
+        // the source position inferred. It is set with `__name` instead of by
+        // naming the class binding: the bundler renames a binding that collides
+        // with the enclosing scope (`const Bar = class Bar2 {}`), and a binding
+        // would shadow the outer `Bar` inside the class body. The block goes
+        // first so static initializers left in the body observe the name.
+        if expr_class_is_anonymous {
+            let this_e = p.new_expr(E::This {}, loc);
+            let name_e = p.new_expr(
+                E::EString {
+                    data: name_from_context.unwrap_or(b"").into(),
+                    ..Default::default()
+                },
+                loc,
+            );
+            let set_name = p.call_rt(loc, b"__name", &[this_e, name_e]);
+            let block = p.make_static_block(set_name, loc);
+            new_properties.insert(0, block);
         }
 
         class.properties = bun_ast::StoreSlice::new_mut(new_properties.into_bump_slice_mut());

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -123,8 +123,7 @@ fn class_copy(c: &G::Class) -> G::Class {
     }
 }
 
-/// A static method or accessor keyed `name` is installed before any static block runs.
-/// (A `static name` field is initialized after them and replaces the name by itself.)
+/// Installed before static blocks run; a `static name` field instead wins on its own.
 fn defines_static_name_method(props: &[Property]) -> bool {
     props.iter().any(|prop| {
         prop.flags.contains(Flags::Property::IsStatic)

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -123,10 +123,13 @@ fn class_copy(c: &G::Class) -> G::Class {
     }
 }
 
-/// `static name`, `static get name()`, ...: the class replaces its own `.name`.
-fn defines_static_name(props: &[Property]) -> bool {
+/// A static method or accessor keyed `name` is installed before any static block runs.
+/// (A `static name` field is initialized after them and replaces the name by itself.)
+fn defines_static_name_method(props: &[Property]) -> bool {
     props.iter().any(|prop| {
         prop.flags.contains(Flags::Property::IsStatic)
+            && (prop.flags.contains(Flags::Property::IsMethod)
+                || prop.kind == PropertyKind::AutoAccessor)
             && match &prop.key {
                 Some(key) => {
                     matches!(&key.data, js_ast::ExprData::EString(s) if s.eql_comptime(b"name"))
@@ -1144,6 +1147,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             class_name_ref = class.class_name.as_ref().unwrap().ref_;
             class_name_loc = class.class_name.as_ref().unwrap().loc;
         }
+        // Decided before Phase 2 replaces decorated computed keys with temporaries.
+        let restore_inferred_name =
+            expr_class_is_anonymous && !defines_static_name_method(class.properties.slice());
 
         let mut inner_class_ref: Ref = class_name_ref;
         if !is_expr {
@@ -2412,7 +2418,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
 
         // A string literal, unlike a class binding, survives the bundler's renaming.
-        if expr_class_is_anonymous && !defines_static_name(&new_properties) {
+        if restore_inferred_name {
             let this_e = p.new_expr(E::This {}, loc);
             let name_e = p.new_expr(
                 E::EString {

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -2411,9 +2411,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             new_properties = merged;
         }
 
-        // `_class = class {}` would be named "_class". A string literal, unlike a
-        // class binding, survives bundler renaming and shadows nothing in the body;
-        // the block goes first so static initializers already see the name.
+        // A string literal, unlike a class binding, survives the bundler's renaming.
         if expr_class_is_anonymous && !defines_static_name(&new_properties) {
             let this_e = p.new_expr(E::This {}, loc);
             let name_e = p.new_expr(

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -128,7 +128,8 @@ fn defines_static_name_method(props: &[Property]) -> bool {
     props.iter().any(|prop| {
         prop.flags.contains(Flags::Property::IsStatic)
             && (prop.flags.contains(Flags::Property::IsMethod)
-                || prop.kind == PropertyKind::AutoAccessor)
+                // A decorated accessor is installed from the suffix instead.
+                || (prop.kind == PropertyKind::AutoAccessor && prop.ts_decorators.len_u32() == 0))
             && match &prop.key {
                 Some(key) => {
                     matches!(&key.data, js_ast::ExprData::EString(s) if s.eql_comptime(b"name"))

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -123,6 +123,20 @@ fn class_copy(c: &G::Class) -> G::Class {
     }
 }
 
+/// Whether the class body defines a static member keyed `name` (`static get
+/// name()`, `static name = ...`), which replaces the constructor's own `name`.
+fn defines_static_name(props: &[Property]) -> bool {
+    props.iter().any(|prop| {
+        prop.flags.contains(Flags::Property::IsStatic)
+            && match &prop.key {
+                Some(key) => {
+                    matches!(&key.data, js_ast::ExprData::EString(s) if s.eql_comptime(b"name"))
+                }
+                None => false,
+            }
+    })
+}
+
 // ── impl P ───────────────────────────────────────────────────────────────────
 
 impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
@@ -2403,8 +2417,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // naming the class binding: the bundler renames a binding that collides
         // with the enclosing scope (`const Bar = class Bar2 {}`), and a binding
         // would shadow the outer `Bar` inside the class body. The block goes
-        // first so static initializers left in the body observe the name.
-        if expr_class_is_anonymous {
+        // first so static initializers left in the body observe the name. A body
+        // with its own static `name` gets no block: static methods and accessors
+        // are installed before any static block runs, so it would overwrite them.
+        if expr_class_is_anonymous && !defines_static_name(&new_properties) {
             let this_e = p.new_expr(E::This {}, loc);
             let name_e = p.new_expr(
                 E::EString {

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -1155,9 +1155,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             class_name_ref = class.class_name.as_ref().unwrap().ref_;
             class_name_loc = class.class_name.as_ref().unwrap().loc;
         }
-        // A statement only carries `name_from_context` ("default") when it is an
-        // anonymous `export default class {}` that the visitor named after the
-        // module's default-export symbol.
+        // Statements only carry a name when they are an anonymous `export default class`.
         let class_is_anonymous =
             expr_class_is_anonymous || (!is_expr && name_from_context.is_some());
         // Decided before Phase 2 replaces decorated computed keys with temporaries.

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -1067,6 +1067,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     pub(crate) fn lower_standard_decorators_stmt(
         &mut self,
         stmt: Stmt,
+        name_from_context: Option<&'a [u8]>,
         out: &mut BumpVec<'a, Stmt>,
     ) {
         // Every call site is the visitStmt `s_class` branch. `Stmt` and the
@@ -1078,7 +1079,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             js_ast::StmtData::SClass(c) => c,
             _ => unreachable!(),
         };
-        self.lower_impl(&mut s_class.class, stmt.loc, None, false, Some(stmt), out);
+        self.lower_impl(
+            &mut s_class.class,
+            stmt.loc,
+            name_from_context,
+            false,
+            Some(stmt),
+            out,
+        );
     }
 
     pub(crate) fn lower_standard_decorators_expr(
@@ -1147,9 +1155,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             class_name_ref = class.class_name.as_ref().unwrap().ref_;
             class_name_loc = class.class_name.as_ref().unwrap().loc;
         }
+        // A statement only carries `name_from_context` ("default") when it is an
+        // anonymous `export default class {}` that the visitor named after the
+        // module's default-export symbol.
+        let class_is_anonymous =
+            expr_class_is_anonymous || (!is_expr && name_from_context.is_some());
         // Decided before Phase 2 replaces decorated computed keys with temporaries.
         let restore_inferred_name =
-            expr_class_is_anonymous && !defines_static_name_method(class.properties.slice());
+            class_is_anonymous && !defines_static_name_method(class.properties.slice());
 
         let mut inner_class_ref: Ref = class_name_ref;
         if !is_expr {
@@ -2025,7 +2038,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             p.record_usage(class_name_ref);
             let class_name_str: E::Str = if let Some(name) = original_class_name_for_decorator {
                 name.into()
-            } else if is_expr && expr_class_is_anonymous {
+            } else if class_is_anonymous {
                 name_from_context.unwrap_or(b"").into()
             } else {
                 // `original_name` is an arena-owned `StoreStr`.

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -6470,7 +6470,12 @@ fn path_package_name<'a>(path: &fs::Path<'a>) -> Option<&'a [u8]> {
 }
 
 impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
-    pub(crate) fn lower_class(&mut self, stmtorexpr: js_ast::StmtOrExpr) -> &'a mut [Stmt] {
+    /// `name_from_context` is `Some("default")` for an anonymous `export default class`.
+    pub(crate) fn lower_class(
+        &mut self,
+        stmtorexpr: js_ast::StmtOrExpr,
+        name_from_context: Option<&'a [u8]>,
+    ) -> &'a mut [Stmt] {
         use js_ast::g::PropertyKind;
         match stmtorexpr {
             js_ast::StmtOrExpr::Stmt(stmt) => {
@@ -6485,7 +6490,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     // `lower_standard_decorators_stmt` takes an out-param Vec; wrap to
                     // keep this function's slice contract.
                     let mut out = BumpVec::<Stmt>::new_in(self.arena);
-                    self.lower_standard_decorators_stmt(stmt, &mut out);
+                    self.lower_standard_decorators_stmt(stmt, name_from_context, &mut out);
                     return out.into_bump_slice_mut();
                 }
 

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -815,6 +815,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         // needs one: legacy TS decorators (`has_decorators`) or
                         // standard decorator lowering, which also covers classes with
                         // only auto-accessor fields and no decorators.
+                        let mut name_from_context: Option<&'a [u8]> = None;
                         if class.class.has_decorators
                             || class.class.should_lower_standard_decorators
                         {
@@ -822,13 +823,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 || class.class.class_name.unwrap().ref_.is_empty()
                             {
                                 class.class.class_name = Some(data.default_name);
+                                name_from_context = Some(js_ast::ClauseItem::DEFAULT_ALIAS);
                             }
                         }
 
                         // Lower the class (handles both TS legacy and standard decorators).
                         // Standard decorator lowering may produce prefix statements
                         // (variable declarations) before the class statement.
-                        let class_stmts = p.lower_class(js_ast::StmtOrExpr::Stmt(s2_copy));
+                        let class_stmts =
+                            p.lower_class(js_ast::StmtOrExpr::Stmt(s2_copy), name_from_context);
 
                         // Find the s_class statement in the returned list
                         let mut class_stmt_idx: usize = 0;
@@ -1063,7 +1066,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
 
         // Lower class field syntax for browsers that don't support it
-        let lowered = p.lower_class(js_ast::StmtOrExpr::Stmt(*stmt));
+        let lowered = p.lower_class(js_ast::StmtOrExpr::Stmt(*stmt), None);
 
         if !mark_as_dead || was_export_inside_namespace {
             // Lower class field syntax for browsers that don't support it

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4899,9 +4899,7 @@ void JSC__VM__releaseWeakRefs(JSC::VM* arg0)
     arg0->finalizeSynchronousJSExecution();
 }
 
-// A "name" redefined with Object.defineProperty (tsc's __setFunctionName, esbuild's and Bun's
-// __name) is what node displays; JSC's calculatedDisplayName() only looks at "displayName" and
-// the executable. "displayName" keeps its precedence.
+// A "name" set with Object.defineProperty, which JSC's calculatedDisplayName() does not consult.
 static WTF::String explicitFunctionName(JSC::VM& vm, JSC::JSFunction* function)
 {
     if (!function->displayName(vm).isEmpty()) {
@@ -4916,8 +4914,7 @@ static WTF::String explicitFunctionName(JSC::VM& vm, JSC::JSFunction* function)
     return WTF::String();
 }
 
-// The function JSObject::calculatedClassName() would name an object after: its own
-// "constructor" (prototype objects) or its prototype's (instances).
+// The constructor JSObject::calculatedClassName() names an object after.
 static JSC::JSFunction* constructorForClassName(JSC::VM& vm, JSC::JSObject* object)
 {
     JSC::JSValue constructor = object->getDirect(vm, vm.propertyNames->constructor);

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4899,6 +4899,38 @@ void JSC__VM__releaseWeakRefs(JSC::VM* arg0)
     arg0->finalizeSynchronousJSExecution();
 }
 
+// A "name" redefined with Object.defineProperty (tsc's __setFunctionName, esbuild's and Bun's
+// __name) is what node displays; JSC's calculatedDisplayName() only looks at "displayName" and
+// the executable. "displayName" keeps its precedence.
+static WTF::String explicitFunctionName(JSC::VM& vm, JSC::JSFunction* function)
+{
+    if (!function->displayName(vm).isEmpty()) {
+        return WTF::String();
+    }
+
+    JSC::JSValue name = function->getDirect(vm, vm.propertyNames->name);
+    if (name && JSC::isJSString(name)) {
+        return JSC::asString(name)->tryGetValue();
+    }
+
+    return WTF::String();
+}
+
+// The function JSObject::calculatedClassName() would name an object after: its own
+// "constructor" (prototype objects) or its prototype's (instances).
+static JSC::JSFunction* constructorForClassName(JSC::VM& vm, JSC::JSObject* object)
+{
+    JSC::JSValue constructor = object->getDirect(vm, vm.propertyNames->constructor);
+    if (!constructor && !object->structure()->typeInfo().overridesGetPrototype()) {
+        JSC::JSValue prototype = object->getPrototypeDirect();
+        if (prototype.isObject()) {
+            constructor = JSC::asObject(prototype)->getDirect(vm, vm.propertyNames->constructor);
+        }
+    }
+
+    return constructor ? dynamicDowncast<JSC::JSFunction>(constructor) : nullptr;
+}
+
 void JSC__JSValue__getClassName(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* arg1, ZigString* arg2)
 {
     JSValue value = JSValue::decode(JSValue0);
@@ -4918,6 +4950,14 @@ void JSC__JSValue__getClassName(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObjec
     }
 
     JSObject* obj = value.toObject(arg1);
+
+    if (JSC::JSFunction* constructor = constructorForClassName(arg1->vm(), obj)) {
+        auto explicitName = explicitFunctionName(arg1->vm(), constructor);
+        if (!explicitName.isEmpty()) {
+            *arg2 = Zig::toZigString(explicitName);
+            return;
+        }
+    }
 
     auto calculated = JSObject::calculatedClassName(obj);
     if (calculated.length() > 0) {
@@ -4961,6 +5001,11 @@ void JSC__JSValue__getNameProperty(JSC::EncodedJSValue JSValue0, JSC::JSGlobalOb
     }
 
     if (JSC::JSFunction* function = dynamicDowncast<JSC::JSFunction>(obj)) {
+        WTF::String explicitName = explicitFunctionName(vm, function);
+        if (!explicitName.isEmpty()) {
+            *arg2 = Zig::toZigString(explicitName);
+            return;
+        }
 
         WTF::String actualName = function->name(vm);
         if (!actualName.isEmpty() || function->isHostOrBuiltinFunction()) {
@@ -4992,6 +5037,14 @@ void JSC__JSValue__getNameProperty(JSC::EncodedJSValue JSValue0, JSC::JSGlobalOb
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
     JSObject* object = value.getObject();
+    if (JSC::JSFunction* function = dynamicDowncast<JSC::JSFunction>(object)) {
+        auto explicitName = explicitFunctionName(vm, function);
+        if (!explicitName.isEmpty()) {
+            *arg2 = Bun::toStringRef(explicitName);
+            return;
+        }
+    }
+
     auto displayName = JSC::getCalculatedDisplayName(vm, object);
 
     // JSC doesn't include @@toStringTag in calculated display name

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -3170,6 +3170,51 @@ describe("bundler", () => {
     },
     run: { stdout: "try:false" },
   });
+  // Standard-decorator lowering rewrites `const Bar = class { ... }` into
+  // `_class = class { ... }`, so the class no longer infers its name from the
+  // binding. The name the lowering attaches instead has to survive the
+  // bundler's renaming of symbols that collide in the enclosing scope (the
+  // function-local `Bar` here, the CommonJS-wrapped module scope below) and
+  // identifier minification.
+  const decoratedAnonymousClassNames = /* js */ `
+    function dec() {}
+    function f() {
+      const Bar = class { @dec m() {} };
+      const Baz = class { accessor x; };
+      let Qux; Qux = class { @dec static s() {} };
+      const obj = { "not-an-identifier": class { @dec m() {} } };
+      return [Bar.name, Baz.name, Qux.name, obj["not-an-identifier"].name];
+    }
+    console.log(JSON.stringify(f()));
+  `;
+  itBundled("edgecase/DecoratedAnonymousClassExprKeepsInferredName", {
+    files: {
+      "/entry.js": decoratedAnonymousClassNames,
+    },
+    run: { stdout: '["Bar","Baz","Qux","not-an-identifier"]' },
+  });
+  itBundled("edgecase/DecoratedAnonymousClassExprKeepsInferredNameMinified", {
+    files: {
+      "/entry.js": decoratedAnonymousClassNames,
+    },
+    minifyIdentifiers: true,
+    minifySyntax: true,
+    minifyWhitespace: true,
+    run: { stdout: '["Bar","Baz","Qux","not-an-identifier"]' },
+  });
+  itBundled("edgecase/DecoratedAnonymousClassExprKeepsInferredNameInCJSWrapper", {
+    files: {
+      "/entry.js": /* js */ `
+        console.log(require("./mod.cjs").name);
+      `,
+      "/mod.cjs": /* js */ `
+        function dec() {}
+        const Bar = class { @dec m() {} };
+        module.exports = Bar;
+      `,
+    },
+    run: { stdout: "Bar" },
+  });
 });
 
 for (const backend of ["api", "cli"] as const) {

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1104,6 +1104,20 @@ describe("ES Decorators", () => {
       );
       expect(exitCode).toBe(0);
     });
+
+    test.concurrent("a decorated static accessor named `name` is installed after the body runs", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() {}
+        const Foo = class {
+          static seenBefore = this.name;
+          @dec static accessor name = "from accessor";
+        };
+        console.log(JSON.stringify([Foo.seenBefore, Foo.name]));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe('["Foo","from accessor"]\n');
+      expect(exitCode).toBe(0);
+    });
   });
 
   describe("private member calls in lowered classes", () => {

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1072,6 +1072,33 @@ describe("ES Decorators", () => {
       expect(stdout).toBe("static block: Bar\nBar Bar Bar\nBaz Baz\n");
       expect(exitCode).toBe(0);
     });
+
+    test.concurrent("a static member named `name` declared by the class wins", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() {}
+        const Getter = class { static get name() { return "from getter"; } @dec m() {} };
+        const Setter = class { static set name(v) {} @dec m() {} };
+        const Method = class { static name() {} @dec m() {} };
+        const DecoratedMethod = class { @dec static name() {} };
+        const Accessor = class { static accessor name = "from accessor"; @dec m() {} };
+        const Field = class { static name = "from field"; @dec m() {} };
+        const Uninitialized = class { static name; @dec m() {} };
+        const Instance = class { name = "instance"; @dec m() {} };
+        console.log(JSON.stringify([
+          Getter.name,
+          Setter.name,
+          typeof Method.name,
+          typeof DecoratedMethod.name,
+          Accessor.name,
+          Field.name,
+          Uninitialized.name,
+          Instance.name,
+        ]));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe('["from getter",null,"function","function","from accessor","from field",null,"Instance"]\n');
+      expect(exitCode).toBe(0);
+    });
   });
 
   describe("private member calls in lowered classes", () => {

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1080,8 +1080,9 @@ describe("ES Decorators", () => {
         const Setter = class { static set name(v) {} @dec m() {} };
         const Method = class { static name() {} @dec m() {} };
         const DecoratedMethod = class { @dec static name() {} };
+        const DecoratedComputed = class { @dec static ["name"]() {} };
         const Accessor = class { static accessor name = "from accessor"; @dec m() {} };
-        const Field = class { static name = "from field"; @dec m() {} };
+        const Field = class { static seenBefore = this.name; static name = "from field"; @dec m() {} };
         const Uninitialized = class { static name; @dec m() {} };
         const Instance = class { name = "instance"; @dec m() {} };
         console.log(JSON.stringify([
@@ -1089,14 +1090,18 @@ describe("ES Decorators", () => {
           Setter.name,
           typeof Method.name,
           typeof DecoratedMethod.name,
+          typeof DecoratedComputed.name,
           Accessor.name,
+          Field.seenBefore,
           Field.name,
           Uninitialized.name,
           Instance.name,
         ]));
       `);
       expect(stderr).toBe("");
-      expect(stdout).toBe('["from getter",null,"function","function","from accessor","from field",null,"Instance"]\n');
+      expect(stdout).toBe(
+        '["from getter",null,"function","function","function","from accessor","Field","from field",null,"Instance"]\n',
+      );
       expect(exitCode).toBe(0);
     });
   });

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -845,6 +845,7 @@ describe("ES Decorators", () => {
           import Cls from "./mod.js";
           const c = new Cls();
           console.log(c.foo());
+          console.log(Cls.name);
         `,
         "mod.js": `
           function dec(fn, ctx) { console.log("decorated", ctx.name); return fn; }
@@ -863,7 +864,7 @@ describe("ES Decorators", () => {
 
       const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(filterStderr(rawStderr)).toBe("");
-      expect(stdout).toBe("decorated foo\n42\n");
+      expect(stdout).toBe("decorated foo\n42\ndefault\n");
       expect(exitCode).toBe(0);
     });
 
@@ -979,6 +980,97 @@ describe("ES Decorators", () => {
       expect(output).not.toContain("class default");
       // the lowered output must still be valid syntax
       expect(() => new Bun.Transpiler({ loader: "js" }).transformSync(output)).not.toThrow();
+    });
+  });
+
+  describe("inferred names of lowered anonymous class expressions", () => {
+    // Lowering turns `const Bar = class { ... }` into `_class = class { ... }`,
+    // which would otherwise make the class infer the name "_class". The name
+    // the source position would have inferred must be restored without adding
+    // a class binding: a binding can only hold identifier names, shadows the
+    // outer variable inside the class body, and is renamed by the bundler.
+    test.concurrent("names that are not valid identifiers", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() {}
+        const obj = {
+          "foo-bar": class { @dec m() {} },
+          "": class { @dec m() {} },
+          default: class { @dec m() {} },
+          "with space": class { accessor x; },
+        };
+        console.log(JSON.stringify([obj["foo-bar"].name, obj[""].name, obj.default.name, obj["with space"].name]));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe('["foo-bar","","default","with space"]\n');
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("every naming context", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() {}
+        const A = class { @dec m() {} };
+        let B; B = class { @dec m() {} };
+        const { C = class { @dec m() {} } } = {};
+        const [D = class { @dec m() {} }] = [];
+        const obj = { E: class { @dec m() {} } };
+        class Holder {
+          static F = class { @dec m() {} };
+          G = class { @dec m() {} };
+        }
+        const H = @dec class {};
+        console.log(JSON.stringify([A.name, B.name, C.name, D.name, obj.E.name, Holder.F.name, new Holder().G.name, H.name]));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe('["A","B","C","D","E","F","G","H"]\n');
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("no naming context leaves the name empty", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() {}
+        const id = x => x;
+        console.log(JSON.stringify([id(class { @dec m() {} }).name, id(@dec class {}).name, id(class { accessor x; }).name]));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe('["","",""]\n');
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("class body still refers to the outer binding", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() {}
+        let Bar = class {
+          @dec m() { return Bar; }
+          static s() { return Bar; }
+        };
+        const Original = Bar;
+        Bar = "reassigned";
+        console.log(Original.name, new Original().m(), Original.s());
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("Bar reassigned reassigned\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("name is set before static initializers run", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() {}
+        const Bar = class {
+          static field = this.name;
+          static #priv = this.name;
+          static priv() { return this.#priv; }
+          static { console.log("static block:", this.name); }
+          @dec m() {}
+        };
+        console.log(Bar.name, Bar.field, Bar.priv());
+        const Baz = @dec class {
+          static field = this.name;
+        };
+        console.log(Baz.name, Baz.field);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("static block: Bar\nBar Bar Bar\nBaz Baz\n");
+      expect(exitCode).toBe(0);
     });
   });
 

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -983,7 +983,7 @@ describe("ES Decorators", () => {
         "entry.js": `
           import Cls from "./mod.js";
           console.log("static field:", Cls.observed);
-          console.log(Cls.name);
+          console.log(Cls.name, Cls, Bun.inspect(new Cls(), { compact: true }));
         `,
         "mod.js": `
           function dec(fn, ctx) {
@@ -993,12 +993,13 @@ describe("ES Decorators", () => {
             static observed = this.name;
             static { console.log("static block:", this.name); }
             @dec static foo() {}
-            @dec bar() {}
           }
         `,
       });
       expect(stderr).toBe("");
-      expect(stdout).toBe("static initializer: default\nstatic block: default\nstatic field: default\ndefault\n");
+      expect(stdout).toBe(
+        "static initializer: default\nstatic block: default\nstatic field: default\ndefault [class default] default {}\n",
+      );
       expect(exitCode).toBe(0);
     });
 
@@ -1028,7 +1029,7 @@ describe("ES Decorators", () => {
       const { stdout, stderr, exitCode } = await runFiles({
         "entry.js": `
           import Cls from "./mod.js";
-          console.log(Cls.name);
+          console.log(Cls.name, Cls);
         `,
         "mod.js": `
           function dec(cls, ctx) { console.log("ctx.name:", ctx.name, "cls.name:", cls.name); }
@@ -1036,7 +1037,7 @@ describe("ES Decorators", () => {
         `,
       });
       expect(stderr).toBe("");
-      expect(stdout).toBe("ctx.name: default cls.name: default\ndefault\n");
+      expect(stdout).toBe("ctx.name: default cls.name: default\ndefault [class default]\n");
       expect(exitCode).toBe(0);
     });
 

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -31,6 +31,20 @@ async function runDecorator(code: string) {
   return { stdout, stderr: filterStderr(rawStderr), exitCode };
 }
 
+async function runFiles(files: Record<string, string>, args: string[] = ["entry.js"]) {
+  using dir = tempDir("es-dec-files", files);
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), ...args],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr: filterStderr(rawStderr), exitCode };
+}
+
 describe("ES Decorators", () => {
   describe("class decorators", () => {
     test("basic class decorator", async () => {
@@ -957,6 +971,91 @@ describe("ES Decorators", () => {
       const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(filterStderr(rawStderr)).toBe("");
       expect(stdout).toBe("true\n");
+      expect(exitCode).toBe(0);
+    });
+
+    // The statement form is lowered as a declaration named after the module's
+    // default-export symbol (`mod_default`), which the lowering needs in order to
+    // refer to the class afterwards. Its `.name` must still be "default", as it
+    // is without decorators.
+    test.concurrent("anonymous export default class with member decorators is named 'default'", async () => {
+      const { stdout, stderr, exitCode } = await runFiles({
+        "entry.js": `
+          import Cls from "./mod.js";
+          console.log("static field:", Cls.observed);
+          console.log(Cls.name);
+        `,
+        "mod.js": `
+          function dec(fn, ctx) {
+            ctx.addInitializer(function () { console.log("static initializer:", this.name); });
+          }
+          export default class {
+            static observed = this.name;
+            static { console.log("static block:", this.name); }
+            @dec static foo() {}
+            @dec bar() {}
+          }
+        `,
+      });
+      expect(stderr).toBe("");
+      expect(stdout).toBe("static initializer: default\nstatic block: default\nstatic field: default\ndefault\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("anonymous TypeScript export default class with member decorators is named 'default'", async () => {
+      const { stdout, stderr, exitCode } = await runFiles(
+        {
+          "tsconfig.json": JSON.stringify({ compilerOptions: {} }),
+          "entry.ts": `
+            import Cls from "./mod.ts";
+            console.log(Cls.name);
+          `,
+          "mod.ts": `
+            function dec(fn: Function, ctx: ClassMethodDecoratorContext) { return fn; }
+            export default class {
+              @dec foo(): void {}
+            }
+          `,
+        },
+        ["entry.ts"],
+      );
+      expect(stderr).toBe("");
+      expect(stdout).toBe("default\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("class decorator on an anonymous export default class statement sees 'default'", async () => {
+      const { stdout, stderr, exitCode } = await runFiles({
+        "entry.js": `
+          import Cls from "./mod.js";
+          console.log(Cls.name);
+        `,
+        "mod.js": `
+          function dec(cls, ctx) { console.log("ctx.name:", ctx.name, "cls.name:", cls.name); }
+          @dec export default class {}
+        `,
+      });
+      expect(stderr).toBe("");
+      expect(stdout).toBe("ctx.name: default cls.name: default\ndefault\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("export default named class keeps its own name", async () => {
+      const { stdout, stderr, exitCode } = await runFiles({
+        "entry.js": `
+          import Cls from "./mod.js";
+          console.log(Cls.name);
+        `,
+        "mod.js": `
+          function classDec(cls, ctx) { console.log("ctx.name:", ctx.name); }
+          function dec(fn, ctx) { return fn; }
+          @classDec export default class Named {
+            @dec foo() {}
+          }
+        `,
+      });
+      expect(stderr).toBe("");
+      expect(stdout).toBe("ctx.name: Named\nNamed\n");
       expect(exitCode).toBe(0);
     });
   });

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1005,6 +1005,25 @@ describe("ES Decorators", () => {
       expect(exitCode).toBe(0);
     });
 
+    test.concurrent("console.log and Bun.inspect show the inferred name", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() {}
+        const Item = class { accessor id; };
+        const Decorated = class { @dec m() {} };
+        class Child extends Item {}
+        console.log(Item, Bun.inspect(new Item(), { compact: true }), Bun.inspect({ item: new Item() }, { compact: true }));
+        console.log(Decorated, Bun.inspect(new Decorated(), { compact: true }), Child);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe(
+        [
+          "[class Item] Item { id: [Getter/Setter] } { item: Item { id: [Getter/Setter] } }",
+          "[class Decorated] Decorated { m: [Function: m] } [class Child extends Item]",
+        ].join("\n") + "\n",
+      );
+      expect(exitCode).toBe(0);
+    });
+
     test.concurrent("every naming context", async () => {
       const { stdout, stderr, exitCode } = await runDecorator(`
         function dec() {}

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1058,6 +1058,36 @@ describe("ES Decorators", () => {
       expect(stdout).toBe("ctx.name: Named\nNamed\n");
       expect(exitCode).toBe(0);
     });
+
+    // The statement form goes through the same static `name` member rule as
+    // expressions: a member installed with the class body keeps the block out,
+    // a decorated accessor is installed afterwards and does not.
+    test.concurrent("anonymous export default class declaring its own static name", async () => {
+      const { stdout, stderr, exitCode } = await runFiles({
+        "entry.js": `
+          import WithGetter from "./getter.js";
+          import WithAccessor from "./accessor.js";
+          console.log(JSON.stringify([WithGetter.name, WithAccessor.seenBefore, WithAccessor.name]));
+        `,
+        "getter.js": `
+          function dec(fn, ctx) { return fn; }
+          export default class {
+            static get name() { return "own getter"; }
+            @dec m() {}
+          }
+        `,
+        "accessor.js": `
+          function dec() {}
+          export default class {
+            static seenBefore = this.name;
+            @dec static accessor name = "from accessor";
+          }
+        `,
+      });
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual(["own getter", "default", "from accessor"]);
+      expect(exitCode).toBe(0);
+    });
   });
 
   describe("anonymous class expressions with reserved-word inferred names", () => {

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -617,6 +617,55 @@ describe("console.logging class displays names and extends", async () => {
   }
 });
 
+describe("a name defined with Object.defineProperty is displayed", () => {
+  // tsc (__setFunctionName) and esbuild/Bun (__name) name the anonymous class their decorator
+  // lowering produces this way; the class binding they assign to is a temporary.
+  function setName(value, name) {
+    return Object.defineProperty(value, "name", { value: name, configurable: true });
+  }
+  class Base {}
+  const Item = setName(class {}, "Item");
+  const Derived = setName(class extends Base {}, "Derived");
+
+  it("class and instances", () => {
+    expect([Bun.inspect(Item), Bun.inspect(new Item()), Bun.inspect({ item: new Item() }, { compact: true })]).toEqual([
+      "[class Item]",
+      "Item {}",
+      "{ item: Item {} }",
+    ]);
+  });
+
+  it("extends clause and subclass instances", () => {
+    class Child extends Item {}
+    expect([Bun.inspect(Derived), Bun.inspect(new Derived()), Bun.inspect(Child), Bun.inspect(Item.prototype)]).toEqual(
+      ["[class Derived extends Base]", "Derived {}", "[class Child extends Item]", "Item {}"],
+    );
+  });
+
+  it("functions", () => {
+    expect(Bun.inspect(setName(function original() {}, "renamed"))).toBe("[Function: renamed]");
+  });
+
+  it("displayName still takes precedence", () => {
+    const fn = setName(function original() {}, "renamed");
+    fn.displayName = "Display";
+    expect(Bun.inspect(fn)).toBe("[Function: Display]");
+  });
+
+  it("a name accessor is not invoked", () => {
+    let called = false;
+    const Cls = Object.defineProperty(class Original {}, "name", {
+      get() {
+        called = true;
+        return "from getter";
+      },
+    });
+    expect(Bun.inspect(Cls)).toBe("[class Original]");
+    expect(Bun.inspect(new Cls())).toBe("Original {}");
+    expect(called).toBe(false);
+  });
+});
+
 it("console.log on a Blob shows name", () => {
   const blob = new Blob(["foo"], { type: "text/plain" });
   expect(Bun.inspect(blob)).toBe('Blob (3 bytes) {\n  type: "text/plain;charset=utf-8"\n}');


### PR DESCRIPTION
Status: the former base of this PR, #38757, is closed. #40833 superseded it. This PR now has main as its base and needs a rebase. Until then the diff also shows the old commits of #38757 and #38922. The own commits of this PR are 8b5c474b49, a547191f71, d7497b631d and 9ca04483bf. The text below describes the PR as it was on top of #38757. See https://github.com/oven-sh/bun/pull/38758#issuecomment-5655524119 for the cases that still fail on main.

### Problem

- With standard (TC39) decorators, an anonymous `export default class` statement gets the wrong name:
  - `export default class { @dec m() {} }` in `mod.js` has `.name === "mod_default"`; without the decorator it is `"default"`.
  - `@dec export default class {}` (decorator before `export`) sets `.name` to `"mod_default"` and passes it to the class decorator as `context.name`. The `export default @dec class {}` and `export default (class { ... })` forms are expressions and are handled by #38757.
- Cause: `s_export_default` (`src/js_parser/visit/visit_stmt.rs:824`) gives an anonymous class the module's default-export symbol as its class name, because decorator lowering needs a binding to refer to the class by. `lower_impl` in `src/js_parser/lower/lower_decorators.rs` cannot tell that binding apart from a user-written name, so the emitted declaration is `class mod_default { ... }` and the `__decorateElement` name argument is `"mod_default"`.

### Fix

- `s_export_default` passes `"default"` down as the class's name-from-context (through `lower_class` and `lower_standard_decorators_stmt`) exactly when it injects the default-export symbol; every other statement passes `None`, so a named class is unchanged.
- `lower_impl` treats a statement with a name-from-context as anonymous: it gets the same leading `static { __name(this, "default"); }` block #38757 emits for anonymous class expressions (same static `name` member guard), and `"default"` is what `__decorateElement` receives when there are class decorators, so `.name` and `context.name` are both `"default"`.
- Why this is correct: the spec names an anonymous default-export class `"default"` at class definition, before its static elements run and before decorators are applied; the block runs at that point, and the `mod_default` symbol stays a purely internal binding (it is still what the module exports as `default`). Legacy `experimentalDecorators` lowering ignores the argument and is unchanged (tsc also emits a generated name there, `default_1`).
- Verified with `test/bundler/transpiler/es-decorators.test.ts`, `export default class` block: the statement form (checking a static field initializer, a relocated static block and a static method initializer all observe `"default"`, and that `console.log` shows `[class default]` and `default {}` rather than the `mod_default` binding), the TypeScript variant, `@dec export default class {}` (`context.name`, the class passed to the decorator, the import, and its `console.log` output), a default export declaring its own static `name` getter (block suppressed) next to one with a decorated `static accessor name` (block emitted, an earlier static field sees `"default"`), and a named `@dec export default class Named` that must keep reporting `Named`. Built on #38757 (68a8a87) without the source change, four of these fail with `mod_default` and the named one passes; with it all 72 tests in the file pass.
- Also passing on the debug build of this branch: `es-decorators-esbuild.test.ts` (esbuild's 147 decorator tests), `decorators.test.ts`, `decorator-metadata.test.ts`, `bundler_decorator_metadata.test.ts`.

### Background

- An anonymous `export default class {}` has no binding of its own in the source; the module's `default` export refers to it through a synthesized symbol (printed as `mod_default`). Decorator lowering emits the class as a declaration and then statements that reference it (`__decorateElement(...)`, relocated static blocks), so it needs that symbol to be the declaration's name.
- #38757 stops the expression path from turning an inferred name into a class binding and instead restores the name with a `static { __name(this, "<name>") }` block at the top of the body, which runs before any other static element; `name_from_context` is the inferred name it uses. This PR feeds the statement path into that same mechanism. #38922 makes `console.log` / `Bun.inspect` display a name set this way, which is why the display assertions here need the full stack.

<details>
<summary>Emitted code and earlier revisions</summary>

`export default class { @dec m() {} }` now lowers to:

```js
export default class d_default {
  static {
    __name(this, "default");
  }
  constructor() { __runInitializers(_init, 5, this); }
  m() {}
}
__decorateElement(_init, 1, "m", _dec, d_default);
__decoratorMetadata(_init, d_default);
```

and `@dec export default class {}` passes `"default"`: `d_default = __decorateElement(_init, 0, "default", _dec, d_default)`.

Earlier revisions of this PR (50085c0, 4bf3526) also replaced the expression path's class binding, first with a `__name` call after the class and then with the leading static block. #38757, opened a minute earlier, makes the same expression-path change with the same guard, so this PR was reduced to the statement-form delta on top of it. The review findings on the earlier revisions (undecorated static fields running before an appended `__name`; the guard missing `@dec static ["name"]()`) are addressed in #38757's shape, which this commit reuses.

</details>

