### PR TITLE
install: keep a peer nothing in bun.lock satisfies where the file records it

### DIFF
--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -3336,13 +3336,9 @@ fn deferred_peer_range<'a>(
 /// `install_peer`): scan the package ids recorded for the dependency's
 /// name — `package_index` lists are kept ordered by descending
 /// `Resolution::order` — and take the first whose resolution satisfies
-/// the range. When nothing satisfies, fall back to the highest-ordered
-/// candidate, and only when it is the same kind as the dependency (the
-/// "incorrect peer dependency" case; the fresh resolver inspects only
-/// `list[0]` there, and reproducing its choice exactly is the point of
-/// this helper). Returns `None` when no package with the name exists
-/// or the fallback is a different kind; the caller then falls back to
-/// the path walk. Edges `deferred_peer_range` rejects also return `None`.
+/// the range. Returns `None` when no candidate satisfies it (the tree the
+/// caller falls back to is the only record of the resolver's "incorrect
+/// peer dependency" pick) and for the edges `deferred_peer_range` rejects.
 ///
 /// Peer edges cannot be resolved from the printed tree the way regular
 /// edges are: a peer never materializes its own `node_modules` path when
@@ -3414,18 +3410,6 @@ pub(crate) fn resolve_peer_dep_version_based(
                 .satisfies_dependency_version(range, string_buf, string_buf)
         {
             return Some(id);
-        }
-    }
-
-    let &first = candidates.first()?;
-    if (first as usize) < pkg_resolutions.len() {
-        let res_tag = pkg_resolutions[first as usize].tag;
-        let ver_tag = range.tag;
-        if (res_tag == ResolutionTag::Npm && ver_tag == DependencyVersionTag::Npm)
-            || (res_tag == ResolutionTag::Git && ver_tag == DependencyVersionTag::Git)
-            || (res_tag == ResolutionTag::Github && ver_tag == DependencyVersionTag::Github)
-        {
-            return Some(first);
         }
     }
 

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -3404,16 +3404,11 @@ pub(crate) fn resolve_peer_dep_version_based(
     }
 
     let candidates = package_index.get(&name_hash)?.as_slice();
-    for &id in candidates {
-        if (id as usize) < pkg_resolutions.len()
-            && pkg_resolutions[id as usize]
-                .satisfies_dependency_version(range, string_buf, string_buf)
-        {
-            return Some(id);
-        }
-    }
-
-    None
+    candidates.iter().copied().find(|&id| {
+        pkg_resolutions
+            .get(id as usize)
+            .is_some_and(|res| res.satisfies_dependency_version(range, string_buf, string_buf))
+    })
 }
 
 // Taking `&mut BinaryLockfile` plus a `&mut Dependency` that

--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -1573,6 +1573,159 @@ it.each([
   await run(["install", "--frozen-lockfile"]);
 });
 
