### PR TITLE
install: re-resolve a peer row instead of binding it to a stale bun.lock leftover

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2458,13 +2458,28 @@ fn get_or_put_resolved_package(
 
                     break 'blk Some(result);
                 }
-                Npm::FindVersionResult::Err(err_type) => match err_type {
-                    Npm::FindVersionError::TooRecent
-                    | Npm::FindVersionError::AllVersionsTooRecent => {
-                        return Err(crate::Error::TooRecentVersion);
+                Npm::FindVersionResult::Err(err_type) => {
+                    // The leftover `existing_peer_target` passed over is all there is.
+                    if install_peer && behavior.is_peer() {
+                        if let Some(id) = highest_peer_candidate(&this.lockfile, name_hash, version)
+                        {
+                            return Ok(Some(bind_existing_peer(
+                                this,
+                                dependency_id,
+                                id,
+                                false,
+                                success_fn,
+                            )));
+                        }
                     }
-                    Npm::FindVersionError::NotFound => None, // Handle below with existing logic
-                },
+                    match err_type {
+                        Npm::FindVersionError::TooRecent
+                        | Npm::FindVersionError::AllVersionsTooRecent => {
+                            return Err(crate::Error::TooRecentVersion);
+                        }
+                        Npm::FindVersionError::NotFound => None, // Handle below with existing logic
+                    }
+                }
             };
 
             let find_result = match find_result_opt {
@@ -2498,22 +2513,9 @@ fn get_or_put_resolved_package(
                         }
                     }
 
