### PR TITLE
base64: check the output length before handing the buffer to simdutf

### DIFF
--- a/scripts/rust-miri.ts
+++ b/scripts/rust-miri.ts
@@ -46,6 +46,7 @@ const MIRI_CRATES = [
   "bun_ptr",
   "bun_resolve_builtins",
   "bun_shell_parser",
+  "bun_simdutf_sys",
   "bun_threading",
   "bun_wyhash",
 ];

--- a/scripts/rust-miri.ts
+++ b/scripts/rust-miri.ts
@@ -51,6 +51,13 @@ const MIRI_CRATES = [
   "bun_wyhash",
 ];
 
+// Crates with tests that pin a check to release builds: an `assert!` in front
+// of an FFI write, which the tests only distinguish from a `debug_assert!`
+// (compiled out in release) when debug assertions are off. They get a second
+// run with `--release`; the default run keeps debug assertions on for every
+// other crate's `debug_assert!` coverage.
+const RELEASE_MIRI_CRATES = ["bun_base64", "bun_simdutf_sys"];
+
 function run(cmd: string, args: string[], opts: Parameters<typeof spawnSync>[2] = {}) {
   return spawnSync(cmd, args, { stdio: "inherit", cwd: repo, ...opts });
 }
@@ -80,14 +87,20 @@ if (!existsSync(buildOptionsRs) || !existsSync(lolhtmlCargo)) {
   }
 }
 
-const extraArgs = process.argv.slice(2);
-const crateArgs = extraArgs.length > 0 ? extraArgs : MIRI_CRATES.flatMap(c => ["-p", c]);
+function miriTest(args: string[]): number {
+  console.log(`\x1b[36m[miri]\x1b[0m cargo miri test ${args.join(" ")}`);
+  const r = run("cargo", ["miri", "test", ...args], {
+    env: {
+      ...process.env,
+      MIRIFLAGS: ["-Zmiri-tree-borrows", process.env.MIRIFLAGS ?? ""].join(" ").trim(),
+    },
+  });
+  return r.status ?? 1;
+}
 
-console.log(`\x1b[36m[miri]\x1b[0m cargo miri test ${crateArgs.join(" ")}`);
-const r = run("cargo", ["miri", "test", ...crateArgs], {
-  env: {
-    ...process.env,
-    MIRIFLAGS: ["-Zmiri-tree-borrows", process.env.MIRIFLAGS ?? ""].join(" ").trim(),
-  },
-});
-process.exit(r.status ?? 1);
+const extraArgs = process.argv.slice(2);
+if (extraArgs.length > 0) process.exit(miriTest(extraArgs));
+
+const status = miriTest(MIRI_CRATES.flatMap(c => ["-p", c]));
+if (status !== 0) process.exit(status);
+process.exit(miriTest(["--release", ...RELEASE_MIRI_CRATES.flatMap(c => ["-p", c])]));

--- a/src/base64/lib.rs
+++ b/src/base64/lib.rs
@@ -173,10 +173,11 @@ pub const fn url_safe_encode_len(source: &[u8]) -> usize {
     simdutf::base64::encode_len(source.len(), true)
 }
 
