### PR TITLE
docs(pm): add the missing flags to the bun install and bun add flag references

### DIFF
--- a/docs/snippets/cli/add.mdx
+++ b/docs/snippets/cli/add.mdx
@@ -100,6 +100,14 @@ bun add <package> <@version>
   <code>-a</code>
 </ParamField>
 
+<ParamField path="--linker" type="string">
+  Linker strategy (one of <code>isolated</code> or <code>hoisted</code>)
+</ParamField>
+
+<ParamField path="--minimum-release-age" type="number">
+  Only install package versions published at least this many seconds ago
+</ParamField>
+
 ### Network & Registry
 
 <ParamField path="--ca" type="string">
@@ -156,6 +164,18 @@ bun add <package> <@version>
 
 <ParamField path="--no-summary" type="boolean">
   Don't print a summary
+</ParamField>
+
+### Platform Targeting
+
+<ParamField path="--cpu" type="string">
+  Override CPU architecture for optional dependencies (e.g., <code>x64</code>, <code>arm64</code>, <code>*</code> for
+  all)
+</ParamField>
+
+<ParamField path="--os" type="string">
+  Override operating system for optional dependencies (e.g., <code>linux</code>, <code>darwin</code>, <code>*</code> for
+  all)
 </ParamField>
 
 ### Global Configuration &amp; Context

--- a/docs/snippets/cli/install.mdx
+++ b/docs/snippets/cli/install.mdx
@@ -54,6 +54,11 @@ bun install <name>@<version>
   Add the exact version instead of the ^ range
 </ParamField>
 
+<ParamField path="--catalog" type="string">
+  Add the resolved version to the root <code>package.json</code> catalog and depend on it as <code>catalog:</code>;{" "}
+  <code>--catalog=NAME</code> targets <code>catalogs.NAME</code>
+</ParamField>
+
 ### Lockfile Control
 
 <ParamField path="--yarn" type="boolean">
@@ -104,12 +109,28 @@ bun install <name>@<version>
   Platform-specific optimizations: "clonefile", "hardlink", "symlink", "copyfile"
 </ParamField>
 
+<ParamField path="--linker" type="string">
+  Linker strategy (one of <code>isolated</code> or <code>hoisted</code>)
+</ParamField>
+
 <ParamField path="--filter" type="string">
   Install packages for the matching workspaces
 </ParamField>
 
 <ParamField path="--analyze" type="boolean">
   Recursively analyze & install all dependencies of files passed as arguments
+</ParamField>
+
+### Platform Targeting
+
+<ParamField path="--cpu" type="string">
+  Override CPU architecture for optional dependencies (e.g., <code>x64</code>, <code>arm64</code>, <code>*</code> for
+  all)
+</ParamField>
+
+<ParamField path="--os" type="string">
+  Override operating system for optional dependencies (e.g., <code>linux</code>, <code>darwin</code>, <code>*</code> for
+  all)
 </ParamField>
 
 ### Caching Options
@@ -148,6 +169,10 @@ bun install <name>@<version>
 
 <ParamField path="--trust" type="boolean">
   Add to trustedDependencies in the project's package.json and install the package(s)
+</ParamField>
+
+<ParamField path="--minimum-release-age" type="number">
+  Only install package versions published at least this many seconds ago
 </ParamField>
 
 ### Concurrency & Performance


### PR DESCRIPTION
### Problem
- `docs/snippets/cli/install.mdx`, the flag reference rendered on the `bun install` page, does not list `--linker`, `--minimum-release-age`, `--cpu`, `--os` or `--catalog`. All five are printed by `bun install --help` (`SHARED_TAIL_PARAMS` and `INSTALL_PARAMS` in `src/install/PackageManager/CommandLineArguments.rs`) and work.
- `docs/snippets/cli/add.mdx` has the same gap for `--linker`, `--minimum-release-age`, `--cpu` and `--os` (it already documents `--catalog`).
- The `link` and `patch` snippets already carry `--linker`, `--cpu` and `--os`, so the two pages where these flags matter most were the ones missing them.

### Fix
- Add the missing `ParamField` entries to both snippets, using the wording the `link`/`patch` snippets and `--help` already use. `--cpu` / `--os` go in a `Platform Targeting` section like the other snippets; `--catalog` sits next to `--exact`, `--linker` next to `--backend`, `--minimum-release-age` under the security flags.
- Docs only; no code or behavior change. Checked the flags against `bun install --help` and `bun add --help` on current main, and ran prettier on both files.
- The entries are placed away from the lines touched by the open #38759 (`--network-concurrency` default) and #36977 (`--offline`), so the branches merge independently.

### Background
- `docs/snippets/cli/*.mdx` are included at the top of the matching `docs/pm/cli/*.mdx` pages and are the per-command flag tables; the prose sections for the linker, minimum release age and `--cpu`/`--os` further down the install page already existed, only the table was incomplete.
