### PR TITLE
fix(cli): resolve symlinks for the entry point when running as node

### DIFF
--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -2950,12 +2950,51 @@ impl RunCommand {
             joined.to_vec().into_boxed_slice()
         };
 
+        let basename: Box<[u8]> = paths::basename(&normalized).to_vec().into_boxed_slice();
+
+        // Node.js resolves symlinks on the main entry point by default
+        // (`resolveMainPath` → `toRealPath`), so a `node_modules/.bin/tool`
+        // symlink runs with module resolution anchored at the real package
+        // directory. Honor the same `--preserve-symlinks-main` /
+        // NODE_PRESERVE_SYMLINKS_MAIN opt-out. `process.argv[1]` becomes the
+        // real path too, consistent with how `bun <symlink>` already behaves
+        // (Node.js keeps the symlink spelling there — a pre-existing,
+        // bun-wide divergence).
+        let entry: Box<[u8]> = 'entry: {
+            if ctx.runtime_options.preserve_symlinks_main
+                || bun_core::env_var::NODE_PRESERVE_SYMLINKS_MAIN
+                    .get()
+                    .unwrap_or(false)
+            {
+                break 'entry normalized;
+            }
+            if normalized.len() >= MAX_PATH_BYTES {
+                break 'entry normalized;
+            }
+            let mut open_buf = PathBuffer::uninit();
+            open_buf[..normalized.len()].copy_from_slice(&normalized);
+            open_buf[normalized.len()] = 0;
+            // SAFETY: the NUL is written above; `open_buf[..len]` is init.
+            let open_z = bun_core::ZStr::from_buf(&open_buf[..], normalized.len());
+            // An unopenable path keeps the user's spelling for the
+            // "Failed to run script" error below.
+            let Ok(fd) = bun_sys::open(open_z, bun_sys::O::RDONLY, 0) else {
+                break 'entry normalized;
+            };
+            let mut real_buf = PathBuffer::uninit();
+            let real = bun_sys::get_fd_path(fd, &mut real_buf);
+            let _ = bun_sys::close(fd);
+            match real {
+                Ok(p) => p.to_vec().into_boxed_slice(),
+                Err(_) => normalized,
+            }
+        };
+
         // This arm calls `Run::boot`
         // directly — NOT `boot_and_handle_error` — so it (a) does not call
         // `Global::configure_allocator` and (b) uses the
         // `Output.err(err, "Failed to run script \"...\"")` form.
