### PR TITLE
bun test: only kill the timed-out test's own subprocesses on timeout

### DIFF
--- a/docs/test/writing-tests.mdx
+++ b/docs/test/writing-tests.mdx
@@ -74,7 +74,7 @@ test("wat", async () => {
 }, 500); // test must run in <500ms
 ```
 
-In `bun:test`, a timeout throws an uncatchable exception to force the test to stop running and fail. Bun also kills any child processes spawned in the test, so they don't linger as zombie processes.
+In `bun:test`, a timeout throws an uncatchable exception to force the test to stop running and fail. Bun also kills any child processes the test (or its `beforeEach`/`afterEach` hooks) spawned that are still running, so they don't linger as zombie processes. Processes started in `beforeAll` or by earlier tests are left alone.
 
 The default timeout for each test is 5000ms (5 seconds) unless you override it with this timeout option or `jest.setTimeout()`.
 
@@ -117,7 +117,7 @@ test(
 
 ### 🧟 Zombie Process Killer
 
-When a test times out, Bun kills any still-running processes that the test spawned with `Bun.spawn`, `Bun.spawnSync`, or `node:child_process`, and logs a message to the console. This prevents zombie processes from lingering after timed-out tests.
+When a test times out, Bun kills any still-running processes that the test (or its `beforeEach`/`afterEach` hooks) spawned with `Bun.spawn`, `Bun.spawnSync`, or `node:child_process`, and logs a message to the console. This prevents zombie processes from lingering after timed-out tests. Processes spawned in `beforeAll` or by earlier tests are not affected; a `beforeAll` or `afterAll` hook that times out only has its own processes killed.
 
 ## Test Modifiers
 

--- a/src/jsc/ProcessAutoKiller.rs
+++ b/src/jsc/ProcessAutoKiller.rs
@@ -9,9 +9,15 @@ bun_core::declare_scope!(AutoKiller, hidden);
 pub struct ProcessAutoKiller {
     /// Keys are intrusively-refcounted `*Process` (ref()'d on insert, deref()'d
     /// on remove/drop). Stored as raw ptr for identity-hash semantics.
-    pub(crate) processes: ArrayHashMap<*mut Process, ()>,
+    /// The value is the [`Self::scope`] that was current when the process was
+    /// spawned.
+    pub(crate) processes: ArrayHashMap<*mut Process, u32>,
     pub enabled: bool,
     pub(crate) ever_enabled: bool,
+    /// Advanced by [`Self::begin_scope`]. The test runner starts a scope per
+    /// test (or hook) so that [`Self::kill_scope`] on a timeout leaves
+    /// processes spawned by earlier tests and `beforeAll` hooks alone.
+    scope: u32,
 }
 
 impl ProcessAutoKiller {
@@ -24,34 +30,64 @@ impl ProcessAutoKiller {
         self.enabled = false;
     }
 
-    pub fn kill(&mut self) -> Result {
-        Result {
-            processes: self.kill_processes(),
-        }
+    /// Attributes every process spawned from now on to a new scope.
+    /// Processes already tracked keep the scope they were spawned in.
+    pub fn begin_scope(&mut self) {
+        self.scope = self.scope.wrapping_add(1);
     }
 
-    fn kill_processes(&mut self) -> u32 {
+    /// Kills every tracked process and stops tracking all of them.
+    pub fn kill(&mut self) -> Result {
         let mut count: u32 = 0;
         while let Some(entry) = self.processes.pop() {
-            {
-                // SAFETY: every key in `processes` was ref()'d on insert and is
-                // live until the matching deref() below; popped entry is
-                // exclusively owned for this scope so `&mut Process` is unaliased.
-                let p: &mut Process = unsafe { &mut *entry.key };
-                if !p.has_exited() {
-                    bun_core::scoped_log!(AutoKiller, "process.kill {}", p.pid);
-                    count += p.kill(SignalCode::DEFAULT.0).is_ok() as u32;
-                }
-            }
-            // SAFETY: key live until this releases the ref taken on insert.
-            unsafe { Process::deref(entry.key) };
+            count += Self::kill_and_release(entry.key);
         }
-        count
+        Result { processes: count }
+    }
+
+    /// Kills only the processes spawned since the last [`Self::begin_scope`]
+    /// and stops tracking them. Processes from earlier scopes are left running
+    /// and stay tracked, so a later [`Self::kill`] still covers them.
+    pub fn kill_scope(&mut self) -> Result {
+        let mut count: u32 = 0;
+        let mut index = self.processes.len();
+        while index > 0 {
+            index -= 1;
+            if self.processes.values()[index] != self.scope {
+                continue;
+            }
+            // Walking backwards, so the entry swapped into `index` has
+            // already been visited.
+            let (process, _) = self.processes.swap_remove_at(index);
+            count += Self::kill_and_release(process);
+        }
+        Result { processes: count }
+    }
+
+    /// Signals `process` if it is still running, then releases the ref taken in
+    /// [`Self::on_subprocess_spawn`]. The caller must already have removed it
+    /// from `processes`. Returns 1 if a signal was sent.
+    fn kill_and_release(process: *mut Process) -> u32 {
+        let killed = {
+            // SAFETY: every key in `processes` was ref()'d on insert and is
+            // live until the matching deref() below; the entry was removed
+            // from the map by the caller, so `&mut Process` is unaliased.
+            let p: &mut Process = unsafe { &mut *process };
+            if p.has_exited() {
+                false
+            } else {
+                bun_core::scoped_log!(AutoKiller, "process.kill {}", p.pid);
+                p.kill(SignalCode::DEFAULT.0).is_ok()
+            }
+        };
+        // SAFETY: key live until this releases the ref taken on insert.
+        unsafe { Process::deref(process) };
+        killed as u32
     }
 
     pub fn clear(&mut self) {
         for process in self.processes.keys() {
-            // SAFETY: see kill_processes — key is live until deref().
+            // SAFETY: see kill_and_release — key is live until deref().
             unsafe { Process::deref(*process) };
         }
 
@@ -69,7 +105,7 @@ impl ProcessAutoKiller {
         if self.enabled {
             // Alloc failure means we never took
             // a ref, so just bail. `put` here is fallible only on OOM.
-            if self.processes.put(process.as_ptr(), ()).is_err() {
+            if self.processes.put(process.as_ptr(), self.scope).is_err() {
                 return;
             }
             // SAFETY: caller passes a live Process; we take a ref to extend its
@@ -99,7 +135,7 @@ pub struct Result {
 impl Drop for ProcessAutoKiller {
     fn drop(&mut self) {
         for process in self.processes.keys() {
-            // SAFETY: see kill_processes — key is live until deref().
+            // SAFETY: see kill_and_release — key is live until deref().
             unsafe { Process::deref(*process) };
         }
         // `self.processes` storage freed by its own Drop.

--- a/src/jsc/ProcessAutoKiller.rs
+++ b/src/jsc/ProcessAutoKiller.rs
@@ -8,12 +8,12 @@ bun_core::declare_scope!(AutoKiller, hidden);
 #[derive(Default)]
 pub struct ProcessAutoKiller {
     /// Keys are intrusively-refcounted `*Process` (ref()'d on insert, deref()'d
-    /// on remove/drop). Stored as raw ptr for identity-hash semantics. Values
-    /// are the [`Self::scope`] each process was spawned in.
+    /// on remove/drop). Stored as raw ptr for identity-hash semantics.
     pub(crate) processes: ArrayHashMap<*mut Process, u32>,
     pub enabled: bool,
     pub(crate) ever_enabled: bool,
-    /// The test runner begins a scope per test, so a timeout only kills what that test spawned.
+    /// Stored per process as the map value. The test runner begins one per execution group
+    /// (a test with its beforeEach/afterEach hooks, or one beforeAll/afterAll).
     scope: u32,
 }
 
@@ -39,8 +39,7 @@ impl ProcessAutoKiller {
         Result { processes: count }
     }
 
-    /// Kills the current scope's processes. Earlier scopes stay tracked so that
-    /// [`Self::kill`] still covers them.
+    /// Earlier scopes stay tracked (and alive) so that [`Self::kill`] still covers them.
     pub fn kill_scope(&mut self) -> Result {
         let mut count: u32 = 0;
         let mut index = self.processes.len();

--- a/src/jsc/ProcessAutoKiller.rs
+++ b/src/jsc/ProcessAutoKiller.rs
@@ -8,15 +8,12 @@ bun_core::declare_scope!(AutoKiller, hidden);
 #[derive(Default)]
 pub struct ProcessAutoKiller {
     /// Keys are intrusively-refcounted `*Process` (ref()'d on insert, deref()'d
-    /// on remove/drop). Stored as raw ptr for identity-hash semantics.
-    /// The value is the [`Self::scope`] that was current when the process was
-    /// spawned.
+    /// on remove/drop). Stored as raw ptr for identity-hash semantics. Values
+    /// are the [`Self::scope`] each process was spawned in.
     pub(crate) processes: ArrayHashMap<*mut Process, u32>,
     pub enabled: bool,
     pub(crate) ever_enabled: bool,
-    /// Advanced by [`Self::begin_scope`]. The test runner starts a scope per
-    /// test (or hook) so that [`Self::kill_scope`] on a timeout leaves
-    /// processes spawned by earlier tests and `beforeAll` hooks alone.
+    /// The test runner begins a scope per test, so a timeout only kills what that test spawned.
     scope: u32,
 }
 
@@ -30,13 +27,10 @@ impl ProcessAutoKiller {
         self.enabled = false;
     }
 
-    /// Attributes every process spawned from now on to a new scope.
-    /// Processes already tracked keep the scope they were spawned in.
     pub fn begin_scope(&mut self) {
         self.scope = self.scope.wrapping_add(1);
     }
 
-    /// Kills every tracked process and stops tracking all of them.
     pub fn kill(&mut self) -> Result {
         let mut count: u32 = 0;
         while let Some(entry) = self.processes.pop() {
@@ -45,9 +39,8 @@ impl ProcessAutoKiller {
         Result { processes: count }
     }
 
-    /// Kills only the processes spawned since the last [`Self::begin_scope`]
-    /// and stops tracking them. Processes from earlier scopes are left running
-    /// and stay tracked, so a later [`Self::kill`] still covers them.
+    /// Kills the current scope's processes. Earlier scopes stay tracked so that
+    /// [`Self::kill`] still covers them.
     pub fn kill_scope(&mut self) -> Result {
         let mut count: u32 = 0;
         let mut index = self.processes.len();
@@ -56,17 +49,14 @@ impl ProcessAutoKiller {
             if self.processes.values()[index] != self.scope {
                 continue;
             }
-            // Walking backwards, so the entry swapped into `index` has
-            // already been visited.
+            // Walking backwards, so the entry swapped into `index` was already visited.
             let (process, _) = self.processes.swap_remove_at(index);
             count += Self::kill_and_release(process);
         }
         Result { processes: count }
     }
 
-    /// Signals `process` if it is still running, then releases the ref taken in
-    /// [`Self::on_subprocess_spawn`]. The caller must already have removed it
-    /// from `processes`. Returns 1 if a signal was sent.
+    /// `process` must already be removed from `processes`; this releases its ref.
     fn kill_and_release(process: *mut Process) -> u32 {
         let killed = {
             // SAFETY: every key in `processes` was ref()'d on insert and is

--- a/src/jsc/ProcessAutoKiller.rs
+++ b/src/jsc/ProcessAutoKiller.rs
@@ -12,8 +12,7 @@ pub struct ProcessAutoKiller {
     pub(crate) processes: ArrayHashMap<*mut Process, u32>,
     pub enabled: bool,
     pub(crate) ever_enabled: bool,
-    /// Stored per process as the map value. The test runner begins one per execution group
-    /// (a test with its beforeEach/afterEach hooks, or one beforeAll/afterAll).
+    /// Map value of each tracked process; the test runner begins a new one per execution group.
     scope: u32,
 }
 

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -299,8 +299,11 @@ impl Execution {
         let _g = group_begin!();
 
         // if the concurrent group has one sequence and the sequence has an active entry that has timed out,
-        //   kill any dangling processes
+        //   kill the dangling processes spawned by that group (each group is its own auto_killer scope, so
+        //   processes spawned by beforeAll or by earlier tests are left alone)
         // when using test.concurrent(), we can't do this because it could kill multiple tests at once.
+        // timespec == EPOCH means the entry has no timeout; the timer that fired was armed by an earlier
+        // entry (update_min_timeout never unsets a timer), same as in ExecutionEntry::evaluate_timeout.
         if let Some(current_group) = self.active_group() {
             // reshaped for borrowck — capture range, drop &mut group, re-borrow sequences
             let (start, end) = (current_group.sequence_start, current_group.sequence_end);
@@ -311,9 +314,11 @@ impl Execution {
                     // SAFETY: arena-owned entry, alive for lifetime of BunTest
                     let entry = unsafe { entry.as_ref() };
                     let now = Timespec::now_force_real_time();
-                    if entry.timespec.order(&now) == core::cmp::Ordering::Less {
+                    if !entry.timespec.eql(&Timespec::EPOCH)
+                        && entry.timespec.order(&now) == core::cmp::Ordering::Less
+                    {
                         // SAFETY: bun_vm() returns the live per-thread VM.
-                        let kill_count = global_this.bun_vm().as_mut().auto_killer.kill();
+                        let kill_count = global_this.bun_vm().as_mut().auto_killer.kill_scope();
                         if kill_count.processes > 0 {
                             bun_core::pretty_errorln!(
                                 "<d>killed {} dangling process{}<r>",
@@ -565,7 +570,9 @@ impl Execution {
 
     fn on_group_started(global_this: &JSGlobalObject) {
         // SAFETY: bun_vm() returns the live per-thread VM.
-        global_this.bun_vm().as_mut().auto_killer.enable();
+        let auto_killer = &mut global_this.bun_vm().as_mut().auto_killer;
+        auto_killer.begin_scope();
+        auto_killer.enable();
     }
 
     fn on_group_completed(global_this: &JSGlobalObject) {

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -300,7 +300,6 @@ impl Execution {
 
         // if the concurrent group has one sequence and the sequence has an active entry that has timed out,
         //   kill the dangling processes it spawned
-        // when using test.concurrent(), we can't do this because it could kill multiple tests at once.
         if let Some(current_group) = self.active_group() {
             // reshaped for borrowck — capture range, drop &mut group, re-borrow sequences
             let (start, end) = (current_group.sequence_start, current_group.sequence_end);
@@ -315,16 +314,7 @@ impl Execution {
                     if !entry.timespec.eql(&Timespec::EPOCH)
                         && entry.timespec.order(&now) == core::cmp::Ordering::Less
                     {
-                        // SAFETY: bun_vm() returns the live per-thread VM.
-                        let kill_count = global_this.bun_vm().as_mut().auto_killer.kill_scope();
-                        if kill_count.processes > 0 {
-                            bun_core::pretty_errorln!(
-                                "<d>killed {} dangling process{}<r>",
-                                kill_count.processes,
-                                if kill_count.processes != 1 { "es" } else { "" },
-                            );
-                            bun_core::Output::flush();
-                        }
+                        kill_dangling_processes(end - start, global_this);
                     }
                 }
             }
@@ -1042,7 +1032,12 @@ fn step_sequence_one(
             // SAFETY: re-deref after run_test_callback; sequence_ptr still valid (sequences is a
             // Box<[ExecutionSequence]>, never reallocated during execution).
             let sequence = unsafe { &mut *sequence_ptr.as_ptr() };
-            let _ = next_item.evaluate_timeout(sequence, now);
+            if next_item.evaluate_timeout(sequence, now) {
+                // The callback overran its deadline synchronously, so handle_timeout may never have run.
+                // SAFETY: group points into buntest.execution.groups; read-only.
+                let g = unsafe { group.as_ref() };
+                kill_dangling_processes(g.sequence_end - g.sequence_start, global_this);
+            }
 
             // the result is available immediately; advance the sequence and run again.
             Execution::advance_sequence(buntest_ptr, sequence_ptr, group);
@@ -1081,5 +1076,22 @@ fn step_sequence_one(
         }
         Execution::advance_sequence(buntest_ptr, sequence_ptr, group);
         return Ok(None); // run again
+    }
+}
+
+/// Kills what the timed-out group spawned (its auto_killer scope). Skipped for test.concurrent()
+/// groups, whose sequences all share one scope, so this could kill other still-running tests' children.
+fn kill_dangling_processes(group_sequence_count: usize, global_this: &JSGlobalObject) {
+    if group_sequence_count != 1 {
+        return;
+    }
+    let kill_count = global_this.bun_vm().as_mut().auto_killer.kill_scope();
+    if kill_count.processes > 0 {
+        bun_core::pretty_errorln!(
+            "<d>killed {} dangling process{}<r>",
+            kill_count.processes,
+            if kill_count.processes != 1 { "es" } else { "" },
+        );
+        bun_core::Output::flush();
     }
 }

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -1079,8 +1079,7 @@ fn step_sequence_one(
     }
 }
 
-/// Kills what the timed-out group spawned (its auto_killer scope). Skipped for test.concurrent()
-/// groups, whose sequences all share one scope, so this could kill other still-running tests' children.
+/// Skipped for test.concurrent() groups: their tests share one scope, so this would hit other tests' children.
 fn kill_dangling_processes(group_sequence_count: usize, global_this: &JSGlobalObject) {
     if group_sequence_count != 1 {
         return;

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -299,11 +299,8 @@ impl Execution {
         let _g = group_begin!();
 
         // if the concurrent group has one sequence and the sequence has an active entry that has timed out,
-        //   kill the dangling processes spawned by that group (each group is its own auto_killer scope, so
-        //   processes spawned by beforeAll or by earlier tests are left alone)
+        //   kill the dangling processes it spawned
         // when using test.concurrent(), we can't do this because it could kill multiple tests at once.
-        // timespec == EPOCH means the entry has no timeout; the timer that fired was armed by an earlier
-        // entry (update_min_timeout never unsets a timer), same as in ExecutionEntry::evaluate_timeout.
         if let Some(current_group) = self.active_group() {
             // reshaped for borrowck — capture range, drop &mut group, re-borrow sequences
             let (start, end) = (current_group.sequence_start, current_group.sequence_end);
@@ -314,6 +311,7 @@ impl Execution {
                     // SAFETY: arena-owned entry, alive for lifetime of BunTest
                     let entry = unsafe { entry.as_ref() };
                     let now = Timespec::now_force_real_time();
+                    // EPOCH: this entry has no timeout; a timer left armed by an earlier entry fired.
                     if !entry.timespec.eql(&Timespec::EPOCH)
                         && entry.timespec.order(&now) == core::cmp::Ordering::Less
                     {

--- a/test/cli/test/test-timeout-behavior.test.ts
+++ b/test/cli/test/test-timeout-behavior.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isFlaky, isLinux } from "harness";
+import { bunEnv, bunExe, isFlaky, isLinux, tempDir } from "harness";
 import path from "path";
 
 if (isFlaky && isLinux) {
@@ -33,3 +33,118 @@ if (isFlaky && isLinux) {
     expect(combined).toContain("(pass) slow test after test timeout");
   });
 }
+
+// Shared by the inline test files below. An echo child stays alive until it is
+// killed, and `echo()` only gets its message back while the child is alive: a
+// killed child never runs again, so its stdout just reports EOF.
+const echoChildHelpers = /* ts */ `
+  function spawnEcho() {
+    return Bun.spawn({
+      cmd: [process.execPath, "-e", "process.stdin.pipe(process.stdout)"],
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "ignore",
+    });
+  }
+
+  async function echo(child: ReturnType<typeof spawnEcho>, message: string) {
+    child.stdin.write(message);
+    await child.stdin.flush();
+    const reader = child.stdout.getReader();
+    let received = "";
+    while (received.length < message.length) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      received += Buffer.from(value).toString();
+    }
+    reader.releaseLock();
+    return received;
+  }
+`;
+
+async function runTestFile(source: string, args: string[] = []) {
+  using dir = tempDir("test-timeout-kill", { "kill.test.ts": echoChildHelpers + source });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", ...args, "./kill.test.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { combined: stdout + stderr, exitCode };
+}
+
+test.concurrent.each([[[]], [["--isolate"]]])(
+  "a test timeout only kills the processes spawned by that test (args: %p)",
+  async args => {
+    const { combined, exitCode } = await runTestFile(
+      /* ts */ `
+        import { afterAll, beforeAll, expect, test } from "bun:test";
+
+        const children: ReturnType<typeof spawnEcho>[] = [];
+        afterAll(() => children.forEach(child => child.kill()));
+
+        beforeAll(() => {
+          children.push(spawnEcho());
+        });
+
+        test("spawns a child that outlives the test", () => {
+          children.push(spawnEcho());
+        });
+
+        test("times out", async () => {
+          children.push(spawnEcho());
+          await new Promise(() => {});
+        }, 100);
+
+        test("children spawned by beforeAll and by an earlier test are still running", async () => {
+          const [fromBeforeAll, fromEarlierTest] = children;
+          expect(await Promise.all([echo(fromBeforeAll, "beforeAll"), echo(fromEarlierTest, "earlier test")])).toEqual([
+            "beforeAll",
+            "earlier test",
+          ]);
+        });
+      `,
+      args,
+    );
+
+    // Only the child of the test that timed out is killed.
+    expect(combined).toContain("killed 1 dangling process");
+    expect(combined).not.toContain("dangling processes");
+    expect(combined).toContain("(pass) spawns a child that outlives the test");
+    expect(combined).toContain("(fail) times out");
+    expect(combined).toContain("(pass) children spawned by beforeAll and by an earlier test are still running");
+    expect(combined).toContain(" 2 pass\n");
+    expect(combined).toContain(" 1 fail\n");
+    expect(exitCode).toBe(1);
+  },
+);
+
+test.concurrent("a test without a timeout keeps its processes when an earlier test's timer fires", async () => {
+  const { combined, exitCode } = await runTestFile(/* ts */ `
+    import { expect, test } from "bun:test";
+
+    // Arms a 50ms timer for this test. The runner never disarms it, so it fires
+    // while the next test is running.
+    test("finishes immediately", () => {}, 50);
+
+    test("has no timeout and spawns a child", async () => {
+      const child = spawnEcho();
+      try {
+        // Both timers live in the same heap and fire in deadline order, so the
+        // first test's 50ms timer has fired by the time this sleep resolves.
+        await Bun.sleep(250);
+        expect(await echo(child, "still here")).toBe("still here");
+      } finally {
+        child.kill();
+      }
+    }, 0);
+  `);
+
+  expect(combined).not.toContain("dangling process");
+  expect(combined).toContain("(pass) finishes immediately");
+  expect(combined).toContain("(pass) has no timeout and spawns a child");
+  expect(combined).toContain(" 2 pass\n");
+  expect(exitCode).toBe(0);
+});

--- a/test/cli/test/test-timeout-behavior.test.ts
+++ b/test/cli/test/test-timeout-behavior.test.ts
@@ -132,9 +132,11 @@ test.concurrent("a test without a timeout keeps its processes when an earlier te
     test("has no timeout and spawns a child", async () => {
       const child = spawnEcho();
       try {
-        // Both timers live in the same heap and fire in deadline order, so the
-        // first test's 50ms timer has fired by the time this sleep resolves.
-        await Bun.sleep(250);
+        // Nothing in this file can observe the stale timer firing, so wait on a
+        // timer with a later deadline instead: the runner's timer and this one
+        // are in the same heap and fire in deadline order, so the 50ms timer
+        // (armed before this test started) has fired once this resolves.
+        await Bun.sleep(100);
         expect(await echo(child, "still here")).toBe("still here");
       } finally {
         child.kill();

--- a/test/cli/test/test-timeout-behavior.test.ts
+++ b/test/cli/test/test-timeout-behavior.test.ts
@@ -75,6 +75,8 @@ async function runTestFile(source: string, args: string[] = []) {
   return { combined: stdout + stderr, exitCode };
 }
 
+// Under --isolate the runner also tracks the module-scope child; without it only
+// the hooks and tests are tracked. Either way the timeout must not touch it.
 test.concurrent.each([[[]], [["--isolate"]]])(
   "a test timeout only kills the processes spawned by that test (args: %p)",
   async args => {
@@ -82,7 +84,7 @@ test.concurrent.each([[[]], [["--isolate"]]])(
       /* ts */ `
         import { afterAll, beforeAll, expect, test } from "bun:test";
 
