### PR TITLE
bun:test: print a function's own name instead of its AsyncFunction / GeneratorFunction tag

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4949,8 +4949,7 @@ void JSC__JSValue__getNameProperty(JSC::EncodedJSValue JSValue0, JSC::JSGlobalOb
         return;
     }
 
-    // The function's own name comes before Symbol.toStringTag: async and generator functions
-    // inherit "AsyncFunction" / "GeneratorFunction" / "AsyncGeneratorFunction" from their prototype.
+    // Name first: async and generator functions inherit a Symbol.toStringTag ("AsyncFunction", ...) from their prototype.
     if (JSC::JSFunction* function = dynamicDowncast<JSC::JSFunction>(obj)) {
         WTF::String actualName = function->name(vm);
         if (actualName.isEmpty() && !function->isHostOrBuiltinFunction()) {

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4949,34 +4949,36 @@ void JSC__JSValue__getNameProperty(JSC::EncodedJSValue JSValue0, JSC::JSGlobalOb
         return;
     }
 
-    JSC::JSValue name = obj->getIfPropertyExists(arg1, vm.propertyNames->toStringTagSymbol);
+    // The function's own name comes before Symbol.toStringTag: async and generator functions
+    // inherit "AsyncFunction" / "GeneratorFunction" / "AsyncGeneratorFunction" from their prototype.
+    if (JSC::JSFunction* function = dynamicDowncast<JSC::JSFunction>(obj)) {
+        WTF::String actualName = function->name(vm);
+        if (actualName.isEmpty() && !function->isHostOrBuiltinFunction()) {
+            actualName = function->jsExecutable()->name().string();
+        }
+
+        if (!actualName.isEmpty()) {
+            *arg2 = Zig::toZigString(actualName);
+            return;
+        }
+    } else if (JSC::InternalFunction* function = dynamicDowncast<JSC::InternalFunction>(obj)) {
+        WTF::String actualName = function->name();
+        if (!actualName.isEmpty()) {
+            *arg2 = Zig::toZigString(actualName);
+            return;
+        }
+    }
+
+    JSC::JSValue toStringTag = obj->getIfPropertyExists(arg1, vm.propertyNames->toStringTagSymbol);
     RETURN_IF_EXCEPTION(scope, );
 
-    if (name && name.isString()) {
-        auto str = name.toWTFString(arg1);
+    if (toStringTag && toStringTag.isString()) {
+        auto str = toStringTag.toWTFString(arg1);
+        RETURN_IF_EXCEPTION(scope, );
         if (!str.isEmpty()) {
             *arg2 = Zig::toZigString(str);
             return;
         }
-    }
-
-    if (JSC::JSFunction* function = dynamicDowncast<JSC::JSFunction>(obj)) {
-
-        WTF::String actualName = function->name(vm);
-        if (!actualName.isEmpty() || function->isHostOrBuiltinFunction()) {
-            *arg2 = Zig::toZigString(actualName);
-            return;
-        }
-
-        actualName = function->jsExecutable()->name().string();
-
-        *arg2 = Zig::toZigString(actualName);
-        return;
-    }
-
-    if (JSC::InternalFunction* function = dynamicDowncast<JSC::InternalFunction>(obj)) {
-        *arg2 = Zig::toZigString(function->name());
-        return;
     }
 
     arg2->len = 0;

--- a/test/js/bun/test/snapshot-tests/snapshots/moremore.test.ts
+++ b/test/js/bun/test/snapshot-tests/snapshots/moremore.test.ts
@@ -118,3 +118,56 @@ test("test snapshots with Boolean and Number", () => {
     },
   });
 });
