### PR TITLE
bun test: number snapshots per test file regardless of which files ran before

### DIFF
--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -3235,9 +3235,6 @@ impl TestCommand {
                 let entry = ZigString::init(file_path);
                 vm.global().delete_module_registry_entry(&entry)?;
             }
-            // Snapshot keys are numbered per test file: counts left over from the
-            // previous file (or the previous rerun of this one) would shift them.
-            reporter.jest.snapshots.reset_counts();
 
             let bun_test_root = &mut jest::Jest::runner().unwrap().bun_test_root;
             // Determine if this file should run tests concurrently based on glob pattern

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -3234,10 +3234,10 @@ impl TestCommand {
                 vm.clear_entry_point()?;
                 let entry = ZigString::init(file_path);
                 vm.global().delete_module_registry_entry(&entry)?;
-                // Reset per-test snapshot counters so rerun N matches the same
-                // snapshot keys as run 1 instead of looking for "test name 2", etc.
-                reporter.jest.snapshots.reset_counts();
             }
+            // Snapshot keys are numbered per test file: counts left over from the
+            // previous file (or the previous rerun of this one) would shift them.
+            reporter.jest.snapshots.reset_counts();
 
             let bun_test_root = &mut jest::Jest::runner().unwrap().bun_test_root;
             // Determine if this file should run tests concurrently based on glob pattern

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -537,7 +537,7 @@ impl Execution {
             if test_failed && sequence.remaining_retry_count > 0 {
                 sequence.remaining_retry_count -= 1;
                 Execution::discard_junit_failure(buntest);
-                Execution::reset_sequence(sequence);
+                Execution::reset_sequence(buntest, sequence);
                 return;
             }
 
@@ -545,7 +545,7 @@ impl Execution {
             if test_passed && sequence.remaining_repeat_count > 0 {
                 sequence.remaining_repeat_count -= 1;
                 Execution::discard_junit_failure(buntest);
-                Execution::reset_sequence(sequence);
+                Execution::reset_sequence(buntest, sequence);
                 return;
             }
 
@@ -716,7 +716,7 @@ impl Execution {
         }
     }
 
-    pub(crate) fn reset_sequence(sequence: &mut ExecutionSequence) {
+    pub(crate) fn reset_sequence(buntest: NonNull<BunTest>, sequence: &mut ExecutionSequence) {
         debug_assert!(!sequence.executing);
         {
             // reset the entries
@@ -754,9 +754,10 @@ impl Execution {
         // Clearing all entries matches Jest (SnapshotState.clear() on test_retry,
         // jestjs/jest#7493). Concurrent tests never touch the counts map — see
         // SnapshotInConcurrentGroup in expect.rs.
-        if let Some(runner) = super::jest::Jest::runner() {
-            runner.snapshots.reset_counts();
-        }
+        // SAFETY: `buntest` points at the live per-file BunTest; `sequence` points into
+        // the heap buffer of `buntest.execution.sequences`, and no borrow of the
+        // `snapshot_counts` field itself is live. Single-threaded test runner.
+        unsafe { (*buntest.as_ptr()).snapshot_counts.clear() };
     }
 
     pub(crate) fn handle_uncaught_exception(

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -751,7 +751,7 @@ impl Execution {
         // toMatchSnapshot() call. Without this reset, retries / repeats would
         // increment the counter to N on attempt N and look for a key that does
         // not exist (https://github.com/oven-sh/bun/issues/23705).
-        // Zeroing all entries matches Jest (SnapshotState.clear() on test_retry,
+        // Clearing all entries matches Jest (SnapshotState.clear() on test_retry,
         // jestjs/jest#7493). Concurrent tests never touch the counts map — see
         // SnapshotInConcurrentGroup in expect.rs.
         if let Some(runner) = super::jest::Jest::runner() {

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -648,10 +648,7 @@ pub struct BunTest {
     /// Only the Box header may be freed in `Drop` — fields alias `DescribeScope` originals.
     pub(crate) cloned_hook_entries: Vec<*mut ExecutionEntry>,
     pub(crate) wants_wakeup: bool,
-    /// Snapshot name -> how many snapshot matchers (file or inline) that test has run in
-    /// this file so far; numbers the `.snap` keys. Lives here rather than on the
-    /// process-wide `Snapshots` so every file run (and every `--rerun-each` pass) starts
-    /// from 1, whether or not the file ever opens a `.snap`.
+    /// Snapshot name -> snapshot matchers (file or inline) run so far; numbers the `.snap` keys.
     pub(crate) snapshot_counts: StringHashMap<usize>,
 
     pub(crate) phase: Phase,

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -3,7 +3,7 @@ use core::ptr::NonNull;
 use std::cell::UnsafeCell;
 use std::rc::{Rc, Weak};
 
-use bun_collections::LinearFifo;
+use bun_collections::{LinearFifo, StringHashMap};
 use bun_core::{Output, Timespec};
 use bun_jsc::{self as jsc, CallFrame, GlobalRef, JSGlobalObject, JSValue, JsResult, Strong, JsClass as _};
 use bun_jsc::virtual_machine::VirtualMachine;
@@ -648,6 +648,11 @@ pub struct BunTest {
     /// Only the Box header may be freed in `Drop` — fields alias `DescribeScope` originals.
     pub(crate) cloned_hook_entries: Vec<*mut ExecutionEntry>,
     pub(crate) wants_wakeup: bool,
+    /// Snapshot name -> how many snapshot matchers (file or inline) that test has run in
+    /// this file so far; numbers the `.snap` keys. Lives here rather than on the
+    /// process-wide `Snapshots` so every file run (and every `--rerun-each` pass) starts
+    /// from 1, whether or not the file ever opens a `.snap`.
+    pub(crate) snapshot_counts: StringHashMap<usize>,
 
     pub(crate) phase: Phase,
     pub(crate) collection: Collection,
@@ -685,6 +690,7 @@ impl BunTest {
             // `next = EPOCH, state = PENDING`.
             timer: EventLoopTimer::init_paused(EventLoopTimerTag::BunTest),
             wants_wakeup: false,
+            snapshot_counts: StringHashMap::new(),
         }
     }
 

--- a/src/runtime/test_runner/snapshot.rs
+++ b/src/runtime/test_runner/snapshot.rs
@@ -33,6 +33,10 @@ pub struct Snapshots {
     // LIFETIMES.tsv said `HashMap<usize, String>`; overridden per §Strings (data is bytes) → Box<[u8]>.
     // Key is u64 to match `bun.hash`'s return type (avoids a narrowing cast).
     values: HashMap<u64, Box<[u8]>>,
+    /// Test name -> number of snapshot matchers (file or inline) that test has run so far;
+    /// numbers the `.snap` keys. Scoped to the test file being run, not to `_current_file`:
+    /// inline snapshots bump it before the file's `.snap` is opened, and a file that only
+    /// uses inline snapshots never opens one.
     counts: StringHashMap<usize>,
     _current_file: Option<File>,
     /// Directory whose `__snapshots__/` was last created (or found existing);
@@ -109,12 +113,10 @@ pub struct File {
 }
 
 impl Snapshots {
-    /// Reset per-run snapshot counters to 0. Keys stay owned by the map until
-    /// `writeSnapshotFile` tears them down on file switch.
+    /// Called when a test file starts running (including each `--rerun-each` pass) and
+    /// when a test is retried, so every run of a file numbers its snapshots from 1.
     pub(crate) fn reset_counts(&mut self) {
-        for v in self.counts.values_mut() {
-            *v = 0;
-        }
+        self.counts.clear();
     }
 
     pub(crate) fn add_count(&mut self, expect: &Expect, hint: &[u8]) -> Result<(Vec<u8>, usize), Error> {
@@ -354,8 +356,6 @@ impl Snapshots {
             self.file_buf.shrink_to_fit();
 
             self.values.clear();
-
-            self.counts.clear();
         }
         Ok(())
     }

--- a/src/runtime/test_runner/snapshot.rs
+++ b/src/runtime/test_runner/snapshot.rs
@@ -1,7 +1,7 @@
 use core::ffi::c_ulong;
 use std::io::Write as _;
 
-use bun_collections::{HashMap, StringHashMap};
+use bun_collections::HashMap;
 use bun_core::output as bun_output;
 use bun_core::printer as js_printer;
 use bun_core;
@@ -33,11 +33,6 @@ pub struct Snapshots {
     // LIFETIMES.tsv said `HashMap<usize, String>`; overridden per §Strings (data is bytes) → Box<[u8]>.
     // Key is u64 to match `bun.hash`'s return type (avoids a narrowing cast).
     values: HashMap<u64, Box<[u8]>>,
-    /// Test name -> number of snapshot matchers (file or inline) that test has run so far;
-    /// numbers the `.snap` keys. Scoped to the test file being run, not to `_current_file`:
-    /// inline snapshots bump it before the file's `.snap` is opened, and a file that only
-    /// uses inline snapshots never opens one.
-    counts: StringHashMap<usize>,
     _current_file: Option<File>,
     /// Directory whose `__snapshots__/` was last created (or found existing);
     /// borrowed from the runner's `File::source.path`, a `Path<'static>`.
@@ -66,7 +61,6 @@ impl Snapshots {
             failed: 0,
             file_buf: Vec::new(),
             values: HashMap::new(),
-            counts: StringHashMap::new(),
             _current_file: None,
             snapshot_dir_path: None,
             inline_snapshots_to_write: IndexMap::new(),
@@ -113,19 +107,16 @@ pub struct File {
 }
 
 impl Snapshots {
-    /// Called when a test file starts running (including each `--rerun-each` pass) and
-    /// when a test is retried, so every run of a file numbers its snapshots from 1.
-    pub(crate) fn reset_counts(&mut self) {
-        self.counts.clear();
-    }
-
     pub(crate) fn add_count(&mut self, expect: &Expect, hint: &[u8]) -> Result<(Vec<u8>, usize), Error> {
         self.total += 1;
         let snapshot_name = expect.get_snapshot_name(hint)?;
+        // `get_snapshot_name` just upgraded this same weak ref, so the test's file is alive.
+        let buntest_strong = expect.bun_test().ok_or(crate::Error::TestNotActive)?;
         // bun_collections::StringHashMap::get_or_put can't hand out `key_ptr`, so return the
         // owned `snapshot_name` (same bytes as the interned key) instead.
-        let gop = self
-            .counts
+        let gop = buntest_strong
+            .get()
+            .snapshot_counts
             .get_or_put(&snapshot_name)
             .map_err(Error::from)?;
         if gop.found_existing {

--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -903,6 +903,36 @@ test("--parallel writes new snapshots from every worker", async () => {
   expect(code2).toBe(0);
 });
 
+test("--parallel: a worker numbers each file's snapshots the same way a single-file run does", async () => {
+  // Each file takes an inline snapshot (number 1) and then a file snapshot, so on its
+  // own it writes `t 2`. Six files on two workers means most files are not the first
+  // file their worker runs; their keys must not depend on that.
+  const body = (n: number) =>
+    `import {test,expect} from "bun:test"; test("t",()=>{ expect("x").toMatchInlineSnapshot(\`"x"\`); expect(${n}).toMatchSnapshot(); });`;
+  const snap = (n: number) =>
+    "// Bun Snapshot v1, https://bun.sh/docs/test/snapshots\n" + `\nexports[\`t 2\`] = \`${n}\`;\n`;
+  const files: Record<string, string> = {};
+  for (let n = 1; n <= 6; n++) {
+    files[`f${n}.test.js`] = body(n);
+    files[`__snapshots__/f${n}.test.js.snap`] = snap(n);
+  }
+  using dir = tempDir("parallel-snapshot-numbering", files);
+
+  // CI: looking up a key that is missing from the .snap file fails instead of adding it.
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--parallel=2"],
+    env: { ...bunEnv, BUN_TEST_PARALLEL_SCALE_MS: "0", CI: "true" },
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout + stderr).not.toContain("Snapshot creation is disabled");
+  expect(stderr).toContain("6 pass");
+  expect(stderr).toContain("0 fail");
+  expect(exitCode).toBe(0);
+});
+
 test("--parallel: a test producing a >64MB result line is truncated, not treated as a crash", async () => {
   // Test name just over the 64MB IPC frame limit → the per-test status line
   // itself exceeds it. The encoder must truncate so the receiver doesn't drop

--- a/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
@@ -933,6 +933,92 @@ test("snapshot numbering", () => {
   expect("hello").toMatchSnapshot("hinted");
 });
 
+describe.concurrent("snapshot numbering across test files", () => {
+  const header = "// Bun Snapshot v1, https://bun.sh/docs/test/snapshots\n";
+
+  // Every file gets its own counters, so the keys a file writes must not depend on
+  // which files ran before it in the same `bun test` process.
+  async function runBunTest(dir: string, env: Record<string, string>) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "./a.test.ts", "./b.test.ts"],
+      env: { ...bunEnv, ...env },
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { output: stdout + stderr, exitCode };
+  }
+
+  const fileSnapshotThenInlineAndFileSnapshot = {
+    "a.test.ts": /*js*/ `
+      import { test, expect } from "bun:test";
+      test("a", () => {
+        expect(1).toMatchSnapshot();
+      });
+    `,
+    "b.test.ts": /*js*/ `
+      import { test, expect } from "bun:test";
+      test("b", () => {
+        expect("x").toMatchInlineSnapshot(\`"x"\`);
+        expect(2).toMatchSnapshot();
+      });
+    `,
+  };
+
+  test("an inline snapshot taken before the file's first toMatchSnapshot() still counts", async () => {
+    using dir = tempDir("snapshot-numbering-inline-first", fileSnapshotThenInlineAndFileSnapshot);
+
+    const { output, exitCode } = await runBunTest(String(dir), { CI: "false" });
+
+    expect(output).toContain("2 pass");
+    expect(exitCode).toBe(0);
+    // Same key `bun test ./b.test.ts` on its own writes: the inline snapshot is number 1.
+    expect(await Bun.file(`${dir}/__snapshots__/b.test.ts.snap`).text()).toBe(header + "\nexports[`b 2`] = `2`;\n");
+    expect(await Bun.file(`${dir}/__snapshots__/a.test.ts.snap`).text()).toBe(header + "\nexports[`a 1`] = `1`;\n");
+  });
+
+  test("snapshots written by running each file on its own pass when the files run together", async () => {
+    using dir = tempDir("snapshot-numbering-committed", {
+      ...fileSnapshotThenInlineAndFileSnapshot,
+      "__snapshots__/a.test.ts.snap": header + "\nexports[`a 1`] = `1`;\n",
+      "__snapshots__/b.test.ts.snap": header + "\nexports[`b 2`] = `2`;\n",
+    });
+
+    // CI: creating a snapshot under a key missing from the .snap file is an error.
+    const { output, exitCode } = await runBunTest(String(dir), { CI: "true" });
+
+    expect(output).not.toContain("Snapshot creation is disabled");
+    expect(output).toContain("2 pass");
+    expect(exitCode).toBe(0);
+  });
+
+  test("counts from a file that only uses inline snapshots do not carry over to the next file", async () => {
+    using dir = tempDir("snapshot-numbering-inline-only-file", {
+      "a.test.ts": /*js*/ `
+        import { test, expect } from "bun:test";
+        test("same name", () => {
+          expect(1).toMatchInlineSnapshot(\`1\`);
+        });
+      `,
+      "b.test.ts": /*js*/ `
+        import { test, expect } from "bun:test";
+        test("same name", () => {
+          expect(2).toMatchSnapshot();
+        });
+      `,
+    });
+
+    const { output, exitCode } = await runBunTest(String(dir), { CI: "false" });
+
+    expect(output).toContain("2 pass");
+    expect(exitCode).toBe(0);
+    expect(await Bun.file(`${dir}/__snapshots__/b.test.ts.snap`).text()).toBe(
+      header + "\nexports[`same name 1`] = `2`;\n",
+    );
+  });
+});
+
 test("write snapshot from filter", async () => {
   const sver = (m: string, a: boolean) => /*js*/ `
     test("mysnap", () => {


### PR DESCRIPTION
### Problem
- The key a `toMatchSnapshot()` writes or looks up depends on which test files ran earlier in the same `bun test` process. With `a.test.ts` taking one file snapshot and `b.test.ts` taking an inline snapshot followed by a file snapshot in test `b`:
  - `bun test ./b.test.ts` writes `` exports[`b 2`] `` (the inline snapshot is number 1, as in Jest)
  - `bun test ./a.test.ts ./b.test.ts` writes `` exports[`b 1`] ``
  - so a `.snap` committed from one shape fails under the other; in CI the second shape fails with `Snapshot creation is disabled in CI environments ... Snapshot name: "b 1"`.
- The opposite direction too: a file that only uses inline snapshots leaves its counts behind, and the next file with a test of the same name starts numbering at 2 (`same name 2` instead of `same name 1`).
- `--parallel` has the same problem for every file after the first one a worker runs (6 identical files on 2 workers end up as 2 x `t 2` and 4 x `t 1`).
- Cause: the counters (`Snapshots.counts`, src/runtime/test_runner/snapshot.rs) lived on the process-wide `Snapshots` and were only cleared inside `write_snapshot_file`, which runs when a file snapshot is taken for a different test file than the `.snap` currently open. `Expect::inline_snapshot` (src/runtime/test_runner/expect.rs) bumps the counters without opening a `.snap`, so the bump either landed before the switch and was wiped, or (for a file that never opens a `.snap`) was never cleared at all. The `--rerun-each` fix for #23705 had already needed a second hand-placed reset of the same map.

### Fix
- The counters move to `BunTest::snapshot_counts` (src/runtime/test_runner/bun_test.rs). `enter_file` builds a fresh `BunTest` for every file run, including each `--rerun-each` pass, so the per-file lifetime comes from the object itself: `Snapshots::reset_counts`, the `--rerun-each` reset in `TestCommand::run`, and the clear in `write_snapshot_file` are all deleted.
- `Snapshots::add_count` bumps the counter on the `BunTest` the `expect()` belongs to, which is the same `BunTest` whose `file_id` already selects the `.snap` file, so the numbering and the file it applies to can no longer disagree.
- The per-test retry/repeat reset (`Execution::reset_sequence`, same behaviour as before, matching Jest's `SnapshotState.clear()` on retry) now takes the `BunTest` and clears that file's map instead of reaching the process-wide one through `Jest::runner()`.
- Why this is right: snapshot numbering is a per-test-file concept (Jest creates a fresh `SnapshotState`, counters included, per test file), and `BunTest` is bun's per-test-file object; the `.snap` file is opened lazily by the first file snapshot, so its lifetime was never a usable proxy for the test file's. Single-file runs already numbered the way Jest does; this makes multi-file and `--parallel` runs agree with them.
- Verified with three new tests in `test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts` (`snapshot numbering across test files`): inline snapshot before the file's first file snapshot, `.snap` files written by single-file runs passing under `CI=true` when the files run together, and an inline-only file followed by a file with the same test name; plus one in `test/cli/test/parallel.test.ts` where two workers run six files each committed from a single-file run. All four fail on the current release (`b 1`, `Snapshot name: "b 1"`, `same name 2`, and 4 of 6 files failing with `"t 1"`) and pass with this change.
- Also ran `test/js/bun/test/snapshot-tests/` (only the pre-existing colour-dependent `error snapshots` failure, which #38833 addresses), `test/cli/test/rerun-each.test.ts` (the #23705 `--rerun-each` and retry/repeat numbering guards, which now exercise the fresh-`BunTest`-per-pass path and the new `reset_sequence`), `test/cli/test/retry-flag.test.ts`, `test/js/bun/test/test-retry-repeats-basic.test.ts`, `test/js/bun/test/ci-restrictions.test.ts`, `test/cli/test/test-filter-lifecycle-snapshot.test.ts`, `test/js/bun/test/bun_test.test.ts`, `test/js/bun/test/test-test.test.ts`, and `test/cli/test/parallel.test.ts`.
- Out of scope, found while looking at this: `--bail` exits without flushing the open `.snap` (with `-u` it leaves the existing file truncated to 0 bytes). That is the lazy flush of the `.snap` contents, independent of the counters, and is being tracked separately alongside #36679 and #34042.

### Background
- Snapshot key: the name under which a value is stored in a `.snap` file, `` exports[`<describe names> <test name> <N>`] ``. `N` counts the snapshot matchers the test has run so far, and inline snapshots consume a number too (Jest behaviour, which bun already matched within a single file), which is why the example above is `b 2`.
- `Snapshots` (`snapshot.rs`) is one object for the whole process, owned by the `TestRunner`. It holds the summary counters (`total`/`added`/`passed`/`failed`) and the currently open `.snap` file (`_current_file`, its parsed entries in `values`, the bytes to write back in `file_buf`). The `.snap` is opened lazily by the first file snapshot in a test file and is flushed and swapped when a file snapshot from a different test file arrives, or at the end of the run.
- `BunTest` (`bun_test.rs`) is the per-test-file object: `BunTestRoot::enter_file` creates one when a file starts running and `exit_file` drops it when the file is done. Each `expect()` holds a weak reference to the `BunTest` it was created under, which is how `add_count` and the `.snap` selection in `get_or_put` find the file a snapshot belongs to.
- `TestCommand::run` (`test_command.rs`) runs one test file (looping for `--rerun-each`, calling `enter_file` on every pass); the serial runner calls it per file, and each `--parallel` worker process calls it for every file it is handed.

<details>
<summary>First revision of this PR</summary>

The first push kept the map on `Snapshots` and cleared it at the top of every file pass in `TestCommand::run` (deleting the clear in `write_snapshot_file`). That fixed the same cases, but it was the second time the reset point of this map had to be moved by hand (#29375 added the first two for #23705), so the current revision moves the map onto the per-file object instead, which removes the reset calls rather than relocating them.

</details>
