### PR TITLE
sys: build compile-time errnos from E instead of libc constants (wrong names on Windows)

### DIFF
--- a/src/runtime/node/dir_iterator.rs
+++ b/src/runtime/node/dir_iterator.rs
@@ -787,7 +787,7 @@ mod platform {
                         w::Errno::NOTDIR => unreachable!(),
                         w::Errno::INVAL => unreachable!(),
                         w::Errno::NOTCAPABLE => {
-                            return Err(sys::Error::from_code_int(libc::EACCES, Tag::getdents64));
+                            return Err(sys::Error::from_code(sys::E::EACCES, Tag::getdents64));
                         }
                         _ => {
                             return Err(sys::Error::from_code_int(errno as i32, Tag::getdents64));

--- a/src/sys/Error.rs
+++ b/src/sys/Error.rs
@@ -144,7 +144,12 @@ impl Error {
         }
     }
 
-    // c_int covers all call sites in practice.
+    /// `errno` must already be an `E` discriminant, which is what the host
+    /// errno is on POSIX. Do not pass `libc::E*` constants: on Windows the
+    /// `libc` crate has the MSVC CRT's numbering (`ENAMETOOLONG` = 38,
+    /// `ENOSYS` = 40, `ENOTSUP` = 129), while `E` keeps Linux numbering there
+    /// (38 is `ENOSYS`, 40 is `ELOOP`, 129 is `EKEYREJECTED`). An errno known
+    /// at compile time goes through `from_code(E::X, tag)` instead.
     pub fn from_code_int(errno: c_int, syscall_tag: Tag) -> Error {
         #[cfg(windows)]
         let n = Int::try_from(errno.unsigned_abs()).unwrap();

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -791,7 +791,7 @@ pub fn open_dir_for_iteration_os_path(dir: Fd, path: &bun_paths::OSPathSlice) ->
         // ENAMETOOLONG on
         // overflow, never silently truncate (would open the wrong directory).
         if path.len() >= buf.len() {
-            return Err(Error::from_code_int(libc::ENAMETOOLONG, Tag::open).with_path(path));
+            return Err(Error::from_code(E::ENAMETOOLONG, Tag::open).with_path(path));
         }
         let len = path.len();
         buf[..len].copy_from_slice(path);
@@ -2001,7 +2001,7 @@ mod posix_impl {
         {
             return match super::linux_syscall::close(fd.native()) {
                 Err(e) if e == libc::EBADF => {
-                    Err(Error::from_code_int(libc::EBADF, Tag::close).with_fd(fd))
+                    Err(Error::from_code(E::EBADF, Tag::close).with_fd(fd))
                 }
                 _ => Ok(()),
             };
@@ -2013,7 +2013,7 @@ mod posix_impl {
             #[cfg(not(target_os = "macos"))]
             let rc = safe_libc::close(fd.native());
             if rc < 0 && last_errno() == libc::EBADF {
-                return Err(Error::from_code_int(libc::EBADF, Tag::close).with_fd(fd));
+                return Err(Error::from_code(E::EBADF, Tag::close).with_fd(fd));
             }
             Ok(())
         }
@@ -2467,9 +2467,7 @@ mod posix_impl {
         bun_paths::make_path_with(it, |p| {
             if p.len() >= buf.len() {
                 // Tag as `.mkdir`; keep consistent with `mkdirat`.
-                return Err(
-                    Error::from_code_int(E::ENAMETOOLONG as _, Tag::mkdir).with_path(sub_path)
-                );
+                return Err(Error::from_code(E::ENAMETOOLONG, Tag::mkdir).with_path(sub_path));
             }
             buf[..p.len()].copy_from_slice(p);
             buf[p.len()] = 0;
@@ -2573,9 +2571,7 @@ mod posix_impl {
         #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "macos")))]
         {
             if flags.int() != 0 {
-                return Err(
-                    Error::from_code_int(libc::ENOSYS, Tag::rename).with_path(from.as_bytes())
-                );
+                return Err(Error::from_code(E::ENOSYS, Tag::rename).with_path(from.as_bytes()));
             }
             renameat(from_dir, from, to_dir, to)
         }
@@ -2619,9 +2615,7 @@ mod posix_impl {
         let n = n as usize;
         // Truncation guard + NUL-terminate.
         if n >= buf.len() {
-            return Err(
-                Error::from_code_int(libc::ENAMETOOLONG, Tag::readlink).with_path(path.as_bytes())
-            );
+            return Err(Error::from_code(E::ENAMETOOLONG, Tag::readlink).with_path(path.as_bytes()));
         }
         buf[n] = 0;
         Ok(n)
@@ -2756,7 +2750,7 @@ mod posix_impl {
     #[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
     pub(crate) fn linkat_tmpfile(_tmpfd: Fd, _dirfd: Fd, name: &ZStr) -> Maybe<()> {
         // Tags as `.link` (matches Linux arm).
-        Err(Error::from_code_int(libc::EOPNOTSUPP, Tag::link).with_path(name.as_bytes()))
+        Err(Error::from_code(E::EOPNOTSUPP, Tag::link).with_path(name.as_bytes()))
     }
     pub fn symlinkat(target: &ZStr, dirfd: impl AsFd, dest: &ZStr) -> Maybe<()> {
         let dirfd = dirfd.as_fd();
@@ -2788,9 +2782,7 @@ mod posix_impl {
         );
         let n = n as usize;
         if n >= buf.len() {
-            return Err(
-                Error::from_code_int(libc::ENAMETOOLONG, Tag::readlink).with_path(path.as_bytes())
-            );
+            return Err(Error::from_code(E::ENAMETOOLONG, Tag::readlink).with_path(path.as_bytes()));
         }
         buf[n] = 0;
         Ok(n)
@@ -4680,7 +4672,7 @@ pub fn writev(fd: Fd, vecs: &[PlatformIoVec]) -> Maybe<usize> {
     {
         // TODO(windows): route through `uv_fs_write` with `uv_buf_t[]`.
         let _ = (fd, vecs);
-        Err(Error::from_code_int(libc::ENOSYS, Tag::writev))
+        Err(Error::from_code(E::ENOSYS, Tag::writev))
     }
 }
 
@@ -4729,7 +4721,7 @@ pub fn readv(fd: Fd, vecs: &[PlatformIoVec]) -> Maybe<usize> {
     #[cfg(not(unix))]
     {
         let _ = (fd, vecs);
-        Err(Error::from_code_int(libc::ENOSYS, Tag::readv))
+        Err(Error::from_code(E::ENOSYS, Tag::readv))
     }
 }
 
@@ -4788,7 +4780,7 @@ pub fn preadv(fd: Fd, vecs: &[PlatformIoVec], position: i64) -> Maybe<usize> {
     #[cfg(not(unix))]
     {
         let _ = (fd, vecs, position);
-        Err(Error::from_code_int(libc::ENOSYS, Tag::preadv))
+        Err(Error::from_code(E::ENOSYS, Tag::preadv))
     }
 }
 
@@ -6155,7 +6147,7 @@ pub fn openat_a(dir: impl AsFd, path: &[u8], flags: i32, perm: Mode) -> Maybe<Fd
     let dir = dir.as_fd();
     let mut buf = bun_paths::PathBuffer::default();
     if path.len() >= buf.0.len() {
-        return Err(Error::from_code_int(libc::ENAMETOOLONG, Tag::open).with_path(path));
+        return Err(Error::from_code(E::ENAMETOOLONG, Tag::open).with_path(path));
     }
     buf.0[..path.len()].copy_from_slice(path);
     buf.0[path.len()] = 0;
@@ -7272,7 +7264,7 @@ pub fn get_fcntl_flags(fd: Fd) -> Maybe<FcntlInt> {
 }
 #[cfg(windows)]
 pub fn get_fcntl_flags(_fd: Fd) -> Maybe<FcntlInt> {
-    Err(Error::from_code_int(libc::ENOSYS, Tag::fcntl))
+    Err(Error::from_code(E::ENOSYS, Tag::fcntl))
 }
 #[inline]
 pub fn set_nonblocking(fd: Fd) -> Maybe<()> {
@@ -7459,7 +7451,7 @@ pub fn kevent(
 pub fn clonefileat(_from_dir: impl AsFd, from: &ZStr, _to_dir: impl AsFd, to: &ZStr) -> Maybe<()> {
     let _from_dir = _from_dir.as_fd();
     let _to_dir = _to_dir.as_fd();
-    Err(Error::from_code_int(libc::ENOTSUP, Tag::clonefileat)
+    Err(Error::from_code(E::ENOTSUP, Tag::clonefileat)
         .with_path_dest(from.as_bytes(), to.as_bytes()))
 }
 
@@ -7605,7 +7597,7 @@ pub fn get_fd_path<'a>(fd: Fd, out: &'a mut bun_paths::PathBuffer) -> Maybe<&'a 
         // The kernel fills kf_path from the namecache and leaves it empty when it
         // has no name for the vnode (seen for a just-created file on UFS).
         if len == 0 {
-            return Err(Error::from_code_int(libc::ENOENT, Tag::fcntl).with_fd(fd));
+            return Err(Error::from_code(E::ENOENT, Tag::fcntl).with_fd(fd));
         }
         // SAFETY: path_ptr has `len` initialized bytes (kernel-written).
         out.0[..len].copy_from_slice(unsafe { core::slice::from_raw_parts(path_ptr, len) });
@@ -7620,7 +7612,7 @@ pub fn get_fd_path<'a>(fd: Fd, out: &'a mut bun_paths::PathBuffer) -> Maybe<&'a 
     )))]
     {
         let _ = (fd, out);
-        Err(Error::from_code_int(libc::ENOSYS, Tag::readlink))
+        Err(Error::from_code(E::ENOSYS, Tag::readlink))
     }
 }
 
@@ -7776,7 +7768,7 @@ pub fn copy_file(in_: Fd, out: Fd) -> Maybe<()> {
         while wrote < n {
             let w = write(out, &buf[wrote..n])?;
             if w == 0 {
-                return Err(Error::from_code_int(libc::EIO, Tag::write));
+                return Err(Error::from_code(E::EIO, Tag::write));
             }
             wrote += w;
         }
@@ -9231,7 +9223,7 @@ pub fn write_file_with_path_buffer(
         PathOrFileDescriptor::Fd(fd) => fd,
         PathOrFileDescriptor::Path(bytes) => {
             if bytes.len() >= path_buf.0.len() {
-                return Err(Error::from_code_int(libc::ENAMETOOLONG, Tag::open).with_path(bytes));
+                return Err(Error::from_code(E::ENAMETOOLONG, Tag::open).with_path(bytes));
             }
             path_buf.0[..bytes.len()].copy_from_slice(bytes);
             path_buf.0[bytes.len()] = 0;

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -180,6 +180,24 @@ describe("Bun.build", () => {
     ).toThrow();
   });
 
+  test("root longer than the path buffer throws ENAMETOOLONG", () => {
+    using dir = tempDir("bun-build-api-long-root", { "index.js": "export default 1;" });
+    // Longer than bun's path buffer on every platform (98302 bytes on Windows,
+    // 4096 on Linux, 1024 on macOS), so the errno is synthesized by bun rather
+    // than reported by the OS. Windows used to name it ENOSYS.
+    const root = Buffer.alloc(100_000, "a").toString();
+    let error: unknown;
+    try {
+      Bun.build({ entrypoints: [join(String(dir), "index.js")], root });
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message.replace(root, "<root>")).toBe(
+      "ENAMETOOLONG: failed to open root directory: <root>",
+    );
+  });
+
   test("returns errors properly", async () => {
     Bun.gc(true);
     const build = await buildNoThrow({

--- a/test/internal/source-lints/errno-libc-constants.test.ts
+++ b/test/internal/source-lints/errno-libc-constants.test.ts
@@ -1,0 +1,75 @@
+import { file } from "bun";
+import { expect, test } from "bun:test";
+import { realpathSync } from "fs";
+import path from "path";
+import { globAllSources } from "../../../scripts/glob-sources.ts";
+
+// `bun_sys::Error` stores its errno as a discriminant of bun's own `E` table
+// (`bun_errno`). On POSIX that table mirrors the host's errno numbers, so a
+// `libc::E*` constant happens to be the right value. On Windows it does not:
+// the `libc` crate carries the MSVC CRT's numbering there while `E` keeps
+// Linux numbering, and the two diverge from the mid 30s on (`libc::ENAMETOOLONG`
+// is 38, which `E` decodes as ENOSYS; `libc::ENOSYS` is 40, decoded as ELOOP;
+// `libc::ENOTSUP` is 129, decoded as EKEYREJECTED). An errno that is known at
+// compile time therefore has to be spelled with bun's enum, which is correct on
+// every target:
+//
+//   Error::from_code_int(libc::ENAMETOOLONG, tag)  ->  Error::from_code(E::ENAMETOOLONG, tag)
+//   Error::new(libc::ENOSYS, tag)                  ->  Error::from_code(E::ENOSYS, tag)
+//
+// `from_code_int` / `Error::new` remain the right constructors for an errno read
+// back from a syscall at runtime, which is what this lint leaves alone.
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+
+// Only scan files tracked in HEAD (a `git stash` round-trip can leave stray
+// `.rs` files in the working tree; CI runs on a clean checkout). Same guard as
+// the other lints in this directory.
+const tracked: Set<string> | null = (() => {
+  const r = Bun.spawnSync({
+    cmd: ["git", "-C", root, "ls-tree", "-r", "--name-only", "-z", "HEAD"],
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  if (!r.success) return null;
+  return new Set(r.stdout.toString().split("\0").filter(Boolean));
+})();
+
+const BANNED: RegExp[] = [/\bfrom_code_int\(\s*libc::E\w*/g, /\bError::new\(\s*libc::E\w*/g];
+
+let scanned = 0;
+const offenders: string[] = [];
+for (const abs of globAllSources().rust) {
+  if (!abs.endsWith(".rs")) continue;
+  const source = path.relative(root, abs).replaceAll(path.sep, "/");
+  // `src/cli` is a symlink into `src/runtime/cli`; count each file once under
+  // its canonical path.
+  if (path.relative(root, realpathSync(abs)).replaceAll(path.sep, "/") !== source) continue;
+  if (tracked !== null && !tracked.has(source)) continue;
+  // Blank out full-line comments so prose mentions of the pattern don't count.
+  // `[ \t]*` rather than `\s*` so the newlines stay and line numbers below
+  // stay right.
+  const content = (await file(abs).text()).replace(/^[ \t]*\/\/.*$/gm, "");
+  scanned++;
+  const found: { line: number; text: string }[] = [];
+  for (const re of BANNED) {
+    for (const match of content.matchAll(re)) {
+      found.push({
+        line: content.slice(0, match.index).split("\n").length,
+        text: match[0].replace(/\s+/g, " "),
+      });
+    }
+  }
+  found.sort((a, b) => a.line - b.line);
+  offenders.push(...found.map(({ line, text }) => `${source}:${line}: ${text}`));
+}
+
+test("scans a non-empty set of tracked Rust sources", () => {
+  // Guards against the tracked/realpath filters above over-firing and leaving
+  // nothing to scan, which would make the assertion below pass vacuously.
+  expect(scanned).toBeGreaterThan(0);
+});
+
+test("bun_sys::Error is never built from a libc errno constant", () => {
+  expect(offenders).toEqual([]);
+});


### PR DESCRIPTION
### Problem
- On Windows, `Bun.build({ root })` with a `root` longer than bun's path buffer throws `ENOSYS: failed to open root directory: ...`; Linux and macOS throw `ENAMETOOLONG: ...` for the same input.
- Cause: `openat_a` (`src/sys/lib.rs:6158` before this change) and a handful of sibling sites build the error with `Error::from_code_int(libc::ENAMETOOLONG, ..)`. `bun_sys::Error` stores an `E` discriminant (`src/sys/Error.rs`, `resolve_system_errno` decodes it with `E::try_from_raw`), and bun's `E` table keeps Linux numbering on Windows, but the `libc` crate's Windows constants are the MSVC CRT's numbers. They agree for the low errnos and diverge from the mid 30s on:
  - `libc::ENAMETOOLONG` = 38 on Windows, which `E` decodes as `ENOSYS` (bun's `ENAMETOOLONG` is 36). Hit by `openat_a` (so `open_a`, `open_dir_at`, `open_dir_absolute`, `File::openat`, ...) and `write_file_with_path_buffer`.
  - `libc::ENOSYS` = 40, decoded as `ELOOP`. Hit by the Windows stubs of `writev` / `readv` / `preadv` / `get_fcntl_flags`.
  - `libc::ENOTSUP` = 129, decoded as `EKEYREJECTED`. Hit by the non-macOS `clonefileat` stub.
- The other `from_code_int(libc::..)` sites in `bun_sys` are POSIX-only, where the two numberings coincide, so they were only correct by coincidence.

### Fix
- Every errno that is known at compile time is now built with `Error::from_code(E::X, tag)`: the 17 `from_code_int(libc::..)` sites in `src/sys/lib.rs`, a neighbouring `from_code_int(E::ENAMETOOLONG as _, ..)` that was correct but roundabout, and the one remaining site in the tree, a never-compiled WASI arm in `src/runtime/node/dir_iterator.rs`, so the new lint below needs no allowlist.
- Correct because `from_code` takes bun's own enum, whose value is the `E` discriminant `Error` decodes on every target. On POSIX `E::X as u16 == libc::X` for each constant touched here (checked against `src/errno/{linux,darwin,freebsd}_errno.rs`), so the POSIX builds are unchanged; on Windows the three values above become `ENAMETOOLONG` / `ENOSYS` / `ENOTSUP`.
- `from_code_int` gets a doc comment stating the contract (the argument must already be an `E` discriminant; `libc::E*` is not one on Windows) so a dynamic-errno caller can still use it but a constant does not end up there.
- `test/internal/source-lints/errno-libc-constants.test.ts`: rejects `from_code_int(libc::E..)` and `Error::new(libc::E..)` anywhere in `src/**/*.rs`. Fails on main with the 18 sites listed above, passes with this change.
- `test/bundler/bun-build-api.test.ts`: `Bun.build` with a 100000 byte `root` (longer than the path buffer on every platform) must throw `ENAMETOOLONG: failed to open root directory`. This is the user-visible repro; it only fails on Windows before the change, since the POSIX numbers coincide.
- Verified:
  - windows-x64: the `Bun.build` test fails on the released build (`Received: "ENOSYS: failed to open root directory: <root>"`) and passes with this branch built locally.
  - linux-x64: both tests pass with `bun bd test`; the lint fails with `src/` stashed; the rest of `bun-build-api.test.ts` passes (the 400-build stress test hits its own 180s timeout under the local debug/ASAN build, unrelated to this change).
  - `cargo check -p bun_sys` for `x86_64-unknown-linux-gnu`, `x86_64-pc-windows-msvc`, `x86_64-apple-darwin` and `x86_64-unknown-freebsd`; `cargo clippy -p bun_sys` clean on Linux and adds nothing on the Windows target; `cargo fmt` and prettier clean.

### Background
- `bun_errno::E` / `SystemErrno`: bun's errno enums. On POSIX they are generated per OS and their discriminants are the host's errno values; on Windows, which has no usable errno of its own, bun defines the table itself using Linux numbering (`src/errno/windows_errno.rs`), and libuv / Win32 errors are mapped onto it.
- `bun_sys::Error`: the syscall error type (`errno` + syscall tag + path). `from_code(E, tag)` stores the enum's discriminant; `from_code_int(c_int, tag)` stores whatever number it is given, which is right for an errno read back from the OS on POSIX and wrong for a `libc` constant on Windows. `name()` / `.code` / error messages all come from decoding the stored number back through `E`.
- `libc` crate on Windows: its `E*` constants are the MSVC CRT `errno.h` values (used by the CRT's `_open` etc.), which are unrelated to both bun's table and libuv's codes.
