### PR TITLE
install: migrate the whole pnpm-workspace.yaml catalog into bun.lock

### DIFF
--- a/docs/pm/cli/install.mdx
+++ b/docs/pm/cli/install.mdx
@@ -523,6 +523,7 @@ The migration process handles:
 - Converts `pnpm-lock.yaml` (lockfile versions 7–9, including pnpm 11's multi-document files) to `bun.lock`
 - Preserves resolved versions and integrity hashes
 - Preserves peer dependency ranges and `peerDependenciesMeta`, so the next `bun install` leaves the migrated lockfile unchanged
+- Writes every catalog entry declared in `pnpm-workspace.yaml` to `bun.lock`, including entries no workspace uses yet (`pnpm-lock.yaml` lists only the entries in use), so the next `bun install` leaves the catalog unchanged
 - Migrates git, GitHub, tarball URL, `file:`, and `npm:` alias dependencies, including transitive ones
 - Resolves pnpm named registries (`name@registry:version`) via `namedRegistries` in `pnpm-workspace.yaml`
 - Converts injected workspace packages (`dependenciesMeta.*.injected`) to ordinary workspace dependencies

--- a/src/install/lockfile/CatalogMap.rs
+++ b/src/install/lockfile/CatalogMap.rs
@@ -10,7 +10,7 @@ use bun_install::dependency::{
     Version as DependencyVersion,
 };
 use bun_install::lockfile::{Buffers, StringBuilder};
-use bun_install::{Behavior, Dependency, Lockfile, PackageManager};
+use bun_install::{Behavior, Dependency, Lockfile, PackageManager, PackageNameHash};
 use bun_semver::SlicedString;
 use core::mem::ManuallyDrop;
 // Layering: every install-side caller (Package.rs / pnpm.rs) parses JSON/YAML
@@ -206,14 +206,7 @@ impl CatalogMap {
         if catalog_name.is_empty() {
             return Ok(&mut self.default);
         }
-
-        let entry = self.groups.get_or_put_adapted(&catalog_name, &ctx(buf))?;
-        if !entry.found_existing {
-            *entry.key_ptr = catalog_name;
-            *entry.value_ptr = Map::default();
-        }
-
-        Ok(entry.value_ptr)
+        get_or_put_named_group(&mut self.groups, buf, catalog_name)
     }
 
     // Deliberately takes no `Lockfile` param so `lockfile.catalogs.parse_count`
@@ -395,6 +388,31 @@ impl CatalogMap {
         Ok(())
     }
 
+    /// `catalog_obj`/`catalogs_obj` are the pnpm-workspace.yaml objects the migration writes into package.json for `parse_append` to read back, so the map takes their shape: pnpm-lock.yaml's section has only the entries in use and spells every default catalog `default`, while entries it does record keep its specifier, which their resolutions were made with.
+    pub(crate) fn put_missing_from_pnpm_workspace(
+        catalogs: &mut CatalogMap,
+        catalog_obj: Option<Expr>,
+        catalogs_obj: Option<Expr>,
+        string_buf: &mut StringBuf,
+    ) -> Result<(), AllocError> {
+        if let Some(declared) = catalog_obj {
+            put_declared_entries(&mut catalogs.default, None, &declared, string_buf)?;
+        }
+        let Some(declared_groups) = catalogs_obj else {
+            return Ok(());
+        };
+        declared_groups.try_for_each_property(|group_name_str, _, declared| {
+            let group_name = string_buf.append(group_name_str)?;
+            if group_name_str != b"default" {
+                let group = catalogs.get_or_put_group(string_buf.bytes.as_slice(), group_name)?;
+                return put_declared_entries(group, None, &declared, string_buf);
+            }
+            let CatalogMap { default, groups } = &mut *catalogs;
+            let group = get_or_put_named_group(groups, string_buf.bytes.as_slice(), group_name)?;
+            put_declared_entries(group, Some(default), &declared, string_buf)
+        })
+    }
+
     // Takes `buffers: &Buffers` rather than the whole `Lockfile` so the call
     // site can hold `&mut lockfile.catalogs` while only borrowing
     // `lockfile.buffers` immutably (disjoint fields), instead of forcing a
@@ -541,26 +559,15 @@ fn put_entries_from_pnpm_lockfile(
         let Some(version_str) = specifier.as_utf8_string_literal() else {
             return Err(FromPnpmLockfileError::InvalidPnpmLockfile);
         };
-        let version_hash = StringBuilderNs::string_hash(version_str);
-        let version = string_buf.append_with_hash(version_str, version_hash)?;
-        let version_sliced = version.sliced(string_buf.bytes.as_slice());
-
-        let Some(parsed_version) = Dependency::parse(
+        let Some(dep) = parse_entry(
             dep_name,
             dep_name_hash,
-            version_sliced.slice,
-            &version_sliced,
+            version_str,
             Some(&mut *log),
-            None,
-        ) else {
+            string_buf,
+        )?
+        else {
             return Err(FromPnpmLockfileError::InvalidPnpmLockfile);
-        };
-
-        let dep = Dependency {
-            name: dep_name,
-            name_hash: dep_name_hash,
-            version: parsed_version,
-            ..Dependency::default()
         };
 
         let buf = string_buf.bytes.as_slice();
@@ -574,4 +581,87 @@ fn put_entries_from_pnpm_lockfile(
         *entry.value_ptr = dep;
     }
     Ok(())
+}
+
+/// Entries `group` records stay as recorded, ones `lockfile_default` recorded move into `group`, the rest are added; an entry that does not parse is left out silently because `parse_append_group` leaves it out and reports it when the next install reads package.json.
+fn put_declared_entries(
+    group: &mut Map,
+    mut lockfile_default: Option<&mut Map>,
+    declared: &Expr,
+    string_buf: &mut StringBuf,
+) -> Result<(), AllocError> {
+    declared.try_for_each_property(|dep_name_str, _, specifier| {
+        let dep_name_hash = StringBuilderNs::string_hash(dep_name_str);
+        let dep_name = string_buf.append_with_hash(dep_name_str, dep_name_hash)?;
+        let buf = string_buf.bytes.as_slice();
+        if group.contains_adapted(&dep_name, &ctx(buf)) {
+            return Ok(());
+        }
+        let recorded = lockfile_default
+            .as_deref_mut()
+            .and_then(|lockfile_default| {
+                let i = lockfile_default.get_index_adapted(&dep_name, &ctx(buf))?;
+                Some(lockfile_default.swap_remove_at(i).1)
+            });
+        let dep = match recorded {
+            Some(dep) => dep,
+            None => {
+                let Some(specifier_str) = specifier.as_utf8_string_literal() else {
+                    return Ok(());
+                };
+                let Some(dep) =
+                    parse_entry(dep_name, dep_name_hash, specifier_str, None, string_buf)?
+                else {
+                    return Ok(());
+                };
+                dep
+            }
+        };
+        let buf = string_buf.bytes.as_slice();
+        let entry = group.get_or_put_adapted(&dep_name, &ctx(buf))?;
+        *entry.key_ptr = dep_name;
+        *entry.value_ptr = dep;
+        Ok(())
+    })
+}
+
+/// `dep_name` is already in `string_buf`; `None` means `specifier` is not a dependency version.
+fn parse_entry(
+    dep_name: String,
+    dep_name_hash: PackageNameHash,
+    specifier: &[u8],
+    log: Option<&mut Log>,
+    string_buf: &mut StringBuf,
+) -> Result<Option<Dependency>, AllocError> {
+    let version = string_buf.append(specifier)?;
+    let version_sliced = version.sliced(string_buf.bytes.as_slice());
+    let Some(version) = Dependency::parse(
+        dep_name,
+        dep_name_hash,
+        version_sliced.slice,
+        &version_sliced,
+        log,
+        None,
+    ) else {
+        return Ok(None);
+    };
+    Ok(Some(Dependency {
+        name: dep_name,
+        name_hash: dep_name_hash,
+        version,
+        ..Dependency::default()
+    }))
+}
+
+fn get_or_put_named_group<'a>(
+    groups: &'a mut ArrayHashMap<String, Map>,
+    buf: &[u8],
+    catalog_name: String,
+) -> Result<&'a mut Map, AllocError> {
+    let entry = groups.get_or_put_adapted(&catalog_name, &ctx(buf))?;
+    if !entry.found_existing {
+        *entry.key_ptr = catalog_name;
+        *entry.value_ptr = Map::default();
+    }
+    Ok(entry.value_ptr)
 }

