### PR TITLE
ci: pin mordant at the renamed lints; rename the disabled list and baseline keys to match

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ exclude = ["vendor"]
 # (see its rust-toolchain), which must still be able to compile this workspace.
 [workspace.metadata.dylint]
 libraries = [
-    { git = "https://github.com/scarletindustries/mordant", rev = "e23ff5571fd0a97ded2f4e0a2242c938c115e1b9" },
+    { git = "https://github.com/scarletindustries/mordant", rev = "173f675deacd57387e78a63ab68b6dd7af8a1361" },
 ]
 
 [workspace.package]

--- a/dylint.toml
+++ b/dylint.toml
@@ -8,14 +8,14 @@ validator-resource-errors = ["bun_alloc::AllocError", "bun_sys::Error", "bun_err
 # on; add a lint here only with a reason.
 disabled = [
     # "list the variants instead of `_`": a per-site style call, ~500 today.
-    "wildcard_local_enum",
+    "wildcard_over_own_enum",
     # Structs with several bools are nearly all option bags here; the state
     # machines among them were found by hand once and are not worth the volume.
-    "flag_cluster",
+    "bool_cluster",
     # Most names it flags are real, on the C++/JS side or in a sibling crate.
     "stale_safety_comment",
     # Variants only ever tested through `!=` / `_`; checked, none were bugs.
     "unread_error_variant",
     # "make the guard a type": style.
-    "guard_flag",
+    "runtime_typestate",
 ]

--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -1,78 +1,75 @@
 [bun_ast]
-"bool_params:src/ast/lib.rs" = 1
-"misbound_arg:src/ast/lib.rs" = 1
+"arg_named_like_other_param:src/ast/lib.rs" = 1
+"bare_bool_args:src/ast/lib.rs" = 1
 
 [bun_bundler]
-"bool_params:src/bundler/Chunk.rs" = 1
+"arg_named_like_other_param:src/bundler/linker.rs" = 1
+"bare_bool_args:src/bundler/Chunk.rs" = 1
 "defaulted_failure:src/bundler/bundle_v2.rs" = 2
-"misbound_arg:src/bundler/linker.rs" = 1
-"uneven_narrowing:src/bundler/bundle_v2.rs" = 1
+"narrowed_two_ways:src/bundler/bundle_v2.rs" = 1
 
 [bun_core]
 "defaulted_failure:src/bun_core/string/immutable.rs" = 1
 
 [bun_css]
-"bool_params:src/css/selectors/builder.rs" = 1
-"misbound_arg:src/css/rules/mod.rs" = 1
-"unnamed_tuple:src/css/css_parser.rs" = 1
-"unnamed_tuple:src/css/values/color.rs" = 5
+"arg_named_like_other_param:src/css/rules/mod.rs" = 1
+"bare_bool_args:src/css/selectors/builder.rs" = 1
+"tuple_wants_struct:src/css/css_parser.rs" = 1
+"tuple_wants_struct:src/css/values/color.rs" = 5
 
 [bun_install]
-"bool_params:src/install/isolated_install.rs" = 1
-"crossed_alias:src/install/lockfile/Tree.rs" = 1
-"crossed_index:src/install/isolated_install.rs" = 1
+"always_unwrapped_option:src/install/PackageInstall.rs" = 1
+"arg_named_like_other_param:src/install/PackageManager/PackageJSONEditor.rs" = 3
+"arg_named_like_other_param:src/install/resolution.rs" = 1
+"bare_bool_args:src/install/isolated_install.rs" = 1
 "defaulted_failure:src/install/npm.rs" = 1
-"misbound_arg:src/install/PackageManager/PackageJSONEditor.rs" = 3
-"misbound_arg:src/install/resolution.rs" = 1
+"index_of_other_kind:src/install/isolated_install.rs" = 1
+"interchangeable_aliases:src/install/lockfile/Tree.rs" = 1
 "same_match_twice:src/install/PackageManager/install_with_manager.rs" = 1
-"unread_none:src/install/PackageInstall.rs" = 1
 
 [bun_js_parser]
-"bool_params:src/js_parser/visit/mod.rs" = 1
+"bare_bool_args:src/js_parser/visit/mod.rs" = 1
 "same_match_twice:src/js_parser/p.rs" = 3
-"sentinel_int:src/js_parser/parse/parse_entry.rs" = 1
+"sentinel_integer:src/js_parser/parse/parse_entry.rs" = 1
 
 [bun_js_printer]
 "parallel_vecs:src/js_printer/lib.rs" = 1
 
 [bun_jsc]
-"bool_params:src/jsc/ZigStackFrame.rs" = 1
+"bare_bool_args:src/jsc/ZigStackFrame.rs" = 1
 "defaulted_failure:src/jsc/ConsoleObject.rs" = 4
+"narrowed_two_ways:src/jsc/RuntimeTranspilerCache.rs" = 1
 "reimplemented_helper:src/jsc/webcore_types.rs" = 1
 "same_match_twice:src/jsc/VirtualMachine.rs" = 1
-"uneven_narrowing:src/jsc/RuntimeTranspilerCache.rs" = 1
 
 [bun_parsers]
 "parallel_vecs:src/parsers/xml.rs" = 1
 
 [bun_react_compiler]
-"bool_params:src/react_compiler/validation/validate_locals_not_reassigned_after_render.rs" = 1
+"bare_bool_args:src/react_compiler/validation/validate_locals_not_reassigned_after_render.rs" = 1
 "reimplemented_helper:src/react_compiler/reactive_scopes/propagate_early_returns.rs" = 1
 
 [bun_runtime]
-"bool_params:src/runtime/api.rs" = 2
-"bool_params:src/runtime/api/bun/h2_frame_parser.rs" = 1
-"bool_params:src/runtime/bake/dev_server/incremental_graph.rs" = 1
-"bool_params:src/runtime/cli/run_command.rs" = 1
-"bool_params:src/runtime/dns_jsc/dns.rs" = 1
-"bool_params:src/runtime/node/types.rs" = 4
-"bypassed_validator:src/runtime/api/js_bundle_completion_task.rs" = 1
-"bypassed_validator:src/runtime/cli/pack_command.rs" = 2
-"bypassed_validator:src/runtime/server/HTMLBundle.rs" = 2
-"bypassed_validator:src/runtime/server/mod.rs" = 1
-"bypassed_validator:src/runtime/server/server_body.rs" = 5
-"collapsed_error:src/runtime/api/bun/Terminal.rs" = 1
-"collapsed_error:src/runtime/api/bun/h2_frame_parser.rs" = 32
-"collapsed_error:src/runtime/ffi/ffi_body.rs" = 1
+"arg_named_like_other_param:src/runtime/cli/install_completions_command.rs" = 4
+"arg_named_like_other_param:src/runtime/cli/open.rs" = 1
+"arg_named_like_other_param:src/runtime/cli/pack_command.rs" = 1
+"arg_named_like_other_param:src/runtime/node/path.rs" = 2
+"bare_bool_args:src/runtime/api.rs" = 2
+"bare_bool_args:src/runtime/api/bun/h2_frame_parser.rs" = 1
+"bare_bool_args:src/runtime/bake/dev_server/incremental_graph.rs" = 1
+"bare_bool_args:src/runtime/cli/run_command.rs" = 1
+"bare_bool_args:src/runtime/dns_jsc/dns.rs" = 1
+"bare_bool_args:src/runtime/node/types.rs" = 4
 "defaulted_failure:src/runtime/ffi/ffi_body.rs" = 1
 "defaulted_failure:src/runtime/server/RequestContext.rs" = 1
 "defaulted_failure:src/runtime/test_runner/pretty_format.rs" = 4
-"dependent_field:src/runtime/cli/filter_run.rs" = 1
-"dependent_field:src/runtime/shell/builtin/rm.rs" = 1
-"misbound_arg:src/runtime/cli/install_completions_command.rs" = 4
-"misbound_arg:src/runtime/cli/open.rs" = 1
-"misbound_arg:src/runtime/cli/pack_command.rs" = 1
-"misbound_arg:src/runtime/node/path.rs" = 2
+"derived_field:src/runtime/test_runner/bun_test.rs" = 1
+"error_collapsed_to_bool:src/runtime/api/bun/Terminal.rs" = 1
+"error_collapsed_to_bool:src/runtime/api/bun/h2_frame_parser.rs" = 32
+"error_collapsed_to_bool:src/runtime/ffi/ffi_body.rs" = 1
+"field_valid_only_when:src/runtime/cli/filter_run.rs" = 1
+"field_valid_only_when:src/runtime/shell/builtin/rm.rs" = 1
+"narrowed_two_ways:src/runtime/node/node_crypto_binding.rs" = 1
 "parallel_vecs:src/runtime/api/html_rewriter.rs" = 1
 "parallel_vecs:src/runtime/bake/dev_server/incremental_graph.rs" = 1
 "reimplemented_helper:src/runtime/api/bun/Terminal.rs" = 1
@@ -92,17 +89,20 @@
 "same_match_twice:src/runtime/shell/builtin/cat.rs" = 1
 "same_match_twice:src/runtime/webcore/Blob.rs" = 2
 "same_match_twice:src/runtime/webcore/Body.rs" = 2
-"stored_projection:src/runtime/test_runner/bun_test.rs" = 1
-"uneven_narrowing:src/runtime/node/node_crypto_binding.rs" = 1
-"unnamed_tuple:src/runtime/server/ServerWebSocket.rs" = 1
-"unnamed_tuple:src/runtime/shell/builtin/which.rs" = 1
+"tuple_wants_struct:src/runtime/server/ServerWebSocket.rs" = 1
+"tuple_wants_struct:src/runtime/shell/builtin/which.rs" = 1
+"unchecked_construction:src/runtime/api/js_bundle_completion_task.rs" = 1
+"unchecked_construction:src/runtime/cli/pack_command.rs" = 2
+"unchecked_construction:src/runtime/server/HTMLBundle.rs" = 2
+"unchecked_construction:src/runtime/server/mod.rs" = 1
+"unchecked_construction:src/runtime/server/server_body.rs" = 5
 
 [bun_shell_parser]
-"bool_params:src/shell_parser/parse.rs" = 1
+"bare_bool_args:src/shell_parser/parse.rs" = 1
 
 [bun_sql_jsc]
-"bool_params:src/sql_jsc/shared/datetime_text.rs" = 1
+"bare_bool_args:src/sql_jsc/shared/datetime_text.rs" = 1
 "same_match_twice:src/sql_jsc/mysql/protocol/ResultSet.rs" = 1
 
 [bun_sys]
-"collapsed_error:src/sys/lib.rs" = 4
+"error_collapsed_to_bool:src/sys/lib.rs" = 4


### PR DESCRIPTION
scarletindustries/mordant#15 renamed twenty-two lints so the name says what is wrong (bypassed_validator is unchecked_construction, wildcard_local_enum is wildcard_over_own_enum, collapsed_error is error_collapsed_to_bool, ...) and dropped the old names outright. This moves the pin there and renames the three affected entries in dylint.toml's `disabled` list and the 47 affected keys in mordant-baseline.toml. Counts are unchanged; the ratchet run is clean at the new pin locally (no over-baseline file).