### PR TITLE
install: migrate pnpm onlyBuiltDependencies and report blocked scripts under the isolated linker

### DIFF
--- a/docs/pm/cli/install.mdx
+++ b/docs/pm/cli/install.mdx
@@ -602,6 +602,7 @@ Bun migrates the following pnpm configuration from both `pnpm-lock.yaml` and `pn
 - **Overrides**: Moved from `pnpm.overrides` to root-level `overrides` in `package.json`
 - **Patched Dependencies**: Moved from `pnpm.patchedDependencies` to root-level `patchedDependencies` in `package.json`
 - **Workspace Overrides**: Applied from `pnpm-workspace.yaml` to root `package.json`
+- **Allowed build scripts**: `onlyBuiltDependencies` (from `pnpm-workspace.yaml` or `pnpm.onlyBuiltDependencies` in `package.json`) is added to [`trustedDependencies`](/pm/lifecycle) in `package.json`, so the same packages keep running their lifecycle scripts
 
 ### Requirements and limitations
 

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -2018,6 +2018,7 @@ pub(crate) fn install_isolated_packages(
                     installer: bun_ptr::BackRef::from(core::ptr::NonNull::dangling()),
                     result: installer::Result::None,
                     relink: installer::Relink::Off,
+                    blocked_scripts: 0,
                     task: bun_threading::thread_pool::Task {
                         callback: installer::Task::callback,
                         node: Default::default(),

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -571,6 +571,18 @@ impl<'a> Installer<'a> {
         let is_duplicate = self.installed.is_set(pkg_id as usize);
         self.summary.success += (!is_duplicate) as u32;
         self.installed.set(pkg_id as usize);
+
+        // Once per package, like `success`: a package has one store entry per peer set.
+        let blocked_scripts = self.tasks[entry_id.get() as usize].blocked_scripts;
+        if blocked_scripts > 0 && !is_duplicate {
+            let dep_id = nodes.items_dep_id()[node_id.get() as usize];
+            let dep_name_hash = self.lockfile().buffers.dependencies[dep_id as usize].name_hash;
+            *self
+                .summary
+                .packages_with_blocked_scripts
+                .entry(dep_name_hash as TruncatedPackageNameHash)
+                .or_default() += usize::from(blocked_scripts);
+        }
     }
 
     /// Main thread only: `completed` just reached `Step::Done`; re-check every entry waiting on it.
@@ -662,6 +674,8 @@ pub struct Task {
 
     pub(crate) result: Result,
     pub(crate) relink: Relink,
+    /// Set by `Step::RunPreinstall` on the task thread, read by `on_task_complete` like `relink`.
+    pub(crate) blocked_scripts: u8,
 }
 
 // SAFETY: `next` is the sole intrusive link for `UnboundedQueue<Task>`.
@@ -1571,22 +1585,7 @@ impl Task {
 
                 Step::RunPreinstall => {
                     let current_step = Step::RunPreinstall;
-                    if !manager_ref.options.do_.contains(Do::RUN_SCRIPTS)
-                        || self.entry_id == StoreEntryId::ROOT
-                    {
-                        step = self.next_step(current_step);
-                        continue;
-                    }
-
-                    // The eligibility check excludes any package whose
-                    // lifecycle scripts are trusted to run, so a global-store
-                    // entry should never reach script enqueueing. Guard it
-                    // anyway: `meta.hasInstallScript` can be a false negative
-                    // (yarn-migrated lockfiles force it to `.false`), and a
-                    // script running with cwd inside a shared content-
-                    // addressed directory would mutate every other project's
-                    // copy.
-                    if installer.entry_uses_global_store(self.entry_id) {
+                    if self.entry_id == StoreEntryId::ROOT {
                         step = self.next_step(current_step);
                         continue;
                     }
@@ -1614,15 +1613,41 @@ impl Task {
                         break 'brk (false, false);
                     };
 
+                    if !(pkg_res.tag != ResolutionTag::Root
+                        && (pkg_res.tag == ResolutionTag::Workspace || is_trusted))
+                    {
+                        // Before the early returns below, like the hoisted installer.
+                        if pkg_res.tag != ResolutionTag::Root
+                            && pkg_metas[pkg_id as usize].has_install_script()
+                        {
+                            self.blocked_scripts = self.count_blocked_scripts(
+                                installer,
+                                manager_ref.get(),
+                                lockfile,
+                                pkg_script_lists[pkg_id as usize],
+                                dep.name.slice(string_buf),
+                                &pkg_res,
+                            );
+                        }
+                        step = self.next_step(current_step);
+                        continue;
+                    }
+
+                    if !manager_ref.options.do_.contains(Do::RUN_SCRIPTS) {
+                        step = self.next_step(current_step);
+                        continue;
+                    }
+
+                    // Trusted entries are never global-store eligible; never run in the shared dir.
+                    if installer.entry_uses_global_store(self.entry_id) {
+                        step = self.next_step(current_step);
+                        continue;
+                    }
+
                     let mut pkg_cwd = AutoAbsPath::init_top_level_dir();
                     installer.append_store_path(&mut pkg_cwd, self.entry_id);
 
                     'enqueue_lifecycle_scripts: {
-                        if !(pkg_res.tag != ResolutionTag::Root
-                            && (pkg_res.tag == ResolutionTag::Workspace || is_trusted))
-                        {
-                            break 'enqueue_lifecycle_scripts;
-                        }
                         let mut pkg_scripts: package::scripts::Scripts =
                             pkg_script_lists[pkg_id as usize];
                         let manager = manager_ref.get();
@@ -1917,6 +1942,49 @@ impl Task {
                     debug_assert!(false);
                     return Ok(Yield::Yield);
                 }
+            }
+        }
+    }
+
+    /// Task thread. Counts the installed scripts; `hasInstallScript` alone can be a false positive.
+    fn count_blocked_scripts(
+        &self,
+        installer: &Installer<'_>,
+        manager: &PackageManager,
+        lockfile: &Lockfile,
+        mut pkg_scripts: package::scripts::Scripts,
+        dep_name: &[u8],
+        pkg_res: &Resolution,
+    ) -> u8 {
+        // A global-store entry stays in its staging dir until `Step::Binaries` renames it.
+        let mut pkg_dir = AutoAbsPath::init_top_level_dir();
+        installer.append_real_store_path(&mut pkg_dir, self.entry_id, Which::Staging);
+
+        let mut log = Log::init();
+        match pkg_scripts.get_list(&mut log, lockfile, &mut pkg_dir, dep_name, pkg_res) {
+            Ok(Some(list)) => {
+                if manager.options.log_level.is_verbose() {
+                    bun_core::pretty_error!(
+                        "Blocked {} scripts for: {}@{}\n",
+                        list.total,
+                        bstr::BStr::new(dep_name),
+                        pkg_res.fmt(
+                            lockfile.buffers.string_bytes.as_slice(),
+                            bun_core::fmt::PathSep::Posix
+                        ),
+                    );
+                }
+                list.total
+            }
+            Ok(None) => 0,
+            Err(err) => {
+                if !manager.options.log_level.is_silent() {
+                    Output::err_generic(
+                        "failed to fill lifecycle scripts for <b>{}<r>: {}",
+                        (bstr::BStr::new(dep_name), err.name()),
+                    );
+                }
+                0
             }
         }
     }

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -1467,13 +1467,9 @@ impl Lockfile {
             name_hash: pkg_name_hashes,
             resolution: pkg_resolutions,
             bin: pkg_bins,
-            meta,
+            meta: pkg_metas,
             ..
         } = pkgs.split_mut();
-        // One loop serves both modes: bind `pkg_metas` as an empty slice
-        // when the const generic is false.
-        let pkg_metas: &mut [self::package::meta::Meta] =
-            if UPDATE_OS_CPU { meta } else { &mut [] };
 
         for i in 0..len {
             let pkg_name = pkg_names[i];
@@ -1551,8 +1547,11 @@ impl Lockfile {
 
                     builder.clamp();
 
+                    let pkg_meta = &mut pkg_metas[i];
+                    // Neither yarn.lock nor pnpm-lock.yaml records this.
+                    pkg_meta.set_has_install_script(pkg.package.has_install_script);
+
                     if UPDATE_OS_CPU {
-                        let pkg_meta = &mut pkg_metas[i];
                         // Update os/cpu metadata if not already set
                         if pkg_meta.os == Npm::OperatingSystem::ALL {
                             pkg_meta.os = pkg.package.os;

--- a/src/install/pnpm.rs
+++ b/src/install/pnpm.rs
@@ -1626,7 +1626,7 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
 
     lockfile.fetch_necessary_package_metadata_after_yarn_or_pnpm_migration::<false>(manager)?;
 
-    update_package_json_after_migration(manager, log, dir, &found_patches)?;
+    update_package_json_after_migration(lockfile, manager, log, dir, &found_patches)?;
 
     Ok(LoadResult::Ok(LoadResultOk {
         lockfile,
@@ -2331,8 +2331,97 @@ fn rewrite_bare_patch_keys(
     Ok(())
 }
 
+/// pnpm's allow-list of packages that may run lifecycle scripts, i.e. bun's `trustedDependencies`.
+fn collect_only_built_dependencies(list: &Expr, out: &mut Vec<&'static [u8]>) -> bool {
+    let Some(mut items) = list.as_array() else {
+        return false;
+    };
+    let mut found_any = false;
+    while let Some(item) = items.next() {
+        let Some(name) = as_string(&item) else {
+            continue;
+        };
+        if name.is_empty() {
+            continue;
+        }
+        found_any = true;
+        if !out.contains(&name) {
+            out.push(js_ast::data_store_dupe_str(name));
+        }
+    }
+    found_any
+}
+
+/// The migrated root skips `Package::parse`, so the lockfile's list is filled in here as well.
+fn add_trusted_dependencies(
+    json: &mut Expr,
+    lockfile: &mut Lockfile,
+    bump: &bun_alloc::Arena,
+    names: &[&'static [u8]],
+) -> Result<bool, AllocError> {
+    let existing = e_object(json).get(b"trustedDependencies");
+    if existing.is_some_and(|existing| !matches!(existing.data, ExprData::EArray(_))) {
+        return Ok(false);
+    }
+
+    let mut items = js_ast::ExprNodeList::init_capacity(names.len());
+    if let Some(mut existing_items) = existing.as_ref().and_then(Expr::as_array) {
+        while let Some(item) = existing_items.next() {
+            VecExt::append(&mut items, item);
+        }
+    }
+
+    let mut added_any = false;
+    for &name in names {
+        if items
+            .slice()
+            .iter()
+            .any(|item| as_string(item) == Some(name))
+        {
+            continue;
+        }
+        VecExt::append(
+            &mut items,
+            Expr::init(E::EString::init(name), bun_ast::Loc::EMPTY),
+        );
+        added_any = true;
+    }
+
+    let trusted = lockfile
+        .trusted_dependencies
+        .get_or_insert_with(Default::default);
+    for item in items.slice() {
+        if let Some(name) = as_string(item) {
+            trusted.put(
+                semver::string::Builder::string_hash(name) as crate::TruncatedPackageNameHash,
+                Box::from(name),
+            )?;
+        }
+    }
+
+    if !added_any {
+        return Ok(false);
+    }
+
+    let is_single_line = items.len_u32() == 1;
+    e_object_mut(json).put(
+        bump,
+        b"trustedDependencies",
+        Expr::init(
+            E::Array {
+                items,
+                is_single_line,
+                ..Default::default()
+            },
+            bun_ast::Loc::EMPTY,
+        ),
+    )?;
+    Ok(true)
+}
+
 /// Updates package.json with workspace and catalog information after migration
 fn update_package_json_after_migration(
+    lockfile: &mut Lockfile,
     manager: &mut PackageManager,
     log: &mut bun_ast::Log,
     dir: Fd,
@@ -2369,6 +2458,11 @@ fn update_package_json_after_migration(
     let mut moved_overrides = false;
     let mut moved_patched_deps = false;
     let mut moved: Vec<&'static str> = Vec::new();
+
+    // Copied rather than moved out of the `pnpm` block: pnpm itself still reads it there.
+    let mut trusted_names: Vec<&'static [u8]> = Vec::new();
+    let mut pnpm_only_built_deps = false;
+    let mut workspace_only_built_deps = false;
 
     if let Some(mut pnpm_prop) = json.as_property(b"pnpm") {
         if pnpm_prop.expr.is_object() {
@@ -2431,6 +2525,11 @@ fn update_package_json_after_migration(
                     needs_update = true;
                     moved.push("pnpm.patchedDependencies to patchedDependencies");
                 }
+            }
+
+            if let Some(only_built) = pnpm_obj.get(b"onlyBuiltDependencies") {
+                pnpm_only_built_deps =
+                    collect_only_built_dependencies(&only_built, &mut trusted_names);
             }
 
             if moved_overrides || moved_patched_deps {
@@ -2573,6 +2672,11 @@ fn update_package_json_after_migration(
             .flatten()
             {
                 data_store_dupe_expr_strings(subtree);
+            }
+
+            if let Some(only_built) = ws_root.get(b"onlyBuiltDependencies") {
+                workspace_only_built_deps =
+                    collect_only_built_dependencies(&only_built, &mut trusted_names);
             }
         }
         Err(_) => {}
@@ -2729,6 +2833,18 @@ fn update_package_json_after_migration(
             }
             needs_update = true;
             moved.push("pnpm-workspace.yaml patchedDependencies to patchedDependencies");
+        }
+    }
+
+    if !trusted_names.is_empty()
+        && add_trusted_dependencies(&mut json, lockfile, &bump, &trusted_names)?
+    {
+        needs_update = true;
+        if pnpm_only_built_deps {
+            moved.push("pnpm.onlyBuiltDependencies to trustedDependencies");
+        }
+        if workspace_only_built_deps {
+            moved.push("pnpm-workspace.yaml onlyBuiltDependencies to trustedDependencies");
         }
     }
 

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -1937,6 +1937,86 @@ test("runs lifecycle scripts correctly", async () => {
   expect(allLifecycleScriptsDir).toEqual(["all-lifecycle-scripts"]);
 });
 
+describe("blocked lifecycle scripts", () => {
+  const blockedLine = "Blocked 4 postinstalls. Run `bun pm untrusted` for details.";
+
+  async function createUntrustedScriptsDir(bunfigOpts: { linker: "isolated"; globalStore?: boolean }) {
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts });
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "test-pkg-blocked-scripts",
+        dependencies: {
+          // one postinstall
+          "lifecycle-postinstall": "1.0.0",
+          // preinstall, install and postinstall
+          "all-lifecycle-scripts": "1.0.0",
+          // no scripts
+          "no-deps": "1.0.0",
+        },
+      }),
+    );
+    return packageDir;
+  }
+
+  test.concurrent("are reported in the install summary like the hoisted linker does", async () => {
+    const packageDir = await createUntrustedScriptsDir({ linker: "isolated" });
+
+    const { out } = await runBunInstall(bunEnv, packageDir);
+
+    expect(out).toContain(blockedLine);
+    expect(existsSync(join(packageDir, "node_modules", "lifecycle-postinstall", "postinstall.txt"))).toBeFalse();
+    expect(existsSync(join(packageDir, "node_modules", "all-lifecycle-scripts", "postinstall.txt"))).toBeFalse();
+  });
+
+  test.concurrent("are not reported for trusted packages", async () => {
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "test-pkg-blocked-scripts-trusted",
+        dependencies: { "lifecycle-postinstall": "1.0.0" },
+        trustedDependencies: ["lifecycle-postinstall"],
+      }),
+    );
+
+    const { out } = await runBunInstall(bunEnv, packageDir);
+
+    expect(out).not.toContain("Blocked");
+    expect(existsSync(join(packageDir, "node_modules", "lifecycle-postinstall", "postinstall.txt"))).toBeTrue();
+  });
+
+  test.concurrent("are still reported with --ignore-scripts", async () => {
+    const packageDir = await createUntrustedScriptsDir({ linker: "isolated" });
+
+    await using proc = spawn({
+      cmd: [bunExe(), "install", "--ignore-scripts"],
+      cwd: packageDir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(out).toContain(blockedLine);
+    expect(err).not.toContain("error:");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("are reported for packages installed into the global store", async () => {
+    const packageDir = await createUntrustedScriptsDir({ linker: "isolated", globalStore: true });
+
+    const { out } = await runBunInstall(bunEnv, packageDir);
+
+    expect(out).toContain(blockedLine);
+    // Untrusted packages are eligible for the global store, so this is the
+    // path that bypasses script enqueueing entirely.
+    expect(lstatSync(join(packageDir, "node_modules", ".bun", "lifecycle-postinstall@1.0.0")).isSymbolicLink()).toBe(
+      true,
+    );
+  });
+});
+
 // Self-contained HTTP server that serves package manifests & tarballs
 // directly from the Verdaccio fixtures, with Cache-Control: max-age=300
 // to replicate npmjs.org behavior (fully synchronous on warm cache).

--- a/test/cli/install/migration/pnpm-lock-v9.test.ts
+++ b/test/cli/install/migration/pnpm-lock-v9.test.ts
@@ -2922,4 +2922,178 @@ snapshots:
       expect(existsSync(join(String(dir), "bun.lock"))).toBe(false);
     });
   });
+
+  // pnpm's `onlyBuiltDependencies` is the allow-list of packages whose lifecycle
+  // scripts may run, which is `trustedDependencies` in bun.
+  describe("onlyBuiltDependencies", () => {
+    const LIFECYCLE_POSTINSTALL_1_0_0_INTEGRITY =
+      "sha512-+frsFSxvy+pkm5fjAsAHptt2NiMMMnU07dan43rZO1yCqxy8vU0X8wNTOYlgkViD7HCHT/bIpPhoki935Nc2pg==";
+
+    // `lifecycle-postinstall`'s postinstall writes postinstall.txt next to itself.
+    const lifecyclePostinstallLockfile = `lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    dependencies:
+      lifecycle-postinstall:
+        specifier: 1.0.0
+        version: 1.0.0
+
+packages:
+
+  lifecycle-postinstall@1.0.0:
+    resolution: {integrity: ${LIFECYCLE_POSTINSTALL_1_0_0_INTEGRITY}}
+
+snapshots:
+
+  lifecycle-postinstall@1.0.0: {}
+`;
+
+    function postinstallRan(dir: string) {
+      return existsSync(join(dir, "node_modules", "lifecycle-postinstall", "postinstall.txt"));
+    }
+
+    for (const linker of ["hoisted", "isolated"] as const) {
+      test.concurrent(`pnpm-workspace.yaml list becomes trustedDependencies (${linker})`, async () => {
+        const { packageDir } = await verdaccio.createTestDir({
+          bunfigOpts: { linker },
+          files: {
+            "package.json": JSON.stringify({
+              name: "only-built-workspace-yaml",
+              dependencies: { "lifecycle-postinstall": "1.0.0" },
+            }),
+            "pnpm-workspace.yaml": "onlyBuiltDependencies:\n  - lifecycle-postinstall\n",
+            "pnpm-lock.yaml": lifecyclePostinstallLockfile,
+          },
+        });
+
+        const { stderr, exitCode } = await migrate(packageDir);
+
+        expect(stderr).toContain("pnpm-workspace.yaml onlyBuiltDependencies to trustedDependencies in package.json");
+        expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
+        expect(exitCode).toBe(0);
+
+        expect(await Bun.file(join(packageDir, "package.json")).json()).toStrictEqual({
+          name: "only-built-workspace-yaml",
+          dependencies: { "lifecycle-postinstall": "1.0.0" },
+          trustedDependencies: ["lifecycle-postinstall"],
+        });
+        expect(await bunLockOf(packageDir)).toContain(`"trustedDependencies": [\n    "lifecycle-postinstall",\n  ]`);
+
+        const install = await run(packageDir, "install");
+
+        expect(install.stderr).not.toContain("error:");
+        expect(install.stdout).not.toContain("Blocked");
+        expect(postinstallRan(packageDir)).toBe(true);
+        expect(install.exitCode).toBe(0);
+      });
+
+      // Without an allow-list the scripts stay blocked, and the install has to say so.
+      test.concurrent(`blocked scripts are reported after migrating (${linker})`, async () => {
+        const { packageDir } = await verdaccio.createTestDir({
+          bunfigOpts: { linker },
+          files: {
+            "package.json": JSON.stringify({
+              name: "only-built-missing",
+              dependencies: { "lifecycle-postinstall": "1.0.0" },
+            }),
+            "pnpm-lock.yaml": lifecyclePostinstallLockfile,
+          },
+        });
+
+        const { stdout, stderr, exitCode } = await run(packageDir, "install");
+
+        expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
+        expect(stderr).not.toContain("trustedDependencies");
+        expect(stdout).toContain("Blocked 1 postinstall. Run `bun pm untrusted` for details.");
+        expect(postinstallRan(packageDir)).toBe(false);
+        expect(exitCode).toBe(0);
+      });
+    }
+
+    test.concurrent("bun install migrates the list and runs the scripts in the same run", async () => {
+      const { packageDir } = await verdaccio.createTestDir({
+        bunfigOpts: { linker: "isolated" },
+        files: {
+          "package.json": JSON.stringify({
+            name: "only-built-install",
+            dependencies: { "lifecycle-postinstall": "1.0.0" },
+          }),
+          "pnpm-workspace.yaml": "onlyBuiltDependencies:\n  - lifecycle-postinstall\n",
+          "pnpm-lock.yaml": lifecyclePostinstallLockfile,
+        },
+      });
+
+      const { stdout, stderr, exitCode } = await run(packageDir, "install");
+
+      expect(stderr).toContain("pnpm-workspace.yaml onlyBuiltDependencies to trustedDependencies in package.json");
+      expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
+      expect(stdout).not.toContain("Blocked");
+      expect(postinstallRan(packageDir)).toBe(true);
+      expect(exitCode).toBe(0);
+      expect((await Bun.file(join(packageDir, "package.json")).json()).trustedDependencies).toEqual([
+        "lifecycle-postinstall",
+      ]);
+    });
+
+    // pnpm 9 kept the list in package.json. Both sources merge into an existing list, and
+    // the pnpm block keeps its copy for anyone still running pnpm on the project.
+    test.concurrent("package.json pnpm.onlyBuiltDependencies merges into an existing trustedDependencies", async () => {
+      const pnpm = { onlyBuiltDependencies: ["esbuild", "from-package-json"] };
+      using dir = tempDir("pnpm-v9-only-built-pnpm-field", {
+        "package.json": JSON.stringify({
+          name: "only-built-pnpm-field",
+          trustedDependencies: ["already-trusted", "esbuild"],
+          pnpm,
+        }),
+        "pnpm-workspace.yaml": "onlyBuiltDependencies:\n  - from-workspace-yaml\n  - esbuild\n",
+        "pnpm-lock.yaml": `lockfileVersion: '9.0'
+
+importers:
+
+  .: {}
+`,
+      });
+
+      const { stderr, exitCode } = await migrate(String(dir));
+
+      expect(stderr).toContain(
+        "pnpm.onlyBuiltDependencies to trustedDependencies, pnpm-workspace.yaml onlyBuiltDependencies to trustedDependencies in package.json",
+      );
+      expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
+      expect(exitCode).toBe(0);
+
+      expect(await Bun.file(join(String(dir), "package.json")).json()).toStrictEqual({
+        name: "only-built-pnpm-field",
+        trustedDependencies: ["already-trusted", "esbuild", "from-package-json", "from-workspace-yaml"],
+        pnpm,
+      });
+    });
+
+    test.concurrent("a list that adds nothing leaves package.json alone", async () => {
+      const packageJson = {
+        name: "only-built-nothing-new",
+        trustedDependencies: ["esbuild"],
+        pnpm: { onlyBuiltDependencies: [] },
+      };
+      using dir = tempDir("pnpm-v9-only-built-nothing-new", {
+        "package.json": JSON.stringify(packageJson),
+        "pnpm-workspace.yaml": "onlyBuiltDependencies:\n  - esbuild\n",
+        "pnpm-lock.yaml": `lockfileVersion: '9.0'
+
+importers:
+
+  .: {}
+`,
+      });
+
+      const { stderr, exitCode } = await migrate(String(dir));
+
+      expect(stderr).not.toContain("onlyBuiltDependencies");
+      expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
+      expect(exitCode).toBe(0);
+      expect(await Bun.file(join(String(dir), "package.json")).json()).toStrictEqual(packageJson);
+    });
+  });
 });


### PR DESCRIPTION
### Problem

- `bun install` / `bun pm migrate` on a pnpm project drops pnpm's `onlyBuiltDependencies` allow-list: `update_package_json_after_migration` (`src/install/pnpm.rs`) reads `packages`, `catalog(s)`, `overrides` and `patchedDependencies` from `pnpm-workspace.yaml` and the `pnpm` block, nothing else. The packages pnpm was building silently stop running their scripts after the switch (only bun's default trusted list still builds), and `package.json` gets no `trustedDependencies`.
- The install that follows says nothing about it. Two separate reasons:
  - The isolated installer never fills `summary.packages_with_blocked_scripts`: `Step::RunPreinstall` (`isolated_install/Installer.rs`) returned as soon as a package was untrusted, so `print_blocked_packages_info` had nothing to print. The hoisted installer records the count in `PackageInstaller.rs` (`install_package_with_name_and_resolution`). Affects every isolated install, not only migrations; `bun pm untrusted` afterwards does list the package.
  - After a pnpm or yarn migration no package has `meta.has_install_script` set (neither lockfile records it, and `fetch_necessary_package_metadata_after_yarn_or_pnpm_migration` only copied `bin` and os/cpu), and both installers gate the notice on that flag. So on main the hoisted linker does not print it after a migration either.

### Fix

- `pnpm.rs`: names from `onlyBuiltDependencies` in `pnpm-workspace.yaml` and from `pnpm.onlyBuiltDependencies` in `package.json` are appended to the root `trustedDependencies` array (created if missing, existing entries kept, duplicates skipped) and put into `lockfile.trusted_dependencies`, which is what `Package::parse` does for a root `package.json` on a normal load; the migrated root package is built without it, so `bun pm migrate` writes the list into `bun.lock` too. The migration line reports `pnpm.onlyBuiltDependencies to trustedDependencies` / `pnpm-workspace.yaml onlyBuiltDependencies to trustedDependencies`. The `pnpm` block keeps its copy (pnpm still reads it; bun ignores it), unlike what this function currently does with `overrides` and `patchedDependencies`, which #38775 is changing to the same copy semantics. An empty list, or one that adds nothing, leaves `package.json` untouched; a `trustedDependencies` that is not an array is left for `bun install` to report.
- `lockfile.rs`: the post-migration manifest pass also copies `hasInstallScript` from the manifest for both pnpm and yarn migrations.
- `isolated_install/Installer.rs`: when `RunPreinstall` decides not to run a package's scripts and the package's manifest says it has some, the task counts them from the installed `package.json` (`Scripts::get_list`, the same probe `bun pm untrusted` uses, which also handles the `hasInstallScript`-but-no-scripts false positive) into a new `Task.blocked_scripts`; `on_task_complete` adds it to the summary on the main thread, once per package like `success`. This happens before the `--ignore-scripts` and global-store early returns, matching the hoisted installer, which reports in both cases. Printing is unchanged: `print_install_summary` already reads the same summary for both linkers.
- Verified with `test/cli/install/migration/pnpm-lock-v9.test.ts` (`onlyBuiltDependencies` describe, 7 tests: 6 fail on main, the no-op case is a control) and `test/cli/install/isolated-install.test.ts` (`blocked lifecycle scripts` describe, 4 tests: 3 fail on main, the trusted case is a control). The migration tests cover both linkers, `bun pm migrate` followed by `bun install`, and `bun install` straight from `pnpm-lock.yaml`; the isolated tests cover the plain case, `--ignore-scripts` and `install.globalStore`.
- Also ran: the rest of `pnpm-lock-v9.test.ts` (84 pass), `test/cli/install/migration/` (yarn and pnpm files pass; `complex-workspace` needs network), `isolated-install.test.ts` (70 pass), `isolated-relink`, `nested-overrides`, `bun-install-native-binlink`, `config-precedence`, `bun-pm`, the isolated cases of `bun-install-lifecycle-scripts`, `test/internal/source-lints`, `cargo clippy -p bun_install`.
- Docs: the pnpm migration section of `docs/pm/cli/install.mdx` lists the new field.
- Related open PRs: #38775 rewrites the same migration function (this change is kept additive so either order rebases); #35106 and #35818 (both stale against main) cover the isolated notice and the hoisted `hasInstallScript` gate respectively with different approaches. Not changed here: neither linker prints the notice when reinstalling from an existing `bun.lock`, because `hasInstallScript` is not stored in the text lockfile (described in #35818).

### Background

- pnpm 10 runs no dependency lifecycle scripts unless the package is listed in `onlyBuiltDependencies` (`pnpm approve-builds` writes it into `pnpm-workspace.yaml`; pnpm 9 projects keep it under the `pnpm` key of `package.json`). bun's equivalent is `trustedDependencies`: when present it is the complete allow-list and bun's default trusted list is not consulted, which is the same meaning.
- `meta.has_install_script` is the registry's `hasInstallScript` packument flag, kept per package in the in-memory lockfile. Scripts never run because of it; it only decides whether an installer bothers to open the package's `package.json` to count the scripts it is blocking.
- The isolated installer runs one `Task` per store entry on the thread pool, stepping through `Step::LinkPackage` .. `Step::Done`; the `Installer` and its summary are only mutated on the main thread when a finished task is popped from `task_queue` (`on_task_complete`). `Task.relink` already crosses the threads the same way `blocked_scripts` does here. A package gets one store entry per distinct peer set, which is why the summary is keyed once per package.
- Global store (`install.globalStore`): untrusted packages are shared across projects from `<cache>/links`, and their files are staged under a temporary name until `Step::Binaries` renames them into place, so the count reads from the staging path (`append_real_store_path(.., Which::Staging)`).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 9 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/isolated-install.test.ts

<!-- robobun:evidence:end -->