### PR TITLE
install: keep the pnpm block in package.json when migrating from pnpm

### DIFF
--- a/docs/pm/cli/install.mdx
+++ b/docs/pm/cli/install.mdx
@@ -583,11 +583,13 @@ Bun preserves dependencies that use pnpm's `catalog:` protocol:
 
 ### Configuration Migration
 
-Bun migrates the following pnpm configuration from both `pnpm-lock.yaml` and `pnpm-workspace.yaml`:
+Bun copies the following pnpm configuration into the root `package.json`:
 
-- **Overrides**: Moved from `pnpm.overrides` to root-level `overrides` in `package.json`
-- **Patched Dependencies**: Moved from `pnpm.patchedDependencies` to root-level `patchedDependencies` in `package.json`
-- **Workspace Overrides**: Applied from `pnpm-workspace.yaml` to root `package.json`
+- **Overrides**: Copied from `pnpm.overrides` to root-level `overrides` in `package.json`
+- **Patched Dependencies**: Copied from `pnpm.patchedDependencies` to root-level `patchedDependencies` in `package.json`
+- **Workspace Overrides**: Copied from `overrides` and `patchedDependencies` in `pnpm-workspace.yaml` to the same root-level fields
+
+Bun leaves the `pnpm` field of `package.json` as it is. pnpm reads its configuration from that field and ignores the root-level fields, so `pnpm install --frozen-lockfile` keeps working for teammates who still use pnpm. Bun reads the root-level fields and ignores the `pnpm` field.
 
 ### Requirements and limitations
 
