### PR TITLE
bun:test: wrap multi-line JSX snapshots in line breaks like every other value

### DIFF
--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -2500,6 +2500,44 @@ impl<'a> Formatter<'a> {
         result
     }
 
+    /// jest surrounds a snapshot value that spans several lines with a newline on each side
+    /// (jest-snapshot's `addExtraLineBreaks`). The other arms of `print_as` write those
+    /// newlines themselves because a non-empty object or array always spans several lines;
+    /// whether an element does depends on its props and children (`<div />` and
+    /// `<div>text</div>` fit on one line), so a top-level element is rendered into a buffer
+    /// first and wrapped afterwards.
+    fn print_jsx<W: bun_io::Write, const ENABLE_ANSI_COLORS: bool>(
+        &mut self,
+        writer: &mut W,
+        value: JSValue,
+        js_type: JSType,
+    ) -> JsResult<()> {
+        if self.indent != 0 {
+            return self.print_as::<W, { Tag::JSX }, ENABLE_ANSI_COLORS>(writer, value, js_type);
+        }
+
+        let mut rendered: Vec<u8> = Vec::new();
+        let result = self.print_as::<Vec<u8>, { Tag::JSX }, ENABLE_ANSI_COLORS>(
+            &mut rendered,
+            value,
+            js_type,
+        );
+
+        let multiline = strings::contains_char(&rendered, b'\n');
+        let mut writer = WrappedWriter::new(writer);
+        if multiline {
+            writer.write_all(b"\n");
+        }
+        writer.write_all(&rendered);
+        if multiline {
+            writer.write_all(b"\n");
+        }
+        if writer.failed {
+            self.failed = true;
+        }
+        result
+    }
+
     pub(crate) fn format<W: bun_io::Write, const ENABLE_ANSI_COLORS: bool>(
         &mut self,
         result: TagResult,
@@ -2579,9 +2617,7 @@ impl<'a> Formatter<'a> {
             }
             Tag::NativeCode => self
                 .print_as::<W, { Tag::NativeCode }, ENABLE_ANSI_COLORS>(writer, value, result.cell),
-            Tag::JSX => {
-                self.print_as::<W, { Tag::JSX }, ENABLE_ANSI_COLORS>(writer, value, result.cell)
-            }
+            Tag::JSX => self.print_jsx::<W, ENABLE_ANSI_COLORS>(writer, value, result.cell),
             Tag::Event => {
                 self.print_as::<W, { Tag::Event }, ENABLE_ANSI_COLORS>(writer, value, result.cell)
             }

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -2500,12 +2500,9 @@ impl<'a> Formatter<'a> {
         result
     }
 
-    /// jest surrounds a snapshot value that spans several lines with a newline on each side
-    /// (jest-snapshot's `addExtraLineBreaks`). The other arms of `print_as` write those
-    /// newlines themselves because a non-empty object or array always spans several lines;
-    /// whether an element does depends on its props and children (`<div />` and
-    /// `<div>text</div>` fit on one line), so a top-level element is rendered into a buffer
-    /// first and wrapped afterwards.
+    /// A top-level value that spans several lines is stored as `"\n...\n"` (jest's
+    /// `addExtraLineBreaks`). Unlike an object or array, an element only sometimes does, so it
+    /// is rendered before deciding.
     fn print_jsx<W: bun_io::Write, const ENABLE_ANSI_COLORS: bool>(
         &mut self,
         writer: &mut W,

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -2500,9 +2500,6 @@ impl<'a> Formatter<'a> {
         result
     }
 
-    /// A top-level value that spans several lines is stored as `"\n...\n"` (jest's
-    /// `addExtraLineBreaks`). Unlike an object or array, an element only sometimes does, so it
-    /// is rendered before deciding.
     fn print_jsx<W: bun_io::Write, const ENABLE_ANSI_COLORS: bool>(
         &mut self,
         writer: &mut W,
@@ -2520,6 +2517,7 @@ impl<'a> Formatter<'a> {
             js_type,
         );
 
+        // jest's addExtraLineBreaks: a multi-line top-level value is stored as "\n...\n".
         let multiline = strings::contains_char(&rendered, b'\n');
         let mut writer = WrappedWriter::new(writer);
         if multiline {

--- a/test/js/bun/test/snapshot-tests/snapshots/__snapshots__/snapshot.test.ts.snap
+++ b/test/js/bun/test/snapshot-tests/snapshots/__snapshots__/snapshot.test.ts.snap
@@ -607,3 +607,36 @@ exports[`snapshot numbering 4`] = `"snap"`;
 exports[`snapshot numbering 6`] = `"hello"`;
 
 exports[`snapshot numbering: hinted 1`] = `"hello"`;
+
+exports[`JSX elements: children 1`] = `
+<div>
+  <span />
+  <b />
+</div>
+`;
+
+exports[`JSX elements: long text child 1`] = `
+<p>
+  xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+</p>
+`;
+
+exports[`JSX elements: object prop 1`] = `
+<div style={
+    "color": "red",
+  } />
+`;
+
+exports[`JSX elements: self-closing 1`] = `<div />`;
+
+exports[`JSX elements: string prop 1`] = `<div id="a" />`;
+
+exports[`JSX elements: short text child 1`] = `<p>hi</p>`;
+
+exports[`JSX elements: nested in object 1`] = `
+{
+  "el": <div>
+    <span />
+  </div>,
+}
+`;

--- a/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
@@ -857,6 +857,29 @@ indentation"
     ]);
     for (const r of settled) if (r.status === "rejected") throw r.reason;
   });
