### PR TITLE
PipeReader: keep the outer read loop's scratch claim when a nested read is refused

### DIFF
--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -162,7 +162,15 @@ struct ReadScratchClaim;
 
 impl ReadScratchClaim {
     fn try_claim() -> Option<Self> {
-        READ_SCRATCH_IN_USE.with(|in_use| (!in_use.replace(true)).then_some(Self))
+        READ_SCRATCH_IN_USE.with(|in_use| {
+            if in_use.get() {
+                // Not `then_some(Self)`: its argument is built before the test,
+                // and dropping that refused claim would release the outer one.
+                return None;
+            }
+            in_use.set(true);
+            Some(Self)
+        })
     }
 }
 
@@ -902,8 +910,14 @@ impl PosixBufferedReader {
             } else {
                 // SAFETY: caller contract; `maxbuf` is Copy, borrow ends at `;`.
                 let maxbuf = unsafe { (*this).maxbuf };
+                // Streaming delivers and clears per read, so this reserve is the
+                // chunk size. Nested reads (a consumer re-pulling from inside its
+                // chunk handler, e.g. `process.stdin.on("data")`) all land here
+                // rather than in the scratch, so give them a whole default pipe
+                // buffer per read.
+                let reserve = if streaming { 64 * 1024 } else { 16 * 1024 };
                 // SAFETY: caller contract; borrow ends at `;`.
-                unsafe { (*this)._buffer.reserve(16 * 1024) };
+                unsafe { (*this)._buffer.reserve(reserve) };
                 // SAFETY: caller contract. `sys::read_nonblocking` writes only
                 // initialized bytes into the prefix it reports; `commit_spare`
                 // exposes exactly that prefix. The `_buffer` borrow ends before

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -1895,8 +1895,18 @@ describe("streamed input pacing", () => {
   const count = 2500; // ~2.4 MB of input: many upstream chunks
   const input = Buffer.alloc(piece.length * count, piece).toString();
   const rewritten = Buffer.alloc((piece.length + 6) * count, `<p x="1">${text}</p>`).toString();
-  const dir = tempDirWithFiles("hr-pacing", { "in.html": input });
+  // A second document made of different bytes, for the tests below that read
+  // it while another document is being parsed: if that read lands in the
+  // other document's buffer, these bytes show up in its output.
+  const otherText = Buffer.alloc(1000, "b").toString();
+  const otherPiece = `<p>${otherText}</p>`;
+  const otherRewritten = Buffer.alloc((otherPiece.length + 6) * count, `<p x="1">${otherText}</p>`).toString();
+  const dir = tempDirWithFiles("hr-pacing", {
+    "in.html": input,
+    "other.html": Buffer.alloc(otherPiece.length * count, otherPiece).toString(),
+  });
   const file = path.join(dir, "in.html");
+  const otherFile = path.join(dir, "other.html");
 
   function transformInput(body = Bun.file(file)) {
     let seen = 0;
@@ -2075,6 +2085,62 @@ describe("streamed input pacing", () => {
       .transform(new Response(Bun.file(file)));
     expect(await outer.text()).toBe(rewritten);
     expect(await inner).toBe(rewritten);
+  });
+
+  // Starting a transform inside the handler and reading it are two reads
+  // nested in the outer one, which still has its document in the read buffer:
+  // the second nested read must be kept out of it just like the first.
+  it("a handler may transform and read another file", async () => {
+    let inner;
+    const outer = new HTMLRewriter()
+      .on("p", {
+        element(e) {
+          e.setAttribute("x", "1");
+          inner ??= transformInput(Bun.file(otherFile)).res.text();
+        },
+      })
+      .transform(new Response(Bun.file(file)));
+    expect(await outer.text()).toBe(rewritten);
+    expect(await inner).toBe(otherRewritten);
+  });
+
+  // Same, with the outer document arriving on a pipe (the child's stdin): a
+  // pipe is read by a different loop than a regular file, out of the same
+  // buffer.
+  it("a handler may transform and read another file while its document arrives on stdin", async () => {
+    const pieces = 64;
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const attr = { element: e => void e.setAttribute("x", "1") };
+         let inner;
+         const outer = new HTMLRewriter()
+           .on("p", {
+             element(e) {
+               attr.element(e);
+               inner ??= new HTMLRewriter().on("p", attr).transform(new Response(Bun.file(process.argv[1]))).text();
+             },
+           })
+           .transform(new Response(Bun.stdin));
+         const out = await outer.text();
+         console.log(JSON.stringify({ out, innerLength: (await inner).length }));`,
+        otherFile,
+      ],
+      env: bunEnv,
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    proc.stdin.write(Buffer.alloc(piece.length * pieces, piece));
+    proc.stdin.end();
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      out: Buffer.alloc((piece.length + 6) * pieces, `<p x="1">${text}</p>`).toString(),
+      innerLength: otherRewritten.length,
+    });
+    expect(exitCode).toBe(0);
   });
 
   // Regular-file reads are synchronous on POSIX, so reading ahead of the


### PR DESCRIPTION
### Problem

- An HTMLRewriter handler that starts a second streamed read while the outer document is being parsed gets the outer document's remaining bytes replaced by the second read's bytes. Repro: a handler doing `new HTMLRewriter().transform(new Response(Bun.file(other))).text()` makes the outer `.text()` come back as `<b x="1">bbbb...` (the other file's content) instead of the outer document. Same result whether the outer document comes from a regular file or from a stdin pipe.
- #38656 added `ReadScratchClaim` (src/io/PipeReader.rs:161) so that only the outermost read loop on the thread reads into the per-loop scratch buffer, and nested loops read into their own `_buffer`. `try_claim()` was written as `(!in_use.replace(true)).then_some(Self)`. `bool::then_some` takes its argument by value, so a `ReadScratchClaim` is constructed before the condition is tested; on the refused path `then_some` drops it, and `impl Drop for ReadScratchClaim` clears `READ_SCRATCH_IN_USE`. The first refused nested read therefore released the outer loop's claim, and every nested read after it claimed the scratch and refilled it under the outer loop's chunk.
- `transform()` + `.text()` inside a handler is exactly two nested reads (the initial read `transform()` performs, then the drain `.text()` triggers), so the case #38656 was written for was still broken in its most natural form. The existing test only consumed a transform created outside the handler, which is a single nested read, so it kept passing.
- Found by the session fixing test/js/node/test/parallel/test-http-chunk-problem.js after #38656; not addressed by #38726, which fixed the re-delivery half of that break.

### Fix

- `try_claim()` tests the flag and sets it explicitly, so no claim value exists on the refused path and the outer loop's claim stays set until its own claim drops.
- Correct because the claim is meant to be held for the whole outer loop: the chunk handed to `on_read_chunk` points into the scratch until that dispatch returns, and a nested loop of any depth or count during that window must stay out of it. Releasing it early is exactly the aliasing the claim exists to prevent.
- With every nested read now reading into `_buffer`, `read_blocking_pipe`'s streamed branch reserves 64 KiB instead of 16 KiB. In streaming mode that branch delivers and clears per read, so the reserve is the chunk size, and a consumer that re-pulls from inside its chunk handler (`process.stdin.on("data")` on a piped stdin) takes every read after the first through it. 16 KiB would have turned one chunk per pipe buffer into four (measurements below); 64 KiB is the default pipe buffer on Linux and macOS and keeps the chunking identical to the current release. The non-streaming (accumulating) reserve is unchanged.
- Tests: test/js/workerd/html-rewriter.test.js, "streamed input pacing" block, two new tests: the outer document read from a regular file (`read_with_fn`) and from the child's stdin pipe (`read_blocking_pipe`), each with a handler that transforms and reads a second file whose bytes differ from the outer document's. Both fail on main with the outer output replaced by the other file's bytes, both pass with this change.
- Also ran on the debug build: the whole html-rewriter file, spawn.test.ts, spawn-streaming-stdout/stdin, spawn-maxbuf, spawn-stream-serve, spawn-stdin-readable-stream, process-stdin, process-stdin-stale-hup, bun-stdin-slice, shell-blocking-pipe, shell-pipe-read-fault, pipeline_stack. The only failures were the stdin-fixtures tests (hard 1 s kill timer; touching `process.stdout` alone takes 1.7 s in this debug build) and shell-blocking-pipe's `generateHeapSnapshot` test (the snapshot alone exceeds the 5 s timeout here); both reproduce without this diff's code paths being involved.

### Background

- Per-loop read scratch: every event loop owns one 256 KiB `PipeReadBuffer`. The POSIX read loops in src/io/PipeReader.rs (`read_with_fn` for files, sockets and non-blocking pipes; `read_blocking_pipe` for blocking pipes such as a piped stdin) read into it and pass the filled slice straight to the parent's `on_read_chunk`, so a streamed chunk lives in the scratch until that callback returns.
- Nested read: `on_read_chunk` can run user JS. FileReader's native-sink path hands the slice to HTMLRewriter, which runs content handlers while lol_html is still parsing out of it; a handler that starts or drains another streamed body runs another read loop synchronously, inside the outer one's dispatch. FileReader's JS-facing path copies the chunk before JS runs, which is why `process.stdin` consumers see no corruption, only the chunking difference above.
- `ReadScratchClaim`: a thread-local flag plus a Drop guard. A read loop that gets the claim uses the scratch; one that is refused reads into the reader's own `_buffer` (16 KiB reserve in `read_with_fn`, which grows as it drains to EAGAIN; per-read delivery in `read_blocking_pipe`, so the reserve there is the chunk size).

<details>
<summary>Chunking measurements: 16 MiB piped into `process.stdin.on("data")`, 64 KiB pipes</summary>

| build | chunks delivered | sizes |
| --- | --- | --- |
| current release (before #38656) | 256 | 256 x 64 KiB |
| main (claim released by the bug) | 263 | 253 x 64 KiB, 9 x 16 KiB, 1 x 48 KiB |
| `try_claim` fix alone | 1021 | 1020 x 16 KiB, 1 x 64 KiB |
| this PR (fix + 64 KiB streamed reserve) | 256 | 256 x 64 KiB |

The 9 x 16 KiB chunks on main are the one correctly refused nested read per outer dispatch; everything after it went back into the scratch. `read_with_fn` consumers (a child's stdout via child_process `data` events, same 16 MiB) deliver 76 chunks of ~220 KiB with this PR against 127 on the current release, so no reserve change is needed there.

Note for anyone reproducing in a container as root: uid 0 can end up with 8 KiB pipes there (pipe-user-pages-soft), which hides the chunking difference; run the pipeline as another uid.
</details>
