### PR TITLE
bake: check for exceptions in the production build's module helpers

### DIFF
--- a/src/runtime/bake/BakeGlobalObject.cpp
+++ b/src/runtime/bake/BakeGlobalObject.cpp
@@ -29,8 +29,7 @@ bakeModuleLoaderImportModule(JSC::JSGlobalObject* global,
     WTF::String keyString = moduleNameValue->getString(global);
     RETURN_IF_EXCEPTION(scope, nullptr);
     if (keyString.startsWith("bake:/"_s)) {
-        RELEASE_AND_RETURN(scope, JSC::importModule(global, JSC::Identifier::fromString(vm, keyString),
-            JSC::Identifier(), WTF::move(parameters), nullptr));
+        RELEASE_AND_RETURN(scope, JSC::importModule(global, JSC::Identifier::fromString(vm, keyString), JSC::Identifier(), WTF::move(parameters), nullptr));
     }
 
     if (!sourceOrigin.isNull() && sourceOrigin.string().startsWith("bake:/"_s)) {
@@ -46,8 +45,7 @@ bakeModuleLoaderImportModule(JSC::JSGlobalObject* global,
         BunString result = BakeProdResolve(global, Bun::toString(refererString), Bun::toString(keyString));
         RETURN_IF_EXCEPTION(scope, nullptr);
 
-        RELEASE_AND_RETURN(scope, JSC::importModule(global, JSC::Identifier::fromString(vm, result.toWTFString()),
-            JSC::Identifier(), WTF::move(parameters), nullptr));
+        RELEASE_AND_RETURN(scope, JSC::importModule(global, JSC::Identifier::fromString(vm, result.toWTFString()), JSC::Identifier(), WTF::move(parameters), nullptr));
     }
 
     // TODO: make static cast instead of jscast

--- a/src/runtime/bake/BakeGlobalObject.cpp
+++ b/src/runtime/bake/BakeGlobalObject.cpp
@@ -78,7 +78,7 @@ JSC::Identifier bakeModuleLoaderResolve(JSC::JSGlobalObject* jsGlobal,
         }
     }
 
-    return Zig::GlobalObject::moduleLoaderResolve(jsGlobal, loader, key, referrer, WTF::move(origin), useImportMap);
+    RELEASE_AND_RETURN(scope, Zig::GlobalObject::moduleLoaderResolve(jsGlobal, loader, key, referrer, WTF::move(origin), useImportMap));
 }
 
 static JSC::JSPromise* rejectedInternalPromise(JSC::JSGlobalObject* globalObject, JSC::JSValue value)
@@ -154,7 +154,7 @@ JSC::JSPromise* bakeModuleLoaderFetch(JSC::JSGlobalObject* globalObject,
 #endif
             JSString* bakePrefixRemovedString = jsNontrivialString(vm, bakePrefixRemoved);
             JSValue bakePrefixRemovedJsvalue = bakePrefixRemovedString;
-            return Zig::GlobalObject::moduleLoaderFetch(globalObject, loader, bakePrefixRemovedJsvalue, WTF::move(parameters), WTF::move(script));
+            RELEASE_AND_RETURN(scope, Zig::GlobalObject::moduleLoaderFetch(globalObject, loader, bakePrefixRemovedJsvalue, WTF::move(parameters), WTF::move(script)));
         }
         return rejectedInternalPromise(globalObject, createTypeError(globalObject, "BakeGlobalObject does not have per-thread data configured"_s));
     }

