### PR TITLE
test(node:fs): keep the FIFO readFileSync test inside the debug timeout

### DIFF
--- a/test/js/node/fs/fs-readfile-fifo-fixture.js
+++ b/test/js/node/fs/fs-readfile-fifo-fixture.js
@@ -1,11 +1,24 @@
-// Spawned by fs.test.ts, which creates the FIFO at argv[2] and feeds it well
-// over the 256 KB readFileSync reads before calling fstat. fstat reports a
-// 0-byte size for a pipe, so everything after that arrives through the "stat
-// size is wrong" grow path. That path used to reallocate (and RawVec-double) on
-// every read because the buffer length was left at capacity, ballooning RSS to
-// multiple GB and never returning, which is why the read runs in a child the
-// test can kill. Prints a single parseable line for the parent to assert on.
+// Spawned by fs.test.ts, which creates the FIFO at argv[2] and feeds it more
+// than the 256 KB readFileSync reads before it calls fstat. fstat reports a
+// 0-byte size for a pipe, so the rest arrives through the "stat size is wrong"
+// grow path, which used to reallocate (and RawVec-double) on every read: the
+// process grew by gigabytes or never returned, which is why the read happens in
+// a child the test can kill. Prints one JSON line with what was read and by how
+// much the read raised this process's peak RSS.
 const fs = require("fs");
 
+// This process's own high-water mark. getrusage() cannot be used for this on
+// Linux: ru_maxrss survives exec, so a child starts out with the high-water
+// mark of the test runner that spawned it.
+function peakRss() {
+  if (process.platform === "linux") {
+    return Number(/^VmHWM:\s+(\d+) kB/m.exec(fs.readFileSync("/proc/self/status", "utf8"))[1]) * 1024;
+  }
+  return process.resourceUsage().maxRSS * 1024;
+}
+
+const before = peakRss();
 const data = fs.readFileSync(process.argv[2]);
-process.stdout.write(`len=${data.length} allA=${data.equals(Buffer.alloc(data.length, "a"))}`);
+const peakGrowth = peakRss() - before;
+
+console.log(JSON.stringify({ len: data.length, allA: data.equals(Buffer.alloc(data.length, "a")), peakGrowth }));

--- a/test/js/node/fs/fs-readfile-fifo-fixture.js
+++ b/test/js/node/fs/fs-readfile-fifo-fixture.js
@@ -1,32 +1,11 @@
-// Spawned by fs.test.ts. Reads a FIFO whose content (>256 KB) far exceeds the
-// 0-byte size `fstat` reports for a pipe. The "stat size is wrong" grow path in
-// readFileSync used to reallocate (and RawVec-double) on every read because the
-// buffer length was left at capacity, ballooning RSS to multiple GB and never
-// returning. Prints a single parseable line so the parent can assert.
+// Spawned by fs.test.ts, which creates the FIFO at argv[2] and feeds it well
+// over the 256 KB readFileSync reads before calling fstat. fstat reports a
+// 0-byte size for a pipe, so everything after that arrives through the "stat
+// size is wrong" grow path. That path used to reallocate (and RawVec-double) on
+// every read because the buffer length was left at capacity, ballooning RSS to
+// multiple GB and never returning, which is why the read runs in a child the
+// test can kill. Prints a single parseable line for the parent to assert on.
 const fs = require("fs");
-const cp = require("child_process");
-const path = require("path");
 
