### PR TITLE
Bump WebKit: process.env.TZ changes reach the no-argument Date toLocale*String formatters

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "autobuild-preview-pr-439-5bec0df0";
+export const WEBKIT_VERSION = "autobuild-preview-pr-439-22bdf5a8";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "f0f60fd2324817dae9656d8bf2fcae25ceaccc37";
+export const WEBKIT_VERSION = "autobuild-preview-pr-439-5bec0df0";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -224,6 +224,81 @@ it("process.env.TZ writes inside a worker do not change the main thread's timezo
   });
 });
 
+it("a main-thread process.env.TZ change reaches a worker's no-argument Date toLocale*String formatters on its next turn", async () => {
+  // A worker only takes over a time zone change when it next enters JS from
+  // its event loop. This pins down what happens to the three per-global
+  // formatters a worker builds in between: while it is still inside the run of
+  // the script that was blocked across the change it keeps seeing its old zone
+  // everywhere (the formatters included), and on the next turn those
+  // formatters have to be rebuilt together with the rest of its time zone
+  // state instead of staying pinned to the zone they were built in.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const { Worker } = require("node:worker_threads");
+        const gate = new Int32Array(new SharedArrayBuffer(4));
+        const worker = new Worker(
+          \`
+            const { parentPort, workerData: gate } = require("node:worker_threads");
+            const d = new Date(Date.UTC(2024, 5, 15, 20, 0));
+            const snapshot = () => ({
+              noArg: [d.toLocaleString(), d.toLocaleDateString(), d.toLocaleTimeString()],
+              fresh: [
+                d.toLocaleString(undefined, {}),
+                d.toLocaleDateString(undefined, {}),
+                d.toLocaleTimeString(undefined, {}),
+              ],
+            });
+            // Resolve this thread's zone so the worker has time zone state of
+            // its own, then block inside this same run while the main thread
+            // changes TZ.
+            const zoneBefore = new Intl.DateTimeFormat().resolvedOptions().timeZone;
+            parentPort.postMessage("ready");
+            Atomics.wait(gate, 0, 0);
+            const midRun = snapshot();
+            parentPort.once("message", () => {
+              parentPort.postMessage({ zoneBefore, midRun, nextTurn: snapshot() });
+            });
+          \`,
+          { eval: true, workerData: gate },
+        );
+        worker.on("message", message => {
+          if (message === "ready") {
+            process.env.TZ = "Asia/Tokyo";
+            Atomics.store(gate, 0, 1);
+            Atomics.notify(gate, 0);
+            // Delivered once the worker's script run has finished, i.e. on a
+            // later turn of its event loop.
+            worker.postMessage("next");
+            return;
+          }
+          console.log(JSON.stringify(message));
+          worker.terminate();
+        });
+        worker.on("error", error => {
+          console.error(error);
+          process.exit(1);
+        });
+      `,
+    ],
+    env: { ...bunEnv, TZ: "America/Los_Angeles" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const { zoneBefore, midRun, nextTurn } = JSON.parse(stdout);
+  expect(zoneBefore).toBe("America/Los_Angeles");
+  expect(midRun.noArg).toEqual(midRun.fresh);
+  expect(nextTurn.noArg).toEqual(nextTurn.fresh);
+  // June 15th 13:00 in Los Angeles versus June 16th 05:00 in Tokyo: the next
+  // turn has to differ from the blocked run in all three methods.
+  expect(nextTurn.fresh.map((s, i) => s !== midRun.fresh[i])).toEqual([true, true, true]);
+  expect(exitCode).toBe(0);
+});
+
 it.skipIf(isWindows)("process.env keeps Node's EnvSetter semantics inside a snapshot-env worker", async () => {
   // new Worker(file, { env: {...} }) seeds process.env from a snapshot dict;
   // writes inside the worker must still coerce to string, reject symbol keys,
@@ -2090,33 +2165,54 @@ it("delete process.env.TZ invalidates existing Date instances", async () => {
   });
 });
 
-it("process.env.TZ changes reach the no-argument Date toLocale*String formatters", async () => {
+it("process.env.TZ changes reach the no-argument Date toLocale*String formatters of every realm", async () => {
   // The no-argument toLocaleString / toLocaleDateString / toLocaleTimeString
   // paths format through three Intl.DateTimeFormat objects JSC keeps per
   // global object, built the first time they are used. Node drops V8's
-  // equivalent caches on every TZ write (DateTimeConfigurationChangeNotification);
-  // here each one is primed under the old zone first so a stale one shows up.
+  // equivalent caches on every TZ write (DateTimeConfigurationChangeNotification).
+  // Every realm (a vm context, a ShadowRealm, the main global) is primed under
+  // the old zone first so a stale formatter shows up, and each phase lets a
+  // different one of the three methods be the first call after the change.
   // Comparing against the explicit `(undefined, {})` form, which builds a fresh
   // formatter with the same defaults, keeps the assertions locale-independent.
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
       "-e",
-      `const d = new Date(Date.UTC(2024, 5, 15, 20, 0));
-       const snapshot = () => ({
-         noArg: [d.toLocaleString(), d.toLocaleDateString(), d.toLocaleTimeString()],
-         fresh: [
-           d.toLocaleString(undefined, {}),
-           d.toLocaleDateString(undefined, {}),
-           d.toLocaleTimeString(undefined, {}),
-         ],
-       });
+      `const vm = require("node:vm");
+       const ms = Date.UTC(2024, 5, 15, 20, 0);
+       const d = new Date(ms);
+       const methods = ["toLocaleString", "toLocaleDateString", "toLocaleTimeString"];
+       // Calls the three methods starting with methods[lead]; results are
+       // returned in the methods order.
+       function inOrder(lead, call) {
+         const out = [];
+         for (let i = 0; i < methods.length; i++) {
+           const k = (lead + i) % methods.length;
+           out[k] = call(methods[k]);
+         }
+         return out;
+       }
+       const inContext = (context, lead) => inOrder(lead, name => vm.runInContext("d." + name + "()", context));
+       const context = vm.createContext({ d });
+       const inShadowRealm = new ShadowRealm().evaluate("(ms, name) => new Date(ms)[name]()");
+       let lateContext;
+       function snapshot(lead) {
+         const realms = {
+           context: inContext(context, lead),
+           shadowRealm: inOrder(lead, name => inShadowRealm(ms, name)),
+         };
+         if (lateContext) realms.lateContext = inContext(lateContext, lead);
+         realms.main = inOrder(lead, name => d[name]());
+         return { fresh: methods.map(name => d[name](undefined, {})), realms };
+       }
        process.env.TZ = "America/Los_Angeles";
-       const la = snapshot();
+       const la = snapshot(0);
        process.env.TZ = "Asia/Tokyo";
-       const tokyo = snapshot();
+       lateContext = vm.createContext({ d });
+       const tokyo = snapshot(1);
        delete process.env.TZ;
-       const afterDelete = snapshot();
+       const afterDelete = snapshot(2);
        console.log(JSON.stringify({ la, tokyo, afterDelete }));`,
     ],
     env: { ...bunEnv, TZ: "UTC" },
@@ -2126,13 +2222,24 @@ it("process.env.TZ changes reach the no-argument Date toLocale*String formatters
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
   const { la, tokyo, afterDelete } = JSON.parse(stdout);
-  expect(la.noArg).toEqual(la.fresh);
-  expect(tokyo.noArg).toEqual(tokyo.fresh);
-  expect(afterDelete.noArg).toEqual(afterDelete.fresh);
+  expect(la.realms).toEqual({ context: la.fresh, shadowRealm: la.fresh, main: la.fresh });
+  expect(tokyo.realms).toEqual({
+    context: tokyo.fresh,
+    shadowRealm: tokyo.fresh,
+    lateContext: tokyo.fresh,
+    main: tokyo.fresh,
+  });
+  expect(afterDelete.realms).toEqual({
+    context: afterDelete.fresh,
+    shadowRealm: afterDelete.fresh,
+    lateContext: afterDelete.fresh,
+    main: afterDelete.fresh,
+  });
   // 2024-06-15T20:00Z is June 15th 13:00 in Los Angeles and June 16th 05:00 in
-  // Tokyo, so all three no-argument results have to change, not just agree
-  // with the fresh formatter.
-  expect(tokyo.noArg.map((s, i) => s !== la.noArg[i])).toEqual([true, true, true]);
+  // Tokyo, so the results every realm was just compared against have to differ
+  // in all three methods; agreeing on a zone that never changed would prove
+  // nothing.
+  expect(tokyo.fresh.map((s, i) => s !== la.fresh[i])).toEqual([true, true, true]);
   expect(exitCode).toBe(0);
 });
 

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -2090,6 +2090,52 @@ it("delete process.env.TZ invalidates existing Date instances", async () => {
   });
 });
 
+it("process.env.TZ changes reach the no-argument Date toLocale*String formatters", async () => {
+  // The no-argument toLocaleString / toLocaleDateString / toLocaleTimeString
+  // paths format through three Intl.DateTimeFormat objects JSC keeps per
+  // global object, built the first time they are used. Node drops V8's
+  // equivalent caches on every TZ write (DateTimeConfigurationChangeNotification);
+  // here each one is primed under the old zone first so a stale one shows up.
+  // Comparing against the explicit `(undefined, {})` form, which builds a fresh
+  // formatter with the same defaults, keeps the assertions locale-independent.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const d = new Date(Date.UTC(2024, 5, 15, 20, 0));
+       const snapshot = () => ({
+         noArg: [d.toLocaleString(), d.toLocaleDateString(), d.toLocaleTimeString()],
+         fresh: [
+           d.toLocaleString(undefined, {}),
+           d.toLocaleDateString(undefined, {}),
+           d.toLocaleTimeString(undefined, {}),
+         ],
+       });
+       process.env.TZ = "America/Los_Angeles";
+       const la = snapshot();
+       process.env.TZ = "Asia/Tokyo";
+       const tokyo = snapshot();
+       delete process.env.TZ;
+       const afterDelete = snapshot();
+       console.log(JSON.stringify({ la, tokyo, afterDelete }));`,
+    ],
+    env: { ...bunEnv, TZ: "UTC" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const { la, tokyo, afterDelete } = JSON.parse(stdout);
+  expect(la.noArg).toEqual(la.fresh);
+  expect(tokyo.noArg).toEqual(tokyo.fresh);
+  expect(afterDelete.noArg).toEqual(afterDelete.fresh);
+  // 2024-06-15T20:00Z is June 15th 13:00 in Los Angeles and June 16th 05:00 in
+  // Tokyo, so all three no-argument results have to change, not just agree
+  // with the fresh formatter.
+  expect(tokyo.noArg.map((s, i) => s !== la.noArg[i])).toEqual([true, true, true]);
+  expect(exitCode).toBe(0);
+});
+
 it("process.traceDeprecation set at runtime prints a stack", async () => {
   await using proc = Bun.spawn({
     cmd: [

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -2178,9 +2178,10 @@ it("process.env.TZ changes reach the no-argument Date toLocale*String formatters
   // paths format through three Intl.DateTimeFormat objects JSC keeps per
   // global object, built the first time they are used. Node drops V8's
   // equivalent caches on every TZ write (DateTimeConfigurationChangeNotification).
-  // Every realm (a vm context, a ShadowRealm, the main global) is primed under
-  // the old zone first so a stale formatter shows up, and each phase lets a
-  // different one of the three methods be the first call after the change.
+  // Every realm (a vm context, a ShadowRealm, the main global) is primed before
+  // each change so a stale formatter shows up, and each of the three changes
+  // (set, set, delete) lets a different one of the three methods be the first
+  // call afterwards, i.e. the one that has to notice the change.
   // Comparing against the explicit `(undefined, {})` form, which builds a fresh
   // formatter with the same defaults, keeps the assertions locale-independent.
   await using proc = Bun.spawn({
@@ -2219,6 +2220,10 @@ it("process.env.TZ changes reach the no-argument Date toLocale*String formatters
          realms.main = inOrder(lead, name => d[name]());
          return { fresh: methods.map(name => d[name](undefined, {})), realms };
        }
+       // Build every realm's formatters under the starting zone (UTC) first, so
+       // that already the Los Angeles phase is a change noticed by a primed
+       // formatter rather than a first build.
+       snapshot(0);
        process.env.TZ = "America/Los_Angeles";
        const la = snapshot(0);
        process.env.TZ = "Asia/Tokyo";

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -2193,8 +2193,13 @@ it("process.env.TZ changes reach the no-argument Date toLocale*String formatters
          }
          return out;
        }
-       const inContext = (context, lead) => inOrder(lead, name => vm.runInContext("d." + name + "()", context));
-       const context = vm.createContext({ d });
+       // The Date has to be created inside the realm: the method is looked up on
+       // the Date's own prototype and runs against its realm's formatters, so
+       // calling a main-realm Date from inside a context would only exercise the
+       // main realm again.
+       const inContext = (context, lead) =>
+         inOrder(lead, name => vm.runInContext("new Date(ms)." + name + "()", context));
+       const context = vm.createContext({ ms });
        const inShadowRealm = new ShadowRealm().evaluate("(ms, name) => new Date(ms)[name]()");
        let lateContext;
        function snapshot(lead) {
@@ -2209,7 +2214,7 @@ it("process.env.TZ changes reach the no-argument Date toLocale*String formatters
        process.env.TZ = "America/Los_Angeles";
        const la = snapshot(0);
        process.env.TZ = "Asia/Tokyo";
-       lateContext = vm.createContext({ d });
+       lateContext = vm.createContext({ ms });
        const tokyo = snapshot(1);
        delete process.env.TZ;
        const afterDelete = snapshot(2);

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -226,12 +226,12 @@ it("process.env.TZ writes inside a worker do not change the main thread's timezo
 
 it("a main-thread process.env.TZ change reaches a worker's no-argument Date toLocale*String formatters on its next turn", async () => {
   // A worker only takes over a time zone change when it next enters JS from
-  // its event loop. This pins down what happens to the three per-global
-  // formatters a worker builds in between: while it is still inside the run of
-  // the script that was blocked across the change it keeps seeing its old zone
-  // everywhere (the formatters included), and on the next turn those
-  // formatters have to be rebuilt together with the rest of its time zone
-  // state instead of staying pinned to the zone they were built in.
+  // its event loop. This pins down what happens to its three per-global
+  // formatters around that: the ones built before the change, and anything
+  // touched while it is still inside the script run that was blocked across
+  // the change, keep agreeing with the old zone it still sees everywhere else,
+  // and on the next turn they have to be rebuilt together with the rest of its
+  // time zone state instead of staying pinned to the zone they were built in.
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
@@ -244,6 +244,7 @@ it("a main-thread process.env.TZ change reaches a worker's no-argument Date toLo
             const { parentPort, workerData: gate } = require("node:worker_threads");
             const d = new Date(Date.UTC(2024, 5, 15, 20, 0));
             const snapshot = () => ({
+              zone: new Intl.DateTimeFormat().resolvedOptions().timeZone,
               noArg: [d.toLocaleString(), d.toLocaleDateString(), d.toLocaleTimeString()],
               fresh: [
                 d.toLocaleString(undefined, {}),
@@ -251,15 +252,14 @@ it("a main-thread process.env.TZ change reaches a worker's no-argument Date toLo
                 d.toLocaleTimeString(undefined, {}),
               ],
             });
-            // Resolve this thread's zone so the worker has time zone state of
-            // its own, then block inside this same run while the main thread
-            // changes TZ.
-            const zoneBefore = new Intl.DateTimeFormat().resolvedOptions().timeZone;
+            // Build the formatters under the starting zone, then block inside
+            // this same run while the main thread changes TZ.
+            const primed = snapshot();
             parentPort.postMessage("ready");
             Atomics.wait(gate, 0, 0);
             const midRun = snapshot();
             parentPort.once("message", () => {
-              parentPort.postMessage({ zoneBefore, midRun, nextTurn: snapshot() });
+              parentPort.postMessage({ primed, midRun, nextTurn: snapshot() });
             });
           \`,
           { eval: true, workerData: gate },
@@ -289,13 +289,21 @@ it("a main-thread process.env.TZ change reaches a worker's no-argument Date toLo
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
-  const { zoneBefore, midRun, nextTurn } = JSON.parse(stdout);
-  expect(zoneBefore).toBe("America/Los_Angeles");
+  const { primed, midRun, nextTurn } = JSON.parse(stdout);
+  // The zones show which state the worker was in at each point: the blocked
+  // run really did still see the old zone, the next turn really has the new one.
+  expect([primed.zone, midRun.zone, nextTurn.zone]).toEqual([
+    "America/Los_Angeles",
+    "America/Los_Angeles",
+    "Asia/Tokyo",
+  ]);
+  expect(primed.noArg).toEqual(primed.fresh);
   expect(midRun.noArg).toEqual(midRun.fresh);
   expect(nextTurn.noArg).toEqual(nextTurn.fresh);
   // June 15th 13:00 in Los Angeles versus June 16th 05:00 in Tokyo: the next
-  // turn has to differ from the blocked run in all three methods.
-  expect(nextTurn.fresh.map((s, i) => s !== midRun.fresh[i])).toEqual([true, true, true]);
+  // turn has to differ from what was built before the change in all three
+  // methods.
+  expect(nextTurn.noArg.map((s, i) => s !== primed.noArg[i])).toEqual([true, true, true]);
   expect(exitCode).toBe(0);
 });
 


### PR DESCRIPTION
Bumps `WEBKIT_VERSION` to pick up [oven-sh/WebKit#439](https://github.com/oven-sh/WebKit/pull/439) and adds the `process.env.TZ` tests for it.

### Problem

- After `process.env.TZ` changes, the no-argument `Date#toLocaleString()`, `toLocaleDateString()` and `toLocaleTimeString()` keep formatting in the previous zone if they were used before the change. Everything else moves: `getHours()`, `new Intl.DateTimeFormat().resolvedOptions().timeZone`, and the same methods called as `toLocaleString(undefined, {})`. Node updates all three.
  ```js
  const d = new Date(Date.UTC(2024, 5, 15));
  process.env.TZ = "America/Los_Angeles";
  d.toLocaleString();              // "6/14/2024, 5:00:00 PM"
  process.env.TZ = "Asia/Tokyo";
  d.getHours();                    // 9
  d.toLocaleString(undefined, {}); // "6/15/2024, 9:00:00 AM"
  d.toLocaleString();              // "6/14/2024, 5:00:00 PM"   <- stale (Date and Time variants too)
  ```
- Cause: the no-argument paths (`DatePrototype.cpp`, also the Temporal `toLocaleString`s) format through three `IntlDateTimeFormat`s that `JSGlobalObject` creates lazily and never invalidates (`m_defaultDateTimeFormat` / `m_defaultDateFormat` / `m_defaultTimeFormat`). Bun's TZ hook (`resetDateCachesAfterTimeZoneChange` in `src/jsc/bindings/JSEnvironmentVariableMap.cpp`) bumps `WTF::lastTimeZoneID()` and clears the VM's `DateCache`, which fixes `Date` itself, but nothing re-armed those three objects. Upstream tracks the engine side as https://bugs.webkit.org/show_bug.cgi?id=318362.

### Fix

- oven-sh/WebKit#439: `DateCache` exposes the time zone ID it was last refreshed for, `JSGlobalObject` records it when it arms the three formatters, and the `defaultDateTimeFormat()` / `defaultDateFormat()` / `defaultTimeFormat()` accessors re-arm them when it has moved. The next no-argument call rebuilds the formatter from the refreshed `DateCache`.
- Correct because the formatters take their zone from `vm.dateCache` when they are built, and Bun already refreshes that cache (and bumps the ID it is tagged with) on every `process.env.TZ` write, delete and `defineProperty`, on Windows, and in `bun:jsc`'s `setTimeZone`. Keying the formatters on the `DateCache`'s own ID makes them exactly as fresh as the cache they read from, for every global object and with no Bun-side call to keep in sync. Keying them on `WTF::lastTimeZoneID()` instead would let a VM that has not refreshed yet (a worker that is still inside a script run when the main thread writes `TZ`; workers refresh on their next entry from the event loop) build formatters from its still-old cache and tag them as current, after which they would stay stale. The worker test below is that case; the variant keyed on `lastTimeZoneID()` fails it.
- No Bun source change: this is engine-side on purpose. Re-arming the `LazyProperty`s from Bun would need `JavaScriptCore/IntlDateTimeFormat.h`, which pulls in `unicode/udat.h` and `unicode/uformattedvalue.h`; on macOS Bun compiles against Apple's SDK, whose `usr/include/unicode/` only carries a couple of dozen ICU headers (apple-oss-distributions/ICU `makefile`, `PUBLIC_HEADERS`), so that header is not includable there (the same constraint that produced `VM::clearForTimeZoneChange()` in the fork).
- Verified with two new tests in `test/js/node/process/process.test.js`. Both fail on the current build (the no-argument results stay `["6/15/2024, 1:00:00 PM", "6/15/2024", "1:00:00 PM"]` while the fresh formatter says `["6/16/2024, 5:00:00 AM", "6/16/2024", "5:00:00 AM"]`) and pass with `bun bd test` against the preview build. Both compare every no-argument result with the `(undefined, {})` form built fresh for the same instant (locale independent) and additionally require the Los Angeles and Tokyo results to differ in all three methods.
  - "...formatters of every realm": primes a `vm` context, a `ShadowRealm` and the main global under `America/Los_Angeles` (each realm formatting a Date created inside it, so each realm's own formatters are the ones primed), switches to `Asia/Tokyo` (also priming a context created after that write), then deletes `TZ` (second re-arm cycle, delete path). Each phase makes a different one of the three methods the first call after the change, so each of the three accessors is exercised as the one that notices it, and the realms are checked independently because the state is per global object. On the current build the context, the ShadowRealm and the main global are stale under Tokyo and all four realms after the delete.
  - "...reaches a worker's ... formatters on its next turn": a worker builds its formatters, then blocks in `Atomics.wait` inside the same script run while the main thread sets `TZ`. It records the zone it sees at each step (`America/Los_Angeles` before and during the blocked run, `Asia/Tokyo` on the next turn, so the window is really exercised); the formatters touched during the blocked run must still agree with the old zone, and on the next turn the no-argument results must match the fresh formatter and differ from the ones built before the change.
- Engine side: `JSTests/stress/intl-datetimeformat-default-formatter-stale-across-tz-change.js` (skipped upstream for this bug) is enabled in oven-sh/WebKit#439, now also using the formatters inside the bump-to-next-entry window; on a local JSCOnly build it fails before, passes after, and fails with the `lastTimeZoneID()`-keyed variant, while its TZ-cache siblings still pass. JSTests are not run by CI in either repo, so the tests in this PR are the CI coverage.

### Background

- `JSGlobalObject` default formatters: JSC keeps one `IntlDateTimeFormat` per (global object, `toLocaleString` flavour) so the no-argument calls do not build a formatter per call. They are `LazyProperty`s: armed with an initializer in `JSGlobalObject::init()` and materialized on first use; re-arming one (`initLater`) just drops the built object so the next use rebuilds it. Every realm (`node:vm` context, `ShadowRealm`, worker global) has its own three.
- `DateCache` (`vm.dateCache`): per-VM cache of the resolved host time zone plus offset/DST tables. `clearForTimeZoneChange()` drops it and records the `WTF::lastTimeZoneID()` it was refreshed for; `Intl.DateTimeFormat` without a `timeZone` option takes its zone from here.
- `WTF::lastTimeZoneID()`: process-wide counter bumped by `WTF::timeZoneDidChange()` whenever the zone may have changed. Bun's TZ setter bumps it and refreshes the writing thread's `DateCache` synchronously; every other VM compares it against its own `DateCache`'s recorded ID when it next enters JS from its event loop and refreshes then, which is the window the worker test exercises.

### Also in this range

Nothing else: oven-sh/WebKit#439 (two commits, the second only touches a JSTest) is directly on top of `f0f60fd232`, the commit this branch replaces.

> [!NOTE]
> `WEBKIT_VERSION` points at the preview tag `autobuild-preview-pr-439-22bdf5a8` while oven-sh/WebKit#439 is open; it needs to be switched to the merged main sha before this lands.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->