### PR TITLE
bundler: give the bundle thread a 16 MiB stack

### DIFF
--- a/src/bundler/BundleThread.rs
+++ b/src/bundler/BundleThread.rs
@@ -150,6 +150,9 @@ impl<C: CompletionStruct> BundleThread<C> {
         let ptr = SendPtr(instance);
         let thread = std::thread::Builder::new()
             .name("Bundler".into())
+            // The linker's per-edge graph walks recurse deeply; Rust's 2 MiB
+            // default is not enough (Zig's std.Thread default was 16 MiB).
+            .stack_size(16 * 1024 * 1024)
             .spawn(move || {
                 let ptr = ptr;
                 // SAFETY: caller guarantees `instance` is valid for 'static; `thread_main`

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -43,6 +43,24 @@ describe("Bun.build", () => {
     expect(await build.outputs[0].text()).toEqualIgnoringWhitespace(".hello{color:#00f}.hi{color:red}\n");
   });
 
+  test("css @import chain of 1000 files does not overflow the bundle thread stack", async () => {
+    const files: Record<string, string> = {};
+    const n = 1000;
+    for (let i = 0; i < n; i++) {
+      files[`c${i}.css`] = (i + 1 < n ? `@import "./c${i + 1}.css";\n` : "") + `.a${i} { color: red; }\n`;
+    }
+    const dir = tempDirWithFiles("bun-build-api-css-chain", files);
+
+    const build = await Bun.build({
+      entrypoints: [join(dir, "c0.css")],
+      write: false,
+    });
+
+    expect(build.success).toBe(true);
+    expect(build.outputs).toHaveLength(1);
+    expect(await build.outputs[0].text()).toContain(`.a${n - 1}`);
+  });
+
   test("bytecode works", async () => {
     const dir = tempDirWithFiles("bun-build-api-bytecode", {
       "package.json": `{}`,


### PR DESCRIPTION
### What does this PR do?

The thread that runs `Bun.build()` was spawned with Rust's default 2 MiB stack. The Zig version used `std.Thread`'s 16 MiB default, and the linker's graph walks (CSS `@import` order, export-star, chunk graph) still recurse per edge, so a `Bun.build()` on a long import chain now overflows where 1.3.14 didn't. The CLI path runs on the main thread and was unaffected. Every other long-lived thread already sets an explicit size (Debugger uses 16 MiB), this one was missed.

Out of scope: converting `find_imported_files_in_css_order` and the remaining walks to an explicit stack. On a debug+ASAN build a 3000-file chain still overflows at 16 MiB (release 1.3.14 handles it); that needs the DFS rewrite, not a bigger stack.

### How did you verify your code works?

Added a `Bun.build()` test with a 1000-file CSS `@import` chain. On main's debug build the same input dies with `AddressSanitizer: stack-overflow` in `find_imported_files_in_css_order::Visitor::visit`; with this change it builds (`bun bd test test/bundler/bun-build-api.test.ts -t "chain of 1000"`, 2.5s).
