### PR TITLE
install: resolve file: dependencies loaded from the lockfile relative to the top-level dir

### DIFF
--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -727,17 +727,10 @@ impl Lockfile {
         })
     }
 
-    /// A loaded lockfile only carries each dependency's literal, and for a folder
-    /// dependency that is the path as the declaring package.json wrote it,
-    /// relative to that package. `Package::parse` stores `Version.value.folder`
-    /// relative to the top-level dir and the resolver relies on that whenever a
-    /// row is resolved again (`bun update <name>`, a changed override), so derive
-    /// the value of every folder row the same way from its literal and the
-    /// declaring package's directory, for every package whose directory the
-    /// lockfile records. Rows declared by registry, git and tarball packages are
-    /// not rebased by `Package::from_npm` either and are left alone. Only the
-    /// value changes, never the literal, so this is idempotent and the lockfile
-    /// is written back unchanged.
+    /// A lockfile stores a folder dependency as its literal, relative to the
+    /// declaring package; give the rows of root, workspace and `file:` packages
+    /// the top-level relative `value.folder` that `Package::parse` gives them.
+    /// Idempotent, since the literal is left as is.
     pub(crate) fn rebase_folder_dependencies(&mut self) -> Result<(), AllocError> {
         let Lockfile {
             packages,

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -11,7 +11,7 @@ use bun_collections::{
     HashMap as BunHashMap, IdentityContext, LinearFifo, linear_fifo::DynamicBuffer,
 };
 use bun_core::fmt::PathSep;
-use bun_core::{Global, Output};
+use bun_core::{Global, Output, UnwrapOrOom as _};
 use bun_paths::{MAX_PATH_BYTES, PathBuffer, SEP, SEP_STR, platform, resolve_path};
 // `bun_install` sits above `bun_resolver` in the crate graph (no cycle), so use
 // the real resolver `FileSystem` directly — same as `PackageManager.rs`.
@@ -500,6 +500,21 @@ impl Lockfile {
     pub fn load_from_dir<'a, const ATTEMPT_LOADING_FROM_OTHER_LOCKFILE: bool>(
         &'a mut self,
         dir: Fd,
+        manager: Option<&mut PackageManager>,
+        log: &mut bun_ast::Log,
+    ) -> LoadResult<'a> {
+        let mut result =
+            self.read_from_dir::<ATTEMPT_LOADING_FROM_OTHER_LOCKFILE>(dir, manager, log);
+        if let LoadResult::Ok(ok) = &mut result {
+            ok.lockfile.rebase_folder_dependencies().unwrap_or_oom();
+        }
+        result
+    }
+
+    /// bun.lock, bun.lockb or, failing both, a foreign lockfile to migrate from.
+    fn read_from_dir<'a, const ATTEMPT_LOADING_FROM_OTHER_LOCKFILE: bool>(
+        &'a mut self,
+        dir: Fd,
         mut manager: Option<&mut PackageManager>,
         log: &mut bun_ast::Log,
     ) -> LoadResult<'a> {
@@ -710,6 +725,83 @@ impl Lockfile {
             migrated: Migrated::None,
             format: LockfileFormat::Binary,
         })
