### PR TITLE
install: only re-resolve rows a package still owns when overrides or catalogs change

### DIFF
--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -1,7 +1,6 @@
 use core::sync::atomic::Ordering;
 
 use bun_collections::DynamicBitSet;
-use bun_collections::bit_set::Range;
 use bun_core::UnwrapOrOom as _;
 use bun_core::time::nano_timestamp;
 use bun_core::{Global, Output};
@@ -524,26 +523,26 @@ pub fn install_with_manager(
                         pinned_rows = enqueue_transitive(manager, &transitive, invalidates_rows)?;
                     }
 
-                    if manager.summary.overrides_changed && !all_name_hashes.is_empty() {
+                    if invalidates_rows {
+                        let catalogs_changed = manager.summary.catalogs_changed;
+                        let mut catalog_overridden: Vec<PackageNameHash> = Vec::new();
+                        if catalogs_changed {
+                            manager
+                                .lockfile
+                                .overrides
+                                .append_catalog_valued_name_hashes(&mut catalog_overridden);
+                            catalog_overridden.sort_unstable();
+                            catalog_overridden.dedup();
+                        }
+                        // `all_name_hashes` is empty unless the overrides changed.
                         reresolve_owned_rows(manager, &pinned_rows, |dependency| {
                             all_name_hashes.binary_search(&dependency.name_hash).is_ok()
-                        })?;
-                    }
-
-                    if manager.summary.catalogs_changed {
-                        let mut catalog_overridden: Vec<PackageNameHash> = Vec::new();
-                        manager
-                            .lockfile
-                            .overrides
-                            .append_catalog_valued_name_hashes(&mut catalog_overridden);
-                        catalog_overridden.sort_unstable();
-                        catalog_overridden.dedup();
-                        reresolve_owned_rows(manager, &pinned_rows, |dependency| {
-                            dependency.version.tag == DependencyVersionTag::Catalog
+                                || (catalogs_changed
+                                    && dependency.version.tag == DependencyVersionTag::Catalog)
                                 || catalog_overridden
                                     .binary_search(&dependency.name_hash)
                                     .is_ok()
-                        })?;
+                        });
                     }
 
                     // Split this into two passes because the below may allocate memory or invalidate pointers
@@ -1534,7 +1533,7 @@ fn report_lockfile_load_error(
     Ok(())
 }
 
