### PR TITLE
install: keep file: folder paths declared by git and tarball packages relative to the package

### DIFF
--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1847,10 +1847,9 @@ impl<'a> PackageInstaller<'a> {
                             );
                         }
 
-                        // One produced by `Package::from_npm` or by `Package::parse` with
-                        // `Features::NPM` (registry, git and tarball packages) is stored as
-                        // declared, i.e. relative to the declaring package, which installs at
-                        // `dirname(node_modules.path)` because transitive folders never hoist.
+                        // One from `Package::from_npm` or a `Features::NPM` parse is relative to
+                        // the declaring package, which installs at `dirname(node_modules.path)`
+                        // because transitive folders never hoist.
                         let dir_name = {
                             let d = dirname::<platform::Auto>(self.node_modules.path.as_slice());
                             if d.is_empty() {

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1847,8 +1847,8 @@ impl<'a> PackageInstaller<'a> {
                             );
                         }
 
-                        // One from `Package::from_npm` or a `Features::NPM` parse is relative to
-                        // the declaring package, which installs at `dirname(node_modules.path)`
+                        // One declared by a cache package (`from_npm`, `Features::NPM`) is
+                        // relative to that package, which installs at `dirname(node_modules.path)`
                         // because transitive folders never hoist.
                         let dir_name = {
                             let d = dirname::<platform::Auto>(self.node_modules.path.as_slice());

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1847,7 +1847,7 @@ impl<'a> PackageInstaller<'a> {
                             );
                         }
 
-                        // One declared by an npm manifest (`Package::from_npm`) is verbatim,
+                        // One declared by a registry, git or tarball package is verbatim,
                         // i.e. relative to the declaring package, which installs at
                         // `dirname(node_modules.path)` because transitive folders never hoist.
                         let dir_name = {

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1847,8 +1847,9 @@ impl<'a> PackageInstaller<'a> {
                             );
                         }
 
-                        // One declared by a registry, git or tarball package is verbatim,
-                        // i.e. relative to the declaring package, which installs at
+                        // One produced by `Package::from_npm` or by `Package::parse` with
+                        // `Features::NPM` (registry, git and tarball packages) is stored as
+                        // declared, i.e. relative to the declaring package, which installs at
                         // `dirname(node_modules.path)` because transitive folders never hoist.
                         let dir_name = {
                             let d = dirname::<platform::Auto>(self.node_modules.path.as_slice());

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -803,7 +803,8 @@ impl Lockfile {
     /// Is the package whose `node_modules` this tree represents resolved from a
     /// local `file:` folder? Its `Resolution::Folder` dependencies were normalized
     /// relative to the top-level dir (`Package::parse` with `Features::FOLDER`), unlike
-    /// those of registry, git and tarball packages, which stay relative to the package.
+    /// those `Package::from_npm` and `Package::parse` with `Features::NPM` produce,
+    /// which are stored as declared, relative to the package.
     pub(crate) fn is_folder_tree_id(&self, id: tree::Id) -> bool {
         if id == 0 {
             return false;

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -800,11 +800,9 @@ impl Lockfile {
                 .is_workspace()
     }
 
-    /// Is the package whose `node_modules` this tree represents resolved from a
-    /// local `file:` folder? Its `Resolution::Folder` dependencies were normalized
-    /// relative to the top-level dir (`Package::parse` with `Features::FOLDER`), unlike
-    /// those `Package::from_npm` and `Package::parse` with `Features::NPM` produce,
-    /// which are stored as declared, relative to the package.
+    /// Is the package whose `node_modules` this tree represents resolved from a local
+    /// `file:` folder? A `Features::FOLDER` parse rebased its `Resolution::Folder` dependencies
+    /// onto the top-level dir; `from_npm` / `Features::NPM` ones are package-relative.
     pub(crate) fn is_folder_tree_id(&self, id: tree::Id) -> bool {
         if id == 0 {
             return false;

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -802,7 +802,8 @@ impl Lockfile {
 
     /// Is the package whose `node_modules` this tree represents resolved from a
     /// local `file:` folder? Its `Resolution::Folder` dependencies were normalized
-    /// relative to the top-level dir (`Package::parse`), unlike npm's (`Package::from_npm`).
+    /// relative to the top-level dir (`Package::parse` with `Features::FOLDER`), unlike
+    /// those of registry, git and tarball packages, which stay relative to the package.
     pub(crate) fn is_folder_tree_id(&self, id: tree::Id) -> bool {
         if id == 0 {
             return false;

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -800,9 +800,8 @@ impl Lockfile {
                 .is_workspace()
     }
 
-    /// Is the package whose `node_modules` this tree represents resolved from a local
-    /// `file:` folder? A `Features::FOLDER` parse rebased its `Resolution::Folder` dependencies
-    /// onto the top-level dir; `from_npm` / `Features::NPM` ones are package-relative.
+    /// Is the package whose `node_modules` this tree represents a local `file:` folder? Its
+    /// folder dependencies are top-level-dir relative; a cache package's are package-relative.
     pub(crate) fn is_folder_tree_id(&self, id: tree::Id) -> bool {
         if id == 0 {
             return false;

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1843,11 +1843,8 @@ impl Package<u64> {
         }
 
         match dependency_version.tag {
-            // Only a manifest that lives in the project can have its `file:` folder
-            // paths rebased onto the top-level dir. A git/tarball package is parsed out
-            // of the cache (`Features::NPM`): its folder paths are kept as declared,
-            // like `Package::from_npm` keeps them, and the hoisted installer resolves
-            // them against the installed copy of the declaring package.
+            // A manifest parsed out of the cache (`Features::NPM`) keeps folder paths
+            // relative to its package, like `Package::from_npm`; see `PackageInstaller`.
             dependency::version::Tag::Folder
                 if features.is_main || features.is_workspace || features.is_folder =>
             {

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1843,11 +1843,11 @@ impl Package<u64> {
         }
 
         match dependency_version.tag {
-            // Only a manifest that lives in the project can have its `file:` paths
-            // rebased onto the top-level dir. A git/tarball package is parsed out of
-            // the cache: its paths stay relative to the package, as `Package::from_npm`
-            // stores them, and the installer resolves them against the installed copy
-            // of the declaring package.
+            // Only a manifest that lives in the project can have its `file:` folder
+            // paths rebased onto the top-level dir. A git/tarball package is parsed out
+            // of the cache (`Features::NPM`): its folder paths are kept as declared,
+            // like `Package::from_npm` keeps them, and the hoisted installer resolves
+            // them against the installed copy of the declaring package.
             dependency::version::Tag::Folder
                 if features.is_main || features.is_workspace || features.is_folder =>
             {

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1843,7 +1843,14 @@ impl Package<u64> {
         }
 
         match dependency_version.tag {
-            dependency::version::Tag::Folder => {
+            // Only a manifest that lives in the project can have its `file:` paths
+            // rebased onto the top-level dir. A git/tarball package is parsed out of
+            // the cache: its paths stay relative to the package, as `Package::from_npm`
+            // stores them, and the installer resolves them against the installed copy
+            // of the declaring package.
+            dependency::version::Tag::Folder
+                if features.is_main || features.is_workspace || features.is_folder =>
+            {
                 let folder = *dependency_version.folder();
                 let mut folder_buf = PathBuffer::uninit();
                 let Some(joined) = resolve_path::join_abs_string_buf_checked::<path::platform::Auto>(

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1843,8 +1843,7 @@ impl Package<u64> {
         }
 
         match dependency_version.tag {
-            // A manifest parsed out of the cache (`Features::NPM`) keeps folder paths
-            // relative to its package, like `Package::from_npm`; see `PackageInstaller`.
+            // Cache packages (`Features::NPM`) keep these package-relative, like `from_npm`.
             dependency::version::Tag::Folder
                 if features.is_main || features.is_workspace || features.is_folder =>
             {

--- a/src/install_types/resolver_hooks.rs
+++ b/src/install_types/resolver_hooks.rs
@@ -1204,8 +1204,6 @@ pub struct Features {
     pub dev_dependencies: bool,
     pub is_main: bool,
     pub is_workspace: bool,
-    /// The package.json of a local `file:` folder dependency. With `is_main` and
-    /// `is_workspace`, the manifests whose folder paths are rebased onto the top-level dir.
     pub is_folder: bool,
     pub optional_dependencies: bool,
     pub peer_dependencies: bool,

--- a/src/install_types/resolver_hooks.rs
+++ b/src/install_types/resolver_hooks.rs
@@ -1204,6 +1204,12 @@ pub struct Features {
     pub dev_dependencies: bool,
     pub is_main: bool,
     pub is_workspace: bool,
+    /// The package.json belongs to a local `file:` folder dependency. Together
+    /// with `is_main` / `is_workspace` this marks the manifests that live in the
+    /// project, whose `file:` dependency paths are stored relative to the
+    /// top-level dir. `NPM` (registry, git and tarball packages) is parsed out of
+    /// the cache and keeps them relative to the package instead.
+    pub is_folder: bool,
     pub optional_dependencies: bool,
     pub peer_dependencies: bool,
     pub trusted_dependencies: bool,
@@ -1218,6 +1224,7 @@ impl Default for Features {
             dev_dependencies: false,
             is_main: false,
             is_workspace: false,
+            is_folder: false,
             optional_dependencies: false,
             peer_dependencies: true,
             trusted_dependencies: false,
@@ -1240,6 +1247,7 @@ impl Features {
             dev_dependencies: false,
             is_main: false,
             is_workspace: false,
+            is_folder: false,
             optional_dependencies: false,
             peer_dependencies: true,
             trusted_dependencies: false,
@@ -1262,6 +1270,7 @@ impl Features {
 
     pub const FOLDER: Self = Self {
         dev_dependencies: true,
+        is_folder: true,
         optional_dependencies: true,
         ..Self::base()
     };

--- a/src/install_types/resolver_hooks.rs
+++ b/src/install_types/resolver_hooks.rs
@@ -1204,12 +1204,8 @@ pub struct Features {
     pub dev_dependencies: bool,
     pub is_main: bool,
     pub is_workspace: bool,
-    /// The package.json belongs to a local `file:` folder dependency. Together
-    /// with `is_main` / `is_workspace` this marks the manifests that live in the
-    /// project: `Package::parse` stores their `file:` folder dependency paths
-    /// relative to the top-level dir. Manifests parsed with `NPM` (git and
-    /// tarball packages, extracted into the cache) keep those paths as declared,
-    /// the same form `Package::from_npm` stores for registry packages.
+    /// The package.json of a local `file:` folder dependency. With `is_main` and
+    /// `is_workspace`, the manifests whose folder paths are rebased onto the top-level dir.
     pub is_folder: bool,
     pub optional_dependencies: bool,
     pub peer_dependencies: bool,

--- a/src/install_types/resolver_hooks.rs
+++ b/src/install_types/resolver_hooks.rs
@@ -1206,9 +1206,10 @@ pub struct Features {
     pub is_workspace: bool,
     /// The package.json belongs to a local `file:` folder dependency. Together
     /// with `is_main` / `is_workspace` this marks the manifests that live in the
-    /// project, whose `file:` dependency paths are stored relative to the
-    /// top-level dir. `NPM` (registry, git and tarball packages) is parsed out of
-    /// the cache and keeps them relative to the package instead.
+    /// project: `Package::parse` stores their `file:` folder dependency paths
+    /// relative to the top-level dir. Manifests parsed with `NPM` (git and
+    /// tarball packages, extracted into the cache) keep those paths as declared,
+    /// the same form `Package::from_npm` stores for registry packages.
     pub is_folder: bool,
     pub optional_dependencies: bool,
     pub peer_dependencies: bool,

--- a/test/cli/install/bun-install-git-deps.test.ts
+++ b/test/cli/install/bun-install-git-deps.test.ts
@@ -435,15 +435,10 @@ test.concurrent("installs a git+file:// dependency", async () => {
   expect(exitCode).toBe(0);
 });
 
-// A git or tarball package whose own package.json declares `file:` folder
-// dependencies (the shape registry packages publish too, see
-// registry/packages/file-dep). The paths are relative to the package, which is
-// extracted into the cache, so resolving them against the project dir turned
-// them into paths into the cache that were then rejected for escaping the
-// declaring package:
-//   error: Could not find package.json for "file:../<cache>/@T@.../sub" dependency "sub"
-//   error: sub@file:./sub failed to resolve
-// Registry packages keep the path as declared; git and tarball packages must too.
+// `file:` folder dependencies declared by a git or tarball package are relative
+// to that package, like a registry package's (registry/packages/file-dep). They
+// used to be resolved against the project dir, which pointed them into the cache
+// and failed the install with `sub@file:./sub failed to resolve`.
 const FILE_DEPS_NAME = "has-file-deps";
 
 // `file:` folder dependencies on a subfolder, on the package itself, and on a

--- a/test/cli/install/bun-install-git-deps.test.ts
+++ b/test/cli/install/bun-install-git-deps.test.ts
@@ -1,13 +1,15 @@
 // Tests for installing git dependencies that live in ONE repository as
-// multiple branches (issue #35420), `git+file://` dependencies, and
+// multiple branches (issue #35420), `git+file://` dependencies,
 // tarball-URL / `github:` dependencies that appear both directly and
-// transitively (issues #10915, #8501, #11348, #28284). Everything is local:
-// a bare repo on disk (served over git's dumb HTTP protocol by Bun.serve
+// transitively (issues #10915, #8501, #11348, #28284), and git / tarball
+// packages whose own package.json declares `file:` dependencies. Everything is
+// local: a bare repo on disk (served over git's dumb HTTP protocol by Bun.serve
 // when an http URL is needed) or static tarballs.
 import { expect, test } from "bun:test";
-import { mkdirSync, writeFileSync } from "fs";
+import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { lstat, readdir, readlink } from "fs/promises";
 import { bunEnv, bunExe, tempDir } from "harness";
-import { join } from "path";
+import { dirname, join, resolve } from "path";
 import { pathToFileURL } from "url";
 
 const gitEnv = {
@@ -35,6 +37,8 @@ interface BranchPackage {
   name: string;
   branch: string;
   dependencies?: Record<string, string>;
+  /** Files committed next to package.json; an `index.js` entry replaces the default one. */
+  files?: Record<string, string>;
 }
 
 // Creates `<root>/shared-repo.git`, a bare repo with one orphan branch per
@@ -47,14 +51,21 @@ async function makeSharedRepo(root: string, packages: BranchPackage[]): Promise<
   await git(work, "init", "-q");
   for (const pkg of packages) {
     await git(work, "checkout", "-q", "--orphan", pkg.branch);
-    writeFileSync(
-      join(work, "package.json"),
-      JSON.stringify({ name: pkg.name, version: "1.0.0", dependencies: pkg.dependencies }, null, 2),
-    );
-    writeFileSync(join(work, "index.js"), `module.exports = ${JSON.stringify(pkg.branch)};\n`);
+    const files: Record<string, string> = {
+      "package.json": JSON.stringify({ name: pkg.name, version: "1.0.0", dependencies: pkg.dependencies }, null, 2),
+      "index.js": `module.exports = ${JSON.stringify(pkg.branch)};\n`,
+      ...pkg.files,
+    };
+    for (const [path, contents] of Object.entries(files)) {
+      mkdirSync(dirname(join(work, path)), { recursive: true });
+      writeFileSync(join(work, path), contents);
+    }
     await git(work, "add", "-A");
     await git(work, "commit", "-q", "-m", pkg.branch, "--no-gpg-sign");
     await git(work, "push", "-q", bare, pkg.branch);
+    // `checkout --orphan` keeps the working tree, so the next branch would
+    // otherwise inherit this one's files.
+    for (const path of Object.keys(files)) rmSync(join(work, path), { force: true });
   }
   // dumb HTTP clients read the static files this generates
   await git(bare, "update-server-info");
@@ -422,4 +433,152 @@ test.concurrent("installs a git+file:// dependency", async () => {
   expect(stderr).not.toContain("error:");
   expect(await installedVersionOf(project, "@scope/pkg-b")).toBe("pkg-b");
   expect(exitCode).toBe(0);
+});
+
+// A git or tarball package whose own package.json declares `file:` dependencies
+// (the shape registry packages publish too, see registry/packages/file-dep).
+// The paths are relative to the package, which is extracted into the cache, so
+// resolving them against the project dir turned them into paths into the cache
+// that were then rejected for escaping the declaring package:
+//   error: Could not find package.json for "file:../<cache>/@T@.../sub" dependency "sub"
+//   error: sub@file:./sub failed to resolve
+// Registry packages keep the path as declared; git and tarball packages must too.
+const FILE_DEPS_NAME = "has-file-deps";
+
+// `file:` dependencies on a subfolder, on the package itself, and on a folder
+// that is not part of the package.
+const fileDepsManifest = {
+  name: FILE_DEPS_NAME,
+  version: "1.0.0",
+  dependencies: {
+    "sub": "file:./sub",
+    [`${FILE_DEPS_NAME}-self`]: "file:.",
+    "gone": "file:./not-in-package",
+  },
+};
+
+const fileDepsFiles = {
+  "index.js": `module.exports = require("sub");\n`,
+  "sub/package.json": JSON.stringify({ name: "sub", version: "1.0.0" }),
+  "sub/index.js": `module.exports = "sub-ok";\n`,
+};
+
+// Writes `<root>/work/package/` and packs it into `tarball`, a `.tgz` path.
+async function packTarball(root: string, tarball: string, manifest: object, files: Record<string, string>) {
+  const pkgDir = join(root, "work", "package");
+  for (const [path, contents] of Object.entries({ "package.json": JSON.stringify(manifest), ...files })) {
+    mkdirSync(dirname(join(pkgDir, path)), { recursive: true });
+    writeFileSync(join(pkgDir, path), contents);
+  }
+  mkdirSync(dirname(tarball), { recursive: true });
+  await run(root, ["tar", "-czf", tarball, "-C", join(root, "work"), "package"], "tar");
+}
+
+function writeProject(root: string, dependencies: Record<string, string>): string {
+  const project = join(root, "project");
+  mkdirSync(project, { recursive: true });
+  writeFileSync(join(project, "package.json"), JSON.stringify({ name: "project", version: "1.0.0", dependencies }));
+  return project;
+}
+
+async function linkedJson(link: string) {
+  expect((await lstat(link)).isSymbolicLink()).toBe(true);
+  return Bun.file(resolve(dirname(link), await readlink(link))).json();
+}
+
+async function expectFileDepsInstalled(project: string) {
+  const name = FILE_DEPS_NAME;
+  const nested = join(project, "node_modules", name, "node_modules");
+  const lockfile = await Bun.file(join(project, "bun.lock")).text();
+  expect(lockfile).toContain(`"${name}/sub": ["sub@file:./sub", {}]`);
+  expect(lockfile).toContain(`"${name}/${name}-self": ["${name}-self@file:.", {}]`);
+  expect(lockfile).toContain(`"${name}/gone": ["gone@file:./not-in-package", {}]`);
+
+  // Transitive folder dependencies are not hoisted: each one is linked file by
+  // file into the declaring package's own node_modules, relative to that
+  // package. The folder missing from the package is skipped, as it is for a
+  // registry package.
+  expect((await readdir(nested)).sort()).toEqual([`${name}-self`, "sub"]);
+  expect(await linkedJson(join(nested, "sub", "package.json"))).toEqual({ name: "sub", version: "1.0.0" });
+  expect(await linkedJson(join(nested, `${name}-self`, "package.json"))).toEqual(fileDepsManifest);
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `console.log(require(${JSON.stringify(name)}))`],
+    cwd: project,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, exitCode }).toEqual({ stdout: "sub-ok\n", stderr: "", exitCode: 0 });
+}
+
+for (const spec of ["file: path", "http url"] as const) {
+  test.concurrent(`installs the file: dependencies declared by a tarball package (${spec})`, async () => {
+    using dir = tempDir("tarball-file-deps", {});
+    const root = String(dir);
+    const tarballs = join(root, "tarballs");
+    await packTarball(root, join(tarballs, `${FILE_DEPS_NAME}.tgz`), fileDepsManifest, fileDepsFiles);
+    await using server = serveStatic(tarballs);
+    const project = writeProject(root, {
+      [FILE_DEPS_NAME]:
+        spec === "file: path"
+          ? `file:../tarballs/${FILE_DEPS_NAME}.tgz`
+          : `http://localhost:${server.port}/${FILE_DEPS_NAME}.tgz`,
+    });
+
+    const { stderr, exitCode } = await runInstall(project, join(root, "cache"), {});
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
+    await expectFileDepsInstalled(project);
+
+    // The stub rows written to bun.lock install again without re-resolving.
+    rmSync(join(project, "node_modules"), { recursive: true });
+    const frozen = await runInstall(project, join(root, "cache"), {}, "--frozen-lockfile");
+    expect(frozen.stderr).not.toContain("error:");
+    expect(frozen.exitCode).toBe(0);
+    await expectFileDepsInstalled(project);
+  });
+}
+
+test.concurrent(
+  "installs the file: dependencies declared by a git dependency",
+  async () => {
+    using dir = tempDir("git-dep-file-deps", {});
+    const root = String(dir);
+    const bare = await makeSharedRepo(root, [
+      { name: FILE_DEPS_NAME, branch: "main", dependencies: fileDepsManifest.dependencies, files: fileDepsFiles },
+    ]);
+    const project = writeProject(root, { [FILE_DEPS_NAME]: `git+${pathToFileURL(bare)}#main` });
+
+    const { stderr, exitCode } = await runInstall(project, join(root, "cache"), {});
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
+    await expectFileDepsInstalled(project);
+  },
+  30_000,
+);
+
+test.concurrent("does not install a file: dependency of a tarball package that points outside of it", async () => {
+  using dir = tempDir("tarball-escaping-file-dep", {
+    "outside/package.json": JSON.stringify({ name: "outside", version: "1.0.0" }),
+  });
+  const root = String(dir);
+  const tarball = join(root, "tarballs", "escaping.tgz");
+  await packTarball(
+    root,
+    tarball,
+    { name: "escaping", version: "1.0.0", dependencies: { outside: "file:../outside" } },
+    {},
+  );
+  const project = writeProject(root, { escaping: `file:../tarballs/escaping.tgz` });
+
+  const { stderr, exitCode } = await runInstall(project, join(root, "cache"), {});
+  expect(stderr).toContain('error: Could not find package.json for "file:../outside" dependency "outside"');
+  expect(stderr).toContain("error: outside@file:../outside failed to resolve");
+  expect(await Bun.file(join(project, "node_modules", "outside", "package.json")).exists()).toBe(false);
+  expect(
+    await Bun.file(join(project, "node_modules", "escaping", "node_modules", "outside", "package.json")).exists(),
+  ).toBe(false);
+  expect(exitCode).toBe(1);
 });

--- a/test/cli/install/bun-install-git-deps.test.ts
+++ b/test/cli/install/bun-install-git-deps.test.ts
@@ -2,9 +2,9 @@
 // multiple branches (issue #35420), `git+file://` dependencies,
 // tarball-URL / `github:` dependencies that appear both directly and
 // transitively (issues #10915, #8501, #11348, #28284), and git / tarball
-// packages whose own package.json declares `file:` dependencies. Everything is
-// local: a bare repo on disk (served over git's dumb HTTP protocol by Bun.serve
-// when an http URL is needed) or static tarballs.
+// packages whose own package.json declares `file:` folder dependencies.
+// Everything is local: a bare repo on disk (served over git's dumb HTTP
+// protocol by Bun.serve when an http URL is needed) or static tarballs.
 import { expect, test } from "bun:test";
 import { mkdirSync, rmSync, writeFileSync } from "fs";
 import { lstat, readdir, readlink } from "fs/promises";
@@ -435,18 +435,19 @@ test.concurrent("installs a git+file:// dependency", async () => {
   expect(exitCode).toBe(0);
 });
 
-// A git or tarball package whose own package.json declares `file:` dependencies
-// (the shape registry packages publish too, see registry/packages/file-dep).
-// The paths are relative to the package, which is extracted into the cache, so
-// resolving them against the project dir turned them into paths into the cache
-// that were then rejected for escaping the declaring package:
+// A git or tarball package whose own package.json declares `file:` folder
+// dependencies (the shape registry packages publish too, see
+// registry/packages/file-dep). The paths are relative to the package, which is
+// extracted into the cache, so resolving them against the project dir turned
+// them into paths into the cache that were then rejected for escaping the
+// declaring package:
 //   error: Could not find package.json for "file:../<cache>/@T@.../sub" dependency "sub"
 //   error: sub@file:./sub failed to resolve
 // Registry packages keep the path as declared; git and tarball packages must too.
 const FILE_DEPS_NAME = "has-file-deps";
 
-// `file:` dependencies on a subfolder, on the package itself, and on a folder
-// that is not part of the package.
+// `file:` folder dependencies on a subfolder, on the package itself, and on a
+// folder that is not part of the package.
 const fileDepsManifest = {
   name: FILE_DEPS_NAME,
   version: "1.0.0",
@@ -514,7 +515,7 @@ async function expectFileDepsInstalled(project: string) {
 }
 
 for (const spec of ["file: path", "http url"] as const) {
-  test.concurrent(`installs the file: dependencies declared by a tarball package (${spec})`, async () => {
+  test.concurrent(`installs the file: folder dependencies declared by a tarball package (${spec})`, async () => {
     using dir = tempDir("tarball-file-deps", {});
     const root = String(dir);
     const tarballs = join(root, "tarballs");
@@ -542,7 +543,7 @@ for (const spec of ["file: path", "http url"] as const) {
 }
 
 test.concurrent(
-  "installs the file: dependencies declared by a git dependency",
+  "installs the file: folder dependencies declared by a git dependency",
   async () => {
     using dir = tempDir("git-dep-file-deps", {});
     const root = String(dir);
@@ -559,7 +560,7 @@ test.concurrent(
   30_000,
 );
 
-test.concurrent("does not install a file: dependency of a tarball package that points outside of it", async () => {
+test.concurrent("rejects a file: folder dependency of a tarball package that points outside of it", async () => {
   using dir = tempDir("tarball-escaping-file-dep", {
     "outside/package.json": JSON.stringify({ name: "outside", version: "1.0.0" }),
   });


### PR DESCRIPTION
### Problem

- `bun install` fails as soon as a git or tarball dependency's own package.json declares a `file:` dependency on a directory (bun 1.4.0 and main, no network needed):
  ```
  error: Could not find package.json for "file:../../../root/.bun/install/cache/@T@5dbbd8f40f3d79f5@@@1/sub" dependency "sub"
  error: sub@file:./sub failed to resolve
  ```
  No `bun.lock` or `node_modules` is written, exit code 1. The same package published to a registry installs fine (`test/cli/install/bun-install-registry.test.ts`, "transitive file dependencies").
- Cause: `Package::parse_dependency` (`src/install/lockfile/Package.rs`, `Tag::Folder` arm) joins every `file:` folder path onto the directory of the package.json being parsed and stores it relative to the top-level dir. Git and tarball packages are parsed with that function too (`src/install/PackageManager/processDependencyList.rs`, `Features::NPM`), but their package.json lives in the install cache, so the stored path points into the cache. The resolver then refuses it as a transitive `file:` target outside the declaring package (`PackageManagerEnqueue.rs`, `bin_target_escapes_package_dir`), which is the error above. If the cache sits inside the project (`install.cache = ".bun-cache"` in bunfig), the path passes that check instead: `bun.lock` gets `"tb/sub": ["sub@file:.bun-cache/@T@5dbbd8f40f3d79f5@@@1/sub", {}]`, the install reports success, and the installer, looking for that path under the installed package, links nothing.
- Registry packages go through `Package::from_npm`, which stores the path exactly as declared, i.e. relative to the package, and that is the form the stub package in `PackageManagerEnqueue.rs` and the hoisted installer (`PackageInstaller.rs`, transitive folder branch: install from the declaring package's own directory) are built for.

### Fix

- `Features` gets an `is_folder` flag, set by `Features::FOLDER` next to the existing `is_main` / `is_workspace`. The `Tag::Folder` arm in `parse_dependency` now only rebases the path when one of the three is set, i.e. for a manifest that lives in the project (root, workspace member, local `file:` folder). `Features::NPM` parses (git, tarball, and the offline auto-install's cached npm manifest in `folder_resolver.rs`) fall through to the `_ => {}` arm and keep the path as declared. The guard on the match arm is the fix; the rest is the flag and keeping the two existing comments about the two path bases accurate.
- Why this is correct: a folder path declared by a package that is copied out of the cache is only meaningful relative to wherever that package gets installed, which is exactly what `from_npm` already records for registry packages and what the resolver and installer consume. A `file:./x.tgz` dependency and the same tarball published to a registry are the same artifact, so they now resolve to the same lockfile rows and the same layout. Rebasing onto the project dir is only defined for manifests that are in the project, and those three callers keep the old behavior byte for byte (#33159's installer branch for local `file:` declarers depends on it).
- Containment is unchanged: the stub path still goes through `bin_target_escapes_package_dir` at resolve time and the installer's checks at install time, so `file:../x` declared in a tarball is still rejected (and is now reported with the declared path instead of a cache path). A declared folder missing from the archive is tolerated the same way it is for registry packages.
- `Dependency::Version::eql` compares `file:` dependencies by their literal, so the stored form does not feed the lockfile diff, and `bun.lock` already loads these rows as declared, so a lockfile written after this change reloads to the same packages. Rows already in a lockfile are never re-resolved: a lockfile produced by the silent variant above keeps its cache-path row until that dependency is resolved again. #38850 (load-time rebase of rows declared by root / workspace / folder packages) skips every other declarer, so it agrees with the form this change produces.
- Verified with `test/cli/install/bun-install-git-deps.test.ts`: a package declaring `file:./sub`, `file:.` and a folder absent from the package, installed as a `file:` tarball path, a tarball URL and a `git+file://` dependency. Each asserts the `bun.lock` stub rows, that only the two existing folders are linked into the package's own `node_modules`, and that `require()` of the package reaches the nested folder at runtime; the tarball variants repeat that from `--frozen-lockfile`. A fourth test pins that `file:../outside` declared in a tarball still fails to resolve and links nothing. All four fail on the released build (`USE_SYSTEM_BUN=1`) and pass with this change. `makeSharedRepo` in that file gained a `files` option for the git case.
- Also run: the rest of `bun-install-git-deps.test.ts`, `bun-install.test.ts -t file` and `-t folder` (the #31417 / #32452 / #33159 transitive `file:` tests), `bun-install-registry.test.ts -t "transitive file dependencies"`, `isolated-install.test.ts -t file`; no changes.
- Out of scope, each tracked separately, none changed by this PR:
  - `file:` dependencies on a `.tgz` are `Tag::Tarball`, never touched this arm, and are resolved against the project root for every non-workspace declarer with no containment check (`enqueue_local_tarball`); identical before and after.
  - The isolated linker resolves every transitive folder stub against the project dir, so it fails on a registry package declaring a `file:` folder today; git and tarball packages now behave identically to registry packages there.
  - Folder rows created by the pnpm / package-lock importers under a registry or tarball declarer are project-relative and are silently skipped by the hoisted installer; the importers do not go through `Package::parse`.
  - #38814 (folder dependencies declared by local `file:` packages) and #33106 (escape check for local declarers) change the other branch of the same resolver arm and do not overlap with this change.

### Background

- A `file:` dependency on a directory is a `Tag::Folder` dependency and resolves to a `Resolution::Folder` whose payload is a path string. There are two bases for that string: manifests in the project (root, workspace members, local `file:` packages) store it relative to the top-level dir, which the resolver joins onto the cwd; everything installed from the cache stores it as declared, relative to the declaring package.
- For a declarer that is not the root or a workspace, the resolver does not read the target's package.json (it may not exist on disk until the declarer is installed). It records a stub package with just a name and the folder path (the `"tb/sub": ["sub@file:./sub", {}]` rows), after checking the path does not leave the declaring package. The hoisted installer later symlinks that folder, file by file, into the declaring package's own `node_modules`; folder packages are never hoisted.
- `Features` (`src/install_types/resolver_hooks.rs`) is the option set passed to `Package::parse`: which dependency sections to read plus which kind of manifest this is. `MAIN`, `WORKSPACE`, `FOLDER` are the project manifests; `NPM` is used for everything extracted into the cache (git, tarballs, cached npm packages) and for registry manifests in `from_npm`.