-                    if behavior.is_peer() {
-                        // `Ok(None)` in the peer pass makes the caller reload the manifest and retry.
-                        if !install_peer {
-                            return Ok(None);
-                        }
-                        // The leftover `existing_peer_target` passed over is all there is.
-                        if let Some(id) = highest_peer_candidate(&this.lockfile, name_hash, version)
-                        {
-                            return Ok(Some(bind_existing_peer(
-                                this,
-                                dependency_id,
-                                id,
-                                false,
-                                success_fn,
-                            )));
-                        }
+                    // `Ok(None)` in the peer pass makes the caller reload the manifest and retry.
+                    if behavior.is_peer() && !install_peer {
+                        return Ok(None);
                     }
 
                     return match version.tag {

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2282,30 +2282,16 @@ fn get_or_put_resolved_package(
     success_fn: SuccessFn,
 ) -> crate::Result<Option<ResolvedPackageResult>> {
     if install_peer && behavior.is_peer() {
-        if let Some((existing_id, satisfied)) = existing_peer_target(this, name_hash, version) {
-            if !satisfied {
-                let existing_package = this.lockfile.packages.get(existing_id as usize);
-                this.log_mut().add_warning_fmt(
-                    None,
-                    bun_ast::Loc::EMPTY,
-                    format_args!(
-                        "incorrect peer dependency \"{}@{}\"",
-                        existing_package
-                            .name
-                            .fmt(this.lockfile.buffers.string_bytes.as_slice()),
-                        existing_package.resolution.fmt(
-                            this.lockfile.buffers.string_bytes.as_slice(),
-                            bun_fmt::PathSep::Auto
-                        ),
-                    ),
-                );
-            }
-            success_fn(this, dependency_id, existing_id);
-            return Ok(Some(ResolvedPackageResult {
-                // we must fetch it from the packages array again, incase the package array mutates the value in the `successFn`
-                package: *this.lockfile.packages.get(existing_id as usize),
-                ..Default::default()
-            }));
+        if let Some((existing_id, satisfied)) =
+            existing_peer_target(this, name_hash, version, dependency_id)
+        {
+            return Ok(Some(bind_existing_peer(
+                this,
+                dependency_id,
+                existing_id,
+                satisfied,
+                success_fn,
+            )));
         }
     }
 
@@ -2512,9 +2498,23 @@ fn get_or_put_resolved_package(
                         }
                     }
 
-                    // `Ok(None)` in the peer pass makes the caller reload the manifest and retry.
-                    if behavior.is_peer() && !install_peer {
-                        return Ok(None);
+                    if behavior.is_peer() {
+                        // `Ok(None)` in the peer pass makes the caller reload the manifest and retry.
+                        if !install_peer {
+                            return Ok(None);
+                        }
+                        // Nothing published to resolve afresh: the entry that passed over its
+                        // leftover in `existing_peer_target` keeps it, with the warning, as before.
+                        if let Some(id) = highest_peer_candidate(&this.lockfile, name_hash, version)
+                        {
+                            return Ok(Some(bind_existing_peer(
+                                this,
+                                dependency_id,
+                                id,
+                                false,
+                                success_fn,
+                            )));
+                        }
                     }
 
                     return match version.tag {
@@ -2831,47 +2831,99 @@ fn locked_version_in_lockfile<'a>(
 
 /// Phase two of peer resolution: the package a peer row binds to among those of its name already
 /// in the lockfile (`package_index` lists the highest first). The first one the range accepts
-/// wins; failing that the highest candidate is bound anyway when it is of the row's kind, flagged
-/// `false` so the caller warns "incorrect peer dependency". Candidates `is_stale_peer_target`
-/// rejects are left out of that fallback, so a row they no longer satisfy resolves afresh.
+/// wins; failing that the highest one is bound anyway when it is of the row's kind, flagged
+/// `false` so the caller warns "incorrect peer dependency", except when binding it
+/// `would_revive_leftover`, in which case the row resolves afresh (and is bound to it after all,
+/// by the caller, when nothing published matches). Loading bun.lock binds the same way
+/// (`resolve_peer_dep_version_based`), so the fallback has to stay the highest candidate or
+/// nothing: a row that resolved afresh gets saved next to a package its range accepts, which that
+/// loader's satisfies scan finds, whereas a lower candidate bound here would be rebound on load.
 fn existing_peer_target(
     this: &PackageManager,
     name_hash: PackageNameHash,
     version: &dependency::Version,
+    row: DependencyID,
 ) -> Option<(PackageID, bool)> {
     let lockfile: &Lockfile::Lockfile = &this.lockfile;
     let candidates = lockfile.package_index.get(&name_hash)?.as_slice();
     let pkg_res = lockfile.packages.items_resolution();
     let buf = lockfile.buffers.string_bytes.as_slice();
-    let mut in_lockfile = candidates
-        .iter()
-        .copied()
-        .filter(|&id| (id as usize) < pkg_res.len());
-    if let Some(id) = in_lockfile
-        .clone()
-        .find(|&id| pkg_res[id as usize].satisfies_dependency_version(version, buf, buf))
-    {
+    if let Some(&id) = candidates.iter().find(|&&id| {
+        (id as usize) < pkg_res.len()
+            && pkg_res[id as usize].satisfies_dependency_version(version, buf, buf)
+    }) {
         return Some((id, true));
     }
-    let id = in_lockfile.find(|&id| !is_stale_peer_target(lockfile, id))?;
+    let highest = highest_peer_candidate(lockfile, name_hash, version)?;
+    (!would_revive_leftover(lockfile, row, highest)).then_some((highest, false))
+}
+
+/// The package an unsatisfied peer row falls back to: the highest of its name, when it is of the
+/// row's kind.
+fn highest_peer_candidate(
+    lockfile: &Lockfile::Lockfile,
+    name_hash: PackageNameHash,
+    version: &dependency::Version,
+) -> Option<PackageID> {
+    let &highest = lockfile.package_index.get(&name_hash)?.as_slice().first()?;
+    let resolution = lockfile.packages.items_resolution().get(highest as usize)?;
     let same_kind = matches!(
-        (pkg_res[id as usize].tag, version.tag),
+        (resolution.tag, version.tag),
         (ResolutionTag::Npm, dependency::version::Tag::Npm)
             | (ResolutionTag::Git, dependency::version::Tag::Git)
             | (ResolutionTag::Github, dependency::version::Tag::Github)
     );
-    same_kind.then_some((id, false))
+    same_kind.then_some(highest)
 }
 
-/// A package loaded from bun.lock that no non-peer row resolves to any more: it was only ever
-/// installed for peer rows, typically a root or workspace `peerDependencies` entry whose range has
-/// since been rewritten (`bun update -i`, `bun update <name>@<version>`, an edit followed by
-/// `bun install`), so it provides nothing and binding the rewritten row back to it would only
-/// keep the stale version and warn about it. Rows of packages the clean pass is about to drop
-/// still count, which errs toward binding as before; packages appended during this resolve never
-/// qualify, so a fresh install binds exactly as it always did.
-fn is_stale_peer_target(lockfile: &Lockfile::Lockfile, id: PackageID) -> bool {
-    if id >= lockfile.loaded_package_count {
+fn bind_existing_peer(
+    this: &mut PackageManager,
+    dependency_id: DependencyID,
+    existing_id: PackageID,
+    satisfied: bool,
+    success_fn: SuccessFn,
+) -> ResolvedPackageResult {
+    if !satisfied {
+        let existing_package = this.lockfile.packages.get(existing_id as usize);
+        this.log_mut().add_warning_fmt(
+            None,
+            bun_ast::Loc::EMPTY,
+            format_args!(
+                "incorrect peer dependency \"{}@{}\"",
+                existing_package
+                    .name
+                    .fmt(this.lockfile.buffers.string_bytes.as_slice()),
+                existing_package.resolution.fmt(
+                    this.lockfile.buffers.string_bytes.as_slice(),
+                    bun_fmt::PathSep::Auto
+                ),
+            ),
+        );
+    }
+    success_fn(this, dependency_id, existing_id);
+    ResolvedPackageResult {
+        // we must fetch it from the packages array again, incase the package array mutates the value in the `successFn`
+        package: *this.lockfile.packages.get(existing_id as usize),
+        ..Default::default()
+    }
+}
+
+/// `row` is a root or workspace `peerDependencies` entry and `package_id`, loaded from bun.lock,
+/// is resolved to by peer rows only: it was installed for such an entry in the first place, and the
+/// entry's range has since been rewritten past it (`bun update -i`, `bun update <name>@<version>`,
+/// an edit followed by `bun install`), so binding the entry back to it would keep the version the
+/// user moved off and warn about it, where installing what the entry now asks for replaces it in
+/// that workspace's node_modules. A package's own peer rows are left out: they take whatever copy
+/// the tree has, a copy resolved for them alone is never placed, so the warning is the right answer
+/// there. Packages appended during this resolve never qualify, so a fresh install binds exactly as
+/// before, and rows of packages the clean pass is about to drop still count, which can only keep
+/// the old binding.
+fn would_revive_leftover(
+    lockfile: &Lockfile::Lockfile,
+    row: DependencyID,
+    package_id: PackageID,
+) -> bool {
+    if package_id >= lockfile.loaded_package_count || !lockfile.is_workspace_dependency(row) {
         return false;
     }
     let deps = lockfile.buffers.dependencies.as_slice();
@@ -2884,7 +2936,7 @@ fn is_stale_peer_target(lockfile: &Lockfile::Lockfile, id: PackageID) -> bool {
         .flat_map(|(dep_slice, res_slice)| {
             dep_slice.get(deps).iter().zip(res_slice.get(resolutions))
         });
-    !owned_rows.any(|(dep, &resolved)| resolved == id && !dep.behavior.is_peer())
+    !owned_rows.any(|(dep, &resolved)| resolved == package_id && !dep.behavior.is_peer())
 }
 
 fn patched_package_satisfying(

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2828,9 +2828,7 @@ fn locked_version_in_lockfile<'a>(
         .map(|locked| (locked, buf))
 }
 
-/// The package of the row's name to bind a deferred peer row to, and whether it satisfies the row.
-/// Mirrors `resolve_peer_dep_version_based`, which rebinds the row on load: first satisfying
-/// candidate, else the highest one or nothing.
+/// The package to bind a deferred peer row to and whether it satisfies the row; the highest-or-nothing fallback is what `resolve_peer_dep_version_based` rebinds to on load.
 fn existing_peer_target(
     this: &PackageManager,
     name_hash: PackageNameHash,
@@ -2900,10 +2898,7 @@ fn bind_existing_peer(
     }
 }
 
-/// `row` is a root or workspace `peerDependencies` entry whose range was rewritten past
-/// `package_id`, the copy bun.lock only holds for peer rows (typically this entry's own earlier
-/// install); the entry resolves afresh instead. A package's own peer rows never do: a copy resolved
-/// for them alone is not placed in the tree.
+/// `row` is a root or workspace `peerDependencies` entry and `package_id` a copy bun.lock holds for peer rows only (usually this entry's own earlier install); a package's peer rows never qualify, a copy resolved for them alone is not placed.
 fn would_revive_leftover(
     lockfile: &Lockfile::Lockfile,
     row: DependencyID,

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2503,8 +2503,7 @@ fn get_or_put_resolved_package(
                         if !install_peer {
                             return Ok(None);
                         }
-                        // Nothing published to resolve afresh: the entry that passed over its
-                        // leftover in `existing_peer_target` keeps it, with the warning, as before.
+                        // The leftover `existing_peer_target` passed over is all there is.
                         if let Some(id) = highest_peer_candidate(&this.lockfile, name_hash, version)
                         {
                             return Ok(Some(bind_existing_peer(
@@ -2829,15 +2828,9 @@ fn locked_version_in_lockfile<'a>(
         .map(|locked| (locked, buf))
 }
 
-/// Phase two of peer resolution: the package a peer row binds to among those of its name already
-/// in the lockfile (`package_index` lists the highest first). The first one the range accepts
-/// wins; failing that the highest one is bound anyway when it is of the row's kind, flagged
-/// `false` so the caller warns "incorrect peer dependency", except when binding it
-/// `would_revive_leftover`, in which case the row resolves afresh (and is bound to it after all,
-/// by the caller, when nothing published matches). Loading bun.lock binds the same way
-/// (`resolve_peer_dep_version_based`), so the fallback has to stay the highest candidate or
-/// nothing: a row that resolved afresh gets saved next to a package its range accepts, which that
-/// loader's satisfies scan finds, whereas a lower candidate bound here would be rebound on load.
+/// The package of the row's name to bind a deferred peer row to, and whether it satisfies the row.
+/// Mirrors `resolve_peer_dep_version_based`, which rebinds the row on load: first satisfying
+/// candidate, else the highest one or nothing.
 fn existing_peer_target(
     this: &PackageManager,
     name_hash: PackageNameHash,
@@ -2858,8 +2851,7 @@ fn existing_peer_target(
     (!would_revive_leftover(lockfile, row, highest)).then_some((highest, false))
 }
 
-/// The package an unsatisfied peer row falls back to: the highest of its name, when it is of the
-/// row's kind.
+/// `package_index` lists the highest version first.
 fn highest_peer_candidate(
     lockfile: &Lockfile::Lockfile,
     name_hash: PackageNameHash,
@@ -2908,16 +2900,10 @@ fn bind_existing_peer(
     }
 }
 
-/// `row` is a root or workspace `peerDependencies` entry and `package_id`, loaded from bun.lock,
-/// is resolved to by peer rows only: it was installed for such an entry in the first place, and the
-/// entry's range has since been rewritten past it (`bun update -i`, `bun update <name>@<version>`,
-/// an edit followed by `bun install`), so binding the entry back to it would keep the version the
-/// user moved off and warn about it, where installing what the entry now asks for replaces it in
-/// that workspace's node_modules. A package's own peer rows are left out: they take whatever copy
-/// the tree has, a copy resolved for them alone is never placed, so the warning is the right answer
-/// there. Packages appended during this resolve never qualify, so a fresh install binds exactly as
-/// before, and rows of packages the clean pass is about to drop still count, which can only keep
-/// the old binding.
+/// `row` is a root or workspace `peerDependencies` entry whose range was rewritten past
+/// `package_id`, the copy bun.lock only holds for peer rows (typically this entry's own earlier
+/// install); the entry resolves afresh instead. A package's own peer rows never do: a copy resolved
+/// for them alone is not placed in the tree.
 fn would_revive_leftover(
     lockfile: &Lockfile::Lockfile,
     row: DependencyID,

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2282,107 +2282,30 @@ fn get_or_put_resolved_package(
     success_fn: SuccessFn,
 ) -> crate::Result<Option<ResolvedPackageResult>> {
     if install_peer && behavior.is_peer() {
-        if let Some(index) = this.lockfile.package_index.get(&name_hash) {
-            let resolutions = this.lockfile.packages.items_resolution();
-            match index {
-                PackageIndexEntry::Id(existing_id) => {
-                    let existing_id = *existing_id;
-                    if (existing_id as usize) < resolutions.len() {
-                        let existing_resolution = resolutions[existing_id as usize];
-                        if resolution_satisfies_dependency(this, &existing_resolution, version) {
-                            success_fn(this, dependency_id, existing_id);
-                            return Ok(Some(ResolvedPackageResult {
-                                // we must fetch it from the packages array again, incase the package array mutates the value in the `successFn`
-                                package: *this.lockfile.packages.get(existing_id as usize),
-                                ..Default::default()
-                            }));
-                        }
-
-                        let res_tag = resolutions[existing_id as usize].tag;
-                        let ver_tag = version.tag;
-                        if (res_tag == ResolutionTag::Npm
-                            && ver_tag == dependency::version::Tag::Npm)
-                            || (res_tag == ResolutionTag::Git
-                                && ver_tag == dependency::version::Tag::Git)
-                            || (res_tag == ResolutionTag::Github
-                                && ver_tag == dependency::version::Tag::Github)
-                        {
-                            let existing_package = this.lockfile.packages.get(existing_id as usize);
-                            this.log_mut().add_warning_fmt(
-                                None,
-                                bun_ast::Loc::EMPTY,
-                                format_args!(
-                                    "incorrect peer dependency \"{}@{}\"",
-                                    existing_package
-                                        .name
-                                        .fmt(this.lockfile.buffers.string_bytes.as_slice()),
-                                    existing_package.resolution.fmt(
-                                        this.lockfile.buffers.string_bytes.as_slice(),
-                                        bun_fmt::PathSep::Auto
-                                    ),
-                                ),
-                            );
-                            success_fn(this, dependency_id, existing_id);
-                            return Ok(Some(ResolvedPackageResult {
-                                // we must fetch it from the packages array again, incase the package array mutates the value in the `successFn`
-                                package: *this.lockfile.packages.get(existing_id as usize),
-                                ..Default::default()
-                            }));
-                        }
-                    }
-                }
-                PackageIndexEntry::Ids(list) => {
-                    for &existing_id in list.iter() {
-                        if (existing_id as usize) < resolutions.len() {
-                            let existing_resolution = resolutions[existing_id as usize];
-                            if resolution_satisfies_dependency(this, &existing_resolution, version)
-                            {
-                                success_fn(this, dependency_id, existing_id);
-                                return Ok(Some(ResolvedPackageResult {
-                                    package: *this.lockfile.packages.get(existing_id as usize),
-                                    ..Default::default()
-                                }));
-                            }
-                        }
-                    }
-
-                    if (list[0] as usize) < resolutions.len() {
-                        let res_tag = resolutions[list[0] as usize].tag;
-                        let ver_tag = version.tag;
-                        if (res_tag == ResolutionTag::Npm
-                            && ver_tag == dependency::version::Tag::Npm)
-                            || (res_tag == ResolutionTag::Git
-                                && ver_tag == dependency::version::Tag::Git)
-                            || (res_tag == ResolutionTag::Github
-                                && ver_tag == dependency::version::Tag::Github)
-                        {
-                            let existing_package_id = list[0];
-                            let existing_package =
-                                this.lockfile.packages.get(existing_package_id as usize);
-                            this.log_mut().add_warning_fmt(
-                                None,
-                                bun_ast::Loc::EMPTY,
-                                format_args!(
-                                    "incorrect peer dependency \"{}@{}\"",
-                                    existing_package
-                                        .name
-                                        .fmt(this.lockfile.buffers.string_bytes.as_slice()),
-                                    existing_package.resolution.fmt(
-                                        this.lockfile.buffers.string_bytes.as_slice(),
-                                        bun_fmt::PathSep::Auto
-                                    ),
-                                ),
-                            );
-                            success_fn(this, dependency_id, list[0]);
-                            return Ok(Some(ResolvedPackageResult {
-                                // we must fetch it from the packages array again, incase the package array mutates the value in the `successFn`
-                                package: *this.lockfile.packages.get(existing_package_id as usize),
-                                ..Default::default()
-                            }));
-                        }
-                    }
-                }
+        if let Some((existing_id, satisfied)) = existing_peer_target(this, name_hash, version) {
+            if !satisfied {
+                let existing_package = this.lockfile.packages.get(existing_id as usize);
+                this.log_mut().add_warning_fmt(
+                    None,
+                    bun_ast::Loc::EMPTY,
+                    format_args!(
+                        "incorrect peer dependency \"{}@{}\"",
+                        existing_package
+                            .name
+                            .fmt(this.lockfile.buffers.string_bytes.as_slice()),
+                        existing_package.resolution.fmt(
+                            this.lockfile.buffers.string_bytes.as_slice(),
+                            bun_fmt::PathSep::Auto
+                        ),
+                    ),
+                );
             }
+            success_fn(this, dependency_id, existing_id);
+            return Ok(Some(ResolvedPackageResult {
+                // we must fetch it from the packages array again, incase the package array mutates the value in the `successFn`
+                package: *this.lockfile.packages.get(existing_id as usize),
+                ..Default::default()
+            }));
         }
     }
 
@@ -2906,13 +2829,62 @@ fn locked_version_in_lockfile<'a>(
         .map(|locked| (locked, buf))
 }
 
-fn resolution_satisfies_dependency(
+/// Phase two of peer resolution: the package a peer row binds to among those of its name already
+/// in the lockfile (`package_index` lists the highest first). The first one the range accepts
+/// wins; failing that the highest candidate is bound anyway when it is of the row's kind, flagged
+/// `false` so the caller warns "incorrect peer dependency". Candidates `is_stale_peer_target`
+/// rejects are left out of that fallback, so a row they no longer satisfy resolves afresh.
+fn existing_peer_target(
     this: &PackageManager,
-    resolution: &Resolution,
-    dependency: &dependency::Version,
-) -> bool {
-    let buf = this.lockfile.buffers.string_bytes.as_slice();
-    resolution.satisfies_dependency_version(dependency, buf, buf)
+    name_hash: PackageNameHash,
+    version: &dependency::Version,
+) -> Option<(PackageID, bool)> {
+    let lockfile: &Lockfile::Lockfile = &this.lockfile;
+    let candidates = lockfile.package_index.get(&name_hash)?.as_slice();
+    let pkg_res = lockfile.packages.items_resolution();
+    let buf = lockfile.buffers.string_bytes.as_slice();
+    let mut in_lockfile = candidates
+        .iter()
+        .copied()
+        .filter(|&id| (id as usize) < pkg_res.len());
+    if let Some(id) = in_lockfile
+        .clone()
+        .find(|&id| pkg_res[id as usize].satisfies_dependency_version(version, buf, buf))
+    {
+        return Some((id, true));
+    }
+    let id = in_lockfile.find(|&id| !is_stale_peer_target(lockfile, id))?;
+    let same_kind = matches!(
+        (pkg_res[id as usize].tag, version.tag),
+        (ResolutionTag::Npm, dependency::version::Tag::Npm)
+            | (ResolutionTag::Git, dependency::version::Tag::Git)
+            | (ResolutionTag::Github, dependency::version::Tag::Github)
+    );
+    same_kind.then_some((id, false))
+}
+
+/// A package loaded from bun.lock that no non-peer row resolves to any more: it was only ever
+/// installed for peer rows, typically a root or workspace `peerDependencies` entry whose range has
+/// since been rewritten (`bun update -i`, `bun update <name>@<version>`, an edit followed by
+/// `bun install`), so it provides nothing and binding the rewritten row back to it would only
+/// keep the stale version and warn about it. Rows of packages the clean pass is about to drop
+/// still count, which errs toward binding as before; packages appended during this resolve never
+/// qualify, so a fresh install binds exactly as it always did.
+fn is_stale_peer_target(lockfile: &Lockfile::Lockfile, id: PackageID) -> bool {
+    if id >= lockfile.loaded_package_count {
+        return false;
+    }
+    let deps = lockfile.buffers.dependencies.as_slice();
+    let resolutions = lockfile.buffers.resolutions.as_slice();
+    let mut owned_rows = lockfile
+        .packages
+        .items_dependencies()
+        .iter()
+        .zip(lockfile.packages.items_resolutions())
+        .flat_map(|(dep_slice, res_slice)| {
+            dep_slice.get(deps).iter().zip(res_slice.get(resolutions))
+        });
+    !owned_rows.any(|(dep, &resolved)| resolved == id && !dep.behavior.is_peer())
 }
 
 fn patched_package_satisfying(

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2898,7 +2898,7 @@ fn bind_existing_peer(
     }
 }
 
-/// `row` is a root or workspace `peerDependencies` entry and `package_id` a copy bun.lock holds for peer rows only (usually this entry's own earlier install); a package's peer rows never qualify, a copy resolved for them alone is not placed.
+/// `row` is a root or workspace `peerDependencies` entry and `package_id` is held only by non-root peer rows (usually this entry's own earlier install): nothing provides it, and it is not a root row's copy, which `Tree::hoist_dependency` dedupes every other peer onto regardless of range.
 fn would_revive_leftover(
     lockfile: &Lockfile::Lockfile,
     row: DependencyID,
@@ -2914,10 +2914,17 @@ fn would_revive_leftover(
         .items_dependencies()
         .iter()
         .zip(lockfile.packages.items_resolutions())
-        .flat_map(|(dep_slice, res_slice)| {
-            dep_slice.get(deps).iter().zip(res_slice.get(resolutions))
+        .enumerate()
+        .flat_map(|(owner, (dep_slice, res_slice))| {
+            dep_slice
+                .get(deps)
+                .iter()
+                .zip(res_slice.get(resolutions))
+                .map(move |(dep, &resolved)| (owner, dep, resolved))
         });
-    !owned_rows.any(|(dep, &resolved)| resolved == package_id && !dep.behavior.is_peer())
+    !owned_rows.any(|(owner, dep, resolved)| {
+        resolved == package_id && (owner == 0 || !dep.behavior.is_peer())
+    })
 }
 
 fn patched_package_satisfying(

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -3341,12 +3341,10 @@ fn deferred_peer_range<'a>(
 /// `Resolution::order` — and take the first whose resolution satisfies
 /// the range. When nothing satisfies, fall back to the highest-ordered
 /// candidate, and only when it is the same kind as the dependency (the
-/// "incorrect peer dependency" case; reproducing the fresh resolver's
-/// choice exactly is the point of this helper. The one case where its
-/// `existing_peer_target` declines that candidate, a root or workspace
-/// entry that `would_revive_leftover`, makes the edge resolve afresh to a
-/// package its range accepts, which is what gets saved and what the
-/// satisfies scan above finds). Returns `None` when no package with the name exists
+/// "incorrect peer dependency" case; `existing_peer_target` makes the same
+/// choice, and reproducing it exactly is the point of this helper; an edge
+/// it resolved afresh instead was saved with a satisfying package, found
+/// above). Returns `None` when no package with the name exists
 /// or the fallback is a different kind; the caller then falls back to
 /// the path walk. Edges `deferred_peer_range` rejects also return `None`.
 ///

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -3342,11 +3342,11 @@ fn deferred_peer_range<'a>(
 /// the range. When nothing satisfies, fall back to the highest-ordered
 /// candidate, and only when it is the same kind as the dependency (the
 /// "incorrect peer dependency" case; reproducing the fresh resolver's
-/// choice exactly is the point of this helper. Its `existing_peer_target`
-/// additionally passes over packages left in the loaded lockfile that
-/// nothing provides any more, but an edge that took that route resolved
-/// to a package satisfying it, which is what gets saved and what the
-/// satisfies scan here finds). Returns `None` when no package with the name exists
+/// choice exactly is the point of this helper. The one case where its
+/// `existing_peer_target` declines that candidate, a root or workspace
+/// entry that `would_revive_leftover`, makes the edge resolve afresh to a
+/// package its range accepts, which is what gets saved and what the
+/// satisfies scan above finds). Returns `None` when no package with the name exists
 /// or the fallback is a different kind; the caller then falls back to
 /// the path walk. Edges `deferred_peer_range` rejects also return `None`.
 ///

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -3341,9 +3341,12 @@ fn deferred_peer_range<'a>(
 /// `Resolution::order` — and take the first whose resolution satisfies
 /// the range. When nothing satisfies, fall back to the highest-ordered
 /// candidate, and only when it is the same kind as the dependency (the
-/// "incorrect peer dependency" case; the fresh resolver inspects only
-/// `list[0]` there, and reproducing its choice exactly is the point of
-/// this helper). Returns `None` when no package with the name exists
+/// "incorrect peer dependency" case; reproducing the fresh resolver's
+/// choice exactly is the point of this helper. Its `existing_peer_target`
+/// additionally passes over packages left in the loaded lockfile that
+/// nothing provides any more, but an edge that took that route resolved
+/// to a package satisfying it, which is what gets saved and what the
+/// satisfies scan here finds). Returns `None` when no package with the name exists
 /// or the fallback is a different kind; the caller then falls back to
 /// the path walk. Edges `deferred_peer_range` rejects also return `None`.
 ///

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -3341,10 +3341,9 @@ fn deferred_peer_range<'a>(
 /// `Resolution::order` — and take the first whose resolution satisfies
 /// the range. When nothing satisfies, fall back to the highest-ordered
 /// candidate, and only when it is the same kind as the dependency (the
-/// "incorrect peer dependency" case; `existing_peer_target` makes the same
-/// choice, and reproducing it exactly is the point of this helper; an edge
-/// it resolved afresh instead was saved with a satisfying package, found
-/// above). Returns `None` when no package with the name exists
+/// "incorrect peer dependency" case; the fresh resolver inspects only
+/// `list[0]` there, and reproducing its choice exactly is the point of
+/// this helper). Returns `None` when no package with the name exists
 /// or the fallback is a different kind; the caller then falls back to
 /// the path walk. Edges `deferred_peer_range` rejects also return `None`.
 ///

--- a/test/cli/install/bun-update-transitive.test.ts
+++ b/test/cli/install/bun-update-transitive.test.ts
@@ -2166,17 +2166,68 @@ test.concurrent("a peerDependencies entry another group provides keeps following
   await frozen(dir);
 });
 
-// peer-deps-fixed@1.0.0 declares peer `no-deps: ^1.0.0`, strict-peer-dep@1.0.0 declares `no-deps: ^2.0.0`, nothing provides it.
-// Swapping one for the other leaves bun.lock holding the no-deps the old one auto-installed; only that old peer row still points at it.
-test.concurrent("a package's peer entry skips the no-deps its replaced sibling auto-installed", async () => {
-  const dir = await setup({ "package.json": pkgJson({ "peer-deps-fixed": "1.0.0" }) });
-  expect(await lockedVersions(dir, "no-deps")).toStrictEqual(["1.1.0"]);
-  await write(join(dir, "package.json"), stringify(pkgJson({ "strict-peer-dep": "1.0.0" })));
+const PEER_ONLY = (range: string) => ({ name: "foo", peerDependencies: { "no-deps": range } });
+
+// no-deps@1.5.0 was never published (a `bun init` project hits this with `bun add typescript@5.0.0`): with nothing to install
+// instead, the entry keeps the copy it has and warns as it always did, instead of spinning on or dropping the unresolvable row.
+test.concurrent(
+  "`bun add <name>@<unpublished version>` on a peerDependencies entry keeps the installed copy",
+  async () => {
+    const dir = await setup({ "package.json": PEER_ONLY("^1.0.0") });
+    expect(await lockedVersions(dir, "no-deps")).toStrictEqual(["1.1.0"]);
+    const { stderr, exitCode } = await run(dir, "add", "no-deps@1.5.0");
+    expect(stderr).toContain('warn: incorrect peer dependency "no-deps@1.1.0"');
+    expect(stderr).not.toContain("error:");
+    expect(await packageJsonOf(dir)).toStrictEqual(PEER_ONLY("1.5.0"));
+    expect(await lockedVersions(dir, "no-deps")).toStrictEqual(["1.1.0"]);
+    expect(await installedVersion(dir, "no-deps")).toBe("1.1.0");
+    await frozen(dir);
+    expect(exitCode).toBe(0);
+  },
+);
+
+// The root's peer entry alone holds no-deps@1.1.0 at the top of node_modules; one-fixed-dep@1.0.0 then nests the no-deps@1.0.0
+// it depends on, so bun.lock carries two copies, the higher of which nothing depends on outright.
+const rootPeer = (range: string, dependencies: Json) =>
+  pkgJson(dependencies, { peerDependencies: { "no-deps": range } });
+
+async function twoCopies() {
+  const dir = await setup({ "package.json": rootPeer("^1.0.0", {}) });
+  await reinstall(dir, rootPeer("^1.0.0", { "one-fixed-dep": "1.0.0" }));
+  expect(await lockedVersions(dir, "no-deps")).toStrictEqual(["1.0.0", "1.1.0"]);
+  expect(await installedVersion(dir, "no-deps")).toBe("1.1.0");
+  expect(await installedVersion(dir, "one-fixed-dep", "node_modules", "no-deps")).toBe("1.0.0");
+  return dir;
+}
+
+// Rewritten past both copies, the entry takes neither: the one that would be bound, the highest, is the one it installed
+// itself, and the provided 1.0.0 is a binding loading bun.lock (which binds the highest copy too) would not reproduce.
+test.concurrent(
+  "a rewritten peerDependencies entry replaces the copy it installed rather than binding a lower one",
+  async () => {
+    const dir = await twoCopies();
+    await write(join(dir, "package.json"), stringify(rootPeer("^2.0.0", { "one-fixed-dep": "1.0.0" })));
+    const stderr = await install(dir);
+    expectCleanStderr(stderr);
+    expect(await lockedVersions(dir, "no-deps")).toStrictEqual(["1.0.0", "2.0.0"]);
+    expect(await installedVersion(dir, "no-deps")).toBe("2.0.0");
+    expect(await installedVersion(dir, "one-fixed-dep", "node_modules", "no-deps")).toBe("1.0.0");
+    await frozen(dir);
+  },
+);
+
+// strict-peer-dep@1.0.0's own peer `no-deps: ^2.0.0` accepts neither copy either, but a package's peer rows take whatever
+// copy the tree has (a copy resolved for them alone would never be placed), so it binds the highest one and warns as before.
+test.concurrent("a package's own peer entry still binds to the highest copy in bun.lock and warns", async () => {
+  const dir = await twoCopies();
+  await write(
+    join(dir, "package.json"),
+    stringify(rootPeer("^1.0.0", { "one-fixed-dep": "1.0.0", "strict-peer-dep": "1.0.0" })),
+  );
   const stderr = await install(dir);
-  expectCleanStderr(stderr);
-  expect(await lockedVersions(dir, "no-deps")).toStrictEqual(["2.0.0"]);
-  expect(await lockedVersions(dir, "peer-deps-fixed")).toStrictEqual([]);
-  expect(await installedVersion(dir, "no-deps")).toBe("2.0.0");
+  expect(stderr).toContain('warn: incorrect peer dependency "no-deps@1.1.0"');
+  expect(await lockedVersions(dir, "no-deps")).toStrictEqual(["1.0.0", "1.1.0"]);
+  expect(await installedVersion(dir, "no-deps")).toBe("1.1.0");
   await frozen(dir);
 });
 
@@ -2477,8 +2528,6 @@ test.concurrent("`bun update -i` installs the Target version a peerDependencies 
 });
 
 // With 1.1.0 locked, the row's Target equals Current, so selecting it takes the Latest column.
-const PEER_ONLY = (range: string) => ({ name: "foo", peerDependencies: { "no-deps": range } });
-
 test.concurrent("`bun update -i` installs the Latest version a peerDependencies row shows", async () => {
   const dir = await setup({ "package.json": PEER_ONLY("^1.0.0") });
   expect(await lockedVersions(dir, "no-deps")).toStrictEqual(["1.1.0"]);

--- a/test/cli/install/bun-update-transitive.test.ts
+++ b/test/cli/install/bun-update-transitive.test.ts
@@ -2083,7 +2083,7 @@ async function stalePeerEntry() {
   return dir;
 }
 
-// A root peerDependencies entry is never re-resolved by `bun update`; a pattern still counts it as a match, a group selector does not.
+// A root peerDependencies entry whose locked version still satisfies it is never re-resolved by `bun update`; a pattern still counts it as a match, a group selector does not.
 test.concurrent("a pattern matches a peerDependencies entry", async () => {
   const dir = await stalePeerEntry();
   const packageJsonBefore = await packageJsonText(dir);
@@ -2117,6 +2117,83 @@ test.concurrent("`bun update --dev` with only a stale peerDependencies entry has
   const packageJsonBefore = await packageJsonText(dir);
   await expectNothingToUpdate(dir, noneSelected(2, "selected by --dev"), "--dev");
   expect(await packageJsonText(dir)).toBe(packageJsonBefore);
+});
+
+// Once its range stops accepting the locked version, a peer entry nothing else depends on resolves afresh. The locked
+// package used to be bound anyway (it has the entry's name) with an "incorrect peer dependency" warning, and the named
+// path then wrote the range back down to it.
+test.concurrent("`bun update <name>@<version>` moves a peerDependencies entry nothing else depends on", async () => {
+  const dir = await stalePeerEntry();
+  const { stdout, stderr, exitCode } = await run(dir, "update", "no-deps@2.0.0");
+  expectMoved(stdout, "no-deps", "1.0.0", "2.0.0");
+  expectCleanStderr(stderr);
+  expect(await packageJsonOf(dir)).toStrictEqual(withPeer("^1.0.1", "^2.0.0"));
+  expect((await lock(dir)).workspaces[""].peerDependencies).toStrictEqual({ "no-deps": "^2.0.0" });
+  expect(await lockedVersions(dir, "no-deps")).toStrictEqual(["2.0.0"]);
+  expect(await lockedVersions(dir, "a-dep")).toStrictEqual(["1.0.1"]);
+  expect(await installedVersion(dir, "no-deps")).toBe("2.0.0");
+  await frozen(dir);
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent(
+  "`bun install` moves a peerDependencies entry nothing else depends on once its range is edited",
+  async () => {
+    const dir = await stalePeerEntry();
+    await write(join(dir, "package.json"), stringify(withPeer("^1.0.1", "^1.1.0")));
+    const stderr = await install(dir);
+    expectCleanStderr(stderr);
+    expect(await lockedVersions(dir, "no-deps")).toStrictEqual(["1.1.0"]);
+    expect(await installedVersion(dir, "no-deps")).toBe("1.1.0");
+    await frozen(dir);
+  },
+);
+
+// devDependencies provides no-deps@1.1.0, so the peer entry keeps pointing at it and the warning is the right answer.
+test.concurrent("a peerDependencies entry another group provides keeps following that group", async () => {
+  const provided = (peerRange: string) => ({
+    name: "foo",
+    devDependencies: { "no-deps": "^1.0.0" },
+    peerDependencies: { "no-deps": peerRange },
+  });
+  const dir = await setup({ "package.json": provided("^1.0.0") });
+  expect(await lockedVersions(dir, "no-deps")).toStrictEqual(["1.1.0"]);
+  await write(join(dir, "package.json"), stringify(provided("^2.0.0")));
+  const stderr = await install(dir);
+  expect(stderr).toContain('warn: incorrect peer dependency "no-deps@1.1.0"');
+  expect(await lockedVersions(dir, "no-deps")).toStrictEqual(["1.1.0"]);
+  expect(await installedVersion(dir, "no-deps")).toBe("1.1.0");
+  await frozen(dir);
+});
+
+// peer-deps-fixed@1.0.0 declares peer `no-deps: ^1.0.0`, strict-peer-dep@1.0.0 declares `no-deps: ^2.0.0`, nothing provides it.
+// Swapping one for the other leaves bun.lock holding the no-deps the old one auto-installed; only that old peer row still points at it.
+test.concurrent("a package's peer entry skips the no-deps its replaced sibling auto-installed", async () => {
+  const dir = await setup({ "package.json": pkgJson({ "peer-deps-fixed": "1.0.0" }) });
+  expect(await lockedVersions(dir, "no-deps")).toStrictEqual(["1.1.0"]);
+  await write(join(dir, "package.json"), stringify(pkgJson({ "strict-peer-dep": "1.0.0" })));
+  const stderr = await install(dir);
+  expectCleanStderr(stderr);
+  expect(await lockedVersions(dir, "no-deps")).toStrictEqual(["2.0.0"]);
+  expect(await lockedVersions(dir, "peer-deps-fixed")).toStrictEqual([]);
+  expect(await installedVersion(dir, "no-deps")).toBe("2.0.0");
+  await frozen(dir);
+});
+
+// Without a lockfile the no-deps the first peer row installs is all the second one can bind to; that still dedupes onto it
+// and warns. Which row goes first follows the order the two manifests arrive in, so only the single copy is pinned down.
+test.concurrent("on a fresh install two peer entries nothing provides still share one no-deps", async () => {
+  const { packageDir: dir } = await registry.createTestDir({
+    bunfigOpts: { saveTextLockfile: true, linker: "hoisted" },
+    files: { "package.json": stringify(pkgJson({ "peer-deps-fixed": "1.0.0", "strict-peer-dep": "1.0.0" })) },
+  });
+  const stderr = await install(dir, ...linkerArgs({}));
+  const [version] = await lockedVersions(dir, "no-deps");
+  expect(["1.1.0", "2.0.0"]).toContain(version);
+  expect(stderr).toContain(`warn: incorrect peer dependency "no-deps@${version}"`);
+  expect(await lockedVersions(dir, "no-deps")).toStrictEqual([version]);
+  expect(await installedVersion(dir, "no-deps")).toBe(version);
+  await frozen(dir);
 });
 
 // pkg1 has a stale entry in every group; pkg2 only in dependencies; the root has none.
@@ -2381,6 +2458,51 @@ test.concurrent("`bun update -i --latest` honours an entry toggled back to its i
   expect(await lockedVersions(dir, "no-deps")).toStrictEqual(["2.0.0"]);
   expect(await installedVersion(dir, "dep-with-tags")).toBe("1.0.1");
   expect(await installedVersion(dir, "no-deps")).toBe("2.0.0");
+  await frozen(dir);
+  expect(exitCode).toBe(0);
+});
+
+// Offered as `a-dep` (dependencies), then the `no-deps` peer row showing Current 1.0.0, Target 1.1.0, Latest 2.0.0.
+test.concurrent("`bun update -i` installs the Target version a peerDependencies row shows", async () => {
+  const dir = await stalePeerEntry();
+  const { stderr, exitCode } = await runInteractive(dir, "j \r");
+  expect(stderr).not.toContain("error:");
+  expect(stderr).not.toContain("warn:");
+  expect(await packageJsonOf(dir)).toStrictEqual(withPeer("^1.0.1", "^1.1.0"));
+  expect(await lockedVersions(dir, "no-deps")).toStrictEqual(["1.1.0"]);
+  expect(await lockedVersions(dir, "a-dep")).toStrictEqual(["1.0.1"]);
+  expect(await installedVersion(dir, "no-deps")).toBe("1.1.0");
+  await frozen(dir);
+  expect(exitCode).toBe(0);
+});
+
+// With 1.1.0 locked, the row's Target equals Current, so selecting it takes the Latest column.
+const PEER_ONLY = (range: string) => ({ name: "foo", peerDependencies: { "no-deps": range } });
+
+test.concurrent("`bun update -i` installs the Latest version a peerDependencies row shows", async () => {
+  const dir = await setup({ "package.json": PEER_ONLY("^1.0.0") });
+  expect(await lockedVersions(dir, "no-deps")).toStrictEqual(["1.1.0"]);
+  const { stderr, exitCode } = await runInteractive(dir, " \r");
+  expect(stderr).not.toContain("error:");
+  expect(stderr).not.toContain("warn:");
+  expect(await packageJsonOf(dir)).toStrictEqual(PEER_ONLY("^2.0.0"));
+  expect((await lock(dir)).workspaces[""].peerDependencies).toStrictEqual({ "no-deps": "^2.0.0" });
+  expect(await lockedVersions(dir, "no-deps")).toStrictEqual(["2.0.0"]);
+  expect(await installedVersion(dir, "no-deps")).toBe("2.0.0");
+  await frozen(dir);
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("`bun update -i -r` installs the version a workspace member's peerDependencies row shows", async () => {
+  const pkg1 = (range: string) => ({ name: "pkg1", version: "1.0.0", peerDependencies: { "no-deps": range } });
+  const dir = await setup({ "package.json": ROOT, "packages/pkg1/package.json": pkg1("^1.0.0") });
+  expect(await lockedVersions(dir, "no-deps")).toStrictEqual(["1.1.0"]);
+  const { stderr, exitCode } = await runInteractive(dir, " \r", "-r");
+  expect(stderr).not.toContain("error:");
+  expect(stderr).not.toContain("warn:");
+  expect(await packageJsonOf(dir, "packages/pkg1")).toStrictEqual(pkg1("^2.0.0"));
+  expect((await lock(dir)).workspaces["packages/pkg1"].peerDependencies).toStrictEqual({ "no-deps": "^2.0.0" });
+  expect(await lockedVersions(dir, "no-deps")).toStrictEqual(["2.0.0"]);
   await frozen(dir);
   expect(exitCode).toBe(0);
 });

--- a/test/cli/install/bun-update-transitive.test.ts
+++ b/test/cli/install/bun-update-transitive.test.ts
@@ -2293,6 +2293,19 @@ test.concurrent("rewriting the root's and a member's entries together moves both
   await frozen(dir);
 });
 
+// Rewriting only the root's entry installs what it asks for; the member's unchanged `^1.0.0` is deduped onto the root's copy,
+// the same as when a root dependency moves past it (the tree warns about neither yet, so stderr is not asserted).
+test.concurrent("rewriting only the root's entry installs its copy for the unchanged member too", async () => {
+  const dir = await sharedPeer(peerRoot("^1.0.0"), ["pkg1", "^1.0.0"]);
+  await write(join(dir, "package.json"), stringify(peerRoot("^2.0.0")));
+  const stderr = await install(dir);
+  expect(stderr).not.toContain("error:");
+  expect(await lockedVersions(dir, "no-deps")).toStrictEqual(["2.0.0"]);
+  expect((await lock(dir)).workspaces["packages/pkg1"].peerDependencies).toStrictEqual({ "no-deps": "^1.0.0" });
+  expect(await installedVersion(dir, "no-deps")).toBe("2.0.0");
+  await frozen(dir);
+});
+
 // With no root entry, pkg2's copy is not forced on pkg1: each member ends up with the copy its own entry asks for.
 test.concurrent(
   "a member's rewritten entry gets its own copy next to a sibling's when the root declares nothing",

--- a/test/cli/install/bun-update-transitive.test.ts
+++ b/test/cli/install/bun-update-transitive.test.ts
@@ -2231,6 +2231,61 @@ test.concurrent("a package's own peer entry still binds to the highest copy in b
   await frozen(dir);
 });
 
+// Workspaces declaring the same peer share the one no-deps@1.1.0 the install put at the top of node_modules.
+const peerRoot = (range?: string) => (range ? { ...ROOT, peerDependencies: { "no-deps": range } } : ROOT);
+const peerMember = (name: string, range: string) => ({
+  name,
+  version: "1.0.0",
+  peerDependencies: { "no-deps": range },
+});
+
+async function sharedPeer(root: Json, ...members: [string, string][]) {
+  const files: Record<string, Json> = { "package.json": root };
+  for (const [name, range] of members) files[`packages/${name}/package.json`] = peerMember(name, range);
+  const dir = await setup(files);
+  expect(await lockedVersions(dir, "no-deps")).toStrictEqual(["1.1.0"]);
+  return dir;
+}
+
+// The tree dedupes every other peer onto the root's copy whatever their range says, so a member's copy of its own would
+// never be installed; the member's entry keeps the root's copy and the warning.
+test.concurrent("a member's rewritten entry keeps binding to the copy the root's own entry holds", async () => {
+  const dir = await sharedPeer(peerRoot("^1.0.0"), ["pkg1", "^1.0.0"]);
+  await write(join(dir, "packages/pkg1/package.json"), stringify(peerMember("pkg1", "^2.0.0")));
+  const stderr = await install(dir);
+  expect(stderr).toContain('warn: incorrect peer dependency "no-deps@1.1.0"');
+  expect(await lockedVersions(dir, "no-deps")).toStrictEqual(["1.1.0"]);
+  expect(await installedVersion(dir, "no-deps")).toBe("1.1.0");
+  await frozen(dir);
+});
+
+test.concurrent("rewriting the root's and a member's entries together moves both onto the new copy", async () => {
+  const dir = await sharedPeer(peerRoot("^1.0.0"), ["pkg1", "^1.0.0"]);
+  await write(join(dir, "package.json"), stringify(peerRoot("^2.0.0")));
+  await write(join(dir, "packages/pkg1/package.json"), stringify(peerMember("pkg1", "^2.0.0")));
+  const stderr = await install(dir);
+  expectCleanStderr(stderr);
+  expect(await lockedVersions(dir, "no-deps")).toStrictEqual(["2.0.0"]);
+  expect(await installedVersion(dir, "no-deps")).toBe("2.0.0");
+  await frozen(dir);
+});
+
+// With no root entry, pkg2's copy is not forced on pkg1: each member ends up with the copy its own entry asks for.
+test.concurrent(
+  "a member's rewritten entry gets its own copy next to a sibling's when the root declares nothing",
+  async () => {
+    const dir = await sharedPeer(peerRoot(), ["pkg1", "^1.0.0"], ["pkg2", "^1.0.0"]);
+    await write(join(dir, "packages/pkg1/package.json"), stringify(peerMember("pkg1", "^2.0.0")));
+    const stderr = await install(dir);
+    expectCleanStderr(stderr);
+    expect(await lockedVersions(dir, "no-deps")).toStrictEqual(["1.1.0", "2.0.0"]);
+    const { workspaces } = await lock(dir);
+    expect(workspaces["packages/pkg1"].peerDependencies).toStrictEqual({ "no-deps": "^2.0.0" });
+    expect(workspaces["packages/pkg2"].peerDependencies).toStrictEqual({ "no-deps": "^1.0.0" });
+    await frozen(dir);
+  },
+);
+
 // Without a lockfile the no-deps the first peer row installs is all the second one can bind to; that still dedupes onto it
 // and warns. Which row goes first follows the order the two manifests arrive in, so only the single copy is pinned down.
 test.concurrent("on a fresh install two peer entries nothing provides still share one no-deps", async () => {

--- a/test/cli/install/bun-update-transitive.test.ts
+++ b/test/cli/install/bun-update-transitive.test.ts
@@ -2186,6 +2186,29 @@ test.concurrent(
   },
 );
 
+// Same when the only release the new range accepts is still inside --minimum-release-age.
+test.concurrent(
+  "a peerDependencies entry whose new range only matches a too recent release keeps the installed copy",
+  async () => {
+    using server = await serveRegistry(
+      { leaf: { "1.0.0": {}, "2.0.0": {} } },
+      {},
+      { times: { leaf: { "1.0.0": daysAgo(30), "2.0.0": daysAgo(1) } } },
+    );
+    const entry = (range: string) => ({ name: "foo", peerDependencies: { leaf: range } });
+    const dir = await installServed(server, "peer-entry-min-age-", entry("^1.0.0"));
+    expect(await lockedVersions(dir, "leaf")).toStrictEqual(["1.0.0"]);
+    await write(join(dir, "package.json"), stringify(entry("^2.0.0")));
+    const { stderr, exitCode } = await run(dir, "install", "--minimum-release-age", THREE_DAYS_SECONDS);
+    expect(stderr).toContain('warn: incorrect peer dependency "leaf@1.0.0"');
+    expect(stderr).not.toContain("error:");
+    expect(await lockedVersions(dir, "leaf")).toStrictEqual(["1.0.0"]);
+    expect(await installedVersion(dir, "leaf")).toBe("1.0.0");
+    await frozen(dir);
+    expect(exitCode).toBe(0);
+  },
+);
+
 // The root's peer entry alone holds no-deps@1.1.0 at the top of node_modules; one-fixed-dep@1.0.0 then nests the no-deps@1.0.0
 // it depends on, so bun.lock carries two copies, the higher of which nothing depends on outright.
 const rootPeer = (range: string, dependencies: Json) =>


### PR DESCRIPTION
### Problem

- `bun update -i` offers a root `peerDependencies` row (`peer-q peer 1.1.0 1.1.0 2.0.0`, the Latest column is what selecting it promises). Enter then prints `warn: incorrect peer dependency "peer-q@1.1.0"`, summarises `(no changes)`, leaves bun.lock and node_modules on 1.1.0, and rewrites package.json from `^1.0.0` to `^1.1.0`. Same for a workspace row under `-i -r`, and for the in-range case (locked 1.0.0, Target 1.1.0: nothing moves, the warning prints, the range is written back as it was).
- Not specific to `-i`: `bun update peer-q@2.0.0` on the same tree warns and writes `^1.1.0`, `bun add peer-q@2.0.0` warns and keeps 1.1.0 (#30855's report), and editing the range to `^2.0.0` by hand and running `bun install` keeps 1.1.0 and warns. `--latest` works only because it writes a dist-tag literal, which the fallback below never matches.
- Cause: `get_or_put_resolved_package` (`src/install/PackageManager/PackageManagerEnqueue.rs`, the `install_peer` branch). In the deferred peer pass a peer row binds to a package of its name already in the lockfile; when none satisfies the range it binds to the highest one anyway and warns. With an existing bun.lock that candidate is the package this same entry installed last time: nothing else depends on it, it is only still there because `clean` has not run yet. `-i` writes the range into package.json and runs `bun update <name>`, the differ re-enqueues the row, the pass binds it back to the leftover, and the named path's write-back then rewrites the range to the version it ended up on.

### Fix

- `existing_peer_target` replaces the `Id`/`Ids` arms (same satisfies scan, same highest-candidate fallback, same kind check; the warning and binding move into `bind_existing_peer`, shared with the site below). The fallback is skipped when `would_revive_leftover`: the row is a root or workspace entry (`Lockfile::is_workspace_dependency`, already used by this function for `file:` rows), the candidate was loaded from bun.lock (`id < loaded_package_count`), and the only rows still resolving to it are peer rows of workspace members or of dependencies. The row then resolves from the manifest like a peer nothing provides, the new package takes the entry's place in its node_modules, and `clean` drops the leftover.
- What still blocks it, and why: a non-peer row resolving to the candidate means it is provided (a `devDependencies` entry next to the peer entry, a dependency's own copy), so the entry binds to it and warns as before. Any row of the root package.json, peer included, also blocks it: `Tree::hoist_dependency` dedupes every other peer row onto the root's copy whatever their ranges say, so a member entry that resolved its own copy would only have it dropped when the tree is written, and the warning with it (that is what the first revision did; "a member's rewritten entry keeps binding to the copy the root's own entry holds" pins it). Packages appended during the current resolve never qualify, so a fresh install binds exactly as before. Root rows are drained before member rows, so when root and member entries are rewritten together the root's new copy is there for the member to bind to.
- A dependency's own peer rows are out of scope on purpose: they take whatever copy the tree offers them, and changing that is a separate decision from making a declared entry mean what it says. They behave exactly as on main (pinned with the two-copy setup below).
- The fallback stays "the highest candidate or nothing" rather than moving down to a lower candidate, because the bun.lock loader binds an unsatisfied peer row to the highest copy too (`resolve_peer_dep_version_based`); a row that resolved afresh is saved next to a package that satisfies it. (Raised in review; the first revision picked the first non-leftover candidate.) The remaining way resolver and loader can disagree, an entry that nothing satisfies whose copy is outranked by another copy in the file, exists on main independently of this change (it is reached today by a regular dependency pulling in a higher copy) and is what #38892 fixes in the loader.
- When the entry passed over its leftover but the manifest has nothing for the new range, because no published version matches it or (raised in review) because the only matching releases are inside `--minimum-release-age`, the `FindVersionResult::Err` arm in the peer pass binds the leftover after all, so both shapes keep behaving exactly as on main: `warn: incorrect peer dependency`, old copy kept. The first of them is what the Windows lanes of `test/cli/install/bunx.test.ts` exercise: `bun init` installs the root peer `typescript@^6`, then the test runs `bun add typescript@5.0.0`, a version that was never published (5.0 shipped as 5.0.2); without the binding the first revision spun forever on a warm manifest cache (the loop #38851 has since fixed on main for the case with no copy at all; rebased onto it), and the age-gated shape turned the warning into an error. Every row that reaches that arm with this change also reached it on main.
- `resolution_satisfies_dependency` had no other caller and is deleted.
- Unchanged on purpose: `bun update <name>` / bare `bun update` on an entry whose locked version still satisfies it (the satisfies scan binds it first; the "never re-resolved" tests in `bun-update-transitive.test.ts` still pass), and `-i` on a peer row whose sibling `devDependencies` row is left unselected.
- #30855 fixes the `bun add` instance by skipping the fallback for every row whose name is an update request, tree-wide: after `bun add react@18`, each package with an older react peer range would resolve its own react instead of binding to the root's and warning. The checks here leave those bound.
- Tests, all in `test/cli/install/bun-update-transitive.test.ts`. Fail on main, pass here: `-i` Target row, `-i` Latest row, `-i -r` member row, `update <name>@<version>`, `install` after an edit, the two-copy case (entry rewritten past both its own 1.1.0 and a dependency's 1.0.0 resolves 2.0.0 instead of binding 1.0.0), root and member entries rewritten together, only the root's entry rewritten (its copy is installed and the unchanged member is deduped onto it, as for a dependency bump; the tree's missing warning there is a pre-existing TODO, filed separately, so that test does not assert on stderr), and a member entry rewritten next to a sibling's when the root declares nothing (each member gets its copy). Pass on both and pin what stays: an entry another group provides, a member entry under a root entry (binds the root's copy and warns), a dependency's own peer row with the two copies (binds the highest and warns), `bun add <name>@<unpublished version>` (keeps the copy and warns; times out without the rebinding), the same entry under `--minimum-release-age` (keeps the copy and warns; errors without it), two unprovided peers on a fresh install. Also run locally: `bun-update-transitive`, `bun-lock` (with #38851's cases), `bun-update-lockfile-sync`, `bun-update`/`bun-add`, `bun-install-registry -t peer`, `bun-install`, `isolated-install`/`bun-workspaces`/`frozen-lockfile-pruned`, `bun-audit`/`nested-overrides`/`hoist`/`bun-dedupe`/`bun-prune`/`isolated-relink`/`test-dev-peer-dependency-priority`, `catalogs`/`bun-add-filter`/`update_interactive_*`, `migration/`; the only failures need public network access or were 5s timeouts on a heavily loaded machine that pass alone. On Windows against registry.npmjs.org: `bun init` + `bun add typescript@5.0.0` warns and keeps 6.0.3 in under a second, `bun add typescript@5.0.4` installs 5.0.4, and the bunx test passes.

### Background

- A package.json dependency is a row (`buffers.dependencies[i]`) owned by a package; `buffers.resolutions[i]` is the package it resolves to; the root package.json is package 0. `package_index` maps a name to every package of that name in the lockfile, highest version first. On an install with an existing bun.lock all of the old packages stay in the lockfile while rows are re-resolved; `Lockfile::clean` rebuilds it from the root at the end and drops whatever nothing reaches. `loaded_package_count` is how many packages came from bun.lock; packages resolved during the run are appended after them.
- Peers resolve in two passes: while regular rows resolve, peer rows are parked in `peer_dependencies`; `wait_for_resolution` then drains them with `install_peer = true`, which is the branch changed here. A peer nothing in the tree provides is installed from the registry at that point; root and workspace peer entries are installed this way too, which is how the leftover got there.
- Writing bun.lock and node_modules goes through the hoisted tree: the root's rows are placed at the top, a workspace's rows are hoisted there or placed in the workspace's own node_modules, and a peer row whose package conflicts with what is already at a level is deduped onto it when that copy satisfies the row, or unconditionally when the root's own row put it there.
- `bun update -i` applies a selection by writing the chosen ranges into package.json and then running `bun update <selected names>`; that path re-resolves the named rows and writes each one's resolved version back into its range, which is where the `^1.1.0` came from.

<details>
<summary>Probes on main (loopback registry with peer-q 1.0.0 / 1.1.0 / 2.0.0)</summary>

```
# package.json: {"dependencies":{"b":"^1.0.0"},"peerDependencies":{"peer-q":"^1.0.0"}}, bun install -> peer-q@1.1.0

$ printf ' \r' | bun update -i
  peerDependencies 1 Current  Target  Latest
  > [x] peer-q peer  1.1.0    1.1.0   2.0.0
warn: incorrect peer dependency "peer-q@1.1.0"
Checked 2 installs across 3 packages (no changes)
# package.json now "peer-q": "^1.1.0", bun.lock still peer-q@1.1.0

$ bun update peer-q@2.0.0
warn: incorrect peer dependency "peer-q@1.1.0"
# package.json now "peer-q": "^1.1.0", bun.lock still peer-q@1.1.0

$ sed -i 's/\^1.0.0"}}/^2.0.0"}}/' package.json && bun install
warn: incorrect peer dependency "peer-q@1.1.0"
# bun.lock still peer-q@1.1.0

$ bun update peer-q --latest
^ peer-q 1.1.0 -> 2.0.0
```

With the fix the first three print `^ peer-q 1.1.0 -> 2.0.0` (install: `+ peer-q@2.0.0`), write `^2.0.0`, lock 2.0.0, and `bun install --frozen-lockfile` afterwards reports no changes. With a dev row on the same name, selecting both rows in `-i` still moves both to `^2.0.0`, selecting the dev row alone still leaves the peer entry untouched, and selecting the peer row alone still warns and keeps 1.1.0, all as on main.
</details>