### PR TITLE
install: rebind ranged peers whose target the saved tree drops

### DIFF
--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -1257,8 +1257,10 @@ impl<'a> Cloner<'a> {
 
 impl Lockfile {
     /// Re-hoists while a pass bound an optional peer late; a reload has that binding up front.
+    /// Ranged peers bound to a package the tree left out are rebound the way a reload binds them.
     pub(crate) fn resolve(&mut self, log: &mut bun_ast::Log) -> Result<(), tree::SubtreeError> {
         while self.hoist::<{ tree::BuilderMethod::Resolvable }>(log, None, true, &[], None)? {}
+        TextLockfile::rebind_peers_to_printed_packages(self)?;
         Ok(())
     }
 

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -4,7 +4,7 @@ use core::fmt::Write as _;
 
 use crate::bun_json as JSON;
 use bun_ast::{Expr, expr::Data as ExprData};
-use bun_collections::{HashMap, StringHashMap};
+use bun_collections::{DynamicBitSet, HashMap, StringHashMap};
 use bun_core::strings;
 use bun_core::{self};
 use bun_paths::PathBuffer;
@@ -3357,6 +3357,28 @@ pub(crate) fn resolve_peer_dep_version_based(
     pkg_resolutions: &[Resolution],
     string_buf: &[u8],
 ) -> Option<PackageID> {
+    resolve_peer_dep_version_based_among(
+        dep,
+        catalogs,
+        package_index,
+        overrides,
+        pkg_resolutions,
+        string_buf,
+        |_| true,
+    )
+}
+
+/// `resolve_peer_dep_version_based` over the candidates `is_candidate` accepts, for callers
+/// whose lockfile holds packages a reload will not see (`rebind_peers_to_printed_packages`).
+pub(crate) fn resolve_peer_dep_version_based_among(
+    dep: &Dependency,
+    catalogs: &CatalogMap,
+    package_index: &PackageIndexMap,
+    overrides: &OverrideMap,
+    pkg_resolutions: &[Resolution],
+    string_buf: &[u8],
+    is_candidate: impl Fn(PackageID) -> bool,
+) -> Option<PackageID> {
     let range = deferred_peer_range(dep, catalogs, string_buf)?;
     // `package_index` is keyed by real package names; `range` (not `dep.name`) carries them for aliases.
     let name_hash = match range.tag {
@@ -3402,28 +3424,95 @@ pub(crate) fn resolve_peer_dep_version_based(
         PackageIndexEntry::Ids(ids) => ids.as_slice(),
     };
 
+    let mut first: Option<PackageID> = None;
     for &id in candidates {
-        if (id as usize) < pkg_resolutions.len()
-            && pkg_resolutions[id as usize]
-                .satisfies_dependency_version(range, string_buf, string_buf)
+        if (id as usize) >= pkg_resolutions.len() || !is_candidate(id) {
+            continue;
+        }
+        if pkg_resolutions[id as usize].satisfies_dependency_version(range, string_buf, string_buf)
         {
             return Some(id);
         }
-    }
-
-    let &first = candidates.first()?;
-    if (first as usize) < pkg_resolutions.len() {
-        let res_tag = pkg_resolutions[first as usize].tag;
-        let ver_tag = range.tag;
-        if (res_tag == ResolutionTag::Npm && ver_tag == DependencyVersionTag::Npm)
-            || (res_tag == ResolutionTag::Git && ver_tag == DependencyVersionTag::Git)
-            || (res_tag == ResolutionTag::Github && ver_tag == DependencyVersionTag::Github)
-        {
-            return Some(first);
+        if first.is_none() {
+            first = Some(id);
         }
     }
 
+    let first = first?;
+    let res_tag = pkg_resolutions[first as usize].tag;
+    let ver_tag = range.tag;
+    if (res_tag == ResolutionTag::Npm && ver_tag == DependencyVersionTag::Npm)
+        || (res_tag == ResolutionTag::Git && ver_tag == DependencyVersionTag::Git)
+        || (res_tag == ResolutionTag::Github && ver_tag == DependencyVersionTag::Github)
+    {
+        return Some(first);
+    }
+
     None
+}
+
+/// Call after hoisting. The printed tree is the lockfile's only record of which packages
+/// exist, and a package whose incoming edges are all ranged peers that `Tree::hoist_dependency`
+/// deduped onto another version of the same name is in no tree at all (pnpm's auto-installed
+/// peers arrive like this from pnpm-lock.yaml; adding a pinned version of a package that was
+/// only auto-installed for a peer creates the same shape). `resolve_peer_dep_version_based`
+/// therefore binds such edges to another package on reload, and the install that wrote the
+/// lockfile links something different from every install that reads it. Binding them here over
+/// the packages the print will contain makes the writing install match its readers.
+///
+/// Every edge rebound here was deduped during hoisting, so it is not in `hoisted_dependencies`
+/// and the tree stays valid; the old target is dropped by the next `clean_with_logger`.
+pub(crate) fn rebind_peers_to_printed_packages(
+    lockfile: &mut BinaryLockfile,
+) -> Result<(), bun_alloc::AllocError> {
+    let pkg_resolutions: &[Resolution] = lockfile.packages.items_resolution();
+    let package_index = &lockfile.package_index;
+    let catalogs = &lockfile.catalogs;
+    let overrides = &lockfile.overrides;
+    let super::Buffers {
+        hoisted_dependencies,
+        resolutions,
+        dependencies,
+        string_bytes,
+        ..
+    } = &mut lockfile.buffers;
+    let string_buf: &[u8] = string_bytes.as_slice();
+
+    // Root and workspaces are printed from the `workspaces` section, everything else from the tree.
+    let mut printed = DynamicBitSet::init_empty(pkg_resolutions.len())?;
+    for (pkg_id, res) in pkg_resolutions.iter().enumerate() {
+        if matches!(res.tag, ResolutionTag::Root | ResolutionTag::Workspace) {
+            printed.set(pkg_id);
+        }
+    }
+    for &dep_id in hoisted_dependencies.iter() {
+        let pkg_id = resolutions[dep_id as usize];
+        if (pkg_id as usize) < pkg_resolutions.len() {
+            printed.set(pkg_id as usize);
+        }
+    }
+
+    for (dep, target) in dependencies.iter().zip(resolutions.iter_mut()) {
+        if (*target as usize) >= pkg_resolutions.len()
+            || printed.is_set(*target as usize)
+            || !dep.behavior.is_peer()
+        {
+            continue;
+        }
+        if let Some(printed_target) = resolve_peer_dep_version_based_among(
+            dep,
+            catalogs,
+            package_index,
+            overrides,
+            pkg_resolutions,
+            string_buf,
+            |id| printed.is_set(id as usize),
+        ) {
+            *target = printed_target;
+        }
+    }
+
+    Ok(())
 }
 
 // Taking `&mut BinaryLockfile` plus a `&mut Dependency` that

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -1214,6 +1214,69 @@ test("ranged peer dependency resolution is stable across installs from bun.lock"
   });
 });
 
+test("a ranged peer whose auto-installed version drops out of the saved tree is rebound before linking", async () => {
+  // The first install auto-installs no-deps@1.1.0 for peer-deps-fixed's
+  // `no-deps@^1.0.0`; nothing else depends on it. Adding one-dep pins
+  // no-deps@1.0.1, which is hoisted to the root of the saved tree, so the
+  // peer edge dedupes onto it and 1.1.0 is no longer written to bun.lock.
+  // Reloading that bun.lock binds the edge to 1.0.1, so the install that
+  // writes it has to link 1.0.1 as well, or the next install re-keys the
+  // entry.
+  const { packageJson, packageDir } = await registry.createTestDir({
+    bunfigOpts: { linker: "isolated" },
+  });
+
+  await write(
+    packageJson,
+    JSON.stringify({
+      name: "dropped-peer-target",
+      dependencies: {
+        "peer-deps-fixed": "1.0.0",
+      },
+    }),
+  );
+
+  await runBunInstall(bunEnv, packageDir);
+
+  const bunDir = join(packageDir, "node_modules", ".bun");
+  const autoInstalledEntry = "peer-deps-fixed@1.0.0+7ff199101204a65d";
+  const reboundEntry = "peer-deps-fixed@1.0.0+f8a822eca018d0a1";
+  expect(await readdirSorted(bunDir)).toContain(autoInstalledEntry);
+  expect(await file(join(bunDir, autoInstalledEntry, "node_modules", "no-deps", "package.json")).json()).toMatchObject({
+    version: "1.1.0",
+  });
+
+  await write(
+    packageJson,
+    JSON.stringify({
+      name: "dropped-peer-target",
+      dependencies: {
+        "one-dep": "1.0.0",
+        "peer-deps-fixed": "1.0.0",
+      },
+    }),
+  );
+
+  await runBunInstall(bunEnv, packageDir);
+
+  const bunLock = await file(join(packageDir, "bun.lock")).text();
+  expect(bunLock).toContain(`"no-deps": ["no-deps@1.0.1"`);
+  expect(bunLock).not.toContain("no-deps@1.1.0");
+  expect(await readlink(join(packageDir, "node_modules", "peer-deps-fixed"))).toBe(
+    join(".bun", reboundEntry, "node_modules", "peer-deps-fixed"),
+  );
+  expect(await file(join(bunDir, reboundEntry, "node_modules", "no-deps", "package.json")).json()).toMatchObject({
+    version: "1.0.1",
+  });
+  const entries = await readdirSorted(bunDir);
+
+  const { out } = await runBunInstall(bunEnv, packageDir, { savesLockfile: false });
+
+  expect(out).toContain("(no changes)");
+  expect(await readdirSorted(bunDir)).toEqual(entries);
+  expect(await file(join(packageDir, "bun.lock")).text()).toBe(bunLock);
+});
+
 test("aliased peer dependency binds to its real package across installs from bun.lock", async () => {
   // The peer alias `no-deps` points at `npm:a-dep@^1.0.2` while the real
   // no-deps package (in two versions) is also in the graph. Loading bun.lock

--- a/test/cli/install/migration/pnpm-lock-v9.test.ts
+++ b/test/cli/install/migration/pnpm-lock-v9.test.ts
@@ -65,6 +65,8 @@ const NO_DEPS_1_0_0_INTEGRITY =
   "sha512-v4w12JRjUGvfHDUP8vFDwu0gUWu04j0cv9hLb1Abf9VdaXu4XcrddYFTMVBVvmldKViGWH7jrb6xPJRF0wq6gw==";
 const NO_DEPS_1_0_1_INTEGRITY =
   "sha512-3X6cn4+UJdXJuLPu11v8i/fGLe2PdI6v1yKTELam04lY5esCAFdG/qQts6N6rLrL6g1YRq+MKBAwxbmUQk355A==";
+const NO_DEPS_1_1_0_INTEGRITY =
+  "sha512-ebG2pipYAKINcNI3YxdsiAgFvNGp2gdRwxAKN2LYBm9+YxuH/lHH2sl+GKQTuGiNfCfNZRMHUyyLPEJD6HWm7w==";
 const NO_DEPS_2_0_0_INTEGRITY =
   "sha512-W3duJKZPcMIG5rA1io5cSK/bhW9rWFz+jFxZsKS/3suK4qHDkQNxUTEXee9/hTaAoDCeHWQqogukWYKzfr6X4g==";
 const ONE_DEP_1_0_0_INTEGRITY =
@@ -1625,6 +1627,90 @@ ${variants}`;
         peerDepsDirs.push(peerDepsDir);
       }
       expect(peerDepsDirs[0]).not.toBe(peerDepsDirs[1]);
+    });
+
+    test("the migrating install links the peer version its bun.lock reloads with the isolated linker", async () => {
+      // pnpm auto-installed no-deps@1.1.0 for peer-deps-fixed's `no-deps: ^1.0.0` while one-dep pins
+      // no-deps@1.0.1, so 1.1.0 is only reachable through the peer edge. The hoisted tree dedupes that
+      // edge onto 1.0.1, bun.lock never records 1.1.0, and reloading binds the edge to 1.0.1. The
+      // migrating install has to link the same binding, or the next install relinks the entry.
+      const { packageDir } = await verdaccio.createTestDir({
+        bunfigOpts: { linker: "isolated" },
+        files: {
+          "package.json": JSON.stringify({
+            name: "v9-auto-installed-peer",
+            dependencies: { "one-dep": "1.0.0", "peer-deps-fixed": "1.0.0" },
+          }),
+          "pnpm-lock.yaml": `lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    dependencies:
+      one-dep:
+        specifier: 1.0.0
+        version: 1.0.0
+      peer-deps-fixed:
+        specifier: 1.0.0
+        version: 1.0.0(no-deps@1.1.0)
+
+packages:
+
+  no-deps@1.0.1:
+    resolution: {integrity: ${NO_DEPS_1_0_1_INTEGRITY}}
+
+  no-deps@1.1.0:
+    resolution: {integrity: ${NO_DEPS_1_1_0_INTEGRITY}}
+
+  one-dep@1.0.0:
+    resolution: {integrity: ${ONE_DEP_1_0_0_INTEGRITY}}
+
+  peer-deps-fixed@1.0.0:
+    resolution: {integrity: ${PEER_DEPS_FIXED_1_0_0_INTEGRITY}}
+    peerDependencies:
+      no-deps: ^1.0.0
+
+snapshots:
+
+  no-deps@1.0.1: {}
+
+  no-deps@1.1.0: {}
+
+  one-dep@1.0.0:
+    dependencies:
+      no-deps: 1.0.1
+
+  peer-deps-fixed@1.0.0(no-deps@1.1.0):
+    dependencies:
+      no-deps: 1.1.0
+`,
+        },
+      });
+
+      const migrating = await run(packageDir, "install");
+
+      expect(migrating.stderr).toContain("migrated lockfile from pnpm-lock.yaml");
+      expect(migrating.stderr).not.toContain("error:");
+      expect(migrating.exitCode).toBe(0);
+
+      const bunLock = await bunLockOf(packageDir);
+      expect(bunLock).toContain(`"no-deps": ["no-deps@1.0.1"`);
+      expect(bunLock).not.toContain("no-deps@1.1.0");
+
+      const storeDir = join(packageDir, "node_modules", ".bun");
+      const peerDepsFixedDir = realpathSync(join(packageDir, "node_modules", "peer-deps-fixed"));
+      expect((await Bun.file(join(dirname(peerDepsFixedDir), "no-deps", "package.json")).json()).version).toBe("1.0.1");
+      const store = readdirSync(storeDir).sort();
+      expect(store).not.toContain("no-deps@1.1.0");
+
+      const reinstall = await run(packageDir, "install");
+
+      expect(reinstall.stderr).not.toContain("error:");
+      expect(reinstall.stdout).toContain("(no changes)");
+      expect(reinstall.exitCode).toBe(0);
+      expect(readdirSync(storeDir).sort()).toEqual(store);
+      expect(realpathSync(join(packageDir, "node_modules", "peer-deps-fixed"))).toBe(peerDepsFixedDir);
+      expect(await bunLockOf(packageDir)).toBe(bunLock);
     });
 
     test("a peer met in one importer and unmet in another is bound from the met variant", async () => {


### PR DESCRIPTION
### Problem
- `bun install` on a pnpm workspace (shadcn-ui/ui at `shadcn@4.18.0`, isolated linker) migrates `pnpm-lock.yaml` and installs. The next `bun install` on the untouched checkout prints `24 packages installed` instead of `(no changes)`, `node_modules/.bun` grows by 28 entries such as `eslint@9.26.0+e85e2cbf7faa9a92` next to the existing `eslint@9.26.0+3be8db87ac283cf5`, and `bun.lock` is byte-identical throughout. The third install is a no-op.
- Exactly one edge differs between the two installs: `@hono/node-server@1.19.9`'s peer `hono@^4` is bound to `hono@4.12.23` by the migration and to `hono@4.11.7` after reloading `bun.lock`. `hono` leaks as a transitive peer through `@modelcontextprotocol/sdk@1.25.3` into `eslint@9.26.0` and from there into every eslint plugin, so the one edge re-keys 24 store entries.
- `hono@4.12.23` is a peer pnpm auto-installed; the peer edge is its only incoming edge. The migration binds the edge by version (`resolve_peer_like_bun_lock`, `src/install/pnpm.rs:131`) and picks 4.12.23 as the highest satisfying version. When the tree is hoisted, `Tree::hoist_dependency` (`src/install/lockfile/Tree.rs:1025`) finds `hono@4.11.7` hoisted at the root, sees that it satisfies `^4`, and dedupes the edge onto it, so 4.12.23 is placed in no tree. `save_from_binary` prints packages from the tree, so 4.12.23 is not in `bun.lock`. On reload, `resolve_peer_dep_version_based` (`src/install/lockfile/bun.lock.rs:3352`) scans the printed packages and binds the edge to 4.11.7.
- `clean_with_logger` keeps 4.12.23 alive for the writing install because a required peer edge points at it, so the migrating install links a binding that its own `bun.lock` cannot reproduce.
- The same shape arises without pnpm: install a package with a ranged peer (bun auto-installs the highest version), then add a dependency that pins a lower version of the peer. The pinned version is hoisted to the root, the peer edge dedupes onto it, the auto-installed version drops out of `bun.lock`, and the install that wrote that `bun.lock` links the old version while every later install links the pinned one.
- The migration side is new in #38333, which made the migration bind peers by version; the build before it (`b7a043103`) binds this edge to pnpm's recorded choice and round-trips on this repo. The non-migration shape predates it.

### Fix
- `Lockfile::resolve`, the hoist that every lockfile goes through before it is printed, now calls `rebind_peers_to_printed_packages` after hoisting. It marks the packages the print will contain (root and workspaces, plus the target of every placed dependency in `hoisted_dependencies`) and, for each peer edge whose target is not among them, reruns the loader's scan restricted to those packages and rebinds the edge to the result.
- The scan is `resolve_peer_dep_version_based` itself with a candidate filter (`resolve_peer_dep_version_based_among`), so the writing install computes the binding with the same function and the same candidate set the reload will use. Edges the loader does not bind by version (optional peers, `*` ranges, overridden names) return `None` from that function and are left alone, as before.
- This does not change what is printed: an edge whose target was not placed is by construction not in the tree, so the tree and the printed `bun.lock` are unchanged (verified on shadcn-ui: the migrated `bun.lock` is byte-identical with and without this change). The dropped package has no incoming edges left and is removed by the next `clean_with_logger`, which on the migration path runs before anything is installed or written.
- Cost on a lockfile loaded from `bun.lock` is one bitset and one pass over the dependency buffer; the targets of such a lockfile are normally all printed, so nothing is scanned.
- With the fix the migrating install on shadcn-ui creates the `eslint@9.26.0+e85e2cbf7faa9a92` style entries directly, that is, the entries a reload produces; the `+3be8db87ac283cf5` entries keyed on `hono@4.12.23` are never created.
- Verified:
  - `test/cli/install/migration/pnpm-lock-v9.test.ts`, "the migrating install links the peer version its bun.lock reloads with the isolated linker": a hand-written `pnpm-lock.yaml` where `peer-deps-fixed`'s `no-deps@^1.0.0` was auto-installed as `no-deps@1.1.0` while `one-dep` pins `no-deps@1.0.1`. Fails before (the migrating install links 1.1.0), passes after (links 1.0.1, second install reports no changes, store listing unchanged).
  - `test/cli/install/isolated-install.test.ts`, "a ranged peer whose auto-installed version drops out of the saved tree is rebound before linking": the non-migration shape above. Fails before (the install that drops 1.1.0 from `bun.lock` still links the `+7ff199101204a65d` entry), passes after.
  - shadcn-ui/ui at `shadcn@4.18.0`: the migrating install now links 1644 packages, the second install prints `Checked 1665 installs across 1868 packages (no changes)`, `node_modules/.bun` is identical across the two, and `rm -rf node_modules && bun install --frozen-lockfile` produces the same store as the migrating install.
  - Suites run locally with the change: isolated-install (67), bun-install-registry (242), the five pnpm migration files (92), migrate, yarn-lock-migration, bun-lock, bun-lockb, isolated-relink, lockfile-version-2, migrate-bun-lockb-v2, frozen-lockfile-*, nested-overrides (445), bun-workspaces, bun-dedupe, bun-prune, catalogs (346), bun-update, bun-update-transitive, bun-pm-why, bun-add, bun-remove (435). All pass; complex-workspace fails locally on git hosts the sandbox cannot reach, with or without the change.
- Related open PRs, not overlapping: #37713 makes `*` peers version-bound too, after which this rebind covers them as well; #37925 changes how optional peers are bound on load, which this change does not touch.

### Background
- `bun.lock` records packages as a hoisted `node_modules` tree: each entry is keyed by the path a package would have in a hoisted install. `Lockfile::resolve` builds that tree (`buffers.trees` / `buffers.hoisted_dependencies`) from the in-memory graph, and `save_from_binary` prints it. A package that ends up in no tree node is not in the file.
- When the hoister meets a peer dependency whose name is already present higher in the tree, it does not place the peer's own target; if the version found above satisfies the peer range it dedupes the edge onto it (`Tree::hoist_dependency`). For regular dependencies a different version is placed nested instead, which is why only peer targets can disappear from the print.
- `bun.lock` has no field for what a peer edge resolved to. Since #32182 the loader binds required, non-`*` peer edges by version: it scans the packages of that name present in the file, highest first, and takes the first one satisfying the range (`resolve_peer_dep_version_based`). This mirrors the fresh resolver, and the pnpm migration calls the same function, but both only agree with a later reload if every package they consider is actually printed.
- The isolated linker (`node_modules/.bun`) keys a store entry as `name@version+<hash of the peer packages it resolved>`, and a package's peer set includes the peers of its dependencies that nothing below it satisfies. Changing one peer binding therefore re-keys the entry of every package the peer leaks through, which is how one edge becomes 24 relinked packages.
- `clean_with_logger` rebuilds the lockfile with only the packages reachable from the root before installing and saving. Required peer edges count as reachability (a peer bun auto-installed has no other edge), which is why the dropped target survives the clean on the install that wrote the file, and why rebinding the edge is what lets the next clean remove it.

<details>
<summary>Resolution diff on shadcn-ui/ui between the migrating install and the reload</summary>

Dumping every `package :: dependency -> resolution` edge right before the isolated store is built on both installs and diffing gives a single line:

```
< @hono/node-server@1.19.9 :: hono [peer] ^4 -> hono@4.12.23
> @hono/node-server@1.19.9 :: hono [peer] ^4 -> hono@4.11.7
```

`pnpm-lock.yaml` has `hono@4.11.7` as a dependency of `@modelcontextprotocol/sdk@1.26.0` and `hono@4.12.23` only as the peer resolution in `@hono/node-server@1.19.9(hono@4.12.23)`, the variant reached from `@modelcontextprotocol/sdk@1.25.3`, which eslint depends on. The migrated `bun.lock` contains only `hono@4.11.7`, before and after this change.

Store entries added by the second install before the change (28): two extra `eslint@9.26.0+...` variants, `@typescript-eslint/{eslint-plugin,parser,type-utils,utils}` at 8.46.2 and 8.49.0/8.54.0, `eslint-config-next@15.5.11` and `@16.0.0`, `eslint-plugin-import`, `eslint-import-resolver-typescript`, `eslint-module-utils`, `eslint-plugin-react`, `eslint-plugin-react-hooks@5.2.0` and `@7.0.1`, `eslint-plugin-jsx-a11y`, `eslint-config-prettier`, `eslint-config-turbo`, `eslint-plugin-turbo`, `typescript-eslint`, `@eslint-community/eslint-utils`, `@modelcontextprotocol/sdk@1.25.3`. All of them have `hono` in their transitive peer set.
</details>
