### PR TITLE
Exit on SIGINT/SIGTERM/SIGHUP when bun is PID 1 of a container

### DIFF
--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -589,25 +589,19 @@ extern "C" void onExitSignal(int sig)
     bun_restore_stdio();
     signal(sig, SIG_DFL);
 
-    // The signal being handled is blocked for the duration of its handler, so
-    // unblock it: with SIG_DFL restored, raise() then terminates the process
-    // before it returns.
+    // `sig` is blocked while its own handler runs; once unblocked, raise() kills us here.
     sigset_t set;
     sigemptyset(&set);
     sigaddset(&set, sig);
     pthread_sigmask(SIG_UNBLOCK, &set, nullptr);
     raise(sig);
 
-    // Still alive, so this process is PID 1 of a pid namespace (a container
-    // entrypoint without an init). The kernel discards default-action signals
-    // aimed at init, including the one just raised; returning would resume the
-    // interrupted command as if the signal had never arrived.
+    // Only reached as PID 1 of a pid namespace: the kernel discards SIG_DFL
+    // signals aimed at init, the re-raise above included.
     _exit(128 + sig);
 }
 
-// Takes over a signal whose default action is to terminate the process, so
-// that the TTY is restored first. A disposition inherited from the parent
-// (`nohup`, `trap '' INT`, a non-interactive shell backgrounding us) is kept.
+// Leaves an inherited SIG_IGN (`nohup`, `trap '' INT`) in place.
 static void installExitSignalHandler(int sig)
 {
     struct sigaction sa;
@@ -712,12 +706,8 @@ extern "C" void bun_initialize_process()
         close(devNullFd_);
     }
 
-    // Restore TTY state on exit.
-    //
-    // Also needed when we are PID 1 of a pid namespace (`docker run image bun
-    // install` without `--init`), TTY or not: the kernel only delivers a signal
-    // to init if init has a handler for it, so with SIG_DFL `docker stop` /
-    // Ctrl-C would be ignored until the SIGKILL escalation.
+    // Restore TTY state on exit. PID 1 of a pid namespace (a container without an
+    // init) needs the handler even without a TTY: the kernel drops signals init does not handle.
     bool isPidNamespaceInit = false;
 #if OS(LINUX)
     isPidNamespaceInit = getpid() == 1;

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -588,7 +588,37 @@ extern "C" void onExitSignal(int sig)
 {
     bun_restore_stdio();
     signal(sig, SIG_DFL);
+
+    // The signal being handled is blocked for the duration of its handler, so
+    // unblock it: with SIG_DFL restored, raise() then terminates the process
+    // before it returns.
+    sigset_t set;
+    sigemptyset(&set);
+    sigaddset(&set, sig);
+    pthread_sigmask(SIG_UNBLOCK, &set, nullptr);
     raise(sig);
+
+    // Still alive, so this process is PID 1 of a pid namespace (a container
+    // entrypoint without an init). The kernel discards default-action signals
+    // aimed at init, including the one just raised; returning would resume the
+    // interrupted command as if the signal had never arrived.
+    _exit(128 + sig);
+}
+
+// Takes over a signal whose default action is to terminate the process, so
+// that the TTY is restored first. A disposition inherited from the parent
+// (`nohup`, `trap '' INT`, a non-interactive shell backgrounding us) is kept.
+static void installExitSignalHandler(int sig)
+{
+    struct sigaction sa;
+    if (sigaction(sig, nullptr, &sa) != 0 || sa.sa_handler != SIG_DFL)
+        return;
+
+    memset(&sa, 0, sizeof(sa));
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = SA_RESETHAND;
+    sa.sa_handler = onExitSignal;
+    sigaction(sig, &sa, nullptr);
 }
 #endif
 
@@ -682,17 +712,20 @@ extern "C" void bun_initialize_process()
         close(devNullFd_);
     }
 
