### PR TITLE
pack/publish: stop panicking on package.json bin and files entries longer than the path buffer

### DIFF
--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -1302,6 +1302,45 @@ pub fn normalize_buf_z<'a, P: PlatformT>(str: &[u8], buf: &'a mut [u8]) -> &'a m
     unsafe { ZStr::from_raw_mut(buf.as_mut_ptr(), len) }
 }
 
+/// [`normalize_buf`] into `buf` when the result is known to fit, otherwise into
+/// `spill` (grown as needed). `spill` is untouched in the common case.
+pub fn normalize_buf_spill<'a, P: PlatformT>(
+    buf: &'a mut [u8],
+    spill: &'a mut Vec<u8>,
+    str: &[u8],
+) -> &'a [u8] {
+    normalize_buf::<P>(str, normalize_buf_or_spill(buf, spill, str))
+}
+
+/// [`normalize_buf_z`] into `buf` when the result is known to fit, otherwise
+/// into `spill` (grown as needed). `spill` is untouched in the common case.
+pub fn normalize_buf_z_spill<'a, P: PlatformT>(
+    buf: &'a mut [u8],
+    spill: &'a mut Vec<u8>,
+    str: &[u8],
+) -> &'a ZStr {
+    normalize_buf_z::<P>(str, normalize_buf_or_spill(buf, spill, str))
+}
+
+fn normalize_buf_or_spill<'a>(
+    buf: &'a mut [u8],
+    spill: &'a mut Vec<u8>,
+    str: &[u8],
+) -> &'a mut [u8] {
+    // Normalizing only removes bytes, except that `""` becomes `"."` and on
+    // Windows a drive-relative `C:` becomes `C:.` and a bare UNC volume gains
+    // its trailing separator (one byte each); `normalize_buf_z` then appends
+    // the NUL.
+    let needed = str.len() + 2;
+    if needed <= buf.len() {
+        return buf;
+    }
+    if spill.len() < needed {
+        spill.resize(needed, 0);
+    }
+    &mut spill[..]
+}
+
 pub fn normalize_buf_t<'a, T: PathChar, P: PlatformT>(str: &[T], buf: &'a mut [T]) -> &'a mut [T] {
     if str.is_empty() {
         buf[0] = T::from_u8(b'.');
@@ -2497,6 +2536,46 @@ mod tests {
             .unwrap_or(text_len)
     }
 
+    /// Returns `haystack_len` when `needle` does not occur, like the kernel.
+    #[unsafe(no_mangle)]
+    unsafe extern "C" fn highway_last_index_of_char(
+        haystack: *const u8,
+        haystack_len: usize,
+        needle: u8,
+    ) -> usize {
+        // SAFETY: test stub; callers pass a valid (ptr, len) pair.
+        let haystack = unsafe { core::slice::from_raw_parts(haystack, haystack_len) };
+        haystack
+            .iter()
+            .rposition(|&b| b == needle)
+            .unwrap_or(haystack_len)
+    }
+
+    /// Returns `usize::MAX` when `needle` does not occur, like the kernel. Only
+    /// reached for u16 input; the u8 tests below merely need it to link.
+    #[unsafe(no_mangle)]
+    unsafe extern "C" fn highway_memrmem16(
+        haystack: *const u16,
+        haystack_len: usize,
+        needle: *const u16,
+        needle_len: usize,
+    ) -> usize {
+        // SAFETY: test stub; callers pass valid (ptr, len) pairs.
+        let (haystack, needle) = unsafe {
+            (
+                core::slice::from_raw_parts(haystack, haystack_len),
+                core::slice::from_raw_parts(needle, needle_len),
+            )
+        };
+        if needle_len > haystack_len {
+            return usize::MAX;
+        }
+        (0..=haystack_len - needle_len)
+            .rev()
+            .find(|&i| haystack[i..i + needle_len] == *needle)
+            .unwrap_or(usize::MAX)
+    }
+
     #[test]
     fn normalize_string_spill_leaves_spill_untouched_when_the_input_fits() {
         let mut spill = Vec::new();
@@ -2560,5 +2639,80 @@ mod tests {
             normalize_string_spill::<true, platform::Windows>(&mut spill, b"c:"),
             b"C:."
         );
+    }
+
+    #[test]
+    fn normalize_buf_spill_leaves_spill_untouched_when_the_input_fits() {
+        let mut buf = [0u8; 32];
+        let mut spill = Vec::new();
+        assert_eq!(
+            normalize_buf_spill::<platform::Posix>(&mut buf, &mut spill, b"./bins/../cli/./x.js"),
+            b"cli/x.js"
+        );
+        assert_eq!(
+            normalize_buf_z_spill::<platform::Posix>(&mut buf, &mut spill, b"./bins/").as_bytes(),
+            b"bins/"
+        );
+        assert!(spill.is_empty());
+    }
+
+    #[test]
+    fn normalize_buf_spill_spills_input_longer_than_buf() {
+        let mut buf = [0u8; 32];
+        let name = vec![b'b'; buf.len() * 3];
+        let mut input = b"./".to_vec();
+        input.extend_from_slice(&name);
+        input.extend_from_slice(b"/./x.js");
+        let mut expected = name;
+        expected.extend_from_slice(b"/x.js");
+
+        let mut spill = Vec::new();
+        assert_eq!(
+            normalize_buf_spill::<platform::Posix>(&mut buf, &mut spill, &input),
+            &expected[..]
+        );
+        expected.push(0);
+        assert_eq!(
+            normalize_buf_z_spill::<platform::Posix>(&mut buf, &mut spill, &input)
+                .as_bytes_with_nul(),
+            &expected[..]
+        );
+        assert!(!spill.is_empty());
+    }
+
+    #[test]
+    fn normalize_buf_z_spill_spills_input_exactly_as_long_as_buf() {
+        // The input normalizes to `buf.len()` bytes, leaving no room for the NUL.
+        let mut buf = [0u8; 32];
+        let input = vec![b'a'; buf.len()];
+        let mut expected = input.clone();
+        expected.push(0);
+
+        let mut spill = Vec::new();
+        assert_eq!(
+            normalize_buf_z_spill::<platform::Posix>(&mut buf, &mut spill, &input)
+                .as_bytes_with_nul(),
+            &expected[..]
+        );
+        assert!(!spill.is_empty());
+    }
+
+    #[test]
+    fn normalize_buf_spill_sizes_the_spill_for_the_empty_input_becoming_a_dot() {
+        let mut buf = [0u8; 1];
+
+        let mut spill = Vec::new();
+        assert_eq!(
+            normalize_buf_spill::<platform::Posix>(&mut buf, &mut spill, b""),
+            b"."
+        );
+        assert_eq!(spill.len(), 2);
+
+        let mut spill = Vec::new();
+        assert_eq!(
+            normalize_buf_z_spill::<platform::Posix>(&mut buf, &mut spill, b"").as_bytes_with_nul(),
+            b".\0"
+        );
+        assert_eq!(spill.len(), 2);
     }
 }

