### PR TITLE
runner: anchor failure annotation links at the first error in the test file

### DIFF
--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -47,6 +47,7 @@ import {
   getDistro,
   getDistroVersion,
   getEnv,
+  getErrorLineInFile,
   getFileUrl,
   getHostname,
   getLoggedInUserCountOrDetails,
@@ -1925,6 +1926,7 @@ async function spawnBun(execPath, { args, cwd, timeout, gracefulTimeout, idleTim
  * @property {boolean} ok
  * @property {string} status
  * @property {string} [error]
+ * @property {TestError[]} errors every error the file reported, in output order
  * @property {TestEntry[]} tests
  * @property {string} stdout
  * @property {string} stdoutPreview
@@ -1936,7 +1938,7 @@ async function spawnBun(execPath, { args, cwd, timeout, gracefulTimeout, idleTim
  * @property {string} file
  * @property {string} test
  * @property {string} status
- * @property {TestError} [error]
+ * @property {TestError[]} [errors] the errors reported before this test's result line
  * @property {number} [duration]
  */
 
@@ -1944,8 +1946,8 @@ async function spawnBun(execPath, { args, cwd, timeout, gracefulTimeout, idleTim
  * @typedef {object} TestError
  * @property {string} [url]
  * @property {string} file
- * @property {number} line
- * @property {number} col
+ * @property {string} [line] as printed in the `::error` annotation; absent when the error had no location
+ * @property {string} [col]
  * @property {string} name
  * @property {string} stack
  */
@@ -2079,7 +2081,7 @@ function pipeTestStdout(io, chunk) {
 /**
  * @typedef {object} TestOutput
  * @property {string} stdout
- * @property {TestResult[]} tests
+ * @property {TestEntry[]} tests
  * @property {TestError[]} errors
  */
 
@@ -2809,25 +2811,13 @@ function formatTestToMarkdown(result, concise, retries) {
   const platform = buildUrl ? `<a href="${buildUrl}">${buildLabel}</a>` : buildLabel;
 
   let markdown = "";
-  for (const { testPath, ok, tests, error, stdoutPreview: stdout } of results) {
+  for (const { testPath, ok, errors, error, stdoutPreview: stdout } of results) {
     if (ok || error === "SIGTERM") {
       continue;
     }
 
-    let errorLine;
-    for (const { error } of tests) {
-      if (!error) {
-        continue;
-      }
-      const { file, line } = error;
-      if (line) {
-        errorLine = line;
-        break;
-      }
-    }
-
     const testTitle = testPath.replace(/\\/g, "/");
-    const testUrl = getFileUrl(testPath, errorLine);
+    const testUrl = getFileUrl(testPath, getErrorLineInFile(testPath, errors));
 
     if (concise) {
       markdown += "<li>";

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -1327,6 +1327,31 @@ export function getFileUrl(filename, line) {
 }
 
 /**
+ * Picks the line to anchor a failed test file's link at: the line of the first
+ * error that `bun test` reported from inside that file. Errors raised in another
+ * file (a helper, node_modules) carry that file's line, which means nothing in
+ * the test file, and errors without a location carry no line at all; both are
+ * skipped. Vendor suites report files relative to the vendored repository while
+ * the runner titles them `vendor/<name>/<file>`, hence the trailing-path match.
+ *
+ * @param {string} testPath
+ * @param {{ file?: string, line?: string | number }[]} [errors] in the order they were reported
+ * @returns {string | number | undefined}
+ */
+export function getErrorLineInFile(testPath, errors = []) {
+  const target = testPath.replace(/\\/g, "/");
+  for (const { file, line } of errors) {
+    if (!file || !line) {
+      continue;
+    }
+    const path = file.replace(/\\/g, "/");
+    if (path === target || target.endsWith(`/${path}`)) {
+      return line;
+    }
+  }
+}
+
+/**
  * @typedef {object} BuildkiteBuild
  * @property {string} id
  * @property {string} commit_id

--- a/test/internal/source-lints/runner-failure-link.test.ts
+++ b/test/internal/source-lints/runner-failure-link.test.ts
@@ -1,0 +1,70 @@
+/**
+ * formatTestToMarkdown() (scripts/runner.node.mjs) links every failed file in
+ * the Buildkite and GitHub failure annotations as getFileUrl(testPath, line),
+ * with the line coming from getErrorLineInFile() (scripts/utils.mjs). Its input
+ * is TestResult.errors: every `::error file=...,line=...` annotation that
+ * parseTestStdout() collected from the file's output, in the order bun test
+ * printed them (a file that throws while loading prints one without any test
+ * result line following it). `file` and `line` are the annotation's strings,
+ * with `file` relative to the directory bun test ran in.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { getErrorLineInFile } from "../../../scripts/utils.mjs";
+
+const testPath = "test/js/bun/foo.test.ts";
+
+// Shaped like parseTestStdout()'s TestError, minus the fields that play no part here.
+function error(file: string, line?: string) {
+  return { file, line, name: "error: boom", stack: "error: boom\n      at <anonymous>" };
+}
+
+describe("getErrorLineInFile", () => {
+  test("anchors at the first error raised in the test file", () => {
+    expect(getErrorLineInFile(testPath, [error(testPath, "7"), error(testPath, "10")])).toBe("7");
+  });
+
+  test("an error raised in another file carries that file's line, so it is skipped", () => {
+    // A test calling into a helper that throws: the first annotation points at the helper.
+    expect(getErrorLineInFile(testPath, [error("test/js/bun/helper.ts", "2"), error(testPath, "7")])).toBe("7");
+    expect(getErrorLineInFile(testPath, [error("test/js/bun/helper.ts", "2")])).toBeUndefined();
+    expect(getErrorLineInFile(testPath, [error("node_modules/assert/index.js", "40")])).toBeUndefined();
+  });
+
+  test("an error without a location is skipped", () => {
+    // parseTestStdout() falls back to the test file for a `::error title=...` annotation
+    // that has no file= and no line=.
+    expect(getErrorLineInFile(testPath, [error(testPath), error(testPath, "10")])).toBe("10");
+    expect(getErrorLineInFile(testPath, [error(testPath)])).toBeUndefined();
+  });
+
+  test("nothing to anchor at leaves the link unanchored", () => {
+    expect(getErrorLineInFile(testPath, [])).toBeUndefined();
+    // spawnBunInstall() and the node test runner report no annotations at all.
+    expect(getErrorLineInFile(testPath)).toBeUndefined();
+  });
+
+  test("compares paths regardless of separator", () => {
+    const windowsPath = "test\\js\\bun\\foo.test.ts";
+    expect(getErrorLineInFile(windowsPath, [error(windowsPath, "7")])).toBe("7");
+    expect(getErrorLineInFile(windowsPath, [error(testPath, "7")])).toBe("7");
+    expect(getErrorLineInFile(testPath, [error(windowsPath, "7")])).toBe("7");
+    expect(getErrorLineInFile(windowsPath, [error("test\\js\\bun\\helper.ts", "2")])).toBeUndefined();
+  });
+
+  test("vendor suites: annotations are relative to the vendored repository, the title is not", () => {
+    // runTest() reports a vendor failure under `vendor/<name>/<path>` while bun test
+    // ran inside vendor/<name>, so its annotations name `<path>`.
+    const title = "vendor/elysia/test/core/handle.test.ts";
+    expect(getErrorLineInFile(title, [error("test/core/handle.test.ts", "12")])).toBe("12");
+    expect(getErrorLineInFile(title, [error("test/utils.ts", "5"), error("test/core/handle.test.ts", "12")])).toBe(
+      "12",
+    );
+    expect(getErrorLineInFile(title, [error("test/utils.ts", "5")])).toBeUndefined();
+  });
+
+  test("a trailing match has to start at a path segment", () => {
+    expect(getErrorLineInFile(testPath, [error("o.test.ts", "7")])).toBeUndefined();
+    expect(getErrorLineInFile("test/js/bun/not-foo.test.ts", [error("foo.test.ts", "7")])).toBeUndefined();
+  });
+});


### PR DESCRIPTION
### Problem

- Every failed test file in the Buildkite and GitHub failure annotations links to the file with no `#L<line>` anchor, even though `bun test` reports the failing line in its `::error file=...,line=...` annotations.
- `formatTestToMarkdown()` (`scripts/runner.node.mjs`) looks for the line in `test.error` of each `TestEntry`. Nothing sets that field: `parseTestStdout()` stores the annotations as `errors` (an array) on each entry and on the `TestResult`, so the loop never finds a line. This has been the case since the runner was added (#11477); the `TestEntry` typedef still documented the singular `error`.

### Fix

- `getErrorLineInFile(testPath, errors)` in `scripts/utils.mjs` returns the line of the first reported error whose `file` is the test file; `formatTestToMarkdown()` passes it `TestResult.errors` and hands the result to `getFileUrl()`, which already appends `#L<line>`.
- Only errors raised in the test file itself are used: an error thrown in a helper is reported with the helper's file and line, and anchoring the test file at that line would point at an unrelated line. When every error came from elsewhere the link stays unanchored, which is what it is today.
- `TestResult.errors` is read rather than the per-test lists because it also holds errors that no test result line follows, such as a file that throws while loading. It is the same array of objects, in output order.
- The match tolerates `\` paths (Windows) and, for vendor suites, a `file` that is a trailing path of the title: the runner reports those under `vendor/<name>/<path>` while `bun test` ran inside `vendor/<name>` and reports `<path>`.
- The `TestResult`, `TestEntry`, `TestError` and `TestOutput` typedefs now describe what `parseTestStdout()` produces (`errors` arrays; `line`/`col` are the annotation's strings and absent when the error has no location). `generateJUnitReport()` already read `errors`.
- Verified with `test/internal/source-lints/runner-failure-link.test.ts` (the runner script runs on import, so the logic lives in `utils.mjs` like the other tests in that directory). It fails with `scripts/` at main (the helper does not exist) and passes with this change, under both `bun bd test` and the released bun the source-lints workflow uses.
- Also ran the runner itself against a fixture whose first failure is thrown from a helper file and second is an inline `expect` on line 7; output below.
- The Buildkite annotations this branch produced for its own unrelated failures show the same thing: `test/bake/deinitialization.test.ts#L12` and `test/napi/napi.test.ts#L1508` (the failing `expect` lines), and no anchor for `test/js/node/test/parallel/test-http-chunk-problem.js`, which does not run under `bun test` and so has no annotations to read.

<details>
<summary>Runner output before and after (GITHUB_ACTIONS=true, fixture removed afterwards)</summary>

Fixture `test/zz-e2e-errorline/anchor.test.ts` (test 1 calls a helper in `boom.ts` that throws on its line 2, test 2 is `expect(1).toBe(2)` on line 7). `comment.md` written by the runner:

`scripts/` at main:

```
<li><a href="https://github.com/oven-sh/bun/blob/0000000/test/zz-e2e-errorline/anchor.test.ts"><code>test/zz-e2e-errorline/anchor.test.ts</code></a> - code 1: error: from helper on <a href="https://github.com/oven-sh/bun/actions/runs/1">e2e</a></li>
```

with this change (the helper's line 2 is skipped, line 7 is the first error in the file):

```
<li><a href="https://github.com/oven-sh/bun/blob/0000000/test/zz-e2e-errorline/anchor.test.ts#L7"><code>test/zz-e2e-errorline/anchor.test.ts</code></a> - code 1: error: from helper on <a href="https://github.com/oven-sh/bun/actions/runs/1">e2e</a></li>
```

The `failing_tests` output written to `GITHUB_OUTPUT` carries the same link. The annotations the fixture produced, as `parseTestStdout()` saw them:

```
::error file=test/zz-e2e-errorline/boom.ts,line=2,col=32,title=error: from helper::...
::error file=test/zz-e2e-errorline/anchor.test.ts,line=7,col=13,title=error: expect(received).toBe(expected)::...
```

</details>

### Background

- `scripts/runner.node.mjs` is the script CI uses to run the test suite: it spawns one `bun test` per file with `GITHUB_ACTIONS=true` so that `bun test` prints a `::error file=<path>,line=<n>,col=<n>,title=<title>::<body>` annotation for each error (`print_github_annotation` in `src/jsc/VirtualMachine.rs`). `file` is relative to the directory `bun test` ran in, and an error with no stack location is printed as `::error title=...` with no file or line.
- `parseTestStdout()` turns that output into a `TestResult`: `errors` is every annotation in order, `tests` is one `TestEntry` per result line (`✓`/`✗`), each carrying the annotations printed before it as `errors`.
- `formatTestToMarkdown()` renders a failed `TestResult` into the HTML that goes into the Buildkite annotation for the step and, on GitHub Actions, into the step summary and PR comment. The link it renders is `getFileUrl(path, line)`, a `blob/<commit>/<path>` URL on the repository with `#L<line>` appended when a line is given.
- Vendor suites (`test/vendor.json`) are cloned into `vendor/<name>` and run with that directory as the working directory, so their annotations are relative to it; the runner reports their failures under the repo-relative title `vendor/<name>/<path>`, and `getFileUrl()` resolves such titles to the vendored repository.
