### PR TITLE
install: read the package.json of a file: dependency declared by a local file: package

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2642,7 +2642,24 @@ fn get_or_put_resolved_package(
         dependency::version::Tag::Folder => {
             let folder = *version.folder();
             let res: FolderResolutionValue = 'res: {
-                if this.lockfile.is_workspace_dependency(dependency_id) {
+                if !this.lockfile.is_workspace_dependency(dependency_id)
+                    && crate::bin::bin_target_escapes_package_dir(this.lockfile.str(&folder))
+                {
+                    // overrides/resolutions are only ever parsed from the root
+                    // package.json, so a folder path that reached here via an
+                    // override was written by the user and is trusted the same
+                    // as a direct dependency of the root.
+                    let buf = this.lockfile.buffers.string_bytes.as_slice();
+                    if !this.lockfile.overrides.contains_name(
+                        dependency.name_hash,
+                        dependency.name.slice(buf),
+                        buf,
+                    ) {
+                        break 'res FolderResolutionValue::Err(crate::Error::MissingPackageJSON);
+                    }
+                }
+
+                if this.lockfile.is_dependency_of_local_package(dependency_id) {
                     // relative to cwd
                     // reshaped for borrowck — `folder_path` borrows
                     // `string_bytes`; detach the slice lifetime so the
@@ -2676,22 +2693,8 @@ fn get_or_put_resolved_package(
                     );
                 }
 
-                // transitive folder dependencies do not have their dependencies resolved
-                if crate::bin::bin_target_escapes_package_dir(this.lockfile.str(&folder)) {
-                    // overrides/resolutions are only ever parsed from the root
-                    // package.json, so a folder path that reached here via an
-                    // override was written by the user and is trusted the same
-                    // as a direct dependency of the root.
-                    let buf = this.lockfile.buffers.string_bytes.as_slice();
-                    if !this.lockfile.overrides.contains_name(
-                        dependency.name_hash,
-                        dependency.name.slice(buf),
-                        buf,
-                    ) {
-                        break 'res FolderResolutionValue::Err(crate::Error::MissingPackageJSON);
-                    }
-                }
-
+                // Declared by a registry package: `Package::from_npm` keeps the path
+                // relative to that package, which is not on disk until it is installed.
                 let mut package = Package::default();
 
                 {

--- a/src/install/PackageManager/PackageManagerResolution.rs
+++ b/src/install/PackageManager/PackageManagerResolution.rs
@@ -330,11 +330,10 @@ impl PackageManager {
                     continue;
                 }
 
-                let features = match pkg_resolutions[parent_id].tag {
-                    ResolutionTag::Root | ResolutionTag::Workspace | ResolutionTag::Folder => {
-                        self.options.local_package_features
-                    }
-                    _ => self.options.remote_package_features,
+                let features = if pkg_resolutions[parent_id].tag.is_local_package() {
+                    self.options.local_package_features
+                } else {
+                    self.options.remote_package_features
                 };
                 // even if optional dependencies are enabled, it's still allowed to fail
                 if failed_dep.behavior.is_optional() || !failed_dep.behavior.is_enabled(features) {

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -802,6 +802,31 @@ impl Lockfile {
         invalid_package_id
     }
 
+    /// The package whose dependency list contains `id`, or `invalid_package_id` when
+    /// no package declares it.
+    pub(crate) fn get_parent_pkg_of_dependency(&self, id: DependencyID) -> PackageID {
+        self.packages
+            .items_dependencies()
+            .iter()
+            .position(|dependencies| dependencies.contains(id))
+            .map_or(invalid_package_id, |pkg_id| {
+                PackageID::try_from(pkg_id).expect("int cast")
+            })
+    }
+
+    /// Is this a direct dependency of a local package (`resolution::Tag::is_local_package`)?
+    ///
+    /// A folder package declared by a registry package gets no dependency list (see the
+    /// Folder arm of `get_or_put_resolved_package`), so every folder package that
+    /// declares anything is reached from the root through local packages only.
+    pub(crate) fn is_dependency_of_local_package(&self, id: DependencyID) -> bool {
+        let parent_id = self.get_parent_pkg_of_dependency(id);
+        parent_id != invalid_package_id
+            && self.packages.items_resolution()[parent_id as usize]
+                .tag
+                .is_local_package()
+    }
+
     /// Does this tree id belong to a workspace (including workspace root)?
     /// TODO(dylan-conway) fix!
     pub(crate) fn is_workspace_tree_id(&self, id: tree::Id) -> bool {

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -602,11 +602,10 @@ pub(crate) fn is_filtered_dependency_or_workspace(
         return true;
     }
 
-    let dep_features = match parent_res.tag {
-        crate::resolution::Tag::Root
-        | crate::resolution::Tag::Workspace
-        | crate::resolution::Tag::Folder => manager.options.local_package_features,
-        _ => manager.options.remote_package_features,
+    let dep_features = if parent_res.tag.is_local_package() {
+        manager.options.local_package_features
+    } else {
+        manager.options.remote_package_features
     };
 
     if !dep.behavior.is_enabled(dep_features) {

--- a/src/install/resolution.rs
+++ b/src/install/resolution.rs
@@ -965,6 +965,13 @@ impl Tag {
         self == Tag::Git || self == Tag::Github
     }
 
+    /// The root, a workspace, or a `file:` folder: a package.json of the project's own,
+    /// so its dependencies get `local_package_features` and `Package::parse` stored its
+    /// `file:` paths relative to the top-level dir.
+    pub(crate) fn is_local_package(self) -> bool {
+        self == Tag::Root || self == Tag::Workspace || self == Tag::Folder
+    }
+
     pub(crate) fn can_enqueue_install_task(self) -> bool {
         self == Tag::Npm
             || self == Tag::LocalTarball

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -5243,6 +5243,97 @@ describe("transitive file dependencies", () => {
       version: "1.1.1",
     });
   });
+
+  // Unlike the registry packages above, whose file: targets only exist once the
+  // package is installed, a local file: package's own file: dependency is on
+  // disk while resolving, so it is read like one declared by the root.
+  for (const linker of ["hoisted", "isolated"] as const) {
+    test(`${linker}: a file: dependency of a local file: package is resolved like a root one`, async () => {
+      const { packageDir } = await registry.createTestDir({
+        bunfigOpts: { linker },
+        files: {
+          "package.json": JSON.stringify({
+            name: "foo",
+            dependencies: {
+              lib: "file:./vendor/lib",
+            },
+          }),
+          "vendor/lib/package.json": JSON.stringify({
+            name: "lib",
+            version: "1.0.0",
+            dependencies: {
+              tool: "file:../tool",
+            },
+          }),
+          "vendor/lib/index.js": `module.exports = "lib->" + require("tool");`,
+          "vendor/tool/package.json": JSON.stringify({
+            name: "tool",
+            version: "1.0.0",
+            bin: { tool: "cli.js" },
+            dependencies: {
+              "no-deps": "1.0.0",
+            },
+          }),
+          "vendor/tool/cli.js": `#!/usr/bin/env node\nconsole.log("tool");`,
+          "vendor/tool/index.js": `module.exports = "tool->no-deps@" + require("no-deps").version;`,
+        },
+      });
+      const libNodeModules =
+        linker === "hoisted"
+          ? join(packageDir, "node_modules", "lib", "node_modules")
+          : join(packageDir, "node_modules", ".bun", "lib@file+vendor+lib", "node_modules");
+
+      let { out } = await runBunInstall(env, packageDir);
+      expect(out).toContain("3 packages installed");
+
+      const lock = (await file(join(packageDir, "bun.lock")).text()).replaceAll(/localhost:\d+/g, "localhost:1234");
+      expect(normalizeBunSnapshot(lock)).toMatchInlineSnapshot(`
+        "{
+          "lockfileVersion": 2,
+          "configVersion": 1,
+          "workspaces": {
+            "": {
+              "name": "foo",
+              "dependencies": {
+                "lib": "file:./vendor/lib",
+              },
+            },
+          },
+          "packages": {
+            "lib": ["lib@file:vendor/lib", { "dependencies": { "tool": "file:../tool" } }],
+
+            "no-deps": ["no-deps@1.0.0", "http://localhost:1234/no-deps/-/no-deps-1.0.0.tgz", {}, "sha512-v4w12JRjUGvfHDUP8vFDwu0gUWu04j0cv9hLb1Abf9VdaXu4XcrddYFTMVBVvmldKViGWH7jrb6xPJRF0wq6gw=="],
+
+            "lib/tool": ["tool@file:vendor/tool", { "dependencies": { "no-deps": "1.0.0" }, "bin": { "tool": "cli.js" } }],
+          }
+        }"
+      `);
+
+      // Once from the package.json files, once from the lockfile they produced.
+      for (const frozenLockfile of [false, true]) {
+        if (frozenLockfile) {
+          await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+          ({ out } = await runBunInstall(env, packageDir, { frozenLockfile }));
+          expect(out).toContain("3 packages installed");
+        }
+
+        expect(await readdirSorted(join(libNodeModules, ".bin"))).toHaveBins(["tool"]);
+        expect(join(libNodeModules, ".bin", "tool")).toBeValidBin(join("..", "tool", "cli.js"));
+
+        await using proc = spawn({
+          cmd: [bunExe(), "-e", `console.log(require("lib"))`],
+          cwd: packageDir,
+          env,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [runOut, runErr, runExit] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(runErr).toBe("");
+        expect(runOut).toBe("lib->tool->no-deps@1.0.0\n");
+        expect(runExit).toBe(0);
+      }
+    });
+  }
 });
 
 test("name from manifest is scoped and url encoded", async () => {

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -1,7 +1,7 @@
 import { file, listen, Socket, spawn, write } from "bun";
 import { afterAll, beforeAll, describe, expect, it, jest, setDefaultTimeout, test } from "bun:test";
 import { readFileSync, readlinkSync, realpathSync, statSync } from "fs";
-import { access, cp, exists, mkdir, readlink, rm, stat, writeFile } from "fs/promises";
+import { access, chmod, cp, exists, mkdir, readlink, rm, stat, writeFile } from "fs/promises";
 import {
   bunEnv,
   bunExe,
@@ -10104,7 +10104,7 @@ for (const field of ["resolutions", "overrides"]) {
         "packages": {
           "pkg-a": ["pkg-a@file:pkg-a", { "dependencies": { "shared": "1.0.0" } }],
 
-          "pkg-a/shared": ["shared@file:./vendor/shared", {}],
+          "pkg-a/shared": ["shared@file:vendor/shared", {}],
         }
       }"
     `);
@@ -10170,6 +10170,152 @@ it("installs the transitive file: dependency of a file: dependency", async () =>
     expect(runExit).toBe(0);
   }
 });
+
+// Where each linker puts the `node_modules` of the two file: packages that have
+// dependencies. Folder packages are never hoisted, so `tool` lives under `lib`.
+// (bun-install-registry.test.ts covers requiring a registry dependency of such a
+// package at runtime.)
+for (const [linker, libNodeModules, toolNodeModules, toolNodeModulesEntries] of [
+  [
+    "hoisted",
+    join("node_modules", "lib", "node_modules"),
+    join("node_modules", "lib", "node_modules", "tool", "node_modules"),
+    [".bin", "dev-only", "helper"],
+  ],
+  [
+    "isolated",
+    join("node_modules", ".bun", "lib@file+vendor+lib", "node_modules"),
+    join("node_modules", ".bun", "tool@file+vendor+tool", "node_modules"),
+    // the isolated store also links a package's own bins into its own entry
+    [".bin", "dev-only", "helper", "tool"],
+  ],
+] as const) {
+  it.concurrent(`${linker}: nested file: dependencies are installed with their dependencies and bins`, async () => {
+    using dir = tempDir("nested-file-dep-bins", {
+      "package.json": JSON.stringify({
+        name: "my-app",
+        version: "1.0.0",
+        dependencies: {
+          lib: "file:./vendor/lib",
+        },
+      }),
+      "vendor/lib/package.json": JSON.stringify({
+        name: "lib",
+        version: "1.0.0",
+        dependencies: {
+          tool: "file:../tool",
+        },
+      }),
+      "vendor/tool/package.json": JSON.stringify({
+        name: "tool",
+        version: "1.0.0",
+        bin: { tool: "cli.js" },
+        dependencies: {
+          helper: "file:../helper",
+        },
+        devDependencies: {
+          "dev-only": "file:../dev-only",
+        },
+      }),
+      "vendor/tool/cli.js": "#!/bin/sh\necho tool\n",
+      "vendor/helper/package.json": JSON.stringify({
+        name: "helper",
+        version: "1.0.0",
+        bin: { helper: "cli.js" },
+      }),
+      "vendor/helper/cli.js": "#!/bin/sh\necho helper\n",
+      "vendor/dev-only/package.json": JSON.stringify({
+        name: "dev-only",
+        version: "1.0.0",
+      }),
+    });
+    const projectDir = String(dir);
+    const locks: string[] = [];
+
+    // The hoisted linker installs these packages as per-file symlinks and its bin
+    // chmod does not reach through them (#38777), so the scripts are made
+    // executable up front; what is checked below is that each .bin link runs
+    // the right script.
+    if (!isWindows) {
+      await chmod(join(projectDir, "vendor", "tool", "cli.js"), 0o755);
+      await chmod(join(projectDir, "vendor", "helper", "cli.js"), 0o755);
+    }
+
+    // The first pass resolves from the package.json files, the second installs
+    // what the first one recorded in bun.lock.
+    for (const args of [["install"], ["install", "--frozen-lockfile"]]) {
+      await rm(join(projectDir, "node_modules"), { recursive: true, force: true });
+
+      await using proc = spawn({
+        cmd: [bunExe(), ...args, `--linker=${linker}`],
+        cwd: projectDir,
+        stdout: "pipe",
+        stdin: "ignore",
+        stderr: "pipe",
+        env,
+      });
+      const [err, out, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+
+      expect(err).not.toContain("error:");
+      expect(out).toContain("4 packages installed");
+      expect(exitCode).toBe(0);
+
+      locks.push(await file(join(projectDir, "bun.lock")).text());
+
+      expect(await readdirSorted(join(projectDir, libNodeModules, ".bin"))).toHaveBins(["tool"]);
+      expect(join(projectDir, libNodeModules, ".bin", "tool")).toBeValidBin(join("..", "tool", "cli.js"));
+      expect(await readdirSorted(join(projectDir, toolNodeModules))).toEqual(toolNodeModulesEntries);
+      expect(join(projectDir, toolNodeModules, ".bin", "helper")).toBeValidBin(join("..", "helper", "cli.js"));
+
+      if (!isWindows) {
+        for (const [bin, expected] of [
+          [join(libNodeModules, ".bin", "tool"), "tool\n"],
+          [join(toolNodeModules, ".bin", "helper"), "helper\n"],
+        ]) {
+          await using binProc = spawn({
+            cmd: [join(projectDir, bin)],
+            cwd: projectDir,
+            stdout: "pipe",
+            stderr: "pipe",
+          });
+          const [binOut, binErr, binExit] = await Promise.all([
+            binProc.stdout.text(),
+            binProc.stderr.text(),
+            binProc.exited,
+          ]);
+          expect(binErr).toBe("");
+          expect(binOut).toBe(expected);
+          expect(binExit).toBe(0);
+        }
+      }
+    }
+
+    expect(locks[1]).toBe(locks[0]);
+    expect(normalizeBunSnapshot(locks[0], projectDir)).toMatchInlineSnapshot(`
+      "{
+        "lockfileVersion": 2,
+        "configVersion": 1,
+        "workspaces": {
+          "": {
+            "name": "my-app",
+            "dependencies": {
+              "lib": "file:./vendor/lib",
+            },
+          },
+        },
+        "packages": {
+          "lib": ["lib@file:vendor/lib", { "dependencies": { "tool": "file:../tool" } }],
+
+          "lib/tool": ["tool@file:vendor/tool", { "dependencies": { "helper": "file:../helper" }, "devDependencies": { "dev-only": "file:../dev-only" }, "bin": { "tool": "cli.js" } }],
+
+          "lib/tool/dev-only": ["dev-only@file:vendor/dev-only", {}],
+
+          "lib/tool/helper": ["helper@file:vendor/helper", { "bin": { "helper": "cli.js" } }],
+        }
+      }"
+    `);
+  });
+}
 
 const fileDepCycleFixture = {
   "package.json": JSON.stringify({
@@ -10267,9 +10413,9 @@ it("installs file: dependencies that depend on each other", async () => {
 
         "b": ["b@file:packages/b", { "dependencies": { "a": "file:../a" } }],
 
-        "a/b": ["b@file:packages/b", {}],
+        "a/b": ["b@file:packages/b", { "dependencies": { "a": "file:../a" } }],
 
-        "b/a": ["a@file:packages/a", {}],
+        "b/a": ["a@file:packages/a", { "dependencies": { "b": "file:../b" } }],
       }
     }"
   `);
@@ -10318,33 +10464,71 @@ it("installs file: dependencies that depend on each other from a lockfile that o
   `);
 });
 
-it("fails when a transitive file: dependency's folder does not exist", async () => {
-  using dir = tempDir("transitive-file-dep-missing", {
-    "package.json": JSON.stringify({
-      name: "my-app",
-      version: "1.0.0",
-      dependencies: {
-        lib: "file:./vendor/lib",
-      },
-    }),
-    "vendor/lib/package.json": JSON.stringify({
-      name: "lib",
-      version: "1.0.0",
-      dependencies: {
-        nested: "file:../nested",
-      },
-    }),
-    "vendor/lib/index.js": `module.exports = require("nested");`,
-  });
+const missingTransitiveFileDepFixture = {
+  "package.json": JSON.stringify({
+    name: "my-app",
+    version: "1.0.0",
+    dependencies: {
+      lib: "file:./vendor/lib",
+    },
+  }),
+  "vendor/lib/package.json": JSON.stringify({
+    name: "lib",
+    version: "1.0.0",
+    dependencies: {
+      nested: "file:../nested",
+    },
+  }),
+  "vendor/lib/index.js": `module.exports = require("nested");`,
+};
 
-  const { stdout, stderr, exited } = spawn({
+it.concurrent("fails to resolve when a transitive file: dependency's folder does not exist", async () => {
+  using dir = tempDir("transitive-file-dep-missing", missingTransitiveFileDepFixture);
+
+  await using proc = spawn({
     cmd: [bunExe(), "install"],
     cwd: String(dir),
     stdout: "pipe",
     stderr: "pipe",
     env,
   });
-  const [err, out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
+  const [err, out, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+
+  // Same failure as a missing file: dependency of the root: the folder is read
+  // while resolving, so nothing is installed and no lockfile is written.
+  expect(normalizeBunSnapshot(err, String(dir))).toMatchInlineSnapshot(`
+    "error: Could not find package.json for "file:vendor/nested" dependency "nested"
+    error: nested@file:../nested failed to resolve"
+  `);
+  expect(out).not.toContain("packages installed");
+  expect(await exists(join(String(dir), "bun.lock"))).toBe(false);
+  expect(await exists(join(String(dir), "node_modules"))).toBe(false);
+  expect(exitCode).toBe(1);
+});
+
+it.concurrent("fails to install a lockfile's transitive file: dependency whose folder is missing", async () => {
+  using dir = tempDir("transitive-file-dep-missing-lock", {
+    ...missingTransitiveFileDepFixture,
+    "bun.lock": JSON.stringify({
+      lockfileVersion: 1,
+      workspaces: {
+        "": { name: "my-app", dependencies: { lib: "file:./vendor/lib" } },
+      },
+      packages: {
+        "lib": ["lib@file:vendor/lib", { dependencies: { nested: "file:../nested" } }],
+        "lib/nested": ["nested@file:vendor/nested", {}],
+      },
+    }),
+  });
+
+  await using proc = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  const [err, out, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
 
   // The printed folder path uses the platform separator on Windows.
   expect(err.replaceAll(sep, "/")).toContain('Could not find folder "file:vendor/nested" for dependency "nested"');


### PR DESCRIPTION
### Problem
- A `file:` dependency declared by a local `file:` package gets a bare lockfile row: `"c/a": ["a@file:packages/a", {}]`. Its dependencies and bins are skipped with exit 0. A chain `app -> c -> a -> b` stops at `a`. Found by reproduction, no user report.
- The `Tag::Folder` arm of `get_or_put_resolved_package` (`src/install/PackageManager/PackageManagerEnqueue.rs:2877`) reads the folder's package.json only for a dependency of the root or a workspace. Other declarers get a stub, a name and a path only (#10445), because a registry package is not on disk while bun resolves.

### Fix
- The arm reads the folder when `is_dependency_of_local_package` holds. Remote declarers keep the stub and the `..` escape check.
- `is_dependency_of_local_package` (`src/install/lockfile.rs`) follows the chain: the declarer is the root, a workspace, or a `file:` package they reach through `file:` packages only. One hop (#33106) cuts a chain at depth three. This widening needs a maintainer's sign-off.
- Correct: each package.json in the chain is user authored, like a root `file:` dependency. The walk never passes through a remote package, so a folder it ships stays untrusted. Nested packages inherit the limits of depth-one `file:` packages (Notes).
- Script trust follows the same set (`Lockfile::local_packages`). A nested `file:` package's scripts are now recorded and blocked, so a `trustedDependencies` entry has to reach it. A `file:` declarer vouches only for another package in that set, declared under that package's own name: a git or tarball package it declares stays blocked (#31495 rule, its test is unchanged), and a trusted name meant for an npm package is not borrowed by a folder declared under that alias.
- Verified: 10 tests in `bun-install.test.ts`, 2 in `bun-install-registry.test.ts`, 1 in `migration/migrate.test.ts` fail on main.
- Draft until three things are settled: #38681 and #38850 land first, or two flows regress (Notes), and a maintainer decides how to bound the lockfile rows for mutually dependent `file:` packages (Notes, "Open: row count").

### Background
- A `file:` directory becomes a `Folder` package. Its lockfile path is root relative, so outside the project it starts with `../`.
- `bin_target_escapes_package_dir` detects a path that leaves its base directory.
- #31417 applied it to transitive folder paths so a registry package cannot link local directories.

<details><summary>Notes</summary>

**Open: row count.** Folder packages are never hoisted, and the tree builder only cuts a path when the same package is already an ancestor (`Tree.rs`). With the full read, every simple path through the local `file:` graph becomes a row. Measured with five `file:` packages that each depend on the other four: 26 rows on the released build (every chain stops at depth two), 326 rows here, 531 directories under `node_modules` with the hoisted linker. Eight such packages give about 110,000 rows. The bound is to place a folder package once per hoist root, that is, hoist local folders like workspaces. That changes the lockfile shape and the hoisted layout for every nested `file:` project and interacts with #40628, so it needs a maintainer's decision before this lands. The isolated store dedupes by package id, so only the lockfile and the hoisted layout grow.

**Landing order.** #38681, #38850, then this PR. Jarred's draft #39403 folds all three in one unit. Both prerequisites conflict with main today. Without them, two flows that work on main regress, because a nested folder no longer gets a stub:
- A nested folder whose package.json has no `name`. Main names the stub after the dependency (`"lib/gen": ["gen@file:lib/gen", {}]`). The full read writes `"lib/gen": ["@file:lib/gen", {}]`, which the next install cannot parse (`Invalid package resolution`, `Ignoring lockfile`, and `--frozen-lockfile` exits 1). A folder that the root declares already fails this way on main (#17060). #38681 names such packages after their folder.
- A nested row that bun re-resolves from bun.lock. bun.lock stores the literal `file:../helper`, and the loader joins it with the project root, not with the declaring package. Remove an override that names a nested local dependency, and `bun install` fails with `Could not find package.json for "file:../helper" dependency "helper"` until bun.lock is deleted. Main exits 0 there because the stub has no dependencies. `bun update <nested>` re-resolves the same literal. It fails on main too (`Failed to install 1 package`), and here while resolving. #38850 fixes the loader. Tests for both flows belong with #38850.

An alias fallback inside this PR for the first flow was considered and rejected: it is a second naming mechanism next to #38681, which fixes the cause for every depth.

**Inherited from depth-one `file:` packages**, on fresh resolves:
- A peer or semver edge to a vendored sibling goes to the registry, and fails for an unpublished name, as it does for a root-declared `file:` package on main. #33156 and #42545 are the open PRs in that area.
- bun.lock gets one row per path through the local `file:` graph, because folder packages are never hoisted.
- `{}` rows written by an older bun, and nested manifests edited later, are not refreshed until `bun update <root file: dep>`. #42030 re-reads `file:` manifests on every install.
- Under the hoisted linker the nested tree cannot be loaded from real-path code until #40628 (see "Known limit" below). Checked on a build of main plus this PR plus the source patch of #40628: the chain runs under the hoisted linker inside and outside the project (`c+a+b+d`, with bun and with node).

**Self-review.** 4 items raised, 2 addressed here: the vacuous lockfile comparison after `--frozen-lockfile` is replaced by a third, plain install in both nested tests, and this description now states the provenance, the landing order, and the inherited limits. The sign-off on the chain rule is a maintainer's decision. The alias fallback is rejected for the reason above. One more edge is known and accepted: the package-lock.json migrator decides trust when it dequeues a declarer, so a folder that a registry package's link entry reaches first is linked before the local chain marks it. The result is a skipped dependency with a warning, never extra trust, and main never trusts such a chain.

**Merge of main after #33106.** #33106 landed the helpers this PR had added in its shape (`Tag::is_local_package`, `get_parent_pkg_of_dependency`, `is_dependency_of_local_package`, `is_trusted_folder_dependency`), so they now come from main. The diff against main is the condition in the `Folder` arm, the chain walk, the one-line migration change, and tests.

**Why the chain rule.** #33106 trusts a `file:` parent only when the root or a workspace declares it directly (`is_workspace_declared_package`). Checked with that rule and this PR's `Folder` arm, on `app -> c -> a -> b -> d`:
- inside the project: `"c/a/b": ["b@file:packages/b", {}]`, `d` is not installed, exit 0 (the cut moves from depth two to depth three);
- outside the project (`file:../packages/c`): `error: Could not find package.json for "file:../packages/b" dependency "b"`.

`local_packages` replaces `is_workspace_declared_package`. It walks forward from the root and the workspaces through `Folder` packages only and returns the set it visited, so `a -> b -> a` terminates. Both callers of `is_trusted_folder_dependency` (the resolver and the hoisted installer's `refusing to install dependency ... with unsafe folder path` check) go through it, and so does `has_trusted_dependency` for non-npm packages. In `npm_lock.rs`, `local_declared` is now also set for the target of a `file:` spec that a trusted folder declares.

**Script trust.** Before this PR a nested `file:` package was a stub with no scripts, so nothing was blocked. With the full read its `postinstall` is blocked, and review found that `trustedDependencies: ["tool"]` did not unblock it: `declared_by_root_or_workspace` only scanned root and workspace dependency lists, so a fresh resolve still printed `Blocked 1 postinstall` and an install from the lockfile ran nothing. `bun pm trust tool` ran the script once but the entry it wrote had no effect. Now `declared_by_local_package` accepts a declarer in `local_packages`, and when that declarer is a `file:` package the dependency has to be in `local_packages` too, declared under its own package name. That keeps the #31495 rule (a trusted alias never unblocks a git or tarball package the root did not name) and its test `trustedDependencies entries for non-npm dependencies only apply to dependencies declared by the root or a workspace`. The name rule closes the case review raised: `vendor/sdk` (a copied third-party tree the root declares) says `sharp: file:./native`, and the root trusts `sharp` for the npm package. `native` is not named `sharp`, so the entry does not reach it. What remains for the sign-off: a root entry for name X runs the scripts of a folder named X that a `file:` package of yours declares as X. Left out on purpose: a nested folder declared under an alias unlike its own package name cannot be unblocked by any entry, because the entry is matched by alias and the alias has to equal the name. Nothing ran for such a folder on the released build, and `bun pm trust <alias>` still runs its scripts once on demand. Accepting the folder name alone is not an option: the #31495 test pins that an entry for the real name of a root-declared alias stays blocked, so it would be a different rule at depth two. The isolated linker prints no blocked count for any package (pre-existing), so the new test asserts that line under the hoisted linker only and the marker file under both. `docs/pm/lifecycle.mdx` states the rule.

With the chain rule, the same recipe gives four full rows (`c`, `c/a`, `c/a/b`, `c/a/b/d`) inside and outside the project, fresh and with `--frozen-lockfile`, with a byte-identical bun.lock on the second install. Also checked by hand: a workspace member as the first declarer, and an absolute `file:` path in the middle of the chain. `--linker=isolated` runs the chain (`c+a+b+d`).

**Still untrusted.** `refuses to install an escaping file: dependency at the end of a folder chain that a registry package ships` (hand-written bun.lock: `baz (registry) -> inner -> mid -> loot`) and `a file: dependency down a registry package's folder chain is still skipped` (migration) pin that a folder whose parent is a folder is not enough. The chain has to start at the root or a workspace. The existing one-hop tests from #33106 are unchanged and pass.

**Known limit, not part of this PR.** With the hoisted linker, a nested folder package is one symlink per file, so its code loads from the source folder and does not see the nested `node_modules` bun creates for it. `require("b")` from `a` fails at run time under the hoisted linker. #40628 changes the install method and fixes that. The new chain test asserts the layout under the hoisted linker and runs the chain under the isolated linker.

**What a user sees change**, on fresh resolution only (rows already in a lockfile are not re-resolved):
- The package's bins are linked into the declaring package's `.bin` under both linkers. Under the hoisted linker the bin chmod does not follow bun's own per-file symlinks (`lchmod`), so the link runs only if the vendored script is already executable. #38777 covers that half.
- The package's dependencies are resolved. A registry dependency of such a package is installed and can be required from its code under both linkers.
- A missing target folder fails while resolving, with the same error as a missing root `file:` dependency. The install-time error from #33159 still covers a lockfile whose folder disappeared later.
- A nested override that points a folder package's dependency at a `file:` path records the normalized path (`shared@file:vendor/shared`), as a root dependency does.
- `has_install_script` now comes from the package.json, so the scripts of such a package are blocked until the root lists the package in `trustedDependencies` (or `bun pm trust` does). See "Script trust" above.
- A folder reached from both the root and a `file:` package is one package, not a package plus a stub. `d1` declared by the root and by `file:` package `d2` installs as 2 packages, where main installs 3.
- A local tarball declared by such a package fails the same way one declared by a root `file:` package already does. #38816 covers `file:` folders declared by git and tarball packages, which this PR does not touch.

**Tests.**
- `bun-install.test.ts`: `hoisted:`/`isolated: nested file: dependencies are installed with their dependencies and bins` (root -> lib -> tool -> helper, bins, a `file:` devDependency, fresh and `--frozen-lockfile`, byte-identical lockfile). `hoisted:`/`isolated: installs a chain of local file: packages that point outside the project` (four hops, all outside). `fails to resolve when a transitive file: dependency's folder does not exist`, plus a lockfile variant that keeps the install-time assertion. `hoisted:`/`isolated: trustedDependencies unblocks the scripts of a nested file: package` (blocked without the entry, runs with it on a fresh resolve, from the lockfile and with `--frozen-lockfile`, a tarball `lib` declares under a trusted name stays blocked, and the `tool` folder declared by `lib` as `sharp` stays blocked when the root trusts `sharp`). Snapshot updates for the cycle test and the nested override test. The registry folder chain test above.
- `bun-install-registry.test.ts`: `hoisted:`/`isolated: a file: dependency of a local file: package is resolved like a root one` (the nested package depends on a registry package, and `require("lib")` reaches it at run time).
- `migration/migrate.test.ts`: `a chain of out-of-tree file: packages migrates` and the registry folder chain test above.
- Fail-before was checked with main's `src/` swapped in: the 8 + 2 + 1 tests named in Fix fail, the guards pass on both sides.
- Suites run with the fix (debug build): `bun-install` (the 13 bitbucket, gitlab, and external URL tests need network and fail without it), `bun-install-registry`, `migration/migrate`, `overrides`, `nested-overrides`, `bun-workspaces`, `isolated-install`, `bun-lock`, `bun-dedupe`, `bun-prune`, `lockfile-only`, `config-version`, `bun-update`, `bun-add`, `bun-remove`, `bun-patch`, `bun-pm`, `catalogs`. `bun-link.test.ts` has one failure that is the same with main's `src/` (a debug build prints a stack trace into the compared stderr).

**Earlier revisions.**
- The first push added a dedicated `Lockfile::is_dependency_of_folder_package` scan. Review pointed out that it was the same predicate #33106 introduces, so it was replaced with helpers in that shape.
- The second push only read the `.bin` links back. Review pointed out that under the hoisted linker a linked bin is not necessarily runnable, so the test makes the scripts executable and runs the links.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/migration/migrate.test.ts, test/cli/install/bun-install.test.ts, test/cli/install/bun-install-registry.test.ts

<!-- robobun:evidence:end -->


