### PR TITLE
ci: bump the mordant pin (sixteen new lints) and record their baseline

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ exclude = ["vendor"]
 # (see its rust-toolchain), which must still be able to compile this workspace.
 [workspace.metadata.dylint]
 libraries = [
-    { git = "https://github.com/scarletindustries/mordant", rev = "3bcf1165e57b7a0e266df661f62781ad368340e7" },
+    { git = "https://github.com/scarletindustries/mordant", rev = "4efc663b11f4598b95c41e7a1aa78f494224b001" },
 ]
 
 [workspace.package]

--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -1,23 +1,155 @@
+[bun_ast]
+"bool_params:src/ast/lib.rs" = 1
+"misbound_arg:src/ast/lib.rs" = 1
+
 [bun_bundler]
+"bool_params:src/bundler/Chunk.rs" = 1
 "defaulted_failure:src/bundler/bundle_v2.rs" = 2
+"misbound_arg:src/bundler/linker.rs" = 1
+"same_match_twice:src/bundler/bundle_v2.rs" = 3
+"same_match_twice:src/bundler/transpiler.rs" = 1
+"uneven_narrowing:src/bundler/bundle_v2.rs" = 1
 
 [bun_core]
 "defaulted_failure:src/bun_core/string/immutable.rs" = 1
+"same_match_twice:src/bun_core/fmt.rs" = 1
+
+[bun_css]
+"bool_params:src/css/selectors/builder.rs" = 1
+"misbound_arg:src/css/rules/mod.rs" = 1
+"same_match_twice:src/css/selectors/parser.rs" = 1
+"same_match_twice:src/css/values/color.rs" = 1
+"unnamed_tuple:src/css/css_parser.rs" = 1
+"unnamed_tuple:src/css/values/color.rs" = 5
 
 [bun_install]
+"bool_beside_option:src/install/PackageManager/security_scanner.rs" = 1
+"bool_params:src/install/PackageManager/security_scanner.rs" = 1
+"bool_params:src/install/isolated_install.rs" = 1
+"crossed_alias:src/install/lockfile/Tree.rs" = 1
+"crossed_index:src/install/isolated_install.rs" = 1
 "defaulted_failure:src/install/npm.rs" = 1
+"misbound_arg:src/install/PackageManager/PackageJSONEditor.rs" = 3
+"misbound_arg:src/install/resolution.rs" = 1
+"same_match_twice:src/install/PackageManager/PackageManagerEnqueue.rs" = 3
+"same_match_twice:src/install/PackageManager/install_with_manager.rs" = 1
+"same_match_twice:src/install/PackageManager/security_scanner.rs" = 1
+"same_match_twice:src/install/hosted_git_info.rs" = 1
+"same_match_twice:src/install/npm.rs" = 1
+"same_match_twice:src/install/update_scope.rs" = 1
+"same_match_twice:src/install/update_transitive.rs" = 1
 "unread_none:src/install/PackageInstall.rs" = 1
 
+[bun_js_parser]
+"bool_params:src/js_parser/visit/mod.rs" = 1
+"same_match_twice:src/js_parser/p.rs" = 3
+"sentinel_int:src/js_parser/parse/parse_entry.rs" = 1
+
+[bun_js_printer]
+"parallel_vecs:src/js_printer/lib.rs" = 1
+
 [bun_jsc]
+"bool_params:src/jsc/ZigStackFrame.rs" = 1
 "defaulted_failure:src/jsc/ConsoleObject.rs" = 4
+"reimplemented_helper:src/jsc/webcore_types.rs" = 1
+"same_match_twice:src/jsc/VirtualMachine.rs" = 1
+"uneven_narrowing:src/jsc/RuntimeTranspilerCache.rs" = 1
+
+[bun_md]
+"dependent_field:src/md/ansi_renderer.rs" = 1
+
+[bun_parsers]
+"parallel_vecs:src/parsers/xml.rs" = 3
+"reimplemented_helper:src/parsers/yaml.rs" = 1
+
+[bun_paths]
+"same_match_twice:src/paths/Path.rs" = 3
+
+[bun_react_compiler]
+"bool_params:src/react_compiler/validation/validate_locals_not_reassigned_after_render.rs" = 1
+"reimplemented_helper:src/react_compiler/lowering/hir_builder.rs" = 2
+"reimplemented_helper:src/react_compiler/reactive_scopes/propagate_early_returns.rs" = 1
+"reimplemented_helper:src/react_compiler/reactive_scopes/prune_hoisted_contexts.rs" = 1
+"reimplemented_helper:src/react_compiler/validation/validate_no_set_state_in_render.rs" = 1
+"same_match_twice:src/react_compiler/codegen.rs" = 1
+"same_match_twice:src/react_compiler/hir/visitors.rs" = 1
+"same_match_twice:src/react_compiler/inference/infer_mutation_aliasing_ranges.rs" = 3
+"same_match_twice:src/react_compiler/inference/infer_reactive_places.rs" = 2
+"same_match_twice:src/react_compiler/lowering/build_hir/expr.rs" = 2
+"same_match_twice:src/react_compiler/optimization/constant_propagation.rs" = 1
+"same_match_twice:src/react_compiler/program.rs" = 1
+"same_match_twice:src/react_compiler/reactive_scopes/extract_scope_declarations_from_destructuring.rs" = 1
+"same_match_twice:src/react_compiler/reactive_scopes/promote_used_temporaries.rs" = 4
+"same_match_twice:src/react_compiler/reactive_scopes/prune_hoisted_contexts.rs" = 1
+"same_match_twice:src/react_compiler/reactive_scopes/prune_non_escaping_scopes.rs" = 3
+"same_match_twice:src/react_compiler/reactive_scopes/rename_variables.rs" = 1
+"same_match_twice:src/react_compiler/reactive_scopes/visitors.rs" = 1
+"same_match_twice:src/react_compiler/ssa/rewrite_instruction_kinds_based_on_reassignment.rs" = 3
+"same_match_twice:src/react_compiler/validation/validate_exhaustive_dependencies.rs" = 3
+"same_match_twice:src/react_compiler/validation/validate_hooks_usage.rs" = 3
+"same_match_twice:src/react_compiler/validation/validate_no_derived_computations_in_effects.rs" = 1
+"same_match_twice:src/react_compiler/validation/validate_no_ref_access_in_render.rs" = 1
+"stringly_state:src/react_compiler/inference/infer_mutation_aliasing_ranges.rs" = 1
+
+[bun_resolver]
+"same_match_twice:src/resolver/dir_info.rs" = 1
+"same_match_twice:src/resolver/resolver.rs" = 1
 
 [bun_runtime]
