### PR TITLE
bundler: print JS part ranges through shared borrows of LinkerContext and Chunk

### DIFF
--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -116,35 +116,33 @@ impl Default for Content {
 // `InputFile`'s blanket impls (bundle_v2.rs).
 //
 // CONCURRENCY: during the `generate_compile_result_for_*_chunk` fan-out, many
-// `PendingPartRange` tasks share ONE `*mut Chunk` and each writes a disjoint
-// `compile_results_for_chunk[i]`. That field is therefore [`CompileResultSlots`]
-// (UnsafeCell-per-slot) so the per-task write is routed through interior
-// mutability and never requires an aliased `&mut Chunk` /
-// `&mut [CompileResult]` — see [`Chunk::write_compile_result_slot`].
-// `files_with_parts_in_chunk` values are bumped via atomic RMW;
-// the renamer is fully populated before fan-out and every part-range task
-// reads it through `ChunkRenamer::as_renamer(&self)`.
+// `PendingPartRange` tasks share ONE `&Chunk` (handed out by
+// `pending_part_range_prologue`, derived in `generate_chunks_in_parallel`
+// after the owner's last write to the chunk) and each publishes into a
+// disjoint `compile_results_for_chunk[i]`. That field is therefore
+// [`CompileResultSlots`] (UnsafeCell-per-slot), so the per-task write goes
+// through interior mutability behind the shared borrow and nothing in the
+// fan-out ever needs `&mut Chunk` — see [`CompileResultSlots::write`].
+// `files_with_parts_in_chunk` values are bumped via atomic RMW; the renamer
+// is fully populated before fan-out and every part-range task reads it
+// through `ChunkRenamer::as_renamer(&self)`.
 unsafe impl Send for Chunk {}
-// SAFETY: shared `&Chunk` access during the worker fan-out touches only
-// `compile_results_for_chunk` (UnsafeCell-per-slot, disjoint indices) and
-// `files_with_parts_in_chunk` atomic counters; the remaining fields
-// (including `renamer`) are frozen before fan-out, only read while it runs,
-// and mutated again only after the pool join. The fan-out callbacks form
-// `&Chunk`, never `&mut Chunk`; the one write goes through the raw pointer
-// in `write_compile_result_slot`.
+// SAFETY: the only writes into a `Chunk` while it is shared across the
+// fan-out are the `compile_results_for_chunk` slot writes (UnsafeCell per
+// slot, one task per index) and the `files_with_parts_in_chunk` atomics,
+// both of which `&Chunk` permits; every other field is written only by the
+// single-threaded owner before the fan-out and after the pool join.
 unsafe impl Sync for Chunk {}
 
 /// Disjoint-slot output buffer for [`Chunk::compile_results_for_chunk`].
 ///
 /// Allocated single-threaded in `generate_chunks_in_parallel` *before* the
 /// `generate_compile_result_for_*_chunk` fan-out, written concurrently by
-/// worker threads at **disjoint** indices (one slot per `PendingPartRange.i`),
-/// then read single-threaded after the batch's `group.wait()`. Wrapping each
-/// slot in `UnsafeCell` makes the per-task write sound through a shared view —
-/// worker callbacks never need to materialize an aliased `&mut Chunk` or
-/// `&mut [CompileResult]` to publish their result.
+/// worker threads at **disjoint** indices (one slot per `PendingPartRange.i`)
+/// through [`CompileResultSlots::write`], then read single-threaded after the
+/// batch's `group.wait()`. Wrapping each slot in `UnsafeCell` is what makes
+/// the per-task write sound through the `&Chunk` every task shares.
 #[derive(Default)]
-#[repr(transparent)]
 pub struct CompileResultSlots(Box<[UnsafeCell<CompileResult>]>);
 
 // SAFETY: writes target disjoint slots (unique `i` per task); reads happen
@@ -162,6 +160,24 @@ impl CompileResultSlots {
     #[inline]
     pub fn len(&self) -> usize {
         self.0.len()
+    }
+
+    /// Publish one part range's result from a `generate_compile_result_for_*_chunk`
+    /// worker callback. Takes `&self` because every task of the chunk holds the
+    /// same `&Chunk`; the `UnsafeCell` around the slot is what makes the write
+    /// legal through that shared borrow.
+    ///
+    /// # Safety
+    /// - No other task may write slot `i` of this chunk (`i` is the task's
+    ///   `PendingPartRange::i`, unique per chunk by construction).
+    /// - Nothing may read slot `i` until the worker-pool join; the post-join
+    ///   readers (`iter`, `get_mut`, `Index`) rely on that happens-before.
+    #[inline]
+    pub(crate) unsafe fn write(&self, i: usize, result: CompileResult) {
+        // SAFETY: per the contract this task is the slot's only accessor until
+        // the join, so the write through the cell cannot race or alias; the old
+        // (default) value is dropped in place. Indexing bounds-checks `i`.
+        unsafe { *self.0[i].get() = result };
     }
 
     /// Post-join read view. Single-threaded callers only (after the batch's `group.wait()`).
@@ -212,55 +228,6 @@ impl Default for Chunk {
 }
 
 impl Chunk {
-    /// Write `result` into `compile_results_for_chunk[i]` through a raw
-    /// `*mut Chunk`, for the `generate_compile_result_for_*_chunk` worker
-    /// callbacks.
-    ///
-    /// Many `PendingPartRange` tasks share one `*mut Chunk` and each writes a
-    /// unique `i`. The write is routed entirely through raw-pointer field
-    /// projection (`addr_of_mut!`) and `UnsafeCell::get`, so no `&Chunk`,
-    /// `&mut Chunk`, or `&mut [CompileResult]` is ever materialized — only a
-    /// raw `*mut CompileResult` to this task's slot. That keeps the write
-    /// sound under Stacked Borrows even while peer tasks hold their own raw
-    /// views into the same `Chunk`.
-    ///
-    /// # Safety
-    /// - `chunk` must point to a live `Chunk` whose `compile_results_for_chunk`
-    ///   was sized by `generate_chunks_in_parallel` (so `i` is in-bounds).
-    /// - No two concurrent callers may pass the same `i` for the same `chunk`.
-    /// - No reader may observe slot `i` until after the worker-pool join.
-    #[inline]
-    pub(crate) unsafe fn write_compile_result_slot(
-        chunk: *mut Chunk,
-        i: usize,
-        result: CompileResult,
-    ) {
-        // SAFETY: per fn contract — `chunk` is live, `i` in-bounds, slot
-        // exclusively owned by this caller.
-        unsafe {
-            // Project to the slots field with no intermediate `&`/`&mut Chunk`.
-            let slots: *mut CompileResultSlots =
-                core::ptr::addr_of_mut!((*chunk).compile_results_for_chunk);
-            // `CompileResultSlots` is `repr(transparent)` over
-            // `Box<[UnsafeCell<CompileResult>]>`; reading the boxed-slice fat
-            // pointer in place (no move/drop) yields `*mut [UnsafeCell<_>]`
-            // without forming `&Box`. `Box<T>` is documented to have the same
-            // layout/ABI as `*mut T` (and `NonNull<T>`).
-            let cells: *mut [UnsafeCell<CompileResult>] =
-                core::ptr::read(slots.cast::<*mut [UnsafeCell<CompileResult>]>());
-            debug_assert!(
-                i < cells.len(),
-                "compile_results_for_chunk slot out of bounds"
-            );
-            let cell: *mut UnsafeCell<CompileResult> =
-                cells.cast::<UnsafeCell<CompileResult>>().add(i);
-            // `UnsafeCell` is `repr(transparent)` — `*mut UnsafeCell<T>` and
-            // `*mut T` address the same byte. Drop the previous (default)
-            // value in place and store the result.
-            *cell.cast::<CompileResult>() = result;
-        }
-    }
-
     #[inline]
     pub(crate) fn is_entry_point(&self) -> bool {
         self.entry_point.is_entry_point()

--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -122,9 +122,7 @@ unsafe impl Send for Chunk {}
 // is written only by the single-threaded owner before and after the fan-out.
 unsafe impl Sync for Chunk {}
 
-/// One output slot per `PendingPartRange` of the chunk, sized before the
-/// fan-out, written concurrently through [`CompileResultSlots::write`], and
-/// read after the pool join.
+/// One slot per `PendingPartRange` of the chunk; see [`CompileResultSlots::write`].
 #[derive(Default)]
 pub struct CompileResultSlots(Box<[UnsafeCell<CompileResult>]>);
 

--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -122,22 +122,16 @@ impl Default for Content {
 // mutability and never requires an aliased `&mut Chunk` /
 // `&mut [CompileResult]` — see [`Chunk::write_compile_result_slot`].
 // `files_with_parts_in_chunk` values are bumped via atomic RMW;
-// the renamer is fully populated before fan-out and treated as
-// read-only by the printer.
-// Caveat: `Renamer<'r>` still borrows `&'r mut {Number,Minify}Renamer`,
-// so the per-chunk renamer is reborrowed mutably from each part-range task;
-// the printer never writes through it, but the borrow should become `&'r`.
+// the renamer is fully populated before fan-out and every part-range task
+// reads it through `ChunkRenamer::as_renamer(&self)`.
 unsafe impl Send for Chunk {}
 // SAFETY: shared `&Chunk` access during the worker fan-out touches only
 // `compile_results_for_chunk` (UnsafeCell-per-slot, disjoint indices) and
-// `files_with_parts_in_chunk` atomic counters; the remaining fields are
-// frozen before fan-out and read single-threaded after the pool join —
-// **except** `renamer`, which the per-part-range printer reborrows `&mut`
-// from each worker (read-only in practice). See the renamer caveat above:
-// once `Renamer<'r>` borrows `&'r` instead of `&'r mut`, this caveat (and
-// the matching split-borrow in `generate_compile_result_for_js_chunk`) goes
-// away. Pre-existing; this impl mirrors `unsafe impl Send for Chunk` and
-// the single-pointer fan-out the workers use.
+// `files_with_parts_in_chunk` atomic counters; the remaining fields
+// (including `renamer`) are frozen before fan-out, only read while it runs,
+// and mutated again only after the pool join. The fan-out callbacks form
+// `&Chunk`, never `&mut Chunk`; the one write goes through the raw pointer
+// in `write_compile_result_slot`.
 unsafe impl Sync for Chunk {}
 
 /// Disjoint-slot output buffer for [`Chunk::compile_results_for_chunk`].
@@ -1594,7 +1588,7 @@ pub mod bun_renamer {
     }
 
     impl ChunkRenamer {
-        pub(crate) fn as_renamer(&mut self) -> bun_js_printer::renamer::Renamer<'_, '_> {
+        pub(crate) fn as_renamer(&self) -> bun_js_printer::renamer::Renamer<'_, '_> {
             match self {
                 ChunkRenamer::None => unreachable!("ChunkRenamer not initialized"),
                 ChunkRenamer::Number(r) => bun_js_printer::renamer::Renamer::NumberRenamer(r),

--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -114,34 +114,17 @@ impl Default for Content {
 // point into bundler-arena storage that outlives the
 // pool join and is only mutated by the owning task; this mirrors
 // `InputFile`'s blanket impls (bundle_v2.rs).
-//
-// CONCURRENCY: during the `generate_compile_result_for_*_chunk` fan-out, many
-// `PendingPartRange` tasks share ONE `&Chunk` (handed out by
-// `pending_part_range_prologue`, derived in `generate_chunks_in_parallel`
-// after the owner's last write to the chunk) and each publishes into a
-// disjoint `compile_results_for_chunk[i]`. That field is therefore
-// [`CompileResultSlots`] (UnsafeCell-per-slot), so the per-task write goes
-// through interior mutability behind the shared borrow and nothing in the
-// fan-out ever needs `&mut Chunk` — see [`CompileResultSlots::write`].
-// `files_with_parts_in_chunk` values are bumped via atomic RMW; the renamer
-// is fully populated before fan-out and every part-range task reads it
-// through `ChunkRenamer::as_renamer(&self)`.
 unsafe impl Send for Chunk {}
-// SAFETY: the only writes into a `Chunk` while it is shared across the
-// fan-out are the `compile_results_for_chunk` slot writes (UnsafeCell per
-// slot, one task per index) and the `files_with_parts_in_chunk` atomics,
-// both of which `&Chunk` permits; every other field is written only by the
-// single-threaded owner before the fan-out and after the pool join.
+// SAFETY: the part-range fan-out (`generate_compile_result_for_*_chunk`)
+// shares one `&Chunk` per chunk across tasks. The only writes while it is
+// shared are the `compile_results_for_chunk` slots (`UnsafeCell`, one task
+// per index) and the `files_with_parts_in_chunk` atomics; every other field
+// is written only by the single-threaded owner before and after the fan-out.
 unsafe impl Sync for Chunk {}
 
-/// Disjoint-slot output buffer for [`Chunk::compile_results_for_chunk`].
-///
-/// Allocated single-threaded in `generate_chunks_in_parallel` *before* the
-/// `generate_compile_result_for_*_chunk` fan-out, written concurrently by
-/// worker threads at **disjoint** indices (one slot per `PendingPartRange.i`)
-/// through [`CompileResultSlots::write`], then read single-threaded after the
-/// batch's `group.wait()`. Wrapping each slot in `UnsafeCell` is what makes
-/// the per-task write sound through the `&Chunk` every task shares.
+/// One output slot per `PendingPartRange` of the chunk, sized before the
+/// fan-out, written concurrently through [`CompileResultSlots::write`], and
+/// read after the pool join.
 #[derive(Default)]
 pub struct CompileResultSlots(Box<[UnsafeCell<CompileResult>]>);
 
@@ -162,21 +145,14 @@ impl CompileResultSlots {
         self.0.len()
     }
 
-    /// Publish one part range's result from a `generate_compile_result_for_*_chunk`
-    /// worker callback. Takes `&self` because every task of the chunk holds the
-    /// same `&Chunk`; the `UnsafeCell` around the slot is what makes the write
-    /// legal through that shared borrow.
+    /// Publish one part range's result from its worker task.
     ///
     /// # Safety
-    /// - No other task may write slot `i` of this chunk (`i` is the task's
-    ///   `PendingPartRange::i`, unique per chunk by construction).
-    /// - Nothing may read slot `i` until the worker-pool join; the post-join
-    ///   readers (`iter`, `get_mut`, `Index`) rely on that happens-before.
+    /// `i` must be this task's own `PendingPartRange::i` (no other task writes
+    /// it), and nothing may read the slot before the pool join.
     #[inline]
     pub(crate) unsafe fn write(&self, i: usize, result: CompileResult) {
-        // SAFETY: per the contract this task is the slot's only accessor until
-        // the join, so the write through the cell cannot race or alias; the old
-        // (default) value is dropped in place. Indexing bounds-checks `i`.
+        // SAFETY: per the contract, this is the slot's only access until the join.
         unsafe { *self.0[i].get() = result };
     }
 

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -1595,32 +1595,20 @@ pub(crate) type ChunkMetaMap = ArrayHashMap<Ref, ()>;
 /// Note: pointer fields (was `&'a mut`) because `each_ptr` requires
 /// `Ctx: Sync + Copy` and the same context is observed from every worker
 /// thread. The per-chunk `each_ptr` passes (`generate_js_renamer`,
-/// `generate_chunk`) receive their own chunk as a separate `*mut Chunk` and
-/// only write to that; reads of `c`/`chunks` are read-only.
+/// `generate_chunk`) write only the chunk they are handed separately.
 #[derive(Clone, Copy)]
 pub struct GenerateChunkCtx<'a> {
     pub(crate) c: bun_ptr::ParentRef<LinkerContext<'a>, bun_ptr::Mut>,
-    /// Shared view of the full `chunks` slice owned by
-    /// `generate_chunks_in_parallel`. The slice outlives every
-    /// `GenerateChunkCtx` (joined via the batch's `group.wait()`), so
-    /// [`bun_ptr::BackRef`]'s owner-outlives-holder invariant holds and reads
-    /// go through safe `Deref`.
+    /// All chunks, outliving every ctx (`generate_chunks_in_parallel` joins
+    /// each pass before returning).
     pub(crate) chunks: bun_ptr::BackRef<[Chunk]>,
-    /// Shared view of this context's `Chunk` (an element of `chunks`), for the
-    /// part-range fan-out: every `PendingPartRange` of the chunk reads through
-    /// it and publishes its result via
-    /// [`CompileResultSlots::write`](crate::chunk::CompileResultSlots::write),
-    /// so no task ever needs write access to the chunk itself.
-    ///
-    /// Both views are taken in `generate_chunks_in_parallel` *after* the
-    /// owner's last write to the chunks (sizing `compile_results_for_chunk`),
-    /// and the owner only reads the slice until the fan-out is joined: a view
-    /// taken earlier would be invalidated by those writes under Rust's
-    /// aliasing rules even though it would still point at the same bytes.
+    /// This ctx's chunk, shared by all of its part-range tasks; they publish
+    /// through `compile_results_for_chunk` and never need `&mut Chunk`. Both
+    /// views are taken after the owner's last write to the chunks (see
+    /// `generate_chunks_in_parallel`).
     pub(crate) chunk: bun_ptr::BackRef<Chunk>,
 }
-// SAFETY: see note above — the shared views are only read through, and each
-// `each_ptr` task writes only the chunk it was handed separately.
+// SAFETY: see note above — the views are only read through.
 unsafe impl<'a> Send for GenerateChunkCtx<'a> {}
 // SAFETY: see the `Send` impl above — same backref-lifetime / disjoint-write invariants.
 unsafe impl<'a> Sync for GenerateChunkCtx<'a> {}
@@ -1663,28 +1651,19 @@ pub struct PendingPartRange<'a> {
     pub(crate) i: u32,
 }
 
-/// Shared prologue for the `generate_compile_result_for_{js,css,html}_chunk`
-/// thread-pool callbacks: recover the intrusive [`PendingPartRange`] from
-/// `task`, borrow the `LinkerContext` and this task's `Chunk` from its
-/// [`GenerateChunkCtx`], and acquire the per-thread
-/// [`Worker`](crate::thread_pool::Worker) (returned as a scopeguard that calls
-/// `unget()` on drop).
+/// Shared prologue for the `generate_compile_result_for_*_chunk` thread-pool
+/// callbacks: recovers the [`PendingPartRange`] from `task` and acquires the
+/// per-thread [`Worker`](crate::thread_pool::Worker) (released on drop).
 ///
-/// CONCURRENCY: every part range of every chunk is in flight at once, so the
-/// callbacks get `&LinkerContext` / `&Chunk` and nothing stronger. That is
-/// all they need: the only writes in this phase are each task's own
-/// `compile_results_for_chunk` slot
-/// ([`CompileResultSlots::write`](crate::chunk::CompileResultSlots::write))
-/// and the `files_with_parts_in_chunk` atomics, both of which go through
-/// interior mutability behind the shared borrow. The owner holds
-/// `&mut LinkerContext` / `&mut [Chunk]` across the fan-out but only reads
-/// through them until the batch is joined (see the views' derivation note on
-/// [`GenerateChunkCtx::chunk`]).
+/// Every part range of every chunk is in flight at once, so the callbacks get
+/// `&LinkerContext` / `&Chunk`; their only writes are their own
+/// `compile_results_for_chunk` slot and the `files_with_parts_in_chunk`
+/// atomics (see `unsafe impl Sync for Chunk`).
 ///
 /// # Safety
 /// `task` must point to the `task` field of a live `PendingPartRange` scheduled
-/// by `generate_chunks_in_parallel`; the returned borrows are valid until the
-/// callback returns, which happens before the owner's `group.wait()` returns.
+/// by `generate_chunks_in_parallel`, whose `group.wait()` keeps everything the
+/// returned borrows point at alive until the callback returns.
 #[inline]
 #[allow(clippy::type_complexity)]
 pub(crate) unsafe fn pending_part_range_prologue<'a>(
@@ -2154,11 +2133,8 @@ impl<'a> LinkerContext<'a> {
         Ok(true)
     }
 
-    // CONCURRENCY: called from every JS part-range task at once (see
-    // `generate_compile_result_for_js_chunk`); `&self` is what makes the
-    // concurrent borrows of one `LinkerContext` legitimate, so everything in
-    // here, including the `require_or_import_meta_for_source` callback the
-    // printer calls back into, must stay read-only over `self`.
+    // Runs on every JS part-range task at once; `&self` (including in the
+    // `require_or_import_meta_for_source` callback below) is load-bearing.
     pub(crate) fn print_code_for_file_in_chunk_js(
         &self,
         r: renamer::Renamer,

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -1592,28 +1592,35 @@ pub struct ChunkMeta {
 
 pub(crate) type ChunkMetaMap = ArrayHashMap<Ref, ()>;
 
-/// Note: raw-pointer fields (was `&'a mut`) because `each_ptr` requires
+/// Note: pointer fields (was `&'a mut`) because `each_ptr` requires
 /// `Ctx: Sync + Copy` and the same context is observed from every worker
-/// thread. Each task only writes to its own `*mut Chunk` slot; reads of
-/// `c`/`chunks` are disjoint or read-only.
+/// thread. The per-chunk `each_ptr` passes (`generate_js_renamer`,
+/// `generate_chunk`) receive their own chunk as a separate `*mut Chunk` and
+/// only write to that; reads of `c`/`chunks` are read-only.
 #[derive(Clone, Copy)]
 pub struct GenerateChunkCtx<'a> {
     pub(crate) c: bun_ptr::ParentRef<LinkerContext<'a>, bun_ptr::Mut>,
-    /// Backref to the full `chunks: &mut [Chunk]` slice owned by
+    /// Shared view of the full `chunks` slice owned by
     /// `generate_chunks_in_parallel`. The slice outlives every
-    /// `GenerateChunkCtx` (joined via the batch's `group.wait()`), so [`bun_ptr::BackRef`]'s
-    /// owner-outlives-holder invariant holds and per-task reads go through
-    /// safe `Deref`. Read-only: each task writes only through its own
-    /// `*mut Chunk`.
+    /// `GenerateChunkCtx` (joined via the batch's `group.wait()`), so
+    /// [`bun_ptr::BackRef`]'s owner-outlives-holder invariant holds and reads
+    /// go through safe `Deref`.
     pub(crate) chunks: bun_ptr::BackRef<[Chunk]>,
-    /// Backref to this task's `Chunk` (an element of `chunks`). Constructed
-    /// via [`bun_ptr::BackRef::new_mut`] so the stored `NonNull` carries write
-    /// provenance; per-task slot writes recover the raw `*mut Chunk` via
-    /// [`bun_ptr::BackRef::as_ptr`], shared reads go through safe `Deref`.
-    pub(crate) chunk: bun_ptr::BackRef<Chunk, bun_ptr::Mut>,
+    /// Shared view of this context's `Chunk` (an element of `chunks`), for the
+    /// part-range fan-out: every `PendingPartRange` of the chunk reads through
+    /// it and publishes its result via
+    /// [`CompileResultSlots::write`](crate::chunk::CompileResultSlots::write),
+    /// so no task ever needs write access to the chunk itself.
+    ///
+    /// Both views are taken in `generate_chunks_in_parallel` *after* the
+    /// owner's last write to the chunks (sizing `compile_results_for_chunk`),
+    /// and the owner only reads the slice until the fan-out is joined: a view
+    /// taken earlier would be invalidated by those writes under Rust's
+    /// aliasing rules even though it would still point at the same bytes.
+    pub(crate) chunk: bun_ptr::BackRef<Chunk>,
 }
-// SAFETY: see note above — each task writes only its own `*mut Chunk` slot;
-// shared reads are read-only.
+// SAFETY: see note above — the shared views are only read through, and each
+// `each_ptr` task writes only the chunk it was handed separately.
 unsafe impl<'a> Send for GenerateChunkCtx<'a> {}
 // SAFETY: see the `Send` impl above — same backref-lifetime / disjoint-write invariants.
 unsafe impl<'a> Sync for GenerateChunkCtx<'a> {}
@@ -1656,50 +1663,48 @@ pub struct PendingPartRange<'a> {
     pub(crate) i: u32,
 }
 
-/// Shared prologue for `generate_compile_result_for_{js,css}_chunk` thread-pool
-/// callbacks: recover the intrusive [`PendingPartRange`] from `task`, extract
-/// the raw `*mut LinkerContext` / `*mut Chunk` from its [`GenerateChunkCtx`],
-/// and acquire the per-thread [`Worker`](crate::thread_pool::Worker) (returned
-/// as a scopeguard that calls `unget()` on drop).
+/// Shared prologue for the `generate_compile_result_for_{js,css,html}_chunk`
+/// thread-pool callbacks: recover the intrusive [`PendingPartRange`] from
+/// `task`, borrow the `LinkerContext` and this task's `Chunk` from its
+/// [`GenerateChunkCtx`], and acquire the per-thread
+/// [`Worker`](crate::thread_pool::Worker) (returned as a scopeguard that calls
+/// `unget()` on drop).
 ///
-/// `GenerateChunkCtx.{c, chunk}` are raw `*mut T` (Copy), so reading them
-/// through `&GenerateChunkCtx` preserves the mutable provenance they were
-/// constructed with in `generate_chunks_in_parallel` — many `PendingPartRange`
-/// tasks share one `chunk_ctx` across worker threads.
+/// CONCURRENCY: every part range of every chunk is in flight at once, so the
+/// callbacks get `&LinkerContext` / `&Chunk` and nothing stronger. That is
+/// all they need: the only writes in this phase are each task's own
+/// `compile_results_for_chunk` slot
+/// ([`CompileResultSlots::write`](crate::chunk::CompileResultSlots::write))
+/// and the `files_with_parts_in_chunk` atomics, both of which go through
+/// interior mutability behind the shared borrow. The owner holds
+/// `&mut LinkerContext` / `&mut [Chunk]` across the fan-out but only reads
+/// through them until the batch is joined (see the views' derivation note on
+/// [`GenerateChunkCtx::chunk`]).
 ///
 /// # Safety
 /// `task` must point to the `task` field of a live `PendingPartRange` scheduled
-/// by `generate_chunks_in_parallel`. The returned `&PendingPartRange` borrows
-/// the task allocation for the callback's duration; the returned raw pointers
-/// carry the mutable provenance the `GenerateChunkCtx` was constructed with.
-/// Callers uphold the disjoint-write contract:
-///   - `chunk.compile_results_for_chunk[i]` is written at a per-task unique `i`
-///     via [`Chunk::write_compile_result_slot`] (raw `addr_of_mut!` +
-///     `UnsafeCell` slot write — never `&mut Chunk`),
-///   - `chunk.files_with_parts_in_chunk` entries are updated via atomic RMW only,
-///   - all other access through `c` / `chunk` during codegen is read-only.
+/// by `generate_chunks_in_parallel`; the returned borrows are valid until the
+/// callback returns, which happens before the owner's `group.wait()` returns.
 #[inline]
 #[allow(clippy::type_complexity)]
 pub(crate) unsafe fn pending_part_range_prologue<'a>(
     task: *mut ThreadPoolLib::Task,
 ) -> (
     &'a PendingPartRange<'a>,
-    *mut LinkerContext<'a>,
-    *mut Chunk,
+    &'a LinkerContext<'a>,
+    &'a Chunk,
     scopeguard::ScopeGuard<
         &'static mut crate::thread_pool::Worker,
         impl FnOnce(&'static mut crate::thread_pool::Worker),
     >,
 ) {
     // SAFETY: per fn contract — `task` is the intrusive `task` field.
-    let part_range: &PendingPartRange =
+    let part_range: &'a PendingPartRange<'a> =
         unsafe { &*bun_core::from_field_ptr!(PendingPartRange, task, task) };
-    let ctx = part_range.ctx;
-    let c_ptr: *mut LinkerContext = ctx.c.as_mut_ptr().cast();
-    let chunk_ptr: *mut Chunk = ctx.chunk.as_ptr();
+    let ctx: &'a GenerateChunkCtx<'a> = part_range.ctx;
     let worker = crate::thread_pool::Worker::get(ctx.bundle());
     let worker = scopeguard::guard(worker, |w| w.unget());
-    (part_range, c_ptr, chunk_ptr, worker)
+    (part_range, ctx.c.get(), ctx.chunk.get(), worker)
 }
 
 impl<'a> LinkerContext<'a> {

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -1602,9 +1602,8 @@ pub struct GenerateChunkCtx<'a> {
     /// All chunks, outliving every ctx (`generate_chunks_in_parallel` joins
     /// each pass before returning).
     pub(crate) chunks: bun_ptr::BackRef<[Chunk]>,
-    /// This ctx's chunk, shared by all of its part-range tasks; they publish
-    /// through `compile_results_for_chunk` and never need `&mut Chunk`. Both
-    /// views are taken after the owner's last write to the chunks (see
+    /// This ctx's chunk, shared by all of its part-range tasks. Both views are
+    /// taken after the owner's last write to the chunks (see
     /// `generate_chunks_in_parallel`).
     pub(crate) chunk: bun_ptr::BackRef<Chunk>,
 }
@@ -1653,12 +1652,9 @@ pub struct PendingPartRange<'a> {
 
 /// Shared prologue for the `generate_compile_result_for_*_chunk` thread-pool
 /// callbacks: recovers the [`PendingPartRange`] from `task` and acquires the
-/// per-thread [`Worker`](crate::thread_pool::Worker) (released on drop).
-///
-/// Every part range of every chunk is in flight at once, so the callbacks get
-/// `&LinkerContext` / `&Chunk`; their only writes are their own
-/// `compile_results_for_chunk` slot and the `files_with_parts_in_chunk`
-/// atomics (see `unsafe impl Sync for Chunk`).
+/// per-thread [`Worker`](crate::thread_pool::Worker) (released on drop). All
+/// part ranges run at once, so the callbacks get `&LinkerContext` / `&Chunk`
+/// (what they may write through those is spelled out on `impl Sync for Chunk`).
 ///
 /// # Safety
 /// `task` must point to the `task` field of a live `PendingPartRange` scheduled
@@ -2133,8 +2129,6 @@ impl<'a> LinkerContext<'a> {
         Ok(true)
     }
 
-    // Runs on every JS part-range task at once; `&self` (including in the
-    // `require_or_import_meta_for_source` callback below) is load-bearing.
     pub(crate) fn print_code_for_file_in_chunk_js(
         &self,
         r: renamer::Renamer,

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2016,7 +2016,7 @@ impl<'a> LinkerContext<'a> {
     }
 
     pub(crate) fn should_remove_import_export_stmt(
-        &mut self,
+        &self,
         stmts: &mut StmtList,
         loc: Loc,
         namespace_ref: Ref,
@@ -2149,8 +2149,13 @@ impl<'a> LinkerContext<'a> {
         Ok(true)
     }
 
+    // CONCURRENCY: called from every JS part-range task at once (see
+    // `generate_compile_result_for_js_chunk`); `&self` is what makes the
+    // concurrent borrows of one `LinkerContext` legitimate, so everything in
+    // here, including the `require_or_import_meta_for_source` callback the
+    // printer calls back into, must stay read-only over `self`.
     pub(crate) fn print_code_for_file_in_chunk_js(
-        &mut self,
+        &self,
         r: renamer::Renamer,
         alloc: &Bump,
         writer: &mut js_printer::BufferWriter,
@@ -2169,30 +2174,11 @@ impl<'a> LinkerContext<'a> {
             ..Default::default()
         }];
 
-        // SAFETY: parse_graph backref; raw deref because `parse_graph` is held
-        // across `RequireOrImportMetaCallback::init(self)` (`&mut self`) below.
-        let parse_graph = unsafe { &*self.parse_graph };
-
-        // Note: reshaped for borrowck — `Options` borrows `ts_enums` /
-        // `line_offset_tables` / `mangled_props` from `self.graph`, but the
-        // `require_or_import_meta_for_source_callback` field below needs
-        // `&mut self`. Detach the read-only borrows via raw-pointer round-trip
-        // (graph SoA storage is never reallocated during the print step).
-        // SAFETY: `self.graph` columns are stable heap allocations valid for
-        // the duration of this call; the printer only reads from them.
-        let ts_enums: &bun_ast::ast_result::TsEnumsMap =
-            unsafe { bun_ptr::detach_lifetime_ref(&self.graph.ts_enums) };
-        // SAFETY: `graph.files` SoA columns are stable heap allocations valid for this
-        // call (see above); the printer only reads from this slot.
-        let line_offset_table: &bun_sourcemap::line_offset_table::List<bun_alloc::AstAlloc> = unsafe {
-            bun_ptr::detach_lifetime_ref(
-                &self.graph.files.items_line_offset_table()[source_index.get() as usize],
-            )
-        };
-        let mangled_props: &MangledProps =
-            // SAFETY: `self.mangled_props` is not mutated during printing; detached borrow
-            // outlives only this call (see above).
-            unsafe { bun_ptr::detach_lifetime_ref(&self.mangled_props) };
+        let parse_graph = self.parse_graph();
+        let ts_enums: &bun_ast::ast_result::TsEnumsMap = &self.graph.ts_enums;
+        let line_offset_table: &bun_sourcemap::line_offset_table::List<bun_alloc::AstAlloc> =
+            &self.graph.files.items_line_offset_table()[source_index.get() as usize];
+        let mangled_props: &MangledProps = &self.mangled_props;
 
         let print_options = js_printer::Options {
             bundling: true,
@@ -2261,18 +2247,6 @@ impl<'a> LinkerContext<'a> {
         // the read is a bitwise copy whose result is never dropped.
         let printer_ast = core::mem::ManuallyDrop::new(unsafe { core::ptr::read(ast) }.to_ast());
 
-        // Note: `print_with_writer<'a>` requires `Renamer<'a,'a>` (the
-        // printer struct stores it with a single lifetime), but `Renamer`'s
-        // `'src` is invariant behind `&mut`, so the caller's `Renamer<'r,'src>`
-        // cannot unify with the local `'a` picked from `alloc`/`mangled_props`.
-        // Rebind via a
-        // lifetime-only cast — sound because the renamer's borrowed data
-        // (symbol map, source) strictly outlives this call.
-        // SAFETY: lifetime-only erase; layout identical across instantiations.
-        let r: renamer::Renamer<'_, '_> = unsafe {
-            core::mem::transmute::<renamer::Renamer<'_, '_>, renamer::Renamer<'_, '_>>(r)
-        };
-
         let enable_source_maps =
             self.options.source_maps != SourceMapOption::None && !source_index.is_runtime();
         let result = if enable_source_maps {
@@ -2307,7 +2281,7 @@ impl<'a> LinkerContext<'a> {
     }
 
     pub(crate) fn require_or_import_meta_for_source(
-        &mut self,
+        &self,
         source_index: crate::IndexInt,
         was_unwrapped_require: bool,
     ) -> js_printer::RequireOrImportMeta {
@@ -2563,7 +2537,7 @@ impl<'a> LinkerContext<'a> {
 impl<'a> js_printer::RequireOrImportMetaSource for LinkerContext<'a> {
     #[inline]
     fn require_or_import_meta_for_source(
-        &mut self,
+        &self,
         id: u32,
         was_unwrapped_require: bool,
     ) -> js_printer::RequireOrImportMeta {

--- a/src/bundler/linker_context/convertStmtsForChunk.rs
+++ b/src/bundler/linker_context/convertStmtsForChunk.rs
@@ -45,11 +45,11 @@ use crate::options::Format;
 /// namespace object (foo) because we cannot know what they are going to
 /// attempt to access statically
 pub(crate) fn convert_stmts_for_chunk(
-    c: &mut LinkerContext<'_>,
+    c: &LinkerContext<'_>,
     source_index: u32,
     stmts: &mut StmtList,
     part_stmts: &[bun_ast::Stmt],
-    chunk: &mut Chunk,
+    chunk: &Chunk,
     bump: &Bump,
     wrap: WrapKind,
     ast: &JSAst<'_>,

--- a/src/bundler/linker_context/convertStmtsForChunkForDevServer.rs
+++ b/src/bundler/linker_context/convertStmtsForChunkForDevServer.rs
@@ -43,7 +43,7 @@ use crate::linker_context_mod::{LinkerContext, StmtList, StmtListWhich};
 ///     }, false ],
 ///        ----- "is the module async?"
 pub(crate) fn convert_stmts_for_chunk_for_dev_server<'bump>(
-    c: &mut LinkerContext,
+    c: &LinkerContext,
     stmts: &mut StmtList,
     part_stmts: &[bun_ast::Stmt],
     bump: &'bump Bump,

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -60,11 +60,12 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
         // TODO: instead of running a renamer per chunk, run it per file
         debug!(" START {} renamers", chunks.len());
         let ctx = GenerateChunkCtx {
-            chunk: bun_ptr::BackRef::new_mut(&mut chunks[0]),
             // SAFETY: `c` is the live `&mut LinkerContext` for the link step;
             // write provenance preserved.
             c: unsafe { bun_ptr::ParentRef::from_raw_mut(std::ptr::from_mut::<LinkerContext>(c)) },
             chunks: bun_ptr::BackRef::new(&*chunks),
+            // Unused by the renamer tasks, which get their chunk from `each_ptr`.
+            chunk: bun_ptr::BackRef::new(&chunks[0]),
         };
         // SAFETY: `parse_graph` is the `BundleV2.graph` backref (valid for the
         // link step); `pool` is the arena-allocated bundler ThreadPool.
@@ -132,20 +133,8 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
 
         {
             let mut total_count: usize = 0;
-            // `GenerateChunkCtx` fields are raw pointers; capture them
-            // before the `iter_mut()` borrow so the same slice backref can be
-            // stored in every ctx.
-            // SAFETY: `c` is the live `&mut LinkerContext` for the link step.
-            let c_ref =
-                unsafe { bun_ptr::ParentRef::from_raw_mut(std::ptr::from_mut::<LinkerContext>(c)) };
-            let chunks_ref: bun_ptr::BackRef<[Chunk]> = bun_ptr::BackRef::new(&*chunks);
             for chunk in chunks.iter_mut() {
-                chunk_contexts.push(GenerateChunkCtx {
-                    c: c_ref,
-                    chunks: chunks_ref,
-                    chunk: bun_ptr::BackRef::new_mut(chunk),
-                });
-                match &mut chunk.content {
+                match &chunk.content {
                     crate::chunk::Content::Javascript(js) => {
                         total_count += js.parts_in_chunk_in_order.len();
                         chunk.compile_results_for_chunk =
@@ -168,6 +157,24 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                 }
             }
 
+            // The sizing above is the owner's last write to any chunk before
+            // the fan-out. The views the tasks read through are taken only
+            // now, and from here until `group.wait()` below this function only
+            // reads `chunks`: under Rust's aliasing rules, writing through the
+            // owner (or reborrowing it `&mut`, e.g. `iter_mut()`) invalidates
+            // every view taken from it earlier, even though the bytes do not
+            // move. See `GenerateChunkCtx::chunk`.
+            // SAFETY: `c` is the live `&mut LinkerContext` for the link step;
+            // the fan-out only reads through this view
+            // (`pending_part_range_prologue`).
+            let c_ref =
+                unsafe { bun_ptr::ParentRef::from_raw_mut(std::ptr::from_mut::<LinkerContext>(c)) };
+            let chunks_ref: bun_ptr::BackRef<[Chunk]> = bun_ptr::BackRef::new(&*chunks);
+            chunk_contexts.extend(chunks.iter().map(|chunk| GenerateChunkCtx {
+                c: c_ref,
+                chunks: chunks_ref,
+                chunk: bun_ptr::BackRef::new(chunk),
+            }));
             debug_assert_eq!(chunks.len(), chunk_contexts.len());
 
             debug!(" START {} compiling part ranges", total_count);
@@ -176,7 +183,7 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
             let group = bun_threading::WaitGroup::init_with_count(total_count);
             let mut combined_part_ranges: Vec<PendingPartRange> = Vec::with_capacity(total_count);
             let mut batch = ThreadPoolLib::Batch::default();
-            for (chunk, chunk_ctx) in chunks.iter_mut().zip(chunk_contexts.iter_mut()) {
+            for (chunk, chunk_ctx) in chunks.iter().zip(chunk_contexts.iter()) {
                 match &chunk.content {
                     crate::chunk::Content::Javascript(js) => {
                         for (i, part_range) in js.parts_in_chunk_in_order.iter().enumerate() {

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -157,16 +157,12 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                 }
             }
 
-            // The sizing above is the owner's last write to any chunk before
-            // the fan-out. The views the tasks read through are taken only
-            // now, and from here until `group.wait()` below this function only
-            // reads `chunks`: under Rust's aliasing rules, writing through the
-            // owner (or reborrowing it `&mut`, e.g. `iter_mut()`) invalidates
-            // every view taken from it earlier, even though the bytes do not
-            // move. See `GenerateChunkCtx::chunk`.
+            // Take the tasks' views only after the writes above, and until
+            // `group.wait()` only read `chunks` (no `iter_mut()`): writing
+            // through, or `&mut`-reborrowing, the owner invalidates every view
+            // previously taken from it.
             // SAFETY: `c` is the live `&mut LinkerContext` for the link step;
-            // the fan-out only reads through this view
-            // (`pending_part_range_prologue`).
+            // the fan-out only reads through this view.
             let c_ref =
                 unsafe { bun_ptr::ParentRef::from_raw_mut(std::ptr::from_mut::<LinkerContext>(c)) };
             let chunks_ref: bun_ptr::BackRef<[Chunk]> = bun_ptr::BackRef::new(&*chunks);

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -21,10 +21,8 @@ use bun_js_parser::lexer as js_lexer;
 use super::convert_stmts_for_chunk::convert_stmts_for_chunk;
 use super::convert_stmts_for_chunk_for_dev_server::convert_stmts_for_chunk_for_dev_server;
 
-// CONCURRENCY: runs on worker threads for every part range of every JS chunk
-// at once (see `generate_compile_result_for_js_chunk`), so `c` and `chunk`
-// are shared borrows and everything reached through them is read-only; all
-// output goes to the caller-owned `writer` / `stmts` / `module_info`.
+// Runs for every part range of every JS chunk at once; `c` and `chunk` are
+// shared with all of those tasks (see `generate_compile_result_for_js_chunk`).
 #[allow(clippy::too_many_arguments)]
 pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
     c: &LinkerContext,

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -21,12 +21,16 @@ use bun_js_parser::lexer as js_lexer;
 use super::convert_stmts_for_chunk::convert_stmts_for_chunk;
 use super::convert_stmts_for_chunk_for_dev_server::convert_stmts_for_chunk_for_dev_server;
 
+// CONCURRENCY: runs on worker threads for every part range of every JS chunk
+// at once (see `generate_compile_result_for_js_chunk`), so `c` and `chunk`
+// are shared borrows and everything reached through them is read-only; all
+// output goes to the caller-owned `writer` / `stmts` / `module_info`.
 #[allow(clippy::too_many_arguments)]
 pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
-    c: &mut LinkerContext,
+    c: &LinkerContext,
     writer: &mut js_printer::BufferWriter,
     r: renamer::Renamer<'r, 'src>,
-    chunk: &mut Chunk,
+    chunk: &Chunk,
     part_range: PartRange,
     to_common_js_ref: Ref,
     to_esm_ref: Ref,
@@ -38,18 +42,8 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
 ) -> js_printer::PrintResult {
     let source_index = part_range.source_index.get() as usize;
 
-    // Grab raw pointers to the SoA columns up front so
-    // subsequent `&mut c` borrows (convert_stmts_for_chunk, print_code_for_file_in_chunk_js)
-    // don't conflict.
-    // SAFETY: the underlying MultiArrayList storage is not resized for the duration of this
-    // function (linking has already sized everything).
-    let parts: *mut [Part] = {
-        let list = &mut c.graph.ast.items_parts_mut()[source_index];
-        core::ptr::addr_of_mut!(
-            list.as_mut_slice()
-                [part_range.part_index_begin as usize..part_range.part_index_end as usize]
-        )
-    };
+    let parts: &[Part] = &c.graph.ast.items_parts()[source_index].as_slice()
+        [part_range.part_index_begin as usize..part_range.part_index_end as usize];
     let flags: crate::js_meta::Flags = c.graph.meta.items_flags()[source_index];
     let wrapper_part_index = if flags.wrap != WrapKind::None {
         c.graph.meta.items_wrapper_part_index()[source_index]
@@ -78,8 +72,7 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
 
             let hmr_api_ref = ast.wrapper_ref;
 
-            // SAFETY: see `parts` raw-pointer note above.
-            for part in unsafe { (*parts).iter() } {
+            for part in parts {
                 let part_stmts: &[Stmt] = part.stmts.slice();
                 if let Err(err) =
                     convert_stmts_for_chunk_for_dev_server(c, stmts, part_stmts, arena, &mut ast)
@@ -274,20 +267,18 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
             .expect("unreachable");
     }
 
-    // `convert_stmts_for_chunk` takes `&mut c` inside the loop body, so capture
-    // the per-file bitset as a BackRef once. The `parts_live` Vec doesn't
-    // reallocate after `tree_shaking_and_code_splitting` initializes it.
-    let parts_live: bun_ptr::BackRef<bun_collections::AutoBitSet> =
-        bun_ptr::BackRef::new(&c.graph.parts_live[source_index]);
+    let parts_live: &bun_collections::AutoBitSet = &c.graph.parts_live[source_index];
 
     // TODO: handle directive
     if namespace_export_part_index >= part_range.part_index_begin
         && namespace_export_part_index < part_range.part_index_end
         && parts_live.is_set(namespace_export_part_index as usize)
     {
-        // SAFETY: see `parts` raw-pointer note above; index bounded by the range check just above.
-        let ns_part_stmts: &[Stmt] =
-            unsafe { (*parts)[namespace_export_part_index as usize].stmts }.slice();
+        // `parts` starts at `part_index_begin`; the range check above bounds the index.
+        let ns_part_stmts: &[Stmt] = parts
+            [(namespace_export_part_index - part_range.part_index_begin) as usize]
+            .stmts
+            .slice();
         if let Err(err) = convert_stmts_for_chunk(
             c,
             source_index as u32,
@@ -323,16 +314,12 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
     }
 
     // Add all other parts in this chunk
-    // SAFETY: see `parts` raw-pointer note above.
-    let parts_len = unsafe { (&*parts).len() };
-    for index_ in 0..parts_len {
+    for (index_, part) in parts.iter().enumerate() {
         let index = part_range.part_index_begin + (index_ as u32);
         if !parts_live.is_set(index as usize) {
             // Skip the part if it's not in this chunk
             continue;
         }
-        // SAFETY: index in bounds.
-        let part: &Part = unsafe { &(*parts)[index_] };
 
         if index == namespace_export_part_index {
             // Skip the namespace export part because we already handled it above
@@ -917,9 +904,6 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
         });
     }
 
-    // `get_source` returns `&'static Source` (parse_graph SoA is append-only and
-    // outlives the link step), so it does not borrow `c` — no split-borrow needed
-    // across the `&mut self` call below.
     let source: &bun_ast::Source = c.get_source(source_index as u32);
     c.print_code_for_file_in_chunk_js(
         r,

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -21,8 +21,6 @@ use bun_js_parser::lexer as js_lexer;
 use super::convert_stmts_for_chunk::convert_stmts_for_chunk;
 use super::convert_stmts_for_chunk_for_dev_server::convert_stmts_for_chunk_for_dev_server;
 
-// Runs for every part range of every JS chunk at once; `c` and `chunk` are
-// shared with all of those tasks (see `generate_compile_result_for_js_chunk`).
 #[allow(clippy::too_many_arguments)]
 pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
     c: &LinkerContext,

--- a/src/bundler/linker_context/generateCompileResultForCssChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForCssChunk.rs
@@ -14,10 +14,10 @@ use crate::{Chunk, CompileResult, Index};
 
 // CONCURRENCY: thread-pool callback — runs on worker threads, one task per
 // `PendingPartRange`. Writes: `chunk.compile_results_for_chunk[i]` (disjoint
-// by per-task `i`). Reads `c.graph.ast.css` / `c.options` shared. Never forms
-// `&mut LinkerContext` — `c_ptr` stays raw; the CSS printer takes
-// `&LinkerContext`. See `generate_compile_result_for_js_chunk` for the
-// `PendingPartRange: Send` justification.
+// by per-task `i`), `chunk.files_with_parts_in_chunk[source]` (atomic RMW).
+// Reads `c.graph.ast.css` / `c.options` through the `&LinkerContext` /
+// `&Chunk` the prologue hands out. See `generate_compile_result_for_js_chunk`
+// for the `PendingPartRange: Send` justification.
 //
 /// # Safety
 ///
@@ -29,28 +29,18 @@ use crate::{Chunk, CompileResult, Index};
 pub(crate) unsafe fn generate_compile_result_for_css_chunk(task: *mut ThreadPoolLib::Task) {
     // SAFETY: `task` is the intrusive `task` field of a `PendingPartRange`
     // scheduled by `generate_chunks_in_parallel`; see the helper's contract.
-    let (part_range, c_ptr, chunk_ptr, mut worker) =
+    let (part_range, c, chunk, mut worker) =
         unsafe { crate::linker_context_mod::pending_part_range_prologue(task) };
 
-    // CONCURRENCY: the CSS impl is read-only over `c`/`chunk` (the
-    // `bytesInOutput` bump goes through `&AtomicUsize`), so form `&` — never
-    // `&mut` — to avoid aliased exclusive borrows across peer worker tasks.
-    // The `&` borrows are scoped to the impl call so they do not overlap the
-    // raw slot write that follows.
-    let result = {
-        // SAFETY: `c_ptr` is the live `LinkerContext` returned by
-        // `pending_part_range_prologue`; see its contract.
-        let c_ref: &LinkerContext = unsafe { &*c_ptr };
-        // SAFETY: `chunk_ptr` is the live `Chunk` from the same prologue; this
-        // `&` is scoped so it does not overlap the raw slot write below.
-        let chunk_ref: &Chunk = unsafe { &*chunk_ptr };
-        generate_compile_result_for_css_chunk_impl(&mut **worker, c_ref, chunk_ref, part_range.i)
-    };
+    let result = generate_compile_result_for_css_chunk_impl(&mut **worker, c, chunk, part_range.i);
 
-    // SAFETY: per-task unique `i`; see `Chunk::write_compile_result_slot`.
-    // The slot write is routed through raw `addr_of_mut!` + `UnsafeCell` so it
-    // never materializes `&mut Chunk` / `&mut [CompileResult]`.
-    unsafe { Chunk::write_compile_result_slot(chunk_ptr, part_range.i as usize, result) };
+    // SAFETY: `part_range.i` is unique among this chunk's tasks and nothing
+    // reads the slot before the pool join; see `CompileResultSlots::write`.
+    unsafe {
+        chunk
+            .compile_results_for_chunk
+            .write(part_range.i as usize, result)
+    };
 }
 
 fn generate_compile_result_for_css_chunk_impl(

--- a/src/bundler/linker_context/generateCompileResultForCssChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForCssChunk.rs
@@ -12,12 +12,10 @@ use crate::linker_context_mod::LinkerContext;
 use crate::thread_pool::Worker;
 use crate::{Chunk, CompileResult, Index};
 
-// CONCURRENCY: thread-pool callback — runs on worker threads, one task per
-// `PendingPartRange`. Writes: `chunk.compile_results_for_chunk[i]` (disjoint
-// by per-task `i`), `chunk.files_with_parts_in_chunk[source]` (atomic RMW).
-// Reads `c.graph.ast.css` / `c.options` through the `&LinkerContext` /
-// `&Chunk` the prologue hands out. See `generate_compile_result_for_js_chunk`
-// for the `PendingPartRange: Send` justification.
+// CONCURRENCY: thread-pool callback — one task per `PendingPartRange`. Writes:
+// `chunk.compile_results_for_chunk[i]` (per-task `i`),
+// `chunk.files_with_parts_in_chunk[source]` (atomic RMW); everything else is
+// read. See `generate_compile_result_for_js_chunk`.
 //
 /// # Safety
 ///
@@ -34,8 +32,7 @@ pub(crate) unsafe fn generate_compile_result_for_css_chunk(task: *mut ThreadPool
 
     let result = generate_compile_result_for_css_chunk_impl(&mut **worker, c, chunk, part_range.i);
 
-    // SAFETY: `part_range.i` is unique among this chunk's tasks and nothing
-    // reads the slot before the pool join; see `CompileResultSlots::write`.
+    // SAFETY: `part_range.i` is this task's own slot; nothing reads it before the join.
     unsafe {
         chunk
             .compile_results_for_chunk

--- a/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
@@ -36,9 +36,10 @@ use crate::{Chunk, CompileResult};
 // CONCURRENCY: thread-pool callback — runs on worker threads, one task per
 // HTML `PendingPartRange` (exactly one per HTML chunk). Writes:
 // `chunk.compile_results_for_chunk[0]` (per-chunk disjoint). Reads
-// `c.parse_graph.input_files` / `c.graph` / `ctx.chunks` shared. Never forms
-// `&mut LinkerContext` — `c_ptr` stays raw; the HTML rewriter takes
-// `&LinkerContext`. See `generate_compile_result_for_js_chunk` for the
+// `c.parse_graph.input_files` / `c.graph` / `ctx.chunks` through the shared
+// views the prologue and `GenerateChunkCtx` hand out; the other chunks' fields
+// it reads (`unique_key`, `content`, `entry_point`) are frozen for the whole
+// fan-out. See `generate_compile_result_for_js_chunk` for the
 // `PendingPartRange: Send` justification.
 //
 /// # Safety
@@ -51,21 +52,19 @@ use crate::{Chunk, CompileResult};
 pub(crate) unsafe fn generate_compile_result_for_html_chunk(task: *mut ThreadPoolLibTask) {
     // SAFETY: `task` is the intrusive `task` field of a `PendingPartRange`
     // scheduled by `generate_chunks_in_parallel`; see the helper's contract.
-    let (part_range, _c_ptr, chunk_ptr, _worker) =
+    let (part_range, c, chunk, _worker) =
         unsafe { crate::linker_context_mod::pending_part_range_prologue(task) };
-    let i = part_range.i as usize;
     let ctx: &GenerateChunkCtx = part_range.ctx;
-
-    // `ctx.c` is a `ParentRef` and `ctx.chunk` / `ctx.chunks` are `BackRef`s;
-    // all yield safe shared borrows via `.get()`. `chunk` is this task's
-    // exclusively-owned HTML chunk for the duration of the compile step.
-    let c_ref: &LinkerContext = ctx.c.get();
-    let chunk_ref: &Chunk = ctx.chunk.get();
     let chunks: &[Chunk] = ctx.chunks.get();
-    let result = generate_compile_result_for_html_chunk_impl(c_ref, chunk_ref, chunks);
-    // SAFETY: HTML chunks have exactly one part-range (i == 0); see
-    // `Chunk::write_compile_result_slot` for the disjoint-slot contract.
-    unsafe { Chunk::write_compile_result_slot(chunk_ptr, i, result) };
+    let result = generate_compile_result_for_html_chunk_impl(c, chunk, chunks);
+    // SAFETY: an HTML chunk has exactly one part range, so this task is the
+    // only writer of the slot, and nothing reads it before the pool join; see
+    // `CompileResultSlots::write`.
+    unsafe {
+        chunk
+            .compile_results_for_chunk
+            .write(part_range.i as usize, result)
+    };
 }
 
 #[derive(Default)]

--- a/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
@@ -33,14 +33,10 @@ use crate::{Chunk, CompileResult};
 ///    a <link rel="modulepreload" href="..." crossorigin> tag that
 ///    points to the module or chunk's unique key so that we tell the
 ///    browser to preload the user's code.
-// CONCURRENCY: thread-pool callback — runs on worker threads, one task per
-// HTML `PendingPartRange` (exactly one per HTML chunk). Writes:
-// `chunk.compile_results_for_chunk[0]` (per-chunk disjoint). Reads
-// `c.parse_graph.input_files` / `c.graph` / `ctx.chunks` through the shared
-// views the prologue and `GenerateChunkCtx` hand out; the other chunks' fields
-// it reads (`unique_key`, `content`, `entry_point`) are frozen for the whole
-// fan-out. See `generate_compile_result_for_js_chunk` for the
-// `PendingPartRange: Send` justification.
+// CONCURRENCY: thread-pool callback — one task per HTML chunk. Writes:
+// `chunk.compile_results_for_chunk[0]`; everything else, including the other
+// chunks' `unique_key` / `content` / `entry_point`, is read. See
+// `generate_compile_result_for_js_chunk`.
 //
 /// # Safety
 ///
@@ -57,9 +53,8 @@ pub(crate) unsafe fn generate_compile_result_for_html_chunk(task: *mut ThreadPoo
     let ctx: &GenerateChunkCtx = part_range.ctx;
     let chunks: &[Chunk] = ctx.chunks.get();
     let result = generate_compile_result_for_html_chunk_impl(c, chunk, chunks);
-    // SAFETY: an HTML chunk has exactly one part range, so this task is the
-    // only writer of the slot, and nothing reads it before the pool join; see
-    // `CompileResultSlots::write`.
+    // SAFETY: an HTML chunk has one part range, so this is the slot's only
+    // writer; nothing reads it before the join.
     unsafe {
         chunk
             .compile_results_for_chunk

--- a/src/bundler/linker_context/generateCompileResultForJSChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForJSChunk.rs
@@ -14,13 +14,17 @@ use crate::{Chunk, CompileResult, Index, PartRange};
 use super::generate_code_for_file_in_chunk_js::generate_code_for_file_in_chunk_js;
 
 // CONCURRENCY: thread-pool callback — runs on worker threads, one task per
-// `PendingPartRange`. Writes: `chunk.compile_results_for_chunk[i]` (disjoint
-// by per-task `i`), `chunk.files_with_parts_in_chunk[source].counter`
-// (atomic RMW). Reads `c.graph`/`c.parse_graph` SoA columns shared. Never
-// forms `&mut LinkerContext` — `c_ptr` stays raw and the printer takes
-// `&LinkerContext` (see `generate_code_for_file_in_chunk_js`).
-// `PendingPartRange` is `Send` because its only non-auto-`Send` field is
-// `&GenerateChunkCtx` whose pointee is `unsafe impl Send + Sync`.
+// `PendingPartRange`, and every part range of every JS chunk is in flight at
+// once against the same `LinkerContext` (and, per chunk, the same `Chunk`).
+// Writes: `chunk.compile_results_for_chunk[i]` (disjoint by per-task `i`),
+// `chunk.files_with_parts_in_chunk[source].counter` (atomic RMW). Reads
+// `c.graph`/`c.parse_graph` SoA columns and `chunk.renamer` shared. Never
+// forms `&mut LinkerContext` or `&mut Chunk`: the whole impl chain
+// (`generate_code_for_file_in_chunk_js`, `convert_stmts_for_chunk*`,
+// `print_code_for_file_in_chunk_js`) takes `&`, exactly like the CSS and
+// HTML callbacks. `PendingPartRange` is `Send` because its only
+// non-auto-`Send` field is `&GenerateChunkCtx` whose pointee is
+// `unsafe impl Send + Sync`.
 //
 /// # Safety
 ///
@@ -33,21 +37,21 @@ pub(crate) unsafe fn generate_compile_result_for_js_chunk(task: *mut ThreadPoolL
     let (part_range, c_ptr, chunk_ptr, mut worker) =
         unsafe { crate::linker_context_mod::pending_part_range_prologue(task) };
 
+    // The `&` borrows are scoped to the impl call so they do not overlap the
+    // raw slot write that follows.
     let result = {
-        // SAFETY: `c_ptr` / `chunk_ptr` carry mutable provenance; the disjoint-write
-        // contract is documented on `pending_part_range_prologue`. The `&mut`
-        // borrows below are scoped to the impl call so they do not overlap the
-        // raw slot write that follows. (Peer tasks still hold their own `&mut`
-        // views into the same `LinkerContext`/`Chunk` for read-only printer use —
-        // see the renamer caveat / SAFETY note on `unsafe impl Sync for
-        // Chunk` in Chunk.rs.)
-        let c_mut: &mut LinkerContext = unsafe { &mut *c_ptr };
-        // SAFETY: same mutable-provenance / disjoint-write contract as `c_ptr` above.
-        let chunk_mut: &mut Chunk = unsafe { &mut *chunk_ptr };
+        // SAFETY: `c_ptr` is the live `LinkerContext` returned by
+        // `pending_part_range_prologue`; peer tasks only ever form `&` to it
+        // too (see its contract), so a shared borrow is valid here.
+        let c_ref: &LinkerContext = unsafe { &*c_ptr };
+        // SAFETY: `chunk_ptr` is the live `Chunk` from the same prologue; the
+        // only concurrent writes into it go through `UnsafeCell` slots and
+        // atomics (see `unsafe impl Sync for Chunk`), so `&Chunk` is valid.
+        let chunk_ref: &Chunk = unsafe { &*chunk_ptr };
         generate_compile_result_for_js_chunk_impl(
             &mut **worker,
-            c_mut,
-            chunk_mut,
+            c_ref,
+            chunk_ref,
             part_range.part_range,
         )
     };
@@ -60,8 +64,8 @@ pub(crate) unsafe fn generate_compile_result_for_js_chunk(task: *mut ThreadPoolL
 
 fn generate_compile_result_for_js_chunk_impl(
     worker: &mut Worker,
-    c: &mut LinkerContext,
-    chunk: &mut Chunk,
+    c: &LinkerContext,
+    chunk: &Chunk,
     part_range: PartRange,
 ) -> CompileResult {
     let _trace = bun_core::perf::trace("Bundler.generateCodeForFileInChunkJS");
@@ -99,7 +103,7 @@ fn generate_compile_result_for_js_chunk_impl(
         .expect("Worker.stmt_list set in create()");
     stmt_list.reset();
 
-    let runtime_scope: &mut Scope = &mut c.graph.ast.items_module_scope_mut()
+    let runtime_scope: &Scope = &c.graph.ast.items_module_scope()
         [c.graph.files.items_input_file()[Index::RUNTIME.get() as usize].get() as usize];
     let runtime_members = &runtime_scope.members;
     let to_common_js_ref = c.graph.symbols.follow(
@@ -133,17 +137,10 @@ fn generate_compile_result_for_js_chunk_impl(
         .options
         .generates_module_info()
         .then(|| ModuleInfo::create(false));
-    // SAFETY: split borrow of `chunk` — `generate_code_for_file_in_chunk_js` never
-    // touches `chunk.renamer` through its `chunk` parameter; take a raw-ptr view so borrowck doesn't
-    // see two overlapping `&mut chunk` borrows.
-    let renamer_ptr: *mut crate::bun_renamer::ChunkRenamer = core::ptr::addr_of_mut!(chunk.renamer);
     let result = generate_code_for_file_in_chunk_js(
         c,
         &mut buffer_writer,
-        // SAFETY: split borrow of `*chunk` — `renamer_ptr` aliases only
-        // `chunk.renamer`, which the callee never touches via its `chunk`
-        // parameter, so this deref does not overlap the `chunk` reborrow below.
-        unsafe { (*renamer_ptr).as_renamer() },
+        chunk.renamer.as_renamer(),
         chunk,
         part_range,
         to_common_js_ref,

--- a/src/bundler/linker_context/generateCompileResultForJSChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForJSChunk.rs
@@ -18,13 +18,14 @@ use super::generate_code_for_file_in_chunk_js::generate_code_for_file_in_chunk_j
 // once against the same `LinkerContext` (and, per chunk, the same `Chunk`).
 // Writes: `chunk.compile_results_for_chunk[i]` (disjoint by per-task `i`),
 // `chunk.files_with_parts_in_chunk[source].counter` (atomic RMW). Reads
-// `c.graph`/`c.parse_graph` SoA columns and `chunk.renamer` shared. Never
-// forms `&mut LinkerContext` or `&mut Chunk`: the whole impl chain
+// `c.graph`/`c.parse_graph` SoA columns and `chunk.renamer` shared. The
+// prologue hands out `&LinkerContext` / `&Chunk` and the whole impl chain
 // (`generate_code_for_file_in_chunk_js`, `convert_stmts_for_chunk*`,
 // `print_code_for_file_in_chunk_js`) takes `&`, exactly like the CSS and
-// HTML callbacks. `PendingPartRange` is `Send` because its only
-// non-auto-`Send` field is `&GenerateChunkCtx` whose pointee is
-// `unsafe impl Send + Sync`.
+// HTML callbacks; nothing here may form `&mut` to either (see
+// test/internal/source-lints/chunk-codegen-shared-borrows.test.ts).
+// `PendingPartRange` is `Send` because its only non-auto-`Send` field is
+// `&GenerateChunkCtx` whose pointee is `unsafe impl Send + Sync`.
 //
 /// # Safety
 ///
@@ -34,32 +35,19 @@ use super::generate_code_for_file_in_chunk_js::generate_code_for_file_in_chunk_j
 pub(crate) unsafe fn generate_compile_result_for_js_chunk(task: *mut ThreadPoolLib::Task) {
     // SAFETY: `task` is the intrusive `task` field of a `PendingPartRange`
     // scheduled by `generate_chunks_in_parallel`; see the helper's contract.
-    let (part_range, c_ptr, chunk_ptr, mut worker) =
+    let (part_range, c, chunk, mut worker) =
         unsafe { crate::linker_context_mod::pending_part_range_prologue(task) };
 
-    // The `&` borrows are scoped to the impl call so they do not overlap the
-    // raw slot write that follows.
-    let result = {
-        // SAFETY: `c_ptr` is the live `LinkerContext` returned by
-        // `pending_part_range_prologue`; peer tasks only ever form `&` to it
-        // too (see its contract), so a shared borrow is valid here.
-        let c_ref: &LinkerContext = unsafe { &*c_ptr };
-        // SAFETY: `chunk_ptr` is the live `Chunk` from the same prologue; the
-        // only concurrent writes into it go through `UnsafeCell` slots and
-        // atomics (see `unsafe impl Sync for Chunk`), so `&Chunk` is valid.
-        let chunk_ref: &Chunk = unsafe { &*chunk_ptr };
-        generate_compile_result_for_js_chunk_impl(
-            &mut **worker,
-            c_ref,
-            chunk_ref,
-            part_range.part_range,
-        )
-    };
+    let result =
+        generate_compile_result_for_js_chunk_impl(&mut **worker, c, chunk, part_range.part_range);
 
-    // SAFETY: per-task unique `i`; see `Chunk::write_compile_result_slot`.
-    // The slot write is routed through raw `addr_of_mut!` + `UnsafeCell` so it
-    // never materializes `&mut Chunk` / `&mut [CompileResult]`.
-    unsafe { Chunk::write_compile_result_slot(chunk_ptr, part_range.i as usize, result) };
+    // SAFETY: `part_range.i` is unique among this chunk's tasks and nothing
+    // reads the slot before the pool join; see `CompileResultSlots::write`.
+    unsafe {
+        chunk
+            .compile_results_for_chunk
+            .write(part_range.i as usize, result)
+    };
 }
 
 fn generate_compile_result_for_js_chunk_impl(

--- a/src/bundler/linker_context/generateCompileResultForJSChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForJSChunk.rs
@@ -13,16 +13,11 @@ use crate::{Chunk, CompileResult, Index, PartRange};
 
 use super::generate_code_for_file_in_chunk_js::generate_code_for_file_in_chunk_js;
 
-// CONCURRENCY: thread-pool callback — runs on worker threads, one task per
-// `PendingPartRange`, and every part range of every JS chunk is in flight at
-// once against the same `LinkerContext` (and, per chunk, the same `Chunk`).
-// Writes: `chunk.compile_results_for_chunk[i]` (disjoint by per-task `i`),
-// `chunk.files_with_parts_in_chunk[source].counter` (atomic RMW). Reads
-// `c.graph`/`c.parse_graph` SoA columns and `chunk.renamer` shared. The
-// prologue hands out `&LinkerContext` / `&Chunk` and the whole impl chain
-// (`generate_code_for_file_in_chunk_js`, `convert_stmts_for_chunk*`,
-// `print_code_for_file_in_chunk_js`) takes `&`, exactly like the CSS and
-// HTML callbacks; nothing here may form `&mut` to either (see
+// CONCURRENCY: thread-pool callback — one task per `PendingPartRange`, all of
+// them in flight at once against one `LinkerContext` and, per chunk, one
+// `Chunk`. Writes: `chunk.compile_results_for_chunk[i]` (per-task `i`),
+// `chunk.files_with_parts_in_chunk[source]` (atomic RMW); everything else is
+// read through the `&LinkerContext` / `&Chunk` from the prologue (enforced by
 // test/internal/source-lints/chunk-codegen-shared-borrows.test.ts).
 // `PendingPartRange` is `Send` because its only non-auto-`Send` field is
 // `&GenerateChunkCtx` whose pointee is `unsafe impl Send + Sync`.
@@ -41,8 +36,7 @@ pub(crate) unsafe fn generate_compile_result_for_js_chunk(task: *mut ThreadPoolL
     let result =
         generate_compile_result_for_js_chunk_impl(&mut **worker, c, chunk, part_range.part_range);
 
-    // SAFETY: `part_range.i` is unique among this chunk's tasks and nothing
-    // reads the slot before the pool join; see `CompileResultSlots::write`.
+    // SAFETY: `part_range.i` is this task's own slot; nothing reads it before the join.
     unsafe {
         chunk
             .compile_results_for_chunk

--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -712,11 +712,10 @@ pub(crate) fn post_process_js_chunk(
 }
 
 // `js_printer::print` ties bump/Options/import_records/renamer to a
-// single `'a`, and `Renamer<'r, 'src>` is invariant in `'src` — so the caller's
-// renamer lifetime fixes `'a`. All by-ref params that flow into `print` must
-// share that lifetime.
+// single `'a`, so all by-ref params that flow into `print` share that
+// lifetime.
 pub(crate) fn generate_entry_point_tail_js<'a>(
-    c: &'a mut LinkerContext,
+    c: &'a LinkerContext,
     to_common_js_ref: Ref,
     to_esm_ref: Ref,
     source_index: IndexInt,

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1306,8 +1306,6 @@ impl Default for RequireOrImportMetaCallback {
 
 /// PORTING.md §Dispatch — manual vtable. The erased thunk is monomorphized
 /// over `T: RequireOrImportMetaSource`, so `callback` stays a captureless `fn`.
-/// `&self` because the bundler prints many part ranges of one `LinkerContext`
-/// concurrently.
 pub trait RequireOrImportMetaSource {
     fn require_or_import_meta_for_source(
         &self,

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1306,10 +1306,8 @@ impl Default for RequireOrImportMetaCallback {
 
 /// PORTING.md §Dispatch — manual vtable. The erased thunk is monomorphized
 /// over `T: RequireOrImportMetaSource`, so `callback` stays a captureless `fn`.
-///
-/// Takes `&self`: the bundler installs one callback per part range while
-/// printing many part ranges of the same `LinkerContext` concurrently, so the
-/// erased context is only ever a shared borrow.
+/// `&self` because the bundler prints many part ranges of one `LinkerContext`
+/// concurrently.
 pub trait RequireOrImportMetaSource {
     fn require_or_import_meta_for_source(
         &self,
@@ -2414,9 +2412,6 @@ pub(crate) mod __gated_printer {
             self.renamer.symbols()
         }
 
-        /// The name borrows the renamer for `'a` (`Renamer<'a, 'a>`), not
-        /// `self`, so callers can hold it across the `&mut self` print calls
-        /// that follow.
         #[inline]
         fn name_for_symbol(&self, ref_: Ref) -> &'a [u8] {
             self.renamer.name_for_symbol(ref_)
@@ -7367,8 +7362,6 @@ pub fn print_ast<'a, W: WriterTrait, const ASCII_ONLY: bool, const GENERATE_SOUR
     let _restore =
         bun_crash_handler::scoped_action(bun_crash_handler::Action::Print(source.path.text));
 
-    // Declared out here so the borrow stored in `renamer` outlives the branch
-    // that fills in whichever of the two is used.
     let no_op_renamer;
     let mut minify_renamer;
     // `Scope` isn't `Copy` here and the only

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1289,12 +1289,12 @@ pub struct RequireOrImportMeta {
 #[derive(Clone, Copy)]
 pub struct RequireOrImportMetaCallback {
     pub(crate) ctx: Option<NonNull<()>>,
-    pub(crate) callback: fn(*mut (), u32, bool) -> RequireOrImportMeta,
+    pub(crate) callback: fn(*const (), u32, bool) -> RequireOrImportMeta,
 }
 
 impl Default for RequireOrImportMetaCallback {
     fn default() -> Self {
-        fn noop(_: *mut (), _: u32, _: bool) -> RequireOrImportMeta {
+        fn noop(_: *const (), _: u32, _: bool) -> RequireOrImportMeta {
             RequireOrImportMeta::default()
         }
         Self {
@@ -1306,9 +1306,13 @@ impl Default for RequireOrImportMetaCallback {
 
 /// PORTING.md §Dispatch — manual vtable. The erased thunk is monomorphized
 /// over `T: RequireOrImportMetaSource`, so `callback` stays a captureless `fn`.
+///
+/// Takes `&self`: the bundler installs one callback per part range while
+/// printing many part ranges of the same `LinkerContext` concurrently, so the
+/// erased context is only ever a shared borrow.
 pub trait RequireOrImportMetaSource {
     fn require_or_import_meta_for_source(
-        &mut self,
+        &self,
         id: u32,
         was_unwrapped_require: bool,
     ) -> RequireOrImportMeta;
@@ -1319,19 +1323,19 @@ impl RequireOrImportMetaCallback {
         (self.callback)(self.ctx.unwrap().as_ptr(), id, was_unwrapped_require)
     }
 
-    pub fn init<T: RequireOrImportMetaSource>(ctx: &mut T) -> Self {
+    pub fn init<T: RequireOrImportMetaSource>(ctx: &T) -> Self {
         fn thunk<T: RequireOrImportMetaSource>(
-            p: *mut (),
+            p: *const (),
             id: u32,
             was_unwrapped_require: bool,
         ) -> RequireOrImportMeta {
-            // SAFETY: `p` was constructed from `&mut T` in `init` below; caller guarantees
+            // SAFETY: `p` was constructed from `&T` in `init` below; caller guarantees
             // `ctx` outlives this `RequireOrImportMetaCallback`, so the cast-back
-            // deref is valid and exclusive.
+            // shared deref is valid.
             unsafe { (*p.cast::<T>()).require_or_import_meta_for_source(id, was_unwrapped_require) }
         }
         Self {
-            // Type-erased to `*mut ()` and cast back to `*mut T` inside the thunk before dereference.
+            // Type-erased to `*const ()` and cast back to `*const T` inside the thunk before dereference.
             ctx: Some(NonNull::from(ctx).cast::<()>()),
             callback: thunk::<T>,
         }
@@ -2410,19 +2414,12 @@ pub(crate) mod __gated_printer {
             self.renamer.symbols()
         }
 
-        /// Borrowck-reshape helper: `Renamer::name_for_symbol` returns a slice
-        /// borrowing `&mut self.renamer`, which conflicts with the immediately
-        /// following `self.print_*` call. The returned bytes always point into
-        /// either the AST arena (`Symbol::original_name: *const [u8]`) or the
-        /// `Source::contents` buffer — both are kept alive for `'a` by the
-        /// caller of `Printer::init`. Detach the borrow to a raw ptr per the
-        /// parser's ARENA convention (matching `slice_of` for AST fields).
-        /// Reshaped for borrowck — a future refactor could thread `'bump` through Renamer.
+        /// The name borrows the renamer for `'a` (`Renamer<'a, 'a>`), not
+        /// `self`, so callers can hold it across the `&mut self` print calls
+        /// that follow.
         #[inline]
-        fn name_for_symbol(&mut self, ref_: Ref) -> &'a [u8] {
-            let p = std::ptr::from_ref::<[u8]>(self.renamer.name_for_symbol(ref_));
-            // SAFETY: arena/source-backed; outlives 'a (see renamer.rs SAFETY notes).
-            unsafe { &*p }
+        fn name_for_symbol(&self, ref_: Ref) -> &'a [u8] {
+            self.renamer.name_for_symbol(ref_)
         }
 
         // Emitting a `throw` shim is a diagnostic/error path — keep it out of the
@@ -5438,7 +5435,7 @@ pub(crate) mod __gated_printer {
 
                     if Self::MAY_HAVE_MODULE_INFO && self.module_info.is_some() {
                         // reshaped for borrowck — re-borrow module_info per item so
-                        // `name_for_symbol` (which needs `&mut self`) can run between uses.
+                        // `name_for_symbol` (which borrows `self`) can run between uses.
                         let irp_id = {
                             let mi = self.module_info().expect("infallible: module_info enabled");
                             let id = mi.str(irp);
@@ -7370,13 +7367,9 @@ pub fn print_ast<'a, W: WriterTrait, const ASCII_ONLY: bool, const GENERATE_SOUR
     let _restore =
         bun_crash_handler::scoped_action(bun_crash_handler::Action::Print(source.path.text));
 
-    // `Renamer<'r,'src>` is invariant in `'src` (it holds `&'r mut`
-    // NoOpRenamer<'src>`), so the two arms must agree on `'src`; constructing the
-    // `MinifyRenamer` variant inline (rather than via `to_renamer() ->
-    // Renamer<'static,'static>`) lets inference unify it with the no-op arm.
-    let mut no_op_renamer;
-    // hoisted out of the `minify_identifiers` arm so the
-    // `&'r mut MinifyRenamer` borrow stored in `renamer` outlives the branch.
+    // Declared out here so the borrow stored in `renamer` outlives the branch
+    // that fills in whichever of the two is used.
+    let no_op_renamer;
     let mut minify_renamer;
     // `Scope` isn't `Copy` here and the only
     // consumer (`compute_reserved_names_for_scope`) walks `members`/`generated`/
@@ -7462,7 +7455,7 @@ pub fn print_ast<'a, W: WriterTrait, const ASCII_ONLY: bool, const GENERATE_SOUR
         let minifier = tree.char_freq.as_ref().unwrap().compile();
         minify_renamer.assign_names_by_frequency(&minifier)?;
 
-        rename::Renamer::MinifyRenamer(&mut *minify_renamer)
+        rename::Renamer::MinifyRenamer(&*minify_renamer)
     } else {
         no_op_renamer = rename::NoOpRenamer::init(symbols, source);
         no_op_renamer.to_renamer()
@@ -7607,8 +7600,7 @@ pub fn print_json<W: WriterTrait>(
     // The printer only needs default-empty `import_records` and `symbols` for
     // the no-op renamer; construct them directly without an `Ast`.
     let bump = bun_alloc::Arena::new();
-    let mut no_op =
-        rename::NoOpRenamer::init(js_ast::symbol::Map::init_list(vec![Vec::new()]), source);
+    let no_op = rename::NoOpRenamer::init(js_ast::symbol::Map::init_list(vec![Vec::new()]), source);
 
     let full_opts = Options {
         indent: opts.indent,

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -139,13 +139,9 @@ impl<'a> NoOpRenamer<'a> {
     }
 }
 
-// Two lifetime params — `'r` is the borrow of the underlying renamer,
-// `'src` is `NoOpRenamer`'s borrow of the `Source`.
-//
-// The variants hold shared borrows: names are fully assigned before anything
-// is printed, and the bundler prints every part range of a chunk in parallel
-// through the chunk's one renamer, so a `Renamer` must be obtainable from
-// `&Chunk` without any task claiming exclusive access to it.
+// `'r` is the borrow of the underlying renamer, `'src` is `NoOpRenamer`'s
+// borrow of the `Source`. Shared borrows: names are assigned before printing,
+// and the bundler prints a chunk's part ranges in parallel through one renamer.
 pub enum Renamer<'r, 'src> {
     NumberRenamer(&'r NumberRenamer),
     NoOpRenamer(&'r NoOpRenamer<'src>),
@@ -161,10 +157,8 @@ impl<'r, 'src> Renamer<'r, 'src> {
         }
     }
 
-    /// The returned bytes live as long as the borrowed renamer (`'r`), not just
-    /// as long as this `Renamer` value: they point into the AST arena
-    /// (`Symbol::original_name`), the `Source` contents, or the renamer's own
-    /// slot storage, none of which change while the renamer is borrowed.
+    /// Returns `&'r` (the renamer's borrow, not this value's) so the printer
+    /// can hold a name across its own `&mut self` calls.
     pub fn name_for_symbol(&self, ref_: Ref) -> &'r [u8] {
         match *self {
             Renamer::NumberRenamer(r) => r.name_for_symbol(ref_),

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -157,8 +157,6 @@ impl<'r, 'src> Renamer<'r, 'src> {
         }
     }
 
-    /// Returns `&'r` (the renamer's borrow, not this value's) so the printer
-    /// can hold a name across its own `&mut self` calls.
     pub fn name_for_symbol(&self, ref_: Ref) -> &'r [u8] {
         match *self {
             Renamer::NumberRenamer(r) => r.name_for_symbol(ref_),

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -134,19 +134,22 @@ impl<'a> NoOpRenamer<'a> {
         }
     }
 
-    pub(crate) fn to_renamer(&mut self) -> Renamer<'_, 'a> {
+    pub(crate) fn to_renamer(&self) -> Renamer<'_, 'a> {
         Renamer::NoOpRenamer(self)
     }
 }
 
 // Two lifetime params — `'r` is the borrow of the underlying renamer,
-// `'src` is `NoOpRenamer`'s borrow of the `Source`. Erasing both with a
-// single lifetime via `&'a mut NoOpRenamer<'a>` would make
-// `'a` invariant and lock the source borrow to the renamer borrow.
+// `'src` is `NoOpRenamer`'s borrow of the `Source`.
+//
+// The variants hold shared borrows: names are fully assigned before anything
+// is printed, and the bundler prints every part range of a chunk in parallel
+// through the chunk's one renamer, so a `Renamer` must be obtainable from
+// `&Chunk` without any task claiming exclusive access to it.
 pub enum Renamer<'r, 'src> {
-    NumberRenamer(&'r mut NumberRenamer),
-    NoOpRenamer(&'r mut NoOpRenamer<'src>),
-    MinifyRenamer(&'r mut MinifyRenamer),
+    NumberRenamer(&'r NumberRenamer),
+    NoOpRenamer(&'r NoOpRenamer<'src>),
+    MinifyRenamer(&'r MinifyRenamer),
 }
 
 impl<'r, 'src> Renamer<'r, 'src> {
@@ -158,8 +161,12 @@ impl<'r, 'src> Renamer<'r, 'src> {
         }
     }
 
-    pub fn name_for_symbol(&mut self, ref_: Ref) -> &[u8] {
-        match self {
+    /// The returned bytes live as long as the borrowed renamer (`'r`), not just
+    /// as long as this `Renamer` value: they point into the AST arena
+    /// (`Symbol::original_name`), the `Source` contents, or the renamer's own
+    /// slot storage, none of which change while the renamer is borrowed.
+    pub fn name_for_symbol(&self, ref_: Ref) -> &'r [u8] {
+        match *self {
             Renamer::NumberRenamer(r) => r.name_for_symbol(ref_),
             Renamer::NoOpRenamer(r) => r.name_for_symbol(ref_),
             Renamer::MinifyRenamer(r) => r.name_for_symbol(ref_),
@@ -212,10 +219,7 @@ impl InlineString {
         this
     }
 
-    // do not make this *const or you will run into memory bugs.
-    // we cannot let the compiler decide to copy this struct because
-    // that would cause this to become a pointer to stack memory.
-    fn slice(&mut self) -> &[u8] {
+    fn slice(&self) -> &[u8] {
         &self.bytes[0..self.len as usize]
     }
 }
@@ -237,10 +241,7 @@ impl TinyString {
         }
     }
 
-    // do not make this *const or you will run into memory bugs.
-    // we cannot let the compiler decide to copy this struct because
-    // that would cause this to become a pointer to stack memory.
-    fn slice(&mut self) -> &[u8] {
+    fn slice(&self) -> &[u8] {
         match self {
             TinyString::InlineString(s) => s.slice(),
             // `StoreStr::slice` centralises the arena-backed deref; the payload
@@ -299,7 +300,7 @@ impl MinifyRenamer {
         }))
     }
 
-    pub fn name_for_symbol(&mut self, ref_: Ref) -> &[u8] {
+    pub fn name_for_symbol(&self, ref_: Ref) -> &[u8] {
         let ref_ = self.symbols.follow(ref_);
         let symbol: &Symbol = self.symbols.get_const(ref_).unwrap();
 
@@ -319,7 +320,7 @@ impl MinifyRenamer {
             None => return symbol.original_name.slice(),
         };
 
-        // This has to be a pointer because the string might be stored inline
+        // Borrow the slot in place: the name may be stored inline in it.
         self.slots[ns][i].name.slice()
     }
 

--- a/test/internal/source-lints/chunk-codegen-shared-borrows.test.ts
+++ b/test/internal/source-lints/chunk-codegen-shared-borrows.test.ts
@@ -4,62 +4,75 @@ import path from "path";
 
 // The chunk codegen fan-out in generateChunksInParallel.rs schedules one
 // thread-pool task per part range of every chunk and runs all of them at once
-// against the single LinkerContext and, per chunk, the single Chunk. Each task
-// is handed the same raw `c_ptr` / `chunk_ptr` by `pending_part_range_prologue`;
-// its only writes are its own `compile_results_for_chunk[i]` slot (through the
-// raw pointer in `Chunk::write_compile_result_slot`) and atomic counters.
+// against the single LinkerContext and, per chunk, the single Chunk. Every task
+// of a chunk therefore reads through the same `&LinkerContext` / `&Chunk`,
+// which `pending_part_range_prologue` (LinkerContext.rs) hands out; a task's
+// only writes are its own `compile_results_for_chunk` slot (an UnsafeCell,
+// written through that shared borrow by `CompileResultSlots::write`) and
+// atomic counters.
 //
-// A task that turns its raw pointer into `&mut LinkerContext` or `&mut Chunk`
-// claims exclusive access to memory every peer task is reading at that moment.
-// That is aliasing UB even while the writes stay disjoint, and rustc cannot see
-// it: the tasks reach the pointers through `unsafe impl Send/Sync` types. It
-// also has no runtime symptom today, which is why this is checked by grep. The
-// JS callback did exactly this (the CSS and HTML callbacks already took `&`);
-// now all three form shared borrows and the code they call takes `&` too, so
-// reintroducing `&mut` in a callback is the only way to get it back.
-//
-// `GenerateChunkCtx::c()` hands out `&mut LinkerContext` for the per-chunk
-// post-process tasks (postProcess*Chunk.rs); it must not be used from these
-// fan-out callbacks either.
+// A task that forms `&mut LinkerContext` or `&mut Chunk` instead claims
+// exclusive access to memory every peer task is reading at that moment. That is
+// aliasing UB even while the writes stay disjoint, rustc cannot see it (the
+// tasks reach the objects through `unsafe impl Send/Sync` types), and it has no
+// runtime symptom, which is why it is checked by grep. The JS callback used to
+// do exactly this. Now the prologue only offers shared borrows and everything
+// the callbacks call takes `&`, so the two ways back are changing the prologue
+// or reaching past it: `GenerateChunkCtx::c()` / `ParentRef::assume_mut` /
+// `as_mut_ptr` (which exist for the per-chunk post-process tasks in
+// postProcess*Chunk.rs) or casting the shared borrow back to a raw `*mut`.
 
 const root = path.resolve(import.meta.dir, "..", "..", "..");
+const linkerContextDir = "src/bundler/linker_context";
 
 const FAN_OUT_CALLBACKS = [
-  "src/bundler/linker_context/generateCompileResultForJSChunk.rs",
-  "src/bundler/linker_context/generateCompileResultForCssChunk.rs",
-  "src/bundler/linker_context/generateCompileResultForHtmlChunk.rs",
+  `${linkerContextDir}/generateCompileResultForCssChunk.rs`,
+  `${linkerContextDir}/generateCompileResultForHtmlChunk.rs`,
+  `${linkerContextDir}/generateCompileResultForJSChunk.rs`,
 ];
 
-const EXCLUSIVE_BORROWS: RegExp[] = [
-  /&mut\s+\*\s*c_ptr\b/,
-  /&mut\s+\*\s*chunk_ptr\b/,
+const EXCLUSIVE_ACCESS: RegExp[] = [
   /&mut\s+LinkerContext\b/,
   /&mut\s+Chunk\b/,
   /\.c\(\)/,
-  /\.assume_mut\(\)/,
+  /\.assume_mut\(/,
+  /\.as_mut_ptr\(/,
+  /\.cast_mut\(/,
+  /\bas\s+\*\s*mut\b/,
 ];
 
-const sources = new Map<string, string>();
-for (const source of FAN_OUT_CALLBACKS) {
-  const content = await file(path.join(root, source)).text();
-  // Blank out full-line comments (the CONCURRENCY notes in these files describe
-  // the borrows they must not form) without changing line numbers.
-  sources.set(source, content.replace(/^[ \t]*\/\/.*$/gm, ""));
+// Blank out full-line comments (the CONCURRENCY notes in these files describe
+// the borrows they must not form) without changing line numbers.
+const stripComments = (content: string) => content.replace(/^[ \t]*\/\/.*$/gm, "");
+
+const callbackSources = new Map<string, string>();
+for (const relative of new Bun.Glob(`${linkerContextDir}/*.rs`).scanSync({ cwd: root })) {
+  const source = relative.replaceAll(path.sep, "/");
+  const stripped = stripComments(await file(path.join(root, source)).text());
+  if (stripped.includes("pending_part_range_prologue(")) callbackSources.set(source, stripped);
 }
 
-test("every fan-out callback still publishes through the raw slot writer", () => {
-  // Anchors the list above to the code it is meant to cover: a callback that
-  // moves or stops using the slot writer has to update this lint.
-  for (const stripped of sources.values()) {
-    expect(stripped).toContain("Chunk::write_compile_result_slot(");
-  }
+test("the prologue hands the fan-out callbacks shared borrows", async () => {
+  const linkerContext = stripComments(await file(path.join(root, "src/bundler/LinkerContext.rs")).text());
+  const signature = /fn pending_part_range_prologue<'a>\([\s\S]*?\)\s*->\s*\(([\s\S]*?)\)\s*\{/.exec(linkerContext);
+  expect(signature).not.toBeNull();
+  const returns = signature![1].replace(/\s+/g, " ");
+  expect(returns).toContain("&'a LinkerContext<'a>,");
+  expect(returns).toContain("&'a Chunk,");
+  expect(returns).not.toContain("*mut");
 });
 
-test("fan-out callbacks never form &mut LinkerContext or &mut Chunk", () => {
+test("every fan-out callback is covered", () => {
+  // The callbacks are found by their use of the prologue, so a new one is
+  // linted automatically; this just keeps the list in the header honest.
+  expect([...callbackSources.keys()].sort()).toEqual(FAN_OUT_CALLBACKS);
+});
+
+test("fan-out callbacks never take exclusive access to the LinkerContext or a Chunk", () => {
   const offenders: string[] = [];
-  for (const [source, stripped] of sources) {
+  for (const [source, stripped] of callbackSources) {
     stripped.split("\n").forEach((line, i) => {
-      if (EXCLUSIVE_BORROWS.some(re => re.test(line))) {
+      if (EXCLUSIVE_ACCESS.some(re => re.test(line))) {
         offenders.push(`${source}:${i + 1}: ${line.trim()}`);
       }
     });

--- a/test/internal/source-lints/chunk-codegen-shared-borrows.test.ts
+++ b/test/internal/source-lints/chunk-codegen-shared-borrows.test.ts
@@ -1,0 +1,68 @@
+import { file } from "bun";
+import { expect, test } from "bun:test";
+import path from "path";
+
+// The chunk codegen fan-out in generateChunksInParallel.rs schedules one
+// thread-pool task per part range of every chunk and runs all of them at once
+// against the single LinkerContext and, per chunk, the single Chunk. Each task
+// is handed the same raw `c_ptr` / `chunk_ptr` by `pending_part_range_prologue`;
+// its only writes are its own `compile_results_for_chunk[i]` slot (through the
+// raw pointer in `Chunk::write_compile_result_slot`) and atomic counters.
+//
+// A task that turns its raw pointer into `&mut LinkerContext` or `&mut Chunk`
+// claims exclusive access to memory every peer task is reading at that moment.
+// That is aliasing UB even while the writes stay disjoint, and rustc cannot see
+// it: the tasks reach the pointers through `unsafe impl Send/Sync` types. It
+// also has no runtime symptom today, which is why this is checked by grep. The
+// JS callback did exactly this (the CSS and HTML callbacks already took `&`);
+// now all three form shared borrows and the code they call takes `&` too, so
+// reintroducing `&mut` in a callback is the only way to get it back.
+//
+// `GenerateChunkCtx::c()` hands out `&mut LinkerContext` for the per-chunk
+// post-process tasks (postProcess*Chunk.rs); it must not be used from these
+// fan-out callbacks either.
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+
+const FAN_OUT_CALLBACKS = [
+  "src/bundler/linker_context/generateCompileResultForJSChunk.rs",
+  "src/bundler/linker_context/generateCompileResultForCssChunk.rs",
+  "src/bundler/linker_context/generateCompileResultForHtmlChunk.rs",
+];
+
+const EXCLUSIVE_BORROWS: RegExp[] = [
+  /&mut\s+\*\s*c_ptr\b/,
+  /&mut\s+\*\s*chunk_ptr\b/,
+  /&mut\s+LinkerContext\b/,
+  /&mut\s+Chunk\b/,
+  /\.c\(\)/,
+  /\.assume_mut\(\)/,
+];
+
+const sources = new Map<string, string>();
+for (const source of FAN_OUT_CALLBACKS) {
+  const content = await file(path.join(root, source)).text();
+  // Blank out full-line comments (the CONCURRENCY notes in these files describe
+  // the borrows they must not form) without changing line numbers.
+  sources.set(source, content.replace(/^[ \t]*\/\/.*$/gm, ""));
+}
+
+test("every fan-out callback still publishes through the raw slot writer", () => {
+  // Anchors the list above to the code it is meant to cover: a callback that
+  // moves or stops using the slot writer has to update this lint.
+  for (const stripped of sources.values()) {
+    expect(stripped).toContain("Chunk::write_compile_result_slot(");
+  }
+});
+
+test("fan-out callbacks never form &mut LinkerContext or &mut Chunk", () => {
+  const offenders: string[] = [];
+  for (const [source, stripped] of sources) {
+    stripped.split("\n").forEach((line, i) => {
+      if (EXCLUSIVE_BORROWS.some(re => re.test(line))) {
+        offenders.push(`${source}:${i + 1}: ${line.trim()}`);
+      }
+    });
+  }
+  expect(offenders).toEqual([]);
+});


### PR DESCRIPTION
### Problem
- `generate_chunks_in_parallel` (`src/bundler/linker_context/generateChunksInParallel.rs`) schedules one thread-pool task per part range of every chunk and runs all of them at once. Every task is pointed at the same `LinkerContext`, and every task of a chunk at the same `Chunk` (`pending_part_range_prologue`).
- The JS task turned both pointers into exclusive borrows: `let c_mut: &mut LinkerContext = unsafe { &mut *c_ptr };` and `let chunk_mut: &mut Chunk = unsafe { &mut *chunk_ptr };` (`generateCompileResultForJSChunk.rs:44` and `:46` on main), and everything below it took `&mut` too: `generate_code_for_file_in_chunk_js`, `convert_stmts_for_chunk`, `convert_stmts_for_chunk_for_dev_server`, `should_remove_import_export_stmt`, `print_code_for_file_in_chunk_js`, and `RequireOrImportMetaCallback::init(&mut T)` (`src/js_printer/lib.rs:1322`), which re-formed `&mut LinkerContext` inside the printer for every `require()` it printed. Nothing in that chain writes through `c` or `chunk`; a task's only writes are its own `compile_results_for_chunk[i]` slot and the atomic `files_with_parts_in_chunk` counters.
- Many live `&mut` to one object is aliasing UB whether or not anything is written through them (Background). rustc cannot see it because the pointers arrive through `unsafe impl Send`/`Sync` types, and there is no runtime symptom because the real writes are disjoint. #31267 has a Miri stacked-borrows witness for this shape; the file's own header claimed it never formed `&mut LinkerContext`.
- Found while reworking this: the pointers themselves were also taken too early. `generate_chunks_in_parallel` stored each chunk's pointer (and the shared `&[Chunk]` view) and *then* wrote `chunk.compile_results_for_chunk` through the owner, and reborrowed the chunks `&mut` again while building the batch. Under the aliasing rules those owner writes invalidate the stored pointers, so every callback (CSS and HTML included, which already formed `&`) was reading through dead pointers. Same category of bug, same phase, no runtime symptom.
- The CSS callback was moved to `&` in #31116; #31267 covers the JS half as well but has been stale and conflicting since May. This PR re-derives that JS half on main and fixes the pointer derivation the three callbacks share.

### Fix
- `generate_chunks_in_parallel` sizes every chunk's slots first, takes the tasks' views (`GenerateChunkCtx::{chunks, chunk}`, now plain shared `BackRef`s) only after that last write, and iterates the chunks shared until the batch is joined.
- `pending_part_range_prologue` returns `&LinkerContext` / `&Chunk` instead of raw pointers, and the result is published with `CompileResultSlots::write(&self, i, result)`, a write through the slot's `UnsafeCell` behind the shared borrow. The raw-pointer slot writer (`Chunk::write_compile_result_slot`, which read the `Box` out of the chunk by hand) is gone, and with it the `#[repr(transparent)]` on `CompileResultSlots` that only existed to justify that read (nothing else depends on its layout); the JS, CSS and HTML callbacks contain no pointer derefs at all.
- `&` is threaded through everything the JS callback calls (the functions listed above); `RequireOrImportMetaSource` and `RequireOrImportMetaCallback::init` take `&T` (erased as `*const ()`); `generate_entry_point_tail_js` takes `&LinkerContext` too, since its `&mut` only existed to satisfy `init`.
- `Renamer<'r, 'src>` holds `&'r` renamers instead of `&'r mut`, so a chunk's renamer can be borrowed from `&Chunk`; `name_for_symbol`, `to_renamer`, `ChunkRenamer::as_renamer` and `TinyString::slice` become `&self`. The "do not make this *const" comments removed from `InlineString::slice` / `TinyString::slice` came verbatim from the 2023 Zig code (#2695), where they guarded against Zig passing a `*const` parameter by value; a Rust `&self` cannot have that problem, and the `&mut self` receivers were only the mechanical port of that workaround.
- Why this is correct: the whole chain compiles against `&` with no other change, which is the compiler confirming it never wrote through `c` or `chunk`; `&` is exactly the access concurrent readers are entitled to, and the two things the phase does write (the slots, the counters) are interior-mutable, so they are legal through `&` by construction. Taking the views after the owner's last write, and only reading the chunks afterwards, is what makes those `&` valid in the first place; the invariant is stated once, at the site in `generate_chunks_in_parallel` that depends on it. `symbols.follow()` is deliberately unchanged: `follow_all()` runs at the end of linking, before the fan-out, so `follow()` never writes during codegen (same design as Zig and esbuild), which is also why #31267's `follow()` rewrite is not taken.
- Workarounds that only existed because of the `&mut` go with it: the renamer lifetime transmute and the `detach_lifetime_ref` / raw `parse_graph` derefs in `print_code_for_file_in_chunk_js`, the `*mut [Part]` and `BackRef` dance in `generate_code_for_file_in_chunk_js`, the renamer split-borrow in the callback, the raw lifetime detach in `Printer::name_for_symbol` (`Renamer::name_for_symbol` returns `&'r [u8]` now), and the raw slot writer. 20 `unsafe` blocks removed, 5 added; no behavior change.
- Not changed, on purpose: the per-chunk renamer and post-process passes (`generate_js_renamer`, `generate_chunk`, run through `each_ptr`) still get `&mut LinkerContext` from `GenerateChunkCtx::c()`. Most of what they call could take `&self`, but `generate_isolated_hash` lazily initializes the browser transpiler through `&mut BundleV2`, and post-processing reuses a ctx built before the fan-out and reads `ctx.chunks` as `&[Chunk]` while peer tasks write their own chunks' fields, so that phase needs its own derivation fix and is a separate PR. This one is only the part-range fan-out, which is the phase with the most concurrent tasks.
- Verification:
  - `test/internal/source-lints/chunk-codegen-shared-borrows.test.ts` (new) checks that `pending_part_range_prologue` returns `&'a LinkerContext<'a>` / `&'a Chunk`, and that every file calling it contains no `&mut LinkerContext`, `&mut Chunk`, `.c()`, `.assume_mut(`, `.as_mut_ptr(`, `cast_mut(` or `as *mut`. On main it fails on both counts (the prologue returns `*mut`, and it lists the four JS lines); here it passes. The bug has no runtime symptom, so this is the before/after evidence; below the callbacks, the `&` signatures make the compiler do the rest.
  - `bun bd test test/bundler/` on the debug build at the first revision: 5967 pass, 6 fail, all six unrelated (`native-plugin`'s node-gyp `beforeAll` over the hook timeout and `compile/HelloWorldWithProcessVersionsBun`, which fails on every debug build, both with fixes in flight; four `bundler_jsx` `ENOENT`s from relinking the binary mid-run, which pass when re-run). After the derivation change: `bundler_html`, `esbuild/css`, `css/css-modules`, `esbuild/splitting`, `bundler_minify`, `bundler_cjs` (180 pass) and `bake/dev/css`, `bake/dev/bundle` (36 pass), covering the JS, CSS, HTML and dev-server paths through the fan-out.
  - `cargo clippy -p bun_js_printer -p bun_bundler`: clean.
- Related: #35361 (open) independently contains the `RequireOrImportMetaCallback::init(&T)` / `detach_lifetime_ref` subset of this diff but keeps the `&mut` callback, so it does not address the aliasing; whichever of the two lands second needs a small rebase in `print_code_for_file_in_chunk_js` and `init`.

### Background
- Part range: a contiguous run of one input file's parts that a chunk prints as one unit. A chunk's output is the concatenation of its part ranges' results, so the linker prints them independently, one `PendingPartRange` task each, into `compile_results_for_chunk` (`CompileResultSlots`, one `UnsafeCell` per slot) and joins the batch afterwards.
- Aliasing rule: `&mut T` promises that no other live pointer to that `T` is used while it is live, and a write through an owner (or a fresh `&mut` reborrow of it) revokes every pointer previously derived from that owner. rustc and LLVM optimize on these promises; Miri's stacked/tree borrows are the models that check them. So two threads creating `&mut` to one object is UB even if neither writes, and a pointer stored before the owner's write is UB to use afterwards even though it still points at the right bytes. `&T` only promises that nothing writes outside `UnsafeCell` while it is live, which atomics and `UnsafeCell` slots satisfy, so it is the right borrow for a phase of concurrent readers with interior-mutability writes.
- `GenerateChunkCtx`: the per-chunk context the tasks receive, holding pointers to the `LinkerContext`, to all chunks, and to the task's own chunk. `BackRef` / `ParentRef` (`src/ptr/`) are the project's non-owning pointer wrappers; both hand out `&T` via `Deref`, and `ParentRef<_, Mut>::assume_mut` is the audited escape hatch the post-process pass still uses.
- Renamer: before the fan-out each chunk builds a `NumberRenamer` or `MinifyRenamer` (stored as `Chunk::renamer`) that assigns every symbol's output name; `Renamer<'r, 'src>` is the borrowed view the printer consults through `name_for_symbol`.
- `RequireOrImportMetaCallback`: the printer's manual vtable back into the linker. When it prints a `require()` or `import.meta` for a bundled file it asks the linker for that file's wrapper and exports refs; the callback stores a type-erased pointer to the `LinkerContext` and is created once per printed part range.

<details>
<summary>Earlier shape of this PR</summary>

The first revision only re-derived #31267's JS half: it formed `&LinkerContext` / `&Chunk` from the prologue's raw pointers inside the JS callback and kept the raw slot writer, mirroring the CSS callback. Review of that revision turned up the early pointer derivation in `generate_chunks_in_parallel` described above, which is why the later commits restructure the setup, change the prologue's return type, replace the slot writer, and extend the lint to the prologue's signature.
</details>
