### PR TITLE
install: resolve a range onto an existing version only when every install has it

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2084,7 +2084,12 @@ fn get_or_put_resolved_package_with_find_result(
     let suppress_peer_satisfies = behavior.is_peer()
         && !install_peer
         && !(version.tag == dependency::version::Tag::Npm && version.npm().version.is_star());
-    let exact = version.tag == dependency::version::Tag::Npm && version.npm().version.is_exact();
+    // Which peer rows have landed on a version by any given moment depends on
+    // what has arrived (they bind on sight or in the peer pass), so only
+    // regular rows' pins are recorded (`AppendedFor::pinned`).
+    let pins = !behavior.is_peer()
+        && version.tag == dependency::version::Tag::Npm
+        && version.npm().version.is_exact();
     if let Some(id) = this.lockfile.get_package_id(
         name_hash,
         if should_update || suppress_peer_satisfies {
@@ -2097,9 +2102,7 @@ fn get_or_put_resolved_package_with_find_result(
             url: find_result.package.tarball_url.value,
         })),
     ) {
-        // A peer binds here or in the peer pass depending on what has arrived,
-        // so only regular rows, which all bind in the first pass, count.
-        if exact && !behavior.is_peer() {
+        if pins {
             this.lockfile.mark_pinned_by_reuse(id);
         }
         success_fn(this, dependency_id, id);
@@ -2131,7 +2134,7 @@ fn get_or_put_resolved_package_with_find_result(
     debug_assert!(package.meta.id != invalid_package_id);
     // SAFETY: `this_ptr` is the sole live `&mut PackageManager` here; `package`
     // was returned by value above.
-    unsafe { &mut *(*this_ptr).lockfile }.mark_appended_for(package.meta.id, dependency_id, exact);
+    unsafe { &mut *(*this_ptr).lockfile }.mark_appended_for(package.meta.id, dependency_id, pins);
     // Use scopeguard so success_fn runs on every
     // return below (including the `?` paths). The guard owns the raw pointer so the
     // `this` reborrow below doesn't conflict with the closure capture.

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2078,20 +2078,12 @@ fn get_or_put_resolved_package_with_find_result(
 
     // Was this package already allocated? Let's reuse the existing one.
     //
-    // Determinism: passing `version` here unconditionally lets a
-    // peer like `>= 1.0.2` collapse onto whichever sibling-appended entry
-    // (e.g. `1.0.9`) happens to be highest in the index *at this instant* — a
-    // network-order artefact that the `^1.0.2` peer-hoisting test already
-    // todoIf's on macOS. The floor guard in `get_package_id` was
-    // meant to close that, but its exact-pinned/same-major exemptions reopen
-    // it when *every* candidate is an exact-pinned same-major sibling
-    // (`uses-a-dep-1..10`). For deferred peers, suppress the satisfies-
-    // fallback so only an exact `eql(find_result)` can bind here; everything
-    // else falls through to the `is_peer && !install_peer` defer below and is
-    // resolved deterministically by phase 2's descending-index scan in
-    // `get_or_put_resolved_package`. `*` is left alone — it expresses no
-    // version preference, and the "peer *" hoisting test depends on it
-    // deduping to whatever sibling pin exists rather than the manifest floor.
+    // A peer that is not being installed yet binds here only to its exact
+    // best match; otherwise it is deferred (`is_peer && !install_peer` below)
+    // and bound in phase 2 (`get_or_put_resolved_package`), once every
+    // non-peer row is resolved, to the highest version present that satisfies
+    // it. `*` expresses no preference, so it may also bind now to a version
+    // that is settled already (`Lockfile::get_package_id`).
     let suppress_peer_satisfies = behavior.is_peer()
         && !install_peer
         && !(version.tag == dependency::version::Tag::Npm && version.npm().version.is_star());
@@ -2134,15 +2126,13 @@ fn get_or_put_resolved_package_with_find_result(
     )?)?;
 
     debug_assert!(package.meta.id != invalid_package_id);
-    // Record exact-version pins so `Lockfile::get_package_id`'s
-    // order-independence guard can tell them apart from range-resolved
-    // entries (which it treats as network-order artefacts).
-    if version.tag == dependency::version::Tag::Npm && version.npm().version.is_exact() {
-        // SAFETY: `this_ptr` is the sole live `&mut PackageManager` here;
-        // `lockfile.exact_pinned` is disjoint from `package` (returned
-        // by-value above).
-        unsafe { &mut *(*this_ptr).lockfile }.mark_exact_pin(package.meta.id);
-    }
+    // SAFETY: `this_ptr` is the sole live `&mut PackageManager` here; `package`
+    // was returned by value above.
+    unsafe { &mut *(*this_ptr).lockfile }.mark_appended_for(
+        package.meta.id,
+        dependency_id,
+        version.tag == dependency::version::Tag::Npm && version.npm().version.is_exact(),
+    );
     // Use scopeguard so success_fn runs on every
     // return below (including the `?` paths). The guard owns the raw pointer so the
     // `this` reborrow below doesn't conflict with the closure capture.

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2078,12 +2078,9 @@ fn get_or_put_resolved_package_with_find_result(
 
     // Was this package already allocated? Let's reuse the existing one.
     //
-    // A peer that is not being installed yet binds here only to its exact
-    // best match; otherwise it is deferred (`is_peer && !install_peer` below)
-    // and bound in phase 2 (`get_or_put_resolved_package`), once every
-    // non-peer row is resolved, to the highest version present that satisfies
-    // it. `*` expresses no preference, so it may also bind now to a version
-    // that is settled already (`Lockfile::get_package_id`).
+    // A peer not being installed yet binds now only to its exact best match
+    // (`*` also to a version every install has) and is otherwise deferred to
+    // the peer pass in `get_or_put_resolved_package`.
     let suppress_peer_satisfies = behavior.is_peer()
         && !install_peer
         && !(version.tag == dependency::version::Tag::Npm && version.npm().version.is_star());

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2084,6 +2084,7 @@ fn get_or_put_resolved_package_with_find_result(
     let suppress_peer_satisfies = behavior.is_peer()
         && !install_peer
         && !(version.tag == dependency::version::Tag::Npm && version.npm().version.is_star());
+    let exact = version.tag == dependency::version::Tag::Npm && version.npm().version.is_exact();
     if let Some(id) = this.lockfile.get_package_id(
         name_hash,
         if should_update || suppress_peer_satisfies {
@@ -2096,6 +2097,11 @@ fn get_or_put_resolved_package_with_find_result(
             url: find_result.package.tarball_url.value,
         })),
     ) {
+        // A peer binds here or in the peer pass depending on what has arrived,
+        // so only regular rows, which all bind in the first pass, count.
+        if exact && !behavior.is_peer() {
+            this.lockfile.mark_pinned_by_reuse(id);
+        }
         success_fn(this, dependency_id, id);
         return Ok(Some(ResolvedPackageResult {
             package: *this.lockfile.packages.get(id as usize),
@@ -2125,11 +2131,7 @@ fn get_or_put_resolved_package_with_find_result(
     debug_assert!(package.meta.id != invalid_package_id);
     // SAFETY: `this_ptr` is the sole live `&mut PackageManager` here; `package`
     // was returned by value above.
-    unsafe { &mut *(*this_ptr).lockfile }.mark_appended_for(
-        package.meta.id,
-        dependency_id,
-        version.tag == dependency::version::Tag::Npm && version.npm().version.is_exact(),
-    );
+    unsafe { &mut *(*this_ptr).lockfile }.mark_appended_for(package.meta.id, dependency_id, exact);
     // Use scopeguard so success_fn runs on every
     // return below (including the `?` paths). The guard owns the raw pointer so the
     // `this` reborrow below doesn't conflict with the closure capture.

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -2095,6 +2095,7 @@ fn wait_for_resolution(manager: &mut PackageManager) -> crate::Result<()> {
     if manager.pending_task_count() > 0 {
         wait_for_everything_except_peers(manager)?;
     }
+    manager.lockfile.mark_settled_packages();
 
     // Resolving a peer dep can create a NEW package whose own peer deps
     // get re-queued to `peer_dependencies` during `drainDependencyList`.

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -190,48 +190,28 @@ pub struct Lockfile {
 
     pub(crate) saved_config_version: Option<ConfigVersion>,
 
-    /// `packages.len()` at the moment lockfile load (including npm/pnpm/yarn
-    /// migration) finished. Packages with `id < this` were carried in from a
-    /// lockfile and represent a user-pinned resolution; packages with
-    /// `id >= this` were appended in the current resolve session. Set by
-    /// `mark_loaded_packages`; a fresh lockfile has `0`.
-    ///
-    /// Runtime-only — never serialised.
+    /// `packages.len()` once the lockfile (or a migrated one) was loaded:
+    /// packages below it came from the lockfile, the rest were appended in
+    /// this run (`mark_loaded_packages`). Runtime-only, never serialised.
     pub(crate) loaded_package_count: PackageID,
 
-    /// Packages with `id < this` are present on every install of this
-    /// package.json, whatever order the registry answers in: they were loaded
-    /// from the lockfile, or were appended before the last point at which
-    /// resolution had drained completely (`mark_settled_packages`). The rest
-    /// were appended while manifests were still arriving, and which of them
-    /// exist at any given moment depends on arrival order, unless they were
-    /// appended for a direct dependency (`AppendedFor::direct`). See
-    /// `get_package_id`.
-    ///
-    /// Runtime-only — never serialised.
+    /// Packages below this were loaded or appended before resolution last
+    /// drained (`mark_settled_packages`), so they exist on every install; see
+    /// `get_package_id`. Runtime-only, never serialised.
     pub(crate) settled_package_count: PackageID,
 
-    /// `appended_for[id]` for every package appended from a registry manifest
-    /// in this resolve session (`mark_appended_for`); indexed by `PackageID`,
-    /// grown lazily, and only consulted for `id >= loaded_package_count`.
-    ///
-    /// Runtime-only — never serialised.
+    /// Indexed by `PackageID`, filled by `mark_appended_for` for the packages
+    /// appended from a manifest in this run. Runtime-only, never serialised.
     pub(crate) appended_for: Vec<AppendedFor>,
 }
 
-/// What `Lockfile::get_package_id` needs to know about the dependency row a
-/// package was appended from a registry manifest to resolve.
+/// The dependency row a package was appended to resolve; see
+/// `Lockfile::get_package_id`.
 #[derive(Clone, Copy, Debug, Default)]
 pub(crate) struct AppendedFor {
-    /// The row belongs to the root or a workspace package. Those rows are
-    /// enqueued before any manifest is processed and each manifest's waiting
-    /// rows are resolved FIFO, so for a given package name they resolve before
-    /// any transitive row, and what they append is present on every install
-    /// even while manifests are still arriving.
+    /// Declared by the root or a workspace package.
     pub direct: bool,
-    /// The row's range (after overrides and catalogs) was an exact version, a
-    /// deliberate choice that ranges from any major may settle on; a version a
-    /// range picked only attracts ranges that would pick the same major.
+    /// Its range (after overrides and catalogs) was an exact version.
     pub exact: bool,
 }
 
@@ -2004,18 +1984,13 @@ impl Lockfile {
         self.settled_package_count = self.loaded_package_count;
     }
 
-    /// Call once nothing is left to resolve (every enqueued row is bound and
-    /// no manifest is in flight), e.g. between resolving regular rows and
-    /// installing peers: the packages present at such a point are the same on
-    /// every install, so rows resolved afterwards may settle on any of them.
+    /// Call only while nothing is being resolved (no row enqueued, no manifest
+    /// in flight); see `get_package_id`.
     #[inline]
     pub(crate) fn mark_settled_packages(&mut self) {
         self.settled_package_count = self.packages.len() as PackageID;
     }
 
-    /// Record that package `id` was just appended from a registry manifest to
-    /// resolve `dependency_id`, whose range (after overrides and catalogs) was
-    /// an exact version iff `exact`.
     pub(crate) fn mark_appended_for(
         &mut self,
         id: PackageID,
@@ -2035,16 +2010,15 @@ impl Lockfile {
 
     /// The package `resolution` is already stored as, if any.
     ///
-    /// When `version` is an npm range, `resolution` is the range's best match
-    /// from the manifest, and the highest version already present that the
-    /// range accepts is preferred over it (lockfile versions unconditionally,
-    /// others when pinned exactly or of the best match's major), provided
-    /// that version is present on every install of this package.json
-    /// (`settled_package_count`, `AppendedFor::direct`). A version that is
-    /// present only because some transitive dependency's manifest happened to
-    /// be processed already is not a candidate, and resolves the range only
-    /// when it is the best match itself, so the answer does not depend on the
-    /// order the registry answered in.
+    /// For an npm range `version`, `resolution` is its best match from the
+    /// manifest, and an existing version the range accepts is preferred (a
+    /// lockfile version always, an appended one when pinned exactly or of the
+    /// best match's major) if it exists on every install: settled, or appended
+    /// for a direct row. Direct rows are enqueued before any manifest is
+    /// processed and a manifest's waiting rows resolve FIFO, so for one name
+    /// they resolve before every transitive row; what transitive rows appended
+    /// so far depends on registry timing, so those only answer for a range
+    /// whose best match they are.
     pub(crate) fn get_package_id(
         &self,
         name_hash: u64,

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -211,9 +211,9 @@ pub struct Lockfile {
 pub(crate) struct AppendedFor {
     /// The row it was appended for is declared by the root or a workspace.
     pub direct: bool,
-    /// A row's range (after overrides and catalogs) was this exact version:
-    /// the appending row's, or a later one's while the package was not yet
-    /// reusable (`mark_pinned_by_reuse`).
+    /// A regular (non-peer) row's range, after overrides and catalogs, was
+    /// this exact version: the appending row's, or a later one's while the
+    /// package was not yet reusable (`mark_pinned_by_reuse`).
     pub pinned: bool,
 }
 

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -197,22 +197,24 @@ pub struct Lockfile {
 
     /// Packages below this were loaded or appended before resolution last
     /// drained (`mark_settled_packages`), so they exist on every install; see
-    /// `get_package_id`. Runtime-only, never serialised.
+    /// `is_reusable`. Runtime-only, never serialised.
     pub(crate) settled_package_count: PackageID,
 
     /// Indexed by `PackageID`, filled by `mark_appended_for` for the packages
     /// appended from a manifest in this run. Runtime-only, never serialised.
-    pub(crate) appended_for: Vec<AppendedFor>,
+    appended_for_by_id: Vec<AppendedFor>,
 }
 
-/// The dependency row a package was appended to resolve; see
+/// The rows a package appended in this run was resolved for; see
 /// `Lockfile::get_package_id`.
 #[derive(Clone, Copy, Debug, Default)]
 pub(crate) struct AppendedFor {
-    /// Declared by the root or a workspace package.
+    /// The row it was appended for is declared by the root or a workspace.
     pub direct: bool,
-    /// Its range (after overrides and catalogs) was an exact version.
-    pub exact: bool,
+    /// A row's range (after overrides and catalogs) was this exact version:
+    /// the appending row's, or a later one's while the package was not yet
+    /// reusable (`mark_pinned_by_reuse`).
+    pub pinned: bool,
 }
 
 pub(crate) type PackageList = self::package::List<u64>;
@@ -1971,7 +1973,7 @@ impl Lockfile {
             saved_config_version: None,
             loaded_package_count: 0,
             settled_package_count: 0,
-            appended_for: Vec::new(),
+            appended_for_by_id: Vec::new(),
         }
     }
 
@@ -1995,30 +1997,55 @@ impl Lockfile {
         &mut self,
         id: PackageID,
         dependency_id: DependencyID,
-        exact: bool,
+        pinned: bool,
     ) {
-        let appended_for = AppendedFor {
-            direct: self.is_workspace_dependency(dependency_id),
-            exact,
-        };
-        let i = id as usize;
-        if self.appended_for.len() <= i {
-            self.appended_for.resize(i + 1, AppendedFor::default());
+        let direct = self.is_workspace_dependency(dependency_id);
+        *self.appended_for_mut(id) = AppendedFor { direct, pinned };
+    }
+
+    /// A regular row whose range is exactly `id`'s version resolved to it.
+    /// Ignored once the package is reusable: from then on rows read
+    /// `pinned`, and which rows have resolved to it by any given moment
+    /// depends on registry timing.
+    pub(crate) fn mark_pinned_by_reuse(&mut self, id: PackageID) {
+        if !self.is_reusable(id) {
+            self.appended_for_mut(id).pinned = true;
         }
-        self.appended_for[i] = appended_for;
+    }
+
+    fn appended_for_mut(&mut self, id: PackageID) -> &mut AppendedFor {
+        let i = id as usize;
+        if self.appended_for_by_id.len() <= i {
+            self.appended_for_by_id
+                .resize(i + 1, AppendedFor::default());
+        }
+        &mut self.appended_for_by_id[i]
+    }
+
+    fn appended_for(&self, id: PackageID) -> AppendedFor {
+        self.appended_for_by_id
+            .get(id as usize)
+            .copied()
+            .unwrap_or_default()
+    }
+
+    /// Whether package `id` exists on every install of this package.json, so a
+    /// range it merely satisfies may resolve to it: it was loaded or settled,
+    /// or appended for a direct row. Direct rows are enqueued before any
+    /// manifest is processed and a manifest's waiting rows resolve FIFO, so
+    /// for one name they resolve before every transitive row; which packages
+    /// transitive rows have appended so far depends on registry timing.
+    fn is_reusable(&self, id: PackageID) -> bool {
+        id < self.settled_package_count || self.appended_for(id).direct
     }
 
     /// The package `resolution` is already stored as, if any.
     ///
     /// For an npm range `version`, `resolution` is its best match from the
-    /// manifest, and an existing version the range accepts is preferred (a
-    /// lockfile version always, an appended one when pinned exactly or of the
-    /// best match's major) if it exists on every install: settled, or appended
-    /// for a direct row. Direct rows are enqueued before any manifest is
-    /// processed and a manifest's waiting rows resolve FIFO, so for one name
-    /// they resolve before every transitive row; what transitive rows appended
-    /// so far depends on registry timing, so those only answer for a range
-    /// whose best match they are.
+    /// manifest, and the highest reusable version the range accepts is
+    /// preferred over it (`is_reusable`; a lockfile version always, an
+    /// appended one when a row pinned it or it is of the best match's major).
+    /// Anything else only answers for a range whose best match it is.
     pub(crate) fn get_package_id(
         &self,
         name_hash: u64,
@@ -2040,7 +2067,7 @@ impl Lockfile {
         {
             let best_match =
                 (resolution.tag == ResolutionTag::Npm).then(|| resolution.npm().version);
-            let present_on_every_install = ids.iter().copied().find(|&id| {
+            let reusable = ids.iter().copied().find(|&id| {
                 let existing = &resolutions[id as usize];
                 if existing.tag != ResolutionTag::Npm {
                     return false;
@@ -2052,18 +2079,13 @@ impl Lockfile {
                 if id < self.loaded_package_count {
                     return true;
                 }
-                let appended_for = self
-                    .appended_for
-                    .get(id as usize)
-                    .copied()
-                    .unwrap_or_default();
-                (id < self.settled_package_count || appended_for.direct)
-                    && (appended_for.exact
+                self.is_reusable(id)
+                    && (self.appended_for(id).pinned
                         || best_match
                             .is_none_or(|best_match| existing_version.major == best_match.major))
             });
-            if present_on_every_install.is_some() {
-                return present_on_every_install;
+            if reusable.is_some() {
+                return reusable;
             }
         }
 

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -193,24 +193,46 @@ pub struct Lockfile {
     /// `packages.len()` at the moment lockfile load (including npm/pnpm/yarn
     /// migration) finished. Packages with `id < this` were carried in from a
     /// lockfile and represent a user-pinned resolution; packages with
-    /// `id >= this` were appended by manifest fetches in the current
-    /// resolve session. `get_package_id` uses this to keep its
-    /// order-independence guard from overriding lockfile pins. Set by
-    /// `mark_loaded_packages`; defaults to `invalid_package_id` (no lockfile
-    /// loaded → guard applies to nothing, equivalent to "all entries are
-    /// session-appended").
+    /// `id >= this` were appended in the current resolve session. Set by
+    /// `mark_loaded_packages`; a fresh lockfile has `0`.
     ///
     /// Runtime-only — never serialised.
     pub(crate) loaded_package_count: PackageID,
 
-    /// `bit[id] == true` ⇔ package `id` was appended for a dependency whose
-    /// version range was an exact `=X.Y.Z` (i.e. the user — root or workspace
-    /// — pinned this exact version somewhere in the tree). `get_package_id`'s
-    /// order-independence guard never blocks deduping to one of these: an
-    /// exact pin is a deliberate choice, not an artifact of which manifest
-    /// happened to land first. Runtime-only — never serialised; sized lazily
-    /// in `mark_exact_pin`.
-    pub(crate) exact_pinned: DynamicBitSet,
+    /// Packages with `id < this` are present on every install of this
+    /// package.json, whatever order the registry answers in: they were loaded
+    /// from the lockfile, or were appended before the last point at which
+    /// resolution had drained completely (`mark_settled_packages`). The rest
+    /// were appended while manifests were still arriving, and which of them
+    /// exist at any given moment depends on arrival order, unless they were
+    /// appended for a direct dependency (`AppendedFor::direct`). See
+    /// `get_package_id`.
+    ///
+    /// Runtime-only — never serialised.
+    pub(crate) settled_package_count: PackageID,
+
+    /// `appended_for[id]` for every package appended from a registry manifest
+    /// in this resolve session (`mark_appended_for`); indexed by `PackageID`,
+    /// grown lazily, and only consulted for `id >= loaded_package_count`.
+    ///
+    /// Runtime-only — never serialised.
+    pub(crate) appended_for: Vec<AppendedFor>,
+}
+
+/// What `Lockfile::get_package_id` needs to know about the dependency row a
+/// package was appended from a registry manifest to resolve.
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct AppendedFor {
+    /// The row belongs to the root or a workspace package. Those rows are
+    /// enqueued before any manifest is processed and each manifest's waiting
+    /// rows are resolved FIFO, so for a given package name they resolve before
+    /// any transitive row, and what they append is present on every install
+    /// even while manifests are still arriving.
+    pub direct: bool,
+    /// The row's range (after overrides and catalogs) was an exact version, a
+    /// deliberate choice that ranges from any major may settle on; a version a
+    /// range picked only attracts ranges that would pick the same major.
+    pub exact: bool,
 }
 
 pub(crate) type PackageList = self::package::List<u64>;
@@ -1967,11 +1989,9 @@ impl Lockfile {
             meta_hash: ZERO_HASH,
             patched_dependencies: PatchedDependenciesMap::default(),
             saved_config_version: None,
-            // Fresh lockfile (no load): every package appended later is
-            // session-appended, so the order-independence guard in
-            // `get_package_id` applies from id 0.
             loaded_package_count: 0,
-            exact_pinned: DynamicBitSet::default(),
+            settled_package_count: 0,
+            appended_for: Vec::new(),
         }
     }
 
@@ -1981,124 +2001,101 @@ impl Lockfile {
     #[inline]
     pub(crate) fn mark_loaded_packages(&mut self) {
         self.loaded_package_count = self.packages.len() as PackageID;
+        self.settled_package_count = self.loaded_package_count;
     }
 
-    /// Record that package `id` was appended via an exact-version dependency
-    /// (`=X.Y.Z`). See the `exact_pinned` field doc.
+    /// Call once nothing is left to resolve (every enqueued row is bound and
+    /// no manifest is in flight), e.g. between resolving regular rows and
+    /// installing peers: the packages present at such a point are the same on
+    /// every install, so rows resolved afterwards may settle on any of them.
     #[inline]
-    pub(crate) fn mark_exact_pin(&mut self, id: PackageID) {
-        let i = id as usize;
-        if self.exact_pinned.bit_length() <= i {
-            bun_core::handle_oom(self.exact_pinned.resize(i + 1, false));
-        }
-        self.exact_pinned.set(i);
+    pub(crate) fn mark_settled_packages(&mut self) {
+        self.settled_package_count = self.packages.len() as PackageID;
     }
 
+    /// Record that package `id` was just appended from a registry manifest to
+    /// resolve `dependency_id`, whose range (after overrides and catalogs) was
+    /// an exact version iff `exact`.
+    pub(crate) fn mark_appended_for(
+        &mut self,
+        id: PackageID,
+        dependency_id: DependencyID,
+        exact: bool,
+    ) {
+        let appended_for = AppendedFor {
+            direct: self.is_workspace_dependency(dependency_id),
+            exact,
+        };
+        let i = id as usize;
+        if self.appended_for.len() <= i {
+            self.appended_for.resize(i + 1, AppendedFor::default());
+        }
+        self.appended_for[i] = appended_for;
+    }
+
+    /// The package `resolution` is already stored as, if any.
+    ///
+    /// When `version` is an npm range, `resolution` is the range's best match
+    /// from the manifest, and the highest version already present that the
+    /// range accepts is preferred over it (lockfile versions unconditionally,
+    /// others when pinned exactly or of the best match's major), provided
+    /// that version is present on every install of this package.json
+    /// (`settled_package_count`, `AppendedFor::direct`). A version that is
+    /// present only because some transitive dependency's manifest happened to
+    /// be processed already is not a candidate, and resolves the range only
+    /// when it is the best match itself, so the answer does not depend on the
+    /// order the registry answered in.
     pub(crate) fn get_package_id(
         &self,
         name_hash: u64,
-        // If non-null, attempt to use an existing package
-        // that satisfies this version range.
         version: Option<&DependencyVersion>,
         resolution: &Resolution,
     ) -> Option<PackageID> {
-        let entry = self.package_index.get(&name_hash)?;
+        // Highest version first (`get_or_put_id`).
+        let ids: &[PackageID] = match self.package_index.get(&name_hash)? {
+            PackageIndexEntry::Id(id) => core::slice::from_ref(id),
+            PackageIndexEntry::Ids(ids) => ids.as_slice(),
+        };
         let resolutions: &[Resolution] = self.packages.items_resolution();
-        // Borrow the `npm` arm's `Semver::Group` (not `Copy` — owns a linked
-        // list head). `version` is held by-value for the whole fn body so the
-        // borrow is sound.
-        let npm_version = match version {
-            Some(v) if v.tag == dependency::Tag::Npm => Some(&v.npm().version),
-            _ => None,
-        };
-        // Order-independence guard for the `satisfies` fallback below: when the
-        // caller already knows the manifest's best-match version (the npm
-        // `resolution` it passes), only dedupe to an existing entry whose
-        // version is at least that. Without this, the result depends on which
-        // sibling's manifest happened to land first — `*` deduping to a
-        // previously-appended `1.0.2` instead of resolving to `2.0.2` is the
-        // long-standing "text lockfile is hoisted" flake. Lockfile-pinned deps
-        // are kept out of this codepath by `Diff::generate`'s
-        // satisfies-preserves-mapping rule (which keeps the resolution slot
-        // populated so the early return in `get_or_put_resolved_package` fires
-        // before we get here).
-        let resolved_npm_floor = if resolution.tag == ResolutionTag::Npm {
-            Some(resolution.npm().version)
-        } else {
-            None
-        };
+        debug_assert!(ids.iter().all(|&id| (id as usize) < resolutions.len()));
         let buf = self.buffers.string_bytes.as_slice();
 
-        let loaded_watermark = self.loaded_package_count;
-        let exact_pinned = &self.exact_pinned;
-        let try_satisfies_dedupe = |id: PackageID| -> bool {
-            let existing = &resolutions[id as usize];
-            if existing.tag != ResolutionTag::Npm {
-                return false;
-            }
-            let Some(npm_v) = npm_version else {
-                return false;
-            };
-            let existing_ver = existing.npm().version;
-            if !npm_v.satisfies(existing_ver, buf, buf) {
-                return false;
-            }
-            // Order-independence guard. We refuse to dedupe a wide range to a
-            // *lower* existing entry only when ALL of the following hold:
-            //   - the entry was appended in this resolve session
-            //     (lockfile-loaded entries are the user's existing pin),
-            //   - the entry was NOT appended for an exact-`=X.Y.Z` dependency
-            //     (an exact pin anywhere in the tree is a deliberate choice,
-            //     not a network-order artefact — `dragon test 2` /
-            //     "dependency from root satisfies range from dependency"),
-            //   - the manifest's best-match is a *different major* (within a
-            //     major, deduping to an older patch is the long-standing
-            //     behaviour and the worst case is still ^-compatible).
-            // What this leaves is exactly the cross-parent network-order
-            // flake: a wide range (`*`, `>=X`) collapsing onto a sibling's
-            // *range-resolved* lower major depending on whose manifest landed
-            // first ("text lockfile is hoisted").
-            if id >= loaded_watermark && !exact_pinned.is_set_allow_out_of_bound(id as usize, false)
-            {
-                if let Some(floor) = resolved_npm_floor {
-                    if existing_ver.order(floor, buf, buf) == Ordering::Less
-                        && existing_ver.major != floor.major
-                    {
-                        return false;
-                    }
+        if let Some(range) = version
+            .filter(|v| v.tag == dependency::Tag::Npm)
+            .map(|v| &v.npm().version)
+        {
+            let best_match =
+                (resolution.tag == ResolutionTag::Npm).then(|| resolution.npm().version);
+            let present_on_every_install = ids.iter().copied().find(|&id| {
+                let existing = &resolutions[id as usize];
+                if existing.tag != ResolutionTag::Npm {
+                    return false;
                 }
-            }
-            true
-        };
-
-        match entry {
-            PackageIndexEntry::Id(id) => {
-                debug_assert!((*id as usize) < resolutions.len());
-
-                if resolutions[*id as usize].eql(resolution, buf, buf) {
-                    return Some(*id);
+                let existing_version = existing.npm().version;
+                if !range.satisfies(existing_version, buf, buf) {
+                    return false;
                 }
-
-                if try_satisfies_dedupe(*id) {
-                    return Some(*id);
+                if id < self.loaded_package_count {
+                    return true;
                 }
-            }
-            PackageIndexEntry::Ids(ids) => {
-                for &id in ids.iter() {
-                    debug_assert!((id as usize) < resolutions.len());
-
-                    if resolutions[id as usize].eql(resolution, buf, buf) {
-                        return Some(id);
-                    }
-
-                    if try_satisfies_dedupe(id) {
-                        return Some(id);
-                    }
-                }
+                let appended_for = self
+                    .appended_for
+                    .get(id as usize)
+                    .copied()
+                    .unwrap_or_default();
+                (id < self.settled_package_count || appended_for.direct)
+                    && (appended_for.exact
+                        || best_match
+                            .is_none_or(|best_match| existing_version.major == best_match.major))
+            });
+            if present_on_every_install.is_some() {
+                return present_on_every_install;
             }
         }
 
-        None
+        ids.iter()
+            .copied()
+            .find(|&id| resolutions[id as usize].eql(resolution, buf, buf))
     }
 
     /// Appends `pkg` to `this.packages`, and adds to `this.package_index`.

--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -1513,6 +1513,23 @@ it.each<{
     z: { "z": "z@1.0.0", "c/z": "z@1.1.0" },
   },
   {
+    // a and b resolve to the same z, so either of them may be the one that appends it; a's pin has to count
+    // either way when p (installed as a's peer after every regular row) brings a range from another major.
+    shape: "a -> z@1.1.0 and b -> z@^1.0.0 share a z that absorbs peer p -> z@*",
+    manifests: {
+      a: { "1.0.0": { dependencies: { z: "1.1.0" }, peerDependencies: { p: "1.0.0" } } },
+      b: { "1.0.0": { dependencies: { z: "^1.0.0" } } },
+      p: { "1.0.0": { dependencies: { z: "*" } } },
+      z: zVersions,
+    },
+    files: { "package.json": { name: "foo", dependencies: { a: "1.0.0", b: "1.0.0" } } },
+    orders: {
+      "a's manifest last": [{ manifest: "a", until: "/z-1.1.0.tgz" }],
+      "b's manifest last": [{ manifest: "b", until: "/z-1.1.0.tgz" }],
+    },
+    z: { "z": "z@1.1.0" },
+  },
+  {
     shape: "root z@1.0.0 absorbs b -> z@^1.0.0",
     manifests: { b: { "1.0.0": { dependencies: { z: "^1.0.0" } } }, z: zVersions },
     files: { "package.json": { name: "foo", dependencies: { b: "1.0.0", z: "1.0.0" } } },
@@ -1544,6 +1561,25 @@ it.each<{
       "z's manifest last": [{ manifest: "z", until: "/b-1.0.0.tgz" }],
     },
     z: { "z": "z@1.0.5" },
+  },
+  {
+    // The root's z is in place for every later row, so a's pin on it must not change what c gets,
+    // whether a's row is resolved before c's or after.
+    shape: "a -> z@1.0.5 pinning the root's z@~1.0.0 does not make it absorb c -> z@*",
+    manifests: {
+      a: { "1.0.0": { dependencies: { z: "1.0.5" } } },
+      c: { "1.0.0": { dependencies: { z: "*" } } },
+      z: zVersions,
+    },
+    files: { "package.json": { name: "foo", dependencies: { a: "1.0.0", c: "1.0.0", z: "~1.0.0" } } },
+    orders: {
+      "a's manifest last": [{ manifest: "a", until: "/z-2.0.0.tgz" }],
+      "c's manifest last": [
+        { manifest: "a", until: "/z" },
+        { manifest: "c", until: "/a-1.0.0.tgz" },
+      ],
+    },
+    z: { "z": "z@1.0.5", "c/z": "z@2.0.0" },
   },
   {
     shape: "root z@^1.0.0 does not absorb c -> z@* from another major",

--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -9,6 +9,7 @@ import {
   normalizeBunSnapshot,
   readdirSorted,
   runBunInstall,
+  tempDir,
   toBeValidBin,
   VerdaccioRegistry,
 } from "harness";
@@ -1376,3 +1377,211 @@ it("an optional peer is rebound when another version of its package takes the sl
   await run(["install", "--lockfile-only"]);
   expect(await file(join(packageDir, "bun.lock")).text()).toBe(lockfile);
 });
+
+// A fresh install resolves transitive rows as their parents' manifests come back
+// from the registry, so whether some other version of a package exists yet when
+// a row is resolved depends on network timing. Each shape below is installed
+// under arrival orders forced by holding one manifest back until a request that
+// can only be made once the other parent's row is resolved (the tarball of the
+// version it resolved to) has come in; every order has to write the same
+// bun.lock. `z`, the package the rows disagree on, has 1.0.0, 1.0.5, 1.1.0 and 2.0.0.
+type OrderedManifests = Record<string, Record<string, Record<string, Record<string, string>>>>;
+type Hold = { manifest: string; until: string };
+const zVersions = { "1.0.0": {}, "1.0.5": {}, "1.1.0": {}, "2.0.0": {} };
+
+async function registryWithHolds(manifests: OrderedManifests) {
+  const tarballs = new Map<string, Uint8Array>();
+  for (const [name, versions] of Object.entries(manifests)) {
+    for (const [version, extra] of Object.entries(versions)) {
+      const archive = new Bun.Archive(
+        { "package/package.json": JSON.stringify({ name, version, ...extra }) },
+        { compress: "gzip" },
+      );
+      tarballs.set(`/${name}-${version}.tgz`, await archive.bytes());
+    }
+  }
+  let gates = new Map<string, PromiseWithResolvers<void>>();
+  let heldUntil = new Map<string, string>();
+  const server = Bun.serve({
+    port: 0,
+    async fetch(request) {
+      const { origin, pathname } = new URL(request.url);
+      gates.get(pathname)?.resolve();
+      const tarball = tarballs.get(pathname);
+      if (tarball) return new Response(tarball);
+      const name = pathname.slice(1);
+      const entry = manifests[name];
+      if (!entry) return new Response("not found", { status: 404 });
+      const until = heldUntil.get(name);
+      if (until) await gates.get(until)!.promise;
+      const versions: Record<string, unknown> = {};
+      for (const [version, extra] of Object.entries(entry)) {
+        versions[version] = { name, version, dist: { tarball: `${origin}/${name}-${version}.tgz` }, ...extra };
+      }
+      const latest = Object.keys(entry).sort(Bun.semver.order).at(-1);
+      return Response.json({ name, versions, "dist-tags": { latest } });
+    },
+  });
+  return {
+    server,
+    hold(holds: Hold[]) {
+      gates = new Map(holds.map(({ until }) => [until, Promise.withResolvers<void>()]));
+      heldUntil = new Map(holds.map(({ manifest, until }) => [manifest, until]));
+    },
+  };
+}
+
+async function freshInstallLock(server: Bun.Server, files: Record<string, object>) {
+  using dir = tempDir("lock-arrival-order", {
+    ...Object.fromEntries(Object.entries(files).map(([path, json]) => [path, JSON.stringify(json)])),
+    "bunfig.toml": `[install]\nregistry = "${server.url.href}"\nlinker = "hoisted"\nsaveTextLockfile = true\n`,
+  });
+  await using proc = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: String(dir),
+    env: { ...env, BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache") },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [out, err, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ out, err, code }).toMatchObject({ err: expect.stringContaining("Saved lockfile"), code: 0 });
+  return await file(join(String(dir), "bun.lock")).text();
+}
+
+// `{ "z": "z@1.0.0", "b/z": "z@1.1.0" }`: every instance of `name`, keyed by where it is placed.
+function instancesOf(lock: string, name: string): Record<string, string> {
+  const { packages } = Bun.JSONC.parse(lock) as { packages: Record<string, [string, ...unknown[]]> };
+  return Object.fromEntries(
+    Object.entries(packages)
+      .filter(([key]) => key === name || key.endsWith(`/${name}`))
+      .map(([key, [resolution]]) => [key, resolution]),
+  );
+}
+
+it.each<{
+  shape: string;
+  manifests: OrderedManifests;
+  files: Record<string, object>;
+  orders: Record<string, Hold[]>;
+  z: Record<string, string>;
+}>([
+  {
+    shape: "a -> z@1.0.0 next to b -> z@^1.0.0",
+    manifests: {
+      a: { "1.0.0": { dependencies: { z: "1.0.0" } } },
+      b: { "1.0.0": { dependencies: { z: "^1.0.0" } } },
+      z: zVersions,
+    },
+    files: { "package.json": { name: "foo", dependencies: { a: "1.0.0", b: "1.0.0" } } },
+    orders: {
+      "a's manifest last": [{ manifest: "a", until: "/z-1.1.0.tgz" }],
+      "b's manifest last": [{ manifest: "b", until: "/z-1.0.0.tgz" }],
+    },
+    z: { "z": "z@1.0.0", "b/z": "z@1.1.0" },
+  },
+  {
+    shape: "a -> z@~1.0.0 next to b -> z@^1.0.0",
+    manifests: {
+      a: { "1.0.0": { dependencies: { z: "~1.0.0" } } },
+      b: { "1.0.0": { dependencies: { z: "^1.0.0" } } },
+      z: zVersions,
+    },
+    files: { "package.json": { name: "foo", dependencies: { a: "1.0.0", b: "1.0.0" } } },
+    orders: {
+      "a's manifest last": [{ manifest: "a", until: "/z-1.1.0.tgz" }],
+      "b's manifest last": [{ manifest: "b", until: "/z-1.0.5.tgz" }],
+    },
+    z: { "z": "z@1.0.5", "b/z": "z@1.1.0" },
+  },
+  {
+    // b's range accepts the root's pin; c puts b's own best match in place, which must not change what b gets.
+    shape: "root z@1.0.0, b -> z@^1.0.0, c -> z@~1.1.0",
+    manifests: {
+      b: { "1.0.0": { dependencies: { z: "^1.0.0" } } },
+      c: { "1.0.0": { dependencies: { z: "~1.1.0" } } },
+      z: zVersions,
+    },
+    files: { "package.json": { name: "foo", dependencies: { b: "1.0.0", c: "1.0.0", z: "1.0.0" } } },
+    orders: {
+      "b's manifest last": [{ manifest: "b", until: "/z-1.1.0.tgz" }],
+      // b's row is resolved (against the root's z alone) before b's tarball is requested.
+      "c's manifest last": [
+        { manifest: "b", until: "/z" },
+        { manifest: "c", until: "/b-1.0.0.tgz" },
+      ],
+    },
+    z: { "z": "z@1.0.0", "c/z": "z@1.1.0" },
+  },
+  {
+    shape: "root z@1.0.0 absorbs b -> z@^1.0.0",
+    manifests: { b: { "1.0.0": { dependencies: { z: "^1.0.0" } } }, z: zVersions },
+    files: { "package.json": { name: "foo", dependencies: { b: "1.0.0", z: "1.0.0" } } },
+    orders: {
+      "b's manifest last": [{ manifest: "b", until: "/z-1.0.0.tgz" }],
+      "z's manifest last": [{ manifest: "z", until: "/b-1.0.0.tgz" }],
+    },
+    z: { "z": "z@1.0.0" },
+  },
+  {
+    shape: "workspace z@1.0.0 absorbs b -> z@^1.0.0",
+    manifests: { b: { "1.0.0": { dependencies: { z: "^1.0.0" } } }, z: zVersions },
+    files: {
+      "package.json": { name: "foo", workspaces: ["pkg"], dependencies: { b: "1.0.0" } },
+      "pkg/package.json": { name: "pkg", dependencies: { z: "1.0.0" } },
+    },
+    orders: {
+      "b's manifest last": [{ manifest: "b", until: "/z-1.0.0.tgz" }],
+      "z's manifest last": [{ manifest: "z", until: "/b-1.0.0.tgz" }],
+    },
+    z: { "z": "z@1.0.0" },
+  },
+  {
+    shape: "root z@~1.0.0 absorbs b -> z@^1.0.0",
+    manifests: { b: { "1.0.0": { dependencies: { z: "^1.0.0" } } }, z: zVersions },
+    files: { "package.json": { name: "foo", dependencies: { b: "1.0.0", z: "~1.0.0" } } },
+    orders: {
+      "b's manifest last": [{ manifest: "b", until: "/z-1.0.5.tgz" }],
+      "z's manifest last": [{ manifest: "z", until: "/b-1.0.0.tgz" }],
+    },
+    z: { "z": "z@1.0.5" },
+  },
+  {
+    shape: "root z@^1.0.0 does not absorb c -> z@* from another major",
+    manifests: { c: { "1.0.0": { dependencies: { z: "*" } } }, z: zVersions },
+    files: { "package.json": { name: "foo", dependencies: { c: "1.0.0", z: "^1.0.0" } } },
+    orders: {
+      "c's manifest last": [{ manifest: "c", until: "/z-1.1.0.tgz" }],
+      "z's manifest last": [{ manifest: "z", until: "/c-1.0.0.tgz" }],
+    },
+    z: { "z": "z@1.1.0", "c/z": "z@2.0.0" },
+  },
+  {
+    // p is installed as a's peer once every regular row is resolved; by then a's z is in place on every install.
+    shape: "a -> z@1.0.0 absorbs peer p -> z@^1.0.0",
+    manifests: {
+      a: { "1.0.0": { dependencies: { z: "1.0.0" }, peerDependencies: { p: "1.0.0" } } },
+      p: { "1.0.0": { dependencies: { z: "^1.0.0" } } },
+      z: zVersions,
+    },
+    files: { "package.json": { name: "foo", dependencies: { a: "1.0.0" } } },
+    orders: {
+      "z's manifest last": [{ manifest: "z", until: "/a-1.0.0.tgz" }],
+      "p's manifest last": [{ manifest: "p", until: "/z-1.0.0.tgz" }],
+    },
+    z: { "z": "z@1.0.0" },
+  },
+])(
+  "a fresh install writes the same bun.lock whichever manifest arrives last: $shape",
+  async ({ manifests, files, orders, z }) => {
+    const ordered = await registryWithHolds(manifests);
+    using server = ordered.server;
+    let expected: string | undefined;
+    for (const [order, holds] of Object.entries(orders)) {
+      ordered.hold(holds);
+      const lock = await freshInstallLock(server, files);
+      expected ??= lock;
+      expect({ order, lock }).toEqual({ order, lock: expected });
+    }
+    expect(instancesOf(expected!, "z")).toEqual(z);
+  },
+);


### PR DESCRIPTION
### Problem
- A fresh `bun install` (no `bun.lock`) of `{"a":"1.0.0","b":"1.0.0"}` where `a` depends on `z@1.0.0` and `b` on `z@^1.0.0` (registry has `z@1.0.0` and `z@1.1.0`) writes one of two lockfiles: `z@1.0.0` alone, or `z@1.0.0` plus `b/z@1.1.0`. Roughly a 1:2 split over 30 clean installs; same on 1.3.14 and with `--linker isolated`. Found by the resolver property fuzzer (fresh-install determinism), which hit it in about a third of generated graphs.
- Cause: `Lockfile::get_package_id` (`src/install/lockfile.rs`) resolves a range onto a lower version of the package that already exists in the lockfile when that version was appended for an exact pin, or is of the same major as the range's best match. Whether `a`'s `z@1.0.0` exists yet when `b`'s row is resolved depends on whose manifest the registry answered first. Holding `a`'s manifest back forces the two-copy lockfile every time, holding `b`'s forces the one-copy lockfile every time.
- The same thing happens with two transitive ranges of one major (`~1.0.0` next to `^1.0.0`), and in the other direction: a range that the root's pin satisfies was instead resolved onto its best match whenever some sibling had appended that version first.
- The Rust port's guard in this function (`exact_pinned`) already stopped the cross-major variant of this; the exact-pin and same-major exemptions it kept are the remaining order-dependent cases.
- The exact-pin record itself has the same problem: `exact_pinned` was set by whichever row happened to append the version. With `a -> z@1.1.0` next to `b -> z@^1.0.0` (both 1.1.0), a range from another major resolved later (for example `z@*` in the subtree of a peer, which is installed after the regular rows) was absorbed onto 1.1.0 or not depending on whether `a`'s or `b`'s manifest came first.

### Fix
- `get_package_id` settles a range onto an existing lower version only when that version is present on every install, whatever order manifests arrive in:
  - loaded from the lockfile (as before),
  - appended for a root or workspace row (`AppendedFor::direct`, recorded per appended package by `mark_appended_for`), or
  - appended before resolution last drained completely (`settled_package_count`, bumped by `mark_settled_packages` in `wait_for_resolution` once every regular row is resolved, before peers are installed).
- The pin record (`AppendedFor::pinned`) is no longer just the appending row's: an exact regular row that resolves to a version which is not reusable yet records the pin too (`mark_pinned_by_reuse`), and the record is frozen once the version becomes reusable, because from then on rows are reading it. So by the time anything reads it, it says whether any regular row pinned that version, which is a property of the inputs. Peer rows do not count, whether they reuse or append, since whether a peer binds on sight or in the peer pass, and which of several peers on one version gets to append it, depend on arrival order. The one already-deterministic outcome this moves: a version appended in the peer pass for a root or workspace exact `peerDependencies` row (which is reusable right away, being direct) still absorbs same-major ranges from later peer-pass subtrees, but no longer cross-major ones.
- The pinned / same-major policy for the versions that do qualify is otherwise the existing one, so outcomes that were already order independent (root pin absorbing a transitive range, root range absorbing a same-major transitive range, cross-major refusal, peer subtrees settling onto regular rows) are unchanged. Only the previously order-dependent cases change, and they now always get the result they already got whenever the range was processed first: each transitive range resolves to its own best match. `bun dedupe` still collapses such copies afterwards when the user wants that.
- Qualifying versions are also preferred over a version some other transitive row appended even when the latter is the range's own best match (the third case above); the best match is otherwise only reused when it is exactly the version the range would append anyway, so the answer no longer depends on what a sibling did first.
- Why this is order independent: direct rows are enqueued before any manifest is processed (workspaces sort first in the root's list), and each manifest's waiting rows are resolved FIFO, so for a given package name the direct rows always resolve before any transitive row; the lockfile's packages are fixed before resolution starts; and by the time `mark_settled_packages` runs nothing is in flight, so the set present at that point is itself a function of the inputs only.
- Verified:
  - `test/cli/install/bun-lock.test.ts`: ten graph shapes, each installed under arrival orders forced by holding one manifest until a request that can only follow the other parent's resolution (the tarball of what it resolved to). The four shapes above fail on main (two different lockfiles); the six preserved-behavior shapes pass on main and still pass, one of them pinning that an exact row landing on the root's range-resolved version does not change what later rows get (which is what freezing the record is for); all ten pass with the fix.
  - `bun-install-registry.test.ts` 242/242 (the peer-subtree snapshot `duplicate dependency in optionalDependencies maintains sort order` is what the settled watermark keeps unchanged), `bun-lock`, `bun-update-transitive`, `bun-dedupe`, `hoist`, `lockfile-only`, `isolated-install`, `bun-workspaces`, `catalogs`, `overrides`, `nested-overrides`, `test-dev-peer-dependency-priority`, `bun-update-lockfile-sync`, `bun-add`, `bun-update`, `minimum-release-age`, `bun-remove`, `bun-prune`, `bun-pm-why`, the autoinstall tests and the migration suites pass with the debug build. `bun-install.test.ts` and `migration/complex-workspace` only fail their bitbucket/gitlab/off-box tests, which need network here.
- Related: #34336 and #38770 extend which direct versions a range may settle on (cross-major); with this structure that is the `pinned` clause in `get_package_id`, so they compose, and whichever lands second rebases one hunk. #37713 changes when `*` peers bind early; under this change that early binding only sees qualifying versions, so the two are independent. #36476 (draft) replaces the resolver wholesale; this is the small fix for the property in the meantime.

### Background
- Resolution is arrival driven. The root's rows (and, through them, each workspace's rows) are enqueued first; every package that resolves pushes its own row list onto a queue that is drained afterwards; a row whose manifest is not in memory yet is put on that manifest's callback list and resolved, in list order, when the response lands. Regular rows are all resolved first; peers that were not bindable on sight are installed in a second pass.
- `get_package_id(name, range, best_match)` is the step that decides whether a row reuses a package already in the lockfile or appends `best_match` (the highest version in the manifest that the range accepts). Reusing a version the range merely satisfies is what keeps one copy of a package in the tree; this PR only changes which existing versions are eligible for that.
- `loaded_package_count` is the existing watermark separating packages loaded from `bun.lock` from ones appended in this run; `settled_package_count` is the same idea taken again once resolution has drained. `is_workspace_dependency` is the existing "is this row declared by the root or a workspace" predicate. `is_reusable` combines the two watermarks with the direct flag; "reusable" throughout means "a range that merely satisfies this version may resolve to it".

<details>
<summary>Probe: 10 shapes x forced arrival orders, main vs this branch</summary>

```
main (1.4.0 release and debug build of 4bf3f3645):
NONDETERMINISTIC (2 distinct lockfiles)   transitive exact pin vs transitive range (reported)
    a last: z=z@1.0.0, b/z=z@1.1.0
    b last: z=z@1.0.0
NONDETERMINISTIC (2 distinct lockfiles)   transitive same-major ranges
    a last: z=z@1.0.5, b/z=z@1.1.0
    b last: z=z@1.0.5
NONDETERMINISTIC (2 distinct lockfiles)   root pin wins over a sibling that appends the range's best match
    b last: z=z@1.0.0, b/z=z@1.1.0, c/z=z@1.1.0
    c last: z=z@1.0.0, c/z=z@1.1.0
deterministic   root exact pin still absorbs a transitive range            {"z":"z@1.0.0"}
deterministic   root same-major range still absorbs a transitive range     {"z":"z@1.0.5"}
deterministic   root range does not absorb a transitive range, other major {"z":"z@1.1.0","c/z":"z@2.0.0"}
deterministic   workspace exact pin absorbs a sibling workspace's star      {"z":"z@1.0.0"}
deterministic   workspace pin vs transitive range                          {"z":"z@1.0.0"}
deterministic   peer star between two transitive pins                      {"z":"z@1.0.0","b/z":"z@1.1.0"}
deterministic   peer range between two transitive pins                     {"z":"z@1.0.0","b/z":"z@1.0.5"}

this branch: all 10 deterministic; the 7 shapes that were deterministic on main
produce the same lockfile as on main, and the first 3 now always produce
    {"z":"z@1.0.0","b/z":"z@1.1.0"}
    {"z":"z@1.0.5","b/z":"z@1.1.0"}
    {"z":"z@1.0.0","c/z":"z@1.1.0"}
```
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-lock.test.ts

<!-- robobun:evidence:end -->

