### PR TITLE
pack: publish workspace: aliases as npm: aliases

### DIFF
--- a/docs/pm/workspaces.mdx
+++ b/docs/pm/workspaces.mdx
@@ -97,6 +97,14 @@ You can also reference a workspace package by the path of its directory. The pat
 "b": "workspace:../pkg-b"     -> "b": "npm:pkg-b@1.0.1"
 ```
 
+To install a workspace package under a different name, put the package name in front of the version: `workspace:<name>@<version>`. Bun publishes these as `npm:` aliases too:
+
+```
+"b": "workspace:pkg-b@*"     -> "b": "npm:pkg-b@1.0.1"
+"b": "workspace:pkg-b@^"     -> "b": "npm:pkg-b@^1.0.1"
+"b": "workspace:pkg-b@1.0.1" -> "b": "npm:pkg-b@1.0.1"
+```
+
 Workspaces have a few major benefits.
 
 - **Split code into logical parts.** If one package relies on another, add it as a dependency in `package.json`. If package `b` depends on `a`, `bun install` installs your local `packages/a` directory into `node_modules` instead of downloading it from the npm registry.

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -3198,7 +3198,8 @@ fn add_archive_entry(
 enum Substitution<'a> {
     /// `workspace:^`, `workspace:~`, `workspace:*`: the workspace's current version behind that prefix.
     WorkspaceVersion { prefix: &'static str },
-    /// `workspace:1.x` on a dependency that is a workspace, or a directory, `workspace:../core`.
+    /// Another workspace under this dependency's name, `workspace:@acme/core@*`; a directory,
+    /// `workspace:../core`; or `workspace:1.x` on a dependency that is itself a workspace.
     WorkspaceRangeOrDirectory(&'a [u8]),
     /// `catalog:` / `catalog:<name>`: that catalog's entry for the dependency.
     Catalog { catalog_name: &'a [u8] },
@@ -3259,40 +3260,88 @@ fn needs_workspace_manifests(package_json: Expr) -> bool {
     needed
 }
 
-/// Directory first: `"pkg1": "workspace:../pkg1"` reads both ways; only a directory has a version.
+/// Alias first, as the installer reads it; directory before range, since only a directory has a version.
 fn publish_spec_for_workspace_range_or_directory(
     manifests: &WorkspaceManifests,
     package_dir: &[u8],
     dependency_name: &[u8],
     spec: &[u8],
 ) -> Result<Vec<u8>, String> {
-    let Some(workspace_name) = manifests.workspace_name_at_path(package_dir, spec) else {
-        // `workspace:<name>@<range>` installs workspace `<name>` under `dependency_name`.
-        let is_alias = strings::last_index_of_char(spec, b'@')
-            .is_some_and(|at| at > 0 && manifests.has_workspace(&spec[..at]));
-        if manifests.has_workspace(dependency_name) || is_alias {
-            return Ok(spec.to_vec());
-        }
-        return Err(format!(
-            "\"{}\" has no workspace named \"{}\" and no workspace in the directory \"{}\"",
-            bstr::BStr::new(manifests.root_package_json_path()),
-            bstr::BStr::new(dependency_name),
-            bstr::BStr::new(spec),
+    let alias = split_workspace_alias(spec);
+    if let Some((workspace_name, range)) = alias.filter(|(name, _)| manifests.has_workspace(name)) {
+        let range = strings::trim(range, &strings::WHITESPACE_CHARS);
+        // The installer links an empty range like `*`.
+        let prefix = match range {
+            b"" | b"*" => Some(""),
+            b"^" => Some("^"),
+            b"~" => Some("~"),
+            _ => None,
+        };
+        let Some(prefix) = prefix else {
+            return Ok(publish_workspace(
+                dependency_name,
+                workspace_name,
+                bstr::BStr::new(range),
+            ));
+        };
+        let Some(version) = manifests.workspace_version(workspace_name) else {
+            return Err(format!(
+                "the package.json of workspace \"{}\" has no version",
+                bstr::BStr::new(workspace_name),
+            ));
+        };
+        return Ok(publish_workspace(
+            dependency_name,
+            workspace_name,
+            format_args!("{prefix}{version}"),
         ));
+    }
+    if let Some(workspace_name) = manifests.workspace_name_at_path(package_dir, spec) {
+        let Some(version) = manifests.workspace_version(workspace_name) else {
+            return Err(format!(
+                "the package.json of workspace \"{}\" in the directory \"{}\" has no version",
+                bstr::BStr::new(workspace_name),
+                bstr::BStr::new(spec),
+            ));
+        };
+        return Ok(publish_workspace(dependency_name, workspace_name, version));
+    }
+    if alias.is_none() && manifests.has_workspace(dependency_name) {
+        return Ok(spec.to_vec());
+    }
+    Err(format!(
+        "\"{}\" has no workspace named \"{}\" and no workspace in the directory \"{}\"",
+        bstr::BStr::new(manifests.root_package_json_path()),
+        bstr::BStr::new(alias.map_or(dependency_name, |(workspace_name, _)| workspace_name)),
+        bstr::BStr::new(spec),
+    ))
+}
+
+/// `<name>@<range>` of `workspace:<name>@<range>`, which installs workspace `<name>` under the
+/// dependency's name. `<name>` may be scoped, so it ends at the last `@`; what a directory such as
+/// `../@scope/pkg` leaves in front of its last `@` is not a package name, so that is not an alias.
+fn split_workspace_alias(spec: &[u8]) -> Option<(&[u8], &[u8])> {
+    let at = strings::last_index_of_char(spec, b'@').filter(|at| *at > 0)?;
+    let (name, range) = (&spec[..at], &spec[at + 1..]);
+    let is_package_name = match bun_install::dependency::is_scoped_package_name(name) {
+        Ok(true) => true,
+        Ok(false) => !strings::contains_char(name, b'/'),
+        Err(_) => false,
     };
-    let Some(version) = manifests.workspace_version(workspace_name) else {
-        return Err(format!(
-            "the package.json of workspace \"{}\" in the directory \"{}\" has no version",
-            bstr::BStr::new(workspace_name),
-            bstr::BStr::new(spec),
-        ));
-    };
-    Ok(if workspace_name == dependency_name {
-        format!("{version}").into_bytes()
+    is_package_name.then_some((name, range))
+}
+
+/// The version itself under the workspace's own name, otherwise the `npm:` alias pnpm publishes too.
+fn publish_workspace(
+    dependency_name: &[u8],
+    workspace_name: &[u8],
+    version: impl fmt::Display,
+) -> Vec<u8> {
+    if workspace_name == dependency_name {
+        version.to_string().into_bytes()
     } else {
-        // What pnpm publishes too: the alias installs the workspace's package under this name.
         format!("npm:{}@{version}", bstr::BStr::new(workspace_name)).into_bytes()
-    })
+    }
 }
 
 /// Edits `json.root` in place (`bun publish` sends that tree to the registry) and returns it printed.

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -651,6 +651,10 @@ describe("workspaces", () => {
     { input: "workspace:1.1.x", expected: "1.1.x" },
     { input: "workspace:*", expected: "1.1.1" },
     { input: "workspace:-", expected: "-" },
+    // aliasing a workspace under its own name needs no `npm:` alias
+    { input: "workspace:pkg1@*", expected: "1.1.1" },
+    { input: "workspace:pkg1@~", expected: "~1.1.1" },
+    { input: "workspace:pkg1@1.x", expected: "1.x" },
   ];
 
   for (const { input, expected } of withLockfileWorkspaceProtocolTests) {
@@ -1054,33 +1058,118 @@ describe("workspaces", () => {
     });
   });
 
-  test("copies workspace: aliases as written", async () => {
-    // `workspace:<name>@<range>` installs workspace <name> under the dependency's name; it is
-    // neither a directory nor a range of the dependency, and must not be rejected as one.
+  // `"core-star": "workspace:@acme/core@*"` installs workspace @acme/core under the name core-star
+  test("replaces workspace: aliases with npm: aliases", async () => {
     await createDirectoryWorkspace({
-      dependencies: { "core-alias": "workspace:@acme/core@^1.0.0", "plain-alias": "workspace:plain@*" },
+      dependencies: {
+        "core-star": "workspace:@acme/core@*",
+        "core-caret": "workspace:@acme/core@^",
+        "core-tilde": "workspace:@acme/core@~",
+        "core-range": "workspace:@acme/core@^1.0.0",
+        "core-exact": "workspace:@acme/core@1.2.3",
+        "core-tag": "workspace:@acme/core@latest",
+        "core-spaced": "workspace:@acme/core@ ^ ",
+        // `bun install` links an empty range like `*`
+        "core-empty": "workspace:@acme/core@",
+        "thing-star": "workspace:thing@*",
+      },
+      devDependencies: {
+        "plain-star": "workspace:plain@*",
+        "plain-range": "workspace:plain@0.x",
+      },
+      peerDependencies: {
+        "plain-peer": "workspace:plain@^",
+      },
+      optionalDependencies: {
+        "plain-optional": "workspace:plain@~",
+      },
     });
+    // every one of these is a spec `bun install` links
+    await runBunInstall(bunEnv, packageDir);
 
     await pack(join(packageDir, "pkgs", "ui"), bunEnv);
 
     const tarball = readTarball(join(packageDir, "pkgs", "ui", "acme-ui-2.0.0.tgz"));
-    expect(JSON.parse(tarball.entries[0].contents).dependencies).toEqual({
-      "core-alias": "@acme/core@^1.0.0",
-      "plain-alias": "plain@*",
+    expect(JSON.parse(tarball.entries[0].contents)).toEqual({
+      name: "@acme/ui",
+      version: "2.0.0",
+      dependencies: {
+        "core-star": "npm:@acme/core@1.2.3",
+        "core-caret": "npm:@acme/core@^1.2.3",
+        "core-tilde": "npm:@acme/core@~1.2.3",
+        "core-range": "npm:@acme/core@^1.0.0",
+        "core-exact": "npm:@acme/core@1.2.3",
+        "core-tag": "npm:@acme/core@latest",
+        "core-spaced": "npm:@acme/core@^1.2.3",
+        "core-empty": "npm:@acme/core@1.2.3",
+        "thing-star": "npm:thing@0.0.7",
+      },
+      devDependencies: {
+        "plain-star": "npm:plain@0.5.0",
+        "plain-range": "npm:plain@0.x",
+      },
+      peerDependencies: {
+        "plain-peer": "npm:plain@^0.5.0",
+      },
+      optionalDependencies: {
+        "plain-optional": "npm:plain@~0.5.0",
+      },
     });
+  });
+
+  test("replaces workspace: aliases with the versions in the package.json files, without a lockfile", async () => {
+    await createDirectoryWorkspace({
+      dependencies: { "core": "workspace:@acme/core@*", "plain-caret": "workspace:plain@^" },
+    });
+    await runBunInstall(bunEnv, packageDir);
+    // bumped after the install, so bun.lock still says 1.2.3
+    await write(
+      join(packageDir, "pkgs", "core", "package.json"),
+      JSON.stringify({ name: "@acme/core", version: "1.3.0" }),
+    );
+
+    await pack(join(packageDir, "pkgs", "ui"), bunEnv);
+    const installed = readTarball(join(packageDir, "pkgs", "ui", "acme-ui-2.0.0.tgz"));
+    expect(JSON.parse(installed.entries[0].contents).dependencies).toEqual({
+      "core": "npm:@acme/core@1.3.0",
+      "plain-caret": "npm:plain@^0.5.0",
+    });
+
+    await rm(join(packageDir, "bun.lock"));
+    await rm(join(packageDir, "pkgs", "ui", "acme-ui-2.0.0.tgz"));
+    await pack(join(packageDir, "pkgs", "ui"), bunEnv);
+    const uninstalled = readTarball(join(packageDir, "pkgs", "ui", "acme-ui-2.0.0.tgz"));
+    expect(uninstalled.entries[0].contents).toBe(installed.entries[0].contents);
+  });
+
+  test("fails when the workspace a workspace: alias installs has no version", async () => {
+    await createDirectoryWorkspace({
+      dependencies: { "core": "workspace:@acme/core@*" },
+      devDependencies: { "no-version": "workspace:unversioned@^" },
+    });
+    await write(join(packageDir, "pkgs", "unversioned", "package.json"), JSON.stringify({ name: "unversioned" }));
+
+    const { err } = await packExpectError(join(packageDir, "pkgs", "ui"), bunEnv);
+    expect(err).toContain(
+      'error: Failed to resolve workspace version for "no-version" in `devDependencies` (the package.json of workspace "unversioned" has no version).',
+    );
+    expect(await exists(join(packageDir, "pkgs", "ui", "acme-ui-2.0.0.tgz"))).toBeFalse();
   });
 
   const notAWorkspaceSpecs = [
     // exists on disk, but the root's `workspaces` does not list it (written below)
-    { group: "devDependencies", name: "unlisted", spec: "workspace:../../unlisted" },
-    { group: "dependencies", name: "missing", spec: "workspace:../missing" },
+    { group: "devDependencies", name: "unlisted", spec: "workspace:../../unlisted", reported: "unlisted" },
+    { group: "dependencies", name: "missing", spec: "workspace:../missing", reported: "missing" },
+    // the `@` in a directory does not make it `<name>@<range>`; the error names the dependency
+    { group: "dependencies", name: "scoped-dir", spec: "workspace:../@scoped/missing", reported: "scoped-dir" },
     // a range only means something for a dependency that is itself a workspace
-    { group: "peerDependencies", name: "not-a-workspace", spec: "workspace:1.2.3" },
-    // and `<name>@<range>` only when <name> is a workspace
-    { group: "optionalDependencies", name: "bogus-alias", spec: "workspace:nope@*" },
+    { group: "peerDependencies", name: "not-a-workspace", spec: "workspace:1.2.3", reported: "not-a-workspace" },
+    // and `<name>@<range>` only when <name> is a workspace, whatever the range, so the error names <name>
+    { group: "optionalDependencies", name: "bogus-alias", spec: "workspace:nope@*", reported: "nope" },
+    { group: "dependencies", name: "bogus-alias", spec: "workspace:@acme/nope@^1.0.0", reported: "@acme/nope" },
   ];
 
-  for (const { group, name, spec } of notAWorkspaceSpecs) {
+  for (const { group, name, spec, reported } of notAWorkspaceSpecs) {
     test(`fails when a workspace: spec is neither a workspace's directory nor a workspace's range: ${spec}`, async () => {
       await createDirectoryWorkspace({ dependencies: { "plain": "workspace:../plain" }, [group]: { [name]: spec } });
       await write(join(packageDir, "unlisted", "package.json"), JSON.stringify({ name: "unlisted", version: "1.0.0" }));
@@ -1088,7 +1177,7 @@ describe("workspaces", () => {
       const { err } = await packExpectError(join(packageDir, "pkgs", "ui"), bunEnv);
       expect(err).toContain(`error: Failed to resolve workspace version for "${name}" in \`${group}\` (`);
       expect(err).toContain(
-        `package.json" has no workspace named "${name}" and no workspace in the directory "${spec.slice("workspace:".length)}").`,
+        `package.json" has no workspace named "${reported}" and no workspace in the directory "${spec.slice("workspace:".length)}").`,
       );
       expect(await exists(join(packageDir, "pkgs", "ui", "acme-ui-2.0.0.tgz"))).toBeFalse();
     });

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -902,6 +902,62 @@ test("a published package can depend on another workspace by its directory", asy
   ).toEqual([corePkgJson, corePkgJson]);
 });
 
