### PR TITLE
compile: store module text in the width JSC loads it in

### DIFF
--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -2622,6 +2622,50 @@ pub fn to_utf16_alloc(
     Ok(Some(out))
 }
 
+/// UTF-8 text converted to the code units a WTF/JSC string stores it in: 8-bit
+/// Latin-1 when every code point is ≤ U+00FF, 16-bit UTF-16 otherwise.
+pub enum WtfUnits {
+    Latin1(Vec<u8>),
+    Utf16(Vec<u16>),
+}
+
+impl WtfUnits {
+    /// Raw-byte view of the code units (UTF-16 is native/little-endian).
+    pub fn as_bytes(&self) -> &[u8] {
+        match self {
+            WtfUnits::Latin1(bytes) => bytes,
+            WtfUnits::Utf16(units) => {
+                // SAFETY: a `u8` view over an initialized `u16` slice is always
+                // in-bounds and aligned.
+                unsafe { core::slice::from_raw_parts(units.as_ptr().cast::<u8>(), units.len() * 2) }
+            }
+        }
+    }
+
+    pub fn is_utf16(&self) -> bool {
+        matches!(self, WtfUnits::Utf16(_))
+    }
+}
+
+/// Convert UTF-8 `bytes` into the width a WTF/JSC string would store them in:
+/// `Ok(None)` when `bytes` is pure ASCII (already its own Latin-1 form),
+/// otherwise [`WtfUnits::Latin1`] when every code point is ≤ U+00FF, else
+/// [`WtfUnits::Utf16`]. Invalid UTF-8 sequences become U+FFFD.
+pub fn to_wtf_units_alloc(bytes: &[u8]) -> Result<Option<WtfUnits>, ToUTF16Error> {
+    let Some(utf16) = to_utf16_alloc(bytes, false, false)? else {
+        return Ok(None);
+    };
+    if utf16.iter().any(|&unit| unit > 0xFF) {
+        return Ok(Some(WtfUnits::Utf16(utf16)));
+    }
+    let mut latin1: Vec<u8> = Vec::new();
+    latin1
+        .try_reserve_exact(utf16.len())
+        .map_err(|_| ToUTF16Error::OutOfMemory)?;
+    latin1.extend(utf16.iter().map(|&unit| unit as u8));
+    Ok(Some(WtfUnits::Latin1(latin1)))
+}
+
 /// WTF-8 → UTF-16LE iff `bytes` contains any non-ASCII byte; pure-ASCII inputs return `None`.
 pub fn wtf8_to_utf16_alloc(bytes: &[u8]) -> Option<Vec<u16>> {
     first_non_ascii(bytes)?;

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1411,6 +1411,7 @@ pub mod bv2_impl {
             safe fn __bun_jsc_generate_cached_bytecode(
                 format: crate::options_impl::Format,
                 source: &[u8],
+                source_encoding: bun_core::strings::EncodingNonAscii,
                 source_provider_url: &bun_core::String,
                 depth: u32,
                 external_strings: Option<core::ptr::NonNull<EncoderStringTable>>,
@@ -1464,6 +1465,7 @@ pub mod bv2_impl {
         pub(crate) fn generate_cached_bytecode(
             format: crate::options_impl::Format,
             source: &[u8],
+            source_encoding: bun_core::strings::EncodingNonAscii,
             source_provider_url: &bun_core::String,
             depth: u32,
             external_strings: Option<core::ptr::NonNull<EncoderStringTable>>,
@@ -1476,6 +1478,7 @@ pub mod bv2_impl {
             __bun_jsc_generate_cached_bytecode(
                 format,
                 source,
+                source_encoding,
                 source_provider_url,
                 depth,
                 external_strings,

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -1063,9 +1063,52 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                             ))
                         };
 
+                        // For --compile, bytecode must be generated from the
+                        // exact code units the executable stores (see
+                        // `stores_transcoded_contents` in
+                        // `StandaloneModuleGraph.rs`), or the SourceCodeKey
+                        // won't match at runtime.
+                        let transcoded = if c.options.compile_mode.is_executable()
+                            && side == options::Side::Server
+                        {
+                            bun_core::handle_oom(
+                                strings::to_wtf_units_alloc(&code_result.buffer)
+                                    .map_err(|_| bun_alloc::AllocError),
+                            )
+                        } else {
+                            None
+                        };
+                        let (source, source_encoding): (&[u8], strings::EncodingNonAscii) =
+                            match &transcoded {
+                                Some(units) => (
+                                    units.as_bytes(),
+                                    if units.is_utf16() {
+                                        strings::EncodingNonAscii::Utf16
+                                    } else {
+                                        strings::EncodingNonAscii::Latin1
+                                    },
+                                ),
+                                None => (
+                                    &code_result.buffer,
+                                    if c.options.compile_mode.is_executable() {
+                                        // Client chunks are stored `Binary`
+                                        // (raw UTF-8, read back with
+                                        // `clone_utf8`); pure-ASCII server
+                                        // text is width-identical either way.
+                                        strings::EncodingNonAscii::Utf8
+                                    } else {
+                                        // The `.jsc` loader's `already_bundled`
+                                        // path builds its runtime string with
+                                        // `clone_latin1`; the key must match.
+                                        strings::EncodingNonAscii::Latin1
+                                    },
+                                ),
+                            };
+
                         if let Some(bytecode) = crate::bundle_v2::dispatch::generate_cached_bytecode(
                             c.options.output_format,
-                            &code_result.buffer,
+                            source,
+                            source_encoding,
                             &source_provider_url,
                             c.options.bytecode_depth,
                             external_string_table.as_ref().and_then(|table| table.get()),

--- a/src/bundler/linker_context/writeOutputFilesToDisk.rs
+++ b/src/bundler/linker_context/writeOutputFilesToDisk.rs
@@ -404,6 +404,9 @@ pub(crate) fn write_output_files_to_disk(
                     if let Some(bytecode) = crate::bundle_v2::dispatch::generate_cached_bytecode(
                         c.options.output_format,
                         &code_result.buffer,
+                        // The `.jsc` loader's `already_bundled` path builds its
+                        // runtime string with `clone_latin1`; the key must match.
+                        bun_core::strings::EncodingNonAscii::Latin1,
                         &source_provider_url,
                         c.options.bytecode_depth,
                         None,

--- a/src/jsc/CachedBytecode.rs
+++ b/src/jsc/CachedBytecode.rs
@@ -187,8 +187,14 @@ pub(crate) fn __bun_jsc_generate_cached_bytecode(
 ) -> Option<Box<[u8]>> {
     crate::virtual_machine::IS_BUNDLER_THREAD_FOR_BYTECODE_CACHE.set(true);
     crate::initialize(crate::InitializeOptions::default());
-    let (bytes, handle) =
-        CachedBytecode::generate(format, source, source_encoding, source_provider_url, depth, external_strings)?;
+    let (bytes, handle) = CachedBytecode::generate(
+        format,
+        source,
+        source_encoding,
+        source_provider_url,
+        depth,
+        external_strings,
+    )?;
     let owned = Box::<[u8]>::from(bytes);
     // `handle` was just produced by C++ and is valid until deref;
     // `CachedBytecode` is an opaque ZST handle so `opaque_mut` is the

--- a/src/jsc/CachedBytecode.rs
+++ b/src/jsc/CachedBytecode.rs
@@ -1,6 +1,7 @@
 use core::ptr::NonNull;
 
 use bun_core::String as BunString;
+use bun_core::strings::EncodingNonAscii;
 use bun_options_types::Format;
 
 bun_opaque::opaque_ffi! {
@@ -36,6 +37,32 @@ impl EncoderStringTable {
     }
 }
 
+/// How the generators read `input_code`; the C++ side of the enum is in
+/// ZigSourceProvider.cpp and the two must stay in step. JSC only accepts
+/// bytecode generated from a string equal to the one the module loader builds,
+/// so the generator has to decode the bytes the same way the load path for
+/// that kind of source does: the on-disk `.jsc` loader reads raw bytes as
+/// Latin-1 (`clone_latin1`), while a compiled executable stores module text in
+/// its final width (see `stores_transcoded_contents` in
+/// `StandaloneModuleGraph.rs`).
+#[repr(u8)]
+#[derive(Clone, Copy)]
+enum BytecodeSourceEncoding {
+    Utf8 = 0,
+    Latin1 = 1,
+    Utf16 = 2,
+}
+
+impl From<EncodingNonAscii> for BytecodeSourceEncoding {
+    fn from(encoding: EncodingNonAscii) -> Self {
+        match encoding {
+            EncodingNonAscii::Utf8 => Self::Utf8,
+            EncodingNonAscii::Latin1 => Self::Latin1,
+            EncodingNonAscii::Utf16 => Self::Utf16,
+        }
+    }
+}
+
 unsafe extern "C" {
     fn Bun__EncoderStringTable__create() -> *mut EncoderStringTable;
     fn Bun__EncoderStringTable__destroy(this: *mut EncoderStringTable);
@@ -49,6 +76,7 @@ unsafe extern "C" {
         source_provider_url: &BunString,
         input_code: *const u8,
         input_source_code_size: usize,
+        input_encoding: BytecodeSourceEncoding,
         depth: u32,
         output_byte_code: *mut Option<NonNull<u8>>,
         output_byte_code_size: *mut usize,
@@ -60,6 +88,7 @@ unsafe extern "C" {
         source_provider_url: &BunString,
         input_code: *const u8,
         input_source_code_size: usize,
+        input_encoding: BytecodeSourceEncoding,
         depth: u32,
         output_byte_code: *mut Option<NonNull<u8>>,
         output_byte_code_size: *mut usize,
@@ -92,6 +121,7 @@ impl CachedBytecode {
     pub(crate) fn generate(
         format: Format,
         input: &[u8],
+        input_encoding: EncodingNonAscii,
         source_provider_url: &BunString,
         depth: u32,
         external_strings: Option<NonNull<EncoderStringTable>>,
@@ -110,6 +140,7 @@ impl CachedBytecode {
                 source_provider_url,
                 input.as_ptr(),
                 input.len(),
+                BytecodeSourceEncoding::from(input_encoding),
                 depth,
                 &raw mut out_ptr,
                 &raw mut out_size,
@@ -149,6 +180,7 @@ impl bun_alloc::Allocator for CachedBytecode {}
 pub(crate) fn __bun_jsc_generate_cached_bytecode(
     format: Format,
     source: &[u8],
+    source_encoding: EncodingNonAscii,
     source_provider_url: &BunString,
     depth: u32,
     external_strings: Option<NonNull<EncoderStringTable>>,
@@ -156,7 +188,7 @@ pub(crate) fn __bun_jsc_generate_cached_bytecode(
     crate::virtual_machine::IS_BUNDLER_THREAD_FOR_BYTECODE_CACHE.set(true);
     crate::initialize(crate::InitializeOptions::default());
     let (bytes, handle) =
-        CachedBytecode::generate(format, source, source_provider_url, depth, external_strings)?;
+        CachedBytecode::generate(format, source, source_encoding, source_provider_url, depth, external_strings)?;
     let owned = Box::<[u8]>::from(bytes);
     // `handle` was just produced by C++ and is valid until deref;
     // `CachedBytecode` is an opaque ZST handle so `opaque_mut` is the

--- a/src/jsc/NodeCompileCache.rs
+++ b/src/jsc/NodeCompileCache.rs
@@ -909,6 +909,9 @@ fn generate_bytecode(format: Format, code: &[u8], url: &[u8]) -> Option<Box<[u8]
                         let result = crate::cached_bytecode::__bun_jsc_generate_cached_bytecode(
                             job.format,
                             &job.code,
+                            // The cached code is the printer's buffer, which
+                            // this path has always read as Latin-1.
+                            bun_core::strings::EncodingNonAscii::Latin1,
                             &url,
                             u32::MAX,
                             None,

--- a/src/jsc/bindings/ZigSourceProvider.cpp
+++ b/src/jsc/bindings/ZigSourceProvider.cpp
@@ -205,10 +205,56 @@ extern "C" void Bun__DecoderStringTable__install(JSC::VM* vm, const uint8_t* byt
     static_cast<WebCore::JSVMClientData*>(vm->clientData)->setDecoderStringTable(std::span<const uint8_t>(bytes, len));
 }
 
-extern "C" bool generateCachedModuleByteCodeFromSourceCode(const BunString* sourceProviderURL, const Latin1Character* inputSourceCode, size_t inputSourceCodeSize, uint32_t depth, const uint8_t** outputByteCode, size_t* outputByteCodeSize, JSC::CachedBytecode** cachedBytecodePtr, JSC::EncoderStringTable* externalStrings)
+// Defined in BunString.cpp; decodes exactly like `String::clone_utf8`.
+extern "C" BunString BunString__fromBytes(const char* bytes, size_t length);
+
+// Mirrors `BytecodeSourceEncoding` in CachedBytecode.rs.
+enum class BytecodeSourceEncoding : uint8_t {
+    // Bytes decoded as UTF-8 (`BunString__fromBytes` semantics). Passed by
+    // the compile-mode fallback arm in generateChunksInParallel.rs: client
+    // chunks (stored `Binary`, read back with `clone_utf8`) and pure-ASCII
+    // server text.
+    Utf8 = 0,
+    // One Latin-1 character per byte: on-disk `.jsc` source (the loader's
+    // `already_bundled` path uses `clone_latin1`) and a compiled executable's
+    // Latin-1-stored module text ...
+    Latin1 = 1,
+    // ... or native-endian UTF-16 code units, two bytes each.
+    Utf16 = 2,
+};
+
+// JSC accepts the bytecode only if the string it was generated from equals the
+// string the module loader later creates, so each encoding is decoded exactly the
+// way the corresponding load path decodes it.
+static WTF::String sourceCodeStringForBytecode(const uint8_t* inputSourceCode, size_t inputSourceCodeSize, BytecodeSourceEncoding encoding)
 {
-    std::span<const Latin1Character> sourceCodeSpan(inputSourceCode, inputSourceCodeSize);
-    JSC::SourceCode sourceCode = JSC::makeSource(WTF::String(sourceCodeSpan), toSourceOrigin(sourceProviderURL->toWTFString(), false), JSC::SourceTaintedOrigin::Untainted);
+    if (inputSourceCodeSize == 0)
+        return WTF::emptyString();
+    switch (encoding) {
+    case BytecodeSourceEncoding::Utf8:
+        return BunString__fromBytes(reinterpret_cast<const char*>(inputSourceCode), inputSourceCodeSize).transferToWTFString();
+    case BytecodeSourceEncoding::Latin1:
+        return WTF::String(std::span { reinterpret_cast<const Latin1Character*>(inputSourceCode), inputSourceCodeSize });
+    case BytecodeSourceEncoding::Utf16: {
+        // The bytes arrive in a byte buffer, so copy rather than alias them as char16_t.
+        RELEASE_ASSERT(inputSourceCodeSize % 2 == 0);
+        std::span<char16_t> units;
+        auto impl = WTF::StringImpl::tryCreateUninitialized(inputSourceCodeSize / 2, units);
+        if (!impl)
+            return WTF::String();
+        memcpy(units.data(), inputSourceCode, units.size_bytes());
+        return WTF::String(WTF::move(impl));
+    }
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+extern "C" bool generateCachedModuleByteCodeFromSourceCode(const BunString* sourceProviderURL, const uint8_t* inputSourceCode, size_t inputSourceCodeSize, uint8_t inputEncoding, uint32_t depth, const uint8_t** outputByteCode, size_t* outputByteCodeSize, JSC::CachedBytecode** cachedBytecodePtr, JSC::EncoderStringTable* externalStrings)
+{
+    WTF::String source = sourceCodeStringForBytecode(inputSourceCode, inputSourceCodeSize, static_cast<BytecodeSourceEncoding>(inputEncoding));
+    if (source.isNull())
+        return false;
+    JSC::SourceCode sourceCode = JSC::makeSource(WTF::move(source), toSourceOrigin(sourceProviderURL->toWTFString(), false), JSC::SourceTaintedOrigin::Untainted);
 
     JSC::VM& vm = vmForBytecodeCache();
 
@@ -242,11 +288,12 @@ extern "C" bool generateCachedModuleByteCodeFromSourceCode(const BunString* sour
     return true;
 }
 
-extern "C" bool generateCachedCommonJSProgramByteCodeFromSourceCode(const BunString* sourceProviderURL, const Latin1Character* inputSourceCode, size_t inputSourceCodeSize, uint32_t depth, const uint8_t** outputByteCode, size_t* outputByteCodeSize, JSC::CachedBytecode** cachedBytecodePtr, JSC::EncoderStringTable* externalStrings)
+extern "C" bool generateCachedCommonJSProgramByteCodeFromSourceCode(const BunString* sourceProviderURL, const uint8_t* inputSourceCode, size_t inputSourceCodeSize, uint8_t inputEncoding, uint32_t depth, const uint8_t** outputByteCode, size_t* outputByteCodeSize, JSC::CachedBytecode** cachedBytecodePtr, JSC::EncoderStringTable* externalStrings)
 {
-    std::span<const Latin1Character> sourceCodeSpan(inputSourceCode, inputSourceCodeSize);
-
-    JSC::SourceCode sourceCode = JSC::makeSource(WTF::String(sourceCodeSpan), toSourceOrigin(sourceProviderURL->toWTFString(), false), JSC::SourceTaintedOrigin::Untainted);
+    WTF::String source = sourceCodeStringForBytecode(inputSourceCode, inputSourceCodeSize, static_cast<BytecodeSourceEncoding>(inputEncoding));
+    if (source.isNull())
+        return false;
+    JSC::SourceCode sourceCode = JSC::makeSource(WTF::move(source), toSourceOrigin(sourceProviderURL->toWTFString(), false), JSC::SourceTaintedOrigin::Untainted);
     JSC::VM& vm = vmForBytecodeCache();
 
     JSC::JSLockHolder locker(vm);

--- a/src/runtime/api/standalone_graph_jsc.rs
+++ b/src/runtime/api/standalone_graph_jsc.rs
@@ -18,12 +18,17 @@ use bun_standalone_graph::File;
 /// type and a shared `name`. `global_this` is null; `file_blob` stamps it per VM.
 fn template_blob(file: &File) -> NonNull<bun_standalone_graph::StandaloneModuleGraph::Blob> {
     *file.cached_blob.get_or_init(|| {
-        // `contents` is a `'static` slice into the embedded executable
-        // section — borrow it directly (no copy) and hand it to a `Bytes`
-        // store with the default allocator. The leaked extra `ref_()` below
-        // pins the refcount ≥ 1 forever, so `Store::deref` never runs and
-        // the (otherwise UB) free of a static slice is unreachable.
-        let contents = file.contents.as_bytes();
+        // UTF-8 view of the contents: a `'static` borrow of the embedded
+        // section for most files, or — for module text stored Latin-1 /
+        // UTF-16 — a one-time materialized copy, leaked because this Blob
+        // template is cached for the process lifetime anyway. The leaked
+        // extra ref below pins the refcount ≥ 1 forever, so `Store::deref`
+        // never runs and the (otherwise UB) free of a static slice is
+        // unreachable.
+        let contents: &'static [u8] = match file.utf8_contents() {
+            std::borrow::Cow::Borrowed(bytes) => bytes,
+            std::borrow::Cow::Owned(utf8) => Box::leak(utf8.into_boxed_slice()),
+        };
         // SAFETY: `contents` is `'static` and never freed (see above);
         // the const-cast is sound because Blob consumers only read via
         // `shared_view()`.

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -6903,7 +6903,10 @@ impl NodeFS {
 
                 if let Some(graph) = standalone_module_graph() {
                     if let Some(file) = graph.find_ref(path.as_bytes()) {
-                        let contents: &[u8] = file.contents.as_bytes();
+                        // UTF-8 regardless of the stored width, so reads
+                        // round-trip the original source bytes.
+                        let contents = file.utf8_contents();
+                        let contents: &[u8] = &contents;
                         return if args.encoding == Encoding::Buffer {
                             // PORTING.md §Forbidden bans `Vec::leak()`; round-trip through
                             // `into_boxed_slice()` so the allocation layout JSC frees with

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -591,7 +591,19 @@ impl File {
 
     pub fn stat(&self) -> Stat {
         let mut result: Stat = bun_core::ffi::zeroed();
-        result.st_size = self.contents.len() as _;
+        // Size of the bytes a read returns (`utf8_contents`), not of the
+        // stored width.
+        result.st_size = if self.loader.is_javascript_like() {
+            match self.encoding {
+                Encoding::Binary => self.contents.len(),
+                Encoding::Latin1 => {
+                    strings::element_length_latin1_into_utf8(self.contents.as_bytes())
+                }
+                Encoding::Utf16 => strings::element_length_utf16_into_utf8(self.utf16_units()),
+            }
+        } else {
+            self.contents.len()
+        } as _;
         // `Stat` is `libc::stat` (POSIX) / `uv_stat_t` (Windows, `st_mode: u64`).
         result.st_mode = (libc::S_IFREG | 0o644) as _;
         result
@@ -625,27 +637,50 @@ impl File {
                         BunString::create_static_external(self.contents.as_bytes(), true)
                     }
                     Encoding::Utf16 => {
-                        let bytes = self.contents.as_bytes();
-                        debug_assert!(bytes.as_ptr().addr().is_multiple_of(align_of::<u16>()));
-                        #[expect(
-                            clippy::cast_ptr_alignment,
-                            reason = "`to_bytes` writes UTF-16 at an even offset and the section base is page-aligned (the 128-byte bytecode alignment relies on the same property)"
-                        )]
-                        // SAFETY: even byte count at a 2-byte-aligned offset of a
-                        // section that is never freed.
-                        let units = unsafe {
-                            core::slice::from_raw_parts(
-                                bytes.as_ptr().cast::<u16>(),
-                                bytes.len() / 2,
-                            )
-                        };
-                        BunString::create_static_external_utf16(units)
+                        BunString::create_static_external_utf16(self.utf16_units())
                     }
                 };
                 s.make_thread_shareable();
                 s
             })
             .clone()
+
+    /// `Utf16` contents viewed as code units.
+    fn utf16_units(&self) -> &'static [u16] {
+        debug_assert!(self.encoding == Encoding::Utf16);
+        let bytes = self.contents.as_bytes();
+        debug_assert!(bytes.len().is_multiple_of(2));
+        debug_assert!(bytes.as_ptr().addr().is_multiple_of(2));
+        #[expect(
+            clippy::cast_ptr_alignment,
+            reason = "`to_bytes` writes UTF-16 at an even offset and the section base is page-aligned (the 128-byte bytecode alignment relies on the same property)"
+        )]
+        // SAFETY: `to_bytes` serializes `Utf16` contents as u16 code units at
+        // a 2-byte-aligned offset of a section that is never freed.
+        unsafe { core::slice::from_raw_parts(bytes.as_ptr().cast::<u16>(), bytes.len() / 2) }
+    }
+
+    /// The bytes a filesystem read of this file returns. JS module text is
+    /// stored in the width JSC loads it in, and a transcoded module
+    /// materializes a UTF-8 copy here so `fs.readFileSync` / `Bun.file()` on
+    /// its bunfs path round-trip the original source bytes. Every other file
+    /// (assets, and text modules whose pre-encoded string body is pinned by
+    /// `compile/TextImport`) reads back verbatim.
+    pub fn utf8_contents(&self) -> std::borrow::Cow<'static, [u8]> {
+        use std::borrow::Cow;
+        let bytes = self.contents.as_bytes();
+        if !self.loader.is_javascript_like() {
+            return Cow::Borrowed(bytes);
+        }
+        match self.encoding {
+            Encoding::Binary => Cow::Borrowed(bytes),
+            Encoding::Latin1 => match strings::to_utf8_from_latin1(bytes) {
+                Some(utf8) => Cow::Owned(utf8),
+                None => Cow::Borrowed(bytes),
+            },
+            Encoding::Utf16 => Cow::Owned(strings::to_utf8_alloc(self.utf16_units())),
+        }
+    }
     }
 }
 
@@ -1122,6 +1157,20 @@ fn module_dest_path(output_file: &OutputFile) -> std::borrow::Cow<'_, [u8]> {
     }
 }
 
+/// Server-side JS modules are stored in the width JSC will load them in
+/// (Latin-1 or UTF-16) so the runtime can wrap the mmapped section bytes in a
+/// zero-copy external string instead of transcoding the whole module into a
+/// 16-bit heap copy at startup. The printer escapes non-ASCII in server JS,
+/// but `--banner`/`--footer`/hashbang text is concatenated verbatim as UTF-8.
+/// Client chunks and non-JS files are served as raw bytes (assets,
+/// `Bun.embeddedFiles`) and must stay verbatim UTF-8. Bytecode generation in
+/// `generateChunksInParallel.rs` mirrors this conversion; the two must agree
+/// or the SourceCodeKey won't match at runtime.
+fn stores_transcoded_contents(output_file: &OutputFile) -> bool {
+    output_file.loader.is_javascript_like()
+        && output_file.side.unwrap_or(options::Side::Server) == options::Side::Server
+}
+
 pub(crate) fn to_bytes(
     prefix: &[u8],
     output_files: &[OutputFile],
@@ -1162,7 +1211,10 @@ pub(crate) fn to_bytes(
                 has_entry_point |= is_entry_point(output_file);
 
                 string_builder.count_z(bytes);
-                if is_text_module_output(output_file) {
+                if is_text_module_output(output_file)
+                    || (stores_transcoded_contents(output_file)
+                        && strings::first_non_ascii(bytes).is_some())
+                {
                     // UTF-16 worst case: 2 bytes per byte, padding, 2-byte NUL.
                     string_builder.cap += bytes.len() + 3;
                 }
@@ -1329,19 +1381,9 @@ pub(crate) fn to_bytes(
             name: StringPointer::default(),
             loader: output_file.loader,
             contents: StringPointer::default(),
-            // Latin1 lets the runtime wrap the mmapped section bytes in a
-            // zero-copy ExternalStringImpl. The printer escapes non-ASCII for
-            // server-side JS, but `--banner`/`--footer`/hashbang and
-            // client-side (target=browser) chunks are concatenated verbatim
-            // as UTF-8, so verify the final bytes before committing to Latin1.
-            encoding: match output_file.loader {
-                Loader::Js | Loader::Jsx | Loader::Ts | Loader::Tsx
-                    if strings::first_non_ascii(buf_bytes).is_none() =>
-                {
-                    Encoding::Latin1
-                }
-                _ => Encoding::Binary,
-            },
+            // Placeholder; the width is decided when the contiguous
+            // source-text run is written below.
+            encoding: Encoding::Binary,
             module_format: if output_file.loader.is_javascript_like() {
                 match output_format {
                     Format::Cjs => ModuleFormat::Cjs,
@@ -1390,12 +1432,41 @@ pub(crate) fn to_bytes(
     }
 
     for (module, output_file) in modules.iter_mut().zip(&module_files) {
+        let buf_bytes = output_file.value.as_slice();
         if is_text_module_output(output_file) {
-            (module.contents, module.encoding) =
-                encode_text_module(&mut string_builder, output_file.value.as_slice());
-        } else {
-            module.contents = string_builder.append_count_z(output_file.value.as_slice());
+            (module.contents, module.encoding) = encode_text_module(&mut string_builder, buf_bytes);
+            continue;
         }
+        // Store JS text in the width JSC loads it in; see
+        // `stores_transcoded_contents` for why and for what must stay UTF-8.
+        let (contents, encoding) = if output_file.loader.is_javascript_like()
+            && strings::first_non_ascii(buf_bytes).is_none()
+        {
+            (string_builder.append_count_z(buf_bytes), Encoding::Latin1)
+        } else if stores_transcoded_contents(output_file) {
+            match strings::to_wtf_units_alloc(buf_bytes).map_err(|_| bun_alloc::AllocError)? {
+                Some(units) => {
+                    if units.is_utf16() && !string_builder.len.is_multiple_of(2) {
+                        // UTF-16 code units must land at an even offset; the
+                        // section base is even on every platform.
+                        string_builder.writable()[0] = 0;
+                        string_builder.len += 1;
+                    }
+                    let encoding = if units.is_utf16() {
+                        Encoding::Utf16
+                    } else {
+                        Encoding::Latin1
+                    };
+                    (string_builder.append_count_z(units.as_bytes()), encoding)
+                }
+                // Pure ASCII (unreachable here): Latin-1 as-is.
+                None => (string_builder.append_count_z(buf_bytes), Encoding::Latin1),
+            }
+        } else {
+            (string_builder.append_count_z(buf_bytes), Encoding::Binary)
+        };
+        module.contents = contents;
+        module.encoding = encoding;
     }
 
     for (module, output_file) in modules.iter_mut().zip(&module_files) {
@@ -1421,12 +1492,16 @@ pub(crate) fn to_bytes(
         )
     };
     // `Flags::HAS_SOURCE_HASHES`: the hash JSC's SourceCodeKey wants, so a launch that runs from bytecode never reads the
-    // source text just to hash it. Only for Latin-1 contents, which are handed to JSC as-is.
+    // source text just to hash it. Only for Latin-1 contents, which are handed
+    // to JSC as-is; hash the stored body, which differs from the UTF-8 input
+    // for a transcoded module.
     let mut source_hashes: Vec<u8> = Vec::with_capacity(modules.len() * size_of::<u32>());
     for (module, output_file) in modules.iter().zip(&module_files) {
         let hash = if module.encoding == Encoding::Latin1 && output_file.loader.is_javascript_like()
         {
-            wtf_latin1_string_hash(output_file.value.as_slice())
+            let contents = &string_builder.written_slice()[module.contents.offset as usize..]
+                [..module.contents.length as usize];
+            wtf_latin1_string_hash(contents)
         } else {
             0
         };

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -644,6 +644,7 @@ impl File {
                 s
             })
             .clone()
+    }
 
     /// `Utf16` contents viewed as code units.
     fn utf16_units(&self) -> &'static [u16] {
@@ -680,7 +681,6 @@ impl File {
             },
             Encoding::Utf16 => Cow::Owned(strings::to_utf8_alloc(self.utf16_units())),
         }
-    }
     }
 }
 

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -636,9 +636,7 @@ impl File {
                     Encoding::Latin1 => {
                         BunString::create_static_external(self.contents.as_bytes(), true)
                     }
-                    Encoding::Utf16 => {
-                        BunString::create_static_external_utf16(self.utf16_units())
-                    }
+                    Encoding::Utf16 => BunString::create_static_external_utf16(self.utf16_units()),
                 };
                 s.make_thread_shareable();
                 s
@@ -658,7 +656,9 @@ impl File {
         )]
         // SAFETY: `to_bytes` serializes `Utf16` contents as u16 code units at
         // a 2-byte-aligned offset of a section that is never freed.
-        unsafe { core::slice::from_raw_parts(bytes.as_ptr().cast::<u16>(), bytes.len() / 2) }
+        unsafe {
+            core::slice::from_raw_parts(bytes.as_ptr().cast::<u16>(), bytes.len() / 2)
+        }
     }
 
     /// The bytes a filesystem read of this file returns. JS module text is

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -857,3 +857,118 @@ describe("compiled binary in a deleted cwd", () => {
 });
 
 // file command test works well
+
+// A compiled executable stores server-side JS modules in the width JSC loads
+// them in (Latin-1 or UTF-16) so the runtime wraps the mmapped bytes zero-copy
+// instead of transcoding the module into a 16-bit heap string at startup.
+// Function.prototype.toString() returns a substring of the module source, so
+// bun:jsc's jscDescribe exposes the width the source was loaded in.
+describe("compile module source text width", () => {
+  const mainJs = `function probeFn() { return 1 + 1; }
+const desc = require("bun:jsc").jscDescribe(probeFn.toString());
+console.log("width", desc.includes("8Bit:(1)") ? "8bit" : "16bit");
+console.log("value", "café 😀");
+`;
+
+  async function buildAndRun(extraArgs: string[], runEnv: Record<string, string> = {}, source: string = mainJs) {
+    using dir = tempDir("compile-text-width", { "main.js": source });
+    await using build = Bun.spawn({
+      cmd: [bunExe(), "build", "--compile", ...extraArgs, "main.js", "--outfile", "app"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [, buildStderr, buildExit] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+    expect(buildStderr).not.toContain("error:");
+    expect(buildExit).toBe(0);
+
+    await using proc = Bun.spawn({
+      cmd: [join(String(dir), isWindows ? "app.exe" : "app")],
+      env: { ...bunEnv, ...runEnv },
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    return await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  }
+
+  test("pure ASCII module text stays 8-bit", async () => {
+    const [stdout, , exitCode] = await buildAndRun([]);
+    expect(stdout).toBe("width 8bit\nvalue café 😀\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("Latin-1-range banner keeps module text 8-bit", async () => {
+    const [stdout, , exitCode] = await buildAndRun(["--banner", "// café ünïcödé"]);
+    expect(stdout).toBe("width 8bit\nvalue café 😀\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("module text above U+00FF loads as 16-bit", async () => {
+    const [stdout, , exitCode] = await buildAndRun(["--banner", "// 😀 emoji"]);
+    expect(stdout).toBe("width 16bit\nvalue café 😀\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("bytecode cache hits with a non-ASCII banner", async () => {
+    const [stdout, stderr, exitCode] = await buildAndRun(["--bytecode", "--banner", "// café"], {
+      BUN_JSC_verboseDiskCache: "1",
+    });
+    expect(stdout).toContain("width 8bit");
+    expect(stdout + stderr).toContain("Cache hit for sourceCode");
+    expect(exitCode).toBe(0);
+  });
+
+  test("bytecode cache hits with UTF-16 source", async () => {
+    const [stdout, stderr, exitCode] = await buildAndRun(["--bytecode", "--banner", "// 😀 emoji"], {
+      BUN_JSC_verboseDiskCache: "1",
+    });
+    expect(stdout).toContain("width 16bit");
+    expect(stdout + stderr).toContain("Cache hit for sourceCode");
+    expect(exitCode).toBe(0);
+  });
+
+  // Whatever width the module text is stored in, reading its bunfs path
+  // through fs or Bun.file must still return the original UTF-8 bytes.
+  const roundTripJs = (banner: string) => `import { readFileSync, statSync } from "node:fs";
+const text = readFileSync(import.meta.path, "utf8");
+const blob = await Bun.file(import.meta.path).text();
+console.log("banner", text.includes(${JSON.stringify(banner)}) ? "intact" : "mangled");
+console.log("blob", blob === text ? "same" : "different");
+console.log("size", statSync(import.meta.path).size === Buffer.byteLength(text, "utf8") ? "matches" : "differs");
+`;
+
+  test.each([
+    ["Latin-1", "// café banner"],
+    ["UTF-16", "// café 😀 banner"],
+  ])("fs reads of the module's bunfs path round-trip the source (%s)", async (_width, banner) => {
+    const [stdout, , exitCode] = await buildAndRun(["--banner", banner], {}, roundTripJs(banner));
+    expect(stdout).toBe("banner intact\nblob same\nsize matches\n");
+    expect(exitCode).toBe(0);
+  });
+
+  // Not --compile: the on-disk .jsc sidecar's key is computed from the raw
+  // bytes read as Latin-1, matching the loader's already_bundled path.
+  test("on-disk .jsc bytecode cache hits with a non-ASCII banner", async () => {
+    using dir = tempDir("jsc-sidecar-nonascii", { "main.js": `console.log("ok");` });
+    await using build = Bun.spawn({
+      cmd: [bunExe(), "build", "--bytecode", "--target=bun", "--banner", "// café", "main.js", "--outdir", "out"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [, buildStderr, buildExit] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+    expect(buildStderr).not.toContain("error:");
+    expect(buildExit).toBe(0);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join("out", "main.js")],
+      env: { ...bunEnv, BUN_JSC_verboseDiskCache: "1" },
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toContain("ok");
+    expect(stdout + stderr).toContain("Cache hit for sourceCode");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
Fixes #38771

Found by inspection during review of #33866 (no user report); filed as #38771 and landed first to de-risk that PR, which makes non-ASCII module text much more common. The FFI surface here uses the same three-valued `BytecodeSourceEncoding` shape as #33866 so its later rebase is additive.

### Problem

- In a `bun build --compile` executable, a JS module is only wrapped as a zero-copy 8-bit external string over the mmapped section when its bundled text is pure ASCII (`Encoding::Latin1` in `StandaloneModuleGraph.rs:to_bytes`).
- Any non-ASCII byte (a `--banner`/`--footer`, a hashbang, a preserved `/*! */` comment) falls to `Encoding::Binary`, and `File::to_wtf_string` transcodes the whole module into a 16-bit heap string at startup via `clone_utf8` while the mmapped bytes stay resident: about 3 bytes of RSS per source byte instead of 1. Measured: a single non-ASCII banner on a 19MB module costs ~40MB of extra RSS.
- The same condition silently disables `--bytecode` for the module: bytecode was generated from the UTF-8 bytes misread as Latin-1 (the generators took a `Latin1Character*` span), so the SourceCodeKey never matches the UTF-16 runtime string and every load is a cache miss. Observable with `BUN_JSC_verboseDiskCache=1`: `[Disk Cache] Cache miss for sourceCode`.

### Fix

- At build time, server-side JS modules that contain non-ASCII text are converted once to the width JSC will load them in (`strings::to_wtf_units_alloc`, new in `bun_core`): Latin-1 bytes when every code point is <= U+00FF, otherwise UTF-16 code units written at a 2-byte-aligned offset. The per-file `Encoding` tag records the width (`Utf16` replaces the never-written `Utf8 = 2` variant).
- At runtime, `File::to_wtf_string` wraps the section bytes in an 8-bit or 16-bit static external string (`create_static_external_utf16`, new in `bun_core`) instead of transcoding. Alignment holds on every platform: the section payload starts 8 bytes past an aligned base, which the existing 128-byte bytecode alignment in the same section already relies on.
- The bytecode generator FFI takes a `BytecodeSourceEncoding` (`Utf8` / `Latin1` / `Utf16`, the shape #33866 introduces) instead of assuming Latin-1, and each encoding is decoded exactly the way the corresponding load path decodes it. The compile path passes the stored width so the SourceCodeKey matches and the cache hits; the on-disk `.jsc` path and the node compile cache keep their Latin-1 interpretation, matching the `already_bundled` loader's `clone_latin1` readback (pinned by a new sidecar cache-hit test).
- `fs.readFileSync`, `Bun.file()` and `fs.stat` on a module's bunfs path go through a new `File::utf8_contents()` view, so reads round-trip the original UTF-8 source bytes regardless of the stored width. `Binary` and pure-ASCII files keep the zero-copy borrow; a transcoded module materializes the UTF-8 copy lazily (once per file for `Bun.file`, whose Blob is process-cached).
- Client (browser) chunks and non-JS files keep `Encoding::Binary`: they are served as raw bytes (assets, `Bun.embeddedFiles`) and must stay verbatim UTF-8.

Verified (`test/bundler/bun-build-compile.test.ts`, new `compile module source text width` block):

- `Function.prototype.toString` returns a substring of the module source, so `bun:jsc`'s `jscDescribe` exposes the loaded width deterministically. A Latin-1-range banner must give an 8-bit source (fails on current main: 16-bit), plus 8-bit ASCII and 16-bit emoji guards.
- `--bytecode` with a non-ASCII banner must log `Cache hit for sourceCode` (fails on current main: miss), for both the Latin-1 and the UTF-16 stored form.
- A non-compile `bun build --bytecode --outdir` sidecar still logs `Cache hit for sourceCode` with a non-ASCII banner.
- `readFileSync(import.meta.path, "utf8")`, `Bun.file().text()` and `statSync().size` round-trip the original source for Latin-1-range and emoji banners.
- Full runs of `bun-build-compile.test.ts`, `bundler_compile.test.ts` (the one failure, `HelloWorldWithProcessVersionsBun`, is a pre-existing debug-build version-string mismatch), `bundler_banner`, `bundler_bun` (bytecode), `compile-asset-bunfs`, both compile sourcemap suites, splitting/autoload/wasm suites, and the node compile-cache tests.
- RSS spot check with the debug build: ascii / Latin-1-banner / emoji-banner builds of a 7MB module now sit within noise of each other; on current main the non-ASCII builds sit ~25-40MB above the ascii one (release numbers in the issue).

### Notes

- Rebase note: successive rebases folded this PR onto main's #40177 (text-import `Utf16` machinery), #39912 (contiguous `to_bytes` layout), #40201 (bytecode aliasing, string tables, precomputed `source_hash`), #40417 (`--bytecode-depth`), and #40436 (thread-shareable blob templates and `to_wtf_string`, which absorbed the external-string wrapping arms). What remains unique here: the build-time JS-module transcode and its `Encoding` tags, the `BytecodeSourceEncoding` contract at every generator call site, the `source_hash` over the stored body, and the fs/Blob/stat UTF-8 round-trip. Main's #40201 precomputes each Latin-1 module's WTF string hash into the graph (`source_hash`); it is now computed over the stored Latin-1 body, which differs from the UTF-8 input for a transcoded module. Main's contiguous-layout rework of `to_bytes` (#39912) moved contents into a dedicated source-text pass; the width decision now runs there. Main's #40177 independently added `Encoding::Utf16`, `create_static_external_utf16`, and `encode_text_module` for text imports; this PR now reuses that machinery (same enum, same helper, shared capacity slack) and adds the JS-module tier on top: Latin-1 storage for text whose code points fit one byte, and the bytecode-key/fs-round-trip handling.

- Cross-compiling with a version-pinned `--target` against an older runtime maps the `Utf16` tag to that runtime's never-written `Utf8` arm, which falls back to a plain copy (wrong text, no crash). The section format already changes between versions without a compatibility gate, and value 2 is the only choice an old runtime handles defensively.

### Background

- A compiled executable embeds a "standalone module graph" section: every bundled module's name, text, sourcemap and optional JSC bytecode, serialized by `to_bytes` and parsed back at startup from the mmapped section. Module text handed to JSC without a copy must be wrapped in a `WTF::ExternalStringImpl`, which points at caller-owned memory.
- WTF strings (JSC's string representation) store text either as 8-bit Latin-1 or 16-bit UTF-16 code units, never UTF-8. Handing JSC UTF-8 therefore always forces a transcode-and-copy; handing it the exact width it stores is what makes zero-copy possible.
- `--bytecode` embeds precompiled JSC bytecode next to the module. JSC only trusts it if the SourceCodeKey (derived from the source string's code units) computed at build time matches the one computed at load time, so the generator input and the runtime string must be code-unit-identical; on mismatch it falls back to parsing, silently.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 13 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bun-build-compile.test.ts

<!-- robobun:evidence:end -->



