### PR TITLE
install: reinstall node_modules when switching between the isolated and hoisted linkers

### DIFF
--- a/docs/pm/isolated-installs.mdx
+++ b/docs/pm/isolated-installs.mdx
@@ -182,6 +182,8 @@ If you encounter issues, you can:
    bun install --linker hoisted
    ```
 
+   Switching linkers in either direction reinstalls the existing `node_modules` from scratch. The previous tree is moved to `node_modules/.old_modules-<random>`, which is safe to delete.
+
 2. **Report compatibility issues** to help improve isolated install support
 
 ### Performance considerations

--- a/src/install/hoisted_install.rs
+++ b/src/install/hoisted_install.rs
@@ -169,6 +169,14 @@ pub(crate) fn install_hoisted_packages(
         this.downloads_node = None;
     });
 
+    // A partial install (security scanner) runs ahead of the real one and must not touch the layout.
+    let replacing_isolated_node_modules = packages_to_install.is_none()
+        && sys::directory_exists_at(Fd::cwd(), bun_paths::path_literal!("node_modules/.bun"))
+            .unwrap_or(false);
+    if replacing_isolated_node_modules {
+        crate::isolated_install::move_node_modules_aside(&this.lockfile);
+    }
+
     // If there was already a valid lockfile and so we did not resolve, i.e. there was zero network activity
     // the packages could still not be in the cache dir
     // this would be a common scenario in a CI environment
@@ -218,7 +226,8 @@ pub(crate) fn install_hoisted_packages(
     let mut skip_delete = new_node_modules;
     let mut skip_verify_installed_version_number = new_node_modules;
 
-    if this.options.enable.force_install() {
+    // Whatever `move_node_modules_aside` could not move is still deleted before it is reinstalled.
+    if this.options.enable.force_install() || replacing_isolated_node_modules {
         skip_verify_installed_version_number = true;
         skip_delete = false;
     }

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -1132,6 +1132,73 @@ pub(crate) fn build_store(
     })
 }
 
+/// Entry by entry rather than renaming `node_modules` itself, which may be a mount point or a symlink.
+pub(crate) fn move_node_modules_aside(lockfile: &Lockfile) {
+    use bun_sys::FdExt as _;
+
+    let mut old_modules = AutoRelPath::from(b"node_modules").assume_ok();
+    let rand = fast_random();
+    old_modules
+        .append_fmt(format_args!(
+            ".old_modules-{}",
+            bun_fmt::hex_lower(bun_core::bytes_of(&rand))
+        ))
+        .assume_ok();
+    if sys::mkdirat(Fd::cwd(), old_modules.slice_z(), 0o755).is_err() {
+        return;
+    }
+    let old_modules_name = old_modules.basename().to_vec();
+
+    let Ok(node_modules) = sys::open_dir_for_iteration(Fd::cwd(), b"node_modules") else {
+        return;
+    };
+    let mut entry_path = AutoRelPath::from(b"node_modules").assume_ok();
+    let mut iter = sys::iterate_dir(node_modules);
+    while let Ok(Some(entry)) = iter.next() {
+        let name = entry.name.slice_u8();
+        if name == b".cache" || name == old_modules_name.as_slice() {
+            continue;
+        }
+
+        let entry_path_len = entry_path.len();
+        entry_path.append(name).assume_ok();
+        let old_modules_len = old_modules.len();
+        old_modules.append(name).assume_ok();
+
+        let _ = sys::renameat(
+            Fd::cwd(),
+            entry_path.slice_z(),
+            Fd::cwd(),
+            old_modules.slice_z(),
+        );
+
+        entry_path.set_length(entry_path_len);
+        old_modules.set_length(old_modules_len);
+    }
+    node_modules.close();
+
+    for workspace_path in lockfile.workspace_paths.values() {
+        let mut workspace_node_modules =
+            AutoRelPath::from(workspace_path.slice(&lockfile.buffers.string_bytes)).assume_ok();
+        let basename = workspace_node_modules.basename().to_vec();
+        workspace_node_modules.append(b"node_modules").assume_ok();
+
+        let old_modules_len = old_modules.len();
+        old_modules
+            .append_fmt(format_args!(".old_{}_modules", BStr::new(&basename)))
+            .assume_ok();
+
+        let _ = sys::renameat(
+            Fd::cwd(),
+            workspace_node_modules.slice_z(),
+            Fd::cwd(),
+            old_modules.slice_z(),
+        );
+
+        old_modules.set_length(old_modules_len);
+    }
+}
+
 /// Runs on main thread
 pub(crate) fn install_isolated_packages(
     manager: &mut PackageManager,
@@ -1675,233 +1742,13 @@ pub(crate) fn install_isolated_packages(
         // matches `Installer::NODE_MODULES_BUN`.
         let bun_modules_path = paths::path_literal!("node_modules/.bun");
 
-        match sys::mkdirat(Fd::cwd(), node_modules_path, 0o755) {
-            Ok(()) => {
-                // fallthrough to creating bun_modules below
+        if sys::mkdirat(Fd::cwd(), node_modules_path, 0o755).is_err() {
+            if sys::directory_exists_at(Fd::cwd(), bun_modules_path).unwrap_or(false) {
+                break 'is_new_bun_modules false;
             }
-            Err(_) => {
-                match sys::mkdirat(Fd::cwd(), bun_modules_path, 0o755) {
-                    Err(_) => break 'is_new_bun_modules false,
-                    Ok(()) => {}
-                }
 
-                // 'node_modules' exists and 'node_modules/.bun' doesn't
-
-                #[cfg(windows)]
-                {
-                    // Windows:
-                    // 1. create 'node_modules/.old_modules-{hex}'
-                    // 2. for each entry in 'node_modules' rename into 'node_modules/.old_modules-{hex}'
-                    // 3. for each workspace 'node_modules' rename into 'node_modules/.old_modules-{hex}/old_{basename}_modules'
-
-                    // `sys::mkdirat`/`renameat` take `&ZStr` (u8) and widen
-                    // internally, so a single u8 `AutoRelPath` covers both the
-                    // mkdir and rename targets.
-                    let mut rename_path = AutoRelPath::from(b"node_modules").assume_ok();
-                    let rand = fast_random();
-                    rename_path
-                        .append_fmt(format_args!(
-                            ".old_modules-{}",
-                            bun_fmt::hex_lower(bun_core::bytes_of(&rand))
-                        ))
-                        .assume_ok();
-
-                    // 1
-                    if sys::mkdirat(Fd::cwd(), rename_path.slice_z(), 0o755).is_err() {
-                        break 'is_new_bun_modules true;
-                    }
-
-                    let Ok(node_modules) = sys::open_dir_for_iteration(Fd::cwd(), b"node_modules")
-                    else {
-                        break 'is_new_bun_modules true;
-                    };
-                    // Windows HANDLE-leak audit: `Fd` is `Copy` (no Drop) and the
-                    // `WrappedIterator` from `sys::iterate_dir` does not own/close it,
-                    // so close explicitly. The guard fires on
-                    // normal fall-through to step 3 and on every
-                    // `break 'is_new_bun_modules true` early exit.
-                    let _close_node_modules = scopeguard::guard(node_modules, |fd| {
-                        use bun_sys::FdExt as _;
-                        fd.close();
-                    });
-
-                    let mut entry_path = AutoRelPath::from(b"node_modules").assume_ok();
-
-                    // 2
-                    let mut node_modules_iter = sys::iterate_dir(node_modules);
-                    loop {
-                        let Some(entry) = (match node_modules_iter.next() {
-                            Ok(v) => v,
-                            Err(_) => break 'is_new_bun_modules true,
-                        }) else {
-                            break;
-                        };
-                        if bun_core::starts_with_char(entry.name.slice_u8(), b'.') {
-                            continue;
-                        }
-
-                        // Capture lengths and truncate manually so
-                        // the paths stay unborrowed across the loop body.
-                        let entry_path_save = entry_path.len();
-                        entry_path.append(entry.name.slice()).assume_ok();
-
-                        let rename_path_save = rename_path.len();
-                        rename_path.append(entry.name.slice()).assume_ok();
-
-                        let _ = sys::renameat(
-                            Fd::cwd(),
-                            entry_path.slice_z(),
-                            Fd::cwd(),
-                            rename_path.slice_z(),
-                        );
-
-                        rename_path.set_length(rename_path_save);
-                        entry_path.set_length(entry_path_save);
-                    }
-
-                    // 3
-                    for workspace_path in lockfile.workspace_paths.values() {
-                        let mut workspace_node_modules =
-                            AutoRelPath::from(workspace_path.slice(&lockfile.buffers.string_bytes))
-                                .assume_ok();
-
-                        // Clone basename before mutating
-                        // `workspace_node_modules`.
-                        let basename = workspace_node_modules.basename().to_vec();
-
-                        workspace_node_modules.append(b"node_modules").assume_ok();
-
-                        // Reshaped for borrowck — capture length instead
-                        // of `save()` so `rename_path` stays unborrowed.
-                        let rename_path_save = rename_path.len();
-                        rename_path
-                            .append_fmt(format_args!(".old_{}_modules", BStr::new(&basename)))
-                            .assume_ok();
-
-                        let _ = sys::renameat(
-                            Fd::cwd(),
-                            workspace_node_modules.slice_z(),
-                            Fd::cwd(),
-                            rename_path.slice_z(),
-                        );
-
-                        rename_path.set_length(rename_path_save);
-                    }
-                }
-                #[cfg(not(windows))]
-                {
-                    // Posix:
-                    // 1. rename existing 'node_modules' to temp location
-                    // 2. create new 'node_modules' directory
-                    // 3. rename temp into 'node_modules/.old_modules-{hex}'
-                    // 4. attempt renaming 'node_modules/.old_modules-{hex}/.cache' to 'node_modules/.cache'
-                    // 5. rename each workspace 'node_modules' into 'node_modules/.old_modules-{hex}/old_{basename}_modules'
-                    let mut temp_node_modules_buf = PathBuffer::uninit();
-                    let temp_node_modules = paths::fs::FileSystem::tmpname(
-                        b"tmp_modules",
-                        &mut temp_node_modules_buf.0,
-                        fast_random(),
-                    )
-                    .expect("unreachable");
-
-                    // 1
-                    if sys::renameat(
-                        Fd::cwd(),
-                        bun_core::zstr!("node_modules"),
-                        Fd::cwd(),
-                        temp_node_modules,
-                    )
-                    .is_err()
-                    {
-                        break 'is_new_bun_modules true;
-                    }
-
-                    // 2
-                    if let Err(err) = sys::mkdirat(Fd::cwd(), node_modules_path, 0o755) {
-                        Output::err(err, "failed to create './node_modules'", format_args!(""));
-                        Global::exit(1);
-                    }
-
-                    if let Err(err) = sys::mkdirat(Fd::cwd(), bun_modules_path, 0o755) {
-                        Output::err(
-                            err,
-                            "failed to create './node_modules/.bun'",
-                            format_args!(""),
-                        );
-                        Global::exit(1);
-                    }
-
-                    let mut rename_path = AutoRelPath::from(b"node_modules").assume_ok();
-
-                    let rand = fast_random();
-                    rename_path
-                        .append_fmt(format_args!(
-                            ".old_modules-{}",
-                            bun_fmt::hex_lower(bun_core::bytes_of(&rand))
-                        ))
-                        .assume_ok();
-
-                    // 3
-                    if sys::renameat(
-                        Fd::cwd(),
-                        temp_node_modules,
-                        Fd::cwd(),
-                        rename_path.slice_z(),
-                    )
-                    .is_err()
-                    {
-                        break 'is_new_bun_modules true;
-                    }
-
-                    rename_path.append(b".cache").assume_ok();
-
-                    let mut cache_path = AutoRelPath::from(b"node_modules").assume_ok();
-                    cache_path.append(b".cache").assume_ok();
-
-                    // 4
-                    let _ = sys::renameat(
-                        Fd::cwd(),
-                        rename_path.slice_z(),
-                        Fd::cwd(),
-                        cache_path.slice_z(),
-                    );
-
-                    // remove .cache so we can append destination for each workspace
-                    rename_path.undo(1);
-
-                    // 5
-                    for workspace_path in lockfile.workspace_paths.values() {
-                        let mut workspace_node_modules =
-                            AutoRelPath::from(workspace_path.slice(&lockfile.buffers.string_bytes))
-                                .assume_ok();
-
-                        // Clone basename before mutating
-                        // `workspace_node_modules`.
-                        let basename = workspace_node_modules.basename().to_vec();
-
-                        workspace_node_modules.append(b"node_modules").assume_ok();
-
-                        // Capture the length and truncate manually
-                        // so `rename_path` stays unborrowed between save/restore.
-                        let rename_path_save = rename_path.len();
-
-                        rename_path
-                            .append_fmt(format_args!(".old_{}_modules", BStr::new(&basename)))
-                            .assume_ok();
-
-                        let _ = sys::renameat(
-                            Fd::cwd(),
-                            workspace_node_modules.slice_z(),
-                            Fd::cwd(),
-                            rename_path.slice_z(),
-                        );
-
-                        rename_path.set_length(rename_path_save);
-                    }
-                }
-
-                break 'is_new_bun_modules true;
-            }
+            // 'node_modules' exists and 'node_modules/.bun' doesn't
+            move_node_modules_aside(lockfile);
         }
 
         if let Err(err) = sys::mkdirat(Fd::cwd(), bun_modules_path, 0o755) {

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -5,6 +5,7 @@ import { mkdir, readlink, rm, symlink } from "fs/promises";
 import { VerdaccioRegistry, bunEnv, bunExe, readdirSorted, runBunInstall, tempDir } from "harness";
 import { createRequire } from "module";
 import { dirname, join } from "path";
+import { SimpleRegistry } from "./simple-dummy-registry";
 
 const registry = new VerdaccioRegistry();
 
@@ -1645,6 +1646,238 @@ describe("--linker flag", () => {
     expect(await exited).toBe(0);
 
     expect(lstatSync(join(packageDir, "node_modules", "no-deps")).isSymbolicLink()).toBeTrue();
+  });
+
+  async function installWithLinker(packageDir: string, linker: "isolated" | "hoisted") {
+    await using proc = spawn({
+      cmd: [bunExe(), "install", "--linker", linker],
+      cwd: packageDir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
+    return stdout;
+  }
+
+  // `peer-deps` has a peer dependency on `no-deps`, so it shows which copy of
+  // `no-deps` a dependency resolves to. Both must resolve to the same copy the
+  // root resolves to, whichever linker laid out the tree.
+  async function resolvedNoDeps(packageDir: string) {
+    await using proc = spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const root = require("no-deps");
+         const viaPeer = require("peer-deps").peerDependencies["no-deps"];
+         console.log(JSON.stringify({ root: root.version, viaPeer: viaPeer.version, sameCopy: root === viaPeer }));`,
+      ],
+      cwd: packageDir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return JSON.parse(stdout);
+  }
+
+  function rootEntryKinds(packageDir: string, names: string[]) {
+    return Object.fromEntries(
+      names.map(name => {
+        const stat = lstatSync(join(packageDir, "node_modules", name), { throwIfNoEntry: false });
+        return [name, stat === undefined ? "missing" : stat.isSymbolicLink() ? "symlink" : "directory"];
+      }),
+    );
+  }
+
+  test("switching linkers on an existing node_modules replaces the whole tree", async () => {
+    const { packageJson, packageDir } = await registry.createTestDir();
+    const writeRootPackageJson = (noDepsVersion: string) =>
+      write(
+        packageJson,
+        JSON.stringify({
+          name: "linker-switch",
+          dependencies: {
+            "no-deps": noDepsVersion,
+            "peer-deps": "1.0.0",
+          },
+        }),
+      );
+
+    await writeRootPackageJson("1.0.0");
+    await installWithLinker(packageDir, "isolated");
+    expect(rootEntryKinds(packageDir, [".bun", "no-deps", "peer-deps"])).toEqual({
+      ".bun": "directory",
+      "no-deps": "symlink",
+      "peer-deps": "symlink",
+    });
+    expect(await resolvedNoDeps(packageDir)).toEqual({ root: "1.0.0", viaPeer: "1.0.0", sameCopy: true });
+
+    // The store symlink for `peer-deps` still points at a package.json with the
+    // right version, so a hoisted install that only compared versions would keep
+    // it linked into the store next to the old `no-deps`.
+    await writeRootPackageJson("2.0.0");
+    expect(await installWithLinker(packageDir, "hoisted")).toContain("2 packages installed");
+    expect(rootEntryKinds(packageDir, [".bun", "no-deps", "peer-deps"])).toEqual({
+      ".bun": "missing",
+      "no-deps": "directory",
+      "peer-deps": "directory",
+    });
+    expect(await readdirSorted(join(packageDir, "node_modules"))).toEqual([
+      expect.stringContaining(".old_modules-"),
+      "no-deps",
+      "peer-deps",
+    ]);
+    expect(await resolvedNoDeps(packageDir)).toEqual({ root: "2.0.0", viaPeer: "2.0.0", sameCopy: true });
+
+    // Only a tree built by the other linker gets replaced.
+    expect(await installWithLinker(packageDir, "hoisted")).toContain("(no changes)");
+    expect(await readdirSorted(join(packageDir, "node_modules"))).toEqual([
+      expect.stringContaining(".old_modules-"),
+      "no-deps",
+      "peer-deps",
+    ]);
+
+    // Back to isolated: the real directory left behind by the hoisted install
+    // must not shadow the store entry for the version the lockfile now has.
+    await writeRootPackageJson("1.0.0");
+    expect(await installWithLinker(packageDir, "isolated")).toContain("2 packages installed");
+    expect(rootEntryKinds(packageDir, [".bun", "no-deps", "peer-deps"])).toEqual({
+      ".bun": "directory",
+      "no-deps": "symlink",
+      "peer-deps": "symlink",
+    });
+    expect(readlinkSync(join(packageDir, "node_modules", "no-deps"))).toBe(
+      join(".bun", "no-deps@1.0.0", "node_modules", "no-deps"),
+    );
+    expect(await readdirSorted(join(packageDir, "node_modules"))).toEqual([
+      ".bun",
+      expect.stringContaining(".old_modules-"),
+      "no-deps",
+      "peer-deps",
+    ]);
+    expect(await resolvedNoDeps(packageDir)).toEqual({ root: "1.0.0", viaPeer: "1.0.0", sameCopy: true });
+
+    expect(await installWithLinker(packageDir, "isolated")).toContain("(no changes)");
+    expect(await readdirSorted(join(packageDir, "node_modules"))).toEqual([
+      ".bun",
+      expect.stringContaining(".old_modules-"),
+      "no-deps",
+      "peer-deps",
+    ]);
+  });
+
+  test("switching from isolated to hoisted also replaces workspace node_modules", async () => {
+    const { packageDir } = await registry.createTestDir({
+      files: {
+        "package.json": JSON.stringify({
+          name: "linker-switch-workspaces",
+          workspaces: ["packages/*"],
+        }),
+        "packages/pkg1/package.json": JSON.stringify({
+          name: "pkg1",
+          dependencies: {
+            "no-deps": "1.0.0",
+          },
+        }),
+        "packages/pkg1/index.js": `console.log(require.resolve("no-deps/package.json"));`,
+      },
+    });
+
+    await installWithLinker(packageDir, "isolated");
+    expect(lstatSync(join(packageDir, "packages", "pkg1", "node_modules", "no-deps")).isSymbolicLink()).toBeTrue();
+
+    await installWithLinker(packageDir, "hoisted");
+    // The workspace's store link would otherwise keep shadowing the hoisted copy.
+    expect(existsSync(join(packageDir, "packages", "pkg1", "node_modules"))).toBeFalse();
+    expect(rootEntryKinds(packageDir, [".bun", "no-deps", "pkg1"])).toEqual({
+      ".bun": "missing",
+      "no-deps": "directory",
+      "pkg1": "symlink",
+    });
+
+    await using proc = spawn({
+      cmd: [bunExe(), "packages/pkg1/index.js"],
+      cwd: packageDir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe(join(packageDir, "node_modules", "no-deps", "package.json"));
+    expect(exitCode).toBe(0);
+  });
+
+  // A security scanner that is not installed yet is installed on its own, with
+  // the hoisted linker, before the real install runs. Finding the store in that
+  // step is not a linker switch.
+  test("installing a missing security scanner into an isolated node_modules keeps the tree", async () => {
+    using scannerRegistry = new SimpleRegistry(false);
+    await scannerRegistry.start();
+
+    const { packageDir } = await registry.createTestDir({
+      files: {
+        "package.json": JSON.stringify({
+          name: "scanner-into-isolated",
+          workspaces: ["packages/*"],
+          devDependencies: {
+            "test-security-scanner": "1.0.0",
+          },
+        }),
+        "packages/app/package.json": JSON.stringify({
+          name: "app",
+          dependencies: {
+            "left-pad": "1.3.0",
+          },
+        }),
+      },
+    });
+    await write(
+      join(packageDir, "bunfig.toml"),
+      Bun.TOML.stringify({
+        install: {
+          cache: join(packageDir, ".bun-cache"),
+          registry: `${scannerRegistry.getUrl()}/`,
+          security: { scanner: "test-security-scanner" },
+        },
+      }),
+    );
+
+    async function installWithScanner() {
+      await using proc = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: packageDir,
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const output = stdout + stderr;
+      expect(output).toContain("Attempting to install security scanner from npm");
+      expect(output).toContain("SCANNER_RAN:");
+      expect(exitCode).toBe(0);
+    }
+
+    await installWithScanner();
+    const nodeModules = join(packageDir, "node_modules");
+    const entriesAfterFirstInstall = await readdirSorted(nodeModules);
+    expect(entriesAfterFirstInstall).toEqual([
+      ".bun",
+      expect.stringContaining(".old_modules-"),
+      "test-security-scanner",
+    ]);
+
+    // Make the scanner need its own install step again, this time into a tree
+    // that already has a store.
+    await rm(join(nodeModules, "test-security-scanner"), { recursive: true, force: true });
+    await installWithScanner();
+    expect(await readdirSorted(nodeModules)).toEqual(entriesAfterFirstInstall);
+    expect(await readdirSorted(join(packageDir, "packages", "app", "node_modules"))).toEqual(["left-pad"]);
   });
 });
 test("many transitive dependencies", async () => {


### PR DESCRIPTION
### Problem
- `bun install --linker hoisted` on a `node_modules` built by the isolated linker leaves a mixed tree: packages whose version changed become real directories, the rest stay symlinks into `node_modules/.bun`, and `.bun` is kept. A dependency then resolves its peers from its store siblings, so the app and its dependencies get two copies of the same package (`react`/`lib-a` in the fuzz ledger, `no-deps`/`peer-deps` in the test). Running it again reports `no changes`.
- Cause: the hoisted linker decides a package is installed by reading `node_modules/<pkg>/package.json` (`PackageInstall::verify`, src/install/PackageInstall.rs:826), which follows the store symlink and finds the right version. Nothing in the hoisted linker knows about `node_modules/.bun`.
- Switching back with `--linker isolated` then reports `no changes` forever, even after a version bump, and the hoisted install's real directories keep shadowing the store. The isolated linker only resets an existing tree when `node_modules/.bun` is missing (`is_new_bun_modules` in src/install/isolated_install.rs), and the leftover `.bun` defeats that; per entry, root links use `Strategy::ExpectExisting`, which leaves a real directory alone on purpose because that is what a `bun patch` workspace looks like (src/install/isolated_install/Symlinker.rs:78). Only `rm -rf node_modules` repaired it.

### Fix
- The fix is in `install_hoisted_packages` (src/install/hoisted_install.rs): if `node_modules/.bun` exists, move the tree aside and install with the `--force` flags (no verification, delete before install), so every package becomes a real directory and whatever the move could not take is still removed first. This mirrors what the isolated linker already did for a hoisted tree, and since `.bun` is gone afterwards, switching back to isolated now goes through that existing reset.
- Not done when `packages_to_install` is set: that is the security scanner's partial install (src/install/PackageManager/security_scanner.rs), which legitimately runs the hoisted linker against an isolated tree and must leave it alone.
- The reset is extracted from the isolated linker into `move_node_modules_aside` (src/install/isolated_install.rs) and shared. It moves every entry of `node_modules` except `.cache`, plus each workspace's `node_modules`, into `node_modules/.old_modules-<hex>`, the layout the isolated direction and its tests already have.
- Two deliberate changes from the extraction: entries are moved one at a time on every platform instead of renaming `node_modules` itself on POSIX (the hoisted direction has to get `.bun` out of the way even when `node_modules` is a mount point or a symlink), and Windows no longer skips dot entries (it has to move `.bun`; stale `.bin` goes too). The isolated side now detects the store with `directory_exists_at` instead of a probing `mkdir` that would have to be undone.
- Unchanged: a real directory at a link path is still indistinguishable from a `bun patch` workspace, so a tree that is already mixed (made by a release without this fix) still needs `rm -rf node_modules` before `--linker isolated`. Trees made with this fix never get into that state.
- Tests in test/cli/install/isolated-install.test.ts (`--linker flag` block): the full isolated -> hoisted -> hoisted -> isolated -> isolated sequence with a version bump each way (entry kinds, `2 packages installed` after each switch and `(no changes)` on each repeat, exactly one `.old_modules-*`, and `require("peer-deps")` seeing the same copy of `no-deps` as the root at every step); a workspace variant checking the workspace's own `node_modules` of store links is gone; and the scanner partial install checking the `node_modules` listing, `.old_modules-*` name included, is identical afterwards. The first two fail on the unfixed build (`1 package installed`; workspace `node_modules` still there); the third fails with the `packages_to_install` guard removed (checked by removing it).
- Also run: the whole isolated-install.test.ts, isolated-relink, bun-install-patch, bun-prune, bun-add (the two tests asserting `.old_modules-` and `.cache`), public-hoist-pattern, bun-workspaces, config-version, config-precedence, migration/pnpm-lock-v9, migration/migrate, bun-security-scanner-workspaces; `cargo check -p bun_install` for x86_64-pc-windows-msvc and aarch64-apple-darwin. The three new tests and the two existing `existing node_modules, missing node_modules/.bun` tests also pass on a Windows debug build (the shared reset now runs there for both directions).
- docs/pm/isolated-installs.mdx: one sentence under the troubleshooting step that recommends `bun install --linker hoisted`, saying the switch reinstalls `node_modules` and where the old tree goes.

### Background
- The hoisted linker writes each package as a real directory at `node_modules/<pkg>` (nested under a dependent for conflicting versions); only workspaces and `link:` dependencies are symlinks. On a warm install it keeps every `node_modules/<pkg>` whose package.json name and version match the lockfile.
- The isolated linker writes each package once into the store, `node_modules/.bun/<name>@<version>/node_modules/<name>`, puts that package's dependencies and peers next to it as symlinks inside the same store entry, and makes `node_modules/<pkg>` a symlink into the store. A package installed this way resolves its dependencies from its store entry, not from the root `node_modules`, which is why a mixed tree yields two copies.
- The presence of `node_modules/.bun` is the only on-disk record of which linker built a tree. The isolated linker has used it since #23311 to reset a hoisted tree (moving it to `node_modules/.old_modules-<hex>`), and `bun prune` uses it to refuse a linker mismatch, with an error that already tells the user to run `bun install` to reinstall with the configured linker. This PR adds the hoisted direction on the same signal.
- #29794 (open) is about stale workspace `node_modules` entries between two hoisted installs; it does not involve linker switching and is unaffected.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/isolated-install.test.ts

<!-- robobun:evidence:end -->