### PR TITLE
Make EString::string() join folded ropes, fixing require.resolve() and other readers of the first segment

### DIFF
--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -1859,11 +1859,13 @@ impl EString {
     }
 
     pub fn eql_bytes(&self, other: &[u8]) -> bool {
-        if self.is_utf8() {
-            strings::eql_long(&self.data, other, true)
-        } else {
-            strings::utf16_eql_string(self.slice16(), other)
+        if !self.is_utf8() {
+            return strings::utf16_eql_string(self.slice16(), other);
         }
+        if self.next.is_none() {
+            return strings::eql_long(&self.data, other, true);
+        }
+        self.eql8_rope(other)
     }
 
     pub fn eql_comptime(&self, value: &'static [u8]) -> bool {
@@ -2446,7 +2448,7 @@ impl Import {
         self.import_record_index == u32::MAX
     }
 
-    pub fn import_record_loader(&self) -> Option<crate::Loader> {
+    pub fn import_record_loader(&self, bump: &Bump) -> Option<crate::Loader> {
         let crate::ExprData::EObject(obj) = &self.options.data else {
             return None;
         };
@@ -2454,7 +2456,10 @@ impl Import {
         let crate::ExprData::EObject(with_obj) = &with.data else {
             return None;
         };
-        let str_ = Object::get(with_obj, b"type")?.data.as_e_string()?;
+        let mut str_ = Object::get(with_obj, b"type")?.data.as_e_string()?;
+        // The options object is visited with constant folding forced on, so
+        // `"js" + "on"` arrives here as a rope.
+        str_.resolve_rope_if_needed(bump);
 
         if !str_.is_utf16 {
             if let Some(loader) = crate::Loader::from_string(&str_.data) {

--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -1896,49 +1896,53 @@ impl EString {
         true
     }
 
+    /// Copies every segment of a rope into one arena slice.
+    fn join_rope<'b>(&self, bump: &'b Bump) -> &'b [u8] {
+        debug_assert!(self.next.is_some() && self.is_utf8());
+        let mut bytes = bun_alloc::ArenaVec::<u8>::with_capacity_in(self.rope_len as usize, bump);
+        let mut segment: Option<&EString> = Some(self);
+        while let Some(part) = segment {
+            bytes.extend_from_slice(&part.data);
+            segment = part.next.as_deref();
+        }
+        bytes.into_bump_slice()
+    }
+
     pub fn resolve_rope_if_needed(&mut self, bump: &Bump) {
         if self.next.is_none() || !self.is_utf8() {
             return;
         }
-        let mut bytes = bun_alloc::ArenaVec::<u8>::with_capacity_in(self.rope_len as usize, bump);
-        bytes.extend_from_slice(&self.data);
-        let mut str_ = self.next;
-        while let Some(part) = str_ {
-            bytes.extend_from_slice(&part.get().data);
-            str_ = part.get().next;
-        }
-        self.data = Str::new(bytes.into_bump_slice());
+        self.data = Str::new(self.join_rope(bump));
         self.next = None;
     }
 
-    /// Return UTF-8 bytes, transcoding if UTF-16.
-    /// The transcode allocates via the global arena then copies into `bump`.
-    /// Does not walk ropes: a string that may have been folded goes through `slice`.
+    /// Return UTF-8 bytes, transcoding if UTF-16 and joining a rope.
+    /// A rope is joined into `bump` on every call; `slice` stores the joined
+    /// bytes back into the node instead.
     pub fn string<'b>(&self, bump: &'b Bump) -> Result<&'b [u8], AllocError> {
-        debug_assert!(
-            self.next.is_none(),
-            "EString::string() called on an unresolved rope; use slice()"
-        );
-        if self.is_utf8() {
-            // `self.data` is arena-owned with the same lifetime as `bump`;
-            // StoreStr re-borrows under that contract.
-            Ok(self.data.slice())
-        } else {
+        if !self.is_utf8() {
             let v = strings::to_utf8_alloc(self.slice16());
-            Ok(bump.alloc_slice_copy(&v))
+            return Ok(bump.alloc_slice_copy(&v));
         }
+        if self.next.is_some() {
+            return Ok(self.join_rope(bump));
+        }
+        // `self.data` is arena-owned with the same lifetime as `bump`;
+        // StoreStr re-borrows under that contract.
+        Ok(self.data.slice())
     }
 
     pub(crate) fn string_cloned<'b>(&self, bump: &'b Bump) -> Result<&'b [u8], AllocError> {
-        if self.is_utf8() {
+        if self.is_utf8() && self.next.is_none() {
             Ok(bump.alloc_slice_copy(&self.data))
         } else {
-            let v = strings::to_utf8_alloc(self.slice16());
-            Ok(bump.alloc_slice_copy(&v))
+            // `string` already returns a fresh copy for these.
+            self.string(bump)
         }
     }
 
     pub fn hash(&self) -> u64 {
+        debug_assert!(self.next.is_none(), "hash() on an unresolved rope");
         if self.is_blank() {
             return 0;
         }
@@ -1967,6 +1971,10 @@ impl EString {
     #[inline]
     pub fn order(&self, other: &EString) -> Ordering {
         debug_assert!(self.is_utf8() == other.is_utf8());
+        debug_assert!(
+            self.next.is_none() && other.next.is_none(),
+            "order() on an unresolved rope"
+        );
         if self.is_utf8() {
             strings::order(&self.data, &other.data)
         } else {
@@ -1990,6 +1998,10 @@ impl EString {
 
     // `eql`, split by operand type.
     pub fn eql_string(&self, other: &EString) -> bool {
+        debug_assert!(
+            self.next.is_none() && other.next.is_none(),
+            "eql_string() on an unresolved rope"
+        );
         if self.is_utf8() {
             if other.is_utf8() {
                 strings::eql_long(&self.data, &other.data, true)

--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -1911,7 +1911,15 @@ impl EString {
 
     /// Return UTF-8 bytes, transcoding if UTF-16.
     /// The transcode allocates via the global arena then copies into `bump`.
+    ///
+    /// Reads `data` only: a string that went through the visit pass may be a
+    /// rope (`fold_string_addition`), of which this is just the first segment.
+    /// Use `slice` (or `resolve_rope_if_needed` first) on those.
     pub fn string<'b>(&self, bump: &'b Bump) -> Result<&'b [u8], AllocError> {
+        debug_assert!(
+            self.next.is_none(),
+            "EString::string() called on an unresolved rope; use slice()"
+        );
         if self.is_utf8() {
             // `self.data` is arena-owned with the same lifetime as `bump`;
             // StoreStr re-borrows under that contract.

--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -1913,10 +1913,7 @@ impl EString {
 
     /// Return UTF-8 bytes, transcoding if UTF-16.
     /// The transcode allocates via the global arena then copies into `bump`.
-    ///
-    /// Reads `data` only: a string that went through the visit pass may be a
-    /// rope (`fold_string_addition`), of which this is just the first segment.
-    /// Use `slice` (or `resolve_rope_if_needed` first) on those.
+    /// Does not walk ropes: a string that may have been folded goes through `slice`.
     pub fn string<'b>(&self, bump: &'b Bump) -> Result<&'b [u8], AllocError> {
         debug_assert!(
             self.next.is_none(),
@@ -2457,8 +2454,7 @@ impl Import {
             return None;
         };
         let mut str_ = Object::get(with_obj, b"type")?.data.as_e_string()?;
-        // The options object is visited with constant folding forced on, so
-        // `"js" + "on"` arrives here as a rope.
+        // import() options are always constant-folded, so this may be a rope.
         str_.resolve_rope_if_needed(bump);
 
         if !str_.is_utf16 {

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -678,12 +678,14 @@ impl ArrayIterator {
 // raw-ptr returns). Those drafts were dropped; only the methods without a live
 // counterpart remain.
 impl Expr {
+    /// Unlike `as_utf8_string_literal`, this accepts visited strings, which may
+    /// be ropes: the rope is flattened in place.
     #[inline]
     pub fn as_string_literal<'b>(&self, bump: &'b Bump) -> Option<&'b [u8]> {
-        let Data::EString(s) = &self.data else {
+        let Data::EString(mut s) = self.data else {
             return None;
         };
-        s.string(bump).ok()
+        Some(s.slice(bump))
     }
 
     /// `as_string_hash` for JSON-parsed trees (always UTF-8, no rope) where no

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -678,13 +678,12 @@ impl ArrayIterator {
 // raw-ptr returns). Those drafts were dropped; only the methods without a live
 // counterpart remain.
 impl Expr {
-    /// Flattens ropes, so unlike `as_utf8_string_literal` it is safe on visited strings.
     #[inline]
     pub fn as_string_literal<'b>(&self, bump: &'b Bump) -> Option<&'b [u8]> {
-        let Data::EString(mut s) = self.data else {
+        let Data::EString(s) = &self.data else {
             return None;
         };
-        Some(s.slice(bump))
+        s.string(bump).ok()
     }
 
     /// `as_string_hash` for JSON-parsed trees (always UTF-8, no rope) where no

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -2306,12 +2306,16 @@ impl Data {
                 hasher.update(&e.value);
             }
             Data::EString(e) => {
-                // Only the *first* rope segment is hashed.
-                let current: &E::String = e;
-                if current.is_utf8() {
-                    hasher.update(&current.data);
+                if e.is_utf8() {
+                    // Hashing the segments back to back gives a folded
+                    // `"a" + "b"` the same hash as `"ab"`.
+                    let mut segment: Option<&E::String> = Some(e.get());
+                    while let Some(current) = segment {
+                        hasher.update(&current.data);
+                        segment = current.next.as_deref();
+                    }
                 } else {
-                    hasher.update(bytemuck::cast_slice::<u16, u8>(current.slice16()));
+                    hasher.update(bytemuck::cast_slice::<u16, u8>(e.slice16()));
                 }
                 hasher.update(b"\x00");
             }

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -678,8 +678,7 @@ impl ArrayIterator {
 // raw-ptr returns). Those drafts were dropped; only the methods without a live
 // counterpart remain.
 impl Expr {
-    /// Unlike `as_utf8_string_literal`, this accepts visited strings, which may
-    /// be ropes: the rope is flattened in place.
+    /// Flattens ropes, so unlike `as_utf8_string_literal` it is safe on visited strings.
     #[inline]
     pub fn as_string_literal<'b>(&self, bump: &'b Bump) -> Option<&'b [u8]> {
         let Data::EString(mut s) = self.data else {
@@ -2307,8 +2306,7 @@ impl Data {
             }
             Data::EString(e) => {
                 if e.is_utf8() {
-                    // Hashing the segments back to back gives a folded
-                    // `"a" + "b"` the same hash as `"ab"`.
+                    // Rope segments hash back to back, so "a" + "b" hashes like "ab".
                     let mut segment: Option<&E::String> = Some(e.get());
                     while let Some(current) = segment {
                         hasher.update(&current.data);

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -7541,6 +7541,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         str_: &mut E::String,
         loc: bun_ast::Loc,
     ) -> Option<js_ast::ExprData> {
+        str_.resolve_rope_if_needed(self.arena);
         let _ = str_.to_utf8(self.arena);
         let specifier = str_.data;
 

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -801,22 +801,20 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         arg: Expr,
         buf: &'b mut BumpVec<'a, u8>,
     ) -> Result<&'b [u8], crate::Error> {
-        if let Some(mut tmpl) = arg.data.e_template() {
+        if let Some(tmpl) = arg.data.e_template() {
             if tmpl.tag.is_some() {
                 return Ok(b""); // tagged template — opaque
             }
-            match &mut tmpl.head {
+            match &tmpl.head {
                 js_ast::e::TemplateContents::Cooked(head) => {
-                    head.resolve_rope_if_needed(self.arena);
                     buf.extend_from_slice(head.string(self.arena)?);
                 }
                 js_ast::e::TemplateContents::Raw(_) => return Ok(b""), // shouldn't happen post-visit but be safe
             }
-            for part in tmpl.parts_mut().iter_mut() {
+            for part in tmpl.parts().iter() {
                 buf.push(0); // \x00 placeholder per interpolation
-                match &mut part.tail {
+                match &part.tail {
                     js_ast::e::TemplateContents::Cooked(tail) => {
-                        tail.resolve_rope_if_needed(self.arena);
                         buf.extend_from_slice(tail.string(self.arena)?);
                     }
                     js_ast::e::TemplateContents::Raw(_) => return Ok(b""), // raw tail — treat as opaque
@@ -1082,9 +1080,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             return self.new_expr(E::Null {}, arg.loc);
         }
 
-        let mut str_ = arg.data.e_string().expect("infallible: variant checked");
-        let import_record_index =
-            self.add_import_record(ImportKind::RequireResolve, arg.loc, str_.slice(self.arena));
+        let import_record_index = self.add_import_record(
+            ImportKind::RequireResolve,
+            arg.loc,
+            arg.data
+                .e_string()
+                .expect("infallible: variant checked")
+                .string(self.arena)
+                .expect("unreachable"),
+        );
         self.import_records.items_mut()[import_record_index as usize]
             .flags
             .set(

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -805,8 +805,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             if tmpl.tag.is_some() {
                 return Ok(b""); // tagged template — opaque
             }
-            // After folding "./fo" + `o/${x}` the head (or a tail) is a rope;
-            // `string` alone would give only its first segment.
             match &mut tmpl.head {
                 js_ast::e::TemplateContents::Cooked(head) => {
                     head.resolve_rope_if_needed(self.arena);
@@ -1084,8 +1082,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             return self.new_expr(E::Null {}, arg.loc);
         }
 
-        // `slice` flattens the rope left behind by folding "./fo" + "o";
-        // `string` would record only its first segment.
         let mut str_ = arg.data.e_string().expect("infallible: variant checked");
         let import_record_index =
             self.add_import_record(ImportKind::RequireResolve, arg.loc, str_.slice(self.arena));

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -801,20 +801,24 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         arg: Expr,
         buf: &'b mut BumpVec<'a, u8>,
     ) -> Result<&'b [u8], crate::Error> {
-        if let Some(tmpl) = arg.data.e_template() {
+        if let Some(mut tmpl) = arg.data.e_template() {
             if tmpl.tag.is_some() {
                 return Ok(b""); // tagged template — opaque
             }
-            match &tmpl.head {
+            // After folding "./fo" + `o/${x}` the head (or a tail) is a rope;
+            // `string` alone would give only its first segment.
+            match &mut tmpl.head {
                 js_ast::e::TemplateContents::Cooked(head) => {
+                    head.resolve_rope_if_needed(self.arena);
                     buf.extend_from_slice(head.string(self.arena)?);
                 }
                 js_ast::e::TemplateContents::Raw(_) => return Ok(b""), // shouldn't happen post-visit but be safe
             }
-            for part in tmpl.parts().iter() {
+            for part in tmpl.parts_mut().iter_mut() {
                 buf.push(0); // \x00 placeholder per interpolation
-                match &part.tail {
+                match &mut part.tail {
                     js_ast::e::TemplateContents::Cooked(tail) => {
+                        tail.resolve_rope_if_needed(self.arena);
                         buf.extend_from_slice(tail.string(self.arena)?);
                     }
                     js_ast::e::TemplateContents::Raw(_) => return Ok(b""), // raw tail — treat as opaque
@@ -1080,15 +1084,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             return self.new_expr(E::Null {}, arg.loc);
         }
 
-        let import_record_index = self.add_import_record(
-            ImportKind::RequireResolve,
-            arg.loc,
-            arg.data
-                .e_string()
-                .expect("infallible: variant checked")
-                .string(self.arena)
-                .expect("unreachable"),
-        );
+        // `slice` flattens the rope left behind by folding "./fo" + "o";
+        // `string` would record only its first segment.
+        let mut str_ = arg.data.e_string().expect("infallible: variant checked");
+        let import_record_index =
+            self.add_import_record(ImportKind::RequireResolve, arg.loc, str_.slice(self.arena));
         self.import_records.items_mut()[import_record_index as usize]
             .flags
             .set(

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1003,6 +1003,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 let unwrapped = e_.index.unwrap_inlined();
                 if let Some(mut s) = unwrapped.data.e_string() {
                     if !s.is_utf16 {
+                        // Both uses of `s.data` below need the whole string,
+                        // not the first segment of a folded `'fo' + 'o'`.
+                        s.resolve_rope_if_needed(p.arena);
                         // "a['b' + '']" => "a.b"
                         // "enum A { B = 'b' }; a[A.B]" => "a.b"
                         if p.options.features.minify_syntax && s.is_identifier(p.arena) {
@@ -1827,7 +1830,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     ),
                 import_options: e_.options,
                 loc: e_.expr.loc,
-                import_loader: e_.import_record_loader(),
+                import_loader: e_.import_record_loader(p.arena),
                 ..Default::default()
             };
 
@@ -2380,9 +2383,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
 
         // Check if the feature flag is enabled
-        // Use the underlying string data directly without allocation.
         // Feature flag names should be ASCII identifiers, so UTF-16 is unexpected.
-        let flag_string = arg.data.e_string().expect("infallible: variant checked");
+        // The argument has already been visited, so under minify_syntax
+        // `"fo" + "o"` arrives as a rope whose `data` is only "fo".
+        let mut flag_string = arg.data.e_string().expect("infallible: variant checked");
+        flag_string.resolve_rope_if_needed(p.arena);
         if flag_string.is_utf16 {
             p.log().add_error(
                 Some(p.source),

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1003,8 +1003,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 let unwrapped = e_.index.unwrap_inlined();
                 if let Some(mut s) = unwrapped.data.e_string() {
                     if !s.is_utf16 {
-                        // Both uses of `s.data` below need the whole string,
-                        // not the first segment of a folded `'fo' + 'o'`.
                         s.resolve_rope_if_needed(p.arena);
                         // "a['b' + '']" => "a.b"
                         // "enum A { B = 'b' }; a[A.B]" => "a.b"
@@ -2384,8 +2382,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         // Check if the feature flag is enabled
         // Feature flag names should be ASCII identifiers, so UTF-16 is unexpected.
-        // The argument has already been visited, so under minify_syntax
-        // `"fo" + "o"` arrives as a rope whose `data` is only "fo".
         let mut flag_string = arg.data.e_string().expect("infallible: variant checked");
         flag_string.resolve_rope_if_needed(p.arena);
         if flag_string.is_utf16 {

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -71,6 +71,35 @@ describe("Bun.build", () => {
     expect(await bunRun(build.outputs[0].path)).toSpawn("world");
   });
 
+  test("reactFastRefresh signature hashes the whole folded string literal", async () => {
+    // minify.syntax folds "a" + "b" into a rope; the hook signature must cover
+    // every segment, otherwise "a" + "b" and "a" + "c" get the same signature.
+    using dir = tempDir("bun-build-api-refresh-sig", {
+      "ab.tsx": `import { useState } from "react"; export function C() { const [v] = useState("ab"); return <b>{v}</b>; }`,
+      "a-b.tsx": `import { useState } from "react"; export function C() { const [v] = useState("a" + "b"); return <b>{v}</b>; }`,
+      "a-c.tsx": `import { useState } from "react"; export function C() { const [v] = useState("a" + "c"); return <b>{v}</b>; }`,
+    });
+    const signatureOf = async (file: string) => {
+      const build = await Bun.build({
+        entrypoints: [join(String(dir), file)],
+        reactFastRefresh: true,
+        minify: { syntax: true },
+        external: ["react"],
+      });
+      const output = await build.outputs[0].text();
+      const match = output.match(/_s\w*\(C, "([^"]+)"\)/);
+      if (!match) throw new Error(`no refresh signature in ${file}:\n${output}`);
+      return match[1];
+    };
+    const [ab, aPlusB, aPlusC] = await Promise.all([
+      signatureOf("ab.tsx"),
+      signatureOf("a-b.tsx"),
+      signatureOf("a-c.tsx"),
+    ]);
+    expect(aPlusB).toBe(ab);
+    expect(aPlusC).not.toBe(ab);
+  });
+
   test("passing undefined doesnt segfault", () => {
     try {
       // @ts-ignore

--- a/test/bundler/bundler_allow_unresolved.test.ts
+++ b/test/bundler/bundler_allow_unresolved.test.ts
@@ -226,4 +226,55 @@ describe("bundler", () => {
     backend: "cli",
     allowUnresolved: ["./locales/*.json"],
   });
+
+  // 17-20. Constant folding turns the template head/tail into a rope of string
+  // segments. The shape must include every segment ("./locales/*.json"), not
+  // just the first one ("./loc*.json"), or a matching pattern is rejected.
+  itBundled("allow-unresolved/RopeHeadFromStringAddition", {
+    files: {
+      "/entry.js": /* js */ `
+        export function load(x) {
+          return import("./loc" + \`ales/\${x}.json\`);
+        }
+      `,
+    },
+    outdir: "/out",
+    allowUnresolved: ["./locales/*.json"],
+  });
+
+  itBundled("allow-unresolved/RopeHeadFromTemplateFolding", {
+    files: {
+      "/entry.js": /* js */ `
+        export function load(x) {
+          return import(\`./loc\${"ales"}/\${x}.json\`);
+        }
+      `,
+    },
+    outdir: "/out",
+    allowUnresolved: ["./locales/*.json"],
+  });
+
+  itBundled("allow-unresolved/RopeTailFromStringAddition", {
+    files: {
+      "/entry.js": /* js */ `
+        export function load(x) {
+          return import(\`./locales/\${x}\` + ".json");
+        }
+      `,
+    },
+    outdir: "/out",
+    allowUnresolved: ["./locales/*.json"],
+  });
+
+  itBundled("allow-unresolved/RequireResolveRopeHead", {
+    files: {
+      "/entry.js": /* js */ `
+        export function load(x) {
+          return require.resolve("./loc" + \`ales/\${x}.json\`);
+        }
+      `,
+    },
+    outdir: "/out",
+    allowUnresolved: ["./locales/*.json"],
+  });
 });

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2913,6 +2913,24 @@ describe("bundler", () => {
     },
     run: { stdout: "true 1" },
   });
+  // require() arguments are constant-folded even without minifySyntax, so the
+  // index here is a rope ("fo" -> "o"). Rewriting ns[...] to an import binding
+  // has to use the whole name: it used to bind the `fo` export instead of `foo`.
+  itBundled("edgecase/FoldedStringIndexOnNamespaceImport", {
+    files: {
+      "/entry.js": /* js */ `
+        import * as ns from "./ns.js";
+        console.log(require(ns["fo" + "o"] === "yes" ? "./yes.js" : "./no.js"));
+      `,
+      "/ns.js": /* js */ `
+        export const foo = "yes";
+        export const fo = "no";
+      `,
+      "/yes.js": `module.exports = "took yes";`,
+      "/no.js": `module.exports = "took no";`,
+    },
+    run: { stdout: "took yes" },
+  });
   // The bundler rewrites bare `require`/`require.main`/`require.resolve` to an
   // ERequireCallTarget / ERequireMain / ERequireResolveCallTarget that prints
   // as `__require` / `__require.main` / `__require.resolve`.

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2913,23 +2913,35 @@ describe("bundler", () => {
     },
     run: { stdout: "true 1" },
   });
-  // require() arguments are constant-folded even without minifySyntax, so the
-  // index here is a rope ("fo" -> "o"). Rewriting ns[...] to an import binding
-  // has to use the whole name: it used to bind the `fo` export instead of `foo`.
-  itBundled("edgecase/FoldedStringIndexOnNamespaceImport", {
+  // Enum initializers are always constant-folded, so K.X inlines as a rope
+  // ("fo" -> "o"). Without minifySyntax the index visitor used to rewrite the
+  // access with only the first segment: `fo` instead of `foo`.
+  itBundled("edgecase/FoldedEnumStringIndexOnNamespaceImport", {
     files: {
-      "/entry.js": /* js */ `
-        import * as ns from "./ns.js";
-        console.log(require(ns["fo" + "o"] === "yes" ? "./yes.js" : "./no.js"));
+      "/entry.ts": /* ts */ `
+        import * as ns from "./ns.ts";
+        enum K { X = "fo" + "o" }
+        console.log(ns[K.X]);
       `,
-      "/ns.js": /* js */ `
+      "/ns.ts": /* ts */ `
         export const foo = "yes";
         export const fo = "no";
       `,
-      "/yes.js": `module.exports = "took yes";`,
-      "/no.js": `module.exports = "took no";`,
     },
-    run: { stdout: "took yes" },
+    run: { stdout: "yes" },
+  });
+  itBundled("edgecase/FoldedEnumStringIndexAsCommonJSExportName", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import * as k from "./k.ts";
+        console.log(JSON.stringify(Object.keys(k).sort()), k.foo);
+      `,
+      "/k.ts": /* ts */ `
+        enum K { X = "fo" + "o" }
+        exports[K.X] = "value";
+      `,
+    },
+    run: { stdout: '["foo"] value' },
   });
   // The bundler rewrites bare `require`/`require.main`/`require.resolve` to an
   // ERequireCallTarget / ERequireMain / ERequireResolveCallTarget that prints

--- a/test/bundler/bundler_feature_flag.test.ts
+++ b/test/bundler/bundler_feature_flag.test.ts
@@ -88,6 +88,28 @@ if (feature("DISABLED_FEATURE")) {
         },
       });
 
+      // minifySyntax folds "ENABLED_" + "FEATURE" before feature() sees it; the
+      // lookup must use the whole folded name, not its first segment.
+      itBundled(`feature_flag/${backend}/FoldedFlagName`, {
+        backend,
+        files: {
+          "/a.js": `
+import { feature } from "bun:bundle";
+if (feature("ENABLED_" + "FEATURE")) {
+  console.log("this should be kept");
+} else {
+  console.log("this should be removed");
+}
+`,
+        },
+        features: ["ENABLED_FEATURE"],
+        minifySyntax: true,
+        onAfterBundle(api) {
+          api.expectFile("out.js").toInclude("this should be kept");
+          api.expectFile("out.js").not.toInclude("this should be removed");
+        },
+      });
+
       itBundled(`feature_flag/${backend}/ImportRemoved`, {
         backend,
         files: {

--- a/test/bundler/bundler_loader.test.ts
+++ b/test/bundler/bundler_loader.test.ts
@@ -151,6 +151,32 @@ describe("bundler", async () => {
     });
   }
 
+  // import() options are visited with constant folding forced on, so these
+  // attribute strings reach the loader lookup as ropes; the lookup must see the
+  // whole string ("json"), not just its first segment ("js" is a real loader).
+  itBundled("bun/loader-dynamic-import-attribute-folded-type", {
+    target: "bun",
+    files: {
+      "/entry.ts": /* js */ `
+        const mod = await import('./hello.notjson', { with: { type: "js" + "on" } });
+        console.write(JSON.stringify(mod.default));
+      `,
+      "/hello.notjson": JSON.stringify({ hello: "world" }),
+    },
+    run: { stdout: '{"hello":"world"}' },
+  });
+  itBundled("bun/loader-dynamic-import-attribute-folded-keys", {
+    target: "bun",
+    files: {
+      "/entry.ts": /* js */ `
+        const mod = await import('./hello.notjson', { ["wi" + "th"]: { ["ty" + "pe"]: "json" } });
+        console.write(JSON.stringify(mod.default));
+      `,
+      "/hello.notjson": JSON.stringify({ hello: "world" }),
+    },
+    run: { stdout: '{"hello":"world"}' },
+  });
+
   itBundled("bun/loader-text-file", {
     target: "bun",
     outfile: "",

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -182,6 +182,30 @@ test("object destructuring of a macro result keeps every bound property regardle
   expect(exitCode).toBe(0);
 });
 
+test("object destructuring of a macro result matches a computed key built from folded string literals", async () => {
+  // ["a" + "b"] is folded into a rope; matching it against the macro result must use the whole
+  // string, or the `ab` property is dropped from the inlined object.
+  using dir = tempDir("macro-destructure-folded-key", {
+    "m.ts": `export function m() {\n  return { ab: 1, c: 2 };\n}\n`,
+    "index.ts": [
+      `import { m } from "./m.ts" with { type: "macro" };`,
+      `const { ["a" + "b"]: x, c } = m();`,
+      `console.log(JSON.stringify([x, c]));`,
+      ``,
+    ].join("\n"),
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", "index.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ lastLine: stdout.trim().split("\n").pop(), stderr }).toEqual({ lastLine: "[1,2]", stderr: "" });
+  expect(exitCode).toBe(0);
+});
+
 describe("--no-macros", () => {
   const files = {
     "macro.ts": `

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3061,6 +3061,20 @@ console.log(resolve.length)
           { kind: "dynamic-import", path: "./bar" },
         ]);
       });
+
+      it("a folded string index into an enum selects the member named by the whole string", () => {
+        // Arguments of require()/require.resolve()/import() are folded even without minification,
+        // so E["fo" + "o"] is looked up with a rope; it used to select E.fo.
+        const out = transpiler.transformSync(`
+          enum E { fo = "./fo", foo = "./foo" }
+          export const a = require(E["fo" + "o"]);
+          export const b = require.resolve(E["fo" + "o"]);
+          export const c = import(E["fo" + "o"]);
+        `);
+        expect(out).toContain(`export const a = require("./foo" /* foo */)`);
+        expect(out).toContain(`export const b = require.resolve("./foo" /* foo */)`);
+        expect(out).toContain(`export const c = import("./foo" /* foo */)`);
+      });
     });
 
     it("define", () => {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3038,6 +3038,29 @@ console.log(resolve.length)
           `export const foo = require.resolve("my-module")`,
         );
       });
+
+      it("require.resolve() keeps every segment of a folded string concatenation", () => {
+        // "./fo" + "o" is folded into a rope; the import record must hold the whole string, not its head.
+        expectPrinted_(
+          `export const foo = require.resolve('./fo' + 'o')`,
+          `export const foo = require.resolve("./foo")`,
+        );
+        expectPrinted_(
+          `export const foo = require.resolve('./a' + '/b' + '/c')`,
+          `export const foo = require.resolve("./a/b/c")`,
+        );
+        expectPrinted_(
+          `export const foo = require.resolve(x ? './fo' + 'o' : './ba' + 'r')`,
+          `export const foo = x ? require.resolve("./foo") : require.resolve("./bar")`,
+        );
+        // require() and import() of the same argument already behaved this way.
+        expectPrinted_(`export const foo = require('./fo' + 'o')`, `export const foo = require("./foo")`);
+        expectPrinted_(`export const foo = import('./fo' + 'o')`, `export const foo = import("./foo")`);
+        expect(transpiler.scan(`require.resolve("./fo" + "o"); import("./ba" + "r");`).imports).toEqual([
+          { kind: "require-resolve", path: "./foo" },
+          { kind: "dynamic-import", path: "./bar" },
+        ]);
+      });
     });
 
     it("define", () => {

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -259,6 +259,28 @@ it("file url in require.resolve resolves", async () => {
   expect(stdout.toString("utf8")).toBe(`${dir}${sep}index.js\n`);
 });
 
+it("require.resolve of a folded string concatenation resolves the whole specifier", async () => {
+  // "./fo" + "o" is constant-folded by the transpiler; it used to record only "./fo".
+  await using dir = tempDir("require-resolve-folded", {
+    "foo.js": "module.exports = 'foo';",
+    "bar.js": "module.exports = 'bar';",
+    "test.js": `
+      console.log(require.resolve("./fo" + "o"));
+      console.log(require.resolve(process.argv.length > 100 ? "./fo" + "o" : "./ba" + "r"));
+      console.log(require("./fo" + "o"));
+    `,
+  });
+
+  const { exitCode, stdout, stderr } = Bun.spawnSync({
+    cmd: [bunExe(), `${dir}/test.js`],
+    env: bunEnv,
+    cwd: String(dir),
+  });
+  expect(stderr.toString("utf8")).toBe("");
+  expect(stdout.toString("utf8")).toBe(`${dir}${sep}foo.js\n${dir}${sep}bar.js\nfoo\n`);
+  expect(exitCode).toBe(0);
+});
+
 it("file url with special characters in require resolves", async () => {
   const filename = "🅱️ndex.js";
   await using dir = tempDir("file url", {


### PR DESCRIPTION
### Problem
- `require.resolve("./fo" + "o")` is transpiled to `require.resolve("./fo")` and throws `Cannot find module './fo'` at runtime, while `require("./fo" + "o")` next to it works. Same through `Bun.Transpiler` (`transformSync` and `scan()` report `./fo`), `bun build`, and each branch of `require.resolve(x ? "./fo" + "o" : "./ba" + "r")`. Node resolves `./foo`.
- Cause: folding `"./fo" + "o"` produces a rope (see Background) whose `data` holds only the first segment, and `EString::string()` (`src/ast/e.rs`) returned `data` without walking the rope. `transpose_require_resolve_known_string` records the import record path through `string()`; `transpose_import` and `transpose_require` happen to flatten first, which is why `require()` and `import()` work.
- Other readers of the same first segment, each reproduced on the unfixed build (repros in the details block):
  - through `string()`: the `--allow-unresolved` shape (`"./lo" + \`cales/${x}.json\`` was reported as `./lo*.json`, so a pattern matching the real specifier was rejected) and macro result destructuring (`const { ["a" + "b"]: x } = m()` dropped the `ab` property).
  - through `data` directly: `import()` attributes (`with: { type: "js" + "on" }` selected the `js` loader, and `Object::get` did not match folded computed keys), `feature()` from `bun:bundle` under `minify.syntax`, the index visitor without `minifySyntax` (`ns[K.X]` and `exports[K.X]` with `enum K { X = "fo" + "o" }` bound and exported `fo` instead of `foo`; `E["fo" + "o"]` inside `require()` picked `E.fo`), the React Fast Refresh signature hash (`useState("a" + "b")` and `useState("a" + "c")` got the same signature), and `import.meta.hot.accept()` matching (not reachable with a rope today, HMR is only on in dev mode where folding is off).
- Long-standing: the Zig sources read these strings the same way.

### Fix
- `EString::string()` (and `string_cloned()`) join the rope into the arena when `next` is set, through the same helper `resolve_rope_if_needed` now uses, and `eql_bytes` compares the whole rope like `eql_comptime` already did. That alone fixes `require.resolve`, the shape and the macro case; those call sites are unchanged from main. `slice()` keeps storing the joined bytes back into the node for callers that read it repeatedly.
- The readers that need `data` itself call `resolve_rope_if_needed` first (`import_record_loader`, which now takes the arena from its one caller; `feature()`; the index visitor; `hot.accept`), and the refresh hasher feeds the segments back to back so a folded string hashes like the equivalent literal.
- `hash()`, `order()` and `eql_string()` still read `data` only; they now `debug_assert` they are not handed a rope. Every caller normalizes first (`Data::eql` and `extract_string_values` resolve both sides, the react compiler's `JsString` asserts the same at construction, package.json sorting never sees ropes), so this only guards future callers.
- Why this is correct: a rope is a deferred concatenation, so joining it yields exactly the string the program would have built, and the printer already joins every rope when printing, so output is unchanged except where the first segment was wrong. `require.resolve` now records the same path `require` records for the same argument, which is what Node resolves.
- Known rope-unaware reads left alone: the decorated class name taken from an object key (that block is replaced, with a `["a" + "b"]` test, in #38787), the `_name` helper variables for decorated auto-accessors (cosmetic), and the `"str"[i]` / `charCodeAt(i)` folds (they bail past the first segment, so they only miss an optimization). Four different rope bugs found while sweeping are tracked separately (React Compiler template text loss, `Template::fold` mutating an inlined enum's rope, `.length` folding counting bytes, and the fold flag staying on after an `import()`).
- #35680 (glob bundling of template specifiers) also walks template ropes when it rewrites `extract_dynamic_specifier_shape`; that function is untouched here, so there is no conflict, and its per-segment `string()` calls keep working since `string()` now handles ropes.
- Verified with `bun bd test`; every new test fails on the unfixed build:
  - `test/bundler/transpiler/transpiler.test.js`: printed output for two- and three-segment concatenations and the ternary form, `scan()` paths, `require()` / `import()` controls, and `E["fo" + "o"]` inside `require()` / `require.resolve()` / `import()`.
  - `test/js/bun/resolve/resolve.test.ts`: `require.resolve` of folded specifiers returns the right files at runtime.
  - `test/bundler/bundler_allow_unresolved.test.ts`: rope head from `+`, rope head from template folding, rope tail, and the `require.resolve()` path accept a pattern matching the full specifier.
  - `test/bundler/transpiler/macro-test.test.ts`: a computed folded key keeps its property when destructuring a macro result.
  - `test/bundler/bundler_loader.test.ts`: folded `type` value, and folded computed `with` / `type` keys, select the JSON loader.
  - `test/bundler/bundler_feature_flag.test.ts`: a folded flag name is looked up whole (CLI and API backends).
  - `test/bundler/bundler_edgecase.test.ts`: `ns[K.X]` reads the `foo` export and `exports[K.X]` exports `foo`, for a string enum member built with `+`, in a plain (unminified) bundle.
  - `test/bundler/bun-build-api.test.ts`: `"a" + "b"` gets the same refresh signature as `"ab"` and a different one from `"a" + "c"`.
  - The asserts stayed quiet across `test/bundler/transpiler/*`, `test/bundler/esbuild/{default,ts,dce}.test.ts`, `bundler_edgecase`, `bundler_minify`, `bundler_string`, `bundler_loader`, `bun-build-api`, the TOML tests and `test/cli/install/npmrc.test.ts` on the debug build.

### Background
- Rope: when the visit pass folds `"a" + "b"` it does not copy bytes. It links the right operand onto the left `E::String` through its `next` pointer and bumps `rope_len`; `data` still holds only `"a"`. Template literals get the same treatment for their head and for the text after each `${}`. Ropes are produced in two places (`fold_string_addition` and `Template::fold`) and read in many, which is why the fix goes into the accessor.
- When folding happens: file-wide when `minify_syntax` or inlining is on (`bun run` and `target: "bun"` builds enable both); always, whatever the flags, for enum initializers and for the arguments of `require()`, `require.resolve()`, macro calls and `import()` including its options object. The enum rule is what makes the index visitor cases reachable from an ordinary unminified `bun build`: a string enum member built with `+` is a rope everywhere it is inlined.
- Import record: the entry the parser creates for every static specifier it finds. The bundler resolves it and the printer prints `E::RequireResolveString` from the record's path, so the recorded text is both what gets resolved and what ends up in the output.
- `--allow-unresolved` shape: for a dynamic specifier written as a template literal, the parser joins the literal parts with `\0` standing in for each interpolation and matches that against the user's glob patterns.
- Macro result destructuring: when `const { a } = someMacro()` inlines the macro's return value, the parser keeps only the properties the pattern names, matching each binding key against the inlined object.
- Refresh signature: with React Fast Refresh, each component gets a hash of the hooks it calls and their arguments; a changed hash tells the runtime to remount instead of preserving state.

<details>
<summary>Repros on the unfixed build</summary>

```console
$ cat index.js
try { console.log("require.resolve:", require.resolve("./fo" + "o")); } catch (e) { console.log("require.resolve threw:", e.message); }
console.log("require:", require("./fo" + "o"));
$ bun index.js
require.resolve threw: Cannot find module './fo'
require: foo-module
$ bun build --no-bundle index.js | grep require
  console.log("require.resolve:", require.resolve("./fo"));
console.log("require:", require("./foo"));

$ cat shape.js
export function load(x) { return import("./fo" + `o/${x}.js`); }
$ bun build shape.js --allow-unresolved './foo/*'
error: This import() expression will not be bundled because the argument is not a string literal
note: The specifier shape "./fo*.js" does not match any --allow-unresolved pattern. ...

$ cat macro.ts     # m.ts: export function obj() { return { ab: 1, c: 2 }; }
import { obj } from "./m.ts" with { type: "macro" };
const { ["a" + "b"]: x, c } = obj();
console.log(x, c);
$ bun macro.ts
undefined 2

$ cat attr.ts      # hello.notjson contains {"hello":"world"}
const mod = await import("./hello.notjson", { with: { type: "js" + "on" } });
$ bun build attr.ts --target=bun
error: Expected ";" but found ":"
    at hello.notjson:1:9

$ cat k.ts
enum K { X = "fo" + "o" }
exports[K.X] = "value";
$ bun build k.ts --target=bun --format=esm | tail -3
export {
  $fo as fo
};
$ cat a.ts
enum E { fo = "./fo", foo = "./foo" }
export const a = require(E["fo" + "o"]);
$ bun build --no-bundle a.ts | tail -1
export const a = require("./fo" /* fo */);

# feature("ENABLED_" + "FEATURE") with --feature=ENABLED_FEATURE --minify-syntax keeps the else branch.
# Bun.build({ reactFastRefresh: true, minify: { syntax: true } }): useState("a" + "b") and useState("a" + "c")
# both produce _s(C, "mNzOb3qKmvI="), while "ab" and "ac" produce different signatures.
```

</details>

<details>
<summary>Earlier revisions of this description</summary>

The first push flattened at the three `string()` call sites and added a `debug_assert` to `string()`; the second push added the direct `data` readers after review; the third push moved the fix into `string()` itself (review pointed out that the invariant lives in `EString` and that per-call-site flattening is how this bug keeps recurring), reverted the three call sites to their original code, and replaced the contrived index-visitor test with the enum cases above.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bun-build-api.test.ts test/bundler/bundler_edgecase.test.ts test/js/bun/resolve/resolve.test.ts

<!-- robobun:evidence:end -->