--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -1327,10 +1327,8 @@ fn normalize_buf_or_spill<'a>(
     spill: &'a mut Vec<u8>,
     str: &[u8],
 ) -> &'a mut [u8] {
-    // Normalizing only removes bytes, except that `""` becomes `"."` and on
-    // Windows a drive-relative `C:` becomes `C:.` and a bare UNC volume gains
-    // its trailing separator (one byte each); `normalize_buf_z` then appends
-    // the NUL.
+    // Normalizing grows a path by at most one byte (`""` -> `.`; on Windows
+    // `C:` -> `C:.` or a bare UNC volume gaining its separator), plus the NUL.
     let needed = str.len() + 2;
     if needed <= buf.len() {
         return buf;
@@ -2494,7 +2492,7 @@ pub use crate::PathChar;
 
 // Run with `cargo test -p bun_paths` (also the Miri lane, `bun run rust:miri -p bun_paths`).
 // Normalizing reaches `bun_core::strings`' byte searches, whose highway kernels
-// are only linked into the full binary, so the two they reference are satisfied
+// are only linked into the full binary, so the ones they reference are satisfied
 // below with scalar stubs (the simdutf counterparts live in string_paths.rs).
 // Under Miri the wrappers take their own scalar path and never call these.
 #[cfg(test)]
@@ -2551,8 +2549,7 @@ mod tests {
             .unwrap_or(haystack_len)
     }
 
-    /// Returns `usize::MAX` when `needle` does not occur, like the kernel. Only
-    /// reached for u16 input; the u8 tests below merely need it to link.
+    /// Returns `usize::MAX` when `needle` does not occur, like the kernel.
     #[unsafe(no_mangle)]
     unsafe extern "C" fn highway_memrmem16(
         haystack: *const u16,

--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -1302,8 +1302,7 @@ pub fn normalize_buf_z<'a, P: PlatformT>(str: &[u8], buf: &'a mut [u8]) -> &'a m
     unsafe { ZStr::from_raw_mut(buf.as_mut_ptr(), len) }
 }
 
