### PR TITLE
jsc: get_length returns 0 for objects without a length property; bun:test reads callback arity before wrapping it

### DIFF
--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -1401,16 +1401,16 @@ impl JSValue {
     pub fn get_index(self, global: &JSGlobalObject, i: u32) -> JsResult<JSValue> {
         JSObject::get_index(self, global, i)
     }
+    /// [`Self::get_length_if_property_exists`] as an integer: 0 when there is
+    /// no length (or the Blob's size is unknown), otherwise clamped to i52.
     pub fn get_length(self, global: &JSGlobalObject) -> JsResult<u64> {
-        let len = host_fn::from_js_host_call_generic(global, || {
-            JSC__JSValue__getLengthIfPropertyExistsInternal(self, global)
-        })?;
-        if len == f64::MAX {
-            return Ok(0);
-        }
-        // Clamps to i52 max (2^51 − 1), not MAX_SAFE_INTEGER.
         const I52_MAX: i64 = (1i64 << 51) - 1;
-        Ok(len.clamp(0.0, I52_MAX as f64) as u64)
+        Ok(match self.get_length_if_property_exists(global)? {
+            None => 0,
+            Some(len) if len == Self::UNKNOWN_BLOB_SIZE => 0,
+            // NaN clamps to NaN, which casts to 0.
+            Some(len) => len.clamp(0.0, I52_MAX as f64) as u64,
+        })
     }
     /// Set a property. Key dispatch goes through the [`PutKey`] trait so
     /// callers may pass `&[u8]`, `ZigString`, `&ZigString`, `bun.String`, or
@@ -2879,13 +2879,18 @@ impl JSValue {
     }
 
     // ── Length introspection. ──────────────────────────
-    /// `JSValue.getLengthIfPropertyExistsInternal` — returns `f64::MAX` when
-    /// no `length`-ish property exists. Do not call directly; prefer
-    /// [`JSValue::get_length`].
-    pub fn get_length_if_property_exists_internal(self, global: &JSGlobalObject) -> JsResult<f64> {
-        host_fn::from_js_host_call_generic(global, || {
+    /// Reported by the C++ side for a Blob whose size is not known (unseekable or missing file).
+    const UNKNOWN_BLOB_SIZE: f64 = f64::MAX;
+
+    /// `JSValue.getLengthIfPropertyExistsInternal` — string/array/typed array
+    /// length, Map/Set/Headers/Blob size, or any other object's `length` as a
+    /// number (possibly NaN). `None` when there is no such length, which the
+    /// C++ side reports as `+Infinity` (so `{length: Infinity}` is `None` too).
+    pub fn get_length_if_property_exists(self, global: &JSGlobalObject) -> JsResult<Option<f64>> {
+        let len = host_fn::from_js_host_call_generic(global, || {
             JSC__JSValue__getLengthIfPropertyExistsInternal(self, global)
-        })
+        })?;
+        Ok((len != f64::INFINITY).then_some(len))
     }
 
     // ── Path lookup. ───────────────────────────────────

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2801,6 +2801,7 @@ double JSC__JSValue__getLengthIfPropertyExistsInternal(JSC::EncodedJSValue value
     }
     }
 
+    // No length at all; JSValue::get_length_if_property_exists (Rust) decodes this as None.
     return std::numeric_limits<double>::infinity();
 }
 

