### PR TITLE
crash_handler: put the executable's debug id in the trace string

### DIFF
--- a/src/crash_handler/debug_id.rs
+++ b/src/crash_handler/debug_id.rs
@@ -1,0 +1,250 @@
+//! The identifier the linker stamps into both the executable and its debug
+//! info: the PDB GUID in the PE CodeView record on Windows, the GNU build-id
+//! note on ELF, `LC_UUID` on Mach-O. Unlike the git sha it names one specific
+//! link: a commit can be published as several links of one platform (an x64
+//! and an x64-baseline zip, a re-run release step), and symbolizing a trace
+//! against the other link's debug info produces plausible-looking nonsense.
+//! The trace string carries this id so bun.report can check the debug file it
+//! picked. Bytes are kept in the order the platform's tools print them
+//! (`dumpbin`, `readelf -n`, `dwarfdump --uuid`), so the hex in a trace string
+//! compares directly against their output.
+//!
+//! Runs inside the crash handler: reads only the loader-mapped image headers,
+//! bounds-checks every offset, and does not allocate.
+
+use bun_collections::BoundedArray;
+
+/// A sha1 build-id is 20 bytes; a PDB GUID or Mach-O UUID is 16.
+pub(crate) const MAX_LEN: usize = 20;
+
+pub(crate) type DebugId = BoundedArray<u8, MAX_LEN>;
+
+/// The debug id of the image whose frames the trace string encodes as bare
+/// image-relative addresses (see `StackLine::from_address`), or `None` when
+/// the image does not carry one.
+pub(crate) fn of_running_executable() -> Option<DebugId> {
+    #[cfg(windows)]
+    {
+        pe_codeview_guid()
+    }
+    #[cfg(target_os = "macos")]
+    {
+        macho_uuid()
+    }
+    #[cfg(not(any(windows, target_os = "macos")))]
+    {
+        elf_gnu_build_id()
+    }
+}
+
+fn debug_id_from(bytes: &[u8]) -> Option<DebugId> {
+    if bytes.is_empty() {
+        return None;
+    }
+    DebugId::from_slice(&bytes[..bytes.len().min(MAX_LEN)]).ok()
+}
+
+#[cfg(windows)]
+fn pe_codeview_guid() -> Option<DebugId> {
+    const IMAGE_DIRECTORY_ENTRY_DEBUG: usize = 6;
+    const IMAGE_DEBUG_TYPE_CODEVIEW: u32 = 2;
+    const IMAGE_DEBUG_DIRECTORY_SIZE: usize = 28;
+
+    /// Bounds-checked reads at RVAs of the mapped image.
+    struct Image<'a>(&'a [u8]);
+
+    impl Image<'_> {
+        fn bytes(&self, rva: usize, len: usize) -> Option<&[u8]> {
+            self.0.get(rva..rva.checked_add(len)?)
+        }
+        fn u16(&self, rva: usize) -> Option<u16> {
+            Some(u16::from_le_bytes(self.bytes(rva, 2)?.try_into().ok()?))
+        }
+        fn u32(&self, rva: usize) -> Option<u32> {
+            Some(u32::from_le_bytes(self.bytes(rva, 4)?.try_into().ok()?))
+        }
+    }
+
+    let range = bun_sys::windows::exe_image_range();
+    // SAFETY: the loader maps the exe's headers and sections contiguously over
+    // `range` (base..base + SizeOfImage) for the lifetime of the process, and
+    // `Image` checks every offset against that length before reading it.
+    let image = Image(unsafe {
+        core::slice::from_raw_parts(range.start as *const u8, range.end - range.start)
+    });
+
+    let nt_headers = image.u32(0x3C)? as usize;
+    if image.bytes(nt_headers, 4)? != b"PE\0\0" {
+        return None;
+    }
+    // Signature(4) + IMAGE_FILE_HEADER(20), then IMAGE_OPTIONAL_HEADER64 with
+    // NumberOfRvaAndSizes at +108 and the 8-byte DataDirectory entries at +112.
+    let optional_header = nt_headers + 4 + 20;
+    if image.u16(optional_header)? != 0x20B {
+        return None;
+    }
+    if image.u32(optional_header + 108)? as usize <= IMAGE_DIRECTORY_ENTRY_DEBUG {
+        return None;
+    }
+    let directory = optional_header + 112 + IMAGE_DIRECTORY_ENTRY_DEBUG * 8;
+    let mut entry = image.u32(directory)? as usize;
+    let end = entry.checked_add(image.u32(directory + 4)? as usize)?;
+
+    // IMAGE_DEBUG_DIRECTORY: Type at +12, AddressOfRawData at +20.
+    while entry + IMAGE_DEBUG_DIRECTORY_SIZE <= end {
+        if image.u32(entry + 12)? == IMAGE_DEBUG_TYPE_CODEVIEW {
+            // CV_INFO_PDB70: "RSDS", GUID, age, pdb path.
+            let codeview = image.u32(entry + 20)? as usize;
+            if codeview != 0 && image.bytes(codeview, 4)? == b"RSDS" {
+                let guid = image.bytes(codeview + 4, 16)?;
+                // GUID {u32, u16, u16, [u8; 8]} is stored little-endian; emit
+                // the byte order of its textual form.
+                let mut id = [0u8; 16];
+                id[0..4].copy_from_slice(&[guid[3], guid[2], guid[1], guid[0]]);
+                id[4..6].copy_from_slice(&[guid[5], guid[4]]);
+                id[6..8].copy_from_slice(&[guid[7], guid[6]]);
+                id[8..16].copy_from_slice(&guid[8..16]);
+                return debug_id_from(&id);
+            }
+        }
+        entry += IMAGE_DEBUG_DIRECTORY_SIZE;
+    }
+    None
+}
+
+#[cfg(target_os = "macos")]
+fn macho_uuid() -> Option<DebugId> {
+    const LC_UUID: u32 = 0x1B;
+
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    struct uuid_command {
+        _cmd: u32,
+        _cmdsize: u32,
+        uuid: [u8; 16],
+    }
+
+    // Image 0 is the main executable, the image `StackLine` encodes as bare addresses.
+    let header = bun_sys::c::_dyld_get_image_header(0);
+    if header.is_null() {
+        return None;
+    }
+    // SAFETY: dyld keeps the main executable's header and the `sizeofcmds`
+    // bytes of load commands following it mapped for the process lifetime.
+    let (ncmds, load_commands) = unsafe {
+        let header_ref = &*header;
+        (
+            header_ref.ncmds,
+            core::slice::from_raw_parts(
+                header
+                    .cast::<u8>()
+                    .add(core::mem::size_of::<bun_sys::macho::mach_header_64>()),
+                header_ref.sizeofcmds as usize,
+            ),
+        )
+    };
+    let mut it = bun_sys::macho::LoadCommandIterator::new(ncmds, load_commands);
+    while let Some(command) = it.next() {
+        if command.cmd() == LC_UUID {
+            return debug_id_from(&command.cast::<uuid_command>()?.uuid);
+        }
+    }
+    None
+}
+
+#[cfg(not(any(windows, target_os = "macos")))]
+fn elf_gnu_build_id() -> Option<DebugId> {
+    use core::ffi::{c_int, c_void};
+
+    const PT_NOTE: u32 = 4;
+
+    struct Ctx {
+        address: usize,
+        result: Option<DebugId>,
+    }
+
+    // Same shape as `bun_sys::elf::find_loaded_module`: the object whose PT_LOAD
+    // covers an address inside this binary is the one whose notes to read.
+    extern "C" fn callback(
+        info: *mut libc::dl_phdr_info,
+        _size: libc::size_t,
+        data: *mut c_void,
+    ) -> c_int {
+        // SAFETY: `data` is the `&mut Ctx` handed to dl_iterate_phdr below.
+        let ctx = unsafe { bun_core::callback_ctx::<Ctx>(data) };
+        // SAFETY: dl_iterate_phdr passes a valid info pointer whose dlpi_phdr
+        // points to dlpi_phnum program headers.
+        let (base, phdrs) = unsafe {
+            let info = &*info;
+            (
+                info.dlpi_addr as usize,
+                core::slice::from_raw_parts(info.dlpi_phdr, info.dlpi_phnum as usize),
+            )
+        };
+        let contains_address = phdrs.iter().any(|phdr| {
+            phdr.p_type == bun_sys::elf::PT_LOAD && {
+                let start = base.wrapping_add(phdr.p_vaddr as usize);
+                ctx.address >= start && ctx.address < start.wrapping_add(phdr.p_memsz as usize)
+            }
+        });
+        if !contains_address {
+            return 0;
+        }
+        for phdr in phdrs.iter().filter(|phdr| phdr.p_type == PT_NOTE) {
+            // SAFETY: a PT_NOTE segment lies inside one of the object's mapped
+            // PT_LOAD segments, so `p_memsz` bytes are readable at
+            // `base + p_vaddr` while the object is loaded, and the main
+            // executable is never unloaded.
+            let notes = unsafe {
+                core::slice::from_raw_parts(
+                    base.wrapping_add(phdr.p_vaddr as usize) as *const u8,
+                    phdr.p_memsz as usize,
+                )
+            };
+            if let Some(id) = gnu_build_id_note(notes) {
+                ctx.result = Some(id);
+                break;
+            }
+        }
+        1
+    }
+
+    let mut ctx = Ctx {
+        address: elf_gnu_build_id as *const () as usize,
+        result: None,
+    };
+    // SAFETY: `ctx` outlives the call and `callback` has the signature libc expects.
+    unsafe {
+        libc::dl_iterate_phdr(Some(callback), (&raw mut ctx).cast::<c_void>());
+    }
+    ctx.result
+}
+
+/// Each note in a PT_NOTE segment is an `Elf64_Nhdr` (namesz, descsz, type as
+/// native-endian u32s) followed by the name and the descriptor, each padded to
+/// a multiple of 4 bytes.
+#[cfg(not(any(windows, target_os = "macos")))]
+fn gnu_build_id_note(mut notes: &[u8]) -> Option<DebugId> {
+    const NT_GNU_BUILD_ID: u32 = 3;
+
+    fn u32_at(bytes: &[u8], offset: usize) -> Option<u32> {
+        Some(u32::from_ne_bytes(
+            bytes.get(offset..offset + 4)?.try_into().ok()?,
+        ))
+    }
+    fn align4(n: usize) -> Option<usize> {
+        Some(n.checked_add(3)? & !3)
+    }
+
+    while notes.len() >= 12 {
+        let name_end = 12usize.checked_add(u32_at(notes, 0)? as usize)?;
+        let desc_start = align4(name_end)?;
+        let desc_end = desc_start.checked_add(u32_at(notes, 4)? as usize)?;
+        let desc = notes.get(desc_start..desc_end)?;
+        if u32_at(notes, 8)? == NT_GNU_BUILD_ID && notes.get(12..name_end)? == b"GNU\0" {
+            return debug_id_from(desc);
+        }
+        notes = notes.get(align4(desc_end)?.min(notes.len())..)?;
+    }
+    None
+}

