### PR TITLE
bun test: name snapshots taken in beforeEach/afterEach after the running test

### DIFF
--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -1463,17 +1463,31 @@ impl RefDataValue {
     }
 
     pub(crate) fn entry<'a>(&self, buntest: &'a mut BunTest) -> Option<&'a mut ExecutionEntry> {
+        let sequence = self.running_sequence(buntest)?;
+        // SAFETY: `active_entry` is a valid intrusive node while the sequence is live.
+        unsafe { sequence.active_entry.map(|p| &mut *p.as_ptr()) }
+    }
+
+    /// The entry a snapshot is named after: the test, also while its beforeEach/afterEach run (jest's currentTestName).
+    pub(crate) fn snapshot_entry<'a>(&self, buntest: &'a mut BunTest) -> Option<&'a ExecutionEntry> {
+        let sequence = self.running_sequence(buntest)?;
+        // beforeAll/afterAll sequences have no test, so their snapshots are named after the hook entry itself.
+        let entry = sequence.test_entry.or(sequence.active_entry)?;
+        // SAFETY: `test_entry`/`active_entry` are valid intrusive nodes while the sequence is live.
+        Some(unsafe { &*entry.as_ptr() })
+    }
+
+    /// The sequence this state was captured in, while it is still the one running (unknown inside a concurrent group).
+    fn running_sequence<'a>(&self, buntest: &'a mut BunTest) -> Option<&'a Execution::ExecutionSequence> {
         if !matches!(self, RefDataValue::Execution { .. }) {
             return None;
         }
         if buntest.phase != Phase::Execution {
             return None;
         }
