### PR TITLE
install: keep bundled peer edges on their own bun.lock entry when loading

### DIFF
--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -3299,18 +3299,23 @@ pub(crate) fn parse_into_binary_lockfile(
 }
 
 /// The catalog-resolved range of a peer edge the fresh resolver defers to its second phase
-/// (`install_peer`) and binds by version there. Two exemptions, matching
-/// `enqueue_dependency_with_main_and_success_fn`: optional peers return
-/// before the deferred phase and are bound to the hoisted-tree sibling by
-/// `process_subtree` instead, and `*` peers express no version preference
-/// and bind to whatever sibling pin existed first. Both of those are
-/// exactly what the printed tree's path walk reproduces, so they keep it.
+/// (`install_peer`) and binds by version there. Three exemptions keep the
+/// printed tree's path walk, which reproduces their saved binding exactly.
+/// Two match `enqueue_dependency_with_main_and_success_fn`: optional peers
+/// return before the deferred phase and are bound to the hoisted-tree
+/// sibling by `process_subtree` instead, and `*` peers express no version
+/// preference and bind to whatever sibling pin existed first. The third is
+/// a bundled peer: `process_subtree` always places a bundled edge under its
+/// own package, so its entry is always printed, and like every other bundled
+/// edge (`bun update` and dedupe hold them in place too) it stays on the
+/// version recorded there, the copy inside the bundle, even once a newer
+/// version satisfying the range exists elsewhere in the lockfile.
 fn deferred_peer_range<'a>(
     dep: &'a Dependency,
     catalogs: &'a CatalogMap,
     string_buf: &[u8],
 ) -> Option<&'a DependencyVersion> {
-    if !dep.behavior.is_peer() || dep.behavior.is_optional_peer() {
+    if !dep.behavior.is_peer() || dep.behavior.is_optional_peer() || dep.behavior.is_bundled() {
         return None;
     }
     let range = catalogs.resolve_range(string_buf, dep);

--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -1376,3 +1376,37 @@ it("an optional peer is rebound when another version of its package takes the sl
   await run(["install", "--lockfile-only"]);
   expect(await file(join(packageDir, "bun.lock")).text()).toBe(lockfile);
 });
+
+it("re-saving bun.lock keeps a bundled peer on the version its own entry records", async () => {
+  const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { saveTextLockfile: true } });
+  const run = makeInstallRunner(packageDir);
+
+  const dependencies = { "no-deps": "1.1.0", "peer-deps-fixed": "1.0.0" };
+  await write(packageJson, JSON.stringify({ name: "foo", dependencies }));
+
+  // peer-deps-fixed's peer on no-deps (^1.0.0) has a bundled entry of its own,
+  // the shape bundled subtrees have in existing lockfiles (for example
+  // @napi-rs/wasm-runtime's peer on @emnapi/core inside
+  // @tailwindcss/oxide-wasm32-wasi). It stays on the no-deps@1.0.0 recorded
+  // there even though the root has since moved on to no-deps@1.1.0, which the
+  // range would also accept. Without a configVersion the install re-saves the
+  // file, as it does for every lockfile written before configVersion existed.
+  await write(
+    join(packageDir, "bun.lock"),
+    JSON.stringify({
+      lockfileVersion: 1,
+      workspaces: { "": { name: "foo", dependencies } },
+      packages: {
+        "no-deps": ["no-deps@1.1.0", "", {}, ""],
+        "peer-deps-fixed": ["peer-deps-fixed@1.0.0", "", { peerDependencies: { "no-deps": "^1.0.0" } }, ""],
+        "peer-deps-fixed/no-deps": ["no-deps@1.0.0", "", { bundled: true }, ""],
+      },
+    }),
+  );
+
+  await run(["install"]);
+  const lockfile = await file(join(packageDir, "bun.lock")).text();
+  expect(lockfile).toContain('"configVersion": 0,');
+  expect(lockfile).toContain('"no-deps": ["no-deps@1.1.0", ');
+  expect(lockfile).toContain('"peer-deps-fixed/no-deps": ["no-deps@1.0.0", ');
+});


