### PR TITLE
js_parser: declare decorator lowering temporaries per evaluation in parameter defaults and field initializers

### DIFF
--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -2536,14 +2536,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     },
                     loc,
                 );
-                let list_is_shared = p.nearest_stmt_list_is_shared;
-                let hoisted = match p.nearest_stmt_list_mut() {
-                    Some(stmt_list) if !list_is_shared => {
-                        stmt_list.push(var_decl_stmt);
-                        true
-                    }
-                    _ => false,
-                };
+                let hoisted = !p.nearest_stmt_list_is_shared
+                    && match p.nearest_stmt_list_mut() {
+                        Some(stmt_list) => {
+                            stmt_list.push(var_decl_stmt);
+                            true
+                        }
+                        None => false,
+                    };
                 if !hoisted {
                     let return_stmt = p.s(
                         S::Return {

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -272,6 +272,25 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         )
     }
 
+    /// `(() => { ...stmts })()`
+    fn iife(&mut self, stmts: js_ast::StmtNodeList, l: bun_ast::Loc) -> Expr {
+        let target = self.new_expr(
+            E::Arrow {
+                body: G::FnBody { loc: l, stmts },
+                ..Default::default()
+            },
+            l,
+        );
+        self.new_expr(
+            E::Call {
+                target,
+                args: bun_alloc::AstAlloc::vec(),
+                ..Default::default()
+            },
+            l,
+        )
+    }
+
     /// Create a static block property from a single expression.
     fn make_static_block(&mut self, expr: Expr, l: bun_ast::Loc) -> Property {
         let bump = self.arena;
@@ -2127,27 +2146,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 }
                             }
                         } else {
-                            // Wrap in IIFE
                             let stmts_ptr = bun_ast::StoreSlice::new_mut(stmts_slice);
-                            let iife_body = p.new_expr(
-                                E::Arrow {
-                                    body: G::FnBody {
-                                        loc,
-                                        stmts: stmts_ptr,
-                                    },
-                                    is_async: false,
-                                    ..Default::default()
-                                },
-                                loc,
-                            );
-                            suffix_exprs.push(p.new_expr(
-                                E::Call {
-                                    target: iife_body,
-                                    args: bun_alloc::AstAlloc::vec(),
-                                    ..Default::default()
-                                },
-                                loc,
-                            ));
+                            suffix_exprs.push(p.iife(stmts_ptr, loc));
                         }
                     }
                     StaticElementKind::FieldOrAccessor => {
@@ -2518,7 +2518,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 );
             }
 
-            // Emit var declarations
+            // The class keeps reading the temporaries after it is created
+            // (`_init` in the constructor, the accessor storage WeakMaps), so
+            // each evaluation of the expression needs its own set. Hoisting
+            // them into the nearest statement list is only right when that list
+            // runs once per evaluation; otherwise (a parameter default value, an
+            // instance field initializer, no list at all) they are declared in
+            // an arrow wrapped around the chain, which keeps `this`, `super`,
+            // `arguments` and `new.target` of the enclosing code. Neither of
+            // those positions can contain `await` or `yield`.
             if !expr_var_decls.is_empty() {
                 let decls = DeclList::from_bump_vec(expr_var_decls);
                 let var_decl_stmt = p.s(
@@ -2528,8 +2536,23 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     },
                     loc,
                 );
-                if let Some(stmt_list) = p.nearest_stmt_list_mut() {
-                    stmt_list.push(var_decl_stmt);
+                let list_is_shared = p.nearest_stmt_list_is_shared;
+                let hoisted = match p.nearest_stmt_list_mut() {
+                    Some(stmt_list) if !list_is_shared => {
+                        stmt_list.push(var_decl_stmt);
+                        true
+                    }
+                    _ => false,
+                };
+                if !hoisted {
+                    let return_stmt = p.s(
+                        S::Return {
+                            value: Some(result),
+                        },
+                        loc,
+                    );
+                    let body = bump.alloc_slice_copy(&[var_decl_stmt, return_stmt]);
+                    result = p.iife(bun_ast::StoreSlice::new_mut(body), loc);
                 }
             }
 

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -604,6 +604,12 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     /// Name from assignment context for anonymous decorated class expressions.
     /// Set before visitExpr, consumed by lowerStandardDecoratorsImpl.
     pub(crate) decorator_class_name: Option<&'a [u8]>,
