### PR TITLE
ci: pin mordant at the plain-language messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ exclude = ["vendor"]
 # (see its rust-toolchain), which must still be able to compile this workspace.
 [workspace.metadata.dylint]
 libraries = [
-    { git = "https://github.com/scarletindustries/mordant", rev = "173f675deacd57387e78a63ab68b6dd7af8a1361" },
+    { git = "https://github.com/scarletindustries/mordant", rev = "12d279767fd7150afe7e549003896b5ec54493f6" },
 ]
 
 [workspace.package]


### PR DESCRIPTION
scarletindustries/mordant#16 rewrote every diagnostic as: what is wrong, a note at the other place that proves it, and an edit to make. This moves the pin there so the mordant job prints those. Detection and counts are unchanged, so the baseline is untouched; the ratchet run is clean at the new pin locally.