### PR TITLE
js_parser: declare temporaries hoisted out of enum initializers inside the enum closure

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -598,7 +598,11 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     // If this is true, then all top-level statements are wrapped in a try/catch
     pub(crate) will_wrap_module_in_try_catch_for_using: bool,
 
-    /// Used for react refresh, it must be able to insert `const _s = $RefreshSig$();`
+    /// Statement list that declarations hoisted out of the expression being
+    /// visited are appended to (react refresh's `const _s = $RefreshSig$();`,
+    /// the `var` temporaries of a lowered class expression). Points at the
+    /// `before` list of the `visit_stmts` in progress, or at the body of the
+    /// closure an enum compiles to while its members are visited (`s_enum`).
     pub(crate) nearest_stmt_list: Option<NonNull<ListManaged<'a, Stmt>>>,
     // Lifetime caution: points at a stack local saved/restored across calls.
     /// Name from assignment context for anonymous decorated class expressions.
@@ -660,9 +664,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     /// Safe mutable projection of `nearest_stmt_list`.
     ///
-    /// The pointer targets a `ListManaged` living on a parent
-    /// `visit_stmts_and_prepend_temp_refs` stack frame (saved/restored around
-    /// each visit), disjoint from `*self`, so a transient `&mut` tied to
+    /// The pointer targets a `ListManaged` living on an enclosing `visit_stmts`
+    /// or `s_enum` stack frame (saved/restored around each visit), disjoint
+    /// from `*self`, so a transient `&mut` tied to
     /// `&mut self` cannot alias any other live borrow. Centralises the
     /// `unsafe` so call sites stay safe.
     #[inline]

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -598,11 +598,8 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     // If this is true, then all top-level statements are wrapped in a try/catch
     pub(crate) will_wrap_module_in_try_catch_for_using: bool,
 
-    /// Statement list that declarations hoisted out of the expression being
-    /// visited are appended to (react refresh's `const _s = $RefreshSig$();`,
-    /// the `var` temporaries of a lowered class expression). Points at the
-    /// `before` list of the `visit_stmts` in progress, or at the body of the
-    /// closure an enum compiles to while its members are visited (`s_enum`).
+    /// Receives declarations hoisted out of the expression being visited: the
+    /// `before` list of the current `visit_stmts`, or the enum closure body in `s_enum`.
     pub(crate) nearest_stmt_list: Option<NonNull<ListManaged<'a, Stmt>>>,
     // Lifetime caution: points at a stack local saved/restored across calls.
     /// Name from assignment context for anonymous decorated class expressions.
@@ -663,12 +660,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     /// Safe mutable projection of `nearest_stmt_list`.
-    ///
-    /// The pointer targets a `ListManaged` living on an enclosing `visit_stmts`
-    /// or `s_enum` stack frame (saved/restored around each visit), disjoint
-    /// from `*self`, so a transient `&mut` tied to
-    /// `&mut self` cannot alias any other live borrow. Centralises the
-    /// `unsafe` so call sites stay safe.
     #[inline]
     pub(crate) fn nearest_stmt_list_mut(&mut self) -> Option<&mut ListManaged<'a, Stmt>> {
         // SAFETY: `nearest_stmt_list` is a back-pointer to stack storage on

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -598,8 +598,7 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     // If this is true, then all top-level statements are wrapped in a try/catch
     pub(crate) will_wrap_module_in_try_catch_for_using: bool,
 
-    /// Receives declarations hoisted out of the expression being visited: the
-    /// `before` list of the current `visit_stmts`, or the enum closure body in `s_enum`.
+    /// Receives hoisted declarations; installed by `visit_stmts` and, for enum members, `s_enum`.
     pub(crate) nearest_stmt_list: Option<NonNull<ListManaged<'a, Stmt>>>,
     // Lifetime caution: points at a stack local saved/restored across calls.
     /// Name from assignment context for anonymous decorated class expressions.

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -598,7 +598,7 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     // If this is true, then all top-level statements are wrapped in a try/catch
     pub(crate) will_wrap_module_in_try_catch_for_using: bool,
 
