### PR TITLE
install: skip root lifecycle scripts and the yarn.lock write under --dry-run

### DIFF
--- a/docs/pm/cli/install.mdx
+++ b/docs/pm/cli/install.mdx
@@ -206,6 +206,12 @@ To perform a dry run, without installing anything:
 bun install --dry-run
 ```
 
+Bun resolves the dependency tree and prints the summary. During a dry run, Bun does not:
+
+- install packages into `node_modules`
+- write `bun.lock` (or `yarn.lock` with `--yarn`)
+- run your project's lifecycle scripts
+
 ---
 
 ## Non-npm dependencies

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -998,12 +998,15 @@ pub fn install_with_manager(
         manager.summary.add = manager.lockfile.packages.len() as u32;
     }
 
-    if manager.options.do_.save_yarn_lock() {
-        write_yarn_lock_with_progress(manager, log_level)?;
-    }
+    if !manager.options.dry_run {
+        if manager.options.do_.save_yarn_lock() {
+            write_yarn_lock_with_progress(manager, log_level)?;
+        }
 
-    if manager.options.do_.run_scripts() && install_root_dependencies && !manager.options.global {
-        run_root_lifecycle_scripts(manager, ctx, log_level)?;
+        if manager.options.do_.run_scripts() && install_root_dependencies && !manager.options.global
+        {
+            run_root_lifecycle_scripts(manager, ctx, log_level)?;
+        }
     }
 
     if log_level != Options::LogLevel::Silent {

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -1616,6 +1616,65 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       assertManifestsPopulated(join(packageDir, ".bun-cache"), verdaccio.registryUrl());
     });
 
+    test("--dry-run should not run root lifecycle scripts", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
+      const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
+
+      await writeFile(
+        packageJson,
+        JSON.stringify({
+          name: "foo",
+          version: "1.0.0",
+          scripts: {
+            preinstall: "echo preinstall > preinstall.txt",
+            postinstall: "echo postinstall > postinstall.txt",
+            prepare: "echo prepare > prepare.txt",
+          },
+        }),
+      );
+
+      const scriptsRan = () =>
+        Promise.all([
+          exists(join(packageDir, "preinstall.txt")),
+          exists(join(packageDir, "postinstall.txt")),
+          exists(join(packageDir, "prepare.txt")),
+        ]);
+
+      for (const args of [["--dry-run"], ["--frozen-lockfile", "--dry-run"]]) {
+        const { stdout, stderr, exited } = spawn({
+          cmd: [bunExe(), "install", ...args],
+          cwd: packageDir,
+          stdout: "pipe",
+          stdin: "ignore",
+          stderr: "pipe",
+          env: testEnv,
+        });
+
+        const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+        expect(err).not.toContain("$ echo");
+        expect(err).not.toContain("error:");
+        expect(out).toContain("bun install v1.");
+        expect(exitCode).toBe(0);
+        expect(await scriptsRan()).toEqual([false, false, false]);
+      }
+
+      // The same package.json runs all three scripts on a real install.
+      const { stderr, exited } = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: packageDir,
+        stdout: "ignore",
+        stdin: "ignore",
+        stderr: "pipe",
+        env: testEnv,
+      });
+
+      const [err, exitCode] = await Promise.all([stderr.text(), exited]);
+      expect(err).not.toContain("error:");
+      expect(exitCode).toBe(0);
+      expect(await scriptsRan()).toEqual([true, true, true]);
+    });
+
     test("it should add `node-gyp rebuild` as the `install` script when `install` and `postinstall` don't exist and `binding.gyp` exists in the root of the package", async () => {
       using ctx = await setupTest();
       const { packageDir, packageJson, env } = ctx;

--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -860,6 +860,42 @@ it("escapes quotes and newlines in requested version literals when writing yarn.
   expect(lines.filter(line => line.trimStart().startsWith('resolved "http://injected.example'))).toEqual([]);
 });
 
+it("--yarn does not write yarn.lock during --dry-run", async () => {
+  const { packageDir, packageJson } = await registry.createTestDir();
+
+  await write(
+    packageJson,
+    JSON.stringify({
+      name: "yarn-lock-dry-run",
+      dependencies: {
+        "no-deps": "1.0.0",
+      },
+    }),
+  );
+
+  const { exited, stdout, stderr } = spawn({
+    cmd: [bunExe(), "install", "--yarn", "--dry-run"],
+    cwd: packageDir,
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+  expect(err).not.toContain("yarn.lock");
+  expect(err).not.toContain("error:");
+  expect(out).toContain("no-deps@1.0.0");
+  expect(exitCode).toBe(0);
+
+  expect(
+    await Promise.all([
+      exists(join(packageDir, "yarn.lock")),
+      exists(join(packageDir, "bun.lock")),
+      exists(join(packageDir, "node_modules")),
+    ]),
+  ).toEqual([false, false, false]);
+});
+
 it("prints an actionable error for a lockfile version newer than this build supports", async () => {
   const { packageDir, packageJson } = await registry.createTestDir();
 


### PR DESCRIPTION
### Problem
- `bun install --dry-run` runs the root package's lifecycle scripts. With `"scripts": {"preinstall": "echo PRE >> proof.txt", "postinstall": ..., "prepare": ...}` and no dependencies, `bun install --frozen-lockfile --dry-run` prints `$ echo PRE >> proof.txt` (and the other two) and `proof.txt` exists afterwards. Same for `bun install --dry-run`, `bun ci --dry-run`, and `bun update --dry-run`. The docs recommend `--frozen-lockfile --dry-run` as the install-free lockfile check for CI, where this executes `prisma generate` / `husky` style hooks (docs ledger #14912).
- `bun install --yarn --dry-run` prints `Saved yarn.lock` and writes the file.
- Cause: `--dry-run` only clears `Do::INSTALL_PACKAGES`, `Do::SAVE_LOCKFILE`, and `Do::WRITE_PACKAGE_JSON` (`src/install/PackageManager/PackageManagerOptions.rs:726`). The tail of `install_with_manager` (`src/install/PackageManager/install_with_manager.rs:1001`) then checks only `Do::SAVE_YARN_LOCK` and `Do::RUN_SCRIPTS`, which `--dry-run` leaves set, so both steps run after the (skipped) install. This has been the behavior since before the Rust port.

### Fix
- `install_with_manager` skips the yarn.lock write and `run_root_lifecycle_scripts` when `options.dry_run` is set. That `if !manager.options.dry_run` block is the whole change; the summary is still printed afterwards.
- The check lives at this call site rather than in the `--dry-run` block of `Options::load` because `Do::RUN_SCRIPTS` is shared with `bun pm pack --dry-run` and `bun publish --dry-run`, which deliberately still run `prepack` / `prepublishOnly` / `postpack` (npm does the same; `bun-publish.test.ts` "should run in order (--dry-run)" pins it). Root install scripts are only dispatched from this one place.
- Root scripts are still loaded into the lockfile before this point (`load_root_lifecycle_scripts`), so the frozen-lockfile comparison and the printed summary are unchanged; only the spawn is skipped.
- `docs/pm/cli/install.mdx`: the "Dry run" section now lists what a dry run does not do.
- Verified:
  - `test/cli/install/bun-install-lifecycle-scripts.test.ts` "--dry-run should not run root lifecycle scripts": `--dry-run` and `--frozen-lockfile --dry-run` create none of the marker files, a following plain `bun install` creates all three. Fails on the unfixed build (stderr contains `$ echo preinstall > preinstall.txt`).
  - `test/cli/install/bun-lock.test.ts` "--yarn does not write yarn.lock during --dry-run": fails on the unfixed build with `Saved yarn.lock` in stderr.
  - Also run locally with the fix: `bun-lock.test.ts`, `bun-install-lifecycle-scripts.test.ts` (the `node -p` / `ensureTempNodeGypScript` cases fail here without the fix too; `node` is not on this machine's PATH), `bun-update-transitive.test.ts`, `bun-dedupe.test.ts`, `frozen-lockfile-pruned.test.ts`, `bun-update-lockfile-sync.test.ts`, `bun-update.test.ts`, `bun-add-filter.test.ts`, `bun-add-catalog.test.ts`, `bun-audit.test.ts`, `bun-pack.test.ts`, `migration/migrate.test.ts`; `cargo fmt -p bun_install --check` is clean.
- Not changed here: a project with a `package-lock.json` / `yarn.lock` / `pnpm-lock.yaml` but no `bun.lock` still writes the migrated `bun.lock` under `--dry-run`. #38804 fixes that (together with `--frozen-lockfile` and `--no-save`) and touches the `should_save_lockfile` predicate a few lines above this change; the two do not overlap. `[install] dryRun` in bunfig.toml is parsed but never read; #34979 covers that.

### Background
- `PackageManager::Options::do_` is a bitflags set of the steps an install performs (`INSTALL_PACKAGES`, `SAVE_LOCKFILE`, `RUN_SCRIPTS`, `SAVE_YARN_LOCK`, ...). Flags and bunfig keys clear bits in `Options::load`; `install_with_manager` consults the bits as it goes. `--ignore-scripts` clears `RUN_SCRIPTS`; `--dry-run` sets `options.dry_run` and clears the three bits listed above.
- Root lifecycle scripts are the `preinstall` / `install` / `postinstall` / `preprepare` / `prepare` / `postprepare` entries of the project's own `package.json` (plus an implicit `node-gyp rebuild` when `binding.gyp` exists). Dependency scripts are spawned by the package installer while packages are linked, so `--dry-run` already skipped them; root scripts run last, from `install_with_manager`, after the lockfile is saved.
- `--yarn` (also `BUN_CONFIG_YARN_LOCKFILE`, or `[install.lockfile] print = "yarn"` in bunfig.toml) makes the install additionally emit a yarn v1 format `yarn.lock` from the resolved lockfile, at the same point in the flow.
- `install_with_manager` is the shared tail of `bun install`, `bun ci`, `bun add`, `bun remove`, and `bun update`, so the change covers all of their `--dry-run` forms. `bun dedupe --dry-run` / `--check` and `bun audit fix --dry-run` exit before reaching it, and `bun pm pack` / `bun publish` do not use it.
