### PR TITLE
cli: exit 128 + signo when the re-raise of a child's signal is not delivered (bun as container PID 1)

### DIFF
--- a/src/bun_core/Global.rs
+++ b/src/bun_core/Global.rs
@@ -800,7 +800,7 @@ pub fn raise_ignoring_panic_handler_raw(sig: c_int) -> ! {
             let _ = libc::sigaction(sig, &raw const sa, core::ptr::null_mut());
         }
 
-        // The mask is inherited across execve; a blocked `sig` would only go pending.
+        // Whatever left `sig` blocked, raise() would only make it pending.
         // SAFETY: zeroed sigset is valid; sigemptyset/sigaddset initialize it.
         unsafe {
             let mut set: libc::sigset_t = crate::ffi::zeroed();

--- a/src/bun_core/Global.rs
+++ b/src/bun_core/Global.rs
@@ -691,6 +691,8 @@ unsafe extern "C" {
     #[cfg(unix)]
     #[link_name = "exit"]
     safe fn libc_exit(code: c_int) -> !;
+    #[cfg(not(windows))]
+    safe fn _exit(code: c_int) -> !;
     #[cfg(all(unix, not(target_os = "macos")))]
     safe fn quick_exit(code: c_int) -> !;
 }
@@ -813,8 +815,8 @@ pub fn raise_ignoring_panic_handler_raw(sig: c_int) -> ! {
 
     #[cfg(not(windows))]
     {
-        // Only PID 1 of a pid namespace gets here (init cannot signal itself); abort() would trap.
-        exit((128 + sig) as u32)
+        // Only PID 1 of a pid namespace gets here; like a signal death, run no exit handlers.
+        _exit(128 + sig)
     }
     #[cfg(windows)]
     {

--- a/src/bun_core/Global.rs
+++ b/src/bun_core/Global.rs
@@ -683,6 +683,7 @@ fn is_exiting() -> bool {
 // calls. `#[link_name]` avoids colliding with this module's own `pub fn exit`.
 #[allow(suspicious_runtime_symbol_definitions)] // signatures are ABI-identical; `safe fn` is intentional (above)
 unsafe extern "C" {
+    #[cfg(windows)]
     #[link_name = "abort"]
     safe fn libc_abort() -> !;
     #[link_name = "raise"]
@@ -735,9 +736,10 @@ pub fn raise_ignoring_panic_handler(sig: crate::SignalCode) -> ! {
     raise_ignoring_panic_handler_raw(sig as c_int)
 }
 
-/// Re-raise `sig` (raw `c_int`) after restoring TTY/crash state. Callers may
-/// forward any signal byte (incl. Linux RT signals 32..=64) that has no
-/// `crate::SignalCode` discriminant.
+/// Re-raise `sig` (raw `c_int`) after restoring TTY/crash state, or exit with
+/// `128 + sig` where the kernel refuses to deliver it (PID 1 of a pid
+/// namespace). Callers may forward any signal byte (incl. Linux RT signals
+/// 32..=64) that has no `crate::SignalCode` discriminant.
 pub fn raise_ignoring_panic_handler_raw(sig: c_int) -> ! {
     Output::flush();
     Output::source::stdio::restore();
@@ -796,11 +798,38 @@ pub fn raise_ignoring_panic_handler_raw(sig: c_int) -> ! {
             sa.sa_flags = libc::SA_RESETHAND;
             let _ = libc::sigaction(sig, &raw const sa, core::ptr::null_mut());
         }
+
+        // The signal mask survives execve, so a parent that had `sig` blocked
+        // started us with it blocked too; raise() would then only leave it
+        // pending.
+        // SAFETY: zeroed sigset is valid; sigemptyset/sigaddset initialize it.
+        unsafe {
+            let mut set: libc::sigset_t = crate::ffi::zeroed();
+            libc::sigemptyset(&raw mut set);
+            libc::sigaddset(&raw mut set, sig);
+            let _ = libc::pthread_sigmask(libc::SIG_UNBLOCK, &raw const set, core::ptr::null_mut());
+        }
     }
 
-    // kill self — `raise`/`abort` have no preconditions (see `safe fn` decls above).
+    // kill self; `raise` has no preconditions (see the `safe fn` decl above).
     let _ = libc_raise(sig);
-    libc_abort();
+
+    #[cfg(not(windows))]
+    {
+        // Unblocked and at SIG_DFL, raise() only returns when this process is
+        // PID 1 of a pid namespace (the entrypoint of a container without an
+        // init): the kernel discards default-action signals sent to init,
+        // SIGABRT included, so abort() would end in its trap instruction and
+        // turn the child's signal into a SIGSEGV/SIGTRAP of our own. Report
+        // the signal the way a shell does instead.
+        exit((128 + sig) as u32)
+    }
+    #[cfg(windows)]
+    {
+        // The CRT's raise() ignores SIGTERM and rejects signals it does not
+        // know, so returning from it is routine here.
+        libc_abort()
+    }
 }
 
 #[derive(Default)]

--- a/src/bun_core/Global.rs
+++ b/src/bun_core/Global.rs
@@ -736,8 +736,7 @@ pub fn raise_ignoring_panic_handler(sig: crate::SignalCode) -> ! {
     raise_ignoring_panic_handler_raw(sig as c_int)
 }
 
-/// Re-raise `sig` (raw `c_int`) after restoring TTY/crash state; as PID 1 of a
-/// pid namespace, where that cannot kill us, exit with `128 + sig`. Callers may
+/// Re-raise `sig` (raw `c_int`) after restoring TTY/crash state. Callers may
 /// forward any signal byte (incl. Linux RT signals 32..=64) that has no
 /// `crate::SignalCode` discriminant.
 pub fn raise_ignoring_panic_handler_raw(sig: c_int) -> ! {
@@ -814,9 +813,7 @@ pub fn raise_ignoring_panic_handler_raw(sig: c_int) -> ! {
 
     #[cfg(not(windows))]
     {
-        // Only PID 1 of a pid namespace gets here: the kernel discards the signals
-        // it raises at itself, abort()'s SIGABRT included, and abort() would end
-        // in a trap (SIGSEGV/SIGTRAP). Report the signal the way a shell does.
+        // Only PID 1 of a pid namespace gets here (init cannot signal itself); abort() would trap.
         exit((128 + sig) as u32)
     }
     #[cfg(windows)]

--- a/src/bun_core/Global.rs
+++ b/src/bun_core/Global.rs
@@ -736,10 +736,10 @@ pub fn raise_ignoring_panic_handler(sig: crate::SignalCode) -> ! {
     raise_ignoring_panic_handler_raw(sig as c_int)
 }
 
-/// Re-raise `sig` (raw `c_int`) after restoring TTY/crash state, or exit with
-/// `128 + sig` where the kernel refuses to deliver it (PID 1 of a pid
-/// namespace). Callers may forward any signal byte (incl. Linux RT signals
-/// 32..=64) that has no `crate::SignalCode` discriminant.
+/// Re-raise `sig` (raw `c_int`) after restoring TTY/crash state; as PID 1 of a
+/// pid namespace, where that cannot kill us, exit with `128 + sig`. Callers may
+/// forward any signal byte (incl. Linux RT signals 32..=64) that has no
+/// `crate::SignalCode` discriminant.
 pub fn raise_ignoring_panic_handler_raw(sig: c_int) -> ! {
     Output::flush();
     Output::source::stdio::restore();
@@ -799,9 +799,7 @@ pub fn raise_ignoring_panic_handler_raw(sig: c_int) -> ! {
             let _ = libc::sigaction(sig, &raw const sa, core::ptr::null_mut());
         }
 
-        // The signal mask survives execve, so a parent that had `sig` blocked
-        // started us with it blocked too; raise() would then only leave it
-        // pending.
+        // The mask is inherited across execve; a blocked `sig` would only go pending.
         // SAFETY: zeroed sigset is valid; sigemptyset/sigaddset initialize it.
         unsafe {
             let mut set: libc::sigset_t = crate::ffi::zeroed();
@@ -816,18 +814,14 @@ pub fn raise_ignoring_panic_handler_raw(sig: c_int) -> ! {
 
     #[cfg(not(windows))]
     {
-        // Unblocked and at SIG_DFL, raise() only returns when this process is
-        // PID 1 of a pid namespace (the entrypoint of a container without an
-        // init): the kernel discards default-action signals sent to init,
-        // SIGABRT included, so abort() would end in its trap instruction and
-        // turn the child's signal into a SIGSEGV/SIGTRAP of our own. Report
-        // the signal the way a shell does instead.
+        // Only PID 1 of a pid namespace gets here: the kernel discards the signals
+        // it raises at itself, abort()'s SIGABRT included, and abort() would end
+        // in a trap (SIGSEGV/SIGTRAP). Report the signal the way a shell does.
         exit((128 + sig) as u32)
     }
     #[cfg(windows)]
     {
-        // The CRT's raise() ignores SIGTERM and rejects signals it does not
-        // know, so returning from it is routine here.
+        // The CRT's raise() returns for SIGTERM and for signals it does not know.
         libc_abort()
     }
 }

--- a/test/cli/run/run-propagate-sigkill.test.ts
+++ b/test/cli/run/run-propagate-sigkill.test.ts
@@ -124,7 +124,10 @@ async function compile(cwd: string, args: string[]) {
   expect(exitCode, stderr).toBe(0);
 }
 
-describe.concurrent.skipIf(!cc)("dies from the child's signal when bun inherited it blocked", () => {
+// The re-raise has to unblock the signal first; otherwise raise() only leaves it
+// pending and bun does not die from it. A launcher that blocked the signal is
+// how a blocked one gets handed to bun from outside.
+describe.concurrent.skipIf(!cc)("dies from the child's signal when bun was started with it blocked", () => {
   test.each(entryPoints)("%s", async (_, cmd, reports) => {
     using dir = project("propagate-signal-blocked");
     const sigmask = join(String(dir), "sigmask");

--- a/test/cli/run/run-propagate-sigkill.test.ts
+++ b/test/cli/run/run-propagate-sigkill.test.ts
@@ -6,6 +6,7 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isGlibc, isLinux, isPosix, tempDir } from "harness";
 import { readdirSync, readFileSync } from "node:fs";
+import { constants } from "node:os";
 import { join } from "node:path";
 
 test.skipIf(!isPosix)("bun run propagates SIGKILL from a child without hitting unreachable", async () => {
@@ -34,8 +35,7 @@ test.skipIf(!isPosix)("bun run propagates SIGKILL from a child without hitting u
   expect(exitCode).not.toBe(0);
 });
 
-const SIGINT = 2;
-const SIGTERM = 15;
+const { SIGINT, SIGTERM } = constants.signals;
 
 /**
  * The fixture's `start` and `postinstall` scripts, and what the

--- a/test/cli/run/run-propagate-sigkill.test.ts
+++ b/test/cli/run/run-propagate-sigkill.test.ts
@@ -1,10 +1,12 @@
-// `bun run <script>` re-raises the child's terminating signal via
-// `Global.raiseIgnoringPanicHandler`, which first resets the signal's
-// disposition with `bun.sys.sigaction(sig, …)`. `SIGKILL`/`SIGSTOP` can't
-// have their disposition changed, so libc returns `EINVAL` there — that
-// must not reach `std.posix.sigaction`'s `else => unreachable`.
-import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isPosix, tempDir } from "harness";
+// A child that dies from a signal is reported by dying from that same signal:
+// `bun run <package.json script>`, `bun run <binary>` and `bun install`'s
+// lifecycle scripts all end in `raise_ignoring_panic_handler_raw`
+// (src/bun_core/Global.rs), so whatever is waiting on bun sees the child's real
+// termination status.
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isGlibc, isLinux, isPosix, tempDir } from "harness";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 
 test.skipIf(!isPosix)("bun run propagates SIGKILL from a child without hitting unreachable", async () => {
   using dir = tempDir("run-sigkill", {
@@ -30,4 +32,213 @@ test.skipIf(!isPosix)("bun run propagates SIGKILL from a child without hitting u
   expect(stdout).toBe("");
   expect(proc.signalCode).toBe("SIGKILL");
   expect(exitCode).not.toBe(0);
+});
+
+const SIGINT = 2;
+const SIGTERM = 15;
+
+/**
+ * The fixture's `start` and `postinstall` scripts, and what the
+ * `bun run <binary>` case hands to `sh`: dies from SIGTERM whatever signal
+ * mask it inherited from bun.
+ */
+const dieFromSigterm = "exec ./sigmask unblock sh -c 'kill -TERM $$'";
+
+function project(prefix: string) {
+  return tempDir(prefix, {
+    "package.json": JSON.stringify({
+      name: "propagate-signal",
+      version: "1.0.0",
+      scripts: { start: dieFromSigterm, postinstall: dieFromSigterm },
+    }),
+    // `sigmask block|unblock <command...>`: adds SIGTERM to the signal mask or
+    // removes it, then execs the command. The mask survives execve, so this is
+    // how a launcher hands bun a blocked signal, and how the script above gets
+    // rid of it again.
+    "sigmask.c": `
+      #include <signal.h>
+      #include <string.h>
+      #include <unistd.h>
+      int main(int argc, char** argv) {
+        sigset_t set;
+        sigemptyset(&set);
+        sigaddset(&set, SIGTERM);
+        if (argc < 3 || sigprocmask(strcmp(argv[1], "block") == 0 ? SIG_BLOCK : SIG_UNBLOCK, &set, 0) != 0) return 98;
+        execvp(argv[2], argv + 2);
+        return 99;
+      }
+    `,
+    // What the kernel makes of a default-action signal that the init of a pid
+    // namespace raises at itself.
+    "raise.c": "int raise(int sig) { (void)sig; return 0; }\n",
+  });
+}
+
+/**
+ * Every command that re-raises, with the line it prints before doing so. The
+ * line shows that the child really died from SIGTERM (as opposed to exiting
+ * 143) and that it was the re-raise that ended bun.
+ */
+const entryPoints: [name: string, cmd: string[], reports: string][] = [
+  [
+    "bun run <package.json script>",
+    [bunExe(), "run", "start"],
+    'error: script "start" was terminated by signal SIGTERM',
+  ],
+  [
+    "bun run <binary>",
+    [bunExe(), "run", "sh", "-c", dieFromSigterm],
+    'error: Failed to run "sh" due to signal SIGTERM',
+  ],
+  [
+    "bun install lifecycle script",
+    [bunExe(), "install"],
+    'error: postinstall script from "propagate-signal" terminated by SIGTERM',
+  ],
+];
+
+async function ending(proc: Bun.Subprocess<"ignore", "pipe", "pipe">) {
+  const [, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { exitCode: proc.exitCode, signalCode: proc.signalCode, stderr };
+}
+
+async function run(cmd: string[], cwd: string, env: NodeJS.Dict<string> = bunEnv) {
+  await using proc = Bun.spawn({ cmd, cwd, env, stdout: "pipe", stderr: "pipe" });
+  // `await`ed here, or leaving the scope kills the process mid-run.
+  return await ending(proc);
+}
+
+const cc = isPosix ? Bun.which("cc") || Bun.which("clang") || Bun.which("gcc") : null;
+
+async function compile(cwd: string, args: string[]) {
+  const { exitCode, stderr } = await run([cc!, ...args], cwd);
+  expect(exitCode, stderr).toBe(0);
+}
+
+describe.concurrent.skipIf(!cc)("dies from the child's signal when bun inherited it blocked", () => {
+  test.each(entryPoints)("%s", async (_, cmd, reports) => {
+    using dir = project("propagate-signal-blocked");
+    const sigmask = join(String(dir), "sigmask");
+    await compile(String(dir), ["-o", sigmask, "sigmask.c"]);
+
+    const { stderr, ...status } = await run([sigmask, "block", ...cmd], String(dir));
+    expect(stderr).toContain(reports);
+    expect(status).toEqual({ exitCode: null, signalCode: "SIGTERM" });
+  });
+});
+
+// As the init of a pid namespace (a container whose entrypoint is bun, with no
+// `--init` in front of it) bun cannot kill itself: the kernel discards the
+// re-raise, raise() returns, and bun has to report the signal the way a shell
+// does, as exit status 128 + signo. Preloading a raise() that does nothing
+// stands in for the kernel here; the real thing is exercised further down.
+describe.concurrent.skipIf(!cc || !isGlibc)("exits 128 + signo when the re-raise is discarded", () => {
+  test.each(entryPoints)("%s", async (_, cmd, reports) => {
+    using dir = project("propagate-signal-discarded");
+    await compile(String(dir), ["-o", "sigmask", "sigmask.c"]);
+    const preload = join(String(dir), "libraise.so");
+    await compile(String(dir), ["-shared", "-fPIC", "-o", preload, "raise.c"]);
+
+    const { stderr, ...status } = await run(cmd, String(dir), { ...bunEnv, LD_PRELOAD: preload });
+    expect(stderr).toContain(reports);
+    expect(status).toEqual({ exitCode: 128 + SIGTERM, signalCode: null });
+  });
+});
+
+// Unprivileged user namespaces are how a test gets a pid namespace without
+// being root; kernels and sandboxes that refuse them skip this part. The
+// processes inside are found through /proc/<pid>/task/<tid>/children.
+const unshare = ["unshare", "--user", "--map-root-user", "--pid", "--fork"];
+const canBecomePid1 =
+  isLinux &&
+  (() => {
+    try {
+      readFileSync(`/proc/self/task/${process.pid}/children`);
+      return Bun.spawnSync({ cmd: [...unshare, "true"], stdio: ["ignore", "ignore", "ignore"] }).exitCode === 0;
+    } catch {
+      return false;
+    }
+  })();
+
+/** Direct children of `pid`, whichever of its threads forked them. None while `pid` is still starting up. */
+function childrenOf(pid: number): number[] {
+  try {
+    return readdirSync(`/proc/${pid}/task`).flatMap(tid =>
+      readFileSync(`/proc/${pid}/task/${tid}/children`, "utf8").split(/\s+/).filter(Boolean).map(Number),
+    );
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * `unsharePid`'s child is bun, PID 1 inside the namespace; bun's child is the
+ * script, which is up once it has exec'd into `sleep`. Both pids are the ones
+ * seen from out here.
+ */
+async function waitForScript(unsharePid: number): Promise<{ bun: number; script: number }> {
+  while (true) {
+    const [bun] = childrenOf(unsharePid);
+    const [script] = bun === undefined ? [] : childrenOf(bun);
+    if (script !== undefined && readFileSync(`/proc/${script}/comm`, "utf8") === "sleep\n") return { bun, script };
+    await Bun.sleep(10);
+  }
+}
+
+describe.concurrent.skipIf(!canBecomePid1)("as PID 1 of a pid namespace", () => {
+  // Stays around until it is signalled; `exec` makes `sleep` itself bun's child.
+  const script = "exec sleep 30";
+
+  function pid1Project() {
+    return tempDir("propagate-signal-pid1", {
+      "package.json": JSON.stringify({
+        name: "propagate-signal",
+        version: "1.0.0",
+        scripts: { start: script, postinstall: script },
+      }),
+    });
+  }
+
+  function spawnAsPid1(cmd: string[], cwd: string) {
+    return Bun.spawn({ cmd: [...unshare, ...cmd], cwd, env: bunEnv, stdout: "pipe", stderr: "pipe" });
+  }
+
+  // `docker stop` and Ctrl-C arrive at bun, which forwards them to the script.
+  test.each([
+    ["SIGTERM", SIGTERM, 'error: script "start" was terminated by signal SIGTERM'],
+    ["SIGINT", SIGINT, `$ ${script}`],
+  ] as const)("bun run <package.json script> forwards %s and exits 128 + signo", async (signal, signo, reports) => {
+    using dir = pid1Project();
+    await using proc = spawnAsPid1([bunExe(), "run", "start"], String(dir));
+    const { bun } = await waitForScript(proc.pid);
+    process.kill(bun, signal);
+
+    const { stderr, ...status } = await ending(proc);
+    expect(stderr).toContain(reports);
+    expect(status).toEqual({ exitCode: 128 + signo, signalCode: null });
+  });
+
+  test("bun run <binary> forwards SIGTERM and exits 128 + signo", async () => {
+    using dir = pid1Project();
+    await using proc = spawnAsPid1([bunExe(), "run", "sh", "-c", script], String(dir));
+    const { bun } = await waitForScript(proc.pid);
+    process.kill(bun, "SIGTERM");
+
+    const { stderr, ...status } = await ending(proc);
+    expect(stderr).toContain('error: Failed to run "sh" due to signal SIGTERM');
+    expect(status).toEqual({ exitCode: 128 + SIGTERM, signalCode: null });
+  });
+
+  // Nothing is forwarded to lifecycle scripts: this is the script itself being
+  // killed (by the OOM killer, say) under a `bun install` entrypoint.
+  test("bun install exits 128 + signo when a lifecycle script is killed", async () => {
+    using dir = pid1Project();
+    await using proc = spawnAsPid1([bunExe(), "install"], String(dir));
+    const { script: scriptPid } = await waitForScript(proc.pid);
+    process.kill(scriptPid, "SIGTERM");
+
+    const { stderr, ...status } = await ending(proc);
+    expect(stderr).toContain('error: postinstall script from "propagate-signal" terminated by SIGTERM');
+    expect(status).toEqual({ exitCode: 128 + SIGTERM, signalCode: null });
+  });
 });

--- a/test/cli/run/run-propagate-sigkill.test.ts
+++ b/test/cli/run/run-propagate-sigkill.test.ts
@@ -97,15 +97,24 @@ const entryPoints: [name: string, cmd: string[], reports: string][] = [
   ],
 ];
 
-async function ending(proc: Bun.Subprocess<"ignore", "pipe", "pipe">) {
+type Proc = Bun.Subprocess<"ignore", "pipe", "pipe">;
+
+async function ending(proc: Proc) {
   const [, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   return { exitCode: proc.exitCode, signalCode: proc.signalCode, stderr };
 }
+
+type Ending = Awaited<ReturnType<typeof ending>>;
 
 async function run(cmd: string[], cwd: string, env: NodeJS.Dict<string> = bunEnv) {
   await using proc = Bun.spawn({ cmd, cwd, env, stdout: "pipe", stderr: "pipe" });
   // `await`ed here, or leaving the scope kills the process mid-run.
   return await ending(proc);
+}
+
+function expectEnding({ stderr, ...status }: Ending, reports: string, expected: Omit<Ending, "stderr">) {
+  expect(stderr).toContain(reports);
+  expect(status, stderr).toEqual(expected);
 }
 
 const cc = isPosix ? Bun.which("cc") || Bun.which("clang") || Bun.which("gcc") : null;
@@ -121,9 +130,10 @@ describe.concurrent.skipIf(!cc)("dies from the child's signal when bun inherited
     const sigmask = join(String(dir), "sigmask");
     await compile(String(dir), ["-o", sigmask, "sigmask.c"]);
 
-    const { stderr, ...status } = await run([sigmask, "block", ...cmd], String(dir));
-    expect(stderr).toContain(reports);
-    expect(status).toEqual({ exitCode: null, signalCode: "SIGTERM" });
+    expectEnding(await run([sigmask, "block", ...cmd], String(dir)), reports, {
+      exitCode: null,
+      signalCode: "SIGTERM",
+    });
   });
 });
 
@@ -139,9 +149,8 @@ describe.concurrent.skipIf(!cc || !isGlibc)("exits 128 + signo when the re-raise
     const preload = join(String(dir), "libraise.so");
     await compile(String(dir), ["-shared", "-fPIC", "-o", preload, "raise.c"]);
 
-    const { stderr, ...status } = await run(cmd, String(dir), { ...bunEnv, LD_PRELOAD: preload });
-    expect(stderr).toContain(reports);
-    expect(status).toEqual({ exitCode: 128 + SIGTERM, signalCode: null });
+    const ended = await run(cmd, String(dir), { ...bunEnv, LD_PRELOAD: preload });
+    expectEnding(ended, reports, { exitCode: 128 + SIGTERM, signalCode: null });
   });
 });
 
@@ -160,29 +169,40 @@ const canBecomePid1 =
     }
   })();
 
-/** Direct children of `pid`, whichever of its threads forked them. None while `pid` is still starting up. */
-function childrenOf(pid: number): number[] {
+/** A file under /proc, or "" while the process it belongs to is not (or no longer) there. */
+function procRead(path: string): string {
   try {
-    return readdirSync(`/proc/${pid}/task`).flatMap(tid =>
-      readFileSync(`/proc/${pid}/task/${tid}/children`, "utf8").split(/\s+/).filter(Boolean).map(Number),
-    );
+    return readFileSync(`/proc/${path}`, "utf8");
   } catch {
-    return [];
+    return "";
   }
 }
 
+/** Direct children of `pid`, whichever of its threads forked them. */
+function childrenOf(pid: number): number[] {
+  let tids: string[];
+  try {
+    tids = readdirSync(`/proc/${pid}/task`);
+  } catch {
+    return [];
+  }
+  return tids.flatMap(tid => procRead(`${pid}/task/${tid}/children`).split(/\s+/).filter(Boolean).map(Number));
+}
+
 /**
- * `unsharePid`'s child is bun, PID 1 inside the namespace; bun's child is the
- * script, which is up once it has exec'd into `sleep`. Both pids are the ones
- * seen from out here.
+ * Resolves once everything under `proc` (unshare) is up: its child is bun,
+ * PID 1 inside the namespace, and bun's child is the script, which has exec'd
+ * into `sleep`. Both pids are the ones seen from out here.
  */
-async function waitForScript(unsharePid: number): Promise<{ bun: number; script: number }> {
-  while (true) {
-    const [bun] = childrenOf(unsharePid);
+async function waitForScript(proc: Proc): Promise<{ bun: number; script: number }> {
+  while (proc.exitCode === null && proc.signalCode === null) {
+    const [bun] = childrenOf(proc.pid);
     const [script] = bun === undefined ? [] : childrenOf(bun);
-    if (script !== undefined && readFileSync(`/proc/${script}/comm`, "utf8") === "sleep\n") return { bun, script };
+    if (script !== undefined && procRead(`${script}/comm`) === "sleep\n") return { bun, script };
     await Bun.sleep(10);
   }
+  const { stderr, ...status } = await ending(proc);
+  throw new Error(`exited before the script was up: ${JSON.stringify(status)}\n${stderr}`);
 }
 
 describe.concurrent.skipIf(!canBecomePid1)("as PID 1 of a pid namespace", () => {
@@ -210,23 +230,22 @@ describe.concurrent.skipIf(!canBecomePid1)("as PID 1 of a pid namespace", () => 
   ] as const)("bun run <package.json script> forwards %s and exits 128 + signo", async (signal, signo, reports) => {
     using dir = pid1Project();
     await using proc = spawnAsPid1([bunExe(), "run", "start"], String(dir));
-    const { bun } = await waitForScript(proc.pid);
+    const { bun } = await waitForScript(proc);
     process.kill(bun, signal);
 
-    const { stderr, ...status } = await ending(proc);
-    expect(stderr).toContain(reports);
-    expect(status).toEqual({ exitCode: 128 + signo, signalCode: null });
+    expectEnding(await ending(proc), reports, { exitCode: 128 + signo, signalCode: null });
   });
 
   test("bun run <binary> forwards SIGTERM and exits 128 + signo", async () => {
     using dir = pid1Project();
     await using proc = spawnAsPid1([bunExe(), "run", "sh", "-c", script], String(dir));
-    const { bun } = await waitForScript(proc.pid);
+    const { bun } = await waitForScript(proc);
     process.kill(bun, "SIGTERM");
 
-    const { stderr, ...status } = await ending(proc);
-    expect(stderr).toContain('error: Failed to run "sh" due to signal SIGTERM');
-    expect(status).toEqual({ exitCode: 128 + SIGTERM, signalCode: null });
+    expectEnding(await ending(proc), 'error: Failed to run "sh" due to signal SIGTERM', {
+      exitCode: 128 + SIGTERM,
+      signalCode: null,
+    });
   });
 
   // Nothing is forwarded to lifecycle scripts: this is the script itself being
@@ -234,11 +253,12 @@ describe.concurrent.skipIf(!canBecomePid1)("as PID 1 of a pid namespace", () => 
   test("bun install exits 128 + signo when a lifecycle script is killed", async () => {
     using dir = pid1Project();
     await using proc = spawnAsPid1([bunExe(), "install"], String(dir));
-    const { script: scriptPid } = await waitForScript(proc.pid);
+    const { script: scriptPid } = await waitForScript(proc);
     process.kill(scriptPid, "SIGTERM");
 
-    const { stderr, ...status } = await ending(proc);
-    expect(stderr).toContain('error: postinstall script from "propagate-signal" terminated by SIGTERM');
-    expect(status).toEqual({ exitCode: 128 + SIGTERM, signalCode: null });
+    expectEnding(await ending(proc), 'error: postinstall script from "propagate-signal" terminated by SIGTERM', {
+      exitCode: 128 + SIGTERM,
+      signalCode: null,
+    });
   });
 });

--- a/test/no-validate-leaksan.txt
+++ b/test/no-validate-leaksan.txt
@@ -374,12 +374,6 @@ test/bake/dev/deinitialization.test.ts
 # Need to terminate HTTP thread.
 test/js/bun/test/parallel/test-http-should-not-accept-untrusted-certificates.ts
 
-# LSAN reports the std::thread::spawn allocations of the detached threads that
-# `bun install` leaves running when it exits (http_thread::init_once,
-# ThreadPool::notify_slow) and aborts; as PID 1 that abort is the SIGSEGV this
-# file checks bun no longer dies from. The file only asserts exit statuses.
-test/cli/run/run-propagate-sigkill.test.ts
-
 # Need to run the event loop once more to ensure sockets close
 test/js/node/test/parallel/test-https-localaddress-bind-error.js
 

--- a/test/no-validate-leaksan.txt
+++ b/test/no-validate-leaksan.txt
@@ -374,6 +374,12 @@ test/bake/dev/deinitialization.test.ts
 # Need to terminate HTTP thread.
 test/js/bun/test/parallel/test-http-should-not-accept-untrusted-certificates.ts
 
+# LSAN reports the std::thread::spawn allocations of the detached threads that
+# `bun install` leaves running when it exits (http_thread::init_once,
+# ThreadPool::notify_slow) and aborts; as PID 1 that abort is the SIGSEGV this
+# file checks bun no longer dies from. The file only asserts exit statuses.
+test/cli/run/run-propagate-sigkill.test.ts
+
 # Need to run the event loop once more to ensure sockets close
 test/js/node/test/parallel/test-https-localaddress-bind-error.js
 


### PR DESCRIPTION
### Problem
- `bun run <script>`, `bun run <binary>`, `bunx` and `bun install`'s lifecycle runner report a child that died from a signal by re-raising that signal on bun itself. They all do it through `raise_ignoring_panic_handler_raw` (src/bun_core/Global.rs:741 on main), which sets the signal to `SIG_DFL`, calls `raise()`, and falls through to `abort()` if that returns.
- `raise()` returns when bun is PID 1 of a pid namespace, i.e. the entrypoint of a container with no init in front of it (`docker run image bun run start`, no `--init`). The kernel discards default-action signals aimed at init, both the re-raised one and the `SIGABRT` that `abort()` raises, so `abort()` ends in its trap instruction. After `docker stop` the script dies from the forwarded `SIGTERM`, bun prints `script "start" was terminated by signal SIGTERM` and then dies from `SIGSEGV` (glibc x86_64, container status 139) or `SIGTRAP` (aarch64, status 133) instead of exiting 143. Same for a script that the OOM killer takes out under a `bun run` or `bun install` entrypoint: status 139 instead of 137.
- `raise()` also returns whenever the signal happens to be blocked in bun's main thread: it stays pending and bun dies from `SIGABRT` (status 134, core dump) instead of the child's signal. Two things leave it blocked today: the mask bun inherited from whatever launched it (reproduced on the released build with `env --block-signal=TERM bun run start` and a `start` script that dies from `SIGTERM`: "Aborted (core dumped)", status 134), and `bun run`'s own forwarding code when the signal arrives before the script's pid is known (found by #38926's test). #38926 fixes both of those at their sources; this PR makes the re-raise itself independent of them, the way the crash handler's `crash()` already is. The two PRs touch different files and can land in either order.

### Fix
- Unblock the signal before `raise()`, the same thing the crash handler's `crash()` does before its own re-raise.
- If `raise()` still returns, `_exit(128 + sig)` instead of `abort()`. Once the signal is unblocked and at `SIG_DFL`, `raise()` of a terminating signal only returns for the init of a pid namespace, and 128 + signo is the status a shell reports for a child killed by that signal, so `docker wait` shows 143 / 137 for the cases above, matching what the same command reports behind `--init`. A normal process still dies inside `raise()`, so nothing changes for it (that is also what keeps the `fastfail` / `raiseIgnoringPanicHandler` test hooks in src/runtime/api/crash_handler_jsc.rs dying from SIGABRT / SIGSEGV as before).
- `_exit()` rather than `Global::exit()`: a process that dies from a signal runs no exit handlers, and neither did the `abort()` being replaced, so the only thing that changes on this path is the status. Output was already flushed and the TTY restored at the top of the function. (`Global::exit()` would run them, and under ASAN that includes LeakSanitizer over a `bun install` that was never going to shut down cleanly; an earlier revision of this PR did that and failed the ASAN lane on exactly the trap it fixes, one layer down.)
- The fallback is unconditional rather than keyed on `raise()`'s return value on purpose: glibc's `raise()` also fails (EINVAL) for the two RT signals it reserves for itself, which a child can still be killed by, and 128 + signo is the right report for that case too.
- One change in the shared function covers the four callers (run_command.rs package-script and binary paths, bunx_command.rs, lifecycle_script_runner.rs).
- Windows keeps `abort()`: the CRT's `raise()` ignores `SIGTERM` and rejects signal numbers it does not know, so returning from it means nothing there. This PR does not change Windows behaviour.
- Left alone on purpose: the crash handler's `crash()` uses the same re-raise idiom with a trap as its fallback, so a bun crash as PID 1 is reported as SIGTRAP/SIGILL rather than the crash's own signal. That is still a crash being reported as a crash, unlike the cases here, and it runs in signal-handler context; it and #38843's `onExitSignal` (a third copy of the idiom, in C++) could share one primitive later, which would be a refactor across the two PRs rather than part of this fix.
- Tests, added to test/cli/run/run-propagate-sigkill.test.ts next to the existing SIGKILL re-raise test (which is unchanged), each run against the package-script, binary and lifecycle-script entry points (`bunx` needs a registry and shares the same function, so it is not in the table):
  - blocked signal: a 10-line C launcher blocks `SIGTERM` and execs the bun command; the script unblocks it again before killing itself, so the cases stay valid whether or not #38926 (which stops bun from passing the mask on) has landed. Unfixed: bun dies from `SIGABRT`; fixed: from `SIGTERM`. Once #38926 is in as well, these cases no longer single out the unblock here (bun then never starts with the signal blocked); they still pin the behaviour a launcher sees.
  - discarded re-raise: an `LD_PRELOAD`ed `raise()` that does nothing (glibc lanes), standing in for the kernel's treatment of init. Unfixed: `SIGABRT`; fixed: exit 143.
  - the real thing: `unshare --user --map-root-user --pid --fork` makes bun PID 1 of a namespace; `SIGTERM` / `SIGINT` sent to bun (forwarded to the script, as with `docker stop`) and the lifecycle script killed directly; expects exit 143 / 130. Skipped where unprivileged user namespaces are unavailable, which includes the environment this PR was developed in; the Linux CI lanes do run them and they pass there.
- Verified:
  - `bun bd test test/cli/run/run-propagate-sigkill.test.ts`: 7 pass, the 4 namespace cases skip here; the namespace cases' mechanics were dry-run locally with a plain forking wrapper in place of `unshare`, and CI runs them for real on the Linux lanes.
  - Same file with `USE_SYSTEM_BUN=1`: the 6 new non-namespace cases fail, bun dying from `SIGABRT` in each.
  - test/cli/run/run-crash-handler.test.ts, test/cli/install/bun-run.test.ts, test/regression/issue/14799.test.ts and test/regression/issue/ctrl-c.test.ts (its `--bun vite` cases re-raise `SIGINT` through the changed function) pass with the debug build; the vite cases needed `--timeout 60000` because vite takes 10-30s to start under the ASAN build in this container, independent of this change.
  - `cargo check -p bun_core` for the windows-msvc, apple-darwin, freebsd and linux-musl targets.

### Background
- Re-raising: the way a wrapper process reports "my child was killed by signal N" is to die from signal N itself, so that its own parent sees the same `WIFSIGNALED` status it would have seen from the child. Shells encode the same fact as exit status 128 + N when they have to report it as an exit code.
- PID 1 of a pid namespace: every container has one (its entrypoint, unless an init like tini or `docker run --init` is used). To keep init from being killed by accident, the kernel drops any signal sent to it for which it has no handler installed (`pid_namespaces(7)`), including signals it sends to itself; only a synchronous fault (a trap instruction, a segfault) can still kill it, and then with that fault's signal. This is why `abort()` as PID 1 shows up as `SIGSEGV` / `SIGTRAP`.
- Signal mask: the per-thread set of blocked signals. A blocked signal is held pending rather than delivered, and the mask is inherited across `fork` and `execve`, so a launcher that blocked a signal passes that on to bun, and today bun passes it on to the script as well (the part #38926 changes).
- Related: #38843 makes bun itself react to `SIGINT` / `SIGTERM` / `SIGHUP` as PID 1 (the `bun install` entrypoint case, where no child is involved; `bun run` as PID 1 already receives them because of its forwarding handlers, which is what leads into the re-raise fixed here). #38926 clears inherited masks at startup and in children. Both are independent of this PR.

