### PR TITLE
pack: publish workspace: directory dependencies as the workspace's version

### DIFF
--- a/docs/pm/workspaces.mdx
+++ b/docs/pm/workspaces.mdx
@@ -90,6 +90,13 @@ A specific version takes precedence over the package's `package.json` version:
 "workspace:1.0.2" -> "1.0.2" // Even if current version is 1.0.1
 ```
 
+You can also reference a workspace package by the path of its directory. The path is relative to the `package.json` that declares the dependency. Bun publishes the version of the package in that directory. When the dependency name differs from the package name, Bun publishes an `npm:` alias:
+
+```
+"pkg-b": "workspace:../pkg-b" -> "pkg-b": "1.0.1"
+"b": "workspace:../pkg-b"     -> "b": "npm:pkg-b@1.0.1"
+```
+
 Workspaces have a few major benefits.
 
 - **Split code into logical parts.** If one package relies on another, add it as a dependency in `package.json`. If package `b` depends on `a`, `bun install` installs your local `packages/a` directory into `node_modules` instead of downloading it from the npm registry.

--- a/src/install/PackageManager/workspace_manifests.rs
+++ b/src/install/PackageManager/workspace_manifests.rs
@@ -94,9 +94,7 @@ impl ScratchManifests {
 /// and releases bump versions between that install and the publish.
 pub struct WorkspaceManifests {
     lockfile: Lockfile,
-    /// The root package's dependencies. The root parse turns each entry of its `workspaces` into a
-    /// `Behavior::WORKSPACE` dependency named after the workspace whose `workspace` value is its
-    /// directory relative to the root.
+    /// Has a `Behavior::WORKSPACE` entry per workspace: its name and root-relative directory.
     root_dependencies: DependencySlice,
     root_package_json_path: Box<[u8]>,
 }
@@ -119,22 +117,15 @@ impl WorkspaceManifests {
         }
     }
 
-    /// Whether one of the workspaces (the root package is not one) is named `name`. This is what
-    /// decides, in `Package::parse_dependency`, whether the text after `workspace:` in a dependency
-    /// of that name is a version range or a directory.
+    /// Whether `name` is one of the workspaces (the root package is not one).
     pub fn has_workspace(&self, name: &[u8]) -> bool {
         let name_hash: PackageNameHash = bun_semver::string::Builder::string_hash(name);
         self.lockfile.workspace_paths.contains(&name_hash)
     }
 
-    /// The name of the workspace whose directory is `path` taken relative to `package_dir`, the
-    /// directory of the package.json declaring `workspace:<path>`. `Package::parse_dependency`
-    /// links such a dependency by computing the same root-relative directory and matching it
-    /// against the workspaces, so this resolves exactly what `bun install` linked. `None` when no
-    /// workspace is in that directory.
+    /// The workspace `workspace:<path>` in `package_dir` links, per `Package::parse_dependency`.
     pub fn workspace_name_at_path(&self, package_dir: &[u8], path: &[u8]) -> Option<&[u8]> {
-        // `workspace:` with nothing after it is an empty range, not the declaring package's own
-        // directory.
+        // Joined as a path, `workspace:` alone would name `package_dir` itself.
         if path.is_empty() {
             return None;
         }

--- a/src/install/PackageManager/workspace_manifests.rs
+++ b/src/install/PackageManager/workspace_manifests.rs
@@ -3,9 +3,11 @@ use core::fmt;
 use bstr::BStr;
 use bun_collections::HashMap;
 use bun_core::{Global, Output};
+use bun_paths::{platform, resolve_path};
+use bun_resolver::fs::FileSystem;
 
 use crate::dependency::{Behavior, Tag as DependencyTag};
-use crate::lockfile::{Lockfile, Package};
+use crate::lockfile::{DependencySlice, Lockfile, Package};
 use crate::{Features, PackageNameHash};
 
 use super::PackageManager;
@@ -92,6 +94,10 @@ impl ScratchManifests {
 /// and releases bump versions between that install and the publish.
 pub struct WorkspaceManifests {
     lockfile: Lockfile,
+    /// The root package's dependencies. The root parse turns each entry of its `workspaces` into a
+    /// `Behavior::WORKSPACE` dependency named after the workspace whose `workspace` value is its
+    /// directory relative to the root.
+    root_dependencies: DependencySlice,
     root_package_json_path: Box<[u8]>,
 }
 
@@ -108,8 +114,58 @@ impl WorkspaceManifests {
         }
         WorkspaceManifests {
             lockfile: scratch.lockfile,
+            root_dependencies: scratch.root.dependencies,
             root_package_json_path: root_package_json_path(),
         }
+    }
+
+    /// Whether one of the workspaces (the root package is not one) is named `name`. This is what
+    /// decides, in `Package::parse_dependency`, whether the text after `workspace:` in a dependency
+    /// of that name is a version range or a directory.
+    pub fn has_workspace(&self, name: &[u8]) -> bool {
+        let name_hash: PackageNameHash = bun_semver::string::Builder::string_hash(name);
+        self.lockfile.workspace_paths.contains(&name_hash)
+    }
+
+    /// The name of the workspace whose directory is `path` taken relative to `package_dir`, the
+    /// directory of the package.json declaring `workspace:<path>`. `Package::parse_dependency`
+    /// links such a dependency by computing the same root-relative directory and matching it
+    /// against the workspaces, so this resolves exactly what `bun install` linked. `None` when no
+    /// workspace is in that directory.
+    pub fn workspace_name_at_path(&self, package_dir: &[u8], path: &[u8]) -> Option<&[u8]> {
+        // `workspace:` with nothing after it is an empty range, not the declaring package's own
+        // directory.
+        if path.is_empty() {
+            return None;
+        }
+        let top_level_dir = FileSystem::get().top_level_dir();
+        let mut directory_buf = bun_paths::path_buffer_pool::get();
+        let directory = resolve_path::join_abs_string_buf_checked::<platform::Auto>(
+            top_level_dir,
+            &mut directory_buf[..],
+            &[package_dir, path],
+        )?;
+        let relative_directory: &[u8] = resolve_path::relative(top_level_dir, directory);
+        // The workspaces' directories are stored with `/` separators on every platform.
+        #[cfg(windows)]
+        let mut posix_buf = bun_paths::path_buffer_pool::get();
+        #[cfg(windows)]
+        let relative_directory: &[u8] = {
+            let len = relative_directory.len();
+            posix_buf[..len].copy_from_slice(relative_directory);
+            bun_paths::dangerously_convert_path_to_posix_in_place::<u8>(&mut posix_buf[..len]);
+            &posix_buf[..len]
+        };
+
+        let string_buf = self.lockfile.buffers.string_bytes.as_slice();
+        self.root_dependencies
+            .get(self.lockfile.buffers.dependencies.as_slice())
+            .iter()
+            .find(|dependency| {
+                dependency.behavior.is_workspace()
+                    && dependency.version.workspace().slice(string_buf) == relative_directory
+            })
+            .map(|dependency| dependency.name.slice(string_buf))
     }
 
     /// The package.json whose `workspaces` and catalogs these are: the workspace root's when the

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -3198,10 +3198,7 @@ fn add_archive_entry(
 enum Substitution<'a> {
     /// `workspace:^`, `workspace:~`, `workspace:*`: the workspace's current version behind that prefix.
     WorkspaceVersion { prefix: &'static str },
-    /// Anything else after `workspace:`. `bun install` reads it as a version range when the
-    /// dependency is itself one of the workspaces (`"pkg1": "workspace:1.x"`) and otherwise as the
-    /// directory of the workspace to link (`"c7": "workspace:../core"`), so which one it is takes
-    /// the manifests; see `publish_spec_for_workspace_range_or_directory`.
+    /// `workspace:1.x` on a dependency that is a workspace, or a directory, `workspace:../core`.
     WorkspaceRangeOrDirectory(&'a [u8]),
     /// `catalog:` / `catalog:<name>`: that catalog's entry for the dependency.
     Catalog { catalog_name: &'a [u8] },
@@ -3262,13 +3259,7 @@ fn needs_workspace_manifests(package_json: Expr) -> bool {
     needed
 }
 
-/// What the tarball gets for `Substitution::WorkspaceRangeOrDirectory`, or why there is nothing to
-/// publish for it. The directory reading is tried first because `"pkg1": "workspace:../pkg1"`
-/// satisfies both readings and only the directory has a version to publish: that workspace's own,
-/// as an `npm:` alias when the dependency is declared under another name (the registry's way of
-/// installing a package under a different name, and what pnpm publishes for this spec). A range is
-/// copied as written; so is `workspace:<name>@<range>`, which installs the workspace `<name>` under
-/// the dependency's name (the installer, too, only reads it that way when `<name>` is a workspace).
+/// Directory first: `"pkg1": "workspace:../pkg1"` reads both ways; only a directory has a version.
 fn publish_spec_for_workspace_range_or_directory(
     manifests: &WorkspaceManifests,
     package_dir: &[u8],
@@ -3276,6 +3267,7 @@ fn publish_spec_for_workspace_range_or_directory(
     spec: &[u8],
 ) -> Result<Vec<u8>, String> {
     let Some(workspace_name) = manifests.workspace_name_at_path(package_dir, spec) else {
+        // `workspace:<name>@<range>` installs workspace `<name>` under `dependency_name`.
         let is_alias = strings::last_index_of_char(spec, b'@')
             .is_some_and(|at| at > 0 && manifests.has_workspace(&spec[..at]));
         if manifests.has_workspace(dependency_name) || is_alias {
@@ -3298,13 +3290,13 @@ fn publish_spec_for_workspace_range_or_directory(
     Ok(if workspace_name == dependency_name {
         format!("{version}").into_bytes()
     } else {
+        // What pnpm publishes too: the alias installs the workspace's package under this name.
         format!("npm:{}@{version}", bstr::BStr::new(workspace_name)).into_bytes()
     })
 }
 
 /// Edits `json.root` in place (`bun publish` sends that tree to the registry) and returns it printed.
-/// `workspace_manifests` is `Some` whenever `needs_workspace_manifests(json.root)` is. `package_dir`
-/// is the directory of `json`, which `workspace:<directory>` specs are relative to.
+/// `workspace_manifests` is `Some` whenever `needs_workspace_manifests(json.root)` is.
 fn edit_root_package_json(
     workspace_manifests: Option<&WorkspaceManifests>,
     package_dir: &[u8],

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -2131,7 +2131,8 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
         // Loading added the other workspaces' package.json files to the cache `json` points into.
         json = read_package_json(manager_ptr, abs_package_json_path);
     }
-    let edited_package_json = edit_root_package_json(workspace_manifests.as_ref(), json)?;
+    let edited_package_json =
+        edit_root_package_json(workspace_manifests.as_ref(), abs_workspace_path, json)?;
 
     let root_dir: Dir = 'root_dir: {
         let mut path_buf = PathBuffer::uninit();
@@ -3197,8 +3198,11 @@ fn add_archive_entry(
 enum Substitution<'a> {
     /// `workspace:^`, `workspace:~`, `workspace:*`: the workspace's current version behind that prefix.
     WorkspaceVersion { prefix: &'static str },
-    /// `workspace:1.2.3`, `workspace:1.x`, ...: the range as written.
-    WorkspaceRange(&'a [u8]),
+    /// Anything else after `workspace:`. `bun install` reads it as a version range when the
+    /// dependency is itself one of the workspaces (`"pkg1": "workspace:1.x"`) and otherwise as the
+    /// directory of the workspace to link (`"c7": "workspace:../core"`), so which one it is takes
+    /// the manifests; see `publish_spec_for_workspace_range_or_directory`.
+    WorkspaceRangeOrDirectory(&'a [u8]),
     /// `catalog:` / `catalog:<name>`: that catalog's entry for the dependency.
     Catalog { catalog_name: &'a [u8] },
 }
@@ -3210,17 +3214,13 @@ impl<'a> Substitution<'a> {
                 b"^" => Substitution::WorkspaceVersion { prefix: "^" },
                 b"~" => Substitution::WorkspaceVersion { prefix: "~" },
                 b"*" => Substitution::WorkspaceVersion { prefix: "" },
-                _ => Substitution::WorkspaceRange(range),
+                _ => Substitution::WorkspaceRangeOrDirectory(range),
             });
         }
         let catalog_name = strings::without_prefix_if_possible_comptime(spec, b"catalog:")?;
         Some(Substitution::Catalog {
             catalog_name: strings::trim(catalog_name, &strings::WHITESPACE_CHARS),
         })
-    }
-
-    fn needs_workspace_manifests(&self) -> bool {
-        !matches!(self, Substitution::WorkspaceRange(_))
     }
 }
 
@@ -3257,15 +3257,57 @@ fn needs_workspace_manifests(package_json: Expr) -> bool {
             .as_ref()
             .and_then(Expr::as_utf8_string_literal)
             .and_then(Substitution::for_spec)
-            .is_some_and(|substitution| substitution.needs_workspace_manifests());
+            .is_some();
     });
     needed
 }
 
+/// What the tarball gets for `Substitution::WorkspaceRangeOrDirectory`, or why there is nothing to
+/// publish for it. The directory reading is tried first because `"pkg1": "workspace:../pkg1"`
+/// satisfies both readings and only the directory has a version to publish: that workspace's own,
+/// as an `npm:` alias when the dependency is declared under another name (the registry's way of
+/// installing a package under a different name, and what pnpm publishes for this spec). A range is
+/// copied as written; so is `workspace:<name>@<range>`, which installs the workspace `<name>` under
+/// the dependency's name (the installer, too, only reads it that way when `<name>` is a workspace).
+fn publish_spec_for_workspace_range_or_directory(
+    manifests: &WorkspaceManifests,
+    package_dir: &[u8],
+    dependency_name: &[u8],
+    spec: &[u8],
+) -> Result<Vec<u8>, String> {
+    let Some(workspace_name) = manifests.workspace_name_at_path(package_dir, spec) else {
+        let is_alias = strings::last_index_of_char(spec, b'@')
+            .is_some_and(|at| at > 0 && manifests.has_workspace(&spec[..at]));
+        if manifests.has_workspace(dependency_name) || is_alias {
+            return Ok(spec.to_vec());
+        }
+        return Err(format!(
+            "\"{}\" has no workspace named \"{}\" and no workspace in the directory \"{}\"",
+            bstr::BStr::new(manifests.root_package_json_path()),
+            bstr::BStr::new(dependency_name),
+            bstr::BStr::new(spec),
+        ));
+    };
+    let Some(version) = manifests.workspace_version(workspace_name) else {
+        return Err(format!(
+            "the package.json of workspace \"{}\" in the directory \"{}\" has no version",
+            bstr::BStr::new(workspace_name),
+            bstr::BStr::new(spec),
+        ));
+    };
+    Ok(if workspace_name == dependency_name {
+        format!("{version}").into_bytes()
+    } else {
+        format!("npm:{}@{version}", bstr::BStr::new(workspace_name)).into_bytes()
+    })
+}
+
 /// Edits `json.root` in place (`bun publish` sends that tree to the registry) and returns it printed.
-/// `workspace_manifests` is `Some` whenever `needs_workspace_manifests(json.root)` is.
+/// `workspace_manifests` is `Some` whenever `needs_workspace_manifests(json.root)` is. `package_dir`
+/// is the directory of `json`, which `workspace:<directory>` specs are relative to.
 fn edit_root_package_json(
     workspace_manifests: Option<&WorkspaceManifests>,
+    package_dir: &[u8],
     json: &mut WorkspacePackageJSONCache::MapEntry,
 ) -> Result<Box<[u8]>, AllocError> {
     let bump = pack_bump();
@@ -3303,7 +3345,6 @@ fn edit_root_package_json(
 
         // `E::EString::init` keeps a pointer to the bytes, so they go into the pack arena.
         let replacement: &[u8] = match substitution {
-            Substitution::WorkspaceRange(range) => bump.alloc_slice_copy(range),
             Substitution::WorkspaceVersion { prefix } => {
                 let Some(version) = manifests().workspace_version(dependency_name) else {
                     fail(
@@ -3316,6 +3357,17 @@ fn edit_root_package_json(
                     )
                 };
                 bump.alloc_slice_copy(format!("{prefix}{version}").as_bytes())
+            }
+            Substitution::WorkspaceRangeOrDirectory(spec) => {
+                match publish_spec_for_workspace_range_or_directory(
+                    manifests(),
+                    package_dir,
+                    dependency_name,
+                    spec,
+                ) {
+                    Ok(published) => bump.alloc_slice_copy(&published),
+                    Err(why) => fail("workspace", format_args!("{why}")),
+                }
             }
             Substitution::Catalog { catalog_name } => {
                 match manifests().catalog_version(catalog_name, dependency_name) {

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -912,6 +912,198 @@ describe("workspaces", () => {
       expect(JSON.parse(tarball.entries[0].contents).dependencies).toEqual({ "pkg1": "1.1.1" });
     });
   }
+
+  // pkgs/ui depends on its sibling workspaces by directory (`workspace:../core`)
+  async function createDirectoryWorkspace(uiDependencies: Record<string, Record<string, string>>) {
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({ name: "root", workspaces: ["pkgs/*", "pkgs/@scoped/*"] }),
+      ),
+      write(join(packageDir, "pkgs", "core", "package.json"), JSON.stringify({ name: "@acme/core", version: "1.2.3" })),
+      write(join(packageDir, "pkgs", "plain", "package.json"), JSON.stringify({ name: "plain", version: "0.5.0" })),
+      write(
+        join(packageDir, "pkgs", "@scoped", "thing", "package.json"),
+        JSON.stringify({ name: "thing", version: "0.0.7" }),
+      ),
+      write(
+        join(packageDir, "pkgs", "ui", "package.json"),
+        JSON.stringify({ name: "@acme/ui", version: "2.0.0", ...uiDependencies }),
+      ),
+    ]);
+  }
+
+  test("replaces workspace: directories with the version of the workspace in that directory", async () => {
+    await createDirectoryWorkspace({
+      dependencies: {
+        "core": "workspace:../core",
+        // declared under the workspace's own name, so no alias is needed
+        "@acme/core": "workspace:../core",
+        "core-dot": "workspace:./../core",
+        "core-slash": "workspace:../core/",
+        // the `@` in the directory does not make this `workspace:<name>@<range>`
+        "scoped-dir": "workspace:../@scoped/thing",
+        "self": "workspace:.",
+      },
+      devDependencies: {
+        "plain": "workspace:../plain",
+      },
+      peerDependencies: {
+        "plain-peer": "workspace:../plain",
+      },
+      optionalDependencies: {
+        "plain-optional": "workspace:../plain",
+      },
+    });
+    // every one of these is a spec `bun install` links
+    await runBunInstall(bunEnv, packageDir);
+
+    await pack(join(packageDir, "pkgs", "ui"), bunEnv);
+
+    const tarball = readTarball(join(packageDir, "pkgs", "ui", "acme-ui-2.0.0.tgz"));
+    expect(JSON.parse(tarball.entries[0].contents)).toEqual({
+      name: "@acme/ui",
+      version: "2.0.0",
+      dependencies: {
+        "core": "npm:@acme/core@1.2.3",
+        "@acme/core": "1.2.3",
+        "core-dot": "npm:@acme/core@1.2.3",
+        "core-slash": "npm:@acme/core@1.2.3",
+        "scoped-dir": "npm:thing@0.0.7",
+        "self": "npm:@acme/ui@2.0.0",
+      },
+      devDependencies: {
+        "plain": "0.5.0",
+      },
+      peerDependencies: {
+        "plain-peer": "npm:plain@0.5.0",
+      },
+      optionalDependencies: {
+        "plain-optional": "npm:plain@0.5.0",
+      },
+    });
+  });
+
+  test("replaces workspace: directories in the workspace root with the versions in the workspaces' package.json files", async () => {
+    await createDirectoryWorkspace({});
+    await write(
+      join(packageDir, "package.json"),
+      JSON.stringify({
+        name: "pack-workspace-root-directories",
+        version: "3.0.0",
+        workspaces: ["pkgs/*", "pkgs/@scoped/*"],
+        dependencies: {
+          "core": "workspace:pkgs/core",
+          "plain": "workspace:./pkgs/plain",
+        },
+      }),
+    );
+    await runBunInstall(bunEnv, packageDir);
+    // bumped after the install, so bun.lock still says 0.5.0
+    await write(join(packageDir, "pkgs", "plain", "package.json"), JSON.stringify({ name: "plain", version: "0.6.0" }));
+
+    await pack(packageDir, bunEnv);
+
+    const tarball = readTarball(join(packageDir, "pack-workspace-root-directories-3.0.0.tgz"));
+    expect(tarball.entries[0]).toMatchObject({ pathname: "package/package.json" });
+    expect(JSON.parse(tarball.entries[0].contents).dependencies).toEqual({
+      "core": "npm:@acme/core@1.2.3",
+      "plain": "0.6.0",
+    });
+  });
+
+  test("replaces a workspace: directory given as a bare directory name", async () => {
+    // `bun install` joins whatever follows `workspace:` onto the declaring package.json's directory,
+    // so from the root the directory name alone is enough. Only a dependency that is itself a
+    // workspace reads it as a version range instead.
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "pack-workspace-bare-directory",
+          version: "3.0.0",
+          workspaces: ["core", "plain"],
+          dependencies: { "bare": "workspace:core", "@acme/core": "workspace:core", "plain": "workspace:0.x" },
+        }),
+      ),
+      write(join(packageDir, "core", "package.json"), JSON.stringify({ name: "@acme/core", version: "1.2.3" })),
+      write(join(packageDir, "plain", "package.json"), JSON.stringify({ name: "plain", version: "0.5.0" })),
+    ]);
+    await runBunInstall(bunEnv, packageDir);
+
+    await pack(packageDir, bunEnv);
+
+    const tarball = readTarball(join(packageDir, "pack-workspace-bare-directory-3.0.0.tgz"));
+    expect(tarball.entries[0]).toMatchObject({ pathname: "package/package.json" });
+    expect(JSON.parse(tarball.entries[0].contents).dependencies).toEqual({
+      "bare": "npm:@acme/core@1.2.3",
+      "@acme/core": "1.2.3",
+      "plain": "0.x",
+    });
+  });
+
+  test("replaces workspace: directories without a lockfile", async () => {
+    await createDirectoryWorkspace({ dependencies: { "core": "workspace:../core", "plain": "workspace:../plain" } });
+
+    await pack(join(packageDir, "pkgs", "ui"), bunEnv);
+
+    const tarball = readTarball(join(packageDir, "pkgs", "ui", "acme-ui-2.0.0.tgz"));
+    expect(JSON.parse(tarball.entries[0].contents).dependencies).toEqual({
+      "core": "npm:@acme/core@1.2.3",
+      "plain": "0.5.0",
+    });
+  });
+
+  test("copies workspace: aliases as written", async () => {
+    // `workspace:<name>@<range>` installs workspace <name> under the dependency's name; it is
+    // neither a directory nor a range of the dependency, and must not be rejected as one.
+    await createDirectoryWorkspace({
+      dependencies: { "core-alias": "workspace:@acme/core@^1.0.0", "plain-alias": "workspace:plain@*" },
+    });
+
+    await pack(join(packageDir, "pkgs", "ui"), bunEnv);
+
+    const tarball = readTarball(join(packageDir, "pkgs", "ui", "acme-ui-2.0.0.tgz"));
+    expect(JSON.parse(tarball.entries[0].contents).dependencies).toEqual({
+      "core-alias": "@acme/core@^1.0.0",
+      "plain-alias": "plain@*",
+    });
+  });
+
+  const notAWorkspaceSpecs = [
+    // exists on disk, but the root's `workspaces` does not list it (written below)
+    { group: "devDependencies", name: "unlisted", spec: "workspace:../../unlisted" },
+    { group: "dependencies", name: "missing", spec: "workspace:../missing" },
+    // a range only means something for a dependency that is itself a workspace
+    { group: "peerDependencies", name: "not-a-workspace", spec: "workspace:1.2.3" },
+    // and `<name>@<range>` only when <name> is a workspace
+    { group: "optionalDependencies", name: "bogus-alias", spec: "workspace:nope@*" },
+  ];
+
+  for (const { group, name, spec } of notAWorkspaceSpecs) {
+    test(`fails when a workspace: spec is neither a workspace's directory nor a workspace's range: ${spec}`, async () => {
+      await createDirectoryWorkspace({ dependencies: { "plain": "workspace:../plain" }, [group]: { [name]: spec } });
+      await write(join(packageDir, "unlisted", "package.json"), JSON.stringify({ name: "unlisted", version: "1.0.0" }));
+
+      const { err } = await packExpectError(join(packageDir, "pkgs", "ui"), bunEnv);
+      expect(err).toContain(`error: Failed to resolve workspace version for "${name}" in \`${group}\` (`);
+      expect(err).toContain(
+        `package.json" has no workspace named "${name}" and no workspace in the directory "${spec.slice("workspace:".length)}").`,
+      );
+      expect(await exists(join(packageDir, "pkgs", "ui", "acme-ui-2.0.0.tgz"))).toBeFalse();
+    });
+  }
+
+  test("fails when the workspace in a workspace: directory has no version", async () => {
+    await createDirectoryWorkspace({ dependencies: { "no-version": "workspace:../unversioned" } });
+    await write(join(packageDir, "pkgs", "unversioned", "package.json"), JSON.stringify({ name: "unversioned" }));
+
+    const { err } = await packExpectError(join(packageDir, "pkgs", "ui"), bunEnv);
+    expect(err).toContain(
+      'error: Failed to resolve workspace version for "no-version" in `dependencies` (the package.json of workspace "unversioned" in the directory "../unversioned" has no version).',
+    );
+    expect(await exists(join(packageDir, "pkgs", "ui", "acme-ui-2.0.0.tgz"))).toBeFalse();
+  });
 });
 
 test("lifecycle scripts execution order", async () => {

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -849,6 +849,59 @@ test("publishes a workspace package next to a bun.lock that does not parse", asy
   });
 });
 
