### PR TITLE
audit: list --production, --omit, --dry-run and --cwd in bun audit --help

### DIFF
--- a/completions/bun-cli.json
+++ b/completions/bun-cli.json
@@ -1530,6 +1530,38 @@
           "valueType": "val",
           "required": false,
           "multiple": false
+        },
+        {
+          "name": "production",
+          "shortName": "p",
+          "description": "Skip packages that are only needed by devDependencies (alias: --prod)",
+          "hasValue": false,
+          "required": false,
+          "multiple": false
+        },
+        {
+          "name": "omit",
+          "description": "Skip packages that are only needed by the given dependency types: dev, optional, or peer (repeatable)",
+          "hasValue": true,
+          "valueType": "val",
+          "required": false,
+          "multiple": false
+        },
+        {
+          "name": "cwd",
+          "description": "Set a specific cwd",
+          "hasValue": true,
+          "valueType": "val",
+          "required": false,
+          "multiple": false
+        },
+        {
+          "name": "help",
+          "shortName": "h",
+          "description": "Print this help menu",
+          "hasValue": false,
+          "required": false,
+          "multiple": false
         }
       ],
       "positionalArgs": [

--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -331,7 +331,7 @@ static AUDIT_PARAMS: &[ParamType] = concat_params![
             "--ignore <STR>...                      Ignore advisories by GHSA or numeric advisory ID (repeatable)"
         ),
         clap::param!(
-            "-L, --latest                           Let bun audit fix also apply fixes that your package.json ranges exclude, rewriting those ranges"
+            "-L, --latest                           Also apply fixes your declared ranges exclude, rewriting package.json"
         ),
     ]
 ];
@@ -354,7 +354,7 @@ const AUDIT_HELP_PARAMS: &[ParamType] = &[
         "--dry-run                              Show what bun audit fix would change without changing anything"
     ),
     clap::param!(
-        "-L, --latest                           Let bun audit fix also apply fixes that your package.json ranges exclude, rewriting those ranges"
+        "-L, --latest                           Also apply fixes your declared ranges exclude, rewriting package.json"
     ),
     clap::param!("--cwd <STR>                            Set a specific cwd"),
     clap::param!("-h, --help                             Print this help menu"),

--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -317,23 +317,48 @@ static OUTDATED_PARAMS: &[ParamType] = concat_params![
     ]
 ];
 
-const AUDIT_PARAMS: &[ParamType] = &[
-    clap::param!(
-        "<POS> ...                              Check installed packages for vulnerabilities"
-    ),
-    clap::param!("--json                                 Output in JSON format"),
+static AUDIT_PARAMS: &[ParamType] = concat_params![
+    SHARED_PARAMS,
+    &[
+        clap::param!(
+            "<POS> ...                              Check installed packages for vulnerabilities"
+        ),
+        clap::param!("--json                                 Output in JSON format"),
+        clap::param!(
+            "--audit-level <STR>                    Only print advisories with severity greater than or equal to \\<level\\> (low, moderate, high, critical)"
+        ),
+        clap::param!(
+            "--ignore <STR>...                      Ignore advisories by GHSA or numeric advisory ID (repeatable)"
+        ),
+        clap::param!(
+            "-L, --latest                           Let bun audit fix also apply fixes that your package.json ranges exclude, rewriting those ranges"
+        ),
+    ]
+];
+
+const AUDIT_HELP_PARAMS: &[ParamType] = &[
     clap::param!(
         "--audit-level <STR>                    Only print advisories with severity greater than or equal to \\<level\\> (low, moderate, high, critical)"
     ),
     clap::param!(
-        "--ignore <STR>...                      Ignore advisories by GHSA or numeric advisory ID (repeatable)"
+        "-p, --production                       Skip packages that are only needed by devDependencies (alias: --prod)"
     ),
     clap::param!(
-        "-L, --latest                           Also apply fixes your declared ranges exclude, rewriting package.json"
+        "--omit <dev|optional|peer>...          Skip packages that are only needed by the given dependency types: dev, optional, or peer (repeatable)"
     ),
+    clap::param!(
+        "--ignore <STR>...                      Ignore advisories by GHSA or numeric advisory ID (repeatable)"
+    ),
+    clap::param!("--json                                 Output in JSON format"),
+    clap::param!(
+        "--dry-run                              Show what bun audit fix would change without changing anything"
+    ),
+    clap::param!(
+        "-L, --latest                           Let bun audit fix also apply fixes that your package.json ranges exclude, rewriting those ranges"
+    ),
+    clap::param!("--cwd <STR>                            Set a specific cwd"),
+    clap::param!("-h, --help                             Print this help menu"),
 ];
-
-static AUDIT_PARAMS_FULL: &[ParamType] = concat_params![SHARED_PARAMS, AUDIT_PARAMS];
 
 static INFO_PARAMS: &[ParamType] = concat_params![
     SHARED_PARAMS,
@@ -1052,7 +1077,7 @@ Full documentation is available at <magenta>https://bun.com/docs/install/audit<r
 ";
 
                 pretty_help(intro_text);
-                clap::simple_help(AUDIT_PARAMS);
+                clap::simple_help(AUDIT_HELP_PARAMS);
                 pretty_help(outro_text);
                 Output::flush();
             }
@@ -1191,10 +1216,7 @@ Full documentation is available at <magenta>https://bun.com/docs/pm/cli/prune<r>
             Subcommand::Why => WHY_PARAMS,
             Subcommand::Dedupe => DEDUPE_PARAMS,
             Subcommand::Prune => PRUNE_PARAMS,
-
-            // TODO: we will probably want to do this for other *_params. this way extra params
-            // are not included in the help text
-            Subcommand::Audit => AUDIT_PARAMS_FULL,
+            Subcommand::Audit => AUDIT_PARAMS,
             Subcommand::Info => INFO_PARAMS,
         };
 

