### PR TITLE
js_parser: accept bigint literal property keys wherever numeric keys are accepted

### DIFF
--- a/src/js_parser/parse/parse_property.rs
+++ b/src/js_parser/parse/parse_property.rs
@@ -350,6 +350,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 p.lexer.token,
                                 T::TOpenBracket
                                     | T::TNumericLiteral
+                                    | T::TBigIntegerLiteral
                                     | T::TStringLiteral
                                     | T::TPrivateIdentifier
                             )

--- a/src/js_parser/parse/parse_skip_typescript.rs
+++ b/src/js_parser/parse/parse_skip_typescript.rs
@@ -115,8 +115,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         }
 
                         // "{1: y}"
+                        // "{1n: y}"
                         // "{'x': y}"
-                        T::TStringLiteral | T::TNumericLiteral => {
+                        T::TStringLiteral | T::TNumericLiteral | T::TBigIntegerLiteral => {
                             self.lexer.next()?;
                         }
 
@@ -1036,6 +1037,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             while self.lexer.is_identifier_or_keyword()
                 || self.lexer.token == T::TStringLiteral
                 || self.lexer.token == T::TNumericLiteral
+                || self.lexer.token == T::TBigIntegerLiteral
             {
                 self.lexer.next()?;
                 found_key = true;

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -328,6 +328,10 @@ describe("Bun.Transpiler", () => {
       exp("class A { declare 1n: number; x = 1 }", "class A {\n  x = 1;\n}");
       exp("class A { declare static 1n: number; x = 1 }", "class A {\n  x = 1;\n}");
       exp("abstract class A { abstract 1n: number; abstract 2n(): void; x = 1 }", "class A {\n  x = 1;\n}");
+      exp(
+        "interface I { 1n(): void }\nclass A implements I { static 1n() {} 1n() {} }",
+        "class A {\n  static 1n() {}\n  1n() {}\n}",
+      );
     });
 
     it("contextual keywords followed by a newline apply ASI instead of acting as modifiers", () => {
@@ -1022,6 +1026,9 @@ function foo() {}
       exp("type x = [-1, 0, 1]\na([])", "a([]);\n");
       exp("type x = [-1n, 0n, 1n]\na([])", "a([]);\n");
       exp("type x = {0: number, readonly 1: boolean}\na([])", "a([]);\n");
+      exp("type x = {0n: number, readonly 1n: boolean, 2n?: string}\na([])", "a([]);\n");
+      exp("type x = {0n(): void, get 1n(): number, set 1n(v: number), 2n?(): void}\na([])", "a([]);\n");
+      exp("interface x {0n: number, 1n(): void}\na([])", "a([]);\n");
       exp("type x = {'a': number, readonly 'b': boolean}\na([])", "a([]);\n");
       exp("type\nFoo = {}", "type;\nFoo = {};\n");
       err("export type\nFoo = {}", 'Unexpected newline after "type"');
@@ -1052,6 +1059,10 @@ function foo() {}
       err("let x: {[typeof: string]: number}", 'Expected identifier but found ":"');
       exp("let x: () => void = Foo", "let x = Foo;\n");
       exp("let x: new () => void = Foo", "let x = Foo;\n");
+      exp("let x: ({ 1: a, 'b': b }: T) => void = Foo", "let x = Foo;\n");
+      exp("let x: ({ 1n: a }: T) => void = Foo", "let x = Foo;\n");
+      exp("let x: new ({ 1n: a }: T) => void = Foo", "let x = Foo;\n");
+      exp("type x = {m({ 1n: a }: T): void}\na([])", "a([]);\n");
       exp("let x = 'x' as keyof T", 'let x = "x";\n');
       exp("let x = [1] as readonly [number]", "let x = [1];\n");
       exp("let x = 'x' as keyof typeof Foo", 'let x = "x";\n');

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -311,6 +311,25 @@ describe("Bun.Transpiler", () => {
       exp("declare class Foo {}", "");
     });
 
+    it("class modifiers followed by a bigint literal key", () => {
+      const exp = ts.expectPrinted_;
+
+      // Same output as tsc: the modifiers are erased and the bigint key is kept.
+      exp("class A { static 1n: bigint = 1n }", "class A {\n  static 1n = 1n;\n}");
+      exp("class A { static 1n!: number }", "class A {\n  static 1n;\n}");
+      exp("class A { public 1n = 1 }", "class A {\n  1n = 1;\n}");
+      exp("class A { private static 1n = 1 }", "class A {\n  static 1n = 1;\n}");
+      exp("class A { protected static readonly 1n = 1 }", "class A {\n  static 1n = 1;\n}");
+      exp("class A { readonly 1n = 1 }", "class A {\n  1n = 1;\n}");
+      exp("class A extends B { override 1n() {} }", "class A extends B {\n  1n() {}\n}");
+      exp("class A extends B { public override async 1n() {} }", "class A extends B {\n  async 1n() {}\n}");
+      exp("class A { public get 1n(): number { return 1 } }", "class A {\n  get 1n() {\n    return 1;\n  }\n}");
+      exp("class A { private static set 1n(v: number) {} }", "class A {\n  static set 1n(v) {}\n}");
+      exp("class A { declare 1n: number; x = 1 }", "class A {\n  x = 1;\n}");
+      exp("class A { declare static 1n: number; x = 1 }", "class A {\n  x = 1;\n}");
+      exp("abstract class A { abstract 1n: number; abstract 2n(): void; x = 1 }", "class A {\n  x = 1;\n}");
+    });
+
     it("contextual keywords followed by a newline apply ASI instead of acting as modifiers", () => {
       const exp = ts.expectPrinted_;
       const err = ts.expectParseError;
@@ -2867,6 +2886,160 @@ console.log(a)
       expectBunPrinted_("export const foo = 1 + 2", "export const foo = 3");
       expectBunPrinted_("export const foo = 1 - 2", "export const foo = -1");
       expectBunPrinted_("export const foo = 1 * 2", "export const foo = 2");
+    });
+
+    it("bigint literal keys after modifier keywords", () => {
+      // A bigint literal is a valid property name, so like a numeric literal it
+      // marks the word before it as a modifier.
+      expectPrinted_("class A { static 1n = 1 }", "class A {\n  static 1n = 1;\n}");
+      expectPrinted_("class A { static 1n }", "class A {\n  static 1n;\n}");
+      expectPrinted_("class A { static 1n() {} }", "class A {\n  static 1n() {}\n}");
+      expectPrinted_("class A { get 1n() { return 1 } }", "class A {\n  get 1n() {\n    return 1;\n  }\n}");
+      expectPrinted_("class A { set 1n(v) {} }", "class A {\n  set 1n(v) {}\n}");
+      expectPrinted_("class A { async 1n() {} }", "class A {\n  async 1n() {}\n}");
+      expectPrinted_(
+        "class A { static get 1n() { return 1 } }",
+        "class A {\n  static get 1n() {\n    return 1;\n  }\n}",
+      );
+      expectPrinted_("class A { static set 1n(v) {} }", "class A {\n  static set 1n(v) {}\n}");
+      expectPrinted_("class A { static async 1n() {} }", "class A {\n  static async 1n() {}\n}");
+      expectPrinted_("class A { static async *1n() {} }", "class A {\n  static async* 1n() {}\n}");
+      expectPrinted_("class A { static *1n() {} }", "class A {\n  static *1n() {}\n}");
+      expectPrinted_("class A { async *1n() {} }", "class A {\n  async* 1n() {}\n}");
+      expectPrinted_("class A { 1n = 1; 2n() {} }", "class A {\n  1n = 1;\n  2n() {}\n}");
+
+      expectPrinted_("x = { get 1n() { return 1 } }", "x = { get 1n() {\n  return 1;\n} };\n");
+      expectPrinted_("x = { set 1n(v) {} }", "x = { set 1n(v) {} };\n");
+      expectPrinted_("x = { async 1n() {} }", "x = { async 1n() {} };\n");
+      expectPrinted_("x = { async *1n() {} }", "x = { async* 1n() {} };\n");
+
+      // "static", "get" and "set" bind to a key on the next line; no semicolon
+      // is inserted because the key can continue the member.
+      expectPrinted_("class A { static\n 1n = 1 }", "class A {\n  static 1n = 1;\n}");
+      expectPrinted_("class A { get\n 1n() { return 1 } }", "class A {\n  get 1n() {\n    return 1;\n  }\n}");
+      expectPrinted_("class A { set\n 1n(v) {} }", "class A {\n  set 1n(v) {}\n}");
+      // "async" must be on the same line as the key, so this is a field named
+      // "async" followed by a method.
+      expectPrinted_("class A { async\n 1n() {} }", "class A {\n  async;\n  1n() {}\n}");
+
+      // The words are still plain keys when a bigint is the value rather than the next key.
+      expectPrinted_("class A { static = 1n }", "class A {\n  static = 1n;\n}");
+      expectPrinted_("class A { static; 1n = 1 }", "class A {\n  static;\n  1n = 1;\n}");
+      expectPrinted_("x = { get: 1n }", "x = { get: 1n };\n");
+      expectPrinted_("x = { async: 1n, set: 2n }", "x = { async: 1n, set: 2n };\n");
+      // "static" is only a modifier in a class body; like `{ static 1() {} }` this is rejected.
+      expectParseError("x = { static 1n() {} }", "Parse error");
+    });
+
+    it("class members with bigint literal keys after modifiers behave like numeric keys at runtime", async () => {
+      // Uses a .js file rather than -e so that "accessor" is parsed (the repo
+      // tsconfig enables experimentalDecorators, which disables it).
+      using dir = tempDir("bigint-member-keys", {
+        "index.js": `
+          class A {
+            static 1n = "static field";
+            get 2n() {
+              return "getter";
+            }
+            set 3n(v) {
+              this.setterValue = v;
+            }
+            async 4n() {
+              return "async method";
+            }
+            static async 5n() {
+              return "static async method";
+            }
+            static get 6n() {
+              return "static getter";
+            }
+            static set 7n(v) {
+              this.staticSetterValue = v;
+            }
+            static async *8n() {
+              yield "static async generator";
+            }
+            static
+            9n = "static field on the next line";
+            get
+            10n() {
+              return "getter on the next line";
+            }
+            async
+            11n() {
+              return "method after a field named async";
+            }
+            accessor 12n = "accessor";
+            static accessor 13n = "static accessor";
+          }
+          const o = {
+            get 1n() {
+              return "object getter";
+            },
+            set 2n(v) {
+              this.setterValue = v;
+            },
+            async 3n() {
+              return "object async method";
+            },
+          };
+
+          const a = new A();
+          a[3] = "setter";
+          A[7] = "static setter";
+          o[2] = "object setter";
+          const isAccessor = (obj, key) => {
+            const { get, set } = Object.getOwnPropertyDescriptor(obj, key);
+            return typeof get === "function" && typeof set === "function";
+          };
+
+          console.log(
+            JSON.stringify({
+              1: A[1],
+              2: a[2],
+              3: a.setterValue,
+              4: await a[4](),
+              5: await A[5](),
+              6: A[6],
+              7: A.staticSetterValue,
+              8: (await A[8]().next()).value,
+              9: A[9],
+              10: a[10],
+              11: [Object.hasOwn(a, "async"), await a[11]()],
+              12: [a[12], isAccessor(A.prototype, "12")],
+              13: [A[13], isAccessor(A, "13")],
+              o: [o[1], o.setterValue, await o[3]()],
+              prototypeKeys: Object.getOwnPropertyNames(A.prototype),
+            }),
+          );
+        `,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "index.js"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual({
+        1: "static field",
+        2: "getter",
+        3: "setter",
+        4: "async method",
+        5: "static async method",
+        6: "static getter",
+        7: "static setter",
+        8: "static async generator",
+        9: "static field on the next line",
+        10: "getter on the next line",
+        11: [true, "method after a field named async"],
+        12: ["accessor", true],
+        13: ["static accessor", true],
+        o: ["object getter", "object setter", "object async method"],
+        prototypeKeys: ["2", "3", "4", "10", "11", "12", "constructor"],
+      });
+      expect(exitCode).toBe(0);
     });
 
     it.todo("pass objects to macros", () => {


### PR DESCRIPTION
### Problem
- A class member or object literal member whose key is a bigint literal fails to parse when a modifier precedes the key:
  ```js
  class A { static 2n = "s"; get 4n() { return "g" } }   // error: Expected ";" but found "2n"
  ({ get 1n() { return 1 } })                             // error: Expected "}" but found "1n"
  ```
  node runs both. `class A { 2n = 1; 4n() {} }` (no modifier) already works in bun.
- With a newline between the modifier and the key the code is accepted but means something else: `static\n 2n = 1` becomes a field named `static` plus an instance field `2n`, `get\n 4n() {}` becomes a field named `get` plus a plain method. node (and bun with a numeric key, `static\n 2 = 1`) produce a static field and a getter.
- The same key is also rejected in TypeScript type positions, so in a `.ts` file a class can declare `9n() {}` but the interface it implements cannot declare `9n(): void`:
  ```ts
  interface I { 1n(): void }                  // error: Unexpected 1n
  let x: { 1n: string }                       // error: Unexpected 1n
  let f: ({ 1n: a }: T) => void               // error: Unexpected 1n
  ```
  tsc parses all of these (the first has no diagnostics at all; property signatures such as `1n: string` get a type-checker diagnostic, TS1539, but still parse and emit), and bun accepts each of them with a numeric key.
- Cause: three token lists that answer "can this token be a property name?" list numeric and string literals but not bigint literals. Every parser that actually consumes a key (`parse_property`'s key match, `parse_property_binding`) already handles bigint; only these lookahead and skip lists were missed. The lists are inherited from esbuild, which has the same omission.
  - `src/js_parser/parse/parse_property.rs:348`: after reading an identifier, `parse_property` only treats it as a modifier if the next token can start a property name. This is why `static`/`get`/`set`/`async`/`accessor` and the TypeScript member modifiers are taken as the member name when a bigint key follows.
  - `src/js_parser/parse/parse_skip_typescript.rs:1036`: the loop in `skip_type_script_object_type` that consumes modifiers and the member name of an interface or type literal member.
  - `src/js_parser/parse/parse_skip_typescript.rs:119`: the member-key arm of `skip_type_script_binding`, used for destructured parameters inside function types and method signatures.

### Fix
- Add `T::TBigIntegerLiteral` next to `T::TNumericLiteral` in each of the three lists. Nothing downstream changes: in `parse_property` every modifier arm sits behind the one lookahead, so the per-modifier rules (`async` and `accessor` must be on the same line as the key, `static` only applies in classes, and so on) now apply to bigint keys exactly as they do to numeric keys; in the two skippers everything after the key is driven by the same `found_key` / `:` handling the numeric path already uses.
- Correct because a bigint literal is a `NumericLiteral` in the spec grammar and therefore a `LiteralPropertyName`, so every position that accepts `2` as a key must accept `2n`. node agrees for the JS forms; tsc parses every TypeScript form, and its `transpileModule` output matches the new expectations (modifiers erased, key kept, types and `declare`/`abstract` members dropped).
- The only previously accepted code that changes meaning is the newline form above (`static`/`get`/`set` followed by a line break and a bigint key), which now parses the way node and bun's own numeric-key handling already parse it. Everything else either errored before or is unaffected: non-modifier words (`static` in an object literal, `static = 1n`, `{ get: 1n }`) fall through to the same path as before.
- Verified:
  - `test/bundler/transpiler/transpiler.test.js`: three new tests (printed output for JS classes and object literals including the newline and non-modifier cases, printed output for the TypeScript member modifiers plus `interface I { 1n(): void }` implemented by a class, and a runtime check of field/getter/setter/async/static/accessor members with bigint keys), plus new rows in the existing TypeScript `types` test for object types, interfaces, method signatures and destructured parameters in function types, next to the existing numeric-key rows. All of these fail on bun 1.4.0 and pass with this change; the runtime expectations were produced by node 26 (node has no `accessor`, so those two values follow the numeric-key behaviour).
  - `bun bd test` on `transpiler.test.js` and on `esbuild/ts`, `esbuild/default`, `esbuild/lower`, `decorators`, `decorator-metadata`, `es-decorators`, `es-decorators-esbuild`, `ts-use-define-for-class-fields`, `property`: all green.
  - The snippet from the report prints `s i g` with the debug build, the same as node; bundling the runtime fixture with `bun build --minify` and running the output under node gives the same values as running the source under node.

### Background
- `parse_property` parses one class or object member. For a member that starts with an identifier it reads the word, advances, and then has to decide whether the word was the member's name (`static = 1`, `get() {}`) or a modifier of the member that follows (`static x`, `get x() {}`). It decides by looking at the next token: if that token could begin a property name, the word is checked against the modifier table and, if it matches, the function restarts on the real key; otherwise the word is the key.
- bun does not type-check TypeScript; the `skip_type_script_*` functions walk over type syntax just far enough to find where it ends and drop it. `skip_type_script_object_type` handles `{ ... }` type literals and interface bodies; `skip_type_script_binding` handles the parameter patterns that can appear inside function types and method signatures (ordinary function declarations use the real binding parser, which already accepts bigint keys). Their job is to accept whatever tsc parses, so a token tsc accepts as a member name has to be in their lists too.
- `TBigIntegerLiteral` is the lexer token for a bigint literal such as `2n`; `TNumericLiteral` is the token for `2`. As property names both evaluate to the string `"2"`.