-        const children: ReturnType<typeof spawnEcho>[] = [];
+        const children: ReturnType<typeof spawnEcho>[] = [spawnEcho()];
         afterAll(() => children.forEach(child => child.kill()));
 
         beforeAll(() => {
@@ -98,28 +100,167 @@ test.concurrent.each([[[]], [["--isolate"]]])(
           await new Promise(() => {});
         }, 100);
 
-        test("children spawned by beforeAll and by an earlier test are still running", async () => {
-          const [fromBeforeAll, fromEarlierTest] = children;
-          expect(await Promise.all([echo(fromBeforeAll, "beforeAll"), echo(fromEarlierTest, "earlier test")])).toEqual([
-            "beforeAll",
-            "earlier test",
-          ]);
+        test("the other children are still running", async () => {
+          const [fromModuleScope, fromBeforeAll, fromEarlierTest] = children;
+          expect(
+            await Promise.all([
+              echo(fromModuleScope, "module scope"),
+              echo(fromBeforeAll, "beforeAll"),
+              echo(fromEarlierTest, "earlier test"),
+            ]),
+          ).toEqual(["module scope", "beforeAll", "earlier test"]);
         });
       `,
       args,
     );
 
-    // Only the child of the test that timed out is killed.
     expect(combined).toContain("killed 1 dangling process");
     expect(combined).not.toContain("dangling processes");
     expect(combined).toContain("(pass) spawns a child that outlives the test");
     expect(combined).toContain("(fail) times out");
-    expect(combined).toContain("(pass) children spawned by beforeAll and by an earlier test are still running");
+    expect(combined).toContain("(pass) the other children are still running");
     expect(combined).toContain(" 2 pass\n");
     expect(combined).toContain(" 1 fail\n");
     expect(exitCode).toBe(1);
   },
 );
+
+test.concurrent("a test timeout kills the children of its beforeEach hooks, not of beforeAll", async () => {
+  const { combined, exitCode } = await runTestFile(/* ts */ `
+    import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+    let fromBeforeAll: ReturnType<typeof spawnEcho>;
+    let fromBeforeEach: ReturnType<typeof spawnEcho>;
+    afterAll(() => {
+      fromBeforeAll.kill();
+      fromBeforeEach.kill();
+    });
+
+    beforeAll(() => {
+      fromBeforeAll = spawnEcho();
+    });
+
+    describe("with a beforeEach", () => {
+      beforeEach(() => {
+        fromBeforeEach = spawnEcho();
+      });
+
+      test("times out", async () => {
+        await new Promise(() => {});
+      }, 100);
+    });
+
+    test("only the beforeEach child was killed", async () => {
+      await fromBeforeEach.exited;
+      expect(await echo(fromBeforeAll, "beforeAll")).toBe("beforeAll");
+    });
+  `);
+
+  expect(combined).toContain("killed 1 dangling process");
+  expect(combined).not.toContain("dangling processes");
+  expect(combined).toContain("(fail) with a beforeEach > times out");
+  expect(combined).toContain("(pass) only the beforeEach child was killed");
+  expect(combined).toContain(" 1 pass\n");
+  expect(combined).toContain(" 1 fail\n");
+  expect(exitCode).toBe(1);
+});
+
+test.concurrent("a beforeAll timeout only kills the children of that hook", async () => {
+  const { combined, exitCode } = await runTestFile(/* ts */ `
+    import { afterAll, beforeAll, test } from "bun:test";
+
+    let fromFirstHook: ReturnType<typeof spawnEcho>;
+    let fromTimedOutHook: ReturnType<typeof spawnEcho>;
+
+    beforeAll(() => {
+      fromFirstHook = spawnEcho();
+    });
+
+    beforeAll(async () => {
+      fromTimedOutHook = spawnEcho();
+      await new Promise(() => {});
+    }, 100);
+
+    test("is skipped because beforeAll failed", () => {});
+
+    afterAll(async () => {
+      await fromTimedOutHook.exited;
+      console.log("first hook's child answered:", JSON.stringify(await echo(fromFirstHook, "still here")));
+      fromFirstHook.kill();
+    });
+  `);
+
+  expect(combined).toContain("killed 1 dangling process");
+  expect(combined).not.toContain("dangling processes");
+  expect(combined).toContain('first hook\'s child answered: "still here"');
+  expect(exitCode).toBe(1);
+});
+
+// on_subprocess_exit swap-removes entries, so once a child from an earlier scope
+// exits, the timed-out test's children are no longer the tail of the tracked set.
+test.concurrent("a test timeout kills all of its children after an earlier child exited", async () => {
+  const { combined, exitCode } = await runTestFile(/* ts */ `
+    import { afterAll, beforeAll, expect, test } from "bun:test";
+
+    const children: ReturnType<typeof spawnEcho>[] = [];
+    afterAll(() => children.forEach(child => child.kill()));
+
+    beforeAll(() => {
+      children.push(spawnEcho(), spawnEcho());
+    });
+
+    test("spawns a child that outlives the test", () => {
+      children.push(spawnEcho());
+    });
+
+    test("times out after the first beforeAll child exited", async () => {
+      children.push(spawnEcho(), spawnEcho());
+      children[0].kill();
+      await children[0].exited;
+      await new Promise(() => {});
+    }, 100);
+
+    test("the second beforeAll child and the earlier test's child are still running", async () => {
+      const [, secondFromBeforeAll, fromEarlierTest] = children;
+      expect(await Promise.all([echo(secondFromBeforeAll, "beforeAll"), echo(fromEarlierTest, "earlier test")])).toEqual([
+        "beforeAll",
+        "earlier test",
+      ]);
+    });
+  `);
+
+  expect(combined).toContain("killed 2 dangling processes");
+  expect(combined).toContain("(pass) the second beforeAll child and the earlier test's child are still running");
+  expect(combined).toContain(" 2 pass\n");
+  expect(combined).toContain(" 1 fail\n");
+  expect(exitCode).toBe(1);
+});
+
+test.concurrent("a test that overruns its timeout without yielding still gets its children killed", async () => {
+  const { combined, exitCode } = await runTestFile(/* ts */ `
+    import { afterAll, test } from "bun:test";
+
+    let child: ReturnType<typeof spawnEcho>;
+    afterAll(() => child.kill());
+
+    test("blocks past its timeout", () => {
+      child = spawnEcho();
+      Bun.sleepSync(150);
+    }, 50);
+
+    test("its child was killed", async () => {
+      await child.exited;
+    });
+  `);
+
+  expect(combined).toContain("killed 1 dangling process");
+  expect(combined).not.toContain("dangling processes");
+  expect(combined).toContain("(fail) blocks past its timeout");
+  expect(combined).toContain("(pass) its child was killed");
+  expect(combined).toContain(" 1 pass\n");
+  expect(combined).toContain(" 1 fail\n");
+  expect(exitCode).toBe(1);
+});
 
 test.concurrent("a test without a timeout keeps its processes when an earlier test's timer fires", async () => {
   const { combined, exitCode } = await runTestFile(/* ts */ `


### PR DESCRIPTION
### Problem
- When one test times out, `bun test` prints `killed N dangling processes` and SIGTERMs every subprocess the file still has running, not only the ones the timed-out test spawned. A registry or server started in a file-level `beforeAll` (for example the Verdaccio instance in `test/cli/install/bun-publish.test.ts`) dies with the first slow test, and every later test in the file fails with `ConnectionRefused`. docs/test/writing-tests.mdx documents the kill as covering the processes the timed-out test spawned.
- Cause: `ProcessAutoKiller` (`src/jsc/ProcessAutoKiller.rs`) is one flat set of every process spawned while tracking is on. `Execution::on_group_started` turns tracking on for every group (`beforeAll` hooks run as their own groups, so their spawns are tracked too), nothing removes a group's processes when the group finishes, and `Execution::handle_timeout` called `auto_killer.kill()`, which empties the whole set. The set is only cleared at the end of the file (`src/runtime/cli/test_command.rs:3396`). The runner before the rewrite in #22534 cleared the set after every test; the rewrite switched to per-group enable/disable and dropped the clear.
- Second way the same code killed processes of a test that had not timed out: `handle_timeout` compared the active entry's deadline with `order()` alone, so an entry with no timeout (`timespec == EPOCH`, i.e. `test(name, fn, 0)`) always counted as expired. The runner never disarms a timer once armed (`BunTest::update_min_timeout`, `src/runtime/test_runner/bun_test.rs:990`), so a quick test with a short timeout leaves a timer that fires during the next test; if that test has no timeout, its subprocesses were killed and `killed 1 dangling process` printed although nothing timed out.
- The opposite gap: a test whose callback overruns its deadline without yielding (`Bun.sleepSync`, a busy loop) is marked as timed out by `evaluate_timeout` on the synchronous return, but nothing killed its children, because the kill only existed in the timer callback.

Repro for the first point (fails on 1.4.0 and on main; the second test sees `signalCode === "SIGTERM"` and the runner prints `killed 1 dangling process`):

```ts
import { beforeAll, afterAll, expect, test } from "bun:test";
let fixture: Bun.Subprocess;
beforeAll(() => { fixture = Bun.spawn({ cmd: [process.execPath, "-e", "setInterval(() => {}, 1000)"] }); });
afterAll(() => fixture.kill());
test("times out", async () => { await new Promise(() => {}); }, 200);
test("fixture survives", () => { expect(fixture.signalCode).toBeNull(); });
```

### Fix
- Each tracked process records the killer's current scope (the map value, previously `()`); `begin_scope()` advances it and `kill_scope()` kills and untracks only the processes of the current scope. `kill()` keeps killing everything.
- `Execution::on_group_started` begins a scope before enabling tracking, so the scope is the execution group: a test together with its `beforeEach`/`afterEach` hooks, or a single `beforeAll`/`afterAll` hook (see Background). A test timeout therefore kills the test's own children and those of its per-test hooks; `beforeAll` children, earlier tests' children and (under `--isolate`, where they are tracked) module-scope children survive, and a hook that times out only loses its own children. This is a deliberate choice rather than a byte-for-byte restoration of the pre-#22534 runner, which did not track `beforeEach` spawns at all: per-test hook children are per-test fixtures, and killing them is what stops them leaking when the test they belong to never finished. The docs are updated to say exactly this.
- The kill itself moves into `kill_dangling_processes()` (`Execution.rs`), called from `handle_timeout` and from the synchronous-return path in `step_sequence_one` when `evaluate_timeout()` reports an overrun, so a callback that blocked past its deadline gets the same cleanup. It still does nothing for `test.concurrent` groups, whose tests share one scope. This is the same shape as the helper #30598 adds, so that PR rebases onto this one and picks up `kill_scope()` and the EPOCH check instead of re-introducing `kill()`.
- `handle_timeout` skips the kill when the entry's deadline is `EPOCH`, the same check `ExecutionEntry::evaluate_timeout` uses to decide whether the entry timed out, so the kill and the failure are decided by the same condition.
- Processes from earlier scopes stay tracked rather than being dropped at group end, so the `--isolate` swap (`VirtualMachine::swap_global_for_test_isolation`, `src/jsc/VirtualMachine.rs`) still `kill()`s everything the file left running; `isolation.test.ts` still passes. Composes with #38750, which keeps tracking on across groups under `--isolate`: after both, module-scope spawns are killed at the swap and never by a timeout.
- Tests, all in `test/cli/test/test-timeout-behavior.test.ts`, run the runner on a generated file whose children are small echo processes; a later test or hook proves a child is alive by round-tripping a message (a SIGTERMed child never answers again, and a killed child is checked by awaiting its exit), and the outer test checks the exact `killed N dangling process(es)` line, which is printed synchronously at kill time:
  - module-scope, `beforeAll` and earlier-test children survive a test timeout, with and without `--isolate` (unfixed: `killed 3` / `killed 4 dangling processes`);
  - a `beforeEach` child dies with the timed-out test while the `beforeAll` child survives (unfixed: `killed 2`; a per-entry scope would kill nothing);
  - a `beforeAll` that times out only kills its own child, observed from `afterAll` (unfixed: `killed 2`);
  - a timed-out test with two children after an earlier child exited: `on_subprocess_exit` swap-removes entries, so the current scope is no longer the tail of the set and the backward walk in `kill_scope()` has to remove a non-tail entry (expects `killed 2`; unfixed: `killed 4`; a forward walk or a stop-at-first-older-entry walk would report 1);
  - a callback that overruns synchronously gets its child killed (unfixed: the child only dies when the next test times out waiting for it);
  - a no-timeout test keeps its child when an earlier test's timer fires; the wait is a timer with a later deadline in the same heap, which is the only thing in the file ordered after the stale timer (unfixed: `killed 1`).
  - With `src/` stashed every new case fails on the debug build and the two pre-existing cases pass; with the fix all nine pass (5 consecutive runs). `isolation.test.ts`, `test/js/bun/spawn/spawn.test.ts`, the source lints, `cargo clippy` on `bun_jsc`/`bun_runtime` and `cargo fmt --check` are clean.

### Background
- `ProcessAutoKiller`: a per-VM map of the live `Bun.spawn`/`spawnSync`/`child_process` processes spawned while `enabled` is set (each entry holds a ref on the `Process`; the entry is removed when the process exits). It exists only for `bun test`, which has two consumers: the timeout kill, and the `--isolate` swap, which kills the whole set between files.
- Execution group: the unit the test runner executes at a time. `Order.rs` builds one group per `beforeAll`/`afterAll` hook and one group per test containing that test plus its `beforeEach`/`afterEach` hooks (retries and repeats rerun inside the same group); consecutive `test.concurrent` tests share one group, which is why the kill is skipped when a group has more than one sequence.
- Scope: a counter inside the killer that `on_group_started` bumps; the value stored next to each tracked process is the counter's value at spawn time. It is a tag, not a lifetime: nothing is untracked when a group ends, so `kill()` still sees everything.
- Timeout detection happens in two places: the `BunTest` timer fires `handle_timeout` while a callback is suspended on a promise, and `evaluate_timeout` runs when a callback returns synchronously (also for the timer path, to record the failure). The timer is shared by all entries and is only ever moved earlier, never cleared, so a deadline armed by one entry can fire while a later entry is active; an entry with timeout 0 has an `EPOCH` deadline.