--- a/src/crash_handler/debug_id.rs
+++ b/src/crash_handler/debug_id.rs
@@ -1,16 +1,7 @@
-//! The identifier the linker stamps into both the executable and its debug
-//! info: the PDB GUID in the PE CodeView record on Windows, the GNU build-id
-//! note on ELF, `LC_UUID` on Mach-O. Unlike the git sha it names one specific
-//! link: a commit can be published as several links of one platform (an x64
-//! and an x64-baseline zip, a re-run release step), and symbolizing a trace
-//! against the other link's debug info produces plausible-looking nonsense.
-//! The trace string carries this id so bun.report can check the debug file it
-//! picked. Bytes are kept in the order the platform's tools print them
-//! (`dumpbin`, `readelf -n`, `dwarfdump --uuid`), so the hex in a trace string
-//! compares directly against their output.
-//!
-//! Runs inside the crash handler: reads only the loader-mapped image headers,
-//! bounds-checks every offset, and does not allocate.
+//! The id the linker stamps into both the executable and its debug info (PDB
+//! GUID, GNU build-id, `LC_UUID`), in the byte order `dumpbin` / `readelf -n` /
+//! `dwarfdump --uuid` print it. Read from the mapped image headers inside the
+//! crash handler, so every offset is bounds-checked and nothing allocates.
 
 use bun_collections::BoundedArray;
 
