### PR TITLE
install: skip workspace members whose package.json has no name

### DIFF
--- a/docs/pm/workspaces.mdx
+++ b/docs/pm/workspaces.mdx
@@ -66,6 +66,8 @@ Each workspace has its own `package.json`. To reference another package in the m
 }
 ```
 
+A workspace needs a `"name"`. Bun skips a matched `package.json` that has no `"name"`, such as a test fixture containing only `{ "type": "module" }`. Bun does not link the skipped directory into `node_modules` and does not install its dependencies. If the skipped `package.json` declares dependencies, `bun install` prints a warning that names the directory.
+
 `bun install` installs dependencies for all workspaces in the monorepo, de-duplicating packages if possible. To install dependencies for specific workspaces only, use the `--filter` flag.
 
 ```bash

--- a/src/install/error.rs
+++ b/src/install/error.rs
@@ -176,8 +176,6 @@ pub enum Error {
     CorruptLockfile,
     #[error("Lockfile is missing resolution data")]
     LockfileIsMissingResolutionData,
-    #[error("MissingPackageName")]
-    MissingPackageName,
     #[error("GlobError")]
     GlobError,
     #[error("Invalid")]
@@ -343,7 +341,6 @@ impl Error {
             }
             Self::CorruptLockfile => "CorruptLockfile",
             Self::LockfileIsMissingResolutionData => "Lockfile is missing resolution data",
-            Self::MissingPackageName => "MissingPackageName",
             Self::GlobError => "GlobError",
             Self::Invalid => "Invalid",
             Self::LockfileValidationFailedListIsImpossiblyLong => {

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -2465,6 +2465,8 @@ impl Package<u64> {
             }
         }
 
+        workspace_names.warn_skipped(log);
+
         if FEATURES.trusted_dependencies {
             if let Some(q) = json.as_property(b"trustedDependencies") {
                 let count = match &q.expr.data {

--- a/src/install/lockfile/Package/WorkspaceMap.rs
+++ b/src/install/lockfile/Package/WorkspaceMap.rs
@@ -18,8 +18,7 @@ bun_output::declare_scope!(Lockfile, hidden);
 
 pub(crate) struct WorkspaceMap {
     map: Map,
-    /// Nameless members whose dependencies are therefore not installed. Only the
-    /// root package.json parse reports them; the other scans of one command stay quiet.
+    /// Relative dirs of nameless members that declare dependencies, for `warn_skipped`.
     skipped_with_dependencies: Vec<Box<[u8]>>,
 }
 

--- a/src/install/lockfile/Package/WorkspaceMap.rs
+++ b/src/install/lockfile/Package/WorkspaceMap.rs
@@ -18,10 +18,8 @@ bun_output::declare_scope!(Lockfile, hidden);
 
 pub(crate) struct WorkspaceMap {
     map: Map,
-    /// Nameless members that declare dependencies (which therefore won't be
-    /// installed). Warned about from the root package.json parse rather than
-    /// during the scan: migrations, `--filter` and locating the root from a
-    /// member dir scan too, and would repeat the warning within one command.
+    /// Nameless members whose dependencies are therefore not installed. Only the
+    /// root package.json parse reports them; the other scans of one command stay quiet.
     skipped_with_dependencies: Vec<Box<[u8]>>,
 }
 
@@ -36,9 +34,7 @@ pub struct Entry {
 
 enum Scanned {
     Workspace(Entry),
-    /// A matched package.json without a usable `"name"` (typically a test
-    /// fixture). Workspaces are linked and resolved by name, so it is not one;
-    /// pnpm and npm accept such members too, so it is skipped rather than an error.
+    /// No usable `"name"`, so nothing to link or resolve it by; skipped, as pnpm and npm do.
     Nameless {
         declares_dependencies: bool,
     },
@@ -58,8 +54,7 @@ impl WorkspaceMap {
             Scanned::Nameless {
                 declares_dependencies,
             } => {
-                // Overlapping patterns match a directory more than once; named
-                // members collapse through `insert`, this list has to on its own.
+                // Overlapping patterns match the same directory more than once.
                 if declares_dependencies
                     && !self
                         .skipped_with_dependencies

--- a/src/install/lockfile/Package/WorkspaceMap.rs
+++ b/src/install/lockfile/Package/WorkspaceMap.rs
@@ -58,7 +58,14 @@ impl WorkspaceMap {
             Scanned::Nameless {
                 declares_dependencies,
             } => {
-                if declares_dependencies {
+                // Overlapping patterns match a directory more than once; named
+                // members collapse through `insert`, this list has to on its own.
+                if declares_dependencies
+                    && !self
+                        .skipped_with_dependencies
+                        .iter()
+                        .any(|dir| **dir == *relative_dir)
+                {
                     self.skipped_with_dependencies.push(relative_dir.into());
                 }
                 None

--- a/src/install/lockfile/Package/WorkspaceMap.rs
+++ b/src/install/lockfile/Package/WorkspaceMap.rs
@@ -8,6 +8,7 @@ use bun_paths as path;
 use bun_paths::resolve_path;
 use bun_paths::{MAX_PATH_BYTES, PathBuffer, SEP_STR};
 
+use super::DependencyGroup;
 use crate::lockfile_real::{Lockfile, StringBuilder, pruned_workspaces};
 use crate::package_manager::workspace_package_json_cache::{
     GetJSONOptions, WorkspacePackageJSONCache,
@@ -17,6 +18,11 @@ bun_output::declare_scope!(Lockfile, hidden);
 
 pub(crate) struct WorkspaceMap {
     map: Map,
+    /// Nameless members that declare dependencies (which therefore won't be
+    /// installed). Warned about from the root package.json parse rather than
+    /// during the scan: migrations, `--filter` and locating the root from a
+    /// member dir scan too, and would repeat the warning within one command.
+    skipped_with_dependencies: Vec<Box<[u8]>>,
 }
 
 type Map = StringArrayHashMap<Entry>;
@@ -28,10 +34,48 @@ pub struct Entry {
     pub(crate) name_loc: bun_ast::Loc,
 }
 
+enum Scanned {
+    Workspace(Entry),
+    /// A matched package.json without a usable `"name"` (typically a test
+    /// fixture). Workspaces are linked and resolved by name, so it is not one;
+    /// pnpm and npm accept such members too, so it is skipped rather than an error.
+    Nameless {
+        declares_dependencies: bool,
+    },
+}
+
 impl WorkspaceMap {
     pub(crate) fn init() -> WorkspaceMap {
         WorkspaceMap {
             map: Map::default(),
+            skipped_with_dependencies: Vec::new(),
+        }
+    }
+
+    fn workspace_entry(&mut self, scanned: Scanned, relative_dir: &[u8]) -> Option<Entry> {
+        match scanned {
+            Scanned::Workspace(entry) => Some(entry),
+            Scanned::Nameless {
+                declares_dependencies,
+            } => {
+                if declares_dependencies {
+                    self.skipped_with_dependencies.push(relative_dir.into());
+                }
+                None
+            }
+        }
+    }
+
+    pub(crate) fn warn_skipped(&self, log: &mut bun_ast::Log) {
+        for dir in &self.skipped_with_dependencies {
+            log.add_warning_fmt(
+                None,
+                bun_ast::Loc::EMPTY,
+                format_args!(
+                    "Skipping workspace \"{}\": its package.json has no \"name\", so its dependencies will not be installed",
+                    BStr::new(dir)
+                ),
+            );
         }
     }
 
@@ -127,7 +171,7 @@ fn process_workspace_name(
     json_cache: &mut WorkspacePackageJSONCache,
     abs_package_json_path: &[u8],
     log: &mut bun_ast::Log,
-) -> crate::Result<Entry> {
+) -> crate::Result<Scanned> {
     let workspace_json = json_cache
         .get_with_path(
             log,
@@ -144,17 +188,32 @@ fn process_workspace_name(
     // results are immediately boxed so the bump can drop at scope exit.
     let scratch = Arena::new();
 
-    let name_expr = workspace_json
-        .root
-        .get(b"name")
-        .ok_or(crate::Error::MissingPackageName)?;
-    let name = name_expr
-        .as_string_cloned(&scratch)?
-        .ok_or(crate::Error::MissingPackageName)?;
+    let name = match workspace_json.root.get(b"name") {
+        Some(name_expr) => name_expr
+            .as_string_cloned(&scratch)?
+            .filter(|name| !name.is_empty())
+            .map(|name| (name, name_expr.loc)),
+        None => None,
+    };
+    let Some((name, name_loc)) = name else {
+        bun_output::scoped_log!(
+            Lockfile,
+            "processWorkspaceName({}) has no name, skipping",
+            BStr::new(abs_package_json_path)
+        );
+        return Ok(Scanned::Nameless {
+            declares_dependencies: DependencyGroup::FOUR.iter().any(|group| {
+                workspace_json
+                    .root
+                    .get(group.prop)
+                    .is_some_and(|deps| deps.property_count() > 0)
+            }),
+        });
+    };
 
     let entry = Entry {
         name: Box::<[u8]>::from(name),
-        name_loc: name_expr.loc,
+        name_loc,
         version: 'brk: {
             if let Some(version_expr) = workspace_json.root.get(b"version") {
                 if let Some(version) = version_expr.as_string_cloned(&scratch)? {
@@ -171,7 +230,7 @@ fn process_workspace_name(
         BStr::new(&entry.name)
     );
 
-    Ok(entry)
+    Ok(Scanned::Workspace(entry))
 }
 
 fn workspace_dir_of(abs_package_json_path: &[u8]) -> &[u8] {
@@ -265,12 +324,12 @@ impl WorkspaceMap {
                     }
 
                     process_workspace_name(json_cache, abs_package_json_path, log)
-                        .map(|entry| (abs_package_json_path, entry))
+                        .map(|scanned| (abs_package_json_path, scanned))
                 }
                 None => Err(crate::Error::Sys(bun_errno::SystemErrno::ENAMETOOLONG)),
             };
 
-            let (abs_package_json_path, workspace_entry) = match processed {
+            let (abs_package_json_path, scanned) = match processed {
                 Ok(processed) => processed,
                 Err(err) => {
                     if err == crate::Error::Sys(bun_errno::SystemErrno::ENOENT) {
@@ -302,15 +361,6 @@ impl WorkspaceMap {
                             arr.item_loc(source, i),
                             format_args!("Workspace not found \"{}\"", BStr::new(input_path)),
                         );
-                    } else if err == crate::Error::MissingPackageName {
-                        let _ = log.add_error_fmt(
-                            Some(source),
-                            loc,
-                            format_args!(
-                                "Missing \"name\" from package.json in {}",
-                                BStr::new(input_path)
-                            ),
-                        );
                     } else {
                         let mut cwd_buf = vec![0u8; MAX_PATH_BYTES];
                         let cwd_len = bun_sys::getcwd(&mut cwd_buf).expect("unreachable");
@@ -329,15 +379,16 @@ impl WorkspaceMap {
                 }
             };
 
-            if workspace_entry.name.len() == 0 {
-                continue;
-            }
-
             let rel_input_path = relative_workspace_path(
                 &mut rel_path_buf.0,
                 root_dir,
                 workspace_dir_of(abs_package_json_path),
             );
+
+            let Some(workspace_entry) = workspace_names.workspace_entry(scanned, rel_input_path)
+            else {
+                continue;
+            };
 
             if let Some(builder) = string_builder.as_deref_mut() {
                 builder.count(&workspace_entry.name);
@@ -484,54 +535,43 @@ impl WorkspaceMap {
                     ) {
                         Some(abs_package_json_path) => {
                             process_workspace_name(json_cache, abs_package_json_path, log)
-                                .map(|entry| (abs_package_json_path, entry))
+                                .map(|scanned| (abs_package_json_path, scanned))
                         }
                         None => Err(crate::Error::Sys(bun_errno::SystemErrno::ENAMETOOLONG)),
                     };
 
-                    let (abs_package_json_path, workspace_entry) = match processed {
+                    let (abs_package_json_path, scanned) = match processed {
                         Ok(processed) => processed,
                         Err(err) => {
-                            let entry_base: &[u8] = path::basename(matched_path);
                             if err == crate::Error::Sys(bun_errno::SystemErrno::ENOENT) {
                                 continue;
-                            } else if err == crate::Error::MissingPackageName {
-                                let _ = log.add_error_fmt(
-                                    Some(source),
-                                    bun_ast::Loc::EMPTY,
-                                    format_args!(
-                                        "Missing \"name\" from package.json in {}{}{}",
-                                        BStr::new(entry_dir),
-                                        SEP_STR,
-                                        BStr::new(entry_base),
-                                    ),
-                                );
-                            } else {
-                                let _ = log.add_error_fmt(
-                                    Some(source),
-                                    bun_ast::Loc::EMPTY,
-                                    format_args!(
-                                        "{} reading package.json for workspace package \"{}\" from \"{}\"",
-                                        err.name(),
-                                        BStr::new(entry_dir),
-                                        BStr::new(entry_base),
-                                    ),
-                                );
                             }
-
+                            let entry_base: &[u8] = path::basename(matched_path);
+                            let _ = log.add_error_fmt(
+                                Some(source),
+                                bun_ast::Loc::EMPTY,
+                                format_args!(
+                                    "{} reading package.json for workspace package \"{}\" from \"{}\"",
+                                    err.name(),
+                                    BStr::new(entry_dir),
+                                    BStr::new(entry_base),
+                                ),
+                            );
                             continue;
                         }
                     };
-
-                    if workspace_entry.name.len() == 0 {
-                        continue;
-                    }
 
                     let workspace_path: &[u8] = relative_workspace_path(
                         &mut rel_path_buf.0,
                         root_dir,
                         workspace_dir_of(abs_package_json_path),
                     );
+
+                    let Some(workspace_entry) =
+                        workspace_names.workspace_entry(scanned, workspace_path)
+                    else {
+                        continue;
+                    };
 
                     if let Some(builder) = string_builder.as_deref_mut() {
                         builder.count(&workspace_entry.name);

--- a/src/install/migration.rs
+++ b/src/install/migration.rs
@@ -133,11 +133,6 @@ pub fn detect_and_load_other_lockfile<'a>(
                                 "Relative link dependencies aren't supported yet. Please follow along at <magenta>https://github.com/oven-sh/bun/issues/23026<r>",
                             );
                         }
-                        MigratePnpmLockfileError::WorkspaceNameMissing => {
-                            bun_core::warn!(
-                                "pnpm-lock.yaml migration failed due to missing workspace name.",
-                            );
-                        }
                         MigratePnpmLockfileError::YamlParseError => {
                             bun_core::warn!("Failed to parse pnpm-lock.yaml.");
                         }

--- a/src/install/pnpm.rs
+++ b/src/install/pnpm.rs
@@ -364,8 +364,6 @@ pub enum MigratePnpmLockfileError {
     NonExistentWorkspaceDependency,
     #[error("RelativeLinkDependency")]
     RelativeLinkDependency,
-    #[error("WorkspaceNameMissing")]
-    WorkspaceNameMissing,
     #[error("DependencyLoop")]
     DependencyLoop,
     #[error("PnpmLockfileNotObject")]
@@ -770,9 +768,12 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
 
             let workspace_root = &importer_pkg_json.root;
 
-            let Some((name, _)) = get_string(workspace_root, b"name") else {
-                // we require workspace names.
-                return Err(MigratePnpmLockfileError::WorkspaceNameMissing);
+            // Same rule as the workspace scan (`WorkspaceMap::process_workspace_name`):
+            // a package.json without a name is not a workspace package.
+            let Some((name, _)) =
+                get_string(workspace_root, b"name").filter(|(name, _)| !name.is_empty())
+            else {
+                continue;
             };
 
             let name_hash = semver::string::Builder::string_hash(name);

--- a/src/install/pnpm.rs
+++ b/src/install/pnpm.rs
@@ -768,8 +768,7 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
 
             let workspace_root = &importer_pkg_json.root;
 
-            // Same rule as the workspace scan (`WorkspaceMap::process_workspace_name`):
-            // a package.json without a name is not a workspace package.
+            // Nameless importers are skipped like `WorkspaceMap::process_workspace_name` skips them.
             let Some((name, _)) =
                 get_string(workspace_root, b"name").filter(|(name, _)| !name.is_empty())
             else {

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -233,6 +233,94 @@ test.concurrent("allowing negative workspace patterns", async () => {
   });
 });
 
+// pnpm and npm accept workspace members whose package.json has no "name" (vite's
+// pnpm-workspace.yaml matches dozens of test fixtures shaped like `{"type":"module"}`).
+describe("workspace member package.json without a name", () => {
+  const skippedWarning =
+    'warn: Skipping workspace "packages/fixture": its package.json has no "name", so its dependencies will not be installed\n';
+
+  async function setupMonorepo(packageDir: string, workspaces: string[], fixturePackageJson: object) {
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "root",
+          workspaces,
+          dependencies: {
+            pkg1: "workspace:*",
+          },
+        }),
+      ),
+      write(join(packageDir, "packages", "pkg1", "package.json"), JSON.stringify({ name: "pkg1", version: "1.0.0" })),
+      write(join(packageDir, "packages", "fixture", "package.json"), JSON.stringify(fixturePackageJson)),
+    ]);
+  }
+
+  async function expectFixtureSkipped(packageDir: string) {
+    expect(await file(join(packageDir, "node_modules", "pkg1", "package.json")).json()).toEqual({
+      name: "pkg1",
+      version: "1.0.0",
+    });
+    expect(await exists(join(packageDir, "node_modules", "fixture"))).toBeFalse();
+    const lockfile = await file(join(packageDir, "bun.lock")).text();
+    expect(lockfile).toContain('"packages/pkg1"');
+    expect(lockfile).not.toContain("packages/fixture");
+  }
+
+  const patterns = {
+    glob: ["packages/*"],
+    listed: ["packages/pkg1", "packages/fixture"],
+  };
+
+  for (const [kind, workspaces] of Object.entries(patterns)) {
+    test.concurrent(`is skipped (${kind})`, async () => {
+      using ctx = await setupTest();
+      const { packageDir, env } = ctx;
+      await setupMonorepo(packageDir, workspaces, { type: "module" });
+
+      // runBunInstall asserts nothing was warned about.
+      await runBunInstall(env, packageDir);
+      await expectFixtureSkipped(packageDir);
+    });
+
+    test.concurrent(`is skipped with a warning when it declares dependencies (${kind})`, async () => {
+      using ctx = await setupTest();
+      const { packageDir, env } = ctx;
+      // Resolving this dependency would fail the install, so a successful install
+      // proves the fixture's dependencies were never looked at.
+      await setupMonorepo(packageDir, workspaces, { devDependencies: { "doesnt-exist-oops": "1.2.3" } });
+
+      const { err } = await runBunInstall(env, packageDir, { allowWarnings: true });
+      expect(err).toContain(skippedWarning);
+      expect(err.split(skippedWarning)).toHaveLength(2);
+      await expectFixtureSkipped(packageDir);
+    });
+  }
+
+  test.concurrent("an empty name counts as no name", async () => {
+    using ctx = await setupTest();
+    const { packageDir, env } = ctx;
+    await setupMonorepo(packageDir, patterns.glob, { name: "", dependencies: { "doesnt-exist-oops": "1.2.3" } });
+
+    const { err } = await runBunInstall(env, packageDir, { allowWarnings: true });
+    expect(err).toContain(skippedWarning);
+    await expectFixtureSkipped(packageDir);
+  });
+
+  test.concurrent("does not stop a member from finding the workspace root", async () => {
+    using ctx = await setupTest();
+    const { packageDir, env } = ctx;
+    await setupMonorepo(packageDir, patterns.glob, { dependencies: { "doesnt-exist-oops": "1.2.3" } });
+
+    const { err } = await runBunInstall(env, join(packageDir, "packages", "pkg1"), { allowWarnings: true });
+
+    expect(await exists(join(packageDir, "packages", "pkg1", "bun.lock"))).toBeFalse();
+    // Both the root lookup and the root package.json parse scan the workspaces; only the latter warns.
+    expect(err.split(skippedWarning)).toHaveLength(2);
+    await expectFixtureSkipped(packageDir);
+  });
+});
+
 test("dependency on same name as workspace and dist-tag", async () => {
   using ctx = await setupTest();
   const { packageDir, env } = ctx;

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -270,6 +270,8 @@ describe("workspace member package.json without a name", () => {
   const patterns = {
     glob: ["packages/*"],
     listed: ["packages/pkg1", "packages/fixture"],
+    // The fixture matches three times; it must still be warned about once.
+    overlapping: ["packages/fixture", "packages/*", "packages/**"],
   };
 
   for (const [kind, workspaces] of Object.entries(patterns)) {

--- a/test/cli/install/migration/__snapshots__/migrate.test.ts.snap
+++ b/test/cli/install/migration/__snapshots__/migrate.test.ts.snap
@@ -4660,8 +4660,26 @@ bun install --frozen-lockfile exit code: 0
 `;
 
 exports[`package-lock.json migration fixes arborist fixtures workspaces-need-update 1`] = `
-"error: failed to migrate lockfile: InstallFailed
-bun pm migrate exit code: 1"
+"warn: skipped 4 package-lock.json entries not depended on by any package: "a", "b", "node_modules/once", "node_modules/wrappy"
+migrated lockfile from package-lock.json
+bun pm migrate exit code: 0
+bun install --frozen-lockfile exit code: 0
+
+{
+  "lockfileVersion": 2,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "dependencies": {
+        "abbrev": "^1.0.4",
+      },
+    },
+  },
+  "packages": {
+    "abbrev": ["abbrev@1.0.4", "", {}, "sha1-vVWuXkE7oXIu5Mq6H26hBBSlns0="],
+  }
+}
+"
 `;
 
 exports[`package-lock.json migration fixes arborist fixtures workspaces-non-simplistic 1`] = `

--- a/test/cli/install/migration/npm-arborist/README.md
+++ b/test/cli/install/migration/npm-arborist/README.md
@@ -53,7 +53,7 @@ Each directory holds only what a `package-lock.json -> bun.lock` migration reads
 - `workspaces-add-new-dep` (v2, workspaces) - single workspace `a` at the fixture root, no registry deps
 - `workspaces-conflicting-versions-virtual` (v2, workspaces) - two workspaces pinning different versions of the root's dep, nested under each workspace
 - `workspaces-ignore-nm-virtual` (v2, workspaces) - workspaces glob `packages/**`
-- `workspaces-need-update` (v2, workspaces) - workspaces a/b whose package.json files have no `name` (Bun rejects nameless workspaces)
+- `workspaces-need-update` (v2, workspaces) - workspaces a/b whose package.json files have no `name` (Bun skips nameless workspaces, so only the root's deps migrate)
 - `workspaces-non-simplistic` (v2, workspaces) - workspace with a scoped transitive dep chain, minified lockfile, root devDependencies
 - `workspaces-not-root` (v2, workspaces) - three workspaces sharing hoisted registry deps, `""` specs, root package.json without a name
 - `workspaces-prefer-linking-virtual` (v2, workspaces) - workspace named `abbrev` satisfying another workspace's `abbrev` dep

--- a/test/cli/install/migration/npm-arborist/fixtures.json
+++ b/test/cli/install/migration/npm-arborist/fixtures.json
@@ -335,7 +335,7 @@
     "lockfile": "package-lock.json",
     "lockfileVersion": 2,
     "workspaces": true,
-    "notes": "workspaces a/b whose package.json files have no `name` (Bun rejects nameless workspaces)"
+    "notes": "workspaces a/b whose package.json files have no `name` (Bun skips nameless workspaces, so only the root's deps migrate)"
   },
   {
     "name": "workspaces-non-simplistic",

--- a/test/cli/install/migration/pnpm-lock-v9.test.ts
+++ b/test/cli/install/migration/pnpm-lock-v9.test.ts
@@ -234,6 +234,111 @@ describe("pnpm-lock.yaml v9", () => {
     expect(existsSync(join(String(dir), "bun.lock"))).toBe(false);
   });
 
+  // pnpm lists every directory matched by pnpm-workspace.yaml as an importer, including
+  // test fixtures whose package.json has no "name" (vite has dozens). Those are not
+  // workspace packages to bun; the migration and the later workspace scan both skip them.
+  describe("importer whose package.json has no name", () => {
+    const fixtureDir = "packages/a/__tests__/fixtures/esm";
+    const files = {
+      "package.json": JSON.stringify({
+        name: "nameless-importer-root",
+        private: true,
+        dependencies: { a: "workspace:*" },
+      }),
+      "pnpm-workspace.yaml": "packages:\n  - 'packages/*'\n  - 'packages/**/__tests__/**'\n",
+      "packages/a/package.json": JSON.stringify({ name: "a" }),
+    };
+    const rootImporter = `lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    dependencies:
+      a:
+        specifier: workspace:*
+        version: link:packages/a
+
+  packages/a: {}
+`;
+
+    async function migrateThenFrozenInstall(dir: string) {
+      const { stderr, exitCode } = await migrate(dir);
+      expect(stderr).toContain("moved pnpm-workspace.yaml to workspaces in package.json");
+      expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
+      expect(stderr).not.toContain("warn:");
+      expect(exitCode).toBe(0);
+
+      const migrated = await bunLockOf(dir);
+      expect(workspacesSection(migrated)).toBe(`  "workspaces": {
+    "": {
+      "name": "nameless-importer-root",
+      "dependencies": {
+        "a": "workspace:*",
+      },
+    },
+    "packages/a": {
+      "name": "a",
+    },
+  },
+`);
+      expect((await Bun.file(join(dir, "package.json")).json()).workspaces).toStrictEqual([
+        "packages/*",
+        "packages/**/__tests__/**",
+      ]);
+
+      // The migrated package.json now matches the fixture through the glob; the
+      // workspace scan has to agree with the migration for a frozen install to pass.
+      const install = await run(dir, "install", "--frozen-lockfile", "--linker", "hoisted");
+      expect(install.stderr).not.toContain("error:");
+      expect(install.exitCode).toBe(0);
+      expect(await bunLockOf(dir)).toBe(migrated);
+      expect(await installedPackageJson(dir, "", "a")).toStrictEqual({ name: "a" });
+      return { migrated, install };
+    }
+
+    test.concurrent("is skipped", async () => {
+      using dir = tempDir("pnpm-v9-nameless-importer", {
+        ...files,
+        [`${fixtureDir}/package.json`]: JSON.stringify({ type: "module" }),
+        "pnpm-lock.yaml": `${rootImporter}
+  ${fixtureDir}: {}
+`,
+      });
+
+      const { install } = await migrateThenFrozenInstall(String(dir));
+      expect(install.stderr).not.toContain("warn:");
+    });
+
+    test.concurrent("its dependencies are not migrated, and bun install warns about them", async () => {
+      using dir = tempDir("pnpm-v9-nameless-importer-with-deps", {
+        ...files,
+        [`${fixtureDir}/package.json`]: JSON.stringify({ type: "module", dependencies: { "no-deps": "^1.0.0" } }),
+        "pnpm-lock.yaml": `${rootImporter}
+  ${fixtureDir}:
+    dependencies:
+      no-deps:
+        specifier: ^1.0.0
+        version: 1.0.1
+
+packages:
+
+  no-deps@1.0.1:
+    resolution: {integrity: ${NO_DEPS_1_0_1_INTEGRITY}}
+
+snapshots:
+
+  no-deps@1.0.1: {}
+`,
+      });
+
+      const { migrated, install } = await migrateThenFrozenInstall(String(dir));
+      expect(migrated).not.toContain("no-deps");
+      expect(install.stderr).toContain(
+        `warn: Skipping workspace "${fixtureDir}": its package.json has no "name", so its dependencies will not be installed\n`,
+      );
+    });
+  });
+
   test("registry-qualified dep path resolves from the configured registry with a warning", async () => {
     // shape from pnpm11/deps/path/test/index.ts parse() `foo@work:1.0.0`
     const { packageDir } = await verdaccio.createTestDir({


### PR DESCRIPTION
### Problem
- `bun install` fails with `error: Missing "name" from package.json in pkgs/fixture/package.json` as soon as one directory matched by `workspaces` (glob or listed path) has a package.json without a `name`, and installs nothing. pnpm 11 and npm 11 install the same tree. Fixtures like `{"type":"module"}` under a workspaces glob are common: vite v8.2.1 has 23 of them under `packages/**/__tests__/**` and `playground/**`, none declaring dependencies. #6317 reports the same failure for nameless package.json files used as folder metadata under `packages/features/*`.
- pnpm-lock.yaml migration fails on such an importer (`warn: pnpm-lock.yaml migration failed due to missing workspace name.`, then `InvalidLockfile`), and package-lock.json migration fails with `InstallFailed` (arborist fixture `workspaces-need-update`).
- `bun install` run inside a named member whose sibling is nameless installed the member as a standalone project: the walk that looks for the workspace root (`src/install/PackageManager.rs`) scans the workspaces with the same code and gives up on the error.
- Cause: `process_workspace_name` in `src/install/lockfile/Package/WorkspaceMap.rs` returned `Error::MissingPackageName`, which both the listed-path and the glob branch of `process_names_array` logged as an error; `migrate_pnpm_lockfile` in `src/install/pnpm.rs` returned `WorkspaceNameMissing` for the importer. The scan already skipped `"name": ""` silently.

### Fix
- `process_workspace_name` returns `Scanned::Nameless` for a missing, non-string or empty name and both branches skip the directory (the old empty-name check is folded into this path). The pnpm migrator applies the same rule and skips the importer; the later passes iterate `lockfile.workspace_paths`, so they never see it. `Error::MissingPackageName`, `WorkspaceNameMissing` and their message arms are removed.
- Skipping rather than deriving a name (npm uses the directory name; #38681 derives names for folder/tarball/git packages): a workspace's name becomes a root dependency and a `node_modules/<name>` link, so derived names would link fixtures into node_modules under whatever the directory is called and collide with each other (five of vite's fixtures are in a directory named `nested`). pnpm does not link them either.
- When a skipped package.json declares dependencies, bun does not install them, unlike pnpm/npm. The scan records the directory and the root `Package::parse` warns once: `warn: Skipping workspace "packages/fixture": its package.json has no "name", so its dependencies will not be installed`. The warning is emitted from the root parse instead of the scan because the migrations, `--filter` and the root-finding walk also scan during the same command; emitting it in the scan printed it twice during a package-lock.json migration. Fixtures without dependencies (vite's) print nothing.
- Verified with the debug build; every new test fails on the released binary (the `Missing "name"` errors, the migration warning, the member installing standalone, and no warning for `"name": ""`):
  - `test/cli/install/bun-workspaces.test.ts`, "workspace member package.json without a name": glob, listed path and overlapping patterns that match the fixture three times, each with and without dependencies (the fixture declares a dependency that does not exist, so a successful install proves it was never resolved; the warning is asserted to appear exactly once), empty name, and `bun install` from a member directory finding the root and warning exactly once.
  - `test/cli/install/migration/pnpm-lock-v9.test.ts`, "importer whose package.json has no name": workspaces defined only in pnpm-workspace.yaml with a `__tests__` glob, as in vite; the migration writes root + `packages/a` only, and the following `bun install --frozen-lockfile` passes without rewriting bun.lock, i.e. the scan agrees with the migration. The second case checks the importer's recorded dependency is not migrated and that the install warns.
  - `test/cli/install/migration/migrate.test.ts`: the arborist `workspaces-need-update` snapshot now records a successful migration (fixture notes updated).
  - Full runs of bun-workspaces, bad-workspace, frozen-lockfile-missing-workspace, frozen-lockfile-pruned, catalogs, bun-add-catalog, overrides, bun-add-filter, pnpm-lock-v9, pnpm-migration, yarn-lock-migration and migrate.
- On vite v8.2.1 itself, `bun pm migrate` now gets past the 23 importers and stops at vite's relative `link:./fixtures/...` dependencies (#23026), which `bun install` without a lockfile rejects too, so that repo additionally needs #23026.
- `docs/pm/workspaces.mdx` documents the behavior.

### Background
- The root `Package::parse` calls `WorkspaceMap::process_names_array`, which resolves every `workspaces` entry (plain paths directly, globs through a directory walk) to a package.json and keys the map by the member's relative directory. Each entry then becomes a `workspace:` dependency of the root named after the member, is linked at `node_modules/<name>`, and is what `workspace:` specifiers elsewhere resolve to through `lockfile.workspace_paths`, a map keyed by name hash. A member without a name therefore has nothing to be stored under.
- The same scan also runs during package-lock.json and yarn.lock migration, `--filter` target selection, and the startup walk that checks whether the cwd belongs to a workspace further up, each into a different log (the startup walk discards its log).
- pnpm-lock.yaml lists every directory pnpm-workspace.yaml matched as an importer. bun's migrator registers each importer's name in `workspace_paths` and finally copies pnpm-workspace.yaml's `packages` into the root package.json `workspaces`, so the root parse that follows scans the same globs and must reach the same conclusion about these directories.

Fixes #6317

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 11 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 10 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-workspaces.test.ts "test/cli/install/migration/pnpm-lock-v9.test.ts"
bun test v1.4.0 (d3b85cbd0)

test/cli/install/bun-workspaces.test.ts:
(pass) dependency on workspace without version in package.json [2875.28ms]
1502 |   expect(stdout).toBeDefined();
1503 |   expect(stderr).toBeDefined();
1504 |   const [err, out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
1505 |   expect(err).not.toContain("panic:");
1506 |   if (!options?.allowErrors) {
1507 |     expect(err).not.toContain("error:");
                           ^
error: expect(received).not.toContain(expected)

Expected to not contain: "error:"
Received: "error: Missing \"name\" from package.json in packages/fixture/package.json\n    at /tmp/verdaccio-test-_SW2QMz/package.json\n"

      at runBunInstall (/workspace/bun/test/harness.ts:1507:21)
      at async <anonymous> (/workspace/bun/test/cli/install/bun-workspaces.test.ts:284:13)
1502 |   expect(stdout).toBeDefined();
1503 |   expect(stderr).toBeDefined();
1504 |   const [err, out,
... (truncated)

release without fix: 82 FAILED
bun test v1.4.0-canary.1 (b7a043103)

test/cli/install/bun-workspaces.test.ts:
(pass) dependency on workspace without version in package.json [112.99ms]
1502 |   expect(stdout).toBeDefined();
1503 |   expect(stderr).toBeDefined();
1504 |   const [err, out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
1505 |   expect(err).not.toContain("panic:");
1506 |   if (!options?.allowErrors) {
1507 |     expect(err).not.toContain("error:");
                           ^
error: expect(received).not.toContain(expected)

Expected to not contain: "error:"
Received: "error: Missing \"name\" from package.json in packages/fixture/package.json\n    at /tmp/verdaccio-test-_IRq4jV/package.json\n"

      at runBunInstall (/workspace/bun/test/harness.ts:1507:21)
      at async <anonymous> (/workspace/bun/test/cli/install/bun-workspaces.test.ts:284:13)
1502 |   expect(stdout).toBeDefined();
1503 |   expect(stderr).toBeDefined();
1504 |   const [err, out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
1505 |   expect(err).not.toContain("panic:");
1506 |   if (!options?.allowErrors) {
1507 |     expect(err).not.toContain("error:");
           
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-workspaces.test.ts "test/cli/install/migration/pnpm-lock-v9.test.ts"
bun test v1.4.0 (d3b85cbd0)

test/cli/install/bun-workspaces.test.ts:
(pass) dependency on workspace without version in package.json [2843.60ms]
(pass) workspace member package.json without a name > is skipped (glob) [296.54ms]
(pass) workspace member package.json without a name > is skipped (listed) [266.71ms]
(pass) workspace member package.json without a name > is skipped with a warning when it declares dependencies (glob) [325.13ms]
(pass) allowing negative workspace patterns [398.77ms]
(pass) workspace member package.json without a name > is skipped with a warning when it declares dependencies (listed) [354.96ms]
(pass) workspace member package.json without a name > is skipped (overlapping) [179.45ms]
(pass) workspace member package.json without a name > is skipped with a warning when it declares dependencies (overlapping) [211.22ms]
(pass) workspace member package.json without a name > an empty name counts as no name [195.16ms]
(pass) worksp
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     d3b85cbd0e
  features     baseline

22 deps, 123 codegen, 1176 objects in 855ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] gen ErrorCode+*.h
[2/1238] install /workspace/bun
bun install v1.4.0-canary.1 (b7a043103)

Checked 107 installs across 153 packages (no changes) [18.00ms]
[3/1238] gen bindgenv2
[4/1238] fetch zlib
[zlib] up to date
[5/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (b7a043103)

Checked 1 install across 2 packages (no changes) [2.00ms]
[6/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1238] fetch tinycc
[tinycc] up to date
[8/1237] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[9/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[10/1237] install /workspace/bun/src/node-fallbacks
bun install
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/pm/workspaces.mdx                             |   2 +
 src/install/error.rs                               |   3 -
 src/install/lockfile/Package.rs                    |   2 +
 src/install/lockfile/Package/WorkspaceMap.rs       | 151 +++++++++++++--------
 src/install/migration.rs                           |   5 -
 src/install/pnpm.rs                                |  10 +-
 test/cli/install/bun-workspaces.test.ts            |  90 ++++++++++++
 .../migration/__snapshots__/migrate.test.ts.snap   |  22 ++-
 test/cli/install/migration/npm-arborist/README.md  |   2 +-
 .../install/migration/npm-arborist/fixtures.json   |   2 +-
 test/cli/install/migration/pnpm-lock-v9.test.ts    | 105 ++++++++++++++
 11 files changed, 322 insertions(+), 72 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
docs/pm/workspaces.mdx                                        1      1      0
src/install/error.rs                                          2      3      0
src/install/lockfile/Package.rs                               2      1      0
src/install/lockfile/Package/WorkspaceMap.rs                 11     28      0
src/install/migration.rs                                      1      1      0
src/install/pnpm.rs                                           6      3      0
test/cli/install/bun-workspaces.test.ts                       2     10      0
…li/install/migration/__snapshots__/migrate.test.ts.snap      0      0      0
test/cli/install/migration/npm-arborist/README.md             1      1      0
test/cli/install/migration/npm-arborist/fixtures.json         1      1      0
test/cli/install/migration/pnpm-lock-v9.test.ts               4      6      0
```

</details>

<!-- robobun:evidence:end -->