### PR TITLE
crash_handler: report Rust panics through crash_handler() and test the panic hook

### DIFF
--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -615,9 +615,6 @@ mod draft {
     static SUPPRESS_REPORTING: AtomicBool = AtomicBool::new(false);
 
     /// This structure and formatter must be kept in sync with `bun.report`'s decoder implementation.
-    ///
-    /// Borrows the message from the crashing frame: a reason is only ever
-    /// formatted and then passed to `crash_handler`/`crash`, never stored.
     #[derive(Clone, Copy)]
     pub enum CrashReason<'a> {
         /// From @panic()
@@ -1735,33 +1732,17 @@ mod draft {
         std::panic::set_hook(Box::new(rust_panic_hook));
     }
 
-    /// `std::panic` hook. A Rust `panic!` (`unwrap()` on `None`/`Err`, a failed
-    /// `assert!`, `unreachable!()`, …) is a bug in Bun, so it is reported through
-    /// the same `crash_handler()` every other crash goes through: same header,
-    /// same `panic(main thread): <message>` line, same trace string and upload,
-    /// same multi-thread/re-entrancy bookkeeping, same SIGABRT at the end.
-    /// `crash_handler` never returns, so nothing unwinds past this hook.
-    ///
-    /// Only the message is reported, not `info.location()`: the call site is in
-    /// the captured trace, and release builds compile with
-    /// `-Zlocation-detail=none` so the location would read `<redacted>:0:0`.
+    /// Omits `info.location()`: release builds use `-Zlocation-detail=none`; the trace has the site.
     #[cold]
     #[inline(never)]
     fn rust_panic_hook(info: &std::panic::PanicHookInfo<'_>) {
-        /// A panic payload can be arbitrarily long (`assert_eq!` on two large
-        /// values), but `encode_trace_string` has to fit the compressed message
-        /// into the fixed-size trace string buffer. Cut on a char boundary so
-        /// the report stays valid UTF-8.
+        /// The trace string must fit the compressed message in a fixed buffer (`encode_trace_string`).
         const MAX_MESSAGE_BYTES: usize = 1024;
 
-        // `panic!` in Rust 2021 always carries a `&'static str` or `String`
-        // payload; only `std::panic::panic_any` can produce anything else.
         let msg = info
             .payload_as_str()
             .unwrap_or("<non-string panic payload>");
         let msg = &msg[..msg.floor_char_boundary(MAX_MESSAGE_BYTES)];
-        // Read in this frame (not inside a closure) so the trim anchor is a
-        // frame that is still on the stack when the trace is captured.
         crash_handler(
             CrashReason::Panic(msg.as_bytes()),
             TraceSeed::BeginAddr(debug::return_address()),

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -615,10 +615,13 @@ mod draft {
     static SUPPRESS_REPORTING: AtomicBool = AtomicBool::new(false);
 
     /// This structure and formatter must be kept in sync with `bun.report`'s decoder implementation.
+    ///
+    /// Borrows the message from the crashing frame: a reason is only ever
+    /// formatted and then passed to `crash_handler`/`crash`, never stored.
     #[derive(Clone, Copy)]
-    pub enum CrashReason {
+    pub enum CrashReason<'a> {
         /// From @panic()
-        Panic(&'static [u8]),
+        Panic(&'a [u8]),
         /// "reached unreachable code"
         Unreachable,
 
@@ -639,12 +642,12 @@ mod draft {
         StackOverflow,
 
         /// Either `main` returned an error, or somewhere else in the code a trace string is printed.
-        ZigError(&'static [u8]),
+        ZigError(&'a [u8]),
 
         OutOfMemory,
     }
 
-    impl CrashReason {
+    impl CrashReason<'_> {
         /// Signal to terminate the process with after the crash report has
         /// been printed. Signal-originated crashes re-raise the original
         /// fault so the parent process (and core-dump analyzers) see the
@@ -669,7 +672,7 @@ mod draft {
         }
     }
 
-    impl fmt::Display for CrashReason {
+    impl fmt::Display for CrashReason<'_> {
         fn fmt(&self, writer: &mut fmt::Formatter<'_>) -> fmt::Result {
             match self {
                 CrashReason::Panic(message) => write!(writer, "{}", bstr::BStr::new(message)),
@@ -788,7 +791,7 @@ mod draft {
 
     /// This function is invoked when a crash happens. A crash is classified in `CrashReason`.
     #[cold]
-    pub fn crash_handler(reason: CrashReason, seed: TraceSeed<'_>) -> ! {
+    pub fn crash_handler(reason: CrashReason<'_>, seed: TraceSeed<'_>) -> ! {
         if cfg!(debug_assertions) {
             Output::disable_scoped_debug_writer();
         }
@@ -1471,8 +1474,7 @@ mod draft {
             if msg == b"reached unreachable code" {
                 CrashReason::Unreachable
             } else {
-                // SAFETY: process is about to abort; the borrow is never invalidated.
-                CrashReason::Panic(unsafe { bun_collections::detach_lifetime(msg) })
+                CrashReason::Panic(msg)
             },
             match error_return_trace {
                 Some(ert) if ert.index > 0 => TraceSeed::ErrorReturn(ert),
@@ -1746,25 +1748,24 @@ mod draft {
     #[cold]
     #[inline(never)]
     fn rust_panic_hook(info: &std::panic::PanicHookInfo<'_>) {
+        /// A panic payload can be arbitrarily long (`assert_eq!` on two large
+        /// values), but `encode_trace_string` has to fit the compressed message
+        /// into the fixed-size trace string buffer. Cut on a char boundary so
+        /// the report stays valid UTF-8.
+        const MAX_MESSAGE_BYTES: usize = 1024;
+
         // `panic!` in Rust 2021 always carries a `&'static str` or `String`
         // payload; only `std::panic::panic_any` can produce anything else.
         let msg = info
             .payload_as_str()
             .unwrap_or("<non-string panic payload>");
-        // `encode_trace_string` has to fit the compressed message into the
-        // fixed-size trace string buffer; cap it so a huge assertion dump still
-        // yields a usable report.
-        let msg = &msg[..msg.floor_char_boundary(1024)];
-        // SAFETY: `CrashReason::Panic` holds a `&'static [u8]` because every
-        // path that builds one ends in `crash_handler`, which never returns.
-        // The payload is owned by the std panic machinery's frames below this
-        // one (or is a string literal), so it stays live for as long as the
-        // process does, and nothing takes a `&mut` to it while the hook runs.
-        let reason =
-            CrashReason::Panic(unsafe { bun_collections::detach_lifetime(msg.as_bytes()) });
+        let msg = &msg[..msg.floor_char_boundary(MAX_MESSAGE_BYTES)];
         // Read in this frame (not inside a closure) so the trim anchor is a
         // frame that is still on the stack when the trace is captured.
-        crash_handler(reason, TraceSeed::BeginAddr(debug::return_address()));
+        crash_handler(
+            CrashReason::Panic(msg.as_bytes()),
+            TraceSeed::BeginAddr(debug::return_address()),
+        );
     }
 
     /// Adapter for non-fatal `bun_core::dump_current_stack_trace` callers
@@ -1865,7 +1866,7 @@ mod draft {
     #[cfg(windows)]
     fn classify_exception_windows(
         record: &bun_sys::windows::EXCEPTION_RECORD,
-    ) -> Option<CrashReason> {
+    ) -> Option<CrashReason<'static>> {
         Some(match record.ExceptionCode {
             bun_sys::windows::EXCEPTION_DATATYPE_MISALIGNMENT => CrashReason::DatatypeMisalignment,
             bun_sys::windows::EXCEPTION_ACCESS_VIOLATION => {
@@ -2489,7 +2490,7 @@ mod draft {
 
     struct TraceString<'a> {
         trace: &'a StackTrace<'a>,
-        reason: CrashReason,
+        reason: CrashReason<'a>,
         action: TraceStringAction,
     }
 
@@ -2855,7 +2856,7 @@ mod draft {
     /// On POSIX this re-raises the signal that caused the crash (or SIGABRT
     /// for panics) so the parent sees the real fault and core dumps are
     /// attributed correctly.
-    fn crash(reason: CrashReason) -> ! {
+    fn crash(reason: CrashReason<'_>) -> ! {
         #[cfg(not(windows))]
         {
             let sig = reason.terminal_signal();
@@ -2959,12 +2960,9 @@ mod draft {
             Output::flush();
             dump_stack_trace(trace, WriteStackTraceLimits::default());
         } else {
-            // SAFETY: `err_name` outlives the local `TraceString` it is formatted through.
-            let reason =
-                CrashReason::ZigError(unsafe { bun_collections::detach_lifetime(err_name) });
             let ts = TraceString {
                 trace,
-                reason,
+                reason: CrashReason::ZigError(err_name),
                 action: TraceStringAction::ViewTrace,
             };
             if IS_ROOT {
@@ -3634,7 +3632,7 @@ mod draft {
         // SAFETY: per the caller contract above, `name` is a valid NUL-terminated C string (non-null).
         let name_bytes = unsafe { bun_core::ffi::cstr(name) }.to_bytes();
         // PORTING.md §Forbidden: no Box::leak. We're on the noreturn path, so a stack
-        // buffer suffices — `panic_impl` erases to &'static for the abort path.
+        // buffer suffices.
         let mut msg = BoundedArray::<u8, 256>::default();
         let _ = write!(
             msg.writer(),
@@ -3651,8 +3649,7 @@ mod draft {
         // SAFETY: caller passes a valid (ptr, len) byte slice
         let msg = unsafe { core::slice::from_raw_parts(message_ptr, message_len) };
         crash_handler(
-            // SAFETY: noreturn — see panic_impl note
-            CrashReason::Panic(unsafe { bun_collections::detach_lifetime(msg) }),
+            CrashReason::Panic(msg),
             TraceSeed::BeginAddr(debug::return_address()),
         );
     }

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -1733,144 +1733,38 @@ mod draft {
         std::panic::set_hook(Box::new(rust_panic_hook));
     }
 
-    /// `std::panic` hook: emit the same trace-string + auto-report as the fatal
-    /// `crash_handler()` path, then **abort**.
-    /// With `panic = "abort"` no unwind starts after this hook returns, so there
-    /// are no `catch_unwind` boundaries to reach.
+    /// `std::panic` hook. A Rust `panic!` (`unwrap()` on `None`/`Err`, a failed
+    /// `assert!`, `unreachable!()`, …) is a bug in Bun, so it is reported through
+    /// the same `crash_handler()` every other crash goes through: same header,
+    /// same `panic(main thread): <message>` line, same trace string and upload,
+    /// same multi-thread/re-entrancy bookkeeping, same SIGABRT at the end.
+    /// `crash_handler` never returns, so nothing unwinds past this hook.
+    ///
+    /// Only the message is reported, not `info.location()`: the call site is in
+    /// the captured trace, and release builds compile with
+    /// `-Zlocation-detail=none` so the location would read `<redacted>:0:0`.
     #[cold]
     #[inline(never)]
     fn rust_panic_hook(info: &std::panic::PanicHookInfo<'_>) {
-        // Re-entry guard: if the hook itself panics (formatter, write, …), the
-        // recursive entry sees stage>0, prints a one-liner, and returns so the
-        // inner unwind tears the process down rather than looping.
-        let stage = PANIC_STAGE.with(|s| s.get());
-        if stage != 0 {
-            PANIC_STAGE.with(|s| s.set(stage + 1));
-            let stderr = &mut stderr_writer();
-            let _ = write!(
-                stderr,
-                "\npanic: {info}\npanicked during a panic. Aborting.\n"
-            );
-            return;
-        }
-        PANIC_STAGE.with(|s| s.set(1));
-
-        // Just the panic message — no `(file:line:col)` suffix. The call site is
-        // captured in the backtrace and symbolized there. With `-Zlocation-detail=none`
-        // in release the location would be `<redacted>:0:0` anyway.
-        let mut msg_buf = BoundedArray::<u8, 1024>::default();
-        {
-            let payload = info.payload();
-            let msg: &str = if let Some(s) = payload.downcast_ref::<&'static str>() {
-                s
-            } else if let Some(s) = payload.downcast_ref::<std::string::String>() {
-                s.as_str()
-            } else {
-                "<non-string panic payload>"
-            };
-            let _ = write!(msg_buf.writer(), "{msg}");
-        }
-        // SAFETY: `CrashReason::Panic` stores `&'static [u8]` (it was designed for
-        // the `-> !` path). `msg_buf` outlives every read of `reason` below — the
-        // borrow is fully consumed by the `Display`/`TraceString` writes inside
-        // this frame and never escapes.
+        // `panic!` in Rust 2021 always carries a `&'static str` or `String`
+        // payload; only `std::panic::panic_any` can produce anything else.
+        let msg = info
+            .payload_as_str()
+            .unwrap_or("<non-string panic payload>");
+        // `encode_trace_string` has to fit the compressed message into the
+        // fixed-size trace string buffer; cap it so a huge assertion dump still
+        // yields a usable report.
+        let msg = &msg[..msg.floor_char_boundary(1024)];
+        // SAFETY: `CrashReason::Panic` holds a `&'static [u8]` because every
+        // path that builds one ends in `crash_handler`, which never returns.
+        // The payload is owned by the std panic machinery's frames below this
+        // one (or is a string literal), so it stays live for as long as the
+        // process does, and nothing takes a `&mut` to it while the hook runs.
         let reason =
-            CrashReason::Panic(unsafe { bun_collections::detach_lifetime(msg_buf.const_slice()) });
-
-        let mut trace_str_buf = BoundedArray::<u8, 1024>::default();
-        {
-            let _panic_guard = PANIC_MUTEX.lock();
-            let writer = &mut stderr_writer();
-
-            let debug_trace = Environment::SHOW_CRASH_TRACE
-                && 'check_flag: {
-                    for arg in bun_core::argv() {
-                        if arg == &b"--debug-crash-handler-use-trace-string"[..] {
-                            break 'check_flag false;
-                        }
-                    }
-                    if is_reporting_enabled() {
-                        break 'check_flag false;
-                    }
-                    true
-                };
-
-            Output::flush();
-            let _ =
-                writer.write_all(b"============================================================\n");
-            let _ = print_metadata(writer);
-
-            if enable_ansi_colors_stderr() {
-                let _ = writer.write_all(&Output::pretty_fmt::<true>("<red>"));
-            }
-            let _ = writer.write_all(b"panic");
-            if enable_ansi_colors_stderr() {
-                let _ = writer.write_all(&Output::pretty_fmt::<true>("<r>"));
-            }
-            let _ = writeln!(writer, ": {}", reason);
-
-            if let Some(action) = CURRENT_ACTION.with(|c| c.get()) {
-                let _ = writeln!(writer, "Crashed while {}", action);
-            }
-
-            let mut addr_buf: [usize; 20] = [0; 20];
-            let idx = debug::capture_stack_trace(debug::return_address(), &mut addr_buf);
-            let trace = StackTrace {
-                index: idx,
-                instruction_addresses: &addr_buf,
-            };
-
-            if debug_trace {
-                dump_stack_trace(&trace, WriteStackTraceLimits::default());
-                let _ = write!(
-                    trace_str_buf.writer(),
-                    "{}",
-                    TraceString {
-                        trace: &trace,
-                        reason,
-                        action: TraceStringAction::ViewTrace,
-                    }
-                );
-            } else {
-                let _ = writer.write_all(b"oh no");
-                if enable_ansi_colors_stderr() {
-                    let _ = writer.write_all(&Output::pretty_fmt::<true>("<r><d>:<r> "));
-                } else {
-                    let _ = writer.write_all(b": ");
-                }
-                let _ = writer.write_all(
-                    b"Bun has crashed. This indicates a bug in Bun, not your code.\n\n\
-                  To send a redacted crash report to Bun's team,\n\
-                  please file a GitHub issue using the link below:\n\n ",
-                );
-                if enable_ansi_colors_stderr() {
-                    let _ = writer.write_all(&Output::pretty_fmt::<true>("<cyan>"));
-                }
-                let _ = write!(
-                    trace_str_buf.writer(),
-                    "{}",
-                    TraceString {
-                        trace: &trace,
-                        reason,
-                        action: TraceStringAction::OpenIssue,
-                    }
-                );
-                let _ = writer.write_all(trace_str_buf.const_slice());
-                let _ = writer.write_all(b"\n");
-            }
-            if enable_ansi_colors_stderr() {
-                let _ = writer.write_all(&Output::pretty_fmt::<true>("<r>\n"));
-            } else {
-                let _ = writer.write_all(b"\n");
-            }
-        }
-
-        report(trace_str_buf.const_slice());
-
-        // A Rust `panic!` is a bug. The process must not continue — with
-        // `panic = "abort"` no unwind starts, so `catch_unwind` boundaries are
-        // unreachable for Rust panics.
-        crash(reason);
+            CrashReason::Panic(unsafe { bun_collections::detach_lifetime(msg.as_bytes()) });
+        // Read in this frame (not inside a closure) so the trim anchor is a
+        // frame that is still on the stack when the trace is captured.
+        crash_handler(reason, TraceSeed::BeginAddr(debug::return_address()));
     }
 
     /// Adapter for non-fatal `bun_core::dump_current_stack_trace` callers

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -120,6 +120,10 @@ export const crash_handler = $rust("crash_handler.rs", "js_bindings.generate") a
   getMachOImageZeroOffset: () => number;
   segfault: () => void;
   panic: () => void;
+  /** A real Rust `panic!`, reported through the `std::panic` hook (`panic()` above calls the crash handler directly). */
+  rustPanic: () => void;
+  /** A real `Result::unwrap()` on an `Err`, also reported through the `std::panic` hook. */
+  rustUnwrap: () => void;
   rootError: () => void;
   outOfMemory: () => void;
   abort: () => void;

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -120,10 +120,7 @@ export const crash_handler = $rust("crash_handler.rs", "js_bindings.generate") a
   getMachOImageZeroOffset: () => number;
   segfault: () => void;
   panic: () => void;
-  /**
-   * A real Rust `panic!`, reported through the `std::panic` hook (`panic()` above calls the crash handler
-   * directly). Panics with a fixed literal, or with `message` when one is given.
-   */
+  /** A real Rust `panic!` (goes through the `std::panic` hook, unlike `panic()` above), with `message` if given. */
   rustPanic: (message?: string) => void;
   /** A real `Result::unwrap()` on an `Err`, also reported through the `std::panic` hook. */
   rustUnwrap: () => void;

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -120,8 +120,11 @@ export const crash_handler = $rust("crash_handler.rs", "js_bindings.generate") a
   getMachOImageZeroOffset: () => number;
   segfault: () => void;
   panic: () => void;
-  /** A real Rust `panic!`, reported through the `std::panic` hook (`panic()` above calls the crash handler directly). */
-  rustPanic: () => void;
+  /**
+   * A real Rust `panic!`, reported through the `std::panic` hook (`panic()` above calls the crash handler
+   * directly). Panics with a fixed literal, or with `message` when one is given.
+   */
+  rustPanic: (message?: string) => void;
   /** A real `Result::unwrap()` on an `Err`, also reported through the `std::panic` hook. */
   rustUnwrap: () => void;
   rootError: () => void;

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -136,11 +136,19 @@ pub(crate) mod js_bindings {
 
     /// Unlike `js_panic`, which calls `panic_impl` directly, this is a real
     /// `panic!`, so it goes through the `std::panic` hook the crash handler
-    /// installs. A literal message reaches the hook as a `&'static str` payload.
+    /// installs. Without an argument the literal reaches the hook as a
+    /// `&'static str` payload; `rustPanic(message)` panics with that message
+    /// (a `String` payload), which is how the tests exercise the hook's
+    /// message cap.
     #[bun_jsc::host_fn]
-    fn js_rust_panic(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
+    fn js_rust_panic(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
         crash_handler::suppress_core_dumps_if_necessary();
-        panic!("invoked crashByRustPanic() handler");
+        let message = frame.argument(0);
+        if message.is_undefined() {
+            panic!("invoked crashByRustPanic() handler");
+        }
+        let message = message.to_slice(global)?;
+        panic!("{}", bstr::BStr::new(message.slice()));
     }
 
     /// `Result::unwrap()` on an `Err`, the shape of the `.unwrap()` sites that

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -24,6 +24,8 @@ pub(crate) mod js_bindings {
             ("segfault", __jsc_host_js_segfault),
             ("segfaultInDll", __jsc_host_js_segfault_in_dll),
             ("panic", __jsc_host_js_panic),
+            ("rustPanic", __jsc_host_js_rust_panic),
+            ("rustUnwrap", __jsc_host_js_rust_unwrap),
             ("rootError", __jsc_host_js_root_error),
             ("outOfMemory", __jsc_host_js_out_of_memory),
             ("abort", __jsc_host_js_abort),
@@ -130,6 +132,27 @@ pub(crate) mod js_bindings {
     fn js_panic(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
         crash_handler::suppress_core_dumps_if_necessary();
         crash_handler::panic_impl(b"invoked crashByPanic() handler", None, None);
+    }
+
+    /// Unlike `js_panic`, which calls `panic_impl` directly, this is a real
+    /// `panic!`, so it goes through the `std::panic` hook the crash handler
+    /// installs. A literal message reaches the hook as a `&'static str` payload.
+    #[bun_jsc::host_fn]
+    fn js_rust_panic(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
+        crash_handler::suppress_core_dumps_if_necessary();
+        panic!("invoked crashByRustPanic() handler");
+    }
+
+    /// `Result::unwrap()` on an `Err`, the shape of the `.unwrap()` sites that
+    /// reach the panic hook in production. std formats the `Err` into the
+    /// message, so this one reaches the hook as a `String` payload.
+    #[bun_jsc::host_fn]
+    fn js_rust_unwrap(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
+        crash_handler::suppress_core_dumps_if_necessary();
+        let result: Result<(), &str> =
+            core::hint::black_box(Err("invoked crashByRustUnwrap() handler"));
+        result.unwrap();
+        Ok(JSValue::UNDEFINED)
     }
 
     #[bun_jsc::host_fn]

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -134,12 +134,7 @@ pub(crate) mod js_bindings {
         crash_handler::panic_impl(b"invoked crashByPanic() handler", None, None);
     }
 
-    /// Unlike `js_panic`, which calls `panic_impl` directly, this is a real
-    /// `panic!`, so it goes through the `std::panic` hook the crash handler
-    /// installs. Without an argument the literal reaches the hook as a
-    /// `&'static str` payload; `rustPanic(message)` panics with that message
-    /// (a `String` payload), which is how the tests exercise the hook's
-    /// message cap.
+    /// A real `panic!` (reaches the crash handler through the std panic hook, unlike `js_panic`).
     #[bun_jsc::host_fn]
     fn js_rust_panic(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
         crash_handler::suppress_core_dumps_if_necessary();
@@ -151,9 +146,7 @@ pub(crate) mod js_bindings {
         panic!("{}", bstr::BStr::new(message.slice()));
     }
 
-    /// `Result::unwrap()` on an `Err`, the shape of the `.unwrap()` sites that
-    /// reach the panic hook in production. std formats the `Err` into the
-    /// message, so this one reaches the hook as a `String` payload.
+    /// A real `Result::unwrap()` on an `Err`; std formats the message, so the hook sees a `String` payload.
     #[bun_jsc::host_fn]
     fn js_rust_unwrap(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
         crash_handler::suppress_core_dumps_if_necessary();

--- a/test/cli/run/crash-report-command-char.test.ts
+++ b/test/cli/run/crash-report-command-char.test.ts
@@ -2,9 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, mergeWindowEnvs, tempDir } from "harness";
 import path from "path";
 
-// NOTE: kept separate from run-crash-handler.test.ts on purpose — that file
-// is skip-listed in test/expectations.txt (its segfault-reporter test is
-// broken), so anything added there never runs in CI.
+// The rest of the crash handler's coverage lives in run-crash-handler.test.ts.
 describe.concurrent("crash report command character", () => {
   // Crash while a given subcommand is running and return the command
   // character from the trace string printed to stderr:

--- a/test/cli/run/fixture-crash.js
+++ b/test/cli/run/fixture-crash.js
@@ -12,6 +12,7 @@ if (approach in crash_handler) {
   crash_handler[approach]();
 } else {
   console.error(
-    "usage: bun fixture-crash.js <segfault|segfaultInDll|panic|rootError|outOfMemory|abort|trap|raiseIgnoringPanicHandler>",
+    "usage: bun fixture-crash.js <segfault|segfaultInDll|panic|rustPanic|rustUnwrap|rootError|outOfMemory|abort|trap|raiseIgnoringPanicHandler>",
   );
+  process.exit(1);
 }

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -29,13 +29,23 @@ const panicApproaches = [
   ["rustUnwrap", 'called `Result::unwrap()` on an `Err` value: "invoked crashByRustUnwrap() handler"'],
 ] as const;
 
+// In trace-string mode (release builds, or --debug-crash-handler-use-trace-string)
+// the report ends with the trace string on its own line after "please file a
+// GitHub issue using the link below:". With noReportEnv's empty base URL it is
+// printed as just the path, `/{version}/...`.
+function traceStringFromReport(stderr: string): string {
+  const traceString = (stderr.split("using the link below:")[1] ?? "").trim().split(/\s+/)[0];
+  expect(traceString).toBeTruthy();
+  return traceString;
+}
+
 // A trace string is `{base}/{version}/{header}{frames...}{VLQ 0}{reason}`. For
 // a panic the reason is the tag `0` followed by the zlib-compressed, base64
 // message (see `encode_trace_string` in src/crash_handler/lib.rs). The frames
 // are variable-length, so find the terminator by trying each `A0` (`A` is the
 // VLQ encoding of 0) until the remainder inflates.
 function panicMessageFromTraceString(traceString: string): string | undefined {
-  const pathname = new URL(traceString).pathname;
+  const pathname = new URL(traceString, "http://trace.invalid").pathname;
   const payload = pathname.slice(pathname.indexOf("/", 1) + 1);
   for (let i = payload.indexOf("A0"); i !== -1; i = payload.indexOf("A0", i + 1)) {
     try {
@@ -114,6 +124,39 @@ describe("panics through panic_impl and through the std panic hook print the sam
     // The message is reported on its own, with no `file:line:col` suffix.
     expect(stderr).toContain(`panic(main thread): ${message}\n`);
     expect(stderr).toContain("oh no: Bun has crashed. This indicates a bug in Bun, not your code.");
+    expect(panicMessageFromTraceString(traceStringFromReport(stderr))).toBe(message);
+    expect(exitCode).not.toBe(0);
+  });
+});
+
+// The one thing the panic hook does besides calling the crash handler: a panic
+// payload can be arbitrarily long (an `assert_eq!` dump), so it reports at most
+// MAX_MESSAGE_BYTES (1024) of it, cut on a char boundary (see `rust_panic_hook`
+// in src/crash_handler/lib.rs). `rustPanic(message)` panics with the given
+// message, which reaches the hook as a `String` payload.
+describe("the panic hook caps the reported message at 1024 bytes", () => {
+  const a = (n: number) => Buffer.alloc(n, "a").toString();
+  // [name, JS expression the child panics with, what the report must contain]
+  test.concurrent.each([
+    ["a 1024-byte message is reported whole", `Buffer.alloc(1019, "a") + ":tail"`, `${a(1019)}:tail`],
+    ["a longer message is cut after 1024 bytes", `Buffer.alloc(1024, "a") + ":tail"`, a(1024)],
+    // Bytes 1023-1024 are one two-byte char; cutting at byte 1024 would split it.
+    ["the cut does not split a multi-byte char", `Buffer.alloc(1023, "a") + "\\u00e9"`, a(1023)],
+  ])("%s", async (_name, messageExpr, reported) => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `require("bun:internal-for-testing").crash_handler.rustPanic(${messageExpr})`,
+        "--debug-crash-handler-use-trace-string",
+      ],
+      env: noReportEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    expect(stderr.match(/^panic\(main thread\): (.*)$/m)?.[1]).toBe(reported);
+    expect(panicMessageFromTraceString(traceStringFromReport(stderr))).toBe(reported);
     expect(exitCode).not.toBe(0);
   });
 });
@@ -595,8 +638,8 @@ describe("automatic crash reporter", () => {
 
       // Assert on the report before waiting for the upload, so a crash that
       // never reports fails here instead of timing out on the promise below.
-      const traceString = stderr.split(/\s+/).find(word => word.startsWith(server.url.toString()));
-      expect(traceString).toBeDefined();
+      const traceString = traceStringFromReport(stderr);
+      expect(traceString).toStartWith(server.url.toString());
       if (approach !== "outOfMemory") {
         expect(stderr).toContain("oh no: Bun has crashed. This indicates a bug in Bun, not your code");
       } else {
@@ -607,7 +650,7 @@ describe("automatic crash reporter", () => {
       // so a real Rust panic must encode its message exactly like panic_impl.
       const panicMessage = panicMessages.get(approach);
       if (panicMessage !== undefined) {
-        expect(panicMessageFromTraceString(traceString!)).toBe(panicMessage);
+        expect(panicMessageFromTraceString(traceString)).toBe(panicMessage);
       }
       expect(exitCode).not.toBe(0);
 

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -2,6 +2,7 @@ import { crash_handler } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, isDebug, isLinux, isPosix, isWindows, mergeWindowEnvs, tempDir } from "harness";
 import { rmSync } from "node:fs";
+import { inflateSync } from "node:zlib";
 import path from "path";
 const { getMachOImageZeroOffset } = crash_handler;
 
@@ -14,11 +15,41 @@ const noReportEnv = { ...bunEnv, BUN_CRASH_REPORT_URL: "", BUN_ENABLE_CRASH_REPO
 // without it the fallback printer has no Rust symbol names to assert on.
 const hasSymbolizer = !!(Bun.which("llvm-symbolizer") || Bun.which("llvm-symbolizer-21"));
 
+const fixture = path.join(import.meta.dir, "fixture-crash.js");
+
+// `panic` calls the crash handler's `panic_impl` directly. `rustPanic` and
+// `rustUnwrap` are a real `panic!` and a real `Result::unwrap()` on an `Err`,
+// which is how every `.unwrap()` / `assert!` / `unreachable!()` in Bun crashes:
+// they reach the crash handler through the `std::panic` hook it installs. The
+// literal `panic!` arrives there as a `&'static str` payload; std formats the
+// unwrapped `Err` into a `String` payload. All three must print the same report.
+const panicApproaches = [
+  ["panic", "invoked crashByPanic() handler"],
+  ["rustPanic", "invoked crashByRustPanic() handler"],
+  ["rustUnwrap", 'called `Result::unwrap()` on an `Err` value: "invoked crashByRustUnwrap() handler"'],
+] as const;
+
+// A trace string is `{base}/{version}/{header}{frames...}{VLQ 0}{reason}`. For
+// a panic the reason is the tag `0` followed by the zlib-compressed, base64
+// message (see `encode_trace_string` in src/crash_handler/lib.rs). The frames
+// are variable-length, so find the terminator by trying each `A0` (`A` is the
+// VLQ encoding of 0) until the remainder inflates.
+function panicMessageFromTraceString(traceString: string): string | undefined {
+  const pathname = new URL(traceString).pathname;
+  const payload = pathname.slice(pathname.indexOf("/", 1) + 1);
+  for (let i = payload.indexOf("A0"); i !== -1; i = payload.indexOf("A0", i + 1)) {
+    try {
+      return inflateSync(Buffer.from(payload.slice(i + 2), "base64")).toString();
+    } catch {}
+  }
+  return undefined;
+}
+
 test.if(isDebug && isLinux && hasSymbolizer)(
   "crash trace starts at the crash site, not inside the crash handler",
   async () => {
     await using proc = Bun.spawn({
-      cmd: [bunExe(), path.join(import.meta.dir, "fixture-crash.js"), "panic"],
+      cmd: [bunExe(), fixture, "panic"],
       env: noReportEnv,
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -42,6 +73,50 @@ test.if(isDebug && isLinux && hasSymbolizer)(
   },
   60_000, // symbolizing the debug binary takes several seconds
 );
+
+// For a real Rust panic the innermost frames are std's panic machinery, so the
+// crash site is not frame 0, but it must be in the trace and the crash
+// handler's own frames must not be.
+describe.if(isDebug && isLinux && hasSymbolizer)("Rust panic trace includes the panic site", () => {
+  test.each([
+    ["rustPanic", "js_rust_panic"],
+    ["rustUnwrap", "js_rust_unwrap"],
+  ] as const)(
+    "%s",
+    async (approach, crashSite) => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), fixture, approach],
+        env: noReportEnv,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr).toContain("panic(main thread): ");
+      expect(stdout).toContain(crashSite);
+      expect(stdout).not.toContain("capture_stack_trace");
+      expect(exitCode).not.toBe(0);
+    },
+    60_000, // symbolizing the debug binary takes several seconds
+  );
+});
+
+describe("panics through panic_impl and through the std panic hook print the same report", () => {
+  test.concurrent.each(panicApproaches)("%s", async (approach, message) => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), fixture, approach, "--debug-crash-handler-use-trace-string"],
+      env: noReportEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    // Metadata header, e.g. "Bun Debug v1.4.0 (eabb96de7) Linux x64".
+    expect(stderr).toMatch(/^Bun (Debug |Canary )?v\d+\.\d+\.\d+/m);
+    // The message is reported on its own, with no `file:line:col` suffix.
+    expect(stderr).toContain(`panic(main thread): ${message}\n`);
+    expect(stderr).toContain("oh no: Bun has crashed. This indicates a bug in Bun, not your code.");
+    expect(exitCode).not.toBe(0);
+  });
+});
 
 // `crash()` resets fatal-signal dispositions to SIG_DFL before re-raising so
 // that JS-registered listeners (`process.on("SIGABRT")` etc., installed by
@@ -95,37 +170,25 @@ test.if(isPosix)(
 // reported "illegal hardware instruction" for every crash and parent
 // processes could not distinguish a panic from a CPU/codegen fault.
 describe.if(isPosix)("terminal signal reflects the crash cause", () => {
-  test.each([
-    ["panic", "SIGABRT"],
-    ["outOfMemory", "SIGABRT"],
-    ["segfault", "SIGSEGV"],
-    ["abort", "SIGABRT"],
-    ["trap", "SIGTRAP"],
-  ] as const)("%s terminates with %s", async (approach, expectedSignal) => {
+  test.concurrent.each([
+    ["panic", "SIGABRT", "invoked crashByPanic() handler"],
+    ["rustPanic", "SIGABRT", "invoked crashByRustPanic() handler"],
+    ["rustUnwrap", "SIGABRT", "called `Result::unwrap()` on an `Err` value"],
+    ["outOfMemory", "SIGABRT", "Bun has run out of memory"],
+    ["segfault", "SIGSEGV", "Segmentation fault at address"],
+    ["abort", "SIGABRT", "abort() called"],
+    ["trap", "SIGTRAP", "Trap instruction"],
+  ] as const)("%s terminates with %s", async (approach, expectedSignal, expectedMessage) => {
     await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        path.join(import.meta.dir, "fixture-crash.js"),
-        approach,
-        "--debug-crash-handler-use-trace-string",
-      ],
+      cmd: [bunExe(), fixture, approach, "--debug-crash-handler-use-trace-string"],
       env: noReportEnv,
       stdio: ["ignore", "pipe", "pipe"],
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
-    if (approach === "segfault") {
-      expect(stderr).toContain("Segmentation fault at address");
-    } else if (approach === "panic") {
-      expect(stderr).toContain("invoked crashByPanic() handler");
-    } else if (approach === "abort") {
-      expect(stderr).toContain("abort() called");
-    } else if (approach === "trap") {
-      expect(stderr).toContain("Trap instruction");
-    }
+    expect(stderr).toContain(expectedMessage);
     expect(proc.signalCode).toBe(expectedSignal);
     expect(exitCode).not.toBe(0);
-    void stdout;
   });
 });
 
@@ -176,7 +239,7 @@ describe.if(isPosix)("cwd deleted before startup", () => {
 // handler's own frames in the trace and none of the bun callers.
 test.if(isWindows && isDebug)("Windows: segfault inside a system DLL captures the bun callers", async () => {
   await using proc = Bun.spawn({
-    cmd: [bunExe(), path.join(import.meta.dir, "fixture-crash.js"), "segfaultInDll"],
+    cmd: [bunExe(), fixture, "segfaultInDll"],
     env: noReportEnv,
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -366,7 +429,7 @@ test("raise ignoring panic handler does not trigger the panic handler", async ()
   });
 
   const proc = Bun.spawn({
-    cmd: [bunExe(), path.join(import.meta.dir, "fixture-crash.js"), "raiseIgnoringPanicHandler"],
+    cmd: [bunExe(), fixture, "raiseIgnoringPanicHandler"],
     env: mergeWindowEnvs([
       bunEnv,
       {
@@ -406,12 +469,7 @@ describe.if(isPosix)("SIGABRT/SIGTRAP are caught by the crash handler", () => {
     });
 
     await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        path.join(import.meta.dir, "fixture-crash.js"),
-        approach,
-        "--debug-crash-handler-use-trace-string",
-      ],
+      cmd: [bunExe(), fixture, approach, "--debug-crash-handler-use-trace-string"],
       env: mergeWindowEnvs([
         bunEnv,
         {
@@ -501,7 +559,8 @@ describe.if(isPosix)("SIGABRT/SIGTRAP are caught by the crash handler", () => {
 });
 
 describe("automatic crash reporter", () => {
-  for (const approach of ["panic", "segfault", "outOfMemory"]) {
+  const panicMessages = new Map<string, string>(panicApproaches);
+  for (const approach of ["panic", "rustPanic", "rustUnwrap", "segfault", "outOfMemory"]) {
     test(`${approach} should report`, async () => {
       let sent = false;
       const resolve_handler = Promise.withResolvers();
@@ -518,7 +577,7 @@ describe("automatic crash reporter", () => {
       });
 
       const proc = Bun.spawn({
-        cmd: [bunExe(), path.join(import.meta.dir, "fixture-crash.js"), approach],
+        cmd: [bunExe(), fixture, approach],
         env: mergeWindowEnvs([
           bunEnv,
           {
@@ -534,16 +593,25 @@ describe("automatic crash reporter", () => {
       const stderr = await proc.stderr.text();
       console.log(stderr);
 
-      await resolve_handler.promise;
-
-      expect(exitCode).not.toBe(0);
-      expect(stderr).toContain(server.url.toString());
+      // Assert on the report before waiting for the upload, so a crash that
+      // never reports fails here instead of timing out on the promise below.
+      const traceString = stderr.split(/\s+/).find(word => word.startsWith(server.url.toString()));
+      expect(traceString).toBeDefined();
       if (approach !== "outOfMemory") {
         expect(stderr).toContain("oh no: Bun has crashed. This indicates a bug in Bun, not your code");
       } else {
         expect(stderr.toLowerCase()).toContain("out of memory");
         expect(stderr.toLowerCase()).not.toContain("panic");
       }
+      // bun.report shows the panic message it decodes from the trace string,
+      // so a real Rust panic must encode its message exactly like panic_impl.
+      const panicMessage = panicMessages.get(approach);
+      if (panicMessage !== undefined) {
+        expect(panicMessageFromTraceString(traceString!)).toBe(panicMessage);
+      }
+      expect(exitCode).not.toBe(0);
+
+      await resolve_handler.promise;
       expect(sent).toBe(true);
     });
   }
@@ -572,7 +640,7 @@ test.if(isWindows)(
       await Bun.write(path.join(String(dir), "powershell.exe"), Bun.file(bunExe()));
 
       await using proc = Bun.spawn({
-        cmd: [bunExe(), path.join(import.meta.dir, "fixture-crash.js"), "panic"],
+        cmd: [bunExe(), fixture, "panic"],
         cwd: String(dir),
         env: mergeWindowEnvs([
           bunEnv,


### PR DESCRIPTION
### Problem

- Every Rust `panic!` in the binary (`unwrap()` on `None`/`Err`, failed `assert!`, `unreachable!()`) is reported by `rust_panic_hook` in `src/crash_handler/lib.rs`, which printed its own hand-copied crash report instead of calling `crash_handler()` like `panic_impl`, `Bun__crashHandler`, OOM and the signal handlers do.
- The copy had drifted from `crash_handler()`:
  - it printed `panic: <msg>` instead of `panic(main thread): <msg>`; `scripts/runner.node.mjs:1657` extracts crash labels with `/panic\(.*\): (.*)/`, so a real Rust panic in CI lost its message while a `panic_impl` crash kept it;
  - it skipped the `PANICKING` count (so `Global::exit()` on another thread could cut the report short), `HAS_PRINTED_MESSAGE`, `Output::source::stdio::restore()`, the native-plugin / unsupported-uv-function notes, `reset_segfault_handler()` and the crash auto-reload;
  - a payload longer than its 1024-byte buffer was reported as an empty message (`BoundedArray` appends are all-or-nothing).
- Nothing tested the hook: the `crash_handler.panic()` helper in `bun:internal-for-testing` calls `panic_impl` directly (`src/runtime/api/crash_handler_jsc.rs`), so `run-crash-handler.test.ts` and `crash-report-command-char.test.ts` only covered `panic_impl`. (Item 12 of the review of #30412.)

### Fix

- `rust_panic_hook` now takes the payload string (`PanicHookInfo::payload_as_str`, the same `&'static str` / `String` pair the old code downcast by hand), cuts it at `MAX_MESSAGE_BYTES` (1024) on a char boundary, and calls `crash_handler(CrashReason::Panic(msg), TraceSeed::BeginAddr(return_address()))`. The duplicated report code is deleted.
- `CrashReason` gets a lifetime (`CrashReason<'a>`). A reason is only formatted and passed down to `crash_handler()`/`crash()`, never stored (every use of the type is in `lib.rs`; the only constructors outside it are the unit/`usize` variants in `crash_handler_jsc.rs`), so the four sites that laundered a message to `&'static` with `unsafe { detach_lifetime(..) }` (`panic_impl`, the hook, `Bun__crashHandler`, `cold_handle_error_return_trace`) become plain constructors and the hook contains no `unsafe`. Same shape as the existing `TraceSeed<'a>`.
- Why this is right:
  - this is exactly what `panic_impl` does with its message, so a Rust panic gets the `panic_impl` report, upload, multi-thread handling and SIGABRT by construction;
  - re-entrancy: std aborts a panic raised inside the hook itself, so the hook's own guard was only reachable for a panic raised while `crash_handler()` was already printing a signal/OOM report, and `crash_handler()`'s `PANIC_STAGE` branches already handle that case;
  - `return_address()` is read in the hook's own frame, so the trace is trimmed where the old code trimmed it (verified below: the trace starts at the hook's caller in std and reaches the panicking function);
  - 1024 bytes is the bound the old buffer already imposed; over it the message is now truncated instead of dropped, and every probed message shape still yields a trace string that decodes (table below).
- Test helpers, named like their neighbours: `crash_handler.rustPanic()` is a real `panic!` (a literal, so a `&'static str` payload; `rustPanic(message)` panics with the given message, a `String` payload) and `crash_handler.rustUnwrap()` is a real `Result::unwrap()` on an `Err` (std formats it, also a `String` payload). `panic()` remains the `panic_impl` case. No-argument `rustPanic()` has the same name and message as the helper #38617 adds for its own test, so the two PRs rebase onto each other in either order (#38617 also adds a call to the old hook body, which becomes unnecessary once the hook delegates).
- Tests in `test/cli/run/run-crash-handler.test.ts`:
  - `panic`, `rustPanic` and `rustUnwrap` held to the same assertions: report header, exact `panic(main thread): <message>` line, the `oh no: Bun has crashed` line, and the message inflated back out of the trace string (all platforms); SIGABRT (POSIX table, which now carries the expected message per row); upload of the report with the same decode (reporter tests); on debug Linux, a symbolized trace containing `js_rust_panic` / `js_rust_unwrap` and no capture machinery.
  - The cap: a 1024-byte message is reported whole, a longer one is cut after exactly 1024 bytes, and a two-byte char straddling the cut is dropped rather than split, checked on both the stderr line and the trace string.
  - `fixture-crash.js` exits 1 on an unknown approach; the reporter test asserts on the report before awaiting the upload so a missing report fails fast; the stale note in `crash-report-command-char.test.ts` saying `run-crash-handler.test.ts` is skip-listed is removed (#33952 un-skipped it).
- Fail-before: on main the new cases fail because the helpers do not exist. They also fail against the old hook body with the helpers built in: 4 report-format cases fail on `panic: ...` lacking the thread tag (output below), and the over-cap cases would see an empty message.
- Verified: `bun bd test test/cli/run/run-crash-handler.test.ts test/cli/run/crash-report-command-char.test.ts` is 32 pass, 9 skip (Windows/macOS/non-ASAN-only cases), 0 fail; `cargo clippy` on `bun_crash_handler` and `bun_runtime`, `cargo fmt --check`, `cargo check` of the crate for `x86_64-pc-windows-msvc` and `aarch64-apple-darwin` (the Windows classifier returns `CrashReason<'static>`), and `test/internal/source-lints/` are clean.
- Not changed here: `encode_trace_string` drops the message from the trace string when its compressed form does not fit the 1024-byte `trace_str_buf` (about 800+ bytes of high-entropy text). That affects `panic_impl` identically and is handed off separately.

### Background

- **Crash report and trace string**: `crash_handler()` prints a header (version, kernel, CPU, args), a `panic(<thread>): <reason>` line, then either a symbolized backtrace (debug builds) or a trace string: a URL under bun.report (or `BUN_CRASH_REPORT_URL`) encoding the version, platform, running command, frame addresses and the crash reason. For `CrashReason::Panic` the reason is the tag `0` followed by the zlib-compressed, base64 message, which bun.report inflates to show the message; the tests inflate it the same way. With reporting enabled the URL is also POSTed by `report()`; the tests observe that with a local `Bun.serve`.
- **`panic_impl` vs the std panic hook**: `panic_impl` is the explicit entry point (the `panic()` test helper, `CrashHandler__unsupportedUVFunction`) and forwards to `crash_handler()`. Rust's `panic!` machinery instead calls whatever `std::panic::set_hook` installed. Bun builds with `panic = "abort"`, so the hook is all that runs for a panic, and every `.unwrap()` / `assert!` in production goes through it.
- **Panic payloads**: `panic!("literal")` and `Option::unwrap()` hand the hook a `&'static str`; `panic!` with arguments and `Result::unwrap()` (std formats `"{msg}: {err:?}"`) hand it a `String`. `payload_as_str()` covers both; anything else only comes from `panic_any`. The payload lives in the std panic frames below the hook, which is why borrowing it for the (never returning) `crash_handler()` call is fine.
- **Trim anchor**: the frame-pointer walk drops every frame above the return address passed as `TraceSeed::BeginAddr`, so that address has to be read in a frame that is still live when the walk runs (see the comment in `panic_impl`). Reading it in the hook makes the trace start at the hook's caller.

<details>
<summary>Report-format tests against the old hook body, helpers built in</summary>

```
error: expect(received).toContain(expected)
Expected to contain: "panic(main thread): invoked crashByRustPanic() handler\n"
Received: "...\n\n\npanic: invoked crashByRustPanic() handler\noh no: Bun has crashed. ..."
(fail) panics through panic_impl and through the std panic hook print the same report > rustPanic
(fail) panics through panic_impl and through the std panic hook print the same report > rustUnwrap
(fail) Rust panic trace includes the panic site > rustPanic
(fail) Rust panic trace includes the panic site > rustUnwrap
 22 pass, 4 fail
```

(Run before the cap tests and the trace-string decode were added.)

</details>

<details>
<summary>Symbolized trace of a real unwrap panic with the fix (debug build)</summary>

```
<bun_crash_handler::draft::rust_panic_hook as core::ops::function::Fn<(&std::panic::PanicHookInfo,)>>::call
<alloc::boxed::Box<dyn Fn(&PanicHookInfo)> as Fn<...>>::call
std::panicking::panic_with_hook
std::panicking::panic_handler::{closure#0}
std::sys::backtrace::__rust_end_short_backtrace
__rustc::rust_begin_unwind
core::panicking::panic_fmt
core::result::unwrap_failed
<core::result::Result<(), &str>>::unwrap
bun_runtime::api::crash_handler_jsc::js_bindings::js_rust_unwrap        src/runtime/api/crash_handler_jsc.rs
bun_runtime::api::crash_handler_jsc::js_bindings::__jsc_host_js_rust_unwrap::{closure#0}
bun_jsc::host_fn::to_js_host_call
bun_runtime::api::crash_handler_jsc::js_bindings::__jsc_host_js_rust_unwrap
llint_op_call_ignore_result
```

</details>

<details>
<summary>Long-message probe behind the 1024-byte cap</summary>

```
message                       stderr line   trace string   message decoded from trace string
repetitive text, 1024 B       1024 B        387 chars      1024 B
repetitive text, 5000 B       1024 B (cut)  387 chars      1024 B
hex, 1024 chars               1024 B        945 chars      1024 B
hex, 3000 chars               1024 B (cut)  944 chars      1024 B
"é" x 600 (1200 B)            1024 B (cut)  217 chars      1024 B, cut on a char boundary
base64-like, 700 chars        747 B         944 chars      747 B
base64-like, 800+ chars       full          133 chars      none: pre-existing encoder limit, handed off
```

The first three rows of this table are what the new cap tests pin (whole at 1024, cut after 1024, char boundary).

</details>

