### PR TITLE
ci: mordant reports findings over the baseline instead of aborting the crate

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -114,6 +114,7 @@
 "defaulted_failure:src/runtime/server/RequestContext.rs" = 1
 "defaulted_failure:src/runtime/test_runner/pretty_format.rs" = 4
 "dependent_field:src/runtime/cli/filter_run.rs" = 1
+"dependent_field:src/runtime/shell/builtin/rm.rs" = 1
 "misbound_arg:src/runtime/cli/install_completions_command.rs" = 4
 "misbound_arg:src/runtime/cli/open.rs" = 1
 "misbound_arg:src/runtime/cli/pack_command.rs" = 1

--- a/scripts/rust-mordant.ts
+++ b/scripts/rust-mordant.ts
@@ -32,6 +32,9 @@ const off = [
 ];
 
 const rustflags = [
+  // The workspace denies warnings; a finding over the baseline should be
+  // reported (and fail the run below), not abort the crate and hide the rest.
+  "--cap-lints warn",
   // Mordant's nightly is older than rust-toolchain.toml's, so `#[allow]`s of
   // lints added since then are unknown to it.
   "-A unknown_lints",
@@ -53,7 +56,21 @@ const prep = spawnSync("bun", ["scripts/build.ts", "--quiet", "--target=codegen"
 if (prep.status !== 0) process.exit(prep.status ?? 1);
 
 const r = spawnSync("cargo", ["dylint", "--all", "--workspace", "--keep-going", "--", "--keep-going"], {
-  stdio: "inherit",
+  stdio: ["inherit", "inherit", "pipe"],
   env: { ...process.env, DYLINT_RUSTFLAGS: rustflags },
+  maxBuffer: 1 << 28,
 });
-process.exit(r.status ?? 1);
+const stderr = r.stderr?.toString() ?? "";
+process.stderr.write(stderr);
+if (r.status !== 0) process.exit(r.status ?? 1);
+// Cargo's own summary lines ("warning: `crate` (lib) generated N warnings")
+// are not findings; anything else at warning level came from a lint.
+const findings = stderr
+  .split("\n")
+  .filter(l => /^warning: /.test(l) && !/generated \d+ warnings?/.test(l) && !/^warning: build failed/.test(l));
+if (findings.length > 0 && !process.env.MORDANT_BASELINE_WRITE) {
+  console.error(
+    `\n${findings.length} finding(s) over mordant-baseline.toml; fix them or regenerate the baseline (MORDANT_BASELINE_WRITE=1 bun run rust:mordant).`,
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
The mordant job went red on main after #38846 for two reasons that this fixes together.

The workspace denies warnings, so a finding that is not in mordant-baseline.toml is a hard error: the crate stops compiling, every crate after it is never linted, and the log shows one finding instead of all of them. rust:mordant now caps lints at warn and fails the run itself at the end if any finding was printed, with a line saying how to regenerate the baseline. Same red/green outcome, complete report.

The one finding that tripped it is Linux-only: dependent_field on RemoveFileParent in the shell's rm builtin, whose fields differ under cfg (allow_enqueue does not exist on Linux, so `enqueued` reads as depending on `treat_as_dir` alone there). The baseline was generated on macOS and did not have it; added.