### PR TITLE
url: parse a bare bracketed IPv6 host so .npmrc //[::1]:port/ credential keys match their registry

### DIFF
--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -586,6 +586,11 @@ impl<'a> URL<'a> {
                 offset += url.parse_password(&base[offset as usize..]).unwrap_or(0);
                 offset += url.parse_host(&base[offset as usize..]).unwrap_or(0);
             }
+            // Bare bracketed IPv6 host, e.g. the `[::1]:4873/` left of an .npmrc
+            // `//[::1]:4873/:_authToken` key once its `//` is stripped.
+            b'[' => {
+                offset += url.parse_host(base).unwrap_or(0);
+            }
             b'/' | b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'-' | b'_' | b':' => {
                 let is_protocol_relative = base.len() > 1 && base[1] == b'/';
                 if is_protocol_relative {

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -1,7 +1,7 @@
 import { write } from "bun";
 import { afterAll, beforeAll, describe, expect, it, test } from "bun:test";
 import { rm } from "fs/promises";
-import { VerdaccioRegistry, bunExe, bunEnv as env, tempDir } from "harness";
+import { VerdaccioRegistry, bunExe, bunEnv as env, isIPv6, tempDir } from "harness";
 import { join } from "path";
 const { iniInternals } = require("bun:internal-for-testing");
 const { loadNpmrc } = iniInternals;
@@ -550,6 +550,59 @@ registry=https://somehost.com/org1/npm/registry/
     expect(result.default_registry_token).toBe("");
   });
 
