### PR TITLE
publish: accept basic auth credentials from .npmrc and bunfig.toml

### DIFF
--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -868,6 +868,7 @@ impl PublishCommand {
         let registry_url = registry.url.url();
 
         if registry.token.is_empty()
+            && registry.auth.is_empty()
             && (registry_url.password.is_empty() || registry_url.username.is_empty())
         {
             return Err(PublishError::NeedAuth);

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -1236,6 +1236,77 @@ test("dist.tarball in the published manifest does not include userinfo from the 
   expect(exitCode).toBe(0);
 });
 
+describe.concurrent("basic auth", () => {
+  // Every spelling below makes `bun install` send `Authorization: Basic`, and npm publishes with
+  // all of them. `bun publish` used to stop with "missing authentication" unless a bearer token
+  // was configured, before sending anything. https://github.com/oven-sh/bun/issues/18670
+  const username = "alice";
+  const password = "s3cret";
+  const userPass = Buffer.from(`${username}:${password}`).toString("base64");
+
+  const configs: [name: string, files: (host: string) => Record<string, string>][] = [
+    [".npmrc _auth", host => ({ ".npmrc": `registry=http://${host}/\n//${host}/:_auth=${userPass}\n` })],
+    [
+      ".npmrc username and _password",
+      host => ({
+        ".npmrc": [
+          `registry=http://${host}/`,
+          `//${host}/:username=${username}`,
+          `//${host}/:_password=${Buffer.from(password).toString("base64")}`,
+          "",
+        ].join("\n"),
+      }),
+    ],
+    [".npmrc registry url with userinfo", host => ({ ".npmrc": `registry=http://${username}:${password}@${host}/\n` })],
+    [
+      "bunfig.toml registry username and password",
+      host => ({
+        "bunfig.toml": Bun.TOML.stringify({
+          install: { cache: false, registry: { url: `http://${host}/`, username, password } },
+        }),
+      }),
+    ],
+  ];
+
+  async function publishWith(files: (host: string) => Record<string, string>) {
+    const requests: string[] = [];
+    using mock = Bun.serve({
+      port: 0,
+      fetch(req) {
+        requests.push(`${req.method} ${new URL(req.url).pathname} ${req.headers.get("authorization")}`);
+        return new Response("OK", { status: 200 });
+      },
+    });
+
+    using dir = tempDir("publish-basic-auth", {
+      "package.json": JSON.stringify({ name: "basic-auth-pkg", version: "1.0.0" }),
+      // Empty home directory so the machine's own .npmrc / bunfig.toml cannot supply credentials.
+      "home/.keep": "",
+      ...files(`localhost:${mock.port}`),
+    });
+    const home = join(String(dir), "home");
+
+    const result = await publish({ ...env, HOME: home, USERPROFILE: home, XDG_CONFIG_HOME: home }, String(dir));
+    return { ...result, requests };
+  }
+
+  test.each(configs)("%s", async (_, files) => {
+    const { out, err, exitCode, requests } = await publishWith(files);
+    expect(err).not.toContain("error:");
+    expect(out).toContain(" + basic-auth-pkg@1.0.0");
+    expect(requests).toEqual([`PUT /basic-auth-pkg Basic ${userPass}`]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("still refuses to publish without any credentials", async () => {
+    const { out, err, exitCode, requests } = await publishWith(host => ({ ".npmrc": `registry=http://${host}/\n` }));
+    expect(err).toContain("error: missing authentication (run `bunx npm login`)");
+    expect(out).not.toContain(" + basic-auth-pkg@1.0.0");
+    expect(requests).toEqual([]);
+    expect(exitCode).toBe(1);
+  });
+});
+
 describe("--tolerate-republish", async () => {
   test("republishing normally fails", async () => {
     const { packageDir, packageJson } = await registry.createTestDir();


### PR DESCRIPTION
Related: #18670 (the `_auth` / Nexus comments on it are this bug; the `publishConfig.registry` report itself is #38322). Redoes #26178, which was closed as stale when the Zig sources went away.

### Problem
- `bun publish` fails with ``error: missing authentication (run `bunx npm login`)`` and sends no request when the registry credentials are Basic auth rather than a bearer token. `bun install` and `bun pm whoami` accept the same configuration, and `npm publish` works with the same `.npmrc`. Same on 1.3.14 and current `main`.
- Affected spellings, all of which `bun install` sends as `Authorization: Basic`: `.npmrc` `//host/:_auth=`, `.npmrc` `//host/:username=` + `//host/:_password=`, `.npmrc` `registry=http://user:pass@host/`, and bunfig.toml `install.registry = { url, username, password }`. Nexus and Artifactory setup snippets commonly hand out the first two.
- Cause: the pre-flight check in `PublishCommand::publish` (`src/runtime/cli/publish_command.rs:870`) only looks at `registry.token` (plus userinfo left in the registry URL). Every spelling above ends up in `Scope.auth` (`Scope::from_api`, `src/install/npm.rs:473`), which the check ignores, so it returns `NeedAuth` before any request is built.
- The request builders in the same file (`construct_publish_headers`, `check_package_version_exists`) already send `Basic <auth>` when `token` is empty, so only the pre-flight check was out of step.

### Fix
- The check also accepts a non-empty `registry.auth`. Nothing else changes: a registry with neither credential still gets the same error and still sends nothing.
- Test: `test/cli/install/bun-publish.test.ts`, `describe("basic auth")`. Each of the four spellings publishes against an in-process registry that records every request, and the test asserts the registry saw exactly `PUT /basic-auth-pkg` with `Authorization: Basic base64(alice:s3cret)`. A fifth case pins that no credentials still produces the error and no request. `HOME`/`XDG_CONFIG_HOME` point at an empty directory so the machine's own config cannot supply credentials.
- `USE_SYSTEM_BUN=1`: the four credential cases fail with the error above, the no-credential case passes. `bun bd test`: all five pass. The whole of `bun-publish.test.ts` (44 tests) passes with the debug build.

### Background
- A `Scope` (`npm::registry::Scope`) is bun's resolved registry: URL plus credentials. `token` holds a bearer token (`_authToken`, bunfig `token`, `NPM_CONFIG_TOKEN`); `auth` holds the base64 `user:password` that goes into a Basic header. The `.npmrc` loader decodes `_auth` into username/password, and `Scope::from_api` re-encodes any username/password pair into `auth`, so all the Basic spellings converge on that one field.
- Not changed here: a registry URL with userinfo given through `--registry` or `npm_config_registry` passes this check (the URL clause) but never turns into an `Authorization` header on any command; that is a separate pre-existing issue and is tracked separately. `.npmrc`/bunfig `registry=` strings with userinfo are split into username/password at parse time and are covered by this fix.
- #33869 (npmrc path-walk rewrite) carries the same one-line change to this check; landing this first leaves it a trivial conflict to resolve there.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-publish.test.ts

<!-- robobun:evidence:end -->