### PR TITLE
Hold a transitive update that would re-fork a deduped package

### DIFF
--- a/src/install/update_transitive.rs
+++ b/src/install/update_transitive.rs
@@ -1318,6 +1318,8 @@ fn edges_on_instances(manager: &mut PackageManager, instances: &[Instance]) -> I
     struct DirectRow {
         dep_id: DependencyID,
         inst: u32,
+        /// Slot of the instance the row currently resolves to, `u32::MAX` when unresolved or unplanned.
+        res_slot: u32,
         catalog: bool,
     }
     let mut followers: Vec<Vec<DependencyID>> = vec![Vec::new(); instances.len()];
@@ -1365,6 +1367,10 @@ fn edges_on_instances(manager: &mut PackageManager, instances: &[Instance]) -> I
                     _ => continue,
                 };
                 let row_hash = Semver::string::Builder::string_hash(names.slice(buf));
+                let res_slot = slot_of
+                    .get(resolutions[row] as usize)
+                    .copied()
+                    .unwrap_or(u32::MAX);
                 for (i, inst) in instances.iter().enumerate() {
                     if name_hashes[inst.pkg_id as usize] == row_hash
                         && names.eql(pkg_names[inst.pkg_id as usize], buf, buf)
@@ -1372,6 +1378,7 @@ fn edges_on_instances(manager: &mut PackageManager, instances: &[Instance]) -> I
                         direct_rows.push(DirectRow {
                             dep_id: row as DependencyID,
                             inst: i as u32,
+                            res_slot,
                             catalog: deps[row].version.tag == DependencyVersionTag::Catalog,
                         });
                     }
@@ -1411,8 +1418,10 @@ fn edges_on_instances(manager: &mut PackageManager, instances: &[Instance]) -> I
             named_row_in_scope(manager, row.dep_id)
         };
         if !reresolves {
-            // The row keeps its locked resolution; only the redirect can carry it.
-            followers[row.inst as usize].push(row.dep_id);
+            // The row keeps its locked resolution, so it sits on exactly that instance; only the redirect can carry it.
+            if row.inst == row.res_slot {
+                followers[row.inst as usize].push(row.dep_id);
+            }
             continue;
         }
         // Mirrors `latest_for_target`; named rows reach plan_edges via the --latest-only path.

--- a/src/install/update_transitive.rs
+++ b/src/install/update_transitive.rs
@@ -1205,24 +1205,64 @@ fn plan_edges(
                 }
             })
             .collect();
