### PR TITLE
install: say --ignore-scripts also skips trusted dependencies' scripts in --help

### DIFF
--- a/completions/bun-cli.json
+++ b/completions/bun-cli.json
@@ -373,7 +373,7 @@
         },
         {
           "name": "ignore-scripts",
-          "description": "Skip lifecycle scripts in the project's package.json (dependency scripts are never run)",
+          "description": "Skip lifecycle scripts for all packages, including the project's package.json and trusted dependencies",
           "hasValue": false,
           "required": false,
           "multiple": false
@@ -694,7 +694,7 @@
         },
         {
           "name": "ignore-scripts",
-          "description": "Skip lifecycle scripts in the project's package.json (dependency scripts are never run)",
+          "description": "Skip lifecycle scripts for all packages, including the project's package.json and trusted dependencies",
           "hasValue": false,
           "required": false,
           "multiple": false
@@ -1025,7 +1025,7 @@
         },
         {
           "name": "ignore-scripts",
-          "description": "Skip lifecycle scripts in the project's package.json (dependency scripts are never run)",
+          "description": "Skip lifecycle scripts for all packages, including the project's package.json and trusted dependencies",
           "hasValue": false,
           "required": false,
           "multiple": false
@@ -1296,7 +1296,7 @@
         },
         {
           "name": "ignore-scripts",
-          "description": "Skip lifecycle scripts in the project's package.json (dependency scripts are never run)",
+          "description": "Skip lifecycle scripts for all packages, including the project's package.json and trusted dependencies",
           "hasValue": false,
           "required": false,
           "multiple": false
@@ -1714,7 +1714,7 @@
         },
         {
           "name": "ignore-scripts",
-          "description": "Skip lifecycle scripts in the project's package.json (dependency scripts are never run)",
+          "description": "Skip lifecycle scripts for all packages, including the project's package.json and trusted dependencies",
           "hasValue": false,
           "required": false,
           "multiple": false
@@ -2095,7 +2095,7 @@
         },
         {
           "name": "ignore-scripts",
-          "description": "Skip lifecycle scripts in the project's package.json (dependency scripts are never run)",
+          "description": "Skip lifecycle scripts for all packages, including the project's package.json and trusted dependencies",
           "hasValue": false,
           "required": false,
           "multiple": false
@@ -2378,7 +2378,7 @@
         },
         {
           "name": "ignore-scripts",
-          "description": "Skip lifecycle scripts in the project's package.json (dependency scripts are never run)",
+          "description": "Skip lifecycle scripts for all packages, including the project's package.json and trusted dependencies",
           "hasValue": false,
           "required": false,
           "multiple": false
@@ -2637,7 +2637,7 @@
         },
         {
           "name": "ignore-scripts",
-          "description": "Skip lifecycle scripts in the project's package.json (dependency scripts are never run)",
+          "description": "Skip lifecycle scripts for all packages, including the project's package.json and trusted dependencies",
           "hasValue": false,
           "required": false,
           "multiple": false
@@ -2889,7 +2889,7 @@
         },
         {
           "name": "ignore-scripts",
-          "description": "Skip lifecycle scripts in the project's package.json (dependency scripts are never run)",
+          "description": "Skip lifecycle scripts for all packages, including the project's package.json and trusted dependencies",
           "hasValue": false,
           "required": false,
           "multiple": false
@@ -3194,7 +3194,7 @@
         },
         {
           "name": "ignore-scripts",
-          "description": "Skip lifecycle scripts in the project's package.json (dependency scripts are never run)",
+          "description": "Skip lifecycle scripts for all packages, including the project's package.json and trusted dependencies",
           "hasValue": false,
           "required": false,
           "multiple": false
@@ -3623,7 +3623,7 @@
         },
         {
           "name": "ignore-scripts",
-          "description": "Skip lifecycle scripts in the project's package.json (dependency scripts are never run)",
+          "description": "Skip lifecycle scripts for all packages, including the project's package.json and trusted dependencies",
           "hasValue": false,
           "required": false,
           "multiple": false

--- a/completions/bun.zsh
+++ b/completions/bun.zsh
@@ -23,7 +23,7 @@ _bun_add_completion() {
         '--no-progress[Disable the progress bar]' \
         '--no-summary[Don'"'"'t print a summary]' \
         '--no-verify[Skip verifying integrity of newly downloaded packages]' \
-        '--ignore-scripts[Skip lifecycle scripts in the package.json (dependency scripts are never run)]' \
+        '--ignore-scripts[Skip lifecycle scripts for all packages, including the project'"'"'s package.json and trusted dependencies]' \
         '--global[Add a package globally]' \
         '-g[Add a package globally]' \
         '--cwd[Set a specific cwd]:cwd' \
@@ -77,7 +77,7 @@ _bun_unlink_completion() {
         '--no-progress[Disable the progress bar]' \
         '--no-summary[Don'"'"'t print a summary]' \
         '--no-verify[Skip verifying integrity of newly downloaded packages]' \
-        '--ignore-scripts[Skip lifecycle scripts in the package.json (dependency scripts are never run)]' \
+        '--ignore-scripts[Skip lifecycle scripts for all packages, including the project'"'"'s package.json and trusted dependencies]' \
         '--global[Add a package globally]' \
         '-g[Add a package globally]' \
         '--cwd[Set a specific cwd]:cwd' \
@@ -121,7 +121,7 @@ _bun_link_completion() {
         '--no-progress[Disable the progress bar]' \
         '--no-summary[Don'"'"'t print a summary]' \
         '--no-verify[Skip verifying integrity of newly downloaded packages]' \
-        '--ignore-scripts[Skip lifecycle scripts in the package.json (dependency scripts are never run)]' \
+        '--ignore-scripts[Skip lifecycle scripts for all packages, including the project'"'"'s package.json and trusted dependencies]' \
         '--global[Add a package globally]' \
         '-g[Add a package globally]' \
         '--cwd[Set a specific cwd]:cwd' \
@@ -387,7 +387,7 @@ _bun_install_completion() {
         '--no-progress[Disable the progress bar]' \
         '--no-summary[Don'"'"'t print a summary]' \
         '--no-verify[Skip verifying integrity of newly downloaded packages]' \
-        '--ignore-scripts[Skip lifecycle scripts in the package.json (dependency scripts are never run)]' \
+        '--ignore-scripts[Skip lifecycle scripts for all packages, including the project'"'"'s package.json and trusted dependencies]' \
         '--global[Add a package globally]' \
         '-g[Add a package globally]' \
         '--cwd[Set a specific cwd]:cwd' \
@@ -437,7 +437,7 @@ _bun_remove_completion() {
         '--no-progress[Disable the progress bar]' \
         '--no-summary[Don'"'"'t print a summary]' \
         '--no-verify[Skip verifying integrity of newly downloaded packages]' \
-        '--ignore-scripts[Skip lifecycle scripts in the package.json (dependency scripts are never run)]' \
+        '--ignore-scripts[Skip lifecycle scripts for all packages, including the project'"'"'s package.json and trusted dependencies]' \
         '--global[Add a package globally]' \
         '-g[Add a package globally]' \
         '--cwd[Set a specific cwd]:cwd' \
@@ -656,7 +656,7 @@ _bun_update_completion() {
         '--no-progress[Disable the progress bar]' \
         '--no-summary[Don'"'"'t print a summary]' \
         '--no-verify[Skip verifying integrity of newly downloaded packages]' \
-        '--ignore-scripts[Skip lifecycle scripts in the package.json (dependency scripts are never run)]' \
+        '--ignore-scripts[Skip lifecycle scripts for all packages, including the project'"'"'s package.json and trusted dependencies]' \
         '-g[Add a package globally]' \
         '--global[Add a package globally]' \
         '--cwd[Set a specific cwd]:cwd' \
@@ -713,7 +713,7 @@ _bun_dedupe_completion() {
         '--no-progress[Disable the progress bar]' \
         '--no-summary[Don'"'"'t print a summary]' \
         '--no-verify[Skip verifying integrity of newly downloaded packages]' \
-        '--ignore-scripts[Skip lifecycle scripts in the package.json (dependency scripts are never run)]' \
+        '--ignore-scripts[Skip lifecycle scripts for all packages, including the project'"'"'s package.json and trusted dependencies]' \
         '--cwd[Set a specific cwd]:cwd' \
         '--backend[Platform-specific optimizations for installing dependencies]:backend:("copyfile" "hardlink" "symlink")' \
         '--linker[Linker strategy]:linker:(isolated hoisted)' \

--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -89,7 +89,7 @@ const SHARED_TAIL_PARAMS: &[ParamType] = &[
         "--no-verify                           Skip verifying integrity of newly downloaded packages"
     ),
     clap::param!(
-        "--ignore-scripts                      Skip lifecycle scripts in the project's package.json (dependency scripts are never run)"
+        "--ignore-scripts                      Skip lifecycle scripts for all packages, including the project's package.json and trusted dependencies"
     ),
     clap::param!(
         "--trust                               Add to trustedDependencies in the project's package.json and install the package(s)"

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -754,13 +754,14 @@ test.concurrent.each([
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   const entry = stdout.split(/\r?\n/).find(line => line.includes("--ignore-scripts"));
   expect(entry).toBeDefined();
   expect(entry).toContain("trusted dependencies");
   // The wording from before trustedDependencies existed.
   expect(entry).not.toContain("dependency scripts are never run");
+  expect(stderr).toBe("");
   expect(exitCode).toBe(0);
 });
 

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -732,6 +732,38 @@ test.concurrent(
   },
 );
 
+// Every subcommand below prints the flag table shared by the install family. The behavior the
+// entry describes is covered by "ignore-scripts is read from npmrc" (above) and "--ignore-scripts
+// should skip lifecycle scripts" (below): both install a trustedDependencies package.
+test.concurrent.each([
+  "install",
+  "add",
+  "update",
+  "remove",
+  "link",
+  "unlink",
+  "patch",
+  "patch-commit",
+  "outdated",
+  "publish",
+  "info",
+])("bun %s --help says --ignore-scripts also skips the scripts of trusted dependencies", async subcommand => {
+  await using proc = spawn({
+    cmd: [bunExe(), subcommand, "--help"],
+    env: baseEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  const entry = stdout.split(/\r?\n/).find(line => line.includes("--ignore-scripts"));
+  expect(entry).toBeDefined();
+  expect(entry).toContain("trusted dependencies");
+  // The wording from before trustedDependencies existed.
+  expect(entry).not.toContain("dependency scripts are never run");
+  expect(exitCode).toBe(0);
+});
+
 // waiter thread is only a thing on Linux.
 for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
   describe.concurrent("lifecycle scripts" + (forceWaiterThread ? " (waiter thread)" : ""), async () => {


### PR DESCRIPTION
### Problem
- `bun install --help` (and `add`, `update`, `remove`, `link`, `unlink`, `patch`, `patch-commit`, `outdated`, `publish`, `info`, which print the same flag table) describes `--ignore-scripts` as `Skip lifecycle scripts in the project's package.json (dependency scripts are never run)`.
- The parenthetical is wrong: packages listed in `trustedDependencies`, or on the default trusted list, do run their lifecycle scripts during `bun install`, and `--ignore-scripts` is what turns those off as well. It dates from 2022 (2094667417), before `trustedDependencies` existed (#3288).
- The flag and `install.ignoreScripts` both clear `Do::RUN_SCRIPTS` (`src/install/PackageManager/PackageManagerOptions.rs:769` and `:554`), and that one bit gates the root scripts (`install_with_manager.rs:994`) and the per-package scripts in both linkers (`PackageInstaller.rs:2470`, `isolated_install/Installer.rs:1590`, `:1885`).
- The same sentence is repeated in `completions/bun-cli.json` (11 copies, generated from `--help`) and, in a shorter form, in `completions/bun.zsh` (7 copies, compiled into the binary for `bun completions`).

### Fix
- The shared entry in `src/install/PackageManager/CommandLineArguments.rs` now reads `Skip lifecycle scripts for all packages, including the project's package.json and trusted dependencies`, which is what `docs/pm/lifecycle.mdx` and the `install.ignoreScripts` entry in `docs/runtime/bunfig.mdx` already say.
- `completions/bun-cli.json` gets the identical sentence for all 11 entries (checked against what `misctools/generate-cli-completions.ts` extracts from the new `--help` line), and `completions/bun.zsh` gets it for its 7 entries. No behavior change.
- The per-command docs flag tables (`docs/snippets/cli/*.mdx`) carry the same stale sentence; they are being updated in a separate docs change.
- Test: `test/cli/install/bun-install-lifecycle-scripts.test.ts` spawns `--help` for each of the 11 subcommands and checks the `--ignore-scripts` entry mentions trusted dependencies and no longer says dependency scripts are never run. All 11 fail on the released binary and pass with this change. The behavior the entry now describes is already covered in the same file: `ignore-scripts is read from npmrc` (a trusted dependency's script runs without the setting and is skipped with it) and `--ignore-scripts should skip lifecycle scripts` (the flag, against a `trustedDependencies` package); both still pass.

### Background
- Lifecycle scripts: `preinstall` / `install` / `postinstall` / `prepare` commands in a package.json. bun runs the root project's by default, and a dependency's only if it is trusted.
- Trusted dependencies: the packages named in the root package.json's `trustedDependencies` array, or, when that field is absent, the built-in list in `src/install/default-trusted-dependencies.txt`. Untrusted dependencies' scripts are blocked and reported at the end of the install.
- `SHARED_TAIL_PARAMS` in `CommandLineArguments.rs` is one flag table concatenated into every install-family subcommand's parameter list, so each of those subcommands' `--help` prints this same entry once.
- `completions/bun-cli.json` is produced by running every subcommand's `--help` through `misctools/generate-cli-completions.ts` and storing each flag's description verbatim; it is checked in, so a help-text change is mirrored there by hand (as #38759 does for `--network-concurrency`). `completions/bun.zsh` is hand-written and embedded in the binary via `include_bytes!` in `src/runtime/cli/shell_completions.rs`.
