### PR TITLE
install: remove the same-filesystem probe from $TMPDIR when the rename into the cache fails

### DIFF
--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -242,6 +242,8 @@ fn get_temporary_directory_run(manager: &mut PackageManager) -> TemporaryDirecto
         match sys::renameat_z(tempdir.fd(), tmpname, cache_directory.fd(), tmpname) {
             Ok(()) => {}
             Err(err) => {
+                // The rename failed, so the probe is still sitting in `tempdir`.
+                let _ = tempdir.delete_file_z(tmpname);
                 if !tried_dot_tmp {
                     tried_dot_tmp = true;
                     tempdir = match cache_directory.make_open_path(b".tmp", Default::default()) {

--- a/test/cli/install/bun-install-tmpdir-exdev.test.ts
+++ b/test/cli/install/bun-install-tmpdir-exdev.test.ts
@@ -1,0 +1,67 @@
+// `bun install` checks whether $TMPDIR and the install cache are on the same
+// filesystem by creating an empty `.<hex>-N.hm` probe in $TMPDIR and
+// renaming it into the cache. When the rename fails with EXDEV, bun falls
+// back to `<cache>/.tmp`; the probe it created in $TMPDIR must not be left
+// behind. Forcing EXDEV needs a writable mount on a different device from
+// the harness temp dir (/dev/shm on Linux).
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isPosix, tempDir } from "harness";
+import { accessSync, constants, existsSync, mkdtempSync, readdirSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+function findCrossDeviceDir(): string | undefined {
+  if (!isPosix) return undefined;
+  const refDev = statSync(tmpdir()).dev;
+  for (const candidate of ["/dev/shm", "/tmp"]) {
+    try {
+      if (statSync(candidate).dev === refDev) continue;
+      accessSync(candidate, constants.W_OK | constants.X_OK);
+      return candidate;
+    } catch {}
+  }
+  return undefined;
+}
+
+const crossDeviceDir = findCrossDeviceDir();
+
+test.skipIf(!crossDeviceDir)(
+  "leaves nothing in $TMPDIR when it is on a different filesystem than the cache",
+  async () => {
+    using dir = tempDir("install-tmpdir-exdev", {
+      "package.json": JSON.stringify({
+        name: "app",
+        dependencies: { localdep: "file:./localdep" },
+      }),
+      "localdep/package.json": JSON.stringify({ name: "localdep", version: "1.0.0" }),
+    });
+    const cache = join(String(dir), "cache");
+    const tmp = mkdtempSync(join(crossDeviceDir!, "bun-install-exdev-"));
+
+    try {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "install"],
+        cwd: String(dir),
+        env: {
+          ...bunEnv,
+          BUN_INSTALL_CACHE_DIR: cache,
+          BUN_TMPDIR: tmp,
+          TMPDIR: tmp,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("error:");
+      expect(stdout).toContain("1 package installed");
+      expect(exitCode).toBe(0);
+
+      // The cross-device rename failed, so bun switched to <cache>/.tmp ...
+      expect(existsSync(join(cache, ".tmp"))).toBe(true);
+      // ... and must have removed the probe it had created in $TMPDIR first.
+      expect(readdirSync(tmp)).toEqual([]);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  },
+);


### PR DESCRIPTION
### Problem
- Every `bun install` leaves one empty `$TMPDIR/.<hex>-N.hm` file behind when `$TMPDIR` and the install cache are on different filesystems (tmpfs `/tmp` with the cache on disk, or a `BUN_INSTALL_CACHE_DIR` on another mount). They accumulate until the tmpfs is cleared; a long-running fuzzer left ~76,000 of them in three hours.
- Present in 1.3.14 and on main, so not a recent regression.
- Cause: `get_temporary_directory_run` in `src/install/PackageManager/PackageManagerDirectories.rs` creates the probe in the tempdir and `renameat`s it into the cache directory (line 242). When the rename fails it switches `tempdir` to `<cache>/.tmp` and retries, and the only unlink in the loop (line 277) removes the retry's probe from the cache directory. The first probe is still in `$TMPDIR` and nothing removes it.

### Fix
- When the rename fails, unlink the probe from the directory it was created in before falling back (or crashing when the fallback has already been tried).
- Correct because a failed `rename` leaves the source in place, so the probe is always still in `tempdir` on that path; the unlink result is ignored like the existing cache-directory unlink.
- Test: `test/cli/install/bun-install-tmpdir-exdev.test.ts` points `TMPDIR`/`BUN_TMPDIR` at a directory on a different device (`/dev/shm`, or `/tmp` when the harness temp dir is elsewhere; skipped when neither differs, which covers Windows and the usual macOS layout), installs a `file:` dependency with the cache inside the test directory, and asserts that `<cache>/.tmp` was created (the fallback actually ran) and that the `TMPDIR` directory is empty afterwards. It fails on the released build with the leaked `.hm` file listed and passes with this change.
- Also ran three installs in a loop with the debug build in both layouts: nothing left in `$TMPDIR` in the cross-device layout, and the same-filesystem layout still removes its probe and does not create `<cache>/.tmp`.
- #33979 fixes a different install tempdir leak (extraction directories on cache-publish races and error paths); the two do not overlap.

### Background
- `bun install` extracts each package into a temp directory and then `rename`s it into the cache, so the tempdir must be on the same filesystem as the cache (`rename` across filesystems fails with `EXDEV`). The probe described above is how bun detects this once per process; on failure it uses `<cache>/.tmp` as the tempdir instead.
- `FileSystem::tmpname` produces the `.<hex>-<counter>.<ext>` names; the probe uses the `hm` extension.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-install-tmpdir-exdev.test.ts
bun test v1.4.0 (24513432d)

test/cli/install/bun-install-tmpdir-exdev.test.ts:
57 |       expect(exitCode).toBe(0);
58 | 
59 |       // The cross-device rename failed, so bun switched to <cache>/.tmp ...
60 |       expect(existsSync(join(cache, ".tmp"))).toBe(true);
61 |       // ... and must have removed the probe it had created in $TMPDIR first.
62 |       expect(readdirSync(tmp)).toEqual([]);
                                    ^
error: expect(received).toEqual(expected)

- []
+ [
+   ".b31a253393dade1b-0.hm",
+ ]

- Expected  - 1
+ Received  + 3

      at <anonymous> (/workspace/bun/test/cli/install/bun-install-tmpdir-exdev.test.ts:62:32)
(fail) leaves nothing in $TMPDIR when it is on a different filesystem than the cache [496.33ms]

 0 pass
 1 fail
 5 expect() calls
Ran 1 test across 1 file. [4.88s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (b7a043103)

test/cli/install/bun-install-tmpdir-exdev.test.ts:
57 |       expect(exitCode).toBe(0);
58 | 
59 |       // The cross-device rename failed, so bun switched to <cache>/.tmp ...
60 |       expect(existsSync(join(cache, ".tmp"))).toBe(true);
61 |       // ... and must have removed the probe it had created in $TMPDIR first.
62 |       expect(readdirSync(tmp)).toEqual([]);
                                    ^
error: expect(received).toEqual(expected)

- []
+ [
+   ".344bd0dcb8645fc4-0.hm",
+ ]

- Expected  - 1
+ Received  + 3

      at <anonymous> (/workspace/bun/test/cli/install/bun-install-tmpdir-exdev.test.ts:62:32)
(fail) leaves nothing in $TMPDIR when it is on a different filesystem than the cache [130.51ms]

 0 pass
 1 fail
 5 expect() calls
Ran 1 test across 1 file. [1178.00ms]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-install-tmpdir-exdev.test.ts
bun test v1.4.0 (24513432d)

test/cli/install/bun-install-tmpdir-exdev.test.ts:
(pass) leaves nothing in $TMPDIR when it is on a different filesystem than the cache [420.54ms]

 1 pass
 0 fail
 5 expect() calls
Ran 1 test across 1 file. [4.60s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1534ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_patch_jsc v0.0.0 (/workspace/bun/src/patch_jsc)
[1m[92m   Compiling[0m bun_semver_jsc v0.0.0 (/workspace/bun/src/semver_jsc)
[1m[92m   Compiling[0m bun_sys_jsc v0.0.0 (/workspace/bun/src/sys_jsc)
[1m[92m   Compiling[0m bun_sql_jsc v0.0.0 (/workspace/bun/src/sql_jsc)
[1m[92m   Compiling[0m bun_sourcemap_jsc v0.0.0 (/workspace/bun/src/sourcemap_jsc)
[1m[92m   Compiling[0m bun_css_jsc v0.0.0 (/workspace/bun/src/css_jsc)
[1m[92m   Compiling[0m bun_bundler_jsc v0.0.0 (/workspace/bun/src/bundler
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../PackageManager/PackageManagerDirectories.rs    |  2 +
 test/cli/install/bun-install-tmpdir-exdev.test.ts  | 67 ++++++++++++++++++++++
 2 files changed, 69 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/install/PackageManager/PackageManagerDirectories.rs      1      1      0
test/cli/install/bun-install-tmpdir-exdev.test.ts            0      1      0
```

</details>

<!-- robobun:evidence:end -->