### PR TITLE
crash_handler(windows): report abort() and int3 crashes, exit with the crash's own status

### DIFF
--- a/src/bun_core/Global.rs
+++ b/src/bun_core/Global.rs
@@ -746,8 +746,7 @@ pub fn raise_ignoring_panic_handler_raw(sig: c_int) -> ! {
     // SIG_DFL instead of recursing into the panic handler. Storage moved down
     // from `bun_crash_handler` — it sets `CRASH_HANDLER_INSTALLED` on init and
     // we do the libc reset ourselves (no fn-ptr hook). Skip when ASAN owns the
-    // signals (we never installed over them); on Windows remove the VEH and
-    // the CRT SIGABRT hook.
+    // signals (we never installed over them); on Windows remove the VEH.
     #[cfg(unix)]
     if CRASH_HANDLER_INSTALLED.load(Ordering::Relaxed) && !crate::env::ENABLE_ASAN {
         // SAFETY: zeroed sigaction with SIG_DFL is a valid disposition.
@@ -784,10 +783,9 @@ pub fn raise_ignoring_panic_handler_raw(sig: c_int) -> ! {
             let _ = RemoveVectoredExceptionHandler(handle);
             let _ = SetUnhandledExceptionFilter(None);
         }
-        // `sig` may be SIGABRT (UCRT `raise(6)` aliases it to the CRT SIGABRT
-        // slot), and `libc_abort()` below always goes through that slot; both
-        // must reach the CRT default rather than the crash handler's hook.
-        // SAFETY: `SIG_DFL` is a valid disposition for `SIGABRT`.
+        // The crash handler's CRT SIGABRT hook; UCRT `raise(6)` and `abort()`
+        // below both go through this slot.
+        // SAFETY: `SIG_DFL` is a valid disposition.
         unsafe {
             let _ = libc::signal(libc::SIGABRT, libc::SIG_DFL);
         }

--- a/src/bun_core/Global.rs
+++ b/src/bun_core/Global.rs
@@ -746,7 +746,8 @@ pub fn raise_ignoring_panic_handler_raw(sig: c_int) -> ! {
     // SIG_DFL instead of recursing into the panic handler. Storage moved down
     // from `bun_crash_handler` — it sets `CRASH_HANDLER_INSTALLED` on init and
     // we do the libc reset ourselves (no fn-ptr hook). Skip when ASAN owns the
-    // signals (we never installed over them); on Windows remove the VEH.
+    // signals (we never installed over them); on Windows remove the VEH and
+    // the CRT SIGABRT hook.
     #[cfg(unix)]
     if CRASH_HANDLER_INSTALLED.load(Ordering::Relaxed) && !crate::env::ENABLE_ASAN {
         // SAFETY: zeroed sigaction with SIG_DFL is a valid disposition.
@@ -782,6 +783,13 @@ pub fn raise_ignoring_panic_handler_raw(sig: c_int) -> ! {
             }
             let _ = RemoveVectoredExceptionHandler(handle);
             let _ = SetUnhandledExceptionFilter(None);
+        }
+        // `sig` may be SIGABRT (UCRT `raise(6)` aliases it to the CRT SIGABRT
+        // slot), and `libc_abort()` below always goes through that slot; both
+        // must reach the CRT default rather than the crash handler's hook.
+        // SAFETY: `SIG_DFL` is a valid disposition for `SIGABRT`.
+        unsafe {
+            let _ = libc::signal(libc::SIGABRT, libc::SIG_DFL);
         }
     }
 

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -487,11 +487,11 @@ mod draft {
     use bun_core::output::enable_ansi_colors_stderr;
 
     /// On POSIX this is `libc::abort()` (async-signal-safe).
-    /// On Windows this is *not* UCRT `abort()` — it is
+    /// On Windows this is *not* UCRT `abort()`; it is
     /// `if (Debug) breakpoint(); kernel32.ExitProcess(3);`. UCRT `abort()` would
     /// raise SIGABRT (which `init` routes back into `crash_handler`, see
     /// `handle_abort_windows`), or without that hook `__fastfail()` and possibly
-    /// pop a Watson/WER dialog — none of which we want here.
+    /// pop a Watson/WER dialog. None of that is wanted here.
     #[inline(always)]
     fn abort() -> ! {
         #[cfg(windows)]

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -486,25 +486,34 @@ mod draft {
     /// `AtomicBool` static. Re-exported here for shorter call sites.
     use bun_core::output::enable_ansi_colors_stderr;
 
-    /// On POSIX this is `libc::abort()` (async-signal-safe).
-    /// On Windows this is *not* UCRT `abort()`; it is
-    /// `if (Debug) breakpoint(); kernel32.ExitProcess(3);`. UCRT `abort()` would
-    /// raise SIGABRT (which `init` routes back into `crash_handler`, see
-    /// `handle_abort_windows`), or without that hook `__fastfail()` and possibly
-    /// pop a Watson/WER dialog. None of that is wanted here.
+    /// Last resort while the crash handler itself is failing (a stderr write
+    /// failed, or it re-entered itself). On POSIX this is `libc::abort()`
+    /// (async-signal-safe); on Windows it exits 3, since no `CrashReason` is at
+    /// hand here. Reported crashes end in `crash()` instead.
     #[inline(always)]
     fn abort() -> ! {
         #[cfg(windows)]
-        {
-            #[cfg(debug_assertions)]
-            core::intrinsics::breakpoint();
-            bun_sys::windows::kernel32::ExitProcess(3)
-        }
+        terminate_windows(3);
         #[cfg(not(windows))]
         // SAFETY: libc::abort has no preconditions; never returns.
         unsafe {
             libc::abort()
         }
+    }
+
+    /// Every Windows crash path ends here, never in UCRT `abort()`: that
+    /// raises SIGABRT, which `init` routes straight back into `crash_handler`
+    /// (`handle_abort_windows`), and without that hook it `__fastfail()`s with
+    /// a fixed status. Debug builds stop in a debugger if one is attached; an
+    /// unconditional `int3` would instead kill an undebugged process with
+    /// `STATUS_BREAKPOINT` before `code` was ever reached.
+    #[cfg(windows)]
+    fn terminate_windows(code: u32) -> ! {
+        #[cfg(debug_assertions)]
+        if bun_sys::windows::kernel32::IsDebuggerPresent() != 0 {
+            core::intrinsics::breakpoint();
+        }
+        bun_sys::windows::kernel32::ExitProcess(code)
     }
     use super::cpu_features::CPUFeatures;
     #[cfg(not(any(target_os = "linux", target_os = "android")))]
@@ -634,7 +643,12 @@ mod draft {
         /// etc. Arrives as SIGABRT on POSIX and via the CRT SIGABRT hook
         /// (`handle_abort_windows`) on Windows.
         Abort,
-        /// Posix-only; `__builtin_trap()` / WTF `CRASH()` / `brk` on aarch64.
+        /// A deliberate trap instruction: `int3`/`brk` from JSC's JIT
+        /// `abortWithReason()` and LLInt `break`, WTF `CRASH()` on Darwin,
+        /// `__builtin_trap()` on aarch64. SIGTRAP on POSIX; `EXCEPTION_BREAKPOINT`
+        /// on Windows, where only x64 `int3` and `brk #0xF000` (`__debugbreak`)
+        /// raise it: arm64 Windows reports a `brk` with any other immediate,
+        /// including WTF's `0xbb08`, as `IllegalInstruction`.
         Trap(usize),
         /// Windows-only
         DatatypeMisalignment,
@@ -668,6 +682,33 @@ mod draft {
                 | CrashReason::StackOverflow
                 | CrashReason::ZigError(_)
                 | CrashReason::OutOfMemory => libc::SIGABRT,
+            }
+        }
+
+        /// Windows counterpart of `terminal_signal`: the exit status the crash
+        /// would have produced had nothing intercepted it, i.e. the exception's
+        /// own code, or for everything that ends in `abort()` on POSIX the
+        /// status a fast-fail (UCRT `abort()`, a Rust abort) exits with. A
+        /// parent that classifies crash exit codes (`bun test --parallel`, CI
+        /// runners) thus sees the same code whether or not a report was
+        /// printed; a fixed code like 3 is indistinguishable from
+        /// `process.exit(3)`.
+        #[cfg(windows)]
+        fn terminal_exit_code(&self) -> u32 {
+            use bun_sys::windows as w;
+            match self {
+                CrashReason::SegmentationFault(_) => w::EXCEPTION_ACCESS_VIOLATION,
+                CrashReason::IllegalInstruction(_) => w::EXCEPTION_ILLEGAL_INSTRUCTION,
+                CrashReason::DatatypeMisalignment => w::EXCEPTION_DATATYPE_MISALIGNMENT,
+                CrashReason::StackOverflow => w::EXCEPTION_STACK_OVERFLOW,
+                CrashReason::Trap(_) => w::EXCEPTION_BREAKPOINT,
+                CrashReason::Abort
+                | CrashReason::Panic(_)
+                | CrashReason::Unreachable
+                | CrashReason::BusError(_)
+                | CrashReason::FloatingPointError(_)
+                | CrashReason::ZigError(_)
+                | CrashReason::OutOfMemory => w::STATUS_STACK_BUFFER_OVERRUN,
             }
         }
     }
@@ -980,7 +1021,7 @@ mod draft {
                                         }
                                         // NOTE: `GetThreadDescription` heap-allocates `name` and the
                                         // caller is meant to `LocalFree` it. This runs on a
-                                        // `noreturn` crash path immediately before `ExitProcess(3)`,
+                                        // `noreturn` crash path immediately before `ExitProcess`,
                                         // so the leak is intentional.
                                     } else {
                                         if write!(
@@ -1711,9 +1752,9 @@ mod draft {
             // sees it: it calls the CRT-level SIGABRT handler if one is
             // installed and otherwise `__fastfail()`s (exit 0xC0000409). WTF
             // `CRASH()`/`RELEASE_ASSERT` is `std::abort()` in release builds
-            // off Darwin, so without this hook every JSC assertion on Windows
-            // dies silently. This is the CRT's signal table, not libuv's;
-            // `process.on("SIGABRT")` never touches it.
+            // off Darwin, so without this hook every C++ assertion in JSC or
+            // Bun dies silently on Windows. This is the CRT's signal table, not
+            // libuv's; `process.on("SIGABRT")` never touches it.
             // SAFETY: `handle_abort_windows` has the `void (*)(int)` signature
             // the CRT calls handlers with, and lives for the whole process.
             unsafe {
@@ -2009,6 +2050,14 @@ mod draft {
                 CrashReason::IllegalInstruction(record.ExceptionAddress as usize)
             }
             bun_sys::windows::EXCEPTION_STACK_OVERFLOW => CrashReason::StackOverflow,
+            // An attached debugger consumes breakpoints before any handler
+            // runs, so one that gets here is a crash. WTF's own VEH
+            // (SignalsWin.cpp) never recovers from this code, and JIT-pool
+            // traps go through the same out-of-image rule as every other code
+            // in `handle_segfault_windows`.
+            bun_sys::windows::EXCEPTION_BREAKPOINT => {
+                CrashReason::Trap(record.ExceptionAddress as usize)
+            }
             _ => return None,
         })
     }
@@ -2939,7 +2988,7 @@ mod draft {
             // NOTE: on success `CreateProcessW` returns two open kernel handles in
             // `process.hProcess` / `process.hThread` that the caller is meant to
             // `CloseHandle`. `report()` runs immediately before
-            // `crash()` → `ExitProcess(3)`, so the kernel reclaims them anyway.
+            // `crash()` → `ExitProcess`, so the kernel reclaims them anyway.
             let _ = spawn_result;
             let _ = url;
         }
@@ -3013,7 +3062,8 @@ mod draft {
     /// Crash. Make sure segfault handlers are off so that this doesnt trigger the crash handler.
     /// On POSIX this re-raises the signal that caused the crash (or SIGABRT
     /// for panics) so the parent sees the real fault and core dumps are
-    /// attributed correctly.
+    /// attributed correctly. Windows has no re-raise: exit with the status
+    /// the unreported crash would have had (`terminal_exit_code`).
     fn crash(reason: CrashReason) -> ! {
         #[cfg(not(windows))]
         {
@@ -3069,17 +3119,7 @@ mod draft {
             core::intrinsics::abort();
         }
         #[cfg(windows)]
-        {
-            let _ = reason;
-            // Node.js exits with code 134 (128 + SIGABRT) instead. We use abort() as it
-            // includes a breakpoint which makes crashes easier to debug.
-            //
-            // The same-module `abort()` helper on
-            // Windows is `breakpoint()` (Debug only) then `kernel32.ExitProcess(3)`.
-            // Do NOT call MSVCRT `libc::abort()` here — that raises SIGABRT, may print
-            // the CRT `abort() has been called` message, and can invoke WER.
-            abort()
-        }
+        terminate_windows(reason.terminal_exit_code())
     }
 
     pub static VERBOSE_ERROR_TRACE: AtomicBool = AtomicBool::new(false);

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -486,10 +486,8 @@ mod draft {
     /// `AtomicBool` static. Re-exported here for shorter call sites.
     use bun_core::output::enable_ansi_colors_stderr;
 
-    /// Last resort while the crash handler itself is failing (a stderr write
-    /// failed, or it re-entered itself). On POSIX this is `libc::abort()`
-    /// (async-signal-safe); on Windows it exits 3, since no `CrashReason` is at
-    /// hand here. Reported crashes end in `crash()` instead.
+    /// Last resort when the crash handler itself fails; reported crashes end
+    /// in `crash()`.
     #[inline(always)]
     fn abort() -> ! {
         #[cfg(windows)]
@@ -501,12 +499,9 @@ mod draft {
         }
     }
 
-    /// Every Windows crash path ends here, never in UCRT `abort()`: that
-    /// raises SIGABRT, which `init` routes straight back into `crash_handler`
-    /// (`handle_abort_windows`), and without that hook it `__fastfail()`s with
-    /// a fixed status. Debug builds stop in a debugger if one is attached; an
-    /// unconditional `int3` would instead kill an undebugged process with
-    /// `STATUS_BREAKPOINT` before `code` was ever reached.
+    /// Not UCRT `abort()`: `init` routes its SIGABRT back into `crash_handler`.
+    /// An unconditional `int3` would also exit with `STATUS_BREAKPOINT`
+    /// instead of `code` whenever no debugger is attached.
     #[cfg(windows)]
     fn terminate_windows(code: u32) -> ! {
         #[cfg(debug_assertions)]
@@ -638,17 +633,12 @@ mod draft {
         BusError(usize),
         /// Posix-only
         FloatingPointError(usize),
-        /// `abort()` from libc/UCRT: WTF `CRASH()`/`RELEASE_ASSERT` in release
-        /// builds on Linux and Windows, mimalloc, BoringSSL, `std::terminate`,
-        /// etc. Arrives as SIGABRT on POSIX and via the CRT SIGABRT hook
-        /// (`handle_abort_windows`) on Windows.
+        /// `abort()` (WTF `RELEASE_ASSERT` in release builds, mimalloc, ...):
+        /// SIGABRT on POSIX, the CRT SIGABRT hook on Windows.
         Abort,
-        /// A deliberate trap instruction: `int3`/`brk` from JSC's JIT
-        /// `abortWithReason()` and LLInt `break`, WTF `CRASH()` on Darwin,
-        /// `__builtin_trap()` on aarch64. SIGTRAP on POSIX; `EXCEPTION_BREAKPOINT`
-        /// on Windows, where only x64 `int3` and `brk #0xF000` (`__debugbreak`)
-        /// raise it: arm64 Windows reports a `brk` with any other immediate,
-        /// including WTF's `0xbb08`, as `IllegalInstruction`.
+        /// `int3`/`brk` (JSC JIT `abortWithReason()`, LLInt `break`): SIGTRAP on
+        /// POSIX, `EXCEPTION_BREAKPOINT` on Windows. arm64 Windows reports every
+        /// `brk` immediate except `0xF000` as `IllegalInstruction` instead.
         Trap(usize),
         /// Windows-only
         DatatypeMisalignment,
@@ -685,14 +675,9 @@ mod draft {
             }
         }
 
-        /// Windows counterpart of `terminal_signal`: the exit status the crash
-        /// would have produced had nothing intercepted it, i.e. the exception's
-        /// own code, or for everything that ends in `abort()` on POSIX the
-        /// status a fast-fail (UCRT `abort()`, a Rust abort) exits with. A
-        /// parent that classifies crash exit codes (`bun test --parallel`, CI
-        /// runners) thus sees the same code whether or not a report was
-        /// printed; a fixed code like 3 is indistinguishable from
-        /// `process.exit(3)`.
+        /// Windows counterpart of `terminal_signal`: the status the unreported
+        /// crash would have exited with, so `bun test --parallel` and CI
+        /// classify it the same way (a fixed code looks like `process.exit`).
         #[cfg(windows)]
         fn terminal_exit_code(&self) -> u32 {
             use bun_sys::windows as w;
@@ -1748,25 +1733,18 @@ mod draft {
                 ));
             }
 
-            // UCRT `abort()` raises no exception, so neither handler above
-            // sees it: it calls the CRT-level SIGABRT handler if one is
-            // installed and otherwise `__fastfail()`s (exit 0xC0000409). WTF
-            // `CRASH()`/`RELEASE_ASSERT` is `std::abort()` in release builds
-            // off Darwin, so without this hook every C++ assertion in JSC or
-            // Bun dies silently on Windows. This is the CRT's signal table, not
-            // libuv's; `process.on("SIGABRT")` never touches it.
-            // SAFETY: `handle_abort_windows` has the `void (*)(int)` signature
-            // the CRT calls handlers with, and lives for the whole process.
+            // UCRT `abort()` (every C++ RELEASE_ASSERT in release builds) raises
+            // no exception for the handlers above: it calls this CRT signal slot
+            // if set and otherwise `__fastfail()`s.
+            // SAFETY: `handle_abort_windows` is a `void (*)(int)` that lives for
+            // the whole process.
             unsafe {
                 libc::signal(
                     libc::SIGABRT,
                     handle_abort_windows as *const () as libc::sighandler_t,
                 );
             }
-            // The debug UCRT's `abort()` first reports "abort() has been
-            // called" (a dialog on an interactive desktop); the crash report
-            // from `handle_abort_windows` replaces it. No-op on the release
-            // UCRT, which never sets this flag.
+            // Debug UCRT only: skip its own "abort() has been called" dialog.
             _set_abort_behavior(0, WRITE_ABORT_MSG);
         }
         #[cfg(any(
@@ -2050,11 +2028,7 @@ mod draft {
                 CrashReason::IllegalInstruction(record.ExceptionAddress as usize)
             }
             bun_sys::windows::EXCEPTION_STACK_OVERFLOW => CrashReason::StackOverflow,
-            // An attached debugger consumes breakpoints before any handler
-            // runs, so one that gets here is a crash. WTF's own VEH
-            // (SignalsWin.cpp) never recovers from this code, and JIT-pool
-            // traps go through the same out-of-image rule as every other code
-            // in `handle_segfault_windows`.
+            // A debugger, if attached, consumes these before any handler runs.
             bun_sys::windows::EXCEPTION_BREAKPOINT => {
                 CrashReason::Trap(record.ExceptionAddress as usize)
             }
@@ -2177,12 +2151,8 @@ mod draft {
         );
     }
 
-    /// CRT SIGABRT handler (`init`). UCRT `abort()` calls this synchronously on
-    /// the aborting thread via `raise(SIGABRT)`, after resetting the slot to
-    /// `SIG_DFL`, so a second `abort()` while this report is being written
-    /// takes the CRT's own `__fastfail()` path (like `SA_RESETHAND` on POSIX).
-    /// The return address is inside UCRT `raise`, so the trace reads
-    /// `raise` -> `abort` -> the asserting frame, like the POSIX SIGABRT trace.
+    /// Called synchronously by UCRT `raise(SIGABRT)` on the aborting thread,
+    /// after the slot has been reset to `SIG_DFL` (one-shot, like `SA_RESETHAND`).
     #[cfg(windows)]
     extern "C" fn handle_abort_windows(_sig: c_int) {
         crash_handler(
@@ -2197,8 +2167,7 @@ mod draft {
 
     #[cfg(windows)]
     unsafe extern "C" {
-        /// UCRT: replaces the `mask` bits of the process-wide abort behavior
-        /// flags with `flags`. Plain integer arguments, no preconditions.
+        /// UCRT `<stdlib.h>`; by-value integers, no preconditions.
         safe fn _set_abort_behavior(
             flags: core::ffi::c_uint,
             mask: core::ffi::c_uint,
@@ -3062,8 +3031,7 @@ mod draft {
     /// Crash. Make sure segfault handlers are off so that this doesnt trigger the crash handler.
     /// On POSIX this re-raises the signal that caused the crash (or SIGABRT
     /// for panics) so the parent sees the real fault and core dumps are
-    /// attributed correctly. Windows has no re-raise: exit with the status
-    /// the unreported crash would have had (`terminal_exit_code`).
+    /// attributed correctly; Windows exits with `terminal_exit_code` instead.
     fn crash(reason: CrashReason) -> ! {
         #[cfg(not(windows))]
         {

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -457,7 +457,6 @@ mod draft {
 
     use core::cell::Cell;
     use core::ffi::c_char;
-    #[cfg(not(windows))]
     use core::ffi::c_int;
     #[cfg(windows)]
     use core::ffi::c_long;
@@ -488,10 +487,11 @@ mod draft {
     use bun_core::output::enable_ansi_colors_stderr;
 
     /// On POSIX this is `libc::abort()` (async-signal-safe).
-    /// On Windows this is *not* MSVCRT `abort()` — it is
+    /// On Windows this is *not* UCRT `abort()` — it is
     /// `if (Debug) breakpoint(); kernel32.ExitProcess(3);`. UCRT `abort()` would
-    /// raise SIGABRT, may print `R6010 - abort() has been called` to stderr, and
-    /// can pop a Watson/WER dialog — none of which we want here.
+    /// raise SIGABRT (which `init` routes back into `crash_handler`, see
+    /// `handle_abort_windows`), or without that hook `__fastfail()` and possibly
+    /// pop a Watson/WER dialog — none of which we want here.
     #[inline(always)]
     fn abort() -> ! {
         #[cfg(windows)]
@@ -629,7 +629,10 @@ mod draft {
         BusError(usize),
         /// Posix-only
         FloatingPointError(usize),
-        /// Posix-only; libc/mimalloc `abort()`, `std::terminate`, etc.
+        /// `abort()` from libc/UCRT: WTF `CRASH()`/`RELEASE_ASSERT` in release
+        /// builds on Linux and Windows, mimalloc, BoringSSL, `std::terminate`,
+        /// etc. Arrives as SIGABRT on POSIX and via the CRT SIGABRT hook
+        /// (`handle_abort_windows`) on Windows.
         Abort,
         /// Posix-only; `__builtin_trap()` / WTF `CRASH()` / `brk` on aarch64.
         Trap(usize),
@@ -1703,6 +1706,27 @@ mod draft {
                     >(handle_unhandled_exception_windows),
                 ));
             }
+
+            // UCRT `abort()` raises no exception, so neither handler above
+            // sees it: it calls the CRT-level SIGABRT handler if one is
+            // installed and otherwise `__fastfail()`s (exit 0xC0000409). WTF
+            // `CRASH()`/`RELEASE_ASSERT` is `std::abort()` in release builds
+            // off Darwin, so without this hook every JSC assertion on Windows
+            // dies silently. This is the CRT's signal table, not libuv's;
+            // `process.on("SIGABRT")` never touches it.
+            // SAFETY: `handle_abort_windows` has the `void (*)(int)` signature
+            // the CRT calls handlers with, and lives for the whole process.
+            unsafe {
+                libc::signal(
+                    libc::SIGABRT,
+                    handle_abort_windows as *const () as libc::sighandler_t,
+                );
+            }
+            // The debug UCRT's `abort()` first reports "abort() has been
+            // called" (a dialog on an interactive desktop); the crash report
+            // from `handle_abort_windows` replaces it. No-op on the release
+            // UCRT, which never sets this flag.
+            _set_abort_behavior(0, WRITE_ABORT_MSG);
         }
         #[cfg(any(
             target_os = "macos",
@@ -1942,9 +1966,10 @@ mod draft {
                 debug_assert!(rc != 0);
             }
             // SAFETY: no memory-safety preconditions; clears the top-level
-            // filter back to the OS default.
+            // filter and the CRT SIGABRT slot back to their defaults.
             unsafe {
                 bun_sys::windows::kernel32::SetUnhandledExceptionFilter(None);
+                libc::signal(libc::SIGABRT, libc::SIG_DFL);
             }
             return;
         }
@@ -2101,6 +2126,34 @@ mod draft {
                 fp: info.ContextRecord as usize,
             },
         );
+    }
+
+    /// CRT SIGABRT handler (`init`). UCRT `abort()` calls this synchronously on
+    /// the aborting thread via `raise(SIGABRT)`, after resetting the slot to
+    /// `SIG_DFL`, so a second `abort()` while this report is being written
+    /// takes the CRT's own `__fastfail()` path (like `SA_RESETHAND` on POSIX).
+    /// The return address is inside UCRT `raise`, so the trace reads
+    /// `raise` -> `abort` -> the asserting frame, like the POSIX SIGABRT trace.
+    #[cfg(windows)]
+    extern "C" fn handle_abort_windows(_sig: c_int) {
+        crash_handler(
+            CrashReason::Abort,
+            TraceSeed::BeginAddr(debug::return_address()),
+        );
+    }
+
+    /// `_WRITE_ABORT_MSG` (`<stdlib.h>`).
+    #[cfg(windows)]
+    const WRITE_ABORT_MSG: core::ffi::c_uint = 0x1;
+
+    #[cfg(windows)]
+    unsafe extern "C" {
+        /// UCRT: replaces the `mask` bits of the process-wide abort behavior
+        /// flags with `flags`. Plain integer arguments, no preconditions.
+        safe fn _set_abort_behavior(
+            flags: core::ffi::c_uint,
+            mask: core::ffi::c_uint,
+        ) -> core::ffi::c_uint;
     }
 
     #[cfg(all(target_os = "linux", target_env = "gnu"))]

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -132,9 +132,7 @@ pub(crate) mod js_bindings {
         crash_handler::panic_impl(b"invoked crashByPanic() handler", None, None);
     }
 
-    /// A real C `abort()`, the way WTF `CRASH()`/`RELEASE_ASSERT`, mimalloc
-    /// and BoringSSL die in release builds: SIGABRT on POSIX, the statically
-    /// linked UCRT's `abort()` (and its CRT SIGABRT hook) on Windows.
+    /// The C `abort()` a release-build `RELEASE_ASSERT` ends in, on every platform.
     #[bun_jsc::host_fn]
     fn js_abort(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
         crash_handler::suppress_core_dumps_if_necessary();
@@ -154,9 +152,8 @@ pub(crate) mod js_bindings {
 
     /// Dies like foreign native code, with Bun's crash handler provably out
     /// of the way on both platforms: `__fastfail` on Windows (uncatchable,
-    /// exit code 0xC0000409: Rust aborts, /GS checks, and `abort()` in an
-    /// addon's own CRT, whose SIGABRT slot Bun's hook is not installed in)
-    /// and a raw SIGABRT on POSIX (handlers reset first, like the
+    /// exit code 0xC0000409, like Rust aborts, /GS checks and an addon CRT's
+    /// `abort()`) and a raw SIGABRT on POSIX (handlers reset first, like the
     /// `raiseIgnoringPanicHandler` binding below). The `abort` binding
     /// above is the opposite: it routes into the crash handler on purpose.
     #[bun_jsc::host_fn]
@@ -168,11 +165,8 @@ pub(crate) mod js_bindings {
         Global::raise_ignoring_panic_handler(bun_core::SignalCode::SIGABRT);
     }
 
-    /// Executes the trap instruction WTF's `WTF_FATAL_CRASH_INST` and JSC's
-    /// JIT `abortWithReason()` / LLInt `break` compile to. SIGTRAP on POSIX;
-    /// on Windows, `EXCEPTION_BREAKPOINT` for x64's `int3` but
-    /// `EXCEPTION_ILLEGAL_INSTRUCTION` for arm64's `brk #0xbb08` (see
-    /// `CrashReason::Trap`), so the Windows test expects per architecture.
+    /// Executes the trap instruction WTF/JSC emit (see `CrashReason::Trap` for
+    /// how each platform reports it).
     #[bun_jsc::host_fn]
     fn js_trap(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
         crash_handler::suppress_core_dumps_if_necessary();
@@ -214,9 +208,7 @@ pub(crate) mod js_bindings {
         bun_core::out_of_memory();
     }
 
-    /// `raiseIgnoringPanicHandler(signal?)`: re-raises `signal` (name or
-    /// number, default SIGSEGV) the way `bun run` forwards a child's fatal
-    /// signal, i.e. with the crash handler's hooks torn down first.
+    /// `raiseIgnoringPanicHandler(signal = "SIGSEGV")`
     #[bun_jsc::host_fn]
     fn js_raise_ignoring_panic_handler(
         global: &JSGlobalObject,

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -168,28 +168,33 @@ pub(crate) mod js_bindings {
         Global::raise_ignoring_panic_handler(bun_core::SignalCode::SIGABRT);
     }
 
+    /// Executes the trap instruction WTF's `WTF_FATAL_CRASH_INST` and JSC's
+    /// JIT `abortWithReason()` / LLInt `break` compile to. SIGTRAP on POSIX;
+    /// on Windows, `EXCEPTION_BREAKPOINT` for x64's `int3` but
+    /// `EXCEPTION_ILLEGAL_INSTRUCTION` for arm64's `brk #0xbb08` (see
+    /// `CrashReason::Trap`), so the Windows test expects per architecture.
     #[bun_jsc::host_fn]
     fn js_trap(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
         crash_handler::suppress_core_dumps_if_necessary();
-        if Environment::ENABLE_ASAN || cfg!(windows) {
+        // Under ASAN the POSIX signal handlers are not installed (see js_abort).
+        if Environment::ENABLE_ASAN {
             crash_handler::crash_handler(
                 crash_handler::CrashReason::Trap(0),
                 crash_handler::TraceSeed::BeginAddr(crash_handler::debug::return_address()),
             );
         }
-        // int3 on x86_64 / brk on aarch64: both deliver SIGTRAP, matching the
-        // instruction WTF's CRASH()/RELEASE_ASSERT emits.
-        #[cfg(all(unix, target_arch = "x86_64"))]
+        #[cfg(target_arch = "x86_64")]
         // SAFETY: single trap instruction; no inputs/outputs.
         unsafe {
             core::arch::asm!("int3", options(nomem, nostack));
         }
-        #[cfg(all(unix, target_arch = "aarch64"))]
+        // 0xbb08 is WTF_FATAL_CRASH_CODE (wtf/Assertions.h).
+        #[cfg(target_arch = "aarch64")]
         // SAFETY: single trap instruction; no inputs/outputs.
         unsafe {
-            core::arch::asm!("brk #0", options(nomem, nostack));
+            core::arch::asm!("brk #0xbb08", options(nomem, nostack));
         }
-        #[cfg(all(unix, not(any(target_arch = "x86_64", target_arch = "aarch64"))))]
+        #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
         crash_handler::crash_handler(
             crash_handler::CrashReason::Trap(0),
             crash_handler::TraceSeed::BeginAddr(crash_handler::debug::return_address()),

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -132,29 +132,30 @@ pub(crate) mod js_bindings {
         crash_handler::panic_impl(b"invoked crashByPanic() handler", None, None);
     }
 
+    /// A real C `abort()`, the way WTF `CRASH()`/`RELEASE_ASSERT`, mimalloc
+    /// and BoringSSL die in release builds: SIGABRT on POSIX, the statically
+    /// linked UCRT's `abort()` (and its CRT SIGABRT hook) on Windows.
     #[bun_jsc::host_fn]
     fn js_abort(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
         crash_handler::suppress_core_dumps_if_necessary();
         // Under ASAN the POSIX signal handlers are not installed; invoke the
         // handler directly so the reporter test still observes the upload.
-        if Environment::ENABLE_ASAN || cfg!(windows) {
+        if Environment::ENABLE_ASAN {
             crash_handler::crash_handler(
                 crash_handler::CrashReason::Abort,
                 crash_handler::TraceSeed::BeginAddr(crash_handler::debug::return_address()),
             );
         }
-        #[cfg(unix)]
         // SAFETY: libc::abort has no preconditions; never returns.
         unsafe {
             libc::abort();
         }
-        #[allow(unreachable_code)]
-        Ok(JSValue::UNDEFINED)
     }
 
     /// Dies like foreign native code, with Bun's crash handler provably out
     /// of the way on both platforms: `__fastfail` on Windows (uncatchable,
-    /// exit code 0xC0000409, same as UCRT abort(), Rust aborts, /GS checks)
+    /// exit code 0xC0000409: Rust aborts, /GS checks, and `abort()` in an
+    /// addon's own CRT, whose SIGABRT slot Bun's hook is not installed in)
     /// and a raw SIGABRT on POSIX (handlers reset first, like the
     /// `raiseIgnoringPanicHandler` binding below). The `abort` binding
     /// above is the opposite: it routes into the crash handler on purpose.
@@ -208,13 +209,22 @@ pub(crate) mod js_bindings {
         bun_core::out_of_memory();
     }
 
+    /// `raiseIgnoringPanicHandler(signal?)`: re-raises `signal` (name or
+    /// number, default SIGSEGV) the way `bun run` forwards a child's fatal
+    /// signal, i.e. with the crash handler's hooks torn down first.
     #[bun_jsc::host_fn]
     fn js_raise_ignoring_panic_handler(
-        _global: &JSGlobalObject,
-        _frame: &CallFrame,
+        global: &JSGlobalObject,
+        frame: &CallFrame,
     ) -> JsResult<JSValue> {
+        let signal_arg = frame.argument(0);
+        let sig = if signal_arg.is_empty_or_undefined_or_null() {
+            bun_core::SignalCode::SIGSEGV as u8
+        } else {
+            bun_sys_jsc::signal_code_jsc::from_js(signal_arg, global)?.0
+        };
         crash_handler::suppress_core_dumps_if_necessary();
-        Global::raise_ignoring_panic_handler(bun_core::SignalCode::SIGSEGV);
+        Global::raise_ignoring_panic_handler_raw(core::ffi::c_int::from(sig));
     }
 
     #[bun_jsc::host_fn]

--- a/src/runtime/cli/test/parallel/Coordinator.rs
+++ b/src/runtime/cli/test/parallel/Coordinator.rs
@@ -827,9 +827,8 @@ impl<'a> Coordinator<'a> {
 /// Windows delivers no signals: an unhandled exception or `__fastfail`
 /// exits with the NTSTATUS as the exit code, so recognized fatal values of
 /// `Exited.raw` (the untruncated code; `Exited.code` is `u8`) classify as
-/// panics too. A crash Bun's crash handler reports exits with the status
-/// the unreported crash would have had (`CrashReason::terminal_exit_code`
-/// in `bun_crash_handler`), so it classifies the same way, banner or not.
+/// panics too; Bun's own crash handler exits with the same values
+/// (`CrashReason::terminal_exit_code`).
 fn is_panic_status(status: &SpawnStatus) -> bool {
     if let Some(sig) = status.signal_code() {
         use bun_core::SignalCode;
@@ -876,10 +875,8 @@ fn is_fatal_windows_exit_code(code: u32) -> bool {
         | 0xC000_0096                // STATUS_PRIVILEGED_INSTRUCTION (SIGILL)
         | 0xC000_00FD                // STATUS_STACK_OVERFLOW
         | 0xC000_0374                // STATUS_HEAP_CORRUPTION
-        | 0xC000_0409                // STATUS_STACK_BUFFER_OVERRUN: __fastfail (UCRT
-                                     // abort(), Rust abort, /GS checks) and what the
-                                     // crash handler exits with for aborts, panics
-                                     // and OOM (SIGABRT)
+        | 0xC000_0409                // STATUS_STACK_BUFFER_OVERRUN: __fastfail, i.e.
+                                     // abort(), Rust abort, /GS checks, panics (SIGABRT)
         | 0xC000_0417                // STATUS_INVALID_CRUNTIME_PARAMETER
         | 0xC000_041D                // STATUS_FATAL_USER_CALLBACK_EXCEPTION
         | 0xC000_0420                // STATUS_ASSERTION_FAILURE

--- a/src/runtime/cli/test/parallel/Coordinator.rs
+++ b/src/runtime/cli/test/parallel/Coordinator.rs
@@ -876,7 +876,9 @@ fn is_fatal_windows_exit_code(code: u32) -> bool {
         | 0xC000_00FD                // STATUS_STACK_OVERFLOW
         | 0xC000_0374                // STATUS_HEAP_CORRUPTION
         | 0xC000_0409                // STATUS_STACK_BUFFER_OVERRUN: __fastfail —
-                                     // UCRT abort(), Rust abort, /GS checks (SIGABRT)
+                                     // Rust abort, /GS checks, abort() in an addon's
+                                     // own CRT (SIGABRT). abort() in bun.exe's CRT is
+                                     // caught by the crash handler and exits 3.
         | 0xC000_0417                // STATUS_INVALID_CRUNTIME_PARAMETER
         | 0xC000_041D                // STATUS_FATAL_USER_CALLBACK_EXCEPTION
         | 0xC000_0420                // STATUS_ASSERTION_FAILURE

--- a/src/runtime/cli/test/parallel/Coordinator.rs
+++ b/src/runtime/cli/test/parallel/Coordinator.rs
@@ -827,9 +827,9 @@ impl<'a> Coordinator<'a> {
 /// Windows delivers no signals: an unhandled exception or `__fastfail`
 /// exits with the NTSTATUS as the exit code, so recognized fatal values of
 /// `Exited.raw` (the untruncated code; `Exited.code` is `u8`) classify as
-/// panics too. A fault Bun's crash handler catches still exits with code
-/// 3, indistinguishable from process.exit(3), and stays a per-file
-/// failure, recognizable only by its banner in stderr.
+/// panics too. A crash Bun's crash handler reports exits with the status
+/// the unreported crash would have had (`CrashReason::terminal_exit_code`
+/// in `bun_crash_handler`), so it classifies the same way, banner or not.
 fn is_panic_status(status: &SpawnStatus) -> bool {
     if let Some(sig) = status.signal_code() {
         use bun_core::SignalCode;
@@ -862,7 +862,8 @@ fn is_panic_status(status: &SpawnStatus) -> bool {
 fn is_fatal_windows_exit_code(code: u32) -> bool {
     matches!(
         code,
-        0x8000_0003                  // STATUS_BREAKPOINT: unhandled int3 (SIGTRAP)
+        0x8000_0002                  // STATUS_DATATYPE_MISALIGNMENT (SIGBUS)
+        | 0x8000_0003                // STATUS_BREAKPOINT: int3/brk (SIGTRAP)
         | 0x8000_0004                // STATUS_SINGLE_STEP (SIGTRAP)
         | 0xC000_0005                // STATUS_ACCESS_VIOLATION (SIGSEGV)
         | 0xC000_0006                // STATUS_IN_PAGE_ERROR (SIGBUS)
@@ -875,10 +876,10 @@ fn is_fatal_windows_exit_code(code: u32) -> bool {
         | 0xC000_0096                // STATUS_PRIVILEGED_INSTRUCTION (SIGILL)
         | 0xC000_00FD                // STATUS_STACK_OVERFLOW
         | 0xC000_0374                // STATUS_HEAP_CORRUPTION
-        | 0xC000_0409                // STATUS_STACK_BUFFER_OVERRUN: __fastfail —
-                                     // Rust abort, /GS checks, abort() in an addon's
-                                     // own CRT (SIGABRT). abort() in bun.exe's CRT is
-                                     // caught by the crash handler and exits 3.
+        | 0xC000_0409                // STATUS_STACK_BUFFER_OVERRUN: __fastfail (UCRT
+                                     // abort(), Rust abort, /GS checks) and what the
+                                     // crash handler exits with for aborts, panics
+                                     // and OOM (SIGABRT)
         | 0xC000_0417                // STATUS_INVALID_CRUNTIME_PARAMETER
         | 0xC000_041D                // STATUS_FATAL_USER_CALLBACK_EXCEPTION
         | 0xC000_0420                // STATUS_ASSERTION_FAILURE

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -89,6 +89,8 @@ pub mod kernel32 {
 
         /// No preconditions; reads the calling thread's ID.
         pub safe fn GetCurrentThreadId() -> DWORD;
+        /// No preconditions; reads `PEB.BeingDebugged`.
+        pub safe fn IsDebuggerPresent() -> BOOL;
     }
 }
 
@@ -1238,9 +1240,14 @@ pub fn exe_image_range() -> core::ops::Range<usize> {
 
 // `STATUS_*` values surfaced as `ExceptionCode` (winnt.h).
 pub const EXCEPTION_ACCESS_VIOLATION: u32 = 0xC0000005;
+pub const EXCEPTION_BREAKPOINT: u32 = 0x80000003;
 pub const EXCEPTION_DATATYPE_MISALIGNMENT: u32 = 0x80000002;
 pub const EXCEPTION_ILLEGAL_INSTRUCTION: u32 = 0xC000001D;
 pub const EXCEPTION_STACK_OVERFLOW: u32 = 0xC00000FD;
+/// The status `__fastfail(FAST_FAIL_FATAL_APP_EXIT)` terminates with, i.e.
+/// how UCRT `abort()` and Rust aborts end a process when nothing intercepts
+/// them. Never an `ExceptionCode`: a fast-fail dispatches no exception.
+pub const STATUS_STACK_BUFFER_OVERRUN: u32 = 0xC0000409;
 
 /// `EXCEPTION_RECORD` (winnt.h).
 #[repr(C)]

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -1244,9 +1244,8 @@ pub const EXCEPTION_BREAKPOINT: u32 = 0x80000003;
 pub const EXCEPTION_DATATYPE_MISALIGNMENT: u32 = 0x80000002;
 pub const EXCEPTION_ILLEGAL_INSTRUCTION: u32 = 0xC000001D;
 pub const EXCEPTION_STACK_OVERFLOW: u32 = 0xC00000FD;
-/// The status `__fastfail(FAST_FAIL_FATAL_APP_EXIT)` terminates with, i.e.
-/// how UCRT `abort()` and Rust aborts end a process when nothing intercepts
-/// them. Never an `ExceptionCode`: a fast-fail dispatches no exception.
+/// Exit status of `__fastfail()`, i.e. of an unhandled `abort()`; never an
+/// `ExceptionCode`.
 pub const STATUS_STACK_BUFFER_OVERRUN: u32 = 0xC0000409;
 
 /// `EXCEPTION_RECORD` (winnt.h).

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -352,37 +352,53 @@ test.if(process.platform === "darwin")("macOS has the assumed image offset", () 
   expect(getMachOImageZeroOffset()).toBe(0x100000000);
 });
 
-test("raise ignoring panic handler does not trigger the panic handler", async () => {
-  let sent = false;
-  const resolve_handler = Promise.withResolvers();
-
-  using server = Bun.serve({
-    port: 0,
-    fetch(request, server) {
-      sent = true;
-      resolve_handler.resolve();
-      return new Response("OK");
-    },
-  });
-
-  const proc = Bun.spawn({
-    cmd: [bunExe(), path.join(import.meta.dir, "fixture-crash.js"), "raiseIgnoringPanicHandler"],
-    env: mergeWindowEnvs([
-      bunEnv,
-      {
-        BUN_CRASH_REPORT_URL: server.url.toString(),
-        BUN_ENABLE_CRASH_REPORTING: "1",
+// `raise_ignoring_panic_handler` is how `bun run` re-raises the signal that
+// killed the script: it must tear down every crash-handler hook first, SIGABRT
+// included (on Windows that is the CRT SIGABRT slot, which UCRT `raise()`
+// reaches from SIGABRT's POSIX number too), then die of the raw signal.
+// The crash handler prints the report URL before uploading, so a clean stderr
+// is the proof that no report was made or sent.
+describe("raise ignoring panic handler does not trigger the panic handler", () => {
+  test.concurrent.each(["SIGSEGV", "SIGABRT"] as const)("%s", async signal => {
+    let sent = false;
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        sent = true;
+        return new Response("OK");
       },
-    ]),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `require("bun:internal-for-testing").crash_handler.raiseIgnoringPanicHandler("${signal}")`,
+        "--debug-crash-handler-use-trace-string",
+      ],
+      env: mergeWindowEnvs([
+        bunEnv,
+        {
+          BUN_CRASH_REPORT_URL: server.url.toString(),
+          BUN_ENABLE_CRASH_REPORTING: "1",
+          GITHUB_ACTIONS: undefined,
+          CI: undefined,
+        },
+      ]),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("oh no");
+    expect(stderr).not.toContain(server.url.toString());
+    expect(sent).toBe(false);
+    if (isWindows) {
+      // UCRT raise() with the disposition back at SIG_DFL is _exit(3).
+      expect(exitCode).toBe(3);
+    } else {
+      expect(proc.signalCode).toBe(signal);
+    }
   });
-
-  await proc.exited;
-
-  /// Wait two seconds for a slow http request, or continue immediately once the request is heard.
-  await Promise.race([resolve_handler.promise, Bun.sleep(2000)]);
-
-  expect(proc.exited).resolves.not.toBe(0);
-  expect(sent).toBe(false);
 });
 
 // SIGABRT (libc abort(), mimalloc/glibc heap-corruption, std::terminate) and
@@ -497,6 +513,93 @@ describe.if(isPosix)("SIGABRT/SIGTRAP are caught by the crash handler", () => {
     expect(stderr).not.toContain(server.url.toString());
     expect(proc.signalCode).toBe("SIGABRT");
     expect(sent).toBe(false);
+  });
+});
+
+// Windows twin of the SIGABRT case above. There is no signal delivery: UCRT
+// abort() (what WTF CRASH()/RELEASE_ASSERT compiles to in release builds, and
+// what mimalloc, BoringSSL and plain C code call) runs the CRT-level SIGABRT
+// handler if one is installed and otherwise __fastfail()s. A fast-fail raises
+// no exception, so the VEH/UEF crash handlers never ran and every JSC
+// assertion on Windows exited 0xC0000409 with nothing on stderr. The crash
+// handler now installs a CRT SIGABRT handler at startup.
+describe.if(isWindows)("Windows: UCRT abort() is caught by the crash handler", () => {
+  const reportingEnv = (url: string) =>
+    mergeWindowEnvs([
+      bunEnv,
+      {
+        BUN_CRASH_REPORT_URL: url,
+        BUN_ENABLE_CRASH_REPORTING: "1",
+        GITHUB_ACTIONS: undefined,
+        CI: undefined,
+      },
+    ]);
+
+  test.concurrent("abort() produces a crash report", async () => {
+    let sent = false;
+    const acked = Promise.withResolvers<void>();
+    using server = Bun.serve({
+      port: 0,
+      fetch(request) {
+        expect(request.url).toEndWith("/ack");
+        sent = true;
+        acked.resolve();
+        return new Response("OK");
+      },
+    });
+
+    // The `abort` hook is a real UCRT abort() from bun.exe's statically
+    // linked CRT, the same call a RELEASE_ASSERT makes.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        path.join(import.meta.dir, "fixture-crash.js"),
+        "abort",
+        "--debug-crash-handler-use-trace-string",
+      ],
+      env: reportingEnv(server.url.toString()),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain("panic(main thread): abort() called");
+    expect(stderr).toContain("oh no: Bun has crashed.");
+    expect(stderr).toContain(server.url.toString());
+    expect(exitCode).not.toBe(0);
+
+    await acked.promise;
+    expect(sent).toBe(true);
+  });
+
+  // Terminations that must stay out of the new hook. process.abort() is a
+  // user action (_exit(134) on Windows); fastfail is a bare __fastfail, which
+  // never enters the CRT, so it still dies with the raw NTSTATUS 0xC0000409
+  // (low byte 9 as an exit code) that `bun test --parallel` classifies on.
+  test.concurrent.each([
+    ["process.abort()", 134],
+    ["crash_handler.fastfail()", 9],
+  ] as const)("%s does not report a crash", async (code, expectedExitCode) => {
+    let sent = false;
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        sent = true;
+        return new Response("OK");
+      },
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `const { crash_handler } = require("bun:internal-for-testing"); ${code}`],
+      env: reportingEnv(server.url.toString()),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("abort() called");
+    expect(stderr).not.toContain("Bun has crashed");
+    expect(stderr).not.toContain(server.url.toString());
+    expect(sent).toBe(false);
+    expect(exitCode).toBe(expectedExitCode);
   });
 });
 

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -516,68 +516,67 @@ describe.if(isPosix)("SIGABRT/SIGTRAP are caught by the crash handler", () => {
   });
 });
 
-// Windows twin of the SIGABRT case above. There is no signal delivery: UCRT
-// abort() (what WTF CRASH()/RELEASE_ASSERT compiles to in release builds, and
-// what mimalloc, BoringSSL and plain C code call) runs the CRT-level SIGABRT
-// handler if one is installed and otherwise __fastfail()s. A fast-fail raises
-// no exception, so the VEH/UEF crash handlers never ran and every JSC
-// assertion on Windows exited 0xC0000409 with nothing on stderr. The crash
-// handler now installs a CRT SIGABRT handler at startup.
-describe.if(isWindows)("Windows: UCRT abort() is caught by the crash handler", () => {
-  const reportingEnv = (url: string) =>
-    mergeWindowEnvs([
-      bunEnv,
-      {
-        BUN_CRASH_REPORT_URL: url,
-        BUN_ENABLE_CRASH_REPORTING: "1",
-        GITHUB_ACTIONS: undefined,
-        CI: undefined,
-      },
-    ]);
+// Windows twin of the two POSIX blocks above ("terminal signal reflects the
+// crash cause" and "SIGABRT/SIGTRAP are caught"). Windows delivers no signals:
+//  - UCRT abort() (what WTF CRASH()/RELEASE_ASSERT compiles to in release
+//    builds, and what mimalloc, BoringSSL and plain C code call) runs the
+//    CRT-level SIGABRT handler if one is installed and otherwise __fastfail()s.
+//    A fast-fail raises no exception, so the VEH/UEF crash handlers never saw
+//    it and every C++ assertion exited 0xC0000409 with nothing on stderr.
+//    init() now installs a CRT SIGABRT handler.
+//  - On x64, int3 (JSC JIT abortWithReason, LLInt break) raises
+//    EXCEPTION_BREAKPOINT, which the exception classifier did not know, so
+//    those died silently too. (arm64 Windows reports JSC's brk immediates as
+//    illegal instructions, which were already classified.)
+//  - After printing, the handler used to ExitProcess(3) for every crash, which
+//    a parent cannot tell from process.exit(3); it now exits with the status
+//    the unreported crash would have had. Bun.spawn reports the low byte of a
+//    Windows exit code, hence the truncated values below.
+describe.if(isWindows)("Windows: aborts and traps are reported, exit status reflects the crash cause", () => {
+  // The `trap` hook executes the instruction WTF/JSC emit (int3, brk #0xbb08).
+  // Either way the address printed must be the instruction's, not the 0 the
+  // hook used to pass when it called the handler directly.
+  const trapRow =
+    process.arch === "arm64"
+      ? // STATUS_ILLEGAL_INSTRUCTION 0xC000001D: only brk #0xF000 (__debugbreak) is
+        // a breakpoint to the arm64 kernel; every other immediate is this.
+        (["trap", /Illegal instruction at address 0x[0-9A-F]{6,}/, 0x1d] as const)
+      : // STATUS_BREAKPOINT 0x80000003
+        (["trap", /Trap instruction at address 0x[0-9A-F]{6,}/, 0x03] as const);
 
-  test.concurrent("abort() produces a crash report", async () => {
-    let sent = false;
-    const acked = Promise.withResolvers<void>();
-    using server = Bun.serve({
-      port: 0,
-      fetch(request) {
-        expect(request.url).toEndWith("/ack");
-        sent = true;
-        acked.resolve();
-        return new Response("OK");
-      },
-    });
-
-    // The `abort` hook is a real UCRT abort() from bun.exe's statically
-    // linked CRT, the same call a RELEASE_ASSERT makes.
+  test.concurrent.each([
+    // STATUS_STACK_BUFFER_OVERRUN 0xC0000409: what an unreported abort() exits with
+    ["abort", "panic(main thread): abort() called", 0x09] as const,
+    ["panic", "panic(main thread): invoked crashByPanic() handler", 0x09] as const,
+    ["outOfMemory", "Bun has run out of memory", 0x09] as const,
+    // STATUS_ACCESS_VIOLATION 0xC0000005
+    ["segfault", "Segmentation fault at address 0xDEADBEEF", 0x05] as const,
+    trapRow,
+  ])("%s is reported and exits with the crash's status", async (approach, message, exitCodeLowByte) => {
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
         path.join(import.meta.dir, "fixture-crash.js"),
-        "abort",
+        approach,
         "--debug-crash-handler-use-trace-string",
       ],
-      env: reportingEnv(server.url.toString()),
+      env: noReportEnv,
       stdio: ["ignore", "pipe", "pipe"],
     });
     const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
-    expect(stderr).toContain("panic(main thread): abort() called");
-    expect(stderr).toContain("oh no: Bun has crashed.");
-    expect(stderr).toContain(server.url.toString());
-    expect(exitCode).not.toBe(0);
-
-    await acked.promise;
-    expect(sent).toBe(true);
+    expect(stderr).toMatch(message);
+    expect(stderr).toContain("oh no");
+    expect(exitCode).toBe(exitCodeLowByte);
   });
 
-  // Terminations that must stay out of the new hook. process.abort() is a
-  // user action (_exit(134) on Windows); fastfail is a bare __fastfail, which
-  // never enters the CRT, so it still dies with the raw NTSTATUS 0xC0000409
-  // (low byte 9 as an exit code) that `bun test --parallel` classifies on.
+  // Terminations that must stay out of the crash handler. process.abort() is
+  // a user action (_exit(134) on Windows). fastfail is a bare __fastfail that
+  // never enters the CRT, so it still dies of the raw 0xC0000409 with nothing
+  // printed; that is the exit code the reported abort above shares with it.
   test.concurrent.each([
     ["process.abort()", 134],
-    ["crash_handler.fastfail()", 9],
+    ["crash_handler.fastfail()", 0x09],
   ] as const)("%s does not report a crash", async (code, expectedExitCode) => {
     let sent = false;
     using server = Bun.serve({
@@ -590,21 +589,27 @@ describe.if(isWindows)("Windows: UCRT abort() is caught by the crash handler", (
 
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", `const { crash_handler } = require("bun:internal-for-testing"); ${code}`],
-      env: reportingEnv(server.url.toString()),
+      env: mergeWindowEnvs([
+        bunEnv,
+        {
+          BUN_CRASH_REPORT_URL: server.url.toString(),
+          BUN_ENABLE_CRASH_REPORTING: "1",
+          GITHUB_ACTIONS: undefined,
+          CI: undefined,
+        },
+      ]),
       stdio: ["ignore", "pipe", "pipe"],
     });
     const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
-    expect(stderr).not.toContain("abort() called");
-    expect(stderr).not.toContain("Bun has crashed");
-    expect(stderr).not.toContain(server.url.toString());
+    expect(stderr).toBe("");
     expect(sent).toBe(false);
     expect(exitCode).toBe(expectedExitCode);
   });
 });
 
 describe("automatic crash reporter", () => {
-  for (const approach of ["panic", "segfault", "outOfMemory"]) {
+  for (const approach of ["panic", "segfault", "outOfMemory", "abort"]) {
     test(`${approach} should report`, async () => {
       let sent = false;
       const resolve_handler = Promise.withResolvers();

--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -258,11 +258,12 @@ test(
   isASAN || isDebug ? 60_000 : 20_000,
 );
 
-// POSIX classifies worker crashes as panics by fatal signal — see
-// is_panic_status. (On Windows a crash caught by Bun's crash handler exits
-// with code 3, indistinguishable from process.exit(3); the Windows
-// classification below works on raw NTSTATUS exit codes instead.)
-test.skipIf(isWindows)(
+// is_panic_status classifies worker crashes by fatal signal on POSIX and by
+// NTSTATUS exit code on Windows. A crash that went through Bun's crash
+// handler must classify too: the handler re-raises the signal on POSIX and
+// exits with the fault's own status on Windows (it used to exit 3 there,
+// indistinguishable from process.exit(3), so the run carried on).
+test(
   "--parallel --bail: a worker panic still prints the panic banner and stops sibling workers",
   async () => {
     using dir = tempDir("parallel-bail-panic", {
@@ -286,7 +287,9 @@ test.skipIf(isWindows)(
       stdout: "pipe",
     });
     const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toContain("a test worker process crashed with");
+    expect(stderr).toContain(
+      `a test worker process crashed with ${isWindows ? "exit code 0xC0000005" /* STATUS_ACCESS_VIOLATION */ : "SIGSEGV"}`,
+    );
     expect(stderr).toContain("Aborting");
     expect(exitCode).not.toBe(0);
   },
@@ -294,11 +297,11 @@ test.skipIf(isWindows)(
 );
 
 // Windows delivers no signals: a native fault that bypasses Bun's crash
-// handler (__fastfail: Rust aborts, /GS checks, abort() in an addon's own
-// CRT) terminates the worker with the raw NTSTATUS as its exit code. The
-// coordinator must recognize that as a crash and abort the run like the
-// fatal-signal path above, not narrow 0xC0000409 to "exit code 9" and carry
-// on as if the test had called process.exit(9).
+// handler entirely (__fastfail: Rust aborts, /GS checks, abort() in an
+// addon's own CRT) terminates the worker with the raw NTSTATUS as its exit
+// code. The coordinator must recognize that as a crash and abort the run like
+// the fatal-signal path above, not narrow 0xC0000409 to "exit code 9" and
+// carry on as if the test had called process.exit(9).
 test.skipIf(!isWindows)(
   "--parallel: a worker dying with a fatal NTSTATUS prints the crash banner and aborts",
   async () => {

--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -294,8 +294,8 @@ test.skipIf(isWindows)(
 );
 
 // Windows delivers no signals: a native fault that bypasses Bun's crash
-// handler (__fastfail — UCRT abort(), Rust aborts in addons, /GS checks)
-// terminates the worker with the raw NTSTATUS as its exit code. The
+// handler (__fastfail: Rust aborts, /GS checks, abort() in an addon's own
+// CRT) terminates the worker with the raw NTSTATUS as its exit code. The
 // coordinator must recognize that as a crash and abort the run like the
 // fatal-signal path above, not narrow 0xC0000409 to "exit code 9" and carry
 // on as if the test had called process.exit(9).

--- a/test/napi/node-napi-tests/test/common/index.js
+++ b/test/napi/node-napi-tests/test/common/index.js
@@ -699,7 +699,9 @@ function nodeProcessAborted(exitCode, signal) {
   // (ii) Otherwise, _exit(134) which is called in place of abort() due to
   // raising SIGABRT exiting with ambiguous exit code '3' by default
   if (isWindows)
-    expectedExitCodes = [0x80000003, 134, 3]; // BUN: crash handler calls std.posix.abort() resulting in code 3
+    // BUN: the crash handler exits with STATUS_STACK_BUFFER_OVERRUN (0xC0000409) for a
+    // panic, and spawnSync reports the low byte of a Windows exit code, so 9.
+    expectedExitCodes = [0x80000003, 134, 9];
 
   // When using --abort-on-uncaught-exception, V8 will use
   // base::OS::Abort to terminate the process.

--- a/test/regression/issue/30205.test.ts
+++ b/test/regression/issue/30205.test.ts
@@ -147,9 +147,8 @@ describe.skipIf(!canBuildNodeAddons())("#30205", () => {
   // here rather than inducing a real @panic so the test doesn't depend on
   // JIT fault-handler behaviour; from the coordinator's point of view
   // SIGABRT is indistinguishable from a JSC assertion failure. Windows has
-  // no process.kill() signals, and the panic-signal classification is
-  // POSIX-specific anyway (Windows abort() surfaces as exit code 3 and
-  // falls into the non-panic branch below).
+  // no process.kill() signals; its exit-status classification is covered in
+  // test/cli/test/parallel.test.ts.
   test.skipIf(isWindows)(
     "--parallel: worker killed by a fatal signal aborts the run instead of retrying",
     async () => {


### PR DESCRIPTION
### Problem

- On Windows, every `abort()` inside bun.exe kills the process with exit code `0xC0000409` and prints nothing: no `Bun has crashed` banner, no bun.report trace string. WTF `RELEASE_ASSERT` / `CRASH()` compiles to `std::abort()` in release builds off Darwin (`vendor/WebKit/Source/WTF/wtf/Assertions.h:353`), so this covers every JSC and Bun C++ assertion, plus aborts in mimalloc, BoringSSL and libuv. POSIX has reported these since #34771.
- Repro on canary `1.4.0-canary.1+a5c86aec7`, Windows Server 2019 x64: the `process.env` snippet from #38821 exits `0xC0000409`; stderr holds only JSC's own `dataLog` line. With the `abort` test hook calling a real `abort()` (below), stderr is empty.
- Cause: UCRT `abort()` (`ucrt/startup/abort.cpp`) calls `raise(SIGABRT)` only if a CRT-level SIGABRT handler is installed, otherwise it `__fastfail`s. A fast-fail is not an exception, so the vectored handler and unhandled-exception filter that `init()` installs in `src/crash_handler/lib.rs` never run. Bun never installed a CRT SIGABRT handler.
- Two adjacent gaps found while fixing it:
  - x64 `int3` (JSC JIT `abortWithReason()`, LLInt `break`, `__debugbreak`) raises `EXCEPTION_BREAKPOINT`, which `classify_exception_windows` did not know, so those died silently too (exit `0x80000003`). The POSIX fix caught SIGABRT and SIGTRAP together; this is its Windows twin.
  - After printing a report, `crash()` ended every Windows crash in `ExitProcess(3)`, which a parent cannot tell from `process.exit(3)`. `bun test --parallel` classifies worker deaths by exit status (`Coordinator.rs`, `is_fatal_windows_exit_code`), so reporting an abort would have turned a run-aborting `0xC0000409` worker death (#37129) into a per-file failure.

### Fix

- `init()` installs a CRT SIGABRT handler (`signal(SIGABRT, handle_abort_windows)`) that enters `crash_handler(CrashReason::Abort, ..)`, the same entry point the POSIX SIGABRT handler uses. It is removed wherever the VEH is: `reset_segfault_handler()` after a report, and `raise_ignoring_panic_handler_raw()` (`bun run` re-raising a child's signal; UCRT `raise(6)` maps onto the same slot, so without that reset a forwarded SIGABRT would print a bogus Bun report). `_set_abort_behavior(0, _WRITE_ABORT_MSG)` stops the debug UCRT from showing its own `abort() has been called` message first; the release UCRT never sets that flag.
- `classify_exception_windows` maps `EXCEPTION_BREAKPOINT` to `CrashReason::Trap`. It goes through the same out-of-image rule as every other code in the VEH (JIT-pool traps reach the handler through JSC's unwind-info route from #35083), and an attached debugger consumes breakpoints before any handler runs. WTF's own VEH (`SignalsWin.cpp`) only recovers access violations, illegal instructions and FP exceptions, never breakpoints.
- `crash()` exits with `CrashReason::terminal_exit_code()`, the Windows counterpart of `terminal_signal()`: the exception's own status for faults (`0xC0000005`, `0xC000001D`, `0xC00000FD`, `0x80000002`, `0x80000003`), `STATUS_STACK_BUFFER_OVERRUN` (`0xC0000409`, what an unreported abort or Rust abort exits with) for the abort/panic/OOM bucket. Parents therefore see the same status with or without a report; the coordinator's allowlist gains `0x80000002`, the one classified code it lacked. The debug-build `int3` before `ExitProcess` now only runs when a debugger is attached; unconditionally it terminated the process with `0x80000003` before the exit code was reached.
- Why the hook is correct: the CRT signal slot is the only hook UCRT `abort()` has and it is consulted before the fast-fail (verified against the UCRT source in the Windows SDK and with a `/MT` probe, below); UCRT `raise()` resets the slot to `SIG_DFL` before calling the handler, so an abort during the report fast-fails instead of recursing (one-shot, like `SA_RESETHAND`); nothing else in bun uses the slot (`process.on("SIGABRT")` is libuv, `process.abort()` is `_exit(134)` on Windows, Rust aborts and the `fastfail` hook are bare `__fastfail`s), and the tests pin all three staying unreported. bun.exe links the UCRT statically, so only `abort()` calls that resolve to bun.exe's CRT (JSC/WTF, Bun, vendored deps) are caught; an addon linked against ucrtbase.dll still fast-fails and still classifies as before.
- arm64 Windows finding (probed on a Windows 11 arm64 machine): the kernel reports a `brk` with any immediate it does not define, including WTF's `0xbb08` that JSC emits everywhere, as `STATUS_ILLEGAL_INSTRUCTION`; only `brk #0xF000` (`__debugbreak`) is a breakpoint. So JSC traps on arm64 were already reported as illegal instructions; the silent-trap gap was x64. Documented on `CrashReason::Trap`, and the Windows test expects per architecture.
- Test hooks: `crash_handler.abort()` and `.trap()` now execute the real `abort()` / `int3` / `brk #0xbb08` on Windows instead of calling the handler directly (which is what hid this); `raiseIgnoringPanicHandler()` takes an optional signal.
- Tests:
  - `test/cli/run/run-crash-handler.test.ts`: a `describe.if(isWindows)` matrix asserting banner text and exit status for `abort`, `panic`, `outOfMemory` (9, the low byte of `0xC0000409` as `Bun.spawn` reports it), `segfault` (5) and `trap` (3 on x64, 0x1D on arm64, with a real fault address); `process.abort()` (134) and `fastfail()` (9) print nothing; `abort` added to the upload loop; the `raise ignoring panic handler` test now covers SIGSEGV and SIGABRT on every platform.
  - `test/cli/test/parallel.test.ts`: the worker-segfault case runs on Windows too and asserts the coordinator sees `exit code 0xC0000005` and aborts the run.
  - `test/napi/node-napi-tests/test/common/index.js`: the Windows abort exit-code list moves from 3 to 9 (verified: `spawnSync` of a panicking bun reports `status: 9` on Windows).
- Verification:
  - Windows Server 2019 x64 debug build with `src/crash_handler/lib.rs` and `src/bun_core/Global.rs` reverted: the abort test fails with `Received: ""`, everything else passes. Full branch: `run-crash-handler.test.ts` 19 pass / 0 fail, `parallel.test.ts` crash cases 6 pass, `crash-report-command-char.test.ts` 3 pass.
  - Linux x64 `bun bd` (ASAN): `run-crash-handler.test.ts` 19 pass / 16 skip, `parallel.test.ts` crash cases 6 pass, `30205.test.ts` 4 pass.
  - `cargo check` of `bun_crash_handler`, `bun_core`, `bun_sys` for `x86_64-` and `aarch64-pc-windows-msvc` clean; `cargo fmt --check`, prettier clean. Deliberately left out, as follow-up material: classifying `IN_PAGE_ERROR` / integer-divide / privileged-instruction exceptions (the SIGBUS/SIGFPE analogs).
  - The discriminating tests are Windows-only, so the automated fail-before check cannot observe them on Linux; the reverted-files run above is that proof, and the Windows CI lanes run them with the fix.

### Background

- CRT signals: the Microsoft C runtime emulates a few POSIX signals in user space. `signal()` stores a function pointer in a CRT-global slot; `raise()` resets the slot and calls it synchronously on the calling thread; `SIG_DFL` is `_exit(3)`. Unrelated to libuv's `uv_signal`, which is what `process.on(signal)` uses on Windows.
- `__fastfail`: an `int 0x29` that makes the kernel terminate the process at once with `0xC0000409`, skipping all user-mode exception dispatch (VEH, SEH, unhandled-exception filter). It is how UCRT `abort()` and Rust's `std::process::abort()` end a process on Windows.
- VEH / UEF: `AddVectoredExceptionHandler` and `SetUnhandledExceptionFilter`, the hooks the crash handler already had. They only see exceptions, so faults were reported and aborts were not; `EXCEPTION_BREAKPOINT` is an exception they did see but did not classify.
- Exit status on Windows: a process killed by an unhandled exception exits with that exception's NTSTATUS as its exit code; that is what `bun test --parallel` and bun's CI runner classify on, and what `terminal_exit_code()` reproduces. Bun's `Bun.spawn` / `child_process` currently expose only the low byte of it (hence 9, 5, 3 in the tests); the coordinator reads the full value.

<details>
<summary>UCRT abort(), probes, and fail-before output</summary>

`ucrt/startup/abort.cpp` (Windows SDK 10.0.26100):

```cpp
__crt_signal_handler_t const sigabrt_action = __acrt_get_sigabrt_handler();
if (sigabrt_action != SIG_DFL)
    raise(SIGABRT);
if (__abort_behavior & _CALL_REPORTFAULT)      // release default
    __fastfail(FAST_FAIL_FATAL_APP_EXIT);
_exit(3);                                      // debug default (_WRITE_ABORT_MSG only)
```

`ucrt/misc/signal.cpp` `raise()`: `SIGABRT` and `SIGABRT_COMPAT` (6) share one action; `SIG_DFL` is `_exit(3)`; the action is set back to `SIG_DFL` before the user handler is called.

x64 probe (`clang-cl`, `abort()` / `raise(6)` with and without a `signal(SIGABRT, h)` that `_exit(77)`s):

```
release /MT   abort(), no handler      -> exit 0xC0000409, nothing printed
release /MT   abort(), handler         -> handler ran (sig=22), exit 77
release /MT   raise(6), SIG_DFL        -> exit 3
release /MT   raise(6), handler        -> handler ran (sig=6), exit 77
debug   /MTd  abort(), no handler      -> exit 3, nothing printed
debug   /MTd  abort(), handler         -> handler ran (sig=22), exit 77
```

arm64 probe (Windows 11 arm64, VEH printing the exception code):

```
brk #0        -> 0xC000001D STATUS_ILLEGAL_INSTRUCTION
brk #1        -> 0xC000001D
brk #0xbb08   -> 0xC000001D   (WTF_FATAL_CRASH_CODE: JIT abortWithReason, LLInt break, WTF_FATAL_CRASH_INST)
brk #0xF000   -> 0x80000003 STATUS_BREAKPOINT   (__debugbreak)
brk #0xF001   -> 0xC0000420 STATUS_ASSERTION_FAILURE
```

Canary `1.4.0-canary.1+a5c86aec7` on Windows Server 2019 running the #38821 snippet:

```
exit: 0xC0000409
stdout: (empty)
stderr: Static hashtable initialiation for env did not produce a property.
```

Fail-before (this branch minus `lib.rs` / `Global.rs`), debug build, Windows Server 2019:

```
error: expect(received).toContain(expected)
Expected to contain: "panic(main thread): abort() called"
Received: ""
(fail) ... abort() produces a crash report
```

Full branch, same machine: `run-crash-handler.test.ts` 19 pass / 16 skip / 0 fail; `parallel.test.ts` prints `a test worker process crashed with exit code 0xC0000005` and `Aborting` for a worker that went through the crash handler; `spawnSync` of a panicking child reports `status: 9`.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/run-crash-handler.test.ts test/cli/test/parallel.test.ts test/regression/issue/30205.test.ts

<!-- robobun:evidence:end -->