### PR TITLE
fix(test): fail the file on unhandled rejections between tests

### DIFF
--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -649,7 +649,25 @@ pub(crate) mod on_unhandled_rejection {
         let exception_list = jsc_vm
             .on_unhandled_rejection_exception_list
             .map(|p| unsafe { &mut *p.as_ptr() });
+
+        // No active test: the rejection escaped every test/hook (e.g. a file's
+        // top-level async IIFE). Report it like an uncaught exception between
+        // tests so the file fails instead of being silently swallowed
+        // (issues/34859).
+        if let Some(runner) = Jest::runner() {
+            runner.unhandled_errors_between_tests += 1;
+            bun_core::pretty_errorln!(
+                "<r>\n<b><d>#<r> <red><b>Unhandled error<r><d> between tests<r>\n<d>-------------------------------<r>\n",
+            );
+            Output::flush();
+        }
+
         jsc_vm.run_error_handler(rejection, exception_list);
+
+        if let Some(runner) = Jest::runner() {
+            bun_core::pretty_error!("<r><d>-------------------------------<r>\n\n");
+            Output::flush();
+        }
     }
 }
 

--- a/test/cli/test/rejections-between-tests.test.ts
+++ b/test/cli/test/rejections-between-tests.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/34859 — an unhandled rejection inside a
+// test file's top-level async IIFE (outside any test()) must fail the file,
+// matching how uncaught exceptions between tests are already reported.
+describe("unhandled rejections between tests", () => {
+  test("file with only a rejecting async IIFE fails", () => {
+    using dir = tempDir("rejecting-iife", {
+      "rejecting.test.ts": `
+(async () => {
+  throw new Error("boom from async IIFE");
+})();
+`,
+      "ok.test.ts": `
+import { test, expect } from "bun:test";
+test("passes", () => {
+  expect(1).toBe(1);
+});
+`,
+    });
+
+    const result = Bun.spawnSync([bunExe(), "test", "rejecting.test.ts"], {
+      cwd: dir,
+      env: bunEnv,
+      stdio: [null, "pipe", "pipe"],
+    });
+
+    const stderr = result.stderr.toString("utf-8");
+    expect(stderr).toContain("boom from async IIFE");
+    expect(stderr).toContain("Unhandled error");
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  test("rejection while a test is running still fails only that test", () => {
+    using dir = tempDir("rejecting-in-test", {
+      "in.test.ts": `
+import { test, expect } from "bun:test";
+test("passes", () => {
+  Promise.reject(new Error("async leak"));
+  expect(1).toBe(1);
+});
+`,
+    });
+
+    const result = Bun.spawnSync([bunExe(), "test", "in.test.ts"], {
+      cwd: dir,
+      env: bunEnv,
+      stdio: [null, "pipe", "pipe"],
+    });
+
+    const stderr = result.stderr.toString("utf-8");
+    expect(stderr).toContain("async leak");
+    expect(result.exitCode).not.toBe(0);
+  });
+});


### PR DESCRIPTION
Fixes #34859

An unhandled rejection that escapes every test/hook (e.g. a plain script file's top-level async IIFE) was silently swallowed by the runner's \on_unhandled_rejection\ fall-through path, and the file passed.

Now, when no test is active, the rejection is reported like an uncaught exception between tests: the error is printed with the \Unhandled error between tests\ header and \unhandled_errors_between_tests\ is incremented, so the file (and the run) fails. Rejections attributed to an active test keep their existing behavior.

Regression tests: a file whose only content is a rejecting async IIFE now fails; a rejection leaked inside a passing test still fails the run.