### PR TITLE
test: un-todo the process.env string coercion test on POSIX

### DIFF
--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -996,21 +996,25 @@ for (const shell of ["system", "bun"]) {
   });
 }
 
-const todoOnPosix = process.platform !== "win32" ? test.todo : test;
-todoOnPosix("setting process.env coerces the value to a string", () => {
-  // @ts-expect-error
-  process.env.SET_TO_TRUE = true;
-  let did_call = 0;
-  // @ts-expect-error
-  process.env.SET_TO_BUN = {
-    toString() {
-      did_call++;
-      return "bun!";
-    },
-  };
-  expect(process.env.SET_TO_TRUE).toBe("true");
-  expect(process.env.SET_TO_BUN).toBe("bun!");
-  expect(did_call).toBe(1);
+test("setting process.env coerces the value to a string", () => {
+  try {
+    // @ts-expect-error
+    process.env.SET_TO_TRUE = true;
+    let did_call = 0;
+    // @ts-expect-error
+    process.env.SET_TO_BUN = {
+      toString() {
+        did_call++;
+        return "bun!";
+      },
+    };
+    expect(process.env.SET_TO_TRUE).toBe("true");
+    expect(process.env.SET_TO_BUN).toBe("bun!");
+    expect(did_call).toBe(1);
+  } finally {
+    delete process.env.SET_TO_TRUE;
+    delete process.env.SET_TO_BUN;
+  }
 });
 
 test.concurrent("NODE_ENV=test loads .env.test even when .env.production exists", async () => {


### PR DESCRIPTION
### Problem
- `test/cli/run/env.test.ts` declares `const todoOnPosix = process.platform !== "win32" ? test.todo : test;` and marks "setting process.env coerces the value to a string" as todo on Linux and macOS.
- The behavior it guards has worked on POSIX since #31831 made `process.env` an exotic object whose `put` runs ToString on the assigned value (`src/jsc/bindings/JSEnvironmentVariableMap.cpp`, `JSEnvironmentVariableMap::put`). Windows already coerced through the `windowsEnv` Proxy `set` trap, which is why the test was only todo on POSIX.
- `bun test test/cli/run/env.test.ts --todo` therefore reports `(fail) setting process.env coerces the value to a string` with `this test is marked as todo but passes`, and in the default run the assertions are skipped on the platforms where the coercion code actually lives.

### Fix
- Declare the test with plain `test(...)` on every platform and drop the `todoOnPosix` indirection (it had no other user).
- The test mutates the real `process.env` of the test runner, so its body now runs in `try`/`finally` and deletes the two keys it adds. The assertions are unchanged.
- Why this is right: `test.todo` is for behavior that does not work yet; the coercion now works on every platform, so the test should run and fail if it regresses. REVIEW.md asks that `.todo` markers be removed once the behavior passes; #31831 landed the behavior but left this marker in place.
- Test-only change, nothing under `src/` is touched.
- Verified:
  - `bun bd test test/cli/run/env.test.ts`: 97 pass, 1 skip (Windows-only case), 1 todo ("src boundary", which still fails for its own reason), 0 fail. The un-todo'd test is among the passes.
  - `bun bd test test/cli/run/env.test.ts -t "setting process.env coerces the value to a string" --todo` fails on the file as it was on main (todo that passes) and passes with this change.
  - `USE_SYSTEM_BUN=1` (bun 1.4.0) gives the same before/after result.
- #34728 and #35264 also flip this marker, but as a side effect of `process.env` implementation changes written before #31831 merged; both now conflict with main. This PR is only the test cleanup.

### Background
- `bun test` does not run the body of a `test.todo` test by default; it just counts it as todo. With `--todo` it runs the body and reports a todo that passes as a failure, which is how a stale marker shows up.
- `process.env` on POSIX is `JSEnvironmentVariableMap`, a JSC object class that overrides `put` so `process.env.X = value` stores `String(value)` (and throws for symbols), matching Node's `process.env`. On Windows `process.env` is a Proxy (`windowsEnv` in `src/js/builtins/ProcessObjectInternals.ts`) whose `set` trap does the same coercion, which is why this test already ran there.

<details>
<summary>Before/after output</summary>

On main (`bun bd test test/cli/run/env.test.ts -t "setting process.env coerces the value to a string" --todo`):

```
(fail) setting process.env coerces the value to a string [8.03ms]
  ^ this test is marked as todo but passes. Remove `.todo` if tested behavior now works

 0 pass
 1 fail
```

With this change (same command):

```
(pass) setting process.env coerces the value to a string [6.04ms]

 1 pass
 0 fail
```

</details>
