### PR TITLE
Clear the inherited signal mask at startup and exec children with an empty one

### DIFF
--- a/src/bun_bin/lib.rs
+++ b/src/bun_bin/lib.rs
@@ -170,6 +170,20 @@ pub(crate) unsafe extern "C" fn main(argc: c_int, argv: *const *const c_char) ->
         libc::signal(libc::SIGXFSZ, libc::SIG_IGN);
     }
 
+    // The blocked-signal mask survives execve, so a launcher that had (say)
+    // SIGTERM blocked starts bun with it blocked, and a blocked signal never
+    // reaches our handlers, JS `process.on(...)` listeners, or its default
+    // action. Clear it like Node does; threads created from here on inherit
+    // the empty mask.
+    // SAFETY: `set` is a valid out-pointer for `sigemptyset` and fully
+    // initialized before `pthread_sigmask` reads it; a null old-set is allowed.
+    #[cfg(unix)]
+    unsafe {
+        let mut set: libc::sigset_t = bun_core::ffi::zeroed();
+        libc::sigemptyset(&raw mut set);
+        libc::pthread_sigmask(libc::SIG_SETMASK, &raw const set, core::ptr::null_mut());
+    }
+
     // Windows-only startup. Must run BEFORE the first libuv
     // call (uv allocator) and before anything reads `Bun.env`/`process.env`
     // (env conversion).

