### PR TITLE
install: keep the workspace: spelling given to bun add <member>@workspace:<range>

### DIFF
--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -1459,8 +1459,7 @@ pub(crate) fn edit(
                     arena_dup(arena, installed)
                 }
 
-                // Not `request.version`: on the root it is bound to the row the `workspaces` list
-                // creates for the member, whose literal is the member's path.
+                // Decided from the entry's text: on the root `request.version` is bound to the member's path.
                 resolution::Tag::Workspace => match dependency::Tag::infer(e_string.data.slice()) {
                     dependency::Tag::Workspace => e_string.data.slice(),
                     _ => b"workspace:*",

--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -1198,10 +1198,19 @@ pub(crate) fn edit(
                     bun_ast::Loc::EMPTY,
                 ));
 
+                // A replaced entry keeps the literal the before-install pass wrote until the write-back
+                // below decides what to save (the `workspace:` arm keeps it as typed).
+                let declared: &[u8] = match new_dependencies[k]
+                    .value
+                    .as_ref()
+                    .and_then(Expr::as_utf8_string_literal)
+                {
+                    Some(literal) => arena_dup(arena, literal),
+                    None => b"",
+                };
                 new_dependencies[k].value = Some(Expr::allocate(
                     arena,
-                    // we set it later
-                    E::EString::init(b""),
+                    E::EString::init(declared),
                     bun_ast::Loc::EMPTY,
                 ));
 
@@ -1451,7 +1460,15 @@ pub(crate) fn edit(
                     arena_dup(arena, installed)
                 }
 
-                resolution::Tag::Workspace => b"workspace:*",
+                // `<member>@workspace:^` (or `~`, or a version) is saved as typed since `bun pm pack`
+                // derives the published range from the spelling; a member linked any other way
+                // (`<member>@1.0.0`, a folder path) is saved as `workspace:*`. `request.version` does
+                // not say which: on the root it is bound to the implicit row the `workspaces` list
+                // creates for the member, whose literal is the member's path.
+                resolution::Tag::Workspace => match dependency::Tag::infer(e_string.data.slice()) {
+                    dependency::Tag::Workspace => e_string.data.slice(),
+                    _ => b"workspace:*",
+                },
                 _ => arena_dup(arena, request.version.literal.slice(request.version_buf())),
             };
             if e_string.data.slice() != new_literal {

--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -1198,8 +1198,7 @@ pub(crate) fn edit(
                     bun_ast::Loc::EMPTY,
                 ));
 
-                // A replaced entry keeps the literal the before-install pass wrote until the write-back
-                // below decides what to save (the `workspace:` arm keeps it as typed).
+                // Read by the `workspace:` arm of the write-back below; every other arm overwrites it.
                 let declared: &[u8] = match new_dependencies[k]
                     .value
                     .as_ref()
@@ -1460,10 +1459,7 @@ pub(crate) fn edit(
                     arena_dup(arena, installed)
                 }
 
