### PR TITLE
fix: recognize bunx.EXE/node.EXE argv0 on Windows (case-insensitive)

### DIFF
--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -1007,6 +1007,14 @@ pub fn ends_with(self_: &[u8], str: &[u8]) -> bool {
     str.is_empty() || self_.ends_with(str)
 }
 
+/// Case-insensitive (ASCII-only) sibling of [`ends_with`] — mirrors
+/// [`starts_with_case_insensitive_ascii`] for suffix matching.
+#[inline]
+pub fn ends_with_case_insensitive_ascii(self_: &[u8], suffix: &[u8]) -> bool {
+    self_.len() >= suffix.len()
+        && eql_case_insensitive_ascii(&self_[self_.len() - suffix.len()..], suffix, false)
+}
+
 #[inline]
 pub fn starts_with_char(self_: &[u8], char: u8) -> bool {
     !self_.is_empty() && self_[0] == char
@@ -2737,6 +2745,17 @@ mod tests {
         assert_eq!(super::first_non_ascii(b"ab\xC3"), Some(2));
         assert!(super::eql_case_insensitive_ascii(b"A", b"a", true));
         assert!(!super::eql_case_insensitive_ascii(b"Ab", b"a", true));
+    }
+
+    #[test]
+    fn ends_with_case_insensitive_ascii_matches_case_variants() {
+        assert!(super::ends_with_case_insensitive_ascii(b"bunx.EXE", b"bunx.exe"));
+        assert!(super::ends_with_case_insensitive_ascii(b"bunx.exe", b"bunx.exe"));
+        assert!(super::ends_with_case_insensitive_ascii(b"bunx.EXE", b"bunx"));
+        assert!(super::ends_with_case_insensitive_ascii(b"BUNX", b"bunx"));
+        assert!(!super::ends_with_case_insensitive_ascii(b"bun.exe", b"bunx"));
+        assert!(!super::ends_with_case_insensitive_ascii(b"xbunx", b"bunx.exe"));
+        assert!(!super::ends_with_case_insensitive_ascii(b"bunx", b"bunx.exe"));
     }
 
     #[test]

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -827,7 +827,10 @@ pub mod command {
     fn is_bun_x(argv0: &[u8]) -> bool {
         #[cfg(windows)]
         {
-            return strings::ends_with(argv0, b"bunx.exe") || strings::ends_with(argv0, b"bunx");
+            // Windows paths are case-insensitive: `bunx.EXE` (e.g. produced by
+            // PATHEXT resolution) must be recognized the same as `bunx.exe`.
+            return strings::ends_with_case_insensitive_ascii(argv0, b"bunx.exe")
+                || strings::ends_with_case_insensitive_ascii(argv0, b"bunx");
         }
         #[cfg(not(windows))]
         {
@@ -838,7 +841,10 @@ pub mod command {
     fn is_node(argv0: &[u8]) -> bool {
         #[cfg(windows)]
         {
-            return strings::ends_with(argv0, b"node.exe") || strings::ends_with(argv0, b"node");
+            // Windows paths are case-insensitive: `NODE.EXE` must be
+            // recognized the same as `node.exe`.
+            return strings::ends_with_case_insensitive_ascii(argv0, b"node.exe")
+                || strings::ends_with_case_insensitive_ascii(argv0, b"node");
         }
         #[cfg(not(windows))]
         {


### PR DESCRIPTION
Fixes #36826

On Windows, executable-name detection compares argv0 case-sensitively: `bunx.EXE` (e.g. produced by PATH x PATHEXT resolution) is not recognized as `bunx` and bun misclassifies itself as plain `bun`, failing with `error: Script not found`. Same applies to `node.exe` vs `NODE.EXE`.

- Add `strings::ends_with_case_insensitive_ascii` (mirror of the existing `starts_with_case_insensitive_ascii`) in `src/bun_core/string/immutable.rs` + unit test
- Use it for `is_bun_x`/`is_node` on Windows in `src/runtime/cli/mod.rs`