### PR TITLE
install: keep BUN_CONFIG_TOKEN / NPM_CONFIG_TOKEN when --registry points at a different host

### DIFF
--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -631,6 +631,30 @@ impl Options {
             }
         }
 
+        if let Some(cli) = &maybe_cli {
+            if !cli.registry.is_empty() {
+                let new_url = bun_url::URL::parse(cli.registry);
+                let same_origin = {
+                    let prev_url = self.scope.url.url();
+                    bun_core::without_trailing_slash(new_url.host)
+                        == bun_core::without_trailing_slash(prev_url.host)
+                        && (new_url.is_https() || !prev_url.is_https())
+                };
+                if !same_origin {
+                    self.scope.token = Box::default();
+                    self.scope.auth = Box::default();
+                    self.scope.user = Box::default();
+                }
+                let href: Box<[u8]> = cli.registry.into();
+                self.scope.url_hash =
+                    Npm::registry::Scope::hash(bun_core::without_trailing_slash(&href));
+                self.scope.url = bun_url::OwnedURL::from_href(href);
+            }
+        }
+
+        // Unlike the credentials dropped by the registry overrides above, these
+        // are not tied to a host: they apply to whichever registry ended up as
+        // the default, so they are read only once that is settled.
         {
             const TOKEN_KEYS: [&[u8]; 3] = [
                 b"BUN_CONFIG_TOKEN",
@@ -686,25 +710,6 @@ impl Options {
             self.do_.set(Do::ANALYZE, cli.analyze);
             self.enable
                 .set(Enable::ONLY_MISSING, cli.only_missing || cli.analyze);
-
-            if !cli.registry.is_empty() {
-                let new_url = bun_url::URL::parse(cli.registry);
-                let same_origin = {
-                    let prev_url = self.scope.url.url();
-                    bun_core::without_trailing_slash(new_url.host)
-                        == bun_core::without_trailing_slash(prev_url.host)
-                        && (new_url.is_https() || !prev_url.is_https())
-                };
-                if !same_origin {
-                    self.scope.token = Box::default();
-                    self.scope.auth = Box::default();
-                    self.scope.user = Box::default();
-                }
-                let href: Box<[u8]> = cli.registry.into();
-                self.scope.url_hash =
-                    Npm::registry::Scope::hash(bun_core::without_trailing_slash(&href));
-                self.scope.url = bun_url::OwnedURL::from_href(href);
-            }
 
             if let Some(cache_dir) = cli.cache_dir {
                 self.cache_directory = cache_dir;

--- a/test/cli/install/config-precedence.test.ts
+++ b/test/cli/install/config-precedence.test.ts
@@ -528,6 +528,38 @@ describe.concurrent("bun install config precedence", () => {
     expect(exitCode).toBe(0);
   });
 
+  test.each(["BUN_CONFIG_TOKEN", "NPM_CONFIG_TOKEN"])(
+    "%s applies to the registry passed with --registry",
+    async key => {
+      using capture = capturingRegistry();
+      using dir = tempDir("config-precedence", {
+        "project/package.json": packageJson({ "@needs-auth/test-pkg": "1.0.0" }),
+      });
+      const { stderr, exitCode } = await install(String(dir), ["--registry", capture.url], { [key]: authToken });
+      expect(stderr).not.toContain("error:");
+      expect(new Set(capture.authorizations)).toStrictEqual(new Set([`Bearer ${authToken}`]));
+      expect(installed(String(dir), "@needs-auth", "test-pkg")).toBe(true);
+      expect(exitCode).toBe(0);
+    },
+  );
+
+  test("--registry drops the _authToken of the .npmrc registry but keeps BUN_CONFIG_TOKEN", async () => {
+    using dead = deadRegistry();
+    using capture = capturingRegistry();
+    using dir = tempDir("config-precedence", {
+      "project/.npmrc": `registry=${dead.url}\n//localhost:${dead.server.port}/:_authToken=token-for-dead\n`,
+      "project/package.json": packageJson({ "@needs-auth/test-pkg": "1.0.0" }),
+    });
+    const { stderr, exitCode } = await install(String(dir), ["--registry", capture.url], {
+      BUN_CONFIG_TOKEN: authToken,
+    });
+    expect(stderr).not.toContain("error:");
+    expect(dead.hits).toBe(0);
+    expect(new Set(capture.authorizations)).toStrictEqual(new Set([`Bearer ${authToken}`]));
+    expect(installed(String(dir), "@needs-auth", "test-pkg")).toBe(true);
+    expect(exitCode).toBe(0);
+  });
+
   test("NPM_CONFIG_REGISTRY beats registry= in project .npmrc", async () => {
     using dead = deadRegistry();
     using dir = tempDir("config-precedence", {


### PR DESCRIPTION
### Problem
- `NPM_CONFIG_TOKEN=<token> bun install --registry=https://npm.corp/` (same with `BUN_CONFIG_TOKEN`) sends no `Authorization` header and fails with `error: GET http://reg:4873/left-pad-x - 401` / `left-pad-x@^1.0.0 failed to resolve`. 1.3.14 sends `Bearer <token>` and installs.
- `Options::load` (src/install/PackageManager/PackageManagerOptions.rs) applied the token env vars to the default registry scope, and only afterwards processed `--registry`. Since #36165 that branch compares the flag's host with the host of the registry configured so far (registry.npmjs.org when nothing is configured) and clears `token` / `auth` / `user` on a mismatch, which also wiped the env token.
- Passing the same registry through `BUN_CONFIG_REGISTRY`, `.npmrc` or `bunfig.toml` was unaffected because those are applied before the env token.

### Fix
- Process `--registry` (URL switch plus the host-mismatch credential drop from #36165) before reading `BUN_CONFIG_TOKEN` / `NPM_CONFIG_TOKEN` / `npm_config_token`, so the env token is applied to the registry that was actually selected.
- Credentials from `.npmrc` / `bunfig.toml` are bound to the registry they were declared for and are still dropped when `--registry` names a different host; the env token is not bound to a host, so applying it after every registry override is the behavior the env var documents ("auth token for the default registry"). Precedence between the token sources is unchanged: config < env < CLI.
- Tests: test/cli/install/config-precedence.test.ts, three new cases (`BUN_CONFIG_TOKEN` and `NPM_CONFIG_TOKEN` with `--registry`, and `.npmrc` token for registry A + `--registry` B + env token: B receives only the env token, A receives nothing). All three fail on the current canary (1.4.0-canary.1, 401 as above) and pass with this change.
- Also run with the change: test/cli/install/npmrc.test.ts `--registry override` (the #36165 test), test/cli/install/bun-install-registry.test.ts env token / registry override tests, test/cli/install/bun-publish.test.ts.

### Background
- The default registry scope (`npm::registry::Scope`) holds the URL plus the credentials used for every unscoped package request; `Options::load` builds it in layers: `.npmrc` / `bunfig.toml`, then `BUN_CONFIG_REGISTRY`-style env vars, then CLI flags.
- `.npmrc` credentials are declared per host (`//host/:_authToken=...`) and bunfig tokens sit next to a URL, so they are only valid for that host; `BUN_CONFIG_TOKEN` / `NPM_CONFIG_TOKEN` carry no host and have always meant "the token for whatever the default registry is".
- Out of scope, unchanged from 1.3.14: an `.npmrc` `//host/:_authToken` line whose host matches only the `--registry` (or `BUN_CONFIG_REGISTRY`) URL is not picked up; the auth lines are matched against the config-file registries when the files are loaded and are not kept around for the overrides.
