### PR TITLE
docs(pm): describe when bun update rewrites catalog entries

### DIFF
--- a/docs/pm/catalogs.mdx
+++ b/docs/pm/catalogs.mdx
@@ -238,6 +238,8 @@ To update versions across all packages, change the version in the root package.j
 
 Then run `bun install` to update all packages.
 
+[`bun update`](/pm/cli/update) with no arguments also rewrites the catalog entries, and `bun update --latest` moves them past their ranges. `bun update <package>` leaves catalog entries as written. To pick individual entries, use `bun update -i -r`.
+
 ## Adding to the catalog with `bun add`
 
 `bun add --catalog` (or `--catalog=<name>`) adds the entry to the root catalog and writes `"catalog:"` to the current package. Bun reuses an existing catalog entry unless you pass an explicit version. See [`bun add --catalog`](/pm/cli/add#--catalog).

--- a/docs/pm/catalogs.mdx
+++ b/docs/pm/catalogs.mdx
@@ -238,7 +238,7 @@ To update versions across all packages, change the version in the root package.j
 
 Then run `bun install` to update all packages.
 
-[`bun update`](/pm/cli/update) with no arguments also rewrites the catalog entries, and `bun update --latest` moves them past their ranges. `bun update <package>` leaves catalog entries as written. To pick individual entries, use `bun update -i -r`.
+[`bun update`](/pm/cli/update) with no arguments also rewrites the catalog entries. `bun update --latest`, still with no package names, moves them past their ranges. `bun update <package>` leaves catalog entries as written, with or without `--latest`. To pick individual entries, use `bun update -i -r`; add `--latest` to also offer versions outside the current ranges.
 
 ## Adding to the catalog with `bun add`
 

--- a/docs/pm/cli/update.mdx
+++ b/docs/pm/cli/update.mdx
@@ -30,7 +30,8 @@ Updated packages appear in the install summary as `↑ name old → new`, with `
 
 - `^1.1.0` → `^1.2.0`, `~1.1.0` → `~1.1.5`. Bun preserves the operator. With [`install.exact`](/runtime/bunfig#install-exact) or `--exact`, Bun writes an exact version instead.
 - Exact pins, dist-tags (`"latest"`, `"next"`), and other range forms (`*`, `1.x`, `>=1.0.0`) are left as written; only `bun.lock` moves. `--latest` rewrites them.
-- Bun never rewrites `catalog:` references; it updates the catalog entry in the root `package.json` instead.
+- Bun never rewrites `catalog:` references. A plain `bun update` also rewrites the [catalog](/pm/catalogs) entries in the root `package.json` by the rules above, even when you run it inside a workspace package. `--latest` moves them past their ranges.
+- Once you narrow the update, with package names, patterns, `--dev`, `--prod`, or `--no-optional`, Bun leaves catalog entries as written. The packages behind them still move in `bun.lock` within the entry's range, and `--latest` does not apply to them. To move one catalog entry past its range, select it in [`bun update -i -r --latest`](#--interactive), or edit the entry and run `bun install`.
 - `--no-save` updates `node_modules` only, leaving `package.json` and `bun.lock` untouched.
 
 ### What is held back
@@ -49,6 +50,8 @@ bun update -i
 ```
 
 `--interactive` opens a terminal interface listing every outdated direct dependency. Bun updates the packages you select as if you had run `bun update <name> ...`; everything else keeps its locked version.
+
+The list includes dependencies a workspace takes from a [catalog](/pm/catalogs). Selecting one rewrites the catalog entry in the root `package.json`. From the root of a monorepo, pass `-r` so that the workspaces using the catalog are included.
 
 ### Interactive Interface
 
@@ -121,10 +124,10 @@ Within each section, individual packages may have a suffix (` dev`, ` peer`, ` o
 
 ## `--recursive` and `--filter`
 
-In a monorepo, `bun update` only rewrites the `package.json` of the workspace you run it in. From the root, it still updates the transitive dependencies of every workspace in `bun.lock`.
+In a monorepo, `bun update` only rewrites the `package.json` of the workspace you run it in. A plain run also rewrites the root's catalog entries. From the root, `bun update` still updates the transitive dependencies of every workspace in `bun.lock`.
 
 - `--recursive` (`-r`) updates every workspace's `package.json`.
-- `--filter <pattern>` (`-F`) updates only the matching workspaces, using the [filter syntax](/pm/filter). As with `bun install --filter`, Bun links only the selected workspaces afterwards.
+- `--filter <pattern>` (`-F`) updates only the matching workspaces, using the [filter syntax](/pm/filter). Bun rewrites catalog entries only when the root is among the selected workspaces. As with `bun install --filter`, Bun links only the selected workspaces afterwards.
 
 Both combine with package names, `--latest`, `--dry-run`, and `--interactive` (which adds a "Workspace" column).
 
@@ -168,7 +171,7 @@ bun update -g typescript
 
 By default, `bun update` updates each dependency to the latest version that satisfies the version range in your `package.json`.
 
-To update direct dependencies to the latest version regardless of the declared range, use `--latest` (`-L`). Bun rewrites the `package.json` entry to a range of the same style on the new version. Transitive dependencies still respect the ranges their dependents declare. Bun does not downgrade a dependency that is already ahead of `latest` (e.g. a prerelease).
+To update direct dependencies to the latest version regardless of the declared range, use `--latest` (`-L`). Bun rewrites the `package.json` entry to a range of the same style on the new version. A plain `bun update --latest` also moves catalog entries past their ranges. Once you narrow the update to particular packages, Bun leaves catalog entries as written. Transitive dependencies still respect the ranges their dependents declare. Bun does not downgrade a dependency that is already ahead of `latest` (e.g. a prerelease).
 
 ```sh terminal icon="terminal"
 bun update --latest


### PR DESCRIPTION
### Problem
- `docs/pm/cli/update.mdx` says "Bun never rewrites `catalog:` references; it updates the catalog entry in the root `package.json` instead", with no condition. On main that only holds for a plain `bun update`.
- `bun update <name>` (also glob patterns, `--dev` / `--prod` / `--no-optional`, and a `--filter` that does not select the root) leaves the catalog entry as written. The `catalog:` rows re-resolve in `bun.lock` within the entry's range and `--latest` has no effect on them: `bun update react --latest -r` against a catalog `react: ^18.2.0` prints `Checked ... (no changes)` and leaves the entry alone. This is the intended split (the catalog hook in `updatePackageJSONAndInstall.rs` is gated on `update_requests.is_empty()` and on the root being a target, and `bun-update.test.ts` "a catalog reference keeps the member's literal and the root catalog entry" pins it), so the page over-claimed.
- The `--latest` paragraph ("regardless of the declared range") and the `--recursive` / `--filter` intro ("only rewrites the `package.json` of the workspace you run it in") had the same gap in the other direction: a plain run rewrites the root's catalog entries even from inside a member, and `--filter` does so only when the root is selected.
- The remaining claim from the same check, that a catalog entry moved by a plain `bun update --latest` gets an `↑ name old → new` row in the summary, is a behavior bug rather than a docs one. #38763 adds the row, so this PR leaves that sentence as is.

### Fix
- `update.mdx`, "How `package.json` is rewritten": split the catalog bullet in two. A plain `bun update` rewrites the root catalog entries by the same rules as direct dependencies (operator kept, exact pins and `1.x` style ranges left alone until `--latest`), from any workspace directory. A narrowed update leaves the entries as written, only `bun.lock` moves within range, `--latest` does not apply, and `bun update -i -r --latest` or editing the entry is how to move one entry past its range.
- `update.mdx`, `--interactive`: catalog-backed dependencies are listed and selecting one rewrites the catalog entry; from the root you need `-r` for them to show up.
- `update.mdx`, `--recursive` / `--filter`: a plain run also rewrites the root's catalog entries; `--filter` does so only when the root is among the selected workspaces.
- `update.mdx`, `--latest`: same condition stated next to the "regardless of the declared range" sentence.
- `catalogs.mdx`, "Updating Versions": one paragraph pointing at `bun update` / `bun update --latest` / `bun update -i -r`, and noting that `bun update <package>` does not touch the entries, so the two pages agree.
- Every sentence added here was run against a debug build of main (2c2ef7cbf) with a local registry: workspace root with `catalog.no-deps` and `catalogs.testing.a-dep`, members `app` / `ui` consuming them via `catalog:`; once with the entries at the newest in-range version (so only `--latest` can move anything) and once with a stale `bun.lock` (so an in-range update has something to do). Runs and outcomes are in the details block.
- `bun run prettier` on both files: unchanged.

### Background
- A catalog is a map of version ranges in the workspace root's `package.json` (`catalog` for the default group, `catalogs.<name>` for named groups, optionally nested under `workspaces`). Members reference an entry with `"react": "catalog:"` or `"catalog:<name>"` so one range is shared across the monorepo; the entry, not the reference, is what carries a version.
- `bun update` has two code paths. With no package names it re-resolves every dependency of the workspace it runs in and rewrites that workspace's `package.json`; the root catalog entries are treated as part of that root rewrite (`PackageJSONEditor::edit_catalogs_before_update` / `edit_catalogs_after_update`). With package names (glob patterns and the `--dev` / `--prod` / `--no-optional` selectors expand to names) it re-resolves only the rows that name those packages, within the ranges those rows already declare, and a `catalog:` row declares its range through the entry, so the entry is left alone.

<details>
<summary>Runs used to check the new wording</summary>

Fixture: root `catalog.no-deps = ^1.1.0` (registry has 1.0.0, 1.0.1, 1.1.0, 2.0.0), `catalogs.testing.a-dep = 1.0.2` (latest 1.0.10), `packages/app` depends on `no-deps: catalog:` and `a-dep: catalog:testing`, `packages/ui` on `no-deps: catalog:`.

| command (from the root unless noted) | root catalog entries | bun.lock | summary |
| --- | --- | --- | --- |
| `bun update no-deps --latest -r` | unchanged | unchanged | `Done! Checked 5 packages (no changes)` |
| `bun update no-deps` | unchanged | unchanged | `error: "no-deps" is not a dependency of this workspace`, suggests `-r` / `--filter app` |
| `bun update --latest` | `^2.0.0`, `1.0.10` | moved | `2 packages installed`, no `↑` rows |
| `bun update -r --latest` | `^2.0.0`, `1.0.10` | moved | same |
| `bun update --latest` from `packages/app` | `^2.0.0`, `1.0.10` | moved | `+ a-dep@1.0.10`, `+ no-deps@2.0.0` |
| `bun update --latest --filter app` | unchanged | unchanged | `(no changes)` |
| `bun update --latest --dry-run` | unchanged | unchanged | `^ a-dep 1.0.2 -> 1.0.10`, `^ no-deps 1.1.0 -> 2.0.0` |
| `bun update 'no-*' --latest -r` | unchanged | unchanged | `(no changes)` |
| `bun update --latest --prod -r` | unchanged | unchanged | `(no changes)` |
| `bun update -i -r --latest`, select all | `^2.0.0`, `1.0.10` | moved | both entries listed |
| `bun update -i --latest` from `packages/app`, select all | `^2.0.0`, `1.0.10` | moved | both entries listed |
| `bun update -i --latest` (root, no `-r`) | unchanged | unchanged | `Checked 2 dependencies, nothing to update` |

Same fixture with a stale lockfile (`catalog.no-deps = ^1.0.0` locked at 1.0.0, `a-dep = ~1.0.1` locked at 1.0.1):

| command | root catalog entries | bun.lock |
| --- | --- | --- |
| `bun update` | `^1.1.0`, `~1.0.10` | moved |
| `bun update --filter '*'` or `--filter root` | `^1.1.0`, `~1.0.10` | moved |
| `bun update --filter './packages/*'` or `--filter app` | unchanged | packages moved to 1.1.0 / 1.0.10, entries in the lock unchanged |
| `bun update no-deps -r`, `bun update 'no-*' -r`, `bun update --prod -r`, `bun update --prod` from `packages/app` | unchanged | `no-deps` moved to 1.1.0, prints `+ no-deps@1.1.0 (v2.0.0 available)` |
| `bun update --dev -r --latest` | unchanged | `a-dep` moved to 1.0.10 |

Range-form check (`catalog.no-deps = 1.x` locked at 1.0.0, `a-dep = 1.0.1` exact): `bun update` leaves both entries as written and moves `no-deps` to 1.1.0 in the lock; `bun update --latest` writes `^2.0.0` and `1.0.10`.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->