--- a/test/cli/install/bun-audit.test.ts
+++ b/test/cli/install/bun-audit.test.ts
@@ -902,6 +902,38 @@ describe("`bun audit --omit`", () => {
   });
 });
 
+describe("`bun audit --help`", () => {
+  test.concurrent("lists the flags bun audit and bun audit fix act on", async () => {
+    using dir = tempDir("audit-help-", {});
+
+    const { stdout, stderr, exitCode } = await audit(dir, "--help");
+    expect(stdout).toContain("Usage: bun audit [flags]");
+    const out = normalizeBunSnapshot(stdout).split("\n");
+    const flagsStart = out.indexOf("Flags:") + 1;
+    expect(flagsStart).toBeGreaterThan(0);
+    const flagLines = out.slice(flagsStart, out.indexOf("", flagsStart));
+    expect(flagLines.map(line => line.match(/--[\w-]+/)![0])).toStrictEqual([
+      "--audit-level",
+      "--production",
+      "--omit",
+      "--ignore",
+      "--json",
+      "--dry-run",
+      "--latest",
+      "--cwd",
+      "--help",
+    ]);
+    expect(flagLines.find(line => line.includes("--production"))).toStartWith("  -p, --production");
+    expect(flagLines.find(line => line.includes("--production"))).toContain("--prod");
+    expect(flagLines.find(line => line.includes("--omit"))).toContain("dev, optional, or peer");
+    expect(flagLines.find(line => line.includes("--dry-run"))).toContain("bun audit fix");
+    expect(flagLines.find(line => line.includes("--latest"))).toStartWith("  -L, --latest");
+    expect(flagLines.find(line => line.includes("--help"))).toStartWith("  -h, --help");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+});
+
 describe("`bun audit` report", () => {
   test.concurrent("an unknown severity is counted and filtered as moderate", async () => {
     await using server = startRegistry({ "a-dep": [{ ...adv("<1.0.4"), severity: "info" }] });

--- a/test/cli/install/bun-audit.test.ts
+++ b/test/cli/install/bun-audit.test.ts
@@ -924,7 +924,7 @@ describe("`bun audit --help`", () => {
       "--help",
     ]);
     expect(flagLines.find(line => line.includes("--production"))).toStartWith("  -p, --production");
-    expect(flagLines.find(line => line.includes("--production"))).toContain("--prod");
+    expect(flagLines.find(line => line.includes("--production"))).toContain("(alias: --prod)");
     expect(flagLines.find(line => line.includes("--omit"))).toContain("dev, optional, or peer");
     expect(flagLines.find(line => line.includes("--dry-run"))).toContain("bun audit fix");
     expect(flagLines.find(line => line.includes("--latest"))).toStartWith("  -L, --latest");


### PR DESCRIPTION
### Problem
- `bun audit --help` only lists `--json`, `--audit-level`, `--ignore` and `-L, --latest`.
- `bun audit` also accepts `-p` / `-P` / `--prod` / `--production` and `--omit=<dev|optional|peer>` (they are parsed from the shared install flag table and applied in `collect_packages_for_audit`, `src/runtime/cli/audit_command.rs:433`), and `bun audit fix` accepts `--dry-run`. The docs page (`docs/pm/cli/audit.mdx`) and the shipped shell completions describe all of them; only the help output was missing them.
- Cause: `print_help` printed `AUDIT_PARAMS`, the audit-only half of the parse table (`src/install/PackageManager/CommandLineArguments.rs`), so nothing inherited from `SHARED_PARAMS` could appear.

### Fix
- Add `AUDIT_HELP_PARAMS`, a curated list printed by `bun audit --help`: `--audit-level`, `-p, --production`, `--omit`, `--ignore`, `--json`, `--dry-run`, `-L, --latest`, `--cwd`, `-h, --help`. This is the same split `bun dedupe` and `bun prune` already use (`DEDUPE_HELP_PARAMS` / `PRUNE_HELP_PARAMS`); the parse table is now `AUDIT_PARAMS` (shared flags plus the audit-only ones), matching how the other commands name theirs. Parsing is unchanged.
- `completions/bun-cli.json`: the audit entry gains the same `production`, `omit`, `cwd` and `help` flags. The zsh, fish and bash completions already listed them.
- Test: `test/cli/install/bun-audit.test.ts`, "`bun audit --help` lists the flags bun audit and bun audit fix act on". It pins the printed flag list in order and the `-p` / `-L` / `-h` short forms. Fails on the current release (the list is `--json`, `--audit-level`, `--ignore`), passes with this change.
- `bun bd test test/cli/install/bun-audit.test.ts`: 178 pass. `bun bd test test/cli/bun.test.ts` (pins several `bun audit --help` strings, all of which are kept verbatim): 34 pass.

### Background
- Every package manager subcommand's flag table is `SHARED_PARAMS` (the `bun install` flags) plus a few command-specific entries, so `bun audit --production` works without audit-specific parsing code. `clap::simple_help` prints whatever table it is handed; printing the full table for audit would list ~40 install flags, so audit, dedupe and prune keep a separate, hand-picked table for `--help`.
- `completions/bun-cli.json` is a checked-in dump of the `--help` output produced by `misctools/generate-cli-completions.ts`; it is patched by hand for the flags a change touches.

