### PR TITLE
valkey: report a TLS context that fails to build from the event loop

### DIFF
--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -1148,7 +1148,16 @@ impl JSValkeyClient {
     /// because `onclose` may call connect(), and a dial that fails the same way
     /// from in there would otherwise re-enter `on_close()` on the same stack.
     fn close_without_socket_next_tick(&self) {
-        self.enqueue_deferred_close(DeferredClose::WithoutSocket);
+        // A pending socket close keeps the wrapper strong through
+        // `update_poll_ref()` (status Connecting); this pending close is
+        // invisible to it, and after `fail()` nothing else it counts as
+        // activity is left, so the task has to hold the wrapper itself.
+        let wrapper = self
+            .this_value
+            .get()
+            .try_get()
+            .map(|this| jsc::Strong::create(this, &self.global_object));
+        self.enqueue_deferred_close(DeferredClose::WithoutSocket { _wrapper: wrapper });
     }
 
     fn enqueue_deferred_close(&self, what: DeferredClose) {
@@ -1471,8 +1480,6 @@ impl JSValkeyClient {
         let _guard = self.ref_scope();
 
         // Socket keep-alive ref, released by on_valkey_close/on_valkey_reconnect.
-        // Taken before the TLS-context check so the `tls_ctx_failed` branch's
-        // `on_valkey_close()` has a ref to consume instead of over-releasing.
         // Forgotten on success (the socket adopts it).
         let socket_ref = self.ref_scope();
 
@@ -1512,11 +1519,10 @@ impl JSValkeyClient {
                 b"Failed to create TLS context",
                 protocol::RedisError::ConnectionClosed,
             )?;
-            // `on_valkey_close()` consumes the socket ref; hand it over so it
-            // isn't released twice.
-            socket_ref.forget();
-            self.client_mut().on_valkey_close()?;
-            self.client_mut().status = valkey::Status::Disconnected;
+            // Settles connect() and runs `onclose` from the event loop, as for
+            // a dial that fails asynchronously; `fail()` already closed the
+            // client, so the deferred close takes the manual-close path.
+            self.close_without_socket_next_tick();
             return Ok(());
         }
         let ssl_ctx: Option<*mut uws::SslCtx> = match &self.client.get().tls {
@@ -2017,13 +2023,14 @@ impl Options {
     }
 }
 
-#[derive(Clone, Copy)]
 enum DeferredClose {
     /// Close the socket the finalized wrapper left behind.
     Socket,
     /// Run the close path for a dial that never produced a socket
-    /// (`close_without_socket_next_tick`).
-    WithoutSocket,
+    /// (`close_without_socket_next_tick`). `_wrapper` is the JS object that
+    /// path settles connect() and calls `onclose` on, held until the task has
+    /// run (or is released unrun); `None` only if it was already finalized.
+    WithoutSocket { _wrapper: Option<jsc::Strong> },
 }
 
 pub(crate) struct ValkeyDeferredClose {
@@ -2043,7 +2050,7 @@ impl ValkeyDeferredClose {
             DeferredClose::Socket => {
                 crate::dispatch::fold(this.client_mut().close(uws::CloseCode::FastShutdown))
             }
-            DeferredClose::WithoutSocket => {
+            DeferredClose::WithoutSocket { .. } => {
                 // `on_close()` ends in `on_valkey_close`/`on_valkey_reconnect`,
                 // which release the ref the socket would have held.
                 this.ref_();
@@ -2065,8 +2072,9 @@ impl bun_event_loop::Taskable for ValkeyDeferredClose {
             // Script-free bookkeeping; do it.
             DeferredClose::Socket => task.run(),
             // The VM is going away: `on_close()` would run `onclose`, so only
-            // give back what `reconnect()` and the enqueue took.
-            DeferredClose::WithoutSocket => {
+            // give back the poll ref and the ref the enqueue took; the wrapper
+            // is released with `task`.
+            DeferredClose::WithoutSocket { .. } => {
                 // SAFETY: as in `run`.
                 let _enqueue_ref = unsafe { ScopedRef::adopt(task.ctx) };
                 // SAFETY: live per the ref above.

--- a/test/js/valkey/reliability/connection-failures.test.ts
+++ b/test/js/valkey/reliability/connection-failures.test.ts
@@ -628,6 +628,119 @@ describe("Valkey: Recovering After fail()", () => {
     },
   );
 
+  // A tls config whose certificates do not parse fails the attempt before
+  // anything is dialed, so no server is involved in these.
+  const badTls = { tls: { ca: "not a certificate" }, autoReconnect: false };
+
+  test.each([
+    ["connect()", (client: RedisClient) => client.connect()],
+    ["a command", (client: RedisClient) => client.ping()],
+  ])("a tls config that fails to load is reported from the event loop when %s starts the attempt", async (_, start) => {
+    const client = new RedisClient("rediss://127.0.0.1:1", badTls);
+    try {
+      let closes = 0;
+      const closed = Promise.withResolvers<Error & { code: string }>();
+      client.onclose = err => {
+        closes++;
+        closed.resolve(err);
+      };
+      const attempt = start(client);
+      // Not from inside the call that started the attempt: an onclose that
+      // dials again from there would recurse straight back into the failure.
+      expect(closes).toBe(0);
+      await expect(attempt).rejects.toMatchObject({ code: "ERR_REDIS_CONNECTION_CLOSED" });
+      expect(await closed.promise).toMatchObject({ code: "ERR_REDIS_CONNECTION_CLOSED" });
+      expect({ closes, connected: client.connected }).toEqual({ closes: 1, connected: false });
+      await expect(client.ping()).rejects.toMatchObject({ code: "ERR_REDIS_CONNECTION_CLOSED" });
+    } finally {
+      client.close();
+    }
+  });
+
+  test("a tls config failure is still reported for a client that nothing but the pending attempt references", async () => {
+    // Once connect() has returned, the report that is on its way is all that
+    // still needs the client. A client collected before it arrives would never
+    // settle its attempt (this test would then time out). Several clients
+    // because the most recent one tends to survive a collection anyway.
+    let closes = 0;
+    const attempts: Promise<string>[] = [];
+    for (let i = 0; i < 3; i++) {
+      const client = new RedisClient("rediss://127.0.0.1:1", badTls);
+      client.onclose = () => closes++;
+      attempts.push(
+        client.connect().then(
+          () => "connected",
+          (err: Error & { code: string }) => `rejected: ${err.code}`,
+        ),
+      );
+      Bun.gc(true);
+    }
+    const outcomes = await Promise.all(attempts);
+    expect({ outcomes, closes }).toEqual({
+      outcomes: Array(3).fill("rejected: ERR_REDIS_CONNECTION_CLOSED"),
+      closes: 3,
+    });
+  });
+
+  test("an onclose that dials again after a tls config failure goes through the event loop instead of recursing", async () => {
+    const client = new RedisClient("rediss://127.0.0.1:1", badTls);
+    try {
+      const ATTEMPTS = 3;
+      const settled = Promise.withResolvers<void>();
+      let closes = 0;
+      let closesInsideConnect = 0;
+      let insideConnect = false;
+      const dial = () => {
+        insideConnect = true;
+        try {
+          return client.connect();
+        } finally {
+          insideConnect = false;
+        }
+      };
+      client.onclose = () => {
+        closes++;
+        if (insideConnect) closesInsideConnect++;
+        if (closes < ATTEMPTS) {
+          dial().catch(() => {});
+        } else {
+          settled.resolve();
+        }
+      };
+      await expect(dial()).rejects.toMatchObject({ code: "ERR_REDIS_CONNECTION_CLOSED" });
+      await settled.promise;
+      expect({ closes, closesInsideConnect }).toEqual({ closes: ATTEMPTS, closesInsideConnect: 0 });
+    } finally {
+      client.close();
+    }
+  });
+
+  test("an onclose that throws after a tls config failure is reported as an uncaught exception", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        process.on("uncaughtException", err => console.log("uncaught", err.message));
+        const client = new Bun.RedisClient("rediss://127.0.0.1:1", ${JSON.stringify(badTls)});
+        client.onclose = () => { throw new Error("from onclose"); };
+        const attempt = client.connect();
+        console.log("connect() returned");
+        await attempt.catch(err => console.log("connect rejected", err.code));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "connect() returned\nuncaught from onclose\nconnect rejected ERR_REDIS_CONNECTION_CLOSED\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
   test("a connect() issued from onclose is not fed the replies left over from the failed connection", async () => {
     // With a database in the URL, HELLO and SELECT are written together, so a
     // server that rejects HELLO delivers both error replies in one read.


### PR DESCRIPTION
Follow-up to #37993, opened against its branch because it reuses the deferred no-socket close added there. Turned up while testing that branch.

### Problem
- `new Bun.RedisClient("rediss://...", { tls: { ca: "not a certificate" } })` constructs fine; the attempt fails when `connect()` cannot build the `SSL_CTX`. That branch (`tls_ctx_failed` in `JSValkeyClient::connect`, src/runtime/valkey_jsc/js_valkey.rs) called `on_valkey_close()` inline, so the `connect()` promise was rejected and the user's `onclose` was called from inside the `connect()` (or command) call that started the attempt. Every other way an attempt can fail reports from the event loop.
- An `onclose` that dials again therefore re-entered the same branch on the same stack: `connect()` -> `onclose` -> `connect()` -> ... until JSC threw `Maximum call stack size exceeded`, which on a debug build ends in `ASSERTION FAILED: Unexpected exception observed` / `releaseAssertNoException` (abort). The same `onclose` against a refused port just loops through the event loop.
- An `onclose` that simply threw was also mishandled on this path: the exception came back out of `connect()` as a `crate::Error`, which `do_connect` takes to mean "dial failed" and answers by rejecting the promise that `on_valkey_close()` had already rejected (`ASSERTION FAILED: Promise is already resolved or rejected`, `JSC__JSPromise__reject`, abort on debug builds).

### Fix
- The branch keeps `enable_auto_reconnect = false` and the inline `fail()`, and replaces the inline `on_valkey_close()` (plus the socket ref it consumed) with `close_without_socket_next_tick()`, the task `reconnect()` already uses when a dial fails before a socket exists. The task marks the client disconnected and runs `on_close()`, which takes the manual-close path `fail()` set up and reaches `on_valkey_close()` on a fresh stack: a redialing `onclose` now loops through the event loop like it does against a refused port, and an `onclose` that throws is reported through the task's fold like any other callback.
- `fail()` stays inline on purpose: commands issued before the task runs are rejected as before, and because `failed` is set, the callers' `reset_connection_timeout()` arms nothing for an attempt that is already over. Only the JS-visible report (promise settlement and `onclose`) moves.
- The deferred close now holds a `Strong` on the JS wrapper while queued. A socket that is still going to report its close keeps the wrapper strong through `update_poll_ref()` (status `Connecting`); this queued close is invisible to `update_poll_ref()`, and after `fail()` nothing else it counts as activity is left, so the `update_poll_ref()` the callers run on the way out downgraded the wrapper before the task ran. With just the deferral, a client that only its pending attempt still referenced was collected in between and `connect()` never settled (0 of 100 settled in a `Bun.gc(true)` loop; 100 of 100 with the `Strong`). `reconnect()`'s existing use of the task was not affected (`is_reconnecting` keeps the wrapper strong there; 30 of 30 settled without the `Strong`), and `duplicate()` of a connected client is a case where nothing in JS references the new wrapper until its promise settles.
- Tests in test/js/valkey/reliability/connection-failures.test.ts ("Recovering After fail()" block, no server needed since nothing is dialed): the report arrives after the starting call returns, for both `connect()` and a command; an `onclose` that redials three times never runs inside a `connect()` call; an `onclose` that throws is reported as an uncaught exception and the process exits 0; and clients referenced by nothing but their pending attempt still get their rejection and `onclose` across a `Bun.gc(true)`. The first four fail against the base branch (the first three on their assertions, the throwing one with the abort above); the GC one fails by timing out against the deferral without the `Strong`.
- Also run on this branch: the rest of connection-failures.test.ts (the docker-gated block is skipped here) and test/js/valkey/valkey-gc.test.ts, whose first test is this exact failure under ASAN.

### Background
- `JSValkeyClient` is the native object behind `Bun.RedisClient`; it is intrusively refcounted, and separately holds `this_value`, a reference to its JS wrapper that `update_poll_ref()` flips between strong and weak depending on whether anything is still going to need the wrapper (an open or connecting socket, queued commands, a scheduled reconnect). The `connect()` promise lives in a slot on the wrapper and `onclose` is read from it, so a close reported after the wrapper is collected reports to nobody.
- `fail()` marks the client failed, rejects everything queued, and closes the socket if there is one; `on_close()` is what runs when a connection ends and decides between retrying and reporting the close (`on_valkey_close()` rejects the cached `connect()` promise and calls `onclose`). #37993 added `ValkeyDeferredClose::WithoutSocket`, an event-loop task that runs `on_close()` for an attempt that failed without ever having a socket, precisely so that `onclose` does not run inside the call that failed.
- `dispatch::fold` is how callbacks dispatched from the event loop report an exception their JS left pending: as an uncaught exception, rather than returning it to a caller that has no idea what to do with it.

<details>
<summary>Probes (debug build of the base branch)</summary>

Synchronous report, bad `ca` vs a real dial:

```
{"label":"bad ca","closesRightAfterConnect":1,"outcome":"rejected: ERR_REDIS_CONNECTION_CLOSED","closesAfterRejection":1}
{"label":"tls:true (real dial to port 1)","closesRightAfterConnect":0,"outcome":"rejected: ERR_REDIS_CONNECTION_CLOSED","closesAfterRejection":1}
```

Unbounded redial from `onclose`:

```
ASSERTION FAILED: Unexpected exception observed on thread ...
Error Exception: Maximum call stack size exceeded.
!exception()
.../JavaScriptCore/ExceptionScope.h(62) : void JSC::ExceptionScope::releaseAssertNoException()
panic(main thread): abort() called
```

`onclose` that throws:

```
ASSERTION FAILED: Promise is already resolved or rejected
arg0->status() == JSC::JSPromise::Status::Pending
../../src/jsc/bindings/bindings.cpp(3876) : void JSC__JSPromise__reject(...)
panic(main thread): abort() called
```

100 clients referenced by nothing but their pending `connect()`, `Bun.gc(true)` after each:

```
deferral only:        unreferenced {"settled":0,"closes":0}    referenced {"settled":100,"closes":100}
deferral + Strong:    unreferenced {"settled":100,"closes":100} referenced {"settled":100,"closes":100}
reconnect() path (#37993 as is), 30 unreferenced clients: {"settled":30,"closes":30}
```
</details>
