### PR TITLE
fix(test): substitute %s for non-string values in test.each titles

### DIFF
--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -753,7 +753,7 @@ pub(crate) fn format_label(
                 b's' => {
                     consume_arg(
                         global_this,
-                        !current_arg.is_empty() && current_arg.js_type().is_string(),
+                        !current_arg.is_empty(),
                         &mut idx,
                         &mut args_idx,
                         &mut list,

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -953,6 +953,27 @@ describe("bun test", () => {
         expect(stderr).toContain(`with a string: ${s}`);
       });
     });
+    test("check formatting for %s with non-string values", () => {
+      const stderr = runTest({
+        args: [],
+        input: `
+          import { test, expect } from "bun:test";
+
+          test.each([1])("integer via %s", (v) => {
+            expect(v).toBeDefined();
+          });
+          test.each([0.8])("float via %s", (v) => {
+            expect(v).toBeDefined();
+          });
+          test.each([["x", 1]])("mixed tuple via %s: %s", (a, b) => {
+            expect([a, b]).toBeDefined();
+          });
+        `,
+      });
+      expect(stderr).toContain("integer via 1");
+      expect(stderr).toContain("float via 0.8");
+      expect(stderr).toContain("mixed tuple via x: 1");
+    });
     test("check formatting for %j", () => {
       const input = [
         {


### PR DESCRIPTION
Fixes #37821

test.each / describe.each only substituted \%s\ when the value was already a string; numbers, floats, booleans and other non-string values left the literal \%s\ in the test title. \%d\/\%f\/\%p\ already accepted both.

Matches Jest's behavior, where titles are formatted through \util.format\ and \%s\ stringifies any value via \String(value)\.

- src/runtime/test_runner/jest.rs: drop the string-only gate on \%s\ (keep the empty-value guard, which keeps the placeholder for empty args like the other specifiers)
- test/cli/test/bun-test.test.ts: regression test asserting substituted titles for integer, float and mixed-tuple cases