### PR TITLE
ci: parse GitHub Actions workflow-command lines in parseAnnotations with a shared line parser

### DIFF
--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -1413,12 +1413,29 @@ export function escapeGitHubAction(string) {
   return string.replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
 }
 
+// Escapes used by GitHub Actions workflow commands (`::error file=a,title=b::message`).
+// The message escapes `%` and newlines; property values also escape the `,` and
+// `:` that delimit them. Decoding happens in one pass so that an escaped literal
+// "%0A" (written "%250A") does not turn into a newline.
+// https://github.com/actions/toolkit/blob/main/packages/core/src/command.ts
+const githubActionEscapes = { "%25": "%", "%0D": "\r", "%0A": "\n", "%3A": ":", "%2C": "," };
+
 /**
+ * Decodes the message of a GitHub Actions workflow command.
  * @param {string} string
  * @returns {string}
  */
 export function unescapeGitHubAction(string) {
-  return string.replace(/%25/g, "%").replace(/%0D/g, "\r").replace(/%0A/g, "\n");
+  return string.replace(/%(?:25|0D|0A)/g, escaped => githubActionEscapes[escaped]);
+}
+
+/**
+ * Decodes a property value (`file=`, `title=`, ...) of a GitHub Actions workflow command.
+ * @param {string} string
+ * @returns {string}
+ */
+export function unescapeGitHubActionProperty(string) {
+  return string.replace(/%(?:25|0D|0A|3A|2C)/g, escaped => githubActionEscapes[escaped]);
 }
 
 /**
@@ -2780,21 +2797,33 @@ export function parseAnnotations(content) {
       return { lines, match };
     };
 
-    // Github Actions
+    // GitHub Actions workflow command, e.g. what `bun test` prints for a failure
+    // when GITHUB_ACTIONS is set, or a step's `echo "::error::message"`:
+    //   ::error file=a.test.ts,line=3,col=5,title=error: boom::Expected: 1%0A    at ...
+    // As in the runner, the properties are optional and end at the first `::`
+    // (only the message may contain an unescaped `::`), and a property splits at
+    // its first `=`.
     // https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions
-    const githubAnnotation = line.match(/^::(error|warning|notice|debug)(?: (.*))?::(.*)$/);
+    const githubAnnotation = line.match(/^::(error|warning|notice|debug)(?: (.*?))?::(.*)$/);
     if (githubAnnotation) {
-      const [, level, attributes, content] = githubAnnotation;
-      const { file, line, col, title } = Object.fromEntries(
-        attributes?.split(",")?.map(entry => entry.split("=")) || {},
-      );
+      const [, level, properties = "", message] = githubAnnotation;
+      /** @type {Record<string, string>} */
+      const attributes = {};
+      for (const property of properties.split(",")) {
+        const separator = property.indexOf("=");
+        if (separator > 0) {
+          attributes[property.slice(0, separator)] = unescapeGitHubActionProperty(property.slice(separator + 1));
+        }
+      }
+      const { file, line, col, title } = attributes;
 
       const annotation = parseAnnotation({
         level,
+        title,
         filename: file,
         line,
         column: col,
-        content: unescapeGitHubAction(title) + unescapeGitHubAction(content),
+        content: unescapeGitHubAction(message),
       });
       annotations.push(annotation);
       continue;

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -1439,6 +1439,56 @@ export function unescapeGitHubActionProperty(string) {
 }
 
 /**
+ * @typedef {object} GitHubActionCommand
+ * @property {string} command `error` for `::error ...::...`
+ * @property {Record<string, string>} properties decoded, e.g. `{ file, line, col, title }`
+ * @property {string} message decoded
+ */
+
+/**
+ * Parses a workflow command line, `::error file=a.ts,line=1,col=2,title=t::message`,
+ * the way the GitHub Actions runner does: the command and its properties end at the
+ * first `::` after the leading one, properties are separated by `,` and each value
+ * starts after the first `=` of its property (the value itself may contain `=`), and
+ * values and message are decoded as above.
+ *
+ * https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions
+ *
+ * @param {string} line
+ * @returns {GitHubActionCommand | undefined} undefined if the line is not a workflow command
+ */
+export function parseGitHubActionCommand(line) {
+  if (!line.startsWith("::")) {
+    return undefined;
+  }
+  const end = line.indexOf("::", 2);
+  if (end === -1) {
+    return undefined;
+  }
+
+  const header = line.slice(2, end);
+  const space = header.indexOf(" ");
+  const command = space === -1 ? header : header.slice(0, space);
+  if (!command) {
+    return undefined;
+  }
+
+  /** @type {Record<string, string>} */
+  const properties = {};
+  if (space !== -1) {
+    for (const property of header.slice(space + 1).split(",")) {
+      const equals = property.indexOf("=");
+      if (equals <= 0) {
+        continue;
+      }
+      properties[property.slice(0, equals)] = unescapeGitHubActionProperty(property.slice(equals + 1));
+    }
+  }
+
+  return { command, properties, message: unescapeGitHubAction(line.slice(end + 2)) };
+}
+
+/**
  * @param {string} string
  * @returns {string}
  */
