### PR TITLE
bundler: fail the build when an entry point has no module to bundle

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2160,6 +2160,19 @@ pub mod bv2_impl {
             );
         }
 
+        /// Callers require an entry point, so none after parsing means one was dropped without an error.
+        fn fail_if_no_entry_points(&self) -> Result<(), Error> {
+            if !self.graph.entry_points.is_empty() {
+                return Ok(());
+            }
+            self.transpiler.log_mut().add_error(
+                None,
+                bun_ast::Loc::EMPTY,
+                "None of the entry points could be bundled",
+            );
+            Err(crate::Error::BuildFailed)
+        }
+
         /// `BUN_THREADPOOL_STATS=1` instrumentation hook — dump aggregate worker
         /// idle/busy time since the previous call. No-op when env var unset.
         #[inline]
@@ -3911,7 +3924,7 @@ pub mod bv2_impl {
                 // sidestep for the `&mut self` overlap.
                 this.enqueue_entry_points_normal(unsafe { &*entry_points })?;
 
-                // Drain before failing on entry point errors: teardown must not race the runtime parse.
+                // Like `run_from_js_in_new_thread`: drain the pool, then report entry point errors.
                 this.wait_for_parse();
                 this.dump_pool_stats("parse");
 
@@ -3923,6 +3936,7 @@ pub mod bv2_impl {
                 if this.transpiler.log().has_errors() {
                     return Err(crate::Error::BuildFailed);
                 }
+                this.fail_if_no_entry_points()?;
 
                 this.scan_for_secondary_paths();
 
@@ -4082,7 +4096,7 @@ pub mod bv2_impl {
 
                 this.enqueue_entry_points_bake_production(entry_points)?;
 
-                // Entry point errors are reported after the drain; see `generate_from_cli`.
+                // Drain the pool, then report entry point errors (as `generate_from_cli` does).
                 this.wait_for_parse();
 
                 if this.transpiler.log().has_errors() {
@@ -4856,23 +4870,6 @@ pub mod bv2_impl {
                     } else {
                         drop(result.namespace);
                         drop(result.path);
-
-                        // Same error as esbuild; otherwise the entry point silently vanishes.
-                        if resolve.import_record.kind == ImportKind::EntryPointBuild {
-                            // No importer for entry points; key the failure by the entry point.
-                            this.log_for_resolution_failures(
-                                &resolve.import_record.specifier,
-                                resolve.import_record.original_target.bake_graph(),
-                            )
-                            .add_error_fmt(
-                                None,
-                                bun_ast::Loc::EMPTY,
-                                format_args!(
-                                    "The entry point {} cannot be marked as external",
-                                    bun_core::fmt::quote(&resolve.import_record.specifier),
-                                ),
-                            );
-                        }
                     }
 
                     if let Some(source_index) = out_source_index {
@@ -5065,6 +5062,7 @@ pub mod bv2_impl {
             if self.transpiler.log().errors > 0 {
                 return Err(crate::Error::BuildFailed);
             }
+            self.fail_if_no_entry_points()?;
 
             self.scan_for_secondary_paths();
 

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -3911,10 +3911,10 @@ pub mod bv2_impl {
                 // sidestep for the `&mut self` overlap.
                 this.enqueue_entry_points_normal(unsafe { &*entry_points })?;
 
-                if this.transpiler.log().has_errors() {
-                    return Err(crate::Error::BuildFailed);
-                }
-
+                // Entry point errors are reported after the pool drains: the
+                // runtime parse is already scheduled, and tearing the workers
+                // down while one is still setting itself up reads a
+                // half-initialized `Worker` out of `workers_assignments`.
                 this.wait_for_parse();
                 this.dump_pool_stats("parse");
 
@@ -4085,10 +4085,7 @@ pub mod bv2_impl {
 
                 this.enqueue_entry_points_bake_production(entry_points)?;
 
-                if this.transpiler.log().has_errors() {
-                    return Err(crate::Error::BuildFailed);
-                }
-
+                // No early return before the drain; see `generate_from_cli`.
                 this.wait_for_parse();
 
                 if this.transpiler.log().has_errors() {
@@ -4862,6 +4859,27 @@ pub mod bv2_impl {
                     } else {
                         drop(result.namespace);
                         drop(result.path);
+
+                        // An external entry point has nothing to bundle; the build
+                        // drivers only find out about a dropped entry point from
+                        // the log. Same error as esbuild.
+                        if resolve.import_record.kind == ImportKind::EntryPointBuild {
+                            // Entry points have no importer (`source_file` is empty);
+                            // the dev server keys the failure by the entry point's
+                            // own path, which is the specifier.
+                            this.log_for_resolution_failures(
+                                &resolve.import_record.specifier,
+                                resolve.import_record.original_target.bake_graph(),
+                            )
+                            .add_error_fmt(
+                                None,
+                                bun_ast::Loc::EMPTY,
+                                format_args!(
+                                    "The entry point {} cannot be marked as external",
+                                    bun_core::fmt::quote(&resolve.import_record.specifier),
+                                ),
+                            );
+                        }
                     }
 
                     if let Some(source_index) = out_source_index {

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -4082,7 +4082,7 @@ pub mod bv2_impl {
 
                 this.enqueue_entry_points_bake_production(entry_points)?;
 
-                // No early return before the drain; see `generate_from_cli`.
+                // Entry point errors are reported after the drain; see `generate_from_cli`.
                 this.wait_for_parse();
 
                 if this.transpiler.log().has_errors() {

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -3911,10 +3911,7 @@ pub mod bv2_impl {
                 // sidestep for the `&mut self` overlap.
                 this.enqueue_entry_points_normal(unsafe { &*entry_points })?;
 
-                // Entry point errors are reported after the pool drains: the
-                // runtime parse is already scheduled, and tearing the workers
-                // down while one is still setting itself up reads a
-                // half-initialized `Worker` out of `workers_assignments`.
+                // Drain before failing on entry point errors: teardown must not race the runtime parse.
                 this.wait_for_parse();
                 this.dump_pool_stats("parse");
 
@@ -4860,13 +4857,9 @@ pub mod bv2_impl {
                         drop(result.namespace);
                         drop(result.path);
 
-                        // An external entry point has nothing to bundle; the build
-                        // drivers only find out about a dropped entry point from
-                        // the log. Same error as esbuild.
+                        // Same error as esbuild; otherwise the entry point silently vanishes.
                         if resolve.import_record.kind == ImportKind::EntryPointBuild {
-                            // Entry points have no importer (`source_file` is empty);
-                            // the dev server keys the failure by the entry point's
-                            // own path, which is the specifier.
+                            // No importer for entry points; key the failure by the entry point.
                             this.log_for_resolution_failures(
                                 &resolve.import_record.specifier,
                                 resolve.import_record.original_target.bake_graph(),

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -456,9 +456,15 @@ impl<'a> Transpiler<'a> {
 
     /// Resolve an entry-point specifier, busting the directory cache and
     /// retrying once on failure before reporting the error to the log.
+    ///
+    /// Every failure is logged before it is returned: callers drop the entry
+    /// point on `Err`, and the build drivers decide whether to keep going from
+    /// the log alone. That includes an entry point the resolver disabled (mapped
+    /// to `false` by a package.json `"browser"` field, or a Node.js builtin that
+    /// browser builds stub out), which has no module to bundle.
     pub fn resolve_entry_point(&mut self, entry_point: &[u8]) -> crate::Result<resolver::Result> {
         match self._resolve_entry_point(entry_point) {
-            Ok(r) => Ok(r),
+            Ok(r) => self.reject_disabled_entry_point(r, entry_point),
             // Nothing that long names a directory whose cache could be stale
             // (and the join below has a PathBuffer to fit `top_level_dir/entry/..` in).
             Err(err)
@@ -515,7 +521,7 @@ impl<'a> Transpiler<'a> {
                 // Only re-query if we previously had something cached.
                 if busted {
                     if let Ok(result) = self._resolve_entry_point(entry_point) {
-                        return Ok(result);
+                        return self.reject_disabled_entry_point(result, entry_point);
                     }
                     // ignore this error, we will print the original error
                 }
@@ -532,6 +538,43 @@ impl<'a> Transpiler<'a> {
                 Err(err)
             }
         }
+    }
+
+    /// A resolver result with no usable path is a module the resolver disabled
+    /// (`Result::path` skips disabled paths). Imports of such a module become an
+    /// empty object, but an entry point has nothing to produce, so report it
+    /// like any other entry point that fails to resolve.
+    fn reject_disabled_entry_point(
+        &self,
+        resolved: resolver::Result,
+        entry_point: &[u8],
+    ) -> crate::Result<resolver::Result> {
+        if resolved.path_const().is_some() {
+            return Ok(resolved);
+        }
+
+        // The resolver gives builtins it stubs out for the browser the "node"
+        // namespace; everything else disabled comes from a "browser" map.
+        if resolved.path_pair.primary.namespace == b"node" {
+            self.log_mut().add_error_fmt(
+                None,
+                bun_ast::Loc::EMPTY,
+                format_args!(
+                    "Browser build cannot use Node.js builtin \"{}\" as an entry point. To use Node.js builtins, set target to 'node' or 'bun'",
+                    bstr::BStr::new(entry_point)
+                ),
+            );
+        } else {
+            self.log_mut().add_error_fmt(
+                None,
+                bun_ast::Loc::EMPTY,
+                format_args!(
+                    "\"{}\" is disabled due to \"browser\" field in package.json (entry point)",
+                    bstr::BStr::new(entry_point)
+                ),
+            );
+        }
+        Err(crate::Error::ResolveMessage)
     }
 
     /// Load env files and build `options.define`. Idempotent — a no-op once

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -457,11 +457,11 @@ impl<'a> Transpiler<'a> {
     /// Resolve an entry-point specifier, busting the directory cache and
     /// retrying once on failure before reporting the error to the log.
     ///
-    /// Every failure is logged before it is returned: callers drop the entry
+    /// Callers rely on every `Err` having been logged here: they drop the entry
     /// point on `Err`, and the build drivers decide whether to keep going from
-    /// the log alone. That includes an entry point the resolver disabled (mapped
-    /// to `false` by a package.json `"browser"` field, or a Node.js builtin that
-    /// browser builds stub out), which has no module to bundle.
+    /// the log alone. An entry point the resolver disabled (mapped to `false` by
+    /// a package.json `"browser"` field, or a Node.js builtin that browser builds
+    /// stub out) has no module to bundle, so it is reported the same way.
     pub fn resolve_entry_point(&mut self, entry_point: &[u8]) -> crate::Result<resolver::Result> {
         match self._resolve_entry_point(entry_point) {
             Ok(r) => self.reject_disabled_entry_point(r, entry_point),

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -550,7 +550,7 @@ impl<'a> Transpiler<'a> {
                 None,
                 bun_ast::Loc::EMPTY,
                 format_args!(
-                    "Browser build cannot use Node.js builtin \"{}\" as an entry point. To use Node.js builtins, set target to 'node' or 'bun'",
+                    "Cannot use Node.js builtin \"{}\" as an entry point",
                     bstr::BStr::new(entry_point)
                 ),
             );

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -456,12 +456,6 @@ impl<'a> Transpiler<'a> {
 
     /// Resolve an entry-point specifier, busting the directory cache and
     /// retrying once on failure before reporting the error to the log.
-    ///
-    /// Callers rely on every `Err` having been logged here: they drop the entry
-    /// point on `Err`, and the build drivers decide whether to keep going from
-    /// the log alone. An entry point the resolver disabled (mapped to `false` by
-    /// a package.json `"browser"` field, or a Node.js builtin that browser builds
-    /// stub out) has no module to bundle, so it is reported the same way.
     pub fn resolve_entry_point(&mut self, entry_point: &[u8]) -> crate::Result<resolver::Result> {
         match self._resolve_entry_point(entry_point) {
             Ok(r) => self.reject_disabled_entry_point(r, entry_point),
@@ -540,10 +534,7 @@ impl<'a> Transpiler<'a> {
         }
     }
 
-    /// A resolver result with no usable path is a module the resolver disabled
-    /// (`Result::path` skips disabled paths). Imports of such a module become an
-    /// empty object, but an entry point has nothing to produce, so report it
-    /// like any other entry point that fails to resolve.
+    /// A disabled module (no usable path) imports as `{}`, but an entry point has nothing to emit.
     fn reject_disabled_entry_point(
         &self,
         resolved: resolver::Result,
@@ -553,8 +544,7 @@ impl<'a> Transpiler<'a> {
             return Ok(resolved);
         }
 
-        // The resolver gives builtins it stubs out for the browser the "node"
-        // namespace; everything else disabled comes from a "browser" map.
+        // Stubbed builtins carry the "node" namespace; anything else came from a "browser" map.
         if resolved.path_pair.primary.namespace == b"node" {
             self.log_mut().add_error_fmt(
                 None,

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -214,6 +214,58 @@ describe("Bun.build", () => {
     }
   });
 
+  // Runs in a child because the unfixed behavior was a process abort: the
+  // disabled entry point was dropped without an error and the linker ran with
+  // zero entry points.
+  test.concurrent("an entry point disabled by the package.json browser field is a build error", async () => {
+    using dir = tempDir("build-entry-point-disabled-by-browser-field", {
+      "package.json": JSON.stringify({ name: "app", browser: { "./entry.js": false } }),
+      "entry.js": `console.log("entry");`,
+      "build.mjs": `
+        const returned = await Bun.build({ entrypoints: ["./entry.js"], target: "browser", throw: false });
+        let thrown;
+        try {
+          await Bun.build({ entrypoints: ["./entry.js"], target: "browser" });
+        } catch (e) {
+          thrown = {
+            isAggregateError: e instanceof AggregateError,
+            errors: e.errors.map(error => ({ name: error.name, level: error.level, position: error.position, message: error.message })),
+          };
+        }
+        console.log(JSON.stringify({
+          returned: {
+            success: returned.success,
+            outputs: returned.outputs.length,
+            logs: returned.logs.map(log => ({ name: log.name, level: log.level, position: log.position, message: log.message })),
+          },
+          thrown,
+        }));
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const message = {
+      name: "BuildMessage",
+      level: "error",
+      position: null,
+      message: '"./entry.js" is disabled due to "browser" field in package.json (entry point)',
+    };
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      returned: { success: false, outputs: 0, logs: [message] },
+      thrown: { isAggregateError: true, errors: [message] },
+    });
+    expect(exitCode).toBe(0);
+  });
+
   test("returns output files", async () => {
     Bun.gc(true);
     const build = await Bun.build({

--- a/test/bundler/bundler_browser.test.ts
+++ b/test/bundler/bundler_browser.test.ts
@@ -374,6 +374,87 @@ describe("bundler", () => {
     },
   });
 
+  // An entry point the "browser" field maps to false has nothing to bundle.
+  // This used to reach the linker with zero entry points and crash
+  // ("index out of bounds" in generateChunksInParallel); with a second, live
+  // entry point it silently built only that one.
+  const browserFieldDisabledEntryPointFiles = {
+    "/package.json": /* json */ `
+      { "name": "app", "browser": { "./entry.js": false } }
+    `,
+    "/entry.js": /* js */ `
+      console.log("entry");
+    `,
+    "/other.js": /* js */ `
+      console.log("other");
+    `,
+  };
+  itBundled("browser/EntryPointDisabledByBrowserField", {
+    skipOnEsbuild: true,
+    backend: "cli",
+    files: browserFieldDisabledEntryPointFiles,
+    entryPointsRaw: ["./entry.js"],
+    target: "browser",
+    bundleErrors: {
+      "<bun>": ['"./entry.js" is disabled due to "browser" field in package.json (entry point)'],
+    },
+  });
+  itBundled("browser/EntryPointDisabledByBrowserFieldNextToLiveEntryPoint", {
+    skipOnEsbuild: true,
+    backend: "cli",
+    files: browserFieldDisabledEntryPointFiles,
+    entryPointsRaw: ["./entry.js", "./other.js"],
+    target: "browser",
+    bundleErrors: {
+      "<bun>": ['"./entry.js" is disabled due to "browser" field in package.json (entry point)'],
+    },
+  });
+  itBundled("browser/EntryPointDisabledByBrowserFieldOnlyAppliesToBrowserTarget", {
+    skipOnEsbuild: true,
+    backend: "cli",
+    files: browserFieldDisabledEntryPointFiles,
+    entryPointsRaw: ["./entry.js"],
+    target: "bun",
+    run: {
+      file: "/out/entry.js",
+      stdout: "entry",
+    },
+  });
+  itBundled("browser/EntryPointDisabledByPackageMainBrowserField", {
+    // The disabled module is reached through a package's "main", so the entry
+    // point specifier and the disabled file differ.
+    skipOnEsbuild: true,
+    backend: "cli",
+    files: {
+      "/node_modules/pkg/package.json": /* json */ `
+        { "name": "pkg", "main": "./node.js", "browser": { "./node.js": false } }
+      `,
+      "/node_modules/pkg/node.js": /* js */ `
+        console.log("node only");
+      `,
+    },
+    entryPointsRaw: ["pkg"],
+    target: "browser",
+    bundleErrors: {
+      "<bun>": ['"pkg" is disabled due to "browser" field in package.json (entry point)'],
+    },
+  });
+  itBundled("browser/EntryPointIsNodeBuiltinStubbedForBrowser", {
+    // Browser builds replace "fs" (and node:* builtins without a polyfill) with
+    // an empty module, so as entry points they have nothing to bundle either.
+    skipOnEsbuild: true,
+    backend: "cli",
+    files: {},
+    entryPointsRaw: ["fs", "node:fs"],
+    target: "browser",
+    bundleErrors: {
+      "<bun>": [
+        `Browser build cannot use Node.js builtin "fs" as an entry point. To use Node.js builtins, set target to 'node' or 'bun'`,
+        `Browser build cannot use Node.js builtin "node:fs" as an entry point. To use Node.js builtins, set target to 'node' or 'bun'`,
+      ],
+    },
+  });
+
   // unsure: do we want polyfills or no-op stuff like node:* has
   // right now all error except bun:wrap which errors at resolve time, but is included if external
   const bunModules: Record<string, "no-op" | "polyfill" | "error"> = {

--- a/test/bundler/bundler_browser.test.ts
+++ b/test/bundler/bundler_browser.test.ts
@@ -449,8 +449,8 @@ describe("bundler", () => {
     target: "browser",
     bundleErrors: {
       "<bun>": [
-        `Browser build cannot use Node.js builtin "fs" as an entry point. To use Node.js builtins, set target to 'node' or 'bun'`,
-        `Browser build cannot use Node.js builtin "node:fs" as an entry point. To use Node.js builtins, set target to 'node' or 'bun'`,
+        `Cannot use Node.js builtin "fs" as an entry point`,
+        `Cannot use Node.js builtin "node:fs" as an entry point`,
       ],
     },
   });

--- a/test/bundler/bundler_plugin.test.ts
+++ b/test/bundler/bundler_plugin.test.ts
@@ -1689,16 +1689,15 @@ describe("bundler", () => {
     });
   }
 
-  // An entry point that an onResolve plugin leaves without a module (marks it
-  // external, or declines it and the package.json "browser" field disables it)
-  // must fail the build. It used to be dropped without a log entry, which
-  // crashed the linker when it was the only entry point and silently produced
-  // fewer outputs when it was not.
+  // An entry point that onResolve leaves without a module used to be dropped
+  // without a log entry, and the linker then aborted on an empty chunk list.
+  // A declined entry point that the package.json "browser" field disables gets
+  // the same error as without plugins; an entry point a plugin marks external
+  // has no error of its own yet, so it reaches the generic one.
   test.concurrent("plugin/entry point left without a module by onResolve fails the build", async () => {
     using dir = tempDir("plugin-entry-point-without-module", {
       "package.json": JSON.stringify({ name: "app", browser: { "./disabled.js": false } }),
       "entry.js": `console.log("entry");`,
-      "other.js": `console.log("other");`,
       "disabled.js": `console.log("disabled");`,
       "build.mjs": `
         const declined = [];
@@ -1721,7 +1720,6 @@ describe("bundler", () => {
         const results = {};
         for (const [name, entrypoints] of Object.entries({
           external: ["./entry.js"],
-          externalNextToLiveEntryPoint: ["./entry.js", "./other.js"],
           declinedThenDisabledByBrowserField: ["./disabled.js"],
         })) {
           const result = await Bun.build({ entrypoints, target: "browser", plugins, throw: false });
@@ -1749,12 +1747,7 @@ describe("bundler", () => {
     expect(JSON.parse(stdout)).toEqual({
       external: {
         success: false,
-        logs: ['The entry point "./entry.js" cannot be marked as external'],
-        outputs: [],
-      },
-      externalNextToLiveEntryPoint: {
-        success: false,
-        logs: ['The entry point "./entry.js" cannot be marked as external'],
+        logs: ["None of the entry points could be bundled"],
         outputs: [],
       },
       declinedThenDisabledByBrowserField: {

--- a/test/bundler/bundler_plugin.test.ts
+++ b/test/bundler/bundler_plugin.test.ts
@@ -1688,4 +1688,82 @@ describe("bundler", () => {
       expect(exitCode).toBe(0);
     });
   }
+
+  // An entry point that an onResolve plugin leaves without a module (marks it
+  // external, or declines it and the package.json "browser" field disables it)
+  // must fail the build. It used to be dropped without a log entry, which
+  // crashed the linker when it was the only entry point and silently produced
+  // fewer outputs when it was not.
+  test.concurrent("plugin/entry point left without a module by onResolve fails the build", async () => {
+    using dir = tempDir("plugin-entry-point-without-module", {
+      "package.json": JSON.stringify({ name: "app", browser: { "./disabled.js": false } }),
+      "entry.js": `console.log("entry");`,
+      "other.js": `console.log("other");`,
+      "disabled.js": `console.log("disabled");`,
+      "build.mjs": `
+        const declined = [];
+        const plugins = [
+          {
+            name: "externalize-entry",
+            setup(build) {
+              build.onResolve({ filter: /entry\\.js$/ }, args => ({ path: args.path, external: true }));
+            },
+          },
+          {
+            name: "decline-disabled",
+            setup(build) {
+              build.onResolve({ filter: /disabled\\.js$/ }, args => {
+                declined.push(args.path);
+              });
+            },
+          },
+        ];
+        const results = {};
+        for (const [name, entrypoints] of Object.entries({
+          external: ["./entry.js"],
+          externalNextToLiveEntryPoint: ["./entry.js", "./other.js"],
+          declinedThenDisabledByBrowserField: ["./disabled.js"],
+        })) {
+          const result = await Bun.build({ entrypoints, target: "browser", plugins, throw: false });
+          results[name] = {
+            success: result.success,
+            logs: result.logs.map(log => log.message),
+            outputs: result.outputs.map(output => output.path),
+          };
+        }
+        results.declined = declined;
+        console.log(JSON.stringify(results));
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      external: {
+        success: false,
+        logs: ['The entry point "./entry.js" cannot be marked as external'],
+        outputs: [],
+      },
+      externalNextToLiveEntryPoint: {
+        success: false,
+        logs: ['The entry point "./entry.js" cannot be marked as external'],
+        outputs: [],
+      },
+      declinedThenDisabledByBrowserField: {
+        success: false,
+        logs: ['"./disabled.js" is disabled due to "browser" field in package.json (entry point)'],
+        outputs: [],
+      },
+      declined: ["./disabled.js"],
+    });
+    expect(exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
### Problem
- `bun build --target=browser ./a.ts` with `{"browser": {"./a.ts": false}}` in the enclosing package.json aborts: `panic: index out of bounds: the len is 0 but the index is 0` (release), `assertion failed: chunks.len() > 0` in `src/bundler/linker_context/generateChunksInParallel.rs` (debug). `Bun.build()` with the same entry point aborts the whole process, `throw: false` or not.
- With a second, live entry point the same build exits 0 and emits only the live one; the disabled entry point disappears without a message.
- Same abort for `bun build --target=browser fs` / `node:fs`, and for a package or directory entry point whose `main`/index the browser field disables.
- Cause: the resolver returns such entry points as a result whose every path is disabled, so `Result::path()` is `None`. `Transpiler::resolve_entry_point` (`src/bundler/transpiler.rs`) returned that as `Ok`, and `BundleV2::enqueue_entry_item` (`src/bundler/bundle_v2.rs`) returns `Ok(None)` for it without logging. The build drivers only check `log.has_errors()`, so the bundle went on to link with zero entry points, and `generate_chunks_in_parallel` indexes `chunks[0]`.
- Other ways of losing every entry point without a logged error reach the same `chunks[0]` (an onResolve plugin returning `external: true` for the entry point, the over-long specifier in #38391); each producer fix only removes its own cause.

### Fix
- `resolve_entry_point` logs an error for a disabled result and returns `Err`, the contract it already has for every other entry point failure (callers skip the entry point on `Err`; the drivers fail the build from the log). Messages: `"./a.ts" is disabled due to "browser" field in package.json (entry point)`, the wording `bun build --no-bundle` already uses for this case, and `Cannot use Node.js builtin "fs" as an entry point` for builtins the browser resolver stubs out (no target hint: a builtin is not a bundleable entry point under `--target bun`/`node` either, those fail with `File not found`).
- Why an error rather than esbuild's empty output for the browser-field case: bun already reports it for `bun build --no-bundle`, the resolver represents "disabled" as "no path" on purpose (imports of the module become `{}`), and emitting fewer outputs than entry points with exit 0 was the silent failure mode here, so the multi-entry case needs the error anyway. esbuild errors for the builtin case too.
- Going through `resolve_entry_point` covers every entry point path with one check: the CLI, `Bun.build()`, the plugin-declined fallback in `on_resolve`, and the bake callers (which pass absolute file paths and cannot hit it today).
- Backstop for the class: `generate_from_cli` and `run_from_js_in_new_thread` now fail with `None of the entry points could be bundled` when parsing ends with `graph.entry_points` empty. Both require at least one entry point, so an empty list there always means every entry point was dropped on a path that did not log; that state now ends as a build error instead of at `chunks[0]`, whatever the cause. The bake production driver is not changed: it already tolerates an empty chunk list on purpose. The plugin-external entry point lands on this error today; #35053 (open) adds esbuild's specific `cannot be marked as external` message for it, so this PR does not carry a second copy.
- The two CLI drivers report entry point errors after `wait_for_parse()` instead of returning before it, as the `Bun.build()` driver always has. The immediate return tore the bundle down while the runtime parse task was still starting on a worker; 26/30 ASAN runs of the CLI fix died in `Worker::deinit_soon` reading a `Worker` that `get_worker_slow` had published to `workers_assignments` before initializing it. #37480 (open) makes `deinit_without_freeing_arena` itself join in-flight work for every driver and does not touch these lines; these two deletions keep this PR's CLI tests deterministic on main today and stay valid after it (the publication order in `get_worker_slow` is reported separately).
- Coordination: #38752 switches `--no-bundle` to `resolve_entry_point` and keeps a `path_const().is_none()` arm with the same message; after this PR that arm is unreachable and can go in whichever of the two lands second. #38391 (over-long specifier) touches the adjacent match arm and its own test at the same spot in `bun-build-api.test.ts`; both rebases are trivial.
- Verified:
  - `test/bundler/bundler_browser.test.ts`: `browser/EntryPointDisabledByBrowserField`, `...NextToLiveEntryPoint` (the silent drop), `...OnlyAppliesToBrowserTarget`, `EntryPointDisabledByPackageMainBrowserField`, `EntryPointIsNodeBuiltinStubbedForBrowser` (CLI, `backend: "cli"` so the unfixed abort stays in the child).
  - `test/bundler/bundler_plugin.test.ts`: a declined entry point that the browser field disables (the `on_resolve` fallback) gets the specific error; an entry point a plugin marks external gets the backstop error. The CLI driver calls the same helper; the only CLI-reachable zero-entry-point routes left (`bun build --target=bun bun:wrap`, builtins under `--target bun`) trip `assert_file_path_is_absolute` first in debug/canary builds, so the backstop is pinned through `Bun.build()`.
  - `test/bundler/bun-build-api.test.ts`: `Bun.build()` returns `success: false` with the `BuildMessage` and rejects with an `AggregateError` carrying it.
  - `USE_SYSTEM_BUN=1`: three browser tests and both child-process tests abort with the panic above, the multi-entry test fails with "Errors were expected while bundling". `bun bd test`: all pass, as do the full `bundler_browser`, `bundler_plugin`, `bundler_files`, `bundler_html`, `bundler_html_server`, `bun-build-api`, `bundler_edgecase`, `bundler_naming`, `cli` and `esbuild/packagejson` files.
  - `bun-debug build --target=browser ./a.ts`: 30/30 runs exit 1 with the message (26/30 ASAN SEGVs with the early return still in place).

### Background
- `"browser"` field: a package.json map that browser builds apply during resolution; mapping a file or package to `false` means "this module is empty in the browser". The resolver expresses that by marking the paths of the result `is_disabled`, and `Result::path()` / `path_const()` skip disabled paths, so a fully disabled module resolves to a result with no path. The same representation is used for `fs` and `node:*` builtins that have no browser polyfill (those carry the `node` namespace). It only applies to `--target browser`; absolute file paths are not looked up in it.
- Entry point pipeline: `enqueue_entry_points_*` resolve each entry point with `resolve_entry_point` and hand the result to `enqueue_entry_item`, which schedules a parse task and appends to `graph.entry_points`. The drivers (`generate_from_cli` for the CLI, `run_from_js_in_new_thread` for `Bun.build()`) then wait for parsing and fail the build if the log has errors; the linker requires at least one entry point, so every way of losing one has to leave an error in the log, and the new check is the last line of defense for that invariant.
- `on_resolve`: when an onResolve plugin matches an entry point, its answer arrives here. `NoMatch` falls back to `resolve_entry_point` (hence the declined-plugin test); `Success` with `external: true` does nothing for entry points (the case #35053 gives a message to).
- `wait_for_parse()` spins the bundler's event loop until every scheduled parse task has completed; `enqueue_entry_points_common` schedules the runtime's parse task before any entry point is resolved, so on the CLI error path there was always a task in flight at teardown.

<details>
<summary>Release repro (1.4.0-canary.1)</summary>

```sh
mkdir /tmp/bf && cd /tmp/bf
echo 'export const a = 1;' > a.ts
echo 'export const b = 2;' > b.ts
echo '{"name":"x","browser":{"./a.ts":false}}' > package.json
bun build --target=browser ./a.ts            # panic: index out of bounds: the len is 0 but the index is 0 (exit 134)
bun build --target=browser ./a.ts ./b.ts --outdir=out   # exit 0, out/ contains only b.js
bun build --target=browser fs                # same panic
bun -e 'await Bun.build({entrypoints:["./a.ts"], target:"browser", throw:false})'   # same panic
bun -e 'await Bun.build({entrypoints:["./b.ts"], throw:false, plugins:[{name:"x", setup(b){ b.onResolve({filter:/b\.ts$/}, a => ({path:a.path, external:true})) }}]})'   # same panic, now the backstop error
```

With this branch each of these prints one error and exits 1 / returns `success: false`; `--target=bun` with the same package.json still bundles `a.ts`.
</details>

<details>
<summary>Earlier revision of this PR</summary>

The first revision also added esbuild's `The entry point "x" cannot be marked as external` error in `on_resolve` and had no backstop. Review turned up #35053, which already carries that error (the two conflicted on the same lines), so the arm was dropped in favor of the generic check above; the builtin message used to end with "set target to 'node' or 'bun'", which does not work for an entry point either.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bun-build-api.test.ts test/bundler/bundler_plugin.test.ts

<!-- robobun:evidence:end -->