### PR TITLE
fix(test): no panic on over-long positional arguments in bun test

### DIFF
--- a/src/runtime/cli/test/Scanner.rs
+++ b/src/runtime/cli/test/Scanner.rs
@@ -7,7 +7,7 @@ use bun_bundler::options::BundleOptions;
 use bun_core::ZStr;
 use bun_core::{StringOrTinyString, strings};
 use bun_output::{declare_scope, scoped_log};
-use bun_paths::resolve_path::{join_abs_string_buf, platform};
+use bun_paths::resolve_path::{join_abs_string_buf_checked, platform};
 use bun_paths::{self, PathBuffer};
 use bun_ptr::Interned;
 use bun_resolver::fs::{self as fs, DirEntryIterator, EntriesOption, FileSystem};
@@ -117,8 +117,8 @@ impl<'a> Scanner<'a> {
         top_level_dir: &'static [u8],
         parts: &[&[u8]],
         buf: &'b mut [u8],
-    ) -> &'b [u8] {
-        join_abs_string_buf::<platform::Loose>(top_level_dir, buf, parts)
+    ) -> Option<&'b [u8]> {
+        join_abs_string_buf_checked::<platform::Loose>(top_level_dir, buf, parts)
     }
 
     /// Take the list of test files out of this scanner. Caller owns the returned
@@ -130,7 +130,12 @@ impl<'a> Scanner<'a> {
     pub(crate) fn scan(&mut self, path_literal: &[u8]) -> Result<(), ScanError> {
         let mut scan_dir_buf = PathBuffer::uninit();
         let parts: [&[u8]; 2] = [self.top_level_dir(), path_literal];
-        let path: &[u8] = Self::abs_buf_projected(self.top_level_dir(), &parts, &mut scan_dir_buf);
+        // `path_literal` is user-controlled and may exceed the fixed-size
+        // buffer; treat an over-long path as a filter that matches nothing
+        // instead of panicking (issues/35728).
+        let Some(path): Option<&[u8]> = Self::abs_buf_projected(self.top_level_dir(), &parts, &mut scan_dir_buf) else {
+            return Err(ScanError::DoesNotExist);
+        };
 
         let root = self
             .read_dir_with_name(path, None)
@@ -385,7 +390,7 @@ impl<'a> Scanner<'a> {
                         &parts,
                         &mut self.open_dir_buf,
                     )
-                    .len();
+                    .map_or(0, |p| p.len());
                     let dir_path = &self.open_dir_buf[..dir_path_len];
                     if self.matches_path_ignore_pattern(dir_path) {
                         return;
@@ -417,9 +422,14 @@ impl<'a> Scanner<'a> {
                 // reshaped for borrowck — drop the &mut borrow from
                 // abs_buf and reborrow open_dir_buf immutably so &self methods
                 // below can be called with the slice.
-                let path_len =
-                    Self::abs_buf_projected(self.top_level_dir(), &parts, &mut self.open_dir_buf)
-                        .len();
+                let Some(path_len) = Self::abs_buf_projected(
+                    self.top_level_dir(),
+                    &parts,
+                    &mut self.open_dir_buf,
+                )
+                .map(|p| p.len()) else {
+                    return;
+                };
                 let path = &self.open_dir_buf[..path_len];
 
                 if !self.does_absolute_path_match_filter(path) {

--- a/test/cli/test/overlong-positional-arg.test.ts
+++ b/test/cli/test/overlong-positional-arg.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+describe("over-long positional argument", () => {
+  // https://github.com/oven-sh/bun/issues/35728 — a single positional argument
+  // of >= 997 bytes used to panic ("range end index ... out of range for slice
+  // of length 1023") because the scanner wrote it into a fixed 1024-byte path
+  // buffer without a bounds check.
+  test("bun test with a 997+ byte positional exits cleanly, no panic", () => {
+    using dir = tempDir("overlong-arg", {
+      "a.test.ts": `
+import { test, expect } from "bun:test";
+test("passes", () => {
+  expect(1).toBe(1);
+});
+`,
+    });
+
+    const longPath = "./x" + "a".repeat(986) + ".test.ts";
+    expect(longPath.length).toBe(997);
+
+    const result = Bun.spawnSync([bunExe(), "test", longPath], {
+      cwd: dir,
+      env: bunEnv,
+      stdio: [null, "pipe", "pipe"],
+    });
+
+    const stderr = result.stderr.toString("utf-8");
+    expect(stderr).not.toContain("panic");
+    expect(stderr).not.toContain("out of range for slice");
+    // Over-long positional behaves like a non-existent path: reports no matches.
+    expect(stderr).toContain("no matches");
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  test("bun test with a 1200-byte positional also exits cleanly", () => {
+    using dir = tempDir("overlong-arg-2", {
+      "a.test.ts": `
+import { test, expect } from "bun:test";
+test("passes", () => {
+  expect(1).toBe(1);
+});
+`,
+    });
+
+    const longPath = "./x" + "a".repeat(1189) + ".test.ts";
+    expect(longPath.length).toBe(1200);
+
+    const result = Bun.spawnSync([bunExe(), "test", longPath], {
+      cwd: dir,
+      env: bunEnv,
+      stdio: [null, "pipe", "pipe"],
+    });
+
+    const stderr = result.stderr.toString("utf-8");
+    expect(stderr).not.toContain("panic");
+    expect(stderr).not.toContain("out of range for slice");
+  });
+});


### PR DESCRIPTION
Fixes #35728

\un test ./x…(997+ bytes).test.ts\ panicked with \ange end index 1024 out of range for slice of length 1023\: \Scanner::scan\ joined cwd + the user-controlled positional into a fixed 1024-byte \PathBuffer\ via the unchecked \join_abs_string_buf\.

- \bs_buf_projected\ now uses \join_abs_string_buf_checked\, which heap-allocates for oversized input and reports when the normalized result cannot fit.
- An over-long positional is reported as a filter that matches nothing (\ScanError::DoesNotExist\) — the same behavior as a short non-existent path — instead of panicking.
- Directory- and file-iteration sites skip entries whose path cannot fit.

Regression tests added for 997- and 1200-byte positionals (both previously panicked).