### PR TITLE
bun test: fix the reason reported when a snapshot matcher's expect() has no running test

### DIFF
--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -623,10 +623,19 @@ impl Expect {
         let parent = self.parent.as_ref().ok_or(crate::Error::NoTest)?;
         let buntest_strong = parent.bun_test().ok_or(crate::Error::TestNotActive)?;
         let buntest = buntest_strong.get();
-        let execution_entry = parent
-            .phase
-            .entry(buntest)
-            .ok_or(crate::Error::SnapshotInConcurrentGroup)?;
+        let execution_entry = match &parent.phase {
+            // `entry()` is None once the runner has advanced past the entry that was
+            // running when this expect() was created.
+            bun_test::RefDataValue::Execution { entry_data: Some(_), .. } => {
+                parent.phase.entry(buntest).ok_or(crate::Error::TestNotActive)?
+            }
+            bun_test::RefDataValue::Execution { entry_data: None, .. } => {
+                return Err(crate::Error::SnapshotInConcurrentGroup);
+            }
+            bun_test::RefDataValue::Start
+            | bun_test::RefDataValue::Collection { .. }
+            | bun_test::RefDataValue::Done => return Err(crate::Error::NoTest),
+        };
 
         let test_name: &[u8] = execution_entry.base.name.as_deref().unwrap_or(b"(unnamed)");
 
@@ -1252,6 +1261,9 @@ impl Expect {
                     }
                     crate::Error::TestNotActive => {
                         global_this.throw(format_args!("Snapshot matchers are not supported after the test has finished executing"))
+                    }
+                    crate::Error::NoTest => {
+                        global_this.throw(format_args!("Snapshot matchers cannot be used outside of a test"))
                     }
                     _ => {
                         let mut formatter = ConsoleObject::Formatter::new(global_this);

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -624,8 +624,7 @@ impl Expect {
         let buntest_strong = parent.bun_test().ok_or(crate::Error::TestNotActive)?;
         let buntest = buntest_strong.get();
         let execution_entry = match &parent.phase {
-            // `entry()` is None once the runner has advanced past the entry that was
-            // running when this expect() was created.
+            // `entry()` only resolves while the captured entry is still the one running.
             bun_test::RefDataValue::Execution { entry_data: Some(_), .. } => {
                 parent.phase.entry(buntest).ok_or(crate::Error::TestNotActive)?
             }

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -175,6 +175,56 @@ impl Flags {
     }
 }
 
+/// Why a snapshot cannot be named after the test an `expect()` was created in.
+#[derive(Clone, Copy)]
+enum SnapshotContextError {
+    TestFinished,
+    ConcurrentGroup,
+    NoTest,
+}
+
+impl SnapshotContextError {
+    /// Judged from the runner state `expect()` captured: once that state no longer resolves to
+    /// a running entry, a captured entry means its test has finished, a concurrent group never
+    /// captures an entry, and the other phases have no test at all.
+    fn from_phase(phase: &bun_test::RefDataValue) -> Self {
+        match phase {
+            bun_test::RefDataValue::Execution { entry_data: Some(_), .. } => Self::TestFinished,
+            bun_test::RefDataValue::Execution { entry_data: None, .. } => Self::ConcurrentGroup,
+            bun_test::RefDataValue::Start
+            | bun_test::RefDataValue::Collection { .. }
+            | bun_test::RefDataValue::Done => Self::NoTest,
+        }
+    }
+
+    fn from_error(err: &crate::Error) -> Option<Self> {
+        match err {
+            crate::Error::TestNotActive => Some(Self::TestFinished),
+            crate::Error::SnapshotInConcurrentGroup => Some(Self::ConcurrentGroup),
+            crate::Error::NoTest => Some(Self::NoTest),
+            _ => None,
+        }
+    }
+
+    fn message(self) -> &'static str {
+        match self {
+            Self::TestFinished => "Snapshot matchers are not supported after the test has finished executing",
+            Self::ConcurrentGroup => "Snapshot matchers are not supported in concurrent tests",
+            Self::NoTest => "Snapshot matchers cannot be used outside of a test",
+        }
+    }
+}
+
+impl From<SnapshotContextError> for crate::Error {
+    fn from(err: SnapshotContextError) -> Self {
+        match err {
+            SnapshotContextError::TestFinished => Self::TestNotActive,
+            SnapshotContextError::ConcurrentGroup => Self::SnapshotInConcurrentGroup,
+            SnapshotContextError::NoTest => Self::NoTest,
+        }
+    }
+}
+
 impl Expect {
     /// R-2 helper: read-modify-write the packed `Cell<Flags>` through `&self`.
     #[inline]
@@ -208,6 +258,36 @@ impl Expect {
     pub(crate) fn bun_test(&self) -> Option<bun_test::BunTestPtr> {
         let parent = self.parent.as_ref()?;
         parent.bun_test()
+    }
+
+    /// Only meaningful once `bun_test()` is None: the file this `expect()` was created in has
+    /// finished (or there was none), so the captured state is all that is left to report from.
+    fn snapshot_context_error(&self) -> SnapshotContextError {
+        match self.parent.as_ref() {
+            Some(parent) => SnapshotContextError::from_phase(&parent.phase),
+            None => SnapshotContextError::NoTest,
+        }
+    }
+
+    /// Throws unless the test file this `expect()` was created in is still running. The file
+    /// snapshot matchers call this before looking at their arguments.
+    pub(crate) fn check_snapshot_context(
+        &self,
+        global_this: &JSGlobalObject,
+        matcher_name: &'static str,
+    ) -> JsResult<()> {
+        if self.bun_test().is_some() {
+            return Ok(());
+        }
+        let signature = Self::get_signature(matcher_name, "", false);
+        throw!(
+            self,
+            global_this,
+            signature,
+            "\n\n<b>Matcher error<r>: {}\n",
+            self.snapshot_context_error().message(),
+        )
+        .map(drop)
     }
 
     pub(crate) fn get_signature(
@@ -621,20 +701,10 @@ impl Expect {
 
     pub(crate) fn get_snapshot_name(&self, hint: &[u8]) -> crate::Result<Vec<u8>> {
         let parent = self.parent.as_ref().ok_or(crate::Error::NoTest)?;
-        let buntest_strong = parent.bun_test().ok_or(crate::Error::TestNotActive)?;
+        let context_error = || crate::Error::from(SnapshotContextError::from_phase(&parent.phase));
+        let buntest_strong = parent.bun_test().ok_or_else(context_error)?;
         let buntest = buntest_strong.get();
-        let execution_entry = match &parent.phase {
-            // `entry()` only resolves while the captured entry is still the one running.
-            bun_test::RefDataValue::Execution { entry_data: Some(_), .. } => {
-                parent.phase.entry(buntest).ok_or(crate::Error::TestNotActive)?
-            }
-            bun_test::RefDataValue::Execution { entry_data: None, .. } => {
-                return Err(crate::Error::SnapshotInConcurrentGroup);
-            }
-            bun_test::RefDataValue::Start
-            | bun_test::RefDataValue::Collection { .. }
-            | bun_test::RefDataValue::Done => return Err(crate::Error::NoTest),
-        };
+        let execution_entry = parent.phase.entry(buntest).ok_or_else(context_error)?;
 
         let test_name: &[u8] = execution_entry.base.name.as_deref().unwrap_or(b"(unnamed)");
 
@@ -1220,8 +1290,11 @@ impl Expect {
         let existing_value = match runner.snapshots.get_or_put(this, &pretty_value, hint) {
             Ok(v) => v,
             Err(err) => {
+                if let Some(reason) = SnapshotContextError::from_error(&err) {
+                    return Err(global_this.throw(format_args!("{}", reason.message())));
+                }
                 let Some(buntest_strong) = this.bun_test() else {
-                    return Err(global_this.throw(format_args!("Snapshot matchers cannot be used outside of a test")));
+                    return Err(global_this.throw(format_args!("{}", this.snapshot_context_error().message())));
                 };
                 let buntest = buntest_strong.get();
                 // MultiArrayList::get requires MultiArrayElement (derive pending); use column accessor.
@@ -1254,15 +1327,6 @@ impl Expect {
                                 bstr::BStr::new(&pretty_value),
                             ))
                         }
-                    }
-                    crate::Error::SnapshotInConcurrentGroup => {
-                        global_this.throw(format_args!("Snapshot matchers are not supported in concurrent tests"))
-                    }
-                    crate::Error::TestNotActive => {
-                        global_this.throw(format_args!("Snapshot matchers are not supported after the test has finished executing"))
-                    }
-                    crate::Error::NoTest => {
-                        global_this.throw(format_args!("Snapshot matchers cannot be used outside of a test"))
                     }
                     _ => {
                         let mut formatter = ConsoleObject::Formatter::new(global_this);

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -184,12 +184,11 @@ enum SnapshotContextError {
 }
 
 impl SnapshotContextError {
-    /// Judged from the runner state `expect()` captured: once that state no longer resolves to
-    /// a running entry, a captured entry means its test has finished, a concurrent group never
-    /// captures an entry, and the other phases have no test at all.
+    /// For a state captured by `expect()` that no longer resolves to a running entry.
     fn from_phase(phase: &bun_test::RefDataValue) -> Self {
         match phase {
             bun_test::RefDataValue::Execution { entry_data: Some(_), .. } => Self::TestFinished,
+            // `get_current_state_data` records no entry only while a concurrent group runs.
             bun_test::RefDataValue::Execution { entry_data: None, .. } => Self::ConcurrentGroup,
             bun_test::RefDataValue::Start
             | bun_test::RefDataValue::Collection { .. }
@@ -260,8 +259,7 @@ impl Expect {
         parent.bun_test()
     }
 
-    /// Only meaningful once `bun_test()` is None: the file this `expect()` was created in has
-    /// finished (or there was none), so the captured state is all that is left to report from.
+    /// Only valid once `bun_test()` is None; a live file is classified by `get_snapshot_name`.
     fn snapshot_context_error(&self) -> SnapshotContextError {
         match self.parent.as_ref() {
             Some(parent) => SnapshotContextError::from_phase(&parent.phase),
@@ -269,8 +267,7 @@ impl Expect {
         }
     }
 
-    /// Throws unless the test file this `expect()` was created in is still running. The file
-    /// snapshot matchers call this before looking at their arguments.
+    /// Throws unless the test file this `expect()` was created in is still running.
     pub(crate) fn check_snapshot_context(
         &self,
         global_this: &JSGlobalObject,

--- a/src/runtime/test_runner/expect/toMatchSnapshot.rs
+++ b/src/runtime/test_runner/expect/toMatchSnapshot.rs
@@ -31,16 +31,7 @@ pub(crate) fn to_match_snapshot(
         );
     }
 
-    let Some(buntest_strong) = this.bun_test() else {
-        let signature = get_signature("toMatchSnapshot", "", true);
-        return throw!(
-            this,
-            global,
-            signature,
-            "\n\n<b>Matcher error<r>: Snapshot matchers cannot be used outside of a test\n",
-        );
-    };
-    let _ = buntest_strong; // released by Drop at scope exit.
+    this.check_snapshot_context(global, "toMatchSnapshot")?;
 
     let mut hint_string: ZigString = ZigString::EMPTY;
     let mut property_matchers: Option<JSValue> = None;

--- a/src/runtime/test_runner/expect/toThrowErrorMatchingSnapshot.rs
+++ b/src/runtime/test_runner/expect/toThrowErrorMatchingSnapshot.rs
@@ -30,16 +30,7 @@ pub(crate) fn to_throw_error_matching_snapshot(
         );
     }
 
-    let Some(bun_test_strong) = this.bun_test() else {
-        let signature = get_signature("toThrowErrorMatchingSnapshot", "", true);
-        return throw!(
-            this,
-            global,
-            signature,
-            "\n\n<b>Matcher error<r>: Snapshot matchers cannot be used outside of a test\n",
-        );
-    };
-    let _ = &bun_test_strong;
+    this.check_snapshot_context(global, "toThrowErrorMatchingSnapshot")?;
 
     let mut hint_string: ZigString = ZigString::EMPTY;
     match arguments.len() {

--- a/test/js/bun/test/bun_test.test.ts
+++ b/test/js/bun/test/bun_test.test.ts
@@ -232,7 +232,9 @@ test("cross-file safety", async () => {
   const exitCode = await result.exited;
   const stdout = await result.stdout.text();
   const stderr = await result.stderr.text();
-  expect(stderr).toInclude("Snapshot matchers cannot be used outside of a test");
+  expect(normalizeBunSnapshot(stderr)).toInclude(
+    "error: expect(received).toMatchSnapshot()\n\nMatcher error: Snapshot matchers are not supported after the test has finished executing",
+  );
   expect(exitCode).toBe(1);
 });
 

--- a/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
+++ b/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it, test } from "bun:test";
+import { beforeAll, describe, expect, it, test } from "bun:test";
 import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+import { readdirSync } from "node:fs";
 import { join } from "node:path";
 
 test("it will create a snapshot file if it doesn't exist", () => {
@@ -65,9 +66,9 @@ describe("toMatchSnapshot errors", () => {
   });
 });
 
-// A snapshot's name comes from the test that was running when expect() was called.
-// These cover the cases where that test cannot name a snapshot by the time the matcher runs.
-describe("snapshot matchers on an expect() created outside of a running test", () => {
+// A snapshot is named after the test that was running when expect() was called. These cover
+// the error reported when that test cannot name a snapshot by the time the matcher runs.
+describe("snapshot matchers on an expect() that has no running test", () => {
   const finishedMessage = "Snapshot matchers are not supported after the test has finished executing";
   const outsideTestMessage = "Snapshot matchers cannot be used outside of a test";
   const concurrentMessage = "Snapshot matchers are not supported in concurrent tests";
@@ -85,17 +86,17 @@ describe("snapshot matchers on an expect() created outside of a running test", (
     });
   });
 
-  describe("expect() created in a test that has since finished", () => {
+  describe("expect() created in a beforeAll that has since finished", () => {
     let value: ReturnType<typeof expect>;
     let thrower: ReturnType<typeof expect>;
     let inline: ReturnType<typeof expect>;
 
-    it("creates the expect() objects", () => {
-      value = expect({ created: "in the previous test" });
+    beforeAll(() => {
+      value = expect({ created: "in beforeAll" });
       thrower = expect(() => {
-        throw new Error("created in the previous test");
+        throw new Error("created in beforeAll");
       });
-      inline = expect("created in the previous test");
+      inline = expect("created in beforeAll");
     });
 
     it("toMatchSnapshot throws the finished-test error", () => {
@@ -108,7 +109,7 @@ describe("snapshot matchers on an expect() created outside of a running test", (
     });
 
     it("inline snapshots are keyed by source location and still work", () => {
-      inline.toMatchInlineSnapshot(`"created in the previous test"`);
+      inline.toMatchInlineSnapshot(`"created in beforeAll"`);
     });
   });
 
@@ -120,7 +121,7 @@ describe("snapshot matchers on an expect() created outside of a running test", (
     }
   });
 
-  it("expect() created in a test that timed out throws the finished-test error and writes nothing", async () => {
+  it.concurrent("expect() from a timed out test throws the finished-test error and writes nothing", async () => {
     using dir = tempDir("snapshot-after-timeout", {
       "timeout.test.ts": `
         import { expect, test } from "bun:test";
@@ -158,9 +159,10 @@ describe("snapshot matchers on an expect() created outside of a running test", (
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(normalizeBunSnapshot(stdout)).toBe(
-      `bun test <version> (<revision>)\nlate toMatchSnapshot: ${finishedMessage}`,
-    );
+    expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`
+      "bun test <version> (<revision>)
+      late toMatchSnapshot: Snapshot matchers are not supported after the test has finished executing"
+    `);
     expect(stderr).toContain("this test timed out after 1ms");
     expect(stderr).toContain("(pass) next");
     expect(stderr).toContain("snapshots: +1 added");
@@ -168,5 +170,70 @@ describe("snapshot matchers on an expect() created outside of a running test", (
       '// Bun Snapshot v1, https://bun.sh/docs/test/snapshots\n\nexports[`next 1`] = `\n{\n  "from": "next",\n}\n`;\n',
     );
     expect(exitCode).toBe(1);
+  });
+
+  it.concurrent("expect() created in a test file that has finished throws the finished-test error", async () => {
+    using dir = tempDir("snapshot-after-file", {
+      "shared.ts": `
+        import type { expect } from "bun:test";
+        export const captured: { value?: ReturnType<typeof expect>; thrower?: ReturnType<typeof expect> } = {};
+      `,
+      "1-create.test.ts": `
+        import { expect, test } from "bun:test";
+        import { captured } from "./shared";
+
+        test("creates", () => {
+          captured.value = expect({ from: "1-create" });
+          captured.thrower = expect(() => {
+            throw new Error("from 1-create");
+          });
+        });
+      `,
+      "2-use.test.ts": `
+        import { expect, test } from "bun:test";
+        import { captured } from "./shared";
+
+        test("uses", () => {
+          for (const [name, matcher] of [
+            ["toMatchSnapshot", () => captured.value!.toMatchSnapshot()],
+            ["toThrowErrorMatchingSnapshot", () => captured.thrower!.toThrowErrorMatchingSnapshot()],
+          ] as const) {
+            try {
+              matcher();
+              console.log(name + ": did not throw");
+            } catch (error) {
+              console.log(name + ": " + (error as Error).message);
+            }
+          }
+          expect({ from: "2-use" }).toMatchSnapshot();
+        });
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "./1-create.test.ts", "./2-use.test.ts"],
+      cwd: String(dir),
+      env: { ...bunEnv, CI: "false" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`
+      "bun test <version> (<revision>)
+      toMatchSnapshot: expect(received).toMatchSnapshot()
+
+      Matcher error: Snapshot matchers are not supported after the test has finished executing
+
+      toThrowErrorMatchingSnapshot: expect(received).toThrowErrorMatchingSnapshot()
+
+      Matcher error: Snapshot matchers are not supported after the test has finished executing"
+    `);
+    expect(stderr).toContain("snapshots: +1 added");
+    expect(readdirSync(join(String(dir), "__snapshots__"))).toEqual(["2-use.test.ts.snap"]);
+    expect(await Bun.file(join(String(dir), "__snapshots__", "2-use.test.ts.snap")).text()).toBe(
+      '// Bun Snapshot v1, https://bun.sh/docs/test/snapshots\n\nexports[`uses 1`] = `\n{\n  "from": "2-use",\n}\n`;\n',
+    );
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
+++ b/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it, test } from "bun:test";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+import { join } from "node:path";
 
 test("it will create a snapshot file if it doesn't exist", () => {
   expect({ a: { b: { c: false } }, c: 2, jkfje: 99238 }).toMatchSnapshot({ a: { b: { c: expect.any(Boolean) } } });
@@ -60,5 +62,111 @@ describe("toMatchSnapshot errors", () => {
       // @ts-expect-error
       expect({ a: 4 }).toMatchSnapshot({ a: expect.any("not a constructor") });
     }).toThrow();
+  });
+});
+
+// A snapshot's name comes from the test that was running when expect() was called.
+// These cover the cases where that test cannot name a snapshot by the time the matcher runs.
+describe("snapshot matchers on an expect() created outside of a running test", () => {
+  const finishedMessage = "Snapshot matchers are not supported after the test has finished executing";
+  const outsideTestMessage = "Snapshot matchers cannot be used outside of a test";
+  const concurrentMessage = "Snapshot matchers are not supported in concurrent tests";
+
+  describe("expect() created in a describe callback", () => {
+    let error: unknown;
+    try {
+      expect("described").toMatchSnapshot();
+    } catch (e) {
+      error = e;
+    }
+
+    it("throws the outside-of-a-test error", () => {
+      expect((error as Error).message).toBe(outsideTestMessage);
+    });
+  });
+
+  describe("expect() created in a test that has since finished", () => {
+    let value: ReturnType<typeof expect>;
+    let thrower: ReturnType<typeof expect>;
+    let inline: ReturnType<typeof expect>;
+
+    it("creates the expect() objects", () => {
+      value = expect({ created: "in the previous test" });
+      thrower = expect(() => {
+        throw new Error("created in the previous test");
+      });
+      inline = expect("created in the previous test");
+    });
+
+    it("toMatchSnapshot throws the finished-test error", () => {
+      expect(() => value.toMatchSnapshot()).toThrow(finishedMessage);
+      expect(() => value.toMatchSnapshot("with hint")).toThrow(finishedMessage);
+    });
+
+    it("toThrowErrorMatchingSnapshot throws the finished-test error", () => {
+      expect(() => thrower.toThrowErrorMatchingSnapshot()).toThrow(finishedMessage);
+    });
+
+    it("inline snapshots are keyed by source location and still work", () => {
+      inline.toMatchInlineSnapshot(`"created in the previous test"`);
+    });
+  });
+
+  describe.concurrent("expect() created in a concurrent group", () => {
+    for (const name of ["first", "second"]) {
+      it(`${name} test throws the concurrent error`, async () => {
+        expect(() => expect(name).toMatchSnapshot()).toThrow(concurrentMessage);
+      });
+    }
+  });
+
+  it("expect() created in a test that timed out throws the finished-test error and writes nothing", async () => {
+    using dir = tempDir("snapshot-after-timeout", {
+      "timeout.test.ts": `
+        import { expect, test } from "bun:test";
+
+        const nextTestStarted = Promise.withResolvers<void>();
+        const lateMatcherRan = Promise.withResolvers<void>();
+
+        test("times out", async () => {
+          const captured = expect({ from: "times out" });
+          // Only "next" resolves this, so this test has always timed out by the time it continues.
+          await nextTestStarted.promise;
+          try {
+            captured.toMatchSnapshot();
+            console.log("late toMatchSnapshot: did not throw");
+          } catch (error) {
+            console.log("late toMatchSnapshot:", (error as Error).message);
+          }
+          lateMatcherRan.resolve();
+        }, 1);
+
+        test("next", async () => {
+          nextTestStarted.resolve();
+          await lateMatcherRan.promise;
+          expect({ from: "next" }).toMatchSnapshot();
+        });
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "timeout.test.ts"],
+      cwd: String(dir),
+      env: { ...bunEnv, CI: "false" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(normalizeBunSnapshot(stdout)).toBe(
+      `bun test <version> (<revision>)\nlate toMatchSnapshot: ${finishedMessage}`,
+    );
+    expect(stderr).toContain("this test timed out after 1ms");
+    expect(stderr).toContain("(pass) next");
+    expect(stderr).toContain("snapshots: +1 added");
+    expect(await Bun.file(join(String(dir), "__snapshots__", "timeout.test.ts.snap")).text()).toBe(
+      '// Bun Snapshot v1, https://bun.sh/docs/test/snapshots\n\nexports[`next 1`] = `\n{\n  "from": "next",\n}\n`;\n',
+    );
+    expect(exitCode).toBe(1);
   });
 });


### PR DESCRIPTION
### Problem
- `toMatchSnapshot()` / `toThrowErrorMatchingSnapshot()` on an `expect()` whose test is no longer running report the wrong reason. The snapshot is correctly refused in every case below; only the message is wrong:
  - `expect()` created in a test (or hook) that has since finished, for example a test that timed out while awaiting and then calls `captured.toMatchSnapshot()` during the next test: `Snapshot matchers are not supported in concurrent tests`. Nothing is concurrent.
  - `expect(x).toMatchSnapshot()` inside a `describe` callback, or on an `expect()` created in a preload: the same concurrent-tests message.
  - `expect()` created in a test file that has already finished (the existing cross-file fixture in `bun_test.test.ts`): `Snapshot matchers cannot be used outside of a test`, printed under an `expect(received).not.toMatchSnapshot()` signature although `.not` was never used.
- Cause: `Expect::get_snapshot_name` (`src/runtime/test_runner/expect.rs`) mapped every failure to resolve the captured entry to `SnapshotInConcurrentGroup`, although `RefDataValue::entry()` also returns `None` for an entry the runner has advanced past and for a capture made outside the execution phase. The guards at the top of `toMatchSnapshot.rs` / `toThrowErrorMatchingSnapshot.rs` handled the finished-file form separately with their own message and passed `not = true` to `get_signature`.
- Noticed in a `yarn-lock-migration` run where a timed-out `test.each` case kept running into the next case. That run's late call created its `expect()` after the timeout, so it was attributed to the test running at that moment; that attribution is not changed by this PR (see Background). The cases above, where the `expect()` already exists when its test ends, are what it fixes.

### Fix
- `SnapshotContextError` (expect.rs) classifies from the `RefDataValue` the `expect()` captured: a captured entry that no longer resolves means its test finished (`TestNotActive`, "not supported after the test has finished executing", a message that already existed but was only reachable once the file was torn down); a capture with no entry means a concurrent group (`SnapshotInConcurrentGroup`, unchanged); a capture from the collection or done phase means no test ("cannot be used outside of a test"). It also owns the three message strings.
- `get_snapshot_name` uses that classification both when the file is gone and when `entry()` fails; `Expect::snapshot` renders any of the three through it (replacing two inlined arms); the two matchers call the new `Expect::check_snapshot_context`, which does the same classification for the finished-file form and prints the matcher's own signature instead of the `.not` one.
- Correct because the captured state is the only thing that differs between the cases: `get_current_state_data` (`bun_test.rs`) records an entry exactly when one sequence is running, records none in a concurrent group, and records the scope or `Done` outside execution; and `entry()` only fails for a recorded entry once the runner has advanced past it (`Execution::get_current_and_valid_execution_sequence`). Behaviour is otherwise unchanged: nothing is written in any of these cases before or after, inline snapshots still ignore the error (they are keyed by source position), and the strong `BunTest` reference the old guards held during the matcher was not load-bearing (`exit_file` only runs from the test command between files).
- The classification stays in expect.rs rather than in `RefDataValue::entry()` because the reasons and messages are specific to the file snapshot matchers (`entry()`'s other caller, `jest.rs`, only needs the `Option`), and this keeps the overlap with the open PRs below to the one line they also touch.
- Tests, all in `test/js/bun/test/snapshot-tests/bun-snapshots.test.ts` unless noted; the ones marked * fail on the released bun with the old messages:
  - * `toMatchSnapshot` inside a `describe` callback: outside-of-a-test message
  - * `expect()` created in `beforeAll`, used by later tests: `toMatchSnapshot` (with and without hint) and `toThrowErrorMatchingSnapshot` report the finished-test message; `toMatchInlineSnapshot` on such an object still works; holds under `-t` and `--randomize`
  - two tests in a `describe.concurrent` group still get the concurrent message (unchanged behaviour, pinned)
  - * spawned file where test 1 times out and later calls `toMatchSnapshot()` on an `expect()` created before the timeout: stdout carries the finished-test message and the `.snap` contains only test 2's entry
  - * spawned two-file run where file 1 creates the `expect()`s and file 2 uses both matchers: both print their own signature and the finished-test message, and `__snapshots__` contains only file 2's own entry
  - * `test/js/bun/test/bun_test.test.ts` "cross-file safety": assertion updated from the old message to the new signature and message
- Verified with `bun bd test test/js/bun/test/snapshot-tests/bun-snapshots.test.ts test/js/bun/test/bun_test.test.ts` (18 pass), the same two files under `USE_SYSTEM_BUN=1` (6 fail, the ones marked above), and `FORCE_COLOR=1 bun bd test test/js/bun/test/snapshot-tests/ test/js/bun/test/ci-restrictions.test.ts test/js/bun/test/expect.test.js test/js/bun/test/test-test.test.ts` (534 pass; `FORCE_COLOR` is needed by the pre-existing `error snapshots` case, as on main).
- Open PRs that touch the same `get_snapshot_name` lines, all compatible with this one, so whichever lands later needs a one-line rebase: #38820 (names a hook's snapshot after its test; this PR only changes what is reported when there is no test), #34042 (moves the name building into a helper), and #29238 (adds an earlier concurrent-group check in front of this classification).

### Background
- `expect(value)` records the runner's state at the moment it is called (`RefDataValue`): during collection the active `describe` scope; during execution the group and, when exactly one sequence is running, the entry (test or hook) that is running. Snapshot matchers later resolve that record against the runner's current state to get the test name.
- A concurrent group runs several sequences at once, so the runner cannot tell which one an `expect()` belongs to and records no entry; file snapshots are refused there (limitation documented in #22534), inline snapshots work because they are keyed by file position.
- Each test file gets its own `BunTest`; an `expect()` holds a weak reference to it, which stops resolving once the runner has moved on to the next file. That is the finished-file form above.
- Because the record is taken when `expect()` is called, an `expect()` created after its test timed out is attributed to whatever test is running then. Jest (`currentTestName`) and Vitest (`getCurrentTest()` inside `expect()`) work the same way; attributing such calls to the timed-out test would need a per-test async context propagated through every `await`, which is a separate feature and not attempted here.

<details>
<summary>Earlier shape of this PR</summary>

The first revision only replaced the `.ok_or(SnapshotInConcurrentGroup)` in `get_snapshot_name` with a match on the captured `RefDataValue` and added a `NoTest` arm to `Expect::snapshot`. Review pointed out that the finished-file form was still reported as "outside of a test" by the matchers' own guards, and that the in-process test used an assertion-less `it` as setup for its siblings, which broke under `-t` and `--randomize`. The current revision moves the classification into one type used by all three sites and captures in `beforeAll` instead.

</details>
