### PR TITLE
Print own enumerable "constructor" properties in expect diffs, snapshots and console.log

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -3126,9 +3126,6 @@ pub mod formatter {
         ) -> Option<TagResult> {
             // SAFETY: caller passes a valid `*ZigString`.
             let key = unsafe { &*key };
-            if key.eql_comptime(b"constructor") {
-                return None;
-            }
             if ctx.formatter.failed {
                 return None;
             }

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5525,9 +5525,14 @@ restart:
             }
             auto* prop = entry.key();
 
-            if (prop == propertyNames->constructor
-                || prop == propertyNames->underscoreProto
+            if (prop == propertyNames->underscoreProto
                 || prop == propertyNames->toStringTagSymbol || (objectToUse != object && prop == propertyNames->__esModule))
+                return true;
+
+            // Hide the `constructor` back-reference every prototype carries (non-enumerable,
+            // or reached by walking the prototype chain). An enumerable own `constructor`
+            // is ordinary user data, so it prints like any other key.
+            if (prop == propertyNames->constructor && (objectToUse != object || (entry.attributes() & PropertyAttribute::DontEnum) != 0))
                 return true;
 
             if (builtinNames.bunNativePtrPrivateName() == prop)
@@ -5616,8 +5621,11 @@ restart:
                 if (property.isNull()) [[unlikely]]
                     continue;
 
-                // ignore constructor
-                if (property == propertyNames->constructor || builtinNames.bunNativePtrPrivateName() == property)
+                if (builtinNames.bunNativePtrPrivateName() == property)
+                    continue;
+
+                // Same rule as the fast path above: only an enumerable own `constructor` is shown.
+                if (property == propertyNames->constructor && iterating != object)
                     continue;
 
                 if constexpr (nonIndexedOnly) {
@@ -5633,7 +5641,8 @@ restart:
                 CLEAR_IF_EXCEPTION(scope);
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
-                    if (property == propertyNames->underscoreProto
+                    if (property == propertyNames->constructor
+                        || property == propertyNames->underscoreProto
                         || property == propertyNames->toStringTagSymbol || property == propertyNames->__esModule)
                         continue;
                 }
@@ -5785,8 +5794,7 @@ extern "C" [[ZIG_EXPORT(nothrow)]] bool JSC__isBigIntInInt64Range(JSC::EncodedJS
         if (property.isNull()) [[unlikely]]
             continue;
 
-        // ignore constructor
-        if (property == vm.propertyNames->constructor || clientData->builtinNames().bunNativePtrPrivateName() == property)
+        if (clientData->builtinNames().bunNativePtrPrivateName() == property)
             continue;
 
         JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
@@ -5796,8 +5804,11 @@ extern "C" [[ZIG_EXPORT(nothrow)]] bool JSC__isBigIntInInt64Range(JSC::EncodedJS
             continue;
         }
 
+        // A non-enumerable `constructor` is the back-reference every prototype carries;
+        // an enumerable one is user data that deepEquals compares, so it has to show up in diffs.
         if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
-            if (property == vm.propertyNames->underscoreProto
+            if (property == vm.propertyNames->constructor
+                || property == vm.propertyNames->underscoreProto
                 || property == vm.propertyNames->toStringTagSymbol)
                 continue;
         }

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -914,9 +914,6 @@ impl<'a, 'f, W: bun_io::Write, const ENABLE_ANSI_COLORS: bool>
 
         // SAFETY: key_ is non-null per JSC contract for property iteration.
         let key = unsafe { *key_ };
-        if key.eql_comptime(b"constructor") {
-            return;
-        }
 
         // SAFETY: ctx_ptr was passed as `&mut Self as *mut c_void` by the caller of for_each.
         let Some(ctx) = (unsafe { ctx_ptr.cast::<Self>().as_mut() }) else { return };

--- a/test/js/bun/test/snapshot-tests/__snapshots__/bun-snapshots.test.ts.snap
+++ b/test/js/bun/test/snapshot-tests/__snapshots__/bun-snapshots.test.ts.snap
@@ -75,3 +75,10 @@ exports[`it will create a snapshot file if it doesn't exist 7`] = `
   "j": Any<RegExp>,
 }
 `;
+
+exports[`an own enumerable 'constructor' property is part of the snapshot 1`] = `
+{
+  "a": 1,
+  "constructor": "K",
+}
+`;

--- a/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
+++ b/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
@@ -14,6 +14,32 @@ test("it will create a snapshot file if it doesn't exist", () => {
   });
 });
 
+test("an own enumerable 'constructor' property is part of the snapshot", () => {
+  expect({ constructor: "K", a: 1 }).toMatchSnapshot();
+  expect({ constructor: "K", a: 1 }).toMatchInlineSnapshot(`
+    {
+      "a": 1,
+      "constructor": "K",
+    }
+  `);
+  expect(JSON.parse('{"constructor":"_class"}')).toMatchInlineSnapshot(`
+    {
+      "constructor": "_class",
+    }
+  `);
+  expect([{ constructor: "K" }]).toMatchInlineSnapshot(`
+    [
+      {
+        "constructor": "K",
+      },
+    ]
+  `);
+
+  // The non-enumerable constructor that classes put on their prototype is still left out.
+  class Foo {}
+  expect(Foo.prototype).toMatchInlineSnapshot(`Foo {}`);
+});
+
 describe("toMatchSnapshot errors", () => {
   it("should throw if property matchers exist and received is not an object", () => {
     expect(() => {

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -3,7 +3,7 @@ import { spawn, spawnSync } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, test } from "bun:test";
 import { copyFileSync, mkdirSync, realpathSync, rmSync, writeFileSync } from "fs";
 import { rm, writeFile } from "fs/promises";
-import { bunEnv, bunExe, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir, tmpdirSync } from "harness";
 import { tmpdir } from "os";
 import { dirname, join } from "path";
 
@@ -586,6 +586,108 @@ it("expect().toEqual() on objects with property indices doesn't print undefined"
 
   expect(err).toMatchSnapshot();
   expect(err).not.toContain("undefined");
+});
+
+it("expect() diffs print an own enumerable 'constructor' property", async () => {
+  // The messages are printed by the fixture (rather than read off the failing test output) so the
+  // snapshot holds only the diffs. bunEnv sets NO_COLOR, so they carry no ANSI codes.
+  using dir = tempDir("diff-constructor-key", {
+    "constructor-key.test.js": /*js*/ `
+      import { expect, test } from "bun:test";
+
+      function failureMessage(fn) {
+        try {
+          fn();
+        } catch (e) {
+          return e.message;
+        }
+        throw new Error("expected the matcher to fail");
+      }
+
+      test("diffs", () => {
+        const received = JSON.parse('{"constructor":"_class","a":1}');
+        console.log(failureMessage(() => expect(received).toEqual({ constructor: "K", a: 1 })));
+        console.log(failureMessage(() => expect(received).toStrictEqual({ constructor: "K", a: 1 })));
+        console.log(failureMessage(() => expect(received).toMatchObject({ constructor: "K", a: 1 })));
+        console.log(failureMessage(() => expect({ outer: received }).toEqual({ outer: { constructor: "K", a: 1 } })));
+
+        // The non-enumerable constructor that classes put on their prototype is not compared by
+        // toEqual, so it stays out of the diff.
+        class Foo {}
+        console.log(failureMessage(() => expect(Foo.prototype).toEqual({ x: 1 })));
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "constructor-key.test.js"],
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+    env: bunEnv,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`
+    "bun test <version> (<revision>)
+    expect(received).toEqual(expected)
+
+      {
+        "a": 1,
+    -   "constructor": "K",
+    +   "constructor": "_class",
+      }
+
+    - Expected  - 1
+    + Received  + 1
+
+    expect(received).toStrictEqual(expected)
+
+      {
+        "a": 1,
+    -   "constructor": "K",
+    +   "constructor": "_class",
+      }
+
+    - Expected  - 1
+    + Received  + 1
+
+    expect(received).toMatchObject(expected)
+
+      {
+        "a": 1,
+    -   "constructor": "K",
+    +   "constructor": "_class",
+      }
+
+    - Expected  - 1
+    + Received  + 1
+
+    expect(received).toEqual(expected)
+
+      {
+        "outer": {
+          "a": 1,
+    -     "constructor": "K",
+    +     "constructor": "_class",
+        },
+      }
+
+    - Expected  - 1
+    + Received  + 1
+
+    expect(received).toEqual(expected)
+
+    - {
+    -   "x": 1,
+    - }
+    + Foo {}
+
+    - Expected  - 3
+    + Received  + 1"
+  `);
+  expect(stderr).toContain("1 pass");
+  expect(exitCode).toBe(0);
 });
 
 it("test --preload supports global lifecycle hooks", () => {

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -100,6 +100,77 @@ it("when prototype defines the same property, don't print the same property twic
   expect(Bun.inspect(obj).trim()).toBe('{\n  foo: "456",\n}'.trim());
 });
 
+describe("'constructor' property", () => {
+  it("prints an own enumerable constructor property like any other key", () => {
+    expect(Bun.inspect({ constructor: "K", a: 1 })).toBe('{\n  constructor: "K",\n  a: 1,\n}');
+    expect(Bun.inspect(JSON.parse('{"constructor":"_class"}'))).toBe('{\n  constructor: "_class",\n}');
+    expect(Bun.inspect({ constructor: "K", a: 1 }, { sorted: true })).toBe('{\n  a: 1,\n  constructor: "K",\n}');
+
+    // A getter takes the object off the fast (structure) enumeration path.
+    expect(Bun.inspect({ constructor: "K", get g() {} })).toBe('{\n  constructor: "K",\n  g: [Getter],\n}');
+
+    const array = [1];
+    array.constructor = "K";
+    expect(Bun.inspect(array)).toBe('[ 1, constructor: "K" ]');
+
+    class Shadowing {
+      constructor() {
+        this.constructor = "own";
+      }
+    }
+    expect(Bun.inspect(new Shadowing())).toBe('Shadowing {\n  constructor: "own",\n}');
+
+    const nullPrototype = Object.create(null);
+    nullPrototype.constructor = "K";
+    expect(Bun.inspect(nullPrototype)).toBe('[Object: null prototype] {\n  constructor: "K",\n}');
+
+    // The old-style prototype literal owns an enumerable constructor, so printing the
+    // prototype itself shows it (as node does).
+    function Old() {}
+    Old.prototype = { constructor: Old, method() {} };
+    expect(Bun.inspect(Old.prototype)).toBe("Old {\n  constructor: [Function: Old],\n  method: [Function: method],\n}");
+  });
+
+  it("hides a non-enumerable constructor", () => {
+    const obj = { a: 1 };
+    Object.defineProperty(obj, "constructor", { value: "hidden", enumerable: false });
+    expect(Bun.inspect(obj)).toBe("{\n  a: 1,\n}");
+    expect(Bun.inspect(obj, { sorted: true })).toBe("{\n  a: 1,\n}");
+
+    class Foo {
+      method() {}
+    }
+    expect(Bun.inspect(Foo.prototype)).toBe("Foo {\n  method: [Function: method],\n}");
+    expect(Bun.inspect(Foo.prototype, { sorted: true })).toBe("Foo {\n  method: [Function: method],\n}");
+
+    class WithGetter {
+      get g() {}
+    }
+    expect(Bun.inspect(WithGetter.prototype)).toBe("WithGetter {\n  g: [Getter],\n}");
+  });
+
+  it("hides the constructor of the prototypes it walks", () => {
+    class Foo {
+      method() {}
+    }
+    expect(Bun.inspect(new Foo())).toBe("Foo {\n  method: [Function: method],\n}");
+
+    class WithGetter {
+      get g() {}
+    }
+    expect(Bun.inspect(new WithGetter())).toBe("WithGetter {\n  g: [Getter],\n}");
+
+    // Enumerable, but inherited: the instance is printed with its class name already.
+    function Old() {}
+    Old.prototype = { constructor: Old, method() {} };
+    expect(Bun.inspect(new Old())).toBe("Old {\n  method: [Function: method],\n}");
+
+    function OldWithGetter() {}
+    OldWithGetter.prototype = { constructor: OldWithGetter, get g() {} };
+    expect(Bun.inspect(new OldWithGetter())).toBe("OldWithGetter {\n  g: [Getter],\n}");
+  });
+});
+
 it("Blob inspect", () => {
   expect(Bun.inspect(new Blob(["123"]))).toBe(`Blob (3 bytes)`);
   expect(Bun.inspect(new Blob(["123".repeat(900)]))).toBe(`Blob (2.70 KB)`);


### PR DESCRIPTION
### Problem
- `expect(received).toEqual(expected)` (same for `toStrictEqual` and `toMatchObject`) that fails only on an own `constructor` key prints a diff without that key, ending in `- Expected  - 0` / `+ Received  + 0`. Repro: `expect(JSON.parse('{"constructor":"_class","a":1}')).toEqual({ constructor: "K", a: 1 })`.
- `toMatchSnapshot` / `toMatchInlineSnapshot` serialize `{ constructor: "K", a: 1 }` as `{ "a": 1 }`, so a change to that value never fails the snapshot.
- `console.log` / `Bun.inspect` print `{ constructor: "K" }` as `{}`. Node, and bun's own `util.inspect`, print the key.
- Cause: the property walkers in `src/jsc/bindings/bindings.cpp` drop every property named `constructor`, whichever object it belongs to: `JSC__JSValue__forEachPropertyOrdered` (expect diffs, snapshots, `Bun.inspect(v, { sorted: true })`) and both the fast and the slow path of `JSC__JSValue__forEachPropertyImpl` (console.log, `Bun.inspect`, named array properties). `src/runtime/test_runner/pretty_format.rs` and `src/jsc/ConsoleObject.rs` repeat the same name check in their callbacks. The skip is there to hide the `constructor` back-reference that every prototype carries, but it also eats a user's own data property.

### Fix
- `constructor` is skipped only when it is non-enumerable, or, in console.log's prototype walk, when it was found on a prototype rather than on the object being printed. An enumerable own `constructor` is printed like any other key. The two Rust-side name checks are removed: they duplicated the C++ filter and would re-hide the key.
- Why non-enumerable is the right line for the diff: `Bun.deepEquals` and the matchers enumerate with `DontEnumPropertiesMode::Exclude`, so an enumerable own `constructor` is compared and a non-enumerable one never is. Printing exactly the enumerable ones puts every key that can fail a comparison into the diff, while the prototype back-reference (non-enumerable for classes, functions, builtins and bun's native classes) stays hidden, so output for class instances and prototypes is unchanged. This is also what jest's pretty-format (enumerable keys only) prints.
- Why console.log additionally hides an inherited `constructor`: bun's console.log walks the prototype chain to show methods. An inherited `constructor`, including the enumerable one in the pre-class pattern `Foo.prototype = { constructor: Foo, ... }`, is already conveyed by the `Foo {` prefix, so instances of such functions print as before. Printing the object that owns it (`console.log(Foo.prototype)`) now shows it, as node does.
- Output changes only for objects that have their own enumerable `constructor` property; committed snapshots of such objects gain the key.
- Deliberately left alone: the same name skip in `JSCommonJSModule.cpp` (`populateESMExports`, slow path only) decides which CommonJS exports become ESM names rather than what gets printed, and the fast walker's unconditional hiding of an own `Symbol.toStringTag` is a separate pre-existing inconsistency. Both are filed separately so this PR stays limited to the reported `constructor` output bug.
- Verified with `bun bd test`; each of the three files fails on the build without this change and passes with it:
  - `test/js/bun/test/test-test.test.ts`: diffs of `toEqual`, `toStrictEqual`, `toMatchObject` and a nested object; `Foo.prototype` still prints as `Foo {}`.
  - `test/js/bun/test/snapshot-tests/bun-snapshots.test.ts`: `toMatchSnapshot` and `toMatchInlineSnapshot`.
  - `test/js/bun/util/inspect.test.js`: `Bun.inspect` through the fast, slow (getter) and sorted walkers, named array properties, null-prototype objects; non-enumerable and inherited `constructor` (class and `Foo.prototype = {...}` style, fast and slow walk) stay hidden.
  - `test/js/bun/console`, `test/js/web/console`, `expect.test.js`, `expect-extend.test.js`, `jest-extended.test.js`, `snapshot-tests` and `test/printing` pass.

### Background
- Property walkers: the formatters do not enumerate properties themselves. They call one of three walkers in `bindings.cpp` that invoke a callback per property. `forEachPropertyOrdered` lists the object's own properties sorted by name and is used by the expect/snapshot formatter and by `Bun.inspect` with `sorted`. `forEachProperty` (console.log, `Bun.inspect`) lists own properties and then walks up to five prototypes so that class methods are shown; it reads the JSC `Structure` directly when it can (fast path) and falls back to `getOwnPropertyNames` otherwise (slow path, taken for example when the object has a getter). `forEachPropertyNonIndexed` is the slow path restricted to the object itself, used for the named properties of arrays.
- `DontEnum` is JSC's attribute for `enumerable: false`. The `constructor` on `Foo.prototype` is created with it for classes, functions, builtins and bun's native classes, while object literals, `JSON.parse` and plain assignment create enumerable properties.
- Both formatters deliberately print non-enumerable own properties in general (that is how prototype methods show up), which is why hiding the back-reference needs an explicit rule instead of falling out of an enumerable-only listing.

<details>
<summary>Repro output before and after</summary>

Before:

```
error: expect(received).toEqual(expected)

  {
    "a": 1,
  }

- Expected  - 0
+ Received  + 0
```

After:

```
error: expect(received).toEqual(expected)

  {
    "a": 1,
-   "constructor": "K",
+   "constructor": "_class",
  }

- Expected  - 1
+ Received  + 1
```

`Bun.inspect` output that changes (everything else in this probe is unchanged):

```
{ constructor: "K", a: 1 }          {}                    -> { constructor: "K", a: 1 }
JSON.parse('{"constructor":"x"}')   {}                    -> { constructor: "x" }
[1] with .constructor = "K"         [ 1 ]                 -> [ 1, constructor: "K" ]
Object.create(null) + .constructor  [Object: null prototype] {}  -> [Object: null prototype] { constructor: "K" }
Old.prototype = { constructor: Old, baz() {} }, printing Old.prototype itself
                                    Old { baz }           -> Old { constructor: [Function: Old], baz }
```

Unchanged: class instances, class prototypes, `new Old()`, objects whose `constructor` was defined with `enumerable: false`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/test/test-test.test.ts test/js/bun/util/inspect.test.js

<!-- robobun:evidence:end -->