### PR TITLE
js_parser: skip computed keys in destructured parameters of TypeScript function types

### DIFF
--- a/src/js_parser/parse/parse_skip_typescript.rs
+++ b/src/js_parser/parse/parse_skip_typescript.rs
@@ -120,6 +120,20 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             self.lexer.next()?;
                         }
 
+                        // "{[key]: y}"
+                        // "{[Symbol.iterator]: y}"
+                        //
+                        // The key is an expression, but it is skipped as a type, like
+                        // the computed keys in skip_type_script_object_type. That covers
+                        // the identifier, member chain and literal forms, and unlike the
+                        // expression parser it has no side effects (scopes, AST) that the
+                        // backtracking in skip_type_script_paren_or_fn_type can't undo.
+                        T::TOpenBracket => {
+                            self.lexer.next()?;
+                            self.skip_type_script_type(Level::Lowest)?;
+                            self.lexer.expect(T::TCloseBracket)?;
+                        }
+
                         _ => {
                             if self.lexer.is_identifier_or_keyword() {
                                 // "{if: x}"

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1399,6 +1399,65 @@ function foo() {}
       // err("async <const const T extends X>() => {}", "Unexpected const");
     });
 
+    it("computed keys in destructuring patterns of function types and method signatures", () => {
+      const exp = ts.expectPrinted_;
+      const err = ts.expectParseError;
+
+      // Function and constructor types
+      exp("let x: ({ [k]: a }: T) => void = Foo", "let x = Foo;\n");
+      exp("let x: new ({ [k]: a }: T) => void = Foo", "let x = Foo;\n");
+      exp("let x: abstract new ({ [k]: a }: T) => void = Foo", "let x = Foo;\n");
+      exp("let x: <T>({ [k]: a }: T) => void = Foo", "let x = Foo;\n");
+      exp("type F = ({ [k]: a }: T) => void", "");
+      exp("function f(): ({ [k]: a }: T) => void {}", "function f() {}");
+      exp("let x = y as ({ [k]: a }: T) => void", "let x = y;\n");
+      exp("let x: Array<({ [k]: a }: T) => void> = []", "let x = [];\n");
+
+      // Method, call and construct signatures
+      exp("interface I { m({ [k]: a }: T): void }", "");
+      exp("interface I { ({ [k]: a }: T): void }", "");
+      exp("interface I { new ({ [k]: a }: T): I }", "");
+      exp("let x: { m({ [k]: a }: T): void } = Foo", "let x = Foo;\n");
+      exp("let x: { [m]({ [k]: a }: T): void } = Foo", "let x = Foo;\n");
+
+      // The key takes the same forms as a computed key in a type literal
+      exp("let x: ({ [a.b.c]: v }: T) => void = Foo", "let x = Foo;\n");
+      exp("let x: ({ [Symbol.iterator]: v }: T) => void = Foo", "let x = Foo;\n");
+      exp("let x: ({ ['k']: v }: T) => void = Foo", "let x = Foo;\n");
+      exp("let x: ({ [1]: v, [-1]: w, [1n]: z }: T) => void = Foo", "let x = Foo;\n");
+      exp("let x: ({ [`${k}`]: v }: T) => void = Foo", "let x = Foo;\n");
+      exp("let x: ({ [keys[0]]: v }: T) => void = Foo", "let x = Foo;\n");
+
+      // Alongside the other member forms, nested, optional and rest parameters
+      exp("let x: ({ [k]: a, b, c: d, 1: e, 's': f, if: g, ...h }: T) => void = Foo", "let x = Foo;\n");
+      exp("let x: ({ [k]: { a, [j]: [b, ...c] } }: T) => void = Foo", "let x = Foo;\n");
+      exp("let x: ([{ [k]: a }]: T) => void = Foo", "let x = Foo;\n");
+      exp("let x: ({ [k]: a }, { [j]: b }?: T, ...[{ [i]: c }]: T[]) => void = Foo", "let x = Foo;\n");
+      exp("let x: ({ [k]: a }) => void = Foo", "let x = Foo;\n");
+
+      // A parenthesized type literal with a computed key or an index signature is still a type
+      exp("let x: ({ [k]: a }) = Foo", "let x = Foo;\n");
+      exp("let x: ({ [k]: a })[] = Foo", "let x = Foo;\n");
+      exp("let x: ({ [k: string]: a }) = Foo", "let x = Foo;\n");
+
+      // In a return type, "({ [k]: v }) => c" is a function type, exactly like
+      // "({ a: v }) => c" already is. It is not a parenthesized type literal
+      // followed by the arrow body.
+      exp("y = (b): ({ a: v }) => c => e", "y = (b) => e;\n");
+      exp("y = (b): ({ [k]: v }) => c => e", "y = (b) => e;\n");
+      exp("y = (b): (({ [k]: v }) => c) => e", "y = (b) => e;\n");
+      err("y = (b): ({ a: v }) => e", 'Expected ";" but found ":"');
+      err("y = (b): ({ [k]: v }) => e", 'Expected ";" but found ":"');
+
+      // A computed key needs a binding after it
+      err("let x: ({ [k] }: T) => void", 'Expected ")" but found ":"');
+      err("interface I { m({ [k] }: T): void }", 'Expected ":" but found "}"');
+
+      // Patterns in value positions are unaffected
+      exp("let g = ({ [k]: a }: T) => a", "let g = ({ [k]: a }) => a;\n");
+      exp("function g({ [k()]: a }: T): void {}", "function g({ [k()]: a }) {}");
+    });
+
     it("non-null assertion with new operator", () => {
       const exp = ts.expectPrinted_;
 


### PR DESCRIPTION
### Problem
- A TypeScript function type, constructor type, or interface / type literal method signature whose parameter is destructured with a computed key does not parse:
  ```ts
  let f: ({ [k]: x }: T) => void          // error: Expected ")" but found ":"
  interface I { m({ [k]: x }: T): void }  // error: Unexpected [
  ```
  tsc parses both (no parse diagnostics) and erases them. The same pattern in a value position (`({ [k]: x }: T) => x`), in a `declare function`, an overload or an abstract method already works in bun, and so do `{ 1: x }` / `{ 's': x }` keys in these exact positions.
- When the function type sits in an arrow's return type, the failure is silent and the output is wrong: in `(b): ({ [k]: v }) => c => e` bun gave up on the function type, read `({ [k]: v })` as a parenthesized type literal and `c => e` as the arrow body, printing `(b) => (c) => e`. tsc (and bun for the equivalent `({ a: v }) => c => e`) print `(b) => e`.
- Cause: `skip_type_script_binding()` in `src/js_parser/parse/parse_skip_typescript.rs`, the `TOpenBrace` arm. Its match over member keys handles identifiers, `...rest`, string / numeric literals and keywords, but has no `[` arm, so a computed key falls into `unexpected()`. This is the binding skipper used by `skip_typescript_fn_args()`, which is reached from `skip_type_script_paren_or_fn_type` (function, constructor and generic function types) and from the method / call / construct signature path in `skip_type_script_object_type`. The code is ported from esbuild's `skipTypeScriptBinding`, which has the same gap, so there is nothing upstream to port.

### Fix
- Add a `TOpenBracket` arm: consume `[`, skip the key with `skip_type_script_type`, expect `]`. `found_identifier` stays false, so the existing code then requires `: binding` after it, which also handles nested patterns (`{ [k]: { y } }`, `{ [k]: [y] }`).
- Skipping the key as a type is how `skip_type_script_object_type` already handles `{ [k]: T }` in type literals. It covers the forms a computed key takes in practice (`[k]`, `[a.b.c]`, `[Symbol.iterator]`, `['k']`, `[1]`, `[1n]`, `` [`${k}`] ``, `[keys[0]]`), and the accepted set is now identical between the two positions (`[k()]` stays rejected in both).
- The expression parser is deliberately not used for the key: this code runs inside `try_skip_type_script_arrow_args_with_backtracking`, which rewinds only the lexer, and the expression parser pushes scopes and allocates AST nodes that the rewind would leave behind. The type skipper has no such side effects and is already what runs for parameter types on this same path.
- Parse results only change for inputs that previously failed the function type attempt. A parenthesized type that is not followed by `=>` (`({ [k]: a })`, `({ [k: string]: a })`) still backtracks to the type literal parse exactly as before, because the attempt still fails at the missing `=>` (or, for an index signature, at the `:` inside the brackets). Inputs followed by `=>` were either errors or the misparse described above, and now resolve the way tsc resolves them, which is also how bun already resolves the same inputs written with a plain key. Verified against tsc 6.0 for every row in the new test.
- Parameter initializers in these positions (`({ x = 1 }: T) => void`) are unchanged: they fail before and after for every key form, and tsc reports them as an error (TS2371), so they are a separate question from this one.
- Verified:
  - `test/bundler/transpiler/transpiler.test.js`, new test "computed keys in destructuring patterns of function types and method signatures": fails on bun 1.4.0 and on a debug build of main without the `src/` change, passes with it.
  - `bun bd test` on the whole of `transpiler.test.js` (189 pass, 0 fail) and on `esbuild/ts`, `esbuild/default`, `decorator-metadata`, `transpiler-stack-overflow`, `property` (215 pass, 0 fail).
  - Deeply nested inputs through the new arm (300k levels of `{ [k]: ` and 20k levels of `{ [{ [`) end in the existing "Maximum call stack size exceeded" error on the ASAN build; both recursion paths already carry a stack check.

### Background
- The TypeScript *type skipper* (`parse_skip_typescript.rs`) is the part of the parser that consumes type annotations without building anything for them, since types are erased from the output. It only has to accept what tsc accepts and leave the lexer positioned after the type. `skip_type_script_binding` is its copy of the destructuring grammar, needed because parameters inside a function type can be patterns (`([a, b]: T) => void`), and `skip_type_script_type` is the entry point for a type.
- `( ... ) => R` is ambiguous with a parenthesized type `( T )` until the `=>` is seen. `skip_type_script_paren_or_fn_type` therefore first tries to skip the whole thing as function parameters plus `=>` with *backtracking*: the lexer position is snapshotted, errors are muted, and on any failure the lexer is restored and the input is re-read as a parenthesized type. Anything run inside that attempt must have no effect outside the lexer, which is why the key is skipped rather than parsed.
- A *computed key* in a destructuring pattern, `{ [expr]: binding }`, takes the property named by the value of `expr`. In the grammar it is an arbitrary expression; in type-position patterns it is in practice an identifier, a member chain such as `Symbol.iterator`, or a literal, all of which the type skipper reads as a type reference or a literal type.

<details>
<summary>Before / after on a few inputs (debug build; tsc 6.0 agrees with every "after" line)</summary>

```
input                                                  before                                   after
let x: ({ [k]: a }: T) => void = Foo                   Expected ")" but found ":"               let x = Foo;
let x: new ({ [k]: a }: T) => void = Foo               Expected ")" but found ":"               let x = Foo;
interface I { m({ [k]: a }: T): void }                 Unexpected [                             (empty)
interface I { new ({ [k]: a }: T): I }                 Unexpected [                             (empty)
let x: ({ [a.b.c]: v, [`${k}`]: w }: T) => void = Foo  Expected ")" but found ":"               let x = Foo;
let x: ({ [k]: { a, [j]: [b, ...c] } }: T) => void     Expected ")" but found ":"               let x;
y = (b): ({ [k]: v }) => c => e                        y = (b) => (c) => e;   (wrong)           y = (b) => e;
y = (b): (({ [k]: v }) => c) => e                      Expected ";" but found ":"               y = (b) => e;
y = (b): ({ [k]: v }) => e                             y = (b) => e;          (tsc: error)      Expected ";" but found ":"
let x: ({ [k]: a }) = Foo                              let x = Foo;                             let x = Foo;   (unchanged)
let x: ({ [k: string]: a }) = Foo                      let x = Foo;                             let x = Foo;   (unchanged)
let x: ({ [k()]: a }: T) => void                       Expected "]" but found "("               Expected "]" but found "("   (unchanged)
let x: ({ [k]: a = 1 }: T) => void                     Unexpected =                             Unexpected =   (unchanged)
```

The `{ a: v }` spellings of the `y = (b): ...` rows produce the "after" column on main today; the test asserts both spellings side by side.
</details>
