### PR TITLE
install: redact secrets in the URLs printed for failed manifest and tarball downloads

### DIFF
--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -484,7 +484,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                             None,
                             bun_ast::Loc::EMPTY,
                             "<r><red><b>GET<r><red> {}<d> - {}<r>",
-                            bstr::BStr::new(metadata.url.slice()),
+                            bun_core::fmt::redacted_npm_url(metadata.url.slice()),
                             response.status_code,
                         );
                     } else {
@@ -493,7 +493,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                             None,
                             bun_ast::Loc::EMPTY,
                             "<r><yellow><b>GET<r><yellow> {}<d> - {}<r>",
-                            bstr::BStr::new(metadata.url.slice()),
+                            bun_core::fmt::redacted_npm_url(metadata.url.slice()),
                             response.status_code,
                         );
                     }
@@ -834,7 +834,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                             None,
                             bun_ast::Loc::EMPTY,
                             "<r><red><b>GET<r><red> {}<d> - {}<r>",
-                            bstr::BStr::new(metadata.url.slice()),
+                            bun_core::fmt::redacted_npm_url(metadata.url.slice()),
                             response.status_code,
                         );
                     } else {
@@ -843,7 +843,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                             None,
                             bun_ast::Loc::EMPTY,
                             "<r><yellow><b>GET<r><yellow> {}<d> - {}<r>",
-                            bstr::BStr::new(metadata.url.slice()),
+                            bun_core::fmt::redacted_npm_url(metadata.url.slice()),
                             response.status_code,
                         );
                     }

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -271,7 +271,7 @@ impl<'a> Installer<'a> {
                     bstr::BStr::new(name),
                     resolution.fmt(string_buf, bun_core::fmt::PathSep::Auto),
                     bstr::BStr::new(download_error_reason(err)),
-                    bstr::BStr::new(url),
+                    bun_core::fmt::redacted_npm_url(url),
                 ),
             );
             Output::flush();
@@ -382,7 +382,7 @@ impl<'a> Installer<'a> {
                         bstr::BStr::new(pkg_name.slice(string_buf)),
                         pkg_res.fmt(string_buf, bun_core::fmt::PathSep::Auto),
                         bstr::BStr::new(download_error_reason(dl.err)),
-                        bstr::BStr::new(&dl.url),
+                        bun_core::fmt::redacted_npm_url(&dl.url),
                     ),
                 );
             }

--- a/test/cli/install/redacted-config-logs.test.ts
+++ b/test/cli/install/redacted-config-logs.test.ts
@@ -243,3 +243,134 @@ describe.concurrent("redact", async () => {
     });
   }
 });