+test("a published package can depend on another workspace by its directory", async () => {
+  const { packageDir, packageJson } = await registry.createTestDir();
+  const bunfig = await registry.authBunfig("workspacepath");
+  const corePkgJson = { name: "publish-pkg-path-core", version: "1.2.3" };
+  await Promise.all([
+    rm(join(registry.packagesPath, "publish-pkg-path-core"), { recursive: true, force: true }),
+    rm(join(registry.packagesPath, "publish-pkg-path-ui"), { recursive: true, force: true }),
+    write(join(packageDir, "bunfig.toml"), bunfig),
+    write(packageJson, JSON.stringify({ name: "root", workspaces: ["packages/*"] })),
+    write(join(packageDir, "packages", "core", "package.json"), JSON.stringify(corePkgJson)),
+    write(
+      join(packageDir, "packages", "ui", "package.json"),
+      JSON.stringify({
+        name: "publish-pkg-path-ui",
+        version: "2.0.0",
+        dependencies: {
+          "core-alias": "workspace:../core",
+          "publish-pkg-path-core": "workspace:../core",
+        },
+      }),
+    ),
+  ]);
+
+  for (const pkg of ["core", "ui"]) {
+    const { out, err, exitCode } = await publish(env, join(packageDir, "packages", pkg));
+    expect(err).not.toContain("error:");
+    expect(out).toContain(`+ publish-pkg-path-${pkg}@`);
+    expect(exitCode).toBe(0);
+  }
+
+  // consume the published package from the registry
+  await Promise.all([
+    rm(join(packageDir, "packages"), { recursive: true, force: true }),
+    write(packageJson, JSON.stringify({ name: "root", dependencies: { "publish-pkg-path-ui": "2.0.0" } })),
+  ]);
+  await runBunInstall(env, packageDir);
+
+  expect(await file(join(packageDir, "node_modules", "publish-pkg-path-ui", "package.json")).json()).toEqual({
+    name: "publish-pkg-path-ui",
+    version: "2.0.0",
+    dependencies: {
+      "core-alias": "npm:publish-pkg-path-core@1.2.3",
+      "publish-pkg-path-core": "1.2.3",
+    },
+  });
+  expect(
+    await Promise.all([
+      file(join(packageDir, "node_modules", "core-alias", "package.json")).json(),
+      file(join(packageDir, "node_modules", "publish-pkg-path-core", "package.json")).json(),
+    ]),
+  ).toEqual([corePkgJson, corePkgJson]);
+});
+
 describe("--dry-run", async () => {
   test("does not publish", async () => {
     const { packageDir, packageJson } = await registry.createTestDir();


### PR DESCRIPTION
Stacked on #38813 (this PR's base branch): the change is the last two commits, and the PR retargets to `main` once that one lands.

### Problem
- `bun install` reads the text after `workspace:` (other than `*`, `^`, `~`) as a version range when the dependency is itself one of the workspaces, and otherwise as the directory of the workspace to link, relative to the package.json declaring it: `"c7": "workspace:../core"`, `"self": "workspace:."`, `"core": "workspace:packages/core"` from the root (`Package::parse_dependency`, `src/install/lockfile/Package.rs`).
- `bun pm pack` and `bun publish` copy every such spec as written (`Substitution::WorkspaceRange` in `src/runtime/cli/pack_command.rs`; the same verbatim copy before #38813), so the tarball and the manifest sent to the registry carry `"c7": "../core"`. Installing the published package fails: `error: Could not find package.json for "file:../core" dependency "c7"` (bun; npm and pnpm read it as a local directory too). Exit code 0, no warning.
- Same in 1.3.14, so not a regression.

### Fix
- Every `workspace:` spec other than `*`/`^`/`~` is now resolved against the workspace manifests (`Substitution::WorkspaceRangeOrDirectory`), applying the installer's rule rather than a syntactic guess: if a workspace is in the directory the spec names, that workspace is published; otherwise, if the dependency is itself a workspace the spec is a range and is copied as written (as before, and as is `workspace:<name>@<range>` when `<name>` is a workspace); otherwise the pack fails, because `bun install` would have failed on the same spec and there is nothing installable to publish.
- The directory is tried first because `"pkg1": "workspace:../pkg1"` (a form in `bun-install.test.ts`) fits both readings and only the directory reading has a version to publish.
- A directory is published as that workspace's current `version` when the dependency is declared under the workspace's own name (`"@acme/core": "workspace:../core"` -> `"1.2.3"`), otherwise as the `npm:<name>@<version>` alias (`"c7": "workspace:../core"` -> `"npm:@acme/core@1.2.3"`), which is the registry spec that installs the same package under the same name and what pnpm publishes for this input.
- `WorkspaceManifests` (`src/install/PackageManager/workspace_manifests.rs`) gains the two lookups this needs: `has_workspace` (the `workspace_paths` membership the installer uses) and `workspace_name_at_path`, which resolves the spec against the packing package's directory, makes it relative to the workspace root (`/` separators on Windows) and matches it against the workspace entries of the parsed root, the same computation `parse_dependency` makes when installing, so pack publishes what install linked. Versions come from the same parse as `workspace:*`, so a version bumped after the last install is what gets published, and no lockfile is needed.
- Because every `workspace:` spec now loads the manifests, a package with only `workspace:<range>` specs now also fails when the root manifests do not parse; such a package is in a workspace that `bun install` reads the same way.
- `workspace:<name>@<range>` is only classified, not rewritten; #38788 rewrites it to an `npm:` alias and is the remaining form.
- Verified with `test/cli/install/bun-pack.test.ts` (10 new cases in the `workspaces` block: sibling directories in all four dependency groups, own-name and aliased, `./../` and trailing-slash normalization, a directory containing `@`, `workspace:.`, directories from the root including a bare directory name and a range of a workspace next to it, a version bumped after the last install, no lockfile at all, aliases copied as written, and failures for a directory that exists but is not a workspace, a missing directory, a range on a non-workspace, a `<name>@<range>` whose name is not a workspace, and a workspace without a version) and `test/cli/install/bun-publish.test.ts` (publishes two workspaces to the test registry without a prior install and installs the dependent one from a fresh project). The 9 behavior-changing pack cases and the publish case fail on the base branch; with this change `bun-pack.test.ts` (96), `bun-publish.test.ts` (42), `catalogs.test.ts`, `bun-add-filter.test.ts` and `bun-add-catalog.test.ts` (the other `ScratchManifests` users) pass with the debug build, and `bun_install` / `bun_runtime` type-check for `x86_64-pc-windows-msvc`. The previous revision's CI run was green on every lane that ran (177 jobs, both Windows test lanes included).
- Docs: added the directory form to the publishing section of `docs/pm/workspaces.mdx`.

### Background
- Workspace protocol: inside a monorepo, `"dep": "workspace:*"` tells the package manager to link the workspace package named `dep` instead of downloading it. The registry knows nothing about the workspace, so pack/publish must rewrite these specs into registry ones. Bun's installer also accepts a directory after `workspace:`; in that form the dependency name can be anything, which is why the rewrite sometimes needs an alias.
- npm alias: `"c7": "npm:@acme/core@1.2.3"` installs the registry package `@acme/core` under `node_modules/c7`; it is the only registry spec that installs a package under a different name.
- `WorkspaceManifests` (#38813): the root package.json and the workspaces it lists, parsed by the code `bun install` uses into a throw-away lockfile. That parse records each workspace's name in `workspace_paths` and adds it to the root's dependencies as a `Behavior::WORKSPACE` entry whose value is the workspace's root-relative directory; those two are what the new lookups read, and the versions come from the same parse.

<details>
<summary>Repro</summary>

```sh
mkdir -p m/packages/core m/packages/ui && cd m
echo '{ "name": "mono", "private": true, "workspaces": ["packages/*"] }' > package.json
echo '{ "name": "@acme/core", "version": "1.2.3" }' > packages/core/package.json
echo '{ "name": "@acme/ui", "version": "2.0.0", "dependencies": { "c7": "workspace:../core", "@acme/core": "workspace:../core" } }' > packages/ui/package.json
bun install
cd packages/ui && bun pm pack && tar -xzOf acme-ui-2.0.0.tgz package/package.json
```

Before:

```json
"c7": "../core",
"@acme/core": "../core"
```

After (same as `pnpm pack`):

```json
"c7": "npm:@acme/core@1.2.3",
"@acme/core": "1.2.3"
```

Error paths with this change:

```
$ bun pm pack   # "x": "workspace:../nope"
error: Failed to resolve workspace version for "x" in `dependencies` ("/tmp/m/package.json" has no workspace named "x" and no workspace in the directory "../nope").
$ bun pm pack   # "nv": "workspace:../noversion", packages/noversion/package.json has no version
error: Failed to resolve workspace version for "nv" in `dependencies` (the package.json of workspace "noversion" in the directory "../noversion" has no version).
```

</details>

<details>
<summary>First revision (superseded)</summary>

The first revision classified specs syntactically (`is_workspace_path`: starts with `.` or contains a separator) and only resolved those. That missed directory forms the installer accepts, such as a bare directory name from the root (`"bare": "workspace:core"`), and duplicated part of the installer's grammar in pack; the current revision applies the installer's own rule through the manifests instead, and the heuristic is gone.

</details>