@@ -598,7 +600,7 @@ Bun migrates the following pnpm configuration from both `pnpm-lock.yaml` and `pn
 - Relative `link:` dependencies and git dependencies with a sub-directory (`resolution.path`) are not supported
 - If migration fails for any of these reasons, Bun prints why and resolves from scratch instead
 
-After migration, you can safely remove `pnpm-lock.yaml` and `pnpm-workspace.yaml` files.
+Once nobody on the repository uses pnpm anymore, you can remove `pnpm-lock.yaml`, `pnpm-workspace.yaml`, and the `pnpm` field of `package.json`.
 
 ---
 

--- a/src/install/pnpm.rs
+++ b/src/install/pnpm.rs
@@ -2365,140 +2365,29 @@ fn update_package_json_after_migration(
         return Ok(());
     }
 
-    let mut needs_update = false;
-    let mut moved_overrides = false;
-    let mut moved_patched_deps = false;
-    let mut moved: Vec<&'static str> = Vec::new();
+    let mut copied: Vec<&'static str> = Vec::new();
 
-    if let Some(mut pnpm_prop) = json.as_property(b"pnpm") {
+    // The `pnpm` block is left as it is: pnpm still reads its config from there, and bun
+    // only reads the root-level fields, so the same package.json keeps working for both.
+    if let Some(pnpm_prop) = json.as_property(b"pnpm") {
         if pnpm_prop.expr.is_object() {
-            let pnpm_obj = e_object_mut(&mut pnpm_prop.expr);
+            let pnpm_obj = e_object(&pnpm_prop.expr);
 
-            if let Some(overrides_field) = pnpm_obj.get(b"overrides") {
-                if is_non_empty_object(&overrides_field) {
-                    if let Some(mut existing_prop) = json.as_property(b"overrides") {
-                        if existing_prop.expr.is_object() {
-                            let existing_overrides = e_object_mut(&mut existing_prop.expr);
-                            for prop in e_object(&overrides_field).properties.slice() {
-                                let Some(key) =
-                                    as_string(prop.key.as_ref().expect("infallible: prop has key"))
-                                else {
-                                    continue;
-                                };
-                                existing_overrides.put(
-                                    &bump,
-                                    key,
-                                    prop.value.expect("infallible: prop has value"),
-                                )?;
-                            }
-                        }
-                    } else {
-                        e_object_mut(&mut json).put(&bump, b"overrides", overrides_field)?;
-                    }
-                    moved_overrides = true;
-                    needs_update = true;
-                    moved.push("pnpm.overrides to overrides");
+            if let Some(overrides) = pnpm_obj.get(b"overrides").filter(is_non_empty_object) {
+                if copy_into_root(&mut json, &bump, b"overrides", copy_object(&overrides))? {
+                    copied.push("pnpm.overrides to overrides");
                 }
             }
 
-            if let Some(mut patched_field) = pnpm_obj.get(b"patchedDependencies") {
-                if is_non_empty_object(&patched_field) {
-                    rewrite_bare_patch_keys(&mut patched_field, patches)?;
-                    if let Some(mut existing_prop) = json.as_property(b"patchedDependencies") {
-                        if existing_prop.expr.is_object() {
-                            let existing_patches = e_object_mut(&mut existing_prop.expr);
-                            for prop in e_object(&patched_field).properties.slice() {
-                                let Some(key) =
-                                    as_string(prop.key.as_ref().expect("infallible: prop has key"))
-                                else {
-                                    continue;
-                                };
-                                existing_patches.put(
-                                    &bump,
-                                    key,
-                                    prop.value.expect("infallible: prop has value"),
-                                )?;
-                            }
-                        }
-                    } else {
-                        e_object_mut(&mut json).put(
-                            &bump,
-                            b"patchedDependencies",
-                            patched_field,
-                        )?;
-                    }
-                    moved_patched_deps = true;
-                    needs_update = true;
-                    moved.push("pnpm.patchedDependencies to patchedDependencies");
+            if let Some(patched) = pnpm_obj
+                .get(b"patchedDependencies")
+                .filter(is_non_empty_object)
+            {
+                let mut patched = copy_object(&patched);
+                rewrite_bare_patch_keys(&mut patched, patches)?;
+                if copy_into_root(&mut json, &bump, b"patchedDependencies", patched)? {
+                    copied.push("pnpm.patchedDependencies to patchedDependencies");
                 }
-            }
-
-            if moved_overrides || moved_patched_deps {
-                let mut remaining_count: usize = 0;
-                for prop in pnpm_obj.properties.slice() {
-                    let Some(key) = as_string(prop.key.as_ref().expect("infallible: prop has key"))
-                    else {
-                        remaining_count += 1;
-                        continue;
-                    };
-                    if moved_overrides && key == b"overrides" {
-                        continue;
-                    }
-                    if moved_patched_deps && key == b"patchedDependencies" {
-                        continue;
-                    }
-                    remaining_count += 1;
-                }
-
-                if remaining_count == 0 {
-                    let mut new_root_count: usize = 0;
-                    for prop in e_object(&json).properties.slice() {
-                        let Some(key) =
-                            as_string(prop.key.as_ref().expect("infallible: prop has key"))
-                        else {
-                            new_root_count += 1;
-                            continue;
-                        };
-                        if key != b"pnpm" {
-                            new_root_count += 1;
-                        }
-                    }
-
-                    let mut new_root_props = G::PropertyList::init_capacity(new_root_count);
-                    for prop in e_object(&json).properties.slice() {
-                        let Some(key) =
-                            as_string(prop.key.as_ref().expect("infallible: prop has key"))
-                        else {
-                            VecExt::append(&mut new_root_props, shallow_clone_prop(prop));
-                            continue;
-                        };
-                        if key != b"pnpm" {
-                            VecExt::append(&mut new_root_props, shallow_clone_prop(prop));
-                        }
-                    }
-
-                    e_object_mut(&mut json).properties = new_root_props;
-                } else {
-                    let mut new_pnpm_props = G::PropertyList::init_capacity(remaining_count);
-                    for prop in pnpm_obj.properties.slice() {
-                        let Some(key) =
-                            as_string(prop.key.as_ref().expect("infallible: prop has key"))
-                        else {
-                            VecExt::append(&mut new_pnpm_props, shallow_clone_prop(prop));
-                            continue;
-                        };
-                        if moved_overrides && key == b"overrides" {
-                            continue;
-                        }
-                        if moved_patched_deps && key == b"patchedDependencies" {
-                            continue;
-                        }
-                        VecExt::append(&mut new_pnpm_props, shallow_clone_prop(prop));
-                    }
-
-                    pnpm_obj.properties = new_pnpm_props;
-                }
-                needs_update = true;
             }
         }
     }
@@ -2673,66 +2562,23 @@ fn update_package_json_after_migration(
         }
     }
     if wrote_workspaces {
-        needs_update = true;
-        moved.push("pnpm-workspace.yaml to workspaces");
+        copied.push("pnpm-workspace.yaml to workspaces");
     }
 
-    // Handle overrides from pnpm-workspace.yaml
-    if let Some(ws_overrides) = &workspace_overrides_obj {
-        if ws_overrides.is_object() {
-            if let Some(mut existing_prop) = json.as_property(b"overrides") {
-                if existing_prop.expr.is_object() {
-                    let existing_overrides = e_object_mut(&mut existing_prop.expr);
-                    for prop in e_object(ws_overrides).properties.slice() {
-                        let Some(key) =
-                            as_string(prop.key.as_ref().expect("infallible: prop has key"))
-                        else {
-                            continue;
-                        };
-                        existing_overrides.put(
-                            &bump,
-                            key,
-                            prop.value.expect("infallible: prop has value"),
-                        )?;
-                    }
-                }
-            } else {
-                e_object_mut(&mut json).put(&bump, b"overrides", *ws_overrides)?;
-            }
-            needs_update = true;
-            moved.push("pnpm-workspace.yaml overrides to overrides");
+    if let Some(ws_overrides) = workspace_overrides_obj {
+        if copy_into_root(&mut json, &bump, b"overrides", ws_overrides)? {
+            copied.push("pnpm-workspace.yaml overrides to overrides");
         }
     }
 
-    // Handle patchedDependencies from pnpm-workspace.yaml
-    if let Some(ws_patched) = &mut workspace_patched_deps_obj {
-        if ws_patched.is_object() {
-            rewrite_bare_patch_keys(ws_patched, patches)?;
-            if let Some(mut existing_prop) = json.as_property(b"patchedDependencies") {
-                if existing_prop.expr.is_object() {
-                    let existing_patches = e_object_mut(&mut existing_prop.expr);
-                    for prop in e_object(ws_patched).properties.slice() {
-                        let Some(key) =
-                            as_string(prop.key.as_ref().expect("infallible: prop has key"))
-                        else {
-                            continue;
-                        };
-                        existing_patches.put(
-                            &bump,
-                            key,
-                            prop.value.expect("infallible: prop has value"),
-                        )?;
-                    }
-                }
-            } else {
-                e_object_mut(&mut json).put(&bump, b"patchedDependencies", *ws_patched)?;
-            }
-            needs_update = true;
-            moved.push("pnpm-workspace.yaml patchedDependencies to patchedDependencies");
+    if let Some(mut ws_patched) = workspace_patched_deps_obj {
+        rewrite_bare_patch_keys(&mut ws_patched, patches)?;
+        if copy_into_root(&mut json, &bump, b"patchedDependencies", ws_patched)? {
+            copied.push("pnpm-workspace.yaml patchedDependencies to patchedDependencies");
         }
     }
 
-    if needs_update {
+    if !copied.is_empty() {
         print_package_json_into_cache_entry(root_pkg_json, json);
         // The edits above spliced `Store`-allocated nodes into the cached tree,
         // and the next `initialize_store()` recycles them. Re-parse so the entry
@@ -2749,10 +2595,12 @@ fn update_package_json_after_migration(
             root_pkg_json.source.contents(),
         )
         .is_ok()
-            && !moved.is_empty()
             && !silent
         {
-            bun_core::pretty_errorln!("<d>moved {} in <r><green>package.json<r>", moved.join(", "));
+            bun_core::pretty_errorln!(
+                "<d>copied {} in <r><green>package.json<r>",
+                copied.join(", ")
+            );
         }
     }
 
@@ -2792,6 +2640,49 @@ fn data_store_dupe_expr_strings(expr: &mut Expr) {
         }
         _ => {}
     }
+}
+
+/// A separate object with the same entries. The root-level copy is edited afterwards
+/// (`rewrite_bare_patch_keys`, entries merged in from pnpm-workspace.yaml), and none of
+/// that may show up in the `pnpm` block it was copied from.
+fn copy_object(src: &Expr) -> Expr {
+    let src_props = e_object(src).properties.slice();
+    let mut properties = G::PropertyList::init_capacity(src_props.len());
+    for prop in src_props {
+        VecExt::append(&mut properties, shallow_clone_prop(prop));
+    }
+    Expr::init(
+        E::Object {
+            properties,
+            ..Default::default()
+        },
+        bun_ast::Loc::EMPTY,
+    )
+}
+
+/// Adds the entries of `src` to the root-level `field` object, creating it when absent.
+/// Returns `false` when `field` exists but is not an object, in which case nothing is written.
+fn copy_into_root(
+    json: &mut Expr,
+    bump: &bun_alloc::Arena,
+    field: &[u8],
+    src: Expr,
+) -> Result<bool, AllocError> {
+    let Some(mut existing) = json.as_property(field) else {
+        e_object_mut(json).put(bump, field, src)?;
+        return Ok(true);
+    };
+    if !existing.expr.is_object() {
+        return Ok(false);
+    }
+    let existing_obj = e_object_mut(&mut existing.expr);
+    for prop in e_object(&src).properties.slice() {
+        let Some(key) = as_string(prop.key.as_ref().expect("infallible: prop has key")) else {
+            continue;
+        };
+        existing_obj.put(bump, key, prop.value.expect("infallible: prop has value"))?;
+    }
+    Ok(true)
 }
 
 fn paths_array(paths: &[&'static [u8]]) -> Expr {

--- a/src/install/pnpm.rs
+++ b/src/install/pnpm.rs
@@ -2367,8 +2367,7 @@ fn update_package_json_after_migration(
 
     let mut copied: Vec<&'static str> = Vec::new();
 
-    // The `pnpm` block is left as it is: pnpm still reads its config from there, and bun
-    // only reads the root-level fields, so the same package.json keeps working for both.
+    // Copied, not moved: pnpm keeps reading this block, bun only reads the root-level fields.
     if let Some(pnpm_prop) = json.as_property(b"pnpm") {
         if pnpm_prop.expr.is_object() {
             let pnpm_obj = e_object(&pnpm_prop.expr);
@@ -2642,9 +2641,7 @@ fn data_store_dupe_expr_strings(expr: &mut Expr) {
     }
 }
 
-/// A separate object with the same entries. The root-level copy is edited afterwards
-/// (`rewrite_bare_patch_keys`, entries merged in from pnpm-workspace.yaml), and none of
-/// that may show up in the `pnpm` block it was copied from.
+/// The root-level copy gets edited further; an `Expr` from `get` would alias the `pnpm` block.
 fn copy_object(src: &Expr) -> Expr {
     let src_props = e_object(src).properties.slice();
     let mut properties = G::PropertyList::init_capacity(src_props.len());
@@ -2660,8 +2657,8 @@ fn copy_object(src: &Expr) -> Expr {
     )
 }
 
-/// Adds the entries of `src` to the root-level `field` object, creating it when absent.
-/// Returns `false` when `field` exists but is not an object, in which case nothing is written.
+/// Merges `src` into the root-level `field` object, creating it when absent.
+/// `false` when `field` exists but is not an object; nothing is written then.
 fn copy_into_root(
     json: &mut Expr,
     bump: &bun_alloc::Arena,

--- a/src/install/pnpm.rs
+++ b/src/install/pnpm.rs
@@ -2657,8 +2657,7 @@ fn copy_object(src: &Expr) -> Expr {
     )
 }
 
-/// Merges `src` into the root-level `field` object, creating it when absent.
-/// `false` when `field` exists but is not an object; nothing is written then.
+/// Merges `src` into the root-level `field` (created when absent); `false` if it is not an object.
 fn copy_into_root(
     json: &mut Expr,
     bump: &bun_alloc::Arena,

--- a/test/cli/install/migration/pnpm-lock-v9.test.ts
+++ b/test/cli/install/migration/pnpm-lock-v9.test.ts
@@ -2546,6 +2546,77 @@ snapshots:
     });
   });
 
+  // #23694: `bun update -i` migrates once to list the outdated packages, edits the root package.json through the
+  // cache, then installs, which migrates again because bun.lock is still not on disk. The editor and the second
+  // migration both used the tree the first migration had edited, which pointed into the contents it had freed.
+  test("bun update -i in a pnpm workspace migrates twice and keeps package.json intact", async () => {
+    const { packageDir } = await verdaccio.createTestDir({
+      bunfigOpts: { linker: "hoisted" },
+      files: {
+        "package.json": JSON.stringify({
+          name: "update-interactive",
+          dependencies: { "no-deps": "^1.0.0" },
+          pnpm: { overrides: { "a-dep": "1.0.1" } },
+        }),
+        "packages/a/package.json": JSON.stringify({ name: "a" }),
+        "pnpm-workspace.yaml": "packages:\n  - packages/*\n",
+        "pnpm-lock.yaml": `lockfileVersion: '9.0'
+
+overrides:
+  a-dep: 1.0.1
+
+importers:
+
+  .:
+    dependencies:
+      no-deps:
+        specifier: ^1.0.0
+        version: 1.0.0
+
+  packages/a: {}
+
+packages:
+
+  no-deps@1.0.0:
+    resolution: {integrity: ${NO_DEPS_1_0_0_INTEGRITY}}
+
+snapshots:
+
+  no-deps@1.0.0: {}
+`,
+      },
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "update", "-i"],
+      cwd: packageDir,
+      env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(packageDir, ".bun-cache") },
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    proc.stdin.write("a\r");
+    proc.stdin.end();
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("error:");
+    expect(stdout).toContain("no-deps");
+    expect(exitCode).toBe(0);
+    expect(await Bun.file(join(packageDir, "package.json")).json()).toStrictEqual({
+      name: "update-interactive",
+      dependencies: { "no-deps": "^1.1.0" },
+      pnpm: { overrides: { "a-dep": "1.0.1" } },
+      overrides: { "a-dep": "1.0.1" },
+      workspaces: ["packages/*"],
+    });
+    expect(existsSync(join(packageDir, "bun.lock"))).toBe(true);
+
+    const frozen = await run(packageDir, "install", "--frozen-lockfile");
+
+    expect(frozen.stderr).not.toContain("error:");
+    expect(frozen.exitCode).toBe(0);
+  });
+
   describe("overrides", () => {
     function overridesLockfile(overrides: string) {
       return `lockfileVersion: '9.0'

