### PR TITLE
url: emit a single slash in href_without_auth() for root-path registry URLs

### DIFF
--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -390,7 +390,9 @@ impl<'a> URL<'a> {
         }
     }
 
-    /// Formats `<displayProtocol>://<displayHost>/<trimmed pathname>/`.
+    /// Formats `<displayProtocol>://<displayHost>/<trimmed pathname>/`, or
+    /// `<displayProtocol>://<displayHost>/` when the pathname is `/`, so the
+    /// result always ends in exactly one slash.
     ///
     /// `display_host()` yields a `bun_core::fmt::HostFormatter` (impls
     /// `Display`); the other two pieces are raw byte slices, so we assemble
@@ -407,8 +409,10 @@ impl<'a> URL<'a> {
         // bun_core::io::Write on Vec<u8> is infallible.
         let _ = buf.print(format_args!("{}", self.display_host()));
         buf.push(b'/');
-        buf.extend_from_slice(path);
-        buf.push(b'/');
+        if !path.is_empty() {
+            buf.extend_from_slice(path);
+            buf.push(b'/');
+        }
         buf.into_boxed_slice()
     }
 

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -390,14 +390,11 @@ impl<'a> URL<'a> {
         }
     }
 
-    /// Formats `<displayProtocol>://<displayHost>/<trimmed pathname>/`, or
-    /// `<displayProtocol>://<displayHost>/` when the pathname is `/`, so the
-    /// result always ends in exactly one slash.
+    /// `<displayProtocol>://<displayHost>/<trimmed pathname>/`, or just
+    /// `<displayProtocol>://<displayHost>/` when the pathname is `/`.
     ///
-    /// `display_host()` yields a `bun_core::fmt::HostFormatter` (impls
-    /// `Display`); the other two pieces are raw byte slices, so we assemble
-    /// into a `Vec<u8>` directly rather than going through `format!` and
-    /// risking lossy UTF-8 round-trips.
+    /// Assembled as bytes because `display_host()` is a `Display` impl while
+    /// the other pieces are raw byte slices.
     pub fn href_without_auth(&self) -> Box<[u8]> {
         let proto = self.display_protocol();
         let path = strings::trim(self.pathname, b"/");

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -390,11 +390,7 @@ impl<'a> URL<'a> {
         }
     }
 
