### PR TITLE
require.extensions: assignments from a repeated statement no longer bypass the loader table

### DIFF
--- a/src/jsc/bindings/JSCommonJSExtensions.h
+++ b/src/jsc/bindings/JSCommonJSExtensions.h
@@ -9,10 +9,7 @@ namespace Bun {
 class JSCommonJSExtensions : public JSC::JSDestructibleObject {
 public:
     using Base = JSC::JSDestructibleObject;
-    // put() and deleteProperty() below mirror every assignment into the native
-    // loader table. Without ProhibitsPropertyCaching, the second assignment from
-    // the same call site is served by an inline cache (a plain store into the
-    // object) and never reaches put(), so the loader table keeps the old handler.
+    // ProhibitsPropertyCaching: an inline-cached store would skip put(), which keeps the native loader table in sync.
     static constexpr unsigned StructureFlags = Base::StructureFlags | JSC::OverridesPut | JSC::ProhibitsPropertyCaching;
     ~JSCommonJSExtensions();
 

--- a/src/jsc/bindings/JSCommonJSExtensions.h
+++ b/src/jsc/bindings/JSCommonJSExtensions.h
@@ -9,7 +9,11 @@ namespace Bun {
 class JSCommonJSExtensions : public JSC::JSDestructibleObject {
 public:
     using Base = JSC::JSDestructibleObject;
-    static constexpr unsigned StructureFlags = Base::StructureFlags | JSC::OverridesPut;
+    // put() and deleteProperty() below mirror every assignment into the native
+    // loader table. Without ProhibitsPropertyCaching, the second assignment from
+    // the same call site is served by an inline cache (a plain store into the
+    // object) and never reaches put(), so the loader table keeps the old handler.
+    static constexpr unsigned StructureFlags = Base::StructureFlags | JSC::OverridesPut | JSC::ProhibitsPropertyCaching;
     ~JSCommonJSExtensions();
 
     WTF::Vector<JSC::WriteBarrier<JSC::Unknown>> m_registeredFunctions;

--- a/test/js/node/module/require-extensions.test.ts
+++ b/test/js/node/module/require-extensions.test.ts
@@ -1,6 +1,7 @@
 import assert from "assert";
-import { expect, mock, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import { tempDir } from "harness";
+import Module from "node:module";
 import path from "path";
 
 test("require.extensions shape makes sense", () => {
@@ -162,6 +163,126 @@ test("wrapping an existing extension but it's secretly sync esm", () => {
     require.extensions[".cjs"] = original;
   }
 });
+// Every assignment in these tests is executed more than once from the same
+// statement (a loop body or a helper function), which is how install()/revert()
+// helpers in packages like pirates, @babel/register and ts-node assign to
+// require.extensions. The second execution of a statement is the one that used
+// to be served by the property inline cache instead of reaching the loader.
+describe("assigning require.extensions repeatedly from one statement", () => {
+  test("a builtin extension can be overridden again after it was restored", () => {
+    using dir = tempDir("require-extensions-reoverride", {
+      "a.js": `module.exports = "a";`,
+      "b.js": `module.exports = "b";`,
+      "c.js": `module.exports = "c";`,
+    });
+    const original = require.extensions[".js"]!;
+    const rounds: { file: string; invoked: boolean; exports: unknown }[] = [];
+    try {
+      for (const file of ["a.js", "b.js", "c.js"]) {
+        let invoked = false;
+        require.extensions[".js"] = function (module, filename) {
+          invoked = true;
+          original(module, filename);
+        };
+        const exports = require(path.join(String(dir), file));
+        rounds.push({ file, invoked, exports });
+        require.extensions[".js"] = original;
+      }
+    } finally {
+      require.extensions[".js"] = original;
+    }
+    expect(rounds).toEqual([
+      { file: "a.js", invoked: true, exports: "a" },
+      { file: "b.js", invoked: true, exports: "b" },
+      { file: "c.js", invoked: true, exports: "c" },
+    ]);
+  });
+
+  test("an override that throws is invoked again by the next require of the same file", () => {
+    using dir = tempDir("require-extensions-throwing-override", {
+      "mod.js": `exports.foo = 1;`,
+    });
+    const file = path.join(String(dir), "mod.js");
+    const original = require.extensions[".js"]!;
+    const rounds: { invoked: boolean; outcome: string; cached: boolean }[] = [];
+    try {
+      for (let i = 0; i < 3; i++) {
+        let invoked = false;
+        require.extensions[".js"] = function () {
+          invoked = true;
+          throw new Error("rejected by override");
+        };
+        let outcome: string;
+        try {
+          require(file);
+          outcome = "loaded";
+        } catch (e) {
+          outcome = (e as Error).message;
+        }
+        rounds.push({ invoked, outcome, cached: file in require.cache });
+        require.extensions[".js"] = original;
+      }
+    } finally {
+      require.extensions[".js"] = original;
+      delete require.cache[file];
+    }
+    const expected = { invoked: true, outcome: "rejected by override", cached: false };
+    expect(rounds).toEqual([expected, expected, expected]);
+  });
+
+  test("restoring the builtin loader through a helper unregisters the current override", () => {
+    using dir = tempDir("require-extensions-restore-helper", {
+      "a.js": `module.exports = "a";`,
+    });
+    const original = require.extensions[".js"]!;
+    const calls: string[] = [];
+    function restore() {
+      require.extensions[".js"] = original;
+    }
+    try {
+      require.extensions[".js"] = function (module, filename) {
+        calls.push("first");
+        original(module, filename);
+      };
+      restore();
+      require.extensions[".js"] = function (module, filename) {
+        calls.push("second");
+        original(module, filename);
+      };
+      restore();
+
+      expect(require.extensions[".js"]).toBe(original);
+      expect(require(path.join(String(dir), "a.js"))).toBe("a");
+      expect(calls).toEqual([]);
+    } finally {
+      restore();
+    }
+  });
+
+  test("re-registering a custom extension through a helper dispatches to the latest handler", () => {
+    using dir = tempDir("require-extensions-reregister", {
+      "one.reregistered": "",
+      "two.reregistered": "",
+      "three.reregistered": "",
+    });
+    function register(tag: string) {
+      Module._extensions[".reregistered"] = function (module) {
+        module.exports = tag;
+      };
+    }
+    const loaded: string[] = [];
+    try {
+      for (const tag of ["one", "two", "three"]) {
+        register(tag);
+        loaded.push(require(path.join(String(dir), `${tag}.reregistered`)));
+      }
+    } finally {
+      delete Module._extensions[".reregistered"];
+    }
+    expect(loaded).toEqual(["one", "two", "three"]);
+  });
+});
+
 test("mutating extensions is banned by some files", () => {
   // vercel is not allowed to mutate require.extensions
   const files = ["node_modules/next/dist/build/next-config-ts/index.js", "node_modules/@meteorjs/babel/index.js"];

--- a/test/js/node/module/require-extensions.test.ts
+++ b/test/js/node/module/require-extensions.test.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 import { describe, expect, mock, test } from "bun:test";
-import { tempDir } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import Module from "node:module";
 import path from "path";
 
@@ -164,10 +164,12 @@ test("wrapping an existing extension but it's secretly sync esm", () => {
   }
 });
 // Every assignment in these tests is executed more than once from the same
-// statement (a loop body or a helper function), which is how install()/revert()
-// helpers in packages like pirates, @babel/register and ts-node assign to
-// require.extensions. The second execution of a statement is the one that used
-// to be served by the property inline cache instead of reaching the loader.
+// statement (a loop body or a helper function). The assignment used to reach
+// the loader only the first time a statement ran; afterwards a property inline
+// cache stored straight into the object. With a literal key (`[".js"] =`) the
+// interpreter caches the second execution already; with a variable key (the
+// `extensions[ext] =` loop in pirates, @babel/register and ts-node) the cache
+// appears once the helper is JIT compiled, which the last test forces.
 describe("assigning require.extensions repeatedly from one statement", () => {
   test("a builtin extension can be overridden again after it was restored", () => {
     using dir = tempDir("require-extensions-reoverride", {
@@ -280,6 +282,75 @@ describe("assigning require.extensions repeatedly from one statement", () => {
       delete Module._extensions[".reregistered"];
     }
     expect(loaded).toEqual(["one", "two", "three"]);
+  });
+
+  test("variable-key install/restore helpers keep working after they are JIT compiled", async () => {
+    const files: Record<string, string> = {
+      "index.js": `
+        const Module = require("node:module");
+        const path = require("node:path");
+        const originalJs = Module._extensions[".js"];
+        const dispatched = [];
+
+        function install(extension, tag) {
+          Module._extensions[extension] = function (module) {
+            dispatched.push(tag);
+            module.exports = tag;
+          };
+        }
+        function restore(extension, previous) {
+          Module._extensions[extension] = previous;
+        }
+
+        // No require() in here: this only gets both helpers compiled by every JIT tier.
+        for (let i = 0; i < 200; i++) {
+          install(".js", "warm-js-" + i);
+          restore(".js", originalJs);
+          install(".hooked", "warm-hooked-" + i);
+        }
+
+        const rounds = [];
+        for (let i = 0; i < 3; i++) {
+          install(".js", "js-" + i);
+          const jsExports = require(path.join(__dirname, "js-" + i + ".js"));
+          restore(".js", originalJs);
+          const afterRestore = require(path.join(__dirname, "restored-" + i + ".js"));
+          install(".hooked", "hooked-" + i);
+          const hookedExports = require(path.join(__dirname, "file-" + i + ".hooked"));
+          rounds.push({ jsExports, afterRestore, hookedExports });
+        }
+
+        console.log(JSON.stringify({ rounds, dispatched, restored: Module._extensions[".js"] === originalJs }));
+      `,
+    };
+    for (let i = 0; i < 3; i++) {
+      files[`js-${i}.js`] = `module.exports = "builtin js-${i}";`;
+      files[`restored-${i}.js`] = `module.exports = "builtin restored-${i}";`;
+      files[`file-${i}.hooked`] = "only loadable through the .hooked handler";
+    }
+    using dir = tempDir("require-extensions-jit", files);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.js"],
+      cwd: String(dir),
+      // Compile on the main thread, so after the warm-up loop the helpers are
+      // guaranteed to run as JIT code (baseline and DFG) when the rounds start.
+      env: { ...bunEnv, BUN_JSC_useConcurrentJIT: "0" },
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      rounds: [
+        { jsExports: "js-0", afterRestore: "builtin restored-0", hookedExports: "hooked-0" },
+        { jsExports: "js-1", afterRestore: "builtin restored-1", hookedExports: "hooked-1" },
+        { jsExports: "js-2", afterRestore: "builtin restored-2", hookedExports: "hooked-2" },
+      ],
+      dispatched: ["js-0", "hooked-0", "js-1", "hooked-1", "js-2", "hooked-2"],
+      restored: true,
+    });
+    expect(exitCode).toBe(0);
   });
 });
 


### PR DESCRIPTION
### Problem

- Assigning to `require.extensions[ext]` (alias `Module._extensions`) only reaches the loader the first time a given statement runs. Once the statement is cached, the new handler shows up on the JS object but `require()` keeps dispatching to whatever the statement stored last time it was not cached. With a literal key (`extensions[".js"] = fn` in a loop) the interpreter caches the second execution already; with a variable key (the `extensions[ext] = fn` loop that pirates, `@babel/register` and ts-node use to install and revert hooks) the cache appears once the helper has been JIT compiled, so it hits programs that install and revert hooks repeatedly.
- Observable shapes, all reproducible on bun 1.4.0 and on main (Node honors every one):
  - override `.js` in a loop: iteration 1 invokes the override, iterations 2+ load the file with the builtin loader and never call it (this is the scenario from the handoff, which attributed it to a failed load; the failure is incidental, a non-throwing override misbehaves the same way).
  - restore the builtin through a helper after installing a second override: `require.extensions[".js"] === original` reads true, but the second override is still what loads `.js` files.
  - register a custom extension through a helper three times: the third handler is never used, the second one keeps being dispatched to.
  - variable-key `install(ext, fn)` / `restore(ext, prev)` helpers called ~200 times and then used for real: every later install and restore is ignored, and the handler from the warm-up iteration at which the helper got compiled is dispatched to forever (for `.js` files too, while `Module._extensions[".js"] === original` reads true).
- Cause: `JSCommonJSExtensions` (`src/jsc/bindings/JSCommonJSExtensions.h`) overrides `put`/`deleteProperty` to mirror each assignment into the native extension table (`onAssign` -> `NodeModuleModule__onRequireExtensionModify`), and its `put` ends in `Base::put`, which fills the `PutPropertySlot` as a cacheable store. JSC then caches the store for that statement (LLInt `put_by_id` metadata; baseline/DFG `put_by_id` and `put_by_val` ICs via `tryCachePutBy`; DFG's static `PutByStatus::computeFor`). All of those check `Structure::propertyAccessesAreCacheable()`, none of them look at `OverridesPut`, so the next execution of the statement writes straight into the object and `put` never runs. The native table, which is what `Bun__transpileFile` consults on `require()`, is left holding the previous handler.

### Fix

- Add `JSC::ProhibitsPropertyCaching` to `JSCommonJSExtensions::StructureFlags`.
- Why this is correct: `propertyAccessesAreCacheable()` is the single predicate consulted by every put and delete caching path in JSC (LLInt, baseline/DFG ICs for both `put_by_id` and `put_by_val`, delete ICs, and `PutByStatus::computeFor`, which can compile a direct store from a known structure even when no IC exists). Clearing it makes every data-property store and delete on this one object take the slow path, which is the only path that calls `put`/`deleteProperty`, so the mirroring those methods do runs on every assignment instead of only on the first one per statement. Calling `slot.disableCaching()` inside `put` would only cover the IC paths, not `PutByStatus::computeFor`. `JSSharedEnvMap` (the SHARE_ENV `process.env`), `NodeVM` and `NodeSqlite` objects in this tree already use the flag for the same reason.
- Scope: this PR only makes the existing `put`/`deleteProperty` run every time. What they do once reached is unchanged, including two pre-existing gaps that are tracked separately and are not made better or worse here: `put`/`defineOwnProperty` update the native table before `Base::put`/`Base::defineOwnProperty` decide whether the store is allowed (a rejected store on a frozen `require.extensions` still registers the handler), and an accessor descriptor passed to `defineProperty` is mirrored as "unregister" because it carries no value (the `Module._extensions` compat work in #15795 / #35774 covers that area).
- Cost: reads and writes of `require.extensions` properties take the slow path (a structure lookup). The loader itself never reads this object per `require()`, it uses the native table, so only user code touching `require.extensions` directly is affected.
- Sibling deliberately left out of this PR: the main-thread `process.env` object (`JSEnvironmentVariableMap`, the one remaining `OverridesPut` class in `src/jsc/bindings/` without the flag) has the same bypass, `process.env.X = 123` run three times from one statement stores the number on the third run. It is not the same one-token fix there: `process.env` is built so that a variable becomes a plain data property after its first read precisely so that reads get inline cached (`JSEnvironmentVariableMap.cpp`, the `CustomValue` comment near the bottom of the file), and `ProhibitsPropertyCaching` would also turn off the get caches for every `process.env.NODE_ENV` read in the JIT tiers. The fix there has to pick between that, `slot.disableCaching()` in `put` (keeps reads fast, leaves the `PutByStatus::computeFor` path open), or a store-only variant of the flag added in oven-sh/WebKit; it is tracked separately and nothing in this PR depends on it.
- Verified with `test/js/node/module/require-extensions.test.ts`: five new tests. Four in-process ones with literal keys (re-override of a builtin extension from a loop, a throwing override being invoked again on every `require`, a shared restore helper, a custom extension registered three times through a helper) pin the interpreter cache; one spawned test with variable-key `install`/`restore` helpers, warmed up 200 times under `BUN_JSC_useConcurrentJIT=0` so both helpers are baseline and DFG compiled before the checked rounds (confirmed with `BUN_JSC_reportCompileTimes`), pins the JIT ICs, and runs in about 0.8 s on a debug build. On a debug build with the header reverted to main: 10 pass / 5 fail; with this change: 15 pass. The spawned test's fixture fails 10/10 on 1.4.0.
- Also ran with the debug build: `test/js/node/module/`, `test/regression/issue/require-extensions-override.test.ts`, `test/regression/issue/22929-module-extensions-asi.test.ts`, `test/js/bun/resolve/builtin-esm-lazy-exports.test.ts`, `test/cli/run/run-cjs.test.ts`, `test/cli/run/transpiler-cache.test.ts`, Node's `test-module-multi-extensions.js` and `test-require-extensions-main.js`: all pass.

### Background

- `require.extensions` is a single `JSCommonJSExtensions` object per global. The `.js`/`.json`/`.ts`/... properties on it are only a mirror; the table `require()` actually dispatches on lives on the native side (`commonjs_custom_extensions` in `src/jsc/NodeModuleModule.rs`, read by `Bun__transpileFile`). `JSCommonJSExtensions::put`/`defineOwnProperty`/`deleteProperty` are what keeps the two in sync, so a store that skips them leaves the loader on the old handler.
- Property inline cache: after a property store succeeds, JSC records (per bytecode statement) the object's structure and the slot offset it wrote to. The next time that statement runs on an object with the same structure, the store is done inline without calling any C++ method. `OverridesPut` only makes the uncached slow path call the subclass's `put`; whether the result may be cached is decided by the `PutPropertySlot` the slow path fills in and by the structure's `ProhibitsPropertyCaching` flag.
- `put_by_id` vs `put_by_val`: `obj["lit"] = v` is compiled to `put_by_id`, which the interpreter itself caches; `obj[key] = v` is `put_by_val`, which has no interpreter cache and is only cached once the function reaches the baseline JIT. That is why the literal-key tests fail on their second iteration while the variable-key test needs a warm-up loop.
- `PutByStatus::computeFor(StructureSet)`: the DFG's way of compiling a store when it already knows the receiver's structure from profiling, without going through an IC. It bails out when `propertyAccessesAreCacheable()` is false, which is why the structure flag is used rather than a per-call `disableCaching()`.

<details>
<summary>Repro</summary>

```js
// mod.js: exports.foo = 1;
const file = require("path").join(__dirname, "mod.js");
const original = require.extensions[".js"];
for (let i = 0; i < 3; i++) {
  let invoked = false;
  require.extensions[".js"] = (m, f) => { invoked = true; original(m, f); };
  require(file);
  console.log(i, invoked);
  require.extensions[".js"] = original;
  delete require.cache[file];
}
```

bun 1.4.0 prints `0 true`, `1 false`, `2 false`. Node, and bun with this change, print `true` three times. Unrolling the loop so each assignment is its own statement makes 1.4.0 print `true` three times as well, which is what points at the per-statement cache.

The variable-key fixture in the new spawned test prints, on 1.4.0 with `BUN_JSC_useConcurrentJIT=0`, `warm-js-50` / `warm-hooked-50` as the exports of every file in every round (the handlers stored by the warm-up iteration at which the helpers were compiled) together with `restored: true`; with this change it prints `js-0`, `builtin restored-0`, `hooked-0`, and so on.

</details>