### PR TITLE
docs(pm): add the Integrity line to the bun pm pack sample output

### DIFF
--- a/docs/pm/cli/pm.mdx
+++ b/docs/pm/cli/pm.mdx
@@ -62,16 +62,17 @@ bun pm pack
 ```
 
 ```txt
-bun pack v1.2.19
+bun pack v1.4.0
 
-packed 131B package.json
-packed 40B index.js
+packed 130B package.json
+packed 39B index.js
 
 my-package-1.0.0.tgz
 
 Total files: 2
-Shasum: f2451d6eb1e818f500a791d9aace80b394258a90
-Unpacked size: 171B
+Shasum: e89c3ac8aeada51cf70269f202f5d593a8cadaf7
+Integrity: sha512-EFIKE818hShHn[...]1oBrEdd5/i1FA==
+Unpacked size: 169B
 Packed size: 249B
 ```
 


### PR DESCRIPTION
### Problem
- The default-output sample for `bun pm pack` in `docs/pm/cli/pm.mdx` has no `Integrity:` line. `bun pm pack` prints one between `Shasum:` and `Unpacked size:` (`src/runtime/cli/pack_command.rs`, `print_summary`), and the `bun publish` sample in `docs/pm/cli/publish.mdx` already shows it.

### Fix
- Replace the sample with the output of a real `bun pm pack` run on a two-file package (package.json + index.js), so every line in the block, including the `Integrity:` line, is what the command prints today. The output is deterministic for the same inputs; two runs gave the same shasum and integrity.
- Docs only. `prettier --check docs/pm/cli/pm.mdx` passes.

The other finding from the same docs check, `bun pm pkg delete 'contributors[0]'` deleting nothing, is fixed by #38025 and is not part of this PR.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->