### PR TITLE
audit fix: report and rewrite the overrides rule that holds a vulnerable version

### DIFF
--- a/docs/pm/cli/audit.mdx
+++ b/docs/pm/cli/audit.mdx
@@ -72,13 +72,15 @@ The JSON is unfiltered — `--audit-level` and `--ignore` only affect the exit c
 bun audit fix
 ```
 
-Runs the audit, then upgrades each vulnerable package to the lowest non-vulnerable version that every dependent's range allows, and installs. Only `bun.lock` and `node_modules` change, with one exception: a direct dependency pinned to an exact version is treated as `^version`, and the pin in `package.json` (or the catalog entry) is rewritten if a fix is found.
+Runs the audit, then upgrades each vulnerable package to the lowest non-vulnerable version that every dependent's range allows, and installs. Only `bun.lock` and `node_modules` change, with one exception: an exact version pin in your own `package.json` (a dependency, a catalog entry, or an [`overrides`](/pm/overrides) rule) is treated as `^version`, and the pin is rewritten if a fix is found.
 
 ```
 fixing:
   ms@0.7.0 → 0.7.1
   lodash@4.17.20 → 4.17.21
     package.json: 4.17.20 → 4.17.21
+  tar@6.1.11 → 6.1.12
+    package.json (overrides): 6.1.11 → 6.1.12
 
 blocked by a dependent's range:
   minimatch@0.3.0 → 3.0.2
@@ -86,16 +88,19 @@ blocked by a dependent's range:
   semver@5.7.1 → 6.3.1
     my-app depends on semver@^5.0.0
     bun audit fix --latest
+  qs@6.5.2 → 6.11.0
+    package.json overrides qs@~6.5.0 (express>qs)
+    bun audit fix --latest
 
 no published version fixes:
   left-pad@1.3.0  GHSA-xxxx-xxxx-xxxx
     bun audit fix --ignore GHSA-xxxx-xxxx-xxxx
 
-Fixed 2 vulnerabilities in 2 packages
+Fixed 3 vulnerabilities in 3 packages
 5 vulnerabilities remaining
 ```
 
-- **blocked by a dependent's range** — no safe version fits a dependent's declared range. If the range is in your own `package.json` or catalog, `bun audit fix --latest` gets past it. Otherwise, update the dependent or add an [`overrides`](/pm/overrides) entry.
+- **blocked by a dependent's range** — no safe version fits a dependent's declared range. If the range is your own (a `package.json` dependency, a catalog entry, or an `overrides` rule, the last reported as `package.json overrides ...` followed by the rule's key when it is scoped), `bun audit fix --latest` gets past it. Otherwise, update the dependent or add an [`overrides`](/pm/overrides) entry.
 - **no published version fixes** — every published version is vulnerable. Replace the package, or silence the advisory with the printed `--ignore` command.
 - If no newer version is safe but an older one is, Bun downgrades and marks the row `(downgrade)`.
 - A safe version newer than `--minimum-release-age` is still installed, marked `(newer than --minimum-release-age)`.
@@ -112,7 +117,7 @@ Fixed 2 vulnerabilities in 2 packages
 bun audit fix --latest
 ```
 
-Same as `bun audit fix`, but ranges in your own `package.json` files and catalogs no longer block a fix — they are rewritten to accept the new version, keeping their style (`^5.0.0` → `^6.3.1`, `~5.7.1` → `~6.3.1`, exact stays exact). Ranges declared by third-party packages still block; use `overrides` for those.
+Same as `bun audit fix`, but ranges in your own `package.json` files, catalogs, and `overrides` no longer block a fix — they are rewritten to accept the new version, keeping their style (`^5.0.0` → `^6.3.1`, `~5.7.1` → `~6.3.1`, exact stays exact). Ranges declared by third-party packages still block; use `overrides` for those.
 
 ### Exit code
 

--- a/src/install/audit_fix.rs
+++ b/src/install/audit_fix.rs
@@ -3,6 +3,7 @@ use core::mem::ManuallyDrop;
 use std::io::Write as _;
 
 use bstr::BStr;
+use bun_ast::Expr;
 use bun_collections::{DynamicBitSet, HashMap, index_sort};
 use bun_core::{Global, Output, UnwrapOrOom as _, pretty, prettyln, strings};
 use bun_semver::query::Group;
@@ -10,6 +11,7 @@ use bun_semver::{self as Semver, SlicedString};
 
 use crate::dependency::Behavior;
 use crate::lockfile::Lockfile;
+use crate::lockfile::override_map::OverrideRule;
 use crate::lockfile::package::PackageColumns as _;
 use crate::npm::PackageManifest;
 use crate::package_manager::Options::{Do, Enable, LogLevel};
