### PR TITLE
bake: release the strings production.rs returns to the module loader hooks

### DIFF
--- a/src/runtime/bake/BakeGlobalObject.cpp
+++ b/src/runtime/bake/BakeGlobalObject.cpp
@@ -8,6 +8,9 @@
 #include "JavaScriptCore/Completion.h"
 #include "JavaScriptCore/JSSourceCode.h"
 
+// These (and BakeProdLoad below) return a BunString whose reference the caller
+// owns: consume it with transferToWTFString(), which releases it. toWTFString()
+// takes a second reference and leaks the one we were handed.
 extern "C" BunString BakeProdResolve(JSC::JSGlobalObject*, BunString a, BunString b);
 extern "C" BunString BakeToWindowsPath(BunString a);
 
@@ -45,7 +48,7 @@ bakeModuleLoaderImportModule(JSC::JSGlobalObject* global,
         BunString result = BakeProdResolve(global, Bun::toString(refererString), Bun::toString(keyString));
         RETURN_IF_EXCEPTION(scope, nullptr);
 
-        return JSC::importModule(global, JSC::Identifier::fromString(vm, result.toWTFString()),
+        return JSC::importModule(global, JSC::Identifier::fromString(vm, result.transferToWTFString()),
             JSC::Identifier(), WTF::move(parameters), nullptr);
     }
 
@@ -71,7 +74,7 @@ JSC::Identifier bakeModuleLoaderResolve(JSC::JSGlobalObject* jsGlobal,
             BunString result = BakeProdResolve(global, Bun::toString(referrer.getString(global)), Bun::toString(keyString));
             RETURN_IF_EXCEPTION(scope, vm.propertyNames->emptyIdentifier);
 
-            return JSC::Identifier::fromString(vm, result.toWTFString(BunString::ZeroCopy));
+            return JSC::Identifier::fromString(vm, result.transferToWTFString());
         }
     }
 
