### PR TITLE
install: keep git, folder, tarball and workspace entries as written on bun update <name>

### DIFF
--- a/docs/pm/cli/update.mdx
+++ b/docs/pm/cli/update.mdx
@@ -31,6 +31,7 @@ Updated packages appear in the install summary as `↑ name old → new`, with `
 - `^1.1.0` → `^1.2.0`, `~1.1.0` → `~1.1.5`. Bun preserves the operator. With [`install.exact`](/runtime/bunfig#install-exact) or `--exact`, Bun writes an exact version instead.
 - Exact pins, dist-tags (`"latest"`, `"next"`), and other range forms (`*`, `1.x`, `>=1.0.0`) are left as written; only `bun.lock` moves. `--latest` rewrites them.
 - Bun never rewrites `catalog:` references; it updates the catalog entry in the root `package.json` instead.
+- Bun leaves `workspace:`, git, GitHub, `file:` and tarball entries as written, even when you name them with `--latest` or a version. To replace one with a registry package, use `bun add`.
 - `--no-save` updates `node_modules` only, leaving `package.json` and `bun.lock` untouched.
 
 ### What is held back

--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -1336,9 +1336,9 @@ pub(crate) fn edit(
             // derived from a `StoreRef` to the same `E::EString` is live inside this loop body,
             // so this is the sole mutable borrow.
             let e_string = unsafe { &mut *e_string };
-            // `bun update <pkg>` keeps a `catalog:` reference; `bun add` still replaces it.
+            // `bun update <pkg>` keeps an entry the registry does not resolve (`catalog:`, `workspace:`, git, folder, tarball) as written, whatever was requested for it; `bun add` still replaces it.
             if manager.subcommand == Subcommand::Update
-                && dependency::Tag::infer(e_string.data.slice()) == dependency::Tag::Catalog
+                && !dependency::Tag::infer(e_string.data.slice()).is_npm()
             {
                 continue;
             }

--- a/test/cli/install/bun-update-lockfile-sync.test.ts
+++ b/test/cli/install/bun-update-lockfile-sync.test.ts
@@ -1,8 +1,9 @@
 import { Archive, file, write } from "bun";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { appendFile, exists } from "fs/promises";
+import { appendFile, exists, mkdir } from "fs/promises";
 import { VerdaccioRegistry, bunEnv, bunExe, normalizeBunSnapshot, runBunInstall } from "harness";
 import { join } from "path";
+import { pathToFileURL } from "url";
 
 // Registry: no-deps 1.0.0/1.0.1/1.1.0/2.0.0, @types/no-deps 1.0.0/2.0.0, a-dep 1.0.1..1.0.10, one-range-dep@1.0.0 -> no-deps ^1.0.0, dep-with-tags 1.0.0..3.0.1 (latest=3.0.0, pre-2=2.0.1).
 
@@ -138,6 +139,63 @@ const WORKSPACES = (rootFields: Json, members: Record<string, Json>) => ({
 const MONOREPO = (pkg1: Json = {}, rootFields: Json = {}) => WORKSPACES(rootFields, { pkg1 });
 const PKG1 = "packages/pkg1";
 const PKG2 = "packages/pkg2";
+
+const gitEnv = {
+  ...bunEnv,
+  GIT_CONFIG_NOSYSTEM: "1",
+  GIT_AUTHOR_NAME: "Test",
+  GIT_AUTHOR_EMAIL: "test@example.com",
+  GIT_COMMITTER_NAME: "Test",
+  GIT_COMMITTER_EMAIL: "test@example.com",
+};
+
+// The git+file:// literal of a repository publishing `name` 1.0.0.
+async function gitRepo(dir: string, name: string) {
+  const repo = join(dir, "repos", name);
+  await mkdir(repo, { recursive: true });
+  await write(join(repo, "package.json"), json({ name, version: "1.0.0" }));
+  for (const args of [
+    ["init", "-q"],
+    ["add", "package.json"],
+    ["commit", "-q", "-m", "1.0.0", "--no-gpg-sign"],
+  ]) {
+    await using proc = Bun.spawn({ cmd: ["git", ...args], cwd: repo, env: gitEnv, stdout: "ignore", stderr: "pipe" });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("fatal:");
+    expect(exitCode).toBe(0);
+  }
+  return `git+${pathToFileURL(repo)}`;
+}
+
+// A root declaring `no-deps` from git although the registry has it (latest 2.0.0), one entry of every other kind the registry does not resolve, and a dist-tag that --latest does rewrite.
+async function setupNonRegistryDeps(members: Record<string, Json> = {}) {
+  const dir = await setup(
+    {
+      ...WORKSPACES({}, { pkg1: {}, ...members }),
+      "folder-target/package.json": { name: "folder-dep", version: "1.0.0" },
+    },
+    { install: false },
+  );
+  const dependencies = {
+    "no-deps": await gitRepo(dir, "no-deps"),
+    "dep-with-tags": "pre-2",
+    "folder-dep": "file:./folder-target",
+    "tgz-dep": "file:./tgz-dep-1.0.0.tgz",
+    pkg1: "workspace:^",
+  };
+  await Promise.all([
+    writePkg(dir, wsRoot({ dependencies })),
+    Archive.write(
+      join(dir, "tgz-dep-1.0.0.tgz"),
+      { "package/package.json": json({ name: "tgz-dep", version: "1.0.0" }) },
+      { compress: "gzip" },
+    ),
+  ]);
+  await runBunInstall(envFor(dir), dir);
+  const gitResolution = (await resolutions(dir, "no-deps")).find(res => res.startsWith("no-deps@git+"))!;
+  expect(gitResolution).toBeDefined();
+  return { dir, dependencies, gitResolution };
+}
 
 describe.concurrent("bun update rewrites bun.lock together with package.json", () => {
   test("bun update", async () => {
@@ -305,6 +363,46 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
     expect((await pkg(dir)).dependencies).toStrictEqual(expected);
     expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual(expected);
     await expectInSync(dir, ["", PKG1]);
+  });
+
+  // With --latest or an explicit spec, naming such an entry used to replace it with the registry package of the same name
+  // (`no-deps` here), or fail with a 404 when there is none; a plain `bun update pkg1` rewrote `workspace:^` to `workspace:*`.
+  test.each([
+    [["no-deps", "dep-with-tags", "folder-dep", "tgz-dep", "pkg1", "--latest"], "^3.0.0"],
+    [["*", "--latest"], "^3.0.0"],
+    [["no-deps", "folder-dep", "tgz-dep", "pkg1"], "pre-2"],
+    [["no-deps@latest"], "pre-2"],
+    [["no-deps@^2.0.0"], "pre-2"],
+  ])(
+    "bun update %j keeps git, folder, tarball and workspace entries as written; dep-with-tags becomes %p",
+    async (args, depWithTags) => {
+      const { dir, dependencies, gitResolution } = await setupNonRegistryDeps();
+      await run(dir, "update", ...args);
+      const expected = { ...dependencies, "dep-with-tags": depWithTags };
+      expect((await pkg(dir)).dependencies).toStrictEqual(expected);
+      expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual(expected);
+      expect(await resolutions(dir, "no-deps")).toStrictEqual([gitResolution]);
+      expect(await installed(dir, "no-deps")).toMatchObject({ version: "1.0.0" });
+      await expectInSync(dir, ["", PKG1]);
+    },
+  );
+
+  test("bun update <name> -r --latest keeps the workspace declaring the name from git and moves the one declaring it from the registry", async () => {
+    const { dir, dependencies, gitResolution } = await setupNonRegistryDeps({
+      pkg2: { dependencies: { "no-deps": "~1.0.0" } },
+    });
+    await run(dir, "update", "no-deps", "-r", "--latest");
+    expect((await pkg(dir)).dependencies).toStrictEqual(dependencies);
+    expect((await pkg(dir, PKG2)).dependencies).toStrictEqual({ "no-deps": "~2.0.0" });
+    const lockfile = await lock(dir);
+    expect(lockfile.workspaces[""].dependencies).toStrictEqual(dependencies);
+    expect(lockfile.workspaces[PKG2].dependencies).toStrictEqual({ "no-deps": "~2.0.0" });
+    expect(await resolutions(dir, "no-deps")).toStrictEqual(["no-deps@2.0.0", gitResolution]);
+    expect(await installed(dir, "no-deps")).toMatchObject({ version: "1.0.0" });
+    expect(await file(join(dir, PKG2, "node_modules", "no-deps", "package.json")).json()).toMatchObject({
+      version: "2.0.0",
+    });
+    await expectInSync(dir, ["", PKG1, PKG2]);
   });
 
   test("bun update -r", async () => {


### PR DESCRIPTION
### Problem

- `bun update <name> --latest` on a dependency declared from git, e.g. `"repo-a": "git+file:///.../repo-a#v1.0.0"`, exits 0 and leaves package.json with `"repo-a": "^1.0.1"` and bun.lock with the registry package `repo-a@1.0.1`: the git dependency is silently replaced by the unrelated registry package of the same name. For a name the registry does not have (a `file:` folder, a local tarball) the command fails with `error: GET <registry>/<name> - 404` instead.
- `bun update <name>@latest` and `bun update <name>@^2` on such an entry do the same thing (with `@latest` the entry is left as the literal string `"latest"`), and `bun update "*" --latest`, `bun update --dev --latest` and `bun update <name> -r/--filter --latest` expand to the same path.
- Cause: the named path in `PackageJSONEditor::edit` (src/install/PackageManager/PackageJSONEditor.rs) rewrites the entry before the install without looking at what kind of literal it holds. It writes `latest` under `--latest` and the requested spec under `<name>@<spec>`, the install resolves that from the registry, and the second pass pins what was resolved. The only kind it already refused to touch was `catalog:` (line 1340), in both passes.
- The bare `bun update --latest` editor (`edit_update_entries`, same file, line 490) and the `-r`/`--filter` resolver (src/install/PackageManager/PackageManagerEnqueue.rs:2449) already restrict themselves to npm ranges and dist-tags; the named editor was the one path without that check.

### Fix

- Widen the existing `catalog:` check to every entry kind the registry does not resolve: `!Tag::infer(entry).is_npm()`, i.e. anything other than an npm range or a dist-tag (`catalog:`, `workspace:`, git, github, folder, tarball, `link:`). Under `bun update` such an entry is now left as written by both passes, whatever was requested for it; `bun add` is unaffected and still replaces it.
- Such an entry is still a named request, so its row is re-resolved during the install, which is what a plain `bun update <name>` already did for it and what the bare `bun update --latest` does for the same entry. `--latest` and `<name>@<range>` both mean "move within the registry", which has no meaning for an entry the registry does not resolve; npm and pnpm do not convert such entries into registry ranges either, and this is already the documented behaviour of `bun update` for `catalog:` references (tested with an explicit spec in test/cli/install/bun-add-catalog.test.ts), so the same rule now covers every kind.
- Because the check runs in the second pass too, the write-back's unconditional `workspace:*` arm is no longer reached for a `workspace:^` / `workspace:~` entry named in `bun update`. #38847 fixes the remaining workspace cases (a plain range that links a member, requests bound to the root's implicit member rows); its widening of this same check is subsumed by this change, the rest of it is not.
- docs/pm/cli/update.mdx states the rule in one line next to the existing `catalog:` one.
- Not changed: entries declared as a registry range whose row resolves elsewhere (an override, or a range that links a workspace member) still go through the registry path on every route, bare included.
- Verified with five rows plus one `-r` case in test/cli/install/bun-update-lockfile-sync.test.ts: explicit names with `--latest`, `"*" --latest`, plain names, `no-deps@latest`, `no-deps@^2.0.0`, and `no-deps -r --latest` where another workspace declares the same name from the registry and must still move. The fixture declares `no-deps` from a local git repository while the registry has `no-deps@2.0.0`, plus `file:` folder and tarball entries and a `workspace:^` member; with the editor from main all six fail (the git entry becomes `^2.0.0` / `latest`, `file:` entries 404, `workspace:^` becomes `workspace:*`), with this change all six pass.
- bun-update-lockfile-sync.test.ts, bun-update.test.ts, bun-update-transitive.test.ts, bun-add-catalog.test.ts and catalogs.test.ts pass with the debug build.

### Background

- `bun update <name>` edits package.json in two passes around the install: before the install, `edit()` may rewrite the named entries to what should be resolved (`latest` under `--latest`, the spec given as `<name>@<spec>`); the install resolves whatever package.json now says; after the install, `edit()` runs again and pins the resolved version in the declared range style. Patterns, the `--dev`/`--prod` selectors and `-r`/`--filter` all feed this same function.
- `dependency::Tag::infer` classifies a version literal: `^1.0.0` is `Npm`, `pre-2` is `DistTag`, `npm:foo@^1` follows the part after the alias, `git+...` / `github:` are `Git` / `Github`, `file:...` is `Folder` or `Tarball`, `workspace:*` is `Workspace`, `catalog:` is `Catalog`. `Tag::is_npm()` is true for exactly the two kinds a registry manifest answers, and is the predicate the resolver uses to decide whether to fetch one.

<details>
<summary>Earlier revision of this PR</summary>

The first revision only gated the `--latest` rewrite (the `if update_to_latest` branch further down in `edit()`) on `is_npm()`. Self-review pointed out that the same entries were still converted by `bun update <name>@latest` / `<name>@<range>`, and that the second pass still rewrote `workspace:^` to `workspace:*`, because the rule belongs on the per-entry check that already existed for `catalog:` and runs in both passes. The current revision moves it there and adds the explicit-spec and plain-name rows to the test.

</details>
