### PR TITLE
undici: honor the dispatcher's connect.lookup hook in fetch and request

### DIFF
--- a/src/js/thirdparty/undici.js
+++ b/src/js/thirdparty/undici.js
@@ -1,10 +1,12 @@
 const EventEmitter = require("node:events");
+const { isIP } = require("node:net");
 const { _ReadableFromWeb: ReadableFromWeb } = require("internal/webstreams_adapters");
 
 const ObjectCreate = Object.create;
+const ObjectDefineProperty = Object.defineProperty;
 const kEmptyObject = ObjectCreate(null);
 
-var fetch = Bun.fetch;
+const nativeFetch = Bun.fetch;
 const bindings = $cpp("Undici.cpp", "createUndiciInternalBinding");
 const Response = bindings[0];
 const Request = bindings[1];
@@ -32,6 +34,244 @@ class FileReader extends EventTarget {
 function notImplemented() {
   throw new Error("This function is not yet implemented in Bun");
 }
+
+// The shim's dispatchers expose their `connect` options through this symbol;
+// dispatchers without it leave the request unchanged.
+const kConnectFor = Symbol("kConnectFor");
+
+function resolveConnect(dispatcher) {
+  if (dispatcher == null) dispatcher = getGlobalDispatcher();
+  if (dispatcher != null && typeof dispatcher[kConnectFor] === "function") {
+    return dispatcher[kConnectFor]();
+  }
+  return undefined;
+}
+
+function runLookup(lookup, hostname, connect, signal) {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) return reject(signal.reason);
+    let onAbort;
+    const settle = fn => value => {
+      if (onAbort !== undefined) signal.removeEventListener("abort", onAbort);
+      fn(value);
+    };
+    const ok = settle(resolve);
+    const fail = settle(reject);
+    if (signal != null) {
+      onAbort = () => fail(signal.reason);
+      signal.addEventListener("abort", onAbort, { once: true });
+    }
+    try {
+      // The options net.connect passes to a custom lookup (family 0 = any).
+      lookup(hostname, { family: connect.family ?? 0, hints: connect.hints ?? 0, all: false }, (err, address) => {
+        if (err) return fail(err);
+        if ($isArray(address)) {
+          // `all: true` shape: [{ address, family }, ...]
+          address = address.length > 0 ? address[0]?.address : undefined;
+        }
+        if (typeof address !== "string" || isIP(address) === 0) {
+          return fail(
+            new TypeError(`lookup did not return a valid IP address for "${hostname}" (received ${String(address)})`),
+          );
+        }
+        ok(address);
+      });
+    } catch (e) {
+      // A synchronous throw must still remove the abort listener.
+      fail(e);
+    }
+  });
+}
+
+// request() also accepts the raw flat header form ["name", "value", ...],
+// which the Headers constructor rejects.
+function headersFromRequestOptions(inputHeaders) {
+  if ($isArray(inputHeaders)) {
+    const { length } = inputHeaders;
+    if (length > 0 && typeof inputHeaders[0] === "string") {
+      if (length % 2 !== 0) {
+        throw new InvalidArgumentError("headers array must be even");
+      }
+      const headers = new Headers();
+      for (let i = 0; i < length; i += 2) {
+        headers.append(inputHeaders[i], inputHeaders[i + 1]);
+      }
+      return headers;
+    }
+  }
+  return new Headers(inputHeaders || kEmptyObject);
+}
+
+// Pins `url` to the address from connect.lookup. `host` is the original
+// authority, sent as the Host header; native fetch also takes SNI and
+// certificate verification from it, so HTTPS still verifies the real hostname.
+async function applyConnect(url, connect, signal) {
+  const { protocol } = url;
+  // Only http(s) opens a socket; data:, blob:, file: never consult the connector.
+  if (protocol !== "http:" && protocol !== "https:") return undefined;
+  if (typeof connect === "function") {
+    throw new NotSupportedError("custom connect functions are not supported in Bun's undici compatibility layer");
+  }
+  const lookup = connect.lookup;
+  if (typeof lookup !== "function") return undefined;
+  const { hostname } = url;
+  // URL#hostname keeps the brackets on IPv6 literals.
+  const bare = hostname.charCodeAt(0) === 0x5b /* [ */ ? hostname.slice(1, -1) : hostname;
+  if (isIP(bare) !== 0) return undefined;
+  const address = await runLookup(lookup, bare, connect, signal);
+  const host = url.host;
+  const pinned = new URL(url);
+  pinned.hostname = isIP(address) === 6 ? `[${address}]` : address;
+  return { url: pinned, host };
+}
+
+function fetchFailed(cause) {
+  // Codegen rewrites `new TypeError` to $makeTypeError, which drops the
+  // options bag, so `cause` is defined manually (same attributes).
+  const wrapped = new TypeError("fetch failed");
+  ObjectDefineProperty(wrapped, "cause", {
+    __proto__: null,
+    configurable: true,
+    enumerable: false,
+    value: cause,
+    writable: true,
+  });
+  return wrapped;
+}
+
+function isRedirectStatus(status) {
+  return status === 301 || status === 302 || status === 303 || status === 307 || status === 308;
+}
+
+// Follows the redirect chain from here (redirect: "manual" per hop) so the
+// lookup hook sees every hostname; native fetch's own `follow` would resolve
+// redirect targets with the OS resolver, bypassing the hook.
+async function followRedirectsWithConnect(url, init, connect, opts) {
+  let { method, body, headers, limit, redirectError, hopError, lookupError } = opts;
+  const { signal } = init;
+  method = typeof method === "string" ? method.toUpperCase() : "GET";
+  for (let hops = 0; ; ) {
+    let pin;
+    try {
+      pin = await applyConnect(url, connect, signal);
+    } catch (err) {
+      // An abort reason surfaces as-is, like native fetch rejecting on abort.
+      if (signal?.aborted && err === signal.reason) throw err;
+      throw lookupError(err);
+    }
+    const hopHeaders = new Headers(headers);
+    let target = url.href;
+    if (pin !== undefined) {
+      target = pin.url.href;
+      if (!hopHeaders.has("host")) hopHeaders.set("host", pin.host);
+    }
+    const resp = await nativeFetch(target, { ...init, method, headers: hopHeaders, body, redirect: "manual" });
+    const { status } = resp;
+    const location = isRedirectStatus(status) ? resp.headers.get("location") : null;
+    if (location === null) {
+      // The Response was fetched from the pinned IP with redirect: "manual";
+      // report the logical URL and redirect state the caller asked about.
+      ObjectDefineProperty(resp, "url", { __proto__: null, configurable: true, value: url.href });
+      ObjectDefineProperty(resp, "redirected", { __proto__: null, configurable: true, value: hops > 0 });
+      return resp;
+    }
+    // Intermediate response; release its connection now instead of at GC.
+    resp.body?.cancel()?.$then(undefined, () => {});
+    if (++hops > limit) throw redirectError();
+    const next = new URL(location, url);
+    if (next.protocol !== "http:" && next.protocol !== "https:") {
+      // file:, data: and blob: targets never reach the lookup hook, and native
+      // following rejects them too (UnsupportedRedirectProtocol).
+      throw hopError(`cannot follow the ${status} redirect to ${next.href}: URL scheme must be http or https`);
+    }
+    if (next.origin !== url.origin) {
+      headers.delete("authorization");
+      headers.delete("proxy-authorization");
+      headers.delete("cookie");
+    }
+    // A user-supplied Host header only applies to the original authority.
+    headers.delete("host");
+    if (
+      (status === 303 && method !== "GET" && method !== "HEAD") ||
+      ((status === 301 || status === 302) && method === "POST")
+    ) {
+      method = "GET";
+      body = undefined;
+      // The request-body-header names (https://fetch.spec.whatwg.org/#request-body-header-name).
+      headers.delete("content-encoding");
+      headers.delete("content-language");
+      headers.delete("content-location");
+      headers.delete("content-type");
+      headers.delete("content-length");
+    } else if (body instanceof ReadableStream || (typeof body?.pipe === "function" && typeof body?.on === "function")) {
+      // Covers web ReadableStream and node:stream Readable bodies alike.
+      throw hopError(
+        `cannot follow the ${status} redirect to ${next.href}: the request body is a stream that was already sent; use a buffered body to follow redirects`,
+      );
+    }
+    url = next;
+  }
+}
+
+function fetchLookupError(err) {
+  return err instanceof UndiciError ? err : fetchFailed(err);
+}
+
+async function fetchWithConnect(input, init, connect) {
+  const isRequest = input instanceof Request;
+  const url = new URL(isRequest ? input.url : input);
+  const redirectMode = init?.redirect ?? (isRequest ? input.redirect : undefined) ?? "follow";
+  const signal = init?.signal ?? (isRequest ? input.signal : undefined);
+  if (redirectMode !== "follow") {
+    // "manual" returns the 3xx and "error" rejects natively; neither follows
+    // a redirect, so only the first hop needs pinning.
+    let pin;
+    try {
+      pin = await applyConnect(url, connect, signal);
+    } catch (err) {
+      if (signal?.aborted && err === signal.reason) throw err;
+      throw fetchLookupError(err);
+    }
+    if (pin === undefined) return nativeFetch(input, init);
+    const headers = new Headers(init?.headers ?? (isRequest ? input.headers : undefined));
+    if (!headers.has("host")) headers.set("host", pin.host);
+    const resp = isRequest
+      ? // Request's constructor reads `input` as an init dict: method/headers/body carry over.
+        await nativeFetch(new Request(pin.url.href, input), { ...init, headers })
+      : await nativeFetch(pin.url.href, { ...init, headers });
+    ObjectDefineProperty(resp, "url", { __proto__: null, configurable: true, value: url.href });
+    return resp;
+  }
+  const headers = new Headers(init?.headers ?? (isRequest ? input.headers : undefined));
+  const method = init?.method ?? (isRequest ? input.method : "GET");
+  // Buffer a Request body so 307/308 hops can replay it.
+  const body =
+    init?.body !== undefined ? init.body : isRequest && input.body != null ? await input.arrayBuffer() : undefined;
+  return followRedirectsWithConnect(url, { ...init, signal }, connect, {
+    method,
+    body,
+    headers,
+    limit: 20,
+    redirectError: () => fetchFailed(new Error("redirect count exceeded")),
+    hopError: message => fetchFailed(new Error(message)),
+    lookupError: fetchLookupError,
+  });
+}
+
+function fetch(input, init) {
+  try {
+    const connect = resolveConnect(init?.dispatcher);
+    // Take over only when there is connect behaviour to apply (a lookup hook,
+    // or a custom connector to reject); otherwise stay on the native path.
+    if (connect == null || (typeof connect !== "function" && typeof connect.lookup !== "function")) {
+      return nativeFetch(input, init);
+    }
+    return fetchWithConnect(input, init, connect);
+  } catch (e) {
+    return Promise.$reject(e);
+  }
+}
+fetch.preconnect = nativeFetch.preconnect;
 
 /**
  * An object representing a URL.
@@ -170,7 +410,7 @@ async function request(
     throwOnError = false,
     body: inputBody,
     maxRedirections,
-    // dispatcher,
+    dispatcher,
   } = options;
 
   // TODO: More validations
@@ -205,17 +445,42 @@ async function request(
 
   const followRedirects = maxRedirections != null && maxRedirections > 0;
 
+  const connect = resolveConnect(dispatcher);
+  const hasLookup = connect != null && (typeof connect === "function" || typeof connect.lookup === "function");
+
   /** @type {Response} */