--- a/src/jsc/bindings/bun-spawn.cpp
+++ b/src/jsc/bindings/bun-spawn.cpp
@@ -247,8 +247,6 @@ extern "C" ssize_t posix_spawn_bun(
 #endif
 
     sigfillset(&blockall);
-    // What the child execs with. Empty rather than this thread's mask, like
-    // libuv and posix_spawnattr_reset_signals: the mask survives execve.
     sigemptyset(&childmask);
     sigprocmask(SIG_SETMASK, &blockall, &oldmask);
 #if !OS(ANDROID)

--- a/src/jsc/bindings/bun-spawn.cpp
+++ b/src/jsc/bindings/bun-spawn.cpp
@@ -230,7 +230,7 @@ extern "C" ssize_t posix_spawn_bun(
     char* const argv[],
     char* const envp[])
 {
-    sigset_t blockall, oldmask;
+    sigset_t blockall, oldmask, childmask;
     int res = 0, cs = 0;
 
 #if OS(DARWIN) || OS(FREEBSD)
@@ -247,6 +247,11 @@ extern "C" ssize_t posix_spawn_bun(
 #endif
 
     sigfillset(&blockall);
+    // The child execs with nothing blocked, like posix_spawnattr_reset_signals
+    // (the libc posix_spawn path) and libuv, rather than with whatever this
+    // thread inherited or has blocked: a blocked signal survives execve, so
+    // the child would silently never receive it.
+    sigemptyset(&childmask);
     sigprocmask(SIG_SETMASK, &blockall, &oldmask);
 #if !OS(ANDROID)
     pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &cs);
@@ -290,8 +295,6 @@ extern "C" ssize_t posix_spawn_bun(
 #endif
 
     const auto startChild = [&]() -> ssize_t {
-        sigset_t childmask = oldmask;
-
         // Reset signals
         struct sigaction sa = { 0 };
         sa.sa_handler = SIG_DFL;

--- a/src/jsc/bindings/bun-spawn.cpp
+++ b/src/jsc/bindings/bun-spawn.cpp
@@ -247,10 +247,8 @@ extern "C" ssize_t posix_spawn_bun(
 #endif
 
     sigfillset(&blockall);
-    // The child execs with nothing blocked, like posix_spawnattr_reset_signals
-    // (the libc posix_spawn path) and libuv, rather than with whatever this
-    // thread inherited or has blocked: a blocked signal survives execve, so
-    // the child would silently never receive it.
+    // What the child execs with. Empty rather than this thread's mask, like
+    // libuv and posix_spawnattr_reset_signals: the mask survives execve.
     sigemptyset(&childmask);
     sigprocmask(SIG_SETMASK, &blockall, &oldmask);
 #if !OS(ANDROID)

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -978,17 +978,20 @@ static struct sigaction previous_actions[NSIG];
     FOR_EACH_LINUX_ONLY_SIGNAL(M)
 #endif
 
+// Called from the handler below, and from Bun__sendPendingSignalIfNecessary for a
+// signal that arrived before the child's pid was known. The mask has to be put
+// back with SIG_SETMASK: on the second path `sig` is not in the saved set, so
+// unblocking the saved set would leave it blocked for the rest of the process,
+// and the re-raise of the child's signal at exit would fall through to abort().
 static void Bun__forwardSignalFromParentToChildAndRestorePreviousAction(pid_t pid, int sig)
 {
-    sigset_t restore_mask;
+    sigset_t previous_mask;
     sigset_t mask;
     sigemptyset(&mask);
     sigaddset(&mask, sig);
-    sigemptyset(&restore_mask);
-    sigaddset(&restore_mask, sig);
-    pthread_sigmask(SIG_BLOCK, &mask, &restore_mask);
+    pthread_sigmask(SIG_BLOCK, &mask, &previous_mask);
     kill(pid, sig);
-    pthread_sigmask(SIG_UNBLOCK, &restore_mask, nullptr);
+    pthread_sigmask(SIG_SETMASK, &previous_mask, nullptr);
 }
 
 extern "C" void Bun__sendPendingSignalIfNecessary()

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -978,11 +978,6 @@ static struct sigaction previous_actions[NSIG];
     FOR_EACH_LINUX_ONLY_SIGNAL(M)
 #endif
 
-// Called from the handler below, and from Bun__sendPendingSignalIfNecessary for a
-// signal that arrived before the child's pid was known. The mask has to be put
-// back with SIG_SETMASK: on the second path `sig` is not in the saved set, so
-// unblocking the saved set would leave it blocked for the rest of the process,
-// and the re-raise of the child's signal at exit would fall through to abort().
 static void Bun__forwardSignalFromParentToChildAndRestorePreviousAction(pid_t pid, int sig)
 {
     sigset_t previous_mask;
@@ -991,6 +986,7 @@ static void Bun__forwardSignalFromParentToChildAndRestorePreviousAction(pid_t pi
     sigaddset(&mask, sig);
     pthread_sigmask(SIG_BLOCK, &mask, &previous_mask);
     kill(pid, sig);
+    // Not SIG_UNBLOCK: from Bun__sendPendingSignalIfNecessary, `sig` is not in previous_mask and would stay blocked.
     pthread_sigmask(SIG_SETMASK, &previous_mask, nullptr);
 }
 

--- a/test/cli/run/inherited-signal-mask.test.ts
+++ b/test/cli/run/inherited-signal-mask.test.ts
@@ -1,0 +1,189 @@
+// The set of blocked signals survives execve, so a launcher that has a signal
+// blocked (JVM and Go wrappers, some supervisors, `env --block-signal`) starts
+// bun with it blocked, and a blocked signal is never delivered. Like node, bun
+// clears the mask at startup (src/bun_bin/lib.rs), and, like libuv, it execs
+// every child with an empty mask whatever its own looks like
+// (posix_spawn_bun in src/jsc/bindings/bun-spawn.cpp).
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isAndroid, isLinux, isPosix, libcPathForDlopen, tempDir } from "harness";
+import { join } from "node:path";
+
+const SIGTERM = 15;
+
+const cc = isPosix ? Bun.which("cc") || Bun.which("clang") || Bun.which("gcc") : null;
+
+// `block-sigterm <command...>`: blocks SIGTERM, then execs the command.
+const LAUNCHER_C = /* c */ `
+#include <signal.h>
+#include <unistd.h>
+int main(int argc, char** argv) {
+  sigset_t set;
+  sigemptyset(&set);
+  sigaddset(&set, SIGTERM);
+  if (argc < 2 || sigprocmask(SIG_BLOCK, &set, 0) != 0) return 98;
+  execvp(argv[1], argv + 1);
+  return 99;
+}
+`;
+
+// `sh` sends SIGTERM to itself. It dies from it, unless it inherited the signal
+// blocked: then the signal stays pending and the script exits 0.
+const KILL_SELF = "kill -TERM $$";
+
+// Runs that script through each way bun has of starting a process and reports
+// how each of them saw it end.
+const CHILDREN_KILLED_FIXTURE = /* js */ `
+  import { spawnSync as nodeSpawnSync } from "node:child_process";
+  const script = ${JSON.stringify(KILL_SELF)};
+  const sync = Bun.spawnSync({ cmd: ["sh", "-c", script] });
+  const spawned = Bun.spawn({ cmd: ["sh", "-c", script] });
+  await spawned.exited;
+  const node = nodeSpawnSync("sh", ["-c", script]);
+  const shell = await Bun.$\`sh -c \${script}\`.nothrow().quiet();
+  console.log(JSON.stringify({
+    spawnSync: [sync.exitCode, sync.signalCode],
+    spawn: [spawned.exitCode, spawned.signalCode],
+    child_process: [node.status, node.signal],
+    shell: shell.exitCode,
+  }));
+`;
+
+const CHILDREN_KILLED = {
+  spawnSync: [null, "SIGTERM"],
+  spawn: [null, "SIGTERM"],
+  child_process: [null, "SIGTERM"],
+  shell: 128 + SIGTERM,
+};
+
+// /proc/<pid>/status shows the mask as a hex bitmask; with SIGTERM blocked it reads ...4000.
+const SIG_BLK_LINE = /^SigBlk:\s*(\S+)$/m;
+const NOTHING_BLOCKED = "0000000000000000";
+
+let dir: ReturnType<typeof tempDir> | undefined;
+let launcher: string;
+
+beforeAll(async () => {
+  if (!cc) return;
+  dir = tempDir("inherited-signal-mask", { "block-sigterm.c": LAUNCHER_C });
+  launcher = join(String(dir), "block-sigterm");
+  await using proc = Bun.spawn({
+    cmd: [cc, "-o", launcher, "block-sigterm.c"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  if (exitCode !== 0) throw new Error(`compiling the launcher failed:\n${stderr}${stdout}`);
+});
+
+afterAll(() => {
+  dir?.[Symbol.dispose]();
+});
+
+async function run(cmd: string[]) {
+  await using proc = Bun.spawn({ cmd, env: bunEnv, stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode: proc.exitCode, signalCode: proc.signalCode };
+}
+
+/** The JSON line a fixture printed, plus whatever would explain it not having printed one. */
+async function report(cmd: string[]) {
+  const { stdout, stderr, exitCode, signalCode } = await run(cmd);
+  let result: unknown = stdout;
+  try {
+    result = JSON.parse(stdout);
+  } catch {}
+  return { result, stderr, exitCode, signalCode };
+}
+
+function reported(result: unknown) {
+  return { result, stderr: "", exitCode: 0, signalCode: null };
+}
+
+describe.concurrent.skipIf(!cc)("started with SIGTERM blocked", () => {
+  test("bun still dies from SIGTERM", async () => {
+    const ended = await run([
+      launcher,
+      bunExe(),
+      "-e",
+      'process.kill(process.pid, "SIGTERM"); console.log("survived")',
+    ]);
+    expect(ended).toEqual({ stdout: "", stderr: "", exitCode: null, signalCode: "SIGTERM" });
+  });
+
+  test("the children bun spawns still die from SIGTERM", async () => {
+    expect(await report([launcher, bunExe(), "-e", CHILDREN_KILLED_FIXTURE])).toEqual(reported(CHILDREN_KILLED));
+  });
+
+  test.skipIf(!isLinux)("neither bun nor its children have anything blocked", async () => {
+    const fixture = /* js */ `
+      import { readFileSync } from "node:fs";
+      const child = Bun.spawnSync({ cmd: ["cat", "/proc/self/status"] });
+      console.log(JSON.stringify({
+        bun: readFileSync("/proc/self/status", "utf8").match(${SIG_BLK_LINE})[1],
+        child: child.stdout.toString().match(${SIG_BLK_LINE})[1],
+      }));
+    `;
+    expect(await report([launcher, bunExe(), "-e", fixture])).toEqual(
+      reported({ bun: NOTHING_BLOCKED, child: NOTHING_BLOCKED }),
+    );
+  });
+
+  test("bun run forwards SIGTERM to the script and dies from it", async () => {
+    using project = tempDir("inherited-signal-mask-run", {
+      "package.json": JSON.stringify({
+        name: "inherited-signal-mask",
+        // `exec`: the process that has to be killable is the script itself.
+        scripts: { start: "echo ready; exec sleep 30" },
+      }),
+    });
+    await using proc = Bun.spawn({
+      cmd: [launcher, bunExe(), "run", "start"],
+      cwd: String(project),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      // For cleanup should the test fail: a bun that fails it is one that ignores SIGTERM.
+      killSignal: "SIGKILL",
+    });
+    // `ready` is printed by the script, so by now bun has installed its forwarding
+    // handler and knows the script's pid. The launcher exec'd into bun, so
+    // proc.pid is bun.
+    const reader = proc.stdout.getReader();
+    let seen = "";
+    while (!seen.includes("ready\n")) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      seen += Buffer.from(value).toString();
+    }
+    expect(seen).toBe("ready\n");
+    proc.kill("SIGTERM");
+
+    const [stderr] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain('script "start" was terminated by signal SIGTERM');
+    expect({ exitCode: proc.exitCode, signalCode: proc.signalCode }).toEqual({ exitCode: null, signalCode: "SIGTERM" });
+  });
+});
+
+// No launcher involved: bun's own thread blocks SIGTERM before spawning, and the
+// children must not inherit that either.
+test.concurrent.skipIf(!isPosix)("children do not inherit a signal bun itself has blocked", async () => {
+  // Linux (glibc, musl, bionic) numbers SIG_BLOCK 0; Darwin and FreeBSD number it 1.
+  const SIG_BLOCK = isLinux || isAndroid ? 0 : 1;
+  const fixture = /* js */ `
+    import { dlopen, FFIType, ptr } from "bun:ffi";
+    const libc = dlopen(${JSON.stringify(libcPathForDlopen())}, {
+      sigemptyset: { args: [FFIType.ptr], returns: FFIType.i32 },
+      sigaddset: { args: [FFIType.ptr, FFIType.i32], returns: FFIType.i32 },
+      pthread_sigmask: { args: [FFIType.i32, FFIType.ptr, FFIType.ptr], returns: FFIType.i32 },
+    }).symbols;
+    // Larger than any platform's sigset_t.
+    const set = new Uint8Array(256);
+    libc.sigemptyset(ptr(set));
+    libc.sigaddset(ptr(set), ${SIGTERM});
+    if (libc.pthread_sigmask(${SIG_BLOCK}, ptr(set), null) !== 0) throw new Error("pthread_sigmask failed");
+    ${CHILDREN_KILLED_FIXTURE}
+  `;
+  expect(await report([bunExe(), "-e", fixture])).toEqual(reported(CHILDREN_KILLED));
+});

--- a/test/cli/run/inherited-signal-mask.test.ts
+++ b/test/cli/run/inherited-signal-mask.test.ts
@@ -1,11 +1,14 @@
-// The set of blocked signals survives execve, so a launcher that has a signal
-// blocked (JVM and Go wrappers, some supervisors, `env --block-signal`) starts
-// bun with it blocked, and a blocked signal is never delivered. Like node, bun
+// A blocked signal is never delivered, and the set of blocked signals survives
+// execve. So a launcher that has a signal blocked (JVM and Go wrappers, some
+// supervisors, `env --block-signal`) starts bun with it blocked: like node, bun
 // clears the mask at startup (src/bun_bin/lib.rs), and, like libuv, it execs
-// every child with an empty mask whatever its own looks like
-// (posix_spawn_bun in src/jsc/bindings/bun-spawn.cpp).
+// every child with an empty mask whatever its own looks like (posix_spawn_bun
+// in src/jsc/bindings/bun-spawn.cpp). The last test covers the one place bun
+// used to block a signal itself: forwarding one to a `bun run` script
+// (src/jsc/bindings/c-bindings.cpp).
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isAndroid, isLinux, isPosix, libcPathForDlopen, tempDir } from "harness";
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 const SIGTERM = 15;
@@ -186,4 +189,63 @@ test.concurrent.skipIf(!isPosix)("children do not inherit a signal bun itself ha
     ${CHILDREN_KILLED_FIXTURE}
   `;
   expect(await report([bunExe(), "-e", fixture])).toEqual(reported(CHILDREN_KILLED));
+});
+
+/** Contents of a /proc file, or "" once the process it belongs to is gone. */
+function procRead(path: string): string {
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+// /proc/<pid>/task/<tid>/children needs CONFIG_PROC_CHILDREN.
+const canListChildren =
+  isLinux &&
+  (() => {
+    try {
+      readFileSync(`/proc/self/task/${process.pid}/children`);
+      return true;
+    } catch {
+      return false;
+    }
+  })();
+
+// `bun run` only learns the script's pid once the spawn returns; a signal that
+// arrives before that is forwarded afterwards, outside the signal handler. That
+// forwarding must not leave the signal blocked in bun: the re-raise that ends
+// `bun run` once the script has died from it would then fall through to
+// abort(), and bun would die from SIGABRT instead. The script shows up in
+// bun's children the moment it is created, while bun is still suspended in
+// vfork, so a signal sent right then is delivered before bun has the pid.
+// Whether or not an attempt wins that race, bun has to die from SIGTERM.
+test.skipIf(!canListChildren)("bun run forwards a signal that arrives before it knows the script's pid", async () => {
+  using project = tempDir("inherited-signal-mask-early", {
+    "package.json": JSON.stringify({ name: "inherited-signal-mask", scripts: { start: "exec sleep 30" } }),
+  });
+  for (let attempt = 0; attempt < 2; attempt++) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "start"],
+      cwd: String(project),
+      env: bunEnv,
+      stdout: "ignore",
+      stderr: "pipe",
+      killSignal: "SIGKILL",
+    });
+    const children = `/proc/${proc.pid}/task/${proc.pid}/children`;
+    // Spinning, not awaiting: the window is the script's pre-exec setup, a
+    // fraction of a millisecond. The deadline only bounds a bun that never spawns.
+    const deadline = performance.now() + 3_000;
+    while (procRead(children).trim() === "" && performance.now() < deadline) {}
+    proc.kill("SIGTERM");
+
+    const [stderr] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain('script "start" was terminated by signal SIGTERM');
+    expect({ attempt, exitCode: proc.exitCode, signalCode: proc.signalCode }).toEqual({
+      attempt,
+      exitCode: null,
+      signalCode: "SIGTERM",
+    });
+  }
 });


### PR DESCRIPTION
### Problem
- A bun started by a launcher that has a signal blocked (JVM and Go based wrappers, some supervisors, `env --block-signal=TERM bun ...`) keeps that signal blocked, and so does everything bun spawns: `Bun.spawn`/`spawnSync`, `child_process`, the shell, `bun run <script>`, lifecycle scripts. Signals sent to any of them are never delivered. Under such a launcher `bun run start` ignores SIGTERM outright (its forwarding handler never runs, and the script could not be killed even if it did), `Bun.spawnSync({cmd: ["sh", "-c", "kill -TERM $$"]})` reports `exitCode 0`, and `process.kill(process.pid, "SIGTERM")` is a no-op. Node clears its mask at startup and libuv execs every child with an empty one, so the same programs work under node.
- bun never touches the mask it inherits: nothing in startup (`src/bun_bin/lib.rs` `main`, `bun_initialize_process`) resets it.
- `posix_spawn_bun` (`src/jsc/bindings/bun-spawn.cpp`) blocks everything around vfork and then restores the *spawning thread's* mask in the child right before `execve` (`childmask = oldmask`), so children also get whatever bun inherited, or whatever a native addon happens to have blocked on the JS thread. This is the spawn path for every child on Linux and FreeBSD and for PTY/uid/gid spawns on macOS. The other ways bun starts a new image already use an empty mask: the libc `posix_spawn` path on macOS (`posix_spawnattr_reset_signals` in `spawn.cpp`), `process.execve` (`BunProcess.cpp`) and the `--watch` reload (`on_before_reload_process_posix`).
- One place where bun blocks a signal itself and does not put it back, found by this PR's own test on the first CI run: `Bun__forwardSignalFromParentToChildAndRestorePreviousAction` (`src/jsc/bindings/c-bindings.cpp`), which `bun run`, `bunx`, `bun create`, `bun upgrade` and install's `git` runs use to pass a signal on to their synchronous child, blocks the signal around `kill()` and then `SIG_UNBLOCK`s the *previously blocked set*. When it runs from `Bun__sendPendingSignalIfNecessary`, for a signal that arrived before the child's pid was stored, that set does not contain the signal, so the signal stays blocked in bun for good: a second delivery is never forwarded, and when the child dies from the forwarded signal, `raise_ignoring_panic_handler_raw` (`src/bun_core/Global.rs`) re-raises it, `raise()` returns, and bun falls through to `abort()`. `bun run start` then dies from SIGABRT instead of SIGTERM (CI build 97560, Ubuntu 25.04 aarch64). Sending the signal the instant the script shows up in `/proc/<bun>/task/<bun>/children`, while bun is still suspended in `vfork`, hits this 195 times out of 200 on the current release.
- Not a regression: all three have been this way since the code was written. Reproduces with the current release and a debug build of main.

### Fix
- `main` clears the mask with `pthread_sigmask(SIG_SETMASK, {})` right after ignoring SIGPIPE, before any thread exists, so every thread bun creates inherits the empty mask. Node's `PlatformInit` does the same (it leaves only SIGUSR1 blocked, for the watchdog thread its inspector starts, and unblocks it once that thread is up; bun has no such thread).
- `posix_spawn_bun` execs the child with an empty mask instead of the parent's. This matches libuv (`uv_spawn` children always start with an empty mask) and bun's own libc `posix_spawn`, `execve` and reload paths, which makes the mask a child starts with the same on every platform and spawn path. The child still runs its setup with everything blocked; only the set it execs with changes.
- The forwarding helper restores the mask it saved with `SIG_SETMASK` instead of `SIG_UNBLOCK`ing it. From the pending-signal path that puts back a set without the signal; from inside the handler it puts back the handler's set, in which the kernel has the signal blocked until the handler returns (and which the old code also undid for every other signal the caller had blocked, such as SIGCHLD in the `bun run` wait loop). Either way the thread ends up exactly where it was.
- Why unconditionally: with that helper fixed, bun only blocks signals for the duration of a call and restores afterwards (`SIGTTOU` around `tcsetattr`, `SIGCHLD` in the `bun run` wait loop, everything inside `posix_spawn_bun`), and none of those spawn while blocked, so the only way a bun process or one of its children ends up with a non-empty mask is inheriting one. A blocked signal is not a way to opt a process out of a signal (that is `SIG_IGN`, which both startup and the spawn path leave alone); it only makes the signal undeliverable, which is never what a launcher that leaked its mask intended, and it already does not survive node.
- Verified with `test/cli/run/inherited-signal-mask.test.ts`, six tests. Four run bun through a small compiled launcher that blocks SIGTERM and execs its arguments: bun still dies from `process.kill(process.pid, "SIGTERM")`; children started through `Bun.spawnSync`, `Bun.spawn`, `child_process.spawnSync` and `Bun.$` still die from a `kill -TERM $$`; `/proc` shows nothing blocked in bun or in a child (Linux); `bun run start` forwards a SIGTERM to the script and dies from it. One has no launcher and blocks SIGTERM on bun's own thread through `bun:ffi` before spawning, which only the `bun-spawn.cpp` change makes pass. The last one (Linux, needs `/proc/<pid>/task/<tid>/children`) signals `bun run` the moment its child appears there, twice, and expects death from SIGTERM both times; it does not depend on winning the race (both paths must end the same way), and on the unfixed build it fails every time tried (5/5 runs, `signalCode: "SIGABRT"`, the CI failure). The whole file is `0 pass, 6 fail` on the build without the `src/` changes and `6 pass` with them.
- Also ran against the debug build: `test/js/bun/spawn/spawn.test.ts`, `spawnSync.test.ts`, `spawn-signal.test.ts`, `spawn-kill-signal.test.ts`, `exit-code.test.ts`, `test/cli/run/run-propagate-sigkill.test.ts`, `test/js/node/process/process-signal-listener-count.test.ts` (all pass); `cargo check -p bun_bin --target aarch64-apple-darwin` for the Rust side.
- Related, not overlapping: #38877 unblocks the signal bun is about to re-raise at itself; with this change both reasons for it to be blocked there (inherited, or left behind by the forwarding helper) are gone at the source, and that PR's change remains a backstop for anything else that blocks it. #38843 is about dispositions as PID 1 and does not touch the mask.

### Background
- Every thread has a *signal mask*, the set of signals it is currently blocking. A blocked signal is neither delivered nor dropped: it stays pending until unblocked, so for a process that never unblocks it, it might as well not exist. The mask is per thread, but the kernel delivers a process-directed signal to any thread that is not blocking it, so a mask that is the same on all threads blocks the signal for the whole process.
- `fork`/`vfork`/`clone` copy the mask into the child and `execve` keeps it, which is why it leaks from launcher to bun and from bun to its children, and why anything that wants a known state has to set it explicitly (node at startup, libuv and Rust's `std::process` in the child before exec).
- Signal *dispositions* (`SIG_DFL`/`SIG_IGN`/a handler) are a separate, per-process table. `execve` keeps `SIG_IGN` and resets handlers to `SIG_DFL`; `posix_spawn_bun` already resets all of them to `SIG_DFL` in the child. This change is only about the mask.
- `posix_spawn_bun` blocks all signals in the parent before `vfork`, so the child does its setup (`setsid`, `dup2`, `chdir`, `setuid`, ...) without a handler running on the shared stack, and sets the mask it wants the new program to have as its last step before `execve`. The parent restores its own mask once the child has exec'd; the child's mask is its own copy, so the change does not affect the parent. The parent is suspended for the whole of the child's setup, which is the window the last test aims at.
- How `bun run` passes signals on (`sync` spawn in `src/spawn/process.rs`, helpers in `c-bindings.cpp`): right before spawning it installs a handler for the usual termination signals; the handler `kill()`s the child with the same signal. The child's pid is only stored once the spawn returns, so a signal that arrives before that is remembered and sent by `Bun__sendPendingSignalIfNecessary` right after, from normal code rather than from the handler. Once the child has died from a signal, `bun run` reports it and then kills itself with the same signal (`raise_ignoring_panic_handler_raw`: set `SIG_DFL`, `raise()`, and `abort()` should `raise()` ever return), so whatever is waiting on bun sees the child's real cause of death.

<details>
<summary>Reproduction (Linux, GNU coreutils `env` as the launcher)</summary>

```
$ env --block-signal=TERM node -e 'console.log(require("fs").readFileSync("/proc/self/status","utf8").match(/SigBlk:.*/)[0])'
SigBlk: 0000000000000000
$ env --block-signal=TERM bun  -e '...same...'
SigBlk: 0000000000004000          # bit 14: SIGTERM still blocked

$ env --block-signal=TERM node -e 'const r=require("child_process").spawnSync("sh",["-c","kill -TERM $$"]); console.log(r.status, r.signal)'
null SIGTERM
$ env --block-signal=TERM bun  -e 'const r=Bun.spawnSync({cmd:["sh","-c","kill -TERM $$"]}); console.log(r.exitCode, r.signalCode)'
0 undefined
$ env --block-signal=TERM bun  -e 'const r=require("child_process").spawnSync("sh",["-c","kill -TERM $$"]); console.log(r.status, r.signal)'
0 null

$ env --block-signal=TERM node -e 'process.kill(process.pid,"SIGTERM"); console.log("still alive")'; echo $?
Terminated
143
$ env --block-signal=TERM bun  -e 'process.kill(process.pid,"SIGTERM"); console.log("still alive")'; echo $?
still alive
0

# package.json: {"scripts":{"start":"sleep 20"}}
$ env --block-signal=TERM bun run start & sleep 1; kill -TERM $!; sleep 1; kill -0 $! && echo "still running"
still running                     # with this change: script "start" was terminated by signal SIGTERM, bun exits 143
```

With this change every bun line above matches the node line.

Forwarding helper, no launcher involved (current release): a loop that starts `bun run start` (`start: "exec sleep 30"`), spins on `/proc/<bun>/task/<bun>/children` and sends SIGTERM as soon as the child is listed, 200 times:

```
{"forwarded + SIGABRT": 195, "forwarded + SIGTERM": 5}
```

"forwarded" means stderr contained `script "start" was terminated by signal SIGTERM`, so the signal did reach the script every time; only the way bun itself then died differs. With this change, 60/60 `forwarded + SIGTERM` on a debug build.
</details>
