### PR TITLE
Bump WebKit (oven-sh/WebKit#438 preview): call the tag of super.tag`...` with the method's this

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "f0f60fd2324817dae9656d8bf2fcae25ceaccc37";
+export const WEBKIT_VERSION = "autobuild-preview-pr-438-31f493c1";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/jsc-stress/fixtures/tagged-templates-super-this.js
+++ b/test/js/bun/jsc-stress/fixtures/tagged-templates-super-this.js
@@ -1,0 +1,347 @@
+// @bun
+// A tagged template whose tag is a super property reference, super.tag`...` or super[key]`...`, must call
+// the tag with the same |this| as super.tag(...) would: the |this| of the method containing it
+// (EvaluateCall, https://tc39.es/ecma262/#sec-evaluatecall, step 1.a.i: GetThisValue of a Super Reference).
+// It used to be called with the object the tag was found on, the home object's prototype, as if it were
+// written Base.prototype.tag`...`.
+
+function describe(value) {
+    if (typeof value === "function")
+        return `function ${value.name}`;
+    if (typeof value === "object" && value !== null)
+        return `[object ${value.constructor ? value.constructor.name : "?"}]`;
+    return `${typeof value} ${String(value)}`;
+}
+
+function shouldBe(actual, expected, message) {
+    if (actual !== expected)
+        throw new Error(`${message}: got ${describe(actual)}, expected ${describe(expected)}`);
+}
+
+function shouldThrowReferenceError(func, message) {
+    let error;
+    try {
+        func();
+    } catch (e) {
+        error = e;
+    }
+    if (!(error instanceof ReferenceError))
+        throw new Error(`${message}: expected a ReferenceError, got ${String(error)}`);
+}
+
+const failures = [];
+function test(name, func) {
+    try {
+        func();
+    } catch (e) {
+        failures.push(`${name}: ${e.message}`);
+    }
+}
+
+// Every tag records the |this| it was called with and returns it, so callers can compare it with `===`.
+// All of them are strict, so they see exactly the value they were passed.
+function tagStrict(strings) {
+    "use strict";
+    tagStrict.lastCall = { thisValue: this, strings, values: Array.prototype.slice.call(arguments, 1) };
+    return this;
+}
+
+class Base {
+    tag(strings, ...values) {
+        Base.lastCall = { thisValue: this, strings, values };
+        return this;
+    }
+    get getterTag() {
+        Base.lastGetterReceiver = this;
+        return tagStrict;
+    }
+    static tag() {
+        return this;
+    }
+}
+const key = "tag";
+const symbolKey = Symbol("tag");
+Base.prototype[symbolKey] = tagStrict;
+Base.prototype[0] = tagStrict;
+
+test("super.tag in a method", () => {
+    class C extends Base {
+        m() { return super.tag`x`; }
+        call() { return super.tag(); }
+    }
+    const c = new C;
+    shouldBe(c.m(), c, "super.tag`x` is called with the receiver as this");
+    shouldBe(Base.lastCall.strings.length, 1, "the template object is still passed");
+    shouldBe(Base.lastCall.strings[0], "x", "the template strings are still passed");
+    shouldBe(c.call(), c, "super.tag() is called with the receiver as this");
+});
+
+test("super.tag is still looked up on the super base, not on this", () => {
+    class C extends Base {
+        tag() { throw new Error("C.prototype.tag must not be called by super.tag`x`"); }
+        m() { return super.tag`x`; }
+    }
+    const c = new C;
+    shouldBe(c.m(), c, "super.tag`x` resolves to Base.prototype.tag and is called with the receiver");
+});
+
+test("super.tag two levels up", () => {
+    class Middle extends Base { }
+    class C extends Middle {
+        m() { return super.tag`x`; }
+    }
+    const c = new C;
+    shouldBe(c.m(), c, "a tag inherited through an intermediate class is called with the receiver");
+});
+
+test("super[key] with a variable, a string literal, a symbol and an index", () => {
+    class C extends Base {
+        variable() { return super[key]`x`; }
+        literal() { return super["tag"]`x`; }
+        symbol() { return super[symbolKey]`x`; }
+        index() { return super[0]`x`; }
+    }
+    const c = new C;
+    shouldBe(c.variable(), c, "super[key]`x`");
+    shouldBe(c.literal(), c, "super[\"tag\"]`x`");
+    shouldBe(c.symbol(), c, "super[symbolKey]`x`");
+    shouldBe(c.index(), c, "super[0]`x`");
+});
+
+test("template object and substitutions", () => {
+    class C extends Base {
+        dot(a, b) { return super.tag`a${a}b${b}c`; }
+        bracket(a, b) { return super[key]`a${a}b${b}c`; }
+    }
+    const c = new C;
+    for (const [name, method] of [["super.tag", c.dot], ["super[key]", c.bracket]]) {
+        shouldBe(method.call(c, 1, 2), c, `${name} with substitutions is called with the receiver`);
+        const { strings, values } = Base.lastCall;
+        shouldBe(strings.length, 3, `${name}: strings.length`);
+        shouldBe(strings.join(","), "a,b,c", `${name}: strings`);
+        shouldBe(strings.raw.join(","), "a,b,c", `${name}: strings.raw`);
+        shouldBe(values.length, 2, `${name}: values.length`);
+        shouldBe(values[0], 1, `${name}: values[0]`);
+        shouldBe(values[1], 2, `${name}: values[1]`);
+        method.call(c, 3, 4);
+        shouldBe(Base.lastCall.strings, strings, `${name}: the template object is cached per call site`);
+    }
+});
+
+test("substitutions are evaluated after the tag is looked up and see the same this", () => {
+    const log = [];
+    class C extends Base {
+        get probe() { log.push("substitution"); return this; }
+        m() { return super.tag`${this.probe}${log.push("second")}`; }
+    }
+    const c = new C;
+    shouldBe(c.m(), c, "this value");
+    shouldBe(log.join(), "substitution,second", "substitution order");
+    shouldBe(Base.lastCall.values[0], c, "the substitution saw the receiver");
+    shouldBe(Base.lastCall.values[1], 2, "the second substitution");
+});
+
+test("getter on the super base", () => {
+    class C extends Base {
+        dot() { return super.getterTag`x`; }
+        bracket() { return super["getterTag"]`x`; }
+    }
+    const c = new C;
+    shouldBe(c.dot(), c, "the function a super getter returns is called with the receiver");
+    shouldBe(Base.lastGetterReceiver, c, "super.getterTag invokes the getter with the receiver");
+    Base.lastGetterReceiver = null;
+    shouldBe(c.bracket(), c, "the same through super[\"getterTag\"]");
+    shouldBe(Base.lastGetterReceiver, c, "super[\"getterTag\"] invokes the getter with the receiver");
+});
+
+test("static method", () => {
+    class C extends Base {
+        static dot() { return super.tag`x`; }
+        static bracket() { return super[key]`x`; }
+    }
+    shouldBe(C.dot(), C, "static super.tag`x` is called with the class as this");
+    shouldBe(C.bracket(), C, "static super[key]`x` is called with the class as this");
+});
+
+test("object literal method", () => {
+    const proto = { tag: tagStrict, [symbolKey]: tagStrict };
+    const object = {
+        __proto__: proto,
+        dot() { return super.tag`x`; },
+        bracket() { return super[symbolKey]`x`; },
+    };
+    shouldBe(object.dot(), object, "super.tag`x` in an object literal method");
+    shouldBe(object.bracket(), object, "super[key]`x` in an object literal method");
+
+    const inheriting = { __proto__: object };
+    shouldBe(inheriting.dot(), inheriting, "the receiver, not the home object, when the method is called through an inheriting object");
+    shouldBe(inheriting.bracket(), inheriting, "the same for super[key]");
+});
+
+test("primitive receivers are passed through like super.tag() passes them", () => {
+    class C extends Base {
+        dot() { return super.tag`x`; }
+        bracket() { return super[key]`x`; }
+        call() { return super.tag(); }
+    }
+    // Class code is strict, so the primitive reaches the method unconverted and is passed on as is.
+    shouldBe(C.prototype.call.call(5), 5, "sanity: super.tag() from a strict method passes the primitive through");
+    shouldBe(C.prototype.dot.call(5), 5, "super.tag`x` from a strict method passes the primitive through");
+    shouldBe(C.prototype.bracket.call(5), 5, "super[key]`x` from a strict method passes the primitive through");
+
+    // A sloppy method (made with Function so that it is sloppy whatever mode this file runs in) boxes its
+    // receiver on entry; the tag has to be called with that box.
+    const proto = { tag: tagStrict };
+    const sloppy = Function("proto", "return { __proto__: proto, dot() { return super.tag`x`; }, call() { return super.tag(); } };")(proto);
+    const boxedByCall = sloppy.call.call(5);
+    shouldBe(typeof boxedByCall, "object", "sanity: super.tag() from a sloppy method passes the boxed receiver");
+    const boxed = sloppy.dot.call(5);
+    shouldBe(typeof boxed, "object", "super.tag`x` from a sloppy method passes the boxed receiver");
+    shouldBe(boxed instanceof Number, true, "the box is a Number object");
+    shouldBe(boxed.valueOf(), 5, "the box holds the receiver");
+});
+
+test("super base replaced after the class was defined", () => {
+    class C extends Base {
+        m() { return super.tag`x`; }
+    }
+    Object.setPrototypeOf(C.prototype, { tag: tagStrict });
+    const c = new C;
+    tagStrict.lastCall = null;
+    shouldBe(c.m(), c, "this is still the receiver when the tag comes from the replacement super base");
+    shouldBe(tagStrict.lastCall.thisValue, c, "the replacement tag is the one that was called");
+});
+
+test("arrow functions inside a method", () => {
+    class C extends Base {
+        dot() { return (() => super.tag`x`)(); }
+        bracket() { return (() => (() => super[key]`x`)())(); }
+    }
+    const c = new C;
+    shouldBe(c.dot(), c, "super.tag`x` inside an arrow function uses the method's this");
+    shouldBe(c.bracket(), c, "super[key]`x` inside nested arrow functions uses the method's this");
+});
+
+test("direct eval inside a method", () => {
+    class C extends Base {
+        dot() { return eval("super.tag`x`"); }
+        bracket() { return eval("super[key]`x`"); }
+    }
+    const c = new C;
+    shouldBe(c.dot(), c, "super.tag`x` in eval code");
+    shouldBe(c.bracket(), c, "super[key]`x` in eval code");
+});
+
+test("class field initializers", () => {
+    class C extends Base {
+        dot = super.tag`x`;
+        bracket = super[key]`x`;
+        static staticDot = super.tag`x`;
+        static staticBracket = super[key]`x`;
+    }
+    const c = new C;
+    shouldBe(c.dot, c, "instance field initializer, super.tag");
+    shouldBe(c.bracket, c, "instance field initializer, super[key]");
+    shouldBe(C.staticDot, C, "static field initializer, super.tag");
+    shouldBe(C.staticBracket, C, "static field initializer, super[key]");
+});
+
+test("generator and async methods", () => {
+    class C extends Base {
+        *generator() { yield super.tag`x`; yield super[key]`x`; }
+        async asyncMethod() { return [super.tag`x`, await null, super[key]`x`]; }
+    }
+    const c = new C;
+    const results = Array.from(c.generator());
+    shouldBe(results[0], c, "generator method, super.tag");
+    shouldBe(results[1], c, "generator method, super[key]");
+
+    let asyncResult;
+    let asyncError;
+    c.asyncMethod().then((value) => { asyncResult = value; }, (error) => { asyncError = error; });
+    drainMicrotasks();
+    if (asyncError)
+        throw asyncError;
+    shouldBe(asyncResult[0], c, "async method, super.tag before an await");
+    shouldBe(asyncResult[2], c, "async method, super[key] after an await");
+});
+
+test("derived constructor after super()", () => {
+    let seen;
+    class C extends Base {
+        constructor() {
+            super();
+            seen = [super.tag`x`, super[key]`x`, this];
+        }
+    }
+    const c = new C;
+    shouldBe(seen[2], c, "sanity: this is the constructed object");
+    shouldBe(seen[0], c, "super.tag`x` after super() is called with the new object");
+    shouldBe(seen[1], c, "super[key]`x` after super() is called with the new object");
+});
+
+test("derived constructor before super(): this is in its TDZ", () => {
+    // Nothing belonging to the tagged template may run before the uninitialized |this| is detected: neither the
+    // key of super[key] nor the substitutions. This is the order super[key]() and a plain super[key] read already use.
+    const log = [];
+    const evaluatedKey = () => { log.push("key"); return "tag"; };
+    const substitution = () => { log.push("substitution"); return 1; };
+    Base.lastCall = null;
+
+    class Dot extends Base {
+        constructor() { super.tag`${substitution()}`; super(); }
+    }
+    shouldThrowReferenceError(() => new Dot, "super.tag`...` before super()");
+
+    class Bracket extends Base {
+        constructor() { super[evaluatedKey()]`${substitution()}`; super(); }
+    }
+    shouldThrowReferenceError(() => new Bracket, "super[key]`...` before super()");
+
+    class InArrow extends Base {
+        constructor() { (() => super[evaluatedKey()]`${substitution()}`)(); super(); }
+    }
+    shouldThrowReferenceError(() => new InArrow, "super[key]`...` in an arrow function before super()");
+
+    shouldBe(log.length, 0, `neither the key nor the substitutions were evaluated (evaluated: ${log.join()})`);
+    shouldBe(Base.lastCall, null, "the tag was never called");
+});
+
+test("tags that are not super references keep their this", () => {
+    const object = { tag: tagStrict, 0: tagStrict };
+    const log = [];
+    function base() { log.push("base"); return object; }
+    function property() { log.push("key"); return "tag"; }
+    shouldBe(object.tag`x`, object, "object.tag`x`");
+    shouldBe(object["tag"]`x`, object, "object[\"tag\"]`x`");
+    shouldBe(object[0]`x`, object, "object[0]`x`");
+    shouldBe(base()[property()]`x`, object, "base()[key()]`x` is called with the base");
+    shouldBe(log.join(), "base,key", "base()[key()]`x` evaluates the base before the key");
+    shouldBe(tagStrict`x`, undefined, "tag`x` through a binding is called with undefined");
+    class C extends Base {
+        other() { return object.tag`x`; }
+        own() { return this.tag`x`; }
+    }
+    const c = new C;
+    shouldBe(c.other(), object, "object.tag`x` inside a method is called with the object");
+    shouldBe(c.own(), c, "this.tag`x` is called with this");
+});
+
+test("optimized tiers", () => {
+    class C extends Base {
+        dot() { return super.tag`x`; }
+        bracket() { return super[key]`x`; }
+    }
+    noInline(C.prototype.dot);
+    noInline(C.prototype.bracket);
+    const c = new C;
+    for (let i = 0; i < testLoopCount; ++i) {
+        if (c.dot() !== c)
+            throw new Error(`super.tag\`x\` was called with the wrong this on iteration ${i}`);
+        if (c.bracket() !== c)
+            throw new Error(`super[key]\`x\` was called with the wrong this on iteration ${i}`);
+    }
+});
+
+if (failures.length)
+    throw new Error(`FAIL:\n${failures.join("\n")}`);

--- a/test/js/bun/jsc-stress/jsc-stress.test.ts
+++ b/test/js/bun/jsc-stress/jsc-stress.test.ts
@@ -121,6 +121,8 @@ const jsFixtures = [
   "varargs-inlined-simple-exit.js",
   "loop-unrolling.js",
   "licm-no-pre-header.js",
+  // Bytecode generator
+  "tagged-templates-super-this.js",
 ];
 
 const wasmFixtures = [

--- a/test/js/bun/jsc-stress/preload.js
+++ b/test/js/bun/jsc-stress/preload.js
@@ -32,3 +32,6 @@ globalThis.fullGC = jsc.fullGC;
 globalThis.edenGC = jsc.edenGC;
 globalThis.numberOfDFGCompiles = jsc.numberOfDFGCompiles;
 globalThis.noDFG = jsc.noFTL;
+
+// drainMicrotasks: the jsc shell's way of settling promises synchronously.
+globalThis.drainMicrotasks = jsc.drainMicrotasks;


### PR DESCRIPTION
### Problem
- `super.tag\`x\`` inside a method calls `tag` with `this` = the object the property was found on (`Base.prototype` for a class, the `[[Prototype]]` for an object literal method) instead of the receiver. `super.tag()` in the same method gets the receiver, and so does node; the spec gives both forms the same `this` (EvaluateCall step 1.a.i: GetThisValue of a Super Reference). Same for `super[key]\`x\``.
- A smaller consequence of the same code: in a derived constructor that has not called `super()` yet, `super[key()]\`x\`` evaluated `key()` before throwing the ReferenceError for the uninitialized `this`; `super[key()]()` and a plain `super[key()]` read throw first (node does too).
- Not the transpiler: `bun build --no-bundle` prints the tagged template unchanged and the same code misbehaves through `new Function`. The cause is in JavaScriptCore, `TaggedTemplateNode::emitBytecode` (`Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp`): one register, `base`, serves both as the object the tag is looked up on and as the call's `this`. For a super reference it already looked the property up with the right receiver, then moved `base` (the home object's prototype) into the call's `this` register. The super call nodes (`FunctionCallDotNode`, `FunctionCallBracketNode`) keep the two apart. Upstream WebKit has the same code.
- Found by inspection while working on the transpiler's decorator lowering of super accesses (that lowering emits `.bind(this)` and is unaffected); there is no user report. It affects every plain JS/TS class or object literal method that forwards to an inherited tag this way.

### Fix
- oven-sh/WebKit#438: the two super branches of `TaggedTemplateNode::emitBytecode` now do what the call nodes do, `ensureThis()` (which is also the `this` TDZ check) first, then the super base for the lookup, and the call receives the `this` register instead of the super base. Non-super tags emit the same bytecode as before.
- Correct because a super property reference's `this` value is by definition the enclosing method's `this` (that is what makes it a Super Reference); the lookup base and the call receiver are different objects, and the engine already used the right receiver for the property read, only the call used the wrong one. Matches node.
- This PR pins `WEBKIT_VERSION` at that PR's preview build (`autobuild-preview-pr-438-31f493c1`) so CI runs Bun against it. Before landing, oven-sh/WebKit#438 has to merge and `WEBKIT_VERSION` has to be repointed at the resulting main sha (the build prints that exact instruction once the preview release disappears).
- The preview is built on current fork main, so relative to the `f0f60fd2` pin it also carries three fork commits that have their own Bun PRs: oven-sh/WebKit#420 (vm.Script compile reuse, #38040), oven-sh/WebKit#437 (threadsafe FFI callback teardown, #38660) and oven-sh/WebKit#421 (i64/u64 FFI argument conversion, #38091). Nothing here depends on them; the existing jsc-stress FFI fixtures pass with this pin, and whichever bump lands first carries them.
- Test: `test/js/bun/jsc-stress/fixtures/tagged-templates-super-this.js`, the `JSTests/stress` file from the WebKit PR with the usual `// @bun` first line (so Bun hands the source to JSC verbatim, like the other fixtures; without it the transpiler rewrites `super["tag"]` to `super.tag` and drops the tag function's own `"use strict"`), registered in `jsc-stress.test.ts`. It covers `super.tag` and `super[key]` (variable, string literal, symbol and index keys) in instance methods, through an intermediate class, static methods, object literal methods (also called through an inheriting object), arrow functions, direct eval, instance and static field initializers, generator and async methods, and a derived constructor after `super()`; a getter on the super base; the template object, raw strings, substitution values and per-site template object caching; primitive receivers from a strict and a sloppy method, each compared against `super.tag()`; a replaced super base; the TDZ ordering (neither key nor substitutions run, tag never called); tags that are not super references keeping their `this`; and a `testLoopCount` loop through the JIT tiers. `jsc-stress/preload.js` gains `drainMicrotasks` (from `bun:jsc`), which the async case uses exactly as it would in the jsc shell (#38285 adds the identical line; whichever lands second gets a trivial overlap).
- Fail before: with the current pin (`f0f60fd2`), `bun bd test test/js/bun/jsc-stress/jsc-stress.test.ts -t tagged-templates-super-this` fails with 18 of the fixture's 20 groups reporting the prototype as `this` (plus `evaluated: key,key` for the TDZ group); the 2 non-super groups pass. The same file passes on node v26 (async group checked separately, node has no synchronous microtask drain).
- Pass after: with this pin, `bun bd test test/js/bun/jsc-stress/jsc-stress.test.ts` passes all 116 fixtures (debug + ASAN build; the new fixture takes about 0.7s there).
- Engine regression check: all 5614 `JSTests/stress` files, default variant, on the `jsc` shells of the `f0f60fd2` and preview release tarballs (details in the WebKit PR). The only deterministic differences are the new test (fail to pass) and 4 FFI tests that belong to the carried oven-sh/WebKit#421; everything else that differed between the two runs was load timeouts or concurrent-JIT timing and gives the same result on both engines when rerun alone. Non-super tagged templates compile to the same bytecode as before by construction (`thisValue` stays null on those paths), and the suite agrees.

### Background
- Bun links a prebuilt JavaScriptCore from oven-sh/WebKit; `scripts/build/deps/webkit.ts` pins which build. An engine fix lands as a WebKit PR plus a pin bump here, and `autobuild-preview-pr-*` tags let a bump PR run Bun's suite against the WebKit PR before it merges.
- `test/js/bun/jsc-stress/` runs files taken verbatim from WebKit's `JSTests/stress` under `bun`; `preload.js` supplies the jsc shell globals they use (`noInline`, `testLoopCount`, now `drainMicrotasks`), which is why the engine test can be shared with the WebKit PR as is.
- A method's home object is the object it was defined on (the class prototype, the class itself for static methods, the literal for object literal methods); `super.x` looks `x` up on the home object's prototype, but a Super Reference remembers the method's own `this` as the receiver, which is what getters and calls through it get.
- A tagged template `f\`...\`` is a call of `f` with the template object and the substitution values as arguments, and the spec computes its `this` exactly as for `f(...)`: for `o.f` it is `o`; for `super.f` it is the enclosing method's `this`, while the property itself is looked up on the home object's prototype (`Base.prototype`). JSC's bytecode generator has separate AST nodes for calls and tagged templates, and only the call nodes handled the super case.
- `ensureThis()` in JSC's bytecode generator returns the register holding the function's `this`, after checking it is initialized when the code is a derived constructor (where `this` is in a TDZ until `super()` returns). Emitting it before the key expression is what fixes the evaluation order.

<details>
<summary>Repro</summary>

```js
class Base { tag() { return this; } f() { return this; } }
class C extends Base {
  m() { return [super.tag`x` === this, super.f() === this]; }
}
console.log(JSON.stringify(new C().m()));

const o = { __proto__: { tag() { return this === o ? "o" : "proto"; } }, m() { return super.tag`x`; } };
console.log(o.m());
```

```
bun 1.4.0 (WebKit f0f60fd2):   [false,true]   proto
node v26:                      [true,true]    o
this PR:                       [true,true]    o
```

</details>
