### PR TITLE
process.env: coerce to string on every execution of an assignment, not just the first

### DIFF
--- a/src/jsc/bindings/JSEnvironmentVariableMap.h
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.h
@@ -18,9 +18,11 @@ namespace Bun {
 class JSEnvironmentVariableMap final : public JSC::JSNonFinalObject {
 public:
     using Base = JSC::JSNonFinalObject;
-    // Put ICs and DFG PutByStatus would otherwise store repeat writes from a site directly, skipping
-    // put()'s ToString; the DFG only looks at the structure, so a PutPropertySlot flag is not enough.
-    static constexpr unsigned StructureFlags = Base::StructureFlags | JSC::OverridesPut | JSC::ProhibitsPropertyCaching;
+    static constexpr unsigned StructureFlags = Base::StructureFlags
+        | JSC::OverridesPut
+        // Cached puts and fast indexed storage would both store without reaching put() / putByIndex().
+        | JSC::ProhibitsPropertyCaching
+        | JSC::InterceptsGetOwnPropertySlotByIndexEvenWhenLengthIsNotZero;
 
     static JSEnvironmentVariableMap* create(JSC::VM& vm, JSC::Structure* structure)
     {

--- a/src/jsc/bindings/JSEnvironmentVariableMap.h
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.h
@@ -18,7 +18,11 @@ namespace Bun {
 class JSEnvironmentVariableMap final : public JSC::JSNonFinalObject {
 public:
     using Base = JSC::JSNonFinalObject;
-    static constexpr unsigned StructureFlags = Base::StructureFlags | JSC::OverridesPut;
+    // Every write has to reach put() for its ToString. Without ProhibitsPropertyCaching,
+    // a put IC (LLInt/JIT) or a DFG PutByStatus fold stores the raw value straight into
+    // the object on later executions of the same site. Neither consults OverridesPut,
+    // and the DFG works from the structure alone, so slot.disableCaching() is not enough.
+    static constexpr unsigned StructureFlags = Base::StructureFlags | JSC::OverridesPut | JSC::ProhibitsPropertyCaching;
 
     static JSEnvironmentVariableMap* create(JSC::VM& vm, JSC::Structure* structure)
     {

--- a/src/jsc/bindings/JSEnvironmentVariableMap.h
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.h
@@ -18,10 +18,8 @@ namespace Bun {
 class JSEnvironmentVariableMap final : public JSC::JSNonFinalObject {
 public:
     using Base = JSC::JSNonFinalObject;
-    // Every write has to reach put() for its ToString. Without ProhibitsPropertyCaching,
-    // a put IC (LLInt/JIT) or a DFG PutByStatus fold stores the raw value straight into
-    // the object on later executions of the same site. Neither consults OverridesPut,
-    // and the DFG works from the structure alone, so slot.disableCaching() is not enough.
+    // Put ICs and DFG PutByStatus would otherwise store repeat writes from a site directly, skipping
+    // put()'s ToString; the DFG only looks at the structure, so a PutPropertySlot flag is not enough.
     static constexpr unsigned StructureFlags = Base::StructureFlags | JSC::OverridesPut | JSC::ProhibitsPropertyCaching;
 
     static JSEnvironmentVariableMap* create(JSC::VM& vm, JSC::Structure* structure)

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -492,6 +492,53 @@ it("process.env coerces integer-like keys to string on every assignment", () => 
   }
 });
 
+it.concurrent("process.env survives a value whose toString() mutates process.env", async () => {
+  // put() ToStrings the value before it stores it, so the value's toString() runs
+  // in the middle of the store and can add or delete keys. A structure transition
+  // inside a store to an existing property is something JSC's put caches cannot
+  // model: slow_path_put_by_id asserts newStructure == oldStructure and aborts the
+  // process, release builds included. Opting out of put caching removes the abort
+  // along with the stale-value bug. Spawned because the failure is a SIGABRT.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        // toString() creates the very key that the assignment then stores
+        process.env.SAME = { toString() { process.env.SAME = "inner"; return "same" } };
+        console.log("same", process.env.SAME);
+        // toString() adds a different key
+        process.env.ADD = "0";
+        process.env.ADD = { toString() { process.env.ADDED = "1"; return "add" } };
+        console.log("add", process.env.ADD, process.env.ADDED);
+        // toString() deletes a different key
+        process.env.DEL = "0";
+        process.env.DOOMED = "0";
+        process.env.DEL = { toString() { delete process.env.DOOMED; return "del" } };
+        console.log("del", process.env.DEL, String(process.env.DOOMED));
+        // Symbol.toPrimitive, from a site the JITs compile
+        const value = { [Symbol.toPrimitive]() { process.env.TMP = "1"; delete process.env.TMP; return "hot" } };
+        function write(v) { process.env.HOT = v }
+        process.env.HOT = "0";
+        for (let i = 0; i < 5000; i++) {
+          write(value);
+          if (typeof process.env.HOT !== "string") throw new Error("raw value stored at " + i);
+        }
+        console.log("hot", process.env.HOT);
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr: exitCode === 0 ? "" : stderr, exitCode }).toEqual({
+    stdout: "same same\nadd add 1\ndel del undefined\nhot hot\n",
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
 it.concurrent("process.env reads are never stale and writes always coerce across JIT tiers", async () => {
   // process.env sets ProhibitsPropertyCaching (JSEnvironmentVariableMap.h), so
   // neither reads nor writes to it may be served by an inline cache or folded by

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -551,8 +551,12 @@ it.concurrent("process.env.TZ and NODE_TLS_REJECT_UNAUTHORIZED writes still reac
   // effect first. After the first write they are ordinary data properties, so
   // without ProhibitsPropertyCaching the DFG folds the write site into a plain
   // store once it is hot: the string still lands in process.env but the timezone
-  // stops changing and non-strings are stored raw. Non-concurrent JIT makes the
-  // tier-up happen at a fixed call count (around call 100) so the loop is short.
+  // stops changing and non-strings are stored raw. The fold only happens if the
+  // Baseline read IC has started watching the property and a write has fired that
+  // watchpoint before the DFG compiles the function, which the default thresholds
+  // do at about call 100 (unfixed, this fails at call 99); non-concurrent JIT pins
+  // that order. jitPolicyScale=0 would compile before the watchpoint exists and
+  // make the unfixed build pass, so the thresholds are deliberately left alone.
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -427,32 +427,74 @@ it("process.env is spreadable and editable", () => {
   expect(eval(`globalThis.process.env.USER = "${orig}"`)).toBe(String(orig));
 });
 
-it("process.env reads are never stale after a write (JIT inline-cache soundness)", async () => {
-  // process.env only sets OverridesPut (not ProhibitsPropertyCaching), so
-  // reads hit the ordinary self-access IC. This test verifies that writes
-  // through the overridden put() still invalidate that IC: same-key Replace,
-  // delete-then-set, and a hot read loop that FTL constant-folds before a
-  // single write. Spawned so the subprocess gets its own tier-up.
+it("process.env coerces to string on every execution of the same assignment", () => {
+  // The first execution of an assignment goes through JSEnvironmentVariableMap::put,
+  // which ToStrings the value like node's EnvSetter. JSC then wants to cache the
+  // site as a plain store that never calls put() again; process.env must opt out
+  // of that caching or the second/third execution stores the raw value.
+  const computedKey = "BUN_TEST_ENV_REPEATED_BYVAL";
+  process.env.BUN_TEST_ENV_REPEATED_EXISTING = "preset";
+  try {
+    const fresh = [];
+    const existing = [];
+    const byVal = [];
+    const objects = [];
+    for (let i = 0; i < 4; i++) {
+      process.env.BUN_TEST_ENV_REPEATED_FRESH = i;
+      fresh.push(process.env.BUN_TEST_ENV_REPEATED_FRESH);
+      process.env.BUN_TEST_ENV_REPEATED_EXISTING = i;
+      existing.push(process.env.BUN_TEST_ENV_REPEATED_EXISTING);
+      process.env[computedKey] = i;
+      byVal.push(process.env[computedKey]);
+      process.env.BUN_TEST_ENV_REPEATED_OBJECT = { toString: () => "object-" + i };
+      objects.push(process.env.BUN_TEST_ENV_REPEATED_OBJECT);
+    }
+    expect({ fresh, existing, byVal, objects }).toEqual({
+      fresh: ["0", "1", "2", "3"],
+      existing: ["0", "1", "2", "3"],
+      byVal: ["0", "1", "2", "3"],
+      objects: ["object-0", "object-1", "object-2", "object-3"],
+    });
+  } finally {
+    delete process.env.BUN_TEST_ENV_REPEATED_FRESH;
+    delete process.env.BUN_TEST_ENV_REPEATED_EXISTING;
+    delete process.env[computedKey];
+    delete process.env.BUN_TEST_ENV_REPEATED_OBJECT;
+  }
+});
+
+it("process.env reads are never stale and writes always coerce across JIT tiers", async () => {
+  // process.env sets ProhibitsPropertyCaching (JSEnvironmentVariableMap.h), so
+  // neither reads nor writes to it may be served by an inline cache or folded by
+  // the DFG. writeAndRead() and readHot() are called often enough to be compiled
+  // by every tier (FTL lands around call 10000 in a debug build): every call of
+  // the write must reach put() (and ToString) and every read must see the latest
+  // value, including one written after the read site went hot. Then
+  // delete-then-set by value. Spawned so the subprocess gets its own tier-up.
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
       "-e",
       `
         const env = process.env;
-        const N = 100000;
-        for (let i = 0; i < N; i++) {
-          const expected = "v" + i;
-          env.PROBE_KEY = expected;
-          if (env.PROBE_KEY !== expected) throw new Error("same-key stale at " + i + ": " + env.PROBE_KEY);
+        const N = 30000;
+        function writeAndRead(value) {
+          env.PROBE_KEY = value;
+          return env.PROBE_KEY;
         }
-        env.PROBE_KEY = 42;
-        if (env.PROBE_KEY !== "42") throw new Error("coerce: " + env.PROBE_KEY);
+        for (let i = 0; i < N; i++) {
+          const stored = writeAndRead(i);
+          if (stored !== String(i)) throw new Error("call " + i + " stored " + typeof stored + " " + stored);
+        }
+        function readHot() {
+          return env.HOT;
+        }
         env.HOT = "initial";
-        let sink = "";
-        for (let i = 0; i < 2 * N; i++) sink = env.HOT;
-        if (sink !== "initial") throw new Error("hot warmup: " + sink);
+        for (let i = 0; i < N; i++) {
+          if (readHot() !== "initial") throw new Error("hot warmup at " + i + ": " + readHot());
+        }
         env.HOT = "changed";
-        if (env.HOT !== "changed") throw new Error("hot post-write: " + env.HOT);
+        if (readHot() !== "changed") throw new Error("hot post-write: " + readHot());
         const key = "PROBE_BYVAL";
         for (let i = 0; i < 2000; i++) {
           env[key] = "b" + i;

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -463,7 +463,36 @@ it("process.env coerces to string on every execution of the same assignment", ()
   }
 });
 
-it("process.env reads are never stale and writes always coerce across JIT tiers", async () => {
+it("process.env coerces integer-like keys to string on every assignment", () => {
+  // Integer-like keys go through putByIndex. The first store used to give the
+  // object ordinary indexed storage, after which JSC stores into that vector
+  // directly, so later stores (to the same index or a neighbouring one) never
+  // reached putByIndex. process.env has to keep indexed keys on the slow path.
+  try {
+    const repeated = [];
+    const stringForm = [];
+    for (let i = 0; i < 4; i++) {
+      process.env[700] = i;
+      repeated.push(process.env[700]);
+      process.env["701"] = i;
+      stringForm.push(process.env["701"]);
+    }
+    process.env[702] = 7;
+    const keys = Object.keys(process.env).filter(key => key === "700" || key === "701" || key === "702");
+    expect({ repeated, stringForm, neighbour: process.env[702], keys }).toEqual({
+      repeated: ["0", "1", "2", "3"],
+      stringForm: ["0", "1", "2", "3"],
+      neighbour: "7",
+      keys: ["700", "701", "702"],
+    });
+  } finally {
+    delete process.env[700];
+    delete process.env[701];
+    delete process.env[702];
+  }
+});
+
+it.concurrent("process.env reads are never stale and writes always coerce across JIT tiers", async () => {
   // process.env sets ProhibitsPropertyCaching (JSEnvironmentVariableMap.h), so
   // neither reads nor writes to it may be served by an inline cache or folded by
   // the DFG. writeAndRead() and readHot() are called often enough to be compiled
@@ -506,6 +535,56 @@ it("process.env reads are never stale and writes always coerce across JIT tiers"
       `,
     ],
     env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr: exitCode === 0 ? "" : stderr, exitCode }).toEqual({
+    stdout: "ok\n",
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
+it.concurrent("process.env.TZ and NODE_TLS_REJECT_UNAUTHORIZED writes still reach put() once optimized", async () => {
+  // put() stores these two keys with putDirect and applies their native side
+  // effect first. After the first write they are ordinary data properties, so
+  // without ProhibitsPropertyCaching the DFG folds the write site into a plain
+  // store once it is hot: the string still lands in process.env but the timezone
+  // stops changing and non-strings are stored raw. Non-concurrent JIT makes the
+  // tier-up happen at a fixed call count (around call 100) so the loop is short.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const env = process.env;
+        const N = 200;
+        const zones = ["Asia/Tokyo", "UTC"];
+        const offsets = [-540, 0];
+        function writeTZ(i) {
+          env.TZ = zones[i & 1];
+          return env.TZ;
+        }
+        for (let i = 0; i < N; i++) {
+          const stored = writeTZ(i);
+          const offset = new Date(0).getTimezoneOffset();
+          if (stored !== zones[i & 1] || offset !== offsets[i & 1]) {
+            throw new Error("call " + i + ": stored " + stored + ", offset " + offset);
+          }
+        }
+        function writeTLS(i) {
+          env.NODE_TLS_REJECT_UNAUTHORIZED = i;
+          return env.NODE_TLS_REJECT_UNAUTHORIZED;
+        }
+        for (let i = 0; i < N; i++) {
+          const stored = writeTLS(i);
+          if (stored !== String(i)) throw new Error("call " + i + ": stored " + typeof stored + " " + stored);
+        }
+        console.log("ok");
+      `,
+    ],
+    env: { ...bunEnv, BUN_JSC_useConcurrentJIT: "0" },
     stdout: "pipe",
     stderr: "pipe",
   });


### PR DESCRIPTION
### Problem
- Only the first assignment to a `process.env` key from a given statement is coerced to a string; later executions store the raw value. Node stores a string every time.
  ```js
  for (let i = 0; i < 3; i++) { process.env.X = i; console.log(typeof process.env.X); }
  // bun 1.4.0: string string number        node: string string string
  ```
  An object value ends up stored as the object itself, and `Bun.env`, `{...process.env}`, `JSON.stringify(process.env)` and `structuredClone(process.env)` all expose the raw value.
- The same caching aborts the process when the assigned value's `toString()` touches `process.env`. `put()` ToStrings the value before it stores it, so that code runs inside the store and can add or delete a key. JSC's put caches cannot model a structure transition in a store to an existing property: `slow_path_put_by_id` hits `RELEASE_ASSERT(newStructure == oldStructure)` (`LLIntSlowPaths.cpp:1148`) and `tryCachePutBy` has the same assert (`Repatch.cpp:1105`). One line is enough, on its first execution, in release builds too. It ships since 1.4.0. Bun 1.3.14 stores the raw object and never calls `toString()`, so it cannot abort. #31831 (45eda514f9) replaced the plain object with this class and its coercing `put()`.
  ```js
  process.env.X = { toString() { process.env.X = "inner"; return "outer" } };
  // bun 1.4.0, 1.4.1, 1.4.2, 1.4.3-canary.1: panic(main thread): abort() called, exit 134
  // bun 1.3.14: exit 0
  ```
- Cause 1, named keys: `JSEnvironmentVariableMap` (POSIX `process.env`) only set `OverridesPut` (`src/jsc/bindings/JSEnvironmentVariableMap.h:21`). Its `put()` ToStrings the value and stores it (`JSEnvironmentVariableMap.cpp:133-167`), but the put caching paths decide from the `PutPropertySlot` and the structure, never from `OverridesPut`: the LLInt `put_by_id` cache (`LLIntSlowPaths.cpp`, `slow_path_put_by_id`), the baseline/DFG/FTL put ICs (`Repatch.cpp`, `tryCachePutBy`) and the DFG's structure-only `PutByStatus::computeFor` used by `tryFoldAsPutByOffset`. Execution 1 of a site goes through `put()`, execution 2 gets cached as a plain store, execution 3 (2 if the key already existed) stores the raw value.
- `TZ` and `NODE_TLS_REJECT_UNAUTHORIZED` are stored with `putDirect` inside `put()`, which keeps them out of the LLInt/JIT ICs but not out of the DFG path: once a read IC has watched the property and one write has replaced it, `PutByStatus::computeFor` reports a plain Replace and the DFG folds the write. On the unfixed build `env.TZ = zone` in a hot function stops changing the timezone at about the 100th call while the stored string still looks right (`call 99: stored UTC, offset -540` in the new test), and a non-string assigned to `NODE_TLS_REJECT_UNAUTHORIZED` is stored raw.
- Cause 2, integer-like keys (`process.env[700] = 1`, `process.env["701"] = 1`): these go through the `putByIndex` override, but the first store gave the object ordinary indexed storage, and `JSObject::putByIndexInline` stores into that vector directly (`trySetIndexQuickly`) without consulting the method table. So the second store to an index, and even the first store to a neighbouring index, skipped `putByIndex`. Independent of the JIT; fails on the first loop iteration for the neighbouring key.
- Windows is not affected by either: its `process.env` is a Proxy whose `set` trap coerces on every write.

### Fix
- `JSEnvironmentVariableMap::StructureFlags` gains two flags (the only `src/` change):
  - `ProhibitsPropertyCaching`: makes `Structure::propertyAccessesAreCacheable()` false, which is the predicate all three put caching paths above check, so every `[[Set]]` takes the generic path and `OverridesPut` dispatches it to `put()`. Same flag the SHARE_ENV `process.env` (`JSSharedEnvMap`, same file) and `JSC::ProxyObject` use; #38854 applies it to `require.extensions`, the only other `OverridesPut` class in `src/` without it (the remaining three, `JSSharedEnvMap`, `NodeVM.h`, `NodeSqlite.h`, already have it). Both abort sites are behind that same predicate, so the flag removes the crash with the stale value.
  - `InterceptsGetOwnPropertySlotByIndexEvenWhenLengthIsNotZero`: `JSObject::indexingShouldBeSparse()` then puts indexed properties in the sparse map (`putByIndexBeyondVectorLength`, blank case), which has no quick-store path, so every indexed store reaches `putByIndex()`. Also what `JSSharedEnvMap` sets. Enumeration order, `structuredClone`, `JSON.stringify`, spread, `defineProperty` and `delete` of index keys were checked against node and are unchanged apart from the values now being strings (probe below).
- `slot.disableCaching()` in `put()` is not a fix: it only reaches the IC paths. I built that variant and the DFG still bypassed `put()` after 1100 to 2100 calls in every shape tried, including a function that only writes (probe below).
- Cost: reads of `process.env` lose their inline cache too, since JSC has no put-only flag. Release bun 1.4.0 with `BUN_JSC_forceICFailure=1` as a stand-in for the uncached path: a `process.env.X` read goes from about 2.6 ns to about 44 ns, a write from the (incorrect) 4.7 ns direct store to about 43 ns, which is what `put()` already cost from any uncached site. Node reads in about 200 ns and writes in about 500 ns on the same machine. Bun's own built-ins read `process.env` at module init or per connection, not per operation.
- `delete` ICs consult the same predicate, but there was no observable bypass to test: each set-then-delete cycle leaves the object in a new structure, so a delete IC never hit.
- Verification, all in `test/js/node/process/process.test.js`; each test fails on bun 1.4.0 (the first and third also checked against a debug build of main) and passes with this diff:
  - "coerces to string on every execution of the same assignment": fresh key, pre-existing key, computed key, object with `toString`, four passes each (fails from pass 3).
  - "coerces integer-like keys to string on every assignment": repeated index store, string-form index, first store to a neighbouring index (fails on pass 1 of the string-form key).
  - "reads are never stale and writes always coerce across JIT tiers": the existing IC-soundness test, now writing numbers; its functions reach Baseline, DFG and FTL within the loop (`BUN_JSC_reportCompileTimes`).
  - "TZ and NODE_TLS_REJECT_UNAUTHORIZED writes still reach put() once optimized": asserts the timezone offset and the stored string on every call with `BUN_JSC_useConcurrentJIT=0`; `BUN_JSC_reportCompileTimes` shows `writeTZ` DFG-compiled before the unfixed build fails at call 99, and both functions DFG-compiled on the fixed build. The default tier-up thresholds are load-bearing: with `jitPolicyScale=0` the DFG compiles before the replacement watchpoint exists and the unfixed build passes (noted in the test).
  - "survives a value whose toString() mutates process.env": the same-key, add-key and delete-key forms, plus a `Symbol.toPrimitive` value written 5000 times from one site. Each form exits 134 (SIGABRT) on release bun 1.4.3-canary.1 and on a debug build of main at 4ff91937; all four print their coerced string with this diff.
  - Also run with the debug build: the rest of `process.test.js`, `test/cli/run/env.test.ts`, the worker_threads env tests and the eight vendored `test/js/node/test/parallel/test-process-env*.js` files (one of which covers `structuredClone(process.env)`).

### Background
- `put()` / `putByIndex()` are JSC's `[[Set]]` hooks on a class's method table. `OverridesPut` makes `JSObject::putInline` dispatch named stores to the class's `put()`; it says nothing about caching, and indexed stores are dispatched separately.
- Inline cache (IC): after a property access site runs once, JSC patches the site to repeat the outcome directly ("object has structure S, store at offset N") whenever the structure matches again, without calling into the runtime. The LLInt has a per-site cache, the JITs have ICs, and the DFG additionally folds accesses at compile time from what it knows about the structure (`PutByStatus`).
- `PutPropertySlot` is the record a `put()` fills in describing what it did; `isCacheablePut()` is how the LLInt and JIT caches learn whether a site may be cached. `Base::put` fills it in as cacheable; `putDirect` does not touch it. The DFG path does not look at it at all.
- Replacement watchpoint: when a read IC caches a property, JSC starts watching that property slot for replacement; the DFG will only fold a write into a plain store once such a watchpoint exists and has fired, which is why the `TZ` bypass needs a read plus one earlier write before it shows up.
- `ProhibitsPropertyCaching` is a structure flag meaning "never cache property accesses on this structure"; `Structure::propertyAccessesAreCacheable()` returns false for it.
- Indexed storage: a plain object stores integer-like keys in a vector (butterfly) once it has any; stores into that vector bypass the method table. `InterceptsGetOwnPropertySlotByIndexEvenWhenLengthIsNotZero` is the flag JSC uses to mark objects that must see every indexed access; it switches them to the sparse map, where every indexed get/put goes through the method table.

<details>
<summary>Probe: slot.disableCaching() alone vs the structure flag (debug builds)</summary>

Each line runs a function 200000 times with `process.env.PROBE_B` starting as `"0"` and reports the first call after which a number is stored.

```
== slot.disableCaching() in put(), no structure flag ==
closure read+write: BYPASS at call 1122 (stored a number)
process.env write+read: BYPASS at call 1591 (stored a number)
write-only fn, read elsewhere: BYPASS at call 2147 (stored a number)
write-only, typeof after loop: BYPASS at call 1832 (stored a number)

== ProhibitsPropertyCaching (this PR) ==
all four shapes: no bypass in 200000 calls

== unfixed ==
all four shapes: BYPASS at call 2
```
</details>

<details>
<summary>Probe: integer-like keys with the sparse flag, compared with node</summary>

Run with an OS env var literally named `5` set to `five`, then `env[42] = 1; env[42] = 2;`.

```
                      bun 1.4.0                      this PR                       node 26
env[42]               2                              "2"                           "2"
descriptor.value      2                              "2"                           "2"
structuredClone       2                              "2"                           "2"
JSON.stringify        2                              "2"                           "2"
{...env}[42]          2                              "2"                           "2"
Object.entries        [["5","five"],["42",2]]        [["5","five"],["42","2"]]     [["5","five"],["42","2"]]
defineProperty 43     "3"                            "3"                           "3"
delete env[42]        gone                           gone                          gone
Object.keys order     index keys first (unchanged)   index keys first (unchanged)  env order
```
The key order difference is pre-existing JSC object behavior and is the same before and after.
</details>

<details>
<summary>Cost measurement</summary>

Hot function reading / writing one `process.env` key, 1M iterations after warm-up, same linux x64 container.

```
bun 1.4.0 release (unfixed)                     read 2.6 ns   write 4.7 ns (direct store, the bug)
bun 1.4.0 release, BUN_JSC_forceICFailure=1     read 44 ns    write 43 ns
node v26.3.0                                    read 197 ns   write 530 ns
```
</details>

<details>
<summary>Earlier version of this PR</summary>

The first revision only added `ProhibitsPropertyCaching` and claimed `TZ` / `NODE_TLS_REJECT_UNAUTHORIZED` were unaffected because `put()` stores them with `putDirect`. Self-review showed that claim only holds for the LLInt/JIT ICs, not for the DFG path, and found the unrelated-to-JIT indexed-storage bypass for integer-like keys; the second revision adds the indexed flag and the two extra tests described above.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/process/process.test.js

<!-- robobun:evidence:end -->
