### PR TITLE
Link statically detected CommonJS export names when importing CJS from ESM

### DIFF
--- a/docs/runtime/module-resolution.mdx
+++ b/docs/runtime/module-resolution.mdx
@@ -334,6 +334,8 @@ Bun's JavaScript runtime has native support for CommonJS. When Bun's JavaScript 
 
 Once the CommonJS module is successfully evaluated, Bun creates a Synthetic Module Record with the `default` ES Module [export set to `module.exports`](https://github.com/oven-sh/bun/blob/9b6913e1a674ceb7f670f917fc355bb8758c6c72/src/bun.js/bindings/CommonJSModuleRecord.cpp#L212-L213). If `module.exports` is an object, Bun also re-exports its keys as named exports.
 
+Like Node.js, Bun additionally exports the names it detects in the source while transpiling (`exports.foo = ...`, `module.exports = { foo }`, `Object.defineProperty(exports, "foo", ...)`, and names re-exported through `module.exports = require(...)` or `__exportStar(require(...))`). A detected name that the evaluated `module.exports` does not have, for example one that is only assigned under a condition, can still be imported and is `undefined`.
+
 Bun's bundler works differently: it wraps the CommonJS module in a `require_${moduleName}` function which returns the `module.exports` object.
 
 </Accordion>

--- a/src/ast/ast_result.rs
+++ b/src/ast/ast_result.rs
@@ -86,8 +86,7 @@ pub struct Ast<'a> {
     /// This is a list of named exports that may exist in a CommonJS module
     /// We use this with `commonjs_at_runtime` to re-export CommonJS
     pub has_commonjs_export_names: bool,
-    /// Serialized by `bun_js_parser::commonjs_static_exports` for runtime-wrapped
-    /// CommonJS modules, empty otherwise; ends up on `JSCommonJSModule`.
+    /// See `bun_js_parser::commonjs_static_exports`; empty unless the runtime wraps the file as CommonJS.
     pub commonjs_static_exports: StoreStr,
     pub has_import_meta: bool,
     pub import_meta_ref: Ref,

--- a/src/ast/ast_result.rs
+++ b/src/ast/ast_result.rs
@@ -86,11 +86,8 @@ pub struct Ast<'a> {
     /// This is a list of named exports that may exist in a CommonJS module
     /// We use this with `commonjs_at_runtime` to re-export CommonJS
     pub has_commonjs_export_names: bool,
-    /// Export names and re-export specifiers detected lexically in a CommonJS
-    /// module that the runtime will wrap (`bun_js_parser::commonjs_static_exports`
-    /// documents the format). The module loader hands it to `JSCommonJSModule` so
-    /// `import { x } from "./cjs"` links for names the evaluated `module.exports`
-    /// lacks, as in Node.js. Empty for ES modules and when bundling.
+    /// Serialized by `bun_js_parser::commonjs_static_exports` for runtime-wrapped
+    /// CommonJS modules, empty otherwise; ends up on `JSCommonJSModule`.
     pub commonjs_static_exports: StoreStr,
     pub has_import_meta: bool,
     pub import_meta_ref: Ref,

--- a/src/ast/ast_result.rs
+++ b/src/ast/ast_result.rs
@@ -86,6 +86,12 @@ pub struct Ast<'a> {
     /// This is a list of named exports that may exist in a CommonJS module
     /// We use this with `commonjs_at_runtime` to re-export CommonJS
     pub has_commonjs_export_names: bool,
+    /// Export names and re-export specifiers detected lexically in a CommonJS
+    /// module that the runtime will wrap (`bun_js_parser::commonjs_static_exports`
+    /// documents the format). The module loader hands it to `JSCommonJSModule` so
+    /// `import { x } from "./cjs"` links for names the evaluated `module.exports`
+    /// lacks, as in Node.js. Empty for ES modules and when bundling.
+    pub commonjs_static_exports: StoreStr,
     pub has_import_meta: bool,
     pub import_meta_ref: Ref,
 }
@@ -127,6 +133,7 @@ impl<'a> Ast<'a> {
             target: Target::Browser,
             ts_enums: Default::default(),
             has_commonjs_export_names: false,
+            commonjs_static_exports: StoreStr::EMPTY,
             has_import_meta: false,
             import_meta_ref: Ref::NONE,
         }

