### PR TITLE
bun:test: format React 19 elements as JSX in snapshots and matcher diffs

### DIFF
--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -496,8 +496,9 @@ impl Tag {
         if js_type.is_object() && js_type != JSType::ProxyObject {
             if let Some(typeof_symbol) = value.get_own_truthy(global_this, "$$typeof")? {
                 const REACT_ELEMENT_SYMBOLS: [&[u8]; 3] = [
-                    b"react.element",              // React 18 and below
-                    b"react.transitional.element", // React 19
+                    b"react.element",
+                    // React 19 - https://github.com/oven-sh/bun/issues/17223
+                    b"react.transitional.element",
                     b"react.fragment",
                 ];
 

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -492,20 +492,20 @@ impl Tag {
             return Tag::get(value.get_proxy_target(), global_this);
         }
 
-        // Is this a react element?
+        // Is this a react element? Same set of `$$typeof` symbols as the console
+        // formatter (`ConsoleObject.rs`): React 19 renamed `react.element` to
+        // `react.transitional.element`.
         if js_type.is_object() && js_type != JSType::ProxyObject {
             if let Some(typeof_symbol) = value.get_own_truthy(global_this, "$$typeof")? {
-                let mut react_element = ZigString::init(b"react.element");
-                let mut react_fragment = ZigString::init(b"react.fragment");
+                const REACT_ELEMENT_SYMBOLS: [&[u8]; 3] =
+                    [b"react.element", b"react.transitional.element", b"react.fragment"];
 
-                if typeof_symbol
-                    .is_same_value(JSValue::symbol_for(global_this, &mut react_element), global_this)?
-                    || typeof_symbol.is_same_value(
-                        JSValue::symbol_for(global_this, &mut react_fragment),
-                        global_this,
-                    )?
-                {
-                    return Ok(TagResult { tag: Tag::JSX, cell: js_type });
+                for symbol_key in REACT_ELEMENT_SYMBOLS {
+                    let mut symbol_key = ZigString::init(symbol_key);
+                    let react_symbol = JSValue::symbol_for(global_this, &mut symbol_key);
+                    if typeof_symbol.is_same_value(react_symbol, global_this)? {
+                        return Ok(TagResult { tag: Tag::JSX, cell: js_type });
+                    }
                 }
             }
         }

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -492,13 +492,14 @@ impl Tag {
             return Tag::get(value.get_proxy_target(), global_this);
         }
 
-        // Is this a react element? Same set of `$$typeof` symbols as the console
-        // formatter (`ConsoleObject.rs`): React 19 renamed `react.element` to
-        // `react.transitional.element`.
+        // Is this a react element? Keep the list in sync with `ConsoleObject.rs`.
         if js_type.is_object() && js_type != JSType::ProxyObject {
             if let Some(typeof_symbol) = value.get_own_truthy(global_this, "$$typeof")? {
-                const REACT_ELEMENT_SYMBOLS: [&[u8]; 3] =
-                    [b"react.element", b"react.transitional.element", b"react.fragment"];
+                const REACT_ELEMENT_SYMBOLS: [&[u8]; 3] = [
+                    b"react.element",              // React 18 and below
+                    b"react.transitional.element", // React 19
+                    b"react.fragment",
+                ];
 
                 for symbol_key in REACT_ELEMENT_SYMBOLS {
                     let mut symbol_key = ZigString::init(symbol_key);

--- a/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
@@ -371,6 +371,53 @@ test("basic unchanging inline snapshot", () => {
   );
 });
 
+// React 18 marks elements with Symbol.for("react.element"), React 19 with
+// Symbol.for("react.transitional.element"). Both serialize as JSX, like Bun.inspect
+// prints them, instead of as the element's fields. test/ pins React 18, so the
+// elements are built by hand.
+describe.each(["react.element", "react.transitional.element"])("inline snapshots of %s elements", $$typeofKey => {
+  const $$typeof = Symbol.for($$typeofKey);
+  const h = (type: unknown, props: Record<string, unknown>, key: string | null = null) => ({
+    $$typeof,
+    type,
+    key,
+    ref: null,
+    props,
+  });
+  function Greeting() {}
+
+  test("serialize as JSX", () => {
+    expect(h("div", { id: "x" })).toMatchInlineSnapshot(`<div id="x" />`);
+    expect(h("li", { children: "one" }, "a")).toMatchInlineSnapshot(`<li key="a">one</li>`);
+    expect(h(Greeting, { name: "bun" })).toMatchInlineSnapshot(`<Greeting name="bun" />`);
+  });
+
+  test("child elements serialize as JSX", () => {
+    expect(h("ul", { className: "list", children: h("li", { children: "one" }) }))
+      .toMatchInlineSnapshot(`<ul className="list">
+  <li>one</li>
+</ul>`);
+    expect(h("ul", { children: [h("li", { children: "one" }, "1"), h("li", { children: "two" }, "2")] }))
+      .toMatchInlineSnapshot(`<ul>
+  <li key="1">one</li>
+  <li key="2">two</li>
+</ul>`);
+  });
+
+  test("elements inside other values serialize as JSX", () => {
+    expect({ el: h("div", { id: "x" }) }).toMatchInlineSnapshot(`
+      {
+        "el": <div id="x" />,
+      }
+    `);
+    expect([h("br", {})]).toMatchInlineSnapshot(`
+      [
+        <br />,
+      ]
+    `);
+  });
+});
+
 class InlineSnapshotTester {
   tmpdir: string;
   tmpid: number;

--- a/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
@@ -372,9 +372,9 @@ test("basic unchanging inline snapshot", () => {
 });
 
 // React 18 marks elements with Symbol.for("react.element"), React 19 with
-// Symbol.for("react.transitional.element"). Both serialize as JSX, like Bun.inspect
-// prints them, instead of as the element's fields. test/ pins React 18, so the
-// elements are built by hand.
+// Symbol.for("react.transitional.element"). Both serialize as JSX, the way React 18
+// elements always have, instead of as the element's fields. test/ pins React 18, so
+// the elements are built by hand.
 describe.each(["react.element", "react.transitional.element"])("inline snapshots of %s elements", $$typeofKey => {
   const $$typeof = Symbol.for($$typeofKey);
   const h = (type: unknown, props: Record<string, unknown>, key: string | null = null) => ({
@@ -393,23 +393,25 @@ describe.each(["react.element", "react.transitional.element"])("inline snapshots
   });
 
   test("child elements serialize as JSX", () => {
-    expect(h("ul", { className: "list", children: h("li", { children: "one" }) }))
-      .toMatchInlineSnapshot(`<ul className="list">
-  <li>one</li>
-</ul>`);
-    expect(h("ul", { children: [h("li", { children: "one" }, "1"), h("li", { children: "two" }, "2")] }))
-      .toMatchInlineSnapshot(`<ul>
-  <li key="1">one</li>
-  <li key="2">two</li>
-</ul>`);
-  });
-
-  test("elements inside other values serialize as JSX", () => {
-    expect({ el: h("div", { id: "x" }) }).toMatchInlineSnapshot(`
+    // Nested in an object so this only covers how the elements and their children are
+    // classified, not how a multi-line top-level value is wrapped.
+    expect({
+      one: h("ul", { className: "list", children: h("li", { children: "one" }) }),
+      many: h("ul", { children: [h("li", { children: "one" }, "1"), h("li", { children: "two" }, "2")] }),
+    }).toMatchInlineSnapshot(`
       {
-        "el": <div id="x" />,
+        "many": <ul>
+          <li key="1">one</li>
+          <li key="2">two</li>
+        </ul>,
+        "one": <ul className="list">
+          <li>one</li>
+        </ul>,
       }
     `);
+  });
+
+  test("elements inside an array serialize as JSX", () => {
     expect([h("br", {})]).toMatchInlineSnapshot(`
       [
         <br />,

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -588,6 +588,64 @@ it("expect().toEqual() on objects with property indices doesn't print undefined"
   expect(err).not.toContain("undefined");
 });
 
+// React 18 marks elements with Symbol.for("react.element"), React 19 with
+// Symbol.for("react.transitional.element"). Matcher diffs print both as JSX, the way
+// Bun.inspect does, instead of dumping the element's fields.
+it.each(["react.element", "react.transitional.element"])(
+  "expect() diffs print %s elements as JSX",
+  async $$typeofKey => {
+    using dir = tempDir("diff-jsx-" + $$typeofKey, {
+      "jsx.test.js": `
+      import { expect, test } from "bun:test";
+      const $$typeof = Symbol.for(${JSON.stringify($$typeofKey)});
+      const h = (type, props) => ({ $$typeof, type, key: null, ref: null, props });
+      test("toEqual", () => {
+        expect(h("div", { id: "received" })).toEqual(h("div", { id: "expected" }));
+      });
+      test("toStrictEqual with child elements", () => {
+        expect(h("ul", { children: [h("li", { children: "one" })] })).toStrictEqual(
+          h("ul", { children: [h("li", { children: "two" })] }),
+        );
+      });
+      test("not.toEqual", () => {
+        const el = h("div", { id: "x" });
+        expect(el).not.toEqual(el);
+      });
+    `,
+    });
+    await using proc = spawn({
+      cmd: [bunExe(), "test", "jsx.test.js"],
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      env: bunEnv,
+    });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // Keep only the matcher output: from each `error:` line up to its stack trace.
+    const diffs = [...stderr.matchAll(/^error: expect\(received\)[^]*?(?=\n\s+at )/gm)].map(m => m[0]);
+    expect(diffs.join("\n")).toMatchInlineSnapshot(`
+    "error: expect(received).toEqual(expected)
+
+    Expected: <div id="expected" />
+    Received: <div id="received" />
+    error: expect(received).toStrictEqual(expected)
+
+      <ul>
+    -   <li>two</li>
+    +   <li>one</li>
+      </ul>
+
+    - Expected  - 1
+    + Received  + 1
+    error: expect(received).not.toEqual(expected)
+
+    Expected: not <div id="x" />"
+  `);
+    expect(exitCode).toBe(1);
+  },
+);
+
 it("test --preload supports global lifecycle hooks", () => {
   const preloadedPath = join(tmp, "test-fixture-preload-global-lifecycle-hook-preloaded.js");
   const path = join(tmp, "test-fixture-preload-global-lifecycle-hook-test.test.js");

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -590,7 +590,7 @@ it("expect().toEqual() on objects with property indices doesn't print undefined"
 
 // React 18 marks elements with Symbol.for("react.element"), React 19 with
 // Symbol.for("react.transitional.element"). Matcher diffs print both as JSX, the way
-// Bun.inspect does, instead of dumping the element's fields.
+// React 18 elements always have, instead of dumping the element's fields.
 it.each(["react.element", "react.transitional.element"])(
   "expect() diffs print %s elements as JSX",
   async $$typeofKey => {
@@ -625,23 +625,23 @@ it.each(["react.element", "react.transitional.element"])(
     // Keep only the matcher output: from each `error:` line up to its stack trace.
     const diffs = [...stderr.matchAll(/^error: expect\(received\)[^]*?(?=\n\s+at )/gm)].map(m => m[0]);
     expect(diffs.join("\n")).toMatchInlineSnapshot(`
-    "error: expect(received).toEqual(expected)
+      "error: expect(received).toEqual(expected)
 
-    Expected: <div id="expected" />
-    Received: <div id="received" />
-    error: expect(received).toStrictEqual(expected)
+      Expected: <div id="expected" />
+      Received: <div id="received" />
+      error: expect(received).toStrictEqual(expected)
 
-      <ul>
-    -   <li>two</li>
-    +   <li>one</li>
-      </ul>
+        <ul>
+      -   <li>two</li>
+      +   <li>one</li>
+        </ul>
 
-    - Expected  - 1
-    + Received  + 1
-    error: expect(received).not.toEqual(expected)
+      - Expected  - 1
+      + Received  + 1
+      error: expect(received).not.toEqual(expected)
 
-    Expected: not <div id="x" />"
-  `);
+      Expected: not <div id="x" />"
+    `);
     expect(exitCode).toBe(1);
   },
 );


### PR DESCRIPTION
### Problem

- `bun test` prints a React 19 element as a plain object in snapshots (`toMatchSnapshot`, `toMatchInlineSnapshot`) and in the Expected/Received output of `toEqual`, `toStrictEqual`, `toMatchObject`, `toHaveBeenCalledWith` and the other matchers that render a diff:
  ```
  Expected: not {
    "$$typeof": Symbol(react.transitional.element),
    "key": null,
    "props": {
      "id": "x",
    },
    "ref": null,
    "type": "div",
  }
  ```
  The React 18 version of the same element prints as `<div id="x" />`, and `Bun.inspect` / `console.log` print the React 19 one as JSX too.
- So a project that upgrades from React 18 to React 19 sees every committed element snapshot flip from JSX to the object dump above, and `bun test` disagrees with `console.log` about the same value.
- Cause: `Tag::get` in `src/runtime/test_runner/pretty_format.rs` (line 495) only compares `$$typeof` against `Symbol.for("react.element")` and `Symbol.for("react.fragment")`. React 19 marks elements with `Symbol.for("react.transitional.element")`. The console formatter (`src/jsc/ConsoleObject.rs`, line 2249) was taught that symbol in the fix for #17223; the test runner formatter was not.
- Children are classified through the same `Tag::get`, so a React 19 element whose `props.children` is an element (or an array of them) also prints its children as objects.

### Fix

- `Tag::get` checks the same three symbols as the console formatter. The fixing change is the `react.transitional.element` entry in `REACT_ELEMENT_SYMBOLS`; the rest of the hunk turns the two chained comparisons into a loop over that list. Nothing else changes: a React 19 element now takes exactly the path a React 18 element takes.
- Why this is right: the symbol is the only difference between a React 18 and a React 19 element, so whatever `bun test` prints for one is what it should print for the other; `ConsoleObject.rs` already treats the symbol that way, and so does vitest's `pretty-format` (its `ReactElement` plugin accepts an element if either the React 18 or the React 19 copy of `react-is` does). `Bun.markdown.react()` also emits `react.transitional.element` elements by default.
- Behavior change: a committed `.snap` that holds a React 19 element was written in the object form and needs `bun test -u` after this change. React 18 snapshots are unchanged (every test below runs with both symbols).
- This PR does not touch the JSX printer itself, so React 19 elements inherit its open defects exactly as React 18 elements have them today:
  - missing space before the last prop of a 2+ prop element: #38957. If that lands first, React 19 snapshots are written once, in their final form, and the `.each` blocks below can take a multi-prop element.
  - empty children: #38935; component names: #38939; wrapping of multi-line top-level elements: #38947.
  - `toMatchObject` with a partial pattern against an element diffs the JSX form against the pattern object, as it does for React 18 today. That is a `toMatchObject` diff issue (jest diffs the received subset) and is tracked separately.
  - The tests here only use shapes whose output is identical before and after each of those changes, so they pass in either landing order.
- Verification:
  - `test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts`, `inline snapshots of %s elements`: hand-built elements (test/ pins React 18, and the symbol is the only thing that differs) with a prop, a key, a component type, a single child element, array children, and an element inside an array. The `react.transitional.element` cases fail on the unfixed build with the object dump above; the `react.element` cases pass before and after.
  - `test/js/bun/test/test-test.test.ts`, `expect() diffs print %s elements as JSX`: spawns `bun test` on a file whose `toEqual`, `toStrictEqual` (child elements) and `not.toEqual` assertions fail, and snapshots the matcher output. Same fail-before pattern.
  - Both files pass in full with `bun bd test`. The one other failure in `snapshot.test.ts` locally (`error snapshots`) also fails on main when stderr is not a TTY and is addressed by #38833.

### Background

- A React element is the object JSX compiles to: `{ $$typeof, type, key, ref, props }`. `$$typeof` is a registered symbol that marks the object as an element. React 18 and older use `Symbol.for("react.element")`; React 19 renamed it to `Symbol.for("react.transitional.element")` so that elements created by the two versions are not mistaken for each other.
- Bun has two value formatters. `src/jsc/ConsoleObject.rs` backs `console.log` and `Bun.inspect`; `src/runtime/test_runner/pretty_format.rs` is the jest `pretty-format` equivalent used to serialize snapshots and to render the Expected/Received values that `DiffFormatter` diffs. Each one classifies a value with its own `Tag::get` before printing, and the `Tag::JSX` result selects that formatter's JSX printer.