+
+// Covers the URL bun reports when a manifest or tarball request fails: the
+// manifest URL (after redirects) and the manifest's dist.tarball. Those come
+// from the registry, so a password or token in them is not something the user
+// wrote down themselves. The registry URL bun is configured with below carries
+// no secret; the secrets only enter through the redirect and dist.tarball.
+describe.concurrent("bun install masks secrets in the registry-supplied URL it prints after a failed download", () => {
+  const password = "s3cret";
+  const token = "npm_" + "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8";
+
+  function startRegistry() {
+    return Bun.serve({
+      port: 0,
+      fetch(req) {
+        const url = new URL(req.url);
+        const secretOrigin = `http://carol:${password}@${url.host}`;
+        switch (url.pathname) {
+          case "/redirected-pkg":
+            return Response.redirect(`${secretOrigin}/private/redirected-pkg?token=${token}`, 302);
+          case "/tarball-pkg":
+            return Response.json({
+              name: "tarball-pkg",
+              "dist-tags": { latest: "1.0.0" },
+              versions: {
+                "1.0.0": {
+                  name: "tarball-pkg",
+                  version: "1.0.0",
+                  dist: { tarball: `${secretOrigin}/cdn/tarball-pkg-1.0.0.tgz?token=${token}` },
+                },
+              },
+            });
+          default:
+            // Every other request, in particular the redirect target and the tarball, fails.
+            return new Response("not found", { status: 404 });
+        }
+      },
+    });
+  }
+
+  type Registry = ReturnType<typeof startRegistry>;
+
+  async function install(server: Registry, args: string[], files: Record<string, string>) {
+    using dir = tempDir("redacted-install-url", files);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install", "--registry", `http://${server.hostname}:${server.port}/`, ...args],
+      cwd: String(dir),
+      env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache") },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(out).not.toContain(password);
+    expect(out).not.toContain(token);
+    expect(err).not.toContain(password);
+    expect(err).not.toContain(token);
+    return { err, exitCode };
+  }
+
+  const masked = (server: Registry) => `http://carol:******@${server.hostname}:${server.port}`;
+
+  test("manifest request redirected to a URL with secrets (required dependency)", async () => {
+    await using server = startRegistry();
+    const { err, exitCode } = await install(server, [], {
+      "package.json": JSON.stringify({ name: "app", dependencies: { "redirected-pkg": "1.0.0" } }),
+    });
+    expect(err).toContain(`error: GET ${masked(server)}/private/redirected-pkg?token=*** - 404`);
+    expect(exitCode).toBe(1);
+  });
+
+  test("manifest request redirected to a URL with secrets (optional dependency)", async () => {
+    await using server = startRegistry();
+    const { err, exitCode } = await install(server, [], {
+      "package.json": JSON.stringify({ name: "app", optionalDependencies: { "redirected-pkg": "1.0.0" } }),
+    });
+    expect(err).toContain(`warn: GET ${masked(server)}/private/redirected-pkg?token=*** - 404`);
+    expect(exitCode).toBe(0);
+  });
+
+  test("dist.tarball URL with secrets (required dependency)", async () => {
+    await using server = startRegistry();
+    const { err, exitCode } = await install(server, [], {
+      "package.json": JSON.stringify({ name: "app", dependencies: { "tarball-pkg": "1.0.0" } }),
+    });
+    expect(err).toContain(`error: GET ${masked(server)}/cdn/tarball-pkg-1.0.0.tgz?token=*** - 404`);
+    expect(exitCode).toBe(1);
+  });
+
+  test("dist.tarball URL with secrets (optional dependency)", async () => {
+    await using server = startRegistry();
+    const { err, exitCode } = await install(server, [], {
+      "package.json": JSON.stringify({ name: "app", optionalDependencies: { "tarball-pkg": "1.0.0" } }),
+    });
+    expect(err).toContain(`warn: GET ${masked(server)}/cdn/tarball-pkg-1.0.0.tgz?token=*** - 404`);
+    expect(exitCode).toBe(0);
+  });
+
+  test("dist.tarball URL recorded in the lockfile, downloaded by the isolated linker", async () => {
+    await using server = startRegistry();
+    // What a previous install writes to bun.lock for an npm package whose
+    // dist.tarball is not the registry's default tarball location.
+    const tarball = `http://carol:${password}@${server.hostname}:${server.port}/cdn/tarball-pkg-1.0.0.tgz?token=${token}`;
+    const { err, exitCode } = await install(server, ["--linker", "isolated"], {
+      "package.json": JSON.stringify({ name: "app", dependencies: { "tarball-pkg": "1.0.0" } }),
+      "bun.lock": JSON.stringify({
+        lockfileVersion: 1,
+        workspaces: { "": { name: "app", dependencies: { "tarball-pkg": "1.0.0" } } },
+        packages: { "tarball-pkg": ["tarball-pkg@1.0.0", tarball, {}, ""] },
+      }),
+    });
+    expect(err).toContain(
+      `error: failed to download tarball-pkg@1.0.0: 404 Not Found\n  ${masked(server)}/cdn/tarball-pkg-1.0.0.tgz?token=***`,
+    );
+    expect(exitCode).toBe(1);
+  });
+
+  // A tarball URL written directly into package.json is printed as the
+  // dependency's resolution by other lines ("<name>@<url> failed to resolve",
+  // and the "failed to download <name>@<url>" prefix of the isolated linker
+  // message checked above), and those still print it verbatim.
+  test.todo("tarball URL written in package.json is masked wherever it is echoed", async () => {
+    await using server = startRegistry();
+    const spec = `http://carol:${password}@${server.hostname}:${server.port}/cdn/direct-1.0.0.tgz?token=${token}`;
+    for (const linker of ["hoisted", "isolated"]) {
+      const { err, exitCode } = await install(server, ["--linker", linker], {
+        "package.json": JSON.stringify({ name: "app", dependencies: { direct: spec } }),
+      });
+      expect(err).toContain(`error: GET ${masked(server)}/cdn/direct-1.0.0.tgz?token=*** - 404`);
+      expect(exitCode).toBe(1);
+    }
+  });
+});