-    /// `<displayProtocol>://<displayHost>/<trimmed pathname>/`, or just
-    /// `<displayProtocol>://<displayHost>/` when the pathname is `/`.
-    ///
-    /// Assembled as bytes because `display_host()` is a `Display` impl while
-    /// the other pieces are raw byte slices.
+    /// The URL without its userinfo, ending in exactly one `/`: `http://host/`, `http://host/npm/`.
     pub fn href_without_auth(&self) -> Box<[u8]> {
         let proto = self.display_protocol();
         let path = strings::trim(self.pathname, b"/");

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -628,9 +628,9 @@ registry=https://somehost.com/org1/npm/registry/
 
 describe.concurrent("registry URL with embedded credentials", () => {
   // Credentials written into the registry URL are split off and the URL is
-  // stored without them. The stored URL is what manifest URLs are joined onto
-  // and what error messages print, so a registry at the root of its host has
-  // to come back as "http://host/", not "http://host//".
+  // stored without them. The stored URL is what requests are built from and
+  // what error messages print, so a registry at the root of its host has to
+  // come back as "http://host/", not "http://host//".
   test.each([
     ["http://alice:s3cret@registry.example.com/", "http://registry.example.com/"],
     ["http://alice:s3cret@registry.example.com", "http://registry.example.com/"],
@@ -657,73 +657,64 @@ describe.concurrent("registry URL with embedded credentials", () => {
   });
 
   type Req = { path: string; auth: string | null };
-  const basicAuth = `Basic ${Buffer.from("alice:s3cret").toString("base64")}`;
 
-  function unauthorizedRegistry(reqs: Req[]) {
+  function mockRegistry(reqs: Req[], respond: () => Response) {
     return Bun.serve({
       port: 0,
       hostname: "127.0.0.1",
       fetch(req) {
         reqs.push({ path: new URL(req.url).pathname, auth: req.headers.get("authorization") });
-        return new Response("unauthorized", { status: 401 });
+        return respond();
       },
     });
   }
 
-  async function install(dir: string) {
+  async function run(dir: string, ...args: string[]) {
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "install"],
+      cmd: [bunExe(), ...args],
       cwd: dir,
       env: { ...env, BUN_INSTALL_CACHE_DIR: join(dir, ".cache") },
       stdout: "pipe",
       stderr: "pipe",
     });
     const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    return { stderr: stderr.split(/\r?\n/), exitCode };
+    return { stderr, exitCode };
   }
+
+  // The documented bunfig form for a token: the token rides on the end of the
+  // URL's path. `bun pm whoami` prints the stored URL verbatim when the
+  // registry does not return a username.
+  test.each([
+    ["/", "/-/whoami"],
+    ["/npm/", "/npm/-/whoami"],
+  ])("_authToken= appended to a bunfig.toml registry URL with path %s", async (path, whoami) => {
+    const reqs: Req[] = [];
+    await using server = mockRegistry(reqs, () => Response.json({}));
+    const base = `http://127.0.0.1:${server.port}${path}`;
+    using dir = tempDir("bunfig-authtoken-suffix", {
+      "bunfig.toml": `[install.registry]\nurl = "${base}_authToken=tok"\n`,
+      "package.json": JSON.stringify({ name: "app" }),
+    });
+
+    const { stderr, exitCode } = await run(String(dir), "pm", "whoami");
+
+    expect(stderr).toBe(`error: failed to authenticate with registry '${base}'\n`);
+    expect(reqs).toEqual([{ path: whoami, auth: "Bearer tok" }]);
+    expect(exitCode).toBe(1);
+  });
 
   test("username:password in the .npmrc registry URL", async () => {
     const reqs: Req[] = [];
-    await using server = unauthorizedRegistry(reqs);
-    using dir = tempDir("npmrc-userinfo-root", {
+    await using server = mockRegistry(reqs, () => new Response("unauthorized", { status: 401 }));
+    using dir = tempDir("npmrc-userinfo", {
       ".npmrc": `registry=http://alice:s3cret@127.0.0.1:${server.port}/\n`,
       "package.json": JSON.stringify({ name: "app", dependencies: { "needs-creds": "1.0.0" } }),
     });
 
-    const { stderr, exitCode } = await install(String(dir));
+    const { stderr, exitCode } = await run(String(dir), "install");
 
-    expect(stderr).toContain(`error: GET http://127.0.0.1:${server.port}/needs-creds - 401`);
-    expect(reqs).toEqual([{ path: "/needs-creds", auth: basicAuth }]);
-    expect(exitCode).toBe(1);
-  });
-
-  test("_authToken= appended to the bunfig.toml registry URL", async () => {
-    const reqs: Req[] = [];
-    await using server = unauthorizedRegistry(reqs);
-    using dir = tempDir("bunfig-authtoken-suffix-root", {
-      "bunfig.toml": `[install.registry]\nurl = "http://127.0.0.1:${server.port}/_authToken=tok"\n`,
-      "package.json": JSON.stringify({ name: "app", dependencies: { "needs-token": "1.0.0" } }),
-    });
-
-    const { stderr, exitCode } = await install(String(dir));
-
-    expect(stderr).toContain(`error: GET http://127.0.0.1:${server.port}/needs-token - 401`);
-    expect(reqs).toEqual([{ path: "/needs-token", auth: "Bearer tok" }]);
-    expect(exitCode).toBe(1);
-  });
-
-  test("registry URL with a path keeps the path", async () => {
-    const reqs: Req[] = [];
-    await using server = unauthorizedRegistry(reqs);
-    using dir = tempDir("npmrc-userinfo-path", {
-      ".npmrc": `registry=http://alice:s3cret@127.0.0.1:${server.port}/npm/\n`,
-      "package.json": JSON.stringify({ name: "app", dependencies: { "needs-creds": "1.0.0" } }),
-    });
-
-    const { stderr, exitCode } = await install(String(dir));
-
-    expect(stderr).toContain(`error: GET http://127.0.0.1:${server.port}/npm/needs-creds - 401`);
-    expect(reqs).toEqual([{ path: "/npm/needs-creds", auth: basicAuth }]);
+    expect(stderr.split(/\r?\n/)).toContain(`error: GET http://127.0.0.1:${server.port}/needs-creds - 401`);
+    expect(reqs).toEqual([{ path: "/needs-creds", auth: `Basic ${Buffer.from("alice:s3cret").toString("base64")}` }]);
     expect(exitCode).toBe(1);
   });
 });

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -678,7 +678,7 @@ describe.concurrent("registry URL with embedded credentials", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     return { stderr: stderr.split(/\r?\n/), exitCode };
   }
 

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -626,6 +626,108 @@ registry=https://somehost.com/org1/npm/registry/
   });
 });
 
