### PR TITLE
bake: require app.plugins and framework.plugins to be arrays

### DIFF
--- a/src/runtime/bake/bake_body.rs
+++ b/src/runtime/bake/bake_body.rs
@@ -244,7 +244,7 @@ impl UserOptions {
             }
         };
 
-        if let Some(plugin_array) = config.get(global, "plugins")? {
+        if let Some(plugin_array) = get_optional_value(config, global, b"plugins")? {
             bundler_options.parse_plugin_array(plugin_array, global)?;
         }
 
@@ -312,6 +312,10 @@ impl SplitBundlerOptions {
         plugin_array: JSValue,
         global: &JSGlobalObject,
     ) -> JsResult<()> {
+        if !plugin_array.is_array() {
+            return Err(global.throw_invalid_arguments(format_args!("plugins must be an array")));
+        }
+
         // Create the Plugin and assign it to `opts.plugin` BEFORE iterating,
         // so `plugins: []` still leaves `self.plugin = Some(_)`.
         let plugin: NonNull<Plugin> = match self.plugin {

--- a/test/bake/dev/plugins.test.ts
+++ b/test/bake/dev/plugins.test.ts
@@ -193,36 +193,6 @@ test.concurrent("app.plugins and framework.plugins must be arrays", async () => 
   expect(exitCode).toBe(0);
 });
 
-// `bun build --app` reads the same options object and used to build with the
-// invalid value ignored.
-test.concurrent("bun build --app rejects a non-array plugins option", async () => {
-  using dir = tempDir("bake-build-plugins-not-array", {
-    "server.ts": `export function render() { return new Response("unused"); }`,
-    "bun.app.ts": `
-      export default {
-        app: {
-          framework: {
-            fileSystemRouterTypes: [{ root: "routes", style: "nextjs-pages", serverEntryPoint: "./server.ts" }],
-          },
-          plugins: 123,
-        },
-      };
-    `,
-  });
-
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "build", "--app"],
-    env: bunEnv,
-    cwd: String(dir),
-    stdout: "ignore",
-    stderr: "pipe",
-  });
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-
-  expect(stderr).toContain("TypeError: plugins must be an array");
-  expect(exitCode).toBe(1);
-});
-
 // devTest("onLoad with watchFile", {
 //   framework: minimalFramework,
 //   pluginFile: `

--- a/test/bake/dev/plugins.test.ts
+++ b/test/bake/dev/plugins.test.ts
@@ -1,4 +1,6 @@
 // Plugin tests concern plugins in development mode.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { devTest, minimalFramework } from "../bake-harness";
 
 // Note: more in depth testing of plugins is done in test/bundler/bundler_plugin.test.ts
@@ -110,6 +112,117 @@ devTest("onResolve + onLoad virtual file", {
     ]);
   },
 });
