### PR TITLE
bundler: warn and disable splitting for non-esm formats instead of failing the build

### DIFF
--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -553,6 +553,11 @@ Running this build results in the following files:
 
 The generated `chunk-2fce6291bf86559d.js` file contains the shared code. To avoid collisions, the file name includes a content hash by default. Customize this with [`naming`](#naming).
 
+<Note>
+  Code splitting is only supported when [`format`](#format) is `"esm"`. With `"cjs"` or `"iife"`, `splitting` is ignored
+  with a warning and each entrypoint is bundled on its own.
+</Note>
+
 ### plugins
 
 A list of plugins to use during bundling.

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2909,20 +2909,22 @@ pub mod bv2_impl {
             // BACKREF: `LinkerContext<'a>.resolver` is `ParentRef<Resolver<'a>>`;
             // the resolver lives in `transpiler` which outlives `self` (same `'a`).
             this.linker.resolver = Some(bun_ptr::ParentRef::new(&this.transpiler.resolver));
-            this.linker.graph.code_splitting = this.transpiler.options.code_splitting;
-
             // Cross-chunk imports/exports are only generated for ESM (see
-            // computeCrossChunkDependencies). Reject other formats up front
-            // rather than panicking later. Matches esbuild.
+            // computeCrossChunkDependencies), so splitting any other format
+            // would panic in the linker. Build tools commonly pass one
+            // `splitting` setting to every format they emit, so this is a
+            // warning that drops the option rather than a build error.
             if this.transpiler.options.code_splitting
                 && this.transpiler.options.output_format != options::Format::Esm
             {
-                this.transpiler.log_mut().add_error(
+                this.transpiler.options.code_splitting = false;
+                this.transpiler.log_mut().add_warning(
                     None,
                     bun_ast::Loc::EMPTY,
-                    "Code splitting is currently only supported when format is set to \"esm\"",
+                    b"Code splitting is currently only supported when format is set to \"esm\"; it has been disabled for this build",
                 );
             }
+            this.linker.graph.code_splitting = this.transpiler.options.code_splitting;
 
             this.linker.options.minify_syntax = this.transpiler.options.minify_syntax;
             this.linker.options.minify_identifiers = this.transpiler.options.minify_identifiers;

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, isDebug, tempDir } from "harness";
 import { readdirSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { itBundled } from "./expectBundled";
 
 const env = {
@@ -402,4 +402,93 @@ describe("bundler", () => {
     }
     expect(runOut.trim()).toBe(`${(N * (N - 1)) / 2} 0 ${N - 1}`);
   }, 60_000);
+
+  // Only ESM chunks can import each other. Tools such as bunup pass the same
+  // `splitting` setting to every format they emit, so a non-ESM format drops
+  // the option with a warning instead of failing the build (and instead of the
+  // linker panic from https://github.com/oven-sh/bun/issues/32395).
+  describe("splitting with a non-esm format is ignored with a warning", () => {
+    const warning =
+      'Code splitting is currently only supported when format is set to "esm"; it has been disabled for this build';
+    const files = {
+      "shared.js": `export const shared = "shared";`,
+      "a.js": `import { shared } from "./shared"; console.log("a", shared);`,
+      "b.js": `import { shared } from "./shared"; console.log("b", shared);`,
+    };
+
+    async function runOutputs(outDir: string) {
+      const out: Record<string, string> = {};
+      for (const name of ["a.js", "b.js"]) {
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), join(outDir, name)],
+          env: bunEnv,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).toBe("");
+        expect(exitCode).toBe(0);
+        out[name] = stdout;
+      }
+      return out;
+    }
+
+    describe.each(["cjs", "iife"] as const)("format %s", format => {
+      test.concurrent("bun build", async () => {
+        using dir = tempDir("splitting-non-esm-cli", files);
+        const root = String(dir);
+
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "build", "--splitting", `--format=${format}`, "--outdir=out", "./a.js", "./b.js"],
+          env: bunEnv,
+          cwd: root,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).toContain(`warn: ${warning}`);
+        expect(stdout).toContain("a.js");
+        expect(exitCode).toBe(0);
+
+        // No shared chunk: each entry point gets its own copy of shared.js.
+        expect(readdirSync(join(root, "out")).sort()).toEqual(["a.js", "b.js"]);
+        expect(await runOutputs(join(root, "out"))).toEqual({ "a.js": "a shared\n", "b.js": "b shared\n" });
+      });
+
+      test.concurrent("Bun.build", async () => {
+        using dir = tempDir("splitting-non-esm-api", files);
+        const root = String(dir);
+
+        const build = await Bun.build({
+          entrypoints: [join(root, "a.js"), join(root, "b.js")],
+          outdir: join(root, "out"),
+          splitting: true,
+          format,
+        });
+        expect(build.logs.map(log => [log.level, log.message])).toEqual([["warn", warning]]);
+        expect(build.success).toBe(true);
+
+        expect(build.outputs.map(output => [output.kind, basename(output.path)]).sort()).toEqual([
+          ["entry-point", "a.js"],
+          ["entry-point", "b.js"],
+        ]);
+        expect(await runOutputs(join(root, "out"))).toEqual({ "a.js": "a shared\n", "b.js": "b shared\n" });
+      });
+    });
+
+    test.concurrent("esm still splits without a warning", async () => {
+      using dir = tempDir("splitting-esm-api", files);
+      const root = String(dir);
+
+      const build = await Bun.build({
+        entrypoints: [join(root, "a.js"), join(root, "b.js")],
+        outdir: join(root, "out"),
+        splitting: true,
+        format: "esm",
+      });
+      expect(build.logs).toEqual([]);
+      expect(build.outputs.map(output => output.kind).sort()).toEqual(["chunk", "entry-point", "entry-point"]);
+      expect(await runOutputs(join(root, "out"))).toEqual({ "a.js": "a shared\n", "b.js": "b shared\n" });
+    });
+  });
 });

