### PR TITLE
install: remove the leftover isolated store when switching to the hoisted linker

### DIFF
--- a/src/install/hoisted_install.rs
+++ b/src/install/hoisted_install.rs
@@ -4,9 +4,10 @@ use core::sync::atomic::Ordering;
 
 use bun_collections::{DynamicBitSet as Bitset, DynamicBitSetList, StringHashMap};
 use bun_core::strings;
-use bun_core::{Global, Output};
-use bun_paths::SEP;
-use bun_sys::{self as sys, Dir, Fd};
+use bun_core::{Global, Output, fast_random, fmt as bun_fmt};
+use bun_paths::path_options::AssumeOk as _;
+use bun_paths::{AutoRelPath, SEP};
+use bun_sys::{self as sys, Dir, E, Fd, FdExt as _};
 
 use crate::analytics;
 use crate::bun_bunfig::Arguments as Command;
@@ -214,6 +215,21 @@ pub(crate) fn install_hoisted_packages(
             }
         }
     };
+
+    // A `node_modules/.bun` store left behind by a previous isolated-linker
+    // install keeps the top-level symlinks into it resolving, so `verify`
+    // would accept them and neither the symlinks nor the store would ever be
+    // replaced. Delete the store up front so those symlinks dangle, fail
+    // verification, and are reinstalled as real directories. Skipped for
+    // partial installs, which may not revisit every package that links into
+    // the store.
+    if !new_node_modules
+        && install_root_dependencies
+        && workspace_filters.is_empty()
+        && packages_to_install.is_none()
+    {
+        remove_leftover_isolated_store();
+    }
 
     let mut skip_delete = new_node_modules;
     let mut skip_verify_installed_version_number = new_node_modules;
@@ -616,4 +632,30 @@ pub(crate) fn install_hoisted_packages(
     }
 
     Ok(summary)
+}
+
+/// Deletes the `node_modules/.bun` store when switching from the isolated
+/// linker to the hoisted linker. The store is renamed aside first so an
+/// interrupted delete cannot leave a partial store that still looks isolated
+/// to `bun prune`.
+fn remove_leftover_isolated_store() {
+    let store_path = bun_paths::path_literal!("node_modules/.bun");
+
+    let mut rename_path = AutoRelPath::from(b"node_modules").assume_ok();
+    rename_path
+        .append_fmt(format_args!(
+            ".old_modules-{}",
+            bun_fmt::hex_lower(bun_core::bytes_of(&fast_random()))
+        ))
+        .assume_ok();
+
+    match sys::renameat(Fd::cwd(), store_path, Fd::cwd(), rename_path.slice_z()) {
+        Ok(()) => {
+            let _ = Fd::cwd().delete_tree(rename_path.slice_z());
+        }
+        Err(err) if err.get_errno() == E::ENOENT => {}
+        Err(_) => {
+            let _ = Fd::cwd().delete_tree(store_path);
+        }
+    }
 }

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -1524,6 +1524,83 @@ describe("existing node_modules, missing node_modules/.bun", () => {
   });
 });
 