+
+test("async and generator functions print their own name", () => {
+  function plain() {}
+  async function load() {}
+  function* entries() {}
+  async function* stream() {}
+  const expression = async function save() {};
+  const methods = { async get() {}, *keys() {} };
+  class Tagged {
+    static get [Symbol.toStringTag]() {
+      return "NotTheClassName";
+    }
+  }
+
+  expect({ plain, load, entries, stream, expression, bound: load.bind(null), methods, Tagged }).toMatchInlineSnapshot(`
+    {
+      "Tagged": [class Tagged],
+      "bound": [Function: load],
+      "entries": [Function: entries],
+      "expression": [Function: save],
+      "load": [Function: load],
+      "methods": {
+        "get": [Function: get],
+        "keys": [Function: keys],
+      },
+      "plain": [Function: plain],
+      "stream": [Function: stream],
+    }
+  `);
+
+  expect(() => expect({ load }).toEqual({})).toThrow('"load": [Function: load]');
+
+  const element = { $$typeof: Symbol.for("react.element"), type: load, props: {} };
+  expect(element).toMatchInlineSnapshot(`<load />`);
+});
+
+test("functions without a name of their own print the way existing snapshots have them", () => {
+  // A name inferred from the variable is not printed, and an anonymous async or generator
+  // function is still labelled with its kind, so existing .snap files keep matching.
+  const arrow = () => {};
+  const asyncArrow = async () => {};
+  const generator = function* () {};
+  const asyncGenerator = async function* () {};
+
+  expect({ arrow, asyncArrow, generator, asyncGenerator }).toMatchInlineSnapshot(`
+    {
+      "arrow": [Function],
+      "asyncArrow": [Function: AsyncFunction],
+      "asyncGenerator": [Function: AsyncGeneratorFunction],
+      "generator": [Function: GeneratorFunction],
+    }
+  `);
+});


### PR DESCRIPTION
### Problem

- In bun:test, a function declared with a name prints as its kind instead of its name when it is async or a generator: `toMatchSnapshot()` stores `"load": [Function: AsyncFunction]` for `async function load() {}` (`[Function: GeneratorFunction]` / `[Function: AsyncGeneratorFunction]` for the other kinds), and `toEqual` / `toStrictEqual` failure diffs show the same text, so two async functions in one object are indistinguishable. A plain `function load() {}` prints `[Function: load]`, and `console.log(load)` prints `[AsyncFunction: load]`; only the test runner's formatter is affected. Found by inspection while working on #38939 (the same lookup names JSX tags there); there is no tracker issue for it, and the behaviour dates back to the formatter's first version.
- The same lookup names JSX tags (an async component prints as `<AsyncFunction />`, in both bun:test output and `Bun.inspect`) and, through `getClassName`, the `[class X]` printer, `describe(Class)`, `expect.any(Class)` and the "Expected constructor:" line of `toThrow(Class)`.
- Cause: `JSC__JSValue__getNameProperty` (`src/jsc/bindings/bindings.cpp`, the binding behind `JSValue::get_name_property`, used by the `Tag::Function` arm of `src/runtime/test_runner/pretty_format.rs` and by `getClassName` for functions) reads `Symbol.toStringTag` with `getIfPropertyExists`, which walks the prototype chain, before it looks at the function. `AsyncFunction.prototype[Symbol.toStringTag]` is `"AsyncFunction"` (likewise `GeneratorFunction` / `AsyncGeneratorFunction`), so for these functions the name is never consulted.

### Fix