@@ -2797,25 +2847,13 @@ export function parseAnnotations(content) {
       return { lines, match };
     };
 
-    // GitHub Actions workflow command, e.g. what `bun test` prints for a failure
-    // when GITHUB_ACTIONS is set, or a step's `echo "::error::message"`:
+    // GitHub Actions workflow command, e.g. what bun prints for an error when
+    // GITHUB_ACTIONS is set, or a step's `echo "::error::message"`:
     //   ::error file=a.test.ts,line=3,col=5,title=error: boom::Expected: 1%0A    at ...
-    // As in the runner, the properties are optional and end at the first `::`
-    // (only the message may contain an unescaped `::`), and a property splits at
-    // its first `=`.
-    // https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions
-    const githubAnnotation = line.match(/^::(error|warning|notice|debug)(?: (.*?))?::(.*)$/);
-    if (githubAnnotation) {
-      const [, level, properties = "", message] = githubAnnotation;
-      /** @type {Record<string, string>} */
-      const attributes = {};
-      for (const property of properties.split(",")) {
-        const separator = property.indexOf("=");
-        if (separator > 0) {
-          attributes[property.slice(0, separator)] = unescapeGitHubActionProperty(property.slice(separator + 1));
-        }
-      }
-      const { file, line, col, title } = attributes;
+    const githubAnnotation = parseGitHubActionCommand(line);
+    if (githubAnnotation && /^(error|warning|notice|debug)$/.test(githubAnnotation.command)) {
+      const { command: level, properties, message } = githubAnnotation;
+      const { file, line, col, title } = properties;
 
       const annotation = parseAnnotation({
         level,
@@ -2823,7 +2861,7 @@ export function parseAnnotations(content) {
         filename: file,
         line,
         column: col,
-        content: unescapeGitHubAction(message),
+        content: message,
       });
       annotations.push(annotation);
       continue;

--- a/test/internal/source-lints/ci-annotations.test.ts
+++ b/test/internal/source-lints/ci-annotations.test.ts
@@ -247,6 +247,17 @@ describe("GitHub Actions workflow commands", () => {
       },
     ]);
   });
+
+  test("other commands and non-commands are not annotations", () => {
+    const output = [
+      "::group::build",
+      "::set-output name=x::1",
+      "::error file=a.ts", // no closing `::`
+      "::errors::not a command",
+      "::endgroup::",
+    ].join("\n");
+    expect(parseAnnotations(output).annotations).toEqual([]);
+  });
 });
 
 describe("other sources", () => {

--- a/test/internal/source-lints/ci-annotations.test.ts
+++ b/test/internal/source-lints/ci-annotations.test.ts
@@ -159,6 +159,96 @@ describe("rustc diagnostics", () => {
   });
 });
 