-  const resp = await fetch(url, {
-    signal,
-    mode: "cors",
-    method,
-    headers: inputHeaders || kEmptyObject,
-    body: inputBody,
-    redirect: followRedirects ? "follow" : "manual",
-    maxRedirects: followRedirects ? maxRedirections : undefined,
-    keepalive: !reset,
-  });
+  let resp;
+  if (hasLookup && followRedirects) {
+    resp = await followRedirectsWithConnect(new URL(url), { signal, mode: "cors", keepalive: !reset }, connect, {
+      method,
+      body: inputBody,
+      headers: headersFromRequestOptions(inputHeaders),
+      limit: maxRedirections,
+      redirectError: () => new Error("redirected too many times"),
+      hopError: message => new Error(message),
+      lookupError: err => err,
+    });
+  } else {
+    let requestHeaders = inputHeaders || kEmptyObject;
+    if (hasLookup) {
+      const pin = await applyConnect(typeof url === "string" ? new URL(url) : url, connect, signal);
+      if (pin !== undefined) {
+        url = pin.url;
+        requestHeaders = headersFromRequestOptions(inputHeaders);
+        if (!requestHeaders.has("host")) requestHeaders.set("host", pin.host);
+      }
+    }
+    resp = await nativeFetch(url, {
+      signal,
+      mode: "cors",
+      method,
+      headers: requestHeaders,
+      body: inputBody,
+      redirect: followRedirects ? "follow" : "manual",
+      maxRedirects: followRedirects ? maxRedirections : undefined,
+      keepalive: !reset,
+    });
+  }
 
   const { status: statusCode, headers, trailers } = resp;
 
