### PR TITLE
install: say --network-concurrency defaults to 64 in help and docs

### DIFF
--- a/completions/bun-cli.json
+++ b/completions/bun-cli.json
@@ -427,7 +427,7 @@
         },
         {
           "name": "network-concurrency",
-          "description": "Maximum number of concurrent network requests (default 48)",
+          "description": "Maximum number of concurrent network requests (default 64)",
           "hasValue": true,
           "valueType": "val",
           "required": false,
@@ -748,7 +748,7 @@
         },
         {
           "name": "network-concurrency",
-          "description": "Maximum number of concurrent network requests (default 48)",
+          "description": "Maximum number of concurrent network requests (default 64)",
           "hasValue": true,
           "valueType": "val",
           "required": false,
@@ -1079,7 +1079,7 @@
         },
         {
           "name": "network-concurrency",
-          "description": "Maximum number of concurrent network requests (default 48)",
+          "description": "Maximum number of concurrent network requests (default 64)",
           "hasValue": true,
           "valueType": "val",
           "required": false,
@@ -1351,7 +1351,7 @@
         },
         {
           "name": "network-concurrency",
-          "description": "Maximum number of concurrent network requests (default 48)",
+          "description": "Maximum number of concurrent network requests (default 64)",
           "hasValue": true,
           "valueType": "val",
           "required": false,
@@ -1769,7 +1769,7 @@
         },
         {
           "name": "network-concurrency",
-          "description": "Maximum number of concurrent network requests (default 48)",
+          "description": "Maximum number of concurrent network requests (default 64)",
           "hasValue": true,
           "valueType": "val",
           "required": false,
@@ -2149,7 +2149,7 @@
         },
         {
           "name": "network-concurrency",
-          "description": "Maximum number of concurrent network requests (default 48)",
+          "description": "Maximum number of concurrent network requests (default 64)",
           "hasValue": true,
           "valueType": "val",
           "required": false,
@@ -2432,7 +2432,7 @@
         },
         {
           "name": "network-concurrency",
-          "description": "Maximum number of concurrent network requests (default 48)",
+          "description": "Maximum number of concurrent network requests (default 64)",
           "hasValue": true,
           "valueType": "val",
           "required": false,
@@ -2691,7 +2691,7 @@
         },
         {
           "name": "network-concurrency",
-          "description": "Maximum number of concurrent network requests (default 48)",
+          "description": "Maximum number of concurrent network requests (default 64)",
           "hasValue": true,
           "valueType": "val",
           "required": false,
@@ -2943,7 +2943,7 @@
         },
         {
           "name": "network-concurrency",
-          "description": "Maximum number of concurrent network requests (default 48)",
+          "description": "Maximum number of concurrent network requests (default 64)",
           "hasValue": true,
           "valueType": "val",
           "required": false,
@@ -3248,7 +3248,7 @@
         },
         {
           "name": "network-concurrency",
-          "description": "Maximum number of concurrent network requests (default 48)",
+          "description": "Maximum number of concurrent network requests (default 64)",
           "hasValue": true,
           "valueType": "val",
           "required": false,
@@ -3677,7 +3677,7 @@
         },
         {
           "name": "network-concurrency",
-          "description": "Maximum number of concurrent network requests (default 48)",
+          "description": "Maximum number of concurrent network requests (default 64)",
           "hasValue": true,
           "valueType": "val",
           "required": false,

--- a/docs/snippets/cli/add.mdx
+++ b/docs/snippets/cli/add.mdx
@@ -115,7 +115,7 @@ bun add <package> <@version>
   variables
 </ParamField>
 
-<ParamField path="--network-concurrency" type="number" default="48">
+<ParamField path="--network-concurrency" type="number" default="64">
   Maximum number of concurrent network requests
 </ParamField>
 

--- a/docs/snippets/cli/install.mdx
+++ b/docs/snippets/cli/install.mdx
@@ -156,7 +156,7 @@ bun install <name>@<version>
   Maximum number of concurrent jobs for lifecycle scripts (default: 2x CPU cores)
 </ParamField>
 
-<ParamField path="--network-concurrency" type="number" default="48">
+<ParamField path="--network-concurrency" type="number" default="64">
   Maximum number of concurrent network requests
 </ParamField>
 

--- a/docs/snippets/cli/link.mdx
+++ b/docs/snippets/cli/link.mdx
@@ -92,7 +92,7 @@ bun link <packages>
   variables
 </ParamField>
 
-<ParamField path="--network-concurrency" type="number" default="48">
+<ParamField path="--network-concurrency" type="number" default="64">
   Maximum number of concurrent network requests
 </ParamField>
 

--- a/docs/snippets/cli/outdated.mdx
+++ b/docs/snippets/cli/outdated.mdx
@@ -98,8 +98,8 @@ bun outdated <filter>
   Use a specific registry by default, overriding <code>.npmrc</code>, <code>bunfig.toml</code> and environment variables
 </ParamField>
 
-<ParamField path="--network-concurrency" type="number" default="48">
-  Maximum number of concurrent network requests (default 48)
+<ParamField path="--network-concurrency" type="number" default="64">
+  Maximum number of concurrent network requests (default 64)
 </ParamField>
 
 ### Caching

--- a/docs/snippets/cli/patch.mdx
+++ b/docs/snippets/cli/patch.mdx
@@ -100,8 +100,8 @@ bun patch <package>@<version>
   variables
 </ParamField>
 
-<ParamField path="--network-concurrency" type="number" default="48">
-  Maximum number of concurrent network requests (default 48)
+<ParamField path="--network-concurrency" type="number" default="64">
+  Maximum number of concurrent network requests (default 64)
 </ParamField>
 
 ### Performance &amp; Resource

--- a/docs/snippets/cli/publish.mdx
+++ b/docs/snippets/cli/publish.mdx
@@ -171,7 +171,7 @@ bun publish --cafile ./ca-cert.pem
   Platform optimizations: `clonefile` (default), `hardlink`, `symlink`, or `copyfile`
 </ParamField>
 
-<ParamField path="--network-concurrency" type="number" default="48">
+<ParamField path="--network-concurrency" type="number" default="64">
   Maximum concurrent network requests
 </ParamField>
 

--- a/docs/snippets/cli/remove.mdx
+++ b/docs/snippets/cli/remove.mdx
@@ -145,6 +145,6 @@ bun remove <package>
   <code>hardlink</code>, <code>symlink</code>, <code>copyfile</code>
 </ParamField>
 
-<ParamField path="--network-concurrency" type="number" default="48">
-  Maximum number of concurrent network requests (default 48)
+<ParamField path="--network-concurrency" type="number" default="64">
+  Maximum number of concurrent network requests (default 64)
 </ParamField>

--- a/docs/snippets/cli/update.mdx
+++ b/docs/snippets/cli/update.mdx
@@ -78,8 +78,8 @@ bun up
   Use a specific registry by default, overriding <code>.npmrc</code>, <code>bunfig.toml</code> and environment variables
 </ParamField>
 
-<ParamField path="--network-concurrency" type="number" default="48">
-  Maximum number of concurrent network requests (default 48)
+<ParamField path="--network-concurrency" type="number" default="64">
+  Maximum number of concurrent network requests (default 64)
 </ParamField>
 
 ### Caching

--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -104,7 +104,7 @@ const SHARED_TAIL_PARAMS: &[ParamType] = &[
         "--concurrent-scripts <NUM>            Maximum number of concurrent jobs for lifecycle scripts (default: 2x CPU cores)"
     ),
     clap::param!(
-        "--network-concurrency <NUM>           Maximum number of concurrent network requests (default 48)"
+        "--network-concurrency <NUM>           Maximum number of concurrent network requests (default 64)"
     ),
     clap::param!("--save-text-lockfile                  Save a text-based lockfile"),
     clap::param!(

--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -50,9 +50,6 @@ const BACKEND_PARAM: ParamType = clap::param!(
     "--backend <STR>                       Platform-specific optimizations for installing dependencies. Possible values: \"hardlink\" (default), \"symlink\", \"copyfile\""
 );
 
-// Same literal-only constraint: the default in this help text is a copy of
-// `DEFAULT_MAX_SIMULTANEOUS_REQUESTS_FOR_BUN_INSTALL`, so the assert below keeps
-// the two from drifting apart again.
 const NETWORK_CONCURRENCY_PARAM: ParamType = clap::param!(
     "--network-concurrency <NUM>           Maximum number of concurrent network requests (default 64)"
 );

--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -50,6 +50,18 @@ const BACKEND_PARAM: ParamType = clap::param!(
     "--backend <STR>                       Platform-specific optimizations for installing dependencies. Possible values: \"hardlink\" (default), \"symlink\", \"copyfile\""
 );
 
+// Same literal-only constraint: the default in this help text is a copy of
+// `DEFAULT_MAX_SIMULTANEOUS_REQUESTS_FOR_BUN_INSTALL`, so the assert below keeps
+// the two from drifting apart again.
+const NETWORK_CONCURRENCY_PARAM: ParamType = clap::param!(
+    "--network-concurrency <NUM>           Maximum number of concurrent network requests (default 64)"
+);
+const _: () = assert!(
+    super::DEFAULT_MAX_SIMULTANEOUS_REQUESTS_FOR_BUN_INSTALL == 64
+        && super::DEFAULT_MAX_SIMULTANEOUS_REQUESTS_FOR_BUN_INSTALL_FOR_PROXIES == 64,
+    "update the default in the --network-concurrency help text (and docs/snippets/cli/*.mdx)"
+);
+
 const SHARED_HEAD_PARAMS: &[ParamType] = &[
     clap::param!("-c, --config <STR>?                   Specify path to config file (bunfig.toml)"),
     clap::param!("-y, --yarn                            Write a yarn.lock file (yarn v1)"),
@@ -103,9 +115,7 @@ const SHARED_TAIL_PARAMS: &[ParamType] = &[
     clap::param!(
         "--concurrent-scripts <NUM>            Maximum number of concurrent jobs for lifecycle scripts (default: 2x CPU cores)"
     ),
-    clap::param!(
-        "--network-concurrency <NUM>           Maximum number of concurrent network requests (default 64)"
-    ),
+    NETWORK_CONCURRENCY_PARAM,
     clap::param!("--save-text-lockfile                  Save a text-based lockfile"),
     clap::param!(
         "--omit <dev|optional|peer>...         Exclude 'dev', 'optional', or 'peer' dependencies from install"

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -161,7 +161,7 @@ describe.concurrent("bun-install", () => {
       setContextHandler(ctx, async () => {
         inFlight++;
         maxInFlight = Math.max(maxInFlight, inFlight);
-        if (inFlight === documented) documentedLimitReached.resolve();
+        if (inFlight >= documented) documentedLimitReached.resolve();
         if (inFlight > documented) documentedLimitExceeded.resolve();
         await release.promise;
         inFlight--;
@@ -177,7 +177,11 @@ describe.concurrent("bun-install", () => {
         env: installEnv,
       });
       try {
-        await documentedLimitReached.promise;
+        // A limit lower than the documented one parks bun (and this wait) with
+        // fewer requests in flight and no further signal, so the wait is bounded
+        // (generously: this is a debug build under CI load) and the assertions
+        // below report what was reached. proc.exited covers bun giving up early.
+        await Promise.race([documentedLimitReached.promise, proc.exited, Bun.sleep(30_000)]);
         // bun sends everything its limit allows in one burst, so a request beyond
         // the documented limit arrives right behind the others. That it never
         // arrives can only be observed by giving it a moment to show up.

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -218,7 +218,7 @@ describe.concurrent("bun-install", () => {
   }`,
         );
         const { stderr, exited } = spawn({
-          cmd: [bunExe(), "install", "--network-concurrency", "abcdef"],
+          cmd: [bunExe(), "install", "--network-concurrency", input],
           cwd: ctx.package_dir,
           stdout: "inherit",
           stdin: "inherit",
@@ -226,7 +226,7 @@ describe.concurrent("bun-install", () => {
           env,
         });
         const err = await stderr.text();
-        expect(err).toContain("Expected --network-concurrency to be a number between 0 and 65535");
+        expect(err).toContain(`Expected --network-concurrency to be a number between 0 and 65535: ${input}`);
         expect(await exited).toBe(1);
         expect(urls).toBeEmpty();
       });

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -67,6 +67,66 @@ async function withContext(
 // Default context options for most tests
 const defaultOpts = { linker: "hoisted" as const };
 
+// BUN_CONFIG_MAX_HTTP_REQUESTS is documented as another way to set the request
+// limit, so it must not leak in from the outer environment while measuring it.
+const networkConcurrencyEnv = { ...env, BUN_CONFIG_MAX_HTTP_REQUESTS: undefined };
+
+// Runs `bun install` with one dependency more than `limit`, against a registry
+// that holds every manifest request open, and asserts that bun has exactly
+// `limit` requests in flight: the extra dependency has to wait for a slot.
+async function expectInstallInFlightLimit(ctx: TestContext, limit: number) {
+  const dependencies: Record<string, string> = {};
+  for (let i = 0; i < limit + 1; i++) dependencies[`dep-${i}`] = "^1";
+  await writeFile(
+    join(ctx.package_dir, "package.json"),
+    JSON.stringify({ name: "foo", version: "0.0.1", dependencies }),
+  );
+
+  let inFlight = 0;
+  let maxInFlight = 0;
+  const limitReached = Promise.withResolvers<void>();
+  const limitExceeded = Promise.withResolvers<void>();
+  const release = Promise.withResolvers<void>();
+  setContextHandler(ctx, async () => {
+    inFlight++;
+    maxInFlight = Math.max(maxInFlight, inFlight);
+    if (inFlight >= limit) limitReached.resolve();
+    if (inFlight > limit) limitExceeded.resolve();
+    await release.promise;
+    inFlight--;
+    return new Response("404", { status: 404 });
+  });
+
+  await using proc = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: ctx.package_dir,
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+    env: networkConcurrencyEnv,
+  });
+  try {
+    // A real limit below `limit` parks bun (and this wait) with fewer requests
+    // in flight and no further signal, so the wait is bounded (generously: this
+    // is a debug build under CI load) and the assertions below report what was
+    // reached. proc.exited covers bun giving up early.
+    await Promise.race([limitReached.promise, proc.exited, Bun.sleep(30_000)]);
+    // bun sends everything its limit allows in one burst, so a request beyond
+    // the limit arrives right behind the others. That it never arrives can only
+    // be observed by giving it a moment to show up.
+    await Promise.race([limitExceeded.promise, Bun.sleep(500)]);
+  } finally {
+    release.resolve();
+  }
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(maxInFlight).toBe(limit);
+  expect(ctx.requested).toBe(limit + 1);
+  expect(stderr).toContain("failed to resolve");
+  expect(stdout).toContain("bun install v1.");
+  expect(exitCode).toBe(1);
+}
+
 const gitEnv = {
   ...bunEnv,
   GIT_AUTHOR_NAME: "bun-test",
@@ -122,14 +182,11 @@ function serveDirectory(root: string) {
 
 describe.concurrent("bun-install", () => {
   it("bun install --help states the --network-concurrency default that bun install actually uses", async () => {
-    // BUN_CONFIG_MAX_HTTP_REQUESTS also configures this limit; this test is about the default.
-    const installEnv = { ...env, BUN_CONFIG_MAX_HTTP_REQUESTS: undefined };
-
     await using help = spawn({
       cmd: [bunExe(), "install", "--help"],
       stdout: "pipe",
       stderr: "pipe",
-      env: installEnv,
+      env,
     });
     const [helpStdout, helpStderr, helpExitCode] = await Promise.all([
       help.stdout.text(),
@@ -140,63 +197,8 @@ describe.concurrent("bun-install", () => {
     const documentedDefault = /Maximum number of concurrent network requests \(default (\d+)\)$/.exec(helpLine ?? "");
     expect(documentedDefault).not.toBeNull();
     expect(helpExitCode).toBe(0);
-    const documented = Number(documentedDefault![1]);
 
-    await withContext(defaultOpts, async ctx => {
-      // One dependency more than the documented limit. Every manifest request is
-      // held open, so bun can only ever have as many in flight as its limit
-      // allows and the extra one has to wait for a slot.
-      const dependencies: Record<string, string> = {};
-      for (let i = 0; i < documented + 1; i++) dependencies[`dep-${i}`] = "^1";
-      await writeFile(
-        join(ctx.package_dir, "package.json"),
-        JSON.stringify({ name: "foo", version: "0.0.1", dependencies }),
-      );
-
-      let inFlight = 0;
-      let maxInFlight = 0;
-      const documentedLimitReached = Promise.withResolvers<void>();
-      const documentedLimitExceeded = Promise.withResolvers<void>();
-      const release = Promise.withResolvers<void>();
-      setContextHandler(ctx, async () => {
-        inFlight++;
-        maxInFlight = Math.max(maxInFlight, inFlight);
-        if (inFlight >= documented) documentedLimitReached.resolve();
-        if (inFlight > documented) documentedLimitExceeded.resolve();
-        await release.promise;
-        inFlight--;
-        return new Response("404", { status: 404 });
-      });
-
-      await using proc = spawn({
-        cmd: [bunExe(), "install"],
-        cwd: ctx.package_dir,
-        stdout: "pipe",
-        stderr: "pipe",
-        stdin: "ignore",
-        env: installEnv,
-      });
-      try {
-        // A limit lower than the documented one parks bun (and this wait) with
-        // fewer requests in flight and no further signal, so the wait is bounded
-        // (generously: this is a debug build under CI load) and the assertions
-        // below report what was reached. proc.exited covers bun giving up early.
-        await Promise.race([documentedLimitReached.promise, proc.exited, Bun.sleep(30_000)]);
-        // bun sends everything its limit allows in one burst, so a request beyond
-        // the documented limit arrives right behind the others. That it never
-        // arrives can only be observed by giving it a moment to show up.
-        await Promise.race([documentedLimitExceeded.promise, Bun.sleep(500)]);
-      } finally {
-        release.resolve();
-      }
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-      expect(maxInFlight).toBe(documented);
-      expect(ctx.requested).toBe(documented + 1);
-      expect(stderr).toContain("failed to resolve");
-      expect(stdout).toContain("bun install v1.");
-      expect(exitCode).toBe(1);
-    });
+    await withContext(defaultOpts, ctx => expectInstallInFlightLimit(ctx, Number(documentedDefault![1])));
   });
 
   for (let input of ["abcdef", "65537", "-1"]) {

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -121,6 +121,80 @@ function serveDirectory(root: string) {
 }
 
 describe.concurrent("bun-install", () => {
+  it("bun install --help states the --network-concurrency default that bun install actually uses", async () => {
+    // BUN_CONFIG_MAX_HTTP_REQUESTS also configures this limit; this test is about the default.
+    const installEnv = { ...env, BUN_CONFIG_MAX_HTTP_REQUESTS: undefined };
+
+    await using help = spawn({
+      cmd: [bunExe(), "install", "--help"],
+      stdout: "pipe",
+      stderr: "pipe",
+      env: installEnv,
+    });
+    const [helpStdout, helpStderr, helpExitCode] = await Promise.all([
+      help.stdout.text(),
+      help.stderr.text(),
+      help.exited,
+    ]);
+    const helpLine = (helpStdout + helpStderr).split(/\r?\n/).find(line => line.includes("--network-concurrency"));
+    const documentedDefault = /Maximum number of concurrent network requests \(default (\d+)\)$/.exec(helpLine ?? "");
+    expect(documentedDefault).not.toBeNull();
+    expect(helpExitCode).toBe(0);
+    const documented = Number(documentedDefault![1]);
+
+    await withContext(defaultOpts, async ctx => {
+      // One dependency more than the documented limit. Every manifest request is
+      // held open, so bun can only ever have as many in flight as its limit
+      // allows and the extra one has to wait for a slot.
+      const dependencies: Record<string, string> = {};
+      for (let i = 0; i < documented + 1; i++) dependencies[`dep-${i}`] = "^1";
+      await writeFile(
+        join(ctx.package_dir, "package.json"),
+        JSON.stringify({ name: "foo", version: "0.0.1", dependencies }),
+      );
+
+      let inFlight = 0;
+      let maxInFlight = 0;
+      const documentedLimitReached = Promise.withResolvers<void>();
+      const documentedLimitExceeded = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      setContextHandler(ctx, async () => {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        if (inFlight === documented) documentedLimitReached.resolve();
+        if (inFlight > documented) documentedLimitExceeded.resolve();
+        await release.promise;
+        inFlight--;
+        return new Response("404", { status: 404 });
+      });
+
+      await using proc = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: ctx.package_dir,
+        stdout: "pipe",
+        stderr: "pipe",
+        stdin: "ignore",
+        env: installEnv,
+      });
+      try {
+        await documentedLimitReached.promise;
+        // bun sends everything its limit allows in one burst, so a request beyond
+        // the documented limit arrives right behind the others. That it never
+        // arrives can only be observed by giving it a moment to show up.
+        await Promise.race([documentedLimitExceeded.promise, Bun.sleep(500)]);
+      } finally {
+        release.resolve();
+      }
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(maxInFlight).toBe(documented);
+      expect(ctx.requested).toBe(documented + 1);
+      expect(stderr).toContain("failed to resolve");
+      expect(stdout).toContain("bun install v1.");
+      expect(exitCode).toBe(1);
+    });
+  });
+
   for (let input of ["abcdef", "65537", "-1"]) {
     it(`bun install --network-concurrency=${input} fails`, async () => {
       await withContext(defaultOpts, async ctx => {


### PR DESCRIPTION
### Problem
- `bun install --help` (and add, remove, update, outdated, patch, publish, link, info, which share the same flag table) prints `--network-concurrency <NUM>  Maximum number of concurrent network requests (default 48)`. The eight `docs/snippets/cli/*.mdx` flag references and `completions/bun-cli.json` say 48 as well.
- `bun install` actually uses 64: `DEFAULT_MAX_SIMULTANEOUS_REQUESTS_FOR_BUN_INSTALL` and its proxy variant are both 64 in `src/install/PackageManager.rs:289-290`, and that is what `init` stores into `MAX_SIMULTANEOUS_REQUESTS` when the flag is not passed (`PackageManager.rs:2276-2290`).
- The constant was raised from 48 to 64 in 2de2e9f600, the same day the flag landed (#14755). The help string is a separate literal (`clap::param!` only takes literals, see the comment above `BACKEND_PARAM`), so nothing tied the two together and the text was never updated.

### Fix
- `src/install/PackageManager/CommandLineArguments.rs`: the help string says `(default 64)`. The param is now a named const with a `const _: () = assert!(...)` under it that checks both install defaults are still 64, so the next change to the constant fails to compile until the help text is updated. Verified by setting the constant to 48: the build stops with `evaluation panicked: update the default in the --network-concurrency help text (and docs/snippets/cli/*.mdx)` at that assert.
- `docs/snippets/cli/{install,add,remove,update,outdated,patch,publish,link}.mdx`: `default="64"`, and the four descriptions that repeated the number now say 64 too.
- `completions/bun-cli.json`: the eleven copies of this flag's description updated to the text the generator would now emit. Other flags in this file are stale as well; that is left for a regeneration, as with the targeted edits in #38333.
- Correct because the number in the help text is documentation of the constant, and the constant is 64. The assert pins the literal to the constant at compile time; the test below checks the other half, that the constant is what a plain `bun install` really runs with and that `--help` prints it.
- Test: `test/cli/install/bun-install.test.ts`, "bun install --help states the --network-concurrency default that bun install actually uses". It reads `(default N)` out of `bun install --help` and hands N to `expectInstallInFlightLimit`, which runs a plain `bun install` with N+1 dependencies against a registry stub that holds every manifest request open and asserts exactly N requests end up in flight (the extra one has to wait for a slot). The stub lives in a helper so #38744, which adds `BUN_CONFIG_MAX_HTTP_REQUESTS` rows to the neighbouring `--network-concurrency=5` test, can use the same mechanism; the two branches currently merge without conflicts.
  - Unfixed build (help says 48): fails with `Expected: 48, Received: 49`, because bun puts all 49 requests in flight.
  - Fixed build: passes (25/25 across reruns of the five `--network-concurrency` tests under the debug build, about 1s each).
  - A real limit below the printed one, or bun exiting early, ends in the same `maxInFlight` assertion (checked by forcing N=65 against the 64 build: `Expected: 65, Received: 64`). The 30s race bound exists only for that failure path; the 500ms window is how long an over-limit request gets to show up.
  - Whole file under `bun bd test`: the only failures are the pre-existing bitbucket/gitlab/external-URL tests, which need internet access and fail identically on an unmodified checkout here. On CI the file passed on the x64 ASAN lane.
  - All nine commands that carry the flag print `(default 64)` with the debug build.
- Also in that file (review finding): the existing `--network-concurrency=<invalid>` loop spawned `abcdef` on every iteration, so its `65537` and `-1` cases tested nothing. It now passes each value and expects it echoed in the error; all three values are rejected by the current parser, so the three tests still pass.

### Background
- `--network-concurrency` caps how many HTTP requests `bun install` keeps in flight at once. The cap is a process-wide atomic in the HTTP client (`MAX_SIMULTANEOUS_REQUESTS`); the HTTP thread starts queued requests until that many are active and parks the rest (`src/http/HTTPThread.rs` around line 890), which is why a registry stub that never answers observes exactly the cap.
- The flag is defined once in `SHARED_TAIL_PARAMS` and concatenated into every package-manager command's flag table, so one help string covers all of the commands listed above.
- `const _: () = assert!(...)` is a compile-time assertion: the expression is evaluated while compiling and a false result is a build error. The crate already uses it to pin literals to the constants they mirror (for example `src/install/npm.rs` pins the manifest cache header length).
- `docs/snippets/cli/*.mdx` are the flag-reference blocks included by the `docs/pm/cli/*.mdx` pages; `completions/bun-cli.json` is a checked-in dump of the `--help` output that `misctools/generate-cli-completions.ts` produces.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install.test.ts

<!-- robobun:evidence:end -->