-// Run under `cargo miri test` (scripts/rust-miri.ts), where reaching simdutf
-// itself fails the test: these check that a too-short destination is rejected
-// before the encoder is handed a buffer it would overflow. One byte encodes to
-// 4 bytes padded and 2 bytes URL-safe; each destination is one byte short.
+// Run under `cargo miri test`, also with `--release` (scripts/rust-miri.ts), where
+// reaching simdutf itself fails the test: a too-short destination has to be
+// rejected before the encoder is handed it, by a check that is still compiled
+// in release builds. One byte encodes to 4 bytes padded and 2 bytes URL-safe;
+// each destination is one byte short.
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/base64/lib.rs
+++ b/src/base64/lib.rs
@@ -131,15 +131,12 @@ pub fn encode_alloc(source: &[u8]) -> Vec<u8> {
 /// * `-` and `_` are used instead of `+` and `/`
 ///
 /// Panics if `dest` is shorter than [`url_safe_encode_len`]`(source)`.
-///
 /// See the documentation for simdutf's `binary_to_base64` function for more details (simdutf_impl.h).
 pub fn encode_url_safe(dest: &mut [u8], source: &[u8]) -> usize {
     simdutf::base64::encode(source, dest, true)
 }
 
-/// `encode_url_safe` into a freshly-allocated `Vec<u8>` sized exactly via
-/// `url_safe_encode_len` (the exact no-padding length, so the trailing
-/// `truncate` is a no-op kept for symmetry with `encode_alloc`).
+/// `encode_url_safe` into a freshly allocated `Vec<u8>` of exactly `url_safe_encode_len(source)` bytes.
 pub fn simdutf_encode_url_safe_alloc(source: &[u8]) -> Vec<u8> {
     let len = url_safe_encode_len(source);
     let mut destination = vec![0u8; len];
@@ -173,11 +170,7 @@ pub const fn url_safe_encode_len(source: &[u8]) -> usize {
     simdutf::base64::encode_len(source.len(), true)
 }
 
-// Run under `cargo miri test`, also with `--release` (scripts/rust-miri.ts), where
-// reaching simdutf itself fails the test: a too-short destination has to be
-// rejected before the encoder is handed it, by a check that is still compiled
-// in release builds. One byte encodes to 4 bytes padded and 2 bytes URL-safe;
-// each destination is one byte short.
+// Run by scripts/rust-miri.ts (also with --release), where reaching simdutf fails the test.
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/base64/lib.rs
+++ b/src/base64/lib.rs
@@ -125,14 +125,12 @@ pub fn encode_alloc(source: &[u8]) -> Vec<u8> {
     destination
 }
 
-fn simdutf_encode_len_url_safe(source_len: usize) -> usize {
-    simdutf::base64::encode_len(source_len, true)
-}
-
 /// Encode with the following differences from regular `encode` function:
 ///
 /// * No padding is added (the extra `=` characters at the end)
 /// * `-` and `_` are used instead of `+` and `/`
+///
+/// Panics if `dest` is shorter than [`url_safe_encode_len`]`(source)`.
 ///
 /// See the documentation for simdutf's `binary_to_base64` function for more details (simdutf_impl.h).
 pub fn encode_url_safe(dest: &mut [u8], source: &[u8]) -> usize {
@@ -140,10 +138,10 @@ pub fn encode_url_safe(dest: &mut [u8], source: &[u8]) -> usize {
 }
 
 /// `encode_url_safe` into a freshly-allocated `Vec<u8>` sized exactly via
-/// `simdutf_encode_len_url_safe` (simdutf computes the exact no-padding length, so
-/// the trailing `truncate` is a no-op kept for symmetry with `encode_alloc`).
+/// `url_safe_encode_len` (the exact no-padding length, so the trailing
+/// `truncate` is a no-op kept for symmetry with `encode_alloc`).
 pub fn simdutf_encode_url_safe_alloc(source: &[u8]) -> Vec<u8> {
-    let len = simdutf_encode_len_url_safe(source.len());
+    let len = url_safe_encode_len(source);
     let mut destination = vec![0u8; len];
     let encoded_len = encode_url_safe(&mut destination, source);
     destination.truncate(encoded_len);
@@ -171,17 +169,31 @@ pub const fn encode_len_from_size(source: usize) -> usize {
 }
 
 #[inline]
-const fn url_safe_encode_len_from_size(n: usize) -> usize {
-    // Equivalent to WebKit's `ceil(n * 4 / 3)`, but split so the intermediate
-    // product can't overflow before the divide for large `n`.
-    let full_chunks = n / 3;
-    let leftover = n % 3;
-    full_chunks * 4 + (leftover * 4).div_ceil(3)
+pub const fn url_safe_encode_len(source: &[u8]) -> usize {
+    simdutf::base64::encode_len(source.len(), true)
 }
 
-#[inline]
-pub const fn url_safe_encode_len(source: &[u8]) -> usize {
-    url_safe_encode_len_from_size(source.len())
+// Run under `cargo miri test` (scripts/rust-miri.ts), where reaching simdutf
+// itself fails the test: these check that a too-short destination is rejected
+// before the encoder is handed a buffer it would overflow. One byte encodes to
+// 4 bytes padded and 2 bytes URL-safe; each destination is one byte short.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[should_panic(expected = "need 4 bytes for a 1-byte input, got 3")]
+    fn encode_panics_when_the_destination_is_too_short() {
+        let mut dest = [0u8; 3];
+        encode(&mut dest, b"a");
+    }
+
+    #[test]
+    #[should_panic(expected = "need 2 bytes for a 1-byte input, got 1")]
+    fn encode_url_safe_panics_when_the_destination_is_too_short() {
+        let mut dest = [0u8; 1];
+        encode_url_safe(&mut dest, b"a");
+    }
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -972,7 +984,7 @@ pub fn wyhash_url_safe<'a>(
     let h: u32 = hasher.final_() as u32; // @truncate
     let h_bytes: [u8; 4] = h.to_le_bytes();
 
-    let encode_len = simdutf_encode_len_url_safe(h_bytes.len());
+    let encode_len = url_safe_encode_len(&h_bytes);
 
     // Always alloc a fresh slice from the arena.
     // PERF: no buffer reuse for large encode_len — profile if hot.

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -3598,20 +3598,19 @@ pub mod base64 {
     /// padded). Port of `bun.base64.encodeLen`.
     #[inline]
     pub const fn encode_len(source: &[u8]) -> usize {
-        // simdutf::base64_length_from_binary(len, default)
         standard_encoder_calc_size(source.len())
     }
 
     /// `bun.base64.encode` — standard alphabet, padded. Returns bytes written.
+    /// Panics if `dest` is shorter than [`encode_len`]`(source)`.
     pub fn encode(dest: &mut [u8], source: &[u8]) -> usize {
-        debug_assert!(dest.len() >= encode_len(source));
         simdutf::base64::encode(source, dest, false)
     }
 
     /// Encoded output size for a standard-base64 input of `source_len` bytes.
     #[inline]
     pub const fn standard_encoder_calc_size(source_len: usize) -> usize {
-        source_len.div_ceil(3) * 4
+        simdutf::base64::encode_len(source_len, false)
     }
 
     /// Standard-base64 encode, returning the written sub-slice of `dest`.

--- a/src/codegen/generate-js2native.ts
+++ b/src/codegen/generate-js2native.ts
@@ -84,6 +84,7 @@ const rustIdentifierPaths: Record<string, string> = {
   "parse_args.rs": "runtime/node/util/parse_args.rs",
   "patch.rs": "patch/patch.rs",
   "postgres.rs": "sql_jsc/postgres.rs",
+  "runtime/base64_testing.rs": "runtime/base64_testing.rs",
   "runtime/dns_jsc/dns.rs": "runtime/dns_jsc/dns.rs",
   "runtime/node/types.rs": "runtime/node/types.rs",
   "runtime/socket/socket.rs": "runtime/socket/socket.rs",

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -580,6 +580,11 @@ export const linearFifoOrderedRemoveProbe = $newRustFunction(
   "TestingAPIs.orderedRemoveProbe",
   1,
 ) as (scenario: number) => number[];
+export const base64EncodeProbe = $newRustFunction("runtime/base64_testing.rs", "encodeProbe", 3) as (
+  inputLength: number,
+  destinationLength: number,
+  urlSafe: boolean,
+) => string;
 export const hasNonReifiedStatic = $newCppFunction("InternalForTesting.cpp", "jsFunction_hasReifiedStatic", 1);
 
 interface setSocketOptionsFn {

--- a/src/runtime/base64_testing.rs
+++ b/src/runtime/base64_testing.rs
@@ -1,21 +1,8 @@
-//! Test-only bridge exposing `bun_base64::encode` / `encode_url_safe` with a
-//! caller-chosen destination length to `bun:internal-for-testing` (see
-//! `src/js/internal-for-testing.ts`).
-//!
-//! Every in-tree caller sizes its destination with the matching length helper,
-//! so no JS API can hand the encoders a destination that is too short. The
-//! encoders' contract for that case (panic before simdutf writes past the end
-//! of the slice, see `simdutf::base64::encode`) therefore needs a probe to be
-//! exercised against the built binary, including release builds, where a
-//! `debug_assert!` would have compiled out. Registered via
-//! `$newRustFunction("runtime/base64_testing.rs", "encodeProbe", 3)`.
+//! `bun:internal-for-testing` probe for test/internal/base64-encode-output-bounds.test.ts: the base64 encoders with a caller-chosen destination length.
 
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult, StringJsc};
 
-/// `base64EncodeProbe(inputLength, destinationLength, urlSafe)`: encodes the
-/// bytes `0, 1, .., inputLength - 1` (truncated to `u8`) into a destination of
-/// `destinationLength` bytes and returns the bytes the encoder reported
-/// writing, as a string.
+/// `base64EncodeProbe(inputLength, destinationLength, urlSafe)`: encodes the bytes `0..inputLength` and returns what was written.
 pub(crate) fn encode_probe(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     let input: Vec<u8> = (0..frame.argument(0).to_u32()).map(|i| i as u8).collect();
     let mut destination = vec![0u8; frame.argument(1).to_u32() as usize];
@@ -27,8 +14,7 @@ pub(crate) fn encode_probe(global: &JSGlobalObject, frame: &CallFrame) -> JsResu
         bun_base64::encode_len(&input)
     };
     if destination.len() < needed {
-        // The panic this provokes is the behavior under test; keep CI free of
-        // core dumps from it, as the crash_handler test hooks do.
+        // The panic below is the expected result; don't leave a core dump behind in CI.
         bun_crash_handler::suppress_core_dumps_if_necessary();
     }
 

--- a/src/runtime/base64_testing.rs
+++ b/src/runtime/base64_testing.rs
@@ -1,0 +1,41 @@
+//! Test-only bridge exposing `bun_base64::encode` / `encode_url_safe` with a
+//! caller-chosen destination length to `bun:internal-for-testing` (see
+//! `src/js/internal-for-testing.ts`).
+//!
+//! Every in-tree caller sizes its destination with the matching length helper,
+//! so no JS API can hand the encoders a destination that is too short. The
+//! encoders' contract for that case (panic before simdutf writes past the end
+//! of the slice, see `simdutf::base64::encode`) therefore needs a probe to be
+//! exercised against the built binary, including release builds, where a
+//! `debug_assert!` would have compiled out. Registered via
+//! `$newRustFunction("runtime/base64_testing.rs", "encodeProbe", 3)`.
+
+use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult, StringJsc};
+
+/// `base64EncodeProbe(inputLength, destinationLength, urlSafe)`: encodes the
+/// bytes `0, 1, .., inputLength - 1` (truncated to `u8`) into a destination of
+/// `destinationLength` bytes and returns the bytes the encoder reported
+/// writing, as a string.
+pub(crate) fn encode_probe(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    let input: Vec<u8> = (0..frame.argument(0).to_u32()).map(|i| i as u8).collect();
+    let mut destination = vec![0u8; frame.argument(1).to_u32() as usize];
+    let url_safe = frame.argument(2).to_boolean();
+
+    let needed = if url_safe {
+        bun_base64::url_safe_encode_len(&input)
+    } else {
+        bun_base64::encode_len(&input)
+    };
+    if destination.len() < needed {
+        // The panic this provokes is the behavior under test; keep CI free of
+        // core dumps from it, as the crash_handler test hooks do.
+        bun_crash_handler::suppress_core_dumps_if_necessary();
+    }
+
+    let written = if url_safe {
+        bun_base64::encode_url_safe(&mut destination, &input)
+    } else {
+        bun_base64::encode(&mut destination, &input)
+    };
+    bun_core::String::clone_latin1(&destination[..written]).to_js(global)
+}

--- a/src/runtime/lib.rs
+++ b/src/runtime/lib.rs
@@ -37,6 +37,7 @@ pub mod shell;
 // cycle the `bun_bun_js` shims were papering over.
 #[path = "api.rs"]
 pub mod api;
+pub mod base64_testing;
 pub mod dispatch;
 pub mod hw_exports;
 pub mod ipc;

--- a/src/simdutf_sys/bun-simdutf.cpp
+++ b/src/simdutf_sys/bun-simdutf.cpp
@@ -187,11 +187,6 @@ size_t simdutf__base64_encode(const char* input, size_t length, char* output, in
     return simdutf::binary_to_base64(input, length, output, is_urlsafe ? simdutf::base64_url : simdutf::base64_default);
 }
 
-size_t simdutf__base64_length_from_binary(size_t length, int is_urlsafe)
-{
-    return simdutf::base64_length_from_binary(length, is_urlsafe ? simdutf::base64_url : simdutf::base64_default);
-}
-
 SIMDUTFResult simdutf__base64_decode_from_binary(const char* input, size_t length, char* output, size_t outlen_, int is_urlsafe)
 {
     size_t outlen = outlen_;

--- a/src/simdutf_sys/simdutf.rs
+++ b/src/simdutf_sys/simdutf.rs
@@ -484,13 +484,7 @@ pub mod base64 {
         ) -> SIMDUTFResult;
     }
 
-    /// Encodes `input` into the front of `output` and returns the number of
-    /// bytes written, which is always `encode_len(input.len(), is_urlsafe)`.
-    ///
-    /// # Panics
-    /// If `output` is shorter than that. simdutf is not told the output
-    /// length and always writes the whole encoding, so a short buffer would
-    /// be a buffer overflow, not a truncated result.
+    /// Writes exactly `encode_len(input.len(), is_urlsafe)` bytes; panics if `output` is shorter (simdutf is never told its length).
     pub fn encode(input: &[u8], output: &mut [u8], is_urlsafe: bool) -> usize {
         let needed = encode_len(input.len(), is_urlsafe);
         assert!(
@@ -523,12 +517,7 @@ pub mod base64 {
         written
     }
 
-    /// Number of bytes [`encode`] writes for `input_len` input bytes: the
-    /// standard alphabet pads to a multiple of 4, base64url does not (a 1-byte
-    /// tail becomes 2 characters, a 2-byte tail 3). Same formula as simdutf's
-    /// `base64_length_from_binary`, which `binary_to_base64` always writes in
-    /// full; computed here so the check in [`encode`] needs no FFI call and
-    /// buffer sizes can be `const`.
+    /// simdutf's `base64_length_from_binary`, which is exactly what [`encode`] writes; in Rust so the check in `encode` is plain arithmetic.
     pub const fn encode_len(input_len: usize, is_urlsafe: bool) -> usize {
         if !is_urlsafe {
             return input_len.div_ceil(3) * 4;
@@ -567,12 +556,7 @@ pub mod base64 {
         }
     }
 
-    // Run under `cargo miri test`, also with `--release` (scripts/rust-miri.ts):
-    // reaching the foreign call fails the test, so a short buffer has to be
-    // rejected before simdutf is handed it, and a `debug_assert!` would only do
-    // that in the non-release run. Exact-fit buffers are covered by every base64
-    // encode in the JS suite. One input byte encodes to 4 bytes padded and 2
-    // bytes URL-safe; each buffer below is one byte short.
+    // Run by scripts/rust-miri.ts (also with --release), where reaching the foreign call fails the test.
     #[cfg(test)]
     mod tests {
         use super::*;

--- a/src/simdutf_sys/simdutf.rs
+++ b/src/simdutf_sys/simdutf.rs
@@ -567,9 +567,10 @@ pub mod base64 {
         }
     }
 
-    // Run under `cargo miri test` (scripts/rust-miri.ts), where reaching the
-    // foreign call fails the test: a short buffer has to be rejected before
-    // simdutf is handed it. Exact-fit buffers are covered by every base64
+    // Run under `cargo miri test`, also with `--release` (scripts/rust-miri.ts):
+    // reaching the foreign call fails the test, so a short buffer has to be
+    // rejected before simdutf is handed it, and a `debug_assert!` would only do
+    // that in the non-release run. Exact-fit buffers are covered by every base64
     // encode in the JS suite. One input byte encodes to 4 bytes padded and 2
     // bytes URL-safe; each buffer below is one byte short.
     #[cfg(test)]

--- a/src/simdutf_sys/simdutf.rs
+++ b/src/simdutf_sys/simdutf.rs
@@ -482,19 +482,26 @@ pub mod base64 {
             output: *mut u8,
             outlen: usize,
         ) -> SIMDUTFResult;
-        fn simdutf__base64_length_from_binary(length: usize, options: c_int) -> usize;
     }
 
+    /// Encodes `input` into the front of `output` and returns the number of
+    /// bytes written, which is always `encode_len(input.len(), is_urlsafe)`.
+    ///
+    /// # Panics
+    /// If `output` is shorter than that. simdutf is not told the output
+    /// length and always writes the whole encoding, so a short buffer would
+    /// be a buffer overflow, not a truncated result.
     pub fn encode(input: &[u8], output: &mut [u8], is_urlsafe: bool) -> usize {
-        // SAFETY: caller guarantees output.len() >= encode_len(input.len(), is_urlsafe).
-        unsafe {
-            simdutf__base64_encode(
-                input.as_ptr(),
-                input.len(),
-                output.as_mut_ptr(),
-                is_urlsafe as c_int,
-            )
-        }
+        let needed = encode_len(input.len(), is_urlsafe);
+        assert!(
+            output.len() >= needed,
+            "base64 encode: output buffer too small: need {needed} bytes for a {}-byte input, got {}",
+            input.len(),
+            output.len(),
+        );
+        // SAFETY: `output` holds at least the `needed` bytes `encode_raw`
+        // writes, and as a live `&mut` it cannot overlap `input`.
+        unsafe { encode_raw(input, output.as_mut_ptr(), is_urlsafe) }
     }
 
     /// Raw-pointer variant of [`encode`] for writing into uninitialised
@@ -509,12 +516,25 @@ pub mod base64 {
     pub unsafe fn encode_raw(input: &[u8], output: *mut u8, is_urlsafe: bool) -> usize {
         // SAFETY: caller contract guarantees `output` is valid for
         // `encode_len(input.len(), is_urlsafe)` bytes and disjoint from `input`.
-        unsafe { simdutf__base64_encode(input.as_ptr(), input.len(), output, is_urlsafe as c_int) }
+        let written = unsafe {
+            simdutf__base64_encode(input.as_ptr(), input.len(), output, is_urlsafe as c_int)
+        };
+        debug_assert_eq!(written, encode_len(input.len(), is_urlsafe));
+        written
     }
 
-    pub fn encode_len(input: usize, is_urlsafe: bool) -> usize {
-        // SAFETY: pure length computation; no pointers dereferenced.
-        unsafe { simdutf__base64_length_from_binary(input, is_urlsafe as c_int) }
+    /// Number of bytes [`encode`] writes for `input_len` input bytes: the
+    /// standard alphabet pads to a multiple of 4, base64url does not (a 1-byte
+    /// tail becomes 2 characters, a 2-byte tail 3). Same formula as simdutf's
+    /// `base64_length_from_binary`, which `binary_to_base64` always writes in
+    /// full; computed here so the check in [`encode`] needs no FFI call and
+    /// buffer sizes can be `const`.
+    pub const fn encode_len(input_len: usize, is_urlsafe: bool) -> usize {
+        if !is_urlsafe {
+            return input_len.div_ceil(3) * 4;
+        }
+        let tail = input_len % 3;
+        input_len / 3 * 4 + if tail == 0 { 0 } else { tail + 1 }
     }
 
     pub fn decode(input: &[u8], output: &mut [u8], is_urlsafe: bool) -> SIMDUTFResult {
@@ -544,6 +564,38 @@ pub mod base64 {
                 output.as_mut_ptr(),
                 output.len(),
             )
+        }
+    }
+
+    // Run under `cargo miri test` (scripts/rust-miri.ts), where reaching the
+    // foreign call fails the test: a short buffer has to be rejected before
+    // simdutf is handed it. Exact-fit buffers are covered by every base64
+    // encode in the JS suite. One input byte encodes to 4 bytes padded and 2
+    // bytes URL-safe; each buffer below is one byte short.
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn encode_len_pads_the_standard_alphabet_only() {
+            let standard: Vec<usize> = (0..8).map(|n| encode_len(n, false)).collect();
+            assert_eq!(standard, [0, 4, 4, 4, 8, 8, 8, 12]);
+            let url_safe: Vec<usize> = (0..8).map(|n| encode_len(n, true)).collect();
+            assert_eq!(url_safe, [0, 2, 3, 4, 6, 7, 8, 10]);
+        }
+
+        #[test]
+        #[should_panic(expected = "need 4 bytes for a 1-byte input, got 3")]
+        fn encode_panics_when_the_padded_output_does_not_fit() {
+            let mut output = [0u8; 3];
+            encode(b"a", &mut output, false);
+        }
+
+        #[test]
+        #[should_panic(expected = "need 2 bytes for a 1-byte input, got 1")]
+        fn encode_panics_when_the_url_safe_output_does_not_fit() {
+            let mut output = [0u8; 1];
+            encode(b"a", &mut output, true);
         }
     }
 }

--- a/test/internal/base64-encode-output-bounds.test.ts
+++ b/test/internal/base64-encode-output-bounds.test.ts
@@ -1,0 +1,77 @@
+/**
+ * `simdutf::base64::encode` (src/simdutf_sys/simdutf.rs) hands C++ the output
+ * slice as a bare pointer; simdutf then writes the whole encoding without ever
+ * seeing the slice length. The length check in that wrapper is all that keeps a
+ * short buffer passed by safe code (`bun_base64::encode` / `encode_url_safe`,
+ * a few dozen callers) from becoming a heap overflow. No JS API reaches the
+ * encoder with a short buffer, so the contract is pinned by `#[should_panic]`
+ * unit tests in bun_simdutf_sys and bun_base64.
+ *
+ * Those test binaries reference simdutf symbols that only exist in the full bun
+ * link, so plain `cargo test` cannot link them; `cargo miri test` (what CI's
+ * `bun run rust:miri` runs, see scripts/rust-miri.ts) interprets them instead.
+ * With the check in place the wrapper panics before the foreign call; without
+ * it, Miri stops the test at the `simdutf__base64_encode` call the short buffer
+ * was about to be handed to. This test runs those unit tests and requires each
+ * one to have passed, so deleting them fails it too. Skipped where miri is not
+ * installed or the cargo workspace is not resolvable (test-only CI lanes run a
+ * prebuilt binary; same prerequisite check as linear-fifo.test.ts).
+ */
+import { expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+const cargoBin = Bun.which("cargo");
+const repoRoot = path.resolve(import.meta.dir, "..", "..");
+const workspaceResolvable =
+  existsSync(path.join(repoRoot, "vendor", "lolhtml", "Cargo.toml")) &&
+  existsSync(path.join(repoRoot, "build", "debug", "codegen", "build_options.rs"));
+const miriAvailable =
+  !!cargoBin &&
+  workspaceResolvable &&
+  Bun.spawnSync({
+    cmd: [cargoBin, "miri", "--version"],
+    cwd: repoRoot,
+    stdout: "ignore",
+    stderr: "ignore",
+    timeout: 30_000,
+  }).exitCode === 0;
+
+// Each short-buffer test is one byte short for its alphabet (one input byte
+// encodes to 4 bytes padded, 2 bytes URL-safe) and asserts on the panic
+// message, so it also fails if the check computes the wrong alphabet's length.
+const expectedResults = {
+  // bun_simdutf_sys: the wrapper that performs the unchecked write.
+  "simdutf::base64::tests::encode_len_pads_the_standard_alphabet_only": "ok",
+  "simdutf::base64::tests::encode_panics_when_the_padded_output_does_not_fit": "ok",
+  "simdutf::base64::tests::encode_panics_when_the_url_safe_output_does_not_fit": "ok",
+  // bun_base64: the safe entry points the rest of the codebase calls.
+  "tests::encode_panics_when_the_destination_is_too_short": "ok",
+  "tests::encode_url_safe_panics_when_the_destination_is_too_short": "ok",
+};
+
+test.skipIf(!miriAvailable)(
+  "base64 encoders panic on a too-short output buffer instead of handing it to simdutf",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [cargoBin!, "miri", "test", "--locked", "-p", "bun_simdutf_sys", "-p", "bun_base64"],
+      cwd: repoRoot,
+      env: { ...process.env, MIRIFLAGS: "-Zmiri-tree-borrows", CARGO_TERM_COLOR: "never" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    if (exitCode !== 0) {
+      // Miri's diagnostic names the foreign call that was reached.
+      console.error(stderr);
+    }
+
+    // libtest prints one line per test: `test <name>[ - should panic] ... ok`.
+    const results: Record<string, string> = {};
+    for (const [, name, status] of stdout.matchAll(/^test (\S+)(?: - should panic)? \.\.\. (\w+)$/gm)) {
+      if (name in expectedResults) results[name] = status;
+    }
+    expect({ results, exitCode }).toEqual({ results: expectedResults, exitCode: 0 });
+  },
+  180_000,
+);

--- a/test/internal/base64-encode-output-bounds.test.ts
+++ b/test/internal/base64-encode-output-bounds.test.ts
@@ -1,77 +1,73 @@
 /**
- * `simdutf::base64::encode` (src/simdutf_sys/simdutf.rs) hands C++ the output
- * slice as a bare pointer; simdutf then writes the whole encoding without ever
- * seeing the slice length. The length check in that wrapper is all that keeps a
- * short buffer passed by safe code (`bun_base64::encode` / `encode_url_safe`,
- * a few dozen callers) from becoming a heap overflow. No JS API reaches the
- * encoder with a short buffer, so the contract is pinned by `#[should_panic]`
- * unit tests in bun_simdutf_sys and bun_base64.
+ * `simdutf::base64::encode` (src/simdutf_sys/simdutf.rs) hands C++ the
+ * destination slice as a bare pointer and simdutf writes the whole encoding
+ * without ever seeing the slice length, so the length check in that wrapper is
+ * all that keeps a too-short destination passed to `bun_base64::encode` or
+ * `encode_url_safe` from becoming a heap overflow. Every in-tree caller sizes
+ * its destination correctly, so no JS API reaches that check; `base64EncodeProbe`
+ * (src/runtime/base64_testing.rs) calls the encoders with a destination length
+ * of the test's choosing. It runs against the built binary, which is what makes
+ * the short-destination cases meaningful on release builds: a `debug_assert!`
+ * there would compile out and the encoder would write past the destination
+ * instead of panicking.
  *
- * Those test binaries reference simdutf symbols that only exist in the full bun
- * link, so plain `cargo test` cannot link them; `cargo miri test` (what CI's
- * `bun run rust:miri` runs, see scripts/rust-miri.ts) interprets them instead.
- * With the check in place the wrapper panics before the foreign call; without
- * it, Miri stops the test at the `simdutf__base64_encode` call the short buffer
- * was about to be handed to. This test runs those unit tests and requires each
- * one to have passed, so deleting them fails it too. Skipped where miri is not
- * installed or the cargo workspace is not resolvable (test-only CI lanes run a
- * prebuilt binary; same prerequisite check as linear-fifo.test.ts).
+ * The probe encodes the bytes 0..inputLength; `Buffer` gives the expected text
+ * and, through its length, the exact number of bytes the encoder writes.
  */
-import { expect, test } from "bun:test";
-import { existsSync } from "node:fs";
-import path from "node:path";
+import { base64EncodeProbe } from "bun:internal-for-testing";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
-const cargoBin = Bun.which("cargo");
-const repoRoot = path.resolve(import.meta.dir, "..", "..");
-const workspaceResolvable =
-  existsSync(path.join(repoRoot, "vendor", "lolhtml", "Cargo.toml")) &&
-  existsSync(path.join(repoRoot, "build", "debug", "codegen", "build_options.rs"));
-const miriAvailable =
-  !!cargoBin &&
-  workspaceResolvable &&
-  Bun.spawnSync({
-    cmd: [cargoBin, "miri", "--version"],
-    cwd: repoRoot,
-    stdout: "ignore",
-    stderr: "ignore",
-    timeout: 30_000,
-  }).exitCode === 0;
+function encoding(inputLength: number, urlSafe: boolean): string {
+  const bytes = Uint8Array.from({ length: inputLength }, (_, i) => i);
+  return Buffer.from(bytes).toString(urlSafe ? "base64url" : "base64");
+}
 
-// Each short-buffer test is one byte short for its alphabet (one input byte
-// encodes to 4 bytes padded, 2 bytes URL-safe) and asserts on the panic
-// message, so it also fails if the check computes the wrong alphabet's length.
-const expectedResults = {
-  // bun_simdutf_sys: the wrapper that performs the unchecked write.
-  "simdutf::base64::tests::encode_len_pads_the_standard_alphabet_only": "ok",
-  "simdutf::base64::tests::encode_panics_when_the_padded_output_does_not_fit": "ok",
-  "simdutf::base64::tests::encode_panics_when_the_url_safe_output_does_not_fit": "ok",
-  // bun_base64: the safe entry points the rest of the codebase calls.
-  "tests::encode_panics_when_the_destination_is_too_short": "ok",
-  "tests::encode_url_safe_panics_when_the_destination_is_too_short": "ok",
-};
+// Covers the empty input and every inputLength % 3 phase several times, for
+// both alphabets: padded output is always a multiple of 4, URL-safe output is not.
+const inputLengths = Array.from({ length: 10 }, (_, i) => i);
 
-test.skipIf(!miriAvailable)(
-  "base64 encoders panic on a too-short output buffer instead of handing it to simdutf",
-  async () => {
+// The last column is the encoded length of a single input byte: 4 padded,
+// 2 URL-safe. The short-destination test is one byte under it, and the panic
+// message carries both numbers, so a check that computed the other alphabet's
+// length fails that test too.
+describe.each([
+  ["base64", false, 4],
+  ["base64url", true, 2],
+])("%s", (_alphabet, urlSafe, encodedLength) => {
+  test("a destination of exactly the encoded length holds the encoding", () => {
+    const expected = inputLengths.map(n => encoding(n, urlSafe));
+    expect(inputLengths.map((n, i) => base64EncodeProbe(n, expected[i].length, urlSafe))).toEqual(expected);
+  });
+
+  test("a larger destination returns only the bytes written", () => {
+    const expected = inputLengths.map(n => encoding(n, urlSafe));
+    expect(inputLengths.map((n, i) => base64EncodeProbe(n, expected[i].length + 3, urlSafe))).toEqual(expected);
+  });
+
+  test.concurrent("a destination one byte too short panics instead of being written past", async () => {
     await using proc = Bun.spawn({
-      cmd: [cargoBin!, "miri", "test", "--locked", "-p", "bun_simdutf_sys", "-p", "bun_base64"],
-      cwd: repoRoot,
-      env: { ...process.env, MIRIFLAGS: "-Zmiri-tree-borrows", CARGO_TERM_COLOR: "never" },
+      cmd: [
+        bunExe(),
+        "-e",
+        `console.log(JSON.stringify(require("bun:internal-for-testing").base64EncodeProbe(1, ${encodedLength - 1}, ${urlSafe})));`,
+        // Without this, debug builds symbolize the panic trace with
+        // llvm-symbolizer, which takes seconds (as in run-crash-handler.test.ts).
+        "--debug-crash-handler-use-trace-string",
+      ],
+      // The panic is the expected outcome; it must not be reported as a crash.
+      env: { ...bunEnv, BUN_CRASH_REPORT_URL: "", BUN_ENABLE_CRASH_REPORTING: "0" },
+      stdin: "ignore",
       stdout: "pipe",
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    if (exitCode !== 0) {
-      // Miri's diagnostic names the foreign call that was reached.
-      console.error(stderr);
-    }
 
-    // libtest prints one line per test: `test <name>[ - should panic] ... ok`.
-    const results: Record<string, string> = {};
-    for (const [, name, status] of stdout.matchAll(/^test (\S+)(?: - should panic)? \.\.\. (\w+)$/gm)) {
-      if (name in expectedResults) results[name] = status;
-    }
-    expect({ results, exitCode }).toEqual({ results: expectedResults, exitCode: 0 });
-  },
-  180_000,
-);
+    const message = `base64 encode: output buffer too small: need ${encodedLength} bytes for a 1-byte input, got ${encodedLength - 1}`;
+    expect({
+      stdout,
+      stderr: stderr.includes(message) ? message : stderr,
+      exitCode: exitCode === 0 ? 0 : "non-zero",
+    }).toEqual({ stdout: "", stderr: message, exitCode: "non-zero" });
+  });
+});


### PR DESCRIPTION
### Problem

- `bun_simdutf_sys::simdutf::base64::encode(input, output, is_urlsafe)` (src/simdutf_sys/simdutf.rs) is a safe function, but it passes `output` to C++ as a bare pointer and never looks at `output.len()`. simdutf's `binary_to_base64` always writes the full `base64_length_from_binary(input.len())` bytes, so a safe caller with a short slice gets a heap or stack buffer overflow. The sibling `encode_raw` is correctly `unsafe fn`, and `decode` / `decode_lenient` do pass `output.len()`.
- Both safe wrappers the rest of the codebase uses inherit the hole:
  - `bun_core::base64::encode` (src/bun_core/util.rs, re-exported as `bun_base64::encode`, about 20 callers) guarded it with a `debug_assert!`, which release builds compile out (scripts/build/rust.ts only enables debug assertions for debug and ASAN builds).
  - `bun_base64::encode_url_safe` (src/base64/lib.rs) had no check at all.
- I audited every caller (listed under details); all of them size their buffers correctly today, so this is an unsound safe API rather than a crash reachable from JS. Found by an internal audit of debug-only preconditions.

### Fix

- `simdutf::base64::encode` asserts `output.len() >= encode_len(input.len(), is_urlsafe)` before the FFI call, so a short buffer from either wrapper panics with the sizes in the message instead of overflowing. The assert is unconditional because continuing would corrupt memory; it is two integer ops per encode.
- `encode_len` is now a pure `const fn` with the same formula as simdutf's `base64_length_from_binary` (vendor/WebKit/Source/WTF/wtf/simdutf/simdutf_impl.h line 10778; padded: `ceil(n / 3) * 4`, base64url: `n / 3 * 4` plus 2 or 3 for a 1 or 2 byte tail). The check therefore costs no FFI call, `bun_core::standard_encoder_calc_size` and `bun_base64::url_safe_encode_len` are derived from it instead of carrying their own copies of the formula, and the `simdutf__base64_length_from_binary` shim in bun-simdutf.cpp becomes unused and is removed (the Rust/C++ symbol parity lint in test/internal/source-lints still passes). The private `simdutf_encode_len_url_safe` helper collapsed into `url_safe_encode_len`.
- `encode_raw` debug-asserts that simdutf wrote exactly `encode_len` bytes, so debug and ASAN runs of the JS suite check the Rust formula against what C++ actually writes.
- The now redundant `debug_assert!` in `bun_core::base64::encode` is removed.
- Intentionally excluded, each handed off separately: the `convert::*` wrappers in the same file have the same shape but their required length needs a length scan rather than O(1) arithmetic; two `bun_highway` wrappers and `JSValue::from_entries` have the same shape with O(1) lengths and take the same fix. `ip_address::pton` has a similar `debug_assert!` but is module-private with both callers in the same file.

### Tests

- test/internal/base64-encode-output-bounds.test.ts drives the encoders through a new `bun:internal-for-testing` probe, `base64EncodeProbe(inputLength, destinationLength, urlSafe)` (src/runtime/base64_testing.rs, same pattern as linear_fifo_testing.rs), since no JS API can reach them with a destination of a chosen length. For both alphabets: an exact-fit destination returns the encoding for input lengths 0 through 9, a larger destination returns only the bytes written, and a destination one byte short panics in a child process with the message naming both sizes (`need 4 bytes for a 1-byte input, got 3` / `need 2 bytes for a 1-byte input, got 1`) and nothing on stdout. It runs on every test lane against the build under test, so the release lanes check that the guard survives release.
- `#[should_panic]` unit tests in bun_simdutf_sys (both alphabets, plus an `encode_len` table) and bun_base64 (`encode` and `encode_url_safe`). Their crates reference simdutf symbols that only exist in the full link, so they run under `cargo miri test` via `bun run rust:miri` (bun_simdutf_sys is added to its crate list), where reaching the foreign call fails the test. scripts/rust-miri.ts now runs these two crates a second time with `--release`: with debug assertions off, the tests pass only if the guard is a real `assert!`. Measured cost of the extra pass here: about 10 s to compile and under 2 s to run.
- Verified:
  - Guard removed, probe kept, debug/ASAN build: the two short-destination tests fail, the child dying with `AddressSanitizer: heap-buffer-overflow ... WRITE of size 1 ... in simdutf::...encode_base64_impl`. With the guard, all 6 pass.
  - Guard demoted to `debug_assert!`: `cargo miri test` in the default profile still passes (the reason for the second pass); `cargo miri test --release` fails at `can't call foreign function simdutf__base64_encode`. With the `assert!`, both profiles pass, and `bun run rust:miri` passes end to end.
  - `bun bd test` on this test, test/js/bun/util/base64-url-safe-encode.test.ts (exact-fit base64url for every length 0 through 513), test/js/web/util/atob.test.js, test/js/node/buffer.test.js, test/js/sql/postgres-duplicate-auth-request.test.ts (SASL nonce encode), and test/internal/source-lints/dead-symbols-ffi-sys-test-runner-cpp.test.ts: all pass.
  - `cargo clippy` on bun_runtime, bun_simdutf_sys, bun_base64, bun_core: clean. rustfmt, prettier, clang-format: clean.

### Background

- simdutf's `binary_to_base64(input, len, output, options)` takes no output length; its documentation says the output buffer must hold `base64_length_from_binary(len, options)` bytes and that exactly that many are written. Bun's shim (`simdutf__base64_encode` in bun-simdutf.cpp) maps `is_urlsafe` to `base64_url` (unpadded) or `base64_default` (padded).
- `debug_assert!` is compiled out whenever the cargo profile has debug assertions off, which for Bun is every release build users run. `cargo test` and `cargo miri test` build the dev profile, which has them on; `--release` is what turns them off.
- Rust unit tests for Bun's own crates only run in CI through `bun run rust:miri` (scripts/rust-miri.ts). Miri interprets the code and reports an error if a test reaches a foreign call, so for the short-buffer tests the only outcomes are the panic (pass) or the foreign call (fail).
- `bun:internal-for-testing` is the module Bun's tests use to reach internal code that has no JS surface. A Rust function is exposed by listing its file in `rustIdentifierPaths` (src/codegen/generate-js2native.ts) and declaring it with `$newRustFunction` in src/js/internal-for-testing.ts.

<details>
<summary>Caller audit (all correctly sized on main)</summary>

Sized exactly via `encode_len` / `standard_encoder_calc_size` of the same source: src/runtime/image/Image.rs, src/runtime/webcore/encoding.rs (both alphabets), src/runtime/bake/DevServer.rs, src/runtime/node/types.rs, src/jsc/VirtualMachine.rs, src/js_parser/p.rs, src/js_parser_jsc/Macro.rs, src/resolver/data_url.rs, src/http/AsyncHTTP.rs, src/md/ansi_renderer.rs, src/install/npm.rs, src/bundler/bundled_ast.rs, src/bundler/linker_context/writeOutputFilesToDisk.rs, src/bundler/linker_context/generateChunksInParallel.rs (2), src/s3_signing/credentials.rs, src/runtime/cli/publish_command.rs (`encode_raw` into reserved spare capacity), src/base64/lib.rs (`encode_alloc`, `simdutf_encode_url_safe_alloc`, `wyhash_url_safe`).

Fixed-size digests into fixed arrays: src/http_jsc/websocket_client/WebSocketUpgradeClient.rs (20 -> 28), src/bun_core/fmt.rs (64 -> 88), src/sql_jsc/postgres/PostgresSQLConnection.rs (32 -> 44 in 48), src/sql_jsc/postgres/SASL.rs (32 -> 44, 18 -> 24), src/bundler/HTMLImportManifest.rs (8 -> 11 in 14).

Explicitly guarded: src/crash_handler/lib.rs returns ENOSPC when the encoding would not fit its 2048 byte buffer.

</details>

<details>
<summary>Earlier shape of the tests (superseded)</summary>

The first revision's JS test spawned `cargo miri test` for the two crates. Self-review found two problems: that test is skipped on every CI test lane (no cargo or miri there), and both it and `rust:miri` ran the dev profile, so nothing in the PR distinguished the new `assert!` from the `debug_assert!` it replaces. The probe test and the `--release` pass above replace it.

</details>
