### PR TITLE
install: print the update row for catalog entries moved by bun update

### DIFF
--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -591,12 +591,24 @@ pub struct PackageUpdateInfo {
 }
 
 impl PackageUpdateInfo {
-    /// `version`'s tag strings live in `buf` (a lockfile string buffer that cleaning rebuilds), so the original keeps its own copy of them.
     pub(crate) fn set_original_version(&mut self, version: Semver::Version, buf: &[u8]) {
-        let mut tag_buf =
-            vec![0u8; version.tag.pre.len() + version.tag.build.len()].into_boxed_slice();
-        self.original_version = Some(version.clone_into(buf, &mut tag_buf, &mut 0));
-        self.original_version_string_buf = tag_buf;
+        let detached = DetachedVersion::new(version, buf);
+        self.original_version = Some(detached.version);
+        self.original_version_string_buf = detached.buf;
+    }
+}
+
+/// A version copied out of a lockfile string buffer (which cleaning rebuilds); its tag strings live in `buf`.
+pub(crate) struct DetachedVersion {
+    pub(crate) version: Semver::Version,
+    pub(crate) buf: Box<[u8]>,
+}
+
+impl DetachedVersion {
+    pub(crate) fn new(version: Semver::Version, string_buf: &[u8]) -> DetachedVersion {
+        let mut buf = vec![0u8; version.tag.pre.len() + version.tag.build.len()].into_boxed_slice();
+        let version = version.clone_into(string_buf, &mut buf, &mut 0);
+        DetachedVersion { version, buf }
     }
 }
 
