### PR TITLE
install: apply both "overrides" and "resolutions" when package.json has both

### DIFF
--- a/docs/pm/overrides.mdx
+++ b/docs/pm/overrides.mdx
@@ -62,7 +62,7 @@ Bun only reads overrides from the root `package.json`, not from workspace packag
 
 ## `"resolutions"`
 
-`"resolutions"` is Yarn's alternative to `"overrides"`, with similar syntax. Bun supports it to help projects migrate from Yarn.
+`"resolutions"` is Yarn's alternative to `"overrides"`, with similar syntax. Bun supports it to help projects migrate from Yarn. When a `package.json` has both fields, Bun applies the rules from both. If the same package (or the same nested selector) appears in both, the `"overrides"` rule wins.
 
 {/* prettier-ignore */}
 ```json package.json icon="file-json"

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -1461,10 +1461,13 @@ fn overrides_field_name(
         return "overrides";
     };
     let root = entry.root;
-    if root.as_property(b"overrides").is_none() && root.as_property(b"resolutions").is_some() {
-        "resolutions"
-    } else {
-        "overrides"
+    match (
+        root.as_property(b"overrides").is_some(),
+        root.as_property(b"resolutions").is_some(),
+    ) {
+        (false, true) => "resolutions",
+        (true, true) => "overrides or resolutions",
+        _ => "overrides",
     }
 }
 

--- a/src/install/lockfile/OverrideMap.rs
+++ b/src/install/lockfile/OverrideMap.rs
@@ -128,8 +128,16 @@ fn is_comment_key(key: &[u8]) -> bool {
     key.starts_with(b"//")
 }
 
+/// Parsing only appends or replaces in place, so the rules `"overrides"` produced are the first `flat` entries of `map` and the first `scoped` entries of `scoped`.
+#[derive(Clone, Copy, Default)]
+struct RuleCount {
+    flat: usize,
+    scoped: usize,
+}
+
 struct ParseContext<'a, 'b> {
     field: Field,
+    from_overrides: RuleCount,
     pm: &'a mut PackageManager,
     lockfile_dependencies: &'a [Dependency],
     root_package: &'a Package,
@@ -488,29 +496,40 @@ impl OverrideMap {
 
     /// Replaces the rule with the same (parent, parent range, target, target range); `buf` is the buffer `rule` was appended into.
     pub(crate) fn push_scoped(&mut self, rule: ScopedOverride, buf: &[u8]) {
-        if self.scoped_names.contains(&rule.dep.name_hash) {
-            if let Some(existing) = self.scoped.iter_mut().find(|existing| {
-                existing.dep.name_hash == rule.dep.name_hash
-                    && match (&existing.parent, &rule.parent) {
-                        (None, None) => true,
-                        (Some(a), Some(b)) => {
-                            a.name_hash == b.name_hash
-                                && a.version.literal.eql(b.version.literal, buf, buf)
-                        }
-                        _ => false,
-                    }
-                    && existing
-                        .target_range
-                        .literal
-                        .eql(rule.target_range.literal, buf, buf)
-            }) {
-                *existing = rule;
-                return;
+        self.put_scoped(rule, buf, 0);
+    }
+
+    /// Like `push_scoped`, except that a matching rule at a position below `keep` is kept and `rule` is dropped.
+    fn put_scoped(&mut self, rule: ScopedOverride, buf: &[u8], keep: usize) {
+        match self.scoped_position(&rule, buf) {
+            Some(index) if index < keep => {}
+            Some(index) => self.scoped[index] = rule,
+            None => {
+                self.scoped_names.insert(rule.dep.name_hash, ());
+                self.scoped.push(rule);
             }
-        } else {
-            self.scoped_names.insert(rule.dep.name_hash, ());
         }
-        self.scoped.push(rule);
+    }
+
+    fn scoped_position(&self, rule: &ScopedOverride, buf: &[u8]) -> Option<usize> {
+        if !self.scoped_names.contains(&rule.dep.name_hash) {
+            return None;
+        }
+        self.scoped.iter().position(|existing| {
+            existing.dep.name_hash == rule.dep.name_hash
+                && match (&existing.parent, &rule.parent) {
+                    (None, None) => true,
+                    (Some(a), Some(b)) => {
+                        a.name_hash == b.name_hash
+                            && a.version.literal.eql(b.version.literal, buf, buf)
+                    }
+                    _ => false,
+                }
+                && existing
+                    .target_range
+                    .literal
+                    .eql(rule.target_range.literal, buf, buf)
+        })
     }
 
     /// Row constructor for bun.lock / pnpm-lock.yaml; `Ok(false)` when `value`, the parent range or the target range does not parse.
@@ -589,14 +608,32 @@ impl OverrideMap {
         expr: Expr,
         builder: &mut StringBuilder,
     ) {
-        let (field, field_expr) = if let Some(overrides) = expr.as_property(b"overrides") {
-            (Field::Overrides, overrides.expr)
-        } else if let Some(resolutions) = expr.as_property(b"resolutions") {
-            (Field::Resolutions, resolutions.expr)
-        } else {
-            return;
-        };
+        for field in [Field::Overrides, Field::Resolutions] {
+            if let Some(property) = expr.as_property(field.json_name().as_bytes()) {
+                Self::count_field(
+                    pm,
+                    log,
+                    json_source,
+                    workspace_names,
+                    &expr,
+                    field,
+                    property.expr,
+                    builder,
+                );
+            }
+        }
+    }
 
+    fn count_field(
+        pm: &mut PackageManager,
+        log: &mut bun_ast::Log,
+        json_source: &bun_ast::Source,
+        workspace_names: &WorkspaceMap,
+        root_json: &Expr,
+        field: Field,
+        field_expr: Expr,
+        builder: &mut StringBuilder,
+    ) {
         field_expr.for_each_property(|key, _key_loc, value| {
             if is_comment_key(key) {
                 return;
@@ -612,7 +649,15 @@ impl OverrideMap {
                     }
                 }
                 builder.count(value);
-                count_ref_value(pm, log, json_source, workspace_names, &expr, value, builder);
+                count_ref_value(
+                    pm,
+                    log,
+                    json_source,
+                    workspace_names,
+                    root_json,
+                    value,
+                    builder,
+                );
                 return;
             }
             if field != Field::Overrides || !value.is_object() {
@@ -637,7 +682,7 @@ impl OverrideMap {
                         log,
                         json_source,
                         workspace_names,
-                        &expr,
+                        root_json,
                         child_value,
                         builder,
                     );
@@ -646,8 +691,8 @@ impl OverrideMap {
         });
     }
 
-    /// Given a package json expression, detect and parse override configuration into the given override map.
-    /// It is assumed the input map is uninitialized (zero entries)
+    /// Parses the root package.json's `"overrides"` and `"resolutions"` into this (empty) map.
+    /// Both fields apply; where they define the same selector the `"overrides"` rule wins.
     pub(crate) fn parse_append(
         &mut self,
         pm: &mut PackageManager,
@@ -660,15 +705,9 @@ impl OverrideMap {
         builder: &mut StringBuilder,
     ) -> Result<(), Error> {
         debug_assert!(self.map.count() == 0 && self.scoped.is_empty()); // only call parse once
-        let (field, field_expr) = if let Some(overrides) = expr.as_property(b"overrides") {
-            (Field::Overrides, overrides.expr)
-        } else if let Some(resolutions) = expr.as_property(b"resolutions") {
-            (Field::Resolutions, resolutions.expr)
-        } else {
-            return Ok(());
-        };
         let mut ctx = ParseContext {
-            field,
+            field: Field::Overrides,
+            from_overrides: RuleCount::default(),
             pm,
             lockfile_dependencies,
             root_package,
@@ -677,9 +716,16 @@ impl OverrideMap {
             workspace_names,
             builder,
         };
-        match field {
-            Field::Overrides => self.parse_from_overrides(&mut ctx, field_expr)?,
-            Field::Resolutions => self.parse_from_resolutions(&mut ctx, field_expr)?,
+        if let Some(overrides) = expr.as_property(b"overrides") {
+            self.parse_from_overrides(&mut ctx, overrides.expr)?;
+            ctx.from_overrides = RuleCount {
+                flat: self.map.count(),
+                scoped: self.scoped.len(),
+            };
+        }
+        if let Some(resolutions) = expr.as_property(b"resolutions") {
+            ctx.field = Field::Resolutions;
+            self.parse_from_resolutions(&mut ctx, resolutions.expr)?;
         }
         scoped_log!(
             OverrideMap,
@@ -898,24 +944,37 @@ impl OverrideMap {
             return Ok(());
         }
 
+        let name_hash = SemverBuilder::string_hash(target.name);
         let is_flat = parent.is_none() && target.range.is_empty();
-        let Some(dep) = parse_override_value(ctx, value_loc, target.name, value, is_flat)? else {
+        // Checked before the value is parsed: a flat `npm:` value also registers an alias, which a skipped rule must not do.
+        if is_flat
+            && self
+                .map
+                .get_index(&name_hash)
+                .is_some_and(|index| index < ctx.from_overrides.flat)
+        {
+            return Ok(());
+        }
+        let Some(dep) =
+            parse_override_value(ctx, value_loc, target.name, name_hash, value, is_flat)?
+        else {
             return Ok(());
         };
         let Some(target_range) = parse_range(ctx, key_loc, dep.name, dep.name_hash, target.range)
         else {
             return Ok(());
         };
-        if parent.is_none() && target_range.tag != VersionTag::Npm {
+        if is_flat {
             self.map.put_assume_capacity(dep.name_hash, dep);
         } else {
-            self.push_scoped(
+            self.put_scoped(
                 ScopedOverride {
                     parent: parent.cloned(),
                     target_range,
                     dep,
                 },
                 ctx.builder.string_bytes.as_slice(),
+                ctx.from_overrides.scoped,
             );
         }
         Ok(())
@@ -1063,6 +1122,7 @@ fn parse_override_value(
     ctx: &mut ParseContext<'_, '_>,
     loc: bun_ast::Loc,
     key: &[u8],
+    name_hash: PackageNameHash,
     value: &[u8],
     register_aliases: bool,
 ) -> Result<Option<Dependency>, Error> {
@@ -1087,7 +1147,6 @@ fn parse_override_value(
         return Ok(None);
     }
 
-    let name_hash = SemverBuilder::string_hash(key);
     let name = ctx.builder.append_with_hash::<SemverString>(key, name_hash);
 
     // https://docs.npmjs.com/cli/v9/configuring-npm/package-json#overrides

--- a/test/cli/install/nested-overrides.test.ts
+++ b/test/cli/install/nested-overrides.test.ts
@@ -557,6 +557,128 @@ describe.concurrent("syntax", () => {
   });
 });
 
+// two-range-deps declares no-deps ^1.0.0 (1.1.0 without a rule) and @types/is-number >=1.0.0 (2.0.0 without a rule).
+describe.concurrent("overrides and resolutions in the same package.json", () => {
+  test("rules from both fields apply", async () => {
+    const dir = await project({
+      dependencies: { "two-range-deps": "1.0.0" },
+      overrides: { "no-deps": "1.0.0" },
+      resolutions: { "@types/is-number": "1.0.0" },
+    });
+    const { err } = await installOk(dir);
+    expect(err).not.toContain("warn:");
+    expect(await versionSeenBy(dir, "two-range-deps", "no-deps")).toBe("1.0.0");
+    expect(await versionSeenBy(dir, "two-range-deps", "@types/is-number")).toBe("1.0.0");
+    const first = await lock(dir);
+    expect(overridesSection(first)).toMatchInlineSnapshot(`
+      ""overrides": {
+        "@types/is-number": "1.0.0",
+        "no-deps": "1.0.0",
+      },"
+    `);
+    await installOk(dir, "--frozen-lockfile");
+    const again = await installOk(dir);
+    expect(again.err).not.toContain("Saved lockfile");
+    expect(await lock(dir)).toBe(first);
+  });
+
+  test("a scoped rule in resolutions applies next to a flat rule in overrides", async () => {
+    const dir = await project({
+      dependencies: { "two-range-deps": "1.0.0", "one-range-dep": "1.0.0" },
+      overrides: { "@types/is-number": "1.0.0" },
+      resolutions: { "one-range-dep/no-deps": "2.0.0" },
+    });
+    const { err } = await installOk(dir);
+    expect(err).not.toContain("warn:");
+    expect(await versionSeenBy(dir, "two-range-deps", "@types/is-number")).toBe("1.0.0");
+    expect(await versionSeenBy(dir, "one-range-dep", "no-deps")).toBe("2.0.0");
+    expect(await versionSeenBy(dir, "two-range-deps", "no-deps")).toBe("1.1.0");
+    expect(overridesSection(await lock(dir))).toMatchInlineSnapshot(`
+      ""overrides": {
+        "@types/is-number": "1.0.0",
+        "one-range-dep": {
+          "no-deps": "2.0.0",
+        },
+      },"
+    `);
+    await installOk(dir, "--frozen-lockfile");
+  });
+
+  test("the same name in both fields: overrides wins", async () => {
+    const dir = await project({
+      dependencies: { "one-range-dep": "1.0.0" },
+      overrides: { "no-deps": "1.0.0" },
+      resolutions: { "no-deps": "1.0.1" },
+    });
+    await installOk(dir);
+    expect(await versionSeenBy(dir, "one-range-dep", "no-deps")).toBe("1.0.0");
+    expect(overridesSection(await lock(dir))).toMatchInlineSnapshot(`
+      ""overrides": {
+        "no-deps": "1.0.0",
+      },"
+    `);
+  });
+
+  // A flat `npm:` rule also registers an alias that redirects matching edges before overrides are consulted,
+  // so a resolutions rule that loses to overrides must not be parsed at all.
+  test("a losing resolutions rule with an npm: value does not redirect the edge", async () => {
+    const dir = await project({
+      dependencies: { "one-range-dep": "1.0.0" },
+      overrides: { "no-deps": "1.0.0" },
+      resolutions: { "no-deps": "npm:a-dep@1.0.1" },
+    });
+    await installOk(dir);
+    expect(await packageSeenBy(dir, "one-range-dep", "no-deps")).toBe("no-deps@1.0.0");
+    expect(await lock(dir)).not.toContain("a-dep");
+  });
+
+  test("the same scoped selector in both fields: overrides wins", async () => {
+    const dir = await project({
+      dependencies: { "one-range-dep": "1.0.0" },
+      overrides: { "one-range-dep": { "no-deps": "1.0.0" } },
+      resolutions: { "one-range-dep/no-deps": "1.0.1" },
+    });
+    await installOk(dir);
+    expect(await versionSeenBy(dir, "one-range-dep", "no-deps")).toBe("1.0.0");
+    expect(overridesSection(await lock(dir))).toMatchInlineSnapshot(`
+      ""overrides": {
+        "one-range-dep": {
+          "no-deps": "1.0.0",
+        },
+      },"
+    `);
+  });
+
+  test("within resolutions the last spelling of a rule still wins", async () => {
+    const dir = await project({
+      dependencies: { "two-range-deps": "1.0.0" },
+      overrides: { "@types/is-number": "1.0.0" },
+      resolutions: { "**/no-deps": "1.0.0", "no-deps": "1.0.1" },
+    });
+    await installOk(dir);
+    expect(await versionSeenBy(dir, "two-range-deps", "no-deps")).toBe("1.0.1");
+    expect(await versionSeenBy(dir, "two-range-deps", "@types/is-number")).toBe("1.0.0");
+  });
+
+  test("editing resolutions is a frozen-lockfile change that names both fields", async () => {
+    const pkg = {
+      dependencies: { "two-range-deps": "1.0.0" },
+      overrides: { "no-deps": "1.0.0" },
+      resolutions: { "@types/is-number": "1.0.0" },
+    };
+    const dir = await project(pkg);
+    await installOk(dir);
+    pkg.resolutions["@types/is-number"] = "2.0.0";
+    await write(join(dir, "package.json"), JSON.stringify({ name: "nested-overrides", ...pkg }));
+    const frozen = await install(dir, "--frozen-lockfile");
+    expect(frozen.err).toContain("error: lockfile had changes, but lockfile is frozen");
+    expect(frozen.err).toContain("note: overrides or resolutions in package.json changed since bun.lock was saved");
+    expect(frozen.exitCode).toBe(1);
+    await installOk(dir);
+    expect(await versionSeenBy(dir, "two-range-deps", "@types/is-number")).toBe("2.0.0");
+  });
+});
+
 // The selector range is matched against the range the dependent declares; a rule applies when the two intersect.
 describe.concurrent("version-scoped targets", () => {
   test("a flat name@range rule applies to edges whose declared range intersects it", async () => {
@@ -1511,6 +1633,47 @@ one-dep@1.0.0:
     expect(text).toContain('"no-deps": "2.0.0"');
     await installOk(dir);
     expect(await versionSeenBy(dir, "one-dep", "no-deps")).toBe("2.0.0");
+  });
+
+  test("yarn.lock migration carries both overrides and resolutions", async () => {
+    const url = registry.registryUrl();
+    const [aDep, noDeps] = await Promise.all([integrityOf("a-dep", "1.0.2"), integrityOf("no-deps", "1.0.0")]);
+    const dir = await project(
+      {
+        dependencies: { "a-dep": "^1.0.1", "no-deps": "^1.0.0" },
+        overrides: { "no-deps": "1.0.0" },
+        resolutions: { "a-dep": "1.0.2" },
+      },
+      "hoisted",
+      {
+        "yarn.lock": `# THIS IS AN AUTOGENERATED FILE. DO NOT EDIT THIS FILE DIRECTLY.
+# yarn lockfile v1
+
+
+a-dep@^1.0.1:
+  version "1.0.2"
+  resolved "${url}a-dep/-/a-dep-1.0.2.tgz"
+  integrity ${aDep}
+
+no-deps@^1.0.0:
+  version "1.0.0"
+  resolved "${url}no-deps/-/no-deps-1.0.0.tgz"
+  integrity ${noDeps}
+`,
+      },
+    );
+    const migrated = await migrate(dir);
+    expect(migrated.err).not.toContain("error:");
+    expect(migrated.exitCode).toBe(0);
+    expect(overridesSection(await lock(dir))).toMatchInlineSnapshot(`
+      ""overrides": {
+        "a-dep": "1.0.2",
+        "no-deps": "1.0.0",
+      },"
+    `);
+    await installOk(dir, "--frozen-lockfile");
+    expect(await versionSeenBy(dir, undefined, "a-dep")).toBe("1.0.2");
+    expect(await versionSeenBy(dir, undefined, "no-deps")).toBe("1.0.0");
   });
 
   // one-dep@1.0.0 declares no-deps@1.0.1; a lockfile snapshot on 2.0.0 is only consistent with an override.


### PR DESCRIPTION
### Problem
- A root `package.json` with both an `"overrides"` map and a `"resolutions"` map silently ignores the whole `"resolutions"` map, even when the two pin different packages. No warning, exit 0. Same on 1.3.14 and on both linkers.
- Repro: `dependencies: {"two-range-deps": "1.0.0"}` (declares `no-deps ^1.0.0` and `@types/is-number >=1.0.0`), `overrides: {"no-deps": "1.0.0"}`, `resolutions: {"@types/is-number": "1.0.0"}` installs `no-deps@1.0.0` but `@types/is-number@2.0.0`. Deleting the `overrides` key makes the same `resolutions` entry apply.
- Cause: `OverrideMap::parse_append` and `parse_count` (`src/install/lockfile/OverrideMap.rs`) are an `if overrides ... else if resolutions ...`: exactly one field is ever parsed. The root `package.json`, `yarn.lock` migration (`yarn.rs`) and `package-lock.json` migration (`migration/npm_lock.rs`) all go through these two functions.
- Projects migrated from Yarn that keep their `resolutions` pins and later gain one `overrides` entry lose every `resolutions` pin.

### Fix
- `parse_append` parses `"overrides"`, records how many flat and scoped rules it produced, then parses `"resolutions"`. `parse_count` counts both fields.
- Precedence when both fields define the same selector: the `"overrides"` rule wins. This keeps today's behavior for conflicting keys and matches pnpm, which reads `resolutions` and lets `pnpm.overrides` win.
- A losing `"resolutions"` rule is skipped before its value is parsed (`put_rule`). This matters because a flat `npm:` value also registers the alias in `known_npm_aliases`, which `PackageManagerEnqueue.rs` consults before the override map; merging by overwriting the map entry would have left that alias behind and redirected edges the override was supposed to pin.
- Rules owned by `"overrides"` are identified by position (the first N flat entries / first M scoped entries), so within `"resolutions"` itself the existing last-spelling-wins behavior is unchanged. `push_scoped` keeps its semantics for the lockfile loaders; the parse path uses the new `put_scoped` with a keep count.
- The `--frozen-lockfile` note says `overrides or resolutions in package.json changed` when the root has both fields (`install_with_manager.rs`), and `docs/pm/overrides.mdx` documents the merge and the precedence.
- Behavior change to be aware of: a project that already has both fields will re-save its lockfile on the next install (the `resolutions` rules now get recorded and applied), so a `--frozen-lockfile` install there fails until the lockfile is updated. That is the fix taking effect; those projects currently have unpinned packages.
- Verified with `test/cli/install/nested-overrides.test.ts`:
  - new `overrides and resolutions in the same package.json` block (7 tests): both fields apply, flat and scoped precedence, the losing `npm:` rule registers nothing, last spelling within `resolutions` still wins, editing `resolutions` is a frozen-lockfile change with the new note
  - new `yarn.lock migration carries both overrides and resolutions` test, frozen-clean after `bun pm migrate`
  - the both-fields-apply, scoped, last-spelling, frozen and migration tests fail without the `src/` change (confirmed against the released binary for the flat cases), all 152 tests in the file pass with it
  - `bun-lock.test.ts`, `bun-workspaces.test.ts`, `migration/migrate.test.ts`, `migration/yarn-lock-migration.test.ts` and `bun-audit.test.ts` override/resolution tests pass; `test/internal/source-lints/byte-search.test.ts` passes; `cargo clippy -p bun_install` is clean

### Background
- `OverrideMap` is the in-memory form of the root's override rules. `map` holds flat rules (one per package name); `scoped` holds rules limited to a parent package and/or a target version range (`"one-dep>no-deps"`, `"no-deps@1"`, npm object form, yarn path form). `PackageManagerEnqueue.rs` consults it for every dependency edge, and bun.lock serializes it as the `"overrides"` section regardless of which field the rule came from.
- Parsing into the lockfile string buffer is two-pass: `parse_count` sizes the buffer by counting every string the rules will need, then `parse_append` appends and builds the rules. Over-counting is harmless (the builder is clamped afterwards), which is why skipped rules can still be counted.
- `known_npm_aliases` is a side table filled while parsing `npm:` specifiers (dependencies, catalogs, flat override rules). When a plain dependency's name matches a registered alias and its range overlaps, the edge is redirected to the alias target before the override map is consulted, so registering an alias for a rule that is then discarded would change resolution.
- `ArrayHashMap` preserves insertion order and `put` on an existing key replaces the value in place, which is what makes "the first N entries came from overrides" stable while `resolutions` is being parsed.