-/// [`normalize_buf`] into `buf` when the result is known to fit, otherwise into
-/// `spill` (grown as needed). `spill` is untouched in the common case.
+/// [`normalize_buf`] into `buf` when the result fits, otherwise into `spill` (grown as needed).
 pub fn normalize_buf_spill<'a, P: PlatformT>(
     buf: &'a mut [u8],
     spill: &'a mut Vec<u8>,
@@ -1312,8 +1311,7 @@ pub fn normalize_buf_spill<'a, P: PlatformT>(
     normalize_buf::<P>(str, normalize_buf_or_spill(buf, spill, str))
 }
 
-/// [`normalize_buf_z`] into `buf` when the result is known to fit, otherwise
-/// into `spill` (grown as needed). `spill` is untouched in the common case.
+/// [`normalize_buf_z`] into `buf` when the result fits, otherwise into `spill` (grown as needed).
 pub fn normalize_buf_z_spill<'a, P: PlatformT>(
     buf: &'a mut [u8],
     spill: &'a mut Vec<u8>,
@@ -1327,8 +1325,7 @@ fn normalize_buf_or_spill<'a>(
     spill: &'a mut Vec<u8>,
     str: &[u8],
 ) -> &'a mut [u8] {
-    // Normalizing grows a path by at most one byte (`""` -> `.`; on Windows
-    // `C:` -> `C:.` or a bare UNC volume gaining its separator), plus the NUL.
+    // Normalizing grows a path by at most one byte (`""` -> `.`, `C:` -> `C:.`), plus the NUL.
     let needed = str.len() + 2;
     if needed <= buf.len() {
         return buf;

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -28,7 +28,7 @@ type CowString = CowSlice<u8>;
 use crate::cli::run_command::RunCommand;
 use bun_core::ZBox;
 use bun_core::{ZStr, strings};
-use bun_paths::resolve_path;
+use bun_paths::resolve_path::{self, normalize_buf_spill};
 use bun_semver as Semver;
 use bun_sha_hmac::sha;
 use bun_sys::{
@@ -1460,12 +1460,14 @@ fn get_package_bins(json: &Expr) -> Result<Vec<BinInfo>, AllocError> {
     let mut bins: Vec<BinInfo> = Vec::new();
 
     let mut path_buf = PathBuffer::uninit();
+    let mut path_spill: Vec<u8> = Vec::new();
 
     if let Some(bin) = json.as_property(b"bin") {
         if let Some(bin_str) = bin.expr.as_string(pack_bump()) {
-            let normalized = resolve_path::normalize_buf::<resolve_path::platform::Posix>(
-                bin_str,
+            let normalized = normalize_buf_spill::<path::platform::Posix>(
                 &mut path_buf,
+                &mut path_spill,
+                bin_str,
             );
             if !bin_path_escapes_root(normalized) {
                 bins.push(BinInfo {
@@ -1484,9 +1486,10 @@ fn get_package_bins(json: &Expr) -> Result<Vec<BinInfo>, AllocError> {
             for bin_prop in bin_obj.properties.slice() {
                 if let Some(bin_prop_value) = &bin_prop.value {
                     if let Some(bin_str) = bin_prop_value.as_string(pack_bump()) {
-                        let normalized = resolve_path::normalize_buf::<resolve_path::platform::Posix>(
-                            bin_str,
+                        let normalized = normalize_buf_spill::<path::platform::Posix>(
                             &mut path_buf,
+                            &mut path_spill,
+                            bin_str,
                         );
                         if !bin_path_escapes_root(normalized) {
                             bins.push(BinInfo {
@@ -1506,9 +1509,10 @@ fn get_package_bins(json: &Expr) -> Result<Vec<BinInfo>, AllocError> {
         if let ExprData::EObject(directories_obj) = &directories.expr.data {
             if let Some(bin) = directories_obj.as_property(b"bin") {
                 if let Some(bin_str) = bin.expr.as_string(pack_bump()) {
-                    let normalized = resolve_path::normalize_buf::<resolve_path::platform::Posix>(
-                        bin_str,
+                    let normalized = normalize_buf_spill::<path::platform::Posix>(
                         &mut path_buf,
+                        &mut path_spill,
+                        bin_str,
                     );
                     if !bin_path_escapes_root(normalized) {
                         bins.push(BinInfo {
@@ -2309,12 +2313,13 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
                     let mut excludes: Vec<Pattern> = Vec::new();
 
                     let mut path_buf = PathBuffer::uninit();
+                    let mut path_spill: Vec<u8> = Vec::new();
                     while let Some(files_entry) = files_array.next() {
                         if let Some(file_entry_str) = files_entry.as_string(bump) {
-                            let normalized = resolve_path::normalize_buf::<
-                                resolve_path::platform::Posix,
-                            >(
-                                file_entry_str, &mut path_buf
+                            let normalized = normalize_buf_spill::<path::platform::Posix>(
+                                &mut path_buf,
+                                &mut path_spill,
+                                file_entry_str,
                             );
                             let Some(parsed) = Pattern::from_utf8(normalized)? else {
                                 continue;

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -15,7 +15,7 @@ use bun_install::lockfile::{LoadResult, LoadStep};
 use bun_install::{self as install, Lockfile, Npm, PackageManager, Subcommand};
 use bun_libarchive::lib::{Archive, ArchiveIterator, IteratorResult as ArchiveIterResult};
 use bun_parsers::json as json_mod;
-use bun_paths::resolve_path::{join_abs_string_buf_z, normalize_buf, normalize_buf_z};
+use bun_paths::resolve_path::{join_abs_string_buf_z, normalize_buf_spill, normalize_buf_z_spill};
 use bun_paths::{self as path, PathBuffer};
 use bun_resolver::fs::FileSystem;
 use bun_sha_hmac as sha;
@@ -1625,14 +1625,16 @@ impl PublishCommand {
             };
         }
         let mut path_buf = PathBuffer::uninit();
+        let mut path_spill: Vec<u8> = Vec::new();
         if let Some(bin_query) = json.as_property(b"bin") {
             match &bin_query.expr.data {
                 ExprData::EString(bin_str) => {
                     let mut bin_props: Vec<G::Property> = Vec::new();
                     let normalized = strings::without_prefix_comptime_z(
-                        normalize_buf_z::<path::platform::Posix>(
-                            bin_str.string(bump)?,
+                        normalize_buf_z_spill::<path::platform::Posix>(
                             &mut *path_buf,
+                            &mut path_spill,
+                            bin_str.string(bump)?,
                         ),
                         b"./",
                     );
@@ -1677,9 +1679,10 @@ impl PublishCommand {
                                     if ks.len() != 0 {
                                         break 'key Some(Box::<[u8]>::from(
                                             strings::without_prefix(
-                                                normalize_buf::<path::platform::Posix>(
-                                                    ks.string(bump)?,
+                                                normalize_buf_spill::<path::platform::Posix>(
                                                     &mut *path_buf,
+                                                    &mut path_spill,
+                                                    ks.string(bump)?,
                                                 ),
                                                 b"./",
                                             ),
@@ -1702,9 +1705,10 @@ impl PublishCommand {
                                         break 'value Some(bun_core::ZBox::from_bytes(
                                             strings::without_prefix_comptime_z(
                                                 // replace separators
-                                                normalize_buf_z::<path::platform::Posix>(
-                                                    vs.string(bump)?,
+                                                normalize_buf_z_spill::<path::platform::Posix>(
                                                     &mut *path_buf,
+                                                    &mut path_spill,
+                                                    vs.string(bump)?,
                                                 ),
                                                 b"./",
                                             )
@@ -1763,7 +1767,11 @@ impl PublishCommand {
                 let mut bin_props: Vec<G::Property> = Vec::new();
                 let normalized_bin_dir = bun_core::ZBox::from_bytes(
                     strings::without_trailing_slash(strings::without_prefix(
-                        normalize_buf::<path::platform::Posix>(bin_dir_str, &mut *path_buf),
+                        normalize_buf_spill::<path::platform::Posix>(
+                            &mut *path_buf,
+                            &mut path_spill,
+                            bin_dir_str,
+                        ),
                         b"./",
                     )),
                 );
@@ -1780,7 +1788,7 @@ impl PublishCommand {
                 ) {
                     Ok(fd) => fd,
                     Err(e) => {
-                        if e.get_errno() == bun_sys::E::ENOENT {
+                        if matches!(e.get_errno(), bun_sys::E::ENOENT | bun_sys::E::ENAMETOOLONG) {
                             bun_core::warn!(
                                 "bin directory '{}' does not exist",
                                 bstr::BStr::new(normalized_bin_dir.as_bytes()),

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -1361,6 +1361,34 @@ describe("files", () => {
       { "pathname": "package/src/index.ts" },
     ]);
   });
+
+  test("an entry longer than the path buffer is still matched", async () => {
+    // A brace group of 1000 names that do not exist, then "dist". ~100KB, longer
+    // than the path buffer on every platform (98302 bytes on Windows).
+    const unused = Buffer.alloc(100, "x").toString();
+    const pattern = `{${Array.from({ length: 1000 }, (_, i) => `${unused}${i}`).join(",")},dist}`;
+    expect(pattern.length).toBeGreaterThan(100_000);
+
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "pack-files-long-entry",
+          version: "1.0.0",
+          files: [pattern],
+        }),
+      ),
+      write(join(packageDir, "dist", "index.js"), "console.log('hello ./dist/index.js')"),
+      write(join(packageDir, "src", "index.js"), "console.log('hello ./src/index.js')"),
+    ]);
+
+    await pack(packageDir, bunEnv);
+    const tarball = readTarball(join(packageDir, "pack-files-long-entry-1.0.0.tgz"));
+    expect(tarball.entries).toMatchObject([
+      { "pathname": "package/package.json" },
+      { "pathname": "package/dist/index.js" },
+    ]);
+  });
 });
 
 describe(".gitignore/.npmignore", () => {
@@ -1596,6 +1624,61 @@ describe("bins", () => {
         pathname: "package/dist/hi.js",
       },
     ]);
+  });
+
+  describe("longer than the path buffer", () => {
+    // Longer than the path buffer on every platform (98302 bytes on Windows), so
+    // nothing on disk can have this name.
+    const long = Buffer.alloc(100_000, "b").toString();
+
+    test.each([
+      ["bin", { bin: long }],
+      ["bin object value", { bin: { cli: long } }],
+      ["directories.bin", { directories: { bin: long } }],
+    ])("%s is skipped like any other bin that does not exist", async (_, fields) => {
+      await Promise.all([
+        write(
+          join(packageDir, "package.json"),
+          JSON.stringify({
+            name: "pack-long-bin",
+            version: "1.0.0",
+            ...fields,
+          }),
+        ),
+        write(join(packageDir, "index.js"), "console.log('hello ./index.js')"),
+      ]);
+
+      await pack(packageDir, bunEnv);
+
+      const tarball = readTarball(join(packageDir, "pack-long-bin-1.0.0.tgz"));
+      expect(tarball.entries).toMatchObject([{ pathname: "package/package.json" }, { pathname: "package/index.js" }]);
+    });
+
+    test("the other bins are still packed", async () => {
+      await Promise.all([
+        write(
+          join(packageDir, "package.json"),
+          JSON.stringify({
+            name: "pack-long-bin",
+            version: "1.0.0",
+            files: ["index.js"],
+            bin: { long, cli: "cli.js" },
+          }),
+        ),
+        write(join(packageDir, "index.js"), "console.log('hello ./index.js')"),
+        write(join(packageDir, "cli.js"), `#!/usr/bin/env bun\n`),
+      ]);
+
+      await pack(packageDir, bunEnv);
+
+      const tarball = readTarball(join(packageDir, "pack-long-bin-1.0.0.tgz"));
+      expect(tarball.entries).toMatchObject([
+        { pathname: "package/package.json" },
+        { pathname: "package/cli.js" },
+        { pathname: "package/index.js" },
+      ]);
+      expect(tarball.entries[1].perm & 0o111).toBe(0o111);
+    });
   });
 });
 

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -654,6 +654,53 @@ for (const info of [
   });
 }
 
+describe("bin longer than the path buffer", () => {
+  // Longer than the path buffer on every platform (98302 bytes on Windows), so
+  // nothing on disk can have this name.
+  const long = Buffer.alloc(100_000, "b").toString();
+  // The registry is never contacted with --dry-run; the userinfo only satisfies the auth check.
+  const dryRunEnv = { ...env, npm_config_registry: "http://user:pass@127.0.0.1:1/" };
+
+  test.each([
+    ["bin", { bin: long }, "warn: bin '<long>' does not exist"],
+    ["bin object value", { bin: { cli: long } }, "warn: bin '<long>' does not exist"],
+    ["bin object key", { bin: { [long]: "cli.js" } }, null],
+    ["directories.bin", { directories: { bin: long } }, "warn: bin directory '<long>' does not exist"],
+  ])("tarball with a long %s", async (_, fields, warning) => {
+    const packageDir = tmpdirSync();
+    const packageJson = JSON.stringify({ name: "publish-long-bin", version: "1.0.0", ...fields });
+    await Promise.all([
+      write(join(packageDir, "package.json"), packageJson),
+      write(join(packageDir, "cli.js"), ""),
+      Bun.Archive.write(
+        join(packageDir, "publish-long-bin-1.0.0.tgz"),
+        { "package/package.json": packageJson },
+        { compress: "gzip" },
+      ),
+    ]);
+
+    const { out, err, exitCode } = await publish(dryRunEnv, packageDir, "./publish-long-bin-1.0.0.tgz", "--dry-run");
+    const stderr = err.replaceAll(long, "<long>");
+    expect(stderr.split("\n").filter(line => line.startsWith("warn:"))).toEqual(warning === null ? [] : [warning]);
+    expect(stderr).not.toContain("error:");
+    expect(out).toContain("+ publish-long-bin@1.0.0 (dry-run)");
+    expect(exitCode).toBe(0);
+  });
+
+  test("directory with a long bin", async () => {
+    const packageDir = tmpdirSync();
+    await write(
+      join(packageDir, "package.json"),
+      JSON.stringify({ name: "publish-long-bin", version: "1.0.0", bin: long }),
+    );
+
+    const { out, err, exitCode } = await publish(dryRunEnv, packageDir, "--dry-run");
+    expect(err).not.toContain("error:");
+    expect(out).toContain("+ publish-long-bin@1.0.0 (dry-run)");
+    expect(exitCode).toBe(0);
+  });
+});
+
 test("dependencies are installed", async () => {
   const { packageDir, packageJson } = await registry.createTestDir();
   const publishDir = tmpdirSync();


### PR DESCRIPTION
### Problem
- `bun pm pack` and `bun publish` abort with `panic: range end index 5000 out of range for slice of length 4096` (exit 134 plus a crash report) when package.json has a `bin` string, a `bin` object value, or a `directories.bin` longer than the path buffer (4096 bytes on Linux, 1024 on macOS, 98302 on Windows). `bun pm pack` does the same for a `files` entry of that length, and `bun publish <tarball>` also for a `bin` object key.
- Cause: those strings are normalized with `resolve_path::normalize_buf` / `normalize_buf_z` into a stack `PathBuffer`, and the normalizer indexes past the end of whatever buffer it is given (`src/paths/resolve_path.rs`, `buf[buf_i..buf_i + count].copy_from_slice(..)` in `normalize_string_generic_tz`). Sites: `get_package_bins` (three) and the `files` loop in `pack()` in `src/runtime/cli/pack_command.rs`; `normalize_bin` (four) in `src/runtime/cli/publish_command.rs`. `normalize_bin` runs for `bun publish <tarball>` too, which never goes through pack, so both files need the change.

### Fix
- Add `resolve_path::normalize_buf_spill` and `normalize_buf_z_spill`: normalize into the caller's buffer when the result is known to fit, otherwise into a caller-owned `Vec` grown to size. Same shape as the existing `join_z_buf_spill`, and the same approach #37526 took for the browser map, which is this bug in another package.json field. The size bound is `input + 2`: normalizing only removes bytes, except that `""` becomes `"."` and two Windows spellings grow by one byte, and the `_z` variant appends a NUL. Unit tests in `bun_paths` pin the fits / spills / exact-length / empty cases.
- The eight sites use them, with one spill `Vec` per function hoisted out of the loops, so inputs that fit are handled exactly as before and longer ones just land in the `Vec`.
- No length cutoff, because the downstream behavior is already right once the string survives normalization. A bin that long cannot exist on disk, and both commands already have a path for a bin that does not exist: pack queues file bins as optional and ignores a bin directory it cannot open (`openat` / `open_dir` / `fstatat` return `ENAMETOOLONG` for these, I checked the POSIX and Windows wrappers), publish prints its existing `bin '...' does not exist` warning and keeps the entry in the registry metadata like npm does. A `files` entry, on the other hand, is a glob, and a long one (a brace group with many names) is legitimate and has to keep matching; cutting it off would be wrong, so it is not a "bad input" case at all.
- `normalize_bin`'s `directories.bin` branch only downgraded `ENOENT` to the warning; `ENAMETOOLONG` now takes the same branch, since like `ENOENT` it means nothing exists at that path (other errors, where something exists but cannot be opened, still fail the publish). Without this line the `directories.bin` tarball test below exits 1 with `failed to open bin directory`.
- Verified with:
  - `test/cli/install/bun-pack.test.ts`: `bins > longer than the path buffer` (string, object value, `directories.bin` are skipped; a normal bin listed next to a long one is still packed executable) and `files > an entry longer than the path buffer is still matched` (a 100 KB brace glob still selects `dist/`). The values are 100,000 bytes so the tests also exceed the Windows buffer and are not platform gated. These 5 panic on the current release and pass with this change; the whole file passes (81).
  - `test/cli/install/bun-publish.test.ts`: `bin longer than the path buffer`, publishing a tarball (built with `Bun.Archive` so the test does not depend on the pack fix) with each of the four shapes, asserting the exact set of warnings, plus a directory publish. `--dry-run` stops before the registry is contacted; the userinfo in the registry URL only satisfies the auth check, the same trick an existing dry-run test uses. These 5 panic on the current release and pass with this change; the whole file passes (44, run with a raised timeout because the debug build is too slow for the file's lifecycle-script tests at the default 5s).
  - `cargo test -p bun_paths` (22 pass) and `bun run rust:miri -p bun_paths` (22 pass).
- Overlap: #38749 (`--destination`) and #38753 (the `bun publish <tarball>` argument) fix the other two length panics in these commands; they are different buffers and different inputs. #38753 also edits the `use bun_paths::resolve_path::{..}` line in `publish_command.rs`, so one of the two will need the one-line import merge (union of both lists). Against the current heads of #38720 and #38707, which edit other lines of `get_package_bins`, `src/` merges cleanly and only the test additions at the end of `describe("bins")` conflict.
- Not covered here: `bun install` of a dependency whose bin value is this long still aborts, in the bin linker's `join_abs_string_z` (`src/install/bin.rs`, `resolve_bin_target`), a different buffer reached from the lockfile rather than from a package.json being packed. Reproduced separately and filed for its own fix.

### Background
- `PathBuffer` is a `[u8; MAX_PATH_BYTES]` stack scratch buffer used for paths about to be handed to the OS. `MAX_PATH_BYTES` is the platform `PATH_MAX`, which is why the threshold differs per OS. Strings read out of package.json have no such bound.
- `resolve_path::normalize_buf` is `path.normalize` into a caller-provided buffer: collapses `./`, `//` and `..`, and here also converts `\` to `/` (the `Posix` platform parameter), which is why pack and publish run bin paths through it before comparing them against tarball entry names. It assumes the buffer is big enough; the `*_spill` functions in `resolve_path.rs` are the family of wrappers that remove that assumption by falling back to a heap `Vec`, which stays empty unless it is needed.
- pack handles bins separately from the file walk: `get_package_bins` reads `bin` / `directories.bin`, file bins are pushed onto the pack queue as optional entries (dropped if they cannot be opened) and a bin directory is walked if it can be opened. publish additionally rewrites `bin` into the object form npm registries expect (`normalize_bin`), which is where it warns about bins that do not exist; `bun publish <tarball>` only runs this second part, on the package.json found inside the tarball.

<details>
<summary>Repro on the current release (1.4.0-canary.1)</summary>

```sh
mkdir binrepro && cd binrepro
bun -e 'require("fs").writeFileSync("package.json", JSON.stringify({name:"bin-repro",version:"1.0.0",bin:Buffer.alloc(5000,"b").toString()}))'
bun pm pack --dry-run
# panic: range end index 5000 out of range for slice of length 4096
bun publish --dry-run
# same panic (directory publish goes through pack)
mkdir -p pkg/package && cp package.json pkg/package && tar -czf long-bin.tgz -C pkg package
bun publish ./long-bin.tgz --dry-run
# same panic, this time from normalize_bin in publish_command.rs
```

Same result for `bin: {x: <long>}`, `directories: {bin: <long>}`, `files: [<long>]` (pack) and `bin: {<long>: "x.js"}` (tarball publish). With this change all of them exit 0; the publish variants print `warn: bin '<long>' does not exist` / `warn: bin directory '<long>' does not exist`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-publish.test.ts

<!-- robobun:evidence:end -->