### PR TITLE
install: fix crash loading a bun.lock with workspaces but no packages object

### DIFF
--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -2488,23 +2488,29 @@ pub(crate) fn parse_into_binary_lockfile(
         }
     }
 
-    let Some(pkgs_expr) = root.get(b"packages") else {
-        // packages is empty, but there might be empty workspace packages
-        if workspace_pkgs_len == 0 {
-            lockfile.init_empty();
-        }
+    let pkgs_expr = root.get(b"packages");
+
+    // A missing "packages" object is parsed like an empty one. With no
+    // workspace packages there is nothing to resolve, otherwise the workspace
+    // packages appended above and the root's dependencies on them still need
+    // the resolution pass below (which also sizes `buffers.resolutions`).
+    if pkgs_expr.is_none() && workspace_pkgs_len == 0 {
+        lockfile.init_empty();
         return Ok(());
-    };
+    }
 
     {
-        if !pkgs_expr.is_object() {
-            log.add_error(
-                Some(source),
-                value_loc_of(source, pkgs_expr.loc),
-                b"Expected an object",
-            );
-            return Err(ParseError::InvalidPackagesObject);
+        if let Some(pkgs_expr) = &pkgs_expr {
+            if !pkgs_expr.is_object() {
+                log.add_error(
+                    Some(source),
+                    value_loc_of(source, pkgs_expr.loc),
+                    b"Expected an object",
+                );
+                return Err(ParseError::InvalidPackagesObject);
+            }
         }
+        let pkg_rows: &[JSON::E::PropertyJSON] = pkgs_expr.as_ref().map_or(&[], object_rows);
 
         // find the bundle roots.
         //
@@ -2518,7 +2524,7 @@ pub(crate) fn parse_into_binary_lockfile(
         // the bundled map, and mark the dependency bundled if it exists. This works
         // because package's direct bundled dependencies can only exist at the top
         // level of it's node_modules.
-        for row in object_rows(&pkgs_expr) {
+        for row in pkg_rows {
             let pkg_path = row.key.slice();
 
             let Some(pkg_info) = row.value.as_array() else {
@@ -2546,7 +2552,7 @@ pub(crate) fn parse_into_binary_lockfile(
             bundled_pkgs.put(pkg_path, ());
         }
 
-        'next_pkg_key: for row in object_rows(&pkgs_expr) {
+        'next_pkg_key: for row in pkg_rows {
             let key_loc = row.key_loc;
             let pkg_path = row.key.slice();
 
@@ -3202,7 +3208,7 @@ pub(crate) fn parse_into_binary_lockfile(
         }
 
         // then each package dependency
-        for row in object_rows(&pkgs_expr) {
+        for row in pkg_rows {
             let pkg_path = row.key.slice();
 
             let Some(&pkg_id) = pkg_map.get(pkg_path) else {

--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -9,6 +9,7 @@ import {
   normalizeBunSnapshot,
   readdirSorted,
   runBunInstall,
+  tempDir,
   toBeValidBin,
   VerdaccioRegistry,
 } from "harness";
@@ -1033,6 +1034,77 @@ describe.concurrent("hand-edited bun.lock overrides", () => {
     `);
     expect(out).toMatchInlineSnapshot(`"bun install <version> (<revision>)"`);
     expect(exitCode).toBe(1);
+  });
+});
+
+describe.concurrent("hand-edited bun.lock that lists workspaces but has no packages object", () => {
+  const lockfileWithoutPackages = (lockfileVersion: number) =>
+    JSON.stringify(
+      {
+        lockfileVersion,
+        workspaces: {
+          "": { name: "no-packages-object" },
+          "packages/member": { name: "member", version: "1.0.0" },
+        },
+      },
+      null,
+      2,
+    );
+
+  const projectFiles = (lockfileVersion: number) => ({
+    "package.json": JSON.stringify({ name: "no-packages-object", workspaces: ["packages/*"] }),
+    "packages/member/package.json": JSON.stringify({ name: "member", version: "1.0.0" }),
+    "bun.lock": lockfileWithoutPackages(lockfileVersion),
+  });
+
+  async function install(cwd: string, ...args: string[]) {
+    await using proc = spawn({
+      cmd: [bunExe(), "install", ...args],
+      cwd,
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { out: normalizeBunSnapshot(out, cwd), err: normalizeBunSnapshot(err, cwd), exitCode };
+  }
+
+  it("bun install links the workspace and writes the packages object back", async () => {
+    using dir = tempDir("bun-lock-no-packages-object", projectFiles(1));
+    const { out, err, exitCode } = await install(String(dir));
+    expect(err).toMatchInlineSnapshot(`"Saved lockfile"`);
+    expect(out).toMatchInlineSnapshot(`
+      "bun install <version> (<revision>)
+
+      1 package installed"
+    `);
+    expect(exitCode).toBe(0);
+
+    expect(await file(join(String(dir), "node_modules", "member", "package.json")).json()).toEqual({
+      name: "member",
+      version: "1.0.0",
+    });
+    expect(await file(join(String(dir), "bun.lock")).text()).toContain(
+      `"packages": {\n    "member": ["member@workspace:packages/member"],\n  }`,
+    );
+  });
+
+  it("bun install --frozen-lockfile treats it like an empty packages object", async () => {
+    using dir = tempDir("bun-lock-no-packages-object-frozen", projectFiles(2));
+    const { out, err, exitCode } = await install(String(dir), "--frozen-lockfile");
+    expect(err).toMatchInlineSnapshot(`""`);
+    expect(out).toMatchInlineSnapshot(`
+      "bun install <version> (<revision>)
+
+      1 package installed"
+    `);
+    expect(exitCode).toBe(0);
+
+    expect(await file(join(String(dir), "node_modules", "member", "package.json")).json()).toEqual({
+      name: "member",
+      version: "1.0.0",
+    });
+    expect(await file(join(String(dir), "bun.lock")).text()).toBe(lockfileWithoutPackages(2));
   });
 });
 


### PR DESCRIPTION
### Problem
- `bun install` crashes on a `bun.lock` that lists a workspace but has no `"packages"` key (a merge-damaged or hand-trimmed lockfile): `panic: index out of bounds: the len is 0 but the index is 0` in `Package::Diff::generate` (1.3.x segfaults at the same place). `bun install --frozen-lockfile`, `bun dedupe`, `bun prune` and `bun pm licenses` crash the same way.
- `parse_into_binary_lockfile` (`src/install/lockfile/bun.lock.rs:2491`) appends the root package and the workspace packages built from the `"workspaces"` object, then returns as soon as `"packages"` is missing. That return skips the resolution pass, so `buffers.resolutions` is never sized while the root package already claims a resolutions slice for its workspace dependencies.
- The differ (`src/install/lockfile/Package.rs:1515`) reads `from_resolutions[i]` for the root's workspace dependency, which indexes the empty buffer.
- The only recovery was deleting `bun.lock`; adding `"packages": {}` by hand also fixed it, which is the hint for the fix.

### Fix
- A missing `"packages"` object is now parsed exactly like `"packages": {}`: the parser falls through to the resolution pass with an empty row list (`pkg_rows`), which sizes `buffers.resolutions` and binds the root's dependencies on the workspace packages.
- This is correct because, at lockfile versions 1 and up, the workspace entries inside `"packages"` are redundant: the parser already builds every workspace package from the `"workspaces"` object and skips their `"packages"` rows (`found_existing` branch). So a workspace-only lockfile is fully recoverable, and a plain `bun install` writes the `"packages"` object back.
- A lockfile that also had real dependencies still fails in the resolution pass (`Failed to resolve root prod dependency 'x'`), which is the normal `failed to parse lockfile` / `Ignoring lockfile` path, the same as with `"packages": {}` today.
- A lockfile with neither workspaces nor `"packages"` is still loaded as empty, as before.
- Verified with `test/cli/install/bun-lock.test.ts` ("hand-edited bun.lock that lists workspaces but has no packages object"): both tests hit the panic above on the released binary and pass with this change.
- Also ran the report's other commands (`install --frozen-lockfile`, `dedupe`, `prune`, `pm licenses`, `pm ls`) against the reproduction at lockfile versions 1 and 3 with the debug build: all exit cleanly.
- The rest of `bun-lock.test.ts`, plus `bun-dedupe`, `bun-prune`, `config-version`, `lockfile-version-2`, `lockfile-only` and `bun-pm-licenses`, still pass.

### Background
- `bun.lock` is parsed into the in-memory `Lockfile`, whose packages do not own their dependency lists. Each package stores an `(offset, len)` pair (`ExternalSlice`) into two parallel flat buffers: `buffers.dependencies` (the declared dependencies) and `buffers.resolutions` (the package id each dependency resolved to, at the same index). Every loaded lockfile relies on both buffers having the same length.
- The text lockfile parser fills `buffers.dependencies` while it reads the `"workspaces"` and `"packages"` objects, and only sizes and fills `buffers.resolutions` in a final resolution pass, which is the pass the early return skipped.
- For a workspace project the root package gets one dependency per workspace member, synthesized from the `"workspaces"` object, so the root has dependencies even when the file has no `"packages"` key.
- `Package::Diff::generate` compares the root package from the loaded lockfile against the one parsed from `package.json` on every install; reading each old dependency's resolution is how it decides what to keep.

<details>
<summary>Reproduction</summary>

```sh
mkdir -p pkgs/w
echo '{"name":"z","workspaces":["pkgs/*"]}'  > package.json
echo '{"name":"w","version":"1.0.0"}'         > pkgs/w/package.json
cat > bun.lock <<'EOF'
{ "lockfileVersion": 1, "workspaces": { "": { "name": "z" }, "pkgs/w": { "name": "w", "version": "1.0.0" } } }
EOF
bun install
```

Before: `panic: index out of bounds: the len is 0 but the index is 0`, exit 134.

After:

```
bun install v1.4.0
Saved lockfile

1 package installed
```

and `bun.lock` gets `"packages": { "w": ["w@workspace:pkgs/w"] }` back.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-lock.test.ts

<!-- robobun:evidence:end -->