### PR TITLE
install: install a git dependency's devDependencies before running its prepare scripts

### DIFF
--- a/docs/pm/cli/add.mdx
+++ b/docs/pm/cli/add.mdx
@@ -213,6 +213,8 @@ Bun supports a variety of protocols, including [`github`](https://docs.npmjs.com
 }
 ```
 
+Bun installs the repository's files as they are. If the package builds its entry point in a `prepare` script, add it to `trustedDependencies`. Bun then installs the package's `devDependencies` and runs the script. See [`prepare` scripts of git dependencies](/pm/lifecycle#prepare-scripts-of-git-dependencies).
+
 ## Tarball dependencies
 
 A package name can correspond to a publicly hosted `.tgz` file. Bun downloads and installs the package from that tarball URL rather than from the package registry.

--- a/docs/pm/lifecycle.mdx
+++ b/docs/pm/lifecycle.mdx
@@ -67,6 +67,22 @@ Set `trustedDependencies: []` when you want to opt out of the default allow list
 
 ---
 
+## `prepare` scripts of git dependencies
+
+A package installed from a git repository (a `git:`, `git+https:`, or `github:` dependency) has no published build output. Many of these packages build their entry point in a `prepare` script, using build tools from their `devDependencies`.
+
+Bun does not run that script until you add the package to `trustedDependencies`. Until then, `bun install` reports the blocked script and the package has no build output. `bun pm untrusted` lists the script.
+
+For a trusted git dependency with a `preprepare`, `prepare`, or `postprepare` script, Bun:
+
+1. Runs `bun install --ignore-scripts` inside the installed package. This installs the package's `dependencies` and `devDependencies` into the package's own `node_modules` folder, using your project's registry and cache directory.
+2. Runs the package's `preprepare`, `prepare`, and `postprepare` scripts.
+3. Removes the `node_modules` folder from step 1. The package uses the dependencies your project installed at runtime.
+
+Because of `--ignore-scripts` in step 1, the lifecycle scripts of the package's own dependencies do not run.
+
+---
+
 ## `--ignore-scripts`
 
 To disable lifecycle scripts for all packages, use the `--ignore-scripts` flag.

--- a/docs/pm/lifecycle.mdx
+++ b/docs/pm/lifecycle.mdx
@@ -75,11 +75,12 @@ Bun does not run that script until you add the package to `trustedDependencies`.
 
 For a trusted git dependency with a `preprepare`, `prepare`, or `postprepare` script, Bun:
 
-1. Runs `bun install --ignore-scripts` inside the installed package. This installs the package's `dependencies` and `devDependencies` into the package's own `node_modules` folder, using your project's registry and cache directory.
-2. Runs the package's `preprepare`, `prepare`, and `postprepare` scripts.
-3. Removes the `node_modules` folder from step 1. The package uses the dependencies your project installed at runtime.
+1. Moves a `node_modules` folder that the package already has out of the way.
+2. Runs `bun install --ignore-scripts --no-save` inside the package. This installs the package's `dependencies` and `devDependencies` into a new `node_modules` folder there, using your project's registry and cache directory. The package's `package.json` and a lockfile committed to the repository stay unchanged.
+3. Runs the package's `preprepare`, `prepare`, and `postprepare` scripts.
+4. Removes the `node_modules` folder from step 2 and moves the one from step 1 back. At runtime, the package uses the dependencies your project installed.
 
-Because of `--ignore-scripts` in step 1, the lifecycle scripts of the package's own dependencies do not run.
+Because of `--ignore-scripts` in step 2, the lifecycle scripts of the package's own dependencies do not run.
 
 ---
 

--- a/src/install/PackageManager/PackageManagerLifecycle.rs
+++ b/src/install/PackageManager/PackageManagerLifecycle.rs
@@ -398,6 +398,13 @@ impl PackageManager {
         // this stack frame (freed by the subprocess's `Drop`).
         let envp = script_env.create_null_delimited_env_map()?;
 
+        let install_envp = if list.install_dependencies_for_prepare {
+            self.put_install_config_for_prepare(&mut script_env)?;
+            Some(script_env.create_null_delimited_env_map()?)
+        } else {
+            None
+        };
+
         let shell_bin: Option<&ZStr> = 'shell_bin: {
             #[cfg(windows)]
             {
@@ -426,12 +433,41 @@ impl PackageManager {
             self,
             list,
             envp,
+            install_envp,
             shell_bin,
             optional,
             log_level,
             foreground,
             install_ctx,
         )?;
+        Ok(())
+    }
+
+    /// The `bun install` that fetches a git dependency's own dependencies for
+    /// its `prepare` scripts runs with the dependency's checkout as its project
+    /// directory, so it does not see this project's `bunfig.toml`/`.npmrc`.
+    /// Forward the settings it would otherwise lose through the environment
+    /// variables `bun install` already reads.
+    fn put_install_config_for_prepare(
+        &mut self,
+        script_env: &mut bun_dotenv::Map,
+    ) -> Result<(), crate::Error> {
+        let scope = &self.options.scope;
+        // The token is only ever forwarded together with the registry it
+        // belongs to, so the nested install cannot send it somewhere else.
+        if self.options.did_override_default_scope || !scope.token.is_empty() {
+            script_env.put(b"BUN_CONFIG_REGISTRY", scope.url.href())?;
+            if !scope.token.is_empty() {
+                script_env.put(b"BUN_CONFIG_TOKEN", &scope.token)?;
+            }
+        }
+
+        let _ = self.get_cache_directory();
+        script_env.put(
+            b"BUN_INSTALL_CACHE_DIR",
+            self.cache_directory_path.as_bytes(),
+        )?;
+
         Ok(())
     }
 

--- a/src/install/PackageManager/PackageManagerLifecycle.rs
+++ b/src/install/PackageManager/PackageManagerLifecycle.rs
@@ -443,18 +443,14 @@ impl PackageManager {
         Ok(())
     }
 
-    /// The `bun install` that fetches a git dependency's own dependencies for
-    /// its `prepare` scripts runs with the dependency's checkout as its project
-    /// directory, so it does not see this project's `bunfig.toml`/`.npmrc`.
-    /// Forward the settings it would otherwise lose through the environment
-    /// variables `bun install` already reads.
+    /// The nested install's project directory is the checkout, so this project's
+    /// `bunfig.toml`/`.npmrc` settings have to reach it through the environment.
     fn put_install_config_for_prepare(
         &mut self,
         script_env: &mut bun_dotenv::Map,
     ) -> Result<(), crate::Error> {
         let scope = &self.options.scope;
-        // The token is only ever forwarded together with the registry it
-        // belongs to, so the nested install cannot send it somewhere else.
+        // The token only travels together with its registry.
         if self.options.did_override_default_scope || !scope.token.is_empty() {
             script_env.put(b"BUN_CONFIG_REGISTRY", scope.url.href())?;
             if !scope.token.is_empty() {
@@ -462,11 +458,12 @@ impl PackageManager {
             }
         }
 
+        // Opening the cache directory is what fills in its path.
         let _ = self.get_cache_directory();
-        script_env.put(
-            b"BUN_INSTALL_CACHE_DIR",
-            self.cache_directory_path.as_bytes(),
-        )?;
+        let cache_directory_path = self.cache_directory_path.as_bytes();
+        if !cache_directory_path.is_empty() {
+            script_env.put(b"BUN_INSTALL_CACHE_DIR", cache_directory_path)?;
+        }
 
         Ok(())
     }

--- a/src/install/lifecycle_script_runner.rs
+++ b/src/install/lifecycle_script_runner.rs
@@ -320,58 +320,120 @@ pub(crate) enum PrepareDependencies {
     Pending,
     /// The running subprocess is `bun install`; `current_script_index` is the
     /// prepare script that runs once it succeeds.
-    Installing(PreviousNodeModules),
-    /// `bun install` succeeded. `cwd/node_modules` is removed again once the
-    /// scripts are done (or failed).
-    Installed(PreviousNodeModules),
+    Installing(NestedInstallCleanup),
+    /// `bun install` succeeded. The cleanup runs once the scripts are done
+    /// (or one of them failed).
+    Installed(NestedInstallCleanup),
 }
 
-/// What `cwd/node_modules` held before the nested `bun install` wrote to it.
-/// With the hoisted linker it can already contain dependencies of the package
-/// that conflict with the versions hoisted above it, and a checkout may commit
-/// one; those have to survive the install.
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub(crate) enum PreviousNodeModules {
-    Nothing,
-    /// Renamed to [`PREVIOUS_NODE_MODULES_NAME`] and renamed back afterwards.
-    SetAside,
-    /// Exists but could not be renamed, so the nested install shares it and
-    /// nothing is removed afterwards.
-    Shared,
-}
-
+/// While the nested `bun install` and the prepare scripts run, this directory
+/// inside the package holds the package's previous `node_modules` (with the
+/// hoisted linker: the dependencies whose versions conflict with the ones
+/// hoisted above it; or one committed to the repository), or is empty if there
+/// was none. It exists for exactly that duration, so finding it at the start
+/// means an earlier run was interrupted: it still holds the original, and the
+/// package's `node_modules` is whatever that run left behind.
 const PREVIOUS_NODE_MODULES_NAME: &[u8] = b".bun-prepare-node_modules";
 
 /// Arguments of the `bun` spawned for `PrepareDependencies::Installing`.
 /// `--ignore-scripts` because the package's own lifecycle scripts are what this
-/// runner is in the middle of executing; `--no-save` so a checkout without a
-/// lockfile does not get one written into it.
+/// runner is in the middle of executing; `--no-save` so the package.json and a
+/// committed lockfile stay as they are.
 const INSTALL_DEPENDENCIES_ARGS: [&core::ffi::CStr; 3] =
     [c"install", c"--ignore-scripts", c"--no-save"];
 /// `INSTALL_DEPENDENCIES_ARGS` as shown in logs and error messages.
 const INSTALL_DEPENDENCIES_COMMAND_LINE: &[u8] = b"bun install --ignore-scripts --no-save";
 
-/// Moves `cwd/node_modules` out of the way of the nested `bun install`.
-fn set_aside_node_modules(cwd: &[u8]) -> PreviousNodeModules {
-    let mut node_modules = AutoAbsPath::init();
-    let _ = node_modules.append(cwd);
-    let _ = node_modules.append(b"node_modules");
-    let mut previous = AutoAbsPath::init();
-    let _ = previous.append(cwd);
-    let _ = previous.append(PREVIOUS_NODE_MODULES_NAME);
+/// What the nested `bun install` leaves in the package directory that has to
+/// go again. The package's runtime dependencies live in the node_modules above
+/// it (or next to it in the isolated store), so everything the nested install
+/// puts here would only shadow them with duplicate copies.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) struct NestedInstallCleanup {
+    /// The previous `node_modules` is in [`PREVIOUS_NODE_MODULES_NAME`]. When
+    /// it could not be moved there, the nested install shares it and it is
+    /// left alone afterwards.
+    restore_node_modules: bool,
+    /// The checkout had no `bun.lock`. `--no-save` keeps the nested install
+    /// from writing one, except that a `package-lock.json`/`yarn.lock`/... it
+    /// migrates is always saved (`saves_migrated_lockfile`).
+    remove_lockfile: bool,
+}
 
-    // Left behind by an interrupted run; the rename below would fail on it.
-    let _ = Fd::cwd().delete_tree(previous.slice());
+fn path_in_package(cwd: &[u8], name: &[u8]) -> AutoAbsPath {
+    let mut path = AutoAbsPath::init();
+    let _ = path.append(cwd);
+    let _ = path.append(name);
+    path
+}
 
-    match bun_sys::renameat(
-        Fd::cwd(),
-        node_modules.slice_z(),
-        Fd::cwd(),
-        previous.slice_z(),
-    ) {
-        Ok(()) => PreviousNodeModules::SetAside,
-        Err(err) if err.get_errno() == bun_sys::E::ENOENT => PreviousNodeModules::Nothing,
-        Err(_) => PreviousNodeModules::Shared,
+impl NestedInstallCleanup {
+    /// Gets the package directory ready for the nested install and records
+    /// what to undo afterwards.
+    fn begin(cwd: &[u8]) -> Self {
+        let remove_lockfile = !bun_sys::exists(path_in_package(cwd, b"bun.lock").slice());
+
+        let mut node_modules = path_in_package(cwd, b"node_modules");
+        let mut previous = path_in_package(cwd, PREVIOUS_NODE_MODULES_NAME);
+        let restore_node_modules = if bun_sys::exists(previous.slice()) {
+            let _ = Fd::cwd().delete_tree(node_modules.slice());
+            true
+        } else {
+            match bun_sys::renameat(
+                Fd::cwd(),
+                node_modules.slice_z(),
+                Fd::cwd(),
+                previous.slice_z(),
+            ) {
+                Ok(()) => true,
+                Err(err) if err.get_errno() == bun_sys::E::ENOENT => {
+                    bun_sys::mkdir(previous.slice_z(), 0o755).is_ok()
+                }
+                Err(_) => false,
+            }
+        };
+
+        Self {
+            restore_node_modules,
+            remove_lockfile,
+        }
+    }
+
+    fn finish(self, cwd: &[u8], package_name: &[u8]) {
+        if self.remove_lockfile {
+            let _ = Fd::cwd().delete_tree(path_in_package(cwd, b"bun.lock").slice());
+        }
+
+        if !self.restore_node_modules {
+            return;
+        }
+
+        let mut node_modules = path_in_package(cwd, b"node_modules");
+        if let Err(err) = Fd::cwd().delete_tree(node_modules.slice()) {
+            bun_core::warn!(
+                "failed to remove the dependencies installed for the prepare scripts of \"{}\": {}",
+                bstr::BStr::new(package_name),
+                err,
+            );
+        }
+
+        let mut previous = path_in_package(cwd, PREVIOUS_NODE_MODULES_NAME);
+        if let Err(err) = bun_sys::renameat(
+            Fd::cwd(),
+            previous.slice_z(),
+            Fd::cwd(),
+            node_modules.slice_z(),
+        ) {
+            bun_core::warn!(
+                "failed to restore the node_modules of \"{}\" after running its prepare scripts: {}",
+                bstr::BStr::new(package_name),
+                err,
+            );
+            return;
+        }
+        // Only succeeds for the empty placeholder `begin` created when the
+        // package had no node_modules of its own.
+        let _ = bun_sys::rmdir(node_modules.slice_z());
     }
 }
 
@@ -619,7 +681,7 @@ impl<'a> LifecycleScriptSubprocess<'a> {
             let mut copy_script: Vec<u8> = Vec::new();
             let command_line: &[u8] = if installing_dependencies {
                 (*this).prepare_dependencies =
-                    PrepareDependencies::Installing(set_aside_node_modules(cwd));
+                    PrepareDependencies::Installing(NestedInstallCleanup::begin(cwd));
                 argv[0] = bun_core::self_exe_path()?.as_ptr();
                 for (slot, arg) in argv[1..].iter_mut().zip(INSTALL_DEPENDENCIES_ARGS) {
                     *slot = arg.as_ptr();
@@ -943,25 +1005,8 @@ impl<'a> LifecycleScriptSubprocess<'a> {
                         return;
                     }
                     self.print_output();
-                    if matches!(
-                        self.prepare_dependencies,
-                        PrepareDependencies::Installing(_)
-                    ) {
-                        bun_core::pretty_errorln!(
-                            "<r><red>error<r><d>:<r> installing the dependencies of \"<b>{}<r>\" for its <b>{}<r> script failed <d>({} exited with {})<r>",
-                            bstr::BStr::new(&self.package_name),
-                            bstr::BStr::new(self.script_name()),
-                            bstr::BStr::new(INSTALL_DEPENDENCIES_COMMAND_LINE),
-                            exit.code,
-                        );
-                    } else {
-                        bun_core::pretty_errorln!(
-                            "<r><red>error<r><d>:<r> <b>{}<r> script from \"<b>{}<r>\" exited with {}<r>",
-                            bstr::BStr::new(self.script_name()),
-                            bstr::BStr::new(&self.package_name),
-                            exit.code,
-                        );
-                    }
+                    self.print_failure_subject();
+                    bun_core::pretty_errorln!(" exited with {}<r>", exit.code);
                     self.remove_prepare_dependencies();
                     // SAFETY: `self` was created by `Self::new` (heap::alloc); uniquely owned here.
                     unsafe { Self::destroy(std::ptr::from_mut::<Self>(self)) };
@@ -969,8 +1014,8 @@ impl<'a> LifecycleScriptSubprocess<'a> {
                     Global::exit(exit.code as u32);
                 }
 
-                if let PrepareDependencies::Installing(previous) = self.prepare_dependencies {
-                    self.prepare_dependencies = PrepareDependencies::Installed(previous);
+                if let PrepareDependencies::Installing(cleanup) = self.prepare_dependencies {
+                    self.prepare_dependencies = PrepareDependencies::Installed(cleanup);
                     let script_index = self.current_script_index;
                     self.reset_polls();
                     // SAFETY: `self` was created by `Self::new` (heap::alloc) and is
@@ -979,14 +1024,7 @@ impl<'a> LifecycleScriptSubprocess<'a> {
                     if let Err(err) = unsafe {
                         Self::spawn_next_script(std::ptr::from_mut::<Self>(self), script_index)
                     } {
-                        Output::err_generic(
-                            "Failed to run script <b>{}<r> due to error <b>{}<r>",
-                            (
-                                bstr::BStr::new(LockfileScripts::NAMES[script_index as usize]),
-                                err.name(),
-                            ),
-                        );
-                        Global::exit(1);
+                        self.exit_after_spawn_failure(script_index, &err);
                     }
                     return;
                 }
@@ -1041,14 +1079,10 @@ impl<'a> LifecycleScriptSubprocess<'a> {
                                 u8::try_from(new_script_index).expect("int cast"),
                             )
                         } {
-                            Output::err_generic(
-                                "Failed to run script <b>{}<r> due to error <b>{}<r>",
-                                (
-                                    bstr::BStr::new(LockfileScripts::NAMES[new_script_index]),
-                                    err.name(),
-                                ),
+                            self.exit_after_spawn_failure(
+                                u8::try_from(new_script_index).expect("int cast"),
+                                &err,
                             );
-                            Global::exit(1);
                         }
                         return;
                     }
@@ -1087,12 +1121,12 @@ impl<'a> LifecycleScriptSubprocess<'a> {
                 self.print_output();
                 let signal_code = bun_sys::SignalCode::from(signal);
 
+                self.print_failure_subject();
                 bun_core::pretty_errorln!(
-                    "<r><red>error<r><d>:<r> <b>{}<r> script from \"<b>{}<r>\" terminated by {}<r>",
-                    bstr::BStr::new(self.script_name()),
-                    bstr::BStr::new(&self.package_name),
+                    " terminated by {}<r>",
                     signal_code.fmt(Output::enable_ansi_colors_stderr()),
                 );
+                self.remove_prepare_dependencies();
 
                 // `Status::signal_code()` range-checks 1..=31 (`bun_core::SignalCode` is
                 // exhaustive); RT signals (>31) fall back to SIGTERM so the diverging
@@ -1122,6 +1156,7 @@ impl<'a> LifecycleScriptSubprocess<'a> {
                     bstr::BStr::new(&self.package_name),
                     err,
                 );
+                self.remove_prepare_dependencies();
                 // SAFETY: `self` was created by `Self::new` (heap::alloc); uniquely owned here.
                 unsafe { Self::destroy(std::ptr::from_mut::<Self>(self)) };
                 Output::flush();
@@ -1200,50 +1235,15 @@ impl<'a> LifecycleScriptSubprocess<'a> {
         unsafe { Self::destroy(std::ptr::from_mut::<Self>(self)) };
     }
 
-    /// Undoes what the nested `bun install` did to `cwd/node_modules`. The
-    /// package's runtime dependencies live in the node_modules above it (or
-    /// next to it in the isolated store), so everything the nested install put
-    /// here would only shadow them with duplicate copies.
     fn remove_prepare_dependencies(&mut self) {
-        let previous = match self.prepare_dependencies {
-            PrepareDependencies::Installing(previous)
-            | PrepareDependencies::Installed(previous) => previous,
+        let cleanup = match self.prepare_dependencies {
+            PrepareDependencies::Installing(cleanup) | PrepareDependencies::Installed(cleanup) => {
+                cleanup
+            }
             PrepareDependencies::NotNeeded | PrepareDependencies::Pending => return,
         };
         self.prepare_dependencies = PrepareDependencies::NotNeeded;
-        if previous == PreviousNodeModules::Shared {
-            return;
-        }
-
-        let cwd = self.scripts.cwd.as_bytes();
-        let mut node_modules = AutoAbsPath::init();
-        let _ = node_modules.append(cwd);
-        let _ = node_modules.append(b"node_modules");
-        if let Err(err) = Fd::cwd().delete_tree(node_modules.slice()) {
-            bun_core::warn!(
-                "failed to remove the dependencies installed for the prepare scripts of \"{}\": {}",
-                bstr::BStr::new(&self.package_name),
-                err,
-            );
-        }
-
-        if previous == PreviousNodeModules::SetAside {
-            let mut set_aside = AutoAbsPath::init();
-            let _ = set_aside.append(cwd);
-            let _ = set_aside.append(PREVIOUS_NODE_MODULES_NAME);
-            if let Err(err) = bun_sys::renameat(
-                Fd::cwd(),
-                set_aside.slice_z(),
-                Fd::cwd(),
-                node_modules.slice_z(),
-            ) {
-                bun_core::warn!(
-                    "failed to restore the node_modules of \"{}\" after running its prepare scripts: {}",
-                    bstr::BStr::new(&self.package_name),
-                    err,
-                );
-            }
-        }
+        cleanup.finish(self.scripts.cwd.as_bytes(), &self.package_name);
     }
 
     pub(crate) fn spawn_package_scripts(
@@ -1309,15 +1309,47 @@ impl<'a> LifecycleScriptSubprocess<'a> {
         // SAFETY: `lifecycle_subprocess` is the allocation-rooted `heap::alloc` pointer
         // from `Self::new`; passing it gives the stored backrefs stable provenance.
         if let Err(err) = unsafe { Self::spawn_next_script(lifecycle_subprocess, first_index) } {
-            bun_core::pretty_errorln!(
-                "<r><red>error<r>: Failed to run script <b>{}<r> due to error <b>{}<r>",
-                bstr::BStr::new(LockfileScripts::NAMES[first_index as usize]),
-                err.name(),
-            );
-            Global::exit(1);
+            // SAFETY: `spawn_next_script` does not free the subprocess when it
+            // fails; `lss` is a non-owning view that is not used again.
+            unsafe { (*lifecycle_subprocess).exit_after_spawn_failure(first_index, &err) }
         }
 
         Ok(())
+    }
+
+    /// The start of every failure message: `error: <what was running>`, which
+    /// is either one of the package's scripts or the `bun install` that
+    /// fetches a git dependency's own dependencies for its prepare scripts.
+    fn print_failure_subject(&self) {
+        if matches!(
+            self.prepare_dependencies,
+            PrepareDependencies::Installing(_)
+        ) {
+            bun_core::pretty_error!(
+                "<r><red>error<r><d>:<r> <b>{}<r> for the <b>{}<r> script of \"<b>{}<r>\"",
+                bstr::BStr::new(INSTALL_DEPENDENCIES_COMMAND_LINE),
+                bstr::BStr::new(self.script_name()),
+                bstr::BStr::new(&self.package_name),
+            );
+        } else {
+            bun_core::pretty_error!(
+                "<r><red>error<r><d>:<r> <b>{}<r> script from \"<b>{}<r>\"",
+                bstr::BStr::new(self.script_name()),
+                bstr::BStr::new(&self.package_name),
+            );
+        }
+    }
+
+    fn exit_after_spawn_failure(&mut self, script_index: u8, err: &crate::Error) -> ! {
+        Output::err_generic(
+            "Failed to run script <b>{}<r> due to error <b>{}<r>",
+            (
+                bstr::BStr::new(LockfileScripts::NAMES[script_index as usize]),
+                err.name(),
+            ),
+        );
+        self.remove_prepare_dependencies();
+        Global::exit(1);
     }
 
     fn increment_pending_script_tasks(&self) {

--- a/src/install/lifecycle_script_runner.rs
+++ b/src/install/lifecycle_script_runner.rs
@@ -367,8 +367,7 @@ fn set_aside_node_modules(cwd: &[u8]) -> bun_sys::Result<()> {
         Fd::cwd(),
         previous.slice_z(),
     ) {
-        // `mkdirat` (like `renameat`) takes the long-path route on Windows;
-        // `mkdir` goes through libuv and stops at MAX_PATH.
+        // `mkdirat` takes the long-path route on Windows; `mkdir` (libuv) stops at MAX_PATH.
         Err(err) if err.get_errno() == bun_sys::E::ENOENT => {
             bun_sys::mkdirat(Fd::cwd(), previous.slice_z(), 0o755)
         }

--- a/src/install/lifecycle_script_runner.rs
+++ b/src/install/lifecycle_script_runner.rs
@@ -14,13 +14,13 @@ use bun_io::heap as io_heap;
 use bun_io::{FilePollFlag, PosixFlags};
 
 use bun_core::ZStr;
+use bun_paths::AutoAbsPath;
 #[cfg(unix)]
 use bun_spawn::SpawnResultExt as _;
 use bun_spawn::{
     Process, ProcessExit, ProcessExitKind, ProcessHandle, Rusage, SpawnOptions, Status,
 };
-#[cfg(unix)]
-use bun_sys::Fd;
+use bun_sys::{Fd, FdExt as _};
 // `BufferedReaderParent::loop_` is typed `*mut bun_uws::Loop` (the
 // `bun_io::Loop` is the trait's nominal: `us_loop_t` on POSIX, `uv_loop_t`
 // on Windows. `AnyEventLoop::native_loop()` projects through the uws wrapper
@@ -270,6 +270,10 @@ pub struct LifecycleScriptSubprocess<'a> {
     /// struct so the `K=V\0` buffers stay alive across every async
     /// `spawn_next_script` for the script chain; freed by `Drop`/`destroy`.
     pub(crate) envp: bun_dotenv::NullDelimitedEnvMap,
+    /// Environment for the `bun install` of a git dependency's own
+    /// dependencies (`Some` iff `scripts.install_dependencies_for_prepare`).
+    pub(crate) install_envp: Option<bun_dotenv::NullDelimitedEnvMap>,
+    pub(crate) prepare_dependencies: PrepareDependencies,
     pub(crate) shell_bin: Option<&'a ZStr>,
 
     pub(crate) has_incremented_alive_count: bool,
@@ -304,6 +308,70 @@ impl<'a> InstallCtx<'a> {
     fn installer_mut(&self) -> &mut Installer<'a> {
         // SAFETY: see fn doc.
         unsafe { &mut *self.installer }
+    }
+}
+
+/// Where a git dependency is in getting its own dependencies installed for
+/// its `prepare` scripts (see `List::install_dependencies_for_prepare`).
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PrepareDependencies {
+    NotNeeded,
+    /// `bun install` still has to run before the first prepare script.
+    Pending,
+    /// The running subprocess is `bun install`; `current_script_index` is the
+    /// prepare script that runs once it succeeds.
+    Installing(PreviousNodeModules),
+    /// `bun install` succeeded. `cwd/node_modules` is removed again once the
+    /// scripts are done (or failed).
+    Installed(PreviousNodeModules),
+}
+
+/// What `cwd/node_modules` held before the nested `bun install` wrote to it.
+/// With the hoisted linker it can already contain dependencies of the package
+/// that conflict with the versions hoisted above it, and a checkout may commit
+/// one; those have to survive the install.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PreviousNodeModules {
+    Nothing,
+    /// Renamed to [`PREVIOUS_NODE_MODULES_NAME`] and renamed back afterwards.
+    SetAside,
+    /// Exists but could not be renamed, so the nested install shares it and
+    /// nothing is removed afterwards.
+    Shared,
+}
+
+const PREVIOUS_NODE_MODULES_NAME: &[u8] = b".bun-prepare-node_modules";
+
+/// Arguments of the `bun` spawned for `PrepareDependencies::Installing`.
+/// `--ignore-scripts` because the package's own lifecycle scripts are what this
+/// runner is in the middle of executing; `--no-save` so a checkout without a
+/// lockfile does not get one written into it.
+const INSTALL_DEPENDENCIES_ARGS: [&core::ffi::CStr; 3] =
+    [c"install", c"--ignore-scripts", c"--no-save"];
+/// `INSTALL_DEPENDENCIES_ARGS` as shown in logs and error messages.
+const INSTALL_DEPENDENCIES_COMMAND_LINE: &[u8] = b"bun install --ignore-scripts --no-save";
+
+/// Moves `cwd/node_modules` out of the way of the nested `bun install`.
+fn set_aside_node_modules(cwd: &[u8]) -> PreviousNodeModules {
+    let mut node_modules = AutoAbsPath::init();
+    let _ = node_modules.append(cwd);
+    let _ = node_modules.append(b"node_modules");
+    let mut previous = AutoAbsPath::init();
+    let _ = previous.append(cwd);
+    let _ = previous.append(PREVIOUS_NODE_MODULES_NAME);
+
+    // Left behind by an interrupted run; the rename below would fail on it.
+    let _ = Fd::cwd().delete_tree(previous.slice());
+
+    match bun_sys::renameat(
+        Fd::cwd(),
+        node_modules.slice_z(),
+        Fd::cwd(),
+        previous.slice_z(),
+    ) {
+        Ok(()) => PreviousNodeModules::SetAside,
+        Err(err) if err.get_errno() == bun_sys::E::ENOENT => PreviousNodeModules::Nothing,
+        Err(_) => PreviousNodeModules::Shared,
     }
 }
 
@@ -529,16 +597,53 @@ impl<'a> LifecycleScriptSubprocess<'a> {
             (*this).current_script_index = next_script_index;
             (*this).has_called_process_exit = false;
 
-            let mut copy_script: Vec<u8> = Vec::with_capacity(original_script.len() + 1);
-            replace_package_manager_run(&mut copy_script, original_script)?;
-            copy_script.push(0);
+            let installing_dependencies = (*this).prepare_dependencies
+                == PrepareDependencies::Pending
+                && next_script_index as usize >= ScriptsList::FIRST_PREPARE_INDEX;
 
-            // SAFETY: we just pushed a NUL byte at copy_script[len-1]; slice [..len-1] is the body.
-            let combined_script: &mut ZStr =
-                ZStr::from_raw_mut(copy_script.as_mut_ptr(), copy_script.len() - 1);
+            // `[_]?[*:0]const u8` argv array with trailing null. Element type MUST be
+            // bare `*const c_char` (null sentinel), never `Option<*const c_char>` —
+            // raw pointers are already nullable, and `Option<*const T>` is a 2-word
+            // (tag, ptr) pair, not niche-optimized. Casting a `[Option<*const c_char>; N]`
+            // to `Argv` would interleave discriminant words and EFAULT in the kernel.
+            // Sized for the longer of the two argvs below (executable, the
+            // install arguments, null).
+            const ARGV_LEN: usize = INSTALL_DEPENDENCIES_ARGS.len() + 2;
+            let mut argv: [*const c_char; ARGV_LEN] = [core::ptr::null(); ARGV_LEN];
+            const _: () = assert!(
+                core::mem::size_of::<[*const c_char; ARGV_LEN]>()
+                    == ARGV_LEN * core::mem::size_of::<usize>()
+            );
+
+            // Owns the script bytes `argv` points into until the spawn below.
+            let mut copy_script: Vec<u8> = Vec::new();
+            let command_line: &[u8] = if installing_dependencies {
+                (*this).prepare_dependencies =
+                    PrepareDependencies::Installing(set_aside_node_modules(cwd));
+                argv[0] = bun_core::self_exe_path()?.as_ptr();
+                for (slot, arg) in argv[1..].iter_mut().zip(INSTALL_DEPENDENCIES_ARGS) {
+                    *slot = arg.as_ptr();
+                }
+                INSTALL_DEPENDENCIES_COMMAND_LINE
+            } else {
+                copy_script.reserve_exact(original_script.len() + 1);
+                replace_package_manager_run(&mut copy_script, original_script)?;
+                copy_script.push(0);
+                let combined_script: &ZStr = ZStr::from_slice_with_nul(&copy_script);
+
+                if (*this).shell_bin.is_some() && !cfg!(windows) {
+                    argv[0] = (*this).shell_bin.unwrap().as_ptr();
+                    argv[1] = c"-c".as_ptr();
+                } else {
+                    argv[0] = bun_core::self_exe_path()?.as_ptr();
+                    argv[1] = c"exec".as_ptr();
+                }
+                argv[2] = combined_script.as_ptr();
+                combined_script.as_bytes()
+            };
 
             if (*this).foreground && (*manager).options.log_level != crate::LogLevel::Silent {
-                Output::command(Output::CommandArgv::Single(combined_script.as_bytes()));
+                Output::command(Output::CommandArgv::Single(command_line));
             } else if let Some(scripts_node) = (*manager).scripts_node_mut() {
                 (*manager).set_node_name::<true>(
                     scripts_node,
@@ -558,32 +663,13 @@ impl<'a> LifecycleScriptSubprocess<'a> {
                 "{} - {} $ {}",
                 bstr::BStr::new(&(*this).package_name),
                 bstr::BStr::new((*this).script_name()),
-                bstr::BStr::new(combined_script.as_bytes())
+                bstr::BStr::new(command_line)
             );
 
-            // `[_]?[*:0]const u8` argv array with trailing null. Element type MUST be
-            // bare `*const c_char` (null sentinel), never `Option<*const c_char>` —
-            // raw pointers are already nullable, and `Option<*const T>` is a 2-word
-            // (tag, ptr) pair, not niche-optimized. Casting a `[Option<*const c_char>; N]`
-            // to `Argv` would interleave discriminant words and EFAULT in the kernel.
-            let mut argv: [*const c_char; 4] = if (*this).shell_bin.is_some() && !cfg!(windows) {
-                [
-                    (*this).shell_bin.unwrap().as_ptr().cast::<c_char>(),
-                    c"-c".as_ptr(),
-                    combined_script.as_ptr().cast::<c_char>(),
-                    core::ptr::null(),
-                ]
-            } else {
-                [
-                    bun_core::self_exe_path()?.as_ptr().cast::<c_char>(),
-                    c"exec".as_ptr(),
-                    combined_script.as_ptr().cast::<c_char>(),
-                    core::ptr::null(),
-                ]
+            let envp: *const *const c_char = match &(*this).install_envp {
+                Some(install_envp) if installing_dependencies => install_envp.as_ptr(),
+                _ => (*this).envp.as_ptr(),
             };
-            const _: () = assert!(
-                core::mem::size_of::<[*const c_char; 4]>() == 4 * core::mem::size_of::<usize>()
-            );
 
             // OWNERSHIP:
             // `bun_io::Source::Pipe` owns a `Box<uv::Pipe>` AND
@@ -663,10 +749,10 @@ impl<'a> LifecycleScriptSubprocess<'a> {
                 .insert(this.cast::<LifecycleScriptSubprocess<'static>>());
             let spawned = match bun_spawn::spawn_process(
                 &spawn_options,
-                // argv is `[*const c_char; 4]` with trailing null — exactly the
+                // argv is a `[*const c_char; N]` with trailing null — exactly the
                 // `[*:null]?[*:0]const u8` layout `spawn_process` expects (1 word/elt).
                 argv.as_mut_ptr().cast(),
-                (*this).envp.as_ptr().cast::<*const c_char>(),
+                envp,
             ) {
                 Ok(Ok(s)) => s,
                 res => {
@@ -857,16 +943,52 @@ impl<'a> LifecycleScriptSubprocess<'a> {
                         return;
                     }
                     self.print_output();
-                    bun_core::pretty_errorln!(
-                        "<r><red>error<r><d>:<r> <b>{}<r> script from \"<b>{}<r>\" exited with {}<r>",
-                        bstr::BStr::new(self.script_name()),
-                        bstr::BStr::new(&self.package_name),
-                        exit.code,
-                    );
+                    if matches!(
+                        self.prepare_dependencies,
+                        PrepareDependencies::Installing(_)
+                    ) {
+                        bun_core::pretty_errorln!(
+                            "<r><red>error<r><d>:<r> installing the dependencies of \"<b>{}<r>\" for its <b>{}<r> script failed <d>({} exited with {})<r>",
+                            bstr::BStr::new(&self.package_name),
+                            bstr::BStr::new(self.script_name()),
+                            bstr::BStr::new(INSTALL_DEPENDENCIES_COMMAND_LINE),
+                            exit.code,
+                        );
+                    } else {
+                        bun_core::pretty_errorln!(
+                            "<r><red>error<r><d>:<r> <b>{}<r> script from \"<b>{}<r>\" exited with {}<r>",
+                            bstr::BStr::new(self.script_name()),
+                            bstr::BStr::new(&self.package_name),
+                            exit.code,
+                        );
+                    }
+                    self.remove_prepare_dependencies();
                     // SAFETY: `self` was created by `Self::new` (heap::alloc); uniquely owned here.
                     unsafe { Self::destroy(std::ptr::from_mut::<Self>(self)) };
                     Output::flush();
                     Global::exit(exit.code as u32);
+                }
+
+                if let PrepareDependencies::Installing(previous) = self.prepare_dependencies {
+                    self.prepare_dependencies = PrepareDependencies::Installed(previous);
+                    let script_index = self.current_script_index;
+                    self.reset_polls();
+                    // SAFETY: `self` was created by `Self::new` (heap::alloc) and is
+                    // uniquely owned here; it is not touched again on the success
+                    // path before `return` (same contract as the loop below).
+                    if let Err(err) = unsafe {
+                        Self::spawn_next_script(std::ptr::from_mut::<Self>(self), script_index)
+                    } {
+                        Output::err_generic(
+                            "Failed to run script <b>{}<r> due to error <b>{}<r>",
+                            (
+                                bstr::BStr::new(LockfileScripts::NAMES[script_index as usize]),
+                                err.name(),
+                            ),
+                        );
+                        Global::exit(1);
+                    }
+                    return;
                 }
 
                 if !self.foreground
@@ -931,6 +1053,8 @@ impl<'a> LifecycleScriptSubprocess<'a> {
                         return;
                     }
                 }
+
+                self.remove_prepare_dependencies();
 
                 if PackageManager::verbose_install() {
                     bun_core::pretty_errorln!(
@@ -1076,10 +1200,57 @@ impl<'a> LifecycleScriptSubprocess<'a> {
         unsafe { Self::destroy(std::ptr::from_mut::<Self>(self)) };
     }
 
+    /// Undoes what the nested `bun install` did to `cwd/node_modules`. The
+    /// package's runtime dependencies live in the node_modules above it (or
+    /// next to it in the isolated store), so everything the nested install put
+    /// here would only shadow them with duplicate copies.
+    fn remove_prepare_dependencies(&mut self) {
+        let previous = match self.prepare_dependencies {
+            PrepareDependencies::Installing(previous)
+            | PrepareDependencies::Installed(previous) => previous,
+            PrepareDependencies::NotNeeded | PrepareDependencies::Pending => return,
+        };
+        self.prepare_dependencies = PrepareDependencies::NotNeeded;
+        if previous == PreviousNodeModules::Shared {
+            return;
+        }
+
+        let cwd = self.scripts.cwd.as_bytes();
+        let mut node_modules = AutoAbsPath::init();
+        let _ = node_modules.append(cwd);
+        let _ = node_modules.append(b"node_modules");
+        if let Err(err) = Fd::cwd().delete_tree(node_modules.slice()) {
+            bun_core::warn!(
+                "failed to remove the dependencies installed for the prepare scripts of \"{}\": {}",
+                bstr::BStr::new(&self.package_name),
+                err,
+            );
+        }
+
+        if previous == PreviousNodeModules::SetAside {
+            let mut set_aside = AutoAbsPath::init();
+            let _ = set_aside.append(cwd);
+            let _ = set_aside.append(PREVIOUS_NODE_MODULES_NAME);
+            if let Err(err) = bun_sys::renameat(
+                Fd::cwd(),
+                set_aside.slice_z(),
+                Fd::cwd(),
+                node_modules.slice_z(),
+            ) {
+                bun_core::warn!(
+                    "failed to restore the node_modules of \"{}\" after running its prepare scripts: {}",
+                    bstr::BStr::new(&self.package_name),
+                    err,
+                );
+            }
+        }
+    }
+
     pub(crate) fn spawn_package_scripts(
         manager: &mut PackageManager,
         list: ScriptsList,
         envp: bun_dotenv::NullDelimitedEnvMap,
+        install_envp: Option<bun_dotenv::NullDelimitedEnvMap>,
         shell_bin: Option<&'a ZStr>,
         optional: bool,
         log_level: crate::LogLevel,
@@ -1087,9 +1258,16 @@ impl<'a> LifecycleScriptSubprocess<'a> {
         ctx: Option<InstallCtx<'a>>,
     ) -> Result<(), crate::Error> {
         let package_name = list.package_name.clone();
+        let prepare_dependencies = if list.install_dependencies_for_prepare {
+            PrepareDependencies::Pending
+        } else {
+            PrepareDependencies::NotNeeded
+        };
         let lifecycle_subprocess = Self::new(LifecycleScriptSubprocess {
             manager: bun_ptr::BackRef::new_mut(manager),
             envp,
+            install_envp,
+            prepare_dependencies,
             shell_bin,
             package_name,
             scripts: list,

--- a/src/install/lifecycle_script_runner.rs
+++ b/src/install/lifecycle_script_runner.rs
@@ -1029,7 +1029,7 @@ impl<'a> LifecycleScriptSubprocess<'a> {
                     if let Err(err) = unsafe {
                         Self::spawn_next_script(std::ptr::from_mut::<Self>(self), script_index)
                     } {
-                        self.exit_after_spawn_failure(script_index, &err);
+                        self.exit_after_spawn_failure(script_index, err);
                     }
                     return;
                 }
@@ -1086,7 +1086,7 @@ impl<'a> LifecycleScriptSubprocess<'a> {
                         } {
                             self.exit_after_spawn_failure(
                                 u8::try_from(new_script_index).expect("int cast"),
-                                &err,
+                                err,
                             );
                         }
                         return;
@@ -1316,7 +1316,7 @@ impl<'a> LifecycleScriptSubprocess<'a> {
         if let Err(err) = unsafe { Self::spawn_next_script(lifecycle_subprocess, first_index) } {
             // SAFETY: `spawn_next_script` does not free the subprocess when it
             // fails; `lss` is a non-owning view that is not used again.
-            unsafe { (*lifecycle_subprocess).exit_after_spawn_failure(first_index, &err) }
+            unsafe { (*lifecycle_subprocess).exit_after_spawn_failure(first_index, err) }
         }
 
         Ok(())
@@ -1343,7 +1343,7 @@ impl<'a> LifecycleScriptSubprocess<'a> {
         }
     }
 
-    fn exit_after_spawn_failure(&mut self, script_index: u8, err: &crate::Error) -> ! {
+    fn exit_after_spawn_failure(&mut self, script_index: u8, err: crate::Error) -> ! {
         Output::err_generic(
             "Failed to run script <b>{}<r> due to error <b>{}<r>",
             (

--- a/src/install/lifecycle_script_runner.rs
+++ b/src/install/lifecycle_script_runner.rs
@@ -14,7 +14,7 @@ use bun_io::heap as io_heap;
 use bun_io::{FilePollFlag, PosixFlags};
 
 use bun_core::ZStr;
-use bun_paths::AutoAbsPath;
+use bun_paths::AutoAbsPathChecked;
 #[cfg(unix)]
 use bun_spawn::SpawnResultExt as _;
 use bun_spawn::{
@@ -270,8 +270,7 @@ pub struct LifecycleScriptSubprocess<'a> {
     /// struct so the `K=V\0` buffers stay alive across every async
     /// `spawn_next_script` for the script chain; freed by `Drop`/`destroy`.
     pub(crate) envp: bun_dotenv::NullDelimitedEnvMap,
-    /// Environment for the `bun install` of a git dependency's own
-    /// dependencies (`Some` iff `scripts.install_dependencies_for_prepare`).
+    /// `Some` iff `scripts.install_dependencies_for_prepare`.
     pub(crate) install_envp: Option<bun_dotenv::NullDelimitedEnvMap>,
     pub(crate) prepare_dependencies: PrepareDependencies,
     pub(crate) shell_bin: Option<&'a ZStr>,
@@ -311,85 +310,84 @@ impl<'a> InstallCtx<'a> {
     }
 }
 
-/// Where a git dependency is in getting its own dependencies installed for
-/// its `prepare` scripts (see `List::install_dependencies_for_prepare`).
+/// See `List::install_dependencies_for_prepare`.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(crate) enum PrepareDependencies {
     NotNeeded,
-    /// `bun install` still has to run before the first prepare script.
     Pending,
-    /// The running subprocess is `bun install`; `current_script_index` is the
-    /// prepare script that runs once it succeeds.
+    /// `bun install` is running; `current_script_index` is the script that follows it.
     Installing(NestedInstallCleanup),
-    /// `bun install` succeeded. The cleanup runs once the scripts are done
-    /// (or one of them failed).
+    /// Cleaned up once the scripts are done or one of them failed.
     Installed(NestedInstallCleanup),
 }
 
-/// While the nested `bun install` and the prepare scripts run, this directory
-/// inside the package holds the package's previous `node_modules` (with the
-/// hoisted linker: the dependencies whose versions conflict with the ones
-/// hoisted above it; or one committed to the repository), or is empty if there
-/// was none. It exists for exactly that duration, so finding it at the start
-/// means an earlier run was interrupted: it still holds the original, and the
-/// package's `node_modules` is whatever that run left behind.
+/// Holds the package's own `node_modules` (or is empty) while the nested install
+/// and the prepare scripts run. Already existing at the start means an earlier
+/// run was interrupted: it has the original and `node_modules` is that run's leftovers.
 const PREVIOUS_NODE_MODULES_NAME: &[u8] = b".bun-prepare-node_modules";
 
-/// Arguments of the `bun` spawned for `PrepareDependencies::Installing`.
-/// `--ignore-scripts` because the package's own lifecycle scripts are what this
-/// runner is in the middle of executing; `--no-save` so the package.json and a
-/// committed lockfile stay as they are.
+/// `--ignore-scripts`: this runner is already running the package's scripts.
+/// `--no-save`: leave the package.json and a committed lockfile alone.
 const INSTALL_DEPENDENCIES_ARGS: [&core::ffi::CStr; 3] =
     [c"install", c"--ignore-scripts", c"--no-save"];
-/// `INSTALL_DEPENDENCIES_ARGS` as shown in logs and error messages.
 const INSTALL_DEPENDENCIES_COMMAND_LINE: &[u8] = b"bun install --ignore-scripts --no-save";
 
-/// What the nested `bun install` leaves in the package directory that has to
-/// go again. The package's runtime dependencies live in the node_modules above
-/// it (or next to it in the isolated store), so everything the nested install
-/// puts here would only shadow them with duplicate copies.
+/// What to undo in the package directory after the nested install. Its runtime
+/// dependencies are installed outside the package, so everything left inside would
+/// only shadow them.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(crate) struct NestedInstallCleanup {
-    /// The previous `node_modules` is in [`PREVIOUS_NODE_MODULES_NAME`]. When
-    /// it could not be moved there, the nested install shares it and it is
-    /// left alone afterwards.
+    /// False when the previous `node_modules` could not be moved out of the way.
     restore_node_modules: bool,
-    /// The checkout had no `bun.lock`. `--no-save` keeps the nested install
-    /// from writing one, except that a `package-lock.json`/`yarn.lock`/... it
-    /// migrates is always saved (`saves_migrated_lockfile`).
+    /// `--no-save` still writes `bun.lock` when it migrates a `package-lock.json`
+    /// (`saves_migrated_lockfile`).
     remove_lockfile: bool,
 }
 
-fn path_in_package(cwd: &[u8], name: &[u8]) -> AutoAbsPath {
-    let mut path = AutoAbsPath::init();
-    let _ = path.append(cwd);
-    let _ = path.append(name);
-    path
+fn path_in_package(cwd: &[u8], name: &[u8]) -> bun_sys::Result<AutoAbsPathChecked> {
+    let mut path = AutoAbsPathChecked::init();
+    if path.append(cwd).is_err() || path.append(name).is_err() {
+        return Err(
+            bun_sys::Error::from_code(bun_sys::E::ENAMETOOLONG, bun_sys::Tag::rename)
+                .with_path(name),
+        );
+    }
+    Ok(path)
+}
+
+fn set_aside_node_modules(cwd: &[u8]) -> bun_sys::Result<()> {
+    let mut node_modules = path_in_package(cwd, b"node_modules")?;
+    let mut previous = path_in_package(cwd, PREVIOUS_NODE_MODULES_NAME)?;
+    if bun_sys::exists(previous.slice()) {
+        return Fd::cwd().delete_tree(node_modules.slice());
+    }
+    match bun_sys::renameat(
+        Fd::cwd(),
+        node_modules.slice_z(),
+        Fd::cwd(),
+        previous.slice_z(),
+    ) {
+        Err(err) if err.get_errno() == bun_sys::E::ENOENT => {
+            bun_sys::mkdir(previous.slice_z(), 0o755)
+        }
+        result => result,
+    }
 }
 
 impl NestedInstallCleanup {
-    /// Gets the package directory ready for the nested install and records
-    /// what to undo afterwards.
-    fn begin(cwd: &[u8]) -> Self {
-        let remove_lockfile = !bun_sys::exists(path_in_package(cwd, b"bun.lock").slice());
+    fn begin(cwd: &[u8], package_name: &[u8]) -> Self {
+        let remove_lockfile = path_in_package(cwd, b"bun.lock")
+            .is_ok_and(|lockfile| !bun_sys::exists(lockfile.slice()));
 
-        let mut node_modules = path_in_package(cwd, b"node_modules");
-        let mut previous = path_in_package(cwd, PREVIOUS_NODE_MODULES_NAME);
-        let restore_node_modules = if bun_sys::exists(previous.slice()) {
-            let _ = Fd::cwd().delete_tree(node_modules.slice());
-            true
-        } else {
-            match bun_sys::renameat(
-                Fd::cwd(),
-                node_modules.slice_z(),
-                Fd::cwd(),
-                previous.slice_z(),
-            ) {
-                Ok(()) => true,
-                Err(err) if err.get_errno() == bun_sys::E::ENOENT => {
-                    bun_sys::mkdir(previous.slice_z(), 0o755).is_ok()
-                }
-                Err(_) => false,
+        let restore_node_modules = match set_aside_node_modules(cwd) {
+            Ok(()) => true,
+            Err(err) => {
+                bun_core::warn!(
+                    "failed to set aside the node_modules of \"{}\" ({}); the dependencies installed for its prepare scripts will be left in it",
+                    bstr::BStr::new(package_name),
+                    err,
+                );
+                false
             }
         };
 
@@ -400,15 +398,23 @@ impl NestedInstallCleanup {
     }
 
     fn finish(self, cwd: &[u8], package_name: &[u8]) {
-        if self.remove_lockfile {
-            let _ = Fd::cwd().delete_tree(path_in_package(cwd, b"bun.lock").slice());
+        if self.remove_lockfile
+            && let Ok(lockfile) = path_in_package(cwd, b"bun.lock")
+        {
+            let _ = Fd::cwd().delete_tree(lockfile.slice());
         }
 
         if !self.restore_node_modules {
             return;
         }
+        // Both paths were built by `set_aside_node_modules` already.
+        let (Ok(mut node_modules), Ok(mut previous)) = (
+            path_in_package(cwd, b"node_modules"),
+            path_in_package(cwd, PREVIOUS_NODE_MODULES_NAME),
+        ) else {
+            return;
+        };
 
-        let mut node_modules = path_in_package(cwd, b"node_modules");
         if let Err(err) = Fd::cwd().delete_tree(node_modules.slice()) {
             bun_core::warn!(
                 "failed to remove the dependencies installed for the prepare scripts of \"{}\": {}",
@@ -417,7 +423,6 @@ impl NestedInstallCleanup {
             );
         }
 
-        let mut previous = path_in_package(cwd, PREVIOUS_NODE_MODULES_NAME);
         if let Err(err) = bun_sys::renameat(
             Fd::cwd(),
             previous.slice_z(),
@@ -431,8 +436,7 @@ impl NestedInstallCleanup {
             );
             return;
         }
-        // Only succeeds for the empty placeholder `begin` created when the
-        // package had no node_modules of its own.
+        // Removes the empty placeholder from `set_aside_node_modules`; fails on a real one.
         let _ = bun_sys::rmdir(node_modules.slice_z());
     }
 }
@@ -668,8 +672,7 @@ impl<'a> LifecycleScriptSubprocess<'a> {
             // raw pointers are already nullable, and `Option<*const T>` is a 2-word
             // (tag, ptr) pair, not niche-optimized. Casting a `[Option<*const c_char>; N]`
             // to `Argv` would interleave discriminant words and EFAULT in the kernel.
-            // Sized for the longer of the two argvs below (executable, the
-            // install arguments, null).
+            // Sized for the longer of the two argvs built below.
             const ARGV_LEN: usize = INSTALL_DEPENDENCIES_ARGS.len() + 2;
             let mut argv: [*const c_char; ARGV_LEN] = [core::ptr::null(); ARGV_LEN];
             const _: () = assert!(
@@ -680,8 +683,9 @@ impl<'a> LifecycleScriptSubprocess<'a> {
             // Owns the script bytes `argv` points into until the spawn below.
             let mut copy_script: Vec<u8> = Vec::new();
             let command_line: &[u8] = if installing_dependencies {
-                (*this).prepare_dependencies =
-                    PrepareDependencies::Installing(NestedInstallCleanup::begin(cwd));
+                (*this).prepare_dependencies = PrepareDependencies::Installing(
+                    NestedInstallCleanup::begin(cwd, &(*this).package_name),
+                );
                 argv[0] = bun_core::self_exe_path()?.as_ptr();
                 for (slot, arg) in argv[1..].iter_mut().zip(INSTALL_DEPENDENCIES_ARGS) {
                     *slot = arg.as_ptr();
@@ -1317,9 +1321,7 @@ impl<'a> LifecycleScriptSubprocess<'a> {
         Ok(())
     }
 
-    /// The start of every failure message: `error: <what was running>`, which
-    /// is either one of the package's scripts or the `bun install` that
-    /// fetches a git dependency's own dependencies for its prepare scripts.
+    /// `error: <what was running>`; the caller appends how it ended.
     fn print_failure_subject(&self) {
         if matches!(
             self.prepare_dependencies,

--- a/src/install/lifecycle_script_runner.rs
+++ b/src/install/lifecycle_script_runner.rs
@@ -367,8 +367,10 @@ fn set_aside_node_modules(cwd: &[u8]) -> bun_sys::Result<()> {
         Fd::cwd(),
         previous.slice_z(),
     ) {
+        // `mkdirat` (like `renameat`) takes the long-path route on Windows;
+        // `mkdir` goes through libuv and stops at MAX_PATH.
         Err(err) if err.get_errno() == bun_sys::E::ENOENT => {
-            bun_sys::mkdir(previous.slice_z(), 0o755)
+            bun_sys::mkdirat(Fd::cwd(), previous.slice_z(), 0o755)
         }
         result => result,
     }

--- a/src/install/lockfile/Package/Scripts.rs
+++ b/src/install/lockfile/Package/Scripts.rs
@@ -235,6 +235,12 @@ impl Scripts {
                 }
             };
 
+            let install_dependencies_for_prepare =
+                matches!(resolution_tag, ResolutionTag::Git | ResolutionTag::Github)
+                    && scripts[List::FIRST_PREPARE_INDEX..]
+                        .iter()
+                        .any(|script| script.is_some());
+
             return Some(List {
                 items: scripts,
                 first_index: u8::try_from(first_index).expect("int cast"),
@@ -242,6 +248,7 @@ impl Scripts {
                 // Owned NUL-terminated copy.
                 cwd: ZBox::from_bytes(cwd),
                 package_name: Box::<[u8]>::from(package_name),
+                install_dependencies_for_prepare,
             });
         }
 
@@ -417,9 +424,19 @@ pub struct List {
     // Owned NUL-terminated heap string, not a borrow.
     pub(crate) cwd: ZBox,
     pub(crate) package_name: Box<[u8]>,
+    /// A git dependency is installed straight from its checkout, so the build
+    /// tools its `prepare` scripts need (usually `devDependencies`) are not
+    /// installed anywhere. When set, the script runner runs `bun install`
+    /// inside `cwd` before the first `(pre|post)prepare` script and removes
+    /// the resulting `node_modules` once the scripts are done, like npm does
+    /// for git dependencies.
+    pub(crate) install_dependencies_for_prepare: bool,
 }
 
 impl List {
+    /// Index of `preprepare` in `items`; `prepare` and `postprepare` follow it.
+    pub(crate) const FIRST_PREPARE_INDEX: usize = 3;
+
     pub fn print_scripts(
         &self,
         resolution: &Resolution,

--- a/src/install/lockfile/Package/Scripts.rs
+++ b/src/install/lockfile/Package/Scripts.rs
@@ -424,14 +424,15 @@ pub struct List {
     // Owned NUL-terminated heap string, not a borrow.
     pub(crate) cwd: ZBox,
     pub(crate) package_name: Box<[u8]>,
-    /// A git dependency is installed straight from its checkout, so the build
-    /// tools its `prepare` scripts need (usually `devDependencies`) are not
-    /// installed anywhere. When set, the script runner runs `bun install`
-    /// inside `cwd` before the first `(pre|post)prepare` script and removes
-    /// the resulting `node_modules` once the scripts are done, like npm does
-    /// for git dependencies.
+    /// Git dependency with prepare scripts: nothing installs the devDependencies
+    /// those build with, so the runner runs `bun install` in `cwd` first (like npm).
     pub(crate) install_dependencies_for_prepare: bool,
 }
+
+const _: () = assert!(matches!(
+    LockfileScripts::NAMES[List::FIRST_PREPARE_INDEX].as_bytes(),
+    b"preprepare"
+));
 
 impl List {
     /// Index of `preprepare` in `items`; `prepare` and `postprepare` follow it.

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -90,6 +90,41 @@ async function setupTest(): Promise<TestCtx> {
   }
 }
 
+/**
+ * Commits `packageJson` to a fresh repository at `<packageDir>/<name>-repo` and returns a
+ * `git+file://` dependency spec for it.
+ */
+async function createGitDependency(
+  packageDir: string,
+  packageJson: { name: string } & Record<string, unknown>,
+): Promise<string> {
+  const repoDir = join(packageDir, `${packageJson.name}-repo`);
+  const emptyGitConfig = join(packageDir, "empty.gitconfig");
+  await Promise.all([mkdir(repoDir, { recursive: true }), writeFile(emptyGitConfig, "")]);
+  await writeFile(join(repoDir, "package.json"), JSON.stringify(packageJson));
+
+  const gitEnv = {
+    ...baseEnv,
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_CONFIG_GLOBAL: emptyGitConfig,
+    GIT_AUTHOR_NAME: "bun",
+    GIT_AUTHOR_EMAIL: "bun@example.com",
+    GIT_COMMITTER_NAME: "bun",
+    GIT_COMMITTER_EMAIL: "bun@example.com",
+  };
+  for (const args of [
+    ["init", "-q"],
+    ["add", "."],
+    ["commit", "-q", "-m", "init", "--no-gpg-sign"],
+  ]) {
+    await using proc = spawn({ cmd: ["git", ...args], cwd: repoDir, env: gitEnv, stdout: "ignore", stderr: "pipe" });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    if (exitCode !== 0) throw new Error(`git ${args.join(" ")} failed:\n${stderr}`);
+  }
+
+  return `git+${Bun.pathToFileURL(repoDir).href}`;
+}
+
 // The six multi-install tests below are the longest in the file (2-3 serial `bun install`s
 // each, some with cold caches). Declare them first so they start before the ~110 shorter
 // tests and overlap with them instead of forming a serial tail at the end of the run.