--- a/src/runtime/bake/BakeGlobalObject.cpp
+++ b/src/runtime/bake/BakeGlobalObject.cpp
@@ -22,35 +22,36 @@ bakeModuleLoaderImportModule(JSC::JSGlobalObject* global,
     bool deferred)
 {
     UNUSED_PARAM(deferred);
+    auto& vm = JSC::getVM(global);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    // Returning nullptr with an exception pending is fine: globalFuncImportModule rejects the import() promise with it.
     WTF::String keyString = moduleNameValue->getString(global);
+    RETURN_IF_EXCEPTION(scope, nullptr);
     if (keyString.startsWith("bake:/"_s)) {
-        auto& vm = JSC::getVM(global);
-        return JSC::importModule(global, JSC::Identifier::fromString(vm, keyString),
-            JSC::Identifier(), WTF::move(parameters), nullptr);
+        RELEASE_AND_RETURN(scope, JSC::importModule(global, JSC::Identifier::fromString(vm, keyString),
+            JSC::Identifier(), WTF::move(parameters), nullptr));
     }
 
     if (!sourceOrigin.isNull() && sourceOrigin.string().startsWith("bake:/"_s)) {
-        auto& vm = JSC::getVM(global);
-        auto scope = DECLARE_THROW_SCOPE(vm);
-
         WTF::String refererString = sourceOrigin.string();
-        WTF::String keyString = moduleNameValue->getString(global);
 
         if (!keyString) {
             auto promise = JSC::JSPromise::create(vm, global->promiseStructure());
             promise->reject(vm, JSC::createError(global, "import() requires a string"_s));
+            RETURN_IF_EXCEPTION(scope, nullptr);
             return promise;
         }
 
         BunString result = BakeProdResolve(global, Bun::toString(refererString), Bun::toString(keyString));
         RETURN_IF_EXCEPTION(scope, nullptr);
 
-        return JSC::importModule(global, JSC::Identifier::fromString(vm, result.toWTFString()),
-            JSC::Identifier(), WTF::move(parameters), nullptr);
+        RELEASE_AND_RETURN(scope, JSC::importModule(global, JSC::Identifier::fromString(vm, result.toWTFString()),
+            JSC::Identifier(), WTF::move(parameters), nullptr));
     }
 
     // TODO: make static cast instead of jscast
-    return uncheckedDowncast<Zig::GlobalObject>(global)->moduleLoaderImportModule(global, moduleLoader, moduleNameValue, WTF::move(parameters), sourceOrigin, false);
+    RELEASE_AND_RETURN(scope, uncheckedDowncast<Zig::GlobalObject>(global)->moduleLoaderImportModule(global, moduleLoader, moduleNameValue, WTF::move(parameters), sourceOrigin, false));
 }
 
 JSC::Identifier bakeModuleLoaderResolve(JSC::JSGlobalObject* jsGlobal,

--- a/src/runtime/bake/BakeGlobalObject.cpp
+++ b/src/runtime/bake/BakeGlobalObject.cpp
@@ -34,14 +34,6 @@ bakeModuleLoaderImportModule(JSC::JSGlobalObject* global,
 
     if (!sourceOrigin.isNull() && sourceOrigin.string().startsWith("bake:/"_s)) {
         WTF::String refererString = sourceOrigin.string();
-
-        if (!keyString) {
-            auto promise = JSC::JSPromise::create(vm, global->promiseStructure());
-            promise->reject(vm, JSC::createError(global, "import() requires a string"_s));
-            RETURN_IF_EXCEPTION(scope, nullptr);
-            return promise;
-        }
-
         BunString result = BakeProdResolve(global, Bun::toString(refererString), Bun::toString(keyString));
         RETURN_IF_EXCEPTION(scope, nullptr);
 

--- a/src/runtime/bake/BakeSourceProvider.cpp
+++ b/src/runtime/bake/BakeSourceProvider.cpp
@@ -182,26 +182,4 @@ extern "C" JSC::EncodedJSValue BakeGetOnModuleNamespace(
   return JSC::JSValue::encode(value);
 }
 
-extern "C" JSC::EncodedJSValue BakeRegisterProductionChunk(JSC::JSGlobalObject* global, BunString virtualPathName, BunString source) {
-  auto& vm = JSC::getVM(global);
-  auto scope = DECLARE_THROW_SCOPE(vm);
-
-  String string = virtualPathName.toWTFString();
-  JSC::JSString* key = JSC::jsString(vm, string);
-  JSC::SourceOrigin origin = JSC::SourceOrigin(WTF::URL(string));
-  JSC::SourceCode sourceCode = JSC::SourceCode(SourceProvider::create(
-    global,
-    source.toWTFString(),
-    origin,
-    WTF::move(string),
-    WTF::TextPosition(),
-    JSC::SourceProviderSourceType::Module
-  ));
-
-  global->moduleLoader()->provideFetch(global, JSC::Identifier::fromString(vm, key->getString(global)), JSC::ScriptFetchParameters::Type::JavaScript, WTF::move(sourceCode));
-  RETURN_IF_EXCEPTION(scope, {});
-
-  return JSC::JSValue::encode(key);
-}
-
 } // namespace Bake

--- a/src/runtime/bake/BakeSourceProvider.cpp
+++ b/src/runtime/bake/BakeSourceProvider.cpp
@@ -24,6 +24,8 @@ extern "C" BunString BakeSourceProvider__getSourceSlice(SourceProvider* provider
     return Bun::toStringView(provider->source());
 }
 
+// Rust calls the EncodedJSValue-returning functions below via `jsc::from_js_host_call`: empty return <=> exception pending.
+
 extern "C" JSC::EncodedJSValue BakeLoadInitialServerCode(JSC::JSGlobalObject* global, BunString source, bool separateSSRGraph) {
   auto& vm = JSC::getVM(global);
   auto scope = DECLARE_THROW_SCOPE(vm);
@@ -51,11 +53,24 @@ extern "C" JSC::EncodedJSValue BakeLoadInitialServerCode(JSC::JSGlobalObject* gl
   args.append(JSC::jsBoolean(separateSSRGraph)); // separateSSRGraph
   args.append(Zig::ImportMetaObject::create(global, "bake://server-runtime.js"_s)); // importMeta
 
-  RELEASE_AND_RETURN(scope, JSC::JSValue::encode(JSC::profiledCall(global, JSC::ProfilingReason::API, fn, callData, JSC::jsUndefined(), args)));
+  // `JSC::call` returns undefined (not empty) when the callee throws.
+  JSC::JSValue result = JSC::profiledCall(global, JSC::ProfilingReason::API, fn, callData, JSC::jsUndefined(), args);
+  RETURN_IF_EXCEPTION(scope, {});
+  return JSC::JSValue::encode(result);
 }
 
-extern "C" JSC::JSPromise* BakeLoadModuleByKey(GlobalObject* global, JSC::JSString* key) {
-  return JSC::loadAndEvaluateModule(global, key->getString(global), nullptr, nullptr);
+extern "C" JSC::EncodedJSValue BakeLoadModuleByKey(GlobalObject* global, JSC::EncodedJSValue keyValue) {
+  auto& vm = JSC::getVM(global);
+  auto scope = DECLARE_THROW_SCOPE(vm);
+
+  JSC::JSString* key = uncheckedDowncast<JSC::JSString>(JSC::JSValue::decode(keyValue));
+  String keyString = key->getString(global);
+  RETURN_IF_EXCEPTION(scope, {});
+
+  JSC::JSPromise* promise = JSC::loadAndEvaluateModule(global, keyString, nullptr, nullptr);
+  RETURN_IF_EXCEPTION(scope, {});
+  ASSERT(promise);
+  return JSC::JSValue::encode(promise);
 }
 
 extern "C" JSC::EncodedJSValue BakeLoadServerHmrPatch(GlobalObject* global, BunString source) {
@@ -108,42 +123,63 @@ extern "C" JSC::EncodedJSValue BakeLoadServerHmrPatchWithSourceMap(GlobalObject*
   return JSC::JSValue::encode(result);
 }
 
-extern "C" JSC::EncodedJSValue BakeGetModuleNamespace(
-  JSC::JSGlobalObject* global,
-  JSC::JSValue keyValue
-) {
-  JSC::JSString* key = uncheckedDowncast<JSC::JSString>(keyValue);
+// Returns nullptr if and only if an exception is pending.
+static JSC::JSModuleNamespaceObject* getModuleNamespace(JSC::JSGlobalObject* global, JSC::JSValue keyValue) {
   auto& vm = JSC::getVM(global);
+  auto scope = DECLARE_THROW_SCOPE(vm);
+
+  JSC::JSString* key = uncheckedDowncast<JSC::JSString>(keyValue);
   auto keyIdent = JSC::Identifier::fromString(vm, key->value(global));
+  RETURN_IF_EXCEPTION(scope, nullptr);
+
   auto* entry = global->moduleLoader()->registryEntry(keyIdent);
-  ASSERT(entry); // should have called BakeLoadServerCode and wait for that promise
+  ASSERT(entry); // should have called BakeLoadModuleByKey and waited for that promise
   auto* module = entry ? entry->record() : nullptr;
   ASSERT(module);
   JSC::JSModuleNamespaceObject* namespaceObject = global->moduleLoader()->getModuleNamespaceObject(global, module);
+  RETURN_IF_EXCEPTION(scope, nullptr);
   ASSERT(namespaceObject);
-  return JSC::JSValue::encode(namespaceObject);
+  return namespaceObject;
+}
+
+extern "C" JSC::EncodedJSValue BakeGetModuleNamespace(
+  JSC::JSGlobalObject* global,
+  JSC::EncodedJSValue keyValue
+) {
+  return JSC::JSValue::encode(getModuleNamespace(global, JSC::JSValue::decode(keyValue)));
 }
 
 extern "C" JSC::EncodedJSValue BakeGetDefaultExportFromModule(
   JSC::JSGlobalObject* global,
-  JSC::JSValue keyValue
+  JSC::EncodedJSValue keyValue
 ) {
   auto& vm = JSC::getVM(global);
-  return JSC::JSValue::encode(uncheckedDowncast<JSC::JSModuleNamespaceObject>(JSC::JSValue::decode(BakeGetModuleNamespace(global, keyValue)))->get(global, vm.propertyNames->defaultKeyword));
+  auto scope = DECLARE_THROW_SCOPE(vm);
+
+  JSC::JSModuleNamespaceObject* namespaceObject = getModuleNamespace(global, JSC::JSValue::decode(keyValue));
+  RETURN_IF_EXCEPTION(scope, {});
+
+  JSC::JSValue defaultExport = namespaceObject->get(global, vm.propertyNames->defaultKeyword);
+  RETURN_IF_EXCEPTION(scope, {});
+  return JSC::JSValue::encode(defaultExport);
 }
 
-// There were issues when trying to use JSValue.get from zig
 extern "C" JSC::EncodedJSValue BakeGetOnModuleNamespace(
   JSC::JSGlobalObject* global,
-  JSC::JSModuleNamespaceObject* moduleNamespace,
+  JSC::EncodedJSValue moduleNamespaceValue,
   const unsigned char* key,
   size_t keyLength
 ) {
   auto& vm = JSC::getVM(global);
+  auto scope = DECLARE_THROW_SCOPE(vm);
+
+  auto* moduleNamespace = uncheckedDowncast<JSC::JSModuleNamespaceObject>(JSC::JSValue::decode(moduleNamespaceValue));
   const auto propertyString = String(StringImpl::createWithoutCopying({ key, keyLength }));
   const auto identifier = JSC::Identifier::fromString(vm, propertyString);
   const auto property = JSC::PropertyName(identifier);
-  return JSC::JSValue::encode(moduleNamespace->get(global, property));
+  JSC::JSValue value = moduleNamespace->get(global, property);
+  RETURN_IF_EXCEPTION(scope, {});
+  return JSC::JSValue::encode(value);
 }
 
 extern "C" JSC::EncodedJSValue BakeRegisterProductionChunk(JSC::JSGlobalObject* global, BunString virtualPathName, BunString source) {

--- a/src/runtime/bake/BakeSourceProvider.cpp
+++ b/src/runtime/bake/BakeSourceProvider.cpp
@@ -123,7 +123,7 @@ extern "C" JSC::EncodedJSValue BakeLoadServerHmrPatchWithSourceMap(GlobalObject*
   return JSC::JSValue::encode(result);
 }
 
-// Returns nullptr if and only if an exception is pending.
+// keyValue must name a module that has already been evaluated; then nullptr means an exception is pending.
 static JSC::JSModuleNamespaceObject* getModuleNamespace(JSC::JSGlobalObject* global, JSC::JSValue keyValue) {
   auto& vm = JSC::getVM(global);
   auto scope = DECLARE_THROW_SCOPE(vm);
@@ -133,7 +133,7 @@ static JSC::JSModuleNamespaceObject* getModuleNamespace(JSC::JSGlobalObject* glo
   RETURN_IF_EXCEPTION(scope, nullptr);
 
   auto* entry = global->moduleLoader()->registryEntry(keyIdent);
-  ASSERT(entry); // should have called BakeLoadModuleByKey and waited for that promise
+  ASSERT(entry); // the caller waited for this module's evaluation promise
   auto* module = entry ? entry->record() : nullptr;
   ASSERT(module);
   JSC::JSModuleNamespaceObject* namespaceObject = global->moduleLoader()->getModuleNamespaceObject(global, module);

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -1240,66 +1240,53 @@ fn load_module(
     }
 }
 
-/// BakeSourceProvider.cpp entry points; each returns empty iff it threw, as
-/// `from_js_host_call` requires.
+/// BakeSourceProvider.cpp entry points; each returns empty iff it threw (`from_js_host_call`).
 mod c {
     use super::*;
 
-    /// Returns the promise for loading and evaluating the module named by the `key` JSString.
+    unsafe extern "C" {
+        safe fn BakeLoadModuleByKey(global: &JSGlobalObject, key: JSValue) -> JSValue;
+        safe fn BakeGetModuleNamespace(global: &JSGlobalObject, key: JSValue) -> JSValue;
+        safe fn BakeGetDefaultExportFromModule(global: &JSGlobalObject, key: JSValue) -> JSValue;
+        /// Not `safe`: `ptr` must be readable for `len` bytes.
+        fn BakeGetOnModuleNamespace(
+            global: &JSGlobalObject,
+            module_namespace: JSValue,
+            ptr: *const u8,
+            len: usize,
+        ) -> JSValue;
+    }
+
+    /// Returns the promise for evaluating the module that `key` (a JSString) names.
     pub(super) fn bake_load_module_by_key(
         global: &JSGlobalObject,
         key: JSValue,
     ) -> JsResult<JSValue> {
-        unsafe extern "C" {
-            safe fn BakeLoadModuleByKey(global: &JSGlobalObject, key: JSValue) -> JSValue;
-        }
         jsc::from_js_host_call(global, || BakeLoadModuleByKey(global, key))
     }
 
-    /// The module's promise from [`bake_load_module_by_key`] must already be fulfilled.
+    /// The promise from [`bake_load_module_by_key`] for `key` must already be fulfilled.
     pub(super) fn bake_get_module_namespace(
         global: &JSGlobalObject,
         key: JSValue,
     ) -> JsResult<JSValue> {
-        unsafe extern "C" {
-            safe fn BakeGetModuleNamespace(global: &JSGlobalObject, key: JSValue) -> JSValue;
-        }
         jsc::from_js_host_call(global, || BakeGetModuleNamespace(global, key))
     }
 
-    /// The module's evaluation promise must already be fulfilled.
+    /// The module `key` names must already be evaluated (here: the config module).
     pub(super) fn bake_get_default_export_from_module(
         global: &JSGlobalObject,
         key: JSValue,
     ) -> JsResult<JSValue> {
-        unsafe extern "C" {
-            safe fn BakeGetDefaultExportFromModule(
-                global: &JSGlobalObject,
-                key: JSValue,
-            ) -> JSValue;
-        }
         jsc::from_js_host_call(global, || BakeGetDefaultExportFromModule(global, key))
     }
 
-    /// `module_namespace` comes from [`bake_get_module_namespace`].
     pub(super) fn bake_get_on_module_namespace(
         global: &JSGlobalObject,
         module_namespace: JSValue,
         property: &[u8],
     ) -> JsResult<JSValue> {
-        unsafe extern "C" {
-            // PRECONDITION: `ptr` must be readable for `len` bytes (C++ builds an
-            // `Identifier` from the slice). Cannot be `safe fn` — raw ptr+len pair
-            // carries a caller-side validity precondition.
-            fn BakeGetOnModuleNamespace(
-                global: &JSGlobalObject,
-                module_namespace: JSValue,
-                ptr: *const u8,
-                len: usize,
-            ) -> JSValue;
-        }
-        // SAFETY: `property.as_ptr()`/`len()` describe a borrowed `&[u8]` that
-        // outlives the call, which discharges the ptr+len precondition above.
+        // SAFETY: `property` is borrowed for the whole call, so `ptr` is readable for `len` bytes.
         jsc::from_js_host_call(global, || unsafe {
             BakeGetOnModuleNamespace(global, module_namespace, property.as_ptr(), property.len())
         })

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -355,10 +355,11 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
     {
         Unwrapped::Pending => unreachable!(),
         Unwrapped::Fulfilled(_) => {
-            let default = BakeGetDefaultExportFromModule(
+            let default = c::bake_get_default_export_from_module(
                 global,
                 config_entry_point_string.to_js(global).map_err(js_err)?,
-            );
+            )
+            .map_err(js_err)?;
 
             if !default.is_object() {
                 return Err(js_err(global.throw_invalid_arguments(format_args!(
@@ -843,17 +844,10 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
 
         let server_file = router_type.server_file;
         let server_entry_point = pt.load_bundled_module(server_file)?;
-        let server_render_func = 'brk: {
-            let Some(raw) = bake_get_on_module_namespace(global, server_entry_point, b"prerender")
-            else {
-                break 'brk None;
-            };
-            if !raw.is_callable() {
-                break 'brk None;
-            }
-            break 'brk Some(raw);
-        };
-        let Some(server_render_func) = server_render_func else {
+        let server_render_func =
+            c::bake_get_on_module_namespace(global, server_entry_point, b"prerender")
+                .map_err(js_err)?;
+        if !server_render_func.is_callable() {
             bun_core::err_generic!("Framework does not support static site generation");
             bun_core::note!(
                 "The file {} is missing the \"prerender\" export, which defines how to generate static files.",
@@ -863,34 +857,23 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
                 ))
             );
             Global::crash();
-        };
+        }
 
         let server_param_func = if router.dynamic_routes.count() > 0 {
-            let f = 'brk: {
-                let Some(raw) =
-                    bake_get_on_module_namespace(global, server_entry_point, b"getParams")
-                else {
-                    break 'brk None;
-                };
-                if !raw.is_callable() {
-                    break 'brk None;
-                }
-                break 'brk Some(raw);
-            };
-            match f {
-                Some(f) => f,
-                None => {
-                    bun_core::err_generic!("Framework does not support static site generation");
-                    bun_core::note!(
-                        "The file {} is missing the \"getParams\" export, which defines how to generate static files.",
-                        bun_core::fmt::quote(resolve_path::relative(
-                            cwd,
-                            pt.input_file(server_file).abs_path()
-                        ))
-                    );
-                    Global::crash();
-                }
+            let f = c::bake_get_on_module_namespace(global, server_entry_point, b"getParams")
+                .map_err(js_err)?;
+            if !f.is_callable() {
+                bun_core::err_generic!("Framework does not support static site generation");
+                bun_core::note!(
+                    "The file {} is missing the \"getParams\" export, which defines how to generate static files.",
+                    bun_core::fmt::quote(resolve_path::relative(
+                        cwd,
+                        pt.input_file(server_file).abs_path()
+                    ))
+                );
+                Global::crash();
             }
+            f
         } else {
             JSValue::NULL
         };
@@ -1225,7 +1208,7 @@ fn load_module(
     global: &JSGlobalObject,
     key: JSValue,
 ) -> crate::Result<JSValue> {
-    let promise_value = BakeLoadModuleByKey(global, key);
+    let promise_value = c::bake_load_module_by_key(global, key).map_err(js_err)?;
     let promise: *mut jsc::JSInternalPromise = match promise_value.as_any_promise().unwrap() {
         AnyPromise::Internal(p) => p,
         AnyPromise::Normal(_) => unreachable!(),
@@ -1252,38 +1235,75 @@ fn load_module(
     let jsc_vm = vm_ref.as_mut().jsc_vm_mut();
     match jsc::JSInternalPromise::opaque_mut(promise).unwrap(jsc_vm, UnwrapMode::MarkHandled) {
         Unwrapped::Pending => unreachable!(),
-        Unwrapped::Fulfilled(_) => Ok(BakeGetModuleNamespace(global, key)),
+        Unwrapped::Fulfilled(_) => c::bake_get_module_namespace(global, key).map_err(js_err),
         Unwrapped::Rejected(err) => Err(js_err(vm_ref.global().throw_value(err))),
     }
 }
 
-// extern apis:
+/// BakeSourceProvider.cpp entry points; each returns empty iff it threw, as
+/// `from_js_host_call` requires.
+mod c {
+    use super::*;
 
-unsafe extern "C" {
-    safe fn BakeGetDefaultExportFromModule(global: &JSGlobalObject, key: JSValue) -> JSValue;
-    safe fn BakeGetModuleNamespace(global: &JSGlobalObject, key: JSValue) -> JSValue;
-    safe fn BakeLoadModuleByKey(global: &JSGlobalObject, key: JSValue) -> JSValue;
-}
-
-fn bake_get_on_module_namespace(
-    global: &JSGlobalObject,
-    module: JSValue,
-    property: &[u8],
-) -> Option<JSValue> {
-    unsafe extern "C" {
-        // PRECONDITION: `ptr` must be readable for `len` bytes (C++ builds an
-        // `Identifier` from the slice). Cannot be `safe fn` — raw ptr+len pair
-        // carries a caller-side validity precondition.
-        #[link_name = "BakeGetOnModuleNamespace"]
-        fn f(global: *const JSGlobalObject, module: JSValue, ptr: *const u8, len: usize)
-        -> JSValue;
+    /// Returns the promise for loading and evaluating the module named by the `key` JSString.
+    pub(super) fn bake_load_module_by_key(
+        global: &JSGlobalObject,
+        key: JSValue,
+    ) -> JsResult<JSValue> {
+        unsafe extern "C" {
+            safe fn BakeLoadModuleByKey(global: &JSGlobalObject, key: JSValue) -> JSValue;
+        }
+        jsc::from_js_host_call(global, || BakeLoadModuleByKey(global, key))
     }
-    // SAFETY: `global` is a live `&JSGlobalObject`, `module` is a stack-held
-    // `JSValue`, and `property.as_ptr()`/`len()` describe a valid borrowed
-    // `&[u8]` for the call duration — discharges the ptr+len precondition above.
-    let result: JSValue = unsafe { f(global, module, property.as_ptr(), property.len()) };
-    debug_assert!(!result.is_empty());
-    Some(result)
+
+    /// The module's promise from [`bake_load_module_by_key`] must already be fulfilled.
+    pub(super) fn bake_get_module_namespace(
+        global: &JSGlobalObject,
+        key: JSValue,
+    ) -> JsResult<JSValue> {
+        unsafe extern "C" {
+            safe fn BakeGetModuleNamespace(global: &JSGlobalObject, key: JSValue) -> JSValue;
+        }
+        jsc::from_js_host_call(global, || BakeGetModuleNamespace(global, key))
+    }
+
+    /// The module's evaluation promise must already be fulfilled.
+    pub(super) fn bake_get_default_export_from_module(
+        global: &JSGlobalObject,
+        key: JSValue,
+    ) -> JsResult<JSValue> {
+        unsafe extern "C" {
+            safe fn BakeGetDefaultExportFromModule(
+                global: &JSGlobalObject,
+                key: JSValue,
+            ) -> JSValue;
+        }
+        jsc::from_js_host_call(global, || BakeGetDefaultExportFromModule(global, key))
+    }
+
+    /// `module_namespace` comes from [`bake_get_module_namespace`].
+    pub(super) fn bake_get_on_module_namespace(
+        global: &JSGlobalObject,
+        module_namespace: JSValue,
+        property: &[u8],
+    ) -> JsResult<JSValue> {
+        unsafe extern "C" {
+            // PRECONDITION: `ptr` must be readable for `len` bytes (C++ builds an
+            // `Identifier` from the slice). Cannot be `safe fn` — raw ptr+len pair
+            // carries a caller-side validity precondition.
+            fn BakeGetOnModuleNamespace(
+                global: &JSGlobalObject,
+                module_namespace: JSValue,
+                ptr: *const u8,
+                len: usize,
+            ) -> JSValue;
+        }
+        // SAFETY: `property.as_ptr()`/`len()` describe a borrowed `&[u8]` that
+        // outlives the call, which discharges the ptr+len precondition above.
+        jsc::from_js_host_call(global, || unsafe {
+            BakeGetOnModuleNamespace(global, module_namespace, property.as_ptr(), property.len())
+        })
+    }
 }
 
 // Renders all routes for static site generation by calling the JavaScript implementation.

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { existsSync } from "fs";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import path from "path";
 import { tempDirWithBakeDeps } from "../bake-harness";
 
@@ -593,5 +593,98 @@ export default function IndexPage() {
 
     // Verify NO JavaScript imports are included in the HTML
     expect(htmlContent).not.toContain('<script type="module"');
+  });
+
+  // BUN_JSC_validateExceptionChecks=1 aborts the child on the first JSC call whose
+  // exception state goes unchecked. Debug and ASAN builds enforce it; release builds
+  // ignore the option, so there these only check that the build succeeds.
+  describe("exception checks", () => {
+    async function buildApp(cwd: string, ...args: string[]) {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build", "--app", ...args],
+        cwd,
+        env: { ...bunEnv, BUN_JSC_validateExceptionChecks: "1", BUN_JSC_dumpSimulatedThrows: "1" },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      // The validator's report names the scope that can throw and the scope that failed to
+      // check it; surfacing those two lines makes a failure point at the offending call.
+      const uncheckedScopes = stderr
+        .split("\n")
+        .map(line => line.trim())
+        .filter(line => line.startsWith("This scope can throw") || line.startsWith("But the exception was unchecked"));
+      return { stdout, exitCode, signalCode: proc.signalCode, uncheckedScopes };
+    }
+
+    test("loading the config file", async () => {
+      // No routes directory, so the build stops after reading the config's default export
+      // (BakeGetDefaultExportFromModule) and bundles nothing.
+      using dir = tempDir("bake-production-validate-config", {
+        "bun.app.ts": `export default {
+          app: {
+            framework: {
+              fileSystemRouterTypes: [{ root: "routes", style: "nextjs-pages", serverEntryPoint: "./server.ts" }],
+            },
+          },
+        };`,
+        "server.ts": `export function render() { return new Response("unused"); }`,
+      });
+
+      const { stdout, exitCode, signalCode, uncheckedScopes } = await buildApp(String(dir));
+      expect({ stdout, exitCode, signalCode, uncheckedScopes }).toEqual({
+        stdout: "done\n",
+        exitCode: 0,
+        signalCode: null,
+        uncheckedScopes: [],
+      });
+    });
+
+    test("loading the server entry point and prerendering routes", async () => {
+      // Reaches the rest of the production path: the server entry point is loaded
+      // (BakeLoadModuleByKey, BakeGetModuleNamespace), its prerender and getParams
+      // exports are read (BakeGetOnModuleNamespace), and rendering import()s the
+      // bundled modules through Bake::GlobalObject's module loader hooks. The client
+      // component matters: server-side rendering it is what makes a bundled "bake:/"
+      // module itself call import(), the hook's second branch.
+      const dir = await tempDirWithBakeDeps("bake-production-validate-prerender", {
+        "src/index.tsx": `export default { app: { framework: "react" } };`,
+        "pages/index.tsx": `import Greeting from "../components/Greeting";
+
+export default function IndexPage() {
+  return (
+    <main>
+      <h1>Static Home</h1>
+      <Greeting />
+    </main>
+  );
+}`,
+        "components/Greeting.tsx": `"use client";
+
+export default function Greeting() {
+  return <p>Hello from the client</p>;
+}`,
+        "pages/posts/[slug].tsx": `export default function Post({ params }) {
+  return <h1>{"Post " + params.slug}</h1>;
+}
+
+export function getStaticPaths() {
+  return { paths: [{ params: { slug: "first" } }, { params: { slug: "second" } }], fallback: false };
+}`,
+      });
+
+      const { exitCode, signalCode, uncheckedScopes } = await buildApp(dir, "./src/index.tsx");
+      expect({ exitCode, signalCode, uncheckedScopes }).toEqual({ exitCode: 0, signalCode: null, uncheckedScopes: [] });
+
+      const rendered = await Promise.all(
+        ["index.html", "posts/first/index.html", "posts/second/index.html"].map(file =>
+          Bun.file(path.join(dir, "dist", file)).text(),
+        ),
+      );
+      expect(rendered[0]).toContain("<h1>Static Home</h1>");
+      expect(rendered[0]).toContain("<p>Hello from the client</p>");
+      expect(rendered[1]).toContain("<h1>Post first</h1>");
+      expect(rendered[2]).toContain("<h1>Post second</h1>");
+    });
   });
 });

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -598,7 +598,7 @@ export default function IndexPage() {
   // BUN_JSC_validateExceptionChecks=1 aborts the child on the first JSC call whose
   // exception state goes unchecked. Debug and ASAN builds enforce it; release builds
   // ignore the option, so there these only check that the build succeeds.
-  describe("exception checks", () => {
+  describe.concurrent("exception checks", () => {
     async function buildApp(cwd: string, ...args: string[]) {
       await using proc = Bun.spawn({
         cmd: [bunExe(), "build", "--app", ...args],
@@ -614,7 +614,7 @@ export default function IndexPage() {
         .split("\n")
         .map(line => line.trim())
         .filter(line => line.startsWith("This scope can throw") || line.startsWith("But the exception was unchecked"));
-      return { stdout, exitCode, signalCode: proc.signalCode, uncheckedScopes };
+      return { stdout, stderr, exitCode, signalCode: proc.signalCode, uncheckedScopes };
     }
 
     test("loading the config file", async () => {
@@ -685,6 +685,41 @@ export function getStaticPaths() {
       expect(rendered[0]).toContain("<p>Hello from the client</p>");
       expect(rendered[1]).toContain("<h1>Post first</h1>");
       expect(rendered[2]).toContain("<h1>Post second</h1>");
+    });
+
+    test("a config import that fails to resolve", async () => {
+      // Resolving the config's imports goes through Bake::GlobalObject's resolve hook; a
+      // specifier it cannot resolve falls through to the regular resolver, which throws.
+      using dir = tempDir("bake-production-validate-unresolved", {
+        "bun.app.ts": `import "./does-not-exist";
+          export default { app: { framework: "react" } };`,
+      });
+
+      const { stderr, exitCode, signalCode, uncheckedScopes } = await buildApp(String(dir));
+      expect({ exitCode, signalCode, uncheckedScopes }).toEqual({ exitCode: 1, signalCode: null, uncheckedScopes: [] });
+      expect(stderr).toContain("Cannot find module './does-not-exist'");
+    });
+
+    test("a route importing a file outside the bundle while rendering", async () => {
+      // import() of a path the bundler never saw is resolved to a "bake:/" key that is not
+      // in the output map, so the fetch hook hands it to the regular loader to read from disk.
+      const dir = await tempDirWithBakeDeps("bake-production-validate-disk-import", {
+        "src/index.tsx": `export default { app: { framework: "react" } };`,
+        "extra/banner.mjs": `export const banner = "read from disk while rendering";`,
+        "pages/index.tsx": `import { join } from "node:path";
+
+export default async function IndexPage() {
+  // A computed specifier, so the bundler leaves this import() for the runtime.
+  const { banner } = await import(join(import.meta.dir, "../extra/banner.mjs"));
+  return <p>{banner}</p>;
+}`,
+      });
+
+      const { exitCode, signalCode, uncheckedScopes } = await buildApp(dir, "./src/index.tsx");
+      expect({ exitCode, signalCode, uncheckedScopes }).toEqual({ exitCode: 0, signalCode: null, uncheckedScopes: [] });
+      expect(await Bun.file(path.join(dir, "dist", "index.html")).text()).toContain(
+        "<p>read from disk while rendering</p>",
+      );
     });
   });
 });

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { existsSync } from "fs";
-import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, normalizeBunSnapshot, tempDir } from "harness";
 import path from "path";
 import { tempDirWithBakeDeps } from "../bake-harness";
 
@@ -700,7 +700,10 @@ export function getStaticPaths() {
       expect(stderr).toContain("Cannot find module './does-not-exist'");
     });
 
-    test("a route importing a file outside the bundle while rendering", async () => {
+    // On Windows this import() currently fails before reaching the loader (the build exits 1
+    // with `EINVAL reading "\\"`: the drive path gets joined as if it were relative), with or
+    // without the exception checks this test is about. Tracked separately.
+    test.skipIf(isWindows)("a route importing a file outside the bundle while rendering", async () => {
       // import() of a path the bundler never saw is resolved to a "bake:/" key that is not
       // in the output map, so the fetch hook hands it to the regular loader to read from disk.
       const dir = await tempDirWithBakeDeps("bake-production-validate-disk-import", {

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { existsSync } from "fs";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 import path from "path";
 import { tempDirWithBakeDeps } from "../bake-harness";
 
@@ -632,8 +632,8 @@ export default function IndexPage() {
       });
 
       const { stdout, exitCode, signalCode, uncheckedScopes } = await buildApp(String(dir));
-      expect({ stdout, exitCode, signalCode, uncheckedScopes }).toEqual({
-        stdout: "done\n",
+      expect({ stdout: normalizeBunSnapshot(stdout), exitCode, signalCode, uncheckedScopes }).toEqual({
+        stdout: "done",
         exitCode: 0,
         signalCode: null,
         uncheckedScopes: [],

--- a/test/no-validate-exceptions.txt
+++ b/test/no-validate-exceptions.txt
@@ -1,7 +1,6 @@
 # List of tests for which we do NOT set validateExceptionChecks=1 when running in ASAN CI
 
 # List of tests that potentially throw inside of reifyStaticProperties
-test/bake/dev/production.test.ts
 test/cli/install/bun-install-lifecycle-scripts.test.ts
 test/integration/vite-build/vite-build.test.ts
 test/js/bun/resolve/import-meta.test.js


### PR DESCRIPTION
### Problem
- Every `bun build --app` run, with a valid config, aborts under `BUN_JSC_validateExceptionChecks=1` right after "Loading configuration":
  ```
  ERROR: Unchecked JS exception:
      This scope can throw a JS exception: getModuleNamespaceObject @ JSModuleLoader.cpp:572
      But the exception was unchecked as of this scope: get @ JSObjectInlines.h:133
  ASSERTION FAILED: exception check validation failed
  ```
- Cause: `BakeGetDefaultExportFromModule` (src/runtime/bake/BakeSourceProvider.cpp) calls `getModuleNamespaceObject()` and then `JSObject::get()` with no throw scope and no exception check in between. `BakeGetModuleNamespace`, `BakeGetOnModuleNamespace` and `BakeLoadModuleByKey` have the same shape (a throwing JSC call, no scope, no check), and their callers in src/runtime/bake/production.rs used the returned value without checking for a pending exception either.
- Once that is fixed, a build whose bundled modules call `import()` (any page rendering a `"use client"` component) aborts the same way in `bakeModuleLoaderImportModule` (src/runtime/bake/BakeGlobalObject.cpp): it returns `JSC::importModule(...)` from inside a throw scope it never releases. The other two hooks in that file have the same shape where they hand off to `Zig::GlobalObject`'s implementation: `bakeModuleLoaderResolve` aborts when a config import fails to resolve (instead of printing "Cannot find module"), and `bakeModuleLoaderFetch` aborts when a route `import()`s a file the bundler never saw (the escape hatch its own comment documents).
- `BakeLoadInitialServerCode` (same file, dev server) returns whatever the runtime's init function returned even when it threw. `JSC::call` returns `undefined` in that case, so the Rust caller (`DevServer::init_server_runtime`), which treats an empty return as "threw", never reaches its error-reporting branch and instead panics on "expected interface ... to be an object" with the real error left unprinted.
- The only test running `bun build --app`, test/bake/dev/production.test.ts, is on test/no-validate-exceptions.txt, which is why the ASAN lane never caught this (it surfaced when #38902 briefly added a build to a validated file).

### Fix
- Each helper in BakeSourceProvider.cpp declares a throw scope, checks after every throwing call, and returns an empty value if and only if an exception is pending. `BakeGetModuleNamespace` and `BakeGetDefaultExportFromModule` share a static `getModuleNamespace()` that returns null on exception. The parameters that were typed as `JSString*` / `JSModuleNamespaceObject*` but receive JSValues from Rust are now `EncodedJSValue` and decoded.
- production.rs wraps the four externs in `jsc::from_js_host_call` (a `mod c`, the shape DevServer.rs already uses for this file's other entry points) and propagates `Err` through `js_err`, so a real exception is printed by `build_command`'s existing `JSError` arm instead of continuing with an empty value. The `prerender` / `getParams` lookups keep their "missing export" messages; only the never-produced `None` case is gone.
- `bakeModuleLoaderImportModule` owns one scope, reads the key once (with a check), and leaves through `RELEASE_AND_RETURN` on every exit. Returning null with an exception pending is what `JSModuleLoader::importModule` itself does; `globalFuncImportModule` rejects the `import()` promise with it. The fallthrough to `Zig::GlobalObject::moduleLoaderImportModule` was already clean and is only released because the function now has a scope. The old `if (!keyString)` rejection is deleted: a `JSString`'s value is only null when reading it threw, which now returns at the top. `bakeModuleLoaderResolve` and `bakeModuleLoaderFetch` get the same `RELEASE_AND_RETURN` at their hand-offs to `Zig::GlobalObject`; their other exits already checked.
- `BakeLoadInitialServerCode` checks the call result before returning it, which makes it honor the empty-iff-threw contract its Rust caller assumes. This one is reachable only if Bun's own server runtime fails to initialize, so it has no test; it is included because it is the same contract as the rest of the file. `BakeRegisterProductionChunk`, the one other function in the file, had no callers anywhere in the tree and is deleted, so the contract comment at the top of the file covers everything below it.
- Why this is right: these are the exception-discipline rules JSC's verifier encodes (every throwing call is checked under a scope, tail calls are released) plus the contract `from_js_host_call` documents (empty return iff exception). Nothing about the success path changes; the existing nine production tests pass unchanged, now under validation too.
- Tests: test/bake/dev/production.test.ts gains an "exception checks" group that runs `bun build --app` with `BUN_JSC_validateExceptionChecks=1` explicitly (so it is enforced by any debug/ASAN run, not only the CI runner). "loading the config file" is a hermetic build with no routes and covers the config path; "loading the server entry point and prerendering routes" is a react build with a static page, a `"use client"` component and a `getStaticPaths` route, covering `BakeLoadModuleByKey`, `BakeGetModuleNamespace`, both `BakeGetOnModuleNamespace` reads and both `bake:/` branches of the import hook; "a config import that fails to resolve" is hermetic and covers the resolve hook's hand-off (expects exit 1 and the "Cannot find module" message); "a route importing a file outside the bundle while rendering" is a react build whose page `import()`s a computed path and covers the fetch hook's hand-off (it is skipped on Windows, where that import fails before reaching the loader regardless of this change, see below). The file also comes off test/no-validate-exceptions.txt, so the other nine builds are validated on the ASAN lane.
- Verified: each new test fails on a tree without the fix it targets and passes with it. The config and prerender tests abort on the unfixed tree naming the `getModuleNamespaceObject` / `get` pair above; with only the import-hook change reverted, the prerender test fails naming `requestImportModule` / `bakeModuleLoaderImportModule`; on the tree before the last two hook changes, the unresolved-import test fails naming `moduleLoaderResolve` / `bakeModuleLoaderResolve` and the out-of-bundle test fails naming `moduleLoaderFetch` / `bakeModuleLoaderFetch`. `BUN_JSC_validateExceptionChecks=1 bun bd test test/bake/dev/production.test.ts`: 13 pass. On Windows (canary build) the group passes with the one test skipped. test/bake/dev/{request-cookies,vfile,server-sourcemap}.test.ts (dev server, goes through `BakeLoadInitialServerCode`) pass under validation. `cargo clippy -p bun_runtime` and `cargo fmt` are clean.
- Not changed here, each reported separately: the second new test uses the file's existing react fixture helper (`tempDirWithBakeDeps`) because a custom framework cannot currently complete a `bun build --app` at all (it panics with "Runtime file not found" at production.rs:787); the `BakeProdResolve` result string that `bakeModuleLoaderResolve` / `ImportModule` never deref (this PR does not touch string ownership); `BakeLoadServerHmrPatch` / `WithSourceMap` declaring a `Bake::GlobalObject*` parameter while the dev server passes a plain `Zig::GlobalObject` (their signatures are untouched here); and, on Windows, `import(join(import.meta.dir, ...))` of a non-bundled file failing with `EINVAL reading "\\"` because `BakeProdResolve` joins the drive path as if it were relative (reproduced with the canary build, which is why the out-of-bundle test is Windows-skipped).

### Background
- JSC exception discipline: a native function that calls anything that can throw declares a `ThrowScope` and must either check for an exception after each such call (`RETURN_IF_EXCEPTION`) or hand the obligation to its caller for a tail call (`RELEASE_AND_RETURN`). With `BUN_JSC_validateExceptionChecks=1` (set by the CI runner on the ASAN lane for every test file not listed in test/no-validate-exceptions.txt), debug builds simulate a throw after every such call and abort the process the next time a scope is created or destroyed while one is still unchecked. Release builds compile this out, so the bug is invisible there, but the same missing checks also mean a real exception would have been carried into unrelated code.
- `jsc::from_js_host_call` is the Rust side of that discipline for hand-written externs: it opens a scope around the FFI call, asserts (in debug/ASAN) that the callee returned an empty `JSValue` exactly when it left an exception pending, and converts that into `JsResult`. It only works if the C++ side actually returns empty on throw, which is the contract each changed function now implements.
- `bun build --app` (Bake's static production build) loads the user's config module and the framework's server entry point into a dedicated VM whose global object is `Bake::GlobalObject`; the helpers in BakeSourceProvider.cpp read exports off those modules, and BakeGlobalObject.cpp's module loader hooks resolve and load the `bake:/...` keys the bundler assigned to the output chunks. `Bake::GlobalObject` is only used by this command, so BakeGlobalObject.cpp changes do not affect the dev server.