+    }
+
+    /// A loaded lockfile only carries each dependency's literal, and for a folder
+    /// dependency that is the path as the declaring package.json wrote it,
+    /// relative to that package. `Package::parse` stores `Version.value.folder`
+    /// relative to the top-level dir and the resolver relies on that whenever a
+    /// row is resolved again (`bun update <name>`, a changed override), so derive
+    /// the value of every folder row the same way from its literal and the
+    /// declaring package's directory, for every package whose directory the
+    /// lockfile records. Rows declared by registry, git and tarball packages are
+    /// not rebased by `Package::from_npm` either and are left alone. Only the
+    /// value changes, never the literal, so this is idempotent and the lockfile
+    /// is written back unchanged.
+    pub(crate) fn rebase_folder_dependencies(&mut self) -> Result<(), AllocError> {
+        let Lockfile {
+            packages,
+            buffers,
+            string_pool,
+            ..
+        } = self;
+        let Buffers {
+            string_bytes,
+            dependencies,
+            ..
+        } = buffers;
+        let pkgs = packages.slice();
+        let mut path_buf = bun_paths::path_buffer_pool::get();
+
+        for (pkg_resolution, pkg_dependencies) in pkgs
+            .items_resolution()
+            .iter()
+            .zip(pkgs.items_dependencies())
+        {
+            let pkg_dir: SemverString = match pkg_resolution.tag {
+                ResolutionTag::Root => SemverString::default(),
+                ResolutionTag::Workspace => *pkg_resolution.workspace(),
+                ResolutionTag::Folder => *pkg_resolution.folder(),
+                _ => continue,
+            };
+
+            for dep in pkg_dependencies.mut_(dependencies.as_mut_slice()) {
+                if dep.version.tag != dependency::Tag::Folder {
+                    continue;
+                }
+                let relative = {
+                    let buf = string_bytes.as_slice();
+                    let literal = dep.version.literal.sliced(buf);
+                    let Some(declared) = dependency::parse_with_tag(
+                        dep.name,
+                        Some(dep.name_hash),
+                        literal.slice,
+                        dependency::Tag::Folder,
+                        &literal,
+                        None,
+                        None,
+                    ) else {
+                        continue;
+                    };
+                    let declared_folder = *declared.folder();
+                    package::folder_relative_to_top_level_dir(
+                        pkg_dir.slice(buf),
+                        declared_folder.slice(buf),
+                        &mut path_buf[..],
+                    )
+                };
+                let Some(relative) = relative else {
+                    continue;
+                };
+                dep.version.value.folder = SemverStringBuf {
+                    bytes: &mut *string_bytes,
+                    pool: &mut *string_pool,
+                }
+                .append(relative)?;
+            }
+        }
+
+        Ok(())
     }
 
     pub(crate) fn is_resolved_dependency_disabled(

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -111,6 +111,33 @@ pub(crate) fn value_loc_of(source: &bun_ast::Source, key_loc: bun_ast::Loc) -> b
     crate::bun_json::property_value_loc(&source.contents, key_loc).unwrap_or(key_loc)
 }
 