@@ -19,9 +10,7 @@ pub(crate) const MAX_LEN: usize = 20;
 
 pub(crate) type DebugId = BoundedArray<u8, MAX_LEN>;
 
-/// The debug id of the image whose frames the trace string encodes as bare
-/// image-relative addresses (see `StackLine::from_address`), or `None` when
-/// the image does not carry one.
+/// The id of the image whose frames `StackLine` encodes as bare addresses.
 pub(crate) fn of_running_executable() -> Option<DebugId> {
     #[cfg(windows)]
     {
@@ -66,9 +55,8 @@ fn pe_codeview_guid() -> Option<DebugId> {
     }
 
     let range = bun_sys::windows::exe_image_range();
-    // SAFETY: the loader maps the exe's headers and sections contiguously over
-    // `range` (base..base + SizeOfImage) for the lifetime of the process, and
-    // `Image` checks every offset against that length before reading it.
+    // SAFETY: the loader keeps base..base + SizeOfImage mapped for the life of
+    // the process; `Image` bounds-checks every read against it.
     let image = Image(unsafe {
         core::slice::from_raw_parts(range.start as *const u8, range.end - range.start)
     });
@@ -77,8 +65,7 @@ fn pe_codeview_guid() -> Option<DebugId> {
     if image.bytes(nt_headers, 4)? != b"PE\0\0" {
         return None;
     }
-    // Signature(4) + IMAGE_FILE_HEADER(20), then IMAGE_OPTIONAL_HEADER64 with
-    // NumberOfRvaAndSizes at +108 and the 8-byte DataDirectory entries at +112.
+    // IMAGE_OPTIONAL_HEADER64: NumberOfRvaAndSizes at +108, DataDirectory at +112.
     let optional_header = nt_headers + 4 + 20;
     if image.u16(optional_header)? != 0x20B {
         return None;
@@ -97,8 +84,7 @@ fn pe_codeview_guid() -> Option<DebugId> {
             let codeview = image.u32(entry + 20)? as usize;
             if codeview != 0 && image.bytes(codeview, 4)? == b"RSDS" {
                 let guid = image.bytes(codeview + 4, 16)?;
-                // GUID {u32, u16, u16, [u8; 8]} is stored little-endian; emit
-                // the byte order of its textual form.
+                // The first three GUID fields are little-endian in memory.
                 let mut id = [0u8; 16];
                 id[0..4].copy_from_slice(&[guid[3], guid[2], guid[1], guid[0]]);
                 id[4..6].copy_from_slice(&[guid[5], guid[4]]);
@@ -124,13 +110,13 @@ fn macho_uuid() -> Option<DebugId> {
         uuid: [u8; 16],
     }
 
-    // Image 0 is the main executable, the image `StackLine` encodes as bare addresses.
+    // Image 0 is the main executable, the one `StackLine` encodes as bare addresses.
     let header = bun_sys::c::_dyld_get_image_header(0);
     if header.is_null() {
         return None;
     }
-    // SAFETY: dyld keeps the main executable's header and the `sizeofcmds`
-    // bytes of load commands following it mapped for the process lifetime.
+    // SAFETY: dyld keeps the main executable's header and its `sizeofcmds`
+    // bytes of load commands mapped for the life of the process.
     let (ncmds, load_commands) = unsafe {
         let header_ref = &*header;
         (
@@ -163,8 +149,7 @@ fn elf_gnu_build_id() -> Option<DebugId> {
         result: Option<DebugId>,
     }
 
-    // Same shape as `bun_sys::elf::find_loaded_module`: the object whose PT_LOAD
-    // covers an address inside this binary is the one whose notes to read.
+    // As in `bun_sys::elf::find_loaded_module`: the object whose PT_LOAD covers `address`.
     extern "C" fn callback(
         info: *mut libc::dl_phdr_info,
         _size: libc::size_t,
@@ -172,8 +157,7 @@ fn elf_gnu_build_id() -> Option<DebugId> {
     ) -> c_int {
         // SAFETY: `data` is the `&mut Ctx` handed to dl_iterate_phdr below.
         let ctx = unsafe { bun_core::callback_ctx::<Ctx>(data) };
-        // SAFETY: dl_iterate_phdr passes a valid info pointer whose dlpi_phdr
-        // points to dlpi_phnum program headers.
+        // SAFETY: dl_iterate_phdr passes a valid info whose dlpi_phdr has dlpi_phnum entries.
         let (base, phdrs) = unsafe {
             let info = &*info;
             (
@@ -191,10 +175,8 @@ fn elf_gnu_build_id() -> Option<DebugId> {
             return 0;
         }
         for phdr in phdrs.iter().filter(|phdr| phdr.p_type == PT_NOTE) {
-            // SAFETY: a PT_NOTE segment lies inside one of the object's mapped
-            // PT_LOAD segments, so `p_memsz` bytes are readable at
-            // `base + p_vaddr` while the object is loaded, and the main
-            // executable is never unloaded.
+            // SAFETY: PT_NOTE lies inside a PT_LOAD of this object, which is the
+            // main executable and therefore stays mapped.
             let notes = unsafe {
                 core::slice::from_raw_parts(
                     base.wrapping_add(phdr.p_vaddr as usize) as *const u8,
@@ -220,9 +202,8 @@ fn elf_gnu_build_id() -> Option<DebugId> {
     ctx.result
 }
 
-/// Each note in a PT_NOTE segment is an `Elf64_Nhdr` (namesz, descsz, type as
-/// native-endian u32s) followed by the name and the descriptor, each padded to
-/// a multiple of 4 bytes.
+/// Notes are `Elf64_Nhdr {namesz, descsz, type}` followed by the name and the
+/// descriptor, each padded to 4 bytes.
 #[cfg(not(any(windows, target_os = "macos")))]
 fn gnu_build_id_note(mut notes: &[u8]) -> Option<DebugId> {
     const NT_GNU_BUILD_ID: u32 = 3;

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -2,10 +2,12 @@
 //! print backtraces that are mapped to source code. In release builds, we do
 //! not have debug symbols in the binary. Bun's solution to this is called
 //! a "trace string", a url with compressed encoding of the captured
-//! backtrace. Version 1 trace strings contain the following information:
+//! backtrace. Trace strings contain the following information:
 //!
 //! - What version and commit of Bun captured the backtrace.
 //! - The platform the backtrace was captured on.
+//! - The debug id of the executable, naming the exact link of that commit
+//!   whose debug info the addresses below must be remapped with.
 //! - The list of addresses with ASLR removed, ready to be remapped.
 //! - If panicking, the message that was panicked with.
 //!
@@ -25,6 +27,8 @@
 #![warn(unused_must_use)]
 #[path = "CPUFeatures.rs"]
 pub mod cpu_features;
+
+mod debug_id;
 
 #[path = "handle_oom.rs"]
 pub mod handle_oom;
@@ -509,6 +513,7 @@ mod draft {
     use super::cpu_features::CPUFeatures;
     #[cfg(not(any(target_os = "linux", target_os = "android")))]
     use super::debug::{Color, SelfInfo, SourceLocation, TtyConfig};
+    use super::debug_id;
 
     /// Print an argv vector as a shell-ish line.
     /// Called when the addr2line spawn fails.
@@ -2394,13 +2399,34 @@ mod draft {
     }
 
     /// Note to the decoder on how to process this string. This ensures backwards
-    /// compatibility with older versions of the tracestring.
+    /// compatibility with older versions of the tracestring. Must be kept in
+    /// sync with `lib/parser.ts` in bun.report.
     ///
     /// '1' - original. uses 7 char hash with VLQ encoded stack-frames
     /// '2' - same as '1' but this build is known to be a canary build
-    const VERSION_CHAR: &str = if Environment::IS_CANARY { "2" } else { "1" };
+    /// '3' - defined by the decoder (build flags + fault registers), never emitted
+    /// '4' - '1' with two fields between the hash and the features: one VLQ of
+    ///       `BuildFlags` (replaces the '1'/'2' split), then the executable's
+    ///       debug id as a VLQ byte count followed by that many bytes in
+    ///       lowercase hex (count 0 when the executable has none). Hex rather
+    ///       than VLQs so the id can be compared with `readelf -n` / `dumpbin`
+    ///       / `dwarfdump --uuid` output straight from the URL.
+    const VERSION_CHAR: &str = "4";
 
-    // The v1/v2 trace-string
+    bitflags::bitflags! {
+        #[derive(Clone, Copy)]
+        struct BuildFlags: u32 {
+            const CANARY = 1 << 0;
+        }
+    }
+
+    const BUILD_FLAGS: BuildFlags = if Environment::IS_CANARY {
+        BuildFlags::CANARY
+    } else {
+        BuildFlags::empty()
+    };
+
+    // The trace-string
     // format encodes exactly 7 hex chars. `Environment::GIT_SHA_SHORT` is 9 chars and would
     // shift every following VLQ byte, making bun.report unable to decode the URL.
     const GIT_SHA: &str = {
@@ -2625,6 +2651,14 @@ mod draft {
 
         writer.write_all(VERSION_CHAR.as_bytes())?;
         writer.write_all(GIT_SHA.as_bytes())?;
+        writer.write_all(VLQ::encode(BUILD_FLAGS.bits() as i32).slice())?;
+
+        let id = debug_id::of_running_executable();
+        let id: &[u8] = id.as_deref().unwrap_or(&[]);
+        writer.write_all(VLQ::encode(id.len() as i32).slice())?;
+        let mut hex = [0u8; 2 * debug_id::MAX_LEN];
+        let hex_len = bun_fmt::bytes_to_hex_lower(id, &mut hex);
+        writer.write_all(&hex[..hex_len])?;
 
         let packed_features: u64 = bun_analytics::packed_features().bits();
         write_u64_as_two_vlqs(writer, packed_features as usize)?;

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -2402,9 +2402,18 @@ mod draft {
     /// '1' - original. uses 7 char hash with VLQ encoded stack-frames
     /// '2' - same as '1' but this build is known to be a canary build
     /// '3' - decoder-only (build flags + fault registers), never emitted
-    /// '4' - '1' plus, after the hash: a `BuildFlags` VLQ, then the debug id as a
-    ///       VLQ byte count and that many bytes of lowercase hex (0 bytes if none)
+    /// '4' - '1' plus a header after the hash: a VLQ field count, then per field a VLQ
+    ///       `HeaderField` tag, a VLQ char count and that many chars. Decoders skip
+    ///       tags they do not know, so adding a field does not need a new version char.
     const VERSION_CHAR: &str = "4";
+
+    /// Tags of the '4' header fields. Only ever append.
+    enum HeaderField {
+        /// One VLQ of `BuildFlags`.
+        BuildFlags = 0,
+        /// The executable's debug id in lowercase hex; absent when it has none.
+        DebugId = 1,
+    }
 
     bitflags::bitflags! {
         #[derive(Clone, Copy)]
@@ -2418,6 +2427,17 @@ mod draft {
     } else {
         BuildFlags::empty()
     };
+
+    fn write_header_field(
+        writer: &mut impl Write,
+        tag: HeaderField,
+        chars: &[u8],
+    ) -> crate::Result<()> {
+        writer.write_all(VLQ::encode(tag as i32).slice())?;
+        writer.write_all(VLQ::encode(chars.len() as i32).slice())?;
+        writer.write_all(chars)?;
+        Ok(())
+    }
 
     // The trace-string
     // format encodes exactly 7 hex chars. `Environment::GIT_SHA_SHORT` is 9 chars and would
@@ -2644,14 +2664,19 @@ mod draft {
 
         writer.write_all(VERSION_CHAR.as_bytes())?;
         writer.write_all(GIT_SHA.as_bytes())?;
-        writer.write_all(VLQ::encode(BUILD_FLAGS.bits() as i32).slice())?;
 
         let id = debug_id::of_running_executable();
-        let id: &[u8] = id.as_deref().unwrap_or(&[]);
-        writer.write_all(VLQ::encode(id.len() as i32).slice())?;
-        let mut hex = [0u8; 2 * debug_id::MAX_LEN];
-        let hex_len = bun_fmt::bytes_to_hex_lower(id, &mut hex);
-        writer.write_all(&hex[..hex_len])?;
+        writer.write_all(VLQ::encode(1 + i32::from(id.is_some())).slice())?;
+        write_header_field(
+            writer,
+            HeaderField::BuildFlags,
+            VLQ::encode(BUILD_FLAGS.bits() as i32).slice(),
+        )?;
+        if let Some(id) = &id {
+            let mut hex = [0u8; 2 * debug_id::MAX_LEN];
+            let hex_len = bun_fmt::bytes_to_hex_lower(id, &mut hex);
+            write_header_field(writer, HeaderField::DebugId, &hex[..hex_len])?;
+        }
 
         let packed_features: u64 = bun_analytics::packed_features().bits();
         write_u64_as_two_vlqs(writer, packed_features as usize)?;

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -6,8 +6,7 @@
 //!
 //! - What version and commit of Bun captured the backtrace.
 //! - The platform the backtrace was captured on.
-//! - The debug id of the executable, naming the exact link of that commit
-//!   whose debug info the addresses below must be remapped with.
+//! - The debug id of the executable, i.e. which link of that commit it is.
 //! - The list of addresses with ASLR removed, ready to be remapped.
 //! - If panicking, the message that was panicked with.
 //!
@@ -2398,19 +2397,13 @@ mod draft {
         };
     }
 
-    /// Note to the decoder on how to process this string. This ensures backwards
-    /// compatibility with older versions of the tracestring. Must be kept in
-    /// sync with `lib/parser.ts` in bun.report.
+    /// Note to the decoder (bun.report's `lib/parser.ts`) on how to process this string.
     ///
     /// '1' - original. uses 7 char hash with VLQ encoded stack-frames
     /// '2' - same as '1' but this build is known to be a canary build
-    /// '3' - defined by the decoder (build flags + fault registers), never emitted
-    /// '4' - '1' with two fields between the hash and the features: one VLQ of
-    ///       `BuildFlags` (replaces the '1'/'2' split), then the executable's
-    ///       debug id as a VLQ byte count followed by that many bytes in
-    ///       lowercase hex (count 0 when the executable has none). Hex rather
-    ///       than VLQs so the id can be compared with `readelf -n` / `dumpbin`
-    ///       / `dwarfdump --uuid` output straight from the URL.
+    /// '3' - decoder-only (build flags + fault registers), never emitted
+    /// '4' - '1' plus, after the hash: a `BuildFlags` VLQ, then the debug id as a
+    ///       VLQ byte count and that many bytes of lowercase hex (0 bytes if none)
     const VERSION_CHAR: &str = "4";
 
     bitflags::bitflags! {

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -570,7 +570,7 @@ describe.concurrent("trace string identifies the build", () => {
       env: mergeWindowEnvs([bunEnv, { BUN_CRASH_REPORT_URL: base, BUN_ENABLE_CRASH_REPORTING: "1" }]),
       stdio: ["ignore", "pipe", "pipe"],
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [stderr, , exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
     expect(exitCode).not.toBe(0);
 
     // {base}/{bun version}/{payload}. The payload itself may contain '/'

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -1,7 +1,8 @@
 import { crash_handler } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, isDebug, isLinux, isPosix, isWindows, mergeWindowEnvs, tempDir } from "harness";
-import { rmSync } from "node:fs";
+import { closeSync, openSync, readSync, rmSync } from "node:fs";
+import { inflateSync } from "node:zlib";
 import path from "path";
 const { getMachOImageZeroOffset } = crash_handler;
 
@@ -547,6 +548,213 @@ describe("automatic crash reporter", () => {
       expect(sent).toBe(true);
     });
   }
+});
+
+// A trace string names the build it came from. The sha alone is not enough:
+// one commit can be published as more than one link of the same platform
+// (the x64 and x64-baseline zips, or a re-run of the release step), and
+// bun.report symbolizing against the wrong link's debug info produces
+// plausible-looking nonsense. So after the sha the string carries the id the
+// linker stamped into the executable and its debug info. Layout (must stay in
+// sync with `encode_trace_string` in src/crash_handler/lib.rs and bun.report's
+// lib/parser.ts):
+//
+//   {platform}{command}4{sha7}{build flags VLQ}{id byte count VLQ}{id hex}{features 2 VLQs}{frames}A{reason}
+describe.concurrent("trace string identifies the build", () => {
+  async function tracePayload(approach: string): Promise<string> {
+    using server = Bun.serve({ port: 0, fetch: () => new Response("OK") });
+    const base = new URL(server.url).origin;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(import.meta.dir, "fixture-crash.js"), approach],
+      env: mergeWindowEnvs([bunEnv, { BUN_CRASH_REPORT_URL: base, BUN_ENABLE_CRASH_REPORTING: "1" }]),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(exitCode).not.toBe(0);
+
+    // {base}/{bun version}/{payload}. The payload itself may contain '/'
+    // (it is in the VLQ alphabet), so cut at the slash after the version.
+    const trace = stderr.match(new RegExp(`${base.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}/(\\S+)`));
+    expect(trace).not.toBeNull();
+    const afterBase = trace![1];
+    return afterBase.slice(afterBase.indexOf("/") + 1);
+  }
+
+  const VLQ_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+  /**
+   * Reads one source-map style VLQ (sign-magnitude i32, as `bun_base64::VLQ`
+   * writes it and bun.report's `decodePart` reads it) at `i`; returns the value
+   * and the index after it.
+   */
+  function vlq(s: string, i: number): [value: number, next: number] {
+    let word = 0;
+    for (let shift = 0; ; shift += 5) {
+      const digit = VLQ_ALPHABET.indexOf(s[i++]);
+      if (digit < 0) throw new Error(`not a VLQ digit at ${i - 1} in ${JSON.stringify(s)}`);
+      word += (digit & 31) * 2 ** shift;
+      if (!(digit & 32)) break;
+    }
+    const magnitude = Math.floor(word / 2);
+    if (word % 2 === 0) return [magnitude, i];
+    return [magnitude === 0 ? -0x80000000 : -magnitude, i];
+  }
+
+  /** `write_u64_as_two_vlqs`: high and low 32-bit halves, each reinterpreted as an i32. */
+  function u64(s: string, i: number): [value: bigint, next: number] {
+    const [hi, j] = vlq(s, i);
+    const [lo, k] = vlq(s, j);
+    return [(BigInt(hi >>> 0) << 32n) | BigInt(lo >>> 0), k];
+  }
+
+  function readAt(fd: number, position: number, length: number): Buffer {
+    const buffer = Buffer.alloc(length);
+    for (let done = 0; done < length; ) {
+      const n = readSync(fd, buffer, done, length - done, position + done);
+      if (n === 0) throw new Error(`short read at ${position}`);
+      done += n;
+    }
+    return buffer;
+  }
+
+  /**
+   * The id as the platform's own tools print it (`readelf -n`, `dumpbin
+   * /headers`, `dwarfdump --uuid`), lowercase and without dashes. Read from
+   * the file on disk, independently of the crash handler's in-memory walk.
+   */
+  function debugIdOfExecutable(file: string): string {
+    const fd = openSync(file, "r");
+    try {
+      const magic = readAt(fd, 0, 4);
+      if (magic.toString("latin1") === "\x7fELF") return elfBuildId(fd);
+      if (magic.toString("latin1", 0, 2) === "MZ") return peCodeViewGuid(fd);
+      if (magic.readUInt32LE(0) === 0xfeedfacf) return machoUuid(fd);
+      throw new Error(`unrecognized executable format: ${magic.toString("hex")}`);
+    } finally {
+      closeSync(fd);
+    }
+  }
+
+  function elfBuildId(fd: number): string {
+    const header = readAt(fd, 0, 64);
+    const phoff = Number(header.readBigUInt64LE(0x20));
+    const phentsize = header.readUInt16LE(0x36);
+    const phnum = header.readUInt16LE(0x38);
+    const phdrs = readAt(fd, phoff, phentsize * phnum);
+    for (let n = 0; n < phnum; n++) {
+      const phdr = phdrs.subarray(n * phentsize);
+      if (phdr.readUInt32LE(0) !== 4 /* PT_NOTE */) continue;
+      const notes = readAt(fd, Number(phdr.readBigUInt64LE(8)), Number(phdr.readBigUInt64LE(32)));
+      for (let off = 0; off + 12 <= notes.length; ) {
+        const nameSize = notes.readUInt32LE(off);
+        const descSize = notes.readUInt32LE(off + 4);
+        const type = notes.readUInt32LE(off + 8);
+        const descStart = (off + 12 + nameSize + 3) & ~3;
+        if (type === 3 /* NT_GNU_BUILD_ID */ && notes.toString("latin1", off + 12, off + 12 + nameSize) === "GNU\0") {
+          return notes.toString("hex", descStart, descStart + descSize);
+        }
+        off = (descStart + descSize + 3) & ~3;
+      }
+    }
+    throw new Error("executable has no NT_GNU_BUILD_ID note");
+  }
+
+  function peCodeViewGuid(fd: number): string {
+    const peOffset = readAt(fd, 0x3c, 4).readUInt32LE(0);
+    const fileHeader = readAt(fd, peOffset, 24);
+    expect(fileHeader.toString("latin1", 0, 4)).toBe("PE\0\0");
+    const sectionCount = fileHeader.readUInt16LE(6);
+    const optionalHeaderSize = fileHeader.readUInt16LE(20);
+    const optionalHeader = readAt(fd, peOffset + 24, optionalHeaderSize);
+    expect(optionalHeader.readUInt16LE(0)).toBe(0x20b); // PE32+
+    // Data directory 6 is IMAGE_DIRECTORY_ENTRY_DEBUG.
+    const debugRva = optionalHeader.readUInt32LE(112 + 6 * 8);
+    const debugSize = optionalHeader.readUInt32LE(112 + 6 * 8 + 4);
+    const sections = readAt(fd, peOffset + 24 + optionalHeaderSize, sectionCount * 40);
+    let debugOffset = -1;
+    for (let n = 0; n < sectionCount; n++) {
+      const section = sections.subarray(n * 40);
+      const virtualAddress = section.readUInt32LE(12);
+      if (debugRva >= virtualAddress && debugRva < virtualAddress + section.readUInt32LE(16)) {
+        debugOffset = debugRva - virtualAddress + section.readUInt32LE(20);
+      }
+    }
+    expect(debugOffset).not.toBe(-1);
+    const entries = readAt(fd, debugOffset, debugSize);
+    for (let off = 0; off + 28 <= entries.length; off += 28) {
+      if (entries.readUInt32LE(off + 12) !== 2 /* IMAGE_DEBUG_TYPE_CODEVIEW */) continue;
+      // PointerToRawData is a file offset; the crash handler uses the RVA next to it.
+      const codeView = readAt(fd, entries.readUInt32LE(off + 24), 20);
+      expect(codeView.toString("latin1", 0, 4)).toBe("RSDS");
+      const g = codeView.subarray(4, 20);
+      // The first three GUID fields are little-endian in the file; tools print them big-endian.
+      return Buffer.from([g[3], g[2], g[1], g[0], g[5], g[4], g[7], g[6], ...g.subarray(8, 16)]).toString("hex");
+    }
+    throw new Error("executable has no CodeView debug directory entry");
+  }
+
+  function machoUuid(fd: number): string {
+    const header = readAt(fd, 0, 32);
+    const commands = readAt(fd, 32, header.readUInt32LE(20));
+    for (let n = 0, off = 0; n < header.readUInt32LE(16); n++, off += commands.readUInt32LE(off + 4)) {
+      if (commands.readUInt32LE(off) === 0x1b /* LC_UUID */) return commands.toString("hex", off + 8, off + 24);
+    }
+    throw new Error("executable has no LC_UUID load command");
+  }
+
+  test.each(["panic", "segfault"])("%s: the trace string carries this executable's debug id", async approach => {
+    const payload = await tracePayload(approach);
+    const { revision, is_canary } = crash_handler.getFeatureData();
+
+    let i = 2; // platform char, command char
+    expect(payload[i++]).toBe("4");
+    expect(payload.slice(i, i + 7)).toBe(revision ? revision.slice(0, 7) : "unknown");
+    i += 7;
+
+    let buildFlags: number;
+    [buildFlags, i] = vlq(payload, i);
+    expect(buildFlags).toBe(is_canary ? 1 : 0);
+
+    let idLength: number;
+    [idLength, i] = vlq(payload, i);
+    const expectedId = debugIdOfExecutable(bunExe());
+    expect(idLength).toBe(expectedId.length / 2);
+    expect(payload.slice(i, i + 2 * idLength)).toBe(expectedId);
+    i += 2 * idLength;
+
+    // Everything after the new fields must still be where the decoder expects
+    // it: features, the frame list, and a reason whose payload round-trips.
+    [, i] = vlq(payload, i);
+    [, i] = vlq(payload, i);
+    for (;;) {
+      if (payload[i] === "_") {
+        i++;
+        continue;
+      }
+      let address: number;
+      [address, i] = vlq(payload, i);
+      if (address === 0) break;
+      if (address === 1) {
+        let nameLength: number;
+        [nameLength, i] = vlq(payload, i);
+        i += nameLength;
+        [, i] = vlq(payload, i);
+      }
+    }
+
+    if (approach === "panic") {
+      expect(payload[i++]).toBe("0");
+      expect(inflateSync(Buffer.from(payload.slice(i), "base64")).toString()).toContain(
+        "invoked crashByPanic() handler",
+      );
+    } else {
+      expect(payload[i++]).toBe("2");
+      const [faultAddress, end] = u64(payload, i);
+      expect(faultAddress).toBe(0xdeadbeefn);
+      expect(payload.slice(end)).toBe("");
+    }
+  });
 });
 
 test.if(isWindows)(

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -550,11 +550,14 @@ describe("automatic crash reporter", () => {
   }
 });
 
-// One commit can be published as several links of the same platform (x64 and
-// x64-baseline), so after the sha the trace string carries the id the linker
-// stamped into the executable. Layout (`encode_trace_string` in src/crash_handler/lib.rs):
+// One commit is published as several links with the same platform char (the
+// glibc, musl and android builds all report 'l'), so after the sha the trace
+// string carries a header with the id the linker stamped into the executable.
+// Layout (`encode_trace_string` in src/crash_handler/lib.rs):
 //
-//   {platform}{command}4{sha7}{build flags VLQ}{id byte count VLQ}{id hex}{features 2 VLQs}{frames}A{reason}
+//   {platform}{command}4{sha7}{field count VLQ}({tag VLQ}{char count VLQ}{chars})*{features 2 VLQs}{frames}A{reason}
+//
+// Tags: 0 = build flags (one VLQ, bit 0 = canary), 1 = debug id (lowercase hex).
 describe.concurrent("trace string identifies the build", () => {
   async function tracePayload(approach: string): Promise<string> {
     using server = Bun.serve({ port: 0, fetch: () => new Response("OK") });
@@ -707,19 +710,26 @@ describe.concurrent("trace string identifies the build", () => {
     expect(payload.slice(i, i + 7)).toBe(revision ? revision.slice(0, 7) : "unknown");
     i += 7;
 
-    let buildFlags: number;
-    [buildFlags, i] = vlq(payload, i);
-    expect(buildFlags).toBe(is_canary ? 1 : 0);
+    let fieldCount: number;
+    [fieldCount, i] = vlq(payload, i);
+    const fields: [tag: number, chars: string][] = [];
+    for (let n = 0; n < fieldCount; n++) {
+      let tag: number, length: number;
+      [tag, i] = vlq(payload, i);
+      [length, i] = vlq(payload, i);
+      expect(i + length).toBeLessThanOrEqual(payload.length);
+      fields.push([tag, payload.slice(i, i + length)]);
+      i += length;
+    }
+    expect(fields).toEqual([
+      [0, expect.stringMatching(/^[A-Za-z0-9+/]+$/)],
+      [1, debugIdOfExecutable(bunExe())],
+    ]);
+    // The build-flags payload is exactly one VLQ.
+    expect(vlq(fields[0][1], 0)).toEqual([is_canary ? 1 : 0, fields[0][1].length]);
 
-    let idLength: number;
-    [idLength, i] = vlq(payload, i);
-    const expectedId = debugIdOfExecutable(bunExe());
-    expect(idLength).toBe(expectedId.length / 2);
-    expect(payload.slice(i, i + 2 * idLength)).toBe(expectedId);
-    i += 2 * idLength;
-
-    // Everything after the new fields must still be where the decoder expects
-    // it: features, the frame list, and a reason whose payload round-trips.
+    // Everything after the header must still be where the decoder expects it:
+    // features, the frame list, and a reason whose payload round-trips.
     [, i] = vlq(payload, i);
     [, i] = vlq(payload, i);
     for (;;) {

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -790,12 +790,13 @@ test.if(isWindows)(
       });
       const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
-      /// Wait two seconds for a slow http request, or continue immediately once the request is heard.
-      await Promise.race([acked.promise, Bun.sleep(2000)]);
-
       expect(stderr).toContain(server.url.toString());
-      expect(sent).toBe(true);
       expect(exitCode).not.toBe(0);
+
+      // Await the ack like the auto-reporter tests above do: PowerShell's cold
+      // start alone takes longer than 2s on the slower Windows agents.
+      await acked.promise;
+      expect(sent).toBe(true);
     } finally {
       try {
         rmSync(String(dir), { recursive: true, force: true, maxRetries: 20, retryDelay: 250 });

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -550,14 +550,9 @@ describe("automatic crash reporter", () => {
   }
 });
 
-// A trace string names the build it came from. The sha alone is not enough:
-// one commit can be published as more than one link of the same platform
-// (the x64 and x64-baseline zips, or a re-run of the release step), and
-// bun.report symbolizing against the wrong link's debug info produces
-// plausible-looking nonsense. So after the sha the string carries the id the
-// linker stamped into the executable and its debug info. Layout (must stay in
-// sync with `encode_trace_string` in src/crash_handler/lib.rs and bun.report's
-// lib/parser.ts):
+// One commit can be published as several links of the same platform (x64 and
+// x64-baseline), so after the sha the trace string carries the id the linker
+// stamped into the executable. Layout (`encode_trace_string` in src/crash_handler/lib.rs):
 //
 //   {platform}{command}4{sha7}{build flags VLQ}{id byte count VLQ}{id hex}{features 2 VLQs}{frames}A{reason}
 describe.concurrent("trace string identifies the build", () => {


### PR DESCRIPTION
Blocked on oven-sh/bun.report#31 (the decoder) being deployed first; see Landing order below.

### Problem
- A trace string identifies the build it came from by the platform character and the 7-character sha (`encode_trace_string`, src/crash_handler/lib.rs). That is not a binary. `Platform::CURRENT` only encodes os and arch, so the glibc, musl and android builds of a commit all report `'l'`/`'L'`, while .buildkite/scripts/upload-release.sh publishes all three per arch (`bun-linux-x64-profile.zip`, `-musl-profile.zip`, `-android-profile.zip`), and bun.report downloads the glibc one for every `'l'` trace. Every musl or android crash report is remapped against a different binary's symbols today, and the output looks like a normal remap.
- The same failure with a separately built `-baseline` binary is where the Windows x64 reports a downstream build of commit `8bb8d04c4` sends come from (BUN-4B1Q, BUN-4BST, BUN-4B64, BUN-4BW6, BUN-4B2Y, about 60 events a day): both of its Windows x64 links report `'w'`, and symbolized against the first link's PDB every frame lands mid-instruction and the groups read as date/time-zone crashes; against the right PDB they are a GC marking-thread crash and an `Intl.Segmenter` crash (evidence in #38789). Upstream CI has shipped one x64 binary under both names since #34782, so re-emitting the old baseline platform characters would fix neither case.

### Fix
- Trace format `'4'`: after the sha, a header of tagged fields: a VLQ field count, then per field a VLQ tag, a VLQ character count and that many characters (`HeaderField`, `write_header_field`). Tag 0 is the build flags VLQ (bit 0 = canary, replacing the `'1'`/`'2'` version-character split), tag 1 the executable's debug id in lowercase hex, omitted when the executable has none. Everything after the header is unchanged.
- The id is read in the crash handler from the loader-mapped image headers (src/crash_handler/debug_id.rs): the PDB GUID of the PE CodeView record on Windows, the `NT_GNU_BUILD_ID` note on ELF, `LC_UUID` on Mach-O. Every offset is bounds-checked and nothing allocates. The bytes are emitted in the order the platform's tools print them, so the hex in a URL compares directly with `readelf -n`, `llvm-readobj --coff-debug-directory` / `dumpbin`, or `dwarfdump --uuid` output.
- Why the id: it is the one value the linker writes into both the executable and its debug file, so it names exactly the build a trace came from whatever the artifacts are called and however many of them a commit has. With it, bun.report#31 checks the debug file it downloaded and tries the commit's other builds for the same platform character (musl, android, a separate baseline) until one carries the id, and leaves the frames raw, tagged, when none does; a triager can also tell from the URL alone which build a report belongs to.
- Why tagged fields: this would otherwise be the third version-character bump in five months to add one field after the sha (two register-block attempts, then this), each needing its own decoder deploy before the emitter could ship. Decoders skip tags they do not know, so the next field (registers, for instance) is an append here and a later decoder change, with no new version character and no ordering constraint. Only this one bump has to be sequenced. Cost: four characters per trace over a fixed layout.
- Also in test/cli/run/run-crash-handler.test.ts: the pre-existing system-PowerShell upload test awaits the ack instead of racing a 2s sleep (same change as #36550). On the Windows 2019 agents without AVX PowerShell takes longer than 2s to start, so that test failed on every run of this file there, including this PR's first two CI runs, while the new tests and the auto-reporter tests passed.
- Landing order: oven-sh/bun.report#31 has to be deployed before this merges, or new canaries' reports stop parsing. The in-repo consumer is the `bun-tracestrings` pin in package.json that `scripts/runner.node.mjs` uses for the CI remap server (already a year behind: it predates the `'a'`/`'b'` reasons and the FreeBSD characters); it gets bumped to the bun.report commit in this PR once #31 lands, so both consumers switch in the same merge. Open PRs whose tests decode trace strings positionally (#38789, #37533) will need to read past the header once this lands; #37569 changes the `LoadCommandIterator` API debug_id.rs uses, so whichever lands second adapts.
- Verified:
  - test/cli/run/run-crash-handler.test.ts, `trace string identifies the build`: crashes via `panic` and `segfault`, checks the version character and sha, decodes the header generically and requires exactly a build-flags field matching `getFeatureData().is_canary` and a debug-id field equal to an independent read of the executable file (ELF program headers, PE debug directory via `PointerToRawData` where the handler uses the RVA, Mach-O load commands), then decodes the features, frame list and reason payload to show nothing after the header moved. Fails on the current build (`Expected: "4", Received: "2"`), passes with `bun bd test` (debug + ASAN) on Linux x64.
  - Windows x64 debug build (fixed-layout revision of the header; the PE reader is unchanged since): the test passes, and the id in an emitted trace (`944668034eead8624c4c44205044422e`) equals the `PDBGUID` llvm-readobj prints for `bun-debug.exe` and the `GUID` llvm-pdbutil prints for `bun-debug.pdb`. The darwin CI lanes passed the test as well, covering the Mach-O reader.
  - Linux x64 debug build: the id in an emitted trace equals the `Build ID` line of `readelf -n`; the stripped release binary carries the same note as `bun-profile` (`-Wl,--build-id=sha1` is unconditional in scripts/build/flags.ts), which is what lets bun.report match a user's binary to the profile artifact. The trace from this build is a parse fixture in bun.report#31.
  - `cargo check -p bun_crash_handler` for the linux, windows-msvc, apple-darwin, freebsd and android targets; `cargo clippy` clean on linux.

### Background
- Trace string: the `https://bun.report/<version>/<payload>` URL the crash handler prints and uploads. The payload is positional: platform character, command character, format version character, 7-character sha, then VLQ-encoded fields (features bitset, image-relative frame addresses, reason). bun.report's `lib/parser.ts` decodes it and downloads the commit's debug file to symbolize the addresses; `scripts/runner.node.mjs` runs the same decoder locally against the binary under test.
- VLQ: the base64 variable-length integer encoding source maps use; every number in the payload is one, which is why new data cannot be inserted without a version character the decoder knows.
- Debug id: the per-link identifier a linker stores in both the executable and its debug info so debuggers can pair them. PE keeps a GUID in a CodeView (`RSDS`) record referenced from the debug data directory and repeats it in the PDB; ELF keeps a hash of the output in a `.note.gnu.build-id` note inside a `PT_NOTE` segment; Mach-O keeps a UUID in an `LC_UUID` load command that the dSYM repeats. All three live in the image headers, which the loader maps read-only, so they can be read after a crash without trusting heap state.
- Builds per commit: upstream publishes glibc, musl and android builds per Linux arch, plus `-baseline` copies of the x64 zips that have been the same binary since #34782 (they used to be a separate no-AVX build with its own platform characters, and some downstream trees still build one).
