### PR TITLE
Rewrite super property accesses in private methods extracted by decorator lowering

### DIFF
--- a/src/ast/runtime.rs
+++ b/src/ast/runtime.rs
@@ -178,10 +178,11 @@ pub struct Imports {
     pub(crate) __superGet: Ref,
     pub(crate) __superSet: Ref,
     pub(crate) __superWrapper: Ref,
+    pub(crate) __superDelete: Ref,
 }
 
 impl Imports {
-    pub const ALL: [&'static [u8]; 30] = [
+    pub const ALL: [&'static [u8]; 31] = [
         b"__name",
         b"__require",
         b"__export",
@@ -212,12 +213,13 @@ impl Imports {
         b"__superGet",
         b"__superSet",
         b"__superWrapper",
+        b"__superDelete",
     ];
 
     /// Rust stable cannot sort in `const`; precomputed here and verified by
     /// the test in `tests` below.
     #[cfg_attr(not(test), allow(dead_code))]
-    const ALL_SORTED: [&'static [u8]; 30] = [
+    const ALL_SORTED: [&'static [u8]; 31] = [
         b"$$typeof",
         b"__EARLY_RETURN_SENTINEL",
         b"__MEMO_CACHE_SENTINEL",
@@ -244,6 +246,7 @@ impl Imports {
         b"__reExport",
         b"__require",
         b"__runInitializers",
+        b"__superDelete",
         b"__superGet",
         b"__superSet",
         b"__superWrapper",
@@ -252,7 +255,7 @@ impl Imports {
 
     /// When generating the list of runtime imports, we sort it for determinism.
     /// This is a lookup table so we don't need to resort the strings each time
-    pub const ALL_SORTED_INDEX: [usize; 30] = [
+    pub const ALL_SORTED_INDEX: [usize; 31] = [
         15, // __name
         24, // __require
         7,  // __export
@@ -274,15 +277,16 @@ impl Imports {
         25, // __runInitializers
         4,  // __decorateElement
         0,  // $$typeof
-        29, // __using
+        30, // __using
         3,  // __callDispose
         10, // __jsonParse
         21, // __promiseAll
         2,  // __MEMO_CACHE_SENTINEL
         1,  // __EARLY_RETURN_SENTINEL
-        26, // __superGet
-        27, // __superSet
-        28, // __superWrapper
+        27, // __superGet
+        28, // __superSet
+        29, // __superWrapper
+        26, // __superDelete
     ];
 
     pub const NAME: &'static [u8] = b"bun:wrap";
@@ -321,6 +325,7 @@ impl Imports {
             27 => self.__superGet,
             28 => self.__superSet,
             29 => self.__superWrapper,
+            30 => self.__superDelete,
             _ => return None,
         };
         r.to_nullable()
@@ -359,6 +364,7 @@ impl Imports {
             27 => Some(&mut self.__superGet),
             28 => Some(&mut self.__superSet),
             29 => Some(&mut self.__superWrapper),
+            30 => Some(&mut self.__superDelete),
             _ => None,
         }
     }

--- a/src/ast/runtime.rs
+++ b/src/ast/runtime.rs
@@ -175,10 +175,13 @@ pub struct Imports {
     pub(crate) __promiseAll: Ref,
     pub(crate) __MEMO_CACHE_SENTINEL: Ref,
     pub(crate) __EARLY_RETURN_SENTINEL: Ref,
+    pub(crate) __superGet: Ref,
+    pub(crate) __superSet: Ref,
+    pub(crate) __superWrapper: Ref,
 }
 
 impl Imports {
-    pub const ALL: [&'static [u8]; 27] = [
+    pub const ALL: [&'static [u8]; 30] = [
         b"__name",
         b"__require",
         b"__export",
@@ -206,12 +209,15 @@ impl Imports {
         b"__promiseAll",
         b"__MEMO_CACHE_SENTINEL",
         b"__EARLY_RETURN_SENTINEL",
+        b"__superGet",
+        b"__superSet",
+        b"__superWrapper",
     ];
 
     /// Rust stable cannot sort in `const`; precomputed here and verified by
     /// the test in `tests` below.
     #[cfg_attr(not(test), allow(dead_code))]
-    const ALL_SORTED: [&'static [u8]; 27] = [
+    const ALL_SORTED: [&'static [u8]; 30] = [
         b"$$typeof",
         b"__EARLY_RETURN_SENTINEL",
         b"__MEMO_CACHE_SENTINEL",
@@ -238,12 +244,15 @@ impl Imports {
         b"__reExport",
         b"__require",
         b"__runInitializers",
+        b"__superGet",
+        b"__superSet",
+        b"__superWrapper",
         b"__using",
     ];
 
     /// When generating the list of runtime imports, we sort it for determinism.
     /// This is a lookup table so we don't need to resort the strings each time
-    pub const ALL_SORTED_INDEX: [usize; 27] = [
+    pub const ALL_SORTED_INDEX: [usize; 30] = [
         15, // __name
         24, // __require
         7,  // __export
@@ -265,12 +274,15 @@ impl Imports {
         25, // __runInitializers
         4,  // __decorateElement
         0,  // $$typeof
-        26, // __using
+        29, // __using
         3,  // __callDispose
         10, // __jsonParse
         21, // __promiseAll
         2,  // __MEMO_CACHE_SENTINEL
         1,  // __EARLY_RETURN_SENTINEL
+        26, // __superGet
+        27, // __superSet
+        28, // __superWrapper
     ];
 
     pub const NAME: &'static [u8] = b"bun:wrap";
@@ -306,6 +318,9 @@ impl Imports {
             24 => self.__promiseAll,
             25 => self.__MEMO_CACHE_SENTINEL,
             26 => self.__EARLY_RETURN_SENTINEL,
+            27 => self.__superGet,
+            28 => self.__superSet,
+            29 => self.__superWrapper,
             _ => return None,
         };
         r.to_nullable()
@@ -341,6 +356,9 @@ impl Imports {
             24 => Some(&mut self.__promiseAll),
             25 => Some(&mut self.__MEMO_CACHE_SENTINEL),
             26 => Some(&mut self.__EARLY_RETURN_SENTINEL),
+            27 => Some(&mut self.__superGet),
+            28 => Some(&mut self.__superSet),
+            29 => Some(&mut self.__superWrapper),
             _ => None,
         }
     }

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -71,7 +71,7 @@ enum RewriteKind<'r> {
 /// `super.x` in a method body that is leaving the class body, where `super` is a syntax error.
 #[derive(Clone, Copy)]
 struct SuperLowering<'r> {
-    /// Allocated by the first access; `lower_impl` then declares it and binds it to the class.
+    /// Bound inside the class body: the class binding itself is reassigned by class decorators.
     class_ref: &'r Cell<Option<Ref>>,
     is_static: bool,
 }
@@ -692,8 +692,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         self.call_rt(l, b"__superSet", &[home, this_e, key, value])
     }
 
-    /// `__superWrapper(home, this, key)._`: an assignable accessor, so `+=`, `++` and
-    /// destructuring keep their native semantics and evaluate the key once.
+    /// `__superWrapper(...)._` is assignable, so `+=`, `++` and patterns keep their native semantics.
     fn super_wrapper_expr(&mut self, ctx: SuperLowering<'_>, key: Expr, l: bun_ast::Loc) -> Expr {
         let home = self.super_home_expr(ctx, l);
         let this_e = self.new_expr(E::This {}, l);
@@ -780,14 +779,21 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
             },
             // super.x++ → __superWrapper(...)._++
+            // delete super.x → __superDelete("x"), which throws like the native form does
             js_ast::ExprData::EUnary(mut unary) => {
-                if js_ast::OpCode::unary_assign_target(unary.op) != js_ast::AssignTarget::Update {
+                let is_update =
+                    js_ast::OpCode::unary_assign_target(unary.op) == js_ast::AssignTarget::Update;
+                if !is_update && unary.op != js_ast::OpCode::UnDelete {
                     return false;
                 }
                 let Some(key) = self.super_member_key(unary.value, ctx) else {
                     return false;
                 };
-                unary.value = self.super_wrapper_expr(ctx, key, unary.value.loc);
+                if is_update {
+                    unary.value = self.super_wrapper_expr(ctx, key, unary.value.loc);
+                } else {
+                    *expr = self.call_rt(loc, b"__superDelete", &[key]);
+                }
                 true
             }
             // super.tag`…` → __superGet(...).bind(this)`…`
@@ -2365,8 +2371,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             prefix_stmts.insert(0, p.var_decl(home_ref, None, loc));
             let this_e = p.new_expr(E::This {}, loc);
             let capture = p.assign_to(home_ref, this_e, loc);
-            // First in the body: static initializers may call the method; unlike the
-            // class binding, this is not reassigned when a class decorator replaces the class.
+            // First in the body: a static initializer may already call a lowered method.
             static_private_add_blocks.insert(0, p.make_static_block(capture, loc));
         }
 

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::too_many_arguments, clippy::needless_late_init)]
 //! Lowering for TC39 standard ES decorators.
 
+use core::cell::Cell;
+
 use bun_alloc::ArenaVecExt as _;
 
 use bun_collections::{HashMap, VecExt};
@@ -60,9 +62,26 @@ struct StaticElement {
 }
 
 #[derive(Clone, Copy)]
-enum RewriteKind {
+enum RewriteKind<'r> {
     ReplaceRef { old: Ref, new: Ref },
     ReplaceThis { ref_: Ref, loc: bun_ast::Loc },
+    LowerSuper(SuperLowering<'r>),
+}
+
+/// Rewrites `super.x` inside a method body that is being moved out of the
+/// class into a plain function expression, where `super` is a syntax error.
+/// Accesses become `__superGet(home, this, key)` / `__superSet(...)` /
+/// `__superWrapper(...)._`, where `home` is the method's [[HomeObject]]: the
+/// class for static members, its prototype otherwise.
+///
+/// `class_ref` is the temporary holding the class. It is allocated by the
+/// first access that needs it; `lower_impl` then declares it and binds it from
+/// a static block at the top of the class body. Classes whose lowered methods
+/// never use `super` get neither.
+#[derive(Clone, Copy)]
+struct SuperLowering<'r> {
+    class_ref: &'r Cell<Option<Ref>>,
+    is_static: bool,
 }
 
 // ── Shallow-copy helpers (Property / Class are not `Clone` because they hold
@@ -416,7 +435,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     // ── Generic tree rewriter ────────────────────────────
 
-    fn rewrite_expr(&mut self, expr: &mut Expr, kind: RewriteKind) {
+    /// Walks the parts of an expression that evaluate in the enclosing
+    /// function's `this`/`super` context: arrow functions are entered,
+    /// non-arrow functions and the members of nested classes are not
+    /// (`ReplaceRef` enters those too, since a ref identifies one binding no
+    /// matter how deeply it is referenced).
+    fn rewrite_expr(&mut self, expr: &mut Expr, kind: RewriteKind<'_>) {
         match kind {
             RewriteKind::ReplaceRef { old, new } => {
                 if let js_ast::ExprData::EIdentifier(id) = &expr.data {
@@ -433,6 +457,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             RewriteKind::ReplaceThis { ref_, loc } => {
                 if matches!(expr.data, js_ast::ExprData::EThis(_)) {
                     *expr = self.use_ref(ref_, loc);
+                    return;
+                }
+            }
+            RewriteKind::LowerSuper(ctx) => {
+                if self.lower_super_in_expr(expr, ctx) {
                     return;
                 }
             }
@@ -477,6 +506,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
             js_ast::ExprData::EObject(e) => {
                 for prop in e.properties.slice_mut() {
+                    // Only computed keys hold an expression; literal keys are a no-op.
+                    if let Some(k) = &mut prop.key {
+                        self.rewrite_expr(k, kind);
+                    }
                     if let Some(v) = &mut prop.value {
                         self.rewrite_expr(v, kind);
                     }
@@ -494,25 +527,380 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     self.rewrite_expr(&mut part.value, kind);
                 }
             }
+            js_ast::ExprData::EAwait(e) => self.rewrite_expr(&mut e.value, kind),
+            js_ast::ExprData::EYield(e) => {
+                if let Some(v) = &mut e.value {
+                    self.rewrite_expr(v, kind);
+                }
+            }
+            js_ast::ExprData::EImport(e) => {
+                self.rewrite_expr(&mut e.expr, kind);
+                self.rewrite_expr(&mut e.options, kind);
+            }
             js_ast::ExprData::EArrow(e) => {
+                self.rewrite_args(e.args.slice_mut(), kind);
                 let stmts = e.body.stmts.slice_mut();
                 self.rewrite_stmts(stmts, kind);
             }
             js_ast::ExprData::EFunction(e) => match kind {
-                RewriteKind::ReplaceThis { .. } => {}
+                RewriteKind::ReplaceThis { .. } | RewriteKind::LowerSuper(_) => {}
                 RewriteKind::ReplaceRef { .. } => {
+                    self.rewrite_args(e.func.args.slice_mut(), kind);
                     let stmts = e.func.body.stmts.slice_mut();
                     if !stmts.is_empty() {
                         self.rewrite_stmts(stmts, kind);
                     }
                 }
             },
-            js_ast::ExprData::EClass(_) => {}
+            js_ast::ExprData::EClass(e) => self.rewrite_class(e, kind),
             _ => {}
         }
     }
 
-    fn rewrite_stmts(&mut self, stmts: &mut [Stmt], kind: RewriteKind) {
+    /// The extends clause and computed keys of a nested class evaluate in the
+    /// enclosing context; everything else in its body has its own `this` and
+    /// [[HomeObject]].
+    fn rewrite_class(&mut self, class: &mut G::Class, kind: RewriteKind<'_>) {
+        if let Some(ext) = &mut class.extends {
+            self.rewrite_expr(ext, kind);
+        }
+        let enter_members = matches!(kind, RewriteKind::ReplaceRef { .. });
+        for prop in class.properties.slice_mut() {
+            if let Some(k) = &mut prop.key {
+                self.rewrite_expr(k, kind);
+            }
+            if !enter_members {
+                continue;
+            }
+            if let Some(v) = &mut prop.value {
+                self.rewrite_expr(v, kind);
+            }
+            if let Some(ini) = &mut prop.initializer {
+                self.rewrite_expr(ini, kind);
+            }
+            if let Some(sb) = prop.class_static_block_mut() {
+                self.rewrite_stmts(sb.stmts.slice_mut(), kind);
+            }
+        }
+    }
+
+    fn rewrite_args(&mut self, args: &mut [G::Arg], kind: RewriteKind<'_>) {
+        for arg in args.iter_mut() {
+            self.rewrite_binding(&mut arg.binding, kind);
+            if let Some(d) = &mut arg.default {
+                self.rewrite_expr(d, kind);
+            }
+        }
+    }
+
+    /// Default values and computed keys are the only expressions inside a
+    /// binding pattern.
+    fn rewrite_binding(&mut self, binding: &mut js_ast::Binding, kind: RewriteKind<'_>) {
+        match &mut binding.data {
+            js_ast::b::B::BIdentifier(_) | js_ast::b::B::BMissing(_) => {}
+            js_ast::b::B::BArray(arr) => {
+                for item in arr.items_mut() {
+                    self.rewrite_binding(&mut item.binding, kind);
+                    if let Some(d) = &mut item.default_value {
+                        self.rewrite_expr(d, kind);
+                    }
+                }
+            }
+            js_ast::b::B::BObject(obj) => {
+                for prop in obj.properties_mut() {
+                    self.rewrite_expr(&mut prop.key, kind);
+                    self.rewrite_binding(&mut prop.value, kind);
+                    if let Some(d) = &mut prop.default_value {
+                        self.rewrite_expr(d, kind);
+                    }
+                }
+            }
+        }
+    }
+
+    /// The head of `for (target in/of …)`: a declaration, or an expression
+    /// statement wrapping an assignment target.
+    fn rewrite_for_head(&mut self, init: &mut Stmt, kind: RewriteKind<'_>) {
+        if let (RewriteKind::LowerSuper(ctx), js_ast::StmtData::SExpr(mut target)) =
+            (kind, init.data)
+        {
+            self.lower_super_in_assign_target(&mut target.value, ctx);
+            return;
+        }
+        self.rewrite_stmts(core::slice::from_mut(init), kind);
+    }
+
+    // ── `super` property access lowering ─────────────────
+
+    /// Entry point for a private method, getter, or setter whose function
+    /// value is leaving the class body.
+    fn lower_super_in_extracted_method(&mut self, value: &mut Expr, ctx: SuperLowering<'_>) {
+        let js_ast::ExprData::EFunction(func) = value.data else {
+            return;
+        };
+        let kind = RewriteKind::LowerSuper(ctx);
+        self.rewrite_args(func.func.args.slice_mut(), kind);
+        self.rewrite_stmts(func.func.body.stmts.slice_mut(), kind);
+    }
+
+    /// For `super.name` / `super[expr]`, returns the property key (a string
+    /// literal, or `expr` after rewriting it). `None` for any other expression.
+    fn super_member_key(&mut self, expr: Expr, ctx: SuperLowering<'_>) -> Option<Expr> {
+        match expr.data {
+            js_ast::ExprData::EDot(dot)
+                if matches!(dot.target.data, js_ast::ExprData::ESuper(_)) =>
+            {
+                Some(self.new_expr(
+                    E::EString {
+                        data: dot.name,
+                        ..Default::default()
+                    },
+                    dot.name_loc,
+                ))
+            }
+            js_ast::ExprData::EIndex(mut index)
+                if matches!(index.target.data, js_ast::ExprData::ESuper(_)) =>
+            {
+                self.rewrite_expr(&mut index.index, RewriteKind::LowerSuper(ctx));
+                Some(index.index)
+            }
+            _ => None,
+        }
+    }
+
+    /// `_home` (static members) or `_home.prototype` (instance members): the
+    /// object whose prototype `super` looks up properties on. Allocates the
+    /// temporary on first use.
+    fn super_home_expr(&mut self, ctx: SuperLowering<'_>, l: bun_ast::Loc) -> Expr {
+        let class_ref = match ctx.class_ref.get() {
+            Some(r) => r,
+            None => {
+                let r = self.new_sym(js_ast::symbol::Kind::Other, b"_home");
+                ctx.class_ref.set(Some(r));
+                r
+            }
+        };
+        let class_expr = self.use_ref(class_ref, l);
+        if ctx.is_static {
+            return class_expr;
+        }
+        self.new_expr(
+            E::Dot {
+                target: class_expr,
+                name: b"prototype".into(),
+                name_loc: l,
+                ..Default::default()
+            },
+            l,
+        )
+    }
+
+    /// `__superGet(home, this, key)`
+    fn super_get_expr(&mut self, ctx: SuperLowering<'_>, key: Expr, l: bun_ast::Loc) -> Expr {
+        let home = self.super_home_expr(ctx, l);
+        let this_e = self.new_expr(E::This {}, l);
+        self.call_rt(l, b"__superGet", &[home, this_e, key])
+    }
+
+    /// `__superSet(home, this, key, value)`
+    fn super_set_expr(
+        &mut self,
+        ctx: SuperLowering<'_>,
+        key: Expr,
+        value: Expr,
+        l: bun_ast::Loc,
+    ) -> Expr {
+        let home = self.super_home_expr(ctx, l);
+        let this_e = self.new_expr(E::This {}, l);
+        self.call_rt(l, b"__superSet", &[home, this_e, key, value])
+    }
+
+    /// `__superWrapper(home, this, key)._`: an accessor property standing in
+    /// for the `super` reference wherever the syntax needs an assignable
+    /// expression (`super.x += 1`, `super.x++`, destructuring targets, for-in/of
+    /// heads). Reads and writes go through the wrapper's getter and setter, so
+    /// the operator itself keeps its native semantics.
+    fn super_wrapper_expr(&mut self, ctx: SuperLowering<'_>, key: Expr, l: bun_ast::Loc) -> Expr {
+        let home = self.super_home_expr(ctx, l);
+        let this_e = self.new_expr(E::This {}, l);
+        let wrapper = self.call_rt(l, b"__superWrapper", &[home, this_e, key]);
+        self.new_expr(
+            E::Dot {
+                target: wrapper,
+                name: b"_".into(),
+                name_loc: l,
+                ..Default::default()
+            },
+            l,
+        )
+    }
+
+    /// Rewrites the `super` access forms whose replacement depends on the
+    /// parent node. Returns true when `expr` (including its children) has been
+    /// handled; false hands the node to the generic traversal, which reaches
+    /// any `super.x` in plain value position through the `super_member_key`
+    /// check at the top.
+    fn lower_super_in_expr(&mut self, expr: &mut Expr, ctx: SuperLowering<'_>) -> bool {
+        let kind = RewriteKind::LowerSuper(ctx);
+        let loc = expr.loc;
+        if let Some(key) = self.super_member_key(*expr, ctx) {
+            *expr = self.super_get_expr(ctx, key, loc);
+            return true;
+        }
+        match expr.data {
+            // super.f(...) → __superGet(...).call(this, ...)
+            // super.f?.(...) → __superGet(...)?.call(this, ...)
+            js_ast::ExprData::ECall(mut call) => {
+                let Some(key) = self.super_member_key(call.target, ctx) else {
+                    return false;
+                };
+                let method = self.super_get_expr(ctx, key, call.target.loc);
+                let is_optional = call.optional_chain.is_some();
+                call.target = self.new_expr(
+                    E::Dot {
+                        target: method,
+                        name: b"call".into(),
+                        name_loc: loc,
+                        optional_chain: is_optional.then_some(js_ast::OptionalChain::Start),
+                        ..Default::default()
+                    },
+                    loc,
+                );
+                if is_optional {
+                    call.optional_chain = Some(js_ast::OptionalChain::Continuation);
+                }
+                let bump = self.arena;
+                let orig_args = call.args.slice_mut();
+                let mut new_args = BumpVec::with_capacity_in(1 + orig_args.len(), bump);
+                new_args.push(self.new_expr(E::This {}, loc));
+                for arg in orig_args.iter_mut() {
+                    self.rewrite_expr(arg, kind);
+                    new_args.push(*arg);
+                }
+                call.args = ExprNodeList::from_bump_vec(new_args);
+                true
+            }
+            js_ast::ExprData::EBinary(mut bin) => match bin.op.binary_assign_target() {
+                js_ast::AssignTarget::None => false,
+                // super.x = v → __superSet(..., v)
+                js_ast::AssignTarget::Replace => {
+                    if let Some(key) = self.super_member_key(bin.left, ctx) {
+                        self.rewrite_expr(&mut bin.right, kind);
+                        *expr = self.super_set_expr(ctx, key, bin.right, loc);
+                        return true;
+                    }
+                    if !matches!(
+                        bin.left.data,
+                        js_ast::ExprData::EArray(_) | js_ast::ExprData::EObject(_)
+                    ) {
+                        return false;
+                    }
+                    self.lower_super_in_assign_target(&mut bin.left, ctx);
+                    self.rewrite_expr(&mut bin.right, kind);
+                    true
+                }
+                // super.x += v, super.x ??= v, … → __superWrapper(...)._ op= v
+                js_ast::AssignTarget::Update => {
+                    let Some(key) = self.super_member_key(bin.left, ctx) else {
+                        return false;
+                    };
+                    bin.left = self.super_wrapper_expr(ctx, key, bin.left.loc);
+                    self.rewrite_expr(&mut bin.right, kind);
+                    true
+                }
+            },
+            // super.x++ → __superWrapper(...)._++
+            js_ast::ExprData::EUnary(mut unary) => {
+                if js_ast::OpCode::unary_assign_target(unary.op) != js_ast::AssignTarget::Update {
+                    return false;
+                }
+                let Some(key) = self.super_member_key(unary.value, ctx) else {
+                    return false;
+                };
+                unary.value = self.super_wrapper_expr(ctx, key, unary.value.loc);
+                true
+            }
+            // super.tag`…` → __superGet(...).bind(this)`…`
+            js_ast::ExprData::ETemplate(mut template) => {
+                let Some(tag) = template.tag else {
+                    return false;
+                };
+                let Some(key) = self.super_member_key(tag, ctx) else {
+                    return false;
+                };
+                let method = self.super_get_expr(ctx, key, tag.loc);
+                let bind = self.new_expr(
+                    E::Dot {
+                        target: method,
+                        name: b"bind".into(),
+                        name_loc: tag.loc,
+                        ..Default::default()
+                    },
+                    tag.loc,
+                );
+                let this_e = self.new_expr(E::This {}, tag.loc);
+                let args = self.arena.alloc_slice_copy(&[this_e]);
+                let bound = self.new_expr(
+                    E::Call {
+                        target: bind,
+                        args: ExprNodeList::from_arena_slice(args),
+                        ..Default::default()
+                    },
+                    tag.loc,
+                );
+                template.tag = Some(bound);
+                for part in template.parts_mut().iter_mut() {
+                    self.rewrite_expr(&mut part.value, kind);
+                }
+                true
+            }
+            _ => false,
+        }
+    }
+
+    /// `expr` is assigned to rather than read: an element of a destructuring
+    /// assignment pattern or a for-in/of head. A `super` member here becomes the
+    /// assignable `__superWrapper(...)._`; nested patterns are walked
+    /// position by position; anything else is an ordinary expression.
+    fn lower_super_in_assign_target(&mut self, expr: &mut Expr, ctx: SuperLowering<'_>) {
+        let kind = RewriteKind::LowerSuper(ctx);
+        let loc = expr.loc;
+        if let Some(key) = self.super_member_key(*expr, ctx) {
+            *expr = self.super_wrapper_expr(ctx, key, loc);
+            return;
+        }
+        match expr.data {
+            js_ast::ExprData::EArray(mut arr) => {
+                for item in arr.items.slice_mut() {
+                    self.lower_super_in_assign_target(item, ctx);
+                }
+            }
+            js_ast::ExprData::EObject(mut obj) => {
+                for prop in obj.properties.slice_mut() {
+                    if let Some(k) = &mut prop.key {
+                        self.rewrite_expr(k, kind);
+                    }
+                    if let Some(v) = &mut prop.value {
+                        self.lower_super_in_assign_target(v, ctx);
+                    }
+                    if let Some(d) = &mut prop.initializer {
+                        self.rewrite_expr(d, kind);
+                    }
+                }
+            }
+            js_ast::ExprData::ESpread(mut spread) => {
+                self.lower_super_in_assign_target(&mut spread.value, ctx);
+            }
+            // `[target = default]`
+            js_ast::ExprData::EBinary(mut bin) if bin.op == js_ast::OpCode::BinAssign => {
+                self.lower_super_in_assign_target(&mut bin.left, ctx);
+                self.rewrite_expr(&mut bin.right, kind);
+            }
+            _ => self.rewrite_expr(expr, kind),
+        }
+    }
+
+    fn rewrite_stmts(&mut self, stmts: &mut [Stmt], kind: RewriteKind<'_>) {
         for cur_stmt in stmts.iter_mut() {
             let cur_loc = cur_stmt.loc;
             match &mut cur_stmt.data {
@@ -529,6 +917,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
                 js_ast::StmtData::SLocal(local) => {
                     for decl in local.decls.slice_mut() {
+                        self.rewrite_binding(&mut decl.binding, kind);
                         if let Some(v) = &mut decl.value {
                             self.rewrite_expr(v, kind);
                         }
@@ -570,6 +959,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     data.body = body;
                 }
                 js_ast::StmtData::SForIn(data) => {
+                    let mut init = data.init;
+                    self.rewrite_for_head(&mut init, kind);
+                    data.init = init;
                     let mut v = data.value;
                     self.rewrite_expr(&mut v, kind);
                     data.value = v;
@@ -578,6 +970,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     data.body = body;
                 }
                 js_ast::StmtData::SForOf(data) => {
+                    let mut init = data.init;
+                    self.rewrite_for_head(&mut init, kind);
+                    data.init = init;
                     let mut v = data.value;
                     self.rewrite_expr(&mut v, kind);
                     data.value = v;
@@ -618,6 +1013,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     let body = data.body.slice_mut();
                     self.rewrite_stmts(body, kind);
                     if let Some(c) = &mut data.catch {
+                        if let Some(b) = &mut c.binding {
+                            self.rewrite_binding(b, kind);
+                        }
                         let cb = c.body.slice_mut();
                         self.rewrite_stmts(cb, kind);
                     }
@@ -639,6 +1037,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     self.rewrite_stmts(core::slice::from_mut(&mut body), kind);
                     data.body = body;
                 }
+                js_ast::StmtData::SFunction(data) => match kind {
+                    RewriteKind::ReplaceThis { .. } | RewriteKind::LowerSuper(_) => {}
+                    RewriteKind::ReplaceRef { .. } => {
+                        self.rewrite_args(data.func.args.slice_mut(), kind);
+                        let stmts = data.func.body.stmts.slice_mut();
+                        self.rewrite_stmts(stmts, kind);
+                    }
+                },
+                js_ast::StmtData::SClass(data) => self.rewrite_class(&mut data.class, kind),
                 _ => {}
             }
         }
@@ -1392,6 +1799,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let mut accessor_storage_counter: usize = 0;
         let mut emitted_private_adds: HashMap<u32, ()> = HashMap::default();
         let mut static_private_add_blocks = BumpVec::<Property>::new_in(bump);
+        let super_home_ref: Cell<Option<Ref>> = Cell::new(None);
 
         // Pre-scan: determine if all private members need lowering
         let mut lower_all_private = false;
@@ -1486,9 +1894,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         }
 
                         // Assign function: _fn = function() { ... }
-                        let val = prop
+                        let mut val = prop
                             .value
                             .unwrap_or_else(|| p.new_expr(E::Undefined {}, loc));
+                        p.lower_super_in_extracted_method(
+                            &mut val,
+                            SuperLowering {
+                                class_ref: &super_home_ref,
+                                is_static: prop.flags.contains(Flags::Property::IsStatic),
+                            },
+                        );
                         let assign = p.assign_to(fn_ref, val, loc);
                         prefix_stmts.push(p.s(
                             S::SExpr {
@@ -1850,10 +2265,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 dec_args.push(p.use_ref(storage_ref, loc));
                 if dec_arg_count == 6 {
                     if (1..=3).contains(&k) {
-                        dec_args.push(
-                            prop.value
-                                .unwrap_or_else(|| p.new_expr(E::Undefined {}, loc)),
+                        let mut val = prop
+                            .value
+                            .unwrap_or_else(|| p.new_expr(E::Undefined {}, loc));
+                        p.lower_super_in_extracted_method(
+                            &mut val,
+                            SuperLowering {
+                                class_ref: &super_home_ref,
+                                is_static: prop.flags.contains(Flags::Property::IsStatic),
+                            },
                         );
+                        dec_args.push(val);
                     } else if k == 4 {
                         dec_args.push(p.use_ref(storage_ref, loc));
                     } else {
@@ -1970,6 +2392,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     instance_non_field_elements.push(element);
                 }
             }
+        }
+
+        // A lowered method body used `super`: `var _home;` next to the other
+        // temporaries, bound by the first element of the class body so that it
+        // is set before any static initializer can call the method, and
+        // unaffected by class decorators replacing the class binding later.
+        if let Some(home_ref) = super_home_ref.get() {
+            prefix_stmts.insert(0, p.var_decl(home_ref, None, loc));
+            let this_e = p.new_expr(E::This {}, loc);
+            let capture = p.assign_to(home_ref, this_e, loc);
+            static_private_add_blocks.insert(0, p.make_static_block(capture, loc));
         }
 
         // ── Phase 5: Rewrite private accesses ────────────

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -717,7 +717,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             return true;
         }
         match expr.data {
-            // super.f(...) → __superGet(...).call(this, ...), or ?.call(this, ...) for super.f?.(...)
+            // super.f(...) → __superGet(...).call(this, ...); super.f?.() keeps the ?. on .call
             js_ast::ExprData::ECall(mut call) => {
                 let Some(key) = self.super_member_key(call.target, ctx) else {
                     return false;

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -68,18 +68,10 @@ enum RewriteKind<'r> {
     LowerSuper(SuperLowering<'r>),
 }
 
-/// Rewrites `super.x` inside a method body that is being moved out of the
-/// class into a plain function expression, where `super` is a syntax error.
-/// Accesses become `__superGet(home, this, key)` / `__superSet(...)` /
-/// `__superWrapper(...)._`, where `home` is the method's [[HomeObject]]: the
-/// class for static members, its prototype otherwise.
-///
-/// `class_ref` is the temporary holding the class. It is allocated by the
-/// first access that needs it; `lower_impl` then declares it and binds it from
-/// a static block at the top of the class body. Classes whose lowered methods
-/// never use `super` get neither.
+/// `super.x` in a method body that is leaving the class body, where `super` is a syntax error.
 #[derive(Clone, Copy)]
 struct SuperLowering<'r> {
+    /// Allocated by the first access; `lower_impl` then declares it and binds it to the class.
     class_ref: &'r Cell<Option<Ref>>,
     is_static: bool,
 }
@@ -435,11 +427,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     // ── Generic tree rewriter ────────────────────────────
 
-    /// Walks the parts of an expression that evaluate in the enclosing
-    /// function's `this`/`super` context: arrow functions are entered,
-    /// non-arrow functions and the members of nested classes are not
-    /// (`ReplaceRef` enters those too, since a ref identifies one binding no
-    /// matter how deeply it is referenced).
     fn rewrite_expr(&mut self, expr: &mut Expr, kind: RewriteKind<'_>) {
         match kind {
             RewriteKind::ReplaceRef { old, new } => {
@@ -557,9 +544,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// The extends clause and computed keys of a nested class evaluate in the
-    /// enclosing context; everything else in its body has its own `this` and
-    /// [[HomeObject]].
+    /// Only the extends clause and computed keys evaluate in the enclosing `this`/`super` context.
     fn rewrite_class(&mut self, class: &mut G::Class, kind: RewriteKind<'_>) {
         if let Some(ext) = &mut class.extends {
             self.rewrite_expr(ext, kind);
@@ -593,8 +578,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// Default values and computed keys are the only expressions inside a
-    /// binding pattern.
     fn rewrite_binding(&mut self, binding: &mut js_ast::Binding, kind: RewriteKind<'_>) {
         match &mut binding.data {
             js_ast::b::B::BIdentifier(_) | js_ast::b::B::BMissing(_) => {}
@@ -618,9 +601,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// The head of `for (target in/of …)`: a declaration, or an expression
-    /// statement wrapping an assignment target.
     fn rewrite_for_head(&mut self, init: &mut Stmt, kind: RewriteKind<'_>) {
+        // `for (super.x of …)`: the head is written to, not read.
         if let (RewriteKind::LowerSuper(ctx), js_ast::StmtData::SExpr(mut target)) =
             (kind, init.data)
         {
@@ -632,8 +614,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     // ── `super` property access lowering ─────────────────
 
-    /// Entry point for a private method, getter, or setter whose function
-    /// value is leaving the class body.
     fn lower_super_in_extracted_method(&mut self, value: &mut Expr, ctx: SuperLowering<'_>) {
         let js_ast::ExprData::EFunction(func) = value.data else {
             return;
@@ -643,8 +623,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         self.rewrite_stmts(func.func.body.stmts.slice_mut(), kind);
     }
 
-    /// For `super.name` / `super[expr]`, returns the property key (a string
-    /// literal, or `expr` after rewriting it). `None` for any other expression.
+    /// The key of `super.name` / `super[expr]`; `None` for any other expression.
     fn super_member_key(&mut self, expr: Expr, ctx: SuperLowering<'_>) -> Option<Expr> {
         match expr.data {
             js_ast::ExprData::EDot(dot)
@@ -668,9 +647,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// `_home` (static members) or `_home.prototype` (instance members): the
-    /// object whose prototype `super` looks up properties on. Allocates the
-    /// temporary on first use.
+    /// The method's [[HomeObject]]: `_home` for static members, `_home.prototype` otherwise.
     fn super_home_expr(&mut self, ctx: SuperLowering<'_>, l: bun_ast::Loc) -> Expr {
         let class_ref = match ctx.class_ref.get() {
             Some(r) => r,
@@ -715,11 +692,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         self.call_rt(l, b"__superSet", &[home, this_e, key, value])
     }
 
-    /// `__superWrapper(home, this, key)._`: an accessor property standing in
-    /// for the `super` reference wherever the syntax needs an assignable
-    /// expression (`super.x += 1`, `super.x++`, destructuring targets, for-in/of
-    /// heads). Reads and writes go through the wrapper's getter and setter, so
-    /// the operator itself keeps its native semantics.
+    /// `__superWrapper(home, this, key)._`: an assignable accessor, so `+=`, `++` and
+    /// destructuring keep their native semantics and evaluate the key once.
     fn super_wrapper_expr(&mut self, ctx: SuperLowering<'_>, key: Expr, l: bun_ast::Loc) -> Expr {
         let home = self.super_home_expr(ctx, l);
         let this_e = self.new_expr(E::This {}, l);
@@ -735,11 +709,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         )
     }
 
-    /// Rewrites the `super` access forms whose replacement depends on the
-    /// parent node. Returns true when `expr` (including its children) has been
-    /// handled; false hands the node to the generic traversal, which reaches
-    /// any `super.x` in plain value position through the `super_member_key`
-    /// check at the top.
+    /// Returns false when `expr` is not a `super` form, leaving it to the generic traversal.
     fn lower_super_in_expr(&mut self, expr: &mut Expr, ctx: SuperLowering<'_>) -> bool {
         let kind = RewriteKind::LowerSuper(ctx);
         let loc = expr.loc;
@@ -858,10 +828,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// `expr` is assigned to rather than read: an element of a destructuring
-    /// assignment pattern or a for-in/of head. A `super` member here becomes the
-    /// assignable `__superWrapper(...)._`; nested patterns are walked
-    /// position by position; anything else is an ordinary expression.
+    /// `expr` is written to, not read: a destructuring assignment target or a for-in/of head.
     fn lower_super_in_assign_target(&mut self, expr: &mut Expr, ctx: SuperLowering<'_>) {
         let kind = RewriteKind::LowerSuper(ctx);
         let loc = expr.loc;
@@ -2394,14 +2361,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
 
-        // A lowered method body used `super`: `var _home;` next to the other
-        // temporaries, bound by the first element of the class body so that it
-        // is set before any static initializer can call the method, and
-        // unaffected by class decorators replacing the class binding later.
         if let Some(home_ref) = super_home_ref.get() {
             prefix_stmts.insert(0, p.var_decl(home_ref, None, loc));
             let this_e = p.new_expr(E::This {}, loc);
             let capture = p.assign_to(home_ref, this_e, loc);
+            // First in the body: static initializers may call the method; unlike the
+            // class binding, this is not reassigned when a class decorator replaces the class.
             static_private_add_blocks.insert(0, p.make_static_block(capture, loc));
         }
 

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -717,8 +717,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             return true;
         }
         match expr.data {
-            // super.f(...) → __superGet(...).call(this, ...)
-            // super.f?.(...) → __superGet(...)?.call(this, ...)
+            // super.f(...) → __superGet(...).call(this, ...), or ?.call(this, ...) for super.f?.(...)
             js_ast::ExprData::ECall(mut call) => {
                 let Some(key) = self.super_member_key(call.target, ctx) else {
                     return false;
@@ -779,7 +778,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
             },
             // super.x++ → __superWrapper(...)._++
-            // delete super.x → __superDelete("x"), which throws like the native form does
             js_ast::ExprData::EUnary(mut unary) => {
                 let is_update =
                     js_ast::OpCode::unary_assign_target(unary.op) == js_ast::AssignTarget::Update;
@@ -792,6 +790,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 if is_update {
                     unary.value = self.super_wrapper_expr(ctx, key, unary.value.loc);
                 } else {
+                    // delete super.x → __superDelete("x"), which throws like the native form
                     *expr = self.call_rt(loc, b"__superDelete", &[key]);
                 }
                 true

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -233,6 +233,26 @@ export var __privateSet = (obj, member, value, setter) => (
 );
 export var __privateMethod = (obj, member, method) => (__accessCheck(obj, member, "access private method"), method);
 
+// `super.key` inside a method that decorator lowering moved out of its class.
+// `home` is the class (static members) or its prototype (instance members),
+// i.e. the method's [[HomeObject]]; `obj` is the method's `this`. Class bodies
+// are strict code, so a failed assignment throws like `super.key = value` does.
+var __reflectGet = Reflect.get;
+var __reflectSet = Reflect.set;
+export var __superGet = (home, obj, key) => __reflectGet(__getProtoOf(home), key, obj);
+export var __superSet = (home, obj, key, value) => (
+  __reflectSet(__getProtoOf(home), key, value, obj) || __typeError("Cannot assign to super property " + String(key)),
+  value
+);
+export var __superWrapper = (home, obj, key) => ({
+  get _() {
+    return __superGet(home, obj, key);
+  },
+  set _(value) {
+    __superSet(home, obj, key, value);
+  },
+});
+
 export var __decoratorStart = base => [, , , __create(base?.[__knownSymbol("metadata")] ?? null)];
 var __decoratorStrings = ["class", "method", "getter", "setter", "accessor", "field", "value", "get", "set"];
 var __expectFn = fn => (fn !== void 0 && typeof fn !== "function" ? __typeError("Function expected") : fn);

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -233,13 +233,11 @@ export var __privateSet = (obj, member, value, setter) => (
 );
 export var __privateMethod = (obj, member, method) => (__accessCheck(obj, member, "access private method"), method);
 
-// `super.key` inside a method that decorator lowering moved out of its class.
-// `home` is the class (static members) or its prototype (instance members),
-// i.e. the method's [[HomeObject]]; `obj` is the method's `this`. Class bodies
-// are strict code, so a failed assignment throws like `super.key = value` does.
+// `super[key]` in a method that decorator lowering moved out of its class; `home` is the method's [[HomeObject]].
 var __reflectGet = Reflect.get;
 var __reflectSet = Reflect.set;
 export var __superGet = (home, obj, key) => __reflectGet(__getProtoOf(home), key, obj);
+// Class bodies are strict code, where a rejected `super[key] = value` throws.
 export var __superSet = (home, obj, key, value) => (
   __reflectSet(__getProtoOf(home), key, value, obj) || __typeError("Cannot assign to super property " + String(key)),
   value

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -250,6 +250,9 @@ export var __superWrapper = (home, obj, key) => ({
     __superSet(home, obj, key, value);
   },
 });
+export var __superDelete = key => {
+  throw ReferenceError("Cannot delete super property " + String(key));
+};
 
 export var __decoratorStart = base => [, , , __create(base?.[__knownSymbol("metadata")] ?? null)];
 var __decoratorStrings = ["class", "method", "getter", "setter", "accessor", "field", "value", "get", "set"];

--- a/test/bundler/bundler_promiseall_deadcode.test.ts
+++ b/test/bundler/bundler_promiseall_deadcode.test.ts
@@ -164,7 +164,7 @@ describe("bundler", () => {
         var { AsyncEntryPoint: AsyncEntryPoint2 } = await Promise.resolve().then(() => exports_AsyncEntryPoint);
         AsyncEntryPoint2();
 
-        //# debugId=4AA6F676013EBB3564756E2164756E21
+        //# debugId=1826429A769E73CB64756E2164756E21
         //# sourceMappingURL=out.js.map
         "
       `);
@@ -410,7 +410,7 @@ describe("bundler", () => {
         var { AsyncEntryPoint: AsyncEntryPoint2 } = await Promise.resolve().then(() => exports_AsyncEntryPoint);
         AsyncEntryPoint2();
 
-        //# debugId=A04C6DAA1C95968064756E2164756E21
+        //# debugId=BD4B06C7FD056F5664756E2164756E21
         //# sourceMappingURL=out.js.map
         "
       `);

--- a/test/bundler/bundler_promiseall_deadcode.test.ts
+++ b/test/bundler/bundler_promiseall_deadcode.test.ts
@@ -164,7 +164,7 @@ describe("bundler", () => {
         var { AsyncEntryPoint: AsyncEntryPoint2 } = await Promise.resolve().then(() => exports_AsyncEntryPoint);
         AsyncEntryPoint2();
 
-        //# debugId=19FD1E5354FE6B6564756E2164756E21
+        //# debugId=4AA6F676013EBB3564756E2164756E21
         //# sourceMappingURL=out.js.map
         "
       `);
@@ -410,7 +410,7 @@ describe("bundler", () => {
         var { AsyncEntryPoint: AsyncEntryPoint2 } = await Promise.resolve().then(() => exports_AsyncEntryPoint);
         AsyncEntryPoint2();
 
-        //# debugId=EA1AA30E1BD7B08E64756E2164756E21
+        //# debugId=A04C6DAA1C95968064756E2164756E21
         //# sourceMappingURL=out.js.map
         "
       `);

--- a/test/bundler/html-import-manifest.test.ts
+++ b/test/bundler/html-import-manifest.test.ts
@@ -107,11 +107,11 @@ console.log(favicon);
             "files": [
               {
                 "input": "client.html",
-                "path": "./client-sjg7egv9.js",
+                "path": "./client-srdztmf7.js",
                 "loader": "js",
                 "isEntry": true,
                 "headers": {
-                  "etag": "efKwB-6QGwk",
+                  "etag": "2djt_1qU7wc",
                   "content-type": "text/javascript;charset=utf-8"
                 }
               },
@@ -121,7 +121,7 @@ console.log(favicon);
                 "loader": "html",
                 "isEntry": true,
                 "headers": {
-                  "etag": "sJJm55rxM4I",
+                  "etag": "SGf9K2pnfdo",
                   "content-type": "text/html;charset=utf-8"
                 }
               },

--- a/test/bundler/html-import-manifest.test.ts
+++ b/test/bundler/html-import-manifest.test.ts
@@ -107,11 +107,11 @@ console.log(favicon);
             "files": [
               {
                 "input": "client.html",
-                "path": "./client-srdztmf7.js",
+                "path": "./client-vsvztfex.js",
                 "loader": "js",
                 "isEntry": true,
                 "headers": {
-                  "etag": "2djt_1qU7wc",
+                  "etag": "W9lbn5rPTh0",
                   "content-type": "text/javascript;charset=utf-8"
                 }
               },
@@ -121,7 +121,7 @@ console.log(favicon);
                 "loader": "html",
                 "isEntry": true,
                 "headers": {
-                  "etag": "SGf9K2pnfdo",
+                  "etag": "Yd4NzwGlsq0",
                   "content-type": "text/html;charset=utf-8"
                 }
               },

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1263,6 +1263,12 @@ describe("ES Decorators", () => {
           out.plainFunction = plain();
           out.typeofGet = typeof super.f;
           out.privateOperands = [super[this.#keyName], super.f(this.#v, this.#p())];
+          let deleteKeyEvals = 0;
+          try {
+            out.deleteSuper = delete super[(deleteKeyEvals++, "probe")];
+          } catch (e) {
+            out.deleteSuper = [e.constructor.name, deleteKeyEvals, probeReads];
+          }
           return out;
         }
         #keyName = "readonly";
@@ -1285,12 +1291,14 @@ describe("ES Decorators", () => {
       const { stdout, stderr, exitCode } = await runDecorator(`
         function dec(value, ctx) { return value; }
         let self, selfClass;
+        let probeReads = 0;
         class Base {
           get x() { return this._x; }
           set x(v) { this._x = v; }
           get y() { return this._y; }
           set y(v) { this._y = v; }
           get readonly() { return "ro"; }
+          get probe() { probeReads++; }
           f(...args) { return [this === self, ...args]; }
           tag(strings, ...subs) { return [strings.raw.join("|"), ...subs]; }
           static get sx() { return this._sx; }
@@ -1340,6 +1348,8 @@ describe("ES Decorators", () => {
             plainFunction: true,
             typeofGet: "function",
             privateOperands: ["ro", [true, 42, "p"]],
+            // The key is evaluated, the inherited getter is not, and the delete throws.
+            deleteSuper: ["ReferenceError", 1, 0],
           },
           acc: 32,
         },

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1154,6 +1154,352 @@ describe("ES Decorators", () => {
     });
   });
 
+  // Once a class has a decorated member, its private methods, getters and
+  // setters are moved out of the class body into plain function expressions
+  // (`_m_fn = function () { ... }`, or the function passed to
+  // __decorateElement). `super.x` is a syntax error in a plain function, so
+  // the lowering rewrites it to __superGet / __superSet / __superWrapper
+  // calls that look the property up on the prototype of the original class
+  // (captured by a static block at the top of the class body), with the
+  // method's `this` as receiver.
+  describe.concurrent("super property access in lowered private methods", () => {
+    test("undecorated private method in a class with a decorated member", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(value, ctx) { return value; }
+        class Base { greet() { return "hi"; } }
+        class C extends Base {
+          @dec m() {}
+          #im() { return super.greet(); }
+          callI() { return this.#im(); }
+        }
+        console.log(new C().callI());
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("hi\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("decorated private method, getter, setter and static method", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(value, ctx) { return value; }
+        function wrap(value, ctx) { return function (...args) { return "wrapped:" + value.call(this, ...args); }; }
+        class Base {
+          greet() { return "hi:" + this.id; }
+          get g() { return "g:" + this.id; }
+          set g(v) { this.last = "set:" + v; }
+          static sgreet() { return "shi:" + this.name; }
+        }
+        class C extends Base {
+          id = "c";
+          @wrap #im() { return super.greet(); }
+          @dec get #acc() { return super.g; }
+          @dec set #acc(v) { super.g = v; }
+          @dec static #sm() { return super.sgreet(); }
+          run() { this.#acc = 1; return [this.#im(), this.#acc, this.last, C.#sm()]; }
+        }
+        console.log(JSON.stringify(new C().run()));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe('["wrapped:hi:c","g:c","set:1","shi:C"]\n');
+      expect(exitCode).toBe(0);
+    });
+
+    test("class without an extends clause looks up Object.prototype and Function.prototype", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(value, ctx) { return value; }
+        class C {
+          @dec m() {}
+          #im() { return [super.hasOwnProperty === Object.prototype.hasOwnProperty, super.constructor === Object]; }
+          static #sm() { return [super.call === Function.prototype.call, super.constructor === Function]; }
+          run() { return [...this.#im(), ...C.#sm()]; }
+        }
+        console.log(JSON.stringify(new C().run()));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("[true,true,true,true]\n");
+      expect(exitCode).toBe(0);
+    });
+
+    // The same members are run twice: natively (class without decorators)
+    // and lowered (one decorated member added). Both must print the same
+    // thing, and the literal below documents what that is.
+    test("every access form behaves like the native class", async () => {
+      const members = `
+        #m(param = super.f("param")) {
+          const out = { param };
+          let keyEvals = 0;
+          const k = () => (keyEvals++, key);
+          super.x = 1;
+          out.get = [super.x, super["x"], super[key] === undefined];
+          out.assignValue = (super[key] = 2);
+          out.getComputed = super[key];
+          out.call = super.f(1, ...[2, 3]);
+          out.callComputed = super[(keyEvals++, "f")](4);
+          out.optionalCall = [super.f?.(5), super.nothing?.(), super.f(6)?.length];
+          out.compound = [(super.x += 10), super.x, (super[k()] **= 3), super.y, keyEvals];
+          this._y = null;
+          out.logical = [(super.x ??= "skipped"), (super.y ??= "filled"), (super.y &&= "and"), (super.x ||= "skipped"), super.x, super.y];
+          super[key] = 5;
+          out.update = [super.x++, ++super.x, super[key]--, --super[key], super.x, super.y];
+          [super.x, super[key]] = [100, 200];
+          out.arrayTarget = [super.x, super.y];
+          ({ a: super.x, b: super.y = "dflt", ...super.rest } = { a: 7, b: undefined, c: 1, d: 2 });
+          out.objectTarget = [super.x, super.y, this.rest];
+          [super.x = "arrDflt", ...super.spreadRest] = [undefined, 1, 2];
+          out.patternDefaults = [super.x, this.spreadRest];
+          for (super.x of [31, 32]) out.forOf = super.x;
+          for (super[key] in { k1: 0 }) out.forIn = super.y;
+          super.defined = "own";
+          out.definesOnReceiver = [Object.hasOwn(this, "defined"), "defined" in Base.prototype];
+          try { super.readonly = 1; out.readonly = "assigned"; } catch (e) { out.readonly = e.constructor.name; }
+          out.tagged = super.tag\`a\${1}b\${2}\`;
+          out.newed = new super.constructor.Made("n").made;
+          out.arrows = [(() => super.f("arrow"))(), ((q = super.x) => q)()];
+          const literal = { value: super.x, method() { return super.toString === Object.prototype.toString; } };
+          out.objectLiteral = [literal.value, literal.method()];
+          class Nested extends super.constructor { own() { return super.f("nested"); } }
+          out.nestedClass = new Nested().own();
+          function plain() { return { m() { return super.constructor === Object; } }.m(); }
+          out.plainFunction = plain();
+          out.typeofGet = typeof super.f;
+          out.privateOperands = [super[this.#keyName], super.f(this.#v, this.#p())];
+          return out;
+        }
+        #keyName = "readonly";
+        #v = 42;
+        #p() { return "p"; }
+        get #acc() { return super.x; }
+        set #acc(v) { super.x = v; }
+        async #asyncM() { return await super.f("async"); }
+        *#gen() { yield super.f("gen"); }
+        static #s() {
+          super.sx = "s";
+          super.sx += "!";
+          return [super.sx, super.sf("a"), super.sf?.("b"), this._sx];
+        }
+        run() { self = this; this.#acc = "viaSetter"; return { m: this.#m(), acc: this.#acc }; }
+        runAsync() { self = this; return this.#asyncM(); }
+        runGen() { self = this; return [...this.#gen()]; }
+        static runStatic() { selfClass = this; return this.#s(); }
+      `;
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(value, ctx) { return value; }
+        let self, selfClass;
+        class Base {
+          get x() { return this._x; }
+          set x(v) { this._x = v; }
+          get y() { return this._y; }
+          set y(v) { this._y = v; }
+          get readonly() { return "ro"; }
+          f(...args) { return [this === self, ...args]; }
+          tag(strings, ...subs) { return [strings.raw.join("|"), ...subs]; }
+          static get sx() { return this._sx; }
+          static set sx(v) { this._sx = v; }
+          static sf(a) { return [this === selfClass, a]; }
+          static Made = class { constructor(a) { this.made = a; } };
+        }
+        const key = "y";
+        class Native extends Base {${members}}
+        class Lowered extends Base {
+          @dec decorated() {}
+          ${members}
+        }
+        for (const C of [Native, Lowered]) {
+          const c = new C();
+          console.log(JSON.stringify({ sync: c.run(), async: await c.runAsync(), gen: c.runGen(), static: C.runStatic() }));
+        }
+      `);
+      expect(stderr).toBe("");
+      const [native, lowered] = stdout.trim().split("\n");
+      expect(lowered).toBe(native);
+      expect(JSON.parse(lowered)).toEqual({
+        sync: {
+          m: {
+            param: [true, "param"],
+            get: [1, 1, true],
+            assignValue: 2,
+            getComputed: 2,
+            call: [true, 1, 2, 3],
+            callComputed: [true, 4],
+            optionalCall: [[true, 5], null, 2],
+            compound: [11, 11, 8, 8, 2],
+            logical: [11, "filled", "and", 11, 11, "and"],
+            update: [11, 13, 5, 3, 13, 3],
+            arrayTarget: [100, 200],
+            objectTarget: [7, "dflt", { c: 1, d: 2 }],
+            patternDefaults: ["arrDflt", [1, 2]],
+            forOf: 32,
+            forIn: "k1",
+            definesOnReceiver: [true, false],
+            readonly: "TypeError",
+            tagged: ["a|b|", 1, 2],
+            newed: "n",
+            arrows: [[true, "arrow"], 32],
+            objectLiteral: [32, true],
+            nestedClass: [false, "nested"],
+            plainFunction: true,
+            typeofGet: "function",
+            privateOperands: ["ro", [true, 42, "p"]],
+          },
+          acc: 32,
+        },
+        async: [true, "async"],
+        gen: [[true, "gen"]],
+        static: ["s!", [true, "a"], [true, "b"], "s!"],
+      });
+      expect(exitCode).toBe(0);
+    });
+
+    test("a super tag function is called with the method's this", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(value, ctx) { return value; }
+        class Base { tag(strings) { return [this, strings[0]]; } }
+        class C extends Base {
+          @dec m() {}
+          #im() { return super.tag\`t\`; }
+          run() { const [receiver, text] = this.#im(); return [receiver === this, text]; }
+        }
+        console.log(JSON.stringify(new C().run()));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe('[true,"t"]\n');
+      expect(exitCode).toBe(0);
+    });
+
+    test("class declaration replaced by a class decorator keeps the original parent", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(value, ctx) { return value; }
+        class Base { greet() { return "base"; } }
+        function replace(cls, ctx) { return class extends cls { greet() { return "replacement:" + super.greet(); } }; }
+        @replace
+        class C extends Base {
+          @dec decorated() {}
+          greet() { return "c:" + super.greet(); }
+          #im() { return super.greet(); }
+          run() { return [this.#im(), this.greet()]; }
+        }
+        console.log(JSON.stringify(new C().run()));
+      `);
+      expect(stderr).toBe("");
+      // #im's super is Base.greet, not the original C.greet that a lookup
+      // through the replacement's prototype chain would find.
+      expect(stdout).toBe('["base","replacement:c:base"]\n');
+      expect(exitCode).toBe(0);
+    });
+
+    test("class expression replaced by a class decorator keeps the original parent", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(value, ctx) { return value; }
+        class Base { greet() { return "base"; } }
+        function replace(cls, ctx) { return class extends cls { greet() { return "replacement:" + super.greet(); } }; }
+        const C = @replace class extends Base {
+          @dec decorated() {}
+          greet() { return "c:" + super.greet(); }
+          #im() { return super.greet(); }
+          run() { return [this.#im(), this.greet()]; }
+        };
+        console.log(JSON.stringify(new C().run()));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe('["base","replacement:c:base"]\n');
+      expect(exitCode).toBe(0);
+    });
+
+    test("static private method using super can run while the class body is still being evaluated", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(value, ctx) { return value; }
+        class Base { static sgreet() { return "shi:" + this.name; } }
+        class C extends Base {
+          @dec m() {}
+          static #make() { return super.sgreet(); }
+          static helper() { return this.#make(); }
+          static early = this.helper();
+        }
+        console.log(C.early);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("shi:C\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("each evaluation of a class inside a function gets its own parent", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(value, ctx) { return value; }
+        function make(base) {
+          class C extends base {
+            @dec m() {}
+            #im() { return super.greet(); }
+            run() { return this.#im(); }
+          }
+          return new C();
+        }
+        class A { greet() { return "a"; } }
+        class B { greet() { return "b"; } }
+        const a = make(A);
+        const b = make(B);
+        console.log(a.run(), b.run());
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("a b\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("a class nested in a lowered method body keeps its own super", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(value, ctx) { return value; }
+        class InnerBase { greet() { return "inner"; } static sgreet() { return "static inner"; } }
+        class OuterBase { greet() { return "outer"; } innerBase() { return InnerBase; } }
+        class Outer extends OuterBase {
+          @dec m() {}
+          #im() {
+            // The extends clause is evaluated in the outer method, so its
+            // super is OuterBase's; everything inside the body is Inner's own.
+            class Inner extends super.innerBase() {
+              static { this.fromBlock = super.sgreet(); }
+              field = super.greet();
+              method() { return super.greet(); }
+            }
+            const inner = new Inner();
+            return [super.greet(), (() => super.greet())(), Inner.fromBlock, inner.field, inner.method()];
+          }
+          run() { return this.#im(); }
+        }
+        console.log(JSON.stringify(new Outer().run()));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe('["outer","outer","static inner","inner","inner"]\n');
+      expect(exitCode).toBe(0);
+    });
+
+    test("the class is only captured when a lowered method uses super", () => {
+      const transpiler = new Bun.Transpiler({ loader: "js" });
+      const withSuper = transpiler.transformSync(`
+        class C extends Base {
+          @dec m() {}
+          #im() { return super.greet(); }
+          static #sm() { return super.sgreet(); }
+        }
+      `);
+      // The runtime helpers are imported from bun:wrap under a suffixed alias.
+      expect(withSuper).toMatch(/__superGet\w*\(_home\.prototype, this, "greet"\)\.call\(this\)/);
+      expect(withSuper).toMatch(/__superGet\w*\(_home, this, "sgreet"\)\.call\(this\)/);
+      expect(withSuper).toContain("_home = this;");
+      expect(withSuper).not.toContain("super.");
+
+      const withoutSuper = transpiler.transformSync(`
+        class C extends Base {
+          @dec m() {}
+          #im() { return this.greet(); }
+          inBody() { return super.greet(); }
+        }
+      `);
+      expect(withoutSuper).not.toContain("_home");
+      expect(withoutSuper).not.toContain("__superGet");
+      // Methods that stay in the class body keep their native super.
+      expect(withoutSuper).toContain("return super.greet();");
+    });
+  });
+
   describe("accessor with TypeScript annotations", () => {
     test("accessor with definite assignment assertion (!)", async () => {
       using dir = tempDir("es-dec-accessor-bang", {

--- a/test/regression/issue/cyclic-imports-async-bundler.test.js
+++ b/test/regression/issue/cyclic-imports-async-bundler.test.js
@@ -180,7 +180,7 @@ test("cyclic imports with async dependencies should generate async wrappers", as
     var { AsyncEntryPoint: AsyncEntryPoint2 } = await Promise.resolve().then(() => exports_AsyncEntryPoint);
     AsyncEntryPoint2();
 
-    //# debugId=66236CFF39257E1264756E2164756E21
+    //# debugId=2B36F7B337BA624364756E2164756E21
     //# sourceMappingURL=entryBuild.js.map
     "
   `);

--- a/test/regression/issue/cyclic-imports-async-bundler.test.js
+++ b/test/regression/issue/cyclic-imports-async-bundler.test.js
@@ -180,7 +180,7 @@ test("cyclic imports with async dependencies should generate async wrappers", as
     var { AsyncEntryPoint: AsyncEntryPoint2 } = await Promise.resolve().then(() => exports_AsyncEntryPoint);
     AsyncEntryPoint2();
 
-    //# debugId=2B36F7B337BA624364756E2164756E21
+    //# debugId=FB376097E5DEA6B664756E2164756E21
     //# sourceMappingURL=entryBuild.js.map
     "
   `);


### PR DESCRIPTION
### Problem

- With standard (TC39) decorators, a class that has a decorated member and a private method, getter or setter using `super.x` fails to load: `SyntaxError: super is not valid in this context.` Decorated private methods (`@dec #m() { return super.x }`) and static private methods fail the same way.
- Cause: `lower_impl` in `src/js_parser/lower/lower_decorators.rs` moves private method bodies out of the class body. Undecorated ones become `_m_fn = function () { ... }` emitted before the class (the `lower_all_private` path), decorated ones are passed to `__decorateElement` as a function argument. The function value was copied verbatim, and `super.x` is only valid inside a class body or object literal method, so the printed module is a syntax error (`bun build --no-bundle` shows `_im_fn = function() { return super.greet(); }` at module level).

```js
function dec(v, c) { return v; }
class Base { greet() { return "hi"; } }
class C extends Base {
  @dec m() {}
  #im() { return super.greet(); }
  callI() { return this.#im(); }
}
console.log(new C().callI()); // bun 1.4: SyntaxError; tsc, esbuild, native decorators: hi
```

### Fix

- Adds a `RewriteKind::LowerSuper` pass to the relocation rewriter already used for `this` in extracted static blocks, and runs it over the parameters and body of every function the two extraction sites take out of the class:
  - `super.x`, `super[k]` in value position become `__superGet(home, this, key)`
  - `super.f(...)` becomes `__superGet(...).call(this, ...)`; `super.f?.(...)` keeps its short-circuit as `?.call(this, ...)`
  - `super.x = v` becomes `__superSet(home, this, key, v)` (evaluates to `v`)
  - every other assignable use (`+=` and the logical assignments, `++`/`--`, destructuring assignment targets, `for (super.x of ...)` heads) becomes `__superWrapper(home, this, key)._`, an object whose `_` accessor reads and writes through the two helpers. The operator itself is left in place, so it keeps its native semantics (ToNumeric, BigInt, return value, short-circuiting) and the key expression is evaluated exactly once without temporaries
  - `` super.tag`...` `` becomes `` __superGet(...).bind(this)`...` ``
  - `delete super.x` becomes `__superDelete(key)`, which evaluates the key and then throws a ReferenceError without reading the property, as the native form does
- `home` is a new temporary holding the class, bound by `static { _home = this; }` emitted as the first element of the class body, and used as `_home` for static members and `_home.prototype` for instance members. Both the temporary and the block are only emitted when a lowered body actually contains a `super` access.
- Why this is correct: per spec, `super.x` in a method means `Reflect.get(HomeObject.[[GetPrototypeOf]](), "x", this)`, where HomeObject is the class for static members and `C.prototype` otherwise; `__superGet(home, obj, key)` is `Reflect.get(Object.getPrototypeOf(home), key, obj)`, i.e. the same operation with the same receiver, so inherited getters, setters and methods see the right `this`, and `super.x = v` with no inherited setter defines the property on the instance like native code does. These are the helpers esbuild uses for the same lowering. `__superSet` throws when `Reflect.set` reports failure because class bodies are strict code, where the native assignment throws too.
- Why the class is captured from inside the body instead of using the class binding (esbuild's `__superGet(C.prototype, ...)`) or the `_base` temporary: class decorators reassign the binding, and with a replacing decorator (`return class extends cls {...}`) a lookup through the replacement's prototype finds the original class's own methods instead of the parent's (esbuild 0.25 has this bug); the binding is also in its TDZ while the body's static initializers run. `Object.getPrototypeOf(_home)` instead follows the class's actual prototype chain at access time, also covers classes without `extends` (Object.prototype / Function.prototype) and later `Object.setPrototypeOf` re-parenting without special cases, and the leading static block makes it available to static initializers that call a lowered static method while the class is still being defined. `_home` is declared the same way as the `_m_fn` temporaries that reference it, so it has exactly their lifetime.
- The walk enters arrow functions, parameter defaults, destructuring defaults, computed keys, `await`/`yield`/`import()` operands and the `extends` clause and computed keys of nested classes, and stops at non-arrow functions, object literal methods and the members of nested classes, which have their own `super`. The traversal positions added to the shared walker (`rewrite_args`, `rewrite_binding`, `rewrite_class`, for-in/of heads, catch bindings) apply to the existing `ReplaceThis`/`ReplaceRef` kinds too, which previously skipped them.
- `__superGet`, `__superSet`, `__superWrapper` and `__superDelete` are added to `src/runtime.js` and to the `bun:wrap` import table in `src/ast/runtime.rs` (appended, so existing indices are unchanged).
- `html-import-manifest.test.ts`, `bundler_promiseall_deadcode.test.ts` and `cyclic-imports-async-bundler.test.js` pin output hashes, etags and debug ids. A chunk's isolated hash includes the part ranges of every file in the chunk, the runtime module among them (`LinkerContext::generate_isolated_hash`), so the statements added to runtime.js move those values even though the emitted code is byte-for-byte unchanged (checked by diffing the client bundle of the manifest test against the released binary's). Earlier runtime.js additions needed the same updates (#26436, #27022).
- Verification:
  - `test/bundler/transpiler/es-decorators.test.ts`, new `super property access in lowered private methods` block (11 tests): the repro, decorated private method/getter/setter/static method, no `extends` clause, a class that runs the same members natively and lowered and asserts identical output for every access form above, `delete` included (that program also prints the same thing under node with the decorator removed), tag receiver, class decorator replacing a declaration and an expression, a static initializer calling a lowered static method during class definition, per-evaluation classes in a function, a nested class keeping its own `super`, and the emitted shape (capture present only when used, in-body methods untouched). All 11 fail on the released binary with the SyntaxError above and pass with this change.
  - `es-decorators-esbuild` (esbuild's 147 conformance tests), `decorators`, `decorator-metadata`, `bundler_decorator_metadata`, `ts-use-define-for-class-fields`, `bundler_edgecase`, `bundler_regressions`, `bundler_minify`, `bundler_cjs`, `esbuild/{ts,lower,default}`, `transpiler.test.js`, `regression/issue/27575`, `test/internal/source-lints`: pass.
  - The access-form program produces identical output through `bun run`, `bun build`, `--minify`, `--target=bun`, `--format=cjs` and `--format=iife`; `cargo clippy -p bun_js_parser -p bun_ast` is clean.
- Scope and landing order: `lower_impl` relocates code out of the class body at five places. This PR adds the mechanism and applies it to the two that extract private method bodies. #38730 is now stacked on this branch and applies the same `SuperLowering` (followed by the existing `ReplaceThis`) to the other three, relocated static blocks and static field/accessor initializers, with its own tests; it should land after this one. The equivalent site in the legacy experimentalDecorators lowering (`p.rs`, decorated static members moved after the class) has the same defect and is tracked separately. #31930 gives lowering temporaries unique names; `_home` is created like the temporaries it is used alongside and is covered by that change the same way. #31922 and #38731 touch the same function (textual overlap only).

### Background

- Standard decorator lowering: a class with TC39 decorators is printed as a plain class followed by `__decorateElement(...)` calls that apply the decorators. Private members cannot be reached by code emitted outside the class body, so once any member is decorated, every private member is lowered to WeakSet/WeakMap storage (`lower_all_private`), and private method bodies become module-level function expressions that the in-body code calls through `__privateMethod(this, _m, _m_fn).call(this)`.
- [[HomeObject]]: every method records the object it was defined on (the class for static methods, `C.prototype` otherwise). `super.x` looks `x` up on that object's prototype, at access time, and uses the method's own `this` as the receiver for getters, setters and the call. `Reflect.get` / `Reflect.set` are the built-ins that take an explicit receiver, which is why the helpers are written in terms of them.
- The relocation rewriter (`rewrite_expr` / `rewrite_stmts`, parameterized by `RewriteKind`) is the lowering's walker for code it moves somewhere `this` or `super` no longer means the same thing; `ReplaceThis` is what relocated static blocks already used.
- `bun:wrap` is the module the transpiler imports runtime helpers from (`src/runtime.js`, bundled into the runtime module for `bun build`); `Imports::ALL` in `src/ast/runtime.rs` is the list of names `call_runtime` is allowed to emit, so new helpers have to be registered there as well.

<details>
<summary>Emitted code for the repro</summary>

```js
var _home;
var _im = new WeakSet, _im_fn;
_im_fn = function() {
  return __superGet(_home.prototype, this, "greet").call(this);
};
var _init = __decoratorStart(_base);
class C extends _base {
  static {
    _home = this;
  }
  constructor() {
    super(...arguments);
    __privateAdd(this, _im);
    __runInitializers(_init, 5, this);
  }
  m() {}
  callI() {
    return __privateMethod(this, _im, _im_fn).call(this);
  }
}
__decorateElement(_init, 1, "m", _dec, C);
__decoratorMetadata(_init, C);
```

Other forms, from the access-form test:

```js
__superSet(_home.prototype, this, "x", 1);
__superWrapper(_home.prototype, this, "x")._ += 10;
__superWrapper(_home.prototype, this, key)._++;
[__superWrapper(_home.prototype, this, "x")._, __superWrapper(_home.prototype, this, key)._] = [100, 200];
for (__superWrapper(_home.prototype, this, "x")._ of [31, 32]) ...
__superGet(_home.prototype, this, "f")?.call(this, 5);
__superGet(_home.prototype, this, "tag").bind(this)`a${1}b${2}`;
__superDelete("probe");                           // delete super.probe
__superGet(_home, this, "sf").call(this, "a");   // static member
```

</details>
