### PR TITLE
Print the separator between JSX props from what was printed, not the property index

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -5177,12 +5177,7 @@ pub mod formatter {
                                 continue;
                             }
 
-                            // Up to five props share the tag's line; each one after that
-                            // goes on its own line:
-                            //   <input type="text" value="foo" />
-                            //   <input a="1" b="2" c="3" d="4" e="5"
-                            //     f="6"
-                            //     g="7" />
+                            // Five props fit on the tag's line; the rest go one per line.
                             if !self.single_line && printed_props >= 5 {
                                 writer.write_all(b"\n");
                                 write_indent_n(self.indent, writer.ctx).expect("unreachable");

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -5072,9 +5072,6 @@ pub mod formatter {
             writer.write_all(pf!("<r>").as_bytes());
             writer.write_all(b"<");
 
-            // Both arms of the `type` if/else below assign these, so deferred
-            // init avoids the dead-store warning.
-            let mut needs_space: bool;
             let mut tag_name_str = ZigString::init(b"");
 
             // `ZigStringSlice` frees on `Drop`, so no explicit cleanup is
@@ -5100,10 +5097,8 @@ pub mod formatter {
                 }
 
                 tag_name_slice = tag_name_str.to_slice();
-                needs_space = true;
             } else {
                 tag_name_slice = ZigString::init(b"unknown").to_slice();
-                needs_space = true;
             }
 
             if !is_tag_kind_primitive {
@@ -5118,11 +5113,7 @@ pub mod formatter {
 
             if let Some(key_value) = value.get(self.global_this, "key")? {
                 if !key_value.is_undefined_or_null() {
-                    if needs_space {
-                        writer.write_all(b" key=");
-                    } else {
-                        writer.write_all(b"key=");
-                    }
+                    writer.write_all(b" key=");
 
                     let old_quote_strings = self.quote_strings;
                     self.quote_strings = true;
@@ -5142,8 +5133,6 @@ pub mod formatter {
                         failed: false,
                         estimated_line_length: &mut self.estimated_line_length,
                     };
-
-                    needs_space = true;
                 }
             }
 
@@ -5173,11 +5162,9 @@ pub mod formatter {
                     {
                         self.indent += 1;
                         let _ind = defer_decrement!(self.indent);
-                        let count_without_children =
-                            props_iter.len - usize::from(children_prop.is_some());
+                        let mut printed_props: usize = 0;
 
                         while let Some(prop) = props_iter.next()? {
-                            let props_i = props_iter.i as usize;
                             if prop.eql_comptime("children") {
                                 continue;
                             }
@@ -5190,10 +5177,19 @@ pub mod formatter {
                                 continue;
                             }
 
-                            if needs_space {
+                            // Up to five props share the tag's line; each one after that
+                            // goes on its own line:
+                            //   <input type="text" value="foo" />
+                            //   <input a="1" b="2" c="3" d="4" e="5"
+                            //     f="6"
+                            //     g="7" />
+                            if !self.single_line && printed_props >= 5 {
+                                writer.write_all(b"\n");
+                                write_indent_n(self.indent, writer.ctx).expect("unreachable");
+                            } else {
                                 writer.space();
                             }
-                            needs_space = false;
+                            printed_props += 1;
 
                             writer.print(format_args!(
                                 "{}{}{}={}",
@@ -5219,26 +5215,6 @@ pub mod formatter {
 
                             if tag.cell.is_string_like() && C {
                                 writer.write_all(pfmt!("<r>", true).as_bytes());
-                            }
-
-                            if !self.single_line
-                                && (
-                                    // count_without_children is necessary to prevent
-                                    // printing an extra newline if there are children
-                                    // and one prop and the child prop is the last prop
-                                    props_i + 1 < count_without_children
-                                    // 3 is arbitrary but basically
-                                    //  <input type="text" value="foo" />
-                                    //  ^ should be one line
-                                    // <input type="text" value="foo" bar="true" baz={false} />
-                                    //  ^ should be multiple lines
-                                    && props_i > 3
-                                )
-                            {
-                                writer.write_all(b"\n");
-                                write_indent_n(self.indent, writer.ctx).expect("unreachable");
-                            } else if props_i + 1 < count_without_children {
-                                writer.space();
                             }
                         }
                     }

--- a/src/jsc/JSPropertyIterator.rs
+++ b/src/jsc/JSPropertyIterator.rs
@@ -100,7 +100,6 @@ impl IntoIterObject for &mut JSObject {
 
 pub struct JSPropertyIterator<'a> {
     pub len: usize,
-    pub(crate) i: u32,
     pub(crate) iter_i: u32,
     /// null if and only if `object` has no properties (i.e. `len == 0`)
     pub(crate) impl_: Option<NonNull<JSPropertyIteratorImpl>>,
@@ -158,7 +157,6 @@ impl<'a> JSPropertyIterator<'a> {
 
         Ok(Self {
             len,
-            i: 0,
             iter_i: 0,
             impl_,
             global_object,
@@ -174,11 +172,9 @@ impl<'a> JSPropertyIterator<'a> {
         loop {
             let i: usize = self.iter_i as usize;
             if i >= self.len {
-                self.i = self.iter_i;
                 return Ok(None);
             }
 
-            self.i = self.iter_i;
             self.iter_i += 1;
             let mut name = bstr::String::DEAD;
             if self.options.include_value {

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -1105,8 +1105,7 @@ pub mod js_bundler {
                     },
                 )?;
 
-                // `loader_iter.len` counts property slots, some of which `next()` skips
-                // (empty names, skipped getters), so it is only a capacity hint.
+                // `len` counts slots that `next()` may skip, so it is only a capacity hint.
                 let mut loader_names: Vec<Box<[u8]>> = Vec::new();
                 // errdefer: Vec<Box<[u8]>> drops automatically
                 let mut loader_values: Vec<api::Loader> = Vec::new();

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -1105,11 +1105,8 @@ pub mod js_bundler {
                     },
                 )?;
 
-                // `loader_iter.i` is the property position, not a dense index of yielded
-                // entries. With `skip_empty_name = true` (or a skipped property getter),
-                // writing at `loader_iter.i` would leave earlier slots uninitialized and
-                // later freed as garbage. Use ArrayLists so the stored slice is always
-                // exactly what was appended.
+                // `loader_iter.len` counts property slots, some of which `next()` skips
+                // (empty names, skipped getters), so it is only a capacity hint.
                 let mut loader_names: Vec<Box<[u8]>> = Vec::new();
                 // errdefer: Vec<Box<[u8]>> drops automatically
                 let mut loader_values: Vec<api::Loader> = Vec::new();

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -188,10 +188,8 @@ impl Config {
                     JSPropertyIterator::init(global, define_obj_ref, PROP_ITER_OPTS)?;
                 // `defer define_iter.deinit()` → Drop
 
-                // `define_iter.i` is the property position, not a dense index of yielded
-                // entries. With `skip_empty_name = true` (or a skipped property getter),
-                // writing at `define_iter.i` would leave earlier slots uninitialized.
-                // Use Vecs so the stored slice is always exactly what was appended.
+                // `define_iter.len` counts property slots, some of which `next()` skips
+                // (empty names, skipped getters), so it is only a capacity hint.
                 let mut names: Vec<Box<[u8]>> = Vec::new();
                 let mut values: Vec<Box<[u8]>> = Vec::new();
                 names.reserve_exact(define_iter.len);

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -188,8 +188,7 @@ impl Config {
                     JSPropertyIterator::init(global, define_obj_ref, PROP_ITER_OPTS)?;
                 // `defer define_iter.deinit()` → Drop
 
-                // `define_iter.len` counts property slots, some of which `next()` skips
-                // (empty names, skipped getters), so it is only a capacity hint.
+                // `len` counts slots that `next()` may skip, so it is only a capacity hint.
                 let mut names: Vec<Box<[u8]>> = Vec::new();
                 let mut values: Vec<Box<[u8]>> = Vec::new();
                 names.reserve_exact(define_iter.len);

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -1978,7 +1978,6 @@ impl<'a> Formatter<'a> {
 
                     writer.write_all(b"<");
 
-                    let mut needs_space;
                     let mut tag_name_str = ZigString::init(b"");
 
                     let tag_name_slice: ZigStringSlice;
@@ -2001,11 +2000,8 @@ impl<'a> Formatter<'a> {
                         }
 
                         tag_name_slice = tag_name_str.to_slice();
-                        needs_space = true;
                     } else {
                         tag_name_slice = ZigString::init(b"unknown").to_slice();
-
-                        needs_space = true;
                     }
 
                     if !is_tag_kind_primitive {
@@ -2026,11 +2022,7 @@ impl<'a> Formatter<'a> {
 
                     if let Some(key_value) = value.get(self.global_this, "key")? {
                         if !key_value.is_undefined_or_null() {
-                            if needs_space {
-                                writer.write_all(b" key=");
-                            } else {
-                                writer.write_all(b"key=");
-                            }
+                            writer.write_all(b" key=");
 
                             let old_quote_strings = self.quote_strings;
                             self.quote_strings = true;
@@ -2045,7 +2037,6 @@ impl<'a> Formatter<'a> {
                             })();
                             self.quote_strings = old_quote_strings;
                             inner?;
-                            needs_space = true;
                         }
                     }
 
@@ -2072,15 +2063,10 @@ impl<'a> Formatter<'a> {
                         if props_iter.len > 0 {
                             {
                                 self.indent += 1;
-                                let count_without_children =
-                                    props_iter.len - usize::from(children_prop.is_some());
 
                                 let loop_result: JsResult<()> = (|| {
-                                // `JSPropertyIterator::i` is private upstream;
-                                // track the 1-based iteration index locally.
-                                let mut iter_i: usize = 0;
+                                let mut printed_props: usize = 0;
                                 while let Some(prop) = props_iter.next()? {
-                                    iter_i += 1;
                                     if prop.eql_comptime(b"children") {
                                         continue;
                                     }
@@ -2092,10 +2078,19 @@ impl<'a> Formatter<'a> {
                                         continue;
                                     }
 
-                                    if needs_space {
+                                    // Up to five props share the tag's line; each one after
+                                    // that goes on its own line:
+                                    //   <input type="text" value="foo" />
+                                    //   <input a="1" b="2" c="3" d="4" e="5"
+                                    //     f="6"
+                                    //     g="7" />
+                                    if printed_props >= 5 {
+                                        writer.write_all(b"\n");
+                                        self.write_indent(writer.ctx).expect("unreachable");
+                                    } else {
                                         writer.write_all(b" ");
                                     }
-                                    needs_space = false;
+                                    printed_props += 1;
 
                                     writer.print(format_args!(
                                         "{}{}{}={}",
@@ -2123,23 +2118,6 @@ impl<'a> Formatter<'a> {
                                                 pretty_fmt_const::<true>("<r>").as_bytes(),
                                             );
                                         }
-                                    }
-
-                                    if
-                                    // count_without_children is necessary to prevent printing an extra newline
-                                    // if there are children and one prop and the child prop is the last prop
-                                    iter_i + 1 < count_without_children
-                                        // 3 is arbitrary but basically
-                                        //  <input type="text" value="foo" />
-                                        //  ^ should be one line
-                                        // <input type="text" value="foo" bar="true" baz={false} />
-                                        //  ^ should be multiple lines
-                                        && iter_i > 3
-                                    {
-                                        writer.write_all(b"\n");
-                                        self.write_indent(writer.ctx).expect("unreachable");
-                                    } else if iter_i + 1 < count_without_children {
-                                        writer.write_all(b" ");
                                     }
                                 }
                                 Ok(())

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -2078,12 +2078,7 @@ impl<'a> Formatter<'a> {
                                         continue;
                                     }
 
-                                    // Up to five props share the tag's line; each one after
-                                    // that goes on its own line:
-                                    //   <input type="text" value="foo" />
-                                    //   <input a="1" b="2" c="3" d="4" e="5"
-                                    //     f="6"
-                                    //     g="7" />
+                                    // Five props fit on the tag's line; the rest go one per line.
                                     if printed_props >= 5 {
                                         writer.write_all(b"\n");
                                         self.write_indent(writer.ctx).expect("unreachable");

--- a/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
@@ -2,6 +2,7 @@ import { $ } from "bun";
 import { describe, expect, it, test } from "bun:test";
 import { readFileSync, writeFileSync } from "fs";
 import { bunEnv, bunExe, DirectoryTree, isDebug, tempDir, tempDirWithFiles } from "harness";
+import { createElement } from "react";
 
 function test1000000(arg1: any, arg218718132: any) {}
 
@@ -368,6 +369,35 @@ test("basic unchanging inline snapshot", () => {
   "v": Any<Date>,
 }
 `,
+  );
+});
+
+test("jsx element props are separated in snapshots and diffs", () => {
+  expect(createElement("x", { a: "1" })).toMatchInlineSnapshot(`<x a="1" />`);
+  expect(createElement("x", { a: "1", b: "2" })).toMatchInlineSnapshot(`<x a="1" b="2" />`);
+  expect(createElement("x", { a: "1", b: "2", c: "3" })).toMatchInlineSnapshot(`<x a="1" b="2" c="3" />`);
+  expect(createElement("x", { key: "k", a: "1", b: "2" })).toMatchInlineSnapshot(`<x key="k" a="1" b="2" />`);
+  expect(createElement("x", { a: "1", b: "2" }, "c")).toMatchInlineSnapshot(`<x a="1" b="2">c</x>`);
+  // A spread can put `children` before the other props.
+  expect(createElement("x", { children: "c", a: "1", b: "2" })).toMatchInlineSnapshot(`<x a="1" b="2">c</x>`);
+  // `children: undefined` is not printed and must not leave a stray space behind.
+  expect(createElement("x", { a: "1", b: "2", children: undefined })).toMatchInlineSnapshot(`<x a="1" b="2" />`);
+  // Five props share the tag's line; the rest go one per line.
+  // (Multi-line JSX is not wrapped in newlines the way objects are, so these templates are verbatim.)
+  expect(createElement("x", { a: "1", b: "2", c: "3", d: "4", e: "5", f: "6", g: "7" }))
+    .toMatchInlineSnapshot(`<x a="1" b="2" c="3" d="4" e="5"
+  f="6"
+  g="7" />`);
+  expect(createElement("x", { children: "c", a: "1", b: "2", c: "3", d: "4", e: "5", f: "6" }))
+    .toMatchInlineSnapshot(`<x a="1" b="2" c="3" d="4" e="5"
+  f="6">c</x>`);
+  expect(createElement("x", { a: "1" }, createElement("y", { p: "1", q: "2" }))).toMatchInlineSnapshot(`<x a="1">
+  <y p="1" q="2" />
+</x>`);
+
+  // toEqual and friends print both sides with the same formatter.
+  expect(() => expect(createElement("x", { a: "1", b: "2" })).toEqual(createElement("x", { a: "1", b: "3" }))).toThrow(
+    'Expected: <x a="1" b="3" />\nReceived: <x a="1" b="2" />',
   );
 });
 

--- a/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
@@ -395,10 +395,14 @@ test("jsx element props are separated in snapshots and diffs", () => {
   <y p="1" q="2" />
 </x>`);
 
-  // toEqual and friends print both sides with the same formatter.
-  expect(() => expect(createElement("x", { a: "1", b: "2" })).toEqual(createElement("x", { a: "1", b: "3" }))).toThrow(
-    'Expected: <x a="1" b="3" />\nReceived: <x a="1" b="2" />',
-  );
+  // toEqual and friends print both sides with the same formatter; the message is colored when colors are on.
+  let message = "";
+  try {
+    expect(createElement("x", { a: "1", b: "2" })).toEqual(createElement("x", { a: "1", b: "3" }));
+  } catch (e) {
+    message = Bun.stripANSI((e as Error).message);
+  }
+  expect(message).toContain('Expected: <x a="1" b="3" />\nReceived: <x a="1" b="2" />');
 });
 
 class InlineSnapshotTester {

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -321,18 +321,21 @@ it("jsx props are separated no matter where children sits in props", () => {
   expect(Bun.inspect(<x {...{ children: "c" }} a="1" b="2" />)).toBe(`<x a="1" b="2">c</x>`);
   expect(Bun.inspect(<x key="k" {...{ children: "c" }} a="1" b="2" />)).toBe(`<x key="k" a="1" b="2">c</x>`);
   // `children: undefined` is not printed and must not leave a stray space behind.
-  expect(
-    Bun.inspect(
-      <x a="1" b="2">
-        {undefined}
-      </x>,
-    ),
-  ).toBe(`<x a="1" b="2" />`);
+  const undefinedChild = (
+    <x a="1" b="2">
+      {undefined}
+    </x>
+  );
+  expect(Bun.inspect(undefinedChild)).toBe(`<x a="1" b="2" />`);
   // Five props share the tag's line; the rest go one per line.
-  expect(Bun.inspect(<x a="1" b="2" c="3" d="4" e="5" f="6" />)).toBe(`<x a="1" b="2" c="3" d="4" e="5"\n  f="6" />`);
+  const sixProps = <x a="1" b="2" c="3" d="4" e="5" f="6" />;
+  expect(Bun.inspect(sixProps)).toBe(`<x a="1" b="2" c="3" d="4" e="5"\n  f="6" />`);
   expect(Bun.inspect(<x {...{ children: "c" }} a="1" b="2" c="3" d="4" e="5" f="6" />)).toBe(
     `<x a="1" b="2" c="3" d="4" e="5"\n  f="6">c</x>`,
   );
+  // compact mode (also used for console.table cells) never wraps props and uses the same separator logic.
+  expect(Bun.inspect(sixProps, { compact: true })).toBe(`<x a="1" b="2" c="3" d="4" e="5" f="6" />`);
+  expect(Bun.inspect(undefinedChild, { compact: true })).toBe(`<x a="1" b="2" />`);
 });
 
 it("inspect", () => {

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -316,6 +316,25 @@ it("jsx with fragment", () => {
   expect(input).toBe(output);
 });
 
+it("jsx props are separated no matter where children sits in props", () => {
+  // A spread can put `children` before the other props.
+  expect(Bun.inspect(<x {...{ children: "c" }} a="1" b="2" />)).toBe(`<x a="1" b="2">c</x>`);
+  expect(Bun.inspect(<x key="k" {...{ children: "c" }} a="1" b="2" />)).toBe(`<x key="k" a="1" b="2">c</x>`);
+  // `children: undefined` is not printed and must not leave a stray space behind.
+  expect(
+    Bun.inspect(
+      <x a="1" b="2">
+        {undefined}
+      </x>,
+    ),
+  ).toBe(`<x a="1" b="2" />`);
+  // Five props share the tag's line; the rest go one per line.
+  expect(Bun.inspect(<x a="1" b="2" c="3" d="4" e="5" f="6" />)).toBe(`<x a="1" b="2" c="3" d="4" e="5"\n  f="6" />`);
+  expect(Bun.inspect(<x {...{ children: "c" }} a="1" b="2" c="3" d="4" e="5" f="6" />)).toBe(
+    `<x a="1" b="2" c="3" d="4" e="5"\n  f="6">c</x>`,
+  );
+});
+
 it("inspect", () => {
   expect(Bun.inspect(new TypeError("what")).includes("TypeError: what")).toBe(true);
   expect(Bun.inspect("hi")).toBe('"hi"');


### PR DESCRIPTION
### Problem
- `toMatchSnapshot` / `toMatchInlineSnapshot` and the Expected/Received lines of `toEqual`, `toStrictEqual`, `toMatchObject`, `toHaveBeenCalledWith`, ... print every JSX element that has two or more props without the space before the last prop: `<x a="1"b="2" />`. With six or more props the line break also lands one prop early. `Bun.inspect` prints the same element correctly, so console output and test output disagree on the same value.
- Cause (bun:test formatter only): `src/runtime/test_runner/pretty_format.rs`, `Tag::JSX` arm. The Zig version compared the iterator's 0-based index; the Rust port (#30412) replaced it with a local counter that is incremented before use (so it is 1-based) and kept the 0-based comparisons (`iter_i + 1 < count_without_children`, `iter_i > 3`), so the separator after the second to last prop is never written.
- Both formatters (`Bun.inspect` / `console.log` in `src/jsc/ConsoleObject.rs` `print_jsx`, and the arm above) derive the separator from the property slot index and `props.length - 1`. Any slot the loop skips throws that arithmetic off:
  - `children` listed before other props (a spread such as `<x {...props} a="1" b="2" />`, or `jsx("x", { children, ...rest })`): `<x a="1"b="2">c</x>`
  - `children` equal to `undefined` (`<x a="1" b="2">{cond && ...}</x>` with `cond` undefined): `<x a="1" b="2"  />` (two spaces)
  - `children` first plus six props: the line break moves one prop earlier and the last space is still dropped
  - the same happens in compact mode (`Bun.inspect(el, { compact: true })`, `console.table` / `Bun.inspect.table` cells), which shares the loop: a table cell for the children-first element reads `<x a="1"b="2" />`

### Fix
- Both loops now write the separator immediately before each prop they are about to print, and pick newline vs space from the number of props printed so far. A separator is only ever written between two props that were actually printed, so nothing the loop skips (children in any position, `children: undefined`, hidden values, empty names) can desynchronize it.
- The layout is unchanged on purpose: for an element whose `children` is last (what `createElement` and the JSX runtime produce), the old "newline after slot index > 3" and the new "newline before the sixth printed prop" are the same rule, so `Bun.inspect` output is byte for byte identical for every element it printed correctly before, and bun:test goes back to what it printed before the port. The existing JSX tests in `inspect.test.js` pass unchanged. Compact mode (`single_line`) keeps its rule too: always a space, never a line break; it only gains the missing separators.
- The always-true `needs_space` flag and `JSPropertyIterator::i` are removed: the separator logic was their only reader (`i` is `pub(crate)` and `dead_code` is denied in the workspace).
- Verified:
  - `test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts` ("jsx element props are separated in snapshots and diffs"): 1 to 7 props, `key`, children last / first / `undefined`, a nested element, and a `toEqual` failure message. Fails on the unfixed build at the 2-prop case; all 11 assertions pass with the fix (per-assertion list below).
  - `test/js/bun/util/inspect.test.js` ("jsx props are separated no matter where children sits in props"): children first via spread, with `key`, `{undefined}` child, the 6-prop layout with children last and first, and compact mode (6 props stay on one line; `{undefined}` child prints `<x a="1" b="2" />`, two spaces before the fix). Fails on the unfixed build at the first assertion, passes with the fix.
  - `bun bd test` on both files plus `test/js/bun/test/snapshot-tests`, `test/js/bun/test/printing`, `test/js/web/console/console-log.test.ts`, `test/cli/run/run-eval.test.ts`: only failures are pre-existing and unrelated (`error snapshots` needs colors enabled, `diffexample` prints a seconds suffix on the slow debug build, `inspect-error` gets an extra `require` frame on debug builds).
- Note: #38947 (open) wraps multi-line top-level JSX snapshots in line breaks. Whichever of the two lands second needs to adjust the three multi-line inline snapshots in the new test; the source changes do not overlap.

### Background
- Bun has two native value printers. `src/jsc/ConsoleObject.rs` backs `Bun.inspect` / `console.log` (and matchers such as `toBe`); `src/runtime/test_runner/pretty_format.rs` is a jest-pretty-format flavoured copy used for snapshots and for the Expected/Received side of the diffing matchers. Both have a near identical arm that prints a React element (`$$typeof === Symbol.for("react.element")`) as JSX: `<type key=... prop=value ...>` followed by either `children` or ` />`.
- Props are walked with `JSPropertyIterator`, which yields the object's own property names in order. `children` is not printed as a prop (it becomes the element body), and values whose JSC cell type is internal (`is_hidden()`) are skipped too, so the number of props printed is not `props.length - 1`, and the slot index of a printed prop is not its position among the printed props. The old code assumed both.

<details>
<summary>Per-assertion status of the new bun:test cases (unfixed canary vs this branch)</summary>

```
=== unfixed ===
PASS a
FAIL a,b                       Received: <x a="1"b="2" />
FAIL a,b,c                     Received: <x a="1" b="2"c="3" />
FAIL key,a,b                   Received: <x key="k" a="1"b="2" />
FAIL a,b + child               Received: <x a="1"b="2">c</x>
FAIL children,a,b              Received: <x a="1"b="2">c</x>
PASS a,b,children:undefined    (the two off-by-ones cancel out here; Bun.inspect prints two spaces, covered in inspect.test.js)
FAIL 7 props                   Received: <x a="1" b="2" c="3" d="4"\n  e="5"\n  f="6"g="7" />
FAIL children + 6 props        Received: <x a="1" b="2" c="3"\n  d="4"e="5"f="6">c</x>
FAIL nested                    Received: <x a="1">\n  <y p="1"q="2" />\n</x>
FAIL toEqual diff              Expected: <x a="1"b="3" /> / Received: <x a="1"b="2" />
=== fixed ===
all 11 PASS
```

`Bun.inspect` on the unfixed build, elements built with real React 18 JSX:

```
<x {...{ children: "c" }} a="1" b="2" />                 -> <x a="1"b="2">c</x>
<x a="1" b="2">{undefined}</x>                            -> <x a="1" b="2"  />
<x a="1" b="2" {...{ "": "z" }} />                        -> <x a="1" b="2"  />
<x {...{ children: "c" }} a="1" ... f="6" />              -> <x a="1" b="2" c="3" d="4"\n  e="5"f="6">c</x>
<x a="1" ... f="6" />                                     -> <x a="1" b="2" c="3" d="4" e="5"\n  f="6" />   (already correct, unchanged)
{ compact: true }:
<x {...{ children: "c" }} a="1" ... f="6" />              -> <x a="1" b="2" c="3" d="4" e="5"f="6" />
<x a="1" b="2">{undefined}</x>                            -> <x a="1" b="2"  />
Bun.inspect.table([{ el: <x {...{ children: "c" }} a="1" b="2" /> }])  cell: <x a="1"b="2" />
```
</details>

