### PR TITLE
bundler: name the entry point flag at every construction and drop the unread is_html bit

### DIFF
--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -1203,7 +1203,7 @@ impl fmt::Display for UniqueKey {
     }
 }
 
-/// packed struct(u64) { source_index: u32, entry_point_id: u30, is_entry_point: bool, is_html: bool }
+/// packed struct(u64) { source_index: u32, entry_point_id: u30, is_entry_point: bool, _: u1 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Default, PartialEq, Eq)]
 pub struct EntryPoint(u64);
@@ -1213,19 +1213,19 @@ pub(crate) type EntryPointId = u32;
 
 impl EntryPoint {
     const ENTRY_POINT_ID_MASK: u64 = (1 << 30) - 1;
+    const IS_ENTRY_POINT_BIT: u64 = 1 << 62;
 
-    pub(crate) fn new(
-        source_index: u32,
-        entry_point_id: u32,
-        is_entry_point: bool,
-        is_html: bool,
-    ) -> Self {
+    /// The chunk that entry point `entry_point_id` itself produces.
+    pub(crate) fn entry_point(source_index: u32, entry_point_id: EntryPointId) -> Self {
+        EntryPoint(Self::non_entry_point(source_index, entry_point_id).0 | Self::IS_ENTRY_POINT_BIT)
+    }
+
+    /// A chunk generated on behalf of `entry_point_id` (code-split, dev-server
+    /// CSS/HTML) that is not itself an entry point.
+    pub(crate) fn non_entry_point(source_index: u32, entry_point_id: EntryPointId) -> Self {
         debug_assert!((entry_point_id as u64) <= Self::ENTRY_POINT_ID_MASK);
         EntryPoint(
-            (source_index as u64)
-                | (((entry_point_id as u64) & Self::ENTRY_POINT_ID_MASK) << 32)
-                | ((is_entry_point as u64) << 62)
-                | ((is_html as u64) << 63),
+            (source_index as u64) | (((entry_point_id as u64) & Self::ENTRY_POINT_ID_MASK) << 32),
         )
     }
 
@@ -1241,7 +1241,7 @@ impl EntryPoint {
 
     #[inline]
     pub(crate) fn is_entry_point(self) -> bool {
-        (self.0 >> 62) & 1 != 0
+        self.0 & Self::IS_ENTRY_POINT_BIT != 0
     }
 
     #[inline]

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5520,7 +5520,7 @@ pub mod bv2_impl {
 
             // First is a chunk to contain all JavaScript modules.
             chunks.push(Chunk {
-                entry_point: chunk::EntryPoint::new(0, 0, true, false),
+                entry_point: chunk::EntryPoint::entry_point(0, 0),
                 content: chunk::Content::Javascript(chunk::JavaScriptChunk {
                     files_in_chunk_order: js_reachable_files
                         .iter()
@@ -5539,11 +5539,9 @@ pub mod bv2_impl {
                 let order = crate::linker_context::find_imported_files_in_css_order::find_imported_files_in_css_order(&mut self.linker, self.graph.heap, &[*entry_point]);
                 let order_len = order.len() as usize;
                 chunks.push(Chunk {
-                    entry_point: chunk::EntryPoint::new(
+                    entry_point: chunk::EntryPoint::non_entry_point(
                         entry_point.get(),
                         entry_point.get(),
-                        false,
-                        false,
                     ),
                     content: chunk::Content::Css(chunk::CssChunk {
                         imports_in_chunk_in_order: order,
@@ -5560,11 +5558,9 @@ pub mod bv2_impl {
             // Then all HTML files
             for source_index in html_files.keys() {
                 chunks.push(Chunk {
-                    entry_point: chunk::EntryPoint::new(
+                    entry_point: chunk::EntryPoint::non_entry_point(
                         source_index.get(),
                         source_index.get(),
-                        false,
-                        true,
                     ),
                     content: chunk::Content::Html,
                     output_source_map: SourceMap::SourceMapPieces::init(),

--- a/src/bundler/linker_context/computeChunks.rs
+++ b/src/bundler/linker_context/computeChunks.rs
@@ -127,7 +127,7 @@ pub(crate) fn compute_chunks(
             let html_chunk_entry = html_chunks.get_or_put(js_chunk_key)?;
             if !html_chunk_entry.found_existing {
                 *html_chunk_entry.value_ptr = Chunk {
-                    entry_point: chunk::EntryPoint::new(source_index, entry_bit, true, false),
+                    entry_point: chunk::EntryPoint::entry_point(source_index, entry_bit),
                     entry_bits: entry_point_chunk_bits.clone()?,
                     content: chunk::Content::Html,
                     output_source_map: SourceMapPieces::init(),
@@ -168,7 +168,7 @@ pub(crate) fn compute_chunks(
                 // const css_chunk_entry = try js_chunks.getOrPut();
                 let order_len = order.len() as usize;
                 *css_chunk_entry.value_ptr = Chunk {
-                    entry_point: chunk::EntryPoint::new(source_index, entry_bit, true, false),
+                    entry_point: chunk::EntryPoint::entry_point(source_index, entry_bit),
                     entry_bits: entry_point_chunk_bits,
                     content: chunk::Content::Css(chunk::CssChunk {
                         imports_in_chunk_in_order: order,
@@ -196,7 +196,7 @@ pub(crate) fn compute_chunks(
         entry_point_to_js_chunk_idx[entry_id_] =
             u32::try_from(js_chunk_entry.index).expect("int cast");
         *js_chunk_entry.value_ptr = Chunk {
-            entry_point: chunk::EntryPoint::new(source_index, entry_bit, true, false),
+            entry_point: chunk::EntryPoint::entry_point(source_index, entry_bit),
             entry_bits: entry_point_chunk_bits,
             content: chunk::Content::Javascript(chunk::JavaScriptChunk::default()),
             output_source_map: SourceMapPieces::init(),
@@ -259,7 +259,7 @@ pub(crate) fn compute_chunks(
                         }
                     }
                     *css_chunk_entry.value_ptr = Chunk {
-                        entry_point: chunk::EntryPoint::new(source_index, entry_bit, true, false),
+                        entry_point: chunk::EntryPoint::entry_point(source_index, entry_bit),
                         entry_bits: entry_bits.clone()?,
                         content: chunk::Content::Css(chunk::CssChunk {
                             imports_in_chunk_in_order: order,
@@ -307,11 +307,9 @@ pub(crate) fn compute_chunks(
                                     && ast_targets[source_index.get() as usize] == Target::Browser;
                             *js_chunk_entry.value_ptr = Chunk {
                                 entry_bits: entry_bits.clone()?,
-                                entry_point: chunk::EntryPoint::new(
+                                entry_point: chunk::EntryPoint::non_entry_point(
                                     source_index.get(),
                                     0,
-                                    false,
-                                    false,
                                 ),
                                 content: chunk::Content::Javascript(
                                     chunk::JavaScriptChunk::default(),


### PR DESCRIPTION
Chunk's EntryPoint was built with `new(source_index, entry_point_id, is_entry_point: bool, is_html: bool)` and all eight call sites passed bare literals. The two HTML-chunk sites disagreed through exactly those slots: computeChunks passed `true, false`, the dev server path in bundle_v2 passed `false, true`, where the Zig set only `.is_entry_point` at both and never touched `is_html` anywhere. Looking for what that stray `true` did turned up that nothing reads `is_html` at all, in Rust or in the Zig before it: every "is this chunk HTML" decision goes through `chunk.content`.

So the bit goes away (bit 63 documented as spare) and the constructor becomes `EntryPoint::entry_point(si, id)` / `EntryPoint::non_entry_point(si, id)`, so each site says by name what it sets and there is nothing left to transpose. `is_entry_point` keeps its position and value at every site.

No behavior change. bundler_html, html-import-manifest and the bake dev html/css/esm tests pass on the debug build; a split HTML build produces the same files and metafile as before.