--- a/src/js_parser/commonjs_static_exports.rs
+++ b/src/js_parser/commonjs_static_exports.rs
@@ -1,0 +1,283 @@
+//! Static detection of CommonJS export names for ESM `import { x } from "./x.cjs"`.
+//!
+//! Node.js decides which named imports a CommonJS module offers by lexing its
+//! source (cjs-module-lexer), so a name that is only assigned conditionally
+//! (`if (dev) exports.debug = ...`) or that was assigned and then replaced
+//! (`exports.a = 1; module.exports = { b }`) still links and imports as
+//! `undefined`. Bun builds the list from the own properties of `module.exports`
+//! after evaluation (`populateESMExports` in JSCommonJSModule.cpp). This pass
+//! collects the same patterns the lexer documents while the runtime transpiler
+//! visits a CommonJS file, and the module loader adds any names that are missing
+//! from the evaluated `module.exports` on top of the runtime ones:
+//!
+//! - `exports.x = ...`, `exports["x"] = ...`, `module.exports.x = ...`
+//! - `module.exports = { x, "y": ..., ...require("./z") }`
+//! - `Object.defineProperty(exports, "x", { value | get })`
+//! - re-exports: `module.exports = require("./z")`, `__exportStar(require("./z"), exports)`,
+//!   `__export(require("./z"))`. Like the lexer, a later `module.exports = ...`
+//!   assignment discards re-exports collected before it.
+//!
+//! Matching is purely lexical (`exports` / `module` by name, whatever they are
+//! bound to, in any scope, reachable or not), exactly like the lexer. The result
+//! travels as one string so it can be stored in the runtime transpiler cache and
+//! handed to C++ without a separate ownership protocol; see [`serialize`] for the
+//! format.
+
+use std::io::Write as _;
+
+use bun_alloc::AstAlloc;
+use bun_collections::StringArrayHashMap;
+use bun_collections::array_hash_map::StringContext;
+use bun_core::strings;
+
+use crate::p::P;
+use bun_ast::{self as js_ast, E, Expr, ExprData, G, StoreStr};
+
+type BumpVec<'a, T> = bun_alloc::ArenaVec<'a, T>;
+
+pub(crate) struct CommonJSStaticExports<'a> {
+    /// Insertion-ordered set; TypeScript output assigns every name twice
+    /// (`exports.x = void 0; ... exports.x = x;`).
+    names: StringArrayHashMap<(), StringContext, AstAlloc>,
+    reexports: BumpVec<'a, &'a [u8]>,
+}
+
+// Entry kind prefixes in the serialized form; JSCommonJSModule.cpp reads them.
+const SERIALIZED_EXPORT_NAME: u8 = b'e';
+const SERIALIZED_REEXPORT: u8 = b'r';
+
+impl<'a> CommonJSStaticExports<'a> {
+    pub(crate) fn new_in(arena: &'a bun_alloc::Arena) -> Self {
+        Self {
+            names: StringArrayHashMap::default(),
+            reexports: BumpVec::new_in(arena),
+        }
+    }
+
+    fn add_name(&mut self, name: &[u8]) {
+        // `default` is always the exports object (or `exports.default` under an
+        // `__esModule` marker) and `__esModule` itself is never a named export;
+        // both are decided from the evaluated object in `populateESMExports`.
+        if name.is_empty() || name == b"default" || name == b"__esModule" {
+            return;
+        }
+        if !self.names.contains(name) {
+            let _ = self.names.put(name, ());
+        }
+    }
+
+    fn add_reexport(&mut self, specifier: &'a [u8]) {
+        if !specifier.is_empty() && !self.reexports.contains(&specifier) {
+            self.reexports.push(specifier);
+        }
+    }
+
+    /// Serializes into `arena` as a sequence of `<kind><utf16 length>:<text>`
+    /// entries, e.g. `e6:alwayse9:debugOnlyr10:./cond.cjs`. The length counts
+    /// UTF-16 code units because the consumer (`JSCommonJSModule`) walks it as a
+    /// `WTF::String`. Returns the empty string when nothing was detected.
+    pub(crate) fn serialize(&self, arena: &'a bun_alloc::Arena) -> StoreStr {
+        if self.names.is_empty() && self.reexports.is_empty() {
+            return StoreStr::EMPTY;
+        }
+
+        let mut out: Vec<u8> = Vec::new();
+        let mut append = |kind: u8, text: &[u8]| {
+            // Names come from identifiers and string literals the lexer already
+            // decoded, so this only rejects a literal that was invalid UTF-8 in
+            // the source; such a name could not be imported anyway.
+            if core::str::from_utf8(text).is_err() {
+                return;
+            }
+            let utf16_len = strings::element_length_utf8_into_utf16(text);
+            out.push(kind);
+            // Writing to a `Vec<u8>` cannot fail.
+            let _ = write!(out, "{utf16_len}:");
+            out.extend_from_slice(text);
+        };
+        for name in self.names.keys() {
+            append(SERIALIZED_EXPORT_NAME, name);
+        }
+        for specifier in self.reexports.iter() {
+            append(SERIALIZED_REEXPORT, specifier);
+        }
+        StoreStr::new(arena.alloc_slice_copy(&out))
+    }
+}
+
+/// Which side of `module.exports` an expression refers to, textually.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ExportsObject {
+    /// `exports`
+    Exports,
+    /// `module.exports` / `module["exports"]`
+    ModuleExports,
+}
+
+impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
+    #[inline]
+    fn collects_commonjs_static_exports(&self) -> bool {
+        self.options.features.commonjs_at_runtime
+    }
+
+    fn identifier_name(&self, expr: &Expr) -> Option<&'a [u8]> {
+        match expr.data {
+            ExprData::EIdentifier(ident) => Some(self.load_name_from_ref(ident.ref_)),
+            _ => None,
+        }
+    }
+
+    fn string_literal(&self, expr: &Expr) -> Option<&'a [u8]> {
+        match expr.data {
+            ExprData::EString(mut str) => Some(str.slice(self.arena)),
+            _ => None,
+        }
+    }
+
+    fn exports_object(&self, expr: &Expr) -> Option<ExportsObject> {
+        let is_module = |target: &Expr| self.identifier_name(target) == Some(b"module");
+        match expr.data {
+            ExprData::EIdentifier(_) => {
+                (self.identifier_name(expr) == Some(b"exports")).then_some(ExportsObject::Exports)
+            }
+            ExprData::EDot(dot) => {
+                (dot.name == b"exports" && is_module(&dot.target)).then_some(ExportsObject::ModuleExports)
+            }
+            ExprData::EIndex(index) => (self.string_literal(&index.index) == Some(b"exports")
+                && is_module(&index.target))
+            .then_some(ExportsObject::ModuleExports),
+            _ => None,
+        }
+    }
+
+    /// `exports.x` / `exports["x"]` / `module.exports.x` / `module.exports["x"]` => `x`
+    fn exports_member_name(&self, expr: &Expr) -> Option<&'a [u8]> {
+        match expr.data {
+            ExprData::EDot(dot) => self.exports_object(&dot.target).map(|_| dot.name.slice()),
+            ExprData::EIndex(index) => {
+                self.exports_object(&index.target)?;
+                self.string_literal(&index.index)
+            }
+            _ => None,
+        }
+    }
+
+    /// `require("x")` => `x`
+    fn require_specifier(&self, expr: &Expr) -> Option<&'a [u8]> {
+        let ExprData::ECall(call) = expr.data else {
+            return None;
+        };
+        if self.identifier_name(&call.target) != Some(b"require") {
+            return None;
+        }
+        match call.args.as_slice() {
+            [specifier] => self.string_literal(specifier),
+            _ => None,
+        }
+    }
+
+    /// Non-computed key of an object literal property, for `{ x }`, `{ x: ... }`,
+    /// `{ "x": ... }`, `{ x() {} }`, `{ get x() {} }`.
+    fn property_key_name(&self, property: &G::Property) -> Option<&'a [u8]> {
+        if property.flags.contains(js_ast::flags::Property::IsComputed) {
+            return None;
+        }
+        match property.kind {
+            G::PropertyKind::Normal | G::PropertyKind::Get | G::PropertyKind::Set => {
+                self.string_literal(&property.key?)
+            }
+            _ => None,
+        }
+    }
+
+    /// Runs before the operands of `left = right` are visited.
+    pub(crate) fn record_commonjs_static_export_assignment(&mut self, left: &Expr, right: &Expr) {
+        if !self.collects_commonjs_static_exports() {
+            return;
+        }
+        if self.exports_object(left) == Some(ExportsObject::ModuleExports) {
+            self.record_commonjs_static_module_exports_value(right);
+        } else if let Some(name) = self.exports_member_name(left) {
+            self.commonjs_static_exports.add_name(name);
+        }
+    }
+
+    /// `module.exports = value` (also TypeScript's `export = value`).
+    pub(crate) fn record_commonjs_static_module_exports_value(&mut self, value: &Expr) {
+        if !self.collects_commonjs_static_exports() {
+            return;
+        }
+        self.commonjs_static_exports.reexports.clear();
+
+        if let Some(specifier) = self.require_specifier(value) {
+            self.commonjs_static_exports.add_reexport(specifier);
+            return;
+        }
+
+        let ExprData::EObject(object) = value.data else {
+            return;
+        };
+        for property in object.properties.iter() {
+            if property.kind == G::PropertyKind::Spread {
+                if let Some(specifier) = property.value.as_ref().and_then(|v| self.require_specifier(v)) {
+                    self.commonjs_static_exports.add_reexport(specifier);
+                }
+            } else if let Some(name) = self.property_key_name(property) {
+                self.commonjs_static_exports.add_name(name);
+            }
+        }
+    }
+
+    /// Runs before the callee and arguments of a call are visited.
+    pub(crate) fn record_commonjs_static_export_call(&mut self, call: &E::Call) {
+        if !self.collects_commonjs_static_exports() {
+            return;
+        }
+        match call.target.data {
+            // Object.defineProperty(exports, "x", { value: ... }) or { get() {...} }
+            ExprData::EDot(dot) => {
+                if dot.name == b"defineProperty" {
+                    if self.identifier_name(&dot.target) == Some(b"Object") {
+                        self.record_commonjs_static_define_property(call.args.as_slice());
+                    }
+                } else if dot.name == b"__exportStar" || dot.name == b"__export" {
+                    self.record_commonjs_static_export_star(call.args.as_slice());
+                }
+            }
+            // __exportStar(require("./x"), exports) (TypeScript), __export(require("./x")) (older TypeScript)
+            ExprData::EIdentifier(_) => {
+                if matches!(self.identifier_name(&call.target), Some(b"__exportStar" | b"__export")) {
+                    self.record_commonjs_static_export_star(call.args.as_slice());
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn record_commonjs_static_define_property(&mut self, args: &[Expr]) {
+        let [target, name, descriptor, ..] = args else {
+            return;
+        };
+        if self.exports_object(target).is_none() {
+            return;
+        }
+        let ExprData::EObject(descriptor) = descriptor.data else {
+            return;
+        };
+        let defines_value_or_getter = descriptor.properties.iter().any(|property| {
+            matches!(self.property_key_name(property), Some(b"value" | b"get"))
+        });
+        if !defines_value_or_getter {
+            return;
+        }
+        if let Some(name) = self.string_literal(name) {
+            self.commonjs_static_exports.add_name(name);
+        }
+    }
+
+    fn record_commonjs_static_export_star(&mut self, args: &[Expr]) {
+        if let Some(specifier) = args.first().and_then(|arg| self.require_specifier(arg)) {
+            self.commonjs_static_exports.add_reexport(specifier);
+        }
+    }
+}

--- a/src/js_parser/commonjs_static_exports.rs
+++ b/src/js_parser/commonjs_static_exports.rs
@@ -1,27 +1,14 @@
-//! Static detection of CommonJS export names for ESM `import { x } from "./x.cjs"`.
+//! The export names Node's cjs-module-lexer would find in a CommonJS file, so that
+//! `import { x } from "./x.cjs"` links (as `undefined`) even when evaluation never
+//! put `x` on `module.exports`. `JSCommonJSModule::toSyntheticSource` unions them
+//! with the evaluated object's own properties.
 //!
-//! Node.js decides which named imports a CommonJS module offers by lexing its
-//! source (cjs-module-lexer), so a name that is only assigned conditionally
-//! (`if (dev) exports.debug = ...`) or that was assigned and then replaced
-//! (`exports.a = 1; module.exports = { b }`) still links and imports as
-//! `undefined`. Bun builds the list from the own properties of `module.exports`
-//! after evaluation (`populateESMExports` in JSCommonJSModule.cpp). This pass
-//! collects the same patterns the lexer documents while the runtime transpiler
-//! visits a CommonJS file, and the module loader adds any names that are missing
-//! from the evaluated `module.exports` on top of the runtime ones:
-//!
-//! - `exports.x = ...`, `exports["x"] = ...`, `module.exports.x = ...`
+//! Detected, lexically (any scope, any binding named `exports` / `module`):
+//! - `exports.x =`, `exports["x"] =`, `module.exports.x =`
 //! - `module.exports = { x, "y": ..., ...require("./z") }`
 //! - `Object.defineProperty(exports, "x", { value | get })`
-//! - re-exports: `module.exports = require("./z")`, `__exportStar(require("./z"), exports)`,
-//!   `__export(require("./z"))`. Like the lexer, a later `module.exports = ...`
-//!   assignment discards re-exports collected before it.
-//!
-//! Matching is purely lexical (`exports` / `module` by name, whatever they are
-//! bound to, in any scope, reachable or not), exactly like the lexer. The result
-//! travels as one string so it can be stored in the runtime transpiler cache and
-//! handed to C++ without a separate ownership protocol; see
-//! `CommonJSStaticExports::serialize` for the format.
+//! - re-exports: `module.exports = require("./z")`, `__exportStar(require("./z"))`,
+//!   `__export(require("./z"))`; a later `module.exports =` discards earlier ones.
 
 use std::io::Write as _;
 
@@ -36,8 +23,6 @@ use bun_ast::{self as js_ast, E, Expr, ExprData, G, StoreStr};
 type BumpVec<'a, T> = bun_alloc::ArenaVec<'a, T>;
 
 pub(crate) struct CommonJSStaticExports<'a> {
-    /// Insertion-ordered set; TypeScript output assigns every name twice
-    /// (`exports.x = void 0; ... exports.x = x;`).
     names: StringArrayHashMap<(), StringContext, AstAlloc>,
     reexports: BumpVec<'a, &'a [u8]>,
 }
@@ -55,15 +40,11 @@ impl<'a> CommonJSStaticExports<'a> {
     }
 
     fn add_name(&mut self, name: &[u8]) {
-        // `default` is always the exports object (or `exports.default` under an
-        // `__esModule` marker) and `__esModule` itself is never a named export;
-        // both are decided from the evaluated object in `populateESMExports`.
+        // `populateESMExports` decides these two from the evaluated object.
         if name.is_empty() || name == b"default" || name == b"__esModule" {
             return;
         }
-        if !self.names.contains(name) {
-            let _ = self.names.put(name, ());
-        }
+        bun_core::handle_oom(self.names.put(name, ()));
     }
 
     fn add_reexport(&mut self, specifier: &'a [u8]) {
@@ -72,10 +53,8 @@ impl<'a> CommonJSStaticExports<'a> {
         }
     }
 
-    /// Serializes into `arena` as a sequence of `<kind><utf16 length>:<text>`
-    /// entries, e.g. `e6:alwayse9:debugOnlyr10:./cond.cjs`. The length counts
-    /// UTF-16 code units because the consumer (`JSCommonJSModule`) walks it as a
-    /// `WTF::String`. Returns the empty string when nothing was detected.
+    /// `<kind><length>:<text>` entries, e.g. `e6:alwayse9:debugOnlyr10:./cond.cjs`;
+    /// lengths are in UTF-16 code units because C++ walks this as a `WTF::String`.
     pub(crate) fn serialize(&self, arena: &'a bun_alloc::Arena) -> StoreStr {
         if self.names.is_empty() && self.reexports.is_empty() {
             return StoreStr::EMPTY;
@@ -83,9 +62,7 @@ impl<'a> CommonJSStaticExports<'a> {
 
         let mut out: Vec<u8> = Vec::new();
         let mut append = |kind: u8, text: &[u8]| {
-            // Names come from identifiers and string literals the lexer already
-            // decoded, so this only rejects a literal that was invalid UTF-8 in
-            // the source; such a name could not be imported anyway.
+            // An invalid name would desynchronize every entry after it.
             if core::str::from_utf8(text).is_err() {
                 return;
             }
@@ -176,8 +153,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// Non-computed key of an object literal property, for `{ x }`, `{ x: ... }`,
-    /// `{ "x": ... }`, `{ x() {} }`, `{ get x() {} }`.
+    /// `{ x }` / `{ x: ... }` / `{ "x": ... }` / `{ x() {} }` / `{ get x() {} }` => `x`
     fn property_key_name(&self, property: &G::Property) -> Option<&'a [u8]> {
         if property.flags.contains(js_ast::flags::Property::IsComputed) {
             return None;

--- a/src/js_parser/commonjs_static_exports.rs
+++ b/src/js_parser/commonjs_static_exports.rs
@@ -20,8 +20,8 @@
 //! Matching is purely lexical (`exports` / `module` by name, whatever they are
 //! bound to, in any scope, reachable or not), exactly like the lexer. The result
 //! travels as one string so it can be stored in the runtime transpiler cache and
-//! handed to C++ without a separate ownership protocol; see [`serialize`] for the
-//! format.
+//! handed to C++ without a separate ownership protocol; see
+//! `CommonJSStaticExports::serialize` for the format.
 
 use std::io::Write as _;
 
@@ -129,7 +129,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     fn string_literal(&self, expr: &Expr) -> Option<&'a [u8]> {
         match expr.data {
-            ExprData::EString(mut str) => Some(str.slice(self.arena)),
+            ExprData::EString(mut string) => Some(string.slice(self.arena)),
             _ => None,
         }
     }

--- a/src/js_parser/commonjs_static_exports.rs
+++ b/src/js_parser/commonjs_static_exports.rs
@@ -1,9 +1,7 @@
-//! The export names Node's cjs-module-lexer would find in a CommonJS file, so that
-//! `import { x } from "./x.cjs"` links (as `undefined`) even when evaluation never
-//! put `x` on `module.exports`. `JSCommonJSModule::toSyntheticSource` unions them
-//! with the evaluated object's own properties.
-//!
-//! Detected, lexically (any scope, any binding named `exports` / `module`):
+//! The export names Node's cjs-module-lexer would find in a CommonJS file.
+//! `JSCommonJSModule::toSyntheticSource` unions them with the evaluated
+//! `module.exports`, so `import { x }` links (as `undefined`) for names evaluation
+//! never produced. Detected lexically, in any scope, whatever `exports`/`module` are bound to:
 //! - `exports.x =`, `exports["x"] =`, `module.exports.x =`
 //! - `module.exports = { x, "y": ..., ...require("./z") }`
 //! - `Object.defineProperty(exports, "x", { value | get })`
@@ -53,8 +51,7 @@ impl<'a> CommonJSStaticExports<'a> {
         }
     }
 
-    /// `<kind><length>:<text>` entries, e.g. `e6:alwayse9:debugOnlyr10:./cond.cjs`;
-    /// lengths are in UTF-16 code units because C++ walks this as a `WTF::String`.
+    /// `e6:alwaysr10:./cond.cjs`: kind, length in UTF-16 units (C++ walks a `WTF::String`), text.
     pub(crate) fn serialize(&self, arena: &'a bun_alloc::Arena) -> StoreStr {
         if self.names.is_empty() && self.reexports.is_empty() {
             return StoreStr::EMPTY;

--- a/src/js_parser/commonjs_static_exports.rs
+++ b/src/js_parser/commonjs_static_exports.rs
@@ -136,18 +136,18 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     fn exports_object(&self, expr: &Expr) -> Option<ExportsObject> {
         let is_module = |target: &Expr| self.identifier_name(target) == Some(b"module");
-        match expr.data {
+        let is_module_exports = match expr.data {
             ExprData::EIdentifier(_) => {
-                (self.identifier_name(expr) == Some(b"exports")).then_some(ExportsObject::Exports)
+                return (self.identifier_name(expr) == Some(b"exports"))
+                    .then_some(ExportsObject::Exports);
             }
-            ExprData::EDot(dot) => {
-                (dot.name == b"exports" && is_module(&dot.target)).then_some(ExportsObject::ModuleExports)
+            ExprData::EDot(dot) => dot.name == b"exports" && is_module(&dot.target),
+            ExprData::EIndex(index) => {
+                self.string_literal(&index.index) == Some(b"exports") && is_module(&index.target)
             }
-            ExprData::EIndex(index) => (self.string_literal(&index.index) == Some(b"exports")
-                && is_module(&index.target))
-            .then_some(ExportsObject::ModuleExports),
-            _ => None,
-        }
+            _ => false,
+        };
+        is_module_exports.then_some(ExportsObject::ModuleExports)
     }
 
     /// `exports.x` / `exports["x"]` / `module.exports.x` / `module.exports["x"]` => `x`
@@ -219,7 +219,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         };
         for property in object.properties.iter() {
             if property.kind == G::PropertyKind::Spread {
-                if let Some(specifier) = property.value.as_ref().and_then(|v| self.require_specifier(v)) {
+                if let Some(specifier) = property
+                    .value
+                    .as_ref()
+                    .and_then(|v| self.require_specifier(v))
+                {
                     self.commonjs_static_exports.add_reexport(specifier);
                 }
             } else if let Some(name) = self.property_key_name(property) {
@@ -246,7 +250,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
             // __exportStar(require("./x"), exports) (TypeScript), __export(require("./x")) (older TypeScript)
             ExprData::EIdentifier(_) => {
-                if matches!(self.identifier_name(&call.target), Some(b"__exportStar" | b"__export")) {
+                if matches!(
+                    self.identifier_name(&call.target),
+                    Some(b"__exportStar" | b"__export")
+                ) {
                     self.record_commonjs_static_export_star(call.args.as_slice());
                 }
             }
@@ -264,9 +271,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let ExprData::EObject(descriptor) = descriptor.data else {
             return;
         };
-        let defines_value_or_getter = descriptor.properties.iter().any(|property| {
-            matches!(self.property_key_name(property), Some(b"value" | b"get"))
-        });
+        let defines_value_or_getter = descriptor
+            .properties
+            .iter()
+            .any(|property| matches!(self.property_key_name(property), Some(b"value" | b"get")));
         if !defines_value_or_getter {
             return;
         }

--- a/src/js_parser/lib.rs
+++ b/src/js_parser/lib.rs
@@ -15,6 +15,7 @@ pub mod parser;
 pub use parser::*;
 pub mod lexer;
 
+pub(crate) mod commonjs_static_exports;
 pub(crate) mod fold;
 pub mod lower;
 pub mod p;

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -293,6 +293,10 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     /// Used by commonjs_at_runtime
     pub(crate) has_commonjs_export_names: bool,
 
+    /// Export names detected lexically for `import { x } from "./cjs"`; see
+    /// `commonjs_static_exports.rs`. Only collected with `commonjs_at_runtime`.
+    pub(crate) commonjs_static_exports: crate::commonjs_static_exports::CommonJSStaticExports<'a>,
+
     pub(crate) stack_check: bun_core::StackCheck,
 
     pub(crate) reported_stack_overflow: core::cell::Cell<bool>,
@@ -8359,6 +8363,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             top_level_await_keyword: self.top_level_await_keyword,
             commonjs_named_exports: core::mem::take(&mut self.commonjs_named_exports),
             has_commonjs_export_names: self.has_commonjs_export_names,
+            commonjs_static_exports: if wrap_mode == WrapMode::BunCommonjs {
+                self.commonjs_static_exports.serialize(arena)
+            } else {
+                bun_ast::StoreStr::EMPTY
+            },
             has_import_meta: self.has_import_meta,
 
             hashbang: hashbang.into(),
@@ -8701,6 +8710,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             commonjs_replacement_stmts: js_ast::StmtNodeList::EMPTY,
             parse_pass_symbol_uses: None,
             has_commonjs_export_names: false,
+            commonjs_static_exports: crate::commonjs_static_exports::CommonJSStaticExports::new_in(
+                arena,
+            ),
             should_fold_typescript_constant_expressions: false,
             emitted_namespace_vars: RefMap::default(),
             is_exported_inside_namespace: Default::default(),

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -293,8 +293,7 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     /// Used by commonjs_at_runtime
     pub(crate) has_commonjs_export_names: bool,
 
-    /// Export names detected lexically for `import { x } from "./cjs"`; see
-    /// `commonjs_static_exports.rs`. Only collected with `commonjs_at_runtime`.
+    /// Only collected with `commonjs_at_runtime`.
     pub(crate) commonjs_static_exports: crate::commonjs_static_exports::CommonJSStaticExports<'a>,
 
     pub(crate) stack_check: bun_core::StackCheck,

--- a/src/js_parser/visit/visit_binary.rs
+++ b/src/js_parser/visit/visit_binary.rs
@@ -749,6 +749,10 @@ impl BinaryExpressionVisitor {
             _ => {}
         }
 
+        if e_.op == Op::Code::BinAssign {
+            p.record_commonjs_static_export_assignment(&e_.left, &e_.right);
+        }
+
         v.left_in = ExprIn {
             assign_target: Op::Code::binary_assign_target(e_.op),
             ..ExprIn::default()

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1836,6 +1836,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn e_call(p: &mut Self, e: &mut Expr, in_: ExprIn) {
         let expr = *e;
         let mut e_ = expr.data.e_call().expect("infallible: variant checked");
+        p.record_commonjs_static_export_call(&e_);
         p.call_target = e_.target.data;
 
         p.then_catch_chain = ThenCatchChain {

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -160,6 +160,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // Evaluate lhs before visiting the rhs
         // (`module_exports` builds via `new_expr`, `visit_expr` mutates parser state).
         let lhs = p.module_exports(stmt.loc);
+        p.record_commonjs_static_module_exports_value(&data.value);
         p.visit_expr(&mut data.value);
         stmts.push(Stmt::assign(lhs, data.value));
         p.record_usage(p.module_ref);

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -7737,9 +7737,7 @@ pub fn print_ast<'a, W: WriterTrait, const ASCII_ONLY: bool, const GENERATE_SOUR
                 .serialize(&mut srlz_res)
                 .map_err(|_| crate::Error::WriteFailed)?;
         }
-        // A CommonJS module has no ESM record; its slot in the cache entry
-        // holds the statically detected export names instead, so a cache hit
-        // links the same named imports as a fresh transpile.
+        // CommonJS entries keep their static export names in the record slot.
         let module_record: &[u8] = if tree.exports_kind == js_ast::ExportsKind::Cjs {
             debug_assert!(!have_module_info);
             tree.commonjs_static_exports.slice()

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -7737,6 +7737,15 @@ pub fn print_ast<'a, W: WriterTrait, const ASCII_ONLY: bool, const GENERATE_SOUR
                 .serialize(&mut srlz_res)
                 .map_err(|_| crate::Error::WriteFailed)?;
         }
+        // A CommonJS module has no ESM record; its slot in the cache entry
+        // holds the statically detected export names instead, so a cache hit
+        // links the same named imports as a fresh transpile.
+        let module_record: &[u8] = if tree.exports_kind == js_ast::ExportsKind::Cjs {
+            debug_assert!(!have_module_info);
+            tree.commonjs_static_exports.slice()
+        } else {
+            &srlz_res
+        };
         // SAFETY: caller guarantees the cache outlives the print call.
         unsafe { &mut *cache.as_ptr() }.put(
             printer.writer.slice(),
@@ -7744,7 +7753,7 @@ pub fn print_ast<'a, W: WriterTrait, const ASCII_ONLY: bool, const GENERATE_SOUR
                 .as_ref()
                 .map(|c| c.buffer.list.as_slice())
                 .unwrap_or(b""),
-            &srlz_res,
+            module_record,
         );
     }
 

--- a/src/jsc/AsyncModule.rs
+++ b/src/jsc/AsyncModule.rs
@@ -1116,6 +1116,8 @@ impl AsyncModule {
         // can `mem::take` instead of cloning.
         let is_commonjs_module = self.parse_result.ast.has_commonjs_export_names
             || self.parse_result.ast.exports_kind == bun_ast::ExportsKind::Cjs;
+        // Backed by `self.arena`, which outlives this fn.
+        let commonjs_static_exports = self.parse_result.ast.commonjs_static_exports;
         let arena = *self.parse_result.ast.parts.allocator();
         let parse_result = core::mem::replace(&mut self.parse_result, ParseResult::empty(arena));
 
@@ -1203,6 +1205,8 @@ impl AsyncModule {
             };
 
             resolved_source.is_commonjs_module = is_commonjs_module;
+            resolved_source.commonjs_static_exports =
+                BunString::clone_utf8(commonjs_static_exports.slice());
 
             return Ok(resolved_source);
         }
@@ -1211,6 +1215,7 @@ impl AsyncModule {
             source_code: BunString::clone_latin1(printer.ctx.get_written()),
             source_url: BunString::from_bytes(path.text),
             is_commonjs_module,
+            commonjs_static_exports: BunString::clone_utf8(commonjs_static_exports.slice()),
             ..Default::default()
         })
     }

--- a/src/jsc/AsyncModule.rs
+++ b/src/jsc/AsyncModule.rs
@@ -1116,7 +1116,6 @@ impl AsyncModule {
         // can `mem::take` instead of cloning.
         let is_commonjs_module = self.parse_result.ast.has_commonjs_export_names
             || self.parse_result.ast.exports_kind == bun_ast::ExportsKind::Cjs;
-        // Backed by `self.arena`, which outlives this fn.
         let commonjs_static_exports = self.parse_result.ast.commonjs_static_exports;
         let arena = *self.parse_result.ast.parts.allocator();
         let parse_result = core::mem::replace(&mut self.parse_result, ParseResult::empty(arena));

--- a/src/jsc/Errorable.rs
+++ b/src/jsc/Errorable.rs
@@ -40,7 +40,7 @@ impl<T> Errorable<T> {
     }
 }
 
-bun_core::assert_ffi_layout!(Errorable<crate::ResolvedSource>, 144, 8);
+bun_core::assert_ffi_layout!(Errorable<crate::ResolvedSource>, 168, 8);
 bun_core::assert_ffi_layout!(Errorable<bun_core::String>, 32, 8);
 
 impl<T> Drop for Errorable<T> {

--- a/src/jsc/ResolvedSource.rs
+++ b/src/jsc/ResolvedSource.rs
@@ -42,6 +42,8 @@ pub struct ResolvedSource {
     /// was used at build time. If empty, the origin is derived from source_url.
     /// This is converted to a file:// URL on the C++ side.
     pub bytecode_origin_path: BunString,
+    /// `Ast.commonjs_static_exports`; `Zig::SourceProvider` / `JSCommonJSModule` take it.
+    pub commonjs_static_exports: BunString,
 }
 
 /// `ResolvedSource.bytecode_cache`: C++ sees `{ uint8_t* ptr; size_t len; bool owned; }`.
@@ -119,4 +121,4 @@ extern "C" fn ResolvedSource__freeBytecode(bytecode: *mut u8) {
     unsafe { bun_alloc::default_alloc::free(bytecode.cast()) };
 }
 
-bun_core::assert_ffi_layout!(ResolvedSource, 136, 8);
+bun_core::assert_ffi_layout!(ResolvedSource, 160, 8);

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -55,7 +55,8 @@ bun_core::declare_scope!(cache, visible);
 /// offsets picked by a header byte) plus a body of tagged records with
 /// u8/u16/u32 ids and implied slots dropped, instead of fixed u32 arrays.
 /// Version 27: ModuleInfo string table holds Latin-1 / UTF-16 bodies, not WTF-8.
-const EXPECTED_VERSION: u32 = 27;
+/// Version 28: CommonJS entries store `Ast.commonjs_static_exports` in the record slot.
+const EXPECTED_VERSION: u32 = 28;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a
@@ -232,6 +233,9 @@ pub struct Entry {
     pub metadata: Metadata,
     pub output_code: BunString,
     pub sourcemap: Box<[u8]>,
+    /// `module_type == Esm`: the serialized `ModuleInfo` (may be empty when the
+    /// entry was written without the isolation cache enabled).
+    /// `module_type == Cjs`: `Ast.commonjs_static_exports`, verbatim.
     pub esm_record: Box<[u8]>,
 }
 

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -965,11 +965,19 @@ impl TranspilerJob {
                 None
             };
 
+            let is_commonjs_module = entry.metadata.module_type == CacheModuleType::Cjs;
+            let commonjs_static_exports = if is_commonjs_module {
+                String::clone_utf8(&entry.esm_record)
+            } else {
+                String::EMPTY
+            };
+
             self.resolved_source = ResolvedSource {
                 source_code: core::mem::take(&mut entry.output_code),
-                is_commonjs_module: entry.metadata.module_type == CacheModuleType::Cjs,
+                is_commonjs_module,
                 module_info,
                 tag: this_tag,
+                commonjs_static_exports,
                 ..Default::default()
             };
 
@@ -1051,6 +1059,8 @@ impl TranspilerJob {
 
         let is_commonjs_module = parse_result.ast.has_commonjs_export_names
             || parse_result.ast.exports_kind == ExportsKind::Cjs;
+        // Arena-backed; read before `print_with_source_map` consumes the AST.
+        let commonjs_static_exports = parse_result.ast.commonjs_static_exports;
         let mut module_info: Option<Box<analyze_transpiled_module::ModuleInfo>> =
             if use_isolation_source_provider_cache
                 && !is_commonjs_module
@@ -1157,6 +1167,7 @@ impl TranspilerJob {
                 mi.into_deserialized()
             }),
             tag: this_tag,
+            commonjs_static_exports: String::clone_utf8(commonjs_static_exports.slice()),
             ..Default::default()
         };
 

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -1059,7 +1059,6 @@ impl TranspilerJob {
 
         let is_commonjs_module = parse_result.ast.has_commonjs_export_names
             || parse_result.ast.exports_kind == ExportsKind::Cjs;
-        // Arena-backed; read before `print_with_source_map` consumes the AST.
         let commonjs_static_exports = parse_result.ast.commonjs_static_exports;
         let mut module_info: Option<Box<analyze_transpiled_module::ModuleInfo>> =
             if use_isolation_source_provider_cache

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -973,7 +973,20 @@ size_t JSCommonJSModule::estimatedSize(JSC::JSCell* cell, JSC::VM& vm)
             additionalSize *= 2;
         }
     }
+    additionalSize += thisObject->m_staticExports.sizeInBytes();
     return Base::estimatedSize(cell, vm) + additionalSize;
+}
+
+void JSCommonJSModule::setSourceMetadata(const Zig::SourceProvider& provider)
+{
+    this->ignoreESModuleAnnotation = provider.ignoreESModuleAnnotation();
+    this->m_staticExports = provider.m_commonJSStaticExports;
+}
+
+void JSCommonJSModule::takeSourceMetadata(ResolvedSource& source)
+{
+    this->ignoreESModuleAnnotation = source.tag == ResolvedSourceTagPackageJSONTypeModule;
+    this->m_staticExports = source.commonjs_static_exports.transferToWTFString();
 }
 
 void JSCommonJSModule::destroy(JSC::JSCell* cell)
@@ -1167,16 +1180,129 @@ void populateESMExports(
     }
 }
 
-void JSCommonJSModule::toSyntheticSource(JSC::JSGlobalObject* globalObject,
+// The CommonJS module `specifier` refers to from `module`, if require() would
+// find it already loaded. Resolution failures are ignored, as in Node.js.
+static JSCommonJSModule* loadedReexportTarget(Zig::GlobalObject* globalObject, JSCommonJSModule* module, const WTF::String& specifier)
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue filenameValue = module->filename();
+    if (!filenameValue || !filenameValue.isString())
+        return nullptr;
+    WTF::String filename = filenameValue.toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+
+    BunString specifierString = Bun::toString(specifier);
+    BunString from = Bun::toString(filename);
+    JSValue resolved = JSValue::decode(Bun__resolveSyncWithStrings(globalObject, &specifierString, &from, false));
+    if (scope.exception()) [[unlikely]] {
+        // A termination stays pending for the caller to notice.
+        (void)scope.tryClearException();
+        return nullptr;
+    }
+    if (!resolved || !resolved.isString())
+        return nullptr;
+
+    JSValue entry = globalObject->requireMap()->get(globalObject, resolved);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    if (!entry)
+        return nullptr;
+    return dynamicDowncast<JSCommonJSModule>(entry);
+}
+
+// Walks `module->m_staticExports` (format: src/js_parser/commonjs_static_exports.rs)
+// and appends every detected name that is not exported yet as `undefined`,
+// following re-exports into modules that were actually loaded.
+static void appendStaticExports(
+    Zig::GlobalObject* globalObject,
+    JSCommonJSModule* module,
+    JSC::IdentifierSet& exported,
+    Vector<JSCommonJSModule*, 4>& visiting,
+    Vector<JSC::Identifier, 4>& exportNames,
+    JSC::MarkedArgumentBuffer& exportValues)
+{
+    if (module->m_staticExports.isEmpty() || visiting.contains(module))
+        return;
+    visiting.append(module);
+
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    // Keep our own reference: resolving a re-export can run plugin code.
+    WTF::String serializedString = module->m_staticExports;
+    StringView serialized = serializedString;
+    size_t i = 0;
+    while (i < serialized.length()) {
+        char16_t kind = serialized[i++];
+        size_t length = 0;
+        size_t digitsStart = i;
+        while (i < serialized.length() && isASCIIDigit(serialized[i])) {
+            length = length * 10 + (serialized[i] - '0');
+            i++;
+            if (length > serialized.length())
+                return;
+        }
+        // Anything unexpected means the rest cannot be trusted either.
+        if (i == digitsStart || i >= serialized.length() || serialized[i] != ':')
+            return;
+        i++;
+        if (length > serialized.length() - i)
+            return;
+        StringView text = serialized.substring(i, length);
+        i += length;
+        if (text.isEmpty())
+            continue;
+
+        switch (kind) {
+        case 'e': {
+            JSC::Identifier name = JSC::Identifier::fromString(vm, text.toString());
+            if (!exported.add(name.impl()).isNewEntry)
+                continue;
+            exportNames.append(WTF::move(name));
+            exportValues.append(jsUndefined());
+            continue;
+        }
+        case 'r': {
+            JSCommonJSModule* target = loadedReexportTarget(globalObject, module, text.toString());
+            RETURN_IF_EXCEPTION(scope, );
+            if (target) {
+                appendStaticExports(globalObject, target, exported, visiting, exportNames, exportValues);
+                RETURN_IF_EXCEPTION(scope, );
+            }
+            continue;
+        }
+        default:
+            return;
+        }
+    }
+}
+
+void JSCommonJSModule::toSyntheticSource(JSC::JSGlobalObject* lexicalGlobalObject,
     const JSC::Identifier& moduleKey,
     Vector<JSC::Identifier, 4>& exportNames,
     JSC::MarkedArgumentBuffer& exportValues)
 {
-    auto scope = DECLARE_THROW_SCOPE(JSC::getVM(globalObject));
+    auto scope = DECLARE_THROW_SCOPE(JSC::getVM(lexicalGlobalObject));
     auto result = this->exportsObject();
     RETURN_IF_EXCEPTION(scope, );
 
-    RELEASE_AND_RETURN(scope, populateESMExports(globalObject, result, exportNames, exportValues, this->ignoreESModuleAnnotation));
+    populateESMExports(lexicalGlobalObject, result, exportNames, exportValues, this->ignoreESModuleAnnotation);
+    RETURN_IF_EXCEPTION(scope, );
+
+    if (this->m_staticExports.isEmpty())
+        return;
+
+    // Node.js links the names cjs-module-lexer finds in the source, so a name
+    // that evaluation did not put on module.exports (assigned conditionally,
+    // or replaced by a later `module.exports = ...`) imports as undefined
+    // instead of failing to link. The evaluated object decides the names it
+    // does have; this only adds what it lacks.
+    JSC::IdentifierSet exported;
+    for (auto& name : exportNames)
+        exported.add(name.impl());
+    Vector<JSCommonJSModule*, 4> visiting;
+    auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
+    RELEASE_AND_RETURN(scope, appendStaticExports(globalObject, this, exported, visiting, exportNames, exportValues));
 }
 
 void JSCommonJSModule::setExportsObject(JSC::JSValue exportsObject)
@@ -1417,7 +1543,7 @@ void JSCommonJSModule::evaluate(
     }
 
     auto sourceProvider = Zig::SourceProvider::create(globalObject, source, JSC::SourceProviderSourceType::Program, isBuiltIn);
-    this->ignoreESModuleAnnotation = source.tag == ResolvedSourceTagPackageJSONTypeModule;
+    this->setSourceMetadata(sourceProvider.get());
     if (!isBuiltIn && !globalObject->hasOverriddenModuleWrapper && Bun::IsolatedModuleCache::canUse(vm, globalObject->bunVM())) {
         Bun::IsolatedModuleCache::insert(vm, key, sourceProvider.get());
     }
@@ -1431,11 +1557,10 @@ void JSCommonJSModule::evaluate(
 
 void JSCommonJSModule::evaluate(
     Zig::GlobalObject* globalObject,
-    Ref<JSC::SourceProvider>&& sourceProvider,
-    bool ignoreESModuleAnnotation)
+    Ref<Zig::SourceProvider>&& sourceProvider)
 {
     auto& vm = JSC::getVM(globalObject);
-    this->ignoreESModuleAnnotation = ignoreESModuleAnnotation;
+    this->setSourceMetadata(sourceProvider.get());
     if (this->hasEvaluated)
         return;
     this->sourceCode = JSC::SourceCode(WTF::move(sourceProvider));
@@ -1460,6 +1585,7 @@ void JSCommonJSModule::evaluateWithPotentiallyOverriddenCompile(
             throwTypeError(globalObject, scope, "overridden module._compile is not a function (called from overridden Module._extensions)"_s);
             return;
         }
+        this->m_staticExports = source.commonjs_static_exports.transferToWTFString();
         WTF::String sourceString = source.source_code.transferToWTFString();
         // Remove the wrapper from the source string, since the transpiler has added it.
         auto trimStart = sourceString.find('\n');
@@ -1499,7 +1625,6 @@ std::optional<JSC::SourceCode> createCommonJSModule(
 
     JSValue entry = globalObject->requireMap()->get(globalObject, requireMapKey);
     RETURN_IF_EXCEPTION(scope, {});
-    bool ignoreESModuleAnnotation = source.tag == ResolvedSourceTagPackageJSONTypeModule;
     SourceOrigin sourceOrigin;
 
     if (entry) {
@@ -1534,10 +1659,13 @@ std::optional<JSC::SourceCode> createCommonJSModule(
             Bun::IsolatedModuleCache::insert(vm, sourceURL, sourceProvider.get());
         }
         sourceOrigin = sourceProvider->sourceOrigin();
+        // Stays alive past the move below: the module's SourceCode holds it.
+        Zig::SourceProvider& provider = sourceProvider.get();
         moduleObject = JSCommonJSModule::create(
             vm,
             globalObject->CommonJSModuleObjectStructure(),
             requireMapKey, filename, dirname, JSC::SourceCode(WTF::move(sourceProvider)));
+        moduleObject->setSourceMetadata(provider);
 
         moduleObject->putDirect(vm,
             WebCore::clientData(vm)->builtinNames().exportsPublicName(),
@@ -1546,10 +1674,11 @@ std::optional<JSC::SourceCode> createCommonJSModule(
         requireMap->set(globalObject, filename, moduleObject);
         RETURN_IF_EXCEPTION(scope, {});
     } else {
+        // Typically require()d first and imported afterwards; the import path
+        // transpiled it again, so apply the fresh metadata without a provider.
         sourceOrigin = Zig::toSourceOrigin(sourceURL, isBuiltIn);
+        moduleObject->takeSourceMetadata(source);
     }
-
-    moduleObject->ignoreESModuleAnnotation = ignoreESModuleAnnotation;
 
     return commonJSModuleSyntheticSourceCode(sourceOrigin, sourceURL);
 }
@@ -1608,14 +1737,16 @@ static JSC::SourceCode commonJSModuleSyntheticSourceCode(const SourceOrigin& sou
 std::optional<JSC::SourceCode> createCommonJSModule(
     Zig::GlobalObject* globalObject,
     JSC::JSString* requireMapKey,
-    Ref<JSC::SourceProvider>&& sourceProvider,
-    bool ignoreESModuleAnnotation)
+    Ref<Zig::SourceProvider>&& sourceProvider)
 {
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSCommonJSModule* moduleObject = nullptr;
-    WTF::String sourceURL = sourceProvider->sourceURL();
-    SourceOrigin sourceOrigin = sourceProvider->sourceOrigin();
+    // Valid for the whole function: either `sourceProvider` still owns it or the
+    // new module's SourceCode does.
+    Zig::SourceProvider& provider = sourceProvider.get();
+    WTF::String sourceURL = provider.sourceURL();
+    SourceOrigin sourceOrigin = provider.sourceOrigin();
 
     JSValue entry = globalObject->requireMap()->get(globalObject, requireMapKey);
     RETURN_IF_EXCEPTION(scope, {});
@@ -1652,7 +1783,7 @@ std::optional<JSC::SourceCode> createCommonJSModule(
         RETURN_IF_EXCEPTION(scope, {});
     }
 
-    moduleObject->ignoreESModuleAnnotation = ignoreESModuleAnnotation;
+    moduleObject->setSourceMetadata(provider);
 
     return commonJSModuleSyntheticSourceCode(sourceOrigin, sourceURL);
 }

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -1180,8 +1180,7 @@ void populateESMExports(
     }
 }
 
-// The CommonJS module `specifier` refers to from `module`, if require() would
-// find it already loaded. Resolution failures are ignored, as in Node.js.
+// What require(specifier) inside `module` resolved to, if it is a loaded CommonJS module.
 static JSCommonJSModule* loadedReexportTarget(Zig::GlobalObject* globalObject, JSCommonJSModule* module, const WTF::String& specifier)
 {
     auto& vm = JSC::getVM(globalObject);
@@ -1211,9 +1210,7 @@ static JSCommonJSModule* loadedReexportTarget(Zig::GlobalObject* globalObject, J
     return dynamicDowncast<JSCommonJSModule>(entry);
 }
 
-// Walks `module->m_staticExports` (format: src/js_parser/commonjs_static_exports.rs)
-// and appends every detected name that is not exported yet as `undefined`,
-// following re-exports into modules that were actually loaded.
+// Decodes m_staticExports (format: src/js_parser/commonjs_static_exports.rs).
 static void appendStaticExports(
     Zig::GlobalObject* globalObject,
     JSCommonJSModule* module,
@@ -1292,11 +1289,7 @@ void JSCommonJSModule::toSyntheticSource(JSC::JSGlobalObject* lexicalGlobalObjec
     if (this->m_staticExports.isEmpty())
         return;
 
-    // Node.js links the names cjs-module-lexer finds in the source, so a name
-    // that evaluation did not put on module.exports (assigned conditionally,
-    // or replaced by a later `module.exports = ...`) imports as undefined
-    // instead of failing to link. The evaluated object decides the names it
-    // does have; this only adds what it lacks.
+    // Like Node.js, names found in the source but not on the evaluated object link as undefined.
     JSC::IdentifierSet exported;
     for (auto& name : exportNames)
         exported.add(name.impl());
@@ -1557,13 +1550,13 @@ void JSCommonJSModule::evaluate(
 
 void JSCommonJSModule::evaluate(
     Zig::GlobalObject* globalObject,
-    Ref<Zig::SourceProvider>&& sourceProvider)
+    Zig::SourceProvider& sourceProvider)
 {
     auto& vm = JSC::getVM(globalObject);
-    this->setSourceMetadata(sourceProvider.get());
+    this->setSourceMetadata(sourceProvider);
     if (this->hasEvaluated)
         return;
-    this->sourceCode = JSC::SourceCode(WTF::move(sourceProvider));
+    this->sourceCode = JSC::SourceCode(Ref(sourceProvider));
     evaluateCommonJSModuleOnce(vm, globalObject, this, this->m_dirname.get(), this->m_filename.get());
 }
 
@@ -1659,13 +1652,11 @@ std::optional<JSC::SourceCode> createCommonJSModule(
             Bun::IsolatedModuleCache::insert(vm, sourceURL, sourceProvider.get());
         }
         sourceOrigin = sourceProvider->sourceOrigin();
-        // Stays alive past the move below: the module's SourceCode holds it.
-        Zig::SourceProvider& provider = sourceProvider.get();
         moduleObject = JSCommonJSModule::create(
             vm,
             globalObject->CommonJSModuleObjectStructure(),
-            requireMapKey, filename, dirname, JSC::SourceCode(WTF::move(sourceProvider)));
-        moduleObject->setSourceMetadata(provider);
+            requireMapKey, filename, dirname, JSC::SourceCode(sourceProvider.copyRef()));
+        moduleObject->setSourceMetadata(sourceProvider.get());
 
         moduleObject->putDirect(vm,
             WebCore::clientData(vm)->builtinNames().exportsPublicName(),
@@ -1674,8 +1665,6 @@ std::optional<JSC::SourceCode> createCommonJSModule(
         requireMap->set(globalObject, filename, moduleObject);
         RETURN_IF_EXCEPTION(scope, {});
     } else {
-        // Typically require()d first and imported afterwards; the import path
-        // transpiled it again, so apply the fresh metadata without a provider.
         sourceOrigin = Zig::toSourceOrigin(sourceURL, isBuiltIn);
         moduleObject->takeSourceMetadata(source);
     }
@@ -1737,16 +1726,13 @@ static JSC::SourceCode commonJSModuleSyntheticSourceCode(const SourceOrigin& sou
 std::optional<JSC::SourceCode> createCommonJSModule(
     Zig::GlobalObject* globalObject,
     JSC::JSString* requireMapKey,
-    Ref<Zig::SourceProvider>&& sourceProvider)
+    Zig::SourceProvider& sourceProvider)
 {
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSCommonJSModule* moduleObject = nullptr;
-    // Valid for the whole function: either `sourceProvider` still owns it or the
-    // new module's SourceCode does.
-    Zig::SourceProvider& provider = sourceProvider.get();
-    WTF::String sourceURL = provider.sourceURL();
-    SourceOrigin sourceOrigin = provider.sourceOrigin();
+    WTF::String sourceURL = sourceProvider.sourceURL();
+    SourceOrigin sourceOrigin = sourceProvider.sourceOrigin();
 
     JSValue entry = globalObject->requireMap()->get(globalObject, requireMapKey);
     RETURN_IF_EXCEPTION(scope, {});
@@ -1773,7 +1759,7 @@ std::optional<JSC::SourceCode> createCommonJSModule(
         moduleObject = JSCommonJSModule::create(
             vm,
             globalObject->CommonJSModuleObjectStructure(),
-            requireMapKey, filename, dirname, JSC::SourceCode(WTF::move(sourceProvider)));
+            requireMapKey, filename, dirname, JSC::SourceCode(Ref(sourceProvider)));
 
         moduleObject->putDirect(vm,
             WebCore::clientData(vm)->builtinNames().exportsPublicName(),
@@ -1783,7 +1769,7 @@ std::optional<JSC::SourceCode> createCommonJSModule(
         RETURN_IF_EXCEPTION(scope, {});
     }
 
-    moduleObject->setSourceMetadata(provider);
+    moduleObject->setSourceMetadata(sourceProvider);
 
     return commonJSModuleSyntheticSourceCode(sourceOrigin, sourceURL);
 }

--- a/src/jsc/bindings/JSCommonJSModule.h
+++ b/src/jsc/bindings/JSCommonJSModule.h
@@ -77,9 +77,7 @@ public:
     mutable JSC::WriteBarrier<Unknown> m_overriddenCompile;
 
     bool ignoreESModuleAnnotation { false };
-    // Export names the transpiler detected in the source (ResolvedSource::
-    // commonjs_static_exports), still serialized; only decoded when the module
-    // is imported from ESM. Empty unless the module came from the transpiler.
+    // ResolvedSource::commonjs_static_exports, decoded by toSyntheticSource.
     WTF::String m_staticExports;
     JSC::SourceCode sourceCode = JSC::SourceCode();
 
@@ -93,13 +91,12 @@ public:
     static JSC::Structure* createStructure(JSC::JSGlobalObject* globalObject);
 
     void evaluate(Zig::GlobalObject* globalObject, const WTF::String& sourceURL, ResolvedSource& resolvedSource, bool isBuiltIn);
-    // For a provider served by IsolatedModuleCache; the module's metadata comes from the provider's ResolvedSource.
-    void evaluate(Zig::GlobalObject* globalObject, Ref<Zig::SourceProvider>&& sourceProvider);
+    // Provider served by IsolatedModuleCache.
+    void evaluate(Zig::GlobalObject* globalObject, Zig::SourceProvider&);
 
-    // What the loader learned while transpiling this module: whether the __esModule
-    // annotation is honored and which export names were detected statically.
+    // ignoreESModuleAnnotation and m_staticExports, from the source's ResolvedSource.
     void setSourceMetadata(const Zig::SourceProvider&);
-    // Same, from a ResolvedSource no provider was created for; takes ownership of its commonjs_static_exports.
+    // Same, taking commonjs_static_exports out of a ResolvedSource that gets no provider.
     void takeSourceMetadata(ResolvedSource&);
     void evaluateWithPotentiallyOverriddenCompile(Zig::GlobalObject* globalObject, const WTF::String& sourceURL, JSValue keyJSString, ResolvedSource& resolvedSource);
     inline void evaluate(Zig::GlobalObject* globalObject, const WTF::String& sourceURL, ResolvedSource& resolvedSource)
@@ -171,11 +168,11 @@ std::optional<JSC::SourceCode> createCommonJSModule(
     ResolvedSource& source,
     bool isBuiltIn);
 
-// For a provider served by IsolatedModuleCache; the module's metadata comes from the provider's ResolvedSource.
+// Provider served by IsolatedModuleCache.
 std::optional<JSC::SourceCode> createCommonJSModule(
     Zig::GlobalObject* globalObject,
     JSC::JSString* specifierValue,
-    Ref<Zig::SourceProvider>&& provider);
+    Zig::SourceProvider& provider);
 
 inline std::optional<JSC::SourceCode> createCommonJSModule(
     Zig::GlobalObject* globalObject,

--- a/src/jsc/bindings/JSCommonJSModule.h
+++ b/src/jsc/bindings/JSCommonJSModule.h
@@ -9,6 +9,7 @@
 
 namespace Zig {
 class GlobalObject;
+class SourceProvider;
 }
 namespace JSC {
 class SourceCode;
@@ -76,6 +77,10 @@ public:
     mutable JSC::WriteBarrier<Unknown> m_overriddenCompile;
 
     bool ignoreESModuleAnnotation { false };
+    // Export names the transpiler detected in the source (ResolvedSource::
+    // commonjs_static_exports), still serialized; only decoded when the module
+    // is imported from ESM. Empty unless the module came from the transpiler.
+    WTF::String m_staticExports;
     JSC::SourceCode sourceCode = JSC::SourceCode();
 
     static size_t estimatedSize(JSC::JSCell* cell, JSC::VM& vm);
@@ -88,7 +93,14 @@ public:
     static JSC::Structure* createStructure(JSC::JSGlobalObject* globalObject);
 
     void evaluate(Zig::GlobalObject* globalObject, const WTF::String& sourceURL, ResolvedSource& resolvedSource, bool isBuiltIn);
-    void evaluate(Zig::GlobalObject* globalObject, Ref<JSC::SourceProvider>&& sourceProvider, bool ignoreESModuleAnnotation);
+    // For a provider served by IsolatedModuleCache; the module's metadata comes from the provider's ResolvedSource.
+    void evaluate(Zig::GlobalObject* globalObject, Ref<Zig::SourceProvider>&& sourceProvider);
+
+    // What the loader learned while transpiling this module: whether the __esModule
+    // annotation is honored and which export names were detected statically.
+    void setSourceMetadata(const Zig::SourceProvider&);
+    // Same, from a ResolvedSource no provider was created for; takes ownership of its commonjs_static_exports.
+    void takeSourceMetadata(ResolvedSource&);
     void evaluateWithPotentiallyOverriddenCompile(Zig::GlobalObject* globalObject, const WTF::String& sourceURL, JSValue keyJSString, ResolvedSource& resolvedSource);
     inline void evaluate(Zig::GlobalObject* globalObject, const WTF::String& sourceURL, ResolvedSource& resolvedSource)
     {
@@ -159,11 +171,11 @@ std::optional<JSC::SourceCode> createCommonJSModule(
     ResolvedSource& source,
     bool isBuiltIn);
 
+// For a provider served by IsolatedModuleCache; the module's metadata comes from the provider's ResolvedSource.
 std::optional<JSC::SourceCode> createCommonJSModule(
     Zig::GlobalObject* globalObject,
     JSC::JSString* specifierValue,
-    Ref<JSC::SourceProvider>&& provider,
-    bool ignoreESModuleAnnotation);
+    Ref<Zig::SourceProvider>&& provider);
 
 inline std::optional<JSC::SourceCode> createCommonJSModule(
     Zig::GlobalObject* globalObject,

--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -784,7 +784,7 @@ JSValue fetchCommonJSModule(
                 // The wrapper override only affects CJS evaluation; if it's
                 // active, fall through and re-transpile so the override can run.
                 if (!globalObject->hasOverriddenModuleWrapper) {
-                    target->evaluate(globalObject, Ref(*cached));
+                    target->evaluate(globalObject, *cached);
                     RETURN_IF_EXCEPTION(scope, {});
                     RELEASE_AND_RETURN(scope, target);
                 }
@@ -1089,7 +1089,7 @@ static JSValue fetchESMSourceCode(
             // affects CJS evaluation, so don't serve a cached Program-type provider
             // when one is active in this global — fall through to re-transpile.
             if (!globalObject->hasOverriddenModuleWrapper) {
-                auto created = Bun::createCommonJSModule(globalObject, specifierJS, Ref(*cached));
+                auto created = Bun::createCommonJSModule(globalObject, specifierJS, *cached);
                 EXCEPTION_ASSERT(created.has_value() == !scope.exception());
                 if (created.has_value()) {
                     RELEASE_AND_RETURN(scope, rejectOrResolve(JSSourceCode::create(vm, WTF::move(created.value()))));

--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -784,7 +784,7 @@ JSValue fetchCommonJSModule(
                 // The wrapper override only affects CJS evaluation; if it's
                 // active, fall through and re-transpile so the override can run.
                 if (!globalObject->hasOverriddenModuleWrapper) {
-                    target->evaluate(globalObject, Ref(*cached), cached->m_tag == ResolvedSourceTagPackageJSONTypeModule);
+                    target->evaluate(globalObject, Ref(*cached));
                     RETURN_IF_EXCEPTION(scope, {});
                     RELEASE_AND_RETURN(scope, target);
                 }
@@ -1089,7 +1089,7 @@ static JSValue fetchESMSourceCode(
             // affects CJS evaluation, so don't serve a cached Program-type provider
             // when one is active in this global — fall through to re-transpile.
             if (!globalObject->hasOverriddenModuleWrapper) {
-                auto created = Bun::createCommonJSModule(globalObject, specifierJS, Ref(*cached), cached->m_tag == ResolvedSourceTagPackageJSONTypeModule);
+                auto created = Bun::createCommonJSModule(globalObject, specifierJS, Ref(*cached));
                 EXCEPTION_ASSERT(created.has_value() == !scope.exception());
                 if (created.has_value()) {
                     RELEASE_AND_RETURN(scope, rejectOrResolve(JSSourceCode::create(vm, WTF::move(created.value()))));

--- a/src/jsc/bindings/ZigSourceProvider.h
+++ b/src/jsc/bindings/ZigSourceProvider.h
@@ -49,6 +49,13 @@ public:
     bun_ModuleInfoDeserialized* m_moduleInfo { nullptr };
     uint32_t m_tag { 0 };
     bool m_alreadyBundled { false };
+    // ResolvedSource::commonjs_static_exports, taken at create().
+    WTF::String m_commonJSStaticExports;
+
+    bool ignoreESModuleAnnotation() const
+    {
+        return m_tag == ResolvedSourceTagPackageJSONTypeModule;
+    }
 
 private:
     SourceProvider(void* bunVM, ResolvedSource& resolvedSource, Ref<WTF::StringImpl>&& sourceImpl,
@@ -59,6 +66,7 @@ private:
         , m_moduleInfo(std::exchange(resolvedSource.module_info, nullptr))
         , m_tag(resolvedSource.tag)
         , m_alreadyBundled(resolvedSource.already_bundled)
+        , m_commonJSStaticExports(resolvedSource.commonjs_static_exports.transferToWTFString())
         , m_bunVM(bunVM)
         , m_source(WTF::move(sourceImpl))
     {

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -140,8 +140,10 @@ typedef struct ResolvedSource {
     // File path used as source origin for bytecode cache validation.
     // Converted to file:// URL. If empty, origin is derived from source_url.
     BunString bytecode_origin_path;
+    // See ResolvedSource.rs. Whoever takes it leaves the field empty.
+    BunString commonjs_static_exports;
 } ResolvedSource;
-static_assert(sizeof(ResolvedSource) == 136, "ResolvedSource layout is mirrored in src/jsc/ResolvedSource.rs");
+static_assert(sizeof(ResolvedSource) == 160, "ResolvedSource layout is mirrored in src/jsc/ResolvedSource.rs");
 inline constexpr uint32_t ResolvedSourceTagPackageJSONTypeModule = 1;
 typedef union ErrorableResolvedSourceResult {
     ResolvedSource value;
@@ -164,13 +166,14 @@ public:
         result.value.source_code.deref();
         result.value.source_url.deref();
         result.value.bytecode_origin_path.deref();
+        result.value.commonjs_static_exports.deref();
         if (result.value.bytecode_cache_owned && result.value.bytecode_cache)
             ResolvedSource__freeBytecode(result.value.bytecode_cache);
         if (result.value.module_info)
             zig__ModuleInfoDeserialized__deinit(result.value.module_info);
     }
 };
-static_assert(sizeof(ErrorableResolvedSource) == 144 && alignof(ErrorableResolvedSource) == 8, "ErrorableResolvedSource layout is mirrored in src/jsc/Errorable.rs");
+static_assert(sizeof(ErrorableResolvedSource) == 168 && alignof(ErrorableResolvedSource) == 8, "ErrorableResolvedSource layout is mirrored in src/jsc/Errorable.rs");
 
 typedef struct SystemError {
     int errno_;

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -3058,8 +3058,6 @@ fn transpile_source_code_inner(
 
                 let is_commonjs_module = parse_result.ast.has_commonjs_export_names
                     || parse_result.ast.exports_kind == bun_ast::ExportsKind::Cjs;
-                // Arena-backed (the arena outlives this fn); read before
-                // `print_with_source_map` consumes the AST.
                 let commonjs_static_exports = parse_result.ast.commonjs_static_exports;
                 // Collect the ESM record while printing, for the isolation
                 // source-provider cache (same shape as `RuntimeTranspilerStore`).

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2918,6 +2918,11 @@ fn transpile_source_code_inner(
                         None
                     };
                     let is_commonjs_module = entry.metadata.module_type == CacheModuleType::Cjs;
+                    let commonjs_static_exports = if is_commonjs_module {
+                        bun_core::String::clone_utf8(&entry.esm_record)
+                    } else {
+                        bun_core::String::EMPTY
+                    };
                     // Node compile cache hook (transpiler-cache-hit path); must
                     // read `output_code` before it is consumed below. UTF-16
                     // output would hash differently than the print path — skip.
@@ -2992,6 +2997,7 @@ fn transpile_source_code_inner(
                         module_info,
                         tag,
                         bytecode_cache: node_compile_cache_blob.unwrap_or_default(),
+                        commonjs_static_exports,
                         ..Default::default()
                     });
                 }
@@ -3052,6 +3058,9 @@ fn transpile_source_code_inner(
 
                 let is_commonjs_module = parse_result.ast.has_commonjs_export_names
                     || parse_result.ast.exports_kind == bun_ast::ExportsKind::Cjs;
+                // Arena-backed (the arena outlives this fn); read before
+                // `print_with_source_map` consumes the AST.
+                let commonjs_static_exports = parse_result.ast.commonjs_static_exports;
                 // Collect the ESM record while printing, for the isolation
                 // source-provider cache (same shape as `RuntimeTranspilerStore`).
                 // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
@@ -3182,6 +3191,8 @@ fn transpile_source_code_inner(
                     resolved_source.is_commonjs_module = is_commonjs_module;
                     resolved_source.module_info = module_info;
                     resolved_source.bytecode_cache = node_compile_cache_blob.unwrap_or_default();
+                    resolved_source.commonjs_static_exports =
+                        bun_core::String::clone_utf8(commonjs_static_exports.slice());
                     return Ok(resolved_source);
                 }
 
@@ -3280,6 +3291,9 @@ fn transpile_source_code_inner(
                     module_info,
                     tag,
                     bytecode_cache: node_compile_cache_blob.unwrap_or_default(),
+                    commonjs_static_exports: bun_core::String::clone_utf8(
+                        commonjs_static_exports.slice(),
+                    ),
                     ..Default::default()
                 });
             }

--- a/test/js/bun/resolve/cjs-static-exports.test.ts
+++ b/test/js/bun/resolve/cjs-static-exports.test.ts
@@ -204,10 +204,11 @@ test.concurrent("a later module.exports assignment discards earlier re-exports, 
   const result = await runJSON({
     "prod.cjs": `exports.shared = "prod"; if (${NEVER}) exports.prodOnly = 1;`,
     "dev.cjs": `exports.shared = "dev"; if (${NEVER}) exports.devOnly = 1;`,
+    // prod.cjs is loaded too, so only the discard rule keeps prodOnly out.
     "mod.cjs": `
       if (${NEVER}) module.exports = require("./prod.cjs");
       else module.exports = require("./dev.cjs");
-      if (${NEVER}) require("./prod.cjs");
+      require("./prod.cjs");
     `,
     "entry.mjs": `
       import { shared, devOnly } from "./mod.cjs";
@@ -221,11 +222,12 @@ test.concurrent("a later module.exports assignment discards earlier re-exports, 
 test.concurrent("re-exports that cannot be resolved or were never loaded are skipped", async () => {
   const result = await runJSON({
     "never-loaded.cjs": `exports.neverLoaded = 1;`,
+    // The __exportStar comes after the module.exports assignment so both re-exports survive.
     "mod.cjs": `
       exports.ok = 1;
       if (${NEVER}) exports.okMaybe = 1;
-      if (${NEVER}) module.exports = require("./does-not-exist.cjs");
       if (${NEVER}) module.exports = require("./never-loaded.cjs");
+      if (${NEVER}) __exportStar(require("./does-not-exist.cjs"), exports);
     `,
     "entry.mjs": `
       import { ok, okMaybe } from "./mod.cjs";

--- a/test/js/bun/resolve/cjs-static-exports.test.ts
+++ b/test/js/bun/resolve/cjs-static-exports.test.ts
@@ -1,0 +1,364 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+
+// `import { x } from "./file.cjs"` links the names Node's cjs-module-lexer would
+// find in the source (exports.x = ..., module.exports = { x }, re-exports, ...)
+// in addition to the own properties of the evaluated `module.exports`. A name
+// that evaluation never produced imports as `undefined` instead of throwing
+// "Export named 'x' not found" at link time, matching Node.
+//
+// Every fixture gates some assignments on an environment variable that is never
+// set, so the evaluated module.exports lacks those names.
+const NEVER = "process.env.CJS_STATIC_EXPORTS_TEST_NEVER_SET";
+
+async function runEntry(cwd: string, env: Record<string, string> = {}) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.mjs"],
+    cwd,
+    env: { ...bunEnv, ...env },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+async function runJSON(files: Record<string, string>) {
+  using dir = tempDir("cjs-static-exports", files);
+  const { stdout, stderr, exitCode } = await runEntry(String(dir));
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+  return JSON.parse(stdout);
+}
+
+test.concurrent("exports.x assigned conditionally or in dead code still links", async () => {
+  const result = await runJSON({
+    "cond.cjs": `
+      exports.always = 1;
+      if (${NEVER}) exports.debugOnly = function debugOnly() {};
+      if (typeof window !== "undefined") exports.browserOnly = 1;
+      function neverCalled() { exports.neverAssigned = 1; }
+    `,
+    "entry.mjs": `
+      import { always, debugOnly, browserOnly, neverAssigned } from "./cond.cjs";
+      import * as ns from "./cond.cjs";
+      console.log(JSON.stringify({
+        always,
+        debugOnly: typeof debugOnly,
+        browserOnly: typeof browserOnly,
+        neverAssigned: typeof neverAssigned,
+        keys: Object.keys(ns),
+        hasDebugOnly: "debugOnly" in ns,
+        defaultKeys: Object.keys(ns.default),
+      }));
+    `,
+  });
+  expect(result).toEqual({
+    always: 1,
+    debugOnly: "undefined",
+    browserOnly: "undefined",
+    neverAssigned: "undefined",
+    keys: ["always", "browserOnly", "debugOnly", "default", "neverAssigned"],
+    hasDebugOnly: true,
+    // require() and the default import see the real object, untouched.
+    defaultKeys: ["always"],
+  });
+});
+
+test.concurrent("a name removed by a later module.exports = {...} still links", async () => {
+  const result = await runJSON({
+    "shapes.cjs": `exports.a = 1; module.exports = { b: 2 };`,
+    "entry.mjs": `
+      import { a, b } from "./shapes.cjs";
+      import * as ns from "./shapes.cjs";
+      console.log(JSON.stringify({ a: typeof a, b, keys: Object.keys(ns) }));
+    `,
+  });
+  expect(result).toEqual({ a: "undefined", b: 2, keys: ["a", "b", "default"] });
+});
+
+test.concurrent("evaluated values win; names only known at runtime are kept", async () => {
+  const result = await runJSON({
+    // TypeScript output declares every export before assigning it.
+    "mod.cjs": `
+      exports.declared = void 0;
+      exports.declared = "assigned";
+      exports["computed" + ""] = "runtime only";
+      if (${NEVER}) exports.missing = 1;
+    `,
+    "entry.mjs": `
+      import { declared, computed, missing } from "./mod.cjs";
+      import * as ns from "./mod.cjs";
+      console.log(JSON.stringify({ declared, computed, missing: typeof missing, keys: Object.keys(ns) }));
+    `,
+  });
+  expect(result).toEqual({
+    declared: "assigned",
+    computed: "runtime only",
+    missing: "undefined",
+    keys: ["computed", "declared", "default", "missing"],
+  });
+});
+
+test.concurrent("exports['string-key'] and Object.defineProperty are detected", async () => {
+  const result = await runJSON({
+    "mod.cjs": `
+      exports["kebab-case"] = 1;
+      if (${NEVER}) exports["maybe-kebab"] = 2;
+      if (${NEVER}) Object.defineProperty(exports, "definedValue", { value: 3 });
+      if (${NEVER}) Object.defineProperty(exports, "definedGetter", { enumerable: true, get: function () { return exports.x; } });
+      Object.defineProperty(exports, "setterOnly", { set(v) {} });
+      Object.defineProperty(exports, "present", { enumerable: true, get: function () { return 4; } });
+    `,
+    "entry.mjs": `
+      import { "kebab-case" as kebab, "maybe-kebab" as maybeKebab, definedValue, definedGetter, present } from "./mod.cjs";
+      import * as ns from "./mod.cjs";
+      console.log(JSON.stringify({
+        kebab,
+        maybeKebab: typeof maybeKebab,
+        definedValue: typeof definedValue,
+        definedGetter: typeof definedGetter,
+        present,
+        keys: Object.keys(ns),
+      }));
+    `,
+  });
+  expect(result).toEqual({
+    kebab: 1,
+    maybeKebab: "undefined",
+    definedValue: "undefined",
+    definedGetter: "undefined",
+    present: 4,
+    keys: ["default", "definedGetter", "definedValue", "kebab-case", "maybe-kebab", "present"],
+  });
+});
+
+test.concurrent("module.exports = { ... } contributes its keys and spread require()s", async () => {
+  const result = await runJSON({
+    "leaf.cjs": `exports.leaf = "leaf"; if (${NEVER}) exports.leafMaybe = 1;`,
+    // leaf.cjs is loaded (re-exports are only followed into loaded modules),
+    // but nothing from the object literal ever reaches module.exports.
+    "mod.cjs": `
+      const helper = () => {};
+      require("./leaf.cjs");
+      if (${NEVER}) module.exports = { helper, "quoted": helper, ...require("./leaf.cjs") };
+      module.exports.actual = true;
+    `,
+    "entry.mjs": `
+      import { helper, quoted, leaf, leafMaybe, actual } from "./mod.cjs";
+      import * as ns from "./mod.cjs";
+      console.log(JSON.stringify({
+        helper: typeof helper,
+        quoted: typeof quoted,
+        leaf: typeof leaf,
+        leafMaybe: typeof leafMaybe,
+        actual,
+        keys: Object.keys(ns),
+      }));
+    `,
+  });
+  expect(result).toEqual({
+    helper: "undefined",
+    quoted: "undefined",
+    leaf: "undefined",
+    leafMaybe: "undefined",
+    actual: true,
+    keys: ["actual", "default", "helper", "leaf", "leafMaybe", "quoted"],
+  });
+});
+
+test.concurrent("names flow through module.exports = require() and __exportStar()", async () => {
+  const result = await runJSON({
+    "cond.cjs": `exports.always = 1; if (${NEVER}) exports.debugOnly = 1;`,
+    "reexport.cjs": `module.exports = require("./cond.cjs");`,
+    "star.cjs": `
+      var __exportStar = function (m, e) { for (var p in m) if (p !== "default") e[p] = m[p]; };
+      __exportStar(require("./cond.cjs"), exports);
+      exports.own = true;
+    `,
+    "nested.cjs": `module.exports = require("./reexport.cjs");`,
+    "entry.mjs": `
+      import { always as a1, debugOnly as d1 } from "./reexport.cjs";
+      import { always as a2, debugOnly as d2, own } from "./star.cjs";
+      import { always as a3, debugOnly as d3 } from "./nested.cjs";
+      import * as star from "./star.cjs";
+      console.log(JSON.stringify({
+        reexport: [a1, typeof d1],
+        star: [a2, typeof d2, own],
+        nested: [a3, typeof d3],
+        starKeys: Object.keys(star),
+      }));
+    `,
+  });
+  expect(result).toEqual({
+    reexport: [1, "undefined"],
+    star: [1, "undefined", true],
+    nested: [1, "undefined"],
+    starKeys: ["always", "debugOnly", "default", "own"],
+  });
+});
+
+test.concurrent("a later module.exports assignment discards earlier re-exports, like the lexer", async () => {
+  const result = await runJSON({
+    "prod.cjs": `exports.shared = "prod"; if (${NEVER}) exports.prodOnly = 1;`,
+    "dev.cjs": `exports.shared = "dev"; if (${NEVER}) exports.devOnly = 1;`,
+    "mod.cjs": `
+      if (${NEVER}) module.exports = require("./prod.cjs");
+      else module.exports = require("./dev.cjs");
+      if (${NEVER}) require("./prod.cjs");
+    `,
+    "entry.mjs": `
+      import { shared, devOnly } from "./mod.cjs";
+      import * as ns from "./mod.cjs";
+      console.log(JSON.stringify({ shared, devOnly: typeof devOnly, keys: Object.keys(ns) }));
+    `,
+  });
+  expect(result).toEqual({ shared: "dev", devOnly: "undefined", keys: ["default", "devOnly", "shared"] });
+});
+
+test.concurrent("re-exports that cannot be resolved or were never loaded are skipped", async () => {
+  const result = await runJSON({
+    "never-loaded.cjs": `exports.neverLoaded = 1;`,
+    "mod.cjs": `
+      exports.ok = 1;
+      if (${NEVER}) exports.okMaybe = 1;
+      if (${NEVER}) module.exports = require("./does-not-exist.cjs");
+      if (${NEVER}) module.exports = require("./never-loaded.cjs");
+    `,
+    "entry.mjs": `
+      import { ok, okMaybe } from "./mod.cjs";
+      import * as ns from "./mod.cjs";
+      console.log(JSON.stringify({ ok, okMaybe: typeof okMaybe, keys: Object.keys(ns) }));
+    `,
+  });
+  expect(result).toEqual({ ok: 1, okMaybe: "undefined", keys: ["default", "ok", "okMaybe"] });
+});
+
+test.concurrent("re-export cycles terminate", async () => {
+  const result = await runJSON({
+    "a.cjs": `
+      require("./b.cjs");
+      exports.a = 1;
+      if (${NEVER}) exports.aMaybe = 1;
+      if (${NEVER}) module.exports = require("./b.cjs");
+    `,
+    "b.cjs": `
+      exports.b = 1;
+      if (${NEVER}) exports.bMaybe = 1;
+      if (${NEVER}) module.exports = require("./a.cjs");
+    `,
+    "entry.mjs": `
+      import { a, aMaybe, b, bMaybe } from "./a.cjs";
+      console.log(JSON.stringify([a, typeof aMaybe, typeof b, typeof bMaybe]));
+    `,
+  });
+  expect(result).toEqual([1, "undefined", "undefined", "undefined"]);
+});
+
+test.concurrent("works when the module was require()d before it was imported", async () => {
+  const result = await runJSON({
+    "cond.cjs": `exports.always = 1; if (${NEVER}) exports.debugOnly = 1;`,
+    "entry.mjs": `
+      import { createRequire } from "node:module";
+      const required = createRequire(import.meta.url)("./cond.cjs");
+      const ns = await import("./cond.cjs");
+      console.log(JSON.stringify({
+        required,
+        keys: Object.keys(ns),
+        debugOnly: typeof ns.debugOnly,
+        sameObject: ns.default === required,
+      }));
+    `,
+  });
+  expect(result).toEqual({
+    required: { always: 1 },
+    keys: ["always", "debugOnly", "default"],
+    debugOnly: "undefined",
+    sameObject: true,
+  });
+});
+
+test.concurrent("export * from a CommonJS module includes the detected names", async () => {
+  const result = await runJSON({
+    "cond.cjs": `exports.always = 1; if (${NEVER}) exports.debugOnly = 1;`,
+    "barrel.mjs": `export * from "./cond.cjs";`,
+    "entry.mjs": `
+      import { always, debugOnly } from "./barrel.mjs";
+      import * as barrel from "./barrel.mjs";
+      console.log(JSON.stringify({ always, debugOnly: typeof debugOnly, keys: Object.keys(barrel) }));
+    `,
+  });
+  expect(result).toEqual({ always: 1, debugOnly: "undefined", keys: ["always", "debugOnly"] });
+});
+
+test.concurrent("TypeScript `export =` participates", async () => {
+  const result = await runJSON({
+    "cond.cjs": `exports.always = 1; if (${NEVER}) exports.debugOnly = 1;`,
+    "reexport.cts": `export = require("./cond.cjs");`,
+    "entry.mjs": `
+      import { always, debugOnly } from "./reexport.cts";
+      console.log(JSON.stringify([always, typeof debugOnly]));
+    `,
+  });
+  expect(result).toEqual([1, "undefined"]);
+});
+
+test.concurrent("default and __esModule keep their evaluated meaning", async () => {
+  const result = await runJSON({
+    "mod.cjs": `
+      if (${NEVER}) Object.defineProperty(exports, "__esModule", { value: true });
+      if (${NEVER}) exports.default = "never";
+      if (${NEVER}) exports.other = 1;
+      exports.real = 1;
+    `,
+    "entry.mjs": `
+      import def, { other } from "./mod.cjs";
+      import * as ns from "./mod.cjs";
+      console.log(JSON.stringify({ def, other: typeof other, keys: Object.keys(ns), esModule: typeof ns.__esModule }));
+    `,
+  });
+  expect(result).toEqual({ def: { real: 1 }, other: "undefined", keys: ["default", "other", "real"], esModule: "undefined" });
+});
+
+test.concurrent("a name that is neither detected nor evaluated is still a link error", async () => {
+  using dir = tempDir("cjs-static-exports", {
+    "mod.cjs": `
+      exports.real = 1;
+      if (${NEVER}) exports.detected = 1;
+      const key = "dyn" + "amic";
+      exports[key] = 1;
+    `,
+    "entry.mjs": `import { real, detected, nope } from "./mod.cjs"; console.log(real, detected);`,
+  });
+  const { stderr, exitCode } = await runEntry(String(dir));
+  expect(stderr).toContain("SyntaxError: Export named 'nope' not found in module");
+  expect(exitCode).toBe(1);
+});
+
+test.concurrent("detected names survive the runtime transpiler cache", async () => {
+  // Files under 4 KiB are never cached; pad past that.
+  const padding = Array.from({ length: 300 }, (_, i) => `exports.pad_${i} = ${i};`).join("\n");
+  using dir = tempDir("cjs-static-exports-cache", {
+    "big.cjs": `exports.always = 1;\nif (${NEVER}) exports.debugOnly = 1;\n${padding}\n`,
+    "entry.mjs": `
+      import { always, debugOnly, pad_299 } from "./big.cjs";
+      console.log(JSON.stringify([always, typeof debugOnly, pad_299]));
+    `,
+  });
+  const env = {
+    BUN_RUNTIME_TRANSPILER_CACHE_PATH: join(String(dir), ".cache"),
+    // Debug builds discard cache hits unless this is set.
+    BUN_DEBUG_ENABLE_RESTORE_FROM_TRANSPILER_CACHE: "1",
+  };
+
+  // The first run writes the cache entry, the second run links from it.
+  for (let i = 0; i < 2; i++) {
+    const { stdout, stderr, exitCode } = await runEntry(String(dir), env);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual([1, "undefined", 299]);
+    expect(exitCode).toBe(0);
+    expect(readdirSync(env.BUN_RUNTIME_TRANSPILER_CACHE_PATH).filter(name => name.endsWith(".pile"))).toHaveLength(1);
+  }
+});

--- a/test/js/bun/resolve/cjs-static-exports.test.ts
+++ b/test/js/bun/resolve/cjs-static-exports.test.ts
@@ -319,7 +319,12 @@ test.concurrent("default and __esModule keep their evaluated meaning", async () 
       console.log(JSON.stringify({ def, other: typeof other, keys: Object.keys(ns), esModule: typeof ns.__esModule }));
     `,
   });
-  expect(result).toEqual({ def: { real: 1 }, other: "undefined", keys: ["default", "other", "real"], esModule: "undefined" });
+  expect(result).toEqual({
+    def: { real: 1 },
+    other: "undefined",
+    keys: ["default", "other", "real"],
+    esModule: "undefined",
+  });
 });
 
 test.concurrent("a name that is neither detected nor evaluated is still a link error", async () => {


### PR DESCRIPTION
### Problem

- `import { name } from "./x.cjs"` fails to link with `SyntaxError: Export named 'name' not found in module '.../x.cjs'` whenever `name` is not an own property of the final `module.exports`, even though the source assigns it. Node links these and the binding is `undefined`. Shapes that hit it:
  - `if (process.env.DEBUG) exports.debugOnly = ...` (conditional or dead assignment)
  - `exports.a = 1; module.exports = { b: 2 }` (`import { a }`)
  - the same names behind `module.exports = require("./x.cjs")` or `__exportStar(require("./x.cjs"), exports)`
- Cause: `populateESMExports` (`src/jsc/bindings/JSCommonJSModule.cpp`) builds the export list only from the own properties of the evaluated `module.exports`. Node builds it from a lexical scan of the source (cjs-module-lexer) and fills in values afterwards, so the two runtimes disagree exactly on names the source mentions but evaluation does not produce. One missing name fails the whole importing graph at link time.

### Fix

- The runtime transpiler collects export names while it visits a CommonJS file (`src/js_parser/commonjs_static_exports.rs`): `exports.x =`, `exports["x"] =`, `module.exports.x =`, keys of `module.exports = { ... }`, `Object.defineProperty(exports, "x", { value | get })`, and re-export specifiers from `module.exports = require(...)`, `...require(...)` spreads, `__exportStar(require(...))` / `__export(require(...))`. Matching is lexical like the lexer (any scope, any binding named `exports`/`module`), and a later `module.exports = ...` drops earlier re-exports, also like the lexer. `default` and `__esModule` are skipped because `populateESMExports` decides those from the evaluated object. Hooks are in `BinaryExpressionVisitor::check_and_prepare`, `e_call`, and `s_export_equals` (TypeScript `export =`), and only do work when `commonjs_at_runtime` is set, so the bundler is untouched.
- The result is serialized once into `Ast.commonjs_static_exports` and travels as a `BunString` on `ResolvedSource` (`commonjs_static_exports`), owned like `source_code`: `Zig::SourceProvider` takes it at construction (so the `--isolate` provider cache has it), `JSCommonJSModule::setSourceMetadata` / `takeSourceMetadata` copy or take it, and the `ErrorableResolvedSource` destructor releases whatever nobody took. CommonJS entries of the runtime transpiler cache store the same bytes in the otherwise empty ESM-record slot (`EXPECTED_VERSION` 27 -> 28), so cache hits link the same names as a fresh transpile.
- At link time `JSCommonJSModule::toSyntheticSource` still runs `populateESMExports` first and then appends every detected name that is not already exported, as `undefined`. Re-export specifiers are resolved with require semantics from the module's filename; when the target is a CommonJS module in the require map, its detected names are appended too (cycle guarded). Unresolvable or never-loaded targets are skipped, as Node skips unresolvable ones.
- Why this is correct: the evaluated object remains authoritative for every name it has, so everything that links today links to the same value, and Bun keeps exporting runtime-only names Node does not (computed keys, UMD). The change only turns link errors into `undefined` bindings for names the source mentions, which is Node's result for them. Following re-exports only into loaded modules covers the shapes that reach `module.exports` at runtime (`module.exports = require()`, `__exportStar`, `...require()`); the one remaining divergence is a re-export target Node would lex without ever loading it (for example the branch of a prod/dev shim that did not run), which behaves as it does today.
- Verified with `test/js/bun/resolve/cjs-static-exports.test.ts` (15 tests: the shapes above, evaluated values winning over detected names, runtime-only names kept, re-export discard rule, unresolvable and never-loaded targets, cycles, require() before import, `export *` over a CommonJS module, `.cts` `export =`, `default`/`__esModule` unchanged, a name that is neither detected nor evaluated still failing, transpiler cache round trip). All 15 fail on the released `bun` and pass with `bun bd`.
- Also run: `test/js/bun/resolve/` (only the two pre-existing 2000-loads timing tests time out in this debug container, both on ES modules), `esModule-annotation.test.js`, `esm-defineProperty.test.ts`, `transpiler-cache.test.ts`, `test/regression/issue/30887.test.ts`, `test/internal/source-lints/`, `bun test --isolate` with two files importing the same conditional CommonJS module, and the new tests under LeakSanitizer with `test/leaksan.supp` (no reports from the new code; repeated loads of a 10000-export file grow RSS the same as main's binary).
- Docs: one paragraph added to the CommonJS interop details in `docs/runtime/module-resolution.mdx`.
- Not changed on purpose: Node's extra `"module.exports"` and `__esModule` named exports (#33030 covers the former). Related: #35971 builds a static export table for the evaluation-order problem; it falls back to today's behaviour for the re-export shapes, so the two are complementary, and if both land the two tables should become one.

### Background

- When ESM imports a CommonJS file, Bun evaluates the file and creates a JSC synthetic module record whose export names and values are produced by one callback (`toSyntheticSource`). JSC resolves `import { x }` against that fixed name list while linking; a name that is not in the list is a `SyntaxError` for the whole graph, while a name whose value is `undefined` links fine.
- cjs-module-lexer is the scanner Node runs over CommonJS sources to decide their ESM export names. It is purely lexical: it does not know whether an assignment runs, so conditional and dead assignments count, and `module.exports = require("x")` makes it union in x's scanned names. Values are read from the real `module.exports` after evaluation, missing ones stay `undefined`.
- `ResolvedSource` is the struct the Rust transpiler hands to C++ for each loaded file (`src/jsc/ResolvedSource.rs`, mirrored in `headers-handwritten.h`). `Zig::SourceProvider` keeps a copy of it for the lifetime of the source; under `bun test --isolate` those providers are reused across globals, which is why the names live there too.
- The runtime transpiler cache (`src/jsc/RuntimeTranspilerCache.rs`) stores transpiled output on disk keyed by input hash; a cache hit skips parsing entirely, so anything derived from the AST that the loader needs has to be stored in the entry, and its version number is bumped whenever the stored shape changes.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 10 · 21 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 15 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/resolve/cjs-static-exports.test.ts
bun test v1.4.1 (65362b53b)

test/js/bun/resolve/cjs-static-exports.test.ts:
26 | }
27 | 
28 | async function runJSON(files: Record<string, string>) {
29 |   using dir = tempDir("cjs-static-exports", files);
30 |   const { stdout, stderr, exitCode } = await runEntry(String(dir));
31 |   expect(stderr).toBe("");
                      ^
error: expect(received).toBe(expected)

- ""
+ "SyntaxError: Export named 'a' not found in module '/tmp/cjs-static-exports_uyvrZ5/shapes.cjs'.
+ 
+ Bun v1.4.1-debug+65362b53b (Linux x64)
+ "

- Expected  - 1
+ Received  + 4

      at runJSON (/workspace/bun/test/js/bun/resolve/cjs-static-exports.test.ts:31:18)
      at async <anonymous> (/workspace/bun/test/js/bun/resolve/cjs-static-exports.test.ts:71:24)
(fail) a name removed by a later module.exports = {...} still links [280.47ms]
26 | }
27 | 
28 | async function runJSON(files: Record<string, string>) {
29 |   using dir = tempDir("cjs-static-exports", files);
30 |   const { stdout, stderr, exitCode } = awai
... (truncated)

release without fix: 15 FAILED
bun test v1.4.1-canary.1 (65362b53b)

test/js/bun/resolve/cjs-static-exports.test.ts:
26 | }
27 | 
28 | async function runJSON(files: Record<string, string>) {
29 |   using dir = tempDir("cjs-static-exports", files);
30 |   const { stdout, stderr, exitCode } = await runEntry(String(dir));
31 |   expect(stderr).toBe("");
                      ^
error: expect(received).toBe(expected)

- ""
+ "SyntaxError: Export named 'a' not found in module '/tmp/cjs-static-exports_YPVabQ/shapes.cjs'.
+ 
+ Bun v1.4.1-canary.1+65362b53b (Linux x64)
+ "

- Expected  - 1
+ Received  + 4

      at runJSON (/workspace/bun/test/js/bun/resolve/cjs-static-exports.test.ts:31:18)
      at async <anonymous> (/workspace/bun/test/js/bun/resolve/cjs-static-exports.test.ts:71:24)
26 | }
27 | 
28 | async function runJSON(files: Record<string, string>) {
29 |   using dir = tempDir("cjs-static-exports", files);
30 |   const { stdout, stderr, exitCode } = await runEntry(String(dir));
31 |   expect(stderr).toBe("");
                      ^
error: expect(received).toBe(expected)

- ""
+ "SyntaxError: Export named 'debugOnly' not found in module '/tmp/cjs-static-exports_WM6MgV/cond.cjs'.
+ 
+ Bun v1.4.1-c
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/resolve/cjs-static-exports.test.ts
bun test v1.4.1 (65362b53b)

test/js/bun/resolve/cjs-static-exports.test.ts:
(pass) exports.x assigned conditionally or in dead code still links [350.32ms]
(pass) a name removed by a later module.exports = {...} still links [290.48ms]
(pass) evaluated values win; names only known at runtime are kept [295.28ms]
(pass) module.exports = { ... } contributes its keys and spread require()s [310.88ms]
(pass) exports['string-key'] and Object.defineProperty are detected [355.69ms]
(pass) re-exports that cannot be resolved or were never loaded are skipped [287.28ms]
(pass) a later module.exports assignment discards earlier re-exports, like the lexer [320.12ms]
(pass) works when the module was require()d before it was imported [297.90ms]
(pass) names flow through module.exports = require() and __exportStar() [427.08ms]
(pass) re-export cycles terminate [389.39ms]
(pass) TypeScript `export =` participates [300.63ms]
(pass) export * from a CommonJS module includes the detected names [378.61ms]
(pass) a
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 637ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/140] cc obj/packages/bun-usockets/src/eventing/libuv.c.o
[2/140] cc obj/packages/bun-usockets/src/fault_inject.c.o
[3/140] cc obj/packages/bun-usockets/src/bsd.c.o
[4/140] cc obj/packages/bun-usockets/src/context.c.o
[5/140] cc obj/packages/bun-usockets/src/crypto/openssl.c.o
[6/140] cc obj/packages/bun-usockets/src/eventing/epoll_kqueue.c.o
[7/140] cc obj/packages/bun-usockets/src/loop.c.o
[8/140] cc obj/packages/bun-usockets/src/node_quic_shim.c.o
[9/140] cc obj/packages/bun-usockets/src/quic.c.o
[10/140] cc obj/packages/bun-usockets/src/socket.c.o
[11/140] cc obj/packages/bun-usockets/src/udp.c.o
[12/140] cc obj/src/jsc/bindings/node/http/llhttp/api.c.o
[13/140] cc obj/src/jsc/bindings/node/http/llhttp/http.c.o
[14/140] cc obj/src/jsc/bindings/uv-posix-polyfills.c.o
[15/140] cc obj/vendor/picohttpparser/picohttpparser.c.o
[16/140] cc obj/src/jsc/bindings/node/http/llhttp/llhttp.c.o
[17/140] cc obj/src/jsc/bindings/uv-posix-stubs.c.o
[18/140] gen generated_host_exports.rs
generated_host_exports.rs: 12
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/module-resolution.mdx             |   2 +
 src/ast/ast_result.rs                          |   3 +
 src/js_parser/commonjs_static_exports.rs       | 264 ++++++++++++++++++
 src/js_parser/lib.rs                           |   1 +
 src/js_parser/p.rs                             |  11 +
 src/js_parser/visit/visit_binary.rs            |   4 +
 src/js_parser/visit/visit_expr.rs              |   1 +
 src/js_parser/visit/visit_stmt.rs              |   1 +
 src/js_printer/lib.rs                          |   9 +-
 src/jsc/AsyncModule.rs                         |   4 +
 src/jsc/Errorable.rs                           |   2 +-
 src/jsc/ResolvedSource.rs                      |   4 +-
 src/jsc/RuntimeTranspilerCache.rs              |   6 +-
 src/jsc/RuntimeTranspilerStore.rs              |  12 +-
 src/jsc/bindings/JSCommonJSModule.cpp          | 153 ++++++++--
 src/jsc/bindings/JSCommonJSModule.h            |  15 +-
 src/jsc/bindings/ModuleLoader.cpp              |   4 +-
 src/jsc/bindings/ZigSourceProvider.h           |   8 +
 src/jsc/bindings/headers-handwritten.h         |   7 +-
 src/runtime/jsc_hooks.rs                       |  12 +
 test/js/bun/resolve/cjs-static-exports.test.ts | 371 +++++++++++++++++++++++++
 21 files changed, 864 insertions(+), 30 deletions(-)
```

</details>

**gate history** · 4 passed · 1 rejected · iteration 10

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
docs/runtime/module-resolution.mdx            2      2      0
src/ast/ast_result.rs                         3      6      0
src/js_parser/commonjs_static_exports.rs      4     17      0
src/js_parser/lib.rs                          1      2      0
src/js_parser/p.rs                            8      4      0
src/js_parser/visit/visit_binary.rs           2      1      0
src/js_parser/visit/visit_expr.rs             3      1      0
src/js_parser/visit/visit_stmt.rs             1      1      0
src/js_printer/lib.rs                         2      2      0
src/jsc/AsyncModule.rs                        4      3      0
src/jsc/Errorable.rs                          1      1      0
src/jsc/ResolvedSource.rs                     3      6      0
src/jsc/RuntimeTranspilerCache.rs             5      4      0
src/jsc/RuntimeTranspilerStore.rs             5      5      0
src/jsc/bindings/JSCommonJSModule.cpp        18     24      0
src/jsc/bindings/JSCommonJSModule.h           3      7      0
(+ 5 more files)
```

</details>

<!-- robobun:evidence:end -->

