### PR TITLE
publish: accept Basic credentials from .npmrc and bunfig.toml

### DIFF
--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -867,7 +867,9 @@ impl PublishCommand {
         let registry = ctx.manager.scope_for_package_name(&ctx.package_name);
         let registry_url = registry.url.url();
 
+        // `construct_publish_headers` sends `auth` (Basic) when there is no token.
         if registry.token.is_empty()
+            && registry.auth.is_empty()
             && (registry_url.password.is_empty() || registry_url.username.is_empty())
         {
             return Err(PublishError::NeedAuth);

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -807,6 +807,137 @@ describe("--dry-run", async () => {
   });
 });
 
+describe("basic auth", () => {
+  type Upload = { method: string; pathname: string; authorization: string | null };
+
+  function mockRegistry(uploads: Upload[]) {
+    return Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req) {
+        uploads.push({
+          method: req.method,
+          pathname: new URL(req.url).pathname,
+          authorization: req.headers.get("authorization"),
+        });
+        return Response.json({ ok: true });
+      },
+    });
+  }
+
+  // Only the project config may supply credentials: bunEnv inherits the
+  // runner's HOME / XDG_CONFIG_HOME, which can carry a real ~/.npmrc.
+  function isolatedEnv(dir: string) {
+    const spawnEnv: NodeJS.Dict<string> = { ...env, HOME: dir, USERPROFILE: dir };
+    delete spawnEnv.XDG_CONFIG_HOME;
+    return spawnEnv;
+  }
+
+  const basic = "Basic " + Buffer.from("basic-user:basic-pass").toString("base64");
+
+  test.concurrent(".npmrc username + _password", async () => {
+    const uploads: Upload[] = [];
+    using server = mockRegistry(uploads);
+    const host = `127.0.0.1:${server.port}`;
+    using dir = tempDir("publish-basic-npmrc-password", {
+      "package.json": JSON.stringify({ name: "basic-auth-password-pkg", version: "1.0.0" }),
+      ".npmrc": [
+        `registry=http://${host}/`,
+        `//${host}/:username=basic-user`,
+        `//${host}/:_password=${Buffer.from("basic-pass").toString("base64")}`,
+        "",
+      ].join("\n"),
+    });
+
+    const { out, err, exitCode } = await publish(isolatedEnv(String(dir)), String(dir));
+    expect(err).not.toContain("missing authentication");
+    expect(uploads).toEqual([{ method: "PUT", pathname: "/basic-auth-password-pkg", authorization: basic }]);
+    expect(out).toContain(" + basic-auth-password-pkg@1.0.0");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent(".npmrc _auth", async () => {
+    const uploads: Upload[] = [];
+    using server = mockRegistry(uploads);
+    const host = `127.0.0.1:${server.port}`;
+    using dir = tempDir("publish-basic-npmrc-auth", {
+      "package.json": JSON.stringify({ name: "basic-auth-auth-pkg", version: "1.0.0" }),
+      ".npmrc": [
+        `registry=http://${host}/`,
+        `//${host}/:_auth=${Buffer.from("basic-user:basic-pass").toString("base64")}`,
+        "",
+      ].join("\n"),
+    });
+
+    const { out, err, exitCode } = await publish(isolatedEnv(String(dir)), String(dir));
+    expect(err).not.toContain("missing authentication");
+    expect(uploads).toEqual([{ method: "PUT", pathname: "/basic-auth-auth-pkg", authorization: basic }]);
+    expect(out).toContain(" + basic-auth-auth-pkg@1.0.0");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("bunfig.toml scoped registry with username + password (#17531)", async () => {
+    const uploads: Upload[] = [];
+    using server = mockRegistry(uploads);
+    using dir = tempDir("publish-basic-bunfig-scope", {
+      "package.json": JSON.stringify({ name: "@basic-auth-scope/pkg", version: "1.0.0" }),
+      "bunfig.toml": Bun.TOML.stringify({
+        install: {
+          scopes: {
+            "@basic-auth-scope": {
+              url: `http://127.0.0.1:${server.port}/`,
+              username: "basic-user",
+              password: "basic-pass",
+            },
+          },
+        },
+      }),
+    });
+
+    const { out, err, exitCode } = await publish(isolatedEnv(String(dir)), String(dir));
+    expect(err).not.toContain("missing authentication");
+    expect(uploads).toEqual([{ method: "PUT", pathname: "/@basic-auth-scope%2fpkg", authorization: basic }]);
+    expect(out).toContain(" + @basic-auth-scope/pkg@1.0.0");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("publishing a tarball", async () => {
+    const uploads: Upload[] = [];
+    using server = mockRegistry(uploads);
+    const host = `127.0.0.1:${server.port}`;
+    using dir = tempDir("publish-basic-tarball", {
+      "package.json": JSON.stringify({ name: "basic-auth-tarball-pkg", version: "1.0.0" }),
+      ".npmrc": [
+        `registry=http://${host}/`,
+        `//${host}/:_auth=${Buffer.from("basic-user:basic-pass").toString("base64")}`,
+        "",
+      ].join("\n"),
+    });
+    const spawnEnv = isolatedEnv(String(dir));
+    await pack(String(dir), spawnEnv);
+
+    const { out, err, exitCode } = await publish(spawnEnv, String(dir), "./basic-auth-tarball-pkg-1.0.0.tgz");
+    expect(err).not.toContain("missing authentication");
+    expect(uploads).toEqual([{ method: "PUT", pathname: "/basic-auth-tarball-pkg", authorization: basic }]);
+    expect(out).toContain(" + basic-auth-tarball-pkg@1.0.0");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("no credentials is still rejected before anything is uploaded", async () => {
+    const uploads: Upload[] = [];
+    using server = mockRegistry(uploads);
+    using dir = tempDir("publish-basic-no-credentials", {
+      "package.json": JSON.stringify({ name: "no-credentials-pkg", version: "1.0.0" }),
+      ".npmrc": `registry=http://127.0.0.1:${server.port}/\n`,
+    });
+
+    const { err, exitCode } = await publish(isolatedEnv(String(dir)), String(dir));
+    expect(err).toContain("missing authentication");
+    expect(uploads).toEqual([]);
+    expect(exitCode).toBe(1);
+  });
+});
+
 describe("lifecycle scripts", async () => {
   const script = `const fs = require("fs");
     fs.writeFileSync(process.argv[2] + ".txt", \`
@@ -834,6 +965,8 @@ postpack: \${fs.existsSync("postpack.txt")}\`)`;
   };
 
   for (const arg of [[], ["--dry-run"]]) {
+    // Spawns six child bun processes, which takes ~5s on a debug build; timing
+    // out here kills the shared Verdaccio and fails the rest of the file.
     test(`should run in order${arg.length > 0 ? " (--dry-run)" : ""}`, async () => {
       const { packageDir, packageJson } = await registry.createTestDir();
       const bunfig = await registry.authBunfig("lifecycle" + (arg.length > 0 ? "dry" : ""));
@@ -864,7 +997,7 @@ postpack: \${fs.existsSync("postpack.txt")}\`)`;
         "\nprepublishOnly: true\npublish: false\npostpublish: false\nprepack: true\nprepare: true\npostpack: true",
         "\nprepublishOnly: true\npublish: true\npostpublish: false\nprepack: true\nprepare: true\npostpack: true",
       ]);
-    });
+    }, 30_000);
   }
 
   test("--ignore-scripts", async () => {


### PR DESCRIPTION
Fixes #17531

### Problem
- `bun publish` exits with "error: missing authentication (run bunx npm login)" and uploads nothing whenever the registry is configured with Basic credentials: `.npmrc` `//host/:username=` + `//host/:_password=`, `.npmrc` `//host/:_auth=`, or a bunfig `registry` / `[install.scopes]` entry with `username` + `password`. `bun install` works with the same config, and so does `npm publish`. This is the shape used with registries that authenticate with Basic (Nexus, Azure DevOps feeds, Verdaccio), and it is the Basic-auth half of #18670 (the `publishConfig.registry` half is #38322).
- Cause: the pre-flight check in `publish()` (src/runtime/cli/publish_command.rs:870) only accepts `scope.token` or userinfo embedded in the registry URL. The Basic credential that the config loaders put in `scope.auth` is ignored, even though `construct_publish_headers` (same file) already sends `Authorization: Basic <scope.auth>` when there is no token, so the rest of the publish path supports it.
- Not a regression: 1.3.14 has the same check. Listed here because it is one of the private-registry publish shapes that fails on the 1.4 release candidate.

### Fix
- The check also accepts a non-empty `scope.auth`. Nothing else changes: a registry with neither a token nor Basic credentials still fails with `missing authentication` before any request is made.
- Tests: `test/cli/install/bun-publish.test.ts`, `describe("basic auth")`, against an in-process registry that records the `PUT` and its `Authorization` header: `.npmrc` username + `_password`, `.npmrc` `_auth`, bunfig scoped registry with username + password (the #17531 config), `bun publish <tarball>`, and the no-credentials rejection. The four positive cases fail on the current canary (`missing authentication`, no request) and pass with this change; all of `bun-publish.test.ts` (44 tests) and `npmrc.test.ts` pass with the debug build.
- Incidental: the two `lifecycle scripts > should run in order` tests in the same file spawn six child bun processes each and take about 5s on a debug build, and their timeout kills the Verdaccio shared by the rest of the file. They now declare a 30s timeout; without it the file cannot pass under a debug build here.
- The same one-line condition change is also part of #33869, which reworks `.npmrc` credential resolution more broadly; this PR only carries the publish check so the RC gets it independently of that work.

### Background
- A registry `Scope` (`src/install/npm.rs`) is bun's resolved registry: the URL plus one credential, either `token` (sent as `Authorization: Bearer`) or `auth`, the base64 `user:password` string (sent as `Authorization: Basic`). `Scope::from_api` builds `auth` from a username + password pair, and the `.npmrc` loader decodes `_auth` into that pair, so every Basic configuration ends up in `scope.auth`.
- `scope_for_package_name` picks the default scope or the `@scope:registry` one for the package being published; `publish()` runs the credential check on that scope and then `construct_publish_headers` turns it into the header, which is why the header side already handled Basic while the check did not.

<details>
<summary>Repro matrix on 1.4.0-canary.1 (b7a043103), mock registry recording the PUT</summary>

```
.npmrc registry= + //host/:_authToken                 exit=0  ["PUT Bearer tok"]
.npmrc registry= + //host/:username + :_password      exit=1  []  error: missing authentication
.npmrc registry= + //host/:_auth                      exit=1  []  error: missing authentication
bunfig registry = { url, username, password }         exit=1  []  error: missing authentication
@corp:registry + //host/:_auth, publishing @corp/x    exit=1  []  error: missing authentication

bun install with each of the Basic shapes above:      GET /no-deps  Authorization: Basic YWxpY2U6czNjcmV0
```

With this change every publish row sends `PUT /<name>` with `Authorization: Basic <base64>` and exits 0.
</details>
