### PR TITLE
fix: keep non-default SSH port in git+ssh URLs

### DIFF
--- a/src/install/hosted_git_info.rs
+++ b/src/install/hosted_git_info.rs
@@ -858,13 +858,23 @@ pub(crate) fn correct_url<'a>(
     };
 
     if col_idx > at_idx {
-        let mut duped: Box<[u8]> = Box::from(url_proto_pair.url_slice());
-        duped[usize::try_from(col_idx).expect("int cast")] = b'/';
+        let col_idx_usize = usize::try_from(col_idx).expect("int cast");
+        let url = url_proto_pair.url_slice();
+        // A colon followed by a digit is an explicit port (`ssh://git@host:2222/user/repo`),
+        // not the scp-style host:path separator. Leave the URL untouched, otherwise the
+        // port would be rewritten into a path segment (`/2222/user/repo`). Fixes #36931.
+        let is_port = url
+            .get(col_idx_usize + 1)
+            .is_some_and(|byte| byte.is_ascii_digit());
+        if !is_port {
+            let mut duped: Box<[u8]> = Box::from(url);
+            duped[col_idx_usize] = b'/';
 
-        return Ok(UrlProtocolPair {
-            url: UrlProtocolPairUrl::Managed(duped),
-            protocol: UrlProtocol::WellFormed(WellDefinedProtocol::GitPlusSsh),
-        });
+            return Ok(UrlProtocolPair {
+                url: UrlProtocolPairUrl::Managed(duped),
+                protocol: UrlProtocol::WellFormed(WellDefinedProtocol::GitPlusSsh),
+            });
+        }
     }
 
     let protocol = if col_idx == -1 && matches!(url_proto_pair.protocol, UrlProtocol::Unknown) {

--- a/test/cli/install/hosted-git-info/cases.ts
+++ b/test/cli/install/hosted-git-info/cases.ts
@@ -138,6 +138,15 @@ export const validGitUrls: { [K in Provider]: { [K in string]: object } } = {
     "git+ssh://bitbucket.org:foo/bar": { ...defaults.bitbucket, default: "sshurl" },
     "git+ssh://bitbucket.org:foo/bar#branch": { ...defaults.bitbucket, default: "sshurl", committish: "branch" },
     "git+ssh://user@bitbucket.org:foo/bar": { ...defaults.bitbucket, default: "sshurl", auth: null },
+    // explicit non-default SSH port: the colon is a port separator, not the
+    // scp-style host:path separator (regression guard for #36931)
+    "git+ssh://user@bitbucket.org:2222/foo/bar": { ...defaults.bitbucket, default: "sshurl", auth: null },
+    "git+ssh://user@bitbucket.org:2222/foo/bar#branch": {
+      ...defaults.bitbucket,
+      default: "sshurl",
+      auth: null,
+      committish: "branch",
+    },
     "git+ssh://user@bitbucket.org:foo/bar#branch": {
       ...defaults.bitbucket,
       default: "sshurl",


### PR DESCRIPTION
Fixes #36931

`hosted_git_info::correct_url` rewrote any colon after the host into a path separator, mangling explicit SSH ports: `ssh://git@git.chagine.com:52626/user/repo` became `ssh://git@git.chagine.com/52626/user/repo` (port treated as the first path segment), so `bun add git+ssh://host:52626/...` failed with `RepositoryNotFound`.

A colon followed by a digit is a port separator, not the scp-style `host:path` separator the correction targets. The rewrite is now skipped for ports.

- `src/install/hosted_git_info.rs`: skip the colon→`/` rewrite when the character after the colon is a digit
- `test/cli/install/hosted-git-info/cases.ts`: regression cases for `git+ssh://user@host:2222/foo/bar` (project must remain `foo/bar`, not `2222/foo/bar`)