### PR TITLE
valkey: exclude every subscription command from auto-pipelining

### DIFF
--- a/docs/runtime/redis.mdx
+++ b/docs/runtime/redis.mdx
@@ -367,8 +367,10 @@ The following commands disable automatic pipelining:
 - `PIPELINE`
 - `SUBSCRIBE`
 - `PSUBSCRIBE`
+- `SSUBSCRIBE`
 - `UNSUBSCRIBE`
-- `UNPSUBSCRIBE`
+- `PUNSUBSCRIBE`
+- `SUNSUBSCRIBE`
 
 ---
 

--- a/src/runtime/valkey_jsc/ValkeyCommand.rs
+++ b/src/runtime/valkey_jsc/ValkeyCommand.rs
@@ -150,7 +150,9 @@ impl Default for Meta {
 }
 
 bun_core::comptime_string_set! {
-    /// Commands that must not be auto-pipelined.
+    /// Commands that must not be auto-pipelined. Subscription commands are
+    /// not listed here: `Meta::check` excludes everything
+    /// `is_subscription_command` matches.
     static AUTO_PIPELINE_DISALLOWED_COMMANDS = {
         b"AUTH",
         b"EXEC",
@@ -164,10 +166,6 @@ bun_core::comptime_string_set! {
         b"DISCARD",
         b"UNWATCH",
         b"PIPELINE",
-        b"SUBSCRIBE",
-        b"PSUBSCRIBE",
-        b"UNSUBSCRIBE",
-        b"UNPSUBSCRIBE",
     };
 }
 
@@ -180,6 +178,9 @@ impl Meta {
         );
         if is_subscription_command(command.command) {
             new.insert(Meta::SUBSCRIPTION_REQUEST);
+        }
+        if new.contains(Meta::SUBSCRIPTION_REQUEST) {
+            new.remove(Meta::SUPPORTS_AUTO_PIPELINING);
         }
         new
     }

