### PR TITLE
js_parser: keep legacy-decorated static field initializers inside the class body

### DIFF
--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -273,7 +273,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     /// Create a static block property from a single expression.
-    fn make_static_block(&mut self, expr: Expr, l: bun_ast::Loc) -> Property {
+    pub(crate) fn make_static_block(&mut self, expr: Expr, l: bun_ast::Loc) -> Property {
         let bump = self.arena;
         let stmt = self.s(
             S::SExpr {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -6499,7 +6499,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 let mut static_decorators = BumpVec::<Stmt>::new_in(self.arena);
                 let mut instance_decorators = BumpVec::<Stmt>::new_in(self.arena);
                 let mut instance_members = BumpVec::<Stmt>::new_in(self.arena);
-                let mut static_members = BumpVec::<Stmt>::new_in(self.arena);
                 let mut class_properties = BumpVec::<G::Property>::new_in(self.arena);
 
                 for prop in s_class.class.properties.slice_mut().iter_mut() {
@@ -6642,28 +6641,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             continue;
                         };
 
-                        let mut target: Expr;
-                        if prop.flags.contains(Flags::Property::IsStatic) {
-                            let class_name = s_class.class.class_name.unwrap();
-                            let class_ref = class_name.ref_;
-                            self.record_usage(class_ref);
-                            target = self.new_expr(E::Identifier::init(class_ref), class_name.loc);
-                        } else {
-                            target = self.new_expr(
-                                E::This {},
-                                prop.key.expect("infallible: prop has key").loc,
-                            );
-                        }
-
                         let key = prop.key.expect("infallible: prop has key");
-                        target = match &key.data {
+                        let this = self.new_expr(E::This {}, key.loc);
+                        let target = match &key.data {
                             js_ast::ExprData::EString(s)
                                 if s.is_utf8()
                                     && !prop.flags.contains(Flags::Property::IsComputed) =>
                             {
                                 self.new_expr(
                                     E::Dot {
-                                        target,
+                                        target: this,
                                         name: s.data,
                                         name_loc: key.loc,
                                         ..Default::default()
@@ -6673,7 +6660,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             }
                             _ => self.new_expr(
                                 E::Index {
-                                    target,
+                                    target: this,
                                     index: key,
                                     optional_chain: None,
                                 },
@@ -6681,9 +6668,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             ),
                         };
 
-                        // remove fields with decorators from class body. Move static members outside of class.
+                        // Static block: keeps the initializer's `this`/`super` bound to the class.
                         if prop.flags.contains(Flags::Property::IsStatic) {
-                            static_members.push(Stmt::assign(target, initializer));
+                            let assign = Expr::assign(target, initializer);
+                            class_properties.push(self.make_static_block(assign, key.loc));
                         } else {
                             instance_members.push(Stmt::assign(target, initializer));
                         }
@@ -6807,13 +6795,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
 
                 let mut stmts_count: usize =
-                    1 + static_members.len() + instance_decorators.len() + static_decorators.len();
+                    1 + instance_decorators.len() + static_decorators.len();
                 if s_class.class.ts_decorators.len_u32() > 0 {
                     stmts_count += 1;
                 }
                 let mut stmts = BumpVec::<Stmt>::with_capacity_in(stmts_count, self.arena);
                 stmts.push(stmt);
-                stmts.extend_from_slice(&static_members);
                 stmts.extend_from_slice(&instance_decorators);
                 stmts.extend_from_slice(&static_decorators);
                 if s_class.class.ts_decorators.len_u32() > 0 {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -6499,6 +6499,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 let mut static_decorators = BumpVec::<Stmt>::new_in(self.arena);
                 let mut instance_decorators = BumpVec::<Stmt>::new_in(self.arena);
                 let mut instance_members = BumpVec::<Stmt>::new_in(self.arena);
+                let mut static_members = BumpVec::<Stmt>::new_in(self.arena);
                 let mut class_properties = BumpVec::<G::Property>::new_in(self.arena);
 
                 for prop in s_class.class.properties.slice_mut().iter_mut() {
@@ -6642,15 +6643,30 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         };
 
                         let key = prop.key.expect("infallible: prop has key");
-                        let this = self.new_expr(E::This {}, key.loc);
-                        let target = match &key.data {
+                        let is_static = prop.flags.contains(Flags::Property::IsStatic);
+                        // A non-literal computed key must still evaluate in the enclosing scope.
+                        let use_static_block = is_static
+                            && (!prop.flags.contains(Flags::Property::IsComputed)
+                                || key.unwrap_inlined().is_primitive_literal());
+
+                        let mut target: Expr;
+                        if is_static && !use_static_block {
+                            let class_name = s_class.class.class_name.unwrap();
+                            let class_ref = class_name.ref_;
+                            self.record_usage(class_ref);
+                            target = self.new_expr(E::Identifier::init(class_ref), class_name.loc);
+                        } else {
+                            target = self.new_expr(E::This {}, key.loc);
+                        }
+
+                        target = match &key.data {
                             js_ast::ExprData::EString(s)
                                 if s.is_utf8()
                                     && !prop.flags.contains(Flags::Property::IsComputed) =>
                             {
                                 self.new_expr(
                                     E::Dot {
-                                        target: this,
+                                        target,
                                         name: s.data,
                                         name_loc: key.loc,
                                         ..Default::default()
@@ -6660,7 +6676,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             }
                             _ => self.new_expr(
                                 E::Index {
-                                    target: this,
+                                    target,
                                     index: key,
                                     optional_chain: None,
                                 },
@@ -6668,10 +6684,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             ),
                         };
 
-                        // Static block: keeps the initializer's `this`/`super` bound to the class.
-                        if prop.flags.contains(Flags::Property::IsStatic) {
+                        if use_static_block {
                             let assign = Expr::assign(target, initializer);
                             class_properties.push(self.make_static_block(assign, key.loc));
+                        } else if is_static {
+                            static_members.push(Stmt::assign(target, initializer));
                         } else {
                             instance_members.push(Stmt::assign(target, initializer));
                         }
@@ -6795,12 +6812,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
 
                 let mut stmts_count: usize =
-                    1 + instance_decorators.len() + static_decorators.len();
+                    1 + static_members.len() + instance_decorators.len() + static_decorators.len();
                 if s_class.class.ts_decorators.len_u32() > 0 {
                     stmts_count += 1;
                 }
                 let mut stmts = BumpVec::<Stmt>::with_capacity_in(stmts_count, self.arena);
                 stmts.push(stmt);
+                stmts.extend_from_slice(&static_members);
                 stmts.extend_from_slice(&instance_decorators);
                 stmts.extend_from_slice(&static_decorators);
                 if s_class.class.ts_decorators.len_u32() > 0 {

--- a/test/bundler/transpiler/decorators.test.ts
+++ b/test/bundler/transpiler/decorators.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import DecoratedClass from "./decorator-export-default-class-fixture";
 import DecoratedAnonClass from "./decorator-export-default-class-fixture-anon";
 
@@ -1105,3 +1105,181 @@ test("lowering many decorated instance fields into a large constructor body stay
   const { tSmall, tLarge } = JSON.parse(stdout);
   expect(tLarge).toBeLessThan(tSmall * 3);
 }, 90_000);
+
+describe("decorated static field initializers", () => {
+  function dec(_target: any, _key?: any) {}
+
+  test("evaluate `this` as the class", () => {
+    const key = Symbol("key");
+    class Base {
+      static tag = "base-tag";
+    }
+    class A extends Base {
+      static own = "own";
+      @dec static self = this;
+      @dec static inheritedTag = this.tag;
+      @dec static ownViaThis = this.own;
+      @dec static [key] = this;
+      @dec static arrow = () => this;
+      @dec static fn = function (this: unknown) {
+        return this;
+      };
+    }
+
+    const receiver = {};
+    expect({
+      self: A.self === A,
+      inheritedTag: A.inheritedTag,
+      ownViaThis: A.ownViaThis,
+      computedKey: A[key] === A,
+      arrow: A.arrow() === A,
+      fn: A.fn.call(receiver) === receiver,
+    }).toEqual({
+      self: true,
+      inheritedTag: "base-tag",
+      ownViaThis: "own",
+      computedKey: true,
+      arrow: true,
+      fn: true,
+    });
+  });
+
+  test("run in source order with the other static members", () => {
+    const order: string[] = [];
+    function log(name: string) {
+      order.push(name);
+      return name;
+    }
+    function logDec(_target: any, key: string) {
+      order.push(`dec:${key}`);
+    }
+
+    class A {
+      static a = log("a");
+      @logDec static b = log("b");
+      static {
+        log("block");
+      }
+      @logDec static c = log("c");
+      static d = log("d");
+      @logDec e = log("e");
+    }
+
+    // Same order as tsc; `e` is an instance field, so only its decorator runs.
+    expect(order).toEqual(["a", "b", "block", "c", "d", "dec:e", "dec:b", "dec:c"]);
+  });
+
+  test.concurrent("can use `super`", async () => {
+    using dir = tempDir("legacy-decorator-static-super", {
+      "tsconfig.json": JSON.stringify({ compilerOptions: { experimentalDecorators: true } }),
+      "base.ts": `
+        export function dec(_target: any, _key?: any) {}
+        export class Base {
+          static x = 1;
+          static receiver() {
+            return this;
+          }
+          static get tagged() {
+            return "base:" + this.label;
+          }
+        }
+      `,
+      "anon.ts": `
+        import { Base, dec } from "./base";
+        export default class extends Base {
+          @dec static me = this;
+          @dec static viaSuper = super.receiver();
+        }
+      `,
+      "main.ts": `
+        import Anon from "./anon";
+        import { Base, dec } from "./base";
+        class A extends Base {
+          static label = "A";
+          @dec static call = super.receiver() === this;
+          @dec static getter = super.tagged;
+          @dec static arrow = (() => super.receiver())() === this;
+          @dec static computedMember = super["receiver"]() === this;
+          @dec static assigned = (super.x = 42);
+          @dec static ["computed" + "Key"] = super.tagged;
+        }
+        console.log(
+          JSON.stringify({
+            call: A.call,
+            getter: A.getter,
+            arrow: A.arrow,
+            computedMember: A.computedMember,
+            assigned: A.assigned,
+            ownX: Object.hasOwn(A, "x") && A.x,
+            baseX: Base.x,
+            computedKey: A.computedKey,
+            anonMe: Anon.me === Anon,
+            anonViaSuper: Anon.viaSuper === Anon,
+          }),
+        );
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stderr, result: stdout.trim() && JSON.parse(stdout), exitCode }).toEqual({
+      stderr: "",
+      result: {
+        call: true,
+        getter: "base:A",
+        arrow: true,
+        computedMember: true,
+        assigned: 42,
+        ownX: 42,
+        baseX: 1,
+        computedKey: "base:A",
+        anonMe: true,
+        anonViaSuper: true,
+      },
+      exitCode: 0,
+    });
+  });
+
+  test("stay in the class body as static blocks", () => {
+    const transpiler = new Bun.Transpiler({
+      loader: "ts",
+      tsconfig: { compilerOptions: { experimentalDecorators: true } },
+    });
+    const out = transpiler.transformSync(`
+      class A extends Base {
+        @dec static a = super.f();
+        static b = 1;
+        @dec static [k] = this.b;
+        @dec static c: number;
+        @dec d = this.e;
+      }
+    `);
+
+    const classStart = out.indexOf("class A");
+    const classEnd = out.indexOf("\n}\n", classStart) + "\n}\n".length;
+    expect(out.slice(classStart, classEnd)).toMatchInlineSnapshot(`
+      "class A extends Base {
+        constructor() {
+          super(...arguments);
+          this.d = this.e;
+        }
+        static {
+          this.a = super.f();
+        }
+        static b = 1;
+        static {
+          this[k] = this.b;
+        }
+      }
+      "
+    `);
+    // Only the decorator calls are left after the class statement.
+    expect(out.slice(classEnd)).toStartWith("__legacyDecorateClassTS");
+  });
+});

--- a/test/bundler/transpiler/decorators.test.ts
+++ b/test/bundler/transpiler/decorators.test.ts
@@ -1110,7 +1110,6 @@ describe("decorated static field initializers", () => {
   function dec(_target: any, _key?: any) {}
 
   test("evaluate `this` as the class", () => {
-    const key = Symbol("key");
     class Base {
       static tag = "base-tag";
     }
@@ -1119,7 +1118,8 @@ describe("decorated static field initializers", () => {
       @dec static self = this;
       @dec static inheritedTag = this.tag;
       @dec static ownViaThis = this.own;
-      @dec static [key] = this;
+      @dec static ["literal key"] = this;
+      @dec static 123 = this;
       @dec static arrow = () => this;
       @dec static fn = function (this: unknown) {
         return this;
@@ -1131,16 +1131,72 @@ describe("decorated static field initializers", () => {
       self: A.self === A,
       inheritedTag: A.inheritedTag,
       ownViaThis: A.ownViaThis,
-      computedKey: A[key] === A,
+      literalKey: A["literal key"] === A,
+      numericKey: A[123] === A,
       arrow: A.arrow() === A,
       fn: A.fn.call(receiver) === receiver,
     }).toEqual({
       self: true,
       inheritedTag: "base-tag",
       ownViaThis: "own",
-      computedKey: true,
+      literalKey: true,
+      numericKey: true,
       arrow: true,
       fn: true,
+    });
+  });
+
+  test("run before the class decorator, against the class it decorates", () => {
+    const events: string[] = [];
+    let decorated: any;
+    function replace(target: any) {
+      events.push(`class:${target.name}`);
+      return class Replacement extends target {};
+    }
+    function member(target: any, key: string) {
+      decorated = target;
+      events.push(`member:${key}=${target[key] === target ? "class" : String(target[key])}`);
+    }
+
+    @replace
+    class A {
+      @member static self = this;
+      @member static n = events.push("init:n");
+    }
+
+    expect({
+      events,
+      binding: A.name,
+      decoratedIsOriginal: decorated === Object.getPrototypeOf(A),
+      selfIsOriginal: A.self === Object.getPrototypeOf(A),
+      n: A.n,
+    }).toEqual({
+      events: ["init:n", "member:self=class", "member:n=1", "class:A"],
+      binding: "Replacement",
+      decoratedIsOriginal: true,
+      selfIsOriginal: true,
+      n: 1,
+    });
+  });
+
+  test("keep a non-literal computed key in the enclosing scope", () => {
+    const decoratedKeys: string[] = [];
+    function record(_target: any, key: string) {
+      decoratedKeys.push(key);
+    }
+    function define(this: { name: string }, _first: string) {
+      class A {
+        @record static [this.name] = "from this";
+        @record static [arguments[0]] = "from arguments";
+      }
+      return A;
+    }
+
+    const A = define.call({ name: "thisKey" }, "argumentsKey");
+    expect({ decoratedKeys, thisKey: A.thisKey, argumentsKey: A.argumentsKey }).toEqual({
+      decoratedKeys: ["thisKey", "argumentsKey"],
+      thisKey: "from this",
+      argumentsKey: "from arguments",
     });
   });
 
@@ -1201,7 +1257,7 @@ describe("decorated static field initializers", () => {
           @dec static arrow = (() => super.receiver())() === this;
           @dec static computedMember = super["receiver"]() === this;
           @dec static assigned = (super.x = 42);
-          @dec static ["computed" + "Key"] = super.tagged;
+          @dec static ["computedKey"] = super.tagged;
         }
         console.log(
           JSON.stringify({
@@ -1255,31 +1311,46 @@ describe("decorated static field initializers", () => {
       class A extends Base {
         @dec static a = super.f();
         static b = 1;
-        @dec static [k] = this.b;
-        @dec static c: number;
-        @dec d = this.e;
+        @dec static ["c"] = this.b;
+        @dec static [k] = 2;
+        @dec static d: number;
+        @dec e = this.f;
       }
     `);
 
-    const classStart = out.indexOf("class A");
-    const classEnd = out.indexOf("\n}\n", classStart) + "\n}\n".length;
-    expect(out.slice(classStart, classEnd)).toMatchInlineSnapshot(`
+    // Everything after the import of the runtime helper.
+    const body = out.slice(out.indexOf("class A")).replace(/__legacyDecorateClassTS_\w+/g, "__legacyDecorateClassTS");
+    expect(body).toMatchInlineSnapshot(`
       "class A extends Base {
         constructor() {
           super(...arguments);
-          this.d = this.e;
+          this.e = this.f;
         }
         static {
           this.a = super.f();
         }
         static b = 1;
         static {
-          this[k] = this.b;
+          this["c"] = this.b;
         }
       }
+      A[k] = 2;
+      __legacyDecorateClassTS([
+        dec
+      ], A.prototype, "e", undefined);
+      __legacyDecorateClassTS([
+        dec
+      ], A, "a", undefined);
+      __legacyDecorateClassTS([
+        dec
+      ], A, "c", undefined);
+      __legacyDecorateClassTS([
+        dec
+      ], A, k, undefined);
+      __legacyDecorateClassTS([
+        dec
+      ], A, "d", undefined);
       "
     `);
-    // Only the decorator calls are left after the class statement.
-    expect(out.slice(classEnd)).toStartWith("__legacyDecorateClassTS");
   });
 });


### PR DESCRIPTION
### Problem
- With `experimentalDecorators: true`, a decorated static field whose initializer uses `super` makes the whole module fail to load: `SyntaxError: super is not valid in this context.`
- One whose initializer uses `this` gets the enclosing scope's `this` (`undefined` in ESM), so `@dec static z = this.tag` throws `TypeError: undefined is not an object (evaluating 'this.tag')`. tsc gives `this` the class and `super.x` the parent's `x` with the class as receiver.
- Cause: the legacy lowering in `lower_class` (`src/js_parser/p.rs`, the `static_members` list) removes the field from the class body and emits `A.y = <initializer>;` as a statement after the class. The initializer is printed verbatim, so its `this` and `super` now belong to whatever encloses the class (and `super` does not parse there at all).
- Same relocation, smaller symptom: decorated static initializers ran after every undecorated static member of the class instead of in source order.

### Fix
- A decorated static field whose key is a name or a literal (`static y`, `static ["y"]`, `static 1`) now stays at its position in the class body as `static { this.y = <initializer>; }`, built with `make_static_block` from the standard-decorator lowering (made `pub(crate)`).
- Why that is correct: a static block is evaluated with exactly the environment a static field initializer has (`this` is the class, `[[HomeObject]]` is the class so every `super` form works natively, strict code, `arguments` forbidden), and `this.y = ...` keeps the `[[Set]]` assignment the lowering already used. Nothing in the initializer is rewritten and no runtime helper is needed, so there is no list of `super` forms to get wrong. It is also the output tsc emits for `experimentalDecorators` + `useDefineForClassFields: false`, and esbuild's.
- What stays the same: the initializer still runs before `__legacyDecorateClassTS` is applied (decorators are still emitted after the class; the existing `decorators random` test checks that a property decorator sees the assigned value), and instance fields are untouched.
- A decorated static field with any other computed key (`static [sym]`, `static [this.k]`, `static [await p]`) keeps the previous emission. A computed key is evaluated in the scope enclosing the class, so printing it inside a static block would change what `this`, `arguments` or `await` in the key mean (or fail to parse). Evaluating the key once, outside the class, is what #38142 adds; once the key is a hoisted temporary these fields can take the static block too. Until then their initializers keep the old behaviour (`this`/`super` in them are still wrong), unchanged by this PR. The `static_members` list in `lower_class` stays for them. One consequence of the split: in a class that mixes the two kinds, a decorated static with a non-literal computed key now runs after its name-keyed decorated siblings, even if it precedes them in the source (before, all decorated statics ran after the class in source order; tsc runs everything in source order). Hoisting the key resolves this as well.
- Behaviour note: a decorated static initializer now runs inside the class body, so a reference to the class name inside it binds like every other class-body reference, to the inner binding (the class as declared). This is only observable when a class decorator returns a replacement class and the initializer captures the name lazily; before this PR such a reference saw the replaced class, unlike references from methods and undecorated fields. tsc's `A_1` aliasing, which makes all of them see the replacement, is not implemented in either of Bun's lowerings and is independent of this change.
- Verified: `test/bundler/transpiler/decorators.test.ts`, new `decorated static field initializers` block: `this` forms (identity, inherited and own reads, literal and numeric keys, arrow capture, a `function` expression keeping its own `this`), the combination with a class decorator, a non-literal computed key using the enclosing `this` and `arguments` (pins the unchanged path), source order against plain statics and a static block, every `super` form in a spawned fixture (call with receiver check, getter, computed member, arrow, assignment through `super` landing on the subclass, literal computed key, anonymous `export default class`), and an inline snapshot of the emitted code showing both emissions. Five of the six fail on the released Bun (`TypeError`, wrong order, `SyntaxError`, missing static blocks); the computed-key test passes before and after and exists to keep that path unchanged.
- Also run: the rest of `decorators.test.ts`, `decorator-metadata.test.ts`, `ts-use-define-for-class-fields.test.ts`, `es-decorators*.test.ts`, `bundler_decorator_metadata.test.ts`, `bundler/esbuild/ts.test.ts`, `transpiler.test.js`, `bundler_edgecase.test.ts`, the nest and typegraphql integration tests; the repro also runs correctly after `bun build`, `--minify` and `--format=cjs` under node.
- Related work on the other lowering: #31922, #38769 and #38730 fix the analogous relocation in the standard (TC39) decorator lowering in `lower_decorators.rs`. That lowering has to relocate (standard semantics run static initializers after the decorators) and therefore rewrites `this`/`super`; the legacy lowering runs initializers before decorators, which is why staying in the class body is available here.

### Background
- Legacy (`experimentalDecorators`) lowering keeps decorated fields as assignments rather than class fields so that a property decorator which installs an accessor on the constructor or prototype is hit by the initializer (`[[Set]]`) instead of being shadowed by an own data property (`[[Define]]`). Instance fields become `this.x = init` in the constructor; static fields are the subject of this PR.
- A class static block (`static { ... }`) runs during class definition, at its position among the other static members, with `this` bound to the class and `super.x` resolving through the class's parent: the same environment a static field initializer is evaluated in.
- A computed member key (`static [expr] = ...`) is different: `expr` is evaluated in the scope that contains the class, before any static initializer runs, so it may legitimately use that scope's `this`, `arguments` or `await`.
- `__legacyDecorateClassTS` is Bun's runtime equivalent of tsc's `__decorate`; it is called once per decorated member after the class statement, so member initializers observe the undecorated class in both the old and the new output.

<details>
<summary>Before / after for the repro</summary>

```ts
// tsconfig.json: { "compilerOptions": { "experimentalDecorators": true } }
function dec(target: any, key?: any) {}
class Base { static sgreet() { return "shi"; } static tag = "base-tag"; }
class A extends Base {
  @dec static y = super.sgreet();
  @dec static z = this.tag;
}
console.log(A.y, A.z);
```

Before (`bun build --no-bundle`), which fails to load with `SyntaxError: super is not valid in this context.`:

```js
class A extends Base {
}
A.y = super.sgreet();
A.z = this.tag;
__legacyDecorateClassTS([dec], A, "y", undefined);
__legacyDecorateClassTS([dec], A, "z", undefined);
```

After, printing `shi base-tag` like tsc:

```js
class A extends Base {
  static {
    this.y = super.sgreet();
  }
  static {
    this.z = this.tag;
  }
}
__legacyDecorateClassTS([dec], A, "y", undefined);
__legacyDecorateClassTS([dec], A, "z", undefined);
```

tsc 5.9, `--experimentalDecorators --target es2022 --useDefineForClassFields false`, for the same input:

```js
class A extends Base {
    static { this.y = super.sgreet(); }
    static { this.z = this.tag; }
}
__decorate([dec], A, "y", void 0);
__decorate([dec], A, "z", void 0);
```

Evaluation order of a mixed class (`static a`, decorated `static b`, a static block, decorated `static c`, `static d`): tsc runs `a, b, block, c, d`; Bun ran `a, block, d, b, c` and now matches tsc.
</details>

<details>
<summary>Computed keys: what is and is not changed</summary>

```ts
function make(this: { k: string }, first: string) {
  class A {
    @dec static [this.k] = 1;        // key uses the enclosing `this`
    @dec static [arguments[0]] = 2;  // key uses the enclosing `arguments`
    @dec static plain = this;        // initializer uses the class
  }
  return A;
}
```

is emitted as

```js
class A {
  static {
    this.plain = this;
  }
}
A[this.k] = 1;
A[arguments[0]] = 2;
__legacyDecorateClassTS([dec], A, this.k, undefined);
...
```

The two computed-key fields are emitted exactly as before this PR (same keys defined and decorated as on the released Bun); `plain` gets the fix. The first revision of this PR put computed keys inside the block as well, which evaluated them in the wrong scope; that is what the `keep a non-literal computed key in the enclosing scope` test pins.
</details>