-    // Restore TTY state on exit
-    if (anyTTYs) {
-        struct sigaction sa;
-        memset(&sa, 0, sizeof(sa));
-        sigemptyset(&sa.sa_mask);
-
-        sa.sa_flags = SA_RESETHAND;
-        sa.sa_handler = onExitSignal;
-
-        sigaction(SIGTERM, &sa, nullptr);
-        sigaction(SIGINT, &sa, nullptr);
+    // Restore TTY state on exit.
+    //
+    // Also needed when we are PID 1 of a pid namespace (`docker run image bun
+    // install` without `--init`), TTY or not: the kernel only delivers a signal
+    // to init if init has a handler for it, so with SIG_DFL `docker stop` /
+    // Ctrl-C would be ignored until the SIGKILL escalation.
+    bool isPidNamespaceInit = false;
+#if OS(LINUX)
+    isPidNamespaceInit = getpid() == 1;
+#endif
+    if (anyTTYs || isPidNamespaceInit) {
+        installExitSignalHandler(SIGTERM);
+        installExitSignalHandler(SIGINT);
+        installExitSignalHandler(SIGHUP);
     }
 #elif OS(WINDOWS)
     for (int fd = 0; fd <= 2; ++fd) {

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -596,8 +596,7 @@ extern "C" void onExitSignal(int sig)
     pthread_sigmask(SIG_UNBLOCK, &set, nullptr);
     raise(sig);
 
-    // Only reached as PID 1 of a pid namespace: the kernel discards SIG_DFL
-    // signals aimed at init, the re-raise above included.
+    // Only reached as PID 1 of a pid namespace: the kernel discards SIG_DFL signals aimed at init, the re-raise above included.
     _exit(128 + sig);
 }
 
@@ -706,8 +705,7 @@ extern "C" void bun_initialize_process()
         close(devNullFd_);
     }
 
-    // Restore TTY state on exit. PID 1 of a pid namespace (a container without an
-    // init) needs the handler even without a TTY: the kernel drops signals init does not handle.
+    // Restore TTY state on exit. PID 1 of a pid namespace needs the handler even without a TTY: the kernel drops signals init does not handle.
     bool isPidNamespaceInit = false;
 #if OS(LINUX)
     isPidNamespaceInit = getpid() == 1;