--- a/test/js/valkey/valkey-auto-pipelining.test.ts
+++ b/test/js/valkey/valkey-auto-pipelining.test.ts
@@ -1,0 +1,139 @@
+import { RedisClient, type TCPSocketListener } from "bun";
+import { describe, expect, test } from "bun:test";
+
+const CRLF = "\r\n";
+const bulk = (s: string) => `$${Buffer.byteLength(s)}${CRLF}${s}${CRLF}`;
+// Minimal RESP3 HELLO reply so the client enters the Connected state.
+const HELLO = `%1${CRLF}${bulk("proto")}:3${CRLF}`;
+
+const SUBSCRIPTION_COMMANDS = [
+  "SUBSCRIBE",
+  "PSUBSCRIBE",
+  "SSUBSCRIBE",
+  "UNSUBSCRIBE",
+  "PUNSUBSCRIBE",
+  "SUNSUBSCRIBE",
+] as const;
+
+/** Split `buf` into the complete `*N\r\n($len\r\n...\r\n){N}` command frames it holds. */
+function parseFrames(buf: Buffer): { frames: string[][]; rest: Buffer } {
+  const frames: string[][] = [];
+  for (;;) {
+    if (buf.length === 0 || buf[0] !== 0x2a /* '*' */) break;
+    const headerEnd = buf.indexOf(CRLF);
+    if (headerEnd < 0) break;
+    const argc = parseInt(buf.subarray(1, headerEnd).toString("latin1"), 10);
+    let pos = headerEnd + 2;
+    const fields: string[] = [];
+    for (let i = 0; i < argc; i++) {
+      const lenEnd = buf.indexOf(CRLF, pos);
+      if (lenEnd < 0 || buf[pos] !== 0x24 /* '$' */) return { frames, rest: buf };
+      const len = parseInt(buf.subarray(pos + 1, lenEnd).toString("latin1"), 10);
+      const next = lenEnd + 2 + len + 2;
+      if (next > buf.length) return { frames, rest: buf };
+      fields.push(buf.subarray(lenEnd + 2, lenEnd + 2 + len).toString("latin1"));
+      pos = next;
+    }
+    frames.push(fields);
+    buf = buf.subarray(pos);
+  }
+  return { frames, rest: buf };
+}
+
+function reply([command, target = ""]: string[]): string {
+  const upper = command.toUpperCase();
+  if (upper === "HELLO") return HELLO;
+  if (upper === "PING") return `+PONG${CRLF}`;
+  if ((SUBSCRIPTION_COMMANDS as readonly string[]).includes(upper)) {
+    // Servers confirm each (un)subscribe with a push frame named after the
+    // command: >3 <command> <channel or pattern> <subscription count>.
+    const count = upper.includes("UNSUBSCRIBE") ? 0 : 1;
+    return `>3${CRLF}${bulk(command.toLowerCase())}${bulk(target)}:${count}${CRLF}`;
+  }
+  return `+OK${CRLF}`;
+}
+
+/**
+ * Mock server that logs the order in which commands arrive (`> CMD`) and
+ * replies go out (`< CMD`). Every complete frame in a socket read is logged
+ * before any of them is answered, so two commands the client flushed as one
+ * batch show up as `> A`, `> B`, `< A`, `< B`, while a command the client held
+ * back until A's reply arrived shows up as `> A`, `< A`, `> B`, `< B`.
+ */
+function listen(log: string[]): TCPSocketListener<Buffer> {
+  return Bun.listen<Buffer>({
+    hostname: "127.0.0.1",
+    port: 0,
+    socket: {
+      open(socket) {
+        socket.data = Buffer.alloc(0);
+      },
+      error() {},
+      close() {},
+      data(socket, chunk) {
+        const { frames, rest } = parseFrames(Buffer.concat([socket.data, chunk]));
+        socket.data = rest;
+        for (const frame of frames) log.push(`> ${frame[0]}`);
+        for (const frame of frames) {
+          socket.write(reply(frame));
+          log.push(`< ${frame[0]}`);
+        }
+      },
+    },
+  });
+}
+
+/**
+ * Connects a client, puts it in subscriber mode (the state an unsubscribe is
+ * normally issued from), then issues a pipelinable PING and `issue` in the
+ * same tick. Returns the server's log for those two commands and whatever
+ * `issue` resolved with.
+ */
+async function issueBehindPing(issue: (client: RedisClient) => Promise<unknown>) {
+  const log: string[] = [];
+  const server = listen(log);
+  const client = new RedisClient(`redis://127.0.0.1:${server.port}`, { autoReconnect: false });
+  client.onconnect = client.onclose = () => {};
+  try {
+    await client.connect();
+    expect(await client.psubscribe("setup.*")).toEqual({ type: "psubscribe", data: ["setup.*", 1] });
+    expect(log).toEqual(["> HELLO", "< HELLO", "> PSUBSCRIBE", "< PSUBSCRIBE"]);
+    log.length = 0;
+
+    const [pong, acked] = await Promise.all([client.send("PING", []), issue(client)]);
+    expect(pong).toBe("PONG");
+    return { log, acked };
+  } finally {
+    client.close();
+    server.stop(true);
+  }
+}
+
+describe.concurrent("RedisClient auto-pipelining", () => {
+  test("pipelinable commands issued in the same tick are flushed as one batch", async () => {
+    const { log, acked } = await issueBehindPing(client => client.send("PING", []));
+    expect(log).toEqual(["> PING", "> PING", "< PING", "< PING"]);
+    expect(acked).toBe("PONG");
+  });
+
+  test("punsubscribe() is held back until the commands ahead of it are answered", async () => {
+    const { log, acked } = await issueBehindPing(client => client.punsubscribe("news.*"));
+    expect(log).toEqual(["> PING", "< PING", "> PUNSUBSCRIBE", "< PUNSUBSCRIBE"]);
+    expect(acked).toEqual({ type: "punsubscribe", data: ["news.*", 0] });
+  });
+
+  test("psubscribe() is held back until the commands ahead of it are answered", async () => {
+    const { log, acked } = await issueBehindPing(client => client.psubscribe("news.*"));
+    expect(log).toEqual(["> PING", "< PING", "> PSUBSCRIBE", "< PSUBSCRIBE"]);
+    expect(acked).toEqual({ type: "psubscribe", data: ["news.*", 1] });
+  });
+
+  // send() forwards the command name as spelled by the caller, and the server
+  // accepts any casing, so the client has to recognize every spelling.
+  const rawSpellings = SUBSCRIPTION_COMMANDS.flatMap(command => [command, command.toLowerCase()]);
+
+  test.each(rawSpellings)('send("%s") is held back until the commands ahead of it are answered', async command => {
+    const { log } = await issueBehindPing(client => client.send(command, ["target"]));
+    expect(log).toEqual(["> PING", "< PING", `> ${command}`, `< ${command}`]);
+  });
+});