+describe("switching from isolated to hoisted", () => {
+  test("removes the leftover store and materializes real directories", async () => {
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "switch-to-hoisted",
+        dependencies: {
+          "no-deps": "1.0.0",
+          "a-dep": "1.0.1",
+        },
+      }),
+    );
+
+    await runBunInstall(bunEnv, packageDir);
+    expect(lstatSync(join(packageDir, "node_modules", "no-deps")).isSymbolicLink()).toBe(true);
+
+    await registry.writeBunfig(packageDir, { linker: "hoisted" });
+    await runBunInstall(bunEnv, packageDir, { savesLockfile: false });
+
+    expect(await readdirSorted(join(packageDir, "node_modules"))).toEqual(["a-dep", "no-deps"]);
+    expect(lstatSync(join(packageDir, "node_modules", "no-deps")).isSymbolicLink()).toBe(false);
+    expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toMatchObject({
+      name: "no-deps",
+      version: "1.0.0",
+    });
+
+    // with the store gone, prune no longer refuses to run
+    await using prune = spawn({
+      cmd: [bunExe(), "prune"],
+      cwd: packageDir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [pruneStderr, pruneExited] = await Promise.all([prune.stderr.text(), prune.exited]);
+    expect(pruneStderr).not.toContain("isolated linker");
+    expect(pruneExited).toBe(0);
+  });
+
+  test("workspace packages get real directories after the switch", async () => {
+    const { packageDir } = await registry.createTestDir({
+      bunfigOpts: { linker: "isolated" },
+      files: {
+        "package.json": JSON.stringify({
+          name: "switch-to-hoisted-workspaces",
+          workspaces: ["packages/*"],
+          dependencies: {
+            "no-deps": "1.0.0",
+          },
+        }),
+        "packages/pkg1/package.json": JSON.stringify({
+          name: "pkg1",
+          dependencies: {
+            "no-deps": "2.0.0",
+          },
+        }),
+      },
+    });
+
+    await runBunInstall(bunEnv, packageDir);
+
+    await registry.writeBunfig(packageDir, { linker: "hoisted" });
+    await runBunInstall(bunEnv, packageDir, { savesLockfile: false });
+
+    expect(await readdirSorted(join(packageDir, "node_modules"))).toEqual(["no-deps", "pkg1"]);
+    expect(lstatSync(join(packageDir, "packages", "pkg1", "node_modules", "no-deps")).isSymbolicLink()).toBe(false);
+    expect(
+      await file(join(packageDir, "packages", "pkg1", "node_modules", "no-deps", "package.json")).json(),
+    ).toMatchObject({
+      name: "no-deps",
+      version: "2.0.0",
+    });
+  });
+});
+
 describe("--linker flag", () => {
   test("can override linker from bunfig", async () => {
     const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });


### PR DESCRIPTION
Fixes #38912

### Problem

- Switching a project from `linker = "isolated"` to `linker = "hoisted"` and re-running `bun install` leaves the entire isolated store (`node_modules/.bun`) behind, so `node_modules` roughly doubles in size (755 MB -> 1113 MB on the reported Next.js app).
- The resulting tree is also not fully hoisted: top-level entries that were symlinks into the store still resolve to the right version, so `verify` in `src/install/PackageInstaller.rs` accepts them and they are never replaced with real directories. Deleting `.bun` by hand therefore breaks the install.
- `bun prune` then refuses with `error: node_modules was installed with the isolated linker, but bun prune would use the hoisted linker`, because its layout detection (`src/install/prune.rs:286`) keys off the leftover store, and its suggested remedy (`bun install`) is the step that produced this state.

### Fix

- `install_hoisted_packages` (`src/install/hoisted_install.rs`) now deletes a leftover `node_modules/.bun` store before the install loop runs. With the store gone, the old symlinks into it dangle, fail verification, and are reinstalled as real directories, which is the same pass the installer already uses for any other stale entry.
- The store is renamed aside (`.old_modules-<hex>`, the same naming the isolated installer uses for the reverse switch) before deletion, so an interrupted delete cannot leave a partial store that still looks isolated to `bun prune`.
- The cleanup is skipped for partial installs (`--filter`, restricted package sets), which may not revisit every package that links into the store; the next full install cleans up.
- This mirrors the switch handling that already exists in the other direction: the isolated installer moves an existing hoisted `node_modules` aside when `node_modules/.bun` is missing (`src/install/isolated_install.rs`).
- With the leftover store gone after `bun install`, `bun prune`'s layout detection no longer misfires, so no prune changes are needed; its refusal now only triggers on genuinely isolated trees, where its message is accurate.
- Verified with two new tests in `test/cli/install/isolated-install.test.ts` ("switching from isolated to hoisted"): both fail on the unfixed build (store and symlink left behind, prune exits 1) and pass with the fix. The full file (68 tests) and `test/cli/install/bun-prune.test.ts` pass with the fix.

### Background

- Bun has two install layouts. The hoisted linker (npm-style) installs real package directories directly under `node_modules`. The isolated linker (pnpm-style) installs every package once into a content store at `node_modules/.bun/<name>@<version>/...` and makes the visible `node_modules/<name>` entries symlinks into that store.
- On install, the hoisted installer verifies each existing `node_modules/<name>` by reading its `package.json`; entries that match the lockfile are kept as-is. A symlink into the store passes that check as long as the store exists, which is why the stale layout was self-perpetuating.