-        let (the_sequence, _) = buntest.execution.get_current_and_valid_execution_sequence(self)?;
-        // SAFETY: `the_sequence` is a NonNull into `execution.sequences`; deref
-        // at point-of-use only. `active_entry` is a valid intrusive node while
-        // the sequence is live.
-        unsafe { the_sequence.as_ref().active_entry.map(|p| &mut *p.as_ptr()) }
+        let (sequence, _) = buntest.execution.get_current_and_valid_execution_sequence(self)?;
+        // SAFETY: `sequence` points into `buntest.execution.sequences`, which stays borrowed for `'a`.
+        Some(unsafe { &*sequence.as_ptr() })
     }
 }
 

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -623,25 +623,10 @@ impl Expect {
         let parent = self.parent.as_ref().ok_or(crate::Error::NoTest)?;
         let buntest_strong = parent.bun_test().ok_or(crate::Error::TestNotActive)?;
         let buntest = buntest_strong.get();
-        let active_entry = core::ptr::NonNull::from(
-            parent
-                .phase
-                .entry(buntest)
-                .ok_or(crate::Error::SnapshotInConcurrentGroup)?,
-        );
-        // While a beforeEach/afterEach/onTestFinished callback runs, the active
-        // entry is the hook, but the snapshot belongs to the test whose sequence
-        // the hook runs in (as with jest's currentTestName). beforeAll/afterAll
-        // sequences have no test and stay keyed by the hook entry itself.
-        let named_entry = parent
+        let execution_entry = parent
             .phase
-            .sequence(buntest)
-            .and_then(|sequence| sequence.test_entry)
-            .unwrap_or(active_entry);
-        // SAFETY: both candidates are entries of the sequence `entry()` just
-        // validated as running; entries are owned by `buntest`, which
-        // `buntest_strong` keeps alive for the rest of this function.
-        let execution_entry = unsafe { named_entry.as_ref() };
+            .snapshot_entry(buntest)
+            .ok_or(crate::Error::SnapshotInConcurrentGroup)?;
 
         let test_name: &[u8] = execution_entry.base.name.as_deref().unwrap_or(b"(unnamed)");
 

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -623,10 +623,25 @@ impl Expect {
         let parent = self.parent.as_ref().ok_or(crate::Error::NoTest)?;
         let buntest_strong = parent.bun_test().ok_or(crate::Error::TestNotActive)?;
         let buntest = buntest_strong.get();
-        let execution_entry = parent
+        let active_entry = core::ptr::NonNull::from(
+            parent
+                .phase
+                .entry(buntest)
+                .ok_or(crate::Error::SnapshotInConcurrentGroup)?,
+        );
+        // While a beforeEach/afterEach/onTestFinished callback runs, the active
+        // entry is the hook, but the snapshot belongs to the test whose sequence
+        // the hook runs in (as with jest's currentTestName). beforeAll/afterAll
+        // sequences have no test and stay keyed by the hook entry itself.
+        let named_entry = parent
             .phase
-            .entry(buntest)
-            .ok_or(crate::Error::SnapshotInConcurrentGroup)?;
+            .sequence(buntest)
+            .and_then(|sequence| sequence.test_entry)
+            .unwrap_or(active_entry);
+        // SAFETY: both candidates are entries of the sequence `entry()` just
+        // validated as running; entries are owned by `buntest`, which
+        // `buntest_strong` keeps alive for the rest of this function.
+        let execution_entry = unsafe { named_entry.as_ref() };
 
         let test_name: &[u8] = execution_entry.base.name.as_deref().unwrap_or(b"(unnamed)");
 

--- a/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
+++ b/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
@@ -72,7 +72,7 @@ describe("snapshots taken in hooks", () => {
       cmd: [bunExe(), "test", "./hooks.test.ts"],
       env: { ...bunEnv, CI: "false" },
       cwd: dir,
-      stdout: "pipe",
+      stdout: "ignore",
       stderr: "pipe",
     });
     const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);

--- a/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
+++ b/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
@@ -130,6 +130,32 @@ describe("snapshots taken in hooks", () => {
     expect(exitCode).toBe(0);
   });
 
+  test.concurrent("per-test hooks share the test's counter, beforeAll/afterAll share the describe's", async () => {
+    using dir = tempDir("snapshot-hook-counters", {
+      "hooks.test.ts": /*js*/ `
+        import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+        describe("d", () => {
+          beforeAll(() => expect("ba").toMatchSnapshot("setup"));
+          beforeEach(() => expect("be").toMatchSnapshot("setup"));
+          afterEach(() => expect("ae").toMatchSnapshot("setup"));
+          afterAll(() => expect("aa").toMatchSnapshot("setup"));
+          test("t1", () => expect("body").toMatchSnapshot("setup"));
+        });
+      `,
+    });
+    const { exitCode, stderr, entries } = await runHooksFile(String(dir));
+    expect(entries).toEqual([
+      'd (unnamed): setup 1 = "ba"',
+      'd t1: setup 1 = "be"',
+      'd t1: setup 2 = "body"',
+      'd t1: setup 3 = "ae"',
+      'd (unnamed): setup 2 = "aa"',
+    ]);
+    expect(stderr).toContain(" 1 pass");
+    expect(stderr).toContain(" 0 fail");
+    expect(exitCode).toBe(0);
+  });
+
   test.concurrent("adding a test does not invalidate the hook snapshots of the other tests", async () => {
     const source = (extraTest: string) => /*js*/ `
       import { afterEach, describe, expect, test } from "bun:test";

--- a/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
+++ b/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it, test } from "bun:test";
+import { writeFileSync } from "fs";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 test("it will create a snapshot file if it doesn't exist", () => {
   expect({ a: { b: { c: false } }, c: 2, jkfje: 99238 }).toMatchSnapshot({ a: { b: { c: expect.any(Boolean) } } });
@@ -60,5 +62,99 @@ describe("toMatchSnapshot errors", () => {
       // @ts-expect-error
       expect({ a: 4 }).toMatchSnapshot({ a: expect.any("not a constructor") });
     }).toThrow();
+  });
+});
+
+describe("snapshots taken in hooks", () => {
+  // Runs <dir>/hooks.test.ts and returns the `key = value` entries of the .snap file it wrote, in file order.
+  async function runHooksFile(dir: string): Promise<{ exitCode: number; stderr: string; entries: string[] }> {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "./hooks.test.ts"],
+      env: { ...bunEnv, CI: "false" },
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const snap = await Bun.file(dir + "/__snapshots__/hooks.test.ts.snap").text();
+    const entries = [...snap.matchAll(/^exports\[`(.*)`\] = `(.*)`;$/gm)].map(m => `${m[1]} = ${m[2]}`);
+    return { exitCode, stderr, entries };
+  }
+
+  test.concurrent("beforeEach/afterEach/onTestFinished snapshots are named after the running test", async () => {
+    using dir = tempDir("snapshot-hook-names", {
+      "hooks.test.ts": /*js*/ `
+        import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, onTestFinished, test } from "bun:test";
+        beforeEach(() => expect("top").toMatchSnapshot("top beforeEach"));
+        describe("outer", () => {
+          beforeEach(() => expect("outer").toMatchSnapshot("outer beforeEach"));
+          describe("inner", () => {
+            beforeAll(() => expect("ba").toMatchSnapshot("beforeAll"));
+            beforeEach(() => expect("inner").toMatchSnapshot("inner beforeEach"));
+            beforeEach(() => expect("inline").toMatchInlineSnapshot('"inline"'));
+            afterEach(() => expect("ae").toMatchSnapshot("afterEach"));
+            afterAll(() => expect("aa").toMatchSnapshot("afterAll"));
+            test("t1", () => {
+              afterEach(() => expect("ae in test").toMatchSnapshot("afterEach in test"));
+              onTestFinished(() => expect("otf").toMatchSnapshot("onTestFinished"));
+              expect("body").toMatchSnapshot("body");
+              expect("body").toMatchSnapshot();
+            });
+            test("t2", () => expect("body").toMatchSnapshot("body"));
+          });
+        });
+      `,
+    });
+    const { exitCode, stderr, entries } = await runHooksFile(String(dir));
+    expect(entries).toEqual([
+      // beforeAll/afterAll do not run for a test, so they keep the hook's own (unnamed) key
+      'outer inner (unnamed): beforeAll 1 = "ba"',
+      'outer inner t1: top beforeEach 1 = "top"',
+      'outer inner t1: outer beforeEach 1 = "outer"',
+      'outer inner t1: inner beforeEach 1 = "inner"',
+      'outer inner t1: body 1 = "body"',
+      // the inline snapshot in beforeEach took number 1 of t1's unhinted counter, as in jest
+      'outer inner t1 2 = "body"',
+      'outer inner t1: afterEach in test 1 = "ae in test"',
+      'outer inner t1: afterEach 1 = "ae"',
+      'outer inner t1: onTestFinished 1 = "otf"',
+      'outer inner t2: top beforeEach 1 = "top"',
+      'outer inner t2: outer beforeEach 1 = "outer"',
+      'outer inner t2: inner beforeEach 1 = "inner"',
+      'outer inner t2: body 1 = "body"',
+      'outer inner t2: afterEach 1 = "ae"',
+      'outer inner (unnamed): afterAll 1 = "aa"',
+    ]);
+    expect(stderr).toContain(" 2 pass");
+    expect(stderr).toContain(" 0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("adding a test does not invalidate the hook snapshots of the other tests", async () => {
+    const source = (extraTest: string) => /*js*/ `
+      import { afterEach, describe, expect, test } from "bun:test";
+      let value;
+      describe("d", () => {
+        afterEach(() => expect(value).toMatchSnapshot("afterEach"));
+        ${extraTest}
+        test("t1", () => { value = "from t1"; });
+        test("t2", () => { value = "from t2"; });
+      });
+    `;
+    using dir = tempDir("snapshot-hook-stability", { "hooks.test.ts": source("") });
+    const first = await runHooksFile(String(dir));
+    expect(first.entries).toEqual(['d t1: afterEach 1 = "from t1"', 'd t2: afterEach 1 = "from t2"']);
+    expect(first.exitCode).toBe(0);
+
+    writeFileSync(String(dir) + "/hooks.test.ts", source(`test("t0", () => { value = "from t0"; });`));
+    const second = await runHooksFile(String(dir));
+    expect(second.stderr).toContain(" 3 pass");
+    expect(second.stderr).toContain(" 0 fail");
+    expect(second.entries).toEqual([
+      'd t1: afterEach 1 = "from t1"',
+      'd t2: afterEach 1 = "from t2"',
+      'd t0: afterEach 1 = "from t0"',
+    ]);
+    expect(second.exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
### Problem
- `toMatchSnapshot()` / `toThrowErrorMatchingSnapshot()` called from `beforeEach`, `afterEach`, an `afterEach` registered inside a test, or `onTestFinished` is written as `` exports[`d (unnamed): hint 1`] `` instead of `` exports[`d t1: hint 1`] `` (repro and the full before/after key lists are in the details block below).
- Every hook snapshot in a describe shares that one key, so its counter runs across tests: adding, removing or reordering a test renumbers every later hook snapshot in the describe and they all stop matching.
- A hook declared in an outer describe only gets the outer describe as prefix (`outer (unnamed): ...`) even when the test lives in an inner describe, and hooks registered from inside a test body get no prefix at all (`(unnamed): hint 1`).
- Cause: `Expect::get_snapshot_name` (`src/runtime/test_runner/expect.rs:626`) builds the key from the execution entry that was active when `expect()` was called. While a hook runs that is the hook's own entry, which has no name, and whose parent is the scope the hook was declared in (none for hooks added during a test). Before the test runner rewrite (#22534) the key came from the pending test; Jest keys these snapshots by `currentTestName`, which is set for the whole test including its hooks.

### Fix
- New `RefDataValue::snapshot_entry()` (`bun_test.rs`, next to `entry()`, both built on a shared `running_sequence()` that keeps the existing validation) returns the sequence's `test_entry`, falling back to the active entry when the sequence has no test. `get_snapshot_name` calls it instead of `entry()` and is otherwise unchanged, so the concurrent-group error and the describe-chain walk are as before.
- Correct because an `ExecutionSequence` is exactly one test plus the beforeEach/afterEach/onTestFinished entries that run for it (`Order.rs` `generate_order_test`, and `generic_hook_impl` in `bun_test.rs` for hooks added while the test runs), so `test_entry` is the test a hook is running for, and its name and describe chain are what the test body's own snapshots are already keyed by. The result matches Jest (and vitest, apart from its ` > ` separator) for every case in the new test, including an inline snapshot in `beforeEach` taking number 1 of the test's unhinted counter.
- `beforeAll` / `afterAll` run in sequences without a `test_entry` (`generate_all_order`) and stay under their current `d (unnamed): hint` key, now counted among themselves only. Jest has no test name there either (`currentTestName` is undefined, or still the previous test's), that key is stable once the per-test hooks stop sharing it, and throwing (what bun did before the rewrite) would break files that work today.
- Behavior change: files that take snapshots inside beforeEach/afterEach/onTestFinished need one `bun test -u` after upgrading. Every such snapshot (file or inline, with or without hint) now counts against the test it runs for, which changes three kinds of existing `.snap` keys:
  - the hook entries themselves move from `<describe> (unnamed)...` to the test's keys;
  - the test body's own entries move up one number for each hook snapshot with the same hint (or none), inline ones included, and those leave no `(unnamed)` entry to grep for;
  - beforeAll/afterAll entries keep their `(unnamed)` key but are renumbered when a per-test hook in the same describe used the same hint.
- First run after upgrading: a moved key that lands on a stale entry fails as a value mismatch; otherwise the new keys fail in CI as "Snapshot creation is disabled" and are appended outside CI. Stale entries are never reported (bun has no obsolete-snapshot tracking); `-u` rewrites the file with only the current keys. Each shape was checked with a `.snap` written by bun 1.4.0 and then run with this branch (details block).
- Tests: `test/js/bun/test/snapshot-tests/bun-snapshots.test.ts`, new `snapshots taken in hooks` block, three tests that all fail on the released bun with the `(unnamed)` keys and pass with this change:
  - one fixture with a top-level, an outer and an inner `beforeEach`, `beforeAll`, `afterEach`, an `afterEach` registered inside the test, `onTestFinished`, `afterAll` and an inline snapshot in `beforeEach`, asserting the full `.snap` contents;
  - one where every hook and the body use the same hint, pinning the counter layout described above (`d (unnamed): setup 1/2` for beforeAll/afterAll, `d t1: setup 1/2/3` for beforeEach/body/afterEach);
  - one that adds a test in front of two tests with existing `afterEach` snapshots and checks the run still passes with the existing entries untouched.
- Also run against the debug build with no failures: `test/js/bun/test/bun_test.test.ts`, `test/js/bun/test/ci-restrictions.test.ts`, `test/cli/test/rerun-each.test.ts` (retry/repeat counter reset), `test/js/bun/test/test-test.test.ts`, `test/js/bun/test/expect.test.js`, and the rest of `test/js/bun/test/snapshot-tests/` (its `error snapshots` case needs `FORCE_COLOR=1`, as on main; CI sets it).

### Background
- Snapshot key: the enclosing describe names and the test name joined by spaces, `: hint` if a hint was given, then a counter. The counter is per key and is incremented by every file or inline snapshot taken under that key during the run (and reset when a test is retried or repeated), so a snapshot charged to the wrong key also shifts the numbering of the others.
- `ExecutionEntry`: one callback the runner executes, a test or a hook. Hooks have no name. `base.parent` is the describe scope the entry was declared in; hooks registered while a test is running have none.
- `ExecutionSequence`: what the runner executes as one unit. For a test it is the test's beforeEach entries, the test, and its afterEach/onTestFinished entries, with `test_entry` pointing at the test; each beforeAll/afterAll hook is a sequence of its own with no `test_entry`. `active_entry` is the entry currently running.
- `expect()` records the runner state it was called in (`RefDataValue`). `RefDataValue::entry()` returns the recorded entry if it is still the one running, and nothing in a concurrent group, where the runner cannot tell which sequence an `expect()` belongs to (hence the existing "not supported in concurrent tests" error, which this keeps). `jest.rs` already compares the active entry with the sequence's `test_entry` the same way to tell a hook failure from a test failure.

<details>
<summary>Repro and keys before/after</summary>

```ts
import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, onTestFinished, test } from "bun:test";
beforeEach(() => expect("top").toMatchSnapshot("top beforeEach"));
describe("outer", () => {
  beforeEach(() => expect("outer").toMatchSnapshot("outer beforeEach"));
  describe("inner", () => {
    beforeAll(() => expect("ba").toMatchSnapshot("beforeAll"));
    beforeEach(() => expect("inner").toMatchSnapshot("inner beforeEach"));
    beforeEach(() => expect("inline").toMatchInlineSnapshot('"inline"'));
    afterEach(() => expect("ae").toMatchSnapshot("afterEach"));
    afterAll(() => expect("aa").toMatchSnapshot("afterAll"));
    test("t1", () => {
      afterEach(() => expect("ae in test").toMatchSnapshot("afterEach in test"));
      onTestFinished(() => expect("otf").toMatchSnapshot("onTestFinished"));
      expect("body").toMatchSnapshot("body");
      expect("body").toMatchSnapshot();
    });
    test("t2", () => expect("body").toMatchSnapshot("body"));
  });
});
```

`CI=false bun test` with bun 1.4.0-canary.1 writes:

```
outer inner (unnamed): beforeAll 1
(unnamed): top beforeEach 1
outer (unnamed): outer beforeEach 1
outer inner (unnamed): inner beforeEach 1
outer inner t1: body 1
outer inner t1 1
(unnamed): afterEach in test 1
outer inner (unnamed): afterEach 1
(unnamed): onTestFinished 1
(unnamed): top beforeEach 2
outer (unnamed): outer beforeEach 2
outer inner (unnamed): inner beforeEach 2
outer inner t2: body 1
outer inner (unnamed): afterEach 2
outer inner (unnamed): afterAll 1
```

With this change:

```
outer inner (unnamed): beforeAll 1
outer inner t1: top beforeEach 1
outer inner t1: outer beforeEach 1
outer inner t1: inner beforeEach 1
outer inner t1: body 1
outer inner t1 2
outer inner t1: afterEach in test 1
outer inner t1: afterEach 1
outer inner t1: onTestFinished 1
outer inner t2: top beforeEach 1
outer inner t2: outer beforeEach 1
outer inner t2: inner beforeEach 1
outer inner t2: body 1
outer inner t2: afterEach 1
outer inner (unnamed): afterAll 1
```

vitest 4.1.9 on the same file (with `vitest` imports) writes the same set of keys with ` > ` as the separator, including `outer > inner > t1 2` for the unhinted body snapshot.

</details>

<details>
<summary>Upgrade path: .snap written by bun 1.4.0, then run with this branch</summary>

```ts
describe("d", () => {
  beforeAll(() => expect("ba").toMatchSnapshot("setup"));
  beforeEach(() => expect("be").toMatchSnapshot("setup"));
  afterEach(() => expect("ae").toMatchSnapshot("setup"));
  afterAll(() => expect("aa").toMatchSnapshot("setup"));
  test("t1", () => expect("body").toMatchSnapshot("setup"));
});
```

bun 1.4.0 writes:

```
d (unnamed): setup 1 = "ba"
d (unnamed): setup 2 = "be"
d t1: setup 1 = "body"
d (unnamed): setup 3 = "ae"
d (unnamed): setup 4 = "aa"
```

This branch against that file, without `-u`: the beforeEach fails (`d t1: setup 1` now receives `"be"`, stored `"body"`), so the body is skipped; the afterEach's `d t1: setup 2` is appended (outside CI); the afterAll fails (`d (unnamed): setup 2` now receives `"aa"`, stored `"be"`). Summary: `snapshots: 1 passed, 1 added, 2 failed`, and the five old entries stay in the file.

After `bun test -u` on this branch:

```
d (unnamed): setup 1 = "ba"
d t1: setup 1 = "be"
d t1: setup 2 = "body"
d t1: setup 3 = "ae"
d (unnamed): setup 2 = "aa"
```

A `beforeEach` with only `toMatchInlineSnapshot()` behaves like the `beforeEach` above for numbering purposes: the body's unhinted `toMatchSnapshot()` entries move from `d t1 1` to `d t1 2`, with no `(unnamed)` entry in the old file.

</details>