+// When no version in the lockfile satisfies a required peer's range, the resolver binds the
+// edge to whichever version it saw first and later installs keep that binding, so the only
+// record of it is the tree: the version is printed next to the dependent when it conflicts
+// with the version hoisted above, and otherwise the edge was deduped onto the hoisted one.
+// Loading has to read that record. Picking the highest version in the file instead moved
+// the edge whenever the file held another out-of-range version, and the re-save then
+// printed a different tree: the recorded copy dropped, or a new nested copy added. These
+// shapes are what a lockfile looks like once the package that provided the version the
+// peer was first bound to has left the project.
+describe("loading bun.lock keeps a peer nothing in the file satisfies where the file records it", () => {
+  const pkg = (nameAndVersion: string, info: object = {}) => [nameAndVersion, "", info, ""];
+  const oneDep = pkg("one-dep@1.0.0", { dependencies: { "no-deps": "1.0.1" } });
+  const strictPeerDep = pkg("strict-peer-dep@1.0.0", { peerDependencies: { "no-deps": "^2.0.0" } });
+
+  type Shape = {
+    root: Record<string, unknown>;
+    workspaces?: Record<string, Record<string, unknown>>;
+    packages: Record<string, unknown[]>;
+    kept: string[];
+    absent?: string[];
+  };
+
+  const shapes: [string, Shape][] = [
+    [
+      "a package's peer on the copy printed next to it",
+      {
+        root: { dependencies: { "one-dep": "1.0.0", "strict-peer-dep": "1.0.0" } },
+        packages: {
+          "no-deps": pkg("no-deps@1.0.1"),
+          "one-dep": oneDep,
+          "strict-peer-dep": strictPeerDep,
+          "strict-peer-dep/no-deps": pkg("no-deps@1.0.0"),
+        },
+        kept: ['"no-deps": ["no-deps@1.0.1"', '"strict-peer-dep/no-deps": ["no-deps@1.0.0"'],
+      },
+    ],
+    [
+      "a package's peer on the copy hoisted above it",
+      {
+        // one-dep is a devDependency so that its no-deps@1.0.1 is hoisted first and holds the
+        // root slot; the higher 1.1.0 is nested, and the peer was deduped onto the root copy.
+        root: {
+          devDependencies: { "one-dep": "1.0.0" },
+          dependencies: { "normal-dep-and-dev-dep": "1.0.1", "strict-peer-dep": "1.0.0" },
+        },
+        packages: {
+          "no-deps": pkg("no-deps@1.0.1"),
+          "normal-dep-and-dev-dep": pkg("normal-dep-and-dev-dep@1.0.1", { dependencies: { "no-deps": "1.1.0" } }),
+          "normal-dep-and-dev-dep/no-deps": pkg("no-deps@1.1.0"),
+          "one-dep": oneDep,
+          "strict-peer-dep": strictPeerDep,
+        },
+        kept: ['"no-deps": ["no-deps@1.0.1"', '"normal-dep-and-dev-dep/no-deps": ["no-deps@1.1.0"'],
+        absent: ['"strict-peer-dep/no-deps"'],
+      },
+    ],
+    [
+      "a workspace's peer on the copy printed next to it",
+      {
+        // workspace `a` is hoisted before `w`, so its no-deps holds the root slot
+        root: { workspaces: ["packages/*"] },
+        workspaces: {
+          "packages/a": { name: "a", version: "1.0.0", dependencies: { "no-deps": "1.0.1" } },
+          "packages/w": { name: "w", version: "1.0.0", peerDependencies: { "no-deps": "^2.0.0" } },
+        },
+        packages: {
+          "a": ["a@workspace:packages/a"],
+          "w": ["w@workspace:packages/w"],
+          "no-deps": pkg("no-deps@1.0.1"),
+          "w/no-deps": pkg("no-deps@1.0.0"),
+        },
+        kept: ['"no-deps": ["no-deps@1.0.1"', '"w/no-deps": ["no-deps@1.0.0"'],
+      },
+    ],
+    [
+      "the root's own peer on the copy at the root",
+      {
+        root: { dependencies: { "one-dep": "1.0.0" }, peerDependencies: { "no-deps": "^2.0.0" } },
+        packages: {
+          "no-deps": pkg("no-deps@1.0.0"),
+          "one-dep": oneDep,
+          "one-dep/no-deps": pkg("no-deps@1.0.1"),
+        },
+        kept: ['"no-deps": ["no-deps@1.0.0"', '"one-dep/no-deps": ["no-deps@1.0.1"'],
+      },
+    ],
+  ];
+
+  async function writeProject(packageDir: string, shape: Shape) {
+    await write(join(packageDir, "package.json"), JSON.stringify({ name: "foo", ...shape.root }));
+    for (const [path, manifest] of Object.entries(shape.workspaces ?? {})) {
+      await write(join(packageDir, path, "package.json"), JSON.stringify(manifest));
+    }
+    await write(
+      join(packageDir, "bun.lock"),
+      JSON.stringify({
+        lockfileVersion: 1,
+        configVersion: 0,
+        workspaces: { "": { name: "foo", ...shape.root, workspaces: undefined }, ...shape.workspaces },
+        packages: shape.packages,
+      }),
+    );
+  }
+
+  it.each(shapes)("re-saving keeps %s", async (_, shape) => {
+    const { packageDir } = await registry.createTestDir({ bunfigOpts: { saveTextLockfile: true } });
+    const run = makeInstallRunner(packageDir);
+    await writeProject(packageDir, shape);
+
+    await run(["install", "--lockfile-only"]);
+    const saved = await file(join(packageDir, "bun.lock")).text();
+    for (const entry of shape.kept) {
+      expect(saved).toContain(entry);
+    }
+    for (const entry of shape.absent ?? []) {
+      expect(saved).not.toContain(entry);
+    }
+
+    await run(["install", "--lockfile-only"]);
+    expect(await file(join(packageDir, "bun.lock")).text()).toBe(saved);
+  });
+
+  const [, nestedCopy] = shapes[0];
+
+  it("the hoisted linker installs the recorded copy next to the dependent", async () => {
+    const { packageDir } = await registry.createTestDir({ bunfigOpts: { saveTextLockfile: true, linker: "hoisted" } });
+    const run = makeInstallRunner(packageDir);
+    await writeProject(packageDir, nestedCopy);
+
+    await run(["install", "--frozen-lockfile"]);
+    expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toMatchObject({
+      version: "1.0.1",
+    });
+    expect(
+      await file(join(packageDir, "node_modules", "strict-peer-dep", "node_modules", "no-deps", "package.json")).json(),
+    ).toMatchObject({ version: "1.0.0" });
+  });
+
+  it("the isolated linker links the dependent against the recorded copy", async () => {
+    const { packageDir } = await registry.createTestDir({ bunfigOpts: { saveTextLockfile: true, linker: "isolated" } });
+    const run = makeInstallRunner(packageDir);
+    await writeProject(packageDir, nestedCopy);
+
+    await run(["install", "--frozen-lockfile"]);
+    const bunDir = join(packageDir, "node_modules", ".bun");
+    const entries = (await readdirSorted(bunDir)).filter(entry => entry.startsWith("strict-peer-dep@"));
+    expect(entries).toHaveLength(1);
+    expect(await file(join(bunDir, entries[0], "node_modules", "no-deps", "package.json")).json()).toMatchObject({
+      version: "1.0.0",
+    });
+  });
+});
+
 it("adding a dependency keeps an optional peer on the package bun.lock bound it to while that package stays next to it", async () => {
   const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { saveTextLockfile: true } });
   const run = makeInstallRunner(packageDir);