--- a/test/cli/install/migration/pnpm-lock-v9.test.ts
+++ b/test/cli/install/migration/pnpm-lock-v9.test.ts
@@ -810,9 +810,9 @@ snapshots:
       );
     });
 
-    // `bun update` migrates, then edits the cached root package.json that the migration rewrote, so the cached
-    // copy has to be re-read from the rewritten contents (a stale copy pointed into the freed previous contents).
-    test("bun update straight from pnpm-lock.yaml edits the package.json the migration rewrote", async () => {
+    // `bun update` prints the root package.json again after the install, from the tree the migration left in the
+    // cache. The pnpm block and the root-level copies both have to survive that second print.
+    test("bun update straight from pnpm-lock.yaml keeps the pnpm block and the root copies", async () => {
       const pnpm = {
         patchedDependencies: { "no-deps": "patches/no-deps.patch" },
         overrides: { "a-dep": "1.0.1" },
@@ -2546,10 +2546,9 @@ snapshots:
     });
   });
 
-  // #23694: `bun update -i` migrates once to list the outdated packages, edits the root package.json through the
-  // cache, then installs, which migrates again because bun.lock is still not on disk. The editor and the second
-  // migration both used the tree the first migration had edited, which pointed into the contents it had freed.
-  test("bun update -i in a pnpm workspace migrates twice and keeps package.json intact", async () => {
+  // `bun update -i` runs the migration twice (once to list the outdated packages, once when it installs). The second
+  // pass finds the root-level copies the first pass wrote and merges into them; the pnpm block survives both passes.
+  test("bun update -i migrates twice without duplicating the copies or touching the pnpm block", async () => {
     const { packageDir } = await verdaccio.createTestDir({
       bunfigOpts: { linker: "hoisted" },
       files: {

--- a/test/cli/install/migration/pnpm-lock-v9.test.ts
+++ b/test/cli/install/migration/pnpm-lock-v9.test.ts
@@ -785,16 +785,19 @@ snapshots:
       const { stderr, exitCode } = await migrate(packageDir);
 
       expect(stderr).not.toContain("is not in patchedDependencies");
+      expect(stderr).toContain("copied pnpm.patchedDependencies to patchedDependencies in package.json");
       expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
       expect(exitCode).toBe(0);
 
       const bunLock = await bunLockOf(packageDir);
       expect(bunLock).toContain(`"patchedDependencies": {\n    "no-deps@1.0.1": "patches/no-deps.patch",\n  }`);
 
+      // The versioned key only goes to the root; pnpm keeps reading the bare key from its own block.
       const packageJson = await Bun.file(join(packageDir, "package.json")).json();
       expect(packageJson).toStrictEqual({
         name: "patch-path-in-package-json",
         dependencies: { "no-deps": "^1.0.0" },
+        pnpm: { patchedDependencies: { "no-deps": "patches/no-deps.patch" } },
         patchedDependencies: { "no-deps@1.0.1": "patches/no-deps.patch" },
       });
 
@@ -805,6 +808,55 @@ snapshots:
       expect(await Bun.file(join(packageDir, "node_modules/no-deps/index.js")).text()).toStartWith(
         "globalThis.patchedByMigration = true;\n",
       );
+    });
+
+    // `bun update` migrates, then edits the cached root package.json that the migration rewrote, so the cached
+    // copy has to be re-read from the rewritten contents (a stale copy pointed into the freed previous contents).
+    test("bun update straight from pnpm-lock.yaml edits the package.json the migration rewrote", async () => {
+      const pnpm = {
+        patchedDependencies: { "no-deps": "patches/no-deps.patch" },
+        overrides: { "a-dep": "1.0.1" },
+      };
+      const { packageDir } = await verdaccio.createTestDir({
+        bunfigOpts: { linker: "hoisted" },
+        files: {
+          "package.json": JSON.stringify({
+            name: "update-after-migration",
+            dependencies: { "no-deps": "^1.0.0" },
+            pnpm,
+          }),
+          "patches/no-deps.patch": NO_DEPS_INDEX_PATCH,
+          "pnpm-lock.yaml": bareHashNoDepsLockfile("no-deps").replace(
+            "importers:",
+            "overrides:\n  a-dep: 1.0.1\n\nimporters:",
+          ),
+        },
+      });
+
+      const update = await run(packageDir, "update");
+
+      expect(update.stderr).toContain(
+        "copied pnpm.overrides to overrides, pnpm.patchedDependencies to patchedDependencies in package.json",
+      );
+      expect(update.stderr).toContain("migrated lockfile from pnpm-lock.yaml");
+      expect(update.stderr).not.toContain("error:");
+      expect(update.stdout).toContain("no-deps@1.0.1");
+      expect(update.exitCode).toBe(0);
+      expect(await Bun.file(join(packageDir, "package.json")).json()).toStrictEqual({
+        name: "update-after-migration",
+        dependencies: { "no-deps": "^1.0.1" },
+        pnpm,
+        overrides: pnpm.overrides,
+        patchedDependencies: { "no-deps@1.0.1": "patches/no-deps.patch" },
+      });
+      expect(await Bun.file(join(packageDir, "node_modules/no-deps/index.js")).text()).toStartWith(
+        "globalThis.patchedByMigration = true;\n",
+      );
+
+      const frozen = await run(packageDir, "install", "--frozen-lockfile");
+
+      expect(frozen.stderr).not.toContain("error:");
+      expect(frozen.exitCode).toBe(0);
     });
 
     test("versioned lockfile key falls back to the bare config key", async () => {
@@ -2515,7 +2567,7 @@ importers:
       return bunLock.slice(start, end + "\n  },".length);
     }
 
-    // pnpm/pnpm#5928 (`-` removes the dependency) is warned once, with a location, when bun install reads the moved package.json overrides; pnpm/pnpm#6774 (`name@range` keys) migrates as ranged rules
+    // pnpm/pnpm#5928 (`-` removes the dependency) is warned once, with a location, when bun install reads the copied package.json overrides; pnpm/pnpm#6774 (`name@range` keys) migrates as ranged rules
     test.concurrent("removal values are dropped; name@range keys migrate as ranged rules", async () => {
       const overrides = {
         "left-pad": "-",
@@ -2538,12 +2590,13 @@ importers:
       const { stderr, exitCode } = await migrate(String(dir));
 
       expect(stderr).not.toContain("warn:");
-      expect(stderr).toContain("moved pnpm.overrides to overrides in package.json");
+      expect(stderr).toContain("copied pnpm.overrides to overrides in package.json");
       expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
       expect(exitCode).toBe(0);
 
       expect(await Bun.file(join(String(dir), "package.json")).json()).toStrictEqual({
         name: "overrides-unsupported",
+        pnpm: { overrides },
         overrides,
       });
 
@@ -2572,6 +2625,76 @@ importers:
       expect(install.stderr).toMatch(/package\.json:\d+:\d+/);
       expect(install.stderr.split("warn:").length - 1).toBe(1);
       expect(install.exitCode).toBe(0);
+    });
+
+    // pnpm reads `pnpm.overrides` and `pnpm.patchedDependencies` from package.json and ignores the root-level
+    // fields, so removing them from the `pnpm` block breaks `pnpm install --frozen-lockfile` for everyone still on
+    // pnpm (ERR_PNPM_LOCKFILE_CONFIG_MISMATCH). The block has to survive the migration as it was.
+    test.concurrent("the pnpm block in package.json is left as it was", async () => {
+      const pnpm = {
+        overrides: { "no-deps": "1.0.0" },
+        patchedDependencies: { "one-dep@1.0.0": "patches/one-dep.patch" },
+        onlyBuiltDependencies: ["one-dep"],
+      };
+      using dir = tempDir("pnpm-v9-pnpm-block-kept", {
+        "package.json": JSON.stringify({ name: "pnpm-block-kept", private: true, pnpm }),
+        "pnpm-lock.yaml": overridesLockfile("  no-deps: 1.0.0"),
+      });
+      using onlyMigratedKeys = tempDir("pnpm-v9-pnpm-block-only-migrated-keys", {
+        "package.json": JSON.stringify({ name: "pnpm-block-only-migrated-keys", pnpm: { overrides: pnpm.overrides } }),
+        "pnpm-lock.yaml": overridesLockfile("  no-deps: 1.0.0"),
+      });
+
+      const { stderr, exitCode } = await migrate(String(dir));
+
+      expect(stderr).not.toContain("warn:");
+      expect(stderr).toContain(
+        "copied pnpm.overrides to overrides, pnpm.patchedDependencies to patchedDependencies in package.json",
+      );
+      expect(exitCode).toBe(0);
+      expect(await Bun.file(join(String(dir), "package.json")).json()).toStrictEqual({
+        name: "pnpm-block-kept",
+        private: true,
+        pnpm,
+        overrides: pnpm.overrides,
+        patchedDependencies: pnpm.patchedDependencies,
+      });
+
+      const onlyMigrated = await migrate(String(onlyMigratedKeys));
+
+      expect(onlyMigrated.stderr).toContain("copied pnpm.overrides to overrides in package.json");
+      expect(onlyMigrated.exitCode).toBe(0);
+      expect(await Bun.file(join(String(onlyMigratedKeys), "package.json")).json()).toStrictEqual({
+        name: "pnpm-block-only-migrated-keys",
+        pnpm: { overrides: pnpm.overrides },
+        overrides: pnpm.overrides,
+      });
+    });
+
+    // pnpm 10 merges `pnpm.overrides` with the `overrides` of pnpm-workspace.yaml, and the lockfile records the
+    // merged set. The yaml entries belong in the root-level copy only.
+    test.concurrent("pnpm-workspace.yaml overrides go into the root copy, not into the pnpm block", async () => {
+      using dir = tempDir("pnpm-v9-overrides-package-json-and-workspace-yaml", {
+        "package.json": JSON.stringify({
+          name: "overrides-package-json-and-workspace-yaml",
+          pnpm: { overrides: { "no-deps": "1.0.0" } },
+        }),
+        "pnpm-workspace.yaml": "overrides:\n  a-dep: 1.0.1\n",
+        "pnpm-lock.yaml": overridesLockfile("  no-deps: 1.0.0\n  a-dep: 1.0.1"),
+      });
+
+      const { stderr, exitCode } = await migrate(String(dir));
+
+      expect(stderr).not.toContain("warn:");
+      expect(stderr).toContain(
+        "copied pnpm.overrides to overrides, pnpm-workspace.yaml overrides to overrides in package.json",
+      );
+      expect(exitCode).toBe(0);
+      expect(await Bun.file(join(String(dir), "package.json")).json()).toStrictEqual({
+        name: "overrides-package-json-and-workspace-yaml",
+        pnpm: { overrides: { "no-deps": "1.0.0" } },
+        overrides: { "no-deps": "1.0.0", "a-dep": "1.0.1" },
+      });
     });
 
     test.concurrent("parent selectors become nested rules", async () => {
@@ -2611,7 +2734,7 @@ importers:
       const deep = await migrate(String(tooDeep));
 
       expect(deep.stderr).not.toContain("warn:");
-      expect(deep.stderr).toContain("moved pnpm.overrides to overrides in package.json");
+      expect(deep.stderr).toContain("copied pnpm.overrides to overrides in package.json");
       expect(deep.stderr).toContain("migrated lockfile from pnpm-lock.yaml");
       expect(deep.exitCode).toBe(0);
       expect(await bunLockOf(String(tooDeep))).not.toContain("a>b");
@@ -2803,7 +2926,7 @@ importers:
 
     const { stderr, exitCode } = await run(packageDir, "add", "no-deps@1.0.0");
 
-    expect(stderr).toContain("moved pnpm-workspace.yaml to workspaces");
+    expect(stderr).toContain("copied pnpm-workspace.yaml to workspaces");
     expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
     expect(stderr).not.toContain("error:");
     expect(await Bun.file(join(packageDir, "package.json")).json()).toStrictEqual({

--- a/test/cli/install/nested-overrides.test.ts
+++ b/test/cli/install/nested-overrides.test.ts
@@ -1553,7 +1553,7 @@ snapshots:
   }
 
   const migratedLine = /\[[\d.]+m?s\] migrated lockfile from pnpm-lock\.yaml\n/;
-  const movedOverridesLine = "moved pnpm.overrides to overrides in package.json";
+  const copiedOverridesLine = "copied pnpm.overrides to overrides in package.json";
 
   test("pnpm-lock.yaml parent>child overrides become nested rules that package.json agrees with", async () => {
     const dir = await project(
@@ -1565,7 +1565,7 @@ snapshots:
     expect(migrated.err).not.toContain("warn:");
     expect(migrated.err).not.toContain("error:");
     expect(migrated.err).toMatch(migratedLine);
-    expect(occurrences(migrated.err, movedOverridesLine)).toBe(1);
+    expect(occurrences(migrated.err, copiedOverridesLine)).toBe(1);
     expect(migrated.exitCode).toBe(0);
     const text = await lock(dir);
     expect(text).toContain('"one-dep": {');
@@ -1575,6 +1575,7 @@ snapshots:
     expect(JSON.parse(packageJson)).toStrictEqual({
       name: "nested-overrides",
       dependencies: { "one-dep": "1.0.0" },
+      pnpm: { overrides: { "one-dep>no-deps": "2.0.0" } },
       overrides: { "one-dep>no-deps": "2.0.0" },
     });
     await installOk(dir, "--frozen-lockfile");
@@ -1589,7 +1590,7 @@ snapshots:
     const migrated = await migrate(dir);
     expect(migrated.err).not.toContain("warn:");
     expect(migrated.err).not.toContain("error:");
-    expect(occurrences(migrated.err, movedOverridesLine)).toBe(1);
+    expect(occurrences(migrated.err, copiedOverridesLine)).toBe(1);
     expect(migrated.exitCode).toBe(0);
     const text = await lock(dir);
     expect(text).toContain('"one-dep": {');
@@ -1607,7 +1608,7 @@ snapshots:
     const migrated = await migrate(dir);
     expect(migrated.err).not.toContain("warn:");
     expect(migrated.err).not.toContain("error:");
-    expect(occurrences(migrated.err, movedOverridesLine)).toBe(1);
+    expect(occurrences(migrated.err, copiedOverridesLine)).toBe(1);
     expect(migrated.exitCode).toBe(0);
     const text = await lock(dir);
     expect(text).toContain('"lockfileVersion": 3');
@@ -1638,7 +1639,7 @@ snapshots:
       })
       .then(({ packageDir }) => packageDir);
     const migrated = await migrate(dir);
-    expect(occurrences(migrated.err, movedOverridesLine)).toBe(1);
+    expect(occurrences(migrated.err, copiedOverridesLine)).toBe(1);
     expect(migrated.err).not.toContain("error:");
     expect(migrated.exitCode).toBe(0);
     const packageJson = await packageJsonText(dir);
@@ -1649,10 +1650,11 @@ snapshots:
       name: "nested-overrides",
       dependencies: { "one-dep": "1.0.0" },
       overrides: { "a-dep": "1.0.1", "one-dep>no-deps": "2.0.0" },
+      pnpm: { overrides: { "one-dep>no-deps": "2.0.0" } },
     });
   });
 
-  test("an empty pnpm.overrides is not moved and package.json is not announced as modified", async () => {
+  test("an empty pnpm.overrides is not copied and package.json is not announced as modified", async () => {
     const dir = await project({ dependencies: { "one-dep": "1.0.0" }, pnpm: { overrides: {} } }, "hoisted", {
       "pnpm-lock.yaml": await pnpmLock({ noDepsVersion: "1.0.1" }),
     });
@@ -1660,7 +1662,7 @@ snapshots:
     const migrated = await migrate(dir);
     expect(migrated.err).not.toContain("warn:");
     expect(migrated.err).not.toContain("error:");
-    expect(migrated.err).not.toContain(movedOverridesLine);
+    expect(migrated.err).not.toContain(copiedOverridesLine);
     expect(migrated.err).toMatch(migratedLine);
     expect(migrated.exitCode).toBe(0);
     expect(await packageJsonText(dir)).toBe(before);
@@ -1696,14 +1698,14 @@ snapshots:
       ),
     );
 
-  test("bun install warns once per rejected rule that the migration moved into package.json", async () => {
+  test("bun install warns once per rejected rule that the migration copied into package.json", async () => {
     const dir = await rejectedRulesProject();
     const { err, exitCode } = await install(dir);
     expect(occurrences(err, 'warn: Removing "left-pad" with "-" is not supported')).toBe(1);
     expect(occurrences(err, 'warn: Bun currently only supports one level of nested "overrides"')).toBe(1);
     expect(occurrences(err, "warn:")).toBe(2);
     expect(err).toMatch(migratedLine);
-    expect(occurrences(err, movedOverridesLine)).toBe(1);
+    expect(occurrences(err, copiedOverridesLine)).toBe(1);
     expect(err).not.toContain("error:");
     expect(exitCode).toBe(0);
     expect((await file(join(dir, "package.json")).json()).overrides).toStrictEqual({


### PR DESCRIPTION
### Problem

- `bun install` / `bun pm migrate` on a project with a `pnpm-lock.yaml` copies `pnpm.overrides` and `pnpm.patchedDependencies` to the root of `package.json` and then removes them from the `"pnpm"` block (`update_package_json_after_migration`, `src/install/pnpm.rs`; the block itself is removed when nothing else is in it). Since #38333 this is announced as `moved pnpm.overrides to overrides in package.json`; the removal itself dates back to the original migration (#22262).
- pnpm reads its configuration only from the `"pnpm"` block and ignores the root-level fields. After one `bun install` is committed, `pnpm install --frozen-lockfile` fails for everyone still on pnpm with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`, and a plain `pnpm install` drops the `overrides:` section from `pnpm-lock.yaml`, so the pins stop applying.
- bun never reads the `"pnpm"` block (`OverrideMap` and `Package` only read the root-level `overrides` / `resolutions` / `patchedDependencies`; `bun-workspaces.test.ts` pins that root `pnpm.overrides` is ignored), so leaving the block in place costs nothing.

### Fix

- `pnpm.overrides` / `pnpm.patchedDependencies` are copied and the `"pnpm"` block is left as it was. The block-pruning code is deleted.
- `copy_object` gives the root a separate object. The `Expr` returned by `get` aliases the object inside the block, so without the copy, `rewrite_bare_patch_keys` (bare `name` keys become `name@version` for bun) and the merge of `pnpm-workspace.yaml` entries would now show up inside the `"pnpm"` block.
- The four identical merge-or-create blocks (package.json and `pnpm-workspace.yaml`, overrides and patchedDependencies) share `copy_into_root`. `needs_update` is gone: the file is written when the list of copied items is not empty. The message reads `copied ... in package.json`, since nothing it lists is modified at its source. The `moved` assertion that #40029 added to `bun add migrates pnpm-workspace.yaml ...` is updated with it.
- Docs: the migration section of `docs/pm/cli/install.mdx` says the fields are copied and the `"pnpm"` block is kept.
- Verified with `test/cli/install/migration/pnpm-lock-v9.test.ts` (88 pass) and `test/cli/install/nested-overrides.test.ts` (144 pass). Fail on main, pass here: `the pnpm block in package.json is left as it was` (a block with other settings, and a block that holds only the migrated keys), `pnpm-workspace.yaml overrides go into the root copy, not into the pnpm block`, `bare hash whose path is only in package.json pnpm.patchedDependencies` (the bare key stays in the block, the root gets `no-deps@1.0.1`), the two `bun update` tests (the block survives `bun update`'s own re-print of package.json, and `update -i`'s second migration pass merges into the copies instead of duplicating them), and the existing assertions that encoded the removal. Also ran `pnpm-lock-migration`, `migrate`, `lockfile-only`, `pnpm-migration`, `pnpm-comprehensive`, `pnpm-migration-complete`.

### Background

- pnpm 9 keeps overrides and patched dependencies under the `"pnpm"` key of `package.json`; pnpm 10 also accepts them in `pnpm-workspace.yaml`, and the lockfile records the merged set. bun uses npm's root-level `overrides` and its own root-level `patchedDependencies`, which is why the migration writes root-level copies. The migration leaves `pnpm-lock.yaml` and `pnpm-workspace.yaml` untouched; the `"pnpm"` block was the one place it edited pnpm's own configuration.
- `update_package_json_after_migration` edits the parsed tree of the root `package.json` in place and prints it. Since #40029 it then re-parses the printed text into the cache entry, so the copies made here only have to live until that print.
- A bare `patchedDependencies` key (`"no-deps"`) is legal for pnpm; `bun.lock` keys patches by `name@version`, so the migration rewrites bare keys in the root copy using the version the lockfile resolved.
- #38754 (open) rewrites other parts of the same function; whichever of the two lands second needs a small rebase, and its `moved ...` test strings become `copied ...` once this is in.

<details>
<summary>Notes</summary>

History of this PR: it originally also carried the `print_package_json_into_cache_entry` + `reparse_root` write-back (a use-after-free hit by `bun update` and by #23694's `bun update -i`, found while testing this change) and a fix for the block-scoped `pnpm-workspace.yaml` arena raised in review. Both landed on main on their own while this was open (#40029 and #39789) and were dropped from here on rebase, so this PR is only the behavior change again. #23694 is fixed by #40029.

Reproduction on bun 1.4.0 (release):

```
package.json: {"name":"r","private":true,"dependencies":{"a":"1.0.0"},
               "pnpm":{"overrides":{"b":"1.0.0"},"onlyBuiltDependencies":["a"]}}
pnpm-lock.yaml: lockfileVersion: '9.0' / overrides: {b: 1.0.0} / importers: {.: {}}

$ bun pm migrate
$ cat package.json
{
  ...
  "pnpm": {
    "onlyBuiltDependencies": ["a"]      <- overrides removed from the pnpm block
  },
  "overrides": { "b": "1.0.0" }         <- added at the root, which pnpm does not read
}
```

With this change the `pnpm` block is unchanged, the root-level `overrides` is added, and the line printed is `copied pnpm.overrides to overrides in package.json`. `bun update -i` prints that line twice because it runs the migration twice; the second pass merges identical values and leaves the file as the first pass wrote it.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 6 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 13 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/cli/install/migration/pnpm-lock-v9.test.ts" test/cli/install/nested-overrides.test.ts
bun test v1.4.1 (4448a2e21)

test/cli/install/nested-overrides.test.ts:
(pass) syntax > $ref inside a nested value resolves against the root's dependencies [774.66ms]
(pass) syntax > $ref inside a nested value that names nothing warns and is skipped [985.16ms]
(pass) syntax > npm object scopes the rule to the parent's edge [1156.98ms]
(pass) syntax > "." overrides the parent itself next to its children [1173.37ms]
(pass) syntax > parent range is matched against the parent's resolved version, through an alias [1299.95ms]
(pass) syntax > yarn resolutions path one-dep/no-deps > applies to one-dep's edge only [1021.63ms]
(pass) syntax > yarn resolutions path **/one-dep/**/no-deps > applies to one-dep's edge only [882.93ms]
(pass) syntax > yarn resolutions path one-dep@npm:1.0.0/no-deps > applies to one-dep's edge only [906.05ms]
(pass) syntax > yarn resolutions path **/one-dep/no-deps > applies to one-dep's edge only [1205.71ms]
(pass) syntax > yarn
... (truncated)

release without fix: 14 FAILED
bun test v1.4.0-canary.1 (4448a2e21)

test/cli/install/nested-overrides.test.ts:
(pass) syntax > $ref inside a nested value resolves against the root's dependencies [179.22ms]
(pass) syntax > $ref inside a nested value that names nothing warns and is skipped [206.54ms]
(pass) syntax > the same rule spelled in two syntaxes: last one wins and one row is written [227.64ms]
(pass) syntax > a "//" comment key in overrides > is ignored without a warning and never reaches bun.lock [52.44ms]
(pass) syntax > pnpm selector one-dep@<2 >=1>no-deps > applies and writes the same bun.lock as the object form [256.05ms]
(pass) syntax > pnpm parent>child selector [268.71ms]
(pass) syntax > yarn resolutions path **/one-dep/**/no-deps > applies to one-dep's edge only [268.93ms]
(pass) syntax > pnpm selector one-dep@1 >0>no-deps > applies and writes the same bun.lock as the object form [281.91ms]
(pass) syntax > yarn resolutions path one-dep@npm:1.0.0/no-deps > applies to one-dep's edge only [282.50ms]
(pass) syntax > yarn resolutions path with scoped parent and child [285.37ms]
(pass) syntax > npm object scopes the rule to the parent's edge [286.28ms]
(pass) syntax > "." overrides the 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/cli/install/migration/pnpm-lock-v9.test.ts" test/cli/install/nested-overrides.test.ts
bun test v1.4.1 (4448a2e21)

test/cli/install/nested-overrides.test.ts:
(pass) syntax > $ref inside a nested value resolves against the root's dependencies [656.47ms]
(pass) syntax > "." overrides the parent itself next to its children [1023.18ms]
(pass) syntax > parent range is matched against the parent's resolved version, through an alias [1049.84ms]
(pass) syntax > $ref inside a nested value that names nothing warns and is skipped [1070.21ms]
(pass) syntax > npm object scopes the rule to the parent's edge [1223.20ms]
(pass) syntax > yarn resolutions path one-dep/no-deps > applies to one-dep's edge only [914.83ms]
(pass) syntax > yarn resolutions path **/one-dep/**/no-deps > applies to one-dep's edge only [798.44ms]
(pass) syntax > yarn resolutions path **/one-dep/no-deps > applies to one-dep's edge only [844.07ms]
(pass) syntax > pnpm parent>child selector [493.49ms]
(pass) syntax > yarn resolutions path one-dep@npm:1.0.0/no-deps > applies t
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 664ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_sys_jsc v0.0.0 (/workspace/bun/src/sys_jsc)
[1m[92m   Compiling[0m bun_http_jsc v0.0.0 (/workspace/bun/src/http_jsc)
[1m[92m   Compiling[0m bun_sql_jsc v0.0.0 (/workspace/bun/src/sql_jsc)
[1m[92m   Compiling[0m bun_patch_jsc v0.0.0 (/workspace/bun/src/patch_jsc)
[1m[92m   Compiling[0m bun_bundler_jsc v0.0.0 (/workspace/bun/src/bundler_jsc)
[1m[92m   Compiling[0m bun_semver_jsc v0.0.0 (/workspace/bun/src/semver_jsc)
[1m[92m   Compiling[0m bun_css_jsc v0.0.0 (/workspace/bun/src/css_jsc
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/pm/cli/install.mdx                         |  12 +-
 src/install/pnpm.rs                             | 253 +++++++-----------------
 test/cli/install/migration/pnpm-lock-v9.test.ts | 201 ++++++++++++++++++-
 test/cli/install/nested-overrides.test.ts       |  20 +-
 4 files changed, 285 insertions(+), 201 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 6

<details><summary>evidence per changed file</summary>

```
file                                             reads  edits  tests
docs/pm/cli/install.mdx                              2      3      0
src/install/pnpm.rs                                 19     18      0
test/cli/install/migration/pnpm-lock-v9.test.ts      8     15      0
test/cli/install/nested-overrides.test.ts            2      5      0
```

</details>

<!-- robobun:evidence:end -->