@@ -255,7 +520,22 @@ class MockAgent {
 function mockErrors() {}
 
 class Dispatcher extends EventEmitter {}
-class Agent extends Dispatcher {}
+class Agent extends Dispatcher {
+  #connect;
+
+  constructor(opts) {
+    super();
+    const connect = opts?.connect;
+    if (connect != null && typeof connect !== "function" && typeof connect !== "object") {
+      throw new InvalidArgumentError("connect must be a function or an object");
+    }
+    this.#connect = connect ?? undefined;
+  }
+
+  [kConnectFor]() {
+    return this.#connect;
+  }
+}
 class Pool extends Dispatcher {
   request() {}
 }

--- a/test/js/first_party/undici/undici.test.ts
+++ b/test/js/first_party/undici/undici.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { tls as tlsCert } from "harness";
 import { Readable } from "node:stream";
-import { request, fetch as undiciFetch } from "undici";
+import { Agent, errors, getGlobalDispatcher, request, setGlobalDispatcher, fetch as undiciFetch } from "undici";
 
 import { createServer } from "../../../http-test-server";
 
@@ -265,5 +266,370 @@ describe("undici.request maxRedirections", () => {
     } finally {
       server.stop(true);
     }
+  });
+});
+
+describe("undici dispatcher connect.lookup", () => {
+  // Reserved TLD (RFC 2606): guaranteed not to resolve, so reaching the local
+  // server proves the lookup hook supplied the address.
+  const UNRESOLVABLE = "this-host-does-not-exist.invalid";
+
+  function pinningAgent(address = "127.0.0.1") {
+    const seen: string[] = [];
+    const agent = new Agent({
+      connect: {
+        lookup: (hostname, _opts, cb) => {
+          seen.push(hostname);
+          cb(null, address, 4);
+        },
+      },
+    });
+    return { agent, seen };
+  }
+
+  it("fetch connects to the address returned by the lookup hook", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      fetch: req => new Response(req.headers.get("host") ?? "none"),
+    });
+    const { agent, seen } = pinningAgent();
+    const res = await undiciFetch(`http://${UNRESOLVABLE}:${server.port}/`, { dispatcher: agent });
+    expect(await res.text()).toBe(`${UNRESOLVABLE}:${server.port}`);
+    expect(res.status).toBe(200);
+    expect(seen).toEqual([UNRESOLVABLE]);
+    // The pinned IP does not leak into the Response.
+    expect(res.url).toBe(`http://${UNRESOLVABLE}:${server.port}/`);
+    expect(res.redirected).toBe(false);
+  });
+
+  it("fetch fails when the lookup hook reports an error, without contacting the server", async () => {
+    let hits = 0;
+    await using server = Bun.serve({
+      port: 0,
+      fetch: () => {
+        hits++;
+        return new Response("served");
+      },
+    });
+    const agent = new Agent({
+      connect: {
+        lookup: (_hostname, _opts, cb) => cb(new Error("blocked by rebinding protection"), "", 0),
+      },
+    });
+    expect(
+      await undiciFetch(`http://localhost:${server.port}/`, { dispatcher: agent }).then(
+        () => ({ name: "resolved" }),
+        (err: TypeError) => ({
+          name: err.constructor.name,
+          message: err.message,
+          cause: (err.cause as Error | undefined)?.message,
+        }),
+      ),
+    ).toEqual({ name: "TypeError", message: "fetch failed", cause: "blocked by rebinding protection" });
+    expect(hits).toBe(0);
+  });
+
+  it("lookup hook is skipped for IP literals", async () => {
+    await using server = Bun.serve({ port: 0, fetch: () => new Response("direct") });
+    const { agent, seen } = pinningAgent("192.0.2.1");
+    const res = await undiciFetch(`http://127.0.0.1:${server.port}/`, { dispatcher: agent });
+    expect(await res.text()).toBe("direct");
+    expect(seen).toEqual([]);
+  });
+
+  it("lookup hook may return the all:true address-array shape", async () => {
+    await using server = Bun.serve({ port: 0, fetch: () => new Response("array") });
+    const agent = new Agent({
+      connect: {
+        lookup: (_hostname, _opts, cb) => cb(null, [{ address: "127.0.0.1", family: 4 }] as any, undefined as any),
+      },
+    });
+    const res = await undiciFetch(`http://${UNRESOLVABLE}:${server.port}/`, { dispatcher: agent });
+    expect(await res.text()).toBe("array");
+  });
+
+  it("the global dispatcher's lookup hook is honored", async () => {
+    await using server = Bun.serve({ port: 0, fetch: () => new Response("global") });
+    const previous = getGlobalDispatcher();
+    setGlobalDispatcher(pinningAgent().agent);
+    try {
+      const res = await undiciFetch(`http://${UNRESOLVABLE}:${server.port}/`);
+      expect(await res.text()).toBe("global");
+    } finally {
+      setGlobalDispatcher(previous);
+    }
+  });
+
+  it("fetch with a Request input keeps method, headers and body through the pin", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      fetch: async req => new Response(`${req.method} ${req.headers.get("x-probe")} ${await req.text()}`),
+    });
+    const { agent } = pinningAgent();
+    const req = new Request(`http://${UNRESOLVABLE}:${server.port}/`, {
+      method: "POST",
+      headers: { "x-probe": "yes" },
+      body: "hello",
+    });
+    const res = await undiciFetch(req, { dispatcher: agent });
+    expect(await res.text()).toBe("POST yes hello");
+  });
+
+  it("request() honors the dispatcher's lookup hook", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      fetch: req => new Response(req.headers.get("host") ?? "none"),
+    });
+    const { agent, seen } = pinningAgent();
+    const { statusCode, body } = await request(`http://${UNRESOLVABLE}:${server.port}/`, { dispatcher: agent });
+    expect(await body!.text()).toBe(`${UNRESOLVABLE}:${server.port}`);
+    expect(statusCode).toBe(200);
+    expect(seen).toEqual([UNRESOLVABLE]);
+  });
+
+  it("https: the pin keeps the original hostname for SNI and certificate verification", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      tls: tlsCert,
+      fetch: req => new Response(req.headers.get("host") ?? "none"),
+    });
+    const { agent, seen } = pinningAgent();
+    const verified: string[] = [];
+    const res = await undiciFetch(`https://localhost:${server.port}/`, {
+      dispatcher: agent,
+      // @ts-expect-error Bun-specific fetch option
+      tls: {
+        ca: tlsCert.cert,
+        checkServerIdentity: (hostname: string) => {
+          verified.push(hostname);
+          return undefined;
+        },
+      },
+    });
+    expect(await res.text()).toBe(`localhost:${server.port}`);
+    expect(seen).toEqual(["localhost"]);
+    expect(verified).toEqual(["localhost"]);
+  });
+
+  it("the lookup hook sees every redirect hop", async () => {
+    await using target = Bun.serve({
+      port: 0,
+      fetch: req =>
+        new Response(
+          `${req.method} ${req.headers.get("host")} body-headers=${req.headers.has("content-type") || req.headers.has("content-encoding")}`,
+        ),
+    });
+    await using origin = Bun.serve({
+      port: 0,
+      fetch: () => Response.redirect(`http://redirect-target.invalid:${target.port}/`, 302),
+    });
+    const { agent, seen } = pinningAgent();
+    const res = await undiciFetch(`http://redirect-origin.invalid:${origin.port}/`, {
+      dispatcher: agent,
+      method: "POST",
+      headers: { "content-encoding": "identity" },
+      body: "payload",
+    });
+    // 302 + POST becomes GET and drops the body headers, like native redirect following.
+    expect(await res.text()).toBe(`GET redirect-target.invalid:${target.port} body-headers=false`);
+    expect(seen).toEqual(["redirect-origin.invalid", "redirect-target.invalid"]);
+    expect(res.url).toBe(`http://redirect-target.invalid:${target.port}/`);
+    expect(res.redirected).toBe(true);
+  });
+
+  it("the lookup hook can veto a redirect hop", async () => {
+    let targetHits = 0;
+    await using target = Bun.serve({
+      port: 0,
+      fetch: () => {
+        targetHits++;
+        return new Response("target");
+      },
+    });
+    await using origin = Bun.serve({
+      port: 0,
+      fetch: () => Response.redirect(`http://blocked.invalid:${target.port}/`, 302),
+    });
+    const agent = new Agent({
+      connect: {
+        lookup: (hostname, _opts, cb) =>
+          hostname === "blocked.invalid" ? cb(new Error("blocked"), "", 0) : cb(null, "127.0.0.1", 4),
+      },
+    });
+    expect(
+      await undiciFetch(`http://ok.invalid:${origin.port}/`, { dispatcher: agent }).then(
+        () => ({ name: "resolved" }),
+        (err: TypeError) => ({
+          name: err.constructor.name,
+          message: err.message,
+          cause: (err.cause as Error | undefined)?.message,
+        }),
+      ),
+    ).toEqual({ name: "TypeError", message: "fetch failed", cause: "blocked" });
+    expect(targetHits).toBe(0);
+  });
+
+  it("redirects to non-http schemes are rejected", async () => {
+    await using origin = Bun.serve({
+      port: 0,
+      fetch: () => new Response(null, { status: 302, headers: { location: "file:///etc/hostname" } }),
+    });
+    const { agent, seen } = pinningAgent();
+    expect(
+      await undiciFetch(`http://scheme.invalid:${origin.port}/`, { dispatcher: agent }).then(
+        () => "resolved",
+        (err: TypeError) => (err.cause as Error).message,
+      ),
+    ).toContain("URL scheme must be http or https");
+    expect(seen).toEqual(["scheme.invalid"]);
+  });
+
+  it("request() re-applies the lookup hook across maxRedirections hops", async () => {
+    await using target = Bun.serve({
+      port: 0,
+      fetch: req => new Response(req.headers.get("host") ?? "none"),
+    });
+    await using origin = Bun.serve({
+      port: 0,
+      fetch: () => Response.redirect(`http://hop2.invalid:${target.port}/`, 302),
+    });
+    const { agent, seen } = pinningAgent();
+    const { statusCode, body } = await request(`http://hop1.invalid:${origin.port}/`, {
+      dispatcher: agent,
+      maxRedirections: 5,
+    });
+    expect(await body!.text()).toBe(`hop2.invalid:${target.port}`);
+    expect(statusCode).toBe(200);
+    expect(seen).toEqual(["hop1.invalid", "hop2.invalid"]);
+  });
+
+  it("a custom connect function rejects loudly instead of being silently ignored", async () => {
+    await using server = Bun.serve({ port: 0, fetch: () => new Response("served") });
+    const agent = new Agent({ connect: (() => {}) as any });
+    expect(
+      await undiciFetch(`http://localhost:${server.port}/`, { dispatcher: agent }).then(
+        () => "resolved",
+        err => (err instanceof errors.NotSupportedError ? "NotSupportedError" : String(err)),
+      ),
+    ).toBe("NotSupportedError");
+  });
+
+  it("redirect manual and error modes still pin the first hop", async () => {
+    await using origin = Bun.serve({
+      port: 0,
+      fetch: () => Response.redirect("http://elsewhere.invalid/", 302),
+    });
+    const { agent, seen } = pinningAgent();
+    const res = await undiciFetch(`http://manual.invalid:${origin.port}/`, { dispatcher: agent, redirect: "manual" });
+    expect(res.status).toBe(302);
+    expect(res.url).toBe(`http://manual.invalid:${origin.port}/`);
+
+    // A Request input goes through the same branch.
+    const req = new Request(`http://manual.invalid:${origin.port}/`, { redirect: "manual" });
+    const res2 = await undiciFetch(req, { dispatcher: agent });
+    expect(res2.status).toBe(302);
+
+    expect(
+      await undiciFetch(`http://manual.invalid:${origin.port}/`, { dispatcher: agent, redirect: "error" }).then(
+        () => "resolved",
+        () => "rejected",
+      ),
+    ).toBe("rejected");
+    expect(seen).toEqual(["manual.invalid", "manual.invalid", "manual.invalid"]);
+  });
+
+  it("an abort signal rejects a lookup that never completes", async () => {
+    const controller = new AbortController();
+    const agent = new Agent({
+      connect: {
+        // Never calls cb; aborting must reject the pending fetch.
+        lookup: () => controller.abort(new Error("abort during lookup")),
+      },
+    });
+    expect(
+      await undiciFetch(`http://${UNRESOLVABLE}:1/`, { dispatcher: agent, signal: controller.signal }).then(
+        () => "resolved",
+        (err: Error) => err.message,
+      ),
+    ).toBe("abort during lookup");
+
+    // An already-aborted signal rejects before the hook runs.
+    const { agent: pinner, seen } = pinningAgent();
+    expect(
+      await undiciFetch(`http://${UNRESOLVABLE}:1/`, {
+        dispatcher: pinner,
+        signal: AbortSignal.abort(new Error("pre-aborted")),
+      }).then(
+        () => "resolved",
+        (err: Error) => err.message,
+      ),
+    ).toBe("pre-aborted");
+    expect(seen).toEqual([]);
+  });
+
+  it("request() accepts flat-array headers on the pinned path", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      fetch: req => new Response(`${req.headers.get("x-a")} ${req.headers.get("cookie")}`),
+    });
+    const { agent } = pinningAgent();
+    const { body } = await request(`http://${UNRESOLVABLE}:${server.port}/`, {
+      dispatcher: agent,
+      maxRedirections: 1,
+      headers: ["x-a", "1", "cookie", "a=1", "cookie", "b=2"],
+    });
+    // Bun's Headers joins repeated cookie entries with "; ".
+    expect(await body!.text()).toBe("1 a=1; b=2");
+  });
+
+  it("request() enforces maxRedirections on the pinned path", async () => {
+    let port = 0;
+    await using server = Bun.serve({
+      port: 0,
+      fetch: req => {
+        const n = Number(new URL(req.url).pathname.slice(1));
+        return n >= 2 ? new Response("done") : Response.redirect(`http://chain.invalid:${port}/${n + 1}`, 302);
+      },
+    });
+    port = server.port;
+    const { agent } = pinningAgent();
+
+    // Exactly at the limit succeeds (two redirects, cap 2).
+    const { statusCode, body } = await request(`http://chain.invalid:${port}/0`, {
+      dispatcher: agent,
+      maxRedirections: 2,
+    });
+    expect(await body!.text()).toBe("done");
+    expect(statusCode).toBe(200);
+
+    // One past the limit rejects.
+    await expect(request(`http://chain.invalid:${port}/0`, { dispatcher: agent, maxRedirections: 1 })).rejects.toThrow(
+      "redirected too many times",
+    );
+  });
+
+  it("URLs without a network authority skip the hook", async () => {
+    const { agent, seen } = pinningAgent();
+    const res = await undiciFetch("data:text/plain,hello", { dispatcher: agent });
+    expect(await res.text()).toBe("hello");
+    expect(seen).toEqual([]);
+  });
+
+  it("a connect object without a lookup hook keeps native redirect following", async () => {
+    await using target = Bun.serve({ port: 0, fetch: () => new Response("followed") });
+    await using origin = Bun.serve({
+      port: 0,
+      fetch: () => Response.redirect(`http://127.0.0.1:${target.port}/`, 302),
+    });
+    const agent = new Agent({ connect: { timeout: 5000 } });
+    const res = await undiciFetch(`http://127.0.0.1:${origin.port}/`, { dispatcher: agent });
+    expect(await res.text()).toBe("followed");
+    expect(res.redirected).toBe(true);
+  });
+
+  it("an Agent without connect options leaves requests untouched", async () => {
+    await using server = Bun.serve({ port: 0, fetch: () => new Response("plain") });
+    const res = await undiciFetch(`http://127.0.0.1:${server.port}/`, { dispatcher: new Agent() });
+    expect(await res.text()).toBe("plain");
   });
 });


