### PR TITLE
websocket client: treat a buffer that cannot grow as out of memory on every path

### DIFF
--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -1000,9 +1000,7 @@ impl<const SSL: bool> WebSocket<SSL> {
         let frame_size = WebsocketHeader::frame_size_including_mask(compressed.len());
         {
             let mut send_buffer = self.send_buffer.borrow_mut();
-            let Ok(writable) = send_buffer.writable_with_size(frame_size) else {
-                return false;
-            };
+            let writable = bun_core::handle_oom(send_buffer.writable_with_size(frame_size));
             Copy::copy_compressed(
                 &self.global_this,
                 &mut writable[..frame_size],
@@ -1027,9 +1025,7 @@ impl<const SSL: bool> WebSocket<SSL> {
 
         {
             let mut send_buffer = self.send_buffer.borrow_mut();
-            let writable = send_buffer
-                .writable_with_size(write_len)
-                .expect("unreachable");
+            let writable = bun_core::handle_oom(send_buffer.writable_with_size(write_len));
             bytes.copy(
                 &self.global_this,
                 &mut writable[..write_len],

--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -485,7 +485,7 @@ impl<const SSL: bool> WebSocket<SSL> {
             return 0;
         }
 
-        self.buffer_payload(data).expect("unreachable");
+        bun_core::handle_oom(self.buffer_payload(data));
         if frame_complete {
             self.receive_body_remain.set(0);
             if is_final {
@@ -502,9 +502,8 @@ impl<const SSL: bool> WebSocket<SSL> {
         kind: Opcode,
         is_final: bool,
     ) -> usize {
-        if !data.is_empty() && self.buffer_payload(data).is_err() {
-            self.terminate(ErrorCode::Closed);
-            return 0;
+        if !data.is_empty() {
+            bun_core::handle_oom(self.buffer_payload(data));
         }
 
         if data.len() == left_in_fragment {

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -1568,13 +1568,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
         let overflow_len = remain_buf.len();
         let overflow_ptr: *mut u8 = if overflow_len > 0 {
             let mut v: Vec<u8> = Vec::new();
-            if v.try_reserve_exact(overflow_len).is_err() {
-                // OOM here terminates with `InvalidResponse` rather than
-                // aborting the process.
-                // SAFETY: no `&mut Self` is live across this call.
-                unsafe { Self::terminate(this, ErrorCode::InvalidResponse) };
-                return;
-            }
+            bun_core::handle_oom(v.try_reserve_exact(overflow_len));
             v.extend_from_slice(remain_buf);
             // Leak across the FFI boundary; `InitialDataHandler` reconstructs
             // the `Box<[u8]>` and drops it after delivery.


### PR DESCRIPTION
The client had two policies for the same allocation failure. Sending: the compressed path returned `false` from send_data when the send buffer could not grow, and its three callers discard that bool, so a compressed ws.send() under memory pressure vanished with no error and no close, while the uncompressed path did .expect("unreachable") on the identical call. Receiving: consume() expected, consume_compressed() terminated the connection with Closed. Both splits came over verbatim from the Zig (`catch return false` / `catch unreachable`).

All four sites now go through bun_core::handle_oom, like the ensure_total_capacity call in the same file already does: a controlled out-of-memory exit instead of a silent drop on one path and a panic that can unwind through the uWS callback on the other. Every non-OOM path is unchanged; the `false` returns that remain from send_data all mean "already terminated or already queued", which is why the callers may keep ignoring them.

permessage-deflate, proxy, upgrade and the main websocket client tests pass on the debug build. No new test: the change is only reachable when an allocation fails.