### PR TITLE
install: send credentials embedded in --registry and registry env var URLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,6 @@ version = "0.0.0"
 dependencies = [
  "bun_alloc",
  "bun_options_types",
- "bun_url",
 ]
 
 [[package]]

--- a/src/api/Cargo.toml
+++ b/src/api/Cargo.toml
@@ -12,4 +12,3 @@ workspace = true
 [dependencies]
 bun_alloc.workspace = true
 bun_options_types.workspace = true
-bun_url.workspace = true

--- a/src/api/lib.rs
+++ b/src/api/lib.rs
@@ -2,8 +2,7 @@
 #![warn(unused_must_use)]
 //! Re-exports of the install config types (`BunInstall`, `NpmRegistry`, …)
 //! whose canonical definitions live in `bun_options_types::schema::api`, plus
-//! the `Parser` handle through which the bunfig and npmrc loaders parse
-//! registry URL strings (`NpmRegistry::from_url`).
+//! the `Parser` handle used by the bunfig and npmrc loaders.
 
 // ──────────────────────────────────────────────────────────────────────────
 // Re-exports — canonical definitions live in `bun_options_types::schema::api`.
@@ -33,8 +32,6 @@ pub mod npm_registry {
     }
 
     impl<'a, L, S> Parser<'a, L, S> {
-        /// The bunfig / .npmrc entry point of `NpmRegistry::from_url`;
-        /// `--registry` and the registry env vars call that directly.
         pub fn parse_registry_url_string_impl(
             &mut self,
             str: &[u8],

--- a/src/api/lib.rs
+++ b/src/api/lib.rs
@@ -2,7 +2,8 @@
 #![warn(unused_must_use)]
 //! Re-exports of the install config types (`BunInstall`, `NpmRegistry`, …)
 //! whose canonical definitions live in `bun_options_types::schema::api`, plus
-//! the registry-URL parser shared by the bunfig and npmrc loaders.
+//! the `Parser` handle through which the bunfig and npmrc loaders parse
+//! registry URL strings (`NpmRegistry::from_url`).
 
 // ──────────────────────────────────────────────────────────────────────────
 // Re-exports — canonical definitions live in `bun_options_types::schema::api`.
@@ -19,8 +20,6 @@ pub use bun_options_types::schema::api::{
 /// `Parser` lives in a sibling module of `NpmRegistry`; the canonical path
 /// is `bun_api::npm_registry::Parser`.
 pub mod npm_registry {
-    use bun_url::URL;
-
     pub use super::NpmRegistry;
 
     // `Parser` stays generic over `L` (Log) / `S` (Source) so this leaf
@@ -34,28 +33,13 @@ pub mod npm_registry {
     }
 
     impl<'a, L, S> Parser<'a, L, S> {
+        /// The bunfig / .npmrc entry point of `NpmRegistry::from_url`;
+        /// `--registry` and the registry env vars call that directly.
         pub fn parse_registry_url_string_impl(
             &mut self,
             str: &[u8],
         ) -> Result<NpmRegistry, bun_alloc::AllocError> {
-            let url = URL::parse(str);
-            let mut registry = NpmRegistry::default();
-
-            // Token
-            if url.username.is_empty() && !url.password.is_empty() {
-                registry.token = Box::<[u8]>::from(url.password);
-                registry.url = url.href_without_auth();
-            } else if !url.username.is_empty() && !url.password.is_empty() {
-                registry.username = Box::<[u8]>::from(url.username);
-                registry.password = Box::<[u8]>::from(url.password);
-
-                registry.url = url.href_without_auth();
-            } else {
-                // Do not include a trailing slash. There might be parameters at the end.
-                registry.url = Box::<[u8]>::from(url.href);
-            }
-
-            Ok(registry)
+            Ok(NpmRegistry::from_url(str))
         }
     }
 }

--- a/src/ini/lib.rs
+++ b/src/ini/lib.rs
@@ -1303,16 +1303,12 @@ mod draft {
         configs
     }
 
-    fn has_credentials(registry: &NpmRegistry) -> bool {
-        !registry.token.is_empty() || !registry.username.is_empty() || !registry.password.is_empty()
-    }
-
     pub fn apply_registry_auth(install: &mut BunInstall, auth: &[RegistryAuth]) {
         if auth.is_empty() {
             return;
         }
         if let Some(registry) = install.default_registry.as_mut() {
-            if !has_credentials(registry) {
+            if !registry.has_credentials() {
                 for item in auth {
                     let matched = item.matches(if registry.url.is_empty() {
                         bun_install_types::NodeLinker::npm::Registry::DEFAULT_URL.as_bytes()
@@ -1327,7 +1323,7 @@ mod draft {
         }
         if let Some(scoped) = install.scoped.as_mut() {
             for registry in scoped.scopes.values_mut() {
-                if has_credentials(registry) {
+                if registry.has_credentials() {
                     continue;
                 }
                 for item in auth {

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -607,23 +607,20 @@ impl Options {
                     if !registry_.is_empty()
                         && (registry_.starts_with(b"https://") || registry_.starts_with(b"http://"))
                     {
-                        let prev_scope = self.scope.clone();
-                        let prev_url = prev_scope.url.url();
-                        let new_url = bun_url::URL::parse(registry_);
-                        let token = if bun_core::without_trailing_slash(new_url.host)
-                            == bun_core::without_trailing_slash(prev_url.host)
-                            && (new_url.is_https() || !prev_url.is_https())
-                        {
-                            prev_scope.token
-                        } else {
-                            Box::default()
-                        };
-                        // Default (empty strings) is the zero value for Api::NpmRegistry.
-                        let api_registry = Api::NpmRegistry {
-                            url: registry_.into(),
-                            token,
-                            ..Default::default()
-                        };
+                        let mut api_registry = Api::NpmRegistry::from_url(registry_);
+                        // Credentials written into the URL replace the configured
+                        // ones, like a `registry=` line with userinfo does in .npmrc.
+                        // Otherwise a token configured for the same host carries over.
+                        if !api_registry.has_credentials() {
+                            let prev_url = self.scope.url.url();
+                            let new_url = bun_url::URL::parse(&api_registry.url);
+                            if bun_core::without_trailing_slash(new_url.host)
+                                == bun_core::without_trailing_slash(prev_url.host)
+                                && (new_url.is_https() || !prev_url.is_https())
+                            {
+                                api_registry.token = core::mem::take(&mut self.scope.token);
+                            }
+                        }
                         self.scope = Npm::registry::Scope::from_api(b"", api_registry, env)?;
                         break;
                     }
@@ -688,22 +685,29 @@ impl Options {
                 .set(Enable::ONLY_MISSING, cli.only_missing || cli.analyze);
 
             if !cli.registry.is_empty() {
-                let new_url = bun_url::URL::parse(cli.registry);
-                let same_origin = {
-                    let prev_url = self.scope.url.url();
-                    bun_core::without_trailing_slash(new_url.host)
-                        == bun_core::without_trailing_slash(prev_url.host)
-                        && (new_url.is_https() || !prev_url.is_https())
-                };
-                if !same_origin {
-                    self.scope.token = Box::default();
-                    self.scope.auth = Box::default();
-                    self.scope.user = Box::default();
+                let api_registry = Api::NpmRegistry::from_url(cli.registry);
+                if api_registry.has_credentials() {
+                    // Same rule as the env registry above: credentials in the
+                    // URL replace whatever was configured for the registry.
+                    self.scope = Npm::registry::Scope::from_api(b"", api_registry, env)?;
+                } else {
+                    let new_url = bun_url::URL::parse(&api_registry.url);
+                    let same_origin = {
+                        let prev_url = self.scope.url.url();
+                        bun_core::without_trailing_slash(new_url.host)
+                            == bun_core::without_trailing_slash(prev_url.host)
+                            && (new_url.is_https() || !prev_url.is_https())
+                    };
+                    if !same_origin {
+                        self.scope.token = Box::default();
+                        self.scope.auth = Box::default();
+                        self.scope.user = Box::default();
+                    }
+                    let href = api_registry.url;
+                    self.scope.url_hash =
+                        Npm::registry::Scope::hash(bun_core::without_trailing_slash(&href));
+                    self.scope.url = bun_url::OwnedURL::from_href(href);
                 }
-                let href: Box<[u8]> = cli.registry.into();
-                self.scope.url_hash =
-                    Npm::registry::Scope::hash(bun_core::without_trailing_slash(&href));
-                self.scope.url = bun_url::OwnedURL::from_href(href);
             }
 
             if let Some(cache_dir) = cli.cache_dir {

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -626,6 +626,32 @@ impl Options {
             }
         }
 
+        if let Some(cli) = &maybe_cli {
+            if !cli.registry.is_empty() {
+                let api_registry = Api::NpmRegistry::from_url(cli.registry);
+                if api_registry.has_credentials() {
+                    self.scope = Npm::registry::Scope::from_api(b"", api_registry, env)?;
+                } else {
+                    let new_url = bun_url::URL::parse(&api_registry.url);
+                    let same_origin = {
+                        let prev_url = self.scope.url.url();
+                        bun_core::without_trailing_slash(new_url.host)
+                            == bun_core::without_trailing_slash(prev_url.host)
+                            && (new_url.is_https() || !prev_url.is_https())
+                    };
+                    if !same_origin {
+                        self.scope.token = Box::default();
+                        self.scope.auth = Box::default();
+                        self.scope.user = Box::default();
+                    }
+                    let href = api_registry.url;
+                    self.scope.url_hash =
+                        Npm::registry::Scope::hash(bun_core::without_trailing_slash(&href));
+                    self.scope.url = bun_url::OwnedURL::from_href(href);
+                }
+            }
+        }
+
         {
             const TOKEN_KEYS: [&[u8]; 3] = [
                 b"BUN_CONFIG_TOKEN",
@@ -681,30 +707,6 @@ impl Options {
             self.do_.set(Do::ANALYZE, cli.analyze);
             self.enable
                 .set(Enable::ONLY_MISSING, cli.only_missing || cli.analyze);
-
-            if !cli.registry.is_empty() {
-                let api_registry = Api::NpmRegistry::from_url(cli.registry);
-                if api_registry.has_credentials() {
-                    self.scope = Npm::registry::Scope::from_api(b"", api_registry, env)?;
-                } else {
-                    let new_url = bun_url::URL::parse(&api_registry.url);
-                    let same_origin = {
-                        let prev_url = self.scope.url.url();
-                        bun_core::without_trailing_slash(new_url.host)
-                            == bun_core::without_trailing_slash(prev_url.host)
-                            && (new_url.is_https() || !prev_url.is_https())
-                    };
-                    if !same_origin {
-                        self.scope.token = Box::default();
-                        self.scope.auth = Box::default();
-                        self.scope.user = Box::default();
-                    }
-                    let href = api_registry.url;
-                    self.scope.url_hash =
-                        Npm::registry::Scope::hash(bun_core::without_trailing_slash(&href));
-                    self.scope.url = bun_url::OwnedURL::from_href(href);
-                }
-            }
 
             if let Some(cache_dir) = cli.cache_dir {
                 self.cache_directory = cache_dir;

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -608,9 +608,7 @@ impl Options {
                         && (registry_.starts_with(b"https://") || registry_.starts_with(b"http://"))
                     {
                         let mut api_registry = Api::NpmRegistry::from_url(registry_);
-                        // Credentials written into the URL replace the configured
-                        // ones, like a `registry=` line with userinfo does in .npmrc.
-                        // Otherwise a token configured for the same host carries over.
+                        // Credentials in the URL win, as they do for `registry=` in .npmrc.
                         if !api_registry.has_credentials() {
                             let prev_url = self.scope.url.url();
                             let new_url = bun_url::URL::parse(&api_registry.url);
@@ -687,8 +685,6 @@ impl Options {
             if !cli.registry.is_empty() {
                 let api_registry = Api::NpmRegistry::from_url(cli.registry);
                 if api_registry.has_credentials() {
-                    // Same rule as the env registry above: credentials in the
-                    // URL replace whatever was configured for the registry.
                     self.scope = Npm::registry::Scope::from_api(b"", api_registry, env)?;
                 } else {
                     let new_url = bun_url::URL::parse(&api_registry.url);

--- a/src/options_types/schema.rs
+++ b/src/options_types/schema.rs
@@ -152,6 +152,37 @@ pub mod api {
         pub email: Box<[u8]>,
     }
 
+    impl NpmRegistry {
+        /// Parses a registry given as a bare URL string (`registry=` in
+        /// .npmrc, `install.registry = "..."` in bunfig, `--registry`,
+        /// `BUN_CONFIG_REGISTRY`). Credentials written into the URL are moved
+        /// out of it: `https://user:pass@host/` becomes `username`/`password`
+        /// and `https://:token@host/` becomes `token`, so the stored `url`
+        /// never carries them.
+        pub fn from_url(str: &[u8]) -> NpmRegistry {
+            let url = bun_url::URL::parse(str);
+            let mut registry = NpmRegistry::default();
+
+            if url.username.is_empty() && !url.password.is_empty() {
+                registry.token = Box::from(url.password);
+                registry.url = url.href_without_auth();
+            } else if !url.username.is_empty() && !url.password.is_empty() {
+                registry.username = Box::from(url.username);
+                registry.password = Box::from(url.password);
+                registry.url = url.href_without_auth();
+            } else {
+                // Do not include a trailing slash. There might be parameters at the end.
+                registry.url = Box::from(url.href);
+            }
+
+            registry
+        }
+
+        pub fn has_credentials(&self) -> bool {
+            !self.token.is_empty() || !self.username.is_empty() || !self.password.is_empty()
+        }
+    }
+
     /// Per-scope npm registry overrides, keyed by scope name.
     #[derive(Default)]
     pub struct NpmRegistryMap {

--- a/src/options_types/schema.rs
+++ b/src/options_types/schema.rs
@@ -153,12 +153,8 @@ pub mod api {
     }
 
     impl NpmRegistry {
-        /// Parses a registry given as a bare URL string (`registry=` in
-        /// .npmrc, `install.registry = "..."` in bunfig, `--registry`,
-        /// `BUN_CONFIG_REGISTRY`). Credentials written into the URL are moved
-        /// out of it: `https://user:pass@host/` becomes `username`/`password`
-        /// and `https://:token@host/` becomes `token`, so the stored `url`
-        /// never carries them.
+        /// `https://user:pass@host/` fills `username`/`password` and
+        /// `https://:token@host/` fills `token`; `url` is stored without them.
         pub fn from_url(str: &[u8]) -> NpmRegistry {
             let url = bun_url::URL::parse(str);
             let mut registry = NpmRegistry::default();

--- a/src/options_types/schema.rs
+++ b/src/options_types/schema.rs
@@ -153,8 +153,6 @@ pub mod api {
     }
 
     impl NpmRegistry {
-        /// `https://user:pass@host/` fills `username`/`password` and
-        /// `https://:token@host/` fills `token`; `url` is stored without them.
         pub fn from_url(str: &[u8]) -> NpmRegistry {
             let url = bun_url::URL::parse(str);
             let mut registry = NpmRegistry::default();

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -868,6 +868,7 @@ impl PublishCommand {
         let registry_url = registry.url.url();
 
         if registry.token.is_empty()
+            && registry.auth.is_empty()
             && (registry_url.password.is_empty() || registry_url.username.is_empty())
         {
             return Err(PublishError::NeedAuth);

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -807,6 +807,95 @@ describe("--dry-run", async () => {
   });
 });
 
+describe.concurrent("credentials in the registry url", () => {
+  // Records every request; `bun publish` against it must send exactly one authenticated PUT.
+  function registryMock() {
+    const requests: { method: string; pathname: string; authorization: string | null }[] = [];
+    const server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        requests.push({
+          method: req.method,
+          pathname: new URL(req.url).pathname,
+          authorization: req.headers.get("authorization"),
+        });
+        return new Response("OK", { status: 200 });
+      },
+    });
+    return {
+      requests,
+      port: server.port,
+      [Symbol.dispose]: () => server.stop(true),
+    };
+  }
+
+  async function packageDirFor(name: string) {
+    const packageDir = tmpdirSync();
+    await write(join(packageDir, "package.json"), JSON.stringify({ name, version: "1.0.0" }));
+    return packageDir;
+  }
+
+  const basicAuth = `Basic ${Buffer.from("pubuser:hunter2").toString("base64")}`;
+
+  test("--registry with user:pass@ publishes with Basic auth", async () => {
+    using mock = registryMock();
+    const packageDir = await packageDirFor("userinfo-flag-pkg");
+
+    const { out, err, exitCode } = await publish(
+      env,
+      packageDir,
+      "--registry",
+      `http://pubuser:hunter2@localhost:${mock.port}/`,
+    );
+    expect(err).not.toContain("error:");
+    expect(out).toContain(`Registry: http://localhost:${mock.port}/\n`);
+    expect(out).toContain(" + userinfo-flag-pkg@1.0.0");
+    expect(out).not.toContain("hunter2");
+    expect(err).not.toContain("hunter2");
+    expect(mock.requests).toEqual([{ method: "PUT", pathname: "/userinfo-flag-pkg", authorization: basicAuth }]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("--registry with :token@ publishes with a Bearer token", async () => {
+    using mock = registryMock();
+    const packageDir = await packageDirFor("userinfo-token-pkg");
+
+    const { out, err, exitCode } = await publish(
+      env,
+      packageDir,
+      "--registry",
+      `http://:publish-token@localhost:${mock.port}/`,
+    );
+    expect(err).not.toContain("error:");
+    expect(out).toContain(" + userinfo-token-pkg@1.0.0");
+    expect(out).not.toContain("publish-token");
+    expect(mock.requests).toEqual([
+      { method: "PUT", pathname: "/userinfo-token-pkg", authorization: "Bearer publish-token" },
+    ]);
+    expect(exitCode).toBe(0);
+  });
+
+  test.each(["npm_config_registry", "NPM_CONFIG_REGISTRY", "BUN_CONFIG_REGISTRY"])(
+    "%s with user:pass@ publishes with Basic auth",
+    async key => {
+      using mock = registryMock();
+      const packageDir = await packageDirFor("userinfo-env-pkg");
+
+      const { out, err, exitCode } = await publish(
+        { ...env, [key]: `http://pubuser:hunter2@localhost:${mock.port}/` },
+        packageDir,
+      );
+      expect(err).not.toContain("error:");
+      expect(out).toContain(`Registry: http://localhost:${mock.port}/\n`);
+      expect(out).toContain(" + userinfo-env-pkg@1.0.0");
+      expect(out).not.toContain("hunter2");
+      expect(err).not.toContain("hunter2");
+      expect(mock.requests).toEqual([{ method: "PUT", pathname: "/userinfo-env-pkg", authorization: basicAuth }]);
+      expect(exitCode).toBe(0);
+    },
+  );
+});
+
 describe("lifecycle scripts", async () => {
   const script = `const fs = require("fs");
     fs.writeFileSync(process.argv[2] + ".txt", \`

--- a/test/cli/install/config-precedence.test.ts
+++ b/test/cli/install/config-precedence.test.ts
@@ -549,6 +549,20 @@ describe.concurrent("bun install config precedence", () => {
     expect(exitCode).toBe(0);
   });
 
+  test("BUN_CONFIG_TOKEN beats credentials embedded in the --registry URL", async () => {
+    using capture = capturingRegistry();
+    using dir = tempDir("config-precedence", {
+      "project/package.json": packageJson({ "@needs-auth/test-pkg": "1.0.0" }),
+    });
+    const { stderr, exitCode } = await install(String(dir), ["--registry", withUserinfo(capture, ":wrong-token")], {
+      BUN_CONFIG_TOKEN: authToken,
+    });
+    expect(stderr).not.toContain("error:");
+    expect(new Set(capture.authorizations)).toStrictEqual(new Set([`Bearer ${authToken}`]));
+    expect(installed(String(dir), "@needs-auth", "test-pkg")).toBe(true);
+    expect(exitCode).toBe(0);
+  });
+
   test.each(["BUN_CONFIG_REGISTRY", "NPM_CONFIG_REGISTRY", "npm_config_registry"])(
     "%s with user:pass@ in the URL sends Basic auth",
     async key => {
@@ -620,6 +634,38 @@ describe.concurrent("bun install config precedence", () => {
     });
     const { stderr, exitCode } = await install(String(dir), [], { BUN_CONFIG_TOKEN: authToken });
     expect(stderr).not.toContain("error:");
+    expect(new Set(capture.authorizations)).toStrictEqual(new Set([`Bearer ${authToken}`]));
+    expect(installed(String(dir), "@needs-auth", "test-pkg")).toBe(true);
+    expect(exitCode).toBe(0);
+  });
+
+  test.each(["BUN_CONFIG_TOKEN", "NPM_CONFIG_TOKEN"])(
+    "%s applies to the registry passed with --registry",
+    async key => {
+      using capture = capturingRegistry();
+      using dir = tempDir("config-precedence", {
+        "project/package.json": packageJson({ "@needs-auth/test-pkg": "1.0.0" }),
+      });
+      const { stderr, exitCode } = await install(String(dir), ["--registry", capture.url], { [key]: authToken });
+      expect(stderr).not.toContain("error:");
+      expect(new Set(capture.authorizations)).toStrictEqual(new Set([`Bearer ${authToken}`]));
+      expect(installed(String(dir), "@needs-auth", "test-pkg")).toBe(true);
+      expect(exitCode).toBe(0);
+    },
+  );
+
+  test("--registry drops the _authToken of the .npmrc registry but keeps BUN_CONFIG_TOKEN", async () => {
+    using dead = deadRegistry();
+    using capture = capturingRegistry();
+    using dir = tempDir("config-precedence", {
+      "project/.npmrc": `registry=${dead.url}\n//localhost:${dead.server.port}/:_authToken=token-for-dead\n`,
+      "project/package.json": packageJson({ "@needs-auth/test-pkg": "1.0.0" }),
+    });
+    const { stderr, exitCode } = await install(String(dir), ["--registry", capture.url], {
+      BUN_CONFIG_TOKEN: authToken,
+    });
+    expect(stderr).not.toContain("error:");
+    expect(dead.hits).toBe(0);
     expect(new Set(capture.authorizations)).toStrictEqual(new Set([`Bearer ${authToken}`]));
     expect(installed(String(dir), "@needs-auth", "test-pkg")).toBe(true);
     expect(exitCode).toBe(0);

--- a/test/cli/install/config-precedence.test.ts
+++ b/test/cli/install/config-precedence.test.ts
@@ -515,6 +515,103 @@ describe.concurrent("bun install config precedence", () => {
     expect(exitCode).toBe(0);
   });
 
+  // `http://user:pass@host/` in a registry URL is sent as Basic auth and `http://:token@host/` as a Bearer
+  // token, however the URL reaches bun. The .npmrc / bunfig string forms already did this; these cover
+  // --registry and the registry env vars, which used to drop the credentials.
+  const basicAuth = `Basic ${Buffer.from("config-precedence:verysecure").toString("base64")}`;
+  const withUserinfo = (capture: { port: number }, userinfo: string) => `http://${userinfo}@localhost:${capture.port}/`;
+
+  test("--registry with user:pass@ in the URL sends Basic auth", async () => {
+    using capture = capturingRegistry();
+    using dir = tempDir("config-precedence", {
+      "project/package.json": packageJson({ "@needs-auth/test-pkg": "1.0.0" }),
+    });
+    const { stderr, exitCode } = await install(String(dir), [
+      "--registry",
+      withUserinfo(capture, "config-precedence:verysecure"),
+    ]);
+    expect(stderr).not.toContain("error:");
+    expect(stderr).not.toContain("verysecure");
+    expect(new Set(capture.authorizations)).toStrictEqual(new Set([basicAuth]));
+    expect(installed(String(dir), "@needs-auth", "test-pkg")).toBe(true);
+    expect(exitCode).toBe(0);
+  });
+
+  test("--registry with :token@ in the URL sends it as a Bearer token", async () => {
+    using capture = capturingRegistry();
+    using dir = tempDir("config-precedence", {
+      "project/package.json": packageJson({ "@needs-auth/test-pkg": "1.0.0" }),
+    });
+    const { stderr, exitCode } = await install(String(dir), ["--registry", withUserinfo(capture, `:${authToken}`)]);
+    expect(stderr).not.toContain("error:");
+    expect(new Set(capture.authorizations)).toStrictEqual(new Set([`Bearer ${authToken}`]));
+    expect(installed(String(dir), "@needs-auth", "test-pkg")).toBe(true);
+    expect(exitCode).toBe(0);
+  });
+
+  test.each(["BUN_CONFIG_REGISTRY", "NPM_CONFIG_REGISTRY", "npm_config_registry"])(
+    "%s with user:pass@ in the URL sends Basic auth",
+    async key => {
+      using capture = capturingRegistry();
+      using dir = tempDir("config-precedence", {
+        "project/package.json": packageJson({ "@needs-auth/test-pkg": "1.0.0" }),
+      });
+      const { stderr, exitCode } = await install(String(dir), [], {
+        [key]: withUserinfo(capture, "config-precedence:verysecure"),
+      });
+      expect(stderr).not.toContain("error:");
+      expect(stderr).not.toContain("verysecure");
+      expect(new Set(capture.authorizations)).toStrictEqual(new Set([basicAuth]));
+      expect(installed(String(dir), "@needs-auth", "test-pkg")).toBe(true);
+      expect(exitCode).toBe(0);
+    },
+  );
+
+  test("BUN_CONFIG_REGISTRY with :token@ in the URL sends it as a Bearer token", async () => {
+    using capture = capturingRegistry();
+    using dir = tempDir("config-precedence", {
+      "project/package.json": packageJson({ "@needs-auth/test-pkg": "1.0.0" }),
+    });
+    const { stderr, exitCode } = await install(String(dir), [], {
+      BUN_CONFIG_REGISTRY: withUserinfo(capture, `:${authToken}`),
+    });
+    expect(stderr).not.toContain("error:");
+    expect(new Set(capture.authorizations)).toStrictEqual(new Set([`Bearer ${authToken}`]));
+    expect(installed(String(dir), "@needs-auth", "test-pkg")).toBe(true);
+    expect(exitCode).toBe(0);
+  });
+
+  test("user:pass@ in --registry replaces the .npmrc _authToken for the same host", async () => {
+    using capture = capturingRegistry();
+    using dir = tempDir("config-precedence", {
+      "project/.npmrc": `registry=${capture.url}\n//localhost:${capture.port}/:_authToken=token-from-npmrc\n`,
+      "project/package.json": packageJson({ "@needs-auth/test-pkg": "1.0.0" }),
+    });
+    const { stderr, exitCode } = await install(String(dir), [
+      "--registry",
+      withUserinfo(capture, "config-precedence:verysecure"),
+    ]);
+    expect(stderr).not.toContain("error:");
+    expect(new Set(capture.authorizations)).toStrictEqual(new Set([basicAuth]));
+    expect(installed(String(dir), "@needs-auth", "test-pkg")).toBe(true);
+    expect(exitCode).toBe(0);
+  });
+
+  test("user:pass@ in BUN_CONFIG_REGISTRY replaces the .npmrc _authToken for the same host", async () => {
+    using capture = capturingRegistry();
+    using dir = tempDir("config-precedence", {
+      "project/.npmrc": `registry=${capture.url}\n//localhost:${capture.port}/:_authToken=token-from-npmrc\n`,
+      "project/package.json": packageJson({ "@needs-auth/test-pkg": "1.0.0" }),
+    });
+    const { stderr, exitCode } = await install(String(dir), [], {
+      BUN_CONFIG_REGISTRY: withUserinfo(capture, "config-precedence:verysecure"),
+    });
+    expect(stderr).not.toContain("error:");
+    expect(new Set(capture.authorizations)).toStrictEqual(new Set([basicAuth]));
+    expect(installed(String(dir), "@needs-auth", "test-pkg")).toBe(true);
+    expect(exitCode).toBe(0);
+  });
+
   test("BUN_CONFIG_TOKEN beats the _authToken in ~/.npmrc", async () => {
     using capture = capturingRegistry();
     using dir = tempDir("config-precedence", {

--- a/test/cli/install/redacted-config-logs.test.ts
+++ b/test/cli/install/redacted-config-logs.test.ts
@@ -3,10 +3,12 @@ import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir, tmpdirSync } from "harness";
 import { join } from "path";
 
-test("registry url password is masked in request error output", async () => {
+test("registry url password is sent as Basic auth and left out of request error output", async () => {
+  const authorizations: (string | null)[] = [];
   await using server = Bun.serve({
     port: 0,
-    fetch() {
+    fetch(req) {
+      authorizations.push(req.headers.get("authorization"));
       return new Response(JSON.stringify({ error: "unauthorized" }), {
         status: 401,
         headers: { "content-type": "application/json" },
@@ -32,10 +34,34 @@ test("registry url password is masked in request error output", async () => {
 
   const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(err).toContain(`401 Unauthorized: http://user:**********@${server.hostname}:${server.port}/is-number`);
+  expect(authorizations).toEqual([`Basic ${Buffer.from("user:secretpass").toString("base64")}`]);
+  expect(err).toContain(`401 Unauthorized: http://${server.hostname}:${server.port}/is-number`);
   expect(err).not.toContain("secretpass");
   expect(out).not.toContain("secretpass");
   expect(exitCode).toBe(1);
+});
+
+test("url password is masked in the verbose request line", async () => {
+  await using server = Bun.serve({
+    port: 0,
+    fetch() {
+      return new Response("ok");
+    },
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `await fetch("http://user:secretpass@${server.hostname}:${server.port}/pkg")`],
+    env: { ...bunEnv, NO_COLOR: "1", BUN_CONFIG_VERBOSE_FETCH: "1" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(err).toContain(`GET http://user:**********@${server.hostname}:${server.port}/pkg`);
+  expect(err).not.toContain("secretpass");
+  expect(out).not.toContain("secretpass");
+  expect(exitCode).toBe(0);
 });
 
 test("registry port is not mistaken for a credential when the package is scoped", async () => {


### PR DESCRIPTION
### Problem
- A registry URL with credentials in it (`http://user:pass@host/`, or `http://:token@host/`) passed as `--registry`, or through `BUN_CONFIG_REGISTRY` / `NPM_CONFIG_REGISTRY` / `npm_config_registry`, sends no `Authorization` header. Against a registry that logs the header (bun 1.4.0, also `main`):
  - `bun publish --registry http://alice:s3cret@127.0.0.1:PORT/` publishes with exit 0 and the registry sees `PUT /ui-pkg authorization=null`; same with `npm_config_registry=...`.
  - `bun pm view somepkg --registry http://alice:s3cret@...` and `bun install --registry http://alice:s3cret@...`: `GET /somepkg authorization=null`.
  - The same URL as `registry=` in `.npmrc` sends `Authorization: Basic YWxpY2U6czNjcmV0` on the manifest and the tarball. npm 11 sends Basic for the flag and the env var too (`minipass-fetch` passes URL userinfo as node's `auth` option).
- Because the credentials stay inside the stored registry URL, they end up in the manifest URL and `bun install` prints them on failure: `error: GET http://alice:s3cret@127.0.0.1:PORT/somepkg - 401`.
- Cause: the config file string forms go through the userinfo splitter (`parse_registry_url_string_impl`, `src/api/lib.rs`), which moves `user:pass` into `NpmRegistry.username`/`password` (or `token`) and strips it from the URL. The flag and env var paths did not:
  - `src/install/PackageManager/PackageManagerOptions.rs`, registry env vars: built `Api::NpmRegistry { url: <raw value> }` and called `Scope::from_api`, which does not read URL userinfo.
  - same file, `--registry`: stored the raw href into `self.scope.url` directly.
  - `src/runtime/cli/publish_command.rs` `publish()`: the "missing authentication" check accepted userinfo in the URL as credentials, so publish went ahead and sent the PUT without a header. The HTTP client (`src/http`) never reads URL userinfo.
- Found while looking at the publish pre-flight check (#38776), not from a user report; the effects above are what the repro shows.
- Also fixed here (folded in from #38764, cdca4ff331): `BUN_CONFIG_TOKEN` / `NPM_CONFIG_TOKEN` were applied before `--registry`, so the host-mismatch check in the `--registry` block dropped them too and `BUN_CONFIG_TOKEN=... bun install --registry <other host>` failed with a 401.

### Fix
- `NpmRegistry::from_url` (`src/options_types/schema.rs`) is the splitter, moved next to the type so `bun_install` can call it; `bun_api`'s `parse_registry_url_string_impl` (the bunfig and `.npmrc` entry point) delegates to it, so there is one parse for every registry URL string. `bun_api` loses its now unused `bun_url` dependency, and `bun_ini`'s private `has_credentials` helper is replaced by the method the new call sites needed.
- The registry env vars and `--registry` run their value through `from_url`:
  - credentials in the URL: the scope is rebuilt with `Scope::from_api`, exactly as for a config file registry string, so `Scope.auth` (Basic) or `Scope.token` (Bearer) is populated and the stored URL no longer contains the userinfo. They replace whatever the config files set up for that registry, which is the rule `.npmrc` already applies (a `registry=` line with userinfo wins over `//host/:_authToken=`: `apply_registry_auth` in `src/ini/lib.rs` skips registries that already have credentials).
  - no credentials in the URL: unchanged (env var keeps a same-host token, `--registry` keeps same-origin credentials and drops them otherwise); `from_url` returns the input href unchanged in that case.
- The `--registry` block now runs before the token env vars are read (cdca4ff331), so the env token survives a registry switch and layers on top of both overrides. Resulting order, lowest to highest: config files, credentials in the `--registry` / registry env var URL, `BUN_CONFIG_TOKEN` / `NPM_CONFIG_TOKEN`, `--token`.
- `publish()` also accepts `Scope.auth` in its pre-flight check, which is where the Basic credentials land. Same one-line hunk as #38776 (the config file side of that check, reported in #17531); it merges in either order and closing those reports is left to #38776.
- Why the split belongs at the string entry points rather than only inside `Scope::from_api`: the loaders need the split result before a scope exists. `.npmrc` loading decides whether host-keyed `_authToken` entries apply by looking at the parsed registry's credentials, and the two override layers decide whether to carry configured credentials over the same way. So the parse-time split is required regardless, and this change wires in the two string entry points that were missing from it. Two ways a URL with userinfo can still reach `from_api` unsplit remain: the bunfig object form `registry = { url = "http://u:p@host/" }` (documented with separate `username`/`password`/`token` fields) and a `registry = "$VAR"` whose value carries userinfo, since `$VAR` is only expanded inside `from_api`. Both need a split inside `from_api` itself, which is tracked separately and kept out of this change because #38183 is rewriting that function's tail; this is also why the publish check keeps its URL userinfo clause.
- Tests (every new case fails on the released bun and passes with this change):
  - `test/cli/install/config-precedence.test.ts`: `bun install` with `--registry` and with each of the three env vars, user:pass form (Basic arrives on every request and verdaccio accepts it, `@needs-auth/test-pkg` installs, password not in stderr) and `:token@` form (Bearer); URL credentials replace a same-host `.npmrc` `_authToken` (flag and env var); from cdca4ff331: `BUN_CONFIG_TOKEN` beats a token in the `--registry` URL, `BUN_CONFIG_TOKEN` / `NPM_CONFIG_TOKEN` apply to the `--registry` registry, and `--registry` drops the `.npmrc` token for the previous host but keeps `BUN_CONFIG_TOKEN`.
  - `test/cli/install/bun-publish.test.ts`, `credentials in the registry url`: `--registry` user:pass (PUT carries Basic, summary line has no userinfo), `--registry` `:token@` (Bearer; previously "missing authentication"), the three env vars.
  - `test/cli/install/redacted-config-logs.test.ts`: the `pm view` test that asserted the password is masked in the 401 line now asserts Basic is sent and the printed URL has no userinfo (the masked form depended on this bug); a verbose `fetch()` case keeps the URL password masking of `redacted_npm_url` covered.
  - Also run with the debug build: all of `bun-publish.test.ts`, `config-precedence.test.ts`, `redacted-config-logs.test.ts`, `npmrc.test.ts`, the `.env` registry override and env var priority tests in `bun-install-registry.test.ts`; `cargo clippy` on the touched crates; the source lints.
- Overlap with open work: #37095 adds the same `from_url` while deleting `bun_api` and `schema.rs` (whichever lands second rebases onto the other's copy; the call sites are the same either way); #38183 touches the same `--registry` block for URL normalization.

### Background
- `Api::NpmRegistry` is the parsed config for one registry: `url` plus optional `username`/`password`/`token`, produced by bunfig and `.npmrc` loading. `Scope::from_api` (`src/install/npm.rs`) turns it into a `Scope`, the resolved registry the package manager uses: the URL, `token` (sent as `Authorization: Bearer`) and `auth` (base64 `user:password`, sent as `Authorization: Basic`; `user` keeps the plain pair for `pm whoami`). Requests only ever look at `Scope.token` / `Scope.auth`; a URL's userinfo is never sent by the HTTP client.
- `Options::load` builds the default scope in layers: config files, the registry env vars, `--registry`, the token env vars, then the remaining CLI flags (`--token`). The registry env vars and `--registry` are the two layers that accept a registry URL string without going through the config parsers, which is why they are the ones changed.
- `URL::href_without_auth()` is the existing helper the splitter uses to rebuild the URL without its userinfo. For a registry with no path it yields `http://host//`; every consumer strips or collapses the extra slash (this pre-dates the change and applies to the `.npmrc` form today), so it is left alone here.

<details>
<summary>Probe against a mock registry (released bun 1.4.0 vs this branch)</summary>

```
# released
bun publish --registry http://alice:s3cret@127.0.0.1:PORT/        -> exit 0,  REQ PUT /ui-pkg authorization=null
npm_config_registry=http://alice:s3cret@...  bun publish            -> exit 0,  REQ PUT /ui-pkg authorization=null
bun pm view somepkg version --registry http://alice:s3cret@...      ->          REQ GET /somepkg authorization=null
bun install --registry http://alice:s3cret@...  (registry answers 401)
    error: GET http://alice:s3cret@127.0.0.1:PORT/somepkg - 401
.npmrc registry=http://alice:s3cret@...  bun install                 ->          REQ GET /somepkg authorization=Basic YWxpY2U6czNjcmV0
npm view somepkg --registry http://alice:s3cret@...                 ->          REQ GET /somepkg authorization=Basic YWxpY2U6czNjcmV0

# this branch
bun publish --registry http://alice:s3cret@...                      -> Registry: http://127.0.0.1:PORT/   REQ PUT /ui-pkg authorization=Basic YWxpY2U6czNjcmV0
BUN_CONFIG_REGISTRY=http://alice:s3cret@...  bun publish            ->                                    REQ PUT /ui-pkg authorization=Basic YWxpY2U6czNjcmV0
bun publish --registry http://:tok123@...                           ->                                    REQ PUT /ui-pkg authorization=Bearer tok123
bun pm view somepkg version --registry http://alice:s3cret@...      ->                                    REQ GET /somepkg authorization=Basic YWxpY2U6czNjcmV0
bun pm whoami --registry http://alice:s3cret@...                    -> alice
bun publish --registry http://alice@...  (no password)              -> error: missing authentication (unchanged)
bunfig install.registry = "http://alice:s3cret@..." (string form)   -> still Basic, via the delegating parser
```
</details>