-                // `<member>@workspace:^` (or `~`, or a version) is saved as typed since `bun pm pack`
-                // derives the published range from the spelling; a member linked any other way
-                // (`<member>@1.0.0`, a folder path) is saved as `workspace:*`. `request.version` does
-                // not say which: on the root it is bound to the implicit row the `workspaces` list
+                // Not `request.version`: on the root it is bound to the row the `workspaces` list
                 // creates for the member, whose literal is the member's path.
                 resolution::Tag::Workspace => match dependency::Tag::infer(e_string.data.slice()) {
                     dependency::Tag::Workspace => e_string.data.slice(),

--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -1459,7 +1459,7 @@ pub(crate) fn edit(
                     arena_dup(arena, installed)
                 }
 
-                // Decided from the entry's text: on the root `request.version` is bound to the member's path.
+                // Not the bound row: an unchanged resolution keeps the old lockfile row and its previous literal.
                 resolution::Tag::Workspace => match dependency::Tag::infer(e_string.data.slice()) {
                     dependency::Tag::Workspace => e_string.data.slice(),
                     _ => b"workspace:*",

--- a/test/cli/install/bun-update-lockfile-sync.test.ts
+++ b/test/cli/install/bun-update-lockfile-sync.test.ts
@@ -602,6 +602,75 @@ describe.concurrent("bun add", () => {
     await expectInSync(dir, ["", PKG1]);
   });
 
+  // The spelling decides what `bun pm pack` / `bun publish` replace the range with (`^1.0.0`, `~1.0.0`, `1.0.0`); it used to be saved as `workspace:*`.
+  test.each(["workspace:^", "workspace:~", "workspace:1.0.0", "workspace:^1.0.0"])(
+    "bun add <workspace>@%s keeps the spelling",
+    async literal => {
+      const dir = await setup(MONOREPO());
+      await run(dir, "add", `pkg1@${literal}`);
+      expect((await pkg(dir)).dependencies).toStrictEqual({ pkg1: literal });
+      expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual({ pkg1: literal });
+      await expectInSync(dir, ["", PKG1]);
+    },
+  );
+
+  test("bun add <workspace>@workspace:^ -d without a lockfile", async () => {
+    const dir = await setup(MONOREPO(), { install: false });
+    await run(dir, "add", "pkg1@workspace:^", "-d");
+    const manifest = await pkg(dir);
+    expect(manifest.dependencies).toBeUndefined();
+    expect(manifest.devDependencies).toStrictEqual({ pkg1: "workspace:^" });
+    expect((await lock(dir)).workspaces[""].devDependencies).toStrictEqual({ pkg1: "workspace:^" });
+    await expectInSync(dir, ["", PKG1]);
+  });
+
+  test("bun add <workspace>@workspace:~ from another member", async () => {
+    const dir = await setup(WORKSPACES({}, { pkg1: {}, pkg2: {} }));
+    await runIn(dir, PKG2, "add", "pkg1@workspace:~");
+    expect((await pkg(dir, PKG2)).dependencies).toStrictEqual({ pkg1: "workspace:~" });
+    expect((await lock(dir)).workspaces[PKG2].dependencies).toStrictEqual({ pkg1: "workspace:~" });
+    expect((await pkg(dir)).dependencies).toBeUndefined();
+    await expectInSync(dir, ["", PKG1, PKG2]);
+  });
+
+  test("bun add <workspace>@workspace:~ replaces the existing entry", async () => {
+    const dir = await setup(MONOREPO({}, { dependencies: { pkg1: "workspace:*" } }));
+    await run(dir, "add", "pkg1@workspace:~");
+    expect((await pkg(dir)).dependencies).toStrictEqual({ pkg1: "workspace:~" });
+    expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual({ pkg1: "workspace:~" });
+    await expectInSync(dir, ["", PKG1]);
+  });
+
+  test("bun add <workspace>@workspace:^ rewrites an entry listed in devDependencies in place", async () => {
+    const dir = await setup(MONOREPO({}, { devDependencies: { pkg1: "workspace:*" } }));
+    await run(dir, "add", "pkg1@workspace:^");
+    const manifest = await pkg(dir);
+    expect(manifest.dependencies).toBeUndefined();
+    expect(manifest.devDependencies).toStrictEqual({ pkg1: "workspace:^" });
+    expect((await lock(dir)).workspaces[""].devDependencies).toStrictEqual({ pkg1: "workspace:^" });
+    await expectInSync(dir, ["", PKG1]);
+  });
+
+  test("bun add <workspace>@workspace:^ --filter keeps the spelling in every target", async () => {
+    const dir = await setup(WORKSPACES({}, { pkg1: {}, pkg2: {} }));
+    await run(dir, "add", "pkg1@workspace:^", "--filter", "pkg2", "--filter", "root");
+    expect((await pkg(dir)).dependencies).toStrictEqual({ pkg1: "workspace:^" });
+    expect((await pkg(dir, PKG2)).dependencies).toStrictEqual({ pkg1: "workspace:^" });
+    const { workspaces } = await lock(dir);
+    expect(workspaces[""].dependencies).toStrictEqual({ pkg1: "workspace:^" });
+    expect(workspaces[PKG2].dependencies).toStrictEqual({ pkg1: "workspace:^" });
+    await expectInSync(dir, ["", PKG1, PKG2]);
+  });
+
+  // A member linked through a plain range is still saved as `workspace:*`.
+  test.each(["1.0.0", "^1.0.0"])("bun add <workspace>@%s saves workspace:*", async range => {
+    const dir = await setup(MONOREPO());
+    await run(dir, "add", `pkg1@${range}`);
+    expect((await pkg(dir)).dependencies).toStrictEqual({ pkg1: "workspace:*" });
+    expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual({ pkg1: "workspace:*" });
+    await expectInSync(dir, ["", PKG1]);
+  });
+
   test("bun add --filter", async () => {
     const dir = await setup(MONOREPO());
     await run(dir, "add", "x@npm:no-deps@latest", "--filter", "pkg1");

--- a/test/cli/install/bun-update-lockfile-sync.test.ts
+++ b/test/cli/install/bun-update-lockfile-sync.test.ts
@@ -633,13 +633,17 @@ describe.concurrent("bun add", () => {
     await expectInSync(dir, ["", PKG1, PKG2]);
   });
 
-  test("bun add <workspace>@workspace:~ replaces the existing entry", async () => {
-    const dir = await setup(MONOREPO({}, { dependencies: { pkg1: "workspace:*" } }));
-    await run(dir, "add", "pkg1@workspace:~");
-    expect((await pkg(dir)).dependencies).toStrictEqual({ pkg1: "workspace:~" });
-    expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual({ pkg1: "workspace:~" });
-    await expectInSync(dir, ["", PKG1]);
-  });
+  // The member resolves the same as before, so the install keeps bun.lock's old row; the entry must still take the new spelling.
+  test.each(["workspace:*", "1.0.0"])(
+    "bun add <workspace>@workspace:~ replaces an existing %s entry",
+    async existing => {
+      const dir = await setup(MONOREPO({}, { dependencies: { pkg1: existing } }));
+      await run(dir, "add", "pkg1@workspace:~");
+      expect((await pkg(dir)).dependencies).toStrictEqual({ pkg1: "workspace:~" });
+      expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual({ pkg1: "workspace:~" });
+      await expectInSync(dir, ["", PKG1]);
+    },
+  );
 
   test("bun add <workspace>@workspace:^ rewrites an entry listed in devDependencies in place", async () => {
     const dir = await setup(MONOREPO({}, { devDependencies: { pkg1: "workspace:*" } }));


### PR DESCRIPTION
### Problem

- In a workspace, `bun add pkg1@workspace:^` (pkg1 being a member) installs fine ("installed pkg1@workspace:packages/pkg1") but writes `"pkg1": "workspace:*"` into package.json, and from there into bun.lock. Same for `workspace:~`, `workspace:1.0.0`, `workspace:^1.0.0`; from the root, from another member, and with `--filter`. The spelling matters: `bun pm pack` / `bun publish` turn `workspace:^` into `^1.0.0`, `workspace:~` into `~1.0.0` and `workspace:*` into `1.0.0` (docs/pm/workspaces.mdx), so the published range silently changes. pnpm and yarn keep the spelling as given. Found while checking pnpm parity; no issue is filed for it.
- Cause: the write-back `PackageJSONEditor::edit` runs after the install (src/install/PackageManager/PackageJSONEditor.rs, the `match` on the resolved package's resolution tag) has an unconditional `resolution::Tag::Workspace => b"workspace:*"` arm. It dates from #11241, which replaced the member's path that the generic arm used to write; at that point the arm had nothing better to write, because neither place that once held the typed spelling still does:
  - `request.version.literal` is the literal of the lockfile row the request was bound to, not the request. Between the two passes `Lockfile::bind_update_requests` binds the request to the first matching row of the workspace being edited. On the root that is today the implicit row created for each member of the `workspaces` list (literal `packages/pkg1`). And when the entry already existed, it is the row of the lockfile the install started with: `dependency::Version::eql` compares two workspace rows by the path they resolve to, so changing `workspace:*` (or a plain `1.0.0` that linked the member) to `workspace:~` is no diff, the old rows are kept, and the bound literal is the previous spelling. `sync_lockfile` corrects the rows from package.json only after this write-back has run.
  - The entry itself held it (the before-install pass wrote `workspace:^` there), but the after-install pass counts a bound request whose name already sits in the target group as `replacing` and rebuilds that property with an empty value (the `// we set it later` slot) before the `match` runs.

### Fix

- The rebuilt property starts out holding the literal the entry declared (after the install, that is what the before-install pass wrote, i.e. the request as typed) instead of `""`. Every arm of the write-back overwrites it except the new case below, so on its own this changes nothing; it only makes the declared text reachable where the decision is made. An entry that lives in another dependency group is edited in place and already held it.
- The workspace arm keeps the entry when its text uses the `workspace:` protocol (`dependency::Tag::infer(...) == Workspace`) and writes `workspace:*` otherwise.
- Why the entry's text and not the bound row: it is the only value that is the request as typed in every case above (fresh entry, entry in another group, entry that previously resolved to the same member, root or member, `--filter`). It is also safe to keep as is: the root's package.json containing exactly this literal is what the install just parsed and resolved. An arm reading `request.version.literal` instead was tried (with the binding fix from #38847 applied) and fails the two existing-entry tests below, writing the previous spelling back.
- Why `workspace:*` stays the fallback: `bun add pkg1@1.0.0`, `bun add pkg1@^1.0.0`, a folder path, or a bare name the registry cannot satisfy all link the member without saying so; their entry text is a range or a path, which `infer` does not classify as `Workspace`, so they are saved exactly as before. `bun add pkg1@workspace:*` still produces `workspace:*`.
- #38847 (open) is the `bun update <member>` side of the same arm (skips the write-back under `Subcommand::Update`, and stops binding to the root's implicit rows); this PR is the `bun add` side. The two touch adjacent lines of the `match` and compose in either order; this change does not depend on the binding fix. Until #38847 lands, `bun update <member>` on a `workspace:` entry incidentally keeps it too, which is the behavior #38847 tests.
- Tests, in the `bun add` block of test/cli/install/bun-update-lockfile-sync.test.ts: `workspace:^` / `~` / `1.0.0` / `^1.0.0` from the root, `-d` without a lockfile, from another member, replacing an existing `workspace:*` entry and an existing `1.0.0` entry (both keep bun.lock's old row through the install), an entry listed in devDependencies (the edit-in-place path), `--filter` targeting a member and the root, plus `pkg1@1.0.0` and `pkg1@^1.0.0` pinning `workspace:*`. The ten spelling tests fail on the unfixed build (package.json has `workspace:*`) and pass with the fix; each asserts package.json and bun.lock and reinstalls with `--frozen-lockfile`.
- Also run with the debug build: bun-update-lockfile-sync, bun-add, bun-add-filter, bun-add-catalog, bun-workspaces, bun-update, catalogs, all passing. `cargo clippy -p bun_install` is clean.

### Background

- `bun add` edits package.json in two passes around the install: `edit()` runs before it to put the requested literal in place (so the install resolves it) and again afterwards to replace that literal with what should be saved (`^1.2.3` for a dist-tag, the literal itself for git/folder/tarball, `workspace:*` for a workspace member). The second pass is where this change lives.
- An `UpdateRequest` is one CLI positional. After resolution, `bind_update_requests` attaches it to a dependency row of the workspace being edited, setting `package_id` (what it resolved to) and `version` (that row's literal and tag).
- When a lockfile exists, the install diffs the freshly parsed root against the lockfile's root and, if nothing differs, keeps the lockfile's rows as they are. Two workspace rows differ only if they resolve to different members, so a respelled entry is "no diff".
- `e_string` is the request's pointer at the string node of its package.json entry. In the after-install pass an entry already in the target group is rebuilt (re-keyed with the resolved name) and `e_string` points at the rebuilt node; an entry found in another group is pointed at directly.
- `dependency::Tag::infer` classifies a version literal by its text; any `workspace:` prefix is `Tag::Workspace`, a range like `1.0.0` is `Npm`, `./x` is `Folder`, an empty string is `DistTag`.
