### PR TITLE
install: send credentials embedded in a registry URL that comes from an env var

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,6 @@ version = "0.0.0"
 dependencies = [
  "bun_alloc",
  "bun_options_types",
- "bun_url",
 ]
 
 [[package]]

--- a/src/api/Cargo.toml
+++ b/src/api/Cargo.toml
@@ -12,4 +12,3 @@ workspace = true
 [dependencies]
 bun_alloc.workspace = true
 bun_options_types.workspace = true
-bun_url.workspace = true

--- a/src/api/lib.rs
+++ b/src/api/lib.rs
@@ -2,7 +2,7 @@
 #![warn(unused_must_use)]
 //! Re-exports of the install config types (`BunInstall`, `NpmRegistry`, …)
 //! whose canonical definitions live in `bun_options_types::schema::api`, plus
-//! the registry-URL parser shared by the bunfig and npmrc loaders.
+//! the `Parser` handle used by the bunfig and npmrc loaders.
 
 // ──────────────────────────────────────────────────────────────────────────
 // Re-exports — canonical definitions live in `bun_options_types::schema::api`.
@@ -19,8 +19,6 @@ pub use bun_options_types::schema::api::{
 /// `Parser` lives in a sibling module of `NpmRegistry`; the canonical path
 /// is `bun_api::npm_registry::Parser`.
 pub mod npm_registry {
-    use bun_url::URL;
-
     pub use super::NpmRegistry;
 
     // `Parser` stays generic over `L` (Log) / `S` (Source) so this leaf
@@ -38,24 +36,7 @@ pub mod npm_registry {
             &mut self,
             str: &[u8],
         ) -> Result<NpmRegistry, bun_alloc::AllocError> {
-            let url = URL::parse(str);
-            let mut registry = NpmRegistry::default();
-
-            // Token
-            if url.username.is_empty() && !url.password.is_empty() {
-                registry.token = Box::<[u8]>::from(url.password);
-                registry.url = url.href_without_auth();
-            } else if !url.username.is_empty() && !url.password.is_empty() {
-                registry.username = Box::<[u8]>::from(url.username);
-                registry.password = Box::<[u8]>::from(url.password);
-
-                registry.url = url.href_without_auth();
-            } else {
-                // Do not include a trailing slash. There might be parameters at the end.
-                registry.url = Box::<[u8]>::from(url.href);
-            }
-
-            Ok(registry)
+            Ok(NpmRegistry::from_url(str))
         }
     }
 }

--- a/src/ini/lib.rs
+++ b/src/ini/lib.rs
@@ -1303,16 +1303,12 @@ mod draft {
         configs
     }
 
