### PR TITLE
node:buffer: return an empty Buffer from Buffer.from(view) when the view is detached

### DIFF
--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -3478,33 +3478,23 @@ static JSC::EncodedJSValue createJSBufferFromJS(JSC::JSGlobalObject* lexicalGlob
         case BigInt64ArrayType:
         case BigUint64ArrayType: {
             // byteOffset and byteLength are ignored in this case, which is consitent with Node.js and new Uint8Array()
+            // A detached view has length 0 (JSC zeroes it on detach), so it becomes an empty Buffer, as in Node.
             JSC::JSArrayBufferView* view = uncheckedDowncast<JSC::JSArrayBufferView>(distinguishingArg.asCell());
-            void* data = view->vector();
-            size_t byteLength = view->length();
-            if (!data) [[unlikely]] {
-                throwException(globalObject, throwScope, createRangeError(globalObject, "Buffer is detached"_s));
-                return {};
-            }
-            auto* uint8Array = createUninitializedBuffer(lexicalGlobalObject, byteLength);
+            size_t length = view->length();
+            auto* uint8Array = createUninitializedBuffer(lexicalGlobalObject, length);
             RETURN_IF_EXCEPTION(throwScope, {});
-            if (byteLength) {
-                uint8Array->setFromTypedArray(lexicalGlobalObject, 0, view, 0, byteLength, CopyType::LeftToRight);
+            if (length) {
+                uint8Array->setFromTypedArray(lexicalGlobalObject, 0, view, 0, length, CopyType::LeftToRight);
             }
             RELEASE_AND_RETURN(throwScope, JSC::JSValue::encode(uint8Array));
-            break;
         }
         case DataViewType:
         case Uint8ArrayType:
         case Uint8ClampedArrayType: {
             // byteOffset and byteLength are ignored in this case, which is consitent with Node.js and new Uint8Array()
+            // A detached view has a null vector and byteLength 0, which createBuffer turns into an empty Buffer, as in Node.
             JSC::JSArrayBufferView* view = uncheckedDowncast<JSC::JSArrayBufferView>(distinguishingArg.asCell());
-            void* data = view->vector();
-            size_t byteLength = view->byteLength();
-            if (!data) [[unlikely]] {
-                throwException(globalObject, throwScope, createRangeError(globalObject, "Buffer is detached"_s));
-                return {};
-            }
-            auto* uint8Array = createBuffer(lexicalGlobalObject, static_cast<uint8_t*>(data), byteLength);
+            auto* uint8Array = createBuffer(lexicalGlobalObject, static_cast<const uint8_t*>(view->vector()), view->byteLength());
             RELEASE_AND_RETURN(throwScope, JSC::JSValue::encode(uint8Array));
         }
         case ArrayBufferType: {

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -3920,6 +3920,88 @@ describe("Buffer.from(arrayBuffer, byteOffset, length) bounds", () => {
   });
 });
 
+// Node's Buffer.from(view) reads view.length, which is 0 once the view's ArrayBuffer
+// has been detached, and returns an empty Buffer rather than throwing.
+describe("Buffer.from(view) and new Buffer(view) with a detached view", () => {
+  function detached(makeView, arrayBuffer = new ArrayBuffer(8)) {
+    const view = makeView(arrayBuffer);
+    arrayBuffer.transfer();
+    return view;
+  }
+
+  function describeResult(makeBuffer) {
+    try {
+      const buf = makeBuffer();
+      return Buffer.isBuffer(buf) ? `Buffer(${buf.length})` : buf;
+    } catch (e) {
+      return `${e.constructor.name}: ${e.message}`;
+    }
+  }
+
+  const viewConstructors = [
+    Uint8Array,
+    Uint8ClampedArray,
+    Int8Array,
+    Uint16Array,
+    Int16Array,
+    Uint32Array,
+    Int32Array,
+    Float16Array,
+    Float32Array,
+    Float64Array,
+    BigInt64Array,
+    BigUint64Array,
+  ];
+
+  it("returns an empty Buffer for every TypedArray type", () => {
+    const results = Object.fromEntries(
+      viewConstructors.map(View => [View.name, describeResult(() => Buffer.from(detached(ab => new View(ab))))]),
+    );
+    expect(results).toEqual(Object.fromEntries(viewConstructors.map(View => [View.name, "Buffer(0)"])));
+  });
+
+  it("returns an empty Buffer for a detached Buffer", () => {
+    const source = detached(ab => Buffer.from(ab));
+    expect([source.buffer.detached, source.length]).toEqual([true, 0]);
+    const copy = Buffer.from(source);
+    expect(Buffer.isBuffer(copy)).toBe(true);
+    expect(copy.length).toBe(0);
+    expect(copy.buffer.detached).toBe(false);
+    expect(copy.toString()).toBe("");
+    // Trailing arguments are ignored for views, detached or not.
+    expect(Buffer.from(source, 1, 2).length).toBe(0);
+  });
+
+  it("returns an empty Buffer from the deprecated constructor forms and for a DataView", () => {
+    const results = {
+      "new Buffer(Uint8Array)": describeResult(() => new Buffer(detached(ab => new Uint8Array(ab)))),
+      "Buffer(Uint8Array)": describeResult(() => Buffer(detached(ab => new Uint8Array(ab)))),
+      "new Buffer(Uint16Array)": describeResult(() => new Buffer(detached(ab => new Uint16Array(ab)))),
+      "Buffer(Uint16Array)": describeResult(() => Buffer(detached(ab => new Uint16Array(ab)))),
+      // A DataView has no .length, so Buffer.from() never copies one; new Buffer() hands it to the native constructor.
+      "new Buffer(DataView)": describeResult(() => new Buffer(detached(ab => new DataView(ab)))),
+      "Buffer(DataView)": describeResult(() => Buffer(detached(ab => new DataView(ab)))),
+      "Buffer.from(DataView)": describeResult(() => Buffer.from(detached(ab => new DataView(ab)))),
+    };
+    expect(results).toEqual(Object.fromEntries(Object.keys(results).map(name => [name, "Buffer(0)"])));
+  });
+
+  it("returns an empty Buffer for length-tracking views of a detached resizable ArrayBuffer", () => {
+    const resizable = () => new ArrayBuffer(8, { maxByteLength: 16 });
+    const results = {
+      Uint8Array: describeResult(() => Buffer.from(detached(rab => new Uint8Array(rab), resizable()))),
+      Uint16Array: describeResult(() => Buffer.from(detached(rab => new Uint16Array(rab), resizable()))),
+      DataView: describeResult(() => new Buffer(detached(rab => new DataView(rab), resizable()))),
+    };
+    expect(results).toEqual({ Uint8Array: "Buffer(0)", Uint16Array: "Buffer(0)", DataView: "Buffer(0)" });
+  });
+
+  it("still copies the bytes of a live view", () => {
+    expect(Buffer.from(new Uint8Array([1, 2, 3, 4]))).toEqual(Buffer.from([1, 2, 3, 4]));
+    expect(Buffer.from(new Uint16Array([1, 258]))).toEqual(Buffer.from([1, 2]));
+  });
+});
+
 describe("ERR_BUFFER_OUT_OF_BOUNDS", () => {
   for (const method of ["writeBigInt64BE", "writeBigInt64LE", "writeBigUInt64BE", "writeBigUInt64LE"]) {
     for (const bufferLength of [0, 1, 2, 3, 4, 5, 6]) {


### PR DESCRIPTION
### Problem
- `Buffer.from(view)`, `new Buffer(view)` and `Buffer(view)` throw `RangeError: Buffer is detached` when `view` is a TypedArray, Buffer or DataView whose ArrayBuffer has been detached. Node (checked against v26.3.0) returns an empty Buffer for every one of these.
- Cause: the two view branches of the native Buffer constructor in `src/jsc/bindings/JSBuffer.cpp` (`createJSBufferFromJS`, previously lines 3484 and 3503) throw whenever `view->vector()` is null, which is what a detached view reports.
- Reproduces on bun 1.4.0 and on main:
  ```js
  const ab = new ArrayBuffer(8);
  const view = new Uint8Array(ab);
  ab.transfer();
  Buffer.from(view).length; // node: 0, bun: RangeError: Buffer is detached
  ```

### Fix
- Removes the two `vector() == null` throws, so a detached view goes through the normal copy path and comes out as an empty Buffer.
- This is correct because JSC zeroes a view's length when it is detached (`JSArrayBufferView::detachFromArrayBuffer` sets `m_length = 0` and clears the vector), so `length()` / `byteLength()` are 0 for a detached view. The non-Uint8 branch only calls `setFromTypedArray` when the length is non-zero, and `createBuffer()` only copies when both the pointer is non-null and the length is non-zero, so neither branch reads through the null vector.
- Matches Node: `lib/buffer.js` `fromObject` -> `fromArrayLike` reads `view.length`, sees 0, and returns `new FastBuffer()`. `Buffer.copyBytesFrom` in the same file already follows this pattern (`view->length() == 0` -> empty Buffer) and returns an empty Buffer for a detached view today.
- `Buffer.from(detachedArrayBuffer)` (the ArrayBuffer itself, not a view) still throws a TypeError, as it does in Node, and `Buffer.concat([detachedView])` still throws a TypeError in both runtimes; this change only touches the view branches.
- Verified with `test/js/node/buffer.test.js` (new `describe` block "Buffer.from(view) and new Buffer(view) with a detached view"): 4 of its 5 tests fail on bun 1.4.0 with `RangeError: Buffer is detached`, all 5 pass with this change. The whole file passes (623 tests), as do the upstream `test-buffer-from`, `test-buffer-new`, `test-buffer-arraybuffer`, `test-buffer-resizable`, `test-buffer-alloc`, `test-buffer-fakes` and `test-buffer-inheritance` tests. The new tests cover every TypedArray type (including the BigInt ones), a detached Buffer, the `new Buffer()` / `Buffer()` forms, DataView through both `new Buffer()` and `Buffer.from()`, length-tracking views of a detached resizable ArrayBuffer (the non-raw-length path in JSC), and a live-view control.

### Background
- Detaching: `ArrayBuffer.prototype.transfer()`, `structuredClone(ab, { transfer })`, `postMessage` transfers and WebAssembly memory growth detach an ArrayBuffer. Every view over it keeps existing but has a length of 0; in JSC this is implemented by zeroing the view's stored length and nulling its data pointer (`vector()`).
- `Buffer.from(value)` is implemented in `src/js/builtins/JSBufferConstructor.ts`. For TypedArrays (including Buffers) it calls `new $Buffer(value)`, which is the native constructor in `JSBuffer.cpp` that this PR changes. A DataView is not a TypedArray, so `Buffer.from(dataView)` takes the JS fallback and already returned an empty Buffer; `new Buffer(dataView)` goes straight to the native constructor and was throwing, which is why the tests exercise the DataView case through `new Buffer()` as well.
- `createBuffer(globalObject, ptr, length)` in `JSBuffer.cpp` allocates a Buffer of `length` bytes and only memcpys when `ptr` is non-null and `length > 0`, so passing it a detached view's `(nullptr, 0)` yields an empty Buffer.

<details>
<summary>Node vs bun on the cases the tests cover</summary>

Each of the following returns a 0-length Buffer in Node v26.3.0 and threw `RangeError: Buffer is detached` in bun 1.4.0 (`Buffer.from(detachedDataView)` was already empty in both):

```
Buffer.from(detached Buffer / Uint8Array / Uint8ClampedArray / Int8Array / Uint16Array / Int16Array /
            Uint32Array / Int32Array / Float16Array / Float32Array / Float64Array / BigInt64Array / BigUint64Array)
Buffer.from(detached Uint8Array, 1, 2)
new Buffer(detached Uint8Array / Uint16Array / DataView), Buffer(detached Uint8Array / Uint16Array / DataView)
Buffer.from(length-tracking Uint8Array / Uint16Array over a detached resizable ArrayBuffer)
new Buffer(length-tracking DataView over a detached resizable ArrayBuffer)
```

Unchanged and already consistent with Node (both throw a TypeError): `Buffer.from(detachedArrayBuffer)`, `Buffer.concat([detachedView])`, `new Uint8Array(detachedView)`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/buffer.test.js

<!-- robobun:evidence:end -->