+  describe("credentials keyed to a bracketed IPv6 host", () => {
+    // The `//` is stripped off the key before it is parsed as a URL, leaving
+    // `[::1]:4873/`. A leading `[` used to parse to an empty host, so these keys
+    // never matched the registry they were written for.
+    test.each([
+      ["loopback with a port", "http://[::1]:4873/", "//[::1]:4873/"],
+      ["loopback without a port", "http://[::1]/", "//[::1]/"],
+      ["full address with a path", "http://[2001:db8::1]:4873/npm/registry/", "//[2001:db8::1]:4873/npm/registry/"],
+      ["key without the trailing slash", "http://[::1]:4873/", "//[::1]:4873"],
+    ])("_authToken is applied: %s", (_, registryUrl, key) => {
+      const result = loadNpmrc(`registry=${registryUrl}\n${key}:_authToken=v6-token\n`);
+      expect(result).toEqual({
+        default_registry_url: registryUrl,
+        default_registry_token: "v6-token",
+        default_registry_username: "",
+        default_registry_password: "",
+        default_registry_email: "",
+      });
+    });
+
+    test("username, _password and _auth are applied", () => {
+      const password = Buffer.from("v6-password").toString("base64");
+      expect(
+        loadNpmrc(`registry=http://[::1]:4873/\n//[::1]:4873/:username=v6-user\n//[::1]:4873/:_password=${password}\n`),
+      ).toEqual({
+        default_registry_url: "http://[::1]:4873/",
+        default_registry_token: "",
+        default_registry_username: "v6-user",
+        default_registry_password: "v6-password",
+        default_registry_email: "",
+      });
+
+      const auth = Buffer.from("v6-user:v6-password").toString("base64");
+      expect(loadNpmrc(`registry=http://[::1]:4873/\n//[::1]:4873/:_auth=${auth}\n`)).toEqual({
+        default_registry_url: "http://[::1]:4873/",
+        default_registry_token: "",
+        default_registry_username: "v6-user",
+        default_registry_password: "v6-password",
+        default_registry_email: "",
+      });
+    });
+
+    test.each([
+      ["a different port", "//[::1]:4874/"],
+      ["a different address", "//[::2]:4873/"],
+      ["a different path", "//[::1]:4873/other/"],
+    ])("a key for %s is not applied", (_, key) => {
+      const result = loadNpmrc(`registry=http://[::1]:4873/\n${key}:_authToken=v6-token\n`);
+      expect(result.default_registry_url).toBe("http://[::1]:4873/");
+      expect(result.default_registry_token).toBe("");
+    });
+  });
+
   it("does not print an undecodable _password value", async () => {
     const secret = "s!ecret!pass";
     using dir = tempDir("npmrc-password-decode", {
@@ -717,5 +770,47 @@ describe("--registry override", () => {
     expect(reqsB.map(r => r.auth)).toEqual(reqsB.map(() => null));
     expect(stdout).toContain("+ no-deps@1.0.0");
     expect(exitCode).toBe(0);
+  });
+});
+
+describe.skipIf(!isIPv6())("registry on a bracketed IPv6 host", () => {
+  test("sends the token keyed to //[::1]:port/ to the default and the scoped registry", async () => {
+    type Req = { path: string; auth: string | null };
+    const reqs: Req[] = [];
+    await using server = Bun.serve({
+      port: 0,
+      hostname: "::1",
+      fetch(req) {
+        reqs.push({ path: new URL(req.url).pathname, auth: req.headers.get("authorization") });
+        return new Response("not found", { status: 404 });
+      },
+    });
+    const url = `http://[::1]:${server.port}/`;
+
+    using dir = tempDir("npmrc-ipv6-registry", {
+      ".npmrc": `registry=${url}\n@v6:registry=${url}\n//[::1]:${server.port}/:_authToken=v6-SECRET-token\n`,
+      "package.json": JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        dependencies: { "no-deps": "1.0.0", "@v6/no-deps": "1.0.0" },
+      }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install", "--no-cache"],
+      cwd: String(dir),
+      // An ambient proxy would intercept the requests to the local registry.
+      env: { ...env, http_proxy: "", https_proxy: "", HTTP_PROXY: "", HTTPS_PROXY: "" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(reqs.toSorted((a, b) => a.path.localeCompare(b.path))).toEqual([
+      { path: "/@v6%2fno-deps", auth: "Bearer v6-SECRET-token" },
+      { path: "/no-deps", auth: "Bearer v6-SECRET-token" },
+    ]);
+    // The registry answers 404 to both manifest requests, so the install itself fails.
+    expect(exitCode).not.toBe(0);
   });
 });


### PR DESCRIPTION
### Problem

- An `.npmrc` whose registry lives on an IPv6 literal never gets its credentials attached, so every request goes out without an `Authorization` header and the registry answers 401:
  ```ini
  registry=http://[::1]:4873/
  //[::1]:4873/:_authToken=tok
  ```
  The same two lines with `127.0.0.1:4873` or `localhost:4873` work.
- The loader strips the leading `//` off a credential key and parses the rest (`[::1]:4873/`) with `bun_url::URL::parse` (`src/ini/lib.rs:1060`, `:1160`). `URL::parse` dispatches on the first byte of its input (`src/url/lib.rs:584`) and has arms for `@`, `/`, letters, digits, `-`, `_` and `:` only; `[` falls through to the wildcard arm, so no host is parsed and the entry is stored with an empty host and pathname `/`.
- `RegistryAuth::matches` (`src/ini/lib.rs:1168`) compares that empty host against the registry's host (`[::1]:4873`, parsed correctly because `registry=` carries a scheme), so the entry matches nothing.

### Fix

- Add a `[` arm to the dispatch in `URL::parse` that hands the input straight to `parse_host`, which already parses bracketed hosts (`[::1]`, port after the closing bracket) whenever a scheme is present. The key now yields host `[::1]:4873` and its path, the same components the `registry=` URL yields, so the existing comparison matches.
- Fixed in the parser rather than in the `.npmrc` loader because the parser is the thing that is wrong: a bracketed host is the one host syntax that cannot start with a letter or digit, and every other caller that hands `URL::parse` a scheme-less value (`http_proxy`, S3 endpoint, `baseURI`, `--origin`, `--registry`) now treats `[::1]:4873` the way it already treats `localhost:4873`. I went through all of them; none relied on a `[` input producing an empty host, and the checks that matter for security (same-origin on redirect, sending tarball credentials, publish `doneUrl`) also require a non-empty protocol, which this arm does not set.
- This matches npm, which keys credentials by `//${url.host}${url.pathname}` and so matches `//[::1]:4873/` for a registry at `http://[::1]:4873/`.
- Tests (`test/cli/install/npmrc.test.ts`):
  - `loadNpmrc` cases: `_authToken` keyed to `[::1]` with and without a port, a full address with a path, and a key without the trailing slash; `username`/`_password` and `_auth` keyed to `[::1]`; keys for a different port, address or path are still not applied.
  - End to end (skipped where the machine has no IPv6): `bun install` against a `Bun.serve` registry on `::1` with `registry=`, `@v6:registry=` and one `//[::1]:<port>/:_authToken=` line sends `Bearer` on both the unscoped and the scoped manifest request.
  - The positive cases fail on the release binary (token is `""`, both requests carry no `authorization` header) and pass with this change; the whole file passes (40 tests).

- Related: #16183 tracks the remaining cases where this parser is handed input without a scheme; the protocol-relative `//host/` branch a few lines below the new arm has the same shape of gap and is left for a separate change.

### Background

- `.npmrc` credentials are keyed by what npm calls a "nerf dart": the registry URL with its scheme removed, `//host[:port]/path/`. Bun's loader (`ConfigIterator` in `src/ini/lib.rs`) cuts the `//` off and keeps the rest as the key's URL, so what reaches the URL parser is a bare `host[:port]/path/` with no scheme.
- `bun_url::URL::parse` is Bun's small, allocation-free URL splitter (distinct from the WHATWG parser behind `new URL()`), used for registry, proxy and similar config strings. It is lenient about missing schemes: when the input does not start with `scheme://` it treats the leading run of characters up to the first `/` as `host[:port]`. `parse_host` is the helper that splits that run into `host`/`hostname`/`port` and has a branch for `[...]` hosts; the bug was only that the first-byte dispatch in front of it never let a `[` input reach it.
- An IPv6 literal in a URL is written in brackets (`http://[::1]:4873/`) so that the colons of the address can be told apart from the port separator. `RegistryAuth` compares the `host` component, which for such a URL is `[::1]:4873`, on both sides.