### PR DESCRIPTION
### Problem
- The first plain `bun install` a 1.4 build runs on a bun.lock that 1.3.14 leaves alone (both versions accept it with `--frozen-lockfile`) rewrites the `"bundled": true` subtree of a package. On C4illin/ConvertX the `@tailwindcss/oxide-wasm32-wasi` cluster changes: `@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core` and `.../@emnapi/runtime` move from 1.11.1 (the copies inside the bundle) to 1.11.2 (the root's copies), and their `@emnapi/wasi-threads` / `tslib` dependencies are re-hoisted as entries without the bundled marker. 1.3.14 only adds `"configVersion": 0`.
- Since #32182, loading bun.lock binds every non-optional, non-wildcard peer edge by version (`resolve_peer_dep_version_based`, `src/install/lockfile/bun.lock.rs`), picking the highest entry in the lockfile that satisfies the range instead of walking the printed tree. That is right for ordinary peers, which have no entry of their own. It was also applied to peer edges marked bundled, whose entry is the one written next to the package (`@napi-rs/wasm-runtime`'s peer on `@emnapi/core` above, pinned to the 1.11.1 shipped in the bundle), so as soon as a newer satisfying version exists anywhere in the lockfile the edge is rebound to it and the next save prints the rebound subtree. Before #32182 (and in 1.3.14) the path walk found the edge's own entry and kept it.
- The rebinding is also wrong on its own terms: a bundled edge is satisfied by the tarball contents, and every other command holds it in place (`bun update` skips bundled rows in `install_with_manager.rs`, dedupe treats them as pinned in `dedupe.rs`), so the rewritten lockfile records a version of the bundled package that is not the one in the tarball. The installed layout is not affected: the install tree is built with `BuilderMethod::Filter`, which drops bundled edges and everything under them, so the damage is the lockfile churn and what lockfile readers (`bun pm ls`, `bun audit`, `bun why`) report for the bundle.

### Fix
- `deferred_peer_range` returns `None` for bundled peer edges, so they keep the path walk, the same exemption optional and `*` peers already have. The path walk is exact for them: `Tree::process_subtree` always places a bundled edge directly under its package, so its entry is always printed and the walk hits it on the first probe.
- No change for non-bundled peers, so the store-key stability #32182 fixed is untouched (its tests in `isolated-install.test.ts` still pass). The pnpm migration binds peers through the same helper and never produces bundled edges, so it is unaffected.
- Test: `test/cli/install/bun-lock.test.ts`, "re-saving bun.lock keeps a bundled peer on the version its own entry records". It writes a lockfile with a bundled peer entry pinned to `no-deps@1.0.0` while the root has `no-deps@1.1.0` and no `configVersion` (so the install re-saves it, the same trigger as in the field), then checks the entry still says 1.0.0. Without the fix the entry is rewritten to `no-deps@1.1.0`; bun 1.3.14 given the same directory produces the fixed output byte for byte.
- ConvertX with this build: `bun install --lockfile-only` now changes only `configVersion` plus the `trustedDependencies` order, which is the separate map-order issue fixed by #38736. The same check on sst/opencode, elizaOS/eliza and can1357/oh-my-pi leaves only the #38736 hunks (and, on opencode, the intentional removal of packages kept alive solely by optional peer edges).
- Also run: the rest of `bun-lock.test.ts`, the `bundledDependencies` suite in `bun-install-registry.test.ts`, the "across installs from bun.lock" tests in `isolated-install.test.ts`, and the pnpm v9 migration suites.
- Related open PRs: #38767 and #38768 apply `resolve_peer_dep_version_based` at save time as well; both go through `deferred_peer_range`, so this exemption carries into them without changes (with #38767 alone, the rebinding above would also happen on every install's clean). #37713 rewrites this same function to make `*` peers version-bound; whichever of the two lands second needs to keep the `is_bundled()` check.

### Background
- A bundled dependency (`bundleDependencies` in package.json) ships inside its parent's tarball. bun records the edge with a bundled flag, never downloads it separately, and prints it in bun.lock as `"<parent path>/<name>"` with `"bundled": true`. When bun.lock is loaded, an edge is marked bundled precisely because such an entry exists for it (`parse_append_dependencies`).
- Peer edges in bun.lock normally have no entry of their own: the peer is satisfied by whatever version is hoisted above it. #32182 added the version scan because the fresh resolver binds such edges to the highest satisfying version, and reproducing that choice on load keeps isolated-linker store keys stable. A bundled peer edge is the one kind of peer edge that does print its own entry, so the scan has nothing to recover for it.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-lock.test.ts

<!-- robobun:evidence:end -->