### PR TITLE
js_parser: name lowered anonymous classes after numeric, non-ASCII and private property keys

### DIFF
--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -721,7 +721,7 @@ impl Number {
     /// by calling out to the APIs in WebKit which are responsible for this operation.
     ///
     /// This can return `None` in wasm builds to avoid linking JSC
-    pub(crate) fn to_string(self, bump: &Bump) -> Option<Str> {
+    pub fn to_string(self, bump: &Bump) -> Option<Str> {
         Self::to_string_from_f64(self.value(), bump)
     }
 
@@ -819,7 +819,7 @@ impl BigInt {
     /// a syntax error, so any literal that starts with `0` and has more than
     /// one character is a radix literal.
     #[inline]
-    pub(crate) fn has_radix(v: &[u8]) -> bool {
+    pub fn has_radix(v: &[u8]) -> bool {
         v.len() >= 2 && v[0] == b'0'
     }
 

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -123,8 +123,7 @@ fn class_copy(c: &G::Class) -> G::Class {
     }
 }
 
-/// Whether the class body defines a static member keyed `name` (`static get
-/// name()`, `static name = ...`), which replaces the constructor's own `name`.
+/// `static name`, `static get name()`, ...: the class replaces its own `.name`.
 fn defines_static_name(props: &[Property]) -> bool {
     props.iter().any(|prop| {
         prop.flags.contains(Flags::Property::IsStatic)
@@ -2412,14 +2411,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             new_properties = merged;
         }
 
-        // `_class = class {}` would infer the name "_class", so restore the one
-        // the source position inferred. It is set with `__name` instead of by
-        // naming the class binding: the bundler renames a binding that collides
-        // with the enclosing scope (`const Bar = class Bar2 {}`), and a binding
-        // would shadow the outer `Bar` inside the class body. The block goes
-        // first so static initializers left in the body observe the name. A body
-        // with its own static `name` gets no block: static methods and accessors
-        // are installed before any static block runs, so it would overwrite them.
+        // `_class = class {}` would be named "_class". A string literal, unlike a
+        // class binding, survives bundler renaming and shadows nothing in the body;
+        // the block goes first so static initializers already see the name.
         if expr_class_is_anonymous && !defines_static_name(&new_properties) {
             let this_e = p.new_expr(E::This {}, loc);
             let name_e = p.new_expr(

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -5,9 +5,8 @@ use bun_alloc::ArenaVecExt as _;
 
 use bun_collections::{HashMap, VecExt};
 
-use crate::lexer as js_lexer;
 use crate::p::P;
-use crate::parser::{ARGUMENTS_STR as arguments_str, Ref, is_eval_or_arguments};
+use crate::parser::{ARGUMENTS_STR as arguments_str, Ref};
 use bun_ast::g::{DeclList, Property, PropertyKind};
 use bun_ast::{self as js_ast, B, E, Expr, ExprNodeList, Flags, G, S, Stmt};
 
@@ -122,21 +121,6 @@ fn class_copy(c: &G::Class) -> G::Class {
         has_decorators: c.has_decorators,
         should_lower_standard_decorators: c.should_lower_standard_decorators,
     }
-}
-
-/// Whether a context-inferred name (`export default` → "default", object
-/// property keys, assignment targets) can be attached to a lowered anonymous
-/// class expression as its syntactic binding name. Class bodies are always
-/// strict mode code and the output may be a module, so reserved words
-/// ("default", "let", "await", …), `eval`/`arguments`, and non-identifier
-/// strings would turn `_class = class <name> {}` into a syntax error.
-#[inline]
-fn can_be_class_binding_name(name: &[u8]) -> bool {
-    js_lexer::is_identifier(name)
-        && js_lexer::keyword(name).is_none()
-        && !js_lexer::is_strict_mode_reserved_word(name)
-        && name != b"await"
-        && !is_eval_or_arguments(name)
 }
 
 // ── impl P ───────────────────────────────────────────────────────────────────
@@ -1142,14 +1126,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 class_name_ref = ecr;
                 class_name_loc = loc;
                 expr_class_is_anonymous = true;
-                if let Some(name) = name_from_context
-                    && can_be_class_binding_name(name)
-                {
-                    class.class_name = Some(js_ast::LocRef {
-                        ref_: p.new_sym(js_ast::symbol::Kind::Other, name),
-                        loc,
-                    });
-                }
             }
         } else {
             class_name_ref = class.class_name.as_ref().unwrap().ref_;
@@ -2420,6 +2396,26 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 merged.push(np);
             }
             new_properties = merged;
+        }
+
+        // `_class = class {}` would infer the name "_class", so restore the one
+        // the source position inferred. It is set with `__name` instead of by
+        // naming the class binding: the bundler renames a binding that collides
+        // with the enclosing scope (`const Bar = class Bar2 {}`), and a binding
+        // would shadow the outer `Bar` inside the class body. The block goes
+        // first so static initializers left in the body observe the name.
+        if expr_class_is_anonymous {
+            let this_e = p.new_expr(E::This {}, loc);
+            let name_e = p.new_expr(
+                E::EString {
+                    data: name_from_context.unwrap_or(b"").into(),
+                    ..Default::default()
+                },
+                loc,
+            );
+            let set_name = p.call_rt(loc, b"__name", &[this_e, name_e]);
+            let block = p.make_static_block(set_name, loc);
+            new_properties.insert(0, block);
         }
 
         class.properties = bun_ast::StoreSlice::new_mut(new_properties.into_bump_slice_mut());

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -123,8 +123,7 @@ fn class_copy(c: &G::Class) -> G::Class {
     }
 }
 
-/// A static method or accessor keyed `name` is installed before any static block runs.
-/// (A `static name` field is initialized after them and replaces the name by itself.)
+/// Installed before static blocks run; a `static name` field instead wins on its own.
 fn defines_static_name_method(props: &[Property]) -> bool {
     props.iter().any(|prop| {
         prop.flags.contains(Flags::Property::IsStatic)

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -123,10 +123,13 @@ fn class_copy(c: &G::Class) -> G::Class {
     }
 }
 
-/// `static name`, `static get name()`, ...: the class replaces its own `.name`.
-fn defines_static_name(props: &[Property]) -> bool {
+/// A static method or accessor keyed `name` is installed before any static block runs.
+/// (A `static name` field is initialized after them and replaces the name by itself.)
+fn defines_static_name_method(props: &[Property]) -> bool {
     props.iter().any(|prop| {
         prop.flags.contains(Flags::Property::IsStatic)
+            && (prop.flags.contains(Flags::Property::IsMethod)
+                || prop.kind == PropertyKind::AutoAccessor)
             && match &prop.key {
                 Some(key) => {
                     matches!(&key.data, js_ast::ExprData::EString(s) if s.eql_comptime(b"name"))
@@ -1144,6 +1147,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             class_name_ref = class.class_name.as_ref().unwrap().ref_;
             class_name_loc = class.class_name.as_ref().unwrap().loc;
         }
+        // Decided before Phase 2 replaces decorated computed keys with temporaries.
+        let restore_inferred_name =
+            expr_class_is_anonymous && !defines_static_name_method(class.properties.slice());
 
         let mut inner_class_ref: Ref = class_name_ref;
         if !is_expr {
@@ -2412,7 +2418,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
 
         // A string literal, unlike a class binding, survives the bundler's renaming.
-        if expr_class_is_anonymous && !defines_static_name(&new_properties) {
+        if restore_inferred_name {
             let this_e = p.new_expr(E::This {}, loc);
             let name_e = p.new_expr(
                 E::EString {

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -2411,9 +2411,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             new_properties = merged;
         }
 
-        // `_class = class {}` would be named "_class". A string literal, unlike a
-        // class binding, survives bundler renaming and shadows nothing in the body;
-        // the block goes first so static initializers already see the name.
+        // A string literal, unlike a class binding, survives the bundler's renaming.
         if expr_class_is_anonymous && !defines_static_name(&new_properties) {
             let this_e = p.new_expr(E::This {}, loc);
             let name_e = p.new_expr(

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -128,7 +128,8 @@ fn defines_static_name_method(props: &[Property]) -> bool {
     props.iter().any(|prop| {
         prop.flags.contains(Flags::Property::IsStatic)
             && (prop.flags.contains(Flags::Property::IsMethod)
-                || prop.kind == PropertyKind::AutoAccessor)
+                // A decorated accessor is installed from the suffix instead.
+                || (prop.kind == PropertyKind::AutoAccessor && prop.ts_decorators.len_u32() == 0))
             && match &prop.key {
                 Some(key) => {
                     matches!(&key.data, js_ast::ExprData::EString(s) if s.eql_comptime(b"name"))

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -123,6 +123,20 @@ fn class_copy(c: &G::Class) -> G::Class {
     }
 }
 
+/// Whether the class body defines a static member keyed `name` (`static get
+/// name()`, `static name = ...`), which replaces the constructor's own `name`.
+fn defines_static_name(props: &[Property]) -> bool {
+    props.iter().any(|prop| {
+        prop.flags.contains(Flags::Property::IsStatic)
+            && match &prop.key {
+                Some(key) => {
+                    matches!(&key.data, js_ast::ExprData::EString(s) if s.eql_comptime(b"name"))
+                }
+                None => false,
+            }
+    })
+}
+
 // ── impl P ───────────────────────────────────────────────────────────────────
 
 impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
@@ -2403,8 +2417,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // naming the class binding: the bundler renames a binding that collides
         // with the enclosing scope (`const Bar = class Bar2 {}`), and a binding
         // would shadow the outer `Bar` inside the class body. The block goes
-        // first so static initializers left in the body observe the name.
-        if expr_class_is_anonymous {
+        // first so static initializers left in the body observe the name. A body
+        // with its own static `name` gets no block: static methods and accessors
+        // are installed before any static block runs, so it would overwrite them.
+        if expr_class_is_anonymous && !defines_static_name(&new_properties) {
             let this_e = p.new_expr(E::This {}, loc);
             let name_e = p.new_expr(
                 E::EString {

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -771,6 +771,30 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         self.stmts_to_single_stmt(stmt.loc, stmts.into_bump_slice_mut())
     }
 
+    /// The `.name` that `key` gives an anonymous class value; lowering the class would lose it.
+    pub(crate) fn decorator_class_name_from_key(
+        &self,
+        key: Option<Expr>,
+        value: &Expr,
+    ) -> Option<&'a [u8]> {
+        let ExprData::EClass(class) = value.data else {
+            return None;
+        };
+        if class.class_name.is_some() || !class.should_lower_standard_decorators {
+            return None;
+        }
+        match key?.unwrap_inlined().data {
+            // `slice` flattens ropes and transcodes UTF-16; `data` alone does not.
+            ExprData::EString(mut str_) => Some(str_.slice(self.arena)),
+            ExprData::ENumber(num) => num.to_string(self.arena).map(|s| s.slice()),
+            ExprData::EBigInt(bigint) if !E::BigInt::has_radix(&bigint.value) => {
+                Some(bigint.value.slice())
+            }
+            ExprData::EPrivateIdentifier(private) => Some(self.load_name_from_ref(private.ref_)),
+            _ => None,
+        }
+    }
+
     pub(crate) fn visit_class(
         &mut self,
         name_scope_loc: bun_ast::Loc,
@@ -953,23 +977,18 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
 
                 if let Some(val) = property.value {
+                    let was_anon = val.is_anonymous_named();
+                    let prev_dcn = self.decorator_class_name;
+                    self.decorator_class_name =
+                        self.decorator_class_name_from_key(property.key, &val);
+                    self.visit_expr(property.value.as_mut().unwrap());
+                    self.decorator_class_name = prev_dcn;
                     if let Some(name) = name_to_keep {
-                        let was_anon = val.is_anonymous_named();
-                        let prev_dcn = self.decorator_class_name;
-                        if let ExprData::EClass(e_class) = &val.data {
-                            if e_class.class_name.is_none()
-                                && e_class.should_lower_standard_decorators
-                            {
-                                self.decorator_class_name = Some(name);
-                            }
-                        }
-                        let mut visited = val;
-                        self.visit_expr(&mut visited);
-                        property.value =
-                            Some(self.maybe_keep_expr_symbol_name(visited, name, was_anon));
-                        self.decorator_class_name = prev_dcn;
-                    } else {
-                        self.visit_expr(property.value.as_mut().unwrap());
+                        property.value = Some(self.maybe_keep_expr_symbol_name(
+                            property.value.expect("unreachable"),
+                            name,
+                            was_anon,
+                        ));
                     }
 
                     if Self::IS_TYPESCRIPT_ENABLED {
@@ -984,24 +1003,18 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
 
                 if let Some(val) = property.initializer {
-                    // if (property.flags.is_static and )
+                    let was_anon = val.is_anonymous_named();
+                    let prev_dcn = self.decorator_class_name;
+                    self.decorator_class_name =
+                        self.decorator_class_name_from_key(property.key, &val);
+                    self.visit_expr(property.initializer.as_mut().unwrap());
+                    self.decorator_class_name = prev_dcn;
                     if let Some(name) = name_to_keep {
-                        let was_anon = val.is_anonymous_named();
-                        let prev_dcn2 = self.decorator_class_name;
-                        if let ExprData::EClass(e_class) = &val.data {
-                            if e_class.class_name.is_none()
-                                && e_class.should_lower_standard_decorators
-                            {
-                                self.decorator_class_name = Some(name);
-                            }
-                        }
-                        let mut visited = val;
-                        self.visit_expr(&mut visited);
-                        property.initializer =
-                            Some(self.maybe_keep_expr_symbol_name(visited, name, was_anon));
-                        self.decorator_class_name = prev_dcn2;
-                    } else {
-                        self.visit_expr(property.initializer.as_mut().unwrap());
+                        property.initializer = Some(self.maybe_keep_expr_symbol_name(
+                            property.initializer.expect("unreachable"),
+                            name,
+                            was_anon,
+                        ));
                     }
                 }
 

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1705,32 +1705,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
 
             if let Some(value) = &mut property.value {
-                // Propagate name from property key for decorated anonymous class expressions
-                // e.g., { Foo: @dec class {} } should give the class .name = "Foo"
-                if in_.assign_target == js_ast::AssignTarget::None
-                    && matches!(value.data, Data::EClass(..))
-                    && value
-                        .data
-                        .e_class()
-                        .unwrap()
-                        .should_lower_standard_decorators
-                    && value
-                        .data
-                        .e_class()
-                        .expect("infallible: variant checked")
-                        .class_name
-                        .is_none()
-                    && let Some(key) = property.key
-                    && matches!(key.data, Data::EString(..))
-                {
-                    let key_str = key.data.e_string().expect("infallible: variant checked");
-                    // While E.rs has duplicate impls (E0034), reach the bytes directly
-                    // — class-name keys are parser-produced (UTF-8, no rope).
-                    p.decorator_class_name = if !key_str.is_utf16 {
-                        Some(key_str.data.slice())
-                    } else {
-                        None
-                    };
+                // { Foo: @dec class {} } gives the class .name = "Foo"
+                if in_.assign_target == js_ast::AssignTarget::None {
+                    p.decorator_class_name = p.decorator_class_name_from_key(property.key, value);
                 }
                 p.visit_expr_in_out(
                     value,

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4899,9 +4899,7 @@ void JSC__VM__releaseWeakRefs(JSC::VM* arg0)
     arg0->finalizeSynchronousJSExecution();
 }
 
-// A "name" redefined with Object.defineProperty (tsc's __setFunctionName, esbuild's and Bun's
-// __name) is what node displays; JSC's calculatedDisplayName() only looks at "displayName" and
-// the executable. "displayName" keeps its precedence.
+// A "name" set with Object.defineProperty, which JSC's calculatedDisplayName() does not consult.
 static WTF::String explicitFunctionName(JSC::VM& vm, JSC::JSFunction* function)
 {
     if (!function->displayName(vm).isEmpty()) {
@@ -4916,8 +4914,7 @@ static WTF::String explicitFunctionName(JSC::VM& vm, JSC::JSFunction* function)
     return WTF::String();
 }
 
-// The function JSObject::calculatedClassName() would name an object after: its own
-// "constructor" (prototype objects) or its prototype's (instances).
+// The constructor JSObject::calculatedClassName() names an object after.
 static JSC::JSFunction* constructorForClassName(JSC::VM& vm, JSC::JSObject* object)
 {
     JSC::JSValue constructor = object->getDirect(vm, vm.propertyNames->constructor);

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4899,6 +4899,38 @@ void JSC__VM__releaseWeakRefs(JSC::VM* arg0)
     arg0->finalizeSynchronousJSExecution();
 }
 
+// A "name" redefined with Object.defineProperty (tsc's __setFunctionName, esbuild's and Bun's
+// __name) is what node displays; JSC's calculatedDisplayName() only looks at "displayName" and
+// the executable. "displayName" keeps its precedence.
+static WTF::String explicitFunctionName(JSC::VM& vm, JSC::JSFunction* function)
+{
+    if (!function->displayName(vm).isEmpty()) {
+        return WTF::String();
+    }
+
+    JSC::JSValue name = function->getDirect(vm, vm.propertyNames->name);
+    if (name && JSC::isJSString(name)) {
+        return JSC::asString(name)->tryGetValue();
+    }
+
+    return WTF::String();
+}
+
+// The function JSObject::calculatedClassName() would name an object after: its own
+// "constructor" (prototype objects) or its prototype's (instances).
+static JSC::JSFunction* constructorForClassName(JSC::VM& vm, JSC::JSObject* object)
+{
+    JSC::JSValue constructor = object->getDirect(vm, vm.propertyNames->constructor);
+    if (!constructor && !object->structure()->typeInfo().overridesGetPrototype()) {
+        JSC::JSValue prototype = object->getPrototypeDirect();
+        if (prototype.isObject()) {
+            constructor = JSC::asObject(prototype)->getDirect(vm, vm.propertyNames->constructor);
+        }
+    }
+
+    return constructor ? dynamicDowncast<JSC::JSFunction>(constructor) : nullptr;
+}
+
 void JSC__JSValue__getClassName(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* arg1, ZigString* arg2)
 {
     JSValue value = JSValue::decode(JSValue0);
@@ -4918,6 +4950,14 @@ void JSC__JSValue__getClassName(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObjec
     }
 
     JSObject* obj = value.toObject(arg1);
+
+    if (JSC::JSFunction* constructor = constructorForClassName(arg1->vm(), obj)) {
+        auto explicitName = explicitFunctionName(arg1->vm(), constructor);
+        if (!explicitName.isEmpty()) {
+            *arg2 = Zig::toZigString(explicitName);
+            return;
+        }
+    }
 
     auto calculated = JSObject::calculatedClassName(obj);
     if (calculated.length() > 0) {
@@ -4961,6 +5001,11 @@ void JSC__JSValue__getNameProperty(JSC::EncodedJSValue JSValue0, JSC::JSGlobalOb
     }
 
     if (JSC::JSFunction* function = dynamicDowncast<JSC::JSFunction>(obj)) {
+        WTF::String explicitName = explicitFunctionName(vm, function);
+        if (!explicitName.isEmpty()) {
+            *arg2 = Zig::toZigString(explicitName);
+            return;
+        }
 
         WTF::String actualName = function->name(vm);
         if (!actualName.isEmpty() || function->isHostOrBuiltinFunction()) {
@@ -4992,6 +5037,14 @@ void JSC__JSValue__getNameProperty(JSC::EncodedJSValue JSValue0, JSC::JSGlobalOb
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
     JSObject* object = value.getObject();
+    if (JSC::JSFunction* function = dynamicDowncast<JSC::JSFunction>(object)) {
+        auto explicitName = explicitFunctionName(vm, function);
+        if (!explicitName.isEmpty()) {
+            *arg2 = Bun::toStringRef(explicitName);
+            return;
+        }
+    }
+
     auto displayName = JSC::getCalculatedDisplayName(vm, object);
 
     // JSC doesn't include @@toStringTag in calculated display name

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -3170,6 +3170,51 @@ describe("bundler", () => {
     },
     run: { stdout: "try:false" },
   });
+  // Standard-decorator lowering rewrites `const Bar = class { ... }` into
+  // `_class = class { ... }`, so the class no longer infers its name from the
+  // binding. The name the lowering attaches instead has to survive the
+  // bundler's renaming of symbols that collide in the enclosing scope (the
+  // function-local `Bar` here, the CommonJS-wrapped module scope below) and
+  // identifier minification.
+  const decoratedAnonymousClassNames = /* js */ `
+    function dec() {}
+    function f() {
+      const Bar = class { @dec m() {} };
+      const Baz = class { accessor x; };
+      let Qux; Qux = class { @dec static s() {} };
+      const obj = { "not-an-identifier": class { @dec m() {} } };
+      return [Bar.name, Baz.name, Qux.name, obj["not-an-identifier"].name];
+    }
+    console.log(JSON.stringify(f()));
+  `;
+  itBundled("edgecase/DecoratedAnonymousClassExprKeepsInferredName", {
+    files: {
+      "/entry.js": decoratedAnonymousClassNames,
+    },
+    run: { stdout: '["Bar","Baz","Qux","not-an-identifier"]' },
+  });
+  itBundled("edgecase/DecoratedAnonymousClassExprKeepsInferredNameMinified", {
+    files: {
+      "/entry.js": decoratedAnonymousClassNames,
+    },
+    minifyIdentifiers: true,
+    minifySyntax: true,
+    minifyWhitespace: true,
+    run: { stdout: '["Bar","Baz","Qux","not-an-identifier"]' },
+  });
+  itBundled("edgecase/DecoratedAnonymousClassExprKeepsInferredNameInCJSWrapper", {
+    files: {
+      "/entry.js": /* js */ `
+        console.log(require("./mod.cjs").name);
+      `,
+      "/mod.cjs": /* js */ `
+        function dec() {}
+        const Bar = class { @dec m() {} };
+        module.exports = Bar;
+      `,
+    },
+    run: { stdout: "Bar" },
+  });
 });
 
 for (const backend of ["api", "cli"] as const) {

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1104,6 +1104,20 @@ describe("ES Decorators", () => {
       );
       expect(exitCode).toBe(0);
     });
+
+    test.concurrent("a decorated static accessor named `name` is installed after the body runs", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() {}
+        const Foo = class {
+          static seenBefore = this.name;
+          @dec static accessor name = "from accessor";
+        };
+        console.log(JSON.stringify([Foo.seenBefore, Foo.name]));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe('["Foo","from accessor"]\n');
+      expect(exitCode).toBe(0);
+    });
   });
 
   describe("private member calls in lowered classes", () => {

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1072,6 +1072,33 @@ describe("ES Decorators", () => {
       expect(stdout).toBe("static block: Bar\nBar Bar Bar\nBaz Baz\n");
       expect(exitCode).toBe(0);
     });
+
+    test.concurrent("a static member named `name` declared by the class wins", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() {}
+        const Getter = class { static get name() { return "from getter"; } @dec m() {} };
+        const Setter = class { static set name(v) {} @dec m() {} };
+        const Method = class { static name() {} @dec m() {} };
+        const DecoratedMethod = class { @dec static name() {} };
+        const Accessor = class { static accessor name = "from accessor"; @dec m() {} };
+        const Field = class { static name = "from field"; @dec m() {} };
+        const Uninitialized = class { static name; @dec m() {} };
+        const Instance = class { name = "instance"; @dec m() {} };
+        console.log(JSON.stringify([
+          Getter.name,
+          Setter.name,
+          typeof Method.name,
+          typeof DecoratedMethod.name,
+          Accessor.name,
+          Field.name,
+          Uninitialized.name,
+          Instance.name,
+        ]));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe('["from getter",null,"function","function","from accessor","from field",null,"Instance"]\n');
+      expect(exitCode).toBe(0);
+    });
   });
 
   describe("private member calls in lowered classes", () => {

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1080,8 +1080,9 @@ describe("ES Decorators", () => {
         const Setter = class { static set name(v) {} @dec m() {} };
         const Method = class { static name() {} @dec m() {} };
         const DecoratedMethod = class { @dec static name() {} };
+        const DecoratedComputed = class { @dec static ["name"]() {} };
         const Accessor = class { static accessor name = "from accessor"; @dec m() {} };
-        const Field = class { static name = "from field"; @dec m() {} };
+        const Field = class { static seenBefore = this.name; static name = "from field"; @dec m() {} };
         const Uninitialized = class { static name; @dec m() {} };
         const Instance = class { name = "instance"; @dec m() {} };
         console.log(JSON.stringify([
@@ -1089,14 +1090,18 @@ describe("ES Decorators", () => {
           Setter.name,
           typeof Method.name,
           typeof DecoratedMethod.name,
+          typeof DecoratedComputed.name,
           Accessor.name,
+          Field.seenBefore,
           Field.name,
           Uninitialized.name,
           Instance.name,
         ]));
       `);
       expect(stderr).toBe("");
-      expect(stdout).toBe('["from getter",null,"function","function","from accessor","from field",null,"Instance"]\n');
+      expect(stdout).toBe(
+        '["from getter",null,"function","function","function","from accessor","Field","from field",null,"Instance"]\n',
+      );
       expect(exitCode).toBe(0);
     });
   });

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -845,6 +845,7 @@ describe("ES Decorators", () => {
           import Cls from "./mod.js";
           const c = new Cls();
           console.log(c.foo());
+          console.log(Cls.name);
         `,
         "mod.js": `
           function dec(fn, ctx) { console.log("decorated", ctx.name); return fn; }
@@ -863,7 +864,7 @@ describe("ES Decorators", () => {
 
       const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(filterStderr(rawStderr)).toBe("");
-      expect(stdout).toBe("decorated foo\n42\n");
+      expect(stdout).toBe("decorated foo\n42\ndefault\n");
       expect(exitCode).toBe(0);
     });
 
@@ -979,6 +980,97 @@ describe("ES Decorators", () => {
       expect(output).not.toContain("class default");
       // the lowered output must still be valid syntax
       expect(() => new Bun.Transpiler({ loader: "js" }).transformSync(output)).not.toThrow();
+    });
+  });
+
+  describe("inferred names of lowered anonymous class expressions", () => {
+    // Lowering turns `const Bar = class { ... }` into `_class = class { ... }`,
+    // which would otherwise make the class infer the name "_class". The name
+    // the source position would have inferred must be restored without adding
+    // a class binding: a binding can only hold identifier names, shadows the
+    // outer variable inside the class body, and is renamed by the bundler.
+    test.concurrent("names that are not valid identifiers", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() {}
+        const obj = {
+          "foo-bar": class { @dec m() {} },
+          "": class { @dec m() {} },
+          default: class { @dec m() {} },
+          "with space": class { accessor x; },
+        };
+        console.log(JSON.stringify([obj["foo-bar"].name, obj[""].name, obj.default.name, obj["with space"].name]));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe('["foo-bar","","default","with space"]\n');
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("every naming context", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() {}
+        const A = class { @dec m() {} };
+        let B; B = class { @dec m() {} };
+        const { C = class { @dec m() {} } } = {};
+        const [D = class { @dec m() {} }] = [];
+        const obj = { E: class { @dec m() {} } };
+        class Holder {
+          static F = class { @dec m() {} };
+          G = class { @dec m() {} };
+        }
+        const H = @dec class {};
+        console.log(JSON.stringify([A.name, B.name, C.name, D.name, obj.E.name, Holder.F.name, new Holder().G.name, H.name]));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe('["A","B","C","D","E","F","G","H"]\n');
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("no naming context leaves the name empty", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() {}
+        const id = x => x;
+        console.log(JSON.stringify([id(class { @dec m() {} }).name, id(@dec class {}).name, id(class { accessor x; }).name]));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe('["","",""]\n');
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("class body still refers to the outer binding", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() {}
+        let Bar = class {
+          @dec m() { return Bar; }
+          static s() { return Bar; }
+        };
+        const Original = Bar;
+        Bar = "reassigned";
+        console.log(Original.name, new Original().m(), Original.s());
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("Bar reassigned reassigned\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("name is set before static initializers run", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() {}
+        const Bar = class {
+          static field = this.name;
+          static #priv = this.name;
+          static priv() { return this.#priv; }
+          static { console.log("static block:", this.name); }
+          @dec m() {}
+        };
+        console.log(Bar.name, Bar.field, Bar.priv());
+        const Baz = @dec class {
+          static field = this.name;
+        };
+        console.log(Baz.name, Baz.field);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("static block: Bar\nBar Bar Bar\nBaz Baz\n");
+      expect(exitCode).toBe(0);
     });
   });
 

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -325,6 +325,168 @@ describe("ES Decorators", () => {
     });
   });
 
+  describe("anonymous class expressions named by the property key", () => {
+    // An anonymous class expression used as a property value is named after the
+    // property key. The lowering moves the class out of that position, so the
+    // parser has to hand it the key's string form, whatever kind of key it is,
+    // and the lowering must apply it as a string (a class binding of that name
+    // would shadow an outer variable spelled like the key inside the body).
+    // Expected values are what the same code prints without the decorators.
+    test.concurrent("object literal keys reach a class decorator as ctx.name and .name", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        const names = [];
+        function dec(cls, ctx) { names.push(ctx.name); }
+        const o = {
+          123: @dec class {},
+          1_000: @dec class {},
+          0x10: @dec class {},
+          0.5: @dec class {},
+          1e21: @dec class {},
+          [-1]: @dec class {},
+          1n: @dec class {},
+          "héllo": @dec class {},
+          "\\u{20BB7}": @dec class {},
+          ["a" + "b"]: @dec class {},
+          "a-b": @dec class {},
+        };
+        const keys = [123, 1000, 16, 0.5, 1e21, -1, 1, "héllo", "\\u{20BB7}", "ab", "a-b"];
+        console.log(JSON.stringify([names, keys.map(key => o[key].name)]));
+      `);
+      expect(stderr).toBe("");
+      const expected = ["123", "1000", "16", "0.5", "1e+21", "-1", "1", "héllo", "\u{20BB7}", "ab", "a-b"];
+      expect(JSON.parse(stdout)).toEqual([expected, expected]);
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("keys name a class that only has member decorators or accessors", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() {}
+        const o = {
+          ascii: class { @dec m() {} },
+          123: class { @dec m() {} },
+          "héllo": class { @dec m() {} },
+          "\\u{20BB7}": class { accessor x; },
+          [-1]: class { accessor x; },
+          1n: class { @dec m() {} },
+          ["a" + "b"]: class { accessor x; },
+        };
+        class Holder {
+          static 456 = class { @dec m() {} };
+          static ["x-y"] = class { accessor x; };
+          #secret = class { @dec m() {} };
+          get secret() { return this.#secret; }
+        }
+        console.log(JSON.stringify([
+          o.ascii.name, o[123].name, o["héllo"].name, o["\\u{20BB7}"].name, o[-1].name, o[1].name, o.ab.name,
+          Holder[456].name, Holder["x-y"].name, new Holder().secret.name,
+        ]));
+      `);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual([
+        "ascii",
+        "123",
+        "héllo",
+        "\u{20BB7}",
+        "-1",
+        "1",
+        "ab",
+        "456",
+        "x-y",
+        "#secret",
+      ]);
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("the key only names the class, it does not shadow a same-named outer binding", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() {}
+        const wörld = "outer", Widget = "outer", Model = "outer";
+        const o = {
+          "wörld": @dec class { static outer() { return wörld; } },
+          ["Wid" + "get"]: class { @dec m() {} static outer() { return Widget; } },
+        };
+        class Holder {
+          static ["Model"] = class { accessor x; static outer() { return Model; } };
+        }
+        const classes = [o["wörld"], o.Widget, Holder.Model];
+        console.log(JSON.stringify(classes.map(cls => [cls.name, cls.outer()])));
+      `);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual([
+        ["wörld", "outer"],
+        ["Widget", "outer"],
+        ["Model", "outer"],
+      ]);
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("class member keys reach a class decorator as ctx.name and .name", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        const names = [];
+        function dec(cls, ctx) { names.push(ctx.name); }
+        class Holder {
+          static 456 = @dec class {};
+          static "wörld" = @dec class {};
+          static ["x-y"] = @dec class {};
+          static #hidden = @dec class {};
+          123 = @dec class {};
+          2n = @dec class {};
+          #secret = @dec class {};
+          static classNames() {
+            const instance = new Holder();
+            return [
+              Holder[456].name,
+              Holder["wörld"].name,
+              Holder["x-y"].name,
+              Holder.#hidden.name,
+              instance[123].name,
+              instance[2].name,
+              instance.#secret.name,
+            ];
+          }
+        }
+        const classNames = Holder.classNames();
+        console.log(JSON.stringify([names, classNames]));
+      `);
+      expect(stderr).toBe("");
+      const expected = ["456", "wörld", "x-y", "#hidden", "123", "2", "#secret"];
+      expect(JSON.parse(stdout)).toEqual([expected, expected]);
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("inlined enum member keys name the class after the enum value", async () => {
+      using dir = tempDir("es-dec-enum-key", {
+        "tsconfig.json": JSON.stringify({ compilerOptions: {} }),
+        "test.ts": `
+          enum Kind { User = "User", Num = 7 }
+          class User {}
+          const names: string[] = [];
+          function dec(cls: unknown, ctx: ClassDecoratorContext) { names.push(String(ctx.name)); }
+          const registry = {
+            [Kind.User]: @dec class { static model() { return User; } },
+            [Kind.Num]: class { accessor x; },
+          };
+          console.log(JSON.stringify([
+            names,
+            registry[Kind.User].name,
+            registry[Kind.User].model() === User,
+            registry[Kind.Num].name,
+          ]));
+        `,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(filterStderr(rawStderr)).toBe("");
+      expect(JSON.parse(stdout)).toEqual([["User"], "User", true, "7"]);
+      expect(exitCode).toBe(0);
+    });
+  });
+
   describe("decorator ordering", () => {
     test("decorators on different elements evaluate in source order", async () => {
       const { stdout, stderr, exitCode } = await runDecorator(`

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1005,6 +1005,25 @@ describe("ES Decorators", () => {
       expect(exitCode).toBe(0);
     });
 
+    test.concurrent("console.log and Bun.inspect show the inferred name", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() {}
+        const Item = class { accessor id; };
+        const Decorated = class { @dec m() {} };
+        class Child extends Item {}
+        console.log(Item, Bun.inspect(new Item(), { compact: true }), Bun.inspect({ item: new Item() }, { compact: true }));
+        console.log(Decorated, Bun.inspect(new Decorated(), { compact: true }), Child);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe(
+        [
+          "[class Item] Item { id: [Getter/Setter] } { item: Item { id: [Getter/Setter] } }",
+          "[class Decorated] Decorated { m: [Function: m] } [class Child extends Item]",
+        ].join("\n") + "\n",
+      );
+      expect(exitCode).toBe(0);
+    });
+
     test.concurrent("every naming context", async () => {
       const { stdout, stderr, exitCode } = await runDecorator(`
         function dec() {}

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -617,6 +617,55 @@ describe("console.logging class displays names and extends", async () => {
   }
 });
 
+describe("a name defined with Object.defineProperty is displayed", () => {
+  // tsc (__setFunctionName) and esbuild/Bun (__name) name the anonymous class their decorator
+  // lowering produces this way; the class binding they assign to is a temporary.
+  function setName(value, name) {
+    return Object.defineProperty(value, "name", { value: name, configurable: true });
+  }
+  class Base {}
+  const Item = setName(class {}, "Item");
+  const Derived = setName(class extends Base {}, "Derived");
+
+  it("class and instances", () => {
+    expect([Bun.inspect(Item), Bun.inspect(new Item()), Bun.inspect({ item: new Item() }, { compact: true })]).toEqual([
+      "[class Item]",
+      "Item {}",
+      "{ item: Item {} }",
+    ]);
+  });
+
+  it("extends clause and subclass instances", () => {
+    class Child extends Item {}
+    expect([Bun.inspect(Derived), Bun.inspect(new Derived()), Bun.inspect(Child), Bun.inspect(Item.prototype)]).toEqual(
+      ["[class Derived extends Base]", "Derived {}", "[class Child extends Item]", "Item {}"],
+    );
+  });
+
+  it("functions", () => {
+    expect(Bun.inspect(setName(function original() {}, "renamed"))).toBe("[Function: renamed]");
+  });
+
+  it("displayName still takes precedence", () => {
+    const fn = setName(function original() {}, "renamed");
+    fn.displayName = "Display";
+    expect(Bun.inspect(fn)).toBe("[Function: Display]");
+  });
+
+  it("a name accessor is not invoked", () => {
+    let called = false;
+    const Cls = Object.defineProperty(class Original {}, "name", {
+      get() {
+        called = true;
+        return "from getter";
+      },
+    });
+    expect(Bun.inspect(Cls)).toBe("[class Original]");
+    expect(Bun.inspect(new Cls())).toBe("Original {}");
+    expect(called).toBe(false);
+  });
+});
+
 it("console.log on a Blob shows name", () => {
   const blob = new Blob(["foo"], { type: "text/plain" });
   expect(Bun.inspect(blob)).toBe('Blob (3 bytes) {\n  type: "text/plain;charset=utf-8"\n}');


### PR DESCRIPTION
Status: the former base of this PR, #38757, is closed. #40833 superseded it. This PR now has main as its base and needs a rebase. Until then the diff also shows the old commits of #38757 and #38922. The own commit of this PR is f6ad721b2f. The text below describes the PR as it was on top of #38757. See https://github.com/oven-sh/bun/pull/38787#issuecomment-5655524359 for the cases that still fail on main.

### Problem

- With standard (TC39) decorators, an anonymous class expression that is the value of a property whose key is numeric or contains a non-ASCII character loses the name the key should give it:
  ```js
  function dec(cls, ctx) { console.log(ctx.name); }
  const o = { 123: @dec class {}, "héllo": @dec class {}, 456: class { @dec m() {} } };
  class H { static 789 = @dec class {}; #p = @dec class {} }
  ```
  `ctx.name` is `""` for all four decorated classes and every `.name` is `""` (`o[456].name` is `"_class"` on `main`, `""` on #38757); node prints `123`, `héllo`, `456`, `789`, `#p` for the same code without the decorators. Same under `bun build`. ASCII string keys work. The lowering is also used for classes with `accessor` members, so `{ 123: class { accessor x } }` is affected with no decorators in the file.
- Two more key shapes go wrong the same way: a computed key folded from a concatenation, `{ ["a" + "b"]: @dec class {} }`, is named `"a"` (the first rope segment), and an inlined enum member key in TypeScript, `{ [Kind.A]: @dec class {} }`, is named `""`.
- Cause: the visitor passes the name to the lowering in `p.decorator_class_name` (`Option<&[u8]>`), and the two places that fill it from a property key only understood keys stored as UTF-8 `E::String`:
  - `src/js_parser/visit/visit_expr.rs` (`e_object`) set it to `None` for `is_utf16` strings (the lexer stores every literal containing a non-ASCII character as UTF-16), skipped `E::Number` / `E::BigInt` / `E::InlinedEnum` keys, and read only the head of a rope;
  - `src/js_parser/visit/mod.rs` (`visit_class`) derived it from `name_to_keep`, which exists only for non-computed `E::String` keys, so numeric, bigint, private and computed member keys were skipped.
- The lowering then gets `None` and emits `""` as the name (`__decorateElement(_init, 0, "", ...)`, and on #38757 `__name(this, "")`).

### Fix

- One helper, `decorator_class_name_from_key` in `visit/mod.rs`, replaces both blocks. For a value that is an anonymous class about to be lowered it returns the key's string form: `E::String` of either encoding through `EString::slice` (flattens ropes, transcodes UTF-16), `E::Number` through the existing `E::Number::to_string` (JS `ToString`, the routine string folding uses: `0x10` -> `"16"`, `1e21` -> `"1e+21"`), decimal bigint literals (stored canonically by the lexer; radix forms stay unnamed, as in `to_string_expr_without_side_effects`), private names (`"#p"`), and inlined enum members via `unwrap_inlined`. A computed key that did not fold to a literal still gives `None`.
- `visit_class` sets `decorator_class_name` from the key around every member value/initializer visit and restores it afterwards; `name_to_keep` keeps its keep-names role unchanged. `E::Number::to_string` and `E::BigInt::has_radix` in `src/ast/e.rs` become `pub`; `lower_decorators.rs` is not touched.
- Why it is correct: the name of an anonymous class in a property position is the property key converted to a string (NamedEvaluation); each branch of the helper produces exactly that string, and the expected values in the tests are what node and undecorated bun print. The name stays a UTF-8 byte string, so on #38757 it becomes the string literal in `__name(this, "...")` / `__decorateElement(...)`, which is valid for any key.
- Why it is based on #38757 rather than `main`: the lowering on `main` turns any identifier-shaped inferred name into a synthesized class binding (`_class = class User { ... }`), which shadows a same-named outer variable inside the class body. That bug already hits ASCII keys today (`{ User: class { accessor x; static make() { return new User() } } }` constructs the inner class), and #38757 fixes it by emitting `__name` instead. On its own, this PR would extend that shadowing to the keys it starts propagating: with the producer change on `main`, `enum Kind { User = "User" }; class User {}; { [Kind.User]: class { accessor loaded; static make() { return new User(1) } } }` stops constructing the outer `User` (it works on 1.4.0, where the class is merely named `"_class"`), and the same for `"wörld"`, `["a" + "b"]` and computed member keys. On #38757 the name is only ever a string literal, so the new tests include a shadowing check that would fail against the `main` lowering.
- Verified with `test/bundler/transpiler/es-decorators.test.ts`, block "anonymous class expressions named by the property key" (5 tests): object keys of every supported shape reaching a class decorator as `ctx.name` and `.name`; the same keys naming classes that only have member decorators or accessors (object and class-member positions, including `#private`); class member keys with a class decorator (static, instance, computed, bigint, private); a `.ts` enum-keyed registry that must keep resolving the outer `User`; and quoted non-ASCII / folded / computed keys not shadowing a same-named outer binding. With this PR's `src/` change reverted on top of the base branch all 5 fail; with it all 5 pass.
- Also passing on the stacked debug build: the whole `es-decorators.test.ts` (including #38757's tests), `es-decorators-esbuild.test.ts` (esbuild's conformance suite), `decorators.test.ts`, `decorator-metadata.test.ts`, `bundler_edgecase.test.ts`, `bundler_decorator_metadata.test.ts`, `transpiler.test.js`, `property.test.ts`, `ts-use-define-for-class-fields.test.ts`, and the decorator regression tests under `test/regression/issue`; `cargo clippy -p bun_js_parser -p bun_ast` is clean.
- Out of scope, tracked separately: positions other than property keys that also do not propagate a name (`x ??= @dec class {}`, parameter defaults, `for (let x = @dec class {};;)`; #38906 covers parameter defaults and the others have owners), and `require.resolve("./a" + "b")` reading only the head of a folded string, which is the same rope mistake in a different reader. While writing the tests I also found that `class A { static 2n = 1 }` fails to parse (bigint key after a modifier keyword), reported separately; the bigint cases here use positions that parse today.

### Background

- NamedEvaluation: an anonymous function or class expression takes its `.name` from the position it is created in; for a property value the name is the property key as a string (`{ 123: class {} }[123].name === "123"`, `class A { #p = class {} }` names the inner class `"#p"`). Any other position gives `""`.
- Standard decorator lowering rewrites `@dec class {}` (and any class with `accessor` members) into `_class = class { ... }, __decorateElement(...), ...`, which takes the class out of the property position, so the engine cannot infer the name. The visitor records the position's name in `p.decorator_class_name` just before visiting the class; `e_class` passes it to the lowering as `name_from_context`. #38757 makes the lowering restore it with `static { __name(this, "<name>") }` (and `__decorateElement(_init, 0, "<name>", ...)`, which also exposes it as `ctx.name`); before #38757 it used the name as a class binding when it was a valid identifier.
- `E::String` is stored as UTF-8 for ASCII-only literals and identifiers, and as UTF-16 for any literal with a non-ASCII character; `data` of a UTF-16 string is not usable as bytes, which is why the old code refused those keys. Folding `"a" + "b"` produces a rope (linked segments); `EString::slice` resolves both representations to one UTF-8 slice.
- `E::InlinedEnum` wraps the literal the parser substitutes for a same-file TypeScript enum member (`Kind.A` is printed as `"a" /* A */`); `unwrap_inlined` returns that literal.

<details>
<summary>Before/after on the repro from the report</summary>

```js
function dec() {}
const o = {
  123: @dec class {},
  456: class { @dec m() {} },
  "héllo": @dec class {},
  "wörld": class { @dec m() {} },
};
console.log(JSON.stringify([o[123].name, o[456].name, o["héllo"].name, o["wörld"].name]));
```

| build | output |
| --- | --- |
| node (decorators removed) | `["123","456","héllo","wörld"]` |
| main (1.4.0) | `["","_class","","_class"]` |
| #38757 alone | `["","","",""]` |
| #38757 + this PR | `["123","456","héllo","wörld"]` |

Emitted code for `{ 123: @dec class {} }` changes from `__decorateElement(_init, 0, "", _dec, _class)` to `__decorateElement(_init, 0, "123", _dec, _class)`; for `{ 123: class { @dec m() {} } }` the class body starts with `static { __name(this, "123") }` instead of `__name(this, "")`.

</details>