@@ -607,6 +619,24 @@ pub struct CatalogUpdateInfo {
     pub original_version_literal: Box<[u8]>,
     /// Set by package_json_editor::resolve_catalog_literals; None leaves the entry as written.
     pub new_version_literal: Option<Box<[u8]>>,
+    /// What the entry's rows resolved to in the loaded lockfile (`package_json_editor::record_catalog_originals`); the install summary's `from` for them.
+    pub(crate) original: Option<DetachedVersion>,
+}
+
+impl CatalogUpdateInfo {
+    /// Index of the entry a `catalog:<catalog_name>` row named `dep_name` resolves through: one spelled exactly like the row first, else the `catalog:` / `catalog:default` equivalent.
+    pub(crate) fn position(
+        infos: &[CatalogUpdateInfo],
+        catalog_name: &[u8],
+        dep_name: &[u8],
+    ) -> Option<usize> {
+        let position = |matches: fn(&[u8], &[u8]) -> bool| {
+            infos.iter().position(|info| {
+                &*info.dep_name == dep_name && matches(&info.catalog_name, catalog_name)
+            })
+        };
+        position(|a, b| a == b).or_else(|| position(lockfile::CatalogMap::same_name))
+    }
 }
 
 pub struct UpdateTargetWorkspace {

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -584,8 +584,20 @@ pub struct PackageUpdateInfo {
     pub(crate) original_version_literal: Box<[u8]>,
     // set by the post-install write-back; the install summary still needs the entry
     pub(crate) written_back: bool,
+    /// Registered by `package_json_editor::record_catalog_originals`: the name's `catalog:` rows carry the move, so the install summary reports it through them.
+    pub(crate) catalog_entry: bool,
     pub(crate) original_version_string_buf: Box<[u8]>,
     pub(crate) original_version: Option<Semver::Version>,
+}
+
+impl PackageUpdateInfo {
+    /// `version`'s tag strings live in `buf` (a lockfile string buffer that cleaning rebuilds), so the original keeps its own copy of them.
+    pub(crate) fn set_original_version(&mut self, version: Semver::Version, buf: &[u8]) {
+        let mut tag_buf =
+            vec![0u8; version.tag.pre.len() + version.tag.build.len()].into_boxed_slice();
+        self.original_version = Some(version.clone_into(buf, &mut tag_buf, &mut 0));
+        self.original_version_string_buf = tag_buf;
+    }
 }
 
 pub struct CatalogUpdateInfo {

--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -507,9 +507,7 @@ fn edit_update_entries(
 
                         *entry.value_ptr = PackageUpdateInfo {
                             original_version_literal: version_literal_owned,
-                            written_back: false,
-                            original_version_string_buf: Box::default(),
-                            original_version: None,
+                            ..Default::default()
                         };
 
                         if update_to_latest {
@@ -749,6 +747,62 @@ pub(crate) fn edit_catalogs_before_update(
     })?;
 
     Ok(!manager.updating_catalogs.is_empty())
+}
+
+/// Runs on the loaded lockfile, before the differ: every `catalog:` row of an entry recorded by `edit_catalogs_before_update` registers its name in `updating_packages` with the row's locked version as the original, the way the cwd's own dependency lists register theirs, so the install summary prints the entry's move as an update row; a name those lists already registered keeps their original.
+pub(crate) fn record_catalog_originals(
+    manager: &mut PackageManager,
+) -> Result<(), bun_alloc::AllocError> {
+    let infos: &[CatalogUpdateInfo] = &manager.updating_catalogs;
+    if infos.is_empty() {
+        return Ok(());
+    }
+    let by_name = CatalogInfoIndex::init(infos)?;
+    let lockfile: &Lockfile = &manager.lockfile;
+    let updating_packages = &mut manager.updating_packages;
+    let string_buf = lockfile.buffers.string_bytes.as_slice();
+    let package_resolutions = lockfile.packages.items_resolution();
+
+    for (dep, &package_id) in lockfile
+        .buffers
+        .dependencies
+        .iter()
+        .zip(lockfile.buffers.resolutions.iter())
+    {
+        if dep.version.tag != dependency::Tag::Catalog
+            || (package_id as usize) >= package_resolutions.len()
+        {
+            continue;
+        }
+        let resolution = &package_resolutions[package_id as usize];
+        if resolution.tag != resolution::Tag::Npm {
+            continue;
+        }
+        let dep_name = dep.name.slice(string_buf);
+        let catalog_name = dep.version.catalog().slice(string_buf);
+        let Some(info) = by_name
+            .candidates(dep_name)
+            .and_then(|candidates| CatalogInfoIndex::pick(candidates, infos, catalog_name))
+            .map(|i| &infos[i])
+        else {
+            continue;
+        };
+        let entry = updating_packages.get_or_put(dep_name)?;
+        if entry.found_existing {
+            continue;
+        }
+        *entry.value_ptr = PackageUpdateInfo {
+            original_version_literal: info.original_version_literal.clone(),
+            // The entry is written by `edit_catalogs_after_update`; `edit_update_entries` has nothing of it to write into the cwd's dependency lists.
+            written_back: true,
+            catalog_entry: true,
+            ..Default::default()
+        };
+        entry
+            .value_ptr
+            .set_original_version(resolution.npm().version, string_buf);
+    }
+    Ok(())
 }
 
 /// Writes each recorded catalog entry's resolved literal (unresolved ones are restored) into the root AST; returns `changed`.
@@ -1041,9 +1095,7 @@ pub(crate) fn edit(
 
                                                 *entry.value_ptr = PackageUpdateInfo {
                                                     original_version_literal: version_literal_owned,
-                                                    written_back: false,
-                                                    original_version_string_buf: Box::default(),
-                                                    original_version: None,
+                                                    ..Default::default()
                                                 };
                                             }
                                         }

--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -13,7 +13,10 @@ use bun_install::{Dependency, INVALID_PACKAGE_ID, Lockfile, resolution};
 use bun_install_types::{DependencyGroup, PackageNameHash};
 
 use super::package_manager_options::Do;
-use super::{CatalogUpdateInfo, PackageManager, PackageUpdateInfo, Subcommand, UpdateRequest};
+use super::{
+    CatalogUpdateInfo, DetachedVersion, PackageManager, PackageUpdateInfo, Subcommand,
+    UpdateRequest,
+};
 
 type ExprDisabler = bun_ast::expr::Disabler;
 
@@ -732,6 +735,7 @@ pub(crate) fn edit_catalogs_before_update(
                 dep_name: Box::from(key_str),
                 original_version_literal: Box::from(version_literal),
                 new_version_literal: None,
+                original: None,
             });
 
             if update_to_latest {
@@ -749,16 +753,15 @@ pub(crate) fn edit_catalogs_before_update(
     Ok(!manager.updating_catalogs.is_empty())
 }
 
-/// Runs on the loaded lockfile, before the differ: every `catalog:` row of an entry recorded by `edit_catalogs_before_update` registers its name in `updating_packages` with the row's locked version as the original, the way the cwd's own dependency lists register theirs, so the install summary prints the entry's move as an update row; a name those lists already registered keeps their original.
+/// Runs on the loaded lockfile, before the differ: every `catalog:` row of an entry recorded by `edit_catalogs_before_update` gives the entry the version it was locked to (the first row of the entry wins) and registers its name in `updating_packages` the way the cwd's own dependency lists register theirs, so the install summary prints the entry's move as an update row; a name those lists already registered keeps their original.
 pub(crate) fn record_catalog_originals(
     manager: &mut PackageManager,
 ) -> Result<(), bun_alloc::AllocError> {
-    let infos: &[CatalogUpdateInfo] = &manager.updating_catalogs;
-    if infos.is_empty() {
+    if manager.updating_catalogs.is_empty() {
         return Ok(());
     }
-    let by_name = CatalogInfoIndex::init(infos)?;
     let lockfile: &Lockfile = &manager.lockfile;
+    let infos: &mut [CatalogUpdateInfo] = &mut manager.updating_catalogs;
     let updating_packages = &mut manager.updating_packages;
     let string_buf = lockfile.buffers.string_bytes.as_slice();
     let package_resolutions = lockfile.packages.items_resolution();
@@ -780,13 +783,15 @@ pub(crate) fn record_catalog_originals(
         }
         let dep_name = dep.name.slice(string_buf);
         let catalog_name = dep.version.catalog().slice(string_buf);
-        let Some(info) = by_name
-            .candidates(dep_name)
-            .and_then(|candidates| CatalogInfoIndex::pick(candidates, infos, catalog_name))
-            .map(|i| &infos[i])
+        let Some(info) =
+            CatalogUpdateInfo::position(infos, catalog_name, dep_name).map(|i| &mut infos[i])
         else {
             continue;
         };
+        let version = resolution.npm().version;
+        if info.original.is_none() {
+            info.original = Some(DetachedVersion::new(version, string_buf));
+        }
         let entry = updating_packages.get_or_put(dep_name)?;
         if entry.found_existing {
             continue;
@@ -798,9 +803,7 @@ pub(crate) fn record_catalog_originals(
             catalog_entry: true,
             ..Default::default()
         };
-        entry
-            .value_ptr
-            .set_original_version(resolution.npm().version, string_buf);
+        entry.value_ptr.set_original_version(version, string_buf);
     }
     Ok(())
 }
@@ -873,6 +876,8 @@ pub(crate) fn edit_catalogs_after_update(
         Ok(())
     })?;
 
+    // The install summary still reads the entries' originals.
+    manager.updating_catalogs = infos;
     Ok(changed)
 }
 

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 // Bring the typed `items_<field>()` column accessors into scope for
 // `MultiArrayList<Package>` / `Slice<Package>`.
-use super::Command;
+use super::{Command, PackageJSONEditor};
 use crate::PackageManager;
 use crate::config_version::ConfigVersion;
 use crate::hoisted_install::install_hoisted_packages;
@@ -1841,23 +1841,13 @@ fn record_updating_package_versions(manager: &mut PackageManager) {
             if original_resolution.tag != ResolutionTag::Npm {
                 continue;
             }
-
-            let mut original = original_resolution.npm().version;
-            let tag_total = original.tag.pre.len() + original.tag.build.len();
-            if tag_total > 0 {
-                let mut tag_buf = vec![0u8; tag_total].into_boxed_slice();
-                original.tag = original_resolution.npm().version.tag.clone_into(
-                    &lockfile.buffers.string_bytes,
-                    &mut tag_buf,
-                    &mut 0,
-                );
-
-                entry_ptr.original_version_string_buf = tag_buf;
-            }
-
-            entry_ptr.original_version = Some(original);
+            entry_ptr.set_original_version(
+                original_resolution.npm().version,
+                &lockfile.buffers.string_bytes,
+            );
         }
     }
