### PR TITLE
Tidy: fold duplicated matches into one method, drop dead state (no behavior change)

### DIFF
--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -568,12 +568,7 @@ pub(crate) fn format_utf16_type_with_path_options(
         } else {
             let mut ptr = to_write;
             while let Some(i) = crate::strings::index_of_any(ptr, b"\\/") {
-                let sep = match opts.path_sep {
-                    PathSep::Windows => b'\\',
-                    PathSep::Posix => b'/',
-                    PathSep::Auto => crate::SEP,
-                    PathSep::Any => ptr[i],
-                };
+                let sep = opts.path_sep.apply(ptr[i]);
                 write_bytes(writer, &ptr[..i])?;
                 writer.write_char(sep as char)?;
                 if opts.escape_backslashes && sep == b'\\' {
@@ -626,12 +621,7 @@ impl Display for FormatUTF8<'_> {
 
             let mut ptr = self.buf;
             while let Some(i) = crate::strings::index_of_any(ptr, b"\\/") {
-                let sep = match opts.path_sep {
-                    PathSep::Windows => b'\\',
-                    PathSep::Posix => b'/',
-                    PathSep::Auto => crate::SEP,
-                    PathSep::Any => ptr[i],
-                };
+                let sep = opts.path_sep.apply(ptr[i]);
                 write!(f, "{}", bstr::BStr::new(&ptr[..i]))?;
                 f.write_char(sep as char)?;
                 if opts.escape_backslashes && sep == b'\\' {
@@ -674,6 +664,17 @@ pub enum PathSep {
     Posix,
     /// Replace all path separators with `\`.
     Windows,
+}
+
+impl PathSep {
+    fn apply(self, found: u8) -> u8 {
+        match self {
+            PathSep::Windows => b'\\',
+            PathSep::Posix => b'/',
+            PathSep::Auto => crate::SEP,
+            PathSep::Any => found,
+        }
+    }
 }
 
 #[cfg(windows)]

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -148,6 +148,16 @@ pub(crate) enum ResultValue {
     Empty { source_index: Index },
 }
 
+impl ResultValue {
+    pub(crate) fn source_index(&self) -> u32 {
+        match self {
+            ResultValue::Empty { source_index } => source_index.get(),
+            ResultValue::Err(data) => data.source_index.get(),
+            ResultValue::Success(val) => val.source.index.0,
+        }
+    }
+}
+
 pub(crate) struct WatcherData {
     pub(crate) fd: Fd,
     pub(crate) dir_fd: Fd,

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2658,14 +2658,10 @@ pub mod bv2_impl {
             task.task.node.next = core::ptr::null_mut();
             task.tree_shaking = self.linker.options.tree_shaking;
             task.known_target = target;
-            {
-                let t = self.transpiler_for_target(target);
-                task.jsx.development = match t.options.force_node_env {
-                    options::ForceNodeEnv::Development => true,
-                    options::ForceNodeEnv::Production => false,
-                    options::ForceNodeEnv::Unspecified => t.options.jsx.development,
-                };
-            }
+            task.jsx.development = self
+                .transpiler_for_target(target)
+                .options
+                .forced_jsx_development();
 
             // Handle onLoad plugins as entry points
             if !self.enqueue_on_load_plugin_if_needed(task) {
@@ -2768,14 +2764,10 @@ pub mod bv2_impl {
             task.tree_shaking = self.linker.options.tree_shaking;
             task.is_entry_point = is_entry_point;
             task.known_target = target;
-            {
-                let bundler = self.transpiler_for_target(target);
-                task.jsx.development = match bundler.options.force_node_env {
-                    options::ForceNodeEnv::Development => true,
-                    options::ForceNodeEnv::Production => false,
-                    options::ForceNodeEnv::Unspecified => bundler.options.jsx.development,
-                };
-            }
+            task.jsx.development = self
+                .transpiler_for_target(target)
+                .options
+                .forced_jsx_development();
 
             // Handle onLoad plugins as entry points
             if !self.enqueue_on_load_plugin_if_needed(task) {
@@ -6218,13 +6210,7 @@ pub mod bv2_impl {
                         resolve_task.known_target = target;
                         // Use transpiler JSX options, applying force_node_env like the disk path does
                         resolve_task.jsx = transpiler.options.jsx.clone();
-                        resolve_task.jsx.development = match transpiler.options.force_node_env {
-                            options::ForceNodeEnv::Development => true,
-                            options::ForceNodeEnv::Production => false,
-                            options::ForceNodeEnv::Unspecified => {
-                                transpiler.options.jsx.development
-                            }
-                        };
+                        resolve_task.jsx.development = transpiler.options.forced_jsx_development();
                         resolve_task.loader = Some(import_record_loader);
                         resolve_task.tree_shaking = transpiler.options.tree_shaking;
                         resolve_task.side_effects = bun_ast::SideEffects::HasSideEffects;
@@ -6591,11 +6577,7 @@ pub mod bv2_impl {
                 };
 
                 resolve_task.jsx = resolve_result.jsx.clone();
-                resolve_task.jsx.development = match transpiler.options.force_node_env {
-                    options::ForceNodeEnv::Development => true,
-                    options::ForceNodeEnv::Production => false,
-                    options::ForceNodeEnv::Unspecified => transpiler.options.jsx.development,
-                };
+                resolve_task.jsx.development = transpiler.options.forced_jsx_development();
 
                 resolve_task.loader = Some(import_record_loader);
                 resolve_task.tree_shaking = transpiler.options.tree_shaking;

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -6940,11 +6940,7 @@ pub mod bv2_impl {
             // across the `this.*` method calls below (each takes
             // `&mut BundleV2`), so re-borrow `this.graph` at each use site instead.
             if parse_result.external.function.is_some() {
-                let source = match &parse_result.value {
-                    parse_task::ResultValue::Empty { source_index } => source_index.get(),
-                    parse_task::ResultValue::Err(data) => data.source_index.get(),
-                    parse_task::ResultValue::Success(val) => val.source.index.0,
-                };
+                let source = parse_result.value.source_index();
                 let loader: Loader = this.graph.input_files.items_loader()[source as usize];
                 // `InputFile.arena` column dropped in the Rust port;
                 // stash the finalizer regardless so plugin-owned bytes are freed.
@@ -6974,11 +6970,7 @@ pub mod bv2_impl {
             // To minimize contention, watchers are appended on the bundle thread.
             if this.bun_watcher.is_some() {
                 if parse_result.watcher_data.fd != bun_sys::Fd::INVALID {
-                    let source_index = match &parse_result.value {
-                        parse_task::ResultValue::Empty { source_index } => source_index.get(),
-                        parse_task::ResultValue::Err(data) => data.source_index.get(),
-                        parse_task::ResultValue::Success(val) => val.source.index.0,
-                    };
+                    let source_index = parse_result.value.source_index();
                     // borrowck — read source path/loader before
                     // `should_add_watcher(&self)` so the column borrow is released.
                     let source_path = this.graph.input_files.items_source()[source_index as usize]

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -1361,6 +1361,14 @@ impl<'a> BundleOptions<'a> {
         }
     }
 
+    pub(crate) fn forced_jsx_development(&self) -> bool {
+        match self.force_node_env {
+            ForceNodeEnv::Development => true,
+            ForceNodeEnv::Production => false,
+            ForceNodeEnv::Unspecified => self.jsx.development,
+        }
+    }
+
     /// Per-worker deep clone — replaces the prior bitwise
     /// `ptr::copy_nonoverlapping` of the parent `Transpiler` (which aliased
     /// every `Box`/`Vec` in here between parent and worker; reassigning any of

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -2708,48 +2708,16 @@ impl<'a> Transpiler<'a> {
 
         // Only the main-thread transpiler reaches here; worker option clones
         // carry `output_dir_handle: None` and would route output to stdout.
-        if self.options.output_dir_handle.is_none() {
-            let outstream = TransformOutstream::Stdout;
-            match self.options.import_path_format {
-                options::ImportPathFormat::Relative => {
-                    self.process_resolve_queue(options::ImportPathFormat::Relative, outstream)?;
-                }
-                options::ImportPathFormat::AbsoluteUrl => {
-                    self.process_resolve_queue(options::ImportPathFormat::AbsoluteUrl, outstream)?;
-                }
-                options::ImportPathFormat::AbsolutePath => {
-                    self.process_resolve_queue(options::ImportPathFormat::AbsolutePath, outstream)?;
-                }
-                options::ImportPathFormat::PackagePath => {
-                    self.process_resolve_queue(options::ImportPathFormat::PackagePath, outstream)?;
-                }
-            }
-        } else {
-            let Some(output_dir) = self
-                .options
-                .output_dir_handle
-                .as_ref()
-                .map(bun_sys::Dir::fd)
-            else {
-                bun_core::Output::print_error("Invalid or missing output directory.");
-                bun_core::Global::crash();
-            };
-            let outstream = TransformOutstream::Dir(output_dir);
-            match self.options.import_path_format {
-                options::ImportPathFormat::Relative => {
-                    self.process_resolve_queue(options::ImportPathFormat::Relative, outstream)?;
-                }
-                options::ImportPathFormat::AbsoluteUrl => {
-                    self.process_resolve_queue(options::ImportPathFormat::AbsoluteUrl, outstream)?;
-                }
-                options::ImportPathFormat::AbsolutePath => {
-                    self.process_resolve_queue(options::ImportPathFormat::AbsolutePath, outstream)?;
-                }
-                options::ImportPathFormat::PackagePath => {
-                    self.process_resolve_queue(options::ImportPathFormat::PackagePath, outstream)?;
-                }
-            }
-        }
+        let outstream = match self
+            .options
+            .output_dir_handle
+            .as_ref()
+            .map(bun_sys::Dir::fd)
+        {
+            None => TransformOutstream::Stdout,
+            Some(output_dir) => TransformOutstream::Dir(output_dir),
+        };
+        self.process_resolve_queue(self.options.import_path_format, outstream)?;
 
         if bun_core::FeatureFlags::TRACING
             && self.options.log().level.at_least(bun_ast::Level::Info)

--- a/src/css/selectors/parser.rs
+++ b/src/css/selectors/parser.rs
@@ -1659,61 +1659,45 @@ impl<Impl: BunSelectorImpl> GenericSelectorList<Impl> {
         recovery: ParseErrorRecovery,
         nesting_requirement: NestingRequirement,
     ) -> CResult<Self> {
-        let original_state = *state;
-        let mut values: SmallList<GenericSelector<Impl>, 1> = SmallList::default();
-
-        loop {
-            // For borrowck, the closure captures a local `saw_nesting` flag
-            // and applies it to `state` after it returns (no raw `*mut`).
-            let mut saw_nesting = false;
-            let selector =
-                input.parse_until_before(css::Delimiters::COMMA, |input2: &mut CssParser| {
-                    let mut selector_state = original_state;
-                    let result = parse_selector::<Impl>(
-                        parser,
-                        input2,
-                        &mut selector_state,
-                        nesting_requirement,
-                    );
-                    if selector_state.contains(SelectorParsingState::AFTER_NESTING) {
-                        saw_nesting = true;
-                    }
-                    result
-                });
-            if saw_nesting {
-                state.insert(SelectorParsingState::AFTER_NESTING);
-            }
-
-            let was_ok = selector.is_ok();
-            match selector {
-                Ok(sel) => {
-                    values.append(sel);
-                }
-                Err(e) => match recovery {
-                    ParseErrorRecovery::DiscardList => return Err(e),
-                    ParseErrorRecovery::IgnoreInvalidSelector => {}
-                },
-            }
-
-            if let Ok(tok) = input.next() {
-                if matches!(tok, Token::Comma) {
-                    continue;
-                }
-                // Shouldn't have got a selector if getting here.
-                debug_assert!(!was_ok);
-            }
-            return Ok(Self { v: values });
-        }
+        Self::parse_list_with_state(
+            parser,
+            input,
+            state,
+            recovery,
+            nesting_requirement,
+            parse_selector::<Impl>,
+        )
     }
 
-    // Same shape as `parse_with_state()` but parses each item with
-    // `parse_relative_selector()` instead of `parse_selector()`.
     pub(crate) fn parse_relative_with_state(
         parser: &mut SelectorParser,
         input: &mut CssParser,
         state: &mut SelectorParsingState,
         recovery: ParseErrorRecovery,
         nesting_requirement: NestingRequirement,
+    ) -> CResult<Self> {
+        Self::parse_list_with_state(
+            parser,
+            input,
+            state,
+            recovery,
+            nesting_requirement,
+            parse_relative_selector::<Impl>,
+        )
+    }
+
+    fn parse_list_with_state(
+        parser: &mut SelectorParser,
+        input: &mut CssParser,
+        state: &mut SelectorParsingState,
+        recovery: ParseErrorRecovery,
+        nesting_requirement: NestingRequirement,
+        parse_one: fn(
+            &mut SelectorParser,
+            &mut CssParser,
+            &mut SelectorParsingState,
+            NestingRequirement,
+        ) -> CResult<GenericSelector<Impl>>,
     ) -> CResult<Self> {
         let original_state = *state;
         let mut values: SmallList<GenericSelector<Impl>, 1> = SmallList::default();
@@ -1725,12 +1709,8 @@ impl<Impl: BunSelectorImpl> GenericSelectorList<Impl> {
             let selector =
                 input.parse_until_before(css::Delimiters::COMMA, |input2: &mut CssParser| {
                     let mut selector_state = original_state;
-                    let result = parse_relative_selector::<Impl>(
-                        parser,
-                        input2,
-                        &mut selector_state,
-                        nesting_requirement,
-                    );
+                    let result =
+                        parse_one(parser, input2, &mut selector_state, nesting_requirement);
                     if selector_state.contains(SelectorParsingState::AFTER_NESTING) {
                         saw_nesting = true;
                     }

--- a/src/css/values/color.rs
+++ b/src/css/values/color.rs
@@ -1470,11 +1470,7 @@ pub(crate) fn parse_number_or_percentage(
     input: &mut css::Parser,
     parser: &ComponentParser,
 ) -> CssResult<f32> {
-    let result = parser.parse_number_or_percentage(input)?;
-    Ok(match result {
-        NumberOrPercentage::Number { value } => value,
-        NumberOrPercentage::Percentage { unit_value } => unit_value,
-    })
+    Ok(parser.parse_number_or_percentage(input)?.unit_value())
 }
 
 impl LABColor {

--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -1195,14 +1195,11 @@ impl<'a> PackageInstall<'a> {
             &[]
         };
 
-        state.walker = Some(
-            walker_skippable::walk(
-                state.cached_package_dir.fd(),
-                &[] as &[&OSPathSlice],
-                skip_dirs,
-            )
-            .expect("oom"), // bun.handleOom
-        );
+        state.walker = Some(bun_core::handle_oom(walker_skippable::walk(
+            state.cached_package_dir.fd(),
+            &[] as &[&OSPathSlice],
+            skip_dirs,
+        )));
         state.walker.as_mut().unwrap().resolve_unknown_entry_types = true;
 
         #[cfg(not(windows))]

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2900,10 +2900,7 @@ fn locked_version_in_lockfile<'a>(
         return None;
     }
     let lockfile: &Lockfile::Lockfile = &this.lockfile;
-    let candidates: &[PackageID] = match lockfile.package_index.get(&name_hash)? {
-        PackageIndexEntry::Id(id) => core::slice::from_ref(id),
-        PackageIndexEntry::Ids(ids) => ids.as_slice(),
-    };
+    let candidates = lockfile.package_index.get(&name_hash)?.as_slice();
     let pkg_res = lockfile.packages.items_resolution();
     let buf = lockfile.buffers.string_bytes.as_slice();
     let range = &version.npm().version;
@@ -2936,10 +2933,7 @@ fn patched_package_satisfying(
     if lockfile.patched_dependencies.count() == 0 {
         return None;
     }
-    let candidates: &[PackageID] = match lockfile.package_index.get(&name_hash)? {
-        PackageIndexEntry::Id(id) => core::slice::from_ref(id),
-        PackageIndexEntry::Ids(ids) => ids.as_slice(),
-    };
+    let candidates = lockfile.package_index.get(&name_hash)?.as_slice();
     let pkg_res = lockfile.packages.items_resolution();
     let buf = lockfile.buffers.string_bytes.as_slice();
     candidates.iter().copied().find(|&id| {

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2705,24 +2705,7 @@ fn get_or_put_resolved_package(
                 break 'res FolderResolutionValue::NewPackageId(package.meta.id);
             };
 
-            match res {
-                FolderResolutionValue::Err(err) => Err(err),
-                FolderResolutionValue::PackageId(package_id) => {
-                    success_fn(this, dependency_id, package_id);
-                    Ok(Some(ResolvedPackageResult {
-                        package: *this.lockfile.packages.get(package_id as usize),
-                        ..Default::default()
-                    }))
-                }
-                FolderResolutionValue::NewPackageId(package_id) => {
-                    success_fn(this, dependency_id, package_id);
-                    Ok(Some(ResolvedPackageResult {
-                        package: *this.lockfile.packages.get(package_id as usize),
-                        is_first_time: true,
-                        task: None,
-                    }))
-                }
-            }
+            resolved_folder_package(this, res, dependency_id, success_fn)
         }
         dependency::version::Tag::Workspace => {
             if !behavior.is_workspace() && !this.lockfile.is_workspace_dependency(dependency_id) {
@@ -2777,24 +2760,7 @@ fn get_or_put_resolved_package(
                 this,
             );
 
-            match res {
-                FolderResolutionValue::Err(err) => Err(err),
-                FolderResolutionValue::PackageId(package_id) => {
-                    success_fn(this, dependency_id, package_id);
-                    Ok(Some(ResolvedPackageResult {
-                        package: *this.lockfile.packages.get(package_id as usize),
-                        ..Default::default()
-                    }))
-                }
-                FolderResolutionValue::NewPackageId(package_id) => {
-                    success_fn(this, dependency_id, package_id);
-                    Ok(Some(ResolvedPackageResult {
-                        package: *this.lockfile.packages.get(package_id as usize),
-                        is_first_time: true,
-                        task: None,
-                    }))
-                }
-            }
+            resolved_folder_package(this, res, dependency_id, success_fn)
         }
         dependency::version::Tag::Symlink => {
             // reshaped for borrowck — `link_dir` / `symlink_path`
@@ -2816,28 +2782,30 @@ fn get_or_put_resolved_package(
                 this,
             );
 
-            match res {
-                FolderResolutionValue::Err(err) => Err(err),
-                FolderResolutionValue::PackageId(package_id) => {
-                    success_fn(this, dependency_id, package_id);
-                    Ok(Some(ResolvedPackageResult {
-                        package: *this.lockfile.packages.get(package_id as usize),
-                        ..Default::default()
-                    }))
-                }
-                FolderResolutionValue::NewPackageId(package_id) => {
-                    success_fn(this, dependency_id, package_id);
-                    Ok(Some(ResolvedPackageResult {
-                        package: *this.lockfile.packages.get(package_id as usize),
-                        is_first_time: true,
-                        task: None,
-                    }))
-                }
-            }
+            resolved_folder_package(this, res, dependency_id, success_fn)
         }
 
         _ => Ok(None),
     }
+}
+
+fn resolved_folder_package(
+    this: &mut PackageManager,
+    res: FolderResolutionValue,
+    dependency_id: DependencyID,
+    success_fn: SuccessFn,
+) -> crate::Result<Option<ResolvedPackageResult>> {
+    let (package_id, is_first_time) = match res {
+        FolderResolutionValue::Err(err) => return Err(err),
+        FolderResolutionValue::PackageId(package_id) => (package_id, false),
+        FolderResolutionValue::NewPackageId(package_id) => (package_id, true),
+    };
+    success_fn(this, dependency_id, package_id);
+    Ok(Some(ResolvedPackageResult {
+        package: *this.lockfile.packages.get(package_id as usize),
+        is_first_time,
+        task: None,
+    }))
 }
 
 /// `--latest` never moves a row below what bun.lock already has (e.g. a prerelease or a version ahead of the tag).

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -1534,28 +1534,11 @@ fn report_lockfile_load_error(
     if log_level != Options::LogLevel::Silent
         && !crate::migration::reported_unsupported_lockfile_version(cause)
     {
-        match cause.step {
-            lockfile::LoadStep::OpenFile => Output::err(
-                cause.value,
-                "failed to open lockfile: '{}'",
-                format_args!("{}", bstr::BStr::new(&cause.lockfile_path)),
-            ),
-            lockfile::LoadStep::ParseFile => Output::err(
-                cause.value,
-                "failed to parse lockfile: '{}'",
-                format_args!("{}", bstr::BStr::new(&cause.lockfile_path)),
-            ),
-            lockfile::LoadStep::ReadFile => Output::err(
-                cause.value,
-                "failed to read lockfile: '{}'",
-                format_args!("{}", bstr::BStr::new(&cause.lockfile_path)),
-            ),
-            lockfile::LoadStep::Migrating => Output::err(
-                cause.value,
-                "failed to migrate lockfile: '{}'",
-                format_args!("{}", bstr::BStr::new(&cause.lockfile_path)),
-            ),
-        }
+        Output::err(
+            cause.value,
+            "failed to {} lockfile: '{}'",
+            (cause.step.verb(), bstr::BStr::new(&cause.lockfile_path)),
+        );
 
         if !manager.options.enable.fail_early() {
             Output::print_errorln("");

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -161,41 +161,30 @@ pub fn install_with_manager(
                 let mut maybe_root = lockfile::Package::default();
 
                 // SAFETY: `manager.log` is a non-null backref to the CLI log set at init().
-                let root_package_json_entry = match manager
-                    .workspace_package_json_cache
-                    .get_with_path(
+                let root_package_json_entry =
+                    match manager.workspace_package_json_cache.get_with_path(
                         manager.log_mut(),
                         root_package_json_path.as_bytes(),
                         Default::default(),
                     ) {
-                    WorkspacePackageJsonCacheResult::Entry(entry) => entry,
-                    WorkspacePackageJsonCacheResult::ReadErr(err) => {
-                        if manager.log_mut().errors > 0 {
-                            manager
-                                .log_mut()
-                                .print(std::ptr::from_mut(Output::error_writer()))?;
+                        WorkspacePackageJsonCacheResult::Entry(entry) => entry,
+                        WorkspacePackageJsonCacheResult::ReadErr(err) => {
+                            return Err(exit_for_root_package_json(
+                                manager,
+                                err,
+                                "read",
+                                root_package_json_path,
+                            ));
                         }
-                        Output::err(
-                            err,
-                            "failed to read '{}'",
-                            format_args!("{}", bstr::BStr::new(root_package_json_path.as_bytes())),
-                        );
-                        Global::exit(1);
-                    }
-                    WorkspacePackageJsonCacheResult::ParseErr(err) => {
-                        if manager.log_mut().errors > 0 {
-                            manager
-                                .log_mut()
-                                .print(std::ptr::from_mut(Output::error_writer()))?;
+                        WorkspacePackageJsonCacheResult::ParseErr(err) => {
+                            return Err(exit_for_root_package_json(
+                                manager,
+                                err,
+                                "parse",
+                                root_package_json_path,
+                            ));
                         }
-                        Output::err(
-                            err,
-                            "failed to parse '{}'",
-                            format_args!("{}", bstr::BStr::new(root_package_json_path.as_bytes())),
-                        );
-                        Global::exit(1);
-                    }
-                };
+                    };
 
                 // `Source` is not `Copy`, so
                 // clone it (cheap — `Source` is a few `Box<[u8]>` handles) so the
@@ -1883,6 +1872,29 @@ fn record_updating_package_versions(manager: &mut PackageManager) {
     }
 }
 
+/// Returns only when printing the log itself fails; otherwise exits.
+fn exit_for_root_package_json(
+    manager: &PackageManager,
+    err: crate::Error,
+    verb: &str,
+    root_package_json_path: &ZStr,
+) -> crate::Error {
+    if manager.log_mut().errors > 0 {
+        if let Err(print_err) = manager
+            .log_mut()
+            .print(std::ptr::from_mut(Output::error_writer()))
+        {
+            return print_err.into();
+        }
+    }
+    Output::err(
+        err,
+        "failed to {} '{}'",
+        (verb, bstr::BStr::new(root_package_json_path.as_bytes())),
+    );
+    Global::exit(1);
+}
+
 #[cold]
 #[inline(never)]
 fn create_new_lockfile_and_enqueue(
@@ -1928,30 +1940,20 @@ fn create_new_lockfile_and_enqueue(
     ) {
         WorkspacePackageJsonCacheResult::Entry(entry) => entry,
         WorkspacePackageJsonCacheResult::ReadErr(err) => {
-            if manager.log_mut().errors > 0 {
-                manager
-                    .log_mut()
-                    .print(std::ptr::from_mut(Output::error_writer()))?;
-            }
-            Output::err(
+            return Err(exit_for_root_package_json(
+                manager,
                 err,
-                "failed to read '{}'",
-                format_args!("{}", bstr::BStr::new(root_package_json_path.as_bytes())),
-            );
-            Global::exit(1);
+                "read",
+                root_package_json_path,
+            ));
         }
         WorkspacePackageJsonCacheResult::ParseErr(err) => {
-            if manager.log_mut().errors > 0 {
-                manager
-                    .log_mut()
-                    .print(std::ptr::from_mut(Output::error_writer()))?;
-            }
-            Output::err(
+            return Err(exit_for_root_package_json(
+                manager,
                 err,
-                "failed to parse '{}'",
-                format_args!("{}", bstr::BStr::new(root_package_json_path.as_bytes())),
-            );
-            Global::exit(1);
+                "parse",
+                root_package_json_path,
+            ));
         }
     };
 

--- a/src/install/PackageManager/security_scanner.rs
+++ b/src/install/PackageManager/security_scanner.rs
@@ -907,7 +907,6 @@ fn attempt_security_scan_with_retry(
         ipc_reader: BufferedReader::init::<SecurityScanSubprocess>(),
         ipc_data: Vec::new(),
         stderr_data: Vec::new(),
-        has_process_exited: false,
         has_received_ipc: false,
         exit_status: None,
         remaining_fds: 0,
@@ -957,7 +956,6 @@ pub struct SecurityScanSubprocess<'a> {
     ipc_reader: BufferedReader,
     ipc_data: Vec<u8>,
     stderr_data: Vec<u8>,
-    has_process_exited: bool,
     has_received_ipc: bool,
     exit_status: Option<Status>,
     remaining_fds: i8,
@@ -1389,7 +1387,7 @@ impl<'a> SecurityScanSubprocess<'a> {
     }
 
     pub(crate) fn is_done(&self) -> bool {
-        self.has_process_exited && self.remaining_fds == 0
+        self.exit_status.is_some() && self.remaining_fds == 0
     }
 
     pub(crate) fn loop_(&mut self) -> *mut AsyncLoop {
@@ -1413,7 +1411,6 @@ impl<'a> SecurityScanSubprocess<'a> {
     }
 
     pub(crate) fn on_process_exit(&mut self, _: &mut Process, status: Status, _: &Rusage) {
-        self.has_process_exited = true;
         self.exit_status = Some(status);
 
         if !self.has_received_ipc {
@@ -1519,15 +1516,13 @@ impl<'a> SecurityScanSubprocess<'a> {
     ) -> Result<ScanAttemptResult, Error> {
         // `defer { ipc_data.deinit(); stderr_data.deinit(); }` — Vec fields drop with self.
 
-        if self.exit_status.is_none() {
+        let Some(status) = self.exit_status.clone() else {
             Output::err_generic(
                 "Security scanner terminated without an exit status. This is a bug in Bun.",
                 (),
             );
             return Err(crate::Error::SecurityScannerProcessFailedWithoutExitStatus);
-        }
-
-        let status = self.exit_status.clone().unwrap();
+        };
 
         if self.ipc_data.is_empty() {
             match &status {

--- a/src/install/PackageManager/security_scanner.rs
+++ b/src/install/PackageManager/security_scanner.rs
@@ -229,6 +229,43 @@ pub(crate) fn perform_security_scan_after_resolution(
 
     let scan_all =
         manager.subcommand == bun_install::Subcommand::Remove || manager.update_requests.is_empty();
+    scan_installing_scanner_if_needed(
+        manager,
+        security_scanner,
+        scan_all,
+        seeds,
+        command_ctx,
+        original_cwd,
+    )
+}
+
+pub fn perform_security_scan_for_all(
+    manager: &mut PackageManager,
+    command_ctx: CommandContext,
+    original_cwd: &[u8],
+) -> Result<Option<SecurityScanResults>, Error> {
+    let Some(security_scanner) = manager.options.security_scanner else {
+        return Ok(None);
+    };
+
+    scan_installing_scanner_if_needed(
+        manager,
+        security_scanner,
+        true,
+        &[],
+        command_ctx,
+        original_cwd,
+    )
+}
+
+fn scan_installing_scanner_if_needed(
+    manager: &mut PackageManager,
+    security_scanner: &[u8],
+    scan_all: bool,
+    seeds: &[PackageID],
+    command_ctx: CommandContext,
+    original_cwd: &[u8],
+) -> Result<Option<SecurityScanResults>, Error> {
     let result = attempt_security_scan(
         manager,
         security_scanner,
@@ -251,48 +288,6 @@ pub(crate) fn perform_security_scan_after_resolution(
                 security_scanner,
                 scan_all,
                 seeds,
-                command_ctx,
-                original_cwd,
-                true,
-            )?;
-            match retry_result {
-                ScanAttemptResult::Success(scan_results) => Ok(Some(scan_results)),
-                ScanAttemptResult::NeedsInstall(_) => Err(crate::Error::SecurityScannerRetryFailed),
-            }
-        }
-    }
-}
-
-pub fn perform_security_scan_for_all(
-    manager: &mut PackageManager,
-    command_ctx: CommandContext,
-    original_cwd: &[u8],
-) -> Result<Option<SecurityScanResults>, Error> {
-    let Some(security_scanner) = manager.options.security_scanner else {
-        return Ok(None);
-    };
-
-    let result = attempt_security_scan(
-        manager,
-        security_scanner,
-        true,
-        &[],
-        command_ctx,
-        original_cwd,
-    )?;
-    match result {
-        ScanAttemptResult::Success(scan_results) => Ok(Some(scan_results)),
-        ScanAttemptResult::NeedsInstall(pkg_id) => {
-            bun_core::prettyln!("<r><yellow>Attempting to install security scanner from npm...<r>");
-            let log_level = manager.options.log_level;
-            do_partial_install_of_security_scanner(manager, command_ctx, log_level, pkg_id)?;
-            bun_core::prettyln!("<r><green><b>Security scanner installed successfully.<r>");
-
-            let retry_result = attempt_security_scan_with_retry(
-                manager,
-                security_scanner,
-                true,
-                &[],
                 command_ctx,
                 original_cwd,
                 true,

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -228,13 +228,10 @@ fn update_package_json_and_install_with_manager_with_updates(
                 if log_level != LogLevel::Silent
                     && !crate::migration::reported_unsupported_lockfile_version(&cause)
                 {
-                    let what: &str = match cause.step {
-                        crate::lockfile::LoadStep::OpenFile => "open",
-                        crate::lockfile::LoadStep::ReadFile => "read",
-                        crate::lockfile::LoadStep::ParseFile => "parse",
-                        crate::lockfile::LoadStep::Migrating => "migrate",
-                    };
-                    Output::err_generic("failed to {s} lockfile: {s}", (what, cause.value.name()));
+                    Output::err_generic(
+                        "failed to {s} lockfile: {s}",
+                        (cause.step.verb(), cause.value.name()),
+                    );
                     if manager.log_mut().has_errors() {
                         let _ = manager
                             .log_mut()

--- a/src/install/PackageManagerTask.rs
+++ b/src/install/PackageManagerTask.rs
@@ -575,7 +575,7 @@ impl<'a> Task<'a> {
         if this.status == Status::Success {
             if let Some(mut pt) = this.apply_patch_task.take() {
                 // `defer pt.deinit()` → Box<PatchTask> drops at end of this block
-                pt.apply().expect("OOM"); // bun.handleOom → panic on OOM
+                bun_core::handle_oom(pt.apply());
                 // `apply_patch_task` is only ever populated with the Apply
                 // variant (see `new_apply_patch_hash`), so destructure it.
                 let crate::patch_install::Callback::Apply(apply) = &mut pt.callback else {

--- a/src/install/dedupe.rs
+++ b/src/install/dedupe.rs
@@ -7,7 +7,7 @@ use bun_collections::{DynamicBitSet, index_sort};
 use bun_core::{Global, Output, UnwrapOrOom as _, strings};
 
 use crate::lockfile::package::PackageColumns as _;
-use crate::lockfile::{LoadResult, LoadStep, Lockfile, Package, PackageIndexEntry};
+use crate::lockfile::{LoadResult, Lockfile, Package, PackageIndexEntry};
 use crate::package_manager::Options::{Enable, LogLevel};
 use crate::package_manager::ROOT_PACKAGE_JSON_PATH;
 use crate::{
@@ -614,15 +614,6 @@ fn reachable(lockfile: &Lockfile, resolutions: &[PackageID]) -> DynamicBitSet {
     )
 }
 
-fn load_step_verb(step: LoadStep) -> &'static str {
-    match step {
-        LoadStep::OpenFile => "open",
-        LoadStep::ReadFile => "read",
-        LoadStep::ParseFile => "parse",
-        LoadStep::Migrating => "migrate",
-    }
-}
-
 pub fn dedupe_before_install(
     manager: &mut PackageManager,
     load_result: &LoadResult<'_>,
@@ -644,7 +635,7 @@ pub fn dedupe_before_install(
             if !quiet {
                 Output::err_generic(
                     "failed to {s} lockfile: {s}",
-                    (load_step_verb(cause.step), cause.value.name()),
+                    (cause.step.verb(), cause.value.name()),
                 );
                 print_log_errors(manager.log_mut());
             }

--- a/src/install/hosted_git_info.rs
+++ b/src/install/hosted_git_info.rs
@@ -651,6 +651,7 @@ impl<'a> UrlProtocol<'a> {
     }
 }
 
+#[derive(Clone)]
 pub(crate) enum UrlProtocolPairUrl<'a> {
     Managed(Box<[u8]>),
     Unmanaged(&'a [u8]),
@@ -866,24 +867,14 @@ pub(crate) fn correct_url<'a>(
         });
     }
 
-    if col_idx == -1 && matches!(url_proto_pair.protocol, UrlProtocol::Unknown) {
-        // `normalize_protocol` only ever returns `Unmanaged` here, so re-borrow
-        // rather than move; the `Managed` arm clones for completeness.
-        return Ok(UrlProtocolPair {
-            url: match &url_proto_pair.url {
-                UrlProtocolPairUrl::Unmanaged(s) => UrlProtocolPairUrl::Unmanaged(s),
-                UrlProtocolPairUrl::Managed(s) => UrlProtocolPairUrl::Managed(s.clone()),
-            },
-            protocol: UrlProtocol::WellFormed(WellDefinedProtocol::GitPlusSsh),
-        });
-    }
-
+    let protocol = if col_idx == -1 && matches!(url_proto_pair.protocol, UrlProtocol::Unknown) {
+        UrlProtocol::WellFormed(WellDefinedProtocol::GitPlusSsh)
+    } else {
+        url_proto_pair.protocol
+    };
     Ok(UrlProtocolPair {
-        url: match &url_proto_pair.url {
-            UrlProtocolPairUrl::Unmanaged(s) => UrlProtocolPairUrl::Unmanaged(s),
-            UrlProtocolPairUrl::Managed(s) => UrlProtocolPairUrl::Managed(s.clone()),
-        },
-        protocol: url_proto_pair.protocol,
+        url: url_proto_pair.url.clone(),
+        protocol,
     })
 }
 

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -323,6 +323,17 @@ pub enum LoadStep {
     Migrating,
 }
 
+impl LoadStep {
+    pub(crate) fn verb(self) -> &'static str {
+        match self {
+            LoadStep::OpenFile => "open",
+            LoadStep::ReadFile => "read",
+            LoadStep::ParseFile => "parse",
+            LoadStep::Migrating => "migrate",
+        }
+    }
+}
+
 #[derive(Clone, Copy, PartialEq, Eq, Default)]
 pub enum Migrated {
     #[default]

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -2565,6 +2565,15 @@ pub mod package_index {
         Ids(PackageIDList),
     }
 
+    impl Entry {
+        pub(crate) fn as_slice(&self) -> &[PackageID] {
+            match self {
+                Entry::Id(id) => core::slice::from_ref(id),
+                Entry::Ids(ids) => ids.as_slice(),
+            }
+        }
+    }
+
     impl Default for Entry {
         /// `HashMap::get_or_put` needs a `Default` to fill the value slot before
         /// the caller writes the real `Entry::Id(..)` / `Entry::Ids(..)`.

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -903,7 +903,6 @@ impl Tree {
                     {
                         // Go through ListExt
                         // accessors sequentially so the &mut borrows do not overlap.
-                        // bun.handleOom -> push (aborts on OOM via global allocator)
                         builder.list.items_dependencies_mut()[dest.id as usize].push(dep_id);
                         builder.list.items_tree_mut()[dest.id as usize]
                             .dependencies

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -170,16 +170,6 @@ pub(crate) struct Stringifier;
 impl Stringifier {
     const INDENT_SCALAR: usize = 2;
 
-    pub(crate) fn save_from_binary(
-        lockfile: &mut BinaryLockfile,
-        load_result: &LoadResult,
-        options: &PackageManagerOptions,
-        writer: &mut Writer,
-    ) -> Result<(), WriteError> {
-        // bun.handleOom → drop wrapper; allocation aborts on OOM in Rust.
-        Self::save_from_binary_inner(lockfile, load_result, options, writer)
-    }
-
     /// Pick the `lockfileVersion` to stamp. A lockfile loaded from disk keeps
     /// the version it already carried — re-saving never silently upgrades an
     /// existing `bun.lock` to a newer format. `text_lockfile_version` holds the
@@ -253,7 +243,7 @@ impl Stringifier {
                         // No supported integrity: only v2-clean if the tarball
                         // URL is under the *default* registry, the one case the
                         // writer normalizes to `""` (see the npm URL
-                        // serialization in `save_from_binary_inner`). An empty
+                        // serialization in `save_from_binary`). An empty
                         // URL never sets the parser's `npm_url_needs_integrity`,
                         // so that round-trips for any reader. A URL under a
                         // configured-but-not-default scope is written verbatim,
@@ -286,7 +276,7 @@ impl Stringifier {
         if has_scoped { Version::V3 } else { Version::V2 }
     }
 
-    fn save_from_binary_inner(
+    pub(crate) fn save_from_binary(
         lockfile: &mut BinaryLockfile,
         load_result: &LoadResult,
         options: &PackageManagerOptions,

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -44,7 +44,7 @@ use super::override_selector::{PackageSelector, parse_package_segment};
 use super::package::{Meta, PackageColumns as _, value_loc_of};
 use super::{
     CatalogMap, DependencySlice, LoadResult, Lockfile as BinaryLockfile, OverrideMap, Package,
-    PackageIndexEntry, PackageIndexMap, PatchedDep, TrustedDependenciesSet, VersionHashMap, tree,
+    PackageIndexMap, PatchedDep, TrustedDependenciesSet, VersionHashMap, tree,
 };
 
 use bun_io::AsFmt;
@@ -3386,12 +3386,7 @@ pub(crate) fn resolve_peer_dep_version_based(
         return None;
     }
 
-    let entry = package_index.get(&name_hash)?;
-    let candidates: &[PackageID] = match entry {
-        PackageIndexEntry::Id(id) => core::slice::from_ref(id),
-        PackageIndexEntry::Ids(ids) => ids.as_slice(),
-    };
-
+    let candidates = package_index.get(&name_hash)?.as_slice();
     for &id in candidates {
         if (id as usize) < pkg_resolutions.len()
             && pkg_resolutions[id as usize]

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -1952,6 +1952,35 @@ impl PackageManifest {
     }
 }
 
+/// Fills `set` with the names listed in `bundle(d)Dependencies`; returns whether it was `true` (bundle everything).
+fn collect_bundled_deps(
+    version_obj: Option<&JSON::E::ObjectJSON>,
+    set: &mut StringSet,
+) -> Result<bool, AllocError> {
+    set.map.clear_retaining_capacity();
+    let mut bundle_all_deps = false;
+    if let Some(bundled_deps_value) = version_obj
+        .and_then(|o| o.get(b"bundleDependencies"))
+        .or_else(|| version_obj.and_then(|o| o.get(b"bundledDependencies")))
+    {
+        match bundled_deps_value {
+            JSON::E::JsonValue::Boolean(boolean) => {
+                bundle_all_deps = *boolean;
+            }
+            JSON::E::JsonValue::Array(arr) => {
+                for bundled_dep in arr.get().items() {
+                    let Some(s) = bundled_dep.as_str() else {
+                        continue;
+                    };
+                    set.insert(s)?;
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(bundle_all_deps)
+}
+
 // Keys are pre-hashed string hashes, so don't re-hash them.
 type ExternalStringMapDeduper = HashMap<u64, ExternalStringList, IdentityContext<u64>>;
 
@@ -2151,27 +2180,7 @@ impl PackageManifest {
                     }
                 }
 
-                bundled_deps_set.map.clear_retaining_capacity();
-                bundle_all_deps = false;
-                if let Some(bundled_deps_value) = version_obj
-                    .and_then(|o| o.get(b"bundleDependencies"))
-                    .or_else(|| version_obj.and_then(|o| o.get(b"bundledDependencies")))
-                {
-                    match bundled_deps_value {
-                        JSON::E::JsonValue::Boolean(boolean) => {
-                            bundle_all_deps = *boolean;
-                        }
-                        JSON::E::JsonValue::Array(arr) => {
-                            for bundled_dep in arr.get().items() {
-                                let Some(s) = bundled_dep.as_str() else {
-                                    continue;
-                                };
-                                bundled_deps_set.insert(s)?;
-                            }
-                        }
-                        _ => {}
-                    }
-                }
+                bundle_all_deps = collect_bundled_deps(version_obj, &mut bundled_deps_set)?;
 
                 for pair in &DEPENDENCY_GROUPS {
                     if let Some(obj) = version_obj
@@ -2375,27 +2384,7 @@ impl PackageManifest {
 
                 let version_obj = prop.value.as_object();
 
-                bundled_deps_set.map.clear_retaining_capacity();
-                bundle_all_deps = false;
-                if let Some(bundled_deps_value) = version_obj
-                    .and_then(|o| o.get(b"bundleDependencies"))
-                    .or_else(|| version_obj.and_then(|o| o.get(b"bundledDependencies")))
-                {
-                    match bundled_deps_value {
-                        JSON::E::JsonValue::Boolean(boolean) => {
-                            bundle_all_deps = *boolean;
-                        }
-                        JSON::E::JsonValue::Array(arr) => {
-                            for bundled_dep in arr.get().items() {
-                                let Some(s) = bundled_dep.as_str() else {
-                                    continue;
-                                };
-                                bundled_deps_set.insert(s)?;
-                            }
-                        }
-                        _ => {}
-                    }
-                }
+                bundle_all_deps = collect_bundled_deps(version_obj, &mut bundled_deps_set)?;
 
                 let mut package_version: PackageVersion = empty_version;
 

--- a/src/install/patch_install.rs
+++ b/src/install/patch_install.rs
@@ -168,8 +168,7 @@ impl PatchTask {
                 // cannot hold a `&mut ch` across the call.
             }
             Callback::Apply(_) => {
-                // bun.handleOom(this.apply()) → panic on OOM.
-                self.apply().expect("OOM");
+                bun_core::handle_oom(self.apply());
             }
         }
         let mgr = self.manager.as_ptr();

--- a/src/install/update_scope.rs
+++ b/src/install/update_scope.rs
@@ -307,13 +307,10 @@ fn exit_on_lockfile_load_failure(manager: &mut PackageManager, subject: &[u8]) -
         crate::lockfile::LoadResult::NotFound => missing(silent, subject),
         crate::lockfile::LoadResult::Err(cause) => {
             if !silent && !crate::migration::reported_unsupported_lockfile_version(&cause) {
-                let what: &str = match cause.step {
-                    crate::lockfile::LoadStep::OpenFile => "open",
-                    crate::lockfile::LoadStep::ReadFile => "read",
-                    crate::lockfile::LoadStep::ParseFile => "parse",
-                    crate::lockfile::LoadStep::Migrating => "migrate",
-                };
-                Output::err_generic("failed to {s} lockfile: {s}", (what, cause.value.name()));
+                Output::err_generic(
+                    "failed to {s} lockfile: {s}",
+                    (cause.step.verb(), cause.value.name()),
+                );
                 if manager.log_mut().has_errors() {
                     let _ = manager
                         .log_mut()

--- a/src/install/update_transitive.rs
+++ b/src/install/update_transitive.rs
@@ -517,11 +517,8 @@ pub(crate) fn moved_targets_after_clean(
         let Some(entry) = cleaned.package_index.get(&old_name_hashes[old_id as usize]) else {
             continue;
         };
-        let candidates: &[PackageID] = match entry {
-            PackageIndexEntry::Id(id) => core::slice::from_ref(id),
-            PackageIndexEntry::Ids(ids) => ids.as_slice(),
-        };
-        if let Some(&id) = candidates
+        if let Some(&id) = entry
+            .as_slice()
             .iter()
             .find(|&&c| new_res[c as usize].eql(&old_res[old_id as usize], new_buf, old_buf))
         {
@@ -757,14 +754,10 @@ pub(crate) fn warn_orphaned_patches(manager: &mut PackageManager) {
             continue;
         };
         let (name, version) = (&key[..at], &key[at + 1..]);
-        let installed: &[PackageID] = match lockfile
+        let installed: &[PackageID] = lockfile
             .package_index
             .get(&Semver::string::Builder::string_hash(name))
-        {
-            Some(PackageIndexEntry::Id(id)) => core::slice::from_ref(id),
-            Some(PackageIndexEntry::Ids(ids)) => ids.as_slice(),
-            None => &[],
-        };
+            .map_or(&[], PackageIndexEntry::as_slice);
         if installed
             .iter()
             .any(|&id| pkg_res[id as usize].tag != ResolutionTag::Npm)

--- a/src/md/ansi_renderer.rs
+++ b/src/md/ansi_renderer.rs
@@ -123,11 +123,8 @@ struct AnsiRenderer<'a> {
     list_indent_cols: u32,
     /// Currently open span styles (bit flags).
     span_flags: u32,
-    /// Non-null when we're inside a link span; the href to emit in OSC 8.
-    /// Always allocator-owned when non-null (freed in leaveSpan).
-    link_href: Option<Box<[u8]>>,
-    /// Depth of enclosing link spans (brackets can nest in markdown parsers).
-    link_depth: u32,
+    /// The outermost open link span, if we're inside one.
+    link: Option<OpenLink>,
     /// Depth of enclosing image spans — text inside images becomes alt text
     /// rather than normal output.
     image_depth: u32,
@@ -171,6 +168,13 @@ struct AnsiRenderer<'a> {
     /// no content has been written since. Used to dedup back-to-back
     /// ensureBlankLine() calls (e.g. enter-quote followed by enter-para).
     blank_emitted: bool,
+}
+
+struct OpenLink {
+    /// Enclosing link spans including this one (brackets can nest in markdown parsers).
+    depth: u32,
+    /// The href to emit in OSC 8.
+    href: Box<[u8]>,
 }
 
 struct BlockContext {
@@ -273,8 +277,7 @@ impl<'a> AnsiRenderer<'a> {
             quote_depth: 0,
             list_indent_cols: 0,
             span_flags: 0,
-            link_href: None,
-            link_depth: 0,
+            link: None,
             image_depth: 0,
             image_alt: Vec::new(),
             image_src: None,
@@ -564,20 +567,21 @@ impl<'a> AnsiRenderer<'a> {
                 self.write_styled(code_span_open(self.theme.light), b"");
             }
             SpanType::A => {
-                self.link_depth += 1;
-                if self.link_depth == 1 {
+                if let Some(link) = &mut self.link {
+                    link.depth += 1;
+                } else {
                     // Resolve final href (prefixes for autolinks).
-                    self.link_href = Some(resolve_href(&detail));
-                    if self.theme.colors && self.theme.hyperlinks {
-                        if let Some(href) = &self.link_href {
-                            // OSC 8 hyperlink start
-                            // Clone the bytes so write_raw_no_color(&mut self)
-                            // doesn't alias `&self.link_href`.
-                            let href = href.clone();
-                            self.write_raw_no_color(b"\x1b]8;;");
-                            self.write_raw_no_color(&href);
-                            self.write_raw_no_color(b"\x1b\\");
-                        }
+                    let href = resolve_href(&detail);
+                    // Clone the bytes so write_raw_no_color(&mut self)
+                    // doesn't alias `&self.link`.
+                    let osc8_href =
+                        (self.theme.colors && self.theme.hyperlinks).then(|| href.clone());
+                    self.link = Some(OpenLink { depth: 1, href });
+                    if let Some(href) = osc8_href {
+                        // OSC 8 hyperlink start
+                        self.write_raw_no_color(b"\x1b]8;;");
+                        self.write_raw_no_color(&href);
+                        self.write_raw_no_color(b"\x1b\\");
                     }
                     self.write_styled(ansi_b::BLUE, b"");
                     self.write_styled(ansi_b::UNDERLINE, b"");
@@ -625,39 +629,34 @@ impl<'a> AnsiRenderer<'a> {
                 self.write_styled(b"\x1b[39m\x1b[49m", b"");
                 self.reapply_styles();
             }
-            SpanType::A => {
-                if self.link_depth == 1 {
-                    // Decrement BEFORE reapplyStyles so it doesn't re-emit
-                    // blue+underline for text after the link.
-                    self.link_depth = 0;
-                    let had_href = self.link_href.is_some();
+            // Taken BEFORE reapplyStyles so it doesn't re-emit
+            // blue+underline for text after the link.
+            SpanType::A => match self.link.take() {
+                Some(OpenLink { depth: 1, href }) => {
                     // Underline off, default fg; reapply outer styles so a
                     // link inside **bold** doesn't drop the bold.
                     self.write_styled(b"\x1b[24m\x1b[39m", b"");
                     self.reapply_styles();
                     if self.theme.colors && self.theme.hyperlinks {
-                        // Only emit the OSC 8 terminator if we emitted the
-                        // opening sequence (which required link_href).
-                        if had_href {
-                            self.write_raw_no_color(b"\x1b]8;;\x1b\\");
-                        }
-                    } else if let Some(href) = self.link_href.take() {
-                        if !href.is_empty() && self.image_depth == 0 {
-                            // Show URL in parens for non-hyperlink terminals.
-                            // image_depth==0 keeps " (url)" out of image alt
-                            // text when a link sits inside an image span.
-                            self.write_styled(ansi_b::DIM, b" (");
-                            self.write_styled(b"", &href);
-                            self.write_styled(ansi_b::DIM, b")");
-                            self.write_styled(b"\x1b[39m\x1b[22m", b"");
-                            self.reapply_styles();
-                        }
+                        // OSC 8 terminator
+                        self.write_raw_no_color(b"\x1b]8;;\x1b\\");
+                    } else if !href.is_empty() && self.image_depth == 0 {
+                        // Show URL in parens for non-hyperlink terminals.
+                        // image_depth==0 keeps " (url)" out of image alt
+                        // text when a link sits inside an image span.
+                        self.write_styled(ansi_b::DIM, b" (");
+                        self.write_styled(b"", &href);
+                        self.write_styled(ansi_b::DIM, b")");
+                        self.write_styled(b"\x1b[39m\x1b[22m", b"");
+                        self.reapply_styles();
                     }
-                    self.link_href = None;
-                } else if self.link_depth > 0 {
-                    self.link_depth -= 1;
                 }
-            }
+                Some(mut link) => {
+                    link.depth -= 1;
+                    self.link = Some(link);
+                }
+                None => {}
+            },
             SpanType::Img => {
                 if self.image_depth == 1 {
                     self.emit_image();
@@ -1043,7 +1042,7 @@ impl<'a> AnsiRenderer<'a> {
     /// indent stay clean, newline, re-emit indent, then reapply the
     /// active span styles so the continuation keeps its color.
     fn wrap_break(&mut self) {
-        let has_style = self.span_flags != 0 || self.link_depth > 0;
+        let has_style = self.span_flags != 0 || self.link.is_some();
         if self.theme.colors && has_style {
             self.out.write(b"\x1b[39m\x1b[49m");
         }
@@ -1136,7 +1135,7 @@ impl<'a> AnsiRenderer<'a> {
         if self.span_flags & SPAN_CODE != 0 {
             self.emit_inline(code_span_open(self.theme.light));
         }
-        if self.link_depth > 0 {
+        if self.link.is_some() {
             self.emit_inline(ansi_b::BLUE);
             self.emit_inline(ansi_b::UNDERLINE);
         }
@@ -1933,7 +1932,7 @@ impl<'a> AnsiRenderer<'a> {
         let link_ok = self.theme.colors
             && self.theme.hyperlinks
             && has_src
-            && self.link_depth == 0
+            && self.link.is_none()
             && !src.as_deref().unwrap().starts_with(b"data:");
         if link_ok {
             self.write_raw_no_color(b"\x1b]8;;");

--- a/src/parsers/xml.rs
+++ b/src/parsers/xml.rs
@@ -2447,6 +2447,12 @@ impl<T: Copy> Rows<T> {
     }
 
     #[inline]
+    fn set(&mut self, i: usize, value: T, loc: Loc) {
+        self.values[i] = value;
+        self.locs[i] = loc;
+    }
+
+    #[inline]
     fn columns(&self, range: core::ops::Range<usize>) -> (&[T], &[Loc]) {
         (&self.values[range.clone()], &self.locs[range])
     }
@@ -2458,8 +2464,7 @@ impl<T: Copy> Rows<T> {
 struct Tape<'a> {
     tape: core::ptr::NonNull<E::JsonTape>,
     bump: &'a Bump,
-    props: Vec<E::PropertyJSON>,
-    prop_locs: Vec<Loc>,
+    props: Rows<E::PropertyJSON>,
     items: Rows<E::JsonValue>,
     /// `{}` and `[]` are immutable and carry no data, so one row of each
     /// serves every empty object / array in the document.
@@ -2479,8 +2484,7 @@ impl<'a> Tape<'a> {
         Tape {
             tape: tape.root_ptr(),
             bump,
-            props: Vec::with_capacity(rows / 4 + 16),
-            prop_locs: Vec::with_capacity(rows / 4 + 16),
+            props: Rows::with_capacity(rows / 4 + 16),
             items: Rows::with_capacity(rows / 8 + 16),
             empty_object: None,
             empty_array: None,
@@ -2494,12 +2498,14 @@ impl<'a> Tape<'a> {
 
     #[inline]
     fn push_prop(&mut self, key: &[u8], value: E::JsonValue, loc: Loc) {
-        self.props.push(E::PropertyJSON {
-            key: E::Str::new(key),
-            key_loc: loc,
-            value,
-        });
-        self.prop_locs.push(loc);
+        self.props.push(
+            E::PropertyJSON {
+                key: E::Str::new(key),
+                key_loc: loc,
+                value,
+            },
+            loc,
+        );
     }
 
     #[inline]
@@ -2525,9 +2531,9 @@ impl<'a> Tape<'a> {
         // SAFETY: `tape` is the arena allocation's own pointer (`root_ptr`),
         // written only through here, and the arena outlives the AST.
         let tape = unsafe { self.tape.as_mut() };
-        let (first, count) = tape.append_props(&self.props[mark..], &self.prop_locs[mark..]);
+        let (props, locs) = self.props.columns(mark..self.props.len());
+        let (first, count) = tape.append_props(props, locs);
         self.props.truncate(mark);
-        self.prop_locs.truncate(mark);
         // SAFETY: as above — the tape's own pointer, and it outlives the node.
         let object = unsafe { E::ObjectJSON::new(self.tape, first, count, false, loc) };
         let Data::EObjectJSON(row) = Expr::init(object, loc).data else {
@@ -2688,7 +2694,7 @@ impl<'a, U: Unit> CompactSink<'a, U> {
     /// array of its values.
     #[inline]
     fn fold_repeats(&mut self, mark: usize) {
-        let children = &self.tape.props[mark..];
+        let children = &self.tape.props.values[mark..];
         let n = children.len();
         // Usually every name is distinct: settle that cheaply first. A
         // 64-slot filter on (length, first, last byte) says "all distinct"
@@ -2729,7 +2735,7 @@ impl<'a, U: Unit> CompactSink<'a, U> {
 
     #[cold]
     fn fold_repeats_slow(&mut self, mark: usize) {
-        let children = &self.tape.props[mark..];
+        let children = &self.tape.props.values[mark..];
         let n = children.len();
         // Group by name.
         self.groups.clear();
@@ -2788,14 +2794,14 @@ impl<'a, U: Unit> CompactSink<'a, U> {
             let group = &mut self.groups[g as usize];
             if group.count > 1 {
                 self.gathered[group.cursor as usize] = children[i].value;
-                self.gathered_locs[group.cursor as usize] = self.tape.prop_locs[mark + i];
+                self.gathered_locs[group.cursor as usize] = self.tape.props.locs[mark + i];
                 group.cursor += 1;
             }
         }
         // Compact the run to one property per group (a group's first
         // property is never behind its final slot, so this is in place).
         for (slot, g) in self.groups.iter().enumerate() {
-            let mut prop = self.tape.props[mark + g.first as usize];
+            let mut prop = self.tape.props.values[mark + g.first as usize];
             if g.count > 1 {
                 let run = (g.cursor - g.count) as usize..g.cursor as usize;
                 prop.value = E::JsonValue::Array(Tape::array_of(
@@ -2805,11 +2811,9 @@ impl<'a, U: Unit> CompactSink<'a, U> {
                     prop.key_loc,
                 ));
             }
-            self.tape.props[mark + slot] = prop;
-            self.tape.prop_locs[mark + slot] = prop.key_loc;
+            self.tape.props.set(mark + slot, prop, prop.key_loc);
         }
         self.tape.props.truncate(mark + self.groups.len());
-        self.tape.prop_locs.truncate(mark + self.groups.len());
     }
 
     /// An element with no child elements: its text if it has no attributes
@@ -2909,13 +2913,12 @@ impl<'a, U: Unit> Sink<'a, U> for CompactSink<'a, U> {
             // Every run, exactly; the placeholder (if any) is re-made last.
             let text = self.concat_text(text_mark, false);
             self.tape.props.truncate(children_mark);
-            self.tape.prop_locs.truncate(children_mark);
             self.leaf_value(&frame, text)
         } else {
             // Whitespace-only runs between child elements are layout.
             if has_text {
                 let text = self.concat_text(text_mark, true);
-                self.tape.props[frame.text_prop as usize].value = Tape::str(text);
+                self.tape.props.values[frame.text_prop as usize].value = Tape::str(text);
             }
             if self.tape.props.len() > children_mark + 1 {
                 self.fold_repeats(children_mark);

--- a/src/parsers/xml.rs
+++ b/src/parsers/xml.rs
@@ -2446,6 +2446,13 @@ impl<T: Copy> Rows<T> {
         self.locs.truncate(len);
     }
 
+    fn reset(&mut self, len: usize, value: T, loc: Loc) {
+        self.values.clear();
+        self.values.resize(len, value);
+        self.locs.clear();
+        self.locs.resize(len, loc);
+    }
+
     #[inline]
     fn set(&mut self, i: usize, value: T, loc: Loc) {
         self.values[i] = value;
@@ -2598,8 +2605,7 @@ struct CompactSink<'a, U: Unit> {
     /// Scratch for `end_element`'s grouping of repeated child names.
     group_of: Vec<u32>,
     groups: Vec<Group>,
-    gathered: Vec<E::JsonValue>,
-    gathered_locs: Vec<Loc>,
+    gathered: Rows<E::JsonValue>,
     group_index: HashMap<&'a [u8], u32>,
     root: Option<(&'a [U], E::JsonValue, Loc)>,
 }
@@ -2660,8 +2666,7 @@ impl<'a, U: Unit> CompactSink<'a, U> {
             key_cache: [None; KEY_CACHE_SIZE],
             group_of: Vec::new(),
             groups: Vec::new(),
-            gathered: Vec::new(),
-            gathered_locs: Vec::new(),
+            gathered: Rows::with_capacity(0),
             group_index: HashMap::default(),
             root: None,
         }
@@ -2786,15 +2791,16 @@ impl<'a, U: Unit> CompactSink<'a, U> {
                 next += g.count;
             }
         }
-        self.gathered.clear();
-        self.gathered.resize(next as usize, E::JsonValue::Null);
-        self.gathered_locs.clear();
-        self.gathered_locs.resize(next as usize, Loc::EMPTY);
+        self.gathered
+            .reset(next as usize, E::JsonValue::Null, Loc::EMPTY);
         for (i, &g) in self.group_of.iter().enumerate() {
             let group = &mut self.groups[g as usize];
             if group.count > 1 {
-                self.gathered[group.cursor as usize] = children[i].value;
-                self.gathered_locs[group.cursor as usize] = self.tape.props.locs[mark + i];
+                self.gathered.set(
+                    group.cursor as usize,
+                    children[i].value,
+                    self.tape.props.locs[mark + i],
+                );
                 group.cursor += 1;
             }
         }
@@ -2804,12 +2810,9 @@ impl<'a, U: Unit> CompactSink<'a, U> {
             let mut prop = self.tape.props.values[mark + g.first as usize];
             if g.count > 1 {
                 let run = (g.cursor - g.count) as usize..g.cursor as usize;
-                prop.value = E::JsonValue::Array(Tape::array_of(
-                    self.tape.tape,
-                    &self.gathered[run.clone()],
-                    &self.gathered_locs[run],
-                    prop.key_loc,
-                ));
+                let (values, locs) = self.gathered.columns(run);
+                prop.value =
+                    E::JsonValue::Array(Tape::array_of(self.tape.tape, values, locs, prop.key_loc));
             }
             self.tape.props.set(mark + slot, prop, prop.key_loc);
         }

--- a/src/parsers/xml.rs
+++ b/src/parsers/xml.rs
@@ -2415,6 +2415,43 @@ trait Sink<'a, U: Unit> {
     fn finish(&mut self) -> Expr;
 }
 
+/// Rows staged for the tape, in the two columns the tape appends them as.
+struct Rows<T> {
+    values: Vec<T>,
+    locs: Vec<Loc>,
+}
+
+impl<T: Copy> Rows<T> {
+    fn with_capacity(capacity: usize) -> Self {
+        Rows {
+            values: Vec::with_capacity(capacity),
+            locs: Vec::with_capacity(capacity),
+        }
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    #[inline]
+    fn push(&mut self, value: T, loc: Loc) {
+        self.values.push(value);
+        self.locs.push(loc);
+    }
+
+    #[inline]
+    fn truncate(&mut self, len: usize) {
+        self.values.truncate(len);
+        self.locs.truncate(len);
+    }
+
+    #[inline]
+    fn columns(&self, range: core::ops::Range<usize>) -> (&[T], &[Loc]) {
+        (&self.values[range.clone()], &self.locs[range])
+    }
+}
+
 /// The document's `E::JsonTape` plus the scratch stacks rows are staged on
 /// until their object or array is complete (a node's rows are contiguous on
 /// the tape, so they can only be appended once all of them are known).
@@ -2423,8 +2460,7 @@ struct Tape<'a> {
     bump: &'a Bump,
     props: Vec<E::PropertyJSON>,
     prop_locs: Vec<Loc>,
-    items: Vec<E::JsonValue>,
-    item_locs: Vec<Loc>,
+    items: Rows<E::JsonValue>,
     /// `{}` and `[]` are immutable and carry no data, so one row of each
     /// serves every empty object / array in the document.
     empty_object: Option<StoreRef<E::ObjectJSON>>,
@@ -2445,8 +2481,7 @@ impl<'a> Tape<'a> {
             bump,
             props: Vec::with_capacity(rows / 4 + 16),
             prop_locs: Vec::with_capacity(rows / 4 + 16),
-            items: Vec::with_capacity(rows / 8 + 16),
-            item_locs: Vec::with_capacity(rows / 8 + 16),
+            items: Rows::with_capacity(rows / 8 + 16),
             empty_object: None,
             empty_array: None,
         }
@@ -2469,8 +2504,7 @@ impl<'a> Tape<'a> {
 
     #[inline]
     fn push_item(&mut self, value: E::JsonValue, loc: Loc) {
-        self.items.push(value);
-        self.item_locs.push(loc);
+        self.items.push(value, loc);
     }
 
     /// Moves the properties staged since `mark` to the tape as one object.
@@ -2513,9 +2547,9 @@ impl<'a> Tape<'a> {
             self.empty_array = Some(row);
             return row;
         }
-        let row = Self::array_of(self.tape, &self.items[mark..], &self.item_locs[mark..], loc);
+        let (items, locs) = self.items.columns(mark..self.items.len());
+        let row = Self::array_of(self.tape, items, locs, loc);
         self.items.truncate(mark);
-        self.item_locs.truncate(mark);
         row
     }
 
@@ -2615,7 +2649,7 @@ impl<'a, U: Unit> CompactSink<'a, U> {
     fn new(tape: Tape<'a>) -> Self {
         CompactSink {
             stack: Vec::with_capacity(64),
-            text_runs: Vec::with_capacity(tape.items.capacity()),
+            text_runs: Vec::with_capacity(tape.items.values.capacity()),
             tape,
             key_cache: [None; KEY_CACHE_SIZE],
             group_of: Vec::new(),

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -422,6 +422,17 @@ pub trait Encoding: Copy + 'static {
     }
 }
 
+#[inline]
+fn byte_literal(s: &'static [u8]) -> EncLit<u8> {
+    debug_assert!(s.len() <= 8, "Enc::literal: bump EncLit cap");
+    let mut buf = [0u8; 8];
+    buf[..s.len()].copy_from_slice(s);
+    EncLit {
+        buf,
+        len: s.len() as u8,
+    }
+}
+
 #[derive(Clone, Copy)]
 pub struct Latin1;
 #[derive(Clone, Copy)]
@@ -438,13 +449,7 @@ impl Encoding for Latin1 {
     }
     #[inline]
     fn literal(s: &'static [u8]) -> EncLit<u8> {
-        debug_assert!(s.len() <= 8, "Enc::literal: bump EncLit cap");
-        let mut buf = [0u8; 8];
-        buf[..s.len()].copy_from_slice(s);
-        EncLit {
-            buf,
-            len: s.len() as u8,
-        }
+        byte_literal(s)
     }
     #[inline]
     fn key_bytes(s: &[u8]) -> &[u8] {
@@ -470,13 +475,7 @@ impl Encoding for Utf8 {
     }
     #[inline]
     fn literal(s: &'static [u8]) -> EncLit<u8> {
-        debug_assert!(s.len() <= 8, "Enc::literal: bump EncLit cap");
-        let mut buf = [0u8; 8];
-        buf[..s.len()].copy_from_slice(s);
-        EncLit {
-            buf,
-            len: s.len() as u8,
-        }
+        byte_literal(s)
     }
     #[inline]
     fn key_bytes(s: &[u8]) -> &[u8] {

--- a/src/paths/Path.rs
+++ b/src/paths/Path.rs
@@ -627,19 +627,22 @@ impl<U: PathUnit, const KIND: u8, const SEP_OPT: u8, const CHECK: u8>
 
     // `deinit` → impl Drop (below). Body returns the buffer to the pool.
 
-    pub fn init_top_level_dir() -> Self {
+    fn trimmed_top_level_dir() -> &'static [u8] {
         debug_assert!(crate::fs::FileSystem::instance_loaded());
         let top_level_dir = crate::fs::FileSystem::instance().top_level_dir();
 
-        let trimmed = match Kind::from_u8(KIND) {
+        match Kind::from_u8(KIND) {
             Kind::Abs => {
                 debug_assert!(is_input_absolute(top_level_dir));
                 trim_input(TrimInputKind::Abs, top_level_dir)
             }
             Kind::Rel => panic!("cannot create a relative path from top_level_dir"),
             Kind::Any => trim_input(TrimInputKind::Abs, top_level_dir),
-        };
+        }
+    }
 
+    pub fn init_top_level_dir() -> Self {
+        let trimmed = Self::trimmed_top_level_dir();
         let mut this = Self::init();
         // top_level_dir is &[u8]; `buf_append_input` routes it through
         // `append_other` (transcoding) when U == u16.
@@ -648,18 +651,7 @@ impl<U: PathUnit, const KIND: u8, const SEP_OPT: u8, const CHECK: u8>
     }
 
     pub fn init_top_level_dir_long_path() -> Self {
-        debug_assert!(crate::fs::FileSystem::instance_loaded());
-        let top_level_dir = crate::fs::FileSystem::instance().top_level_dir();
-
-        let trimmed = match Kind::from_u8(KIND) {
-            Kind::Abs => {
-                debug_assert!(is_input_absolute(top_level_dir));
-                trim_input(TrimInputKind::Abs, top_level_dir)
-            }
-            Kind::Rel => panic!("cannot create a relative path from top_level_dir"),
-            Kind::Any => trim_input(TrimInputKind::Abs, top_level_dir),
-        };
-
+        let trimmed = Self::trimmed_top_level_dir();
         let mut this = Self::init();
 
         #[cfg(windows)]
@@ -753,7 +745,7 @@ impl<U: PathUnit, const KIND: u8, const SEP_OPT: u8, const CHECK: u8>
         Ok(this)
     }
 
-    pub fn from_long_path<C: PathUnit>(input: &[C]) -> options::Result<Self> {
+    fn trim_input_for_kind<C: PathUnit>(input: &[C]) -> options::Result<&[C]> {
         let trimmed = match Kind::from_u8(KIND) {
             Kind::Abs => {
                 debug_assert!(is_input_absolute(input));
@@ -779,6 +771,11 @@ impl<U: PathUnit, const KIND: u8, const SEP_OPT: u8, const CHECK: u8>
             }
         }
 
+        Ok(trimmed)
+    }
+
+    pub fn from_long_path<C: PathUnit>(input: &[C]) -> options::Result<Self> {
+        let trimmed = Self::trim_input_for_kind(input)?;
         let mut this = Self::init();
         #[cfg(windows)]
         {
@@ -790,31 +787,7 @@ impl<U: PathUnit, const KIND: u8, const SEP_OPT: u8, const CHECK: u8>
     }
 
     pub fn from<C: PathUnit>(input: &[C]) -> options::Result<Self> {
-        let trimmed = match Kind::from_u8(KIND) {
-            Kind::Abs => {
-                debug_assert!(is_input_absolute(input));
-                trim_input(TrimInputKind::Abs, input)
-            }
-            Kind::Rel => {
-                debug_assert!(!is_input_absolute(input));
-                trim_input(TrimInputKind::Rel, input)
-            }
-            Kind::Any => trim_input(
-                if is_input_absolute(input) {
-                    TrimInputKind::Abs
-                } else {
-                    TrimInputKind::Rel
-                },
-                input,
-            ),
-        };
-
-        if CheckLength::from_u8(CHECK) == CheckLength::CheckForGreaterThanMaxPath {
-            if trimmed.len() >= U::MAX_PATH {
-                return Err(PathError::MaxPathExceeded);
-            }
-        }
-
+        let trimmed = Self::trim_input_for_kind(input)?;
         let mut this = Self::init();
         this.buf_append_input(trimmed, false);
         Ok(this)
@@ -1052,13 +1025,7 @@ impl<U: PathUnit, const KIND: u8, const SEP_OPT: u8, const CHECK: u8>
         self.append(input)
     }
 
-    pub fn join(&mut self, parts: &[&[U]]) -> options::Result<()> {
-        // Rust can't compile-error on a
-        // type parameter without specialization; enforced here at runtime.
-        if core::any::TypeId::of::<U>() == core::any::TypeId::of::<u16>() {
-            panic!("unsupported unit type");
-        }
-
+    fn assert_joinable(&self) {
         match Kind::from_u8(KIND) {
             Kind::Abs => {}
             Kind::Rel => panic!("cannot join with relative path"),
@@ -1066,6 +1033,16 @@ impl<U: PathUnit, const KIND: u8, const SEP_OPT: u8, const CHECK: u8>
                 debug_assert!(self.is_absolute());
             }
         }
+    }
+
+    pub fn join(&mut self, parts: &[&[U]]) -> options::Result<()> {
+        // Rust can't compile-error on a
+        // type parameter without specialization; enforced here at runtime.
+        if core::any::TypeId::of::<U>() == core::any::TypeId::of::<u16>() {
+            panic!("unsupported unit type");
+        }
+
+        self.assert_joinable();
 
         let cloned = self.clone();
 
@@ -1098,13 +1075,7 @@ impl<U: PathUnit, const KIND: u8, const SEP_OPT: u8, const CHECK: u8>
     }
 
     pub fn append_join<C: PathUnit>(&mut self, part: &[C]) -> options::Result<()> {
-        match Kind::from_u8(KIND) {
-            Kind::Abs => {}
-            Kind::Rel => panic!("cannot join with relative path"),
-            Kind::Any => {
-                debug_assert!(self.is_absolute());
-            }
-        }
+        self.assert_joinable();
 
         if CheckLength::from_u8(CHECK) == CheckLength::CheckForGreaterThanMaxPath
             && self.len() + 1 + part.len() >= U::MAX_PATH

--- a/src/react_compiler/codegen.rs
+++ b/src/react_compiler/codegen.rs
@@ -469,10 +469,7 @@ fn codegen_reactive_function(
     func: &ReactiveFunction,
 ) -> Result<CodegenFunction, CompilerError> {
     for param in &func.params {
-        let place = match param {
-            ParamPattern::Place(p) => p,
-            ParamPattern::Spread(sp) => &sp.place,
-        };
+        let place = param.place();
         let ident = &cx.env.identifiers[place.identifier.0 as usize];
         cx.temp.insert(ident.declaration_id, None);
         cx.declare(place.identifier);

--- a/src/react_compiler/diagnostics/mod.rs
+++ b/src/react_compiler/diagnostics/mod.rs
@@ -288,6 +288,13 @@ impl CompilerErrorOrDiagnostic {
             Self::ErrorDetail(d) => d.logged_severity(),
         }
     }
+
+    pub fn category(&self) -> ErrorCategory {
+        match self {
+            Self::Diagnostic(d) => d.category,
+            Self::ErrorDetail(d) => d.category,
+        }
+    }
 }
 
 impl CompilerError {
@@ -324,13 +331,9 @@ impl CompilerError {
 
     /// Check if any error detail has Invariant category.
     pub fn has_invariant_errors(&self) -> bool {
-        self.details.iter().any(|d| {
-            let cat = match d {
-                CompilerErrorOrDiagnostic::Diagnostic(d) => d.category,
-                CompilerErrorOrDiagnostic::ErrorDetail(d) => d.category,
-            };
-            cat == ErrorCategory::Invariant
-        })
+        self.details
+            .iter()
+            .any(|d| d.category() == ErrorCategory::Invariant)
     }
 
     pub fn merge(&mut self, other: CompilerError) {

--- a/src/react_compiler/hir/mod.rs
+++ b/src/react_compiler/hir/mod.rs
@@ -1311,6 +1311,23 @@ pub enum PlaceOrSpread {
     Spread(SpreadPattern),
 }
 
+impl PlaceOrSpread {
+    /// The argument's place, whether or not it is spread.
+    pub fn place(&self) -> &Place {
+        match self {
+            PlaceOrSpread::Place(p) => p,
+            PlaceOrSpread::Spread(s) => &s.place,
+        }
+    }
+
+    pub fn place_mut(&mut self) -> &mut Place {
+        match self {
+            PlaceOrSpread::Place(p) => p,
+            PlaceOrSpread::Spread(s) => &mut s.place,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum ArrayElement {
     Place(Place),

--- a/src/react_compiler/hir/mod.rs
+++ b/src/react_compiler/hir/mod.rs
@@ -679,6 +679,18 @@ pub enum InstructionKind {
     Function,
 }
 
+impl InstructionKind {
+    /// Corresponds to TS `convertHoistedLValueKind` — returns None for non-hoisted kinds.
+    pub fn unhoisted(self) -> Option<InstructionKind> {
+        match self {
+            InstructionKind::HoistedLet => Some(InstructionKind::Let),
+            InstructionKind::HoistedConst => Some(InstructionKind::Const),
+            InstructionKind::HoistedFunction => Some(InstructionKind::Function),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct LValue {
     pub place: Place,

--- a/src/react_compiler/hir/mod.rs
+++ b/src/react_compiler/hir/mod.rs
@@ -311,6 +311,23 @@ pub enum ParamPattern {
     Spread(SpreadPattern),
 }
 
+impl ParamPattern {
+    /// The parameter's binding, whether or not it is a rest parameter.
+    pub fn place(&self) -> &Place {
+        match self {
+            ParamPattern::Place(p) => p,
+            ParamPattern::Spread(s) => &s.place,
+        }
+    }
+
+    pub fn place_mut(&mut self) -> &mut Place {
+        match self {
+            ParamPattern::Place(p) => p,
+            ParamPattern::Spread(s) => &mut s.place,
+        }
+    }
+}
+
 /// The HIR control-flow graph
 #[derive(Debug, Clone)]
 pub struct HIR {

--- a/src/react_compiler/hir/mod.rs
+++ b/src/react_compiler/hir/mod.rs
@@ -1789,6 +1789,15 @@ pub fn is_set_state_type(ty: &Type) -> bool {
     matches!(ty, Type::Function { shape_id: Some(id), .. } if *id == object_shape::BUILT_IN_SET_STATE_ID)
 }
 
+pub fn is_set_state_identifier(
+    identifier_id: IdentifierId,
+    identifiers: &[Identifier],
+    types: &[Type],
+) -> bool {
+    let ident = &identifiers[identifier_id.0 as usize];
+    is_set_state_type(&types[ident.type_.0 as usize])
+}
+
 /// Returns true if the type is a useEffect hook.
 pub fn is_use_effect_hook_type(ty: &Type) -> bool {
     matches!(ty, Type::Function { shape_id: Some(id), .. } if *id == object_shape::BUILT_IN_USE_EFFECT_HOOK_ID)

--- a/src/react_compiler/hir/mod.rs
+++ b/src/react_compiler/hir/mod.rs
@@ -1192,6 +1192,19 @@ impl IdentifierName {
             IdentifierName::Named(v) | IdentifierName::Promoted(v) => v.slice(),
         }
     }
+
+    /// `#<kind><n>`, e.g. `#t12` for a promoted temporary.
+    pub fn promoted(kind: u8, n: u32) -> IdentifierName {
+        let mut itoa = bun_core::fmt::ItoaBuf::new();
+        let digits = itoa.format(n).as_bytes();
+        let mut buf = [0u8; 16];
+        buf[0] = b'#';
+        buf[1] = kind;
+        buf[2..2 + digits.len()].copy_from_slice(digits);
+        IdentifierName::Promoted(StoreStr::new(bun_ast::data_store_dupe_str(
+            &buf[..2 + digits.len()],
+        )))
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/react_compiler/hir/visitors.rs
+++ b/src/react_compiler/hir/visitors.rs
@@ -309,14 +309,7 @@ pub fn each_instruction_value_operand_with_functions(
 pub fn each_call_argument(args: &[PlaceOrSpread]) -> Vec<Place> {
     let mut result = Vec::new();
     for arg in args {
-        match arg {
-            PlaceOrSpread::Place(place) => {
-                result.push(place.clone());
-            }
-            PlaceOrSpread::Spread(spread) => {
-                result.push(spread.place.clone());
-            }
-        }
+        result.push(arg.place().clone());
     }
     result
 }
@@ -1265,10 +1258,7 @@ pub fn for_each_instruction_value_operand_mut(
 /// In-place mutation of call arguments.
 pub fn for_each_call_argument_mut(args: &mut [PlaceOrSpread], f: &mut impl FnMut(&mut Place)) {
     for arg in args.iter_mut() {
-        match arg {
-            PlaceOrSpread::Place(place) => f(place),
-            PlaceOrSpread::Spread(spread) => f(&mut spread.place),
-        }
+        f(arg.place_mut());
     }
 }
 
@@ -1396,10 +1386,7 @@ pub fn each_operand(v: &InstructionValue, mut f: impl FnMut(&Place)) {
         | InstructionValue::CallExpression { callee, args, .. } => {
             f(callee);
             for arg in args {
-                match arg {
-                    PlaceOrSpread::Place(p) => f(p),
-                    PlaceOrSpread::Spread(s) => f(&s.place),
-                }
+                f(arg.place());
             }
         }
         InstructionValue::MethodCall {
@@ -1411,10 +1398,7 @@ pub fn each_operand(v: &InstructionValue, mut f: impl FnMut(&Place)) {
             f(receiver);
             f(property);
             for arg in args {
-                match arg {
-                    PlaceOrSpread::Place(p) => f(p),
-                    PlaceOrSpread::Spread(s) => f(&s.place),
-                }
+                f(arg.place());
             }
         }
         InstructionValue::BinaryExpression { left, right, .. } => {

--- a/src/react_compiler/imports.rs
+++ b/src/react_compiler/imports.rs
@@ -8,9 +8,7 @@
 
 use crate::collections::{IndexMap, IndexSet};
 
-use crate::diagnostics::{
-    CompilerError, CompilerErrorDetail, ErrorCategory, Position, SourceLocation,
-};
+use crate::diagnostics::{CompilerError, CompilerErrorDetail, ErrorCategory};
 use bun_alloc::{AstAlloc, AstVec};
 use bun_ast::{
     ClauseItem, ImportKind, ImportRecord, Loc, LocRef, S, Stmt, StoreSlice, StoreStr, Symbol,
@@ -210,7 +208,7 @@ pub(crate) fn validate_restricted_imports(
                 "Import from module {}",
                 bun_core::BStr::new(import.path.text)
             ));
-            detail.loc = convert_loc(import.range.loc);
+            detail.loc = crate::lowering::convert_loc(import.range.loc);
             error.push_error_detail(detail);
         }
     }
@@ -220,21 +218,6 @@ pub(crate) fn validate_restricted_imports(
     } else {
         None
     }
-}
-
-fn convert_loc(loc: Loc) -> Option<SourceLocation> {
-    if loc.start < 0 {
-        return None;
-    }
-    let pos = Position {
-        line: 0,
-        column: 0,
-        index: Some(loc.start as u32),
-    };
-    Some(SourceLocation {
-        start: pos,
-        end: pos,
-    })
 }
 
 /// Insert import declarations into the program body.

--- a/src/react_compiler/inference/infer_mutation_aliasing_effects.rs
+++ b/src/react_compiler/inference/infer_mutation_aliasing_effects.rs
@@ -106,10 +106,7 @@ pub(crate) fn infer_mutation_aliasing_effects(
             );
         }
         if params_len > 1 {
-            let ref_place = match &func.params[1] {
-                ParamPattern::Place(p) => p,
-                ParamPattern::Spread(s) => &s.place,
-            };
+            let ref_place = func.params[1].place();
             let value_id = ValueId(next_value_id);
             next_value_id += 1;
             initial_state.initialize(
@@ -1359,10 +1356,7 @@ fn infer_param(
     param_kind: AbstractValue,
     next_value_id: &mut u32,
 ) {
-    let place = match param {
-        ParamPattern::Place(p) => p,
-        ParamPattern::Spread(s) => &s.place,
-    };
+    let place = param.place();
     let value_id = ValueId(*next_value_id);
     *next_value_id += 1;
     state.initialize(value_id, param_kind);
@@ -3241,10 +3235,7 @@ fn are_arguments_immutable_and_non_mutating(
                     if let Some(&func_id) = function_values.get(vid) {
                         let inner_func = &env.functions[func_id.0 as usize];
                         let mutates_params = inner_func.params.iter().any(|param| {
-                            let param_id = match param {
-                                ParamPattern::Place(p) => p.identifier,
-                                ParamPattern::Spread(s) => s.place.identifier,
-                            };
+                            let param_id = param.place().identifier;
                             let ident = &env.identifiers[param_id.0 as usize];
                             ident.mutable_range.end.0 > ident.mutable_range.start.0 + 1
                         });

--- a/src/react_compiler/inference/infer_mutation_aliasing_ranges.rs
+++ b/src/react_compiler/inference/infer_mutation_aliasing_ranges.rs
@@ -497,10 +497,7 @@ pub(crate) fn infer_mutation_aliasing_ranges(
 
     // Create nodes for params, context vars, and return
     for param in &func.params {
-        let place = match param {
-            crate::hir::ParamPattern::Place(p) => p,
-            crate::hir::ParamPattern::Spread(s) => &s.place,
-        };
+        let place = param.place();
         state.create(place, NodeValue::Object);
     }
     for ctx in &func.context {
@@ -722,10 +719,7 @@ pub(crate) fn infer_mutation_aliasing_ranges(
         collect_param_effects(&state, ctx, &mut function_effects);
     }
     for param in &func.params {
-        let place = match param {
-            crate::hir::ParamPattern::Place(p) => p,
-            crate::hir::ParamPattern::Spread(s) => &s.place,
-        };
+        let place = param.place();
         collect_param_effects(&state, place, &mut function_effects);
     }
 
@@ -734,10 +728,7 @@ pub(crate) fn infer_mutation_aliasing_ranges(
     // were mutated before setting effects
     let mut captured_params: HashSet<IdentifierId> = HashSet::default();
     for param in &func.params {
-        let place = match param {
-            crate::hir::ParamPattern::Place(p) => p,
-            crate::hir::ParamPattern::Spread(s) => &s.place,
-        };
+        let place = param.place();
         if let Some(node) = state.nodes.get(&place.identifier) {
             if node.local.is_some() || node.transitive.is_some() {
                 captured_params.insert(place.identifier);
@@ -754,10 +745,7 @@ pub(crate) fn infer_mutation_aliasing_ranges(
 
     // Now mutate the effects on params/context in place
     for param in &mut func.params {
-        let place = match param {
-            crate::hir::ParamPattern::Place(p) => p,
-            crate::hir::ParamPattern::Spread(s) => &mut s.place,
-        };
+        let place = param.place_mut();
         if captured_params.contains(&place.identifier) {
             place.effect = Effect::Capture;
         }
@@ -1062,10 +1050,7 @@ pub(crate) fn infer_mutation_aliasing_ranges(
     // Determine precise data-flow effects by simulating transitive mutations
     let mut tracked: Vec<Place> = Vec::new();
     for param in &func.params {
-        let place = match param {
-            crate::hir::ParamPattern::Place(p) => p.clone(),
-            crate::hir::ParamPattern::Spread(s) => s.place.clone(),
-        };
+        let place = param.place().clone();
         tracked.push(place);
     }
     for ctx in &func.context {

--- a/src/react_compiler/inference/infer_mutation_aliasing_ranges.rs
+++ b/src/react_compiler/inference/infer_mutation_aliasing_ranges.rs
@@ -336,10 +336,7 @@ impl AliasingState {
             // Forward edges: Capture a -> b, Alias a -> b: mutate(a) => mutate(b)
             // Collect edges to avoid borrow conflict
             let edges: Vec<Edge> = node.edges.clone();
-            let node_value_kind = match &node.value {
-                NodeValue::Phi => "Phi",
-                _ => "Other",
-            };
+            let node_is_phi = matches!(node.value, NodeValue::Phi);
             let node_aliases: Vec<(IdentifierId, usize)> =
                 node.aliases.iter().map(|(&k, &v)| (k, v)).collect();
             let node_maybe_aliases: Vec<(IdentifierId, usize)> =
@@ -378,7 +375,7 @@ impl AliasingState {
                 });
             }
 
-            if entry.direction == Direction::Backwards || node_value_kind != "Phi" {
+            if entry.direction == Direction::Backwards || !node_is_phi {
                 // Backward alias edges
                 for (alias, when) in &node_aliases {
                     if *when >= index {

--- a/src/react_compiler/inference/infer_reactive_places.rs
+++ b/src/react_compiler/inference/infer_reactive_places.rs
@@ -22,8 +22,7 @@ use crate::hir::environment::Environment;
 use crate::hir::object_shape::HookKind;
 use crate::hir::visitors;
 use crate::hir::{
-    BlockId, Effect, FunctionId, HirFunction, IdentifierId, InstructionValue, ParamPattern,
-    Terminal, Type,
+    BlockId, Effect, FunctionId, HirFunction, IdentifierId, InstructionValue, Terminal, Type,
 };
 
 use crate::utils::DisjointSet;
@@ -48,10 +47,7 @@ pub(crate) fn infer_reactive_places(
 
     // Mark all function parameters as reactive
     for param in &func.params {
-        let place = match param {
-            ParamPattern::Place(p) => p,
-            ParamPattern::Spread(s) => &s.place,
-        };
+        let place = param.place();
         reactive_map.mark_reactive(place.identifier);
     }
 
@@ -558,10 +554,7 @@ fn apply_reactive_flags_replay(
 
     // 1. Mark params
     for param in &mut func.params {
-        let place = match param {
-            ParamPattern::Place(p) => p,
-            ParamPattern::Spread(s) => &mut s.place,
-        };
+        let place = param.place_mut();
         place.reactive = true;
     }
 

--- a/src/react_compiler/inference/propagate_scope_dependencies_hir.rs
+++ b/src/react_compiler/inference/propagate_scope_dependencies_hir.rs
@@ -256,16 +256,6 @@ fn is_load_context_mutable(
     false
 }
 
-/// Corresponds to TS `convertHoistedLValueKind` — returns None for non-hoisted kinds.
-fn convert_hoisted_lvalue_kind(kind: InstructionKind) -> Option<InstructionKind> {
-    match kind {
-        InstructionKind::HoistedLet => Some(InstructionKind::Let),
-        InstructionKind::HoistedConst => Some(InstructionKind::Const),
-        InstructionKind::HoistedFunction => Some(InstructionKind::Function),
-        _ => None,
-    }
-}
-
 /// Recursive implementation. Corresponds to TS `collectTemporariesSidemapImpl`.
 fn collect_temporaries_sidemap_impl(
     func: &HirFunction,
@@ -2087,7 +2077,7 @@ fn handle_instruction(
         }
         InstructionValue::DeclareLocal { lvalue, .. }
         | InstructionValue::DeclareContext { lvalue, .. } => {
-            if convert_hoisted_lvalue_kind(lvalue.kind).is_none() {
+            if lvalue.kind.unhoisted().is_none() {
                 let scope_stack_copy = ctx.scope_stack.clone();
                 ctx.declare(
                     lvalue.place.identifier,

--- a/src/react_compiler/lowering/build_hir/expr.rs
+++ b/src/react_compiler/lowering/build_hir/expr.rs
@@ -1383,34 +1383,10 @@ fn is_reorderable_expression(
             }
         }),
         Data::EDot(d) if d.optional_chain.is_none() => {
-            let mut inner = &d.target;
-            loop {
-                match &inner.data {
-                    Data::EDot(d2) if d2.optional_chain.is_none() => inner = &d2.target,
-                    Data::EIndex(i2) if i2.optional_chain.is_none() => inner = &i2.target,
-                    _ => break,
-                }
-            }
-            match &inner.data {
-                Data::EIdentifier(ident) => is_module_level_or_global(builder, ident.ref_),
-                Data::EImportIdentifier(_) => true,
-                _ => false,
-            }
+            is_member_chain_of_module_level_or_global(builder, &d.target)
         }
         Data::EIndex(i) if i.optional_chain.is_none() => {
-            let mut inner = &i.target;
-            loop {
-                match &inner.data {
-                    Data::EDot(d2) if d2.optional_chain.is_none() => inner = &d2.target,
-                    Data::EIndex(i2) if i2.optional_chain.is_none() => inner = &i2.target,
-                    _ => break,
-                }
-            }
-            match &inner.data {
-                Data::EIdentifier(ident) => is_module_level_or_global(builder, ident.ref_),
-                Data::EImportIdentifier(_) => true,
-                _ => false,
-            }
+            is_member_chain_of_module_level_or_global(builder, &i.target)
         }
         Data::EArrow(arrow) => {
             let stmts = arrow.body.stmts.slice();
@@ -1440,6 +1416,23 @@ fn is_reorderable_expression(
         Data::EInlinedEnum(e) => {
             is_reorderable_expression(builder, &e.value, allow_local_identifiers)
         }
+        _ => false,
+    }
+}
+
+/// `a.b[c].d` rooted at a module-level or global binding (no optional chaining).
+fn is_member_chain_of_module_level_or_global(builder: &HirBuilder, target: &Expr) -> bool {
+    let mut inner = target;
+    loop {
+        match &inner.data {
+            Data::EDot(d) if d.optional_chain.is_none() => inner = &d.target,
+            Data::EIndex(i) if i.optional_chain.is_none() => inner = &i.target,
+            _ => break,
+        }
+    }
+    match &inner.data {
+        Data::EIdentifier(ident) => is_module_level_or_global(builder, ident.ref_),
+        Data::EImportIdentifier(_) => true,
         _ => false,
     }
 }

--- a/src/react_compiler/lowering/hir_builder.rs
+++ b/src/react_compiler/lowering/hir_builder.rs
@@ -12,6 +12,7 @@ use crate::diagnostics::CompilerError;
 use crate::diagnostics::CompilerErrorDetail;
 use crate::diagnostics::ErrorCategory;
 use crate::diagnostics::Position;
+use crate::hir::cfg_utils::mark_instruction_ids;
 use crate::hir::environment::Environment;
 use crate::hir::visitors::each_terminal_successor;
 use crate::hir::visitors::terminal_fallthrough;
@@ -1246,18 +1247,6 @@ fn remove_unnecessary_try_catch(hir: &mut HIR) {
                 fallthrough.preds.shift_remove(&handler_id);
             }
         }
-    }
-}
-
-fn mark_instruction_ids(hir: &mut HIR, instructions: &mut [Instruction]) {
-    let mut order: u32 = 0;
-    for block in hir.blocks.values_mut() {
-        for &instr_id in &block.instructions {
-            order += 1;
-            instructions[instr_id.0 as usize].id = EvaluationOrder(order);
-        }
-        order += 1;
-        block.terminal.set_evaluation_order(EvaluationOrder(order));
     }
 }
 

--- a/src/react_compiler/lowering/mod.rs
+++ b/src/react_compiler/lowering/mod.rs
@@ -9,4 +9,4 @@ mod find_context_identifiers;
 mod hir_builder;
 
 pub(crate) use build_hir::lower;
-pub(crate) use hir_builder::FunctionNode;
+pub(crate) use hir_builder::{FunctionNode, convert_loc};

--- a/src/react_compiler/optimization/constant_propagation.rs
+++ b/src/react_compiler/optimization/constant_propagation.rs
@@ -395,11 +395,7 @@ fn evaluate_instruction(
                 loc: prev_loc,
             }) = previous
             {
-                let prev_val = n.value();
-                let next_val = match operation {
-                    UpdateOperator::Increment => prev_val + 1.0,
-                    UpdateOperator::Decrement => prev_val - 1.0,
-                };
+                let next_val = apply_update(*operation, n.value());
                 // Store the updated value for the lvalue
                 let lvalue_id = lvalue.identifier;
                 constants.insert(
@@ -429,11 +425,7 @@ fn evaluate_instruction(
                 ..
             }) = previous
             {
-                let prev_val = n.value();
-                let next_val = match operation {
-                    UpdateOperator::Increment => prev_val + 1.0,
-                    UpdateOperator::Decrement => prev_val - 1.0,
-                };
+                let next_val = apply_update(*operation, n.value());
                 let result = Constant::Primitive {
                     value: PrimitiveValue::Number(FloatValue::new(next_val)),
                     loc: *loc,
@@ -736,6 +728,13 @@ fn process_inner_function(func_id: FunctionId, env: &mut Environment, constants:
 // =============================================================================
 // Helper: read constant for a place
 // =============================================================================
+
+fn apply_update(operation: UpdateOperator, value: f64) -> f64 {
+    match operation {
+        UpdateOperator::Increment => value + 1.0,
+        UpdateOperator::Decrement => value - 1.0,
+    }
+}
 
 fn read(constants: &Constants, place: &Place) -> Option<Constant> {
     constants.get(place.identifier).cloned()

--- a/src/react_compiler/optimization/inline_iifes.rs
+++ b/src/react_compiler/optimization/inline_iifes.rs
@@ -415,13 +415,6 @@ fn declare_temporary(
 /// Promote a temporary identifier to a named identifier.
 fn promote_temporary(env: &mut Environment, identifier_id: IdentifierId) {
     let decl_id = env.identifiers[identifier_id.0 as usize].declaration_id;
-    let mut itoa = bun_core::fmt::ItoaBuf::new();
-    let digits = itoa.format(decl_id.0).as_bytes();
-    let mut buf = [0u8; 16];
-    buf[0] = b'#';
-    buf[1] = b't';
-    buf[2..2 + digits.len()].copy_from_slice(digits);
-    env.identifiers[identifier_id.0 as usize].name = Some(IdentifierName::Promoted(
-        crate::hir::StoreStr::new(bun_ast::data_store_dupe_str(&buf[..2 + digits.len()])),
-    ));
+    env.identifiers[identifier_id.0 as usize].name =
+        Some(IdentifierName::promoted(b't', decl_id.0));
 }

--- a/src/react_compiler/optimization/outline_jsx.rs
+++ b/src/react_compiler/optimization/outline_jsx.rs
@@ -46,18 +46,6 @@ struct OutlinedJsxAttribute {
     place: Place,
 }
 
-fn promoted_name(kind: u8, n: u32) -> IdentifierName {
-    let mut itoa = bun_core::fmt::ItoaBuf::new();
-    let digits = itoa.format(n).as_bytes();
-    let mut buf = [0u8; 16];
-    buf[0] = b'#';
-    buf[1] = kind;
-    buf[2..2 + digits.len()].copy_from_slice(digits);
-    IdentifierName::Promoted(StoreStr::new(bun_ast::data_store_dupe_str(
-        &buf[..2 + digits.len()],
-    )))
-}
-
 struct OutlinedResult {
     instrs: Vec<Instruction>,
     func: HirFunction,
@@ -326,12 +314,12 @@ fn collect_props(
                     let decl_id = env.identifiers[child_id.0 as usize].declaration_id;
                     if env.identifiers[child_id.0 as usize].name.is_none() {
                         env.identifiers[child_id.0 as usize].name =
-                            Some(promoted_name(b't', decl_id.0));
+                            Some(IdentifierName::promoted(b't', decl_id.0));
                     }
 
                     let child_name = match &env.identifiers[child_id.0 as usize].name {
                         Some(IdentifierName::Named(n)) | Some(IdentifierName::Promoted(n)) => *n,
-                        None => match promoted_name(b't', decl_id.0) {
+                        None => match IdentifierName::promoted(b't', decl_id.0) {
                             IdentifierName::Promoted(s) => s,
                             _ => unreachable!(),
                         },
@@ -366,7 +354,7 @@ fn emit_outlined_jsx(
     let load_id = env.next_identifier_id();
     // Promote it as a JSX tag temporary
     let decl_id = env.identifiers[load_id.0 as usize].declaration_id;
-    env.identifiers[load_id.0 as usize].name = Some(promoted_name(b'T', decl_id.0));
+    env.identifiers[load_id.0 as usize].name = Some(IdentifierName::promoted(b'T', decl_id.0));
 
     let load_place = Place {
         identifier: load_id,
@@ -422,7 +410,7 @@ fn emit_outlined_fn(
     // Create props parameter
     let props_obj_id = env.next_identifier_id();
     let decl_id = env.identifiers[props_obj_id.0 as usize].declaration_id;
-    env.identifiers[props_obj_id.0 as usize].name = Some(promoted_name(b't', decl_id.0));
+    env.identifiers[props_obj_id.0 as usize].name = Some(IdentifierName::promoted(b't', decl_id.0));
     let props_obj = Place {
         identifier: props_obj_id,
         effect: crate::hir::Effect::Unknown,

--- a/src/react_compiler/program.rs
+++ b/src/react_compiler/program.rs
@@ -13,9 +13,7 @@
 //! original in place; a final `finish()` call emits the runtime import and
 //! any outlined function decls as a separate `Part`.
 
-use crate::diagnostics::{
-    CompilerError, CompilerErrorOrDiagnostic, ErrorCategory, cold_diagnostic,
-};
+use crate::diagnostics::{CompilerError, ErrorCategory, cold_diagnostic};
 use crate::hir::ReactFunctionType;
 use crate::hir::environment::OutputMode;
 use crate::hir::environment_config::EnvironmentConfig;
@@ -1009,22 +1007,19 @@ fn handle_error(
         // surface as Invariant/Todo for inputs upstream compiles cleanly. Those
         // are port bugs, not user-facing diagnostics; bail per-function so the
         // suite measures the user-visible error surface.
-        "all_errors" if opts.parse_test_pragmas => err.details.iter().any(|d| {
-            let cat = match d {
-                CompilerErrorOrDiagnostic::Diagnostic(d) => d.category,
-                CompilerErrorOrDiagnostic::ErrorDetail(d) => d.category,
-            };
-            !matches!(cat, ErrorCategory::Invariant | ErrorCategory::Todo)
-        }),
+        "all_errors" if opts.parse_test_pragmas => err
+            .details
+            .iter()
+            .any(|d| !matches!(d.category(), ErrorCategory::Invariant | ErrorCategory::Todo)),
         "all_errors" => true,
         "critical_errors" => err.has_errors(),
         _ => false,
     };
 
-    let is_config_error = err.details.iter().any(|d| match d {
-        CompilerErrorOrDiagnostic::Diagnostic(d) => d.category == ErrorCategory::Config,
-        CompilerErrorOrDiagnostic::ErrorDetail(d) => d.category == ErrorCategory::Config,
-    });
+    let is_config_error = err
+        .details
+        .iter()
+        .any(|d| d.category() == ErrorCategory::Config);
 
     if should_panic || is_config_error {
         Some(CompileOutput::Error {

--- a/src/react_compiler/reactive_scopes/extract_scope_declarations_from_destructuring.rs
+++ b/src/react_compiler/reactive_scopes/extract_scope_declarations_from_destructuring.rs
@@ -129,16 +129,8 @@ impl<'a> ReactiveFunctionTransform for Transform<'a> {
                     // (matches TS makeTemporaryIdentifier which receives place.loc)
                     env.identifiers[temp_id.0 as usize].loc = place.loc.clone();
                     // Promote the temporary
-                    let mut itoa = bun_core::fmt::ItoaBuf::new();
-                    let digits = itoa.format(decl_id.0).as_bytes();
-                    let mut buf = [0u8; 16];
-                    buf[0] = b'#';
-                    buf[1] = b't';
-                    buf[2..2 + digits.len()].copy_from_slice(digits);
                     env.identifiers[temp_id.0 as usize].name =
-                        Some(IdentifierName::Promoted(crate::hir::StoreStr::new(
-                            bun_ast::data_store_dupe_str(&buf[..2 + digits.len()]),
-                        )));
+                        Some(IdentifierName::promoted(b't', decl_id.0));
                     let temporary = Place {
                         identifier: temp_id,
                         effect: place.effect,

--- a/src/react_compiler/reactive_scopes/extract_scope_declarations_from_destructuring.rs
+++ b/src/react_compiler/reactive_scopes/extract_scope_declarations_from_destructuring.rs
@@ -11,9 +11,9 @@
 use std::collections::HashSet;
 
 use crate::hir::{
-    DeclarationId, IdentifierId, IdentifierName, InstructionKind, InstructionValue, LValue,
-    ParamPattern, Place, ReactiveFunction, ReactiveInstruction, ReactiveScopeBlock,
-    ReactiveStatement, ReactiveValue, environment::Environment, visitors,
+    DeclarationId, IdentifierId, IdentifierName, InstructionKind, InstructionValue, LValue, Place,
+    ReactiveFunction, ReactiveInstruction, ReactiveScopeBlock, ReactiveStatement, ReactiveValue,
+    environment::Environment, visitors,
 };
 
 use crate::reactive_scopes::visitors::{
@@ -33,10 +33,7 @@ pub(crate) fn extract_scope_declarations_from_destructuring(
 ) -> Result<(), crate::diagnostics::CompilerError> {
     let mut declared: HashSet<DeclarationId> = HashSet::new();
     for param in &func.params {
-        let place = match param {
-            ParamPattern::Place(p) => p,
-            ParamPattern::Spread(s) => &s.place,
-        };
+        let place = param.place();
         let identifier = &env.identifiers[place.identifier.0 as usize];
         declared.insert(identifier.declaration_id);
     }

--- a/src/react_compiler/reactive_scopes/promote_used_temporaries.rs
+++ b/src/react_compiler/reactive_scopes/promote_used_temporaries.rs
@@ -1179,14 +1179,7 @@ fn promote_identifier(identifier_id: IdentifierId, state: &mut State, env: &mut 
     } else {
         b't'
     };
-    let mut itoa = bun_core::fmt::ItoaBuf::new();
-    let digits = itoa.format(decl_id.0).as_bytes();
-    let mut buf = [0u8; 16];
-    buf[0] = b'#';
-    buf[1] = kind;
-    buf[2..2 + digits.len()].copy_from_slice(digits);
-    env.identifiers[identifier_id.0 as usize].name = Some(IdentifierName::Promoted(
-        crate::hir::StoreStr::new(bun_ast::data_store_dupe_str(&buf[..2 + digits.len()])),
-    ));
+    env.identifiers[identifier_id.0 as usize].name =
+        Some(IdentifierName::promoted(kind, decl_id.0));
     state.promoted.insert(decl_id);
 }

--- a/src/react_compiler/reactive_scopes/promote_used_temporaries.rs
+++ b/src/react_compiler/reactive_scopes/promote_used_temporaries.rs
@@ -64,10 +64,7 @@ pub(crate) fn promote_used_temporaries(func: &mut ReactiveFunction, env: &mut En
 
     // Promote params
     for param in &func.params {
-        let place = match param {
-            ParamPattern::Place(p) => p,
-            ParamPattern::Spread(s) => &s.place,
-        };
+        let place = param.place();
         let identifier = &env.identifiers[place.identifier.0 as usize];
         if identifier.name.is_none() {
             promote_identifier(place.identifier, &mut state, env);
@@ -510,10 +507,7 @@ fn visit_hir_function_for_promotion(func_id: FunctionId, state: &mut State, env:
         let func = &env.functions[func_id.0 as usize];
         func.params
             .iter()
-            .map(|param| match param {
-                ParamPattern::Place(p) => p.identifier,
-                ParamPattern::Spread(s) => s.place.identifier,
-            })
+            .map(|param| param.place().identifier)
             .collect()
     };
     for id in param_ids {
@@ -929,10 +923,7 @@ fn promote_interposed_terminal(
 
 fn promote_all_instances_params(func: &ReactiveFunction, state: &mut State, env: &mut Environment) {
     for param in &func.params {
-        let place = match param {
-            ParamPattern::Place(p) => p,
-            ParamPattern::Spread(s) => &s.place,
-        };
+        let place = param.place();
         let identifier = &env.identifiers[place.identifier.0 as usize];
         if identifier.name.is_none() && state.promoted.contains(&identifier.declaration_id) {
             promote_identifier(place.identifier, state, env);
@@ -1034,10 +1025,7 @@ fn promote_all_instances_value(value: &ReactiveValue, state: &mut State, env: &m
                     let param_ids: Vec<IdentifierId> = inner_func
                         .params
                         .iter()
-                        .map(|p| match p {
-                            ParamPattern::Place(p) => p.identifier,
-                            ParamPattern::Spread(s) => s.place.identifier,
-                        })
+                        .map(|p| p.place().identifier)
                         .collect();
                     for id in param_ids {
                         let identifier = &env.identifiers[id.0 as usize];

--- a/src/react_compiler/reactive_scopes/propagate_early_returns.rs
+++ b/src/react_compiler/reactive_scopes/propagate_early_returns.rs
@@ -284,17 +284,6 @@ fn create_temporary_place_id(
 
 fn promote_temporary(env: &mut Environment, identifier_id: IdentifierId) {
     let decl_id = env.identifiers[identifier_id.0 as usize].declaration_id;
-    env.identifiers[identifier_id.0 as usize].name = Some(promoted_name(b't', decl_id.0));
-}
-
-fn promoted_name(kind: u8, n: u32) -> IdentifierName {
-    let mut itoa = bun_core::fmt::ItoaBuf::new();
-    let digits = itoa.format(n).as_bytes();
-    let mut buf = [0u8; 16];
-    buf[0] = b'#';
-    buf[1] = kind;
-    buf[2..2 + digits.len()].copy_from_slice(digits);
-    IdentifierName::Promoted(StoreStr::new(bun_ast::data_store_dupe_str(
-        &buf[..2 + digits.len()],
-    )))
+    env.identifiers[identifier_id.0 as usize].name =
+        Some(IdentifierName::promoted(b't', decl_id.0));
 }

--- a/src/react_compiler/reactive_scopes/prune_hoisted_contexts.rs
+++ b/src/react_compiler/reactive_scopes/prune_hoisted_contexts.rs
@@ -132,7 +132,7 @@ impl<'a> ReactiveFunctionTransform for Transform<'a> {
         if let ReactiveValue::Instruction(InstructionValue::DeclareContext { lvalue, .. }) =
             &instruction.value
         {
-            let maybe_non_hoisted = convert_hoisted_lvalue_kind(lvalue.kind);
+            let maybe_non_hoisted = lvalue.kind.unhoisted();
             if let Some(non_hoisted) = maybe_non_hoisted {
                 if non_hoisted == InstructionKind::Function
                     && state.uninitialized.contains_key(lvalue.place.identifier)
@@ -181,15 +181,5 @@ impl<'a> ReactiveFunctionTransform for Transform<'a> {
 
         self.visit_instruction(instruction, state)?;
         Ok(Transformed::Keep)
-    }
-}
-
-/// Corresponds to TS `convertHoistedLValueKind` — returns None for non-hoisted kinds.
-fn convert_hoisted_lvalue_kind(kind: InstructionKind) -> Option<InstructionKind> {
-    match kind {
-        InstructionKind::HoistedLet => Some(InstructionKind::Let),
-        InstructionKind::HoistedConst => Some(InstructionKind::Const),
-        InstructionKind::HoistedFunction => Some(InstructionKind::Function),
-        _ => None,
     }
 }

--- a/src/react_compiler/reactive_scopes/prune_non_escaping_scopes.rs
+++ b/src/react_compiler/reactive_scopes/prune_non_escaping_scopes.rs
@@ -24,7 +24,6 @@ use crate::hir::JsxTag;
 use crate::hir::ObjectPropertyOrSpread;
 use crate::hir::Pattern;
 use crate::hir::Place;
-use crate::hir::PlaceOrSpread;
 use crate::hir::ReactiveFunction;
 use crate::hir::ReactiveInstruction;
 use crate::hir::ReactiveScopeBlock;
@@ -960,10 +959,7 @@ impl<'a> CollectDependenciesVisitor<'a> {
                     let no_alias = env.has_no_alias_signature(callee.identifier);
                     if !no_alias {
                         for arg in args {
-                            let place = match arg {
-                                PlaceOrSpread::Spread(spread) => &spread.place,
-                                PlaceOrSpread::Place(place) => place,
-                            };
+                            let place = arg.place();
                             let decl = env.identifiers[place.identifier.0 as usize].declaration_id;
                             state.escaping_values.insert(decl);
                         }
@@ -985,10 +981,7 @@ impl<'a> CollectDependenciesVisitor<'a> {
                     let no_alias = env.has_no_alias_signature(property.identifier);
                     if !no_alias {
                         for arg in args {
-                            let place = match arg {
-                                PlaceOrSpread::Spread(spread) => &spread.place,
-                                PlaceOrSpread::Place(place) => place,
-                            };
+                            let place = arg.place();
                             let decl = env.identifiers[place.identifier.0 as usize].declaration_id;
                             state.escaping_values.insert(decl);
                         }
@@ -998,10 +991,7 @@ impl<'a> CollectDependenciesVisitor<'a> {
                     let type_id = env.identifiers[receiver.identifier.0 as usize].type_;
                     if is_array_type(&env.types[type_id.0 as usize]) {
                         for arg in args {
-                            let place = match arg {
-                                PlaceOrSpread::Spread(spread) => &spread.place,
-                                PlaceOrSpread::Place(place) => place,
-                            };
+                            let place = arg.place();
                             let decl = env.identifiers[place.identifier.0 as usize].declaration_id;
                             state.escaping_values.insert(decl);
                         }

--- a/src/react_compiler/reactive_scopes/prune_non_escaping_scopes.rs
+++ b/src/react_compiler/reactive_scopes/prune_non_escaping_scopes.rs
@@ -58,10 +58,7 @@ pub(crate) fn prune_non_escaping_scopes(
     // and which values are returned.
     let mut state = CollectState::new();
     for param in &func.params {
-        let place = match param {
-            crate::hir::ParamPattern::Place(p) => p,
-            crate::hir::ParamPattern::Spread(s) => &s.place,
-        };
+        let place = param.place();
         let identifier = &env.identifiers[place.identifier.0 as usize];
         state.declare(identifier.declaration_id);
     }

--- a/src/react_compiler/reactive_scopes/rename_variables.rs
+++ b/src/react_compiler/reactive_scopes/rename_variables.rs
@@ -17,7 +17,6 @@ use crate::hir::EvaluationOrder;
 use crate::hir::FunctionId;
 use crate::hir::IdentifierName;
 use crate::hir::InstructionValue;
-use crate::hir::ParamPattern;
 use crate::hir::Place;
 use crate::hir::PrunedReactiveScopeBlock;
 use crate::hir::ReactiveBlock;
@@ -257,10 +256,7 @@ fn rename_variables_with_parent(
 fn rename_variables_impl(func: &ReactiveFunction, visitor: &Visitor, scopes: &mut Scopes) {
     scopes.enter();
     for param in &func.params {
-        let place = match param {
-            ParamPattern::Place(p) => p,
-            ParamPattern::Spread(s) => &s.place,
-        };
+        let place = param.place();
         visitor.visit_param(place, scopes);
     }
     visitors::visit_reactive_function(func, visitor, scopes);

--- a/src/react_compiler/reactive_scopes/visitors.rs
+++ b/src/react_compiler/reactive_scopes/visitors.rs
@@ -9,9 +9,9 @@
 
 use crate::diagnostics::CompilerError;
 use crate::hir::{
-    EvaluationOrder, FunctionId, InstructionValue, ParamPattern, Place, PrunedReactiveScopeBlock,
-    ReactiveBlock, ReactiveFunction, ReactiveInstruction, ReactiveScopeBlock, ReactiveStatement,
-    ReactiveTerminal, ReactiveTerminalStatement, ReactiveValue, environment::Environment,
+    EvaluationOrder, FunctionId, InstructionValue, Place, PrunedReactiveScopeBlock, ReactiveBlock,
+    ReactiveFunction, ReactiveInstruction, ReactiveScopeBlock, ReactiveStatement, ReactiveTerminal,
+    ReactiveTerminalStatement, ReactiveValue, environment::Environment,
 };
 
 // =============================================================================
@@ -46,10 +46,7 @@ pub(crate) trait ReactiveFunctionVisitor {
     fn visit_hir_function(&self, func_id: FunctionId, state: &mut Self::State) {
         let inner_func = &self.env().functions[func_id.0 as usize];
         for param in &inner_func.params {
-            let place = match param {
-                ParamPattern::Place(p) => p,
-                ParamPattern::Spread(s) => &s.place,
-            };
+            let place = param.place();
             self.visit_param(place, state);
         }
         let block_ids: Vec<_> = inner_func.body.blocks.keys().copied().collect();

--- a/src/react_compiler/ssa/rewrite_instruction_kinds_based_on_reassignment.rs
+++ b/src/react_compiler/ssa/rewrite_instruction_kinds_based_on_reassignment.rs
@@ -20,9 +20,7 @@ use crate::diagnostics::{
     CompilerDiagnostic, CompilerDiagnosticDetail, CompilerError, ErrorCategory, SourceLocation,
 };
 use crate::hir::visitors::each_pattern_operand;
-use crate::hir::{
-    BlockKind, DeclarationId, HirFunction, InstructionKind, InstructionValue, ParamPattern, Place,
-};
+use crate::hir::{BlockKind, DeclarationId, HirFunction, InstructionKind, InstructionValue, Place};
 
 use crate::hir::environment::Environment;
 
@@ -130,10 +128,7 @@ pub(crate) fn rewrite_instruction_kinds_based_on_reassignment(
 
     // Seed with parameters
     for param in &func.params {
-        let place: &Place = match param {
-            ParamPattern::Place(p) => p,
-            ParamPattern::Spread(s) => &s.place,
-        };
+        let place: &Place = param.place();
         let ident = &env.identifiers[place.identifier.0 as usize];
         if ident.name.is_some() {
             declarations.insert(ident.declaration_id, DeclarationLoc::ParamOrContext);

--- a/src/react_compiler/ssa/rewrite_instruction_kinds_based_on_reassignment.rs
+++ b/src/react_compiler/ssa/rewrite_instruction_kinds_based_on_reassignment.rs
@@ -108,6 +108,18 @@ enum DeclarationLoc {
     ParamOrContext,
 }
 
+impl DeclarationLoc {
+    fn instruction(&self) -> Option<(usize, usize)> {
+        match self {
+            DeclarationLoc::Instruction {
+                block_index,
+                instr_local_index,
+            } => Some((*block_index, *instr_local_index)),
+            DeclarationLoc::ParamOrContext => None,
+        }
+    }
+}
+
 pub(crate) fn rewrite_instruction_kinds_based_on_reassignment(
     func: &mut HirFunction,
     env: &Environment,
@@ -178,16 +190,9 @@ pub(crate) fn rewrite_instruction_kinds_based_on_reassignment(
                         let decl_id = ident.declaration_id;
                         if let Some(existing) = declarations.get(decl_id) {
                             // Reassignment: mark existing declaration as Let, current as Reassign
-                            match existing {
-                                DeclarationLoc::Instruction {
-                                    block_index: bi,
-                                    instr_local_index: ili,
-                                } => {
-                                    let_locs.push((*bi, *ili));
-                                }
-                                DeclarationLoc::ParamOrContext => {
-                                    // Already Let, no-op
-                                }
+                            // A parameter or context variable is already Let.
+                            if let Some(loc) = existing.instruction() {
+                                let_locs.push(loc);
                             }
                             reassign_locs.push((block_index, local_idx));
                         } else {
@@ -247,16 +252,9 @@ pub(crate) fn rewrite_instruction_kinds_based_on_reassignment(
                                     ));
                                 }
                                 kind = Some(InstructionKind::Reassign);
-                                match existing {
-                                    DeclarationLoc::Instruction {
-                                        block_index: bi,
-                                        instr_local_index: ili,
-                                    } => {
-                                        let_locs.push((*bi, *ili));
-                                    }
-                                    DeclarationLoc::ParamOrContext => {
-                                        // Already Let
-                                    }
+                                // A parameter or context variable is already Let.
+                                if let Some(loc) = existing.instruction() {
+                                    let_locs.push(loc);
                                 }
                             } else {
                                 // New declaration
@@ -304,16 +302,9 @@ pub(crate) fn rewrite_instruction_kinds_based_on_reassignment(
                             lvalue.loc,
                         ));
                     };
-                    match existing {
-                        DeclarationLoc::Instruction {
-                            block_index: bi,
-                            instr_local_index: ili,
-                        } => {
-                            let_locs.push((*bi, *ili));
-                        }
-                        DeclarationLoc::ParamOrContext => {
-                            // Already Let
-                        }
+                    // A parameter or context variable is already Let.
+                    if let Some(loc) = existing.instruction() {
+                        let_locs.push(loc);
                     }
                 }
                 _ => {}

--- a/src/react_compiler/validation/validate_exhaustive_dependencies.rs
+++ b/src/react_compiler/validation/validate_exhaustive_dependencies.rs
@@ -13,8 +13,8 @@ use crate::hir::visitors::{
 use crate::hir::{
     ArrayElement, AstAlloc, BlockId, DependencyPathEntry, HirFunction, HirVec, Identifier,
     IdentifierId, InstructionKind, InstructionValue, ManualMemoDependency,
-    ManualMemoDependencyRoot, NonLocalBinding, ParamPattern, Place, PlaceOrSpread, PropertyLiteral,
-    StoreStr, Terminal, Type, hir_vec,
+    ManualMemoDependencyRoot, NonLocalBinding, Place, PlaceOrSpread, PropertyLiteral, StoreStr,
+    Terminal, Type, hir_vec,
 };
 use bun_core::BStr;
 use core::fmt::Write as _;
@@ -38,10 +38,7 @@ pub(crate) fn validate_exhaustive_dependencies(
 
     let mut temporaries: IdMap<IdentifierId, Temporary> = IdMap::new();
     for param in &func.params {
-        let place = match param {
-            ParamPattern::Place(p) => p,
-            ParamPattern::Spread(s) => &s.place,
-        };
+        let place = param.place();
         temporaries.insert(
             place.identifier,
             Temporary::Local {
@@ -469,10 +466,7 @@ fn collect_dependencies(
 
     if is_function_expression {
         for param in &func.params {
-            let place = match param {
-                ParamPattern::Place(p) => p,
-                ParamPattern::Spread(s) => &s.place,
-            };
+            let place = param.place();
             locals.insert(place.identifier);
         }
     }

--- a/src/react_compiler/validation/validate_exhaustive_dependencies.rs
+++ b/src/react_compiler/validation/validate_exhaustive_dependencies.rs
@@ -1080,10 +1080,7 @@ fn collect_dependencies(
                     visit_candidate_dependency(receiver, temporaries, &mut dependencies, &locals);
                     // Skip property — matches TS behavior
                     for arg in args {
-                        let place = match arg {
-                            PlaceOrSpread::Place(p) => p,
-                            PlaceOrSpread::Spread(s) => &s.place,
-                        };
+                        let place = arg.place();
                         visit_candidate_dependency(place, temporaries, &mut dependencies, &locals);
                     }
                 }

--- a/src/react_compiler/validation/validate_exhaustive_dependencies.rs
+++ b/src/react_compiler/validation/validate_exhaustive_dependencies.rs
@@ -179,6 +179,15 @@ fn is_stable_type(ty: &Type) -> bool {
     }
 }
 
+fn effect_report_mode(mode: ExhaustiveEffectDepsMode) -> &'static str {
+    match mode {
+        ExhaustiveEffectDepsMode::All => "all",
+        ExhaustiveEffectDepsMode::MissingOnly => "missing-only",
+        ExhaustiveEffectDepsMode::ExtraOnly => "extra-only",
+        ExhaustiveEffectDepsMode::Off => unreachable!(),
+    }
+}
+
 fn is_effect_hook(ty: &Type) -> bool {
     matches!(ty, Type::Function { shape_id: Some(id), .. }
         if matches!(*id,
@@ -891,12 +900,8 @@ fn collect_dependencies(
                                         }),
                                     ) = (fn_deps, manual_deps)
                                     {
-                                        let effect_report_mode = match &cb.validate_effect {
-                                            ExhaustiveEffectDepsMode::All => "all",
-                                            ExhaustiveEffectDepsMode::MissingOnly => "missing-only",
-                                            ExhaustiveEffectDepsMode::ExtraOnly => "extra-only",
-                                            ExhaustiveEffectDepsMode::Off => unreachable!(),
-                                        };
+                                        let effect_report_mode =
+                                            effect_report_mode(cb.validate_effect);
                                         // Convert manual deps to ManualMemoDependency format
                                         let manual_memo_deps: Vec<ManualMemoDependency> =
                                             manual_dep_list
@@ -1008,12 +1013,8 @@ fn collect_dependencies(
                                         }),
                                     ) = (fn_deps, manual_deps)
                                     {
-                                        let effect_report_mode = match &cb.validate_effect {
-                                            ExhaustiveEffectDepsMode::All => "all",
-                                            ExhaustiveEffectDepsMode::MissingOnly => "missing-only",
-                                            ExhaustiveEffectDepsMode::ExtraOnly => "extra-only",
-                                            ExhaustiveEffectDepsMode::Off => unreachable!(),
-                                        };
+                                        let effect_report_mode =
+                                            effect_report_mode(cb.validate_effect);
                                         let manual_memo_deps: Vec<ManualMemoDependency> =
                                             manual_dep_list
                                                 .iter()

--- a/src/react_compiler/validation/validate_hooks_usage.rs
+++ b/src/react_compiler/validation/validate_hooks_usage.rs
@@ -19,8 +19,8 @@ use crate::hir::environment::{Environment, is_hook_name};
 use crate::hir::object_shape::HookKind;
 use crate::hir::visitors::{each_pattern_operand, each_terminal_operand};
 use crate::hir::{
-    FunctionId, HirFunction, Identifier, IdentifierId, InstructionValue, ParamPattern, Place,
-    PropertyLiteral, Type, visitors,
+    FunctionId, HirFunction, Identifier, IdentifierId, InstructionValue, Place, PropertyLiteral,
+    Type, visitors,
 };
 
 /// Value classification for hook validation.
@@ -208,10 +208,7 @@ pub(crate) fn validate_hooks_usage(
 
     // Process params
     for param in &func.params {
-        let place = match param {
-            ParamPattern::Place(p) => p,
-            ParamPattern::Spread(s) => &s.place,
-        };
+        let place = param.place();
         let kind = get_kind_for_place(place, &value_kinds, &env.identifiers);
         value_kinds.insert(place.identifier, kind);
     }

--- a/src/react_compiler/validation/validate_hooks_usage.rs
+++ b/src/react_compiler/validation/validate_hooks_usage.rs
@@ -318,10 +318,7 @@ pub(crate) fn validate_hooks_usage(
                     }
                     // Visit all operands except callee
                     for arg in args {
-                        let place = match arg {
-                            crate::hir::PlaceOrSpread::Place(p) => p,
-                            crate::hir::PlaceOrSpread::Spread(s) => &s.place,
-                        };
+                        let place = arg.place();
                         visit_place(place, &value_kinds, &mut errors_by_loc, env)?;
                     }
                 }
@@ -347,10 +344,7 @@ pub(crate) fn validate_hooks_usage(
                     // Visit receiver and args (not property)
                     visit_place(receiver, &value_kinds, &mut errors_by_loc, env)?;
                     for arg in args {
-                        let place = match arg {
-                            crate::hir::PlaceOrSpread::Place(p) => p,
-                            crate::hir::PlaceOrSpread::Spread(s) => &s.place,
-                        };
+                        let place = arg.place();
                         visit_place(place, &value_kinds, &mut errors_by_loc, env)?;
                     }
                 }

--- a/src/react_compiler/validation/validate_no_derived_computations_in_effects.rs
+++ b/src/react_compiler/validation/validate_no_derived_computations_in_effects.rs
@@ -1435,10 +1435,7 @@ fn non_exp_value_operands(value: &InstructionValue) -> Vec<IdentifierId> {
         InstructionValue::CallExpression { callee, args, .. } => {
             let mut op_ids = vec![callee.identifier];
             for a in args {
-                match a {
-                    PlaceOrSpread::Place(p) => op_ids.push(p.identifier),
-                    PlaceOrSpread::Spread(s) => op_ids.push(s.place.identifier),
-                }
+                op_ids.push(a.place().identifier)
             }
             op_ids
         }
@@ -1450,10 +1447,7 @@ fn non_exp_value_operands(value: &InstructionValue) -> Vec<IdentifierId> {
         } => {
             let mut op_ids = vec![receiver.identifier, property.identifier];
             for a in args {
-                match a {
-                    PlaceOrSpread::Place(p) => op_ids.push(p.identifier),
-                    PlaceOrSpread::Spread(s) => op_ids.push(s.place.identifier),
-                }
+                op_ids.push(a.place().identifier)
             }
             op_ids
         }

--- a/src/react_compiler/validation/validate_no_ref_access_in_render.rs
+++ b/src/react_compiler/validation/validate_no_ref_access_in_render.rs
@@ -590,10 +590,7 @@ fn validate_no_ref_access_in_render_impl(
 
     // Process params
     for param in &func.params {
-        let place = match param {
-            crate::hir::ParamPattern::Place(p) => p,
-            crate::hir::ParamPattern::Spread(s) => &s.place,
-        };
+        let place = param.place();
         ref_env.set(
             place.identifier,
             ref_type_of_type(place.identifier, identifiers, types),

--- a/src/react_compiler/validation/validate_no_set_state_in_effects.rs
+++ b/src/react_compiler/validation/validate_no_set_state_in_effects.rs
@@ -22,7 +22,7 @@ use crate::hir::environment::Environment;
 use crate::hir::{
     BlockId, HirFunction, Identifier, IdentifierId, IdentifierName, InstructionValue,
     PlaceOrSpread, PropertyLiteral, SourceLocation, Terminal, Type, is_ref_value_type,
-    is_set_state_type, is_use_effect_event_type, is_use_effect_hook_type,
+    is_set_state_identifier, is_use_effect_event_type, is_use_effect_hook_type,
     is_use_insertion_effect_hook_type, is_use_layout_effect_hook_type, is_use_ref_type, visitors,
 };
 
@@ -61,7 +61,7 @@ pub(crate) fn validate_no_set_state_in_effects(
                     // Check if any context capture references a setState
                     let inner_func = &functions[lowered_func.func.0 as usize];
                     let has_set_state_operand = inner_func.context.iter().any(|ctx_place| {
-                        is_set_state_type_by_id(ctx_place.identifier, identifiers, types)
+                        is_set_state_identifier(ctx_place.identifier, identifiers, types)
                             || set_state_functions.contains_key(&ctx_place.identifier)
                     });
 
@@ -178,16 +178,6 @@ fn get_identifier_name_with_loc(
         }
     }
     None
-}
-
-fn is_set_state_type_by_id(
-    identifier_id: IdentifierId,
-    identifiers: &[Identifier],
-    types: &[Type],
-) -> bool {
-    let ident = &identifiers[identifier_id.0 as usize];
-    let ty = &types[ident.type_.0 as usize];
-    is_set_state_type(ty)
 }
 
 fn push_error(errors: &mut CompilerError, info: &SetStateInfo, enable_verbose: bool) {
@@ -533,7 +523,7 @@ fn get_set_state_call(
                     }
                 }
                 InstructionValue::CallExpression { callee, args, .. } => {
-                    if is_set_state_type_by_id(callee.identifier, identifiers, types)
+                    if is_set_state_identifier(callee.identifier, identifiers, types)
                         || set_state_functions.contains_key(&callee.identifier)
                     {
                         if enable_allow_set_state_from_refs {

--- a/src/react_compiler/validation/validate_no_set_state_in_render.rs
+++ b/src/react_compiler/validation/validate_no_set_state_in_render.rs
@@ -12,7 +12,10 @@ use std::collections::HashSet;
 use crate::diagnostics::{CompilerDiagnostic, CompilerDiagnosticDetail, ErrorCategory};
 use crate::hir::dominator::compute_unconditional_blocks;
 use crate::hir::environment::Environment;
-use crate::hir::{HirFunction, Identifier, IdentifierId, InstructionValue, SourceLocation, Type};
+use crate::hir::{
+    HirFunction, Identifier, IdentifierId, InstructionValue, SourceLocation, Type,
+    is_set_state_identifier,
+};
 
 pub(crate) fn validate_no_set_state_in_render(
     func: &HirFunction,
@@ -33,16 +36,6 @@ pub(crate) fn validate_no_set_state_in_render(
         env.record_diagnostic(diag);
     }
     Ok(())
-}
-
-fn is_set_state_id(
-    identifier_id: IdentifierId,
-    identifiers: &[Identifier],
-    types: &[Type],
-) -> bool {
-    let ident = &identifiers[identifier_id.0 as usize];
-    let ty = &types[ident.type_.0 as usize];
-    crate::hir::is_set_state_type(ty)
 }
 
 fn validate_impl(
@@ -80,7 +73,7 @@ fn validate_impl(
                     // Check if any operand references a setState.
                     // For FunctionExpression/ObjectMethod, operands are the context captures.
                     let has_set_state_operand = inner_func.context.iter().any(|ctx_place| {
-                        is_set_state_id(ctx_place.identifier, identifiers, types)
+                        is_set_state_identifier(ctx_place.identifier, identifiers, types)
                             || unconditional_set_state_functions.contains(&ctx_place.identifier)
                     });
 
@@ -114,7 +107,7 @@ fn validate_impl(
                     active_manual_memo_id = None;
                 }
                 InstructionValue::CallExpression { callee, .. } => {
-                    if is_set_state_id(callee.identifier, identifiers, types)
+                    if is_set_state_identifier(callee.identifier, identifiers, types)
                         || unconditional_set_state_functions.contains(&callee.identifier)
                     {
                         if active_manual_memo_id.is_some() {

--- a/src/react_compiler/validation/validate_use_memo.rs
+++ b/src/react_compiler/validation/validate_use_memo.rs
@@ -7,8 +7,8 @@ use crate::diagnostics::{
 use crate::hir::environment::Environment;
 use crate::hir::visitors::{each_instruction_value_operand_with_functions, each_terminal_operand};
 use crate::hir::{
-    FunctionId, HirFunction, IdentifierId, InstructionValue, ParamPattern, Place, PlaceOrSpread,
-    ReturnVariant, Terminal,
+    FunctionId, HirFunction, IdentifierId, InstructionValue, Place, PlaceOrSpread, ReturnVariant,
+    Terminal,
 };
 
 /// Validates useMemo() usage patterns.
@@ -258,10 +258,7 @@ fn handle_possible_use_memo_call(
     // Validate no parameters
     if !body_func.params.is_empty() {
         let first_param = &body_func.params[0];
-        let loc = match first_param {
-            ParamPattern::Place(place) => place.loc,
-            ParamPattern::Spread(spread) => spread.place.loc,
-        };
+        let loc = first_param.place().loc;
         errors.push_diagnostic(diag_params_not_allowed(loc));
     }
 

--- a/src/resolver/dir_info.rs
+++ b/src/resolver/dir_info.rs
@@ -231,13 +231,10 @@ impl DirInfo {
     /// `unsafe` here. The `.data` map must only be probed/iterated while the
     /// lock is held; use [`get_entry`](Self::get_entry) for one-shot lookups.
     pub fn get_entries_ref_locked(&self, generation: Generation) -> Option<&'static fs::DirEntry> {
-        let entries_ptr = fs::FileSystem::instance()
+        fs::FileSystem::instance()
             .fs
-            .entries_at_locked(self.entries, generation)?;
-        match entries_ptr {
-            fs::EntriesOption::Entries(entries) => Some(&**entries),
-            fs::EntriesOption::Err(_) => None,
-        }
+            .entries_at_locked(self.entries, generation)?
+            .as_entries()
     }
 
     /// Generation-checked lookup of one basename in this directory's cached
@@ -257,13 +254,9 @@ impl DirInfo {
         // `MutexGuard` stores the mutex by raw pointer, so holding it does not
         // keep `rfs` borrowed.
         let _lock = rfs.entries_mutex.lock_guard();
-        match rfs.entries_at_locked(self.entries, generation)? {
-            fs::EntriesOption::Entries(entries) => {
-                let entries: &'static fs::DirEntry = entries;
-                entries.get(query)
-            }
-            fs::EntriesOption::Err(_) => None,
-        }
+        rfs.entries_at_locked(self.entries, generation)?
+            .as_entries()?
+            .get(query)
     }
 
     /// As-cached listing access with no generation check and no locking.
@@ -271,14 +264,11 @@ impl DirInfo {
     /// `.data` map must only be probed/iterated while `entries_mutex` is held
     /// (a concurrent stale-generation re-read rewrites it in place).
     pub fn get_entries_const(&self) -> Option<&fs::DirEntry> {
-        let entries_ptr = fs::FileSystem::instance()
+        fs::FileSystem::instance()
             .fs
             .entries
-            .at_index(self.entries)?;
-        match entries_ptr {
-            fs::EntriesOption::Entries(entries) => Some(&**entries),
-            fs::EntriesOption::Err(_) => None,
-        }
+            .at_index(self.entries)?
+            .as_entries()
     }
 
     #[inline]

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -885,6 +885,13 @@ pub mod fs {
         // Payload is `&'static mut DirEntry`; auto-deref coerces to `&DirEntry` / `&mut DirEntry`.
         bun_core::enum_unwrap!(pub EntriesOption, Entries => fn entries / entries_mut -> DirEntry);
 
+        pub(crate) fn as_entries(&self) -> Option<&DirEntry> {
+            match self {
+                EntriesOption::Entries(entries) => Some(&**entries),
+                EntriesOption::Err(_) => None,
+            }
+        }
+
         /// Probe the cached listing for `query` and return the lookup plus the
         /// listing fd, in one `entries_mutex` critical section. A
         /// stale-generation re-read rewrites the slot's `DirEntry` (and frees

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -1571,33 +1571,8 @@ impl<'a> Resolver<'a> {
                     PJSideEffects::Unspecified | PJSideEffects::Glob(_) | PJSideEffects::Mixed(_)
                 );
 
-                result.primary_side_effects_data = match &existing.side_effects {
-                    PJSideEffects::Unspecified => SideEffects::HasSideEffects,
-                    PJSideEffects::False => SideEffects::NoSideEffectsPackageJson,
-                    PJSideEffects::Map(map) => {
-                        if map.contains_key(&crate::package_json::StringHashMapUnownedKey::init(
-                            path.text(),
-                        )) {
-                            SideEffects::HasSideEffects
-                        } else {
-                            SideEffects::NoSideEffectsPackageJson
-                        }
-                    }
-                    PJSideEffects::Glob(_) => {
-                        if existing.side_effects.has_side_effects(path.text()) {
-                            SideEffects::HasSideEffects
-                        } else {
-                            SideEffects::NoSideEffectsPackageJson
-                        }
-                    }
-                    PJSideEffects::Mixed(_) => {
-                        if existing.side_effects.has_side_effects(path.text()) {
-                            SideEffects::HasSideEffects
-                        } else {
-                            SideEffects::NoSideEffectsPackageJson
-                        }
-                    }
-                };
+                result.primary_side_effects_data =
+                    primary_side_effects(&existing.side_effects, path.text());
 
                 if existing.name.is_empty() || self.care_about_bin_folder {
                     result.package_json = None;
@@ -1610,34 +1585,8 @@ impl<'a> Resolver<'a> {
 
             if needs_side_effects {
                 if let Some(package_json) = Result::deref_package_json(result.package_json) {
-                    use crate::package_json::SideEffects as PJSideEffects;
-                    result.primary_side_effects_data = match &package_json.side_effects {
-                        PJSideEffects::Unspecified => SideEffects::HasSideEffects,
-                        PJSideEffects::False => SideEffects::NoSideEffectsPackageJson,
-                        PJSideEffects::Map(map) => {
-                            if map.contains_key(
-                                &crate::package_json::StringHashMapUnownedKey::init(path.text()),
-                            ) {
-                                SideEffects::HasSideEffects
-                            } else {
-                                SideEffects::NoSideEffectsPackageJson
-                            }
-                        }
-                        PJSideEffects::Glob(_) => {
-                            if package_json.side_effects.has_side_effects(path.text()) {
-                                SideEffects::HasSideEffects
-                            } else {
-                                SideEffects::NoSideEffectsPackageJson
-                            }
-                        }
-                        PJSideEffects::Mixed(_) => {
-                            if package_json.side_effects.has_side_effects(path.text()) {
-                                SideEffects::HasSideEffects
-                            } else {
-                                SideEffects::NoSideEffectsPackageJson
-                            }
-                        }
-                    };
+                    result.primary_side_effects_data =
+                        primary_side_effects(&package_json.side_effects, path.text());
                 }
             }
 
@@ -6799,6 +6748,17 @@ impl<'b> BrowserMapPath<'b> {
         }
 
         false
+    }
+}
+
+fn primary_side_effects(
+    side_effects: &crate::package_json::SideEffects,
+    path: &[u8],
+) -> SideEffects {
+    if side_effects.has_side_effects(path) {
+        SideEffects::HasSideEffects
+    } else {
+        SideEffects::NoSideEffectsPackageJson
     }
 }
 

--- a/src/runtime/cli/update_interactive_command.rs
+++ b/src/runtime/cli/update_interactive_command.rs
@@ -120,6 +120,14 @@ struct CatalogUpdateRequest {
     catalog_name: Option<Box<[u8]>>,
 }
 
+/// How risky an update looks from its semver distance.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum CheckboxColor {
+    Green,
+    Yellow,
+    Red,
+}
+
 struct ColumnWidths {
     name: usize,
     current: usize,
@@ -1559,7 +1567,7 @@ impl UpdateInteractiveCommand {
                         ))
                     };
 
-                    let mut checkbox_color: &str = "green"; // default
+                    let mut checkbox_color = CheckboxColor::Green;
                     if current_ver_parsed.valid && update_ver_parsed.valid {
                         let current_full = semver::Version {
                             major: current_ver_parsed.version.major.unwrap_or(0),
@@ -1589,22 +1597,24 @@ impl UpdateInteractiveCommand {
                         );
                         if let Some(d) = diff {
                             match d {
-                                semver::version::ChangedVersion::Major => checkbox_color = "red",
+                                semver::version::ChangedVersion::Major => {
+                                    checkbox_color = CheckboxColor::Red
+                                }
                                 semver::version::ChangedVersion::Minor => {
                                     if current_full.major == 0 {
-                                        checkbox_color = "red"; // 0.x.y minor changes are breaking
+                                        checkbox_color = CheckboxColor::Red; // 0.x.y minor changes are breaking
                                     } else {
-                                        checkbox_color = "yellow";
+                                        checkbox_color = CheckboxColor::Yellow;
                                     }
                                 }
                                 semver::version::ChangedVersion::Patch => {
                                     if current_full.major == 0 && current_full.minor == 0 {
-                                        checkbox_color = "red"; // 0.0.x patch changes are breaking
+                                        checkbox_color = CheckboxColor::Red; // 0.0.x patch changes are breaking
                                     } else {
-                                        checkbox_color = "green";
+                                        checkbox_color = CheckboxColor::Green;
                                     }
                                 }
-                                _ => checkbox_color = "green",
+                                _ => checkbox_color = CheckboxColor::Green,
                             }
                         }
                     }
@@ -1618,9 +1628,9 @@ impl UpdateInteractiveCommand {
 
                     // Checkbox with appropriate color
                     if selected {
-                        if checkbox_color == "red" {
+                        if checkbox_color == CheckboxColor::Red {
                             bun_core::pretty!("<r><red>{}<r> ", checkbox);
-                        } else if checkbox_color == "yellow" {
+                        } else if checkbox_color == CheckboxColor::Yellow {
                             bun_core::pretty!("<r><yellow>{}<r> ", checkbox);
                         } else {
                             bun_core::pretty!("<r><green>{}<r> ", checkbox);
@@ -1672,9 +1682,9 @@ impl UpdateInteractiveCommand {
                     );
 
                     if selected {
-                        if checkbox_color == "red" {
+                        if checkbox_color == CheckboxColor::Red {
                             bun_core::pretty!("<r><red>{}<r>", hyperlink);
-                        } else if checkbox_color == "yellow" {
+                        } else if checkbox_color == CheckboxColor::Yellow {
                             bun_core::pretty!("<r><yellow>{}<r>", hyperlink);
                         } else {
                             bun_core::pretty!("<r><green>{}<r>", hyperlink);

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -850,7 +850,7 @@ impl<'bump> Parser<'bump> {
         let mut exprs = bun_alloc::ArenaVec::new_in(self.alloc);
 
         while if self.inside_subshell.is_none() {
-            !self.match_any_comptime(&[TokenTag::Semicolon, TokenTag::Newline, TokenTag::Eof])
+            !self.match_any(&[TokenTag::Semicolon, TokenTag::Newline, TokenTag::Eof])
         } else {
             !self.match_any(&[
                 TokenTag::Semicolon,
@@ -882,7 +882,7 @@ impl<'bump> Parser<'bump> {
 
     fn parse_binary(&mut self) -> ParseResult<ast::Expr<'bump>> {
         let mut left = self.parse_pipeline()?;
-        while self.match_any_comptime(&[TokenTag::DoubleAmpersand, TokenTag::DoublePipe]) {
+        while self.match_any(&[TokenTag::DoubleAmpersand, TokenTag::DoublePipe]) {
             let op: ast::BinaryOp = {
                 let previous = self.prev().tag();
                 match previous {
@@ -1790,17 +1790,6 @@ impl<'bump> Parser<'bump> {
         if self.peek().tag() == toktag {
             let _ = self.advance();
             return true;
-        }
-        false
-    }
-
-    fn match_any_comptime(&mut self, toktags: &[TokenTag]) -> bool {
-        let peeked = self.peek().tag();
-        for &tag in toktags {
-            if peeked == tag {
-                let _ = self.advance();
-                return true;
-            }
         }
         false
     }


### PR DESCRIPTION
Thirty-eight small commits, each independent and each meant to change nothing observable; if any one looks wrong it can be dropped on its own. Net about 520 lines go away across install, bundler, resolver, css, xml, md, shell, paths and react_compiler.

Most of them are the same shape: a `match` on some enum that was written out two or three times in different functions (LoadStep to its verb, ForceNodeEnv to jsx.development, ScanAttemptResult to a Result, ParamPattern to its place, SideEffects to the resolver's flag, PathSep to a byte) becomes one method on the enum and the copies call it. A few are a private function that existed twice with the same body (shell match_any / match_any_comptime, yaml's two literal encoders, react_compiler's convert_loc, mark_instruction_ids, promoted_name, is_set_state_identifier), reduced to one. The rest remove state the type did not need: the security scanner's `has_process_exited` flag beside its `exit_status: Option` (exited is now "has a status"), the md renderer's link depth beside an optional href (one `Option<OpenLink>`), the xml tape's parallel value/location vectors (one row type keeps them the same length), a checkbox colour and an aliasing-node kind that were strings compared against literals (enums), and the remaining `.expect("oom") // bun.handleOom` markers from the port in install (real handle_oom calls).

Checked with the tests nearest each area on the debug build: xml and the xml suite, yaml, css, shell parse/lex/bunshell, md spec and edge cases, hosted-git-info, esbuild default, update-interactive formatting, security provider, workspaces, install workspace/patch. The failures seen (RequireShimSubstitution in esbuild default, registry-backed pm scan/patch cases) fail the same way on main here.