### PR DESCRIPTION
### Problem
- When a manifest or tarball request fails with an HTTP error, `bun install` prints the URL of that request verbatim, including any secret inside it:
  - `error: GET http://alice:s3cret@127.0.0.1:PORT/no-deps - 404`
  - `error: GET http://127.0.0.1:PORT/cdn/pkg-1.0.0.tgz?token=npm_... - 404`
  - `error: failed to download pkg@1.0.0: 404 Not Found` followed by the same unredacted URL (isolated linker)
- These URLs come from the registry, not from the user's own files: the manifest URL as finally requested (a redirect target when the registry redirected), or the `dist.tarball` URL out of the manifest (also what bun.lock records for an npm package whose tarball is not at the default location). Registries and CDNs do hand out URLs with a token or password in them, so the user may never have seen the secret that ends up in their CI log. Credentials written into the configured registry URL itself used to end up here too; #38796 (merged) moves those into the Authorization header, which removes that one source but not the other two, which still print on current main.
- Cause: the four `GET {} - {}` lines in `src/install/PackageManager/runTasks.rs` (manifest and tarball, error and warning variants) and the two `failed to download` lines in `src/install/isolated_install/Installer.rs` format the URL with `bstr::BStr::new`. #36165 routed the `bun publish` / `bun pm view` error path and the verbose request line through `redacted_npm_url`; these lines were missed.

### Fix
- Format the URL operand at those six sites with `bun_core::fmt::redacted_npm_url` instead of `BStr::new`. The lines now read `GET http://alice:******@127.0.0.1:PORT/no-deps - 404` and `...tgz?token=*** - 404`.
- Correct because it is the formatter the rest of the package manager already uses for exactly this (`Npm::response_error` in `src/install/npm.rs`, the verbose `> HTTP/1.1 GET` line in `src/http/lib.rs`, `bun pm whoami`), so the install lines now behave like those. A URL without a password, UUID or `npm_` token prints byte for byte as before, and `bun audit fix` / `bun update`, which re-read the `GET <url>/<name> - <status>` text out of the log, still match it (their tests pass).
- Scope: the request URL operand only. A tarball or git URL that the user wrote into package.json is printed as the dependency's *resolution* by other lines (`name@<url> failed to resolve`, the `name@<url>` prefix of the isolated linker's `failed to download` line, the install summary, `bun pm ls`, ...) and those still print it verbatim. That is a sweep over the `Resolution` display sites, which #38631 is wrapping for control-character escaping at the same time; it is tracked separately so it can be done once, on top of #38631, rather than half of it here. The todo test at the end of the new block pins the shape that is still open.
- Overlap with #38631: it touches the same four tarball lines (`runTasks.rs` tarball error/warning, both `Installer.rs` lines) to wrap the URL in `escape_control_chars(..)`. Whichever lands second resolves those four lines to `EscapeControlChars(bun_core::fmt::redacted_npm_url(url))` (redact the raw bytes first, since the password scan stops at a newline; then escape what is printed). The manifest lines are not touched by #38631.
- Verified with `test/cli/install/redacted-config-logs.test.ts`: five new tests, one per print site, where the registry URL bun is configured with carries no secret and the secret reaches bun only through a manifest redirect or `dist.tarball` (so they stay meaningful after #38796). All five fail on current main (with #38796 and #38183 in) with the unredacted URL on stderr and pass with this change; the whole file passes (21 pass, 1 todo).
- Also ran `bun-install-retry.test.ts` (plain URLs through both the error and warning variants), the `bun audit fix` and `bun update` tests that parse these lines, and the `optionalDependencies` tests in `bun-install-registry.test.ts`.

### Background
- `redacted_npm_url` (`src/bun_core/fmt.rs`) is a `Display` adapter over URL bytes. It replaces the password part of `scheme://user:password@host` with one `*` per character, and any UUID or `npm_`/`npms_` token anywhere in the string with `***`; everything else is written through unchanged.
- The install loop keeps two copies of a request URL: `task.url_buf` is what it asked for, `metadata.url` is the URL of the response it actually got (the redirect target when the registry redirected). The `GET` lines print the latter.
- A package's *resolution* is how bun records where it came from: for a registry package it displays as the version (`pkg@1.0.0`), for a tarball or git dependency written in package.json it displays as that URL. Only the registry case is touched here, because there the URL is carried by the separate URL operand that this PR redacts.
- With `--linker isolated`, tarballs still missing from the cache at install time are downloaded by the store installer; its failures (HTTP status, network error, extract failure) all go through `on_package_download_error` / `on_task_fail` and print the `failed to download` line instead of the `GET` line. The hoisted linker prints the `GET` line in both phases.

