### PR TITLE
Print JSX component tags with the component's inferred name or displayName

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -3247,10 +3247,8 @@ pub mod formatter {
         Ok(None)
     }
 
-    /// Tag name for a JSX element whose `type` is a component (function, class,
-    /// or a `memo`/`forwardRef` object) rather than a string. Same rule React
-    /// uses to name a component: `displayName`, else the function/class name
-    /// (the one `[Function: x]` / `[class x]` print).
+    /// How React itself names a component: `displayName`, else the name
+    /// `[Function: x]` / `[class x]` print.
     pub fn jsx_component_tag_name(
         global_this: &JSGlobalObject,
         component: JSValue,

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -3247,8 +3247,6 @@ pub mod formatter {
         Ok(None)
     }
 
-    /// How React itself names a component: `displayName`, else the name
-    /// `[Function: x]` / `[class x]` print.
     pub fn jsx_component_tag_name(
         global_this: &JSGlobalObject,
         component: JSValue,

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -1516,7 +1516,9 @@ pub struct CustomFormattedObject {
 // Formatter
 // ───────────────────────────────────────────────────────────────────────────
 
-pub use formatter::{Formatter, Tag, TagOptions, TagPayload, TagResult, visited};
+pub use formatter::{
+    Formatter, Tag, TagOptions, TagPayload, TagResult, jsx_component_tag_name, visited,
+};
 
 pub mod formatter {
     use super::*;
@@ -3243,6 +3245,28 @@ pub mod formatter {
             return Ok(Some(ZigString::static_("[Object: null prototype]")));
         }
         Ok(None)
+    }
+
+    /// Tag name for a JSX element whose `type` is a component (function, class,
+    /// or a `memo`/`forwardRef` object) rather than a string. Same rule React
+    /// uses to name a component: `displayName`, else the function/class name
+    /// (the one `[Function: x]` / `[class x]` print).
+    pub fn jsx_component_tag_name(
+        global_this: &JSGlobalObject,
+        component: JSValue,
+    ) -> JsResult<bun_core::ZigStringSlice> {
+        if let Some(display_name) = component
+            .get_truthy(global_this, "displayName")?
+            .filter(|display_name| display_name.is_string())
+        {
+            return display_name.to_slice(global_this);
+        }
+
+        let name = OwnedString::new(component.get_name(global_this)?);
+        if name.is_empty() {
+            return Ok(bun_core::ZigStringSlice::from_utf8_never_free(b"NoName"));
+        }
+        Ok(name.to_utf8())
     }
 
     // `JSGlobalObject` is an opaque `UnsafeCell`-backed ZST handle; remaining
@@ -5072,39 +5096,29 @@ pub mod formatter {
             writer.write_all(pf!("<r>").as_bytes());
             writer.write_all(b"<");
 
-            // Both arms of the `type` if/else below assign these, so deferred
-            // init avoids the dead-store warning.
-            let mut needs_space: bool;
-            let mut tag_name_str = ZigString::init(b"");
+            let mut needs_space = true;
+            let mut is_tag_kind_primitive = false;
 
             // `ZigStringSlice` frees on `Drop`, so no explicit cleanup is
             // needed.
-            let tag_name_slice: bun_core::ZigStringSlice;
-            let mut is_tag_kind_primitive = false;
+            let tag_name_slice: bun_core::ZigStringSlice =
+                if let Some(type_value) = value.get(self.global_this, "type")? {
+                    let _tag = Tag::get_advanced(type_value, self.global_this, tag_opts)?;
 
-            if let Some(type_value) = value.get(self.global_this, "type")? {
-                let _tag = Tag::get_advanced(type_value, self.global_this, tag_opts)?;
-
-                if _tag.cell == jsc::JSType::Symbol {
-                    // nothing
-                } else if _tag.cell.is_string_like() {
-                    type_value.to_zig_string(&mut tag_name_str, self.global_this)?;
-                    is_tag_kind_primitive = true;
-                } else if _tag.cell.is_object() || type_value.is_callable() {
-                    type_value.get_name_property(self.global_this, &mut tag_name_str)?;
-                    if tag_name_str.len == 0 {
-                        tag_name_str = ZigString::init(b"NoName");
+                    if _tag.cell == jsc::JSType::Symbol {
+                        // A fragment prints as `<>...</>`.
+                        bun_core::ZigStringSlice::EMPTY
+                    } else if _tag.cell.is_string_like() {
+                        is_tag_kind_primitive = true;
+                        type_value.to_slice(self.global_this)?
+                    } else if _tag.cell.is_object() || type_value.is_callable() {
+                        jsx_component_tag_name(self.global_this, type_value)?
+                    } else {
+                        type_value.to_slice(self.global_this)?
                     }
                 } else {
-                    type_value.to_zig_string(&mut tag_name_str, self.global_this)?;
-                }
-
-                tag_name_slice = tag_name_str.to_slice();
-                needs_space = true;
-            } else {
-                tag_name_slice = ZigString::init(b"unknown").to_slice();
-                needs_space = true;
-            }
+                    bun_core::ZigStringSlice::from_utf8_never_free(b"unknown")
+                };
 
             if !is_tag_kind_primitive {
                 writer.write_all(pf!("<cyan>").as_bytes());

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -1978,35 +1978,30 @@ impl<'a> Formatter<'a> {
 
                     writer.write_all(b"<");
 
-                    let mut needs_space;
-                    let mut tag_name_str = ZigString::init(b"");
-
-                    let tag_name_slice: ZigStringSlice;
+                    let mut needs_space = true;
                     let mut is_tag_kind_primitive = false;
 
-                    if let Some(type_value) = value.get(self.global_this, "type")? {
-                        let _tag = Tag::get(type_value, self.global_this)?;
+                    let tag_name_slice: ZigStringSlice =
+                        if let Some(type_value) = value.get(self.global_this, "type")? {
+                            let _tag = Tag::get(type_value, self.global_this)?;
 
-                        if _tag.cell == JSType::Symbol {
-                        } else if _tag.cell.is_string_like() {
-                            type_value.to_zig_string(&mut tag_name_str, self.global_this)?;
-                            is_tag_kind_primitive = true;
-                        } else if _tag.cell.is_object() || type_value.is_callable() {
-                            type_value.get_name_property(self.global_this, &mut tag_name_str)?;
-                            if tag_name_str.len == 0 {
-                                tag_name_str = ZigString::init(b"NoName");
+                            if _tag.cell == JSType::Symbol {
+                                // A fragment prints as `<>...</>`.
+                                ZigStringSlice::EMPTY
+                            } else if _tag.cell.is_string_like() {
+                                is_tag_kind_primitive = true;
+                                type_value.to_slice(self.global_this)?
+                            } else if _tag.cell.is_object() || type_value.is_callable() {
+                                jsc::console_object::jsx_component_tag_name(
+                                    self.global_this,
+                                    type_value,
+                                )?
+                            } else {
+                                type_value.to_slice(self.global_this)?
                             }
                         } else {
-                            type_value.to_zig_string(&mut tag_name_str, self.global_this)?;
-                        }
-
-                        tag_name_slice = tag_name_str.to_slice();
-                        needs_space = true;
-                    } else {
-                        tag_name_slice = ZigString::init(b"unknown").to_slice();
-
-                        needs_space = true;
-                    }
+                            ZigStringSlice::from_utf8_never_free(b"unknown")
+                        };
 
                     if !is_tag_kind_primitive {
                         writer.write_all(

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -300,12 +300,58 @@ it("jsx with two elements", () => {
 
 const Foo = () => <div hello="quoted">foo</div>;
 
-it("jsx with anon component", () => {
-  const input = Bun.inspect(<Foo />);
+// Module scope on purpose: the transpiler inlines a single-use `const` declared
+// inside a test body, and the inlined function loses its inferred `.name`.
+const FunctionExpression = function () {};
+function Declaration() {}
+const WithDisplayName = function RenderName() {};
+WithDisplayName.displayName = "Shown";
+class ClassComponent {}
+const ClassExpression = class {};
+async function AsyncComponent() {}
+// `React.forwardRef()` / `React.memo()` return objects, not functions; they are
+// named by assigning `displayName`.
+const ForwardRefLike = { $$typeof: Symbol.for("react.forward_ref"), render: () => null, displayName: "Button" };
+function makeUnnamed() {
+  return () => null;
+}
+const Unnamed = makeUnnamed();
 
-  const output = `<NoName />`;
+describe("jsx component tag name", () => {
+  const cases = [
+    ["arrow function", Foo, "Foo"],
+    ["anonymous function expression", FunctionExpression, "FunctionExpression"],
+    ["function declaration", Declaration, "Declaration"],
+    ["displayName wins over the function name", WithDisplayName, "Shown"],
+    ["class", ClassComponent, "ClassComponent"],
+    ["anonymous class expression", ClassExpression, "ClassExpression"],
+    ["async function", AsyncComponent, "AsyncComponent"],
+    ["displayName on a forwardRef/memo-style object", ForwardRefLike, "Button"],
+    ["function with no name at all", Unnamed, "NoName"],
+  ];
 
-  expect(input).toBe(output);
+  for (const [description, Component, tagName] of cases) {
+    it(description, () => {
+      const element = <Component />;
+
+      expect(Bun.inspect(element)).toBe(`<${tagName} />`);
+      // The test runner's formatter (diffs, snapshots) has its own JSX printer.
+      expect(element).toMatchInlineSnapshot(`<${tagName} />`);
+    });
+  }
+
+  it("closing tag uses the same name", () => {
+    const element = <Foo>child</Foo>;
+
+    expect(Bun.inspect(element)).toBe(`<Foo>child</Foo>`);
+    expect(element).toMatchInlineSnapshot(`<Foo>child</Foo>`);
+  });
+
+  it("is the name console.log prints for the component itself", () => {
+    expect(Bun.inspect(Foo)).toBe("[Function: Foo]");
+    expect(Bun.inspect(ClassExpression)).toBe("[class ClassExpression]");
+    expect(Bun.inspect(WithDisplayName)).toBe("[Function: Shown]");
+  });
 });
 
 it("jsx with fragment", () => {

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -312,6 +312,7 @@ async function AsyncComponent() {}
 // `React.forwardRef()` / `React.memo()` return objects, not functions; they are
 // named by assigning `displayName`.
 const ForwardRefLike = { $$typeof: Symbol.for("react.forward_ref"), render: () => null, displayName: "Button" };
+const MemoLike = { $$typeof: Symbol.for("react.memo"), type: Foo };
 function makeUnnamed() {
   return () => null;
 }
@@ -327,6 +328,7 @@ describe("jsx component tag name", () => {
     ["anonymous class expression", ClassExpression, "ClassExpression"],
     ["async function", AsyncComponent, "AsyncComponent"],
     ["displayName on a forwardRef/memo-style object", ForwardRefLike, "Button"],
+    ["memo-style object without a displayName", MemoLike, "NoName"],
     ["function with no name at all", Unnamed, "NoName"],
   ];
 


### PR DESCRIPTION
### Problem

- `Bun.inspect` / `console.log` of a JSX element prints `<NoName />` for the most common kinds of components: `const Bar = () => null` and `const Bar = function () {}` (name inferred from the binding), `const Bar = class {}`, and anything named through `displayName`. `console.log(Bar)` prints `[Function: Bar]` for the same values, so the two disagree. (Same symptom as #4104; the `function App() {}` case reported there has since been fixed, the cases above were not.)
- An async component (`async function Page() {}`) prints `<AsyncFunction />`.
- The test runner's formatter has the same bug, so `expect(<Bar />).toMatchSnapshot()` stores `<NoName />` and failure diffs show `<NoName />`.
- Cause: both JSX printers (`print_jsx` in `src/jsc/ConsoleObject.rs`, the `Tag::JSX` arm in `src/runtime/test_runner/pretty_format.rs`) look the tag name up with `JSValue::get_name_property` (`JSC__JSValue__getNameProperty`, `src/jsc/bindings/bindings.cpp`). That binding reads `Symbol.toStringTag` first (which is how `AsyncFunction.prototype[Symbol.toStringTag]` wins over the function's own name) and then only the explicit name from the function's executable; it never consults the inferred name or `displayName`. The function and class printers were moved to `JSValue::get_name` (`getCalculatedDisplayName`) in #6612; the JSX printers were not.

### Fix

- Adds `jsx_component_tag_name` next to the console formatter and uses it from both JSX printers. Lookup order: a non-empty string `displayName` property, else `get_name` (the lookup `[Function: x]` / `[class x]` use, which falls back to `Symbol.toStringTag` when there is no name), else `NoName` as before.
- Why this is correct: `displayName || name` is the rule React itself uses to name a component in its warnings and devtools, and the rule jest's React element serializer uses for function components. Taking the `name` half from `get_name` means that for a function or class component the tag is the same string `console.log` prints for the component value (`[Function: x]` / `[class x]`), which is the consistency the report asks for.
- `displayName` is read as a property rather than left to `getCalculatedDisplayName` (which already honors it for functions) because `React.memo()` / `React.forwardRef()` results are plain objects, and `Button.displayName = "Button"` is the only way they get a name; `get_name` returns nothing for a non-function.
- Each tag-name branch now yields the `ZigStringSlice` directly instead of going through a `ZigString` first; the string / symbol / primitive branches produce the same bytes as before (fragments still print as `<>...</>`).
- Behavior that changes besides the cases above, for the record: a component that has both a name and a `Symbol.toStringTag` now prints its name (before, the tag won; async and generator functions are the practical instance). A function whose `displayName` is the empty string prints `<NoName />` (before: its function name), because `getCalculatedDisplayName` returns the empty `displayName` as the name; this is the same thing `console.log` already prints for such a function (`[Function]`), so the two printers still agree, and it is not a pattern React code uses.
- Behavior deliberately unchanged: a `memo` / `forwardRef` object without a `displayName` still prints `<NoName />` (naming it after the wrapped function is a separate feature), an object `type` with a `Symbol.toStringTag` still prints the tag, and a component with no name at all still prints `<NoName />`.
- Not changed: `get_name_property` itself. `pretty_format.rs` still uses it to print `[Function]` for inferred-name functions in snapshots, which #6612 deliberately kept so existing `.snap` files do not change; this PR only changes the JSX tag, which was `NoName` before and therefore not something a snapshot could usefully depend on.
- Verified:
  - `test/js/bun/util/inspect.test.js`, `describe("jsx component tag name")`: arrow function, anonymous function expression, function declaration, `displayName` over an explicit function name, class, anonymous class expression, async function, `displayName` on a forwardRef-style object, a memo-style object without `displayName` (still `NoName`), a function with no name at all (still `NoName`), the closing tag of an element with children, and the `[Function: x]` / `[class x]` output for the same values. Each element case asserts `Bun.inspect` and, through `toMatchInlineSnapshot`, the test runner's printer. 7 of the 12 tests fail on the released bun 1.4.0 (`<NoName />` / `<AsyncFunction />` / `<NoName>child</NoName>`); all pass with this change. The previous `"jsx with anon component"` test, which asserted `<NoName />` for `const Foo = () => ...`, is replaced by the arrow function case.
  - The rest of `inspect.test.js`, `bundler_jsx.test.ts`, `run-eval.test.ts` (string tags and fragments through the restructured branches), `snapshot-tests/snapshots/snapshot.test.ts` and `console-table.test.ts` pass with the debug build.
  - The test runner formatter's output for function values themselves (`[Function]`, `[class]`, `[Function: AsyncFunction]`) is byte-identical before and after, per the note above.

### Background

- React element: the object JSX compiles to, `{ $$typeof: Symbol.for("react.element"), type, props, key }`. `type` is a string for host elements (`"div"`) and a function, class, or (for `memo` / `forwardRef`) an object for components. Both formatters detect it by `$$typeof` and print it back as JSX, using `type`'s name as the tag.
- Inferred function name: `const Bar = () => null` gives the arrow `Bar.name === "Bar"`, but JSC stores that as the executable's `ecmaName`, separate from the explicit name of `function Bar() {}`. `JSFunction::name()` returns only the explicit one; `getCalculatedDisplayName` (what `JSValue::get_name` wraps) checks `displayName`, then the explicit name, then the inferred one.
- `displayName`: a plain property React reads to name a component in warnings and devtools. React honors it on functions and on `memo` / `forwardRef` objects alike.
- `JSValue::get_name` returns a `bun_core::String` holding a +1 ref; `OwnedString` releases it on scope exit and `to_utf8()` takes its own ref (or makes a copy), which is why the returned slice can outlive the `OwnedString`.

<details>
<summary>Before / after on the cases from the report</summary>

```
$ bun -e '
const Bar = () => null;
console.log(Bar);
console.log(Bun.inspect({ $$typeof: Symbol.for("react.element"), type: Bar, props: {} }));
const W = function () {}; W.displayName = "Pretty";
console.log(W);
console.log(Bun.inspect({ $$typeof: Symbol.for("react.element"), type: W, props: {} }));
async function Page() {}
console.log(Bun.inspect({ $$typeof: Symbol.for("react.element"), type: Page, props: {} }));
'
# bun 1.4.0            # this branch
[Function: Bar]        [Function: Bar]
<NoName />             <Bar />
[Function: Pretty]     [Function: Pretty]
<NoName />             <Pretty />
<AsyncFunction />      <Page />
```

</details>