+    /// Set while visiting an expression that runs once per call or per
+    /// construction (a parameter default value, an instance field initializer)
+    /// although `nearest_stmt_list` runs once: a declaration hoisted there would
+    /// be shared by every evaluation of the expression. `visit_stmts` clears it
+    /// for the statements of any body nested inside such an expression.
+    pub(crate) nearest_stmt_list_is_shared: bool,
 }
 
 // `binding::ToExprWrapper` type-erases `*P` (which is generic over
@@ -8847,6 +8853,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             will_wrap_module_in_try_catch_for_using: false,
             nearest_stmt_list: None,
             decorator_class_name: None,
+            nearest_stmt_list_is_shared: false,
 
             jsx_transform,
 

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -218,6 +218,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             duplicate_args_check = Some(StringVoidMap::get());
         }
 
+        // Default values (including those nested in destructuring patterns) run
+        // once per call, while the statement list enclosing the function runs
+        // once; the function's own body installs its list later.
+        let old_nearest_stmt_list_is_shared = self.nearest_stmt_list_is_shared;
+        self.nearest_stmt_list_is_shared = true;
+
         for arg in args.iter_mut() {
             if arg.ts_decorators.len_u32() > 0 {
                 self.visit_ts_decorators(&mut arg.ts_decorators);
@@ -230,6 +236,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 self.visit_expr(default);
             }
         }
+
+        self.nearest_stmt_list_is_shared = old_nearest_stmt_list_is_shared;
     }
 
     // `Vec<Expr>` is not `Copy`; mutate in place.
@@ -984,7 +992,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
 
                 if let Some(val) = property.initializer {
-                    // if (property.flags.is_static and )
+                    // An instance initializer runs once per construction; a
+                    // static one runs with the class itself.
+                    let old_nearest_stmt_list_is_shared = self.nearest_stmt_list_is_shared;
+                    if !property.flags.contains(flags::Property::IsStatic) {
+                        self.nearest_stmt_list_is_shared = true;
+                    }
                     if let Some(name) = name_to_keep {
                         let was_anon = val.is_anonymous_named();
                         let prev_dcn2 = self.decorator_class_name;
@@ -1003,6 +1016,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     } else {
                         self.visit_expr(property.initializer.as_mut().unwrap());
                     }
+                    self.nearest_stmt_list_is_shared = old_nearest_stmt_list_is_shared;
                 }
 
                 // manual restore for the three `defer`s above
@@ -1341,11 +1355,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 ListManaged::with_capacity_in(stmts.len(), p.arena);
 
             let prev_nearest_stmt_list = p.nearest_stmt_list;
+            let prev_nearest_stmt_list_is_shared = p.nearest_stmt_list_is_shared;
             // BACKREF — `before` outlives this block; raw NonNull avoids
             // the `&'a mut` borrow conflict. Derive via `addr_of_mut!` (no intermediate
             // `&mut`) so the pointer shares the local's base tag and survives the
             // direct `&mut before` reborrows in the loop below (Stacked Borrows).
             p.nearest_stmt_list = NonNull::new(core::ptr::addr_of_mut!(before));
+            // `before` runs every time the statements it is emitted ahead of run.
+            p.nearest_stmt_list_is_shared = false;
 
             let mut preprocessed_enum_i: usize = 0;
 
@@ -1538,6 +1555,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
             // manual restore for the block-level `defer`s
             p.nearest_stmt_list = prev_nearest_stmt_list;
