### PR TITLE
install: resolve .npmrc //host/ credentials by request URL

### DIFF
--- a/docs/pm/npmrc.mdx
+++ b/docs/pm/npmrc.mdx
@@ -13,7 +13,7 @@ Configuration is loaded in this order, with later sources overriding earlier one
 4. `BUN_CONFIG_REGISTRY` / `NPM_CONFIG_REGISTRY` and `BUN_CONFIG_TOKEN` / `NPM_CONFIG_TOKEN` environment variables
 5. Command-line flags such as `--registry`
 
-Bun matches credentials in `.npmrc` (`//<registry>/:_authToken`, etc.) to registries by host and path, even if you set the registry URL itself in `bunfig.toml`.
+Bun matches credentials in `.npmrc` (`//<registry>/:_authToken`, etc.) by host and path to the URLs it requests, so they apply no matter where you set the registry URL itself (`.npmrc`, `bunfig.toml`, an environment variable or `--registry`). Bun also uses them for tarballs a registry serves from a different host than its own, as long as that host has its own `//<host>/:_authToken` line; it never sends a registry's credentials to another host.
 
 Values may reference environment variables. Bun replaces `${NAME}` with the variable's value, or leaves it as-is if the variable is unset. `${NAME?}` becomes an empty string if unset.
 

--- a/src/api/lib.rs
+++ b/src/api/lib.rs
@@ -9,7 +9,7 @@
 // ──────────────────────────────────────────────────────────────────────────
 
 pub use bun_options_types::schema::api::{
-    BunInstall, Ca, NodeLinker, NpmRegistry, NpmRegistryMap, PnpmMatcher,
+    BunInstall, Ca, NodeLinker, NpmRegistry, NpmRegistryMap, NpmUrlAuth, PnpmMatcher,
 };
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/ini/lib.rs
+++ b/src/ini/lib.rs
@@ -131,7 +131,7 @@ mod draft {
     use core::ptr;
 
     use bun_alloc::{AllocError, Arena, ArenaVec, ArenaVecExt as _};
-    use bun_api::{self, BunInstall, NpmRegistry, npm_registry};
+    use bun_api::{self, BunInstall, NpmRegistry, NpmUrlAuth, npm_registry};
     use bun_ast::E::Rope;
     use bun_ast::{E, Expr, ExprData, StoreRef};
     use bun_ast::{Loc, Log, Source};
@@ -1183,6 +1183,26 @@ mod draft {
                 RegistryCredential::Email(email) => registry.email.clone_from(email),
             }
         }
+
+        /// Record this line under its `//host/path/` prefix so the package
+        /// manager can also resolve it by request URL (see `NpmUrlAuth`).
+        fn apply_to_url_auth(&self, url_auth: &mut Vec<NpmUrlAuth>) {
+            let entry = match url_auth
+                .iter_mut()
+                .find(|entry| entry.host == self.host && entry.pathname == self.pathname)
+            {
+                Some(entry) => entry,
+                None => {
+                    url_auth.push(NpmUrlAuth {
+                        host: self.host.clone(),
+                        pathname: self.pathname.clone(),
+                        credentials: NpmRegistry::default(),
+                    });
+                    url_auth.last_mut().expect("just pushed")
+                }
+            };
+            self.apply_to(&mut entry.credentials);
+        }
     }
 
     // ──────────────────────────────────────────────────────────────────────────
@@ -1594,6 +1614,7 @@ mod draft {
                     continue;
                 }
                 if let Some(auth) = RegistryAuth::from_config_item(conf_item, iter.log, source) {
+                    auth.apply_to_url_auth(&mut install.url_auth);
                     configs.push(auth);
                 }
             }

--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -65,6 +65,11 @@ pub struct NetworkTask {
     /// (`github:` and URL tarball dependencies are not). Read back when a
     /// 401/403 is reported, so the suggested fix is one that would apply.
     pub(crate) authorization: Authorization,
+    /// Whether a tarball request went out with an `Authorization` header from
+    /// any source (registry credentials, a `.npmrc` line for its host, or the
+    /// URL's own userinfo). A 401/403 after that is a rejection, not missing
+    /// configuration.
+    pub(crate) sent_authorization: bool,
     pub(crate) retried: u16,
     pub(crate) response_buffer: MutableString,
     // BACKREF: PackageManager owns this task via `preallocated_network_tasks`.
@@ -871,6 +876,7 @@ impl NetworkTask {
                 b""
             }
         };
+        self.sent_authorization = !header_buf.is_empty();
 
         // SAFETY: lifetime extension — `url_buf` is a heap allocation owned by
         // `*self`, which outlives the HTTP request. `AsyncHTTP::init` demands a
