### PR TITLE
install: keep workspace and other non-registry entries as written on bun update <name>

### DIFF
--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -1131,14 +1131,9 @@ pub(crate) fn edit(
     }
 
     // `bun update <name>` never adds `<name>`: a name this file does not declare only moves in the lockfile.
-    let update_in_place = manager.subcommand == Subcommand::Update;
-    if update_in_place {
-        remaining -= updates
-            .iter()
-            .filter(|request| {
-                request.e_string.is_none() && request.package_id == INVALID_PACKAGE_ID
-            })
-            .count();
+    // (`package_id` is no substitute for this check: the root's rows include every workspace member, declared or not.)
+    if manager.subcommand == Subcommand::Update {
+        remaining = 0;
     }
 
     if remaining != 0 {
@@ -1160,9 +1155,7 @@ pub(crate) fn edit(
         };
 
         for request in updates.iter_mut() {
-            if request.e_string.is_some()
-                || (update_in_place && request.package_id == INVALID_PACKAGE_ID)
-            {
+            if request.e_string.is_some() {
                 continue;
             }
 
@@ -1451,6 +1444,9 @@ pub(crate) fn edit(
                     arena_dup(arena, installed)
                 }
 
+                // `bun update <name>` leaves an entry that links a workspace member as written (`workspace:^`,
+                // `workspace:1.2.3`, a plain range), like the bare update does; `workspace:*` is what `bun add` writes.
+                resolution::Tag::Workspace if manager.subcommand == Subcommand::Update => continue,
                 resolution::Tag::Workspace => b"workspace:*",
                 _ => arena_dup(arena, request.version.literal.slice(request.version_buf())),
             };

--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -1131,9 +1131,14 @@ pub(crate) fn edit(
     }
 
     // `bun update <name>` never adds `<name>`: a name this file does not declare only moves in the lockfile.
-    // (`package_id` is no substitute for this check: the root's rows include every workspace member, declared or not.)
-    if manager.subcommand == Subcommand::Update {
-        remaining = 0;
+    let update_in_place = manager.subcommand == Subcommand::Update;
+    if update_in_place {
+        remaining -= updates
+            .iter()
+            .filter(|request| {
+                request.e_string.is_none() && request.package_id == INVALID_PACKAGE_ID
+            })
+            .count();
     }
 
     if remaining != 0 {
@@ -1155,7 +1160,9 @@ pub(crate) fn edit(
         };
 
         for request in updates.iter_mut() {
-            if request.e_string.is_some() {
+            if request.e_string.is_some()
+                || (update_in_place && request.package_id == INVALID_PACKAGE_ID)
+            {
                 continue;
             }
 
@@ -1329,9 +1336,13 @@ pub(crate) fn edit(
             // derived from a `StoreRef` to the same `E::EString` is live inside this loop body,
             // so this is the sole mutable borrow.
             let e_string = unsafe { &mut *e_string };
-            // `bun update <pkg>` keeps a `catalog:` reference; `bun add` still replaces it.
+            // `bun update <pkg>` keeps a `catalog:` reference or a `workspace:` range as written, in both passes:
+            // before the install so neither --latest nor `<pkg>@<range>` replaces it; `bun add` still replaces it.
             if manager.subcommand == Subcommand::Update
-                && dependency::Tag::infer(e_string.data.slice()) == dependency::Tag::Catalog
+                && matches!(
+                    dependency::Tag::infer(e_string.data.slice()),
+                    dependency::Tag::Catalog | dependency::Tag::Workspace
+                )
             {
                 continue;
             }
@@ -1444,8 +1455,8 @@ pub(crate) fn edit(
                     arena_dup(arena, installed)
                 }
 
-                // `bun update <name>` leaves an entry that links a workspace member as written (`workspace:^`,
-                // `workspace:1.2.3`, a plain range), like the bare update does; `workspace:*` is what `bun add` writes.
+                // A range or dist-tag that linked a workspace member has nothing to move to: `bun update <name>`
+                // leaves it as written, like the bare update does. `workspace:*` is what `bun add` writes.
                 resolution::Tag::Workspace if manager.subcommand == Subcommand::Update => continue,
                 resolution::Tag::Workspace => b"workspace:*",
                 _ => arena_dup(arena, request.version.literal.slice(request.version_buf())),

--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -1336,8 +1336,7 @@ pub(crate) fn edit(
             // derived from a `StoreRef` to the same `E::EString` is live inside this loop body,
             // so this is the sole mutable borrow.
             let e_string = unsafe { &mut *e_string };
-            // `bun update <pkg>` keeps a `catalog:` reference or a `workspace:` range as written, in both passes:
-            // before the install so neither --latest nor `<pkg>@<range>` replaces it; `bun add` still replaces it.
+            // `bun update <pkg>` keeps a `catalog:` reference or a `workspace:` range as written; `bun add` still replaces them.
             if manager.subcommand == Subcommand::Update
                 && matches!(
                     dependency::Tag::infer(e_string.data.slice()),
@@ -1455,8 +1454,7 @@ pub(crate) fn edit(
                     arena_dup(arena, installed)
                 }
 
-                // A range or dist-tag that linked a workspace member has nothing to move to: `bun update <name>`
-                // leaves it as written, like the bare update does. `workspace:*` is what `bun add` writes.
+                // A range that linked a workspace member has nothing to move to; `workspace:*` is what `bun add` writes.
                 resolution::Tag::Workspace if manager.subcommand == Subcommand::Update => continue,
                 resolution::Tag::Workspace => b"workspace:*",
                 _ => arena_dup(arena, request.version.literal.slice(request.version_buf())),

--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -1336,12 +1336,9 @@ pub(crate) fn edit(
             // derived from a `StoreRef` to the same `E::EString` is live inside this loop body,
             // so this is the sole mutable borrow.
             let e_string = unsafe { &mut *e_string };
-            // `bun update <pkg>` keeps a `catalog:` reference or a `workspace:` range as written; `bun add` still replaces them.
+            // `bun update <pkg>` only moves registry entries, like `edit_update_entries`; `bun add` still replaces any entry.
             if manager.subcommand == Subcommand::Update
-                && matches!(
-                    dependency::Tag::infer(e_string.data.slice()),
-                    dependency::Tag::Catalog | dependency::Tag::Workspace
-                )
+                && !dependency::Tag::infer(e_string.data.slice()).is_npm()
             {
                 continue;
             }

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -880,8 +880,7 @@ impl Lockfile {
                 let resolved_ids: &[PackageID] = res_list.get(self.buffers.resolutions.as_slice());
                 debug_assert_eq!(resolved_ids.len(), workspace_deps.len());
                 for (&package_id, dep) in resolved_ids.iter().zip(workspace_deps.iter()) {
-                    // The root's `workspaces` rows precede its package.json entries and are not editable;
-                    // a request binds to the entry that spells its name.
+                    // The root's implicit `workspaces` rows are not package.json entries; bind to the entry naming the package.
                     if dep.behavior.is_workspace() {
                         continue;
                     }

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -880,6 +880,11 @@ impl Lockfile {
                 let resolved_ids: &[PackageID] = res_list.get(self.buffers.resolutions.as_slice());
                 debug_assert_eq!(resolved_ids.len(), workspace_deps.len());
                 for (&package_id, dep) in resolved_ids.iter().zip(workspace_deps.iter()) {
+                    // The root's `workspaces` rows precede its package.json entries and are not editable;
+                    // a request binds to the entry that spells its name.
+                    if dep.behavior.is_workspace() {
+                        continue;
+                    }
                     if update.matches(dep, string_buf) {
                         if package_id as usize > self.packages.len() {
                             continue;

--- a/test/cli/install/bun-update-lockfile-sync.test.ts
+++ b/test/cli/install/bun-update-lockfile-sync.test.ts
@@ -280,18 +280,24 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
     await expectInSync(dir);
   });
 
-  // Naming a workspace member used to rewrite the entry linking it to `workspace:*`, and to add one to a root that did not declare it.
-  test.each(["workspace:^", "workspace:~", "workspace:1.0.0", "^1.0.0"])(
-    "bun update <workspace member> keeps a %s entry as written",
-    async literal => {
-      const dir = await setup(MONOREPO({}, { dependencies: { pkg1: literal } }));
-      const [pkgBefore, lockBefore] = await Promise.all([pkgText(dir), lockText(dir)]);
-      await run(dir, "update", "pkg1");
-      expect(await pkgText(dir)).toBe(pkgBefore);
-      expect(await lockText(dir)).toBe(lockBefore);
-      await expectInSync(dir, ["", PKG1]);
-    },
-  );
+  // Naming a workspace member used to rewrite the entry linking it to `workspace:*` (or, with --latest / an explicit
+  // range, to send the name to the registry), and to add an entry to a root that did not declare the member.
+  test.each([
+    ["workspace:^", ["pkg1"]],
+    ["workspace:~", ["pkg1"]],
+    ["workspace:1.0.0", ["pkg1"]],
+    ["^1.0.0", ["pkg1"]],
+    ["workspace:^", ["pkg1", "--latest"]],
+    ["workspace:^", ["pkg1@^1.0.0"]],
+    ["workspace:^", ["pkg1@latest"]],
+  ])("a %s entry linking a workspace member is kept as written by bun update %j", async (literal, args) => {
+    const dir = await setup(MONOREPO({}, { dependencies: { pkg1: literal } }));
+    const [pkgBefore, lockBefore] = await Promise.all([pkgText(dir), lockText(dir)]);
+    await run(dir, "update", ...args);
+    expect(await pkgText(dir)).toBe(pkgBefore);
+    expect(await lockText(dir)).toBe(lockBefore);
+    await expectInSync(dir, ["", PKG1]);
+  });
 
   test("bun update <workspace member> from a member declaring it keeps the entry as written", async () => {
     const dir = await setup(WORKSPACES({}, { pkg1: {}, pkg2: { dependencies: { pkg1: "workspace:~" } } }));

--- a/test/cli/install/bun-update-lockfile-sync.test.ts
+++ b/test/cli/install/bun-update-lockfile-sync.test.ts
@@ -280,6 +280,51 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
     await expectInSync(dir);
   });
 
+  // Naming a workspace member used to rewrite the entry linking it to `workspace:*`, and to add one to a root that did not declare it.
+  test.each(["workspace:^", "workspace:~", "workspace:1.0.0", "^1.0.0"])(
+    "bun update <workspace member> keeps a %s entry as written",
+    async literal => {
+      const dir = await setup(MONOREPO({}, { dependencies: { pkg1: literal } }));
+      const [pkgBefore, lockBefore] = await Promise.all([pkgText(dir), lockText(dir)]);
+      await run(dir, "update", "pkg1");
+      expect(await pkgText(dir)).toBe(pkgBefore);
+      expect(await lockText(dir)).toBe(lockBefore);
+      await expectInSync(dir, ["", PKG1]);
+    },
+  );
+
+  test("bun update <workspace member> from a member declaring it keeps the entry as written", async () => {
+    const dir = await setup(WORKSPACES({}, { pkg1: {}, pkg2: { dependencies: { pkg1: "workspace:~" } } }));
+    const [pkgBefore, lockBefore] = await Promise.all([pkgText(dir, PKG2), lockText(dir)]);
+    await runIn(dir, PKG2, "update", "pkg1");
+    expect(await pkgText(dir, PKG2)).toBe(pkgBefore);
+    expect(await lockText(dir)).toBe(lockBefore);
+    await expectInSync(dir, ["", PKG1, PKG2]);
+  });
+
+  test("bun update <workspace member> -r keeps every workspace's entry as written", async () => {
+    const dir = await setup(
+      WORKSPACES(
+        { dependencies: { pkg1: "workspace:^" } },
+        { pkg1: {}, pkg2: { dependencies: { pkg1: "workspace:1.0.0" } } },
+      ),
+    );
+    const [rootBefore, pkg2Before, lockBefore] = await Promise.all([pkgText(dir), pkgText(dir, PKG2), lockText(dir)]);
+    await run(dir, "update", "pkg1", "-r");
+    expect(await pkgText(dir)).toBe(rootBefore);
+    expect(await pkgText(dir, PKG2)).toBe(pkg2Before);
+    expect(await lockText(dir)).toBe(lockBefore);
+    await expectInSync(dir, ["", PKG1, PKG2]);
+  });
+
+  test("bun update <workspace member> does not add it to a root that does not declare it", async () => {
+    const dir = await setup(MONOREPO());
+    const [pkgBefore, lockBefore] = await Promise.all([pkgText(dir), lockText(dir)]);
+    await run(dir, "update", "pkg1");
+    expect(await pkgText(dir)).toBe(pkgBefore);
+    expect(await lockText(dir)).toBe(lockBefore);
+  });
+
   test.each([[[]], [["--latest"]]])("bun update %j leaves folder, tarball and workspace literals alone", async args => {
     const dependencies = {
       "no-deps": "^1.0.0",

--- a/test/cli/install/bun-update-lockfile-sync.test.ts
+++ b/test/cli/install/bun-update-lockfile-sync.test.ts
@@ -296,7 +296,6 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
     await run(dir, "update", ...args);
     expect(await pkgText(dir)).toBe(pkgBefore);
     expect(await lockText(dir)).toBe(lockBefore);
-    await expectInSync(dir, ["", PKG1]);
   });
 
   // Same rule for the other non-registry kinds: the registry has a no-deps, so naming this entry with --latest or an
@@ -313,7 +312,6 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
       expect(await pkgText(dir)).toBe(pkgBefore);
       expect(await lockText(dir)).toBe(lockBefore);
       expect(await installed(dir, "no-deps")).toMatchObject({ version: "1.0.0" });
-      await expectInSync(dir);
     },
   );
 
@@ -323,7 +321,6 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
     await runIn(dir, PKG2, "update", "pkg1");
     expect(await pkgText(dir, PKG2)).toBe(pkgBefore);
     expect(await lockText(dir)).toBe(lockBefore);
-    await expectInSync(dir, ["", PKG1, PKG2]);
   });
 
   test("bun update <workspace member> -r keeps every workspace's entry as written", async () => {
@@ -338,7 +335,6 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
     expect(await pkgText(dir)).toBe(rootBefore);
     expect(await pkgText(dir, PKG2)).toBe(pkg2Before);
     expect(await lockText(dir)).toBe(lockBefore);
-    await expectInSync(dir, ["", PKG1, PKG2]);
   });
 
   test("bun update <workspace member> does not add it to a root that does not declare it", async () => {

--- a/test/cli/install/bun-update-lockfile-sync.test.ts
+++ b/test/cli/install/bun-update-lockfile-sync.test.ts
@@ -299,6 +299,24 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
     await expectInSync(dir, ["", PKG1]);
   });
 
+  // Same rule for the other non-registry kinds: the registry has a no-deps, so naming this entry with --latest or an
+  // explicit spec used to replace the folder with the registry package (exit 0).
+  test.each([[["no-deps"]], [["no-deps", "--latest"]], [["no-deps@^1.0.0"]], [["no-deps@latest"]]])(
+    "a file: entry is kept as written by bun update %j",
+    async args => {
+      const dir = await setup({
+        "package.json": root({ dependencies: { "no-deps": "file:./local-no-deps" } }),
+        "local-no-deps/package.json": { name: "no-deps", version: "1.0.0" },
+      });
+      const [pkgBefore, lockBefore] = await Promise.all([pkgText(dir), lockText(dir)]);
+      await run(dir, "update", ...args);
+      expect(await pkgText(dir)).toBe(pkgBefore);
+      expect(await lockText(dir)).toBe(lockBefore);
+      expect(await installed(dir, "no-deps")).toMatchObject({ version: "1.0.0" });
+      await expectInSync(dir);
+    },
+  );
+
   test("bun update <workspace member> from a member declaring it keeps the entry as written", async () => {
     const dir = await setup(WORKSPACES({}, { pkg1: {}, pkg2: { dependencies: { pkg1: "workspace:~" } } }));
     const [pkgBefore, lockBefore] = await Promise.all([pkgText(dir, PKG2), lockText(dir)]);


### PR DESCRIPTION
### Problem

- In a workspace whose root declares `"pkg1": "workspace:^"` for a member, `bun update pkg1` reports `(no changes)` but rewrites the entry to `"pkg1": "workspace:*"` in package.json and bun.lock. Same for `workspace:~`, `workspace:1.2.3` and a plain range such as `^1.0.0` that links the member; same from a member that declares it, and in every workspace with `-r` / `--filter`.
- With `--latest` or an explicit spec (`bun update pkg1 --latest`, `pkg1@^1.0.0`, `pkg1@latest`) the entry is first replaced by `latest` / the spec, so the install asks the registry for the member's name. The same happens to every other non-registry entry: with `"no-deps": "file:./local-no-deps"` and a registry that has `no-deps`, `bun update no-deps --latest` exits 0 and leaves `"no-deps": "^2.0.0"` (the registry package) in package.json and bun.lock; `no-deps@^1.0.0` leaves `^1.1.0`, `no-deps@latest` leaves `latest`.
- In a root that does not declare the member, `bun update pkg1` adds `"pkg1": "workspace:*"` to the root's `dependencies`; a named update is documented never to add.
- Causes, all in the named-update path (`PackageJSONEditor::edit`, which runs once before and once after the install):
  - The literal check at the top of the write-back loop only exempted `catalog:` entries. Every other kind went on to the rewrite before the install (`latest` / the explicit spec) and, after it, to the unconditional `resolution::Tag::Workspace => b"workspace:*"` arm, which is the value `bun add <member>@workspace:*` needs for the entry it just created.
  - `Lockfile::bind_update_requests` attached a request to the first row of the workspace with that name. The root's rows begin with one implicit row per workspace member (Package.rs parses the `workspaces` list as a dependency group ahead of `dependencies`), so on the root a member's name was always bound, whether or not the root declared it: that is what let the undeclared name past the editor's never-add check (`package_id == INVALID_PACKAGE_ID`), and for a declared entry it keyed the write-back on the member row instead of the entry's own resolution.

### Fix

- The literal check now uses the predicate the bare update already applies (`edit_update_entries`: only `Npm` and `DistTag` literals move): under `bun update`, an entry whose literal is not a registry range or tag is skipped in both passes. That covers `catalog:` as before plus `workspace:`, `file:` folders and tarballs, git and `link:` entries; `bun add` is unchanged. This is the rule `bun update` already follows for patterns (`update_scope.rs` skips rows resolving to a workspace) and that bun-add-catalog.test.ts pins for `catalog:` entries with an explicit spec; pnpm and yarn leave such entries alone on update as well. A named update still re-resolves the entry (a git entry follows its branch); only package.json is left as written.
- The write-back arm for a resolution of kind Workspace is skipped under `bun update` (`continue`), which is what keeps a plain range or dist-tag that happened to link a member (`"pkg1": "^1.0.0"`) as written; `bun add` still takes the `workspace:*` arm.
- `bind_update_requests` skips rows with the `WORKSPACE` behavior, so a request is bound to the package.json entry that names it, as the tree printer already does when it decides what to print (`should_print_package_install`). An undeclared member stays unbound and the existing never-add check holds. The other case where the member row and the entry resolve differently (a dist-tag the registry satisfies on a member's name) does not install on main at all (`DependencyLoop`, noted on #37248), so today this hunk is only observable as the spurious add.
- Overlap with #38827: that PR guards the `--latest` rewrite in this same function with `is_npm()`. With this change that line is no longer reached for a non-registry entry on the named path, and its tests pass either way; a note is left there.
- Tests, all in test/cli/install/bun-update-lockfile-sync.test.ts: `workspace:^` / `workspace:~` / `workspace:1.0.0` / `^1.0.0` with `bun update pkg1`; `workspace:^` with `pkg1 --latest`, `pkg1@^1.0.0`, `pkg1@latest`; a `file:` entry whose name the registry has, with `no-deps`, `no-deps --latest`, `no-deps@^1.0.0`, `no-deps@latest`; from a member that declares it; `-r`; and the undeclared root. Each asserts package.json and bun.lock byte-identical to what `bun install` wrote (so a frozen reinstall would add nothing and is not run). With the two source files at their main versions, 13 of the 14 fail (rewrite, registry 404, `^2.0.0` / `^1.1.0` / `latest` written, or the added entry); the plain `file:` case already passed and guards the new route. All pass with the fix.
- Also run with the debug build: bun-update-lockfile-sync, bun-update, bun-update-transitive, bun-add, bun-add-filter, bun-add-catalog, bun-workspaces, catalogs, lockfile-only, update_interactive_install and the `update` block of bun-install-registry, all passing; `cargo clippy -p bun_install` is clean.

### Background

- `bun add` / `bun update <name>` edit package.json in two passes around the install: `edit()` runs before it to put the literal to resolve into the entry (for update: the existing one, `latest` under `--latest`, or the spec given on the command line), and again after it to replace that with the resolved version in the declared style.
- `dependency::Tag::infer` classifies a version literal by its text: `^1.0.0` and `latest` are `Npm` / `DistTag` (`is_npm()`), while `workspace:^`, `catalog:`, `file:...`, a git URL or `link:` each get their own tag. It is what the bare `bun update` uses to decide which entries it may rewrite.
- An `UpdateRequest` is one command-line positional. After resolution, `Lockfile::bind_update_requests` attaches it to a dependency row of the current workspace by name, which sets `package_id` (the package that row resolved to); the second pass switches on that package's resolution. `e_string` points at the package.json value the first pass found for the name; a request without one is a name the file does not declare.
- The root package's dependency rows contain one row per workspace member (behavior `WORKSPACE`, literal = the member's path) ahead of the root's own entries. They are what links members into node_modules; they do not correspond to anything in the root's package.json.