+            p.nearest_stmt_list_is_shared = prev_nearest_stmt_list_is_shared;
             p.is_control_flow_dead = old_is_control_flow_dead;
         }
 

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "node:path";
 
 // ES standard decorators are used for .js files (always) and for .ts files
 // when experimentalDecorators is NOT set in tsconfig.
@@ -27,6 +28,21 @@ async function runDecorator(code: string) {
     stderr: "pipe",
   });
 
+  const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr: filterStderr(rawStderr), exitCode };
+}
+
+async function runDecoratorTS(code: string) {
+  using dir = tempDir("es-dec-ts", {
+    "tsconfig.json": JSON.stringify({ compilerOptions: {} }),
+    "test.ts": code,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
   const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   return { stdout, stderr: filterStderr(rawStderr), exitCode };
 }
@@ -390,21 +406,6 @@ describe("ES Decorators", () => {
       expect(stdout).toBe("hello bar\ndone\n");
       expect(exitCode).toBe(0);
     });
-
-    async function runDecoratorTS(code: string) {
-      using dir = tempDir("es-dec-ts", {
-        "tsconfig.json": JSON.stringify({ compilerOptions: {} }),
-        "test.ts": code,
-      });
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "test.ts"],
-        env: bunEnv,
-        cwd: String(dir),
-        stderr: "pipe",
-      });
-      const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      return { stdout, stderr: filterStderr(rawStderr), exitCode };
-    }
 
     test("non-null assertion in decorator member expression", async () => {
       const { stdout, stderr, exitCode } = await runDecoratorTS(`
@@ -1208,6 +1209,248 @@ describe("ES Decorators", () => {
       expect(filterStderr(rawStderr)).toBe("");
       expect(stdout).toBe("undefined\nworld\n");
       expect(exitCode).toBe(0);
+    });
+  });
+
+  // Lowering a class expression produces `(_dec = [...], _x = new WeakMap, _init = ...,
+  // _class = class { ... }, __decorateElement(...), _class)` plus a declaration of the
+  // temporaries, and the class keeps reading them whenever it is constructed. A parameter
+  // default value or an instance field initializer is evaluated once per call or per
+  // construction while the statement around it runs once, so the temporaries have to be
+  // declared per evaluation as well; hoisting a single `var` next to the statement made
+  // every class created there use the storage of the most recent evaluation.
+  describe("class expressions evaluated once per call or per construction", () => {
+    // `dec` gives each class it decorates a distinct id, which instances receive through
+    // addInitializer (kept in the lowering's `_init`); `accessor x` keeps its value in the
+    // lowering's per-class WeakMap. `report` constructs an instance of each class only
+    // after both classes exist, when a class reading another evaluation's temporaries
+    // either throws from the WeakMap lookup or receives the other evaluation's id.
+    const prelude = `
+      let evaluations = 0;
+      function dec(_value, ctx) {
+        const id = ++evaluations;
+        ctx.addInitializer(function () { this.id = id; });
+      }
+      function report(K1, K2) {
+        const a = new K1(), b = new K2();
+        a.x += "!";
+        console.log(JSON.stringify([K1 !== K2, evaluations, a.id, b.id, a.x, b.x]));
+      }
+    `;
+    const body = `{ @dec accessor x = "x" }`;
+    const firstReport = [true, 2, 1, 2, "x!", "x"];
+    const secondReport = [true, 4, 3, 4, "x!", "x"];
+    const reports = (stdout: string) =>
+      stdout
+        .trim()
+        .split("\n")
+        .map(line => JSON.parse(line));
+
+    test.concurrent("default parameter of a function declaration", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`${prelude}
+        function make(K = class ${body}) { return K; }
+        report(make(), make());
+      `);
+      expect(stderr).toBe("");
+      expect(reports(stdout)).toEqual([firstReport]);
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("default parameter of an arrow function", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`${prelude}
+        const make = (K = class ${body}) => K;
+        report(make(), make());
+      `);
+      expect(stderr).toBe("");
+      expect(reports(stdout)).toEqual([firstReport]);
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("default parameters of a constructor and of a method", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`${prelude}
+        class Factory {
+          constructor(K = class ${body}) { this.K = K; }
+          make(K = class ${body}) { return K; }
+        }
+        const first = new Factory(), second = new Factory();
+        report(first.K, second.K);
+        report(first.make(), second.make());
+      `);
+      expect(stderr).toBe("");
+      expect(reports(stdout)).toEqual([firstReport, secondReport]);
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("default value inside a destructured parameter", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`${prelude}
+        function make({ K = class ${body} } = {}) { return K; }
+        report(make(), make());
+      `);
+      expect(stderr).toBe("");
+      expect(reports(stdout)).toEqual([firstReport]);
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("instance field initializer", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`${prelude}
+        class Outer {
+          inner = class ${body};
+        }
+        report(new Outer().inner, new Outer().inner);
+      `);
+      expect(stderr).toBe("");
+      expect(reports(stdout)).toEqual([firstReport]);
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("instance field initializer in a TypeScript file", async () => {
+      const { stdout, stderr, exitCode } = await runDecoratorTS(`${prelude}
+        class Outer {
+          inner: any = class ${body};
+        }
+        report(new Outer().inner, new Outer().inner);
+      `);
+      expect(stderr).toBe("");
+      expect(reports(stdout)).toEqual([firstReport]);
+      expect(exitCode).toBe(0);
+    });
+
+    // The outer class has an `accessor`, so it is lowered too and its initializer is moved
+    // into the outer constructor; the inner class must stay self-contained through that.
+    test.concurrent("instance accessor initializer of a class that is lowered itself", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`${prelude}
+        class Outer {
+          accessor inner = class ${body};
+        }
+        report(new Outer().inner, new Outer().inner);
+      `);
+      expect(stderr).toBe("");
+      expect(reports(stdout)).toEqual([firstReport]);
+      expect(exitCode).toBe(0);
+    });
+
+    // The decorated class is in a static initializer, which by itself runs with the class
+    // around it, but that class is a parameter default and so is created once per call.
+    test.concurrent("static initializer of a class expression that is a parameter default", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`${prelude}
+        function make(Holder = class { static inner = class ${body}; }) { return Holder.inner; }
+        report(make(), make());
+      `);
+      expect(stderr).toBe("");
+      expect(reports(stdout)).toEqual([firstReport]);
+      expect(exitCode).toBe(0);
+    });
+
+    // Member initializers of a top-level enum are visited before the module's statement
+    // list exists, so there is nothing to hoist into.
+    test.concurrent("initializer of a top-level enum", async () => {
+      const { stdout, stderr, exitCode } = await runDecoratorTS(`${prelude}
+        let K1: any, K2: any;
+        enum E {
+          A = ((K1 = class ${body}), 1),
+          B = ((K2 = class ${body}), 2),
+        }
+        report(K1, K2);
+        console.log(JSON.stringify([E.A, E.B]));
+      `);
+      expect(stderr).toBe("");
+      expect(reports(stdout)).toEqual([firstReport, [1, 2]]);
+      expect(exitCode).toBe(0);
+    });
+
+    // The temporaries are declared inside an arrow function wrapped around the lowered
+    // expression, so `this`, `super` and `arguments` of the surrounding code must still be
+    // what the decorator expressions of the class see.
+    test.concurrent("decorator expressions still see this, super and arguments", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        const seen = [];
+        function tagged(tag) {
+          return function (_value, ctx) { seen.push(tag + ":" + ctx.name); };
+        }
+        class Base {
+          baseTag() { return "super"; }
+        }
+        class Outer extends Base {
+          tag = "this";
+          inner = class {
+            @tagged(this.tag) accessor viaThis = 1;
+            @tagged(super.baseTag()) accessor viaSuper = 2;
+          };
+        }
+        function make(K = class { @tagged("arguments:" + arguments.length) accessor x = 3 }) { return K; }
+        const inner = new (new Outer().inner)();
+        const k = new (make())();
+        console.log(JSON.stringify([seen, inner.viaThis, inner.viaSuper, k.x]));
+      `);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual([["this:viaThis", "super:viaSuper", "arguments:0:x"], 1, 2, 3]);
+      expect(exitCode).toBe(0);
+    });
+
+    test("temporaries are declared inside the expression only where the statement does not run per evaluation", () => {
+      const transpiler = new Bun.Transpiler({ loader: "js", target: "bun" });
+      const lower = (code: string) => {
+        const output = transpiler.transformSync(`function dec() {}\n${code}`);
+        expect(() => new Bun.Transpiler({ loader: "js" }).transformSync(output)).not.toThrow();
+        return output;
+      };
+      const hoistedToModule = /^var [^\n]*\b_init\b/m;
+      const declaredInWrapper = /\(\(\) => \{\s+var [^\n]*\b_init\b[^\n]*;\s+return /;
+
+      for (const code of [
+        `function make(K = class { @dec accessor x = 0 }) { return K; }`,
+        `class Outer { inner = class { @dec accessor x = 0 }; }`,
+      ]) {
+        const output = lower(code);
+        expect(output).toMatch(declaredInWrapper);
+        expect(output).not.toMatch(hoistedToModule);
+      }
+
+      // The statement these belong to runs exactly as often as the expression does.
+      for (const code of [
+        `const K = class { @dec accessor x = 0 };`,
+        `class Outer { static inner = class { @dec accessor x = 0 }; }`,
+        `class Outer { [class { @dec accessor x = 0 }.name]() {} }`,
+      ]) {
+        const output = lower(code);
+        expect(output).toMatch(hoistedToModule);
+        expect(output).not.toMatch(declaredInWrapper);
+      }
+
+      // A function body nested inside an initializer is a statement list of its own again.
+      const nestedBody = lower(`class Outer { make = () => { const K = class { @dec accessor x = 0 }; return K; }; }`);
+      expect(nestedBody).toMatch(/\n\s+var [^\n]*\b_init\b/);
+      expect(nestedBody).not.toMatch(hoistedToModule);
+      expect(nestedBody).not.toMatch(declaredInWrapper);
+    });
+
+    test.concurrent("Bun.build output, plain and minified", async () => {
+      using dir = tempDir("es-dec-per-evaluation-build", {
+        "entry.js": `${prelude}
+          function makeA(K = class ${body}) { return K; }
+          function makeB(K = class ${body}) { return K; }
+          class Outer { inner = class ${body}; }
+          report(makeA(), makeB());
+          report(makeA(), new Outer().inner);
+        `,
+      });
+
+      for (const minify of [false, true]) {
+        const outdir = join(String(dir), minify ? "out-minified" : "out");
+        const result = await Bun.build({ entrypoints: [join(String(dir), "entry.js")], outdir, target: "bun", minify });
+        expect(result.success).toBe(true);
+
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), join(outdir, "entry.js")],
+          env: bunEnv,
+          cwd: String(dir),
+          stderr: "pipe",
+        });
+        const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(filterStderr(rawStderr)).toBe("");
+        expect(reports(stdout)).toEqual([firstReport, secondReport]);
+        expect(exitCode).toBe(0);
+      }
     });
   });
 });


### PR DESCRIPTION
### Problem

- A class expression that needs the standard decorator lowering (decorators or an `accessor` member) fails when it is a parameter default value or an instance field initializer and the function is called, or the outer class constructed, more than once: constructing an instance of an earlier class throws `TypeError: Cannot read from private field`, and with a method decorator that uses `addInitializer` the instance silently receives a later class's initializers.
  ```js
  function dec(_value, _ctx) {}
  function make(K = class { @dec accessor x = 0 }) { return K; }
  const K1 = make(), K2 = make();
  new K1().x; // TypeError: Cannot read from private field

  class Outer { inner = class { @dec accessor x = 0 }; }
  const a = new Outer(), b = new Outer();
  new a.inner().x; // same
  ```
- The expression-mode lowering (`src/js_parser/lower/lower_decorators.rs`, phase 8) emits `(_dec = [dec], _x = new WeakMap, _init = __decoratorStart(), _class = class {...}, __decorateElement(..., _x), _class)` and pushes the `var _class, _init, _dec, _x` for those temporaries into `p.nearest_stmt_list`, the statement list around the enclosing statement (the function declaration, the outer class). That list runs once, the expression runs once per call / per construction, so every evaluation assigns the same variables. The class body reads them later, at construction time (`__privateAdd(this, _x, ...)`, `__runInitializers(_init, ...)`), so an instance of the first class uses the second evaluation's WeakMap and initializer array, while its accessor was bound to the first one by `__decorateElement`.
- `visit_args` visits default values before the function body installs its own list (`src/js_parser/visit/mod.rs`), and `visit_class` visits field initializers with the list of the surrounding statements installed; nothing in between runs once per evaluation, so there is no list the declaration could go into.
- When `nearest_stmt_list` is `None` the declaration was silently dropped (`ReferenceError: _dec is not defined`); top-level enum member initializers are visited that way (#38761 covers that case by giving the enum body a list; see below).
- esbuild 0.25 emits the same shared module-level `var` for these inputs and fails the same way; tsc wraps every such class expression in an IIFE that declares the temporaries locally.

### Fix

- New `P::nearest_stmt_list_is_shared`: `visit_args` sets it while visiting the parameter list (plain and destructuring defaults) and `visit_class` while visiting a non-static field or accessor initializer; `visit_stmts` saves it, clears it while its own list is installed, and restores it, so a function body, arrow body or static block nested inside one of those expressions hoists exactly as before. Everything else inherits the value, which is what makes nested cases right: a class inside the static initializer, computed key or extends clause of a class expression that is itself a parameter default is still created once per call, and is wrapped; the same positions in a class statement still hoist.
- Phase 8 hoists the `var` only when a list is installed and the flag is clear. Otherwise it emits `(() => { var _class, _init, _dec, _x; return _dec = [dec], ..., _class; })()` in place of the comma chain, so each evaluation of the expression gets fresh bindings. This is also the fallback for `nearest_stmt_list == None`.
- Why the arrow is correct there: an arrow function keeps the `this`, `super`, `arguments` and `new.target` of the code it appears in, so the class's decorator expressions, computed keys and extends clause (the only user code evaluated in the chain; everything else in it is generated) behave as they did in the source; the new test checks `this`, `super` and `arguments` explicitly. A parameter default value and a class field initializer are the two expression positions where `await` and `yield` are early errors, so the chain can never contain one, which is what would make a plain arrow wrapper invalid in ordinary statement context. Evaluation order is unchanged because the wrapper is called in the exact position the chain occupied. Output for every other position is byte-for-byte unchanged (the transpiler test pins a statement, a static initializer, a computed key and a body nested in an initializer).
- Both renamer paths are fine with the wrapper: the temporaries are still registered in the scope current at lowering time, so `bun build` / `--minify` give them names distinct from everything visible there, and the declaration now sits in a scope nested inside it. Sibling functions that each have such a default used to share one module-level declaration even in bundled output; they are independent now (the `Bun.build` test covers plain and minified output).
- Verified with `test/bundler/transpiler/es-decorators.test.ts`, describe "class expressions evaluated once per call or per construction" (12 tests: function, arrow, constructor and method defaults, a destructuring default, instance field initializer in JS and TS, instance `accessor` initializer of a class that is lowered itself, a static initializer nested in a parameter default, the top-level enum fallback, the `this`/`super`/`arguments` guard, transpiler output shape, `Bun.build` plain and minified). 11 fail on the unfixed build with the error above; the `this`/`super`/`arguments` test passes on both and guards the wrapper's semantics.
- Also pass with the fix: es-decorators-esbuild (the ported esbuild suite), decorators, decorator-metadata, bundler_decorator_metadata, ts-use-define-for-class-fields, ts-enum-redecl-panic, transpiler.test.js, react-compiler and react-compiler-fixtures (react refresh is the other `nearest_stmt_list` user; it is not affected by the flag), bundler_edgecase, bundler_minify, bundler_naming, esbuild/ts, esbuild/default, esbuild/lower; `cargo clippy -p bun_js_parser` clean.
- Relation to open work in this file: #38761 makes enum bodies install their own list, which is leaner than the fallback here for enums; both can land in either order. #38734 changes how the temporaries are named and does not change where they are declared; its duplicate `_dec` entry in the `var` (visible in the output below) is unrelated to this change. Two related bugs found while working on this are tracked separately: temporaries declared with `var` are also shared across the iterations of a loop (statement and expression mode), and a decorated class used as a plain parameter default gets `.name === "_class"`.

### Background

- Standard decorator lowering: Bun has no runtime support for TC39 decorators or `accessor`, so the parser rewrites such a class into a plain class plus calls to runtime helpers. For a class expression the result has to stay an expression, so the temporaries it needs are assigned inside a comma expression and declared by a separate `var` statement emitted somewhere else. The constructor of the rewritten class refers to those temporaries by name, which is why it matters where and how often they are declared: `_init` holds the per-class array of initializers that `addInitializer` callbacks and field initializers go into, and each `accessor` gets a WeakMap (`_x`) that stores the per-instance value.
- `nearest_stmt_list` is a pointer to the list that `visit_stmts` emits ahead of the statements it is currently visiting; it is saved and restored around every nested statement list (function bodies, blocks, static blocks). React fast refresh uses it to insert `_s = $RefreshSig$()` declarations, and the decorator lowering uses it for the `var` above.
- Visiting order for the two positions: `visit_func` / the arrow visitor push the argument scope and visit the parameters before pushing the body scope and visiting the body statements, so during a default value the list installed is still the one around the function. `visit_class` visits member initializers directly, inside the class body scope, with the list around the class statement installed; whether a field is static is a flag on the property.

<details>
<summary>Output for the first repro, before and after (<code>bun build --no-bundle</code>, helper import elided)</summary>

Before:

```js
var _class, _init, _dec, _dec, _x;
function dec(_value, _ctx) {}
function make(K = (_dec = [dec], _x = new WeakMap, _init = __decoratorStart(undefined), _class = class {
  constructor() {
    __runInitializers(_init, 5, this);
    __privateAdd(this, _x, __runInitializers(_init, 8, this, 0));
    __runInitializers(_init, 11, this);
  }
}, __decorateElement(_init, 4, "x", _dec, _class, _x), __decoratorMetadata(_init, _class), _class)) {
  return K;
}
```

After:

```js
function dec(_value, _ctx) {}
function make(K = (() => {
  var _class, _init, _dec, _dec, _x;
  return _dec = [dec], _x = new WeakMap, _init = __decoratorStart(undefined), _class = class {
    constructor() {
      __runInitializers(_init, 5, this);
      __privateAdd(this, _x, __runInitializers(_init, 8, this, 0));
      __runInitializers(_init, 11, this);
    }
  }, __decorateElement(_init, 4, "x", _dec, _class, _x), __decoratorMetadata(_init, _class), _class;
})()) {
  return K;
}
```

For comparison, tsc 6.0 emits `K = (() => { let _x_decorators; let _x_initializers = []; ...; return class { ... }; })()` for the same input, and esbuild 0.25.12 emits `var _x_dec, _init, _x;` at module level and fails at runtime like Bun did.

</details>
