### PR TITLE
create: resolve bun-create task commands against PATH

### DIFF
--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -65,8 +65,6 @@ fn exec_task(task_: &[u8], cwd: &[u8], path_env: &[u8], npm_client: Option<NPMCl
         return;
     }
 
-    // `bun ...` tasks run this executable directly instead of going through
-    // `<bun> run`.
     let is_bun_task = strings::starts_with(task, b"bun ");
 
     let mut argv: Vec<&[u8]> = Vec::new();
@@ -92,22 +90,20 @@ fn exec_task(task_: &[u8], cwd: &[u8], path_env: &[u8], npm_client: Option<NPMCl
 
     let _unbuffered = Output::disable_buffering_scope();
 
-    // `spawn_sync::spawn` execs argv[0] as given, without a $PATH search, so a
-    // bare command name is resolved here and passed as the exec path (`argv0`)
-    // while the task's own words stay argv. argv[0] needs no resolving when it
-    // is already the npm client's absolute path, or contains a slash (the spawn
-    // resolves that against `cwd` itself).
-    let mut exe_buf = bun_paths::path_buffer_pool::get();
-    let exe: Option<&bun_core::ZStr> = if is_bun_task {
+    // The spawn does no $PATH search of its own: a bare command name is resolved
+    // here and passed as the exec path, and a path containing a slash is
+    // resolved against `cwd` by the spawn.
+    let mut exec_path_buf = bun_paths::path_buffer_pool::get();
+    let exec_path: Option<&bun_core::ZStr> = if is_bun_task {
         match bun_core::self_exe_path() {
-            Ok(exe) => Some(exe),
+            Ok(exec_path) => Some(exec_path),
             Err(err) => return print_task_error(task, err),
         }
     } else if npm_client.is_some() || strings::contains_char(argv[0], b'/') {
         None
     } else {
-        match which_for_spawn(&mut *exe_buf, path_env, cwd, argv[0]) {
-            Some(exe) => Some(exe),
+        match which_for_spawn(&mut *exec_path_buf, path_env, cwd, argv[0]) {
+            Some(exec_path) => Some(exec_path),
             None => {
                 return print_task_error(
                     task,
@@ -122,7 +118,7 @@ fn exec_task(task_: &[u8], cwd: &[u8], path_env: &[u8], npm_client: Option<NPMCl
 
     let result = spawn_sync::spawn(&spawn_sync::Options {
         argv: argv.iter().map(|s| Box::<[u8]>::from(*s)).collect(),
-        argv0: exe.map(bun_core::ZStr::as_ptr),
+        argv0: exec_path.map(bun_core::ZStr::as_ptr),
         envp: None,
         cwd: Box::from(cwd),
         stderr: spawn_sync::SyncStdio::Inherit,

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -59,6 +59,9 @@ const NEVER_CONFLICT: &[&[u8]] = &[b"README.md", b"gitignore", b".gitignore", b"
 
 const NPM_TASK_ARGS: &[&[u8]] = &[b"run"];
 
+/// A task command containing one of these is a path, spawned as written.
+const TASK_PATH_SEPARATORS: &[u8] = if cfg!(windows) { b"/\\" } else { b"/" };
+
 fn exec_task(task_: &[u8], cwd: &[u8], path_env: &[u8], npm_client: Option<NPMClient>) {
     let task = strings::trim(task_, b" \n\r\t");
     if task.is_empty() {
@@ -97,7 +100,7 @@ fn exec_task(task_: &[u8], cwd: &[u8], path_env: &[u8], npm_client: Option<NPMCl
             Ok(exec_path) => Some(exec_path),
             Err(err) => return print_task_error(task, err),
         }
-    } else if npm_client.is_some() || strings::contains_char(argv[0], b'/') {
+    } else if npm_client.is_some() || strings::contains_any(argv[0], TASK_PATH_SEPARATORS) {
         None
     } else {
         match which_for_spawn(&mut *exec_path_buf, path_env, cwd, argv[0]) {

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -117,8 +117,6 @@ fn exec_task(task_: &[u8], cwd: &[u8], path_env: &[u8], npm_client: Option<NPMCl
         }
     };
 
-    // cmd.exe re-tokenizes the arguments of a `.bat`/`.cmd` file, so they
-    // cannot be quoted safely (same check as `Bun.spawn`).
     let program: &[u8] = exec_path.map_or(argv[0], bun_core::ZStr::as_bytes);
     if cfg!(windows)
         && bun_which::is_batch_file(program)

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -90,9 +90,7 @@ fn exec_task(task_: &[u8], cwd: &[u8], path_env: &[u8], npm_client: Option<NPMCl
 
     let _unbuffered = Output::disable_buffering_scope();
 
-    // The spawn does no $PATH search of its own: a bare command name is resolved
-    // here and passed as the exec path, and a path containing a slash is
-    // resolved against `cwd` by the spawn.
+    // The spawn itself does no $PATH search.
     let mut exec_path_buf = bun_paths::path_buffer_pool::get();
     let exec_path: Option<&bun_core::ZStr> = if is_bun_task {
         match bun_core::self_exe_path() {

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -20,7 +20,7 @@ use bun_sys::FdDirExt as _;
 use bun_sys::copy_file as CopyFile;
 use bun_threading::Futex;
 use bun_url::URL;
-use bun_which::which;
+use bun_which::{which, which_for_spawn};
 use bun_zlib as Zlib;
 
 use crate::Command;
@@ -59,38 +59,24 @@ const NEVER_CONFLICT: &[&[u8]] = &[b"README.md", b"gitignore", b".gitignore", b"
 
 const NPM_TASK_ARGS: &[&[u8]] = &[b"run"];
 
-fn exec_task(task_: &[u8], cwd: &[u8], _path: &[u8], npm_client: Option<NPMClient>) {
+fn exec_task(task_: &[u8], cwd: &[u8], path_env: &[u8], npm_client: Option<NPMClient>) {
     let task = strings::trim(task_, b" \n\r\t");
     if task.is_empty() {
         return;
     }
 
-    let mut count: usize = 0;
-    for _ in strings::split(task, b" ") {
-        count += 1;
-    }
+    // `bun ...` tasks run this executable directly instead of going through
+    // `<bun> run`.
+    let is_bun_task = strings::starts_with(task, b"bun ");
 
-    let npm_args = 2 * usize::from(npm_client.is_some());
-    let total = count + npm_args;
-    // `set_len` + index-write into uninitialized `&[u8]` slots is UB (invalid
-    // references exist before assignment). Build with `push` instead — same
-    // allocation, no unsafe.
-    let mut argv: Vec<&[u8]> = Vec::with_capacity(total);
-
-    if let Some(ref client) = npm_client {
+    let mut argv: Vec<&[u8]> = Vec::new();
+    if let Some(client) = npm_client
+        && !is_bun_task
+    {
         argv.push(client.bin);
         argv.push(NPM_TASK_ARGS[0]);
     }
-
-    for split in strings::split(task, b" ") {
-        argv.push(split);
-    }
-    debug_assert_eq!(argv.len(), total);
-
-    let mut argv: &[&[u8]] = &argv;
-    if npm_client.is_some() && strings::starts_with(task, b"bun ") {
-        argv = &argv[2..];
-    }
+    argv.extend(strings::split(task, b" "));
 
     pretty!("\n<r><d>$<b>");
     for (i, arg) in argv.iter().enumerate() {
@@ -106,8 +92,37 @@ fn exec_task(task_: &[u8], cwd: &[u8], _path: &[u8], npm_client: Option<NPMClien
 
     let _unbuffered = Output::disable_buffering_scope();
 
-    let _ = spawn_sync::spawn(&spawn_sync::Options {
+    // `spawn_sync::spawn` execs argv[0] as given, without a $PATH search, so a
+    // bare command name is resolved here and passed as the exec path (`argv0`)
+    // while the task's own words stay argv. argv[0] needs no resolving when it
+    // is already the npm client's absolute path, or contains a slash (the spawn
+    // resolves that against `cwd` itself).
+    let mut exe_buf = bun_paths::path_buffer_pool::get();
+    let exe: Option<&bun_core::ZStr> = if is_bun_task {
+        match bun_core::self_exe_path() {
+            Ok(exe) => Some(exe),
+            Err(err) => return print_task_error(task, err),
+        }
+    } else if npm_client.is_some() || strings::contains_char(argv[0], b'/') {
+        None
+    } else {
+        match which_for_spawn(&mut *exe_buf, path_env, cwd, argv[0]) {
+            Some(exe) => Some(exe),
+            None => {
+                return print_task_error(
+                    task,
+                    format_args!(
+                        "executable not found in $PATH: \"{}\"",
+                        bstr::BStr::new(argv[0])
+                    ),
+                );
+            }
+        }
+    };
+
+    let result = spawn_sync::spawn(&spawn_sync::Options {
         argv: argv.iter().map(|s| Box::<[u8]>::from(*s)).collect(),
+        argv0: exe.map(bun_core::ZStr::as_ptr),
         envp: None,
         cwd: Box::from(cwd),
         stderr: spawn_sync::SyncStdio::Inherit,
@@ -126,6 +141,20 @@ fn exec_task(task_: &[u8], cwd: &[u8], _path: &[u8], npm_client: Option<NPMClien
         windows: (),
         ..Default::default()
     });
+
+    match result {
+        Ok(Ok(_)) => {}
+        Ok(Err(err)) => print_task_error(task, err),
+        Err(err) => print_task_error(task, err),
+    }
+}
+
+fn print_task_error(task: &[u8], reason: impl core::fmt::Display) {
+    pretty_errorln!(
+        "<r><red>error<r><d>:<r> Failed to run \"<b>{}<r>\": {}",
+        bstr::BStr::new(task),
+        reason,
+    );
 }
 
 // We don't want to allocate memory each time

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -109,8 +109,8 @@ fn exec_task(task_: &[u8], cwd: &[u8], path_env: &[u8], npm_client: Option<NPMCl
                 return print_task_error(
                     task,
                     format_args!(
-                        "executable not found in $PATH: \"{}\"",
-                        bstr::BStr::new(argv[0])
+                        "executable not found in $PATH: {}",
+                        bun_core::fmt::quote(argv[0])
                     ),
                 );
             }
@@ -148,8 +148,8 @@ fn exec_task(task_: &[u8], cwd: &[u8], path_env: &[u8], npm_client: Option<NPMCl
 
 fn print_task_error(task: &[u8], reason: impl core::fmt::Display) {
     pretty_errorln!(
-        "<r><red>error<r><d>:<r> Failed to run \"<b>{}<r>\": {}",
-        bstr::BStr::new(task),
+        "<r><red>error<r><d>:<r> Failed to run <b>{}<r>: {}",
+        bun_core::fmt::quote(task),
         reason,
     );
 }

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -117,6 +117,24 @@ fn exec_task(task_: &[u8], cwd: &[u8], path_env: &[u8], npm_client: Option<NPMCl
         }
     };
 
+    // cmd.exe re-tokenizes the arguments of a `.bat`/`.cmd` file, so they
+    // cannot be quoted safely (same check as `Bun.spawn`).
+    let program: &[u8] = exec_path.map_or(argv[0], bun_core::ZStr::as_bytes);
+    if cfg!(windows)
+        && bun_which::is_batch_file(program)
+        && let Some(arg) = argv
+            .iter()
+            .find(|arg| bun_which::batch_arg_has_cmd_metachars(arg))
+    {
+        return print_task_error(
+            task,
+            format_args!(
+                "argument {} contains a cmd.exe special character and cannot be passed to a .bat/.cmd file",
+                bun_core::fmt::quote(arg)
+            ),
+        );
+    }
+
     let result = spawn_sync::spawn(&spawn_sync::Options {
         argv: argv.iter().map(|s| Box::<[u8]>::from(*s)).collect(),
         argv0: exec_path.map(bun_core::ZStr::as_ptr),

--- a/test/cli/install/bun-create.test.ts
+++ b/test/cli/install/bun-create.test.ts
@@ -570,6 +570,33 @@ describe.concurrent("bun-create tasks", () => {
     expect(exitCode).toBe(0);
   });
 
+  // A bare command is looked up the way a spawn would look it up: only on
+  // $PATH on POSIX, while Windows (CreateProcess order) checks the working
+  // directory, here the destination, first.
+  const localTaskTemplate = {
+    template: { name: "tmpl", "bun-create": { postinstall: "local-task first" } },
+    files: { "local-task": taskStubs["bin/create-task"], "local-task.cmd": taskStubs["bin/create-task.cmd"] },
+    executable: ["local-task"],
+  };
+
+  it.skipIf(isWindows)("does not look for a bare command in the destination on POSIX", async () => {
+    const { template, files, executable } = localTaskTemplate;
+    const { err, exitCode, ran } = await createFromTemplate("create-task-local-posix", template, files, executable);
+
+    expect(err).toContain('error: Failed to run "local-task first": executable not found in $PATH: "local-task"');
+    expect(ran).toEqual({});
+    expect(exitCode).toBe(0);
+  });
+
+  it.skipIf(!isWindows)("finds a bare command in the destination on Windows", async () => {
+    const { template, files, executable } = localTaskTemplate;
+    const { err, exitCode, ran } = await createFromTemplate("create-task-local-windows", template, files, executable);
+
+    expect(err).not.toContain("error:");
+    expect(ran).toEqual({ "task-ran.txt": "first" });
+    expect(exitCode).toBe(0);
+  });
+
   it("runs a command through `bun run` when the template has dependencies", async () => {
     const { out, err, exitCode, ran } = await createFromTemplate(
       "create-task-deps",

--- a/test/cli/install/bun-create.test.ts
+++ b/test/cli/install/bun-create.test.ts
@@ -2,7 +2,7 @@ import { spawn, spawnSync } from "bun";
 import { beforeEach, describe, expect, it } from "bun:test";
 import { chmodSync, mkdirSync } from "fs";
 import { exists, stat } from "fs/promises";
-import { bunExe, bunEnv as env, isPosix, tempDir, tls, tmpdirSync } from "harness";
+import { bunExe, bunEnv as env, isPosix, mergeWindowEnvs, tempDir, tls, tmpdirSync } from "harness";
 import { once } from "node:events";
 import * as nodetls from "node:tls";
 import { delimiter, join } from "path";
@@ -535,11 +535,15 @@ async function createFromTemplate(
   await using proc = spawn({
     cmd: [bunExe(), "create", "tmpl", dest, "--no-git"],
     cwd: String(root),
-    env: {
-      ...env,
-      PATH: `${join(String(root), "bin")}${delimiter}${env.PATH ?? process.env.PATH ?? ""}`,
-      BUN_CREATE_DIR: join(String(root), "bun-create"),
-    },
+    // Windows spells the inherited variable `Path`; merging keeps a single
+    // PATH entry instead of handing the child both spellings.
+    env: mergeWindowEnvs([
+      env,
+      {
+        PATH: `${join(String(root), "bin")}${delimiter}${process.env.PATH ?? ""}`,
+        BUN_CREATE_DIR: join(String(root), "bun-create"),
+      },
+    ]),
     stdout: "pipe",
     stderr: "pipe",
   });

--- a/test/cli/install/bun-create.test.ts
+++ b/test/cli/install/bun-create.test.ts
@@ -661,6 +661,21 @@ describe.concurrent("bun-create tasks", () => {
     expect(exitCode).toBe(0);
   });
 
+  // cmd.exe re-tokenizes the arguments of a .cmd file, so an argument with a
+  // cmd.exe special character is rejected instead of spawned (as Bun.spawn does).
+  it.skipIf(!isWindows)("refuses to pass a cmd.exe special character to a .cmd task", async () => {
+    const { err, exitCode, ran } = await createFromTemplate("create-task-batch-metachar", {
+      name: "tmpl",
+      "bun-create": { postinstall: ['create-task first"second', "create-task third"] },
+    });
+
+    expect(err).toContain(
+      'error: Failed to run "create-task first\\"second": argument "first\\"second" contains a cmd.exe special character and cannot be passed to a .bat/.cmd file',
+    );
+    expect(ran).toEqual({ "task-ran.txt": "third" });
+    expect(exitCode).toBe(0);
+  });
+
   // The script needs a shebang to be spawned directly, so POSIX only.
   it.skipIf(!isPosix)("runs a task given as a path relative to the destination", async () => {
     const { out, err, exitCode, ran } = await createFromTemplate(

--- a/test/cli/install/bun-create.test.ts
+++ b/test/cli/install/bun-create.test.ts
@@ -2,7 +2,7 @@ import { spawn, spawnSync } from "bun";
 import { beforeEach, describe, expect, it } from "bun:test";
 import { chmodSync, mkdirSync } from "fs";
 import { exists, stat } from "fs/promises";
-import { bunExe, bunEnv as env, isPosix, mergeWindowEnvs, tempDir, tls, tmpdirSync } from "harness";
+import { bunExe, bunEnv as env, isPosix, isWindows, mergeWindowEnvs, tempDir, tls, tmpdirSync } from "harness";
 import { once } from "node:events";
 import * as nodetls from "node:tls";
 import { delimiter, join } from "path";
@@ -615,17 +615,21 @@ describe.concurrent("bun-create tasks", () => {
   });
 
   it("reports a task that cannot be started and still runs the remaining tasks", async () => {
+    // A path-shaped command (either separator on Windows) is spawned as written
+    // and gets the spawn's own error rather than a $PATH lookup.
+    const missingPath = isWindows ? ".\\no-such-file" : "./no-such-file";
     const { err, exitCode, ran } = await createFromTemplate("create-task-missing", {
       name: "tmpl",
       "bun-create": {
-        postinstall: ["no-such-create-task first", "./no-such-file first", "create-task second"],
+        postinstall: ["no-such-create-task first", `${missingPath} first`, "create-task second"],
       },
     });
 
     expect(err).toContain(
       'error: Failed to run "no-such-create-task first": executable not found in $PATH: "no-such-create-task"',
     );
-    expect(err).toContain('error: Failed to run "./no-such-file first": ');
+    expect(err).toContain(`error: Failed to run "${missingPath} first": `);
+    expect(err).not.toContain(`executable not found in $PATH: "${missingPath}"`);
     expect(ran).toEqual({ "task-ran.txt": "second" });
     expect(exitCode).toBe(0);
   });

--- a/test/cli/install/bun-create.test.ts
+++ b/test/cli/install/bun-create.test.ts
@@ -5,7 +5,7 @@ import { exists, stat } from "fs/promises";
 import { bunExe, bunEnv as env, isPosix, tempDir, tls, tmpdirSync } from "harness";
 import { once } from "node:events";
 import * as nodetls from "node:tls";
-import { join } from "path";
+import { delimiter, join } from "path";
 import { gzipSync } from "zlib";
 
 let x_dir: string;
@@ -489,4 +489,155 @@ it("should not crash with --no-install and bun-create.postinstall starting with 
   const [err, _out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
   expect(err).not.toContain("error:");
   expect(exitCode).toBe(0);
+});
+
+// bun-create tasks are spawned directly (not through a shell), so a task whose
+// first word is a bare command name has to be resolved against $PATH. These
+// stubs go on $PATH and record, in the directory they were run in, the
+// arguments they were invoked with.
+const taskStubs = {
+  "bin/create-task": `#!/bin/sh\necho "$@" > task-ran.txt\n`,
+  "bin/create-task.cmd": "@echo %*> task-ran.txt\r\n",
+  // Decoy: a `bun ...` task must run the bun executing `bun create`, not
+  // whatever `bun` is first on $PATH.
+  "bin/bun": `#!/bin/sh\necho decoy > decoy-bun-ran.txt\n`,
+  "bin/bun.cmd": "@echo decoy> decoy-bun-ran.txt\r\n",
+};
+
+// Run as `bun marker.ts <name>`: records which bun executable ran it.
+const markerScript = `await Bun.write(process.argv[2] + "-ran.txt", process.execPath);`;
+
+// A `file:` dependency makes the template take the install path without
+// touching the network.
+const localdep = { dependencies: { localdep: "file:./localdep" } };
+const localdepFiles = { "localdep/package.json": JSON.stringify({ name: "localdep", version: "1.0.0" }) };
+
+// Creates a project from a local template whose package.json is `template`
+// (plus `files`), with the stubs above on $PATH, and collects the marker
+// files the tasks left behind in the destination.
+async function createFromTemplate(
+  name: string,
+  template: object,
+  files: Record<string, string> = {},
+  executable: string[] = [],
+) {
+  using root = tempDir(name, {
+    ...taskStubs,
+    "bun-create/tmpl/index.js": "// hi\n",
+    "bun-create/tmpl/package.json": JSON.stringify(template),
+    ...Object.fromEntries(Object.entries(files).map(([file, contents]) => [`bun-create/tmpl/${file}`, contents])),
+  });
+  for (const stub of ["bin/create-task", "bin/bun", ...executable.map(file => `bun-create/tmpl/${file}`)]) {
+    chmodSync(join(String(root), stub), 0o755);
+  }
+  const dest = join(String(root), "dest");
+
+  await using proc = spawn({
+    cmd: [bunExe(), "create", "tmpl", dest, "--no-git"],
+    cwd: String(root),
+    env: {
+      ...env,
+      PATH: `${join(String(root), "bin")}${delimiter}${env.PATH ?? process.env.PATH ?? ""}`,
+      BUN_CREATE_DIR: join(String(root), "bun-create"),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const ran: Record<string, string> = {};
+  for (const marker of ["task-ran.txt", "pre-ran.txt", "post-ran.txt", "decoy-bun-ran.txt"]) {
+    const file = Bun.file(join(dest, marker));
+    if (await file.exists()) ran[marker] = (await file.text()).trim();
+  }
+  return { out, err, exitCode, ran };
+}
+
+describe.concurrent("bun-create tasks", () => {
+  it("runs a command from $PATH when the template has no dependencies", async () => {
+    const { out, err, exitCode, ran } = await createFromTemplate("create-task-no-deps", {
+      name: "tmpl",
+      "bun-create": { postinstall: "create-task first second" },
+    });
+
+    expect(out).toContain("\n$ create-task first second\n");
+    expect(err).not.toContain("error:");
+    expect(ran).toEqual({ "task-ran.txt": "first second" });
+    expect(exitCode).toBe(0);
+  });
+
+  it("runs a command through `bun run` when the template has dependencies", async () => {
+    const { out, err, exitCode, ran } = await createFromTemplate(
+      "create-task-deps",
+      { name: "tmpl", ...localdep, "bun-create": { postinstall: "create-task first second" } },
+      localdepFiles,
+    );
+
+    expect(out).toContain(" run create-task first second\n");
+    expect(err).not.toContain("error:");
+    expect(ran).toEqual({ "task-ran.txt": "first second" });
+    expect(exitCode).toBe(0);
+  });
+
+  it("runs a `bun ...` task with the bun running `bun create` when the template has no dependencies", async () => {
+    const { out, err, exitCode, ran } = await createFromTemplate(
+      "create-bun-task-no-deps",
+      { name: "tmpl", "bun-create": { postinstall: "bun marker.ts post" } },
+      { "marker.ts": markerScript },
+    );
+
+    expect(out).toContain("\n$ bun marker.ts post\n");
+    expect(err).not.toContain("error:");
+    expect(ran).toEqual({ "post-ran.txt": process.execPath });
+    expect(exitCode).toBe(0);
+  });
+
+  it("runs `bun ...` preinstall and postinstall tasks with the bun running `bun create` when the template has dependencies", async () => {
+    const { out, err, exitCode, ran } = await createFromTemplate(
+      "create-bun-task-deps",
+      {
+        name: "tmpl",
+        ...localdep,
+        "bun-create": { preinstall: "bun marker.ts pre", postinstall: "bun marker.ts post" },
+      },
+      { "marker.ts": markerScript, ...localdepFiles },
+    );
+
+    expect(out).toContain("\n$ bun marker.ts pre\n");
+    expect(out).toContain("\n$ bun marker.ts post\n");
+    expect(err).not.toContain("error:");
+    expect(ran).toEqual({ "pre-ran.txt": process.execPath, "post-ran.txt": process.execPath });
+    expect(exitCode).toBe(0);
+  });
+
+  it("reports a task that cannot be started and still runs the remaining tasks", async () => {
+    const { err, exitCode, ran } = await createFromTemplate("create-task-missing", {
+      name: "tmpl",
+      "bun-create": {
+        postinstall: ["no-such-create-task first", "./no-such-file first", "create-task second"],
+      },
+    });
+
+    expect(err).toContain(
+      'error: Failed to run "no-such-create-task first": executable not found in $PATH: "no-such-create-task"',
+    );
+    expect(err).toContain('error: Failed to run "./no-such-file first": ');
+    expect(ran).toEqual({ "task-ran.txt": "second" });
+    expect(exitCode).toBe(0);
+  });
+
+  // The script needs a shebang to be spawned directly, so POSIX only.
+  it.skipIf(!isPosix)("runs a task given as a path relative to the destination", async () => {
+    const { out, err, exitCode, ran } = await createFromTemplate(
+      "create-task-relative",
+      { name: "tmpl", "bun-create": { postinstall: "./setup.sh first second" } },
+      { "setup.sh": taskStubs["bin/create-task"] },
+      ["setup.sh"],
+    );
+
+    expect(out).toContain("\n$ ./setup.sh first second\n");
+    expect(err).not.toContain("error:");
+    expect(ran).toEqual({ "task-ran.txt": "first second" });
+    expect(exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
### Problem
- There is no user report of this bug. It was found while working on #36953, where a `bun ...` postinstall task did not run. The bare-command case below is the same defect in general form.
- A local template whose `package.json` has no dependencies but declares a `bun-create.postinstall` task such as `"sh setup.sh"` prints the task's `$ sh setup.sh` banner and then does nothing: the task never runs, nothing is printed about it, and `bun create` exits 0. Reproduces on bun 1.4.0 and canary.
- `exec_task` (`src/runtime/cli/create_command.rs:62`) spawns the task with `spawn_sync::spawn`, which execs `argv[0]` exactly as given, with no `$PATH` search (bun's own spawn on Linux, `posix_spawn` on macOS). With dependencies the task becomes `<bun> run sh setup.sh`, so `argv[0]` is an absolute path and it works; without dependencies `npm_client` is `None` and `argv[0]` is the bare `sh`, so the exec fails with `ENOENT`.
- The spawn result was discarded (`let _ = spawn_sync::spawn(...)`, line 109), which is why the failure was silent.
- Tasks starting with `bun ` hit the same thing in both modes: the `<bun> run` prefix is stripped (or never added), leaving the bare word `bun` as `argv[0]`.
- This is a regression from #9588 (e8bb3389ef, March 2024): `execTask` used `std.ChildProcess`, which searches `$PATH` like `execvp`, and was switched to `bun.spawnSync`, which does not. The Rust port kept that shape.
- Postinstall tasks are meant to run for dependency-less templates: only `--no-install` skips them (line 1163), and the docs list "run postinstall tasks" unconditionally after "run `bun install` unless `--no-install` or there are no dependencies".

### Fix
- `exec_task` resolves a bare command with `bun_which::which_for_spawn` against the PATH `bun create` already passes in (previously the unused `_path` parameter) and hands the result to the spawn as `argv0` (the exec path); the task's own words remain the child's argv. A `bun ...` task uses the running executable (`self_exe_path()`), which is what the dependency path already uses for `bun install`. An `argv[0]` that is the npm client's absolute path, or that contains a path separator (`/`, plus `\` on Windows), is passed through unchanged, so relative tasks like `./setup.sh` keep resolving against the destination as they do today.
- A task that cannot be started (not on PATH, or the spawn fails) is reported as `error: Failed to run "<task>": ...`. The remaining tasks still run and the exit code stays 0. That matches how a task that exits nonzero is treated today. A maintainer can decide if a task that cannot start should fail `bun create` instead (#38485 does that for a failed `bun install`). The test pins the current policy and is easy to flip.
- Why this shape: it restores exactly the contract the tasks had before #9588 (`execvp` resolution of the first word, nothing else changed), and it is the same resolution `Bun.spawn` performs for its own argv (`get_argv0` in `js_bun_spawn_bindings.rs`) and `bun run` performs for a binary on PATH (`argv0` in `run_command.rs`). Every task shape that works today keeps working: `<bin> args` and package.json script names in the dependency mode (still `<bun> run ...`), and `./script args` in both modes. The two alternatives considered both change working shapes. Running tasks through the shell (`<bun> exec <task>`, as lifecycle scripts do) would add quoting and `&&` but drop script-name tasks and `node_modules/.bin` access in the dependency mode unless PATH is rebuilt as well; routing dependency-less tasks through `<bun> run` would make `./setup.sh args` be interpreted by the bun shell with its arguments dropped. Either is a contract change for templates that work today, so neither belongs in the regression fix.
- On Windows, libuv resolved a bare name against the cwd and PATH, but only with the `.exe` and `.com` extensions. `which_for_spawn` uses the same search order and also finds `.cmd` and `.bat` files, so a bare `.cmd` task now runs on Windows. cmd.exe re-tokenizes the arguments of a batch file, so an argument with a cmd.exe special character is rejected with an error, the same check that `Bun.spawn` applies (`is_batch_file` and `batch_arg_has_cmd_metachars` in `src/which/lib.rs`). One Windows test covers it.
- Verified with `test/cli/install/bun-create.test.ts` (new `bun-create tasks` block, 8 tests). On the released bun, 4 of them fail (bare command with no dependencies, `bun ...` task with and without dependencies, error reporting); the rest pin behavior this change must not alter: a task run through `<bun> run` when there are dependencies, a task given as a relative path, and where a bare command is looked up (PATH only on POSIX, destination first on Windows, which is what the old code got from libuv). With the fix the file passes on a Linux debug build (27 tests at 97f4c31, before the two lookup-location tests were added), on a Windows x64 debug build at 8c342ce (26, plus the 2 POSIX-only skips), where the tasks are `.cmd` stubs and the error test uses a backslash path, and on every Linux and Windows CI lane at 8c342ce.
- The `bun ...` tests put a decoy `bun` first on PATH and have the task record `process.execPath`, so they prove the task ran under the bun executing `bun create` rather than whichever `bun` PATH finds.

Related PRs: #41342 also edits `create_command.rs`. It runs git before the template's tasks and `bun install`. The two PRs change different functions and do not conflict, so either can merge first. `test/cli/install/bun-create.test.ts` passes with both applied. #36954 is closed: this PR covers its task change, and #41342 covers its git change.

### Background
- A `bun-create` task is a string from the template's `package.json` (`"bun-create": { "preinstall": ..., "postinstall": ... }`, string or array). `bun create` splits it on spaces and spawns it directly; there is no shell involved.
- `bun create` only wraps tasks in `<bun> run ...` when it is also going to run `bun install`, i.e. when the template has dependencies and `--no-install` was not passed. `npm_client` being `None` in `exec_task` means "not installing", which is the dependency-less case.
- `spawn_sync::Options.argv0` is the path to exec, separate from `argv` (what the child sees as its arguments). It is how `execvp`-style behavior is expressed on top of a spawn that does not search PATH; `bun run` and `bun_spawn::run` use it the same way.
- `which_for_spawn` is `which()` with spawn semantics: on POSIX a plain `$PATH` lookup, on Windows the working directory is searched first, the way `CreateProcess`/libuv do.

<details>
<summary>Repro on the released bun</summary>

```sh
mkdir -p /tmp/r/bun-create/tmpl && cd /tmp/r
printf '%s' '{"name":"tmpl","version":"1.0.0","bun-create":{"postinstall":"sh setup.sh"}}' > bun-create/tmpl/package.json
echo 'echo SETUP_RAN; touch setup_ran' > bun-create/tmpl/setup.sh
echo '// hi' > bun-create/tmpl/index.js
BUN_CREATE_DIR=/tmp/r/bun-create bun create tmpl dest --no-git
ls dest/setup_ran   # missing; stdout shows "$ sh setup.sh" but no SETUP_RAN, exit code 0
```

With the fix, the same template prints `SETUP_RAN` and creates `setup_ran`. Failure variants now print, for example:

```
$ no-such-cmd x
error: Failed to run "no-such-cmd x": executable not found in $PATH: "no-such-cmd"

$ ./no-such-file y
error: Failed to run "./no-such-file y": ENOENT: ./no-such-file: No such file or directory (posix_spawn())
```

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-create.test.ts

<!-- robobun:evidence:end -->

