### PR TITLE
patch: locate hunks by their "-" context instead of trusting the "+" offset

### DIFF
--- a/src/patch/lib.rs
+++ b/src/patch/lib.rs
@@ -253,7 +253,16 @@ impl<'a> PatchFile<'a> {
 
 /// Invariants:
 /// - Hunk parts are ordered by first to last in file
-/// - The original starting line and the patched starting line are equal in the first hunk part
+///
+/// Hunks are located using `header.original` (the "-" side), which is anchored to the
+/// pristine input file and never shifts as earlier hunks are applied. `header.patched`
+/// (the "+" side) is not used for positioning: it accumulates the net line delta of every
+/// prior hunk, and patch generators that miscount it (`yarn patch-commit` does, in practice)
+/// emit a stale value that still passes every bounds check while splicing content at the
+/// wrong line (see https://github.com/oven-sh/bun/issues/38879). Context and deletion lines
+/// are verified against the file's actual content before anything is written, so a hunk that
+/// doesn't match where `header.original` says it should errors out instead of silently
+/// applying at the wrong offset.
 ///
 /// TODO: this is a very naive and slow implementation which works by creating a list of lines
 /// we can speed it up by:
@@ -340,68 +349,73 @@ fn apply_patch(patch: &FilePatch<'_>, patch_dir: Fd, state: &mut ApplyState) -> 
         debug_assert!(i == file_line_count);
     }
 
-    for hunk in &patch.hunks {
-        let mut line_cursor = (hunk.header.patched.start - 1) as usize;
+    // Rebuild the file by walking the original lines once, copying unchanged
+    // spans verbatim and splicing in each hunk at its verified position —
+    // rather than mutating `lines` in place at trusted-but-possibly-stale
+    // absolute offsets (see the fn doc comment above).
+    let mut out_lines: Vec<&[u8]> = Vec::with_capacity(lines_count);
+    let mut src_cursor: usize = 0;
 
-        // Validate hunk start position is within bounds
-        if line_cursor > lines.len() {
+    for hunk in &patch.hunks {
+        let hunk_start = hunk.header.original.start.saturating_sub(1) as usize;
+
+        // Hunks must be in order and non-overlapping against the original file.
+        if hunk_start < src_cursor || hunk_start > lines.len() {
             return sys::Result::Err(
-                sys::Error::from_code(sys::E::EINVAL, sys::Tag::fstatat)
+                sys::Error::from_code(sys::E::EINVAL, sys::Tag::TODO)
                     .with_path(file_path.as_bytes()),
             );
         }
 
+        // Carry forward the unchanged span between the previous hunk (or the
+        // start of the file) and this one.
+        out_lines.extend_from_slice(&lines[src_cursor..hunk_start]);
+        src_cursor = hunk_start;
+
         for part in &hunk.parts {
             let part: &PatchMutationPart = part;
             match part.ty {
-                PartType::Context => {
-                    // TODO: check if the lines match in the original file?
-
-                    // Validate context lines exist
-                    if line_cursor + part.lines.len() > lines.len() {
+                PartType::Context | PartType::Deletion => {
+                    if src_cursor + part.lines.len() > lines.len() {
                         return sys::Result::Err(
-                            sys::Error::from_code(sys::E::EINVAL, sys::Tag::fstatat)
+                            sys::Error::from_code(sys::E::EINVAL, sys::Tag::TODO)
                                 .with_path(file_path.as_bytes()),
                         );
                     }
 
-                    line_cursor += part.lines.len();
+                    // The hunk claims these lines are present at this offset —
+                    // refuse to guess if the file doesn't actually match,
+                    // rather than splicing at a position we can't verify.
+                    let actual = &lines[src_cursor..src_cursor + part.lines.len()];
+                    if actual != part.lines.as_slice() {
+                        return sys::Result::Err(
+                            sys::Error::from_code(sys::E::EINVAL, sys::Tag::TODO)
+                                .with_path(file_path.as_bytes()),
+                        );
+                    }
+
+                    if part.ty == PartType::Context {
+                        out_lines.extend_from_slice(actual);
+                    } else if part.no_newline_at_end_of_file {
+                        // Deleting the line carrying the "no newline at EOF"
+                        // pragma means the file now ends with a newline.
+                        out_lines.push(b"");
+                    }
+                    src_cursor += part.lines.len();
                 }
                 PartType::Insertion => {
-                    // Validate insertion position is within bounds
-                    if line_cursor > lines.len() {
-                        return sys::Result::Err(
-                            sys::Error::from_code(sys::E::EINVAL, sys::Tag::fstatat)
-                                .with_path(file_path.as_bytes()),
-                        );
-                    }
-
-                    lines.splice(line_cursor..line_cursor, part.lines.iter().copied());
-                    line_cursor += part.lines.len();
+                    out_lines.extend_from_slice(&part.lines);
                     if part.no_newline_at_end_of_file {
-                        let _ = lines.pop();
+                        let _ = out_lines.pop();
                     }
-                }
-                PartType::Deletion => {
-                    // TODO: check if the lines match in the original file?
-
-                    // Validate deletion range is within bounds
-                    if line_cursor + part.lines.len() > lines.len() {
-                        return sys::Result::Err(
-                            sys::Error::from_code(sys::E::EINVAL, sys::Tag::fstatat)
-                                .with_path(file_path.as_bytes()),
-                        );
-                    }
-
-                    lines.drain(line_cursor..line_cursor + part.lines.len());
-                    if part.no_newline_at_end_of_file {
-                        lines.push(b"");
-                    }
-                    // line_cursor -= part.lines.len();
                 }
             }
         }
     }
+
+    // Everything after the last hunk is unchanged.
+    out_lines.extend_from_slice(&lines[src_cursor..]);
+    let lines = out_lines;
 
     let file_fd = match sys::openat(
         patch_dir,

--- a/src/patch/lib.rs
+++ b/src/patch/lib.rs
@@ -355,9 +355,23 @@ fn apply_patch(patch: &FilePatch<'_>, patch_dir: Fd, state: &mut ApplyState) -> 
     // absolute offsets (see the fn doc comment above).
     let mut out_lines: Vec<&[u8]> = Vec::with_capacity(lines_count);
     let mut src_cursor: usize = 0;
+    // Set by a part carrying the "\ No newline at end of file" pragma.
+    // Applied once at the very end (not inline) because more unchanged tail
+    // may still be appended to `out_lines` after this part is processed —
+    // popping/pushing immediately would touch the wrong element.
+    let mut trailing_newline: Option<bool> = None;
 
     for hunk in &patch.hunks {
-        let hunk_start = hunk.header.original.start.saturating_sub(1) as usize;
+        // A hunk whose original range is empty (pure insertion, e.g.
+        // `@@ -2,0 +3 @@`) uses a different anchor than a non-empty range:
+        // `start` is the line *after which* to insert, not a 1-based line to
+        // convert to a 0-based index. `@@ -0,0 +1,3 @@` (insert into an
+        // empty file) falls out of the same rule for free (start=0 → index 0).
+        let hunk_start = if hunk.header.original.len == 0 {
+            hunk.header.original.start as usize
+        } else {
+            hunk.header.original.start.saturating_sub(1) as usize
+        };
 
         // Hunks must be in order and non-overlapping against the original file.
         if hunk_start < src_cursor || hunk_start > lines.len() {
@@ -399,14 +413,14 @@ fn apply_patch(patch: &FilePatch<'_>, patch_dir: Fd, state: &mut ApplyState) -> 
                     } else if part.no_newline_at_end_of_file {
                         // Deleting the line carrying the "no newline at EOF"
                         // pragma means the file now ends with a newline.
-                        out_lines.push(b"");
+                        trailing_newline = Some(true);
                     }
                     src_cursor += part.lines.len();
                 }
                 PartType::Insertion => {
                     out_lines.extend_from_slice(&part.lines);
                     if part.no_newline_at_end_of_file {
-                        let _ = out_lines.pop();
+                        trailing_newline = Some(false);
                     }
                 }
             }
@@ -415,6 +429,18 @@ fn apply_patch(patch: &FilePatch<'_>, patch_dir: Fd, state: &mut ApplyState) -> 
 
     // Everything after the last hunk is unchanged.
     out_lines.extend_from_slice(&lines[src_cursor..]);
+
+    // Apply the deferred no-newline-at-EOF pragma now that every line —
+    // including the unchanged tail above — is in its final position.
+    if let Some(has_trailing_newline) = trailing_newline {
+        let ends_with_empty = matches!(out_lines.last(), Some(l) if l.is_empty());
+        if has_trailing_newline && !ends_with_empty {
+            out_lines.push(b"");
+        } else if !has_trailing_newline && ends_with_empty {
+            let _ = out_lines.pop();
+        }
+    }
+
     let lines = out_lines;
 
     let file_fd = match sys::openat(

--- a/test/js/bun/patch/patch.test.ts
+++ b/test/js/bun/patch/patch.test.ts
@@ -588,6 +588,68 @@ line10
 
       expect(await $`cat ${join(afolder, "file.txt")}`.cwd(tempdir).text()).toBe(bfile);
     });
+
+    test("insertion-only hunk (zero-length original range) in the middle of a file", async () => {
+      // `@@ -2,0 +3 @@` anchors differently than a non-empty range: `start`
+      // is the original line *after which* to insert, not a 1-based line to
+      // convert to a 0-based index (see #38879 review discussion).
+      const afile = `line1
+line2
+line3
+line4
+line5
+`;
+      const bfile = `line1
+line2
+NEW
+line3
+line4
+line5
+`;
+
+      await using tempdir = tempDir("patch-test", {
+        "a/file.txt": afile,
+      });
+      const afolder = join(tempdir, "a");
+
+      const patchfile = ["diff --git a/file.txt b/file.txt", "--- a/file.txt", "+++ b/file.txt", "@@ -2,0 +3 @@", "+NEW", ""].join(
+        "\n",
+      );
+
+      await apply(patchfile, afolder);
+
+      expect(await $`cat ${join(afolder, "file.txt")}`.cwd(tempdir).text()).toBe(bfile);
+    });
+
+    test("insertion at EOF whose added line has no trailing newline", async () => {
+      // Regression: the insertion's own last-pushed line must not be popped
+      // to represent the "no newline at EOF" pragma — only the tail's
+      // trailing empty sentinel (if any) should be. Popping immediately
+      // (before the unchanged tail is appended) silently drops the inserted
+      // content instead.
+      const afile = `line1
+line2
+`;
+
+      await using tempdir = tempDir("patch-test", {
+        "a/file.txt": afile,
+      });
+      const afolder = join(tempdir, "a");
+
+      const patchfile = [
+        "diff --git a/file.txt b/file.txt",
+        "--- a/file.txt",
+        "+++ b/file.txt",
+        "@@ -2,0 +3 @@",
+        "+line3",
+        "\\ No newline at end of file",
+        "",
+      ].join("\n");
+
+      await apply(patchfile, afolder);
+
+      expect(await $`cat ${join(afolder, "file.txt")}`.cwd(tempdir).text()).toBe("line1\nline2\nline3");
+    });
   });
 
   describe("No newline at end of file", () => {
@@ -738,6 +800,9 @@ line10
         stderr: "",
         exitCode: 0,
       });
+
+      // The rejected hunk must not have partially written the file.
+      expect(await Bun.file(`${dir}/target.txt`).text()).toBe("only line\n");
     });
   });
 });