-    fn has_credentials(registry: &NpmRegistry) -> bool {
-        !registry.token.is_empty() || !registry.username.is_empty() || !registry.password.is_empty()
-    }
-
     pub fn apply_registry_auth(install: &mut BunInstall, auth: &[RegistryAuth]) {
         if auth.is_empty() {
             return;
         }
         if let Some(registry) = install.default_registry.as_mut() {
-            if !has_credentials(registry) {
+            if !registry.has_credentials() {
                 for item in auth {
                     let matched = item.matches(if registry.url.is_empty() {
                         bun_install_types::NodeLinker::npm::Registry::DEFAULT_URL.as_bytes()
@@ -1327,7 +1323,7 @@ mod draft {
         }
         if let Some(scoped) = install.scoped.as_mut() {
             for registry in scoped.scopes.values_mut() {
-                if has_credentials(registry) {
+                if registry.has_credentials() {
                     continue;
                 }
                 for item in auth {

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -351,6 +351,21 @@ pub mod registry {
                 }
             }
 
+            // The config loaders only split `user:pass@` / `:token@` out of
+            // literal registry strings; an expanded `$ENV_VAR` gets the same
+            // split here. Explicitly configured credentials take precedence.
+            let from_url = api::NpmRegistry::from_url(&registry.url);
+            registry.url = from_url.url;
+            if registry.token.is_empty() {
+                registry.token = from_url.token;
+            }
+            if registry.username.is_empty() {
+                registry.username = from_url.username;
+            }
+            if registry.password.is_empty() {
+                registry.password = from_url.password;
+            }
+
             // `url` borrows the owned `registry_url` buffer for the duration
             // of parsing. The final href is moved into `Scope.url: OwnedURL`
             // (owned `Box<[u8]>`).
@@ -359,22 +374,6 @@ pub mod registry {
             let mut auth: &[u8] = b"";
             let mut user: &mut [u8] = &mut [];
             let mut needs_normalize = false;
-
-            // Userinfo is still in the URL here when it came from `$VAR` or the object form.
-            if !url.password.is_empty() {
-                if registry.token.is_empty()
-                    && registry.username.is_empty()
-                    && registry.password.is_empty()
-                {
-                    if url.username.is_empty() {
-                        registry.token = url.password.into();
-                    } else {
-                        registry.username = url.username.into();
-                        registry.password = url.password.into();
-                    }
-                }
-                needs_normalize = true;
-            }
 
             // Backing storage for `user`/`auth` when synthesized from
             // username:password.

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -304,9 +304,8 @@ pub mod registry {
         // https://github.com/npm/npm-registry-fetch/blob/main/lib/auth.js#L96
         // base64("${username}:${password}")
         pub auth: Box<[u8]>,
-        // The configured URL may carry credentials, which `from_api` moves
-        // into `token`/`auth` and strips from here: `user:pass@` / `:token@`
-        // userinfo, or these special suffixes in the pathname:
+        // Stored without the credentials `from_api` accepts in the configured
+        // URL: `user:pass@` / `:token@`, or these suffixes in the pathname:
         //  :_authToken
         //  :username
         //  :_password
@@ -362,12 +361,9 @@ pub mod registry {
             let mut user: &mut [u8] = &mut [];
             let mut needs_normalize = false;
 
-            // `https://user:pass@host/` or `https://:token@host/`. The config
-            // loaders only split these out of literal registry strings
-            // (`parse_registry_url_string_impl`); a `$VAR` reference or the
-            // object form's `url` still carries them here. Credentials
-            // configured next to the URL win, as with the path suffixes
-            // below, but the URL is stripped either way.
+            // Userinfo survives config parsing when the URL was a `$VAR`
+            // reference or the object form's `url`; explicit credentials win,
+            // as with the pathname suffixes below.
             if !url.password.is_empty() {
                 if registry.token.is_empty()
                     && registry.username.is_empty()

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -304,8 +304,7 @@ pub mod registry {
         // https://github.com/npm/npm-registry-fetch/blob/main/lib/auth.js#L96
         // base64("${username}:${password}")
         pub auth: Box<[u8]>,
-        // Stored without the credentials `from_api` accepts in the configured
-        // URL: `user:pass@` / `:token@`, or these suffixes in the pathname:
+        // URL may contain these special suffixes in the pathname:
         //  :_authToken
         //  :username
         //  :_password
@@ -361,9 +360,7 @@ pub mod registry {
             let mut user: &mut [u8] = &mut [];
             let mut needs_normalize = false;
 
-            // Userinfo survives config parsing when the URL was a `$VAR`
-            // reference or the object form's `url`; explicit credentials win,
-            // as with the pathname suffixes below.
+            // Userinfo is still in the URL here when it came from `$VAR` or the object form.
             if !url.password.is_empty() {
                 if registry.token.is_empty()
                     && registry.username.is_empty()

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -351,9 +351,7 @@ pub mod registry {
                 }
             }
 
-            // The config loaders only split `user:pass@` / `:token@` out of
-            // literal registry strings; an expanded `$ENV_VAR` gets the same
-            // split here. Explicitly configured credentials take precedence.
+            // The config loaders split literal strings; an expanded $ENV_VAR is split here.
             let from_url = api::NpmRegistry::from_url(&registry.url);
             registry.url = from_url.url;
             if registry.token.is_empty() {

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -354,13 +354,9 @@ pub mod registry {
             // The config loaders split literal strings; an expanded $ENV_VAR is split here.
             let from_url = api::NpmRegistry::from_url(&registry.url);
             registry.url = from_url.url;
-            if registry.token.is_empty() {
+            if !registry.has_credentials() {
                 registry.token = from_url.token;
-            }
-            if registry.username.is_empty() {
                 registry.username = from_url.username;
-            }
-            if registry.password.is_empty() {
                 registry.password = from_url.password;
             }
 

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -304,7 +304,9 @@ pub mod registry {
         // https://github.com/npm/npm-registry-fetch/blob/main/lib/auth.js#L96
         // base64("${username}:${password}")
         pub auth: Box<[u8]>,
-        // URL may contain these special suffixes in the pathname:
+        // The configured URL may carry credentials, which `from_api` moves
+        // into `token`/`auth` and strips from here: `user:pass@` / `:token@`
+        // userinfo, or these special suffixes in the pathname:
         //  :_authToken
         //  :username
         //  :_password
@@ -359,6 +361,27 @@ pub mod registry {
             let mut auth: &[u8] = b"";
             let mut user: &mut [u8] = &mut [];
             let mut needs_normalize = false;
+
+            // `https://user:pass@host/` or `https://:token@host/`. The config
+            // loaders only split these out of literal registry strings
+            // (`parse_registry_url_string_impl`); a `$VAR` reference or the
+            // object form's `url` still carries them here. Credentials
+            // configured next to the URL win, as with the path suffixes
+            // below, but the URL is stripped either way.
+            if !url.password.is_empty() {
+                if registry.token.is_empty()
+                    && registry.username.is_empty()
+                    && registry.password.is_empty()
+                {
+                    if url.username.is_empty() {
+                        registry.token = url.password.into();
+                    } else {
+                        registry.username = url.username.into();
+                        registry.password = url.password.into();
+                    }
+                }
+                needs_normalize = true;
+            }
 
             // Backing storage for `user`/`auth` when synthesized from
             // username:password.

--- a/src/options_types/schema.rs
+++ b/src/options_types/schema.rs
@@ -152,6 +152,31 @@ pub mod api {
         pub email: Box<[u8]>,
     }
 
+    impl NpmRegistry {
+        pub fn from_url(str: &[u8]) -> NpmRegistry {
+            let url = bun_url::URL::parse(str);
+            let mut registry = NpmRegistry::default();
+
+            if url.username.is_empty() && !url.password.is_empty() {
+                registry.token = Box::from(url.password);
+                registry.url = url.href_without_auth();
+            } else if !url.username.is_empty() && !url.password.is_empty() {
+                registry.username = Box::from(url.username);
+                registry.password = Box::from(url.password);
+                registry.url = url.href_without_auth();
+            } else {
+                // Do not include a trailing slash. There might be parameters at the end.
+                registry.url = Box::from(url.href);
+            }
+
+            registry
+        }
+
+        pub fn has_credentials(&self) -> bool {
+            !self.token.is_empty() || !self.username.is_empty() || !self.password.is_empty()
+        }
+    }
+
     /// Per-scope npm registry overrides, keyed by scope name.
     #[derive(Default)]
     pub struct NpmRegistryMap {

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -868,6 +868,7 @@ impl PublishCommand {
         let registry_url = registry.url.url();
 
         if registry.token.is_empty()
+            && registry.auth.is_empty()
             && (registry_url.password.is_empty() || registry_url.username.is_empty())
         {
             return Err(PublishError::NeedAuth);

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -854,6 +854,159 @@ describe.concurrent("bun-install", () => {
     expect(exitCode).toBe(0);
   });
 
+  // `registry = "https://user:pass@host/"` written literally is split into
+  // credentials while bunfig.toml is parsed. These cover the registry URLs that
+  // only exist later, when `Scope::from_api` runs: `$ENV_VAR` references and
+  // the object form's `url`.
+  describe("credentials embedded in a registry URL that is not a literal registry string", () => {
+    const tgz = join(import.meta.dir, "registry", "packages", "no-deps", "no-deps-1.0.0.tgz");
+    const integrity = "sha512-v4w12JRjUGvfHDUP8vFDwu0gUWu04j0cv9hLb1Abf9VdaXu4XcrddYFTMVBVvmldKViGWH7jrb6xPJRF0wq6gw==";
+    const basic = `Basic ${Buffer.from("alice:s3cret").toString("base64")}`;
+
+    async function installWith(opts: {
+      bunfig: (registryOrigin: string) => string;
+      env?: (registryOrigin: string) => Record<string, string>;
+      dependency?: string;
+    }) {
+      const requests: { path: string; authorization: string | null }[] = [];
+      await using registry = Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        fetch(req) {
+          const { pathname } = new URL(req.url);
+          requests.push({ path: pathname, authorization: req.headers.get("authorization") });
+          if (pathname.endsWith(".tgz")) {
+            return new Response(Bun.file(tgz));
+          }
+          const name = decodeURIComponent(pathname.slice(1));
+          if (name !== "no-deps" && name !== "@myorg/pkg") {
+            return new Response("not found", { status: 404 });
+          }
+          return Response.json({
+            name,
+            "dist-tags": { latest: "1.0.0" },
+            versions: {
+              "1.0.0": {
+                name,
+                version: "1.0.0",
+                dist: { integrity, tarball: `http://127.0.0.1:${registry.port}/${name}/-/pkg-1.0.0.tgz` },
+              },
+            },
+          });
+        },
+      });
+      const origin = `127.0.0.1:${registry.port}`;
+      const dependency = opts.dependency ?? "no-deps";
+
+      using dir = tempDir("registry-url-credentials", {
+        "package.json": JSON.stringify({ name: "app", version: "1.0.0", dependencies: { [dependency]: "1.0.0" } }),
+        "bunfig.toml": opts.bunfig(origin),
+      });
+
+      await using proc = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: String(dir),
+        env: { ...env, BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache"), ...opts.env?.(origin) },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { requests, stdout, stderr, exitCode };
+    }
+
+    const basicAuthForms: [name: string, opts: Parameters<typeof installWith>[0]][] = [
+      [
+        "install.registry = $ENV_VAR",
+        {
+          bunfig: () => `[install]\nregistry = "$MY_REG"\n`,
+          env: origin => ({ MY_REG: `http://alice:s3cret@${origin}/` }),
+        },
+      ],
+      [
+        "install.registry = { url = $ENV_VAR }",
+        {
+          bunfig: () => `[install]\nregistry = { url = "$MY_REG" }\n`,
+          env: origin => ({ MY_REG: `http://alice:s3cret@${origin}/` }),
+        },
+      ],
+      [
+        "install.registry = { url = literal }",
+        {
+          bunfig: origin => `[install]\nregistry = { url = "http://alice:s3cret@${origin}/" }\n`,
+        },
+      ],
+      [
+        "install.scopes entry = $ENV_VAR",
+        {
+          bunfig: () => `[install.scopes]\n"@myorg" = "$MY_REG"\n`,
+          env: origin => ({ MY_REG: `http://alice:s3cret@${origin}/` }),
+          dependency: "@myorg/pkg",
+        },
+      ],
+    ];
+
+    for (const [name, opts] of basicAuthForms) {
+      it(`sends user:pass@ from the URL as Basic auth (${name})`, async () => {
+        const { requests, stdout, stderr, exitCode } = await installWith(opts);
+        const manifestPath = opts.dependency === "@myorg/pkg" ? "/@myorg%2fpkg" : "/no-deps";
+        const tarballPath = `/${opts.dependency ?? "no-deps"}/-/pkg-1.0.0.tgz`;
+        expect({ requests, stderr }).toEqual({
+          requests: [
+            { path: manifestPath, authorization: basic },
+            { path: tarballPath, authorization: basic },
+          ],
+          stderr: expect.not.stringContaining("s3cret"),
+        });
+        expect(stdout).toContain("1 package installed");
+        expect(exitCode).toBe(0);
+      });
+    }
+
+    it("sends :token@ from the URL as a Bearer token", async () => {
+      const { requests, stdout, stderr, exitCode } = await installWith({
+        bunfig: () => `[install]\nregistry = "$MY_REG"\n`,
+        env: origin => ({ MY_REG: `http://:tok-from-env@${origin}/` }),
+      });
+      expect({ requests, stderr }).toEqual({
+        requests: [
+          { path: "/no-deps", authorization: "Bearer tok-from-env" },
+          { path: "/no-deps/-/pkg-1.0.0.tgz", authorization: "Bearer tok-from-env" },
+        ],
+        stderr: expect.not.stringContaining("tok-from-env"),
+      });
+      expect(stdout).toContain("1 package installed");
+      expect(exitCode).toBe(0);
+    });
+
+    it("does not print the credentials with the request URL", async () => {
+      const { requests, stderr, exitCode } = await installWith({
+        bunfig: () => `[install]\nregistry = "$MY_REG"\n`,
+        env: origin => ({ MY_REG: `http://alice:s3cret@${origin}/` }),
+        dependency: "not-on-this-registry",
+      });
+      expect({ requests, stderr }).toEqual({
+        requests: [{ path: "/not-on-this-registry", authorization: basic }],
+        stderr: expect.stringMatching(/error: GET http:\/\/127\.0\.0\.1:\d+\/+not-on-this-registry - 404/),
+      });
+      expect(stderr).not.toContain("s3cret");
+      expect(exitCode).toBe(1);
+    });
+
+    it("credentials configured next to the URL win over the ones inside it", async () => {
+      const { requests, stderr, exitCode } = await installWith({
+        bunfig: () => `[install]\nregistry = { url = "$MY_REG", token = "configured-token" }\n`,
+        env: origin => ({ MY_REG: `http://alice:s3cret@${origin}/` }),
+        dependency: "not-on-this-registry",
+      });
+      expect({ requests, stderr }).toEqual({
+        requests: [{ path: "/not-on-this-registry", authorization: "Bearer configured-token" }],
+        stderr: expect.stringMatching(/error: GET http:\/\/127\.0\.0\.1:\d+\/+not-on-this-registry - 404/),
+      });
+      expect(stderr).not.toContain("s3cret");
+      expect(exitCode).toBe(1);
+    });
+  });
+
   it("--silent suppresses verbose output even when RUNNER_DEBUG is set", async () => {
     using dir = tempDir("install-silent-verbose", {
       "package.json": JSON.stringify({ name: "app", dependencies: {} }),

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -995,19 +995,39 @@ describe.concurrent("bun-install", () => {
       expect(exitCode).toBe(1);
     });
 
-    it("credentials configured explicitly override the ones inside the URL", async () => {
-      const { requests, stderr, exitCode } = await installWith({
-        bunfig: () => `[install]\nregistry = { url = "$MY_REG", token = "configured-token" }\n`,
-        env: origin => ({ MY_REG: `http://alice:s3cret@${origin}/` }),
-        dependency: "not-on-this-registry",
+    // Either kind of configured credential has to win: `from_api` sends a token
+    // in preference to a username/password pair, so a token taken from the URL
+    // would otherwise displace an explicitly configured pair.
+    const explicitWins: [name: string, bunfig: string, urlUserinfo: string, expected: string][] = [
+      [
+        "configured token vs user:pass@ in the URL",
+        `[install]\nregistry = { url = "$MY_REG", token = "configured-token" }\n`,
+        "alice:s3cret",
+        "Bearer configured-token",
+      ],
+      [
+        "configured username/password vs :token@ in the URL",
+        `[install]\nregistry = { url = "$MY_REG", username = "configured-user", password = "configured-pass" }\n`,
+        ":s3cret",
+        `Basic ${Buffer.from("configured-user:configured-pass").toString("base64")}`,
+      ],
+    ];
+
+    for (const [name, bunfig, urlUserinfo, expected] of explicitWins) {
+      it(`credentials configured explicitly override the ones inside the URL (${name})`, async () => {
+        const { requests, stderr, exitCode } = await installWith({
+          bunfig: () => bunfig,
+          env: origin => ({ MY_REG: `http://${urlUserinfo}@${origin}/` }),
+          dependency: "not-on-this-registry",
+        });
+        expect({ requests, stderr }).toEqual({
+          requests: [{ path: "/not-on-this-registry", authorization: expected }],
+          stderr: expect.stringMatching(/error: GET http:\/\/127\.0\.0\.1:\d+\/+not-on-this-registry - 404/),
+        });
+        expect(stderr).not.toContain("s3cret");
+        expect(exitCode).toBe(1);
       });
-      expect({ requests, stderr }).toEqual({
-        requests: [{ path: "/not-on-this-registry", authorization: "Bearer configured-token" }],
-        stderr: expect.stringMatching(/error: GET http:\/\/127\.0\.0\.1:\d+\/+not-on-this-registry - 404/),
-      });
-      expect(stderr).not.toContain("s3cret");
-      expect(exitCode).toBe(1);
-    });
+    }
   });
 
   it("--silent suppresses verbose output even when RUNNER_DEBUG is set", async () => {

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -855,10 +855,10 @@ describe.concurrent("bun-install", () => {
   });
 
   // `registry = "https://user:pass@host/"` written literally is split into
-  // credentials while bunfig.toml is parsed. These cover the registry URLs that
-  // only exist later, when `Scope::from_api` runs: `$ENV_VAR` references and
-  // the object form's `url`.
-  describe("credentials embedded in a registry URL that is not a literal registry string", () => {
+  // credentials while bunfig.toml is parsed. A `registry = "$ENV_VAR"` value is
+  // only expanded later, in `Scope::from_api`, so the credentials inside the
+  // variable's URL have to be split out there.
+  describe("credentials embedded in a registry URL taken from an env var", () => {
     const tgz = join(import.meta.dir, "registry", "packages", "no-deps", "no-deps-1.0.0.tgz");
     const integrity = "sha512-v4w12JRjUGvfHDUP8vFDwu0gUWu04j0cv9hLb1Abf9VdaXu4XcrddYFTMVBVvmldKViGWH7jrb6xPJRF0wq6gw==";
     const basic = `Basic ${Buffer.from("alice:s3cret").toString("base64")}`;
@@ -866,6 +866,7 @@ describe.concurrent("bun-install", () => {
     async function installWith(opts: {
       bunfig: (registryOrigin: string) => string;
       env?: (registryOrigin: string) => Record<string, string>;
+      files?: (registryOrigin: string) => Record<string, string>;
       dependency?: string;
     }) {
       const requests: { path: string; authorization: string | null }[] = [];
@@ -901,6 +902,7 @@ describe.concurrent("bun-install", () => {
       using dir = tempDir("registry-url-credentials", {
         "package.json": JSON.stringify({ name: "app", version: "1.0.0", dependencies: { [dependency]: "1.0.0" } }),
         "bunfig.toml": opts.bunfig(origin),
+        ...opts.files?.(origin),
       });
 
       await using proc = spawn({
@@ -923,16 +925,17 @@ describe.concurrent("bun-install", () => {
         },
       ],
       [
+        "install.registry = $ENV_VAR, set in the project's .env",
+        {
+          bunfig: () => `[install]\nregistry = "$MY_REG"\n`,
+          files: origin => ({ ".env": `MY_REG=http://alice:s3cret@${origin}/\n` }),
+        },
+      ],
+      [
         "install.registry = { url = $ENV_VAR }",
         {
           bunfig: () => `[install]\nregistry = { url = "$MY_REG" }\n`,
           env: origin => ({ MY_REG: `http://alice:s3cret@${origin}/` }),
-        },
-      ],
-      [
-        "install.registry = { url = literal }",
-        {
-          bunfig: origin => `[install]\nregistry = { url = "http://alice:s3cret@${origin}/" }\n`,
         },
       ],
       [
@@ -992,7 +995,7 @@ describe.concurrent("bun-install", () => {
       expect(exitCode).toBe(1);
     });
 
-    it("credentials configured next to the URL win over the ones inside it", async () => {
+    it("credentials configured explicitly override the ones inside the URL", async () => {
       const { requests, stderr, exitCode } = await installWith({
         bunfig: () => `[install]\nregistry = { url = "$MY_REG", token = "configured-token" }\n`,
         env: origin => ({ MY_REG: `http://alice:s3cret@${origin}/` }),

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -1236,6 +1236,45 @@ test("dist.tarball in the published manifest does not include userinfo from the 
   expect(exitCode).toBe(0);
 });
 
+test("user:pass@ in a registry url taken from an env var is sent as Basic auth", async () => {
+  const requests: { method: string; pathname: string; authorization: string | null }[] = [];
+  using mock = Bun.serve({
+    port: 0,
+    fetch(req) {
+      requests.push({
+        method: req.method,
+        pathname: new URL(req.url).pathname,
+        authorization: req.headers.get("authorization"),
+      });
+      return new Response("OK", { status: 200 });
+    },
+  });
+
+  using packageDir = tempDir("publish-env-registry-userinfo", {
+    "package.json": JSON.stringify({ name: "env-userinfo-pkg", version: "1.0.0" }),
+    "bunfig.toml": `[install]\nregistry = "$PUBLISH_REGISTRY"\n`,
+  });
+
+  const { out, err, exitCode } = await publish(
+    { ...env, PUBLISH_REGISTRY: `http://pubuser:hunter2@localhost:${mock.port}/` },
+    String(packageDir),
+  );
+  expect({ requests, err }).toEqual({
+    requests: [
+      {
+        method: "PUT",
+        pathname: "/env-userinfo-pkg",
+        authorization: `Basic ${Buffer.from("pubuser:hunter2").toString("base64")}`,
+      },
+    ],
+    err: expect.not.stringContaining("error:"),
+  });
+  expect(out).toContain(`Registry: http://localhost:${mock.port}/\n`);
+  expect(out).toContain(" + env-userinfo-pkg@1.0.0");
+  expect(out).not.toContain("hunter2");
+  expect(exitCode).toBe(0);
+});
+
 describe("--tolerate-republish", async () => {
   test("republishing normally fails", async () => {
     const { packageDir, packageJson } = await registry.createTestDir();

--- a/test/cli/install/redacted-config-logs.test.ts
+++ b/test/cli/install/redacted-config-logs.test.ts
@@ -3,10 +3,12 @@ import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir, tmpdirSync } from "harness";
 import { join } from "path";
 
-test("registry url password is masked in request error output", async () => {
+test("registry url password is sent as Basic auth and left out of request error output", async () => {
+  const authorizations: (string | null)[] = [];
   await using server = Bun.serve({
     port: 0,
-    fetch() {
+    fetch(req) {
+      authorizations.push(req.headers.get("authorization"));
       return new Response(JSON.stringify({ error: "unauthorized" }), {
         status: 401,
         headers: { "content-type": "application/json" },
@@ -32,10 +34,34 @@ test("registry url password is masked in request error output", async () => {
 
   const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(err).toContain(`401 Unauthorized: http://user:**********@${server.hostname}:${server.port}/is-number`);
+  expect(authorizations).toEqual([`Basic ${Buffer.from("user:secretpass").toString("base64")}`]);
+  expect(err).toContain(`401 Unauthorized: http://${server.hostname}:${server.port}/is-number`);
   expect(err).not.toContain("secretpass");
   expect(out).not.toContain("secretpass");
   expect(exitCode).toBe(1);
+});
+
+test("url password is masked in the verbose request line", async () => {
+  await using server = Bun.serve({
+    port: 0,
+    fetch() {
+      return new Response("ok");
+    },
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `await fetch("http://user:secretpass@${server.hostname}:${server.port}/pkg")`],
+    env: { ...bunEnv, NO_COLOR: "1", BUN_CONFIG_VERBOSE_FETCH: "1" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(err).toContain(`GET http://user:**********@${server.hostname}:${server.port}/pkg`);
+  expect(err).not.toContain("secretpass");
+  expect(out).not.toContain("secretpass");
+  expect(exitCode).toBe(0);
 });
 
 test("registry port is not mistaken for a credential when the package is scoped", async () => {


### PR DESCRIPTION
Related: #17531 and #18670 are the `bun publish` "missing authentication" reports for Basic credentials; the publish hunk here is the one from #38776, which has the tests for those configurations and closes them. Found while probing registry credential handling, not from a user report.

### Problem
- `registry = "$MY_REG"` in bunfig.toml, with `MY_REG=http://alice:s3cret@127.0.0.1:PORT/`, sends no `Authorization` header and prints the secret on failure: `error: GET http://alice:s3cret@127.0.0.1:PORT/no-deps - 404` (bun 1.4.0 and `main`). Same for `registry = { url = "$MY_REG" }` and for `[install.scopes]` entries, and the `:token@` form is dropped the same way. `bun publish` against such a registry sends its PUT with no header.
- The same URL written literally works: the bunfig and `.npmrc` loaders split `user:pass@` / `:token@` out of literal registry strings (`parse_registry_url_string_impl`, `src/api/lib.rs`) into `NpmRegistry.username`/`password` or `token`.
- Cause: a `$VAR` value has no userinfo when the config is parsed, so that split is a no-op. The variable is expanded later, in `Scope::from_api` (`src/install/npm.rs`), which goes straight on to parse the expanded URL and only looks for the yarn-style `/:_authToken=` pathname suffixes. The userinfo stays inside `Scope.url`, which requests never read for credentials (`NetworkTask` only sends `Scope.token` / `Scope.auth`) and which error output prints.
- `.npmrc` is not affected: its `${VAR}` syntax is expanded while the file is parsed, before the split.

### Fix
- `Scope::from_api`, right after the `$VAR` expansion, runs the expanded URL through the same splitter the config loaders use, `NpmRegistry::from_url`, stores the URL it returns (userinfo removed, otherwise byte-identical to the input) and, if no credential was configured explicitly (`NpmRegistry::has_credentials`), takes the credentials the URL carried. The rest of `from_api` is unchanged and sees exactly the `NpmRegistry` a literal string would have produced, so `registry = "$VAR"` now behaves the same as pasting the variable's value. URLs without userinfo are unaffected (same href, same `url_hash`, same manifest cache names).
- Precedence: anything configured explicitly (`token`, or `username`/`password`, next to `url = "$VAR"`) wins and the URL's credentials are dropped; they are only used when nothing was configured. The gate is all-or-nothing on purpose: `from_api` sends a token in preference to a username/password pair, so filling the fields one by one (an earlier revision of this PR) let a `:token@` URL displace an explicitly configured pair, turning a working Basic configuration into a Bearer one. Both directions are pinned by tests. #38824 (merged meanwhile) applies the same rule to the object form's literal `url`, where explicit keys replace the URL's credentials as a set, so `{ url = "$VAR", ... }` and the literal object agree; and it is the same `has_credentials` gate #38796 applies when the registry env var layer decides whether to carry over a token; that layer hands `from_api` an already-split registry, at which point this hunk is a no-op for it, and until then it keeps behaving as today.
- `NpmRegistry::from_url` / `has_credentials` (`src/options_types/schema.rs`, with `src/api/lib.rs` and `src/ini/lib.rs` delegating to them) are taken byte-for-byte from #38796, and the `publish()` pre-flight change (`src/runtime/cli/publish_command.rs`, accept `Scope.auth`) byte-for-byte from #38776. They are here so this PR is correct on its own: `from_api` needs the shared splitter to exist, and stripping the userinfo out of `Scope.url` would otherwise make `bun publish` report "missing authentication" for an env var registry (its check accepted userinfo left in the URL). Being identical hunks, they rebase to nothing once either sibling lands, in whichever order; only the `from_api` hunk and the tests are specific to this PR.
- Why the expansion itself stays in `from_api` rather than moving up to config parsing: bunfig.toml is parsed before `PackageManager::init` loads the project's `.env` into the loader `from_api` expands against, and a variable defined in `.env` is one of the cases tested here. Expanding earlier would also start matching `.npmrc` `//host/` credential lines against expanded URLs, a separate behavior change; this PR only makes the expanded URL go through the split every other spelling already gets.
- #33869 rewrites the body of `from_api` below this point (the suffix parsing); this hunk operates on the `NpmRegistry` before that body starts, so it applies on either side of that rewrite. The branch also merges cleanly with #38183, which landed meanwhile and changed the end of the same function.
- Tests (each fails on `main`, passes with this change; checked against a debug build of `main` with `src/` stashed):
  - `test/cli/install/bun-install.test.ts`, new `describe` next to the existing tarball auth test: a mock registry serving a manifest and tarball records the `Authorization` it receives. `registry = "$VAR"` (variable from the process environment, and from the project's `.env`), `registry = { url = "$VAR" }` and an `[install.scopes]` entry send Basic on both the manifest and the tarball request; `:token@` sends Bearer; a 404 is reported with the credentials removed from the printed URL; a configured `token` beats `user:pass@` in the URL and a configured username/password beats `:token@` in the URL (the headers these two send are the ones `main` sends today, so they pin that nothing regresses; on `main` they fail on the leaked URL).
  - `test/cli/install/bun-publish.test.ts`: `registry = "$VAR"` publish sends one PUT with Basic auth and prints the registry without the userinfo.
  - `test/cli/install/redacted-config-logs.test.ts`: its `npm_config_registry` test asserted the masked form of the leaked URL (`http://user:**********@...`), which this change removes from the output, so it now asserts Basic is sent and the URL is printed clean; a verbose `fetch()` test keeps the masking helper covered. This hunk is identical to #38796's for the same reason.
  - Also run with the debug build: the rest of `bun-install.test.ts`, all of `bun-publish.test.ts`, `npmrc.test.ts`, `config-precedence.test.ts`, `redacted-config-logs.test.ts`, `bun-install-pathname-trailing-slash.test.ts`, the whoami and env var registry tests in `bun-install-registry.test.ts`; `cargo clippy` on the touched crates; the source lints.
- Other related PRs: #38824 (merged) splits the object form's literal `url` at config time, which a `$VAR` url cannot go through, so the object form with `url = "$VAR"` is covered here; #38812 fixes `href_without_auth` producing `http://host//` for a path-less registry, which every credential-splitting spelling inherits (the tests here accept either form); #38817 redacts the install error lines themselves.

### Background
- `Api::NpmRegistry` is the parsed config for one registry (`url` plus optional `username` / `password` / `token`), produced by the bunfig and `.npmrc` loaders. `Scope` is what the package manager uses per registry: the URL, `token` (sent as `Authorization: Bearer`, and preferred when both are set) and `auth` (base64 `user:password`, sent as `Authorization: Basic`). `Scope::from_api` converts one into the other and is called by `Options::load` for the default registry, each scoped registry and the registry env vars.
- `$VAR` registry values: bunfig registry URLs (like the `username` / `password` / `token` fields) may name an environment variable, e.g. `url = "$NPM_CONFIG_REGISTRY"` in the Artifactory guide; `from_api` resolves them against the package manager's env loader, which includes the project's `.env`.
- `NpmRegistry::from_url` is the userinfo rule used for literal strings: `http://:x@host/` is a bearer token, `http://u:p@host/` is a basic auth pair, a username without a password is left alone; when it splits something off it rebuilds the href without the userinfo (`URL::href_without_auth`), otherwise it returns the input unchanged. `has_credentials` is true when any of `token` / `username` / `password` is set; the `.npmrc` loader already used that predicate to decide whether `//host/` lines apply to a registry.

<details>
<summary>Earlier revisions of this PR (superseded)</summary>

- The first revision split the userinfo inline in `from_api` from the already-parsed `bun_url::URL` (a second copy of the token-vs-basic rule) and also claimed the object form's literal `url`. Self-review pointed out that this duplicated the splitter #38796 consolidates and the object-form fix in #38824, so it was reworked to call the shared splitter on the `NpmRegistry` before `from_api` parses anything, and the object-literal test case was dropped in favor of #38824's.
- The reworked revision briefly filled `token` / `username` / `password` from the URL one field at a time; review caught that a `:token@` URL then displaced an explicitly configured username/password pair (Bearer sent where Basic used to be), which the all-or-nothing gate and the second precedence test now cover.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install.test.ts test/cli/install/bun-publish.test.ts

<!-- robobun:evidence:end -->