### PR TITLE
build: pass --locked to cargo

### DIFF
--- a/scripts/build/rust.ts
+++ b/scripts/build/rust.ts
@@ -347,6 +347,7 @@ export function cargoBuildInvocation(cfg: Config): CargoInvocation {
     triple,
     "--profile",
     profile.name,
+    "--locked",
   ];
   if (tier3 || cfg.release || cfg.asan) {
     // Build std/core/alloc from source instead of linking the rustup prebuilt.
@@ -760,6 +761,7 @@ export function emitRust(n: Ninja, cfg: Config, inputs: RustBuildInputs): string
       triple,
       "--profile",
       "shim",
+      "--locked",
       "-Zbuild-std=core,compiler_builtins",
       "-Zbuild-std-features=compiler-builtins-mem",
     ];


### PR DESCRIPTION
### What does this PR do?

Passes `--locked` to the two `cargo build` invocations in `scripts/build/rust.ts` (the main `bun_bin` build and the Windows shim). `Cargo.lock` is committed, but without `--locked` cargo will silently re-resolve and rewrite it if a `Cargo.toml` edit leaves the two out of sync, so a release could link different crate versions than the ones checked in. With the flag that becomes a build error. The vendored helper build in `scripts/build/source.ts` already passed it.

### How did you verify your code works?

`bun bd -e 'console.log("ok")'` builds and runs with the flag; `--locked` shows up in the generated `build/debug/build.ninja` cargo edge. Not tested: a deliberately out-of-sync lockfile (would need to touch `Cargo.toml`), but that is cargo's documented behavior for `--locked`.
