### PR TITLE
pm: polish dedupe, prune, pm ls and pm licenses output

### DIFF
--- a/docs/guides/install/from-npm-install-to-bun-install.mdx
+++ b/docs/guides/install/from-npm-install-to-bun-install.mdx
@@ -155,7 +155,7 @@ bun pm ls
 ```
 
 ```txt
-my-pkg node_modules (781)
+my-pkg node_modules (781 installed)
 ├── @types/node@20.16.5
 ├── @types/react@18.3.8
 ├── @types/react-dom@18.3.0

--- a/docs/pm/cli/dedupe.mdx
+++ b/docs/pm/cli/dedupe.mdx
@@ -15,7 +15,7 @@ bun dedupe v1.4.0 (abc12345)
 ↳ esbuild 0.15.10 → 0.15.11
 ↳ react 18.2.0 → 18.3.1
 
-2 duplicate versions removed, 3 packages installed (checked 5 packages) [12.00ms]
+2 duplicate versions removed, 3 packages installed (checked 5 packages in bun.lock) [12.00ms]
 ```
 
 Each row is a version Bun removed and the version its dependents now use.
@@ -36,7 +36,7 @@ bun dedupe v1.4.0 (abc12345)
 ↳ esbuild 0.15.10 → 0.15.11
 ↳ react 18.2.0 → 18.3.1
 
-2 duplicate versions can be removed (checked 5 packages) [9.00ms]
+2 duplicate versions can be removed (checked 5 packages in bun.lock) [9.00ms]
   bun dedupe
 ```
 

--- a/docs/pm/cli/pm.mdx
+++ b/docs/pm/cli/pm.mdx
@@ -118,7 +118,7 @@ bun list
 ```
 
 ```txt
-/path/to/project node_modules (135)
+/path/to/project node_modules (135 installed)
 ├── eslint@8.38.0
 ├── react@18.2.0
 ├── react-dom@18.2.0
@@ -135,7 +135,7 @@ bun list --all
 ```
 
 ```txt
-/path/to/project node_modules (135)
+/path/to/project node_modules (135 installed)
 ├── @eslint-community/eslint-utils@4.4.0
 ├── @eslint-community/regexpp@4.5.0
 ├── @eslint/eslintrc@2.0.2
@@ -159,7 +159,7 @@ bun list --trusted
 ```
 
 ```txt
-/path/to/project node_modules (135)
+/path/to/project node_modules (135 installed)
 └── esbuild@0.21.5
 ```
 
@@ -174,6 +174,8 @@ bun pm licenses ls
 ```
 
 ```txt
+bun pm licenses v1.3.0 (a4b2f86f)
+
 MIT (2)
 ├── path-parse@1.0.6
 └── resolve@1.9.0
@@ -183,6 +185,8 @@ Unknown (4)
 ├── no-deps@1.0.0
 ├── no-deps@1.0.1
 └── one-dep@1.0.0
+
+6 packages across 2 licenses (checked 6 packages in bun.lock) [4.00ms]
 ```
 
 | Flag                           | Description                                                                     |

--- a/docs/pm/cli/prune.mdx
+++ b/docs/pm/cli/prune.mdx
@@ -16,7 +16,7 @@ bun prune v1.4.0 (abc12345)
 
 - @types/node@20.11.5
 - left-pad@1.3.0
-2 packages removed (checked 948) [22.00ms]
+2 packages removed (checked 948 installed packages) [22.00ms]
 ```
 
 Packages removed from a workspace or nested `node_modules` folder show the folder in parentheses, e.g. `- typescript@5.4.0 (packages/app/node_modules)`.
@@ -47,7 +47,7 @@ bun prune --production --dry-run
 bun prune v1.4.0 (abc12345)
 
 - typescript@5.4.0
-1 package can be removed (checked 948) [9.00ms]
+1 package can be removed (checked 948 installed packages) [9.00ms]
   bun prune --production
 ```
 

--- a/src/install/dedupe.rs
+++ b/src/install/dedupe.rs
@@ -329,10 +329,9 @@ struct Row {
     name: Box<[u8]>,
     /// The removed version.
     from: Box<[u8]>,
-    /// Surviving version(s) its dependents now resolve to; empty when the
-    /// version is dropped outright (no dependents remain).
+    /// Surviving version(s); empty when `from` is dropped outright.
     to: Box<[u8]>,
-    /// Every surviving version is a lower major than the removed one.
+    /// Every survivor is a lower major than `from`.
     downgrade: bool,
 }
 

--- a/src/install/dedupe.rs
+++ b/src/install/dedupe.rs
@@ -325,8 +325,16 @@ fn sort_by_name_then_version(lockfile: &Lockfile, ids: &mut [PackageID]) {
     index_sort::sort_indices(ids, &mut |a, b| order_by_name_then_version(lockfile, a, b));
 }
 
