### PR TITLE
types: add lockfileVersion 3 and the object form of overrides to BunLockFile

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -9808,12 +9808,26 @@ declare module "bun" {
    * The structure of Bun's lockfile, `bun.lock`
    */
   type BunLockFile = {
-    lockfileVersion: 0 | 1 | 2;
+    /**
+     * Version of the file format. A release of Bun that does not know a lockfile's version cannot read it.
+     *
+     * - `0`: workspace entries in {@link BunLockFile.packages} carry a trailing object with the workspace's dependencies.
+     * - `1`: workspace entries are `["name@workspace:path"]` only.
+     * - `2`: same content as `1`. Bun reads it more strictly, for example an npm package resolved to a tarball
+     *   outside the configured registry must carry an integrity hash.
+     * - `3`: {@link BunLockFile.overrides} holds nested or version-scoped rules, see {@link BunLockFileScopedOverrides}.
+     */
+    lockfileVersion: 0 | 1 | 2 | 3;
     workspaces: {
       [workspace: string]: BunLockFileWorkspacePackage;
     };
-    /** @see https://bun.com/docs/install/overrides */
-    overrides?: Record<string, string>;
+    /**
+     * A string value applies to every dependency on the package named by the key.
+     * An object value holds the rules scoped to the package selected by the key, see {@link BunLockFileScopedOverrides}.
+     *
+     * @see https://bun.com/docs/install/overrides
+     */
+    overrides?: Record<string, string | BunLockFileScopedOverrides>;
     /** @see https://bun.com/docs/install/patch */
     patchedDependencies?: Record<string, string>;
     /** @see https://bun.com/docs/install/lifecycle#trusteddependencies */
@@ -9852,6 +9866,28 @@ declare module "bun" {
       [pkg: string]: BunLockFilePackageArray;
     };
   };
+
+  /**
+   * The object form of a {@link BunLockFile.overrides} value. Bun writes it for the nested
+   * (`"parent": { "child": "1.0.0" }`, `"parent>child"`) and version-scoped (`"pkg@1"`) rules of
+   * `package.json`.
+   *
+   * The key in `overrides` selects the package these rules are scoped to, as `name` or `name@range`.
+   * Inside the object, `"."` is the rule for the selected package itself and every other key, again
+   * `name` or `name@range`, is the rule for that dependency of the selected package. Every value is a
+   * dependency specifier: rules nest one level deep only.
+   *
+   * @example
+   * ```jsonc
+   * "overrides": {
+   *   "no-deps": "1.0.0",
+   *   "no-deps@1": { ".": "1.1.0" },
+   *   "one-dep": { "no-deps": "2.0.0" },
+   *   "one-range-dep": { "no-deps": "1.0.1", "no-deps@1": "2.0.0" },
+   * }
+   * ```
+   */
+  type BunLockFileScopedOverrides = Record<string, string>;
 
   type BunLockFileBasePackageInfo = {
     dependencies?: Record<string, string>;

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -369,33 +369,101 @@ describe("@types/bun integration test", () => {
 
   // Runs on debug builds too: spawning tsc over a single file is cheap,
   // unlike the in-process LanguageService runs above.
+  async function tsc(checkDirName: string, fileName: string, source: string) {
+    const checkDir = join(TEMP_DIR, checkDirName);
+    const tsconfig = structuredClone(sourceTsconfig);
+    tsconfig.include = [fileName];
+    tsconfig.compilerOptions.typeRoots = [join(BASE_FIXTURE_DIR, "node_modules", "@types")];
+    await mkdir(checkDir, { recursive: true });
+    await makeTree(checkDir, {
+      "tsconfig.json": JSON.stringify(tsconfig, null, 2),
+      [fileName]: source,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(BASE_FIXTURE_DIR, "node_modules", "typescript", "bin", "tsc"), "-p", "."],
+      env: bunEnv,
+      cwd: checkDir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode };
+  }
+
   describe("Bun.mmap", () => {
     test("MMapOptions accepts offset and size", async () => {
-      const checkDir = join(TEMP_DIR, "mmap-options-check");
-      const tsconfig = structuredClone(sourceTsconfig);
-      tsconfig.include = ["mmap-options.ts"];
-      tsconfig.compilerOptions.typeRoots = [join(BASE_FIXTURE_DIR, "node_modules", "@types")];
-      await mkdir(checkDir, { recursive: true });
-      await makeTree(checkDir, {
-        "tsconfig.json": JSON.stringify(tsconfig, null, 2),
-        "mmap-options.ts": `const view = Bun.mmap("./data.bin", { shared: true, sync: false, offset: 4096, size: 1024 });
-           view satisfies Uint8Array<ArrayBuffer>;
-           Bun.mmap("./data.bin", { offset: 4096 }) satisfies Uint8Array<ArrayBuffer>;
-           Bun.mmap("./data.bin", { size: 1024 }) satisfies Uint8Array<ArrayBuffer>;`,
-      });
+      const { stdout, stderr, exitCode } = await tsc(
+        "mmap-options-check",
+        "mmap-options.ts",
+        `const view = Bun.mmap("./data.bin", { shared: true, sync: false, offset: 4096, size: 1024 });
+         view satisfies Uint8Array<ArrayBuffer>;
+         Bun.mmap("./data.bin", { offset: 4096 }) satisfies Uint8Array<ArrayBuffer>;
+         Bun.mmap("./data.bin", { size: 1024 }) satisfies Uint8Array<ArrayBuffer>;`,
+      );
 
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), join(BASE_FIXTURE_DIR, "node_modules", "typescript", "bin", "tsc"), "-p", "."],
-        env: bunEnv,
-        cwd: checkDir,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
+      expect(stderr).toBe("");
+      expect(stdout).toBe("");
+      expect(exitCode).toBe(0);
+    });
+  });
 
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  describe("BunLockFile", () => {
+    test("accepts lockfileVersion 3 and the object form of overrides", async () => {
+      // The overrides below are what bun install writes for nested and version-scoped
+      // rules (test/cli/install/nested-overrides.test.ts).
+      const { stdout, stderr, exitCode } = await tsc(
+        "bun-lock-check",
+        "bun-lock.ts",
+        `import type { BunLockFile, BunLockFileScopedOverrides } from "bun";
+         // No such file exists here: typed by the "*/bun.lock" module declaration in extensions.d.ts.
+         import imported from "./bun.lock";
 
-      expect(stderr.trim()).toBe("");
-      expect(stdout.trim()).toBe("");
+         ({
+           lockfileVersion: 3,
+           workspaces: { "": { name: "app", dependencies: { "one-dep": "1.0.0" } } },
+           overrides: {
+             "no-deps": "1.0.0",
+             "no-deps@1": { ".": "1.1.0" },
+             "one-dep": { "no-deps": "2.0.0" },
+             "one-range-dep": { "no-deps": "1.0.1", "no-deps@1": "2.0.0" },
+           },
+           packages: {},
+         }) satisfies BunLockFile;
+
+         ({ ".": "1.1.0", "no-deps@1": "2.0.0" }) satisfies BunLockFileScopedOverrides;
+
+         declare const parsed: BunLockFile;
+         if (parsed.lockfileVersion === 3) parsed.lockfileVersion satisfies 3;
+         if (imported.lockfileVersion === 3) imported.lockfileVersion satisfies 3;
+
+         for (const rule of Object.values(parsed.overrides ?? {})) {
+           if (typeof rule === "string") continue;
+           rule satisfies BunLockFileScopedOverrides;
+           for (const specifier of Object.values(rule)) specifier satisfies string;
+         }
+
+         ({
+           lockfileVersion: 3,
+           workspaces: {},
+           overrides: {
+             // @ts-expect-error rules nest one level deep only
+             "one-dep": { "no-deps": { ".": "2.0.0" } },
+           },
+           packages: {},
+         }) satisfies BunLockFile;
+
+         ({
+           // @ts-expect-error the union stays closed; bump this when bun.lock.rs gains a version
+           lockfileVersion: 4,
+           workspaces: {},
+           packages: {},
+         }) satisfies BunLockFile;`,
+      );
+
+      expect(stderr).toBe("");
+      expect(stdout).toBe("");
       expect(exitCode).toBe(0);
     });
   });

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -369,101 +369,106 @@ describe("@types/bun integration test", () => {
 
   // Runs on debug builds too: spawning tsc over a single file is cheap,
   // unlike the in-process LanguageService runs above.
-  async function tsc(checkDirName: string, fileName: string, source: string) {
-    const checkDir = join(TEMP_DIR, checkDirName);
-    const tsconfig = structuredClone(sourceTsconfig);
-    tsconfig.include = [fileName];
-    tsconfig.compilerOptions.typeRoots = [join(BASE_FIXTURE_DIR, "node_modules", "@types")];
-    await mkdir(checkDir, { recursive: true });
-    await makeTree(checkDir, {
-      "tsconfig.json": JSON.stringify(tsconfig, null, 2),
-      [fileName]: source,
-    });
-
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), join(BASE_FIXTURE_DIR, "node_modules", "typescript", "bin", "tsc"), "-p", "."],
-      env: bunEnv,
-      cwd: checkDir,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode };
-  }
-
   describe("Bun.mmap", () => {
     test("MMapOptions accepts offset and size", async () => {
-      const { stdout, stderr, exitCode } = await tsc(
-        "mmap-options-check",
-        "mmap-options.ts",
-        `const view = Bun.mmap("./data.bin", { shared: true, sync: false, offset: 4096, size: 1024 });
-         view satisfies Uint8Array<ArrayBuffer>;
-         Bun.mmap("./data.bin", { offset: 4096 }) satisfies Uint8Array<ArrayBuffer>;
-         Bun.mmap("./data.bin", { size: 1024 }) satisfies Uint8Array<ArrayBuffer>;`,
-      );
+      const checkDir = join(TEMP_DIR, "mmap-options-check");
+      const tsconfig = structuredClone(sourceTsconfig);
+      tsconfig.include = ["mmap-options.ts"];
+      tsconfig.compilerOptions.typeRoots = [join(BASE_FIXTURE_DIR, "node_modules", "@types")];
+      await mkdir(checkDir, { recursive: true });
+      await makeTree(checkDir, {
+        "tsconfig.json": JSON.stringify(tsconfig, null, 2),
+        "mmap-options.ts": `const view = Bun.mmap("./data.bin", { shared: true, sync: false, offset: 4096, size: 1024 });
+           view satisfies Uint8Array<ArrayBuffer>;
+           Bun.mmap("./data.bin", { offset: 4096 }) satisfies Uint8Array<ArrayBuffer>;
+           Bun.mmap("./data.bin", { size: 1024 }) satisfies Uint8Array<ArrayBuffer>;`,
+      });
 
-      expect(stderr).toBe("");
-      expect(stdout).toBe("");
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), join(BASE_FIXTURE_DIR, "node_modules", "typescript", "bin", "tsc"), "-p", "."],
+        env: bunEnv,
+        cwd: checkDir,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr.trim()).toBe("");
+      expect(stdout.trim()).toBe("");
       expect(exitCode).toBe(0);
     });
   });
 
   describe("BunLockFile", () => {
     test("accepts lockfileVersion 3 and the object form of overrides", async () => {
-      // The overrides below are what bun install writes for nested and version-scoped
-      // rules (test/cli/install/nested-overrides.test.ts).
-      const { stdout, stderr, exitCode } = await tsc(
-        "bun-lock-check",
-        "bun-lock.ts",
-        `import type { BunLockFile, BunLockFileScopedOverrides } from "bun";
-         // No such file exists here: typed by the "*/bun.lock" module declaration in extensions.d.ts.
-         import imported from "./bun.lock";
+      const checkDir = join(TEMP_DIR, "bun-lock-check");
+      const tsconfig = structuredClone(sourceTsconfig);
+      tsconfig.include = ["bun-lock.ts"];
+      tsconfig.compilerOptions.typeRoots = [join(BASE_FIXTURE_DIR, "node_modules", "@types")];
+      await mkdir(checkDir, { recursive: true });
+      await makeTree(checkDir, {
+        "tsconfig.json": JSON.stringify(tsconfig, null, 2),
+        // The overrides are what bun install writes for nested and version-scoped rules
+        // (test/cli/install/nested-overrides.test.ts). No bun.lock exists in checkDir: the
+        // import is typed by the "*/bun.lock" module declaration in extensions.d.ts.
+        "bun-lock.ts": `import type { BunLockFile, BunLockFileScopedOverrides } from "bun";
+           import imported from "./bun.lock";
 
-         ({
-           lockfileVersion: 3,
-           workspaces: { "": { name: "app", dependencies: { "one-dep": "1.0.0" } } },
-           overrides: {
-             "no-deps": "1.0.0",
-             "no-deps@1": { ".": "1.1.0" },
-             "one-dep": { "no-deps": "2.0.0" },
-             "one-range-dep": { "no-deps": "1.0.1", "no-deps@1": "2.0.0" },
-           },
-           packages: {},
-         }) satisfies BunLockFile;
+           ({
+             lockfileVersion: 3,
+             workspaces: { "": { name: "app", dependencies: { "one-dep": "1.0.0" } } },
+             overrides: {
+               "no-deps": "1.0.0",
+               "no-deps@1": { ".": "1.1.0" },
+               "one-dep": { "no-deps": "2.0.0" },
+               "one-range-dep": { "no-deps": "1.0.1", "no-deps@1": "2.0.0" },
+             },
+             packages: {},
+           }) satisfies BunLockFile;
 
-         ({ ".": "1.1.0", "no-deps@1": "2.0.0" }) satisfies BunLockFileScopedOverrides;
+           ({ ".": "1.1.0", "no-deps@1": "2.0.0" }) satisfies BunLockFileScopedOverrides;
 
-         declare const parsed: BunLockFile;
-         if (parsed.lockfileVersion === 3) parsed.lockfileVersion satisfies 3;
-         if (imported.lockfileVersion === 3) imported.lockfileVersion satisfies 3;
+           declare const parsed: BunLockFile;
+           if (parsed.lockfileVersion === 3) parsed.lockfileVersion satisfies 3;
+           if (imported.lockfileVersion === 3) imported.lockfileVersion satisfies 3;
 
-         for (const rule of Object.values(parsed.overrides ?? {})) {
-           if (typeof rule === "string") continue;
-           rule satisfies BunLockFileScopedOverrides;
-           for (const specifier of Object.values(rule)) specifier satisfies string;
-         }
+           for (const rule of Object.values(parsed.overrides ?? {})) {
+             if (typeof rule === "string") continue;
+             rule satisfies BunLockFileScopedOverrides;
+             for (const specifier of Object.values(rule)) specifier satisfies string;
+           }
 
-         ({
-           lockfileVersion: 3,
-           workspaces: {},
-           overrides: {
-             // @ts-expect-error rules nest one level deep only
-             "one-dep": { "no-deps": { ".": "2.0.0" } },
-           },
-           packages: {},
-         }) satisfies BunLockFile;
+           ({
+             lockfileVersion: 3,
+             workspaces: {},
+             overrides: {
+               // @ts-expect-error rules nest one level deep only
+               "one-dep": { "no-deps": { ".": "2.0.0" } },
+             },
+             packages: {},
+           }) satisfies BunLockFile;
 
-         ({
-           // @ts-expect-error the union stays closed; bump this when bun.lock.rs gains a version
-           lockfileVersion: 4,
-           workspaces: {},
-           packages: {},
-         }) satisfies BunLockFile;`,
-      );
+           ({
+             // @ts-expect-error lockfileVersion is a closed set of known versions, not number
+             lockfileVersion: 4,
+             workspaces: {},
+             packages: {},
+           }) satisfies BunLockFile;`,
+      });
 
-      expect(stderr).toBe("");
-      expect(stdout).toBe("");
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), join(BASE_FIXTURE_DIR, "node_modules", "typescript", "bin", "tsc"), "-p", "."],
+        env: bunEnv,
+        cwd: checkDir,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr.trim()).toBe("");
+      expect(stdout.trim()).toBe("");
       expect(exitCode).toBe(0);
     });
   });