--- a/src/runtime/test_runner/ScopeFunctions.rs
+++ b/src/runtime/test_runner/ScopeFunctions.rs
@@ -329,6 +329,9 @@ impl ScopeFunctions {
     ) -> JsResult<()> {
         let _g = group_log::begin();
 
+        // Wrapped only now: the caller reads `.length` / `.bind()` off the bare function, and the wrapper has neither.
+        let callback = callback.map(|cb| cb.with_async_context_if_needed(global));
+
         // only allow in collection phase
         match bun_test.phase {
             bun_test::Phase::Collection => {} // ok
@@ -519,6 +522,7 @@ fn error_in_ci(global: &JSGlobalObject, signature: &[u8]) -> JsResult<()> {
 
 pub struct ParseArgumentsResult {
     pub(crate) description: Option<Vec<u8>>,
+    /// The function as passed by the user; whoever stores it applies `with_async_context_if_needed`.
     pub callback: Option<JSValue>,
     pub(crate) options: ParseArgumentsOptions,
 }
@@ -667,7 +671,7 @@ pub(crate) fn parse_arguments(
     let result_callback: Option<JSValue> = if cfg.callback != CallbackMode::Require && callback.is_undefined_or_null() {
         None
     } else if callback.is_function() {
-        Some(callback.with_async_context_if_needed(global))
+        Some(callback)
     } else {
         let ordinal = if cfg.kind == FunctionKind::Hook { "first" } else { "second" };
         return Err(global.throw(format_args!("{} expects a function as the {} argument", signature, ordinal)));

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -186,6 +186,11 @@ pub mod js_fns {
                 false
             };
 
+            // Wrapped only after reading `.length`: the wrapper has none.
+            let callback = args
+                .callback
+                .map(|cb| cb.with_async_context_if_needed(global_this));
+
             let bun_test_root = get_active_test_root(
                 global_this,
                 &GetActiveCfg { signature: Signature::Str(sig_bytes), allow_in_preload: true },
@@ -208,7 +213,7 @@ pub mod js_fns {
 
                 let _ = bun_test_root.hook_scope.append_hook(
                     tag.as_hook_tag().unwrap(),
-                    args.callback,
+                    callback,
                     cfg,
                     BaseScopeCfg::default(),
                     AddedInPhase::Preload,
@@ -226,7 +231,7 @@ pub mod js_fns {
                     }
                     let _ = bun_test.collection.active_scope_mut().append_hook(
                         tag.as_hook_tag().unwrap(),
-                        args.callback,
+                        callback,
                         cfg,
                         BaseScopeCfg::default(),
                         AddedInPhase::Collection,
@@ -299,7 +304,7 @@ pub mod js_fns {
 
                     let new_item = ExecutionEntry::create(
                         None,
-                        args.callback,
+                        callback,
                         cfg,
                         None,
                         BaseScopeCfg::default(),

--- a/src/runtime/test_runner/expect/toBeEmpty.rs
+++ b/src/runtime/test_runner/expect/toBeEmpty.rs
@@ -16,9 +16,9 @@ pub(crate) fn to_be_empty(
     let mut formatter = super::make_formatter(global);
     // `defer formatter.deinit()` — handled by Drop.
 
-    let actual_length = value.get_length_if_property_exists_internal(global)?;
+    let actual_length = value.get_length_if_property_exists(global)?;
 
-    if actual_length == f64::INFINITY {
+    if actual_length.is_none() {
         if value.js_type_loose().is_object() {
             if value.is_iterable(global)? {
                 let mut any_properties_in_iterator = false;
@@ -71,13 +71,13 @@ pub(crate) fn to_be_empty(
                 value.to_fmt(&mut formatter)
             );
         }
-    } else if actual_length.is_nan() {
+    } else if let Some(actual_length) = actual_length.filter(|len| len.is_nan()) {
         return Err(global.throw(format_args!(
             "Received value has non-number length property: {}",
             actual_length
         )));
     } else {
-        pass = actual_length == 0.0;
+        pass = actual_length == Some(0.0);
     }
 
     if not && pass {

--- a/src/runtime/test_runner/expect/toHaveLength.rs
+++ b/src/runtime/test_runner/expect/toHaveLength.rs
@@ -51,15 +51,15 @@ pub(crate) fn to_have_length(
 
     let mut pass = false;
 
-    let actual_length = value.get_length_if_property_exists_internal(global)?;
-
-    if actual_length == f64::INFINITY {
+    let Some(actual_length) = value.get_length_if_property_exists(global)? else {
         let mut fmt = super::make_formatter(global);
         return Err(global.throw(format_args!(
             "Received value does not have a length property: {}",
             value.to_fmt(&mut fmt),
         )));
-    } else if actual_length.is_nan() {
+    };
+
+    if actual_length.is_nan() {
         return Err(global.throw(format_args!(
             "Received value has non-number length property: {}",
             actual_length,

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -182,6 +182,26 @@ test("object destructuring of a macro result keeps every bound property regardle
   expect(exitCode).toBe(0);
 });
 
+// An arguments object is converted to an array expression by walking it up to its length. With
+// `length` deleted it has none and must convert to an empty array; the length used to come back as
+// 2^51 - 1, which sized the array expression at 2^32 - 1 items and walked every index.
+test("macro returning an arguments object without a length property becomes an empty array", async () => {
+  using dir = tempDir("macro-arguments-without-length", {
+    "m.ts": `export function m() {\n  delete arguments.length;\n  return arguments;\n}\n`,
+    "index.ts": `import { m } from "./m.ts" with { type: "macro" };\nconsole.log(JSON.stringify(m()));\n`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", "index.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ lastLine: stdout.trim().split("\n").pop(), stderr }).toEqual({ lastLine: "[]", stderr: "" });
+  expect(exitCode).toBe(0);
+});
+
 describe("--no-macros", () => {
   const files = {
     "macro.ts": `

--- a/test/js/bun/test/als-hook-arity.fixture.ts
+++ b/test/js/bun/test/als-hook-arity.fixture.ts
@@ -1,0 +1,83 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { AsyncLocalStorage } from "node:async_hooks";
+
+// When a test or hook is registered while an AsyncLocalStorage context is
+// active, bun:test wraps the callback in an AsyncContextFrame so the context
+// is restored at call time. The wrapper has no `.length` and is not itself
+// callable via JSC::getCallData, so `.length` (done-param detection) and
+// `.bind()` (test.each) must be read from the user's function before wrapping.
+
+const als = new AsyncLocalStorage<{ tag: string }>();
+const order: string[] = [];
+const mark = (label: string) => order.push(`${label}:${als.getStore()?.tag ?? "none"}`);
+
+describe("registered inside an active ALS context", () => {
+  als.run({ tag: "ctx" }, () => {
+    beforeAll(function zeroArg() {
+      mark("beforeAll");
+    });
+    beforeEach(function zeroArg() {
+      mark("beforeEach");
+    });
+    afterEach(function zeroArg() {
+      mark("afterEach");
+    });
+    afterAll(function zeroArg() {
+      mark("afterAll");
+    });
+    afterAll(function withDone(done) {
+      mark("afterAll-done");
+      setImmediate(done);
+    });
+
+    test("zero-arg test", function zeroArg() {
+      mark("zero-arg test");
+    });
+
+    test("one-arg test still receives done", function withDone(done) {
+      mark("done test");
+      expect(typeof done).toBe("function");
+      setImmediate(done);
+    });
+
+    test.each([[1], [2]])("each %p", function withArg(n) {
+      mark(`each ${n}`);
+    });
+
+    describe("nested describe", function zeroArg() {
+      mark("nested.body");
+      afterAll(function zeroArg() {
+        mark("nested.afterAll");
+      });
+      test("passes", function zeroArg() {
+        mark("nested.test");
+      });
+    });
+  });
+});
+
+test("hooks and tests registered inside an ALS context use the callback's real arity and restore the context", () => {
+  // Every entry ran inside the restored `{ tag: "ctx" }` store, in order.
+  expect(order).toEqual([
+    "nested.body:ctx",
+    "beforeAll:ctx",
+    "beforeEach:ctx",
+    "zero-arg test:ctx",
+    "afterEach:ctx",
+    "beforeEach:ctx",
+    "done test:ctx",
+    "afterEach:ctx",
+    "beforeEach:ctx",
+    "each 1:ctx",
+    "afterEach:ctx",
+    "beforeEach:ctx",
+    "each 2:ctx",
+    "afterEach:ctx",
+    "beforeEach:ctx",
+    "nested.test:ctx",
+    "afterEach:ctx",
+    "nested.afterAll:ctx",
+    "afterAll:ctx",
+    "afterAll-done:ctx",
+  ]);
+});

--- a/test/js/bun/test/als-hook-arity.test.ts
+++ b/test/js/bun/test/als-hook-arity.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, normalizeBunSnapshot } from "harness";
+import path from "node:path";
+
+// Registering a zero-arg test() or hook inside an active AsyncLocalStorage
+// context used to be treated as taking a done callback (the AsyncContextFrame
+// wrapper has no `.length`), so the callback would wait for done() and time
+// out; test.each() threw "bind() called on non-callable" on the same wrapper.
+// Run the fixture with a short per-test timeout so the unfixed build fails
+// fast rather than sitting on the 5s default for each entry.
+test("tests and hooks registered inside an AsyncLocalStorage context detect done-callback arity correctly", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--timeout=500", path.join(import.meta.dir, "als-hook-arity.fixture.ts")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(normalizeBunSnapshot(stderr)).toMatchInlineSnapshot(`
+    "test/js/bun/test/als-hook-arity.fixture.ts:
+    (pass) registered inside an active ALS context > zero-arg test
+    (pass) registered inside an active ALS context > one-arg test still receives done
+    (pass) registered inside an active ALS context > each 1
+    (pass) registered inside an active ALS context > each 2
+    (pass) registered inside an active ALS context > nested describe > passes
+    (pass) hooks and tests registered inside an ALS context use the callback's real arity and restore the context
+
+     6 pass
+     0 fail
+     2 expect() calls
+    Ran 6 tests across 1 file."
+  `);
+  expect(stdout).toStartWith("bun test ");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -2375,6 +2375,10 @@ describe("expect()", () => {
       // if a file doesn't exist, it should throw (not return 0 size)
       expect(() => expect(Bun.file(tmpFile(false))).toHaveLength(0)).toThrow();
 
+      // objects without a length, or with one that is not a number
+      expect(() => expect({}).toHaveLength(0)).toThrow("Received value does not have a length property");
+      expect(() => expect({ length: "abc" }).toHaveLength(0)).toThrow("Received value has non-number length property");
+
       // Blob
       expect(new Blob(ANY([1, 2, 3]))).toHaveLength(3);
       expect(new Blob()).toHaveLength(0);
@@ -3762,6 +3766,13 @@ describe("expect()", () => {
       });
     }
   });
+
+  if (isBun) {
+    test("toBeEmpty() on objects with a non-number length property", () => {
+      expect(() => expect({ length: "abc" }).toBeEmpty()).toThrow("Received value has non-number length property");
+      expect(() => expect({ length: "abc" }).not.toBeEmpty()).toThrow("Received value has non-number length property");
+    });
+  }
 
   test("toBeEmptyObject()", () => {
     // Map and Set are not considered as object in jest-extended

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -678,6 +678,38 @@ it("console.log on a arguments shows list", () => {
   fn(1, [1], fn);
 });
 
+// An arguments object is printed like an array, but unlike an array its `length` can be
+// deleted. The formatter must then treat it as empty instead of probing index after index
+// (it used to see a length of 2^51 - 1). Run it in a child so a regression times this test
+// out instead of hanging the runner.
+it("Bun.inspect treats an arguments object without a length property as empty", async () => {
+  const code = `
+    const element = children => ({ $$typeof: Symbol.for("react.element"), type: "div", props: { children } });
+    const out = (function () {
+      delete arguments.length;
+      return {
+        args: Bun.inspect(arguments),
+        jsxWithArgsChildren: Bun.inspect(element(arguments)),
+        jsxWithEmptyChildren: Bun.inspect(element([])),
+      };
+    })();
+    console.log(JSON.stringify(out));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const out = JSON.parse(stdout);
+  expect(out.args).toBe("[]");
+  // A length-less children object formats exactly like `children: []`, however that is rendered.
+  expect(out.jsxWithArgsChildren).toBe(out.jsxWithEmptyChildren);
+  expect(exitCode).toBe(0);
+});
+
 it("console.log on null prototype", () => {
   expect(Bun.inspect(Object.create(null))).toBe("[Object: null prototype] {}");
 });


### PR DESCRIPTION
Closes #35334 (its change is the second commit here, rebased; see Fix).
Merge #38902 first (see Problem, last bullet).

### Problem
- Found by inspection while auditing the bindings, not from a user report.
- `JSValue::get_length` returns `2^51 - 1` for any object that has no `length` property. Consumers that walk a value up to its length then probe billions of indexes: `console.log(arguments)` / `Bun.inspect(arguments)` after `delete arguments.length` never returns (`print_array`, `src/jsc/ConsoleObject.rs:4322`), and a macro returning such an object sizes its array expression at `2^32 - 1` items and walks them all (`src/js_parser_jsc/Macro.rs:700`).
- Cause: `JSC__JSValue__getLengthIfPropertyExistsInternal` (`src/jsc/bindings/bindings.cpp:2804`) signals "no length property" by returning `+infinity`; `double max` is only returned for a Blob whose size is unknown. `get_length` (`src/jsc/JSValue.rs:1408`) mapped only `f64::MAX` to 0 and clamped everything else, and the doc comment on the wrapper described the `f64::MAX` contract. The Zig version had the same mismatch, so this is long-standing, not a port regression. `toHaveLength()` and `toBeEmpty()`, the only other users of the binding, compare against `+infinity` and were right.
- Two places were silently relying on the wrong value, which is why this is more than a one-line PR:
  - `node:test` registers every test and hook declared inside a `describe()` body from within `AsyncLocalStorage.run()`, so bun:test wrapped the callback in an `AsyncContextFrame` before reading its `.length`. The wrapper has no `length`; the `2^51 - 1` was the only reason those `(done) =>` runners were handed a `done` callback. With only the `get_length` change, 7 tests in `test/js/node/test_runner/node-test.test.ts` fail with `TypeError: done is not a function` (output in the details block). This is the bug #35334 fixes from the bun:test side.
  - bake's `app.plugins` / `framework.plugins` are not validated as arrays; a single plugin object passed there is rejected today only because its bogus length makes the loop read `undefined`. After this change it would be silently ignored, so #38902 (adds the validation) should land before this.

### Fix
- First commit: the Rust wrapper decodes the sentinel once and returns `Option<f64>` (`get_length_if_property_exists`, renamed from `..._internal`); `get_length` maps `None` (and the unknown-Blob-size value) to 0, and `toHaveLength()` / `toBeEmpty()` match on the `Option` instead of comparing against the sentinel themselves. The C++ is unchanged apart from a comment. Correct because `+infinity` is the contract the C++ has always implemented, and "no length returns 0" is what `get_length` has documented since it was introduced; moving the decoding into the one wrapper every caller goes through is what keeps this from recurring. I audited the `get_length` / `array_iterator` callers: apart from the ones named here and in the details block they all check `is_array` first and cannot observe the change.
- Second commit: bun:test reads `.length` (and, for `test.each`, calls `.bind()`) on the function the user passed and applies `with_async_context_if_needed` where the callback is stored, which still runs synchronously inside the caller's `als.run()` body, so the captured context is unchanged. This is #35334 rebased onto current main (that PR no longer applies cleanly); merging this closes it. #38880 relocates the same wrap for its own reasons and will rebase onto whichever of the two lands first.
- Verified with:
  - `test/js/bun/util/inspect.test.js`: arguments object with `length` deleted formats as `[]`, and as JSX children formats the same as `children: []`. Times out on the released bun, passes here.
  - `test/bundler/transpiler/macro-test.test.ts`: macro returning such an object becomes `[]`. Times out on the released bun, passes here.
  - `test/js/bun/test/expect.test.js`: `toHaveLength()` on an object without a length / with a non-number length, `toBeEmpty()` with a non-number length (the matcher branches the first commit rewrites; behavior unchanged).
  - `test/js/bun/test/als-hook-arity.test.ts` (from #35334): zero-arg, `done` and `test.each` entries registered under an active ALS context, plus context restoration. Fails on the released bun; the `done` cases are the ones the first commit alone would break.
  - `test/js/node/test_runner/node-test.test.ts`: 7 failures with the first commit alone, 45/45 with both.
  - Also green: `expect.test.js`, `jest-extended.test.js`, `mock-fn.test.js`, `bun_test.test.ts`, `jest-hooks.test.ts`, `jest-each.test.ts`, `test-test.test.ts`, `console-table.test.ts`, `spawn-large-array-length.test.ts`, several `test/js/node/test/parallel/test-runner-*.js` (one wall-clock assertion in `test-runner-mock-timers-scheduler.js` is too slow for the debug build and passes on a release build).

### Background
- `get_length` is bun's internal "how many elements does this array-like have" helper. The C++ side returns a real length for strings, arrays, typed arrays, `ArrayBuffer`, Map/Set, Headers and Blob, and for any other object reads its `length` property. Since it returns a `double`, the absence of a `length` has to be encoded as a sentinel value; the bug was that the two sides disagreed on which value that is.
- An `AsyncContextFrame` is the object bun wraps a callback in when an `AsyncLocalStorage` context is active at registration time, so the context can be restored when the callback eventually runs. It is an internal object, not a function: it has no `length` and cannot be `bind()`-ed.
- bun:test decides whether a test or hook callback takes a `done` callback by reading the callback's `.length`: arity 0 is simply called, arity 1 is handed `done` and waited on.
- `arguments` objects are the way to hit "array-like without a length" from JS: the formatter and the macro converter treat them as arrays, and unlike a real array their `length` property is configurable.

<details>
<summary>node:test with only the get_length change</summary>

```
TypeError: done is not a function. (In 'done()', 'done' is undefined)
      at <anonymous> (node:test:2139:78)
...
(fail) node:test > should run hooks in the right order
(fail) node:test > should run basic tests
(fail) node:test > should run tests with different variations
(fail) node:test > should run async tests
(fail) node:test > should run all tests from multiple files
(fail) node:test > should treat only as a no-op instead of using bun:test's CI-banned only()
(fail) node:test > should capture plan at first t.assert access and resolve subtests started after their parent finished
 38 pass
 7 fail
```

</details>

<details>
<summary>Other callers whose behavior changes, and pre-existing issues found during the audit</summary>

- `Bun.spawn({cmd: {}})` now throws "cmd must not be empty" instead of "cmd array is too large". Neither message is right because the options form never checks that `cmd` is an array (`Bun.spawnSync({cmd: "ls"})` tries to run `l`); reported separately.
- `Bun.inspect` of a React element whose `children` is `[]` or `""` prints an unterminated `<div`; a length-less `children` object now takes that same path. Reported separately; the inspect test here compares against the `children: []` output instead of pinning it.
- `{length: Infinity}` was already indistinguishable from "no length" for `toHaveLength()`; it now also reads as 0 in `get_length` (previously `2^51 - 1`). An arguments object with an explicit huge finite `length` still makes the formatter probe every index, as before.
- `bun:internal-for-testing`'s `isArchitectureMatch` / `isOperatingSystemMatch` given a non-array used to spin; they now return immediately.
- A Blob of unknown size still reports `f64::MAX` through `get_length_if_property_exists` (`toHaveLength()` keeps failing on it, as `expect.test.js` already asserts); only `get_length` special-cases it, as before.

Earlier revision of this PR: the first commit only changed the comparison in `get_length` and documented both sentinels; review pointed out that keeping the raw sentinel in the wrapper's return value is how the mismatch went unnoticed, hence the `Option` return.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/inspect.test.js

<!-- robobun:evidence:end -->