@@ -2039,6 +2074,217 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       expect(await exists(join(packageDir, "node_modules", "lifecycle-install-test", "preinstall.txt"))).toBeTrue();
       expect(await exists(join(packageDir, "node_modules", "lifecycle-install-test", "install.txt"))).toBeTrue();
       expect(await exists(join(packageDir, "node_modules", "lifecycle-install-test", "postinstall.txt"))).toBeTrue();
+    });
+
+    // A git dependency is installed from its checkout, so whatever its `prepare` script builds
+    // with (its devDependencies) has to be installed before the script runs, the way npm does
+    // it. https://github.com/oven-sh/bun/issues/10297
+    describe("git dependency with a prepare script that needs its devDependencies", () => {
+      // `what-bin` writes `what-bin.txt` (containing its own version) into the cwd it runs in.
+      const gitDependency = {
+        name: "needs-dev-deps-to-prepare",
+        version: "1.0.0",
+        devDependencies: { "what-bin": "1.0.0" },
+        scripts: { prepare: "what-bin" },
+      };
+
+      async function installedState(packageDir: string, name: string) {
+        const depDir = join(packageDir, "node_modules", name);
+        return {
+          prepareOutput: (await exists(join(depDir, "what-bin.txt")))
+            ? await file(join(depDir, "what-bin.txt")).text()
+            : null,
+          depDirEntries: (await readdirSorted(depDir)).filter(entry => entry !== ".bun-tag"),
+          hoistedDevDependency: await exists(join(packageDir, "node_modules", "what-bin")),
+          lockfileMentionsDevDependency: (await file(join(packageDir, "bun.lock")).text()).includes("what-bin"),
+        };
+      }
+
+      for (const linker of ["hoisted", "isolated"] as const) {
+        test(`${linker} linker: installs them for the prepare script and removes them afterwards`, async () => {
+          using ctx = await setupTest();
+          const { packageDir, packageJson, env } = ctx;
+          const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
+          await verdaccio.writeBunfig(packageDir, { linker });
+
+          const spec = await createGitDependency(packageDir, gitDependency);
+          await writeFile(
+            packageJson,
+            JSON.stringify({
+              name: "foo",
+              version: "1.0.0",
+              dependencies: { [gitDependency.name]: spec },
+              trustedDependencies: [gitDependency.name],
+            }),
+          );
+
+          await using proc = spawn({
+            cmd: [bunExe(), "install"],
+            cwd: packageDir,
+            stdout: "pipe",
+            stdin: "ignore",
+            stderr: "pipe",
+            env: testEnv,
+          });
+          const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+          expect(err).not.toContain("error:");
+          expect(err).not.toContain("warn:");
+          expect(out).toContain(`+ ${gitDependency.name}@git+file://`);
+          expect(exitCode).toBe(0);
+
+          expect(await installedState(packageDir, gitDependency.name)).toEqual({
+            prepareOutput: "what-bin@1.0.0",
+            // no `node_modules` from the nested install, and no `bun.lock` written into the checkout
+            depDirEntries: ["package.json", "what-bin.txt"],
+            hoistedDevDependency: false,
+            lockfileMentionsDevDependency: false,
+          });
+        });
+      }
+
+      test("the dependencies bun already nested under the package survive", async () => {
+        using ctx = await setupTest();
+        const { packageDir, packageJson, env } = ctx;
+        const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
+
+        // The project hoists what-bin@1.5.0, so the git dependency's own what-bin@1.0.0 is installed
+        // under node_modules/<name>/node_modules, which is exactly where the nested install writes.
+        const spec = await createGitDependency(packageDir, {
+          name: "has-nested-deps",
+          version: "1.0.0",
+          dependencies: { "what-bin": "1.0.0" },
+          devDependencies: { "no-deps": "1.0.0" },
+          scripts: { prepare: "what-bin" },
+        });
+        await writeFile(
+          packageJson,
+          JSON.stringify({
+            name: "foo",
+            version: "1.0.0",
+            dependencies: { "what-bin": "1.5.0", "has-nested-deps": spec },
+            trustedDependencies: ["has-nested-deps"],
+          }),
+        );
+
+        await using proc = spawn({
+          cmd: [bunExe(), "install"],
+          cwd: packageDir,
+          stdout: "pipe",
+          stdin: "ignore",
+          stderr: "pipe",
+          env: testEnv,
+        });
+        const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+        expect(err).not.toContain("error:");
+        expect(err).not.toContain("warn:");
+        expect(exitCode).toBe(0);
+
+        const depDir = join(packageDir, "node_modules", "has-nested-deps");
+        const nestedVersion = async (dir: string) =>
+          (await file(join(dir, "node_modules", "what-bin", "package.json")).json()).version;
+        expect({
+          prepareOutput: await file(join(depDir, "what-bin.txt")).text(),
+          hoistedWhatBin: await nestedVersion(packageDir),
+          nestedWhatBin: await nestedVersion(depDir),
+          nestedDevDependency: await exists(join(depDir, "node_modules", "no-deps")),
+          depDirEntries: (await readdirSorted(depDir)).filter(entry => entry !== ".bun-tag"),
+        }).toEqual({
+          prepareOutput: "what-bin@1.0.0",
+          hoistedWhatBin: "1.5.0",
+          nestedWhatBin: "1.0.0",
+          nestedDevDependency: false,
+          depDirEntries: ["node_modules", "package.json", "what-bin.txt"],
+        });
+      });
+
+      test("`bun pm trust` installs them too", async () => {
+        using ctx = await setupTest();
+        const { packageDir, packageJson, env } = ctx;
+        const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
+
+        const spec = await createGitDependency(packageDir, gitDependency);
+        await writeFile(
+          packageJson,
+          JSON.stringify({ name: "foo", version: "1.0.0", dependencies: { [gitDependency.name]: spec } }),
+        );
+
+        {
+          await using proc = spawn({
+            cmd: [bunExe(), "install"],
+            cwd: packageDir,
+            stdout: "pipe",
+            stdin: "ignore",
+            stderr: "pipe",
+            env: testEnv,
+          });
+          const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          expect(err).not.toContain("error:");
+          expect(out).toContain("Blocked 1 postinstall");
+          expect(exitCode).toBe(0);
+          expect((await installedState(packageDir, gitDependency.name)).prepareOutput).toBeNull();
+        }
+
+        await using proc = spawn({
+          cmd: [bunExe(), "pm", "trust", gitDependency.name],
+          cwd: packageDir,
+          stdout: "pipe",
+          stdin: "ignore",
+          stderr: "pipe",
+          env: testEnv,
+        });
+        const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(err).not.toContain("error:");
+        expect(out).toContain("1 script ran across 1 package");
+        expect(exitCode).toBe(0);
+
+        expect(await installedState(packageDir, gitDependency.name)).toEqual({
+          prepareOutput: "what-bin@1.0.0",
+          depDirEntries: ["package.json", "what-bin.txt"],
+          hoistedDevDependency: false,
+          lockfileMentionsDevDependency: false,
+        });
+      });
+
+      test("a failing dependency install fails the install and says why", async () => {
+        using ctx = await setupTest();
+        const { packageDir, packageJson, env } = ctx;
+        const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
+
+        const spec = await createGitDependency(packageDir, {
+          ...gitDependency,
+          name: "dev-dep-does-not-exist",
+          devDependencies: { "this-package-does-not-exist": "1.0.0" },
+        });
+        await writeFile(
+          packageJson,
+          JSON.stringify({
+            name: "foo",
+            version: "1.0.0",
+            dependencies: { "dev-dep-does-not-exist": spec },
+            trustedDependencies: ["dev-dep-does-not-exist"],
+          }),
+        );
+
+        await using proc = spawn({
+          cmd: [bunExe(), "install"],
+          cwd: packageDir,
+          stdout: "pipe",
+          stdin: "ignore",
+          stderr: "pipe",
+          env: testEnv,
+        });
+        const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+        // the nested install's own output comes first, then bun's summary of what it was doing
+        expect(err).toContain("this-package-does-not-exist");
+        expect(err).toContain(
+          'installing the dependencies of "dev-dep-does-not-exist" for its prepare script failed (bun install --ignore-scripts --no-save exited with 1)',
+        );
+        expect(exitCode).toBe(1);
+
+        const depDir = join(packageDir, "node_modules", "dev-dep-does-not-exist");
+        expect((await readdirSorted(depDir)).filter(entry => entry !== ".bun-tag")).toEqual(["package.json"]);
+      });
     });
 
     test("root lifecycle scripts should wait for dependency lifecycle scripts", async () => {

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -2128,54 +2128,46 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       }
 
       for (const linker of ["hoisted", "isolated"] as const) {
-        // On Windows the isolated store path of a git dependency embeds the whole repository URL
-        // (here: a temp dir path) plus the commit, which puts the package past MAX_PATH, and every
-        // lifecycle script of such a package then fails to spawn with ENOENT, with or without this
-        // feature. That is a separate isolated-linker bug; `pm trust` and the tests below still
-        // cover the nested install on Windows through the hoisted linker.
-        test.skipIf(isWindows && linker === "isolated")(
-          `${linker} linker: installs them for the prepare script and removes them afterwards`,
-          async () => {
-            using ctx = await setupTest();
-            const { packageDir, packageJson, env } = ctx;
-            const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
-            await verdaccio.writeBunfig(packageDir, { linker });
+        test(`${linker} linker: installs them for the prepare script and removes them afterwards`, async () => {
+          using ctx = await setupTest();
+          const { packageDir, packageJson, env } = ctx;
+          const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
+          await verdaccio.writeBunfig(packageDir, { linker });
 
-            const spec = await createGitDependency(packageDir, gitDependency, { files: gitDependencyFiles });
-            await writeFile(
-              packageJson,
-              JSON.stringify({
-                name: "foo",
-                version: "1.0.0",
-                dependencies: { [gitDependency.name]: spec },
-                trustedDependencies: [gitDependency.name],
-              }),
-            );
+          const spec = await createGitDependency(packageDir, gitDependency, { files: gitDependencyFiles });
+          await writeFile(
+            packageJson,
+            JSON.stringify({
+              name: "foo",
+              version: "1.0.0",
+              dependencies: { [gitDependency.name]: spec },
+              trustedDependencies: [gitDependency.name],
+            }),
+          );
 
-            await using proc = spawn({
-              cmd: [bunExe(), "install"],
-              cwd: packageDir,
-              stdout: "pipe",
-              stdin: "ignore",
-              stderr: "pipe",
-              env: testEnv,
-            });
-            const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          await using proc = spawn({
+            cmd: [bunExe(), "install"],
+            cwd: packageDir,
+            stdout: "pipe",
+            stdin: "ignore",
+            stderr: "pipe",
+            env: testEnv,
+          });
+          const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-            expect(err).not.toContain("error:");
-            expect(err).not.toContain("warn:");
-            expect(out).toContain(`+ ${gitDependency.name}@git+file://`);
-            expect(exitCode).toBe(0);
+          expect(err).not.toContain("error:");
+          expect(err).not.toContain("warn:");
+          expect(out).toContain(`+ ${gitDependency.name}@git+file://`);
+          expect(exitCode).toBe(0);
 
-            expect(await installedState(packageDir, gitDependency.name)).toEqual({
-              prepareOutput: "what-bin@1.0.0",
-              // neither the nested install's `node_modules` nor the `bun.lock` it migrated are left behind
-              depDirEntries: preparedDepDirEntries,
-              hoistedDevDependency: false,
-              lockfileMentionsDevDependency: false,
-            });
-          },
-        );
+          expect(await installedState(packageDir, gitDependency.name)).toEqual({
+            prepareOutput: "what-bin@1.0.0",
+            // neither the nested install's `node_modules` nor the `bun.lock` it migrated are left behind
+            depDirEntries: preparedDepDirEntries,
+            hoistedDevDependency: false,
+            lockfileMentionsDevDependency: false,
+          });
+        });
       }
 
       test("the dependencies bun already nested under the package survive", async () => {

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -91,17 +91,25 @@ async function setupTest(): Promise<TestCtx> {
 }
 
 /**
- * Commits `packageJson` to a fresh repository at `<packageDir>/<name>-repo` and returns a
- * `git+file://` dependency spec for it.
+ * Commits `packageJson` (plus `files`, plus whatever `beforeCommit` adds) to a fresh repository at
+ * `<packageDir>/<name>-repo` and returns a `git+file://` dependency spec for it.
  */
 async function createGitDependency(
   packageDir: string,
   packageJson: { name: string } & Record<string, unknown>,
+  {
+    files = {},
+    beforeCommit,
+  }: { files?: Record<string, string>; beforeCommit?: (repoDir: string) => Promise<void> } = {},
 ): Promise<string> {
   const repoDir = join(packageDir, `${packageJson.name}-repo`);
   const emptyGitConfig = join(packageDir, "empty.gitconfig");
   await Promise.all([mkdir(repoDir, { recursive: true }), writeFile(emptyGitConfig, "")]);
-  await writeFile(join(repoDir, "package.json"), JSON.stringify(packageJson));
+  await Promise.all([
+    writeFile(join(repoDir, "package.json"), JSON.stringify(packageJson)),
+    ...Object.entries(files).map(([name, contents]) => writeFile(join(repoDir, name), contents)),
+  ]);
+  await beforeCommit?.(repoDir);
 
   const gitEnv = {
     ...baseEnv,
@@ -2087,6 +2095,25 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         devDependencies: { "what-bin": "1.0.0" },
         scripts: { prepare: "what-bin" },
       };
+      // Like most repositories, this one ships an npm lockfile. The nested install migrates it,
+      // and a migrated lockfile is the one case where bun writes `bun.lock` despite `--no-save`.
+      const gitDependencyFiles = {
+        "package-lock.json": JSON.stringify({
+          name: gitDependency.name,
+          version: gitDependency.version,
+          lockfileVersion: 3,
+          requires: true,
+          packages: {
+            "": {
+              name: gitDependency.name,
+              version: gitDependency.version,
+              devDependencies: gitDependency.devDependencies,
+            },
+            "node_modules/what-bin": { version: "1.0.0", dev: true, bin: { "what-bin": "what-bin.js" } },
+          },
+        }),
+      };
+      const preparedDepDirEntries = ["package-lock.json", "package.json", "what-bin.txt"];
 
       async function installedState(packageDir: string, name: string) {
         const depDir = join(packageDir, "node_modules", name);
@@ -2101,46 +2128,54 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       }
 
       for (const linker of ["hoisted", "isolated"] as const) {
-        test(`${linker} linker: installs them for the prepare script and removes them afterwards`, async () => {
-          using ctx = await setupTest();
-          const { packageDir, packageJson, env } = ctx;
-          const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
-          await verdaccio.writeBunfig(packageDir, { linker });
+        // On Windows the isolated store path of a git dependency embeds the whole repository URL
+        // (here: a temp dir path) plus the commit, which puts the package past MAX_PATH, and every
+        // lifecycle script of such a package then fails to spawn with ENOENT, with or without this
+        // feature. That is a separate isolated-linker bug; `pm trust` and the tests below still
+        // cover the nested install on Windows through the hoisted linker.
+        test.skipIf(isWindows && linker === "isolated")(
+          `${linker} linker: installs them for the prepare script and removes them afterwards`,
+          async () => {
+            using ctx = await setupTest();
+            const { packageDir, packageJson, env } = ctx;
+            const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
+            await verdaccio.writeBunfig(packageDir, { linker });
 
-          const spec = await createGitDependency(packageDir, gitDependency);
-          await writeFile(
-            packageJson,
-            JSON.stringify({
-              name: "foo",
-              version: "1.0.0",
-              dependencies: { [gitDependency.name]: spec },
-              trustedDependencies: [gitDependency.name],
-            }),
-          );
+            const spec = await createGitDependency(packageDir, gitDependency, { files: gitDependencyFiles });
+            await writeFile(
+              packageJson,
+              JSON.stringify({
+                name: "foo",
+                version: "1.0.0",
+                dependencies: { [gitDependency.name]: spec },
+                trustedDependencies: [gitDependency.name],
+              }),
+            );
 
-          await using proc = spawn({
-            cmd: [bunExe(), "install"],
-            cwd: packageDir,
-            stdout: "pipe",
-            stdin: "ignore",
-            stderr: "pipe",
-            env: testEnv,
-          });
-          const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+            await using proc = spawn({
+              cmd: [bunExe(), "install"],
+              cwd: packageDir,
+              stdout: "pipe",
+              stdin: "ignore",
+              stderr: "pipe",
+              env: testEnv,
+            });
+            const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-          expect(err).not.toContain("error:");
-          expect(err).not.toContain("warn:");
-          expect(out).toContain(`+ ${gitDependency.name}@git+file://`);
-          expect(exitCode).toBe(0);
+            expect(err).not.toContain("error:");
+            expect(err).not.toContain("warn:");
+            expect(out).toContain(`+ ${gitDependency.name}@git+file://`);
+            expect(exitCode).toBe(0);
 
-          expect(await installedState(packageDir, gitDependency.name)).toEqual({
-            prepareOutput: "what-bin@1.0.0",
-            // no `node_modules` from the nested install, and no `bun.lock` written into the checkout
-            depDirEntries: ["package.json", "what-bin.txt"],
-            hoistedDevDependency: false,
-            lockfileMentionsDevDependency: false,
-          });
-        });
+            expect(await installedState(packageDir, gitDependency.name)).toEqual({
+              prepareOutput: "what-bin@1.0.0",
+              // neither the nested install's `node_modules` nor the `bun.lock` it migrated are left behind
+              depDirEntries: preparedDepDirEntries,
+              hoistedDevDependency: false,
+              lockfileMentionsDevDependency: false,
+            });
+          },
+        );
       }
 
       test("the dependencies bun already nested under the package survive", async () => {
@@ -2150,13 +2185,35 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
 
         // The project hoists what-bin@1.5.0, so the git dependency's own what-bin@1.0.0 is installed
         // under node_modules/<name>/node_modules, which is exactly where the nested install writes.
-        const spec = await createGitDependency(packageDir, {
-          name: "has-nested-deps",
-          version: "1.0.0",
-          dependencies: { "what-bin": "1.0.0" },
-          devDependencies: { "no-deps": "1.0.0" },
-          scripts: { prepare: "what-bin" },
-        });
+        // This repository also commits a `bun.lock`, which the nested install must leave alone.
+        let committedLockfile = "";
+        const spec = await createGitDependency(
+          packageDir,
+          {
+            name: "has-nested-deps",
+            version: "1.0.0",
+            dependencies: { "what-bin": "1.0.0" },
+            devDependencies: { "no-deps": "1.0.0" },
+            scripts: { prepare: "what-bin" },
+          },
+          {
+            async beforeCommit(repoDir) {
+              await using proc = spawn({
+                cmd: [bunExe(), "install", "--lockfile-only"],
+                cwd: repoDir,
+                stdout: "ignore",
+                stdin: "ignore",
+                stderr: "pipe",
+                env: { ...testEnv, BUN_CONFIG_REGISTRY: verdaccio.registryUrl() },
+              });
+              const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+              expect(err).not.toContain("error:");
+              expect(exitCode).toBe(0);
+              committedLockfile = await file(join(repoDir, "bun.lock")).text();
+              expect(committedLockfile).toContain("no-deps");
+            },
+          },
+        );
         await writeFile(
           packageJson,
           JSON.stringify({
@@ -2170,7 +2227,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         await using proc = spawn({
           cmd: [bunExe(), "install"],
           cwd: packageDir,
-          stdout: "pipe",
+          stdout: "ignore",
           stdin: "ignore",
           stderr: "pipe",
           env: testEnv,
@@ -2189,12 +2246,14 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
           nestedWhatBin: await nestedVersion(depDir),
           nestedDevDependency: await exists(join(depDir, "node_modules", "no-deps")),
           depDirEntries: (await readdirSorted(depDir)).filter(entry => entry !== ".bun-tag"),
+          lockfileUnchanged: (await file(join(depDir, "bun.lock")).text()) === committedLockfile,
         }).toEqual({
           prepareOutput: "what-bin@1.0.0",
           hoistedWhatBin: "1.5.0",
           nestedWhatBin: "1.0.0",
           nestedDevDependency: false,
-          depDirEntries: ["node_modules", "package.json", "what-bin.txt"],
+          depDirEntries: ["bun.lock", "node_modules", "package.json", "what-bin.txt"],
+          lockfileUnchanged: true,
         });
       });
 
@@ -2203,7 +2262,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         const { packageDir, packageJson, env } = ctx;
         const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
-        const spec = await createGitDependency(packageDir, gitDependency);
+        const spec = await createGitDependency(packageDir, gitDependency, { files: gitDependencyFiles });
         await writeFile(
           packageJson,
           JSON.stringify({ name: "foo", version: "1.0.0", dependencies: { [gitDependency.name]: spec } }),
@@ -2240,7 +2299,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
 
         expect(await installedState(packageDir, gitDependency.name)).toEqual({
           prepareOutput: "what-bin@1.0.0",
-          depDirEntries: ["package.json", "what-bin.txt"],
+          depDirEntries: preparedDepDirEntries,
           hoistedDevDependency: false,
           lockfileMentionsDevDependency: false,
         });
@@ -2269,7 +2328,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         await using proc = spawn({
           cmd: [bunExe(), "install"],
           cwd: packageDir,
-          stdout: "pipe",
+          stdout: "ignore",
           stdin: "ignore",
           stderr: "pipe",
           env: testEnv,
@@ -2278,12 +2337,58 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         // the nested install's own output comes first, then bun's summary of what it was doing
         expect(err).toContain("this-package-does-not-exist");
         expect(err).toContain(
-          'installing the dependencies of "dev-dep-does-not-exist" for its prepare script failed (bun install --ignore-scripts --no-save exited with 1)',
+          'error: bun install --ignore-scripts --no-save for the prepare script of "dev-dep-does-not-exist" exited with 1',
         );
         expect(exitCode).toBe(1);
 
+        // the failed nested install is cleaned up like a successful one
         const depDir = join(packageDir, "node_modules", "dev-dep-does-not-exist");
         expect((await readdirSorted(depDir)).filter(entry => entry !== ".bun-tag")).toEqual(["package.json"]);
+      });
+
+      test("recovers from a run that was interrupted while its dependencies were installed", async () => {
+        using ctx = await setupTest();
+        const { packageDir, packageJson, env } = ctx;
+        const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
+
+        const spec = await createGitDependency(packageDir, gitDependency);
+        await writeFile(
+          packageJson,
+          JSON.stringify({ name: "foo", version: "1.0.0", dependencies: { [gitDependency.name]: spec } }),
+        );
+        await runBunInstall(testEnv, packageDir);
+
+        // What a run that died (kill -9, power loss) between moving the package's own `node_modules`
+        // aside and putting it back leaves behind: the original in `.bun-prepare-node_modules`, and
+        // the half-installed dependencies of that run in `node_modules`.
+        const depDir = join(packageDir, "node_modules", gitDependency.name);
+        await Promise.all([
+          write(join(depDir, ".bun-prepare-node_modules", "original-nested-dep", "package.json"), "{}"),
+          write(join(depDir, "node_modules", "leftover-from-interrupted-run", "package.json"), "{}"),
+        ]);
+
+        await using proc = spawn({
+          cmd: [bunExe(), "pm", "trust", gitDependency.name],
+          cwd: packageDir,
+          stdout: "ignore",
+          stdin: "ignore",
+          stderr: "pipe",
+          env: testEnv,
+        });
+        const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+        expect(err).not.toContain("error:");
+        expect(err).not.toContain("warn:");
+        expect(exitCode).toBe(0);
+
+        expect({
+          prepareOutput: await file(join(depDir, "what-bin.txt")).text(),
+          depDirEntries: (await readdirSorted(depDir)).filter(entry => entry !== ".bun-tag"),
+          nodeModulesEntries: await readdirSorted(join(depDir, "node_modules")),
+        }).toEqual({
+          prepareOutput: "what-bin@1.0.0",
+          depDirEntries: ["node_modules", "package.json", "what-bin.txt"],
+          nodeModulesEntries: ["original-nested-dep"],
+        });
       });
     });
 


### PR DESCRIPTION
### Problem
- A git or github dependency is installed straight from its checkout. Most such packages build their entry point in a `prepare` script with tools from their `devDependencies` (`tsc`, `tshy`, `tsup`, ...), and nothing installs those devDependencies.
- With the package in `trustedDependencies`, bun runs the script anyway and the whole install fails:
  `bash: tshy: command not found` / `error: prepare script from "rimraf" exited with 127`. `bun pm trust <pkg>` fails the same way.
- Cause: `Scripts::get_script_entries` (src/install/lockfile/Package/Scripts.rs) queues the prepare family for `Git`/`Github` resolutions like any other lifecycle script, and `LifecycleScriptSubprocess` runs it in `node_modules/<pkg>` with only the package's hoisted runtime dependencies around. npm and pnpm install the checkout's dependencies and devDependencies before running `prepare`.

### Fix
- `List` gets `install_dependencies_for_prepare`, set in `create_list` for `Git`/`Github` packages that have a `preprepare`/`prepare`/`postprepare` script.
- The runner (`lifecycle_script_runner.rs`) then spawns `bun install --ignore-scripts --no-save` with the package directory as cwd before the first prepare-family script, runs the scripts as before, and removes what the nested install left when the last script exits or anything fails (non-zero exit, signal, spawn failure). `--ignore-scripts` because the runner is in the middle of running this package's own scripts; `--no-save` so the package.json and a committed lockfile stay as they are. A `bun.lock` the nested install still writes while migrating a committed `package-lock.json` (bun saves migrated lockfiles regardless of `--no-save`) is removed too.
- Removing the nested `node_modules` matters: the nested install also installs the package's peer and regular dependencies, so leaving it in place would make the package load its own copies of `react` and friends instead of the project's. The package's runtime dependencies are the ones the project installed, outside the package directory with both linkers.
- A `node_modules` the package already has (with the hoisted linker: version conflicts bun nested there; or one committed to the repository) is renamed to `.bun-prepare-node_modules` for the duration and renamed back at the end; an empty placeholder is created when there was none. Finding that directory already present means an earlier run was interrupted: it still holds the original, so the current `node_modules` is the leftovers and gets deleted instead. If the package directory cannot be prepared this way (rename/mkdir failure, path too long), bun warns and leaves the installed dependencies in place.
- `spawn_package_lifecycle_scripts` builds a second environment for the nested install with `BUN_CONFIG_REGISTRY` (+ `BUN_CONFIG_TOKEN`, only ever together with its registry) when the project overrides the default registry or has a token, and `BUN_INSTALL_CACHE_DIR`. The nested install's project directory is the checkout, so it would not otherwise see the project's `bunfig.toml`/`.npmrc`.
- Failure messages share one prefix: a failing nested install prints its output and `error: bun install --ignore-scripts --no-save for the prepare script of "<pkg>" exited with 1`; scripts keep their existing `error: prepare script from "<pkg>" exited with N` text. Optional dependencies are dropped like they are for any failing script.
- Nothing changes for untrusted packages (`Blocked 1 postinstall` / `bun pm untrusted` as before), for `--ignore-scripts`, or for npm/folder/tarball packages. `bun pm trust` and the isolated linker use the same runner.
- Verified with the new `describe` block in test/cli/install/bun-install-lifecycle-scripts.test.ts: hoisted and isolated linker (the repository ships a `package-lock.json`, so the migrated `bun.lock` cleanup is exercised), a pre-existing nested `node_modules` and a committed `bun.lock` survive while the devDependency is removed, `bun pm trust`, a failing nested install, and recovery from an interrupted run. Against the released bun, 8 of the original 10 cases fail with `what-bin: command not found` / exit 127; with this change all pass.
- The rest of bun-install-lifecycle-scripts.test.ts, bun-pm.test.ts and isolated-install.test.ts pass locally (the existing github `preprepare`/`prepare`/`postprepare` test now also exercises the nested install); `cargo check -p bun_install --target x86_64-pc-windows-msvc` is clean.
- All cases run on every platform. An earlier revision skipped the isolated-linker case on Windows because the isolated store path of a git dependency exceeded MAX_PATH and no lifecycle script of such a package could be spawned there; #38867 bounds those store names on main, and after rebasing onto it the case passes on Windows (the set-aside placeholder is created through `mkdirat`, which takes the long-path route there; `mkdir` goes through libuv and stops at MAX_PATH).
- Docs: a section in docs/pm/lifecycle.mdx and a pointer from the git dependencies section of docs/pm/cli/add.mdx, which did not mention that `trustedDependencies` is what turns `prepare` on.

Fixes #10297

Supersedes #35677, which injected the nested install into the `preprepare` slot but left the installed devDependencies (and peers) in `node_modules/<pkg>/node_modules`.

Known limits, unchanged from before: the checkout is copied as is (`files` is not applied), the lifecycle scripts of the package's own dependencies do not run during the nested install, and scoped registries / `_auth` credentials are not forwarded to it. Whether `prepare` should run without `trustedDependencies` (npm's behavior) is a separate policy decision and not touched here.

### Background
- Lifecycle scripts: `package.json` `scripts` that package managers run while installing. `preinstall`/`install`/`postinstall` run for every installed package; `preprepare`/`prepare`/`postprepare` run for the project itself and, because there is no published build to download, for packages installed from git. Bun only runs a dependency's scripts if it is in `trustedDependencies` (git dependencies are never in the default allow list).
- `LifecycleScriptSubprocess`: one instance per package with scripts. It holds the package's `List` (one optional command per script slot, in `Scripts::NAMES` order: preinstall, install, postinstall, preprepare, prepare, postprepare), spawns the slots one after another through `sh -c` (`bun exec` on Windows), and handles each exit in `handle_exit`. The nested install is one more spawn of the same object, with a direct argv instead of a shell command; `current_script_index` keeps pointing at the prepare script it is preparing for.
- Hoisted vs isolated linker: the hoisted linker copies packages into `node_modules` and puts version conflicts into `node_modules/<pkg>/node_modules`; the isolated linker puts each package in `node_modules/.bun/<pkg>@<version>/node_modules/<pkg>` with its dependencies symlinked next to it. In both layouts the package's runtime dependencies live outside the package directory, which is why everything the nested install writes inside it can be removed again.

<details>
<summary>Earlier revision</summary>

The first push deleted a leftover `.bun-prepare-node_modules` at the start of a run and only cleaned up on a non-zero exit, which would have destroyed the package's own nested dependencies after an interrupted run; it also left a migrated `bun.lock` behind and reported a failed nested install as `installing the dependencies of "<pkg>" for its prepare script failed (...)`. Review of that revision led to the placeholder/interrupted-run handling, the cleanup on every failure path, the lockfile removal, the shared message prefix, and the length-checked paths described above.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-install-lifecycle-scripts.test.ts

<!-- robobun:evidence:end -->
