### PR TITLE
bun test: ignore completions from an earlier attempt of a retried test

### DIFF
--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -159,12 +159,8 @@ pub struct ExecutionSequence {
     pub(crate) test_entry: Option<NonNull<ExecutionEntry>>,
     pub(crate) remaining_repeat_count: u32,
     pub(crate) remaining_retry_count: u32,
-    /// Bumped by every [`Execution::reset_sequence`] (retry or repeat). Each
-    /// callback's [`EntryData`] records the generation it started under, so a
-    /// completion arriving from an earlier attempt of this sequence (a timed-out
-    /// attempt's promise settling or `done()` firing while the retry runs) is
-    /// rejected by [`Execution::get_current_and_valid_execution_sequence`]
-    /// instead of finishing the attempt that is currently running.
+    /// Bumped by every [`Execution::reset_sequence`] (retry or repeat). [`EntryData`] carries the
+    /// generation a callback started under, so a completion from an earlier attempt is stale.
     pub(crate) generation: u32,
     pub(crate) result: Result,
     pub(crate) executing: bool,

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -93,7 +93,7 @@ pub struct Execution {
     /// around `run_test_callback` so code re-entered from a test body (e.g.
     /// spawnSync's wait loop) can read the calling entry's own deadline.
     pub(crate) on_stack_entry: core::cell::Cell<Option<NonNull<ExecutionEntry>>>,
-    /// The (group_index, sequence_index, entry, repeat) for `on_stack_entry`,
+    /// The (sequence_index, entry, generation) for `on_stack_entry`,
     /// set/restored alongside it. `get_current_state_data()` can't name a
     /// sequence inside a concurrent group; this can, for code re-entered from
     /// the microtask drain inside `run_test_callback` (node:test's runtime
@@ -159,6 +159,13 @@ pub struct ExecutionSequence {
     pub(crate) test_entry: Option<NonNull<ExecutionEntry>>,
     pub(crate) remaining_repeat_count: u32,
     pub(crate) remaining_retry_count: u32,
+    /// Bumped by every [`Execution::reset_sequence`] (retry or repeat). Each
+    /// callback's [`EntryData`] records the generation it started under, so a
+    /// completion arriving from an earlier attempt of this sequence (a timed-out
+    /// attempt's promise settling or `done()` firing while the retry runs) is
+    /// rejected by [`Execution::get_current_and_valid_execution_sequence`]
+    /// instead of finishing the attempt that is currently running.
+    pub(crate) generation: u32,
     pub(crate) result: Result,
     pub(crate) executing: bool,
     pub(crate) started_at: Timespec,
@@ -183,6 +190,7 @@ impl ExecutionSequence {
             remaining_repeat_count: repeat_count,
             remaining_retry_count: retry_count,
             // defaults:
+            generation: 0,
             result: Result::Pending,
             executing: false,
             started_at: Timespec::EPOCH,
@@ -475,9 +483,9 @@ impl Execution {
             return None;
         }
         let sequence = &mut self.sequences[seq_abs];
-        if i64::from(sequence.remaining_repeat_count) != entry_data.remaining_repeat_count {
+        if sequence.generation != entry_data.generation {
             group_log::log(format_args!(
-                "runOneCompleted: the data is for a previous repeat count (outdated)",
+                "runOneCompleted: the data is for a previous retry/repeat of the sequence (outdated)",
             ));
             return None;
         }
@@ -740,12 +748,14 @@ impl Execution {
         }
 
         // Preserve retry/repeat counts across reset
+        let generation = sequence.generation;
         *sequence = ExecutionSequence::init(
             sequence.first_entry,
             sequence.test_entry,
             sequence.remaining_retry_count,
             sequence.remaining_repeat_count,
         );
+        sequence.generation = generation.wrapping_add(1);
 
         // Snapshot counters are keyed by full test name and incremented on every
         // toMatchSnapshot() call. Without this reset, retries / repeats would
@@ -1004,7 +1014,7 @@ fn step_sequence_one(
         let entry_data = EntryData {
             sequence_index,
             entry: next_item_ptr.as_ptr() as *const (),
-            remaining_repeat_count: sequence.remaining_repeat_count as i64,
+            generation: sequence.generation,
         };
         let callback_data = RefDataValue::Execution {
             group_index: this.group_index,

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -159,8 +159,7 @@ pub struct ExecutionSequence {
     pub(crate) test_entry: Option<NonNull<ExecutionEntry>>,
     pub(crate) remaining_repeat_count: u32,
     pub(crate) remaining_retry_count: u32,
-    /// Bumped by every [`Execution::reset_sequence`] (retry or repeat). [`EntryData`] carries the
-    /// generation a callback started under, so a completion from an earlier attempt is stale.
+    /// Bumped by every [`Execution::reset_sequence`]; an [`EntryData`] with an older one is from an earlier retry/repeat.
     pub(crate) generation: u32,
     pub(crate) result: Result,
     pub(crate) executing: bool,

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -819,40 +819,31 @@ impl BunTest {
         let [value] = callframe.arguments_as_array::<1>();
 
         let was_error = !value.is_empty_or_undefined_or_null();
-        // A second done() is a no-op (as in Bun 1.2.20; Jest reports it as an error).
         // SAFETY: `this` is the live `*mut DoneCallback` returned by `from_js`;
         // single-threaded JS VM, GC keeps the wrapper alive for the call frame.
-        let (first_call, ref_in) = unsafe {
-            let first_call = !(*this).called;
-            (*this).called = true;
-            (first_call, (*this).r#ref.take())
-        };
-        // RefPtr<T> currently has NO Drop impl, so decrement the
-        // intrusive count explicitly at scope exit. Without this the
-        // paired promise then/catch path never sees has_one_ref()==true and the RefData leaks.
-        let ref_in = ref_in.map(|r| scopeguard::guard(r, |r: RefDataPtr| r.deref()));
-
-        // error is only reported for the first done() call
-        if first_call && was_error {
-            let owner = ref_in
-                .as_ref()
-                .and_then(|r| Some((r.buntest_weak.upgrade()?, &r.phase)));
-            match owner {
-                // Same attribution as `bun_test_then_or_catch`: a stale ref is reported as unhandled, not charged to the running entry.
-                Some((strong, phase)) => {
-                    // SAFETY: `&mut` derived via `UnsafeCell`; the borrow ends with this call.
-                    strong.get().on_uncaught_exception(global_this, Some(value), false, phase);
-                }
-                // No ref yet: done() is still inside its own callback (`run_test_callback` attaches the ref after it returns).
-                None => {
-                    let _ = global_this.bun_vm().as_mut().uncaught_exception(global_this, value, false);
-                }
+        if unsafe { (*this).called } {
+            // in Bun 1.2.20, this is a no-op
+            // in Jest, this is "Expected done to be called once, but it was called multiple times."
+            // Vitest does not support done callbacks
+        } else {
+            // error is only reported for the first done() call
+            if was_error {
+                let _ = global_this.bun_vm().as_mut().uncaught_exception(global_this, value, false);
             }
         }
-
+        // SAFETY: see above — `this` is a live `*mut DoneCallback`.
+        let ref_in = unsafe {
+            (*this).called = true;
+            (*this).r#ref.take()
+        };
         let Some(ref_in) = ref_in else {
             return Ok(JSValue::UNDEFINED);
         };
+        // `this.ref` was already taken above.
+        // RefPtr<T> currently has NO Drop impl, so decrement the
+        // intrusive count explicitly at scope exit. Without this the
+        // paired promise then/catch path never sees has_one_ref()==true and the RefData leaks.
+        let ref_in = scopeguard::guard(ref_in, |r: RefDataPtr| r.deref());
 
         // dupe the ref and enqueue a task to call the done callback.
         // this makes it so if you do something else after calling done(), the next test doesn't start running until the next tick.

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -834,17 +834,16 @@ impl BunTest {
 
         // error is only reported for the first done() call
         if first_call && was_error {
-            // Report against the entry the ref names, like `bun_test_then_or_catch`, so a late
-            // done(error) from a timed-out entry is not charged to whatever runs now. No ref means
-            // done() is still inside its own callback (the ref is attached after it returns).
             let owner = ref_in
                 .as_ref()
                 .and_then(|r| Some((r.buntest_weak.upgrade()?, &r.phase)));
             match owner {
+                // Same attribution as `bun_test_then_or_catch`: a stale ref is reported as unhandled, not charged to the running entry.
                 Some((strong, phase)) => {
                     // SAFETY: `&mut` derived via `UnsafeCell`; the borrow ends with this call.
                     strong.get().on_uncaught_exception(global_this, Some(value), false, phase);
                 }
+                // No ref yet: done() is still inside its own callback (`run_test_callback` attaches the ref after it returns).
                 None => {
                     let _ = global_this.bun_vm().as_mut().uncaught_exception(global_this, value, false);
                 }

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -721,7 +721,7 @@ impl BunTest {
                     entry_data: Some(EntryData {
                         sequence_index: active_sequence_index,
                         entry: active_entry.as_ptr().cast::<()>(),
-                        remaining_repeat_count: sequence.remaining_repeat_count as i64,
+                        generation: sequence.generation,
                     }),
                 }
             }
@@ -1426,7 +1426,8 @@ bun_jsc::jsc_host_abi! {
 pub struct EntryData {
     pub(crate) sequence_index: usize,
     pub(crate) entry: *const (),
-    pub(crate) remaining_repeat_count: i64,
+    /// `ExecutionSequence::generation` at the time the entry was started.
+    pub(crate) generation: u32,
 }
 
 // Clone: bitwise OK — `active_scope` is a non-owning borrow of a
@@ -1493,8 +1494,8 @@ impl fmt::Display for RefDataValue {
                 if let Some(ed) = entry_data {
                     write!(
                         f,
-                        "execution: group_index={},sequence_index={},entry_index={:x},remaining_repeat_count={}",
-                        group_index, ed.sequence_index, ed.entry as usize, ed.remaining_repeat_count
+                        "execution: group_index={},sequence_index={},entry_index={:x},generation={}",
+                        group_index, ed.sequence_index, ed.entry as usize, ed.generation
                     )
                 } else {
                     write!(f, "execution: group_index={}", group_index)

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -819,31 +819,45 @@ impl BunTest {
         let [value] = callframe.arguments_as_array::<1>();
 
         let was_error = !value.is_empty_or_undefined_or_null();
+        // A second done() is a no-op, as in Bun 1.2.20.
+        // In Jest it is "Expected done to be called once, but it was called multiple times."
+        // Vitest does not support done callbacks.
         // SAFETY: `this` is the live `*mut DoneCallback` returned by `from_js`;
         // single-threaded JS VM, GC keeps the wrapper alive for the call frame.
-        if unsafe { (*this).called } {
-            // in Bun 1.2.20, this is a no-op
-            // in Jest, this is "Expected done to be called once, but it was called multiple times."
-            // Vitest does not support done callbacks
-        } else {
-            // error is only reported for the first done() call
-            if was_error {
-                let _ = global_this.bun_vm().as_mut().uncaught_exception(global_this, value, false);
-            }
-        }
-        // SAFETY: see above — `this` is a live `*mut DoneCallback`.
-        let ref_in = unsafe {
+        let (first_call, ref_in) = unsafe {
+            let first_call = !(*this).called;
             (*this).called = true;
-            (*this).r#ref.take()
+            (first_call, (*this).r#ref.take())
         };
-        let Some(ref_in) = ref_in else {
-            return Ok(JSValue::UNDEFINED);
-        };
-        // `this.ref` was already taken above.
         // RefPtr<T> currently has NO Drop impl, so decrement the
         // intrusive count explicitly at scope exit. Without this the
         // paired promise then/catch path never sees has_one_ref()==true and the RefData leaks.
-        let ref_in = scopeguard::guard(ref_in, |r: RefDataPtr| r.deref());
+        let ref_in = ref_in.map(|r| scopeguard::guard(r, |r: RefDataPtr| r.deref()));
+
+        // error is only reported for the first done() call
+        if first_call && was_error {
+            // Report against the entry/attempt the callback was handed to (as `bun_test_then_or_catch`
+            // does for a rejection), so a done(error) that arrives after that entry timed out is an
+            // unhandled error rather than a failure of whatever runs now. The ref is only attached
+            // once the callback returns; a done(error) made while it is still on the stack has no
+            // ref, and the generic path reports against the running entry.
+            let owner = ref_in
+                .as_ref()
+                .and_then(|r| Some((r.buntest_weak.upgrade()?, &r.phase)));
+            match owner {
+                Some((strong, phase)) => {
+                    // SAFETY: `&mut` derived via `UnsafeCell`; the borrow ends with this call.
+                    strong.get().on_uncaught_exception(global_this, Some(value), false, phase);
+                }
+                None => {
+                    let _ = global_this.bun_vm().as_mut().uncaught_exception(global_this, value, false);
+                }
+            }
+        }
+
+        let Some(ref_in) = ref_in else {
+            return Ok(JSValue::UNDEFINED);
+        };
 
         // dupe the ref and enqueue a task to call the done callback.
         // this makes it so if you do something else after calling done(), the next test doesn't start running until the next tick.

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -819,9 +819,7 @@ impl BunTest {
         let [value] = callframe.arguments_as_array::<1>();
 
         let was_error = !value.is_empty_or_undefined_or_null();
-        // A second done() is a no-op, as in Bun 1.2.20.
-        // In Jest it is "Expected done to be called once, but it was called multiple times."
-        // Vitest does not support done callbacks.
+        // A second done() is a no-op (as in Bun 1.2.20; Jest reports it as an error).
         // SAFETY: `this` is the live `*mut DoneCallback` returned by `from_js`;
         // single-threaded JS VM, GC keeps the wrapper alive for the call frame.
         let (first_call, ref_in) = unsafe {
@@ -836,11 +834,9 @@ impl BunTest {
 
         // error is only reported for the first done() call
         if first_call && was_error {
-            // Report against the entry/attempt the callback was handed to (as `bun_test_then_or_catch`
-            // does for a rejection), so a done(error) that arrives after that entry timed out is an
-            // unhandled error rather than a failure of whatever runs now. The ref is only attached
-            // once the callback returns; a done(error) made while it is still on the stack has no
-            // ref, and the generic path reports against the running entry.
+            // Report against the entry the ref names, like `bun_test_then_or_catch`, so a late
+            // done(error) from a timed-out entry is not charged to whatever runs now. No ref means
+            // done() is still inside its own callback (the ref is attached after it returns).
             let owner = ref_in
                 .as_ref()
                 .and_then(|r| Some((r.buntest_weak.upgrade()?, &r.phase)));

--- a/test/js/bun/test/test-error-code-done-callback.test.ts
+++ b/test/js/bun/test/test-error-code-done-callback.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe } from "harness";
 import path from "path";
 
 test("verify we print error messages passed to done callbacks", () => {
@@ -80,6 +80,7 @@ test("verify we print error messages passed to done callbacks", () => {
     ^
     error: you should see this(async)
     at <anonymous> (<dir>/test-error-done-callback-fixture.ts:42:14)
+    at <anonymous> (<dir>/test-error-done-callback-fixture.ts:37:3)
     (fail) error done callback (async)
     43 |   });
     44 | });
@@ -110,6 +111,7 @@ test("verify we print error messages passed to done callbacks", () => {
     ^
     error: you should see this(async, nextTick)
     at <anonymous> (<dir>/test-error-done-callback-fixture.ts:60:14)
+    at <anonymous> (<dir>/test-error-done-callback-fixture.ts:54:5)
     (fail) error done callback (async, nextTick)
     62 | });
     63 |
@@ -137,71 +139,4 @@ test("verify we print error messages passed to done callbacks", () => {
     Ran 9 tests across 1 file.
     "
   `);
-});
-
-async function runDoneFixture(name: string, source: string) {
-  using dir = tempDir(name, { "done.test.ts": source });
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "test", "done.test.ts"],
-    env: bunEnv,
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  return { stdout, stderr, exitCode };
-}
-
-test.concurrent("done(error) from a test that already timed out is not charged to the test running now", async () => {
-  const { stdout, stderr, exitCode } = await runDoneFixture(
-    "done-error-after-timeout",
-    `
-      import { test } from "bun:test";
-      let firstDone: (err?: unknown) => void;
-      test("first", done => {
-        firstDone = done;
-      }, { timeout: 100 });
-      test("second", done => {
-        firstDone(new Error("late error from first"));
-        setTimeout(() => {
-          console.log("second body finished");
-          done();
-        }, 1);
-      }, { timeout: 500 });
-    `,
-  );
-
-  // Same report as a timed-out test's promise rejecting during the next test.
-  expect(stdout).toContain("second body finished");
-  expect(stderr).toContain("(fail) first");
-  expect(stderr).toContain("Unhandled error between tests");
-  expect(stderr).toContain("error: late error from first");
-  expect(stderr).toContain("(pass) second");
-  expect(stderr).toContain("1 pass");
-  expect(stderr).toContain("1 fail");
-  expect(stderr).toContain("1 error");
-  expect(exitCode).toBe(1);
-});
-
-test.concurrent("done(error) called later from a concurrent test fails that test", async () => {
-  const { stderr, exitCode } = await runDoneFixture(
-    "done-error-concurrent",
-    `
-      import { test } from "bun:test";
-      test.concurrent("fails", done => {
-        setTimeout(() => done(new Error("reported through done")), 1);
-      });
-      test.concurrent("passes", done => {
-        setTimeout(() => done(), 1);
-      });
-    `,
-  );
-
-  expect(stderr).toContain("error: reported through done");
-  expect(stderr).toContain("(fail) fails");
-  expect(stderr).toContain("(pass) passes");
-  expect(stderr).not.toContain("Unhandled error between tests");
-  expect(stderr).toContain("1 pass");
-  expect(stderr).toContain("1 fail");
-  expect(exitCode).toBe(1);
 });

--- a/test/js/bun/test/test-error-code-done-callback.test.ts
+++ b/test/js/bun/test/test-error-code-done-callback.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import path from "path";
 
 test("verify we print error messages passed to done callbacks", () => {
@@ -80,7 +80,6 @@ test("verify we print error messages passed to done callbacks", () => {
     ^
     error: you should see this(async)
     at <anonymous> (<dir>/test-error-done-callback-fixture.ts:42:14)
-    at <anonymous> (<dir>/test-error-done-callback-fixture.ts:37:3)
     (fail) error done callback (async)
     43 |   });
     44 | });
@@ -111,7 +110,6 @@ test("verify we print error messages passed to done callbacks", () => {
     ^
     error: you should see this(async, nextTick)
     at <anonymous> (<dir>/test-error-done-callback-fixture.ts:60:14)
-    at <anonymous> (<dir>/test-error-done-callback-fixture.ts:54:5)
     (fail) error done callback (async, nextTick)
     62 | });
     63 |
@@ -139,4 +137,71 @@ test("verify we print error messages passed to done callbacks", () => {
     Ran 9 tests across 1 file.
     "
   `);
+});
+
+async function runDoneFixture(name: string, source: string) {
+  using dir = tempDir(name, { "done.test.ts": source });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "done.test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+test.concurrent("done(error) from a test that already timed out is not charged to the test running now", async () => {
+  const { stdout, stderr, exitCode } = await runDoneFixture(
+    "done-error-after-timeout",
+    `
+      import { test } from "bun:test";
+      let firstDone: (err?: unknown) => void;
+      test("first", done => {
+        firstDone = done;
+      }, { timeout: 100 });
+      test("second", done => {
+        firstDone(new Error("late error from first"));
+        setTimeout(() => {
+          console.log("second body finished");
+          done();
+        }, 1);
+      }, { timeout: 500 });
+    `,
+  );
+
+  // Same report as a timed-out test's promise rejecting during the next test.
+  expect(stdout).toContain("second body finished");
+  expect(stderr).toContain("(fail) first");
+  expect(stderr).toContain("Unhandled error between tests");
+  expect(stderr).toContain("error: late error from first");
+  expect(stderr).toContain("(pass) second");
+  expect(stderr).toContain("1 pass");
+  expect(stderr).toContain("1 fail");
+  expect(stderr).toContain("1 error");
+  expect(exitCode).toBe(1);
+});
+
+test.concurrent("done(error) called later from a concurrent test fails that test", async () => {
+  const { stderr, exitCode } = await runDoneFixture(
+    "done-error-concurrent",
+    `
+      import { test } from "bun:test";
+      test.concurrent("fails", done => {
+        setTimeout(() => done(new Error("reported through done")), 1);
+      });
+      test.concurrent("passes", done => {
+        setTimeout(() => done(), 1);
+      });
+    `,
+  );
+
+  expect(stderr).toContain("error: reported through done");
+  expect(stderr).toContain("(fail) fails");
+  expect(stderr).toContain("(pass) passes");
+  expect(stderr).not.toContain("Unhandled error between tests");
+  expect(stderr).toContain("1 pass");
+  expect(stderr).toContain("1 fail");
+  expect(exitCode).toBe(1);
 });

--- a/test/js/bun/test/test-retry-repeats-basic.test.ts
+++ b/test/js/bun/test/test-retry-repeats-basic.test.ts
@@ -37,6 +37,13 @@ async function runRetryFixture(name: string, source: string) {
 // In each fixture below, attempt 1 times out while waiting on something that
 // attempt 2 completes as soon as it starts. Attempt 1's late completion must
 // not count as the completion of attempt 2.
+//
+// The ordering does not depend on timers: attempt 1's completion is queued while
+// attempt 2's body is still on the stack (synchronously by done(), or in the
+// microtask drain that follows the body), and the runner consumes it in the same
+// step, before anything attempt 2 scheduled can run. On an unfixed runner attempt
+// 2 is therefore reported as passed before its own timer fires; the timers only
+// keep attempt 2 alive past that point.
 
 test.concurrent("a late resolve from a timed-out attempt does not complete the retry", async () => {
   const { stdout, stderr, exitCode } = await runRetryFixture(

--- a/test/js/bun/test/test-retry-repeats-basic.test.ts
+++ b/test/js/bun/test/test-retry-repeats-basic.test.ts
@@ -36,7 +36,9 @@ async function runRetryFixture(name: string, source: string) {
 
 // In each fixture below, attempt 1 times out while waiting on something that
 // attempt 2 completes as soon as it starts. Attempt 1's late completion must
-// not count as the completion of attempt 2.
+// not count as the completion of attempt 2, and a late error from attempt 1 is
+// reported the way a timed-out test's late error is reported while the next
+// test runs: as an unhandled error between tests, leaving attempt 2 alone.
 
 test.concurrent("a late resolve from a timed-out attempt does not complete the retry", async () => {
   const { stdout, stderr, exitCode } = await runRetryFixture(
@@ -124,6 +126,39 @@ test.concurrent("a late done() from a timed-out attempt does not complete the re
   expect(exitCode).toBe(1);
 });
 
+test.concurrent("a late done(error) from a timed-out attempt is not attributed to the retry", async () => {
+  const { stdout, stderr, exitCode } = await runRetryFixture(
+    "retry-stale-done-error",
+    `
+      import { test } from "bun:test";
+      let firstDone: (err?: unknown) => void;
+      let attempt = 0;
+      test("retry", done => {
+        attempt++;
+        if (attempt === 1) {
+          firstDone = done;
+          return;
+        }
+        firstDone(new Error("late error from attempt 1"));
+        setTimeout(() => {
+          console.log("attempt 2 body finished");
+          done();
+        }, 1);
+      }, { retry: 2, timeout: 500 });
+    `,
+  );
+
+  expect(stdout).toContain("attempt 2 body finished");
+  expect(stderr).toContain("Unhandled error between tests");
+  expect(stderr).toContain("error: late error from attempt 1");
+  expect(stderr).toContain("(pass) retry (attempt 2)");
+  expect(stderr).not.toContain("(attempt 3)");
+  expect(stderr).toContain("1 pass");
+  expect(stderr).toContain("0 fail");
+  expect(stderr).toContain("1 error");
+  expect(exitCode).toBe(1);
+});
+
 test.concurrent("a late rejection from a timed-out attempt is not attributed to the retry", async () => {
   const { stdout, stderr, exitCode } = await runRetryFixture(
     "retry-stale-reject",
@@ -144,8 +179,6 @@ test.concurrent("a late rejection from a timed-out attempt is not attributed to 
     `,
   );
 
-  // Same as a timed-out test's promise rejecting while the next test runs: the
-  // error is reported between tests, and the running attempt is left alone.
   expect(stdout).toContain("attempt 2 body finished");
   expect(stderr).toContain("Unhandled error between tests");
   expect(stderr).toContain("error: late rejection from attempt 1");

--- a/test/js/bun/test/test-retry-repeats-basic.test.ts
+++ b/test/js/bun/test/test-retry-repeats-basic.test.ts
@@ -1,8 +1,8 @@
-// Runs the retry/repeats hook-ordering checks in a subprocess so the
-// intentional intermediate retry failures don't leak into this run's
-// reporter output (JUnit, GitHub Actions annotations).
+// Every check here runs `bun test` in a subprocess so the intentional
+// intermediate retry failures don't leak into this run's reporter output
+// (JUnit, GitHub Actions annotations).
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "node:path";
 
 test("retry and repeats hook ordering", async () => {
@@ -19,4 +19,140 @@ test("retry and repeats hook ordering", async () => {
   expect(stderr).toContain("0 fail");
   expect(stderr).toContain("(attempt 3)");
   expect(exitCode).toBe(0);
+});
+
+async function runRetryFixture(name: string, source: string) {
+  using dir = tempDir(name, { "retry.test.ts": source });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "retry.test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+// In each fixture below, attempt 1 times out while waiting on something that
+// attempt 2 completes as soon as it starts. Attempt 1's late completion must
+// not count as the completion of attempt 2.
+
+test.concurrent("a late resolve from a timed-out attempt does not complete the retry", async () => {
+  const { stdout, stderr, exitCode } = await runRetryFixture(
+    "retry-stale-resolve",
+    `
+      import { test, expect } from "bun:test";
+      const first = Promise.withResolvers<void>();
+      let attempt = 0;
+      test("retry", async () => {
+        attempt++;
+        if (attempt === 1) {
+          await first.promise;
+          return;
+        }
+        first.resolve();
+        await Bun.sleep(1);
+        console.log("attempt 2 body finished");
+        expect(attempt).toBe(1);
+      }, { retry: 1, timeout: 500 });
+    `,
+  );
+
+  expect(stdout).toContain("attempt 2 body finished");
+  expect(stderr).toContain("(fail) retry (attempt 2)");
+  expect(stderr).toContain("Expected: 1");
+  expect(stderr).toContain("Received: 2");
+  expect(stderr).toContain("0 pass");
+  expect(stderr).toContain("1 fail");
+  expect(exitCode).toBe(1);
+});
+
+test.concurrent("a late resolve from a timed-out attempt keeps the retry's own timeout armed", async () => {
+  const { stderr, exitCode } = await runRetryFixture(
+    "retry-stale-resolve-timeout",
+    `
+      import { test } from "bun:test";
+      const first = Promise.withResolvers<void>();
+      let attempt = 0;
+      test("retry", async () => {
+        attempt++;
+        if (attempt === 1) {
+          await first.promise;
+          return;
+        }
+        first.resolve();
+        await new Promise(() => {});
+      }, { retry: 1, timeout: 100 });
+    `,
+  );
+
+  expect(stderr).toContain("(fail) retry (attempt 2)");
+  expect(stderr).toContain("this test timed out after 100ms");
+  expect(stderr).toContain("0 pass");
+  expect(stderr).toContain("1 fail");
+  expect(exitCode).toBe(1);
+});
+
+test.concurrent("a late done() from a timed-out attempt does not complete the retry", async () => {
+  const { stdout, stderr, exitCode } = await runRetryFixture(
+    "retry-stale-done",
+    `
+      import { test } from "bun:test";
+      let firstDone: (err?: unknown) => void;
+      let attempt = 0;
+      test("retry", done => {
+        attempt++;
+        if (attempt === 1) {
+          firstDone = done;
+          return;
+        }
+        firstDone();
+        setTimeout(() => {
+          console.log("attempt 2 body finished");
+          done(new Error("attempt 2 failed on its own"));
+        }, 1);
+      }, { retry: 1, timeout: 500 });
+    `,
+  );
+
+  expect(stdout).toContain("attempt 2 body finished");
+  expect(stderr).toContain("error: attempt 2 failed on its own");
+  expect(stderr).toContain("(fail) retry (attempt 2)");
+  expect(stderr).toContain("0 pass");
+  expect(stderr).toContain("1 fail");
+  expect(exitCode).toBe(1);
+});
+
+test.concurrent("a late rejection from a timed-out attempt is not attributed to the retry", async () => {
+  const { stdout, stderr, exitCode } = await runRetryFixture(
+    "retry-stale-reject",
+    `
+      import { test } from "bun:test";
+      const first = Promise.withResolvers<void>();
+      let attempt = 0;
+      test("retry", async () => {
+        attempt++;
+        if (attempt === 1) {
+          await first.promise;
+          return;
+        }
+        first.reject(new Error("late rejection from attempt 1"));
+        await Bun.sleep(1);
+        console.log("attempt 2 body finished");
+      }, { retry: 2, timeout: 500 });
+    `,
+  );
+
+  // Same as a timed-out test's promise rejecting while the next test runs: the
+  // error is reported between tests, and the running attempt is left alone.
+  expect(stdout).toContain("attempt 2 body finished");
+  expect(stderr).toContain("Unhandled error between tests");
+  expect(stderr).toContain("error: late rejection from attempt 1");
+  expect(stderr).toContain("(pass) retry (attempt 2)");
+  expect(stderr).not.toContain("(attempt 3)");
+  expect(stderr).toContain("1 pass");
+  expect(stderr).toContain("0 fail");
+  expect(stderr).toContain("1 error");
+  expect(exitCode).toBe(1);
 });

--- a/test/js/bun/test/test-retry-repeats-basic.test.ts
+++ b/test/js/bun/test/test-retry-repeats-basic.test.ts
@@ -36,9 +36,7 @@ async function runRetryFixture(name: string, source: string) {
 
 // In each fixture below, attempt 1 times out while waiting on something that
 // attempt 2 completes as soon as it starts. Attempt 1's late completion must
-// not count as the completion of attempt 2, and a late error from attempt 1 is
-// reported the way a timed-out test's late error is reported while the next
-// test runs: as an unhandled error between tests, leaving attempt 2 alone.
+// not count as the completion of attempt 2.
 
 test.concurrent("a late resolve from a timed-out attempt does not complete the retry", async () => {
   const { stdout, stderr, exitCode } = await runRetryFixture(
@@ -126,39 +124,6 @@ test.concurrent("a late done() from a timed-out attempt does not complete the re
   expect(exitCode).toBe(1);
 });
 
-test.concurrent("a late done(error) from a timed-out attempt is not attributed to the retry", async () => {
-  const { stdout, stderr, exitCode } = await runRetryFixture(
-    "retry-stale-done-error",
-    `
-      import { test } from "bun:test";
-      let firstDone: (err?: unknown) => void;
-      let attempt = 0;
-      test("retry", done => {
-        attempt++;
-        if (attempt === 1) {
-          firstDone = done;
-          return;
-        }
-        firstDone(new Error("late error from attempt 1"));
-        setTimeout(() => {
-          console.log("attempt 2 body finished");
-          done();
-        }, 1);
-      }, { retry: 2, timeout: 500 });
-    `,
-  );
-
-  expect(stdout).toContain("attempt 2 body finished");
-  expect(stderr).toContain("Unhandled error between tests");
-  expect(stderr).toContain("error: late error from attempt 1");
-  expect(stderr).toContain("(pass) retry (attempt 2)");
-  expect(stderr).not.toContain("(attempt 3)");
-  expect(stderr).toContain("1 pass");
-  expect(stderr).toContain("0 fail");
-  expect(stderr).toContain("1 error");
-  expect(exitCode).toBe(1);
-});
-
 test.concurrent("a late rejection from a timed-out attempt is not attributed to the retry", async () => {
   const { stdout, stderr, exitCode } = await runRetryFixture(
     "retry-stale-reject",
@@ -179,6 +144,8 @@ test.concurrent("a late rejection from a timed-out attempt is not attributed to 
     `,
   );
 
+  // Same as a timed-out test's promise rejecting while the next test runs: the
+  // error is reported between tests, and the running attempt is left alone.
   expect(stdout).toContain("attempt 2 body finished");
   expect(stderr).toContain("Unhandled error between tests");
   expect(stderr).toContain("error: late rejection from attempt 1");


### PR DESCRIPTION
### Problem

- `test(name, fn, { retry, timeout })`: when attempt 1 times out and its promise settles (or its `done()` fires) while attempt 2 is running, the runner takes that as attempt 2 finishing. Attempt 2 is printed as `(pass) name (attempt 2)` while its body is still running, and the assertion failure or timeout it would have produced is never reported. Repro below ends with `1 pass`, exit 0.
- A late rejection from attempt 1 is charged to attempt 2 instead: attempt 2 is failed and, with `retry: 2`, attempt 3 starts while attempt 2's body is still running.
- Cause: a completion carries `EntryData { sequence_index, entry, remaining_repeat_count }` (`src/runtime/test_runner/bun_test.rs`) and `Execution::get_current_and_valid_execution_sequence` (`src/runtime/test_runner/Execution.rs`) accepts it as long as those still match the sequence. A retry (`advance_sequence` -> `reset_sequence`, same file) decrements `remaining_retry_count` only and re-activates the same entry pointer, so attempt 1's completion is indistinguishable from attempt 2's. Repeats were already told apart because each repeat changes `remaining_repeat_count`; retries were not.

### Fix

- `ExecutionSequence` gets a `generation` counter that every `reset_sequence` (retry or repeat) bumps. `EntryData` records the generation the callback started under, in place of the repeat count, and `get_current_and_valid_execution_sequence` compares it.
- Correct because the generation identifies one attempt of a sequence, and every consumer of a stored `EntryData` goes through that one check: `Execution::step` (the promise `then` registered in `run_test_callback`, and `done()`), `Execution::handle_uncaught_exception` (the promise `catch`), `RefDataValue::entry`, and node:test's runtime `t.skip()`/`t.todo()` mark. Data from an earlier attempt is discarded on all of them, exactly as data from an earlier repeat already was; repeats themselves behave as before since a repeat bumps the generation too.
- A late rejection from an earlier attempt now takes the path a timed-out test's promise rejecting during the next test already takes: it is printed as an unhandled error between tests (`1 error`, exit 1) and the running attempt is left alone.
- Not covered here: `done(error)`. `bun_test_done_callback` reports the error through the VM's generic uncaught-exception path, which never looks at the callback's stored `EntryData`, so a late `done(error)` from an earlier attempt is still charged to the running attempt (today it is also charged to the next test in the no-retry case). #33089 reroutes `done(error)` through the stored ref; rebased on this change it covers the retry case as well, and the test cases for it are posted there. An earlier revision of this PR carried a subset of that rerouting; it was dropped because it overlapped #33089 (and #34041, which edits the same block) and changed hook `done(error)` semantics only for callbacks fired from a macrotask.
- Also not covered here: what an abandoned attempt's body does apart from completing, such as late `expect()` or snapshot calls landing on the running attempt. `expect()` records the sequence slot it was created in on purpose (an expect created in a hook counts toward its test), so this PR's entry/generation check is not the right filter for it; #38880 tracks abandoned invocations for that.
- Verified with `test/js/bun/test/test-retry-repeats-basic.test.ts`: four new cases (late resolve; late resolve with the retry then hitting its own timeout; late `done()`; late rejection). All four fail on the unfixed binary and pass with the fix; 10 consecutive local runs pass.
- Also green with the fix: `test/cli/test/retry-flag.test.ts`, `test/cli/test/rerun-each.test.ts`, `test/cli/test/bun-test.test.ts`, `test/js/junit-reporter/junit.test.js`, `test/js/node/test_runner/node-test.test.ts`, and the runner suites in `test/js/bun/test` (`bun_test`, `bun-test`, `test-test`, `concurrent*`, `done-async`, `failure-skip`, `expect-assertions`, `test-failing`, `test-on-test-finished`, `test-error-code-done-callback`, `jest-hooks`).

### Background

- An `ExecutionSequence` is the runner's unit for one test: its `beforeEach` hooks, the test callback and its `afterEach` hooks, run in order. `retry` and `repeats` rerun the same sequence object: `reset_sequence` re-initializes it in place and keeps the same entry pointers.
- When the runner starts an entry's callback it builds an `EntryData` (wrapped in a `RefDataValue`) and attaches it to the callback's promise reactions and to its `done` callback. When one of those fires, the record is compared with what is running now, so a callback that outlived its attempt (for example by timing out) cannot act on whatever the runner moved on to. Before this change the only per-attempt component of that record was the repeat count.
- "Unhandled error between tests" is the runner's report for an error it cannot attribute to a running entry; it counts as an error in the summary and fails the run.

<details>
<summary>Repro</summary>

```ts
import { test, expect } from "bun:test";
const first = Promise.withResolvers<void>();
let attempt = 0;
test("retry", async () => {
  attempt++;
  if (attempt === 1) {
    await first.promise; // times out
    return;
  }
  first.resolve(); // attempt 1's promise now settles, during attempt 2
  await Bun.sleep(1);
  console.log("attempt 2 body finished"); // never printed before the fix
  expect(attempt).toBe(1); // attempt 2 must fail
}, { retry: 1, timeout: 500 });
```

Before:

```
(pass) retry (attempt 2) [0.10ms]

 1 pass
 0 fail
```

After:

```
attempt 2 body finished
error: expect(received).toBe(expected)
...
(fail) retry (attempt 2) [5.84ms]

 0 pass
 1 fail
```

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/test-retry-repeats-basic.test.ts
bun test v1.4.0 (1bec8cdaa)

test/js/bun/test/test-retry-repeats-basic.test.ts:
(pass) retry and repeats hook ordering [2797.72ms]
92 |         await new Promise(() => {});
93 |       }, { retry: 1, timeout: 100 });
94 |     `,
95 |   );
96 | 
97 |   expect(stderr).toContain("(fail) retry (attempt 2)");
                      ^
error: expect(received).toContain(expected)

Expected to contain: "(fail) retry (attempt 2)"
Received: "\nretry.test.ts:\n(pass) retry (attempt 2) [6.51ms]\n\n 1 pass\n 0 fail\nRan 1 test across 1 file. [615.00ms]\n"

      at <anonymous> (/workspace/bun/test/js/bun/test/test-retry-repeats-basic.test.ts:97:18)
(fail) a late resolve from a timed-out attempt keeps the retry's own timeout armed [788.91ms]
64 |         expect(attempt).toBe(1);
65 |       }, { retry: 1, timeout: 500 });
66 |     `,
67 |   );
68 | 
69 |   expect(stdout).toContain("attempt 2 body finished");
                      ^
error: expect(received).toContain(expected)

Expected to contain: "attemp
... (truncated)

release without fix: 4 FAILED
bun test v1.4.0-canary.1 (eabb96de7)

test/js/bun/test/test-retry-repeats-basic.test.ts:
(pass) retry and repeats hook ordering [61.05ms]
92 |         await new Promise(() => {});
93 |       }, { retry: 1, timeout: 100 });
94 |     `,
95 |   );
96 | 
97 |   expect(stderr).toContain("(fail) retry (attempt 2)");
                      ^
error: expect(received).toContain(expected)

Expected to contain: "(fail) retry (attempt 2)"
Received: "\nretry.test.ts:\n(pass) retry (attempt 2) [3.45ms]\n\n 1 pass\n 0 fail\nRan 1 test across 1 file. [163.00ms]\n"

      at <anonymous> (/workspace/bun/test/js/bun/test/test-retry-repeats-basic.test.ts:97:18)
(fail) a late resolve from a timed-out attempt keeps the retry's own timeout armed [208.48ms]
64 |         expect(attempt).toBe(1);
65 |       }, { retry: 1, timeout: 500 });
66 |     `,
67 |   );
68 | 
69 |   expect(stdout).toContain("attempt 2 body finished");
                      ^
error: expect(received).toContain(expected)

Expected to contain: "attempt 2 body finished"
Received: "bun test v1.4.0-canary.1 (eabb96de7)\n"

      at <anonymous> (/workspace/bun/test/js/bun/test/test-retry-repeats-basic.test.ts:69:18)
(fail) a la
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/test-retry-repeats-basic.test.ts
bun test v1.4.0 (1bec8cdaa)

test/js/bun/test/test-retry-repeats-basic.test.ts:
(pass) retry and repeats hook ordering [2467.88ms]
(pass) a late resolve from a timed-out attempt keeps the retry's own timeout armed [656.25ms]
(pass) a late rejection from a timed-out attempt is not attributed to the retry [948.55ms]
(pass) a late done() from a timed-out attempt does not complete the retry [977.64ms]
(pass) a late resolve from a timed-out attempt does not complete the retry [1059.82ms]

 5 pass
 0 fail
 31 expect() calls
Ran 5 tests across 1 file. [6.45s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 808ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/656] cc obj/vendor/tinycc/tccpp.c.o
[2/656] cc obj/vendor/tinycc/x86_64-gen.c.o
[3/656] cc obj/vendor/tinycc/libtcc.c.o
[4/656] fetch lshpack
[lshpack] up to date
[5/654] cc obj/vendor/tinycc/tccdbg.c.o
[6/654] cc obj/vendor/tinycc/tccasm.c.o
[7/654] cc obj/vendor/tinycc/i386-asm.c.o
[8/654] cc obj/vendor/tinycc/x86_64-link.c.o
[9/654] fetch boringssl
[boringssl] up to date
[10/232] cc obj/vendor/tinycc/tccrun.c.o
[11/232] gen ZigGeneratedClasses.lut.h
Generating /workspace/bun/build/release/codegen/ZigGeneratedClasses.lut.h from /workspace/bun/build/release/codegen/ZigGeneratedClasses.lut.txt
[12/232] fetch lsqpack
[lsqpack] up to date
[13/232] fetch lsquic
[lsquic] up to date
[14/163] fetch WebKit (prebuilt)
[WebKit] up to date
[15/163] cc obj/vendor/tinycc/tccgen.c.o
[16/163] cc obj/vendor/tinycc/tccelf.c.o
[17/163] fetch lolhtml
[lolhtml] up to date
[18/163] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 240 extern-C blocks audited
[19/163]
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/test_runner/Execution.rs              |  13 +-
 src/runtime/test_runner/bun_test.rs               |   9 +-
 test/js/bun/test/test-retry-repeats-basic.test.ts | 151 +++++++++++++++++++++-
 3 files changed, 161 insertions(+), 12 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
src/runtime/test_runner/Execution.rs                   6      9      0
src/runtime/test_runner/bun_test.rs                    9      9      0
test/js/bun/test/test-retry-repeats-basic.test.ts      3      8      0
```

</details>

<!-- robobun:evidence:end -->