### PR TITLE
napi: abort on a NULL external buffer pointer with a non-zero length, like Node

### DIFF
--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -2401,6 +2401,18 @@ private:
     bool m_finalized { false };
 };
 
+// Node CHECKs this in node::Buffer::New, which both external buffer
+// constructors go through, so the process aborts there too. Wrapping a null
+// pointer with a non-zero length would produce a JSC::ArrayBuffer whose data()
+// is null (which JSC reads as "detached") but whose byteLength() is not 0.
+// Every detached buffer JSC itself produces has byteLength 0, so code that
+// takes span() without re-checking (crypto.subtle.digest, for one) would read
+// `length` bytes from address 0.
+static void checkExternalBufferData(const char* function, const void* data, size_t length)
+{
+    NAPI_RELEASE_ASSERT(data != nullptr || length == 0, "%s: data is NULL but length is %zu", function, length);
+}
+
 extern "C" napi_status napi_create_external_buffer(napi_env env, size_t length,
     void* data,
     napi_finalize finalize_cb,
@@ -2409,12 +2421,13 @@ extern "C" napi_status napi_create_external_buffer(napi_env env, size_t length,
 {
     NAPI_PREAMBLE(env);
     NAPI_CHECK_ARG(env, result);
+    checkExternalBufferData("napi_create_external_buffer", data, length);
 
     Zig::GlobalObject* globalObject = toJS(env);
     JSC::VM& vm = JSC::getVM(globalObject);
     auto* subclassStructure = globalObject->JSBufferSubclassStructure();
 
-    if (data == nullptr || length == 0) {
+    if (length == 0) {
 
         // TODO: is there a way to create a detached uint8 array?
         auto arrayBuffer = JSC::ArrayBuffer::createUninitialized(0, 1);
@@ -2454,6 +2467,7 @@ extern "C" napi_status napi_create_external_arraybuffer(napi_env env, void* exte
 {
     NAPI_PREAMBLE(env);
     NAPI_CHECK_ARG(env, result);
+    checkExternalBufferData("napi_create_external_arraybuffer", external_data, byte_length);
 
     Zig::GlobalObject* globalObject = toJS(env);
     JSC::VM& vm = JSC::getVM(globalObject);

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -1734,16 +1734,24 @@ static void checkExternalBufferData(const char* function, const void* data, size
 // env parameter. This destructor mirrors NapiExternalBufferDestructor but
 // calls a (data, hint) callback directly instead of routing through
 // NapiEnv::doFinalizer.
+//
+// ownsPlaceholder: `data` is our stand-in for the addon's NULL pointer (see the
+// caller), so it is freed here and the addon's callback still receives NULL.
 class NapiNoEnvExternalBufferDestructor final : public SharedTask<void(void*)> {
 public:
-    NapiNoEnvExternalBufferDestructor(node_api_noenv_finalize cb, void* hint)
+    NapiNoEnvExternalBufferDestructor(node_api_noenv_finalize cb, void* hint, bool ownsPlaceholder)
         : m_cb(cb)
         , m_hint(hint)
+        , m_ownsPlaceholder(ownsPlaceholder)
     {
     }
 
     void run(void* data) override
     {
+        if (m_ownsPlaceholder) {
+            fastFree(data);
+            data = nullptr;
+        }
         if (m_armed && m_cb) {
             m_cb(data, m_hint);
         }
@@ -1754,6 +1762,7 @@ public:
 private:
     node_api_noenv_finalize m_cb;
     void* m_hint;
+    bool m_ownsPlaceholder;
     bool m_armed { false };
 };
 
@@ -1770,32 +1779,17 @@ extern "C" JS_EXPORT napi_status node_api_create_external_sharedarraybuffer(napi
 
     Zig::GlobalObject* globalObject = toJS(env);
     JSC::VM& vm = JSC::getVM(globalObject);
-    auto* structure = globalObject->arrayBufferStructure(ArrayBufferSharingMode::Shared);
 
-    if (external_data == nullptr) {
-        // byte_length is 0. makeShared() asserts !isDetached(), and a null data pointer is what detached means to JSC.
-        RefPtr<ArrayBuffer> arrayBuffer = ArrayBuffer::tryCreate(0, 1);
-        NAPI_RETURN_EARLY_IF_FALSE(env, arrayBuffer, napi_generic_failure);
-        arrayBuffer->makeShared();
-
-        auto* buffer = JSC::JSArrayBuffer::create(vm, structure, WTF::move(arrayBuffer));
-        if (finalize_cb) {
-            vm.heap.addFinalizer(buffer, [finalize_cb, finalize_hint](JSCell*) {
-                NAPI_LOG("external sharedarraybuffer finalizer (empty buffer)");
-                finalize_cb(nullptr, finalize_hint);
-            });
-        }
-
-        *result = toNapi(buffer, globalObject);
-        NAPI_RETURN_SUCCESS(env);
-    }
-
-    Ref<NapiNoEnvExternalBufferDestructor> destructor = adoptRef(*new NapiNoEnvExternalBufferDestructor(finalize_cb, finalize_hint));
+    // To JSC a null data pointer means detached, and makeShared() asserts the buffer is not,
+    // so a NULL external_data (byte_length is 0 then) is stood in for by a byte of ours.
+    bool usePlaceholder = external_data == nullptr;
+    const void* data = usePlaceholder ? fastMalloc(1) : external_data;
+    Ref<NapiNoEnvExternalBufferDestructor> destructor = adoptRef(*new NapiNoEnvExternalBufferDestructor(finalize_cb, finalize_hint, usePlaceholder));
     auto* destructorPtr = destructor.ptr();
-    auto arrayBuffer = ArrayBuffer::createFromBytes({ reinterpret_cast<const uint8_t*>(external_data), byte_length }, WTF::move(destructor));
+    auto arrayBuffer = ArrayBuffer::createFromBytes({ static_cast<const uint8_t*>(data), byte_length }, WTF::move(destructor));
     arrayBuffer->makeShared();
 
-    auto* buffer = JSC::JSArrayBuffer::create(vm, structure, WTF::move(arrayBuffer));
+    auto* buffer = JSC::JSArrayBuffer::create(vm, globalObject->arrayBufferStructure(ArrayBufferSharingMode::Shared), WTF::move(arrayBuffer));
     destructorPtr->arm();
 
     *result = toNapi(buffer, globalObject);

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -1734,9 +1734,6 @@ static void checkExternalBufferData(const char* function, const void* data, size
 // env parameter. This destructor mirrors NapiExternalBufferDestructor but
 // calls a (data, hint) callback directly instead of routing through
 // NapiEnv::doFinalizer.
-//
-// ownsPlaceholder: `data` is our stand-in for the addon's NULL pointer (see the
-// caller), so it is freed here and the addon's callback still receives NULL.
 class NapiNoEnvExternalBufferDestructor final : public SharedTask<void(void*)> {
 public:
     NapiNoEnvExternalBufferDestructor(node_api_noenv_finalize cb, void* hint, bool ownsPlaceholder)
@@ -1780,8 +1777,7 @@ extern "C" JS_EXPORT napi_status node_api_create_external_sharedarraybuffer(napi
     Zig::GlobalObject* globalObject = toJS(env);
     JSC::VM& vm = JSC::getVM(globalObject);
 
-    // To JSC a null data pointer means detached, and makeShared() asserts the buffer is not,
-    // so a NULL external_data (byte_length is 0 then) is stood in for by a byte of ours.
+    // A null data pointer is JSC's representation of "detached", which makeShared() asserts against.
     bool usePlaceholder = external_data == nullptr;
     const void* data = usePlaceholder ? fastMalloc(1) : external_data;
     Ref<NapiNoEnvExternalBufferDestructor> destructor = adoptRef(*new NapiNoEnvExternalBufferDestructor(finalize_cb, finalize_hint, usePlaceholder));

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -1723,9 +1723,7 @@ extern "C" JS_EXPORT napi_status node_api_create_sharedarraybuffer(napi_env env,
     NAPI_RETURN_SUCCESS(env);
 }
 
-// Node CHECKs this too (node::Buffer::New, V8's SharedArrayBuffer::New). A null
-// data pointer means "detached" to JSC, which then assumes byteLength is 0, so
-// wrapping NULL with a length would be read as `length` bytes at address 0.
+// Node CHECKs this too (node::Buffer::New, V8's SharedArrayBuffer::New).
 static void checkExternalBufferData(const char* function, const void* data, size_t length)
 {
     NAPI_RELEASE_ASSERT(data != nullptr || length == 0, "%s: data is NULL but length is %zu", function, length);
@@ -1775,9 +1773,7 @@ extern "C" JS_EXPORT napi_status node_api_create_external_sharedarraybuffer(napi
     auto* structure = globalObject->arrayBufferStructure(ArrayBufferSharingMode::Shared);
 
     if (external_data == nullptr) {
-        // byte_length is 0 here. A SharedArrayBuffer cannot be detached, which
-        // is what a null data pointer means to JSC (makeShared() asserts), so
-        // allocate the empty buffer as node_api_create_sharedarraybuffer does.
+        // byte_length is 0. makeShared() asserts !isDetached(), and a null data pointer is what detached means to JSC.
         RefPtr<ArrayBuffer> arrayBuffer = ArrayBuffer::tryCreate(0, 1);
         NAPI_RETURN_EARLY_IF_FALSE(env, arrayBuffer, napi_generic_failure);
         arrayBuffer->makeShared();

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -2431,7 +2431,7 @@ extern "C" napi_status napi_create_external_buffer(napi_env env, size_t length,
     JSC::VM& vm = JSC::getVM(globalObject);
     auto* subclassStructure = globalObject->JSBufferSubclassStructure();
 
-    if (length == 0) {
+    if (data == nullptr || length == 0) {
 
         // TODO: is there a way to create a detached uint8 array?
         auto arrayBuffer = JSC::ArrayBuffer::createUninitialized(0, 1);

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -1723,6 +1723,21 @@ extern "C" JS_EXPORT napi_status node_api_create_sharedarraybuffer(napi_env env,
     NAPI_RETURN_SUCCESS(env);
 }
 
+// Shared by the three constructors that wrap addon memory in a buffer
+// (node_api_create_external_sharedarraybuffer, napi_create_external_buffer,
+// napi_create_external_arraybuffer). Node aborts on this input in all three
+// (node::Buffer::New and V8's SharedArrayBuffer::New CHECK it). Letting it
+// through would produce a JSC::ArrayBuffer whose data() is null but whose
+// byteLength() is not 0. JSC reads a null data() as "detached" and every
+// detached buffer it produces itself has byteLength 0, so anything that takes
+// span() without re-checking (crypto.subtle.digest on the ArrayBuffer,
+// SharedArrayBuffer.prototype.slice, which has no detached state to check)
+// reads `length` bytes from address 0.
+static void checkExternalBufferData(const char* function, const void* data, size_t length)
+{
+    NAPI_RELEASE_ASSERT(data != nullptr || length == 0, "%s: data is NULL but length is %zu", function, length);
+}
+
 // SharedArrayBuffer backing stores can outlive the creating napi_env (they
 // may be posted to other agents), so Node-API specifies a finalizer with no
 // env parameter. This destructor mirrors NapiExternalBufferDestructor but
@@ -1760,16 +1775,41 @@ extern "C" JS_EXPORT napi_status node_api_create_external_sharedarraybuffer(napi
     NAPI_CHECK_ENV_NOT_IN_GC(env);
     NAPI_CHECK_ARG(env, result);
     NAPI_RETURN_EARLY_IF_FALSE(env, !env->hasPendingException(), napi_pending_exception);
+    checkExternalBufferData("node_api_create_external_sharedarraybuffer", external_data, byte_length);
 
     Zig::GlobalObject* globalObject = toJS(env);
     JSC::VM& vm = JSC::getVM(globalObject);
+    auto* structure = globalObject->arrayBufferStructure(ArrayBufferSharingMode::Shared);
+
+    if (external_data == nullptr) {
+        // byte_length is 0 here. JSC has no shared-and-detached state: a null
+        // data pointer means detached, and makeShared() asserts it is not, so
+        // a zero-length SharedArrayBuffer needs a (one byte) allocation behind
+        // it, the same one node_api_create_sharedarraybuffer(env, 0, ...) makes.
+        // As in napi_create_external_buffer's empty case, finalize_cb then runs
+        // when the wrapper dies.
+        RefPtr<ArrayBuffer> arrayBuffer = ArrayBuffer::tryCreate(0, 1);
+        NAPI_RETURN_EARLY_IF_FALSE(env, arrayBuffer, napi_generic_failure);
+        arrayBuffer->makeShared();
+
+        auto* buffer = JSC::JSArrayBuffer::create(vm, structure, WTF::move(arrayBuffer));
+        if (finalize_cb) {
+            vm.heap.addFinalizer(buffer, [finalize_cb, finalize_hint](JSCell*) {
+                NAPI_LOG("external sharedarraybuffer finalizer (empty buffer)");
+                finalize_cb(nullptr, finalize_hint);
+            });
+        }
+
+        *result = toNapi(buffer, globalObject);
+        NAPI_RETURN_SUCCESS(env);
+    }
 
     Ref<NapiNoEnvExternalBufferDestructor> destructor = adoptRef(*new NapiNoEnvExternalBufferDestructor(finalize_cb, finalize_hint));
     auto* destructorPtr = destructor.ptr();
     auto arrayBuffer = ArrayBuffer::createFromBytes({ reinterpret_cast<const uint8_t*>(external_data), byte_length }, WTF::move(destructor));
     arrayBuffer->makeShared();
 
-    auto* buffer = JSC::JSArrayBuffer::create(vm, globalObject->arrayBufferStructure(ArrayBufferSharingMode::Shared), WTF::move(arrayBuffer));
+    auto* buffer = JSC::JSArrayBuffer::create(vm, structure, WTF::move(arrayBuffer));
     destructorPtr->arm();
 
     *result = toNapi(buffer, globalObject);
@@ -2400,18 +2440,6 @@ private:
     bool m_armed { false };
     bool m_finalized { false };
 };
-
-// Node CHECKs this in node::Buffer::New, which both external buffer
-// constructors go through, so the process aborts there too. Wrapping a null
-// pointer with a non-zero length would produce a JSC::ArrayBuffer whose data()
-// is null (which JSC reads as "detached") but whose byteLength() is not 0.
-// Every detached buffer JSC itself produces has byteLength 0, so code that
-// takes span() without re-checking (crypto.subtle.digest, for one) would read
-// `length` bytes from address 0.
-static void checkExternalBufferData(const char* function, const void* data, size_t length)
-{
-    NAPI_RELEASE_ASSERT(data != nullptr || length == 0, "%s: data is NULL but length is %zu", function, length);
-}
 
 extern "C" napi_status napi_create_external_buffer(napi_env env, size_t length,
     void* data,

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -1723,16 +1723,9 @@ extern "C" JS_EXPORT napi_status node_api_create_sharedarraybuffer(napi_env env,
     NAPI_RETURN_SUCCESS(env);
 }
 
-// Shared by the three constructors that wrap addon memory in a buffer
-// (node_api_create_external_sharedarraybuffer, napi_create_external_buffer,
-// napi_create_external_arraybuffer). Node aborts on this input in all three
-// (node::Buffer::New and V8's SharedArrayBuffer::New CHECK it). Letting it
-// through would produce a JSC::ArrayBuffer whose data() is null but whose
-// byteLength() is not 0. JSC reads a null data() as "detached" and every
-// detached buffer it produces itself has byteLength 0, so anything that takes
-// span() without re-checking (crypto.subtle.digest on the ArrayBuffer,
-// SharedArrayBuffer.prototype.slice, which has no detached state to check)
-// reads `length` bytes from address 0.
+// Node CHECKs this too (node::Buffer::New, V8's SharedArrayBuffer::New). A null
+// data pointer means "detached" to JSC, which then assumes byteLength is 0, so
+// wrapping NULL with a length would be read as `length` bytes at address 0.
 static void checkExternalBufferData(const char* function, const void* data, size_t length)
 {
     NAPI_RELEASE_ASSERT(data != nullptr || length == 0, "%s: data is NULL but length is %zu", function, length);
@@ -1782,12 +1775,9 @@ extern "C" JS_EXPORT napi_status node_api_create_external_sharedarraybuffer(napi
     auto* structure = globalObject->arrayBufferStructure(ArrayBufferSharingMode::Shared);
 
     if (external_data == nullptr) {
-        // byte_length is 0 here. JSC has no shared-and-detached state: a null
-        // data pointer means detached, and makeShared() asserts it is not, so
-        // a zero-length SharedArrayBuffer needs a (one byte) allocation behind
-        // it, the same one node_api_create_sharedarraybuffer(env, 0, ...) makes.
-        // As in napi_create_external_buffer's empty case, finalize_cb then runs
-        // when the wrapper dies.
+        // byte_length is 0 here. A SharedArrayBuffer cannot be detached, which
+        // is what a null data pointer means to JSC (makeShared() asserts), so
+        // allocate the empty buffer as node_api_create_sharedarraybuffer does.
         RefPtr<ArrayBuffer> arrayBuffer = ArrayBuffer::tryCreate(0, 1);
         NAPI_RETURN_EARLY_IF_FALSE(env, arrayBuffer, napi_generic_failure);
         arrayBuffer->makeShared();

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -1438,6 +1438,30 @@ nativeTests.test_reference_ref_after_collect_driver = async gc => {
   nativeTests.test_reference_ref_after_collect(gc, ext);
 };
 
+// node_api_create_external_sharedarraybuffer's finalizer belongs to the shared
+// contents, so it must wait for every SharedArrayBuffer object sharing them
+// (here: a structuredClone), not just the one the addon created. Node never
+// delivers it at all for a NULL pointer (V8 skips the deleter of a NULL backing
+// store), so the delivery half is only run on Bun in that case.
+nativeTests.test_external_sharedarraybuffer_lifetime_driver = async (_, usePtr, expectDelivery) => {
+  const label = usePtr ? "(ptr, 0)" : "(NULL, 0)";
+  const report = () => nativeTests.zero_length_external_sab_finalizer(usePtr);
+  // The addon's own object only ever lives in the callee's frame. The clone is
+  // dropped by clearing the property: JSC can keep the returned object itself
+  // reachable from this async function's frame, so clearing a destructured
+  // local binding instead leaves the clone alive.
+  const held = (() => {
+    const sab = nativeTests.create_zero_length_external_sab(usePtr);
+    return { original: new WeakRef(sab), clone: structuredClone(sab) };
+  })();
+  await gcUntil(() => held.original.deref() === undefined);
+  console.log(`${label} original collected, clone alive: ${report()}`);
+  if (!expectDelivery) return;
+  held.clone = null;
+  await gcUntil(() => !report().startsWith("count=0"));
+  console.log(`${label} clone collected: ${report()}`);
+};
+
 // Microtasks queued by one threadsafe-function callback must be drained before
 // the next callback in the same dispatch, and not before the first one.
 nativeTests.test_threadsafe_function_microtask_order = async () => {

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -2794,89 +2794,6 @@ static napi_value test_external_buffer_with_pending_exception(
   return ok(env);
 }
 
-// A NULL data pointer with a non-zero length is a CHECK failure in Node
-// (node::Buffer::New), so both of these are expected to abort the process
-// (run via checkBothFail). Bun used to return napi_ok: the buffer variant
-// handed back an empty Buffer, and the arraybuffer variant an ArrayBuffer with
-// a NULL data pointer and byteLength 64, which crashed whatever read it later.
-static napi_value
-test_external_buffer_null_data_nonzero_length(const Napi::CallbackInfo &info) {
-  napi_env env = info.Env();
-  napi_value buffer = nullptr;
-  napi_status status =
-      napi_create_external_buffer(env, 64, nullptr, nullptr, nullptr, &buffer);
-  printf("FAIL: napi_create_external_buffer(NULL, 64) returned status=%d\n",
-         (int)status);
-  return ok(env);
-}
-
-static napi_value test_external_arraybuffer_null_data_nonzero_length(
-    const Napi::CallbackInfo &info) {
-  napi_env env = info.Env();
-  napi_value arraybuffer = nullptr;
-  napi_status status = napi_create_external_arraybuffer(
-      env, nullptr, 64, nullptr, nullptr, &arraybuffer);
-  printf("FAIL: napi_create_external_arraybuffer(NULL, 64) returned "
-         "status=%d\n",
-         (int)status);
-  return ok(env);
-}
-
-// The NULL-data check must not preempt the argument validation that runs
-// before it in Node, and a NULL pointer is still fine when the length is 0.
-static napi_value
-test_external_buffer_null_data_status_paths(const Napi::CallbackInfo &info) {
-  napi_env env = info.Env();
-  napi_value value = nullptr;
-  napi_value exc;
-  napi_status status;
-
-  NODE_API_CALL(env, napi_throw_error(env, nullptr, "stashed before create"));
-  status =
-      napi_create_external_buffer(env, 64, nullptr, nullptr, nullptr, &value);
-  napi_get_and_clear_last_exception(env, &exc);
-  printf("napi_create_external_buffer(NULL, 64) with pending exception: "
-         "status=%d\n",
-         (int)status);
-
-  NODE_API_CALL(env, napi_throw_error(env, nullptr, "stashed before create"));
-  status = napi_create_external_arraybuffer(env, nullptr, 64, nullptr, nullptr,
-                                            &value);
-  napi_get_and_clear_last_exception(env, &exc);
-  printf("napi_create_external_arraybuffer(NULL, 64) with pending exception: "
-         "status=%d\n",
-         (int)status);
-
-  status =
-      napi_create_external_buffer(env, 64, nullptr, nullptr, nullptr, nullptr);
-  printf("napi_create_external_buffer(NULL, 64) with result=NULL: status=%d\n",
-         (int)status);
-
-  static char dummy;
-  struct {
-    const char *label;
-    void *data;
-  } zero_length_cases[] = {{"NULL", nullptr}, {"ptr", &dummy}};
-  for (const auto &c : zero_length_cases) {
-    status = napi_create_external_arraybuffer(env, c.data, 0, nullptr, nullptr,
-                                              &value);
-    bool detached = false;
-    void *data = reinterpret_cast<void *>(0xDEADBEEF);
-    size_t byte_length = 99;
-    if (status == napi_ok) {
-      NODE_API_CALL(env, napi_is_detached_arraybuffer(env, value, &detached));
-      NODE_API_CALL(env,
-                    napi_get_arraybuffer_info(env, value, &data, &byte_length));
-    }
-    printf("napi_create_external_arraybuffer(%s, 0): status=%d detached=%d "
-           "data_is_input=%d byte_length=%zu\n",
-           c.label, (int)status, (int)detached, (int)(data == c.data),
-           byte_length);
-  }
-
-  return ok(env);
-}
-
 // With an exception pending (via napi_throw_error), every napi call that
 // Node.js gates with NAPI_PREAMBLE must return napi_pending_exception and
 // perform NO side effects. Before the fix, NAPI_PREAMBLE only consulted the
@@ -3945,6 +3862,138 @@ test_node_api_sharedarraybuffer(const Napi::CallbackInfo &info) {
   return ok(env);
 }
 
+// The three constructors that wrap addon-owned memory, behind one signature
+// (no finalizer) so the NULL-pointer tests below can drive each of them.
+struct ExternalBufferConstructor {
+  const char *name;
+  napi_status (*create)(napi_env env, void *data, size_t length,
+                        napi_value *result);
+};
+
+static const ExternalBufferConstructor external_buffer_constructor = {
+    "napi_create_external_buffer",
+    [](napi_env env, void *data, size_t length, napi_value *result) {
+      return napi_create_external_buffer(env, length, data, nullptr, nullptr,
+                                         result);
+    }};
+static const ExternalBufferConstructor external_arraybuffer_constructor = {
+    "napi_create_external_arraybuffer",
+    [](napi_env env, void *data, size_t length, napi_value *result) {
+      return napi_create_external_arraybuffer(env, data, length, nullptr,
+                                              nullptr, result);
+    }};
+static const ExternalBufferConstructor external_sharedarraybuffer_constructor =
+    {"node_api_create_external_sharedarraybuffer",
+     [](napi_env env, void *data, size_t length, napi_value *result) {
+       return node_api_create_external_sharedarraybuffer(
+           env, data, length, nullptr, nullptr, result);
+     }};
+static const ExternalBufferConstructor *const external_buffer_constructors[] = {
+    &external_buffer_constructor,
+    &external_arraybuffer_constructor,
+    &external_sharedarraybuffer_constructor,
+};
+
+// Called as test_external_buffer_null_data_nonzero_length(gc, name) through
+// checkBothFail. A NULL pointer with a non-zero length is a CHECK failure in
+// Node (node::Buffer::New, V8's SharedArrayBuffer::New), so the call must not
+// return. Bun used to return napi_ok: an empty Buffer from the buffer variant,
+// and from the other two a buffer with a NULL data pointer and byteLength 64
+// that crashed whatever later read through it.
+static napi_value
+test_external_buffer_null_data_nonzero_length(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  std::string name = info[1].As<Napi::String>().Utf8Value();
+  for (const auto *ctor : external_buffer_constructors) {
+    if (name != ctor->name)
+      continue;
+    napi_value value = nullptr;
+    napi_status status = ctor->create(env, nullptr, 64, &value);
+    printf("FAIL: %s(NULL, 64) returned status=%d\n", ctor->name, (int)status);
+    return ok(env);
+  }
+  printf("FAIL: unknown constructor %s\n", name.c_str());
+  return ok(env);
+}
+
+// `new Uint8Array(value).length`, or "throws": whether JS can actually use
+// what a constructor handed back, asked the same way of every kind of buffer.
+static std::string view_length_or_throws(napi_env env, napi_value value) {
+  napi_value source, make_view, global, length;
+  NODE_API_CALL_CUSTOM_RETURN(
+      env, "error",
+      napi_create_string_utf8(env, "(b) => new Uint8Array(b).length",
+                              NAPI_AUTO_LENGTH, &source));
+  NODE_API_CALL_CUSTOM_RETURN(env, "error",
+                              napi_run_script(env, source, &make_view));
+  NODE_API_CALL_CUSTOM_RETURN(env, "error", napi_get_global(env, &global));
+  if (napi_call_function(env, global, make_view, 1, &value, &length) !=
+      napi_ok) {
+    napi_value exc;
+    napi_get_and_clear_last_exception(env, &exc);
+    return "throws";
+  }
+  uint32_t n = 0;
+  NODE_API_CALL_CUSTOM_RETURN(env, "error",
+                              napi_get_value_uint32(env, length, &n));
+  return std::to_string(n);
+}
+
+// The NULL-pointer check must not preempt the checks Node runs before it, and
+// a NULL pointer is still accepted when the length is 0.
+static napi_value
+test_external_buffer_null_data_status_paths(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  napi_value value = nullptr;
+  napi_status status;
+
+  for (const auto *ctor : external_buffer_constructors) {
+    NODE_API_CALL(env, napi_throw_error(env, nullptr, "stashed before create"));
+    status = ctor->create(env, nullptr, 64, &value);
+    napi_value exc;
+    napi_get_and_clear_last_exception(env, &exc);
+    printf("%s(NULL, 64) with pending exception: status=%d\n", ctor->name,
+           (int)status);
+  }
+
+  // Not the arraybuffer variant: Node implements that one on top of
+  // napi_create_external_buffer with a local out-pointer, so it reaches the
+  // data CHECK without ever looking at result.
+  status =
+      napi_create_external_buffer(env, 64, nullptr, nullptr, nullptr, nullptr);
+  printf("napi_create_external_buffer(NULL, 64) with result=NULL: status=%d\n",
+         (int)status);
+  status = node_api_create_external_sharedarraybuffer(env, nullptr, 64, nullptr,
+                                                      nullptr, nullptr);
+  printf("node_api_create_external_sharedarraybuffer(NULL, 64) with "
+         "result=NULL: status=%d\n",
+         (int)status);
+
+  // These two wrap the pointer they are given as-is. Zero-length Buffers go
+  // through their own path, covered by test_napi_create_external_buffer_empty.
+  static char dummy;
+  struct {
+    const char *label;
+    void *data;
+  } zero_length_cases[] = {{"NULL", nullptr}, {"ptr", &dummy}};
+  for (const auto *ctor : {&external_arraybuffer_constructor,
+                           &external_sharedarraybuffer_constructor}) {
+    for (const auto &c : zero_length_cases) {
+      status = ctor->create(env, c.data, 0, &value);
+      if (status != napi_ok) {
+        printf("%s(%s, 0): status=%d\n", ctor->name, c.label, (int)status);
+        continue;
+      }
+      bool detached = false;
+      NODE_API_CALL(env, napi_is_detached_arraybuffer(env, value, &detached));
+      printf("%s(%s, 0): status=0 detached=%d view=%s\n", ctor->name, c.label,
+             (int)detached, view_length_or_throws(env, value).c_str());
+    }
+  }
+
+  return ok(env);
+}
+
 static void noop_tsfn_cb(napi_env, napi_value, void *, void *) {}
 
 // Each case below returns a different napi_status in Bun than in Node.js 26
@@ -4518,11 +4567,6 @@ void register_standalone_tests(Napi::Env env, Napi::Object exports) {
                     test_external_arraybuffer_with_pending_exception);
   REGISTER_FUNCTION(env, exports,
                     test_external_buffer_with_pending_exception);
-  REGISTER_FUNCTION(env, exports,
-                    test_external_buffer_null_data_nonzero_length);
-  REGISTER_FUNCTION(env, exports,
-                    test_external_arraybuffer_null_data_nonzero_length);
-  REGISTER_FUNCTION(env, exports, test_external_buffer_null_data_status_paths);
   REGISTER_FUNCTION(env, exports, test_pending_exception_gate);
   REGISTER_FUNCTION(env, exports, make_ungated_calls_spinner);
   REGISTER_FUNCTION(env, exports, test_ungated_calls_with_engine_exception);
@@ -4535,6 +4579,9 @@ void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, test_node_api_set_prototype);
   REGISTER_FUNCTION(env, exports, test_node_api_create_object_with_properties);
   REGISTER_FUNCTION(env, exports, test_node_api_sharedarraybuffer);
+  REGISTER_FUNCTION(env, exports,
+                    test_external_buffer_null_data_nonzero_length);
+  REGISTER_FUNCTION(env, exports, test_external_buffer_null_data_status_paths);
   REGISTER_FUNCTION(env, exports, test_napi_status_codes_node26);
   REGISTER_FUNCTION(env, exports, test_tsfn_null_js_callback);
   REGISTER_FUNCTION(env, exports, test_tsfn_null_js_callback_ran);

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -2794,6 +2794,89 @@ static napi_value test_external_buffer_with_pending_exception(
   return ok(env);
 }
 
+// A NULL data pointer with a non-zero length is a CHECK failure in Node
+// (node::Buffer::New), so both of these are expected to abort the process
+// (run via checkBothFail). Bun used to return napi_ok: the buffer variant
+// handed back an empty Buffer, and the arraybuffer variant an ArrayBuffer with
+// a NULL data pointer and byteLength 64, which crashed whatever read it later.
+static napi_value
+test_external_buffer_null_data_nonzero_length(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  napi_value buffer = nullptr;
+  napi_status status =
+      napi_create_external_buffer(env, 64, nullptr, nullptr, nullptr, &buffer);
+  printf("FAIL: napi_create_external_buffer(NULL, 64) returned status=%d\n",
+         (int)status);
+  return ok(env);
+}
+
+static napi_value test_external_arraybuffer_null_data_nonzero_length(
+    const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  napi_value arraybuffer = nullptr;
+  napi_status status = napi_create_external_arraybuffer(
+      env, nullptr, 64, nullptr, nullptr, &arraybuffer);
+  printf("FAIL: napi_create_external_arraybuffer(NULL, 64) returned "
+         "status=%d\n",
+         (int)status);
+  return ok(env);
+}
+
+// The NULL-data check must not preempt the argument validation that runs
+// before it in Node, and a NULL pointer is still fine when the length is 0.
+static napi_value
+test_external_buffer_null_data_status_paths(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  napi_value value = nullptr;
+  napi_value exc;
+  napi_status status;
+
+  NODE_API_CALL(env, napi_throw_error(env, nullptr, "stashed before create"));
+  status =
+      napi_create_external_buffer(env, 64, nullptr, nullptr, nullptr, &value);
+  napi_get_and_clear_last_exception(env, &exc);
+  printf("napi_create_external_buffer(NULL, 64) with pending exception: "
+         "status=%d\n",
+         (int)status);
+
+  NODE_API_CALL(env, napi_throw_error(env, nullptr, "stashed before create"));
+  status = napi_create_external_arraybuffer(env, nullptr, 64, nullptr, nullptr,
+                                            &value);
+  napi_get_and_clear_last_exception(env, &exc);
+  printf("napi_create_external_arraybuffer(NULL, 64) with pending exception: "
+         "status=%d\n",
+         (int)status);
+
+  status =
+      napi_create_external_buffer(env, 64, nullptr, nullptr, nullptr, nullptr);
+  printf("napi_create_external_buffer(NULL, 64) with result=NULL: status=%d\n",
+         (int)status);
+
+  static char dummy;
+  struct {
+    const char *label;
+    void *data;
+  } zero_length_cases[] = {{"NULL", nullptr}, {"ptr", &dummy}};
+  for (const auto &c : zero_length_cases) {
+    status = napi_create_external_arraybuffer(env, c.data, 0, nullptr, nullptr,
+                                              &value);
+    bool detached = false;
+    void *data = reinterpret_cast<void *>(0xDEADBEEF);
+    size_t byte_length = 99;
+    if (status == napi_ok) {
+      NODE_API_CALL(env, napi_is_detached_arraybuffer(env, value, &detached));
+      NODE_API_CALL(env,
+                    napi_get_arraybuffer_info(env, value, &data, &byte_length));
+    }
+    printf("napi_create_external_arraybuffer(%s, 0): status=%d detached=%d "
+           "data_is_input=%d byte_length=%zu\n",
+           c.label, (int)status, (int)detached, (int)(data == c.data),
+           byte_length);
+  }
+
+  return ok(env);
+}
+
 // With an exception pending (via napi_throw_error), every napi call that
 // Node.js gates with NAPI_PREAMBLE must return napi_pending_exception and
 // perform NO side effects. Before the fix, NAPI_PREAMBLE only consulted the
@@ -4435,6 +4518,11 @@ void register_standalone_tests(Napi::Env env, Napi::Object exports) {
                     test_external_arraybuffer_with_pending_exception);
   REGISTER_FUNCTION(env, exports,
                     test_external_buffer_with_pending_exception);
+  REGISTER_FUNCTION(env, exports,
+                    test_external_buffer_null_data_nonzero_length);
+  REGISTER_FUNCTION(env, exports,
+                    test_external_arraybuffer_null_data_nonzero_length);
+  REGISTER_FUNCTION(env, exports, test_external_buffer_null_data_status_paths);
   REGISTER_FUNCTION(env, exports, test_pending_exception_gate);
   REGISTER_FUNCTION(env, exports, make_ungated_calls_spinner);
   REGISTER_FUNCTION(env, exports, test_ungated_calls_with_engine_exception);

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -3969,8 +3969,8 @@ test_external_buffer_null_data_status_paths(const Napi::CallbackInfo &info) {
          "result=NULL: status=%d\n",
          (int)status);
 
-  // These two wrap the pointer they are given as-is. Zero-length Buffers go
-  // through their own path, covered by test_napi_create_external_buffer_empty.
+  // Zero-length Buffers take a path of their own, covered by
+  // test_napi_create_external_buffer_empty.
   static char dummy;
   struct {
     const char *label;
@@ -3992,6 +3992,56 @@ test_external_buffer_null_data_status_paths(const Napi::CallbackInfo &info) {
   }
 
   return ok(env);
+}
+
+// Used by test_external_sharedarraybuffer_lifetime_driver in module.js. One
+// slot per kind of pointer, handed to the constructor as the finalize hint, so
+// the callback has to arrive with the right hint to move the right slot.
+struct ZeroLengthSabFinalizer {
+  int count;
+  void *data;
+};
+static ZeroLengthSabFinalizer zero_length_sab_finalizers[2];
+static char zero_length_sab_dummy;
+
+static void *zero_length_sab_pointer(bool use_ptr) {
+  return use_ptr ? static_cast<void *>(&zero_length_sab_dummy) : nullptr;
+}
+
+// create_zero_length_external_sab(use_ptr): external SharedArrayBuffer over
+// (ptr, 0) or (NULL, 0) whose finalizer records into the slot for that kind.
+static napi_value
+create_zero_length_external_sab(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  bool use_ptr = info[0].As<Napi::Boolean>().Value();
+  ZeroLengthSabFinalizer &slot = zero_length_sab_finalizers[use_ptr];
+  slot = {0, nullptr};
+  napi_value sab;
+  NODE_API_CALL(env, node_api_create_external_sharedarraybuffer(
+                         env, zero_length_sab_pointer(use_ptr), 0,
+                         +[](void *data, void *hint) {
+                           auto *s =
+                               static_cast<ZeroLengthSabFinalizer *>(hint);
+                           s->count++;
+                           s->data = data;
+                         },
+                         &slot, &sab));
+  return sab;
+}
+
+// zero_length_external_sab_finalizer(use_ptr): "count=N" plus, once it has
+// run, whether it received the pointer the addon passed in.
+static napi_value
+zero_length_external_sab_finalizer(const Napi::CallbackInfo &info) {
+  bool use_ptr = info[0].As<Napi::Boolean>().Value();
+  const ZeroLengthSabFinalizer &slot = zero_length_sab_finalizers[use_ptr];
+  std::string report = "count=" + std::to_string(slot.count);
+  if (slot.count != 0) {
+    report += slot.data == zero_length_sab_pointer(use_ptr)
+                  ? " data=as passed in"
+                  : " data=something else";
+  }
+  return Napi::String::New(info.Env(), report);
 }
 
 static void noop_tsfn_cb(napi_env, napi_value, void *, void *) {}
@@ -4582,6 +4632,8 @@ void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports,
                     test_external_buffer_null_data_nonzero_length);
   REGISTER_FUNCTION(env, exports, test_external_buffer_null_data_status_paths);
+  REGISTER_FUNCTION(env, exports, create_zero_length_external_sab);
+  REGISTER_FUNCTION(env, exports, zero_length_external_sab_finalizer);
   REGISTER_FUNCTION(env, exports, test_napi_status_codes_node26);
   REGISTER_FUNCTION(env, exports, test_tsfn_null_js_callback);
   REGISTER_FUNCTION(env, exports, test_tsfn_null_js_callback_ran);

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -386,6 +386,10 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
       expect(result).toContain("PASS: caller retains ownership on failure with pending exception");
       expect(result).not.toContain("FAIL");
     });
+
+    it("aborts like Node when data is NULL but length is not 0", async () => {
+      await checkBothFail("test_external_buffer_null_data_nonzero_length", []);
+    });
   });
 
   describe("napi_create_external_arraybuffer", () => {
@@ -404,6 +408,21 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
       expect(result).toContain("status=10");
       expect(result).toContain("PASS: caller retains ownership on failure with pending exception");
       expect(result).not.toContain("FAIL");
+    });
+
+    it("aborts like Node when external_data is NULL but byte_length is not 0", async () => {
+      await checkBothFail("test_external_arraybuffer_null_data_nonzero_length", []);
+    });
+
+    it("NULL data: the checks Node runs first still return a status, and length 0 is still accepted", async () => {
+      const result = await checkSameOutput("test_external_buffer_null_data_status_paths", []);
+      expect(result).toMatchInlineSnapshot(`
+        "napi_create_external_buffer(NULL, 64) with pending exception: status=10
+        napi_create_external_arraybuffer(NULL, 64) with pending exception: status=10
+        napi_create_external_buffer(NULL, 64) with result=NULL: status=1
+        napi_create_external_arraybuffer(NULL, 0): status=0 detached=1 data_is_input=1 byte_length=0
+        napi_create_external_arraybuffer(ptr, 0): status=0 detached=0 data_is_input=1 byte_length=0"
+      `);
     });
   });
 
@@ -1553,6 +1572,10 @@ async function checkBothFail(test: string, args: any[] | string, envArgs: Record
           join(__dirname, "napi-app/main.js"),
           test,
           typeof args == "string" ? args : JSON.stringify(args),
+          // A plain script argument to main.js and to node. Bun's debug crash
+          // handler looks for it anywhere in argv and skips its llvm-symbolizer
+          // pass (~5s per crash); this helper only looks at how the process died.
+          "--debug-crash-handler-use-trace-string",
         ],
         env,
         stdout: Bun.version_with_sha.includes("debug") ? "inherit" : "pipe",

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -430,6 +430,37 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
         node_api_create_external_sharedarraybuffer(ptr, 0): status=0 detached=0 view=0"
       `);
     });
+
+    // finalize_cb has to outlive the object the addon got back: a structuredClone
+    // shares the contents, so nothing may run until that dies too.
+    it("node_api_create_external_sharedarraybuffer(ptr, 0) finalizes once, after the last clone", async () => {
+      const result = await checkSameOutput("test_external_sharedarraybuffer_lifetime_driver", [true, true]);
+      expect(result).toMatchInlineSnapshot(`
+        "(ptr, 0) original collected, clone alive: count=0
+        (ptr, 0) clone collected: count=1 data=as passed in
+        resolved to undefined"
+      `);
+    });
+
+    it("node_api_create_external_sharedarraybuffer(NULL, 0) does not finalize while a clone is alive", async () => {
+      const result = await checkSameOutput("test_external_sharedarraybuffer_lifetime_driver", [false, false]);
+      expect(result).toMatchInlineSnapshot(`
+        "(NULL, 0) original collected, clone alive: count=0
+        resolved to undefined"
+      `);
+    });
+
+    // Node 26 never runs the callback for a NULL pointer (V8 drops the deleter of
+    // a NULL backing store); Bun keeps to the documented contract and runs it once,
+    // with the NULL the addon passed rather than the byte standing in for it.
+    it("node_api_create_external_sharedarraybuffer(NULL, 0) finalizes once with NULL on Bun", async () => {
+      const result = await runOn(bunExe(), "test_external_sharedarraybuffer_lifetime_driver", [false, true]);
+      expect(result.replaceAll(/^\[\w+\].+$/gm, "").trim()).toMatchInlineSnapshot(`
+        "(NULL, 0) original collected, clone alive: count=0
+        (NULL, 0) clone collected: count=1 data=as passed in
+        resolved to undefined"
+      `);
+    });
   });
 
   describe("pending-exception gate", () => {

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -386,10 +386,6 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
       expect(result).toContain("PASS: caller retains ownership on failure with pending exception");
       expect(result).not.toContain("FAIL");
     });
-
-    it("aborts like Node when data is NULL but length is not 0", async () => {
-      await checkBothFail("test_external_buffer_null_data_nonzero_length", []);
-    });
   });
 
   describe("napi_create_external_arraybuffer", () => {
@@ -409,19 +405,29 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
       expect(result).toContain("PASS: caller retains ownership on failure with pending exception");
       expect(result).not.toContain("FAIL");
     });
+  });
 
-    it("aborts like Node when external_data is NULL but byte_length is not 0", async () => {
-      await checkBothFail("test_external_arraybuffer_null_data_nonzero_length", []);
+  describe("external buffer constructors given a NULL pointer", () => {
+    it.each([
+      "napi_create_external_buffer",
+      "napi_create_external_arraybuffer",
+      "node_api_create_external_sharedarraybuffer",
+    ])("%s aborts like Node when the length is not 0", async name => {
+      await checkBothFail("test_external_buffer_null_data_nonzero_length", [name]);
     });
 
-    it("NULL data: the checks Node runs first still return a status, and length 0 is still accepted", async () => {
+    it("the checks Node runs first still return a status, and length 0 is still accepted", async () => {
       const result = await checkSameOutput("test_external_buffer_null_data_status_paths", []);
       expect(result).toMatchInlineSnapshot(`
         "napi_create_external_buffer(NULL, 64) with pending exception: status=10
         napi_create_external_arraybuffer(NULL, 64) with pending exception: status=10
+        node_api_create_external_sharedarraybuffer(NULL, 64) with pending exception: status=10
         napi_create_external_buffer(NULL, 64) with result=NULL: status=1
-        napi_create_external_arraybuffer(NULL, 0): status=0 detached=1 data_is_input=1 byte_length=0
-        napi_create_external_arraybuffer(ptr, 0): status=0 detached=0 data_is_input=1 byte_length=0"
+        node_api_create_external_sharedarraybuffer(NULL, 64) with result=NULL: status=1
+        napi_create_external_arraybuffer(NULL, 0): status=0 detached=1 view=throws
+        napi_create_external_arraybuffer(ptr, 0): status=0 detached=0 view=0
+        node_api_create_external_sharedarraybuffer(NULL, 0): status=0 detached=0 view=0
+        node_api_create_external_sharedarraybuffer(ptr, 0): status=0 detached=0 view=0"
       `);
     });
   });


### PR DESCRIPTION
### Problem
- `napi_create_external_arraybuffer(env, NULL, 64, ...)` returns `napi_ok` and a live `ArrayBuffer`. Node aborts on the same call (`Assertion failed: !(data == nullptr) || (length == 0)` in `node::Buffer::New`, Node v26.3.0).
- The buffer it returns has `data() == NULL` and `byteLength() == 64`: `src/jsc/bindings/napi.cpp` passed `external_data` straight to `ArrayBuffer::createFromBytes`. JSC uses a NULL data pointer to mean "detached" and every detached buffer it makes itself has byteLength 0, so native code that reads `span()` without a detached check reads 64 bytes from address 0. On the released bun, `crypto.subtle.digest("SHA-256", ab)` dies with `panic(main thread): Segmentation fault at address 0x0`; `Bun.inspect(ab)` prints `ArrayBuffer(64) []`; `napi_get_arraybuffer_info` hands the addon back `data=NULL, length=64`.
- `node_api_create_external_sharedarraybuffer(env, NULL, 64, ...)` does the same thing, and since a SharedArrayBuffer has no detached state even JS sees `sab.byteLength === 64`; `sab.slice(0, 8)` segfaults at address 0 on the released bun. (Found in review; V8's `SharedArrayBuffer::New` CHECKs this in Node: `Check failed: backing_store->ByteLength() != 0 implies backing_store->Data() != nullptr`.)
- `napi_create_external_buffer(env, 64, NULL, ...)` folded the same input into its empty-buffer path and silently returned a 0-length `Buffer` for a 64-byte request. Node aborts here too (same `Buffer::New` CHECK).
- Related, on the shared constructor only: `(NULL, 0)` went through `createFromBytes` + `makeShared()`, which asserts the buffer is not detached. Debug builds died on that assertion; release builds returned a SharedArrayBuffer that JSC considered detached (`new Uint8Array(sab)` threw). Node returns a usable empty SharedArrayBuffer.

### Fix
- One shared release assertion, `data != NULL || length == 0`, called from all three constructors. A violation aborts with `<function>: data is NULL but length is 64`, the same way the duplicate cleanup hook check already does. These three are the only `createFromBytes` callers fed by addon pointers; external strings already return `napi_invalid_arg` for the equivalent input because that is what Node does there.
- Why aborting is right: all three of Node's implementations CHECK exactly this, so no addon that works on Node can reach the new abort; what reaches it today is an addon bug that Bun turned into a crash somewhere else later.
- The check runs after `NAPI_PREAMBLE`, the `result` check and (shared variant) the pending-exception check, which is the order Node's `napi_create_external_buffer` and shared constructor use: a pending exception still returns `napi_pending_exception`, a NULL `result` still returns `napi_invalid_arg`. Node's arraybuffer variant delegates to the buffer one with a local out-pointer, so it aborts even when `result` is NULL; Bun uses the buffer variant's order there too.
- Shared variant, `(NULL, 0)`: the NULL pointer is replaced by a one-byte placeholder of our own and the call then takes the same `createFromBytes` + `NapiNoEnvExternalBufferDestructor` path as every other call (JSC itself puts a one-byte allocation behind zero-length buffers for the same reason). The destructor frees the placeholder and still hands the addon `finalize_cb(NULL, hint)`, and because `makeShared()` moves it onto the shared contents it runs when the last agent lets go of the buffer, not when the creating VM's wrapper dies. (Bun already delivered this callback for `(NULL, 0)`; Node happens not to, because V8 skips deleters on NULL stores.) Two things this does not change: `napi_get_arraybuffer_info` on the result reports the placeholder's address rather than NULL, the same non-NULL-pointer-for-zero-bytes answer every other zero-length buffer in Bun gives (JSC backs them all with a one-byte allocation); and `napi_create_external_buffer`'s `(NULL, 0)` finalizer stays registered on the Buffer cell as before, which is fine for a Buffer because nothing else can share its contents.
- Zero-length calls on the other two constructors are unchanged: `(NULL, 0)` still yields a detached ArrayBuffer / empty Buffer (Node's own `test_typedarray` relies on the former), `(ptr, 0)` still works. The buffer variant's empty-path condition (`data == nullptr || length == 0`) is left as it is even though the assertion makes its first half dead: #38802 changes that line to `data == nullptr`, which is the form wanted once both land, and rewriting it here would only create a conflict.
- Tests (`test/napi/napi.test.ts`, addon side in `test/napi/napi-app/standalone_tests.cpp`, which now drives the three constructors through one table):
  - `<constructor> aborts like Node when the length is not 0`, one per constructor, via `checkBothFail` (Node and Bun must die the same way). All three fail on the released bun (every constructor returns status 0). Against the merge base in a debug build the buffer and arraybuffer cases fail and the shared one already died, on JSC's `makeShared()` assertion rather than on the new check.
  - `the checks Node runs first still return a status, and length 0 is still accepted`: same-output run against Node covering the pending-exception and `result == NULL` orderings, and `(NULL, 0)` / `(ptr, 0)` on the arraybuffer and shared constructors, including whether JS can build a `Uint8Array` over the result. Fails before on the shared `(NULL, 0)` line (assertion in debug, `view=throws` in release). The buffer constructor is left out of the zero-length part because `(ptr, 0)` there returns a detached Buffer today, a separate divergence from Node that is tracked separately.
  - `node_api_create_external_sharedarraybuffer(...) finalizes ...` (three cases, driver in `module.js`): a counting finalizer whose hint selects a per-kind slot; for `(ptr, 0)` and `(NULL, 0)` it must not run while a `structuredClone` of the buffer is alive (same output as Node, and the original's collection is proven with a WeakRef first), and once the clone dies it runs once and receives the pointer the addon passed in. Node never delivers it for a NULL pointer, so that last case runs on Bun only. Both `(NULL, 0)` cases fail against the earlier wrapper-bound revision of this PR (verified by rebuilding it); `(ptr, 0)` pins the path that already existed.
  - `checkBothFail` now appends `--debug-crash-handler-use-trace-string` (a plain script argument to `main.js` and to Node) so a debug build's crash handler skips its ~5s llvm-symbolizer pass; the existing duplicate cleanup hook test drops from ~5.5s to ~2s in debug builds as a result.
  - Also ran: the rest of `test/napi/napi.test.ts`, and Node's own `test_typedarray`, `test_buffer`, `test_worker_buffer_callback`, `test_instance_data`, `test_exception`, `test_worker_terminate_finalization` suites under `test/napi/node-napi-tests` (every caller of these constructors in the tree passes either a real pointer or length 0).

### Background
- `napi_create_external_buffer`, `napi_create_external_arraybuffer` and (Node 24+/26 experimental) `node_api_create_external_sharedarraybuffer` wrap memory the addon owns in a JS `Buffer` / `ArrayBuffer` / `SharedArrayBuffer` without copying; the addon's finalizer is called when the JS object dies.
- `JSC::ArrayBuffer` stores a data pointer and a byte length separately. `isDetached()` is simply "data pointer is NULL" (JSC's own allocator comment: a zero-length buffer still gets a one-byte allocation because "we use null to mean that the buffer is detached"). JS-visible paths (`byteLength` getter, typed array and DataView constructors, `slice`, `structuredClone`) consult it and so report 0 or throw on the ArrayBuffer variant of this bug, but native paths such as WebCrypto's BufferSource conversion read `span()` (pointer + stored length) directly, and SharedArrayBuffer paths never check at all.
- `NAPI_RELEASE_ASSERT` (`src/jsc/bindings/napi.h`) is Bun's equivalent of a Node `CHECK` in Node-API code: it prints the assertion and aborts through the crash handler; `BUN_INTERNAL_SUPPRESS_CRASH_ON_NAPI_ABORT` lets tests opt out of crash reporting.

<details>
<summary>Probe addon output, Node 26.3.0 vs released Bun (before) vs this branch</summary>

```
case                                     node            bun before                         bun after
buffer(NULL, 64)                         abort (CHECK)   napi_ok, empty Buffer              abort
arraybuffer(NULL, 64)                    abort (CHECK)   napi_ok, AB: detached, byteLength  abort
                                                         reads 0 from JS, 64 natively
sharedarraybuffer(NULL, 64)              abort (CHECK)   napi_ok, SAB with byteLength 64    abort
                                                         over a NULL pointer
any of the three, exception pending      status=10       status=10                          status=10
buffer(NULL, 64), result=NULL            status=1        status=1                           status=1
sharedarraybuffer(NULL, 64), result=NULL status=1        status=1                           status=1
arraybuffer(NULL, 64), result=NULL       abort           status=1                           status=1
arraybuffer(NULL, 0)                     ok, detached    ok, detached                       ok, detached
arraybuffer(ptr, 0)                      ok, usable      ok, usable                         ok, usable
sharedarraybuffer(NULL, 0)               ok, usable      ok, but JSC sees it as detached    ok, usable
                                                         (debug builds: assertion)
sharedarraybuffer(ptr, 0)                ok, usable      ok, usable                         ok, usable
buffer(NULL, 0)                          ok, detached    ok, detached                       ok, detached
```

Released Bun (1.4.0 canary):

```
ab  = napi_create_external_arraybuffer(env, NULL, 64, ...)
ab.byteLength                         -> 0
ab.detached                           -> true
Bun.inspect(ab)                       -> "ArrayBuffer(64) []"
new Uint8Array(ab)                    -> TypeError: Buffer is already detached
crypto.subtle.digest("SHA-256", ab)   -> panic(main thread): Segmentation fault at address 0x0

sab = node_api_create_external_sharedarraybuffer(env, NULL, 64, ...)
sab.byteLength                        -> 64
Bun.inspect(sab)                      -> "SharedArrayBuffer(64) []"
sab.slice(0, 8)                       -> panic(main thread): Segmentation fault at address 0x0
```
</details>

<details>
<summary>Earlier revision of this PR</summary>

The first push covered `napi_create_external_buffer` and `napi_create_external_arraybuffer` only. Review pointed out that `node_api_create_external_sharedarraybuffer` wraps the pointer the same way; adding it to the same check is what surfaced the shared `(NULL, 0)` assertion described above. That case first got its own branch built on `ArrayBuffer::tryCreate(0, 1)` with `finalize_cb` registered on the wrapper cell; review noted that a SharedArrayBuffer's wrapper can die before the buffer does, so it became the placeholder described above and the branch went away. The tests were reorganized around one table of the three constructors along the way.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/napi/napi.test.ts

<!-- robobun:evidence:end -->