### PR TITLE
inspect: clear exceptions thrown by property lookups in forEachProperty

### DIFF
--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -320,9 +320,6 @@ static JSValue defaultBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, vm.propertyNames->defaultKeyword));
 }
@@ -332,9 +329,6 @@ static JSValue constructBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     auto clientData = WebCore::clientData(vm);
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, clientData->builtinNames().SQLPublicName()));

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5627,10 +5627,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
                 // Ignore exceptions from "Get" proxy traps.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto
@@ -5702,7 +5703,12 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue prototype = iterating->getPrototype(globalObject);
+            // Ignore exceptions from "getPrototypeOf" proxy traps.
+            CLEAR_IF_EXCEPTION(scope);
+            if (!prototype) [[unlikely]]
+                break;
+            iterating = prototype.getObject();
         }
     }
 

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -2077,14 +2077,17 @@ extern "C" napi_status napi_get_all_property_names(
             if (key_mode == napi_key_include_prototypes) {
                 // Climb up the prototype chain to find inherited properties
                 while (!owner->getOwnPropertyDescriptor(globalObject, propKey, desc)) {
-                    JSObject* proto = owner->getPrototype(globalObject).getObject();
-                    if (!proto) {
+                    NAPI_RETURN_IF_EXCEPTION(env);
+                    JSValue proto = owner->getPrototype(globalObject);
+                    NAPI_RETURN_IF_EXCEPTION(env);
+                    if (!proto.isObject()) {
                         break;
                     }
-                    owner = proto;
+                    owner = asObject(proto);
                 }
             } else {
                 owner->getOwnPropertyDescriptor(globalObject, propKey, desc);
+                NAPI_RETURN_IF_EXCEPTION(env);
             }
 
             // V8 never applies ONLY_WRITABLE/ONLY_CONFIGURABLE to Proxy keys

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -928,3 +928,71 @@ describe.skipIf(!isASAN)("object mutated while being formatted", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+// The slow property walk (objects with static tables, proxies in the prototype
+// chain) looks each property up with getPropertySlot. When that lookup threw,
+// the exception stayed pending while the walk moved on to the next property,
+// and the prototype step dereferenced the empty value a throwing getPrototype
+// returns. Run in a child: before the fix these abort or segfault.
+describe.concurrent("property lookup throws while formatting", () => {
+  async function run(code) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code],
+      env: {
+        ...bunEnv,
+        // Skip symbolizing a failure report; symbolization of the debug
+        // binary takes longer than the test timeout.
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "symbolize=0"].filter(Boolean).join(":"),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  it("lazy static property whose builder throws", async () => {
+    // Formatting Bun reifies its static table. Its first entry is `$`, whose
+    // builder calls into JS. Right after a stack overflow unwinds, native code
+    // may still run but JSC refuses to enter JS, so at the first depth where
+    // Bun.inspect(Bun) gets through, `$` throws and the entries after it must
+    // still be walked.
+    expect(
+      await run(`
+        let result;
+        function recurse() {
+          try { recurse(); } catch {}
+          if (result === undefined) {
+            try { result = Bun.inspect(Bun); } catch {}
+          }
+        }
+        recurse();
+        console.log(result.includes("Archive: [class Archive]"), result.includes("$:"));
+      `),
+    ).toEqual({ stdout: "true false\n", stderr: "", exitCode: 0 });
+  });
+
+  it("proxy get trap in the prototype chain throws", async () => {
+    expect(
+      await run(`
+        const proto = new Proxy({}, {
+          ownKeys() { return ["a", "b"]; },
+          get(target, key) {
+            if (key === "a") throw new Error("a");
+            return key === "b" ? 2 : undefined;
+          },
+        });
+        console.log(Bun.inspect(Object.create(proto)));
+      `),
+    ).toEqual({ stdout: "{\n  b: 2,\n}\n", stderr: "", exitCode: 0 });
+  });
+
+  it("proxy getPrototypeOf trap in the prototype chain throws", async () => {
+    expect(
+      await run(`
+        const proto = new Proxy({}, { getPrototypeOf() { throw new Error("x"); } });
+        console.log(Bun.inspect(Object.create(proto)));
+      `),
+    ).toEqual({ stdout: "{}\n", stderr: "", exitCode: 0 });
+  });
+});

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -952,13 +952,23 @@ describe.concurrent("property lookup throws while formatting", () => {
   }
 
   it("lazy static property whose builder throws", async () => {
-    // Formatting Bun reifies its static table. Its first entry is `$`, whose
-    // builder calls into JS. Right after a stack overflow unwinds, native code
-    // may still run but JSC refuses to enter JS, so at the first depth where
-    // Bun.inspect(Bun) gets through, `$` throws and the entries after it must
-    // still be walked.
+    // Formatting Bun reifies its static table, and the builders of `$`, `sql`,
+    // `postgres` and `SQL` call into JS. Right after a stack overflow unwinds,
+    // native code may still run but JSC refuses to enter JS, so at the first
+    // depth where Bun.inspect(Bun) gets through those builders throw, and the
+    // entry after the last of them is only printed if the walk kept going
+    // (debug builds used to abort instead).
+    //
+    // process.env and util.inspect are set up before recursing: creating
+    // either one enters JS too, and failing inside their lazy initializers
+    // aborts the process regardless of this fix (Bun.env is a Proxy with a
+    // custom inspect function on Windows).
     expect(
       await run(`
+        void process.env;
+        Bun.inspect({ [Symbol.for("nodejs.util.inspect.custom")]() { return ""; } });
+        const names = Object.getOwnPropertyNames(Bun);
+        const afterSQL = names[names.indexOf("SQL") + 1];
         let result;
         function recurse() {
           try { recurse(); } catch {}
@@ -967,9 +977,9 @@ describe.concurrent("property lookup throws while formatting", () => {
           }
         }
         recurse();
-        console.log(result.includes("Archive: [class Archive]"), result.includes("$:"));
+        console.log(result.includes("\\n  " + afterSQL + ":"));
       `),
-    ).toEqual({ stdout: "true false\n", stderr: "", exitCode: 0 });
+    ).toEqual({ stdout: "true\n", stderr: "", exitCode: 0 });
   });
 
   it("proxy get trap in the prototype chain throws", async () => {

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -321,6 +321,69 @@ nativeTests.test_get_all_property_names_proxy_and_string_wrapper = () => {
   show("frozen writable:", apn(Object.freeze({ a: 1, b: 2 }), napi_key_writable));
 };
 
+// A trap that throws while the keys are being filtered must surface as the
+// thrown exception, both when the proxy is the object itself and when it is
+// found while climbing the prototype chain.
+nativeTests.test_get_all_property_names_throwing_trap = () => {
+  const napi_key_include_prototypes = 0;
+  const napi_key_own_only = 1;
+  const napi_key_enumerable = 1 << 1;
+  const napi_key_keep_numbers = 0;
+
+  const proxy = new Proxy(
+    {},
+    {
+      ownKeys: () => ["x"],
+      getOwnPropertyDescriptor() {
+        throw new Error("getOwnPropertyDescriptor trap");
+      },
+    },
+  );
+  for (const [label, object, mode] of [
+    ["own_only proxy:", proxy, napi_key_own_only],
+    ["include_prototypes proxy-proto:", Object.create(proxy), napi_key_include_prototypes],
+  ]) {
+    try {
+      const r = nativeTests.get_all_property_names(object, mode, napi_key_enumerable, napi_key_keep_numbers);
+      console.log(label, "returned status=" + r.status, "keys=" + JSON.stringify(r.keys));
+    } catch (e) {
+      console.log(label, "threw", e.message);
+    }
+  }
+};
+
+// Bun walks the chain once to collect the keys and again to filter them, so a
+// getPrototypeOf trap can succeed while collecting and throw while filtering.
+// Node only walks once and never sees the second call, so this is not compared
+// against it.
+nativeTests.test_get_all_property_names_throwing_get_prototype_of = () => {
+  const napi_key_include_prototypes = 0;
+  const napi_key_enumerable = 1 << 1;
+  const napi_key_keep_numbers = 0;
+
+  let calls = 0;
+  const proxy = new Proxy(
+    {},
+    {
+      getPrototypeOf() {
+        if (++calls > 1) throw new Error("getPrototypeOf trap");
+        return { z: 1 };
+      },
+    },
+  );
+  try {
+    const r = nativeTests.get_all_property_names(
+      Object.create(proxy),
+      napi_key_include_prototypes,
+      napi_key_enumerable,
+      napi_key_keep_numbers,
+    );
+    console.log("returned status=" + r.status, "keys=" + JSON.stringify(r.keys));
+  } catch (e) {
+    console.log("threw", e.message);
+  }
+};
+
 nativeTests.test_set_property = () => {
   const objects = [
     {},

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -880,6 +880,17 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
       expect(output).toContain(`plain writable: status=0 keys=["w","nc"]`);
       expect(output).toContain(`frozen writable: status=0 keys=[]`);
     });
+    it("reports a trap that throws while filtering instead of leaving it pending", async () => {
+      const output = await checkSameOutput("test_get_all_property_names_throwing_trap", []);
+      expect(output.split(/\r?\n/)).toEqual([
+        "own_only proxy: threw getOwnPropertyDescriptor trap",
+        "include_prototypes proxy-proto: threw getOwnPropertyDescriptor trap",
+      ]);
+    });
+    it("reports a getPrototypeOf trap that throws while filtering", async () => {
+      const output = await runOn(bunExe(), "test_get_all_property_names_throwing_get_prototype_of", []);
+      expect(output.trim()).toBe("threw getPrototypeOf trap");
+    });
   });
 
   describe("napi_value <=> integer conversion", () => {


### PR DESCRIPTION
### What does this PR do?

Fixes a fuzzer-found abort in the property walk behind `Bun.inspect` / `console.log` (`JSC__JSValue__forEachPropertyImpl`, the slow path used for objects with static tables and for prototype chains containing exotic objects).

The loop looked each property up with `getPropertySlot` and `continue`d when it returned false. If the lookup returned false *because it threw*, the exception stayed pending and the walk carried on:

* A lazy static property whose builder throws (`Bun.$` calls into JS to build the shell object, which throws a stack overflow when the formatter runs right after unwinding one) leaves its exception pending; the next entry in the table (`Bun.Archive`) is reified through the Rust host call wrapper, whose exception scope then asserts. This is the fuzzer crash (`releaseAssertNoException` while formatting the `Bun` object for an `ERR_INVALID_ARG_VALUE` message).
* A proxy in the prototype chain whose `get` trap throws does the same thing. Once the exception is pending, the prototype step at the end of the loop (`iterating->getPrototype(globalObject).getObject()`) gets the empty value back from the proxy and dereferences it: release builds segfault at address `0x5` on `Bun.inspect(Object.create(new Proxy({}, { get() { throw 1 } })))` with any keys reported by `ownKeys`. A `getPrototypeOf` trap that throws hits the same dereference without needing the first bug.

The fix clears the exception regardless of what `getPropertySlot` returned (this is already what `forEachPropertyOrdered` does a few lines down), and stops walking the chain when `getPrototype` throws.

`napi_get_all_property_names` had the same `getPrototype(...).getObject()` chain in its filter loop (found in review). A `getOwnPropertyDescriptor` trap that throws, or a `getPrototypeOf` trap that throws on the second walk, segfaulted at the same address there; it now returns `napi_pending_exception` like the key collection step above it already did. That is the only other site with the pattern under `src/jsc/bindings`; the fast path of `forEachPropertyImpl` and `forEachPropertyOrdered` already handle both cases.

With the walk fixed, the fuzzer script got further and tripped a second debug-only assertion: the `Bun.sql` / `Bun.SQL` builders reported a failed internal module load via `reportUncaughtExceptionAtEventLoop` while that exception was still pending (`#if BUN_DEBUG` block). Running the uncaught exception handler with an exception pending makes `process->get("_fatalException")` reify the static entry but report it as missing, which fails a structure assertion in `getPropertySlot`. Every other caller of `reportUncaughtExceptionAtEventLoop` clears first, and the exception is propagated to whoever touched the property anyway, so the block is removed rather than reworked.

Not changed here: two lazy initializers that enter JS (`process.env` on Windows, and the `util.inspect` function used for `inspect.custom`) still abort the process when they fail at the stack limit. That is independent of the walk (it reproduces on main without any of this) and is tracked separately; the static table test below sets both up before recursing so it does not run into them.

### How did you verify your code works?

* The fuzzer script aborts within a second on an unfixed debug build; with this change it runs to the same result as a release build (the `ERR_INVALID_ARG_VALUE` error, exit code 1, no assertions). The Proxy variants segfault on the current canary release build and print `{ b: 2 }` / `{}` with the fix.
* `test/js/bun/util/inspect.test.js`: three tests, each run in a child process. All three fail with `USE_SYSTEM_BUN=1` (truncated output for the static table case, dead child for the proxy cases) and pass with `bun bd test`. The static table test inspects `Bun` at every depth while unwinding a stack overflow and checks that the entry after the last builder that needs JS (`$`, `sql`, `postgres`, `SQL` all fail there) is still printed. Checked on Linux (debug+ASAN build, and the unfixed release canary prints `false`) and on Windows x64 (debug build of this branch prints `true`, the unfixed canary prints `false`); the first version of this test died on Windows because of the `process.env` initializer mentioned above.
* `test/napi/napi.test.ts`: two new cases under `napi_get_all_property_names`. The throwing `getOwnPropertyDescriptor` case is compared against Node; the stateful `getPrototypeOf` case is Bun only, since Node walks the chain once and never calls the trap a second time. Both segfault with `USE_SYSTEM_BUN=1` and pass with the debug build.
* The rest of `inspect.test.js`, `bun-inspect.test.ts`, `custom-inspect.test.js`, `BunObject.test.ts`, `console-table.test.ts`, `node-inspect-tests/` and the `napi_get_all_property_names` describe block pass locally.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/inspect.test.js test/napi/napi.test.ts

<!-- robobun:evidence:end -->