### PR TITLE
install: fix yarn.lock migration panic on tarball URLs with "/-/" right after the host

### DIFF
--- a/src/install/yarn.rs
+++ b/src/install/yarn.rs
@@ -159,6 +159,18 @@ impl<'a> Entry<'a> {
         strings::without_trailing_slash(path)
     }
 
+    /// `https://registry.npmjs.org/@scope/name/-/name-1.0.0.tgz` -> `@scope/name`
+    pub(crate) fn get_package_name_from_default_registry_url(url: &[u8]) -> Option<&[u8]> {
+        let host_and_path = url
+            .strip_prefix(b"https://")
+            .or_else(|| url.strip_prefix(b"http://"))?;
+        let path = host_and_path
+            .strip_prefix(b"registry.npmjs.org/")
+            .or_else(|| host_and_path.strip_prefix(b"registry.yarnpkg.com/"))?;
+        let name = &path[..strings::index_of(path, b"/-/")?];
+        (!name.is_empty()).then_some(name)
+    }
+
     pub(crate) fn parse_git_url(
         _yarn_lock: &YarnLock<'a>,
         version: &'a [u8],
@@ -947,23 +959,10 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
                     || Entry::is_remote_tarball(resolved)
                     || resolved.ends_with(b".tgz")
                 {
-                    // https://registry.npmjs.org/package/-/package-version.tgz
-                    if strings::index_of(resolved, b"registry.npmjs.org/").is_some()
-                        || strings::index_of(resolved, b"registry.yarnpkg.com/").is_some()
+                    if let Some(name) = Entry::get_package_name_from_default_registry_url(resolved)
                     {
-                        if let Some(separator_idx) = strings::index_of(resolved, b"/-/") {
-                            if let Some(registry_idx) = strings::index_of(resolved, b"registry.") {
-                                let after_registry = &resolved[registry_idx..];
-                                if let Some(domain_slash) = strings::index_of(after_registry, b"/")
-                                {
-                                    let package_start = registry_idx + domain_slash + 1;
-                                    let extracted_name = &resolved[package_start..separator_idx];
-                                    break 'blk extracted_name;
-                                }
-                            }
-                        }
+                        break 'blk name;
                     }
-                    break 'blk base_name;
                 }
             }
             break 'blk base_name;

--- a/test/cli/install/migration/yarn-lock-migration.test.ts
+++ b/test/cli/install/migration/yarn-lock-migration.test.ts
@@ -903,6 +903,74 @@ needs-node-types@1.0.0:
     expect([...requestedManifests].sort()).toStrictEqual(["@types/node", "needs-node-types"]);
   });
 