### PR DESCRIPTION
### Problem
- `AUTO_PIPELINE_DISALLOWED_COMMANDS` in `src/runtime/valkey_jsc/ValkeyCommand.rs:170` contained `b"UNPSUBSCRIBE"`, which is not a Redis command. The intended entry is `PUNSUBSCRIBE`; its siblings `SUBSCRIBE`, `PSUBSCRIBE` and `UNSUBSCRIBE` are listed correctly. The typo dates back to the original `Bun.redis` implementation, so the entry never matched anything.
- Effect: `client.punsubscribe(...)` and `client.send("PUNSUBSCRIBE", ...)` kept `SUPPORTS_AUTO_PIPELINING` after `Meta::check` (`ValkeyCommand.rs:177`), so they were written to the socket in the same batch as the pipelined commands issued in the same tick, and were not held back until in-flight commands were answered. Every other subscription command takes the held-back path.
- The same list disagreed with `is_subscription_command()` (`ValkeyCommand.rs:188`) in two more ways: it had no entry for the sharded `SSUBSCRIBE` / `SUNSUBSCRIBE`, and it only matched the uppercase spelling, while `is_subscription_command()` matches all six commands in any casing when it sets `SUBSCRIPTION_REQUEST`. So a raw `send("unsubscribe", ...)` was classified as a subscription request for reply pairing but pipelined like a normal command.
- `docs/runtime/redis.mdx:371` documented the list with the same typo.

### Fix
- `Meta::check` now clears `SUPPORTS_AUTO_PIPELINING` on any command that ends up flagged `SUBSCRIPTION_REQUEST`, and the four subscription entries (including the misspelled one) are removed from `AUTO_PIPELINE_DISALLOWED_COMMANDS`. There is now one classification of subscription commands, `is_subscription_command()`, driving both the reply-pairing flag and the pipelining exclusion, so the two cannot drift apart again.
- Why this is correct: `PUNSUBSCRIBE` was always meant to be excluded (the misspelled entry is that intent), and the fix gives it exactly the code path `UNSUBSCRIBE` and `PSUBSCRIBE` already take. Extending the exclusion to the sharded variants and to other spellings only affects raw `send()` calls that the client already treats as subscription requests; the dedicated methods all send the canonical uppercase names, so `subscribe()`, `unsubscribe()` and `psubscribe()` behave exactly as before. No other command's classification changes.
- Docs: the list in `docs/runtime/redis.mdx` now reads `PUNSUBSCRIBE` and includes `SSUBSCRIBE` / `SUNSUBSCRIBE`.
- Test: `test/js/valkey/valkey-auto-pipelining.test.ts`. A mock RESP3 server logs the order in which commands arrive and replies leave. Each test issues a pipelined `PING` and a subscription command in the same tick and expects `> PING, < PING, > X, < X` (X was held back until the PING was answered); a batched X shows up as `> PING, > X, ...`. Rows: `punsubscribe()`, `psubscribe()`, raw `send()` of all six commands in upper and lower case, plus a control showing two `PING`s do get batched. It needs no docker, unlike the rest of the `test/js/valkey` suite.
  - Released `bun` 1.4.0 and an unfixed debug build: 10 of 15 rows fail (`punsubscribe()`, `PUNSUBSCRIBE`, both sharded commands, all lowercase spellings); the 5 that pass are the control and the commands that were already excluded. 20 reruns give the same 200 failures / 100 passes on both builds.
  - Fixed debug (ASAN) build: 15 of 15 pass, and 300 of 300 with `--rerun-each=20`.
  - Fixed debug build against a real redis-server: the psubscribe / get / publish / punsubscribe flow from `valkey.test.ts`, psubscribe plus punsubscribe in the same tick, pipelined commands queued on both sides of a punsubscribe, and raw lowercase / sharded spellings all resolve with their own replies (output below).
  - `resp-nesting-depth`, `valkey-incremental-scan`, `valkey-gc` and `connection-failures` still pass (31 pass, 13 skipped for docker).