### PR DESCRIPTION
### Problem

- The builtin `undici` module's `fetch` was a direct alias of `Bun.fetch`, and `request()` never read the option either, so the `dispatcher` option was ignored outright. An `Agent` whose `connect.lookup` hook returns a pre-resolved IP (the standard undici way to prevent DNS rebinding / TOCTOU: resolve once, validate, then pin the connection to that address) silently did nothing, and the OS resolver ran again at connect time. The request succeeded with the protection disabled, with no error or warning.
- `Agent` itself was an empty `EventEmitter` subclass: constructor options were dropped on the floor.
- Fixes #38840. Complementary to #35145, which wires `ProxyAgent`/`setGlobalDispatcher` to native fetch's `proxy` option and deliberately leaves plain `Agent` untouched; this PR covers the `connect.lookup` side with the same structure (a symbol the shim's own dispatchers expose, unknown dispatchers leave the request unchanged).

### Fix

- `Agent` stores its `connect` options and exposes them through an internal symbol. `undici.fetch` and `undici.request` read that from the explicit `dispatcher` option, or from the global dispatcher when none is passed.
- When the dispatcher has a `connect.lookup` hook, the shim calls it with the URL hostname (same `{ family, hints }` options shape `net.connect` passes) and pins the request to the returned address by rewriting the URL host, while sending the original authority as the `Host` header. Native fetch sends a user `Host` header verbatim (`src/http/lib.rs` `build_request`) and uses it, port-stripped, for TLS SNI and certificate verification (`get_tls_hostname`), so HTTPS through a pin still verifies against the real hostname. IP-literal hosts skip the hook, matching `net.connect`.
- A `Location` target outside http(s) (`file:`, `data:`, `blob:`) is rejected like native following does (native: `UnsupportedRedirectProtocol`); those schemes bypass the hook, so following them would fail open. An aborted signal rejects a pending lookup (the hook may never call back), with the abort reason surfacing as-is.
- Redirects do not escape the hook: when it is active and redirects are followed (`fetch` with `redirect: "follow"`, `request()` with `maxRedirections > 0`), the shim forces `redirect: "manual"` per hop and walks the chain itself, re-running the hook for every hostname. Cross-origin hops drop `authorization`/`proxy-authorization`/`cookie`, and 301/302/303 method rewrites match native following. In real undici the hook runs for every socket the Agent opens, including redirect hops, so native `follow` (which resolves `Location` targets with the OS resolver) would have reopened the hole.
- A lookup error rejects the fetch with `TypeError: fetch failed` carrying the hook's error as `cause` (undici's error shape), so "veto the connection" protections work on any hop.
- The hook only applies where undici would consult the connector: http(s) URLs (`data:`/`blob:` fetch natively) and hostnames that are not IP literals. Responses through a pin report the logical `url`/`redirected`, intermediate 3xx bodies are cancelled, and dispatchers whose `connect` options carry no lookup hook stay entirely on the native path.
- `connect` passed as a function (a custom connector, which the shim cannot emulate) now rejects with `NotSupportedError` instead of being silently ignored; `Agent` validates `connect` like upstream (`InvalidArgumentError`).
- `request()`'s raw flat header array form (`["name", "value", ...]`) is normalized on the pinned paths, where the Headers constructor would reject it.
- Verified with 20 new tests in `test/js/first_party/undici/undici.test.ts`: pin to a local server via an unresolvable `.invalid` hostname (fetch, `request()`, Request input with method/headers/body, global dispatcher, `all: true` address-array callback shape), lookup errors reject without contacting the server, IP literals skip the hook, HTTPS through a pin where `checkServerIdentity` observes the original hostname, the hook sees and can veto every redirect hop (fetch and `request()` with `maxRedirections`), custom connect functions reject, `data:` URLs skip the hook, and dispatchers without connect options or without a lookup hook keep native behavior. Also covered: redirect to `file:` rejects, abort during and before a lookup, flat-array headers, `redirect: manual`/`error` modes, and the exact `maxRedirections` boundary. 16 of the 20 fail on the unfixed build (the negative controls pass both ways); all 30 tests in the file pass with the fix.

