### PR TITLE
http: report a refused HTTP client thread as an error instead of a crash

### DIFF
--- a/src/errno/lib.rs
+++ b/src/errno/lib.rs
@@ -304,6 +304,22 @@ pub fn from_errno(errno: i32) -> SystemErrno {
     SystemErrno::init(errno as i64).unwrap_or(SystemErrno::EIO)
 }
 
+impl SystemErrno {
+    /// The OS error behind a `std::io::Error`; `None` if it is not an OS error or its code has no `SystemErrno`.
+    pub fn from_io_error(err: &std::io::Error) -> Option<SystemErrno> {
+        let code = err.raw_os_error()?;
+        #[cfg(windows)]
+        {
+            // A Win32 code: the `u32` entry point maps it, `i64` would read it as an errno discriminant.
+            SystemErrno::init(code as u32)
+        }
+        #[cfg(not(windows))]
+        {
+            SystemErrno::init(i64::from(code))
+        }
+    }
+}
+
 #[cfg(not(windows))]
 impl SystemErrno {
     // `i64` covers every concrete call site (errno-range values).
@@ -501,6 +517,32 @@ mod errno_name_tests {
             assert_eq!(win32_errno_name(2), None);
             assert_eq!(win32_errno_name(u32::MAX), None);
         }
+    }
+
+    #[test]
+    fn io_error_to_errno() {
+        // Deliberately not EAGAIN, which is what the callers fall back to.
+        #[cfg(not(windows))]
+        assert_eq!(
+            SystemErrno::from_io_error(&std::io::Error::from_raw_os_error(libc::ENOMEM)),
+            Some(SystemErrno::ENOMEM)
+        );
+        #[cfg(windows)]
+        {
+            // Win32 ERROR_NOT_ENOUGH_MEMORY and ERROR_ACCESS_DENIED; read as errno values, 8 and 5 would be ENOEXEC and EIO.
+            assert_eq!(
+                SystemErrno::from_io_error(&std::io::Error::from_raw_os_error(8)),
+                Some(SystemErrno::ENOMEM)
+            );
+            assert_eq!(
+                SystemErrno::from_io_error(&std::io::Error::from_raw_os_error(5)),
+                Some(SystemErrno::EPERM)
+            );
+        }
+        assert_eq!(
+            SystemErrno::from_io_error(&std::io::Error::other("not from the OS")),
+            None
+        );
     }
 
     #[test]

--- a/src/http/HTTPThread.rs
+++ b/src/http/HTTPThread.rs
@@ -5,6 +5,7 @@ use std::time::Instant;
 
 use bun_collections::ArrayHashMap;
 use bun_core::{self, Output};
+use bun_errno::SystemErrno;
 
 use bun_threading::{Mutex, UnboundedQueue};
 use bun_uws as uws;
@@ -1285,8 +1286,31 @@ mod _event_loop_draft {
             Ok(t) => {
                 let _ = HTTP_THREAD_HANDLE.set(t);
             }
-            Err(err) => Output::panic(format_args!("Failed to start HTTP Client thread: {}", err)),
+            Err(err) => exit_spawn_failed(&err),
         }
