### PR TITLE
Bump WebKit (oven-sh/WebKit#441 preview): Intl.Segmenter no longer crashes in ubrk_clone when ICU cannot allocate

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "f0f60fd2324817dae9656d8bf2fcae25ceaccc37";
+export const WEBKIT_VERSION = "autobuild-preview-pr-441-3998109f";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.


### PR DESCRIPTION
### Problem
- Windows crash reports from 1.4.0 (and #32133 from 1.3.14, closed at the time as an unreproducible out-of-memory artifact) die inside `Intl.Segmenter.prototype.segment()` with `Segmentation fault at address 0x10`, top frame first: `icu::RuleBasedBreakIterator::BreakCache::reset` with `this == nullptr` <- `RuleBasedBreakIterator::operator=` <- `RuleBasedBreakIterator::clone` <- `ubrk_clone` <- `JSC::IntlSegmenter::segment` (`IntlSegmenter.cpp:130`).
- `segment()` and `Segments[Symbol.iterator]()` clone the segmenter's ICU break iterator per call. ICU's copy constructor (`rbbi.cpp:235`) delegates to a constructor that allocates two caches and two 32 byte buffers; if any of those four allocations fails it records the error and leaves the pointers null, and the copy constructor then runs `operator=`, which ends in `fBreakCache->reset()` (`rbbi.cpp:334`). `operator=` also ignores a failed `fLookAheadMatches` allocation, which crashes on the first `ubrk_next` instead. Only a failure of the iterator object itself is reported. The bug is the same in ICU 73.2 (what 1.3.x shipped on Windows), 78.3 (what every platform ships now) and ICU main.
- On Windows ICU allocates with the static CRT's `malloc`, which returns null once the process cannot commit more memory (Windows does not overcommit), so a Segmenter-heavy program that runs out of memory dies with this signature instead of an error. JSC already checks the status after the clone (`IntlSegmenter.cpp:131`, `IntlSegments.cpp:96`); the crash happens before there is a status to check, so Bun and JSC have nothing to fix themselves.

### Fix
- oven-sh/WebKit#441 adds `icu/rbbi-clone-allocation-failure.patch` to the bundled ICU and applies it in every ICU build (glibc, musl, windows cross, freebsd, android Dockerfiles and the native `build-icu.ps1`): `operator=` leaves an iterator whose construction failed alone and records a failed look-ahead buffer, and `clone()` reports such a copy as a failed clone, which `ubrk_clone` already maps to `U_MEMORY_ALLOCATION_ERROR`. `segment()` then throws JSC's existing `TypeError: failed to initialize Segments` (`SegmentIterator` for the iterator path) instead of crashing. Successful clones run the same code plus two null checks.
- Correct because `fErrorCode` is ICU's own record of a failed setup (the constructor already writes it; nothing read it) and `clone()` is the last point where that can still be reported to the caller; every other `RuleBasedBreakIterator` constructor already reports these allocations through its status parameter, the copy path was the one that swallowed them.
- This PR pins `WEBKIT_VERSION` at that PR's preview build (`autobuild-preview-pr-441-3998109f`) so CI runs Bun against the patched prebuilts. Before landing, oven-sh/WebKit#441 has to merge and `WEBKIT_VERSION` has to be repointed at the resulting main sha (the build prints that instruction once the preview release disappears). The preview is built on current fork main, so relative to the `f0f60fd2` pin it also carries oven-sh/WebKit#420 (#38040), #437 and #440 (#38660) and #421 (#38091), which have their own Bun PRs; nothing here depends on them and whichever bump lands first carries them.
- No Bun test: the failure only exists when a 32 to 832 byte `malloc` inside ICU returns null, and nothing in Bun can make that happen on demand (a JS-level test would pass before and after). The regression test therefore lives where the allocator can be hooked: `icu/rbbi-clone-allocation-failure-check.cpp` in the WebKit PR installs `u_setMemoryFunctions`, fails each allocation `ubrk_clone` makes in turn for all three granularities, and runs as part of the ICU build; against the unpatched library it segfaults on the first injected failure (13 of the 16 cases, including the `libicuuc.a` from the current `f0f60fd2` prebuilt), against the patched one every case returns `U_MEMORY_ALLOCATION_ERROR`. Details and per-allocation output are in the WebKit PR.
- Verified here: a debug+ASAN build with this pin reports `process.versions.webkit === "preview-pr-441-3998109f"`; `test/js/web/intl/intl.test.ts` (the Segmenter snapshots across 12 locales among them) passes 33/33 with 6249 assertions; `test/js/bun/ffi`, `test/js/bun/jsc-stress/jsc-stress.test.ts` and `test/js/bun/util/fuzzy-wuzzy.test.ts` (a Segmenter user) pass 447 tests, the only three failures being `ffi.test.js` "integer identities" cases that take 4 to 6 seconds in this ASAN build and pass with `--timeout 120000`.

Fixes #32133

### Background
- Bun links a prebuilt JavaScriptCore from oven-sh/WebKit, and those prebuilts bundle their own ICU built from the upstream source tarball; `scripts/build/deps/webkit.ts` pins which build. An engine or ICU fix lands as a WebKit PR plus a pin bump here, and `autobuild-preview-pr-*` tags let a bump PR run Bun's suite against the WebKit PR before it merges (`scripts/build/download.ts` explains the repointing step).
- `ubrk_clone` is ICU's C entry point for copying a break iterator; `RuleBasedBreakIterator` is the C++ object behind it. ICU never throws: allocating operations either set `U_MEMORY_ALLOCATION_ERROR` in a status out-parameter or return null, which is why JSC can turn an ICU failure into a JS exception when ICU reports it.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · build/CI scripts only; test-proof not applicable

<!-- robobun:evidence:end -->