+"bool_params:src/runtime/api.rs" = 2
+"bool_params:src/runtime/api/bun/h2_frame_parser.rs" = 1
+"bool_params:src/runtime/bake/dev_server/incremental_graph.rs" = 1
+"bool_params:src/runtime/cli/run_command.rs" = 1
+"bool_params:src/runtime/dns_jsc/dns.rs" = 1
+"bool_params:src/runtime/node/types.rs" = 4
 "bypassed_validator:src/runtime/api/js_bundle_completion_task.rs" = 1
 "bypassed_validator:src/runtime/cli/pack_command.rs" = 2
 "bypassed_validator:src/runtime/server/HTMLBundle.rs" = 2
 "bypassed_validator:src/runtime/server/mod.rs" = 1
 "bypassed_validator:src/runtime/server/server_body.rs" = 5
+"collapsed_error:src/runtime/api/bun/Terminal.rs" = 1
+"collapsed_error:src/runtime/api/bun/h2_frame_parser.rs" = 32
+"collapsed_error:src/runtime/ffi/ffi_body.rs" = 1
 "defaulted_failure:src/runtime/ffi/ffi_body.rs" = 1
 "defaulted_failure:src/runtime/server/RequestContext.rs" = 1
 "defaulted_failure:src/runtime/test_runner/pretty_format.rs" = 4
+"dependent_field:src/runtime/cli/filter_run.rs" = 1
+"misbound_arg:src/runtime/cli/install_completions_command.rs" = 4
+"misbound_arg:src/runtime/cli/open.rs" = 1
+"misbound_arg:src/runtime/cli/pack_command.rs" = 1
+"misbound_arg:src/runtime/node/path.rs" = 2
+"parallel_vecs:src/runtime/api/html_rewriter.rs" = 1
+"parallel_vecs:src/runtime/bake/dev_server/incremental_graph.rs" = 1
+"reimplemented_helper:src/runtime/api/bun/Terminal.rs" = 1
+"reimplemented_helper:src/runtime/ffi/abi_type.rs" = 1
+"reimplemented_helper:src/runtime/hw_exports.rs" = 1
+"same_match_twice:src/runtime/api/YAMLObject.rs" = 1
+"same_match_twice:src/runtime/api/bun/h2_frame_parser.rs" = 1
+"same_match_twice:src/runtime/api/csrf_jsc.rs" = 1
+"same_match_twice:src/runtime/bake/dev_server/mod.rs" = 1
+"same_match_twice:src/runtime/bake/production.rs" = 2
+"same_match_twice:src/runtime/cli/pack_command.rs" = 1
+"same_match_twice:src/runtime/cli/publish_command.rs" = 1
+"same_match_twice:src/runtime/cli/update_interactive_command.rs" = 2
+"same_match_twice:src/runtime/ipc.rs" = 2
+"same_match_twice:src/runtime/server/RequestContext.rs" = 4
+"same_match_twice:src/runtime/server/server_body.rs" = 1
+"same_match_twice:src/runtime/shell/builtin/cat.rs" = 1
+"same_match_twice:src/runtime/webcore/Blob.rs" = 2
+"same_match_twice:src/runtime/webcore/Body.rs" = 2
 "stored_projection:src/runtime/test_runner/bun_test.rs" = 1
+"stringly_state:src/runtime/cli/update_interactive_command.rs" = 1
+"uneven_narrowing:src/runtime/node/node_crypto_binding.rs" = 1
+"unnamed_tuple:src/runtime/server/ServerWebSocket.rs" = 1
+"unnamed_tuple:src/runtime/shell/builtin/which.rs" = 1
+
+[bun_shell_parser]
+"bool_params:src/shell_parser/parse.rs" = 1
+"reimplemented_helper:src/shell_parser/parse.rs" = 1
+
+[bun_sql_jsc]
+"bool_params:src/sql_jsc/shared/datetime_text.rs" = 1
+"same_match_twice:src/sql_jsc/mysql/protocol/ResultSet.rs" = 1
+
+[bun_sys]
+"collapsed_error:src/sys/lib.rs" = 4


### PR DESCRIPTION
Moves the pinned mordant revision to 4efc663, which adds sixteen lints (duplicated matches and helpers, parallel vecs, bool parameter runs, integer aliases used interchangeably, a Result collapsed to a bool and dropped, the same place narrowed two ways, and a few more; https://github.com/scarletindustries/mordant/pull/12 has the list). mordant-baseline.toml is regenerated against main so the job stays advisory and only reports instances a change adds; the recorded counts are what exists today (largest: 81 same_match_twice, 38 collapsed_error, 20 bool_params). #38841 already removes a good share of the same_match_twice and reimplemented_helper entries and can shrink the file when it lands.

Nothing else changes: same nightly, same dylint version, so the workflow's caches key over on the rev alone.