### PR TITLE
ci: run the darwin previous-tier test lane on main and opt-in only, like the other darwin lanes

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -186,10 +186,13 @@ const testPlatforms = [
   // The darwin test suite runs on real macOS agents against the Linux-built
   // artifacts from the `darwin-<arch>-build-bun` steps (the only darwin build
   // lanes — see buildPlatforms).
-  // The `latest` lane only has two agents behind it right now (the Studios
-  // came back on macOS 15 and can only host 15 guests), so until they are on
-  // 26 it runs on main and on opt-in (see darwinLatestLaneEnabled), not on
-  // every PR push.
+  // All three darwin lanes run on main, on manual builds and on opt-in (see
+  // darwinTestLanesEnabled), not on every PR push. The fleet cannot keep up
+  // with PR volume: `latest` is the two bare macOS 26 minis (the Studios came
+  // back on macOS 15 and can only host 15 guests), and `previous` is six tart
+  // guests on three Studios, ~26 jobs an hour against the ~60 an hour that PR
+  // builds generate, so it ran 3-6 hours behind and expired unrun on most PRs.
+  // Put a lane back on PRs once it can absorb that rate.
   { os: "darwin", arch: "aarch64", release: "26", tier: "latest" },
   { os: "darwin", arch: "aarch64", release: "14", tier: "previous" },
   { os: "darwin", arch: "x64", release: "14", tier: "latest" },
@@ -1544,12 +1547,13 @@ async function getPipeline(options = {}) {
 
   // Tests run on main too so the canary release step below can gate on them.
   // ASAN is PR-only (see includeASAN above), so the asan test lane is dropped
-  // on main along with its build.
-  const darwinLatestLaneEnabled =
+  // on main along with its build. The darwin lanes are the other way around:
+  // main, manual builds and `[macos tests]` commits only (see testPlatforms).
+  const darwinTestLanesEnabled =
     isMainBranch() || isBuildManual() || /\[(macos|darwin) tests?\]/i.test(getCommitMessage());
   const relevantTestPlatforms = (
     includeASAN ? testPlatforms : testPlatforms.filter(({ profile }) => profile !== "asan")
-  ).filter(({ os, tier }) => os !== "darwin" || tier !== "latest" || darwinLatestLaneEnabled);
+  ).filter(({ os }) => os !== "darwin" || darwinTestLanesEnabled);
   /** @type {string[]} */
   const testStepKeys = [];
   {


### PR DESCRIPTION
### Problem
- `:darwin: 14 aarch64 - test-bun` (the `release-tier=previous` lane, the only darwin test lane PR builds still run after #37980 and #38293) is hours behind on PR builds. Of the 1200 builds created between 2026-08-14 16:00Z and 2026-08-15 05:30Z (96218 to 97412), 416 were not canceled and reached the lane: 104 got a result, 135 had both shards expire (117 of those builds are red with every other job green), 175 were still queued. PR shards that did run waited a median of 199 min (p90 278, max 315); main's waited 8 min (`getPriority()` gives main 2 and PRs 0, so PRs absorb the whole shortfall).
- Capacity: six agents serve the lane (`darwin-arm64-{ciabatta,focaccia,sourdough}-tart-15-{1,2}`), a shard takes 15 min (median of 191 passed), and the lane started 25 to 28 jobs an hour all night. Demand: about 30 non-canceled builds an hour reach the lane, 2 shards each, about 60 jobs an hour.
- Not caused by the fourth tart host dropping out: on 2026-08-13 06:00Z to 10:00Z all eight agents (`challah` included) were serving and PR shards still waited a median of 377 min.
- Every expiry fails the build, and something retries the expired shards within a second of the hourly expiry sweep, so an affected build goes red once an hour until the lane reaches it. Build 96929 (created 00:18Z) had both shards expire at 02:05Z, 03:05Z and 05:05Z; the fourth attempt ran at 05:32Z and passed, 5.5 hours after the build was created. Every retry in those chains is `retry_type: manual`; the `automatic` rules in `getRetry()` are not involved.
- Cause: `getPipeline()` in `.buildkite/ci.mjs` only gates the `latest` tier (`darwinLatestLaneEnabled`, lines 1548 to 1552 on main), so the `previous` lane is still generated on every PR push.

### Fix
- The existing gate now covers every darwin test lane: `darwinTestLanesEnabled` (main, manual builds, or `[macos tests]` / `[darwin tests]` in the commit subject, the same condition as before) and `.filter(({ os }) => os !== "darwin" || darwinTestLanesEnabled)`. `tier` no longer takes part in the gate; it still selects the agents for the aarch64 lanes in `getTestAgent()`. The comment on `testPlatforms` records the numbers and the condition for putting a lane back on PRs.
- Why this is the right call today: the lane gives PR builds a result on about 1 in 4 of the builds that reach it and a false red on most of the rest, so PRs lose very little signal; main keeps all three darwin lanes and the canary release still waits on them (`testStepKeys`); a PR that needs darwin coverage gets all three lanes with `[macos tests]`; and it is the treatment #37980 gave the 26 lane and #38293 gave x64 for the same reason. Main demand is small (45 main builds in the window; 36 were canceled by the next push to main before the lane ran, 6 ran it), so once the 175 queued builds drain, main and opt-in shards are served within minutes.
- Verified by generating the pipeline with `node .buildkite/ci.mjs` in three throwaway checkouts (a plain branch, a branch whose commit subject has `[macos tests]`, and `main`) before and after the change: the `main` and opt-in outputs are byte for byte identical; the plain branch output only loses the `darwin-aarch64-14` test group (two shards, 42 lines) and keeps both `darwin-*-build-bun` steps. Prettier is clean.

### Background
- `release-tier` is a tag the darwin agents put on themselves from the macOS major version they run (`scripts/agent.mjs` on bare boxes, `scripts/darwin-ci/lib/config.ts` on tart hosts, where it is the guest image's version): `latest` is 26, `previous` is 14 and 15. A test step's `agents` rules must all match for an agent to take the job, so the `previous` lane can only run on the tart guests.
- A tart host runs each job in a fresh macOS VM; Virtualization.framework allows two guests per host (`spawn: 2` in `config.ts`), so the lane's capacity is two agents per host and nothing in this repo can raise it.
- `expired` is the state Buildkite gives a job that no agent accepted within the configured window (an hourly sweep here); it fails the build like a red job. Retrying it creates a new job that keeps the build's place in the queue, which is why the same build fails again an hour later.
- `getTestBunStep()` gives darwin `parallelism: 2`, so each build that reaches the lane needs two agent slots.

<details>
<summary>How the numbers were gathered</summary>

Buildkite REST API, read only: `GET /v2/organizations/bun/pipelines/bun/builds?per_page=100&page=1..12` for the 1200-build window, and the same endpoint with `created_from` / `created_to` for the 2026-08-13 and 2026-08-14 06:00Z to 10:00Z comparisons. For each build, the jobs named `:darwin: 14 aarch64 - test-bun` were classified by state (both shards canceled; both `waiting_failed` because a build step failed; finished; expired; still scheduled or running), queue wait is `started_at - scheduled_at`, and agent names come from the job's `agent` field. The retry chain for build 96929 is from `GET .../builds/96929?include_retried_jobs=true`. Other lanes expired in the window too, but only in a single burst: builds created 20:19Z to 21:03Z on 2026-08-14 had every `build-bun` job expire, and nothing after that; the darwin lane is the only one expiring continuously.
</details>