+  it("writes a multi-line JSX element indented like an object", async () => {
+    await tester.test(
+      // prettier-ignore
+      v => /*js*/ `
+        const el = (type, props) => ({ $$typeof: Symbol.for("react.element"), type, key: null, ref: null, props });
+        test("cases", () => {
+          expect(el("div", { children: [el("span", {}), el("b", {})] })).toMatchInlineSnapshot(${v("", bad, `\`
+            <div>
+              <span />
+              <b />
+            </div>
+          \``)});
+          expect(el("div", { children: el("span", {}) })).toMatchInlineSnapshot(${v("", bad, `\`
+            <div>
+              <span />
+            </div>
+          \``)});
+          expect(el("div", {})).toMatchInlineSnapshot(${v("", bad, "`<div />`")});
+          expect(el("p", { children: "hi" })).toMatchInlineSnapshot(${v("", bad, "`<p>hi</p>`")});
+        });
+      `,
+    );
+  });
 });
 test("indented inline snapshots", () => {
   expect("a\nb").toMatchInlineSnapshot(`
@@ -875,6 +898,86 @@ test("indented inline snapshots", () => {
                 }
 `);
   }).toThrow();
+});
+
+function reactElement(type: unknown, props: Record<string, unknown>) {
+  return { $$typeof: Symbol.for("react.element"), type, key: null, ref: null, props };
+}
+
+// jest-snapshot puts a newline on each side of any serialized value that spans several lines
+// (addExtraLineBreaks), whatever its type: a multi-line element is stored as `\n<div>...</div>\n`
+// exactly like an object, while a single-line element is stored bare.
+test("JSX elements", () => {
+  const children = reactElement("div", { children: [reactElement("span", {}), reactElement("b", {})] });
+  const longText = reactElement("p", { children: Buffer.alloc(128, "x").toString() });
+  const objectProp = reactElement("div", { style: { color: "red" } });
+  const selfClosing = reactElement("div", {});
+  const stringProp = reactElement("div", { id: "a" });
+  const shortText = reactElement("p", { children: "hi" });
+  const nested = { el: reactElement("div", { children: reactElement("span", {}) }) };
+
+  expect(children).toMatchSnapshot("children");
+  expect(longText).toMatchSnapshot("long text child");
+  expect(objectProp).toMatchSnapshot("object prop");
+  expect(selfClosing).toMatchSnapshot("self-closing");
+  expect(stringProp).toMatchSnapshot("string prop");
+  expect(shortText).toMatchSnapshot("short text child");
+  expect(nested).toMatchSnapshot("nested in object");
+
+  expect(children).toMatchInlineSnapshot(`
+    <div>
+      <span />
+      <b />
+    </div>
+  `);
+  expect(longText).toMatchInlineSnapshot(`
+    <p>
+      xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    </p>
+  `);
+  expect(objectProp).toMatchInlineSnapshot(`
+    <div style={
+        "color": "red",
+      } />
+  `);
+  expect(selfClosing).toMatchInlineSnapshot(`<div />`);
+  expect(stringProp).toMatchInlineSnapshot(`<div id="a" />`);
+  expect(shortText).toMatchInlineSnapshot(`<p>hi</p>`);
+  expect(nested).toMatchInlineSnapshot(`
+    {
+      "el": <div>
+        <span />
+      </div>,
+    }
+  `);
+});
+
+test("a .snap of a multi-line JSX element written by jest matches", async () => {
+  const snap =
+    "// Jest Snapshot v1, https://jest.dev/docs/expect#tomatchsnapshot\n\n" +
+    "exports[`renders a list 1`] = `\n<ul>\n  <li />\n  <li />\n</ul>\n`;\n";
+  using dir = tempDir("jest-jsx-snap", {
+    "list.test.ts": /*js*/ `
+      import { expect, test } from "bun:test";
+      const el = (type, props) => ({ $$typeof: Symbol.for("react.element"), type, key: null, ref: null, props });
+      test("renders a list", () => {
+        expect(el("ul", { children: [el("li", {}), el("li", {})] })).toMatchSnapshot();
+      });
+    `,
+    "__snapshots__/list.test.ts.snap": snap,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "./list.test.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toContain(" 1 pass\n");
+  expect(stderr).not.toContain("error:");
+  expect(exitCode).toBe(0);
+  expect(await Bun.file(`${dir}/__snapshots__/list.test.ts.snap`).text()).toBe(snap);
 });
 
 test("error snapshots", () => {


### PR DESCRIPTION
### Problem
- `toMatchSnapshot()` / `toMatchInlineSnapshot()` of a React element that prints on several lines stores it bare (`<div>\n  <span />\n</div>`), while every other multi-line value (object, array, Map, multi-line string, ...) is stored as `\n...\n`, which is also what jest stores for elements.
- A `.snap` written by jest for such an element therefore fails under `bun test` with a diff that only adds and removes blank lines, and the other way round.
- A new inline snapshot of such an element is written unindented (`toMatchInlineSnapshot(\`<div>\n  <span />\n</div>\`)`) because the inline writer (`snapshot.rs`, `write_inline_snapshots`) only re-indents values that start with a newline.
- Cause: the object, array and typed array arms of `Formatter::print_as` in `src/runtime/test_runner/pretty_format.rs` write the surrounding newlines themselves when `self.indent == 0`; the `Tag::JSX` arm never did.

### Fix
- `Formatter::format` now dispatches `Tag::JSX` through a new `print_jsx`: at `indent == 0` the element is rendered into a `Vec<u8>` and written out surrounded by `\n` if the rendering contains a newline, otherwise as is. Nested elements (`indent != 0`) take the old path unchanged.
- Buffering instead of deciding up front: whether an element spans several lines depends on its children (child elements, a children array, text of 128+ chars) and on its props (an object-valued prop, a string containing a newline, more than a handful of props). Rendering first and checking for a newline is exactly jest's rule (`addExtraLineBreaks` wraps iff the serialized string contains `\n`) and cannot drift from the arm's layout.
- Single-line elements (`<div />`, `<div id="a" />`, `<p>hi</p>`) stay bare, as in jest. Elements nested inside objects, arrays, props or other elements are unchanged.
- `toEqual` / `not.toEqual` failure output is unchanged: `DiffFormatter` already strips one leading and one trailing newline from the formatted values (it is how objects are handled), verified byte for byte against the released build.
- Snapshots that bun previously wrote for multi-line elements no longer match and need one `bun test -u`; afterwards the files are interchangeable with jest's. No `.snap` in this repo contained one. #38934 adds inline snapshots of multi-line elements in the bare form (`child elements serialize as JSX`); whichever of the two lands second needs those three expectations rewritten in the wrapped form.
- Tests, all in `test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts` (fail on the released build, pass with this change):
  - `JSX elements`: committed `.snap` entries and inline snapshots for an element with child elements, long text, an object prop (multi-line through props only), plus self-closing / string prop / short text (stay bare) and an element nested in an object (unchanged).
  - `inline snapshots > writes a multi-line JSX element indented like an object`: bun now writes the indented inline form and re-reads it, through the existing `InlineSnapshotTester`.
  - `a .snap of a multi-line JSX element written by jest matches`: a jest-format `.snap` passes under `bun test` and is left untouched.
- Also ran the whole `test/js/bun/test/snapshot-tests/` directory with the debug build: all pass.

### Background
- `src/runtime/test_runner/pretty_format.rs` is the serializer behind snapshot matchers and `expect` diffs (not `Bun.inspect`, which lives in `src/jsc/ConsoleObject.rs` and is unaffected). `Formatter::format` dispatches on a `Tag` to one arm of `print_as`; `indent` is 0 only for the top-level value, every container arm increments it before formatting its entries.
- jest-snapshot's `addExtraLineBreaks` surrounds a serialized value with `\n` when it contains a newline, so that multi-line values read naturally between the backticks of a `.snap` file or an inline snapshot. bun implements the same rule inside each arm; the inline snapshot writer relies on it to decide whether to indent, and `DiffFormatter` strips it again for `toEqual` output.
- A value is recognized as a React element when it has a `$$typeof` of `Symbol.for("react.element")` (React 18), so the tests build elements by hand instead of depending on the React version installed in `test/`.

<details>
<summary>Before / after on the released build</summary>

`.snap` written by bun for `<div>` with two children:

```
# before
exports[`children 1`] = `<div>
  <span />
  <b />
</div>`;

# after (identical to what jest writes)
exports[`children 1`] = `
<div>
  <span />
  <b />
</div>
`;
```

Inline snapshot written by bun:

```ts
// before
expect(el).toMatchInlineSnapshot(`<div>
  <span />
  <b />
</div>`);

// after
expect(el).toMatchInlineSnapshot(`
  <div>
    <span />
    <b />
  </div>
`);
```

jest-written `.snap` under the released build:

```
error: expect(received).toMatchSnapshot(expected)

-
  <ul>
    <li />
    <li />
- </ul>
-
+ </ul>

- Expected  - 3
+ Received  + 1
```
</details>
