### PR TITLE
install: load root and workspace dependencies from bun.lock the way package.json parses them

### DIFF
--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -3051,10 +3051,6 @@ pub(crate) fn parse_into_binary_lockfile(
             .resize(lockfile.buffers.dependencies.len(), invalid_package_id);
         lockfile.buffers.resolutions.fill(invalid_package_id);
 
-        // a package can list the same dependency in each dependnecy group, but only the first
-        // is chosen (dev -> optional -> prod -> peer)
-        let mut seen_deps: bun_collections::StringArrayHashMap<()> = Default::default();
-
         // The two `[0]` writes are done first via
         // sequential `&mut` accessors so the loops can take all column views
         // immutably without overlapping exclusive borrows or `unsafe`.
@@ -3065,6 +3061,7 @@ pub(crate) fn parse_into_binary_lockfile(
         let pkgs = lockfile.packages.slice();
         let pkg_deps = pkgs.items_dependencies();
         let pkg_names = pkgs.items_name();
+        let pkg_name_hashes: &[PackageNameHash] = pkgs.items_name_hash();
         let pkg_resolutions: &[Resolution] = pkgs.items_resolution();
 
         // Populated by `append_package_dedupe` while the packages object was
@@ -3073,6 +3070,10 @@ pub(crate) fn parse_into_binary_lockfile(
         let package_index = &lockfile.package_index;
         let overrides = &lockfile.overrides;
         let catalogs: &CatalogMap = &lockfile.catalogs;
+        let workspace_versions: &VersionHashMap = &lockfile.workspace_versions;
+        let link_workspace_packages = manager
+            .as_deref()
+            .is_none_or(|manager| manager.options.link_workspace_packages);
 
         // Disjoint-field split of `lockfile.buffers` so each loop body can hold
         // `&mut dependencies[i]` and `&mut resolutions[i]` together with a shared
@@ -3081,6 +3082,16 @@ pub(crate) fn parse_into_binary_lockfile(
         let string_buf: &[u8] = buffers.string_bytes.as_slice();
         let dependencies: &mut [Dependency] = buffers.dependencies.as_mut_slice();
         let resolutions: &mut [PackageID] = buffers.resolutions.as_mut_slice();
+
+        let workspace_links = WorkspaceLinks {
+            pkg_names,
+            pkg_name_hashes,
+            workspace_versions,
+            catalogs,
+            overrides,
+            string_buf,
+            link_workspace_packages,
+        };
 
         {
             // first the root dependencies are resolved
@@ -3113,22 +3124,14 @@ pub(crate) fn parse_into_binary_lockfile(
                     return Err(ParseError::InvalidPackageInfo);
                 };
 
-                if !dep.behavior.is_workspace()
-                    && seen_deps
-                        .get_or_put(dep.name.slice(string_buf))?
-                        .found_existing
-                {
-                    resolutions[dep_id as usize] = res_id;
-                    continue;
-                }
-
-                map_dep_to_pkg(
+                map_manifest_dep_to_pkg(
                     dep,
                     dep_id,
                     res_id,
                     resolutions,
                     lockfile_version,
                     pkg_resolutions,
+                    &workspace_links,
                 );
             }
         }
@@ -3140,8 +3143,6 @@ pub(crate) fn parse_into_binary_lockfile(
             for _pkg_id in workspace_pkgs_off..workspace_pkgs_off + workspace_pkgs_len {
                 let pkg_id: PackageID = _pkg_id;
                 let workspace_name = pkg_names[pkg_id as usize].slice(string_buf);
-
-                seen_deps.clear_retaining_capacity();
 
                 let deps = pkg_deps[pkg_id as usize];
                 for _dep_id in deps.begin()..deps.end() {
@@ -3198,18 +3199,14 @@ pub(crate) fn parse_into_binary_lockfile(
                         return Err(ParseError::InvalidPackageInfo);
                     };
 
-                    if seen_deps.get_or_put(dep_name)?.found_existing {
-                        resolutions[dep_id as usize] = res_id;
-                        continue;
-                    }
-
-                    map_dep_to_pkg(
+                    map_manifest_dep_to_pkg(
                         dep,
                         dep_id,
                         res_id,
                         resolutions,
                         lockfile_version,
                         pkg_resolutions,
+                        &workspace_links,
                     );
                 }
             }
@@ -3450,16 +3447,7 @@ fn map_dep_to_pkg(
     if text_lockfile_version != Version::V0 {
         let res = &pkg_resolutions[pkg_id as usize];
         if res.tag == ResolutionTag::Workspace {
-            // Whole-struct assign so `DependencyVersion::Drop` frees any prior
-            // npm chain. SAFETY: `res.tag == Workspace` checked above.
-            let literal = dep.version.literal;
-            dep.version = DependencyVersion {
-                tag: DependencyVersionTag::Workspace,
-                literal,
-                value: DependencyVersionValue {
-                    workspace: *res.workspace(),
-                },
-            };
+            link_dep_to_workspace(dep, res);
         }
     }
 }
@@ -3467,6 +3455,103 @@ fn map_dep_to_pkg(
 /// Edges a fresh install may itself leave unresolved, so bun.lock lists them without a package.
 fn may_stay_unresolved(dep: &Dependency) -> bool {
     dep.behavior.intersects(Behavior::OPTIONAL | Behavior::PEER)
+}
+
+fn map_manifest_dep_to_pkg(
+    dep: &mut Dependency,
+    dep_id: DependencyID,
+    pkg_id: PackageID,
+    resolutions: &mut [PackageID],
+    text_lockfile_version: Version,
+    pkg_resolutions: &[Resolution],
+    workspace_links: &WorkspaceLinks<'_>,
+) {
+    resolutions[dep_id as usize] = pkg_id;
+
+    if text_lockfile_version == Version::V0 {
+        return;
+    }
+
+    let res = &pkg_resolutions[pkg_id as usize];
+    if res.tag == ResolutionTag::Workspace && workspace_links.links(dep, pkg_id) {
+        link_dep_to_workspace(dep, res);
+    }
+}
+
+struct WorkspaceLinks<'a> {
+    pkg_names: &'a [String],
+    pkg_name_hashes: &'a [PackageNameHash],
+    workspace_versions: &'a VersionHashMap,
+    catalogs: &'a CatalogMap,
+    overrides: &'a OverrideMap,
+    string_buf: &'a [u8],
+    link_workspace_packages: bool,
+}
+
+impl WorkspaceLinks<'_> {
+    /// Whether `Package::parse_dependency` links `dep` to the workspace `bun.lock`
+    /// bound it to, so that `Diff::generate` sees the loaded and the parsed
+    /// dependency as equal. With `linkWorkspacePackages` off it links no range, and
+    /// a range still bound to a workspace is loaded as linked on purpose: the diff
+    /// re-resolves it. Peers, overridden entries and dist-tags bind to a workspace
+    /// either way.
+    fn links(&self, dep: &Dependency, workspace_pkg_id: PackageID) -> bool {
+        if dep.version.tag == DependencyVersionTag::Workspace {
+            return true;
+        }
+
+        let range = if self.link_workspace_packages {
+            &dep.version
+        } else {
+            if dep.behavior.is_peer() || self.overridden(dep) {
+                return false;
+            }
+            self.catalogs.resolve_range(self.string_buf, dep)
+        };
+        if range.tag != DependencyVersionTag::Npm {
+            return false;
+        }
+
+        let npm = range.npm();
+        let workspace_pkg = workspace_pkg_id as usize;
+        // `workspace_versions` and a peer's binding are keyed by name hash; the
+        // names themselves have to match as well.
+        if !npm.name.eql(
+            self.pkg_names[workspace_pkg],
+            self.string_buf,
+            self.string_buf,
+        ) {
+            return false;
+        }
+
+        !self.link_workspace_packages
+            || self
+                .workspace_versions
+                .get(&self.pkg_name_hashes[workspace_pkg])
+                .is_some_and(|workspace_version| {
+                    npm.version
+                        .satisfies(*workspace_version, self.string_buf, self.string_buf)
+                })
+    }
+
+    /// Same exemption as `enqueue_dependency_with_main_and_success_fn`: an `npm:`
+    /// alias is never overridden.
+    fn overridden(&self, dep: &Dependency) -> bool {
+        let is_alias = dep.version.tag == DependencyVersionTag::Npm && dep.version.npm().is_alias;
+        !is_alias && self.overrides.has_rule_for_name(dep.name_hash)
+    }
+}
+
+fn link_dep_to_workspace(dep: &mut Dependency, res: &Resolution) {
+    // Whole-struct assign so `DependencyVersion::Drop` frees any prior npm chain.
+    let literal = dep.version.literal;
+    dep.version = DependencyVersion {
+        tag: DependencyVersionTag::Workspace,
+        literal,
+        value: DependencyVersionValue {
+            workspace: *res.workspace(),
+        },
+    };
 }
 
 fn dependency_resolution_failure(

--- a/test/cli/install/__snapshots__/bun-workspaces.test.ts.snap
+++ b/test/cli/install/__snapshots__/bun-workspaces.test.ts.snap
@@ -50,7 +50,10 @@ exports[`dependency on workspace without version in package.json: version: * 1`]
     {
       "name": "no-deps",
       "literal": "*",
-      "workspace": "packages/mono",
+      "npm": {
+        "name": "no-deps",
+        "version": ">=0.0.0"
+      },
       "package_id": 2,
       "behavior": {
         "prod": true
@@ -173,7 +176,10 @@ exports[`dependency on workspace without version in package.json: version: *.*.*
     {
       "name": "no-deps",
       "literal": "*.*.*",
-      "workspace": "packages/mono",
+      "npm": {
+        "name": "no-deps",
+        "version": ">=0.0.0"
+      },
       "package_id": 2,
       "behavior": {
         "prod": true
@@ -296,7 +302,10 @@ exports[`dependency on workspace without version in package.json: version: =* 1`
     {
       "name": "no-deps",
       "literal": "=*",
-      "workspace": "packages/mono",
+      "npm": {
+        "name": "no-deps",
+        "version": ">=0.0.0"
+      },
       "package_id": 2,
       "behavior": {
         "prod": true
@@ -419,7 +428,10 @@ exports[`dependency on workspace without version in package.json: version: kjwoe
     {
       "name": "no-deps",
       "literal": "kjwoehcojrgjoj",
-      "workspace": "packages/mono",
+      "dist_tag": {
+        "name": "no-deps",
+        "tag": "no-deps"
+      },
       "package_id": 2,
       "behavior": {
         "prod": true
@@ -542,7 +554,10 @@ exports[`dependency on workspace without version in package.json: version: *.1.*
     {
       "name": "no-deps",
       "literal": "*.1.*",
-      "workspace": "packages/mono",
+      "npm": {
+        "name": "no-deps",
+        "version": ">=0.0.0"
+      },
       "package_id": 2,
       "behavior": {
         "prod": true
@@ -665,7 +680,10 @@ exports[`dependency on workspace without version in package.json: version: *-pre
     {
       "name": "no-deps",
       "literal": "*-pre",
-      "workspace": "packages/mono",
+      "npm": {
+        "name": "no-deps",
+        "version": ">=0.0.0"
+      },
       "package_id": 2,
       "behavior": {
         "prod": true

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -2512,6 +2512,350 @@ test("matching workspace devDependency and npm peerDependency", async () => {
   expect(out).toContain("no changes");
 });
 
+// bun.lock stores a workspace's dependencies as the specifiers written in its package.json, so
+// loading it has to rebuild exactly the dependencies parsing that package.json produces: on the
+// next install the two are diffed, and any dependency that differs makes the install report the
+// workspace as updated and re-resolve it, on every install, with nothing changed on disk.
+//
+// Parsing makes a dependency a workspace dependency (version = the workspace's path) only when its
+// specifier links the workspace: `workspace:` or an npm range the workspace's version satisfies.
+// Anything else that ends up resolved to the workspace keeps its parsed version. Every entry is
+// classified on its own, including a name listed in more than one dependency group.
+//
+// With linkWorkspacePackages off, parsing links no range, so a range (written out or through a
+// catalog) that bun.lock still binds to a workspace was linked while the setting was on: it keeps
+// loading as linked and the difference gets it re-resolved. Peers, overridden entries, catalog
+// entries holding `workspace:` and dist-tags the registry does not have are bound to the workspace
+// either way and load as parsed.
+describe("dependencies on a workspace load from bun.lock the way package.json parses them", () => {
+  const linked = "workspace packages/pkg2";
+
+  // setupTest's bunfig.toml, plus linkWorkspacePackages = false
+  async function disableLinking(packageDir: string) {
+    await write(
+      join(packageDir, "bunfig.toml"),
+      Bun.TOML.stringify({
+        install: {
+          cache: join(packageDir, ".bun-cache"),
+          registry: verdaccio.registryUrl(),
+          linker: "hoisted",
+          linkWorkspacePackages: false,
+        },
+      }),
+    );
+  }
+
+  // One line per dependency on `depName` declared by `pkgName`, in lockfile order (dev, optional,
+  // prod, peer): the groups it is declared in, the specifier, and what it was loaded as. Every one
+  // of them must also resolve to the workspace package.
+  function loadedDependencies(packageDir: string, pkgName: string, depName: string): string[] {
+    const lockfile = parseLockfile(packageDir);
+    const pkg = lockfile.packages.find((p: any) => p.name === pkgName);
+    const workspacePkg = lockfile.packages.find((p: any) => p.resolution.value === "workspace:packages/pkg2");
+    return pkg.dependencies
+      .map((id: number) => lockfile.dependencies[id])
+      .filter((dep: any) => dep.name === depName)
+      .map((dep: any) => {
+        expect(dep.package_id).toBe(workspacePkg.id);
+        const loadedAs =
+          "workspace" in dep
+            ? `workspace ${dep.workspace}`
+            : "npm" in dep
+              ? "npm"
+              : "catalog" in dep
+                ? "catalog"
+                : "dist_tag" in dep
+                  ? "dist-tag"
+                  : JSON.stringify(dep);
+        return `${Object.keys(dep.behavior).join("+")} ${JSON.stringify(dep.literal)} -> ${loadedAs}`;
+      });
+  }
+
+  const cases: {
+    label: string;
+    /** dependency groups of packages/pkg1 */
+    pkg1: Record<string, Record<string, string>>;
+    /** packages/pkg2 is `no-deps@1.0.0` unless given */
+    pkg2?: Record<string, string>;
+    /** root `workspaces.catalog` */
+    catalog?: Record<string, string>;
+    /** root `overrides` */
+    overrides?: Record<string, string>;
+    linkWorkspacePackages?: false;
+    /** the name pkg1 declares the dependency under, when not `no-deps` itself */
+    declaredAs?: string;
+    loaded: string[];
+  }[] = [
+    {
+      label: "workspace:* in dependencies and devDependencies",
+      pkg1: { dependencies: { "no-deps": "workspace:*" }, devDependencies: { "no-deps": "workspace:*" } },
+      loaded: [`dev "workspace:*" -> ${linked}`, `prod "workspace:*" -> ${linked}`],
+    },
+    {
+      label: "workspace:* in dependencies and peerDependencies",
+      pkg1: { dependencies: { "no-deps": "workspace:*" }, peerDependencies: { "no-deps": "workspace:*" } },
+      loaded: [`prod "workspace:*" -> ${linked}`, `peer "workspace:*" -> ${linked}`],
+    },
+    {
+      label: "workspace:* in dependencies and optionalDependencies",
+      pkg1: { dependencies: { "no-deps": "workspace:*" }, optionalDependencies: { "no-deps": "workspace:*" } },
+      loaded: [`optional "workspace:*" -> ${linked}`, `prod "workspace:*" -> ${linked}`],
+    },
+    {
+      label: "workspace:* in dependencies, devDependencies and peerDependencies",
+      pkg1: {
+        dependencies: { "no-deps": "workspace:*" },
+        devDependencies: { "no-deps": "workspace:*" },
+        peerDependencies: { "no-deps": "workspace:*" },
+      },
+      loaded: [`dev "workspace:*" -> ${linked}`, `prod "workspace:*" -> ${linked}`, `peer "workspace:*" -> ${linked}`],
+    },
+    {
+      label: "a satisfied range in dependencies and devDependencies",
+      pkg1: { dependencies: { "no-deps": "^1.0.0" }, devDependencies: { "no-deps": "^1.0.0" } },
+      loaded: [`dev "^1.0.0" -> ${linked}`, `prod "^1.0.0" -> ${linked}`],
+    },
+    {
+      // the range names the workspace, the entry does not
+      label: "a satisfied range aliased in dependencies and devDependencies",
+      pkg1: {
+        dependencies: { "deps-alias": "npm:no-deps@^1.0.0" },
+        devDependencies: { "deps-alias": "npm:no-deps@^1.0.0" },
+      },
+      declaredAs: "deps-alias",
+      loaded: [`dev "npm:no-deps@^1.0.0" -> ${linked}`, `prod "npm:no-deps@^1.0.0" -> ${linked}`],
+    },
+    {
+      label: "workspace:* in devDependencies and a satisfied range in peerDependencies",
+      pkg1: { devDependencies: { "no-deps": "workspace:*" }, peerDependencies: { "no-deps": "^1.0.0" } },
+      loaded: [`dev "workspace:*" -> ${linked}`, `peer "^1.0.0" -> ${linked}`],
+    },
+    {
+      label: "workspace:* in devDependencies and an unsatisfied range in peerDependencies",
+      pkg1: { devDependencies: { "no-deps": "workspace:*" }, peerDependencies: { "no-deps": "2.0.0" } },
+      loaded: [`dev "workspace:*" -> ${linked}`, `peer "2.0.0" -> npm`],
+    },
+    {
+      label: "an unsatisfied range in peerDependencies",
+      pkg1: { peerDependencies: { "no-deps": "2.0.0" } },
+      loaded: [`peer "2.0.0" -> npm`],
+    },
+    {
+      label: "a range on a workspace without a version",
+      pkg1: { dependencies: { "no-deps": "*" } },
+      pkg2: { name: "no-deps" },
+      loaded: [`prod "*" -> npm`],
+    },
+    {
+      label: "a catalog entry pointing at the workspace",
+      pkg1: { dependencies: { "no-deps": "catalog:" } },
+      catalog: { "no-deps": "workspace:*" },
+      loaded: [`prod "catalog:" -> catalog`],
+    },
+    {
+      // the registry has no such tag, so the resolver links the workspace
+      label: "a dist-tag the registry does not have",
+      pkg1: { dependencies: { "no-deps": "no-such-tag" } },
+      loaded: [`prod "no-such-tag" -> dist-tag`],
+    },
+    {
+      label: "an override sends an unsatisfied range to the workspace",
+      pkg1: { dependencies: { "no-deps": "^5.0.0" } },
+      overrides: { "no-deps": "workspace:*" },
+      loaded: [`prod "^5.0.0" -> npm`],
+    },
+    {
+      label: "linkWorkspacePackages off: workspace:* in dependencies and devDependencies",
+      pkg1: { dependencies: { "no-deps": "workspace:*" }, devDependencies: { "no-deps": "workspace:*" } },
+      linkWorkspacePackages: false,
+      loaded: [`dev "workspace:*" -> ${linked}`, `prod "workspace:*" -> ${linked}`],
+    },
+    {
+      label: "linkWorkspacePackages off: an unsatisfied range in peerDependencies",
+      pkg1: { peerDependencies: { "no-deps": "2.0.0" } },
+      linkWorkspacePackages: false,
+      loaded: [`peer "2.0.0" -> npm`],
+    },
+    {
+      label: "linkWorkspacePackages off: workspace:* in devDependencies and an unsatisfied range in peerDependencies",
+      pkg1: { devDependencies: { "no-deps": "workspace:*" }, peerDependencies: { "no-deps": "2.0.0" } },
+      linkWorkspacePackages: false,
+      loaded: [`dev "workspace:*" -> ${linked}`, `peer "2.0.0" -> npm`],
+    },
+    {
+      label: "linkWorkspacePackages off: a catalog entry pointing at the workspace",
+      pkg1: { dependencies: { "no-deps": "catalog:" } },
+      catalog: { "no-deps": "workspace:*" },
+      linkWorkspacePackages: false,
+      loaded: [`prod "catalog:" -> catalog`],
+    },
+    {
+      label: "linkWorkspacePackages off: a dist-tag the registry does not have",
+      pkg1: { dependencies: { "no-deps": "no-such-tag" } },
+      linkWorkspacePackages: false,
+      loaded: [`prod "no-such-tag" -> dist-tag`],
+    },
+    {
+      label: "linkWorkspacePackages off: an override sends an unsatisfied range to the workspace",
+      pkg1: { dependencies: { "no-deps": "^5.0.0" } },
+      overrides: { "no-deps": "workspace:*" },
+      linkWorkspacePackages: false,
+      loaded: [`prod "^5.0.0" -> npm`],
+    },
+  ];
+
+  for (const {
+    label,
+    pkg1,
+    pkg2 = { name: "no-deps", version: "1.0.0" },
+    catalog,
+    overrides,
+    linkWorkspacePackages,
+    declaredAs = "no-deps",
+    loaded,
+  } of cases) {
+    test.concurrent(label, async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
+      if (linkWorkspacePackages === false) await disableLinking(packageDir);
+      await Promise.all([
+        write(
+          packageJson,
+          JSON.stringify({
+            name: "foo",
+            workspaces: catalog ? { packages: ["packages/*"], catalog } : ["packages/*"],
+            overrides,
+          }),
+        ),
+        write(
+          join(packageDir, "packages", "pkg1", "package.json"),
+          JSON.stringify({ name: "pkg1", version: "1.0.0", ...pkg1 }),
+        ),
+        write(join(packageDir, "packages", "pkg2", "package.json"), JSON.stringify(pkg2)),
+      ]);
+
+      await runBunInstall(env, packageDir);
+      // parseLockfile loads with this test process's settings (linking on); for the linking-off rows the
+      // install below, which reads the fixture's bunfig.toml, is what exercises that setting.
+      expect(loadedDependencies(packageDir, "pkg1", declaredAs)).toEqual(loaded);
+
+      // nothing changed, so the second install must not report pkg1 as changed
+      // ("Workspace package "packages/pkg1" has added 0 dependencies, removed 0 dependencies, and updated 1 dependencies")
+      const { err } = await runBunInstall(env, packageDir, { savesLockfile: false, verbose: true });
+      expect(err).not.toContain('Workspace package "packages/pkg1"');
+    });
+  }
+
+  test.concurrent("the root lists a workspace in dependencies and devDependencies", async () => {
+    using ctx = await setupTest();
+    const { packageDir, packageJson, env } = ctx;
+    await Promise.all([
+      write(
+        packageJson,
+        JSON.stringify({
+          name: "foo",
+          workspaces: ["packages/*"],
+          dependencies: { "no-deps": "workspace:*" },
+          devDependencies: { "no-deps": "workspace:*" },
+        }),
+      ),
+      write(
+        join(packageDir, "packages", "pkg2", "package.json"),
+        JSON.stringify({ name: "no-deps", version: "1.0.0" }),
+      ),
+    ]);
+
+    // the root warns "Duplicate dependency" and keeps both entries, next to the entry every
+    // workspace gets
+    const { err } = await runBunInstall(env, packageDir, { allowWarnings: true });
+    expect(err).toContain('Duplicate dependency: "no-deps"');
+    expect(loadedDependencies(packageDir, "foo", "no-deps")).toEqual([
+      `workspace "" -> ${linked}`,
+      `dev "workspace:*" -> ${linked}`,
+      `prod "workspace:*" -> ${linked}`,
+    ]);
+
+    // (the root has no per-package "has added ..." message; what it loads as, above, is what gets diffed)
+    await runBunInstall(env, packageDir, { allowWarnings: true, savesLockfile: false });
+  });
+
+  // The range is checked against the version bun.lock recorded, so a workspace that moved out of
+  // range is still noticed and the dependency re-resolved.
+  test.concurrent("a workspace bumped out of a range is re-resolved", async () => {
+    using ctx = await setupTest();
+    const { packageDir, packageJson, env } = ctx;
+    const pkg2Json = join(packageDir, "packages", "pkg2", "package.json");
+    await Promise.all([
+      write(packageJson, JSON.stringify({ name: "foo", workspaces: ["packages/*"] })),
+      write(
+        join(packageDir, "packages", "pkg1", "package.json"),
+        JSON.stringify({ name: "pkg1", version: "1.0.0", dependencies: { "no-deps": "^1.0.0" } }),
+      ),
+      write(pkg2Json, JSON.stringify({ name: "no-deps", version: "1.0.0" })),
+    ]);
+
+    await runBunInstall(env, packageDir);
+    expect(loadedDependencies(packageDir, "pkg1", "no-deps")).toEqual([`prod "^1.0.0" -> ${linked}`]);
+
+    await write(pkg2Json, JSON.stringify({ name: "no-deps", version: "3.0.0" }));
+    const { err } = await runBunInstall(env, packageDir, { verbose: true });
+    expect(err).toContain(
+      'Workspace package "packages/pkg1" has added 0 dependencies, removed 0 dependencies, and updated 1 dependencies',
+    );
+
+    // ^1.0.0 now comes from the registry
+    expect(pkg1Resolution(packageDir)).toMatchObject({ tag: "npm", value: "1.1.0" });
+  });
+
+  // A range the lockfile linked keeps loading as linked after linkWorkspacePackages is turned off;
+  // package.json no longer parses it as linked, and that difference is what gets it re-resolved
+  // against the registry.
+  for (const [spec, root, loadedWhileLinking] of [
+    ["^1.0.0", {}, `prod "^1.0.0" -> ${linked}`],
+    // a catalog entry stays a catalog entry while linking; the range behind it is what is stale
+    ["catalog:", { catalog: { "no-deps": "^1.0.0" } }, `prod "catalog:" -> catalog`],
+  ] as const) {
+    test.concurrent(`a linked range (${spec}) is re-resolved after linkWorkspacePackages is turned off`, async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
+      await Promise.all([
+        write(packageJson, JSON.stringify({ name: "foo", workspaces: { packages: ["packages/*"], ...root } })),
+        write(
+          join(packageDir, "packages", "pkg1", "package.json"),
+          JSON.stringify({ name: "pkg1", version: "1.0.0", dependencies: { "no-deps": spec } }),
+        ),
+        write(
+          join(packageDir, "packages", "pkg2", "package.json"),
+          JSON.stringify({ name: "no-deps", version: "1.0.0" }),
+        ),
+      ]);
+
+      await runBunInstall(env, packageDir);
+      expect(loadedDependencies(packageDir, "pkg1", "no-deps")).toEqual([loadedWhileLinking]);
+
+      await disableLinking(packageDir);
+      const { err } = await runBunInstall(env, packageDir, { verbose: true });
+      expect(err).toContain(
+        'Workspace package "packages/pkg1" has added 0 dependencies, removed 0 dependencies, and updated 1 dependencies',
+      );
+      expect(pkg1Resolution(packageDir)).toMatchObject({ tag: "npm", value: "1.1.0" });
+
+      // and only once
+      const again = await runBunInstall(env, packageDir, { savesLockfile: false, verbose: true });
+      expect(again.err).not.toContain('Workspace package "packages/pkg1"');
+    });
+  }
+
+  /** what pkg1's only dependency resolves to */
+  function pkg1Resolution(packageDir: string) {
+    const lockfile = parseLockfile(packageDir);
+    const pkg1 = lockfile.packages.find((p: any) => p.name === "pkg1");
+    expect(pkg1.dependencies).toHaveLength(1);
+    const dep = lockfile.dependencies[pkg1.dependencies[0]];
+    return lockfile.packages.find((p: any) => p.id === dep.package_id).resolution;
+  }
+});
+
 // While linking, the hoisted installer formats each package's version label (its
 // version, or for tarball/folder/git packages the spec it was resolved from) into a
 // 512 byte stack buffer. Labels longer than that used to abort the whole install.


### PR DESCRIPTION
### Problem
- In a monorepo where a workspace package lists a sibling workspace in two dependency groups (activepieces: `packages/core/shared` has `"@activepieces/core-piece-types": "workspace:*"` under both `dependencies` and `devDependencies`), every `bun install` reports the workspace as changed, with nothing changed on disk: `bun install --verbose` prints `Workspace package "packages/core/shared" has added 0 dependencies, removed 0 dependencies, and updated 1 dependencies` on every run, `summary.update` is non-zero, and the install takes the re-resolve path instead of the no-op path. Same when the root lists a workspace in two groups. Reproduces on 1.3.14, 1.4.0 and main.
- Cause: `bun.lock` stores a workspace's dependencies as the literal specifiers, and the loader rewrites each entry that resolved to a workspace package into the form `Package::parse_dependency` produces (`map_dep_to_pkg`, src/install/lockfile/bun.lock.rs), but a `seen_deps` check skipped the rewrite for the second and later entries of a name (root loop and workspace loop, formerly around lines 3102 and 3187). The parser rewrites every entry, so the two `Dependency` lists never compare equal in `Diff::generate_inner` (src/install/lockfile/Package.rs, the `Dependency::eql` check) and `summary.update` is bumped once per extra entry, forever.
- The check cannot simply be dropped: the rewrite itself is broader than the parser's rule. The parser links an entry only for a `workspace:` specifier or a range the workspace's version satisfies; the loader rewrote anything bound to a workspace. Dropping the check alone makes the existing test `matching workspace devDependency and npm peerDependency` (a `workspace:*` devDependency plus an unsatisfied `2.0.0` peer on the same workspace) report an update on every install instead, because the peer entry then gets rewritten too. The same over-broad rewrite already makes these single-entry shapes report an update on every install on main: an unsatisfied peer range on a workspace (which also re-resolves the peer against the registry on every install), a range on a versionless workspace (#37249's shape), a `catalog:` entry pointing at a workspace, and a dist-tag the registry does not have (which the resolver answers with the workspace).

### Fix
- Root and workspace entries go through `map_manifest_dep_to_pkg`, which binds the entry and rewrites it only when `WorkspaceLinks::links` says the parser would: `workspace:` specifiers always; npm ranges when they name the bound workspace package (the name inside the range is compared against the package's name, not only the hashes the version map and peer bindings are keyed by) and the version `bun.lock` recorded for it satisfies them; nothing else. Every entry is classified on its own, so a name listed in several groups gets each entry rewritten or left alone exactly as the parser does. `seen_deps` is gone.
- Why this is the right rule: `Diff::generate` compares the loaded list against a fresh parse of the same package.json, so the loader has to reproduce the parser's output, and the parser's rule is the one in `Package::parse_dependency` (src/install/lockfile/Package.rs, the `Tag::Npm` arm linking a satisfied range and the `Tag::Workspace` arm). Resolutions are untouched: every entry still binds to the same package as before, only the in-memory version differs, and that in-memory state is now the one a fresh install has too (the fresh resolver binds unsatisfied peers and versionless wildcards to the workspace without retagging the dependency). The saved `bun.lock` is byte-identical before and after, so existing lockfiles load as they are.
- Ranges are checked against the version recorded in `bun.lock`, not the one on disk, so a workspace bumped out of an entry's range still loads as linked, diffs against the parse, and gets re-resolved (tested).
- `linkWorkspacePackages = false`: the parser then links no range, so a range `bun.lock` still binds to a workspace, written out or behind a `catalog:` entry, was linked while the setting was on. Those keep loading as linked, which is the previous behavior and is what makes them diff once and re-resolve against the registry (tested for both forms, including that the next install is quiet again). Everything a fresh install binds to the workspace under either setting loads as parsed: peers (bound to the workspace of their name by the hoister), entries an override redirects (an `npm:` alias is never overridden, the same exemption the resolver applies), `catalog:` entries holding `workspace:`, and dist-tags the registry does not have; marking any of those would be the same permanent update, and was, on main (tested for each). This is the rule #33632's loader commit arrives at as well, so that PR can rebase its loader half onto this.
- Entries of installed (non-workspace) packages keep the unconditional rewrite in `map_dep_to_pkg`; nothing diffs them, and this change does not touch their behavior.
- Tests, all in test/cli/install/bun-workspaces.test.ts under `dependencies on a workspace load from bun.lock the way package.json parses them`: a table of 19 shapes (the two-group shapes from the report in every group combination, satisfied ranges plain and as an `npm:` alias, unsatisfied ranges, versionless wildcard, catalog entry, missing dist-tag, an override sending a range to the workspace, and six of those with linking off) asserting the loaded entries via the lockfile dump and that a second `--verbose` install does not report the workspace (the dump loads with the test process's default settings, so for the linking-off rows the `--verbose` install in the fixture is the assertion that exercises that setting); a root variant; the bump test; and the linking-off re-resolution test for a plain and for a catalog range, each also checking the third install is quiet. Against main's bun.lock.rs 19 of the 23 fail (the dump shows `workspace *` for the second entry, or `workspace packages/pkg2` for the peer/wildcard/catalog/dist-tag/override entries); the 4 that pass on main pin behavior that must not change (the dev+unsatisfied-peer shape with linking on and off, the bump, the plain-range re-resolution after turning linking off). With the override exemption removed, the linking-off override row fails on the `--verbose` line, with the re-resolve binding the workspace again. All 23 pass with the fix.
- The 6 changed snapshots in `dependency on workspace without version in package.json` show the only in-memory change for that test: wildcard and dist-tag entries on a versionless workspace keep their parsed tag, `package_id` unchanged. (The `"tag": "no-deps"` value in the new dist-tag snapshot is a pre-existing bug in the debug dump, already certified by three other snapshots in that file; #33632's last commit fixes it.)
- Also green locally: bun-workspaces, bun-lock, catalogs, lockfile-only, lockfile-version-2, frozen-lockfile-missing-workspace, frozen-lockfile-pruned, bad-workspace, bun-add-catalog, isolated-install, isolated-relink, bun-lockb, migrate-bun-lockb-v2, bun-update-lockfile-sync, bun-install-registry, migration/migrate, pnpm-migration, yarn-lock-migration, source lints; `cargo clippy -p bun_install` clean. migration/complex-workspace needs gitlab/bitbucket access and fails here with or without the change.
- Overlapping open PRs, so the reviewer can sequence them: #33632 (large, frozen-lockfile manifest checks) contains this same loader change as part of its first commit (same `seen_deps` removal, a `map_manifest_dep_to_pkg` with the same rule, the same 6 snapshot hunks) plus unrelated pieces; this PR is that loader slice on its own, with the name check and the catalog handling added in review, and #33632 would rebase down to its remaining pieces. #37249 gates only npm entries and keeps `seen_deps`, so it fixes the versionless-wildcard shape but not the two-group ones; this supersedes it (noted there). #37264 is changing the parser's range rule (a wildcard accepting a prerelease member) through a shared predicate; `WorkspaceLinks::links` mirrors the rule as it is on main today, and whichever of the two lands second points the loader at that predicate (noted there). The merged #36303 is about hoisting two entries with different versions and does not interact with this.

<details>
<summary>Earlier revision</summary>

The first push exempted only peers from the linking-off fallback, so with linking off a <code>catalog:</code> entry holding <code>workspace:</code> or a missing dist-tag was still marked and diffed forever (as on main). Review caught it; the fallback now applies to ranges only, with the catalog and dist-tag shapes in the table and a catalog-range variant of the re-resolution test. A second round asked for the workspace's name to be compared rather than trusting the hash-keyed lookups alone; that is the name check in <code>links</code> and the aliased-range row. A third pass compared the rule with #33632's and took its one extra exemption (overridden entries with linking off), with the two override rows; the branch was also squashed and rebased onto current main at that point.
</details>

### Background
- Dependency entry: each line of a package.json dependency group becomes one `Dependency` in `lockfile.buffers.dependencies` (name, behavior = which group, parsed version); a package owns a contiguous range of them, and `buffers.resolutions` maps each one to a package id. The same name in two groups is two entries with different behaviors.
- Workspace dependency: a `Dependency` whose version tag is `workspace` and whose value is the workspace's path. The parser produces one for a `workspace:` specifier, and, while `linkWorkspacePackages` is on, for an npm range satisfied by the workspace's version (the literal is kept either way, which is what `bun.lock` prints). `Dependency::eql` compares tag and value, so a `workspace:*` entry left with the value `*` is not equal to one carrying the path.
- `bun.lock` loading (`parse_into_binary_lockfile`): parses every literal back into a `Dependency`, resolves the root's and each workspace's entries by name against the packages map, then the installed packages' entries by tree path. The rewrite discussed here happens at that binding step.
- `Diff::generate` (Package.rs): on every install, compares the loaded root with a fresh parse of package.json and recurses into each workspace; any entry that is not `eql` counts as an update, which prints the verbose line above, makes `had_any_diffs` true and re-resolves the workspace. `bun install --frozen-lockfile` does not consult these counts, so this shape never failed CI; it only did the extra work and (for unsatisfied peers) the extra registry round trip on every install.
- The lockfile dump used by the tests (`install_test_helpers.parseLockfile`) loads `bun.lock` through this same loader and prints each entry keyed by its version tag, which is how the tests observe the loaded form directly.

<details>
<summary>Repro (released bun)</summary>

```sh
mkdir -p repro/packages/{a,b} && cd repro
echo '{"name":"root","private":true,"workspaces":["packages/*"]}' > package.json
echo '{"name":"a","version":"1.0.0"}' > packages/a/package.json
echo '{"name":"b","version":"1.0.0","dependencies":{"a":"workspace:*"},"devDependencies":{"a":"workspace:*"}}' > packages/b/package.json
bun install
bun install --verbose 2>&1 | grep "Workspace package"
# Workspace package "packages/b" has added 0 dependencies, removed 0 dependencies, and updated 1 dependencies
```

Listing `a` in three groups prints `updated 2`. The same line appears for `dependencies` + `peerDependencies`, `dependencies` + `optionalDependencies`, `^1.0.0` in two groups, a lone `peerDependencies: {"a": "2.0.0"}`, `dependencies: {"a": "*"}` on a versionless `a`, and `dependencies: {"a": "catalog:"}` with `catalog: {"a": "workspace:*"}`; a single `workspace:*`, `^1.0.0` or `workspace:*` + `2.0.0` peer entry is quiet. On 1.3.x/1.4.0 the second install also prints `Saved lockfile`; main since #38333 skips the write when the bytes are unchanged, so there the symptom is the verbose line and the re-resolve.
</details>