--- a/test/cli/install/bun-install-signals.test.ts
+++ b/test/cli/install/bun-install-signals.test.ts
@@ -1,0 +1,154 @@
+// How `bun install` dies on SIGINT / SIGTERM / SIGHUP.
+//
+// The interesting case is bun as PID 1 of a pid namespace, which is what a
+// container whose entrypoint is `bun install` (no `--init`) looks like. The
+// kernel only delivers a signal to init when init has a handler for it, and it
+// also discards the SIG_DFL re-raise that handler does, so without special
+// handling `docker stop` is ignored and the install runs to completion.
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux, isPosix, tempDir } from "harness";
+import { join } from "node:path";
+
+const signals: [NodeJS.Signals, number][] = [
+  ["SIGINT", 130],
+  ["SIGTERM", 143],
+  ["SIGHUP", 129],
+];
+
+// Unprivileged user namespaces are how a test gets a pid namespace without
+// root. Kernels or container runtimes that refuse them skip the PID 1 cases.
+const unshare = ["unshare", "--user", "--map-root-user", "--pid", "--fork"];
+const canBecomePid1 = (() => {
+  if (!isLinux) return false;
+  try {
+    return Bun.spawnSync({ cmd: [...unshare, "true"], stdio: ["ignore", "ignore", "ignore"] }).exitCode === 0;
+  } catch {
+    return false;
+  }
+})();
+
+/**
+ * A project whose only dependency lives on a registry that accepts the
+ * manifest request and never answers it, so `bun install` sits in "Resolving"
+ * until it is signalled. `requested` resolving proves bun is fully up (signal
+ * dispositions are configured before argv is even parsed), which is when the
+ * tests send their signal.
+ *
+ * The idle timeout bounds the failure mode: an install that wrongly survives
+ * its signal gives up on the manifest after a few seconds and exits 1.
+ */
+function stalledInstall() {
+  const dir = tempDir("install-signals", {
+    "package.json": JSON.stringify({ name: "install-signals", dependencies: { "stalled-dep": "1.0.0" } }),
+  });
+  const requested = Promise.withResolvers<void>();
+  const answer = Promise.withResolvers<Response>();
+  const registry = Bun.serve({
+    port: 0,
+    fetch() {
+      requested.resolve();
+      return answer.promise;
+    },
+  });
+  return {
+    cmd: [bunExe(), "install", "--registry", `http://127.0.0.1:${registry.port}/`],
+    cwd: String(dir),
+    env: {
+      ...bunEnv,
+      BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache"),
+      BUN_CONFIG_HTTP_IDLE_TIMEOUT: "1",
+      BUN_CONFIG_HTTP_RETRY_COUNT: "0",
+    },
+    requested: requested.promise,
+    answerNotFound: () => answer.resolve(new Response(null, { status: 404 })),
+    [Symbol.dispose]() {
+      answer.resolve(new Response(null, { status: 404 }));
+      registry.stop(true);
+      dir[Symbol.dispose]();
+    },
+  };
+}
+
+describe.concurrent.skipIf(!canBecomePid1)("bun install as PID 1 of a pid namespace", () => {
+  test.each(signals)("exits 128 + signo on %s", async (signal, exitCode) => {
+    using install = stalledInstall();
+    await using proc = Bun.spawn({
+      cmd: [...unshare, ...install.cmd],
+      cwd: install.cwd,
+      env: install.env,
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    await install.requested;
+
+    // `proc` is unshare, waiting on its one child: bun, which is PID 1 inside
+    // the new namespace. Signal bun from out here, the way `docker stop` does.
+    // unshare exits with whatever status bun exits with.
+    const children = (await Bun.file(`/proc/${proc.pid}/task/${proc.pid}/children`).text()).trim().split(/\s+/);
+    expect(children).toHaveLength(1);
+    process.kill(Number(children[0]), signal);
+
+    const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ exitCode: proc.exitCode, signalCode: proc.signalCode }, stdout + stderr).toEqual({
+      exitCode,
+      signalCode: null,
+    });
+  });
+});
+
+// Outside of a pid namespace the handler above must stay invisible: the
+// process has to die *by* the signal (so a shell script running `bun install`
+// still aborts on Ctrl-C), not exit with 128 + signo itself.
+describe.concurrent.skipIf(!isPosix)("bun install on a terminal", () => {
+  test.each(signals)("is killed by %s", async signal => {
+    using install = stalledInstall();
+    await using proc = Bun.spawn({
+      cmd: install.cmd,
+      cwd: install.cwd,
+      env: install.env,
+      terminal: { data() {} },
+    });
+    await install.requested;
+
+    proc.kill(signal);
+    await proc.exited;
+    proc.terminal!.close();
+
+    expect({ exitCode: proc.exitCode, signalCode: proc.signalCode }).toEqual({ exitCode: null, signalCode: signal });
+  });
+
+  test.each(signals)("keeps %s ignored when it was inherited that way", async signal => {
+    using install = stalledInstall();
+    let output = "";
+    const ptyClosed = Promise.withResolvers<void>();
+    await using proc = Bun.spawn({
+      // `trap '' SIG` makes the shell ignore the signal; exec hands that
+      // disposition to bun, just like `nohup` or a shell backgrounding a job.
+      cmd: ["sh", "-c", `trap '' ${signal.slice(3)}; exec "$@"`, "sh", ...install.cmd],
+      cwd: install.cwd,
+      env: install.env,
+      terminal: {
+        data(_terminal, chunk) {
+          output += new TextDecoder().decode(chunk);
+        },
+        exit() {
+          ptyClosed.resolve();
+        },
+      },
+    });
+    await install.requested;
+
+    // An ignored signal is discarded by the kernel before kill() returns, so
+    // bun is provably unaffected by the time the registry answers and it
+    // finishes the install on its own terms (a failed resolution, exit 1).
+    proc.kill(signal);
+    install.answerNotFound();
+    await proc.exited;
+    await ptyClosed.promise;
+    proc.terminal!.close();
+
+    expect({ exitCode: proc.exitCode, signalCode: proc.signalCode }, output).toEqual({ exitCode: 1, signalCode: null });
+    expect(output).toContain("stalled-dep");
+  });
+});