+    }
+
+    /// Nothing that needs the HTTP thread can go on without it, but a refused
+    /// `pthread_create`/`CreateThread` (`RLIMIT_NPROC`, a container pids limit,
+    /// no memory) is the environment's limit, not a bug: report it like any
+    /// other fatal CLI error rather than through the crash reporter.
+    #[cold]
+    #[inline(never)]
+    fn exit_spawn_failed(err: &std::io::Error) -> ! {
+        match SystemErrno::from_io_error(err) {
+            Some(errno) => {
+                bun_core::err_generic!("Failed to start HTTP Client thread: {}", errno);
+                if errno == SystemErrno::EAGAIN {
+                    bun_core::note!(
+                        "The process or thread limit may have been reached (ulimit -u, or the container's pids limit); raise it or reduce concurrency"
+                    );
+                }
+            }
+            // No errno name for this OS code (most Windows thread-creation
+            // failures): show the OS's own description instead of guessing one.
+            None => bun_core::err_generic!("Failed to start HTTP Client thread: {}", err),
+        }
+        bun_core::Global::crash()
     }
 
     fn on_start(opts: InitOpts) {

--- a/test/cli/install/bun-install-thread-spawn-failure.test.ts
+++ b/test/cli/install/bun-install-thread-spawn-failure.test.ts
@@ -1,0 +1,57 @@
+// `bun install` starts the HTTP client thread unconditionally. When the OS
+// refuses the thread (EAGAIN under a tight `ulimit -u` / RLIMIT_NPROC or a
+// container pids limit) that is the environment's limit, not a bug in bun, so
+// it must be reported as a plain error with exit code 1 instead of going
+// through the crash reporter ("oh no: Bun has crashed", bun.report link).
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, compileFixture, isLinux, isMusl, tempDir } from "harness";
+import { join } from "node:path";
+
+const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
+
+// Models a process sitting at its thread limit: every further pthread_create
+// fails with `code`, the way pthread_create reports errors (a returned errno).
+const shimC = (code: string) => /* c */ `
+#include <errno.h>
+#include <pthread.h>
+
+int pthread_create(pthread_t *thread, const pthread_attr_t *attr, void *(*start)(void *), void *arg) {
+  (void)thread; (void)attr; (void)start; (void)arg;
+  return ${code};
+}
+`;
+
+// bun-musl is statically linked, so LD_PRELOAD cannot intercept pthread_create.
+describe.skipIf(!isLinux || isMusl || !cc)("bun install when the HTTP client thread cannot be started", () => {
+  test.concurrent.each([
+    // [pthread_create result, how it is reported, whether the thread-limit hint applies]
+    ["EAGAIN", "EAGAIN", true],
+    ["EPERM", "EPERM", false],
+    // A code bun has no errno name for is reported with the OS's own description.
+    ["9999", "Unknown error 9999 (os error 9999)", false],
+  ])("pthread_create returning %s exits 1 with an error naming %s", async (code, reported, hintApplies) => {
+    using dir = tempDir(`install-thread-spawn-${code}`, {
+      "shim.c": shimC(code),
+      "package.json": JSON.stringify({ name: "thread-spawn-failure", dependencies: {} }),
+    });
+    const shim = compileFixture(join(String(dir), "shim.c"));
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: {
+        ...bunEnv,
+        BUN_INSTALL_CACHE_DIR: join(String(dir), "cache"),
+        LD_PRELOAD: [shim, bunEnv.LD_PRELOAD].filter(Boolean).join(":"),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, , exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+
+    expect(stderr).toContain(`Failed to start HTTP Client thread: ${reported}`);
+    expect(stderr.includes("ulimit -u")).toBe(hintApplies);
+    expect(stderr).not.toContain("Bun has crashed");
+    expect(exitCode).toBe(1);
+  });
+});


### PR DESCRIPTION
### Problem
- `bun install` run under a tight thread limit (`ulimit -u`, or a container `--pids-limit`) dies with `panic: Failed to start HTTP Client thread: Resource temporarily unavailable (os error 11)` followed by `oh no: Bun has crashed. This indicates a bug in Bun, not your code.` and a bun.report link, exit code 134.
- Cause: `src/http/HTTPThread.rs:1288` handles a failed `std::thread::Builder::spawn` with `Output::panic`, so a refused `pthread_create` (a limit of the environment, not a bug) goes through the crash reporter. Every command that starts the HTTP client (`bun install`, `bun add`, `bun update`, `bunx`, `bun upgrade`, `bun create`, auto-install) shares this one spawn site.

### Fix
- The failed spawn now prints the errno and exits 1 like the other fatal errors in this file (the CA-file failures a few lines up use the same `err`/`Global::crash()` sequence):
  ```
  error: Failed to start HTTP Client thread: EAGAIN
  note: The process or thread limit may have been reached (ulimit -u, or the container's pids limit); raise it or reduce concurrency
  ```
  The `note:` line is only added for `EAGAIN`, which is what a thread or pid limit produces; other errnos are reported by name (`EPERM`, `ENOMEM`), and an OS code bun has no errno name for (most failed thread creations on Windows) is reported with the OS's own description, e.g. `Unknown error 9999 (os error 9999)`, instead of a guessed errno.
- Exiting is still the right outcome at this site: nothing that asked for the HTTP thread can continue without it, and the CLI commands above have no recovery. #32245 (making `init()` fallible so `fetch()` can reject) keeps the process exit for these CLI entry points, and its `init_or_crash` is where this message would live once it lands.
- `SystemErrno::from_io_error` holds the `io::Error` to errno mapping (Win32 code on Windows). It is byte-identical to the helper added by #37738 and #37753, so the PRs merge cleanly in any order; `Watcher::start`, which has the same mapping inline, is left for those PRs to switch over.
- Verified by `test/cli/install/bun-install-thread-spawn-failure.test.ts` (Linux glibc, needs a C compiler like the existing LD_PRELOAD tests): a preloaded `pthread_create` that returns `EAGAIN`, `EPERM` or `9999` makes `bun install` print the matching message, with the hint only for `EAGAIN`, and exit 1. All three cases fail on the unfixed build (the first two print the OS text instead of the errno name, all three print the crash banner and exit 134).
- Also verified against a real limit with the debug build: `ulimit -u 1` (and `2`) as a non-root uid, then `bun install`, prints the two lines above and exits 1; the unfixed release build prints the panic and banner (output below).
- `cargo test -p bun_errno` passes; `cargo check -p bun_errno -p bun_http` passes for `x86_64-pc-windows-msvc` and `aarch64-apple-darwin`.

### Background
- The HTTP client thread is a single process-wide thread that runs all of bun's outgoing HTTP (registry requests for `bun install`, `fetch()`); `http_thread::init` starts it once and callers queue work to it. The package manager starts it during its own initialization, before it knows whether the install needs the network, which is why even a fully cached `bun install` hits this.
- On Linux, `RLIMIT_NPROC` and the cgroup pids controller count threads as well as processes, so a process at the limit gets `EAGAIN` from `pthread_create`; `std::thread::Builder::spawn` returns it as an `io::Error` whose `raw_os_error()` is the errno (a Win32 error code on Windows, which is why the mapping has two arms).
- `Global::crash()` is bun's "print was already done, exit with status 1" exit; unlike a panic it does not print a crash report or ask for a bug report.
- Sibling spawn sites that also panic or hang under the same limit each have their own open PR and are deliberately not touched here: the thread pool that backs `bun install`'s extraction (the hang at the next notch of the limit, #37738), the bundler thread (#37753), the IO request loop (#33845), the waiter thread (#35924), workers (#34705), and the crash report text for failures inside JavaScriptCore (#36985).

<details>
<summary>Real-limit runs (uid 300000, no other processes, warm cache)</summary>

Unfixed release build:

```
$ bash -c 'ulimit -u 1; exec bun install'
panic: Failed to start HTTP Client thread: Resource temporarily unavailable (os error 11)
oh no: Bun has crashed. This indicates a bug in Bun, not your code.

To send a redacted crash report to Bun's team,
please file a GitHub issue using the link below:

 https://bun.report/1.4.0/...
$ echo $?
134
```

With this change (debug build), `ulimit -u 1` and `ulimit -u 2` both give:

```
error: Failed to start HTTP Client thread: EAGAIN
note: The process or thread limit may have been reached (ulimit -u, or the container's pids limit); raise it or reduce concurrency
$ echo $?
1
```

At `ulimit -u 3` the HTTP thread starts and the install instead hangs in "Resolving dependencies" with zero pool workers; that is the case #37738 fixes.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install-thread-spawn-failure.test.ts

<!-- robobun:evidence:end -->