+describe.concurrent("registry URL with embedded credentials", () => {
+  // Credentials written into the registry URL are split off and the URL is
+  // stored without them. The stored URL is what manifest URLs are joined onto
+  // and what error messages print, so a registry at the root of its host has
+  // to come back as "http://host/", not "http://host//".
+  test.each([
+    ["http://alice:s3cret@registry.example.com/", "http://registry.example.com/"],
+    ["http://alice:s3cret@registry.example.com", "http://registry.example.com/"],
+    ["http://alice:s3cret@registry.example.com:8080", "http://registry.example.com:8080/"],
+    ["http://alice:s3cret@registry.example.com/npm/", "http://registry.example.com/npm/"],
+    ["http://alice:s3cret@registry.example.com/npm", "http://registry.example.com/npm/"],
+  ])("registry=%s is stored as %s", (registry, url) => {
+    expect(loadNpmrc(`registry=${registry}\n`)).toMatchObject({
+      default_registry_url: url,
+      default_registry_username: "alice",
+      default_registry_password: "s3cret",
+    });
+  });
+
+  test.each([
+    ["http://:tok@registry.example.com/", "http://registry.example.com/"],
+    ["http://:tok@registry.example.com:8080", "http://registry.example.com:8080/"],
+    ["http://:tok@registry.example.com:8080/a/b/", "http://registry.example.com:8080/a/b/"],
+  ])("registry=%s is stored as %s", (registry, url) => {
+    expect(loadNpmrc(`registry=${registry}\n`)).toMatchObject({
+      default_registry_url: url,
+      default_registry_token: "tok",
+    });
+  });
+
+  type Req = { path: string; auth: string | null };
+  const basicAuth = `Basic ${Buffer.from("alice:s3cret").toString("base64")}`;
+
+  function unauthorizedRegistry(reqs: Req[]) {
+    return Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req) {
+        reqs.push({ path: new URL(req.url).pathname, auth: req.headers.get("authorization") });
+        return new Response("unauthorized", { status: 401 });
+      },
+    });
+  }
+
+  async function install(dir: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: dir,
+      env: { ...env, BUN_INSTALL_CACHE_DIR: join(dir, ".cache") },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    return { stderr: stderr.split(/\r?\n/), exitCode };
+  }
+
+  test("username:password in the .npmrc registry URL", async () => {
+    const reqs: Req[] = [];
+    await using server = unauthorizedRegistry(reqs);
+    using dir = tempDir("npmrc-userinfo-root", {
+      ".npmrc": `registry=http://alice:s3cret@127.0.0.1:${server.port}/\n`,
+      "package.json": JSON.stringify({ name: "app", dependencies: { "needs-creds": "1.0.0" } }),
+    });
+
+    const { stderr, exitCode } = await install(String(dir));
+
+    expect(stderr).toContain(`error: GET http://127.0.0.1:${server.port}/needs-creds - 401`);
+    expect(reqs).toEqual([{ path: "/needs-creds", auth: basicAuth }]);
+    expect(exitCode).toBe(1);
+  });
+
+  test("_authToken= appended to the bunfig.toml registry URL", async () => {
+    const reqs: Req[] = [];
+    await using server = unauthorizedRegistry(reqs);
+    using dir = tempDir("bunfig-authtoken-suffix-root", {
+      "bunfig.toml": `[install.registry]\nurl = "http://127.0.0.1:${server.port}/_authToken=tok"\n`,
+      "package.json": JSON.stringify({ name: "app", dependencies: { "needs-token": "1.0.0" } }),
+    });
+
+    const { stderr, exitCode } = await install(String(dir));
+
+    expect(stderr).toContain(`error: GET http://127.0.0.1:${server.port}/needs-token - 401`);
+    expect(reqs).toEqual([{ path: "/needs-token", auth: "Bearer tok" }]);
+    expect(exitCode).toBe(1);
+  });
+
+  test("registry URL with a path keeps the path", async () => {
+    const reqs: Req[] = [];
+    await using server = unauthorizedRegistry(reqs);
+    using dir = tempDir("npmrc-userinfo-path", {
+      ".npmrc": `registry=http://alice:s3cret@127.0.0.1:${server.port}/npm/\n`,
+      "package.json": JSON.stringify({ name: "app", dependencies: { "needs-creds": "1.0.0" } }),
+    });
+
+    const { stderr, exitCode } = await install(String(dir));
+
+    expect(stderr).toContain(`error: GET http://127.0.0.1:${server.port}/npm/needs-creds - 401`);
+    expect(reqs).toEqual([{ path: "/npm/needs-creds", auth: basicAuth }]);
+    expect(exitCode).toBe(1);
+  });
+});
+
 describe("scoped registry routing", () => {
   // A request for a @scope package must be sent only to that scope's configured
   // registry with that scope's token. The registry map was keyed by a bare


### PR DESCRIPTION
### Problem
- A registry whose URL carries credentials that bun strips out (`.npmrc` `registry=http://alice:s3cret@127.0.0.1:PORT/`, the same string in `bunfig.toml`, or the documented `url = "http://host/_authToken=TOKEN"` suffix form) is stored as `http://127.0.0.1:PORT//`. The same registry configured without credentials is stored as written, with one slash.
- The stored href is printed as-is by `bun pm whoami` (`failed to authenticate with registry 'http://127.0.0.1:PORT//'`) and quoted in the `for_manifest` diagnostics (`src/install/NetworkTask.rs:480-554`), and everything that builds a request from it inherits the extra slash: today the manifest URL (`error: GET http://127.0.0.1:PORT//somepkg - 401`) and the tarball URLs synthesized by the package-lock.json migration (`http://127.0.0.1:PORT//foo/-/foo-1.0.0.tgz`, written into `bun.lock`).
- Cosmetic on the wire: the HTTP client parses request URLs with `bun_url::URL::parse`, which collapses a leading `//` in the pathname, so the server still receives `GET /somepkg`. Found by inspection while working on #38796 (which leaves this helper alone), not from a user report.
- Cause: `URL::href_without_auth()` (`src/url/lib.rs`) writes `<proto>://<host>` + `/` + `trim(pathname, "/")` + `/` unconditionally, so a root pathname (trimmed to an empty string) yields `//`. Registries with a path (`/npm/`) come out right. The Zig implementation used the same format string, so this is not a regression.

### Fix
- When the trimmed path is empty, stop after the first `/`. The result now always ends in exactly one slash: `http://host/`, `http://host:8080/`, `http://host/npm/`.
- Correct because `http://host/` is what the same registry is stored as when nothing needs stripping, and it is the only producer of the `//` form: both credential-stripping callers (`src/api/lib.rs` for `.npmrc`/`bunfig.toml` strings, `Scope::from_api` in `src/install/npm.rs` for the `_authToken=`/`_auth=`/`:username=`/`:_password=` suffixes) store its return value, and #38796 still calls it after moving the first caller.
- Nothing else changes: the consumers that neither print nor build on the raw href (`url_hash`, tarball `build_url`, the manifest cache header, `url_is_under_registry`, `bun publish`, `bun pm view`, `bun audit`) already strip trailing slashes before use. The one persisted effect is the `@@<host>__<hash>` cache folder name, used for hostnames longer than 32 bytes, which hashes the href: such a registry configured with credentials in its URL gets a fresh cache folder once. (#36294 and #38183 deliberately leave the stored href as configured; this change rewrites only the value this helper already rewrites.)
- Relationship to the other changes in this area: #38183 (merged, this branch is rebased on it) passes the stored href through the WHATWG serializer, which keeps `//` (`new URL("http://h//").href` is `http://h//`), so the 7 failing tests below still fail on current main without this change. The open #36294 normalizes the join base in `for_manifest` and #38698 fixes the migration concatenation, so each of those removes the `//` from the request it builds regardless of what is stored; neither changes the stored value, `whoami`, or the quoted diagnostics, which is what this change fixes. None of them touches `src/url/lib.rs`; this composes with all of them. If the stored href should get a trailing-slash policy of its own, `Scope::set_url` from #38183 is the place, as a follow-up.
- Test: `test/cli/install/npmrc.test.ts`, new `registry URL with embedded credentials` block. The `loadNpmrc` rows assert the stored `default_registry_url` for the `user:pass@` and `:token@` forms (root path with and without a trailing slash or port, plus path forms that must stay unchanged); the `bun pm whoami` cases assert the stored href that `Scope::from_api` produces for the `_authToken=` suffix form (root and `/npm/`) and that the token is still sent. Both assert the stored value directly, so they keep exercising this change once #36294 lands. The `bun install` case pins today's `GET` line for the `.npmrc` userinfo form and checks the request path and `Basic` header. 7 of the 11 new tests fail on bun 1.4.0 and on a debug build of current main (`//`), all pass with this change.
- Also run with the fix: the rest of `npmrc.test.ts`, `redacted-config-logs.test.ts`, `config-precedence.test.ts`, the `whoami` tests in `bun-install-registry.test.ts`, and the two `bun-publish.test.ts` tests that print or embed the registry href.

### Background
- `bun_url::URL` is bun's lenient zero-copy URL scanner: each field is a slice of the input, and `pathname` defaults to `/` when the input has no path. `href_without_auth()` re-serializes such a URL without its `user:pass@` part and is only used when bun removes credentials from a configured registry URL; the resulting string becomes the registry's stored href (`Scope.url`).
- `NetworkTask::for_manifest` builds manifest URLs with `bun_url::join`, the WHATWG parser. Like `new URL("pkg", "http://host//")`, it keeps the double slash, which is how the stored value reached the `GET` line.

<details>
<summary>Output on bun 1.4.0 (mock registry answering 401)</summary>

```
.npmrc registry=http://127.0.0.1:PORT/                      -> error: GET http://127.0.0.1:PORT/somepkg - 401
.npmrc registry=http://alice:s3cret@127.0.0.1:PORT/         -> error: GET http://127.0.0.1:PORT//somepkg - 401
.npmrc registry=http://:s3cret@127.0.0.1:PORT/              -> error: GET http://127.0.0.1:PORT//somepkg - 401
.npmrc registry=http://alice:s3cret@127.0.0.1:PORT/npm/     -> error: GET http://127.0.0.1:PORT/npm/somepkg - 401
bunfig registry = "http://alice:s3cret@127.0.0.1:PORT/"     -> error: GET http://127.0.0.1:PORT//somepkg - 401
bunfig url = "http://127.0.0.1:PORT/_authToken=abc"         -> error: GET http://127.0.0.1:PORT//somepkg - 401
bunfig url = "http://127.0.0.1:PORT/_authToken=abc", bun pm whoami against a registry answering {} ->
    error: failed to authenticate with registry 'http://127.0.0.1:PORT//'
```

In every install case the mock server logged `GET /somepkg`; whoami requested `/-/whoami` with `Bearer abc`.
</details>