+
+// `app.plugins` and `framework.plugins` share one parser. It used to iterate whatever
+// it was handed: a non-array was either accepted and ignored (123, an array-like) or
+// rejected for its first "element" ("abc", a single plugin object passed without the
+// surrounding array).
+test.concurrent("app.plugins and framework.plugins must be arrays", async () => {
+  using dir = tempDir("bake-plugins-not-array", {
+    "server.ts": `export function render() { return new Response("unused"); }`,
+    "check.ts": `
+      const framework = {
+        fileSystemRouterTypes: [{ root: "routes", style: "nextjs-pages", serverEntryPoint: "./server.ts" }],
+      };
+      let setupCalls = 0;
+      const plugin = { name: "counted", setup() { setupCalls++; } };
+      const values = {
+        "string": "abc",
+        "single plugin object": plugin,
+        "number": 123,
+        "array-like": { length: 0 },
+        "array": [plugin],
+        "empty array": [],
+        "null": null,
+      };
+      const sites = {
+        "app.plugins": plugins => ({ framework, plugins }),
+        "framework.plugins": plugins => ({ framework: { ...framework, plugins } }),
+      };
+
+      const results = {};
+      for (const [site, app] of Object.entries(sites)) {
+        for (const [name, plugins] of Object.entries(values)) {
+          try {
+            const server = Bun.serve({
+              port: 0,
+              development: true,
+              app: app(plugins),
+              fetch: () => new Response(""),
+            });
+            server.stop(true);
+            results[site + " = " + name] = "accepted";
+          } catch (e) {
+            results[site + " = " + name] = e.message;
+          }
+        }
+      }
+      results.setupCalls = setupCalls;
+      console.log(JSON.stringify(results));
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "check.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({
+    "app.plugins = string": "plugins must be an array",
+    "app.plugins = single plugin object": "plugins must be an array",
+    "app.plugins = number": "plugins must be an array",
+    "app.plugins = array-like": "plugins must be an array",
+    "app.plugins = array": "accepted",
+    "app.plugins = empty array": "accepted",
+    "app.plugins = null": "accepted",
+    "framework.plugins = string": "plugins must be an array",
+    "framework.plugins = single plugin object": "plugins must be an array",
+    "framework.plugins = number": "plugins must be an array",
+    "framework.plugins = array-like": "plugins must be an array",
+    "framework.plugins = array": "accepted",
+    "framework.plugins = empty array": "accepted",
+    "framework.plugins = null": "accepted",
+    // once per site, from the two "array" cases
+    setupCalls: 2,
+  });
+  expect(exitCode).toBe(0);
+});
+
+// `bun build --app` reads the same options object and used to build with the
+// invalid value ignored.
+test.concurrent("bun build --app rejects a non-array plugins option", async () => {
+  using dir = tempDir("bake-build-plugins-not-array", {
+    "server.ts": `export function render() { return new Response("unused"); }`,
+    "bun.app.ts": `
+      export default {
+        app: {
+          framework: {
+            fileSystemRouterTypes: [{ root: "routes", style: "nextjs-pages", serverEntryPoint: "./server.ts" }],
+          },
+          plugins: 123,
+        },
+      };
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "--app"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "ignore",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("TypeError: plugins must be an array");
+  expect(exitCode).toBe(1);
+});
+
 // devTest("onLoad with watchFile", {
 //   framework: minimalFramework,
 //   pluginFile: `

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { existsSync } from "fs";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import path from "path";
 import { tempDirWithBakeDeps } from "../bake-harness";
 
@@ -327,6 +327,29 @@ export default function GettingStarted() {
       expect(stderr.toString()).not.toContain("reached unreachable code");
       expect(stderr.toString()).not.toContain("assert(this.cap > 0)");
     }
+  });
+
+  // Same options parser as `Bun.serve({ app })` (dev/plugins.test.ts covers the value
+  // matrix); this used to build with the option silently ignored.
+  test("rejects a non-array plugins option", async () => {
+    using dir = tempDir("bake-production-plugins-not-array", {
+      "server.ts": `export function render() { return new Response("unused"); }`,
+      "bun.app.ts": `
+        export default {
+          app: {
+            framework: {
+              fileSystemRouterTypes: [{ root: "routes", style: "nextjs-pages", serverEntryPoint: "./server.ts" }],
+            },
+            plugins: 123,
+          },
+        };
+      `,
+    });
+
+    const { exitCode, stderr } = await Bun.$`${bunExe()} build --app`.cwd(String(dir)).env(bunEnv).throws(false);
+
+    expect(stderr.toString()).toContain("TypeError: plugins must be an array");
+    expect(exitCode).toBe(1);
   });
 
   test("client-side component with default import should work", async () => {


### PR DESCRIPTION
### Problem
- `Bun.serve({ app: { plugins: <non-array> } })`, the same key inside `app.framework`, and `bun build --app` with either one never check that `plugins` is an array.
- `plugins: 123`, `plugins: true`, `plugins: { length: 0 }` or a function are accepted and silently do nothing.
- `plugins: "abc"` or `plugins: { name, setup }` (one plugin passed without the surrounding array) throw `Expected plugin to be an object`, which describes the first "element" of the value, not the mistake.
- Cause: both call sites (`src/runtime/bake/bake_body.rs:247` for `app.plugins`, `:1097` for `framework.plugins`) hand the value straight to `SplitBundlerOptions::parse_plugin_array`, which calls `array_iterator()` on it (`:329`). `JSArrayIterator` works on any value: it reads `length` and indexes, so a string iterates its characters and a value without a usable `length` iterates nothing.
- The `{ name, setup }` case only throws today because `JSValue::get_length` returns 2^51-1 for objects with no `length` property (the C++ side returns infinity, the Rust side checks for `f64::MAX`); once that is fixed a single plugin object would be silently ignored too.
- Same check was missing in the Zig version (`bake.zig` `parsePluginArray`), so this is long-standing rather than a port regression.

### Fix
- `parse_plugin_array` rejects a non-array with `plugins must be an array` before doing anything else. Both call sites go through it, so `app.plugins`, `framework.plugins`, `Bun.serve` and `bun build --app` are all covered by the one check.
- The message and the `is_array()` test are the ones `Bun.build` already uses for its `plugins` option (`JSValue::get_array`, `src/runtime/api/JSBundler.rs:488`), so the same mistake now reports the same error in both APIs.
- `get_array` itself is not used here because it also returns `None` for an empty array, and `plugins: []` has to keep creating the (empty) plugin set: the dev server uses its presence to decide whether to fall back to the bunfig `[serve.static]` plugins (`src/runtime/bake/DevServer.rs:1978`).
- The check runs before the plugin set is created, so the new error path does not allocate a GC-protected `JSBundlerPlugin` of its own. A plugin set already created by a valid `framework.plugins` is still leaked when a later option (including this new `app.plugins` error) fails: `from_js` error paths have never released it, and #37837 fixes that class by making the handle release itself on drop.
- `app.plugins` is now read with the same `get_optional_value` helper `framework.plugins` uses, so `plugins: null` means "not provided" at both sites, as it already does for `Bun.build`. Without this, `app.plugins: null` (accepted today) would start throwing.
- Verified with `test/bake/dev/plugins.test.ts`, `app.plugins and framework.plugins must be arrays`: one process runs the same seven values through both sites via `Bun.serve`. A string, a single plugin object, a number and an array-like all get `plugins must be an array`; `[plugin]`, `[]` and `null` are still accepted, and `setup()` still runs for the real arrays. It fails on the released `bun` with the accepted/misleading results listed above and passes with this build; the existing tests in the file still pass.
- `bun build --app` reaches the same `UserOptions::from_js` (`src/runtime/bake/production.rs:395`) and is covered by `test/bake/dev/production.test.ts`, `production > rejects a non-array plugins option` (a `bun.app.ts` with `plugins: 123`): the release build bundles with the option ignored, this build prints `TypeError: plugins must be an array` and exits 1.
- That test sits in `production.test.ts` rather than next to the matrix because every `bun build --app` run trips a pre-existing unchecked-exception assertion in `BakeSourceProvider.cpp` (`BakeGetDefaultExportFromModule`) under the exception-check validation the ASAN lane enables, and `production.test.ts` is the bake file listed in `test/no-validate-exceptions.txt`. The assertion is independent of this change and is being fixed separately. Run the test alone with `-t "rejects a non-array plugins option"`: the file's other tests build a React app and exceed the default per-test timeout on a debug build.
- Intentionally left out: the other shape checks missing from the same file, `bundlerOptions.{server,client,ssr}` being objects (#30125) and `fileSystemRouterTypes[i]` being objects (#30401), already have their own open PRs. Note for sequencing: #37837 rewrites the body of `parse_plugin_array` directly below the inserted check, so whichever of the two lands second needs a trivial rebase.

### Background
- Bake is the `app` option of `Bun.serve` and the `bun build --app` command. Both parse the user's options object with `UserOptions::from_js` in `bake_body.rs`; `framework` can be the string `"react"` or an object parsed by `Framework::from_js`, and both the outer object and the framework object accept a `plugins` array of Bun bundler plugins.
- The plugins from both arrays are registered into one native `JSBundlerPlugin` object (created on the first `plugins` key seen, even an empty one), which every bundle run by the dev server or the production build consults.
- `JSArrayIterator` is Bun's helper for walking a JS array from native code. It does not require an actual array: it reads a `length` and indexes, so callers are expected to validate the value first; `JSValue::get_array` is the helper that does that for object properties.