@@ -1013,6 +1019,7 @@ impl NetworkTask {
             addr_of_mut!((*slot).url_buf).write(Box::default());
             addr_of_mut!((*slot).header_buf).write(Box::default());
             addr_of_mut!((*slot).authorization).write(Authorization::NoAuthorization);
+            addr_of_mut!((*slot).sent_authorization).write(false);
             addr_of_mut!((*slot).retried).write(0);
             addr_of_mut!((*slot).next).write(bun_threading::Link::new());
             addr_of_mut!((*slot).tarball_stream).write(None);

--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -722,6 +722,15 @@ impl NetworkTask {
         Ok(())
     }
 
+    /// Moves the fully written header block into `self.header_buf` and returns
+    /// the view of it that the HTTP thread reads.
+    fn store_header_buf(&mut self, header_builder: &mut HeaderBuilder) -> &'static [u8] {
+        debug_assert_eq!(header_builder.content.len, header_builder.content.cap);
+        self.header_buf = header_builder.content.move_to_slice();
+        // SAFETY: `self.header_buf` outlives the request; it is freed when the slot returns to the pool.
+        unsafe { bun_ptr::detach_lifetime(&*self.header_buf) }
+    }
+
     pub(crate) fn get_completion_callback(&mut self) -> HTTPClientResultCallback {
         // `HTTPClientResultCallback::new`
         // performs type erasure over a `fn(*mut T, *mut AsyncHTTP, _)`.
@@ -823,59 +832,37 @@ impl NetworkTask {
             None => None,
         };
 
-        // Only attach the registry `Authorization` header when the tarball URL
-        // origin matches the configured registry scope origin. The npm manifest
-        // is registry-controlled, so a malicious registry could otherwise point
-        // the tarball at an attacker-controlled host and receive the scope
-        // credentials. The empty-`tarball_url` branch builds the URL from
-        // `scope.url.href()`, so its origin matches and authorized downloads
-        // keep working.
-        // Compare (protocol, hostname, effective port) rather than the raw
-        // `URL.origin` slice — `origin` is a borrowed prefix of the input
-        // string and is not normalized for default ports, so a tarball URL of
-        // `https://host:443/...` would not byte-match a `.npmrc` registry of
-        // `https://host/...` even though they are the same origin. Some
-        // registries emit `dist.tarball` URLs with the default port spelled
-        // out; without normalization those installs lose the `Authorization`
-        // header and fail with 401.
-        let send_auth = matches!(authorization, Authorization::AllowAuthorization) && {
-            let tarball = URL::parse(&self.url_buf);
-            let registry = scope.url.url();
-            tarball.protocol == registry.protocol
-                && tarball.hostname == registry.hostname
-                && tarball.get_port_auto() == registry.get_port_auto()
+        // The empty-`tarball_url` branch above built the URL from `scope.url`,
+        // so it is same-origin and gets the scope's credentials.
+        let credentials = match authorization {
+            Authorization::NoAuthorization => None,
+            Authorization::AllowAuthorization => pm
+                .options
+                .tarball_credentials(scope, &URL::parse(&self.url_buf)),
         };
 
         self.response_buffer = MutableString::init_empty();
 
         let mut header_builder = HeaderBuilder::default();
 
-        if send_auth {
-            count_auth(&mut header_builder, scope);
-        }
-
-        // Registry credentials win over URL userinfo, as in npm.
-        let url_authorization = match url_authorization {
-            Some(value) if header_builder.header_count == 0 => {
+        // Configured credentials win over the URL's userinfo, as in npm.
+        let header_buf: &'static [u8] = match (credentials, url_authorization) {
+            (Some(credentials), _) => {
+                count_auth(&mut header_builder, credentials);
+                header_builder.allocate()?;
+                append_auth(&mut header_builder, credentials);
+                self.store_header_buf(&mut header_builder)
+            }
+            (None, Some(value)) => {
                 header_builder.count("Authorization", &value);
-                Some(value)
+                header_builder.allocate()?;
+                header_builder.append("Authorization", &value);
+                self.store_header_buf(&mut header_builder)
             }
-            _ => None,
-        };
-
-        let header_buf: &'static [u8] = if header_builder.header_count > 0 {
-            header_builder.allocate()?;
-            match &url_authorization {
-                Some(value) => header_builder.append("Authorization", value),
-                None => append_auth(&mut header_builder, scope),
+            (None, None) => {
+                self.header_buf = Box::default();
+                b""
             }
-            debug_assert_eq!(header_builder.content.len, header_builder.content.cap);
-            self.header_buf = header_builder.content.move_to_slice();
-            // SAFETY: `self.header_buf` outlives the request; it is freed when the slot returns to the pool.
-            unsafe { bun_ptr::detach_lifetime(&*self.header_buf) }
-        } else {
-            self.header_buf = Box::default();
-            b""
         };
 
         // SAFETY: lifetime extension — `url_buf` is a heap allocation owned by

--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -61,6 +61,10 @@ pub struct NetworkTask {
     // into `callback`; owning avoids that at the cost of one copy per tarball download.
     pub(crate) url_buf: Box<[u8]>,
     pub(crate) header_buf: Box<[u8]>,
+    /// Whether this request was allowed to carry registry credentials at all
+    /// (`github:` and URL tarball dependencies are not). Read back when a
+    /// 401/403 is reported, so the suggested fix is one that would apply.
+    pub(crate) authorization: Authorization,
     pub(crate) retried: u16,
     pub(crate) response_buffer: MutableString,
     // BACKREF: PackageManager owns this task via `preallocated_network_tasks`.
@@ -599,6 +603,8 @@ impl NetworkTask {
             }
         }
 
+        self.authorization = Authorization::AllowAuthorization;
+
         let mut header_builder = HeaderBuilder::default();
 
         count_auth(&mut header_builder, scope);
@@ -832,6 +838,7 @@ impl NetworkTask {
             None => None,
         };
 
+        self.authorization = authorization;
         // The empty-`tarball_url` branch above built the URL from `scope.url`,
         // so it is same-origin and gets the scope's credentials.
         let credentials = match authorization {
@@ -1005,6 +1012,7 @@ impl NetworkTask {
             addr_of_mut!((*slot).response).write(HTTPClientResult::default());
             addr_of_mut!((*slot).url_buf).write(Box::default());
             addr_of_mut!((*slot).header_buf).write(Box::default());
+            addr_of_mut!((*slot).authorization).write(Authorization::NoAuthorization);
             addr_of_mut!((*slot).retried).write(0);
             addr_of_mut!((*slot).next).write(bun_threading::Link::new());
             addr_of_mut!((*slot).tarball_stream).write(None);

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1377,6 +1377,7 @@ fn overlay_bunfig_install(install: &mut Api::BunInstall, bunfig: Api::BunInstall
     let Api::BunInstall {
         default_registry,
         scoped,
+        url_auth,
         lockfile_path,
         save_lockfile_path,
         cache_directory,
@@ -1424,6 +1425,8 @@ fn overlay_bunfig_install(install: &mut Api::BunInstall, bunfig: Api::BunInstall
             }
         }
     }
+
+    install.url_auth.extend(url_auth);
 
     macro_rules! overlay {
         ($($field:ident),* $(,)?) => {

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -288,10 +288,10 @@ impl Options {
 
     /// Text to append to the `GET <url> - 401` line of a request that bun sent
     /// without an `Authorization` header, saying which `.npmrc` line would have
-    /// supplied one. Empty when credentials were sent (the registry rejected
-    /// them, and the status line already says everything bun knows) and for
-    /// downloads that never carry registry credentials, where no `.npmrc` line
-    /// would change anything.
+    /// supplied one. Empty when a header was sent (the server rejected it, and
+    /// the status line already says everything bun knows) and for downloads
+    /// that never carry registry credentials, where no `.npmrc` line would
+    /// change anything.
     pub(crate) fn missing_credentials_note(
         &self,
         package_name: &[u8],
@@ -315,12 +315,19 @@ impl Options {
                     RegistryPath(registry.pathname),
                 );
             }
-            RequestKind::Tarball(Authorization::NoAuthorization) => {}
-            RequestKind::Tarball(Authorization::AllowAuthorization) => {
+            RequestKind::Tarball {
+                sent_authorization: true,
+                ..
+            }
+            | RequestKind::Tarball {
+                authorization: Authorization::NoAuthorization,
+                ..
+            } => {}
+            RequestKind::Tarball {
+                authorization: Authorization::AllowAuthorization,
+                sent_authorization: false,
+            } => {
                 let url = bun_url::URL::parse(url);
-                if self.tarball_credentials(scope, &url).is_some() {
-                    return note;
-                }
                 if scope.has_credentials() {
                     let _ = write!(
                         note,
@@ -377,9 +384,15 @@ fn is_same_origin(a: &bun_url::URL, b: &bun_url::URL) -> bool {
 pub(crate) enum RequestKind {
     /// Always on the package's registry, so it carries the scope's credentials.
     Manifest,
-    /// May be anywhere; see `Options::tarball_credentials`. Carries what the
-    /// request was enqueued with (`NetworkTask::authorization`).
-    Tarball(Authorization),
+    /// May be anywhere; see `Options::tarball_credentials`. Both fields are
+    /// read back from the `NetworkTask` that made the request.
+    Tarball {
+        /// Whether registry credentials were allowed on this download at all.
+        authorization: Authorization,
+        /// Whether some `Authorization` header actually went out (registry
+        /// credentials, a `.npmrc` line, or the URL's own userinfo).
+        sent_authorization: bool,
+    },
 }
 
 /// A registry pathname in the form `.npmrc` keys use: `/` or `/some/path/`.

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -5,6 +5,7 @@ use bun_paths::PathBuffer;
 
 use super::Subcommand;
 use super::command_line_arguments::{self, CommandLineArguments};
+use crate::network_task::Authorization;
 use bun_dotenv::Loader as DotEnvLoader;
 use bun_install::{Features, Npm};
 
@@ -287,8 +288,10 @@ impl Options {
 
     /// Text to append to the `GET <url> - 401` line of a request that bun sent
     /// without an `Authorization` header, saying which `.npmrc` line would have
-    /// supplied one. Empty when credentials were sent: then the registry
-    /// rejected them and the status line already says everything bun knows.
+    /// supplied one. Empty when credentials were sent (the registry rejected
+    /// them, and the status line already says everything bun knows) and for
+    /// downloads that never carry registry credentials, where no `.npmrc` line
+    /// would change anything.
     pub(crate) fn missing_credentials_note(
         &self,
         package_name: &[u8],
@@ -298,10 +301,12 @@ impl Options {
         use std::io::Write as _;
 
         let scope = self.scope_for_package_name(package_name);
-        let url = bun_url::URL::parse(url);
         let mut note = Vec::new();
         match request {
-            RequestKind::Manifest if !scope.has_credentials() => {
+            RequestKind::Manifest => {
+                if scope.has_credentials() {
+                    return note;
+                }
                 let registry = scope.url.url();
                 let _ = write!(
                     note,
@@ -310,7 +315,12 @@ impl Options {
                     RegistryPath(registry.pathname),
                 );
             }
-            RequestKind::Tarball if self.tarball_credentials(scope, &url).is_none() => {
+            RequestKind::Tarball(Authorization::NoAuthorization) => {}
+            RequestKind::Tarball(Authorization::AllowAuthorization) => {
+                let url = bun_url::URL::parse(url);
+                if self.tarball_credentials(scope, &url).is_some() {
+                    return note;
+                }
                 if scope.has_credentials() {
                     let _ = write!(
                         note,
@@ -328,7 +338,6 @@ impl Options {
                     );
                 }
             }
-            RequestKind::Manifest | RequestKind::Tarball => {}
         }
         note
     }
@@ -368,8 +377,9 @@ fn is_same_origin(a: &bun_url::URL, b: &bun_url::URL) -> bool {
 pub(crate) enum RequestKind {
     /// Always on the package's registry, so it carries the scope's credentials.
     Manifest,
-    /// May be anywhere; see `Options::tarball_credentials`.
-    Tarball,
+    /// May be anywhere; see `Options::tarball_credentials`. Carries what the
+    /// request was enqueued with (`NetworkTask::authorization`).
+    Tarball(Authorization),
 }
 
 /// A registry pathname in the form `.npmrc` keys use: `/` or `/some/path/`.

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -26,6 +26,10 @@ pub struct Options {
     pub scope: Npm::registry::Scope,
 
     pub(crate) registries: Npm::registry::Map,
+    /// `.npmrc` `//host/path/` credential lines, resolved by request URL. Fills
+    /// in scopes whose registry was configured without credentials of its own
+    /// and authenticates tarballs hosted somewhere other than their registry.
+    pub(crate) url_auth: Vec<Npm::registry::UrlAuth>,
     pub(crate) cache_directory: &'static [u8],
     pub enable: Enable,
     pub do_: Do,
@@ -110,6 +114,7 @@ impl Default for Options {
             // Always assigned in `load()` before read.
             scope: Npm::registry::Scope::default(),
             registries: Npm::registry::Map::default(),
+            url_auth: Vec::new(),
             cache_directory: b"",
             enable: Enable::default(),
             do_: Do::default(),
@@ -257,6 +262,126 @@ impl Options {
             Some(scope) if *scope.name == *scope_name => scope,
             _ => &self.scope,
         }
+    }
+
+    /// The credentials a tarball download may carry.
+    ///
+    /// The manifest that names the tarball URL comes from the registry, so a
+    /// malicious registry could point `dist.tarball` at a host of its choosing;
+    /// `scope`'s credentials therefore only go to `scope`'s own origin. Any
+    /// other origin gets exactly what the user configured for it in `.npmrc`
+    /// (`//that-host/:_authToken=...`), which covers registries that serve
+    /// tarballs from a separate host and lockfiles recorded against a
+    /// registry that has since moved; an origin without such a line gets
+    /// nothing.
+    pub(crate) fn tarball_credentials<'a>(
+        &'a self,
+        scope: &'a Npm::registry::Scope,
+        tarball: &bun_url::URL,
+    ) -> Option<&'a Npm::registry::Scope> {
+        if scope.has_credentials() && is_same_origin(tarball, &scope.url.url()) {
+            return Some(scope);
+        }
+        Npm::registry::UrlAuth::find(&self.url_auth, tarball)
+    }
+
+    /// Text to append to the `GET <url> - 401` line of a request that bun sent
+    /// without an `Authorization` header, saying which `.npmrc` line would have
+    /// supplied one. Empty when credentials were sent: then the registry
+    /// rejected them and the status line already says everything bun knows.
+    pub(crate) fn missing_credentials_note(
+        &self,
+        package_name: &[u8],
+        url: &[u8],
+        request: RequestKind,
+    ) -> Vec<u8> {
+        use std::io::Write as _;
+
+        let scope = self.scope_for_package_name(package_name);
+        let url = bun_url::URL::parse(url);
+        let mut note = Vec::new();
+        match request {
+            RequestKind::Manifest if !scope.has_credentials() => {
+                let registry = scope.url.url();
+                let _ = write!(
+                    note,
+                    "\n  no credentials are configured for this registry; add //{}{}:_authToken=<token> to .npmrc",
+                    bstr::BStr::new(registry.host),
+                    RegistryPath(registry.pathname),
+                );
+            }
+            RequestKind::Tarball if self.tarball_credentials(scope, &url).is_none() => {
+                if scope.has_credentials() {
+                    let _ = write!(
+                        note,
+                        "\n  the credentials configured for {} are not sent to {}; add //{}/:_authToken=<token> to .npmrc if this host needs them",
+                        bstr::BStr::new(scope.url.url().host),
+                        bstr::BStr::new(url.host),
+                        bstr::BStr::new(url.host),
+                    );
+                } else {
+                    let _ = write!(
+                        note,
+                        "\n  no credentials are configured for {}; add //{}/:_authToken=<token> to .npmrc",
+                        bstr::BStr::new(url.host),
+                        bstr::BStr::new(url.host),
+                    );
+                }
+            }
+            RequestKind::Manifest | RequestKind::Tarball => {}
+        }
+        note
+    }
+
+    /// Give every scope that ended up without credentials the ones `.npmrc`
+    /// configures for its registry URL. This is how `--registry` and
+    /// `$NPM_CONFIG_REGISTRY` pick up a `//host/:_authToken=` line: they are
+    /// applied after the `.npmrc` files were read, so the loader could not
+    /// attach the line to them.
+    fn fill_credentials_from_url_auth(&mut self) {
+        if self.url_auth.is_empty() {
+            return;
+        }
+        let url_auth = &self.url_auth;
+        for scope in core::iter::once(&mut self.scope).chain(self.registries.values_mut()) {
+            if scope.has_credentials() {
+                continue;
+            }
+            let found = Npm::registry::UrlAuth::find(url_auth, &scope.url.url());
+            if let Some(credentials) = found {
+                scope.copy_credentials_from(credentials);
+            }
+        }
+    }
+}
+
+/// Scheme, host and effective port are equal. Compared component-wise rather
+/// than on the raw `URL.origin` slice: some registries spell out the default
+/// port in `dist.tarball` (`https://host:443/...`) while `.npmrc` does not.
+fn is_same_origin(a: &bun_url::URL, b: &bun_url::URL) -> bool {
+    a.protocol.eq_ignore_ascii_case(b.protocol)
+        && a.hostname.eq_ignore_ascii_case(b.hostname)
+        && a.get_port_auto() == b.get_port_auto()
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum RequestKind {
+    /// Always on the package's registry, so it carries the scope's credentials.
+    Manifest,
+    /// May be anywhere; see `Options::tarball_credentials`.
+    Tarball,
+}
+
+/// A registry pathname in the form `.npmrc` keys use: `/` or `/some/path/`.
+struct RegistryPath<'a>(&'a [u8]);
+
+impl core::fmt::Display for RegistryPath<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", bstr::BStr::new(self.0))?;
+        if !self.0.ends_with(b"/") {
+            f.write_str("/")?;
+        }
+        Ok(())
     }
 }
 
@@ -447,6 +572,12 @@ impl Options {
                         Npm::registry::Scope::hash(name),
                         Npm::registry::Scope::from_api(name, registry, env)?,
                     )?;
+                }
+            }
+
+            for url_auth in &config.url_auth {
+                if let Some(url_auth) = Npm::registry::UrlAuth::from_api(url_auth, env)? {
+                    self.url_auth.push(url_auth);
                 }
             }
 
@@ -904,6 +1035,10 @@ impl Options {
             self.do_.set(Do::SAVE_LOCKFILE, false);
             self.enable.set(Enable::FORCE_SAVE_LOCKFILE, false);
         }
+
+        // After every source that can set a registry URL (bunfig, .npmrc,
+        // environment, command line) has been applied.
+        self.fill_credentials_from_url_auth();
 
         // moved from `defer { ... }` after scope assignment (see note above).
         self.did_override_default_scope = self.scope.url_hash != *Npm::registry::DEFAULT_URL_HASH;

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -34,7 +34,7 @@ use bun_install::package_manager_task as Task;
 // Import the *module* under the `Options` name so `Options::LogLevel` resolves as a path
 // (matches the `Task` module-alias pattern above and `CommandLineArguments.rs`).
 use super::package_manager_options as Options;
-use super::package_manager_options::{Do, Enable};
+use super::package_manager_options::{Do, Enable, RequestKind};
 use crate::isolated_install::store as Store;
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -478,23 +478,32 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                         continue;
                     }
 
+                    let note = http_status_note(
+                        manager,
+                        response.status_code,
+                        name,
+                        &task.url_buf,
+                        RequestKind::Manifest,
+                    );
                     if manager.is_network_task_required(task.task_id) {
                         bun_ast::add_error_pretty!(
                             manager.log_mut(),
                             None,
                             bun_ast::Loc::EMPTY,
-                            "<r><red><b>GET<r><red> {}<d> - {}<r>",
+                            "<r><red><b>GET<r><red> {}<d> - {}<r>{}",
                             bstr::BStr::new(metadata.url.slice()),
                             response.status_code,
+                            bstr::BStr::new(&note),
                         );
                     } else {
                         bun_ast::add_warning_pretty!(
                             manager.log_mut(),
                             None,
                             bun_ast::Loc::EMPTY,
-                            "<r><yellow><b>GET<r><yellow> {}<d> - {}<r>",
+                            "<r><yellow><b>GET<r><yellow> {}<d> - {}<r>{}",
                             bstr::BStr::new(metadata.url.slice()),
                             response.status_code,
+                            bstr::BStr::new(&note),
                         );
                     }
                     if manager.subcommand != Subcommand::Remove {
@@ -828,23 +837,32 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                         continue;
                     }
 
+                    let note = http_status_note(
+                        manager,
+                        response.status_code,
+                        extract.name.slice(),
+                        &task.url_buf,
+                        RequestKind::Tarball,
+                    );
                     if is_required {
                         bun_ast::add_error_pretty!(
                             manager.log_mut(),
                             None,
                             bun_ast::Loc::EMPTY,
-                            "<r><red><b>GET<r><red> {}<d> - {}<r>",
+                            "<r><red><b>GET<r><red> {}<d> - {}<r>{}",
                             bstr::BStr::new(metadata.url.slice()),
                             response.status_code,
+                            bstr::BStr::new(&note),
                         );
                     } else {
                         bun_ast::add_warning_pretty!(
                             manager.log_mut(),
                             None,
                             bun_ast::Loc::EMPTY,
-                            "<r><yellow><b>GET<r><yellow> {}<d> - {}<r>",
+                            "<r><yellow><b>GET<r><yellow> {}<d> - {}<r>{}",
                             bstr::BStr::new(metadata.url.slice()),
                             response.status_code,
+                            bstr::BStr::new(&note),
                         );
                     }
                     if manager.subcommand != Subcommand::Remove {
@@ -1559,6 +1577,24 @@ pub fn run_tasks<C: RunTasksCallbacks>(
     }
 
     Ok(())
+}
+
+/// Extra line for the `GET <url> - <status>` message: on 401/403, what the
+/// user can configure to authenticate the request (see
+/// `Options::missing_credentials_note`); empty for every other status.
+fn http_status_note(
+    manager: &PackageManager,
+    status_code: u32,
+    package_name: &[u8],
+    url: &[u8],
+    request: RequestKind,
+) -> Vec<u8> {
+    match status_code {
+        401 | 403 => manager
+            .options
+            .missing_credentials_note(package_name, url, request),
+        _ => Vec::new(),
+    }
 }
 
 #[inline]

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -842,7 +842,10 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                         response.status_code,
                         extract.name.slice(),
                         &task.url_buf,
-                        RequestKind::Tarball(task.authorization),
+                        RequestKind::Tarball {
+                            authorization: task.authorization,
+                            sent_authorization: task.sent_authorization,
+                        },
                     );
                     if is_required {
                         bun_ast::add_error_pretty!(

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -842,7 +842,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                         response.status_code,
                         extract.name.slice(),
                         &task.url_buf,
-                        RequestKind::Tarball,
+                        RequestKind::Tarball(task.authorization),
                     );
                     if is_required {
                         bun_ast::add_error_pretty!(

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -329,6 +329,18 @@ pub mod registry {
             self.url_hash = Self::hash(strings::without_trailing_slash(self.url.href()));
         }
 
+        /// Whether requests to this scope carry an `Authorization` header.
+        pub(crate) fn has_credentials(&self) -> bool {
+            !self.token.is_empty() || !self.auth.is_empty()
+        }
+
+        /// Take `other`'s credentials, leaving this scope's registry URL as is.
+        pub(crate) fn copy_credentials_from(&mut self, other: &Scope) {
+            self.token.clone_from(&other.token);
+            self.auth.clone_from(&other.auth);
+            self.user.clone_from(&other.user);
+        }
+
         pub(crate) fn get_name(name: &[u8]) -> &[u8] {
             if name.is_empty() || name[0] != b'@' {
                 return name;
@@ -529,6 +541,83 @@ pub mod registry {
 
     // Keys are pre-hashed (`Scope::hash`), so don't re-hash them.
     pub type Map = HashMap<u64, Scope, bun_collections::IdentityContext<u64>>;
+
+    /// Credentials from a `.npmrc` `//host/path/:...` line, matched against
+    /// request URLs the way npm resolves credentials for a URL: the host
+    /// (including the port) must be the same and the key's path must be the
+    /// request path or one of its parent directories. Keys have no scheme, so
+    /// a key applies to both `http` and `https` requests to its host.
+    pub(crate) struct UrlAuth {
+        hostname: Box<[u8]>,
+        /// `None` when the key does not spell out a port, which means the
+        /// scheme's default port of whatever request is being matched.
+        port: Option<u16>,
+        /// Without trailing slash; `/` for a bare host.
+        pathname: Box<[u8]>,
+        /// Only the credential fields are meaningful; `url` is empty.
+        credentials: Scope,
+    }
+
+    impl UrlAuth {
+        /// `None` when the line carries nothing that can be sent as an
+        /// `Authorization` header (for example only an `email`), so it never
+        /// shadows a shallower key that does.
+        pub(crate) fn from_api(
+            api: &api::NpmUrlAuth,
+            env: &mut DotEnv,
+        ) -> Result<Option<UrlAuth>, AllocError> {
+            let credentials = Scope::from_api(b"", api.credentials.clone(), env)?;
+            if !credentials.has_credentials() {
+                return Ok(None);
+            }
+            let host = URL::parse(&api.host);
+            let port = if host.port.is_empty() {
+                None
+            } else {
+                match host.get_port() {
+                    Some(port) => Some(port),
+                    // `//host:notaport/` cannot match any request.
+                    None => return Ok(None),
+                }
+            };
+            if host.hostname.is_empty() {
+                return Ok(None);
+            }
+            Ok(Some(UrlAuth {
+                hostname: host.hostname.into(),
+                port,
+                pathname: api.pathname.clone(),
+                credentials,
+            }))
+        }
+
+        fn matches(&self, url: &URL) -> bool {
+            if !strings::eql_case_insensitive_ascii(url.hostname, &self.hostname, true) {
+                return false;
+            }
+            let port = url.get_port_auto();
+            let port_matches = match self.port {
+                Some(expected) => port == expected,
+                None => port == if url.is_https() { 443 } else { 80 },
+            };
+            if !port_matches {
+                return false;
+            }
+            let prefix: &[u8] = &self.pathname;
+            prefix == b"/"
+                || (url.pathname.starts_with(prefix)
+                    && url.pathname.get(prefix.len()).is_none_or(|&c| c == b'/'))
+        }
+
+        /// The credentials configured for `url`: the matching key with the
+        /// longest path (`//host/a/b/` beats `//host/`).
+        pub(crate) fn find<'a>(list: &'a [UrlAuth], url: &URL) -> Option<&'a Scope> {
+            list.iter()
+                .filter(|entry| entry.matches(url))
+                .max_by_key(|entry| entry.pathname.len())
+                .map(|entry| &entry.credentials)
+        }
+    }
 
     pub(crate) enum PackageVersionResponse {
         Cached(PackageManifest),

--- a/src/options_types/schema.rs
+++ b/src/options_types/schema.rs
@@ -183,6 +183,24 @@ pub mod api {
         pub scopes: bun_collections::StringArrayHashMap<NpmRegistry>,
     }
 
+    /// The credentials `.npmrc` configures for one `//host/path/` prefix
+    /// (`//host/path/:_authToken=...`, `:_auth=`, `:username=` + `:_password=`).
+    ///
+    /// Unlike `default_registry` / `scoped`, these are not attached to a
+    /// registry declared in a config file: the package manager matches them
+    /// against the URL of each request, so they also apply to a registry
+    /// given on the command line or in the environment and to tarballs served
+    /// from a different host than the registry that published them.
+    #[derive(Default)]
+    pub struct NpmUrlAuth {
+        /// `host[:port]` as written between `//` and the first `/` of the key.
+        pub host: Box<[u8]>,
+        /// Pathname of the key without its trailing slash; `/` for a bare host.
+        pub pathname: Box<[u8]>,
+        /// Only the credential fields are set; `url` stays empty.
+        pub credentials: NpmRegistry,
+    }
+
     /// Value of `BunInstall.ca`; hoisted to a named type so callers can
     /// construct it.
     #[derive(Clone, Debug)]
@@ -208,6 +226,10 @@ pub mod api {
         pub default_registry: Option<NpmRegistry>,
         /// scoped
         pub scoped: Option<NpmRegistryMap>,
+        /// Every `//host/path/` credential prefix found in the `.npmrc` files,
+        /// in file order (a later file's lines override an earlier file's for
+        /// the same prefix).
+        pub url_auth: Vec<NpmUrlAuth>,
         /// lockfile_path
         pub lockfile_path: Option<Box<[u8]>>,
         /// save_lockfile_path

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -814,3 +814,346 @@ describe.skipIf(!isIPv6())("registry on a bracketed IPv6 host", () => {
     expect(exitCode).not.toBe(0);
   });
 });
+
+// `//host/path/:_authToken=` lines are keyed by URL, not by a registry declared
+// in the same file. Like npm, they have to apply to whatever request ends up on
+// that host: a registry that only exists on the command line or in the
+// environment, or a tarball served from a different host than the registry.
+describe.concurrent("//host/ credential lines are matched against the request URL", () => {
+  const tgz = join(import.meta.dir, "registry", "packages", "no-deps", "no-deps-1.0.0.tgz");
+  const basic = (user: string, password: string) => `Basic ${Buffer.from(`${user}:${password}`).toString("base64")}`;
+  const packageJson = JSON.stringify({ name: "app", version: "1.0.0", dependencies: { "no-deps": "1.0.0" } });
+
+  type Req = { path: string; auth: string | null };
+
+  type MockRegistryOptions = {
+    /** Serve dist.tarball from another server instead of this one. */
+    tarballOrigin?: () => string;
+    /** Mount the registry under this path prefix instead of `/`. */
+    registryPath?: string;
+    /** Path of the tarball on its server. */
+    tarballPath?: string;
+    /** Let the manifest through without credentials; only the tarball is protected. */
+    publicManifest?: boolean;
+  };
+
+  // Serves no-deps@1.0.0 and answers 401 to any request that does not carry
+  // exactly `expectedAuth`.
+  function mockRegistry(expectedAuth: string, options: MockRegistryOptions = {}) {
+    const { tarballOrigin, registryPath = "", tarballPath = "/no-deps/-/no-deps-1.0.0.tgz", publicManifest } = options;
+    const requests: Req[] = [];
+    const server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req) {
+        const url = new URL(req.url);
+        const auth = req.headers.get("authorization");
+        requests.push({ path: url.pathname, auth });
+        const isManifest = url.pathname === `${registryPath}/no-deps`;
+        if (auth !== expectedAuth && !(isManifest && publicManifest)) {
+          return new Response("unauthorized", { status: 401 });
+        }
+        if (url.pathname === tarballPath) return new Response(Bun.file(tgz));
+        if (isManifest) {
+          const origin = tarballOrigin ? tarballOrigin() : `http://127.0.0.1:${server.port}`;
+          return Response.json({
+            name: "no-deps",
+            "dist-tags": { latest: "1.0.0" },
+            versions: {
+              "1.0.0": {
+                name: "no-deps",
+                version: "1.0.0",
+                dist: { tarball: `${origin}${tarballPath}` },
+              },
+            },
+          });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
+    return {
+      requests,
+      host: `127.0.0.1:${server.port}`,
+      origin: `http://127.0.0.1:${server.port}`,
+      [Symbol.dispose]() {
+        server.stop(true);
+      },
+    };
+  }
+
+  async function install(dir: string, args: string[] = [], extraEnv: Record<string, string> = {}) {
+    // bunEnv spreads process.env; the user-level .npmrc of the machine running the
+    // tests must not leak in, and the cache must be cold so the tarball is fetched.
+    const spawnEnv: Record<string, string> = {
+      ...(env as Record<string, string>),
+      HOME: join(dir, "home"),
+      USERPROFILE: join(dir, "home"),
+      BUN_INSTALL_CACHE_DIR: join(dir, ".cache"),
+      ...extraEnv,
+    };
+    delete spawnEnv.XDG_CONFIG_HOME;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install", ...args],
+      cwd: dir,
+      env: spawnEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  const manifestPath = "/no-deps";
+  const tarballPath = "/no-deps/-/no-deps-1.0.0.tgz";
+
+  test("--registry uses the token the user-level .npmrc has for that host", async () => {
+    using registry = mockRegistry("Bearer user-npmrc-token");
+    using dir = tempDir("npmrc-url-auth-cli-registry", {
+      "package.json": packageJson,
+      "home/.npmrc": `//${registry.host}/:_authToken=user-npmrc-token\n`,
+    });
+
+    const { stderr, exitCode } = await install(String(dir), ["--registry", `${registry.origin}/`]);
+
+    expect({ requests: registry.requests, exitCode, stderr }).toEqual({
+      requests: [
+        { path: manifestPath, auth: "Bearer user-npmrc-token" },
+        { path: tarballPath, auth: "Bearer user-npmrc-token" },
+      ],
+      exitCode: 0,
+      stderr: expect.not.stringContaining("401"),
+    });
+  });
+
+  test.each(["NPM_CONFIG_REGISTRY", "BUN_CONFIG_REGISTRY"])(
+    "a registry from %s uses the token the project .npmrc has for that host",
+    async variable => {
+      using registry = mockRegistry("Bearer env-registry-token");
+      using dir = tempDir("npmrc-url-auth-env-registry", {
+        "package.json": packageJson,
+        ".npmrc": `//${registry.host}/:_authToken=env-registry-token\n`,
+      });
+
+      const { exitCode } = await install(String(dir), [], { [variable]: `${registry.origin}/` });
+
+      expect({ requests: registry.requests, exitCode }).toEqual({
+        requests: [
+          { path: manifestPath, auth: "Bearer env-registry-token" },
+          { path: tarballPath, auth: "Bearer env-registry-token" },
+        ],
+        exitCode: 0,
+      });
+    },
+  );
+
+  test("username and _password lines for the --registry host are sent as basic auth", async () => {
+    using registry = mockRegistry(basic("alice", "open sesame"));
+    using dir = tempDir("npmrc-url-auth-basic", {
+      "package.json": packageJson,
+      ".npmrc": [
+        `//${registry.host}/:username=alice`,
+        `//${registry.host}/:_password=${Buffer.from("open sesame").toString("base64")}`,
+        "",
+      ].join("\n"),
+    });
+
+    const { exitCode } = await install(String(dir), ["--registry", `${registry.origin}/`]);
+
+    expect({ requests: registry.requests, exitCode }).toEqual({
+      requests: [
+        { path: manifestPath, auth: basic("alice", "open sesame") },
+        { path: tarballPath, auth: basic("alice", "open sesame") },
+      ],
+      exitCode: 0,
+    });
+  });
+
+  test("a 401 for credentials that were sent is reported without a suggestion", async () => {
+    using registry = mockRegistry("Bearer the-token-the-registry-wants");
+    using dir = tempDir("npmrc-url-auth-rejected", {
+      "package.json": packageJson,
+      ".npmrc": `//${registry.host}/:_authToken=revoked-token\n`,
+    });
+
+    const { stderr, exitCode } = await install(String(dir), ["--registry", `${registry.origin}/`]);
+
+    expect({ requests: registry.requests, exitCode }).toEqual({
+      requests: [{ path: manifestPath, auth: "Bearer revoked-token" }],
+      exitCode: 1,
+    });
+    expect(stderr).toContain(`error: GET ${registry.origin}${manifestPath} - 401\nerror:`);
+    expect(stderr).not.toContain(".npmrc");
+  });
+
+  test("a tarball on a different host than its registry gets that host's own line", async () => {
+    using cdn = mockRegistry("Bearer cdn-token");
+    using registry = mockRegistry("Bearer registry-token", { tarballOrigin: () => cdn.origin });
+    using dir = tempDir("npmrc-url-auth-tarball-host", {
+      "package.json": packageJson,
+      ".npmrc": [
+        `registry=${registry.origin}/`,
+        `//${registry.host}/:_authToken=registry-token`,
+        `//${cdn.host}/:_authToken=cdn-token`,
+        "",
+      ].join("\n"),
+    });
+
+    const { exitCode } = await install(String(dir));
+
+    expect({ registry: registry.requests, cdn: cdn.requests, exitCode }).toEqual({
+      registry: [{ path: manifestPath, auth: "Bearer registry-token" }],
+      cdn: [{ path: tarballPath, auth: "Bearer cdn-token" }],
+      exitCode: 0,
+    });
+  });
+
+  test("the line with the deepest path covering the tarball url wins; other paths on the host do not apply", async () => {
+    using cdn = mockRegistry("Bearer deep-token");
+    using registry = mockRegistry("Bearer registry-token", { tarballOrigin: () => cdn.origin });
+    using dir = tempDir("npmrc-url-auth-tarball-path", {
+      "package.json": packageJson,
+      ".npmrc": [
+        `registry=${registry.origin}/`,
+        `//${registry.host}/:_authToken=registry-token`,
+        `//${cdn.host}/no-deps-other/:_authToken=other-token`,
+        `//${cdn.host}/:_authToken=shallow-token`,
+        `//${cdn.host}/no-deps/:_authToken=deep-token`,
+        "",
+      ].join("\n"),
+    });
+
+    const { exitCode } = await install(String(dir));
+
+    expect({ cdn: cdn.requests, exitCode }).toEqual({
+      cdn: [{ path: tarballPath, auth: "Bearer deep-token" }],
+      exitCode: 0,
+    });
+  });
+
+  test("a line for another path on the tarball host does not authenticate it, even if it is a string prefix", async () => {
+    using cdn = mockRegistry("Bearer other-token");
+    using registry = mockRegistry("Bearer registry-token", { tarballOrigin: () => cdn.origin });
+    using dir = tempDir("npmrc-url-auth-tarball-wrong-path", {
+      "package.json": packageJson,
+      ".npmrc": [
+        `registry=${registry.origin}/`,
+        `//${registry.host}/:_authToken=registry-token`,
+        // "/no" is a prefix of "/no-deps/..." but not a parent directory of it.
+        `//${cdn.host}/no/:_authToken=other-token`,
+        "",
+      ].join("\n"),
+    });
+
+    const { stderr, exitCode } = await install(String(dir));
+
+    expect({ cdn: cdn.requests, exitCode }).toEqual({
+      cdn: [{ path: tarballPath, auth: null }],
+      exitCode: 1,
+    });
+    expect(stderr).toContain(
+      `error: GET ${cdn.origin}${tarballPath} - 401\n` +
+        `  the credentials configured for ${registry.host} are not sent to ${cdn.host}; ` +
+        `add //${cdn.host}/:_authToken=<token> to .npmrc if this host needs them\n`,
+    );
+  });
+
+  test("a 401 from a registry nothing is configured for says which .npmrc line would authenticate it", async () => {
+    using registry = mockRegistry("Bearer some-token");
+    using dir = tempDir("npmrc-url-auth-missing-note", { "package.json": packageJson });
+
+    const { stderr, exitCode } = await install(String(dir), ["--registry", `${registry.origin}/`]);
+
+    expect(registry.requests).toEqual([{ path: manifestPath, auth: null }]);
+    expect(stderr).toContain(
+      `error: GET ${registry.origin}${manifestPath} - 401\n` +
+        `  no credentials are configured for this registry; add //${registry.host}/:_authToken=<token> to .npmrc\n`,
+    );
+    expect(exitCode).toBe(1);
+  });
+
+  // https://github.com/oven-sh/bun/issues/30513: GitLab resolves packages through
+  // an instance-level registry path but serves tarballs from (and keys tokens to)
+  // a project-level path. The token line covers the tarball URL and nothing else.
+  test("a line keyed to the tarball path authenticates the tarball when the registry itself has no credentials", async () => {
+    const registryPath = "/api/v4/packages/npm";
+    const tarballPath = "/api/v4/projects/123/packages/npm/no-deps/-/no-deps-1.0.0.tgz";
+    using registry = mockRegistry("Bearer project-token", { registryPath, tarballPath, publicManifest: true });
+    using dir = tempDir("npmrc-url-auth-divergent-path", {
+      "package.json": packageJson,
+      ".npmrc": [
+        `registry=${registry.origin}${registryPath}/`,
+        `//${registry.host}/api/v4/projects/123/packages/npm/:_authToken=project-token`,
+        "",
+      ].join("\n"),
+    });
+
+    const { exitCode } = await install(String(dir));
+
+    expect({ requests: registry.requests, exitCode }).toEqual({
+      requests: [
+        { path: `${registryPath}/no-deps`, auth: null },
+        { path: tarballPath, auth: "Bearer project-token" },
+      ],
+      exitCode: 0,
+    });
+  });
+
+  test("a line keyed to a parent path of the registry url applies to the registry", async () => {
+    const registryPath = "/api/v4/packages/npm";
+    const tarballPath = `${registryPath}/no-deps/-/no-deps-1.0.0.tgz`;
+    using registry = mockRegistry("Bearer host-token", { registryPath, tarballPath });
+    using dir = tempDir("npmrc-url-auth-parent-path", {
+      "package.json": packageJson,
+      ".npmrc": [`registry=${registry.origin}${registryPath}/`, `//${registry.host}/:_authToken=host-token`, ""].join(
+        "\n",
+      ),
+    });
+
+    const { exitCode } = await install(String(dir));
+
+    expect({ requests: registry.requests, exitCode }).toEqual({
+      requests: [
+        { path: `${registryPath}/no-deps`, auth: "Bearer host-token" },
+        { path: tarballPath, auth: "Bearer host-token" },
+      ],
+      exitCode: 0,
+    });
+  });
+
+  test("a lockfile recorded against a registry that has since moved still downloads from the old host", async () => {
+    using oldRegistry = mockRegistry("Bearer old-token");
+    using newRegistry = mockRegistry("Bearer new-token");
+    using dir = tempDir("npmrc-url-auth-moved-registry", {
+      "package.json": packageJson,
+      ".npmrc": [`registry=${oldRegistry.origin}/`, `//${oldRegistry.host}/:_authToken=old-token`, ""].join("\n"),
+    });
+
+    const first = await install(String(dir));
+    expect(first.exitCode).toBe(0);
+    const lockfile = await Bun.file(join(String(dir), "bun.lock")).text();
+    expect(lockfile).toContain(`${oldRegistry.origin}${tarballPath}`);
+    oldRegistry.requests.length = 0;
+
+    // The registry moves; the user keeps credentials for both hosts, as npm
+    // needs them to for the same lockfile.
+    await Bun.write(
+      join(String(dir), ".npmrc"),
+      [
+        `registry=${newRegistry.origin}/`,
+        `//${newRegistry.host}/:_authToken=new-token`,
+        `//${oldRegistry.host}/:_authToken=old-token`,
+        "",
+      ].join("\n"),
+    );
+    await rm(join(String(dir), "node_modules"), { recursive: true, force: true });
+    await rm(join(String(dir), ".cache"), { recursive: true, force: true });
+
+    const second = await install(String(dir), ["--frozen-lockfile"]);
+
+    expect({ old: oldRegistry.requests, new: newRegistry.requests, exitCode: second.exitCode }).toEqual({
+      old: [{ path: tarballPath, auth: "Bearer old-token" }],
+      new: [],
+      exitCode: 0,
+    });
+  });
+});

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -985,6 +985,28 @@ describe.concurrent("//host/ credential lines are matched against the request UR
     expect(stderr).not.toContain(".npmrc");
   });
 
+  // Tarball dependencies written as a URL never carry registry credentials, so
+  // there is no .npmrc line to suggest for them.
+  test("a 401 for a tarball dependency given by URL is reported without a suggestion", async () => {
+    using host = mockRegistry("Bearer something");
+    using dir = tempDir("npmrc-url-auth-url-dependency", {
+      "package.json": JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        dependencies: { "no-deps": `${host.origin}${tarballPath}` },
+      }),
+    });
+
+    const { stderr, exitCode } = await install(String(dir));
+
+    expect({ requests: host.requests, exitCode }).toEqual({
+      requests: [{ path: tarballPath, auth: null }],
+      exitCode: 1,
+    });
+    expect(stderr).toContain(`error: GET ${host.origin}${tarballPath} - 401\n`);
+    expect(stderr).not.toContain(".npmrc");
+  });
+
   test("a tarball on a different host than its registry gets that host's own line", async () => {
     using cdn = mockRegistry("Bearer cdn-token");
     using registry = mockRegistry("Bearer registry-token", { tarballOrigin: () => cdn.origin });

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -1007,6 +1007,51 @@ describe.concurrent("//host/ credential lines are matched against the request UR
     expect(stderr).not.toContain(".npmrc");
   });
 
+  test("a 401 for a dist.tarball whose own userinfo was sent is reported without a suggestion", async () => {
+    using cdn = mockRegistry("Bearer what-the-cdn-actually-wants");
+    using registry = mockRegistry("Bearer registry-token", {
+      tarballOrigin: () => `http://carol:wrong-password@${cdn.host}`,
+    });
+    using dir = tempDir("npmrc-url-auth-tarball-userinfo-rejected", {
+      "package.json": packageJson,
+      ".npmrc": [`registry=${registry.origin}/`, `//${registry.host}/:_authToken=registry-token`, ""].join("\n"),
+    });
+
+    const { stderr, exitCode } = await install(String(dir));
+
+    // The URL's userinfo went out as basic auth and was rejected; no .npmrc
+    // line is missing, so none is suggested.
+    expect({ cdn: cdn.requests, exitCode }).toEqual({
+      cdn: [{ path: tarballPath, auth: basic("carol", "wrong-password") }],
+      exitCode: 1,
+    });
+    expect(stderr).toContain(`error: GET ${cdn.origin}${tarballPath} - 401\n`);
+    expect(stderr).not.toContain(".npmrc");
+  });
+
+  test("a line for the tarball host takes precedence over userinfo in the dist.tarball url", async () => {
+    using cdn = mockRegistry("Bearer cdn-token");
+    using registry = mockRegistry("Bearer registry-token", {
+      tarballOrigin: () => `http://carol:s3cret@${cdn.host}`,
+    });
+    using dir = tempDir("npmrc-url-auth-line-over-userinfo", {
+      "package.json": packageJson,
+      ".npmrc": [
+        `registry=${registry.origin}/`,
+        `//${registry.host}/:_authToken=registry-token`,
+        `//${cdn.host}/:_authToken=cdn-token`,
+        "",
+      ].join("\n"),
+    });
+
+    const { exitCode } = await install(String(dir));
+
+    expect({ cdn: cdn.requests, exitCode }).toEqual({
+      cdn: [{ path: tarballPath, auth: "Bearer cdn-token" }],
+      exitCode: 0,
+    });
+  });
+
   test("a tarball on a different host than its registry gets that host's own line", async () => {
     using cdn = mockRegistry("Bearer cdn-token");
     using registry = mockRegistry("Bearer registry-token", { tarballOrigin: () => cdn.origin });

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -1029,6 +1029,29 @@ describe.concurrent("//host/ credential lines are matched against the request UR
     });
   });
 
+  test("username and _password lines for the tarball host are sent to it as basic auth", async () => {
+    using cdn = mockRegistry(basic("cdn-user", "cdn-pass"));
+    using registry = mockRegistry("Bearer registry-token", { tarballOrigin: () => cdn.origin });
+    using dir = tempDir("npmrc-url-auth-tarball-host-basic", {
+      "package.json": packageJson,
+      ".npmrc": [
+        `registry=${registry.origin}/`,
+        `//${registry.host}/:_authToken=registry-token`,
+        `//${cdn.host}/:username=cdn-user`,
+        `//${cdn.host}/:_password=${Buffer.from("cdn-pass").toString("base64")}`,
+        "",
+      ].join("\n"),
+    });
+
+    const { exitCode } = await install(String(dir));
+
+    expect({ registry: registry.requests, cdn: cdn.requests, exitCode }).toEqual({
+      registry: [{ path: manifestPath, auth: "Bearer registry-token" }],
+      cdn: [{ path: tarballPath, auth: basic("cdn-user", "cdn-pass") }],
+      exitCode: 0,
+    });
+  });
+
   test("the line with the deepest path covering the tarball url wins; other paths on the host do not apply", async () => {
     using cdn = mockRegistry("Bearer deep-token");
     using registry = mockRegistry("Bearer registry-token", { tarballOrigin: () => cdn.origin });


### PR DESCRIPTION
### Problem

- `.npmrc` credential lines (`//host/path/:_authToken=`, `:_auth=`, `:username=` + `:_password=`) are only attached to registries declared in a config file, at the moment that file is read (`src/ini/lib.rs`, `load_npmrc` / `apply_registry_auth`). Nothing looks a credential up by the URL of the request being made, which is how npm applies them.
- Setups that npm handles therefore send no `Authorization` header and fail with a bare `error: GET <url> - 401`:
  - `~/.npmrc` containing only `//reg/:_authToken=T`, plus `bun install --registry http://reg/`
  - the same `.npmrc`, plus `NPM_CONFIG_REGISTRY` or `BUN_CONFIG_REGISTRY` (both are applied in `Options::load`, after the `.npmrc` lines were matched)
  - a registry whose `dist.tarball` URLs are on another host that has its own `//host/` line (`NetworkTask::for_tarball` only ever consulted the package's scope, and correctly refuses to send the scope's credentials cross-origin)
  - a registry that moved: `bun.lock` still holds absolute tarball URLs on the old host, `.npmrc` has lines for both hosts, `bun install --frozen-lockfile` on a cold cache 401s on every tarball
  - #30513: the token is keyed to GitLab's project-level path, tarballs are served from that path, and the registry is declared at the instance-level path, so the line matches neither the registry URL nor anything else bun compares it against
  - a line keyed to a parent path of the registry URL (`//host/` with a registry at `/api/v4/.../npm/`)
- The failure output gives no hint that the request went out without credentials or which line would fix it.

### Fix

- `bun_ini` keeps every credential line, merged per `//host/path/` key, in the new `BunInstall.url_auth`. The existing load-time attachment is unchanged.
- `Options::load` turns them into `npm::registry::UrlAuth` entries (`npm.rs`), matched the way npm resolves credentials for a URL: same host, same port (a key without a port means the scheme's default port), key path equal to or a parent directory of the request path, deepest matching key wins. Entries with nothing sendable (an `email` line on its own) are dropped so they cannot shadow a shallower key.
- At the end of `Options::load`, after bunfig, `.npmrc`, the environment and the command line have all been applied, any scope still without credentials takes the entry matching its registry URL (`fill_credentials_from_url_auth`). This covers `--registry`, the environment variables and the parent-path case, and leaves a scope that already has credentials (including `--token` / `BUN_CONFIG_TOKEN`) alone.
- `for_tarball` asks `Options::tarball_credentials`: the scope's credentials when the tarball is on the scope's origin (the existing guard, unchanged), otherwise the entry matching the tarball URL, otherwise nothing configured. Since #38867 a tarball URL's own userinfo is also sent as basic auth; it is used only when neither of the above applies, the same order npm uses between configured credentials and URL auth (#38867 already applied it between scope credentials and userinfo). A registry still cannot get a scope's credentials sent anywhere else; the existing cross-origin test in `bun-install.test.ts` and #38867's userinfo tests are unchanged.
- A 401/403 for a registry request bun sent without credentials gets a second line naming the `.npmrc` key that would have authenticated it (`Options::missing_credentials_note`, called from the two `GET <url> - <status>` sites in `runTasks.rs`). The `NetworkTask` records whether registry credentials were allowed on the download at all and whether any `Authorization` header went out, so the note is not offered for `github:` and URL tarball dependencies (no line would be used) nor after a header from any source (scope, line or userinfo) was rejected.
- The change is additive: the env var and `--registry` code in `Options::load` is not touched. Rebased on top of #38796 (credentials embedded in those URLs): a URL with credentials fills the scope before the lookup runs at the end of `load`, so the lookup stays out of its way, and the merged `npmrc.test.ts` (this PR's tests plus #38796's and #38828's) passes as a whole. Independent of #38776 (`bun publish` with basic auth). #33869 reworks how lines attach to declared registries at load time; this change leaves that code alone and adds the by-URL lookup next to it. Supersedes #34329 (now closed), which handled the separate-tarball-host case only.
- Verified:
  - `test/cli/install/npmrc.test.ts`, new `describe` block: 16 tests against `Bun.serve` registries that 401 unless the exact expected header arrives, one per shape above plus basic auth from `username`/`_password` lines (for the registry host and for a separate tarball host), deepest-key precedence, a `/no/` key not matching `/no-deps/...`, a line for the tarball host winning over userinfo in `dist.tarball`, and the note (present when nothing was sent; absent when a sent token was rejected, for a URL dependency, and after rejected userinfo). 14 of them fail on the 1.4.0 release build; the two note guards fail on the revision of this PR before each was added. The whole file (56 tests, including #38796's and #38828's) passes with this change.
  - Run locally with the debug build: `config-precedence`, `bun-install-retry`, `redacted-config-logs`, `bun-info`, `bun-audit`, `bun-publish`, and the auth/registry subsets of `bun-install` and `bun-install-registry`; `cargo clippy` on the touched crates and `test/internal/source-lints` are clean.

<details>
<summary>Rebase notes</summary>

- #38796 (credentials in `--registry` / env var URLs): no code overlap; the docs sentence and the end of `npmrc.test.ts` (where #38828's IPv6 block landed) were merged by keeping both sides.
- #38183 (`Scope::set_url`): both sides added methods at the same spot in `impl Scope`; both kept. The canonical URL it stores is what the end-of-load lookup and the same-origin check now read.
- #38867 (tarball URL userinfo): the only non-trivial one. Its `for_tarball` splits the userinfo off the URL and, when the scope's credentials do not apply, sends it as basic auth. This PR's `for_tarball` replaces the scope-only decision with `tarball_credentials`, so the two were merged into one chain (configured credentials from the scope or a line, else userinfo, else nothing), the credential lookup runs on the URL after the userinfo is removed, and the shared header-building tail became `store_header_buf`. Because a tarball request can now carry a header the note's recomputation could not see, 4688f54 makes the note go by whether a header was actually sent (`NetworkTask::sent_authorization`), with two tests for the interaction.

</details>

Fixes #30513

### Background

- **Scope** (`npm::registry::Scope`): bun's unit of registry configuration, one for the default registry plus one per `@scope:registry`. It holds the registry URL and the credentials sent with every request to it; `Options::scope_for_package_name` picks it per package, and `NetworkTask::for_manifest` / `for_tarball` send its `token` (bearer) or `auth` (base64 `user:pass`).
- **Credential lines** (npm calls the keys "nerf darts"): `.npmrc` keys of the form `//host/path/`. npm never attaches them to a registry; for every request it builds `//host/path` from the request URL and walks up the path until a key with credentials matches. A registry's own key matches its manifests and tarballs because they share its host and path; a tarball served elsewhere gets credentials only if that location has its own key.
- **Why tarballs are special**: the tarball URL comes from the manifest, which the registry controls, so a hostile registry could direct a download anywhere. bun therefore sends a scope's credentials only to the scope's own origin. The by-URL lookup only ever sends credentials to the place the user wrote them down for, so it does not weaken that.
- **Config order** (`PackageManager::init`, then `Options::load`): `.npmrc` files are parsed into `BunInstall`, bunfig is overlaid, then `Options::load` applies environment variables and command-line flags. Registries set in that last step did not exist when the `.npmrc` lines were attached, which is why the lookup has to run at the end of `load` and again at request time for tarballs.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 8 · 10 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 14 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/npmrc.test.ts
bun test v1.4.0 (8326d1bd3)

test/cli/install/npmrc.test.ts:
{
  out: "/tmp/verdaccio-test-_fXI0v8/hi!",
  err: "",
}
(pass) npmrc > should convert to utf8 if BOM [185.77ms]
package dir /tmp/verdaccio-test-_XKIOv3
bun install v1.4.0 (8326d1bd3)
No packages! Deleted empty lockfile

[92.00ms] done
(pass) npmrc > works with empty file [187.64ms]
package dir /tmp/verdaccio-test-_aFVDYU
bun install v1.4.0 (8326d1bd3)
Resolving dependencies
Resolved, downloaded and extracted [2]
Saved lockfile

+ no-deps@1.0.0 (v2.0.0 available)

1 package installed [150.00ms]
(pass) npmrc > sets default registry [216.92ms]
bun install v1.4.0 (8326d1bd3)
Resolving dependencies
Resolved, downloaded and extracted [2]
Saved lockfile

+ @types/no-deps@1.0.0 (v2.0.0 available)

1 package installed [133.00ms]
(pass) npmrc > sets scoped registry [211.77ms]
package dir /tmp/verdaccio-test-_UMH3IM
home dir /tmp/verdaccio-test-_UMH3IM/home_dir
bun install v1.4.0 (8326d1bd3)
Saved lockfile

+ no-deps@1.0.0 (v2.0.0 available)

1 package in
... (truncated)

release without fix: 15 FAILED
bun test v1.4.0-canary.1 (8326d1bd3)

test/cli/install/npmrc.test.ts:
{
  out: "/tmp/verdaccio-test-_i8dErt/hi!",
  err: "",
}
(pass) npmrc > should convert to utf8 if BOM [4.62ms]
package dir /tmp/verdaccio-test-_r1N7W1
bun install v1.4.0-canary.1 (8326d1bd3)
No packages! Deleted empty lockfile

[0.00ms] done
(pass) npmrc > works with empty file [4.30ms]
package dir /tmp/verdaccio-test-_X5jgrE
bun install v1.4.0-canary.1 (8326d1bd3)
Resolving dependencies
Resolved, downloaded and extracted [2]
Saved lockfile

+ no-deps@1.0.0 (v2.0.0 available)

1 package installed [19.00ms]
(pass) npmrc > sets default registry [22.67ms]
bun install v1.4.0-canary.1 (8326d1bd3)
Resolving dependencies
Resolved, downloaded and extracted [2]
Saved lockfile

+ @types/no-deps@1.0.0 (v2.0.0 available)

1 package installed [4.00ms]
(pass) npmrc > sets scoped registry [7.71ms]
package dir /tmp/verdaccio-test-_MiX1NW
home dir /tmp/verdaccio-test-_MiX1NW/home_dir
bun install v1.4.0-canary.1 (8326d1bd3)
Saved lockfile

+ no-deps@1.0.0 (v2.0.0 available)

1 package installed [1.00ms]
(pass) npmrc > works with home config [4.25ms]
package dir /tmp/verdaccio-test-_FALt7K
home dir /tmp/verdaccio-te
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/npmrc.test.ts
bun test v1.4.0 (8326d1bd3)

test/cli/install/npmrc.test.ts:
{
  out: "/tmp/verdaccio-test-_AsA7H5/hi!",
  err: "",
}
(pass) npmrc > should convert to utf8 if BOM [199.84ms]
package dir /tmp/verdaccio-test-_LLASwW
bun install v1.4.0 (8326d1bd3)
No packages! Deleted empty lockfile

[97.00ms] done
(pass) npmrc > works with empty file [194.34ms]
package dir /tmp/verdaccio-test-_t4XuKB
bun install v1.4.0 (8326d1bd3)
Resolving dependencies
Resolved, downloaded and extracted [2]
Saved lockfile

+ no-deps@1.0.0 (v2.0.0 available)

1 package installed [146.00ms]
(pass) npmrc > sets default registry [213.96ms]
bun install v1.4.0 (8326d1bd3)
Resolving dependencies
Resolved, downloaded and extracted [2]
Saved lockfile

+ @types/no-deps@1.0.0 (v2.0.0 available)

1 package installed [129.00ms]
(pass) npmrc > sets scoped registry [198.56ms]
package dir /tmp/verdaccio-test-_UKfePt
home dir /tmp/verdaccio-test-_UKfePt/home_dir
bun install v1.4.0 (8326d1bd3)
Saved lockfile

+ no-deps@1.0.0 (v2.0.0 available)

1 package in
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1003ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/642] cc obj/vendor/tinycc/tccrun.c.o
[2/642] cc obj/vendor/tinycc/x86_64-link.c.o
[3/642] cc obj/vendor/tinycc/i386-asm.c.o
[4/642] cc obj/vendor/tinycc/x86_64-gen.c.o
[5/642] fetch mimalloc
[mimalloc] up to date
[6/641] fetch libspng
[libspng] up to date
[7/640] fetch boringssl
[boringssl] up to date
[8/218] fetch lsquic
[lsquic] up to date
[9/149] cc obj/codegen/InternalModuleRegistryConstants.S.o
[10/149] fetch lolhtml
[lolhtml] up to date
[10/149] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m std v0.0.0 (/root/.rustup/toolchains/nightly-2026-07-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std)
[1m[92m   Compiling[0m bun_output_tags v0.0.0 (/workspace/bun/src/bun_output_tags)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_parsers v0.0.0 (/workspace/bun/src/parsers)
[1m[92m   Comp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/pm/npmrc.mdx                                  |   2 +-
 src/api/lib.rs                                     |   2 +-
 src/ini/lib.rs                                     |  23 +-
 src/install/NetworkTask.rs                         |  90 ++---
 src/install/PackageManager.rs                      |   3 +
 .../PackageManager/PackageManagerOptions.rs        | 158 ++++++++
 src/install/PackageManager/runTasks.rs             |  49 ++-
 src/install/npm.rs                                 |  89 +++++
 src/options_types/schema.rs                        |  22 ++
 test/cli/install/npmrc.test.ts                     | 433 +++++++++++++++++++++
 10 files changed, 819 insertions(+), 52 deletions(-)
```

</details>

**gate history** · 2 passed · 2 rejected · iteration 8

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
docs/pm/npmrc.mdx                                        2      3      0
src/api/lib.rs                                           2      6      0
src/ini/lib.rs                                           6      8      0
src/install/NetworkTask.rs                               7     14      0
src/install/PackageManager.rs                            4      2      0
src/install/PackageManager/PackageManagerOptions.rs      8     25      0
src/install/PackageManager/runTasks.rs                   7      7      0
src/install/npm.rs                                       5     10      0
src/options_types/schema.rs                              2      5      0
test/cli/install/npmrc.test.ts                          10     18      0
```

</details>

<!-- robobun:evidence:end -->