--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -1581,7 +1581,9 @@ it.each([
 // the edge whenever the file held another out-of-range version, and the re-save then
 // printed a different tree: the recorded copy dropped, or a new nested copy added. These
 // shapes are what a lockfile looks like once the package that provided the version the
-// peer was first bound to has left the project.
+// peer was first bound to has left the project. The record only holds while nothing in the
+// file satisfies the range: once a satisfying version enters the file, loading binds the peer
+// to it by version (as a fresh install would) and the next save drops the recorded copy.
 describe("loading bun.lock keeps a peer nothing in the file satisfies where the file records it", () => {
   const pkg = (nameAndVersion: string, info: object = {}) => [nameAndVersion, "", info, ""];
   const oneDep = pkg("one-dep@1.0.0", { dependencies: { "no-deps": "1.0.1" } });
@@ -1591,8 +1593,10 @@ describe("loading bun.lock keeps a peer nothing in the file satisfies where the 
     root: Record<string, unknown>;
     workspaces?: Record<string, Record<string, unknown>>;
     packages: Record<string, unknown[]>;
-    kept: string[];
+    saved: string[];
     absent?: string[];
+    /** Set when the shape names packages the test registry does not have, so only `--lockfile-only` can run. */
+    unpublished?: true;
   };
 
   const shapes: [string, Shape][] = [
@@ -1606,7 +1610,7 @@ describe("loading bun.lock keeps a peer nothing in the file satisfies where the 
           "strict-peer-dep": strictPeerDep,
           "strict-peer-dep/no-deps": pkg("no-deps@1.0.0"),
         },
-        kept: ['"no-deps": ["no-deps@1.0.1"', '"strict-peer-dep/no-deps": ["no-deps@1.0.0"'],
+        saved: ['"no-deps": ["no-deps@1.0.1"', '"strict-peer-dep/no-deps": ["no-deps@1.0.0"'],
       },
     ],
     [
@@ -1625,7 +1629,7 @@ describe("loading bun.lock keeps a peer nothing in the file satisfies where the 
           "one-dep": oneDep,
           "strict-peer-dep": strictPeerDep,
         },
-        kept: ['"no-deps": ["no-deps@1.0.1"', '"normal-dep-and-dev-dep/no-deps": ["no-deps@1.1.0"'],
+        saved: ['"no-deps": ["no-deps@1.0.1"', '"normal-dep-and-dev-dep/no-deps": ["no-deps@1.1.0"'],
         absent: ['"strict-peer-dep/no-deps"'],
       },
     ],
@@ -1644,7 +1648,7 @@ describe("loading bun.lock keeps a peer nothing in the file satisfies where the 
           "no-deps": pkg("no-deps@1.0.1"),
           "w/no-deps": pkg("no-deps@1.0.0"),
         },
-        kept: ['"no-deps": ["no-deps@1.0.1"', '"w/no-deps": ["no-deps@1.0.0"'],
+        saved: ['"no-deps": ["no-deps@1.0.1"', '"w/no-deps": ["no-deps@1.0.0"'],
       },
     ],
     [
@@ -1656,12 +1660,39 @@ describe("loading bun.lock keeps a peer nothing in the file satisfies where the 
           "one-dep": oneDep,
           "one-dep/no-deps": pkg("no-deps@1.0.1"),
         },
-        kept: ['"no-deps": ["no-deps@1.0.0"', '"one-dep/no-deps": ["no-deps@1.0.1"'],
+        saved: ['"no-deps": ["no-deps@1.0.0"', '"one-dep/no-deps": ["no-deps@1.0.1"'],
+      },
+    ],
+    [
+      "a package printed at two paths on the copy printed next to its last path",
+      {
+        // dup@1.0.0 is printed under both parents because the root holds dup@2.0.0. Its peer's
+        // copy is printed under z-parent/dup only: under a-parent/dup it was deduped onto the
+        // root's own no-deps, which root dependencies do regardless of range. The loader binds
+        // the package's edges once per printed path and the last path wins, so the record is
+        // read back here because z-parent sorts after a-parent; were the parents named the
+        // other way round, the root's copy would win and the next save would rewrite the entry to it.
+        root: {
+          dependencies: { "a-parent": "1.0.0", "dup": "2.0.0", "no-deps": "1.0.1", "z-parent": "1.0.0" },
+        },
+        packages: {
+          "a-parent": pkg("a-parent@1.0.0", { dependencies: { dup: "1.0.0" } }),
+          "dup": pkg("dup@2.0.0"),
+          "no-deps": pkg("no-deps@1.0.1"),
+          "z-parent": pkg("z-parent@1.0.0", { dependencies: { "dup": "1.0.0", "no-deps": "1.1.0" } }),
+          "a-parent/dup": pkg("dup@1.0.0", { peerDependencies: { "no-deps": "^2.0.0" } }),
+          "z-parent/dup": pkg("dup@1.0.0", { peerDependencies: { "no-deps": "^2.0.0" } }),
+          "z-parent/no-deps": pkg("no-deps@1.1.0"),
+          "z-parent/dup/no-deps": pkg("no-deps@1.0.0"),
+        },
+        saved: ['"z-parent/dup/no-deps": ["no-deps@1.0.0"'],
+        absent: ['"a-parent/dup/no-deps"'],
+        unpublished: true,
       },
     ],
   ];
 