### PR DESCRIPTION
### Problem
- `bun install` writes `"lockfileVersion": 3` and object-valued `overrides` entries since #38333 (nested and version-scoped overrides), for example `"one-dep": { "no-deps": "2.0.0" }` and `"no-deps@1": { ".": "1.1.0" }` (pinned by the inline snapshots in `test/cli/install/nested-overrides.test.ts`).
- `BunLockFile` in `packages/bun-types/bun.d.ts` still declares `lockfileVersion: 0 | 1 | 2` (line 9811) and `overrides?: Record<string, string>` (line 9816). #31539 added `| 2` when version 2 was introduced; #38333 did not update the type for version 3.
- Typing such a file as `BunLockFile`, whether through a cast or through `import lock from "./bun.lock"` (typed by `extensions.d.ts`), fails to compile: `lock.lockfileVersion === 3` is `TS2367: This comparison appears to be unintentional because the types '0 | 1 | 2' and '3' have no overlap`, and each object value is `TS2322: Type '{ ".": string; }' is not assignable to type 'string'`.
- Version 3 has not shipped in a release yet, so this is catching the published types up before the `@types/bun` that ships with it. Types only, no runtime change.

### Fix
- `lockfileVersion` becomes `0 | 1 | 2 | 3`, with a JSDoc line per version. The versions are the `Version` enum in `src/install/lockfile/bun.lock.rs` (`V3` is `Version::CURRENT`).
- `overrides` values become `string | BunLockFileScopedOverrides`, a new `Record<string, string>` alias whose JSDoc explains the `name` / `name@range` keys and the `"."` entry. This is exactly what the writer emits (`write_override_rules` in `bun.lock.rs`) and what the parser accepts (the `overrides` loop in `parse_into_binary_lockfile`: a value is a string, or an object whose values are all strings), so the alias is as wide as the format and no wider. The object's values are plain `string` like the sibling `Record<string, string>` fields, so `Object.entries` on one keeps yielding strings.
- The object form is deliberately not tied to `lockfileVersion === 3` (no discriminated union): `Stringifier::version_to_write` keeps a lockfile at version 1 when one of its packages fails the version 2 checks and still writes the override objects, and the parser reads the objects at every version. A union keyed on the version would reject lockfiles Bun itself writes.
- Out of scope, tracked elsewhere: the `BunLockFilePackageArray` tuples also lag the writer (a tarball entry may carry a trailing integrity string, a git or github entry may carry one as a fourth element), so a lockfile with such a dependency still needs the tuple changes in #34204 to type-check as a whole. That PR rewrites the tuple union; this one only touches the two fields above and adds `BunLockFileScopedOverrides`, so the two do not overlap.
- Verified with `test/integration/bun-types/bun-types.test.ts`, new case "BunLockFile accepts lockfileVersion 3 and the object form of overrides". It spawns `tsc` over a file that assigns the shapes above to `BunLockFile`, compares `lockfileVersion === 3` on both a `BunLockFile` value and a `./bun.lock` import, narrows an override value to the object form, and pins with `@ts-expect-error` that two-level nesting and a version outside the union are still rejected. Without the `bun.d.ts` change it fails with 9 diagnostics (the two quoted above plus `TS2305` for the missing alias); with it the file type-checks cleanly.
  - `USE_SYSTEM_BUN=1 bun test test/integration/bun-types/bun-types.test.ts`: 16 pass (the fixture-based cases under every lib configuration still pass with the widened type). This is also what the `bun-types` GitHub workflow runs; that check is green on this PR.
  - `bun bd test test/integration/bun-types/bun-types.test.ts`: 4 pass, 12 skipped (the skipped ones are the release-only LanguageService cases; the new case runs on debug builds too).
