### PR TITLE
install: read git+git:// resolutions back from bun.lock

### DIFF
--- a/src/install/dependency.rs
+++ b/src/install/dependency.rs
@@ -806,7 +806,12 @@ impl TagExt for Tag {
                                 }
                             }
                             b'+' => {
-                                if url.starts_with(b"+ssh:") || url.starts_with(b"+file:") {
+                                // `git+git:` is how a Git resolution of a `git://` dependency is
+                                // written back to bun.lock (`git+` label + the original URL).
+                                if url.starts_with(b"+ssh:")
+                                    || url.starts_with(b"+file:")
+                                    || url.starts_with(b"+git:")
+                                {
                                     return Tag::Git;
                                 }
                                 if url.starts_with(b"+http") {

--- a/src/install/dependency.rs
+++ b/src/install/dependency.rs
@@ -806,8 +806,7 @@ impl TagExt for Tag {
                                 }
                             }
                             b'+' => {
-                                // `git+git:` is how a Git resolution of a `git://` dependency is
-                                // written back to bun.lock (`git+` label + the original URL).
+                                // bun.lock writes a `git://` resolution as `git+git://...`.
                                 if url.starts_with(b"+ssh:")
                                     || url.starts_with(b"+file:")
                                     || url.starts_with(b"+git:")

--- a/test/cli/install/migration/migrate.test.ts
+++ b/test/cli/install/migration/migrate.test.ts
@@ -964,6 +964,31 @@ describe("package-lock.json migration fixes", () => {
     expect(fs.existsSync(join(String(dir), "node_modules/alias/index.js"))).toBeTrue();
   });
 
+  // A git resolution is written to bun.lock as "git+" + the repository URL, so a
+  // dependency on a plain git:// host comes back as "git+git://...". The lockfile
+  // parser has to accept that spelling, otherwise every later install throws the
+  // lockfile away ("Unexpected resolution") and --frozen-lockfile can never pass.
+  test.concurrent("git:// hosts round-trip through bun.lock", async () => {
+    const dependencies = {
+      g: "git://example.com/user/g.git",
+      h: "git://example.com/user/h.git#v1",
+    };
+    using dir = synthetic("npm-migrate-git-protocol", {
+      "package.json": JSON.stringify({ name: "git-protocol", dependencies }),
+      "package-lock.json": npmLock("git-protocol", {
+        "": { name: "git-protocol", dependencies },
+        "node_modules/g": { version: "1.0.0", resolved: `git://example.com/user/g.git#${sha(1)}` },
+        "node_modules/h": { version: "1.0.0", resolved: `git://example.com/user/h.git#${sha(2)}` },
+      }),
+    });
+
+    const { lock } = await migrate(dir);
+    expect(lock.workspaces[""].dependencies).toStrictEqual(dependencies);
+    expect(lock.packages.g[0]).toBe(`g@git+git://example.com/user/g.git#${sha(1)}`);
+    expect(lock.packages.h[0]).toBe(`h@git+git://example.com/user/h.git#${sha(2)}`);
+    await frozen(dir);
+  });
+
   test.concurrent("root bundleDependencies keeps its subtree (B2)", async () => {
     using dir = fixture("testing-rebuild-bundle--a");
     const { text, lock } = await migrate(dir);


### PR DESCRIPTION
### Problem
- A dependency on a plain `git://` URL (what `git daemon` serves, e.g. `"repo-a": "git://127.0.0.1:9418/repo-a#v1.0.0"`) installs, but every install after that one prints `error: Unexpected resolution: git+git://127.0.0.1:9418/repo-a#49b7cef...` / `InvalidLockfile: failed to parse lockfile: 'bun.lock'`, warns `Ignoring lockfile`, and re-resolves from scratch.
- Because the lockfile never loads, `bun install --frozen-lockfile` always fails with `lockfile had changes, but lockfile is frozen`, and `bun pm ls`, `bun dedupe` and `bun prune` exit 1 on the same parse error. The same happens to a `bun.lock` migrated from a `package-lock.json` that has a `"resolved": "git://..."` entry (the form npm 11 writes).
- Cause: `bun.lock` writes every Git resolution as the `git+` label followed by the repository URL as written (`src/install/lockfile/bun.lock.rs`, `repo.fmt("git+", ...)`), so a `git://` dependency becomes `git+git://host/repo#sha`. When the lockfile is read back, `Resolution::from_text_lockfile` (`src/install/resolution.rs`) classifies that string with `Tag::infer` (`src/install/dependency.rs`), whose `git+` branch only knows `git+ssh:`, `git+file:` and `git+http(s):`. `git+git:` falls through to `DistTag`, which `from_text_lockfile` reports as `UnexpectedResolution`.
- On 1.3.14 this was hidden because `git://` dependencies did not install at all there (`no commit matching ...`); on current main the clone succeeds, so the unreadable lockfile is what users hit.

### Fix
- `Tag::infer` treats `git+git:` like `git+ssh:` and `git+file:`, returning `Tag::Git`. `Repository::parse_append_git` already strips the `git+` label, so the repository stored from the lockfile (`git://host/repo`) is identical to the one parsed from `package.json`, and the existing package lookup matches it.
- The written format is unchanged on purpose: lockfiles already written with `git+git://` entries become readable without being rewritten.
- Test: `test/cli/install/migration/migrate.test.ts`, "git:// hosts round-trip through bun.lock". It migrates a `package-lock.json` with two `git://` entries (no network: `bun pm migrate` only writes `bun.lock`), asserts the `git+git://` rows bun writes, then runs `bun install --frozen-lockfile --lockfile-only`, which fails with the error above without the fix and passes with it.
- Also verified against a local `git daemon`: `bun install` twice (second one byte-identical, "no changes"), `--frozen-lockfile` with and without `node_modules`, `--linker=isolated --frozen-lockfile`, `bun pm ls`, `bun dedupe --check`, `bun prune --dry-run`, all clean with the fix; `--frozen-lockfile` failed as described before it.
- `bun bd test` on `test/cli/install/migration/migrate.test.ts`, `hosted-git-info/`, `bun-install-git-deps.test.ts`, `bun-lock.test.ts` passes; the git-related cases of `bun-install.test.ts` / `bun-add.test.ts` pass except the bitbucket/gitlab ones, which need network access and fail identically without this change.

### Background
- `bun.lock` stores each package as `"<name>@<resolution>"`. For git packages the resolution is the clone URL plus `#<commit>`, prefixed with `git+` for plain git remotes or `github:` for GitHub tarball installs. The prefix is what lets the reader tell the resolution kinds apart.
- `Tag::infer` is the one classifier used both for version strings in `package.json` (`^1.0.0`, `github:a/b`, `git+ssh://...`) and, via `from_text_lockfile`, for resolution strings read from `bun.lock`. Anything the lockfile writer can emit therefore has to be a shape `infer` recognizes; `git+git://` was the only prefix the writer produces that it did not.
- A dependency's `git://` URL is kept verbatim as the repository string (only a leading `git+` is stripped), which is why the label ends up doubled rather than replacing the scheme.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/migration/migrate.test.ts

<!-- robobun:evidence:end -->