### PR TITLE
process.env: make a failed env build throw instead of aborting (Windows 0xC0000409 on Bun.$ / Bun.sql / process.env near the stack limit)

### DIFF
--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -108,7 +108,10 @@ static JSValue constructWebViewObject(VM& vm, JSObject* bunObject);
 
 static JSValue constructEnvObject(VM& vm, JSObject* object)
 {
-    return uncheckedDowncast<Zig::GlobalObject>(object->globalObject())->processEnvObject();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSObject* env = uncheckedDowncast<Zig::GlobalObject>(object->globalObject())->processEnvObject();
+    RETURN_IF_EXCEPTION(scope, {});
+    return env;
 }
 
 JSC::EncodedJSValue flattenArrayOfBuffersIntoArrayBufferOrUint8Array(JSGlobalObject* lexicalGlobalObject, JSValue arrayValue, size_t maxLength, bool asUint8Array)

--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -108,9 +108,11 @@ static JSValue constructWebViewObject(VM& vm, JSObject* bunObject);
 
 static JSValue constructEnvObject(VM& vm, JSObject* object)
 {
-    auto scope = DECLARE_THROW_SCOPE(vm);
+    // Same shape as constructEnv in BunProcess.cpp: the exception is left pending so the read throws and the property is retried next time.
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     JSObject* env = uncheckedDowncast<Zig::GlobalObject>(object->globalObject())->processEnvObject();
-    RETURN_IF_EXCEPTION(scope, {});
+    if (scope.exception()) [[unlikely]]
+        return {};
     return env;
 }
 

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -2636,7 +2636,9 @@ static JSValue constructReportObjectComplete(VM& vm, Zig::GlobalObject* globalOb
     };
 
     auto constructEnvironmentVariables = [&]() -> JSC::JSValue {
-        return globalObject->processEnvObject();
+        JSC::JSObject* env = globalObject->processEnvObject();
+        RETURN_IF_EXCEPTION(scope, {});
+        return env;
     };
 
     auto constructCpus = [&]() -> JSC::JSValue {
@@ -3217,15 +3219,13 @@ static JSValue constructRevision(VM& vm, JSObject* processObject)
 static JSValue constructEnv(VM& vm, JSObject* processObject)
 {
     auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(processObject->globalObject());
-    // Lazy property builder: exceptions must not propagate into
-    // reifyStaticProperty, which performs no exception check.
-    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-    JSValue env = globalObject->processEnvObject();
-    if (auto* exception = scope.exception()) [[unlikely]] {
-        (void)scope.tryClearException();
-        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
-        return JSC::jsUndefined();
-    }
+    // Returning empty with the exception pending makes the read throw and
+    // leaves `env` unreified, so the next read builds it (same as Bun.$ and
+    // Bun.env). Clearing and returning undefined would pin process.env to
+    // undefined for the rest of the process after one failed build.
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSObject* env = globalObject->processEnvObject();
+    RETURN_IF_EXCEPTION(scope, {});
     return env;
 }
 

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -3219,13 +3219,10 @@ static JSValue constructRevision(VM& vm, JSObject* processObject)
 static JSValue constructEnv(VM& vm, JSObject* processObject)
 {
     auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(processObject->globalObject());
-    // On failure return empty and leave the exception pending: the read throws
-    // and `env` stays unreified, so the next read builds it (like Bun.$). Caching
-    // undefined instead would pin process.env to undefined for the whole process.
-    // TopExceptionScope like the sibling builders: reifyAllStaticProperties runs
-    // builders back to back with no exception check in between, and the simulated
-    // throw a ThrowScope leaves behind fails the next builder's scope under
-    // BUN_JSC_validateExceptionChecks (`delete process._fatalException`).
+    // Empty with the exception left pending: the read throws and `env` stays
+    // unreified for the next read (like Bun.$). Not a ThrowScope: its simulated
+    // throw fails the next builder under validateExceptionChecks, since
+    // reifyAllStaticProperties does not check between builders.
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     JSObject* env = globalObject->processEnvObject();
     if (scope.exception()) [[unlikely]]

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -3219,12 +3219,10 @@ static JSValue constructRevision(VM& vm, JSObject* processObject)
 static JSValue constructEnv(VM& vm, JSObject* processObject)
 {
     auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(processObject->globalObject());
-    // Empty with the exception left pending: the read throws and `env` stays
-    // unreified for the next read (like Bun.$). Not a ThrowScope: its simulated
-    // throw fails the next builder under validateExceptionChecks, since
-    // reifyAllStaticProperties does not check between builders.
+    // Not a ThrowScope: reifyAllStaticProperties runs the next builder without an exception check, which validateExceptionChecks flags as an unchecked simulated throw.
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     JSObject* env = globalObject->processEnvObject();
+    // Left pending on purpose: the read throws and `env` stays unreified, so the next read builds it (like Bun.$).
     if (scope.exception()) [[unlikely]]
         return {};
     return env;

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -3219,13 +3219,17 @@ static JSValue constructRevision(VM& vm, JSObject* processObject)
 static JSValue constructEnv(VM& vm, JSObject* processObject)
 {
     auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(processObject->globalObject());
-    // Returning empty with the exception pending makes the read throw and
-    // leaves `env` unreified, so the next read builds it (same as Bun.$ and
-    // Bun.env). Clearing and returning undefined would pin process.env to
-    // undefined for the rest of the process after one failed build.
-    auto scope = DECLARE_THROW_SCOPE(vm);
+    // On failure return empty and leave the exception pending: the read throws
+    // and `env` stays unreified, so the next read builds it (like Bun.$). Caching
+    // undefined instead would pin process.env to undefined for the whole process.
+    // TopExceptionScope like the sibling builders: reifyAllStaticProperties runs
+    // builders back to back with no exception check in between, and the simulated
+    // throw a ThrowScope leaves behind fails the next builder's scope under
+    // BUN_JSC_validateExceptionChecks (`delete process._fatalException`).
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     JSObject* env = globalObject->processEnvObject();
-    RETURN_IF_EXCEPTION(scope, {});
+    if (scope.exception()) [[unlikely]]
+        return {};
     return env;
 }
 

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1800,9 +1800,14 @@ static JSValue constructLoadEnvFile(VM& vm, JSObject* processObject)
     return JSC::JSFunction::create(vm, globalObject, processObjectInternalsLoadEnvFileCodeGenerator(vm), globalObject);
 }
 
-// Lazy PropertyCallback builders that enter JS. reifyAllStaticProperties wraps these in
-// DeferTerminationForAWhile; a non-termination throw is cleared+reported so the worker's
-// reifyAllStaticProperties (node:worker_threads preload) doesn't leave a pending exception.
+// Throw handling in the lazy process builders. Returning empty with the exception pending
+// (constructEnv) reifies nothing, so the read throws and the next read retries; that builder's
+// object is shared with Bun.env and import.meta.env and must not be cached in a failed state.
+// The builders using the blocks below clear and report instead and reify undefined, so a failure
+// inside the worker_threads preload's reifyAllStaticProperties (which defers termination around
+// the builders) is reported rather than thrown out of an unrelated delete. Both use a
+// TopExceptionScope: that bulk path does not check between builders, so a ThrowScope's simulated
+// throw would fail the next builder under validateExceptionChecks.
 static JSValue callLazyProcessBuilder(VM& vm, JSC::JSGlobalObject* globalObject, JSC::FunctionExecutable* (*generator)(VM&), const JSC::ArgList& args)
 {
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
@@ -2635,12 +2640,6 @@ static JSValue constructReportObjectComplete(VM& vm, Zig::GlobalObject* globalOb
         return workers;
     };
 
-    auto constructEnvironmentVariables = [&]() -> JSC::JSValue {
-        JSC::JSObject* env = globalObject->processEnvObject();
-        RETURN_IF_EXCEPTION(scope, {});
-        return env;
-    };
-
     auto constructCpus = [&]() -> JSC::JSValue {
         JSC::JSObject* cpus = JSC::constructEmptyArray(globalObject, nullptr);
         RETURN_IF_EXCEPTION(scope, {});
@@ -2688,8 +2687,9 @@ static JSValue constructReportObjectComplete(VM& vm, Zig::GlobalObject* globalOb
         RETURN_IF_EXCEPTION(scope, {});
         report->putDirect(vm, JSC::Identifier::fromString(vm, "workers"_s), constructWorkers(), 0);
         RETURN_IF_EXCEPTION(scope, {});
-        report->putDirect(vm, JSC::Identifier::fromString(vm, "environmentVariables"_s), constructEnvironmentVariables(), 0);
+        JSC::JSObject* environmentVariables = globalObject->processEnvObject();
         RETURN_IF_EXCEPTION(scope, {});
+        report->putDirect(vm, JSC::Identifier::fromString(vm, "environmentVariables"_s), environmentVariables, 0);
         report->putDirect(vm, JSC::Identifier::fromString(vm, "userLimits"_s), constructUserLimits(), 0);
         RETURN_IF_EXCEPTION(scope, {});
         report->putDirect(vm, JSC::Identifier::fromString(vm, "sharedObjects"_s), constructSharedObjects(), 0);
@@ -2774,8 +2774,7 @@ static JSValue constructProcessConfigObject(VM& vm, JSObject* processObject)
     //      v8_use_snapshot: 1
     //    }
     // }
-    // Lazy property builder: exceptions must not propagate into
-    // reifyStaticProperty, which performs no exception check.
+    // Clears and reports rather than propagating; see callLazyProcessBuilder.
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     JSC::JSObject* config = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 2);
     JSC::JSObject* variables = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 2);
@@ -3219,10 +3218,9 @@ static JSValue constructRevision(VM& vm, JSObject* processObject)
 static JSValue constructEnv(VM& vm, JSObject* processObject)
 {
     auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(processObject->globalObject());
-    // Not a ThrowScope: reifyAllStaticProperties runs the next builder without an exception check, which validateExceptionChecks flags as an unchecked simulated throw.
+    // Propagates (returns empty with the exception pending); see callLazyProcessBuilder.
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     JSObject* env = globalObject->processEnvObject();
-    // Left pending on purpose: the read throws and `env` stays unreified, so the next read builds it (like Bun.$).
     if (scope.exception()) [[unlikely]]
         return {};
     return env;
@@ -4270,8 +4268,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_stubFunctionReturningArray, (JSGlobalObject * g
 
 static JSValue Process_stubEmptyArray(VM& vm, JSObject* processObject)
 {
-    // Lazy property builder: exceptions must not propagate into
-    // reifyStaticProperty, which performs no exception check.
+    // Clears and reports rather than propagating; see callLazyProcessBuilder.
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     JSC::JSArray* array = JSC::constructEmptyArray(processObject->globalObject(), nullptr);
     if (auto* exception = scope.exception()) [[unlikely]] {
@@ -4405,8 +4402,7 @@ extern "C" void Bun__Process__queueNextTick2(GlobalObject* globalObject, Encoded
 // return require.cache.get(Bun.main)
 static JSValue constructMainModuleProperty(VM& vm, JSObject* processObject)
 {
-    // Lazy property builder: exceptions must not propagate into
-    // reifyStaticProperty, which performs no exception check.
+    // Clears and reports rather than propagating; see callLazyProcessBuilder.
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(processObject->globalObject());
     auto* bun = globalObject->bunObject();
@@ -4445,8 +4441,7 @@ JSValue Process::constructNextTickFn(JSC::VM& vm, Zig::GlobalObject* globalObjec
     args.append(JSC::JSFunction::create(vm, globalObject, 1, String(), jsFunctionDrainMicrotaskQueue, ImplementationVisibility::Private));
     args.append(JSC::JSFunction::create(vm, globalObject, 1, String(), jsFunctionReportUncaughtException, ImplementationVisibility::Private));
 
-    // Lazy property builder: exceptions must not propagate into
-    // reifyStaticProperty, which performs no exception check.
+    // Clears and reports rather than propagating; see callLazyProcessBuilder.
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     JSValue nextTickFunction = JSC::profiledCall(globalObject, ProfilingReason::API, initializer, JSC::getCallData(initializer), globalObject->globalThis(), args);
     if (auto* exception = scope.exception()) [[unlikely]] {

--- a/src/jsc/bindings/BunProcessReportObjectWindows.cpp
+++ b/src/jsc/bindings/BunProcessReportObjectWindows.cpp
@@ -396,8 +396,9 @@ JSValue constructReportObjectWindows(VM& vm, Zig::GlobalObject* globalObject, Pr
     RETURN_IF_EXCEPTION(scope, {});
 
     // Environment variables
-    report->putDirect(vm, Identifier::fromString(vm, "environmentVariables"_s), globalObject->processEnvObject(), 0);
+    JSObject* env = globalObject->processEnvObject();
     RETURN_IF_EXCEPTION(scope, {});
+    report->putDirect(vm, Identifier::fromString(vm, "environmentVariables"_s), env, 0);
 
     return report;
 }

--- a/src/jsc/bindings/ImportMetaObject.cpp
+++ b/src/jsc/bindings/ImportMetaObject.cpp
@@ -516,7 +516,10 @@ JSC_DEFINE_CUSTOM_SETTER(jsImportMetaObjectSetter_require, (JSGlobalObject * jsG
 JSC_DEFINE_CUSTOM_GETTER(jsImportMetaObjectGetter_env, (JSGlobalObject * jsGlobalObject, JSC::EncodedJSValue thisValue, PropertyName propertyName))
 {
     auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(jsGlobalObject);
-    return JSValue::encode(globalObject->m_processEnvObject.getInitializedOnMainThread(globalObject));
+    auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
+    JSObject* env = globalObject->processEnvObject();
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSValue::encode(env);
 }
 
 static const HashTableValue ImportMetaObjectPrototypeValues[] = {

--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -924,6 +924,7 @@ RefPtr<SharedEnvStore> ensureSharedEnvStoreForWorker(Zig::GlobalObject* globalOb
     // Founding a new tree. processEnvObject() forces the lazy init so the OS
     // environment is captured before the swap below.
     JSObject* envObject = globalObject->processEnvObject();
+    RETURN_IF_EXCEPTION(scope, nullptr);
     if (!envObject->staticPropertiesReified()) {
         envObject->reifyAllStaticProperties(globalObject);
         RETURN_IF_EXCEPTION(scope, nullptr);
@@ -979,7 +980,7 @@ RefPtr<SharedEnvStore> ensureSharedEnvStoreForWorker(Zig::GlobalObject* globalOb
     return store;
 }
 
-JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject)
+JSObject* createEnvironmentVariablesMap(Zig::GlobalObject* globalObject)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -998,7 +999,7 @@ JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject)
     }
 
     JSArray* keyArray = constructEmptyArray(globalObject, nullptr, count);
-    RETURN_IF_EXCEPTION(scope, {});
+    RETURN_IF_EXCEPTION(scope, nullptr);
 #else
     auto* structure = JSEnvironmentVariableMap::createStructure(vm, globalObject, globalObject->objectPrototype());
     JSC::JSObject* object = JSEnvironmentVariableMap::create(vm, structure);
@@ -1078,9 +1079,9 @@ JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject)
                 ZigString nameStr = toZigString(name);
                 if (Bun__getEnvValue(globalObject, &nameStr, &valueString)) {
                     JSValue value = jsString(vm, Zig::toStringCopy(valueString));
-                    RETURN_IF_EXCEPTION(scope, {});
+                    RETURN_IF_EXCEPTION(scope, nullptr);
                     object->putDirectIndex(globalObject, *index, value, 0, PutDirectIndexLikePutDirect);
-                    RETURN_IF_EXCEPTION(scope, {});
+                    RETURN_IF_EXCEPTION(scope, nullptr);
                 }
                 continue;
             }
@@ -1135,25 +1136,20 @@ JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject)
     auto editWindowsEnvVar = JSC::JSFunction::create(vm, globalObject, 0, String("editWindowsEnvVar"_s), jsEditWindowsEnvVar, ImplementationVisibility::Public);
 
     JSC::JSFunction* getSourceEvent = JSC::JSFunction::create(vm, globalObject, processObjectInternalsWindowsEnvCodeGenerator(vm), globalObject);
-    RETURN_IF_EXCEPTION(scope, {});
+    RETURN_IF_EXCEPTION(scope, nullptr);
     JSC::MarkedArgumentBuffer args;
     args.append(object);
     args.append(keyArray);
     args.append(editWindowsEnvVar);
     args.append(JSC::JSFunction::create(vm, globalObject, 2, "coerceForWrite"_s, jsProcessEnvCoerceForWrite, ImplementationVisibility::Private));
     args.append(JSC::JSFunction::create(vm, globalObject, 1, "resetForDelete"_s, jsProcessEnvResetForDelete, ImplementationVisibility::Private));
-    auto clientData = WebCore::clientData(vm);
     JSC::CallData callData = JSC::getCallData(getSourceEvent);
-    NakedPtr<JSC::Exception> returnedException = nullptr;
-    auto result = JSC::profiledCall(globalObject, JSC::ProfilingReason::API, getSourceEvent, callData, globalObject->globalThis(), args, returnedException);
-    RETURN_IF_EXCEPTION(scope, {});
-
-    if (returnedException) {
-        throwException(globalObject, scope, returnedException.get());
-        return jsUndefined();
-    }
-
-    RELEASE_AND_RETURN(scope, result);
+    // Entering JS here fails with a RangeError when process.env is first read
+    // close to the stack limit; leave it pending for processEnvObject()'s caller.
+    JSValue result = JSC::profiledCall(globalObject, JSC::ProfilingReason::API, getSourceEvent, callData, globalObject->globalThis(), args);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    // windowsEnv returns `new Proxy(...)`, so a normal return is always an object.
+    return asObject(result);
 #else
     return object;
 #endif

--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -1045,7 +1045,9 @@ JSObject* createEnvironmentVariablesMap(Zig::GlobalObject* globalObject)
         // We can't really trust that the OS gives us valid UTF-8
         auto name = String::fromUTF8ReplacingInvalidSequences(std::span { chars, len });
 #if OS(WINDOWS)
-        keyArray->putByIndexInline(globalObject, (unsigned)i, jsString(vm, name), false);
+        // Define, don't [[Set]]: `list` points into the env table until this loop ends, and a [[Set]] can run an indexed setter from Object.prototype.
+        keyArray->putDirectIndex(globalObject, (unsigned)i, jsString(vm, name));
+        RETURN_IF_EXCEPTION(scope, nullptr);
 #endif
         if (name == TZ) {
             hasTZ = true;

--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -1076,13 +1076,15 @@ JSObject* createEnvironmentVariablesMap(Zig::GlobalObject* globalObject)
         // CustomGetterSetter doesn't support indexed properties yet.
         // This causes strange issues when the environment variable name is an integer.
         if (chars[0] >= '0' && chars[0] <= '9') [[unlikely]] {
-            if (auto index = parseIndex(identifier)) {
+            if (parseIndex(identifier)) {
                 ZigString valueString = { nullptr, 0 };
                 ZigString nameStr = toZigString(name);
                 if (Bun__getEnvValue(globalObject, &nameStr, &valueString)) {
                     JSValue value = jsString(vm, Zig::toStringCopy(valueString));
                     RETURN_IF_EXCEPTION(scope, nullptr);
-                    object->putDirectIndex(globalObject, *index, value, 0, PutDirectIndexLikePutDirect);
+                    // The base define, not putDirectIndex: on this exotic object putDirectIndex ends in a [[Set]], which can run an indexed setter from Object.prototype while `list` is still in use.
+                    PropertyDescriptor descriptor(value, 0);
+                    JSObject::defineOwnProperty(object, globalObject, identifier, descriptor, false);
                     RETURN_IF_EXCEPTION(scope, nullptr);
                 }
                 continue;

--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -1144,8 +1144,6 @@ JSObject* createEnvironmentVariablesMap(Zig::GlobalObject* globalObject)
     args.append(JSC::JSFunction::create(vm, globalObject, 2, "coerceForWrite"_s, jsProcessEnvCoerceForWrite, ImplementationVisibility::Private));
     args.append(JSC::JSFunction::create(vm, globalObject, 1, "resetForDelete"_s, jsProcessEnvResetForDelete, ImplementationVisibility::Private));
     JSC::CallData callData = JSC::getCallData(getSourceEvent);
-    // Entering JS here fails with a RangeError when process.env is first read
-    // close to the stack limit; leave it pending for processEnvObject()'s caller.
     JSValue result = JSC::profiledCall(globalObject, JSC::ProfilingReason::API, getSourceEvent, callData, globalObject->globalThis(), args);
     RETURN_IF_EXCEPTION(scope, nullptr);
     // windowsEnv returns `new Proxy(...)`, so a normal return is always an object.

--- a/src/jsc/bindings/JSEnvironmentVariableMap.h
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.h
@@ -53,7 +53,10 @@ private:
     }
 };
 
-JSC::JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject);
+// Returns null with an exception pending if building the map threw (on Windows
+// the map is finished by a JS builtin). Callers go through
+// Zig::GlobalObject::processEnvObject(), which caches the result.
+JSC::JSObject* createEnvironmentVariablesMap(Zig::GlobalObject* globalObject);
 
 // Setting TZ must make *existing* Date instances recompute local time. JSC's DateCache
 // reset only clears shared slots; live DateInstances keep a Ref to DateInstanceData

--- a/src/jsc/bindings/JSEnvironmentVariableMap.h
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.h
@@ -53,9 +53,7 @@ private:
     }
 };
 
-// Returns null with an exception pending if building the map threw (on Windows
-// the map is finished by a JS builtin). Callers go through
-// Zig::GlobalObject::processEnvObject(), which caches the result.
+// Null with an exception pending if it threw (Windows finishes the map in JS).
 JSC::JSObject* createEnvironmentVariablesMap(Zig::GlobalObject* globalObject);
 
 // Setting TZ must make *existing* Date instances recompute local time. JSC's DateCache

--- a/src/jsc/bindings/JSPropertyIterator.cpp
+++ b/src/jsc/bindings/JSPropertyIterator.cpp
@@ -56,24 +56,22 @@ extern "C" JSPropertyIterator* Bun__JSPropertyIterator__create(JSC::JSGlobalObje
     if (object->type() == JSC::ProxyObjectType) [[unlikely]] {
         // Check if we're actually iterating through the JSEnvironmentVariableMap's proxy.
         auto* zigGlobal = defaultGlobalObject(globalObject);
-        if (zigGlobal->m_processEnvObject.isInitialized()) {
-            if (object == zigGlobal->m_processEnvObject.get(zigGlobal)) {
-                object->methodTable()->getOwnPropertyNames(
-                    object,
-                    globalObject,
-                    array,
-                    DontEnumPropertiesMode::Exclude);
-                RETURN_IF_EXCEPTION(scope, nullptr);
+        if (object == zigGlobal->m_processEnvObject.get()) {
+            object->methodTable()->getOwnPropertyNames(
+                object,
+                globalObject,
+                array,
+                DontEnumPropertiesMode::Exclude);
+            RETURN_IF_EXCEPTION(scope, nullptr);
 
-                *count = array.size();
-                if (array.size() == 0) {
-                    return nullptr;
-                }
-
-                auto* iter = JSPropertyIterator::create(vm, array.releaseData());
-                iter->isSpecialProxy = true;
-                return iter;
+            *count = array.size();
+            if (array.size() == 0) {
+                return nullptr;
             }
+
+            auto* iter = JSPropertyIterator::create(vm, array.releaseData());
+            iter->isSpecialProxy = true;
+            return iter;
         }
     }
 #endif

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -2541,11 +2541,6 @@ void GlobalObject::finishCreation(VM& vm)
             init.set(toJS(init.owner, globalObject, globalObject->performance().get()).getObject());
         });
 
-    m_processEnvObject.initLater(
-        [](const JSC::LazyProperty<JSC::JSGlobalObject, JSC::JSObject>::Initializer& init) {
-            init.set(Bun::createEnvironmentVariablesMap(static_cast<Zig::GlobalObject*>(init.owner)).getObject());
-        });
-
     m_processObject.initLater(
         [](const JSC::LazyProperty<JSC::JSGlobalObject, Bun::Process>::Initializer& init) {
             auto* globalObject = defaultGlobalObject(init.owner);
@@ -3084,6 +3079,25 @@ JSC_DEFINE_CUSTOM_GETTER(functionLazyNavigatorGetter,
         JSC::PropertyName))
 {
     return JSC::JSValue::encode(static_cast<Zig::GlobalObject*>(globalObject)->navigatorObject());
+}
+
+JSC::JSObject* GlobalObject::processEnvObject()
+{
+    if (JSObject* env = m_processEnvObject.get())
+        return env;
+
+    auto& vm = this->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSObject* env = Bun::createEnvironmentVariablesMap(this);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    // The Windows builtin assigns onto an ordinary object, so user code (an
+    // Object.prototype setter) can run inside the build and read process.env;
+    // if that built one first, keep it so process.env, Bun.env and
+    // import.meta.env stay the same object.
+    if (JSObject* existing = m_processEnvObject.get())
+        return existing;
+    m_processEnvObject.set(vm, this, env);
+    return env;
 }
 
 JSC::GCClient::IsoSubspace* GlobalObject::subspaceForImpl(JSC::VM& vm)

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3090,10 +3090,8 @@ JSC::JSObject* GlobalObject::processEnvObject()
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSObject* env = Bun::createEnvironmentVariablesMap(this);
     RETURN_IF_EXCEPTION(scope, nullptr);
-    // The Windows builtin assigns onto an ordinary object, so user code (an
-    // Object.prototype setter) can run inside the build and read process.env;
-    // if that built one first, keep it so process.env, Bun.env and
-    // import.meta.env stay the same object.
+    // User code run by the Windows builtin (an Object.prototype setter) may have
+    // read process.env and built one already; every entry point must share that one.
     if (JSObject* existing = m_processEnvObject.get())
         return existing;
     m_processEnvObject.set(vm, this, env);

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3090,8 +3090,7 @@ JSC::JSObject* GlobalObject::processEnvObject()
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSObject* env = Bun::createEnvironmentVariablesMap(this);
     RETURN_IF_EXCEPTION(scope, nullptr);
-    // User code run by the Windows builtin (an Object.prototype setter) may have
-    // read process.env and built one already; every entry point must share that one.
+    // Built re-entrantly if user code run by the Windows builtin read process.env; everyone must get that one.
     if (JSObject* existing = m_processEnvObject.get())
         return existing;
     m_processEnvObject.set(vm, this, env);

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -356,7 +356,10 @@ public:
     void forbidExecution();
 
     Bun::Process* processObject() const { return m_processObject.getInitializedOnMainThread(this); }
-    JSC::JSObject* processEnvObject() const { return m_processEnvObject.getInitializedOnMainThread(this); }
+    // Builds process.env on first use. On Windows that runs a JS builtin, which can
+    // throw (stack overflow, clobbered globals); then this returns nullptr with the
+    // exception pending and caches nothing, so the next access tries again.
+    JSC::JSObject* processEnvObject();
     JSC::JSObject* bunObject() const { return m_bunObject.getInitializedOnMainThread(this); }
 
     uint8_t drainMicrotasks();
@@ -563,7 +566,7 @@ public:
                                                                                                              \
     V(public, Bun::JSMockModule, mockModule)                                                                 \
                                                                                                              \
-    V(public, LazyPropertyOfGlobalObject<JSObject>, m_processEnvObject)                                      \
+    V(public, WriteBarrier<JSObject>, m_processEnvObject)                                                    \
                                                                                                              \
     V(public, LazyPropertyOfGlobalObject<Structure>, m_JSS3FileStructure)                                    \
     V(public, LazyPropertyOfGlobalObject<Structure>, m_S3ErrorStructure)                                     \

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -356,9 +356,7 @@ public:
     void forbidExecution();
 
     Bun::Process* processObject() const { return m_processObject.getInitializedOnMainThread(this); }
-    // Builds process.env on first use. On Windows that runs a JS builtin, which can
-    // throw (stack overflow, clobbered globals); then this returns nullptr with the
-    // exception pending and caches nothing, so the next access tries again.
+    // Null with the exception pending if building it threw; nothing is cached then.
     JSC::JSObject* processEnvObject();
     JSC::JSObject* bunObject() const { return m_bunObject.getInitializedOnMainThread(this); }
 

--- a/src/jsc/bindings/webcore/JSWorker.cpp
+++ b/src/jsc/bindings/webcore/JSWorker.cpp
@@ -271,8 +271,10 @@ template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSWorkerDOMConstructor::
 
             if (envValue && envValue.isCell()) {
                 envObject = dynamicDowncast<JSC::JSObject>(envValue);
-            } else if (globalObject->m_processEnvObject.isInitialized()) {
-                envObject = globalObject->processEnvObject();
+            } else {
+                // Copy process.env only if it was ever built (and so possibly
+                // modified); otherwise the worker reads the environment itself.
+                envObject = globalObject->m_processEnvObject.get();
             }
 
             if (envObject) {

--- a/src/jsc/bindings/webcore/JSWorker.cpp
+++ b/src/jsc/bindings/webcore/JSWorker.cpp
@@ -272,8 +272,7 @@ template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSWorkerDOMConstructor::
             if (envValue && envValue.isCell()) {
                 envObject = dynamicDowncast<JSC::JSObject>(envValue);
             } else {
-                // Copy process.env only if it was ever built (and so possibly
-                // modified); otherwise the worker reads the environment itself.
+                // Null (nothing to copy) unless process.env was ever built.
                 envObject = globalObject->m_processEnvObject.get();
             }
 

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1,7 +1,7 @@
 import { spawnSync, which } from "bun";
 import { describe, expect, it } from "bun:test";
 import { familySync } from "detect-libc";
-import { bunEnv, bunExe, isMacOS, isWindows, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isDebug, isMacOS, isWindows, tempDir, tmpdirSync } from "harness";
 import { basename, join, resolve } from "path";
 
 const process_sleep = resolve(import.meta.dir, "process-sleep.js");
@@ -1437,6 +1437,131 @@ describe.concurrent(() => {
       } finally {
         delete process.env.BUN_TEST_ENV_PROXY;
       }
+    });
+
+    // Windows finishes building process.env by calling the windowsEnv JS
+    // builtin (POSIX builds the map without entering JS), so a first read with
+    // almost no stack left throws a RangeError out of the builder. That used to
+    // hit the RELEASE_ASSERT in the LazyProperty initializer holding the env,
+    // which on Windows exits with STATUS_STACK_BUFFER_OVERRUN (0xC0000409) and
+    // prints nothing; Bun.$ reads process.env and bun:sql reads Bun.env while
+    // being created, so first-touching them died the same way. The read has to
+    // throw and the next one has to build the real env, so the child retries the
+    // entry point at every depth while unwinding and then checks the env.
+    async function firstReadNearStackLimitBuildsRealEnv(entryPoint) {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const entryPoint = process.argv[1];
+           let reached = false;
+           const readers = {
+             "process.env": () => { reached = true; return process.env; },
+             "Bun.env": () => { reached = true; return Bun.env; },
+             "import.meta.env": () => { reached = true; return import.meta.env; },
+             "Bun.$": () => { reached = true; return Bun.$; },
+             "Bun.sql": () => { reached = true; return Bun.sql; },
+           };
+           const read = readers[entryPoint];
+           let value;
+           let readThrew = 0;
+           function recurse() {
+             try {
+               recurse();
+             } catch {}
+             if (value !== undefined) return;
+             reached = false;
+             try {
+               value = read();
+             } catch {
+               // Only count throws from the read itself, not from failing to
+               // enter the reader at the very bottom of the stack.
+               if (reached) readThrew++;
+             }
+           }
+           recurse();
+           const result = {
+             retried: readThrew > 0,
+             type: typeof value,
+             envIntact: process.env.BUN_TEST_LAZY_ENV === "lazy-env-value",
+             sameObject: Bun.env === process.env && import.meta.env === process.env,
+           };
+           if (entryPoint.endsWith("env")) result.isEnv = value === process.env;
+           if (entryPoint === "Bun.$") result.echo = (await value({ raw: ["echo $BUN_TEST_LAZY_ENV"] }).text()).trim();
+           console.log(JSON.stringify(result));`,
+          entryPoint,
+        ],
+        env: { ...bunEnv, BUN_TEST_LAZY_ENV: "lazy-env-value" },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      const expected = { retried: true, envIntact: true, sameObject: true };
+      if (entryPoint.endsWith("env")) Object.assign(expected, { type: "object", isEnv: true });
+      else if (entryPoint === "Bun.$") Object.assign(expected, { type: "function", echo: "lazy-env-value" });
+      else Object.assign(expected, { type: "function" });
+      expect({ stderr, exitCode, result: stdout && JSON.parse(stdout) }).toEqual({
+        stderr: "",
+        exitCode: 0,
+        result: expected,
+      });
+    }
+
+    it.each(["process.env", "import.meta.env"])(
+      "%s first read near the stack limit throws and the next read builds the real env",
+      firstReadNearStackLimitBuildsRealEnv,
+    );
+
+    // These three are looked up on the Bun object, and the env builder reifies
+    // Bun.inspect (transitioning Bun) before the point where it can throw, so
+    // assertion builds trip the stale-structure ASSERT in Structure::storedPrototype
+    // that the WebKit change in #37001 removes. Release builds (what CI runs on
+    // Windows) are unaffected.
+    it.skipIf(isDebug).each(["Bun.env", "Bun.$", "Bun.sql"])(
+      "%s first read near the stack limit throws and the next read builds the real env",
+      firstReadNearStackLimitBuildsRealEnv,
+    );
+
+    // The windowsEnv builtin assigns toJSON onto an ordinary object, so a setter
+    // on Object.prototype runs user code in the middle of the env build and can
+    // read process.env, re-entering it. The inner read used to come back empty
+    // without an exception, which is another RELEASE_ASSERT ("did not produce a
+    // property") and the same 0xC0000409 exit. Now the inner read builds the env
+    // and the outer one adopts it instead of installing a second object.
+    it("env build re-entered from user code yields one env object", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `let inner;
+           Object.defineProperty(Object.prototype, "toJSON", {
+             configurable: true,
+             set(fn) {
+               // Remove the trap first: the inner build assigns toJSON too.
+               delete Object.prototype.toJSON;
+               inner = process.env;
+               Object.defineProperty(this, "toJSON", { value: fn, writable: true, configurable: true, enumerable: true });
+             },
+           });
+           const outer = Bun.env;
+           console.log(JSON.stringify({
+             reentered: inner !== undefined,
+             oneObject: outer === inner && process.env === inner && import.meta.env === inner,
+             envIntact: inner.BUN_TEST_LAZY_ENV,
+             json: JSON.parse(JSON.stringify(process.env)).BUN_TEST_LAZY_ENV,
+           }));`,
+        ],
+        env: { ...bunEnv, BUN_TEST_LAZY_ENV: "lazy-env-value" },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stderr, exitCode, result: stdout && JSON.parse(stdout) }).toEqual({
+        stderr: "",
+        exitCode: 0,
+        result: { reentered: true, oneObject: true, envIntact: "lazy-env-value", json: "lazy-env-value" },
+      });
     });
   }
 

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1563,6 +1563,48 @@ describe.concurrent(() => {
         result: { reentered: true, oneObject: true, envIntact: "lazy-env-value", json: "lazy-env-value" },
       });
     });
+
+    // The only point where user code may run during the build is the builtin
+    // call above, after the walk over the native environment table is done. An
+    // indexed setter on Object.prototype makes every [[Set]] into an array hole
+    // run user code; the key array used to be filled with [[Set]] while the walk
+    // still held a pointer into that table, which both ran the setter from inside
+    // the walk (where a re-entered build may grow the table) and dropped the key.
+    it("building the env map runs no user code while walking the environment", async () => {
+      const env = { ...bunEnv, BUN_TEST_LAZY_ENV: "lazy-env-value" };
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `let fired = 0;
+           Object.defineProperty(Object.prototype, "0", {
+             configurable: true,
+             set() {
+               fired++;
+               process.env;
+             },
+           });
+           const env = process.env;
+           delete Object.prototype[0];
+           const keys = new Set(Object.keys(env));
+           console.log(JSON.stringify({
+             fired,
+             missing: JSON.parse(process.argv[1]).filter(key => !keys.has(key)),
+             cached: Bun.env === env,
+           }));`,
+          JSON.stringify(Object.keys(env)),
+        ],
+        env,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stderr, exitCode, result: stdout && JSON.parse(stdout) }).toEqual({
+        stderr: "",
+        exitCode: 0,
+        result: { fired: 0, missing: [], cached: true },
+      });
+    });
   }
 
   it("catches exceptions with process.setUncaughtExceptionCaptureCallback", async () => {

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1396,6 +1396,48 @@ describe.concurrent(() => {
     expect(exitCode).toBe(0);
   });
 
+  // A variable whose name is an array index ("0=zero") is stored on the env
+  // object as an indexed property while the build is still walking the native
+  // env table. Storing it with [[Set]] semantics consulted the prototype chain,
+  // so an indexed setter on Object.prototype ran user code from inside that walk
+  // on every platform; when it threw, main died dereferencing the empty result
+  // of the build. The entry is now defined directly, so the setter never runs and
+  // the variable still comes through.
+  it("an index-named variable is stored without running prototype setters during the env build", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `let fired = 0;
+         let caught = null;
+         Object.defineProperty(Object.prototype, "0", {
+           configurable: true,
+           set() {
+             fired++;
+             throw new Error("boom");
+           },
+         });
+         try {
+           process.env;
+         } catch (e) {
+           caught = e.message;
+         }
+         delete Object.prototype[0];
+         const env = process.env;
+         console.log(JSON.stringify({ fired, caught, zero: env[0], named: env.BUN_TEST_LAZY_ENV, cached: Bun.env === env }));`,
+      ],
+      env: { ...bunEnv, "0": "zero", BUN_TEST_LAZY_ENV: "lazy-env-value" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stderr, exitCode, result: stdout && JSON.parse(stdout) }).toEqual({
+      stderr: "",
+      exitCode: 0,
+      result: { fired: 0, caught: null, zero: "zero", named: "lazy-env-value", cached: true },
+    });
+  });
+
   if (isWindows) {
     it("ownKeys trap windows process.env", () => {
       expect(() => Object.keys(process.env)).not.toThrow();


### PR DESCRIPTION
### Problem

- On Windows, the first read of `process.env`, `Bun.env` or `import.meta.env` that happens with almost no JS stack left kills the process with exit code `0xC0000409` (`STATUS_STACK_BUFFER_OVERRUN`) and nothing on stdout or stderr. `Bun.$` (shell.ts reads `process.env` while building the shell) and `Bun.sql` / `Bun.SQL` / `Bun.postgres` (`internal/sql/shared.ts` reads `Bun.env` at module scope) die the same way when first touched there. Linux prints a result and exits 0 for the same script.
- A Windows debug build names the crash:

  ```
  ASSERTION FAILED: value
  JSC::LazyProperty<JSC::JSGlobalObject,JSC::JSObject>::set
  Zig::GlobalObject::finishCreation::<lambda>   (the m_processEnvObject initializer)
  Zig::GlobalObject::processEnvObject
  Bun::constructEnv
  JSC::reifyStaticProperty
  JSC::setUpStaticFunctionSlot
  ```

- Cause: on Windows `createEnvironmentVariablesMap` finishes the env object by calling the `windowsEnv` JS builtin (`src/jsc/bindings/JSEnvironmentVariableMap.cpp`, the `profiledCall` at the end). Entering JS at the stack limit throws a `RangeError`, the function returned `jsUndefined()` (main, line 1153), and the `m_processEnvObject` `LazyProperty` initializer (`src/jsc/bindings/ZigGlobalObject.cpp:2544` on main) called `init.set(nullptr)`, which is a `RELEASE_ASSERT`. A `LazyProperty` initializer has no way to report failure. On Windows release builds `CRASH()` is `abort()`, and the UCRT implements that with `__fastfail`, so no exception reaches the crash handler: hence the silent `0xC0000409`.
- Same initializer, second way in: the builtin assigns onto an ordinary object, so an `Object.prototype` setter runs user code during the build; if that reads `process.env`, the re-entered `LazyProperty` returns null, the builder hands back an empty value with no exception, and `setUpStaticFunctionSlot` hits `RELEASE_ASSERT_NOT_REACHED` ("Static hashtable initialiation for env did not produce a property"), also `0xC0000409` on the current canary.
- Found while reviewing the re-entry path: the Windows build also filled its key array with `putByIndexInline`, a [[Set]], while walking the native env table through a raw pointer (`list` from `Bun__getEnvCount`). An indexed setter installed on `Object.prototype` (which puts JSC in "bad time", so a [[Set]] into an array hole consults the prototype chain) therefore ran user code from inside that walk and swallowed the key. On main that user code could only re-enter the build and abort; with a working re-entrant build it could add variables and grow the table the walk was still reading.
- POSIX was thought to be unaffected because the map is built without calling into JS, but it has the same hole in miniature: a variable whose name is an array index (`0=zero`) is stored with `putDirectIndex`, which on the exotic env object ends in a [[Set]] and so runs an indexed setter from `Object.prototype` from inside the walk. If that setter throws, main dereferences the empty build result: `process.env` exits with SIGSEGV on Linux (reproduced with the current build; the control run without the index-named variable is fine).

### Fix

- `m_processEnvObject` becomes a `WriteBarrier<JSObject>` filled in by `GlobalObject::processEnvObject()` (`src/jsc/bindings/ZigGlobalObject.cpp:3084`). On failure it returns null with the exception pending and caches nothing, so the read throws a catchable `RangeError` and the next read builds the real env. If the build re-entered itself and an env object already exists when it returns, that one is kept, so `process.env`, `Bun.env` and `import.meta.env` stay a single object.
- `createEnvironmentVariablesMap` now returns `JSObject*` and leaves the builtin's exception pending instead of catching and rethrowing it around a `jsUndefined()` return.
- The Windows key walk uses `putDirectIndex` (a define, which never runs setters) and checks for an exception, so no user code runs until the builtin call after the walk, when `list` is no longer used. That makes the builtin the only point at which the build can be re-entered, which is the case the accessor's adopt-the-existing-object check handles.
- The index-named-variable path (both platforms) stores the entry with the base `JSObject::defineOwnProperty`, which never consults the prototype chain, so after this the walk runs no user code anywhere and the builtin call on Windows is the only point at which the build can be re-entered. The POSIX `process.report` path checks for the exception before storing the env object instead of storing an empty value first.
- `BunProcess.cpp`: the comment on `callLazyProcessBuilder` now states both throw policies the process builders use and why `env` is the one that propagates; the four comments that said `reifyStaticProperty` performs no exception check (no longer true of the pinned engine, and the opposite of what this PR relies on) now just point there. Comment-only; the other builders' behavior is unchanged (see the scope note below).
- The `process.env` builder (`BunProcess.cpp` `constructEnv`) returns empty with the exception left pending, like `Bun.$` already does, instead of clearing the exception, reporting it as uncaught, and reifying `process.env` as `undefined` for the rest of the process after one failed build. It keeps the `TopExceptionScope` the other process builders use (check, then return empty) rather than a `ThrowScope`: `reifyAllStaticProperties` runs the builders back to back with no exception check in between, so the simulated throw a `ThrowScope` leaves behind fails the next builder's scope under `BUN_JSC_validateExceptionChecks`, which the ASAN lane sets (`delete process._fatalException` in `process.test.js` caught exactly that on the first CI run of this PR). `Bun.env` (`BunObject.cpp` `constructEnvObject`) has the same shape. (Bulk reification of the Bun object still stops at the pre-existing `Bun.$` builder under validation, exactly as on main, which is why the tests doing it are listed in `test/no-validate-exceptions.txt`; this PR does not change that list.) The other consumers (`import.meta.env` getter, `process.report`, SHARE_ENV seeding, `JSPropertyIterator`, `JSWorker`) check for the exception or read the barrier directly.
- Propagating out of a `process` builder is safe for the bulk path too: the fork's `reifyAllStaticProperties` stops at the throwing builder and leaves the rest lazy, `JSPropertyIterator` already checks for the exception after it, and the worker preload's `delete process.X` calls are wrapped in `try`/`catch` and re-run reification on the next delete.
- No reachable behavior changes other than crash to throw: on main every path on which the new accessor now throws ended in an abort. A throwing build asserted inside the `LazyProperty` initializer before `constructEnv` / `constructEnvObject` ever saw the exception, a re-entrant build made them return empty without an exception (`RELEASE_ASSERT_NOT_REACHED` in `setUpStaticFunctionSlot`), and on POSIX the build cannot throw at all (only OOM, which null-dereferenced the empty value). So `constructEnv`'s clear-and-report branch was never executed on any platform, and the success path is unchanged: same object built by the same code, still built once and shared by `process.env`, `Bun.env` and `import.meta.env`.
- Why this shape: the failure is transient (stack depth, or user code running inside the build), so the only correct outcomes are "throw and retry later" or "succeed"; anything cached on failure (an empty object, `undefined`) would silently hand every later `process.env` / `Bun.$` / `Bun.sql` user an empty environment. Our JSC fork already supports a `PropertyCallback` builder returning empty with an exception pending (`Bun.$` relies on it today, and this is what makes the Linux behavior in the report work), and #37338 (`require.cache`) and #37175 (`util.inspect`) convert their `LazyProperty`s the same way for the same reason.
- Relation to #37258: its second hunk hits this same assertion through a clobbered `Proxy` and makes the initializer install an empty object on failure, which would pin the env to `{}` after a transient failure; this PR replaces that hunk and its `constructEnv` hunk (its `constructEnvObject` change is equivalent to the one here; its change to how the other process builders report still applies). With this change a clobbered `Proxy` makes the read throw the builtin's `TypeError` and a later read, after the global is restored, returns a working env.
- Verification, `test/js/node/process/process.test.js`. One test runs on every platform, so the build's hostile-prototype path is exercised on the Linux lane that has assertions, `validateExceptionChecks` and ASAN: `an index-named variable is stored without running prototype setters during the env build` (spawns with `0=zero` in the environment and a throwing indexed setter on `Object.prototype`; asserts the setter never ran, the variable and a named one come through, and `Bun.env` is the cached object). It fails on the current build on Linux with exit code 139 and on the Windows canary with the `0xC0000409` exit, and passes with this branch on the Linux debug build and the Windows debug build. The rest are in the Windows-only block, since a build that actually throws now needs the Windows builtin: `%s first read near the stack limit throws and the next read builds the real env` for `process.env`, `import.meta.env`, `Bun.env`, `Bun.$`, `Bun.sql` (each spawns a child that retries the entry point at every depth while unwinding and then checks the env var is there, the three entry points are one object, and for `Bun.$` that `echo $VAR` through the shell prints it), `env build re-entered from user code yields one env object`, and `building the env map runs no user code while walking the environment` (indexed setter on `Object.prototype`; asserts the setter never fires during the build, every variable passed to the child is enumerable, and `Bun.env` is the cached object).
  - Windows Server 2019 x64, unfixed canary (`USE_SYSTEM_BUN=1`): all 7 fail, child exits with `0xC0000409`, empty stdout.
  - Same machine, this branch, release build: 6 pass (before the key-walk test existed); the key-walk test fails on the canary with the same exit code, fails on this branch before its fix (the setter re-enters the build 592 times deep and the read ends in a RangeError), and passes on the debug build after it, as do the same-object re-entry through the builtin plus proxy-variable writes and the single-re-entry indexed-setter shape. Debug build: 3 pass; the `Bun.env` / `Bun.$` / `Bun.sql` cases are `skipIf(isDebug)` because the builtin's `Bun.inspect` read transitions the Bun object mid-lookup and assertion builds then trip the `Structure::storedPrototype` assert that #37001 fixes on the WebKit side (CI's Windows lanes are release builds; the skip can go once #37001 lands). The reporter's probe script exits 0 for `shell`, `sql` and `env` on the release build.
  - Windows release build: full `process.test.js`, `worker.test.ts` env cases, `worker_threads.test.ts` env / SHARE_ENV cases, `test-worker-process-env-shared.js`, bunshell env cases all pass. Windows debug build: `import-meta.test.js` passes; full `process.test.js` passes except the pre-existing JIT inline-cache test, which does 100k env writes and times out on a debug build regardless of this change (10k writes take 0.9s there).
  - Linux release build with ASAN and assertions, run the way the ASAN lane runs tests (`BUN_JSC_validateExceptionChecks=1`, `BUN_DESTRUCT_VM_ON_EXIT=1`, LSAN on): `process.test.js` passes apart from the two tests that need `$USER` / a working LSAN tracer in this container (both fail the same way on main here); `delete process._fatalException`, `{ ...process }`, `Object.entries(process)`, `import.meta.env`, `Bun.env` and `process.report.getReport()` are clean; `import-meta.test.js`, `process-execve.test.ts`, the worker env cases and `test-worker-process-env-shared.js` pass under the same settings. The Windows debug build also runs the three non-skipped new tests green with the validator on.
  - Linux debug (ASAN): `process.test.js` (the only failure is the existing `process` test, which needs `$USER` and fails identically on main in this container), `worker_threads.test.ts` (132 pass), `process-execve.test.ts`, `env.test.ts`, `import-meta.test.js`, `BunObject.test.ts`, `test-worker-process-env-shared.js` pass; a script touching every consumer (`import.meta.env`, `process.env`, `Bun.env`, `process.report.getReport()`, a SHARE_ENV worker and a plain worker) is clean under `BUN_JSC_validateExceptionChecks=1`.
- Once this and #38700 are both in, the `skipIf(isWindows)` on #38700's "throwing lazy property initializer" inspect test can be dropped: on this branch's release build that scenario exits 0 on Windows (it prints `false` only because this build does not contain #38700's property-walk fix).

- Scope note: `BunProcess.cpp` still has the clear-and-report blocks for the other lazy process builders (`stdout`/`stderr`/`stdin`/`nextTick`/`config`/`mainModule`/`finalization`/`allowedNodeEnvironmentFlags`/`channel`/the stub arrays). They have the problem this PR argues against (a first touch near the stack limit pins the property to `undefined` and reports an uncaught exception), but converting them changes the failure behavior of eleven more properties and is the area #37258 is working in, so this PR only does `env`, which is the one that crashed. Converting the rest to the same `if (scope.exception()) return {};` shape is a mechanical follow-up (they already hold `TopExceptionScope`s) and would make #37258's deferred reporting unnecessary.

### Background

- Lazy static properties: most properties of `Bun` and `process` are entries in a static hash table with a `PropertyCallback` builder that runs on first lookup (`reifyStaticProperty`, called from `setUpStaticFunctionSlot`). In our JSC fork a builder may return an empty `JSValue` with an exception pending; the lookup is then reported as not found, the exception propagates to the JS reader, and nothing is stored, so the next lookup runs the builder again. A builder that returns a real value gets that value stored permanently.
- `LazyProperty`: JSC's set-once slot on the global object. Its initializer must call `init.set()` with a non-null cell before returning (`LazyProperty::set` is `RELEASE_ASSERT(value)`, `callFunc` asserts the slot was filled), and a re-entrant initialization returns null. It has no failure path, which is why a fallible build has to live in a plain `WriteBarrier` plus an accessor.
- `WriteBarrier<T>`: a GC-visited pointer slot; null until set. `Zig::GlobalObject` members listed in `FOR_EACH_GLOBALOBJECT_GC_MEMBER` are visited automatically for both `LazyProperty` and `WriteBarrier`, so swapping the type needs no visitor change.
- JS stack limit: JSC stops JS execution a fixed distance before the end of the native stack and throws `RangeError: Maximum call stack size exceeded` whenever JS is entered below that line, including when native code such as a property builder calls a JS builtin. Native code keeps running below the line, so a builder that enters JS near the limit fails even though the native part of it succeeds; as the stack unwinds the same read succeeds a few frames later.
- `0xC0000409` on Windows: WTF's `CRASH()` (behind `RELEASE_ASSERT`) is `abort()` in release builds, and the x64 UCRT implements `abort()` with `__fastfail`, which terminates the process with `STATUS_STACK_BUFFER_OVERRUN` without dispatching an exception, so Bun's crash handler never runs and nothing is printed.

<details>
<summary>Reporter's probe on Windows Server 2019 x64</summary>

```
# canary 1.4.0-canary.1+eabb96de7
reviver    exit=0x00000000 out=reviver ok, threw 47 times
sort       exit=0x00000000 out=sort ok, threw 30 times
semver     exit=0x00000000 out=semver ok, threw 1 times
password   exit=0x00000000 out=password ok, threw 1 times
shell      exit=0xC0000409 out=
sql        exit=0xC0000409 out=
env        exit=0xC0000409 out=          (added: `return process.env`)

# this branch, release build
shell  exit=0x00000000 :: shell ok, threw 52 times
sql    exit=0x00000000 :: sql ok, threw 265 times
env    exit=0x00000000 :: env ok, threw 31 times
```

Re-entrancy variant on the canary (no stack overflow involved):

```js
Object.defineProperty(Object.prototype, "toJSON", {
  configurable: true,
  set(fn) { delete Object.prototype.toJSON; process.env; Object.defineProperty(this, "toJSON", { value: fn, writable: true, configurable: true, enumerable: true }); },
});
Bun.env;
// canary: "Static hashtable initialiation for env did not produce a property." then exit 0xC0000409
// this branch: exits 0, Bun.env === process.env === import.meta.env
```

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/process/process.test.js

<!-- robobun:evidence:end -->