+test("a published package can depend on another workspace through a workspace: alias", async () => {
+  const { packageDir, packageJson } = await registry.createTestDir();
+  const bunfig = await registry.authBunfig("workspacealias");
+  const corePkgJson = { name: "publish-pkg-alias-core", version: "1.2.3" };
+  await Promise.all([
+    rm(join(registry.packagesPath, "publish-pkg-alias-core"), { recursive: true, force: true }),
+    rm(join(registry.packagesPath, "publish-pkg-alias-ui"), { recursive: true, force: true }),
+    write(join(packageDir, "bunfig.toml"), bunfig),
+    write(packageJson, JSON.stringify({ name: "root", workspaces: ["packages/*"] })),
+    write(join(packageDir, "packages", "core", "package.json"), JSON.stringify(corePkgJson)),
+    write(
+      join(packageDir, "packages", "ui", "package.json"),
+      JSON.stringify({
+        name: "publish-pkg-alias-ui",
+        version: "2.0.0",
+        dependencies: {
+          "core-alias": "workspace:publish-pkg-alias-core@*",
+          "core-compatible": "workspace:publish-pkg-alias-core@^",
+          "publish-pkg-alias-core": "workspace:publish-pkg-alias-core@*",
+        },
+      }),
+    ),
+  ]);
+
+  for (const pkg of ["core", "ui"]) {
+    const { out, err, exitCode } = await publish(env, join(packageDir, "packages", pkg));
+    expect(err).not.toContain("error:");
+    expect(out).toContain(`+ publish-pkg-alias-${pkg}@`);
+    expect(exitCode).toBe(0);
+  }
+
+  // consume the published package from the registry
+  await Promise.all([
+    rm(join(packageDir, "packages"), { recursive: true, force: true }),
+    write(packageJson, JSON.stringify({ name: "root", dependencies: { "publish-pkg-alias-ui": "2.0.0" } })),
+  ]);
+  await runBunInstall(env, packageDir);
+
+  expect(await file(join(packageDir, "node_modules", "publish-pkg-alias-ui", "package.json")).json()).toEqual({
+    name: "publish-pkg-alias-ui",
+    version: "2.0.0",
+    dependencies: {
+      "core-alias": "npm:publish-pkg-alias-core@1.2.3",
+      "core-compatible": "npm:publish-pkg-alias-core@^1.2.3",
+      "publish-pkg-alias-core": "1.2.3",
+    },
+  });
+  expect(
+    await Promise.all([
+      file(join(packageDir, "node_modules", "core-alias", "package.json")).json(),
+      file(join(packageDir, "node_modules", "core-compatible", "package.json")).json(),
+      file(join(packageDir, "node_modules", "publish-pkg-alias-core", "package.json")).json(),
+    ]),
+  ).toEqual([corePkgJson, corePkgJson, corePkgJson]);
+});
+
 describe("--dry-run", async () => {
   test("does not publish", async () => {
     const { packageDir, packageJson } = await registry.createTestDir();


### PR DESCRIPTION
Stacked on #38813 and #38835 (this PR's base branch is #38835's): the change is the last commit, and the PR retargets to `main` once those land.

### Problem
- `bun install` accepts the alias form of the workspace protocol, `"c2": "workspace:@acme/core@*"`, and links `c2 -> packages/core`.
- `bun pm pack` and `bun publish` copy it into the tarball's package.json (and the manifest sent to the registry) with only the protocol removed: `"c2": "@acme/core@*"`. That is not a registry specifier: installing the published package fails with `error: c2@@acme/core@* failed to resolve` (bun), npm and pnpm create dangling links.
- Cause: `publish_spec_for_workspace_range_or_directory` in `src/runtime/cli/pack_command.rs` recognizes the alias shape only to avoid rejecting it, and passes the spec through as written.
- Same in 1.3.14, so not a regression.

### Fix
- `split_workspace_alias` recognizes the alias shape: `<name>@<range>`, split at the last `@` because `<name>` can be scoped (the same split `Package::parse_dependency` makes), and only when the part before it is shaped like a package name, so a directory such as `../@scoped/pkg` is not an alias. When `<name>` is one of the workspaces, `publish_spec_for_workspace_range_or_directory` resolves it before the directory and range readings, the order the installer uses:
  - `workspace:<name>@*` / `^` / `~` (and an empty range, which the installer links like `*`) -> `npm:<name>@1.2.3` / `npm:<name>@^1.2.3` / `npm:<name>@~1.2.3`, using the version currently in `<name>`'s package.json (`WorkspaceManifests::workspace_version`, the same lookup `workspace:*` and the directory form use, so a version bumped after the last `bun install` is published and no lockfile is needed). A workspace without a version fails the pack like the directory form does.
  - `workspace:<name>@<range>` -> `npm:<name>@<range>`.
- `publish_workspace` (factored out of the directory form, which did the same thing inline) drops the `npm:` prefix when `<name>` is the dependency name itself, where the alias would be redundant: `"pkg1": "workspace:pkg1@*"` -> `"1.1.1"`. Otherwise the output is what `pnpm pack` writes for the same input.
- An alias-shaped spec whose `<name>` is not a workspace is no longer published as a range of the dependency (the installer does not link it that way either); it falls through to the directory reading and then fails with the existing "no workspace named ... and no workspace in the directory ..." error, which now names `<name>` for these specs since that is the name that was not found.
- `bun publish` builds its manifest through the same `pack()` path, so it is covered by the same change.
- Verified with `test/cli/install/bun-pack.test.ts` (#38835's placeholder `copies workspace: aliases as written` becomes `replaces workspace: aliases with npm: aliases`, covering every form, including the empty range, in all four dependency groups; plus the redundant-alias table entries, a version bumped after the install and packing without a lockfile, an alias of an unversioned workspace, and error-table rows for two unknown aliases and for a missing directory containing an `@`) and `test/cli/install/bun-publish.test.ts` (publishes two workspaces to the test registry and installs the one depending on the other through aliases from a fresh project). The 8 pack cases and the publish case fail on the base branch (the publish one with the `failed to resolve` error above); with this change `bun-pack.test.ts` passes (103 tests), as do the workspace and catalog tests in `bun-publish.test.ts`.
- Docs: the alias form is added to the publishing section of `docs/pm/workspaces.mdx`.

### Background
- Workspace protocol: inside a monorepo, `"dep": "workspace:*"` tells the package manager to link the workspace package named `dep` instead of downloading it. The registry knows nothing about workspaces, so pack/publish rewrite these specs into registry ones; `*`, `^` and `~` become the linked package's current version behind that prefix.
- Alias form: pnpm and bun's installer also accept `"alias": "workspace:<name>@<range>"`, which links workspace package `<name>` under the directory name `alias`. The registry's way to install one package under another name is an npm alias, `"alias": "npm:<name>@<range>"`, which is what pnpm writes on publish and what this change writes.
- #38813 makes pack read versions from the workspace's package.json files (`WorkspaceManifests`) instead of `bun.lock`, which is stale in exactly the release flow pack runs in. #38835 adds the directory form (`workspace:../core`) on top and, with it, the rule that any other `workspace:` spec must be a range of a dependency that is itself a workspace. The alias form is the remaining reading of the spec, and this change slots it into the same function.

<details>
<summary>Repro</summary>

```sh
mkdir -p m/packages/core m/packages/ui && cd m
echo '{ "name": "mono", "private": true, "workspaces": ["packages/*"] }' > package.json
echo '{ "name": "@acme/core", "version": "1.2.3" }' > packages/core/package.json
echo '{ "name": "@acme/ui", "version": "2.0.0", "dependencies": { "c2": "workspace:@acme/core@*" } }' > packages/ui/package.json
bun install
cd packages/ui && bun pm pack && tar -xzOf acme-ui-2.0.0.tgz package/package.json | grep c2
# before: "c2": "@acme/core@*"
# after:  "c2": "npm:@acme/core@1.2.3"   (same as pnpm pack)
```

Earlier revisions of this PR made the same rewrite against `main` (taking the version from `bun.lock`) and then as separate `Substitution` variants on a previous revision of the stack; the current revision follows the base PRs' reworked structure.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 6 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-publish.test.ts

<!-- robobun:evidence:end -->