### PR TITLE
crash_handler(windows): unwind through LLInt and vmEntryToJavaScript frames and stop the walk at non-code PCs

### DIFF
--- a/src/bun_core/debug.rs
+++ b/src/bun_core/debug.rs
@@ -167,12 +167,9 @@ impl Drop for MemoryAccessor {
     }
 }
 
-/// Protection flags of the committed, accessible page containing `address`.
-/// `None` for free/reserved pages and for committed pages that would still
-/// fault on access: "not MEM_FREE" is not enough to make a read safe, since
-/// MEM_RESERVE has no backing and MEM_COMMIT pages can be PAGE_NOACCESS or
-/// PAGE_GUARD (the stack guard page after EXCEPTION_STACK_OVERFLOW is exactly
-/// this).
+/// Protection of the page at `address`, or `None` if touching it would fault:
+/// MEM_RESERVE has no backing, and a committed page can still be PAGE_NOACCESS
+/// or PAGE_GUARD (the stack guard page after a stack overflow).
 #[cfg(windows)]
 fn accessible_page_protection(address: usize) -> Option<u32> {
     use bun_windows_sys::kernel32::{
@@ -194,9 +191,8 @@ fn accessible_page_protection(address: usize) -> Option<u32> {
         .then_some(mbi.Protect)
 }
 
-/// Whether `address` points into mapped code: an image `.text` section or a
-/// JIT/FFI allocation. Return addresses always do; the stack slots a derailed
-/// walk would otherwise report (JSValues, heap pointers, counters) never do.
+/// Return addresses are always in mapped code (image `.text`, the JIT pool, FFI
+/// trampolines); the stack slots a derailed walk would report never are.
 #[cfg(windows)]
 fn is_executable_memory(address: usize) -> bool {
     use bun_windows_sys::kernel32::{
@@ -371,13 +367,11 @@ fn context_pc_sp(ctx: &bun_windows_sys::CONTEXT) -> (u64, u64) {
     }
 }
 
-/// Step out of a leaf function (no unwind info because it never touches the
-/// stack): the return address is still where the call left it, `[Rsp]` on x64
-/// and `Lr` on ARM64 (`bl` pushes nothing, so `Sp` is correctly left alone).
-/// Only frame 0 can be a leaf; a return address never points into a function
-/// that makes no calls. Declines, leaving `ctx` untouched, when the slot does
-/// not hold a code address: the faulting code is then offlineasm (see
-/// [`unwind_frame_pointer`]) and the slot is scratch.
+/// A leaf has no unwind info and its return address is still where the call
+/// left it: `[Rsp]`, or `Lr` on ARM64 (`bl` pushes nothing). Only frame 0 can
+/// be a leaf, since a return address never points into a function that makes
+/// no calls. Declines when the slot is not a code address: the faulting code
+/// is then offlineasm (`unwind_frame_pointer`) and the slot is scratch.
 #[cfg(windows)]
 fn unwind_leaf(ctx: &mut bun_windows_sys::CONTEXT, ma: &mut MemoryAccessor) -> bool {
     #[cfg(target_arch = "x86_64")]
@@ -406,18 +400,13 @@ fn unwind_leaf(ctx: &mut bun_windows_sys::CONTEXT, ma: &mut MemoryAccessor) -> b
     }
 }
 
-/// Step out of a frame that has no unwind info and is not a leaf. In bun that
-/// is JSC's offlineasm code (the LLInt opcode handlers and the `vmEntryTo*`
-/// trampolines carry no `.seh_*` directives, and for a PC inside the image
-/// `RtlLookupFunctionEntry` consults only its static `.pdata`) and tinycc's
-/// `bun:ffi` trampolines. Both keep the frame-pointer register (`rbp`/`x29`)
-/// on a frame whose first two slots are the caller's frame pointer and the
-/// return address: the `CallFrame` layout, which is also what the unwind info
-/// JSC registers for its JIT pool describes (`registerJITUnwindInfo` in
-/// WebKit's `ExecutableAllocator.cpp`). The Rtl unwinder restores that
-/// register when it steps out of a compiled frame, so it holds the right frame
-/// here however many C++ and JIT frames sat above. A frame pointer below the
-/// stack pointer, or with unreadable slots, holds something else: stop.
+/// No unwind info and not a leaf: in bun that is JSC's offlineasm (LLInt and
+/// the `vmEntryTo*` trampolines; it is emitted without unwind info, and the
+/// dynamic tables JSC registers cannot cover in-image code) or a tinycc
+/// `bun:ffi` trampoline. Both keep `rbp`/`x29` on a frame whose first two
+/// slots are the caller's frame pointer and the return address, the layout
+/// JSC's JIT-pool unwind info describes too (`registerJITUnwindInfo`), and
+/// `RtlVirtualUnwind` restores that register across the compiled frames above.
 #[cfg(windows)]
 fn unwind_frame_pointer(ctx: &mut bun_windows_sys::CONTEXT, ma: &mut MemoryAccessor) -> bool {
     #[cfg(target_arch = "x86_64")]
@@ -463,13 +452,12 @@ fn unwind_frame_pointer(ctx: &mut bun_windows_sys::CONTEXT, ma: &mut MemoryAcces
 /// Windows: `fp` is the `*const CONTEXT` the VEH received (`EXCEPTION_POINTERS
 /// ::ContextRecord`). The walk is `RtlLookupFunctionEntry` + `RtlVirtualUnwind`
 /// seeded from that context, so it starts at the fault frame and the handler's
-/// own frames are never in the chain. Compiled code always has unwind info and
-/// JSC registers it for the JIT pool; the frames that lack it are JSC's
+/// own frames are never in the chain. The frames without unwind info are JSC's
 /// offlineasm (LLInt, `vmEntryToJavaScript`), which every JS-initiated crash
-/// passes through, and those are stepped over via the frame pointer
-/// ([`unwind_frame_pointer`]). A pure frame-pointer walk is still not an
-/// option: the prebuilt C++ does not maintain one, and it is the Rtl unwinder
-/// stepping through those frames that keeps the frame-pointer register valid.
+/// passes through; those are stepped via the frame pointer instead
+/// (`unwind_frame_pointer`). A frame-pointer walk on its own would still
+/// derail: the prebuilt C++ keeps no frame pointer, and it is `RtlVirtualUnwind`
+/// stepping through those frames that leaves the register valid.
 pub fn capture_from_context(pc: usize, fp: usize, out: &mut [usize]) -> usize {
     if out.is_empty() {
         return 0;
@@ -494,11 +482,9 @@ pub fn capture_from_context(pc: usize, fp: usize, out: &mut [usize]) -> usize {
         // Pc-only check truncates legitimate stacks: an ARM64 fault at prolog
         // offset 0 (or a .pdata-bearing zero-stack leaf) sets Pc = Lr while
         // leaving Sp unchanged, and directly-recursive frames share a return
-        // Pc. A step that produces a non-code Pc has lost the chain (a smashed
-        // return address, or a fallback applied to a frame it does not fit);
-        // the trace ends at the last frame that was actually recovered rather
-        // than continuing into whatever the stack slots happen to hold. The
-        // `n < out.len()` cap is the ultimate bound.
+        // Pc. A non-code Pc means the chain is lost (smashed return address, or
+        // a fallback that did not fit the frame): stop rather than report stack
+        // slots. The `n < out.len()` cap is the ultimate bound.
         while n < out.len() {
             let (control_pc, control_sp) = context_pc_sp(&ctx);
             let mut image_base: u64 = 0;

--- a/src/bun_core/debug.rs
+++ b/src/bun_core/debug.rs
@@ -167,6 +167,46 @@ impl Drop for MemoryAccessor {
     }
 }
 
+/// Protection flags of the committed, accessible page containing `address`.
+/// `None` for free/reserved pages and for committed pages that would still
+/// fault on access: "not MEM_FREE" is not enough to make a read safe, since
+/// MEM_RESERVE has no backing and MEM_COMMIT pages can be PAGE_NOACCESS or
+/// PAGE_GUARD (the stack guard page after EXCEPTION_STACK_OVERFLOW is exactly
+/// this).
+#[cfg(windows)]
+fn accessible_page_protection(address: usize) -> Option<u32> {
+    use bun_windows_sys::kernel32::{
+        MEM_COMMIT, MEMORY_BASIC_INFORMATION, PAGE_GUARD, PAGE_NOACCESS, VirtualQuery,
+    };
+    // SAFETY: MEMORY_BASIC_INFORMATION is a plain Win32 POD; all-zeros is
+    // a valid representation.
+    let mut mbi: MEMORY_BASIC_INFORMATION = unsafe { crate::ffi::zeroed_unchecked() };
+    // SAFETY: `mbi` is a valid out-param of the size we pass; VirtualQuery
+    // only inspects the address-space mapping at `address`.
+    let rc = unsafe {
+        VirtualQuery(
+            core::ptr::without_provenance(address),
+            &raw mut mbi,
+            core::mem::size_of::<MEMORY_BASIC_INFORMATION>(),
+        )
+    };
+    (rc != 0 && mbi.State == MEM_COMMIT && mbi.Protect & (PAGE_NOACCESS | PAGE_GUARD) == 0)
+        .then_some(mbi.Protect)
+}
+
+/// Whether `address` points into mapped code: an image `.text` section or a
+/// JIT/FFI allocation. Return addresses always do; the stack slots a derailed
+/// walk would otherwise report (JSValues, heap pointers, counters) never do.
+#[cfg(windows)]
+fn is_executable_memory(address: usize) -> bool {
+    use bun_windows_sys::kernel32::{
+        PAGE_EXECUTE, PAGE_EXECUTE_READ, PAGE_EXECUTE_READWRITE, PAGE_EXECUTE_WRITECOPY,
+    };
+    const EXECUTABLE: u32 =
+        PAGE_EXECUTE | PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE | PAGE_EXECUTE_WRITECOPY;
+    accessible_page_protection(address).is_some_and(|p| p & EXECUTABLE != 0)
+}
+
 fn is_valid_memory(address: usize) -> bool {
     let page_size = bun_alloc::page_size();
     let aligned_address = address & !(page_size - 1);
@@ -176,35 +216,16 @@ fn is_valid_memory(address: usize) -> bool {
     #[cfg(windows)]
     {
         use bun_windows_sys::kernel32::{
-            MEM_COMMIT, MEMORY_BASIC_INFORMATION, PAGE_EXECUTE_READ, PAGE_EXECUTE_READWRITE,
-            PAGE_EXECUTE_WRITECOPY, PAGE_GUARD, PAGE_NOACCESS, PAGE_READONLY, PAGE_READWRITE,
-            PAGE_WRITECOPY, VirtualQuery,
+            PAGE_EXECUTE_READ, PAGE_EXECUTE_READWRITE, PAGE_EXECUTE_WRITECOPY, PAGE_READONLY,
+            PAGE_READWRITE, PAGE_WRITECOPY,
         };
-        // SAFETY: MEMORY_BASIC_INFORMATION is a plain Win32 POD; all-zeros is
-        // a valid representation.
-        let mut mbi: MEMORY_BASIC_INFORMATION = unsafe { crate::ffi::zeroed_unchecked() };
-        // SAFETY: `mbi` is a valid out-param of the size we pass; VirtualQuery
-        // only inspects the address-space mapping at `aligned_address`.
-        let rc = unsafe {
-            VirtualQuery(
-                core::ptr::without_provenance(aligned_address),
-                &raw mut mbi,
-                core::mem::size_of::<MEMORY_BASIC_INFORMATION>(),
-            )
-        };
-        // "Not MEM_FREE" is not enough to make a read safe: MEM_RESERVE has no
-        // backing, and MEM_COMMIT pages can be PAGE_NOACCESS or PAGE_GUARD (the
-        // stack guard page after EXCEPTION_STACK_OVERFLOW is exactly this).
         const READABLE: u32 = PAGE_READONLY
             | PAGE_READWRITE
             | PAGE_WRITECOPY
             | PAGE_EXECUTE_READ
             | PAGE_EXECUTE_READWRITE
             | PAGE_EXECUTE_WRITECOPY;
-        rc != 0
-            && mbi.State == MEM_COMMIT
-            && mbi.Protect & (PAGE_NOACCESS | PAGE_GUARD) == 0
-            && mbi.Protect & READABLE != 0
+        accessible_page_protection(aligned_address).is_some_and(|p| p & READABLE != 0)
     }
     #[cfg(not(windows))]
     {
@@ -338,6 +359,99 @@ pub(crate) fn capture_current(first_address: Option<usize>, out: &mut [usize]) -
     n
 }
 
+#[cfg(windows)]
+fn context_pc_sp(ctx: &bun_windows_sys::CONTEXT) -> (u64, u64) {
+    #[cfg(target_arch = "x86_64")]
+    {
+        (ctx.Rip, ctx.Rsp)
+    }
+    #[cfg(target_arch = "aarch64")]
+    {
+        (ctx.Pc, ctx.Sp)
+    }
+}
+
+/// Step out of a leaf function (no unwind info because it never touches the
+/// stack): the return address is still where the call left it, `[Rsp]` on x64
+/// and `Lr` on ARM64 (`bl` pushes nothing, so `Sp` is correctly left alone).
+/// Only frame 0 can be a leaf; a return address never points into a function
+/// that makes no calls. Declines, leaving `ctx` untouched, when the slot does
+/// not hold a code address: the faulting code is then offlineasm (see
+/// [`unwind_frame_pointer`]) and the slot is scratch.
+#[cfg(windows)]
+fn unwind_leaf(ctx: &mut bun_windows_sys::CONTEXT, ma: &mut MemoryAccessor) -> bool {
+    #[cfg(target_arch = "x86_64")]
+    {
+        if ctx.Rsp & 7 != 0 {
+            return false;
+        }
+        let Some(return_pc) = ma.load_usize(ctx.Rsp as usize) else {
+            return false;
+        };
+        if !is_executable_memory(return_pc) {
+            return false;
+        }
+        ctx.Rip = return_pc as u64;
+        ctx.Rsp += 8;
+        true
+    }
+    #[cfg(target_arch = "aarch64")]
+    {
+        let _ = ma;
+        if ctx.Lr == ctx.Pc || !is_executable_memory(ctx.Lr as usize) {
+            return false;
+        }
+        ctx.Pc = ctx.Lr;
+        true
+    }
+}
+
+/// Step out of a frame that has no unwind info and is not a leaf. In bun that
+/// is JSC's offlineasm code (the LLInt opcode handlers and the `vmEntryTo*`
+/// trampolines carry no `.seh_*` directives, and for a PC inside the image
+/// `RtlLookupFunctionEntry` consults only its static `.pdata`) and tinycc's
+/// `bun:ffi` trampolines. Both keep the frame-pointer register (`rbp`/`x29`)
+/// on a frame whose first two slots are the caller's frame pointer and the
+/// return address: the `CallFrame` layout, which is also what the unwind info
+/// JSC registers for its JIT pool describes (`registerJITUnwindInfo` in
+/// WebKit's `ExecutableAllocator.cpp`). The Rtl unwinder restores that
+/// register when it steps out of a compiled frame, so it holds the right frame
+/// here however many C++ and JIT frames sat above. A frame pointer below the
+/// stack pointer, or with unreadable slots, holds something else: stop.
+#[cfg(windows)]
+fn unwind_frame_pointer(ctx: &mut bun_windows_sys::CONTEXT, ma: &mut MemoryAccessor) -> bool {
+    #[cfg(target_arch = "x86_64")]
+    let (frame, sp) = (ctx.Rbp, ctx.Rsp);
+    #[cfg(target_arch = "aarch64")]
+    let (frame, sp) = (ctx.Fp, ctx.Sp);
+    const SLOT: u64 = core::mem::size_of::<usize>() as u64;
+    if frame % SLOT != 0 || frame < sp {
+        return false;
+    }
+    let Some(caller_sp) = frame.checked_add(2 * SLOT) else {
+        return false;
+    };
+    let (Some(caller_frame), Some(return_pc)) = (
+        ma.load_usize(frame as usize),
+        ma.load_usize((frame + SLOT) as usize),
+    ) else {
+        return false;
+    };
+    #[cfg(target_arch = "x86_64")]
+    {
+        ctx.Rbp = caller_frame as u64;
+        ctx.Rip = return_pc as u64;
+        ctx.Rsp = caller_sp;
+    }
+    #[cfg(target_arch = "aarch64")]
+    {
+        ctx.Fp = caller_frame as u64;
+        ctx.Pc = return_pc as u64;
+        ctx.Sp = caller_sp;
+    }
+    true
+}
+
 /// Capture a faulting thread's call stack from the fault context. `pc` is the
 /// exact faulting instruction (`ExceptionAddress` / `mcontext` PC) and becomes
 /// frame 0.
@@ -349,9 +463,13 @@ pub(crate) fn capture_current(first_address: Option<usize>, out: &mut [usize]) -
 /// Windows: `fp` is the `*const CONTEXT` the VEH received (`EXCEPTION_POINTERS
 /// ::ContextRecord`). The walk is `RtlLookupFunctionEntry` + `RtlVirtualUnwind`
 /// seeded from that context, so it starts at the fault frame and the handler's
-/// own frames are never in the chain. `rbp` is not a reliable frame pointer
-/// across the prebuilt JavaScriptCore/LLInt code, so an fp-walk would derail;
-/// `.pdata` is always emitted, so the Rtl unwinder works everywhere.
+/// own frames are never in the chain. Compiled code always has unwind info and
+/// JSC registers it for the JIT pool; the frames that lack it are JSC's
+/// offlineasm (LLInt, `vmEntryToJavaScript`), which every JS-initiated crash
+/// passes through, and those are stepped over via the frame pointer
+/// ([`unwind_frame_pointer`]). A pure frame-pointer walk is still not an
+/// option: the prebuilt C++ does not maintain one, and it is the Rtl unwinder
+/// stepping through those frames that keeps the frame-pointer register valid.
 pub fn capture_from_context(pc: usize, fp: usize, out: &mut [usize]) -> usize {
     if out.is_empty() {
         return 0;
@@ -369,50 +487,27 @@ pub fn capture_from_context(pc: usize, fp: usize, out: &mut [usize]) -> usize {
         // valid for the duration of the handler. Copy so RtlVirtualUnwind can
         // mutate freely without touching the kernel's record.
         let mut ctx: CONTEXT = unsafe { *(fp as *const CONTEXT) };
+        let mut ma = MemoryAccessor::INIT;
         // Termination: on x64 RtlVirtualUnwind sets Pc = 0 at the end of the
         // chain; on ARM64 it can leave the CONTEXT entirely unchanged, so a
         // step that changed neither Pc nor Sp is also terminal. An Sp-only or
         // Pc-only check truncates legitimate stacks: an ARM64 fault at prolog
         // offset 0 (or a .pdata-bearing zero-stack leaf) sets Pc = Lr while
         // leaving Sp unchanged, and directly-recursive frames share a return
-        // Pc. The `n < out.len()` cap is the ultimate bound.
+        // Pc. A step that produces a non-code Pc has lost the chain (a smashed
+        // return address, or a fallback applied to a frame it does not fit);
+        // the trace ends at the last frame that was actually recovered rather
+        // than continuing into whatever the stack slots happen to hold. The
+        // `n < out.len()` cap is the ultimate bound.
         while n < out.len() {
-            #[cfg(target_arch = "x86_64")]
-            let (control_pc, control_sp) = (ctx.Rip, ctx.Rsp);
-            #[cfg(target_arch = "aarch64")]
-            let (control_pc, control_sp) = (ctx.Pc, ctx.Sp);
+            let (control_pc, control_sp) = context_pc_sp(&ctx);
             let mut image_base: u64 = 0;
             // SAFETY: `control_pc` is a code address from the fault context;
             // `image_base` is valid for write; history table may be null.
             let rf = unsafe {
                 ntdll::RtlLookupFunctionEntry(control_pc, &mut image_base, core::ptr::null_mut())
             };
-            if rf.is_null() {
-                // Leaf function with no `.pdata` entry: manually pop the
-                // return address. On x64 it is at `[Rsp]`; on ARM64 it is in
-                // `Lr`. An ARM64 leaf allocates no stack (bl does not push),
-                // so `Sp` is correctly left unchanged here.
-                #[cfg(target_arch = "x86_64")]
-                {
-                    if ctx.Rsp & 7 != 0 || !is_valid_memory(ctx.Rsp as usize) {
-                        break;
-                    }
-                    // SAFETY: is_valid_memory confirmed the page at `Rsp` is
-                    // committed and readable (not reserved/guard/noaccess),
-                    // and `Rsp` is 8-aligned.
-                    unsafe {
-                        ctx.Rip = *(ctx.Rsp as *const u64);
-                    }
-                    ctx.Rsp += 8;
-                }
-                #[cfg(target_arch = "aarch64")]
-                {
-                    if ctx.Lr == control_pc {
-                        break;
-                    }
-                    ctx.Pc = ctx.Lr;
-                }
-            } else {
+            if !rf.is_null() {
                 let mut handler_data: *mut core::ffi::c_void = core::ptr::null_mut();
                 let mut establisher_frame: u64 = 0;
                 // SAFETY: `rf` and `image_base` came from RtlLookupFunctionEntry
@@ -430,12 +525,16 @@ pub fn capture_from_context(pc: usize, fp: usize, out: &mut [usize]) -> usize {
                         core::ptr::null_mut(),
                     );
                 }
+            } else if !(n == 1 && unwind_leaf(&mut ctx, &mut ma))
+                && !unwind_frame_pointer(&mut ctx, &mut ma)
+            {
+                break;
             }
-            #[cfg(target_arch = "x86_64")]
-            let (next_pc, next_sp) = (ctx.Rip, ctx.Rsp);
-            #[cfg(target_arch = "aarch64")]
-            let (next_pc, next_sp) = (ctx.Pc, ctx.Sp);
-            if next_pc == 0 || (next_pc == control_pc && next_sp == control_sp) {
+            let (next_pc, next_sp) = context_pc_sp(&ctx);
+            if next_pc == 0
+                || (next_pc == control_pc && next_sp == control_sp)
+                || !is_executable_memory(next_pc as usize)
+            {
                 break;
             }
             out[n] = next_pc as usize;

--- a/src/bun_core/debug.rs
+++ b/src/bun_core/debug.rs
@@ -299,8 +299,11 @@ pub(crate) const PC_OFFSET: usize = StackIterator::PC_OFFSET;
 
 /// Capture the current thread's call stack.
 ///
-/// POSIX: walk frame pointers. Windows: `RtlCaptureStackBackTrace` via
-/// `.pdata` (rbp is not a reliable frame pointer across all linked code).
+/// POSIX: walk frame pointers. Windows: `RtlCaptureStackBackTrace`, which
+/// stops at the first frame without static unwind info, i.e. at the JIT thunk
+/// whenever the caller was reached from JS. That is acceptable for what this is
+/// used for (`StoredTrace`, captured on every debug-build refcount init, so it
+/// has to stay this cheap); crash reports use [`capture_current_for_crash`].
 ///
 /// `first_address`, when present, trims every frame above (and including) the
 /// capture machinery: frames are dropped until one matches `first_address`.
@@ -346,6 +349,10 @@ pub(crate) fn capture_current(first_address: Option<usize>, out: &mut [usize]) -
         }
         n
     };
+    trim_to_first_address(first_address, out, n)
+}
+
+fn trim_to_first_address(first_address: Option<usize>, out: &mut [usize], n: usize) -> usize {
     if let Some(target) = first_address {
         if let Some(skip) = out[..n].iter().position(|&a| a == target) {
             out.copy_within(skip..n, 0);
@@ -353,6 +360,32 @@ pub(crate) fn capture_current(first_address: Option<usize>, out: &mut [usize]) -
         }
     }
     n
+}
+
+/// [`capture_current`] for a crash report, which is captured once and so can
+/// afford the fault path's walk: on Windows this seeds [`walk_context`] from
+/// this thread's own registers, so the report continues through the JS frames
+/// into the code that entered JS exactly as a fault's does. Trimmed the same
+/// way as `capture_current`.
+pub(crate) fn capture_current_for_crash(first_address: Option<usize>, out: &mut [usize]) -> usize {
+    #[cfg(windows)]
+    {
+        if out.is_empty() {
+            return 0;
+        }
+        // SAFETY: CONTEXT is a plain Win32 register dump; all-zeros is valid.
+        let mut ctx: bun_windows_sys::CONTEXT = unsafe { crate::ffi::zeroed_unchecked() };
+        // SAFETY: `ctx` is a writable CONTEXT with the 16-byte alignment the
+        // type declares; RtlCaptureContext only writes into it.
+        unsafe { bun_windows_sys::ntdll::RtlCaptureContext(&raw mut ctx) };
+        out[0] = context_pc_sp(&ctx).0 as usize;
+        let n = walk_context(ctx, out);
+        trim_to_first_address(first_address, out, n)
+    }
+    #[cfg(not(windows))]
+    {
+        capture_current(first_address, out)
+    }
 }
 
 #[cfg(windows)]
@@ -400,13 +433,16 @@ fn unwind_leaf(ctx: &mut bun_windows_sys::CONTEXT, ma: &mut MemoryAccessor) -> b
     }
 }
 
-/// No unwind info and not a leaf: in bun that is JSC's offlineasm (LLInt and
-/// the `vmEntryTo*` trampolines; it is emitted without unwind info, and the
-/// dynamic tables JSC registers cannot cover in-image code) or a tinycc
-/// `bun:ffi` trampoline. Both keep `rbp`/`x29` on a frame whose first two
+/// No unwind info and not a leaf: in bun that is only JSC's offlineasm (LLInt
+/// and the `vmEntryTo*` trampolines), which is assembled without unwind info
+/// and, being inside the image, cannot be covered by a registered table the way
+/// the JIT pool is (everything else that runs, including tinycc output,
+/// registers one). Offlineasm keeps `rbp`/`x29` on a frame whose first two
 /// slots are the caller's frame pointer and the return address, the layout
 /// JSC's JIT-pool unwind info describes too (`registerJITUnwindInfo`), and
 /// `RtlVirtualUnwind` restores that register across the compiled frames above.
+/// This step becomes dead, and should go, once the WebKit build emits `.pdata`
+/// for the offlineasm blob.
 #[cfg(windows)]
 fn unwind_frame_pointer(ctx: &mut bun_windows_sys::CONTEXT, ma: &mut MemoryAccessor) -> bool {
     #[cfg(target_arch = "x86_64")]
@@ -441,6 +477,73 @@ fn unwind_frame_pointer(ctx: &mut bun_windows_sys::CONTEXT, ma: &mut MemoryAcces
     true
 }
 
+/// Walks the stack described by `ctx` with `RtlLookupFunctionEntry` +
+/// `RtlVirtualUnwind`, appending return addresses after the frame-0 PC the
+/// caller already stored in `out[0]`; returns the frame count. Frames without
+/// unwind info are JSC's offlineasm (LLInt, `vmEntryToJavaScript`), which
+/// every JS-initiated crash passes through; those are stepped via the frame
+/// pointer instead (`unwind_frame_pointer`). A frame-pointer walk on its own
+/// would still derail: the prebuilt C++ keeps no frame pointer, and it is
+/// `RtlVirtualUnwind` stepping through those frames that leaves the register
+/// valid.
+#[cfg(windows)]
+fn walk_context(mut ctx: bun_windows_sys::CONTEXT, out: &mut [usize]) -> usize {
+    use bun_windows_sys::{UNW_FLAG_NHANDLER, ntdll};
+    let mut ma = MemoryAccessor::INIT;
+    let mut n = 1usize;
+    // Termination: on x64 RtlVirtualUnwind sets Pc = 0 at the end of the
+    // chain; on ARM64 it can leave the CONTEXT entirely unchanged, so a
+    // step that changed neither Pc nor Sp is also terminal. An Sp-only or
+    // Pc-only check truncates legitimate stacks: an ARM64 fault at prolog
+    // offset 0 (or a .pdata-bearing zero-stack leaf) sets Pc = Lr while
+    // leaving Sp unchanged, and directly-recursive frames share a return
+    // Pc. A non-code Pc means the chain is lost (smashed return address, or
+    // a fallback that did not fit the frame): stop rather than report stack
+    // slots. The `n < out.len()` cap is the ultimate bound.
+    while n < out.len() {
+        let (control_pc, control_sp) = context_pc_sp(&ctx);
+        let mut image_base: u64 = 0;
+        // SAFETY: `control_pc` is a code address from the context;
+        // `image_base` is valid for write; history table may be null.
+        let rf = unsafe {
+            ntdll::RtlLookupFunctionEntry(control_pc, &raw mut image_base, core::ptr::null_mut())
+        };
+        if !rf.is_null() {
+            let mut handler_data: *mut core::ffi::c_void = core::ptr::null_mut();
+            let mut establisher_frame: u64 = 0;
+            // SAFETY: `rf` and `image_base` came from RtlLookupFunctionEntry
+            // for `control_pc`; `ctx` is a valid local CONTEXT; out-params
+            // are valid for write; ContextPointers may be null.
+            unsafe {
+                ntdll::RtlVirtualUnwind(
+                    UNW_FLAG_NHANDLER,
+                    image_base,
+                    control_pc,
+                    rf,
+                    &raw mut ctx,
+                    &raw mut handler_data,
+                    &raw mut establisher_frame,
+                    core::ptr::null_mut(),
+                );
+            }
+        } else if !(n == 1 && unwind_leaf(&mut ctx, &mut ma))
+            && !unwind_frame_pointer(&mut ctx, &mut ma)
+        {
+            break;
+        }
+        let (next_pc, next_sp) = context_pc_sp(&ctx);
+        if next_pc == 0
+            || (next_pc == control_pc && next_sp == control_sp)
+            || !is_executable_memory(next_pc as usize)
+        {
+            break;
+        }
+        out[n] = next_pc as usize;
+        n += 1;
+    }
+    n
+}
+
 /// Capture a faulting thread's call stack from the fault context. `pc` is the
 /// exact faulting instruction (`ExceptionAddress` / `mcontext` PC) and becomes
 /// frame 0.
@@ -450,86 +553,29 @@ fn unwind_frame_pointer(ctx: &mut bun_windows_sys::CONTEXT, ma: &mut MemoryAcces
 /// signal handler's own frames (on the altstack) are never in the chain.
 ///
 /// Windows: `fp` is the `*const CONTEXT` the VEH received (`EXCEPTION_POINTERS
-/// ::ContextRecord`). The walk is `RtlLookupFunctionEntry` + `RtlVirtualUnwind`
-/// seeded from that context, so it starts at the fault frame and the handler's
-/// own frames are never in the chain. The frames without unwind info are JSC's
-/// offlineasm (LLInt, `vmEntryToJavaScript`), which every JS-initiated crash
-/// passes through; those are stepped via the frame pointer instead
-/// (`unwind_frame_pointer`). A frame-pointer walk on its own would still
-/// derail: the prebuilt C++ keeps no frame pointer, and it is `RtlVirtualUnwind`
-/// stepping through those frames that leaves the register valid.
+/// ::ContextRecord`); `walk_context` is seeded from it, so the walk starts
+/// at the fault frame and the handler's own frames are never in the chain.
 pub fn capture_from_context(pc: usize, fp: usize, out: &mut [usize]) -> usize {
     if out.is_empty() {
         return 0;
     }
     out[0] = pc;
-    let mut n = 1usize;
     #[cfg(windows)]
     {
-        use bun_windows_sys::{CONTEXT, UNW_FLAG_NHANDLER, ntdll};
         if fp == 0 {
             // No CONTEXT available (should not happen for a real VEH fault).
-            return n;
+            return 1;
         }
         // SAFETY: `fp` is `EXCEPTION_POINTERS::ContextRecord` from the kernel;
-        // valid for the duration of the handler. Copy so RtlVirtualUnwind can
-        // mutate freely without touching the kernel's record.
-        let mut ctx: CONTEXT = unsafe { *(fp as *const CONTEXT) };
-        let mut ma = MemoryAccessor::INIT;
-        // Termination: on x64 RtlVirtualUnwind sets Pc = 0 at the end of the
-        // chain; on ARM64 it can leave the CONTEXT entirely unchanged, so a
-        // step that changed neither Pc nor Sp is also terminal. An Sp-only or
-        // Pc-only check truncates legitimate stacks: an ARM64 fault at prolog
-        // offset 0 (or a .pdata-bearing zero-stack leaf) sets Pc = Lr while
-        // leaving Sp unchanged, and directly-recursive frames share a return
-        // Pc. A non-code Pc means the chain is lost (smashed return address, or
-        // a fallback that did not fit the frame): stop rather than report stack
-        // slots. The `n < out.len()` cap is the ultimate bound.
-        while n < out.len() {
-            let (control_pc, control_sp) = context_pc_sp(&ctx);
-            let mut image_base: u64 = 0;
-            // SAFETY: `control_pc` is a code address from the fault context;
-            // `image_base` is valid for write; history table may be null.
-            let rf = unsafe {
-                ntdll::RtlLookupFunctionEntry(control_pc, &mut image_base, core::ptr::null_mut())
-            };
-            if !rf.is_null() {
-                let mut handler_data: *mut core::ffi::c_void = core::ptr::null_mut();
-                let mut establisher_frame: u64 = 0;
-                // SAFETY: `rf` and `image_base` came from RtlLookupFunctionEntry
-                // for `control_pc`; `ctx` is a valid local CONTEXT; out-params
-                // are valid for write; ContextPointers may be null.
-                unsafe {
-                    ntdll::RtlVirtualUnwind(
-                        UNW_FLAG_NHANDLER,
-                        image_base,
-                        control_pc,
-                        rf,
-                        &mut ctx,
-                        &mut handler_data,
-                        &mut establisher_frame,
-                        core::ptr::null_mut(),
-                    );
-                }
-            } else if !(n == 1 && unwind_leaf(&mut ctx, &mut ma))
-                && !unwind_frame_pointer(&mut ctx, &mut ma)
-            {
-                break;
-            }
-            let (next_pc, next_sp) = context_pc_sp(&ctx);
-            if next_pc == 0
-                || (next_pc == control_pc && next_sp == control_sp)
-                || !is_executable_memory(next_pc as usize)
-            {
-                break;
-            }
-            out[n] = next_pc as usize;
-            n += 1;
-        }
+        // valid for the duration of the handler. Copied so the walk can mutate
+        // it freely without touching the kernel's record.
+        let ctx: bun_windows_sys::CONTEXT = unsafe { *(fp as *const bun_windows_sys::CONTEXT) };
+        walk_context(ctx, out)
     }
     #[cfg(not(windows))]
     {
         let mut it = StackIterator::init(fp);
+        let mut n = 1usize;
         while n < out.len() {
             match it.next() {
                 Some(addr) => {
@@ -539,6 +585,6 @@ pub fn capture_from_context(pc: usize, fp: usize, out: &mut [usize]) -> usize {
                 None => break,
             }
         }
+        n
     }
-    n
 }

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -2850,6 +2850,15 @@ pub fn capture_stack_trace(begin: usize, addrs: &mut [usize]) -> usize {
     debug::capture_current(first, addrs)
 }
 
+/// [`capture_stack_trace`] for the crash reporter: the same trace on POSIX; on
+/// Windows the thorough walk the fault path uses, which `capture_stack_trace`
+/// cannot afford on the debug-build `StoredTrace` paths.
+#[inline]
+pub fn capture_crash_stack_trace(begin: usize, addrs: &mut [usize]) -> usize {
+    let first = if begin == 0 { None } else { Some(begin) };
+    debug::capture_current_for_crash(first, addrs)
+}
+
 /// A PC inside the caller's caller. `#[inline(always)]`
 /// so this has no frame of its own — `frame_address()` reads the caller's fp,
 /// and `[fp + PC_OFFSET]` is the caller's saved return address. Used as the

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -80,11 +80,12 @@ pub mod debug {
         bun_core::return_address()
     }
 
-    /// Thin re-export of the canonical safe
-    /// wrapper in bun_core so this crate's internal callers don't churn.
+    /// Every capture in this crate is for a report of the current crash (or
+    /// an on-demand dump), so all of them take the thorough variant; the cheap
+    /// `bun_core::capture_stack_trace` is for `StoredTrace`.
     #[inline]
     pub(crate) fn capture_stack_trace(begin: usize, addrs: &mut [usize]) -> usize {
-        bun_core::capture_stack_trace(begin, addrs)
+        bun_core::capture_crash_stack_trace(begin, addrs)
     }
 
     pub(crate) const HAVE_ERROR_RETURN_TRACING: bool = false;

--- a/src/windows_sys/externs.rs
+++ b/src/windows_sys/externs.rs
@@ -688,6 +688,10 @@ pub mod ntdll {
             EstablisherFrame: *mut u64,
             ContextPointers: *mut c_void,
         ) -> *mut c_void;
+        /// Fills `ContextRecord` with the caller's register state, as a seed
+        /// for `RtlVirtualUnwind`. `CONTEXT` carries the 16-byte alignment it
+        /// requires.
+        pub fn RtlCaptureContext(ContextRecord: *mut CONTEXT);
     }
 
     #[cfg_attr(windows, link(name = "ntdll"))]

--- a/src/windows_sys/externs.rs
+++ b/src/windows_sys/externs.rs
@@ -572,7 +572,8 @@ pub struct M128A {
 }
 
 /// `_CONTEXT` for AMD64 (winnt.h). Full layout so `RtlVirtualUnwind` can
-/// mutate it in place during a stack walk. Only `Rip`/`Rsp` are read by bun.
+/// mutate it in place during a stack walk. Only `Rip`/`Rsp`/`Rbp` are read by
+/// bun.
 #[cfg(all(windows, target_arch = "x86_64"))]
 #[repr(C, align(16))]
 #[derive(Clone, Copy)]
@@ -629,10 +630,11 @@ pub struct CONTEXT {
 const _: () = {
     assert!(core::mem::size_of::<CONTEXT>() == 1232);
     assert!(core::mem::offset_of!(CONTEXT, Rsp) == 0x98);
+    assert!(core::mem::offset_of!(CONTEXT, Rbp) == 0xa0);
     assert!(core::mem::offset_of!(CONTEXT, Rip) == 0xf8);
 };
 
-/// `_ARM64_NT_CONTEXT` (winnt.h). Only `Pc`/`Sp`/`Lr` are read by bun.
+/// `_ARM64_NT_CONTEXT` (winnt.h). Only `Fp`/`Lr`/`Sp`/`Pc` are read by bun.
 #[cfg(all(windows, target_arch = "aarch64"))]
 #[repr(C, align(16))]
 #[derive(Clone, Copy)]
@@ -656,6 +658,7 @@ pub struct CONTEXT {
 #[cfg(all(windows, target_arch = "aarch64"))]
 const _: () = {
     assert!(core::mem::size_of::<CONTEXT>() == 912);
+    assert!(core::mem::offset_of!(CONTEXT, Fp) == 0xf0);
     assert!(core::mem::offset_of!(CONTEXT, Lr) == 0xf8);
     assert!(core::mem::offset_of!(CONTEXT, Sp) == 0x100);
     assert!(core::mem::offset_of!(CONTEXT, Pc) == 0x108);

--- a/src/windows_sys/externs.rs
+++ b/src/windows_sys/externs.rs
@@ -840,6 +840,7 @@ pub mod kernel32 {
     pub const PAGE_READONLY: u32 = 0x02;
     pub const PAGE_READWRITE: u32 = 0x04;
     pub const PAGE_WRITECOPY: u32 = 0x08;
+    pub const PAGE_EXECUTE: u32 = 0x10;
     pub const PAGE_EXECUTE_READ: u32 = 0x20;
     pub const PAGE_EXECUTE_READWRITE: u32 = 0x40;
     pub const PAGE_EXECUTE_WRITECOPY: u32 = 0x80;

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -430,7 +430,8 @@ describe.if(isWindows)("Windows: crash trace continues below the JS frames", () 
 
     expect(stderr).toContain("Segmentation fault at address 0xE8");
     const images = traceStringFrameImages(stderr);
-    expect(images[0]).toBe("ntdll.dll");
+    // The loader reports system DLL names in whatever case it mapped them.
+    expect(images[0]).toMatch(/^ntdll\.dll$/i);
     // The FFI call stub and the native-call thunk are JIT-pool code even for
     // interpreted callers; a third JIT frame proves the JS was compiled (the
     // DFG may inline the three functions into one frame).

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -364,7 +364,9 @@ function traceStringFrameImages(stderr: string): (string | null)[] {
 // them as leaf functions read a CallFrame slot as the return address instead:
 // the null CodeBlock slot ended the trace one frame below the JIT thunk, and
 // below vmEntryToJavaScript the remaining slots were reported as frames in no
-// module until the frame buffer was full.
+// module until the frame buffer was full. Panics (and everything else that is
+// not a fault) were captured with RtlCaptureStackBackTrace, which stopped at
+// the JIT thunk itself.
 describe.if(isWindows)("Windows: crash trace continues below the JS frames", () => {
   // JIT-pool code is in no loaded module; "JIT" is the tag a trace string may
   // carry for it instead of the bare unknown-module marker.
@@ -378,14 +380,19 @@ describe.if(isWindows)("Windows: crash trace continues below the JS frames", () 
     return images.slice(lastJitFrame + 1).filter(image => image === "bun").length;
   }
 
-  test.concurrent("fault in bun's image called from interpreted JS", async () => {
+  // `segfault` is reported from the fault context the VEH receives; `panic`
+  // is reported from inside the panicking code, capturing its own stack.
+  test.concurrent.each([
+    ["segfault", "Segmentation fault at address 0xDEADBEEF"],
+    ["panic", "invoked crashByPanic() handler"],
+  ])("%s in bun's image called from interpreted JS", async (hook, header) => {
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
         "--debug-crash-handler-use-trace-string",
         "-e",
         `const { crash_handler } = require("bun:internal-for-testing");
-         function innermost() { crash_handler.segfault(); }
+         function innermost() { crash_handler.${hook}(); }
          function middle() { innermost(); }
          function outermost() { middle(); }
          outermost();`,
@@ -395,12 +402,13 @@ describe.if(isWindows)("Windows: crash trace continues below the JS frames", () 
     });
     const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
-    expect(stderr).toContain("Segmentation fault at address 0xDEADBEEF");
+    expect(stderr).toContain(header);
     const images = traceStringFrameImages(stderr);
     expect(images[0]).toBe("bun");
     // Interpreter return addresses for innermost, middle, outermost and the
     // module body, then vmEntryToJavaScript, then at least the native code
-    // that called it. Unfixed, the trace ended at the first of these.
+    // that called it. Unfixed, the segfault trace ended at the first of these
+    // and the panic trace had nothing below the thunk at all.
     expect(bunFramesBelowTheJitFrames(images)).toBeGreaterThanOrEqual(4 + 1 + 1);
     expect(exitCode).not.toBe(0);
   });

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -366,8 +366,12 @@ function traceStringFrameImages(stderr: string): (string | null)[] {
 // below vmEntryToJavaScript the remaining slots were reported as frames in no
 // module until the frame buffer was full.
 describe.if(isWindows)("Windows: crash trace continues below the JS frames", () => {
+  // JIT-pool code is in no loaded module; "JIT" is the tag a trace string may
+  // carry for it instead of the bare unknown-module marker.
+  const isJitFrame = (image: string | null) => image === null || image === "JIT";
+
   function bunFramesBelowTheJitFrames(images: (string | null)[]): number {
-    const lastJitFrame = images.lastIndexOf(null);
+    const lastJitFrame = images.findLastIndex(isJitFrame);
     // The thunk that called the native function is JIT-pool code even when
     // the JS itself is interpreted; without it the count below is meaningless.
     expect(lastJitFrame).toBeGreaterThan(0);
@@ -430,7 +434,7 @@ describe.if(isWindows)("Windows: crash trace continues below the JS frames", () 
     // The FFI call stub and the native-call thunk are JIT-pool code even for
     // interpreted callers; a third JIT frame proves the JS was compiled (the
     // DFG may inline the three functions into one frame).
-    expect(images.filter(image => image === null).length).toBeGreaterThanOrEqual(2 + 1);
+    expect(images.filter(isJitFrame).length).toBeGreaterThanOrEqual(2 + 1);
     // vmEntryToJavaScript plus at least the JSC entry point that called it and
     // the bun code that called that. Unfixed, the frames after
     // vmEntryToJavaScript were stack slots in no module, so this was zero.

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -306,6 +306,139 @@ describe.if(isWindows)("Windows VEH handler and first-chance faults in external 
   });
 });
 
+/**
+ * Decodes the frames of the trace string in a crash report into the image each
+ * one belongs to: `"bun"` for bun's own executable, the file name of any other
+ * loaded module, or `null` for an address in no module at all (JIT code, or a
+ * stack slot that was reported as a frame without being a return address).
+ *
+ * Layout, from `encode_trace_string` in src/crash_handler/lib.rs: platform,
+ * command and format-version characters, the 7-character commit sha, two
+ * source-map VLQs of feature bits, then one entry per frame (`_`; or `VLQ(1)`,
+ * a VLQ length, the module name and a VLQ address; or just a VLQ address for a
+ * frame in bun's executable) and a zero VLQ terminator.
+ */
+function traceStringFrameImages(stderr: string): (string | null)[] {
+  const match = /\/\d+\.\d+\.\d+[^/\s]*\/([wW]\S+)/.exec(stderr);
+  if (!match) throw new Error(`no trace string in crash output:\n${stderr}`);
+  const body = match[1];
+  const VLQ_DIGITS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  let pos = 3 + 7;
+  function readVlq(): number {
+    let magnitude = 0;
+    for (let shift = 0; ; shift += 5) {
+      const digit = VLQ_DIGITS.indexOf(body[pos++]);
+      if (digit < 0) throw new Error(`malformed trace string: ${body}`);
+      magnitude += (digit & 31) * 2 ** shift;
+      if (!(digit & 32)) break;
+    }
+    return magnitude % 2 ? -(magnitude - 1) / 2 : magnitude / 2;
+  }
+  readVlq();
+  readVlq();
+  const images: (string | null)[] = [];
+  for (;;) {
+    if (body[pos] === "_") {
+      pos++;
+      images.push(null);
+      continue;
+    }
+    const value = readVlq();
+    if (value === 0) return images;
+    if (value !== 1) {
+      images.push("bun");
+      continue;
+    }
+    const length = readVlq();
+    images.push(body.slice(pos, pos + length));
+    pos += length;
+    readVlq();
+  }
+}
+
+// A native function called from JS sits above a JIT-pool thunk, then the JS
+// frames, then vmEntryToJavaScript and the C++ and Rust that entered JS. LLInt
+// and vmEntryToJavaScript are in bun's image but have no unwind info
+// (offlineasm emits none), so the walker steps through them with the frame
+// pointer, as the unwind info JSC registers for the JIT pool does. Treating
+// them as leaf functions read a CallFrame slot as the return address instead:
+// the null CodeBlock slot ended the trace one frame below the JIT thunk, and
+// below vmEntryToJavaScript the remaining slots were reported as frames in no
+// module until the frame buffer was full.
+describe.if(isWindows)("Windows: crash trace continues below the JS frames", () => {
+  function bunFramesBelowTheJitFrames(images: (string | null)[]): number {
+    const lastJitFrame = images.lastIndexOf(null);
+    // The thunk that called the native function is JIT-pool code even when
+    // the JS itself is interpreted; without it the count below is meaningless.
+    expect(lastJitFrame).toBeGreaterThan(0);
+    return images.slice(lastJitFrame + 1).filter(image => image === "bun").length;
+  }
+
+  test.concurrent("fault in bun's image called from interpreted JS", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "--debug-crash-handler-use-trace-string",
+        "-e",
+        `const { crash_handler } = require("bun:internal-for-testing");
+         function innermost() { crash_handler.segfault(); }
+         function middle() { innermost(); }
+         function outermost() { middle(); }
+         outermost();`,
+      ],
+      env: noReportEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain("Segmentation fault at address 0xDEADBEEF");
+    const images = traceStringFrameImages(stderr);
+    expect(images[0]).toBe("bun");
+    // Interpreter return addresses for innermost, middle, outermost and the
+    // module body, then vmEntryToJavaScript, then at least the native code
+    // that called it. Unfixed, the trace ended at the first of these.
+    expect(bunFramesBelowTheJitFrames(images)).toBeGreaterThanOrEqual(4 + 1 + 1);
+    expect(exitCode).not.toBe(0);
+  });
+
+  // The fault is in a system DLL, so the report comes from the JSC SEH handler
+  // rather than the VEH, and the JS frames are JIT-compiled, so everything
+  // above vmEntryToJavaScript unwinds through JSC's registered unwind info.
+  test.concurrent("fault in a system DLL called from JIT-compiled JS", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "--debug-crash-handler-use-trace-string",
+        "-e",
+        `const { dlopen } = require("bun:ffi");
+         const ntdll = dlopen("ntdll.dll", {
+           RtlFillMemory: { args: ["usize", "usize", "i32"], returns: "void" },
+         });
+         function innermost(i) { if (i === 10000) ntdll.symbols.RtlFillMemory(0xE8, 8, 0); return i; }
+         function middle(i) { return innermost(i); }
+         function outermost(i) { return middle(i); }
+         for (let i = 0; i <= 10000; i++) outermost(i);`,
+      ],
+      env: { ...noReportEnv, BUN_JSC_jitPolicyScale: "0", BUN_JSC_useConcurrentJIT: "0" },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain("Segmentation fault at address 0xE8");
+    const images = traceStringFrameImages(stderr);
+    expect(images[0]).toBe("ntdll.dll");
+    // The FFI call stub and the native-call thunk are JIT-pool code even for
+    // interpreted callers; a third JIT frame proves the JS was compiled (the
+    // DFG may inline the three functions into one frame).
+    expect(images.filter(image => image === null).length).toBeGreaterThanOrEqual(2 + 1);
+    // vmEntryToJavaScript plus at least the JSC entry point that called it and
+    // the bun code that called that. Unfixed, the frames after
+    // vmEntryToJavaScript were stack slots in no module, so this was zero.
+    expect(bunFramesBelowTheJitFrames(images)).toBeGreaterThanOrEqual(1 + 2);
+    expect(exitCode).not.toBe(0);
+  });
+});
+
 test.if(process.platform === "darwin")("macOS has the assumed image offset", () => {
   // If this fails, then https://bun.report will be incorrect and the stack
   // trace remappings will stop working.


### PR DESCRIPTION
### Problem

- Every Windows crash that starts in JS passes through frames that have no unwind info: the LLInt opcode handlers and `vmEntryToJavaScript`. Both of bun's Windows stack captures mishandle them (src/bun_core/debug.rs):
  - faults: `capture_from_context` treats any PC without a `RUNTIME_FUNCTION` as a leaf and pops `[Rsp]` as the return address. Those frames are not leaves, so the pop reads a `CallFrame` slot. Native function called from interpreted JS (host function or `bun:ffi` call in a script): the slot is the null CodeBlock slot and the trace ends one frame below the JIT thunk (`... __jsc_host_js_segfault, <JIT thunk>, llint_entry`, end). JIT-compiled callers get as far as `vmEntryToJavaScript`, after which the slots of its frame are reported as frames until the 20-entry buffer is full: the second handoff trace decodes to `intlSegmenterPrototypeFuncSegment`, 7 JIT frames, `vmEntryToJavaScript`, 5 frames in no module (`pkg:"?"` on bun.report); the shipped `8bb8d04c4` binary gives 11 of them for the same shape.
  - panics, `RELEASE_ASSERT`s, OOM (every `TraceSeed` other than `Fault`, via `capture_current`): `RtlCaptureStackBackTrace` stops at the first frame without static unwind info, which is the JIT thunk itself. `crash_handler.panic()` called through three JS functions reports the panic machinery, the thunk, and nothing else.
- In both cases the JS frames and the C++/Rust that entered JS, the part of a report that says what the process was doing, are missing.
- The "stale frames" the handoff was opened for turned out to be a different problem, see the details block at the end: those traces are correct, they were symbolized against the wrong one of the two x64 links of that commit.

### Fix

- One walk, `walk_context`, used by both captures. `capture_from_context` seeds it from the fault `CONTEXT` as before; crash reports that are not faults now go through `capture_current_for_crash` (`bun_core::capture_crash_stack_trace`, which is what the crash handler's `debug::capture_stack_trace` wrapper now calls), seeding it with `RtlCaptureContext` and trimming with the same `first_address` logic. `capture_current` itself keeps `RtlCaptureStackBackTrace`: `StoredTrace` captures it on every debug-build refcount init (`ThreadLock::lock`), which cannot afford a `VirtualQuery` per frame, and those dumps are diagnostics, not reports. That is the one Windows capture deliberately left as is.
- A PC without unwind info is handled by position in the walk: frame 0 may be a genuine leaf (the handoff's ICU crash and `RtlFillMemory` both are), so `[Rsp]` (`Lr` on ARM64) is still taken there, but only when it holds a code address (`unwind_leaf`); otherwise, and for every later frame, step through the frame-pointer register, caller frame at `[fp]`, return address at `[fp+8]`, caller `sp = fp + 16` (`unwind_frame_pointer`).
- Every PC the walk produces, from either fallback or from `RtlVirtualUnwind`, has to be in executable memory (`VirtualQuery`), or the walk stops. `is_valid_memory` and the new `is_executable_memory` share the query; `PAGE_EXECUTE` and `RtlCaptureContext` are added to `bun_windows_sys`, and the `CONTEXT` docs and layout asserts now cover `Rbp`/`Fp`, which the step reads.
- Why the frame-pointer step is correct: a return address never points into a leaf, so a frame past the first with no unwind info is offlineasm, and offlineasm keeps `rbp`/`x29` on a `CallFrame`, whose first two slots are exactly the caller frame and return address. It is the same layout the unwind info JSC registers for the JIT pool describes (`registerJITUnwindInfo`, #35083), so the two compose, and it is not a frame-pointer walk: the prebuilt C++ keeps no frame pointer, and it is `RtlVirtualUnwind` stepping through those frames that restores `rbp`/`x29` by the time an offlineasm return address comes up. Offlineasm is the only such code: tinycc registers a function table for everything it compiles (`tccrun.c`, `win64_add_function_table`), and the `bun:ffi` call stubs are JIT-pool code; an earlier revision of this PR wrongly listed tinycc here.
- Why the leaf step is restricted to frame 0 and validated: at a later frame it is always wrong (that is this bug); at frame 0 a fault directly inside LLInt would have scratch at `[Rsp]`, and the code-address check routes that case to the frame-pointer step too.
- Why stopping on a non-code PC: a return address is always in mapped code (image `.text`, JIT pool, FFI stubs; frame 1 of the FFI test is a pool address produced by the leaf step, so that case is exercised). Anything else means the chain is lost, and continuing is what produced the padding.
- This is the interim, bun-side fix. The root fix is for the WebKit build to emit one `.pdata`/`.xdata` entry over the offlineasm blob (`jsc_llint_begin..jsc_llint_end`, the SEH twin of the `.cfi_*` block LowLevelInterpreter.cpp already emits for DWARF), which is the follow-up ExecutableAllocator.cpp and #35083 already name; it would also give LLInt faults an SEH catch point and fix ETW/WinDbg. It is a WebKit change plus a pin bump, so it is tracked separately; when it lands, `unwind_frame_pointer` becomes dead and its doc comment says to delete it. The frame-0 rule, the executable check and the report-path capture stay useful after it.
- Verified with test/cli/run/run-crash-handler.test.ts, `Windows: crash trace continues below the JS frames` (3 tests, Windows only): `segfault` and `panic` called through three interpreted JS functions, and an `RtlFillMemory` fault reached through JIT-compiled JS. Unfixed, they report 1, 0 and 0 bun frames below the JIT frames (the `panic` case measured on a build that already had the fault-path fix, so it isolates the `capture_current_for_crash` change); fixed, all three pass. Fixed traces symbolized with the debug PDBs give the same chain on x64 and ARM64 for both the fault and the panic: `llint_entry` x3, `llint_entry` (module body), `vmEntryToJavaScript`, `JSC::Interpreter::executeProgram`, `JSC::evaluate`, `Bun::evaluateCommonJSModuleOnce`, ... to the 20-frame cap, no unknown frames; the panic trace's frames above the thunk are byte-for-byte the ones the old capture produced, so trimming is unchanged.
- Whole file: 13 pass / 13 skip on Windows Server 2019 x64 and Windows 11 ARM64 debug builds. `cargo check -p bun_crash_handler` clean on `x86_64-pc-windows-msvc`, `aarch64-pc-windows-msvc` and Linux; debug.rs is clippy-clean on both Windows targets (the four `borrow_as_ptr` hits main has in the moved loop are fixed in passing, which is also what #37605 does to those lines).
- Not covered by a test: the frame-0 decline path (a fault directly inside LLInt needs a JSC bug to trigger) and the stop conditions; both are argued above. The gate cannot run these tests on Linux, same as #35074 and #35083.
- Open PRs touching the same lines, none of them this fix: #32871 (POSIX leaf recovery, changes `capture_from_context`'s signature), #35440 (tags JIT-pool frames `"JIT"`; the new tests accept either encoding), #37605 (the clippy lines above).

### Background

- Windows stack walking: the linker emits a `RUNTIME_FUNCTION` (`.pdata`) for every compiled function that uses the stack; `RtlLookupFunctionEntry` finds it for a PC and `RtlVirtualUnwind` applies it to a register `CONTEXT`, restoring callee-saved registers including `rbp`/`x29`. Leaf functions (no stack use) get no entry; for them the return address is still at `[rsp]` (in `lr` on ARM64). For a PC inside a loaded image `RtlLookupFunctionEntry` consults only that image's static `.pdata`, so dynamic function tables (what #35083 registers for the JIT pool and tinycc registers for its output, both outside the image) cannot cover in-image code. `RtlCaptureContext` fills a `CONTEXT` with the calling function's registers; `RtlCaptureStackBackTrace` is ntdll's own walker over the same tables, with no way to step a frame the tables do not describe.
- offlineasm: JSC's assembler that produces the LLInt interpreter and the `vmEntryTo*` trampolines. Its output is linked into bun's `.text` without `.seh_*` directives, so it has no `.pdata`, but it keeps the frame-pointer register pointing at the current `CallFrame`.
- `CallFrame`: JSC's JS stack frame. On both architectures the frame-pointer register points at it; slot 0 is the caller's frame pointer and slot 1 the return address, which is what every JIT tier's prologue and LLInt's `functionPrologue` push.
- `TraceSeed` (src/crash_handler/lib.rs): how a report's trace is obtained. `Fault` carries the signal/exception context; the other seeds (panic, OOM, C++ `Bun__crashHandler`) capture the current stack from inside the handler and trim everything above a caller-supplied return address.
- Trace string: the crash report URL encodes one entry per captured frame from a 20-entry buffer: an offset for bun's own image, a name plus offset for another DLL, or `_` for an address in no module. The tests decode that and count bun-image frames below the last JIT-pool frame.

<details>
<summary>What the handed-off traces actually were</summary>

The handoff's two bun.report traces (build `8bb8d04c4`) have mid-instruction addresses in every frame including frame 0, which a real fault PC cannot be. That commit has two separate x64 links, `bun-windows-x64-profile` and `bun-windows-x64-baseline-profile` (different PDB GUIDs, `.text` differs by 40 KB), and a trace string identifies a build only by platform character plus 7-character sha. Symbolized against the baseline link, every frame of both traces is an instruction boundary directly after a `call` into the previous frame's function:

- trace 1, frame 0 first: `JSC::SlotVisitor::visitChildren` (the fault is `mov rax, [rax+0x50]` with `rax = 0x20200000000`, matching the reported fault address `0x20200000050`), `SlotVisitor::drain`, `drainFromShared`, the `Heap::runBeginPhase` lambda, `ParallelHelperClient::runTask`, `AutomaticThread`, `WTF::Thread::entryPoint`, `wtfThreadEntryPoint`, ucrt `thread_start`, `BaseThreadInitThunk`, `RtlUserThreadStart`. A GC marking thread hitting a corrupt cell, not date code.
- trace 2, frame 0 first: `icu_73::RuleBasedBreakIterator::BreakCache::reset` entered with a null `this` (fault address `0x10`, PC at the function's first instruction, no `.pdata`, so this is the leaf step working), `RuleBasedBreakIterator::operator=`, `RuleBasedBreakIterator::clone`, `ubrk_clone`, `JSC::cloneUBreakIterator` (IntlWorkaround.cpp) inlined into `IntlSegmenter::segment`, `intlSegmenterPrototypeFuncSegment`, 7 JIT frames, `vmEntryToJavaScript`, then 5 frames of padding. The padding is what this PR fixes; the rest of the trace was right.

So the walker was sound for those crashes; the fix here is for what happens below `vmEntryToJavaScript`, plus the interpreted-caller truncation. The build-identity problem (which link a `w` + sha7 trace string came from) is a release/bun.report matter and is not changed here.

</details>