-        let basename: Box<[u8]> = paths::basename(&normalized).to_vec().into_boxed_slice();
-        if let Err(err) = Self::boot(ctx, normalized, None) {
+        if let Err(err) = Self::boot(ctx, entry, None) {
             Self::exec_as_if_node_boot_failed(ctx, &basename, err);
         }
         Ok(())

--- a/test/cli/run/as-node.test.ts
+++ b/test/cli/run/as-node.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { join } from "path";
-import { bunEnv, bunExe, fakeNodeRun, tempDir } from "../../harness";
+import { dirname, join } from "path";
+import { symlinkSync } from "fs";
+import { bunEnv, bunExe, fakeNodeRun, isWindows, tempDir } from "../../harness";
 
 describe("fake node cli", () => {
   test("the node cli actually works", () => {
@@ -110,5 +111,69 @@ describe("fake node cli", () => {
     });
     expect(result.stderr.toString()).toContain("Missing script");
     expect(result.success).toBe(false);
+  });
+
+  // Node.js resolves symlinks on the main entry point by default (its
+  // `resolveMainPath` calls `toRealPath`), so `node_modules/.bin/tool ->
+  // ../pkg/cli.mjs` runs with module resolution anchored at the real package
+  // directory. Regression tests for https://github.com/oven-sh/bun/issues/28331.
+  test.skipIf(isWindows)("binary asset import works through an extensionless .bin symlink entry", () => {
+    // The extensionless symlink otherwise classifies the entry as CommonJS,
+    // and the synchronous loader feeds the .woff2 to the JS transpiler:
+    // `error: Expected ";" but found ...` at font.woff2:1:1.
+    using temp = tempDir("fake-node-binary", {
+      "node_modules/my-tool/cli.mjs": 'import fontPath from "./font.woff2";\nconsole.log("loaded:", typeof fontPath);',
+      "node_modules/.bin/.gitkeep": "",
+    });
+    require("fs").writeFileSync(join(temp, "node_modules/my-tool/font.woff2"), Buffer.from([0x77, 0x4f, 0x46, 0x32, 0x00, 0x01, 0x02]));
+    symlinkSync(join(temp, "node_modules/my-tool/cli.mjs"), join(temp, "node_modules/.bin/my-tool"));
+    expect(fakeNodeRun(temp, join(temp, "node_modules/.bin/my-tool")).stdout).toBe("loaded: string");
+  });
+  test.skipIf(isWindows)("resolves the entry symlink so relative imports work", () => {
+    using temp = tempDir("fake-node-symlink", {
+      "node_modules/my-tool/cli.mjs": 'import { greet } from "./lib.mjs";\nconsole.log(greet());',
+      "node_modules/my-tool/lib.mjs": 'export function greet() { return "hello from my-tool"; }',
+      "node_modules/.bin/.gitkeep": "",
+    });
+    symlinkSync(join(temp, "node_modules/my-tool/cli.mjs"), join(temp, "node_modules/.bin/my-tool"));
+    expect(fakeNodeRun(temp, join(temp, "node_modules/.bin/my-tool")).stdout).toBe("hello from my-tool");
+  });
+  test.skipIf(isWindows)("__dirname of a symlinked entry is the real directory", () => {
+    using temp = tempDir("fake-node-symlink", {
+      "node_modules/my-tool/cli.js": "console.log(__dirname)",
+      "node_modules/.bin/.gitkeep": "",
+    });
+    const real = join(temp, "node_modules/my-tool/cli.js");
+    symlinkSync(real, join(temp, "node_modules/.bin/my-tool"));
+    expect(fakeNodeRun(temp, join(temp, "node_modules/.bin/my-tool")).stdout).toBe(dirname(real));
+  });
+  test.skipIf(isWindows)("process.argv[1] is the real path, like plain bun", () => {
+    // Bun realpaths argv[1] for symlinked entries in every mode (`bun
+    // <symlink>` does too); Node.js keeps the symlink spelling there, but
+    // that divergence predates this fix and applies bun-wide.
+    using temp = tempDir("fake-node-symlink", {
+      "node_modules/my-tool/cli.js": "console.log(process.argv[1])",
+      "node_modules/.bin/.gitkeep": "",
+    });
+    const real = join(temp, "node_modules/my-tool/cli.js");
+    symlinkSync(real, join(temp, "node_modules/.bin/my-tool"));
+    expect(fakeNodeRun(temp, join(temp, "node_modules/.bin/my-tool")).stdout).toBe(real);
+  });
+  test.skipIf(isWindows)("bun run --bun runs a .bin symlink with working relative imports", () => {
+    // The full flow behind `bunx --bun tool`: PATH lookup finds the .bin
+    // symlink, the shebang re-enters bun as node, and relative imports must
+    // resolve against the real file location.
+    using temp = tempDir("bun-run-symlink", {
+      "node_modules/my-tool/cli.mjs": '#!/usr/bin/env node\nimport { greet } from "./lib.mjs";\nconsole.log(greet());',
+      "node_modules/my-tool/lib.mjs": 'export function greet() { return "it works"; }',
+      "node_modules/.bin/.gitkeep": "",
+      "package.json": "{}",
+    });
+    require("fs").chmodSync(join(temp, "node_modules/my-tool/cli.mjs"), 0o755);
+    symlinkSync(join(temp, "node_modules/my-tool/cli.mjs"), join(temp, "node_modules/.bin/my-tool"));
+    const result = Bun.spawnSync([bunExe(), "run", "--bun", "my-tool"], { cwd: String(temp), env: bunEnv });
+    expect(result.stderr.toString("utf8").trim()).toBe("");
+    expect(result.stdout.toString("utf8").trim()).toBe("it works");
+    expect(result.exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
When bun runs as `node` (the shim behind `bunx --bun` and `bun run --bun`), `exec_as_if_node` in `src/runtime/cli/run_command.rs` normalizes the entry path but passes it to `Run::boot` without resolving symlinks. A `node_modules/.bin/tool` entry is an extensionless symlink, so the loader classifies the entry as CommonJS and walks the module graph synchronously; a binary asset imported through that graph is fed to the JS transpiler and the run dies with `error: Expected ";" but found ...` pointing into the binary. Node resolves the main entry symlink by default (`resolveMainPath` calls `toRealPath`, with a comment saying it exists for `.bin/` entries), and bun's own normal entry path does the same through `get_fd_path` in `maybe_open_with_bun_js`, so the as-node path is the odd one out. In practice this breaks `bunx --bun vite dev` for any app whose SSR graph reaches a font or other binary asset: every request 500s.

The fix resolves the entry with the same open plus `get_fd_path` idiom `maybe_open_with_bun_js` uses, skipped when `--preserve-symlinks-main` or `NODE_PRESERVE_SYMLINKS_MAIN` is set. An unopenable path falls through unchanged so the missing-script error keeps the user's spelling. `process.argv[1]` becomes the real path, which matches what `bun <symlink>` already does (Node keeps the symlink spelling there; that divergence predates this change and applies bun-wide).

Repro, fails on 1.3.14 and passes with this change:

```bash
mkdir -p app/node_modules/.bin app/node_modules/my-tool && cd app
printf 'import u from "./font.woff2";\nconsole.log("loaded:", typeof u);\n' > node_modules/my-tool/cli.mjs
printf 'wOF2\x00\x01\x02' > node_modules/my-tool/font.woff2
ln -s ../my-tool/cli.mjs node_modules/.bin/my-tool
ln -s $(which bun) ./node
./node node_modules/.bin/my-tool
```

This redoes #28332, which was closed unmergeable after the Zig to Rust rewrite. Two of the new tests fail on current main, the binary asset one above and the `process.argv[1]` one; all 16 in the file pass with the fix, built and run locally on Linux x64.

Fixes #28331