-const dir = process.argv[2];
-const fifo = path.join(dir, "thefifo");
-try {
-  fs.unlinkSync(fifo);
-} catch {}
-cp.execFileSync("mkfifo", [fifo]);
-if (!fs.statSync(fifo).isFIFO()) throw new Error(`not a FIFO: ${fifo}`);
-
-const SIZE = 400 * 1024;
-cp.spawn(
-  process.execPath,
-  [
-    "-e",
-    `const fs=require("fs");const fd=fs.openSync(process.argv[1],"w");` +
-      `const b=Buffer.alloc(${SIZE},0x61);let o=0;` +
-      `while(o<b.length){o+=fs.writeSync(fd,b,o,Math.min(16384,b.length-o))}fs.closeSync(fd);`,
-    fifo,
-  ],
-  { stdio: "inherit" },
-);
-
-const data = fs.readFileSync(fifo);
-process.stdout.write(`len=${data.length} allA=${data.every(x => x === 0x61)}`);
+const data = fs.readFileSync(process.argv[2]);
+process.stdout.write(`len=${data.length} allA=${data.equals(Buffer.alloc(data.length, "a"))}`);

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5943,21 +5943,19 @@ describe.skipIf(isWindows)("readFileSync on a FIFO larger than the stat size", (
     // process: on a debug build each extra bun startup costs most of a second
     // of this test's budget. writeFile's open() parks on the pool until the
     // fixture opens the read end, and its close() is the fixture's EOF.
+    //
+    // The fixture's output is asserted before the writer is awaited so that a
+    // failure reports the fixture's error: pre-fix it either never returns
+    // (RawVec doubling balloons RSS to multiple GB) or dies with ENOMEM, which
+    // fails the writer with EPIPE, and a fixture that dies before opening the
+    // FIFO leaves the writer parked in open() with nothing to report.
     const writer = promises.writeFile(fifo, Buffer.alloc(SIZE, "a")).catch(err => err);
 
-    // Pre-fix the fixture either never returns (RawVec doubling balloons RSS to
-    // multiple GB) or dies with ENOMEM, which also fails the writer with EPIPE;
-    // the fixture's output is asserted first so that is what a failure reports.
-    const [stdout, stderr, exitCode, writeError] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-      writer,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     expect(stdout).toBe(`len=${SIZE} allA=true`);
     expect(exitCode).toBe(0);
-    expect(writeError).toBeUndefined();
+    expect(await writer).toBeUndefined();
   });
 });
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5922,19 +5922,42 @@ describe("synchronous I/O string flags", () => {
 describe.skipIf(isWindows)("readFileSync on a FIFO larger than the stat size", () => {
   it("does not balloon the read buffer", async () => {
     using dir = tempDir("fs-readfile-fifo", {});
+    const fifo = join(String(dir), "thefifo");
+    mkfifo(fifo);
+
     await using proc = Bun.spawn({
-      cmd: [bunExe(), join(import.meta.dir, "fs-readfile-fifo-fixture.js"), String(dir)],
+      cmd: [bunExe(), join(import.meta.dir, "fs-readfile-fifo-fixture.js"), fifo],
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
     });
-    // Pre-fix this never returns (RawVec doubling balloons RSS to multiple GB);
-    // the per-test timeout would fire. Fixed: completes promptly with the full
-    // 400 KB of content intact.
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // readFileSync reads 256 KB before it calls fstat; only the bytes after that
+    // go through the grow path under test, and one read() from a pipe returns at
+    // most one pipe buffer, which is 64 KB on Linux and smaller on macOS. 1 MB
+    // past the pre-stat buffer is therefore at least 16 grow steps however the
+    // kernel chunks the data, and before the fix every step doubled the buffer.
+    const SIZE = 256 * 1024 + 1024 * 1024;
+
+    // Fed from this process, on the fs thread pool, rather than by a second bun
+    // process: on a debug build each extra bun startup costs most of a second
+    // of this test's budget. writeFile's open() parks on the pool until the
+    // fixture opens the read end, and its close() is the fixture's EOF.
+    const writer = promises.writeFile(fifo, Buffer.alloc(SIZE, "a")).catch(err => err);
+
+    // Pre-fix the fixture either never returns (RawVec doubling balloons RSS to
+    // multiple GB) or dies with ENOMEM, which also fails the writer with EPIPE;
+    // the fixture's output is asserted first so that is what a failure reports.
+    const [stdout, stderr, exitCode, writeError] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+      writer,
+    ]);
     expect(stderr).toBe("");
-    expect(stdout).toBe("len=409600 allA=true");
+    expect(stdout).toBe(`len=${SIZE} allA=true`);
     expect(exitCode).toBe(0);
+    expect(writeError).toBeUndefined();
   });
 });
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5925,6 +5925,17 @@ describe.skipIf(isWindows)("readFileSync on a FIFO larger than the stat size", (
     const fifo = join(String(dir), "thefifo");
     mkfifo(fifo);
 
+    // readFileSync reads 256 KB before it calls fstat; only the bytes after that
+    // go through the grow path under test, and one read() from a pipe returns at
+    // most one pipe buffer (64 KB on Linux, no larger on macOS), so the 768 KB
+    // after it are at least 13 grow steps however the kernel chunks the data.
+    // Before the fix every step doubled the buffer: 13 steps is a 2 GB buffer,
+    // and copying into it raises the fixture's peak RSS by 1.5 GB or more,
+    // against a few MB now. Hosts with smaller pipe buffers get more steps; a
+    // regression there keeps doubling until the kernel kills the fixture or the
+    // test times out.
+    const SIZE = 1024 * 1024;
+
     await using proc = Bun.spawn({
       cmd: [bunExe(), join(import.meta.dir, "fs-readfile-fifo-fixture.js"), fifo],
       env: bunEnv,
@@ -5932,30 +5943,25 @@ describe.skipIf(isWindows)("readFileSync on a FIFO larger than the stat size", (
       stderr: "pipe",
     });
 
-    // readFileSync reads 256 KB before it calls fstat; only the bytes after that
-    // go through the grow path under test, and one read() from a pipe returns at
-    // most one pipe buffer, which is 64 KB on Linux and no larger on macOS. 1 MB
-    // past the pre-stat buffer is therefore at least 16 grow steps however the
-    // kernel chunks the data, and before the fix every step doubled the buffer.
-    const SIZE = 256 * 1024 + 1024 * 1024;
-
-    // Fed from this process, on the fs thread pool, rather than by a second bun
-    // process: on a debug build each extra bun startup costs most of a second
-    // of this test's budget. writeFile's open() parks on the pool until the
-    // fixture opens the read end, and its close() is the fixture's EOF.
-    //
-    // The fixture's output is asserted before the writer is awaited so that a
-    // failure reports the fixture's error: pre-fix it either never returns
-    // (RawVec doubling balloons RSS to multiple GB) or dies with ENOMEM, which
-    // fails the writer with EPIPE, and a fixture that dies before opening the
-    // FIFO leaves the writer parked in open() with nothing to report.
-    const writer = promises.writeFile(fifo, Buffer.alloc(SIZE, "a")).catch(err => err);
+    // The FIFO is fed by a throwaway cat: a second bun process costs most of a
+    // second of startup on a debug build, and writing from this process would
+    // leave an uncancellable open() on the fs thread pool if the fixture died
+    // before opening its end. sh blocks in the open() until the fixture opens
+    // the read end, cat exiting is the fixture's EOF, and `await using` kills
+    // whatever is still around if an assertion below fails.
+    await using writer = Bun.spawn({
+      cmd: ["sh", "-c", 'exec cat > "$1"', "sh", fifo],
+      stdin: Buffer.alloc(SIZE, "a"),
+      stdout: "ignore",
+    });
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
-    expect(stdout).toBe(`len=${SIZE} allA=true`);
     expect(exitCode).toBe(0);
-    expect(await writer).toBeUndefined();
+    const { peakGrowth, ...read } = JSON.parse(stdout);
+    expect(read).toEqual({ len: SIZE, allA: true });
+    expect(peakGrowth).toBeLessThan(64 * 1024 * 1024);
+    expect(await writer.exited).toBe(0);
   });
 });
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5934,7 +5934,7 @@ describe.skipIf(isWindows)("readFileSync on a FIFO larger than the stat size", (
 
     // readFileSync reads 256 KB before it calls fstat; only the bytes after that
     // go through the grow path under test, and one read() from a pipe returns at
-    // most one pipe buffer, which is 64 KB on Linux and smaller on macOS. 1 MB
+    // most one pipe buffer, which is 64 KB on Linux and no larger on macOS. 1 MB
     // past the pre-stat buffer is therefore at least 16 grow steps however the
     // kernel chunks the data, and before the fix every step doubled the buffer.
     const SIZE = 256 * 1024 + 1024 * 1024;


### PR DESCRIPTION
### Problem
- `test/js/node/fs/fs.test.ts` > "readFileSync on a FIFO larger than the stat size > does not balloon the read buffer" fails with `this test timed out after 5000ms` in full-file `bun bd test` runs on a debug/ASAN build (seen at 87b26b57fa; 4.67s when it passed here, 3.4 to 4.8s for the fixture run by hand).
- The `readFileSync` under test takes a few ms. The rest is `fs-readfile-fifo-fixture.js` doing work around it, measured on the debug build: its own startup (~0.3s) plus `require("fs")` (0.6 to 0.9s), the first `child_process` call (`execFileSync("mkfifo")`, 0.6 to 1.0s of one-time module setup), a second debug bun spawned as the FIFO writer (the read blocks until it is up, 1.0 to 1.2s), and `data.every(x => x === 0x61)` over 400 KB, 1.1s of debug-JSC callbacks by itself.
- The test also did not pin down the bug it was written for (#31005). Without the fix the read still returns the right bytes; it just doubles its buffer on every `read()` after the first 256 KB. The old test asserted only the bytes, so it could only fail by timing out, and whether it did depended on the host: the data after the first 256 KB (144 KB of the 400 KB) arrives in ~18 reads on a host whose FIFOs have 8 KB buffers (this container, `F_GETPIPE_SZ` = 8192) and the unfixed build blows up, but in 3 or 4 reads with the usual 64 KB buffer, and 4 doublings of a 256 KB buffer finish instantly. Giving it more data only moves the line: a bigger payload makes the unfixed build take more memory and more time, and it still passes wherever the machine has that memory and the timeout (90s per test in CI, 270s on ASAN) allows it.

### Fix
- `fs.test.ts` creates the FIFO with the `mkfifo` helper the file already imports, spawns the fixture on it, and feeds it with a throwaway `sh -c 'exec cat > "$1"'` that gets the 1 MiB payload on stdin. `sh` blocks in its `open()` until the fixture opens the read end, `cat` exiting is the fixture's EOF, and `await using` kills whatever is left if an assertion fails.
- The fixture reads the FIFO with `readFileSync` and prints `{ len, allA, peakGrowth }`, where `peakGrowth` is how much the read raised the fixture's own peak RSS. The test asserts empty stderr, exit 0, `{ len: 1 MiB, allA: true }`, `peakGrowth < 64 MiB`, and that `cat` exited 0.
- Why this catches the regression on any host: `readFileSync` reads 256 KB before its `fstat`, and one `read()` from a pipe returns at most one pipe buffer (64 KB on Linux, no larger on macOS), so the remaining 768 KB is at least 13 trips through the grow path. Unfixed, 13 doublings is a 2 GiB buffer and the copies into it raise peak RSS by 1.5 GiB or more; fixed, the read measures 4.0 MiB (release) and 7.7 MiB (debug+ASAN) of growth, stable across runs. 64 MiB is 8x above the fixed number and 24x below the unfixed floor. Hosts with smaller pipe buffers get more doublings; a regression there still runs away until the fixture is killed or the test times out, which also fails.
- Why the fixture measures itself with `VmHWM` on Linux: `ru_maxrss` survives exec, so a child's `resourceUsage().maxRSS` (and the parent-side `Subprocess.resourceUsage()`) starts at the test runner's own high-water mark. Checked here: a child spawned from a parent that had touched 1.5 GiB reported `maxRSS` 1564 MB while its `VmHWM` was 33 MB. On macOS `ru_maxrss` is the process's own, so the fixture uses `process.resourceUsage()` there (Bun reports it in KB on every platform, `BunProcess.cpp`).
- Why the writer is a separate process: writing from the test process (`fs.promises.writeFile`, as an earlier version of this PR did) leaves an `open()` parked on the fs thread pool if the fixture dies before opening the FIFO. That job holds a VM ticket and cannot be cancelled, and with `BUN_DESTRUCT_VM_ON_EXIT=1` (which `scripts/runner.node.mjs` sets for this file on the ASAN lane and for local runner use) `bun test` then never exits. Reproduced with a fixture that exits immediately: the `writeFile` version fails the test in 0.46s and then logs `teardown has waited 10s ... for 1 ticket(s)` until killed at 60s; the `cat` version fails in 0.45s and the process exits 3s later. A second debug bun as the writer is what the test did before, and it is the startup cost being removed.
- The fixture's stderr and exit code are asserted before its output is parsed and before `cat` is awaited, so a fixture failure is what a failure reports.
- Verified, debug/ASAN build at the PR base:
  - `bun bd test test/js/node/fs/fs.test.ts -t "does not balloon"`: 13 of 13 runs pass, 1.0 to 1.5s each (was 4.67s). Full file: 511 pass, 6 skip; this test 1.06s.
  - `USE_SYSTEM_BUN=1 bun test ... -t "does not balloon"`: pass, 28ms.
  - With `buf.truncate(total)` removed from `src/runtime/node/node_fs.rs` (the #31005 fix) and the binary rebuilt: the test fails 3 of 3 (this container's 8 KB FIFO buffers give ~100 doublings, so it runs away and times out). To see what a 64 KB host would see, the payload was sized to 13 to 14 doublings at 8 KB per read: the unfixed fixture then finishes in 4.2s with the right bytes and reports `peakGrowth` of 3.39 GB, which the 64 MiB bound fails and which nothing in the old test would have failed within CI's timeout. Fixed build, same payload: a few MB.
- Test-only change; no `src/` change. #37828 (open) speeds up other tests in this file and does not touch this test or the fixture.

### Background
- `readFileSync` on a path first reads up to 256 KB (`PIPE_READ_BUFFER_SIZE`) without calling `fstat`. Only if that fills does it `fstat`, size a `Vec` from `max(st_size, bytes so far)` and keep reading; a FIFO's `st_size` is 0, so every further `read()` takes the "stat size is wrong" arm in `node_fs.rs`, which reserves more room each time. #31005 fixed that arm leaving `len == capacity`, which made every reserve a reallocation and `RawVec` double the capacity on every `read()`. The reallocation copies the whole old buffer, so what balloons is the process's peak RSS; the bytes returned are correct either way.
- The read runs in a child process because a regression blocks inside one synchronous native call, which a per-test timeout cannot interrupt in the test process itself; `await using proc` can kill a child.
- A FIFO is a named pipe. Its kernel buffer is at most 64 KB on Linux (less when a user is over `fs.pipe-user-pages-soft`, as in this container) and no larger on macOS, and a `read()` returns at most what the buffer holds, which is what bounds the bytes consumed per grow step from above and therefore the number of grow steps from below.
- `VmHWM` in `/proc/self/status` is the peak RSS of the current memory image. `ru_maxrss` is kept per process and, on Linux, set at `exec` to the peak of the image being replaced, so a freshly spawned child inherits its parent's peak.
- Async `node:fs` operations run as jobs on bun's fs thread pool; each job holds a ticket on the VM that scheduled it. `BUN_DESTRUCT_VM_ON_EXIT=1` makes bun tear the VM down at exit instead of just exiting, and the teardown waits for every outstanding ticket; a job blocked in a FIFO `open()` with no reader never returns its ticket.

<details>
<summary>Timings on the debug build (linux-x64 container, 8 CPUs)</summary>

```
bun-debug -e 1                                          280-317ms

original fixture, phases (3 runs)
  require("fs") + require("path")                        566-897ms
  require("child_process")                               155-230ms
  execFileSync("mkfifo")  (first child_process call)     589-1016ms
  execFileSync("true")    (second call, for comparison)  15-19ms
  cp.spawn(bun -e writer)                                97-121ms
  readFileSync(fifo) incl. waiting for the writer bun    1009-1178ms
  Buffer(409600).every(x => x === 0x61), measured alone  1104ms   (Buffer.equals: 5ms)
  whole fixture, wall                                    2977-4825ms

test on main, bun bd test (one run)                      4673ms
test as in this PR, bun bd test (13 runs)                989-1503ms
test as in this PR, full-file run                        1063ms
test as in this PR, USE_SYSTEM_BUN=1                     28ms

peakGrowth reported by the fixture for the 1 MiB payload
  release (system bun), 3 runs                           4157440 bytes each
  debug+ASAN, 3 runs                                     8040448 / 8085504 / 8089600 bytes
  unfixed debug+ASAN, payload sized to 13-14 doublings   3388755968 / 3386621952 bytes, exit 0, 4.1-4.2s
unfixed debug+ASAN, real test                            3/3 timed out at 5s (~100 doublings on 8 KB FIFOs)

fixture exits before opening the FIFO, BUN_DESTRUCT_VM_ON_EXIT=1
  writer = fs.promises.writeFile in the test process     test fails at 0.46s, bun test never exits (killed at 60s)
  writer = sh/cat as in this PR                          test fails at 0.45s, bun test exits after 3s
```
</details>

<details>
<summary>Superseded versions of this PR</summary>

The first push fed the FIFO with `fs.promises.writeFile` from the test process and asserted only the bytes, with a 256 KB + 1 MB payload chosen so the unfixed build would take at least 17 doublings. Review pointed out two problems: the unfixed build still completes 17 doublings (a 32 GiB buffer, about 24 GiB of peak RSS) on a machine with enough memory, so the bytes-only assertion still depended on host RAM and the timeout; and the in-process writer's `open()` parks on the fs pool, which under `BUN_DESTRUCT_VM_ON_EXIT=1` turns a fixture that fails early into a `bun test` that never exits. The second push only moved the `await` of the writer after the fixture's assertions. The current version replaces both: the fixture reports its peak RSS growth, and a disposable `cat` feeds the FIFO.
</details>
