### PR TITLE
js_parser: name an anonymous decorated class after the parameter or for loop variable it initializes

### DIFF
--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -232,10 +232,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// Visits the initializer of a parameter, `for` loop declaration or destructuring
-    /// element. An anonymous class takes its name from the binding, but standard
-    /// decorator lowering rewrites it to `_class = class {}`, so the name is handed to
-    /// the lowering through `decorator_class_name` instead (see `e_class`).
+    /// Decorator lowering turns the initializer into `_class = class {}`, so an anonymous
+    /// class gets the binding's name through `decorator_class_name` (see `e_class`).
     pub(crate) fn visit_binding_initializer(
         &mut self,
         binding: BindingNodeIndex,

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -232,8 +232,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// Decorator lowering turns the initializer into `_class = class {}`, so an anonymous
-    /// class gets the binding's name through `decorator_class_name` (see `e_class`).
+    /// Names an anonymous decorated class after the binding it initializes (`decorator_class_name`).
     pub(crate) fn visit_binding_initializer(
         &mut self,
         binding: BindingNodeIndex,

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -227,19 +227,30 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             let dup: Option<&mut StringVoidMap> = duplicate_args_check.as_deref_mut();
             self.visit_binding(arg.binding, dup);
             if let Some(default) = arg.default.as_mut() {
-                // Propagate name from the parameter to an anonymous decorated class default value
-                let prev_decorator_class_name = self.decorator_class_name;
-                if default.is_anonymous_named()
-                    && let ExprData::EClass(e_class) = &default.data
-                    && e_class.should_lower_standard_decorators
-                    && let BData::BIdentifier(id) = arg.binding.data
-                {
-                    self.decorator_class_name = Some(self.load_name_from_ref(id.r#ref));
-                }
-                self.visit_expr(default);
-                self.decorator_class_name = prev_decorator_class_name;
+                self.visit_binding_initializer(arg.binding, default);
             }
         }
+    }
+
+    /// Visits the initializer of a parameter, `for` loop declaration or destructuring
+    /// element. An anonymous class takes its name from the binding, but standard
+    /// decorator lowering rewrites it to `_class = class {}`, so the name is handed to
+    /// the lowering through `decorator_class_name` instead (see `e_class`).
+    pub(crate) fn visit_binding_initializer(
+        &mut self,
+        binding: BindingNodeIndex,
+        initializer: &mut Expr,
+    ) {
+        let prev_decorator_class_name = self.decorator_class_name;
+        if initializer.is_anonymous_named()
+            && let ExprData::EClass(e_class) = &initializer.data
+            && e_class.should_lower_standard_decorators
+            && let BData::BIdentifier(id) = binding.data
+        {
+            self.decorator_class_name = Some(self.load_name_from_ref(id.r#ref));
+        }
+        self.visit_expr(initializer);
+        self.decorator_class_name = prev_decorator_class_name;
     }
 
     // `Vec<Expr>` is not `Copy`; mutate in place.
@@ -586,7 +597,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 for dec in st.decls.slice_mut() {
                     self.visit_binding(dec.binding, None);
                     if let Some(val) = dec.value.as_mut() {
-                        self.visit_expr(val);
+                        self.visit_binding_initializer(dec.binding, val);
                     }
                 }
                 st.kind = self.select_local_kind(st.kind);
@@ -642,22 +653,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // Arena-owned B::Array valid for 'a; exclusive during visit pass.
                 for item in bind.items_mut() {
                     self.visit_binding(item.binding, duplicate_arg_check.as_deref_mut());
-                    if let Some(default_value) = item.default_value {
+                    if let Some(default_value) = item.default_value.as_mut() {
                         let was_anonymous_named_expr = default_value.is_anonymous_named();
-                        let prev_decorator_class_name2 = self.decorator_class_name;
-                        if was_anonymous_named_expr {
-                            if let ExprData::EClass(e_class) = &default_value.data {
-                                if e_class.should_lower_standard_decorators {
-                                    if let BData::BIdentifier(id) = item.binding.data {
-                                        let id = id.get();
-                                        self.decorator_class_name =
-                                            Some(self.load_name_from_ref(id.r#ref));
-                                    }
-                                }
-                            }
-                        }
-                        self.visit_expr(item.default_value.as_mut().unwrap());
-                        self.decorator_class_name = prev_decorator_class_name2;
+                        self.visit_binding_initializer(item.binding, default_value);
 
                         if let BData::BIdentifier(bind_) = item.binding.data {
                             let bind_ = bind_.get();
@@ -681,22 +679,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     }
 
                     self.visit_binding(property.value, duplicate_arg_check.as_deref_mut());
-                    if let Some(default_value) = property.default_value {
+                    if let Some(default_value) = property.default_value.as_mut() {
                         let was_anonymous_named_expr = default_value.is_anonymous_named();
-                        let prev_decorator_class_name3 = self.decorator_class_name;
-                        if was_anonymous_named_expr {
-                            if let ExprData::EClass(e_class) = &default_value.data {
-                                if e_class.should_lower_standard_decorators {
-                                    if let BData::BIdentifier(id) = property.value.data {
-                                        let id = id.get();
-                                        self.decorator_class_name =
-                                            Some(self.load_name_from_ref(id.r#ref));
-                                    }
-                                }
-                            }
-                        }
-                        self.visit_expr(property.default_value.as_mut().unwrap());
-                        self.decorator_class_name = prev_decorator_class_name3;
+                        self.visit_binding_initializer(property.value, default_value);
 
                         if let BData::BIdentifier(bind_) = property.value.data {
                             let bind_ = bind_.get();

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -227,27 +227,31 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             let dup: Option<&mut StringVoidMap> = duplicate_args_check.as_deref_mut();
             self.visit_binding(arg.binding, dup);
             if let Some(default) = arg.default.as_mut() {
-                self.visit_binding_initializer(arg.binding, default);
+                let prev_decorator_class_name = self.decorator_class_name;
+                self.decorator_class_name =
+                    self.decorator_class_name_from_binding(arg.binding, default);
+                self.visit_expr(default);
+                self.decorator_class_name = prev_decorator_class_name;
             }
         }
     }
 
-    /// Names an anonymous decorated class after the binding it initializes (`decorator_class_name`).
-    pub(crate) fn visit_binding_initializer(
-        &mut self,
+    /// The `.name` that `binding` gives an anonymous class initializer; lowering the class would lose it.
+    pub(crate) fn decorator_class_name_from_binding(
+        &self,
         binding: BindingNodeIndex,
-        initializer: &mut Expr,
-    ) {
-        let prev_decorator_class_name = self.decorator_class_name;
-        if initializer.is_anonymous_named()
-            && let ExprData::EClass(e_class) = &initializer.data
-            && e_class.should_lower_standard_decorators
-            && let BData::BIdentifier(id) = binding.data
-        {
-            self.decorator_class_name = Some(self.load_name_from_ref(id.r#ref));
+        value: &Expr,
+    ) -> Option<&'a [u8]> {
+        let ExprData::EClass(class) = value.data else {
+            return None;
+        };
+        if class.class_name.is_some() || !class.should_lower_standard_decorators {
+            return None;
         }
-        self.visit_expr(initializer);
-        self.decorator_class_name = prev_decorator_class_name;
+        let BData::BIdentifier(id) = binding.data else {
+            return None;
+        };
+        Some(self.load_name_from_ref(id.r#ref))
     }
 
     // `Vec<Expr>` is not `Copy`; mutate in place.
@@ -315,18 +319,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     !SCAN_ONLY,
                     "only_scan_imports_and_do_not_visit must not run this."
                 );
-                // Propagate name from binding to anonymous decorated class expressions
                 let prev_decorator_class_name = self.decorator_class_name;
-                if was_anonymous_named_expr {
-                    if let ExprData::EClass(e_class) = &val.data {
-                        if e_class.should_lower_standard_decorators {
-                            if let BData::BIdentifier(id) = decl.binding.data {
-                                let id = id.get();
-                                self.decorator_class_name = Some(self.load_name_from_ref(id.r#ref));
-                            }
-                        }
-                    }
-                }
+                self.decorator_class_name =
+                    self.decorator_class_name_from_binding(decl.binding, &val);
                 if self.react_compiler.is_some()
                     && self.current_scope == self.module_scope
                     && let BData::BIdentifier(id) = decl.binding.data
@@ -594,7 +589,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 for dec in st.decls.slice_mut() {
                     self.visit_binding(dec.binding, None);
                     if let Some(val) = dec.value.as_mut() {
-                        self.visit_binding_initializer(dec.binding, val);
+                        let prev_decorator_class_name = self.decorator_class_name;
+                        self.decorator_class_name =
+                            self.decorator_class_name_from_binding(dec.binding, val);
+                        self.visit_expr(val);
+                        self.decorator_class_name = prev_decorator_class_name;
                     }
                 }
                 st.kind = self.select_local_kind(st.kind);
@@ -652,7 +651,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     self.visit_binding(item.binding, duplicate_arg_check.as_deref_mut());
                     if let Some(default_value) = item.default_value.as_mut() {
                         let was_anonymous_named_expr = default_value.is_anonymous_named();
-                        self.visit_binding_initializer(item.binding, default_value);
+                        let prev_decorator_class_name = self.decorator_class_name;
+                        self.decorator_class_name =
+                            self.decorator_class_name_from_binding(item.binding, default_value);
+                        self.visit_expr(default_value);
+                        self.decorator_class_name = prev_decorator_class_name;
 
                         if let BData::BIdentifier(bind_) = item.binding.data {
                             let bind_ = bind_.get();
@@ -678,7 +681,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     self.visit_binding(property.value, duplicate_arg_check.as_deref_mut());
                     if let Some(default_value) = property.default_value.as_mut() {
                         let was_anonymous_named_expr = default_value.is_anonymous_named();
-                        self.visit_binding_initializer(property.value, default_value);
+                        let prev_decorator_class_name = self.decorator_class_name;
+                        self.decorator_class_name =
+                            self.decorator_class_name_from_binding(property.value, default_value);
+                        self.visit_expr(default_value);
+                        self.decorator_class_name = prev_decorator_class_name;
 
                         if let BData::BIdentifier(bind_) = property.value.data {
                             let bind_ = bind_.get();

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -227,7 +227,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             let dup: Option<&mut StringVoidMap> = duplicate_args_check.as_deref_mut();
             self.visit_binding(arg.binding, dup);
             if let Some(default) = arg.default.as_mut() {
+                // Propagate name from the parameter to an anonymous decorated class default value
+                let prev_decorator_class_name = self.decorator_class_name;
+                if default.is_anonymous_named()
+                    && let ExprData::EClass(e_class) = &default.data
+                    && e_class.should_lower_standard_decorators
+                    && let BData::BIdentifier(id) = arg.binding.data
+                {
+                    self.decorator_class_name = Some(self.load_name_from_ref(id.r#ref));
+                }
                 self.visit_expr(default);
+                self.decorator_class_name = prev_decorator_class_name;
             }
         }
     }

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -982,11 +982,11 @@ describe("ES Decorators", () => {
     });
   });
 
-  describe("anonymous decorated class as a parameter default value", () => {
+  describe("anonymous decorated class as a binding initializer", () => {
     // The lowering rewrites the class to `_class = class {}`, so the name the
-    // parameter would have given it has to be carried over explicitly, the same
-    // way it is for `const K = class {}` and destructuring defaults. Expected
-    // values match node running the same code with the decorators removed.
+    // binding would have given it has to be carried over explicitly, the same
+    // way it already is for `const K = class {}`. Expected values match node
+    // running the same code with the decorators removed.
     test.concurrent("takes the parameter name in every kind of parameter list", async () => {
       const { stdout, stderr, exitCode } = await runDecorator(`
         function dec() {}
@@ -1004,7 +1004,8 @@ describe("ES Decorators", () => {
           set setter(K = class { @dec m() {} }) { this.fromSetter = K.name; },
         };
         obj.setter = undefined;
-        function destructured({ K = class { @dec m() {} } } = {}) { return K.name; }
+        function objectPattern({ K = class { @dec m() {} } } = {}) { return K.name; }
+        function arrayPattern([K = class { @dec m() {} }] = []) { return K.name; }
         console.log(JSON.stringify({
           declaration: declaration(),
           expression: expression(),
@@ -1015,7 +1016,8 @@ describe("ES Decorators", () => {
           staticMethod: C.staticMethod(),
           objectMethod: obj.method(),
           setter: obj.fromSetter,
-          destructured: destructured(),
+          objectPattern: objectPattern(),
+          arrayPattern: arrayPattern(),
         }));
       `);
       expect(stderr).toBe("");
@@ -1029,8 +1031,24 @@ describe("ES Decorators", () => {
         staticMethod: "K",
         objectMethod: "K",
         setter: "K",
-        destructured: "K",
+        objectPattern: "K",
+        arrayPattern: "K",
       });
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("takes the variable name in a for loop declaration", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() {}
+        const names = [];
+        for (const K = class { @dec m() {} }; names.length < 1; ) names.push(K.name);
+        for (let K = class { @dec m() {} }, L = class { accessor x; }; names.length < 3; ) names.push(K.name, L.name);
+        for (var V = class { @dec m() {} }; names.length < 4; ) names.push(V.name);
+        for (const [D = class { @dec m() {} }] = []; names.length < 5; ) names.push(D.name);
+        console.log(JSON.stringify(names));
+      `);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual(["K", "K", "L", "V", "D"]);
       expect(exitCode).toBe(0);
     });
 

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -982,6 +982,119 @@ describe("ES Decorators", () => {
     });
   });
 
+  describe("anonymous decorated class as a parameter default value", () => {
+    // The lowering rewrites the class to `_class = class {}`, so the name the
+    // parameter would have given it has to be carried over explicitly, the same
+    // way it is for `const K = class {}` and destructuring defaults. Expected
+    // values match node running the same code with the decorators removed.
+    test.concurrent("takes the parameter name in every kind of parameter list", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() {}
+        function declaration(K = class { @dec m() {} }) { return K.name; }
+        const expression = function (K = class { @dec m() {} }) { return K.name; };
+        const arrow = (K = class { @dec m() {} }) => K.name;
+        function secondParameter(first, K = class { @dec m() {} }) { return K.name; }
+        class C {
+          constructor(K = class { @dec m() {} }) { this.fromConstructor = K.name; }
+          method(K = class { @dec m() {} }) { return K.name; }
+          static staticMethod(K = class { @dec m() {} }) { return K.name; }
+        }
+        const obj = {
+          method(K = class { @dec m() {} }) { return K.name; },
+          set setter(K = class { @dec m() {} }) { this.fromSetter = K.name; },
+        };
+        obj.setter = undefined;
+        function destructured({ K = class { @dec m() {} } } = {}) { return K.name; }
+        console.log(JSON.stringify({
+          declaration: declaration(),
+          expression: expression(),
+          arrow: arrow(),
+          secondParameter: secondParameter(1),
+          constructorParameter: new C().fromConstructor,
+          method: new C().method(),
+          staticMethod: C.staticMethod(),
+          objectMethod: obj.method(),
+          setter: obj.fromSetter,
+          destructured: destructured(),
+        }));
+      `);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual({
+        declaration: "K",
+        expression: "K",
+        arrow: "K",
+        secondParameter: "K",
+        constructorParameter: "K",
+        method: "K",
+        staticMethod: "K",
+        objectMethod: "K",
+        setter: "K",
+        destructured: "K",
+      });
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("class decorator sees the parameter name as context.name", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(cls, ctx) { console.log("ctx.name:", JSON.stringify(ctx.name)); }
+        function f(K = @dec class {}) { return K.name; }
+        console.log(JSON.stringify(f()));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe('ctx.name: "K"\n"K"\n');
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("class with an accessor and no decorators is lowered too", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function f(K = class { accessor x = 1; }) { return [K.name, new K().x]; }
+        console.log(JSON.stringify(f()));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe('["K",1]\n');
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("parameter name does not override an explicit class name or reach a nested class", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() {}
+        function named(K = class Named { @dec m() {} }) { return K.name; }
+        function nested(K = [class { @dec m() {} }][0]) { return K.name; }
+        function passed(K = class { @dec m() {} }) { return K.name; }
+        console.log(JSON.stringify([named(), nested(), passed(class Passed {})]));
+      `);
+      expect(stderr).toBe("");
+      const [named, nested, passed] = JSON.parse(stdout);
+      expect(named).toBe("Named");
+      expect(nested).not.toBe("K");
+      expect(passed).toBe("Passed");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("TypeScript constructor parameter property", async () => {
+      using dir = tempDir("es-dec-param-property", {
+        "tsconfig.json": JSON.stringify({ compilerOptions: {} }),
+        "test.ts": `
+          function dec(value: unknown, ctx: ClassMethodDecoratorContext) {}
+          class Holder {
+            constructor(public K = class { @dec m() {} }) {}
+          }
+          console.log(new Holder().K.name);
+        `,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(filterStderr(rawStderr)).toBe("");
+      expect(stdout).toBe("K\n");
+      expect(exitCode).toBe(0);
+    });
+  });
+
   describe("private member calls in lowered classes", () => {
     // When a class is lowered for standard decorators, `recv.#m(...)` becomes
     // `__privateGet(recv, _m).call(recv, ...)`. The receiver must be evaluated


### PR DESCRIPTION
### Problem

- With standard (TC39) decorators, an anonymous class expression used directly as the initializer of a parameter or of a `for` loop declaration ends up named `"_class"`:
  ```js
  function dec() {}
  function f(K = class { @dec m() {} }) { return K.name; }
  console.log(f()); // bun 1.4.0: "_class"    node, decorators removed: "K"
  for (const L = class { @dec m() {} }; ; ) { console.log(L.name); break; } // "_class", node: "L"
  ```
  The parameter form misbehaves the same way in function expressions, arrows, methods, setters and constructors (including TypeScript parameter properties), with a class decorator on the default (`K.name` and the decorator's `context.name` are both `""`), and for an `accessor`-only class with no decorators at all, which goes through the same lowering. Destructuring defaults (`function f({ K = class { @dec m() {} } } = {})`), `const K = ...`, `K = ...`, object keys and class fields were already right.
- Cause: the lowering rewrites the expression to `_class = class {}, __decorateElement(...), _class` (`lower_impl`, `src/js_parser/lower/lower_decorators.rs:1145`), which on its own would name the class after the temporary, so it relies on the visitor having recorded the name the source position gives the class in `p.decorator_class_name`. `visit_decls`, `visit_binding` (destructuring defaults), `visit_binary`, `visit_class` and the `export default` path set it. Two sites that visit a binding's initializer did not: `visit_args` (parameter defaults) and the `SLocal` arm of `visit_for_loop_init`, which iterates a `for (;;)` head's declarations itself instead of going through `visit_decls`.

### Fix

- The check that `visit_decls` and the two destructuring arms of `visit_binding` each had inline becomes `decorator_class_name_from_binding(binding, value) -> Option<&[u8]>`: the binding's name when the binding is a plain identifier and the value is an anonymous class that will be lowered, `None` otherwise. Those three sites and the two missing ones assign its result to `decorator_class_name` around the visit and restore the previous value afterwards. It returns the name rather than doing the visit itself so that `visit_decls`, which visits through `visit_expr_in_out`, can use it too, and so it has the same shape as the `decorator_class_name_from_key` helper #38787 adds for property keys.
- This is correct because a binding's initializer is one of the positions where the language names an anonymous class after the binding (see Background), and that applies to a parameter or a `for` head declaration exactly as it does to the `const` and destructuring cases that already worked; so the binding's name is the name the class has without lowering, which is what node prints. The guard keeps everything else unchanged: a named class, a class that is not lowered, or a class nested inside some other initializer (`K = [class { @dec m() {} }][0]`) gets `None`, and `e_class` clears the field before visiting the class body, so it cannot leak into nested classes. At the three converted sites the conditions are the ones that were inline before; the only difference is that a non-matching value now stores `None` instead of leaving the field alone, and every writer of the field only sets it immediately before visiting the class that consumes it, so it is already `None` whenever these sites run. Every parameter list (functions, arrows, methods, accessors, constructors) is visited through `visit_args`, so that one call covers all of them.
- Merge order: the lowering applies the recorded name by giving the class expression a binding of that name, which shadows the variable inside the class body. At the two new positions this PR therefore reproduces what `const K = ...` does today: a body that refers to the parameter while a class decorator replaces the class, or after the parameter is reassigned, sees the original class, and `bun build` renames the binding (`K2`). #38757 replaces that binding with a `__name` call for every context and still reads `decorator_class_name`, so this propagation is needed with or without it; merged on top of this branch locally, the probes for those shapes match node (details below). Landing #38757 first avoids the intermediate state, if convenient.
- Not touched here: `??=`, `||=` and `&&=` have the same gap at the assignment site in `visit_binary` (#38924), and the remaining inline copies that derive the name from an assignment target or `export default` are a separate cleanup.
- Verification, `test/bundler/transpiler/es-decorators.test.ts`, new `anonymous decorated class as a binding initializer` block: every kind of parameter list plus object and array destructuring defaults (the converted `visit_binding` sites), `const`/`let`/`var`/destructuring declarations in a `for` head, a class decorator's `context.name`, an `accessor`-only class, a TypeScript parameter property, and a guard test (explicit class name kept, nested class not renamed, explicitly passed argument unaffected). Expected values match node 26 running the same code with the decorators removed. Five of the six tests fail on the unfixed build (`"_class"` or `""`); with the fix all 65 tests in the file pass. The converted `visit_decls` site is covered by the existing `const X = class { @dec ... }` tests in this file and `es-decorators-esbuild.test.ts`.
  - Also run with the fix: `es-decorators-esbuild.test.ts`, `decorators.test.ts`, `decorator-metadata.test.ts`, `bundler_decorator_metadata.test.ts`, `regression/issue/27575.test.ts`, `transpiler.test.js`, `esbuild/ts.test.ts`, `esbuild/default.test.ts`, `esbuild/lower.test.ts`, `bundler_naming.test.ts`: 603 pass, 0 fail.
  - `cargo clippy -p bun_js_parser` is clean.

### Background

- Name inference: an anonymous function or class expression takes its `.name` from the position it appears in, provided it appears there directly. The positions are a variable initializer (`const K = class {}`, including in a `for` head), an assignment (`K = class {}`), a property value (`{ K: class {} }`), `export default`, and the initializer of a binding named `K`, whether that binding is a destructuring element or a plain parameter. Wrapping the class in something else (an array literal, an assignment to a temporary) gives it that context's name instead, or none.
- Standard decorator lowering: a class with decorators or `accessor` members (`should_lower_standard_decorators`, decided at parse time) is rewritten into `_class = class { ... }` followed by `__decorateElement(...)` calls. Since the class is now assigned to `_class`, the visitor records the source position's name in `p.decorator_class_name` before visiting the class expression; `e_class` in `visit_expr.rs` takes it (and clears the field) and passes it to the lowering as `name_from_context`, which uses it for the class's name and for the class decorator's `context.name`.
- Open PRs on the same mechanism: #38757 changes how the recorded name is applied (see merge order above), #38758 covers `export default`, #38787 adds the key-derived counterpart of this helper, #38924 covers logical assignment, and #38904 adds bookkeeping around the loop in `visit_args`. None of them changes the sites edited here; #38787 and this PR merge cleanly apart from both appending tests at the same spot. The `"_class"` fallback for a class with no naming context at all (the nested case above; node prints `""`) belongs to #38757 and is not changed here.

<details>
<summary>Emitted code for the repro, before and after</summary>

Before:

```js
function f(K = (_dec = [dec], _init = __decoratorStart(undefined), _class = class {
  constructor() { __runInitializers(_init, 5, this); }
  m() {}
}, __decorateElement(_init, 1, "m", _dec, _class), __decoratorMetadata(_init, _class), _class)) {
  return K.name;
}
```

After:

```js
function f(K = (_dec = [dec], _init = __decoratorStart(undefined), _class = class K {
  constructor() { __runInitializers(_init, 5, this); }
  m() {}
}, __decorateElement(_init, 1, "m", _dec, _class), __decoratorMetadata(_init, _class), _class)) {
  return K.name;
}
```

This is the same shape destructuring defaults and `const K = class { @dec m() {} }` already produce.

</details>

<details>
<summary>Shadowing probe, with and without #38757</summary>

```js
function dec() {}
function replace(cls) { return class Replacement extends cls {}; }
function a(K = class { @dec m() { return K; } }) { return new K().m() === K; }
function b(K = @replace class { m() { return K; } }) { return new K().m() === K; }
function c(K = class { @dec m() { return K; } }) { const C = K; K = 1; return new C().m(); }
// d: the same three shapes written as `const K = ...` / `let K = ...` in a block
```

| | a | b | c | d (const/let contexts) |
|---|---|---|---|---|
| node (decorators removed) | true | true | 1 | true, true, 1 |
| bun 1.4.0 | true | true | 1 | true, false, class |
| this PR | true | false | class | true, false, class |
| this PR + #38757 merged locally | true | true | 1 | true, true, 1 |

With #38757 applied on top, the combined `es-decorators.test.ts` (this PR's tests and its own) passes, 73 tests.

</details>