+// `::error file=..,line=..,col=..,title=..::message` lines: what `bun test`
+// prints for a failure when GITHUB_ACTIONS is set (property values escape
+// `%` `\r` `\n` `:` `,` as %25 %0D %0A %3A %2C; the message only escapes the
+// first three), and what workflow steps print by hand (`echo "::error::msg"`).
+describe("GitHub Actions workflow commands", () => {
+  test("a bun test failure becomes an annotation titled by its title= property", () => {
+    const line =
+      "::error file=test/odd%2Cname%25.test.ts,line=3,col=5,title=error: ENOENT%3A no such file%2C open '100%25'" +
+      '::Expected: "::1"%0A      at f (test/odd,name%.test.ts:3:5)';
+
+    const { annotations, content } = parseAnnotations(["before", line, "after"].join("\n"));
+    expect(annotations).toEqual([
+      {
+        source: undefined,
+        level: "error",
+        title: "error: ENOENT: no such file, open '100%'",
+        filename: "test/odd,name%.test.ts",
+        line: 3,
+        column: 5,
+        // The message runs from the first `::` after the properties, so a `::`
+        // inside it stays in the body instead of being taken for the separator.
+        content: 'Expected: "::1"\n      at f (test/odd,name%.test.ts:3:5)',
+        metadata: {},
+      },
+    ]);
+    expect(content).toBe("before\nafter");
+  });
+
+  test("title= is optional: the level names the annotation", () => {
+    expect(parseAnnotations("::error file=app.js,line=1::Missing semicolon").annotations).toEqual([
+      {
+        level: "error",
+        title: "error",
+        filename: "app.js",
+        line: 1,
+        column: undefined,
+        content: "Missing semicolon",
+        metadata: {},
+      },
+    ]);
+  });
+
+  test("the whole property list is optional", () => {
+    expect(parseAnnotations("::warning::Prettier failed\n::notice::100%25 done%0Asecond line").annotations).toEqual([
+      { level: "warning", title: "warning", content: "Prettier failed", metadata: {} },
+      { level: "notice", title: "notice", content: "100% done\nsecond line", metadata: {} },
+    ]);
+  });
+
+  test("a property value may contain '=' and the message may be empty", () => {
+    // bun test's timeout line.
+    expect(parseAnnotations('::error title=error: Test "a = b" timed out after 5000ms::').annotations).toEqual([
+      {
+        level: "error",
+        title: 'error: Test "a = b" timed out after 5000ms',
+        filename: undefined,
+        line: undefined,
+        column: undefined,
+        content: "",
+        metadata: {},
+      },
+    ]);
+  });
+
+  test("a bare workflow command line does not cost the build its compiler annotations", () => {
+    // ci.ts parses the whole captured output of a failed build in one call and
+    // falls back to a single generic annotation if that call throws.
+    const clang = ["src/jsc/bindings/Foo.cpp:12:5: error: use of undeclared identifier 'bar'", "1 error generated."];
+    const { annotations } = parseAnnotations([...clang, "::error::ninja failed"].join("\n"));
+    expect(annotations.map(({ source, title, content }) => ({ source, title, content }))).toEqual([
+      { source: "clang", title: "clang error", content: clang.join("\n") },
+      { source: undefined, title: "error", content: "ninja failed" },
+    ]);
+  });
+
+  test("escapes are decoded in one pass, and %3A/%2C only where they are escapes", () => {
+    expect(parseAnnotations("::error title=a%3Ab%2Cc%25 %250A::x%3Ay%2Cz%25 %250A").annotations).toEqual([
+      {
+        level: "error",
+        // "%250A" is an escaped literal "%0A", not a newline.
+        title: "a:b,c% %0A",
+        // The message is not delimited by `:` or `,`, so writers leave them raw
+        // there and a literal "%3A" in a message is data.
+        content: "x%3Ay%2Cz% %0A",
+        metadata: {},
+      },
+    ]);
+  });
+});
+
 describe("other sources", () => {
   test("CMake messages are attributed to the innermost call-stack frame with a single-spaced body", () => {
     const message = [


### PR DESCRIPTION
### Problem
- `parseAnnotations()` in `scripts/utils.mjs` throws on most GitHub Actions workflow-command lines: `TypeError: undefined is not an object (evaluating 'string.replace')` for an `::error` line whose property list has no `title=` (`unescapeGitHubAction(undefined)`), and `TypeError: {} is not iterable` for one with no property list at all (`::warning::message`; the `|| {}` fallback is handed to `Object.fromEntries`). `scripts/utils.mjs:2806` on main.
- `scripts/build/ci.ts:171` runs it once over the whole captured output of a failed build step and falls back to one generic "build failed" annotation if the call throws, so a single such line would discard every rustc/clang/cmake annotation of that build. Today nothing on that path prints these lines (bun only prints them when `GITHUB_ACTIONS` is set, which Buildkite build steps do not do), so this is a latent failure mode of the parser, found by reading it, not an observed loss of annotations.
- The lines it did accept were read wrong: the property list was matched greedily, so the message was cut at its last `::` instead of its first; a property was split at every `=`, truncating a title containing `=`; property values were not decoded, so the `%3A` / `%2C` / `%25` bun has written for `:` `,` `%` since #36165 stayed in the title and file name; and the title was glued onto the body (`LintMissing semicolon`) instead of becoming the annotation's title.
- `unescapeGitHubAction()` replaced `%25` first, so an escaped literal `%0A` (`%250A`) came back as a newline.
- The repo has a second reader of the same lines, `parseTestStdout()` in `scripts/runner.node.mjs`, with the same `=` and decoding bugs (#38956). Fixing one copy in place would have left two implementations of the grammar.

### Fix
- Adds `parseGitHubActionCommand(line)` to `scripts/utils.mjs`, returning `{ command, properties, message }` or `undefined`, and has `parseAnnotations()` read `::error` / `::warning` / `::notice` / `::debug` lines through it, passing `title=` on as the annotation title (the level name remains the fallback, as before). `unescapeGitHubAction()` decodes in one pass and `unescapeGitHubActionProperty()` is added beside it.
- The helper and the two decoders are the same text as in #38956, which switches the runner to them; whichever of the two lands second drops its copy (checked by running #38956's `test/internal/runner-annotations.test.ts` against this branch's `utils.mjs`: 7 pass). Together the two PRs leave one implementation of the grammar with two consumers.
- Correct because it is the grammar every writer of these lines targets: the Actions runner ends the command and its properties at the first `::`, splits properties on `,` and each at its first `=`, and decodes `%25 %0D %0A` in the message plus `%3A %2C` in property values. bun's writers (`github_action_writer` / `github_action_property_writer` in `src/bun_core/fmt.rs`) emit exactly those escapes and leave `:` `,` `=` raw in the message, which is why the message must be allowed to contain `::` and why a `%3A` in it is data. One-pass decoding is the inverse of a writer that escapes `%` first.
- `ci.ts` and `formatAnnotationToHtml()` already consume `title` and `content` separately (the rustc matcher produces the same shape), so no consumer changes; `unescapeGitHubAction()` has no caller outside this function.
- Verified: `test/internal/source-lints/ci-annotations.test.ts`, new "GitHub Actions workflow commands" block. With `scripts/utils.mjs` from main, the six positive cases fail (the two TypeErrors; the title glued into the body, cut at `=`, and left encoded; the clang annotation lost next to a `::error::` line) and the guard case plus the eight existing cases pass; with this branch all fifteen pass under `bun bd test` and under the released bun, which is how the source-lints workflow runs this directory. Also ran `parseAnnotations()` + `formatAnnotationToHtml()` over a clang diagnostic followed by a bun failure line and a bare `::error::` line: three annotations titled `clang error`, `error: ENOENT: no such file`, `error`. `bunx tsc -p scripts/build/tsconfig.json` reports the same pre-existing errors before and after.

### Background
- **Workflow commands**: lines of the form `::error file=a,line=1,col=2,title=t::message` printed to stdout; on GitHub Actions the runner turns them into annotations. bun prints one per failure or uncaught error when `GITHUB_ACTIONS` is set (`scripts/runner.node.mjs` sets it for every test file it runs, so it can read the failures back), and workflow steps print them by hand (`echo "::error::Prettier failed"`). Because `::` ends the property list and `,` / `=` separate properties, property values escape `%` `\r` `\n` `:` `,` as `%25 %0D %0A %3A %2C`; the message only escapes `%` `\r` `\n`.
- **Buildkite annotations from builds**: bun's CI builds run on Buildkite, so `scripts/build/ci.ts` captures the output of a failed build step and runs it through `parseAnnotations()`, which has one matcher per diagnostic format (rustc, clang, cmake, node, shell, and these lines) and posts one Buildkite annotation per match; if nothing matches or the parser throws, it posts one annotation containing the raw output instead.

<details>
<summary>Earlier shape of this PR</summary>

The first revision fixed the `parseAnnotations()` branch in place (non-greedy match, first-`=` split, the two decoders, title passed through). Self-review pointed out that the branch has no producer on its only call path today and that `runner.node.mjs` carries the same bugs, so the second revision factors the line parsing into `parseGitHubActionCommand()`, shared with #38956, and makes this branch its consumer. The tests are unchanged apart from one added guard case.

</details>