### Background

- undici (Node's fetch implementation, also a standalone npm package) routes every request through a "dispatcher"; `Agent` is the default dispatcher and its `connect` options configure how sockets are made. `connect.lookup` has the same contract as the `lookup` option of `net.connect`: `(hostname, options, callback)` with `callback(err, address, family)`.
- Bun aliases `import "undici"` to this builtin shim even when the npm package is installed, so there is no userland workaround; the shim maps what it can onto native fetch options.
- DNS rebinding: an attacker's DNS name resolves to a safe address during validation, then to an internal address when the request is made. Resolving once and pinning the connection to the validated address closes that window, which is exactly what the lookup hook exists to do. A redirect is another route to the connect effect, which is why the hook has to run per hop.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 16 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/first_party/undici/undici.test.ts
bun test v1.4.0 (6e906e468)

test/js/first_party/undici/undici.test.ts:
(pass) undici > request > should make a GET request when passed a URL string [82.01ms]
(pass) undici > request > should error when body has already been consumed [19.08ms]
(pass) undici > request > should make a POST request when provided a body and POST method [19.23ms]
(pass) undici > request > should stream a node:stream Readable body [260.62ms]
(pass) undici > request > should accept a URL class object [11.60ms]
(pass) undici > request > should prevent body from being attached to GET or HEAD requests [12.35ms]
(pass) undici > request > a 204 has no body [59.21ms]
(pass) undici > request > the response to a HEAD request has no body [21.36ms]
(pass) undici > request > should allow a query string to be passed [22.35ms]
(pass) undici > request > should throw on HTTP 4xx or 5xx error when throwOnError is true [19.14ms]
(pass) undici > request > should allow us to abort the request with a signal [529.28ms]
(pass) undici > req
... (truncated)

release without fix: 19 FAILED
bun test v1.4.0-canary.1 (6e906e468)

test/js/first_party/undici/undici.test.ts:
(pass) undici > request > should make a GET request when passed a URL string [4.14ms]
(pass) undici > request > should error when body has already been consumed [0.42ms]
(pass) undici > request > should make a POST request when provided a body and POST method [0.28ms]
83 |   }
84 |   if (method = method && typeof method === "string" ? method.toUpperCase() : null, inputBody && (method === "GET" || method === "HEAD"))
85 |     throw Error("Body not allowed for GET or HEAD requests");
86 |   if (inputBody && inputBody.read && inputBody instanceof Readable) {
87 |     let data = "";
88 |     for await (let chunk of stream)
                              ^
TypeError: iterable should have an iterator symbol
      at request (undici:88:26)
      at <anonymous> (/workspace/bun/test/js/first_party/undici/undici.test.ts:81:42)
(fail) undici > request > should stream a node:stream Readable body [1.38ms]
(pass) undici > request > should accept a URL class object [0.25ms]
(pass) undici > request > should prevent body from being attached to GET or HEAD requests [0.15ms]
133 |     it.each([
134 |      
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/first_party/undici/undici.test.ts
bun test v1.4.0 (6e906e468)

test/js/first_party/undici/undici.test.ts:
(pass) undici > request > should make a GET request when passed a URL string [87.28ms]
(pass) undici > request > should error when body has already been consumed [17.83ms]
(pass) undici > request > should make a POST request when provided a body and POST method [18.50ms]
(pass) undici > request > should stream a node:stream Readable body [250.91ms]
(pass) undici > request > should accept a URL class object [10.58ms]
(pass) undici > request > should prevent body from being attached to GET or HEAD requests [11.55ms]
(pass) undici > request > a 204 has no body [57.70ms]
(pass) undici > request > the response to a HEAD request has no body [22.88ms]
(pass) undici > request > should allow a query string to be passed [22.72ms]
(pass) undici > request > should throw on HTTP 4xx or 5xx error when throwOnError is true [18.43ms]
(pass) undici > request > should allow us to abort the request with a signal [533.07ms]
(pass) undici > req
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     808558139c
  features     baseline

23 deps, 129 codegen, 1172 objects in 766ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.0-canary.1 (6e906e468)

Checked 26 installs across 63 packages (no changes) [4.00ms]
[2/1244] gen ErrorCode+*.h
[3/1244] gen bindgenv2
[4/1244] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (6e906e468)

Checked 1 install across 2 packages (no changes) [6.00ms]
[5/1244] gen .bind.ts → GeneratedBindings.cpp
[6/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1217] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (6e906e468)

Checked 111 installs across 104 packages (no changes) [5.00ms]
[8/1217] fetch tinycc
[tinycc] up to date
[9/1216] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[10/1216] fetch zlib
[zlib] up to date
[11
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/thirdparty/undici.js               | 306 +++++++++++++++++++++++--
 test/js/first_party/undici/undici.test.ts | 368 +++++++++++++++++++++++++++++-
 2 files changed, 660 insertions(+), 14 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/js/thirdparty/undici.js                   15     44      0
test/js/first_party/undici/undici.test.ts      6     16      0
```

</details>

**root cause** · written by the author bot

Bun's builtin undici compatibility shim discarded the dispatcher option entirely and implemented Agent as an inert stub, so a connect.lookup hook never ran and requests fell through to native fetch, which re-resolved the hostname with the OS resolver and defeated DNS rebinding protections. The fix has Agent retain its validated connect options and makes fetch and request honor them: when a lookup hook is present, the shim resolves the hostname through the hook, pins the connection by rewriting the URL host to the returned IP while sending the original authority as the Host header so SNI and…

<!-- robobun:evidence:end -->