### PR TITLE
build: make the logs option reach Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,11 +201,11 @@ overflow-checks = false
 # back to "warn" (their priority 0 beats the group's -1) where a warning level
 # is intentional.
 warnings = { level = "deny", priority = -1 }
-# `bun_asan` / `bun_debug` / `socket_fault_injection` are set via RUSTFLAGS
-# (`--cfg=...` + `--check-cfg=cfg(...)`) by scripts/build/rust.ts; register
-# them here so a plain `cargo build` / `cargo check` (without those flags)
-# doesn't warn.
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(bun_asan)', 'cfg(bun_debug)', 'cfg(socket_fault_injection)'] }
+# `bun_asan` / `bun_debug` / `bun_logs` / `socket_fault_injection` are set via
+# RUSTFLAGS (`--cfg=...` + `--check-cfg=cfg(...)`) by scripts/build/rust.ts;
+# register them here so a plain `cargo build` / `cargo check` (without those
+# flags) doesn't warn.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(bun_asan)', 'cfg(bun_debug)', 'cfg(bun_logs)', 'cfg(socket_fault_injection)'] }
 # link.exe unconditionally prints "Creating library X.dll.lib and object
 # X.dll.exp" to stdout when linking each proc-macro DLL on Windows hosts;
 # there is no linker flag to suppress it. The lint already exempts itself

--- a/scripts/build/buildOptionsRs.ts
+++ b/scripts/build/buildOptionsRs.ts
@@ -12,10 +12,12 @@
  * keeps the mtime stable so a reconfigure with the same sha doesn't
  * recompile `bun_core` and its dependents.
  *
- * Target-dependent constants (`ENABLE_TINYCC`, `ENABLE_ASAN`, `ENABLE_LOGS`)
+ * Target-dependent constants (`ENABLE_TINYCC`) and the ones mirroring a
+ * `--cfg` that `rust.ts` passes in RUSTFLAGS (`ENABLE_ASAN`, `ENABLE_LOGS`)
  * stay as `cfg!()` expressions inside the generated file rather than literals
- * so a `cargo check --target <other-triple>` against the same generated file
- * still evaluates them per-target.
+ * so a `cargo check --target <other-triple>`, or a bare `cargo check` / `cargo
+ * miri test` with no RUSTFLAGS at all, against the same generated file still
+ * evaluates them per invocation.
  *
  * Written at configure time alongside `depVersionsHeader.ts` /
  * `cargo-config.ts` — it's a constant manifest, not a build edge.
