### PR TITLE
run: stop holding &mut VirtualMachine across the code that re-enters it; inventory the &'static mut accessors

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -479,10 +479,8 @@ impl VMHolder {
     #[unsafe(no_mangle)]
     extern "C" fn Bun__setDefaultGlobalObject(global: *mut JSGlobalObject) {
         if let Some(vm_instance) = VM.get() {
-            // SAFETY: vm pointer set by init() on this thread. Called back from
-            // inside the global-object FFI that `init` (or the test runner's
-            // global swap) is in the middle of, so touch the fields through the
-            // pointer rather than forming a `&mut` over the whole VM.
+            // SAFETY: vm pointer set by init() on this thread. Raw accesses: this
+            // is a callback out of FFI the caller may be holding a VM borrow across.
             unsafe {
                 (*vm_instance).global = global;
                 if (*vm_instance).is_main_thread {
@@ -518,9 +516,6 @@ impl VMHolder {
     pub(crate) extern "C" fn Bun__writeProfilesBeforeSelfKill() {
         let Some(vm_ptr) = VM.get() else { return };
         // SAFETY: called on the JS thread that owns this VM (process._kill).
-        // Shared, not `&mut`: writing the heap profile can run a GC whose
-        // finalizers reach this VM through the same thread-local, so each
-        // `take()` below is its own `as_mut()` borrow.
         let vm = unsafe { &*vm_ptr };
         if let Some(config) = vm.as_mut().cpu_profiler_config.take() {
             if let Err(e) =
@@ -4031,12 +4026,9 @@ impl VirtualMachine {
         // instead of `ZigGlobalObject__create`. Route through `init` then
         // swap the global.
         let vm = Self::init(init_opts)?;
-        // SAFETY: `vm` is the live VM `init` just installed for this thread.
-        // `BakeCreateProdGlobal` reaches back into it (`Bun__getVM()`, then
-        // `Bun__VmHandle__retain` reads `vm.handle`), so, exactly as `init` does
-        // around `Zig__GlobalObject__create`, the global is created and the
-        // fields patched through the raw pointer, with no `&mut VirtualMachine`
-        // live across the FFI call. The uws loop is this thread's live loop.
+        // SAFETY: `vm` is the VM `init` just installed for this thread; the uws
+        // loop is this thread's. Raw accesses, as in `init`: `BakeCreateProdGlobal`
+        // re-enters the VM (`Bun__getVM` -> `Bun__VmHandle__retain`).
         unsafe {
             // `console` is the opaque round-trip pointer C++ stores into the new global.
             let new_global = BakeCreateProdGlobal((*vm).console.cast());

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -479,11 +479,15 @@ impl VMHolder {
     #[unsafe(no_mangle)]
     extern "C" fn Bun__setDefaultGlobalObject(global: *mut JSGlobalObject) {
         if let Some(vm_instance) = VM.get() {
-            // SAFETY: vm pointer set by init() on this thread
-            let vm_instance = unsafe { &mut *vm_instance };
-            vm_instance.global = global;
-            if vm_instance.is_main_thread {
-                MAIN_THREAD_VM.store(vm_instance, core::sync::atomic::Ordering::Release);
+            // SAFETY: vm pointer set by init() on this thread. Called back from
+            // inside the global-object FFI that `init` (or the test runner's
+            // global swap) is in the middle of, so touch the fields through the
+            // pointer rather than forming a `&mut` over the whole VM.
+            unsafe {
+                (*vm_instance).global = global;
+                if (*vm_instance).is_main_thread {
+                    MAIN_THREAD_VM.store(vm_instance, core::sync::atomic::Ordering::Release);
+                }
             }
         }
         CACHED_GLOBAL_OBJECT.set(Some(global));
@@ -514,18 +518,22 @@ impl VMHolder {
     pub(crate) extern "C" fn Bun__writeProfilesBeforeSelfKill() {
         let Some(vm_ptr) = VM.get() else { return };
         // SAFETY: called on the JS thread that owns this VM (process._kill).
-        let vm = unsafe { &mut *vm_ptr };
-        if let Some(config) = vm.cpu_profiler_config.take() {
+        // Shared, not `&mut`: writing the heap profile can run a GC whose
+        // finalizers reach this VM through the same thread-local, so each
+        // `take()` below is its own `as_mut()` borrow.
+        let vm = unsafe { &*vm_ptr };
+        if let Some(config) = vm.as_mut().cpu_profiler_config.take() {
             if let Err(e) =
-                crate::bun_cpu_profiler::stop_and_write_profile(vm.jsc_vm_mut(), &config)
+                crate::bun_cpu_profiler::stop_and_write_profile(vm.as_mut().jsc_vm_mut(), &config)
             {
                 bun_core::Output::err(<&'static str>::from(e), "Failed to write CPU profile", ());
             }
         }
-        if let Some(config) = vm.heap_profiler_config.take() {
-            if let Err(e) =
-                crate::bun_heap_profiler::generate_and_write_profile(vm.jsc_vm_mut(), &config)
-            {
+        if let Some(config) = vm.as_mut().heap_profiler_config.take() {
+            if let Err(e) = crate::bun_heap_profiler::generate_and_write_profile(
+                vm.as_mut().jsc_vm_mut(),
+                &config,
+            ) {
                 bun_core::Output::err(e, "Failed to write heap profile", ());
             }
         }
@@ -4023,20 +4031,26 @@ impl VirtualMachine {
         // instead of `ZigGlobalObject__create`. Route through `init` then
         // swap the global.
         let vm = Self::init(init_opts)?;
-        // SAFETY: `vm` is the unique live VM on this thread.
-        let vm_ref = unsafe { &mut *vm };
-        // `console` is the opaque round-trip pointer C++ stores into the new global.
-        let new_global = BakeCreateProdGlobal(vm_ref.console.cast());
-        vm_ref.global = new_global;
-        VMHolder::set_cached_global_object(Some(new_global));
-        vm_ref.regular_event_loop.global = NonNull::new(new_global);
-        // `new_global` is freshly created and live for VM lifetime; safe
-        // ZST-handle deref. `vm_ptr()` returns the FFI `*mut VM` directly
-        // (no `&VM` reborrow).
-        vm_ref.jsc_vm = JSGlobalObject::opaque_ref(new_global).vm_ptr();
-        // SAFETY: per-thread uws loop is live.
-        unsafe { (*uws::Loop::get()).internal_loop_data.jsc_vm = vm_ref.jsc_vm.cast() };
-        vm_ref.event_loop_mut().ensure_waker();
+        // SAFETY: `vm` is the live VM `init` just installed for this thread.
+        // `BakeCreateProdGlobal` reaches back into it (`Bun__getVM()`, then
+        // `Bun__VmHandle__retain` reads `vm.handle`), so, exactly as `init` does
+        // around `Zig__GlobalObject__create`, the global is created and the
+        // fields patched through the raw pointer, with no `&mut VirtualMachine`
+        // live across the FFI call. The uws loop is this thread's live loop.
+        unsafe {
+            // `console` is the opaque round-trip pointer C++ stores into the new global.
+            let new_global = BakeCreateProdGlobal((*vm).console.cast());
+            (*vm).global = new_global;
+            VMHolder::set_cached_global_object(Some(new_global));
+            (*vm).regular_event_loop.global = NonNull::new(new_global);
+            // `new_global` is freshly created and live for VM lifetime; safe
+            // ZST-handle deref. `vm_ptr()` returns the FFI `*mut VM` directly
+            // (no `&VM` reborrow).
+            let jsc_vm = JSGlobalObject::opaque_ref(new_global).vm_ptr();
+            (*vm).jsc_vm = jsc_vm;
+            (*uws::Loop::get()).internal_loop_data.jsc_vm = jsc_vm.cast();
+            (*vm).event_loop_mut().ensure_waker();
+        }
         if opts.smol {
             // SAFETY: process-global written once at startup.
             IS_SMOL_MODE.store(true, core::sync::atomic::Ordering::Relaxed);

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -702,24 +702,22 @@ impl WebWorker {
                 ..Default::default()
             },
         )?;
-        // Scoped `&mut VirtualMachine` for the worker-specific fields; ends
-        // before anything else on this thread re-derives access to the VM.
-        {
-            // SAFETY: init_worker returns a valid heap-allocated VM ptr;
-            // not yet published, so this `&mut` is exclusive.
-            let vm_ref = unsafe { &mut *vm };
+        // SAFETY: init_worker returns a valid heap-allocated VM ptr; not yet
+        // published, so nothing else can reach it. Per-field writes through the
+        // raw pointer, like the rest of this function (and `VirtualMachine::init`).
+        unsafe {
             // arena initialised above; worker-thread only field. `with_mut`
             // scopes a `&mut Option<Arena>` to the closure; we extract the raw
             // address (escaping as `*mut`, no borrow) for the VM backref.
-            vm_ref.arena = self
+            (*vm).arena = self
                 .arena
                 .with_mut(|a| NonNull::new(std::ptr::from_mut(a.as_mut().unwrap())));
 
-            *vm_ref.proxy_env_storage.lock() = proxy_env_slots;
+            *(*vm).proxy_env_storage.lock() = proxy_env_slots;
 
-            vm_ref.is_main_thread = false;
+            (*vm).is_main_thread = false;
             VirtualMachine::set_is_main_thread_vm(false);
-            vm_ref.on_unhandled_rejection = on_unhandled_rejection;
+            (*vm).on_unhandled_rejection = on_unhandled_rejection;
         }
 
         // Publish now (rather than at the end of startVM) so that:
@@ -1002,12 +1000,17 @@ impl WebWorker {
         // ---- 2. User exit handlers -----------------------------------------
         let mut exit_code: i32 = 0;
         if !vm_ptr.is_null() {
-            // SAFETY: vm_ptr valid; no other thread holds a pointer to it (they
-            // only ever held its handle) — `&mut` is exclusive.
-            let vm = unsafe { &mut *vm_ptr };
-            vm.is_shutting_down = true;
-            vm.on_exit();
-            exit_code = i32::from(vm.exit_handler.exit_code);
+            // SAFETY: vm_ptr is this thread's live VM; no other thread holds a
+            // pointer to it (they only ever held its handle). `on_exit` runs
+            // the user's 'exit' listeners, which reach the VM again through its
+            // thread-local (e.g. `process.exitCode = n` writes the field read
+            // right after), so each access here is its own statement-scoped
+            // borrow rather than one `&mut` held across the call.
+            unsafe {
+                (*vm_ptr).is_shutting_down = true;
+                (*vm_ptr).on_exit();
+                exit_code = i32::from((*vm_ptr).exit_handler.exit_code);
+            }
             log!(
                 "[{}] shutdown: exit handlers done",
                 self.execution_context_id

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -703,8 +703,7 @@ impl WebWorker {
             },
         )?;
         // SAFETY: init_worker returns a valid heap-allocated VM ptr; not yet
-        // published, so nothing else can reach it. Per-field writes through the
-        // raw pointer, like the rest of this function (and `VirtualMachine::init`).
+        // published, so nothing else can reach it.
         unsafe {
             // arena initialised above; worker-thread only field. `with_mut`
             // scopes a `&mut Option<Arena>` to the closure; we extract the raw
@@ -1001,11 +1000,8 @@ impl WebWorker {
         let mut exit_code: i32 = 0;
         if !vm_ptr.is_null() {
             // SAFETY: vm_ptr is this thread's live VM; no other thread holds a
-            // pointer to it (they only ever held its handle). `on_exit` runs
-            // the user's 'exit' listeners, which reach the VM again through its
-            // thread-local (e.g. `process.exitCode = n` writes the field read
-            // right after), so each access here is its own statement-scoped
-            // borrow rather than one `&mut` held across the call.
+            // pointer to it (they only ever held its handle). Per-statement
+            // accesses: `on_exit` runs 'exit' listeners, which reach the VM too.
             unsafe {
                 (*vm_ptr).is_shutting_down = true;
                 (*vm_ptr).on_exit();

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -279,8 +279,6 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
     // `pt.vm` is the live per-thread VM's BackRef set in `build_command`;
     // `as_ptr()` is `Copy` and does not borrow `pt`.
     let vm_ptr: *mut VirtualMachine = pt.vm.as_ptr();
-    // Shared: the config module and the renders run JS, which reaches this VM
-    // through `VirtualMachine::get()`; `&mut self` methods go through `as_mut()`.
     debug_assert!(core::ptr::eq(vm_ptr, VirtualMachine::get_mut_ptr()));
     let vm: &VirtualMachine = VirtualMachine::get();
     // Load and evaluate the configuration module.

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -279,10 +279,14 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
     // `pt.vm` is the live per-thread VM's BackRef set in `build_command`;
     // `as_ptr()` is `Copy` and does not borrow `pt`.
     let vm_ptr: *mut VirtualMachine = pt.vm.as_ptr();
-    // SAFETY: exclusive access on this thread for the duration of the call.
-    let vm = unsafe { &mut *vm_ptr };
-    // Load and evaluate the configuration module. `global()` returns
-    // `&'static`, decoupled from `vm` so later `&mut vm` reborrows are allowed.
+    // Evaluating the config module and rendering the routes run JS, and the
+    // host functions that JS calls reach this VM through `VirtualMachine::get()`
+    // (as does `PerThread` through `vm_ptr`), so this function never holds a
+    // `&mut` to the VM across them: the few `&mut self` methods it needs are
+    // called through `as_mut()`, one borrow per call.
+    debug_assert!(core::ptr::eq(vm_ptr, VirtualMachine::get_mut_ptr()));
+    let vm: &VirtualMachine = VirtualMachine::get();
+    // Load and evaluate the configuration module.
     let global = vm.global();
     // allocator = bun.default_allocator — dropped per §Allocators
 
@@ -300,7 +304,7 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
         unresolved_config_entry_point = prefixed;
     }
 
-    let config_entry_point = match vm.transpiler.resolver.resolve(
+    let config_entry_point = match vm.as_mut().transpiler.resolver.resolve(
         cwd,
         &unresolved_config_entry_point,
         bun_ast::ImportKind::EntryPointBuild,
@@ -346,9 +350,10 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
     // `opaque_mut` is the const-asserted safe `*mut → &mut` accessor
     // (`load_and_evaluate_module_ptr` returned a live JSC-heap cell).
     jsc::JSInternalPromise::opaque_mut(config_promise_ptr).set_handled();
-    vm.wait_for_promise(AnyPromise::Internal(config_promise_ptr))
-        .map_err(|stopped| js_err(stopped.throw(vm.global())))?;
-    let jsc_vm = vm.jsc_vm_mut();
+    vm.as_mut()
+        .wait_for_promise(AnyPromise::Internal(config_promise_ptr))
+        .map_err(|stopped| js_err(stopped.throw(global)))?;
+    let jsc_vm = vm.jsc_vm();
     // Promise cell is still live (rooted via the module loader).
     let mut options = match jsc::JSInternalPromise::opaque_mut(config_promise_ptr)
         .unwrap(jsc_vm, UnwrapMode::MarkHandled)
@@ -1197,14 +1202,10 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
         )
     };
     render_promise.set_handled();
-    // Rebind from the raw pointer: `PerThread::init`/`attach`/`load_bundled_module`
-    // above accessed the same allocation through `vm_ptr`, invalidating the
-    // earlier `&mut` under Stacked Borrows.
-    let vm = VirtualMachine::get().as_mut();
-    vm.wait_for_promise(AnyPromise::Normal(render_promise))
-        .map_err(|stopped| js_err(stopped.throw(vm.global())))?;
-    let jsc_vm = vm.jsc_vm_mut();
-    match render_promise.unwrap(jsc_vm, UnwrapMode::MarkHandled) {
+    vm.as_mut()
+        .wait_for_promise(AnyPromise::Normal(render_promise))
+        .map_err(|stopped| js_err(stopped.throw(global)))?;
+    match render_promise.unwrap(vm.jsc_vm(), UnwrapMode::MarkHandled) {
         Unwrapped::Pending => unreachable!(),
         Unwrapped::Fulfilled(_) => {
             bun_core::prettyln!("done");
@@ -1214,7 +1215,7 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
             return Err(js_err(global.throw_value(err)));
         }
     }
-    vm.wait_for_tasks();
+    vm.as_mut().wait_for_tasks();
     Ok(())
 }
 

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -279,11 +279,8 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
     // `pt.vm` is the live per-thread VM's BackRef set in `build_command`;
     // `as_ptr()` is `Copy` and does not borrow `pt`.
     let vm_ptr: *mut VirtualMachine = pt.vm.as_ptr();
-    // Evaluating the config module and rendering the routes run JS, and the
-    // host functions that JS calls reach this VM through `VirtualMachine::get()`
-    // (as does `PerThread` through `vm_ptr`), so this function never holds a
-    // `&mut` to the VM across them: the few `&mut self` methods it needs are
-    // called through `as_mut()`, one borrow per call.
+    // Shared: the config module and the renders run JS, which reaches this VM
+    // through `VirtualMachine::get()`; `&mut self` methods go through `as_mut()`.
     debug_assert!(core::ptr::eq(vm_ptr, VirtualMachine::get_mut_ptr()));
     let vm: &VirtualMachine = VirtualMachine::get();
     // Load and evaluate the configuration module.

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -957,9 +957,37 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
             is_main_thread: true,
             ..Default::default()
         })?;
-        // SAFETY: `init` returns the unique freshly-boxed VM on this thread.
-        let vm = unsafe { &mut *vm_ptr };
+        // SAFETY: `init` returned the VM it just created and installed for this
+        // thread. Nothing reaches it through `VirtualMachine::get()` until
+        // `Run::start` runs code, so this exclusive borrow, which ends when
+        // `configure_vm` returns, is the only access during configuration.
+        let run_entry = Self::configure_vm(unsafe { &mut *vm_ptr }, ctx, entry_path, loader);
 
+        // `init` installed the VM it returned as this thread's VM, so from
+        // here on it is driven through the same accessor everything else uses.
+        debug_assert!(::core::ptr::eq(vm_ptr, VirtualMachine::get_mut_ptr()));
+        Run {
+            ctx,
+            vm: VirtualMachine::get(),
+            entry_path: run_entry,
+        }
+        .start()
+    }
+
+    /// Everything `boot` does to the freshly created VM before `Run::start`:
+    /// CLI state hand-off, `--eval`/cron entry synthesis, transpiler options,
+    /// `$TZ`, env, preconnects. Returns the path `Run::start` loads.
+    ///
+    /// Takes the VM exclusively because this is the one window where that is
+    /// true: no JS has run yet, so nothing re-derives the VM through its
+    /// thread-local. `Run::start` runs JS and therefore holds only a shared
+    /// reference.
+    fn configure_vm(
+        vm: &mut VirtualMachine,
+        ctx: &mut ContextData,
+        entry_path: Box<[u8]>,
+        loader: Option<Loader>,
+    ) -> &'static [u8] {
         // `vm.preload`/`vm.argv` are `Vec<Box<[u8]>>` on both sides;
         // hand the CLI's vectors over wholesale (process-lifetime, never freed).
         vm.preload = std::mem::take(&mut ctx.preloads);
@@ -1093,12 +1121,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         // from `self.ctx` to drive the hot-reloader enable.
         vm.hot_reload = ctx.debug.hot_reload;
 
-        Run {
-            ctx,
-            vm,
-            entry_path: run_entry,
-        }
-        .start()
+        run_entry
     }
 
     /// Entry point for
@@ -1153,10 +1176,28 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
             ) as u8,
             ..Default::default()
         })?;
-        // SAFETY: `init_with_module_graph` returns the unique freshly-boxed VM
-        // on this thread.
-        let vm = unsafe { &mut *vm_ptr };
+        // SAFETY: as in `boot`: the VM was just created for this thread and
+        // nothing else reaches it until `Run::start`; the borrow ends when
+        // `configure_standalone_vm` returns.
+        let entry = Self::configure_standalone_vm(unsafe { &mut *vm_ptr }, ctx, entry_path, graph);
 
+        debug_assert!(::core::ptr::eq(vm_ptr, VirtualMachine::get_mut_ptr()));
+        Run {
+            ctx,
+            vm: VirtualMachine::get(),
+            entry_path: entry,
+        }
+        .start()
+    }
+
+    /// Standalone counterpart of [`Self::configure_vm`]; same exclusivity
+    /// argument. Returns the entry path `Run::start` loads.
+    fn configure_standalone_vm(
+        vm: &mut VirtualMachine,
+        ctx: &mut ContextData,
+        entry_path: Box<[u8]>,
+        graph: &bun_standalone_graph::Graph,
+    ) -> &'static [u8] {
         vm.preload = std::mem::take(&mut ctx.preloads);
         vm.argv = std::mem::take(&mut ctx.passthrough);
 
@@ -1204,12 +1245,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         );
         Self::do_preconnect(&ctx.runtime_options.preconnect);
 
-        Run {
-            ctx,
-            vm,
-            entry_path: entry,
-        }
-        .start()
+        entry
     }
 }
 
@@ -1223,7 +1259,13 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
 /// `RunCommand::boot` / `boot_standalone`.
 pub struct Run<'a> {
     ctx: &'a ContextData,
-    vm: &'a mut VirtualMachine,
+    /// Shared, not `&mut`: `start` runs JS, and everything JS calls back into
+    /// reaches this same VM through `VirtualMachine::get()`, so an exclusive
+    /// borrow held across `load_entry_point`/`tick`/`on_exit` would be
+    /// aliased by every one of those accesses. The `&mut self` VM methods are
+    /// called through `as_mut()`, which mints a borrow that lasts for that
+    /// one call, the same way `WebWorker::spin` drives a worker's VM.
+    vm: &'a VirtualMachine,
     /// `vm.main` already points into these bytes; `'static` because the hot
     /// reloader stores them too (`boot` leaks the `Box<[u8]>`, cron mode uses
     /// the runner arena).
@@ -1280,8 +1322,8 @@ impl Run<'_> {
         } = self;
         let _api_lock = vm.global().vm().get_api_lock();
 
-        vm.hot_reload = ctx.debug.hot_reload;
-        vm.on_unhandled_rejection = Run::on_unhandled_rejection_before_close;
+        vm.as_mut().hot_reload = ctx.debug.hot_reload;
+        vm.as_mut().on_unhandled_rejection = Run::on_unhandled_rejection_before_close;
 
         // ── CPU profiler ────────────────────────────────────────────────────
         if ctx.runtime_options.cpu_prof.enabled {
@@ -1291,7 +1333,7 @@ impl Run<'_> {
             let name: &'static [u8] = unsafe { &*std::ptr::from_ref::<[u8]>(opts.name.as_ref()) };
             // SAFETY: same process-lifetime erasure as `name` above.
             let dir: &'static [u8] = unsafe { &*std::ptr::from_ref::<[u8]>(opts.dir.as_ref()) };
-            vm.cpu_profiler_config = Some(bun_jsc::bun_cpu_profiler::CPUProfilerConfig {
+            vm.as_mut().cpu_profiler_config = Some(bun_jsc::bun_cpu_profiler::CPUProfilerConfig {
                 name,
                 dir,
                 md_format: opts.md_format,
@@ -1311,11 +1353,12 @@ impl Run<'_> {
             let name: &'static [u8] = unsafe { &*std::ptr::from_ref::<[u8]>(opts.name.as_ref()) };
             // SAFETY: same process-lifetime erasure as `name` above.
             let dir: &'static [u8] = unsafe { &*std::ptr::from_ref::<[u8]>(opts.dir.as_ref()) };
-            vm.heap_profiler_config = Some(bun_jsc::bun_heap_profiler::HeapProfilerConfig {
-                name,
-                dir,
-                text_format: opts.text_format,
-            });
+            vm.as_mut().heap_profiler_config =
+                Some(bun_jsc::bun_heap_profiler::HeapProfilerConfig {
+                    name,
+                    dir,
+                    text_format: opts.text_format,
+                });
             bun_analytics::features::heap_snapshot.fetch_add(1, Ordering::Relaxed);
         }
 
@@ -1373,23 +1416,25 @@ impl Run<'_> {
         }
 
         // ── hot-reloader enable ─────────────────────────────────────────────
+        // The reloader stores a back-reference it later writes through, so it
+        // gets the thread-local `*mut` (the pointer every other mutation of
+        // this VM derives from), not a pointer cast from the shared `vm`.
         match ctx.debug.hot_reload {
             cli::command::HotReload::Hot => {
-                // SAFETY: `vm` is the boxed-and-leaked main-thread VM
-                // (process-lifetime); it outlives the leaked reloader.
+                // SAFETY: the main-thread VM is process-lifetime; it outlives
+                // the leaked reloader.
                 unsafe {
                     bun_jsc::hot_reloader::HotReloader::enable_hot_module_reloading(
-                        std::ptr::from_mut::<VirtualMachine>(vm),
+                        VirtualMachine::get_mut_ptr(),
                         Some(entry),
                     )
                 }
             }
             cli::command::HotReload::Watch => {
-                // SAFETY: `vm` is the boxed-and-leaked main-thread VM
-                // (process-lifetime); it outlives the leaked reloader.
+                // SAFETY: as above.
                 unsafe {
                     bun_jsc::hot_reloader::WatchReloader::enable_hot_module_reloading(
-                        std::ptr::from_mut::<VirtualMachine>(vm),
+                        VirtualMachine::get_mut_ptr(),
                         Some(entry),
                     )
                 }
@@ -1409,39 +1454,35 @@ impl Run<'_> {
             }
         }
 
-        match vm.load_entry_point(entry) {
+        match vm.as_mut().load_entry_point(entry) {
             Ok(promise) => {
                 // SAFETY: `promise` is a live GC cell returned by the module loader.
                 let promise = unsafe { &mut *promise };
                 if promise.status() == PromiseStatus::Rejected {
-                    // SAFETY: `vm.jsc_vm` set in `init`; FFI takes `*mut`.
-                    let result = promise.result(unsafe { &mut *vm.jsc_vm });
-                    let global = vm.global;
+                    let result = promise.result(vm.jsc_vm());
                     // A CJS entry runs synchronously in Node, so its top-level
                     // throw is an uncaughtException; only an ESM entry
                     // rejection reports origin "unhandledRejection".
                     let is_rejection = !vm.entry_point_result.evaluated_as_cjs;
-                    // SAFETY: `global` valid for VM lifetime.
-                    let handled = vm.uncaught_exception(unsafe { &*global }, result, is_rejection);
+                    let handled = vm
+                        .as_mut()
+                        .uncaught_exception(vm.global(), result, is_rejection);
                     promise.set_handled();
-                    vm.pending_internal_promise_reported_at = vm.hot_reload_counter;
+                    vm.as_mut().pending_internal_promise_reported_at = vm.hot_reload_counter;
 
                     // When --hot/--watch is on (or a user
                     // `uncaughtException` handler swallowed the error), keep the
                     // process alive instead of hard-exiting on a rejected entry.
                     // The core run-loop below does the actual waiting.
                     if vm.hot_reload != cli::command::HotReload::None || handled {
-                        vm.add_main_to_watcher_if_needed();
-                        // SAFETY: `event_loop` is a self-pointer into this VM;
-                        // uniquely accessed here.
-                        vm.event_loop_ref().tick();
+                        vm.as_mut().add_main_to_watcher_if_needed();
+                        vm.as_mut().tick();
                     } else {
                         exit_with_unhandled_note(vm);
                     }
                 }
 
-                // SAFETY: `vm.jsc_vm` set in `init`.
-                let _ = promise.result(unsafe { &mut *vm.jsc_vm });
+                let _ = promise.result(vm.jsc_vm());
 
                 if log_has_msgs(vm) {
                     dump_build_error(vm);
@@ -1457,7 +1498,7 @@ impl Run<'_> {
             // `bun_alloc::Arena` has no per-heap collect to run alongside this
             // GC; it would only be a memory-usage hint, not correctness.
             let _ = vm.global().vm().run_gc(false);
-            vm.tick();
+            vm.as_mut().tick();
         }
 
         // Initial synchronous evaluation of the entrypoint is done (TLA may
@@ -1470,24 +1511,25 @@ impl Run<'_> {
 
         // ── core run-loop ──────────────────────────────────────────────────
         if vm.is_watcher_enabled() {
-            vm.report_exception_in_hot_reloaded_module_if_needed();
+            vm.as_mut()
+                .report_exception_in_hot_reloaded_module_if_needed();
             loop {
                 while vm.is_event_loop_alive() {
-                    vm.tick();
-                    vm.report_exception_in_hot_reloaded_module_if_needed();
-                    vm.auto_tick_active();
+                    vm.as_mut().tick();
+                    vm.as_mut()
+                        .report_exception_in_hot_reloaded_module_if_needed();
+                    vm.as_mut().auto_tick_active();
                 }
-                vm.on_before_exit();
-                vm.report_exception_in_hot_reloaded_module_if_needed();
-                // SAFETY: `event_loop` is a self-pointer into this VM; uniquely
-                // accessed here. Watcher arm keeps the process alive across
-                // reloads.
+                vm.as_mut().on_before_exit();
+                vm.as_mut()
+                    .report_exception_in_hot_reloaded_module_if_needed();
+                // Watcher arm keeps the process alive across reloads.
                 vm.event_loop_ref().tick_possibly_forever();
             }
         } else {
             while vm.is_event_loop_alive() {
-                vm.tick();
-                vm.auto_tick_active();
+                vm.as_mut().tick();
+                vm.as_mut().auto_tick_active();
             }
 
             if ctx.runtime_options.eval.eval_and_print {
@@ -1510,11 +1552,11 @@ impl Run<'_> {
                                     crate::generated_host_exports::Bun__onResolveEntryPointResult,
                                     crate::generated_host_exports::Bun__onRejectEntryPointResult,
                                 );
-                                vm.tick();
-                                vm.auto_tick_active();
+                                vm.as_mut().tick();
+                                vm.as_mut().auto_tick_active();
                                 while vm.is_event_loop_alive() {
-                                    vm.tick();
-                                    vm.auto_tick_active();
+                                    vm.as_mut().tick();
+                                    vm.as_mut().auto_tick_active();
                                 }
                                 break 'brk result;
                             }
@@ -1537,7 +1579,7 @@ impl Run<'_> {
                 }
             }
 
-            vm.on_before_exit();
+            vm.as_mut().on_before_exit();
         }
 
         if log_has_msgs(vm) {
@@ -1545,9 +1587,9 @@ impl Run<'_> {
             Output::flush();
         }
 
-        vm.on_unhandled_rejection = Run::on_unhandled_rejection_before_close;
+        vm.as_mut().on_unhandled_rejection = Run::on_unhandled_rejection_before_close;
         vm.global().handle_rejected_promises();
-        vm.on_exit();
+        vm.as_mut().on_exit();
 
         if ANY_UNHANDLED.load(Ordering::Relaxed) {
             print_unhandled_version_note(vm);
@@ -1563,7 +1605,7 @@ impl Run<'_> {
         crate::napi::fix_dead_code_elimination();
         crate::webcore::bake_response::fix_dead_code_elimination();
         bun_crash_handler::fix_dead_code_elimination();
-        vm.global_exit();
+        vm.as_mut().global_exit();
     }
 }
 
@@ -1578,7 +1620,7 @@ fn log_has_msgs(vm: &VirtualMachine) -> bool {
 }
 
 #[inline]
-fn log_clear_msgs(vm: &mut VirtualMachine) {
+fn log_clear_msgs(vm: &VirtualMachine) {
     if let Some(p) = vm.log {
         // SAFETY: see `log_has_msgs`.
         unsafe { (*p.as_ptr()).msgs.clear() };
@@ -1591,7 +1633,7 @@ fn log_clear_msgs(vm: &mut VirtualMachine) {
     any(target_os = "linux", target_os = "android"),
     unsafe(link_section = ".text.unlikely")
 )]
-fn dump_build_error(vm: &mut VirtualMachine) {
+fn dump_build_error(vm: &VirtualMachine) {
     Output::flush();
     if let Some(log) = vm.log {
         // SAFETY: `vm.log` set in `init`; single-threaded CLI.
@@ -1614,14 +1656,17 @@ fn dump_build_error(vm: &mut VirtualMachine) {
     any(target_os = "linux", target_os = "android"),
     unsafe(link_section = ".text.unlikely")
 )]
-fn exit_with_unhandled_note(vm: &mut VirtualMachine) -> ! {
-    vm.exit_handler.exit_code = 1;
-    vm.on_exit();
+fn exit_with_unhandled_note(vm: &VirtualMachine) -> ! {
+    vm.as_mut().exit_handler.exit_code = 1;
+    // Runs the user's 'exit' listeners; `process.exitCode = n` in one of them
+    // lands in `Bun__setExitCode` with its own `&mut` to this VM, so the borrow
+    // that set the code above must not still be live here.
+    vm.as_mut().on_exit();
     if ANY_UNHANDLED.load(Ordering::Relaxed) {
         bun_sourcemap::SavedSourceMap::MissingSourceMapNoteInfo::print();
         pretty_errorln!("<r>\n<d>{}<r>", Global::unhandled_error_bun_version_string,);
     }
-    vm.global_exit();
+    vm.as_mut().global_exit();
 }
 
 /// Cold `Err(err)` arm of `vm.load_entry_point` in `Run::start`.
@@ -1631,7 +1676,7 @@ fn exit_with_unhandled_note(vm: &mut VirtualMachine) -> ! {
     any(target_os = "linux", target_os = "android"),
     unsafe(link_section = ".text.unlikely")
 )]
-fn entry_point_load_failed(vm: &mut VirtualMachine, err: &crate::Error) -> ! {
+fn entry_point_load_failed(vm: &VirtualMachine, err: &crate::Error) -> ! {
     if log_has_msgs(vm) {
         dump_build_error(vm);
         log_clear_msgs(vm);
@@ -1653,8 +1698,8 @@ fn entry_point_load_failed(vm: &mut VirtualMachine, err: &crate::Error) -> ! {
     any(target_os = "linux", target_os = "android"),
     unsafe(link_section = ".text.unlikely")
 )]
-fn print_unhandled_version_note(vm: &mut VirtualMachine) {
-    vm.exit_handler.exit_code = 1;
+fn print_unhandled_version_note(vm: &VirtualMachine) {
+    vm.as_mut().exit_handler.exit_code = 1;
     bun_sourcemap::SavedSourceMap::MissingSourceMapNoteInfo::print();
     pretty_errorln!("<r>\n<d>{}<r>", Global::unhandled_error_bun_version_string,);
 }

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -972,7 +972,6 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
 
     /// The CLI-state hand-off, `--eval`/cron entry synthesis and option wiring
     /// `boot` does before `Run::start`; returns the path `Run::start` loads.
-    /// Exclusive access is sound here and only here: no JS has run yet.
     fn configure_vm(
         vm: &mut VirtualMachine,
         ctx: &mut ContextData,
@@ -1247,10 +1246,8 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
 /// `RunCommand::boot` / `boot_standalone`.
 pub struct Run<'a> {
     ctx: &'a ContextData,
-    /// Shared: `start` runs JS, which reaches this VM through
-    /// `VirtualMachine::get()`, so a `&mut` held across `tick()`/`on_exit()`
-    /// would be aliased. `&mut self` methods go through `as_mut()`, one
-    /// borrow per call, as in `WebWorker::spin`.
+    /// Not `&mut`: `start` runs JS, which reaches this VM through
+    /// `VirtualMachine::get()`. Mutation goes through `VirtualMachine::as_mut`.
     vm: &'a VirtualMachine,
     /// `vm.main` already points into these bytes; `'static` because the hot
     /// reloader stores them too (`boot` leaks the `Box<[u8]>`, cron mode uses
@@ -1402,8 +1399,7 @@ impl Run<'_> {
         }
 
         // ── hot-reloader enable ─────────────────────────────────────────────
-        // The reloader writes through the pointer it stores, so it gets the
-        // thread-local `*mut`, not one cast from the shared `vm`.
+        // The reloader writes through the pointer it keeps: hand it the `*mut`.
         match ctx.debug.hot_reload {
             cli::command::HotReload::Hot => {
                 // SAFETY: the main-thread VM is process-lifetime; it outlives

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -957,14 +957,10 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
             is_main_thread: true,
             ..Default::default()
         })?;
-        // SAFETY: `init` returned the VM it just created and installed for this
-        // thread. Nothing reaches it through `VirtualMachine::get()` until
-        // `Run::start` runs code, so this exclusive borrow, which ends when
-        // `configure_vm` returns, is the only access during configuration.
+        // SAFETY: the VM `init` just created; nothing else reaches it until
+        // `Run::start`, and this borrow ends when `configure_vm` returns.
         let run_entry = Self::configure_vm(unsafe { &mut *vm_ptr }, ctx, entry_path, loader);
 
-        // `init` installed the VM it returned as this thread's VM, so from
-        // here on it is driven through the same accessor everything else uses.
         debug_assert!(::core::ptr::eq(vm_ptr, VirtualMachine::get_mut_ptr()));
         Run {
             ctx,
@@ -974,14 +970,9 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         .start()
     }
 
-    /// Everything `boot` does to the freshly created VM before `Run::start`:
-    /// CLI state hand-off, `--eval`/cron entry synthesis, transpiler options,
-    /// `$TZ`, env, preconnects. Returns the path `Run::start` loads.
-    ///
-    /// Takes the VM exclusively because this is the one window where that is
-    /// true: no JS has run yet, so nothing re-derives the VM through its
-    /// thread-local. `Run::start` runs JS and therefore holds only a shared
-    /// reference.
+    /// The CLI-state hand-off, `--eval`/cron entry synthesis and option wiring
+    /// `boot` does before `Run::start`; returns the path `Run::start` loads.
+    /// Exclusive access is sound here and only here: no JS has run yet.
     fn configure_vm(
         vm: &mut VirtualMachine,
         ctx: &mut ContextData,
@@ -1176,9 +1167,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
             ) as u8,
             ..Default::default()
         })?;
-        // SAFETY: as in `boot`: the VM was just created for this thread and
-        // nothing else reaches it until `Run::start`; the borrow ends when
-        // `configure_standalone_vm` returns.
+        // SAFETY: as in `boot`.
         let entry = Self::configure_standalone_vm(unsafe { &mut *vm_ptr }, ctx, entry_path, graph);
 
         debug_assert!(::core::ptr::eq(vm_ptr, VirtualMachine::get_mut_ptr()));
@@ -1190,8 +1179,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         .start()
     }
 
-    /// Standalone counterpart of [`Self::configure_vm`]; same exclusivity
-    /// argument. Returns the entry path `Run::start` loads.
+    /// Standalone counterpart of [`Self::configure_vm`].
     fn configure_standalone_vm(
         vm: &mut VirtualMachine,
         ctx: &mut ContextData,
@@ -1259,12 +1247,10 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
 /// `RunCommand::boot` / `boot_standalone`.
 pub struct Run<'a> {
     ctx: &'a ContextData,
-    /// Shared, not `&mut`: `start` runs JS, and everything JS calls back into
-    /// reaches this same VM through `VirtualMachine::get()`, so an exclusive
-    /// borrow held across `load_entry_point`/`tick`/`on_exit` would be
-    /// aliased by every one of those accesses. The `&mut self` VM methods are
-    /// called through `as_mut()`, which mints a borrow that lasts for that
-    /// one call, the same way `WebWorker::spin` drives a worker's VM.
+    /// Shared: `start` runs JS, which reaches this VM through
+    /// `VirtualMachine::get()`, so a `&mut` held across `tick()`/`on_exit()`
+    /// would be aliased. `&mut self` methods go through `as_mut()`, one
+    /// borrow per call, as in `WebWorker::spin`.
     vm: &'a VirtualMachine,
     /// `vm.main` already points into these bytes; `'static` because the hot
     /// reloader stores them too (`boot` leaks the `Box<[u8]>`, cron mode uses
@@ -1416,9 +1402,8 @@ impl Run<'_> {
         }
 
         // ── hot-reloader enable ─────────────────────────────────────────────
-        // The reloader stores a back-reference it later writes through, so it
-        // gets the thread-local `*mut` (the pointer every other mutation of
-        // this VM derives from), not a pointer cast from the shared `vm`.
+        // The reloader writes through the pointer it stores, so it gets the
+        // thread-local `*mut`, not one cast from the shared `vm`.
         match ctx.debug.hot_reload {
             cli::command::HotReload::Hot => {
                 // SAFETY: the main-thread VM is process-lifetime; it outlives
@@ -1658,9 +1643,6 @@ fn dump_build_error(vm: &VirtualMachine) {
 )]
 fn exit_with_unhandled_note(vm: &VirtualMachine) -> ! {
     vm.as_mut().exit_handler.exit_code = 1;
-    // Runs the user's 'exit' listeners; `process.exitCode = n` in one of them
-    // lands in `Bun__setExitCode` with its own `&mut` to this VM, so the borrow
-    // that set the code above must not still be live here.
     vm.as_mut().on_exit();
     if ANY_UNHANDLED.load(Ordering::Relaxed) {
         bun_sourcemap::SavedSourceMap::MissingSourceMapNoteInfo::print();

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -623,11 +623,8 @@ impl<'a> WorkerLoop<'a> {
 /// `vm` must be a valid pointer to this thread's live `VirtualMachine` for the
 /// entire duration of the call (i.e. for the rest of the process, since this
 /// never returns).
-// `vm` stays a raw pointer because `WorkerLoop` stores it as one. Everything
-// here goes through `vm_ref`, a shared reference: `begin()` runs the test
-// files, and the JS in them reaches this VM through `VirtualMachine::get()`,
-// so no `&mut` to it may be live across that call (or the ticks below). The
-// writes are one `as_mut()` borrow each.
+// Raw because `WorkerLoop` stores it; used here only as the shared `vm_ref`,
+// since `begin()` runs JS that reaches the VM through `VirtualMachine::get()`.
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub(crate) fn run_as_worker(
     reporter: &mut CommandLineReporter,

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -623,8 +623,7 @@ impl<'a> WorkerLoop<'a> {
 /// `vm` must be a valid pointer to this thread's live `VirtualMachine` for the
 /// entire duration of the call (i.e. for the rest of the process, since this
 /// never returns).
-// Raw because `WorkerLoop` stores it; used here only as the shared `vm_ref`,
-// since `begin()` runs JS that reaches the VM through `VirtualMachine::get()`.
+// Raw because `WorkerLoop` stores it as such.
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub(crate) fn run_as_worker(
     reporter: &mut CommandLineReporter,

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -620,22 +620,25 @@ impl<'a> WorkerLoop<'a> {
 /// run each file with isolation, stream per-test events back. Never returns.
 ///
 /// # Safety
-/// `vm` must be a valid, exclusively-accessed pointer to a live `VirtualMachine`
-/// for the entire duration of the call (i.e. for the rest of the process, since
-/// this never returns).
-// `vm` must stay a raw pointer: it is stored in `WorkerLoop`/`WorkerCommands`
-// while a `&mut` derived from it (`vm_ref`) is also live, so a reference param
-// would alias. The `# Safety` contract above documents the caller's obligation.
+/// `vm` must be a valid pointer to this thread's live `VirtualMachine` for the
+/// entire duration of the call (i.e. for the rest of the process, since this
+/// never returns).
+// `vm` stays a raw pointer because `WorkerLoop` stores it as one. Everything
+// here goes through `vm_ref`, a shared reference: `begin()` runs the test
+// files, and the JS in them reaches this VM through `VirtualMachine::get()`,
+// so no `&mut` to it may be live across that call (or the ticks below). The
+// writes are one `as_mut()` borrow each.
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub(crate) fn run_as_worker(
     reporter: &mut CommandLineReporter,
     vm: *mut VirtualMachine,
     ctx: Command::Context,
 ) -> ! {
+    debug_assert!(core::ptr::eq(vm, VirtualMachine::get_mut_ptr()));
     // SAFETY: caller guarantees `vm` is a valid live VM pointer for the duration.
-    let vm_ref = unsafe { &mut *vm };
-    vm_ref.test_isolation_enabled = ctx.test_options.isolate;
-    vm_ref.auto_killer.enabled = ctx.test_options.isolate;
+    let vm_ref: &VirtualMachine = unsafe { &*vm };
+    vm_ref.as_mut().test_isolation_enabled = ctx.test_options.isolate;
+    vm_ref.as_mut().auto_killer.enabled = ctx.test_options.isolate;
 
     // `vm.arena` is currently a write-only backref: the `MimallocArena.gc()`
     // reader was dropped from the GC path (see web_worker.rs, which wires its
@@ -643,7 +646,7 @@ pub(crate) fn run_as_worker(
     let mut arena = bun_alloc::MimallocArena::new();
     // SAFETY: event_loop pointer is valid while vm lives.
     unsafe { (*vm_ref.event_loop()).ensure_waker() };
-    vm_ref.arena = Some(NonNull::from(&mut arena));
+    vm_ref.as_mut().arena = Some(NonNull::from(&mut arena));
     // vm.allocator = arena.arena(); — allocator params dropped in Rust
 
     let env = vm_ref.env_loader();
@@ -681,8 +684,9 @@ pub(crate) fn run_as_worker(
     }
     // Mirror TestCommand::exec's exit path so BUN_DESTRUCT_VM_ON_EXIT teardown
     // (lastChanceToFinalize) runs; bypassing it leaks JSC-owned native state.
-    vm_ref.exit_handler.exit_code = 0;
-    vm_ref.exit_handler.skip_exit_listeners = test_command::skip_exit_listeners(wloop.reporter);
+    vm_ref.as_mut().exit_handler.exit_code = 0;
+    vm_ref.as_mut().exit_handler.skip_exit_listeners =
+        test_command::skip_exit_listeners(wloop.reporter);
     vm_ref.run_with_api_lock(|| {
         // SAFETY: caller guarantees `vm` is a valid live VM pointer for the worker's lifetime.
         unsafe {
@@ -697,7 +701,7 @@ pub(crate) fn run_as_worker(
 
 fn worker_flush_aggregates(
     reporter: &mut CommandLineReporter,
-    vm: &mut VirtualMachine,
+    vm: &VirtualMachine,
     ctx: &Command::ContextData,
     cmds: &mut WorkerCommands,
 ) {

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1618,7 +1618,7 @@ impl CommandLineReporter {
 
     pub(crate) fn render_lcov(
         &mut self,
-        vm: &mut VirtualMachine,
+        vm: &VirtualMachine,
         opts: &CodeCoverageOptions,
     ) -> Option<Vec<u8>> {
         let map = ByteRangeMapping::map()?;

--- a/src/runtime/timer/EventLoopDelayMonitor.rs
+++ b/src/runtime/timer/EventLoopDelayMonitor.rs
@@ -1,8 +1,7 @@
 use bun_jsc::JSValue;
 use bun_jsc::virtual_machine::VirtualMachine;
 
-// Export functions for C++. The monitor lives in `runtime_state().timer`, not
-// on the VM, so the VM pointer C++ passes is not dereferenced.
+// Export functions for C++
 #[unsafe(no_mangle)]
 extern "C" fn Timer_enableEventLoopDelayMonitoring(
     _vm: *mut VirtualMachine,

--- a/src/runtime/timer/EventLoopDelayMonitor.rs
+++ b/src/runtime/timer/EventLoopDelayMonitor.rs
@@ -1,15 +1,14 @@
 use bun_jsc::JSValue;
 use bun_jsc::virtual_machine::VirtualMachine;
 
-// Export functions for C++
+// Export functions for C++. The monitor lives in `runtime_state().timer`, not
+// on the VM, so the VM pointer C++ passes is not dereferenced.
 #[unsafe(no_mangle)]
 extern "C" fn Timer_enableEventLoopDelayMonitoring(
-    vm: *mut VirtualMachine,
+    _vm: *mut VirtualMachine,
     histogram: JSValue,
     resolution_ms: i32,
 ) {
-    // SAFETY: vm is a valid non-null pointer passed from C++.
-    let vm = unsafe { &mut *vm };
     // `vm.timer` is `()` (jsc/runtime crate cycle) — recover `All` via runtime_state().
     let state = crate::jsc_hooks::runtime_state();
     // SAFETY: `runtime_state()` is non-null after `bun_runtime::init()`; single
@@ -18,15 +17,13 @@ extern "C" fn Timer_enableEventLoopDelayMonitoring(
         (*state)
             .timer
             .event_loop_delay
-            .enable(vm, histogram, resolution_ms)
+            .enable(histogram, resolution_ms)
     };
 }
 
 #[unsafe(no_mangle)]
-extern "C" fn Timer_disableEventLoopDelayMonitoring(vm: *mut VirtualMachine) {
-    // SAFETY: vm is a valid non-null pointer passed from C++.
-    let vm = unsafe { &mut *vm };
+extern "C" fn Timer_disableEventLoopDelayMonitoring(_vm: *mut VirtualMachine) {
     let state = crate::jsc_hooks::runtime_state();
     // SAFETY: see `Timer_enableEventLoopDelayMonitoring`.
-    unsafe { (*state).timer.event_loop_delay.disable(vm) };
+    unsafe { (*state).timer.event_loop_delay.disable() };
 }

--- a/src/runtime/timer/mod.rs
+++ b/src/runtime/timer/mod.rs
@@ -453,12 +453,7 @@ impl EventLoopDelayMonitor {
         crate::jsc_hooks::timer_all()
     }
 
-    fn enable(
-        &mut self,
-        _vm: &mut bun_jsc::virtual_machine::VirtualMachine,
-        histogram: JSValue,
-        resolution_ms: i32,
-    ) {
+    fn enable(&mut self, histogram: JSValue, resolution_ms: i32) {
         if self.enabled {
             return;
         }
@@ -479,7 +474,7 @@ impl EventLoopDelayMonitor {
         unsafe { (*Self::timer_all()).insert(elt) };
     }
 
-    fn disable(&mut self, _vm: &mut bun_jsc::virtual_machine::VirtualMachine) {
+    fn disable(&mut self) {
         if !self.enabled {
             return;
         }

--- a/test/internal/source-lints/fn-long-mut-reborrow.inventory.json
+++ b/test/internal/source-lints/fn-long-mut-reborrow.inventory.json
@@ -1,0 +1,324 @@
+{
+  "src/bundler/BundleThread.rs": [
+    "completion"
+  ],
+  "src/bundler/LinkerContext.rs": [
+    "chunk",
+    "chunk"
+  ],
+  "src/bundler/ParseTask.rs": [
+    "args",
+    "result",
+    "result_ptr"
+  ],
+  "src/bundler/bundle_v2.rs": [
+    "chunks",
+    "load",
+    "resolve",
+    "transpiler_ptr",
+    "value"
+  ],
+  "src/bundler/linker_context/generateCompileResultForJSChunk.rs": [
+    "c_ptr",
+    "chunk_ptr"
+  ],
+  "src/bunfig/arguments.rs": [
+    "log"
+  ],
+  "src/bunfig/bunfig.rs": [
+    "log_ptr"
+  ],
+  "src/css/css_parser.rs": [
+    "references_ptr"
+  ],
+  "src/css_jsc/css_internals.rs": [
+    "log_ptr"
+  ],
+  "src/event_loop/MiniEventLoop.rs": [
+    "global_ptr"
+  ],
+  "src/exe_format/pe.rs": [
+    "optional_header",
+    "pe_header"
+  ],
+  "src/http/AsyncHTTP.rs": [
+    "async_http"
+  ],
+  "src/http/HTTPThread.rs": [
+    "cloned_ptr"
+  ],
+  "src/install/NetworkTask.rs": [
+    "async_http"
+  ],
+  "src/install/PackageInstaller.rs": [
+    "subpath_buf_ptr"
+  ],
+  "src/install/PackageManager.rs": [
+    "ctx_ptr",
+    "manager_ptr",
+    "manager_ptr",
+    "manager_ptr",
+    "uws_loop"
+  ],
+  "src/install/PackageManager/PackageJSONEditor.rs": [
+    "e_string"
+  ],
+  "src/install/PackageManager/PopulateManifestCache.rs": [
+    "manager_ptr",
+    "net_ptr"
+  ],
+  "src/install/PackageManager/runTasks.rs": [
+    "extract_ptr",
+    "manager_ptr",
+    "net_ptr",
+    "network_task",
+    "patch_task",
+    "task_ptr",
+    "task_ptr",
+    "task_ptr"
+  ],
+  "src/install/PackageManager/updatePackageJSONAndInstall.rs": [
+    "current_package_json_ptr",
+    "root_package_json_ptr"
+  ],
+  "src/install/PackageManagerTask.rs": [
+    "this_raw"
+  ],
+  "src/install/auto_installer.rs": [
+    "pm"
+  ],
+  "src/install/hoisted_install.rs": [
+    "mgr_ptr",
+    "mgr_ptr",
+    "mgr_ptr",
+    "mgr_ptr",
+    "mgr_ptr"
+  ],
+  "src/install/isolated_install.rs": [
+    "lockfile",
+    "progress"
+  ],
+  "src/install/isolated_install/Installer.rs": [
+    "list"
+  ],
+  "src/install/lockfile/Package.rs": [
+    "common_raw"
+  ],
+  "src/io/PipeWriter.rs": [
+    "file_raw",
+    "file_raw"
+  ],
+  "src/io/lib.rs": [
+    "request_ptr",
+    "request_ptr"
+  ],
+  "src/jsc/VirtualMachine.rs": [
+    "jsc_vm_ptr",
+    "jsc_vm_ptr",
+    "vm",
+    "vm"
+  ],
+  "src/jsc_macros/lib.rs": [
+    "__this"
+  ],
+  "src/parsers/toml.rs": [
+    "cur",
+    "cur",
+    "obj"
+  ],
+  "src/resolver/fs.rs": [
+    "existing_ptr",
+    "stored"
+  ],
+  "src/resolver/resolver.rs": [
+    "info",
+    "merged_config",
+    "parent_config_ptr"
+  ],
+  "src/runtime/api/Archive.rs": [
+    "blob_ptr"
+  ],
+  "src/runtime/api/BunObject.rs": [
+    "server"
+  ],
+  "src/runtime/api/JSBundler.rs": [
+    "plugin",
+    "resolve"
+  ],
+  "src/runtime/api/bun/h2_frame_parser.rs": [
+    "signal_ptr",
+    "stream",
+    "stream",
+    "stream",
+    "stream",
+    "stream",
+    "stream",
+    "stream",
+    "stream_ptr",
+    "stream_ptr",
+    "stream_ptr",
+    "stream_ptr",
+    "stream_ptr",
+    "stream_ptr",
+    "stream_ptr"
+  ],
+  "src/runtime/api/bun/js_bun_spawn_bindings.rs": [
+    "jsc_vm_ptr",
+    "subprocess_ptr"
+  ],
+  "src/runtime/api/standalone_graph_jsc.rs": [
+    "store_ptr"
+  ],
+  "src/runtime/bake/DevServer.rs": [
+    "dev_ptr",
+    "dev_ptr",
+    "request_ptr"
+  ],
+  "src/runtime/bake/dev_server/hmr_socket.rs": [
+    "s"
+  ],
+  "src/runtime/bake/dev_server/mod.rs": [
+    "dev"
+  ],
+  "src/runtime/bake/production.rs": [
+    "vm_ptr",
+    "vm_ptr"
+  ],
+  "src/runtime/cli/build_command.rs": [
+    "log"
+  ],
+  "src/runtime/cli/create_command.rs": [
+    "filesystem",
+    "node"
+  ],
+  "src/runtime/cli/exec_command.rs": [
+    "mini"
+  ],
+  "src/runtime/cli/filter_run.rs": [
+    "dep",
+    "dependent",
+    "env_ptr",
+    "process"
+  ],
+  "src/runtime/cli/mod.rs": [
+    "graph"
+  ],
+  "src/runtime/cli/multi_run.rs": [
+    "dependent",
+    "dependent",
+    "env_ptr",
+    "process"
+  ],
+  "src/runtime/cli/outdated_command.rs": [
+    "log_ptr"
+  ],
+  "src/runtime/cli/package_manager_command.rs": [
+    "pm_ptr",
+    "pm_ptr"
+  ],
+  "src/runtime/cli/pm_trusted_command.rs": [
+    "pm_raw"
+  ],
+  "src/runtime/cli/run_command.rs": [
+    "mini",
+    "mini",
+    "promise"
+  ],
+  "src/runtime/cli/test/parallel/Coordinator.rs": [
+    "v_ptr"
+  ],
+  "src/runtime/cli/test/parallel/Worker.rs": [
+    "process_ptr"
+  ],
+  "src/runtime/cli/test/parallel/runner.rs": [
+    "cmds_ptr"
+  ],
+  "src/runtime/dispatch.rs": [
+    "poll"
+  ],
+  "src/runtime/dns_jsc/dns_sd.rs": [
+    "poll_ptr"
+  ],
+  "src/runtime/image/Image.rs": [
+    "blob"
+  ],
+  "src/runtime/node/path_watcher.rs": [
+    "owner_watcher"
+  ],
+  "src/runtime/server/NodeHTTPResponse.rs": [
+    "has_body"
+  ],
+  "src/runtime/server/RequestContext.rs": [
+    "pair",
+    "response_ptr",
+    "response_ptr",
+    "value"
+  ],
+  "src/runtime/shell/Builtin.rs": [
+    "body"
+  ],
+  "src/runtime/shell/states/Cmd.rs": [
+    "child"
+  ],
+  "src/runtime/test_runner/Collection.rs": [
+    "bun_test_root"
+  ],
+  "src/runtime/test_runner/Order.rs": [
+    "current",
+    "last"
+  ],
+  "src/runtime/test_runner/bun_test.rs": [
+    "scope_ptr",
+    "scope_ptr"
+  ],
+  "src/runtime/test_runner/pretty_format.rs": [
+    "blob",
+    "request",
+    "response"
+  ],
+  "src/runtime/timer/mod.rs": [
+    "timer"
+  ],
+  "src/runtime/webcore/BakeResponse.rs": [
+    "bake_ssr_has_jsx"
+  ],
+  "src/runtime/webcore/Body.rs": [
+    "blob_ptr",
+    "blob_ptr"
+  ],
+  "src/runtime/webcore/FileReader.rs": [
+    "remaining"
+  ],
+  "src/runtime/webcore/ReadableStream.rs": [
+    "blobby"
+  ],
+  "src/runtime/webcore/Request.rs": [
+    "response"
+  ],
+  "src/runtime/webcore/blob/copy_file.rs": [
+    "result"
+  ],
+  "src/runtime/webcore/blob/read_file.rs": [
+    "promise"
+  ],
+  "src/runtime/webcore/fetch/FetchTasklet.rs": [
+    "body",
+    "fetch_tasklet_ptr"
+  ],
+  "src/runtime/webcore/s3/client.rs": [
+    "ctx_ptr",
+    "reader",
+    "response_stream",
+    "task_ptr",
+    "task_ptr"
+  ],
+  "src/sql_jsc/mysql/MySQLConnection.rs": [
+    "new_socket"
+  ],
+  "src/sql_jsc/mysql/MySQLQuery.rs": [
+    "statement"
+  ],
+  "src/sql_jsc/postgres/PostgresSQLConnection.rs": [
+    "new_socket"
+  ]
+}

--- a/test/internal/source-lints/fn-long-mut-reborrow.test.ts
+++ b/test/internal/source-lints/fn-long-mut-reborrow.test.ts
@@ -1,36 +1,59 @@
 import { file } from "bun";
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { realpathSync } from "fs";
 import path from "path";
 import { globAllSources } from "../../../scripts/glob-sources.ts";
 
 // `let this = unsafe { &mut *this };` — the fn-long exclusive reborrow of a
-// callback's raw pointer — is banned, under any binding name.
+// raw pointer — is banned, under any binding name.
 //
 // The shape asserts exclusive access to the object for the rest of the
-// function, but the functions that receive these pointers are callbacks
-// (uSockets/libuv handlers, task-queue arms, vtable dispatch) whose bodies run
-// JS or dispatch events that can re-enter the same object through its own
-// accessors. Under Stacked/Tree Borrows the re-entrant access pops the
-// fn-long tag, making every later use of the binding UB; before that it's an
-// LLVM `noalias` miscompile hazard.
+// function, but the functions that form it are callbacks (uSockets/libuv
+// handlers, task-queue arms, vtable dispatch) or drivers (`Run::start`,
+// `WebWorker::spin`, `bun build --app`) whose bodies run JS or dispatch events
+// that re-enter the same object through its own accessors
+// (`VirtualMachine::get()`, `http_thread()`, a stored back-reference). Under
+// Stacked/Tree Borrows the re-entrant access pops the fn-long tag, making every
+// later use of the binding UB; before that it's an LLVM `noalias` miscompile
+// hazard.
 //
 // Replacements, in preference order (see the sweep that removed the last ~370
 // of these for worked examples):
 //   - `let x = unsafe { &*ptr };` when everything reached is `&self` /
-//     `Cell`/`JsCell` (TRAMPOLINE).
+//     `Cell`/`JsCell`, with `x.as_mut().m()` for the odd `&mut self` method
+//     (TRAMPOLINE) — `Run::start` in src/runtime/cli/run_command.rs.
 //   - Statement-scoped raw place access `unsafe { (*ptr).field = v };`, a
 //     call-scoped `unsafe { &mut *ptr }` argument, `heap::take(ptr)` Box
 //     reclaim, or a `&mut self` prep method invoked as
-//     `unsafe { (*ptr).prep() }` (DEAD).
+//     `unsafe { (*ptr).prep() }` (DEAD) — `VirtualMachine::init`.
 //   - Convert the type's touched state to `Cell`/`JsCell` and its methods to
 //     `&self` (REENTRANT) — exemplars: `src/runtime/ipc.rs` (SendQueue),
 //     `src/runtime/socket/UpgradedDuplex.rs`, `src/io/PipeReader.rs`'s raw
 //     `read`/`on_poll` entry chain.
 //
-// Sibling guards: frozen-nonnull-reborrow.test.ts, unsound-erased-box.test.ts.
+// Two tiers:
+//   1. Operands named like raw callback parameters (`this`, `ctx`, `ptr`, ...)
+//      are banned outright; the tree is at zero.
+//   2. Every other identifier operand (`&mut *vm_ptr`, `&mut *manager_ptr`,
+//      `&mut *vm`, ...) is the same shape reached through a local, and is
+//      pinned per file in fn-long-mut-reborrow.inventory.json: the operand
+//      names each file still contains. Not every entry is a live bug (some
+//      are init windows nothing else can reach yet, some reborrow opaque ZST
+//      handles); the inventory exists so that a new one fails here and gets
+//      looked at, and so the list only shrinks. Reborrows of field paths and
+//      call results (`&mut *self.ptr`, `&mut *x.as_ptr()`) are a further
+//      population this lint does not cover.
+//
+// If this fails because you ADDED one: use one of the replacements above.
+// If it fails because you REMOVED one: regenerate the inventory:
+//   bun ./test/internal/source-lints/fn-long-mut-reborrow.test.ts --update
+//
+// Sibling guards: frozen-nonnull-reborrow.test.ts, unsound-erased-box.test.ts,
+// static-mut-accessors.test.ts (the accessors that hand out the `&'static mut`
+// these sites are re-entered through).
 
 const root = path.resolve(import.meta.dir, "..", "..", "..");
+const INVENTORY = import.meta.dir + "/fn-long-mut-reborrow.inventory.json";
 const rustSources = globAllSources().rust.filter(p => p.endsWith(".rs"));
 
 // Only scan files tracked in HEAD (a `git stash` round-trip can leave stray
@@ -46,28 +69,43 @@ const tracked: Set<string> | null = (() => {
   return new Set(r.stdout.toString().split("\0").filter(Boolean));
 })();
 
-// A `let` binding (any name, optionally typed) of `unsafe { &mut *<param> }`
-// where <param> is one of the raw-pointer callback-parameter names used across
-// the tree. Matched across newlines so a rustfmt-wrapped binding can't evade
-// it. `[^=;{}]*` after the binding name permits a type ascription but cannot
-// cross into a different statement; the trailing `;` requires the unsafe
-// block to be the entire initializer, so a call-scoped
-// `unsafe { &mut *p }.method()` expression does not count.
-//
-// The name list is the enforcement boundary: reborrows of locals or fields
-// (`&mut *self.log()`, `&mut *existing_ptr`) are a separate, pre-existing
-// population outside this lint's scope. If you add a new raw callback-param
-// name, add it here.
-const BANNED =
-  /let\s+(?:mut\s+)?\w+\s*(?::[^=;{}]*)?=\s*unsafe\s*\{\s*&mut\s+\*(?:this|ctx|p|ptr|self_ptr|this_ptr|raw|task|handle|data|context|user_data|parent|client|ws|req|resp|socket)\b\s*\}\s*;/g;
+// A `let` binding (any name, optionally typed) whose whole initializer is
+// `unsafe { &mut *<identifier> }`. Matched across newlines so a
+// rustfmt-wrapped binding can't evade it. `[^=;{}]*` after the binding name
+// permits a type ascription but cannot cross into a different statement; the
+// trailing `;` requires the unsafe block to be the entire initializer, so a
+// call-scoped `unsafe { &mut *p }.method()` expression does not count, and
+// the operand must be a bare identifier followed by `}`, so `&mut *p.as_ptr()`
+// and `&mut **p` do not count (see the header).
+const REBORROW = /let\s+(?:mut\s+)?\w+\s*(?::[^=;{}]*)?=\s*unsafe\s*\{\s*&mut\s+\*([A-Za-z_]\w*)\s*\}\s*;/g;
 
-// Documented, ratcheted exceptions: files allowed to keep exactly N of the
-// shape, with a stated reason. Empty by design — the whole tree is at zero.
-// Prefer converting over adding an entry here.
-const ALLOW: Record<string, number> = {};
+// Tier 1: the raw-pointer callback-parameter names used across the tree. If
+// you add a new raw callback-param name, add it here.
+const CALLBACK_PARAMS = new Set([
+  "this",
+  "ctx",
+  "p",
+  "ptr",
+  "self_ptr",
+  "this_ptr",
+  "raw",
+  "task",
+  "handle",
+  "data",
+  "context",
+  "user_data",
+  "parent",
+  "client",
+  "ws",
+  "req",
+  "resp",
+  "socket",
+]);
 
-const counts: Record<string, number> = {};
 const offenders: string[] = [];
+// Tier 2: file → sorted operand names (one entry per site, so a second
+// `&mut *vm_ptr` in a file that already has one still shows up).
+const found: Record<string, string[]> = {};
 let scanned = 0;
 for (const abs of rustSources) {
   const source = path.relative(root, abs).replaceAll(path.sep, "/");
@@ -81,18 +119,34 @@ for (const abs of rustSources) {
   // count. `[ \t]*`, not `\s*`: `\s` crosses newlines, so a comment preceded
   // by blank lines would swallow them and shift every reported line number.
   const stripped = content.replace(/^[ \t]*\/\/.*$/gm, "");
-  for (const m of stripped.matchAll(BANNED)) {
-    const line = stripped.slice(0, m.index).split("\n").length;
-    counts[source] = (counts[source] ?? 0) + 1;
-    if ((counts[source] ?? 0) > (ALLOW[source] ?? 0)) {
+  for (const m of stripped.matchAll(REBORROW)) {
+    const operand = m[1];
+    if (CALLBACK_PARAMS.has(operand)) {
+      const line = stripped.slice(0, m.index).split("\n").length;
       offenders.push(`${source}:${line}: ${m[0].replace(/\s+/g, " ")}`);
+    } else {
+      (found[source] ??= []).push(operand);
     }
   }
 }
 
+const normalized: Record<string, string[]> = Object.fromEntries(
+  Object.entries(found)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([source, names]) => [source, names.sort()]),
+);
+
+if (process.argv.includes("--update")) {
+  await Bun.write(INVENTORY, JSON.stringify(normalized, null, 2) + "\n");
+  console.log(`Wrote ${Object.keys(normalized).length} files to ${path.basename(INVENTORY)}`);
+  process.exit(0);
+}
+
+const inventory: Record<string, string[]> = await Bun.file(INVENTORY).json();
+
 test("scans a non-empty set of tracked Rust sources", () => {
   // Guards against the tracked/realpath filters above over-firing and leaving
-  // nothing to scan, which would make the ban below pass vacuously.
+  // nothing to scan, which would make the checks below pass vacuously.
   expect(scanned).toBeGreaterThan(0);
 });
 
@@ -100,10 +154,20 @@ test("fn-long `&mut *<callback param>` reborrow is banned", () => {
   expect(offenders).toEqual([]);
 });
 
-test("allowlisted files still carry exactly their documented count", () => {
-  // Ratchet: if an allowlisted file drops below its budget (the shape was
-  // finally converted), lower the ALLOW entry so no new one can slip back in.
-  for (const [f, n] of Object.entries(ALLOW)) {
-    expect(counts[f] ?? 0).toBe(n);
-  }
+describe("fn-long `&mut *<local>` reborrow inventory", () => {
+  const files = [...new Set([...Object.keys(inventory), ...Object.keys(normalized)])].sort();
+  test.each(files)("%s", source => {
+    const expected = inventory[source] ?? [];
+    const actual = normalized[source] ?? [];
+    if (!Bun.deepEquals(actual, expected)) {
+      throw new Error(
+        `${source}: fn-long \`let x = unsafe { &mut *<local> };\` sites changed.\n` +
+          `  inventoried: ${JSON.stringify(expected)}\n` +
+          `  in tree:     ${JSON.stringify(actual)}\n` +
+          `A new one must be rewritten as a shared reborrow, a statement-scoped raw access, or a call-scoped ` +
+          `argument (see the header of this file). After removing one, regenerate: ` +
+          `bun ./test/internal/source-lints/fn-long-mut-reborrow.test.ts --update`,
+      );
+    }
+  });
 });

--- a/test/internal/source-lints/static-mut-accessors.inventory.json
+++ b/test/internal/source-lints/static-mut-accessors.inventory.json
@@ -1,0 +1,122 @@
+{
+  "src/brotli_sys/brotli_c.rs": [
+    "create_instance"
+  ],
+  "src/bun_core/output.rs": [
+    "error_writer",
+    "error_writer_buffered",
+    "source_writer_escape",
+    "writer",
+    "writer_buffered"
+  ],
+  "src/bun_core/string/mod.rs": [
+    "create_uninitialized_latin1",
+    "create_uninitialized_utf16"
+  ],
+  "src/bundler/LinkerContext.rs": [
+    "pending_part_range_prologue"
+  ],
+  "src/bundler/ThreadPool.rs": [
+    "get",
+    "get_worker",
+    "get_worker_slow"
+  ],
+  "src/http/HTTPThread.rs": [
+    "abort_tracker",
+    "custom_ssl_context_map"
+  ],
+  "src/http/h3_client/AltSvc.rs": [
+    "cache"
+  ],
+  "src/http/lib.rs": [
+    "abort_tracker",
+    "http_thread",
+    "http_thread_mut",
+    "request_headers",
+    "response_headers",
+    "single_packet_small_buffer",
+    "temp_hostname"
+  ],
+  "src/install/PackageManager.rs": [
+    "init",
+    "init"
+  ],
+  "src/install/PackageManager/PackageManagerDirectories.rs": [
+    "cached_package_folder_name_buf"
+  ],
+  "src/install/repository.rs": [
+    "final_path_buf",
+    "folder_name_buf",
+    "json_path_buf",
+    "ssh_path_buf"
+  ],
+  "src/io/lib.rs": [
+    "file_polls_mut",
+    "inner",
+    "loop_mut",
+    "pipe_read_buffer_mut",
+    "platform_event_loop"
+  ],
+  "src/jsc/JSObject.rs": [
+    "create",
+    "create_from_struct_with_prototype",
+    "create_null_proto"
+  ],
+  "src/jsc/RuntimeTranspilerStore.rs": [
+    "tls_get_or_leak"
+  ],
+  "src/jsc/VirtualMachine.rs": [
+    "get_mut"
+  ],
+  "src/paths/resolve_path.rs": [
+    "lazy_path_buf",
+    "tl_buf_mut"
+  ],
+  "src/resolver/lib.rs": [
+    "instance",
+    "read_directory",
+    "read_directory_error",
+    "read_directory_with_iterator",
+    "temp_entries_option_write"
+  ],
+  "src/runtime/api/bun/subprocess.rs": [
+    "timer_all"
+  ],
+  "src/runtime/cli/mod.rs": [
+    "create_context_data",
+    "write_context_no_parse"
+  ],
+  "src/runtime/cli/test/Scanner.rs": [
+    "read_dir_with_name"
+  ],
+  "src/runtime/jsc_hooks.rs": [
+    "active_handles",
+    "timer_all_mut"
+  ],
+  "src/runtime/shell/subproc.rs": [
+    "cmd_mut"
+  ],
+  "src/runtime/test_runner/bun_test.rs": [
+    "get_active_test_root"
+  ],
+  "src/runtime/test_runner/jest.rs": [
+    "runner"
+  ],
+  "src/sql_jsc/mysql/JSMySQLConnection.rs": [
+    "event_loop",
+    "vm_mut"
+  ],
+  "src/sql_jsc/mysql/JSMySQLQuery.rs": [
+    "vm_mut"
+  ],
+  "src/sql_jsc/postgres/PostgresSQLConnection.rs": [
+    "event_loop",
+    "vm_mut"
+  ],
+  "src/sys/lib.rs": [
+    "mmap_file"
+  ],
+  "src/uws_sys/vtable.rs": [
+    "ext"
+  ]
+}

--- a/test/internal/source-lints/static-mut-accessors.test.ts
+++ b/test/internal/source-lints/static-mut-accessors.test.ts
@@ -50,13 +50,17 @@ const tracked: Set<string> | null = (() => {
 
 const STATIC_MUT = /&\s*'static\s+mut\b/;
 
-/** Skip a balanced `open`..`close` group starting at `source[i] === open`; returns the index after `close`, or -1. */
+/**
+ * Skip a balanced `open`..`close` group starting at `source[i] === open`;
+ * returns the index after `close`, or -1. The `>` of a `->` token inside a
+ * generic list (`<F: FnOnce() -> T>`) is not a closer.
+ */
 function skipBalanced(source: string, i: number, open: string, close: string): number {
   let depth = 0;
   for (; i < source.length; i++) {
     const c = source[i];
     if (c === open) depth++;
-    else if (c === close && --depth === 0) return i + 1;
+    else if (c === close && !(close === ">" && source[i - 1] === "-") && --depth === 0) return i + 1;
   }
   return -1;
 }
@@ -148,6 +152,7 @@ describe("staticMutFns", () => {
         fn buf<const N: usize>(b: &UnsafeCell<[u8; N]>) -> &'static mut [u8; N] { todo!() }
         fn pair(len: usize) -> (Self, &'static mut [u8]) { todo!() }
         fn after_array_semi() -> Result<[u8; 4], &'static mut Thing> { todo!() }
+        fn lazy_init<F: FnOnce() -> Box<Thing>>(init: F) -> &'static mut Thing { todo!() }
         pub(crate) fn take_worker<T: Send>(
             slot: &Slot<T>,
         ) -> &'static mut T
@@ -163,7 +168,17 @@ describe("staticMutFns", () => {
         fn callback(project: fn(&mut Source) -> &mut Writer) -> &'static str { "" }
         let not_a_fn: fn() -> &'static mut u8 = f;
       `),
-    ).toEqual(["after_array_semi", "buf", "ffi_thing", "http_thread", "pair", "runner", "take_worker", "vm_mut"]);
+    ).toEqual([
+      "after_array_semi",
+      "buf",
+      "ffi_thing",
+      "http_thread",
+      "lazy_init",
+      "pair",
+      "runner",
+      "take_worker",
+      "vm_mut",
+    ]);
   });
 });
 

--- a/test/internal/source-lints/static-mut-accessors.test.ts
+++ b/test/internal/source-lints/static-mut-accessors.test.ts
@@ -1,0 +1,180 @@
+// Inventory of the functions that hand out a `&'static mut` (bare, or inside
+// `Option`/`Result`/a tuple).
+//
+// Nearly all of them are accessors for a per-process or per-thread singleton:
+// `VirtualMachine::get_mut()`, `http_thread()`, `FileSystem::instance()`,
+// `Output::writer()`, the thread-local scratch buffers. Each call mints a new
+// exclusive borrow of the same object with nothing tying it to the previous
+// one, so two callers on the stack at once (a driver holding the VM across
+// `tick()` while a host function re-derives it; `http_thread()` re-minted
+// inside code the HTTP thread is already running with its own `&mut`) hold
+// overlapping `&mut`s to one allocation: aliasing UB, and the `noalias`
+// attribute rustc puts on `&mut` arguments lets LLVM act on it. The type
+// system cannot see this (the lifetime is `'static`, the borrow checker has
+// nothing to tie it to), and clippy's `mut_from_ref` only fires when the
+// function takes a reference, which these mostly do not, so nothing in the
+// build inventories them. This lint does: every such function is listed in
+// static-mut-accessors.inventory.json, a new one fails here, and removing one
+// means regenerating, so the list only shrinks.
+//
+// If this fails because you ADDED one: prefer returning `&'static T` over a
+// type whose mutable state is in `Cell`/`JsCell`/`UnsafeCell` (what
+// `VirtualMachine::get()` does), a raw `*mut` the caller reborrows per
+// statement (what `VirtualMachine::event_loop()` does), or a scoped
+// `with(|x: &mut T| ..)` accessor. If it has to stay, say in its doc comment
+// why callers cannot overlap, then regenerate:
+//   bun ./test/internal/source-lints/static-mut-accessors.test.ts --update
+// If it fails because you REMOVED one: regenerate the same way.
+//
+// Siblings: fn-long-mut-reborrow.test.ts pins the call-site half of the same
+// shape (a `&mut` formed from a raw pointer and held for a whole function).
+
+import { file } from "bun";
+import { describe, expect, test } from "bun:test";
+import { realpathSync } from "fs";
+import path from "path";
+import { globAllSources } from "../../../scripts/glob-sources.ts";
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+const INVENTORY = import.meta.dir + "/static-mut-accessors.inventory.json";
+
+const tracked: Set<string> | null = (() => {
+  const r = Bun.spawnSync({
+    cmd: ["git", "-C", root, "ls-tree", "-r", "--name-only", "-z", "HEAD"],
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  if (!r.success) return null;
+  return new Set(r.stdout.toString().split("\0").filter(Boolean));
+})();
+
+const STATIC_MUT = /&\s*'static\s+mut\b/;
+
+/** Skip a balanced `open`..`close` group starting at `source[i] === open`; returns the index after `close`, or -1. */
+function skipBalanced(source: string, i: number, open: string, close: string): number {
+  let depth = 0;
+  for (; i < source.length; i++) {
+    const c = source[i];
+    if (c === open) depth++;
+    else if (c === close && --depth === 0) return i + 1;
+  }
+  return -1;
+}
+
+/**
+ * Names of the `fn` items in `source` whose signature, after the parameter
+ * list (return type and `where` clause, up to the body's `{` or a declaration's
+ * `;`), mentions `&'static mut`, sorted. One entry per function, so a file with
+ * two same-named accessors in different impls lists the name twice.
+ */
+function staticMutFns(source: string): string[] {
+  const names: string[] = [];
+  // `fn name` (any qualifiers before it are irrelevant); `fn(` alone is a fn
+  // pointer type and has no name, so it is not matched.
+  for (const m of source.matchAll(/\bfn\s+([A-Za-z_]\w*)/g)) {
+    let i = m.index + m[0].length;
+    while (i < source.length && /\s/.test(source[i])) i++;
+    if (source[i] === "<") {
+      i = skipBalanced(source, i, "<", ">");
+      if (i < 0) continue;
+      while (i < source.length && /\s/.test(source[i])) i++;
+    }
+    if (source[i] !== "(") continue;
+    i = skipBalanced(source, i, "(", ")");
+    if (i < 0) continue;
+    // Return type (and `where` clause) run up to the body's `{`, or the `;`
+    // that ends a declaration; a `;` inside an array type (`[u8; N]`) or a
+    // tuple does not end the signature.
+    const start = i;
+    for (let depth = 0; i < source.length; i++) {
+      const c = source[i];
+      if (c === "(" || c === "[") depth++;
+      else if (c === ")" || c === "]") depth--;
+      else if (c === "{" || (c === ";" && depth === 0)) break;
+    }
+    if (STATIC_MUT.test(source.slice(start, i))) names.push(m[1]);
+  }
+  return names.sort();
+}
+
+const found: Record<string, string[]> = {};
+let scanned = 0;
+for (const abs of globAllSources().rust.filter(p => p.endsWith(".rs"))) {
+  const source = path.relative(root, abs).replaceAll(path.sep, "/");
+  // `src/cli` is a symlink into `src/runtime/cli`; count each file once under
+  // its canonical path.
+  if (path.relative(root, realpathSync(abs)).replaceAll(path.sep, "/") !== source) continue;
+  if (tracked !== null && !tracked.has(source)) continue;
+  scanned++;
+  // Comments (`//` lines, including doc comments, and `/* */` blocks) talk
+  // about these signatures; only code counts.
+  const stripped = (await file(abs).text()).replace(/^[ \t]*\/\/.*$/gm, "").replace(/\/\*[\s\S]*?\*\//g, "");
+  const names = staticMutFns(stripped);
+  if (names.length > 0) found[source] = names;
+}
+
+const normalized: Record<string, string[]> = Object.fromEntries(
+  Object.entries(found).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)),
+);
+
+if (process.argv.includes("--update")) {
+  await Bun.write(INVENTORY, JSON.stringify(normalized, null, 2) + "\n");
+  console.log(`Wrote ${Object.keys(normalized).length} files to ${path.basename(INVENTORY)}`);
+  process.exit(0);
+}
+
+const inventory: Record<string, string[]> = await Bun.file(INVENTORY).json();
+
+describe("staticMutFns", () => {
+  test("matches bare, wrapped, multi-line and declared returns, not parameters or prose", () => {
+    expect(
+      staticMutFns(`
+        pub fn http_thread() -> &'static mut HTTPThread { todo!() }
+        fn vm_mut(&self) -> &'static mut VirtualMachine { todo!() }
+        pub(crate) fn runner() -> Option<&'static mut TestRunner<'static>> { None }
+        fn buf<const N: usize>(b: &UnsafeCell<[u8; N]>) -> &'static mut [u8; N] { todo!() }
+        fn pair(len: usize) -> (Self, &'static mut [u8]) { todo!() }
+        fn after_array_semi() -> Result<[u8; 4], &'static mut Thing> { todo!() }
+        pub(crate) fn take_worker<T: Send>(
+            slot: &Slot<T>,
+        ) -> &'static mut T
+        where
+            T: Default,
+        { todo!() }
+        unsafe extern "C" { fn ffi_thing() -> &'static mut Thing; }
+        fn consumes(slice: &'static mut [u8]) -> StoreRef { todo!() }
+        fn plain(&self) -> &'static Loader { todo!() }
+        fn shared_mut(&self) -> &mut EventLoop { todo!() }
+        fn callback(project: fn(&mut Source) -> &mut Writer) -> &'static str { "" }
+        let not_a_fn: fn() -> &'static mut u8 = f;
+      `),
+    ).toEqual(["after_array_semi", "buf", "ffi_thing", "http_thread", "pair", "runner", "take_worker", "vm_mut"]);
+  });
+});
+
+describe("`-> &'static mut` accessor inventory", () => {
+  test("scans a non-empty set of tracked Rust sources", () => {
+    expect(scanned).toBeGreaterThan(0);
+    // The singleton accessors the header names are the reason this lint
+    // exists; if the scanner ever stops seeing them, it is the scanner that
+    // broke, not the tree that got fixed.
+    expect(normalized["src/bun_core/output.rs"]).toContain("writer");
+  });
+
+  const files = [...new Set([...Object.keys(inventory), ...Object.keys(normalized)])].sort();
+  test.each(files)("%s", source => {
+    const expected = inventory[source] ?? [];
+    const actual = normalized[source] ?? [];
+    if (!Bun.deepEquals(actual, expected)) {
+      throw new Error(
+        `${source}: functions returning \`&'static mut\` changed.\n` +
+          `  inventoried: ${JSON.stringify(expected)}\n` +
+          `  in tree:     ${JSON.stringify(actual)}\n` +
+          `A new one hands out overlapping exclusive borrows of a singleton; return \`&'static T\` with ` +
+          `interior mutability, a raw pointer, or a scoped accessor instead (see the header of this file). ` +
+          `If it must stay, or after removing one, regenerate: ` +
+          `bun ./test/internal/source-lints/static-mut-accessors.test.ts --update`,
+      );
+    }
+  });
+});

--- a/test/internal/source-lints/static-mut-accessors.test.ts
+++ b/test/internal/source-lints/static-mut-accessors.test.ts
@@ -61,11 +61,14 @@ function skipBalanced(source: string, i: number, open: string, close: string): n
   return -1;
 }
 
+const WHERE = /\bwhere\b/y;
+
 /**
- * Names of the `fn` items in `source` whose signature, after the parameter
- * list (return type and `where` clause, up to the body's `{` or a declaration's
- * `;`), mentions `&'static mut`, sorted. One entry per function, so a file with
- * two same-named accessors in different impls lists the name twice.
+ * Names of the `fn` items in `source` whose return type mentions
+ * `&'static mut`, sorted. Parameters and `where` bounds do not count: a
+ * function that takes or constrains such a reference is not what hands it out.
+ * One entry per function, so a file with two same-named accessors in different
+ * impls lists the name twice.
  */
 function staticMutFns(source: string): string[] {
   const names: string[] = [];
@@ -82,15 +85,25 @@ function staticMutFns(source: string): string[] {
     if (source[i] !== "(") continue;
     i = skipBalanced(source, i, "(", ")");
     if (i < 0) continue;
-    // Return type (and `where` clause) run up to the body's `{`, or the `;`
-    // that ends a declaration; a `;` inside an array type (`[u8; N]`) or a
-    // tuple does not end the signature.
-    const start = i;
+    while (i < source.length && /\s/.test(source[i])) i++;
+    if (!source.startsWith("->", i)) continue;
+    // The return type runs up to the body's `{`, the `;` ending a declaration,
+    // or a `where` clause. `(`/`[` nesting is tracked so the `;` of an array
+    // type (`[u8; N]`) inside it does not end it; `->` inside an `impl Fn`
+    // return type is just text here.
+    const start = i + 2;
     for (let depth = 0; i < source.length; i++) {
       const c = source[i];
       if (c === "(" || c === "[") depth++;
       else if (c === ")" || c === "]") depth--;
-      else if (c === "{" || (c === ";" && depth === 0)) break;
+      else if (c === "{") break;
+      else if (depth === 0) {
+        if (c === ";") break;
+        if (c === "w") {
+          WHERE.lastIndex = i;
+          if (WHERE.test(source)) break;
+        }
+      }
     }
     if (STATIC_MUT.test(source.slice(start, i))) names.push(m[1]);
   }
@@ -126,7 +139,7 @@ if (process.argv.includes("--update")) {
 const inventory: Record<string, string[]> = await Bun.file(INVENTORY).json();
 
 describe("staticMutFns", () => {
-  test("matches bare, wrapped, multi-line and declared returns, not parameters or prose", () => {
+  test("matches bare, wrapped, multi-line and declared returns, not parameters, where bounds or prose", () => {
     expect(
       staticMutFns(`
         pub fn http_thread() -> &'static mut HTTPThread { todo!() }
@@ -143,6 +156,8 @@ describe("staticMutFns", () => {
         { todo!() }
         unsafe extern "C" { fn ffi_thing() -> &'static mut Thing; }
         fn consumes(slice: &'static mut [u8]) -> StoreRef { todo!() }
+        fn bounded<F>(f: F) -> usize where F: FnOnce(&'static mut Thing) { 0 }
+        fn bounded_no_return<F>(f: F) where F: FnOnce() -> &'static mut Thing { f(); }
         fn plain(&self) -> &'static Loader { todo!() }
         fn shared_mut(&self) -> &mut EventLoop { todo!() }
         fn callback(project: fn(&mut Source) -> &mut Writer) -> &'static str { "" }


### PR DESCRIPTION
### Problem
- `Run::start` (src/runtime/cli/run_command.rs) held one `&mut VirtualMachine`, formed from the pointer `VirtualMachine::init` returned, across `load_entry_point`, every `tick()`, `on_before_exit` and `on_exit`, and kept using it afterwards.
- The JS those calls run reaches the same VM through other pointers: host functions via `VirtualMachine::get()` / `as_mut()` / `get_mut()`, and `process.exitCode = n` via `Bun__setExitCode(vm: &mut VirtualMachine)` (src/jsc/VirtualMachine.rs). An `exit` listener setting the exit code therefore wrote the field through a second `&mut` while `start` still held its own and read the exit code through it next. That is aliasing UB (Background); `as_mut`/`get_mut` document "keep the borrow short, do not hold it across reentrant JS calls", and `VirtualMachine::init` itself avoids forming the `&mut` around its FFI calls for this reason.
- The same shape drove `build_with_vm` in src/runtime/bake/production.rs (held across config evaluation and route rendering), `run_as_worker` in src/runtime/cli/test/parallel/runner.rs (held across every test file the worker runs; the comment above it names the raw pointer it aliases), `WebWorker::shutdown` (held across `on_exit`, then reads the exit code the listeners may have set), `VirtualMachine::init_bake` (`BakeCreateProdGlobal` re-enters through `Bun__getVM()` -> `Bun__VmHandle__retain(&VirtualMachine)` while the `&mut` is live), `Bun__setDefaultGlobalObject` (called back from inside the test runner's global swap, which holds its own `&mut`), `Bun__writeProfilesBeforeSelfKill`, and the two `Timer_*EventLoopDelayMonitoring` exports (a `&mut` minted only to feed a parameter nothing reads).
- Nothing reported any of it: `test/internal/source-lints/fn-long-mut-reborrow.test.ts` only matched `let x = unsafe { &mut *NAME };` for a fixed list of callback-parameter names, so `vm_ptr`, `vm`, `manager_ptr`, ... were invisible; and the functions that hand out `&'static mut` to a singleton (`VirtualMachine::get_mut`, `http_thread`, `FileSystem::instance`, `Output::writer`, ...: 62 functions in 29 files) are inventoried by nothing, since clippy's `mut_from_ref` needs a reference parameter to fire.

### Fix
- `boot` / `boot_standalone`: the post-init setup moves into `configure_vm` / `configure_standalone_vm`, which take `&mut VirtualMachine` for the one window where that is true (nothing has run yet) and are called with a call-scoped reborrow. `Run` then holds `&VirtualMachine` (from `VirtualMachine::get()`, asserted to be the VM `init` returned) and calls the `&mut self` methods through `as_mut()`, one borrow per call, which is how `WebWorker::spin` already drives a worker's VM. The hot reloader gets the thread-local `*mut` instead of a pointer cast from the reference; the cold exit helpers take `&VirtualMachine`.
- `build_with_vm` and `run_as_worker` (plus `worker_flush_aggregates` / `render_lcov`, which only read the VM): the same shared-reference shape. `WebWorker::shutdown`, `init_bake`, `Bun__setDefaultGlobalObject`, `start_vm`: statement-scoped accesses through the raw pointer, the style `VirtualMachine::init` uses. `Bun__writeProfilesBeforeSelfKill`: shared reference, `as_mut()` per `take()`. `EventLoopDelayMonitor::enable/disable` lose the parameter they never read.
- Why this is correct: every converted site performs the same reads, writes and calls in the same order; the only thing removed is a borrow spanning the call that re-enters the VM. Each access now starts from the same thread-local / raw pointer the re-entering code starts from, so no exclusive borrow is live while another access happens. The struct-wide move of JS-mutated plain fields to `JsCell`, which `VirtualMachine` documents as its direction, is separate and not claimed here.
- `fn-long-mut-reborrow.test.ts` now matches the shape for any identifier operand. The callback-parameter names stay banned outright; the other 160 sites (81 files) are pinned by operand name in `fn-long-mut-reborrow.inventory.json`, exact per file, `--update` to regenerate, so a new one fails and the list only shrinks. On main's `src/` it fails for run_command.rs, production.rs, web_worker.rs, VirtualMachine.rs, runner.rs and EventLoopDelayMonitor.rs; with this diff it passes.
- New `static-mut-accessors.test.ts` + `static-mut-accessors.inventory.json`: every `fn` whose return type contains `&'static mut` (bare or inside `Option`/`Result`/a tuple, multi-line signatures included; the scanner has a fixture self-test), 62 in 29 files, exact per file. Seeded from main; this PR removes none, so its proof is leave-one-out: deleting the VirtualMachine.rs entry fails with `inventoried: []` / `in tree: ["get_mut"]`.
- There is no runtime test for this: the aliasing has no symptom current compilers produce. The reborrow lint is the fail-before / pass-after test for the conversions.
- Verified: `bun test test/internal/source-lints/` (263 pass); `bun bd test test/cli/run/` (1111 pass; the 11 failures are environmental, see details); targeted runs of heap-prof (self-kill profile write), perf_hooks (`monitorEventLoopDelay`), test isolation, `--parallel`, bake production (9/9 once the 5s default timeout is raised, the ASAN build here needs 6-11s per test), dev-and-prod, hot, watch, worker_threads, web workers and the process tests; by hand, a worker whose `exit` listener sets `process.exitCode = 7` reports 7, a main-thread listener setting 5 exits 5, and a rejected entry plus a listener setting 9 exits 9 (same as node).

Left as they are (inventoried), for separate PRs:
- `TestCommand::exec` (test_command.rs) holds `&mut VirtualMachine` for the whole `bun test` run and threads it through `run_all_tests` / `TestCommand::run` / `Context`; `run_as_coordinator` (runner.rs:57) feeds the same signatures. Its own operand is a call expression, so it is outside even the generalized lint.
- `init_with_module_graph` / `init_worker` (post-init patching, no FFI), `build_command` in production.rs (two sites; #38241 rewrites that exit path and keeps the count at two, so the lint passes in either merge order), run_command's `mini` x2 (`MiniEventLoop`) and `promise` (opaque ZST handle), and the `host_fn` macro's `&mut self` template, which is the documented design there.
- The `&mut self` receivers of `tick` / `on_exit` / ..., `Bun__setExitCode` taking `&mut` from C++, and `VirtualMachine::get_mut` plus the sql `vm_mut` shims.
- The http entries of the accessor inventory are being removed by #37706 / #37694 and the four `repository.rs` buffers by #37616; whichever side lands second reruns `--update`.

### Background
- Re-entrancy: `tick()` runs JS; JS calls host functions; host functions get the VM from a thread-local raw pointer (`VirtualMachine::get()`) or are handed `&mut VirtualMachine` by C++ (`Bun__setExitCode`). Any borrow a driver loop holds across `tick()` therefore coexists with the borrows made inside it.
- Aliasing rule: a `&mut T` asserts that nothing else touches `T` until the reference's last use. Accessing the memory some other way and then using the `&mut` again is UB under both Stacked Borrows and Tree Borrows (what Miri checks), and rustc marks `&mut` parameters `noalias`, which lets LLVM keep values read through them across calls. A `&T` is fine for state behind interior mutability (`JsCell`), and a `&mut` formed for a single call is no longer in use by the time the callee runs JS.
- `VirtualMachine::as_mut()` returns a `&mut` rebuilt from the thread-local pointer (not cast from `&self`) and is documented for exactly this one-call use; `VirtualMachine::get_mut_ptr()` is the same pointer, for callees that store one.
- Source lints: `test/internal/source-lints/` holds grep-style tests over `src/**` that GitHub Actions runs on every PR without a build. Several (`vm-thread-door`, `dead-code-escapes`) pin the current population of a shape in a JSON inventory that a change must regenerate, so the population can only shrink; both lints here follow that pattern.

<details>
<summary>Local failures in <code>bun bd test test/cli/run/</code>, all environmental</summary>

- `run-file-on-fuse` / `glob-on-fuse`: `fuse: device not found` in the container.
- `no-orphans` uid/gid case: fails identically with the released binary (`USE_SYSTEM_BUN=1`); the grandchild cannot be spawned with credentials here.
- `self-reference`: the unresolvable `require("pkg")` step takes ~18s per spawn on this ASAN build (3.4s total on the release binary against a 5s budget); resolvable runs take 0.4s.
- `require-cache` leak tests: 20-60s timeouts; the children finish later and print RSS deltas of 7-149 MB, under the 320-400 MB ASAN thresholds.
- `parallel.test.ts` "lazily scales" / "work-stealing": a trivial test file takes 346ms on this build (7ms on release) against the tests' 250ms scale-up budget; both pass on the release binary.
- `process.test.js` "process": expects `$USER`, unset in the container. `worker.test.ts` "message flood": a worker takes seconds to boot on this build, the test waits 30ms. Every test that timed out at the default 5s (bake production, worker terminate races, `process.on` inside `--compile`, the onBeforeExit worker case) passes with `--timeout 120000`.
</details>