+  test("package names are only read from the path of default registry tarball URLs", async () => {
+    // Dependencies declared as tarball URLs. A tarball on registry.npmjs.org / registry.yarnpkg.com
+    // is named after the path segment(s) before "/-/"; every other URL keeps the dependency's name.
+    const tarballs = {
+      "host-after-separator": "https://evil.example/-/registry.npmjs.org/x.tgz",
+      "nothing-before-separator": "https://registry.npmjs.org/-/y.tgz",
+      "empty-segment-before-separator": "https://registry.npmjs.org//-/z.tgz",
+      "mirror-with-registry-in-path": "https://registry.mirror.example/registry.npmjs.org/other/-/other-1.0.0.tgz",
+      "dash-package": "https://registry.npmjs.org/-/-/--0.0.1.tgz",
+      "scoped-npmjs-https": "https://registry.npmjs.org/@scope/real/-/real-1.0.0.tgz",
+      "npmjs-http": "http://registry.npmjs.org/real-a/-/real-a-1.0.0.tgz",
+      "yarnpkg-https": "https://registry.yarnpkg.com/real-b/-/real-b-1.0.0.tgz",
+      "yarnpkg-http": "http://registry.yarnpkg.com/real-c/-/real-c-1.0.0.tgz",
+    };
+
+    await using tmpDir = tempDir("yarn-migration-tarball-names", {
+      "package.json": JSON.stringify({ name: "tarball-names-test", version: "1.0.0", dependencies: tarballs }, null, 2),
+      "yarn.lock":
+        "# yarn lockfile v1\n\n\n" +
+        Object.entries(tarballs)
+          .map(([name, url]) => `"${name}@${url}":\n  version "1.0.0"\n  resolved "${url}"\n`)
+          .join("\n"),
+    });
+
+    // Every entry is a tarball package, so the migration has no registry manifests to fetch.
+    const registryRequests: string[] = [];
+    await using registry = Bun.serve({
+      port: 0,
+      fetch(req) {
+        registryRequests.push(new URL(req.url).pathname);
+        return new Response("not found", { status: 404 });
+      },
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "pm", "migrate", "-f"],
+      cwd: tmpDir,
+      env: {
+        ...bunEnv,
+        BUN_CONFIG_REGISTRY: registry.url.href,
+        BUN_INSTALL_CACHE_DIR: join(tmpDir, ".bun-cache"),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(exitCode, stdout + stderr).toBe(0);
+
+    const lock = Bun.JSONC.parse(await Bun.file(join(tmpDir, "bun.lock")).text()) as { packages: unknown };
+    expect(lock.packages).toStrictEqual({
+      "host-after-separator": [`host-after-separator@${tarballs["host-after-separator"]}`, {}],
+      "nothing-before-separator": [`nothing-before-separator@${tarballs["nothing-before-separator"]}`, {}],
+      "empty-segment-before-separator": [
+        `empty-segment-before-separator@${tarballs["empty-segment-before-separator"]}`,
+        {},
+      ],
+      "mirror-with-registry-in-path": [`mirror-with-registry-in-path@${tarballs["mirror-with-registry-in-path"]}`, {}],
+      "dash-package": [`-@${tarballs["dash-package"]}`, {}],
+      "scoped-npmjs-https": [`@scope/real@${tarballs["scoped-npmjs-https"]}`, {}],
+      "npmjs-http": [`real-a@${tarballs["npmjs-http"]}`, {}],
+      "yarnpkg-https": [`real-b@${tarballs["yarnpkg-https"]}`, {}],
+      "yarnpkg-http": [`real-c@${tarballs["yarnpkg-http"]}`, {}],
+    });
+    expect(registryRequests).toStrictEqual([]);
+  });
+
   test("yarn.lock with resolutions", async () => {
     await using tmpDir = tempDir("yarn-migration-resolutions", {
       "package.json": JSON.stringify(


### PR DESCRIPTION
### Problem
- `bun install` / `bun pm migrate` in a project whose `yarn.lock` has a tarball entry such as `"x@https://evil.example/-/registry.npmjs.org/x.tgz"` aborts instead of migrating or returning a migration error the way other bad lockfile input does (`src/install/migration.rs:79-88`):
  `panic: slice index starts at 42 but ends at 20` (top frame `bun_install::yarn::migrate_yarn_lockfile`). Reproduces on the released canary (b7a043103) and on main.
- Cause: the `name_to_use` block in `migrate_yarn_lockfile` (`src/install/yarn.rs:942-970` on main) names a tarball package after its URL by running two unrelated substring searches over `resolved`, `"/-/"` and `"registry."`, and slicing between them. It assumes the host comes first; the only guard is that `registry.npmjs.org/` or `registry.yarnpkg.com/` occurs somewhere in the URL.
- The same slice panics (`27..26`) whenever `/-/` directly follows the registry host. The one real package this applies to is the npm package named `-` (tarball `https://registry.npmjs.org/-/-/--0.0.1.tgz`) declared as a URL dependency; every other shape needs a hand-edited `yarn.lock`, which `bun install` still has to survive. No issue reports this; it was found by reading the code.
- Same code, no crash: `https://registry.npmjs.org//-/z.tgz` is written to `bun.lock` with an empty package name (`"@https://..."`), and a mirror whose hostname starts with `registry.` (`https://registry.mirror.example/registry.npmjs.org/other/-/...`) gets the name `registry.npmjs.org/other`, because `"registry."` matched the mirror's hostname.

### Fix
- Adds `Entry::get_package_name_from_default_registry_url`: strip `https://` or `http://`, require `registry.npmjs.org/` or `registry.yarnpkg.com/` as the prefix of what remains, take the path up to the first `/-/`, and return `None` for an empty name or anything else. The `name_to_use` block calls it in place of the arithmetic and otherwise falls back to the spec name, as off-registry tarballs always did. Net 14 lines in `yarn.rs`; nothing else in the migrator changes.
- Why this is correct: every index is taken from one left-to-right parse of the URL, so the slice bounds are ordered by construction and nothing is left to panic on. For the two default registries the layout is exactly `<host>/<name>/-/...` (with `<name>` possibly `@scope/name`), so the names produced for real URLs are the ones the old code produced (the `remote` entry of the `yarn-stuff` fixture is such a URL and its snapshot is unchanged), plus `-` for the `-` package. Tarballs on any other host were already named after the spec; anchoring the host check on the prefix makes the `registry.`-prefixed mirror behave like every other mirror.
- Verified:
  - `test/cli/install/migration/yarn-lock-migration.test.ts`, "package names are only read from the path of default registry tarball URLs": one `bun pm migrate` over nine URL dependencies (both panicking shapes, the `-` package, the empty segment, the mirror, and the scheme/host combinations whose names are still extracted), asserting the full `packages` object of the resulting `bun.lock` and that the loopback registry saw no requests. With main's `yarn.rs` it dies with the panic above; each row was also run on its own against main (the `/-/`-after-host rows and the `-` package panic, `//-/` writes an empty name, the mirror writes `registry.npmjs.org/other`, the remaining rows already produced the asserted names). Passes with this change.
  - The rest of the file passes with the debug build, all 14 snapshots unchanged (`yarn-cli-repo` needs `--timeout` on a loaded machine, the pre-existing debug-build timing in #35377); `lockfile-only.test.ts` and the yarn cases in `nested-overrides.test.ts` and `migrate.test.ts` pass.
- Relation to the other open yarn migration PRs (checked with `git merge-tree` against both branches):
  - #38948 (alias names from the spec) touches neither this block nor the new helper; the two merge cleanly in either order.
  - #38795 (`#sha1` suffix) rewrites this block too but keeps the slice arithmetic, so it does not fix the crash, and the two conflict in this one block. This PR is the smaller change and the only one removing a panic, so it should go first; #38795 then keeps its narrower condition around the one-line helper call. If #38795 lands first, this PR is rebased to that narrower condition; the helper and the test are unaffected either way, since every test row is a URL dependency.
- Left alone: the `is_default_registry` check in the resolution block decides how the URL is stored (and accepts `https://` only); sharing one predicate between it and the naming helper would change one of the two behaviors, and #38795 is editing that block.

### Background
- yarn v1 lockfile entries are keyed by their specs (`name@range`, or `name@https://...` for a dependency declared as a URL) and carry a `resolved` tarball URL. The migrator creates one bun lockfile package per entry and has to pick its name without downloading anything: normally from the spec, and for tarballs on the default registries from the URL, so that a dependency declared under one name but pointing at another package's registry tarball is recorded under the package's real name.
- Registry tarball URLs have the fixed shape `<registry>/<name>/-/<basename>-<version>.tgz`, where `<name>` is one segment or `@scope/name`. `/-/` separates the name from the file, which is why the path before it is a usable name on a known registry, and why the package literally named `-` is the one real package whose URL has `/-/` directly after the host.
- `bun.lock` `packages` entries are `["<name>@<version or url>", ...]`; the name in that position is what `bun install` later works with, so an empty or hostname-shaped name there surfaces as a broken install rather than a migration error.

<details>
<summary>Earlier revisions of this PR</summary>

The first revision was this same helper. A review suggested folding the fix into `Entry::get_package_name_from_resolved_url` (the alias name parser) so that alias entries with the same URL shape would stop being named after the host; the second revision did that. #38948 has since been opened to name aliases from their specs and delete that parser entirely, which is the better fix for the alias side, so this PR went back to the self-contained tarball helper, which #38948 does not touch.
</details>
