### PR TITLE
runner: decode bun test's ::error annotation properties and split them at the first =

### DIFF
--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -63,6 +63,7 @@ import {
   isWindows,
   isX64,
   markBuildkiteStepReported,
+  parseGitHubActionCommand,
   printEnvironment,
   reportAnnotationToBuildKite,
   startGroup,
@@ -2125,14 +2126,14 @@ function parseTestStdout(stdout, testPath) {
     }
 
     if (string.startsWith("::error")) {
-      const eol = string.indexOf("::", 8);
-      const message = unescapeGitHubAction(string.substring(eol + 2));
-      const { file, line, col, title } = Object.fromEntries(
-        string
-          .substring(8, eol)
-          .split(",")
-          .map(entry => entry.split("=")),
-      );
+      const annotation = parseGitHubActionCommand(string);
+      if (annotation?.command !== "error") {
+        continue;
+      }
+      const {
+        properties: { file, line, col, title },
+        message,
+      } = annotation;
 
       const errorPath = file || testPath;
       const error = {
@@ -2957,22 +2958,6 @@ function getAnsi(color) {
  */
 function stripAnsi(string) {
   return string.replace(/\u001b\[\d+m/g, "");
-}
-
-/**
- * @param {string} string
- * @returns {string}
- */
-function escapeGitHubAction(string) {
-  return string.replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
-}
-
-/**
- * @param {string} string
- * @returns {string}
- */
-function unescapeGitHubAction(string) {
-  return string.replace(/%25/g, "%").replace(/%0D/g, "\r").replace(/%0A/g, "\n");
 }
 
 /**

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -1413,12 +1413,79 @@ export function escapeGitHubAction(string) {
   return string.replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
 }
 
+// Escapes used by GitHub Actions workflow commands (`::error file=a,title=b::message`).
+// The message escapes `%` and newlines; property values also escape the `,` and
+// `:` that delimit them. Decoding happens in one pass so that an escaped literal
+// "%0A" (written "%250A") does not turn into a newline.
+// https://github.com/actions/toolkit/blob/main/packages/core/src/command.ts
+const githubActionEscapes = { "%25": "%", "%0D": "\r", "%0A": "\n", "%3A": ":", "%2C": "," };
+
 /**
+ * Decodes the message of a GitHub Actions workflow command.
  * @param {string} string
  * @returns {string}
  */
 export function unescapeGitHubAction(string) {
-  return string.replace(/%25/g, "%").replace(/%0D/g, "\r").replace(/%0A/g, "\n");
+  return string.replace(/%(?:25|0D|0A)/g, escaped => githubActionEscapes[escaped]);
+}
+
+/**
+ * Decodes a property value (`file=`, `title=`, ...) of a GitHub Actions workflow command.
+ * @param {string} string
+ * @returns {string}
+ */
+export function unescapeGitHubActionProperty(string) {
+  return string.replace(/%(?:25|0D|0A|3A|2C)/g, escaped => githubActionEscapes[escaped]);
+}
+
+/**
+ * @typedef {object} GitHubActionCommand
+ * @property {string} command `error` for `::error ...::...`
+ * @property {Record<string, string>} properties decoded, e.g. `{ file, line, col, title }`
+ * @property {string} message decoded
+ */
+
+/**
+ * Parses a workflow command line, `::error file=a.ts,line=1,col=2,title=t::message`,
+ * the way the GitHub Actions runner does: the command and its properties end at the
+ * first `::` after the leading one, properties are separated by `,` and each value
+ * starts after the first `=` of its property (the value itself may contain `=`), and
+ * values and message are decoded as above.
+ *
+ * https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions
+ *
+ * @param {string} line
+ * @returns {GitHubActionCommand | undefined} undefined if the line is not a workflow command
+ */
+export function parseGitHubActionCommand(line) {
+  if (!line.startsWith("::")) {
+    return undefined;
+  }
+  const end = line.indexOf("::", 2);
+  if (end === -1) {
+    return undefined;
+  }
+
+  const header = line.slice(2, end);
+  const space = header.indexOf(" ");
+  const command = space === -1 ? header : header.slice(0, space);
+  if (!command) {
+    return undefined;
+  }
+
+  /** @type {Record<string, string>} */
+  const properties = {};
+  if (space !== -1) {
+    for (const property of header.slice(space + 1).split(",")) {
+      const equals = property.indexOf("=");
+      if (equals <= 0) {
+        continue;
+      }
+      properties[property.slice(0, equals)] = unescapeGitHubActionProperty(property.slice(equals + 1));
+    }
+  }
+
+  return { command, properties, message: unescapeGitHubAction(line.slice(end + 2)) };
 }
 
 /**

--- a/test/internal/runner-annotations.test.ts
+++ b/test/internal/runner-annotations.test.ts
@@ -1,0 +1,112 @@
+/**
+ * scripts/runner.node.mjs runs every test file with GITHUB_ACTIONS=true and reads the
+ * `::error file=...,line=...,col=...,title=...::stack` lines bun test prints for each
+ * failure back out of its output; the title and stack become the <failure> of the junit
+ * report it uploads. parseGitHubActionCommand() in scripts/utils.mjs is that parsing step.
+ * bun test escapes the values the way actions/toolkit does (src/bun_core/fmt.rs), so the
+ * parser has to undo exactly that.
+ */
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { parseGitHubActionCommand, unescapeGitHubAction, unescapeGitHubActionProperty } from "../../scripts/utils.mjs";
+
+describe("parseGitHubActionCommand", () => {
+  test("decodes the properties and the message of a bun test failure", () => {
+    // The title is `<name>: <first line of the message>` with `:` `,` `%` encoded; the
+    // message is the rest of the error message and the stack, with newlines encoded.
+    const line =
+      "::error file=test/a%2Cb.test.ts,line=3,col=5,title=error: ENOENT%3A a = b%2C c 100%25::Expected: x%0A      at f (test/a,b.test.ts:3:5)";
+    expect(parseGitHubActionCommand(line)).toEqual({
+      command: "error",
+      properties: {
+        file: "test/a,b.test.ts",
+        line: "3",
+        col: "5",
+        title: "error: ENOENT: a = b, c 100%",
+      },
+      message: "Expected: x\n      at f (test/a,b.test.ts:3:5)",
+    });
+  });
+
+  test("keeps everything after the first = of a property", () => {
+    expect(parseGitHubActionCommand('::error title=error: Test "a = b" timed out after 5000ms::')).toEqual({
+      command: "error",
+      properties: { title: 'error: Test "a = b" timed out after 5000ms' },
+      message: "",
+    });
+  });
+
+  test("parses commands without properties and ignores lines that are not commands", () => {
+    expect(parseGitHubActionCommand("::group::test/a.test.ts")).toEqual({
+      command: "group",
+      properties: {},
+      message: "test/a.test.ts",
+    });
+    expect(parseGitHubActionCommand("::endgroup::")).toEqual({ command: "endgroup", properties: {}, message: "" });
+    expect(parseGitHubActionCommand("error: not a command")).toBeUndefined();
+    expect(parseGitHubActionCommand("::error file=a.test.ts,title=cut off before the terminator")).toBeUndefined();
+    expect(parseGitHubActionCommand("::::")).toBeUndefined();
+  });
+});
+
+describe("unescaping", () => {
+  test("properties decode the five property escapes, messages only the three data escapes", () => {
+    expect(unescapeGitHubActionProperty("a%3Ab%2Cc%0Ad%0De%25f")).toBe("a:b,c\nd\re%f");
+    expect(unescapeGitHubAction("a%3Ab%2Cc%0Ad%0De%25f")).toBe("a%3Ab%2Cc\nd\re%f");
+  });
+
+  test("an escaped % is not decoded a second time", () => {
+    // Text that itself read "%0A" or "%2C" was escaped to %250A / %252C.
+    expect(unescapeGitHubAction("see %250A here")).toBe("see %0A here");
+    expect(unescapeGitHubActionProperty("see %252C here")).toBe("see %2C here");
+  });
+
+  test("other % sequences are left alone", () => {
+    expect(unescapeGitHubAction("%0a %2F 100% %")).toBe("%0a %2F 100% %");
+    expect(unescapeGitHubActionProperty("%0a %2F 100% %")).toBe("%0a %2F 100% %");
+  });
+});
+
+test("round-trips the annotations bun test prints for a failure and a timeout", async () => {
+  using dir = tempDir("runner-annotations", {
+    "odd,name%path.test.ts": [
+      `import { test } from "bun:test";`,
+      `test("a = b", () => {`,
+      `  throw new Error("ENOENT: a = b, c 100%");`,
+      `});`,
+      `test("t = 1", () => new Promise(() => {}), 1);`,
+      ``,
+    ].join("\n"),
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test"],
+    cwd: String(dir),
+    env: { ...bunEnv, GITHUB_ACTIONS: "true" },
+    stdout: "ignore",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  const annotations = stderr
+    .split("\n")
+    .filter(line => line.startsWith("::error"))
+    .map(line => parseGitHubActionCommand(line));
+  expect(annotations).toEqual([
+    {
+      command: "error",
+      properties: {
+        file: expect.stringMatching(/(^|[\\/])odd,name%path\.test\.ts$/),
+        line: "3",
+        col: expect.stringMatching(/^\d+$/),
+        title: "error: ENOENT: a = b, c 100%",
+      },
+      message: expect.stringMatching(/^\n {6}at /),
+    },
+    {
+      command: "error",
+      properties: { title: expect.stringMatching(/^error: Test "t = 1" timed out after \d+ms$/) },
+      message: "",
+    },
+  ]);
+  expect(exitCode).toBe(1);
+});


### PR DESCRIPTION
### Problem
- `scripts/runner.node.mjs` runs every test file with `GITHUB_ACTIONS=true` and `parseTestStdout()` reads the `::error file=...,line=...,col=...,title=...::message` line bun prints for each failure into a `TestError` (`name` = title, `stack` = title + message), the shape `generateJUnitReport()` writes as `<failure message= type=>`.
- The properties were read with `.split(",").map(e => e.split("="))` + `Object.fromEntries`, so a title is cut at its first `=`: bun 1.4.0 prints `title=error: ENOENT%3A a = b%2C c 100%25` for `new Error("ENOENT: a = b, c 100%")` and the runner records `error: ENOENT%3A a `; `error: Test "t = 1" timed out after 5ms` (the timeout annotation from `src/runtime/cli/test_command.rs`) becomes `error: Test "t `.
- `title` and `file` were never decoded. Since #36165 bun escapes `%` `\r` `\n` `:` `,` in property values (`github_action_property_writer`, `src/bun_core/fmt.rs`), so any failure whose first message line has a `:` or `,` (`ENOENT: ..., open 'x'`) is recorded with `%3A` / `%2C` in it, and a file like `odd,name%path.test.ts` as `odd%2Cname%25path.test.ts`.
- The message was decoded by replacing `%25` before `%0A` / `%0D`, so an escaped literal `%0A` (`%250A`, which is what the property writer emits today and what #38268 makes the body writer emit) turned into a line break.
- None of this is visible in CI today: the only reader of `TestError.name` / `.stack` is the runner's own JUnit report, which is opt-in (`--junit`, off since 8d3f1d07f9) and only generated for files whose output does not go through this parser. The fix is to the parser, so that what the runner records is what bun printed.

### Fix
- Add `parseGitHubActionCommand(line)` to `scripts/utils.mjs` and use it from `parseTestStdout()`; the runner's private `escapeGitHubAction` (unused) and `unescapeGitHubAction` copies are removed.
- It reads the line the way the GitHub Actions runner itself does (`ActionCommand.TryParseV2` in actions/runner): the command and its properties end at the first `::` after the leading one, properties are split on `,`, each value starts after the property's first `=`, property values decode `%25 %0D %0A %3A %2C` and the message decodes `%25 %0D %0A`. Since bun's writers are the toolkit's `escapeProperty` / `escapeData`, this is the exact inverse and the recorded title, file and message are the original text.
- Each decoder is a single `replace` over the escape set. In escaped text every `%` begins an escape, so decoding in one pass (equivalently, `%25` last, which is also the order actions/runner uses) cannot create a new escape out of the `%` it produced; the old `%25`-first order did.
- `unescapeGitHubAction` in `utils.mjs` gets the same one-pass fix and `unescapeGitHubActionProperty` is added next to it. These two helpers are the same text as in #38946, which fixes the sibling parser `parseAnnotations()` in the same file; whichever lands second only drops its copy of them, and `parseAnnotations()` can then switch to `parseGitHubActionCommand()`.
- Verified with `test/internal/runner-annotations.test.ts`: unit cases for the three bugs above and for the two escape sets, plus a round trip that runs `bun test` with `GITHUB_ACTIONS=true` on a fixture named `odd,name%path.test.ts` whose failure and timeout titles contain `:` `,` `%` `=`, and checks the parsed annotations equal the original text. Fails on main (`unescapeGitHubAction("see %250A here")` gives `"see \n here"`; `parseGitHubActionCommand` does not exist), passes with `bun bd test` and with the released bun 1.4.0 as the emitter (`USE_SYSTEM_BUN=1`).
- The runner's handling of `::group` / `::endgroup` lines and of the output preview is unchanged; a `::error` line without a closing `::` (a truncated line) is now skipped instead of being recorded with an `undefined` title.

### Background
- A workflow command is one line of the form `::name key=value,key=value::message`; GitHub Actions turns `::error` into an annotation. The runner sets `GITHUB_ACTIONS=true` for every `bun test` it spawns (`spawnBunTest`) precisely so that it can read the failure's title, location and stack back out of the output, and strips these lines from what it shows.
- actions/toolkit defines two escape sets for these lines: `escapeData` for the message (`%` `\r` `\n`) and `escapeProperty` for property values (additionally `:` and `,`, the delimiters of the line). bun implements them as `github_action_writer` and `github_action_property_writer` in `src/bun_core/fmt.rs`; the title it prints is `<error name>: <first line of the message>`, so the `:` after the name is literal while the message's own `:` `,` `%` are escaped.

<details>
<summary>bun 1.4.0 output and what the parsing on main makes of it</summary>

Fixture (`a.test.ts`):

```ts
import { test } from "bun:test";
test("a = b", () => { throw new Error("ENOENT: a = b, c 100%"); });
test("t = 1 times out", () => new Promise(() => {}), 5);
```

`GITHUB_ACTIONS=true bun test ./a.test.ts` with bun 1.4.0 prints:

```
::error file=a.test.ts,line=2,col=62,title=error: ENOENT%3A a = b%2C c 100%25::%0A      at <anonymous> (/tmp/gha-repro2/a.test.ts:2:62)
::error title=error: Test "t = 1 times out" timed out after 5ms::
```

The properties `parseTestStdout()` on main gets out of those two lines:

```
{"file":"a.test.ts","line":"2","col":"62","title":"error: ENOENT%3A a "}
{"title":"error: Test \"t "}
```

`parseGitHubActionCommand()` on the same lines:

```
{"file":"a.test.ts","line":"2","col":"62","title":"error: ENOENT: a = b, c 100%"}
{"title":"error: Test \"t = 1 times out\" timed out after 5ms"}
```

</details>
