### PR TITLE
test: make the error snapshots test pass with colors disabled

### DIFF
--- a/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
@@ -891,11 +891,18 @@ test("error snapshots", () => {
     throw undefined; // this one doesn't work in jest because it doesn't think the function threw
   }).toThrowErrorMatchingInlineSnapshot(`undefined`);
   expect(() => {
-    expect(() => {}).toThrowErrorMatchingInlineSnapshot(`undefined`);
+    try {
+      expect(() => {}).toThrowErrorMatchingInlineSnapshot(`undefined`);
+    } catch (e) {
+      // The matcher error is colored only when this process has colors enabled
+      // (CI runs tests with FORCE_COLOR=1, a piped `bun test` run does not).
+      (e as Error).message = Bun.stripANSI((e as Error).message);
+      throw e;
+    }
   }).toThrowErrorMatchingInlineSnapshot(`
-"\x1B[2mexpect(\x1B[0m\x1B[31mreceived\x1B[0m\x1B[2m).\x1B[0mtoThrowErrorMatchingInlineSnapshot\x1B[2m(\x1B[0m\x1B[2m)\x1B[0m
+"expect(received).toThrowErrorMatchingInlineSnapshot()
 
-\x1B[1mMatcher error\x1B[0m: Received function did not throw
+Matcher error: Received function did not throw
 "
 `);
 });

--- a/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
@@ -894,8 +894,6 @@ test("error snapshots", () => {
     try {
       expect(() => {}).toThrowErrorMatchingInlineSnapshot(`undefined`);
     } catch (e) {
-      // The matcher error is colored only when this process has colors enabled
-      // (CI runs tests with FORCE_COLOR=1, a piped `bun test` run does not).
       (e as Error).message = Bun.stripANSI((e as Error).message);
       throw e;
     }


### PR DESCRIPTION
### Problem
- `bun bd test test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts` fails on main when run the way CLAUDE.md tells contributors to run it (stdout and stderr piped, no `FORCE_COLOR` in the environment):
  ```
  (fail) error snapshots
  - "\x1B[2mexpect(\x1B[0m\x1B[31mreceived\x1B[0m\x1B[2m).\x1B[0mtoThrowErrorMatchingInlineSnapshot\x1B[2m(\x1B[0m\x1B[2m)\x1B[0m
  + "expect(received).toThrowErrorMatchingInlineSnapshot()
  - \x1B[1mMatcher error\x1B[0m: Received function did not throw
  + Matcher error: Received function did not throw
  ```
- Cause: the last assertion of `"error snapshots"` (snapshot.test.ts:893) inline-snapshots the nested matcher error in its ANSI-colored form, so it only holds when the test process itself has colors enabled.
- CI is green because `scripts/runner.node.mjs:1785` spawns every test file with `FORCE_COLOR=1`; a run with both stdio streams piped has colors off and gets the uncolored message.
- It is the only color dependent assertion in `test/js/bun/test/snapshot-tests/`, and it keeps getting in the way: #34978, #37461, #38339, #38799 and #38820 each had to note in their verification that this one case needs `FORCE_COLOR=1`, and #34978 carries a `Bun.enableANSIColors` branch around it in its diff.

### Fix
- Test only change. The nested matcher error is caught, `Bun.stripANSI` is applied to its `message`, and it is rethrown; the inline snapshot becomes the uncolored text. Same idiom as `test/js/bun/test/mock-fn.test.js` (`toHaveReturned` failure message stripped, then inline-snapshotted); rethrowing keeps the outer `toThrowErrorMatchingInlineSnapshot` in the picture, which is what this test is about.
- Correct because the assertion exists to check that `toThrowErrorMatchingInlineSnapshot` on a function that does not throw raises `Matcher error: Received function did not throw`. Whether that message carries escape codes is decided once per process from `FORCE_COLOR` / `NO_COLOR` / a TTY on either stdio stream (`src/bun_core/output.rs`), not by the matcher, so it does not belong in the expectation. `toThrowErrorMatchingInlineSnapshot` snapshots the thrown error's `message` property (`fn_to_err_string_or_undefined`, `src/runtime/test_runner/expect.rs`), so the stripped message is exactly what the outer snapshot compares, and it is byte for byte the same with colors on and off.
- Nothing is left unpinned by dropping the colored literal: the colored matcher header bytes are already inline-snapshotted by `test/js/bun/test/printing/diffexample.test.ts` (`"color"`), which spawns a child with an explicit `FORCE_COLOR=1` instead of depending on the test process's own environment; the bold on `Matcher error` is generic output markup, not behavior of this matcher.
- No runtime change is warranted: matcher output being colored whenever `bun test` has colors enabled is the intended behavior, and whether snapshots themselves should strip color is a separate open question (#28439; #28443 attempted it and was not merged). This assertion holds either way that is decided.
- Once this lands, the `Bun.enableANSIColors` branch in #34978 can be dropped when it rebases.
- Verified with the debug build, all on this file:
  - unfixed test, colors off: `61 pass, 1 fail` (`error snapshots`), exit 1
  - fixed test, colors off: `62 pass, 0 fail`
  - fixed test, `FORCE_COLOR=1` (what CI does): `62 pass, 0 fail`
  - fixed test, `NO_COLOR=1` (release binary): `62 pass, 0 fail`
  - `snapshots: 111 passed, 1 failed` in every passing run, the same counts as main under `FORCE_COLOR=1` (the one failing snapshot is the intentional one inside `toThrow()` in `"indented inline snapshots"`)

### Background
- `bun test` decides once at startup whether to emit ANSI colors: `FORCE_COLOR` wins, then `NO_COLOR`, then whether either stdout or stderr is a terminal. When colors are on, the matcher errors that `expect` throws (the `expect(received).matcher()` header, the `Matcher error` label) carry the escape codes inside `error.message`, as Jest's chalk based messages do.
- `toThrowErrorMatchingInlineSnapshot(fn)` calls `fn`, takes `.message` off whatever it threw (`undefined` for a non-Error), and compares that string against the inline snapshot. Nesting two of them, as this assertion does, snapshots the inner matcher's error text verbatim.
- `Bun.stripANSI` removes ANSI escape sequences from a string and leaves a string without any unchanged, which is why one expectation serves both color modes.