-// (name, removed version, surviving version(s) its dependents now resolve to)
-type Row = (Box<[u8]>, Box<[u8]>, Box<[u8]>);
+struct Row {
+    name: Box<[u8]>,
+    /// The removed version.
+    from: Box<[u8]>,
+    /// Surviving version(s) its dependents now resolve to; empty when the
+    /// version is dropped outright (no dependents remain).
+    to: Box<[u8]>,
+    /// Every surviving version is a lower major than the removed one.
+    downgrade: bool,
+}
 
 #[derive(Default)]
 pub(crate) struct Report {
@@ -540,8 +548,9 @@ fn dedupe_lockfile(lockfile: &mut Lockfile) -> Report {
         .iter()
         .zip(&targets)
         .map(|(&id, moved_to)| {
+            let from_version = pkg_res[id as usize].npm().version;
             let mut from: Vec<u8> = Vec::new();
-            let _ = write!(from, "{}", pkg_res[id as usize].npm().version.fmt(buf));
+            let _ = write!(from, "{}", from_version.fmt(buf));
             let mut survivors: Vec<PackageID> = moved_to.clone();
             index_sort::sort_vec_by(&mut survivors, |&a, &b| {
                 pkg_res[a as usize]
@@ -556,11 +565,15 @@ fn dedupe_lockfile(lockfile: &mut Lockfile) -> Report {
                 }
                 let _ = write!(to, "{}", pkg_res[c as usize].npm().version.fmt(buf));
             }
-            (
-                Box::from(names[id as usize].slice(buf)),
-                from.into_boxed_slice(),
-                to.into_boxed_slice(),
-            )
+            let downgrade = survivors
+                .last()
+                .is_some_and(|&c| pkg_res[c as usize].npm().version.major < from_version.major);
+            Row {
+                name: Box::from(names[id as usize].slice(buf)),
+                from: from.into_boxed_slice(),
+                to: to.into_boxed_slice(),
+                downgrade,
+            }
         })
         .collect();
 
@@ -729,7 +742,7 @@ fn report_already_deduplicated(manager: &PackageManager, report: &Report) -> ! {
                 bun_core::pretty!("\n");
             }
             bun_core::pretty!(
-                "🎉 <green>No duplicates<r> <d>— checked {} package{}, every one already resolves to a single version<r> ",
+                "🎉 <green>No duplicates<r> <d>— checked {} package{} in bun.lock, every one already resolves to a single version<r> ",
                 report.checked,
                 plural(report.checked)
             );
@@ -757,7 +770,7 @@ fn print_would_remove(manager: &PackageManager, report: &Report) {
     }
     let n = report.rows.len();
     bun_core::pretty!(
-        "\n<b>{}<r> duplicate version{} can be removed <d>(checked {} package{})<r> ",
+        "\n<b>{}<r> duplicate version{} can be removed <d>(checked {} package{} in bun.lock)<r> ",
         n,
         plural(n),
         report.checked,
@@ -773,22 +786,32 @@ fn print_rows(report: &Report) {
     } else {
         ("~", "->")
     };
-    for (name, from, to) in &report.rows {
-        if to.is_empty() {
+    for row in &report.rows {
+        if row.to.is_empty() {
             bun_core::prettyln!(
-                "<cyan>{}<r> <b>{}<r> <d>{}<r>",
+                "<cyan>{}<r> <b>{}<r> <d>{} {} (removed)<r>",
                 glyph,
-                BStr::new(name),
-                BStr::new(from)
+                BStr::new(&row.name),
+                BStr::new(&row.from),
+                arrow
+            );
+        } else if row.downgrade {
+            bun_core::prettyln!(
+                "<cyan>{}<r> <b>{}<r> <d>{} {}<r> <b>{}<r> <yellow>(downgrade)<r>",
+                glyph,
+                BStr::new(&row.name),
+                BStr::new(&row.from),
+                arrow,
+                BStr::new(&row.to)
             );
         } else {
             bun_core::prettyln!(
                 "<cyan>{}<r> <b>{}<r> <d>{} {}<r> <b>{}<r>",
                 glyph,
-                BStr::new(name),
-                BStr::new(from),
+                BStr::new(&row.name),
+                BStr::new(&row.from),
                 arrow,
-                BStr::new(to)
+                BStr::new(&row.to)
             );
         }
     }
@@ -817,7 +840,7 @@ pub(crate) fn print_dedupe_summary(manager: &PackageManager, installed: u32, sta
         );
     }
     bun_core::pretty!(
-        " <d>(checked {} package{})<r> ",
+        " <d>(checked {} package{} in bun.lock)<r> ",
         report.checked,
         plural(report.checked)
     );

--- a/src/install/prune.rs
+++ b/src/install/prune.rs
@@ -14,7 +14,7 @@ use crate::isolated_install::store::{EntryColumns as _, NodeColumns as _, entry 
 use crate::isolated_install::{Store, build_store};
 use crate::lockfile::package::PackageColumns as _;
 use crate::lockfile::tree::is_filtered_dependency_or_workspace;
-use crate::lockfile::{LoadResult, Lockfile, reachable, tree};
+use crate::lockfile::{LoadResult, Lockfile, PackageIndexEntry, reachable, tree};
 use crate::lockfile_real::package::{Diff, DiffSummary, Package};
 use crate::package_manager::Options::{Enable, LogLevel};
 use crate::package_manager::ROOT_PACKAGE_JSON_PATH;
@@ -311,7 +311,7 @@ pub fn prune(manager: &mut PackageManager, original_cwd: &[u8]) -> crate::Result
                 .filter(|f| matches!(f.kind, FolderKind::NodeModules | FolderKind::Store))
                 .count();
             bun_core::pretty!(
-                "<r><green>Done<r>! Checked <green>{} package{}<r> across {} folder{} <d>(nothing to prune)<r> ",
+                "<r><green>Done<r>! Checked <green>{} installed package{}<r> across {} folder{} <d>(nothing to prune)<r> ",
                 checked,
                 plural(checked),
                 folders,
@@ -333,10 +333,11 @@ pub fn prune(manager: &mut PackageManager, original_cwd: &[u8]) -> crate::Result
                 plan.print_row(removal);
             }
             bun_core::pretty!(
-                "<r><b>{}<r> package{} can be removed <d>(checked {})<r> ",
+                "<r><b>{}<r> package{} can be removed <d>(checked {} installed package{})<r> ",
                 n,
                 plural(n),
-                checked
+                checked,
+                plural(checked)
             );
             print_elapsed();
             print_apply_hint();
@@ -354,7 +355,11 @@ pub fn prune(manager: &mut PackageManager, original_cwd: &[u8]) -> crate::Result
         if failed > 0 {
             bun_core::pretty!(", <red>{} failed<r>", failed);
         }
-        bun_core::pretty!(" <d>(checked {})<r> ", checked);
+        bun_core::pretty!(
+            " <d>(checked {} installed package{})<r> ",
+            checked,
+            plural(checked)
+        );
         print_elapsed();
     }
     if failed > 0 {
@@ -641,10 +646,14 @@ struct HoistedTree<'a> {
     paths: Vec<u8>,
     expected: Vec<(&'a [u8], PackageID)>,
     quiet: bool,
+    /// The expected tree excludes dev/optional/peer dependencies, so the
+    /// hoisted positions can differ from the ones a full install produced.
+    filtered: bool,
     kept_mismatched: Cell<bool>,
     checked: RefCell<DynamicBitSet>,
     matched: RefCell<DynamicBitSet>,
     missing: RefCell<DynamicBitSet>,
+    other_version: RefCell<DynamicBitSet>,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -652,10 +661,15 @@ enum Installed {
     Matches,
     Missing,
     Mismatch,
+    /// The position holds a different version that the lockfile does install
+    /// somewhere. Only produced when `filtered` is set: excluding dev or
+    /// optional dependencies changes which copy the hoist favors, so a full
+    /// install legitimately leaves the other copy here. Kept without warning.
+    OtherVersion,
 }
 
 impl<'a> HoistedTree<'a> {
-    fn init(lockfile: &'a Lockfile, quiet: bool) -> HoistedTree<'a> {
+    fn init(lockfile: &'a Lockfile, quiet: bool, filtered: bool) -> HoistedTree<'a> {
         let trees = lockfile.buffers.trees.as_slice();
         let deps = lockfile.buffers.dependencies.as_slice();
         let resolutions = lockfile.buffers.resolutions.as_slice();
@@ -700,6 +714,7 @@ impl<'a> HoistedTree<'a> {
         let checked = handle_oom(DynamicBitSet::init_empty(expected.len()));
         let matched = handle_oom(DynamicBitSet::init_empty(expected.len()));
         let missing = handle_oom(DynamicBitSet::init_empty(expected.len()));
+        let other_version = handle_oom(DynamicBitSet::init_empty(expected.len()));
         HoistedTree {
             lockfile,
             trees,
@@ -707,10 +722,12 @@ impl<'a> HoistedTree<'a> {
             paths,
             expected,
             quiet,
+            filtered,
             kept_mismatched: Cell::new(false),
             checked: RefCell::new(checked),
             matched: RefCell::new(matched),
             missing: RefCell::new(missing),
+            other_version: RefCell::new(other_version),
         }
     }
 
@@ -750,8 +767,10 @@ impl<'a> HoistedTree<'a> {
         };
         let (alias, pkg_id) = self.expected[idx];
         let installed = self.verified_installed(id, idx, alias, pkg_id);
-        if installed == Installed::Matches {
-            return true;
+        match installed {
+            Installed::Matches => return true,
+            Installed::OtherVersion => return false,
+            Installed::Missing | Installed::Mismatch => {}
         }
         self.kept_mismatched.set(true);
         if !self.quiet {
@@ -789,6 +808,8 @@ impl<'a> HoistedTree<'a> {
                 Installed::Matches
             } else if self.missing.borrow().is_set(idx) {
                 Installed::Missing
+            } else if self.other_version.borrow().is_set(idx) {
+                Installed::OtherVersion
             } else {
                 Installed::Mismatch
             };
@@ -798,6 +819,7 @@ impl<'a> HoistedTree<'a> {
         match installed {
             Installed::Matches => self.matched.borrow_mut().set(idx),
             Installed::Missing => self.missing.borrow_mut().set(idx),
+            Installed::OtherVersion => self.other_version.borrow_mut().set(idx),
             Installed::Mismatch => {}
         }
         installed
@@ -837,12 +859,20 @@ impl<'a> HoistedTree<'a> {
         let expected_name = self.lockfile.packages.items_name()[pkg_id as usize].slice(buf);
         let matches = match res.tag {
             ResolutionTag::Npm => {
-                installed_package_json(&package).is_some_and(|(name, version)| {
-                    let expected = res.npm().version.fmt(buf).to_string();
-                    version.is_some_and(|version| {
-                        without_build(&version) == without_build(expected.as_bytes())
-                    }) && name == expected_name
-                })
+                let Some((name, Some(version))) = installed_package_json(&package) else {
+                    return Installed::Mismatch;
+                };
+                if name != expected_name {
+                    return Installed::Mismatch;
+                }
+                let expected = res.npm().version.fmt(buf).to_string();
+                if without_build(&version) == without_build(expected.as_bytes()) {
+                    return Installed::Matches;
+                }
+                if self.filtered && self.version_in_lockfile(pkg_id, &version) {
+                    return Installed::OtherVersion;
+                }
+                return Installed::Mismatch;
             }
             ResolutionTag::Git | ResolutionTag::Github => {
                 sys::File::read_from(package.fd(), b".bun-tag")
@@ -858,6 +888,30 @@ impl<'a> HoistedTree<'a> {
         } else {
             Installed::Mismatch
         }
+    }
+
+    /// Whether some npm package with the same name in the lockfile resolves to
+    /// `version`: the copy at this position came from the lockfile, the
+    /// filtered view just favors a different one.
+    fn version_in_lockfile(&self, pkg_id: PackageID, version: &[u8]) -> bool {
+        let lockfile = self.lockfile;
+        let buf = lockfile.buffers.string_bytes.as_slice();
+        let name_hash = lockfile.packages.items_name_hash()[pkg_id as usize];
+        let Some(entry) = lockfile.package_index.get(&name_hash) else {
+            return false;
+        };
+        let ids: &[PackageID] = match entry {
+            PackageIndexEntry::Id(id) => core::slice::from_ref(id),
+            PackageIndexEntry::Ids(ids) => ids,
+        };
+        let pkg_res = lockfile.packages.items_resolution();
+        ids.iter().any(|&id| {
+            pkg_res.get(id as usize).is_some_and(|res| {
+                res.tag == ResolutionTag::Npm
+                    && without_build(version)
+                        == without_build(res.npm().version.fmt(buf).to_string().as_bytes())
+            })
+        })
     }
 }
 
@@ -904,8 +958,11 @@ fn plan_hoisted(
     hoist_filtered(manager);
 
     let quiet = manager.options.log_level == LogLevel::Silent;
+    let features = manager.options.local_package_features;
+    let filtered =
+        !features.dev_dependencies || !features.optional_dependencies || !features.peer_dependencies;
     let lockfile: &Lockfile = &manager.lockfile;
-    let hoisted = HoistedTree::init(lockfile, quiet);
+    let hoisted = HoistedTree::init(lockfile, quiet, filtered);
     let buf = lockfile.buffers.string_bytes.as_slice();
     let deps = lockfile.buffers.dependencies.as_slice();
     let trees = lockfile.buffers.trees.as_slice();
@@ -1089,8 +1146,8 @@ pub(crate) fn remove_collapsed_copies(manager: &PackageManager, before: &Lockfil
         return;
     }
     let quiet = manager.options.log_level == LogLevel::Silent;
-    let old = HoistedTree::init(before, true);
-    let new = HoistedTree::init(after, quiet);
+    let old = HoistedTree::init(before, true, false);
+    let new = HoistedTree::init(after, quiet, false);
     let targets = manager.filtered_link_targets.as_ref();
     let selected: Option<Vec<PackageID>> = targets.map(|targets| targets.package_ids(before));
     let importers = selected.as_ref().map(|_| tree_importers(before));

--- a/src/install/prune.rs
+++ b/src/install/prune.rs
@@ -646,8 +646,7 @@ struct HoistedTree<'a> {
     paths: Vec<u8>,
     expected: Vec<(&'a [u8], PackageID)>,
     quiet: bool,
-    /// The expected tree excludes dev/optional/peer dependencies, so the
-    /// hoisted positions can differ from the ones a full install produced.
+    /// The expected tree excludes dev/optional/peer dependencies.
     filtered: bool,
     kept_mismatched: Cell<bool>,
     checked: RefCell<DynamicBitSet>,
@@ -661,10 +660,9 @@ enum Installed {
     Matches,
     Missing,
     Mismatch,
-    /// The position holds a different version that the lockfile does install
-    /// somewhere. Only produced when `filtered` is set: excluding dev or
-    /// optional dependencies changes which copy the hoist favors, so a full
-    /// install legitimately leaves the other copy here. Kept without warning.
+    /// A version the lockfile installs elsewhere; the filter just favors a
+    /// different copy at this position, so it is kept without warning.
+    /// Only produced when `filtered` is set.
     OtherVersion,
 }
 
@@ -890,9 +888,8 @@ impl<'a> HoistedTree<'a> {
         }
     }
 
-    /// Whether some npm package with the same name in the lockfile resolves to
-    /// `version`: the copy at this position came from the lockfile, the
-    /// filtered view just favors a different one.
+    /// Whether some npm package with the same name in the lockfile resolves
+    /// to `version`.
     fn version_in_lockfile(&self, pkg_id: PackageID, version: &[u8]) -> bool {
         let lockfile = self.lockfile;
         let buf = lockfile.buffers.string_bytes.as_slice();

--- a/src/install/prune.rs
+++ b/src/install/prune.rs
@@ -959,8 +959,9 @@ fn plan_hoisted(
 
     let quiet = manager.options.log_level == LogLevel::Silent;
     let features = manager.options.local_package_features;
-    let filtered =
-        !features.dev_dependencies || !features.optional_dependencies || !features.peer_dependencies;
+    let filtered = !features.dev_dependencies
+        || !features.optional_dependencies
+        || !features.peer_dependencies;
     let lockfile: &Lockfile = &manager.lockfile;
     let hoisted = HoistedTree::init(lockfile, quiet, filtered);
     let buf = lockfile.buffers.string_bytes.as_slice();

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -616,7 +616,7 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
                 let root_deps = slice.items_dependencies()[0];
 
                 Output::println(format_args!(
-                    "{} node_modules ({})",
+                    "{} node_modules ({} installed)",
                     bstr::BStr::new(path),
                     lockfile.buffers.hoisted_dependencies.len(),
                 ));

--- a/src/runtime/cli/pm_licenses_command.rs
+++ b/src/runtime/cli/pm_licenses_command.rs
@@ -309,7 +309,12 @@ impl PmLicensesCommand {
         if json_output {
             print_json(&entries);
         } else {
-            print_text(&entries, flags.long, checked, pm.options.should_print_command_name());
+            print_text(
+                &entries,
+                flags.long,
+                checked,
+                pm.options.should_print_command_name(),
+            );
         }
 
         Output::flush();

--- a/src/runtime/cli/pm_licenses_command.rs
+++ b/src/runtime/cli/pm_licenses_command.rs
@@ -155,7 +155,7 @@ impl PmLicensesCommand {
         };
 
         // After the exits above so error output keeps a clean stdout.
-        if not_silent && !json_output {
+        if pm.options.should_print_command_name() && !json_output {
             bun_core::pretty!(
                 "<r><b>bun pm licenses <r><d>v{}<r>\n\n",
                 Global::package_json_version_with_sha
@@ -309,7 +309,7 @@ impl PmLicensesCommand {
         if json_output {
             print_json(&entries);
         } else {
-            print_text(&entries, flags.long, checked, not_silent);
+            print_text(&entries, flags.long, checked, pm.options.should_print_command_name());
         }
 
         Output::flush();

--- a/src/runtime/cli/pm_licenses_command.rs
+++ b/src/runtime/cli/pm_licenses_command.rs
@@ -154,6 +154,15 @@ impl PmLicensesCommand {
             (selection.ids, false)
         };
 
+        // After the exits above so error output keeps a clean stdout.
+        if not_silent && !json_output {
+            bun_core::pretty!(
+                "<r><b>bun pm licenses <r><d>v{}<r>\n\n",
+                Global::package_json_version_with_sha
+            );
+            Output::flush();
+        }
+
         let options = reachable::Options {
             root: 0,
             dev: features.dev_dependencies,
@@ -300,7 +309,7 @@ impl PmLicensesCommand {
         if json_output {
             print_json(&entries);
         } else {
-            print_text(&entries, flags.long, checked);
+            print_text(&entries, flags.long, checked, not_silent);
         }
 
         Output::flush();
@@ -681,18 +690,23 @@ impl DiskIndex {
     }
 }
 
-fn print_text(entries: &[Entry], long: bool, checked: usize) {
+fn plural(n: usize) -> &'static str {
+    if n == 1 { "" } else { "s" }
+}
+
+fn print_text(entries: &[Entry], long: bool, checked: usize, summary: bool) {
     if entries.is_empty() {
         bun_core::pretty!(
             "No packages to list <d>(checked {} package{} in bun.lock)<r> ",
             checked,
-            if checked == 1 { "" } else { "s" }
+            plural(checked)
         );
         Output::print_start_end_stdout(bun_core::start_time(), bun_core::time::nano_timestamp());
         bun_core::pretty!("\n");
         return;
     }
 
+    let mut licenses = 0;
     let mut start = 0;
     while start < entries.len() {
         let license = &entries[start].license;
@@ -704,6 +718,7 @@ fn print_text(entries: &[Entry], long: bool, checked: usize) {
         if start > 0 {
             Output::print(format_args!("\n"));
         }
+        licenses += 1;
         bun_core::prettyln!(
             "<b>{}<r> <d>({})<r>",
             BStr::new(&printable(license)),
@@ -736,6 +751,20 @@ fn print_text(entries: &[Entry], long: bool, checked: usize) {
         }
 
         start = end;
+    }
+
+    if summary {
+        bun_core::pretty!(
+            "\n<b>{}<r> package{} across {} license{} <d>(checked {} package{} in bun.lock)<r> ",
+            entries.len(),
+            plural(entries.len()),
+            licenses,
+            plural(licenses),
+            checked,
+            plural(checked)
+        );
+        Output::print_start_end_stdout(bun_core::start_time(), bun_core::time::nano_timestamp());
+        bun_core::pretty!("\n");
     }
 }
 

--- a/src/runtime/cli/pm_licenses_command.rs
+++ b/src/runtime/cli/pm_licenses_command.rs
@@ -701,12 +701,18 @@ fn plural(n: usize) -> &'static str {
 
 fn print_text(entries: &[Entry], long: bool, checked: usize, summary: bool) {
     if entries.is_empty() {
-        bun_core::pretty!(
-            "No packages to list <d>(checked {} package{} in bun.lock)<r> ",
-            checked,
-            plural(checked)
-        );
-        Output::print_start_end_stdout(bun_core::start_time(), bun_core::time::nano_timestamp());
+        bun_core::pretty!("No packages to list");
+        if summary {
+            bun_core::pretty!(
+                " <d>(checked {} package{} in bun.lock)<r> ",
+                checked,
+                plural(checked)
+            );
+            Output::print_start_end_stdout(
+                bun_core::start_time(),
+                bun_core::time::nano_timestamp(),
+            );
+        }
         bun_core::pretty!("\n");
         return;
     }

--- a/test/cli/install/bun-dedupe.test.ts
+++ b/test/cli/install/bun-dedupe.test.ts
@@ -55,9 +55,9 @@ const packagesWord = (n: number) => `${n} package${n === 1 ? "" : "s"}`;
 const versionsWord = (n: number) => `${n} duplicate version${n === 1 ? "" : "s"}`;
 
 const noDuplicates = (checked: number) =>
-  `🎉 No duplicates — checked ${packagesWord(checked)}, every one already resolves to a single version`;
+  `🎉 No duplicates — checked ${packagesWord(checked)} in bun.lock, every one already resolves to a single version`;
 const wouldRemove = (removed: number, checked: number) =>
-  `${versionsWord(removed)} can be removed (checked ${packagesWord(checked)})`;
+  `${versionsWord(removed)} can be removed (checked ${packagesWord(checked)} in bun.lock)`;
 const HINT = "  bun dedupe";
 
 const row = (label: string) => `~ ${label}`;
@@ -77,7 +77,7 @@ function removedSummary(removed: number, checked?: number) {
   return new RegExp(
     `^${versionsWord(removed)} removed(, [1-9]\\d* packages? installed)? \\(checked ${
       checked === undefined ? "[1-9]\\d* packages?" : packagesWord(checked)
-    }\\)$`,
+    } in bun\\.lock\\)$`,
   );
 }
 
@@ -125,7 +125,7 @@ function expectNoDuplicates({ stdout, stderr, exitCode }: Result, checked?: numb
     ...kept,
     ...(kept.length ? [""] : []),
     checked === undefined
-      ? expect.stringMatching(/^🎉 No duplicates — checked [1-9]\d* packages?, /)
+      ? expect.stringMatching(/^🎉 No duplicates — checked [1-9]\d* packages? in bun\.lock, /)
       : noDuplicates(checked),
   ]);
   expectTimed(stdout, NO_DUPLICATES);
@@ -215,7 +215,7 @@ test.concurrent("collapses a range onto the exact version that satisfies every e
     HEADER,
     "~ no-deps 1.1.0 -> 1.0.0",
     "",
-    "1 duplicate version removed (checked 4 packages)",
+    "1 duplicate version removed (checked 4 packages in bun.lock)",
   ]);
   expectRemoved(stdout, "no-deps 1.1.0 -> 1.0.0", { checked: 4 });
   expect(lines(stderr)).toStrictEqual(["Saved lockfile"]);
@@ -279,7 +279,7 @@ test.concurrent("--check reports and exits 1 without writing", async () => {
       "bun dedupe <version> (<revision>)",
       "~ no-deps 1.1.0 -> 1.0.0",
       "",
-      "1 duplicate version can be removed (checked 4 packages)",
+      "1 duplicate version can be removed (checked 4 packages in bun.lock)",
       "  bun dedupe",
     ]
   `);
@@ -347,7 +347,7 @@ test.concurrent("already deduplicated", async () => {
   expect(lines(second.stdout)).toMatchInlineSnapshot(`
     [
       "bun dedupe <version> (<revision>)",
-      "🎉 No duplicates — checked 3 packages, every one already resolves to a single version",
+      "🎉 No duplicates — checked 3 packages in bun.lock, every one already resolves to a single version",
     ]
   `);
   expect(second.stderr).toBe("");
@@ -672,7 +672,7 @@ test.concurrent("cascading removal lists every unreachable duplicate in name ord
     expect(lockfile).toContain(label);
   }
 
-  const rows = ["no-deps 2.0.0", "one-fixed-dep 2.0.0 -> 1.0.0"];
+  const rows = ["no-deps 2.0.0 -> (removed)", "one-fixed-dep 2.0.0 -> 1.0.0 (downgrade)"];
   const checked = lockPackageCount(lockfile);
   expect(checked).toBe(5);
   const check = await dedupe(packageDir, "--check");
@@ -706,7 +706,7 @@ test.concurrent("multiple names removed in one run are sorted, scoped names firs
     expect(lockfile).toContain(label);
   }
 
-  const rows = ["@types/is-number 2.0.0 -> 1.0.0", "no-deps 1.1.0 -> 1.0.0"];
+  const rows = ["@types/is-number 2.0.0 -> 1.0.0 (downgrade)", "no-deps 1.1.0 -> 1.0.0"];
   const checked = lockPackageCount(lockfile);
   expect(checked).toBe(6);
   const check = await dedupe(packageDir, "--check");
@@ -850,7 +850,7 @@ test.concurrent("the report is printed as one block after root lifecycle script 
   expect(out.slice(firstRow)).toStrictEqual([
     "~ no-deps 1.1.0 -> 1.0.0",
     "",
-    "1 duplicate version removed (checked 4 packages)",
+    "1 duplicate version removed (checked 4 packages in bun.lock)",
   ]);
   expectRemoved(stdout, "no-deps 1.1.0 -> 1.0.0", { checked: 4 });
   expect(stderr).not.toContain("error:");
@@ -945,7 +945,7 @@ test.concurrent("--lockfile-only rewrites bun.lock without installing", async ()
     HEADER,
     "~ no-deps 1.1.0 -> 1.0.0",
     "",
-    "1 duplicate version removed (checked 4 packages)",
+    "1 duplicate version removed (checked 4 packages in bun.lock)",
   ]);
   expectRemoved(stdout, "no-deps 1.1.0 -> 1.0.0", { checked: 4 });
   expect(lines(stderr)).toStrictEqual(["Saved lockfile"]);
@@ -1554,7 +1554,7 @@ test.concurrent("a version that is the only way to reach a patched package is ke
       "~ dep-with-tags 3.0.1 -> 3.0.0",
       "  kept one-fixed-dep@1.0.0 (needed to reach patched no-deps@1.0.0)",
       "",
-      "1 duplicate version can be removed (checked 7 packages)",
+      "1 duplicate version can be removed (checked 7 packages in bun.lock)",
       "  bun dedupe",
     ]
   `);
@@ -1588,7 +1588,7 @@ test.concurrent("a version that is the only way to reach a patched package is ke
       "bun dedupe <version> (<revision>)",
       "  kept one-fixed-dep@1.0.0 (needed to reach patched no-deps@1.0.0)",
       "",
-      "🎉 No duplicates — checked 6 packages, every one already resolves to a single version",
+      "🎉 No duplicates — checked 6 packages in bun.lock, every one already resolves to a single version",
     ]
   `);
   expectNoDuplicates(recheck, 6, kept);
@@ -1631,7 +1631,7 @@ test.concurrent("a version removed by the run does not vote for its own dependen
   }
   expect(await nodeModulesVersion(packageDir, "no-deps")).toBe("1.1.0");
 
-  const rows = ["no-deps 1.0.0", "one-fixed-dep 1.0.0 -> 2.0.0"];
+  const rows = ["no-deps 1.0.0 -> (removed)", "one-fixed-dep 1.0.0 -> 2.0.0"];
   const checked = lockPackageCount(lockfile);
   expect(checked).toBe(7);
   const check = await dedupe(packageDir, "--check");
@@ -1837,7 +1837,7 @@ test.concurrent("a lockfile whose root has no dependencies is reported as dedupl
   expect(lines(check.stdout)).toMatchInlineSnapshot(`
     [
       "bun dedupe <version> (<revision>)",
-      "🎉 No duplicates — checked 1 package, every one already resolves to a single version",
+      "🎉 No duplicates — checked 1 package in bun.lock, every one already resolves to a single version",
     ]
   `);
   expectNoDuplicates(check, 1);
@@ -1905,7 +1905,7 @@ test.concurrent("migrates package-lock.json when there is no bun.lock", async ()
   // Nothing was installed before this run, so the summary also carries the install count.
   const { stdout, stderr, exitCode } = await dedupe(packageDir);
   expectRemoved(stdout, "no-deps 1.1.0 -> 1.0.0", { checked: 4 });
-  expect(lines(stdout).at(-1)).toBe("1 duplicate version removed, 2 packages installed (checked 4 packages)");
+  expect(lines(stdout).at(-1)).toBe("1 duplicate version removed, 2 packages installed (checked 4 packages in bun.lock)");
   expect(stderr).toContain("migrated lockfile from package-lock.json");
   expect(stderr).toContain("Saved lockfile");
   expect(stderr).not.toContain("error:");

--- a/test/cli/install/bun-dedupe.test.ts
+++ b/test/cli/install/bun-dedupe.test.ts
@@ -1905,7 +1905,9 @@ test.concurrent("migrates package-lock.json when there is no bun.lock", async ()
   // Nothing was installed before this run, so the summary also carries the install count.
   const { stdout, stderr, exitCode } = await dedupe(packageDir);
   expectRemoved(stdout, "no-deps 1.1.0 -> 1.0.0", { checked: 4 });
-  expect(lines(stdout).at(-1)).toBe("1 duplicate version removed, 2 packages installed (checked 4 packages in bun.lock)");
+  expect(lines(stdout).at(-1)).toBe(
+    "1 duplicate version removed, 2 packages installed (checked 4 packages in bun.lock)",
+  );
   expect(stderr).toContain("migrated lockfile from package-lock.json");
   expect(stderr).toContain("Saved lockfile");
   expect(stderr).not.toContain("error:");

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -2469,7 +2469,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         });
         const out = await stdout.text();
         expect(await stderr.text()).toBe("");
-        expect(out).toBe(`${packageDir} node_modules (2)
+        expect(out).toBe(`${packageDir} node_modules (2 installed)
 └── electron@1.0.0
 `);
         expect(await exited).toBe(0);
@@ -2514,7 +2514,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         });
         const out = await stdout.text();
         expect(await stderr.text()).toBe("");
-        expect(out).toBe(`${packageDir} node_modules (2)
+        expect(out).toBe(`${packageDir} node_modules (2 installed)
 └── no-deps@1.0.0
 `);
         expect(await exited).toBe(0);

--- a/test/cli/install/bun-pm-licenses.test.ts
+++ b/test/cli/install/bun-pm-licenses.test.ts
@@ -60,11 +60,13 @@ async function gitRepo(manifest: Record<string, unknown>) {
   return repoDir;
 }
 
+const HEADER = "bun pm licenses <version> (<revision>)";
+
 const emptyText = (checked: number) => `No packages to list (checked ${checked} packages in bun.lock)`;
 
 function expectEmptyText(stdout: string, checked: number) {
-  expect(normalizeBunSnapshot(stdout)).toBe(emptyText(checked));
-  expect(stdout).toMatch(/^No packages to list \(checked \d+ packages in bun\.lock\) \[\d+\.\d+m?s\]\n$/);
+  expect(normalizeBunSnapshot(stdout)).toBe(`${HEADER}\n\n${emptyText(checked)}`);
+  expect(stdout).toMatch(/\nNo packages to list \(checked \d+ packages in bun\.lock\) \[\d+\.\d+m?s\]\n$/);
 }
 
 const MISSING_NOTE = "note: run 'bun install' first";
@@ -269,7 +271,9 @@ describe("bun pm licenses", () => {
   test.concurrent("text output groups packages by license, Unknown last, dev-only packages marked", async () => {
     const [stdout, stderr, exitCode] = await licenses(hoistedDir);
     expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`
-      "MIT (2)
+      "bun pm licenses <version> (<revision>)
+
+      MIT (2)
       ├── path-parse@1.0.6
       └── resolve@1.9.0
 
@@ -277,7 +281,9 @@ describe("bun pm licenses", () => {
       ├── a-dep@1.0.1 (dev)
       ├── no-deps@1.0.0
       ├── no-deps@1.0.1
-      └── one-dep@1.0.0"
+      └── one-dep@1.0.0
+
+      6 packages across 2 licenses (checked 6 packages in bun.lock)"
     `);
     expect(stdout.split("\n").filter(line => line.endsWith(" (dev)"))).toStrictEqual(["├── a-dep@1.0.1 (dev)"]);
     expect(stdout).not.toContain(hoistedDir);
@@ -355,7 +361,9 @@ describe("bun pm licenses", () => {
 
     const [stdout, stderr, exitCode] = await licenses(dir);
     expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`
-      "BSD-3-Clause (1)
+      "bun pm licenses <version> (<revision>)
+
+      BSD-3-Clause (1)
       └── no-deps@1.0.1
 
       ISC (1)
@@ -377,7 +385,9 @@ describe("bun pm licenses", () => {
       └── a-dep@1.0.9
 
       Unknown (1)
-      └── uses-a-dep-9@1.0.0"
+      └── uses-a-dep-9@1.0.0
+
+      8 packages across 8 licenses (checked 8 packages in bun.lock)"
     `);
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
@@ -491,11 +501,15 @@ describe("bun pm licenses", () => {
 
     const [stdout, stderr, exitCode] = await licenses(dir);
     expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`
-      "Unknown (4)
+      "bun pm licenses <version> (<revision>)
+
+      Unknown (4)
       ├── a-dep@1.0.9
       ├── a-dep@1.0.10
       ├── uses-a-dep-10@1.0.0
-      └── uses-a-dep-9@1.0.0"
+      └── uses-a-dep-9@1.0.0
+
+      4 packages across 1 license (checked 4 packages in bun.lock)"
     `);
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
@@ -511,9 +525,13 @@ describe("bun pm licenses", () => {
 
     const [stdout, stderr, exitCode] = await licenses(dir);
     expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`
-      "Unknown (2)
+      "bun pm licenses <version> (<revision>)
+
+      Unknown (2)
       ├── a-dep@1.0.9
-      └── uses-a-dep-9@1.0.0 (dev)"
+      └── uses-a-dep-9@1.0.0 (dev)
+
+      2 packages across 1 license (checked 2 packages in bun.lock)"
     `);
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
@@ -531,9 +549,13 @@ describe("bun pm licenses", () => {
       Unknown: [u("a-dep", "1.0.9"), u("uses-a-dep-9", "1.0.0")],
     });
     expect(normalizeBunSnapshot(await licensesText(dir, "--dev"))).toMatchInlineSnapshot(`
-      "Unknown (2)
+      "bun pm licenses <version> (<revision>)
+
+      Unknown (2)
       ├── a-dep@1.0.9
-      └── uses-a-dep-9@1.0.0 (dev)"
+      └── uses-a-dep-9@1.0.0 (dev)
+
+      2 packages across 1 license (checked 2 packages in bun.lock)"
     `);
   });
 
@@ -547,21 +569,29 @@ describe("bun pm licenses", () => {
     });
 
     expect(normalizeBunSnapshot(await licensesText(dir))).toMatchInlineSnapshot(`
-      "Unknown (6)
+      "bun pm licenses <version> (<revision>)
+
+      Unknown (6)
       ├── a-dep@1.0.9 (dev)
       ├── a-dep@1.0.10
       ├── no-deps@1.0.1
       ├── one-dep@1.0.0 (dev)
       ├── uses-a-dep-10@1.0.0
-      └── uses-a-dep-9@1.0.0 (dev)"
+      └── uses-a-dep-9@1.0.0 (dev)
+
+      6 packages across 1 license (checked 6 packages in bun.lock)"
     `);
 
     expect(normalizeBunSnapshot(await licensesText(dir, "--dev"))).toMatchInlineSnapshot(`
-      "Unknown (4)
+      "bun pm licenses <version> (<revision>)
+
+      Unknown (4)
       ├── a-dep@1.0.9 (dev)
       ├── no-deps@1.0.1
       ├── one-dep@1.0.0 (dev)
-      └── uses-a-dep-9@1.0.0 (dev)"
+      └── uses-a-dep-9@1.0.0 (dev)
+
+      4 packages across 1 license (checked 4 packages in bun.lock)"
     `);
     expect(await licensesJson(dir, "--dev")).toStrictEqual({
       Unknown: [u("a-dep", "1.0.9"), u("no-deps", "1.0.1"), u("one-dep", "1.0.0"), u("uses-a-dep-9", "1.0.0")],
@@ -577,14 +607,22 @@ describe("bun pm licenses", () => {
     expect(await licensesJson(dir, "--dev")).toStrictEqual(expected);
     expect(await licensesJson(dir, "-D")).toStrictEqual(expected);
     expect(normalizeBunSnapshot(await licensesText(dir, "--dev"))).toMatchInlineSnapshot(`
-      "Unknown (2)
+      "bun pm licenses <version> (<revision>)
+
+      Unknown (2)
       ├── no-deps@1.0.1 (dev)
-      └── one-dep@1.0.0 (dev)"
+      └── one-dep@1.0.0 (dev)
+
+      2 packages across 1 license (checked 2 packages in bun.lock)"
     `);
 
     expect(normalizeBunSnapshot(await licensesText(hoistedDir, "--dev"))).toMatchInlineSnapshot(`
-      "Unknown (1)
-      └── a-dep@1.0.1 (dev)"
+      "bun pm licenses <version> (<revision>)
+
+      Unknown (1)
+      └── a-dep@1.0.1 (dev)
+
+      1 package across 1 license (checked 1 package in bun.lock)"
     `);
     expect(await licensesJson(hoistedDir, "--dev")).toStrictEqual({ Unknown: [u("a-dep", "1.0.1")] });
   });
@@ -620,14 +658,18 @@ describe("bun pm licenses", () => {
   test.concurrent("--prod omits devDependencies (text)", async () => {
     const [stdout, stderr, exitCode] = await licenses(hoistedDir, "--prod");
     expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`
-      "MIT (2)
+      "bun pm licenses <version> (<revision>)
+
+      MIT (2)
       ├── path-parse@1.0.6
       └── resolve@1.9.0
 
       Unknown (3)
       ├── no-deps@1.0.0
       ├── no-deps@1.0.1
-      └── one-dep@1.0.0"
+      └── one-dep@1.0.0
+
+      5 packages across 2 licenses (checked 5 packages in bun.lock)"
     `);
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
@@ -669,7 +711,9 @@ describe("bun pm licenses", () => {
   test.concurrent("--long prints author, description and homepage under each entry", async () => {
     const [stdout, stderr, exitCode] = await licenses(hoistedDir, "--long");
     expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`
-      "MIT (2)
+      "bun pm licenses <version> (<revision>)
+
+      MIT (2)
       ├── path-parse@1.0.6
       │   Javier Blanco <http://jbgutierrez.info>
       │   Node.js path.parse() ponyfill
@@ -683,12 +727,14 @@ describe("bun pm licenses", () => {
       ├── a-dep@1.0.1 (dev)
       ├── no-deps@1.0.0
       ├── no-deps@1.0.1
-      └── one-dep@1.0.0"
+      └── one-dep@1.0.0
+
+      6 packages across 2 licenses (checked 6 packages in bun.lock)"
     `);
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
 
-    expect(await licensesText(hoistedDir, "ls", "--long")).toBe(stdout);
+    expect(normalizeBunSnapshot(await licensesText(hoistedDir, "ls", "--long"))).toBe(normalizeBunSnapshot(stdout));
     expect(stdout).not.toContain(nm(hoistedDir));
 
     const [plainJson, longJson] = await Promise.all([
@@ -767,7 +813,9 @@ describe("bun pm licenses", () => {
       ],
     });
     expect(normalizeBunSnapshot(await licensesText(dir, "--long"))).toMatchInlineSnapshot(`
-      "MIT (2)
+      "bun pm licenses <version> (<revision>)
+
+      MIT (2)
       ├── path-parse@1.0.6
       │   Javier Blanco <http://jbgutierrez.info>
       │   Node.js path.parse() ponyfill
@@ -783,7 +831,9 @@ describe("bun pm licenses", () => {
       │   https://no-deps.example
       ├── no-deps@1.0.1
       └── one-dep@1.0.0
-          git+ssh://git@github.com/example/one-dep.git"
+          git+ssh://git@github.com/example/one-dep.git
+
+      6 packages across 2 licenses (checked 6 packages in bun.lock)"
     `);
   });
 
@@ -850,9 +900,11 @@ describe("bun pm licenses", () => {
   test.concurrent("isolated linker matches hoisted: marker, --dev and --long", async () => {
     const dir = await setup("isolated");
     const [[expected], [stdout, stderr, exitCode]] = await Promise.all([licenses(hoistedDir), licenses(dir)]);
-    expect(stdout).toBe(expected);
+    expect(normalizeBunSnapshot(stdout)).toBe(normalizeBunSnapshot(expected));
     expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`
-      "MIT (2)
+      "bun pm licenses <version> (<revision>)
+
+      MIT (2)
       ├── path-parse@1.0.6
       └── resolve@1.9.0
 
@@ -860,7 +912,9 @@ describe("bun pm licenses", () => {
       ├── a-dep@1.0.1 (dev)
       ├── no-deps@1.0.0
       ├── no-deps@1.0.1
-      └── one-dep@1.0.0"
+      └── one-dep@1.0.0
+
+      6 packages across 2 licenses (checked 6 packages in bun.lock)"
     `);
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
@@ -876,8 +930,8 @@ describe("bun pm licenses", () => {
         licensesJson(dir, "--long"),
         licensesJson(hoistedDir, "--long"),
       ]);
-    expect(isoLong).toBe(hoistedLong);
-    expect(isoDev).toBe(hoistedDev);
+    expect(normalizeBunSnapshot(isoLong)).toBe(normalizeBunSnapshot(hoistedLong));
+    expect(normalizeBunSnapshot(isoDev)).toBe(normalizeBunSnapshot(hoistedDev));
     expect(isoDevJson).toStrictEqual(hoistedDevJson);
     expect(isoLongJson).toStrictEqual(hoistedLongJson);
     expect(isoLong).toContain("│   Javier Blanco <http://jbgutierrez.info>\n");
@@ -1044,13 +1098,17 @@ describe("bun pm licenses", () => {
     });
 
     expect(normalizeBunSnapshot(await licensesText(dir))).toMatchInlineSnapshot(`
-      "MIT (2)
+      "bun pm licenses <version> (<revision>)
+
+      MIT (2)
       ├── path-parse@1.0.6
       └── resolve@1.9.0
 
       Unknown (2)
       ├── a-dep@1.0.1 (dev)
-      └── no-deps@1.0.0"
+      └── no-deps@1.0.0
+
+      4 packages across 2 licenses (checked 4 packages in bun.lock)"
     `);
     expect(await licensesText(join(dir, "packages", "foo"))).toContain("├── a-dep@1.0.1 (dev)\n└── no-deps@1.0.0\n");
   });
@@ -1097,9 +1155,13 @@ describe("bun pm licenses", () => {
     expect(packagesGlob).toStrictEqual(monoJson);
     expectEmptyText(rootOnly, 0);
     expect(normalizeBunSnapshot(fooText)).toMatchInlineSnapshot(`
-      "Unknown (2)
+      "bun pm licenses <version> (<revision>)
+
+      Unknown (2)
       ├── a-dep@1.0.1 (dev)
-      └── no-deps@1.0.0"
+      └── no-deps@1.0.0
+
+      2 packages across 1 license (checked 2 packages in bun.lock)"
     `);
     expect(await licensesJson(monoDir, "--filter", "foo", "--prod")).toStrictEqual({
       Unknown: [u("no-deps", "1.0.0")],
@@ -1158,9 +1220,13 @@ describe("bun pm licenses", () => {
       `"warn: No workspace packages matched the filters "nomatch", "alsonone""`,
     );
     expect(normalizeBunSnapshot(text)).toMatchInlineSnapshot(`
-      "MIT (2)
+      "bun pm licenses <version> (<revision>)
+
+      MIT (2)
       ├── path-parse@1.0.6
-      └── resolve@1.9.0"
+      └── resolve@1.9.0
+
+      2 packages across 1 license (checked 2 packages in bun.lock)"
     `);
     expect(textExit).toBe(0);
   });
@@ -1220,7 +1286,9 @@ describe("bun pm licenses", () => {
       `warn: 1 package in bun.lock is not installed and was skipped\n${MISSING_NOTE}`,
     );
     expect(quietStderr).toBe("");
-    expect(quiet).toBe(loud);
+    // The loud run wraps the same listing in the banner and summary.
+    expect(loud).toContain(quiet);
+    expect(normalizeBunSnapshot(loud)).toStartWith(HEADER);
     expect(normalizeBunSnapshot(quiet)).toMatchInlineSnapshot(`
       "MIT (1)
       └── resolve@1.9.0
@@ -1279,8 +1347,8 @@ describe("bun pm licenses", () => {
       licenses(hoistedDir, "ls"),
     ]);
     expect(plain).toContain("MIT (2)");
-    expect(list).toBe(plain);
-    expect(ls).toBe(plain);
+    expect(normalizeBunSnapshot(list)).toBe(normalizeBunSnapshot(plain));
+    expect(normalizeBunSnapshot(ls)).toBe(normalizeBunSnapshot(plain));
     expect([plainExit, listExit, lsExit]).toStrictEqual([0, 0, 0]);
 
     const [stdout, stderr, exitCode] = await licenses(hoistedDir, "bogus");
@@ -1433,9 +1501,13 @@ describe("bun pm licenses", () => {
 
     const [stdout, stderr, exitCode] = await licenses(dir);
     expect(normalizeBunSnapshot(stdout).replace(/git\+file:\/\/\S+/, "git+file://<repo>")).toMatchInlineSnapshot(`
-      "Unknown (2)
+      "bun pm licenses <version> (<revision>)
+
+      Unknown (2)
       ├── no-deps@1.0.0
-      └── no-deps@git+file://<repo>"
+      └── no-deps@git+file://<repo>
+
+      2 packages across 1 license (checked 2 packages in bun.lock)"
     `);
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
@@ -1479,7 +1551,9 @@ describe("bun pm licenses", () => {
   test.concurrent("--omit=dev and bunfig install.production behave like --prod", async () => {
     expect(await licensesJson(hoistedDir, "--omit=dev")).toStrictEqual(prodJson);
     expect(await licensesText(hoistedDir, "--omit=dev")).not.toContain("(dev)");
-    expect(await licensesText(hoistedDir, "--omit", "dev")).toBe(await licensesText(hoistedDir, "--prod"));
+    expect(normalizeBunSnapshot(await licensesText(hoistedDir, "--omit", "dev"))).toBe(
+      normalizeBunSnapshot(await licensesText(hoistedDir, "--prod")),
+    );
 
     const dir = await setup();
     const bunfig = readFileSync(join(dir, "bunfig.toml"), "utf8");
@@ -1499,8 +1573,12 @@ describe("bun pm licenses", () => {
     expect(await licensesJson(dir)).toStrictEqual({ Unknown: [u("no-deps", "1.0.0", "1.0.1"), u("one-dep", "1.0.0")] });
     expect(await licensesJson(dir, "--omit=optional")).toStrictEqual({ Unknown: [u("no-deps", "1.0.0")] });
     expect(normalizeBunSnapshot(await licensesText(dir, "--omit=optional"))).toMatchInlineSnapshot(`
-      "Unknown (1)
-      └── no-deps@1.0.0"
+      "bun pm licenses <version> (<revision>)
+
+      Unknown (1)
+      └── no-deps@1.0.0
+
+      1 package across 1 license (checked 1 package in bun.lock)"
     `);
   });
 
@@ -1510,8 +1588,12 @@ describe("bun pm licenses", () => {
 
     expect(await licensesJson(dir)).toStrictEqual({ Unknown: [u("no-deps", "1.0.0")] });
     expect(normalizeBunSnapshot(await licensesText(dir))).toMatchInlineSnapshot(`
-      "Unknown (1)
-      └── no-deps@1.0.0"
+      "bun pm licenses <version> (<revision>)
+
+      Unknown (1)
+      └── no-deps@1.0.0
+
+      1 package across 1 license (checked 1 package in bun.lock)"
     `);
     expectEmptyText(await licensesText(dir, "--omit=peer"), 0);
     expect(await licensesJson(dir, "--omit=peer")).toStrictEqual({});
@@ -1634,7 +1716,9 @@ describe("bun pm licenses", () => {
       ],
     });
     expect(normalizeBunSnapshot(await licensesText(dir, "--long"))).toMatchInlineSnapshot(`
-      "MIT (2)
+      "bun pm licenses <version> (<revision>)
+
+      MIT (2)
       ├── path-parse@1.0.6
       │   Javier Blanco <http://jbgutierrez.info>
       │   Node.js path.parse() ponyfill
@@ -1650,7 +1734,9 @@ describe("bun pm licenses", () => {
       ├── no-deps@1.0.1
       │   (https://nd.example)
       └── one-dep@1.0.0
-          <one@example.com>"
+          <one@example.com>
+
+      6 packages across 2 licenses (checked 6 packages in bun.lock)"
     `);
   });
 

--- a/test/cli/install/bun-pm-licenses.test.ts
+++ b/test/cli/install/bun-pm-licenses.test.ts
@@ -1275,6 +1275,23 @@ describe("bun pm licenses", () => {
     expect(jsonExit).toBe(0);
   });
 
+  test.concurrent("--no-summary prints the bare listing without banner or summary", async () => {
+    const [stdout, stderr, exitCode] = await licenses(hoistedDir, "--no-summary");
+    expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`
+      "MIT (2)
+      ├── path-parse@1.0.6
+      └── resolve@1.9.0
+
+      Unknown (4)
+      ├── a-dep@1.0.1 (dev)
+      ├── no-deps@1.0.0
+      ├── no-deps@1.0.1
+      └── one-dep@1.0.0"
+    `);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
   test.concurrent("--silent still prints the listing but no diagnostics", async () => {
     const dir = await setup();
     rmSync(nm(dir, "path-parse"), { recursive: true });

--- a/test/cli/install/bun-pm-licenses.test.ts
+++ b/test/cli/install/bun-pm-licenses.test.ts
@@ -1290,6 +1290,13 @@ describe("bun pm licenses", () => {
     `);
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
+
+    // The empty listing keeps its message but drops the checked-count and timing.
+    const dir = await setup("hoisted", { "package.json": pkg({ devDependencies: { "no-deps": "1.0.0" } }) });
+    const [empty, emptyStderr, emptyExit] = await licenses(dir, "--prod", "--no-summary");
+    expect(empty).toBe("No packages to list\n");
+    expect(emptyStderr).toBe("");
+    expect(emptyExit).toBe(0);
   });
 
   test.concurrent("--silent still prints the listing but no diagnostics", async () => {

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -73,7 +73,7 @@ it("should list top-level dependency", async () => {
     env,
   });
   expect(await stderr.text()).toBe("");
-  expect(await stdout.text()).toBe(`${package_dir} node_modules (2)
+  expect(await stdout.text()).toBe(`${package_dir} node_modules (2 installed)
 └── moo@moo
 `);
   expect(await exited).toBe(0);
@@ -190,7 +190,7 @@ it("should list top-level aliased dependency", async () => {
     env,
   });
   expect(await stderr.text()).toBe("");
-  expect(await stdout.text()).toBe(`${package_dir} node_modules (2)
+  expect(await stdout.text()).toBe(`${package_dir} node_modules (2 installed)
 └── moo-1@moo
 `);
   expect(await exited).toBe(0);
@@ -316,7 +316,7 @@ it("should list only trusted dependencies with --trusted", async () => {
       env,
     });
     expect(await stderr.text()).toBe("");
-    expect(await stdout.text()).toBe(`${package_dir} node_modules (2)
+    expect(await stdout.text()).toBe(`${package_dir} node_modules (2 installed)
 └── bar@0.0.2
 `);
     expect(await exited).toBe(0);
@@ -333,7 +333,7 @@ it("should list only trusted dependencies with --trusted", async () => {
       env,
     });
     expect(await stderr.text()).toBe("");
-    expect(await stdout.text()).toBe(`${package_dir} node_modules (2)
+    expect(await stdout.text()).toBe(`${package_dir} node_modules (2 installed)
 ├── bar@0.0.2
 └── moo@moo
 `);
@@ -525,7 +525,7 @@ it("should list nothing with --trusted when no dependencies are trusted", async 
     env,
   });
   expect(await stderr.text()).toBe("");
-  expect(await stdout.text()).toBe(`${package_dir} node_modules (1)
+  expect(await stdout.text()).toBe(`${package_dir} node_modules (1 installed)
 `);
   expect(await exited).toBe(0);
 });
@@ -724,7 +724,7 @@ test.each([
     cmd: ["list"],
     packageName: "test-list",
     dependencies: { bar: "latest" },
-    expectedOutput: (dir: string) => `${dir} node_modules (1)\n└── bar@0.0.2\n`,
+    expectedOutput: (dir: string) => `${dir} node_modules (1 installed)\n└── bar@0.0.2\n`,
     checkReservationMessage: true,
   },
   {
@@ -732,7 +732,7 @@ test.each([
     cmd: ["pm", "list"],
     packageName: "test-pm-list",
     dependencies: { bar: "latest" },
-    expectedOutput: (dir: string) => `${dir} node_modules (1)\n└── bar@0.0.2\n`,
+    expectedOutput: (dir: string) => `${dir} node_modules (1 installed)\n└── bar@0.0.2\n`,
     checkReservationMessage: false,
   },
   {
@@ -740,7 +740,7 @@ test.each([
     cmd: ["pm", "ls"],
     packageName: "test-pm-ls",
     dependencies: { bar: "latest" },
-    expectedOutput: (dir: string) => `${dir} node_modules (1)\n└── bar@0.0.2\n`,
+    expectedOutput: (dir: string) => `${dir} node_modules (1 installed)\n└── bar@0.0.2\n`,
     checkReservationMessage: false,
   },
 ])("$name", async ({ cmd, packageName, dependencies, expectedOutput, checkReservationMessage }) => {

--- a/test/cli/install/bun-prune.test.ts
+++ b/test/cli/install/bun-prune.test.ts
@@ -42,9 +42,11 @@ const PRUNED_NOTE = 'note: skipped 1 workspace listed in bun.lock but not on dis
 const BANNER = "bun prune <version> (<revision>)";
 const plural = (n: number, noun: string) => `${n} ${noun}${n === 1 ? "" : "s"}`;
 const NOTHING = (packages: number, folders: number) =>
-  `Done! Checked ${plural(packages, "package")} across ${plural(folders, "folder")} (nothing to prune)`;
-const REMOVED = (n: number, checked: number) => `${plural(n, "package")} removed (checked ${checked})`;
-const CAN_BE_REMOVED = (n: number, checked: number) => `${plural(n, "package")} can be removed (checked ${checked})`;
+  `Done! Checked ${plural(packages, "installed package")} across ${plural(folders, "folder")} (nothing to prune)`;
+const REMOVED = (n: number, checked: number) =>
+  `${plural(n, "package")} removed (checked ${plural(checked, "installed package")})`;
+const CAN_BE_REMOVED = (n: number, checked: number) =>
+  `${plural(n, "package")} can be removed (checked ${plural(checked, "installed package")})`;
 // The copy-pasteable line `--dry-run` prints last: the invocation with `--dry-run` taken out.
 const APPLY_HINT = (...flags: string[]) => ["  bun prune", ...flags].join(" ");
 const DURATION = /\) \[\d+(\.\d+)?m?s\]$/m;
@@ -283,9 +285,9 @@ test.concurrent("removes extraneous packages, keeps everything the lockfile inst
     - @other/thing
     - @scoped/junk
     - junk
-    3 packages removed (checked 5)"
+    3 packages removed (checked 5 installed packages)"
   `);
-  expect(first.stdout).toMatch(/\(checked 5\) \[\d+(\.\d+)?m?s\]\n?$/);
+  expect(first.stdout).toMatch(/\(checked 5 installed packages\) \[\d+(\.\d+)?m?s\]\n?$/);
   expect(first.exitCode).toBe(0);
 
   for (const path of planted) {
@@ -316,7 +318,7 @@ test.concurrent("prunes nested node_modules folders the tree installs into", asy
     "bun prune <version> (<revision>)
 
     - junk (node_modules/one-dep/node_modules)
-    1 package removed (checked 4)"
+    1 package removed (checked 4 installed packages)"
   `);
   expect(exitCode).toBe(0);
   expect(existsSync(junk)).toBeFalse();
@@ -344,7 +346,7 @@ test.concurrent.each([["--production"], ["--prod"], ["--omit=dev"]])(
       - no-deps-bins@1.0.0
       - one-fixed-dep-bins@1.0.0
       - what-bin@1.0.0
-      3 packages removed (checked 5)"
+      3 packages removed (checked 5 installed packages)"
     `);
     expect(exitCode).toBe(0);
 
@@ -375,7 +377,7 @@ test.concurrent("--production keeps a package that prod and dev both need", asyn
     "bun prune <version> (<revision>)
 
     - one-fixed-dep@1.0.0
-    1 package removed (checked 2)"
+    1 package removed (checked 2 installed packages)"
   `);
   expect(production.exitCode).toBe(0);
   expect(existsSync(join(dir, "node_modules", "no-deps"))).toBeTrue();
@@ -385,7 +387,7 @@ test.concurrent("--production keeps a package that prod and dev both need", asyn
   expect(out(plain.stdout)).toMatchInlineSnapshot(`
     "bun prune <version> (<revision>)
 
-    Done! Checked 2 packages across 1 folder (nothing to prune)"
+    Done! Checked 2 installed packages across 1 folder (nothing to prune)"
   `);
   expect(plain.exitCode).toBe(0);
   expect(existsSync(join(plainDir, "node_modules", "one-fixed-dep"))).toBeTrue();
@@ -400,7 +402,7 @@ test.concurrent("--dry-run prints without deleting; --silent deletes without pri
     "bun prune <version> (<revision>)
 
     - junk
-    1 package can be removed (checked 2)
+    1 package can be removed (checked 2 installed packages)
       bun prune"
   `);
   expect(dryRun.stdout).toMatch(DURATION);
@@ -458,7 +460,7 @@ test.concurrent("nothing to prune when node_modules is missing or clean", async 
   expect(out(clean.stdout)).toMatchInlineSnapshot(`
     "bun prune <version> (<revision>)
 
-    Done! Checked 1 package across 1 folder (nothing to prune)"
+    Done! Checked 1 installed package across 1 folder (nothing to prune)"
   `);
   expect(clean.exitCode).toBe(0);
   expect(existsSync(join(cleanDir, "node_modules", "no-deps"))).toBeTrue();
@@ -479,7 +481,7 @@ test.concurrent("never follows symlinks out of node_modules", async () => {
     "bun prune <version> (<revision>)
 
     - linked-junk
-    1 package removed (checked 2)"
+    1 package removed (checked 2 installed packages)"
   `);
   expect(exitCode).toBe(0);
   expect(() => lstatSync(link)).toThrow();
@@ -563,7 +565,7 @@ test.concurrent("workspaces: prunes workspace folders, keeps workspace links, ru
 
     - a-dep@1.0.1
     - junk (node_modules/a/node_modules)
-    2 packages removed (checked 5)"
+    2 packages removed (checked 5 installed packages)"
   `);
   expect(exitCode).toBe(0);
 
@@ -582,7 +584,7 @@ test.concurrent("keeps dependencies bundled inside a package", async () => {
   expect(out(stdout)).toMatchInlineSnapshot(`
     "bun prune <version> (<revision>)
 
-    Done! Checked 3 packages across 1 folder (nothing to prune)"
+    Done! Checked 3 installed packages across 1 folder (nothing to prune)"
   `);
   expect(exitCode).toBe(0);
   expect(existsSync(bundled)).toBeTrue();
@@ -621,7 +623,7 @@ test.concurrent("isolated linker: removes unused store entries and their links",
     - no-deps@1.0.1
     - one-dep@1.0.0
     - zzz@1.0.0
-    6 packages removed (checked 9)"
+    6 packages removed (checked 9 installed packages)"
   `);
   expect(exitCode).toBe(0);
 
@@ -669,7 +671,7 @@ test.concurrent("isolated linker: prune removes the peer-hash variants a peer bu
     "",
     "- no-deps@1.0.0",
     `- ${before}`,
-    "2 packages removed (checked 6)",
+    "2 packages removed (checked 6 installed packages)",
   ]);
   expect(exitCode).toBe(0);
   expect(peerEntries()).toStrictEqual([after]);
@@ -693,7 +695,7 @@ test.concurrent("isolated linker + global store: unlinks the store link, never d
 
   const { stdout, exitCode } = await prune(dir, "--production");
   expect(out(stdout)).toContain("- one-dep@1.0.0");
-  expect(out(stdout)).toEndWith("2 packages removed (checked 3)");
+  expect(out(stdout)).toEndWith("2 packages removed (checked 3 installed packages)");
   expect(exitCode).toBe(0);
 
   expect(() => lstatSync(storeEntry)).toThrow();
@@ -712,7 +714,7 @@ test.concurrent("isolated linker: bins of removed packages are removed, live one
   expectBinInstalled(nm, "has-bin-entry");
 
   const { stdout, exitCode } = await prune(dir, "--production", "--linker", "isolated");
-  expect(out(stdout)).toEndWith("- what-bin@1.0.0\n1 package removed (checked 4)");
+  expect(out(stdout)).toEndWith("- what-bin@1.0.0\n1 package removed (checked 4 installed packages)");
   expect(exitCode).toBe(0);
 
   expectBinRemoved(nm, "what-bin");
@@ -751,7 +753,7 @@ test.concurrent("hoisted: dot entries and files are never touched even when the 
     "bun prune <version> (<revision>)
 
     - junk
-    1 package removed (checked 1)"
+    1 package removed (checked 1 installed package)"
   `);
   expect(exitCode).toBe(0);
   expect(existsSync(junk)).toBeFalse();
@@ -811,7 +813,7 @@ test.concurrent(
     expect(out(stdout)).toMatchInlineSnapshot(`
     "bun prune <version> (<revision>)
 
-    Done! Checked 2 packages across 1 folder (nothing to prune)"
+    Done! Checked 2 installed packages across 1 folder (nothing to prune)"
   `);
     expect(exitCode).toBe(0);
     expect(existsSync(keepMe)).toBeTrue();
@@ -832,7 +834,7 @@ test.concurrent("hoisted: a symlinked scope dir is unlinked, not followed", asyn
 
     - @fake
     - @real/junk
-    2 packages removed (checked 3)"
+    2 packages removed (checked 3 installed packages)"
   `);
   expect(exitCode).toBe(0);
   expect(() => lstatSync(join(nm, "@fake"))).toThrow();
@@ -866,7 +868,7 @@ test.concurrent(
       "bun prune <version> (<revision>)
 
       - junk (node_modules/a/node_modules)
-      1 package can be removed (checked 4)
+      1 package can be removed (checked 4 installed packages)
         bun prune --linker hoisted"
     `);
     expect(dryRun.exitCode).toBe(0);
@@ -877,7 +879,7 @@ test.concurrent(
       "bun prune <version> (<revision>)
 
       - junk (node_modules/a/node_modules)
-      1 package removed (checked 4)"
+      1 package removed (checked 4 installed packages)"
     `);
     expect(exitCode).toBe(0);
     expect(existsSync(junk)).toBeFalse();
@@ -902,7 +904,7 @@ test.concurrent.skipIf(isWindows)("a symlinked .bin directory is never cleaned t
     "bun prune <version> (<revision>)
 
     - junk
-    1 package removed (checked 2)"
+    1 package removed (checked 2 installed packages)"
   `);
   expect(exitCode).toBe(0);
   expect(existsSync(junk)).toBeFalse();
@@ -922,7 +924,7 @@ test.concurrent("isolated: extraneous symlinks are removed even when the store i
 
     - @ext/thing
     - ext
-    2 packages removed (checked 4)"
+    2 packages removed (checked 4 installed packages)"
   `);
   expect(first.exitCode).toBe(0);
   expect(() => lstatSync(join(nm, "ext"))).toThrow();
@@ -956,7 +958,7 @@ test.concurrent(
 
     - @scoped/has-bin-entry@1.0.0
     - one-dep@1.0.0
-    2 packages removed (checked 3)"
+    2 packages removed (checked 3 installed packages)"
   `);
     expect(exitCode).toBe(0);
     expect(existsSync(join(nm, "one-dep"))).toBeFalse();
@@ -982,7 +984,7 @@ test.concurrent("hoisted: removing only a scoped package also removes its bin li
     "bun prune <version> (<revision>)
 
     - @scoped/has-bin-entry@1.0.0
-    1 package removed (checked 2)"
+    1 package removed (checked 2 installed packages)"
   `);
   expect(exitCode).toBe(0);
   expect(existsSync(join(nm, "@scoped"))).toBeFalse();
@@ -1010,7 +1012,7 @@ test.concurrent(
     - @scoped/has-bin-entry@1.0.0
     - no-deps@1.0.1
     - one-dep@1.0.0
-    3 packages removed (checked 7)"
+    3 packages removed (checked 7 installed packages)"
   `);
     expect(exitCode).toBe(0);
     expect(() => lstatSync(join(nm, "one-dep"))).toThrow();
@@ -1043,7 +1045,7 @@ test.concurrent("hoisted: --production empties a workspace folder that only held
     "bun prune <version> (<revision>)
 
     - no-deps@1.0.0 (packages/a/node_modules)
-    1 package removed (checked 3)"
+    1 package removed (checked 3 installed packages)"
   `);
   expect(exitCode).toBe(0);
   expect(existsSync(nested)).toBeFalse();
@@ -1083,7 +1085,7 @@ test.concurrent(
 
       - a-dep@1.0.1
       - tool@1.0.0 (packages/app/node_modules)
-      2 packages can be removed (checked 6)
+      2 packages can be removed (checked 6 installed packages)
         bun prune --production --linker isolated"
     `);
     expect(dryRun.exitCode).toBe(0);
@@ -1095,7 +1097,7 @@ test.concurrent(
 
       - a-dep@1.0.1
       - tool@1.0.0 (packages/app/node_modules)
-      2 packages removed (checked 6)"
+      2 packages removed (checked 6 installed packages)"
     `);
     expect(exitCode).toBe(0);
     expect(() => lstatSync(join(appNm, "a-dep"))).toThrow();
@@ -1123,7 +1125,7 @@ test.concurrent("isolated: a real directory named like a workspace is never dele
     "bun prune <version> (<revision>)
 
     - a-dep@1.0.1
-    1 package removed (checked 6)"
+    1 package removed (checked 6 installed packages)"
   `);
   expect(exitCode).toBe(0);
   expect(existsSync(join(planted, "package.json"))).toBeTrue();
@@ -1160,7 +1162,7 @@ test.concurrent(
       "bun prune <version> (<revision>)
 
       - @scope/tool@1.0.0 (packages/app/node_modules)
-      1 package removed (checked 4)"
+      1 package removed (checked 4 installed packages)"
     `);
     expect(mixed.exitCode).toBe(0);
     expect(() => lstatSync(join(mixedScope, "tool"))).toThrow();
@@ -1173,7 +1175,7 @@ test.concurrent(
       "bun prune <version> (<revision>)
 
       - @scope/tool@1.0.0 (packages/app/node_modules)
-      1 package removed (checked 3)"
+      1 package removed (checked 3 installed packages)"
     `);
     expect(devOnly.exitCode).toBe(0);
     expect(existsSync(devOnlyScope)).toBeFalse();
@@ -1203,7 +1205,7 @@ test.concurrent(
       "bun prune <version> (<revision>)
 
       - tool@1.0.0 (packages/app/node_modules)
-      1 package removed (checked 4)"
+      1 package removed (checked 4 installed packages)"
     `);
     expect(exitCode).toBe(0);
     expect(() => lstatSync(appTool)).toThrow();
@@ -1350,7 +1352,7 @@ test.concurrent.each(linkers)("%s: a workspace lifecycle script is not out of sy
     "bun prune <version> (<revision>)
 
     - junk
-    1 package removed (checked 3)"
+    1 package removed (checked 3 installed packages)"
   `);
   expect(exitCode).toBe(0);
   expect(existsSync(junk)).toBeFalse();
@@ -1371,7 +1373,7 @@ test.concurrent("trustedDependencies stripped from bun.lock is not out of sync",
     "bun prune <version> (<revision>)
 
     - junk
-    1 package removed (checked 2)"
+    1 package removed (checked 2 installed packages)"
   `);
   expect(exitCode).toBe(0);
   expect(existsSync(junk)).toBeFalse();
@@ -1427,7 +1429,7 @@ test.concurrent("isolated: a workspace missing from disk no longer keeps its sto
 
     - junk
     - left-pad@1.0.0
-    2 packages removed (checked 4)"
+    2 packages removed (checked 4 installed packages)"
   `);
   expect(exitCode).toBe(0);
   expect(existsSync(junk)).toBeFalse();
@@ -1456,7 +1458,7 @@ test.concurrent("hoisted: --filter on a pruned checkout does not protect the mis
 
     - left-pad@1.0.0
     - other
-    2 packages removed (checked 4)"
+    2 packages removed (checked 4 installed packages)"
   `);
   expect(exitCode).toBe(0);
   expect(existsSync(join(nm, "left-pad"))).toBeFalse();
@@ -1498,7 +1500,7 @@ test.concurrent(
       "bun prune <version> (<revision>)
 
       - shared-alias@1.0.0
-      1 package removed (checked 3)"
+      1 package removed (checked 3 installed packages)"
     `);
     expect(exitCode).toBe(0);
     expect(isSymlink(join(nm, "app"))).toBeTrue();
@@ -1538,7 +1540,7 @@ test.concurrent(
 
       - a-dep@1.0.1
       - junk (node_modules/a/node_modules)
-      2 packages removed (checked 8)"
+      2 packages removed (checked 8 installed packages)"
     `);
     expect(onlyA.exitCode).toBe(0);
     expect(existsSync(aJunk)).toBeFalse();
@@ -1553,7 +1555,7 @@ test.concurrent(
       "bun prune <version> (<revision>)
 
       - left-pad@1.0.0
-      1 package removed (checked 5)"
+      1 package removed (checked 5 installed packages)"
     `);
     expect(onlyRoot.exitCode).toBe(0);
     expect(existsSync(bJunk)).toBeTrue();
@@ -1565,7 +1567,7 @@ test.concurrent(
 
       - junk (node_modules/b/node_modules)
       - one-fixed-dep@1.0.0
-      2 packages removed (checked 7)"
+      2 packages removed (checked 7 installed packages)"
     `);
     expect(everything.exitCode).toBe(0);
     expect(existsSync(bJunk)).toBeFalse();
@@ -1593,7 +1595,7 @@ test.concurrent(
 
       - a-dep@1.0.1 (packages/a/node_modules)
       - one-fixed-dep@1.0.0
-      2 packages removed (checked 7)"
+      2 packages removed (checked 7 installed packages)"
     `);
     expect(onlyA.exitCode).toBe(0);
     expect(existsSync(join(store, "a-dep@1.0.1"))).toBeTrue();
@@ -1611,7 +1613,7 @@ test.concurrent(
 
       - a-dep@1.0.1
       - left-pad@1.0.0
-      2 packages removed (checked 6)"
+      2 packages removed (checked 6 installed packages)"
     `);
     expect(everything.exitCode).toBe(0);
     expect(() => lstatSync(join(bNm, "a-dep"))).toThrow();
@@ -1635,7 +1637,7 @@ test.concurrent(
       "bun prune <version> (<revision>)
 
       - a-dep@1.0.1 (packages/selected/node_modules)
-      1 package removed (checked 4)"
+      1 package removed (checked 4 installed packages)"
     `);
     expect(first.exitCode).toBe(0);
     expect(() => lstatSync(selectedADep)).toThrow();
@@ -1647,7 +1649,7 @@ test.concurrent(
       "bun prune <version> (<revision>)
 
       - a-dep@1.0.1 (packages/unselected/node_modules)
-      1 package removed (checked 4)"
+      1 package removed (checked 4 installed packages)"
     `);
     expect(second.exitCode).toBe(0);
     expect(() => lstatSync(unselectedADep)).toThrow();
@@ -1658,7 +1660,7 @@ test.concurrent(
       "bun prune <version> (<revision>)
 
       - a-dep@1.0.1
-      1 package removed (checked 4)"
+      1 package removed (checked 4 installed packages)"
     `);
     expect(everything.exitCode).toBe(0);
     expect(existsSync(storeEntry)).toBeFalse();
@@ -1802,7 +1804,7 @@ test.concurrent("hoisted: --filter with no match is an error; path filters resol
     "bun prune <version> (<revision>)
 
     - junk (node_modules/a/node_modules)
-    1 package removed (checked 4)"
+    1 package removed (checked 4 installed packages)"
   `);
   expect(exitCode).toBe(0);
   expect(existsSync(junk)).toBeFalse();
@@ -1883,7 +1885,7 @@ test.concurrent.each([["--os=aix"], ["--cpu=s390x"]])(
       "bun prune <version> (<revision>)
 
       - test-postinstall-skip-native@1.0.0
-      1 package removed (checked 2)"
+      1 package removed (checked 2 installed packages)"
     `);
     expect(other.exitCode).toBe(0);
     expect(existsSync(native)).toBeFalse();
@@ -1908,7 +1910,7 @@ test.concurrent.each(["hoisted", "isolated"] as Linker[])(
 
     const { stdout, exitCode } = await prune(dir, "--linker", linker);
     expect(out(stdout)).toBe(
-      `bun prune <version> (<revision>)\n\n- junk\n1 package removed (checked ${linker === "hoisted" ? 4 : 6})`,
+      `bun prune <version> (<revision>)\n\n- junk\n${REMOVED(1, linker === "hoisted" ? 4 : 6)}`,
     );
     expect(exitCode).toBe(0);
     expect(existsSync(junk)).toBeFalse();
@@ -1944,7 +1946,7 @@ test.concurrent("isolated + publicHoistPattern: hoisted links follow their store
 
     - no-deps@1.0.1
     - one-dep@1.0.0
-    2 packages removed (checked 5)"
+    2 packages removed (checked 5 installed packages)"
   `);
   expect(production.exitCode).toBe(0);
   expect(() => lstatSync(join(store, "node_modules", "one-dep"))).toThrow();
@@ -1970,7 +1972,7 @@ test.concurrent.skipIf(isWindows || process.getuid?.() === 0)(
         "",
         "- junk-a",
         expect.stringMatching(failure),
-        "1 package removed, 1 failed (checked 3)",
+        "1 package removed, 1 failed (checked 3 installed packages)",
       ]);
       expect(exitCode).toBe(1);
       expect(existsSync(junkA)).toBeFalse();
@@ -1991,7 +1993,7 @@ test.concurrent.skipIf(isWindows || process.getuid?.() === 0)(
     "bun prune <version> (<revision>)
 
     - junk-b
-    1 package removed (checked 2)"
+    1 package removed (checked 2 installed packages)"
   `);
     expect(exitCode).toBe(0);
     expect(existsSync(junkB)).toBeFalse();
@@ -2020,7 +2022,7 @@ test.concurrent("never runs the project's lifecycle scripts", async () => {
     "bun prune <version> (<revision>)
 
     - junk
-    1 package removed (checked 3)"
+    1 package removed (checked 3 installed packages)"
   `);
   expect(plain.exitCode).toBe(0);
   expect(existsSync(junk)).toBeFalse();
@@ -2031,7 +2033,7 @@ test.concurrent("never runs the project's lifecycle scripts", async () => {
     "bun prune <version> (<revision>)
 
     - a-dep@1.0.1
-    1 package removed (checked 2)"
+    1 package removed (checked 2 installed packages)"
   `);
   expect(production.exitCode).toBe(0);
   expect(existsSync(ran)).toBeFalse();
@@ -2090,7 +2092,7 @@ test.concurrent.each(["peer-deps-fixed", "optional-peer-deps"])(
       "bun prune <version> (<revision>)",
       "",
       "- no-deps@1.0.0",
-      "1 package removed (checked 4)",
+      "1 package removed (checked 4 installed packages)",
     ]);
     expect(exitCode).toBe(0);
     expect(storeEntries(dir)).toStrictEqual(["no-deps@1.0.0", entry]);
@@ -2157,7 +2159,7 @@ test.concurrent(
       "",
       "- a-dep@1.0.1",
       "- no-deps@2.0.0",
-      "2 packages removed (checked 10)",
+      "2 packages removed (checked 10 installed packages)",
     ]);
     expect(exitCode).toBe(0);
     expect(storeEntries(dir)).toStrictEqual(["no-deps@1.0.1", "one-dep@1.0.0", productionEntry, fullEntry].toSorted());
@@ -2194,7 +2196,7 @@ test.concurrent("isolated: --production removes the stale peer-hash variant and 
     "- a-dep@1.0.1",
     "- no-deps@1.0.0",
     `- ${before}`,
-    "3 packages removed (checked 8)",
+    "3 packages removed (checked 8 installed packages)",
   ]);
   expect(exitCode).toBe(0);
   expect(storeEntries(dir)).toStrictEqual(["no-deps@1.0.1", after]);
@@ -2228,7 +2230,7 @@ test.concurrent("keeps dependencies bundled inside a file: dependency", async ()
     "bun prune <version> (<revision>)
 
     - junk
-    1 package removed (checked 2)"
+    1 package removed (checked 2 installed packages)"
   `);
   expect(exitCode).toBe(0);
   expect(existsSync(junk)).toBeFalse();
@@ -2275,7 +2277,7 @@ test.concurrent(
       "bun prune <version> (<revision>)
 
       - no-deps@1.0.1 (node_modules/one-dep/node_modules)
-      1 package removed (checked 3)"
+      1 package removed (checked 3 installed packages)"
     `);
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
@@ -2295,18 +2297,30 @@ test.concurrent(
     expect(await file(rootPkgJson).json()).toMatchObject({ version: "2.0.0" });
     expect(await file(nestedPkgJson).json()).toMatchObject({ version: "1.0.0" });
 
+    // The root copy is the one a full install hoists there, not a stale tree:
+    // no "is not the version bun.lock expects" warning, no install hint.
     const { stdout, stderr, exitCode } = await prune(dir, "--production");
     expect(out(stdout)).toMatchInlineSnapshot(`
       "bun prune <version> (<revision>)
 
-      Done! Checked 3 packages across 2 folders (nothing to prune)"
+      Done! Checked 3 installed packages across 2 folders (nothing to prune)"
     `);
-    expect(out(stderr)).toBe(
-      `${WARN("node_modules/no-deps", "node_modules/one-fixed-dep/node_modules/no-deps")}\n${NOTE}`,
-    );
+    expect(stderr).toBe("");
     expect(exitCode).toBe(0);
     expect(await file(nestedPkgJson).json()).toMatchObject({ version: "1.0.0" });
     expect(await file(rootPkgJson).json()).toMatchObject({ version: "2.0.0" });
+
+    // A root copy whose version the lockfile does not know anywhere is a
+    // genuinely stale tree and still warns under --production.
+    const rootPkg = await file(rootPkgJson).json();
+    await write(rootPkgJson, JSON.stringify({ ...rootPkg, version: "9.9.9" }));
+    const stale = await prune(dir, "--production", "--dry-run");
+    expect(out(stale.stderr)).toBe(
+      `${WARN("node_modules/no-deps", "node_modules/one-fixed-dep/node_modules/no-deps")}\n${NOTE}`,
+    );
+    expect(stale.exitCode).toBe(0);
+    await write(rootPkgJson, JSON.stringify(rootPkg));
+
     await runBunInstall(installEnv(dir), dir, { production: true });
 
     const silent = await prune(silentDir, "--production", "--silent");
@@ -2377,13 +2391,15 @@ test.concurrent(
     expect(await file(rootPkgJson).json()).toMatchObject({ version: "2.0.0" });
     expect(await file(workspacePkgJson).json()).toMatchObject({ version: "1.0.0" });
 
+    // The root copy is the dev version a full install hoists there; not a
+    // stale tree, so no warning under --production.
     const { stdout, stderr, exitCode } = await prune(dir, "--production", "--linker", "hoisted");
     expect(out(stdout)).toMatchInlineSnapshot(`
       "bun prune <version> (<revision>)
 
-      Done! Checked 3 packages across 2 folders (nothing to prune)"
+      Done! Checked 3 installed packages across 2 folders (nothing to prune)"
     `);
-    expect(out(stderr)).toBe(`${WARN("node_modules/no-deps", "packages/a/node_modules/no-deps")}\n${NOTE}`);
+    expect(stderr).toBe("");
     expect(exitCode).toBe(0);
     expect(await file(workspacePkgJson).json()).toMatchObject({ version: "1.0.0" });
     expect(isSymlink(join(nm, "a"))).toBeTrue();
@@ -2411,7 +2427,7 @@ test.concurrent(
       "bun prune <version> (<revision>)
 
       - what-bin@1.0.0
-      1 package can be removed (checked 4)
+      1 package can be removed (checked 4 installed packages)
         bun prune --production --linker isolated"
     `);
     expect(dryRun.exitCode).toBe(0);
@@ -2423,7 +2439,7 @@ test.concurrent(
       "bun prune <version> (<revision>)
 
       - what-bin@1.0.0
-      1 package removed (checked 4)"
+      1 package removed (checked 4 installed packages)"
     `);
     expect(exitCode).toBe(0);
     expect(() => lstatSync(join(nm, "what-bin"))).toThrow();
@@ -2456,7 +2472,7 @@ test.concurrent("hoisted: nested node_modules of packages without a tree node ar
 
     - @other/thing (node_modules/@scoped/has-bin-entry/node_modules)
     - junk (node_modules/no-deps/node_modules)
-    2 packages removed (checked 4)"
+    2 packages removed (checked 4 installed packages)"
   `);
   expect(exitCode).toBe(0);
   expect(existsSync(junk)).toBeFalse();
@@ -2512,7 +2528,7 @@ test.concurrent("refuses to prune an isolated install with the hoisted linker", 
 
     - no-deps@1.0.1
     - one-dep@1.0.0
-    2 packages removed (checked 3)"
+    2 packages removed (checked 3 installed packages)"
   `);
   expect(same.exitCode).toBe(0);
   expect(() => lstatSync(join(nm, "one-dep"))).toThrow();
@@ -2631,7 +2647,7 @@ test.concurrent(
       - git-pkg@1.0.0
       - junk@1.0.0
       - local@file+elsewhere
-      3 packages removed (checked 11)"
+      3 packages removed (checked 11 installed packages)"
     `);
     expect(exitCode).toBe(0);
     expect(storeEntries(dir)).toStrictEqual(installed);
@@ -2666,7 +2682,7 @@ test.concurrent(
 
       - a-dep@1.0.1
       - junk@1.0.0
-      2 packages removed (checked 6)"
+      2 packages removed (checked 6 installed packages)"
     `);
     expect(exitCode).toBe(0);
     expect(existsSync(junk)).toBeFalse();
@@ -2709,7 +2725,7 @@ test.concurrent(
 
       - a-dep@1.0.1
       - junk
-      2 packages removed (checked 5)"
+      2 packages removed (checked 5 installed packages)"
     `);
     expect(exitCode).toBe(0);
     expect(existsSync(junk)).toBeFalse();
@@ -2741,7 +2757,7 @@ test.concurrent("without --linker, a project without workspaces is pruned with t
 
     - a-dep@1.0.1
     - junk
-    2 packages removed (checked 4)"
+    2 packages removed (checked 4 installed packages)"
   `);
   expect(exitCode).toBe(0);
   expect(existsSync(junk)).toBeFalse();
@@ -2771,7 +2787,7 @@ test.concurrent.each([["--os=aix"], ["--cpu=s390x"]])(
       "bun prune <version> (<revision>)
 
       - test-postinstall-skip-native@1.0.0
-      1 package removed (checked 4)"
+      1 package removed (checked 4 installed packages)"
     `);
     expect(other.exitCode).toBe(0);
     expect(existsSync(join(store, "test-postinstall-skip-native@1.0.0"))).toBeFalse();
@@ -2827,7 +2843,7 @@ test.concurrent("hoisted: the nested tree of a package with bundled dependencies
     "bun prune <version> (<revision>)
 
     - junk (node_modules/one-dep/node_modules)
-    1 package removed (checked 5)"
+    1 package removed (checked 5 installed packages)"
   `);
   expect(exitCode).toBe(0);
   expect(existsSync(junk)).toBeTrue();
@@ -2865,7 +2881,7 @@ test.concurrent(
       "bun prune <version> (<revision>)
 
       - git-pkg (node_modules/no-deps/node_modules)
-      1 package removed (checked 3)"
+      1 package removed (checked 3 installed packages)"
     `);
     expect(exitCode).toBe(0);
     expect(existsSync(nested)).toBeFalse();
@@ -2921,7 +2937,7 @@ test.concurrent(
       "bun prune <version> (<revision>)
 
       - left-pad (node_modules/no-deps/node_modules)
-      1 package removed (checked 3)"
+      1 package removed (checked 3 installed packages)"
     `);
     expect(exitCode).toBe(0);
     expect(existsSync(nested)).toBeFalse();
@@ -2953,7 +2969,7 @@ test.concurrent("hoisted: a nested copy of a link: dependency is removed when th
     "bun prune <version> (<revision>)
 
     - linked (node_modules/no-deps/node_modules)
-    1 package removed (checked 3)"
+    1 package removed (checked 3 installed packages)"
   `);
   expect(exitCode).toBe(0);
   expect(existsSync(nested)).toBeFalse();
@@ -2987,7 +3003,7 @@ test.concurrent("hoisted: a nested copy left behind by an override to a tarball 
     "bun prune <version> (<revision>)
 
     - no-deps@1.0.1 (node_modules/one-dep/node_modules)
-    1 package removed (checked 3)"
+    1 package removed (checked 3 installed packages)"
   `);
   expect(exitCode).toBe(0);
   expect(existsSync(nested)).toBeFalse();
@@ -3012,7 +3028,7 @@ test.concurrent(
       "bun prune <version> (<revision>)
 
       - no-deps-build-metadata (node_modules/no-deps/node_modules)
-      1 package removed (checked 3)"
+      1 package removed (checked 3 installed packages)"
     `);
     expect(exitCode).toBe(0);
     expect(existsSync(nested)).toBeFalse();
@@ -3044,7 +3060,7 @@ test.concurrent(
 
       - no-deps@1.0.1
       - one-dep@1.0.0
-      2 packages removed (checked 6)"
+      2 packages removed (checked 6 installed packages)"
     `);
     expect(production.exitCode).toBe(0);
     expect(existsSync(join(store, "no-deps@1.0.1"))).toBeFalse();
@@ -3083,7 +3099,7 @@ test.concurrent(
       - no-deps@1.0.1
       - one-dep@1.0.0
       - one-dep@1.0.0+0123456789abcdef
-      4 packages removed (checked 7)"
+      4 packages removed (checked 7 installed packages)"
     `);
     expect(exitCode).toBe(0);
     expect(existsSync(variant)).toBeFalse();
@@ -3114,7 +3130,7 @@ test.concurrent("isolated: an emptied scope dir of dangling hidden-hoist links i
     - @scope/zzz@1.0.0
     - no-deps@1.0.1
     - one-dep@1.0.0
-    3 packages removed (checked 6)"
+    3 packages removed (checked 6 installed packages)"
   `);
   expect(exitCode).toBe(0);
   expect(existsSync(scopeDir)).toBeFalse();
@@ -3134,7 +3150,7 @@ test.concurrent("isolated: --filter on a pruned checkout does not protect the mi
     "bun prune <version> (<revision>)
 
     - left-pad@1.0.0
-    1 package removed (checked 3)"
+    1 package removed (checked 3 installed packages)"
   `);
   expect(exitCode).toBe(0);
   expect(existsSync(join(store, "left-pad@1.0.0"))).toBeFalse();
@@ -3222,7 +3238,7 @@ test.concurrent("missing package.json is an error; --cwd prunes another director
     "bun prune <version> (<revision>)
 
     - junk
-    1 package removed (checked 2)"
+    1 package removed (checked 2 installed packages)"
   `);
   expect(exitCode).toBe(0);
   expect(existsSync(junk)).toBeFalse();
@@ -3263,7 +3279,7 @@ test.concurrent(
       "bun prune <version> (<revision>)
 
       - junk
-      1 package removed (checked 2)"
+      1 package removed (checked 2 installed packages)"
     `);
     expect(pruned.exitCode).toBe(0);
     expect(existsSync(junk)).toBeFalse();
@@ -3293,7 +3309,7 @@ test.concurrent("--no-optional is not --omit=optional", async () => {
     "bun prune <version> (<revision>)
 
     - a-dep@1.0.1
-    1 package can be removed (checked 2)
+    1 package can be removed (checked 2 installed packages)
       bun prune --omit=optional"
   `);
   expect(omit.exitCode).toBe(0);
@@ -3365,7 +3381,7 @@ test.concurrent("--help lists every flag; -F is --filter, -p is --production", a
     "bun prune <version> (<revision>)
 
     - junk (node_modules/b/node_modules)
-    1 package removed (checked 5)"
+    1 package removed (checked 5 installed packages)"
   `);
   expect(exitCode).toBe(0);
   expect(existsSync(aJunk)).toBeTrue();

--- a/test/cli/install/bun-prune.test.ts
+++ b/test/cli/install/bun-prune.test.ts
@@ -1909,9 +1909,7 @@ test.concurrent.each(["hoisted", "isolated"] as Linker[])(
     const junk = plant(dir, "node_modules/junk");
 
     const { stdout, exitCode } = await prune(dir, "--linker", linker);
-    expect(out(stdout)).toBe(
-      `bun prune <version> (<revision>)\n\n- junk\n${REMOVED(1, linker === "hoisted" ? 4 : 6)}`,
-    );
+    expect(out(stdout)).toBe(`bun prune <version> (<revision>)\n\n- junk\n${REMOVED(1, linker === "hoisted" ? 4 : 6)}`);
     expect(exitCode).toBe(0);
     expect(existsSync(junk)).toBeFalse();
     expect(await file(join(nm, "my-alias", "package.json")).json()).toMatchObject({

--- a/test/cli/install/isolated-relink.test.ts
+++ b/test/cli/install/isolated-relink.test.ts
@@ -204,7 +204,7 @@ test.concurrent("the orphaned store entry survives the re-link until bun prune",
     "bun prune <version> (<revision>)
 
     - no-deps@1.1.0
-    1 package removed (checked 4)"
+    1 package removed (checked 4 installed packages)"
   `);
   expect(err).not.toContain("error:");
   expect(exitCode).toBe(0);


### PR DESCRIPTION
### Problem

Five rough edges in the package manager command output, reported in #38925. The resolutions and lockfiles are correct in every case; only the output misleads.

- `bun dedupe` prints a row like `↳ undici-types 7.24.6` with no arrow or target when a duplicate is dropped outright, which reads like truncated output next to `name old → new` rows (`src/install/dedupe.rs`, `print_rows`)
- a multi-major downgrade like `@types/node 25.9.1 → 22.19.19` is styled exactly like a patch bump
- `bun prune --production` on a freshly installed tree warns `node_modules/<pkg> is not the version bun.lock expects` plus `note: run 'bun install' first`, claiming a correct tree is stale (`src/install/prune.rs`, `HoistedTree::removable`). Excluding dev deps changes which copy the hoist favors, so the hoisted position legitimately holds a different copy than the production view expects, and running `bun install` changes nothing
- `bun pm licenses` prints no command banner and no closing summary, unlike every other pm command
- summary lines count different things without naming them: dedupe counts lockfile entries, prune counts installed entries, `bun pm ls` counts tree positions, so the numbers look contradictory across commands

### Fix

- dedupe: a dropped duplicate now prints `↳ undici-types 7.24.6 → (removed)`; a row whose surviving versions are all a lower major is marked `(downgrade)` (yellow on a terminal). Same-major downgrades stay unmarked to keep the marker meaningful
- prune: when pruning with `--production`/`--omit` and the hoisted position holds a different version, the copy is kept silently if that version exists in the lockfile under the same name (it is the copy a full install put there). A version the lockfile does not know anywhere is still a stale tree and keeps the existing warning and note. Plain `bun prune` behavior is unchanged; only the messages changed, never what is kept or removed
- `bun pm licenses`: prints the standard `bun pm licenses v<version> (<sha>)` banner and closes with `N packages across M licenses (checked K packages in bun.lock) [elapsed]`. The banner prints after all validation exits so error output keeps a clean stdout, and `--json` output is byte-for-byte unchanged
- units named: dedupe summaries say `checked N packages in bun.lock` (matching the existing `bun pm licenses` empty-case wording), prune says `checked N installed packages`, `bun pm ls` says `node_modules (N installed)`. `bun install`/`bun update`'s `Saved bun.lock (N packages)` is left alone: the count sits next to the file it describes, and changing it would churn `bun install` output wholesale
- docs samples in `docs/pm/cli/{dedupe,prune,pm}.mdx` and the npm-migration guide updated to match

Verified by updating the existing output assertions in `test/cli/install/bun-dedupe.test.ts`, `bun-prune.test.ts`, `bun-pm-licenses.test.ts`, `bun-pm.test.ts` and `bun-install-lifecycle-scripts.test.ts`; all five files pass with the debug build. The previously asserted spurious `--production` warnings (two prune tests) now assert empty stderr, and one of them gains a stale-tree case proving the warning still fires when the installed version is foreign to the lockfile.

The reporter also mentioned `bun outdated` drawing a rule between every row; that predates the pm work (reproduces on 1.3.14) and is left out of this PR.

### Background

- The hoisted install tree assigns each package a position in `node_modules`; when two versions of one package are needed, one wins the top-level spot and the others nest under their dependents. Which one wins depends on which dependency edges exist, so excluding dev dependencies (`--production`) can flip the winner
- `bun prune` compares the tree on disk against the positions the lockfile implies for the requested view; a keep decision on mismatch was already conservative, this PR only changes when it narrates that decision as a problem
- `bun dedupe` collapses duplicate versions that a single surviving version can satisfy; a duplicate whose dependents all move elsewhere leaves no target, which is the `(removed)` case

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install-lifecycle-scripts.test.ts test/cli/install/bun-prune.test.ts test/cli/install/isolated-relink.test.ts

<!-- robobun:evidence:end -->