### PR TITLE
inspect, bun:test: self-close JSX elements whose children are "" or []

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -5250,8 +5250,6 @@ pub mod formatter {
                             matches!(tag.tag.tag(), Tag::String | Tag::JSX | Tag::Array);
 
                         if print_children && !self.single_line {
-                            // Empty children (`""` or `[]`) break out of this block and
-                            // fall through to the self-closing ` />` below.
                             'print_children: {
                                 match tag.tag.tag() {
                                     Tag::String => {

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -5250,6 +5250,8 @@ pub mod formatter {
                             matches!(tag.tag.tag(), Tag::String | Tag::JSX | Tag::Array);
 
                         if print_children && !self.single_line {
+                            // Empty children (`""` or `[]`) break out of this block and
+                            // fall through to the self-closing ` />` below.
                             'print_children: {
                                 match tag.tag.tag() {
                                     Tag::String => {
@@ -5372,12 +5374,12 @@ pub mod formatter {
                                     writer.write_all(pf!("<r>").as_bytes());
                                 }
                                 writer.write_all(b">");
-                            }
 
-                            if writer.failed {
-                                self.failed = true;
+                                if writer.failed {
+                                    self.failed = true;
+                                }
+                                return Ok(());
                             }
-                            return Ok(());
                         }
                     }
                 }

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -2155,8 +2155,6 @@ impl<'a> Formatter<'a> {
                                     matches!(tag.tag, Tag::String | Tag::JSX | Tag::Array);
 
                                 if print_children {
-                                    // Empty children (`""` or `[]`) break out of this block and
-                                    // fall through to the self-closing ` />` below.
                                     'print_children: {
                                         match tag.tag {
                                             Tag::String => {

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -2155,6 +2155,8 @@ impl<'a> Formatter<'a> {
                                     matches!(tag.tag, Tag::String | Tag::JSX | Tag::Array);
 
                                 if print_children {
+                                    // Empty children (`""` or `[]`) break out of this block and
+                                    // fall through to the self-closing ` />` below.
                                     'print_children: {
                                         match tag.tag {
                                             Tag::String => {
@@ -2282,9 +2284,9 @@ impl<'a> Formatter<'a> {
                                             );
                                         }
                                         writer.write_all(b">");
-                                    }
 
-                                    return Ok(true);
+                                        return Ok(true);
+                                    }
                                 }
                             }
                         }

--- a/test/js/bun/test/snapshot-tests/snapshots/moremore.test.ts
+++ b/test/js/bun/test/snapshot-tests/snapshots/moremore.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 
 class Number2 extends Number {
   constructor(value: number) {
@@ -116,5 +116,49 @@ test("test snapshots with Boolean and Number", () => {
         },
       },
     },
+  });
+});
+
+describe("JSX elements with empty children", () => {
+  // The shape the React runtime produces for <div>{[]}</div>, <div>{""}</div>, etc.
+  function jsx(type: unknown, props: Record<string, unknown>, key: string | null = null) {
+    return { $$typeof: Symbol.for("react.element"), type, key, ref: null, props };
+  }
+  function Foo() {}
+
+  test.each([
+    ["children: []", jsx("div", { children: [] }), "<div />"],
+    ['children: ""', jsx("div", { children: "" }), "<div />"],
+    ["attribute and children: []", jsx("div", { id: "x", children: [] }), '<div id="x" />'],
+    ['attribute and children: ""', jsx("div", { id: "x", children: "" }), '<div id="x" />'],
+    ["key and children: []", jsx("div", { children: [] }, "k"), '<div key="k" />'],
+    ["component and children: []", jsx(Foo, { children: [] }), "<Foo />"],
+    ["no children", jsx("div", { id: "x" }), '<div id="x" />'],
+    [
+      "nested single child with children: []",
+      jsx("div", { children: jsx("span", { children: [] }) }),
+      "<div>\n  <span />\n</div>",
+    ],
+    [
+      'nested children with children: [] and children: ""',
+      jsx("div", { children: [jsx("span", { children: [] }), jsx("b", { children: "" })] }),
+      "<div>\n  <span />\n  <b />\n</div>",
+    ],
+  ])("%s prints in expect() failure messages", (_, element, expected) => {
+    let message = "";
+    try {
+      expect(element).not.toEqual(element);
+    } catch (e: any) {
+      message = e.message.replaceAll(/\x1b\[[0-9;]*m/g, "");
+    }
+    expect(message).toContain(`Expected: not ${expected}\n`);
+  });
+
+  test("snapshots", () => {
+    expect(jsx("div", { children: [] })).toMatchInlineSnapshot(`<div />`);
+    expect(jsx("div", { children: "" })).toMatchInlineSnapshot(`<div />`);
+    expect(jsx("div", { id: "x", children: [] })).toMatchInlineSnapshot(`<div id="x" />`);
+    expect(jsx("div", { id: "x", children: "" })).toMatchInlineSnapshot(`<div id="x" />`);
+    expect(jsx(Foo, { children: [] })).toMatchInlineSnapshot(`<Foo />`);
   });
 });

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -316,6 +316,58 @@ it("jsx with fragment", () => {
   expect(input).toBe(output);
 });
 
+describe("jsx with empty children self-closes", () => {
+  function Foo() {}
+
+  it.each([
+    ["{[]}", <div>{[]}</div>, "<div />"],
+    ['{""}', <div>{""}</div>, "<div />"],
+    ["attribute and {[]}", <div id="x">{[]}</div>, '<div id="x" />'],
+    ['attribute and {""}', <div id="x">{""}</div>, '<div id="x" />'],
+    ["key and {[]}", <div key="k">{[]}</div>, '<div key="k" />'],
+    ["component and {[]}", <Foo>{[]}</Foo>, "<Foo />"],
+    ["no children", <div id="x" />, '<div id="x" />'],
+    [
+      "nested single child with {[]}",
+      <div>
+        <span>{[]}</span>
+      </div>,
+      "<div>\n  <span />\n</div>",
+    ],
+    [
+      'nested children with {[]} and {""}',
+      <div>
+        <span>{[]}</span>
+        <b>{""}</b>
+      </div>,
+      "<div>\n  <span />\n  <b />\n</div>",
+    ],
+  ])("%s", (_, element, expected) => {
+    expect(Bun.inspect(element)).toBe(expected);
+  });
+
+  it("with colors", () => {
+    expect(Bun.inspect(<div>{[]}</div>, { colors: true })).toBe("\x1b[0m<\x1b[32mdiv\x1b[0m />");
+  });
+
+  it("console.log", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `console.log({ $$typeof: Symbol.for("react.element"), type: "div", props: { id: "x", children: [] } });
+         console.log({ $$typeof: Symbol.for("react.element"), type: "div", props: { children: "" } });`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe('<div id="x" />\n<div />\n');
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+});
+
 it("inspect", () => {
   expect(Bun.inspect(new TypeError("what")).includes("TypeError: what")).toBe(true);
   expect(Bun.inspect("hi")).toBe('"hi"');


### PR DESCRIPTION
### Problem
- `Bun.inspect` / `console.log` of a React element whose `props.children` is `[]` or `""` prints an unterminated opening tag: `<div>{[]}</div>` prints `<div`, `<div id="x">{""}</div>` prints `<div id="x"`. The same elements print as `<div />` when `children` is absent or `undefined`, and when inspected with `compact: true`.
- bun:test has a copy of the printer with the same defect, so `toMatchSnapshot` / `toMatchInlineSnapshot` serialize such an element as `<div`, and `toEqual`-style failure messages print `Expected: <div`.
- Bun's own `Bun.markdown.react()` always emits a `children` array, so it hits this without any user JSX: `Bun.inspect(Bun.markdown.react(""))` prints `<`, and an empty heading inside a document prints as `<h1` (both verified on 1.4.0; `< />` and `<h1 />` with this change).
- Cause: in both printers the children block is a labelled block (`'print_children`) followed by an unconditional return. The empty string arm and the empty array arm `break` out of the block to skip printing children, but the return after the block still runs, so neither the closing tag nor the self-closing ` />` (written after the whole `props` section) is emitted.
  - `src/jsc/ConsoleObject.rs`, `print_jsx`: `break` at the `children_string.len == 0` and `length == 0` checks, `return Ok(())` after the block.
  - `src/runtime/test_runner/pretty_format.rs`, `Tag::JSX` arm: same two `break`s, `return Ok(true)` after the block (`true` tells the caller the closing tag was written, so it skips ` />`).
- The structure dates back to the original JSX console.log support, so this is not a recent regression.

### Fix
- Move the return inside the labelled block, directly after the closing tag is written. The empty-children `break`s now land after the block and fall through to the existing ` />` write, so these elements print `<div />`, `<div id="x" />`, `<Foo />`, and nested ones `<div>\n  <span />\n</div>`.
- This is the output the printers already produce for the same element with no `children` prop, with `children: undefined`, and in single-line mode, so empty children now render the same as absent children everywhere. `children: []` also matches what jest's pretty-format prints for the same element (`<div />`); for `""` both printers already contained the explicit "treat as no children" check, this just makes it reach the right exit.
- Elements with non-empty children are unchanged: that path still writes the closing tag and returns from the same place it did before. Other children shapes the printers handle differently from jest's pretty-format (`null` / `false` entries are printed, nested arrays print as an array literal, a lone number child is dropped) are pre-existing, produce well-formed output, and are left for a separate change.
- Verified:
  - `test/js/bun/util/inspect.test.js` ("jsx with empty children self-closes"): `Bun.inspect` of real JSX with `{[]}` / `{""}`, with attributes, `key`, a component type, nested elements, colors, and `console.log` in a child process. 10 cases fail on the released binary, all pass with this change.
  - `test/js/bun/test/snapshot-tests/snapshots/moremore.test.ts` ("JSX elements with empty children"): the same shapes through `expect().toEqual` failure messages and `toMatchInlineSnapshot`. 9 cases fail on the released binary, all pass with this change (with and without `FORCE_COLOR=1`).
  - `bun bd test test/js/bun/util/inspect.test.js` and `bun bd test test/js/bun/test/snapshot-tests/` pass in full.

### Background
- A React element is a plain object whose own `$$typeof` is `Symbol.for("react.element")` (or the fragment / React 19 symbol); `<div id="x">{[]}</div>` compiles to `{ $$typeof, type: "div", props: { id: "x", children: [] } }`. Both printers recognize that shape and print it as JSX markup: the tag name from `type`, `key`, then the remaining props as attributes, then either `>children</tag>` or ` />`.
- There are two copies of this printer: `print_jsx` in `ConsoleObject.rs` backs `Bun.inspect`, `console.log` and the matcher utils, and `pretty_format.rs` in the test runner backs snapshot serialization and the Expected/Received lines of `expect` failures. Node's `util.inspect` (a separate JS implementation) does not render JSX and is not affected.
- A labelled block in Rust (`'label: { ... break 'label; ... }`) runs to its end unless a `break 'label` jumps past it; code placed after the block runs in both cases, which is what put the return on the empty-children path.
