### PR TITLE
test(no-orphans): gate the uid/gid test on being able to signal a nobody-owned process

### DIFF
--- a/test/cli/run/no-orphans.test.ts
+++ b/test/cli/run/no-orphans.test.ts
@@ -26,25 +26,26 @@ const isSupported = isPosix || isWindows;
 // 65534 is "nobody" on Linux and macOS.
 const NOBODY = 65534;
 
-// uid 0 is not enough for the uid/gid test. Spawning the grandchild as nobody
-// takes CAP_SETUID/CAP_SETGID; signalling it afterwards takes CAP_KILL, both
-// for this file's kill(2)-based isAlive()/reap() and for the kernel's
-// PR_SET_PDEATHSIG delivery, which runs the same permission check with the
-// dying bun as the sender. Containers commonly run as uid 0 with set*id but
-// without CAP_KILL, so probe the operations themselves. The probe blocks on
-// stdin and exits on EOF, so it needs no signal to clean up.
-function canSignalProcessSpawnedAsNobody(): boolean {
+// The tests whose grandchild changes ids need two things uid 0 by itself does
+// not guarantee: CAP_SETUID/CAP_SETGID to spawn with those ids, and permission
+// to signal the result. Signal permission goes by uid, so a uid change needs
+// CAP_KILL, both for this file's kill(2)-based isAlive()/reap() and for the
+// kernel's PR_SET_PDEATHSIG delivery, which runs the same permission check
+// with the dying bun as the sender; a gid-only change stays signallable.
+// Containers routinely run as uid 0 with set*id but without CAP_KILL, so probe
+// the operations themselves instead of getuid(). The probe blocks on stdin and
+// exits on EOF, so it needs no signal to clean up.
+function canSpawnAndSignal(ids: { uid?: number; gid?: number }): boolean {
   if (!isPosix) return false;
   try {
     const probe = Bun.spawn({
       cmd: ["/bin/sh", "-c", "read x"],
-      uid: NOBODY,
-      gid: NOBODY,
+      ...ids,
       stdio: ["pipe", "ignore", "ignore"],
     });
     try {
       // Bun.spawn returns after the child has exec'd (vfork / exec-status
-      // pipe), so the child already carries nobody's ids here.
+      // pipe), so the child already carries the requested ids here.
       process.kill(probe.pid, 0);
       return true;
     } finally {
@@ -55,7 +56,23 @@ function canSignalProcessSpawnedAsNobody(): boolean {
     return false;
   }
 }
-const canReapNobodyGrandchild = canSignalProcessSpawnedAsNobody();
+
+// Same shape as child.js, but the grandchild is plain /bin/sh — never calls
+// prctl itself, so reaping it proves the spawn-side linux_pdeathsig (Linux)
+// and the libproc walk (macOS) cover non-Bun descendants. `ids` is spliced
+// into the grandchild's spawn options.
+function nonBunChild(ids = "") {
+  return `
+    const gc = Bun.spawn({
+      cmd: ["/bin/sh", "-c", "echo r; while :; do sleep 1; done"],
+      ${ids}
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    await gc.stdout.getReader().read();
+    console.log(process.pid, process.ppid, gc.pid);
+    setInterval(()=>{}, 1000);
+  `;
+}
 
 // Shared fixture dir — child.js spawns grandchild.js, prints
 // "<self> <ppid> <grandchild>", then idles. Kept on disk so we can pass it
@@ -85,32 +102,12 @@ const fixture = tempDir("no-orphans", {
   // of /bin/sh. A .bat avoids cmd /c's quote-stripping around a quoted exe +
   // arg. %1 is the child script name.
   "supervisor.bat": `@"${bunExe()}" "%~dp0%~1"\r\n`,
-  // Same shape as child.js, but the grandchild is plain /bin/sh — never calls
-  // prctl itself, so reaping it proves the spawn-side linux_pdeathsig (Linux)
-  // and the libproc walk (macOS) cover non-Bun descendants.
-  "child-nonbun.js": `
-    const gc = Bun.spawn({
-      cmd: ["/bin/sh", "-c", "echo r; while :; do sleep 1; done"],
-      stdio: ["ignore", "pipe", "ignore"],
-    });
-    await gc.stdout.getReader().read();
-    console.log(process.pid, process.ppid, gc.pid);
-    setInterval(()=>{}, 1000);
-  `,
-  // Same as child-nonbun.js but the grandchild drops to nobody. On Linux the
-  // kernel clears PR_SET_PDEATHSIG when the child's effective ids change
-  // (prctl(2)), so the spawn must re-arm it after setgid/setuid.
-  "child-nonbun-uid.js": `
-    const gc = Bun.spawn({
-      cmd: ["/bin/sh", "-c", "echo r; while :; do sleep 1; done"],
-      uid: ${NOBODY},
-      gid: ${NOBODY},
-      stdio: ["ignore", "pipe", "ignore"],
-    });
-    await gc.stdout.getReader().read();
-    console.log(process.pid, process.ppid, gc.pid);
-    setInterval(()=>{}, 1000);
-  `,
+  "child-nonbun.js": nonBunChild(),
+  // The grandchild changes ids. On Linux the kernel clears PR_SET_PDEATHSIG
+  // when a process's effective uid or gid changes (prctl(2)), so the spawn
+  // must re-arm it after setgid/setuid.
+  "child-nonbun-uid.js": nonBunChild(`uid: ${NOBODY}, gid: ${NOBODY},`),
+  "child-nonbun-gid.js": nonBunChild(`gid: ${NOBODY},`),
 });
 
 async function spawnTree(noOrphans: string | undefined, childScript = "child.js") {
@@ -176,10 +173,6 @@ async function waitUntilDead(pid: number, timeoutMs: number): Promise<boolean> {
   return !isAlive(pid);
 }
 
-/**
- * Tests record their observations, call this, and only then `expect()`: an
- * assertion that throws before reap() leaves the whole tree running.
- */
 function reap(...pids: number[]) {
   for (const pid of pids) {
     if (isAlive(pid)) {
@@ -221,7 +214,7 @@ test.concurrent.skipIf(!isSupported)(
   "BUN_FEATURE_FLAG_NO_ORPHANS=1: grandchildren are reaped when bun dies with its parent",
   async () => {
     const { sh, bunPid, grandchildPid } = await spawnTree("1");
-    const grandchildWasAlive = isAlive(grandchildPid);
+    expect(isAlive(grandchildPid)).toBe(true);
     process.kill(sh.pid!, "SIGKILL");
     await sh.exited;
     const bunDied = await waitUntilDead(bunPid, 10000);
@@ -230,7 +223,6 @@ test.concurrent.skipIf(!isSupported)(
     // also Bun with the env var inherited and so has its own PDEATHSIG.
     const grandchildDied = await waitUntilDead(grandchildPid, 10000);
     reap(bunPid, grandchildPid);
-    expect(grandchildWasAlive).toBe(true);
     expect(bunDied).toBe(true);
     expect(grandchildDied).toBe(true);
   },
@@ -244,36 +236,43 @@ test.concurrent.skipIf(!isPosix)(
   "BUN_FEATURE_FLAG_NO_ORPHANS=1: non-Bun grandchildren are reaped when bun dies with its parent",
   async () => {
     const { sh, bunPid, grandchildPid } = await spawnTree("1", "child-nonbun.js");
-    const grandchildWasAlive = isAlive(grandchildPid);
+    expect(isAlive(grandchildPid)).toBe(true);
     process.kill(sh.pid!, "SIGKILL");
     await sh.exited;
     const bunDied = await waitUntilDead(bunPid, 10000);
     const grandchildDied = await waitUntilDead(grandchildPid, 10000);
     reap(bunPid, grandchildPid);
-    expect(grandchildWasAlive).toBe(true);
     expect(bunDied).toBe(true);
     expect(grandchildDied).toBe(true);
   },
 );
 
-// Same as above but the grandchild is spawned with uid/gid. The credential
-// change clears the pdeathsig the spawn armed (prctl(2)), so this proves it
-// gets re-armed after setgid/setuid.
-test.concurrent.skipIf(!canReapNobodyGrandchild)(
-  "BUN_FEATURE_FLAG_NO_ORPHANS=1: a non-Bun grandchild spawned with uid/gid is reaped",
-  async () => {
-    const { sh, bunPid, grandchildPid } = await spawnTree("1", "child-nonbun-uid.js");
-    const grandchildWasAlive = isAlive(grandchildPid);
-    process.kill(sh.pid!, "SIGKILL");
-    await sh.exited;
-    const bunDied = await waitUntilDead(bunPid, 10000);
-    const grandchildDied = await waitUntilDead(grandchildPid, 10000);
-    reap(bunPid, grandchildPid);
-    expect(grandchildWasAlive).toBe(true);
-    expect(bunDied).toBe(true);
-    expect(grandchildDied).toBe(true);
-  },
-);
+// Same as above but the grandchild is spawned with new ids. The credential
+// change clears the pdeathsig the spawn armed (prctl(2)), so these prove it
+// gets re-armed after setgid/setuid. Each variant runs only where this process
+// can spawn with those ids and then signal the result (canSpawnAndSignal):
+// non-root can do neither; uid 0 without CAP_KILL, the usual shape of a
+// container, can for the gid-only variant but not the uid one, which is what
+// keeps the re-arm covered there.
+for (const { ids, script, enabled } of [
+  { ids: "uid/gid", script: "child-nonbun-uid.js", enabled: canSpawnAndSignal({ uid: NOBODY, gid: NOBODY }) },
+  { ids: "gid", script: "child-nonbun-gid.js", enabled: canSpawnAndSignal({ gid: NOBODY }) },
+]) {
+  test.concurrent.skipIf(!enabled)(
+    `BUN_FEATURE_FLAG_NO_ORPHANS=1: a non-Bun grandchild spawned with ${ids} is reaped`,
+    async () => {
+      const { sh, bunPid, grandchildPid } = await spawnTree("1", script);
+      expect(isAlive(grandchildPid)).toBe(true);
+      process.kill(sh.pid!, "SIGKILL");
+      await sh.exited;
+      const bunDied = await waitUntilDead(bunPid, 10000);
+      const grandchildDied = await waitUntilDead(grandchildPid, 10000);
+      reap(bunPid, grandchildPid);
+      expect(bunDied).toBe(true);
+      expect(grandchildDied).toBe(true);
+    },
+  );
+}
 
 test.concurrent.skipIf(!isSupported)("BUN_FEATURE_FLAG_NO_ORPHANS=0 is treated as unset", async () => {
   const { sh, bunPid, grandchildPid } = await spawnTree("0");

--- a/test/cli/run/no-orphans.test.ts
+++ b/test/cli/run/no-orphans.test.ts
@@ -23,6 +23,40 @@ setDefaultTimeout(30_000);
 const isPosix = process.platform === "linux" || process.platform === "darwin";
 const isSupported = isPosix || isWindows;
 
+// 65534 is "nobody" on Linux and macOS.
+const NOBODY = 65534;
+
+// uid 0 is not enough for the uid/gid test. Spawning the grandchild as nobody
+// takes CAP_SETUID/CAP_SETGID; signalling it afterwards takes CAP_KILL, both
+// for this file's kill(2)-based isAlive()/reap() and for the kernel's
+// PR_SET_PDEATHSIG delivery, which runs the same permission check with the
+// dying bun as the sender. Containers commonly run as uid 0 with set*id but
+// without CAP_KILL, so probe the operations themselves. The probe blocks on
+// stdin and exits on EOF, so it needs no signal to clean up.
+function canSignalProcessSpawnedAsNobody(): boolean {
+  if (!isPosix) return false;
+  try {
+    const probe = Bun.spawn({
+      cmd: ["/bin/sh", "-c", "read x"],
+      uid: NOBODY,
+      gid: NOBODY,
+      stdio: ["pipe", "ignore", "ignore"],
+    });
+    try {
+      // Bun.spawn returns after the child has exec'd (vfork / exec-status
+      // pipe), so the child already carries nobody's ids here.
+      process.kill(probe.pid, 0);
+      return true;
+    } finally {
+      probe.stdin.end();
+    }
+  } catch {
+    // EPERM from set*id in the child (spawn threw) or from kill(2).
+    return false;
+  }
+}
+const canReapNobodyGrandchild = canSignalProcessSpawnedAsNobody();
+
 // Shared fixture dir — child.js spawns grandchild.js, prints
 // "<self> <ppid> <grandchild>", then idles. Kept on disk so we can pass it
 // through /bin/sh without fighting shell quoting of an inline -e payload.
@@ -69,8 +103,8 @@ const fixture = tempDir("no-orphans", {
   "child-nonbun-uid.js": `
     const gc = Bun.spawn({
       cmd: ["/bin/sh", "-c", "echo r; while :; do sleep 1; done"],
-      uid: 65534,
-      gid: 65534,
+      uid: ${NOBODY},
+      gid: ${NOBODY},
       stdio: ["ignore", "pipe", "ignore"],
     });
     await gc.stdout.getReader().read();
@@ -142,6 +176,10 @@ async function waitUntilDead(pid: number, timeoutMs: number): Promise<boolean> {
   return !isAlive(pid);
 }
 
+/**
+ * Tests record their observations, call this, and only then `expect()`: an
+ * assertion that throws before reap() leaves the whole tree running.
+ */
 function reap(...pids: number[]) {
   for (const pid of pids) {
     if (isAlive(pid)) {
@@ -183,7 +221,7 @@ test.concurrent.skipIf(!isSupported)(
   "BUN_FEATURE_FLAG_NO_ORPHANS=1: grandchildren are reaped when bun dies with its parent",
   async () => {
     const { sh, bunPid, grandchildPid } = await spawnTree("1");
-    expect(isAlive(grandchildPid)).toBe(true);
+    const grandchildWasAlive = isAlive(grandchildPid);
     process.kill(sh.pid!, "SIGKILL");
     await sh.exited;
     const bunDied = await waitUntilDead(bunPid, 10000);
@@ -192,6 +230,7 @@ test.concurrent.skipIf(!isSupported)(
     // also Bun with the env var inherited and so has its own PDEATHSIG.
     const grandchildDied = await waitUntilDead(grandchildPid, 10000);
     reap(bunPid, grandchildPid);
+    expect(grandchildWasAlive).toBe(true);
     expect(bunDied).toBe(true);
     expect(grandchildDied).toBe(true);
   },
@@ -205,12 +244,13 @@ test.concurrent.skipIf(!isPosix)(
   "BUN_FEATURE_FLAG_NO_ORPHANS=1: non-Bun grandchildren are reaped when bun dies with its parent",
   async () => {
     const { sh, bunPid, grandchildPid } = await spawnTree("1", "child-nonbun.js");
-    expect(isAlive(grandchildPid)).toBe(true);
+    const grandchildWasAlive = isAlive(grandchildPid);
     process.kill(sh.pid!, "SIGKILL");
     await sh.exited;
     const bunDied = await waitUntilDead(bunPid, 10000);
     const grandchildDied = await waitUntilDead(grandchildPid, 10000);
     reap(bunPid, grandchildPid);
+    expect(grandchildWasAlive).toBe(true);
     expect(bunDied).toBe(true);
     expect(grandchildDied).toBe(true);
   },
@@ -218,17 +258,18 @@ test.concurrent.skipIf(!isPosix)(
 
 // Same as above but the grandchild is spawned with uid/gid. The credential
 // change clears the pdeathsig the spawn armed (prctl(2)), so this proves it
-// gets re-armed after setgid/setuid. Needs root to setuid.
-test.concurrent.skipIf(!isPosix || process.getuid?.() !== 0)(
+// gets re-armed after setgid/setuid.
+test.concurrent.skipIf(!canReapNobodyGrandchild)(
   "BUN_FEATURE_FLAG_NO_ORPHANS=1: a non-Bun grandchild spawned with uid/gid is reaped",
   async () => {
     const { sh, bunPid, grandchildPid } = await spawnTree("1", "child-nonbun-uid.js");
-    expect(isAlive(grandchildPid)).toBe(true);
+    const grandchildWasAlive = isAlive(grandchildPid);
     process.kill(sh.pid!, "SIGKILL");
     await sh.exited;
     const bunDied = await waitUntilDead(bunPid, 10000);
     const grandchildDied = await waitUntilDead(grandchildPid, 10000);
     reap(bunPid, grandchildPid);
+    expect(grandchildWasAlive).toBe(true);
     expect(bunDied).toBe(true);
     expect(grandchildDied).toBe(true);
   },


### PR DESCRIPTION
### Problem
- `test/cli/run/no-orphans.test.ts` "BUN_FEATURE_FLAG_NO_ORPHANS=1: a non-Bun grandchild spawned with uid/gid is reaped" fails with `expect(isAlive(grandchildPid)).toBe(true)` -> `Received: false` when the suite runs as uid 0 in a container whose capability set lacks CAP_KILL (observed with `CapEff: 00000000000000cb`, i.e. chown/dac_override/fowner/setgid/setuid only). Each failing run also leaves the supervisor `sh`, the `bun` child and the nobody-owned `sh` grandchild running, because the guard throws before `reap()`.
- The skip condition was `process.getuid?.() !== 0` (line 222). uid 0 with CAP_SETUID/CAP_SETGID can spawn the grandchild as nobody (65534), but without CAP_KILL `kill(pid, 0)` on it fails with EPERM, so `isAlive()` reports a live process as dead.
- The same missing capability also stops the feature under test: the kernel applies the normal kill(2) permission check when it delivers PR_SET_PDEATHSIG, with the dying parent (bun) as the sender. Without CAP_KILL a nobody-owned grandchild survives bun's death no matter what bun armed, so there is nothing the test could observe in such an environment (probe below). Skipping is the only correct outcome there; an EPERM-aware `isAlive()` would just move the failure to `grandchildDied`.
- Buildkite runs the suite as `buildkite-agent`, so this test was already skipped in CI. Its executors are root shells and containers, and containers are commonly exactly the capability-restricted shape above, so gating the uid variant alone would leave the set*id re-arm in `src/jsc/bindings/bun-spawn.cpp:433-437` without a routine executor.

### Fix
- Test-only change. `canSpawnAndSignal(ids)` spawns `/bin/sh -c 'read x'` with the given ids and a stdin pipe at module load and `kill(pid, 0)`s it; a variant is skipped if either step throws. This probes the two privileges the tests need (set*id for the spawn, signal permission for every kill involved) instead of using uid 0 as a stand-in for them. `Bun.spawn` returns only after the child has exec'd (vfork on Linux, exec-status pipe on macOS), so the probe is checked against the child's final ids; the probe blocks on stdin and exits on EOF, so it needs no signal to clean up even when the answer is "cannot signal". Same module-load-probe shape as `test/js/bun/spawn/spawn-cgroup.test.ts`.
- Adds a gid-only variant of the test (`child-nonbun-gid.js`, same body via a small `nonBunChild(ids)` fixture template). Signal permission goes by uid, so a grandchild that only changes its gid stays observable and reapable by a uid 0 process without CAP_KILL, while the kernel still clears PR_SET_PDEATHSIG on the gid change. It keeps the re-arm exercised in the environments where the uid variant now skips, and a regression there is cleaned up by `reap()` rather than leaked.
- Outcomes per environment: non-root skips both variants (the probe's spawn throws EPERM, as the fixture's spawn did before); full-capability root runs both; uid 0 without CAP_KILL runs the gid variant and skips the uid one (previously: failed and leaked). Nothing else in the file changes; the other tests' assertion order is left as is.
- Verified in the capability-restricted container: unfixed file -> 1 fail at line 226 plus a leaked 3-process tree per run; this branch -> `bun bd test test/cli/run/no-orphans.test.ts` 19 pass, 6 skip (uid variant plus the 5 Windows tests), nothing left behind.
- Verified the gid variant exercises the re-arm: with the `prctl` re-arm after set*id in `bun-spawn.cpp` disabled and bun rebuilt, it fails with `grandchildDied` -> `false` and leaves no processes behind; with the re-arm restored it passes.

### Background
- Linux capabilities: root's privileges are split into per-operation capabilities, and container runtimes start uid 0 with a reduced set. CAP_SETUID/CAP_SETGID allow changing a child's ids; CAP_KILL allows signalling a process whose uid differs from yours (gid plays no part in that check). kill(2) returns EPERM, not ESRCH, for a live process you may not signal, which is why a `kill(pid, 0)` liveness check across a uid boundary needs CAP_KILL.
- PR_SET_PDEATHSIG is the prctl the no-orphans spawn path arms on each child so the kernel signals it when bun dies. The kernel clears it when the process's effective uid or gid changes, which is why the spawn re-arms it after set*id and what these tests cover. Delivery goes through the same permission check as a kill(2) issued by the dying parent.

<details>
<summary>Kernel-level probe: pdeathsig is not delivered across uids without CAP_KILL</summary>

Plain C, no bun involved: fork; child does setgid/setuid(65534) and then arms `PR_SET_PDEATHSIG, SIGKILL`; parent exits once the child is ready. Run as uid 0 with `CapEff: 00000000000000cb` on Linux 6.17:

```
child uid 65534 (PPid: parent, Uid: 65534 65534 65534 65534)
kill -0 <child> from the shell: Operation not permitted
parent exits
child: State: S (sleeping), PPid: 1      <- survived
```

Control run with the child left as uid 0: the child is gone as soon as the parent exits. The unfixed bun test shows the same thing: after the supervisor is killed, the bun child dies via its own pdeathsig and the nobody-owned grandchild stays alive.
</details>

<details>
<summary>First revision of this PR (superseded)</summary>

The first push gated only the uid variant and also moved the `isAlive` guard assertion after `reap()` in the three grandchild tests. Self-review pointed out that the reordering covered three of the file's several assert-before-reap sites while documenting it as a file-wide convention, and that gating the uid variant left the set*id re-arm with no routine executor. The reordering was dropped (the gate removes the failure that leaked; a structural cleanup of `spawnTree` can be its own change) and the gid-only variant was added instead.
</details>