- #32858 corrects the same list entry in passing as part of a much larger reply-pairing rework; this is the focused fix, with the docs line and a test for the scheduling behavior itself.

### Background
- Auto-pipelining: `RedisClient` does not write each command to the socket immediately. A command whose meta has `SUPPORTS_AUTO_PIPELINING` is queued and everything queued is written in one batch at the end of the current tick (`on_auto_flush` in `valkey.rs`). A command without the flag is held until every in-flight command has been answered and is then written on its own (`enqueue` / `drain` / `send_next_command` in `valkey.rs`), and `on_auto_flush` stops a batch at the first such command.
- `Meta::check` (`ValkeyCommand.rs`) computes the final meta for every command right before it is sent, for the dedicated methods and for raw `send()` alike. It is the only consumer of `AUTO_PIPELINE_DISALLOWED_COMMANDS`.
- `SUBSCRIPTION_REQUEST`: subscription commands are answered with RESP3 push frames rather than ordinary replies. This flag tells the response handler (`handle_response` in `valkey.rs`) that the in-flight entry at the head of the queue is waiting for such a push. `is_subscription_command()` was added recently so that raw `send()` of any of the six subscription commands, in any casing, gets the flag; the pipelining list predates it and was not updated.
- The debug-only `assertion failed: self.is_subscriber()` that a second back-to-back `punsubscribe()` trips is pre-existing (it reproduces identically on an unfixed debug build, and release builds are unaffected) and is being fixed separately in #37340; the new test issues one unsubscribe per client, from subscriber mode, so it does not depend on that fix.

<details>
<summary>Real-server probe output (fixed debug build)</summary>

```
1: {"type":"psubscribe","data":["probe-chan-1*",1]} A B
1: publish -> 1
1: ping -> PONG
1: punsubscribe -> {"type":"punsubscribe","data":["probe-chan-1*",1]}
1: ping after -> PONG connected: true
2: {"type":"psubscribe","data":["probe-x.*",1]} {"type":"punsubscribe","data":["probe-x.*",0]}
2: ping after -> PONG
4: ["before",{"type":"punsubscribe","data":["probe-w.*",0]},"after"]
5: psubscribe -> {"type":"psubscribe","data":["probe-v.*",1]}
5: punsubscribe -> {"type":"punsubscribe","data":["probe-v.*",0]}
5: ssubscribe -> {"type":"ssubscribe","data":["probe-shard",1]}
5: sunsubscribe -> {"type":"sunsubscribe","data":["probe-shard",0]}
5: ping after -> PONG
```

Step 1 mirrors "commands issued alongside a multi-pattern psubscribe resolve with their own values" in `valkey.test.ts`. Step 4 is `Promise.all([send("PING",["before"]), punsubscribe(...), send("PING",["after"])])`, i.e. pipelined commands queued on both sides of the now held-back command.

</details>

<details>
<summary>Unfixed failure shape (released bun 1.4.0)</summary>

```
  [
    "> PING",
-   "< PING",
    "> PUNSUBSCRIBE",
+   "< PING",
    "< PUNSUBSCRIBE",
  ]
```

</details>
