### PR TITLE
install: describe the real --save default in bun link and bun unlink --help

### DIFF
--- a/completions/bun-cli.json
+++ b/completions/bun-cli.json
@@ -2269,14 +2269,14 @@
         },
         {
           "name": "no-save",
-          "description": "Don't update package.json or save a lockfile",
+          "description": "Don't update package.json or save a lockfile (the default)",
           "hasValue": false,
           "required": false,
           "multiple": false
         },
         {
           "name": "save",
-          "description": "Save to package.json (true by default)",
+          "description": "Update package.json and save a lockfile (false by default)",
           "hasValue": false,
           "required": false,
           "multiple": false
@@ -2528,14 +2528,14 @@
         },
         {
           "name": "no-save",
-          "description": "Don't update package.json or save a lockfile",
+          "description": "Don't update package.json or save a lockfile (the default)",
           "hasValue": false,
           "required": false,
           "multiple": false
         },
         {
           "name": "save",
-          "description": "Save to package.json (true by default)",
+          "description": "Update package.json and save a lockfile (false by default)",
           "hasValue": false,
           "required": false,
           "multiple": false

--- a/completions/bun-cli.json
+++ b/completions/bun-cli.json
@@ -2492,7 +2492,7 @@
           "completionType": "package"
         }
       ],
-      "examples": ["bun link", "bun link <package>"],
+      "examples": ["bun link", "bun link <package>", "bun link --save <package>"],
       "usage": "Usage: bun link [flags] [<packages>]",
       "documentationUrl": "https://bun.com/docs/cli/link.",
       "dynamicCompletions": {}

--- a/docs/pm/cli/link.mdx
+++ b/docs/pm/cli/link.mdx
@@ -31,7 +31,11 @@ cd /path/to/my-app
 bun link cool-pkg
 ```
 
-The `--save` flag also adds `cool-pkg` to the `dependencies` field of your app's package.json, with a version specifier that tells Bun to load from the registered local directory instead of installing from `npm`:
+Pass `--save` to also add `cool-pkg` to the `dependencies` field of your app's package.json, with a version specifier that tells Bun to load from the registered local directory instead of installing from `npm`:
+
+```bash terminal icon="terminal"
+bun link --save cool-pkg
+```
 
 ```json package.json icon="file-json"
 {

--- a/docs/snippets/cli/link.mdx
+++ b/docs/snippets/cli/link.mdx
@@ -39,11 +39,11 @@ bun link <packages>
 </ParamField>
 
 <ParamField path="--no-save" type="boolean">
-  Don't update <code>package.json</code> or save a lockfile
+  Don't update <code>package.json</code> or save a lockfile (the default)
 </ParamField>
 
-<ParamField path="--save" type="boolean" default="true">
-  Save to <code>package.json</code>
+<ParamField path="--save" type="boolean">
+  Update <code>package.json</code> and save a lockfile (false by default)
 </ParamField>
 
 <ParamField path="--trust" type="boolean">

--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -1445,8 +1445,7 @@ Full documentation is available at <magenta>https://bun.com/docs/pm/cli/prune<r>
             cli.tolerate_republish = args.flag(b"--tolerate-republish");
         }
 
