### PR TITLE
test: move the shell heap snapshot out of the 1 MiB pipe test into a fixture process

### DIFF
--- a/test/js/bun/shell/shell-blocking-pipe.test.ts
+++ b/test/js/bun/shell/shell-blocking-pipe.test.ts
@@ -1,22 +1,18 @@
-import { $, generateHeapSnapshot } from "bun";
+import { $ } from "bun";
 
-import { test } from "bun:test";
-import { isWindows } from "harness";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows } from "harness";
+import { join } from "node:path";
 
-// We skip this test on Windows becasue:
+// We skip these tests on Windows because:
 // 1. Windows didn't have this problem to begin with
 // 2. We need system cat.
 test.skipIf(isWindows)("writing > send buffer size doesn't block the main thread", async () => {
   const expected = Buffer.alloc(1024 * 1024, "bun!").toString();
   const massiveComamnd = "echo " + expected + " | " + Bun.which("cat");
-  const pendingResult = $`${{
+  const result = await $`${{
     raw: massiveComamnd,
   }}`.text();
-
-  // Ensure that heap snapshot works, to excercise the memoryCost & estimated fields.
-  generateHeapSnapshot("v8");
-
-  const result = await pendingResult;
 
   if (result !== expected + "\n") {
     throw new Error("Expected " + expected + "\n but got " + result);
@@ -30,4 +26,26 @@ test.skipIf(isWindows)("writing > send buffer size (with a variable) doesn't blo
   if (result !== expected + "\n") {
     throw new Error("Expected " + expected + "\n but got " + result);
   }
+});
+
+// The snapshots are taken in a separate process; the fixture explains why.
+test.skipIf(isWindows)("heap snapshots report the script held by a pending shell command", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(import.meta.dir, "shell-heap-snapshot-fixture.ts")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  const { scriptLength, parsedScriptBeforeRun, interpreterWhileRunning, interpreterAfterExit, stdoutMatches } =
+    JSON.parse(stdout);
+  expect(parsedScriptBeforeRun).toBeGreaterThanOrEqual(scriptLength);
+  expect(interpreterWhileRunning).toBeGreaterThanOrEqual(scriptLength);
+  expect(interpreterAfterExit).toBeLessThan(scriptLength);
+  // The second snapshot ran a full GC underneath the running command; its
+  // output must still come through intact.
+  expect(stdoutMatches).toBe(true);
+  expect(exitCode).toBe(0);
 });

--- a/test/js/bun/shell/shell-heap-snapshot-fixture.ts
+++ b/test/js/bun/shell/shell-heap-snapshot-fixture.ts
@@ -1,0 +1,55 @@
+// Spawned by shell-blocking-pipe.test.ts.
+//
+// A heap snapshot asks every ParsedShellScript and ShellInterpreter in the heap
+// for its memoryCost(). Neither object is reachable from JS, so a snapshot is
+// the only way a test gets those hooks called. A snapshot walks the whole heap,
+// and the heap of a `bun test` process is several times the size of this one
+// (under a debug + ASAN build, one snapshot of it outlasts the default test
+// timeout), so the snapshots are taken here, in a process of their own.
+import { $, generateHeapSnapshot } from "bun";
+
+// Large enough that a memoryCost() which counts the script is clearly
+// distinguishable from one which does not.
+const script = Buffer.alloc(1024 * 1024, "bun!").toString();
+
+// Bytes reported by every cell named `className`: its instances plus its
+// prototype, which reports a few bytes of its own. `nodes` holds four numbers
+// per cell: id, size, index into nodeClassNames, flags.
+function reportedSize(className: string): number {
+  const { nodes, nodeClassNames } = generateHeapSnapshot();
+  const classNameIndex = nodeClassNames.indexOf(className);
+  let size = 0;
+  for (let i = 0; i < nodes.length; i += 4) {
+    if (nodes[i + 2] === classNameIndex) size += nodes[i + 1];
+  }
+  return size;
+}
+
+// Bun.which("cat") is the system cat, not the shell's builtin: with a child
+// process in the pipeline the command cannot finish until the event loop runs.
+const promise = $`${{ raw: "echo " + script + " | " + Bun.which("cat") }}`.quiet();
+
+// Nothing has run yet: the ParsedShellScript owns the parsed script.
+const parsedScriptBeforeRun = reportedSize("ParsedShellScript");
+
+// then() is what starts the command. The parsed script now belongs to the
+// interpreter, which is still running when the snapshot is taken because we
+// have not yielded to the event loop yet.
+const running = promise.then(output => output.text());
+const interpreterWhileRunning = reportedSize("ShellInterpreter");
+
+const stdout = await running;
+
+// Finishing releases the parsed script, whether or not the interpreter
+// itself has been collected yet.
+const interpreterAfterExit = reportedSize("ShellInterpreter");
+
+console.log(
+  JSON.stringify({
+    scriptLength: script.length,
+    parsedScriptBeforeRun,
+    interpreterWhileRunning,
+    interpreterAfterExit,
+    stdoutMatches: stdout === script + "\n",
+  }),
+);

--- a/test/js/bun/shell/shell-heap-snapshot-fixture.ts
+++ b/test/js/bun/shell/shell-heap-snapshot-fixture.ts
@@ -13,13 +13,14 @@ import { $, generateHeapSnapshot } from "bun";
 const script = Buffer.alloc(1024 * 1024, "bun!").toString();
 
 // Bytes reported by every cell named `className`: its instances plus its
-// prototype, which reports a few bytes of its own. `nodes` holds four numbers
-// per cell: id, size, index into nodeClassNames, flags.
+// prototype, which reports a few bytes of its own. Each cell's entry in
+// `nodes` starts with id, size, index into nodeClassNames.
 function reportedSize(className: string): number {
-  const { nodes, nodeClassNames } = generateHeapSnapshot();
+  const { nodes, nodeClassNames, type } = generateHeapSnapshot();
+  const nodeStride = type === "GCDebugging" ? 7 : 4;
   const classNameIndex = nodeClassNames.indexOf(className);
   let size = 0;
-  for (let i = 0; i < nodes.length; i += 4) {
+  for (let i = 0; i < nodes.length; i += nodeStride) {
     if (nodes[i + 2] === classNameIndex) size += nodes[i + 1];
   }
   return size;


### PR DESCRIPTION
Test-only change.

### Problem
- `bun bd test test/js/bun/shell/shell-blocking-pipe.test.ts` on a debug + ASAN build fails the first test ("writing > send buffer size doesn't block the main thread") with `this test timed out after 5000ms` (8033ms on this machine; on main 87b26b57fa it was seen failing at 5107ms and passing at 4879ms). The sibling test, which runs the same 1 MiB `echo ... | cat` pipeline, takes about 100ms. `bun bd test` is the workflow CLAUDE.md prescribes, so any change that adds to this file (#34697 does, for example) runs into it when verified with a debug build. CI itself does not fail: `scripts/runner.node.mjs` passes `--timeout=90000` (270000 on ASAN lanes) to every file, so there the ASAN lanes just spend the 6 to 8 seconds.
- The time is the `generateHeapSnapshot("v8")` call at line 17. A snapshot walks every live cell, and inside `bun test` the heap also holds the runner, the preload and harness: about 13.6k nodes and 44k edges, which the v8 snapshot builder takes 6 to 8 seconds to walk under debug + ASAN here (about 10ms in a release build). The pipeline is irrelevant to the cost: a v8 snapshot of an otherwise idle `bun test` heap costs the same.
- The call existed to exercise the `memoryCost` hooks of the shell's native classes (`ParsedShellScript`, `ShellInterpreter`). It asserted nothing, and because `.text()` only starts the command on a later microtask, it ran before any `ShellInterpreter` existed.

### Fix
- The two pipe tests no longer take a snapshot; they check only the property in their names.
- The `memoryCost` coverage moves to `test/js/bun/shell/shell-heap-snapshot-fixture.ts`, spawned from the same test file, which is how `v8-heap-snapshot.test.ts` already takes its snapshots. The fixture's heap is about 2k nodes, so a snapshot costs about 0.2s under debug + ASAN; the new test takes 1.1 to 1.5s under `bun bd test` and about 60ms in release, independent of what the test runner has loaded.
- The fixture asserts what the hooks report at the three points where the objects exist: before the command starts, `ParsedShellScript` reports at least the 1 MiB script; while it runs, `ShellInterpreter` reports at least the script (the snapshot is taken synchronously after `.then()` starts the command, and a pipeline with a child process in it cannot finish until the event loop runs); after it finishes, whatever `ShellInterpreter` cells remain report far less than the script, because `finish()` resets the parse arena. It also checks the command's output survived the full GC a snapshot runs.
- Why this shape rather than the smaller alternatives:
  - Switching the existing call to the JSC format in place would fit the budget (one in-process JSC snapshot is 1.2 to 1.6s here) but keeps an assertion-free call whose cost tracks the runner's heap.
  - Making the assertions in-process does not fit: successive JSC snapshots inside `bun test` measured 1.3s, 1.7s, 2.1s, 3.9s, 5.2s as each one's output stays in the heap the next one walks, so three of them are back over the budget.
  - Exposing the two objects through `bun:internal-for-testing` and calling `estimateShallowMemoryUsageOf` on them would reach the same hook in microseconds and also run on Windows, but needs runtime changes plus a test that rebuilds the interpreter's construction protocol by hand; the fixture uses only the public `$` API and the snapshot, like the native-size checks in `heap-snapshot.test.ts`. Happy to do the binding version instead if that is preferred.
- The JSC and v8 formats reach the shell through the same hook (`JSCell::estimatedSizeInBytes` -> generated `estimatedSize` -> `memoryCost` -> Rust `memory_cost()`), so the JSC format used by the fixture exercises the same shell code the v8 call did, and its output can be read directly.
- Verified:
  - `bun bd test test/js/bun/shell/shell-blocking-pipe.test.ts`: 3 pass, new test 1.1 to 1.5s. The unmodified file still times out under the same build on this machine.
  - `USE_SYSTEM_BUN=1 bun test test/js/bun/shell/shell-blocking-pipe.test.ts`: 3 pass.
  - With `Interpreter::compute_estimated_size_for_gc` temporarily not counting `args`, the new test fails with `Expected: >= 1048576, Received: 3162`; with the same change in `ParsedShellScript::compute_estimated_size_for_gc` it fails with `Received: 1868`. Both experiments were reverted; this PR touches no `src/` file.

### Background
- `memoryCost` / `estimatedSize`: a class declared in a `*.classes.ts` file with `memoryCost: true` gets a generated `estimatedSize(cell, vm)` entry in its JSC method table which calls the wrapped Rust object's `memory_cost()`. Both heap snapshot builders (and `estimateShallowMemoryUsageOf`) record that value as the cell's size. The GC itself reads a separately cached `estimated_size()`, so in the test suite a heap snapshot is what calls `memory_cost()`.
- `ParsedShellScript` / `ShellInterpreter`: `` $`...` `` parses the script right away into a `ParsedShellScript` owned by the returned promise. The first `then()` (which is what `await` ends up calling) creates a `ShellInterpreter`, moves the parsed script into it and starts it. The parsed script is an arena holding the tokens, strings and AST, so it is at least as large as the script text; `finish()` resets the arena before resolving the promise, and the interpreter's JS wrapper can outlive that until the next GC. Neither object is reachable from JS.
- Test budgets: `bun test` defaults to 5s per test and `bun bd test` forwards its arguments unchanged, while the CI runner passes `--timeout` of 90s (270s with ASAN) per test. Whether `bun bd test` should mirror the runner is a separate question; this PR only makes this file cheap under either budget.

<details>
<summary>Snapshot timings measured for this PR (debug + ASAN build, 12 CPU container; release numbers from the baked release build)</summary>

| heap | nodes | v8 format | jsc format |
|---|---|---|---|
| plain script, debug | ~1.6k | 760 to 1270ms | 160 to 220ms |
| inside `bun test`, debug | ~13.6k | 5.9 to 7.6s | 1.2 to 1.3s |
| plain script, release | ~1.6k | 6 to 10ms | 8 to 10ms |
| inside `bun test`, debug, with the 1 MiB pipeline pending | ~13.6k | same as idle | same as idle |

Strings are truncated to 1024 characters by both builders, so the 1 MiB strings do not affect the cost; the node count does. Inside `bun test` the count is the same with or without the test file importing harness, since `test/preload.ts` imports it anyway.

Fixture phases under debug + ASAN: process start ~0.35s, parse + start + drain of the 1 MiB pipeline ~0.1s, three snapshots ~0.2 to 0.3s each. An earlier version of the fixture used `summarizeByType` from `test/js/bun/util/heap.ts`; that allocates an array per node, which survived into the following snapshots and roughly doubled the fixture's time, so the fixture sums node sizes directly.
</details>