### PR TITLE
bunfig: send credentials written into the url of a registry object

### DIFF
--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -1207,8 +1207,7 @@ impl<'a> Parser<'a> {
         let password = obj.get(b"password");
         let token = obj.get(b"token");
 
-        // Keys replace the URL's credentials as a set: `Scope::from_api` prefers a
-        // token, so a `:token@` from the URL would outrank username/password keys.
+        // Keys replace the URL's credentials as a set: from_api would favor a URL token over keys.
         if username.is_some() || password.is_some() || token.is_some() {
             registry = api::NpmRegistry {
                 url: registry.url,

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -1195,8 +1195,7 @@ impl<'a> Parser<'a> {
     fn parse_registry_object(&mut self, obj: &E::Object) -> crate::Result<api::NpmRegistry> {
         // Credentials written into `url` (`https://user:pass@host/`,
         // `https://:token@host/`) are split out exactly as for the string form;
-        // userinfo left in the URL is never sent. The explicit keys below
-        // override what the URL provided.
+        // userinfo left in the URL is never sent.
         let mut registry = match obj.get(b"url") {
             Some(url) => {
                 self.expect_string(&url)?;
@@ -1206,21 +1205,36 @@ impl<'a> Parser<'a> {
             None => api::NpmRegistry::default(),
         };
 
-        if let Some(username) = obj.get(b"username") {
+        let username = obj.get(b"username");
+        let password = obj.get(b"password");
+        let token = obj.get(b"token");
+
+        // The URL's credentials only apply when the object configures none of
+        // its own; the keys replace them as a set. `Scope::from_api` sends a
+        // token in preference to a username/password pair, so a `:token@` left
+        // in the URL must not survive next to `username`/`password` keys.
+        if username.is_some() || password.is_some() || token.is_some() {
+            registry = api::NpmRegistry {
+                url: registry.url,
+                ..Default::default()
+            };
+        }
+
+        if let Some(username) = username {
             self.expect_string(&username)?;
             registry.username = username
                 .as_string(self.bump)
                 .expect("infallible: type checked")
                 .into();
         }
-        if let Some(password) = obj.get(b"password") {
+        if let Some(password) = password {
             self.expect_string(&password)?;
             registry.password = password
                 .as_string(self.bump)
                 .expect("infallible: type checked")
                 .into();
         }
-        if let Some(token) = obj.get(b"token") {
+        if let Some(token) = token {
             self.expect_string(&token)?;
             registry.token = token
                 .as_string(self.bump)

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -1193,9 +1193,7 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_registry_object(&mut self, obj: &E::Object) -> crate::Result<api::NpmRegistry> {
-        // Credentials written into `url` (`https://user:pass@host/`,
-        // `https://:token@host/`) are split out exactly as for the string form;
-        // userinfo left in the URL is never sent.
+        // `user:pass@` / `:token@` in the URL are credentials, as in the string form.
         let mut registry = match obj.get(b"url") {
             Some(url) => {
                 self.expect_string(&url)?;
@@ -1209,10 +1207,8 @@ impl<'a> Parser<'a> {
         let password = obj.get(b"password");
         let token = obj.get(b"token");
 
-        // The URL's credentials only apply when the object configures none of
-        // its own; the keys replace them as a set. `Scope::from_api` sends a
-        // token in preference to a username/password pair, so a `:token@` left
-        // in the URL must not survive next to `username`/`password` keys.
+        // Keys replace the URL's credentials as a set: `Scope::from_api` prefers a
+        // token, so a `:token@` from the URL would outrank username/password keys.
         if username.is_some() || password.is_some() || token.is_some() {
             registry = api::NpmRegistry {
                 url: registry.url,

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -1181,28 +1181,31 @@ impl Bunfig {
 // ─────────────────────────────────────────────────────────────────────────────
 
 impl<'a> Parser<'a> {
-    fn parse_registry_url_string(&mut self, str: &E::EString) -> crate::Result<api::NpmRegistry> {
+    fn parse_registry_url(&mut self, url: &[u8]) -> crate::Result<api::NpmRegistry> {
         // Dedup D009: body is the canonical port in `bun_api::npm_registry`.
         // The api `Parser` is generic over log/source and never reads them for
         // this path, so we just hand it our reborrowed handles.
-        let bytes = str.string(self.bump)?;
         Ok(bun_api::npm_registry::Parser {
             log: &mut *self.log,
             source: self.source,
         }
-        .parse_registry_url_string_impl(bytes)?)
+        .parse_registry_url_string_impl(url)?)
     }
 
     fn parse_registry_object(&mut self, obj: &E::Object) -> crate::Result<api::NpmRegistry> {
-        let mut registry = api::NpmRegistry::default();
+        // Credentials written into `url` (`https://user:pass@host/`,
+        // `https://:token@host/`) are split out exactly as for the string form;
+        // userinfo left in the URL is never sent. The explicit keys below
+        // override what the URL provided.
+        let mut registry = match obj.get(b"url") {
+            Some(url) => {
+                self.expect_string(&url)?;
+                let url = url.as_string(self.bump).expect("infallible: type checked");
+                self.parse_registry_url(url)?
+            }
+            None => api::NpmRegistry::default(),
+        };
 
-        if let Some(url) = obj.get(b"url") {
-            self.expect_string(&url)?;
-            registry.url = url
-                .as_string(self.bump)
-                .expect("infallible: type checked")
-                .into();
-        }
         if let Some(username) = obj.get(b"username") {
             self.expect_string(&username)?;
             registry.username = username
@@ -1230,7 +1233,10 @@ impl<'a> Parser<'a> {
 
     fn parse_registry(&mut self, expr: &Expr) -> crate::Result<api::NpmRegistry> {
         match &expr.data {
-            ExprData::EString(s) => self.parse_registry_url_string(s),
+            ExprData::EString(s) => {
+                let url = s.string(self.bump)?;
+                self.parse_registry_url(url)
+            }
             ExprData::EObject(o) => self.parse_registry_object(o),
             _ => {
                 self.add_error(

--- a/test/cli/install/config-precedence.test.ts
+++ b/test/cli/install/config-precedence.test.ts
@@ -379,20 +379,47 @@ describe.concurrent("bun install config precedence", () => {
     },
   );
 
-  test("bunfig registry object keys override the credentials written into its URL", async () => {
+  // Credential keys replace the credentials written into the URL as a set.
+  // `authToken` is only known after beforeAll, hence the thunks.
+  const keyedRegistries: [
+    name: string,
+    registry: (port: number) => Record<string, string>,
+    expectedAuthorization: () => string,
+  ][] = [
+    [
+      "username/password keys beat the user:password written into its URL",
+      port => ({
+        url: `http://user-from-url:password-from-url@localhost:${port}/`,
+        username: "config-precedence",
+        password: "verysecure",
+      }),
+      () => userBasicAuth,
+    ],
+    [
+      "username/password keys beat the :token written into its URL",
+      port => ({
+        url: `http://:token-from-url@localhost:${port}/`,
+        username: "config-precedence",
+        password: "verysecure",
+      }),
+      () => userBasicAuth,
+    ],
+    [
+      "token key beats the user:password written into its URL",
+      port => ({ url: `http://user-from-url:password-from-url@localhost:${port}/`, token: authToken }),
+      () => `Bearer ${authToken}`,
+    ],
+  ];
+
+  test.each(keyedRegistries)("bunfig registry object %s", async (_, registry, expectedAuthorization) => {
     using capture = capturingRegistry();
     using dir = tempDir("config-precedence", {
-      "project/bunfig.toml": bunfig({
-        registry: {
-          url: `http://config-precedence:password-from-url@localhost:${capture.port}/`,
-          password: "verysecure",
-        },
-      }),
+      "project/bunfig.toml": bunfig({ registry: registry(capture.port) }),
       "project/package.json": packageJson({ "@needs-auth/test-pkg": "1.0.0" }),
     });
     const { stderr, exitCode } = await install(String(dir));
     expect(stderr).not.toContain("error:");
-    expect(new Set(capture.authorizations)).toStrictEqual(new Set([userBasicAuth]));
+    expect(new Set(capture.authorizations)).toStrictEqual(new Set([expectedAuthorization()]));
     expect(installed(String(dir), "@needs-auth", "test-pkg")).toBe(true);
     expect(exitCode).toBe(0);
   });

--- a/test/cli/install/config-precedence.test.ts
+++ b/test/cli/install/config-precedence.test.ts
@@ -322,6 +322,97 @@ describe.concurrent("bun install config precedence", () => {
     expect(exitCode).toBe(0);
   });
 
+  // `registry = "<url>"` and `registry = { url = "<url>" }` must read credentials
+  // written into the URL the same way.
+  const registryForms: [form: string, registry: (url: string) => unknown][] = [
+    ["string", url => url],
+    ["object", url => ({ url })],
+  ];
+  const userBasicAuth = `Basic ${Buffer.from("config-precedence:verysecure").toString("base64")}`;
+
+  test.each(registryForms)("bunfig registry %s sends the user:password written into its URL", async (_, registry) => {
+    using capture = capturingRegistry();
+    using dir = tempDir("config-precedence", {
+      "project/bunfig.toml": bunfig({
+        registry: registry(`http://config-precedence:verysecure@localhost:${capture.port}/`),
+      }),
+      "project/package.json": packageJson({ "@needs-auth/test-pkg": "1.0.0" }),
+    });
+    const { stderr, exitCode } = await install(String(dir));
+    expect(stderr).not.toContain("error:");
+    expect(new Set(capture.authorizations)).toStrictEqual(new Set([userBasicAuth]));
+    expect(installed(String(dir), "@needs-auth", "test-pkg")).toBe(true);
+    expect(exitCode).toBe(0);
+  });
+
+  test.each(registryForms)("bunfig registry %s sends the :token written into its URL", async (_, registry) => {
+    using capture = capturingRegistry();
+    using dir = tempDir("config-precedence", {
+      "project/bunfig.toml": bunfig({ registry: registry(`http://:token-from-url@localhost:${capture.port}/`) }),
+      "project/package.json": packageJson({ "no-deps": "1.0.0" }),
+    });
+    const { stderr, exitCode } = await install(String(dir));
+    expect(stderr).not.toContain("error:");
+    expect(new Set(capture.authorizations)).toStrictEqual(new Set(["Bearer token-from-url"]));
+    expect(installed(String(dir), "no-deps")).toBe(true);
+    expect(exitCode).toBe(0);
+  });
+
+  test.each(registryForms)(
+    "bunfig scoped registry %s sends the user:password written into its URL",
+    async (_, registry) => {
+      using dead = deadRegistry();
+      using capture = capturingRegistry();
+      using dir = tempDir("config-precedence", {
+        "project/bunfig.toml": bunfig({
+          registry: dead.url,
+          scopes: { "needs-auth": registry(`http://config-precedence:verysecure@localhost:${capture.port}/`) },
+        }),
+        "project/package.json": packageJson({ "@needs-auth/test-pkg": "1.0.0" }),
+      });
+      const { stderr, exitCode } = await install(String(dir));
+      expect(stderr).not.toContain("error:");
+      expect(dead.hits).toBe(0);
+      expect(new Set(capture.authorizations)).toStrictEqual(new Set([userBasicAuth]));
+      expect(installed(String(dir), "@needs-auth", "test-pkg")).toBe(true);
+      expect(exitCode).toBe(0);
+    },
+  );
+
+  test("bunfig registry object keys override the credentials written into its URL", async () => {
+    using capture = capturingRegistry();
+    using dir = tempDir("config-precedence", {
+      "project/bunfig.toml": bunfig({
+        registry: {
+          url: `http://config-precedence:password-from-url@localhost:${capture.port}/`,
+          password: "verysecure",
+        },
+      }),
+      "project/package.json": packageJson({ "@needs-auth/test-pkg": "1.0.0" }),
+    });
+    const { stderr, exitCode } = await install(String(dir));
+    expect(stderr).not.toContain("error:");
+    expect(new Set(capture.authorizations)).toStrictEqual(new Set([userBasicAuth]));
+    expect(installed(String(dir), "@needs-auth", "test-pkg")).toBe(true);
+    expect(exitCode).toBe(0);
+  });
+
+  test("credentials written into a bunfig registry object URL beat the _authToken for the same registry in ~/.npmrc", async () => {
+    using capture = capturingRegistry();
+    using dir = tempDir("config-precedence", {
+      "home/.npmrc": `//localhost:${capture.port}/:_authToken=token-from-npmrc\n`,
+      "project/bunfig.toml": bunfig({
+        registry: { url: `http://config-precedence:verysecure@localhost:${capture.port}/` },
+      }),
+      "project/package.json": packageJson({ "@needs-auth/test-pkg": "1.0.0" }),
+    });
+    const { stderr, exitCode } = await install(String(dir));
+    expect(stderr).not.toContain("error:");
+    expect(new Set(capture.authorizations)).toStrictEqual(new Set([userBasicAuth]));
+    expect(installed(String(dir), "@needs-auth", "test-pkg")).toBe(true);
+    expect(exitCode).toBe(0);
+  });
+
   test("--linker beats ~/.npmrc, project .npmrc and bunfig", async () => {
     using dir = tempDir("config-precedence", {
       "home/.npmrc": "install-strategy=hoisted\n",


### PR DESCRIPTION
### Problem
- `registry = { url = "http://alice:s3cret@host/" }` in bunfig.toml (and the same object shape under `[install.scopes]`) sends no `Authorization` header: the registry sees `authorization: null` on the manifest and the tarball request. The same URL written as the string form, `registry = "http://alice:s3cret@host/"`, sends `Authorization: Basic YWxpY2U6czNjcmV0` on both. `{ url = "http://:token@host/" }` drops the token the same way.
- Because the credentials stay inside the stored URL, they are also printed when a request fails: `error: GET http://alice:s3cret@127.0.0.1:PORT/no-deps - 401`.
- Cause: `parse_registry_object` in `src/bunfig/bunfig.rs` copies `url` into `NpmRegistry.url` verbatim. Only the string form runs the userinfo splitter (`bun_api::npm_registry::Parser::parse_registry_url_string_impl`, `src/api/lib.rs`). Nothing downstream reads userinfo out of `NpmRegistry.url`: `Scope::from_api` (`src/install/npm.rs`) builds the header from `token` / `username` / `password` only, and the HTTP client ignores userinfo in a request URL.

### Fix
- `parse_registry_object` now runs `url` through the same splitter the string form uses (`parse_registry_url`, shared by both forms), so the URL's credentials land in the credential fields and the stored URL no longer carries them. The `match obj.get(b"url")` block is the fix; the rest of the diff renames the string-form helper to take bytes.
- If the object has any `username` / `password` / `token` key, the credentials taken from the URL are dropped before the keys are applied. Objects with credential keys therefore produce exactly the `NpmRegistry` they produce today (the URL's userinfo was always ignored for them); the only configs whose behavior changes are the ones that sent nothing. This has to be all-or-nothing rather than per field: `from_api` sends a token in preference to a username/password pair, so merging per field would let a `:token@` in the URL outrank `username` / `password` keys written next to it, which works today. It is also the rule the `.npmrc` merge already uses for the next layer down (`apply_registry_auth` in `src/ini/lib.rs` only fills in `.npmrc` credentials when the registry has none).
- Correct because `NpmRegistry` is read on the assumption that credentials live in its fields and `url` carries none: `Scope::from_api` only reads the fields, and the `.npmrc` merge decides whether to apply `//host/:_authToken=` lines by checking those fields. The string form establishes that shape at parse time; the object form was the one producer that did not. Splitting at the same point makes a given `url` text mean the same thing in both forms, including in the `.npmrc` precedence check (tested).
- URLs without userinfo come back from the splitter byte for byte (it returns the input href unchanged in that case), so existing object-form configs, with or without a trailing slash, are unaffected.
- Not changed here: `--registry` and the `*_config_registry` env vars (#38796), `registry = "$VAR"` where the variable's value carries credentials (the expansion happens later, in `from_api`; filed separately), and the `http://host//` spelling the splitter produces for root-path URLs (#38812, cosmetic, same for both forms). No docs change: the documented way to pass credentials in the object form stays the explicit keys; this only makes the `url` value behave like the string form's.
- Verified: `test/cli/install/config-precedence.test.ts` gains three string/object pairs (`user:password` in the URL, `:token` in the URL, `user:password` in a scoped registry URL), a `.npmrc` precedence test (URL credentials in the object beat a `~/.npmrc` `_authToken` for the same host), and a three-row table pinning that credential keys beat the URL (`username`/`password` keys over `user:password` in the URL, `username`/`password` keys over `:token` in the URL, `token` key over `user:password` in the URL). Every test asserts the exact `Authorization` header seen on each request and that the auth-only package installs. On the released build the four url-only object tests fail (`authorization: null`, 401, password in the error line); the string rows and the keyed rows pass there, as they must, since that behavior is unchanged. The `:token` row fails against a per-field merge, which is the regression it guards. All 39 tests in the file pass with this branch.
- Also run with the fix: the Registry URLs / scoped authentication / same-origin tarball tests of `bun-install.test.ts`, `npmrc.test.ts`, `bun-install-retry.test.ts`, `redacted-config-logs.test.ts`, `bun-install-pathname-trailing-slash.test.ts`, `bun-run-bunfig.test.ts`, `test/config/bunfig`, `cargo clippy -p bun_bunfig`, and the source lints. In `bun-publish.test.ts` the lifecycle tests hit the local 5 s default timeout both with and without this change (CI passes a longer `--timeout`); the rest of the file passes.

### Background
- bunfig accepts a registry in two shapes: a string, `registry = "<url>"`, and an object, `registry = { url, username, password, token }`. Both `[install] registry` and each `[install.scopes]` entry go through `parse_registry`, so one fix covers both.
- `api::NpmRegistry` (`src/options_types/schema.rs`) is the config-level record produced by the bunfig and `.npmrc` loaders: `url` plus `username` / `password` / `token`. After the loaders run, `.npmrc` credential lines are merged into it, and the package manager turns it into an `npm::registry::Scope`, which holds the final URL and the pre-computed `Authorization` value. `from_api` uses `token` when it is set and only otherwise builds Basic auth from `username` / `password`.
- The userinfo splitter takes `scheme://user:pass@host/path` and returns an `NpmRegistry` with `username` / `password` set (or `token`, when the user part is empty) and `url` rewritten without the userinfo. The bunfig string form and the `.npmrc` `registry=` / `@scope:registry=` keys all use it.

<details>
<summary>Probe: mock registry on port 0 logging the Authorization header, released 1.4.0 vs this branch</summary>

```
registry = "http://alice:s3cret@127.0.0.1:PORT/"                    (string form)
  1.4.0:       /no-deps  Basic YWxpY2U6czNjcmV0   /no-deps/-/x-1.0.0.tgz  Basic YWxpY2U6czNjcmV0
  this branch: same

registry = { url = "http://alice:s3cret@127.0.0.1:PORT/" }
  1.4.0:       /no-deps  null                     /no-deps/-/x-1.0.0.tgz  null
  this branch: /no-deps  Basic YWxpY2U6czNjcmV0   /no-deps/-/x-1.0.0.tgz  Basic YWxpY2U6czNjcmV0

registry = { url = "http://:tok123@127.0.0.1:PORT/" }
  1.4.0:       null on both
  this branch: Bearer tok123 on both

registry = { url = "http://alice:s3cret@127.0.0.1:PORT/", token = "explicit" }
  1.4.0:       Bearer explicit on both
  this branch: same

registry = { url = "http://alice:s3cret@127.0.0.1:PORT/", password = "override" }
  1.4.0:       null on both (no username configured by keys)
  this branch: same

[install.scopes] myorg = { url = "http://bob:hunter2@127.0.0.1:PORT/" }
  1.4.0:       null on both
  this branch: Basic Ym9iOmh1bnRlcjI= on both (same as the scoped string form)

401 from the registry, object form:
  1.4.0:       error: GET http://alice:s3cret@127.0.0.1:PORT/no-deps - 401
  this branch: error: GET http://127.0.0.1:PORT//no-deps - 401   (the // is #38812)
```

</details>

<details>
<summary>Superseded first version</summary>

The first push merged the URL's credentials with the keys field by field (a `password` key on top of `user:pass@` in the URL gave `user:<key>`). Review pointed out that `{ url = "http://:t@host/", username = "u", password = "p" }`, which sends `Basic u:p` today, would have started sending `Bearer t`, because the URL's token survived next to the keys and `from_api` prefers a token. The current version drops the URL's credentials whenever a credential key is present, and the keyed rows in the test table pin that.

</details>