@@ -137,7 +140,7 @@ JSC::JSPromise* bakeModuleLoaderFetch(JSC::JSGlobalObject* globalObject,
                 JSC::SourceOrigin origin = JSC::SourceOrigin(WTF::URL(moduleKey));
                 JSC::SourceCode sourceCode = JSC::SourceCode(Bake::SourceProvider::create(
                     globalObject,
-                    source.toWTFString(),
+                    source.transferToWTFString(),
                     origin,
                     WTF::move(moduleKey),
                     WTF::TextPosition(),
@@ -159,7 +162,7 @@ JSC::JSPromise* bakeModuleLoaderFetch(JSC::JSGlobalObject* globalObject,
             // it, because `moduleLoaderFetch(...)` may read the path from disk
             // and so we need to give a Windows path to it.
             auto temp = BakeToWindowsPath(Bun::toString(bakePrefixRemoved));
-            bakePrefixRemoved = temp.toWTFString();
+            bakePrefixRemoved = temp.transferToWTFString();
 #endif
             JSString* bakePrefixRemovedString = jsNontrivialString(vm, bakePrefixRemoved);
             JSValue bakePrefixRemovedJsvalue = bakePrefixRemovedString;

--- a/src/runtime/bake/BakeGlobalObject.cpp
+++ b/src/runtime/bake/BakeGlobalObject.cpp
@@ -8,9 +8,7 @@
 #include "JavaScriptCore/Completion.h"
 #include "JavaScriptCore/JSSourceCode.h"
 
-// These (and BakeProdLoad below) return a BunString whose reference the caller
-// owns: consume it with transferToWTFString(), which releases it. toWTFString()
-// takes a second reference and leaks the one we were handed.
+// These (and BakeProdLoad below) return an owned reference: consume it with transferToWTFString().
 extern "C" BunString BakeProdResolve(JSC::JSGlobalObject*, BunString a, BunString b);
 extern "C" BunString BakeToWindowsPath(BunString a);
 

--- a/src/runtime/bake/BakeSourceProvider.cpp
+++ b/src/runtime/bake/BakeSourceProvider.cpp
@@ -58,8 +58,7 @@ extern "C" JSC::JSPromise* BakeLoadModuleByKey(GlobalObject* global, JSC::JSStri
   return JSC::loadAndEvaluateModule(global, key->getString(global), nullptr, nullptr);
 }
 
-// Both HMR patch entry points own `source` (DevServer.rs hands over a fresh copy)
-// and release it through transferToWTFString().
+// Both HMR patch entry points take ownership of `source` (DevServer.rs passes an OwnedString).
 extern "C" JSC::EncodedJSValue BakeLoadServerHmrPatch(GlobalObject* global, BunString source) {
   JSC::VM&vm = global->vm();
   auto scope = DECLARE_THROW_SCOPE(vm);

--- a/src/runtime/bake/BakeSourceProvider.cpp
+++ b/src/runtime/bake/BakeSourceProvider.cpp
@@ -58,6 +58,8 @@ extern "C" JSC::JSPromise* BakeLoadModuleByKey(GlobalObject* global, JSC::JSStri
   return JSC::loadAndEvaluateModule(global, key->getString(global), nullptr, nullptr);
 }
 
+// Both HMR patch entry points own `source` (DevServer.rs hands over a fresh copy)
+// and release it through transferToWTFString().
 extern "C" JSC::EncodedJSValue BakeLoadServerHmrPatch(GlobalObject* global, BunString source) {
   JSC::VM&vm = global->vm();
   auto scope = DECLARE_THROW_SCOPE(vm);
@@ -66,7 +68,7 @@ extern "C" JSC::EncodedJSValue BakeLoadServerHmrPatch(GlobalObject* global, BunS
   JSC::SourceOrigin origin = JSC::SourceOrigin(WTF::URL(string));
   JSC::SourceCode sourceCode = JSC::SourceCode(SourceProvider::create(
     global,
-    source.toWTFString(),
+    source.transferToWTFString(),
     origin,
     WTF::move(string),
     WTF::TextPosition(),
@@ -90,7 +92,7 @@ extern "C" JSC::EncodedJSValue BakeLoadServerHmrPatchWithSourceMap(GlobalObject*
   // Use DevServerSourceProvider with the source map JSON
   auto provider = DevServerSourceProvider::create(
     global,
-    source.toWTFString(),
+    source.transferToWTFString(),
     sourceMapJSONPtr,
     sourceMapJSONLength,
     origin,

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -5560,6 +5560,8 @@ impl DevServer {
 mod c {
     use super::*;
 
+    /// `code` must carry its own reference (`clone_utf8`/`clone_latin1`); the
+    /// C++ side releases it.
     pub(super) fn bake_load_server_hmr_patch(
         global: &JSGlobalObject,
         code: BunString,
@@ -5570,6 +5572,7 @@ mod c {
         jsc::from_js_host_call(global, || BakeLoadServerHmrPatch(global, code))
     }
 
+    /// Same ownership of `code` as `bake_load_server_hmr_patch`.
     pub(super) fn bake_load_server_hmr_patch_with_source_map(
         global: &JSGlobalObject,
         code: BunString,

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -4254,7 +4254,7 @@ pub(super) fn finalize_bundle(
 
             match c::bake_load_server_hmr_patch_with_source_map(
                 global,
-                BunString::clone_utf8(&server_bundle),
+                OwnedString::new(BunString::clone_utf8(&server_bundle)),
                 json.as_ptr(),
                 json.len(),
             ) {
@@ -4272,7 +4272,10 @@ pub(super) fn finalize_bundle(
                 }
             }
         } else {
-            match c::bake_load_server_hmr_patch(global, BunString::clone_latin1(&server_bundle)) {
+            match c::bake_load_server_hmr_patch(
+                global,
+                OwnedString::new(BunString::clone_latin1(&server_bundle)),
+            ) {
                 Ok(v) => v,
                 Err(err) => {
                     // SAFETY: vm is JSC_BORROW — valid for DevServer lifetime;
@@ -5560,22 +5563,21 @@ impl DevServer {
 mod c {
     use super::*;
 
-    /// `code` must carry its own reference (`clone_utf8`/`clone_latin1`); the
-    /// C++ side releases it.
+    /// The C++ side releases `code` (transferToWTFString).
     pub(super) fn bake_load_server_hmr_patch(
         global: &JSGlobalObject,
-        code: BunString,
+        code: OwnedString,
     ) -> JsResult<JSValue> {
         unsafe extern "C" {
             safe fn BakeLoadServerHmrPatch(global: &JSGlobalObject, code: BunString) -> JSValue;
         }
-        jsc::from_js_host_call(global, || BakeLoadServerHmrPatch(global, code))
+        jsc::from_js_host_call(global, || BakeLoadServerHmrPatch(global, code.into_inner()))
     }
 
-    /// Same ownership of `code` as `bake_load_server_hmr_patch`.
+    /// The C++ side releases `code` (transferToWTFString).
     pub(super) fn bake_load_server_hmr_patch_with_source_map(
         global: &JSGlobalObject,
-        code: BunString,
+        code: OwnedString,
         source_map_json_ptr: *const u8,
         source_map_json_len: usize,
     ) -> JsResult<JSValue> {
@@ -5598,7 +5600,7 @@ mod c {
         jsc::from_js_host_call(global, || unsafe {
             BakeLoadServerHmrPatchWithSourceMap(
                 global,
-                code,
+                code.into_inner(),
                 source_map_json_ptr,
                 source_map_json_len,
             )

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -20,8 +20,8 @@ use bun_bundler::options::{self as bundler_options, OutputFile, SourceMapOption}
 use bun_bundler::output_file::Index as OutputFileIndex;
 
 use bun_collections::{AutoBitSet, StringArrayHashMap};
-use bun_core::String as BunString;
 use bun_core::{Global, Output};
+use bun_core::{OwnedString, String as BunString};
 use bun_dotenv as dotenv;
 use bun_jsc::js_promise::{UnwrapMode, Unwrapped};
 use bun_jsc::virtual_machine::VirtualMachine;
@@ -332,8 +332,9 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
         }
     };
 
-    let config_entry_point_string =
-        BunString::clone_utf8(config_entry_point.path_const().unwrap().text);
+    let config_entry_point_string = OwnedString::new(BunString::clone_utf8(
+        config_entry_point.path_const().unwrap().text,
+    ));
 
     let Some(config_promise) =
         JSModuleLoader::load_and_evaluate_module_ptr(vm.global, Some(&config_entry_point_string))
@@ -657,7 +658,9 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
     // Client files go to disk.
     // Server files get loaded in memory.
     // Populate indexes in `entry_points` to be looked up during prerendering
-    let mut module_keys: Vec<BunString> = vec![BunString::dead(); entry_points.files.count()];
+    let mut module_keys: Vec<OwnedString> = (0..entry_points.files.count())
+        .map(|_| OwnedString::new(BunString::dead()))
+        .collect();
     let mut output_module_map: StringArrayHashMap<OutputFileIndex> = StringArrayHashMap::default();
     let mut source_maps: StringArrayHashMap<OutputFileIndex> = StringArrayHashMap::default();
     {
@@ -748,7 +751,7 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
                                         BStr::new(without_prefix)
                                     ));
                                     str.to_thread_safe();
-                                    module_keys[entry_point_index as usize] = str;
+                                    module_keys[entry_point_index as usize] = OwnedString::new(str);
                                 }
                             }
 
@@ -825,15 +828,14 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
 
     for (i, router_type) in router.types.iter().enumerate() {
         if let Some(client_file) = router_type.client_file {
-            let str = BunString::create_format(format_args!(
+            let mut url = BunString::create_format(format_args!(
                 "{}{}",
                 BStr::new(public_path),
                 BStr::new(&pt.output_file(client_file).dest_path),
-            ))
-            .to_js(global)
-            .map_err(js_err)?;
+            ));
+            let url = jsc::bun_string_jsc::transfer_to_js(&mut url, global).map_err(js_err)?;
             client_entry_urls
-                .put_index(global, u32::try_from(i).expect("int cast"), str)
+                .put_index(global, u32::try_from(i).expect("int cast"), url)
                 .map_err(js_err)?;
         } else {
             client_entry_urls
@@ -928,15 +930,15 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
         debug_assert!(output_file.dest_path[0] != b'.');
         // CSS chunks must be in contiguous order!!
         debug_assert!(output_file.loader.is_css());
+        let mut url = BunString::create_format(format_args!(
+            "{}{}",
+            BStr::new(public_path),
+            BStr::new(&output_file.dest_path),
+        ));
         css_chunk_js_strings.push(
-            BunString::create_format(format_args!(
-                "{}{}",
-                BStr::new(public_path),
-                BStr::new(&output_file.dest_path),
-            ))
-            .to_js(global)
-            .map_err(js_err)?
-            .protected(),
+            jsc::bun_string_jsc::transfer_to_js(&mut url, global)
+                .map_err(js_err)?
+                .protected(),
         );
     }
 
@@ -1104,12 +1106,12 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
         }
 
         // Init the items
-        let pattern_string = BunString::clone_utf8(pattern.slice());
+        let mut pattern_string = BunString::clone_utf8(pattern.slice());
         route_patterns
             .put_index(
                 global,
                 u32::try_from(nav_index).expect("int cast"),
-                pattern_string.to_js(global).map_err(js_err)?,
+                jsc::bun_string_jsc::transfer_to_js(&mut pattern_string, global).map_err(js_err)?,
             )
             .map_err(js_err)?;
 
@@ -1448,7 +1450,7 @@ pub struct PerThread {
     pub(crate) entry_points: EntryPointMap,
     pub(crate) bundled_outputs: Vec<OutputFile>,
     /// Indexed by entry point index (OpaqueFileId)
-    pub(crate) module_keys: Vec<BunString>,
+    pub(crate) module_keys: Vec<OwnedString>,
     /// Unordered
     pub(crate) module_map: StringArrayHashMap<OutputFileIndex>,
     pub(crate) source_maps: StringArrayHashMap<OutputFileIndex>,
@@ -1513,7 +1515,7 @@ impl PerThread {
         vm: *mut VirtualMachine,
         entry_points: EntryPointMap,
         bundled_outputs: Vec<OutputFile>,
-        module_keys: Vec<BunString>,
+        module_keys: Vec<OwnedString>,
         module_map: StringArrayHashMap<OutputFileIndex>,
         source_maps: StringArrayHashMap<OutputFileIndex>,
     ) -> crate::Result<PerThread> {

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -650,6 +650,9 @@ export default async function AboutPage() {
       expect(output).toContain("Processing thread");
       return output;
     }
+    // LSan symbolizes every record it reports through llvm-symbolizer, which
+    // takes tens of seconds against the debug binary on a loaded machine.
+    const leakScanTimeout = 120_000;
 
     // LSan prints one record per allocation site: "Direct leak of N byte(s) in
     // M object(s) allocated from:" followed by "#k 0x... in <function> <file>"
@@ -695,9 +698,7 @@ export default async function AboutPage() {
         expect(aboutHtml).toContain("<div>about lazy<p>shared from about</p></div>");
         expect(leakedBunStrings(stderr)).toEqual([]);
       },
-      // LSan symbolizes every record through llvm-symbolizer, which is slow
-      // against the debug binary.
-      60_000,
+      leakScanTimeout,
     );
 
     // A successful build exits without tearing its VM down, and the VM's module
@@ -720,7 +721,7 @@ export default async function AboutPage() {
         expect(stderr).toContain("about page failed to render");
         expect(leakedBunStrings(stderr)).toEqual([]);
       },
-      60_000,
+      leakScanTimeout,
     );
   });
 });

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -595,14 +595,16 @@ export default function IndexPage() {
     expect(htmlContent).not.toContain('<script type="module"');
   });
 
-  // BakeProdResolve and BakeProdLoad (production.rs) return BunStrings that own
-  // a reference to their WTF string. BakeGlobalObject.cpp's module loader hooks
-  // used to read them with toWTFString(), which adds a second reference instead
-  // of taking over that one, so every import edge resolved and every chunk
-  // loaded while prerendering leaked its string. Only LeakSanitizer can see
-  // that, and only with Malloc=1: WTF strings otherwise live in bmalloc, which
-  // LSan does not track.
-  describe.skipIf(!isASAN || isWindows)("module loader releases the strings production.rs hands it", () => {
+  // Every BunString production.rs creates (module keys from BakeProdResolve,
+  // chunk sources from BakeProdLoad, the config path, route patterns, client
+  // entry URLs) carries a reference that exactly one consumer has to release:
+  // transferToWTFString() in BakeGlobalObject.cpp, transfer_to_js()/OwnedString
+  // in production.rs. The build used to read them with toWTFString()/to_js(),
+  // which take a reference of their own and leave that one behind, so every
+  // import edge resolved and every chunk loaded while prerendering leaked its
+  // string. Only LeakSanitizer can see that, and only with Malloc=1: WTF strings
+  // otherwise live in bmalloc, which LSan does not track.
+  describe.skipIf(!isASAN || isWindows)("strings created for the build are released", () => {
     // Both pages statically import one shared chunk and dynamically import
     // another, so the same "bake:/..." keys are resolved more than once through
     // bakeModuleLoaderResolve (static imports) and bakeModuleLoaderImportModule
@@ -638,45 +640,49 @@ export default async function AboutPage() {
           Malloc: "1",
           ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=0:detect_leaks=1",
           // With Malloc=1 about 20 bmalloc frames sit between malloc and the
-          // production.rs function that allocated the string; keep it in view.
-          LSAN_OPTIONS: "malloc_context_size=40",
+          // code that created the string; keep that code in view. log_threads
+          // makes the leak check announce itself even when it finds nothing.
+          LSAN_OPTIONS: "malloc_context_size=40:log_threads=1",
         })
         .quiet()
         .throws(false);
-      return stderr.toString();
+      const output = stderr.toString();
+      expect(output).toContain("Processing thread");
+      return output;
     }
 
     // LSan prints one record per allocation site: "Direct leak of N byte(s) in
     // M object(s) allocated from:" followed by "#k 0x... in <function> <file>"
     // frames. `bun build --app` still leaks unrelated process-lifetime bundler
     // state, so neither the report as a whole nor the exit code LSan forces
-    // means anything here; only the records allocated inside the two
-    // production.rs functions do. Each is reduced to its Bake frames so a
-    // failure reads as a stack.
-    const allocatedByProductionRs = /\bBakeProd(?:Resolve|Load)\b/;
-    function leakedBakeStrings(stderr: string): string[] {
+    // means anything here. Every BunString is created through bun_core::String
+    // and the BunString__* exports of BunString.cpp, so the records with those
+    // on the stack are exactly the strings this build created and never
+    // released. Each is reduced to the two frames above the string machinery,
+    // so a failure reads as "who created it".
+    const stringMachinery = /\bBunString__\w+|bun_core::string::/;
+    function leakedBunStrings(stderr: string): string[] {
       return stderr
         .split(/^(?=(?:Direct|Indirect) leak of )/m)
-        .filter(record => allocatedByProductionRs.test(record))
+        .filter(record => stringMachinery.test(record))
         .map(record => {
-          const [header, ...frames] = record.split("\n");
-          const bakeFrames = frames
-            .filter(frame => allocatedByProductionRs.test(frame) || frame.includes("BakeGlobalObject.cpp"))
-            .map(frame =>
-              frame
-                .trim()
-                .replace(/^#\d+ 0x[0-9a-f]+ in /, "")
-                .replace(/\(.*\) /, "() "),
-            );
-          return [header, ...bakeFrames].join("\n");
+          const [header, ...lines] = record.split("\n");
+          const frames = lines.map(line => line.trim().replace(/^#\d+ 0x[0-9a-f]+ in /, ""));
+          const created = frames.findIndex(frame => stringMachinery.test(frame));
+          const creators = frames
+            .slice(created)
+            .filter(frame => !stringMachinery.test(frame))
+            .slice(0, 2)
+            .map(frame => frame.replace(/\(.*\) /, "() ").replace(/ \S*\/src\//, " src/"));
+          return [header, ...creators].join("\n");
         });
     }
 
     test.concurrent(
-      "module keys resolved for static imports and import()",
+      "after a successful build",
       async () => {
         const dir = await tempDirWithBakeDeps(
-          "bake-production-resolve-leak",
+          "bake-production-string-leaks",
           app(`return <div>{"about " + lazy}<Shared page="about" /></div>;`),
         );
 
@@ -687,23 +693,24 @@ export default async function AboutPage() {
         const aboutHtml = await Bun.file(path.join(dir, "dist", "about", "index.html")).text();
         expect(indexHtml).toContain("<div>index lazy<p>shared from index</p></div>");
         expect(aboutHtml).toContain("<div>about lazy<p>shared from about</p></div>");
-        expect(leakedBakeStrings(stderr)).toEqual([]);
+        expect(leakedBunStrings(stderr)).toEqual([]);
       },
       // LSan symbolizes every record through llvm-symbolizer, which is slow
       // against the debug binary.
       60_000,
     );
 
-    // The module registry keeps its own reference to each chunk source for as
-    // long as the VM lives, and a successful build exits without tearing its
-    // VM down, which hides the BakeProdLoad leak. A failing build exits through
-    // the VM's exit path, so under BUN_DESTRUCT_VM_ON_EXIT the registry lets go
-    // and only the leaked reference is left holding each source.
+    // A successful build exits without tearing its VM down, and the VM's module
+    // registry and JS strings keep most of these strings reachable (the chunk
+    // sources BakeProdLoad returns, the config path, the client entry URL), so
+    // a leaked reference to them goes unreported above. A failing build exits
+    // through the VM's exit path, so under BUN_DESTRUCT_VM_ON_EXIT the VM lets
+    // go of them and only a leaked reference would be left holding them.
     test.concurrent(
-      "chunk sources loaded for the modules, once a failed build tears the VM down",
+      "after a failed build tears the VM down",
       async () => {
         const dir = await tempDirWithBakeDeps(
-          "bake-production-load-leak",
+          "bake-production-string-leaks-teardown",
           app(`throw new Error("about page failed to render");`),
         );
 
@@ -711,7 +718,7 @@ export default async function AboutPage() {
 
         // The build got as far as loading and running the page modules.
         expect(stderr).toContain("about page failed to render");
-        expect(leakedBakeStrings(stderr)).toEqual([]);
+        expect(leakedBunStrings(stderr)).toEqual([]);
       },
       60_000,
     );

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { existsSync } from "fs";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isASAN, isWindows } from "harness";
 import path from "path";
 import { tempDirWithBakeDeps } from "../bake-harness";
 
@@ -593,5 +593,127 @@ export default function IndexPage() {
 
     // Verify NO JavaScript imports are included in the HTML
     expect(htmlContent).not.toContain('<script type="module"');
+  });
+
+  // BakeProdResolve and BakeProdLoad (production.rs) return BunStrings that own
+  // a reference to their WTF string. BakeGlobalObject.cpp's module loader hooks
+  // used to read them with toWTFString(), which adds a second reference instead
+  // of taking over that one, so every import edge resolved and every chunk
+  // loaded while prerendering leaked its string. Only LeakSanitizer can see
+  // that, and only with Malloc=1: WTF strings otherwise live in bmalloc, which
+  // LSan does not track.
+  describe.skipIf(!isASAN || isWindows)("module loader releases the strings production.rs hands it", () => {
+    // Both pages statically import one shared chunk and dynamically import
+    // another, so the same "bake:/..." keys are resolved more than once through
+    // bakeModuleLoaderResolve (static imports) and bakeModuleLoaderImportModule
+    // (import()). Only a repeat resolution leaks a string LSan can report: the
+    // first one's string becomes the interned module key, which the atom table
+    // still points at.
+    const app = (aboutPageBody: string) => ({
+      "src/index.tsx": `export default { app: { framework: "react" } };`,
+      "components/Shared.tsx": `export function Shared({ page }: { page: string }) {
+  return <p>{"shared from " + page}</p>;
+}`,
+      "components/lazy.ts": `export const lazy = "lazy";`,
+      "pages/index.tsx": `import { Shared } from "../components/Shared";
+
+export default async function IndexPage() {
+  const { lazy } = await import("../components/lazy");
+  return <div>{"index " + lazy}<Shared page="index" /></div>;
+}`,
+      "pages/about.tsx": `import { Shared } from "../components/Shared";
+
+export default async function AboutPage() {
+  const { lazy } = await import("../components/lazy");
+  ${aboutPageBody}
+}`,
+    });
+
+    async function buildUnderLeakSanitizer(dir: string, env: Record<string, string> = {}): Promise<string> {
+      const { stderr } = await Bun.$`${bunExe()} build --app ./src/index.tsx`
+        .cwd(dir)
+        .env({
+          ...bunEnv,
+          ...env,
+          Malloc: "1",
+          ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=0:detect_leaks=1",
+          // With Malloc=1 about 20 bmalloc frames sit between malloc and the
+          // production.rs function that allocated the string; keep it in view.
+          LSAN_OPTIONS: "malloc_context_size=40",
+        })
+        .quiet()
+        .throws(false);
+      return stderr.toString();
+    }
+
+    // LSan prints one record per allocation site: "Direct leak of N byte(s) in
+    // M object(s) allocated from:" followed by "#k 0x... in <function> <file>"
+    // frames. `bun build --app` still leaks unrelated process-lifetime bundler
+    // state, so neither the report as a whole nor the exit code LSan forces
+    // means anything here; only the records allocated inside the two
+    // production.rs functions do. Each is reduced to its Bake frames so a
+    // failure reads as a stack.
+    const allocatedByProductionRs = /\bBakeProd(?:Resolve|Load)\b/;
+    function leakedBakeStrings(stderr: string): string[] {
+      return stderr
+        .split(/^(?=(?:Direct|Indirect) leak of )/m)
+        .filter(record => allocatedByProductionRs.test(record))
+        .map(record => {
+          const [header, ...frames] = record.split("\n");
+          const bakeFrames = frames
+            .filter(frame => allocatedByProductionRs.test(frame) || frame.includes("BakeGlobalObject.cpp"))
+            .map(frame =>
+              frame
+                .trim()
+                .replace(/^#\d+ 0x[0-9a-f]+ in /, "")
+                .replace(/\(.*\) /, "() "),
+            );
+          return [header, ...bakeFrames].join("\n");
+        });
+    }
+
+    test.concurrent(
+      "module keys resolved for static imports and import()",
+      async () => {
+        const dir = await tempDirWithBakeDeps(
+          "bake-production-resolve-leak",
+          app(`return <div>{"about " + lazy}<Shared page="about" /></div>;`),
+        );
+
+        const stderr = await buildUnderLeakSanitizer(dir);
+
+        // Both pages rendered, so every import above was resolved and loaded.
+        const indexHtml = await Bun.file(path.join(dir, "dist", "index.html")).text();
+        const aboutHtml = await Bun.file(path.join(dir, "dist", "about", "index.html")).text();
+        expect(indexHtml).toContain("<div>index lazy<p>shared from index</p></div>");
+        expect(aboutHtml).toContain("<div>about lazy<p>shared from about</p></div>");
+        expect(leakedBakeStrings(stderr)).toEqual([]);
+      },
+      // LSan symbolizes every record through llvm-symbolizer, which is slow
+      // against the debug binary.
+      60_000,
+    );
+
+    // The module registry keeps its own reference to each chunk source for as
+    // long as the VM lives, and a successful build exits without tearing its
+    // VM down, which hides the BakeProdLoad leak. A failing build exits through
+    // the VM's exit path, so under BUN_DESTRUCT_VM_ON_EXIT the registry lets go
+    // and only the leaked reference is left holding each source.
+    test.concurrent(
+      "chunk sources loaded for the modules, once a failed build tears the VM down",
+      async () => {
+        const dir = await tempDirWithBakeDeps(
+          "bake-production-load-leak",
+          app(`throw new Error("about page failed to render");`),
+        );
+
+        const stderr = await buildUnderLeakSanitizer(dir, { BUN_DESTRUCT_VM_ON_EXIT: "1" });
+
+        // The build got as far as loading and running the page modules.
+        expect(stderr).toContain("about page failed to render");
+        expect(leakedBakeStrings(stderr)).toEqual([]);
+      },
+      60_000,
+    );
   });
 });


### PR DESCRIPTION
### Problem
- Strings that bake's Rust code creates for its C++ entry points, and a few it creates for itself, are never released. LeakSanitizer (with `Malloc=1`, see Background) reports them on a two page `bun build --app` as, for example:
  ```
  Direct leak of 294 byte(s) in 7 object(s) allocated from:
      ... BunString__fromBytes -> bun_core::string::String::clone_utf8 -> create_format
      BakeProdResolve                  src/runtime/bake/production.rs:1371
      Bake::bakeModuleLoaderResolve    src/runtime/bake/BakeGlobalObject.cpp:71
  Direct leak of 80 byte(s) in 2 object(s) allocated from:
      ... BunString__createExternal -> OutputFile.rs to_bun_string_ref
      BakeProdLoad                     src/runtime/bake/production.rs:1629
      Bake::bakeModuleLoaderFetch      src/runtime/bake/BakeGlobalObject.cpp:135
  Direct leak of 48 byte(s) in 2 object(s) allocated from:
      ... BunString__fromBytes -> clone_utf8
      build_with_vm                    src/runtime/bake/production.rs:1107
  ```
  (all 23 records from the two test scenarios are in the details block below; every leaked string in a production build is one of these.)
- Cause, same mistake at every site: a `bun_core::String` (`BunString`) holding a `WTF::StringImpl` is a plain struct whose reference has to be released by exactly one consumer. These consumers used the borrowing conversions instead, which take a reference of their own and leave the one they were handed:
  - src/runtime/bake/BakeGlobalObject.cpp: the results of `BakeProdResolve` (lines 48 and 74), `BakeProdLoad` (140) and, on Windows, `BakeToWindowsPath` (162) read with `toWTFString()`. One leak per import edge resolved and per chunk loaded while prerendering. The referrer-less branch at line 86 already used `transferToWTFString()`.
  - src/runtime/bake/BakeSourceProvider.cpp: `BakeLoadServerHmrPatch` and `BakeLoadServerHmrPatchWithSourceMap` (lines 69 and 93) read the patch source with `toWTFString()`. DevServer.rs (`finalize_bundle`, lines 4257 and 4275) hands them a fresh `clone_utf8`/`clone_latin1` copy of the whole server bundle and never touches it again, so the dev server leaked one copy of the server bundle per server-side hot update.
  - src/runtime/bake/production.rs: the config path (line 336), client entry URLs (828), CSS chunk URLs (932) and route patterns (1107) were converted with the borrowing `to_js()` (compare the `transfer_to_js()` directly below at 1124), and the module keys (746) were kept in a plain `Vec<BunString>`, which frees nothing when dropped.

### Fix
- C++ consumers of Rust-created strings consume them with `transferToWTFString()` (six sites in the two files above). production.rs converts its temporaries with `transfer_to_js()` and holds the config path and `PerThread.module_keys` in `OwnedString`, the RAII wrapper the rest of bake (DevServer.rs, bake_body.rs, FrameworkRouter.rs) already uses.
- Correct because `transferToWTFString()` / `transferToJS()` (src/jsc/bindings/BunString.cpp) build the `WTF::String` or `JSString` and then drop the `BunString`'s own reference, so the string ends up owned only by the module key, `SourceProvider`, or JS string it was converted into; `OwnedString` drops the reference when the owner goes away. The non-owned values these paths can carry are unaffected: `transferToWTFString()` on the static builtin alias `BakeProdResolve` returns takes the same `toStringStatic` path line 74's `toWTFString(ZeroCopy)` already took, `transferToJS()` and `toJS()` treat `Empty`/`Dead` identically, and the thrown cases return before any conversion.
- The DevServer.rs wrappers for the two HMR patch entry points now take an `OwnedString` and hand its reference to C++ with `into_inner()`, so the type says the callee releases the string; `finalize_bundle`, their only caller, wraps the copies it makes. `BakeLoadInitialServerCode` keeps a plain `BunString` because it receives a static string.
- Verified with the two tests added to test/bake/dev/production.test.ts (ASAN builds only; LSan does not exist on Windows). Each builds a two page app under LeakSanitizer, checks that the leak scan ran (`log_threads=1` makes it announce itself), and fails on any leak record that has bake's string machinery (`BunString__*` / `bun_core::string`) on its stack, reduced to the frames that created the string:
  - "after a successful build": pages rendered; fails before with 4 records (both module loader hooks, route patterns), passes after.
  - "after a failed build tears the VM down": one page throws, `BUN_DESTRUCT_VM_ON_EXIT=1`. Only that exit path tears the VM down (production.rs `build_command`), which is what makes the chunk sources, config path and client entry URL visible to LSan. Fails before with 19 records, passes after.
  - `bun bd test --timeout 90000 test/bake/dev/production.test.ts`: 11/11 (the pre-existing tests need more than the 5s local default on a debug build; CI passes its own timeout). On CI's x64-asan lane the file passes 11/11 in about 12s (builds 97734 and 98233).
  - The dev server hunks are not leak-tested: observing a server hot update under LSan needs a dev server driven outside the bake harness, which treats sanitizer output as a crash. test/bake/dev/server-sourcemap.test.ts (5/5 under the ASAN debug build) exercises `BakeLoadServerHmrPatchWithSourceMap` across repeated reloads and the provider's destruction at exit, so the string now being owned solely by the provider is exercised; the plain variant differs only in the provider class, which the production tests cover.
- Overlap with open PRs: #38714 carries the `BakeProdLoad` hunk and the two BakeSourceProvider.cpp hunks incidentally (identical lines) and also edits the `clone_latin1` call in `finalize_bundle` that this PR wraps in `OwnedString`; #38949 rewrites the `import()` line of BakeGlobalObject.cpp while keeping `toWTFString()` there. Whichever lands second needs a one-line rebase in each case, and the end state should keep the transferring calls everywhere. This PR is the one that is about the ownership bug and carries the test for it.

### Background
- `BunString` (`bun_core::String` in Rust) is the string type shared across the Rust/C++ boundary. With the `WTFStringImpl` tag it points at a refcounted `WTF::StringImpl`, and the value itself is `Copy` with no destructor: a reference it holds is released only by explicit code. A Rust function returning one by value, or passing one by value to C++, hands its +1 reference to the receiver.
- `toWTFString()` / `to_js()` copy a string out by adding a reference (for strings the caller does not own); `transferToWTFString()` / `transfer_to_js()` do the same and then release the `BunString`'s reference (for strings it does own). `OwnedString` is the Rust RAII wrapper that releases on drop.
- `Bake::GlobalObject` is the JS global only `bun build --app` uses to prerender routes. Its module loader hooks map `bake:/...` specifiers onto the server chunks the bundler just produced: `bakeModuleLoaderResolve` and `bakeModuleLoaderImportModule` turn a specifier plus referrer into a key via `BakeProdResolve`; `bakeModuleLoaderFetch` gets a chunk's source from `BakeProdLoad`. The dev server instead evaluates each incremental server bundle through the HMR patch entry points in BakeSourceProvider.cpp.
- LeakSanitizer only sees allocations made through the system allocator. WTF strings normally come from bmalloc, which it does not track; the `Malloc=1` environment variable makes bmalloc route through the system allocator (bmalloc's Environment.cpp checks it unconditionally). `Identifier::fromString` interns its string in the per-thread atom table, so the first resolution of each key stays reachable through that table and only repeat resolutions (every shared chunk) show up as records; the tests' two pages import the same chunks for that reason.

<details>
<summary>Leak records from the unfixed build for the two test scenarios</summary>

Successful build (4 records):
```
Direct leak of 294 byte(s) in 7 object(s)   BakeProdResolve production.rs:1371 <- bakeModuleLoaderResolve BakeGlobalObject.cpp:71
Direct leak of 42 byte(s) in 1 object(s)    BakeProdResolve production.rs:1371 <- bakeModuleLoaderResolve BakeGlobalObject.cpp:71
Direct leak of 42 byte(s) in 1 object(s)    BakeProdResolve production.rs:1371 <- bakeModuleLoaderImportModule BakeGlobalObject.cpp:45
Direct leak of 21 byte(s) in 1 object(s)    build_with_vm production.rs:1107 (route pattern)
```

Failed build with `BUN_DESTRUCT_VM_ON_EXIT=1` (19 records):
```
Direct leak of 168 byte(s) in 4 object(s)   BakeProdResolve production.rs:1371 <- bakeModuleLoaderResolve BakeGlobalObject.cpp:71
Direct leak of 126 byte(s) in 3 object(s)   BakeProdResolve production.rs:1371 <- bakeModuleLoaderResolve BakeGlobalObject.cpp:71
Direct leak of 42 byte(s) in 1 object(s)    BakeProdResolve production.rs:1371 <- bakeModuleLoaderImportModule BakeGlobalObject.cpp:45   (x2 records)
Direct leak of 80 byte(s) in 2 object(s)    to_bun_string_ref OutputFile.rs:169 <- BakeProdLoad production.rs:1629 <- bakeModuleLoaderFetch BakeGlobalObject.cpp:135
Direct leak of 40 byte(s) in 1 object(s)    same BakeProdLoad stack                                                                      (x5 records)
Indirect leak of 16/32 byte(s)              same BakeProdLoad stack (the ExternalStringImpl's callback storage)                          (x6 records)
Direct leak of 48 byte(s) in 2 object(s)    build_with_vm production.rs:1107 (route patterns)
Direct leak of 45 byte(s) in 1 object(s)    build_with_vm production.rs:336  (config path)
Direct leak of 37 byte(s) in 1 object(s)    build_with_vm production.rs:828  (client entry URL)
```

With this branch both scenarios report zero records with string machinery on the stack; the remaining LSan output is unrelated process-lifetime bundler state, which is why test/bake/dev/production.test.ts stays on test/no-validate-leaksan.txt and the tests filter instead of asserting an empty report.
</details>