+    PackageJSONEditor::record_catalog_originals(manager).unwrap_or_oom();
 }
 
 fn root_package_json_source(

--- a/src/install/lockfile/printer/tree_printer.rs
+++ b/src/install/lockfile/printer/tree_printer.rs
@@ -7,8 +7,8 @@ use crate::package_manager_real::TrackInstalledBin;
 use bun_core::fmt::PathSep;
 use bun_install::lockfile::{Printer, package::Meta as PackageMeta};
 use bun_install::{
-    self as install, Bin, Dependency, DependencyID, INVALID_PACKAGE_ID, PackageID, PackageManager,
-    PackageNameHash, Resolution, Subcommand, bin, resolution,
+    self as install, Bin, Dependency, DependencyID, DependencyVersionTag, INVALID_PACKAGE_ID,
+    PackageID, PackageManager, PackageNameHash, Resolution, Subcommand, bin, resolution,
 };
 use bun_sys::Fd;
 
@@ -114,6 +114,17 @@ where
     }
 
     if !PRINT_SECTION_HEADER {
+        if print_catalog_entry_updates::<W, ENABLE_ANSI_COLORS>(
+            this,
+            manager,
+            installed,
+            pkg_metas,
+            &mut update_dedupe,
+            writer,
+        )? {
+            *printed_new_install = true;
+            printed_update = true;
+        }
         if print_transitive_updates::<W, ENABLE_ANSI_COLORS>(
             this,
             manager,
@@ -373,6 +384,53 @@ where
     writer.write_str("\n")?;
 
     Ok(())
+}
+
+/// A bare `bun update` moves the root's catalog entries for every importer at once, so an entry's move is reported through whichever `catalog:` row names it, not just the rows of `update_owners` (walked above, hence the shared `update_dedupe`). Like a direct dependency's row it prints whether or not the new version had to be installed.
+fn print_catalog_entry_updates<W, const ENABLE_ANSI_COLORS: bool>(
+    this: &Printer,
+    manager: &mut PackageManager,
+    installed: &Bitset,
+    pkg_metas: &[PackageMeta],
+    update_dedupe: &mut HashMap<PackageNameHash, ()>,
+    writer: &mut W,
+) -> Result<bool, crate::Error>
+where
+    W: Write,
+{
+    if !manager
+        .updating_packages
+        .values()
+        .iter()
+        .any(|info| info.catalog_entry)
+    {
+        return Ok(false);
+    }
+    let string_buf = this.lockfile.buffers.string_bytes.as_slice();
+    let dependencies = this.lockfile.buffers.dependencies.as_slice();
+    let mut printed = false;
+    for (dep_id, dep) in dependencies.iter().enumerate() {
+        if dep.version.tag != DependencyVersionTag::Catalog
+            || !manager
+                .updating_packages
+                .get(dep.name.slice(string_buf))
+                .is_some_and(|info| info.catalog_entry)
+        {
+            continue;
+        }
+        let dep_id = DependencyID::try_from(dep_id).expect("int cast");
+        let ShouldPrintPackageInstallResult::Update(update_info) =
+            should_print_package_install(this, manager, dep_id, installed, None, pkg_metas)
+        else {
+            continue;
+        };
+        if update_dedupe.get_or_put(dep.name_hash)?.found_existing {
+            continue;
+        }
+        print_updated_package::<W, ENABLE_ANSI_COLORS>(this, manager, &update_info, writer)?;
+        printed = true;
+    }
+    Ok(printed)
 }
 
 /// Packages registered by the transitive half of `bun update` are not rows of the walked workspaces, so the walk above never reaches them; the walked workspaces' own targets stay with them.

--- a/src/install/lockfile/printer/tree_printer.rs
+++ b/src/install/lockfile/printer/tree_printer.rs
@@ -27,6 +27,8 @@ fn print_installed_workspace_section<
     printed_new_install: &mut bool,
     id_map: Option<&mut [DependencyID]>,
     update_owners: &[PackageID],
+    // The summary has no other sections, so `print_catalog_entry_updates` runs here.
+    sole_section: bool,
 ) -> Result<(), crate::Error>
 where
     W: Write,