-        for (w, want) in inst.wants.iter().enumerate() {
-            let Some(plan) = &planned[w] else {
-                continue;
-            };
-            let (v, to) = (plan.v, plan.to);
-            if to.is_some()
-                && forks_surviving_instance(
+        let edge_wants: Vec<(DependencyID, Option<usize>)> = edges_on.followers[inst_i]
+            .iter()
+            .map(|&edge| {
+                let owner = inst
+                    .wants
+                    .iter()
+                    .position(|want| want.dep_ids.contains(&edge));
+                (edge, owner)
+            })
+            .collect();
+        let direct_stays = edges_on.direct[inst_i].iter().any(|&dep_id| {
+            direct_row_stays(
+                &manager.lockfile,
+                manifest,
+                dep_id,
+                inst.current,
+                min_age,
+                excludes,
+            )
+        });
+        // Holds cascade (a held want stays behind and can block another), so iterate to a fixed point.
+        let mut held_wants = vec![false; inst.wants.len()];
+        loop {
+            let mut changed = false;
+            for w in 0..inst.wants.len() {
+                let Some(plan) = &planned[w] else {
+                    continue;
+                };
+                if held_wants[w] || plan.to.is_none() {
+                    continue;
+                }
+                if forks_surviving_instance(
                     &manager.lockfile,
                     inst,
                     w,
                     &planned,
-                    &edges_on[inst_i],
-                    v,
+                    &held_wants,
+                    &edge_wants,
+                    direct_stays,
+                    plan.v,
                     manifest_buf,
-                )
-            {
+                ) {
+                    held_wants[w] = true;
+                    changed = true;
+                }
+            }
+            if !changed {
+                break;
+            }
+        }
+        for (w, want) in inst.wants.iter().enumerate() {
+            let Some(plan) = &planned[w] else {
+                continue;
+            };
+            if held_wants[w] {
                 continue;
             }
+            let (v, to) = (plan.v, plan.to);
             if to.is_some() && !v.tag.pre.value.is_inline() {
                 let end = pins.len() + want.dep_ids.len();
                 pre_strings.push((
@@ -1267,31 +1307,105 @@ fn plan_edges(
     Ok((pins, report))
 }
 
-/// For each planned instance, every edge in the lockfile still resolving to it.
-fn edges_on_instances(lockfile: &Lockfile, instances: &[Instance]) -> Vec<Vec<DependencyID>> {
-    let mut slot_of: Vec<u32> = vec![u32::MAX; lockfile.packages.len()];
+/// Live rows grouped per planned instance. `followers` resolve to the instance and only the
+/// post-resolve redirect can move them; `direct` rows (root/workspace-owned) name its package and
+/// are re-resolved by the differ instead, so they are matched by name (after the differ re-appends
+/// root rows their resolutions are not yet valid). Orphaned rows outside every live slice are skipped.
+struct InstanceEdges {
+    followers: Vec<Vec<DependencyID>>,
+    direct: Vec<Vec<DependencyID>>,
+}
+
+fn edges_on_instances(lockfile: &Lockfile, instances: &[Instance]) -> InstanceEdges {
+    let packages_len = lockfile.packages.len();
+    let mut slot_of: Vec<u32> = vec![u32::MAX; packages_len];
     for (i, inst) in instances.iter().enumerate() {
         slot_of[inst.pkg_id as usize] = i as u32;
     }
-    let mut edges_on: Vec<Vec<DependencyID>> = vec![Vec::new(); instances.len()];
-    for (j, &target) in lockfile.buffers.resolutions.iter().enumerate() {
-        let Some(&slot) = slot_of.get(target as usize) else {
-            continue;
-        };
-        if slot != u32::MAX {
-            edges_on[slot as usize].push(j as DependencyID);
+    let buf = lockfile.buffers.string_bytes.as_slice();
+    let pkg_res = lockfile.packages.items_resolution();
+    let pkg_names = lockfile.packages.items_name();
+    let dep_slices = lockfile.packages.items_dependencies();
+    let deps = lockfile.buffers.dependencies.as_slice();
+    let resolutions = lockfile.buffers.resolutions.as_slice();
+
+    let mut followers: Vec<Vec<DependencyID>> = vec![Vec::new(); instances.len()];
+    let mut direct: Vec<Vec<DependencyID>> = vec![Vec::new(); instances.len()];
+    for owner in 0..packages_len {
+        let slice = dep_slices[owner];
+        let is_direct = matches!(
+            pkg_res[owner].tag,
+            ResolutionTag::Root | ResolutionTag::Workspace
+        );
+        for row in slice.begin() as usize..slice.end() as usize {
+            if !is_direct {
+                let Some(&slot) = slot_of.get(resolutions[row] as usize) else {
+                    continue;
+                };
+                if slot != u32::MAX {
+                    followers[slot as usize].push(row as DependencyID);
+                }
+                continue;
+            }
+            let Some(version) =
+                dedupe::effective_version(lockfile, row as DependencyID, &deps[row])
+            else {
+                continue;
+            };
+            let names = match version.tag {
+                DependencyVersionTag::Npm => version.npm().name,
+                DependencyVersionTag::DistTag => version.dist_tag().name,
+                _ => continue,
+            };
+            for (i, inst) in instances.iter().enumerate() {
+                if names.eql(pkg_names[inst.pkg_id as usize], buf, buf) {
+                    direct[i].push(row as DependencyID);
+                }
+            }
         }
     }
-    edges_on
+    InstanceEdges { followers, direct }
+}
+
+/// Whether the differ will land this root/workspace row back on `current`: the best release its
+/// range allows (or its dist-tag target) is `current` itself.
+fn direct_row_stays(
+    lockfile: &Lockfile,
+    manifest: &PackageManifest,
+    dep_id: DependencyID,
+    current: Semver::Version,
+    min_age: Option<f64>,
+    excludes: Option<&[&[u8]]>,
+) -> bool {
+    let buf = lockfile.buffers.string_bytes.as_slice();
+    let dep = &lockfile.buffers.dependencies[dep_id as usize];
+    let Some(version) = dedupe::effective_version(lockfile, dep_id, dep) else {
+        return false;
+    };
+    let found = match version.tag {
+        DependencyVersionTag::Npm => manifest
+            .find_best_version_with_filter(&version.npm().version, buf, min_age, excludes)
+            .unwrap(),
+        DependencyVersionTag::DistTag => manifest
+            .find_by_dist_tag_with_filter(version.dist_tag().tag.slice(buf), min_age, excludes)
+            .unwrap(),
+        _ => return false,
+    };
+    found.is_some_and(|found| {
+        found.version.order(current, &manifest.string_buf, buf) == Ordering::Equal
+    })
 }
 
 /// An edge left behind at a still-satisfying `current` would re-create the duplicate `bun dedupe` removes.
+#[allow(clippy::too_many_arguments)]
 fn forks_surviving_instance(
     lockfile: &Lockfile,
     inst: &Instance,
     want_index: usize,
     planned: &[Option<Planned>],
-    edges: &[DependencyID],
+    held_wants: &[bool],
+    edge_wants: &[(DependencyID, Option<usize>)],
+    direct_stays: bool,
     v: Semver::Version,
     manifest_buf: &[u8],
 ) -> bool {
@@ -1302,25 +1416,21 @@ fn forks_surviving_instance(
     {
         return false;
     }
+    if direct_stays {
+        return true;
+    }
     let deps = lockfile.buffers.dependencies.as_slice();
     let stays = |version: &dependency::Version| {
         version.tag != DependencyVersionTag::Npm
             || !version.npm().version.satisfies(v, buf, manifest_buf)
     };
-    edges.iter().any(|&edge| {
-        match inst
-            .wants
-            .iter()
-            .position(|other| other.dep_ids.contains(&edge))
-        {
-            Some(w) if w == want_index => false,
-            Some(w) => planned[w].is_none() && stays(&inst.wants[w].version),
-            None => {
-                let dep = &deps[edge as usize];
-                dep.behavior.is_bundled()
-                    || dedupe::effective_npm_range(lockfile, edge, dep)
-                        .is_none_or(|range| stays(&range))
-            }
+    edge_wants.iter().any(|&(edge, owner)| match owner {
+        Some(w) if w == want_index => false,
+        Some(w) => (planned[w].is_none() || held_wants[w]) && stays(&inst.wants[w].version),
+        None => {
+            let dep = &deps[edge as usize];
+            dep.behavior.is_bundled()
+                || dedupe::effective_npm_range(lockfile, edge, dep).is_none_or(|range| stays(&range))
         }
     })
 }

--- a/src/install/update_transitive.rs
+++ b/src/install/update_transitive.rs
@@ -1133,7 +1133,7 @@ fn plan_edges(
     if instances.is_empty() {
         return Ok((Vec::new(), Report::default()));
     }
-    let edges_on = edges_on_instances(&manager.lockfile, &instances);
+    let edges_on = edges_on_instances(manager, &instances);
 
     let ids: Vec<PackageID> = instances.iter().map(|inst| inst.pkg_id).collect();
     let msgs_before = manager.log_mut().msgs.len();
@@ -1215,11 +1215,12 @@ fn plan_edges(
                 (edge, owner)
             })
             .collect();
-        let direct_stays = edges_on.direct[inst_i].iter().any(|&dep_id| {
+        let direct_stays = edges_on.direct[inst_i].iter().any(|&(dep_id, latest)| {
             direct_row_stays(
                 &manager.lockfile,
                 manifest,
                 dep_id,
+                latest,
                 inst.current,
                 min_age,
                 excludes,
@@ -1307,89 +1308,182 @@ fn plan_edges(
     Ok((pins, report))
 }
 
-/// Live rows per planned instance: `followers` resolve to it and move only via the post-resolve redirect; `direct` root/workspace rows are re-resolved by the differ, so they are matched by name.
+/// Live rows per planned instance: `followers` move only via the post-resolve redirect; `direct` rows are the root/workspace rows the differ re-resolves (`true` lands on the `latest` dist-tag), per `should_update`.
 struct InstanceEdges {
     followers: Vec<Vec<DependencyID>>,
-    direct: Vec<Vec<DependencyID>>,
+    direct: Vec<Vec<(DependencyID, bool)>>,
 }
 
-fn edges_on_instances(lockfile: &Lockfile, instances: &[Instance]) -> InstanceEdges {
-    let packages_len = lockfile.packages.len();
-    let mut slot_of: Vec<u32> = vec![u32::MAX; packages_len];
-    for (i, inst) in instances.iter().enumerate() {
-        slot_of[inst.pkg_id as usize] = i as u32;
+fn edges_on_instances(manager: &mut PackageManager, instances: &[Instance]) -> InstanceEdges {
+    struct DirectRow {
+        dep_id: DependencyID,
+        inst: u32,
+        catalog: bool,
     }
-    let buf = lockfile.buffers.string_bytes.as_slice();
-    let pkg_res = lockfile.packages.items_resolution();
-    let pkg_names = lockfile.packages.items_name();
-    let name_hashes = lockfile.packages.items_name_hash();
-    let dep_slices = lockfile.packages.items_dependencies();
-    let deps = lockfile.buffers.dependencies.as_slice();
-    let resolutions = lockfile.buffers.resolutions.as_slice();
-
     let mut followers: Vec<Vec<DependencyID>> = vec![Vec::new(); instances.len()];
-    let mut direct: Vec<Vec<DependencyID>> = vec![Vec::new(); instances.len()];
-    for owner in 0..packages_len {
-        let slice = dep_slices[owner];
-        let is_direct = matches!(
-            pkg_res[owner].tag,
-            ResolutionTag::Root | ResolutionTag::Workspace
-        );
-        for row in slice.begin() as usize..slice.end() as usize {
-            if !is_direct {
-                let Some(&slot) = slot_of.get(resolutions[row] as usize) else {
+    let mut direct: Vec<Vec<(DependencyID, bool)>> = vec![Vec::new(); instances.len()];
+    let mut direct_rows: Vec<DirectRow> = Vec::new();
+    {
+        let lockfile: &Lockfile = &manager.lockfile;
+        let packages_len = lockfile.packages.len();
+        let mut slot_of: Vec<u32> = vec![u32::MAX; packages_len];
+        for (i, inst) in instances.iter().enumerate() {
+            slot_of[inst.pkg_id as usize] = i as u32;
+        }
+        let buf = lockfile.buffers.string_bytes.as_slice();
+        let pkg_res = lockfile.packages.items_resolution();
+        let pkg_names = lockfile.packages.items_name();
+        let name_hashes = lockfile.packages.items_name_hash();
+        let dep_slices = lockfile.packages.items_dependencies();
+        let deps = lockfile.buffers.dependencies.as_slice();
+        let resolutions = lockfile.buffers.resolutions.as_slice();
+
+        for owner in 0..packages_len {
+            let slice = dep_slices[owner];
+            let is_direct = matches!(
+                pkg_res[owner].tag,
+                ResolutionTag::Root | ResolutionTag::Workspace
+            );
+            for row in slice.begin() as usize..slice.end() as usize {
+                if !is_direct {
+                    let Some(&slot) = slot_of.get(resolutions[row] as usize) else {
+                        continue;
+                    };
+                    if slot != u32::MAX {
+                        followers[slot as usize].push(row as DependencyID);
+                    }
+                    continue;
+                }
+                let Some(version) =
+                    dedupe::effective_version(lockfile, row as DependencyID, &deps[row])
+                else {
                     continue;
                 };
-                if slot != u32::MAX {
-                    followers[slot as usize].push(row as DependencyID);
-                }
-                continue;
-            }
-            let Some(version) =
-                dedupe::effective_version(lockfile, row as DependencyID, &deps[row])
-            else {
-                continue;
-            };
-            let names = match version.tag {
-                DependencyVersionTag::Npm => version.npm().name,
-                DependencyVersionTag::DistTag => version.dist_tag().name,
-                _ => continue,
-            };
-            let row_hash = Semver::string::Builder::string_hash(names.slice(buf));
-            for (i, inst) in instances.iter().enumerate() {
-                if name_hashes[inst.pkg_id as usize] == row_hash
-                    && names.eql(pkg_names[inst.pkg_id as usize], buf, buf)
-                {
-                    direct[i].push(row as DependencyID);
+                let names = match version.tag {
+                    DependencyVersionTag::Npm => version.npm().name,
+                    DependencyVersionTag::DistTag => version.dist_tag().name,
+                    _ => continue,
+                };
+                let row_hash = Semver::string::Builder::string_hash(names.slice(buf));
+                for (i, inst) in instances.iter().enumerate() {
+                    if name_hashes[inst.pkg_id as usize] == row_hash
+                        && names.eql(pkg_names[inst.pkg_id as usize], buf, buf)
+                    {
+                        direct_rows.push(DirectRow {
+                            dep_id: row as DependencyID,
+                            inst: i as u32,
+                            catalog: deps[row].version.tag == DependencyVersionTag::Catalog,
+                        });
+                    }
                 }
             }
         }
     }
+
+    let bare = manager.update_requests.is_empty();
+    let has_targets = manager.update_target_workspaces.is_some();
+    let to_latest = manager
+        .options
+        .do_
+        .contains(crate::package_manager::options::Do::UPDATE_TO_LATEST);
+    for row in direct_rows {
+        let in_targets = {
+            let lockfile: &Lockfile = &manager.lockfile;
+            manager
+                .update_target_workspaces
+                .as_deref()
+                .is_some_and(|targets| lockfile.is_dependency_of_workspace_in(targets, row.dep_id))
+        };
+        // Mirrors `should_update`: bare update re-resolves the target workspaces' rows (the cwd
+        // workspace's without -r/--filter) and every catalog row; a named update re-resolves the
+        // in-scope rows naming a requested package.
+        let reresolves = if bare {
+            row.catalog
+                || if has_targets {
+                    in_targets
+                } else {
+                    let this_ptr: *mut PackageManager = manager;
+                    // SAFETY: as in `should_update` — `is_root_dependency` reads
+                    // `manager.root_package_id` and the workspace package.json cache only,
+                    // disjoint from `manager.lockfile`.
+                    unsafe { &*(*this_ptr).lockfile }
+                        .is_root_dependency(unsafe { &mut *this_ptr }, row.dep_id)
+                }
+        } else {
+            named_row_in_scope(manager, row.dep_id)
+        };
+        if !reresolves {
+            // The row keeps its locked resolution; only the redirect can carry it.
+            followers[row.inst as usize].push(row.dep_id);
+            continue;
+        }
+        // Mirrors `latest_for_target`; named rows reach plan_edges via the --latest-only path.
+        let latest =
+            to_latest && (!bare || in_targets) && !overridden_row(&manager.lockfile, row.dep_id);
+        direct[row.inst as usize].push((row.dep_id, latest));
+    }
     InstanceEdges { followers, direct }
 }
 
-/// The differ lands this root/workspace row back on `current` when that is the best release (or dist-tag target) its range allows.
+/// Mirrors `should_update`'s named branch: the row names a requested package and sits in the update scope.
+fn named_row_in_scope(manager: &PackageManager, dep_id: DependencyID) -> bool {
+    let lockfile: &Lockfile = &manager.lockfile;
+    let buf = lockfile.buffers.string_bytes.as_slice();
+    let dep = &lockfile.buffers.dependencies[dep_id as usize];
+    let aliased =
+        dedupe::effective_version(lockfile, dep_id, dep).and_then(|version| match version.tag {
+            DependencyVersionTag::Npm => Some(version.npm().name),
+            DependencyVersionTag::DistTag => Some(version.dist_tag().name),
+            _ => None,
+        });
+    let named = manager.is_update_request(dep.name_hash, dep.name.slice(buf))
+        || aliased.is_some_and(|name| {
+            let hash = Semver::string::Builder::string_hash(name.slice(buf));
+            hash != dep.name_hash && manager.is_update_request(hash, name.slice(buf))
+        });
+    named && UpdateScope::of(manager).contains_dependency(lockfile, dep_id)
+}
+
+/// Overridden rows resolve by the override range, never by `latest` (`!version_was_replaced` in `latest_for_target`).
+fn overridden_row(lockfile: &Lockfile, dep_id: DependencyID) -> bool {
+    let dep = &lockfile.buffers.dependencies[dep_id as usize];
+    !dep.behavior.is_workspace()
+        && !(dep.version.tag == DependencyVersionTag::Npm && dep.version.npm().is_alias)
+        && lockfile
+            .overrides
+            .get(lockfile, dep_id, dep.name_hash)
+            .is_some()
+}
+
+/// The differ lands this row back on `current` when that is the release it re-resolves to: the `latest` dist-tag for `--latest` target rows, otherwise the best release the row's range allows.
 fn direct_row_stays(
     lockfile: &Lockfile,
     manifest: &PackageManifest,
     dep_id: DependencyID,
+    latest: bool,
     current: Semver::Version,
     min_age: Option<f64>,
     excludes: Option<&[&[u8]]>,
 ) -> bool {
     let buf = lockfile.buffers.string_bytes.as_slice();
-    let dep = &lockfile.buffers.dependencies[dep_id as usize];
-    let Some(version) = dedupe::effective_version(lockfile, dep_id, dep) else {
-        return false;
-    };
-    let found = match version.tag {
-        DependencyVersionTag::Npm => manifest
-            .find_best_version_with_filter(&version.npm().version, buf, min_age, excludes)
-            .unwrap(),
-        DependencyVersionTag::DistTag => manifest
-            .find_by_dist_tag_with_filter(version.dist_tag().tag.slice(buf), min_age, excludes)
-            .unwrap(),
-        _ => return false,
+    let found = if latest {
+        manifest
+            .find_by_dist_tag_with_filter(b"latest", min_age, excludes)
+            .unwrap()
+    } else {
+        let dep = &lockfile.buffers.dependencies[dep_id as usize];
+        let Some(version) = dedupe::effective_version(lockfile, dep_id, dep) else {
+            return false;
+        };
+        match version.tag {
+            DependencyVersionTag::Npm => manifest
+                .find_best_version_with_filter(&version.npm().version, buf, min_age, excludes)
+                .unwrap(),
+            DependencyVersionTag::DistTag => manifest
+                .find_by_dist_tag_with_filter(version.dist_tag().tag.slice(buf), min_age, excludes)
+                .unwrap(),
+            _ => return false,
+        }
     };
     found.is_some_and(|found| {
         found.version.order(current, &manifest.string_buf, buf) == Ordering::Equal

--- a/src/install/update_transitive.rs
+++ b/src/install/update_transitive.rs
@@ -259,6 +259,13 @@ struct Pin {
     to: Option<Semver::Version>,
 }
 
+struct Planned {
+    v: Semver::Version,
+    /// `None` re-resolves the edge through its own dist-tag.
+    to: Option<Semver::Version>,
+    later: Box<[u8]>,
+}
+
 /// The transitive half of a bare `bun update`: every edge owned by a non-workspace package the selected workspaces reach (all of them from the root or with -r) moves to the newest release its own range allows, or to wherever its dist-tag points now.
 #[derive(Default)]
 pub struct TransitiveUpdate {
@@ -1126,6 +1133,7 @@ fn plan_edges(
     if instances.is_empty() {
         return Ok((Vec::new(), Report::default()));
     }
+    let edges_on = edges_on_instances(&manager.lockfile, &instances);
 
     let ids: Vec<PackageID> = instances.iter().map(|inst| inst.pkg_id).collect();
     let msgs_before = manager.log_mut().msgs.len();
@@ -1142,7 +1150,7 @@ fn plan_edges(
     let mut unchecked: Vec<(Box<[u8]>, Box<[u8]>)> = Vec::new();
     // Non-inline prerelease strings of planned versions live in the manifest buffer; copied into the lockfile's below.
     let mut pre_strings: Vec<(core::ops::Range<usize>, u64, Box<[u8]>)> = Vec::new();
-    for inst in &instances {
+    for (inst_i, inst) in instances.iter().enumerate() {
         if inst.held {
             continue;
         }
@@ -1166,41 +1174,63 @@ fn plan_edges(
         let manifest: &PackageManifest = manifest;
         let manifest_buf: &[u8] = &manifest.string_buf;
         let rows_before = report.rows.len();
-        for want in &inst.wants {
-            let (v, to, later) = if want.version.tag == DependencyVersionTag::Npm {
-                let range = &want.version.npm().version;
-                let Some(found) = manifest
-                    .find_best_version_with_filter(range, buf, min_age, excludes)
-                    .unwrap()
-                else {
-                    continue;
-                };
-                let v = found.version;
-                if v.order(inst.current, manifest_buf, buf) != Ordering::Greater {
-                    continue;
+        let planned: Vec<Option<Planned>> = inst
+            .wants
+            .iter()
+            .map(|want| {
+                if want.version.tag == DependencyVersionTag::Npm {
+                    let range = &want.version.npm().version;
+                    manifest
+                        .find_best_version_with_filter(range, buf, min_age, excludes)
+                        .unwrap()
+                        .map(|found| found.version)
+                        .filter(|&v| v.order(inst.current, manifest_buf, buf) == Ordering::Greater)
+                        .map(|v| Planned {
+                            v,
+                            to: Some(v),
+                            later: later_than(manifest, v, min_age, excludes),
+                        })
+                } else {
+                    let tag = want.version.dist_tag().tag.slice(buf);
+                    manifest
+                        .find_by_dist_tag_with_filter(tag, min_age, excludes)
+                        .unwrap()
+                        .map(|found| found.version)
+                        .filter(|&v| v.order(inst.current, manifest_buf, buf) != Ordering::Equal)
+                        .map(|v| Planned {
+                            v,
+                            to: None,
+                            later: Box::default(),
+                        })
                 }
-                if !v.tag.pre.value.is_inline() {
-                    let end = pins.len() + want.dep_ids.len();
-                    pre_strings.push((
-                        pins.len()..end,
-                        v.tag.pre.hash,
-                        Box::from(v.tag.pre.slice(manifest_buf)),
-                    ));
-                }
-                (v, Some(v), later_than(manifest, v, min_age, excludes))
-            } else {
-                let tag = want.version.dist_tag().tag.slice(buf);
-                let Some(found) = manifest
-                    .find_by_dist_tag_with_filter(tag, min_age, excludes)
-                    .unwrap()
-                else {
-                    continue;
-                };
-                if found.version.order(inst.current, manifest_buf, buf) == Ordering::Equal {
-                    continue;
-                }
-                (found.version, None, Box::default())
+            })
+            .collect();
+        for (w, want) in inst.wants.iter().enumerate() {
+            let Some(plan) = &planned[w] else {
+                continue;
             };
+            let (v, to) = (plan.v, plan.to);
+            if to.is_some()
+                && forks_surviving_instance(
+                    &manager.lockfile,
+                    inst,
+                    w,
+                    &planned,
+                    &edges_on[inst_i],
+                    v,
+                    manifest_buf,
+                )
+            {
+                continue;
+            }
+            if to.is_some() && !v.tag.pre.value.is_inline() {
+                let end = pins.len() + want.dep_ids.len();
+                pre_strings.push((
+                    pins.len()..end,
+                    v.tag.pre.hash,
+                    Box::from(v.tag.pre.slice(manifest_buf)),
+                ));
+            }
             pins.extend(want.dep_ids.iter().map(|&dep_id| Pin {
                 dep_id,
                 from: inst.pkg_id,
@@ -1210,7 +1240,7 @@ fn plan_edges(
                 name: Box::from(name),
                 from: text(inst.current.fmt(buf)),
                 to: text(v.fmt(manifest_buf)),
-                later,
+                later: plan.later.clone(),
             });
         }
         if report.rows.len() != rows_before {
@@ -1235,6 +1265,67 @@ fn plan_edges(
 
     sort_dedup_rows(&mut report.rows);
     Ok((pins, report))
+}
+
+/// For each planned instance, every edge in the lockfile still resolving to it.
+fn edges_on_instances(lockfile: &Lockfile, instances: &[Instance]) -> Vec<Vec<DependencyID>> {
+    let mut slot_of: Vec<u32> = vec![u32::MAX; lockfile.packages.len()];
+    for (i, inst) in instances.iter().enumerate() {
+        slot_of[inst.pkg_id as usize] = i as u32;
+    }
+    let mut edges_on: Vec<Vec<DependencyID>> = vec![Vec::new(); instances.len()];
+    for (j, &target) in lockfile.buffers.resolutions.iter().enumerate() {
+        let Some(&slot) = slot_of.get(target as usize) else {
+            continue;
+        };
+        if slot != u32::MAX {
+            edges_on[slot as usize].push(j as DependencyID);
+        }
+    }
+    edges_on
+}
+
+/// A move to `v` is dropped when another edge on the instance stays behind at `current` (its range
+/// rejects `v`, or it is bundled or has no npm range, so the post-resolve redirect cannot carry it)
+/// while `current` already satisfies the moving range: the fork would add exactly the duplicate
+/// `bun dedupe` removes, and the two commands would undo each other forever.
+fn forks_surviving_instance(
+    lockfile: &Lockfile,
+    inst: &Instance,
+    want_index: usize,
+    planned: &[Option<Planned>],
+    edges: &[DependencyID],
+    v: Semver::Version,
+    manifest_buf: &[u8],
+) -> bool {
+    let buf = lockfile.buffers.string_bytes.as_slice();
+    let want = &inst.wants[want_index];
+    if want.version.tag != DependencyVersionTag::Npm
+        || !want.version.npm().version.satisfies(inst.current, buf, buf)
+    {
+        return false;
+    }
+    let deps = lockfile.buffers.dependencies.as_slice();
+    let stays = |version: &dependency::Version| {
+        version.tag != DependencyVersionTag::Npm
+            || !version.npm().version.satisfies(v, buf, manifest_buf)
+    };
+    edges.iter().any(|&edge| {
+        match inst
+            .wants
+            .iter()
+            .position(|other| other.dep_ids.contains(&edge))
+        {
+            Some(w) if w == want_index => false,
+            Some(w) => planned[w].is_none() && stays(&inst.wants[w].version),
+            None => {
+                let dep = &deps[edge as usize];
+                dep.behavior.is_bundled()
+                    || dedupe::effective_npm_range(lockfile, edge, dep)
+                        .is_none_or(|range| stays(&range))
+            }
+        }
+    })
 }
 
 /// The `latest` dist-tag when it is newer than the release `v` an in-range move stops at, like the `+` rows' `(vX available)`.

--- a/src/install/update_transitive.rs
+++ b/src/install/update_transitive.rs
@@ -1215,23 +1215,29 @@ fn plan_edges(
                 (edge, owner)
             })
             .collect();
-        // Rows the differ lands back on `current`; like followers, the redirect can still carry them.
-        let direct_stayers: Vec<DependencyID> = edges_on.direct[inst_i]
-            .iter()
-            .filter(|&&(dep_id, latest, keep)| {
-                direct_row_stays(
-                    &manager.lockfile,
-                    manifest,
-                    dep_id,
-                    latest,
-                    keep,
-                    inst.current,
-                    min_age,
-                    excludes,
-                )
-            })
-            .map(|&(dep_id, ..)| dep_id)
-            .collect();
+        // Where the differ lands each direct row: rows back on `current` are stayers the redirect
+        // can still carry; moved rows' landings are earlier redirect targets of their own.
+        let mut direct_stayers: Vec<DependencyID> = Vec::new();
+        let mut direct_landings: Vec<(Semver::Version, bool)> = Vec::new();
+        for &(dep_id, latest, keep) in &edges_on.direct[inst_i] {
+            let Some((landing, in_manifest)) = direct_row_landing(
+                &manager.lockfile,
+                manifest,
+                dep_id,
+                latest,
+                keep,
+                min_age,
+                excludes,
+            ) else {
+                continue;
+            };
+            let landing_buf = if in_manifest { manifest_buf } else { buf };
+            if landing.order(inst.current, landing_buf, buf) == Ordering::Equal {
+                direct_stayers.push(dep_id);
+            } else {
+                direct_landings.push((landing, in_manifest));
+            }
+        }
         // Holds cascade (a held want stays behind and can block another), so iterate to a fixed point.
         let mut held_wants = vec![false; inst.wants.len()];
         loop {
@@ -1243,11 +1249,9 @@ fn plan_edges(
                 if held_wants[w] || plan.to.is_none() {
                     continue;
                 }
-                // The redirect carries every remaining edge toward the FIRST pinned want's target.
+                // The redirect carries every remaining edge toward the FIRST pinned want's target (dist-tag pins included).
                 let redirect_v = (0..inst.wants.len())
-                    .find(|&i| {
-                        !held_wants[i] && planned[i].as_ref().is_some_and(|plan| plan.to.is_some())
-                    })
+                    .find(|&i| !held_wants[i] && planned[i].is_some())
                     .and_then(|i| planned[i].as_ref().map(|plan| plan.v))
                     .unwrap_or(plan.v);
                 if forks_surviving_instance(
@@ -1258,6 +1262,7 @@ fn plan_edges(
                     &held_wants,
                     &edge_wants,
                     &direct_stayers,
+                    &direct_landings,
                     redirect_v,
                     manifest_buf,
                 ) {
@@ -1639,18 +1644,16 @@ fn overridden_row(lockfile: &Lockfile, dep_id: DependencyID) -> bool {
             .is_some()
 }
 
-/// The differ lands this row back on `current` when that is the release it re-resolves to: the `latest` dist-tag for `--latest` target rows, otherwise the best release the row's range allows.
-#[allow(clippy::too_many_arguments)]
-fn direct_row_stays(
+/// The release the differ lands this row on (with whether it lives in the manifest buffer): the patched capture, the keep-locked version, or the lookup (`latest` dist-tag for `--latest` target rows, else the row's own range or tag).
+fn direct_row_landing(
     lockfile: &Lockfile,
     manifest: &PackageManifest,
     dep_id: DependencyID,
     latest: bool,
     keep: KeepLocked,
-    current: Semver::Version,
     min_age: Option<f64>,
     excludes: Option<&[&[u8]]>,
-) -> bool {
+) -> Option<(Semver::Version, bool)> {
     let buf = lockfile.buffers.string_bytes.as_slice();
     // `patched_package_satisfying` captures the row before any lookup; peer rows fall through.
     if !lockfile.buffers.dependencies[dep_id as usize]
@@ -1658,7 +1661,7 @@ fn direct_row_stays(
         .is_peer()
     {
         if let Some(patched) = patched_capture(lockfile, dep_id) {
-            return patched.order(current, buf, buf) == Ordering::Equal;
+            return Some((patched, false));
         }
     }
     let found = if latest {
@@ -1667,9 +1670,7 @@ fn direct_row_stays(
             .unwrap()
     } else {
         let dep = &lockfile.buffers.dependencies[dep_id as usize];
-        let Some(version) = dedupe::effective_version(lockfile, dep_id, dep) else {
-            return false;
-        };
+        let version = dedupe::effective_version(lockfile, dep_id, dep)?;
         match version.tag {
             DependencyVersionTag::Npm => manifest
                 .find_best_version_with_filter(&version.npm().version, buf, min_age, excludes)
@@ -1677,25 +1678,24 @@ fn direct_row_stays(
             DependencyVersionTag::DistTag => manifest
                 .find_by_dist_tag_with_filter(version.dist_tag().tag.slice(buf), min_age, excludes)
                 .unwrap(),
-            _ => return false,
+            _ => return None,
         }
     };
+    let found = found?;
     // `keep_locked_if_ahead`: a lookup below the row's locked version lands it back on that version, when the manifest still has it.
-    found.is_some_and(|found| {
-        let locked = match keep {
-            KeepLocked::No => None,
-            KeepLocked::Version(locked) => Some(locked),
-            KeepLocked::Range => locked_in_lockfile(lockfile, dep_id),
-        };
-        if let Some(locked) = locked {
-            if found.version.order(locked, &manifest.string_buf, buf) == Ordering::Less
-                && manifest.find_by_version(locked).is_some()
-            {
-                return locked.order(current, buf, buf) == Ordering::Equal;
-            }
+    let locked = match keep {
+        KeepLocked::No => None,
+        KeepLocked::Version(locked) => Some(locked),
+        KeepLocked::Range => locked_in_lockfile(lockfile, dep_id),
+    };
+    if let Some(locked) = locked {
+        if found.version.order(locked, &manifest.string_buf, buf) == Ordering::Less
+            && manifest.find_by_version(locked).is_some()
+        {
+            return Some((locked, false));
         }
-        found.version.order(current, &manifest.string_buf, buf) == Ordering::Equal
-    })
+    }
+    Some((found.version, true))
 }
 
 /// An edge left behind at a still-satisfying `current` would re-create the duplicate `bun dedupe` removes.
@@ -1708,6 +1708,7 @@ fn forks_surviving_instance(
     held_wants: &[bool],
     edge_wants: &[(DependencyID, Option<usize>)],
     direct_stayers: &[DependencyID],
+    direct_landings: &[(Semver::Version, bool)],
     redirect_v: Semver::Version,
     manifest_buf: &[u8],
 ) -> bool {
@@ -1720,11 +1721,14 @@ fn forks_surviving_instance(
     }
     let deps = lockfile.buffers.dependencies.as_slice();
     let stays = |version: &dependency::Version| {
-        version.tag != DependencyVersionTag::Npm
-            || !version
-                .npm()
-                .version
-                .satisfies(redirect_v, buf, manifest_buf)
+        if version.tag != DependencyVersionTag::Npm {
+            return true;
+        }
+        let range = &version.npm().version;
+        !range.satisfies(redirect_v, buf, manifest_buf)
+            && !direct_landings.iter().any(|&(landing, in_manifest)| {
+                range.satisfies(landing, buf, if in_manifest { manifest_buf } else { buf })
+            })
     };
     let uncarried = |edge: DependencyID| {
         let dep = &deps[edge as usize];

--- a/src/install/update_transitive.rs
+++ b/src/install/update_transitive.rs
@@ -293,7 +293,7 @@ impl TransitiveUpdate {
             }
             edges
         };
-        let (pins, report) = plan_edges(manager, &edges, direct)?;
+        let (pins, report) = plan_edges(manager, &edges, direct, false)?;
         register_moved(manager, &report.moved)?;
         let printed_here = manager.options.dry_run || manager.options.lockfile_only;
         Ok(TransitiveUpdate {
@@ -424,7 +424,7 @@ pub(crate) fn refresh_children_of(
         }
         edges
     };
-    let (pins, report) = plan_edges(manager, &edges, &DirectDependencies::default())?;
+    let (pins, report) = plan_edges(manager, &edges, &DirectDependencies::default(), true)?;
     register_moved(manager, &report.moved)?;
     let update = TransitiveUpdate { pins, report: None };
     update.enqueue(manager)?;
@@ -1027,11 +1027,12 @@ pub(crate) fn plannable_peer_rows(
     rows
 }
 
-/// `edges` selects the rows to plan; each moves to the newest release its (post-override/catalog) range allows, or follows its dist-tag.
+/// `edges` selects the rows to plan; each moves to the newest release its (post-override/catalog) range allows, or follows its dist-tag. `post_resolution` marks the `refresh_children_of` call, which runs after the named rows resolved.
 fn plan_edges(
     manager: &mut PackageManager,
     edges: &DynamicBitSet,
     direct: &DirectDependencies,
+    post_resolution: bool,
 ) -> crate::Result<(Vec<Pin>, Report)> {
     let mut instances: Vec<Instance> = Vec::new();
     let mut kept: Vec<PackageID> = Vec::new();
@@ -1133,7 +1134,7 @@ fn plan_edges(
     if instances.is_empty() {
         return Ok((Vec::new(), Report::default()));
     }
-    let edges_on = edges_on_instances(manager, &instances);
+    let edges_on = edges_on_instances(manager, &instances, direct, post_resolution);
 
     let ids: Vec<PackageID> = instances.iter().map(|inst| inst.pkg_id).collect();
     let msgs_before = manager.log_mut().msgs.len();
@@ -1314,7 +1315,12 @@ struct InstanceEdges {
     direct: Vec<Vec<(DependencyID, bool)>>,
 }
 
-fn edges_on_instances(manager: &mut PackageManager, instances: &[Instance]) -> InstanceEdges {
+fn edges_on_instances(
+    manager: &mut PackageManager,
+    instances: &[Instance],
+    direct_deps: &DirectDependencies,
+    post_resolution: bool,
+) -> InstanceEdges {
     struct DirectRow {
         dep_id: DependencyID,
         inst: u32,
@@ -1340,12 +1346,34 @@ fn edges_on_instances(manager: &mut PackageManager, instances: &[Instance]) -> I
         let deps = lockfile.buffers.dependencies.as_slice();
         let resolutions = lockfile.buffers.resolutions.as_slice();
 
+        // After the named rows resolved, a superseded package's rows are still in the buffers;
+        // only owners something still resolves to contribute followers.
+        let referenced = post_resolution.then(|| {
+            let mut referenced = DynamicBitSet::init_empty(packages_len).unwrap_or_oom();
+            for owner in 0..packages_len {
+                let slice = dep_slices[owner];
+                for row in slice.begin() as usize..slice.end() as usize {
+                    if (resolutions[row] as usize) < packages_len {
+                        referenced.set(resolutions[row] as usize);
+                    }
+                }
+            }
+            referenced
+        });
+
         for owner in 0..packages_len {
             let slice = dep_slices[owner];
             let is_direct = matches!(
                 pkg_res[owner].tag,
                 ResolutionTag::Root | ResolutionTag::Workspace
             );
+            if !is_direct
+                && referenced
+                    .as_ref()
+                    .is_some_and(|referenced| !referenced.is_set(owner))
+            {
+                continue;
+            }
             for row in slice.begin() as usize..slice.end() as usize {
                 if !is_direct {
                     let Some(&slot) = slot_of.get(resolutions[row] as usize) else {
@@ -1367,10 +1395,21 @@ fn edges_on_instances(manager: &mut PackageManager, instances: &[Instance]) -> I
                     _ => continue,
                 };
                 let row_hash = Semver::string::Builder::string_hash(names.slice(buf));
-                let res_slot = slot_of
+                let mut res_slot = slot_of
                     .get(resolutions[row] as usize)
                     .copied()
                     .unwrap_or(u32::MAX);
+                if (resolutions[row] as usize) >= packages_len {
+                    // The differ re-appends root rows unresolved; their pre-diff resolution lives in the snapshot.
+                    res_slot = snapshot_resolution(
+                        direct_deps,
+                        owner as PackageID,
+                        deps[row].name_hash,
+                        deps[row].behavior,
+                    )
+                    .and_then(|resolved| slot_of.get(resolved as usize).copied())
+                    .unwrap_or(u32::MAX);
+                }
                 for (i, inst) in instances.iter().enumerate() {
                     if name_hashes[inst.pkg_id as usize] == row_hash
                         && names.eql(pkg_names[inst.pkg_id as usize], buf, buf)
@@ -1434,6 +1473,23 @@ fn edges_on_instances(manager: &mut PackageManager, instances: &[Instance]) -> I
     InstanceEdges { followers, direct }
 }
 
+/// The pre-differ resolution of a root/workspace row, matched by owner, name hash and behavior like `moved_pairs`.
+fn snapshot_resolution(
+    direct_deps: &DirectDependencies,
+    owner: PackageID,
+    name_hash: PackageNameHash,
+    behavior: Behavior,
+) -> Option<PackageID> {
+    let &(_, start, len) = direct_deps
+        .owners
+        .iter()
+        .find(|&&(pkg, _, _)| pkg == owner)?;
+    direct_deps.rows[start as usize..(start + len) as usize]
+        .iter()
+        .find(|&&(row_hash, row_behavior, _)| row_hash == name_hash && row_behavior == behavior)
+        .map(|&(_, _, resolved)| resolved)
+}
+
 /// Mirrors `should_update`'s named branch: the row names a requested package and sits in the update scope.
 fn named_row_in_scope(manager: &PackageManager, dep_id: DependencyID) -> bool {
     let lockfile: &Lockfile = &manager.lockfile;
@@ -1494,8 +1550,10 @@ fn direct_row_stays(
             _ => return false,
         }
     };
+    // `keep_locked_if_ahead`: update never moves a direct row below what bun.lock already has,
+    // so a lookup at or below `current` lands the row back on `current`.
     found.is_some_and(|found| {
-        found.version.order(current, &manifest.string_buf, buf) == Ordering::Equal
+        found.version.order(current, &manifest.string_buf, buf) != Ordering::Greater
     })
 }
 

--- a/src/install/update_transitive.rs
+++ b/src/install/update_transitive.rs
@@ -1346,8 +1346,7 @@ fn edges_on_instances(
         let deps = lockfile.buffers.dependencies.as_slice();
         let resolutions = lockfile.buffers.resolutions.as_slice();
 
-        // After the named rows resolved, a superseded package's rows are still in the buffers;
-        // only owners something still resolves to contribute followers.
+        // Post-resolution, a superseded package's rows are still in the buffers: only owners something still resolves to contribute followers.
         let referenced = post_resolution.then(|| {
             let mut referenced = DynamicBitSet::init_empty(packages_len).unwrap_or_oom();
             for owner in 0..packages_len {
@@ -1550,8 +1549,7 @@ fn direct_row_stays(
             _ => return false,
         }
     };
-    // `keep_locked_if_ahead`: update never moves a direct row below what bun.lock already has,
-    // so a lookup at or below `current` lands the row back on `current`.
+    // `keep_locked_if_ahead`: a lookup at or below `current` lands the row back on `current`.
     found.is_some_and(|found| {
         found.version.order(current, &manifest.string_buf, buf) != Ordering::Greater
     })

--- a/src/install/update_transitive.rs
+++ b/src/install/update_transitive.rs
@@ -1424,9 +1424,11 @@ fn edges_on_instances(manager: &mut PackageManager, instances: &[Instance]) -> I
             }
             continue;
         }
-        // Mirrors `latest_for_target`; named rows reach plan_edges via the --latest-only path.
-        let latest =
-            to_latest && (!bare || in_targets) && !overridden_row(&manager.lockfile, row.dep_id);
+        // Mirrors `latest_for_target` (catalog and overridden rows resolve by their range, never by `latest`); named rows reach plan_edges via the --latest-only path.
+        let latest = to_latest
+            && (!bare || in_targets)
+            && !row.catalog
+            && !overridden_row(&manager.lockfile, row.dep_id);
         direct[row.inst as usize].push((row.dep_id, latest));
     }
     InstanceEdges { followers, direct }

--- a/src/install/update_transitive.rs
+++ b/src/install/update_transitive.rs
@@ -1215,8 +1215,7 @@ fn plan_edges(
                 (edge, owner)
             })
             .collect();
-        // Where the differ lands each direct row: rows back on `current` are stayers the redirect
-        // can still carry; moved rows' landings are earlier redirect targets of their own.
+        // Rows landing back on `current` are stayers the redirect can still carry; moved rows' landings are redirect targets of their own.
         let mut direct_stayers: Vec<DependencyID> = Vec::new();
         let mut direct_landings: Vec<(Semver::Version, bool)> = Vec::new();
         for &(dep_id, latest, keep) in &edges_on.direct[inst_i] {

--- a/src/install/update_transitive.rs
+++ b/src/install/update_transitive.rs
@@ -293,7 +293,7 @@ impl TransitiveUpdate {
             }
             edges
         };
-        let (pins, report) = plan_edges(manager, &edges, direct, false)?;
+        let (pins, report) = plan_edges(manager, &edges, direct)?;
         register_moved(manager, &report.moved)?;
         let printed_here = manager.options.dry_run || manager.options.lockfile_only;
         Ok(TransitiveUpdate {
@@ -424,7 +424,7 @@ pub(crate) fn refresh_children_of(
         }
         edges
     };
-    let (pins, report) = plan_edges(manager, &edges, &DirectDependencies::default(), true)?;
+    let (pins, report) = plan_edges(manager, &edges, &DirectDependencies::default())?;
     register_moved(manager, &report.moved)?;
     let update = TransitiveUpdate { pins, report: None };
     update.enqueue(manager)?;
@@ -1027,12 +1027,11 @@ pub(crate) fn plannable_peer_rows(
     rows
 }
 
-/// `edges` selects the rows to plan; each moves to the newest release its (post-override/catalog) range allows, or follows its dist-tag. `post_resolution` marks the `refresh_children_of` call, which runs after the named rows resolved.
+/// `edges` selects the rows to plan; each moves to the newest release its (post-override/catalog) range allows, or follows its dist-tag.
 fn plan_edges(
     manager: &mut PackageManager,
     edges: &DynamicBitSet,
     direct: &DirectDependencies,
-    post_resolution: bool,
 ) -> crate::Result<(Vec<Pin>, Report)> {
     let mut instances: Vec<Instance> = Vec::new();
     let mut kept: Vec<PackageID> = Vec::new();
@@ -1134,7 +1133,7 @@ fn plan_edges(
     if instances.is_empty() {
         return Ok((Vec::new(), Report::default()));
     }
-    let edges_on = edges_on_instances(manager, &instances, direct, post_resolution);
+    let edges_on = edges_on_instances(manager, &instances, direct);
 
     let ids: Vec<PackageID> = instances.iter().map(|inst| inst.pkg_id).collect();
     let msgs_before = manager.log_mut().msgs.len();
@@ -1216,17 +1215,20 @@ fn plan_edges(
                 (edge, owner)
             })
             .collect();
-        let direct_stays = edges_on.direct[inst_i].iter().any(|&(dep_id, latest)| {
-            direct_row_stays(
-                &manager.lockfile,
-                manifest,
-                dep_id,
-                latest,
-                inst.current,
-                min_age,
-                excludes,
-            )
-        });
+        let direct_stays = edges_on.direct[inst_i]
+            .iter()
+            .any(|&(dep_id, latest, keep_locked)| {
+                direct_row_stays(
+                    &manager.lockfile,
+                    manifest,
+                    dep_id,
+                    latest,
+                    keep_locked,
+                    inst.current,
+                    min_age,
+                    excludes,
+                )
+            });
         // Holds cascade (a held want stays behind and can block another), so iterate to a fixed point.
         let mut held_wants = vec![false; inst.wants.len()];
         loop {
@@ -1309,17 +1311,16 @@ fn plan_edges(
     Ok((pins, report))
 }
 
-/// Live rows per planned instance: `followers` move only via the post-resolve redirect; `direct` rows are the root/workspace rows the differ re-resolves (`true` lands on the `latest` dist-tag), per `should_update`.
+/// Live rows per planned instance: `followers` move only via the post-resolve redirect; `direct` rows are the root/workspace rows the differ re-resolves, as `(dep_id, lands on the latest dist-tag, keep_locked_if_ahead applies here)` per `should_update`.
 struct InstanceEdges {
     followers: Vec<Vec<DependencyID>>,
-    direct: Vec<Vec<(DependencyID, bool)>>,
+    direct: Vec<Vec<(DependencyID, bool, bool)>>,
 }
 
 fn edges_on_instances(
     manager: &mut PackageManager,
     instances: &[Instance],
     direct_deps: &DirectDependencies,
-    post_resolution: bool,
 ) -> InstanceEdges {
     struct DirectRow {
         dep_id: DependencyID,
@@ -1329,7 +1330,7 @@ fn edges_on_instances(
         catalog: bool,
     }
     let mut followers: Vec<Vec<DependencyID>> = vec![Vec::new(); instances.len()];
-    let mut direct: Vec<Vec<(DependencyID, bool)>> = vec![Vec::new(); instances.len()];
+    let mut direct: Vec<Vec<(DependencyID, bool, bool)>> = vec![Vec::new(); instances.len()];
     let mut direct_rows: Vec<DirectRow> = Vec::new();
     {
         let lockfile: &Lockfile = &manager.lockfile;
@@ -1346,19 +1347,42 @@ fn edges_on_instances(
         let deps = lockfile.buffers.dependencies.as_slice();
         let resolutions = lockfile.buffers.resolutions.as_slice();
 
-        // Post-resolution, a superseded package's rows are still in the buffers: only owners something still resolves to contribute followers.
-        let referenced = post_resolution.then(|| {
-            let mut referenced = DynamicBitSet::init_empty(packages_len).unwrap_or_oom();
-            for owner in 0..packages_len {
-                let slice = dep_slices[owner];
-                for row in slice.begin() as usize..slice.end() as usize {
-                    if (resolutions[row] as usize) < packages_len {
-                        referenced.set(resolutions[row] as usize);
-                    }
+        // Rows of removed or superseded subtrees are still in the buffers: only owners reachable
+        // from a root/workspace contribute followers (re-appended root rows reach via the snapshot).
+        let mut reachable = DynamicBitSet::init_empty(packages_len).unwrap_or_oom();
+        let mut queue: Vec<usize> = Vec::new();
+        for owner in 0..packages_len {
+            if matches!(
+                pkg_res[owner].tag,
+                ResolutionTag::Root | ResolutionTag::Workspace
+            ) {
+                reachable.set(owner);
+                queue.push(owner);
+            }
+        }
+        while let Some(owner) = queue.pop() {
+            let slice = dep_slices[owner];
+            let snapshot = matches!(
+                pkg_res[owner].tag,
+                ResolutionTag::Root | ResolutionTag::Workspace
+            );
+            for row in slice.begin() as usize..slice.end() as usize {
+                let mut target = resolutions[row] as usize;
+                if target >= packages_len && snapshot {
+                    target = snapshot_resolution(
+                        direct_deps,
+                        owner as PackageID,
+                        deps[row].name_hash,
+                        deps[row].behavior,
+                    )
+                    .map_or(usize::MAX, |resolved| resolved as usize);
+                }
+                if target < packages_len && !reachable.is_set(target) {
+                    reachable.set(target);
+                    queue.push(target);
                 }
             }
-            referenced
-        });
+        }
 
         for owner in 0..packages_len {
             let slice = dep_slices[owner];
@@ -1366,11 +1390,7 @@ fn edges_on_instances(
                 pkg_res[owner].tag,
                 ResolutionTag::Root | ResolutionTag::Workspace
             );
-            if !is_direct
-                && referenced
-                    .as_ref()
-                    .is_some_and(|referenced| !referenced.is_set(owner))
-            {
+            if !is_direct && !reachable.is_set(owner) {
                 continue;
             }
             for row in slice.begin() as usize..slice.end() as usize {
@@ -1463,11 +1483,11 @@ fn edges_on_instances(
             continue;
         }
         // Mirrors `latest_for_target` (catalog and overridden rows resolve by their range, never by `latest`); named rows reach plan_edges via the --latest-only path.
-        let latest = to_latest
-            && (!bare || in_targets)
-            && !row.catalog
-            && !overridden_row(&manager.lockfile, row.dep_id);
-        direct[row.inst as usize].push((row.dep_id, latest));
+        let overridden = overridden_row(&manager.lockfile, row.dep_id);
+        let latest = to_latest && (!bare || in_targets) && !row.catalog && !overridden;
+        // `keep_locked_if_ahead` only applies under --latest, and only against the row's own locked instance.
+        let keep_locked = to_latest && row.inst == row.res_slot && !row.catalog && !overridden;
+        direct[row.inst as usize].push((row.dep_id, latest, keep_locked));
     }
     InstanceEdges { followers, direct }
 }
@@ -1520,11 +1540,13 @@ fn overridden_row(lockfile: &Lockfile, dep_id: DependencyID) -> bool {
 }
 
 /// The differ lands this row back on `current` when that is the release it re-resolves to: the `latest` dist-tag for `--latest` target rows, otherwise the best release the row's range allows.
+#[allow(clippy::too_many_arguments)]
 fn direct_row_stays(
     lockfile: &Lockfile,
     manifest: &PackageManifest,
     dep_id: DependencyID,
     latest: bool,
+    keep_locked: bool,
     current: Semver::Version,
     min_age: Option<f64>,
     excludes: Option<&[&[u8]]>,
@@ -1549,9 +1571,14 @@ fn direct_row_stays(
             _ => return false,
         }
     };
-    // `keep_locked_if_ahead`: a lookup at or below `current` lands the row back on `current`.
+    // Under `keep_locked_if_ahead`, a lookup at or below the locked `current` lands the row back on it.
     found.is_some_and(|found| {
-        found.version.order(current, &manifest.string_buf, buf) != Ordering::Greater
+        let order = found.version.order(current, &manifest.string_buf, buf);
+        if keep_locked {
+            order != Ordering::Greater
+        } else {
+            order == Ordering::Equal
+        }
     })
 }
 

--- a/src/install/update_transitive.rs
+++ b/src/install/update_transitive.rs
@@ -1215,10 +1215,10 @@ fn plan_edges(
                 (edge, owner)
             })
             .collect();
-        // Rows landing back on `current` are stayers the redirect can still carry; moved rows' landings are redirect targets of their own.
+        // Rows landing back on `current` are stayers the redirect can still carry; a moved row's landing is a redirect target only for the instance it resolved to.
         let mut direct_stayers: Vec<DependencyID> = Vec::new();
         let mut direct_landings: Vec<(Semver::Version, bool)> = Vec::new();
-        for &(dep_id, latest, keep) in &edges_on.direct[inst_i] {
+        for &(dep_id, latest, keep, res_slot) in &edges_on.direct[inst_i] {
             let Some((landing, in_manifest)) = direct_row_landing(
                 &manager.lockfile,
                 manifest,
@@ -1233,7 +1233,7 @@ fn plan_edges(
             let landing_buf = if in_manifest { manifest_buf } else { buf };
             if landing.order(inst.current, landing_buf, buf) == Ordering::Equal {
                 direct_stayers.push(dep_id);
-            } else {
+            } else if res_slot == inst_i as u32 {
                 direct_landings.push((landing, in_manifest));
             }
         }
@@ -1328,7 +1328,7 @@ fn plan_edges(
 /// Live rows per planned instance: `followers` move only via the post-resolve redirect; `direct` rows are the root/workspace rows the differ re-resolves, as `(dep_id, lands on the latest dist-tag, keep_locked_if_ahead model)` per `should_update`.
 struct InstanceEdges {
     followers: Vec<Vec<DependencyID>>,
-    direct: Vec<Vec<(DependencyID, bool, KeepLocked)>>,
+    direct: Vec<Vec<(DependencyID, bool, KeepLocked, u32)>>,
 }
 
 fn edges_on_instances(
@@ -1348,7 +1348,8 @@ fn edges_on_instances(
         npm: bool,
     }
     let mut followers: Vec<Vec<DependencyID>> = vec![Vec::new(); instances.len()];
-    let mut direct: Vec<Vec<(DependencyID, bool, KeepLocked)>> = vec![Vec::new(); instances.len()];
+    let mut direct: Vec<Vec<(DependencyID, bool, KeepLocked, u32)>> =
+        vec![Vec::new(); instances.len()];
     let mut direct_rows: Vec<DirectRow> = Vec::new();
     {
         let lockfile: &Lockfile = &manager.lockfile;
@@ -1515,7 +1516,7 @@ fn edges_on_instances(
         } else {
             KeepLocked::No
         };
-        direct[row.inst as usize].push((row.dep_id, latest, keep));
+        direct[row.inst as usize].push((row.dep_id, latest, keep, row.res_slot));
     }
     InstanceEdges { followers, direct }
 }

--- a/src/install/update_transitive.rs
+++ b/src/install/update_transitive.rs
@@ -1322,6 +1322,7 @@ fn edges_on_instances(lockfile: &Lockfile, instances: &[Instance]) -> InstanceEd
     let buf = lockfile.buffers.string_bytes.as_slice();
     let pkg_res = lockfile.packages.items_resolution();
     let pkg_names = lockfile.packages.items_name();
+    let name_hashes = lockfile.packages.items_name_hash();
     let dep_slices = lockfile.packages.items_dependencies();
     let deps = lockfile.buffers.dependencies.as_slice();
     let resolutions = lockfile.buffers.resolutions.as_slice();
@@ -1354,8 +1355,11 @@ fn edges_on_instances(lockfile: &Lockfile, instances: &[Instance]) -> InstanceEd
                 DependencyVersionTag::DistTag => version.dist_tag().name,
                 _ => continue,
             };
+            let row_hash = Semver::string::Builder::string_hash(names.slice(buf));
             for (i, inst) in instances.iter().enumerate() {
-                if names.eql(pkg_names[inst.pkg_id as usize], buf, buf) {
+                if name_hashes[inst.pkg_id as usize] == row_hash
+                    && names.eql(pkg_names[inst.pkg_id as usize], buf, buf)
+                {
                     direct[i].push(row as DependencyID);
                 }
             }

--- a/src/install/update_transitive.rs
+++ b/src/install/update_transitive.rs
@@ -1383,14 +1383,14 @@ fn edges_on_instances(
         }
 
         for owner in 0..packages_len {
+            if !reachable.is_set(owner) {
+                continue;
+            }
             let slice = dep_slices[owner];
             let is_direct = matches!(
                 pkg_res[owner].tag,
                 ResolutionTag::Root | ResolutionTag::Workspace
             );
-            if !reachable.is_set(owner) {
-                continue;
-            }
             for row in slice.begin() as usize..slice.end() as usize {
                 if !is_direct {
                     let Some(&slot) = slot_of.get(resolutions[row] as usize) else {

--- a/src/install/update_transitive.rs
+++ b/src/install/update_transitive.rs
@@ -9,7 +9,7 @@ use bun_semver as Semver;
 
 use crate::audit_fix;
 use crate::dedupe;
-use crate::dependency::{self, Behavior};
+use crate::dependency::{self, Behavior, TagExt as _};
 use crate::lockfile::package::PackageColumns as _;
 use crate::lockfile::{Lockfile, PackageIndexEntry};
 use crate::npm::PackageManifest;
@@ -1429,7 +1429,8 @@ fn edges_on_instances(
                     .and_then(|id| slot_of.get(id as usize).copied())
                     .unwrap_or(u32::MAX);
                 let locked = locked_id.and_then(|id| {
-                    let res = &pkg_res[id as usize];
+                    // An optional row the loaded lockfile left unresolved snapshots as invalid.
+                    let res = pkg_res.get(id as usize)?;
                     (res.tag == ResolutionTag::Npm).then(|| res.npm().version)
                 });
                 for (i, inst) in instances.iter().enumerate() {
@@ -1490,12 +1491,12 @@ fn edges_on_instances(
         // Mirrors `latest_for_target` (catalog and overridden rows resolve by their range, never by `latest`); named rows reach plan_edges via the --latest-only path.
         let overridden = overridden_row(&manager.lockfile, row.dep_id);
         let latest = to_latest && (!bare || in_targets) && !row.catalog && !overridden;
-        // `keep_locked_if_ahead` finds a locked version only where its path can: the range's loaded lockfile instance for -r/--filter npm rows, the invoking workspace's own dist-tag row otherwise.
+        // `keep_locked_if_ahead` finds a locked version only where its path can: the range's loaded lockfile instance for -r/--filter npm rows, the invoking workspace's rewritten rows otherwise (rows that were dist-tag literals follow their tag).
         let keep = if !to_latest || row.catalog || overridden {
             KeepLocked::No
         } else if has_targets && in_targets && row.npm {
             KeepLocked::Range
-        } else if !has_targets && !row.npm {
+        } else if !has_targets && !row.npm && !original_literal_is_dist_tag(manager, row.dep_id) {
             row.locked.map_or(KeepLocked::No, KeepLocked::Version)
         } else {
             KeepLocked::No
@@ -1512,6 +1513,51 @@ enum KeepLocked {
     Range,
     /// The row's own locked version keeps it when ahead of the lookup.
     Version(Semver::Version),
+}
+
+/// Mirrors `locked_version_of_invoking_workspace_row`'s dist-tag-literal exclusion.
+fn original_literal_is_dist_tag(manager: &PackageManager, dep_id: DependencyID) -> bool {
+    let lockfile: &Lockfile = &manager.lockfile;
+    let dep = &lockfile.buffers.dependencies[dep_id as usize];
+    manager
+        .updating_packages
+        .get(lockfile.str(&dep.name))
+        .is_some_and(|entry| {
+            DependencyVersionTag::infer(&entry.original_version_literal)
+                == DependencyVersionTag::DistTag
+        })
+}
+
+/// Mirrors `patched_package_satisfying`: a patched loaded instance the row's range accepts captures the row before any lookup.
+fn patched_capture(lockfile: &Lockfile, dep_id: DependencyID) -> Option<Semver::Version> {
+    if lockfile.patched_dependencies.count() == 0 {
+        return None;
+    }
+    let buf = lockfile.buffers.string_bytes.as_slice();
+    let dep = &lockfile.buffers.dependencies[dep_id as usize];
+    let version = dedupe::effective_version(lockfile, dep_id, dep)?;
+    if version.tag != DependencyVersionTag::Npm {
+        return None;
+    }
+    let hash = Semver::string::Builder::string_hash(version.npm().name.slice(buf));
+    let candidates = lockfile.package_index.get(&hash)?.as_slice();
+    let pkg_res = lockfile.packages.items_resolution();
+    let range = &version.npm().version;
+    candidates
+        .iter()
+        .copied()
+        .filter(|&id| (id as usize) < lockfile.packages.len())
+        .find(|&id| {
+            let res = &pkg_res[id as usize];
+            res.tag == ResolutionTag::Npm
+                && range.satisfies(res.npm().version, buf, buf)
+                && lockfile
+                    .patched_dependencies
+                    .contains(&Semver::string::Builder::string_hash(&dedupe::label(
+                        lockfile, id,
+                    )))
+        })
+        .map(|id| pkg_res[id as usize].npm().version)
 }
 
 /// Mirrors `locked_version_in_lockfile`: the highest loaded npm instance the row's range accepts.
@@ -1596,6 +1642,10 @@ fn direct_row_stays(
     excludes: Option<&[&[u8]]>,
 ) -> bool {
     let buf = lockfile.buffers.string_bytes.as_slice();
+    // `patched_package_satisfying` captures the row before any lookup.
+    if let Some(patched) = patched_capture(lockfile, dep_id) {
+        return patched.order(current, buf, buf) == Ordering::Equal;
+    }
     let found = if latest {
         manifest
             .find_by_dist_tag_with_filter(b"latest", min_age, excludes)

--- a/src/install/update_transitive.rs
+++ b/src/install/update_transitive.rs
@@ -1327,6 +1327,8 @@ fn edges_on_instances(
         inst: u32,
         /// Slot of the instance the row currently resolves to, `u32::MAX` when unresolved or unplanned.
         res_slot: u32,
+        /// The version of the npm instance the row resolved to (live or snapshot).
+        locked: Option<Semver::Version>,
         catalog: bool,
         /// The effective version is an npm range (as opposed to a dist-tag).
         npm: bool,
@@ -1412,21 +1414,24 @@ fn edges_on_instances(
                     _ => continue,
                 };
                 let row_hash = Semver::string::Builder::string_hash(names.slice(buf));
-                let mut res_slot = slot_of
-                    .get(resolutions[row] as usize)
-                    .copied()
-                    .unwrap_or(u32::MAX);
-                if (resolutions[row] as usize) >= packages_len {
-                    // The differ re-appends root rows unresolved; their pre-diff resolution lives in the snapshot.
-                    res_slot = snapshot_resolution(
+                // The differ re-appends root rows unresolved; their pre-diff resolution lives in the snapshot.
+                let locked_id = if (resolutions[row] as usize) < packages_len {
+                    Some(resolutions[row])
+                } else {
+                    snapshot_resolution(
                         direct_deps,
                         owner as PackageID,
                         deps[row].name_hash,
                         deps[row].behavior,
                     )
-                    .and_then(|resolved| slot_of.get(resolved as usize).copied())
+                };
+                let res_slot = locked_id
+                    .and_then(|id| slot_of.get(id as usize).copied())
                     .unwrap_or(u32::MAX);
-                }
+                let locked = locked_id.and_then(|id| {
+                    let res = &pkg_res[id as usize];
+                    (res.tag == ResolutionTag::Npm).then(|| res.npm().version)
+                });
                 for (i, inst) in instances.iter().enumerate() {
                     if name_hashes[inst.pkg_id as usize] == row_hash
                         && names.eql(pkg_names[inst.pkg_id as usize], buf, buf)
@@ -1435,6 +1440,7 @@ fn edges_on_instances(
                             dep_id: row as DependencyID,
                             inst: i as u32,
                             res_slot,
+                            locked,
                             catalog: deps[row].version.tag == DependencyVersionTag::Catalog,
                             npm: version.tag == DependencyVersionTag::Npm,
                         });
@@ -1489,8 +1495,8 @@ fn edges_on_instances(
             KeepLocked::No
         } else if has_targets && in_targets && row.npm {
             KeepLocked::Range
-        } else if !has_targets && !row.npm && row.inst == row.res_slot {
-            KeepLocked::Current
+        } else if !has_targets && !row.npm {
+            row.locked.map_or(KeepLocked::No, KeepLocked::Version)
         } else {
             KeepLocked::No
         };
@@ -1499,13 +1505,13 @@ fn edges_on_instances(
     InstanceEdges { followers, direct }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy)]
 enum KeepLocked {
     No,
     /// The highest loaded instance the row's range accepts keeps the row when it is ahead.
     Range,
-    /// The instance under evaluation is the row's own locked one; it keeps the row when ahead.
-    Current,
+    /// The row's own locked version keeps it when ahead of the lookup.
+    Version(Semver::Version),
 }
 
 /// Mirrors `locked_version_in_lockfile`: the highest loaded npm instance the row's range accepts.
@@ -1613,7 +1619,7 @@ fn direct_row_stays(
     found.is_some_and(|found| {
         let locked = match keep {
             KeepLocked::No => None,
-            KeepLocked::Current => Some(current),
+            KeepLocked::Version(locked) => Some(locked),
             KeepLocked::Range => locked_in_lockfile(lockfile, dep_id),
         };
         if let Some(locked) = locked {

--- a/src/install/update_transitive.rs
+++ b/src/install/update_transitive.rs
@@ -1394,9 +1394,7 @@ fn edges_on_instances(manager: &mut PackageManager, instances: &[Instance]) -> I
                 .as_deref()
                 .is_some_and(|targets| lockfile.is_dependency_of_workspace_in(targets, row.dep_id))
         };
-        // Mirrors `should_update`: bare update re-resolves the target workspaces' rows (the cwd
-        // workspace's without -r/--filter) and every catalog row; a named update re-resolves the
-        // in-scope rows naming a requested package.
+        // Mirrors `should_update`: bare updates re-resolve the target (or cwd) workspaces' rows and catalog rows; named updates re-resolve the in-scope requested rows.
         let reresolves = if bare {
             row.catalog
                 || if has_targets {

--- a/src/install/update_transitive.rs
+++ b/src/install/update_transitive.rs
@@ -1285,10 +1285,8 @@ fn edges_on_instances(lockfile: &Lockfile, instances: &[Instance]) -> Vec<Vec<De
     edges_on
 }
 
-/// A move to `v` is dropped when another edge on the instance stays behind at `current` (its range
-/// rejects `v`, or it is bundled or has no npm range, so the post-resolve redirect cannot carry it)
-/// while `current` already satisfies the moving range: the fork would add exactly the duplicate
-/// `bun dedupe` removes, and the two commands would undo each other forever.
+/// True when some edge on the instance cannot follow the move to `v` and stays at `current`,
+/// which still satisfies the moving range: the fork would re-add the duplicate `bun dedupe` removes.
 fn forks_surviving_instance(
     lockfile: &Lockfile,
     inst: &Instance,

--- a/src/install/update_transitive.rs
+++ b/src/install/update_transitive.rs
@@ -1347,8 +1347,7 @@ fn edges_on_instances(
         let deps = lockfile.buffers.dependencies.as_slice();
         let resolutions = lockfile.buffers.resolutions.as_slice();
 
-        // Rows of removed or superseded subtrees are still in the buffers: only owners reachable
-        // from a root/workspace contribute followers (re-appended root rows reach via the snapshot).
+        // Removed or superseded subtrees are still in the buffers: only owners reachable from a root/workspace contribute followers.
         let mut reachable = DynamicBitSet::init_empty(packages_len).unwrap_or_oom();
         let mut queue: Vec<usize> = Vec::new();
         for owner in 0..packages_len {

--- a/src/install/update_transitive.rs
+++ b/src/install/update_transitive.rs
@@ -1307,10 +1307,7 @@ fn plan_edges(
     Ok((pins, report))
 }
 
-/// Live rows grouped per planned instance. `followers` resolve to the instance and only the
-/// post-resolve redirect can move them; `direct` rows (root/workspace-owned) name its package and
-/// are re-resolved by the differ instead, so they are matched by name (after the differ re-appends
-/// root rows their resolutions are not yet valid). Orphaned rows outside every live slice are skipped.
+/// Live rows per planned instance: `followers` resolve to it and move only via the post-resolve redirect; `direct` root/workspace rows are re-resolved by the differ, so they are matched by name.
 struct InstanceEdges {
     followers: Vec<Vec<DependencyID>>,
     direct: Vec<Vec<DependencyID>>,
@@ -1367,8 +1364,7 @@ fn edges_on_instances(lockfile: &Lockfile, instances: &[Instance]) -> InstanceEd
     InstanceEdges { followers, direct }
 }
 
-/// Whether the differ will land this root/workspace row back on `current`: the best release its
-/// range allows (or its dist-tag target) is `current` itself.
+/// The differ lands this root/workspace row back on `current` when that is the best release (or dist-tag target) its range allows.
 fn direct_row_stays(
     lockfile: &Lockfile,
     manifest: &PackageManifest,

--- a/src/install/update_transitive.rs
+++ b/src/install/update_transitive.rs
@@ -1285,8 +1285,7 @@ fn edges_on_instances(lockfile: &Lockfile, instances: &[Instance]) -> Vec<Vec<De
     edges_on
 }
 
-/// True when some edge on the instance cannot follow the move to `v` and stays at `current`,
-/// which still satisfies the moving range: the fork would re-add the duplicate `bun dedupe` removes.
+/// An edge left behind at a still-satisfying `current` would re-create the duplicate `bun dedupe` removes.
 fn forks_surviving_instance(
     lockfile: &Lockfile,
     inst: &Instance,

--- a/src/install/update_transitive.rs
+++ b/src/install/update_transitive.rs
@@ -1215,9 +1215,10 @@ fn plan_edges(
                 (edge, owner)
             })
             .collect();
-        let direct_stays = edges_on.direct[inst_i]
+        // Rows the differ lands back on `current`; like followers, the redirect can still carry them.
+        let direct_stayers: Vec<DependencyID> = edges_on.direct[inst_i]
             .iter()
-            .any(|&(dep_id, latest, keep)| {
+            .filter(|&&(dep_id, latest, keep)| {
                 direct_row_stays(
                     &manager.lockfile,
                     manifest,
@@ -1228,7 +1229,9 @@ fn plan_edges(
                     min_age,
                     excludes,
                 )
-            });
+            })
+            .map(|&(dep_id, ..)| dep_id)
+            .collect();
         // Holds cascade (a held want stays behind and can block another), so iterate to a fixed point.
         let mut held_wants = vec![false; inst.wants.len()];
         loop {
@@ -1240,6 +1243,13 @@ fn plan_edges(
                 if held_wants[w] || plan.to.is_none() {
                     continue;
                 }
+                // The redirect carries every remaining edge toward the FIRST pinned want's target.
+                let redirect_v = (0..inst.wants.len())
+                    .find(|&i| {
+                        !held_wants[i] && planned[i].as_ref().is_some_and(|plan| plan.to.is_some())
+                    })
+                    .and_then(|i| planned[i].as_ref().map(|plan| plan.v))
+                    .unwrap_or(plan.v);
                 if forks_surviving_instance(
                     &manager.lockfile,
                     inst,
@@ -1247,8 +1257,8 @@ fn plan_edges(
                     &planned,
                     &held_wants,
                     &edge_wants,
-                    direct_stays,
-                    plan.v,
+                    &direct_stayers,
+                    redirect_v,
                     manifest_buf,
                 ) {
                     held_wants[w] = true;
@@ -1670,7 +1680,7 @@ fn direct_row_stays(
             _ => return false,
         }
     };
-    // `keep_locked_if_ahead`: a lookup below the row's locked version lands it back on that version.
+    // `keep_locked_if_ahead`: a lookup below the row's locked version lands it back on that version, when the manifest still has it.
     found.is_some_and(|found| {
         let locked = match keep {
             KeepLocked::No => None,
@@ -1678,7 +1688,9 @@ fn direct_row_stays(
             KeepLocked::Range => locked_in_lockfile(lockfile, dep_id),
         };
         if let Some(locked) = locked {
-            if found.version.order(locked, &manifest.string_buf, buf) == Ordering::Less {
+            if found.version.order(locked, &manifest.string_buf, buf) == Ordering::Less
+                && manifest.find_by_version(locked).is_some()
+            {
                 return locked.order(current, buf, buf) == Ordering::Equal;
             }
         }
@@ -1695,8 +1707,8 @@ fn forks_surviving_instance(
     planned: &[Option<Planned>],
     held_wants: &[bool],
     edge_wants: &[(DependencyID, Option<usize>)],
-    direct_stays: bool,
-    v: Semver::Version,
+    direct_stayers: &[DependencyID],
+    redirect_v: Semver::Version,
     manifest_buf: &[u8],
 ) -> bool {
     let buf = lockfile.buffers.string_bytes.as_slice();
@@ -1706,23 +1718,26 @@ fn forks_surviving_instance(
     {
         return false;
     }
-    if direct_stays {
-        return true;
-    }
     let deps = lockfile.buffers.dependencies.as_slice();
     let stays = |version: &dependency::Version| {
         version.tag != DependencyVersionTag::Npm
-            || !version.npm().version.satisfies(v, buf, manifest_buf)
+            || !version
+                .npm()
+                .version
+                .satisfies(redirect_v, buf, manifest_buf)
     };
+    let uncarried = |edge: DependencyID| {
+        let dep = &deps[edge as usize];
+        dep.behavior.is_bundled()
+            || dedupe::effective_npm_range(lockfile, edge, dep).is_none_or(|range| stays(&range))
+    };
+    if direct_stayers.iter().any(|&edge| uncarried(edge)) {
+        return true;
+    }
     edge_wants.iter().any(|&(edge, owner)| match owner {
         Some(w) if w == want_index => false,
         Some(w) => (planned[w].is_none() || held_wants[w]) && stays(&inst.wants[w].version),
-        None => {
-            let dep = &deps[edge as usize];
-            dep.behavior.is_bundled()
-                || dedupe::effective_npm_range(lockfile, edge, dep)
-                    .is_none_or(|range| stays(&range))
-        }
+        None => uncarried(edge),
     })
 }
 

--- a/src/install/update_transitive.rs
+++ b/src/install/update_transitive.rs
@@ -1426,7 +1426,8 @@ fn forks_surviving_instance(
         None => {
             let dep = &deps[edge as usize];
             dep.behavior.is_bundled()
-                || dedupe::effective_npm_range(lockfile, edge, dep).is_none_or(|range| stays(&range))
+                || dedupe::effective_npm_range(lockfile, edge, dep)
+                    .is_none_or(|range| stays(&range))
         }
     })
 }

--- a/src/install/update_transitive.rs
+++ b/src/install/update_transitive.rs
@@ -1642,9 +1642,14 @@ fn direct_row_stays(
     excludes: Option<&[&[u8]]>,
 ) -> bool {
     let buf = lockfile.buffers.string_bytes.as_slice();
-    // `patched_package_satisfying` captures the row before any lookup.
-    if let Some(patched) = patched_capture(lockfile, dep_id) {
-        return patched.order(current, buf, buf) == Ordering::Equal;
+    // `patched_package_satisfying` captures the row before any lookup; peer rows fall through.
+    if !lockfile.buffers.dependencies[dep_id as usize]
+        .behavior
+        .is_peer()
+    {
+        if let Some(patched) = patched_capture(lockfile, dep_id) {
+            return patched.order(current, buf, buf) == Ordering::Equal;
+        }
     }
     let found = if latest {
         manifest

--- a/src/install/update_transitive.rs
+++ b/src/install/update_transitive.rs
@@ -1217,13 +1217,13 @@ fn plan_edges(
             .collect();
         let direct_stays = edges_on.direct[inst_i]
             .iter()
-            .any(|&(dep_id, latest, keep_locked)| {
+            .any(|&(dep_id, latest, keep)| {
                 direct_row_stays(
                     &manager.lockfile,
                     manifest,
                     dep_id,
                     latest,
-                    keep_locked,
+                    keep,
                     inst.current,
                     min_age,
                     excludes,
@@ -1311,10 +1311,10 @@ fn plan_edges(
     Ok((pins, report))
 }
 
-/// Live rows per planned instance: `followers` move only via the post-resolve redirect; `direct` rows are the root/workspace rows the differ re-resolves, as `(dep_id, lands on the latest dist-tag, keep_locked_if_ahead applies here)` per `should_update`.
+/// Live rows per planned instance: `followers` move only via the post-resolve redirect; `direct` rows are the root/workspace rows the differ re-resolves, as `(dep_id, lands on the latest dist-tag, keep_locked_if_ahead model)` per `should_update`.
 struct InstanceEdges {
     followers: Vec<Vec<DependencyID>>,
-    direct: Vec<Vec<(DependencyID, bool, bool)>>,
+    direct: Vec<Vec<(DependencyID, bool, KeepLocked)>>,
 }
 
 fn edges_on_instances(
@@ -1328,9 +1328,11 @@ fn edges_on_instances(
         /// Slot of the instance the row currently resolves to, `u32::MAX` when unresolved or unplanned.
         res_slot: u32,
         catalog: bool,
+        /// The effective version is an npm range (as opposed to a dist-tag).
+        npm: bool,
     }
     let mut followers: Vec<Vec<DependencyID>> = vec![Vec::new(); instances.len()];
-    let mut direct: Vec<Vec<(DependencyID, bool, bool)>> = vec![Vec::new(); instances.len()];
+    let mut direct: Vec<Vec<(DependencyID, bool, KeepLocked)>> = vec![Vec::new(); instances.len()];
     let mut direct_rows: Vec<DirectRow> = Vec::new();
     {
         let lockfile: &Lockfile = &manager.lockfile;
@@ -1347,14 +1349,11 @@ fn edges_on_instances(
         let deps = lockfile.buffers.dependencies.as_slice();
         let resolutions = lockfile.buffers.resolutions.as_slice();
 
-        // Removed or superseded subtrees are still in the buffers: only owners reachable from a root/workspace contribute followers.
+        // Removed or superseded subtrees (a dropped workspace member included) are still in the buffers: only owners reachable from the root contribute rows.
         let mut reachable = DynamicBitSet::init_empty(packages_len).unwrap_or_oom();
         let mut queue: Vec<usize> = Vec::new();
         for owner in 0..packages_len {
-            if matches!(
-                pkg_res[owner].tag,
-                ResolutionTag::Root | ResolutionTag::Workspace
-            ) {
+            if pkg_res[owner].tag == ResolutionTag::Root {
                 reachable.set(owner);
                 queue.push(owner);
             }
@@ -1389,7 +1388,7 @@ fn edges_on_instances(
                 pkg_res[owner].tag,
                 ResolutionTag::Root | ResolutionTag::Workspace
             );
-            if !is_direct && !reachable.is_set(owner) {
+            if !reachable.is_set(owner) {
                 continue;
             }
             for row in slice.begin() as usize..slice.end() as usize {
@@ -1437,6 +1436,7 @@ fn edges_on_instances(
                             inst: i as u32,
                             res_slot,
                             catalog: deps[row].version.tag == DependencyVersionTag::Catalog,
+                            npm: version.tag == DependencyVersionTag::Npm,
                         });
                     }
                 }
@@ -1484,11 +1484,50 @@ fn edges_on_instances(
         // Mirrors `latest_for_target` (catalog and overridden rows resolve by their range, never by `latest`); named rows reach plan_edges via the --latest-only path.
         let overridden = overridden_row(&manager.lockfile, row.dep_id);
         let latest = to_latest && (!bare || in_targets) && !row.catalog && !overridden;
-        // `keep_locked_if_ahead` only applies under --latest, and only against the row's own locked instance.
-        let keep_locked = to_latest && row.inst == row.res_slot && !row.catalog && !overridden;
-        direct[row.inst as usize].push((row.dep_id, latest, keep_locked));
+        // `keep_locked_if_ahead` finds a locked version only where its path can: the range's loaded lockfile instance for -r/--filter npm rows, the invoking workspace's own dist-tag row otherwise.
+        let keep = if !to_latest || row.catalog || overridden {
+            KeepLocked::No
+        } else if has_targets && in_targets && row.npm {
+            KeepLocked::Range
+        } else if !has_targets && !row.npm && row.inst == row.res_slot {
+            KeepLocked::Current
+        } else {
+            KeepLocked::No
+        };
+        direct[row.inst as usize].push((row.dep_id, latest, keep));
     }
     InstanceEdges { followers, direct }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum KeepLocked {
+    No,
+    /// The highest loaded instance the row's range accepts keeps the row when it is ahead.
+    Range,
+    /// The instance under evaluation is the row's own locked one; it keeps the row when ahead.
+    Current,
+}
+
+/// Mirrors `locked_version_in_lockfile`: the highest loaded npm instance the row's range accepts.
+fn locked_in_lockfile(lockfile: &Lockfile, dep_id: DependencyID) -> Option<Semver::Version> {
+    let buf = lockfile.buffers.string_bytes.as_slice();
+    let dep = &lockfile.buffers.dependencies[dep_id as usize];
+    let version = dedupe::effective_version(lockfile, dep_id, dep)?;
+    if version.tag != DependencyVersionTag::Npm {
+        return None;
+    }
+    let hash = Semver::string::Builder::string_hash(version.npm().name.slice(buf));
+    let candidates = lockfile.package_index.get(&hash)?.as_slice();
+    let pkg_res = lockfile.packages.items_resolution();
+    let range = &version.npm().version;
+    candidates
+        .iter()
+        .copied()
+        .filter(|&id| id < lockfile.loaded_package_count)
+        .map(|id| &pkg_res[id as usize])
+        .filter(|res| res.tag == ResolutionTag::Npm)
+        .map(|res| res.npm().version)
+        .find(|&locked| range.satisfies(locked, buf, buf))
 }
 
 /// The pre-differ resolution of a root/workspace row, matched by owner, name hash and behavior like `moved_pairs`.
@@ -1545,7 +1584,7 @@ fn direct_row_stays(
     manifest: &PackageManifest,
     dep_id: DependencyID,
     latest: bool,
-    keep_locked: bool,
+    keep: KeepLocked,
     current: Semver::Version,
     min_age: Option<f64>,
     excludes: Option<&[&[u8]]>,
@@ -1570,14 +1609,19 @@ fn direct_row_stays(
             _ => return false,
         }
     };
-    // Under `keep_locked_if_ahead`, a lookup at or below the locked `current` lands the row back on it.
+    // `keep_locked_if_ahead`: a lookup below the row's locked version lands it back on that version.
     found.is_some_and(|found| {
-        let order = found.version.order(current, &manifest.string_buf, buf);
-        if keep_locked {
-            order != Ordering::Greater
-        } else {
-            order == Ordering::Equal
+        let locked = match keep {
+            KeepLocked::No => None,
+            KeepLocked::Current => Some(current),
+            KeepLocked::Range => locked_in_lockfile(lockfile, dep_id),
+        };
+        if let Some(locked) = locked {
+            if found.version.order(locked, &manifest.string_buf, buf) == Ordering::Less {
+                return locked.order(current, buf, buf) == Ordering::Equal;
+            }
         }
+        found.version.order(current, &manifest.string_buf, buf) == Ordering::Equal
     })
 }
 

--- a/src/install/update_transitive.rs
+++ b/src/install/update_transitive.rs
@@ -1215,9 +1215,9 @@ fn plan_edges(
                 (edge, owner)
             })
             .collect();
-        // Rows landing back on `current` are stayers the redirect can still carry; a moved row's landing is a redirect target only for the instance it resolved to.
+        // Rows landing back on `current` are stayers the redirect can still carry; the first moved row's landing is the instance's only direct redirect target (`redirect` is first-wins over `moved_pairs`, both in owner order).
         let mut direct_stayers: Vec<DependencyID> = Vec::new();
-        let mut direct_landings: Vec<(Semver::Version, bool)> = Vec::new();
+        let mut direct_landing: Option<(Semver::Version, bool)> = None;
         for &(dep_id, latest, keep, res_slot) in &edges_on.direct[inst_i] {
             let Some((landing, in_manifest)) = direct_row_landing(
                 &manager.lockfile,
@@ -1233,8 +1233,8 @@ fn plan_edges(
             let landing_buf = if in_manifest { manifest_buf } else { buf };
             if landing.order(inst.current, landing_buf, buf) == Ordering::Equal {
                 direct_stayers.push(dep_id);
-            } else if res_slot == inst_i as u32 {
-                direct_landings.push((landing, in_manifest));
+            } else if res_slot == inst_i as u32 && direct_landing.is_none() {
+                direct_landing = Some((landing, in_manifest));
             }
         }
         // Holds cascade (a held want stays behind and can block another), so iterate to a fixed point.
@@ -1261,7 +1261,7 @@ fn plan_edges(
                     &held_wants,
                     &edge_wants,
                     &direct_stayers,
-                    &direct_landings,
+                    direct_landing,
                     redirect_v,
                     manifest_buf,
                 ) {
@@ -1708,7 +1708,7 @@ fn forks_surviving_instance(
     held_wants: &[bool],
     edge_wants: &[(DependencyID, Option<usize>)],
     direct_stayers: &[DependencyID],
-    direct_landings: &[(Semver::Version, bool)],
+    direct_landing: Option<(Semver::Version, bool)>,
     redirect_v: Semver::Version,
     manifest_buf: &[u8],
 ) -> bool {
@@ -1726,7 +1726,7 @@ fn forks_surviving_instance(
         }
         let range = &version.npm().version;
         !range.satisfies(redirect_v, buf, manifest_buf)
-            && !direct_landings.iter().any(|&(landing, in_manifest)| {
+            && !direct_landing.is_some_and(|(landing, in_manifest)| {
                 range.satisfies(landing, buf, if in_manifest { manifest_buf } else { buf })
             })
     };

--- a/test/cli/install/bun-update-transitive.test.ts
+++ b/test/cli/install/bun-update-transitive.test.ts
@@ -1,8 +1,10 @@
 import { file, write } from "bun";
-import { afterAll, beforeAll, expect, test } from "bun:test";
+import { afterAll, beforeAll, expect, setDefaultTimeout, test } from "bun:test";
 import { exists } from "fs/promises";
 import { VerdaccioRegistry, bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
+
+setDefaultTimeout(1000 * 60 * 5);
 
 // Registry: no-deps 1.0.0/1.0.1/1.1.0/2.0.0, a-dep 1.0.1..1.0.10, @types/no-deps 1.0.0/2.0.0, one-range-dep@1.0.0 -> no-deps ^1.0.0, one-fixed-dep@1.0.0 -> no-deps 1.0.0, dep-with-tags latest=3.0.0, pre-2=2.0.1, 3.0.1 published above latest.
 

--- a/test/cli/install/bun-update-transitive.test.ts
+++ b/test/cli/install/bun-update-transitive.test.ts
@@ -678,6 +678,39 @@ test.concurrent("a member's parked edge holds its transitive siblings under a ro
   expect(check.exitCode).toBe(0);
 });
 
+// pkg1's `^1.0.0` sits on leaf@1.0.0 only; it must not hold parent-b's `>=2.0.0` edge on the
+// separate leaf@2.0.0 instance, which is free to move to 3.0.0.
+test.concurrent("a member's parked row does not hold wants on another instance of its package", async () => {
+  using server = await serveRegistry({
+    "parent-a": { "1.0.0": { dependencies: { leaf: "^1.0.0" } } },
+    "parent-b": { "1.0.0": { dependencies: { leaf: ">=2.0.0" } } },
+    leaf: { "1.0.0": {}, "2.0.0": {}, "3.0.0": {} },
+  });
+  const dependents = { "parent-a": "1.0.0", "parent-b": "1.0.0" };
+  using tmp = tempDir("update-member-other-instance-", {
+    "package.json": stringify({ name: "root", workspaces: ["packages/*"], dependencies: { ...dependents, leaf: "2.0.0" } }),
+    "packages/pkg1/package.json": stringify({ name: "pkg1", dependencies: { leaf: "^1.0.0" } }),
+  });
+  const dir = String(tmp);
+  await servedBunfig(server, dir);
+  await install(dir);
+  const deduped = await run(dir, "dedupe");
+  expect(deduped.stderr).not.toContain("error:");
+  expect(deduped.exitCode).toBe(0);
+  expect(await lockedVersions(dir, "leaf")).toStrictEqual(["1.0.0", "2.0.0"]);
+  await reinstall(dir, { name: "root", workspaces: ["packages/*"], dependencies: dependents });
+  expect(await lockedVersions(dir, "leaf")).toStrictEqual(["1.0.0", "2.0.0"]);
+
+  const { stderr, exitCode } = await run(dir, "update");
+  expectCleanStderr(stderr);
+  expect(await lockedVersions(dir, "leaf")).toStrictEqual(["1.0.0", "3.0.0"]);
+  expect(exitCode).toBe(0);
+
+  const check = await run(dir, "dedupe", "--check");
+  expect(check.stderr).not.toContain("error:");
+  expect(check.exitCode).toBe(0);
+});
+
 // The root's exact 1.0.0 takes the root slot and pushes one-range-dep's 1.1.0 into a nested folder; widening the root keeps 1.0.0 locked, so the update collapses both rows onto 1.1.0.
 test.concurrent("hoisted: a bare update removes the nested copy whose row it collapsed", async () => {
   const dir = await setup({ "package.json": pkgJson({ "one-range-dep": "1.0.0" }) });

--- a/test/cli/install/bun-update-transitive.test.ts
+++ b/test/cli/install/bun-update-transitive.test.ts
@@ -744,6 +744,82 @@ test.concurrent("`bun update --latest -r` with a catalog pin converges with dedu
   expect(check.exitCode).toBe(0);
 });
 
+// `--latest` never moves a row below bun.lock: with `latest` behind the locked 2.0.0, the exact pin
+// stays, so parent's `>=2.0.0` edge is held instead of re-forking what dedupe removed.
+test.concurrent("`bun update --latest -r`: a pin ahead of `latest` keeps holding its siblings", async () => {
+  using server = await serveRegistry(
+    {
+      parent: { "1.0.0": { dependencies: { leaf: ">=2.0.0" } } },
+      leaf: { "1.9.0": {}, "2.0.0": {}, "2.1.0": {} },
+    },
+    { leaf: { latest: "1.9.0" } },
+  );
+  const dir = await installServed(server, "update-latest-behind-", pkgJson({ parent: "1.0.0", leaf: "2.0.0" }));
+  const deduped = await run(dir, "dedupe");
+  expect(deduped.stderr).not.toContain("error:");
+  expect(deduped.exitCode).toBe(0);
+  expect(await lockedVersions(dir, "leaf")).toStrictEqual(["2.0.0"]);
+
+  const { stderr, exitCode } = await run(dir, "update", "--latest", "-r");
+  expect(stderr).not.toContain("error:");
+  expect(await lockedVersions(dir, "leaf")).toStrictEqual(["2.0.0"]);
+  expect(exitCode).toBe(0);
+
+  const check = await run(dir, "dedupe", "--check");
+  expect(check.stderr).not.toContain("error:");
+  expect(check.exitCode).toBe(0);
+});
+
+// Root rows are re-appended unresolved before the plan runs; the snapshot recovers where they sat,
+// so a root pin still holds a member-scoped update's wants even though root is out of scope.
+test.concurrent("a root pin holds transitive wants when updating from a member", async () => {
+  using server = await serveRegistry({
+    parent: { "1.0.0": { dependencies: { leaf: "*" } } },
+    leaf: { "1.0.0": {}, "2.0.0": {} },
+  });
+  using tmp = tempDir("update-member-cwd-", {
+    "package.json": stringify({ name: "root", workspaces: ["packages/*"], dependencies: { leaf: "1.0.0" } }),
+    "packages/pkg1/package.json": stringify({ name: "pkg1", dependencies: { parent: "1.0.0" } }),
+  });
+  const dir = String(tmp);
+  await servedBunfig(server, dir);
+  await install(dir);
+  const deduped = await run(dir, "dedupe");
+  expect(deduped.stderr).not.toContain("error:");
+  expect(deduped.exitCode).toBe(0);
+  expect(await lockedVersions(dir, "leaf")).toStrictEqual(["1.0.0"]);
+
+  const { stderr, exitCode } = await runIn(dir, "packages/pkg1", "update");
+  expect(stderr).not.toContain("error:");
+  expect(await lockedVersions(dir, "leaf")).toStrictEqual(["1.0.0"]);
+  expect(exitCode).toBe(0);
+
+  const check = await run(dir, "dedupe", "--check");
+  expect(check.stderr).not.toContain("error:");
+  expect(check.exitCode).toBe(0);
+});
+
+// `bun update parent --latest` moves parent 1.0.0 -> 3.0.0; the superseded parent@1.0.0's `~1.0.0`
+// row must not hold the new parent's `^1.0.0` child edge, which moves in-range to 1.5.0.
+test.concurrent("`bun update <name> --latest`: a superseded version's rows do not hold the new children", async () => {
+  using server = await serveRegistry({
+    parent: {
+      "1.0.0": { dependencies: { leaf: "~1.0.0" } },
+      "3.0.0": { dependencies: { leaf: "^1.0.0" } },
+    },
+    leaf: { "1.0.0": {}, "1.5.0": {} },
+  });
+  const dir = await installServed(server, "update-superseded-", pkgJson({ parent: "1.0.0" }));
+  expect(await lockedVersions(dir, "parent")).toStrictEqual(["1.0.0"]);
+  expect(await lockedVersions(dir, "leaf")).toStrictEqual(["1.0.0"]);
+
+  const { stderr, exitCode } = await run(dir, "update", "parent", "--latest");
+  expect(stderr).not.toContain("error:");
+  expect(await lockedVersions(dir, "parent")).toStrictEqual(["3.0.0"]);
+  expect(await lockedVersions(dir, "leaf")).toStrictEqual(["1.5.0"]);
+  expect(exitCode).toBe(0);
+});
+
 // The root's exact 1.0.0 takes the root slot and pushes one-range-dep's 1.1.0 into a nested folder; widening the root keeps 1.0.0 locked, so the update collapses both rows onto 1.1.0.
 test.concurrent("hoisted: a bare update removes the nested copy whose row it collapsed", async () => {
   const dir = await setup({ "package.json": pkgJson({ "one-range-dep": "1.0.0" }) });

--- a/test/cli/install/bun-update-transitive.test.ts
+++ b/test/cli/install/bun-update-transitive.test.ts
@@ -905,6 +905,7 @@ test.concurrent("a direct row on a lower instance does not hold wants on a highe
     leaf: { "1.5.0": {}, "2.0.0": {}, "2.5.0": {} },
   };
   using server = await serveRegistry(manifests);
+  // Tarballs are built eagerly, versions are read per request: hide 2.5.0 from the install only.
   const hidden = manifests.leaf["2.5.0"];
   delete manifests.leaf["2.5.0"];
   const dir = await installServed(server, "update-two-instances-", pkgJson({ parent: "1.0.0", leaf: "^1.0.0" }));

--- a/test/cli/install/bun-update-transitive.test.ts
+++ b/test/cli/install/bun-update-transitive.test.ts
@@ -887,7 +887,10 @@ test.concurrent("a removed workspace member's rows do not hold the remaining wan
   expect(deduped.exitCode).toBe(0);
   expect(await lockedVersions(dir, "leaf")).toStrictEqual(["1.0.0"]);
 
-  await write(join(dir, "package.json"), stringify({ name: "root", workspaces: [], dependencies: { parent: "1.0.0" } }));
+  await write(
+    join(dir, "package.json"),
+    stringify({ name: "root", workspaces: [], dependencies: { parent: "1.0.0" } }),
+  );
   const { stderr, exitCode } = await run(dir, "update");
   expect(stderr).not.toContain("error:");
   expect(await lockedVersions(dir, "leaf")).toStrictEqual(["1.5.0"]);

--- a/test/cli/install/bun-update-transitive.test.ts
+++ b/test/cli/install/bun-update-transitive.test.ts
@@ -715,6 +715,35 @@ test.concurrent("a member's parked row does not hold wants on another instance o
   expect(check.exitCode).toBe(0);
 });
 
+// `--latest -r` bumps the catalog definition itself before resolving, so the catalog row is
+// modeled by its rewritten range (never the `latest` dist-tag) and every edge converges on 2.0.0.
+test.concurrent("`bun update --latest -r` with a catalog pin converges with dedupe", async () => {
+  using server = await serveRegistry({
+    parent: { "1.0.0": { dependencies: { leaf: "*" } } },
+    leaf: { "1.0.0": {}, "2.0.0": {} },
+  });
+  using tmp = tempDir("update-latest-catalog-", {
+    "package.json": stringify({ name: "root", workspaces: ["packages/*"], catalog: { leaf: "1.0.0" } }),
+    "packages/pkg1/package.json": stringify({ name: "pkg1", dependencies: { leaf: "catalog:", parent: "1.0.0" } }),
+  });
+  const dir = String(tmp);
+  await servedBunfig(server, dir);
+  await install(dir);
+  const deduped = await run(dir, "dedupe");
+  expect(deduped.stderr).not.toContain("error:");
+  expect(deduped.exitCode).toBe(0);
+  expect(await lockedVersions(dir, "leaf")).toStrictEqual(["1.0.0"]);
+
+  const { stderr, exitCode } = await run(dir, "update", "--latest", "-r");
+  expect(stderr).not.toContain("error:");
+  expect(await lockedVersions(dir, "leaf")).toStrictEqual(["2.0.0"]);
+  expect(exitCode).toBe(0);
+
+  const check = await run(dir, "dedupe", "--check");
+  expect(check.stderr).not.toContain("error:");
+  expect(check.exitCode).toBe(0);
+});
+
 // The root's exact 1.0.0 takes the root slot and pushes one-range-dep's 1.1.0 into a nested folder; widening the root keeps 1.0.0 locked, so the update collapses both rows onto 1.1.0.
 test.concurrent("hoisted: a bare update removes the nested copy whose row it collapsed", async () => {
   const dir = await setup({ "package.json": pkgJson({ "one-range-dep": "1.0.0" }) });

--- a/test/cli/install/bun-update-transitive.test.ts
+++ b/test/cli/install/bun-update-transitive.test.ts
@@ -625,6 +625,59 @@ test.concurrent("a direct edge that moves away does not hold its transitive sibl
   expect(await lockText(dir)).toBe(before);
 });
 
+// `--latest -r` resolves the targeted rows by the `latest` dist-tag, so the exact pin jumps to 2.0.0
+// and does not keep 1.0.0 alive; parent's `^1.0.0` edge must still move to its in-range best.
+test.concurrent("`bun update --latest -r`: a pin that jumps to latest does not hold its siblings", async () => {
+  using server = await serveRegistry({
+    parent: { "1.0.0": { dependencies: { leaf: "^1.0.0" } } },
+    leaf: { "1.0.0": {}, "1.5.0": {}, "2.0.0": {} },
+  });
+  const dir = await installServed(server, "update-latest-target-", pkgJson({ parent: "1.0.0", leaf: "1.0.0" }));
+  const deduped = await run(dir, "dedupe");
+  expect(deduped.stderr).not.toContain("error:");
+  expect(deduped.exitCode).toBe(0);
+  expect(await lockedVersions(dir, "leaf")).toStrictEqual(["1.0.0"]);
+
+  const { stderr, exitCode } = await run(dir, "update", "--latest", "-r");
+  expect(stderr).not.toContain("error:");
+  expect(await lockedVersions(dir, "leaf")).toStrictEqual(["1.5.0", "2.0.0"]);
+  expect(exitCode).toBe(0);
+});
+
+// A workspace member's row is not re-resolved by a bare update from the root, so its parked 1.0.0
+// keeps the instance alive and parent's `*` edge is held: the deduped lockfile stays a fixed point.
+test.concurrent("a member's parked edge holds its transitive siblings under a root update", async () => {
+  using server = await serveRegistry({
+    parent: { "1.0.0": { dependencies: { leaf: "*" } } },
+    leaf: { "1.0.0": {}, "1.5.0": {}, "2.0.0": {} },
+  });
+  using tmp = tempDir("update-member-hold-", {
+    "package.json": stringify({ name: "root", workspaces: ["packages/*"], dependencies: { leaf: "1.0.0" } }),
+    "packages/pkg1/package.json": stringify({ name: "pkg1", dependencies: { leaf: "^1.0.0", parent: "1.0.0" } }),
+  });
+  const dir = String(tmp);
+  await servedBunfig(server, dir);
+  await install(dir);
+  const deduped = await run(dir, "dedupe");
+  expect(deduped.stderr).not.toContain("error:");
+  expect(deduped.exitCode).toBe(0);
+  expect(await lockedVersions(dir, "leaf")).toStrictEqual(["1.0.0"]);
+  await reinstall(dir, { name: "root", workspaces: ["packages/*"] });
+  expect(await lockedVersions(dir, "leaf")).toStrictEqual(["1.0.0"]);
+  const before = await lockText(dir);
+
+  const { stdout, stderr, exitCode } = await run(dir, "update");
+  expectNoMoves(stdout);
+  expectCleanStderr(stderr);
+  expect(await lockedVersions(dir, "leaf")).toStrictEqual(["1.0.0"]);
+  expect(await lockText(dir)).toBe(before);
+  expect(exitCode).toBe(0);
+
+  const check = await run(dir, "dedupe", "--check");
+  expect(check.stderr).not.toContain("error:");
+  expect(check.exitCode).toBe(0);
+});
+
 // The root's exact 1.0.0 takes the root slot and pushes one-range-dep's 1.1.0 into a nested folder; widening the root keeps 1.0.0 locked, so the update collapses both rows onto 1.1.0.
 test.concurrent("hoisted: a bare update removes the nested copy whose row it collapsed", async () => {
   const dir = await setup({ "package.json": pkgJson({ "one-range-dep": "1.0.0" }) });

--- a/test/cli/install/bun-update-transitive.test.ts
+++ b/test/cli/install/bun-update-transitive.test.ts
@@ -976,6 +976,37 @@ test.concurrent("only the first moved direct row's landing carries an instance's
   expect(check.exitCode).toBe(0);
 });
 
+// pkg1's `1.0.0 || 2.0.0` row binds to the workspace member leaf@2.0.0, never the npm leaf@1.0.0 it
+// name-matches, so it must not hold parent-b's `~1.0.0` want from vacating that instance to 1.0.5.
+test.concurrent("a row a workspace member captures does not hold its package's npm instances", async () => {
+  const manifests: Manifests = {
+    "parent-b": { "1.0.0": { dependencies: { leaf: "~1.0.0" } } },
+    leaf: { "1.0.0": {}, "1.0.5": {} },
+  };
+  using server = await serveRegistry(manifests);
+  const revealed = manifests.leaf["1.0.5"];
+  delete manifests.leaf["1.0.5"];
+  using tmp = tempDir("update-workspace-capture-", {
+    "package.json": stringify({
+      name: "root",
+      workspaces: ["packages/*"],
+      dependencies: { "parent-b": "1.0.0" },
+    }),
+    "packages/leaf/package.json": stringify({ name: "leaf", version: "2.0.0" }),
+    "packages/pkg1/package.json": stringify({ name: "pkg1", dependencies: { leaf: "1.0.0 || 2.0.0" } }),
+  });
+  const dir = String(tmp);
+  await servedBunfig(server, dir);
+  await install(dir);
+  expect(await lockedVersions(dir, "leaf")).toStrictEqual(["1.0.0", "workspace:packages/leaf"]);
+  manifests.leaf["1.0.5"] = revealed;
+
+  const { stderr, exitCode } = await run(dir, "update", "-r");
+  expect(stderr).not.toContain("error:");
+  expect(await lockedVersions(dir, "leaf")).toStrictEqual(["1.0.5", "workspace:packages/leaf"]);
+  expect(exitCode).toBe(0);
+});
+
 // The root's exact 1.0.0 takes the root slot and pushes one-range-dep's 1.1.0 into a nested folder; widening the root keeps 1.0.0 locked, so the update collapses both rows onto 1.1.0.
 test.concurrent("hoisted: a bare update removes the nested copy whose row it collapsed", async () => {
   const dir = await setup({ "package.json": pkgJson({ "one-range-dep": "1.0.0" }) });

--- a/test/cli/install/bun-update-transitive.test.ts
+++ b/test/cli/install/bun-update-transitive.test.ts
@@ -940,6 +940,42 @@ test.concurrent("a direct row on a lower instance does not hold wants on a highe
   expect(exitCode).toBe(0);
 });
 
+// The redirect is first-wins per instance: root's row lands on 3.0.0 first, so pkg1's 4.0.0 landing is
+// never offered to peer-host's edge; that edge stays on 1.0.0 and parent's `*` want must be held.
+test.concurrent("only the first moved direct row's landing carries an instance's followers", async () => {
+  const manifests: Manifests = {
+    parent: { "1.0.0": { dependencies: { leaf: "*" } } },
+    "peer-host": { "1.0.0": { peerDependencies: { leaf: "~1.0.0 || ~4.0.0" } } },
+    leaf: { "1.0.0": {}, "3.0.0": {}, "4.0.0": {}, "5.0.0": {} },
+  };
+  using server = await serveRegistry(manifests);
+  const { "1.0.0": kept, ...hidden } = manifests.leaf;
+  manifests.leaf = { "1.0.0": kept };
+  using tmp = tempDir("update-first-landing-", {
+    "package.json": stringify({
+      name: "root",
+      workspaces: ["packages/*"],
+      dependencies: { leaf: "~1.0.0 || 3.0.0", parent: "1.0.0", "peer-host": "1.0.0" },
+    }),
+    "packages/pkg1/package.json": stringify({ name: "pkg1", dependencies: { leaf: "~1.0.0 || 4.0.0" } }),
+  });
+  const dir = String(tmp);
+  await servedBunfig(server, dir);
+  await install(dir);
+  expect(await lockedVersions(dir, "leaf")).toStrictEqual(["1.0.0"]);
+  Object.assign(manifests.leaf, hidden);
+
+  const { stderr, exitCode } = await run(dir, "update", "-r");
+  expect(stderr).not.toContain("error:");
+  // parent's `*` want is held and its edge carried to 3.0.0 instead of forking off a removable 5.0.0.
+  expect(await lockedVersions(dir, "leaf")).toStrictEqual(["3.0.0", "4.0.0"]);
+  expect(exitCode).toBe(0);
+
+  const check = await run(dir, "dedupe", "--check");
+  expect(check.stderr).not.toContain("error:");
+  expect(check.exitCode).toBe(0);
+});
+
 // The root's exact 1.0.0 takes the root slot and pushes one-range-dep's 1.1.0 into a nested folder; widening the root keeps 1.0.0 locked, so the update collapses both rows onto 1.1.0.
 test.concurrent("hoisted: a bare update removes the nested copy whose row it collapsed", async () => {
   const dir = await setup({ "package.json": pkgJson({ "one-range-dep": "1.0.0" }) });
@@ -1643,7 +1679,10 @@ test.concurrent("in a workspace, `bun update` from one member also re-points a s
   expect(exitCode).toBe(0);
 });
 
-type Manifests = Record<string, Record<string, { dependencies?: Record<string, string> }>>;
+type Manifests = Record<
+  string,
+  Record<string, { dependencies?: Record<string, string>; peerDependencies?: Record<string, string> }>
+>;
 type Tags = Record<string, Record<string, string>>;
 
 // Serves one manifest per name from memory; verdaccio has no parent whose newer version keeps a range on the same child, and its dist-tags cannot move mid-test. `tags` is read per request, so a test can move a tag after installing.

--- a/test/cli/install/bun-update-transitive.test.ts
+++ b/test/cli/install/bun-update-transitive.test.ts
@@ -820,6 +820,74 @@ test.concurrent("`bun update <name> --latest`: a superseded version's rows do no
   expect(exitCode).toBe(0);
 });
 
+// Same through an intermediate package: the superseded parent@1.0.0 -> mid -> leaf `~1.0.0` chain
+// is unreachable once parent moves, so mid's row does not hold the new parent's `^1.0.0` edge.
+test.concurrent("`bun update <name> --latest`: a superseded chain's rows do not hold the new children", async () => {
+  using server = await serveRegistry({
+    parent: {
+      "1.0.0": { dependencies: { mid: "1.0.0" } },
+      "3.0.0": { dependencies: { leaf: "^1.0.0" } },
+    },
+    mid: { "1.0.0": { dependencies: { leaf: "~1.0.0" } } },
+    leaf: { "1.0.0": {}, "1.5.0": {} },
+  });
+  const dir = await installServed(server, "update-superseded-chain-", pkgJson({ parent: "1.0.0" }));
+  expect(await lockedVersions(dir, "leaf")).toStrictEqual(["1.0.0"]);
+
+  const { stderr, exitCode } = await run(dir, "update", "parent", "--latest");
+  expect(stderr).not.toContain("error:");
+  expect(await lockedVersions(dir, "parent")).toStrictEqual(["3.0.0"]);
+  expect(await lockedVersions(dir, "mid")).toStrictEqual([]);
+  expect(await lockedVersions(dir, "leaf")).toStrictEqual(["1.5.0"]);
+  expect(exitCode).toBe(0);
+});
+
+// Removing a root dependency and updating in one step: the removed subtree's rows are unreachable
+// and do not hold the remaining `^1.0.0` want at the 1.0.0 they used to share.
+test.concurrent("a removed root dependency's rows do not hold the remaining wants", async () => {
+  using server = await serveRegistry({
+    "parent-a": { "1.0.0": { dependencies: { leaf: "~1.0.0" } } },
+    "parent-b": { "1.0.0": { dependencies: { leaf: "^1.0.0" } } },
+    leaf: { "1.0.0": {}, "1.5.0": {} },
+  });
+  const dir = await installServed(
+    server,
+    "update-removed-root-",
+    pkgJson({ "parent-a": "1.0.0", "parent-b": "1.0.0" }),
+  );
+  const deduped = await run(dir, "dedupe");
+  expect(deduped.stderr).not.toContain("error:");
+  expect(deduped.exitCode).toBe(0);
+  expect(await lockedVersions(dir, "leaf")).toStrictEqual(["1.0.0"]);
+
+  await write(join(dir, "package.json"), stringify(pkgJson({ "parent-b": "1.0.0" })));
+  const { stderr, exitCode } = await run(dir, "update");
+  expect(stderr).not.toContain("error:");
+  expect(await lockedVersions(dir, "parent-a")).toStrictEqual([]);
+  expect(await lockedVersions(dir, "leaf")).toStrictEqual(["1.5.0"]);
+  expect(exitCode).toBe(0);
+});
+
+// The root's `^1.0.0` row sits on leaf@1.5.0; its lookup (1.5.0) is below leaf@2.0.0 but the row
+// never resolved there, so it must not hold parent's `^2.0.0` want from moving to 2.5.0.
+test.concurrent("a direct row on a lower instance does not hold wants on a higher instance", async () => {
+  const manifests: Manifests = {
+    parent: { "1.0.0": { dependencies: { leaf: "^2.0.0" } } },
+    leaf: { "1.5.0": {}, "2.0.0": {}, "2.5.0": {} },
+  };
+  using server = await serveRegistry(manifests);
+  const hidden = manifests.leaf["2.5.0"];
+  delete manifests.leaf["2.5.0"];
+  const dir = await installServed(server, "update-two-instances-", pkgJson({ parent: "1.0.0", leaf: "^1.0.0" }));
+  expect(await lockedVersions(dir, "leaf")).toStrictEqual(["1.5.0", "2.0.0"]);
+  manifests.leaf["2.5.0"] = hidden;
+
+  const { stderr, exitCode } = await run(dir, "update");
+  expect(stderr).not.toContain("error:");
+  expect(await lockedVersions(dir, "leaf")).toStrictEqual(["1.5.0", "2.5.0"]);
+  expect(exitCode).toBe(0);
+});
+
 // The root's exact 1.0.0 takes the root slot and pushes one-range-dep's 1.1.0 into a nested folder; widening the root keeps 1.0.0 locked, so the update collapses both rows onto 1.1.0.
 test.concurrent("hoisted: a bare update removes the nested copy whose row it collapsed", async () => {
   const dir = await setup({ "package.json": pkgJson({ "one-range-dep": "1.0.0" }) });

--- a/test/cli/install/bun-update-transitive.test.ts
+++ b/test/cli/install/bun-update-transitive.test.ts
@@ -688,7 +688,11 @@ test.concurrent("a member's parked row does not hold wants on another instance o
   });
   const dependents = { "parent-a": "1.0.0", "parent-b": "1.0.0" };
   using tmp = tempDir("update-member-other-instance-", {
-    "package.json": stringify({ name: "root", workspaces: ["packages/*"], dependencies: { ...dependents, leaf: "2.0.0" } }),
+    "package.json": stringify({
+      name: "root",
+      workspaces: ["packages/*"],
+      dependencies: { ...dependents, leaf: "2.0.0" },
+    }),
     "packages/pkg1/package.json": stringify({ name: "pkg1", dependencies: { leaf: "^1.0.0" } }),
   });
   const dir = String(tmp);

--- a/test/cli/install/bun-update-transitive.test.ts
+++ b/test/cli/install/bun-update-transitive.test.ts
@@ -507,25 +507,52 @@ test.concurrent("a transitive dependency pinned exactly by its dependent stays p
   expect(exitCode).toBe(0);
 });
 
-// The root's no-deps@1.0.0 dedupes both dependents onto 1.0.0 before it is dropped; the update forks only the `^1.0.0` edge.
-test.concurrent("dependents with different ranges are resolved independently", async () => {
+// The root's no-deps@1.0.0 dedupes both dependents onto 1.0.0 before it is dropped; the fixed edge keeps 1.0.0 alive, so the `^1.0.0` edge is held instead of forked into the duplicate `bun dedupe` would remove.
+test.concurrent("a range edge is not forked off an instance a fixed sibling keeps alive", async () => {
   const dependents = { "one-fixed-dep": "1.0.0", "one-range-dep": "1.0.0" };
   const dir = await setup({ "package.json": pkgJson({ "no-deps": "1.0.0", ...dependents }) });
   const packageJson = pkgJson(dependents);
   await reinstall(dir, packageJson);
   expect(await lockedVersions(dir, "no-deps")).toStrictEqual(["1.0.0"]);
+  const before = await lockText(dir);
   const { stdout, stderr, exitCode } = await run(dir, "update");
-  expectSummary(stdout, NO_DEPS_ROW_HINTED, "", installed(1));
+  expectSummary(stdout, noChanges(3, 4));
   expectCleanStderr(stderr);
+  expect(stderr).not.toContain("Saved lockfile");
   expect(await packageJsonOf(dir)).toStrictEqual(packageJson);
-  expect(await lockedVersions(dir, "no-deps")).toStrictEqual(["1.0.0", "1.1.0"]);
-  const { packages } = await lock(dir);
-  expect([packages["no-deps"][0], packages["one-range-dep/no-deps"][0]]).toStrictEqual([
-    "no-deps@1.0.0",
-    "no-deps@1.1.0",
-  ]);
+  expect(await lockText(dir)).toBe(before);
+  expect(await lockedVersions(dir, "no-deps")).toStrictEqual(["1.0.0"]);
   await frozen(dir);
   expect(exitCode).toBe(0);
+});
+
+// #38903: `bun update` and `bun dedupe` must reach a fixed point. After dedupe collapses the `^1.0.0`
+// edge onto the exact pin's 1.0.0, a bare update holds that edge instead of re-adding the duplicate.
+test.concurrent("a deduped lockfile is a fixed point of `bun update`", async () => {
+  const dir = await setup({ "package.json": pkgJson({ "one-range-dep": "1.0.0" }) });
+  const packageJson = pkgJson({ "one-range-dep": "1.0.0", "no-deps": "1.0.0" });
+  await reinstall(dir, packageJson);
+  expect(await lockedVersions(dir, "no-deps")).toStrictEqual(["1.0.0", "1.1.0"]);
+
+  const deduped = await run(dir, "dedupe");
+  expect(deduped.stderr).not.toContain("error:");
+  expect(deduped.exitCode).toBe(0);
+  expect(await lockedVersions(dir, "no-deps")).toStrictEqual(["1.0.0"]);
+  const before = await lockText(dir);
+
+  const { stdout, stderr, exitCode } = await run(dir, "update");
+  expectSummary(stdout, noChanges(2, 3));
+  expectCleanStderr(stderr);
+  expect(stderr).not.toContain("Saved lockfile");
+  expect(await packageJsonOf(dir)).toStrictEqual(packageJson);
+  expect(await lockText(dir)).toBe(before);
+  expect(exitCode).toBe(0);
+
+  const check = await run(dir, "dedupe", "--check");
+  expect(check.stderr).not.toContain("error:");
+  expect(check.exitCode).toBe(0);
+  expect(await lockText(dir)).toBe(before);
+  await frozen(dir);
 });
 
 // The root's exact 1.0.0 takes the root slot and pushes one-range-dep's 1.1.0 into a nested folder; widening the root keeps 1.0.0 locked, so the update collapses both rows onto 1.1.0.

--- a/test/cli/install/bun-update-transitive.test.ts
+++ b/test/cli/install/bun-update-transitive.test.ts
@@ -868,6 +868,32 @@ test.concurrent("a removed root dependency's rows do not hold the remaining want
   expect(exitCode).toBe(0);
 });
 
+// The workspace analog: a member dropped from the glob keeps its Workspace tag until the clean,
+// but its rows are unreachable and do not hold the remaining `^1.0.0` want.
+test.concurrent("a removed workspace member's rows do not hold the remaining wants", async () => {
+  using server = await serveRegistry({
+    parent: { "1.0.0": { dependencies: { leaf: "^1.0.0" } } },
+    leaf: { "1.0.0": {}, "1.5.0": {} },
+  });
+  using tmp = tempDir("update-removed-member-", {
+    "package.json": stringify({ name: "root", workspaces: ["packages/*"], dependencies: { parent: "1.0.0" } }),
+    "packages/a/package.json": stringify({ name: "a", dependencies: { leaf: "~1.0.0" } }),
+  });
+  const dir = String(tmp);
+  await servedBunfig(server, dir);
+  await install(dir);
+  const deduped = await run(dir, "dedupe");
+  expect(deduped.stderr).not.toContain("error:");
+  expect(deduped.exitCode).toBe(0);
+  expect(await lockedVersions(dir, "leaf")).toStrictEqual(["1.0.0"]);
+
+  await write(join(dir, "package.json"), stringify({ name: "root", workspaces: [], dependencies: { parent: "1.0.0" } }));
+  const { stderr, exitCode } = await run(dir, "update");
+  expect(stderr).not.toContain("error:");
+  expect(await lockedVersions(dir, "leaf")).toStrictEqual(["1.5.0"]);
+  expect(exitCode).toBe(0);
+});
+
 // The root's `^1.0.0` row sits on leaf@1.5.0; its lookup (1.5.0) is below leaf@2.0.0 but the row
 // never resolved there, so it must not hold parent's `^2.0.0` want from moving to 2.5.0.
 test.concurrent("a direct row on a lower instance does not hold wants on a higher instance", async () => {

--- a/test/cli/install/bun-update-transitive.test.ts
+++ b/test/cli/install/bun-update-transitive.test.ts
@@ -557,6 +557,72 @@ test.concurrent("a deduped lockfile is a fixed point of `bun update`", async () 
   await frozen(dir);
 });
 
+// Holds cascade: the peer's range rejects 2.0.0, holding bounded-dep's edge; that held edge in turn
+// rejects 4.0.0, so wide-dep's edge must be held too instead of forking leaf off the kept 1.0.0.
+test.concurrent("a held edge blocks its sibling from forking the instance", async () => {
+  using server = await serveRegistry({
+    "wide-dep": { "1.0.0": { dependencies: { leaf: ">=1.0.0" } } },
+    "bounded-dep": { "1.0.0": { dependencies: { leaf: ">=1.0.0 <3.0.0" } } },
+    "peer-host": { "1.0.0": { peerDependencies: { leaf: "1.0.0 || >=4.0.0" } } },
+    leaf: { "1.0.0": {}, "2.0.0": {}, "4.0.0": {} },
+  });
+  const packageJson = pkgJson({ "wide-dep": "1.0.0", "bounded-dep": "1.0.0", "peer-host": "1.0.0" });
+  const dir = await installServed(
+    server,
+    "update-hold-cascade-",
+    pkgJson({ ...packageJson.dependencies, leaf: "1.0.0" }),
+  );
+  const deduped = await run(dir, "dedupe");
+  expect(deduped.stderr).not.toContain("error:");
+  expect(deduped.exitCode).toBe(0);
+  expect(await lockedVersions(dir, "leaf")).toStrictEqual(["1.0.0"]);
+  await reinstall(dir, packageJson);
+  expect(await lockedVersions(dir, "leaf")).toStrictEqual(["1.0.0"]);
+  const before = await lockText(dir);
+
+  const { stdout, stderr, exitCode } = await run(dir, "update");
+  expectNoMoves(stdout);
+  expectCleanStderr(stderr);
+  expect(await lockedVersions(dir, "leaf")).toStrictEqual(["1.0.0"]);
+  expect(await lockText(dir)).toBe(before);
+  expect(exitCode).toBe(0);
+
+  const check = await run(dir, "dedupe", "--check");
+  expect(check.stderr).not.toContain("error:");
+  expect(check.exitCode).toBe(0);
+});
+
+// A direct range that will move is no reason to hold: root leaf `^1.0.0 || ^3.0.0` moves to 3.0.0,
+// so parent's `^1.0.0 || ^2.0.0` edge moves to 2.0.0 instead of being held at the 1.0.0 the root leaves.
+test.concurrent("a direct edge that moves away does not hold its transitive siblings", async () => {
+  using server = await serveRegistry({
+    parent: { "1.0.0": { dependencies: { leaf: "^1.0.0 || ^2.0.0" } } },
+    leaf: { "1.0.0": {}, "2.0.0": {}, "3.0.0": {} },
+  });
+  const dir = await installServed(server, "update-direct-moves-", pkgJson({ parent: "1.0.0", leaf: "1.0.0" }));
+  const deduped = await run(dir, "dedupe");
+  expect(deduped.stderr).not.toContain("error:");
+  expect(deduped.exitCode).toBe(0);
+  expect(await lockedVersions(dir, "leaf")).toStrictEqual(["1.0.0"]);
+
+  // Widen the root range in package.json and bun.lock, keeping the locked resolution at 1.0.0.
+  await write(join(dir, "package.json"), stringify(pkgJson({ parent: "1.0.0", leaf: "^1.0.0 || ^3.0.0" })));
+  const lockfile = await lockText(dir);
+  expect(lockfile.split(`"leaf": "1.0.0"`)).toHaveLength(2);
+  await write(join(dir, "bun.lock"), lockfile.replace(`"leaf": "1.0.0"`, `"leaf": "^1.0.0 || ^3.0.0"`));
+
+  const { stderr, exitCode } = await run(dir, "update");
+  expectCleanStderr(stderr);
+  expect(await lockedVersions(dir, "leaf")).toStrictEqual(["2.0.0", "3.0.0"]);
+  expect(exitCode).toBe(0);
+  const before = await lockText(dir);
+
+  const again = await run(dir, "dedupe");
+  expect(again.stderr).not.toContain("error:");
+  expect(again.exitCode).toBe(0);
+  expect(await lockText(dir)).toBe(before);
+});
+
 // The root's exact 1.0.0 takes the root slot and pushes one-range-dep's 1.1.0 into a nested folder; widening the root keeps 1.0.0 locked, so the update collapses both rows onto 1.1.0.
 test.concurrent("hoisted: a bare update removes the nested copy whose row it collapsed", async () => {
   const dir = await setup({ "package.json": pkgJson({ "one-range-dep": "1.0.0" }) });

--- a/test/cli/install/bun-update-transitive.test.ts
+++ b/test/cli/install/bun-update-transitive.test.ts
@@ -897,6 +897,28 @@ test.concurrent("a removed workspace member's rows do not hold the remaining wan
   expect(exitCode).toBe(0);
 });
 
+// An optional dependency the registry cannot resolve is skipped at install and its row stays
+// unresolved in bun.lock; a later `bun update` must tolerate that row.
+test.concurrent("`bun update` tolerates an unresolved optional dependency row", async () => {
+  using server = await serveRegistry({
+    parent: { "1.0.0": { dependencies: { leaf: "^1.0.0" } } },
+    leaf: { "1.0.0": {}, "1.5.0": {} },
+  });
+  using tmp = tempDir("update-optional-unresolved-", {
+    "package.json": stringify({ name: "root", workspaces: ["packages/*"], dependencies: { parent: "1.0.0" } }),
+    "packages/a/package.json": stringify({ name: "a", optionalDependencies: { gone: "^1.0.0" } }),
+  });
+  const dir = String(tmp);
+  await servedBunfig(server, dir);
+  const first = await run(dir, "install");
+  expect(first.exitCode).toBe(0);
+
+  const { stderr, exitCode } = await run(dir, "update");
+  expect(stderr).not.toContain("error:");
+  expect(await lockedVersions(dir, "leaf")).toStrictEqual(["1.5.0"]);
+  expect(exitCode).toBe(0);
+});
+
 // The root's `^1.0.0` row sits on leaf@1.5.0; its lookup (1.5.0) is below leaf@2.0.0 but the row
 // never resolved there, so it must not hold parent's `^2.0.0` want from moving to 2.5.0.
 test.concurrent("a direct row on a lower instance does not hold wants on a higher instance", async () => {

--- a/test/cli/install/bun-update-transitive.test.ts
+++ b/test/cli/install/bun-update-transitive.test.ts
@@ -611,7 +611,9 @@ test.concurrent("a direct edge that moves away does not hold its transitive sibl
   expect(lockfile.split(`"leaf": "1.0.0"`)).toHaveLength(2);
   await write(join(dir, "bun.lock"), lockfile.replace(`"leaf": "1.0.0"`, `"leaf": "^1.0.0 || ^3.0.0"`));
 
-  const { stderr, exitCode } = await run(dir, "update");
+  const { stdout, stderr, exitCode } = await run(dir, "update");
+  // The summary prints one row per name; the direct move wins the slot.
+  expect(movedRows(stdout)).toStrictEqual([movedRow("leaf", "1.0.0", "3.0.0")]);
   expectCleanStderr(stderr);
   expect(await lockedVersions(dir, "leaf")).toStrictEqual(["2.0.0", "3.0.0"]);
   expect(exitCode).toBe(0);


### PR DESCRIPTION
### Problem

- Fixes #38903: `bun update` and `bun dedupe` undo each other forever when a wide range (`*`) sits alongside a narrower one for the same package.
- `bun dedupe` collapses onto the fewest versions that satisfy every edge, so with `cookie@^1.1.1` at the root and `"cookie": "*"` from `@types/cookie` it removes `cookie@2.0.1` and points the `*` edge at `1.1.1`.
- A bare `bun update` then re-resolves the `*` edge to the newest release its range allows (`plan_edges` in `src/install/update_transitive.rs`), re-adding `2.0.1` next to the `1.1.1` the root pin keeps alive, which the next dedupe removes again, and so on.

### Fix

- `plan_edges` now computes each want's candidate first, then drops (holds) a move that would fork the package: some other edge on the same instance stays behind at the current version while that version still satisfies the moving range, so the fork is exactly the duplicate dedupe removes.
- A held move itself counts as staying, so holds cascade; the hold set is computed to a fixed point (monotone, at most one pass per want).
- "Stays" is judged against the versions the post-resolve redirect could actually carry an edge to, in the redirect's own first-wins order: the instance's first surviving pin (dist-tag pins included) plus the landing of any direct row that moves off that same instance. An edge stays only when its range rejects all of them, or when the redirect cannot carry it at all (bundled, no npm range).
- Which edges are carried vs re-resolved mirrors the resolver's `should_update` / `latest_for_target`:
  - follower rows (owned by npm packages, plus root/workspace rows outside the update scope, which keep their locked resolution) move only via the redirect; an out-of-scope row that the differ re-appended unresolved recovers its pre-diff resolution from the `DirectDependencies` snapshot;
  - root/workspace rows the differ re-resolves stay when it lands them back on the current version: the best release their range allows, or the `latest` dist-tag for `--latest` target rows (catalog and overridden rows keep the range model, as do rows whose package.json literal is itself a dist-tag). A locked version is kept only when the manifest still contains it, and a lookup at or below current also counts as staying, since update never moves a direct row below bun.lock (`keep_locked_if_ahead`). They are matched by name against live dep slices because the differ re-appends root rows before the plan runs; orphaned rows outside every live slice are ignored.
- Follower sets come from a root-reachability walk, so rows of superseded versions, removed dependencies, and dropped workspace members hold nothing; unresolved optional rows are skipped instead of panicking.
- Dist-tag edges are never held: they follow their tag, and dedupe treats them as immovable, so they cannot oscillate.
- Instances whose edges can all move (the common case), or that vacate entirely, update exactly as before; non-peer rows a patched package captures land on the patched version, as in the resolver.
- Verified:
  - new tests in `test/cli/install/bun-update-transitive.test.ts`: the deduped fixed point (install, dedupe, update, `dedupe --check`, lockfile byte-identical), the hold cascade through a peer edge, a direct edge that moves away not holding its transitive siblings (and its landing carrying only its own instance's followers), a `--latest -r` pin that jumps to latest not holding its siblings, a pin ahead of a lagging `latest` tag still holding, a workspace member's parked row holding a `*` sibling under a root update (and not holding wants on another instance), a root pin holding when updating from a member cwd, a catalog pin converging under `--latest -r`, superseded or removed subtrees (chained supersede, removed root dependency, removed workspace member) holding nothing, a direct row on a lower instance whose locked version left the manifest, and an unresolved optional row not panicking
  - updated `dependents with different ranges are resolved independently` (now `a range edge is not forked off an instance a fixed sibling keeps alive`): the old assertion pinned the re-forking behavior and has been flipped to the held state
  - full runs: `bun-update-transitive.test.ts` (183 pass), `bun-dedupe.test.ts` (76 pass), `bun-update.test.ts` (156 pass), `bun-update-lockfile-sync.test.ts` (77 pass)
  - manual run of the issue's cookie repro against npm: install forks (unchanged), dedupe collapses, update reports no changes, `dedupe --check` exits 0

### Background

- The lockfile is edge-based: each dependency row (edge) resolves to a package instance (a concrete `name@version`). Several edges with different ranges can resolve to the same instance, and the same name can have several instances when ranges cannot be unified.
- Bare `bun update` has two halves: the differ re-resolves the update-scope root/workspace edges to the newest release their ranges allow (the `latest` dist-tag under `--latest` with `-r`/`--filter`), and the transitive pass (`plan_edges`) pins every other in-scope edge the same way. After resolution, a redirect pass carries edges that were not pinned onto a moved target when their range accepts it; that redirect is why an instance whose every edge accepts the candidate vacates completely and produces no duplicate.
- `bun dedupe` is a greedy minimum set cover over already-installed versions: it keeps the fewest instances that satisfy every edge's range (preferring higher versions on ties) and re-points edges onto survivors. It never contacts the registry.
- Both commands landed in #38333. Each is self-consistent; this change makes update recognize the states dedupe produces instead of dismantling them.

<details>
<summary>Repro from the issue</summary>

```json
{
  "dependencies": {
    "cookie": "^1.1.1",
    "@types/cookie": "^1.0.0"
  }
}
```

`@types/cookie` declares `"cookie": "*"`.

Before:

```
after install:  cookie@1.1.1  cookie@2.0.1
after dedupe:   cookie@1.1.1
after update:   cookie@1.1.1  cookie@2.0.1   <- re-forked
after dedupe:   cookie@1.1.1                 <- forever
```

After:

```
after install:  cookie@1.1.1  cookie@2.0.1
after dedupe:   cookie@1.1.1
after update:   cookie@1.1.1   (Checked 2 installs across 3 packages (no changes))
dedupe --check: exit 0
```

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 5 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-update-transitive.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/183] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[2/183] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 240 extern-C blocks audited
[3/183] gen cpp.rs (cppbind)
[4/183] gen BunProcess.lut.h
Generating /workspace/bun/build/debug/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[5/183] gen BunObject.lut.h
Generating /workspace/bun/build/debug/codegen/BunObject.lut.h from /workspace/bun/src/jsc/bindings/BunObject.cpp
[6/183] gen JS modules (bundle-modules)
Preprocess modules (8464ms)
Bundle modules (107ms)
Postprocesss modules (219ms)
Bundle Functions (746ms)
Generate Code (13ms)

[9.57s] Bundled "src/js" for development
  2826 kb
  197 internal modules
  13 native modules
  91 internal functions across 17 files
[6/182] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x8
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (bb246b257)

test/cli/install/bun-update-transitive.test.ts:
(pass) without a lockfile, `bun update <undeclared>` is rejected and writes no lockfile [29.97ms]
(pass) without a lockfile, `bun update <declared>` resolves and saves [138.45ms]
(pass) `bun update <name>` and a pattern that match nothing in bun.lockb name that file [142.89ms]
(pass) `bun update <name>` and a pattern that match nothing in bun.lock name that file [145.82ms]
(pass) `bun update <name>` naming a package with nothing newer is the same no-op as a bare rerun [154.68ms]
(pass) `bun update` with a pattern alongside a direct name reaches a package that is only a transitive dependency [165.42ms]
(pass) a moved direct dependency is still followed after its row index shifted [164.99ms]
(pass) `bun update` moves a transitive dependency within its dependent's range (binary lockfile) [176.74ms]
(pass) `bun update --frozen-lockfile` refuses to move the transitive dependency [177.73ms]
(pass) `bun update --dry-run` (bare) prints the plan as summary rows and writes nothing [177.71ms]
(pass) `bun update --dry-run` (no-deps) prints the plan as summary rows and writes nothing [147.91ms]
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-update-transitive.test.ts
bun test v1.4.0 (cda4023ad)

test/cli/install/bun-update-transitive.test.ts:
(pass) `bun update` moves a transitive dependency within its dependent's range (text lockfile) [846.75ms]
(pass) `bun update` moves a transitive dependency within its dependent's range (binary lockfile) [834.40ms]
(pass) `bun update` moves a transitive dependency within its dependent's range (isolated linker) [900.56ms]
(pass) `bun update --latest` still moves transitive dependencies only within their ranges [909.24ms]
(pass) `bun update no-deps` reaches a package that is only a transitive dependency [1047.73ms]
(pass) `bun update` with a pattern reaches a package that is only a transitive dependency [672.99ms]
(pass) `bun update` with a bare `*` reaches a package that is only a transitive dependency [702.94ms]
(pass) `bun update` with a negated name reaches a package that is only a transitive dependency [715.26ms]
(pass) `bun update --latest no-deps` reaches a package that is only a transitive dependency [842.14m
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 665ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/141] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[2/141] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 240 extern-C blocks audited
[3/141] gen cpp.rs (cppbind)
[4/141] gen BunProcess.lut.h
Generating /workspace/bun/build/release/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[5/141] gen BunObject.lut.h
Generating /workspace/bun/build/release/codegen/BunObject.lut.h from /workspace/bun/src/jsc/bindings/BunObject.cpp
[6/141] gen JS modules (bundle-modules)
Preprocess modules (8294ms)
Bundle modules (61ms)
Postprocesss modules (258ms)
Bundle Functions (693ms)
Generate Code (31ms)

[9.36s] Bundled "src/js" for production
  2632 kb
  197 internal modules
  13 native modules
  91 internal functions across 17 files
[6/140] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 202
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/install/update_transitive.rs               | 572 +++++++++++++++++++++++--
 test/cli/install/bun-update-transitive.test.ts | 502 +++++++++++++++++++++-
 2 files changed, 1032 insertions(+), 42 deletions(-)
```

</details>

**gate history** · 8 passed · 2 rejected · iteration 5

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
src/install/update_transitive.rs                   33     75      0
test/cli/install/bun-update-transitive.test.ts     13     25      0
```

</details>

**root cause** · written by the author bot

The bug occurred because bun update re-resolved every edge to the newest version its own range allowed, so a wide range like the `*` on cookie was moved to 2.0.1 and forked off the existing 1.1.1 instance, while bun dedupe collapsed that fork back because 1.1.1 also satisfied the range, leaving the two commands to undo each other indefinitely. The fix changes the transitive update planner to index edges onto package instances and evaluate each candidate npm move against the rows that would remain behind, skipping any move that would leave a surviving fork when an already-kept version satisf…

<!-- robobun:evidence:end -->

