### PR TITLE
inspect: display a class or function name set with Object.defineProperty

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4899,9 +4899,7 @@ void JSC__VM__releaseWeakRefs(JSC::VM* arg0)
     arg0->finalizeSynchronousJSExecution();
 }
 
-// A "name" redefined with Object.defineProperty (tsc's __setFunctionName, esbuild's and Bun's
-// __name) is what node displays; JSC's calculatedDisplayName() only looks at "displayName" and
-// the executable. "displayName" keeps its precedence.
+// A "name" set with Object.defineProperty, which JSC's calculatedDisplayName() does not consult.
 static WTF::String explicitFunctionName(JSC::VM& vm, JSC::JSFunction* function)
 {
     if (!function->displayName(vm).isEmpty()) {
@@ -4916,8 +4914,7 @@ static WTF::String explicitFunctionName(JSC::VM& vm, JSC::JSFunction* function)
     return WTF::String();
 }
 
-// The function JSObject::calculatedClassName() would name an object after: its own
-// "constructor" (prototype objects) or its prototype's (instances).
+// The constructor JSObject::calculatedClassName() names an object after.
 static JSC::JSFunction* constructorForClassName(JSC::VM& vm, JSC::JSObject* object)
 {
     JSC::JSValue constructor = object->getDirect(vm, vm.propertyNames->constructor);

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4899,6 +4899,38 @@ void JSC__VM__releaseWeakRefs(JSC::VM* arg0)
     arg0->finalizeSynchronousJSExecution();
 }
 
+// A "name" redefined with Object.defineProperty (tsc's __setFunctionName, esbuild's and Bun's
+// __name) is what node displays; JSC's calculatedDisplayName() only looks at "displayName" and
+// the executable. "displayName" keeps its precedence.
+static WTF::String explicitFunctionName(JSC::VM& vm, JSC::JSFunction* function)
+{
+    if (!function->displayName(vm).isEmpty()) {
+        return WTF::String();
+    }
+
+    JSC::JSValue name = function->getDirect(vm, vm.propertyNames->name);
+    if (name && JSC::isJSString(name)) {
+        return JSC::asString(name)->tryGetValue();
+    }
+
+    return WTF::String();
+}
+
+// The function JSObject::calculatedClassName() would name an object after: its own
+// "constructor" (prototype objects) or its prototype's (instances).
+static JSC::JSFunction* constructorForClassName(JSC::VM& vm, JSC::JSObject* object)
+{
+    JSC::JSValue constructor = object->getDirect(vm, vm.propertyNames->constructor);
+    if (!constructor && !object->structure()->typeInfo().overridesGetPrototype()) {
+        JSC::JSValue prototype = object->getPrototypeDirect();
+        if (prototype.isObject()) {
+            constructor = JSC::asObject(prototype)->getDirect(vm, vm.propertyNames->constructor);
+        }
+    }
+
+    return constructor ? dynamicDowncast<JSC::JSFunction>(constructor) : nullptr;
+}
+
 void JSC__JSValue__getClassName(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* arg1, ZigString* arg2)
 {
     JSValue value = JSValue::decode(JSValue0);
@@ -4918,6 +4950,14 @@ void JSC__JSValue__getClassName(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObjec
     }
 
     JSObject* obj = value.toObject(arg1);
+
+    if (JSC::JSFunction* constructor = constructorForClassName(arg1->vm(), obj)) {
+        auto explicitName = explicitFunctionName(arg1->vm(), constructor);
+        if (!explicitName.isEmpty()) {
+            *arg2 = Zig::toZigString(explicitName);
+            return;
+        }
+    }
 
     auto calculated = JSObject::calculatedClassName(obj);
     if (calculated.length() > 0) {
@@ -4961,6 +5001,11 @@ void JSC__JSValue__getNameProperty(JSC::EncodedJSValue JSValue0, JSC::JSGlobalOb
     }
 
     if (JSC::JSFunction* function = dynamicDowncast<JSC::JSFunction>(obj)) {
+        WTF::String explicitName = explicitFunctionName(vm, function);
+        if (!explicitName.isEmpty()) {
+            *arg2 = Zig::toZigString(explicitName);
+            return;
+        }
 
         WTF::String actualName = function->name(vm);
         if (!actualName.isEmpty() || function->isHostOrBuiltinFunction()) {
@@ -4992,6 +5037,14 @@ void JSC__JSValue__getNameProperty(JSC::EncodedJSValue JSValue0, JSC::JSGlobalOb
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
     JSObject* object = value.getObject();
+    if (JSC::JSFunction* function = dynamicDowncast<JSC::JSFunction>(object)) {
+        auto explicitName = explicitFunctionName(vm, function);
+        if (!explicitName.isEmpty()) {
+            *arg2 = Bun::toStringRef(explicitName);
+            return;
+        }
+    }
+
     auto displayName = JSC::getCalculatedDisplayName(vm, object);
 
     // JSC doesn't include @@toStringTag in calculated display name

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4899,19 +4899,21 @@ void JSC__VM__releaseWeakRefs(JSC::VM* arg0)
     arg0->finalizeSynchronousJSExecution();
 }
 
-// A "name" set with Object.defineProperty, which JSC's calculatedDisplayName() does not consult.
-static WTF::String explicitFunctionName(JSC::VM& vm, JSC::JSFunction* function)
+// Null unless the program redefined "name" (tsc's __setFunctionName, __name); a name JSC merely reified stays as printed today.
+static WTF::String redefinedFunctionName(JSC::VM& vm, JSC::JSFunction* function)
 {
-    if (!function->displayName(vm).isEmpty()) {
+    JSC::FunctionRareData* rareData = function->rareData();
+    if (!rareData || !rareData->hasModifiedNameForBoundOrNonHostFunction() || !function->displayName(vm).isEmpty()) {
         return WTF::String();
     }
 
     JSC::JSValue name = function->getDirect(vm, vm.propertyNames->name);
-    if (name && JSC::isJSString(name)) {
-        return JSC::asString(name)->tryGetValue();
+    if (!name || !JSC::isJSString(name)) {
+        return WTF::String();
     }
 
-    return WTF::String();
+    // Empty when the program made the function anonymous; callers print it like any anonymous function.
+    return JSC::asString(name)->tryGetValue();
 }
 
 // The constructor JSObject::calculatedClassName() names an object after.
@@ -4949,9 +4951,10 @@ void JSC__JSValue__getClassName(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObjec
     JSObject* obj = value.toObject(arg1);
 
     if (JSC::JSFunction* constructor = constructorForClassName(arg1->vm(), obj)) {
-        auto explicitName = explicitFunctionName(arg1->vm(), constructor);
-        if (!explicitName.isEmpty()) {
-            *arg2 = Zig::toZigString(explicitName);
+        auto redefinedName = redefinedFunctionName(arg1->vm(), constructor);
+        if (!redefinedName.isNull()) {
+            // Empty: same fallback as an instance of an anonymous class takes below.
+            *arg2 = redefinedName.isEmpty() ? Zig::toZigString(view) : Zig::toZigString(redefinedName);
             return;
         }
     }
@@ -4998,9 +5001,9 @@ void JSC__JSValue__getNameProperty(JSC::EncodedJSValue JSValue0, JSC::JSGlobalOb
     }
 
     if (JSC::JSFunction* function = dynamicDowncast<JSC::JSFunction>(obj)) {
-        WTF::String explicitName = explicitFunctionName(vm, function);
-        if (!explicitName.isEmpty()) {
-            *arg2 = Zig::toZigString(explicitName);
+        WTF::String redefinedName = redefinedFunctionName(vm, function);
+        if (!redefinedName.isNull()) {
+            *arg2 = Zig::toZigString(redefinedName);
             return;
         }
 
@@ -5034,15 +5037,13 @@ void JSC__JSValue__getNameProperty(JSC::EncodedJSValue JSValue0, JSC::JSGlobalOb
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
     JSObject* object = value.getObject();
+    WTF::String displayName;
     if (JSC::JSFunction* function = dynamicDowncast<JSC::JSFunction>(object)) {
-        auto explicitName = explicitFunctionName(vm, function);
-        if (!explicitName.isEmpty()) {
-            *arg2 = Bun::toStringRef(explicitName);
-            return;
-        }
+        displayName = redefinedFunctionName(vm, function);
     }
-
-    auto displayName = JSC::getCalculatedDisplayName(vm, object);
+    if (displayName.isNull()) {
+        displayName = JSC::getCalculatedDisplayName(vm, object);
+    }
 
     // JSC doesn't include @@toStringTag in calculated display name
     if (displayName.isEmpty()) {

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -617,6 +617,55 @@ describe("console.logging class displays names and extends", async () => {
   }
 });
 
+describe("a name defined with Object.defineProperty is displayed", () => {
+  // tsc (__setFunctionName) and esbuild/Bun (__name) name the anonymous class their decorator
+  // lowering produces this way; the class binding they assign to is a temporary.
+  function setName(value, name) {
+    return Object.defineProperty(value, "name", { value: name, configurable: true });
+  }
+  class Base {}
+  const Item = setName(class {}, "Item");
+  const Derived = setName(class extends Base {}, "Derived");
+
+  it("class and instances", () => {
+    expect([Bun.inspect(Item), Bun.inspect(new Item()), Bun.inspect({ item: new Item() }, { compact: true })]).toEqual([
+      "[class Item]",
+      "Item {}",
+      "{ item: Item {} }",
+    ]);
+  });
+
+  it("extends clause and subclass instances", () => {
+    class Child extends Item {}
+    expect([Bun.inspect(Derived), Bun.inspect(new Derived()), Bun.inspect(Child), Bun.inspect(Item.prototype)]).toEqual(
+      ["[class Derived extends Base]", "Derived {}", "[class Child extends Item]", "Item {}"],
+    );
+  });
+
+  it("functions", () => {
+    expect(Bun.inspect(setName(function original() {}, "renamed"))).toBe("[Function: renamed]");
+  });
+
+  it("displayName still takes precedence", () => {
+    const fn = setName(function original() {}, "renamed");
+    fn.displayName = "Display";
+    expect(Bun.inspect(fn)).toBe("[Function: Display]");
+  });
+
+  it("a name accessor is not invoked", () => {
+    let called = false;
+    const Cls = Object.defineProperty(class Original {}, "name", {
+      get() {
+        called = true;
+        return "from getter";
+      },
+    });
+    expect(Bun.inspect(Cls)).toBe("[class Original]");
+    expect(Bun.inspect(new Cls())).toBe("Original {}");
+    expect(called).toBe(false);
+  });
+});
+
 it("console.log on a Blob shows name", () => {
   const blob = new Blob(["foo"], { type: "text/plain" });
   expect(Bun.inspect(blob)).toBe('Blob (3 bytes) {\n  type: "text/plain;charset=utf-8"\n}');

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -664,6 +664,28 @@ describe("a name defined with Object.defineProperty is displayed", () => {
     expect(Bun.inspect(new Cls())).toBe("Original {}");
     expect(called).toBe(false);
   });
+
+  it("a name redefined as empty prints like an anonymous function", () => {
+    const Unnamed = setName(class Original {}, "");
+    class Child extends Unnamed {}
+    expect([
+      Bun.inspect(Unnamed),
+      Bun.inspect(new Unnamed()),
+      Bun.inspect({ u: new Unnamed() }, { compact: true }),
+      Bun.inspect(Child),
+      Bun.inspect(setName(function original() {}, "")),
+    ]).toEqual(["[class (anonymous)]", "{}", "{ u: {} }", "[class Child]", "[Function]"]);
+  });
+
+  it("reading .name does not change the output of an untouched function", () => {
+    const { get } = Object.getOwnPropertyDescriptor({ get accessor() {} }, "accessor");
+    const Cls = class {};
+    const holder = { key: function () {} };
+    const values = [get, Cls, new Cls(), holder.key];
+    const before = values.map(value => Bun.inspect(value));
+    expect([get.name, Cls.name, holder.key.name]).toEqual(["get accessor", "Cls", "key"]);
+    expect(values.map(value => Bun.inspect(value))).toEqual(before);
+  });
 });
 
 it("console.log on a Blob shows name", () => {


### PR DESCRIPTION
### Problem

- A class or function whose `name` was set with `Object.defineProperty` is displayed under the name of the binding it was created in:
  ```js
  const Item = (() => { const _classThis = class {}; Object.defineProperty(_classThis, "name", { value: "Item" }); return _classThis; })();
  console.log(Item, new Item(), { nested: new Item() });
  // bun 1.4.0: [class _classThis] _classThis {} { nested: _classThis {} }
  // node:      [class Item]       Item {}       { nested: Item {} }
  ```
  `Item.name` is `"Item"` in both. The same applies to `Bun.inspect`, to the `extends` clause (`[class Child extends _classThis]`), to bun:test output and snapshots, and to `[Function: ...]`.
- This is the shape of every anonymous class that goes through a decorator lowering: tsc emits `__setFunctionName(_classThis, "Item")` for standard decorators, and esbuild's `--keep-names` and Bun's own lowering (#38757) use the `__name` helper, so tsc-compiled decorated classes already display like this in Bun today.
- Cause: `JSC__JSValue__getName`, `JSC__JSValue__getNameProperty` and `JSC__JSValue__getClassName` in `src/jsc/bindings/bindings.cpp` take the name from JSC's `calculatedDisplayName()` / `calculatedClassName()`, which consult the `displayName` property and then the executable's name, never the `name` property.

### Fix

- `redefinedFunctionName`: when JSC records that the program touched the function's `name` property (`FunctionRareData::hasModifiedNameForBoundOrNonHostFunction`, set by `defineProperty`, assignment and `delete`), read the own `name` string data property with `getDirect` (accessors are not invoked) and display it; a `displayName` property still wins, as before. Applied in all three lookups; for instances and prototype objects, `constructorForClassName` finds the constructor the way `JSObject::calculatedClassName` does (own `constructor`, else the prototype's) and applies the same rule to it. A name redefined as `""` is honored too and takes the path an anonymous class already takes (`[class (anonymous)]`, `{}`); everything else falls through to the existing code.
- Correct because this is the name the program observes (`Item.name`) and the name node's `util.inspect` prints. Keying on the modified flag rather than on the property existing matters because JSC creates the `name` property lazily the first time `.name` is read (`JSFunction::reifyName`): keyed on presence, reading `.name` would change how a getter (`x` vs `get x`) or an anonymous `export default` prints; keyed on the flag, an untouched function prints exactly as today whether or not its name was reified, and only names the program redefined change output. The lookup has no side effects, which is also why a `name` accessor is ignored (node would call it).
- Verification: `test/js/bun/util/inspect.test.js`, new block `a name defined with Object.defineProperty is displayed`: class, instance, nested instance, `extends` clause, subclass of the renamed class, prototype object, function, a name redefined as empty, plus guards that `displayName` keeps precedence, that a `name` getter is not called, and that reading `.name` on a getter, a class, an instance and a property-initialized function leaves their output unchanged. 4 of the 7 fail on bun 1.4.0. `inspect.test.js`, `node/util/util.test.js`, `custom-inspect`, `bun-inspect`, `console-table`, `console-iterator`, `expect.test.js`, `jest-extended`, the snapshot tests and `error-name-preservation` pass with the debug build (`inspect-error.test.js` has two minified-file failures locally that are identical without this change).
- Related: #38517 / #38530 change the fallback in the same functions for anonymous `export default` (`starDefault`); this change adds a check before those fallbacks and composes with them. #38757 (decorator lowering switching to `__name`) is stacked on this branch so its output displays correctly from the start.

### Background

- JSC functions have two names: the executable's name, fixed when the function is created from its source position or binding (`_classThis` above), and the `name` property, which JSC creates lazily from the executable name and which `Object.defineProperty` can replace. `calculatedDisplayName()` is JSC's debugger-oriented helper and reads the executable side; `displayName` is a non-standard property JSC and Bun already honor for display.
- Bun's formatter (`src/jsc/ConsoleObject.rs`, and `pretty_format.rs` for bun:test) asks these three bindings for the text it prints: `get_name` for a function or class value and for the class in an `extends` clause, `get_class_name` for an instance (`Item {}`), and `get_name_property` for JSX tags and some bun:test paths.
- `getDirect` reads a property straight out of the object's own property storage: no prototype walk, no getters. JSC materializes a function's `name` property lazily on first access and, separately, flags in the function's `FunctionRareData` when the program has modified it; `JSFunction::canAssumeNameAndLengthAreOriginal` is JSC's own use of that flag, and this change uses it the same way.