@@ -23,7 +25,7 @@ use crate::{
 
 mod json;
 mod package_json_edits;
-pub use package_json_edits::PackageJsonEdit;
+pub use package_json_edits::{EditSite, OverrideSelector, PackageJsonEdit};
 
 pub struct Advisory {
     pub package_name: Box<[u8]>,
@@ -52,11 +54,15 @@ pub struct PlannedEdge {
     pub parent: PackageID,
 }
 
+#[derive(PartialEq, Eq)]
 pub struct Blocker {
+    /// The dependent package or importer file; `package.json` when `override_rule` is set, since the range then comes from its `overrides`.
     pub dependent: Box<[u8]>,
     pub range: Box<[u8]>,
     pub bundled: bool,
     pub latest_fixes: bool,
+    /// Key of the `overrides` rule that holds the version, in the form `OverrideSelector::key` produces.
+    pub override_rule: Option<Box<[u8]>>,
 }
 
 pub struct BlockedFix {
@@ -182,9 +188,12 @@ pub struct FixOutcome {
 struct Edge {
     dep_id: DependencyID,
     parent: PackageID,
+    /// What the edge resolves against once overrides and catalogs are applied; `None` unless that is an npm range.
     range: Option<dependency::Version>,
+    /// The override rule's value when one applies, else the dependent's own specifier; shown when `range` is `None`.
     literal: Box<[u8]>,
     dependent: Box<[u8]>,
+    override_rule: Option<Box<[u8]>>,
     bundled: bool,
     peer: bool,
     latest_fixes: bool,
@@ -427,41 +436,38 @@ fn print_manifest_unavailable(manager: &PackageManager, items: &[ManifestUnavail
     Output::flush();
 }
 
+/// The root/workspace package.json (or catalog, or override rule) entry whose rewrite would move this edge: an exact pin, or with `latest` any npm range.
 fn pin_for(
     lockfile: &Lockfile,
-    dep_id: usize,
+    root_json: Option<&Expr>,
     dep: &Dependency,
     parent: PackageID,
+    rule: Option<OverrideRule<'_>>,
     latest: bool,
 ) -> Option<PackageJsonEdit> {
-    if parent == invalid_package_id || dep.behavior.is_bundled() || dep.behavior.is_workspace() {
+    if dep.behavior.is_bundled() || dep.behavior.is_workspace() {
         return None;
     }
     let buf = lockfile.buffers.string_bytes.as_slice();
-    let res = lockfile.packages.items_resolution();
-    let parent_res = &res[parent as usize];
-    if !matches!(
-        parent_res.tag,
-        ResolutionTag::Root | ResolutionTag::Workspace
-    ) {
-        return None;
-    }
-    let is_alias = dep.version.tag == DependencyVersionTag::Npm && dep.version.npm().is_alias;
-    if !is_alias
-        && lockfile
-            .overrides
-            .get(lockfile, dep_id as DependencyID, dep.name_hash)
-            .is_some()
-    {
-        return None;
-    }
-    let key: Box<[u8]> = Box::from(dep.name.slice(buf));
-    match dep.version.tag {
+    let name = dep.name.slice(buf);
+    let version = match rule {
+        Some(rule) => rule.version(),
+        None => {
+            if parent == invalid_package_id
+                || !matches!(
+                    lockfile.packages.items_resolution()[parent as usize].tag,
+                    ResolutionTag::Root | ResolutionTag::Workspace
+                )
+            {
+                return None;
+            }
+            &dep.version
+        }
+    };
+    match version.tag {
         DependencyVersionTag::Catalog => {
-            let catalog_name = dep.version.catalog().slice(buf);
-            let entry = lockfile
-                .catalogs
-                .find(buf, catalog_name, dep.name.slice(buf))?;
+            let catalog_name = version.catalog().slice(buf);
+            let entry = lockfile.catalogs.find(buf, catalog_name, name)?;
             if entry.version.tag != DependencyVersionTag::Npm
                 || (!latest && entry.version.npm().version.get_exact_version().is_none())
             {
@@ -470,24 +476,44 @@ fn pin_for(
             Some(PackageJsonEdit {
                 owner: 0,
                 file: Box::from(&b"package.json"[..]),
-                catalog: Some(Box::from(catalog_name)),
-                key,
+                site: EditSite::Catalog(Box::from(catalog_name)),
+                key: Box::from(name),
                 old_literal: Box::from(entry.version.literal.slice(buf)),
                 new_literal: Box::default(),
             })
         }
         DependencyVersionTag::Npm => {
             if !latest {
-                dep.version.npm().version.get_exact_version()?;
+                version.npm().version.get_exact_version()?;
             }
-            Some(PackageJsonEdit {
-                owner: parent,
-                file: importer_file(lockfile, parent)?,
-                catalog: None,
-                key,
-                old_literal: Box::from(dep.version.literal.slice(buf)),
-                new_literal: Box::default(),
-            })
+            let literal = version.literal.slice(buf);
+            match rule {
+                Some(rule) => {
+                    let selector = OverrideSelector::from_rule(rule, buf);
+                    let written =
+                        package_json_edits::override_literal(root_json?, name, &selector)?;
+                    // Differs when package.json spells the value as a `$ref` to a dependency; bun.lock stores what it resolved to.
+                    if *written != *strings::trim(literal, &strings::WHITESPACE_CHARS) {
+                        return None;
+                    }
+                    Some(PackageJsonEdit {
+                        owner: 0,
+                        file: Box::from(&b"package.json"[..]),
+                        site: EditSite::Override(selector),
+                        key: Box::from(name),
+                        old_literal: written,
+                        new_literal: Box::default(),
+                    })
+                }
+                None => Some(PackageJsonEdit {
+                    owner: parent,
+                    file: importer_file(lockfile, parent)?,
+                    site: EditSite::Dependencies,
+                    key: Box::from(name),
+                    old_literal: Box::from(literal),
+                    new_literal: Box::default(),
+                }),
+            }
         }
         _ => None,
     }
@@ -501,15 +527,12 @@ pub fn plan_fixes(manager: &mut PackageManager, advisories: &[Advisory]) -> crat
 
     let mut instances: Vec<Instance> = Vec::new();
     let mut checked_names: HashMap<PackageNameHash, ()> = HashMap::new();
-    {
+    let instance_of: Vec<u32> = {
         let lockfile = &*manager.lockfile;
         let buf = lockfile.buffers.string_bytes.as_slice();
         let names = lockfile.packages.items_name();
         let name_hashes = lockfile.packages.items_name_hash();
         let res = lockfile.packages.items_resolution();
-        let dep_slices = lockfile.packages.items_dependencies();
-        let deps = lockfile.buffers.dependencies.as_slice();
-        let resolutions = lockfile.buffers.resolutions.as_slice();
 
         let mut instance_of: Vec<u32> = vec![u32::MAX; res.len()];
         for pkg_id in 0..res.len() {
@@ -543,49 +566,63 @@ pub fn plan_fixes(manager: &mut PackageManager, advisories: &[Advisory]) -> crat
                 edges: Vec::new(),
             });
         }
+        instance_of
+    };
 
-        if !instances.is_empty() {
-            let mut parent_of: Vec<PackageID> = vec![invalid_package_id; deps.len()];
-            for (pkg_id, slice) in dep_slices.iter().enumerate() {
-                let end = (slice.end() as usize).min(deps.len());
-                for slot in &mut parent_of[(slice.begin() as usize).min(end)..end] {
-                    *slot = pkg_id as PackageID;
-                }
+    if !instances.is_empty() {
+        let root_json: Option<Expr> = (!manager.lockfile.overrides.is_empty())
+            .then(|| package_json_edits::root_package_json(manager));
+        let lockfile = &*manager.lockfile;
+        let buf = lockfile.buffers.string_bytes.as_slice();
+        let deps = lockfile.buffers.dependencies.as_slice();
+        let mut parent_of: Vec<PackageID> = vec![invalid_package_id; deps.len()];
+        for (pkg_id, slice) in lockfile.packages.items_dependencies().iter().enumerate() {
+            let end = (slice.end() as usize).min(deps.len());
+            for slot in &mut parent_of[(slice.begin() as usize).min(end)..end] {
+                *slot = pkg_id as PackageID;
             }
+        }
 
-            for (dep_id, &target) in resolutions.iter().enumerate() {
-                if target == invalid_package_id {
-                    continue;
-                }
-                let Some(&instance) = instance_of.get(target as usize) else {
-                    continue;
-                };
-                if instance == u32::MAX || deps[dep_id].behavior.is_optional_peer() {
-                    continue;
-                }
-                let dep = &deps[dep_id];
-                let parent = parent_of[dep_id];
-                let mut pin = pin_for(lockfile, dep_id, dep, parent, true);
-                let latest_fixes = !latest && pin.is_some();
-                if latest_fixes {
-                    pin = pin_for(lockfile, dep_id, dep, parent, false);
-                }
-                instances[instance as usize].edges.push(Edge {
-                    dep_id: dep_id as DependencyID,
-                    parent,
-                    range: crate::dedupe::effective_npm_range(
-                        lockfile,
-                        dep_id as DependencyID,
-                        dep,
-                    ),
-                    literal: Box::from(dep.version.literal.slice(buf)),
-                    dependent: dependent_label(lockfile, parent),
-                    bundled: dep.behavior.is_bundled(),
-                    peer: dep.behavior.is_peer(),
-                    latest_fixes,
-                    pin,
-                });
+        for (dep_id, &target) in lockfile.buffers.resolutions.iter().enumerate() {
+            if target == invalid_package_id {
+                continue;
             }
+            let Some(&instance) = instance_of.get(target as usize) else {
+                continue;
+            };
+            if instance == u32::MAX || deps[dep_id].behavior.is_optional_peer() {
+                continue;
+            }
+            let dep = &deps[dep_id];
+            let parent = parent_of[dep_id];
+            // A bundled copy ships inside its dependent whatever an override says, so it stays attributed to the dependent.
+            let rule = if dep.behavior.is_bundled() {
+                None
+            } else {
+                crate::dedupe::applied_override(lockfile, dep_id as DependencyID, dep)
+            };
+            let mut pin = pin_for(lockfile, root_json.as_ref(), dep, parent, rule, true);
+            let latest_fixes = !latest && pin.is_some();
+            if latest_fixes {
+                pin = pin_for(lockfile, root_json.as_ref(), dep, parent, rule, false);
+            }
+            instances[instance as usize].edges.push(Edge {
+                dep_id: dep_id as DependencyID,
+                parent,
+                range: crate::dedupe::effective_npm_range(lockfile, dep_id as DependencyID, dep),
+                literal: Box::from(
+                    rule.map_or(&dep.version, OverrideRule::version)
+                        .literal
+                        .slice(buf),
+                ),
+                dependent: dependent_label(lockfile, parent),
+                override_rule: rule
+                    .map(|rule| OverrideSelector::from_rule(rule, buf).key(dep.name.slice(buf))),
+                bundled: dep.behavior.is_bundled(),
+                peer: dep.behavior.is_peer(),
+                latest_fixes,
+                pin,
+            });
         }
     }
 
@@ -854,13 +891,14 @@ pub fn plan_fixes(manager: &mut PackageManager, advisories: &[Advisory]) -> crat
             });
         }
 
-        let blockers: Vec<Blocker> = inst
-            .edges
-            .iter()
-            .zip(&target)
-            .filter(|(_, t)| t.is_none())
-            .map(|(edge, _)| Blocker {
-                dependent: edge.dependent.clone(),
+        let mut blockers: Vec<Blocker> = Vec::new();
+        for (edge, _) in inst.edges.iter().zip(&target).filter(|(_, t)| t.is_none()) {
+            let blocker = Blocker {
+                dependent: if edge.override_rule.is_some() {
+                    Box::from(&b"package.json"[..])
+                } else {
+                    edge.dependent.clone()
+                },
                 range: if edge.bundled {
                     inst.from.clone()
                 } else {
@@ -871,8 +909,13 @@ pub fn plan_fixes(manager: &mut PackageManager, advisories: &[Advisory]) -> crat
                 },
                 bundled: edge.bundled,
                 latest_fixes: edge.latest_fixes,
-            })
-            .collect();
+                override_rule: edge.override_rule.clone(),
+            };
+            // Every edge a rule holds reports the same blocker.
+            if !blockers.contains(&blocker) {
+                blockers.push(blocker);
+            }
+        }
         if blockers.is_empty() {
             expected_gone.push((inst.name_hash, inst.from));
             continue;
@@ -941,10 +984,18 @@ impl FixPlan {
                 prettyln!("");
                 for edit in &fix.edits {
                     pretty!("    {}", BStr::new(&edit.file));
-                    match edit.catalog.as_deref() {
-                        None => {}
-                        Some(b"" | b"default") => pretty!(" (catalog)"),
-                        Some(catalog) => pretty!(" (catalog {})", BStr::new(catalog)),
+                    match &edit.site {
+                        EditSite::Dependencies => {}
+                        EditSite::Catalog(catalog) => match &**catalog {
+                            b"" | b"default" => pretty!(" (catalog)"),
+                            catalog => pretty!(" (catalog {})", BStr::new(catalog)),
+                        },
+                        EditSite::Override(selector) if selector.is_bare() => {
+                            pretty!(" (overrides)");
+                        }
+                        EditSite::Override(selector) => {
+                            pretty!(" (overrides {})", BStr::new(&selector.key(&edit.key)));
+                        }
                     }
                     prettyln!(
                         ": <d>{} {}<r> {}",
@@ -976,17 +1027,24 @@ impl FixPlan {
                 }
                 prettyln!("");
                 for blocker in &item.blockers {
-                    prettyln!(
+                    pretty!(
                         "    {} {} {}@{}",
                         BStr::new(&blocker.dependent),
                         if blocker.bundled {
                             "bundles"
+                        } else if blocker.override_rule.is_some() {
+                            "overrides"
                         } else {
                             "depends on"
                         },
                         BStr::new(&item.name),
                         BStr::new(&blocker.range)
                     );
+                    match &blocker.override_rule {
+                        Some(rule) if **rule != *item.name => pretty!(" ({})", BStr::new(rule)),
+                        _ => {}
+                    }
+                    prettyln!("");
                 }
                 if item.blockers.iter().any(|blocker| blocker.latest_fixes) {
                     prettyln!("    <cyan>bun audit fix --latest<r>");

--- a/src/install/audit_fix/json.rs
+++ b/src/install/audit_fix/json.rs
@@ -2,7 +2,7 @@ use std::io::Write as _;
 
 use bun_core::Output;
 
-use super::{FixOutcome, FixPlan, PackageJsonEdit};
+use super::{EditSite, FixOutcome, FixPlan, PackageJsonEdit};
 
 pub(super) fn write(plan: &FixPlan, outcome: Option<&FixOutcome>, dry_run: bool) {
     let (fixed, remaining) = match outcome {
@@ -59,7 +59,12 @@ pub(super) fn write(plan: &FixPlan, outcome: Option<&FixOutcome>, dry_run: bool)
             s(&mut out, &blocker.dependent);
             out.extend_from_slice(b",\"range\":");
             s(&mut out, &blocker.range);
-            let _ = write!(out, ",\"bundled\":{}}}", blocker.bundled);
+            let _ = write!(out, ",\"bundled\":{},\"override\":", blocker.bundled);
+            match &blocker.override_rule {
+                None => out.extend_from_slice(b"null"),
+                Some(rule) => s(&mut out, rule),
+            }
+            out.push(b'}');
         }
         out.extend_from_slice(b"]}");
     }
@@ -140,10 +145,15 @@ fn write_edit(out: &mut Vec<u8>, edit: &PackageJsonEdit) {
     out.extend_from_slice(b"{\"file\":");
     s(out, &edit.file);
     out.extend_from_slice(b",\"catalog\":");
-    match edit.catalog.as_deref() {
-        None => out.extend_from_slice(b"null"),
-        Some(b"") => out.extend_from_slice(b"\"default\""),
-        Some(catalog) => s(out, catalog),
+    match &edit.site {
+        EditSite::Catalog(catalog) if catalog.is_empty() => out.extend_from_slice(b"\"default\""),
+        EditSite::Catalog(catalog) => s(out, catalog),
+        EditSite::Dependencies | EditSite::Override(_) => out.extend_from_slice(b"null"),
+    }
+    out.extend_from_slice(b",\"override\":");
+    match &edit.site {
+        EditSite::Override(selector) => s(out, &selector.key(&edit.key)),
+        EditSite::Dependencies | EditSite::Catalog(_) => out.extend_from_slice(b"null"),
     }
     out.extend_from_slice(b",\"key\":");
     s(out, &edit.key);

--- a/src/install/audit_fix/package_json_edits.rs
+++ b/src/install/audit_fix/package_json_edits.rs
@@ -1,4 +1,4 @@
-use bun_ast::{E, Expr};
+use bun_ast::{E, Expr, ExprData};
 use bun_collections::VecExt as _;
 use bun_collections::index_sort;
 use bun_core::strings;
@@ -8,7 +8,9 @@ use bun_semver::{PinnedVersion, Version};
 
 use crate::bun_fs::FileSystem;
 use crate::lockfile::CatalogMap;
+use crate::lockfile::override_map::OverrideRule;
 use crate::lockfile::package::PackageColumns as _;
+use crate::lockfile_real::override_selector::{Selector, parse_package_segment, parse_selector};
 use crate::package_manager_real::add_remove_with_filter::{
     WorkspaceTarget, fetch_entry_root, root_package_json_path, store_entry,
 };
@@ -27,16 +29,92 @@ const DEPENDENCY_GROUPS: [&[u8]; 4] = [
 pub struct PackageJsonEdit {
     pub owner: PackageID,
     pub file: Box<[u8]>,
-    pub catalog: Option<Box<[u8]>>,
+    pub site: EditSite,
+    /// The package whose range is rewritten.
     pub key: Box<[u8]>,
     pub old_literal: Box<[u8]>,
     pub new_literal: Box<[u8]>,
 }
 
+#[derive(Clone, PartialEq, Eq)]
+pub enum EditSite {
+    /// `key` in whichever of the four dependency groups of `file` declares `old_literal`.
+    Dependencies,
+    /// `key` in this catalog of the root package.json; empty means the default catalog.
+    Catalog(Box<[u8]>),
+    /// The rule for `key` in the root package.json's `overrides` (or `resolutions`).
+    Override(OverrideSelector),
+}
+
+/// A rule of the root package.json's `overrides`/`resolutions` as `OverrideMap` normalizes it, minus the target name (the edit's `key`).
+#[derive(Clone, PartialEq, Eq)]
+pub struct OverrideSelector {
+    /// Name and declared range of the dependent the rule is scoped to; the range is empty when any version of it qualifies.
+    pub parent: Option<(Box<[u8]>, Box<[u8]>)>,
+    /// Empty when the rule applies whatever range the dependent declares.
+    pub target_range: Box<[u8]>,
+}
+
+impl OverrideSelector {
+    pub(super) fn from_rule(rule: OverrideRule<'_>, buf: &[u8]) -> OverrideSelector {
+        match rule {
+            OverrideRule::Flat(_) => OverrideSelector {
+                parent: None,
+                target_range: Box::default(),
+            },
+            OverrideRule::Scoped(rule) => OverrideSelector {
+                parent: rule.parent.as_ref().map(|parent| {
+                    (
+                        Box::from(parent.name.slice(buf)),
+                        Box::from(parent.version.literal.slice(buf)),
+                    )
+                }),
+                target_range: Box::from(rule.target_range.literal.slice(buf)),
+            },
+        }
+    }
+
+    /// A plain `"name": ...` rule, as opposed to one scoped to a parent or to a declared range.
+    pub fn is_bare(&self) -> bool {
+        self.parent.is_none() && self.target_range.is_empty()
+    }
+
+    /// The rule's key in the `parent@range>name@range` form bun.lock writes, which `overrides` also accepts.
+    pub fn key(&self, name: &[u8]) -> Box<[u8]> {
+        let mut out: Vec<u8> = Vec::new();
+        if let Some((parent, parent_range)) = &self.parent {
+            push_segment(&mut out, parent, parent_range);
+            out.push(b'>');
+        }
+        push_segment(&mut out, name, &self.target_range);
+        out.into_boxed_slice()
+    }
+
+    fn matches(&self, name: &[u8], selector: &Selector<'_>) -> bool {
+        selector.target.name == name
+            && selector.target.range == &*self.target_range
+            && match (&self.parent, &selector.parent) {
+                (None, None) => true,
+                (Some((parent, parent_range)), Some(declared)) => {
+                    declared.name == &**parent && declared.range == &**parent_range
+                }
+                _ => false,
+            }
+    }
+}
+
+fn push_segment(out: &mut Vec<u8>, name: &[u8], range: &[u8]) {
+    out.extend_from_slice(name);
+    if !range.is_empty() {
+        out.push(b'@');
+        out.extend_from_slice(range);
+    }
+}
+
 impl PackageJsonEdit {
     pub(crate) fn same_site(&self, other: &PackageJsonEdit) -> bool {
         self.owner == other.owner
-            && self.catalog == other.catalog
+            && self.site == other.site
             && self.key == other.key
             && self.old_literal == other.old_literal
     }
@@ -145,8 +223,8 @@ fn apply_to_target(
         let _guard = bun_ast::expr::Disabler::scope();
         let arena = &manager.ast_arena;
         for edit in edits {
-            match &edit.catalog {
-                None => {
+            match &edit.site {
+                EditSite::Dependencies => {
                     for group in DEPENDENCY_GROUPS {
                         let Some(mut query) = root.as_property(group) else {
                             continue;
@@ -154,12 +232,22 @@ fn apply_to_target(
                         rewrite_property(arena, &mut query.expr, edit);
                     }
                 }
-                Some(catalog) => for_each_catalog_object(&root, |catalog_name, mut object| {
-                    if CatalogMap::same_name(catalog_name, catalog) {
-                        rewrite_property(arena, &mut object, edit);
+                EditSite::Catalog(catalog) => {
+                    for_each_catalog_object(&root, |catalog_name, mut object| {
+                        if CatalogMap::same_name(catalog_name, catalog) {
+                            rewrite_property(arena, &mut object, edit);
+                        }
+                        Ok(())
+                    })?;
+                }
+                EditSite::Override(selector) => {
+                    let Some(mut rules) = override_rules(&root) else {
+                        continue;
+                    };
+                    if let Some(value) = override_rule_value(&mut rules, &edit.key, selector) {
+                        rewrite_value(arena, value, edit);
                     }
-                    Ok(())
-                })?,
+                }
             }
         }
     }
@@ -175,19 +263,128 @@ fn rewrite_property(arena: &bun_alloc::Arena, object: &mut Expr, edit: &PackageJ
         let Some(key) = prop.key.as_ref().and_then(Expr::as_utf8_string_literal) else {
             continue;
         };
-        if key != &*edit.key {
-            continue;
+        if key == &*edit.key {
+            rewrite_value(arena, &mut prop.value, edit);
         }
-        let Some(value) = prop.value.as_ref().and_then(Expr::as_utf8_string_literal) else {
+    }
+}
+
+fn rewrite_value(arena: &bun_alloc::Arena, value: &mut Option<Expr>, edit: &PackageJsonEdit) {
+    let Some(literal) = value.as_ref().and_then(Expr::as_utf8_string_literal) else {
+        return;
+    };
+    if strings::trim(literal, &strings::WHITESPACE_CHARS) != &*edit.old_literal {
+        return;
+    }
+    *value = Some(Expr::allocate(
+        arena,
+        E::EString::init(arena.alloc_slice_copy(&edit.new_literal)),
+        bun_ast::Loc::EMPTY,
+    ));
+}
+
+pub(super) fn root_package_json(manager: &mut PackageManager) -> Expr {
+    let target = WorkspaceTarget {
+        name: Box::default(),
+        name_hash: None,
+        package_json_path: root_package_json_path(),
+    };
+    fetch_entry_root(manager, &target)
+}
+
+struct OverrideRules {
+    object: Expr,
+    /// npm's `"parent": { "child": ... }` form is only read from `overrides` (`OverrideMap::parse_from_resolutions` skips object values).
+    nested: bool,
+}
+
+/// Same precedence as `OverrideMap::parse_append`: `overrides` wins even when `resolutions` is also present.
+fn override_rules(root: &Expr) -> Option<OverrideRules> {
+    if let Some(object) = root.get(b"overrides") {
+        return Some(OverrideRules {
+            object,
+            nested: true,
+        });
+    }
+    root.get(b"resolutions").map(|object| OverrideRules {
+        object,
+        nested: false,
+    })
+}
+
+/// What `name`'s rule `selector` is currently set to in the root package.json, or `None` when its value is not a range that can be rewritten in place (a `$ref`, for example).
+pub(super) fn override_literal(
+    root: &Expr,
+    name: &[u8],
+    selector: &OverrideSelector,
+) -> Option<Box<[u8]>> {
+    let mut rules = override_rules(root)?;
+    let value = override_rule_value(&mut rules, name, selector)?;
+    let literal = value.as_ref()?.as_utf8_string_literal()?;
+    Some(Box::from(strings::trim(
+        literal,
+        &strings::WHITESPACE_CHARS,
+    )))
+}
+
+/// The value slot of the entry declaring `selector` for `name`, whichever of the accepted key spellings (`a>b`, `a/b`, `**/b`, `{"a": {"b": ..}}`, `{"b": {".": ..}}`) it uses.
+fn override_rule_value<'a>(
+    rules: &'a mut OverrideRules,
+    name: &[u8],
+    selector: &OverrideSelector,
+) -> Option<&'a mut Option<Expr>> {
+    let nested = rules.nested;
+    let object = rules.object.data.e_object_mut()?;
+    for prop in object.properties.slice_mut() {
+        let Some(key) = prop.key.as_ref().and_then(Expr::as_utf8_string_literal) else {
             continue;
         };
-        if strings::trim(value, &strings::WHITESPACE_CHARS) != &*edit.old_literal {
+        let is_group = nested
+            && prop
+                .value
+                .as_ref()
+                .is_some_and(|value| matches!(value.data, ExprData::EObject(_)));
+        if !is_group {
+            if parse_selector(key).is_ok_and(|rule| selector.matches(name, &rule)) {
+                return Some(&mut prop.value);
+            }
             continue;
         }
-        prop.value = Some(Expr::allocate(
-            arena,
-            E::EString::init(arena.alloc_slice_copy(&edit.new_literal)),
-            bun_ast::Loc::EMPTY,
-        ));
+        let Ok(parent) = parse_package_segment(key) else {
+            continue;
+        };
+        let Some(group) = prop
+            .value
+            .as_mut()
+            .and_then(|value| value.data.e_object_mut())
+        else {
+            continue;
+        };
+        for child in group.properties.slice_mut() {
+            let Some(child_key) = child.key.as_ref().and_then(Expr::as_utf8_string_literal) else {
+                continue;
+            };
+            let rule = if child_key == b"." {
+                Selector {
+                    parent: None,
+                    target: parent,
+                }
+            } else {
+                match parse_selector(child_key) {
+                    Ok(Selector {
+                        parent: None,
+                        target,
+                    }) => Selector {
+                        parent: Some(parent),
+                        target,
+                    },
+                    _ => continue,
+                }
+            };
+            if selector.matches(name, &rule) {
+                return Some(&mut child.value);
+            }
+        }
     }
+    None
 }

--- a/src/install/audit_fix/package_json_edits.rs
+++ b/src/install/audit_fix/package_json_edits.rs
@@ -241,12 +241,9 @@ fn apply_to_target(
                     })?;
                 }
                 EditSite::Override(selector) => {
-                    let Some(mut rules) = override_rules(&root) else {
-                        continue;
-                    };
-                    if let Some(value) = override_rule_value(&mut rules, &edit.key, selector) {
+                    for_each_override_value(&root, &edit.key, selector, |value| {
                         rewrite_value(arena, value, edit);
-                    }
+                    });
                 }
             }
         }
@@ -292,49 +289,40 @@ pub(super) fn root_package_json(manager: &mut PackageManager) -> Expr {
     fetch_entry_root(manager, &target)
 }
 
-struct OverrideRules {
-    object: Expr,
-    /// npm's `"parent": { "child": ... }` form is only read from `overrides` (`OverrideMap::parse_from_resolutions` skips object values).
-    nested: bool,
-}
-
-/// Same precedence as `OverrideMap::parse_append`: `overrides` wins even when `resolutions` is also present.
-fn override_rules(root: &Expr) -> Option<OverrideRules> {
-    if let Some(object) = root.get(b"overrides") {
-        return Some(OverrideRules {
-            object,
-            nested: true,
-        });
-    }
-    root.get(b"resolutions").map(|object| OverrideRules {
-        object,
-        nested: false,
-    })
-}
-
-/// What `name`'s rule `selector` is currently set to in the root package.json, or `None` when its value is not a range that can be rewritten in place (a `$ref`, for example).
+/// The string the root package.json currently gives `name`'s rule `selector`; when several entries spell the same rule, the last one, which is the one `OverrideMap` keeps.
 pub(super) fn override_literal(
     root: &Expr,
     name: &[u8],
     selector: &OverrideSelector,
 ) -> Option<Box<[u8]>> {
-    let mut rules = override_rules(root)?;
-    let value = override_rule_value(&mut rules, name, selector)?;
-    let literal = value.as_ref()?.as_utf8_string_literal()?;
-    Some(Box::from(strings::trim(
-        literal,
-        &strings::WHITESPACE_CHARS,
-    )))
+    let mut literal: Option<Box<[u8]>> = None;
+    for_each_override_value(root, name, selector, |value| {
+        if let Some(text) = value.as_ref().and_then(Expr::as_utf8_string_literal) {
+            literal = Some(Box::from(strings::trim(text, &strings::WHITESPACE_CHARS)));
+        }
+    });
+    literal
 }
 
-/// The value slot of the entry declaring `selector` for `name`, whichever of the accepted key spellings (`a>b`, `a/b`, `**/b`, `{"a": {"b": ..}}`, `{"b": {".": ..}}`) it uses.
-fn override_rule_value<'a>(
-    rules: &'a mut OverrideRules,
+/// Visits, in file order, the value of every entry declaring `selector` for `name`, whichever of the accepted key spellings (`a>b`, `a/b`, `**/b`, `{"a": {"b": ..}}`, `{"b": {".": ..}}`) each uses.
+///
+/// Reads `overrides`, else `resolutions`, like `OverrideMap::parse_append`; npm's `"parent": { "child": .. }` form only counts in `overrides`, where the parser accepts it.
+fn for_each_override_value(
+    root: &Expr,
     name: &[u8],
     selector: &OverrideSelector,
-) -> Option<&'a mut Option<Expr>> {
-    let nested = rules.nested;
-    let object = rules.object.data.e_object_mut()?;
+    mut f: impl FnMut(&mut Option<Expr>),
+) {
+    let (mut rules, nested) = match root.get(b"overrides") {
+        Some(overrides) => (overrides, true),
+        None => match root.get(b"resolutions") {
+            Some(resolutions) => (resolutions, false),
+            None => return,
+        },
+    };
+    let Some(object) = rules.data.e_object_mut() else {
+        return;
+    };
     for prop in object.properties.slice_mut() {
         let Some(key) = prop.key.as_ref().and_then(Expr::as_utf8_string_literal) else {
             continue;
@@ -346,7 +334,7 @@ fn override_rule_value<'a>(
                 .is_some_and(|value| matches!(value.data, ExprData::EObject(_)));
         if !is_group {
             if parse_selector(key).is_ok_and(|rule| selector.matches(name, &rule)) {
-                return Some(&mut prop.value);
+                f(&mut prop.value);
             }
             continue;
         }
@@ -382,9 +370,8 @@ fn override_rule_value<'a>(
                 }
             };
             if selector.matches(name, &rule) {
-                return Some(&mut child.value);
+                f(&mut child.value);
             }
         }
     }
-    None
 }

--- a/src/install/dedupe.rs
+++ b/src/install/dedupe.rs
@@ -6,6 +6,7 @@ use bun_collections::bit_set::Range;
 use bun_collections::{DynamicBitSet, index_sort};
 use bun_core::{Global, Output, UnwrapOrOom as _, strings};
 
+use crate::lockfile::override_map::OverrideRule;
 use crate::lockfile::package::PackageColumns as _;
 use crate::lockfile::{LoadResult, LoadStep, Lockfile, Package, PackageIndexEntry};
 use crate::package_manager::Options::{Enable, LogLevel};
@@ -581,21 +582,27 @@ pub(crate) fn effective_npm_range(
         .filter(|version| version.tag == DependencyVersionTag::Npm)
 }
 
+/// The override rule the resolver applies to this edge; `workspace:` and `npm:` alias edges are never overridden (PackageManagerEnqueue.rs).
+pub(crate) fn applied_override<'a>(
+    lockfile: &'a Lockfile,
+    dep_id: DependencyID,
+    dep: &Dependency,
+) -> Option<OverrideRule<'a>> {
+    if dep.behavior.is_workspace()
+        || (dep.version.tag == DependencyVersionTag::Npm && dep.version.npm().is_alias)
+    {
+        return None;
+    }
+    lockfile.overrides.lookup(lockfile, dep_id, dep.name_hash)
+}
+
 pub(crate) fn effective_version(
     lockfile: &Lockfile,
     dep_id: DependencyID,
     dep: &Dependency,
 ) -> Option<dependency::Version> {
-    let mut version = if dep.behavior.is_workspace()
-        || (dep.version.tag == DependencyVersionTag::Npm && dep.version.npm().is_alias)
-    {
-        dep.version.clone()
-    } else {
-        lockfile
-            .overrides
-            .get(lockfile, dep_id, dep.name_hash)
-            .unwrap_or_else(|| dep.version.clone())
-    };
+    let mut version = applied_override(lockfile, dep_id, dep)
+        .map_or_else(|| dep.version.clone(), |rule| rule.version().clone());
     if version.tag == DependencyVersionTag::Catalog {
         version = lockfile
             .catalogs

--- a/src/install/lockfile/OverrideMap.rs
+++ b/src/install/lockfile/OverrideMap.rs
@@ -40,6 +40,23 @@ pub struct ScopedOverride {
     pub(crate) dep: Dependency,
 }
 
+/// The rule `OverrideMap::lookup` chose for one dependency edge.
+#[derive(Clone, Copy)]
+pub(crate) enum OverrideRule<'a> {
+    Flat(&'a Dependency),
+    Scoped(&'a ScopedOverride),
+}
+
+impl<'a> OverrideRule<'a> {
+    #[inline]
+    pub(crate) fn version(self) -> &'a dependency::Version {
+        match self {
+            OverrideRule::Flat(dep) => &dep.version,
+            OverrideRule::Scoped(rule) => &rule.dep.version,
+        }
+    }
+}
+
 impl ScopedOverride {
     #[inline]
     pub(crate) fn parent_has_range(&self) -> bool {
@@ -147,24 +164,34 @@ impl OverrideMap {
         dependency_id: DependencyID,
         name_hash: PackageNameHash,
     ) -> Option<dependency::Version> {
+        self.lookup(lockfile, dependency_id, name_hash)
+            .map(|rule| rule.version().clone())
+    }
+
+    pub(crate) fn lookup(
+        &self,
+        lockfile: &Lockfile,
+        dependency_id: DependencyID,
+        name_hash: PackageNameHash,
+    ) -> Option<OverrideRule<'_>> {
         scoped_log!(OverrideMap, "looking up override for {:x}", name_hash);
         if self.scoped.is_empty() {
             return self.get_flat(name_hash);
         }
         if self.scoped_names.contains(&name_hash) {
             if let Some(rule) = self.scoped_rule_for(lockfile, dependency_id, name_hash) {
-                return Some(rule.dep.version.clone());
+                return Some(OverrideRule::Scoped(rule));
             }
         }
         self.get_flat(name_hash)
     }
 
     #[inline]
-    fn get_flat(&self, name_hash: PackageNameHash) -> Option<dependency::Version> {
+    fn get_flat(&self, name_hash: PackageNameHash) -> Option<OverrideRule<'_>> {
         if self.map.count() == 0 {
             return None;
         }
-        self.map.get(&name_hash).map(|dep| dep.version.clone())
+        self.map.get(&name_hash).map(OverrideRule::Flat)
     }
 
     fn scoped_rule_for<'s>(

--- a/test/cli/install/bun-audit.test.ts
+++ b/test/cli/install/bun-audit.test.ts
@@ -1460,7 +1460,7 @@ describe("`bun audit fix`", () => {
         to: "1.0.4",
         downgrade: false,
         latestFixes: true,
-        blockers: [{ dependent: "package.json", range: "<1.0.4", bundled: false }],
+        blockers: [{ dependent: "package.json", range: "<1.0.4", bundled: false, override: null }],
       },
       {
         name: "no-deps",
@@ -1468,7 +1468,7 @@ describe("`bun audit fix`", () => {
         to: "1.1.0",
         downgrade: false,
         latestFixes: false,
-        blockers: [{ dependent: "one-dep@1.0.0", range: "1.0.1", bundled: false }],
+        blockers: [{ dependent: "one-dep@1.0.0", range: "1.0.1", bundled: false, override: null }],
       },
     ]);
     expect(json.exitCode).toBe(1);
@@ -1502,7 +1502,7 @@ describe("`bun audit fix`", () => {
 
     const json = await auditFix(dir, "--json");
     expect(JSON.parse(json.stdout).blocked[0].blockers).toStrictEqual([
-      { dependent: "packages/pkg-a/package.json", range: "<1.0.4", bundled: false },
+      { dependent: "packages/pkg-a/package.json", range: "<1.0.4", bundled: false, override: null },
     ]);
     expect(json.exitCode).toBe(1);
   });
@@ -2186,15 +2186,143 @@ describe("`bun audit fix`", () => {
     await runBunInstall(installEnv(dir), dir, { frozenLockfile: true });
   });
 
-  test.concurrent("a version held by an overrides entry is blocked and the override is not rewritten", async () => {
+  test.concurrent("a direct dependency pinned by an overrides entry is fixed by rewriting the override", async () => {
     await using server = startRegistry({ "a-dep": [adv("<1.0.4")] });
     using dir = await setup(server, {
       name: "foo",
       dependencies: { "a-dep": "^1.0.2" },
       overrides: { "a-dep": "1.0.2" },
     });
+    expect(await lock(dir)).toContain('"a-dep@1.0.2"');
+
+    const { stdout, exitCode } = await auditFix(dir);
+    expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`
+      "bun audit fix <version> (<revision>)
+
+      fixing:
+        ^ a-dep 1.0.2 -> 1.0.4
+          package.json (overrides): 1.0.2 -> 1.0.4
+
+      Fixed 1 vulnerability in 1 package (checked 1)"
+    `);
+    expect(exitCode).toBe(0);
+
+    expect(await pkgJson(dir)).toStrictEqual({
+      name: "foo",
+      dependencies: { "a-dep": "^1.0.2" },
+      overrides: { "a-dep": "1.0.4" },
+    });
+    const lockfile = await lock(dir);
+    expect(lockfile).toContain('"a-dep@1.0.4"');
+    expect(lockfile).not.toContain('"a-dep@1.0.2"');
+    expect(lockfile).toContain('"a-dep": "1.0.4"');
+    expect(await installedVersion(dir, "a-dep")).toBe("1.0.4");
+
+    expectClean(await audit(dir), 1);
+    await runBunInstall(installEnv(dir), dir, { frozenLockfile: true });
+  });
+
+  // one-range-dep and one-range-dep-too both declare no-deps@^1.0.0; only the override holds it at 1.0.0.
+  test.concurrent(
+    "a transitive dependency pinned by an overrides entry is fixed by rewriting the override",
+    async () => {
+      await using server = startRegistry({ "no-deps": [adv("<1.0.1")] });
+      using dir = await setup(server, {
+        name: "foo",
+        dependencies: { "one-range-dep": "1.0.0", "one-range-dep-too": "1.0.0" },
+        overrides: { "no-deps": "1.0.0" },
+      });
+      expect(await lock(dir)).toContain('"no-deps@1.0.0"');
+
+      const { stdout, stderr, exitCode } = await auditFix(dir);
+      expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`
+      "bun audit fix <version> (<revision>)
+
+      fixing:
+        ^ no-deps 1.0.0 -> 1.0.1
+          package.json (overrides): 1.0.0 -> 1.0.1
+
+      Fixed 1 vulnerability in 1 package (checked 3)"
+    `);
+      expect(stderr).not.toContain("error:");
+      expect(exitCode).toBe(0);
+
+      expect(await pkgJson(dir)).toStrictEqual({
+        name: "foo",
+        dependencies: { "one-range-dep": "1.0.0", "one-range-dep-too": "1.0.0" },
+        overrides: { "no-deps": "1.0.1" },
+      });
+      const lockfile = await lock(dir);
+      expect(lockfile).toContain('"no-deps@1.0.1"');
+      expect(lockfile).not.toContain('"no-deps@1.0.0"');
+      expect(lockfile).toContain('"no-deps": "1.0.1"');
+      expect(await installedVersion(dir, "no-deps")).toBe("1.0.1");
+
+      expectClean(await audit(dir), 3);
+      await runBunInstall(installEnv(dir), dir, { frozenLockfile: true });
+    },
+  );
+
+  test.concurrent.each([
+    ["overrides", { "no-deps": "1.0.0" }, "(overrides)", { "no-deps": "1.0.1" }],
+    ["overrides", { "no-deps": { ".": "1.0.0" } }, "(overrides)", { "no-deps": { ".": "1.0.1" } }],
+    ["resolutions", { "**/no-deps": "1.0.0" }, "(overrides)", { "**/no-deps": "1.0.1" }],
+    [
+      "overrides",
+      { "one-range-dep>no-deps": "1.0.0" },
+      "(overrides one-range-dep>no-deps)",
+      { "one-range-dep>no-deps": "1.0.1" },
+    ],
+    [
+      "overrides",
+      { "one-range-dep": { "no-deps": "1.0.0" } },
+      "(overrides one-range-dep>no-deps)",
+      { "one-range-dep": { "no-deps": "1.0.1" } },
+    ],
+    [
+      "resolutions",
+      { "one-range-dep/no-deps": "1.0.0" },
+      "(overrides one-range-dep>no-deps)",
+      { "one-range-dep/no-deps": "1.0.1" },
+    ],
+    [
+      "overrides",
+      { "one-range-dep@1>no-deps": "1.0.0" },
+      "(overrides one-range-dep@1>no-deps)",
+      { "one-range-dep@1>no-deps": "1.0.1" },
+    ],
+    ["overrides", { "no-deps@<1.0.1": "1.0.0" }, "(overrides no-deps@<1.0.1)", { "no-deps@<1.0.1": "1.0.1" }],
+  ])("rewrites the rule in place when %s is written as %j", async (field, rules, label, rewritten) => {
+    await using server = startRegistry({ "no-deps": [adv("<1.0.1")] });
+    using dir = await setup(server, { name: "foo", dependencies: { "one-range-dep": "1.0.0" }, [field]: rules });
+    expect(await lock(dir)).toContain('"no-deps@1.0.0"');
+
+    const { stdout, exitCode } = await auditFix(dir);
+    expect(stdout).toContain(`  ^ no-deps 1.0.0 -> 1.0.1\n    package.json ${label}: 1.0.0 -> 1.0.1\n`);
+    expect(stdout).toContain("Fixed 1 vulnerability in 1 package");
+    expect(exitCode).toBe(0);
+
+    expect(await pkgJson(dir)).toStrictEqual({
+      name: "foo",
+      dependencies: { "one-range-dep": "1.0.0" },
+      [field]: rewritten,
+    });
+    const lockfile = await lock(dir);
+    expect(lockfile).toContain('"no-deps@1.0.1"');
+    expect(lockfile).not.toContain('"no-deps@1.0.0"');
+
+    await runBunInstall(installEnv(dir), dir, { frozenLockfile: true });
+  });
+
+  test.concurrent("an override written as a $reference is reported as the blocker and left alone", async () => {
+    await using server = startRegistry({ "no-deps": [adv("<1.0.1")] });
+    using dir = await setup(server, {
+      name: "foo",
+      dependencies: { "no-deps": "1.0.0", "one-range-dep": "1.0.0" },
+      overrides: { "no-deps": "$no-deps" },
+    });
     const lockBefore = await lock(dir);
-    expect(lockBefore).toContain('"a-dep@1.0.2"');
+    expect(lockBefore).toContain('"no-deps@1.0.0"');
     const pkgJsonBefore = await pkgJsonText(dir);
 
     const { stdout, exitCode } = await auditFix(dir);
@@ -2202,15 +2330,15 @@ describe("`bun audit fix`", () => {
       "bun audit fix <version> (<revision>)
 
       blocked by a dependent's range:
-        ^ a-dep 1.0.2 -> 1.0.4
-          package.json depends on a-dep@1.0.2
+        ^ no-deps 1.0.0 -> 1.0.1
+          package.json overrides no-deps@1.0.0
 
-      Fixed 0 of 1 vulnerability (checked 1)
+      Fixed 0 of 1 vulnerability (checked 2)
       1 vulnerability remaining"
     `);
     expect(exitCode).toBe(1);
-    expect(await lock(dir)).toBe(lockBefore);
     expect(await pkgJsonText(dir)).toBe(pkgJsonBefore);
+    expect(await lock(dir)).toBe(lockBefore);
   });
 
   test.concurrent("a pinned catalog entry is rewritten and the member keeps `catalog:`", async () => {
@@ -2976,7 +3104,9 @@ describe("`bun audit fix`", () => {
           to: "1.0.4",
           downgrade: false,
           newerThanMinimumReleaseAge: false,
-          packageJson: [{ file: "package.json", catalog: null, key: "a-dep", from: "1.0.2", to: "1.0.4" }],
+          packageJson: [
+            { file: "package.json", catalog: null, override: null, key: "a-dep", from: "1.0.2", to: "1.0.4" },
+          ],
         },
       ],
       blocked: [],
@@ -3068,7 +3198,7 @@ describe("`bun audit fix`", () => {
         to: "1.1.0",
         downgrade: false,
         latestFixes: false,
-        blockers: [{ dependent: "one-dep@1.0.0", range: "1.0.1", bundled: false }],
+        blockers: [{ dependent: "one-dep@1.0.0", range: "1.0.1", bundled: false, override: null }],
       },
     ]);
     expect(doc.unmatched).toStrictEqual([{ name: "no-deps", range: ">=9.0.0" }]);
@@ -3211,7 +3341,9 @@ describe("`bun audit fix`", () => {
           to: "1.0.4",
           downgrade: false,
           newerThanMinimumReleaseAge: false,
-          packageJson: [{ file: "package.json", catalog: null, key: "a-dep", from: "1.0.2", to: "1.0.4" }],
+          packageJson: [
+            { file: "package.json", catalog: null, override: null, key: "a-dep", from: "1.0.2", to: "1.0.4" },
+          ],
         },
       ],
       blocked: [],
@@ -3522,7 +3654,7 @@ describe("`bun audit fix`", () => {
         to: "2.0.0",
         downgrade: false,
         latestFixes: false,
-        blockers: [{ dependent: "package.json", range: "pre-1", bundled: false }],
+        blockers: [{ dependent: "package.json", range: "pre-1", bundled: false, override: null }],
       },
     ]);
     expect(exitCode).toBe(1);
@@ -3736,7 +3868,7 @@ describe("`bun audit fix`", () => {
         to: "1.0.1",
         downgrade: false,
         latestFixes: false,
-        blockers: [{ dependent: "bundled-1@1.0.0", range: "1.0.0", bundled: true }],
+        blockers: [{ dependent: "bundled-1@1.0.0", range: "1.0.0", bundled: true, override: null }],
       },
     ]);
     expect(doc).toMatchObject({ dryRun: false, fixed: 0, remaining: 1, fixes: [] });
@@ -3758,7 +3890,7 @@ describe("`bun audit fix`", () => {
         to: "1.1.0",
         downgrade: true,
         latestFixes: true,
-        blockers: [{ dependent: "package.json", range: "^2.0.0", bundled: false }],
+        blockers: [{ dependent: "package.json", range: "^2.0.0", bundled: false, override: null }],
       },
     ]);
     expect(doc).toMatchObject({ dryRun: false, fixed: 0, remaining: 1, fixes: [] });
@@ -3787,7 +3919,7 @@ describe("`bun audit fix`", () => {
         to: "1.0.1",
         downgrade: false,
         newerThanMinimumReleaseAge: false,
-        packageJson: [{ file: "package.json", catalog, key: "no-deps", from: "1.0.0", to: "1.0.1" }],
+        packageJson: [{ file: "package.json", catalog, override: null, key: "no-deps", from: "1.0.0", to: "1.0.1" }],
       },
     ]);
     expect(doc).toMatchObject({ dryRun: false, fixed: 1, remaining: 0 });
@@ -4117,7 +4249,9 @@ describe("`bun audit fix --latest`", () => {
         to: "2.0.0",
         downgrade: false,
         newerThanMinimumReleaseAge: false,
-        packageJson: [{ file: "package.json", catalog: null, key: "no-deps", from: "^1.0.0", to: "^2.0.0" }],
+        packageJson: [
+          { file: "package.json", catalog: null, override: null, key: "no-deps", from: "^1.0.0", to: "^2.0.0" },
+        ],
       },
     ]);
     expect(doc).toMatchObject({ dryRun: false, fixed: 1, remaining: 0, blocked: [] });
@@ -4150,24 +4284,137 @@ describe("`bun audit fix --latest`", () => {
     expect(await lock(dir)).toBe(lockBefore);
   });
 
-  test.concurrent("a version held by an overrides entry stays blocked", async () => {
-    await using server = startRegistry({ "a-dep": [adv("<1.0.4")] });
+  // Both dependents declare no-deps@^1.0.0, which also rejects 2.0.0; the override is what the user can change, so it alone is reported.
+  test.concurrent(
+    "a range held by an overrides entry is blocked on the override, which --latest rewrites",
+    async () => {
+      await using server = noDeps1x();
+      using dir = await setup(server, {
+        name: "foo",
+        dependencies: { "one-range-dep": "1.0.0", "one-range-dep-too": "1.0.0" },
+        overrides: { "no-deps": "~1.0.0" },
+      });
+      const lockBefore = await lock(dir);
+      expect(lockBefore).toContain('"no-deps@1.0.1"');
+      const pkgJsonBefore = await pkgJsonText(dir);
+
+      const blocked = await auditFix(dir);
+      expect(normalizeBunSnapshot(blocked.stdout)).toMatchInlineSnapshot(`
+      "bun audit fix <version> (<revision>)
+
+      blocked by a dependent's range:
+        ^ no-deps 1.0.1 -> 2.0.0
+          package.json overrides no-deps@~1.0.0
+          bun audit fix --latest
+
+      Fixed 0 of 1 vulnerability (checked 3)
+      1 vulnerability remaining"
+    `);
+      expect(blocked.exitCode).toBe(1);
+      expect(await pkgJsonText(dir)).toBe(pkgJsonBefore);
+      expect(await lock(dir)).toBe(lockBefore);
+
+      const { stdout, stderr, exitCode } = await auditFix(dir, "--latest");
+      expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`
+      "bun audit fix <version> (<revision>)
+
+      fixing:
+        ^ no-deps 1.0.1 -> 2.0.0
+          package.json (overrides): ~1.0.0 -> ~2.0.0
+
+      Fixed 1 vulnerability in 1 package (checked 3)"
+    `);
+      expect(stderr).not.toContain("error:");
+      expect(exitCode).toBe(0);
+
+      expect(await pkgJson(dir)).toStrictEqual({
+        name: "foo",
+        dependencies: { "one-range-dep": "1.0.0", "one-range-dep-too": "1.0.0" },
+        overrides: { "no-deps": "~2.0.0" },
+      });
+      const lockfile = await lock(dir);
+      expect(lockfile).toContain('"no-deps@2.0.0"');
+      expect(lockfile).not.toContain('"no-deps@1.0.1"');
+      expect(lockfile).toContain('"no-deps": "~2.0.0"');
+      expect(await installedVersion(dir, "no-deps")).toBe("2.0.0");
+
+      expectClean(await audit(dir), 3);
+      await runBunInstall(installEnv(dir), dir, { frozenLockfile: true });
+    },
+  );
+
+  test.concurrent("a nested override is blocked with its key and rewritten under it", async () => {
+    await using server = noDeps1x();
     using dir = await setup(server, {
       name: "foo",
-      dependencies: { "a-dep": "^1.0.2" },
-      overrides: { "a-dep": "1.0.2" },
+      dependencies: { "one-range-dep": "1.0.0" },
+      overrides: { "one-range-dep>no-deps": "~1.0.0" },
     });
-    const lockBefore = await lock(dir);
-    const pkgJsonBefore = await pkgJsonText(dir);
+    expect(await lock(dir)).toContain('"no-deps@1.0.1"');
+
+    const blocked = await auditFix(dir);
+    expect(blocked.stdout).toContain(
+      "    package.json overrides no-deps@~1.0.0 (one-range-dep>no-deps)\n    bun audit fix --latest\n",
+    );
+    expect(blocked.exitCode).toBe(1);
 
     const { stdout, exitCode } = await auditFix(dir, "--latest");
-    expect(stdout).toContain("blocked by a dependent's range:");
-    expect(stdout).toContain("package.json depends on a-dep@1.0.2");
-    expect(stdout).not.toContain("fixing:");
-    expect(stdout).not.toContain("bun audit fix --latest");
-    expect(exitCode).toBe(1);
-    expect(await pkgJsonText(dir)).toBe(pkgJsonBefore);
-    expect(await lock(dir)).toBe(lockBefore);
+    expect(stdout).toContain(
+      "  ^ no-deps 1.0.1 -> 2.0.0\n    package.json (overrides one-range-dep>no-deps): ~1.0.0 -> ~2.0.0\n",
+    );
+    expect(stdout).toContain("Fixed 1 vulnerability in 1 package");
+    expect(exitCode).toBe(0);
+    expect((await pkgJson(dir)).overrides).toStrictEqual({ "one-range-dep>no-deps": "~2.0.0" });
+    expect(await installedVersion(dir, "no-deps")).toBe("2.0.0");
+
+    await runBunInstall(installEnv(dir), dir, { frozenLockfile: true });
+  });
+
+  test.concurrent("--json names the overrides rule on the blocker and on the edit that rewrites it", async () => {
+    await using server = noDeps1x();
+    using dir = await setup(server, {
+      name: "foo",
+      dependencies: { "one-range-dep": "1.0.0" },
+      overrides: { "one-range-dep>no-deps": "~1.0.0" },
+    });
+
+    const blocked = await auditFix(dir, "--json");
+    expect(JSON.parse(blocked.stdout).blocked).toStrictEqual([
+      {
+        name: "no-deps",
+        from: "1.0.1",
+        to: "2.0.0",
+        downgrade: false,
+        latestFixes: true,
+        blockers: [{ dependent: "package.json", range: "~1.0.0", bundled: false, override: "one-range-dep>no-deps" }],
+      },
+    ]);
+    expect(blocked.exitCode).toBe(1);
+
+    const { stdout, exitCode } = await auditFix(dir, "--latest", "--dry-run", "--json");
+    const doc = JSON.parse(stdout);
+    expect(doc.fixes).toStrictEqual([
+      {
+        name: "no-deps",
+        from: "1.0.1",
+        to: "2.0.0",
+        downgrade: false,
+        newerThanMinimumReleaseAge: false,
+        packageJson: [
+          {
+            file: "package.json",
+            catalog: null,
+            override: "one-range-dep>no-deps",
+            key: "no-deps",
+            from: "~1.0.0",
+            to: "~2.0.0",
+          },
+        ],
+      },
+    ]);
+    expect(doc).toMatchObject({ dryRun: true, fixed: 1, remaining: 0, blocked: [] });
+    expect(exitCode).toBe(0);
+    expect((await pkgJson(dir)).overrides).toStrictEqual({ "one-range-dep>no-deps": "~1.0.0" });
   });
 
   test.concurrent("a bundled dependency stays blocked without a --latest hint", async () => {

--- a/test/cli/install/bun-audit.test.ts
+++ b/test/cli/install/bun-audit.test.ts
@@ -2292,6 +2292,19 @@ describe("`bun audit fix`", () => {
       { "one-range-dep@1>no-deps": "1.0.1" },
     ],
     ["overrides", { "no-deps@<1.0.1": "1.0.0" }, "(overrides no-deps@<1.0.1)", { "no-deps@<1.0.1": "1.0.1" }],
+    // Two spellings of one rule: the last one is the rule bun applies, and every entry holding the version is rewritten.
+    [
+      "overrides",
+      { "**/no-deps": "1.0.0", "no-deps": "1.0.0" },
+      "(overrides)",
+      { "**/no-deps": "1.0.1", "no-deps": "1.0.1" },
+    ],
+    [
+      "overrides",
+      { "**/no-deps": "1.1.0", "no-deps": "1.0.0" },
+      "(overrides)",
+      { "**/no-deps": "1.1.0", "no-deps": "1.0.1" },
+    ],
   ])("rewrites the rule in place when %s is written as %j", async (field, rules, label, rewritten) => {
     await using server = startRegistry({ "no-deps": [adv("<1.0.1")] });
     using dir = await setup(server, { name: "foo", dependencies: { "one-range-dep": "1.0.0" }, [field]: rules });


### PR DESCRIPTION
### Problem
- `bun audit fix` on a project whose `overrides` entry pins the vulnerable version blames the third-party dependents: the plan prints `a@1.0.0 depends on b@1.0.0` and `c@1.0.0 depends on b@1.0.0` although `a` and `c` declare `b@^1.0.0`; `1.0.0` is the override's value.
- No remedy is printed for that class, and `bun audit fix --latest` also ends in `Fixed 0 of 1`, so the one file the user controls is never named or touched. docs/pm/cli/audit.mdx even suggests adding an override as the way out.
- Cause: `src/install/audit_fix.rs` builds each `Blocker` from the edge's post-override range (`effective_npm_range`) and labels it with the dependent, and `pin_for` returned `None` for every edge matched by `lockfile.overrides`, so neither mode had an edit to offer.
- Overrides are how people pinned transitive dependencies for earlier advisories, so this is a common shape for `audit fix` to meet.

### Fix
- `OverrideMap::lookup` returns the rule that applies to an edge (`get` is now a wrapper over it); `dedupe::applied_override` adds the existing "aliases and `workspace:` edges are never overridden" condition, and `effective_version` is built on it, so the planner and the range computation agree on which rule governs an edge.
- Blocked section: an edge held by a rule reports `package.json overrides b@<value>`, followed by the rule's key when it is scoped (`(a>b)`, `(b@<1.1.0)`); all edges held by one rule collapse into one line. Bundled edges stay attributed to the package that bundles them.
- `pin_for` plans an edit for the rule's value under the same policy as dependency pins and catalog entries: an exact value is rewritten whenever the fix stays within `^current`, any range is rewritten under `--latest`, and the `bun audit fix --latest` hint appears in the blocked section when that would help. A rule whose value is `catalog:` produces the usual catalog edit.
- `PackageJsonEdit.catalog` becomes `EditSite { Dependencies, Catalog, Override(OverrideSelector) }`. Applying an override edit walks `overrides` (else `resolutions`) and matches each entry by its normalized selector, so the entry is found in any accepted spelling: `"b"`, `"a>b"`, `"a/b"`, `"**/b"`, `{"a": {"b": ..}}`, `{"b": {".": ..}}`, `"a@1>b"`, `"b@<1.0.1"`. The edit is only planned when the entry's current text equals the value bun.lock recorded; an entry written as `"$dep"` is therefore reported as the blocker and left alone instead of being claimed as fixed.
- Text output: `package.json (overrides): 1.0.0 -> 1.0.1`, or `(overrides a>b)` for a scoped rule. `--json`: blockers and `packageJson` edits gain `"override"` (the rule key, `null` elsewhere); the other keys are unchanged.
- Verified with test/cli/install/bun-audit.test.ts: the new and rewritten override cases (direct and transitive dependents, the eight key spellings, `$ref`, scoped rule blocked and rewritten, `--json`) fail on the unfixed build (25 failures, 14 of them these cases, the rest the `override` JSON key) and the whole file passes with it (189 tests).
- test/cli/install/overrides.test.ts, nested-overrides.test.ts, bun-dedupe.test.ts and bun-update-transitive.test.ts pass (395 tests), covering the `OverrideMap`/`effective_version` refactor; the byte-search and pub-exports source lints pass.
- docs/pm/cli/audit.mdx describes the new lines.

### Background
- `overrides` (npm) / `resolutions` (yarn) in the root package.json replace the range a dependent declares for a package. bun stores each rule in the lockfile's `OverrideMap` in a normalized form: either a flat rule keyed by name, or a `ScopedOverride` carrying an optional parent (name plus optional range) and an optional target range; the key text the user wrote is not kept, which is why the edit matches entries by re-parsing their keys with the same selector parser `OverrideMap` uses.
- A `$name` value copies the range declared for `name` in the project's own dependencies; bun.lock records the resolved range, so it is the one case where the file and the lockfile literal differ.
- `bun audit fix` plans per installed vulnerable version ("instance") over the edges that resolve to it. An edge either accepts a safe candidate through its effective range (fixed in bun.lock only), or through a `PackageJsonEdit` ("pin") that will be rewritten before the install runs; edges with neither become `Blocker`s. After a package.json edit, the regular install differ notices the changed override and re-resolves every edge of that name, which is what moves the dependents onto the fixed version.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 27 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-audit.test.ts
bun test v1.4.0 (8934192ec)

test/cli/install/bun-audit.test.ts:
(pass) `bun audit` > should fail with no package.json [290.47ms]
(pass) `bun audit` > should fail with package.json but no lockfile [240.12ms]
(pass) `bun audit` > should exit 0 when there are no dependencies in package.json [207.44ms]
(pass) `bun audit` > should exit 0 when there are no vulnerabilities [319.83ms]
(pass) `bun audit` > should exit code 1 when there are vulnerabilities [348.53ms]
(pass) `bun audit` > --audit-level that drops every advisory says how many it dropped [199.22ms]
(pass) `bun audit` > --ignore that drops every advisory says how many it ignored [205.06ms]
(pass) `bun audit` > --audit-level and --ignore drops are listed separately [169.16ms]
(pass) `bun audit` > should print valid JSON and exit 0 when --json is passed and there are no vulnerabilities [200.49ms]
(pass) `bun audit` > should print valid JSON and exit 1 when --json is passed and there are vulnerabilities [369.87ms]
(pass) `bun audit` > --json exits 0 
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (e8fb0578b)

test/cli/install/bun-audit.test.ts:
(pass) `bun audit` > should fail with no package.json [12.67ms]
(pass) `bun audit` > should fail with package.json but no lockfile [8.83ms]
(pass) `bun audit` > should exit 0 when there are no dependencies in package.json [19.58ms]
(pass) `bun audit` > should exit 0 when there are no vulnerabilities [18.72ms]
(pass) `bun audit` > should exit code 1 when there are vulnerabilities [14.65ms]
(pass) `bun audit` > --audit-level that drops every advisory says how many it dropped [6.79ms]
(pass) `bun audit` > --ignore that drops every advisory says how many it ignored [11.37ms]
(pass) `bun audit` > --audit-level and --ignore drops are listed separately [5.95ms]
(pass) `bun audit` > should print valid JSON and exit 0 when --json is passed and there are no vulnerabilities [4.89ms]
(pass) `bun audit` > should print valid JSON and exit 1 when --json is passed and there are vulnerabilities [11.84ms]
(pass) `bun audit` > --json exits 0 when --audit-level filters out every advisory, but still prints them all [8.23ms]
(pass) `bun audit` > --json exits 0 when --ignore covers every advisory, but still prints t
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-audit.test.ts
bun test v1.4.0 (8934192ec)

test/cli/install/bun-audit.test.ts:
(pass) `bun audit` > should fail with no package.json [230.13ms]
(pass) `bun audit` > should fail with package.json but no lockfile [204.59ms]
(pass) `bun audit` > should exit 0 when there are no dependencies in package.json [211.18ms]
(pass) `bun audit` > should exit 0 when there are no vulnerabilities [297.93ms]
(pass) `bun audit` > should exit code 1 when there are vulnerabilities [407.47ms]
(pass) `bun audit` > --audit-level that drops every advisory says how many it dropped [265.44ms]
(pass) `bun audit` > --ignore that drops every advisory says how many it ignored [228.83ms]
(pass) `bun audit` > --audit-level and --ignore drops are listed separately [235.19ms]
(pass) `bun audit` > should print valid JSON and exit 0 when --json is passed and there are no vulnerabilities [218.27ms]
(pass) `bun audit` > should print valid JSON and exit 1 when --json is passed and there are vulnerabilities [374.12ms]
(pass) `bun audit` > --json exits 0 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1004ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/28] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 240 extern-C blocks audited
[2/28] gen cpp.rs (cppbind)
[3/28] gen JS modules (bundle-modules)
Preprocess modules (12729ms)
Bundle modules (58ms)
Postprocesss modules (217ms)
Bundle Functions (1009ms)
Generate Code (34ms)

[14.07s] Bundled "src/js" for production
  2632 kb
  197 internal modules
  13 native modules
  91 internal functions across 17 files
[3/23] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/pm/cli/audit.mdx                       |  13 +-
 src/install/audit_fix.rs                    | 246 +++++++++++++--------
 src/install/audit_fix/json.rs               |  22 +-
 src/install/audit_fix/package_json_edits.rs | 222 +++++++++++++++++--
 src/install/dedupe.rs                       |  27 ++-
 src/install/lockfile/OverrideMap.rs         |  33 ++-
 test/cli/install/bun-audit.test.ts          | 320 +++++++++++++++++++++++++---
 7 files changed, 717 insertions(+), 166 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
docs/pm/cli/audit.mdx                            1      4      0
src/install/audit_fix.rs                         6     13      0
src/install/audit_fix/json.rs                    2      6      0
src/install/audit_fix/package_json_edits.rs      3      5      0
src/install/dedupe.rs                            2      2      0
src/install/lockfile/OverrideMap.rs              4      2      0
test/cli/install/bun-audit.test.ts              11     12      0
```

</details>

<!-- robobun:evidence:end -->