--- a/test/js/bun/patch/patch.test.ts
+++ b/test/js/bun/patch/patch.test.ts
@@ -530,6 +530,64 @@ describe("apply", () => {
 
       expect(await $`cat ${join(afolder, "hello.txt")}`.cwd(tempdir).text()).toBe(bfile);
     });
+
+    test("multi-hunk patch with a stale + offset (yarn patch-commit style) applies at the correct position", async () => {
+      // The second hunk's declared `+` start (6) doesn't account for the two
+      // lines the first hunk inserts — the correct value is 8. This is the
+      // exact miscount `yarn patch-commit` produces (see #38879). Bun must
+      // locate the hunk by its `-` context, which is always correct, rather
+      // than trust the stale `+` offset.
+      const afile = `line1
+line2
+line3
+line4
+line5
+line6
+line7
+line8
+line9
+line10
+`;
+      const bfile = `line1
+line2
+NEW-1
+NEW-2
+line3
+line4
+line5
+line6
+NEW-3
+line7
+line8
+line9
+line10
+`;
+
+      await using tempdir = tempDir("patch-test", {
+        "a/file.txt": afile,
+      });
+      const afolder = join(tempdir, "a");
+
+      const patchfile = [
+        "diff --git a/file.txt b/file.txt",
+        "--- a/file.txt",
+        "+++ b/file.txt",
+        "@@ -2,2 +2,4 @@",
+        " line2",
+        "+NEW-1",
+        "+NEW-2",
+        " line3",
+        "@@ -6,2 +6,3 @@",
+        " line6",
+        "+NEW-3",
+        " line7",
+        "",
+      ].join("\n");
+
+      await apply(patchfile, afolder);
+
+      expect(await $`cat ${join(afolder, "file.txt")}`.cwd(tempdir).text()).toBe(bfile);
+    });
   });
 
   describe("No newline at end of file", () => {
@@ -623,6 +681,43 @@ describe("apply", () => {
              "+++ b/target.txt",
              "@@ -1,10 +1,1 @@",
              ...body,
+             "",
+           ].join("\\n");
+           try {
+             patchInternals.apply(patch, ${JSON.stringify(dir)});
+             console.log("no-error");
+           } catch (e) {
+             console.log("caught: " + e.code);
+           }`,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+        stdout: "caught: EINVAL",
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+
+    test("hunk context that doesn't match the target file errors instead of silently corrupting it", async () => {
+      await using dir = tempDir("patch-context-mismatch", { "target.txt": "only line\n" });
+
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `import { patchInternals } from "bun:internal-for-testing";
+           const patch = [
+             "diff --git a/target.txt b/target.txt",
+             "--- a/target.txt",
+             "+++ b/target.txt",
+             "@@ -1,1 +1,2 @@",
+             " this context does not match the file",
+             "+inserted",
              "",
            ].join("\\n");
            try {


### PR DESCRIPTION
## Summary
- Root cause: `apply_patch` in `src/patch/lib.rs` reset its write cursor to `header.patched.start - 1` (the "+" side) for every hunk, instead of accounting for the net line delta already applied by earlier hunks. `patch(1)`/`git apply` avoid this by locating each hunk via its "-" context, which is anchored to the pristine original file and never shifts as prior hunks are applied.
- `yarn patch-commit` emits patches whose "+" starts don't account for prior hunks (a real, reproducible miscount, not a hypothetical). The stale offset still lands inside file bounds, so nothing previously caught it — Bun spliced content at the wrong line silently, with `bun install` exiting `0`.
- Fix: rebuild the file by walking the original line numbering (the "-" side) instead of mutating in place at absolute "+" offsets, and verify context/deletion lines against the file's actual content before writing anything. A hunk that doesn't match where its "-" side says it should now errors out (`EINVAL`) instead of corrupting the file.
- Also hardened `header.original.start - 1` to `saturating_sub(1)` to avoid a debug-build overflow panic on the `start == 0` (empty-file hunk) edge case — same class of arithmetic the file already uses `saturating_*` for elsewhere.

Fixes #38879

## Test plan
- Added `test/js/bun/patch/patch.test.ts`: a multi-hunk regression reproducing the exact stale-`+`-offset scenario from the issue (second hunk's header declares `+6` when the correct value is `8`), asserting the output matches applying at the verified `-` position.
- Added a second test asserting that a hunk whose context doesn't match the target file's actual content errors with `EINVAL` instead of applying anyway, alongside the existing "header deleting more lines than the target file has" EINVAL test.

**I could not run these tests or compile this change locally** — this environment has no `bun`, `cargo`, or C++ toolchain available (verified: not on `PATH`, not found anywhere on disk). I reviewed the Rust changes carefully by hand for type/lifetime/overflow correctness, but this has only been checked by reading, not by building. Please treat `buildkite/bun` actually passing as load-bearing here, more than usual for a PR of this size.