### PR TITLE
Make bun pm ls list installed packages instead of lockfile entries

### DIFF
--- a/completions/bun-cli.json
+++ b/completions/bun-cli.json
@@ -3368,7 +3368,7 @@
         },
         "ls": {
           "name": "ls",
-          "description": "list the dependency tree according to the current lockfile",
+          "description": "list the tree of installed dependencies",
           "flags": [],
           "positionalArgs": []
         },

--- a/completions/bun.zsh
+++ b/completions/bun.zsh
@@ -259,7 +259,7 @@ _bun_pm_completion() {
     cmd2)
         sub_commands=(
             'bin\:"print the path to bin folder" '
-            'ls\:"list the dependency tree according to the current lockfile" '
+            'ls\:"list the tree of installed dependencies" '
             'licenses\:"list installed packages grouped by license" '
             'hash\:"generate & print the hash of the current lockfile" '
             'hash-string\:"print the string used to hash the lockfile" '
@@ -295,7 +295,7 @@ _bun_pm_completion() {
             ;;
         ls)
             pmargs=(
-                "--all[list the entire dependency tree according to the current lockfile]"
+                "--all[list the entire tree of installed dependencies]"
                 "--trusted[list only trusted dependencies]"
             )
 

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -134,8 +134,8 @@ impl PackageManagerCommand {
   <d>└<r> <cyan>--quiet<r>                   only output the tarball filename
   <b><green>bun pm<r> <blue>bin<r>                  print the path to bin folder
   <d>└<r> <cyan>-g<r>                        print the <b>global<r> path to bin folder
-  <b><green>bun pm<r> <blue>ls<r>                   list the dependency tree according to the current lockfile
-  <d>├<r> <cyan>--all<r>                     list the entire dependency tree according to the current lockfile
+  <b><green>bun pm<r> <blue>ls<r>                   list the tree of installed dependencies
+  <d>├<r> <cyan>--all<r>                     list the entire tree of installed dependencies
   <d>└<r> <cyan>--trusted<r>                 list only trusted dependencies
   <b><green>bun pm<r> <blue>why<r> <d>\<pkg\><r>            show dependency tree explaining why a package is installed
   <b><green>bun pm<r> <blue>licenses<r>             list installed packages grouped by license

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -2260,7 +2260,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/why<r>
 
 <b>Commands:<r>
   <b><green>bun pm<r> <blue>bin<r>              print the path to bin folder
-  <b><green>bun pm<r> <blue>ls<r>               list the dependency tree according to the current lockfile
+  <b><green>bun pm<r> <blue>ls<r>               list the tree of installed dependencies
   <b><green>bun pm<r> <blue>whoami<r>           print the current npm username
   <b><green>bun pm<r> <blue>hash<r>             generate & print the hash of the current lockfile
   <b><green>bun pm<r> <blue>cache<r>            print the path to the cache folder

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -12,14 +12,14 @@ use bun_install::package_manager_real::{
     CommandLineArguments, Subcommand, fetch_cache_directory_path, get_cache_directory,
     package_manager_options::LogLevel, setup_global_dir,
 };
-use bun_install::{DependencyID, PackageID, PackageManager, migration};
-use bun_paths::{self as Path, PathBuffer};
+use bun_install::{DependencyID, PackageID, PackageManager, ResolutionTag, migration};
+use bun_paths::{self as Path, AutoAbsPath, PathBuffer};
 use bun_resolver::fs as Fs;
 use bun_sys::{self, Dir, Fd, File};
 
 use crate::cli::Command;
 use crate::cli::pm_diff_command as PmDiffCommand;
-use crate::cli::pm_licenses_command::{LicensesFlags, PmLicensesCommand};
+use crate::cli::pm_licenses_command::{BunStore, LicensesFlags, PmLicensesCommand};
 use crate::cli::pm_pkg_command::PmPkgCommand;
 use crate::cli::pm_trusted_command::{DefaultTrustedCommand, TrustCommand, UntrustedCommand};
 use crate::cli::pm_version_command::PmVersionCommand;
@@ -36,6 +36,83 @@ pub(crate) use crate::cli::scan_command::ScanCommand;
 pub(crate) struct NodeModulesFolder {
     relative_path: bun_core::ZBox,
     dependencies: Box<[DependencyID]>,
+}
+
+/// Disk-existence check for `bun pm ls`: the lockfile also contains entries
+/// that were never installed (platform-mismatched optionals) or were removed
+/// after install (`bun prune --production`), and those must not be listed as
+/// the contents of `node_modules`.
+struct InstalledFilter {
+    path: AutoAbsPath,
+    top_len: usize,
+    store: BunStore,
+}
+
+impl InstalledFilter {
+    fn init() -> Self {
+        let path = AutoAbsPath::init_top_level_dir();
+        let top_len = path.len();
+        Self {
+            path,
+            top_len,
+            store: BunStore::init(),
+        }
+    }
+
+    fn node_modules_exists(&mut self) -> bool {
+        self.path.set_length(self.top_len);
+        let _ = self.path.append(b"node_modules");
+        let exists = bun_sys::exists(self.path.slice());
+        self.path.set_length(self.top_len);
+        exists
+    }
+
+    fn is_installed(
+        &mut self,
+        lockfile: &Lockfile,
+        relative_path: &[u8],
+        dep_id: DependencyID,
+    ) -> bool {
+        let package_id = lockfile.buffers.resolutions.as_slice()[dep_id as usize];
+        if package_id as usize >= lockfile.packages.len() {
+            return false;
+        }
+        let slice = lockfile.packages.slice();
+        let resolution = &slice.items_resolution()[package_id as usize];
+        // Local sources (the project itself, workspaces, `bun link`ed packages)
+        // always exist on disk outside of node_modules.
+        if matches!(
+            resolution.tag,
+            ResolutionTag::Root | ResolutionTag::Workspace | ResolutionTag::Symlink
+        ) {
+            return true;
+        }
+
+        let buf = lockfile.buffers.string_bytes.as_slice();
+        let alias = lockfile.buffers.dependencies.as_slice()[dep_id as usize]
+            .name
+            .slice(buf);
+        self.path.set_length(self.top_len);
+        let _ = self.path.append(relative_path);
+        let _ = self.path.append(alias);
+        let exists = bun_sys::exists(self.path.slice());
+        self.path.set_length(self.top_len);
+        if exists {
+            return true;
+        }
+
+        // Isolated installs (`node_modules/.bun`) only link direct dependencies
+        // into each package's node_modules; transitive packages live in the store.
+        self.store
+            .lookup(
+                &mut self.path,
+                self.top_len,
+                slice.items_name()[package_id as usize],
+                resolution,
+                buf,
+            )
+            .is_some()
+    }
 }
 
 // Transient sort-comparator context; lifetime is fn-local.
@@ -186,8 +263,8 @@ impl PackageManagerCommand {
   <d>└<r> <cyan>--quiet<r>                   only output the tarball filename\n\
   <b><green>bun pm<r> <blue>bin<r>                  print the path to bin folder\n\
   <d>└<r> <cyan>-g<r>                        print the <b>global<r> path to bin folder\n\
-  <b><green>bun pm<r> <blue>ls<r>                   list the dependency tree according to the current lockfile\n\
-  <d>├<r> <cyan>--all<r>                     list the entire dependency tree according to the current lockfile\n\
+  <b><green>bun pm<r> <blue>ls<r>                   list the tree of installed dependencies\n\
+  <d>├<r> <cyan>--all<r>                     list the entire tree of installed dependencies\n\
   <d>└<r> <cyan>--trusted<r>                 list only trusted dependencies\n\
   <b><green>bun pm<r> <blue>why<r> <d>\\<pkg\\><r>            show dependency tree explaining why a package is installed\n\
   <b><green>bun pm<r> <blue>diff<r> <d>[a] [b]<r>           show what changed between two versions of a package (or vs a folder/tarball)\n\
@@ -563,10 +640,21 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
             Output::flush();
             Output::disable_buffering();
             let lockfile: &Lockfile = &pm.lockfile;
+
+            let mut installed = InstalledFilter::init();
+            if !installed.node_modules_exists() {
+                if log_level != LogLevel::Silent {
+                    Output::err_generic("node_modules not found, nothing to list", ());
+                    bun_core::note!("run 'bun install' first");
+                }
+                Global::exit(1);
+            }
+
             let mut iterator =
                 tree::Iterator::<{ tree::IteratorPathStyle::NodeModules }>::init(lockfile);
 
             let mut max_depth: usize = 0;
+            let mut installed_count: usize = 0;
 
             let mut directories: Vec<NodeModulesFolder> = Vec::new();
             while let Some(node_modules) = iterator.next(None) {
@@ -575,7 +663,19 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
                 path.extend_from_slice(node_modules.relative_path.as_bytes());
                 path.push(0);
 
-                let dependencies: Box<[DependencyID]> = Box::from(node_modules.dependencies);
+                let dependencies: Box<[DependencyID]> = node_modules
+                    .dependencies
+                    .iter()
+                    .copied()
+                    .filter(|&dep_id| {
+                        installed.is_installed(
+                            lockfile,
+                            node_modules.relative_path.as_bytes(),
+                            dep_id,
+                        )
+                    })
+                    .collect();
+                installed_count += dependencies.len();
 
                 if max_depth < node_modules.depth + 1 {
                     max_depth = node_modules.depth + 1;
@@ -638,7 +738,7 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
                 Output::println(format_args!(
                     "{} node_modules ({})",
                     bstr::BStr::new(path),
-                    lockfile.buffers.hoisted_dependencies.len(),
+                    installed_count,
                 ));
                 let string_bytes = lockfile.buffers.string_bytes.as_slice();
                 let mut sorted_dependencies: Vec<DependencyID> =
@@ -653,6 +753,9 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
                 // The root lists a workspace it also declares once per declaration.
                 index_sort::sort_indices(&mut sorted_dependencies, &mut |a, b| by_name.cmp(a, b));
                 sorted_dependencies.dedup_by(|a, b| by_name.cmp(*a, *b) == Ordering::Equal);
+
+                sorted_dependencies
+                    .retain(|&dep_id| installed.is_installed(lockfile, b"node_modules", dep_id));
 
                 if trusted_only {
                     sorted_dependencies.retain(|&dep_id| {

--- a/src/runtime/cli/pm_licenses_command.rs
+++ b/src/runtime/cli/pm_licenses_command.rs
@@ -44,7 +44,7 @@ struct Entry {
 }
 
 /// Lazily-scanned, sorted entry names of `node_modules/.bun/`; `None` until first needed.
-struct BunStore {
+pub(crate) struct BunStore {
     entries: Option<Vec<Box<[u8]>>>,
 }
 
@@ -197,7 +197,7 @@ impl PmLicensesCommand {
         let buf = lockfile.buffers.string_bytes.as_slice();
 
         let mut log = Log::init();
-        let mut store = BunStore { entries: None };
+        let mut store = BunStore::init();
         let mut disk = DiskIndex { entries: None };
         let mut entries: Vec<Entry> = Vec::new();
         let mut missing: usize = 0;
@@ -523,6 +523,10 @@ fn author_of(json: &Expr) -> Option<Box<[u8]>> {
 }
 
 impl BunStore {
+    pub(crate) fn init() -> Self {
+        Self { entries: None }
+    }
+
     fn read_info(
         &mut self,
         path: &mut AutoAbsPath,
@@ -543,7 +547,7 @@ impl BunStore {
         read_package_info_at(path, top_len, &segments, log)
     }
 
-    fn lookup(
+    pub(crate) fn lookup(
         &mut self,
         path: &mut AutoAbsPath,
         top_len: usize,

--- a/test/cli/bun.test.ts
+++ b/test/cli/bun.test.ts
@@ -259,7 +259,7 @@ describe("bun", () => {
         "bun pm --help",
         ["pm"],
         [
-          /^ {2}bun pm ls +list the dependency tree according to the current lockfile$/m,
+          /^ {2}bun pm ls +list the tree of installed dependencies$/m,
           /^ {2}bun pm licenses +list installed packages grouped by license$/m,
         ],
       ],

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -1,6 +1,6 @@
 import { spawn } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, expect, it, test } from "bun:test";
-import { exists, mkdir, writeFile } from "fs/promises";
+import { exists, mkdir, rm, writeFile } from "fs/promises";
 import { bunEnv, bunExe, bunEnv as env, normalizeBunSnapshot, readdirSorted, tempDir, tmpdirSync } from "harness";
 import { cpSync } from "node:fs";
 import { join } from "path";
@@ -138,6 +138,134 @@ it("should list all dependencies", async () => {
   expect(await exited).toBe(0);
   expect(urls.sort()).toEqual([]);
   expect(requested).toBe(2);
+});
+
+it("should not list packages missing from node_modules", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls));
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "foo",
+      version: "0.0.1",
+      dependencies: {
+        bar: "latest",
+        moo: "./moo",
+      },
+    }),
+  );
+  await mkdir(join(package_dir, "moo"));
+  await writeFile(
+    join(package_dir, "moo", "package.json"),
+    JSON.stringify({
+      name: "moo",
+      version: "0.1.0",
+    }),
+  );
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const err = await stderr.text();
+    expect(err).not.toContain("error:");
+    expect(err).toContain("Saved lockfile");
+    expect(await exited).toBe(0);
+  }
+  {
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "pm", "ls"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    expect(await stderr.text()).toBe("");
+    expect(await stdout.text()).toBe(`${package_dir} node_modules (2)
+├── bar@0.0.2
+└── moo@moo
+`);
+    expect(await exited).toBe(0);
+  }
+  // simulates `bun prune --production` or a platform-mismatched optional
+  // dependency: the package is in the lockfile but not on disk
+  await rm(join(package_dir, "node_modules", "bar"), { recursive: true });
+  {
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "pm", "ls"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    expect(await stderr.text()).toBe("");
+    expect(await stdout.text()).toBe(`${package_dir} node_modules (1)
+└── moo@moo
+`);
+    expect(await exited).toBe(0);
+  }
+  {
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "pm", "ls", "--all"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    expect(await stderr.text()).toBe("");
+    expect(await stdout.text()).toBe(`${package_dir} node_modules
+└── moo@moo
+`);
+    expect(await exited).toBe(0);
+  }
+});
+
+it("should error when node_modules does not exist", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls));
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "foo",
+      version: "0.0.1",
+      dependencies: {
+        bar: "latest",
+      },
+    }),
+  );
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const err = await stderr.text();
+    expect(err).not.toContain("error:");
+    expect(err).toContain("Saved lockfile");
+    expect(await exited).toBe(0);
+  }
+  await rm(join(package_dir, "node_modules"), { recursive: true });
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "pm", "ls"],
+    cwd: package_dir,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  expect(await stderr.text()).toContain("node_modules not found");
+  expect(await stdout.text()).toBe("");
+  expect(await exited).toBe(1);
 });
 
 it("should list top-level aliased dependency", async () => {

--- a/test/cli/install/frozen-lockfile-pruned.test.ts
+++ b/test/cli/install/frozen-lockfile-pruned.test.ts
@@ -659,26 +659,29 @@ describe.each(["hoisted", "isolated"] as Linker[])("linker: %s", linker => {
     expect(await exists(installedPath(packageDir, linker, "left-pad", "1.0.0"))).toBeFalse();
   });
 
-  // docs/pm/cli/install.mdx: the skipped workspaces stay in bun.lock, so lockfile-driven commands still see them.
-  test.concurrent("bun pm ls --all still lists the skipped workspace and its exclusive dependency", async () => {
-    const { packageDir, full } = await verbatimTree(linker);
-    await frozen(packageDir, linker, 0);
+  // The skipped workspace stays in bun.lock and is still listed, but its
+  // exclusive dependency was never installed so `bun pm ls` omits it.
+  test.concurrent(
+    "bun pm ls --all lists the skipped workspace but not its uninstalled exclusive dependency",
+    async () => {
+      const { packageDir, full } = await verbatimTree(linker);
+      await frozen(packageDir, linker, 0);
 
-    const { stdout, stderr, exitCode } = await spawnBun(packageDir, ["pm", "ls", "--all"]);
+      const { stdout, stderr, exitCode } = await spawnBun(packageDir, ["pm", "ls", "--all"]);
 
-    expect(stderr).toBe("");
-    expect(normalizeBunSnapshot(stdout, packageDir)).toMatchInlineSnapshot(`
-      "<dir> node_modules
-      ├── a-dep@1.0.1
-      ├── app@workspace:packages/app
-      ├── left-pad@1.0.0
-      ├── no-deps@1.0.0
-      ├── other@workspace:packages/other
-      └── shared@workspace:packages/shared"
-    `);
-    expect(await lockText(packageDir)).toBe(full);
-    expect(exitCode).toBe(0);
-  });
+      expect(stderr).toBe("");
+      expect(normalizeBunSnapshot(stdout, packageDir)).toMatchInlineSnapshot(`
+        "<dir> node_modules
+        ├── a-dep@1.0.1
+        ├── app@workspace:packages/app
+        ├── no-deps@1.0.0
+        ├── other@workspace:packages/other
+        └── shared@workspace:packages/shared"
+      `);
+      expect(await lockText(packageDir)).toBe(full);
+      expect(exitCode).toBe(0);
+    },
+  );
 
   test.concurrent("bun audit still submits the skipped workspace's exclusive dependency", async () => {
     const { packageDir, full } = await verbatimTree(linker);


### PR DESCRIPTION
Fixes #38909

### Problem

- `bun pm ls` prints a header labelled `node_modules (N)` where N is `lockfile.buffers.hoisted_dependencies.len()`, and the listing walks the lockfile's dependency tree. Nothing ever checks the disk.
- Platform-specific optional dependencies that were never installed on the current machine are counted (the reporter saw 681 counted vs 567 directories on disk), and `--all` lists them.
- Packages removed from disk after install (`bun prune --production`, manual deletion) stay listed.
- `bun pm licenses` already checks the disk and gets both cases right.

### Fix

- `src/runtime/cli/package_manager_command.rs`: filter every entry through a disk-existence check before listing or counting. A dependency counts as installed when its directory exists at its hoisted path (`<tree position>/<alias>`), or, as a fallback, when it has an entry in the isolated-install store (`node_modules/.bun/<name@version>`), since isolated installs only link direct dependencies into each package's `node_modules`.
- Root, workspace, and `bun link` resolutions are always kept: they are local sources that live outside `node_modules`.
- The store check reuses `BunStore` from `bun pm licenses` (now `pub(crate)`), which also handles peer-suffixed store keys.
- When `node_modules` does not exist at all, `bun pm ls` now errors with `node_modules not found, nothing to list` and a `run 'bun install' first` note, matching `bun pm licenses`.
- Help text and completions updated: "list the dependency tree according to the current lockfile" described the old behavior; now "list the tree of installed dependencies". The docs page for `bun pm ls` already said "installed dependencies".
- Verified: new tests in `test/cli/install/bun-pm.test.ts` (deleted package disappears from listing and count; missing `node_modules` errors), both fail on the released bun and pass with this change. Full runs of `bun-pm.test.ts` (20/20), `frozen-lockfile-pruned.test.ts` (101/101, hoisted and isolated linkers), `bun-pm-licenses.test.ts` (79/79), plus the `pm ls` tests in `bun.test.ts`, `bun-install-registry.test.ts`, and `bun-install-lifecycle-scripts.test.ts`.

One existing test changed behavior: `frozen-lockfile-pruned.test.ts` asserted that after a pruned-monorepo install skips a workspace, `bun pm ls --all` still lists the skipped workspace's exclusive dependency. That dependency was never installed, which is exactly the case this issue reports, so the snapshot now omits it. The skipped workspace itself is still listed.

### Background

- The lockfile stores resolutions for every platform, so `bun.lock` legitimately contains packages that will never exist on a given machine (for example `@esbuild/win32-x64` on Linux). The lockfile is not a description of `node_modules`; the install step decides what actually lands on disk.
- Hoisted installs (the default) place each package at a physical path derived from the dependency tree (`node_modules/a/node_modules/b`). Isolated installs (`nodeLinker: isolated`) instead keep one copy per package under `node_modules/.bun/<name@version>/` and symlink only direct dependencies into each package's `node_modules`, which is why the hoisted path check alone would wrongly drop transitive packages in isolated mode.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/frozen-lockfile-pruned.test.ts, test/cli/bun.test.ts

<!-- robobun:evidence:end -->