### PR TITLE
install: replace an existing manifest cache entry atomically instead of unlinking it first

### DIFF
--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -1177,10 +1177,8 @@ pub mod package_manifest {
                 if bun_sys::linkat_tmpfile(file.handle, cache_dir, outpath).is_ok() {
                     return Ok(());
                 }
-                // Usually because an entry exists, which linkat() cannot replace. Unlinking
-                // it first is not an option: nothing waits for this task (see `save_async`),
-                // so exiting in between would leave the cache without an entry. Give the
-                // file a temporary name and rename it over the entry below instead.
+                // Rename over the existing entry (below) rather than unlink it first: nothing
+                // waits for this task, so exiting in between would delete the entry.
                 bun_sys::linkat_tmpfile(file.handle, tmpdir, tmp_path)?;
             }
 

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -1174,14 +1174,17 @@ pub mod package_manifest {
 
             #[cfg(any(target_os = "linux", target_os = "android"))]
             if is_using_o_tmpfile {
-                // Attempt #1.
-                if bun_sys::linkat_tmpfile(file.handle, cache_dir, outpath).is_err() {
-                    // Attempt #2: the file may already exist. Let's unlink and try again.
-                    let _ = bun_sys::unlinkat(cache_dir, outpath);
-                    bun_sys::linkat_tmpfile(file.handle, cache_dir, outpath)?;
-                    // There is no attempt #3. This is a cache, so it's not essential.
+                match bun_sys::linkat_tmpfile(file.handle, cache_dir, outpath) {
+                    Ok(()) => return Ok(()),
+                    // linkat() cannot replace the existing entry, and unlinking it first
+                    // is not an option: nothing waits for this task (see `save_async`), so
+                    // exiting in between would leave the cache without an entry. Give the
+                    // file a temporary name and rename it over the entry below instead.
+                    Err(err) if err.get_errno() == bun_sys::Errno::EEXIST => {
+                        bun_sys::linkat_tmpfile(file.handle, tmpdir, tmp_path)?;
+                    }
+                    Err(err) => return Err(err.into()),
                 }
-                return Ok(());
             }
 
             #[cfg(not(windows))]

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -1177,8 +1177,7 @@ pub mod package_manifest {
                 if bun_sys::linkat_tmpfile(file.handle, cache_dir, outpath).is_ok() {
                     return Ok(());
                 }
-                // Rename over the existing entry (below) rather than unlink it first: nothing
-                // waits for this task, so exiting in between would delete the entry.
+                // Keep the entry present throughout: rename over it below instead of unlinking it.
                 bun_sys::linkat_tmpfile(file.handle, tmpdir, tmp_path)?;
             }
 

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -1174,17 +1174,14 @@ pub mod package_manifest {
 
             #[cfg(any(target_os = "linux", target_os = "android"))]
             if is_using_o_tmpfile {
-                match bun_sys::linkat_tmpfile(file.handle, cache_dir, outpath) {
-                    Ok(()) => return Ok(()),
-                    // linkat() cannot replace the existing entry, and unlinking it first
-                    // is not an option: nothing waits for this task (see `save_async`), so
-                    // exiting in between would leave the cache without an entry. Give the
-                    // file a temporary name and rename it over the entry below instead.
-                    Err(err) if err.get_errno() == bun_sys::Errno::EEXIST => {
-                        bun_sys::linkat_tmpfile(file.handle, tmpdir, tmp_path)?;
-                    }
-                    Err(err) => return Err(err.into()),
+                if bun_sys::linkat_tmpfile(file.handle, cache_dir, outpath).is_ok() {
+                    return Ok(());
                 }
+                // Usually because an entry exists, which linkat() cannot replace. Unlinking
+                // it first is not an option: nothing waits for this task (see `save_async`),
+                // so exiting in between would leave the cache without an entry. Give the
+                // file a temporary name and rename it over the entry below instead.
+                bun_sys::linkat_tmpfile(file.handle, tmpdir, tmp_path)?;
             }
 
             #[cfg(not(windows))]

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -1,13 +1,14 @@
 import { file, spawn, write } from "bun";
 import { install_test_helpers, npm_manifest_test_helpers } from "bun:internal-for-testing";
 import { afterAll, beforeEach, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { copyFileSync, mkdirSync } from "fs";
+import { copyFileSync, existsSync, mkdirSync } from "fs";
 import { cp, exists, lstat, mkdir, readlink, rm, writeFile } from "fs/promises";
 import {
   assertManifestsPopulated,
   bunExe,
   bunEnv as env,
   isFlaky,
+  isLinux,
   isMacOS,
   isWindows,
   mergeWindowEnvs,
@@ -9770,16 +9771,20 @@ describe("manifest conditional requests", () => {
   const etag = '"no-deps-manifest-v1"';
   const lastModified = "Wed, 21 Oct 2015 07:28:00 GMT";
 
-  function startRegistry(validators: { etag?: string; lastModified?: string }) {
+  /** `served` is read on every request, so a test can change what the registry serves between installs. */
+  function startRegistry(served: { etag?: string; lastModified?: string; versions?: string[] }) {
     const requests: ManifestRequest[] = [];
-    let tarballRequests = 0;
+    const tarballRequests: string[] = [];
     const server = Bun.serve({
       port: 0,
       fetch(req) {
         const { pathname } = new URL(req.url);
-        if (pathname === "/no-deps/-/no-deps-1.0.0.tgz") {
-          tarballRequests++;
-          return new Response(file(join(import.meta.dir, "registry", "packages", "no-deps", "no-deps-1.0.0.tgz")));
+        const tarball = pathname.match(/^\/no-deps\/-\/no-deps-(.+)\.tgz$/);
+        if (tarball) {
+          tarballRequests.push(tarball[1]);
+          return new Response(
+            file(join(import.meta.dir, "registry", "packages", "no-deps", `no-deps-${tarball[1]}.tgz`)),
+          );
         }
         if (pathname !== "/no-deps") {
           return new Response("unexpected", { status: 404 });
@@ -9793,34 +9798,38 @@ describe("manifest conditional requests", () => {
         };
         requests.push(entry);
         const notModified =
-          (validators.etag !== undefined && entry.ifNoneMatch === validators.etag) ||
-          (validators.etag === undefined &&
-            validators.lastModified !== undefined &&
-            entry.ifModifiedSince === validators.lastModified);
+          (served.etag !== undefined && entry.ifNoneMatch === served.etag) ||
+          (served.etag === undefined &&
+            served.lastModified !== undefined &&
+            entry.ifModifiedSince === served.lastModified);
         if (notModified) {
           entry.status = 304;
           return new Response(null, { status: 304 });
         }
         const headers: Record<string, string> = {};
-        if (validators.etag !== undefined) headers["ETag"] = validators.etag;
-        if (validators.lastModified !== undefined) headers["Last-Modified"] = validators.lastModified;
+        if (served.etag !== undefined) headers["ETag"] = served.etag;
+        if (served.lastModified !== undefined) headers["Last-Modified"] = served.lastModified;
+        const versions = served.versions ?? ["1.0.0"];
         return Response.json(
           {
             name: "no-deps",
-            "dist-tags": { latest: "1.0.0" },
-            versions: {
-              "1.0.0": {
-                name: "no-deps",
-                version: "1.0.0",
-                dist: { tarball: `http://localhost:${server.port}/no-deps/-/no-deps-1.0.0.tgz` },
-              },
-            },
+            "dist-tags": { latest: versions.at(-1) },
+            versions: Object.fromEntries(
+              versions.map(version => [
+                version,
+                {
+                  name: "no-deps",
+                  version,
+                  dist: { tarball: `http://localhost:${server.port}/no-deps/-/no-deps-${version}.tgz` },
+                },
+              ]),
+            ),
           },
           { headers },
         );
       },
     });
-    return { server, requests, tarballRequests: () => tarballRequests };
+    return { server, requests, tarballRequests };
   }
 
   let registryPort = 0;
@@ -9840,12 +9849,18 @@ describe("manifest conditional requests", () => {
     ]);
   }
 
-  async function install(...args: string[]) {
+  /** Without a lockfile, the next install has to resolve no-deps again (from the manifest cache or the registry). */
+  async function clean() {
     await Promise.all([
       rm(join(packageDir, "node_modules"), { recursive: true, force: true }),
       rm(join(packageDir, "bun.lock"), { force: true }),
       rm(join(packageDir, "bun.lockb"), { force: true }),
     ]);
+  }
+
+  /** Runs `bun install` from scratch and checks that it installed `no-deps@${version}`. */
+  async function install(version: string, ...args: string[]) {
+    await clean();
     await using proc = spawn({
       cmd: [bunExe(), "install", ...args],
       cwd: packageDir,
@@ -9855,17 +9870,17 @@ describe("manifest conditional requests", () => {
     });
     const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(err).not.toContain("error:");
-    expect(out).toContain("+ no-deps@1.0.0");
+    expect(out).toContain(`+ no-deps@${version}`);
     expect(exitCode).toBe(0);
     expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toStrictEqual({
       name: "no-deps",
-      version: "1.0.0",
+      version,
     });
     const npmPackages = (Object.values(parseLockfile(packageDir).packages) as any[]).filter(
       pkg => pkg.resolution.tag === "npm",
     );
     expect(npmPackages.map(pkg => [pkg.name, pkg.resolution.resolved])).toStrictEqual([
-      ["no-deps", `http://localhost:${registryPort}/no-deps/-/no-deps-1.0.0.tgz`],
+      ["no-deps", `http://localhost:${registryPort}/no-deps/-/no-deps-${version}.tgz`],
     ]);
   }
 
@@ -9877,34 +9892,42 @@ describe("manifest conditional requests", () => {
     using _ = server;
     await setup(server.port);
 
-    await install();
-    await install("--force");
+    await install("1.0.0");
+    await install("1.0.0", "--force");
     expect(requests).toStrictEqual([
       { accept, authorization, ifNoneMatch: null, ifModifiedSince: null, status: 200 },
       { accept, authorization, ifNoneMatch: etag, ifModifiedSince: null, status: 304 },
     ]);
-    expect(tarballRequests()).toBe(1);
+    expect(tarballRequests).toStrictEqual(["1.0.0"]);
 
-    await install();
+    // Whether or not the --force install got to rewrite the cache entry before it
+    // exited (nothing waits for that write), a fresh manifest is on disk.
+    await install("1.0.0");
     expect(requests).toHaveLength(2);
-    expect(tarballRequests()).toBe(1);
+    expect(tarballRequests).toStrictEqual(["1.0.0"]);
   });
 
-  test("a changed etag returns 200 and the new etag is cached", async () => {
-    const validators = { etag };
-    const { server, requests } = startRegistry(validators);
+  test("a changed etag returns 200 and the new manifest and etag are cached", async () => {
+    const served = { etag, versions: ["1.0.0"] };
+    const { server, requests, tarballRequests } = startRegistry(served);
     using _ = server;
     await setup(server.port);
 
-    await install();
-    validators.etag = '"no-deps-manifest-v2"';
-    await install("--force");
-    await install("--force");
+    await install("1.0.0");
+
+    // The registry's manifest changes because a version was published. Installing it
+    // downloads a tarball after the manifest arrived, which is what gives the rewrite
+    // of the cache entry (nothing waits for it) time to land before the install exits.
+    served.versions.push("1.0.1");
+    served.etag = '"no-deps-manifest-v2"';
+    await install("1.0.1", "--force");
+    await install("1.0.1", "--force");
     expect(requests).toStrictEqual([
       { accept, authorization, ifNoneMatch: null, ifModifiedSince: null, status: 200 },
       { accept, authorization, ifNoneMatch: etag, ifModifiedSince: null, status: 200 },
       { accept, authorization, ifNoneMatch: '"no-deps-manifest-v2"', ifModifiedSince: null, status: 304 },
     ]);
+    expect(tarballRequests).toStrictEqual(["1.0.0", "1.0.1"]);
   });
 
   test("If-Modified-Since is sent when the registry only provided Last-Modified", async () => {
@@ -9912,13 +9935,13 @@ describe("manifest conditional requests", () => {
     using _ = server;
     await setup(server.port);
 
-    await install();
-    await install("--force");
+    await install("1.0.0");
+    await install("1.0.0", "--force");
     expect(requests).toStrictEqual([
       { accept, authorization, ifNoneMatch: null, ifModifiedSince: null, status: 200 },
       { accept, authorization, ifNoneMatch: null, ifModifiedSince: lastModified, status: 304 },
     ]);
-    expect(tarballRequests()).toBe(1);
+    expect(tarballRequests).toStrictEqual(["1.0.0"]);
   });
 
   test("no validators means every --force install refetches unconditionally", async () => {
@@ -9926,11 +9949,71 @@ describe("manifest conditional requests", () => {
     using _ = server;
     await setup(server.port);
 
-    await install();
-    await install("--force");
+    await install("1.0.0");
+    await install("1.0.0", "--force");
     expect(requests).toStrictEqual([
       { accept, authorization, ifNoneMatch: null, ifModifiedSince: null, status: 200 },
       { accept, authorization, ifNoneMatch: null, ifModifiedSince: null, status: 200 },
+    ]);
+  });
+
+  // The 304 makes the install rewrite the cache entry from a thread pool task that nothing
+  // waits for, so the install can exit at any point of the rewrite. On Linux the rewrite used
+  // to unlink the entry and link the new file in its place, so an install exiting in between
+  // deleted the entry, and another install reading the cache in between missed it. The poll
+  // below is that other reader. Linux only: the other platforms rename the new file into place.
+  test.skipIf(!isLinux)("rewriting a cached manifest never leaves the cache without the entry", async () => {
+    const { server, requests } = startRegistry({ etag });
+    using _ = server;
+    await setup(server.port);
+    await install("1.0.0");
+
+    const cacheDir = join(packageDir, ".bun-cache");
+    const manifestFiles = (await readdirSorted(cacheDir)).filter(name => name.endsWith(".npm"));
+    expect(manifestFiles).toHaveLength(1);
+    const manifestPath = join(cacheDir, manifestFiles[0]);
+
+    const forcedInstalls = 10;
+    for (let i = 0; i < forcedInstalls; i++) {
+      await clean();
+      await using proc = spawn({
+        cmd: [bunExe(), "install", "--force"],
+        cwd: packageDir,
+        stdout: "pipe",
+        stderr: "pipe",
+        env,
+      });
+      let running = true;
+      const exited = proc.exited.finally(() => {
+        running = false;
+      });
+      let timesMissing = 0;
+      while (running) {
+        for (let poll = 0; poll < 512; poll++) {
+          if (!existsSync(manifestPath)) timesMissing++;
+        }
+        // Gives the event loop a turn to notice the exit between batches of polls.
+        await new Promise(resolve => setImmediate(resolve));
+      }
+      const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), exited]);
+      expect(err).not.toContain("error:");
+      expect(out).toContain("+ no-deps@1.0.0");
+      expect(exitCode).toBe(0);
+      expect({ install: i, timesMissing, presentAfterExit: existsSync(manifestPath) }).toStrictEqual({
+        install: i,
+        timesMissing: 0,
+        presentAfterExit: true,
+      });
+    }
+    expect(requests).toStrictEqual([
+      { accept, authorization, ifNoneMatch: null, ifModifiedSince: null, status: 200 },
+      ...Array.from({ length: forcedInstalls }, () => ({
+        accept,
+        authorization,
+        ifNoneMatch: etag,
+        ifModifiedSince: null,
+        status: 304,
+      })),
     ]);
   });
 });


### PR DESCRIPTION
### Problem
- `test/cli/install/bun-install-registry.test.ts` > "manifest conditional requests" flakes on Linux lanes. Two shapes seen on the alpine aarch64 lane, on a PR that does not touch manifest caching:
  - build 97236, "If-None-Match is sent from the cached etag and a 304 reuses the cached manifest": `expect(requests).toHaveLength(2)` received 3. The install after the `--force` install fetched the manifest again.
  - build 97080, "a changed etag returns 200 and the new etag is cached": the third request still sent `If-None-Match: "no-deps-manifest-v1"` and got a 200. The `--force` install that received the new etag exited before its cache write happened.
- Both come from the manifest cache write being a thread pool task that the install does not wait for (`Serializer::save_async`, src/install/npm.rs). That is deliberate: #37203 tried waiting and reverted it, on the grounds that a lost write only costs a refetch because the old entry stays in place.
- On Linux the old entry did not stay in place. `Serializer::write_file` writes the manifest to an `O_TMPFILE` and `linkat()`s it into the cache directory. `linkat()` cannot replace an existing entry, so when one existed (every rewrite: a 304, or a 200 for a manifest that changed) it ran `unlinkat(entry)` and then `linkat()` again (src/install/npm.rs:1175-1185 before this change). An install exiting between those two syscalls deleted the entry outright, and another install reading the cache between them did not find it either. Build 97236 is the first case: the entry deleted by the 304 rewrite made the next install fetch unconditionally.
- This is not rare. With the release binary on an idle 8 core box, 500 x (`bun install`, then `bun install --force` answered with a 304): 6 runs ended with the entry deleted and 19 with the rewrite lost; with the registry returning a changed manifest instead of a 304: 18 deleted, 14 lost. It affects every `bun install` that revalidates expired manifests while the tarballs are already cached, which is the common repeat install; a deleted entry turns the next revalidation (a 304) into a full manifest download.

### Fix
- `write_file`: when the direct `linkat()` into the cache directory fails (usually because an entry exists, but for whatever reason), link the tmpfile under its temporary name in the temporary directory and fall through to the `renameat()` that the non-`O_TMPFILE` path already uses. `rename(2)` replaces the entry atomically, so the cache has the old or the new entry at every moment, however far the task got when the process exits. If that second `linkat()` or the rename fails, the error is returned and the existing entry is untouched; the old code unlinked the entry before retrying on any failure, so a failure that was not `EEXIST` deleted the entry outright.
- The temporary directory is on the cache directory's filesystem by construction (`get_temporary_directory_run` verifies a rename into the cache directory works and falls back to `<cache>/.tmp`), which is what the existing rename path relies on as well. The rename path's error handling already unlinks the temporary name on failure, so nothing is left behind.
- First saves (no existing entry) still take the single `linkat()` as before. macOS and the non-`O_TMPFILE` fallback already rename into place, and Windows renames with replace, so they are unaffected. `bun_sys::Tmpfile::finish` has the same unlink-then-link shape, but it is behind `ALLOW_TMPFILE = false` and is left alone.
- The lost-write case (build 97080) stays by design; the test that depended on it is changed so it no longer does, see below. With the entry guaranteed to survive, the original "304 reuses the cached manifest" test is deterministic as written: whether or not the rewrite landed, a fresh entry is on disk for the third install.
- Tests, all in the existing "manifest conditional requests" group:
  - New "rewriting a cached manifest never leaves the cache without the entry" (Linux only, the path is Linux only): one install populates the cache, then 10 x `bun install --force` (each answered with a 304) while the test polls `existsSync` on the `.npm` entry; the entry must never be observed missing and must exist after each exit, and the registry must have seen exactly one unconditional request followed by ten 304s. Unfixed it fails on the first or second forced install: 6 of 6 runs with the debug build (`timesMissing: 1`), 3 of 3 with `USE_SYSTEM_BUN=1` (6 to 23 missing observations per run, the gap is wider than the poll interval on release). Fixed: 3 of 3 runs of the group pass, plus a 60 iteration poll probe and 250 exit-race probes against the fixed debug build with 0 deleted entries. Detection per forced install is about 50-70% on the debug build and about 80% on release, hence 10 installs. The count only sets how reliably the unfixed build fails: with the fix the pass does not depend on timing, since `rename(2)` never leaves the name absent and nothing else in a forced install touches the entry. The passing case takes 2.4-3.9s on the debug build; a forced install with the poll running costs about 15ms with the released binary, so roughly 0.2s for the test on a release build.
  - "a changed etag returns 200 and the new manifest and etag are cached": the registry now changes its manifest by publishing `no-deps@1.0.1` (fixture already in the repo) along with the new etag, so the `--force` install downloads a tarball after the manifest arrives, which is the same room every first install in the suite gives its cache writes. The request sequence asserted is unchanged; the test additionally checks that 1.0.1 was installed from the 200 body and again from the rewritten entry after the 304, and that its tarball was downloaded once. To support this, `startRegistry` serves a list of versions and `install()` takes the version it expects; the other tests in the group only changed to pass `"1.0.0"` and to assert the exact tarball list instead of a count.
  - Whole file: 244 pass, 0 fail on the debug build. `cargo clippy -p bun_install` and `cargo fmt --check` are clean.
- Related: #38580 removes a different test's dependency on the same unawaited write and does not touch this code; #37203 is the decision to keep the write unawaited that this change makes sound.

### Background
- Manifest cache: `bun install` stores each registry manifest it fetched as `<cache>/<hash>.npm`, with the registry's `ETag` / `Last-Modified` and a freshness stamp 5 minutes out. A later install uses a fresh entry without a request; an expired one (or any entry under `--force`) is revalidated with `If-None-Match` / `If-Modified-Since`, and both a 304 and a 200 rewrite the entry (`runTasks.rs` for the 304, `get_package_metadata` for the 200).
- `save_async`: the rewrite is scheduled on the install thread pool and not counted as a pending task, so `bun install` can exit while it is still running. A `--force` install whose tarballs are already cached has nothing left to do after the 304, so it regularly exits during the rewrite; that is the shape both failing tests have.
- `O_TMPFILE`: a Linux way to create an unnamed file and give it a name afterwards with `linkat()`, so an interrupted write leaves nothing behind. `linkat()` only creates new names, it never replaces one; `rename()` is the operation that replaces a name atomically.

<details>
<summary>Probes (release binary unless noted, 8 core box, no load)</summary>

Each iteration: fresh cache, `bun install` (200, caches the entry), then `bun install --force`, then look at the entry. `landed` = new inode, `lostUnchanged` = old entry still there (write never happened), `lostMissing` = entry gone.

```
registry answers the --force install with 304:
  unfixed release:      500 iterations: landed 473, lostUnchanged 19, lostMissing 6
  unfixed release, --dry-run (exits sooner): 300: landed 13, lostUnchanged 269, lostMissing 18
  fixed debug, --dry-run: 150: landed 134, lostUnchanged 16, lostMissing 0
registry answers with a changed manifest (200, new etag):
  unfixed release:      500 iterations: landed 463, lostUnchanged 14, lostMissing 18
  fixed debug:          100 iterations: landed 100, lostUnchanged 0, lostMissing 0
50 cached packages, 10 x forced install per run, entry count checked after each:
  unfixed debug: 19 of 50 installs ended with at least one entry missing (28 entries total)
  fixed debug:   0 of 50
Polling the entry during single forced installs (the shape of the new test):
  unfixed release: 41 of 50 installs observed the entry missing (typically 10-40 polls of ~1us each)
  unfixed debug:   24 of 50, 13 of 20, 14 of 20
  fixed debug:     0 of 60
```

The first install of an iteration also lost its write once per 500 iterations in two of the runs, with the tarball download after it. That is the rate the rest of the suite lives with and is unchanged here.
</details>