@@ -114,14 +116,16 @@ where
     }
 
     if !PRINT_SECTION_HEADER {
-        if print_catalog_entry_updates::<W, ENABLE_ANSI_COLORS>(
-            this,
-            manager,
-            installed,
-            pkg_metas,
-            &mut update_dedupe,
-            writer,
-        )? {
+        if sole_section
+            && print_catalog_entry_updates::<W, ENABLE_ANSI_COLORS>(
+                this,
+                manager,
+                installed,
+                pkg_metas,
+                &mut update_dedupe,
+                writer,
+            )?
+        {
             *printed_new_install = true;
             printed_update = true;
         }
@@ -386,7 +390,7 @@ where
     Ok(())
 }
 
-/// A bare `bun update` moves the root's catalog entries for every importer at once, so an entry's move is reported through whichever `catalog:` row names it, not just the rows of `update_owners` (walked above, hence the shared `update_dedupe`). Like a direct dependency's row it prints whether or not the new version had to be installed.
+/// A bare `bun update` moves the root's catalog entries for every importer at once, but the summary's one section only walks the rows of `update_owners` (above, hence the shared `update_dedupe`), so the entries consumed elsewhere are reported through whichever `catalog:` row names them. The verbose summary prints a section per importer, each reporting its own `catalog:` rows, and skips this. Like a direct dependency's row, a row prints whether or not its new version had to be installed.
 fn print_catalog_entry_updates<W, const ENABLE_ANSI_COLORS: bool>(
     this: &Printer,
     manager: &mut PackageManager,
@@ -687,6 +691,7 @@ where
                 &mut had_printed_new_install,
                 None,
                 &[0],
+                false,
             )?;
 
             for &workspace_dep_id in &workspaces_to_print {
@@ -700,6 +705,7 @@ where
                     &mut had_printed_new_install,
                     None,
                     &[workspace_package_id],
+                    false,
                 )?;
             }
         } else {
@@ -751,6 +757,7 @@ where
                 &mut had_printed_new_install,
                 Some(&mut id_map),
                 &update_owners,
+                true,
             )?;
         }
     } else {

--- a/src/install/lockfile/printer/tree_printer.rs
+++ b/src/install/lockfile/printer/tree_printer.rs
@@ -3,7 +3,7 @@ use bun_io::Write;
 use bun_semver as semver;
 
 use crate::lockfile_real::package::PackageColumns as _;
-use crate::package_manager_real::TrackInstalledBin;
+use crate::package_manager_real::{CatalogUpdateInfo, TrackInstalledBin};
 use bun_core::fmt::PathSep;
 use bun_install::lockfile::{Printer, package::Meta as PackageMeta};
 use bun_install::{
@@ -52,8 +52,7 @@ where
     // It's possible to have duplicate dependencies with the same version and resolution.
     // While both are technically installed, only one was chosen and should be printed.
     let mut dep_dedupe: HashMap<PackageNameHash, ()> = HashMap::new();
-    // `updating_packages` holds one original per name, so a name declared by several owners (or groups) is one row.
-    let mut update_dedupe: HashMap<PackageNameHash, ()> = HashMap::new();
+    let mut update_dedupe = UpdateRowDedupe::new();
 
     // Reshaped for borrowck — `id_map` is reborrowed per call below.
     let mut id_map = id_map;
@@ -81,9 +80,8 @@ where
                 | ShouldPrintPackageInstallResult::No
                 | ShouldPrintPackageInstallResult::Return => {}
                 ShouldPrintPackageInstallResult::Update(update_info) => {
-                    if update_dedupe
-                        .get_or_put(dependencies[dep_id as usize].name_hash)?
-                        .found_existing
+                    if !update_dedupe
+                        .first_sighting(&dependencies[dep_id as usize], &update_info)?
                     {
                         continue;
                     }
@@ -200,10 +198,50 @@ where
 }
 
 struct PackageUpdatePrintInfo {
+    /// The version the row was locked to; its tag strings live in `version_buf`.
     version: semver::Version,
+    version_buf: Box<[u8]>,
     resolution: Resolution,
     dependency_id: DependencyID,
     package_id: PackageID,
+}
+
+/// The `^` rows of one section. A dependency list's rows print once per name (`updating_packages` holds one original per name); a `catalog:` row prints once per move, so two catalog entries for one name each get a row, while a move already printed (same name, from and to) is not repeated.
+struct UpdateRowDedupe {
+    names: HashMap<PackageNameHash, ()>,
+    printed: Vec<(PackageNameHash, PackageID, semver::Version)>,
+}
+
+impl UpdateRowDedupe {
+    fn new() -> UpdateRowDedupe {
+        UpdateRowDedupe {
+            names: HashMap::new(),
+            printed: Vec::new(),
+        }
+    }
+
+    fn first_sighting(
+        &mut self,
+        dependency: &Dependency,
+        update: &PackageUpdatePrintInfo,
+    ) -> Result<bool, crate::Error> {
+        if dependency.version.tag != DependencyVersionTag::Catalog
+            && self.names.get_or_put(dependency.name_hash)?.found_existing
+        {
+            return Ok(false);
+        }
+        let repeated = self.printed.iter().any(|&(name_hash, package_id, from)| {
+            name_hash == dependency.name_hash
+                && package_id == update.package_id
+                && from.eql(update.version)
+        });
+        if repeated {
+            return Ok(false);
+        }
+        self.printed
+            .push((dependency.name_hash, update.package_id, update.version));
+        Ok(true)
+    }
 }
 
 enum ShouldPrintPackageInstallResult {
@@ -271,15 +309,21 @@ fn should_print_package_install(
     let resolution = this.lockfile.packages.items_resolution()[package_id as usize];
     if resolution.tag == resolution::Tag::Npm {
         let npm_version = resolution.npm().version;
-        let name = dependency
-            .name
-            .slice(this.lockfile.buffers.string_bytes.as_slice());
+        let string_buf = this.lockfile.buffers.string_bytes.as_slice();
+        let name = dependency.name.slice(string_buf);
         if let Some(entry) = manager.updating_packages.get(name) {
-            if let Some(original_version) = entry.original_version {
+            // A `catalog:` row moves with its entry, which keeps its own locked version; other rows share the name's.
+            let original = catalog_original(manager, dependency, string_buf).or_else(|| {
+                entry
+                    .original_version
+                    .map(|version| (version, &entry.original_version_string_buf[..]))
+            });
+            if let Some((original_version, original_buf)) = original {
                 if !original_version.eql(npm_version) {
                     return ShouldPrintPackageInstallResult::Update(Box::new(
                         PackageUpdatePrintInfo {
                             version: original_version,
+                            version_buf: Box::from(original_buf),
                             resolution,
                             dependency_id: dep_id,
                             package_id,
@@ -295,6 +339,25 @@ fn should_print_package_install(
     }
 
     ShouldPrintPackageInstallResult::Yes
+}
+
+/// What a `catalog:` row resolved to before the update, as `record_catalog_originals` recorded it on the row's catalog entry.
+fn catalog_original<'a>(
+    manager: &'a PackageManager,
+    dependency: &Dependency,
+    string_buf: &[u8],
+) -> Option<(semver::Version, &'a [u8])> {
+    if dependency.version.tag != DependencyVersionTag::Catalog {
+        return None;
+    }
+    let infos = &manager.updating_catalogs;
+    let index = CatalogUpdateInfo::position(
+        infos,
+        dependency.version.catalog().slice(string_buf),
+        dependency.name.slice(string_buf),
+    )?;
+    let original = infos[index].original.as_ref()?;
+    Some((original.version, &original.buf))
 }
 
 fn print_updated_package<W, const ENABLE_ANSI_COLORS: bool>(
@@ -318,14 +381,11 @@ where
         packages_slice.items_name_hash()[package_id],
         &update_info.resolution,
     )?;
-    let Some(entry) = manager.updating_packages.get(dep_name) else {
-        return Ok(());
-    };
     write_updated_row::<W, ENABLE_ANSI_COLORS>(
         writer,
         dep_name,
         update_info.version,
-        &entry.original_version_string_buf,
+        &update_info.version_buf,
         update_info.resolution.npm().version,
         string_buf,
         later.as_deref(),
@@ -396,7 +456,7 @@ fn print_catalog_entry_updates<W, const ENABLE_ANSI_COLORS: bool>(
     manager: &mut PackageManager,
     installed: &Bitset,
     pkg_metas: &[PackageMeta],
-    update_dedupe: &mut HashMap<PackageNameHash, ()>,
+    update_dedupe: &mut UpdateRowDedupe,
     writer: &mut W,
 ) -> Result<bool, crate::Error>
 where
@@ -428,7 +488,7 @@ where
         else {
             continue;
         };
-        if update_dedupe.get_or_put(dep.name_hash)?.found_existing {
+        if !update_dedupe.first_sighting(dep, &update_info)? {
             continue;
         }
         print_updated_package::<W, ENABLE_ANSI_COLORS>(this, manager, &update_info, writer)?;

--- a/src/install/update_transitive.rs
+++ b/src/install/update_transitive.rs
@@ -574,15 +574,8 @@ pub(crate) fn register_moved(
                 continue;
             }
         }
-        let mut tag_buf =
-            vec![0u8; current.tag.pre.len() + current.tag.build.len()].into_boxed_slice();
-        let original = current.clone_into(buf, &mut tag_buf, &mut 0);
-        *entry.value_ptr = PackageUpdateInfo {
-            original_version_literal: Box::default(),
-            written_back: false,
-            original_version_string_buf: tag_buf,
-            original_version: Some(original),
-        };
+        *entry.value_ptr = PackageUpdateInfo::default();
+        entry.value_ptr.set_original_version(current, buf);
     }
     Ok(())
 }

--- a/test/cli/install/catalogs.test.ts
+++ b/test/cli/install/catalogs.test.ts
@@ -352,8 +352,13 @@ describe("update", () => {
       await createUpdateMonorepo(packageDir, `catalog-update-latest-${label.replace(/\W+/g, "-")}`, isTopLevel);
       await runBunInstall(bunEnv, packageDir);
 
-      const { err, exitCode } = await runUpdate(packageDir, ...flags);
+      const { out, err, exitCode } = await runUpdate(packageDir, ...flags);
       expect(err).not.toContain("error:");
+
+      // The moved entry is reported like a direct dependency of the root, even though only pkg1 depends on it.
+      // a-dep still resolves to 1.0.10 (only its literal changes), so it gets no row.
+      expect(out.match(/^.*no-deps.*$/gm)).toStrictEqual(["^ no-deps 1.1.0 -> 2.0.0"]);
+      expect(out.match(/^.*a-dep.*$/gm)).toBeNull();
 
       // catalog entries are updated, preserving the pinning style
       const root = await file(join(packageDir, "package.json")).json();
@@ -405,8 +410,11 @@ describe("update", () => {
     await createUpdateMonorepo(packageDir, "catalog-update-in-workspace");
     await runBunInstall(bunEnv, packageDir);
 
-    const { err, exitCode } = await runUpdate(join(packageDir, "packages", "pkg1"), "--latest");
+    const { out, err, exitCode } = await runUpdate(join(packageDir, "packages", "pkg1"), "--latest");
     expect(err).not.toContain("error:");
+
+    // pkg1's own `catalog:` row is an update row, not a `+ no-deps@2.0.0` install row.
+    expect(out.match(/^.*no-deps.*$/gm)).toStrictEqual(["^ no-deps 1.1.0 -> 2.0.0"]);
 
     const root = await file(join(packageDir, "package.json")).json();
     expect(root.workspaces.catalog).toEqual({ "no-deps": "^2.0.0" });
@@ -417,6 +425,60 @@ describe("update", () => {
       "a-dep": "catalog:a",
     });
     expect(exitCode).toBe(0);
+  });
+
+  test("--latest reports a catalog entry the root itself depends on once", async () => {
+    const { packageDir } = await registry.createTestDir();
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "catalog-update-root-consumer",
+          workspaces: { packages: ["packages/*"], catalog: { "no-deps": "^1.0.0" } },
+          dependencies: { "no-deps": "catalog:" },
+        }),
+      ),
+      write(
+        join(packageDir, "packages", "pkg1", "package.json"),
+        JSON.stringify({ name: "pkg1", dependencies: { "no-deps": "catalog:" } }),
+      ),
+    ]);
+    await runBunInstall(bunEnv, packageDir);
+
+    const { out, err, exitCode } = await runUpdate(packageDir, "--latest");
+    expect(err).not.toContain("error:");
+    expect(out.match(/^.*no-deps.*$/gm)).toStrictEqual(["^ no-deps 1.1.0 -> 2.0.0"]);
+
+    const root = await file(join(packageDir, "package.json")).json();
+    expect(root.workspaces.catalog).toEqual({ "no-deps": "^2.0.0" });
+    expect(root.dependencies).toEqual({ "no-deps": "catalog:" });
+    expect(exitCode).toBe(0);
+  });
+
+  test("--latest reports a catalog entry whose new version needs no install (isolated store already has it)", async () => {
+    const { packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+    await createUpdateMonorepo(packageDir, "catalog-update-isolated-rerun");
+    await runBunInstall(bunEnv, packageDir);
+    const rootBefore = await file(join(packageDir, "package.json")).text();
+    const lockBefore = await file(join(packageDir, "bun.lock")).text();
+
+    const first = await runUpdate(packageDir, "--latest");
+    expect(first.err).not.toContain("error:");
+    expect(first.out.match(/^.*no-deps.*$/gm)).toStrictEqual(["^ no-deps 1.1.0 -> 2.0.0"]);
+    expect(first.exitCode).toBe(0);
+
+    // Like `git checkout .` followed by `bun install`: the project is back on 1.1.0 while node_modules/.bun keeps no-deps@2.0.0.
+    await Promise.all([
+      write(join(packageDir, "package.json"), rootBefore),
+      write(join(packageDir, "bun.lock"), lockBefore),
+    ]);
+    await runBunInstall(bunEnv, packageDir, { savesLockfile: false });
+
+    const second = await runUpdate(packageDir, "--latest");
+    expect(second.err).not.toContain("error:");
+    expect(second.out.match(/^.*no-deps.*$/gm)).toStrictEqual(["^ no-deps 1.1.0 -> 2.0.0"]);
+    expect((await file(join(packageDir, "package.json")).json()).workspaces.catalog).toEqual({ "no-deps": "^2.0.0" });
+    expect(second.exitCode).toBe(0);
   });
 
   test("--latest updates the same package independently per catalog", async () => {
@@ -542,8 +604,9 @@ describe("update", () => {
         ),
       ]);
 
-      const { err, exitCode } = await runUpdate(packageDir, ...args);
+      const { out, err, exitCode } = await runUpdate(packageDir, ...args);
       expect(err).not.toContain("error:");
+      expect(out.match(/^.*no-deps.*$/gm)).toStrictEqual(["^ no-deps 1.0.0 -> 1.1.0 (v2.0.0 available)"]);
 
       const root = await file(join(packageDir, "package.json")).json();
       expect(root.workspaces.catalog).toEqual({ "no-deps": "^1.1.0" });

--- a/test/cli/install/catalogs.test.ts
+++ b/test/cli/install/catalogs.test.ts
@@ -455,6 +455,19 @@ describe("update", () => {
     expect(exitCode).toBe(0);
   });
 
+  test("--latest --verbose reports a catalog entry once, under the workspace that depends on it", async () => {
+    const { packageDir } = await registry.createTestDir();
+    await createUpdateMonorepo(packageDir, "catalog-update-verbose");
+    await runBunInstall(bunEnv, packageDir);
+
+    const { out, err, exitCode } = await runUpdate(packageDir, "--latest", "--verbose");
+    expect(err).not.toContain("error:");
+    const lines = out.split(/\r?\n/);
+    expect(lines.filter(line => line.includes("no-deps"))).toStrictEqual(["^ no-deps 1.1.0 -> 2.0.0"]);
+    expect(lines[lines.indexOf("pkg1:") + 1]).toBe("^ no-deps 1.1.0 -> 2.0.0");
+    expect(exitCode).toBe(0);
+  });
+
   test("--latest reports a catalog entry whose new version needs no install (isolated store already has it)", async () => {
     const { packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
     await createUpdateMonorepo(packageDir, "catalog-update-isolated-rerun");

--- a/test/cli/install/catalogs.test.ts
+++ b/test/cli/install/catalogs.test.ts
@@ -538,8 +538,13 @@ describe("update", () => {
     ]);
     await runBunInstall(bunEnv, packageDir);
 
-    const { err, exitCode } = await runUpdate(packageDir, "--latest");
+    const { out, err, exitCode } = await runUpdate(packageDir, "--latest");
     expect(err).not.toContain("error:");
+    // one row per moved entry, each from the version that entry was locked to
+    expect(out.match(/^.*no-deps.*$/gm)?.sort()).toStrictEqual([
+      "^ no-deps 1.0.1 -> 2.0.0",
+      "^ no-deps 1.1.0 -> 2.0.0",
+    ]);
 
     const root = await file(join(packageDir, "package.json")).json();
     // each catalog entry keeps its own pinning style
@@ -547,6 +552,69 @@ describe("update", () => {
     expect(root.workspaces.catalogs.pinned).toEqual({ "no-deps": "2.0.0" });
     // entries not referenced by any workspace are left unchanged
     expect(root.workspaces.catalogs.unused).toEqual({ "no-deps": "1.0.0" });
+    expect(exitCode).toBe(0);
+  });
+
+  test("update reports the catalog entry that moved, not another entry for the same name", async () => {
+    // The default catalog pins no-deps@2.0.0 exactly; `catalogs.old` allows ^1.0.0 and the lockfile has it at 1.0.0 (as if 1.1.0 was published after install).
+    const { packageDir } = await registry.createTestDir();
+    const url = registry.registryUrl();
+    const lockfile = {
+      lockfileVersion: 2,
+      configVersion: 1,
+      workspaces: {
+        "": { name: "catalog-update-two-entries" },
+        "packages/pkg1": { name: "pkg1", dependencies: { "no-deps": "catalog:" } },
+        "packages/pkg2": { name: "pkg2", dependencies: { "no-deps": "catalog:old" } },
+      },
+      catalog: { "no-deps": "2.0.0" },
+      catalogs: { old: { "no-deps": "^1.0.0" } },
+      packages: {
+        "no-deps": [
+          "no-deps@2.0.0",
+          `${url}no-deps/-/no-deps-2.0.0.tgz`,
+          {},
+          "sha512-W3duJKZPcMIG5rA1io5cSK/bhW9rWFz+jFxZsKS/3suK4qHDkQNxUTEXee9/hTaAoDCeHWQqogukWYKzfr6X4g==",
+        ],
+        "pkg1": ["pkg1@workspace:packages/pkg1"],
+        "pkg2": ["pkg2@workspace:packages/pkg2"],
+        "pkg2/no-deps": [
+          "no-deps@1.0.0",
+          `${url}no-deps/-/no-deps-1.0.0.tgz`,
+          {},
+          "sha512-v4w12JRjUGvfHDUP8vFDwu0gUWu04j0cv9hLb1Abf9VdaXu4XcrddYFTMVBVvmldKViGWH7jrb6xPJRF0wq6gw==",
+        ],
+      },
+    };
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "catalog-update-two-entries",
+          workspaces: {
+            packages: ["packages/*"],
+            catalog: { "no-deps": "2.0.0" },
+            catalogs: { old: { "no-deps": "^1.0.0" } },
+          },
+        }),
+      ),
+      write(join(packageDir, "packages", "pkg1", "package.json"), JSON.stringify(lockfile.workspaces["packages/pkg1"])),
+      write(join(packageDir, "packages", "pkg2", "package.json"), JSON.stringify(lockfile.workspaces["packages/pkg2"])),
+      write(join(packageDir, "bun.lock"), JSON.stringify(lockfile)),
+    ]);
+
+    const { out, err, exitCode } = await runUpdate(packageDir);
+    expect(err).not.toContain("error:");
+    // Only the `old` entry moved, and the row says so; the default entry stays at 2.0.0 without a row.
+    expect(out.match(/^.*no-deps.*$/gm)).toStrictEqual(["^ no-deps 1.0.0 -> 1.1.0 (v2.0.0 available)"]);
+
+    const root = await file(join(packageDir, "package.json")).json();
+    expect(root.workspaces.catalog).toEqual({ "no-deps": "2.0.0" });
+    expect(root.workspaces.catalogs).toEqual({ old: { "no-deps": "^1.1.0" } });
+    const lock = await file(join(packageDir, "bun.lock")).text();
+    expect(lock).toContain("no-deps@2.0.0");
+    expect(lock).toContain("no-deps@1.1.0");
+    expect(lock).not.toContain("no-deps@1.0.0");
     expect(exitCode).toBe(0);
   });
 


### PR DESCRIPTION
### Problem
- A bare `bun update` / `bun update --latest` that moves a root catalog entry rewrites package.json and bun.lock but the summary never prints the `^ name old -> new` row for it. Catalog `zed: ^1.0.0` consumed by a workspace member, locked at 1.4.0, latest 3.0.0:
  - `bun update --latest` from the root prints only `1 package installed`; with `-r` the same.
  - Run from the consuming member, or when the root itself has `zed: "catalog:"`, it prints `+ zed@3.0.0` (a plain install row).
  - With the isolated linker and the new version already in `node_modules/.bun`, a second run prints `Done! Checked 3 packages (no changes)` while a semver-major bump was written.
  - The same project with a direct `zed: ^1.0.0` prints `^ zed 1.4.0 -> 3.0.0` in every one of those cases, and `--dry-run` / `--lockfile-only` already print the row for the catalog case too (`update_transitive::print_plan` diffs the rows directly), so only the install summary disagreed.
- Cause: the summary derives update rows from `manager.updating_packages` (`tree_printer.rs`, `should_print_package_install`), keyed by dependency name with the version the name was locked to. `edit_catalogs_before_update` records catalog entries only in `updating_catalogs`, and `record_updating_package_versions` (`install_with_manager.rs`) skips every row whose version is not `Npm`/`DistTag`, so a `catalog:` row never has an original to compare against. The printer also only walks the rows of the workspaces whose package.json it edited, so an entry consumed elsewhere had no row to print from even if it had been registered.

### Fix
- `package_json_editor::record_catalog_originals` (called at the end of `record_updating_package_versions`, i.e. on the loaded lockfile before the differ re-enqueues anything): for every `catalog:` row whose entry `edit_catalogs_before_update` recorded, keep the row's locked version on that entry (`CatalogUpdateInfo.original`, first row of an entry wins) and register the dependency name in `updating_packages` the same way the cwd's own dependency lists do. The summary takes a `catalog:` row's `from` from its entry, so two catalog entries for one package each report their own move (the existing per-catalog test now asserts both rows, and a plain update that moves only `catalogs.old` prints `^ no-deps 1.0.0 -> 1.1.0`, not `2.0.0 -> 1.1.0` from the default entry). The entry is marked `catalog_entry` and `written_back`, so the post-install `edit_update_entries` pass does not rewrite a same-named non-catalog dependency of the cwd from it (verified: a root `zed: "latest"` next to a catalog `zed` entry stays `"latest"` on a plain update). A name the dependency lists already registered keeps their original, so the existing `+` / `^` output for direct dependencies is unchanged.
- `tree_printer.rs`: rows of the walked workspaces now print `^` rows for their `catalog:` dependencies for free (and stop printing `+` for them). In the normal single-section summary, `print_catalog_entry_updates` additionally walks the `catalog:` rows of names registered this way, sharing the section's dedupe (by name for dependency-list rows as before, by name + from + to for catalog rows), so an entry consumed only outside the walked set is reported too; the `--verbose` summary prints one section per workspace, each of which already reports its own `catalog:` rows, so it skips the walk (`sole_section`) and a moved entry shows up once, under the workspace that depends on it. Both go through `should_print_package_install`, which for `bun update` reports a moved row whether or not its new version had to be installed, so the isolated-store rerun now prints the row as well (the count line stays `(no changes)`, as it does for a direct dependency in the same situation).
- Entries that do not move print nothing: a registered name whose rows still resolve to the original version compares equal, exactly like a direct dependency that did not move. Checked by hand with an exact catalog entry on a plain update, a two-entry catalog where only one entry moves, a name declared both directly and in the catalog (one row), and `--filter <member>` (catalogs untouched, no row).
- The version copy that `record_updating_package_versions` and `update_transitive::register_moved` each open-coded becomes `DetachedVersion` (behind `PackageUpdateInfo::set_original_version` and `CatalogUpdateInfo.original`), on the `clone_into` signature from #40406.
- Verified with `test/cli/install/catalogs.test.ts` (`update` block): the `--latest` variants (catalog in `workspaces`, top-level `catalog`, `-r`), the plain update within range (with and without `-r`), the run from inside a member, plus four new cases: the root itself consuming the entry (one row, no `+` row), `--verbose` (exactly one row, under `pkg1:`), the isolated-store rerun, and two catalogs declaring the same package where only one entry moves. All 11 row assertions fail on the unfixed build (`null` or `+ no-deps@2.0.0` instead of the row) and pass with the fix; the unmoved `a-dep` entry is asserted to produce no row. Also ran `bun-update.test.ts` (156), `bun-update-transitive`, `bun-update-lockfile-sync`, `bun-add-catalog`, `lockfile-only` (413) and the `update` subset of `bun-install-registry.test.ts`: all green.

### Background
- Catalogs: the root package.json's `catalog` / `catalogs` maps hold version ranges; a workspace declares `"zed": "catalog:"` (or `catalog:<group>`) and resolves through the map. A bare `bun update` treats the entries like the root's own dependencies: `edit_catalogs_before_update` points them at `latest` (with `--latest`) in memory and remembers each entry in `updating_catalogs`; after resolving, `edit_catalogs_after_update` writes the resolved range back into the root package.json.
- `updating_packages`: the map a bare update keeps per dependency name, holding the literal being updated and (`record_updating_package_versions`) the version bun.lock had for it. The install summary walks the rows of the updated workspaces and prints `^ name old -> new` for every row whose name is in the map and whose resolution now differs from that recorded version; that check runs before the "was it installed" check, which is why direct dependencies print even when nothing new was linked. `update_transitive::register_moved` uses the same map, with an empty literal, for packages moved by the transitive half of the update; `print_transitive_updates` prints those from the set of packages installed this run, which is why this change does not reuse that path for catalogs.
- Per-name granularity is pre-existing for dependency-list rows: the map holds one original per name, so a name declared with different ranges in several workspaces prints one row from whichever registration came first. Catalog rows are the exception: their `from` comes from their own entry, so each catalog entry reports its own move.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 11 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/catalogs.test.ts
bun test v1.4.1 (861e9ae04)

test/cli/install/catalogs.test.ts:
(pass) basic > both catalog and catalogs in top-level [432.09ms]
(pass) basic > both catalog and catalogs in workspaces [349.78ms]
(pass) basic > detect changes (bun.lockb) [623.17ms]
(pass) basic > detect changes (bun.lock) [594.07ms]
(pass) basic > switching a dependency to a different catalog is detected [512.30ms]
(pass) basic > catalog and catalogs.default may split different packages between them [348.90ms]
355 |       const { out, err, exitCode } = await runUpdate(packageDir, ...flags);
356 |       expect(err).not.toContain("error:");
357 | 
358 |       // The moved entry is reported like a direct dependency of the root, even though only pkg1 depends on it.
359 |       // a-dep still resolves to 1.0.10 (only its literal changes), so it gets no row.
360 |       expect(out.match(/^.*no-deps.*$/gm)).toStrictEqual(["^ no-deps 1.1.0 -> 2.0.0"]);
                                                 ^
error: expect(received).toStrictEqual(expe
... (truncated)

release without fix: 11 FAILED
bun test v1.4.1-canary.1 (861e9ae04)

test/cli/install/catalogs.test.ts:
(pass) basic > both catalog and catalogs in top-level [70.27ms]
(pass) basic > both catalog and catalogs in workspaces [21.73ms]
(pass) basic > detect changes (bun.lockb) [40.64ms]
(pass) basic > detect changes (bun.lock) [40.04ms]
(pass) basic > switching a dependency to a different catalog is detected [22.58ms]
(pass) basic > catalog and catalogs.default may split different packages between them [22.07ms]
355 |       const { out, err, exitCode } = await runUpdate(packageDir, ...flags);
356 |       expect(err).not.toContain("error:");
357 | 
358 |       // The moved entry is reported like a direct dependency of the root, even though only pkg1 depends on it.
359 |       // a-dep still resolves to 1.0.10 (only its literal changes), so it gets no row.
360 |       expect(out.match(/^.*no-deps.*$/gm)).toStrictEqual(["^ no-deps 1.1.0 -> 2.0.0"]);
                                                 ^
error: expect(received).toStrictEqual(expected)

- [
-   "^ no-deps 1.1.0 -> 2.0.0",
- ]
+ null

- Expected  - 3
+ Received  + 1

      at <anonymous> (/workspace/bun/test/cli/install/catalogs.test.ts:360:4
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/catalogs.test.ts
bun test v1.4.1 (861e9ae04)

test/cli/install/catalogs.test.ts:
(pass) basic > both catalog and catalogs in top-level [470.51ms]
(pass) basic > both catalog and catalogs in workspaces [444.23ms]
(pass) basic > detect changes (bun.lockb) [592.32ms]
(pass) basic > detect changes (bun.lock) [686.52ms]
(pass) basic > switching a dependency to a different catalog is detected [521.45ms]
(pass) basic > catalog and catalogs.default may split different packages between them [405.71ms]
(pass) update > --latest updates catalog versions in top-level [495.11ms]
(pass) update > --latest updates catalog versions in workspaces [395.33ms]
(pass) update > --latest updates catalog versions with -r [478.08ms]
(pass) update > --frozen-lockfile passes after --latest updates catalogs [574.84ms]
(pass) update > --latest run from inside a workspace package updates the root catalog [492.32ms]
(pass) update > --latest reports a catalog entry the root itself depends on once [387.68ms]
(pass) update > --latest --verbose reports a 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     220891f13b
  features     baseline

23 deps, 129 codegen, 1172 objects in 697ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] gen ErrorCode+*.h
[2/1244] install /workspace/bun
bun install v1.4.1-canary.1 (861e9ae04)

Checked 26 installs across 63 packages (no changes) [11.00ms]
[3/1244] gen bindgenv2
[4/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (861e9ae04)

Checked 1 install across 2 packages (no changes) [3.00ms]
[5/1244] fetch zlib
[zlib] up to date
[6/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (861e9ae04)

Checked 111 installs across 104 packages (no changes) [10.00ms]
[7/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1217] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[9/1217] fetch tinycc
[tinycc] up to date
[10/1216] gen .bind.ts → GeneratedBindings.cpp
[11/1216] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/Pro
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/install/PackageManager.rs                      |  42 ++++++
 src/install/PackageManager/PackageJSONEditor.rs    |  71 +++++++++-
 src/install/PackageManager/install_with_manager.rs |  22 +--
 src/install/lockfile/printer/tree_printer.rs       | 157 ++++++++++++++++++---
 src/install/update_transitive.rs                   |  11 +-
 test/cli/install/catalogs.test.ts                  | 152 +++++++++++++++++++-
 6 files changed, 403 insertions(+), 52 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/install/PackageManager.rs                           3      5      0
src/install/PackageManager/PackageJSONEditor.rs         6      5      0
src/install/PackageManager/install_with_manager.rs      6      2      0
src/install/lockfile/printer/tree_printer.rs            6     14      0
src/install/update_transitive.rs                        3      2      0
test/cli/install/catalogs.test.ts                       6      9      0
```

</details>

<!-- robobun:evidence:end -->

