### PR TITLE
spawnSync: don't run the bun:test timeout callback while the isolated loop is active

### DIFF
--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -289,7 +289,7 @@ pub(crate) fn spawn(
     args: JSValue,
     secondary_args_value: Option<JSValue>,
 ) -> JsResult<JSValue> {
-    spawn_maybe_sync::<false>(global_this, args, secondary_args_value)
+    spawn_maybe_sync::<false>(global_this, args, secondary_args_value, &mut None)
 }
 
 /// Bun.spawnSync() calls this.
@@ -298,13 +298,39 @@ pub(crate) fn spawn_sync(
     args: JSValue,
     secondary_args_value: Option<JSValue>,
 ) -> JsResult<JSValue> {
-    spawn_maybe_sync::<true>(global_this, args, secondary_args_value)
+    let mut bun_test_deadline: Option<Timespec> = None;
+    let result = spawn_maybe_sync::<true>(
+        global_this,
+        args,
+        secondary_args_value,
+        &mut bun_test_deadline,
+    );
+    // A bun:test deadline that passed while the isolated loop was blocking is reported only now: the loop is torn down and the child reaped, so the runner's callback re-enters nothing that is mid-flight. With an exception pending (spawn failure, termination) the file timer is left armed and reports it from the main loop instead.
+    if let Some(deadline) = bun_test_deadline
+        && result.is_ok()
+        && !global_this.has_exception()
+        && let Some(runner) = crate::test_runner::jest::Jest::runner()
+        && let Some(active_file) = runner.bun_test_root.active_file.clone()
+    {
+        let vm = global_this.bun_vm().as_mut();
+        runner.remove_active_timeout(vm);
+        crate::test_runner::bun_test::BunTest::bun_test_timeout_callback(
+            &active_file,
+            &deadline,
+            vm,
+        );
+        if global_this.has_exception() {
+            return Ok(JSValue::ZERO);
+        }
+    }
+    result
 }
 
 fn spawn_maybe_sync<const IS_SYNC: bool>(
     global_this: &JSGlobalObject,
     args_: JSValue,
     secondary_args_value: Option<JSValue>,
+    bun_test_deadline: &mut Option<Timespec>,
 ) -> JsResult<JSValue> {
     if IS_SYNC {
         // We skip this on Windows due to test failures.
@@ -1977,39 +2003,22 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
                     // Support bun:test timeouts AND spawnSync() timeout.
                     // There is a scenario where inside of spawnSync() a totally
                     // different test fails, and that SHOULD be okay.
-                    if has_bun_test_timeout {
-                        if bun_test_timeout.order(&now) == core::cmp::Ordering::Less {
-                            bun_test_fired = true;
-                            let mut active_file_strong = crate::test_runner::jest::Jest::runner()
-                                .unwrap()
-                                .bun_test_root
-                                .active_file
-                                // TODO: add a .cloneNonOptional()?
-                                .clone();
-
-                            let taken_active_file = active_file_strong.take().unwrap();
-
-                            // SAFETY: jsc_vm_ptr is the live thread VM.
-                            crate::test_runner::jest::Jest::runner()
-                                .unwrap()
-                                .remove_active_timeout(unsafe { &mut *jsc_vm_ptr });
-
-                            // This might internally call `kill(2)` on this
-                            // spawnSync process. Even if we do that, we still
-                            // need to reap the process. So we may go through
-                            // the event loop again, but it should wake up
-                            // ~instantly so we can drain the events.
-                            crate::test_runner::bun_test::BunTest::bun_test_timeout_callback(
-                                &taken_active_file,
-                                &absolute_timespec,
-                                // SAFETY: jsc_vm_ptr is the live thread VM.
-                                unsafe { &*jsc_vm_ptr },
-                            );
-                            // The direct child may already be reaped (and
-                            // gone from the auto-killer), so kill it here too.
-                            let _ = subprocess.try_kill(subprocess.kill_signal);
-                            // active_file_strong / taken_active_file drop here (was `defer .deinit()`).
+                    // Kill the dangling processes now so this loop can drain, but leave the runner's timeout callback to `spawn_sync`: it re-enters the test runner and must not run while this isolated loop is still active.
+                    if has_bun_test_timeout
+                        && bun_test_timeout.order(&now) == core::cmp::Ordering::Less
+                    {
+                        bun_test_fired = true;
+                        *bun_test_deadline = Some(absolute_timespec);
+                        if let Some(active_file) = crate::test_runner::jest::Jest::runner()
+                            .unwrap()
+                            .bun_test_root
+                            .active_file
+                            .clone()
+                        {
+                            // `Err` means the exception is pending on `global_this`; the check after this loop propagates it.
+                            let _ = active_file.get().execution.handle_timeout(global_this);
                         }
+                        let _ = subprocess.try_kill(subprocess.kill_signal);
                     }
                 }
             }

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -2015,8 +2015,10 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
                             .active_file
                             .clone()
                         {
-                            // `Err` means the exception is pending on `global_this`; the check after this loop propagates it.
-                            let _ = active_file.get().execution.handle_timeout(global_this);
+                            active_file
+                                .get()
+                                .execution
+                                .kill_dangling_processes_on_timeout(global_this);
                         }
                         let _ = subprocess.try_kill(subprocess.kill_signal);
                     }

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -297,7 +297,15 @@ impl Execution {
 
     pub(crate) fn handle_timeout(&mut self, global_this: &JSGlobalObject) -> JsResult<()> {
         let _g = group_begin!();
+        self.kill_dangling_processes_on_timeout(global_this);
+        let buntest = self.bun_test();
+        // SAFETY: deref parent at point-of-use; `self` is not accessed while this `&mut BunTest` is live.
+        unsafe { (*buntest).add_result(RefDataValue::Start) };
+        Ok(())
+    }
 
+    /// The kill-only half of [`handle_timeout`]: reaps a timed-out test's spawned processes without touching the runner's queue, so it may run from inside `spawnSync`'s isolated loop.
+    pub(crate) fn kill_dangling_processes_on_timeout(&mut self, global_this: &JSGlobalObject) {
         // if the concurrent group has one sequence and the sequence has an active entry that has timed out,
         //   kill any dangling processes
         // when using test.concurrent(), we can't do this because it could kill multiple tests at once.
@@ -326,11 +334,6 @@ impl Execution {
                 }
             }
         }
-
-        let buntest = self.bun_test();
-        // SAFETY: deref parent at point-of-use; `self` is not accessed while this `&mut BunTest` is live.
-        unsafe { (*buntest).add_result(RefDataValue::Start) };
-        Ok(())
     }
 
     pub(crate) fn step(


### PR DESCRIPTION
### What does this PR do?

`test/regression/issue/07261.test.ts` has been hanging in the `bun test --parallel` batch on the glibc Linux lanes (17 of the last ~110 PR builds; passes when retried alone). In the shard log the batch goes quiet with 07261 as the only file left, the 90s per-test deadline passes with **no `(fail) … timed out` line ever printed**, and the runner's idle timeout kills the batch 4 minutes later. A live capture of a hung batch shows the worker running the file spinning at 100% CPU with no syscalls, its `spawnSync` child a zombie, the pidfd still open.

When the per-test deadline passed while `Bun.spawnSync` was blocking, the sync wait loop called `BunTest::bun_test_timeout_callback` *in place* — re-entering the whole test runner (result queue, `handle_test_completed`, junit, worker IPC, timer heap) while `vm.event_loop_handle` still pointed at the isolated loop and before the child had been reaped. Nothing outside the sync child's own I/O should run there.

Now the loop only calls `Execution::handle_timeout` (kill the dangling processes so the child dies and the wait drains, `killed N dangling process` is still printed at the deadline) and hands the deadline back to `spawn_sync`, which fires the runner's callback once `spawn_maybe_sync` has torn the isolated loop down. If an exception is pending by then (spawn failure, termination), the file timer is left armed and reports the timeout from the main loop; an exception raised by the deferred callback is propagated (`Ok(JSValue::ZERO)` with the exception on the global, same as the existing post-loop path). Only `src/runtime/api/bun/js_bun_spawn_bindings.rs` changes.

### How did you verify your code works?

- `test/cli/test/test-timeout-behavior.test.ts` (sync fixture: spawnSync outliving the per-test timeout still prints `killed 1 dangling process`, `(fail) …`, no `JavaScript execution terminated`, and the next test runs), `test/js/bun/spawn/spawnSync.test.ts`, `spawnsync-no-microtask-drain`, `spawn-signal`, `spawn-maxbuf`, `bun-test.test.ts -t timeout`, `parallel.test.ts` (33/35; the `unique JEST_WORKER_ID` failure is the known debug-build timing flake noted in #38442) — on the debug build of this branch.
- The CI hang itself only reproduced under host load in a Linux container with the CI binary (~1/100 batches); there is no deterministic test for it in this PR. I'll re-run that stress against this branch's Linux CI build and post the counts here.