+/// A folder dependency declared in the package.json of `pkg_dir`, rewritten
+/// relative to the top-level dir. This is the form `Version.value.folder` takes
+/// for every folder dependency declared by a root, workspace or `file:`
+/// package: `parse_dependency` stores it this way, and because lockfiles only
+/// keep the literal, `Lockfile::rebase_folder_dependencies` re-derives it
+/// after loading one. Returns `None` when the joined path does not fit in `buf`.
+pub(crate) fn folder_relative_to_top_level_dir<'a>(
+    pkg_dir: &[u8],
+    folder: &[u8],
+    buf: &'a mut [u8],
+) -> Option<&'a [u8]> {
+    let top_level_dir = FileSystem::instance().top_level_dir();
+    let joined = resolve_path::join_abs_string_buf_checked::<path::platform::Auto>(
+        top_level_dir,
+        buf,
+        &[pkg_dir, folder],
+    )?;
+    let relative = resolve_path::relative(top_level_dir, joined);
+    // empty when the package depends on itself
+    let relative: &[u8] = if relative.is_empty() { b"." } else { relative };
+    let len = relative.len();
+    buf[..len].copy_from_slice(relative);
+    #[cfg(windows)]
+    path::dangerously_convert_path_to_posix_in_place::<u8>(&mut buf[..len]);
+    Some(&buf[..len])
+}
+
 #[cold]
 fn invalid_trusted_dependencies(
     log: &mut bun_ast::Log,
@@ -1846,10 +1873,10 @@ impl Package<u64> {
             dependency::version::Tag::Folder => {
                 let folder = *dependency_version.folder();
                 let mut folder_buf = PathBuffer::uninit();
-                let Some(joined) = resolve_path::join_abs_string_buf_checked::<path::platform::Auto>(
-                    FileSystem::instance().top_level_dir(),
+                let Some(relative) = folder_relative_to_top_level_dir(
+                    source.path.name().dir,
+                    folder.slice(buf),
                     &mut folder_buf.0,
-                    &[source.path.name().dir, folder.slice(buf)],
                 ) else {
                     log.add_error_fmt(
                         source,
@@ -1861,20 +1888,7 @@ impl Package<u64> {
                     );
                     return Err(crate::Error::InstallFailed);
                 };
-                let relative: &[u8] =
-                    resolve_path::relative(FileSystem::instance().top_level_dir(), joined);
-                #[cfg(windows)]
-                let relative: &[u8] = {
-                    let len = relative.len();
-                    folder_buf.0[..len].copy_from_slice(relative);
-                    path::dangerously_convert_path_to_posix_in_place::<u8>(
-                        &mut folder_buf.0[..len],
-                    );
-                    &folder_buf.0[..len]
-                };
-                // if relative is empty, we are linking the package to itself
-                dependency_version.value.folder = string_builder
-                    .append::<String>(if relative.is_empty() { b"." } else { relative });
+                dependency_version.value.folder = string_builder.append::<String>(relative);
             }
             dependency::version::Tag::Npm => {
                 if let Some(workspace_version) = workspace_version {

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -111,9 +111,7 @@ pub(crate) fn value_loc_of(source: &bun_ast::Source, key_loc: bun_ast::Loc) -> b
     crate::bun_json::property_value_loc(&source.contents, key_loc).unwrap_or(key_loc)
 }
 
-/// `folder` as declared by the package.json in `pkg_dir`, made relative to the
-/// top-level dir: the form `Version.value.folder` has in root, workspace and
-/// `file:` packages. `None` if it does not fit in `buf`.
+/// The form `Version.value.folder` has in root, workspace and `file:` packages (`None`: too long for `buf`).
 pub(crate) fn folder_relative_to_top_level_dir<'a>(
     pkg_dir: &[u8],
     folder: &[u8],

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -111,12 +111,9 @@ pub(crate) fn value_loc_of(source: &bun_ast::Source, key_loc: bun_ast::Loc) -> b
     crate::bun_json::property_value_loc(&source.contents, key_loc).unwrap_or(key_loc)
 }
 
-/// A folder dependency declared in the package.json of `pkg_dir`, rewritten
-/// relative to the top-level dir. This is the form `Version.value.folder` takes
-/// for every folder dependency declared by a root, workspace or `file:`
-/// package: `parse_dependency` stores it this way, and because lockfiles only
-/// keep the literal, `Lockfile::rebase_folder_dependencies` re-derives it
-/// after loading one. Returns `None` when the joined path does not fit in `buf`.
+/// `folder` as declared by the package.json in `pkg_dir`, made relative to the
+/// top-level dir: the form `Version.value.folder` has in root, workspace and
+/// `file:` packages. `None` if it does not fit in `buf`.
 pub(crate) fn folder_relative_to_top_level_dir<'a>(
     pkg_dir: &[u8],
     folder: &[u8],

--- a/src/install/pnpm.rs
+++ b/src/install/pnpm.rs
@@ -1620,6 +1620,7 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
     // pnpm records `os`/`cpu` for every `packages:` entry whose manifest
     // declares them, including `file:` folders, tarballs, and git packages.
     crate::migration::clear_non_registry_platform_constraints(lockfile);
+    declare_folder_dependencies_relative_to_their_package(lockfile)?;
 
     lockfile.resolve(log)?;
 
@@ -1778,6 +1779,52 @@ fn declared_package_peers(
     }
 
     Ok(peers)
+}
+
+/// pnpm writes the `file:` dependencies of a `file:` package as directories
+/// relative to the lockfile (`file:sub-dep/child` for the `file:./child` that
+/// `sub-dep/package.json` declares), and the resolution pass above looks the
+/// packages up by that form. bun.lock stores what the package.json declares,
+/// relative to the package, and `Lockfile::rebase_folder_dependencies` reads the
+/// literal back that way, so once everything is resolved rewrite the literals
+/// of every folder package's folder rows into that form. Importers keep their
+/// `specifier`, which already is the declared literal.
+fn declare_folder_dependencies_relative_to_their_package(
+    lockfile: &mut Lockfile,
+) -> Result<(), AllocError> {
+    let mut literal: Vec<u8> = Vec::new();
+    for pkg_id in 0..lockfile.packages.len() {
+        let pkg_resolution = lockfile.packages.items_resolution()[pkg_id];
+        if pkg_resolution.tag != resolution::Tag::Folder {
+            continue;
+        }
+        let pkg_dir = *pkg_resolution.folder();
+        let rows = lockfile.packages.items_dependencies()[pkg_id];
+
+        for dep_id in rows.begin() as usize..rows.end() as usize {
+            let dep = &lockfile.buffers.dependencies[dep_id];
+            if dep.version.tag != dependency::VersionTag::Folder {
+                continue;
+            }
+            let folder = *dep.version.folder();
+
+            literal.clear();
+            literal.extend_from_slice(b"file:");
+            let relative = bun_paths::resolve_path::relative(
+                pkg_dir.slice(string_bytes!(lockfile)),
+                folder.slice(string_bytes!(lockfile)),
+            );
+            literal.extend_from_slice(if relative.is_empty() { b"." } else { relative });
+            #[cfg(windows)]
+            bun_paths::dangerously_convert_path_to_posix_in_place::<u8>(
+                &mut literal[b"file:".len()..],
+            );
+
+            let appended = sbuf!(lockfile).append(&literal)?;
+            lockfile.buffers.dependencies[dep_id].version.literal = appended;
+        }
+    }
+    Ok(())
 }
 
 fn parse_append_package_dependencies(

--- a/src/install/pnpm.rs
+++ b/src/install/pnpm.rs
@@ -1781,14 +1781,10 @@ fn declared_package_peers(
     Ok(peers)
 }
 
-/// pnpm writes the `file:` dependencies of a `file:` package as directories
-/// relative to the lockfile (`file:sub-dep/child` for the `file:./child` that
-/// `sub-dep/package.json` declares), and the resolution pass above looks the
-/// packages up by that form. bun.lock stores what the package.json declares,
-/// relative to the package, and `Lockfile::rebase_folder_dependencies` reads the
-/// literal back that way, so once everything is resolved rewrite the literals
-/// of every folder package's folder rows into that form. Importers keep their
-/// `specifier`, which already is the declared literal.
+/// pnpm records a folder package's `file:` dependencies relative to the lockfile
+/// (`file:sub-dep/child` for a declared `file:./child`), which the resolution
+/// pass above keys on; bun.lock stores them relative to the declaring package,
+/// as declared. Importers already carry the declared `specifier`.
 fn declare_folder_dependencies_relative_to_their_package(
     lockfile: &mut Lockfile,
 ) -> Result<(), AllocError> {

--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -1826,3 +1826,113 @@ describe.each(["hoisted", "isolated"] as const)("peer no published version satis
     expect(await file(lockfilePath).text()).toBe(lockfile);
   });
 });
+
+// A lockfile stores the `file:` path of a dependency exactly as the declaring
+// package.json wrote it, i.e. relative to that package.json, while a fresh parse
+// of the same package.json stores it relative to the project. The rows below
+// only get resolved again from the loaded lockfile (an override for their name
+// went away, or `bun update <name>` targets them), which is when the two forms
+// have to agree.
+describe.concurrent("re-resolving file: dependencies declared by a file: package or a workspace", () => {
+  const pkg = (name: string, version: string, dependencies?: Record<string, string>) =>
+    JSON.stringify({ name, version, dependencies });
+  const app = (overrides?: Record<string, string>) =>
+    JSON.stringify({ name: "app", dependencies: { a: "file:./vendor/a" }, overrides });
+  const installedVersion = async (packageDir: string, ...segments: string[]) =>
+    (await file(join(packageDir, ...segments, "package.json")).json()).version;
+
+  // `a` declares `b` relative to itself; the override redirects `b` elsewhere.
+  const vendored = {
+    "vendor/a/package.json": pkg("a", "1.0.0", { b: "file:../b" }),
+    "vendor/b/package.json": pkg("b", "1.0.0"),
+    "vendor/b2/package.json": pkg("b", "2.0.0"),
+  };
+
+  it.each([
+    ["bun.lock", true],
+    ["bun.lockb", false],
+  ])("removing an override resolves the file: package's dependency next to it again (%s)", async (_, text) => {
+    const { packageDir, packageJson } = await registry.createTestDir({
+      bunfigOpts: { linker: "hoisted", saveTextLockfile: text },
+      files: { ...vendored, "package.json": app({ b: "file:./vendor/b2" }) },
+    });
+    const run = makeInstallRunner(packageDir);
+
+    await run(["install"]);
+    expect(await installedVersion(packageDir, "node_modules", "a", "node_modules", "b")).toBe("2.0.0");
+    expect(await exists(join(packageDir, text ? "bun.lock" : "bun.lockb"))).toBe(true);
+
+    await write(packageJson, app());
+    await run(["install"]);
+    expect(await installedVersion(packageDir, "node_modules", "a", "node_modules", "b")).toBe("1.0.0");
+    await run(["install", "--frozen-lockfile"]);
+
+    await run(["install", "--save-text-lockfile", "--lockfile-only"]);
+    const lockfile = await file(join(packageDir, "bun.lock")).text();
+    expect(lockfile).toContain('"a": ["a@file:vendor/a", { "dependencies": { "b": "file:../b" } }]');
+    expect(lockfile).toContain('"a/b": ["b@file:vendor/b", {}]');
+  });
+
+  it("a path without .. is resolved from the declaring package, not from the project root", async () => {
+    const { packageDir, packageJson } = await registry.createTestDir({
+      bunfigOpts: { linker: "hoisted" },
+      files: {
+        "vendor/a/package.json": pkg("a", "1.0.0", { b: "file:./b" }),
+        "vendor/a/b/package.json": pkg("b", "1.0.0"),
+        // same relative path from the project root
+        "b/package.json": pkg("b", "9.9.9"),
+        "vendor/b2/package.json": pkg("b", "2.0.0"),
+        "package.json": app({ b: "file:./vendor/b2" }),
+      },
+    });
+    const run = makeInstallRunner(packageDir);
+
+    await run(["install"]);
+    await write(packageJson, app());
+    await run(["install"]);
+    expect(await file(join(packageDir, "bun.lock")).text()).toContain('"a/b": ["b@file:vendor/a/b", {}]');
+    expect(await installedVersion(packageDir, "node_modules", "a", "node_modules", "b")).toBe("1.0.0");
+  });
+
+  it("bun update <name> re-resolves the file: package's dependency", async () => {
+    const { packageDir } = await registry.createTestDir({
+      bunfigOpts: { linker: "hoisted" },
+      files: { ...vendored, "package.json": app() },
+    });
+    const run = makeInstallRunner(packageDir);
+
+    await run(["install"]);
+    const lockfile = await file(join(packageDir, "bun.lock")).text();
+    expect(lockfile).toContain('"a/b": ["b@file:vendor/b", {}]');
+
+    await run(["update", "b"]);
+    expect(await file(join(packageDir, "bun.lock")).text()).toBe(lockfile);
+    expect(await installedVersion(packageDir, "node_modules", "a", "node_modules", "b")).toBe("1.0.0");
+  });
+
+  it("removing an override resolves a workspace's file: dependency relative to the workspace again", async () => {
+    const workspaceRoot = (overrides?: Record<string, string>) =>
+      JSON.stringify({ name: "app", workspaces: ["packages/*"], overrides });
+    const { packageDir, packageJson } = await registry.createTestDir({
+      bunfigOpts: { linker: "hoisted" },
+      files: {
+        "packages/ws1/package.json": pkg("ws1", "1.0.0", { b: "file:../../vendor/b" }),
+        "vendor/b/package.json": pkg("b", "1.0.0"),
+        "vendor/b2/package.json": pkg("b", "2.0.0"),
+        "package.json": workspaceRoot({ b: "file:./vendor/b2" }),
+      },
+    });
+    const run = makeInstallRunner(packageDir);
+
+    await run(["install"]);
+    expect(await file(join(packageDir, "bun.lock")).text()).toContain('"ws1/b": ["b@file:vendor/b2", {}]');
+
+    await write(packageJson, workspaceRoot());
+    await run(["install"]);
+    const lockfile = await file(join(packageDir, "bun.lock")).text();
+    expect(lockfile).toContain('"b": "file:../../vendor/b"');
+    expect(lockfile).toContain('"ws1/b": ["b@file:vendor/b", {}]');
+    expect(await installedVersion(packageDir, "packages", "ws1", "node_modules", "b")).toBe("1.0.0");
+    await run(["install", "--frozen-lockfile"]);
+  });
+});

--- a/test/cli/install/migration/__snapshots__/pnpm-lock-v9.test.ts.snap
+++ b/test/cli/install/migration/__snapshots__/pnpm-lock-v9.test.ts.snap
@@ -42,7 +42,7 @@ exports[`pnpm-lock.yaml v9 snapshot alias whose dep-path version is a file: dire
   "packages": {
     "fork": ["bar@github:o/bar#aeb6b15f9c9957c8fa56f9731e914c4d8a6d2f2b", {}, ""],
 
-    "outer": ["outer@file:outer", { "dependencies": { "config": "file:shared/config", "fork": "https://codeload.github.com/o/bar/tar.gz/aeb6b15f9c9957c8fa56f9731e914c4d8a6d2f2b" } }],
+    "outer": ["outer@file:outer", { "dependencies": { "config": "file:../shared/config", "fork": "https://codeload.github.com/o/bar/tar.gz/aeb6b15f9c9957c8fa56f9731e914c4d8a6d2f2b" } }],
 
     "outer/config": ["hi2@file:shared/config", {}],
   }

--- a/test/cli/install/migration/migrate.test.ts
+++ b/test/cli/install/migration/migrate.test.ts
@@ -217,6 +217,49 @@ test("npm lockfile migration skips extraneous packages that also declare inBundl
   expect(fs.existsSync(join(testDir, "bun.lock"))).toBeTrue();
 });
 
+test("bun update <name> re-resolves a file: dependency of a file: package in the same run as the migration", async () => {
+  // package-lock.json (as `npm install --package-lock-only` writes it) keeps `b` the way
+  // vendor/a/package.json declares it, relative to vendor/a. Updating `b` resolves that row again
+  // straight from the migrated lockfile, so it has to be looked up from vendor/a, not the project.
+  await using testDir = tempDir("migrate-nested-file-dep", {
+    "package.json": JSON.stringify({ name: "app", dependencies: { a: "file:./vendor/a" } }),
+    "vendor/a/package.json": JSON.stringify({ name: "a", version: "1.0.0", dependencies: { b: "file:../b" } }),
+    "vendor/b/package.json": JSON.stringify({ name: "b", version: "1.0.0" }),
+    "package-lock.json": JSON.stringify({
+      name: "app",
+      lockfileVersion: 3,
+      requires: true,
+      packages: {
+        "": { name: "app", dependencies: { a: "file:./vendor/a" } },
+        "node_modules/a": { resolved: "vendor/a", link: true },
+        "node_modules/b": { resolved: "vendor/b", link: true },
+        "vendor/a": { version: "1.0.0", dependencies: { b: "file:../b" } },
+        "vendor/b": { version: "1.0.0" },
+      },
+    }),
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "update", "b"],
+    cwd: String(testDir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  expect(stderr).toContain("migrated lockfile from package-lock.json");
+  expect(stderr).not.toContain("error:");
+  expect(exitCode).toBe(0);
+
+  const bunLock = await Bun.file(join(testDir, "bun.lock")).text();
+  expect(bunLock).toContain(`"a": ["a@file:vendor/a", { "dependencies": { "b": "file:../b" } }]`);
+  expect(bunLock).toContain(`"a/b": ["b@file:vendor/b", {}]`);
+  expect(await Bun.file(join(testDir, "node_modules", "a", "node_modules", "b", "package.json")).json()).toEqual({
+    name: "b",
+    version: "1.0.0",
+  });
+});
+
 test("package-lock.json migration requires integrity for tarball URLs outside the configured registry", async () => {
   // A package-lock.json entry whose `resolved` tarball URL points outside the configured
   // registry and that carries no `integrity` field must not be imported as-is. The bun.lock

--- a/test/cli/install/migration/migrate.test.ts
+++ b/test/cli/install/migration/migrate.test.ts
@@ -243,7 +243,7 @@ test("bun update <name> re-resolves a file: dependency of a file: package in the
     cmd: [bunExe(), "update", "b"],
     cwd: String(testDir),
     env: bunEnv,
-    stdout: "pipe",
+    stdout: "ignore",
     stderr: "pipe",
   });
   const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);

--- a/test/cli/install/migration/pnpm-lock-v9.test.ts
+++ b/test/cli/install/migration/pnpm-lock-v9.test.ts
@@ -999,7 +999,8 @@ snapshots:
     expect(exitCode).toBe(0);
 
     const bunLock = await bunLockOf(String(dir));
-    expect(bunLock).toContain(`"config": "file:shared/config"`);
+    // as outer/package.json declares it, not pnpm's lockfile-relative `file:shared/config`
+    expect(bunLock).toContain(`"config": "file:../shared/config"`);
     expect(bunLock).toContain(
       `"fork": "https://codeload.github.com/o/bar/tar.gz/aeb6b15f9c9957c8fa56f9731e914c4d8a6d2f2b"`,
     );
@@ -1081,8 +1082,15 @@ snapshots:
 
     const bunLock = await bunLockOf(String(dir));
     expect(bunLock).toContain(`"sub-dep": "file:./sub-dep"`);
-    expect(bunLock).toContain(`["sub-dep@file:sub-dep", { "dependencies": { "nested-child": "file:sub-dep/child" } }]`);
+    // pnpm-lock.yaml has `nested-child: file:sub-dep/child`; bun.lock stores the path relative to
+    // sub-dep, the way sub-dep/package.json declares it, and resolves it from there when loaded.
+    expect(bunLock).toContain(`["sub-dep@file:sub-dep", { "dependencies": { "nested-child": "file:child" } }]`);
     expect(bunLock).toContain(`["nested-child@file:sub-dep/child", {}]`);
+
+    const update = await run(String(dir), "update", "nested-child");
+    expect(update.stderr).not.toContain("error:");
+    expect(update.exitCode).toBe(0);
+    expect(await bunLockOf(String(dir))).toBe(bunLock);
   });
 
   test.concurrent("codeload tarballs with and without gitHosted: true", async () => {


### PR DESCRIPTION
### Problem

- A `file:` package in the project declares its own `file:` dependency relative to itself (`vendor/a/package.json` has `"b": "file:../b"`). Install once with a root override for `b`, remove the override, and every `bun install` afterwards fails until bun.lock is deleted:
  ```
  error: Could not find package.json for "file:../b" dependency "b"
  error: b@file:../b failed to resolve
  ```
- Same failure for a workspace member declaring `"b": "file:../../vendor/b"`, for `bun update b` in the first setup (no overrides involved), for `bun update b` run directly against a package-lock.json that is being migrated, and with bun.lockb instead of bun.lock. Reproduces on bun 1.4.0 and main. `bun update <name>` started re-resolving transitive rows in #36360 / #38333, so that trigger is new.
- When the declared path has no `..` (`vendor/a` declares `"b": "file:./b"`) nothing fails: `b` is resolved against the project root instead, bun.lock records `b@file:./b`, and whatever sits at `<project>/b` is installed.
- Cause: `Package::parse_dependency` (src/install/lockfile/Package.rs, `Tag::Folder` arm) stores a folder dependency's `Version.value.folder` relative to the top-level dir, and the resolver's Folder arm (src/install/PackageManager/PackageManagerEnqueue.rs:2619) assumes that form. A lockfile only stores the declared literal, and every loader keeps it as is, i.e. relative to the declaring package: bun.lock (`parse_append_dependencies` via `dependency::parse`), bun.lockb (`Version::to_version`) and the package-lock.json / yarn.lock importers. Loaded rows are normally never resolved again, so this only surfaces when something re-enqueues them: the overrides-changed loop in src/install/PackageManager/install_with_manager.rs:531 and `enqueue_named_updates` (`bun update <name>`). A `..` in the verbatim path then trips the transitive folder escape check; a path without `..` is joined onto the wrong directory.
- The pnpm importer has the opposite problem: for a folder package's `file:` rows it wrote pnpm's lockfile-relative directory as the bun.lock literal (`"nested-child": "file:sub-dep/child"` where `sub-dep/package.json` declares `file:./child`), which is not what bun.lock means by a literal. That code is a day old (#38333), so no released bun has written such a lockfile.

### Fix

- `Lockfile::rebase_folder_dependencies` (src/install/lockfile.rs): for every package whose directory the lockfile records (`Root`, `Workspace`, `Folder` resolutions), re-derive each `Folder` row's `value.folder` from its literal and that directory, with `folder_relative_to_top_level_dir`, the computation lifted out of `parse_dependency`. `load_from_dir` runs it once on every successful load, so bun.lock, bun.lockb and the three importers all hand the resolver rows in the shape a package.json parse produces; the old body of `load_from_dir` is now `read_from_dir`.
- The pnpm importer now writes those literals relative to the declaring package (`declare_folder_dependencies_relative_to_their_package`, after its own resolution pass, which keys on pnpm's form). With the `v9-alias-non-registry-dep-path` fixture the migrated row becomes `"config": "file:../shared/config"`, which is exactly what `outer/package.json` declares.
- Why this is correct: the literal is what bun.lock stores and what the differ compares (`Version::eql` compares folder rows by literal), so it has to stay the declared, package-relative path; `value.folder` is derived from it, and the resolver needs the derived form. The pass touches only `value.folder`, never the literal, so it is idempotent and lockfiles are written back byte for byte (`--frozen-lockfile` and byte-identical re-saves are asserted in the tests). Rows of registry, git and tarball packages are skipped: `Package::from_npm` leaves theirs verbatim and the installer resolves those against the installed declaring package (src/install/PackageInstaller.rs:1850), so the loaded form already matches for them.
- Alternative considered: making the resolver's Folder arm join the declared path onto the declaring package's directory instead of having producers store the rebased value. That arm also receives override and catalog values, which are root-relative, so it would have to track where each version came from, and #33106, #38814 and #38816 are all modifying that arm at the moment. This PR keeps the existing convention (rows reach the resolver top-level relative) and makes the remaining producers honour it. #38816, which stops the parse-time rebase for git and tarball manifests, covers the same set of packages as the pass here; #38814 reads a file: package's file: dependency from disk and relies on the form this PR supplies for loaded rows.
- Not addressed here: removing an override for a dependency the root itself declares as `file:../x` also fails, for a different reason (the root's previous rows are re-enqueued after the differ replaces them); tracked separately.
- Verified with test/cli/install/bun-lock.test.ts (five cases: override removed with bun.lock and with bun.lockb, a path without `..`, `bun update <name>`, a workspace member), test/cli/install/migration/migrate.test.ts (`bun update b` in the same run as a package-lock.json migration, using the lockfile `npm install --package-lock-only` writes for the layout) and test/cli/install/migration/pnpm-lock-v9.test.ts (migrated literal, then `bun update nested-child` against the migrated bun.lock; updated literal expectation and snapshot for the alias fixture). All of them fail on bun 1.4.0 / without the src changes and pass with them.
- Also run: bun-lockb, bun-install, bun-install-registry, bun-workspaces, isolated-install, bun-update, bun-update-transitive, catalogs, overrides, bun-add, bun-pm, bun-pm-why and the migration suites. Failures seen locally were network-dependent cases (git hosts, remote URLs) that fail identically without this change, and 5s timeouts on a heavily loaded host that pass when run alone. `cargo check --target x86_64-pc-windows-msvc` for the install crate passes (both new functions have a Windows branch).

### Background

- Folder dependency: a dependency written as `file:<dir>` (or a bare path). `Dependency.version` carries the `literal` as written plus a derived `value.folder`. Lockfile writers emit only the literal.
- Top-level dir: the project root `bun install` runs in. A folder package's `Resolution::Folder` is its directory relative to it (`a@file:vendor/a` in bun.lock), a workspace package's resolution is its workspace path, and the root's directory is the top-level dir itself. Those are the directories the pass joins the declared paths onto.
- Re-enqueue: `bun install` diffs package.json against the loaded lockfile and re-resolves only rows that changed, plus every row whose name an overrides change affects and the rows `bun update <name>` targets. All other rows keep their lockfile resolution, which is why loaded rows could stay in the wrong form unnoticed.
- Importers: package-lock.json, yarn.lock and pnpm-lock.yaml are converted into an in-memory lockfile by `migration::detect_and_load_other_lockfile` and returned through the same `load_from_dir` as bun.lock, so the pass covers them too. package-lock.json and yarn.lock record the declared specs; pnpm-lock.yaml records resolved, lockfile-relative references, hence the importer-side rewrite.

<details>
<summary>Repro script</summary>

```sh
mkdir -p app/vendor/{a,b,b2} && cd app
echo '{"name":"a","version":"1.0.0","dependencies":{"b":"file:../b"}}' > vendor/a/package.json
echo '{"name":"b","version":"1.0.0"}' > vendor/b/package.json
echo '{"name":"b","version":"2.0.0"}' > vendor/b2/package.json
echo '{"name":"app","dependencies":{"a":"file:./vendor/a"},"overrides":{"b":"file:./vendor/b2"}}' > package.json
bun install   # ok
echo '{"name":"app","dependencies":{"a":"file:./vendor/a"}}' > package.json
bun install   # error: Could not find package.json for "file:../b" dependency "b"

# without overrides:
rm bun.lock && bun install && bun update b   # same error

# straight from a package-lock.json:
rm bun.lock && npm install --package-lock-only && bun update b   # same error
```

After the fix every command exits 0 and bun.lock contains `"a/b": ["b@file:vendor/b", {}]` while `a`'s row still reads `"b": "file:../b"`.
</details>

<details>
<summary>Earlier shape of this PR</summary>

The first version ran the pass inside the bun.lock and bun.lockb parsers only and rebased the existing `value.folder` rather than re-deriving it from the literal. Review of that version pointed at the importers: package-lock.json rows have the same problem in the run that migrates them (reproduced; yarn.lock rows go through the same kind of code), and the pnpm importer's rows were already top-level relative, so a pass keyed on the value would have double-applied to them. Deriving from the literal, running it once in `load_from_dir`, and fixing the pnpm literals covers all five producers.
</details>