- The case is added as a sibling of the existing `Bun.mmap` spawned-`tsc` case rather than by extracting a shared helper: several open types PRs already rewrite that block in different ways, so this PR leaves it untouched.

### Background
- `bun.lock` is a JSONC file whose first key, `lockfileVersion`, gates compatibility: a Bun release that does not know the number refuses the file. Versions 1, 2 and 3 share the same content layout; 2 only turns on stricter parse checks, and 3 marks that `overrides` carries scoped rules.
- Overrides normally map a package name to the specifier every dependency on it must use. Nested (`"parent": { "child": "..." }`, `"parent>child"`) and version-scoped (`"pkg@1"`) rules apply to one parent's dependency, or only to dependents declaring a matching range. In `bun.lock` every such rule is normalized to one object per selector (`name` or `name@range`); inside it, `"."` is the rule for the selected package itself and any other key is the rule for that dependency of it. Bun supports one level of nesting, so the object's values are always strings.
- `bun-types.test.ts` is excluded from the BuildKite test lanes and runs in the `bun-types` GitHub workflow instead (triggered by changes under `packages/bun-types` and this test directory). Its fixture-based cases drive the TypeScript LanguageService in-process and are skipped on debug builds; spawning `tsc` over one file is the pattern the file already uses for a case that also has to run there.

<details>
<summary>Earlier revision</summary>

The first push extracted the `Bun.mmap` case's `tsc` spawning into a helper shared with the new case. That was dropped in favor of an additive block (see the last Fix bullet); the `bun.d.ts` change is unchanged.

</details>