-    /// Receives hoisted declarations; installed by `visit_stmts` and, for enum members, `s_enum`.
+    /// Receives hoisted declarations; `visit_stmts` and `s_enum` keep it installed while visiting.
     pub(crate) nearest_stmt_list: Option<NonNull<ListManaged<'a, Stmt>>>,
     // Lifetime caution: points at a stack local saved/restored across calls.
     /// Name from assignment context for anonymous decorated class expressions.
@@ -661,6 +661,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     /// Safe mutable projection of `nearest_stmt_list`.
     #[inline]
     pub(crate) fn nearest_stmt_list_mut(&mut self) -> Option<&mut ListManaged<'a, Stmt>> {
+        debug_assert!(
+            self.nearest_stmt_list.is_some(),
+            "nearest_stmt_list read outside of visit_stmts / s_enum; the hoisted declaration would be dropped"
+        );
         // SAFETY: `nearest_stmt_list` is a back-pointer to stack storage on
         // the enclosing visit frame, set before recursion and restored before
         // that frame returns. It is disjoint from `*self` and from any other

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -2511,7 +2511,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         if let Some(hook) = react_hook_data.as_mut() {
             'try_mark_hook: {
-                if p.nearest_stmt_list.is_none() {
+                if p.nearest_stmt_list_mut().is_none() {
                     break 'try_mark_hook;
                 }
                 let decl = p.get_react_refresh_hook_signal_decl(hook.signature_cb);
@@ -2591,7 +2591,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         if let Some(hook) = react_hook_data.as_mut() {
             'try_mark_hook: {
-                if p.nearest_stmt_list.is_none() {
+                if p.nearest_stmt_list_mut().is_none() {
                     break 'try_mark_hook;
                 }
                 let decl = p.get_react_refresh_hook_signal_decl(hook.signature_cb);

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -2191,6 +2191,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             p.should_fold_typescript_constant_expressions;
         p.should_fold_typescript_constant_expressions = true;
 
+        // `var`s hoisted out of the initializers (e.g. the temporaries of a lowered
+        // class expression) go at the top of the closure the body compiles to. The
+        // enclosing statement list is not usable here: enums are visited ahead of
+        // their siblings, before `visit_stmts` installs it, and at the top level
+        // there is none at all, which used to drop the declarations.
+        let mut hoisted_stmts: StmtList<'a> = BumpVec::new_in(p.arena);
+        let prev_nearest_stmt_list = p.nearest_stmt_list;
+        p.nearest_stmt_list = core::ptr::NonNull::new(core::ptr::addr_of_mut!(hoisted_stmts));
+
         // Create an assignment for each enum value
         for value in values.iter_mut() {
             let name: &'a [u8] = value.name.slice();
@@ -2313,11 +2322,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
 
+        p.nearest_stmt_list = prev_nearest_stmt_list;
         p.pop_scope();
         p.should_fold_typescript_constant_expressions =
             old_should_fold_typescript_constant_expressions;
 
-        let mut value_stmts: StmtList<'a> = BumpVec::with_capacity_in(value_exprs.len(), p.arena);
+        let mut value_stmts: StmtList<'a> = hoisted_stmts;
+        value_stmts.reserve(value_exprs.len());
         // Generate statements from expressions
         for expr in value_exprs.iter() {
             value_stmts.push(p.s(

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -2191,11 +2191,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             p.should_fold_typescript_constant_expressions;
         p.should_fold_typescript_constant_expressions = true;
 
-        // `var`s hoisted out of the initializers (e.g. the temporaries of a lowered
-        // class expression) go at the top of the closure the body compiles to. The
-        // enclosing statement list is not usable here: enums are visited ahead of
-        // their siblings, before `visit_stmts` installs it, and at the top level
-        // there is none at all, which used to drop the declarations.
+        // Declarations hoisted out of the initializers (e.g. a lowered class expression's
+        // temporaries) go at the top of the enum closure; enums are visited before the
+        // enclosing statement list exists.
         let mut hoisted_stmts: StmtList<'a> = BumpVec::new_in(p.arena);
         let prev_nearest_stmt_list = p.nearest_stmt_list;
         p.nearest_stmt_list = core::ptr::NonNull::new(core::ptr::addr_of_mut!(hoisted_stmts));

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -2191,9 +2191,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             p.should_fold_typescript_constant_expressions;
         p.should_fold_typescript_constant_expressions = true;
 
-        // Declarations hoisted out of the initializers (e.g. a lowered class expression's
-        // temporaries) go at the top of the enum closure; enums are visited before the
-        // enclosing statement list exists.
+        // Declarations hoisted out of the initializers are emitted at the top of the enum closure.
         let mut hoisted_stmts: StmtList<'a> = BumpVec::new_in(p.arena);
         let prev_nearest_stmt_list = p.nearest_stmt_list;
         p.nearest_stmt_list = core::ptr::NonNull::new(core::ptr::addr_of_mut!(hoisted_stmts));

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -31,6 +31,21 @@ async function runDecorator(code: string) {
   return { stdout, stderr: filterStderr(rawStderr), exitCode };
 }
 
+async function runDecoratorTS(code: string) {
+  using dir = tempDir("es-dec-ts", {
+    "tsconfig.json": JSON.stringify({ compilerOptions: {} }),
+    "test.ts": code,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr: filterStderr(rawStderr), exitCode };
+}
+
 describe("ES Decorators", () => {
   describe("class decorators", () => {
     test("basic class decorator", async () => {
@@ -390,21 +405,6 @@ describe("ES Decorators", () => {
       expect(stdout).toBe("hello bar\ndone\n");
       expect(exitCode).toBe(0);
     });
-
-    async function runDecoratorTS(code: string) {
-      using dir = tempDir("es-dec-ts", {
-        "tsconfig.json": JSON.stringify({ compilerOptions: {} }),
-        "test.ts": code,
-      });
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "test.ts"],
-        env: bunEnv,
-        cwd: String(dir),
-        stderr: "pipe",
-      });
-      const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      return { stdout, stderr: filterStderr(rawStderr), exitCode };
-    }
 
     test("non-null assertion in decorator member expression", async () => {
       const { stdout, stderr, exitCode } = await runDecoratorTS(`
@@ -1208,6 +1208,100 @@ describe("ES Decorators", () => {
       expect(filterStderr(rawStderr)).toBe("");
       expect(stdout).toBe("undefined\nworld\n");
       expect(exitCode).toBe(0);
+    });
+  });
+
+  // Lowering a class expression hoists its temporaries (_dec, _init, _class,
+  // accessor storage, ...) as a `var` into the nearest statement list. An enum
+  // body is visited before the statements around it, so the temporaries used to
+  // land in the list enclosing the enum's own (none at the top level, where
+  // they were dropped) instead of in the closure the enum body compiles to.
+  describe("class expressions inside enum initializers", () => {
+    test.concurrent("top-level enum", async () => {
+      const { stdout, stderr, exitCode } = await runDecoratorTS(`
+        const kinds: string[] = [];
+        function dec(_value: any, ctx: any) { kinds.push(ctx.kind); }
+        let Decorated: any;
+        let WithAccessor: any;
+        enum E {
+          A = ((Decorated = @dec class { @dec m() {} }), 1),
+          B = ((WithAccessor = class { accessor x = "x" }), 2),
+        }
+        const instance = new WithAccessor();
+        instance.x += "!";
+        console.log(JSON.stringify([E.A, E.B, E[2], kinds, typeof Decorated, instance.x]));
+      `);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual([1, 2, "B", ["method", "class"], "function", "x!"]);
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("enum inside a function gets fresh temporaries per call", async () => {
+      const { stdout, stderr, exitCode } = await runDecoratorTS(`
+        let calls = 0;
+        function dec(_value: any, _ctx: any) {
+          const id = ++calls;
+          return { init: () => id };
+        }
+        function make() {
+          let K: any;
+          enum E {
+            A = ((K = class { @dec accessor x = 0 }), 0),
+          }
+          return K;
+        }
+        const K1 = make();
+        const K2 = make();
+        console.log(new K1().x, new K2().x);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("1 2\n");
+      expect(exitCode).toBe(0);
+    });
+
+    // Each enum body gets its own temporaries, so a class created by the first
+    // enum keeps working after the second enum has been evaluated.
+    test.concurrent("sibling enums do not share temporaries", async () => {
+      const { stdout, stderr, exitCode } = await runDecoratorTS(`
+        let A: any;
+        let B: any;
+        enum First {
+          M = ((A = class { accessor x = 1 }), 0),
+        }
+        const a = new A();
+        enum Second {
+          M = ((B = class { accessor x = 2 }), 0),
+        }
+        console.log(a.x, new B().x);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("1 2\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("Bun.Transpiler declares the temporaries inside the enum closure", () => {
+      const transpiler = new Bun.Transpiler({ loader: "ts" });
+      const declaredInsideClosure = /\(\(E\) => \{\s*var [^;]*\b_init\b[^;]*;/;
+
+      const topLevel = transpiler.transformSync(`
+        declare const dec: any;
+        enum E {
+          A = (@dec class {}, 0),
+        }
+      `);
+      expect(topLevel).toMatch(declaredInsideClosure);
+      expect(topLevel).not.toMatch(/^var [^;]*\b_init\b/m);
+
+      const nested = transpiler.transformSync(`
+        declare const dec: any;
+        function make() {
+          enum E {
+            A = (@dec class {}, 0),
+          }
+        }
+      `);
+      expect(nested).toMatch(declaredInsideClosure);
+      expect(nested).not.toMatch(/^var /m);
     });
   });
 });

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
 
 // ES standard decorators are used for .js files (always) and for .ts files
 // when experimentalDecorators is NOT set in tsconfig.
@@ -1212,27 +1213,32 @@ describe("ES Decorators", () => {
   });
 
   // Lowering a class expression hoists its temporaries (_dec, _init, _class,
-  // accessor storage, ...) as a `var` into the nearest statement list. An enum
-  // body is visited before the statements around it, so the temporaries used to
-  // land in the list enclosing the enum's own (none at the top level, where
-  // they were dropped) instead of in the closure the enum body compiles to.
-  describe("class expressions inside enum initializers", () => {
+  // accessor storage, ...) as a `var` into the nearest statement list; react
+  // refresh hoists its `_s = $RefreshSig$()` the same way. An enum body is
+  // visited before the statements around it, so these used to land in the list
+  // enclosing the enum's own (none at the top level, where they were dropped)
+  // instead of in the closure the enum body compiles to.
+  describe("declarations hoisted out of enum initializers", () => {
     test.concurrent("top-level enum", async () => {
       const { stdout, stderr, exitCode } = await runDecoratorTS(`
         const kinds: string[] = [];
         function dec(_value: any, ctx: any) { kinds.push(ctx.kind); }
         let Decorated: any;
-        let WithAccessor: any;
+        let DecoratedAccessor: any;
+        let PlainAccessor: any;
         enum E {
           A = ((Decorated = @dec class { @dec m() {} }), 1),
-          B = ((WithAccessor = class { accessor x = "x" }), 2),
+          B = ((DecoratedAccessor = class { @dec accessor x = "x" }), 2),
+          C = ((PlainAccessor = class { accessor y = "y" }), 3),
         }
-        const instance = new WithAccessor();
-        instance.x += "!";
-        console.log(JSON.stringify([E.A, E.B, E[2], kinds, typeof Decorated, instance.x]));
+        const b = new DecoratedAccessor();
+        b.x += "!";
+        const c = new PlainAccessor();
+        c.y += "!";
+        console.log(JSON.stringify([E.A, E.B, E.C, E[3], kinds, typeof Decorated, b.x, c.y]));
       `);
       expect(stderr).toBe("");
-      expect(JSON.parse(stdout)).toEqual([1, 2, "B", ["method", "class"], "function", "x!"]);
+      expect(JSON.parse(stdout)).toEqual([1, 2, 3, "C", ["method", "class", "accessor"], "function", "x!", "y!"]);
       expect(exitCode).toBe(0);
     });
 
@@ -1263,20 +1269,42 @@ describe("ES Decorators", () => {
     // enum keeps working after the second enum has been evaluated.
     test.concurrent("sibling enums do not share temporaries", async () => {
       const { stdout, stderr, exitCode } = await runDecoratorTS(`
+        function dec(_value: any, _ctx: any) {}
         let A: any;
         let B: any;
         enum First {
-          M = ((A = class { accessor x = 1 }), 0),
+          M = ((A = class { @dec accessor x = 1 }), 0),
         }
         const a = new A();
         enum Second {
-          M = ((B = class { accessor x = 2 }), 0),
+          M = ((B = class { @dec accessor x = 2 }), 0),
         }
         console.log(a.x, new B().x);
       `);
       expect(stderr).toBe("");
       expect(stdout).toBe("1 2\n");
       expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("react refresh declares the hook signature inside the enum closure", async () => {
+      using dir = tempDir("es-dec-enum-refresh", {
+        "hooks.tsx": `
+          import { useState } from "react";
+          export enum E {
+            A = ((globalThis as any).useThing = function useThing() { return useState(1)[0]; }, 0),
+          }
+        `,
+      });
+      const build = await Bun.build({
+        entrypoints: [join(String(dir), "hooks.tsx")],
+        reactFastRefresh: true,
+        target: "browser",
+        external: ["react"],
+      });
+      expect(build.success).toBe(true);
+      const output = await build.outputs[0].text();
+      expect(output).toMatch(/=> \{\s*var _s = \$RefreshSig\$\(\);/);
+      expect(output).toContain("_s(function useThing()");
     });
 
     test("Bun.Transpiler declares the temporaries inside the enum closure", () => {


### PR DESCRIPTION
### Problem

- A class expression that needs the standard decorator lowering (it has decorators, or an `accessor` field) inside a member initializer of a top-level TypeScript enum fails at runtime: `ReferenceError: _dec is not defined` (or `_x is not defined` for an accessor named `x`). The same class expression outside the enum works.
  ```ts
  function dec(v: any, ctx: any) {}
  enum E {
    A = (globalThis.K = class { accessor x = 1 }, 0),
    B = (globalThis.L = @dec class {}, 1),
  }
  ```
- The lowering emits a `var` declaring the temporaries it assigns in the comma expression (`_dec`, `_init`, `_class`, the accessor's WeakMap) and appends it to `p.nearest_stmt_list` (`src/js_parser/lower/lower_decorators.rs:2531`), silently doing nothing when that is `None`. React refresh appends its `var _s = $RefreshSig$()` the same way (`src/js_parser/visit/visit_expr.rs`), and for a hook function inside a top-level enum it emitted the `_s()` call in the body without ever declaring `_s`.
- `visit_stmts` visits the enum statements of a list before the list's other statements, ahead of installing its own list in `nearest_stmt_list` (`src/js_parser/visit/mod.rs`, the `preprocessed_enums` loop runs before the assignment a few lines below it). So while enum members are visited the pointer still refers to the list around the enclosing `visit_stmts`:
  - at the top level that is `None`, and the declaration is dropped;
  - inside a function it is the list the function statement lives in, so the `var` is emitted at module level and every call of the function shares one set of temporaries. Calling such a function twice and then constructing an instance of the first class throws `TypeError: Cannot read from private field`: the constructor reads the second call's WeakMap while the accessor installed by `__decorateElement` still uses the first.

### Fix

- `s_enum` (`src/js_parser/visit/visit_stmt.rs`) points `nearest_stmt_list` at a local list while the member initializers are visited and emits that list at the top of the closure the enum body compiles to, ahead of the member assignments.
- Why this is the right place: the enum body is already its own hoisting scope in the parser (`Kind::Entry`, the scope the temporaries are registered in) and compiles to a closure that runs once per evaluation of the enum declaration, so declaring the temporaries there gives every evaluation of every enum its own bindings, the same way a namespace body (visited with its own statement list) already behaves. Declaring them in the enclosing list instead would keep the `var` outside the scope the symbols belong to, and two top-level enums would share one `_x` even under the renamer (`bun build`), since sibling scopes legitimately receive the same names.
- With that, every visit runs with a list installed, so `nearest_stmt_list_mut()` (`src/js_parser/p.rs`) now `debug_assert!`s that; the two react refresh sites go through the accessor as well. The release fallbacks are unchanged. This is what turns the next stale-pointer producer into a test failure instead of a silently dropped declaration, which is how this one went unnoticed.
- The pointer handling follows the existing pattern in `visit_stmts`: a stack local, save/restore around the visit, `addr_of_mut!` so the pointer is not derived from a temporary `&mut`; nothing touches the local while the pointer is installed and there is no early return in between.
- This fixes the enum producer of this bug shape. Two more producers exist and are tracked separately: a class expression in a default parameter (`function f(K = class { @dec accessor x = 0 }) {}`) or in a class field initializer (`class Outer { inner = class { ... } }`) still gets its `var` hoisted to the enclosing statement list, so calling the function / constructing `Outer` twice shares the temporaries. Neither has a per-evaluation statement list, so that fix belongs in the lowering's expression-mode emission, not here.
- Independent of #38734 (unique names for the temporaries): that PR does not change where the `var` is emitted and this one does not change how the temporaries are named; #38734 registers them in the `Kind::Entry` scope, i.e. the closure this PR declares them in. Two lowered classes inside one enum still share names until it lands, exactly like two classes in one function today. The tests use decorated accessors, so they keep exercising the hoisting path if #31926 / #35708 (undecorated accessors lowered in place) land first.
- Verified:
  - `test/bundler/transpiler/es-decorators.test.ts`, describe "declarations hoisted out of enum initializers" (5 tests: top-level enum with a decorated class, a decorated accessor and a plain accessor; enum in a function called twice; two sibling top-level enums; `Bun.build({ reactFastRefresh: true })` declaring `_s` inside the closure; `Bun.Transpiler` output declaring the temporaries inside the closure and not at module level, top-level and nested). All 5 fail on the released build with the errors above, pass with the fix.
  - The debug assertion did not fire across `test/bundler/transpiler/`, `test/bundler/esbuild/`, bundler_edgecase, bundler_jsx, bundler_decorator_metadata, bundler_cjs2esm, bundler_naming, bundler_minify, bundler_regressions, bun-build-api, regression/issue/25716 (react refresh), and the bake dev suites react-spa, hot, esm, bundle (all of which are also transpiled by the debug build themselves); all pass. `cargo clippy -p bun_js_parser` clean.
  - `bun build` of the sibling-enum case runs correctly with the fix; the released build's output throws.

### Background

- The standard decorator lowering turns `class { ... }` in expression position into `(_init = ..., _class = class { ... }, ..., _class)` and hoists a `var _init, _class, ...;` for the temporaries into the nearest statement list, because an expression cannot declare variables. The class body keeps referring to those temporaries at runtime (constructors run `__runInitializers(_init, ...)`, accessors look their value up in a hoisted WeakMap), so where the `var` lands decides which code shares them.
- `nearest_stmt_list` is a raw pointer to the statement list currently being built; `visit_stmts` points it at the `before` list that is emitted ahead of the visited statements and restores it when done. Its two consumers are the decorator lowering above and react refresh, which declares one `_s = $RefreshSig$()` per hook-calling function next to that function.
- `visit_stmts` visits every enum in a list before the list's other statements so that enum members can be inlined into code that precedes the declaration (TypeScript itself relies on this). That is why the enum's members are visited while the enclosing list is not installed yet.
- A TypeScript enum compiles to `var E; ((E) => { E[E["A"] = ...] = "A"; })(E ||= {});`; the parser gives the body a `Kind::Entry` scope, the same kind a namespace body gets, and `generate_closure_for_type_script_namespace_or_enum` wraps whatever statements it is handed into that closure.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/es-decorators.test.ts
bun test v1.4.0 (ccae66185)

test/bundler/transpiler/es-decorators.test.ts:
(pass) ES Decorators > class decorators > basic class decorator [371.49ms]
(pass) ES Decorators > class decorators > class decorator receives correct context [344.48ms]
(pass) ES Decorators > class decorators > class decorator can replace class [390.63ms]
(pass) ES Decorators > class decorators > multiple class decorators apply in reverse order [329.93ms]
(pass) ES Decorators > method decorators > instance method decorator [342.51ms]
(pass) ES Decorators > method decorators > static method decorator [341.91ms]
(pass) ES Decorators > method decorators > method decorator context has correct access [338.45ms]
(pass) ES Decorators > getter decorators > getter decorator [341.51ms]
(pass) ES Decorators > setter decorators > setter decorator [336.44ms]
(pass) ES Decorators > field decorators > field decorator receives undefined value [361.25ms]
(pass) ES Decorators > field decorators > multiple field decorators [347.03ms]

... (truncated)

release without fix: 5 FAILED
bun test v1.4.0-canary.1 (b7a043103)

test/bundler/transpiler/es-decorators.test.ts:
(pass) ES Decorators > class decorators > basic class decorator [12.98ms]
(pass) ES Decorators > class decorators > class decorator receives correct context [10.08ms]
(pass) ES Decorators > class decorators > class decorator can replace class [9.30ms]
(pass) ES Decorators > class decorators > multiple class decorators apply in reverse order [9.71ms]
(pass) ES Decorators > method decorators > instance method decorator [9.53ms]
(pass) ES Decorators > method decorators > static method decorator [8.73ms]
(pass) ES Decorators > method decorators > method decorator context has correct access [9.14ms]
(pass) ES Decorators > getter decorators > getter decorator [10.54ms]
(pass) ES Decorators > setter decorators > setter decorator [9.60ms]
(pass) ES Decorators > field decorators > field decorator receives undefined value [9.59ms]
(pass) ES Decorators > field decorators > multiple field decorators [9.61ms]
(pass) ES Decorators > field decorators > static field decorator [10.27ms]
(pass) ES Decorators > non-ASCII string-literal keys > Bun.Transpiler output preserves the key [0.73ms]
(pass) ES 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/es-decorators.test.ts
bun test v1.4.0 (ccae66185)

test/bundler/transpiler/es-decorators.test.ts:
(pass) ES Decorators > class decorators > basic class decorator [438.94ms]
(pass) ES Decorators > class decorators > class decorator receives correct context [373.37ms]
(pass) ES Decorators > class decorators > class decorator can replace class [380.08ms]
(pass) ES Decorators > class decorators > multiple class decorators apply in reverse order [387.65ms]
(pass) ES Decorators > method decorators > instance method decorator [394.33ms]
(pass) ES Decorators > method decorators > static method decorator [374.26ms]
(pass) ES Decorators > method decorators > method decorator context has correct access [357.57ms]
(pass) ES Decorators > getter decorators > getter decorator [430.52ms]
(pass) ES Decorators > setter decorators > setter decorator [389.56ms]
(pass) ES Decorators > field decorators > field decorator receives undefined value [366.76ms]
(pass) ES Decorators > field decorators > multiple field decorators [398.27ms]

... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 786ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 240 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/p.rs                            |  12 +-
 src/js_parser/visit/visit_expr.rs             |   4 +-
 src/js_parser/visit/visit_stmt.rs             |   9 +-
 test/bundler/transpiler/es-decorators.test.ts | 152 +++++++++++++++++++++++---
 4 files changed, 152 insertions(+), 25 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
src/js_parser/p.rs                                12      9      0
src/js_parser/visit/visit_expr.rs                  4      2      0
src/js_parser/visit/visit_stmt.rs                  4      5      0
test/bundler/transpiler/es-decorators.test.ts      4      9      0
```

</details>

<!-- robobun:evidence:end -->