### PR TITLE
audit: redact secrets in the registry URLs printed by bun audit and bun audit fix

### DIFF
--- a/src/install/audit_fix.rs
+++ b/src/install/audit_fix.rs
@@ -87,6 +87,7 @@ pub struct UnmatchedAdvisory {
 }
 
 pub struct UnauditedRegistry {
+    /// The registry's href without URL credentials or a trailing slash.
     pub registry: Box<[u8]>,
     pub packages: Vec<Box<[u8]>>,
     /// Status code or error name; empty when unknown.

--- a/src/install/audit_fix.rs
+++ b/src/install/audit_fix.rs
@@ -297,13 +297,13 @@ pub fn print_unaudited(groups: &[UnauditedRegistry]) {
         if group.reason.is_empty() {
             bun_core::warn!(
                 "{} did not answer the audit request; skipped {}",
-                BStr::new(&group.registry),
+                bun_core::fmt::redacted_npm_url(&group.registry),
                 BStr::new(&packages)
             );
         } else {
             bun_core::warn!(
                 "{} did not answer the audit request ({}); skipped {}",
-                BStr::new(&group.registry),
+                bun_core::fmt::redacted_npm_url(&group.registry),
                 BStr::new(&group.reason),
                 BStr::new(&packages)
             );

--- a/src/install/audit_fix/json.rs
+++ b/src/install/audit_fix/json.rs
@@ -101,8 +101,14 @@ pub(super) fn write(plan: &FixPlan, outcome: Option<&FixOutcome>, dry_run: bool)
     out.extend_from_slice(b"],\"unaudited\":[");
     for (i, group) in plan.unaudited.iter().enumerate() {
         comma(&mut out, i);
+        let mut registry: Vec<u8> = Vec::new();
+        let _ = write!(
+            registry,
+            "{}",
+            bun_core::fmt::redacted_npm_url(&group.registry)
+        );
         out.extend_from_slice(b"{\"registry\":");
-        s(&mut out, &group.registry);
+        s(&mut out, &registry);
         out.extend_from_slice(b",\"packages\":[");
         for (j, package) in group.packages.iter().enumerate() {
             comma(&mut out, j);

--- a/src/runtime/cli/audit_command.rs
+++ b/src/runtime/cli/audit_command.rs
@@ -99,8 +99,8 @@ fn default_registry_href(pm: &PackageManager) -> &[u8] {
 
 fn report_non_json_response(registry: &[u8]) {
     Output::err_generic(
-        "{s} returned a non-JSON audit response",
-        (BStr::new(registry),),
+        "{f} returned a non-JSON audit response",
+        (bun_core::fmt::redacted_npm_url(registry),),
     );
 }
 
@@ -783,7 +783,7 @@ fn send_audit_request(
         reason => {
             bun_core::pretty_errorln!(
                 "<r><red>error<r><d>:<r> <red><b>POST<r><red> {}<d> - {}<r>",
-                BStr::new(&url_str),
+                bun_core::fmt::redacted_npm_url(&url_str),
                 reason
             );
         }

--- a/src/runtime/cli/audit_command.rs
+++ b/src/runtime/cli/audit_command.rs
@@ -419,8 +419,6 @@ impl core::fmt::Display for SkipReason {
 fn unaudited(request: &AuditRequest, reason: &SkipReason) -> audit_fix::UnauditedRegistry {
     let mut reason_text: Vec<u8> = Vec::new();
     write!(&mut reason_text, "{reason}").expect("unreachable");
-    // Only ever reported, never requested: credentials configured inside the URL are left out,
-    // as in the registry line of `bun publish`.
     let registry = URL::parse(&request.registry.href).href_without_auth();
     audit_fix::UnauditedRegistry {
         registry: Box::from(strings::without_trailing_slash(&registry)),

--- a/src/runtime/cli/audit_command.rs
+++ b/src/runtime/cli/audit_command.rs
@@ -419,8 +419,11 @@ impl core::fmt::Display for SkipReason {
 fn unaudited(request: &AuditRequest, reason: &SkipReason) -> audit_fix::UnauditedRegistry {
     let mut reason_text: Vec<u8> = Vec::new();
     write!(&mut reason_text, "{reason}").expect("unreachable");
+    // Only ever reported, never requested: credentials configured inside the URL are left out,
+    // as in the registry line of `bun publish`.
+    let registry = URL::parse(&request.registry.href).href_without_auth();
     audit_fix::UnauditedRegistry {
-        registry: request.registry.href.clone(),
+        registry: Box::from(strings::without_trailing_slash(&registry)),
         packages: request
             .packages
             .iter()

--- a/test/cli/install/bun-audit.test.ts
+++ b/test/cli/install/bun-audit.test.ts
@@ -752,10 +752,12 @@ describe("`bun audit`", () => {
   });
 });
 
-// Every audit line that names a registry prints it through the same redaction as the install error lines: an npm
-// token or UUID anywhere in the URL becomes `***`, a URL password one `*` per byte. These tests put the token in the
-// registry path because that reaches the audit command from every config source, while `user:password@` is split
-// out of the URL by some of them (`.npmrc`, bunfig registry strings) and kept by others (the env vars today).
+// Every audit line that names a registry prints it through the same redaction as the install error lines, which
+// replaces an npm token or UUID anywhere in the URL with `***`; the skipped-registry record (the warning and the
+// `unaudited` entries of `audit fix --json`) additionally leaves out credentials written into the URL itself. Most
+// of these tests put the token in the registry path because that reaches the audit command from every config
+// source, while `user:password@` is split out of the URL by some of them (`.npmrc`, bunfig registry strings) and
+// kept by others (the bunfig object form used below, the env vars today).
 describe("`bun audit` with a secret in the registry URL", () => {
   const SECRET = "npm_" + "secret".padEnd(36, "0");
   const BULK_PATH = "/-/npm/v1/security/advisories/bulk";
@@ -844,10 +846,9 @@ describe("`bun audit` with a secret in the registry URL", () => {
     expect(fix.exitCode).toBe(1);
   });
 
-  test.concurrent("the skipped registry warning and the --json unaudited entry mask the secret", async () => {
-    await using scoped = registryAnswering("not found", { status: 404 });
-    const { url, printed } = secretRegistry(scoped);
-    using dir = project({ "@foo/bar": "1.0.0" }, { ".npmrc": `@foo:registry=${url}\n` });
+  // `bun audit` and `bun audit fix --json` against a project whose only package comes from a scoped registry that
+  // answers 404, so both commands report that registry as skipped; `printed` is how it must be named.
+  async function expectSkippedRegistry(dir: string, printed: string) {
     const skipped = skippedWarning(printed, "404", "@foo/bar");
 
     const report = await auditAgainst(dir, registryHref(server));
@@ -870,6 +871,22 @@ describe("`bun audit` with a secret in the registry URL", () => {
       vulnerableAfterInstall: [],
     });
     expect(fix.exitCode).toBe(0);
+  }
+
+  test.concurrent("the skipped registry warning and the --json unaudited entry mask the secret", async () => {
+    await using scoped = registryAnswering("not found", { status: 404 });
+    const { url, printed } = secretRegistry(scoped);
+    using dir = project({ "@foo/bar": "1.0.0" }, { ".npmrc": `@foo:registry=${url}\n` });
+
+    await expectSkippedRegistry(dir, printed);
+  });
+
+  test.concurrent("the skipped registry warning and the --json unaudited entry leave out URL credentials", async () => {
+    await using scoped = registryAnswering("not found", { status: 404 });
+    const url = `${scoped.url.protocol}//alice:s3cret@${scoped.url.host}/`;
+    using dir = project({ "@foo/bar": "1.0.0" }, { "bunfig.toml": `[install.scopes]\nfoo = { url = "${url}" }\n` });
+
+    await expectSkippedRegistry(dir, registryHref(scoped));
   });
 });
 

--- a/test/cli/install/bun-audit.test.ts
+++ b/test/cli/install/bun-audit.test.ts
@@ -752,6 +752,127 @@ describe("`bun audit`", () => {
   });
 });
 
+// Every audit line that names a registry prints it through the same redaction as the install error lines: an npm
+// token or UUID anywhere in the URL becomes `***`, a URL password one `*` per byte. These tests put the token in the
+// registry path because that reaches the audit command from every config source, while `user:password@` is split
+// out of the URL by some of them (`.npmrc`, bunfig registry strings) and kept by others (the env vars today).
+describe("`bun audit` with a secret in the registry URL", () => {
+  const SECRET = "npm_" + "secret".padEnd(36, "0");
+  const BULK_PATH = "/-/npm/v1/security/advisories/bulk";
+  const NON_JSON = (registry: string) => `error: ${registry} returned a non-JSON audit response`;
+
+  // `url` is what the project is configured with, `printed` is how every audit line must render it.
+  function secretRegistry(registry: Registry) {
+    return { url: `${registry.url}${SECRET}/`, printed: `${registry.url}***` };
+  }
+
+  // The bulk endpoint lives under the token path, so the registry answers every request the same way.
+  function registryAnswering(body: string, init?: ResponseInit) {
+    return Bun.serve({ port: 0, fetch: () => new Response(body, init) });
+  }
+
+  // `bun audit` only reads bun.lock, so the project never needs an install.
+  function project(dependencies: Record<string, string>, extraFiles: Record<string, string> = {}) {
+    return tempDir("audit-registry-secret-", {
+      "package.json": JSON.stringify({ name: "app", dependencies }),
+      "bun.lock": JSON.stringify({
+        lockfileVersion: 1,
+        workspaces: { "": { name: "app", dependencies } },
+        packages: Object.fromEntries(
+          Object.entries(dependencies).map(([name, version]) => [name, [`${name}@${version}`, "", {}, ""]]),
+        ),
+      }),
+      ...extraFiles,
+    });
+  }
+
+  async function auditAgainst(dir: string, defaultRegistry: string, ...args: string[]) {
+    await using proc = spawn({
+      cmd: [bunExe(), "audit", ...args],
+      cwd: String(dir),
+      env: { ...bunEnv, NPM_CONFIG_REGISTRY: defaultRegistry },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test.concurrent("the failed POST line masks the secret", async () => {
+    await using registry = registryAnswering("not found", { status: 404 });
+    const { url, printed } = secretRegistry(registry);
+    using dir = project({ "no-deps": "1.0.0" });
+
+    const { stdout, stderr, exitCode } = await auditAgainst(dir, url);
+    expect(normalizeBunSnapshot(stderr)).toBe(`error: POST ${printed}${BULK_PATH} - 404`);
+    expect(normalizeBunSnapshot(stdout)).toBe("bun audit <version> (<revision>)");
+    expect(exitCode).toBe(1);
+  });
+
+  test.concurrent("the non-JSON response line masks the secret", async () => {
+    await using registry = registryAnswering("<html><body>sign in</body></html>");
+    const { url, printed } = secretRegistry(registry);
+    using dir = project({ "no-deps": "1.0.0" });
+
+    const { stdout, stderr, exitCode } = await auditAgainst(dir, url);
+    expect(normalizeBunSnapshot(stderr)).toBe(NON_JSON(printed));
+    expect(normalizeBunSnapshot(stdout)).toBe("bun audit <version> (<revision>)");
+    expect(exitCode).toBe(1);
+  });
+
+  // A body starting with `{` gets past the response check and is rejected when it is parsed instead; the report,
+  // --json and fix code paths each report that themselves.
+  test.concurrent("the unparsable response line masks the secret in every mode", async () => {
+    const body = "{ not json";
+    await using registry = registryAnswering(body);
+    const { url, printed } = secretRegistry(registry);
+    using dir = project({ "no-deps": "1.0.0" });
+
+    const report = await auditAgainst(dir, url);
+    expect(normalizeBunSnapshot(report.stderr)).toBe(NON_JSON(printed));
+    expect(normalizeBunSnapshot(report.stdout)).toBe("bun audit <version> (<revision>)");
+    expect(report.exitCode).toBe(1);
+
+    const json = await auditAgainst(dir, url, "--json");
+    expect(normalizeBunSnapshot(json.stderr)).toBe(NON_JSON(printed));
+    expect(json.stdout).toBe(body + "\n");
+    expect(json.exitCode).toBe(1);
+
+    const fix = await auditAgainst(dir, url, "fix");
+    expect(normalizeBunSnapshot(fix.stderr)).toBe(NON_JSON(printed));
+    expect(normalizeBunSnapshot(fix.stdout)).toBe("bun audit fix <version> (<revision>)");
+    expect(fix.exitCode).toBe(1);
+  });
+
+  test.concurrent("the skipped registry warning and the --json unaudited entry mask the secret", async () => {
+    await using scoped = registryAnswering("not found", { status: 404 });
+    const { url, printed } = secretRegistry(scoped);
+    using dir = project({ "@foo/bar": "1.0.0" }, { ".npmrc": `@foo:registry=${url}\n` });
+    const skipped = skippedWarning(printed, "404", "@foo/bar");
+
+    const report = await auditAgainst(dir, registryHref(server));
+    expect(normalizeBunSnapshot(report.stderr)).toBe(skipped);
+    expect(normalizeBunSnapshot(report.stdout)).toBe(AUDIT_HEADER + noVulnerabilities(0, "1 skipped"));
+    expect(report.exitCode).toBe(0);
+
+    const fix = await auditAgainst(dir, registryHref(server), "fix", "--json");
+    expect(normalizeBunSnapshot(fix.stderr)).toBe(skipped);
+    expect(JSON.parse(fix.stdout)).toStrictEqual({
+      dryRun: false,
+      fixed: 0,
+      remaining: 0,
+      fixes: [],
+      blocked: [],
+      unfixable: [],
+      manifestUnavailable: [],
+      unmatched: [],
+      unaudited: [{ registry: printed, packages: ["@foo/bar"], reason: "404" }],
+      vulnerableAfterInstall: [],
+    });
+    expect(fix.exitCode).toBe(0);
+  });
+});
+
 describe("`bun audit --prod`", () => {
   // pnpm#13605: an optional peer that only a devDependency brought in is not a production dependency.
   test.concurrent("bun audit --prod skips a dev-only optional peer of a production package", async () => {


### PR DESCRIPTION
### Problem
- With a registry URL that carries a secret, `bun audit` and `bun audit fix` print it. With `npm_config_registry=http://alice:s3cret@127.0.0.1:PORT/` and a registry answering 404, stderr is `error: POST http://alice:s3cret@127.0.0.1:PORT/-/npm/v1/security/advisories/bulk - 404`. A token in the registry path (`http://host/npm_.../`) is printed the same way, and reaches these lines from every config source, including `.npmrc`.
- Four outputs format the registry href verbatim (`BStr::new`), where the rest of the package manager formats such URLs with `bun_core::fmt::redacted_npm_url` (`Npm::response_error` in `src/install/npm.rs`, the verbose request trace in `src/http/lib.rs`, `bun pm whoami`):
  - `src/runtime/cli/audit_command.rs` `send_audit_request`: the `POST <url> - <status or error>` line (the repro above).
  - `src/runtime/cli/audit_command.rs` `report_non_json_response`: `<registry> returned a non-JSON audit response`, reached from the report, `--json` and `audit fix` paths.
  - `src/install/audit_fix.rs` `print_unaudited`: `warn: <registry> did not answer the audit request (<reason>); skipped <packages>`, printed by both commands for a scoped registry that failed.
  - `src/install/audit_fix/json.rs`: the `registry` field of each `unaudited` entry in `bun audit fix --json`.
- The href is `scope.url.href()` as configured (`AuditRegistry::from_scope`; `unaudited()` copies it into the `UnauditedRegistry` record behind the last two outputs). `.npmrc` and bunfig registry strings move `user:password@` out of it while loading, the bunfig object form, the registry env vars and `--registry` keep it (#38796 and #38834 change the latter two), and a token in the path stays in it in every case.
- The 1.3.x binaries print `audit request failed (status N)` without a URL; the URL in these lines came with the audit rewrite in #38333, so this has not shipped in a release.

### Fix
- The `POST` line and `report_non_json_response` format the URL with `redacted_npm_url`: these quote the request URL, so they get the same masked form as the manifest and tarball error lines (`http://alice:******@host/...`, path token as `***`). `AuditRegistry.href` itself stays raw because it is also what the request is sent to.
- The skipped-registry record names a registry rather than quoting a request, so `unaudited()` builds it from `href_without_auth()` (trailing slash stripped), the same form `bun publish` prints as its registry: credentials written into the URL are left out instead of masked, and the record reads the same whichever config source the scope came from (`http://host:PORT`, matching what `.npmrc` scopes already produced). Its two emitters, the warning and the `--json` field, format it with `redacted_npm_url` for tokens in the path (`http://host:PORT/***`); the `--json` value is rendered into a buffer first because the JSON string writer takes bytes. The `unaudited` array is new in #38333, so nothing depends on the raw form.
- For a URL without a password, UUID or `npm_` token the output is byte for byte unchanged; the 177 existing tests in `bun-audit.test.ts`, many of which assert these exact lines with plain URLs, still pass.
- Not touched, same class elsewhere: `bun audit fix`'s `was not checked for updates` lines repeat the install log's `GET <url> - <status>` text, which #38817 redacts at its source; the registry URL lines in `src/install/NetworkTask.rs` (`Failed to join registry ...`, `... is not on registry ...`) and `src/install/pnpm.rs` (`fetching pnpm registry ... from <url>`) are install-side and have been filed separately. This PR and #38817 touch disjoint files.
- Tests: `test/cli/install/bun-audit.test.ts`, new `bun audit with a secret in the registry URL` block, one test per output: the `POST` line, the non-JSON line from the response check, the non-JSON line from the parse step in report, `--json` and `fix` mode, the skipped-registry warning and `unaudited[].registry` with a token in the registry path (`.npmrc` scope), and the same two outputs with `user:password@` in the URL (bunfig object-form scope, which keeps it), asserting the credential-free form. The path-token cases use a token rather than a password because a token reaches the audit command from every config source; the credential case asserts the stripped form, which stays true once #38796 / #38834 strip credentials earlier, so this PR does not depend on their landing order. All five fail on this branch with `src/` stashed (the token or password is printed); the credential case also fails with only the `unaudited()` hunk removed (it then prints `alice:******@`), and the `--json` case with only the `json.rs` hunk removed; all 182 tests in the file pass with the change.
- Also ran `cargo clippy -p bun_install -p bun_runtime`, `cargo fmt --check` on both crates, and `test/internal/source-lints`.

### Background
- `bun audit` POSTs the lockfile's package versions to `<registry>/-/npm/v1/security/advisories/bulk`. Packages whose scope (`@foo/*`) is configured with its own registry are sent to that registry instead; when a non-default registry fails to answer (HTTP error, connection error, non-JSON body) its packages are reported as skipped (one `UnauditedRegistry` record per registry, printed as the warning and, by `audit fix --json`, as the `unaudited` entries) rather than failing the command, while a failure from the default registry fails the command with the `POST` or non-JSON line.
- `redacted_npm_url` (`src/bun_core/fmt.rs`) is a `Display` adapter over URL bytes: the password of `scheme://user:password@host` is written as one `*` per byte (the per-byte form is shared with the config-excerpt redactor, which needs column alignment), and any UUID or `npm_`/`npms_` token anywhere in the string as `***`; everything else is written through unchanged. `Output::err_generic`, `warn!` and `pretty_errorln!` take any `Display` argument, so it is a drop-in replacement for `BStr::new` (`err_generic`'s `{s}`/`{f}` placeholder letters are cosmetic; `{f}` is what the other `redacted_npm_url` call site uses).
- `URL::href_without_auth()` (`src/url/lib.rs`) rebuilds `scheme://host[:port]/path/` from the parsed URL, dropping any userinfo; it is what the config loaders use to store a registry URL whose credentials were split out, and what `bun publish` prints as `Registry:`. It currently yields `http://host//` for a root-path registry (#38812 changes that to one slash); `unaudited()` strips trailing slashes afterwards, so the record is `http://host:PORT` either way. Tokens that are part of the path survive it, which is why the record's emitters still go through `redacted_npm_url`.

<details>
<summary>Before / after on a debug build (404 registry, non-JSON registry, scoped registry with a path token, scoped registry configured as <code>{ url = "http://alice:s3cret@..." }</code>)</summary>

Before:

```
error: POST http://alice:s3cret@127.0.0.1:PORT/npm_a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8/-/npm/v1/security/advisories/bulk - 404
error: http://alice:s3cret@127.0.0.1:PORT/npm_a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8 returned a non-JSON audit response
warn: http://127.0.0.1:PORT/npm_a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8 did not answer the audit request (404); skipped @foo/bar
{"dryRun":false,...,"unaudited":[{"registry":"http://127.0.0.1:PORT/npm_a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8","packages":["@foo/bar"],"reason":"404"}],...}
warn: http://alice:s3cret@localhost:PORT did not answer the audit request (404); skipped @foo/bar
{"dryRun":false,...,"unaudited":[{"registry":"http://alice:s3cret@localhost:PORT","packages":["@foo/bar"],"reason":"404"}],...}
```

After:

```
error: POST http://alice:******@127.0.0.1:PORT/***/-/npm/v1/security/advisories/bulk - 404
error: http://alice:******@127.0.0.1:PORT/*** returned a non-JSON audit response
warn: http://127.0.0.1:PORT/*** did not answer the audit request (404); skipped @foo/bar
{"dryRun":false,...,"unaudited":[{"registry":"http://127.0.0.1:PORT/***","packages":["@foo/bar"],"reason":"404"}],...}
warn: http://localhost:PORT did not answer the audit request (404); skipped @foo/bar
{"dryRun":false,...,"unaudited":[{"registry":"http://localhost:PORT","packages":["@foo/bar"],"reason":"404"}],...}
```

</details>

<details>
<summary>Earlier revision of this PR</summary>

The first revision applied `redacted_npm_url` to the `UnauditedRegistry` record as well, so for the config sources that keep credentials in the URL the warning and the `--json` field came out as `http://alice:******@host` (username and password length, and a different shape from the `.npmrc` case, which had no userinfo to begin with). Review pointed out that every other place bun emits a registry URL as data drops the credentials instead; the record is now built with `href_without_auth()` and the per-byte masking is confined to the two lines that quote the request URL.

</details>