--- a/test/bundler/esbuild/splitting.test.ts
+++ b/test/bundler/esbuild/splitting.test.ts
@@ -632,33 +632,4 @@ describe("bundler", () => {
       stdout: "success",
     },
   });
-  // https://github.com/oven-sh/bun/issues/32395
-  for (const format of ["cjs", "iife"] as const) {
-    for (const backend of ["cli", "api"] as const) {
-      itBundled(`splitting/ErrorWithNonEsmFormat_${format}_${backend}`, {
-        files: {
-          "/shared.js": /* js */ `
-            export function sharedFn() { return "shared"; }
-            export const sharedConst = 42;
-          `,
-          "/a.js": /* js */ `
-            import { sharedFn, sharedConst } from "./shared";
-            export const a = sharedFn() + sharedConst;
-          `,
-          "/b.js": /* js */ `
-            import { sharedFn, sharedConst } from "./shared";
-            export const b = sharedFn() + sharedConst;
-          `,
-        },
-        entryPoints: ["/a.js", "/b.js"],
-        outdir: "/out",
-        splitting: true,
-        format,
-        backend,
-        bundleErrors: {
-          "<bun>": ['Code splitting is currently only supported when format is set to "esm"'],
-        },
-      });
-    }
-  }
 });


### PR DESCRIPTION
### Problem
- `Bun.build({ splitting: true, format: "cjs" })` (and `"iife"`, CLI `--splitting --format=cjs`) builds on 1.3.14 and fails on current main with `error: Code splitting is currently only supported when format is set to "esm"`.
- The error was added in #32685 (`src/bundler/bundle_v2.rs`, `BundleV2::init`) to replace the linker panic from #32395 / #15125, which fired when a non-ESM build actually produced a shared chunk.
- Build tools forward one `splitting` setting to every format they emit (bunup: `getResolvedSplitting` in `packages/bunup/src/options.ts`), so any `format: ["esm", "cjs"]` project with `splitting: true` now fails `bun run build` on upgrade. persian-tools/persian-tools is one example; its cjs build has a single entry point, so nothing was ever split there.

### Fix
- `BundleV2::init` turns `code_splitting` off when the output format is not ESM and logs a warning instead of an error. The check runs before `linker.graph.code_splitting` is copied, and the parse and link steps read the same `transpiler.options.code_splitting`, so the whole build runs as a non-splitting build.
- The build succeeds with the output a non-splitting build of that format produces: one self-contained file per entry point. The panic stays fixed because the code path that needed cross-chunk imports is never entered.
- The warning shows up as `warn: ...` on stderr for `bun build` and as a `"warn"` entry in the `logs` of the `Bun.build` result, so the mismatch is still visible.
- Docs: a note under `splitting` in `docs/bundler/index.mdx`.
- Tests: `test/bundler/bundler_splitting.test.ts` covers cjs and iife through both `bun build` and `Bun.build` (build succeeds, warning emitted, outputs are exactly the two entry points and both run), plus an esm control that still emits a chunk with no warning. The error expectations added by #32685 in `test/bundler/esbuild/splitting.test.ts` are removed. The new tests fail on main (the build errors) and pass with this change; `test/bundler/esbuild/splitting.test.ts` still passes.

If the hard error is the intended 1.4 behavior, this can be closed; the change only exists to keep 1.3 build scripts working across the upgrade.

### Background
- Code splitting: with several entry points (or dynamic imports), the bundler moves code shared between them into separate chunk files that the entry files import. Those chunk-to-chunk links are emitted as ESM `import`/`export` statements (`computeCrossChunkDependencies` only fills `exports_to_other_chunks` for the ESM format), which is why cjs and iife output cannot be split.
- Without splitting, every entry point gets a complete copy of everything it imports, which is valid output for any format.