-        // link and unlink default to not saving (their --help says so via
-        // `LINK_SAVE_PARAMS`), all others default to saving.
+        // link and unlink default to not saving (see `LINK_SAVE_PARAMS`), all others to saving.
         if matches!(subcommand, Subcommand::Link | Subcommand::Unlink) {
             cli.no_save = !args.flag(b"--save");
         } else {

--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -930,8 +930,11 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/remove<r>.
   <d>Directory should contain a package.json.<r>
   <b><green>bun link<r>
 
-  <d>Add a previously-registered linkable package as a dependency of the current project.<r>
+  <d>Link a previously-registered linkable package into the current project's node_modules.<r>
   <b><green>bun link<r> <blue>\<package\><r>
+
+  <d>Also add it to the current project's package.json as a link: dependency.<r>
+  <b><green>bun link<r> <cyan>--save<r> <blue>\<package\><r>
 
 Full documentation is available at <magenta>https://bun.com/docs/cli/link<r>.
 ";

--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -60,11 +60,24 @@ const PRODUCTION_PARAMS: &[ParamType] = &[
     clap::param!("-P, --prod"),
 ];
 
-const SHARED_TAIL_PARAMS: &[ParamType] = &[
+const SAVE_PARAMS: &[ParamType] = &[
     clap::param!(
         "--no-save                             Don't update package.json or save a lockfile"
     ),
     clap::param!("--save                                Save to package.json (true by default)"),
+];
+
+// `parse` gives link and unlink the opposite default: they only save when --save is passed.
+const LINK_SAVE_PARAMS: &[ParamType] = &[
+    clap::param!(
+        "--no-save                             Don't update package.json or save a lockfile (the default)"
+    ),
+    clap::param!(
+        "--save                                Update package.json and save a lockfile (false by default)"
+    ),
+];
+
+const SHARED_TAIL_PARAMS: &[ParamType] = &[
     clap::param!(
         "--ca <STR>...                         Provide a Certificate Authority signing certificate"
     ),
@@ -128,8 +141,19 @@ const SHARED_TAIL_PARAMS: &[ParamType] = &[
     clap::param!("-h, --help                            Print this help menu"),
 ];
 
-const SHARED_PARAMS: &[ParamType] =
-    concat_params![SHARED_HEAD_PARAMS, PRODUCTION_PARAMS, SHARED_TAIL_PARAMS];
+const SHARED_PARAMS: &[ParamType] = concat_params![
+    SHARED_HEAD_PARAMS,
+    PRODUCTION_PARAMS,
+    SAVE_PARAMS,
+    SHARED_TAIL_PARAMS
+];
+
+const LINK_SHARED_PARAMS: &[ParamType] = concat_params![
+    SHARED_HEAD_PARAMS,
+    PRODUCTION_PARAMS,
+    LINK_SAVE_PARAMS,
+    SHARED_TAIL_PARAMS
+];
 
 pub(crate) static INSTALL_PARAMS: &[ParamType] = concat_params![
     SHARED_PARAMS,
@@ -165,6 +189,7 @@ pub(crate) static UPDATE_PARAMS: &[ParamType] = concat_params![
         ),
         clap::param!("-P, --prod"),
     ],
+    SAVE_PARAMS,
     SHARED_TAIL_PARAMS,
     &[
         clap::param!(
@@ -269,14 +294,14 @@ pub(crate) static REMOVE_PARAMS: &[ParamType] = concat_params![
 ];
 
 pub(crate) static LINK_PARAMS: &[ParamType] = concat_params![
-    SHARED_PARAMS,
+    LINK_SHARED_PARAMS,
     &[clap::param!(
         "<POS> ...                         \"name\" install package as a link"
     ),]
 ];
 
 pub(crate) static UNLINK_PARAMS: &[ParamType] = concat_params![
-    SHARED_PARAMS,
+    LINK_SHARED_PARAMS,
     &[clap::param!(
         "<POS> ...                         \"name\" uninstall package as a link"
     ),]
@@ -1420,8 +1445,8 @@ Full documentation is available at <magenta>https://bun.com/docs/pm/cli/prune<r>
             cli.tolerate_republish = args.flag(b"--tolerate-republish");
         }
 
-        // link and unlink default to not saving, all others default to
-        // saving.
+        // link and unlink default to not saving (their --help says so via
+        // `LINK_SAVE_PARAMS`), all others default to saving.
         if matches!(subcommand, Subcommand::Link | Subcommand::Unlink) {
             cli.no_save = !args.flag(b"--save");
         } else {

--- a/test/cli/bun.test.ts
+++ b/test/cli/bun.test.ts
@@ -212,6 +212,16 @@ describe("bun", () => {
           /^ {2}Add to the workspace catalog instead of pinning a version\n {2}bun add --catalog react\n {2}bun add --catalog=testing vitest$/m,
         ],
       ],
+      // The bare form only installs the symlink; package.json is written with --save (see the --save
+      // flag row), so the examples must say which form does what.
+      [
+        "bun link --help",
+        ["link"],
+        [
+          /^ {2}Link a previously-registered linkable package into the current project's node_modules\.\n {2}bun link <package>$/m,
+          /^ {2}Also add it to the current project's package\.json as a link: dependency\.\n {2}bun link --save <package>$/m,
+        ],
+      ],
       [
         "bun audit --help",
         ["audit"],

--- a/test/cli/install/bun-link.test.ts
+++ b/test/cli/install/bun-link.test.ts
@@ -7,6 +7,7 @@ import {
   isWindows,
   readdirSorted,
   runBunInstall,
+  tempDir,
   tmpdirSync,
   toBeValidBin,
   toHaveBins,
@@ -470,4 +471,98 @@ it("should link dependency without crashing", async () => {
 
   // This should fail with a non-zero exit code.
   expect(await exited4).toBe(1);
+});
+
+// The install family shares one flag table, but `bun link <package>` and `bun unlink` invert the
+// --save default (CommandLineArguments.parse): they only touch package.json and the lockfile when
+// --save is passed, so their --help has to describe the flag differently from bun install's.
+it.each([
+  ["install", "Save to package.json (true by default)", "Don't update package.json or save a lockfile"],
+  ["add", "Save to package.json (true by default)", "Don't update package.json or save a lockfile"],
+  ["update", "Save to package.json (true by default)", "Don't update package.json or save a lockfile"],
+  ["remove", "Save to package.json (true by default)", "Don't update package.json or save a lockfile"],
+  [
+    "link",
+    "Update package.json and save a lockfile (false by default)",
+    "Don't update package.json or save a lockfile (the default)",
+  ],
+  [
+    "unlink",
+    "Update package.json and save a lockfile (false by default)",
+    "Don't update package.json or save a lockfile (the default)",
+  ],
+])("bun %s --help describes the --save default it actually has", async (subcommand, save, noSave) => {
+  await using proc = spawn({
+    cmd: [bunExe(), subcommand, "--help"],
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  const lines = stdout.split(/\r?\n/).map(line => line.trim());
+  const descriptionOf = (flag: string) =>
+    lines
+      .find(line => line.startsWith(`${flag} `))
+      ?.slice(flag.length)
+      .trim();
+  expect({ "--save": descriptionOf("--save"), "--no-save": descriptionOf("--no-save") }).toEqual({
+    "--save": save,
+    "--no-save": noSave,
+  });
+  expect(exitCode).toBe(0);
+});
+
+it("bun link <package> only writes package.json and a lockfile when --save is passed", async () => {
+  const appPackageJson = JSON.stringify({ name: "app", version: "1.0.0" });
+  using dir = tempDir("bun-link-save", {
+    "lib/package.json": JSON.stringify({ name: "lib-to-link", version: "1.0.0" }),
+    "app/package.json": appPackageJson,
+  });
+  const app = join(String(dir), "app");
+  // Register the package in a global dir private to this test instead of the machine's real one.
+  const linkEnv = {
+    ...env,
+    BUN_INSTALL_GLOBAL_DIR: join(String(dir), "global", "install", "global"),
+    BUN_INSTALL_BIN: join(String(dir), "global", "bin"),
+  };
+  async function bun(cwd: string, ...args: string[]) {
+    await using proc = spawn({
+      cmd: [bunExe(), ...args],
+      cwd,
+      env: linkEnv,
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  let { stdout, stderr, exitCode } = await bun(join(String(dir), "lib"), "link");
+  expect(stderr).toBe("");
+  expect(stdout).toContain('Success! Registered "lib-to-link"');
+  expect(exitCode).toBe(0);
+
+  ({ stdout, stderr, exitCode } = await bun(app, "link", "lib-to-link"));
+  expect(stderr).toBe("");
+  expect(stdout).toContain("installed lib-to-link@link:lib-to-link");
+  expect(exitCode).toBe(0);
+  expect(await file(join(app, "node_modules", "lib-to-link", "package.json")).json()).toEqual({
+    name: "lib-to-link",
+    version: "1.0.0",
+  });
+  expect(await file(join(app, "package.json")).text()).toBe(appPackageJson);
+  expect(await readdirSorted(app)).toEqual(["node_modules", "package.json"]);
+
+  ({ stdout, stderr, exitCode } = await bun(app, "link", "lib-to-link", "--save"));
+  expect(stderr).toContain("Saved lockfile");
+  expect(stdout).toContain("installed lib-to-link@link:lib-to-link");
+  expect(exitCode).toBe(0);
+  expect(await file(join(app, "package.json")).json()).toEqual({
+    name: "app",
+    version: "1.0.0",
+    dependencies: { "lib-to-link": "link:lib-to-link" },
+  });
+  expect(await readdirSorted(app)).toEqual(["bun.lock", "node_modules", "package.json"]);
 });

--- a/test/cli/install/bun-link.test.ts
+++ b/test/cli/install/bun-link.test.ts
@@ -498,7 +498,7 @@ it.each([
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   const lines = stdout.split(/\r?\n/).map(line => line.trim());
   const descriptionOf = (flag: string) =>
@@ -506,11 +506,12 @@ it.each([
       .find(line => line.startsWith(`${flag} `))
       ?.slice(flag.length)
       .trim();
-  expect({ "--save": descriptionOf("--save"), "--no-save": descriptionOf("--no-save") }).toEqual({
+  expect({ "--save": descriptionOf("--save"), "--no-save": descriptionOf("--no-save"), stderr, exitCode }).toEqual({
     "--save": save,
     "--no-save": noSave,
+    stderr: "",
+    exitCode: 0,
   });
-  expect(exitCode).toBe(0);
 });
 
 it("bun link <package> only writes package.json and a lockfile when --save is passed", async () => {


### PR DESCRIPTION
### Problem
- `bun link --help` and `bun unlink --help` print `--save    Save to package.json (true by default)`, and `docs/snippets/cli/link.mdx` declares `--save` with `default="true"`.
- For these two subcommands the default is the opposite: `bun link <pkg>` only writes the `link:` entry to package.json (and saves a lockfile) when `--save` is passed. `CommandLineArguments::parse` sets `no_save = !--save` for `Link | Unlink` and `no_save = --no-save` for everything else (`src/install/PackageManager/CommandLineArguments.rs`, the block above the `Patch` handling), and `PackageManagerOptions.rs` turns `no_save` into `WRITE_PACKAGE_JSON = false` and `SAVE_LOCKFILE = false`.
- The same `bun link --help` screen also described the bare `bun link <package>` example as adding the package "as a dependency of the current project", which is what `--save` does. #28937 ("nothing changes in my package.json" after `bun link --dev <pkg>`) is the user-facing confusion this produces.
- The flag string comes from the single table shared by install, add, update, remove, link, unlink, patch, patch-commit, outdated, publish and info, so the claim is right everywhere except link and unlink. The prose in `docs/pm/cli/link.mdx` already describes the real behavior; only the flag table and the example disagreed with it.

### Fix
- Split the two save entries out of `SHARED_TAIL_PARAMS` into `SAVE_PARAMS`, and give link and unlink a `LINK_SAVE_PARAMS` override (`--no-save ... (the default)`, `--save    Update package.json and save a lockfile (false by default)`), composed into `LINK_SHARED_PARAMS` the same way `UPDATE_PARAMS` overrides `--production`. Both flags are still accepted by both subcommands; only the descriptions change.
- Reword the `bun link <package>` example to say it links into node_modules, and add a `bun link --save <package>` example, so the flag row and the examples on that screen agree.
- Correct because it describes what `parse` does, and that behavior is the intended one: it matches `npm link <pkg>`, which also leaves package.json alone unless `--save` is given, and it is what the `bun link` docs prose already says. The shared entry stays as it is because it is true for the other nine subcommands.
- `docs/snippets/cli/link.mdx`, the `--save` paragraph in `docs/pm/cli/link.mdx` (now shows the command), and the link/unlink entries plus the link examples in `completions/bun-cli.json` (generated from `--help` by `misctools/generate-cli-completions.ts`) are updated to the new text. Regenerating the JSON from this build produces exactly these entries; the wording deliberately avoids the generator's `default is/to:` pattern so it does not pick up a bogus `defaultValue`.
- Verified:
  - `test/cli/install/bun-link.test.ts`: `bun <install|add|update|remove|link|unlink> --help` asserts the exact `--save` and `--no-save` descriptions, so the shared table is pinned as unchanged and link/unlink as changed; `bun link <package>` in a private `BUN_INSTALL_GLOBAL_DIR` leaves package.json byte-identical and writes no lockfile without `--save`, and writes the `link:` dependency plus `bun.lock` with it (this one pins the behavior the text claims and passes before and after, since the behavior is unchanged).
  - `test/cli/bun.test.ts`: a `bun link --help` row in the existing examples table pins both example blocks.
  - The link/unlink help cases and the examples row fail on the released binary and pass with this branch.
  - Diffed `--help` of all twelve install-family subcommands between a build of main and this branch: only the link/unlink save rows and the link examples differ.
- Not in this PR:
  - The behavior half of #28937 (`bun link --dev|--optional|--peer <pkg>` is silently ignored; `bun link --save --dev <pkg>` writes to `dependencies`) is a separate change, previously attempted in #28938, that would add the dependency-group flags to `LINK_PARAMS` and read them for `Link` in `parse`. It stacks on top of this PR without touching the same lines.
  - `should link dependency without crashing` in `bun-link.test.ts` fails under a debug build on main independent of this change (debug-only stack dump on install failure); #37335 fixes that and relies on the assertion as written.
  - #38899 drops the same `default="true"` in `link.mdx` as part of a docs-wide sweep; this PR's wording for that entry supersedes it, and whichever lands second has a one-hunk conflict there. The other stale link/unlink entries in `bun-cli.json` (missing `--cpu`/`--os`/`--minimum-release-age`, old `--dry-run` text) predate this PR and are left for a regeneration of the whole file.

### Background
- The install subcommands build their clap tables out of shared slices (`SHARED_HEAD_PARAMS`, `PRODUCTION_PARAMS`, `SHARED_TAIL_PARAMS`) with `concat_params!`; a subcommand whose flag means something different swaps in its own slice at the same position, which is what `UPDATE_PARAMS` already does for `--production`. The help printer aligns descriptions itself, so the order of entries is the only thing the slice order affects, and it is unchanged for every subcommand.
- `bun link` with no argument registers the current directory as a linkable package in the global link dir (`BUN_INSTALL_GLOBAL_DIR`, default `~/.bun/install/global`); `bun link <pkg>` installs a registered package into the current project's node_modules through the same code path as `bun add`, with `no_save` deciding whether package.json and the lockfile are written. `bun unlink` currently only unregisters the current directory and never writes package.json; its table shares the link entries because `parse` applies the same inverted default to it.
- `completions/bun-cli.json` is the parsed form of every command's `--help` output (flag rows and the `bun ...` lines of the Examples block), used to generate the shell completions, which is why the help changes are mirrored there by hand. `completions/bun.zsh` says only `--save[Save to package.json]` and needs no change.