--- a/test/cli/install/bun-install-signals.test.ts
+++ b/test/cli/install/bun-install-signals.test.ts
@@ -35,7 +35,9 @@ const canBecomePid1 = (() => {
  * tests send their signal.
  *
  * The idle timeout bounds the failure mode: an install that wrongly survives
- * its signal gives up on the manifest after a few seconds and exits 1.
+ * its signal gives up on the manifest after a few seconds and exits 1. It is
+ * long enough that a passing run never races it: the signal goes out as soon
+ * as `requested` resolves.
  */
 function stalledInstall() {
   const dir = tempDir("install-signals", {
@@ -56,7 +58,7 @@ function stalledInstall() {
     env: {
       ...bunEnv,
       BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache"),
-      BUN_CONFIG_HTTP_IDLE_TIMEOUT: "1",
+      BUN_CONFIG_HTTP_IDLE_TIMEOUT: "5",
       BUN_CONFIG_HTTP_RETRY_COUNT: "0",
     },
     requested: requested.promise,
@@ -85,8 +87,13 @@ describe.concurrent.skipIf(!canBecomePid1)("bun install as PID 1 of a pid namesp
     // `proc` is unshare, waiting on its one child: bun, which is PID 1 inside
     // the new namespace. Signal bun from out here, the way `docker stop` does.
     // unshare exits with whatever status bun exits with.
-    const children = (await Bun.file(`/proc/${proc.pid}/task/${proc.pid}/children`).text()).trim().split(/\s+/);
-    expect(children).toHaveLength(1);
+    //
+    // The file is empty if bun is already gone (an empty split would still be
+    // one element, and kill(0) would signal this test runner's process group).
+    const children = (await Bun.file(`/proc/${proc.pid}/task/${proc.pid}/children`).text())
+      .split(/\s+/)
+      .filter(Boolean);
+    expect(children).toEqual([expect.stringMatching(/^\d+$/)]);
     process.kill(Number(children[0]), signal);
 
     const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);


### PR DESCRIPTION
### Problem
- `bun install` (and every other bun command) running as PID 1 of a container ignores SIGINT, SIGTERM and SIGHUP: `docker stop`, `docker kill --signal=INT` and Ctrl-C on `docker run -it` do nothing, the install runs to completion and exits 0, so `docker stop` always waits out its grace period and SIGKILLs the container mid-install. With `--init` in front of bun the same commands exit 130/143 within about a second. Same behavior on 1.3.14, so not a regression.
- Two causes, both in `bun_initialize_process` (`src/jsc/bindings/c-bindings.cpp`):
  - No TTY (`docker run -d ... bun install`): the INT/TERM handler is only installed when a stdio fd is a TTY, so PID 1 has SIG_DFL for them, and the kernel drops signals that init has no handler for.
  - TTY (`docker run -it`): the handler is installed, but `onExitSignal` terminates by resetting to SIG_DFL and calling `raise()`. The kernel drops that re-raise for init as well (and SA_RESETHAND has already removed the handler), so the handler returns and the command resumes as if nothing happened.

### Fix
- `bun_initialize_process` also installs the handler when `getpid() == 1` (Linux only; pid namespaces do not exist elsewhere). TTY or not, PID 1 now has a handler, which is the condition for the kernel to deliver the signal at all.
- `onExitSignal` unblocks the signal before re-raising it. A handler runs with its own signal blocked, so `raise()` now terminates a normal process synchronously, exactly as before (death by the signal, not an exit code, so a shell script running `bun install` still aborts on Ctrl-C). If `raise()` returns, the process is init and the kernel discarded the signal, so the handler `_exit(128 + signo)`s: 130/143/129, the status tini produces in the `--init` setup.
- The handler now covers SIGHUP too (`docker kill --signal=HUP`), and a disposition inherited as SIG_IGN (`nohup`, `trap '' INT`, a non-interactive shell backgrounding the command) is no longer replaced. Previously the TTY path overrode an inherited SIG_IGN for INT/TERM.
- Applies to every command, since this is process startup, not install-specific; `bun run <script>` as PID 1 already worked because it installs forwarding handlers of its own. #33827 touches the same lines (it broadens the install condition for a different reason); it does not include the `_exit` fallback, which is what the PID 1 case needs.
- Verification, `test/cli/install/bun-install-signals.test.ts`. Each case runs `bun install` against a local registry that accepts the manifest request and never answers it, and signals bun once the request has arrived (so bun is fully started); a 1 second HTTP idle timeout bounds a run that wrongly survives its signal (exit 1):
  - PID 1: `unshare --user --map-root-user --pid --fork bun install`, signal sent to bun from outside the namespace like `docker stop` does, expects exit 128 + signo for INT/TERM/HUP (unfixed: exit 1 after the timeout). Needs unprivileged user namespaces, so it skips where they are unavailable (the container this was developed in, and the Ubuntu 25.04 lane); in CI the three cases ran and passed on the Debian 13 (x64, x64-asan, aarch64) and Alpine 3.23 (x64, aarch64) lanes (`9 pass` for the file, the PID 1 cases included).
  - On a pty, bun is still killed *by* each of the three signals (`signalCode` set, `exitCode` null); this is what would catch a missing unblock, which would turn into exit 130 everywhere.
  - On a pty with the signal inherited as ignored via `sh -c "trap '' INT; exec bun install"`, bun survives it and finishes the install on its own (exit 1 once the registry answers 404). Fails on the released build for INT and TERM.
  - Also ran `test/js/bun/terminal/terminal-spawn.test.ts` (termios restore on exit), `test/regression/issue/ctrl-c.test.ts` (bun run forwarding) and `test/js/node/process/process-signal-listener-count.test.ts` against the debug build.

### Background
- PID 1 of a pid namespace (the first process in a container, unless an init such as tini is used) is treated as `init` by the kernel: a signal whose disposition in that process is SIG_DFL is discarded instead of applying the default action, whether it comes from inside the namespace, from the host (`docker stop`), or from the process itself. Only SIGKILL/SIGSTOP from the host are forced through. Installing a handler is what makes the signal deliverable; the handler then has to end the process itself, because the usual "reset to SIG_DFL and re-raise" idiom hits the same rule.
- While a signal handler runs, the kernel blocks that signal for the thread, so a `raise()` inside the handler only marks it pending; it is acted on after the handler returns. Unblocking first makes `raise()` synchronous, which is what lets the code tell "the signal killed us" (never returns) from "the kernel discarded it" (returns). The crash handler's re-raise path in `src/crash_handler/lib.rs` uses the same idiom.
- `onExitSignal` exists so that a bun process dying from Ctrl-C puts the terminal back into the mode it found it in (`bun_restore_stdio`); that is why it was only installed when a TTY was present.

<details>
<summary>Reproduction from the report</summary>

```sh
mkdir app && cd app
printf '{"dependencies":{"next":"15.3.3","react":"^19","react-dom":"^19"}}' > package.json
docker run -d --name b1 --cpus=0.5 -v $PWD:/app -w /app oven/bun:canary bun install
sleep 2.5; docker kill --signal=INT b1; docker wait b1
# reported: prints 0 a few seconds later, node_modules fully populated
# expected with this change: 130 right away (TERM: 143, HUP: 129), matching the --init control below
# (docker recipe not run by me: no docker in the development environment; the unshare test in CI is the equivalent)
docker rm -f b1; rm -rf node_modules bun.lock
docker run -d --name b1 --init --cpus=0.5 -v $PWD:/app -w /app oven/bun:canary bun install
sleep 2.5; docker kill --signal=INT b1; docker wait b1
# 130 within about a second
```
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install-signals.test.ts

<!-- robobun:evidence:end -->