-  async function writeProject(packageDir: string, shape: Shape) {
+  async function writeProject(packageDir: string, shape: Pick<Shape, "root" | "workspaces" | "packages">) {
     await write(join(packageDir, "package.json"), JSON.stringify({ name: "foo", ...shape.root }));
     for (const [path, manifest] of Object.entries(shape.workspaces ?? {})) {
       await write(join(packageDir, path, "package.json"), JSON.stringify(manifest));
@@ -1677,14 +1708,16 @@ describe("loading bun.lock keeps a peer nothing in the file satisfies where the 
     );
   }
 
-  it.each(shapes)("re-saving keeps %s", async (_, shape) => {
+  // Re-saves the shape once, checks the entries it must and must not print, and checks that
+  // the result is a fixed point: a further re-save leaves it alone and a frozen install accepts it.
+  async function resave(shape: Shape) {
     const { packageDir } = await registry.createTestDir({ bunfigOpts: { saveTextLockfile: true } });
     const run = makeInstallRunner(packageDir);
     await writeProject(packageDir, shape);
 
     await run(["install", "--lockfile-only"]);
     const saved = await file(join(packageDir, "bun.lock")).text();
-    for (const entry of shape.kept) {
+    for (const entry of shape.saved) {
       expect(saved).toContain(entry);
     }
     for (const entry of shape.absent ?? []) {
@@ -1692,11 +1725,62 @@ describe("loading bun.lock keeps a peer nothing in the file satisfies where the 
     }
 
     await run(["install", "--lockfile-only"]);
-    await run(["install", "--frozen-lockfile"]);
+    if (!shape.unpublished) await run(["install", "--frozen-lockfile"]);
     expect(await file(join(packageDir, "bun.lock")).text()).toBe(saved);
-  });
+  }
+
+  it.each(shapes)("re-saving keeps %s", (_, shape) => resave(shape));
 
   const [, nestedCopy] = shapes[0];
+
+  it("re-saving rebinds the peer once a version satisfying its range enters the file", () =>
+    resave({
+      // The first shape after `bun add one-fixed-dep@2.0.0` brought in no-deps@2.0.0: the
+      // recorded 1.0.0 is no longer the binding, so the re-save replaces it instead of keeping it.
+      root: { dependencies: { ...(nestedCopy.root.dependencies as object), "one-fixed-dep": "2.0.0" } },
+      packages: {
+        ...nestedCopy.packages,
+        "one-fixed-dep": pkg("one-fixed-dep@2.0.0", { dependencies: { "no-deps": "2.0.0" } }),
+        "one-fixed-dep/no-deps": pkg("no-deps@2.0.0"),
+      },
+      saved: [
+        '"no-deps": ["no-deps@1.0.1"',
+        '"one-fixed-dep/no-deps": ["no-deps@2.0.0"',
+        '"strict-peer-dep/no-deps": ["no-deps@2.0.0"',
+      ],
+      absent: ["no-deps@1.0.0"],
+    }));
+
+  it("a package's peer on the root's own out-of-range copy binds to it, not to the higher version nested elsewhere", async () => {
+    // Nothing is printed for this edge: either binding dedupes onto the root's copy when the
+    // tree is built, so the file is the same both ways and both linkers install the root's copy.
+    // The binding itself is what `pm why` reports (and what a tree built without the root's
+    // copy, such as `--production` when it is a devDependency, installs next to the dependent).
+    const { packageDir } = await registry.createTestDir({ bunfigOpts: { saveTextLockfile: true } });
+    await writeProject(packageDir, {
+      root: { dependencies: { "no-deps": "1.0.0", "one-dep": "1.0.0", "strict-peer-dep": "1.0.0" } },
+      packages: {
+        "no-deps": pkg("no-deps@1.0.0"),
+        "one-dep": oneDep,
+        "one-dep/no-deps": pkg("no-deps@1.0.1"),
+        "strict-peer-dep": strictPeerDep,
+      },
+    });
+
+    const { out } = await makeInstallRunner(packageDir)(["pm", "why", "no-deps"]);
+    expect(out).toMatchInlineSnapshot(`
+      "no-deps@1.0.0
+        ├─ foo (requires 1.0.0)
+        └─ peer strict-peer-dep@1.0.0 (requires ^2.0.0)
+           └─ foo (requires 1.0.0)
+
+      no-deps@1.0.1
+        └─ one-dep@1.0.0 (requires 1.0.1)
+           └─ foo (requires 1.0.0)
+
+      "
+    `);
+  });
 
   it("the hoisted linker installs the recorded copy next to the dependent", async () => {
     const { packageDir } = await registry.createTestDir({ bunfigOpts: { saveTextLockfile: true, linker: "hoisted" } });

--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -1692,6 +1692,7 @@ describe("loading bun.lock keeps a peer nothing in the file satisfies where the 
     }
 
     await run(["install", "--lockfile-only"]);
+    await run(["install", "--frozen-lockfile"]);
     expect(await file(join(packageDir, "bun.lock")).text()).toBe(saved);
   });
 

--- a/test/cli/install/migration/pnpm-lock-v9.test.ts
+++ b/test/cli/install/migration/pnpm-lock-v9.test.ts
@@ -79,6 +79,8 @@ const PEER_DEPS_TOO_1_0_0_INTEGRITY =
   "sha512-sBx0TKrsB8FkRN2lzkDjMuctPGEKn1TmNUBv3dJOtnZM8nd255o5ZAPRpAI2XFLHZAavBlK/e73cZNwnUxlRog==";
 const ONE_OPTIONAL_PEER_DEP_1_0_2_INTEGRITY =
   "sha512-S25U8/QXGIKfn/AWtsce1aVMnDjDL+ykFtAufpsuKGad32NlsCpi9TDuXvzoTQ+MdaZpGV3c4xghUZUsNeMp4A==";
+const STRICT_PEER_DEP_1_0_0_INTEGRITY =
+  "sha512-bz2RC/Fp4Nvc9aIiHB6Szko9m6sxNy/clIHnTAGeD9VSpQJTvlPAJqJ09lWo7N3q4JNLEqDTf3Mn+zNUsYOKWQ==";
 const LOCAL_TARBALL_INTEGRITY =
   "sha512-HP/5Rgt3pVFLzjmN9qJJ6vZMgCwoCIl/m2bPndYT283CUqnmFiMx0GeeIJ7SyK6TYoJM78SEvFEOQie++caHqw==";
 
@@ -1468,6 +1470,87 @@ snapshots:
         node_modules/peer-deps/peer-deps@1.0.0
         node_modules/provides-peer-deps-1-0-0/node_modules/no-deps/no-deps@1.0.0
         node_modules/provides-peer-deps-1-0-0/provides-peer-deps-1-0-0@1.0.0"
+      `);
+    });
+
+    test("a peer nothing in the lockfile satisfies keeps the version pnpm resolved it to", async () => {
+      // strict-peer-dep wants no-deps@^2.0.0; pnpm resolved it to 1.0.0 (the snapshot suffix) while
+      // one-dep brings in 1.0.1. Neither satisfies the range, so there is nothing to rebind the
+      // peer by; binding it to the highest version present would drop pnpm's 1.0.0 from the tree.
+      const { packageDir } = await verdaccio.createTestDir({
+        bunfigOpts: { linker: "hoisted" },
+        files: {
+          "package.json": JSON.stringify({
+            name: "unsatisfied-peer",
+            dependencies: { "one-dep": "1.0.0", "strict-peer-dep": "1.0.0" },
+          }),
+          "pnpm-lock.yaml": `lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+
+importers:
+
+  .:
+    dependencies:
+      one-dep:
+        specifier: 1.0.0
+        version: 1.0.0
+      strict-peer-dep:
+        specifier: 1.0.0
+        version: 1.0.0(no-deps@1.0.0)
+
+packages:
+
+  no-deps@1.0.0:
+    resolution: {integrity: ${NO_DEPS_1_0_0_INTEGRITY}}
+
+  no-deps@1.0.1:
+    resolution: {integrity: ${NO_DEPS_1_0_1_INTEGRITY}}
+
+  one-dep@1.0.0:
+    resolution: {integrity: ${ONE_DEP_1_0_0_INTEGRITY}}
+
+  strict-peer-dep@1.0.0:
+    resolution: {integrity: ${STRICT_PEER_DEP_1_0_0_INTEGRITY}}
+    peerDependencies:
+      no-deps: ^2.0.0
+
+snapshots:
+
+  no-deps@1.0.0: {}
+
+  no-deps@1.0.1: {}
+
+  one-dep@1.0.0:
+    dependencies:
+      no-deps: 1.0.1
+
+  strict-peer-dep@1.0.0(no-deps@1.0.0):
+    dependencies:
+      no-deps: 1.0.0
+`,
+        },
+      });
+
+      const { stderr, exitCode } = await migrate(packageDir);
+
+      expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
+      expect(exitCode).toBe(0);
+
+      const bunLock = await bunLockOf(packageDir);
+      expect(bunLock).toContain(`"no-deps": ["no-deps@1.0.1"`);
+      expect(bunLock).toContain(`"strict-peer-dep/no-deps": ["no-deps@1.0.0"`);
+
+      const install = await run(packageDir, "install", "--frozen-lockfile");
+
+      expect(install.stderr).not.toContain("error:");
+      expect(install.exitCode).toBe(0);
+      expect(nodeModulesPackages(packageDir)).toMatchInlineSnapshot(`
+        "node_modules/no-deps/no-deps@1.0.1
+        node_modules/one-dep/one-dep@1.0.0
+        node_modules/strict-peer-dep/node_modules/no-deps/no-deps@1.0.0
+        node_modules/strict-peer-dep/strict-peer-dep@1.0.0"
       `);
     });
 

--- a/test/cli/install/migration/pnpm-lock-v9.test.ts
+++ b/test/cli/install/migration/pnpm-lock-v9.test.ts
@@ -81,6 +81,10 @@ const ONE_OPTIONAL_PEER_DEP_1_0_2_INTEGRITY =
   "sha512-S25U8/QXGIKfn/AWtsce1aVMnDjDL+ykFtAufpsuKGad32NlsCpi9TDuXvzoTQ+MdaZpGV3c4xghUZUsNeMp4A==";
 const STRICT_PEER_DEP_1_0_0_INTEGRITY =
   "sha512-bz2RC/Fp4Nvc9aIiHB6Szko9m6sxNy/clIHnTAGeD9VSpQJTvlPAJqJ09lWo7N3q4JNLEqDTf3Mn+zNUsYOKWQ==";
+const NO_DEPS_1_1_0_INTEGRITY =
+  "sha512-ebG2pipYAKINcNI3YxdsiAgFvNGp2gdRwxAKN2LYBm9+YxuH/lHH2sl+GKQTuGiNfCfNZRMHUyyLPEJD6HWm7w==";
+const NORMAL_DEP_AND_DEV_DEP_1_0_1_INTEGRITY =
+  "sha512-MzZS9lLNBdqXf/lI+TKlXGeWrcDkOjzdSPJtvkRUN1FUjXg2DcGVldEqx9D8kNwF87Hxf2cRLvLv4a8GqZ6zPg==";
 const LOCAL_TARBALL_INTEGRITY =
   "sha512-HP/5Rgt3pVFLzjmN9qJJ6vZMgCwoCIl/m2bPndYT283CUqnmFiMx0GeeIJ7SyK6TYoJM78SEvFEOQie++caHqw==";
 
@@ -1550,6 +1554,104 @@ snapshots:
         "node_modules/no-deps/no-deps@1.0.1
         node_modules/one-dep/one-dep@1.0.0
         node_modules/strict-peer-dep/node_modules/no-deps/no-deps@1.0.0
+        node_modules/strict-peer-dep/strict-peer-dep@1.0.0"
+      `);
+    });
+
+    test("a peer nothing in the lockfile satisfies and pnpm left unmet is not given a copy of the highest version", async () => {
+      // pnpm recorded no resolution for strict-peer-dep's no-deps@^2.0.0 (no snapshot suffix),
+      // so in pnpm's layout the package sees whatever no-deps sits at the root: 1.0.1, hoisted
+      // there from one-dep. Binding the peer to the highest version present instead (1.1.0,
+      // nested under normal-dep-and-dev-dep) would add a strict-peer-dep/no-deps copy to the
+      // migrated tree that pnpm's tree does not have. Left unbound, the peer is bound to the
+      // root copy when the migrated bun.lock is loaded, like any other peer the file prints
+      // nothing for.
+      const { packageDir } = await verdaccio.createTestDir({
+        bunfigOpts: { linker: "hoisted" },
+        files: {
+          "package.json": JSON.stringify({
+            name: "unmet-peer",
+            // one-dep is a devDependency so that its no-deps@1.0.1 takes the root slot.
+            dependencies: { "normal-dep-and-dev-dep": "1.0.1", "strict-peer-dep": "1.0.0" },
+            devDependencies: { "one-dep": "1.0.0" },
+          }),
+          "pnpm-lock.yaml": `lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: false
+
+importers:
+
+  .:
+    dependencies:
+      normal-dep-and-dev-dep:
+        specifier: 1.0.1
+        version: 1.0.1
+      strict-peer-dep:
+        specifier: 1.0.0
+        version: 1.0.0
+    devDependencies:
+      one-dep:
+        specifier: 1.0.0
+        version: 1.0.0
+
+packages:
+
+  no-deps@1.0.1:
+    resolution: {integrity: ${NO_DEPS_1_0_1_INTEGRITY}}
+
+  no-deps@1.1.0:
+    resolution: {integrity: ${NO_DEPS_1_1_0_INTEGRITY}}
+
+  normal-dep-and-dev-dep@1.0.1:
+    resolution: {integrity: ${NORMAL_DEP_AND_DEV_DEP_1_0_1_INTEGRITY}}
+
+  one-dep@1.0.0:
+    resolution: {integrity: ${ONE_DEP_1_0_0_INTEGRITY}}
+
+  strict-peer-dep@1.0.0:
+    resolution: {integrity: ${STRICT_PEER_DEP_1_0_0_INTEGRITY}}
+    peerDependencies:
+      no-deps: ^2.0.0
+
+snapshots:
+
+  no-deps@1.0.1: {}
+
+  no-deps@1.1.0: {}
+
+  normal-dep-and-dev-dep@1.0.1:
+    dependencies:
+      no-deps: 1.1.0
+
+  one-dep@1.0.0:
+    dependencies:
+      no-deps: 1.0.1
+
+  strict-peer-dep@1.0.0: {}
+`,
+        },
+      });
+
+      const { stderr, exitCode } = await migrate(packageDir);
+
+      expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
+      expect(exitCode).toBe(0);
+
+      const bunLock = await bunLockOf(packageDir);
+      expect(bunLock).toContain(`"no-deps": ["no-deps@1.0.1"`);
+      expect(bunLock).toContain(`"normal-dep-and-dev-dep/no-deps": ["no-deps@1.1.0"`);
+      expect(bunLock).not.toContain(`"strict-peer-dep/no-deps"`);
+
+      const install = await run(packageDir, "install", "--frozen-lockfile");
+
+      expect(install.stderr).not.toContain("error:");
+      expect(install.exitCode).toBe(0);
+      expect(nodeModulesPackages(packageDir)).toMatchInlineSnapshot(`
+        "node_modules/no-deps/no-deps@1.0.1
+        node_modules/normal-dep-and-dev-dep/node_modules/no-deps/no-deps@1.1.0
+        node_modules/normal-dep-and-dev-dep/normal-dep-and-dev-dep@1.0.1
+        node_modules/one-dep/one-dep@1.0.0
         node_modules/strict-peer-dep/strict-peer-dep@1.0.0"
       `);
     });


### PR DESCRIPTION
### Problem
- A required peer whose range no version in `bun.lock` satisfies does not stay on the version the file records. activepieces/activepieces at HEAD has `react-json-view` (peers `react` / `react-dom` at `^17.0.0 || ^16.3.0 || ^15.5.4`) with `react-json-view/react-dom` = 18.3.1 and `react-json-view/react` = 18.3.1 printed next to it, and `flux/react` = 18.3.1 likewise, while the root holds 19.2.5. On an untouched checkout the 1.4 canary's `bun install --lockfile-only` binds those edges to 19.2.5 and removes `flux/react`, `react-json-view/react`, `react-json-view/react-dom` and `react-json-view/react-dom/scheduler` from the file; 1.3.14 leaves them alone.
- The installed tree changes the same way when the file is not rewritten: with `--frozen-lockfile` the hoisted linker no longer installs the nested copy (the dependent resolves the root copy at runtime) and the isolated linker links the dependent against the other version, re-keying its store entry. The drift also runs the other way: when the peer was deduped onto the copy hoisted above it and a higher out-of-range version is nested elsewhere, a no-op re-save adds a `<dependent>/<peer>` entry for that higher version (second test shape below).
- Cause: `resolve_peer_dep_version_based` (`src/install/lockfile/bun.lock.rs`), which since #32182 binds required ranged peers on load and since #38333 in the pnpm migration, falls back to the highest version present when nothing satisfies the range (`candidates.first()`, mirroring the resolver's "incorrect peer dependency" branch). The resolver makes that pick once, against the versions present at that moment, and later installs keep the binding (`Package::clone`), so the version the edge is actually on is recorded only by the tree; re-picking the highest version of the final set moves the edge whenever another out-of-range version exists. The recorded target then has no edge left, the clean drops it, and the next save prints a different tree than the one loaded. The pnpm migration loses pnpm's recorded resolution the same way.

### Fix
- The helper returns `None` when nothing satisfies the range. Every caller already has the record for that case and already uses it for the other edges the helper declines (optional, `*`, overridden): the three loader loops fall back to the printed tree (the root entry, `<workspace>/<name>` then the root, and the path walk, whose first probe is `<dependent>/<name>`), and the pnpm migration falls back to the version pnpm recorded in the snapshot.
- Why this is right: the satisfying scan has a criterion (highest version matching the declared range) that can be recomputed from any package set, which is what makes the binding reproducible. An unsatisfied edge has none; the resolver's pick is arbitrary and recorded only in the tree, so the tree is the thing to read. Every edge this changes ends up bound exactly where 1.3's loader bound it; edges with a satisfying candidate are not touched, so #32182's store-key stability is unchanged (its `isolated-install.test.ts` tests pass; none of them has an unsatisfied range), and a satisfying version entering the file later still rebinds the edge (pinned by the "rebinds" test). The resolver's own highest-version pick for a fresh resolve is intentionally kept; only the re-derivation on load goes. Since #38851 an edge the fallback cannot bind stays unbound rather than failing the load.
- Shape that binds differently from a fresh resolve: the root `package.json` itself pins an out-of-range version and a higher out-of-range version is nested elsewhere. Nothing is printed for the edge (the hoister dedupes a peer onto a root dependency regardless of range), the fresh resolve binds the higher version, this PR binds the root's copy. Both linkers install the root's copy for either binding (the hoister by that same rule, the isolated linker because its ancestor walk takes a parent's dependency of that name regardless of range), so the file, the hoisted layout and the store key (`+7347ae2d86f1441a` for the test shape, checked with both builds) are identical either way; the binding shows in `pm why` and in trees built without the root copy (`--production` when the pin is a devDependency, `--filter`). Pinned by the `pm why` test.
- Shape this improves without fully fixing: a dependent printed at two or more paths. The loader binds a package's edges once per printed path and the last path wins, so the recorded copy is read back when it sits under the last-sorted path, while a walk from another path can reach a different copy (the root's) and the next save then rewrites the entry to that copy, once. Main drops such a record in every order; when nothing is recorded (the root-pin shape above with two paths) main is exact and this PR can rewrite once depending on the order. The per-path overwrite is pre-existing loader behavior for every edge the walk binds (optional and `*` peers included) and is tracked separately; the order that works is pinned by the "two paths" shape.
- pnpm migration: for a peer pnpm recorded a resolution for, the snapshot suffix now wins (first pnpm test). For a peer pnpm left unmet (no suffix), main bound the highest version present, nesting a copy under the dependent that pnpm's tree did not have whenever that version was not the root's; it is now left unbound, like unmet `*` peers already are, and the first load of the migrated file binds it to the root copy, which is what the package sees in pnpm's layout too (second pnpm test). The isolated linker keys the migration's own install without that peer and re-keys the entry on the next install; unmet `*` peers already do that on main, tracked separately.
- Interaction with the open peer work: #38767 rebinds every peer edge through this same helper inside the hoister, on every tree build including the one at the end of a load; with the fallback in place it would move these edges at save time too, with this change it leaves them where the loader put them (verified by applying #38767's `src/` on top of this branch: the tests here, #38767's own tests and the activepieces re-save all agree with this branch alone). #38768's `resolve_peer_dep_version_based_among` re-implements the fallback for edges whose target was dropped from the tree and should drop it for the same reason. #38901's `existing_peer_target` describes the loader as binding to the highest candidate and should say the tree is read instead once this lands. #38837 (bundled peers) is independent.
- #38992 fixed the same activepieces case in the same function and is consolidated into this PR. It kept the fallback and looked up only the `<dependent>/<peer>` entry before it, which covers the first test shape and none of the others: built with its `src/`, the "hoisted above" shape gains `strict-peer-dep/no-deps` = 1.1.0, the root's-own-peer shape rebinds to 1.0.1 and drops `no-deps@1.0.0`, and the pnpm migration still binds 1.0.1 (its root loop and the migration passed nothing to look up). Its own test passes on this branch; the one assertion it had that the tests here lacked, `--frozen-lockfile` accepting the re-saved file, is now the last step of every re-save test.
- Verified:
  - `test/cli/install/bun-lock.test.ts`, `describe("loading bun.lock keeps a peer nothing in the file satisfies where the file records it")`, nine tests on hand-written lockfiles: five re-save shapes (the copy printed next to a package; deduped onto the copy hoisted above it with a higher version nested elsewhere; printed next to a workspace; the root's own peer; a package printed at two paths), each of which must print the expected entries, be a fixed point and pass `--frozen-lockfile`; the rebind-once-something-satisfies boundary; the root-pin shape via `pm why`; and `--frozen-lockfile` placement of the first shape under the hoisted and the isolated linker. Built with main's helper (`732491c`) eight of the nine fail (the boundary test passes on both by design): entries removed or rewritten to the higher version, the second shape gains `strict-peer-dep/no-deps` = 1.1.0, the two-paths record is dropped, `pm why` lists the peer under 1.0.1, the hoisted copy is missing, the isolated entry links 1.0.1.
  - `test/cli/install/migration/pnpm-lock-v9.test.ts`, two tests under "peer dependencies": the recorded suffix is kept (`strict-peer-dep/no-deps` = 1.0.0, installed there by `--frozen-lockfile`; main binds 1.0.1 and drops it) and an unmet peer gets no nested copy (main adds `strict-peer-dep/no-deps` = 1.1.0).
  - activepieces (workspace manifests regenerated from the lockfile): with this build `bun install --lockfile-only` keeps the four entries above; the only remaining diff is the `dockerode` cluster, held solely by an optional peer of `sandbox-agent`, which is a separate case.
  - Suites run with this build: bun-lock (49), pnpm-lock-v9 (83), and with the same `src/` change before the test additions: isolated-install (66), bun-install-registry (243), the pnpm and npm migration suites (all snapshots unchanged), hoist, bun-workspaces, catalogs, overrides, nested-overrides, frozen-lockfile-*, lockfile-only, lockfile-version-2, bun-lockb, migrate-bun-lockb-v2, isolated-relink, config-version, test-dev-peer-dependency-priority, yarn-lock-migration, bun-add, bun-remove, bun-update, bun-update-transitive, bun-prune, bun-pm-why, bun-dedupe. The only failures were 5-second per-test timeouts under the debug build when many files ran at once (pnpm-migration-complete, yarn-cli-repo, a few nested-overrides and bun-prune cases); each passes run on its own with unchanged snapshots.
  - `cargo clippy` on the crate passes; the first revision's `for` scan tripped `manual_find`, which is why the scan is written as `find`.

### Background
- `bun.lock` stores packages keyed by their path in a hoisted `node_modules` layout (`"a"`, `"a/b"`) and has no field for what an edge resolved to. On load a regular edge is bound by probing `<dependent path>/<name>` and then each enclosing path up to the root.
- A peer edge is satisfied by whatever is installed next to or above the dependent. When the version hoisted above satisfies the range, `Tree::hoist_dependency` dedupes the edge onto it and prints nothing for the edge, which is why #32182 binds such edges by version on load (the path walk would rebind them to the hoisted copy while the writer had bound the highest satisfying version, re-keying isolated store entries, which are named `name@version+<hash of peer bindings>`). When the version above is out of range and not a root dependency, the hoister places the edge's own target in the dependent's node instead, which is what produces a `<dependent>/<peer>` entry.
- When no version in the tree satisfies a peer, the resolver binds the edge to the highest version present at that moment and warns `incorrect peer dependency`. A required peer edge keeps its target alive through the clean, so a version nothing else depends on can stay in the file next to its dependent for as long as the edge points at it; the shapes in the tests are what such a file looks like after the dependency that originally brought that version in has left the project.
- Two rules the trade-off bullets lean on: `Tree::hoist_dependency` dedupes a peer onto a copy held as a direct dependency of the root even when it is out of range, and the isolated linker resolves a peer by walking the dependent's ancestors for a regular dependency of that name, taking the first one regardless of range; the edge's own binding only matters to either linker when no such copy is above the dependent. A package that is nested (because the root holds another version of it) under two parents is printed once per parent, and the loader binds its edges once per printed row.

<details>
<summary>Earlier revision of this PR</summary>

The first revision kept the fallback and instead made the three loader loops bind any peer edge to the entry printed in its dependent's own node before running the scan, which also covered entries holding an in-range version lower than one elsewhere in the file. Review pointed out that #38767 rebinds every edge through the helper inside the hoister, so a loader-only rule is overridden during the same load, and that the field case (and every shape with a printed record) goes through the helper's nothing-satisfies fallback, which all callers share. This revision fixes that fallback instead; the in-range case is left to the hoister-side binding #38767 is establishing.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-lock.test.ts

<!-- robobun:evidence:end -->
