### PR TITLE
install: stop looping on a peer dependency no published version satisfies

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -799,6 +799,8 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                 if dependency.behavior.is_required() {
                                     if let Some(fail) = fail_fn {
                                         fail(this, dependency, id, err);
+                                    } else if dependency.behavior.is_peer() {
+                                        warn_unmet_peer_dependency(this, name, &version);
                                     } else {
                                         this.log_mut()
                     .add_error_fmt(
@@ -819,6 +821,8 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                 if dependency.behavior.is_required() {
                                     if let Some(fail) = fail_fn {
                                         fail(this, dependency, id, err);
+                                    } else if dependency.behavior.is_peer() {
+                                        warn_unmet_peer_dependency(this, name, &version);
                                     } else {
                                         bun_ast::add_error_pretty!(
                                             this.log_mut(),
@@ -1636,6 +1640,27 @@ pub fn enqueue_dependency_with_main_and_success_fn(
         }
         _ => Ok(()),
     }
+}
+
+/// A peer that nothing in the tree provides and that no published version
+/// satisfies stays unresolved; unlike a regular dependency it does not fail
+/// the install. bun.lock then records the edge without a package
+/// (`may_stay_unresolved` in bun.lock.rs).
+#[cold]
+#[inline(never)]
+fn warn_unmet_peer_dependency(
+    this: &PackageManager,
+    name: SemverString,
+    version: &dependency::Version,
+) {
+    bun_ast::add_warning_pretty!(
+        this.log_mut(),
+        None,
+        bun_ast::Loc::EMPTY,
+        "No version matching \"{}\" found for peer dependency \"{}\"<r> <d>(but package exists)<r>",
+        bstr::BStr::new(this.lockfile.str(&version.literal)),
+        bstr::BStr::new(this.lockfile.str(&name)),
+    );
 }
 
 /// Allocate and initialise an `.extract` Task for an npm tarball.
@@ -2567,7 +2592,10 @@ fn get_or_put_resolved_package(
                         }
                     }
 
-                    if behavior.is_peer() {
+                    // Deferred to the peer pass, as in `get_or_put_resolved_package_with_find_result`.
+                    // Not from the peer pass itself: the caller takes `Ok(None)` to mean the
+                    // manifest is not loaded yet and would reload it from the cache forever.
+                    if behavior.is_peer() && !install_peer {
                         return Ok(None);
                     }
 

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1642,10 +1642,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
     }
 }
 
-/// A peer that nothing in the tree provides and that no published version
-/// satisfies stays unresolved; unlike a regular dependency it does not fail
-/// the install. bun.lock then records the edge without a package
-/// (`may_stay_unresolved` in bun.lock.rs).
+/// Unmet peers stay unresolved instead of failing the install; see `may_stay_unresolved`.
 #[cold]
 #[inline(never)]
 fn warn_unmet_peer_dependency(
@@ -2592,9 +2589,7 @@ fn get_or_put_resolved_package(
                         }
                     }
 
-                    // Deferred to the peer pass, as in `get_or_put_resolved_package_with_find_result`.
-                    // Not from the peer pass itself: the caller takes `Ok(None)` to mean the
-                    // manifest is not loaded yet and would reload it from the cache forever.
+                    // `Ok(None)` in the peer pass makes the caller reload the manifest and retry.
                     if behavior.is_peer() && !install_peer {
                         return Ok(None);
                     }

--- a/src/install/PackageManager/PackageManagerResolution.rs
+++ b/src/install/PackageManager/PackageManagerResolution.rs
@@ -325,9 +325,7 @@ impl PackageManager {
                     continue;
                 }
 
-                // A peer that nothing provides stays unresolved (at most a
-                // warning, see `warn_unmet_peer_dependency`), and bun.lock
-                // records it that way (`may_stay_unresolved` in bun.lock.rs).
+                // Unmet peers only warn (`warn_unmet_peer_dependency`).
                 if failed_dep.behavior.is_peer() {
                     continue;
                 }

--- a/src/install/PackageManager/PackageManagerResolution.rs
+++ b/src/install/PackageManager/PackageManagerResolution.rs
@@ -325,8 +325,9 @@ impl PackageManager {
                     continue;
                 }
 
-                // TODO lockfile rewrite: remove this and make non-optional peer dependencies error if they did not resolve.
-                //      Need to keep this for now because old lockfiles might have a peer dependency without the optional flag set.
+                // A peer that nothing provides stays unresolved (at most a
+                // warning, see `warn_unmet_peer_dependency`), and bun.lock
+                // records it that way (`may_stay_unresolved` in bun.lock.rs).
                 if failed_dep.behavior.is_peer() {
                     continue;
                 }

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -3458,10 +3458,7 @@ fn map_dep_to_pkg(
     }
 }
 
-/// Edges a fresh install itself leaves unresolved, so a lockfile bun wrote can
-/// list them without a package entry: optional dependencies, and peers that
-/// nothing in the tree provided and no published version satisfied (see
-/// `warn_unmet_peer_dependency` in `PackageManagerEnqueue.rs`).
+/// Edges a fresh install may itself leave unresolved, so bun.lock lists them without a package.
 fn may_stay_unresolved(dep: &Dependency) -> bool {
     dep.behavior.intersects(Behavior::OPTIONAL | Behavior::PEER)
 }

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -3085,7 +3085,7 @@ pub(crate) fn parse_into_binary_lockfile(
                 let Some(res_id) =
                     peer_res_id.or_else(|| pkg_map.get(dep.name.slice(string_buf)).copied())
                 else {
-                    if dep.behavior.contains(Behavior::OPTIONAL) {
+                    if may_stay_unresolved(dep) {
                         continue;
                     }
                     dependency_resolution_failure(
@@ -3170,7 +3170,7 @@ pub(crate) fn parse_into_binary_lockfile(
                             .or_else(|| pkg_map.get(dep_name))
                             .copied()
                     }) else {
-                        if dep.behavior.contains(Behavior::OPTIONAL) {
+                        if may_stay_unresolved(dep) {
                             continue;
                         }
                         dependency_resolution_failure(
@@ -3259,7 +3259,7 @@ pub(crate) fn parse_into_binary_lockfile(
                                 return Err(ParseError::InvalidPackageKey);
                             }
                             Err(ResolveError::Unresolvable) => {
-                                if dep.behavior.contains(Behavior::OPTIONAL) {
+                                if may_stay_unresolved(dep) {
                                     continue 'deps;
                                 }
                                 dependency_resolution_failure(
@@ -3456,6 +3456,14 @@ fn map_dep_to_pkg(
             };
         }
     }
+}
+
+/// Edges a fresh install itself leaves unresolved, so a lockfile bun wrote can
+/// list them without a package entry: optional dependencies, and peers that
+/// nothing in the tree provided and no published version satisfied (see
+/// `warn_unmet_peer_dependency` in `PackageManagerEnqueue.rs`).
+fn may_stay_unresolved(dep: &Dependency) -> bool {
+    dep.behavior.intersects(Behavior::OPTIONAL | Behavior::PEER)
 }
 
 fn dependency_resolution_failure(

--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -9,6 +9,7 @@ import {
   normalizeBunSnapshot,
   readdirSorted,
   runBunInstall,
+  tempDir,
   toBeValidBin,
   VerdaccioRegistry,
 } from "harness";
@@ -1375,4 +1376,180 @@ it("an optional peer is rebound when another version of its package takes the sl
 
   await run(["install", "--lockfile-only"]);
   expect(await file(join(packageDir, "bun.lock")).text()).toBe(lockfile);
+});
+
+// https://github.com/oven-sh/bun/issues/26046
+// A required peer that nothing in the tree provides and that no published
+// version satisfies stays unresolved. The bun.lock written afterwards has to
+// load back, and resolving it again with every manifest already in the cache
+// has to finish (it used to retry the cached manifest forever).
+describe.each(["hoisted", "isolated"] as const)("peer no published version satisfies (%s linker)", linker => {
+  const manifests: Record<string, Record<string, Record<string, unknown>>> = {
+    "has-unmet-peer": { "1.0.0": { peerDependencies: { "peer-target": "^1.0.1" } } },
+    "peer-target": { "2.0.1": {} },
+  };
+
+  const unmetPeerWarning =
+    'warn: No version matching "^1.0.1" found for peer dependency "peer-target" (but package exists)';
+
+  async function serveRegistry() {
+    const tarballs = new Map<string, Uint8Array>();
+    for (const [name, versions] of Object.entries(manifests)) {
+      for (const [version, extra] of Object.entries(versions)) {
+        const archive = new Bun.Archive(
+          { "package/package.json": JSON.stringify({ name, version, ...extra }) },
+          { compress: "gzip" },
+        );
+        tarballs.set(`/${name}-${version}.tgz`, await archive.bytes());
+      }
+    }
+    const requests: string[] = [];
+    const server = Bun.serve({
+      port: 0,
+      fetch(request) {
+        const { origin, pathname } = new URL(request.url);
+        requests.push(pathname);
+        const tarball = tarballs.get(pathname);
+        if (tarball) return new Response(tarball);
+        const name = pathname.slice(1);
+        const entry = manifests[name];
+        if (!entry) return new Response("not found", { status: 404 });
+        const versions: Record<string, unknown> = {};
+        for (const [version, extra] of Object.entries(entry)) {
+          versions[version] = { name, version, dist: { tarball: `${origin}/${name}-${version}.tgz` }, ...extra };
+        }
+        return Response.json(
+          { name, versions, "dist-tags": { latest: Object.keys(entry).at(-1) } },
+          // Like registry.npmjs.org. Within this window bun resolves from the
+          // manifest cache without going back to the registry.
+          { headers: { "cache-control": "public, max-age=300" } },
+        );
+      },
+    });
+    return {
+      url: server.url.href,
+      origin: server.url.origin,
+      requests,
+      [Symbol.dispose]() {
+        server.stop(true);
+      },
+    };
+  }
+
+  function createProject(registryUrl: string, files: Record<string, string>) {
+    return tempDir("unmet-peer-", {
+      ...files,
+      "bunfig.toml": ({ root }) =>
+        Bun.TOML.stringify({ install: { cache: join(root, ".bun-cache"), registry: registryUrl, linker } }),
+    });
+  }
+
+  async function install(cwd: string, ...args: string[]) {
+    await using proc = spawn({
+      cmd: [bunExe(), "install", ...args],
+      cwd,
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+      // Only matters if an install never returns.
+      timeout: 30_000,
+    });
+    const [out, err, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ args, err, code }).toMatchObject({ args, err: expect.not.stringContaining("error:"), code: 0 });
+    return { out, err };
+  }
+
+  it.concurrent("declared by a registry package", async () => {
+    using registry = await serveRegistry();
+    using dir = createProject(registry.url, {
+      "package.json": JSON.stringify({ name: "app", dependencies: { "has-unmet-peer": "1.0.0" } }),
+    });
+    const lockfilePath = join(String(dir), "bun.lock");
+
+    let { err } = await install(String(dir));
+    expect(err).toContain(unmetPeerWarning);
+    expect(err).toContain("Saved lockfile");
+    expect(registry.requests.toSorted()).toEqual(["/has-unmet-peer", "/has-unmet-peer-1.0.0.tgz", "/peer-target"]);
+    const lockfile = await file(lockfilePath).text();
+    expect(lockfile.replaceAll(registry.origin, "<registry>")).toMatchInlineSnapshot(`
+      "{
+        "lockfileVersion": 1,
+        "configVersion": 1,
+        "workspaces": {
+          "": {
+            "name": "app",
+            "dependencies": {
+              "has-unmet-peer": "1.0.0",
+            },
+          },
+        },
+        "packages": {
+          "has-unmet-peer": ["has-unmet-peer@1.0.0", "<registry>/has-unmet-peer-1.0.0.tgz", { "peerDependencies": { "peer-target": "^1.0.1" } }, ""],
+        }
+      }
+      "
+    `);
+    expect(await exists(join(String(dir), "node_modules", "peer-target"))).toBeFalse();
+
+    ({ err } = await install(String(dir), "--frozen-lockfile"));
+    expect(err).not.toContain("Ignoring lockfile");
+    expect(await file(lockfilePath).text()).toBe(lockfile);
+
+    // Resolve from scratch again. Both manifests are cached now, so the peer
+    // is looked up synchronously instead of through a network task.
+    await rm(lockfilePath);
+    await rm(join(String(dir), "node_modules"), { recursive: true });
+    registry.requests.length = 0;
+    ({ err } = await install(String(dir)));
+    expect(err).toContain(unmetPeerWarning);
+    expect(registry.requests).toEqual([]);
+    expect(await file(lockfilePath).text()).toBe(lockfile);
+  });
+
+  it.concurrent("declared by the root package and a workspace", async () => {
+    using registry = await serveRegistry();
+    using dir = createProject(registry.url, {
+      "package.json": JSON.stringify({
+        name: "app",
+        workspaces: ["packages/*"],
+        peerDependencies: { "peer-target": "^1.0.1" },
+      }),
+      "packages/ws/package.json": JSON.stringify({ name: "ws", peerDependencies: { "peer-target": "^1.0.1" } }),
+    });
+    const lockfilePath = join(String(dir), "bun.lock");
+
+    let { err } = await install(String(dir));
+    expect(err).toContain(unmetPeerWarning);
+    expect(err).toContain("Saved lockfile");
+    expect(registry.requests).toEqual(["/peer-target"]);
+    const lockfile = await file(lockfilePath).text();
+    expect(lockfile).toMatchInlineSnapshot(`
+      "{
+        "lockfileVersion": 2,
+        "configVersion": 1,
+        "workspaces": {
+          "": {
+            "name": "app",
+            "peerDependencies": {
+              "peer-target": "^1.0.1",
+            },
+          },
+          "packages/ws": {
+            "name": "ws",
+            "peerDependencies": {
+              "peer-target": "^1.0.1",
+            },
+          },
+        },
+        "packages": {
+          "ws": ["ws@workspace:packages/ws"],
+        }
+      }
+      "
+    `);
+
+    ({ err } = await install(String(dir), "--frozen-lockfile"));
+    expect(err).not.toContain("Ignoring lockfile");
+    expect(await file(lockfilePath).text()).toBe(lockfile);
+  });
 });

--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -1439,8 +1439,7 @@ describe.each(["hoisted", "isolated"] as const)("peer no published version satis
   function createProject(registryUrl: string, files: Record<string, string>) {
     return tempDir("unmet-peer-", {
       ...files,
-      "bunfig.toml": ({ root }) =>
-        Bun.TOML.stringify({ install: { cache: join(root, ".bun-cache"), registry: registryUrl, linker } }),
+      "bunfig.toml": Bun.TOML.stringify({ install: { registry: registryUrl, linker } }),
     });
   }
 
@@ -1448,7 +1447,10 @@ describe.each(["hoisted", "isolated"] as const)("peer no published version satis
     await using proc = spawn({
       cmd: [bunExe(), "install", ...args],
       cwd,
-      env,
+      // The request assertions below need a cache of their own per project: the
+      // environment's cache dir takes precedence over bunfig, and a package
+      // extracted there by one of the concurrent tests is not downloaded again.
+      env: { ...env, BUN_INSTALL_CACHE_DIR: join(cwd, ".bun-cache") },
       stdout: "pipe",
       stderr: "pipe",
       // Only matters if an install never returns.


### PR DESCRIPTION
### Problem

A package declares a required `peerDependencies` entry whose package exists in the registry but whose range no published version satisfies, and nothing else in the tree provides it. Registry: `a@2.1.0` with `peerDependencies: { b: "^1.0.1" }`, only `b@2.0.1` published; project depends on `a`. (Real-world shape, #26046: `rolldown-plugin-solid-oxc`'s peer `solid-jsx-oxc@*`, whose only versions are prereleases.)

- `bun install` exits 0 with no diagnostic and leaves the peer edge unresolved.
- The `bun.lock` it writes does not load back: `bun install --frozen-lockfile` / `bun ci` / `bun pm ls` fail with `error: Failed to resolve peer dependency 'b' for package 'a'`, `InvalidLockfile: failed to parse lockfile`, then `lockfile had changes, but lockfile is frozen`. A peer declared by the root or a workspace package.json fails the same way (`Failed to resolve root peer dependency 'b'`).
- The next plain `bun install` (which ignores the unparseable lockfile and re-resolves), or any install without a lockfile, never returns while `b`'s manifest is still fresh in the manifest cache: 100% CPU in `wait_for_resolution` -> `process_peer_dependency_list` -> `enqueue_dependency_with_main` -> `get_or_put_resolved_package`.
- Cause of the loop: in `get_or_put_resolved_package` (`src/install/PackageManager/PackageManagerEnqueue.rs`, `FindVersionError::NotFound` path) a peer returned `Ok(None)` even during the peer pass (`install_peer`). The caller, `enqueue_dependency_with_main_and_success_fn`, takes `Ok(None)` to mean the manifest is not loaded; in the peer pass it drops the manifest's dedupe entry, loads the still-fresh manifest from the cache and `continue`s into the same lookup, which returns `Ok(None)` again. With a cold cache the same `Ok(None)` pushes a callback onto a manifest task that has already completed, which is why the first install is silent.
- Cause of the unloadable lockfile: the three dependency loops in `parse_into_binary_lockfile` (`src/install/lockfile/bun.lock.rs`) only tolerate an unbound edge that carries the `OPTIONAL` bit, while the resolver can leave a required peer unbound and the writer records such an edge without a package entry.
- Not new to the Rust port: 1.3.14 spins on the same repro with either linker.

### Fix

- `get_or_put_resolved_package` defers with `Ok(None)` only when `!install_peer`, the condition `get_or_put_resolved_package_with_find_result` already uses for the same deferral. In the peer pass it returns `NoMatchingVersion` / `DistTagNotFound` like a regular dependency, so the loop ends.
- The caller turns those two errors into a warning for peers (`warn: No version matching "^1.0.1" found for peer dependency "b" (but package exists)`) and leaves the edge unresolved. Failing the install instead would change established behavior: `verify_resolutions` deliberately accepts unresolved peers, `test/cli/install/bun-install.test.ts` ("should handle installing the same peerDependency with the same version") pins exit 0 for a root peer with no matching version, and `catalogs.test.ts` documents the same policy. A peer whose package 404s still errors as before.
- The bun.lock parser accepts an unbound peer edge the way it accepts an unbound optional edge (`may_stay_unresolved`, at the root, workspace and package sites). Nothing else is needed: the hoisted tree, the isolated linker, `Lockfile::eql` and `verify_resolutions` already skip unresolved peers, and the writer already emits the declaration. The loaded state equals the freshly resolved state, so `--frozen-lockfile` passes and a reload writes identical bytes, including for root and workspace peers. Recording such peers as `optionalPeers` instead (what the lockb and pnpm migrations do) would not be stable for those: `Package::Diff` compares behavior bits, so package.json's plain peer edge would be re-resolved on every install and `Lockfile::eql` would then see a different tree.
- Overlaps with the parser part of #33156 (its third item is this lockfile symptom); that PR is about `file:` peers and does not touch the loop or the warning.
- Verified with `test/cli/install/bun-lock.test.ts`, "peer no published version satisfies", for both linkers: the install warns, `peer-target` is not installed, the lockfile matches an inline snapshot, `--frozen-lockfile` passes and leaves it unchanged, and a second resolve with both manifests cached (the test registry sees zero requests) finishes and writes the same bytes; plus a root + workspace variant. Without the fix each step fails on its own: no warning; the `InvalidLockfile` errors above; the re-resolve is killed by the spawn timeout (exit 143).
- Also ran `bun-install-registry` (242 pass), `bun-lock`, `bun-install`, `isolated-install`, `catalogs`, `nested-overrides`, `frozen-lockfile-pruned`, `bun-lockb` and `migration/` locally. The only failures need public network access (bitbucket/gitlab/badssl), which this environment does not have.

Fixes #26046

### Background

- Peer resolution has two passes. While regular edges resolve, every peer edge is parked in `peer_dependencies`; `wait_for_resolution` then drains that queue with `install_peer = true`. In that pass a peer is first bound to a same-named package already in the tree (a satisfying one, or any one with the "incorrect peer dependency" warning) and otherwise installed from the registry. `Ok(None)` from `get_or_put_resolved_package` means "park it" in the first pass and "manifest not loaded yet" in the second, so in the second pass only a genuinely unloaded manifest may produce it.
- The manifest cache keeps registry responses on disk together with their `max-age`; inside that window bun resolves from the cache without creating a network task, so the whole peer pass runs synchronously. That is why the loop needs a warm cache and why the test registry sends `cache-control: max-age=300`, as registry.npmjs.org does.
- `bun.lock` stores each package's declared dependency groups plus the resolved packages keyed by tree path. On load every declared edge is bound to a package entry; an edge that cannot be bound is a parse error unless it is allowed to stay unbound, which until now meant the `OPTIONAL` bit (optional dependencies and `peerDependenciesMeta` optional peers).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-lock.test.ts

<!-- robobun:evidence:end -->