### PR TITLE
install: migrate workspace packages from yarn.lock

### DIFF
--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -3358,6 +3358,28 @@ pub(crate) fn resolve_peer_dep_version_based(
     string_buf: &[u8],
 ) -> Option<PackageID> {
     let range = deferred_peer_range(dep, catalogs, string_buf)?;
+    resolve_peer_dep_by_range(
+        dep,
+        range,
+        package_index,
+        overrides,
+        pkg_resolutions,
+        string_buf,
+    )
+}
+
+/// The scan behind `resolve_peer_dep_version_based`, for callers that have no printed tree to fall
+/// back on: lockfile migration binds every non-optional peer of the root and the workspaces this
+/// way, `*` ranges included. `None` (overridden name, or nothing to bind to) leaves the edge to a
+/// fresh resolve.
+pub(crate) fn resolve_peer_dep_by_range(
+    dep: &Dependency,
+    range: &DependencyVersion,
+    package_index: &PackageIndexMap,
+    overrides: &OverrideMap,
+    pkg_resolutions: &[Resolution],
+    string_buf: &[u8],
+) -> Option<PackageID> {
     // `package_index` is keyed by real package names; `range` (not `dep.name`) carries them for aliases.
     let name_hash = match range.tag {
         DependencyVersionTag::Npm => StringBuilder::string_hash(range.npm().name.slice(string_buf)),

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -3368,10 +3368,8 @@ pub(crate) fn resolve_peer_dep_version_based(
     )
 }
 
-/// The scan behind `resolve_peer_dep_version_based`, for callers that have no printed tree to fall
-/// back on: lockfile migration binds every non-optional peer of the root and the workspaces this
-/// way, `*` ranges included. `None` (overridden name, or nothing to bind to) leaves the edge to a
-/// fresh resolve.
+/// The scan behind `resolve_peer_dep_version_based`, for a caller with no printed tree to fall back
+/// on (the yarn.lock migration binds the root's and workspaces' required peers with it, `*` included).
 pub(crate) fn resolve_peer_dep_by_range(
     dep: &Dependency,
     range: &DependencyVersion,

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -3368,8 +3368,7 @@ pub(crate) fn resolve_peer_dep_version_based(
     )
 }
 
-/// The scan behind `resolve_peer_dep_version_based`, for a caller with no printed tree to fall back
-/// on (the yarn.lock migration binds the root's and workspaces' required peers with it, `*` included).
+/// `resolve_peer_dep_version_based`'s scan; the yarn.lock migration binds `*` peers with it too.
 pub(crate) fn resolve_peer_dep_by_range(
     dep: &Dependency,
     range: &DependencyVersion,

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -3358,42 +3358,7 @@ pub(crate) fn resolve_peer_dep_version_based(
     string_buf: &[u8],
 ) -> Option<PackageID> {
     let range = deferred_peer_range(dep, catalogs, string_buf)?;
-    resolve_peer_dep_by_range(
-        dep,
-        range,
-        package_index,
-        overrides,
-        pkg_resolutions,
-        string_buf,
-    )
-}
-
-/// `resolve_peer_dep_version_based`'s scan; the yarn.lock migration binds `*` peers with it too.
-pub(crate) fn resolve_peer_dep_by_range(
-    dep: &Dependency,
-    range: &DependencyVersion,
-    package_index: &PackageIndexMap,
-    overrides: &OverrideMap,
-    pkg_resolutions: &[Resolution],
-    string_buf: &[u8],
-) -> Option<PackageID> {
-    // `package_index` is keyed by real package names; `range` (not `dep.name`) carries them for aliases.
-    let name_hash = match range.tag {
-        DependencyVersionTag::Npm => StringBuilder::string_hash(range.npm().name.slice(string_buf)),
-        DependencyVersionTag::DistTag => {
-            StringBuilder::string_hash(range.dist_tag().name.slice(string_buf))
-        }
-        DependencyVersionTag::Git => {
-            StringBuilder::string_hash(range.git().package_name.slice(string_buf))
-        }
-        DependencyVersionTag::Github => {
-            StringBuilder::string_hash(range.github().package_name.slice(string_buf))
-        }
-        DependencyVersionTag::Tarball => {
-            StringBuilder::string_hash(range.tarball().package_name.slice(string_buf))
-        }
-        _ => dep.name_hash,
-    };
+    let name_hash = peer_candidate_name_hash(dep, range, string_buf);
 
     // The fresh resolver rewrites the name and range through
     // `lockfile.overrides` (and any catalog entry an override points at)
@@ -3415,6 +3380,41 @@ pub(crate) fn resolve_peer_dep_by_range(
         return None;
     }
 
+    resolve_peer_dep_by_range(range, name_hash, package_index, pkg_resolutions, string_buf)
+}
+
+/// `package_index` is keyed by real package names; `range` (not `dep.name`) carries them for aliases.
+pub(crate) fn peer_candidate_name_hash(
+    dep: &Dependency,
+    range: &DependencyVersion,
+    string_buf: &[u8],
+) -> PackageNameHash {
+    match range.tag {
+        DependencyVersionTag::Npm => StringBuilder::string_hash(range.npm().name.slice(string_buf)),
+        DependencyVersionTag::DistTag => {
+            StringBuilder::string_hash(range.dist_tag().name.slice(string_buf))
+        }
+        DependencyVersionTag::Git => {
+            StringBuilder::string_hash(range.git().package_name.slice(string_buf))
+        }
+        DependencyVersionTag::Github => {
+            StringBuilder::string_hash(range.github().package_name.slice(string_buf))
+        }
+        DependencyVersionTag::Tarball => {
+            StringBuilder::string_hash(range.tarball().package_name.slice(string_buf))
+        }
+        _ => dep.name_hash,
+    }
+}
+
+/// The scan itself; the yarn.lock migration also binds `*` and overridden peers with it.
+pub(crate) fn resolve_peer_dep_by_range(
+    range: &DependencyVersion,
+    name_hash: PackageNameHash,
+    package_index: &PackageIndexMap,
+    pkg_resolutions: &[Resolution],
+    string_buf: &[u8],
+) -> Option<PackageID> {
     let entry = package_index.get(&name_hash)?;
     let candidates: &[PackageID] = match entry {
         PackageIndexEntry::Id(id) => core::slice::from_ref(id),

--- a/src/install/migration.rs
+++ b/src/install/migration.rs
@@ -76,7 +76,7 @@ pub fn detect_and_load_other_lockfile<'a>(
         let Ok(data) = File::read_from(dir, b"yarn.lock") else {
             break 'yarn;
         };
-        let migrate_result = match yarn::migrate_yarn_lockfile(this, manager, log, &data, dir) {
+        let migrate_result = match yarn::migrate_yarn_lockfile(this, manager, log, &data) {
             Ok(r) => r,
             Err(e) => {
                 return LoadResult::Err(LoadResultErr {

--- a/src/install/yarn.rs
+++ b/src/install/yarn.rs
@@ -594,11 +594,10 @@ fn bind_importer_dependencies(
 
 #[derive(Clone)]
 struct VersionInfo {
-    version: Vec<u8>,
     // Owned Vec<u8> (rather than a borrow from the input) avoids a second
     // lifetime on the local map.
+    version: Vec<u8>,
     package_id: PackageID,
-    yarn_idx: usize,
 }
 
 pub(crate) fn migrate_yarn_lockfile<'a>(
@@ -741,18 +740,13 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
                 }
 
                 if !found_existing {
-                    list.push(VersionInfo {
-                        yarn_idx: existing.yarn_idx,
-                        version: existing.version.clone(),
-                        package_id: existing.package_id,
-                    });
+                    list.push(existing);
                 }
 
                 if !found_new {
                     let package_id = next_package_id;
                     next_package_id += 1;
                     list.push(VersionInfo {
-                        yarn_idx,
                         version: version.to_vec(),
                         package_id,
                     });
@@ -779,7 +773,6 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
                 VersionInfo {
                     version: version.to_vec(),
                     package_id,
-                    yarn_idx,
                 },
             )?;
         }

--- a/src/install/yarn.rs
+++ b/src/install/yarn.rs
@@ -497,9 +497,20 @@ fn read_package_json(
     ) {
         // Cloned because parsing the root's `workspaces` grows the cache holding this entry.
         GetJsonResult::Entry(entry) => Ok((entry.source.clone(), entry.root)),
-        GetJsonResult::ReadErr(_) | GetJsonResult::ParseErr(_) => {
-            Err(crate::Error::InvalidPackageJSON)
+        GetJsonResult::ReadErr(err) => {
+            log.add_error_fmt(
+                None,
+                bun_ast::Loc::EMPTY,
+                format_args!(
+                    "{} reading \"{}\"",
+                    err.name(),
+                    bstr::BStr::new(abs_package_json_path)
+                ),
+            );
+            Err(err)
         }
+        // The parse diagnostics are already in `log`.
+        GetJsonResult::ParseErr(_) => Err(crate::Error::InvalidPackageJSON),
     }
 }
 
@@ -510,10 +521,7 @@ struct Binder<'a> {
 }
 
 impl Binder<'_> {
-    /// A root or workspace dependency is keyed in yarn.lock by the exact `name@range` it declares;
-    /// a same-name entry that merely satisfies the range is a different resolution. yarn never locked
-    /// peers, so required peers bind like a loaded bun.lock's and optional peers are left to the
-    /// hoister. `None` drops the row, and `bun install` resolves it like a newly added dependency.
+    /// Only the exact `name@range` key binds; an entry that merely satisfies it is another resolution.
     fn bind(&mut self, this: &Lockfile, dep: &Dependency) -> Option<PackageID> {
         let string_bytes = this.buffers.string_bytes.as_slice();
         if dep.version.tag == dependency::Tag::Workspace {
@@ -522,8 +530,10 @@ impl Binder<'_> {
                 .get(dep.version.workspace().slice(string_bytes))
                 .copied();
         }
+        // yarn never locked these peers; bind them the way loading a bun.lock does.
         if dep.behavior.is_peer() {
             if dep.behavior.is_optional_peer() {
+                // Bound by the hoister, as after a fresh resolve.
                 return Some(install::INVALID_PACKAGE_ID);
             }
             return lockfile::bun_lock::resolve_peer_dep_by_range(
@@ -544,8 +554,7 @@ impl Binder<'_> {
     }
 }
 
-/// Packages `0..importer_count` are the root and the workspaces; their package.json rows are the
-/// only rows in the buffers at this point, and the buffers are rebuilt with the ones that bind.
+/// Packages `0..importer_count` (root, then workspaces) own every row in the buffers so far.
 fn bind_importer_dependencies(
     this: &mut Lockfile,
     importer_count: usize,
@@ -573,6 +582,7 @@ fn bind_importer_dependencies(
         let off = u32::try_from(this.buffers.dependencies.len()).expect("int cast");
         for dep in declared.by_ref().take(declared_slice.len as usize) {
             let Some(resolution) = binder.bind(this, &dep) else {
+                // `bun install` resolves it, like a dependency added after yarn.lock was written.
                 continue;
             };
             this.buffers.dependencies.push(dep);

--- a/src/install/yarn.rs
+++ b/src/install/yarn.rs
@@ -510,15 +510,10 @@ struct Binder<'a> {
 }
 
 impl Binder<'_> {
-    /// yarn.lock has no entries for the root and the workspaces themselves; what it records for each
-    /// dependency they declare is keyed by the exact `name@range` written in package.json, so only
-    /// that key may bind it. Another entry for the same name that happens to satisfy the range is a
-    /// different resolution. Peers are the exception: yarn never locked them, so they are bound the
-    /// way a fresh `bun install` binds them, and optional peers stay unresolved for the hoister.
-    ///
-    /// `None` drops the dependency from the migrated package, which makes `bun install` resolve it
-    /// like any dependency added after the lockfile was written (instead of failing on a dependency
-    /// that has no resolution).
+    /// A root or workspace dependency is keyed in yarn.lock by the exact `name@range` it declares;
+    /// a same-name entry that merely satisfies the range is a different resolution. yarn never locked
+    /// peers, so required peers bind like a loaded bun.lock's and optional peers are left to the
+    /// hoister. `None` drops the row, and `bun install` resolves it like a newly added dependency.
     fn bind(&mut self, this: &Lockfile, dep: &Dependency) -> Option<PackageID> {
         let string_bytes = this.buffers.string_bytes.as_slice();
         if dep.version.tag == dependency::Tag::Workspace {
@@ -549,9 +544,8 @@ impl Binder<'_> {
     }
 }
 
-/// Binds the dependencies of the root and the workspace packages (ids `0..importer_count`). They
-/// were parsed straight from the package.json files, so at this point they are the only rows in the
-/// dependency buffers; the buffers are rebuilt with the rows that bound.
+/// Packages `0..importer_count` are the root and the workspaces; their package.json rows are the
+/// only rows in the buffers at this point, and the buffers are rebuilt with the ones that bind.
 fn bind_importer_dependencies(
     this: &mut Lockfile,
     importer_count: usize,
@@ -632,9 +626,6 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
         };
     }
 
-    // The root and the workspaces are parsed from their package.json files exactly like a fresh
-    // install parses them; their dependencies are bound to the yarn.lock entries once those have
-    // package ids (`bind_importer_dependencies`).
     let root = {
         let mut package_json_path = AutoAbsPath::init_top_level_dir();
         let _ = package_json_path.append(b"package.json");

--- a/src/install/yarn.rs
+++ b/src/install/yarn.rs
@@ -536,11 +536,12 @@ impl Binder<'_> {
                 // Bound by the hoister, as after a fresh resolve.
                 return Some(install::INVALID_PACKAGE_ID);
             }
+            // Overrides are not consulted: yarn applied them to the entries the candidates come from.
+            let range = this.catalogs.resolve_range(string_bytes, dep);
             return lockfile::bun_lock::resolve_peer_dep_by_range(
-                dep,
-                this.catalogs.resolve_range(string_bytes, dep),
+                range,
+                lockfile::bun_lock::peer_candidate_name_hash(dep, range, string_bytes),
                 &this.package_index,
-                &this.overrides,
                 this.packages.items_resolution(),
                 string_bytes,
             );

--- a/src/install/yarn.rs
+++ b/src/install/yarn.rs
@@ -1,12 +1,11 @@
-use bun_collections::VecExt;
 use std::borrow::Cow;
 use std::io::Write as _;
 
-use crate::Error;
-use bun_collections::{HashMap, StringHashMap};
+use crate::{Error, Features, GetJsonResult};
+use bun_collections::StringHashMap;
 use bun_install::bin::Bin;
 use bun_install::dependency::{self, Dependency, DependencyExt as _};
-use bun_install::install::{self, DependencyID, PackageID, PackageManager};
+use bun_install::install::{self, PackageID, PackageManager};
 use bun_install::integrity::Integrity;
 // `bun_install::lockfile` is the column-accessor stub used by the
 // audit/why CLI walkers; the yarn migrator needs the real Lockfile/Tree/
@@ -15,23 +14,20 @@ use bun_install::integrity::Integrity;
 // resolve against the ported types.
 use crate::Origin;
 use crate::lockfile_real::package::meta::HasInstallScript;
-use crate::lockfile_real::package::workspace_map::{MissingWorkspace, NamesArray, WorkspaceMap};
 use crate::lockfile_real::package::{
-    Meta as PackageMeta, Package as LockfilePackage, PackageColumns as _, value_loc_of,
+    Meta as PackageMeta, Package as LockfilePackage, PackageColumns as _,
 };
-use crate::lockfile_real::{self as lockfile, LoadResult, Lockfile, tree, tree::Tree};
+use crate::lockfile_real::{self as lockfile, LoadResult, Lockfile};
 use bun_install::npm;
 // `Package.resolution` is the file-backed `resolution_real::ResolutionType<u64>`
 // (tag + zero-padded `Value` union), constructed via `init(TaggedValue::*)`; the
 // `bun_install::resolution` stub keeps `Value` as a struct-of-fields and has no `init`.
-use crate::bun_json;
 use crate::repository::Repository;
-use crate::resolution_real::{Resolution, Tag as ResolutionTag, TaggedValue as ResolutionValue};
+use crate::resolution_real::{Resolution, TaggedValue as ResolutionValue};
 use crate::versioned_url::VersionedURL;
 use bun_core::strings;
-use bun_paths::PathBuffer;
+use bun_paths::AutoAbsPath;
 use bun_semver::{self as Semver, SlicedString, String as SemverString};
-use bun_sys::Fd;
 
 // Entry/YarnLock borrow from the input `data: &[u8]` passed to `migrate_yarn_lockfile`;
 // `resolved` may instead own a rewritten URL (see `Cow` below) and `git_repo_name` is
@@ -451,20 +447,6 @@ impl<'a> YarnLock<'a> {
         Ok(())
     }
 
-    fn find_entry_by_spec(&self, spec: &[u8]) -> Option<&Entry<'a>> {
-        // Every caller only reads `.workspace` / `.specs`, so `&self`
-        // suffices and avoids the borrowck conflict with the outer
-        // `entries.iter()` loops.
-        for entry in self.entries.iter() {
-            for entry_spec in entry.specs.iter() {
-                if *entry_spec == spec {
-                    return Some(entry);
-                }
-            }
-        }
-        None
-    }
-
     fn consolidate_and_append_entry(&mut self, new_entry: Entry<'a>) -> Result<(), Error> {
         if new_entry.specs.is_empty() {
             return Ok(());
@@ -503,83 +485,111 @@ enum DependencyType {
     Peer,
 }
 
-fn process_deps(
-    deps: &StringHashMap<&[u8]>,
-    dep_type: DependencyType,
-    yarn_lock_: &YarnLock<'_>,
-    string_buf_: &mut Semver::string::Buf,
-    deps_buf: &mut [Dependency],
-    res_buf: &mut [PackageID],
-    log: &mut bun_ast::Log,
+fn read_package_json(
     manager: &mut PackageManager,
-    yarn_entry_to_package_id: &[PackageID],
-) -> Result<usize, Error> {
-    // Returns count instead of slice to avoid borrowck conflict with caller's bufs.
-    let mut count: usize = 0;
-
-    for (dep_name_key, dep_version_ref) in deps.iter() {
-        let dep_name: &[u8] = dep_name_key.as_ref();
-        let dep_version: &[u8] = *dep_version_ref;
-        let mut dep_spec = Vec::new();
-        write!(
-            &mut dep_spec,
-            "{}@{}",
-            bstr::BStr::new(dep_name),
-            bstr::BStr::new(dep_version)
-        )
-        .expect("unreachable");
-
-        if let Some(dep_entry) = yarn_lock_.find_entry_by_spec(&dep_spec) {
-            let dep_entry_workspace = dep_entry.workspace;
-            let dep_name_hash = string_hash(dep_name);
-            let dep_name_str = string_buf_.append_with_hash(dep_name, dep_name_hash)?;
-
-            let parsed_version = if Entry::is_npm_alias(dep_version) {
-                let alias_info = Entry::parse_npm_alias(dep_version);
-                alias_info.version
-            } else {
-                dep_version
-            };
-
-            let dep = Dependency {
-                name: dep_name_str,
-                name_hash: dep_name_hash,
-                version: Dependency::parse(
-                    dep_name_str,
-                    Some(dep_name_hash),
-                    parsed_version,
-                    &SlicedString::init(parsed_version, parsed_version),
-                    Some(&mut *log),
-                    Some(&mut *manager),
-                )
-                .unwrap_or_default(),
-                behavior: behavior_for(dep_type, dep_entry_workspace),
-            };
-            let mut found_package_id: Option<PackageID> = None;
-            'outer: for (yarn_idx, entry_) in yarn_lock_.entries.iter().enumerate() {
-                for entry_spec in entry_.specs.iter() {
-                    if *entry_spec == dep_spec.as_slice() {
-                        found_package_id = Some(yarn_entry_to_package_id[yarn_idx]);
-                        break 'outer;
-                    }
-                }
-            }
-
-            if let Some(pkg_id) = found_package_id {
-                // SAFETY: `deps_buf` is uninitialized spare capacity; `ptr::write` skips Drop.
-                unsafe { core::ptr::write(deps_buf.as_mut_ptr().add(count), dep) };
-                res_buf[count] = pkg_id;
-                count += 1;
-            }
+    log: &mut bun_ast::Log,
+    abs_package_json_path: &[u8],
+) -> Result<(bun_ast::Source, bun_ast::Expr), Error> {
+    match manager.workspace_package_json_cache.get_with_path(
+        log,
+        abs_package_json_path,
+        Default::default(),
+    ) {
+        // Cloned because parsing the root's `workspaces` grows the cache holding this entry.
+        GetJsonResult::Entry(entry) => Ok((entry.source.clone(), entry.root)),
+        GetJsonResult::ReadErr(_) | GetJsonResult::ParseErr(_) => {
+            Err(crate::Error::InvalidPackageJSON)
         }
     }
-    Ok(count)
 }
 
-struct RootDep {
-    name: Vec<u8>,
-    version: Vec<u8>,
-    dep_type: DependencyType,
+struct Binder<'a> {
+    spec_to_package_id: &'a StringHashMap<PackageID>,
+    workspace_id_by_path: &'a StringHashMap<PackageID>,
+    spec: Vec<u8>,
+}
+
+impl Binder<'_> {
+    /// yarn.lock has no entries for the root and the workspaces themselves; what it records for each
+    /// dependency they declare is keyed by the exact `name@range` written in package.json, so only
+    /// that key may bind it. Another entry for the same name that happens to satisfy the range is a
+    /// different resolution. Peers are the exception: yarn never locked them, so they are bound the
+    /// way a fresh `bun install` binds them, and optional peers stay unresolved for the hoister.
+    ///
+    /// `None` drops the dependency from the migrated package, which makes `bun install` resolve it
+    /// like any dependency added after the lockfile was written (instead of failing on a dependency
+    /// that has no resolution).
+    fn bind(&mut self, this: &Lockfile, dep: &Dependency) -> Option<PackageID> {
+        let string_bytes = this.buffers.string_bytes.as_slice();
+        if dep.version.tag == dependency::Tag::Workspace {
+            return self
+                .workspace_id_by_path
+                .get(dep.version.workspace().slice(string_bytes))
+                .copied();
+        }
+        if dep.behavior.is_peer() {
+            if dep.behavior.is_optional_peer() {
+                return Some(install::INVALID_PACKAGE_ID);
+            }
+            return lockfile::bun_lock::resolve_peer_dep_by_range(
+                dep,
+                this.catalogs.resolve_range(string_bytes, dep),
+                &this.package_index,
+                &this.overrides,
+                this.packages.items_resolution(),
+                string_bytes,
+            );
+        }
+        self.spec.clear();
+        self.spec.extend_from_slice(dep.name.slice(string_bytes));
+        self.spec.push(b'@');
+        self.spec
+            .extend_from_slice(dep.version.literal.slice(string_bytes));
+        self.spec_to_package_id.get(self.spec.as_slice()).copied()
+    }
+}
+
+/// Binds the dependencies of the root and the workspace packages (ids `0..importer_count`). They
+/// were parsed straight from the package.json files, so at this point they are the only rows in the
+/// dependency buffers; the buffers are rebuilt with the rows that bound.
+fn bind_importer_dependencies(
+    this: &mut Lockfile,
+    importer_count: usize,
+    spec_to_package_id: &StringHashMap<PackageID>,
+    workspace_id_by_path: &StringHashMap<PackageID>,
+) {
+    debug_assert_eq!(
+        this.buffers.dependencies.len(),
+        this.buffers.resolutions.len()
+    );
+    let mut declared = core::mem::take(&mut this.buffers.dependencies).into_iter();
+    this.buffers.resolutions.clear();
+
+    let mut binder = Binder {
+        spec_to_package_id,
+        workspace_id_by_path,
+        spec: Vec::new(),
+    };
+    let mut consumed: u32 = 0;
+    for package_id in 0..importer_count {
+        let declared_slice = this.packages.items_dependencies()[package_id];
+        debug_assert_eq!(declared_slice.off, consumed);
+        consumed += declared_slice.len;
+
+        let off = u32::try_from(this.buffers.dependencies.len()).expect("int cast");
+        for dep in declared.by_ref().take(declared_slice.len as usize) {
+            let Some(resolution) = binder.bind(this, &dep) else {
+                continue;
+            };
+            this.buffers.dependencies.push(dep);
+            this.buffers.resolutions.push(resolution);
+        }
+        let len = u32::try_from(this.buffers.dependencies.len()).expect("int cast") - off;
+        this.packages.items_dependencies_mut()[package_id] =
+            lockfile::DependencySlice::new(off, len);
+        this.packages.items_resolutions_mut()[package_id] = lockfile::PackageIDSlice::new(off, len);
+    }
+    debug_assert!(declared.next().is_none());
 }
 
 #[derive(Clone)]
@@ -596,7 +606,6 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
     manager: &mut PackageManager,
     log: &mut bun_ast::Log,
     data: &[u8],
-    dir: Fd,
 ) -> Result<LoadResult<'a>, Error> {
     // yarn v2+ (berry) lockfiles are not supported; only the v1 format migrates.
     if !strings::index_of(data, b"# yarn lockfile v1").is_some() {
@@ -624,183 +633,61 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
         };
     }
 
-    let mut num_deps: u32 = 0;
-    let root_dep_count: u32;
-    let mut root_dep_count_from_package_json: u32 = 0;
-
-    let mut root_dependencies: Vec<RootDep> = Vec::new();
-
-    // read package.json to get specified dependencies
-    let Ok(package_json_fd) = bun_sys::File::openat(dir, b"package.json", bun_sys::O::RDONLY, 0)
-    else {
-        return Err(crate::Error::InvalidPackageJSON);
+    // The root and the workspaces are parsed from their package.json files exactly like a fresh
+    // install parses them; their dependencies are bound to the yarn.lock entries once those have
+    // package ids (`bind_importer_dependencies`).
+    let root = {
+        let mut package_json_path = AutoAbsPath::init_top_level_dir();
+        let _ = package_json_path.append(b"package.json");
+        let (source, json) = read_package_json(manager, log, package_json_path.slice())?;
+        let mut root = LockfilePackage::default();
+        let mut resolver: () = ();
+        root.parse_with_json(
+            this,
+            manager,
+            log,
+            &source,
+            json,
+            &mut resolver,
+            Features::main(),
+        )?;
+        this.append_package(&root)?
     };
-    let Ok(package_json_contents) = package_json_fd.read_to_end() else {
-        return Err(crate::Error::InvalidPackageJSON);
-    };
+    debug_assert_eq!(root.meta.id, 0);
 
-    // `package_json_source.path` borrows this buffer (lifetime-erased); keep it alive until the overrides are parsed below.
-    let mut package_json_path_buf = PathBuffer::uninit();
-    let package_json_source = {
-        let Ok(package_json_path) =
-            bun_sys::get_fd_path(package_json_fd.handle(), &mut package_json_path_buf)
-        else {
-            return Err(crate::Error::InvalidPackageJSON);
-        };
-        bun_ast::Source::init_path_string(&*package_json_path, package_json_contents.as_slice())
-    };
-    drop(package_json_fd);
-
-    let json_bump = bun_alloc::Arena::new();
-    let Ok(package_json_expr) = bun_json::parse_package_json_utf8_with_opts(
-        bun_json::JSONOptions {
-            json_warn_duplicate_keys: false,
-            guess_indentation: true,
-            ..bun_json::PACKAGE_JSON_OPTS
-        },
-        &package_json_source,
-        log,
-        &json_bump,
-    ) else {
-        return Err(crate::Error::InvalidPackageJSON);
-    };
-
-    let package_json = package_json_expr.root;
-
-    {
-        let package_name: Option<Vec<u8>> = 'blk: {
-            if let Some(name_prop) = package_json.as_property(b"name") {
-                if let bun_ast::ExprData::EString(e_string) = &name_prop.expr.data {
-                    let name_slice = e_string.string(&json_bump).unwrap_or(b"");
-                    if !name_slice.is_empty() {
-                        break 'blk Some(name_slice.to_vec());
-                    }
-                }
-            }
-            break 'blk None;
-        };
-        let package_name_hash = if let Some(name) = &package_name {
-            Semver::string::Builder::string_hash(name)
-        } else {
-            0
-        };
-
-        use bun_install_types::DependencyGroup;
-        // prop literals come from canonical; DependencyType retained as yarn-lexer-local discriminant
-        for (group, dep_type) in [
-            (DependencyGroup::DEPENDENCIES, DependencyType::Production),
-            (DependencyGroup::DEV, DependencyType::Development),
-            (DependencyGroup::OPTIONAL, DependencyType::Optional),
-            (DependencyGroup::PEER, DependencyType::Peer),
-        ] {
-            let Some(prop) = package_json.as_property(group.prop) else {
-                continue;
-            };
-            let bun_ast::ExprData::EObject(e_object) = &prop.expr.data else {
-                continue;
-            };
-
-            for p in e_object.properties.slice() {
-                let Some(key) = &p.key else { continue };
-                let bun_ast::ExprData::EString(key_str) = &key.data else {
-                    continue;
-                };
-
-                let Ok(name_slice) = key_str.string(&json_bump) else {
-                    continue;
-                };
-                let Some(value) = &p.value else { continue };
-                let bun_ast::ExprData::EString(value_str) = &value.data else {
-                    continue;
-                };
-
-                let Ok(version_slice) = value_str.string(&json_bump) else {
-                    continue;
-                };
-                if version_slice.is_empty() {
-                    continue;
-                }
-
-                let name = name_slice.to_vec();
-                let version = version_slice.to_vec();
-                root_dependencies.push(RootDep {
-                    name,
-                    version,
-                    dep_type,
-                });
-                root_dep_count_from_package_json += 1;
-            }
+    let mut workspace_id_by_path: StringHashMap<PackageID> = StringHashMap::new();
+    for dep_id in root.dependencies.begin()..root.dependencies.end() {
+        let dep = &this.buffers.dependencies[dep_id as usize];
+        if !dep.behavior.is_workspace() {
+            continue;
         }
+        let workspace_path = *dep.version.workspace();
 
-        root_dep_count = root_dep_count_from_package_json.max(10);
-        num_deps += root_dep_count;
+        let mut package_json_path = AutoAbsPath::init_top_level_dir();
+        let _ =
+            package_json_path.append(workspace_path.slice(this.buffers.string_bytes.as_slice()));
+        let _ = package_json_path.append(b"package.json");
+        let (source, json) = read_package_json(manager, log, package_json_path.slice())?;
 
-        for entry in yarn_lock.entries.iter() {
-            if let Some(deps) = &entry.dependencies {
-                num_deps += u32::try_from(deps.count()).expect("int cast");
-            }
-            if let Some(deps) = &entry.optional_dependencies {
-                num_deps += u32::try_from(deps.count()).expect("int cast");
-            }
-            if let Some(deps) = &entry.peer_dependencies {
-                num_deps += u32::try_from(deps.count()).expect("int cast");
-            }
-            if let Some(deps) = &entry.dev_dependencies {
-                num_deps += u32::try_from(deps.count()).expect("int cast");
-            }
-        }
-
-        let num_packages = u32::try_from(yarn_lock.entries.len() + 1).expect("int cast");
-
-        this.buffers
-            .dependencies
-            .reserve((num_deps as usize).saturating_sub(this.buffers.dependencies.len()));
-        this.buffers
-            .resolutions
-            .reserve((num_deps as usize).saturating_sub(this.buffers.resolutions.len()));
-        this.packages.ensure_total_capacity(num_packages as usize)?;
-        this.package_index
-            .ensure_total_capacity(num_packages as usize)?;
-
-        let root_name = if let Some(name) = &package_name {
-            sbuf!().append_with_hash(name, package_name_hash)?
-        } else {
-            sbuf!().append(b"")?
-        };
-
-        this.packages.append(LockfilePackage {
-            name: root_name,
-            name_hash: package_name_hash,
-            resolution: Resolution::init(ResolutionValue::Root),
-            dependencies: Default::default(),
-            resolutions: Default::default(),
-            meta: PackageMeta {
-                id: 0,
-                origin: Origin::Local,
-                arch: npm::Architecture::ALL,
-                os: npm::OperatingSystem::ALL,
-                man_dir: SemverString::default(),
-                has_install_script: HasInstallScript::False,
-                integrity: Integrity::default(),
-                ..Default::default()
-            },
-            bin: Bin::init(),
-            scripts: Default::default(),
-        })?;
+        let mut workspace = LockfilePackage::default();
+        let mut resolver: () = ();
+        workspace.parse_with_json(
+            this,
+            manager,
+            log,
+            &source,
+            json,
+            &mut resolver,
+            Features::WORKSPACE,
+        )?;
+        workspace.resolution = Resolution::init(ResolutionValue::Workspace(workspace_path));
+        let workspace = this.append_package(&workspace)?;
+        workspace_id_by_path.put(
+            workspace_path.slice(this.buffers.string_bytes.as_slice()),
+            workspace.meta.id,
+        )?;
     }
-
-    // SAFETY: capacity reserved above to num_deps; we write past `len` through
-    // raw pointers into the reserved capacity and set `len` at the end.
-    let dependencies_base_ptr = this.buffers.dependencies.as_mut_ptr();
-    let resolutions_base_ptr = this.buffers.resolutions.as_mut_ptr();
-    let mut dependencies_buf: &mut [Dependency] = unsafe {
-        // SAFETY: capacity >= num_deps reserved above
-        bun_core::ffi::slice_mut(dependencies_base_ptr, num_deps as usize)
-    };
-    let mut resolutions_buf: &mut [PackageID] = unsafe {
-        // SAFETY: capacity >= num_deps reserved above
-        bun_core::ffi::slice_mut(resolutions_base_ptr, num_deps as usize)
-    };
+    let importer_count = this.packages.len();
 
     let mut yarn_entry_to_package_id: Vec<PackageID> = vec![0; yarn_lock.entries.len()];
 
@@ -808,7 +695,7 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
 
     let mut scoped_packages: StringHashMap<Vec<VersionInfo>> = StringHashMap::new();
 
-    let mut next_package_id: PackageID = 1; // 0 is root
+    let mut next_package_id: PackageID = PackageID::try_from(importer_count).expect("int cast");
 
     for (yarn_idx, entry) in yarn_lock.entries.iter().enumerate() {
         let mut is_npm_alias = false;
@@ -899,9 +786,6 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
     }
 
     let mut package_id_to_yarn_idx: Vec<usize> = vec![usize::MAX; next_package_id as usize];
-
-    let created_packages: StringHashMap<bool> = StringHashMap::new();
-    let _ = &created_packages; // never populated
 
     for (yarn_idx, entry) in yarn_lock.entries.iter().enumerate() {
         let mut is_npm_alias = false;
@@ -1074,6 +958,7 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
             }
         };
 
+        debug_assert_eq!(this.packages.len(), package_id as usize);
         this.packages.append(LockfilePackage {
             name: pkg_name,
             name_hash,
@@ -1113,569 +998,22 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
             bin: Bin::init(),
             scripts: Default::default(),
         })?;
+        this.get_or_put_id(package_id, name_hash)?;
     }
-
-    // The derive's `&mut self` accessors can't alias, so we re-borrow per write
-    // below via `this.packages.items_*_mut()[idx] = …` instead of caching
-    // two field slices simultaneously.
-
-    let mut actual_root_dep_count: u32 = 0;
-
-    if !root_dependencies.is_empty() {
-        for dep in root_dependencies.iter() {
-            let mut dep_spec = Vec::new();
-            write!(
-                &mut dep_spec,
-                "{}@{}",
-                bstr::BStr::new(&dep.name),
-                bstr::BStr::new(&dep.version)
-            )
-            .expect("unreachable");
-
-            let mut found_idx: Option<usize> = None;
-            for (idx, entry) in yarn_lock.entries.iter().enumerate() {
-                for spec in entry.specs.iter() {
-                    if *spec == dep_spec.as_slice() {
-                        found_idx = Some(idx);
-                        break;
-                    }
-                }
-                if found_idx.is_some() {
-                    break;
-                }
-            }
-
-            if let Some(idx) = found_idx {
-                let name_hash = string_hash(&dep.name);
-                let dep_name_string = sbuf!().append_with_hash(&dep.name, name_hash)?;
-                let version_string = sbuf!().append(&dep.version)?;
-
-                // SAFETY: `dependencies_buf` is uninitialized spare capacity; `ptr::write` skips Drop.
-                unsafe {
-                    core::ptr::write(
-                        dependencies_buf
-                            .as_mut_ptr()
-                            .add(actual_root_dep_count as usize),
-                        Dependency {
-                            name: dep_name_string,
-                            name_hash,
-                            version: Dependency::parse(
-                                dep_name_string,
-                                Some(name_hash),
-                                version_string.slice(this.buffers.string_bytes.as_slice()),
-                                &version_string.sliced(this.buffers.string_bytes.as_slice()),
-                                Some(&mut *log),
-                                Some(&mut *manager),
-                            )
-                            .unwrap_or_default(),
-                            behavior: behavior_for(dep.dep_type, false),
-                        },
-                    );
-                }
-
-                resolutions_buf[actual_root_dep_count as usize] = yarn_entry_to_package_id[idx];
-                actual_root_dep_count += 1;
-            }
-        }
-    }
-
-    this.packages.items_dependencies_mut()[0] =
-        lockfile::DependencySlice::new(0, actual_root_dep_count);
-    this.packages.items_resolutions_mut()[0] =
-        lockfile::DependencyIDSlice::new(0, actual_root_dep_count);
-
-    dependencies_buf = &mut dependencies_buf[actual_root_dep_count as usize..];
-    resolutions_buf = &mut resolutions_buf[actual_root_dep_count as usize..];
-
-    for yarn_idx in 0..yarn_lock.entries.len() {
-        let package_id = yarn_entry_to_package_id[yarn_idx];
-        if package_id == install::INVALID_PACKAGE_ID {
-            continue;
-        }
-
-        let dependencies_start = dependencies_buf.as_mut_ptr();
-        let resolutions_start = resolutions_buf.as_mut_ptr();
-
-        // reshaped for borrowck — iterate by index and re-borrow
-        // `yarn_lock.entries[yarn_idx]` for each map so the shared borrow of
-        // `yarn_lock` passed into `process_deps` doesn't overlap an iterator.
-        if let Some(deps) = yarn_lock.entries[yarn_idx].dependencies.as_ref() {
-            let processed = process_deps(
-                deps,
-                DependencyType::Production,
-                &yarn_lock,
-                &mut sbuf!(),
-                dependencies_buf,
-                resolutions_buf,
-                &mut *log,
-                &mut *manager,
-                &yarn_entry_to_package_id,
-            )?;
-            dependencies_buf = &mut dependencies_buf[processed..];
-            resolutions_buf = &mut resolutions_buf[processed..];
-        }
-
-        if let Some(deps) = yarn_lock.entries[yarn_idx].optional_dependencies.as_ref() {
-            let processed = process_deps(
-                deps,
-                DependencyType::Optional,
-                &yarn_lock,
-                &mut sbuf!(),
-                dependencies_buf,
-                resolutions_buf,
-                &mut *log,
-                &mut *manager,
-                &yarn_entry_to_package_id,
-            )?;
-            dependencies_buf = &mut dependencies_buf[processed..];
-            resolutions_buf = &mut resolutions_buf[processed..];
-        }
-
-        if let Some(deps) = yarn_lock.entries[yarn_idx].peer_dependencies.as_ref() {
-            let processed = process_deps(
-                deps,
-                DependencyType::Peer,
-                &yarn_lock,
-                &mut sbuf!(),
-                dependencies_buf,
-                resolutions_buf,
-                &mut *log,
-                &mut *manager,
-                &yarn_entry_to_package_id,
-            )?;
-            dependencies_buf = &mut dependencies_buf[processed..];
-            resolutions_buf = &mut resolutions_buf[processed..];
-        }
-
-        if let Some(deps) = yarn_lock.entries[yarn_idx].dev_dependencies.as_ref() {
-            let processed = process_deps(
-                deps,
-                DependencyType::Development,
-                &yarn_lock,
-                &mut sbuf!(),
-                dependencies_buf,
-                resolutions_buf,
-                &mut *log,
-                &mut *manager,
-                &yarn_entry_to_package_id,
-            )?;
-            dependencies_buf = &mut dependencies_buf[processed..];
-            resolutions_buf = &mut resolutions_buf[processed..];
-        }
-
-        // dependencies_start/dependencies_buf.as_ptr() are within the same allocation
-        let deps_len = (dependencies_buf.as_mut_ptr() as usize) - (dependencies_start as usize);
-        let deps_off = (dependencies_start as usize) - (dependencies_base_ptr as usize);
-        this.packages.items_dependencies_mut()[package_id as usize] =
-            lockfile::DependencySlice::new(
-                u32::try_from(deps_off / core::mem::size_of::<Dependency>()).expect("int cast"),
-                u32::try_from(deps_len / core::mem::size_of::<Dependency>()).expect("int cast"),
-            );
-        let res_off = (resolutions_start as usize) - (resolutions_base_ptr as usize);
-        let res_len = (resolutions_buf.as_mut_ptr() as usize) - (resolutions_start as usize);
-        this.packages.items_resolutions_mut()[package_id as usize] =
-            lockfile::DependencyIDSlice::new(
-                u32::try_from(res_off / core::mem::size_of::<PackageID>()).expect("int cast"),
-                u32::try_from(res_len / core::mem::size_of::<PackageID>()).expect("int cast"),
-            );
-    }
-
-    let final_deps_len = ((dependencies_buf.as_mut_ptr() as usize)
-        - (dependencies_base_ptr as usize))
-        / core::mem::size_of::<Dependency>();
-    unsafe {
-        // SAFETY: all elements in 0..final_deps_len initialized above; capacity >= num_deps
-        this.buffers.dependencies.set_len(final_deps_len);
-        this.buffers.resolutions.set_len(final_deps_len);
-    }
-
-    this.buffers.hoisted_dependencies.reserve(
-        (this.buffers.dependencies.len() * 2)
-            .saturating_sub(this.buffers.hoisted_dependencies.len()),
-    );
-
-    this.buffers.trees.push(Tree {
-        id: 0,
-        parent: tree::INVALID_ID,
-        dependency_id: tree::ROOT_DEP_ID,
-        dependencies: lockfile::DependencyIDSlice::new(0, 0),
-    });
-
-    let mut package_dependents: Vec<Vec<PackageID>> =
-        (0..next_package_id).map(|_| Vec::new()).collect();
-
-    for (yarn_idx, entry) in yarn_lock.entries.iter().enumerate() {
-        let parent_package_id = yarn_entry_to_package_id[yarn_idx];
-
-        let dep_maps: [Option<&StringHashMap<&[u8]>>; 4] = [
-            entry.dependencies.as_ref(),
-            entry.optional_dependencies.as_ref(),
-            entry.peer_dependencies.as_ref(),
-            entry.dev_dependencies.as_ref(),
-        ];
-
-        for deps in dep_maps.iter().flatten() {
-            for (dep_name_key, dep_version_ref) in deps.iter() {
-                let dep_name: &[u8] = dep_name_key.as_ref();
-                let dep_version: &[u8] = *dep_version_ref;
-                let mut dep_spec = Vec::new();
-                write!(
-                    &mut dep_spec,
-                    "{}@{}",
-                    bstr::BStr::new(dep_name),
-                    bstr::BStr::new(dep_version)
-                )
-                .expect("unreachable");
-
-                let found_entry_idx: Option<usize> = yarn_lock
-                    .entries
-                    .iter()
-                    .position(|e| e.specs.contains(&dep_spec.as_slice()));
-
-                if let Some(found_entry_idx) = found_entry_idx {
-                    let dep_entry_specs = &yarn_lock.entries[found_entry_idx].specs;
-                    for (idx, e) in yarn_lock.entries.iter().enumerate() {
-                        let mut found = false;
-                        for spec in e.specs.iter() {
-                            for dep_spec_item in dep_entry_specs.iter() {
-                                if *spec == *dep_spec_item {
-                                    found = true;
-                                    break;
-                                }
-                            }
-                            if found {
-                                break;
-                            }
-                        }
-
-                        if found {
-                            let dep_package_id = yarn_entry_to_package_id[idx];
-                            package_dependents[dep_package_id as usize].push(parent_package_id);
-                            break;
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    for dep in root_dependencies.iter() {
-        let mut dep_spec = Vec::new();
-        write!(
-            &mut dep_spec,
-            "{}@{}",
-            bstr::BStr::new(&dep.name),
-            bstr::BStr::new(&dep.version)
-        )
-        .expect("unreachable");
-
-        for (idx, entry) in yarn_lock.entries.iter().enumerate() {
-            for spec in entry.specs.iter() {
-                if *spec == dep_spec.as_slice() {
-                    let dep_package_id = yarn_entry_to_package_id[idx];
-                    package_dependents[dep_package_id as usize].push(0); // 0 is root package
-                    break;
-                }
-            }
-        }
-    }
-
-    for (base_name, versions) in scoped_packages.iter_mut() {
-        let base_name: &[u8] = base_name.as_ref();
-
-        versions.sort_by_key(|a| a.package_id);
-
-        let original_name_hash = string_hash(base_name);
-        // `remove` drops the value (and thus the `Ids` Vec) automatically.
-        let _ = this.package_index.remove(&original_name_hash);
-    }
-
-    for (base_name, versions) in scoped_packages.iter() {
-        let base_name: &[u8] = base_name.as_ref();
-
-        for version_info in versions.iter() {
-            let package_id = version_info.package_id;
-
-            let mut found_in_index = false;
-            for (_, index_value) in this.package_index.iter() {
-                match index_value {
-                    lockfile::PackageIndexEntry::Id(id) => {
-                        if *id == package_id {
-                            found_in_index = true;
-                            break;
-                        }
-                    }
-                    lockfile::PackageIndexEntry::Ids(ids) => {
-                        for id in ids.iter() {
-                            if *id == package_id {
-                                found_in_index = true;
-                                break;
-                            }
-                        }
-                        if found_in_index {
-                            break;
-                        }
-                    }
-                }
-            }
-
-            if !found_in_index {
-                let mut fallback_name = Vec::new();
-                write!(
-                    &mut fallback_name,
-                    "{}#{}",
-                    bstr::BStr::new(base_name),
-                    package_id
-                )
-                .expect("unreachable");
-
-                let fallback_hash = string_hash(&fallback_name);
-                this.get_or_put_id(package_id, fallback_hash)?;
-            }
-        }
-    }
-
-    let mut package_names: Vec<&[u8]> = vec![b"".as_slice(); next_package_id as usize];
-
-    for (yarn_idx, entry) in yarn_lock.entries.iter().enumerate() {
-        let package_id = yarn_entry_to_package_id[yarn_idx];
-        if package_names[package_id as usize].is_empty() {
-            package_names[package_id as usize] = Entry::get_name_from_spec(entry.specs[0]);
-        }
-    }
-
-    let mut root_packages: StringHashMap<PackageID> = StringHashMap::new();
-
-    let mut usage_count: StringHashMap<u32> = StringHashMap::new();
-    for entry_idx in 0..yarn_lock.entries.len() {
-        let package_id = yarn_entry_to_package_id[entry_idx];
-        if package_id == install::INVALID_PACKAGE_ID {
-            continue;
-        }
-        let base_name = package_names[package_id as usize];
-
-        for dep_entry in yarn_lock.entries.iter() {
-            if let Some(deps) = &dep_entry.dependencies {
-                for (dep_name_key, _) in deps.iter() {
-                    if dep_name_key.as_ref() == base_name {
-                        let count = usage_count.get(base_name).copied().unwrap_or(0);
-                        usage_count.put(base_name, count + 1)?;
-                    }
-                }
-            }
-        }
-    }
-
-    for entry_idx in 0..yarn_lock.entries.len() {
-        let package_id = yarn_entry_to_package_id[entry_idx];
-        if package_id == install::INVALID_PACKAGE_ID {
-            continue;
-        }
-        let base_name = package_names[package_id as usize];
-
-        if root_packages.get(base_name).is_none() {
-            root_packages.put(base_name, package_id)?;
-            let name_hash = string_hash(base_name);
-            this.get_or_put_id(package_id, name_hash)?;
-        }
-    }
-
-    let mut scoped_names: HashMap<PackageID, Vec<u8>> = HashMap::new();
-    let mut scoped_count: u32 = 0;
-    for entry_idx in 0..yarn_lock.entries.len() {
-        let package_id = yarn_entry_to_package_id[entry_idx];
-        if package_id == install::INVALID_PACKAGE_ID {
-            continue;
-        }
-        let base_name = package_names[package_id as usize];
-
-        if let Some(root_pkg_id) = root_packages.get(base_name).copied() {
-            if root_pkg_id == package_id {
-                continue;
-            }
-        } else {
-            continue;
-        }
-
-        let mut scoped_name: Option<Vec<u8>> = None;
-        for (dep_entry_idx, dep_entry) in yarn_lock.entries.iter().enumerate() {
-            let dep_package_id = yarn_entry_to_package_id[dep_entry_idx];
-            if dep_package_id == install::INVALID_PACKAGE_ID {
-                continue;
-            }
-
-            if let Some(deps) = &dep_entry.dependencies {
-                for (dep_name_key, _) in deps.iter() {
-                    if dep_name_key.as_ref() == base_name {
-                        if dep_package_id != package_id {
-                            let parent_name = package_names[dep_package_id as usize];
-
-                            let mut potential_name = Vec::new();
-                            write!(
-                                &mut potential_name,
-                                "{}/{}",
-                                bstr::BStr::new(parent_name),
-                                bstr::BStr::new(base_name)
-                            )
-                            .expect("unreachable");
-
-                            let mut name_already_used = false;
-                            for existing_name in scoped_names.values() {
-                                if existing_name.as_slice() == potential_name.as_slice() {
-                                    name_already_used = true;
-                                    break;
-                                }
-                            }
-
-                            if !name_already_used {
-                                scoped_name = Some(potential_name);
-                                break;
-                            }
-                            // else: potential_name dropped
-                        }
-                    }
-                }
-                if scoped_name.is_some() {
-                    break;
-                }
-            }
-        }
-
-        if scoped_name.is_none() {
-            let pkg_resolution = this.packages.get(package_id as usize).resolution;
-            let version_str: Vec<u8> = match pkg_resolution.tag {
-                ResolutionTag::Npm => 'brk: {
-                    let mut version_buf = [0u8; 64];
-                    let mut cursor = &mut version_buf[..];
-                    let npm_version = pkg_resolution.npm().version;
-                    let _ = write!(
-                        &mut cursor,
-                        "{}",
-                        npm_version.fmt(this.buffers.string_bytes.as_slice())
-                    );
-                    let written = 64 - cursor.len();
-                    break 'brk version_buf[..written].to_vec();
-                }
-                _ => b"unknown".to_vec(),
-            };
-            let mut name = Vec::new();
-            write!(
-                &mut name,
-                "{}@{}",
-                bstr::BStr::new(base_name),
-                bstr::BStr::new(&version_str)
-            )
-            .expect("unreachable");
-            scoped_name = Some(name);
-        }
-
-        if let Some(final_scoped_name) = scoped_name {
-            let name_hash = string_hash(&final_scoped_name);
-            this.get_or_put_id(package_id, name_hash)?;
-            scoped_names.put(package_id, final_scoped_name)?;
-            scoped_count += 1;
-        }
-    }
-    let _ = scoped_count;
-
-    for (yarn_idx, entry) in yarn_lock.entries.iter().enumerate() {
-        let package_id = yarn_entry_to_package_id[yarn_idx];
-        if package_id == install::INVALID_PACKAGE_ID {
-            continue;
-        }
-
-        if let Some(resolved) = entry.resolved.as_deref() {
-            if let Some(real_name) = Entry::get_package_name_from_resolved_url(resolved) {
-                for spec in entry.specs.iter() {
-                    let alias_name = Entry::get_name_from_spec(spec);
-
-                    if alias_name != real_name {
-                        let alias_hash = string_hash(alias_name);
-                        this.get_or_put_id(package_id, alias_hash)?;
-                    }
-                }
-            }
-        }
-    }
-
-    this.buffers.trees[0].dependencies = lockfile::DependencyIDSlice::new(0, 0);
 
     let mut spec_to_package_id: StringHashMap<PackageID> = StringHashMap::new();
-
     for (yarn_idx, entry) in yarn_lock.entries.iter().enumerate() {
-        let package_id = yarn_entry_to_package_id[yarn_idx];
-        if package_id == install::INVALID_PACKAGE_ID {
-            continue;
-        }
-
         for spec in entry.specs.iter() {
-            spec_to_package_id.put(*spec, package_id)?;
+            spec_to_package_id.put(spec, yarn_entry_to_package_id[yarn_idx])?;
         }
     }
 
-    let root_deps_off = u32::try_from(this.buffers.dependencies.len()).expect("int cast");
-    let root_resolutions_off = u32::try_from(this.buffers.resolutions.len()).expect("int cast");
-
-    if !root_dependencies.is_empty() {
-        for root_dep in root_dependencies.iter() {
-            let _ = DependencyID::try_from(this.buffers.dependencies.len()).expect("int cast");
-
-            let name_hash = string_hash(&root_dep.name);
-            let dep_name_string = sbuf!().append_with_hash(&root_dep.name, name_hash)?;
-            let dep_version_string = sbuf!().append(&root_dep.version)?;
-            let sliced_string = SlicedString::init(
-                dep_version_string.slice(this.buffers.string_bytes.as_slice()),
-                dep_version_string.slice(this.buffers.string_bytes.as_slice()),
-            );
-
-            let mut parsed_version = Dependency::parse(
-                dep_name_string,
-                Some(name_hash),
-                dep_version_string.slice(this.buffers.string_bytes.as_slice()),
-                &sliced_string,
-                Some(&mut *log),
-                Some(&mut *manager),
-            )
-            .unwrap_or_default();
-
-            parsed_version.literal = dep_version_string;
-
-            let dep = Dependency {
-                name_hash,
-                name: dep_name_string,
-                version: parsed_version,
-                behavior: behavior_for(root_dep.dep_type, false),
-            };
-
-            this.buffers.dependencies.push(dep);
-
-            let mut dep_spec = Vec::new();
-            write!(
-                &mut dep_spec,
-                "{}@{}",
-                bstr::BStr::new(&root_dep.name),
-                bstr::BStr::new(&root_dep.version)
-            )
-            .expect("unreachable");
-
-            if let Some(pkg_id) = spec_to_package_id.get(dep_spec.as_slice()).copied() {
-                this.buffers.resolutions.push(pkg_id);
-            } else {
-                this.buffers.resolutions.push(install::INVALID_PACKAGE_ID);
-            }
-        }
-    }
-
-    this.packages.items_dependencies_mut()[0] = lockfile::DependencySlice::new(
-        root_deps_off,
-        u32::try_from(root_dependencies.len()).expect("int cast"),
+    bind_importer_dependencies(
+        this,
+        importer_count,
+        &spec_to_package_id,
+        &workspace_id_by_path,
     );
-    this.packages.items_resolutions_mut()[0] = lockfile::DependencyIDSlice::new(
-        root_resolutions_off,
-        u32::try_from(root_dependencies.len()).expect("int cast"),
-    );
-
-    parse_root_overrides(this, manager, log, &package_json_source, package_json)?;
 
     for (yarn_idx, entry) in yarn_lock.entries.iter().enumerate() {
         let package_id = yarn_entry_to_package_id[yarn_idx];
@@ -1925,98 +1263,7 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
     Ok(result)
 }
 
-/// Must run after the root package's dependencies are laid out: `$ref` values resolve through them, then through the workspaces.
-fn parse_root_overrides(
-    this: &mut Lockfile,
-    manager: &mut PackageManager,
-    log: &mut bun_ast::Log,
-    source: &bun_ast::Source,
-    package_json: bun_ast::Expr,
-) -> Result<(), Error> {
-    if package_json.as_property(b"overrides").is_none()
-        && package_json.as_property(b"resolutions").is_none()
-    {
-        return Ok(());
-    }
-
-    let mut workspace_names = WorkspaceMap::init();
-    let workspaces = package_json.as_property(b"workspaces");
-    let packages = workspaces
-        .as_ref()
-        .filter(|q| !q.expr.is_array())
-        .and_then(|q| q.expr.as_property(b"packages"));
-    let names: Option<(NamesArray<'_>, bun_ast::Loc)> = match (&workspaces, &packages) {
-        (Some(q), _) if q.expr.is_array() => Some((
-            NamesArray::from_expr(&q.expr, value_loc_of(source, q.loc))
-                .expect("is_array was checked above"),
-            q.loc,
-        )),
-        (Some(_), Some(p)) if p.expr.is_array() => Some((
-            NamesArray::from_expr(&p.expr, value_loc_of(source, p.loc))
-                .expect("is_array was checked above"),
-            p.loc,
-        )),
-        _ => None,
-    };
-    if let Some((arr, loc)) = names {
-        workspace_names.process_names_array(
-            &mut manager.workspace_package_json_cache,
-            log,
-            arr,
-            source,
-            loc,
-            None,
-            MissingWorkspace::Skip,
-        )?;
-    }
-
-    let root_package = *this.packages.get(0);
-    let (mut string_builder, lf) = this.string_builder_split();
-    lf.overrides.parse_count(
-        manager,
-        log,
-        source,
-        &workspace_names,
-        package_json,
-        &mut string_builder,
-    );
-    string_builder.allocate()?;
-    lf.overrides.parse_append(
-        manager,
-        lf.dependencies.as_slice(),
-        &root_package,
-        log,
-        source,
-        &workspace_names,
-        package_json,
-        &mut string_builder,
-    )?;
-    string_builder.clamp();
-    Ok(())
-}
-
 #[inline]
 fn string_hash(s: &[u8]) -> u64 {
     Semver::string::Builder::string_hash(s)
-}
-
-/// The bitflags-backed `Behavior` has no named fields, so build via
-/// `with(FLAG, cond)` chaining.
-#[inline]
-fn behavior_for(dep_type: DependencyType, workspace: bool) -> dependency::Behavior {
-    dependency::Behavior::default()
-        .with(
-            dependency::Behavior::PROD,
-            dep_type == DependencyType::Production,
-        )
-        .with(
-            dependency::Behavior::OPTIONAL,
-            dep_type == DependencyType::Optional,
-        )
-        .with(
-            dependency::Behavior::DEV,
-            dep_type == DependencyType::Development,
-        )
-        .with(dependency::Behavior::PEER, dep_type == DependencyType::Peer)
-        .with(dependency::Behavior::WORKSPACE, workspace)
 }

--- a/test/cli/install/migration/__snapshots__/yarn-lock-migration.test.ts.snap
+++ b/test/cli/install/migration/__snapshots__/yarn-lock-migration.test.ts.snap
@@ -231,9 +231,34 @@ exports[`yarn.lock migration basic yarn.lock with workspace dependencies: worksp
         "lodash": "^4.17.21",
       },
     },
+    "packages/a": {
+      "name": "@workspace/a",
+      "version": "1.0.0",
+      "dependencies": {
+        "@workspace/b": "workspace:*",
+        "is-number": "^7.0.0",
+      },
+    },
+    "packages/b": {
+      "name": "@workspace/b",
+      "version": "1.0.0",
+      "dependencies": {
+        "is-odd": "^3.0.1",
+      },
+    },
   },
   "packages": {
+    "@workspace/a": ["@workspace/a@workspace:packages/a"],
+
+    "@workspace/b": ["@workspace/b@workspace:packages/b"],
+
+    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
+
+    "is-odd": ["is-odd@3.0.1", "", { "dependencies": { "is-number": "^6.0.0" } }, "sha512-CQpnWPrDwmP1+SMHXZhtLtJv90yiyVfluGsX5iNCVkrhQtU3TQHsUWPG9wkdk9Lgd5yNpAg9jQEo90CBaXgWMA=="],
+
     "lodash": ["lodash@4.17.21", "", {}, "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="],
+
+    "is-odd/is-number": ["is-number@6.0.0", "", {}, "sha512-Wu1VHeILBK8KAWJUAiSZQX94GmOE45Rg6/538fKwiloUu21KncEkYGPqob2oSZ5mUT73vLGrHQjKw3KMPwfDzg=="],
   }
 }
 "
@@ -275,15 +300,15 @@ exports[`yarn.lock migration basic migration with realistic complex yarn.lock: c
     "": {
       "name": "complex-app",
       "dependencies": {
+        "@babel/core": "^7.20.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "@babel/core": "^7.20.0",
         "webpack": "^5.75.0",
       },
       "devDependencies": {
         "@types/react": "^18.0.0",
-        "typescript": "^4.9.0",
         "eslint": "^8.0.0",
+        "typescript": "^4.9.0",
       },
       "optionalDependencies": {
         "fsevents": "^2.3.2",
@@ -3186,8 +3211,8 @@ exports[`bun pm migrate for existing yarn.lock yarn.lock with packages that have
     "": {
       "name": "os-cpu-test",
       "dependencies": {
-        "fsevents": "^2.3.2",
         "esbuild": "^0.17.0",
+        "fsevents": "^2.3.2",
       },
     },
   },

--- a/test/cli/install/migration/yarn-lock-migration.test.ts
+++ b/test/cli/install/migration/yarn-lock-migration.test.ts
@@ -1791,9 +1791,19 @@ describe.concurrent("yarn.lock migration of workspace dependencies", () => {
         },
         peerDependenciesMeta: { typescript: { optional: true } },
       }),
-      "packages/b/package.json": JSON.stringify({ name: "@mono/b", version: "1.2.0" }),
-      "packages/c/package.json": JSON.stringify({ name: "@mono/c", version: "0.0.1" }),
+      "packages/b/package.json": JSON.stringify({
+        name: "@mono/b",
+        version: "1.2.0",
+        dependencies: { "is-number": "6.0.0" },
+      }),
+      "packages/c/package.json": JSON.stringify({
+        name: "@mono/c",
+        version: "0.0.1",
+        // Neither peer is satisfied by the first `is-number` / `lodash` yarn.lock has.
+        peerDependencies: { "is-number": "6.0.0", lodash: "^3.0.0" },
+      }),
       "yarn.lock": yarnLock(
+        yarnLockEntries["is-number-6"]("is-number@6.0.0"),
         yarnLockEntries["is-number-7"]("is-number@^7.0.0"),
         yarnLockEntries["lodash"]("lodash@^4.17.21"),
       ),
@@ -1813,13 +1823,21 @@ describe.concurrent("yarn.lock migration of workspace dependencies", () => {
         peerDependencies: { "is-number": ">=6", lodash: "*", typescript: ">=4" },
         optionalPeers: ["typescript"],
       },
-      "packages/b": { name: "@mono/b", version: "1.2.0" },
-      "packages/c": { name: "@mono/c", version: "0.0.1" },
+      "packages/b": { name: "@mono/b", version: "1.2.0", dependencies: { "is-number": "6.0.0" } },
+      "packages/c": {
+        name: "@mono/c",
+        version: "0.0.1",
+        // `is-number` binds to the 6.0.0 entry; `lodash` falls back to the only lodash there is, as a
+        // fresh install would ("incorrect peer dependency").
+        peerDependencies: { "is-number": "6.0.0", lodash: "^3.0.0" },
+      },
     });
     expect(resolvedPackages(lock)).toEqual({
       "@mono/a": "@mono/a@workspace:packages/a",
       "@mono/b": "@mono/b@workspace:packages/b",
+      "@mono/b/is-number": "is-number@6.0.0",
       "@mono/c": "@mono/c@workspace:packages/c",
+      "@mono/c/is-number": "is-number@6.0.0",
       "is-number": "is-number@7.0.0",
       "lodash": "lodash@4.17.21",
     });
@@ -1895,7 +1913,8 @@ describe("bun install migrating a yarn.lock with workspaces", () => {
     expect(first.stderr).toContain("migrated lockfile from yarn.lock");
     expect(first.stderr).toContain("Saved lockfile");
 
-    expect(nodeModulesPackages(packageDir)).toMatchInlineSnapshot(`
+    const installed = nodeModulesPackages(packageDir);
+    expect(installed).toMatchInlineSnapshot(`
       "node_modules/a-dep/a-dep@1.0.1
       node_modules/no-deps/no-deps@1.0.0
       packages/a/a@1.0.0
@@ -1903,8 +1922,8 @@ describe("bun install migrating a yarn.lock with workspaces", () => {
       packages/b/node_modules/no-deps/no-deps@1.0.1"
     `);
 
-    const lock = Bun.JSONC.parse(await Bun.file(join(packageDir, "bun.lock")).text()) as MigratedLock;
-    expect(resolvedPackages(lock)).toEqual({
+    const lockText = await Bun.file(join(packageDir, "bun.lock")).text();
+    expect(resolvedPackages(Bun.JSONC.parse(lockText) as MigratedLock)).toEqual({
       "a": "a@workspace:packages/a",
       "a-dep": "a-dep@1.0.1",
       "b": "b@workspace:packages/b",
@@ -1915,5 +1934,7 @@ describe("bun install migrating a yarn.lock with workspaces", () => {
     // The migrated lockfile describes the package.json files exactly, so the next install has nothing to change.
     const second = await install(packageDir);
     expect(second.stderr).not.toContain("Saved lockfile");
+    expect(await Bun.file(join(packageDir, "bun.lock")).text()).toBe(lockText);
+    expect(nodeModulesPackages(packageDir)).toBe(installed);
   });
 });

--- a/test/cli/install/migration/yarn-lock-migration.test.ts
+++ b/test/cli/install/migration/yarn-lock-migration.test.ts
@@ -1783,6 +1783,8 @@ describe.concurrent("yarn.lock migration of workspace dependencies", () => {
         // Not in yarn.lock (added to package.json after the last `yarn install`).
         dependencies: { "is-odd": "^3.0.1" },
         devDependencies: { lodash: "^4.17.21" },
+        // yarn applied this when it wrote yarn.lock; the workspaces' lodash peers bind all the same.
+        resolutions: { lodash: "^4.17.21" },
       }),
       "packages/a/package.json": JSON.stringify({
         name: "@mono/a",

--- a/test/cli/install/migration/yarn-lock-migration.test.ts
+++ b/test/cli/install/migration/yarn-lock-migration.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, nodeModulesPackages, tempDir, VerdaccioRegistry } from "harness";
+import { bunEnv, bunExe, isDebug, nodeModulesPackages, tempDir, VerdaccioRegistry } from "harness";
 import { join } from "path";
 
 describe("yarn.lock migration basic", () => {
@@ -1519,30 +1519,41 @@ describe("bun pm migrate for existing yarn.lock", () => {
     "yarn-stuff",
     "yarn-stuff/abbrev-link-target",
   ];
-  test.each(folders)("%s", async folder => {
-    const packageJsonContent = await Bun.file(join(import.meta.dir, "yarn", folder, "package.json")).text();
-    const yarnLockContent = await Bun.file(join(import.meta.dir, "yarn", folder, "yarn.lock")).text();
+  test.each(folders)(
+    "%s",
+    async folder => {
+      const packageJsonContent = await Bun.file(join(import.meta.dir, "yarn", folder, "package.json")).text();
+      const yarnLockContent = await Bun.file(join(import.meta.dir, "yarn", folder, "yarn.lock")).text();
 
-    await using tmpDir = tempDir("yarn-lock-migration-", {
-      "package.json": packageJsonContent,
-      "yarn.lock": yarnLockContent,
-    });
+      await using tmpDir = tempDir("yarn-lock-migration-", {
+        "package.json": packageJsonContent,
+        "yarn.lock": yarnLockContent,
+      });
 
-    const migrateResult = Bun.spawn({
-      cmd: [bunExe(), "pm", "migrate", "-f"],
-      cwd: tmpDir,
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-      stdin: "ignore",
-    });
+      await using migrateResult = Bun.spawn({
+        cmd: [bunExe(), "pm", "migrate", "-f"],
+        cwd: tmpDir,
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+        stdin: "ignore",
+      });
 
-    expect(migrateResult.exited).resolves.toBe(0);
-    expect(Bun.file(join(tmpDir, "bun.lock")).exists()).resolves.toBe(true);
+      const [stdout, stderr, exitCode] = await Promise.all([
+        migrateResult.stdout.text(),
+        migrateResult.stderr.text(),
+        migrateResult.exited,
+      ]);
+      expect(stdout).toBe("");
+      expect(stderr).toContain("migrated lockfile from yarn.lock");
+      expect(exitCode).toBe(0);
 
-    const bunLockContent = await Bun.file(join(tmpDir, "bun.lock")).text();
-    expect(bunLockContent).toMatchSnapshot(folder);
-  });
+      const bunLockContent = await Bun.file(join(tmpDir, "bun.lock")).text();
+      expect(bunLockContent).toMatchSnapshot(folder);
+    },
+    // yarn-cli-repo is yarn's own 8k-line lockfile; a debug build takes several seconds to migrate it.
+    isDebug ? 60_000 : undefined,
+  );
 
   test("yarn.lock with packages that have os/cpu requirements", async () => {
     await using tmpDir = tempDir("yarn-migration-os-cpu", {

--- a/test/cli/install/migration/yarn-lock-migration.test.ts
+++ b/test/cli/install/migration/yarn-lock-migration.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, nodeModulesPackages, tempDir, VerdaccioRegistry } from "harness";
 import { join } from "path";
 
 describe("yarn.lock migration basic", () => {
@@ -1153,8 +1153,19 @@ lodash@^4.17.21:
     const bunLockContent = fs.readFileSync(join(tmpDir, "bun.lock"), "utf8");
     expect(bunLockContent).toMatchSnapshot("workspace-yarn-migration");
 
-    // TODO: Workspace dependencies are not yet supported in yarn migration
-    // expect(bunLockContent).toContain("workspace:");
+    const lock = Bun.JSONC.parse(bunLockContent) as {
+      workspaces: Record<string, unknown>;
+      packages: Record<string, unknown[]>;
+    };
+    expect(Object.keys(lock.workspaces)).toEqual(["", "packages/a", "packages/b"]);
+    expect(Object.fromEntries(Object.entries(lock.packages).map(([key, info]) => [key, info[0]]))).toEqual({
+      "@workspace/a": "@workspace/a@workspace:packages/a",
+      "@workspace/b": "@workspace/b@workspace:packages/b",
+      "is-number": "is-number@7.0.0",
+      "is-odd": "is-odd@3.0.1",
+      "is-odd/is-number": "is-number@6.0.0",
+      "lodash": "lodash@4.17.21",
+    });
   });
 
   test("yarn.lock with scoped packages and parent/child relationships", async () => {
@@ -1638,5 +1649,271 @@ fsevents@^2.3.2:
     expect(bunLockContent).toContain("fsevents");
     expect(bunLockContent).toContain("@esbuild/linux-arm64");
     expect(bunLockContent).toContain("@esbuild/darwin-arm64");
+  });
+});
+
+// yarn.lock has no entries for the root or the workspaces themselves: each dependency they declare is
+// looked up by the exact `name@range` key, the same way yarn resolves it.
+const yarnLockEntries = {
+  "is-number-6": (specs: string) => `${specs}:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-6.0.0.tgz#e6d15ad31fc262887d1846d1c6c84c9b3b0b5982"
+  integrity sha512-Wu1VHeILBK8KAWJUAiSZQX94GmOE45Rg6/538fKwiloUu21KncEkYGPqob2oSZ5mUT73vLGrHQjKw3KMPwfDzg==
+`,
+  "is-number-7": (specs: string) => `${specs}:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
+  integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
+`,
+  "lodash": (specs: string) => `${specs}:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+`,
+};
+
+function yarnLock(...entries: string[]) {
+  return `# yarn lockfile v1\n\n\n${entries.join("\n")}`;
+}
+
+type MigratedLock = {
+  workspaces: Record<string, Record<string, unknown>>;
+  packages: Record<string, unknown[]>;
+};
+
+async function migrate(dir: string): Promise<MigratedLock & { stderr: string }> {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "pm", "migrate", "-f"],
+    cwd: dir,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("");
+  expect(stderr).toContain("migrated lockfile from yarn.lock");
+  expect(exitCode).toBe(0);
+  const lock = Bun.JSONC.parse(await Bun.file(join(dir, "bun.lock")).text()) as MigratedLock;
+  return { ...lock, stderr };
+}
+
+function resolvedPackages(lock: MigratedLock) {
+  return Object.fromEntries(Object.entries(lock.packages).map(([key, info]) => [key, info[0]]));
+}
+
+describe.concurrent("yarn.lock migration of workspace dependencies", () => {
+  test("workspace dependencies are taken from yarn.lock when the root has no dependencies of its own", async () => {
+    using dir = tempDir("yarn-migration-workspaces-root-without-deps", {
+      "package.json": JSON.stringify({ name: "mono", private: true, workspaces: ["packages/*"] }),
+      "packages/a/package.json": JSON.stringify({ name: "a", version: "1.0.0", dependencies: { "is-number": ">=6" } }),
+      "packages/b/package.json": JSON.stringify({ name: "b", version: "1.0.0" }),
+      // One entry keyed by several ranges, as yarn writes it when the ranges resolve to the same version.
+      "yarn.lock": yarnLock(yarnLockEntries["is-number-7"]("is-number@>=6, is-number@^7.0.0")),
+    });
+
+    const lock = await migrate(String(dir));
+
+    expect(lock.workspaces).toEqual({
+      "": { name: "mono" },
+      "packages/a": { name: "a", version: "1.0.0", dependencies: { "is-number": ">=6" } },
+      "packages/b": { name: "b", version: "1.0.0" },
+    });
+    expect(resolvedPackages(lock)).toEqual({
+      "a": "a@workspace:packages/a",
+      "b": "b@workspace:packages/b",
+      "is-number": "is-number@7.0.0",
+    });
+  });
+
+  test("a range binds to its own yarn.lock entry, not to another entry of the same name that satisfies it", async () => {
+    using dir = tempDir("yarn-migration-workspaces-same-name", {
+      "package.json": JSON.stringify({
+        name: "mono",
+        private: true,
+        workspaces: ["packages/*"],
+        devDependencies: { lodash: "^4.17.21" },
+      }),
+      "packages/a/package.json": JSON.stringify({ name: "a", version: "1.0.0", dependencies: { "is-number": ">=6" } }),
+      "packages/b/package.json": JSON.stringify({
+        name: "b",
+        version: "1.0.0",
+        dependencies: { "is-number": "6.0.0" },
+      }),
+      "yarn.lock": yarnLock(
+        yarnLockEntries["is-number-6"]("is-number@6.0.0"),
+        yarnLockEntries["is-number-7"]("is-number@>=6"),
+        yarnLockEntries["lodash"]("lodash@^4.17.21"),
+      ),
+    });
+
+    const lock = await migrate(String(dir));
+
+    expect(lock.workspaces).toEqual({
+      "": { name: "mono", devDependencies: { lodash: "^4.17.21" } },
+      "packages/a": { name: "a", version: "1.0.0", dependencies: { "is-number": ">=6" } },
+      "packages/b": { name: "b", version: "1.0.0", dependencies: { "is-number": "6.0.0" } },
+    });
+    expect(resolvedPackages(lock)).toEqual({
+      "a": "a@workspace:packages/a",
+      "b": "b@workspace:packages/b",
+      "b/is-number": "is-number@6.0.0",
+      "is-number": "is-number@7.0.0",
+      "lodash": "lodash@4.17.21",
+    });
+  });
+
+  test("workspace links, peers, and dependencies missing from yarn.lock", async () => {
+    using dir = tempDir("yarn-migration-workspaces-links", {
+      "package.json": JSON.stringify({
+        name: "mono",
+        private: true,
+        workspaces: ["packages/*"],
+        // Not in yarn.lock (added to package.json after the last `yarn install`).
+        dependencies: { "is-odd": "^3.0.1" },
+        devDependencies: { lodash: "^4.17.21" },
+      }),
+      "packages/a/package.json": JSON.stringify({
+        name: "@mono/a",
+        version: "1.0.0",
+        dependencies: {
+          // Satisfied by the workspace's version, so yarn links it and yarn.lock has no entry for it.
+          "@mono/b": "^1.0.0",
+          "@mono/c": "workspace:*",
+          "is-number": "^7.0.0",
+          "left-pad": "^1.3.0",
+        },
+        peerDependencies: {
+          "is-number": ">=6",
+          "lodash": "*",
+          "react": ">=16",
+          "typescript": ">=4",
+        },
+        peerDependenciesMeta: { typescript: { optional: true } },
+      }),
+      "packages/b/package.json": JSON.stringify({ name: "@mono/b", version: "1.2.0" }),
+      "packages/c/package.json": JSON.stringify({ name: "@mono/c", version: "0.0.1" }),
+      "yarn.lock": yarnLock(
+        yarnLockEntries["is-number-7"]("is-number@^7.0.0"),
+        yarnLockEntries["lodash"]("lodash@^4.17.21"),
+      ),
+    });
+
+    const lock = await migrate(String(dir));
+
+    expect(lock.workspaces).toEqual({
+      // `is-odd` has no yarn.lock entry, so it is left for `bun install` to resolve.
+      "": { name: "mono", devDependencies: { lodash: "^4.17.21" } },
+      "packages/a": {
+        name: "@mono/a",
+        version: "1.0.0",
+        // `left-pad` has no yarn.lock entry either.
+        dependencies: { "@mono/b": "^1.0.0", "@mono/c": "workspace:*", "is-number": "^7.0.0" },
+        // Peers bind to the packages yarn.lock has for their names; `react` has none.
+        peerDependencies: { "is-number": ">=6", lodash: "*", typescript: ">=4" },
+        optionalPeers: ["typescript"],
+      },
+      "packages/b": { name: "@mono/b", version: "1.2.0" },
+      "packages/c": { name: "@mono/c", version: "0.0.1" },
+    });
+    expect(resolvedPackages(lock)).toEqual({
+      "@mono/a": "@mono/a@workspace:packages/a",
+      "@mono/b": "@mono/b@workspace:packages/b",
+      "@mono/c": "@mono/c@workspace:packages/c",
+      "is-number": "is-number@7.0.0",
+      "lodash": "lodash@4.17.21",
+    });
+  });
+});
+
+describe("bun install migrating a yarn.lock with workspaces", () => {
+  const verdaccio = new VerdaccioRegistry();
+
+  beforeAll(async () => {
+    await verdaccio.start();
+  });
+
+  afterAll(() => {
+    verdaccio.stop();
+  });
+
+  function registryEntry(name: string, specs: string, version: string) {
+    const manifest = JSON.parse(fs.readFileSync(join(verdaccio.packagesPath, name, "package.json"), "utf8"));
+    const { integrity, shasum } = manifest.versions[version].dist;
+    return `${specs}:
+  version "${version}"
+  resolved "${verdaccio.registryUrl()}${name}/-/${name}-${version}.tgz#${shasum}"
+  integrity ${integrity}
+`;
+  }
+
+  async function install(cwd: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
+    return { stdout, stderr };
+  }
+
+  test("installs the versions yarn.lock resolved each workspace's dependencies to", async () => {
+    const { packageDir } = await verdaccio.createTestDir({
+      files: {
+        "package.json": JSON.stringify({
+          name: "mono",
+          private: true,
+          workspaces: ["packages/*"],
+          // Not in yarn.lock: resolved from the registry, without disturbing the locked versions.
+          dependencies: { "a-dep": "1.0.1" },
+        }),
+        "packages/a/package.json": JSON.stringify({
+          name: "a",
+          version: "1.0.0",
+          dependencies: { "no-deps": "^1.0.0" },
+        }),
+        "packages/b/package.json": JSON.stringify({
+          name: "b",
+          version: "1.0.0",
+          dependencies: { "no-deps": "1.0.1" },
+        }),
+        // The registry has no-deps 1.0.0, 1.0.1, 1.1.0 and 2.0.0; yarn resolved `^1.0.0` to 1.0.0.
+        // The `1.0.1` entry comes first, like yarn sorts it, and also satisfies `^1.0.0`.
+        "yarn.lock": yarnLock(
+          registryEntry("no-deps", "no-deps@1.0.1", "1.0.1"),
+          registryEntry("no-deps", "no-deps@^1.0.0", "1.0.0"),
+        ),
+      },
+    });
+
+    const first = await install(packageDir);
+    expect(first.stderr).toContain("migrated lockfile from yarn.lock");
+    expect(first.stderr).toContain("Saved lockfile");
+
+    expect(nodeModulesPackages(packageDir)).toMatchInlineSnapshot(`
+      "node_modules/a-dep/a-dep@1.0.1
+      node_modules/no-deps/no-deps@1.0.0
+      packages/a/a@1.0.0
+      packages/b/b@1.0.0
+      packages/b/node_modules/no-deps/no-deps@1.0.1"
+    `);
+
+    const lock = Bun.JSONC.parse(await Bun.file(join(packageDir, "bun.lock")).text()) as MigratedLock;
+    expect(resolvedPackages(lock)).toEqual({
+      "a": "a@workspace:packages/a",
+      "a-dep": "a-dep@1.0.1",
+      "b": "b@workspace:packages/b",
+      "b/no-deps": "no-deps@1.0.1",
+      "no-deps": "no-deps@1.0.0",
+    });
+
+    // The migrated lockfile describes the package.json files exactly, so the next install has nothing to change.
+    const second = await install(packageDir);
+    expect(second.stderr).not.toContain("Saved lockfile");
   });
 });


### PR DESCRIPTION
### Problem
- Migrating a yarn v1 `yarn.lock` in a workspaces monorepo prints `migrated lockfile from yarn.lock` and exits 0, but the workspace packages' dependencies are not taken from `yarn.lock`: a workspace declaring `ms@^2.0.0` that `yarn.lock` resolved to `2.1.1` ends up with `2.1.3` (registry latest), or with `2.0.0` when another `ms@2.0.0` entry exists. Root dependencies and non-workspace projects migrate exactly. Same in 1.3.14 (fuzz ledger entry, not a regression).
- Cause: `migrate_yarn_lockfile` (`src/install/yarn.rs`) only created the root package and the lock entries; it never created the workspace packages, so `bun install` resolved their dependencies itself:
  - root without dependencies of its own: the migrated root had 0 dependencies, so `install_with_manager.rs:152` treated the lockfile as empty and resolved everything from the registry;
  - otherwise the differ added the workspaces and resolved their dependencies against the migrated lockfile by name + satisfies, and the migration had indexed only one version per name under the real name (the other versions under synthetic `parent/name` and `name@version` hashes, `yarn.rs` former lines 1383-1578), so `^2.0.0` bound to whatever single entry was indexed.
- Also fixed on the way: a root dependency missing from `yarn.lock` (package.json edited after the last `yarn install`) was written with no resolution, so `bun install` failed with `<name>@<range> failed to resolve` and `bun pm migrate` wrote a `bun.lock` that did not load.

### Fix
- The migration parses the root and every workspace `package.json` with `Package::parse_with_json` (`Features::main()` / `Features::WORKSPACE`), the same parse `bun install` uses, and appends them as packages 0..n, then the lock entries. Each dependency they declare is bound to the `yarn.lock` entry keyed by the exact `name@range` written in package.json (`Binder::bind`), which is how yarn itself resolves it; another entry of the same name that happens to satisfy the range is never used.
  - `workspace:` links and ranges satisfied by a workspace (which `parse_with_json` already turns into workspace edges) bind to the workspace package.
  - Peers: yarn v1 never installs or locks the root's and workspaces' `peerDependencies`, so required peers are bound by version the way loading a `bun.lock` binds them: the scan behind `resolve_peer_dep_version_based` is split out as `resolve_peer_dep_by_range` (plus `peer_candidate_name_hash`), and the migration runs it for `*` ranges and for names that have an `overrides`/`resolutions` rule as well, since yarn applied those rules to the entries the candidates come from (the loader exempts both because it can fall back to the printed tree; the migration has none, and a dropped peer would make the workspace differ from its package.json). Optional peers keep an unresolved edge for the hoister, as in a fresh resolve. Without this every workspace with a peer would differ from its package.json and be re-resolved wholesale by `bun install`.
  - A dependency with nothing to bind to is dropped from the migrated package, so `bun install` adds and resolves it like any dependency added after the lockfile was written.
- Every lock entry is registered in `package_index` under its real name (`get_or_put_id`), like every other lockfile; the synthetic names are gone. `bun install` after a partially stale `yarn.lock` therefore sees all locked versions of a name when it re-resolves.
- Because the root now comes from `parse_with_json`, the hand-written root dependency parsing and `parse_root_overrides` are gone, and overrides/resolutions, catalogs, `trustedDependencies` and `patchedDependencies` are recorded the way a fresh install records them. The first dependency pass (whose buffers the second pass overwrote), `process_deps`, `find_entry_by_spec`, and the `package_dependents` / `usage_count` / scoped-name bookkeeping (written, never read) are deleted; the lock entry resolution code and the entry dependency pass are unchanged. Migrating the yarn CLI's own lockfile (`yarn-cli-repo` fixture) takes 3.4-4.0s instead of 5.3-6.6s in a debug build here.
- Output differences for existing projects: root/workspace dependencies in the migrated `bun.lock` are in the order a fresh install writes them (grouped, name-sorted) instead of package.json order, hence the two reordered snapshots; the `yarn-cli-repo`, `yarn-stuff` and other fixture snapshots are byte-identical.
- Verified: `test/cli/install/migration/yarn-lock-migration.test.ts`: the existing workspace test now asserts the workspace packages (it carried a TODO), plus `bun pm migrate` tests for the three reported shapes (root without dependencies + multi-range key, two entries of one name, links/peers/missing dependencies; the peers case covers several candidates, none satisfying, and a root `resolutions` rule on the peer's name) and a Verdaccio `bun install` test checking the installed versions, the stale root dependency, and that a second install leaves `bun.lock` and `node_modules` unchanged. All 4 new tests and the updated one fail on the current build; the file passes with the fix. The fixture cases in the same file (`yarn-cli-repo` etc.) now await the process and get a longer timeout in debug builds, where yarn's own 8k-line lockfile takes 4-5s to migrate (same problem #35377 addresses). `test/cli/install/migration/` (except the git-clone test, which needs the network here), `test/cli/install/bun-lock.test.ts`, `hoist.test.ts` and the peer tests in `isolated-install.test.ts` pass. Also checked by hand that `bun install --frozen-lockfile` straight from such a `yarn.lock` passes and installs the locked versions.
- Related open PRs touching the same code: #37244 and #37539 rework the code this deletes; #38767 rebinds peers with the same scan after the npm migration and skips the yarn migration because of the index shape this PR fixes; #38773 records `trustedDependencies` after migration, which `parse_with_json` now also does for yarn. Whichever lands first, the others need a rebase.

### Background
- A yarn v1 lockfile has one entry per `name@range` that some package.json declared (several ranges resolving to the same version share one entry), and no entries for the root or the workspace packages themselves: their dependencies are found by looking up the exact declared `name@range`. Workspace-to-workspace dependencies whose version satisfies the range are linked and not recorded at all.
- Bun's lockfile stores packages in a table; `buffers.dependencies` / `buffers.resolutions` hold, per package, the dependencies it declares and the package id each one resolved to. `package_index` maps a package name hash to the ids of every version of that name; resolution (`get_package_id`) and peer binding scan it, so a version missing from it is invisible to them.
- `Package::parse_with_json` builds a package's rows from a package.json; with `Features::main()` it also walks `workspaces` and fills `workspace_paths` / `workspace_versions`, which is what lets workspace members' `workspace:` ranges resolve, so the root is parsed first. It is what `bun install` runs, and what the differ (`Package::Diff`) compares the loaded lockfile against; producing the same rows here is what makes the post-migration install a no-op instead of a re-resolve.
- `resolve_peer_dep_version_based` (`bun.lock.rs`) is how loading a `bun.lock` binds a required peer: the highest version of that name in the lockfile that satisfies the range, mirroring the resolver's deferred peer phase. Optional peers are bound later by the hoister (`Tree.rs`), which skips any other unresolved dependency.