-/// Returns the rows the plan re-resolved so the overrides/catalogs invalidation loops that follow leave them pinned; only tracked when those loops will run.
+/// Returns the rows the plan re-resolved so the overrides/catalogs invalidation pass that follows leaves them pinned; only tracked when that pass will run.
 fn enqueue_transitive(
     manager: &mut PackageManager,
     transitive: &TransitiveUpdate,
@@ -1547,50 +1546,40 @@ fn enqueue_transitive(
     transitive.enqueue_tracked(manager)
 }
 
-/// Re-resolves every row `selects` that a package still owns; the rows the differ orphaned (the root's list from the loaded lockfile) resolve as nobody's, and `pinned_rows` were just resolved by the update plan.
+/// Re-resolves the rows `selects`, walking each package's current dependency list in package order. The root's
+/// list (just rebuilt by the differ) goes first because a later row dedupes onto what an earlier one appended
+/// (`Lockfile::get_package_id`); the root's loaded rows, now in no list, would resolve as nobody's and are not
+/// walked, nor are `pinned_rows`, which the update plan just resolved. A workspace the add/update pass is about
+/// to re-read still holds its loaded list here and is walked like any other package.
 fn reresolve_owned_rows(
     manager: &mut PackageManager,
     pinned_rows: &DynamicBitSet,
     selects: impl Fn(&Dependency) -> bool,
-) -> crate::Result<()> {
-    let owned_rows = {
-        let lockfile = &*manager.lockfile;
-        let mut owned = DynamicBitSet::init_empty(lockfile.buffers.dependencies.len())?;
-        for slice in lockfile.packages.items_dependencies() {
-            if slice.len == 0 {
+) {
+    // Resolving appends packages and rows; only the lists present now are walked.
+    let lists: Vec<lockfile::DependencySlice> =
+        manager.lockfile.packages.items_dependencies().to_vec();
+    for list in lists {
+        for dep_id in list.begin()..list.end() {
+            if pinned_rows.is_set_allow_out_of_bound(dep_id as usize, false) {
                 continue;
             }
-            owned.set_range_value(
-                Range {
-                    start: slice.begin() as usize,
-                    end: slice.end() as usize,
-                },
-                true,
-            );
-        }
-        owned
-    };
-    // Resolving appends rows; the bitset's length bounds the walk to the rows that existed when it was built.
-    for dep_id in 0..owned_rows.bit_length() {
-        if !owned_rows.is_set(dep_id) || pinned_rows.is_set_allow_out_of_bound(dep_id, false) {
-            continue;
-        }
-        let dependency = manager.lockfile.buffers.dependencies[dep_id].clone();
-        if !selects(&dependency) {
-            continue;
-        }
-        manager.lockfile.buffers.resolutions[dep_id] = invalid_package_id;
-        if let Err(err) = enqueue_dependency_with_main(
-            manager,
-            dep_id as DependencyID,
-            &dependency,
-            invalid_package_id,
-            false,
-        ) {
-            add_dependency_error(manager, &dependency, err);
+            let dependency = manager.lockfile.buffers.dependencies[dep_id as usize].clone();
+            if !selects(&dependency) {
+                continue;
+            }
+            manager.lockfile.buffers.resolutions[dep_id as usize] = invalid_package_id;
+            if let Err(err) = enqueue_dependency_with_main(
+                manager,
+                dep_id,
+                &dependency,
+                invalid_package_id,
+                false,
+            ) {
+                add_dependency_error(manager, &dependency, err);
+            }
         }
     }
-    Ok(())
 }
 
 #[derive(Default)]

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -1,6 +1,7 @@
 use core::sync::atomic::Ordering;
 
 use bun_collections::DynamicBitSet;
+use bun_collections::bit_set::Range;
 use bun_core::UnwrapOrOom as _;
 use bun_core::time::nano_timestamp;
 use bun_core::{Global, Output};
@@ -523,33 +524,10 @@ pub fn install_with_manager(
                         pinned_rows = enqueue_transitive(manager, &transitive, invalidates_rows)?;
                     }
 
-                    // `enqueueDependencyWithMain` can reach `Lockfile.Package.fromNPM`,
-                    // which grows `buffers.dependencies` and may reallocate it.
-                    // Iterate by index against a snapshot of the original length and
-                    // copy each entry to the stack so neither the loop nor the callee
-                    // ever reads through a pointer into the old backing storage.
                     if manager.summary.overrides_changed && !all_name_hashes.is_empty() {
-                        let dependencies_len = manager.lockfile.buffers.dependencies.len();
-                        for dependency_i in 0..dependencies_len {
-                            if pinned_rows.is_set_allow_out_of_bound(dependency_i, false) {
-                                continue;
-                            }
-                            let dependency =
-                                manager.lockfile.buffers.dependencies[dependency_i].clone();
-                            if all_name_hashes.binary_search(&dependency.name_hash).is_ok() {
-                                manager.lockfile.buffers.resolutions[dependency_i] =
-                                    invalid_package_id;
-                                if let Err(err) = enqueue_dependency_with_main(
-                                    manager,
-                                    dependency_i as u32,
-                                    &dependency,
-                                    invalid_package_id,
-                                    false,
-                                ) {
-                                    add_dependency_error(manager, &dependency, err);
-                                }
-                            }
-                        }
+                        reresolve_owned_rows(manager, &pinned_rows, |dependency| {
+                            all_name_hashes.binary_search(&dependency.name_hash).is_ok()
+                        })?;
                     }
 
                     if manager.summary.catalogs_changed {
@@ -560,33 +538,12 @@ pub fn install_with_manager(
                             .append_catalog_valued_name_hashes(&mut catalog_overridden);
                         catalog_overridden.sort_unstable();
                         catalog_overridden.dedup();
-                        let dependencies_len = manager.lockfile.buffers.dependencies.len();
-                        for _dep_id in 0..dependencies_len {
-                            let dep_id: DependencyID = u32::try_from(_dep_id).expect("int cast");
-                            if pinned_rows.is_set_allow_out_of_bound(_dep_id, false) {
-                                continue;
-                            }
-                            let dep =
-                                manager.lockfile.buffers.dependencies[dep_id as usize].clone();
-                            if dep.version.tag != DependencyVersionTag::Catalog
-                                && (catalog_overridden.is_empty()
-                                    || catalog_overridden.binary_search(&dep.name_hash).is_err())
-                            {
-                                continue;
-                            }
-
-                            manager.lockfile.buffers.resolutions[dep_id as usize] =
-                                invalid_package_id;
-                            if let Err(err) = enqueue_dependency_with_main(
-                                manager,
-                                dep_id,
-                                &dep,
-                                invalid_package_id,
-                                false,
-                            ) {
-                                add_dependency_error(manager, &dep, err);
-                            }
-                        }
+                        reresolve_owned_rows(manager, &pinned_rows, |dependency| {
+                            dependency.version.tag == DependencyVersionTag::Catalog
+                                || catalog_overridden
+                                    .binary_search(&dependency.name_hash)
+                                    .is_ok()
+                        })?;
                     }
 
                     // Split this into two passes because the below may allocate memory or invalidate pointers
@@ -1588,6 +1545,57 @@ fn enqueue_transitive(
         return Ok(DynamicBitSet::default());
     }
     transitive.enqueue_tracked(manager)
+}
+
+/// Invalidates and re-resolves every row `selects`, except `pinned_rows` and rows no package owns any more:
+/// the differ just gave the root a fresh dependency list, so the rows it was loaded with are dead. The resolver
+/// decides how far to trust a row by its owner (`Lockfile::is_workspace_dependency`), so re-resolving a dead
+/// root row is wasted work at best and, for a `file:` path outside the project that nothing overrides any
+/// more, a resolution error.
+fn reresolve_owned_rows(
+    manager: &mut PackageManager,
+    pinned_rows: &DynamicBitSet,
+    selects: impl Fn(&Dependency) -> bool,
+) -> crate::Result<()> {
+    let owned_rows = {
+        let lockfile = &*manager.lockfile;
+        let mut owned = DynamicBitSet::init_empty(lockfile.buffers.dependencies.len())?;
+        for slice in lockfile.packages.items_dependencies() {
+            if slice.len == 0 {
+                continue;
+            }
+            owned.set_range_value(
+                Range {
+                    start: slice.begin() as usize,
+                    end: slice.end() as usize,
+                },
+                true,
+            );
+        }
+        owned
+    };
+    // Resolving may append packages and grow `buffers.dependencies`, so only the rows present when this pass
+    // started are visited, each copied out before the resolver runs.
+    for dep_id in 0..owned_rows.bit_length() {
+        if !owned_rows.is_set(dep_id) || pinned_rows.is_set_allow_out_of_bound(dep_id, false) {
+            continue;
+        }
+        let dependency = manager.lockfile.buffers.dependencies[dep_id].clone();
+        if !selects(&dependency) {
+            continue;
+        }
+        manager.lockfile.buffers.resolutions[dep_id] = invalid_package_id;
+        if let Err(err) = enqueue_dependency_with_main(
+            manager,
+            dep_id as DependencyID,
+            &dependency,
+            invalid_package_id,
+            false,
+        ) {
+            add_dependency_error(manager, &dependency, err);
+        }
+    }
+    Ok(())
 }
 
 #[derive(Default)]

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -1547,11 +1547,7 @@ fn enqueue_transitive(
     transitive.enqueue_tracked(manager)
 }
 
-/// Invalidates and re-resolves every row `selects`, except `pinned_rows` and rows no package owns any more:
-/// the differ just gave the root a fresh dependency list, so the rows it was loaded with are dead. The resolver
-/// decides how far to trust a row by its owner (`Lockfile::is_workspace_dependency`), so re-resolving a dead
-/// root row is wasted work at best and, for a `file:` path outside the project that nothing overrides any
-/// more, a resolution error.
+/// Re-resolves every row `selects` that a package still owns; the rows the differ orphaned (the root's list from the loaded lockfile) resolve as nobody's, and `pinned_rows` were just resolved by the update plan.
 fn reresolve_owned_rows(
     manager: &mut PackageManager,
     pinned_rows: &DynamicBitSet,
@@ -1574,8 +1570,7 @@ fn reresolve_owned_rows(
         }
         owned
     };
-    // Resolving may append packages and grow `buffers.dependencies`, so only the rows present when this pass
-    // started are visited, each copied out before the resolver runs.
+    // Resolving appends rows; the bitset's length bounds the walk to the rows that existed when it was built.
     for dep_id in 0..owned_rows.bit_length() {
         if !owned_rows.is_set(dep_id) || pinned_rows.is_set_allow_out_of_bound(dep_id, false) {
             continue;

--- a/test/cli/install/catalogs.test.ts
+++ b/test/cli/install/catalogs.test.ts
@@ -1371,6 +1371,14 @@ describe("peer dependencies", () => {
       const dir = await installedAlone(packageJson("1.0.0"));
       expect(await reinstall(dir, packageJson("^1.0.1"))).toBe(1);
     });
+
+    // Selected both as an overridden name and as a catalog: row; one pass handles both.
+    test.concurrent("declared through the catalog while an override of the same name changes too", async () => {
+      const packageJson = (range: string) =>
+        rootWithPeer("catalog:", { overrides: { "no-deps": range }, workspaces: { catalog: { "no-deps": range } } });
+      const dir = await installedAlone(packageJson("1.0.0"));
+      expect(await reinstall(dir, packageJson("^1.0.1"))).toBe(1);
+    });
   });
 
   // pnpm: deps-installer/test/catalogs.ts "frozen lockfile error is thrown if catalog config changes"

--- a/test/cli/install/catalogs.test.ts
+++ b/test/cli/install/catalogs.test.ts
@@ -1322,6 +1322,57 @@ describe("peer dependencies", () => {
     expect(await packageKeys(dir)).toStrictEqual(dedupedKeys);
   });
 
+  // When the catalog changes, every row declared through it is re-resolved. The root's rows from bun.lock have
+  // been replaced by then and belong to no package; re-resolving them too bound the peer a second time and
+  // repeated its warning.
+  describe("a root peer whose catalog range stops matching the installed version is checked once", () => {
+    const peerWarning = 'warn: incorrect peer dependency "no-deps@1.0.0"';
+    const peerWarnings = (err: string) => err.split(peerWarning).length - 1;
+
+    function rootWithPeer(peerSpec: string, fields: Record<string, unknown> = {}) {
+      return JSON.stringify({ name: "root", peerDependencies: { "no-deps": peerSpec }, ...fields });
+    }
+
+    async function installedAlone(packageJson: string) {
+      const { packageDir } = await registry.createTestDir({
+        bunfigOpts: { linker: "hoisted" },
+        files: { "package.json": packageJson },
+      });
+      const { err } = await install(packageDir, "hoisted");
+      expect(peerWarnings(err)).toBe(0);
+      expect((await Bun.file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).version).toBe(
+        "1.0.0",
+      );
+      return packageDir;
+    }
+
+    async function reinstall(dir: string, packageJson: string) {
+      await Bun.write(join(dir, "package.json"), packageJson);
+      const { err } = await install(dir, "hoisted");
+      expect(err).toContain("Saved lockfile");
+      return peerWarnings(err);
+    }
+
+    // The inline row is the baseline: it changes itself and is only re-enqueued by the add/update pass.
+    test.concurrent.each([
+      [
+        "through the catalog",
+        (range: string) => rootWithPeer("catalog:", { workspaces: { catalog: { "no-deps": range } } }),
+      ],
+      ["inline", (range: string) => rootWithPeer(range)],
+    ])("declared %s", async (_, packageJson) => {
+      const dir = await installedAlone(packageJson("1.0.0"));
+      expect(await reinstall(dir, packageJson("^1.0.1"))).toBe(1);
+    });
+
+    test.concurrent("overridden to catalog:", async () => {
+      const packageJson = (range: string) =>
+        rootWithPeer("1.0.0", { overrides: { "no-deps": "catalog:" }, workspaces: { catalog: { "no-deps": range } } });
+      const dir = await installedAlone(packageJson("1.0.0"));
+      expect(await reinstall(dir, packageJson("^1.0.1"))).toBe(1);
+    });
+  });
+
   // pnpm: deps-installer/test/catalogs.ts "frozen lockfile error is thrown if catalog config changes"
   test.concurrent("--frozen-lockfile fails when only a peer's catalog range changed", async () => {
     const dir = await makeRepo({ catalog: { "no-deps": ">=1.0.0" }, peerSpec: "catalog:", linker: "hoisted" });

--- a/test/cli/install/catalogs.test.ts
+++ b/test/cli/install/catalogs.test.ts
@@ -259,6 +259,54 @@ describe("basic", () => {
     await runBunInstall(bunEnv, packageDir, { savesLockfile: false });
   });
 
+  // A file: path outside the project is only accepted on a row the root (or a workspace) owns. A catalog change
+  // re-resolves every catalog: row; the rows the root was loaded with have been replaced by then and belong to
+  // nobody, so re-resolving them fails the way an escaping transitive file: dependency does.
+  test.concurrent("changing the entry of a catalog: dependency pointing outside the project", async () => {
+    const packageJson = (xPath: string) =>
+      JSON.stringify({
+        name: "catalog-file-dep",
+        workspaces: { packages: [], catalog: { x: xPath } },
+        dependencies: { x: "catalog:" },
+      });
+    using dir = tempDir("catalog-file-dep", {
+      "x/package.json": JSON.stringify({ name: "x", version: "1.0.0" }),
+      "x2/package.json": JSON.stringify({ name: "x", version: "2.0.0" }),
+      "project/package.json": packageJson("file:../x"),
+    });
+    const packageDir = join(String(dir), "project");
+    const installedVersion = async () =>
+      (await file(join(packageDir, "node_modules", "x", "package.json")).json()).version;
+
+    await runBunInstall(bunEnv, packageDir);
+    expect(await installedVersion()).toBe("1.0.0");
+
+    await write(join(packageDir, "package.json"), packageJson("file:../x2"));
+    await runBunInstall(bunEnv, packageDir);
+    expect(await installedVersion()).toBe("2.0.0");
+    expect(normalizeBunSnapshot(await file(join(packageDir, "bun.lock")).text(), packageDir)).toMatchInlineSnapshot(`
+      "{
+        "lockfileVersion": 2,
+        "configVersion": 1,
+        "workspaces": {
+          "": {
+            "name": "catalog-file-dep",
+            "dependencies": {
+              "x": "catalog:",
+            },
+          },
+        },
+        "catalog": {
+          "x": "file:../x2",
+        },
+        "packages": {
+          "x": ["x@file:../x2", {}],
+        }
+      }"
+    `);
+    await runBunInstall(bunEnv, packageDir, { frozenLockfile: true });
+  });
+
   test.concurrent("catalog and catalogs.default may split different packages between them", async () => {
     const { packageDir } = await registry.createTestDir({
       files: {

--- a/test/cli/install/nested-overrides.test.ts
+++ b/test/cli/install/nested-overrides.test.ts
@@ -2,7 +2,7 @@ import { file, write } from "bun";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { existsSync, realpathSync } from "fs";
 import { rm } from "fs/promises";
-import { VerdaccioRegistry, bunEnv, bunExe } from "harness";
+import { VerdaccioRegistry, bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 import { join } from "path";
 
 const registry = new VerdaccioRegistry();
@@ -1288,6 +1288,84 @@ describe.concurrent("lockfile", () => {
     expect(after).not.toContain("no-deps@2.0.0");
     expect(after).toContain('"lockfileVersion": 2');
     await installOk(dir, "--frozen-lockfile");
+  });
+
+  // A file: path outside the project is only accepted on a row the root (or a workspace) owns. An overrides change
+  // re-resolves every row naming a previously or newly overridden package; the rows the root was loaded with have
+  // been replaced by then and belong to nobody, so re-resolving them fails the way an escaping transitive one does.
+  describe.concurrent("removing a flat rule for a root file: dependency outside the project", () => {
+    const outside = {
+      "x/package.json": JSON.stringify({ name: "x", version: "1.0.0" }),
+      "x2/package.json": JSON.stringify({ name: "x", version: "2.0.0" }),
+      "project/y/package.json": JSON.stringify({ name: "y", version: "1.0.0" }),
+    };
+    const rootPackageJson = (pkg: Record<string, unknown>) => JSON.stringify({ name: "nested-overrides", ...pkg });
+    const before = rootPackageJson({
+      dependencies: { x: "file:../x", y: "file:./y" },
+      overrides: { x: "file:../x2" },
+    });
+
+    test("the dependency re-resolves to its own path", async () => {
+      using root = tempDir("override-removed-file-dep", { ...outside, "project/package.json": before });
+      const dir = join(String(root), "project");
+      await installOk(dir);
+      expect(await versionSeenBy(dir, undefined, "x")).toBe("2.0.0");
+
+      await write(join(dir, "package.json"), rootPackageJson({ dependencies: { x: "file:../x", y: "file:./y" } }));
+      const { err } = await installOk(dir);
+      expect(err).toContain("Saved lockfile");
+      expect(await versionSeenBy(dir, undefined, "x")).toBe("1.0.0");
+      expect(normalizeBunSnapshot(await lock(dir), dir)).toMatchInlineSnapshot(`
+        "{
+          "lockfileVersion": 2,
+          "configVersion": 1,
+          "workspaces": {
+            "": {
+              "name": "nested-overrides",
+              "dependencies": {
+                "x": "file:../x",
+                "y": "file:./y",
+              },
+            },
+          },
+          "packages": {
+            "x": ["x@file:../x", {}],
+
+            "y": ["y@file:y", {}],
+          }
+        }"
+      `);
+      await installOk(dir, "--frozen-lockfile");
+    });
+
+    test("together with the dependency itself", async () => {
+      using root = tempDir("override-and-file-dep-removed", { ...outside, "project/package.json": before });
+      const dir = join(String(root), "project");
+      await installOk(dir);
+      expect(await versionSeenBy(dir, undefined, "x")).toBe("2.0.0");
+
+      await write(join(dir, "package.json"), rootPackageJson({ dependencies: { y: "file:./y" } }));
+      const { err } = await installOk(dir);
+      expect(err).toContain("Saved lockfile");
+      expect(normalizeBunSnapshot(await lock(dir), dir)).toMatchInlineSnapshot(`
+        "{
+          "lockfileVersion": 2,
+          "configVersion": 1,
+          "workspaces": {
+            "": {
+              "name": "nested-overrides",
+              "dependencies": {
+                "y": "file:./y",
+              },
+            },
+          },
+          "packages": {
+            "y": ["y@file:y", {}],
+          }
+        }"
+      `);
+      await installOk(dir, "--frozen-lockfile");
+    });
   });
 
   test("changing only the parent's range text is a frozen-lockfile change", async () => {

--- a/test/cli/install/nested-overrides.test.ts
+++ b/test/cli/install/nested-overrides.test.ts
@@ -1290,10 +1290,31 @@ describe.concurrent("lockfile", () => {
     await installOk(dir, "--frozen-lockfile");
   });
 
-  // A file: path outside the project is only accepted on a row the root (or a workspace) owns. An overrides change
-  // re-resolves every row naming a previously or newly overridden package; the rows the root was loaded with have
-  // been replaced by then and belong to nobody, so re-resolving them fails the way an escaping transitive one does.
-  describe.concurrent("removing a flat rule for a root file: dependency outside the project", () => {
+  // An overrides change re-resolves every row naming a previously or newly overridden package. By then the root's
+  // rows from bun.lock have been replaced by freshly parsed ones and belong to no package; they must not be
+  // re-resolved as well: a range that is no longer in package.json would add a package the current row then dedupes
+  // onto, and a file: path outside the project is only accepted on a row the root (or a workspace) owns.
+  describe.concurrent("removing a flat rule re-resolves only the root's current rows", () => {
+    test("a range changed in the same edit resolves on its own", async () => {
+      const dir = await project({ dependencies: { "no-deps": "~1.0.0" }, overrides: { "no-deps": "2.0.0" } });
+      await installOk(dir);
+      expect(await versionSeenBy(dir, undefined, "no-deps")).toBe("2.0.0");
+
+      await write(
+        join(dir, "package.json"),
+        JSON.stringify({ name: "nested-overrides", dependencies: { "no-deps": "^1.0.0" } }),
+      );
+      const { err } = await installOk(dir);
+      expect(err).toContain("Saved lockfile");
+      // 1.0.1 is what the dropped ~1.0.0 range would pick.
+      expect(await versionSeenBy(dir, undefined, "no-deps")).toBe("1.1.0");
+      const after = await lock(dir);
+      expect(after).not.toContain('"overrides"');
+      expect(after).not.toContain("no-deps@1.0.1");
+      expect(after).not.toContain("no-deps@2.0.0");
+      await installOk(dir, "--frozen-lockfile");
+    });
+
     const outside = {
       "x/package.json": JSON.stringify({ name: "x", version: "1.0.0" }),
       "x2/package.json": JSON.stringify({ name: "x", version: "2.0.0" }),
@@ -1305,7 +1326,7 @@ describe.concurrent("lockfile", () => {
       overrides: { x: "file:../x2" },
     });
 
-    test("the dependency re-resolves to its own path", async () => {
+    test("a file: dependency outside the project re-resolves to its own path", async () => {
       using root = tempDir("override-removed-file-dep", { ...outside, "project/package.json": before });
       const dir = join(String(root), "project");
       await installOk(dir);
@@ -1338,7 +1359,7 @@ describe.concurrent("lockfile", () => {
       await installOk(dir, "--frozen-lockfile");
     });
 
-    test("together with the dependency itself", async () => {
+    test("a file: dependency outside the project removed together with its rule", async () => {
       using root = tempDir("override-and-file-dep-removed", { ...outside, "project/package.json": before });
       const dir = join(String(root), "project");
       await installOk(dir);

--- a/test/cli/install/nested-overrides.test.ts
+++ b/test/cli/install/nested-overrides.test.ts
@@ -1293,8 +1293,28 @@ describe.concurrent("lockfile", () => {
   // An overrides change re-resolves every row naming a previously or newly overridden package. By then the root's
   // rows from bun.lock have been replaced by freshly parsed ones and belong to no package; they must not be
   // re-resolved as well: a range that is no longer in package.json would add a package the current row then dedupes
-  // onto, and a file: path outside the project is only accepted on a row the root (or a workspace) owns.
+  // onto, and a file: path outside the project is only accepted on a row the root (or a workspace) owns. The
+  // root's current rows also have to be resolved before everybody else's, as on a fresh install, since a row
+  // resolved later dedupes onto a same-major package an earlier one added.
   describe.concurrent("removing a flat rule re-resolves only the root's current rows", () => {
+    test("the root's row resolves before a dependency's row of the same name", async () => {
+      const deps = { "no-deps": "^1.0.0", "one-dep": "1.0.0" }; // one-dep@1.0.0 depends on no-deps@1.0.1
+      const [dir, fresh] = await Promise.all([
+        project({ dependencies: deps, overrides: { "no-deps": "2.0.0" } }),
+        project({ dependencies: deps }),
+      ]);
+      await Promise.all([installOk(dir), installOk(fresh)]);
+      expect(await lock(dir)).toContain("no-deps@2.0.0");
+
+      await write(join(dir, "package.json"), JSON.stringify({ name: "nested-overrides", dependencies: deps }));
+      const { err } = await installOk(dir);
+      expect(err).toContain("Saved lockfile");
+      expect(await versionSeenBy(dir, undefined, "no-deps")).toBe("1.1.0");
+      expect(await versionSeenBy(dir, "one-dep", "no-deps")).toBe("1.0.1");
+      // Same packages as installing this package.json from scratch.
+      expect(await lock(dir)).toBe(await lock(fresh));
+    });
+
     test("a range changed in the same edit resolves on its own", async () => {
       const dir = await project({ dependencies: { "no-deps": "~1.0.0" }, overrides: { "no-deps": "2.0.0" } });
       await installOk(dir);


### PR DESCRIPTION
### Problem
- A project whose root package.json has `"x": "file:../x"` installs fine with an override for `x`, but once that override is removed (or, for `"x": "catalog:"`, once the catalog changes) every following `bun install` fails until the lockfile is deleted:
  ```
  error: Could not find package.json for "file:../x" dependency "x"
  ```
  Reproduces on bun 1.4.0 and main, with bun.lock and bun.lockb alike; a fresh install of the same package.json works.
- The same defect also mis-resolves registry dependencies: with `"no-deps": "~1.0.0"` plus an override, removing the override while changing the range to `^1.0.0` installs no-deps 1.0.1 (the best match of the range that was just removed) instead of 1.1.0.
- Cause: when overrides or catalogs changed, `install_with_manager` appends the freshly parsed root rows to `buffers.dependencies` and points package 0 at them (`src/install/PackageManager/install_with_manager.rs:353`), then re-resolves every row in `buffers.dependencies` whose name is overridden, or that is a `catalog:` row (the two loops at `:531` and `:555` before this change). The root's previous rows are still in the buffer, owned by no package, so they get re-resolved too, ahead of the live rows.
- `file:` case: for an unowned row `Lockfile::is_workspace_dependency` is false, so the Folder arm of `get_or_put_resolved_package` (`src/install/PackageManager/PackageManagerEnqueue.rs:2656`) treats it as a transitive folder dependency and rejects a path that leaves the package directory unless the name is still overridden. The live row resolves fine; the error comes from the dead one.
- npm case: the dead `~1.0.0` row appends no-deps@1.0.1, and the live `^1.0.0` row is then deduped onto that package by the satisfies fallback in `Lockfile::get_package_id` (`src/install/lockfile.rs:2034`), which accepts a same-major package appended earlier in the session.
- Peer case: a root `peerDependencies` entry declared through the catalog (or overridden to `catalog:`) is bound twice when the catalog entry stops matching the installed version, so `warn: incorrect peer dependency` is printed twice.
- Every other dead row naming an overridden package (git, tarball, in-project folders, ...) was resolved a second time for nothing; `Lockfile::clean` drops whatever that produced.

### Fix
- Both loops now go through `reresolve_owned_rows`, which builds a bitset of the rows covered by some package's dependency list and only invalidates and re-resolves those (still skipping the rows a bare `bun update` pinned). The selection predicates are unchanged.
- Correct because a row only means something through its owner: the resolver decides how far to trust a `file:` / `workspace:` target from the owning package, `locked_version_of_invoking_workspace_row` only honors rows in the root's current list, and once resolution is done nothing reads an unowned row (`Lockfile::clean` and the tree builder both walk package lists). A row no package owns therefore has no owner to be resolved under and nothing to contribute; its live replacement is in the buffer and is visited by the same pass.
- The dead rows had no side effect worth keeping. The only way their resolution reached a live row is the `get_package_id` dedupe described above, which is the 1.0.1-instead-of-1.1.0 bug: it let a range that is no longer in package.json pick the version. The locked-version helpers (`locked_version_in_lockfile` only looks at lockfile-loaded packages) and manifest fetches (the same manifest is fetched for the live row) are unaffected by whether a dead row was resolved.
- This is the rule the newer passes already follow (`UpdateScope::walkable_rows`, `update_transitive::set_rows_of`, `audit_fix::live_edge`); these two loops predate it.
- Out of scope: rows that are owned but get visited twice by these passes for other reasons (a root row the differ left unmapped, which the add/update pass re-enqueues as well; the rows of a workspace the add/update pass is about to re-read; a `catalog:` row whose name is also overridden when both changed). Those only repeat a peer warning and are a separate change on top of this one (see the comments below).
- Verified with:
  - `test/cli/install/nested-overrides.test.ts`, "removing a flat rule re-resolves only the root's current rows": the npm range case above, a `file:` dependency outside the project whose override is removed, and one removed together with its override.
  - `test/cli/install/catalogs.test.ts`: "changing the entry of a catalog: dependency pointing outside the project", and "a root peer whose catalog range stops matching the installed version is checked once" (declared through the catalog, overridden to `catalog:`, plus the inline declaration as the baseline that already warned once).
  - The six non-baseline tests fail on the released binary (the `file:` ones with the error above, the npm one with 1.0.1, the peer ones with a wrong warning count) and pass with this change; the nested-overrides ones 3 of 3 runs each way.
  - `bun bd test` on nested-overrides, catalogs, bun-update-transitive, frozen-lockfile-pruned, bun-lock and bun-install: no new failures (the bun-install failures in this sandbox are the tests that need network access).

### Background
- `buffers.dependencies` / `buffers.resolutions` are flat, parallel arrays of dependency rows; each package owns a contiguous `(off, len)` slice of them. A row is "owned" when some package's slice covers its index.
- The differ (`Diff::generate`) compares the root package.json against the lockfile's root. When anything relevant changed, the root gets a new slice appended at the end of the buffers rather than having its old rows rewritten, so the old rows stay in the buffer, unowned, until `Lockfile::clean` rebuilds the lockfile after resolution.
- Folder (`file:`) trust: a `file:` target on a root or workspace row is user-written and may point anywhere; the same target declared by a transitive package is rejected when it escapes that package's directory, except for names listed in the root's overrides, whose values are also user-written. Ownership is how the resolver tells the two apart.
- `Lockfile::get_package_id` dedupe: when an npm row resolves, a package of that name already in the lockfile that satisfies the row's range is reused instead of appending the manifest's best match; for packages appended during the current install this is only refused across majors. Resolution order therefore decides which of two overlapping ranges wins, which is why a dead row resolved first could pick for the live one.
- `pinned_rows` is the set of rows a bare `bun update` already re-resolved to a chosen version just before these loops run; it was already excluded and still is.
