### PR TITLE
bundler: keep the cwd tsconfig.json out of the per-file JSX base

### DIFF
--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -325,7 +325,8 @@ impl<'a> Transpiler<'a> {
                 from.options.for_worker(),
             )
         };
-        let resolver_opts = resolver_bundle_options_subset(&options);
+        let resolver_opts =
+            resolver_bundle_options_subset(&options, from.resolver.opts.jsx.clone());
         let log_nn = core::ptr::NonNull::new(log).expect("Transpiler::for_worker: log is non-null");
         // SAFETY: see fn doc — `Resolver::for_worker` widens
         // `standalone_module_graph` / `env_loader` lifetimes.
@@ -611,8 +612,13 @@ impl<'a> Transpiler<'a> {
     /// crate carries a FORWARD_DECL subset of `BundleOptions`, so re-project
     /// rather than `Clone`. Called after `init_transpiler_with_options` mutates
     /// `self.options` so the resolver sees the same conditions/target/public_path.
+    ///
+    /// `jsx` is kept, not re-projected: by now `configure_linker` /
+    /// `run_env_loader` have merged the cwd tsconfig.json into `options.jsx`
+    /// (see `resolver_bundle_options_subset`).
     pub fn sync_resolver_opts(&mut self) {
-        self.resolver.opts = resolver_bundle_options_subset(&self.options);
+        let jsx = core::mem::take(&mut self.resolver.opts.jsx);
+        self.resolver.opts = resolver_bundle_options_subset(&self.options, jsx);
     }
 
     /// Print the loaded environment variables to stdout as 2-space-indented
@@ -1048,6 +1054,11 @@ fn init_file_system(top_level_dir: Option<&'static [u8]>) -> crate::Result<*mut 
 /// `Box<[Box<[u8]>]>`/`StringSet`/`StringArrayHashMap` so this is a faithful
 /// value copy rather than a `Default` stub.
 ///
+/// `jsx` is not taken from `src`: `configure_linker` / `run_env_loader` merge
+/// the cwd tsconfig.json into `src.jsx`, while the resolver merges each file's
+/// own tsconfig over `opts.jsx`, so the base it gets must stay the user's
+/// configuration (`options.jsx` as built by `from_api`).
+///
 /// This projection can be dropped once `bun_options_types::BundleOptions` exists and both
 /// crates re-export it — `Resolver::init1` will then take the canonical type
 /// directly.
@@ -1061,6 +1072,7 @@ fn init_file_system(top_level_dir: Option<&'static [u8]>) -> crate::Result<*mut 
 #[inline(never)]
 fn resolver_bundle_options_subset(
     src: &options::BundleOptions<'_>,
+    jsx: crate::options_impl::jsx::Pragma,
 ) -> resolver::options::BundleOptions {
     use resolver::options as ropts;
 
@@ -1070,8 +1082,7 @@ fn resolver_bundle_options_subset(
             options::PackagesOption::External => ropts::Packages::External,
             options::PackagesOption::Bundle => ropts::Packages::Bundle,
         },
-        // D042: same nominal type on both sides.
-        jsx: src.jsx.clone(),
+        jsx,
         // Spec `options.ResolveFileExtensions` — clone all four owned slices so
         // the resolver honours user `--extension-order` and the per-target
         // `.node` augmentation `from_api` applied.
@@ -1274,7 +1285,8 @@ impl<'a> Transpiler<'a> {
         // crate's `options::BundleOptions<'a>`. Project the fields the resolver
         // reads; the rest stay at `Default` until MOVE_DOWN to
         // `bun_options_types` unifies the two (resolver/lib.rs:2773 note).
-        let resolver_opts = resolver_bundle_options_subset(&bundle_options);
+        let resolver_opts =
+            resolver_bundle_options_subset(&bundle_options, bundle_options.jsx.clone());
 
         let outbase = bundle_options.output_dir.clone();
         let resolve_results = Box::new(ResolveResults::default());

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -612,7 +612,7 @@ impl<'a> Transpiler<'a> {
     /// crate carries a FORWARD_DECL subset of `BundleOptions`, so re-project
     /// rather than `Clone`. Called after `init_transpiler_with_options` mutates
     /// `self.options` so the resolver sees the same conditions/target/public_path.
-    /// `jsx` is kept: see `resolver_bundle_options_subset`.
+    /// `jsx` is kept: see `bun_resolver::options::BundleOptions::jsx`.
     pub fn sync_resolver_opts(&mut self) {
         let jsx = core::mem::take(&mut self.resolver.opts.jsx);
         self.resolver.opts = resolver_bundle_options_subset(&self.options, jsx);
@@ -1050,8 +1050,6 @@ fn init_file_system(top_level_dir: Option<&'static [u8]>) -> crate::Result<*mut 
 /// `Box::leak`); the resolver-side FORWARD_DECL types were widened to owned
 /// `Box<[Box<[u8]>]>`/`StringSet`/`StringArrayHashMap` so this is a faithful
 /// value copy rather than a `Default` stub.
-///
-/// `jsx` is the base each file's own tsconfig is merged over; `src.jsx` has the cwd's merged in.
 ///
 /// This projection can be dropped once `bun_options_types::BundleOptions` exists and both
 /// crates re-export it — `Resolver::init1` will then take the canonical type

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -1051,8 +1051,7 @@ fn init_file_system(top_level_dir: Option<&'static [u8]>) -> crate::Result<*mut 
 /// `Box<[Box<[u8]>]>`/`StringSet`/`StringArrayHashMap` so this is a faithful
 /// value copy rather than a `Default` stub.
 ///
-/// `jsx` is a parameter because `src.jsx` has the cwd tsconfig merged in
-/// (`configure_linker`), and the resolver merges each file's own tsconfig over it.
+/// `jsx` is the base each file's own tsconfig is merged over; `src.jsx` has the cwd's merged in.
 ///
 /// This projection can be dropped once `bun_options_types::BundleOptions` exists and both
 /// crates re-export it — `Resolver::init1` will then take the canonical type

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -612,10 +612,7 @@ impl<'a> Transpiler<'a> {
     /// crate carries a FORWARD_DECL subset of `BundleOptions`, so re-project
     /// rather than `Clone`. Called after `init_transpiler_with_options` mutates
     /// `self.options` so the resolver sees the same conditions/target/public_path.
-    ///
-    /// `jsx` is kept, not re-projected: by now `configure_linker` /
-    /// `run_env_loader` have merged the cwd tsconfig.json into `options.jsx`
-    /// (see `resolver_bundle_options_subset`).
+    /// `jsx` is kept: see `resolver_bundle_options_subset`.
     pub fn sync_resolver_opts(&mut self) {
         let jsx = core::mem::take(&mut self.resolver.opts.jsx);
         self.resolver.opts = resolver_bundle_options_subset(&self.options, jsx);
@@ -1054,10 +1051,8 @@ fn init_file_system(top_level_dir: Option<&'static [u8]>) -> crate::Result<*mut 
 /// `Box<[Box<[u8]>]>`/`StringSet`/`StringArrayHashMap` so this is a faithful
 /// value copy rather than a `Default` stub.
 ///
-/// `jsx` is not taken from `src`: `configure_linker` / `run_env_loader` merge
-/// the cwd tsconfig.json into `src.jsx`, while the resolver merges each file's
-/// own tsconfig over `opts.jsx`, so the base it gets must stay the user's
-/// configuration (`options.jsx` as built by `from_api`).
+/// `jsx` is a parameter because `src.jsx` has the cwd tsconfig merged in
+/// (`configure_linker`), and the resolver merges each file's own tsconfig over it.
 ///
 /// This projection can be dropped once `bun_options_types::BundleOptions` exists and both
 /// crates re-export it — `Resolver::init1` will then take the canonical type

--- a/src/resolver/options.rs
+++ b/src/resolver/options.rs
@@ -207,8 +207,7 @@ pub struct Framework {
 pub struct BundleOptions {
     pub target: Target,
     pub packages: Packages,
-    /// The user's JSX configuration with no tsconfig.json applied: `Result::jsx`
-    /// is the resolved file's own enclosing tsconfig merged over this.
+    /// User configuration only; each resolved file's tsconfig is merged over it.
     pub jsx: jsx::Pragma,
     pub extension_order: ExtensionOrder,
     pub conditions: Conditions,

--- a/src/resolver/options.rs
+++ b/src/resolver/options.rs
@@ -207,6 +207,8 @@ pub struct Framework {
 pub struct BundleOptions {
     pub target: Target,
     pub packages: Packages,
+    /// The user's JSX configuration with no tsconfig.json applied: `Result::jsx`
+    /// is the resolved file's own enclosing tsconfig merged over this.
     pub jsx: jsx::Pragma,
     pub extension_order: ExtensionOrder,
     pub conditions: Conditions,

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -1189,9 +1189,7 @@ impl<'a> Resolver<'a> {
                             .to_vec(),
                     );
                 }
-                let _ = self.flush_debug_logs(FlushMode::Success);
-                self.extension_order = original_order;
-                return ResultUnion::Success(Result {
+                let mut result = Result {
                     import_kind: kind,
                     path_pair: res.path_pair,
                     package_json: res.package_json,
@@ -1199,7 +1197,16 @@ impl<'a> Resolver<'a> {
                     file_fd: res.file_fd,
                     jsx: self.opts.jsx.clone(),
                     ..Default::default()
-                });
+                };
+                // Same as the regular success path below: this is a file on
+                // disk, so it gets its own tsconfig, sideEffects and realpath.
+                if let Err(err) = self.finalize_result(&mut result, kind) {
+                    self.extension_order = original_order;
+                    return ResultUnion::Failure(err);
+                }
+                let _ = self.flush_debug_logs(FlushMode::Success);
+                self.extension_order = original_order;
+                return ResultUnion::Success(result);
             }
         }
 

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -1198,8 +1198,6 @@ impl<'a> Resolver<'a> {
                     jsx: self.opts.jsx.clone(),
                     ..Default::default()
                 };
-                // Same as the regular success path below: this is a file on
-                // disk, so it gets its own tsconfig, sideEffects and realpath.
                 if let Err(err) = self.finalize_result(&mut result, kind) {
                     self.extension_order = original_order;
                     return ResultUnion::Failure(err);

--- a/src/resolver/tsconfig_json.rs
+++ b/src/resolver/tsconfig_json.rs
@@ -239,6 +239,8 @@ impl TSConfigJSON {
 
         if self.jsx_flags.contains(JsxField::ImportSource) {
             out.import_source = self.jsx.import_source.clone();
+            // The key-after-spread `createElement` fallback is imported from `package_name`.
+            out.package_name.clone_from(&self.jsx.package_name);
         }
 
         if self.jsx_flags.contains(JsxField::Runtime) {

--- a/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
+++ b/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
@@ -187,10 +187,15 @@ describe("the cwd tsconfig.json is not the base for files governed by another ts
     ],
   ];
 
-  async function build(cmd: string[], cwd: string) {
-    await using proc = Bun.spawn({ cmd, cwd, env: noNodeEnv, stdout: "pipe", stderr: "pipe" });
+  async function buildOutput(cmd: string[], cwd: string, env: Record<string, string | undefined> = noNodeEnv) {
+    await using proc = Bun.spawn({ cmd, cwd, env, stdout: "pipe", stderr: "pipe" });
     // stderr is drained but not asserted: the key-after-spread fixture prints a deprecation warning.
     const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, exitCode };
+  }
+
+  async function build(cmd: string[], cwd: string) {
+    const { stdout, exitCode } = await buildOutput(cmd, cwd);
     return { refs: runtimeRefsOf(stdout), exitCode };
   }
 
@@ -238,6 +243,40 @@ describe("the cwd tsconfig.json is not the base for files governed by another ts
       expect(await run(join(String(dir), c.cwd ?? ""), c)).toEqual({ refs: c.refs, exitCode: 0 });
     });
   }
+
+  // The dev/prod bit is part of the base as well. Bundled builds then choose dev/prod per build from
+  // the cwd tsconfig / NODE_ENV / --production (the force_node_env arms in bundle_v2), so the per-file
+  // value only shows in --no-bundle, which emits it as is.
+  describe("bun build --no-bundle", () => {
+    const importsOf = (code: string) => [...code.matchAll(/ from "([^"]+)"/g)].map(m => m[1]);
+
+    test.concurrent('a nested tsconfig without "jsx" does not inherit the cwd tsconfig\'s "react-jsx"', async () => {
+      using dir = tempDir("jsx-tsconfig-base-dev", {
+        "tsconfig.json": tsconfig({ jsx: "react-jsx" }),
+        "app/tsconfig.json": tsconfig({ jsxImportSource: "nested-src" }),
+        "app/m.jsx": element,
+      });
+      const { stdout, exitCode } = await buildOutput([bunExe(), "build", "--no-bundle", "app/m.jsx"], String(dir));
+      expect({ imports: importsOf(stdout), exitCode }).toEqual({
+        imports: ["nested-src/jsx-dev-runtime"],
+        exitCode: 0,
+      });
+    });
+
+    // NODE_ENV is applied to the base before the cwd tsconfig is read; copying the cwd tsconfig's
+    // settings (development: true unless it sets "jsx") over the base used to discard it.
+    test.concurrent('NODE_ENV=production survives a cwd tsconfig that does not set "jsx"', async () => {
+      using dir = tempDir("jsx-tsconfig-base-node-env", {
+        "tsconfig.json": tsconfig({ jsxImportSource: "shim" }),
+        "m.jsx": element,
+      });
+      const { stdout, exitCode } = await buildOutput([bunExe(), "build", "--no-bundle", "m.jsx"], String(dir), {
+        ...noNodeEnv,
+        NODE_ENV: "production",
+      });
+      expect({ imports: importsOf(stdout), exitCode }).toEqual({ imports: ["shim/jsx-runtime"], exitCode: 0 });
+    });
+  });
 
   // A browser-side HTML entry point inside a server-side build is resolved by a second transpiler
   // derived from the main one, so its base has to be carried over without the cwd tsconfig too.

--- a/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
+++ b/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
@@ -81,7 +81,7 @@ describe("tsconfig compilerOptions.jsx", () => {
 describe("the cwd tsconfig.json is not the base for files governed by another tsconfig.json", () => {
   const noNodeEnv = { ...bunEnv, NODE_ENV: undefined, BUN_ENV: undefined };
   const element = `globalThis.a = <><div /></>;\n`;
-  const tsconfig = (compilerOptions: Record<string, string>) => JSON.stringify({ compilerOptions });
+  const tsconfig = (compilerOptions: Record<string, unknown>) => JSON.stringify({ compilerOptions });
 
   /**
    * What the output's JSX is wired to: the packages it imports its runtime from (the dev and prod
@@ -213,28 +213,29 @@ describe("the cwd tsconfig.json is not the base for files governed by another ts
       );
   }
 
-  function api(extraOptions: Record<string, unknown>) {
+  function api(options: Record<string, unknown>) {
     return (cwd: string, c: Case) => {
-      const options = {
+      const config = {
         entrypoints: [c.entry],
-        external: ["*"],
         ...(c.jsxImportSource ? { jsx: { importSource: c.jsxImportSource } } : {}),
-        ...extraOptions,
+        ...options,
       };
-      const script = `const result = await Bun.build(${JSON.stringify(options)});\nconsole.write(await result.outputs[0].text());`;
+      const script = `const result = await Bun.build(${JSON.stringify(config)});\nconsole.write(await result.outputs[0].text());`;
       return build([bunExe(), "-e", script], cwd);
     };
   }
 
+  type Mode = [name: string, run: (cwd: string, c: Case) => Promise<{ refs: string[]; exitCode: number }>];
+
   // Bundling modes mark everything external so the runtime imports stay visible in the output.
   // --env / env: "inline" reach the cwd tsconfig through a second code path (the env loader), so
   // they are covered separately.
-  const modes: [name: string, run: (cwd: string, c: Case) => Promise<{ refs: string[]; exitCode: number }>][] = [
+  const modes: Mode[] = [
     ["bun build", cli(["--external", "*"])],
     ["bun build --no-bundle", cli(["--no-bundle"])],
     ["bun build --env=inline", cli(["--env=inline", "--external", "*"])],
-    ["Bun.build()", api({})],
-    ['Bun.build({ env: "inline" })', api({ env: "inline" })],
+    ["Bun.build()", api({ external: ["*"] })],
+    ['Bun.build({ env: "inline" })', api({ external: ["*"], env: "inline" })],
   ];
 
   for (const [mode, run] of modes) {
@@ -243,6 +244,36 @@ describe("the cwd tsconfig.json is not the base for files governed by another ts
       expect(await run(join(String(dir), c.cwd ?? ""), c)).toEqual({ refs: c.refs, exitCode: 0 });
     });
   }
+
+  // With packages: "external", an import that matches a tsconfig "paths" alias is resolved by a
+  // separate early return in the resolver (#29590). Files found that way are files on disk like any
+  // other and get their own tsconfig: lib/ is governed by the cwd tsconfig, app/ by its own. (The
+  // runtime packages themselves are bare imports, so packages: "external" keeps them visible.)
+  const aliased: Case = {
+    files: {
+      "tsconfig.json": tsconfig({
+        jsxImportSource: "cwd-src",
+        paths: { "@lib/*": ["./lib/*"], "@app/*": ["./app/*"] },
+      }),
+      "app/tsconfig.json": tsconfig({ jsxImportSource: "nested-src" }),
+      "lib/a.jsx": element,
+      "app/b.jsx": element,
+      "main.js": `import "@lib/a";\nimport "@app/b";\n`,
+    },
+    entry: "main.js",
+    refs: ["cwd-src/jsx-runtime", "nested-src/jsx-runtime"],
+  };
+  const packagesExternalModes: Mode[] = [
+    ["bun build --packages=external", cli(["--packages=external"])],
+    ['Bun.build({ packages: "external" })', api({ packages: "external" })],
+  ];
+  test.concurrent.each(packagesExternalModes)(
+    "%s: files reached through tsconfig paths aliases get their own tsconfig",
+    async (_, run) => {
+      using dir = tempDir("jsx-tsconfig-base-paths", aliased.files);
+      expect(await run(String(dir), aliased)).toEqual({ refs: aliased.refs, exitCode: 0 });
+    },
+  );
 
   // The dev/prod bit is part of the base as well. Bundled builds then choose dev/prod per build from
   // the cwd tsconfig / NODE_ENV / --production (the force_node_env arms in bundle_v2), so the per-file

--- a/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
+++ b/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "node:path";
 
 // tsconfig "jsx": "react-jsx" selects the production automatic runtime (jsx/jsxs),
 // "react-jsxdev" selects the development runtime (jsxDEV), matching TypeScript/esbuild.
@@ -67,5 +68,216 @@ describe("tsconfig compilerOptions.jsx", () => {
       expect(stdout).not.toContain(importSource === "shim/jsx-runtime" ? "jsx-dev-runtime" : '"shim/jsx-runtime"');
       expect(exitCode).toBe(0);
     }
+  });
+});
+
+// A file's JSX settings are the tsconfig.json nearest to it merged over the settings given on the
+// command line / in bunfig.toml / to Bun.build({ jsx }). The tsconfig.json of the directory the build
+// is started from is not part of that base: it only applies to the files it governs, like in tsc.
+// `bun build` (and Bun.build() / `bun build` with an --env option) used to merge each file's tsconfig
+// over the cwd's tsconfig instead, so the cwd's jsxImportSource / jsxFactory / "jsx" filled in
+// whatever a nested tsconfig.json left unset, and the same file built differently depending on the
+// cwd and on whether it was built through the CLI or through Bun.build().
+describe("the cwd tsconfig.json is not the base for files governed by another tsconfig.json", () => {
+  const noNodeEnv = { ...bunEnv, NODE_ENV: undefined, BUN_ENV: undefined };
+  const element = `globalThis.a = <><div /></>;\n`;
+  const tsconfig = (compilerOptions: Record<string, string>) => JSON.stringify({ compilerOptions });
+
+  /**
+   * What the output's JSX is wired to: the packages it imports its runtime from (the dev and prod
+   * entries of a package are folded together: which one a file gets is decided by the cwd tsconfig
+   * or NODE_ENV for the CLI and by the jsx option for Bun.build(), and is not what is under test
+   * here) plus, for the classic runtime, which factory/fragment identifiers it calls. The fixtures'
+   * cwd tsconfigs always name theirs cwdFactory/cwdFragment.
+   */
+  function runtimeRefsOf(code: string): string[] {
+    const imports = [...code.matchAll(/ from "([^"]+)"/g)].map(m => m[1].replace(/\/jsx-dev-runtime$/, "/jsx-runtime"));
+    const classic = [...code.matchAll(/\b(cwdFactory|cwdFragment|React\.createElement|React\.Fragment)\b/g)].map(
+      m => m[1],
+    );
+    return [...new Set([...imports, ...classic])].sort();
+  }
+
+  interface Case {
+    files: Record<string, string>;
+    /** Directory inside the fixture to build from. */
+    cwd?: string;
+    entry: string;
+    /** Passed as --jsx-import-source / jsx.importSource, i.e. part of the base the tsconfigs merge over. */
+    jsxImportSource?: string;
+    refs: string[];
+  }
+
+  const cases: [name: string, c: Case][] = [
+    [
+      'nested tsconfig sets "jsx": jsxImportSource is the default, not the cwd tsconfig\'s',
+      {
+        files: {
+          "tsconfig.json": tsconfig({ jsx: "react-jsx", jsxImportSource: "cwd-src" }),
+          "app/tsconfig.json": tsconfig({ jsx: "react-jsx" }),
+          "app/m.jsx": element,
+        },
+        entry: "app/m.jsx",
+        refs: ["react/jsx-runtime"],
+      },
+    ],
+    [
+      'nested tsconfig sets jsxImportSource: the runtime is the default automatic one, not the cwd tsconfig\'s "react"',
+      {
+        files: {
+          "tsconfig.json": tsconfig({ jsx: "react", jsxFactory: "cwdFactory", jsxFragmentFactory: "cwdFragment" }),
+          "app/tsconfig.json": tsconfig({ jsxImportSource: "nested-src" }),
+          "app/m.jsx": element,
+        },
+        entry: "app/m.jsx",
+        refs: ["nested-src/jsx-runtime"],
+      },
+    ],
+    [
+      'nested tsconfig sets "jsx": "react": the factories are the defaults, not the cwd tsconfig\'s',
+      {
+        files: {
+          "tsconfig.json": tsconfig({ jsx: "react", jsxFactory: "cwdFactory", jsxFragmentFactory: "cwdFragment" }),
+          "app/tsconfig.json": tsconfig({ jsx: "react" }),
+          "app/m.jsx": element,
+        },
+        entry: "app/m.jsx",
+        refs: ["React.Fragment", "React.createElement"],
+      },
+    ],
+    [
+      "file outside of every tsconfig gets the defaults",
+      {
+        files: {
+          "proj/tsconfig.json": tsconfig({ jsx: "react-jsx", jsxImportSource: "cwd-src" }),
+          "lib/m.jsx": element,
+        },
+        cwd: "proj",
+        entry: "../lib/m.jsx",
+        refs: ["react/jsx-runtime"],
+      },
+    ],
+    [
+      "the command line / Bun.build() jsxImportSource stays the base a nested tsconfig merges over",
+      {
+        files: {
+          "tsconfig.json": tsconfig({ jsx: "react-jsx", jsxImportSource: "cwd-src" }),
+          "app/tsconfig.json": tsconfig({ jsx: "react-jsx" }),
+          "app/m.jsx": element,
+        },
+        entry: "app/m.jsx",
+        jsxImportSource: "flag-src",
+        refs: ["flag-src/jsx-runtime"],
+      },
+    ],
+    [
+      // A key after a {...spread} makes the automatic runtime fall back to createElement, imported
+      // from the jsxImportSource package itself. Merging a tsconfig used to carry only the
+      // /jsx-runtime import over; the CLI got this right only because the cwd tsconfig was copied
+      // over the base wholesale, which is the copy that leaked it into every other file above.
+      "the createElement fallback import follows the governing tsconfig's jsxImportSource as well",
+      {
+        files: {
+          "tsconfig.json": tsconfig({ jsxImportSource: "shim" }),
+          "k.jsx": `const p = {};\nglobalThis.a = <div {...p} key="k" />;\nglobalThis.b = <span />;\n`,
+        },
+        entry: "k.jsx",
+        refs: ["shim", "shim/jsx-runtime"],
+      },
+    ],
+  ];
+
+  async function build(cmd: string[], cwd: string) {
+    await using proc = Bun.spawn({ cmd, cwd, env: noNodeEnv, stdout: "pipe", stderr: "pipe" });
+    // stderr is drained but not asserted: the key-after-spread fixture prints a deprecation warning.
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { refs: runtimeRefsOf(stdout), exitCode };
+  }
+
+  function cli(args: string[]) {
+    return (cwd: string, c: Case) =>
+      build(
+        [
+          bunExe(),
+          "build",
+          ...args,
+          ...(c.jsxImportSource ? [`--jsx-import-source=${c.jsxImportSource}`] : []),
+          c.entry,
+        ],
+        cwd,
+      );
+  }
+
+  function api(extraOptions: Record<string, unknown>) {
+    return (cwd: string, c: Case) => {
+      const options = {
+        entrypoints: [c.entry],
+        external: ["*"],
+        ...(c.jsxImportSource ? { jsx: { importSource: c.jsxImportSource } } : {}),
+        ...extraOptions,
+      };
+      const script = `const result = await Bun.build(${JSON.stringify(options)});\nconsole.write(await result.outputs[0].text());`;
+      return build([bunExe(), "-e", script], cwd);
+    };
+  }
+
+  // Bundling modes mark everything external so the runtime imports stay visible in the output.
+  // --env / env: "inline" reach the cwd tsconfig through a second code path (the env loader), so
+  // they are covered separately.
+  const modes: [name: string, run: (cwd: string, c: Case) => Promise<{ refs: string[]; exitCode: number }>][] = [
+    ["bun build", cli(["--external", "*"])],
+    ["bun build --no-bundle", cli(["--no-bundle"])],
+    ["bun build --env=inline", cli(["--env=inline", "--external", "*"])],
+    ["Bun.build()", api({})],
+    ['Bun.build({ env: "inline" })', api({ env: "inline" })],
+  ];
+
+  for (const [mode, run] of modes) {
+    test.concurrent.each(cases)(`${mode}: %s`, async (_, c) => {
+      using dir = tempDir("jsx-tsconfig-base", c.files);
+      expect(await run(join(String(dir), c.cwd ?? ""), c)).toEqual({ refs: c.refs, exitCode: 0 });
+    });
+  }
+
+  // A browser-side HTML entry point inside a server-side build is resolved by a second transpiler
+  // derived from the main one, so its base has to be carried over without the cwd tsconfig too.
+  // Nothing is external here, so the test reads back which runtime package got bundled in.
+  test.concurrent("bun build --target=bun index.html", async () => {
+    const runtimePackage = (name: string) => ({
+      [`node_modules/${name}/package.json`]: JSON.stringify({
+        name,
+        exports: { "./jsx-runtime": "./runtime.js", "./jsx-dev-runtime": "./runtime.js" },
+      }),
+      [`node_modules/${name}/runtime.js`]: `
+        export const Fragment = "RUNTIME_PACKAGE:${name}";
+        export const jsx = () => Fragment;
+        export const jsxs = jsx;
+        export const jsxDEV = jsx;
+      `,
+    });
+    using dir = tempDir("jsx-tsconfig-base-html", {
+      ...runtimePackage("react"),
+      ...runtimePackage("cwd-src"),
+      "tsconfig.json": tsconfig({ jsx: "react-jsx", jsxImportSource: "cwd-src" }),
+      "app/tsconfig.json": tsconfig({ jsx: "react-jsx" }),
+      "app/m.jsx": element,
+      "index.html": `<!doctype html><script type="module" src="./app/m.jsx"></script>`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--target=bun", "--outdir=out", "index.html"],
+      cwd: String(dir),
+      env: noNodeEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+    expect(stdout).toContain("index.html");
+
+    const outputs = await Array.fromAsync(new Bun.Glob("*.js").scan(join(String(dir), "out")));
+    expect(outputs).toHaveLength(1);
+    const code = await Bun.file(join(String(dir), "out", outputs[0])).text();
+    expect([...code.matchAll(/RUNTIME_PACKAGE:([\w-]+)/g)].map(m => m[1])).toEqual(["react"]);
   });
 });


### PR DESCRIPTION
### Problem
- For a file governed by a nested `tsconfig.json`, the fields that tsconfig leaves unset (`jsxImportSource`, `jsxFactory`, `jsxFragmentFactory`, `"jsx"`) are filled in from the `tsconfig.json` of the directory the build is started from. With `tsconfig.json` = `{"jsx":"react-jsx","jsxImportSource":"preact"}` and `app/tsconfig.json` = `{"jsx":"react-jsx"}`, `bun build app/m.tsx` imports `preact/jsx-runtime`, while `Bun.build({entrypoints:["./app/m.tsx"]})` and `cd app && bun build m.tsx` import from `react`. tsc applies only `app/tsconfig.json` to `app/m.tsx`. Found while working on #38719; no user report. Reproduces on 1.4.0 and main.
- The same leak affects `bun build --no-bundle`, anything built with `--env=...` / `Bun.build({ env: "inline" })` (there it also overrides an explicit `--jsx-import-source`), files outside of every tsconfig (they get the cwd's settings), and the scripts of an HTML entry point in a `--target=bun` build.
- Cause: the resolver builds each file's pragma as `enclosing_tsconfig.merge_jsx(opts.jsx)` (`src/resolver/resolver.rs`, `finalize_result`), so `resolver.opts.jsx` is the base every file's own tsconfig is merged over. `configure_linker()` / `run_env_loader()` (`src/bundler/transpiler.rs`) merge the cwd tsconfig into `options.jsx`, which is what `bun run` parses every file with, and `sync_resolver_opts()` plus `Transpiler::for_worker` (the client transpiler used for HTML entry points) then re-projected `resolver.opts` from `options`, copying that merged pragma into the base. A default `Bun.build()` was unaffected only because its env behavior skips the `run_env_loader` merge and its explicit `jsx` config skips the `configure_linker` copy.
- Two more defects the first fix exposes, both pre-existing:
  - `TSConfigJSON::merge_jsx` copied `import_source` but not `package_name`, which is where the key-after-spread `createElement` fallback is imported from. `Bun.build()`, `Bun.Transpiler({ tsconfig })`, `extends` chains and CLI builds with a bunfig.toml already emitted `jsx` from `shim/jsx-runtime` next to `createElement` from `react`; the plain CLI was right only because of the wholesale copy above.
  - With `packages: "external"`, imports that match a tsconfig `paths` alias return early from `resolve_and_auto_install` (the #29590 block) without `finalize_result`, so those files got the bare `opts.jsx` and never their own tsconfig. `Bun.build({ packages: "external" })` already lost the tsconfig's JSX settings for such files; the CLI was right for cwd-governed files only through the same copy, so fixing the base alone would have regressed it there.

### Fix
- `resolver_bundle_options_subset()` takes the base pragma as a parameter. `Transpiler::init` passes `options.jsx` as `from_api` built it (CLI flags / bunfig / `Bun.build({ jsx })`, no tsconfig read yet); `sync_resolver_opts()` keeps the pragma the resolver holds; `for_worker` copies the parent resolver's. `options.jsx` itself is untouched, so `bun run` and bundled-mode dev/prod selection (see below) behave exactly as before.
- `merge_jsx` copies `package_name` with `import_source`. #38050 and #36728 carry this same line for their own reasons; whichever lands last drops its copy. It stays here because without it this PR regresses the CLI's `createElement` fallback (shown by the test below).
- The #29590 early return builds its `Result` and runs it through `finalize_result` like every other file on disk, which gives those files their tsconfig merge (and the per-file decorator flags, sideEffects data, module type and realpath that path also skipped).
- Why this layer: the per-file merge already exists in the resolver, and its base is what every other in-flight change in this area assumes it to be. The production flips that do belong in the base are already written to `resolver.opts` directly (`set_production` in `configure_defines` / `run_env_loader`, `--production` in `build_command.rs`), so they still apply. Removing the cwd fold-in from `options.jsx` instead would be the smaller end state, but on main `options.jsx` still has two readers that need it: the runtime parse sites (per-file in #38719) and bundled mode's per-build dev/prod choice (`forced_jsx_development` in `bundle_v2`, changed by #36269). Once those land, the fold-in can go and this base is what remains. Bake / the dev server configure their transpilers through the same `configure_linker` -> `sync_resolver_opts` path and are covered by the same change.
- Landing order: this is the base the cluster builds on. #38719 currently merges the nearest tsconfig over `options.jsx` at runtime and asserts `bun run` == `bun build` for exactly this layout; on top of this PR it should merge over `resolver.opts.jsx` instead (one line), after which its test pins both tools to the same base. #36269's new plugin-path merges (`t.options.jsx.clone()` then `merge_jsx`) want the same swap. If #38719 lands first, this PR's rebase makes that change.
- Visible consequences of the base no longer carrying the cwd tsconfig, beyond the fields above, are confined to `--no-bundle` (bundled builds overwrite every file's dev/prod bit from `options.jsx.development` / `force_node_env`, which #36269, #38050 and #38070 deal with and this PR leaves alone): a nested tsconfig without `"jsx"` no longer inherits the cwd's `react-jsx` dev/prod choice (the result `Bun.build()` already gives), and `NODE_ENV=production` is no longer discarded by a cwd tsconfig that does not set `"jsx"` (the result `bun run` already gives). The sites where `bundle_v2` takes a file's pragma from `options.jsx` directly (`onResolve` results, `files:` entries, and the plugin fallback in `enqueue_parse_task`, which #36269 rewrites) are unchanged.
- Tests: `test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts`, new `describe` block. Six layouts (each leaking field, a file outside every tsconfig, the `createElement` fallback, and a `--jsx-import-source` / `jsx.importSource` case showing the flags remain the base) run through `bun build`, `bun build --no-bundle`, `bun build --env=inline`, `Bun.build()` and `Bun.build({ env: "inline" })`; plus the `--target=bun index.html` build, the `--packages=external` / `packages: "external"` alias case (cwd-governed and nested file side by side), and the two `--no-bundle` dev/prod cases. 25 of the 37 tests fail on the unfixed build. Reverting the `merge_jsx` line fails the `createElement` cases, reverting the `for_worker` line fails the HTML case, and reverting the resolver hunk fails the alias case with both files on the bare base.
- Also run: `bundler_jsx`, `bundler_edgecase` (has the #29590 tests), `bundler_npm`, `bundler_html`, `esbuild/tsconfig`, `bun-build-api`, `transpiler/transpiler.test.js`, `cli/run/tsconfig-override`, `bake/dev/react-spa`, `resolve/resolve`, `resolve/tsconfig-extends-leak`, `regression/issue/32492`: pass. `cargo clippy -p bun_resolver -p bun_bundler` is clean.

### Background
- JSX pragma (`jsx::Pragma`, `src/options_types/jsx.rs`): the settings the parser transpiles JSX with: runtime (classic `h(...)` calls vs automatic `jsx()` imports), factory/fragment names for classic, the package the automatic runtime is imported from (`import_source` for `x/jsx-runtime`, `package_name` for the `createElement` fallback), and the dev/prod bit.
- A build has two pragmas. `options.jsx` is transpiler-wide: `bun run` parses every file with it, and `configure_linker` / `run_env_loader` fold the cwd tsconfig into it for that purpose. `resolver.opts.jsx` is only the base of the per-file merge; `bun build` (`ParseTask`) and `bun build --no-bundle` (`Transpiler::transform`) parse with the merged per-file result, `Result::jsx`.
- `TSConfigJSON::merge_jsx` copies only the fields a tsconfig actually sets (tracked in `jsx_flags`), which is why whatever is in the base shows through for the fields it leaves unset.
- `resolver_bundle_options_subset` projects the bundler's `BundleOptions` into the smaller struct the resolver crate reads. It runs at `Transpiler::init`, again from `sync_resolver_opts()` once an entry point (`bun build`, `Bun.build`, bake) has finished configuring `options`, and from `for_worker`, which derives the extra transpiler a server-side build uses for browser-target files such as HTML entry points.
- `finalize_result` is the resolver's common post-processing for a file found on disk: package.json sideEffects, the enclosing tsconfig's JSX and decorator settings, module type, and symlink realpath. Every success path reaches it except the #29590 early return, which this PR routes through it as well.

<details>
<summary>Repro on 1.4.0</summary>

```sh
mkdir -p t/app && cd t && mkdir node_modules
echo '{"compilerOptions":{"jsx":"react-jsx","jsxImportSource":"preact"}}' > tsconfig.json
echo '{"compilerOptions":{"jsx":"react-jsx"}}' > app/tsconfig.json
echo 'export const el = <div />;' > app/m.tsx

bun build app/m.tsx --external '*'                                # preact/jsx-runtime
bun build --no-bundle app/m.tsx                                   # preact/jsx-runtime
bun build --env=inline --jsx-import-source=foo app/m.tsx --external '*'   # preact/jsx-runtime (flag ignored)
(cd app && bun build m.tsx --external '*')                        # react/jsx-runtime
bun -e 'const r = await Bun.build({entrypoints:["./app/m.tsx"], external:["*"]}); console.log(await r.outputs[0].text())'
                                                                  # react/jsx-dev-runtime
bun -e 'const r = await Bun.build({entrypoints:["./app/m.tsx"], external:["*"], env:"inline"}); console.log(await r.outputs[0].text())'
                                                                  # preact/jsx-runtime
```

createElement fallback, `tsconfig.json` = `{"compilerOptions":{"jsxImportSource":"preact"}}`, `k.tsx` = `declare const p: any; export const el = <div {...p} key="k" />;`:

```sh
bun build k.tsx --external '*'     # import { createElement } from "preact";   (wholesale copy)
bun -e 'const r = await Bun.build({entrypoints:["./k.tsx"], external:["*"]}); console.log(await r.outputs[0].text())'
                                   # import { createElement } from "react";    (merge_jsx)
```

paths alias under packages=external, `tsconfig.json` = `{"compilerOptions":{"jsxImportSource":"cwd-src","paths":{"@lib/*":["./lib/*"],"@app/*":["./app/*"]}}}`, `app/tsconfig.json` = `{"compilerOptions":{"jsxImportSource":"nested-src"}}`, `lib/a.jsx` and `app/b.jsx` each containing JSX, `main.js` importing `@lib/a` and `@app/b`:

```sh
bun build --packages=external main.js        # both files: cwd-src
bun -e 'const r = await Bun.build({entrypoints:["./main.js"], packages:"external"}); console.log(await r.outputs[0].text())'
                                             # both files: react
```

After this PR: `app/m.tsx` imports from `react` in every command above except the `--jsx-import-source=foo` one (`foo`); the fallback case imports from `preact` on both lines everywhere; `lib/a.jsx` gets `cwd-src` and `app/b.jsx` gets `nested-src` in both the CLI and the API.
</details>