@@ -61,10 +63,10 @@ export function generateBuildOptionsRs(cfg: Config): string {
     "",
     "// Target/profile-derived — kept as `cfg!()` so cross-target",
     "// `cargo check` evaluates per-triple. Values agree with `Config`:",
-    "// rust.ts sets `--cfg=bun_debug` ⇔ `cfg.debug`, `--cfg=bun_asan` ⇔",
+    "// rust.ts sets `--cfg=bun_logs` ⇔ `cfg.logs`, `--cfg=bun_asan` ⇔",
     "// `cfg.asan`, and `cfg.tinycc`'s default (config.ts) is the negation",
     "// of this predicate.",
-    "pub const ENABLE_LOGS: bool = cfg!(bun_debug);",
+    "pub const ENABLE_LOGS: bool = cfg!(bun_logs);",
     "pub const ENABLE_ASAN: bool = cfg!(bun_asan);",
     "pub const ENABLE_TINYCC: bool = !cfg!(any(",
     `    target_os = "android",`,

--- a/scripts/build/rust.ts
+++ b/scripts/build/rust.ts
@@ -454,8 +454,8 @@ export function cargoBuildInvocation(cfg: Config): CargoInvocation {
     rustflags.push("--cfg=bun_asan");
   }
   // `bun_debug`: the cargo profile is `dev` (a Debug-buildtype build).
-  // `bun_core::env::IS_DEBUG` and `build_options::ENABLE_LOGS` key on this
-  // instead of `cfg!(debug_assertions)` so that release-asan /
+  // `bun_core::env::IS_DEBUG` keys on this instead of
+  // `cfg!(debug_assertions)` so that release-asan /
   // release-assertions (which enable `debug-assertions` below for
   // `debug_assert!()` coverage) don't also flip on Debug-only conveniences:
   // `DUMP_SOURCE` (per-module writes to /tmp/bun-debug-src/), `debug_warn!`
@@ -466,6 +466,20 @@ export function cargoBuildInvocation(cfg: Config): CargoInvocation {
   rustflags.push("--check-cfg=cfg(bun_debug)");
   if (cfg.debug) {
     rustflags.push("--cfg=bun_debug");
+  }
+  // `bun_logs`: `build_options::ENABLE_LOGS`, the compile-time gate on
+  // `scoped_log!` (`BUN_DEBUG_<scope>=1`). Follows `cfg.logs`, which defaults
+  // to `cfg.debug` but diverges from it under `release-assertions` /
+  // `--logs=on` (release build with logs) and `--logs=off` (debug build
+  // without), hence a cfg of its own instead of `bun_debug`. A cfg rather
+  // than a literal in build_options.rs so that a bare `cargo check` /
+  // `cargo miri test` (which reads build/debug's build_options.rs but gets no
+  // RUSTFLAGS) keeps the log bodies dead like `bun_debug` does; with logs live
+  // there, `ScopedLogger::is_visible()` would scan the environment through
+  // the Highway FFI, which Miri can't call.
+  rustflags.push("--check-cfg=cfg(bun_logs)");
+  if (cfg.logs) {
+    rustflags.push("--cfg=bun_logs");
   }
   // `bun_codegen_embed`: embed codegen-output `.js` (`include_bytes!`) instead
   // of reading them from `BUN_CODEGEN_DIR` at runtime. Mirrors Zig

--- a/scripts/build/rust.ts
+++ b/scripts/build/rust.ts
@@ -511,9 +511,12 @@ export function cargoBuildInvocation(cfg: Config): CargoInvocation {
   // file:line server-side, so the panic call site is recoverable from the trace
   // without embedding the location in the binary — same as the Zig build, which
   // had ~0 embedded source paths. Kept off for debug and `release-assertions`
-  // where panic messages are read locally. Nightly-only; the pinned toolchain
-  // is nightly.
-  if (cfg.release && !cfg.assertions) {
+  // where panic messages are read locally, and for `--logs=on` builds: the
+  // `bun_jsc::mark_binding()` / test-runner `group::begin()` loggers print
+  // `Location::caller()`, which this flag turns into `<redacted>:0`, and a
+  // build that embeds every `scoped_log!` format string is not the one the
+  // size matters for. Nightly-only; the pinned toolchain is nightly.
+  if (cfg.release && !cfg.assertions && !cfg.logs) {
     rustflags.push("-Zlocation-detail=none");
   }
   // Path remapping (CI reproducibility) — rustc equivalent of the C/C++

--- a/scripts/build/rust.ts
+++ b/scripts/build/rust.ts
@@ -468,15 +468,12 @@ export function cargoBuildInvocation(cfg: Config): CargoInvocation {
     rustflags.push("--cfg=bun_debug");
   }
   // `bun_logs`: `build_options::ENABLE_LOGS`, the compile-time gate on
-  // `scoped_log!` (`BUN_DEBUG_<scope>=1`). Follows `cfg.logs`, which defaults
-  // to `cfg.debug` but diverges from it under `release-assertions` /
-  // `--logs=on` (release build with logs) and `--logs=off` (debug build
-  // without), hence a cfg of its own instead of `bun_debug`. A cfg rather
-  // than a literal in build_options.rs so that a bare `cargo check` /
-  // `cargo miri test` (which reads build/debug's build_options.rs but gets no
-  // RUSTFLAGS) keeps the log bodies dead like `bun_debug` does; with logs live
-  // there, `ScopedLogger::is_visible()` would scan the environment through
-  // the Highway FFI, which Miri can't call.
+  // `scoped_log!`. Follows `cfg.logs`, which `release-assertions` / `--logs`
+  // set independently of `cfg.debug`. A cfg rather than a literal in
+  // build_options.rs so that bare `cargo check` / `cargo miri test` (no
+  // RUSTFLAGS, reading build/debug's file) keep the log bodies dead like
+  // `bun_debug` does; live, `ScopedLogger::is_visible()` would scan the
+  // environment through the Highway FFI, which Miri can't call.
   rustflags.push("--check-cfg=cfg(bun_logs)");
   if (cfg.logs) {
     rustflags.push("--cfg=bun_logs");
@@ -511,11 +508,9 @@ export function cargoBuildInvocation(cfg: Config): CargoInvocation {
   // file:line server-side, so the panic call site is recoverable from the trace
   // without embedding the location in the binary — same as the Zig build, which
   // had ~0 embedded source paths. Kept off for debug and `release-assertions`
-  // where panic messages are read locally, and for `--logs=on` builds: the
-  // `bun_jsc::mark_binding()` / test-runner `group::begin()` loggers print
-  // `Location::caller()`, which this flag turns into `<redacted>:0`, and a
-  // build that embeds every `scoped_log!` format string is not the one the
-  // size matters for. Nightly-only; the pinned toolchain is nightly.
+  // where panic messages are read locally, and for logs builds, whose
+  // `mark_binding()`-style loggers print `Location::caller()` (`<redacted>:0`
+  // under this flag). Nightly-only; the pinned toolchain is nightly.
   if (cfg.release && !cfg.assertions && !cfg.logs) {
     rustflags.push("-Zlocation-detail=none");
   }

--- a/src/bun_core/Global.rs
+++ b/src/bun_core/Global.rs
@@ -436,10 +436,10 @@ macro_rules! mark_binding {
     };
     ($fn_name:expr) => {
         // Opt-in via BUN_DEBUG_JSC=1. The `JSC` scope is owned by bun_core. Gate on
-        // `env::IS_DEBUG` (== `Environment::ENABLE_LOGS`) — never on a Cargo
-        // feature, since `cfg!(feature = ..)` is resolved against the *calling*
-        // crate and would warn (or silently no-op) in crates without it.
-        if $crate::env::IS_DEBUG && $crate::Global::JSC_SCOPE.is_visible() {
+        // `env::ENABLE_LOGS` like `scoped_log!` does, never on a Cargo feature,
+        // since `cfg!(feature = ..)` is resolved against the *calling* crate and
+        // would warn (or silently no-op) in crates without it.
+        if $crate::env::ENABLE_LOGS && $crate::Global::JSC_SCOPE.is_visible() {
             $crate::Global::JSC_SCOPE.log(::core::format_args!(
                 "[JSC] {} ({}:{})\n",
                 $fn_name,

--- a/src/bun_core/Global.rs
+++ b/src/bun_core/Global.rs
@@ -435,10 +435,8 @@ macro_rules! mark_binding {
         $crate::mark_binding!(::core::panic::Location::caller().file())
     };
     ($fn_name:expr) => {
-        // Opt-in via BUN_DEBUG_JSC=1. The `JSC` scope is owned by bun_core. Gate on
-        // `env::ENABLE_LOGS` like `scoped_log!` does, never on a Cargo feature,
-        // since `cfg!(feature = ..)` is resolved against the *calling* crate and
-        // would warn (or silently no-op) in crates without it.
+        // Opt-in via BUN_DEBUG_JSC=1. Same gate as `scoped_log!`; not a Cargo
+        // feature, which `cfg!` would resolve against the *calling* crate.
         if $crate::env::ENABLE_LOGS && $crate::Global::JSC_SCOPE.is_visible() {
             $crate::Global::JSC_SCOPE.log(::core::format_args!(
                 "[JSC] {} ({}:{})\n",

--- a/src/bun_core/env.rs
+++ b/src/bun_core/env.rs
@@ -65,10 +65,8 @@ pub(crate) const CANARY_REVISION: &str = if IS_CANARY {
 };
 pub const DUMP_SOURCE: bool = IS_DEBUG && !IS_TEST;
 pub const BASE_PATH: &[u8] = build_options::BASE_PATH;
-/// The build's `logs` option (`--cfg=bun_logs`, set by `scripts/build/rust.ts`
-/// from `cfg.logs`): on by default in Debug builds and in `release-assertions`,
-/// off in plain release, `--logs=on|off` overrides. Independent of `IS_DEBUG`.
-/// Compile-time gate for `scoped_log!` and the other `BUN_DEBUG_*` loggers.
+/// The build's `logs` option (`--cfg=bun_logs` from scripts/build/rust.ts; defaults
+/// to `IS_DEBUG`, `release-assertions` and `--logs=on|off` override). Gates `scoped_log!`.
 pub const ENABLE_LOGS: bool = build_options::ENABLE_LOGS;
 pub const ENABLE_ASAN: bool = build_options::ENABLE_ASAN;
 pub const ENABLE_FUZZILLI: bool = build_options::ENABLE_FUZZILLI;

--- a/src/bun_core/env.rs
+++ b/src/bun_core/env.rs
@@ -65,6 +65,10 @@ pub(crate) const CANARY_REVISION: &str = if IS_CANARY {
 };
 pub const DUMP_SOURCE: bool = IS_DEBUG && !IS_TEST;
 pub const BASE_PATH: &[u8] = build_options::BASE_PATH;
+/// The build's `logs` option (`--cfg=bun_logs`, set by `scripts/build/rust.ts`
+/// from `cfg.logs`): on by default in Debug builds and in `release-assertions`,
+/// off in plain release, `--logs=on|off` overrides. Independent of `IS_DEBUG`.
+/// Compile-time gate for `scoped_log!` and the other `BUN_DEBUG_*` loggers.
 pub const ENABLE_LOGS: bool = build_options::ENABLE_LOGS;
 pub const ENABLE_ASAN: bool = build_options::ENABLE_ASAN;
 pub const ENABLE_FUZZILLI: bool = build_options::ENABLE_FUZZILLI;

--- a/src/bun_core/output.rs
+++ b/src/bun_core/output.rs
@@ -1540,14 +1540,17 @@ macro_rules! declare_scope {
 
 /// `bun.Output.scoped(.X, vis)("fmt", .{args})` → `scoped_log!(X, "fmt", args...)`
 ///
-/// MUST gate arg evaluation: expands to a dead branch in release builds.
+/// MUST gate arg evaluation: expands to a dead branch in builds without logs.
 #[macro_export]
 macro_rules! scoped_log {
     ($scope:path, $fmt:expr $(, $arg:expr)* $(,)?) => {
-        // Gate on `env::IS_DEBUG` (== `Environment::ENABLE_LOGS`) so release
-        // builds dead-strip the body. Do NOT gate on a Cargo feature — there
-        // is no `debug_logs` feature and §Forbidden bans silent no-ops.
-        if $crate::env::IS_DEBUG && $scope.is_visible() {
+        // Gate on `env::ENABLE_LOGS` (the build's `logs` option, passed as
+        // `--cfg=bun_logs` by scripts/build/rust.ts) so builds without it
+        // dead-strip the body. Not `IS_DEBUG`: `release-assertions` and
+        // `--logs=on` carry logs in a non-Debug build, `--logs=off` drops them
+        // from a Debug one. Do NOT gate on a Cargo feature: there is no
+        // `debug_logs` feature and §Forbidden bans silent no-ops.
+        if $crate::env::ENABLE_LOGS && $scope.is_visible() {
             const __NL: &str = $crate::output::_needs_nl($crate::pretty_fmt!($fmt, false));
             // Branch on ANSI *before* `format_args!` so each `$arg` evaluates
             // exactly once.
@@ -2592,12 +2595,12 @@ fn init_scoped_debug_writer_at_startup() {
 
 fn scoped_writer() -> QuietWriter {
     // All callers are already gated on `Environment::ENABLE_LOGS`; this is a
-    // Debug-build self-check (release-asan/release-assertions enable
-    // `debug_assertions` with `ENABLE_LOGS == false`, so keying on
-    // `debug_assertions` would turn it into a guaranteed abort there).
+    // Debug-build self-check (release-asan enables `debug_assertions` with
+    // `ENABLE_LOGS == false`, so keying on `debug_assertions` would turn it
+    // into a guaranteed abort there).
     #[cfg(bun_debug)]
     if !Environment::ENABLE_LOGS {
-        unreachable!("scopedWriter() should only be called in debug mode");
+        unreachable!("scopedWriter() should only be called when logs are enabled");
     }
     // SAFETY: initialized in init_scoped_debug_writer_at_startup; QuietWriter is Copy POD.
     unsafe { scoped_debug_writer::SCOPED_FILE_WRITER.read() }

--- a/src/bun_core/output.rs
+++ b/src/bun_core/output.rs
@@ -1544,12 +1544,10 @@ macro_rules! declare_scope {
 #[macro_export]
 macro_rules! scoped_log {
     ($scope:path, $fmt:expr $(, $arg:expr)* $(,)?) => {
-        // Gate on `env::ENABLE_LOGS` (the build's `logs` option, passed as
-        // `--cfg=bun_logs` by scripts/build/rust.ts) so builds without it
-        // dead-strip the body. Not `IS_DEBUG`: `release-assertions` and
-        // `--logs=on` carry logs in a non-Debug build, `--logs=off` drops them
-        // from a Debug one. Do NOT gate on a Cargo feature: there is no
-        // `debug_logs` feature and §Forbidden bans silent no-ops.
+        // Gate on `env::ENABLE_LOGS` (the build's `logs` option, which the
+        // `--logs` / `release-assertions` configs set independently of
+        // `IS_DEBUG`) so builds without logs dead-strip the body. Do NOT gate
+        // on a Cargo feature: there is none and §Forbidden bans silent no-ops.
         if $crate::env::ENABLE_LOGS && $scope.is_visible() {
             const __NL: &str = $crate::output::_needs_nl($crate::pretty_fmt!($fmt, false));
             // Branch on ANSI *before* `format_args!` so each `$arg` evaluates
@@ -2594,10 +2592,8 @@ fn init_scoped_debug_writer_at_startup() {
 }
 
 fn scoped_writer() -> QuietWriter {
-    // All callers are already gated on `Environment::ENABLE_LOGS`; this is a
-    // Debug-build self-check (release-asan enables `debug_assertions` with
-    // `ENABLE_LOGS == false`, so keying on `debug_assertions` would turn it
-    // into a guaranteed abort there).
+    // Callers are gated on `ENABLE_LOGS`; this self-check is `bun_debug`, not
+    // `debug_assertions`, which release-asan enables with logs off.
     #[cfg(bun_debug)]
     if !Environment::ENABLE_LOGS {
         unreachable!("scopedWriter() should only be called when logs are enabled");

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1978,7 +1978,7 @@ pub mod bv2_impl {
                 }
             }
 
-            if bun_core::env::IS_DEBUG && ReachableFiles.is_visible() {
+            if bun_core::env::ENABLE_LOGS && ReachableFiles.is_visible() {
                 bun_core::scoped_log!(
                     ReachableFiles,
                     "Reachable count: {} / {}",

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -1381,7 +1381,7 @@ pub use self::Node as node;
 #[track_caller]
 #[inline]
 pub fn mark_binding() {
-    if bun_core::env::IS_DEBUG && bun_core::Global::JSC_SCOPE.is_visible() {
+    if bun_core::env::ENABLE_LOGS && bun_core::Global::JSC_SCOPE.is_visible() {
         let loc = core::panic::Location::caller();
         bun_core::Global::JSC_SCOPE.log(format_args!("[jsc] ({}:{})\n", loc.file(), loc.line()));
     }
@@ -1390,7 +1390,7 @@ pub fn mark_binding() {
 /// Like [`mark_binding`], with a class-name prefix.
 #[inline]
 pub(crate) fn mark_member_binding(class: &'static str, src: &core::panic::Location<'static>) {
-    if bun_core::env::IS_DEBUG && bun_core::Global::JSC_SCOPE.is_visible() {
+    if bun_core::env::ENABLE_LOGS && bun_core::Global::JSC_SCOPE.is_visible() {
         bun_core::Global::JSC_SCOPE.log(format_args!(
             "[jsc] {} ({}:{})\n",
             class,

--- a/src/output/lib.rs
+++ b/src/output/lib.rs
@@ -17,8 +17,8 @@
 //     bun_output::scoped_log!(X, "fmt {} {}", a, b);
 //
 // `declare_scope!` expands to a `pub static X: ScopedLogger`; `scoped_log!`
-// gates arg evaluation behind `env::IS_DEBUG` so release builds pay zero
-// cost (see PORTING.md — args MUST sit inside the dead branch).
+// gates arg evaluation behind `env::ENABLE_LOGS` so builds without logs pay
+// zero cost (see PORTING.md: args MUST sit inside the dead branch).
 pub use bun_core::declare_scope;
 pub use bun_core::define_scoped_log;
 pub use bun_core::scoped_log;

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -4925,9 +4925,9 @@ pub type EnvMap = std::collections::HashMap<String, String>;
 #[macro_export]
 macro_rules! syslog {
     ($fmt:literal $(, $arg:expr)* $(,)?) => {
-        // Gate on `env::IS_DEBUG` (== `Environment::ENABLE_LOGS`) — matches
-        // bun_core::scoped_log!; there is no `debug_logs` Cargo feature.
-        if ::bun_core::env::IS_DEBUG && $crate::fd::SYS.is_visible() {
+        // Gate on `env::ENABLE_LOGS`, matching bun_core::scoped_log!; there is
+        // no `debug_logs` Cargo feature.
+        if ::bun_core::env::ENABLE_LOGS && $crate::fd::SYS.is_visible() {
             const __NL: &str =
                 ::bun_core::output::_needs_nl(::bun_core::pretty_fmt!($fmt, false));
             // Branch on ANSI *before* `format_args!` so each `$arg` evaluates

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -397,7 +397,7 @@ unsafe extern "system" {
 
 pub fn GetFileType(hFile: HANDLE) -> DWORD {
     let rc = GetFileType_raw(hFile);
-    // `syslog!` self-gates on `env::IS_DEBUG` (see lib.rs); no extra feature
+    // `syslog!` self-gates on `env::ENABLE_LOGS` (see lib.rs); no extra feature
     // flag needed (there is no `debug_logs` feature in bun_sys).
     bun_sys::syslog!("GetFileType({}) = {}", Fd::from_system(hFile), rc);
     rc

--- a/test/internal/source-lints/build-logs-option.test.ts
+++ b/test/internal/source-lints/build-logs-option.test.ts
@@ -1,0 +1,205 @@
+/**
+ * The build's `logs` option (scripts/build/config.ts: on by default in debug
+ * builds, set by the `release-assertions` profile and `bun run build:logs`,
+ * overridable with `--logs=on|off`) decides whether `scoped_log!` /
+ * `BUN_DEBUG_<scope>=1` logging is compiled into the Rust side. It reaches
+ * Rust as `bun_core::Environment::ENABLE_LOGS`, through pieces that have to
+ * agree with each other, pinned here:
+ *
+ *   - scripts/build/buildOptionsRs.ts emits `ENABLE_LOGS` into build_options.rs
+ *     as a `cfg!(...)`, and scripts/build/rust.ts passes that `--cfg` exactly
+ *     when `cfg.logs` is set (it used to be `cfg!(bun_debug)`, which made the
+ *     option dead: a release build configured with logs had none, a debug
+ *     build configured without still logged);
+ *   - Cargo.toml registers the cfg so a bare `cargo check` doesn't warn;
+ *   - the loggers in src gate on `ENABLE_LOGS`, not on `IS_DEBUG`, otherwise
+ *     a non-debug build configured with logs still compiles them out.
+ *
+ * Pure config evaluation plus a source scan: no compiler is involved.
+ */
+import { describe, expect, test } from "bun:test";
+import { tempDir } from "harness";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { generateBuildOptionsRs } from "../../../scripts/build/buildOptionsRs.ts";
+import { resolveConfig, type Config, type PartialConfig, type Toolchain } from "../../../scripts/build/config.ts";
+import { getProfile } from "../../../scripts/build/profiles.ts";
+import { cargoBuildInvocation } from "../../../scripts/build/rust.ts";
+
+const repoRoot = resolve(import.meta.dir, "..", "..", "..");
+
+/** A fully-populated fake toolchain; nothing here is ever executed. */
+function mockToolchain(): Toolchain {
+  return {
+    cc: "/fake/llvm/bin/clang",
+    cxx: "/fake/llvm/bin/clang++",
+    hostCc: undefined,
+    hostCxx: undefined,
+    clangVersion: "21.1.8",
+    clangResourceDir: "/fake/llvm/lib/clang/21",
+    ar: "/fake/llvm/bin/llvm-ar",
+    ranlib: "/fake/llvm/bin/llvm-ranlib",
+    ld: "/fake/llvm/bin/ld.lld",
+    ld64Lld: undefined,
+    rustLld: undefined,
+    rustLlvmVersion: "22.1.4",
+    rustSysroot: undefined,
+    rustHostTriple: undefined,
+    strip: "/fake/llvm/bin/llvm-strip",
+    llvmStrip: "/fake/llvm/bin/llvm-strip",
+    dsymutil: undefined,
+    bun: "/fake/bin/bun",
+    jsRuntime: "/fake/bin/bun",
+    esbuild: "/fake/bin/esbuild",
+    ccache: undefined,
+    cmake: "/fake/bin/cmake",
+    cargo: undefined,
+    cargoHome: undefined,
+    rustupHome: undefined,
+    msvcLinker: undefined,
+    rc: undefined,
+    mt: undefined,
+    nasm: undefined,
+  };
+}
+
+/**
+ * A linux-x64 target resolves on every host once it is told where its sysroot
+ * is (the path is only recorded, never opened).
+ */
+function linuxConfig(partial: PartialConfig, buildDir: string): Config {
+  return resolveConfig(
+    { os: "linux", arch: "x64", abi: "gnu", buildDir, linuxSysroot: buildDir, ...partial },
+    mockToolchain(),
+  );
+}
+
+function rustflags(cfg: Config): string[] {
+  return cargoBuildInvocation(cfg).env.CARGO_ENCODED_RUSTFLAGS?.split("\x1f") ?? [];
+}
+
+/** The right-hand side of `pub const ENABLE_LOGS: bool = ...;` in the build_options.rs generated for `cfg`. */
+function generatedEnableLogs(cfg: Config): string {
+  const source = readFileSync(generateBuildOptionsRs(cfg), "utf8");
+  const match = /^pub const ENABLE_LOGS: bool = (.+);$/m.exec(source);
+  if (!match) throw new Error(`build_options.rs has no ENABLE_LOGS constant:\n${source}`);
+  return match[1];
+}
+
+/** The name inside `cfg!(...)`, or undefined when the constant is a plain literal. */
+function cfgName(expr: string): string | undefined {
+  return /^cfg!\((\w+)\)$/.exec(expr)?.[1];
+}
+
+/**
+ * What `bun_core::Environment::ENABLE_LOGS` evaluates to in the cargo build
+ * rust.ts emits for `cfg`: the generated constant, resolved against the
+ * rustflags of that same build.
+ */
+function rustEnableLogs(cfg: Config): boolean {
+  const expr = generatedEnableLogs(cfg);
+  if (expr === "true" || expr === "false") return expr === "true";
+  const name = cfgName(expr);
+  if (name === undefined) throw new Error(`unexpected ENABLE_LOGS initializer: ${expr}`);
+  const flags = rustflags(cfg);
+  // rustc's unexpected_cfgs lint needs the cfg declared in the same build
+  // that may set it, whether or not this configuration sets it.
+  expect(flags).toContain(`--check-cfg=cfg(${name})`);
+  return flags.includes(`--cfg=${name}`);
+}
+
+describe("ENABLE_LOGS follows the logs option", () => {
+  const cases: { name: string; partial: PartialConfig; logs: boolean }[] = [
+    // The profile's doc comment promises "Release + assertions + logs".
+    { name: "release-assertions profile", partial: getProfile("release-assertions"), logs: true },
+    // `bun run build:logs`.
+    { name: "release --logs=on", partial: { buildType: "Release", logs: true }, logs: true },
+    { name: "debug --logs=off", partial: { buildType: "Debug", logs: false }, logs: false },
+    { name: "debug (default on)", partial: { buildType: "Debug" }, logs: true },
+    { name: "release (default off)", partial: { buildType: "Release" }, logs: false },
+    // release-asan / the CI asan lane: assertions on, logs stay off.
+    {
+      name: "release-asan (default off)",
+      partial: { buildType: "Release", asan: true, assertions: true },
+      logs: false,
+    },
+  ];
+
+  for (const { name, partial, logs } of cases) {
+    test(`${name}: rust ENABLE_LOGS is ${logs}`, () => {
+      using dir = tempDir("build-logs-option", {});
+      const cfg = linuxConfig(partial, String(dir));
+      // The option itself resolves as documented; what is under test is
+      // whether the Rust build sees that value.
+      expect(cfg.logs).toBe(logs);
+      expect(rustEnableLogs(cfg)).toBe(logs);
+    });
+  }
+
+  test("logs is independent of the Debug-build cfg", () => {
+    using dir = tempDir("build-logs-option", {});
+    const releaseWithLogs = rustflags(linuxConfig({ buildType: "Release", logs: true }, String(dir)));
+    expect(releaseWithLogs).not.toContain("--cfg=bun_debug");
+    const debugWithoutLogs = rustflags(linuxConfig({ buildType: "Debug", logs: false }, String(dir)));
+    expect(debugWithoutLogs).toContain("--cfg=bun_debug");
+  });
+
+  test("the cfg build_options.rs reads is registered for bare cargo in Cargo.toml", () => {
+    using dir = tempDir("build-logs-option", {});
+    const name = cfgName(generatedEnableLogs(linuxConfig({ buildType: "Debug" }, String(dir))));
+    if (name === undefined) return; // a literal needs no registration
+    const cargoToml = readFileSync(resolve(repoRoot, "Cargo.toml"), "utf8");
+    const unexpectedCfgs = /^unexpected_cfgs\s*=.*$/m.exec(cargoToml)?.[0];
+    expect(unexpectedCfgs).toBeDefined();
+    expect(unexpectedCfgs).toContain(`'cfg(${name})'`);
+  });
+});
+
+describe("the loggers in src gate on ENABLE_LOGS", () => {
+  /** `//` comments blanked out (newlines kept, so line numbers survive). */
+  const stripComments = (source: string) => source.replace(/\/\/[^\n]*/g, "");
+
+  /** Body of `macro_rules! <name> { ... }` in `source`, up to the first line that is just `}`. */
+  function macroBody(source: string, name: string): string {
+    const match = new RegExp(String.raw`^macro_rules! ${name} \{\n([\s\S]*?)^\}`, "m").exec(source);
+    if (!match) throw new Error(`macro_rules! ${name} not found`);
+    return match[1];
+  }
+
+  // `<CONST> && scope.is_visible()`: one `if` condition, however rustfmt
+  // wraps it, since `;` and `{` cannot occur inside it.
+  const guardOn = (constant: string, flags = "") =>
+    new RegExp(String.raw`\b${constant}\b[^;{]*\.is_visible\(\)`, flags);
+
+  test("scoped_log!, syslog! and mark_binding! check ENABLE_LOGS before the scope", () => {
+    const macros = [
+      { file: "src/bun_core/output.rs", name: "scoped_log" },
+      { file: "src/sys/lib.rs", name: "syslog" },
+      { file: "src/bun_core/Global.rs", name: "mark_binding" },
+    ];
+    for (const { file, name } of macros) {
+      const body = macroBody(stripComments(readFileSync(resolve(repoRoot, file), "utf8")), name);
+      expect(body, `${name}! in ${file}`).toMatch(guardOn("ENABLE_LOGS"));
+      expect(body, `${name}! in ${file}`).not.toMatch(/\bIS_DEBUG\b/);
+    }
+  });
+
+  test("no logger guard keys on IS_DEBUG", () => {
+    // `IS_DEBUG && scope.is_visible()` compiles the log out of every non-debug
+    // build, including the ones configured with logs. Gate on ENABLE_LOGS
+    // instead, or just call scoped_log!, which does.
+    const offenders: string[] = [];
+    const guard = guardOn("IS_DEBUG", "g");
+    for (const rel of new Bun.Glob("src/**/*.rs").scanSync({ cwd: repoRoot })) {
+      const raw = readFileSync(resolve(repoRoot, rel), "utf8");
+      if (!raw.includes(".is_visible()")) continue;
+      const source = stripComments(raw);
+      for (const match of source.matchAll(guard)) {
+        const line = source.slice(0, match.index).split("\n").length;
+        offenders.push(`${rel.replaceAll("\\", "/")}:${line}`);
+      }
+    }
+    expect(offenders.sort()).toEqual([]);
+  });
+});

--- a/test/internal/source-lints/build-logs-option.test.ts
+++ b/test/internal/source-lints/build-logs-option.test.ts
@@ -12,6 +12,9 @@
  *     option dead: a release build configured with logs had none, a debug
  *     build configured without still logged);
  *   - Cargo.toml registers the cfg so a bare `cargo check` doesn't warn;
+ *   - a release build with logs keeps `#[track_caller]` locations, which the
+ *     `mark_binding()` style of logger prints (`-Zlocation-detail=none` would
+ *     turn them into `<redacted>:0`);
  *   - the loggers in src gate on `ENABLE_LOGS`, not on `IS_DEBUG`, otherwise
  *     a non-debug build configured with logs still compiles them out.
  *
@@ -143,6 +146,21 @@ describe("ENABLE_LOGS follows the logs option", () => {
     expect(releaseWithLogs).not.toContain("--cfg=bun_debug");
     const debugWithoutLogs = rustflags(linuxConfig({ buildType: "Debug", logs: false }, String(dir)));
     expect(debugWithoutLogs).toContain("--cfg=bun_debug");
+  });
+
+  test("a release build with logs keeps the call-site locations its loggers print", () => {
+    using dir = tempDir("build-logs-option", {});
+    const locationDetail = (partial: PartialConfig) =>
+      rustflags(linuxConfig(partial, String(dir))).includes("-Zlocation-detail=none");
+    expect({
+      release: locationDetail({ buildType: "Release" }),
+      "release --logs=on": locationDetail({ buildType: "Release", logs: true }),
+      "release-assertions": locationDetail(getProfile("release-assertions")),
+    }).toEqual({
+      release: true,
+      "release --logs=on": false,
+      "release-assertions": false,
+    });
   });
 
   test("the cfg build_options.rs reads is registered for bare cargo in Cargo.toml", () => {


### PR DESCRIPTION
### Problem
- The build's `logs` option does nothing for Rust. `release-assertions` (documented as "Release + assertions + logs", used by `bun run build:assert`) and `bun run build:logs` (`--profile=release --logs=on`) produce binaries in which every `scoped_log!` is compiled out, so `BUN_DEBUG_<scope>=1` prints nothing; conversely `bun bd --logs=off` still logs. Configure even reports the option as live: `bun scripts/build.ts --profile=release-assertions --configure-only` prints `features: assertions, logs, baseline`.
- Cause, build side: `scripts/build/buildOptionsRs.ts:67` emits `pub const ENABLE_LOGS: bool = cfg!(bun_debug);` and `scripts/build/rust.ts:467` passes `--cfg=bun_debug` only when `cfg.debug`. `cfg.logs` (`config.ts:889`, default `debug`) is read nowhere except the configure-time `features:` line (`config.ts:1576`); C++ never consumed it, so Rust is the only consumer that matters.
- Cause, Rust side: the loggers do not even read `ENABLE_LOGS`. `scoped_log!` (`src/bun_core/output.rs:1550`), `syslog!` (`src/sys/lib.rs:4930`), `mark_binding!` (`src/bun_core/Global.rs:442`), `mark_binding()` / `mark_member_binding()` (`src/jsc/lib.rs:1384`, `:1393`) and the `ReachableFiles` dump (`src/bundler/bundle_v2.rs:1981`) gate on `env::IS_DEBUG`, with comments asserting it equals `ENABLE_LOGS`. Fixing the generated constant alone would therefore still log nothing in a non-debug build.
- On main (generated into scratch build dirs, commands in the details block): `release-assertions` gets `ENABLE_LOGS = cfg!(bun_debug)` and no `--cfg=bun_debug` in the cargo edge; `debug --logs=off` gets `--cfg=bun_debug`.

### Fix
- `rust.ts`: pass `--check-cfg=cfg(bun_logs)` always and `--cfg=bun_logs` exactly when `cfg.logs`, next to `bun_debug` / `bun_asan`. `buildOptionsRs.ts` emits `ENABLE_LOGS = cfg!(bun_logs)`. `Cargo.toml` registers `cfg(bun_logs)` in `unexpected_cfgs` like the other RUSTFLAGS cfgs, so a bare `cargo check` does not warn about the generated file.
- The six sites above gate on `env::ENABLE_LOGS` instead of `IS_DEBUG`; `ScopedLogger::is_visible()` / `log()` already did. `ENABLE_LOGS` gets a doc comment; the comments claiming the two constants are equal are updated.
- Why this is right: `ENABLE_LOGS` is the Rust spelling of the `logs` option (the Zig build passed it as `-Denable_logs=${cfg.logs}` and gated `Output.Scoped` on it), and the option was only meant to default to `debug`, not to be `debug`. The two constants became one value in #32520, which moved the loggers onto `IS_DEBUG` so that release-asan would not pick up logs; they are unchanged by this PR because `cfg.logs` is false there. Every profile CI builds (`ci-build`, with and without `--asan=on`) and the default debug build resolve to the same `ENABLE_LOGS` as before (the test pins debug, release and release+asan); only `release-assertions` and explicit `--logs=on|off` change, and those are the cases that asked for it.
- Why a cfg and not a literal in `build_options.rs`: a bare `cargo check`, `cargo clippy` and the `cargo miri test` CI job read `build/debug/codegen/build_options.rs` with no RUSTFLAGS. With a literal `true` from a debug configure, `scoped_log!` bodies would go live there and `ScopedLogger::evaluate_is_visible()` scans the environment through `bun_core::strings` (Highway FFI), which Miri cannot call; `bun_ptr`'s ref-count paths and `bun_shell_parser`'s brace expansion, both in the Miri crate list, call `scoped_log!`. A cfg keeps bare cargo on logs-off semantics exactly as `bun_debug` does today.
- Plain release codegen is unchanged: `cfg!(bun_logs)` without the flag is the same `false` constant the old `cfg!(bun_debug)` was, so the `if` still folds away. The new `--check-cfg` flag changes RUSTFLAGS, so the first build after this lands recompiles the Rust side once.
- `rust.ts` also stops passing `-Zlocation-detail=none` when `cfg.logs` is set (second commit, found in self-review). That flag was keyed on `release && !assertions`, which `release --logs=on` satisfies, and the loggers this PR turns on there include `mark_binding()` and the test runner's `group::begin()`, which print `Location::caller()`: with the flag they logged `[jsc] (<redacted>:0)`. `release-assertions` already kept the flag off; shipped profiles have logs off and are unchanged.
- Out of scope, noted for the record: `--tinycc` has the same kind of bug (`ENABLE_TINYCC` and `tcc_externs!` hard-code the target default instead of following `cfg.tinycc`) and can use the same `--cfg` mechanism; it touches the FFI crate and overlaps #31528, so it is left to a separate change.
- Verified:
  - `test/internal/source-lints/build-logs-option.test.ts` (new file; this directory keeps one file per build-script topic and nothing existing covers rustflags or `build_options.rs`): resolves release-assertions, release `--logs=on`, debug `--logs=off`, debug, release and release+asan configs, generates `build_options.rs` for each into a temp dir, reads the cfg it names and checks it against the rustflags `cargoBuildInvocation()` emits; checks the cfg is registered in `Cargo.toml`; checks the three macros gate on `ENABLE_LOGS`; scans `src/**/*.rs` for `IS_DEBUG ... .is_visible()` guards; and checks `-Zlocation-detail=none` is passed for release but not for release `--logs=on` or release-assertions (fails with the second commit's `rust.ts` hunk reverted). With `src/` stashed the two source tests fail (listing the six sites); with `scripts/` stashed the three changed configs fail (`bun_debug` is named but not set for release-assertions and `--logs=on`, set for debug `--logs=off`); with only `Cargo.toml` stashed the registration test fails; the debug / release / release+asan cases pass in every state, which is the "nothing else moves" claim. 0.3s on a release bun, ~6s under `bun bd`.
  - `bun bd` (debug, `--cfg=bun_logs` now in the cargo edge): `BUN_DEBUG_fs=1 bun bd -e 1`, `BUN_DEBUG_SYS=1`, `BUN_DEBUG_JSC=1` (`mark_binding`) and `BUN_DEBUG_ReachableFiles=1 bun bd build` (the `bundle_v2` site) all still print.
  - `bun scripts/build.ts --profile=release --logs=on` (what `bun run build:logs` runs) on this branch, on top of a `release` tree built from main the day before: with `BUN_DEBUG_fs=1` the main-built `bun-profile` prints nothing and the rebuilt one prints `[fs] open(/)` ...; `BUN_DEBUG_JSC=1` prints `[jsc] (src/jsc/VirtualMachine.rs:2382)` ... (`mark_binding`; it was `[jsc] (<redacted>:0)` before the second commit, rebuilt to confirm); `BUN_DEBUG_SYS=1 bun-profile build --compile` prints `[sys] ioctl_ficlone(6, 5) = -1` / `[sys] copy_file_range(...)` (`syslog!`, from `bun_sys::copy_file`). Without any `BUN_DEBUG_*` variable the binary stays quiet (`BUN_DEBUG_QUIET_LOGS=1` in this environment; `visible` scopes otherwise print by default, as in debug builds). The stripped `bun` behaves the same. Note that some individual call sites are additionally wrapped in `cfg!(debug_assertions)` (`Fd::close`'s `[sys] close(...)`, `posix_spawn`'s), so those still need `release-assertions`; that gating predates this PR.
  - `--configure-only` for release-assertions, release, release `--logs=on`, debug, debug `--logs=off` and release-asan: `--cfg=bun_logs` appears in exactly the first, third and fourth; `--check-cfg=cfg(bun_logs)` in all six.
  - `rustfmt --check` on the touched `.rs` files; `tsc -p scripts/build` reports the same 11 pre-existing diagnostics as main; `windows-cross-config`, `macos-cross-config` and `build-debug-info-flags` tests still pass.

### Background
- **`logs` option**: a boolean in the flat `Config` (`scripts/build/config.ts`), defaulting to `debug`; settable per profile (`profiles.ts`, only `release-assertions` sets it) or with `--logs=on|off`. It is the TypeScript build's version of the old CMake `ENABLE_LOGS` / Zig `-Denable_logs`.
- **Scoped logging**: `declare_scope!(name, hidden|visible)` defines a `ScopedLogger`; `scoped_log!` writes through it when the scope is enabled at runtime (`BUN_DEBUG_<name>=1`, `BUN_DEBUG_ALL`, or `visible` by default). The macro wraps the whole body, including argument evaluation, in `if <const> && scope.is_visible()` so that builds with the constant false compile the call to nothing; that constant is what this PR changes.
- **`build_options.rs`**: generated at configure time by `buildOptionsRs.ts` from `Config` and `include!`d as `bun_core::build_options`; `env.rs` re-exports its values as `Environment::*`. A bare cargo invocation (no `BUN_CODEGEN_DIR`) reads the copy in `build/debug/codegen/`, which is why constants that must follow RUSTFLAGS rather than whichever profile last configured that directory are written as `cfg!(...)`.
- **`--cfg` / `--check-cfg`**: rustc takes arbitrary cfg names from RUSTFLAGS; `--check-cfg=cfg(name)` (or the `unexpected_cfgs` entry in `Cargo.toml`) declares the name so the `unexpected_cfgs` lint does not fire on `cfg!(name)` in builds that do not set it. `rust.ts` already wires `bun_asan`, `bun_debug`, `bun_codegen_embed` and `socket_fault_injection` this way.
- **`IS_DEBUG`** (`cfg!(bun_debug)`): true only for the `dev` cargo profile; it gates Debug-build conveniences (`debug_warn!`, `DUMP_SOURCE`, the `bun-debug` name). It stays as is; logging is the one thing moved off it.

<details>
<summary>Configure probes on main vs this branch</summary>

```
$ bun scripts/build.ts --profile=release-assertions --build-dir=/tmp/relassert --configure-only
  features     assertions, logs, baseline
$ grep ENABLE_LOGS /tmp/relassert/codegen/build_options.rs
pub const ENABLE_LOGS: bool = cfg!(bun_debug);
$ grep -o -- '--cfg=[a-z_]*' /tmp/relassert/build.ninja | sort -u
--cfg=bun_codegen_embed                                   <- no bun_debug: ENABLE_LOGS is false

$ bun scripts/build.ts --profile=debug --logs=off --build-dir=/tmp/dbg-nologs --configure-only
  features     asan, assertions, baseline                 <- logs reported off...
$ grep -o -- '--cfg=[a-z_]*' /tmp/dbg-nologs/build.ninja | sort -u
--cfg=bun_asan
--cfg=bun_debug                                           <- ...but ENABLE_LOGS = cfg!(bun_debug) is true
--cfg=socket_fault_injection
```

This branch (`ENABLE_LOGS = cfg!(bun_logs)` in every build_options.rs; `--check-cfg=cfg(bun_logs)` in every build.ninja):

```
release-assertions   --cfg=bun_codegen_embed --cfg=bun_logs
release --logs=on    --cfg=bun_codegen_embed --cfg=bun_logs
debug                --cfg=bun_asan --cfg=bun_debug --cfg=bun_logs --cfg=socket_fault_injection
debug --logs=off     --cfg=bun_asan --cfg=bun_debug --cfg=socket_fault_injection
release              --cfg=bun_codegen_embed
release-asan         --cfg=bun_asan --cfg=bun_codegen_embed --cfg=socket_fault_injection
```

The source scan's output with `src/` at main:

```
+   "src/bun_core/Global.rs:442",
+   "src/bun_core/output.rs:1550",
+   "src/bundler/bundle_v2.rs:1981",
+   "src/jsc/lib.rs:1384",
+   "src/jsc/lib.rs:1393",
+   "src/sys/lib.rs:4930",
```

</details>