- `getNameProperty` now takes the `JSFunction` / `InternalFunction` name first and reads `Symbol.toStringTag` only when the object has no name of its own. The name sources and the tag lookup are the ones the function already used; only the order changes (plus an exception check after resolving the tag string).
- Why this order is right: on a function, `Symbol.toStringTag` is never its name, it is the kind inherited from the prototype (or, for a class with a static `[Symbol.toStringTag]`, a description of the class object); the name is what `console.log`, node's `util.inspect` and jest's `[Function name]` all print first. Non-function objects never reach the name branches, so the `Symbol.toStringTag` behaviour that `handle_first_property` relies on for the `Foo {` prefix of tagged plain objects is unchanged.
- Scope, stated plainly: only functions with a name of their own change. A function whose name is merely inferred from its binding or property key, which is the most common async shape (`const save = async () => {}`, `{ update: async () => {} }`), still prints exactly as today, `[Function: AsyncFunction]`, through the tag fallback, just as `const f = () => {}` still prints `[Function]`. This formatter has never printed inferred names (#6612 changed that for `console.log` only) and existing `.snap` files with such functions depend on it, so moving this printer to `console.log`'s resolution (`[Function: save]`, or `[AsyncFunction: save]`) is a snapshot-format change for a separate decision; this PR only fixes the output that was wrong under the formatter's existing rule. The second new test pins the unchanged cases so that a later change to the rule is made on purpose.
- Also affected, in the same direction: `<Page />` instead of `<AsyncFunction />` for an async JSX component in both printers (#38939 reworks JSX tag naming separately and composes with this), and a class with a static `Symbol.toStringTag` getter now prints as `[class Tagged]` / `Any<Tagged>` / `Expected constructor: Tagged` instead of the tag, matching what `console.log` prints for the class. #38922 and #38517 add name sources inside the same branch of this function; whichever of those and this lands second needs a small textual rebase, and the reorder keeps their additions ahead of the tag lookup.
- Verified:
  - `test/js/bun/test/snapshot-tests/snapshots/moremore.test.ts`, "async and generator functions print their own name": declaration, generator, async generator, named function expression, bound async function, object-literal async / generator methods, a class with a static `Symbol.toStringTag`, the `toEqual` diff text, and a JSX element whose type is an async function. Fails on bun 1.4.0 (every one of those prints as its kind), passes with this change.
  - Same file, "functions without a name of their own print the way existing snapshots have them": arrow, async arrow, anonymous generator and async generator expressions. Passes before and after; it pins the scope described above.
  - With the debug build: the rest of `snapshot-tests/`, `describe.test.ts`, `expect.test.js`, `expect-extend.test.js`, `jest-extended.test.js`, `spyMatchers.test.ts`, `test-test.test.ts`, `util/inspect.test.js`, `console/console-log.test.ts` pass. `printing/diffexample.test.ts` differs only in an unstripped `[4.22s]` duration and `pretty-format-overflow.test.ts` overflows the stack, both pre-existing under debug builds and both already tracked by open PRs; the ~700 lines of diff output in the former are byte-identical.
  - A `Symbol.toStringTag` getter that throws while a diff is being formatted trips a JSC exception-scope assertion in debug builds before and after this change alike (the diff formatter discards the formatter's error at `diff_format.rs:47`); that is a separate pre-existing bug and has been reported on its own.

### Background

- `Symbol.toStringTag`: the property `Object.prototype.toString` reads to produce `[object Foo]`. JSC defines it on `AsyncFunction.prototype`, `GeneratorFunction.prototype` and `AsyncGeneratorFunction.prototype`, so every function of those kinds inherits it; ordinary functions inherit nothing from `Function.prototype`. Bun's formatters also use it to prefix plain objects that carry one (`Foo {}`).
- `JSFunction::name()`: the name a function was declared with (`function load() {}`, `async get() {}` in a literal, a bound function's target name). A name that was only inferred from a binding (`const f = () => {}`) is stored separately (`ecmaName`) and is what `f.name` and `getCalculatedDisplayName` (used by `console.log`) report; `getNameProperty` never read it, and still does not. `InternalFunction` is the base class of native constructors such as `Promise` or `Error`, which carry their name directly.
- `getClassName` (`bindings.cpp`) delegates to `getNameProperty` whenever the cell's class is `Function`, i.e. for every function and class value, which is how the `[class X]` printer and the matcher messages above share this code path.

<details>
<summary>Before / after (bun:test snapshot output)</summary>

```
async function load() {}            "load":   [Function: AsyncFunction]           -> [Function: load]
const save = async () => {};        "save":   [Function: AsyncFunction]           -> [Function: AsyncFunction]   (unchanged, inferred name only)
function* gen() {}                  "gen":    [Function: GeneratorFunction]       -> [Function: gen]
async function* agen() {}           "agen":   [Function: AsyncGeneratorFunction]  -> [Function: agen]
{ async m1() {} }                   "m1":     [Function: AsyncFunction]           -> [Function: m1]
load.bind(null)                     "bound":  [Function: AsyncFunction]           -> [Function: load]
const arrow = () => {};             "arrow":  [Function]                          -> [Function]                  (unchanged)
fs.promises.readFile                          [Function: AsyncFunction]           -> [Function: AsyncFunction]   (unchanged, builtin with an empty name)
class T { static get [Symbol.toStringTag]() { return "X" } }
                                    "T":      [class X]                           -> [class T]
JSX element with type: load                   <AsyncFunction />                   -> <load />
```

</details>