--- a/src/install/pnpm.rs
+++ b/src/install/pnpm.rs
@@ -1625,7 +1625,7 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
 
     lockfile.fetch_necessary_package_metadata_after_yarn_or_pnpm_migration::<false>(manager)?;
 
-    update_package_json_after_migration(manager, log, dir, &found_patches)?;
+    update_package_json_after_migration(lockfile, manager, log, dir, &found_patches)?;
 
     Ok(LoadResult::Ok(LoadResultOk {
         lockfile,
@@ -2332,6 +2332,7 @@ fn rewrite_bare_patch_keys(
 
 /// Updates package.json with workspace and catalog information after migration
 fn update_package_json_after_migration(
+    lockfile: &mut Lockfile,
     manager: &mut PackageManager,
     log: &mut bun_ast::Log,
     dir: Fd,
@@ -2552,6 +2553,13 @@ fn update_package_json_after_migration(
 
             catalog_obj = ws_root.get_object(b"catalog").filter(is_non_empty_object);
             catalogs_obj = ws_root.get_object(b"catalogs").filter(is_non_empty_object);
+            // The migrated root skips `Package::parse`, so the catalog these declare is recorded in the lockfile here.
+            crate::lockfile_real::CatalogMap::put_missing_from_pnpm_workspace(
+                &mut lockfile.catalogs,
+                catalog_obj,
+                catalogs_obj,
+                &mut sbuf!(lockfile),
+            )?;
             workspace_overrides_obj = ws_root.get_object(b"overrides").filter(is_non_empty_object);
             workspace_patched_deps_obj = ws_root
                 .get_object(b"patchedDependencies")

--- a/test/cli/install/migration/__snapshots__/pnpm-migration-complete.test.ts.snap
+++ b/test/cli/install/migration/__snapshots__/pnpm-migration-complete.test.ts.snap
@@ -255,9 +255,11 @@ exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with al
   },
   "catalog": {
     "react": "18.2.0",
+    "react-dom": "18.2.0",
   },
   "catalogs": {
     "tools": {
+      "eslint": "8.56.0",
       "lodash": "4.17.21",
     },
   },

--- a/test/cli/install/migration/pnpm-lock-v9.test.ts
+++ b/test/cli/install/migration/pnpm-lock-v9.test.ts
@@ -39,12 +39,31 @@ async function bunLockOf(dir: string) {
   return await Bun.file(join(dir, "bun.lock")).text();
 }
 
+// A migrated bun.lock is complete when the install after it finds nothing to save.
+async function expectInstallToLeaveUnchanged(dir: string, migratedBunLock: string) {
+  const install = await run(dir, "install");
+
+  expect(install.stderr).not.toContain("Saved lockfile");
+  expect(install.stderr).not.toContain("error:");
+  expect(install.exitCode).toBe(0);
+  expect(await bunLockOf(dir)).toBe(migratedBunLock);
+}
+
 function workspacesSection(bunLock: string) {
   const start = bunLock.indexOf(`  "workspaces": {`);
   const end = bunLock.indexOf(`  "packages": {`);
   expect(start).not.toBe(-1);
   expect(end).not.toBe(-1);
   return bunLock.slice(start, end);
+}
+
+// bun.lock writes `catalog` and `catalogs` between the workspaces and packages sections.
+function catalogSections(bunLock: string) {
+  const workspacesEnd = bunLock.indexOf("\n  },\n", bunLock.indexOf(`  "workspaces": {`));
+  const packagesStart = bunLock.indexOf(`  "packages": {`);
+  expect(workspacesEnd).not.toBe(-1);
+  expect(packagesStart).not.toBe(-1);
+  return bunLock.slice(workspacesEnd + "\n  },\n".length, packagesStart);
 }
 
 function workspaceBlock(bunLock: string, key: string) {
@@ -2144,12 +2163,7 @@ snapshots:
       expect(root).toContain(`      "dependencies": {\n        "no-deps": "~1.0.0",\n      },`);
       expect(root.split(`"a-dep"`).length - 1).toBe(1);
 
-      const install = await run(packageDir, "install");
-
-      expect(install.stderr).not.toContain("Saved lockfile");
-      expect(install.stderr).not.toContain("error:");
-      expect(install.exitCode).toBe(0);
-      expect(await bunLockOf(packageDir)).toBe(migrated);
+      await expectInstallToLeaveUnchanged(packageDir, migrated);
       expect(await installedPackageJson(packageDir, "", "a-dep")).toStrictEqual({ name: "a-dep", version: "1.0.1" });
     });
 
@@ -2723,6 +2737,288 @@ importers:
       const bunLock = await bunLockOf(packageDir);
       expect(bunLock).toContain(`"catalog": {\n    "no-deps": "^1.0.0",\n  }`);
       expect(bunLock).toContain(`"no-deps@1.0.1"`);
+    });
+
+    // pnpm-lock.yaml only records the catalog entries some importer uses; the migration copies the whole
+    // pnpm-workspace.yaml catalog into package.json, so bun.lock has to get the whole catalog too or the
+    // next `bun install` sees a catalog change and rewrites it.
+    test("entries no importer uses are migrated into bun.lock", async () => {
+      const { packageDir } = await verdaccio.createTestDir({
+        bunfigOpts: { linker: "hoisted" },
+        files: {
+          "package.json": JSON.stringify({ name: "unused-catalog", dependencies: { "no-deps": "^1.0.0" } }),
+          "pnpm-workspace.yaml": `catalog:
+  unused-default: ^9.0.0
+
+catalogs:
+  tools:
+    unused-tool: ^8.0.0
+`,
+          "pnpm-lock.yaml": `lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    dependencies:
+      no-deps:
+        specifier: ^1.0.0
+        version: 1.0.1
+
+packages:
+
+  no-deps@1.0.1:
+    resolution: {integrity: ${NO_DEPS_1_0_1_INTEGRITY}}
+
+snapshots:
+
+  no-deps@1.0.1: {}
+`,
+        },
+      });
+
+      const { stderr, exitCode } = await migrate(packageDir);
+
+      expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
+      expect(exitCode).toBe(0);
+
+      const migrated = await bunLockOf(packageDir);
+      expect(catalogSections(migrated)).toBe(
+        [
+          `  "catalog": {`,
+          `    "unused-default": "^9.0.0",`,
+          `  },`,
+          `  "catalogs": {`,
+          `    "tools": {`,
+          `      "unused-tool": "^8.0.0",`,
+          `    },`,
+          `  },`,
+          ``,
+        ].join("\n"),
+      );
+      expect((await Bun.file(join(packageDir, "package.json")).json()).workspaces).toEqual({
+        catalog: { "unused-default": "^9.0.0" },
+        catalogs: { tools: { "unused-tool": "^8.0.0" } },
+      });
+
+      await expectInstallToLeaveUnchanged(packageDir, migrated);
+    });
+
+    // Peers keep their catalog: reference through the migration, so the install afterwards is a no-op
+    // exactly when the catalog sections match what package.json declares.
+    test("declared entries are merged into the groups the lockfile recorded", async () => {
+      const { packageDir } = await verdaccio.createTestDir({
+        bunfigOpts: { linker: "hoisted" },
+        files: {
+          "package.json": JSON.stringify({
+            name: "merged-catalog",
+            peerDependencies: { "a-dep": "catalog:tools", "no-deps": "catalog:" },
+          }),
+          "pnpm-workspace.yaml": `catalog:
+  no-deps: ^1.0.0
+  unused-default: ^9.0.0
+
+catalogs:
+  tools:
+    a-dep: ^1.0.0
+    unused-tool: ^8.0.0
+`,
+          "pnpm-lock.yaml": `lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+
+catalogs:
+  default:
+    no-deps:
+      specifier: ^1.0.0
+      version: 1.0.1
+  tools:
+    a-dep:
+      specifier: ^1.0.0
+      version: 1.0.1
+
+importers:
+
+  .:
+    dependencies:
+      a-dep:
+        specifier: catalog:tools
+        version: 1.0.1
+      no-deps:
+        specifier: 'catalog:'
+        version: 1.0.1
+
+packages:
+
+  a-dep@1.0.1:
+    resolution: {integrity: ${A_DEP_1_0_1_INTEGRITY}}
+
+  no-deps@1.0.1:
+    resolution: {integrity: ${NO_DEPS_1_0_1_INTEGRITY}}
+
+snapshots:
+
+  a-dep@1.0.1: {}
+
+  no-deps@1.0.1: {}
+`,
+        },
+      });
+
+      const { stderr, exitCode } = await migrate(packageDir);
+
+      expect(stderr).not.toContain("missing entry");
+      expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
+      expect(exitCode).toBe(0);
+
+      const migrated = await bunLockOf(packageDir);
+      expect(catalogSections(migrated)).toBe(
+        [
+          `  "catalog": {`,
+          `    "no-deps": "^1.0.0",`,
+          `    "unused-default": "^9.0.0",`,
+          `  },`,
+          `  "catalogs": {`,
+          `    "tools": {`,
+          `      "a-dep": "^1.0.0",`,
+          `      "unused-tool": "^8.0.0",`,
+          `    },`,
+          `  },`,
+          ``,
+        ].join("\n"),
+      );
+      expect(workspaceBlock(migrated, "")).toContain(
+        `      "peerDependencies": {\n        "a-dep": "catalog:tools",\n        "no-deps": "catalog:",\n      },`,
+      );
+
+      await expectInstallToLeaveUnchanged(packageDir, migrated);
+      expect(await installedPackageJson(packageDir, "", "a-dep")).toStrictEqual({ name: "a-dep", version: "1.0.1" });
+    });
+
+    // pnpm-lock.yaml records the default catalog as `catalogs.default` whether pnpm-workspace.yaml spelled it
+    // `catalog:` or `catalogs.default:`; bun.lock and package.json keep the two spellings apart.
+    test("a default catalog declared as catalogs.default stays catalogs.default", async () => {
+      const { packageDir } = await verdaccio.createTestDir({
+        bunfigOpts: { linker: "hoisted" },
+        files: {
+          "package.json": JSON.stringify({ name: "catalogs-default", peerDependencies: { "no-deps": "catalog:" } }),
+          "pnpm-workspace.yaml": `catalogs:
+  default:
+    no-deps: ^1.0.0
+    unused-default: ^9.0.0
+`,
+          "pnpm-lock.yaml": `lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+
+catalogs:
+  default:
+    no-deps:
+      specifier: ^1.0.0
+      version: 1.0.1
+
+importers:
+
+  .:
+    dependencies:
+      no-deps:
+        specifier: 'catalog:'
+        version: 1.0.1
+
+packages:
+
+  no-deps@1.0.1:
+    resolution: {integrity: ${NO_DEPS_1_0_1_INTEGRITY}}
+
+snapshots:
+
+  no-deps@1.0.1: {}
+`,
+        },
+      });
+
+      const { stderr, exitCode } = await migrate(packageDir);
+
+      expect(stderr).not.toContain("missing entry");
+      expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
+      expect(exitCode).toBe(0);
+
+      const migrated = await bunLockOf(packageDir);
+      expect(catalogSections(migrated)).toBe(
+        [
+          `  "catalogs": {`,
+          `    "default": {`,
+          `      "no-deps": "^1.0.0",`,
+          `      "unused-default": "^9.0.0",`,
+          `    },`,
+          `  },`,
+          ``,
+        ].join("\n"),
+      );
+      expect((await Bun.file(join(packageDir, "package.json")).json()).workspaces).toEqual({
+        catalogs: { default: { "no-deps": "^1.0.0", "unused-default": "^9.0.0" } },
+      });
+
+      await expectInstallToLeaveUnchanged(packageDir, migrated);
+    });
+
+    // The lockfile's specifier is the one its resolutions were made with: taking the yaml's would hide the
+    // edit from the next install and leave no-deps@1.0.0 locked under a range it does not satisfy.
+    test("an entry edited in pnpm-workspace.yaml after the last pnpm install keeps the lockfile's specifier", async () => {
+      const { packageDir } = await verdaccio.createTestDir({
+        bunfigOpts: { linker: "hoisted" },
+        files: {
+          "package.json": JSON.stringify({ name: "edited-catalog", dependencies: { "no-deps": "catalog:" } }),
+          "pnpm-workspace.yaml": `catalog:
+  no-deps: ^1.0.1
+`,
+          "pnpm-lock.yaml": `lockfileVersion: '9.0'
+
+catalogs:
+  default:
+    no-deps:
+      specifier: ^1.0.0
+      version: 1.0.0
+
+importers:
+
+  .:
+    dependencies:
+      no-deps:
+        specifier: 'catalog:'
+        version: 1.0.0
+
+packages:
+
+  no-deps@1.0.0:
+    resolution: {integrity: ${NO_DEPS_1_0_0_INTEGRITY}}
+
+snapshots:
+
+  no-deps@1.0.0: {}
+`,
+        },
+      });
+
+      const { stderr, exitCode } = await migrate(packageDir);
+
+      expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
+      expect(exitCode).toBe(0);
+
+      const migrated = await bunLockOf(packageDir);
+      expect(catalogSections(migrated)).toBe(`  "catalog": {\n    "no-deps": "^1.0.0",\n  },\n`);
+      expect(migrated).toContain(`"no-deps@1.0.0"`);
+
+      const install = await run(packageDir, "install");
+
+      expect(install.stderr).toContain("Saved lockfile");
+      expect(install.stderr).not.toContain("error:");
+      expect(install.exitCode).toBe(0);
+      const updated = await bunLockOf(packageDir);
+      expect(catalogSections(updated)).toBe(`  "catalog": {\n    "no-deps": "^1.0.1",\n  },\n`);
+      expect(updated).toContain(`"no-deps@1.1.0"`);
+      expect(updated).not.toContain(`"no-deps@1.0.0"`);
     });
 
     // pnpm/pnpm#10456: `pnpm remove` can drop the catalogs: section while importers still say catalog:


### PR DESCRIPTION
### Problem
- After `bun pm migrate` (or the first `bun install`) in a pnpm project, the next plain `bun install` prints `Saved lockfile` and rewrites `bun.lock` whenever `pnpm-workspace.yaml` declares a catalog entry that no workspace currently uses, or declares the default catalog as `catalogs.default:` instead of `catalog:`. The differ reports `catalogs_changed`, so `install_with_manager` also re-enqueues every `catalog:` dependency; when a second satisfying version of one of them is already in the lockfile, that re-resolve can move the dependency off the version pnpm had locked.
- Cause: `bun.lock`'s catalog sections were seeded only from `pnpm-lock.yaml`'s `catalogs:` section (`CatalogMap::from_pnpm_lockfile`, `src/install/pnpm.rs:597`). pnpm writes that section as a cache of the entries in use, and always files the default catalog under `default`. Meanwhile `update_package_json_after_migration` copies the full `catalog`/`catalogs` objects from `pnpm-workspace.yaml` into `package.json`, which `CatalogMap::parse_append` reads back entry for entry and spelling for spelling (`catalog` -> `CatalogMap.default`, `catalogs.default` -> `groups["default"]`). `Diff::generate` (`src/install/lockfile/Package.rs:1056`) compares the two structurally, so the migrated lockfile never matched the `package.json` the same migration wrote. A `bun install` of a `package.json` catalog records every declared entry in `bun.lock`, used or not; the migration recorded the used subset.

### Fix
- `update_package_json_after_migration` (`src/install/pnpm.rs`) now takes the lockfile, and at the point where it takes the `catalog`/`catalogs` objects out of `pnpm-workspace.yaml` for `package.json` it hands the same two objects to `CatalogMap::put_missing_from_pnpm_workspace`. One extraction feeds both files, so `bun.lock` declares exactly the catalog `package.json` declares; the migrated root never goes through `Package::parse`, which is what records a catalog on a normal install. The parameter and call-site change are the same lines #38780 adds for `onlyBuiltDependencies`, so whichever lands second rebases onto identical text.
- `CatalogMap::put_missing_from_pnpm_workspace` (`src/install/lockfile/CatalogMap.rs`): an entry the lockfile section already records is skipped, an entry declared under `catalogs.default` that the section filed in `default` moves to `groups["default"]`, and any other declared entry is added with its declared specifier. Named groups go through the same `get_or_put_group` that `parse_append` uses, so the shape is what the next install parses out of `package.json`.
- Recorded entries keep the lockfile's specifier on purpose. The lockfile's resolutions were made against that specifier; if `pnpm-workspace.yaml` was edited after the last `pnpm install`, the next `bun install` must still see the edit and re-resolve, and taking the yaml's specifier would instead leave e.g. `no-deps@1.0.0` locked under `^1.0.1` with no change detected.
- The call runs after every importer row has been migrated (the function is the last step of `migrate_pnpm_lockfile`). A row referencing an entry missing from the lockfile section has already failed the migration by then (`pnpm-lock.yaml catalog ... missing entry`, existing test), so nothing the lockfile resolved refers to an entry this adds.
- Entries that do not parse are left out without logging: they are copied into `package.json` unchanged, and `parse_append_group` reports them with a location when the next install reads that file.
- `put_entries_from_pnpm_lockfile` now shares `parse_entry` with the new code; its behaviour (specifier parsed with the log, duplicate or unparsable entry is `InvalidPnpmLockfile`) is unchanged. `get_or_put_group`'s named-group half became `get_or_put_named_group` so the move case can hold `default` and `groups` at the same time.
- Tests (`test/cli/install/migration/pnpm-lock-v9.test.ts`, `catalogs` block): unused entries in `catalog` and in a named group when the lockfile has no `catalogs:` section at all; unused entries merged into groups the lockfile did record (the used entries are `catalog:` peers, which already round-trip, so the install after the migration is a no-op exactly when the catalog sections match); `catalogs.default:` staying `catalogs.default`. Each asserts the exact catalog text of the migrated `bun.lock` and then, through the new `expectInstallToLeaveUnchanged` helper (also used by the pre-existing no-op test), that `bun install` prints no `Saved lockfile` and leaves the file byte-identical. With `src/` at main the three fail on the first assertion (no section / entries missing / `catalog` instead of `catalogs.default`). A fourth test pins the specifier rule above: the lockfile's `^1.0.0` is what gets migrated, and the next install moves the catalog to the yaml's `^1.0.1` and re-resolves `no-deps` to 1.1.0; it passes before and after and fails if the skip is removed.
- The `catalogs` snapshot in `pnpm-migration-complete.test.ts` gains the two entries its `pnpm-workspace.yaml` declares but nothing uses (`react-dom`, `eslint`). Also run: all of `pnpm-lock-v9.test.ts` (81 pass), `pnpm-migration-complete`, `pnpm-lock-migration`, `pnpm-comprehensive`, `catalogs.test.ts`; `cargo clippy -p bun_install` is clean. Under the ASAN build I also checked quoted, double-quoted and folded yaml scalars (they live in the parse arena, which is still alive at the call site), `catalog:` and `catalogs.default:` declared together, a `catalogs.x: {}` group, and a non-string specifier: each migrates to what the following install would have written, and that install is a no-op.
- Docs: one bullet under "Lockfile Migration" in `docs/pm/cli/install.mdx`.
- Touches `update_package_json_after_migration`, which #38780 (identical parameter), #38804, #38775 and #38754 also change; apart from #38780 the overlap is one signature line plus the seven-line call, which is inside the block #38754 and #38775 keep.
- Out of scope: with regular (non-peer) `catalog:` dependencies the install after a migration still rewrites the importer rows themselves; that is the row-shape issue #38791 fixes, which deliberately leaves the catalog sections to this PR. A catalog written by hand into `package.json` before migrating (no yaml catalog) is also still recorded as the used subset; the migration does not create that state, and it is a different input than the one this PR mirrors.

### Background
- pnpm catalogs: `pnpm-workspace.yaml` declares named ranges (`catalog:` for the default catalog, or `catalogs.default:`, plus `catalogs.<name>:`), and manifests reference them as `"dep": "catalog:"` / `"catalog:<name>"`. `pnpm-lock.yaml` additionally has a `catalogs:` section recording, for the entries some importer references, the specifier they had when the lockfile was written.
- bun stores the same thing in the root `package.json` under `workspaces.catalog` / `workspaces.catalogs`, and `bun.lock` has `catalog` and `catalogs` sections holding every declared entry. `CatalogMap` is the in-memory form: `default` (the singular `catalog` object) and `groups` (one map per `catalogs` key, so `catalogs.default` is a group named `default`, distinct from `default`). Lookups of `catalog:` / `catalog:default` try both places, which is why moving entries between them is safe for every row that references them.
- On each install, `Diff::generate` compares the `CatalogMap` loaded from `bun.lock` with the one parsed from `package.json`; any difference sets `catalogs_changed`, which saves the lockfile and re-enqueues every `catalog:` dependency. `--frozen-lockfile` separately tolerates a lockfile that lacks unreferenced entries (for turbo-pruned checkouts), which is why only the plain install showed the rewrite.
- The migration rewrites the root `package.json` once (yaml `packages`/`catalog`/`catalogs` become the `workspaces` field, and so on) and later installs read `package.json` like any bun project; the migrated lockfile itself is built directly from `pnpm-lock.yaml`, so anything `Package::parse` would have derived from the edited `package.json` has to be filled in by the migration.

<details>
<summary>Earlier shape of this PR</summary>

The first revision added a separate `put_catalog_entries_from_pnpm_workspace` in `pnpm.rs` that re-read and re-parsed `pnpm-workspace.yaml` (the fourth independent parse of that file during a migration) into a scratch log and called the same `CatalogMap` function with the yaml root, one line before `update_package_json_after_migration`. Review pointed out that this left the invariant enforced by two readers of the same file that merely agree, and that it would conflict with #38780 and #38804, which both rework that call; the seeding was moved into `update_package_json_after_migration` as described above. `CatalogMap.rs`, the tests, the snapshot and the docs bullet are unchanged apart from the function now taking the two objects instead of the root.
</details>

<details>
<summary>Manual runs against the debug build</summary>

Layout from the report (`catalog:` with `no-deps` used and `unused-entry` unused), before this change:

```
$ bun pm migrate && bun install
moved pnpm-workspace.yaml to workspaces in package.json
migrated lockfile from pnpm-lock.yaml
Saved lockfile            # bun.lock gains "unused-entry": "^9.0.0"
```

Same layout with `catalogs:\n  default:` in the yaml, before this change: the migrated `bun.lock` has a `"catalog": {` section and the install rewrites it as `"catalogs": { "default": {`.

After this change both migrate to the sections the install would write; with a `catalog:` peer the install prints nothing and leaves the file byte-identical (the new tests), with a regular `catalog:` dependency only the importer row changes (#38791).

Re-resolution on a catalog change is not affected by the peer shape used in the tests: a root `peerDependencies` range that the installed version stops satisfying is updated in `bun.lock` with `warn: incorrect peer dependency` and the installed version kept, with or without catalogs and with or without a migration. The fourth test therefore uses a regular dependency for its re-resolution assertion.
</details>
