### PR TITLE
crash_handler: wait for a full non-blocking stderr instead of dropping the report

### DIFF
--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -399,12 +399,16 @@ pub use bun_io::{FmtAdapter, Write};
 /// `bun_sys::stderr_writer()` (not yet exposed by T1).
 /// Only impls `bun_io::Write` — `write!` resolves to `bun_io::Write::write_fmt`
 /// (alloc-free stack `Bridge`, async-signal-safe).
+///
+/// Never returns `Err`: callers `abort()` on error, which would also skip the
+/// report upload and the re-raise of the original signal, so a closed stderr
+/// or a vanished reader silently drops the bytes. A full stderr is waited for.
 pub(crate) struct StderrWriter;
 pub(crate) fn stderr_writer() -> StderrWriter {
     StderrWriter
 }
 impl Write for StderrWriter {
-    fn write_all(&mut self, bytes: &[u8]) -> bun_io::Result<()> {
+    fn write_all(&mut self, mut bytes: &[u8]) -> bun_io::Result<()> {
         #[cfg(windows)]
         {
             // On Windows this is `GetStdHandle(STD_ERROR_HANDLE)` + kernel32
@@ -413,39 +417,57 @@ impl Write for StderrWriter {
             // per-fd lock, which can self-deadlock when the VEH crash handler
             // fires on a thread that faulted *inside* CRT stdio. WriteFile is
             // lock-free at the kernel32 layer.
-            // `WriteFile` is declared locally because `bun_windows_sys::
-            // kernel32` does not (yet) export it (cf. src/sys/lib.rs).
-            #[link(name = "kernel32")]
-            unsafe extern "system" {
-                fn WriteFile(
-                    hFile: bun_sys::windows::HANDLE,
-                    lpBuffer: *const u8,
-                    nNumberOfBytesToWrite: u32,
-                    lpNumberOfBytesWritten: *mut u32,
-                    lpOverlapped: *mut core::ffi::c_void,
-                ) -> i32;
-            }
             let h = bun_sys::windows::kernel32::GetStdHandle(bun_sys::windows::STD_ERROR_HANDLE);
-            let mut written: u32 = 0;
-            // SAFETY: `h` is the cached stderr HANDLE (or INVALID_HANDLE_VALUE,
-            // in which case WriteFile fails harmlessly); `bytes` is valid for
-            // reads of `len`; `written` is a valid out-pointer; lpOverlapped
-            // is null for synchronous I/O.
-            unsafe {
-                WriteFile(
-                    h,
-                    bytes.as_ptr(),
-                    bytes.len() as u32,
-                    &mut written,
-                    core::ptr::null_mut(),
-                );
+            while !bytes.is_empty() {
+                let mut written: u32 = 0;
+                // SAFETY: `h` is the cached stderr HANDLE (or INVALID_HANDLE_VALUE,
+                // in which case WriteFile fails harmlessly); `bytes` is valid for
+                // reads of `len`; `written` is a valid out-pointer; lpOverlapped
+                // is null for synchronous I/O.
+                let ok = unsafe {
+                    bun_sys::windows::kernel32::WriteFile(
+                        h,
+                        bytes.as_ptr(),
+                        u32::try_from(bytes.len()).unwrap_or(u32::MAX),
+                        &mut written,
+                        core::ptr::null_mut(),
+                    )
+                };
+                if ok == 0 || written == 0 {
+                    break;
+                }
+                bytes = &bytes[written as usize..];
             }
         }
         #[cfg(not(windows))]
         {
-            // SAFETY: fd 2 is always open; libc::write is async-signal-safe.
-            unsafe {
-                libc::write(2, bytes.as_ptr().cast(), bytes.len() as _);
+            // Everything here is async-signal-safe: write(2) and poll(2), and
+            // `bun_sys::Error` carries no allocation.
+            let stderr = bun_sys::Fd::stderr();
+            while !bytes.is_empty() {
+                match bun_sys::write(stderr, bytes) {
+                    Ok(0) => break,
+                    Ok(n) => bytes = &bytes[n..],
+                    Err(err) => match err.get_errno() {
+                        bun_sys::E::EINTR => {}
+                        // fd 2 is O_NONBLOCK once `process.stderr` has touched a
+                        // pipe (the flag is on the open file description, so it is
+                        // inherited too). A full pipe only means the reader is
+                        // behind: wait for it, as a blocking stderr would, instead
+                        // of dropping the rest of the report.
+                        bun_sys::E::EAGAIN => {
+                            let mut pfd = [bun_sys::posix::PollFd {
+                                fd: stderr.native(),
+                                events: bun_sys::posix::POLL_OUT,
+                                revents: 0,
+                            }];
+                            if bun_sys::posix::poll(&mut pfd, -1).is_err() {
+                                break;
+                            }
+                        }
+                        _ => break,
+                    },
+                }
             }
         }
         Ok(())

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -403,71 +403,57 @@ pub use bun_io::{FmtAdapter, Write};
 /// Never returns `Err`: callers `abort()` on error, which would also skip the
 /// report upload and the re-raise of the original signal, so a closed stderr
 /// or a vanished reader silently drops the bytes. A full stderr is waited for.
+///
+/// Everything below is async-signal-safe: `bun_sys::write` is a bare
+/// `write(2)` (a bare kernel32 `WriteFile` on Windows, which matters there
+/// too: the CRT's `_write` takes a per-fd lock that the VEH handler would
+/// self-deadlock on when the faulting thread was inside CRT stdio),
+/// `bun_sys::posix::poll` is a bare `poll(2)`, and `bun_sys::Error` does not
+/// allocate.
 pub(crate) struct StderrWriter;
 pub(crate) fn stderr_writer() -> StderrWriter {
     StderrWriter
 }
 impl Write for StderrWriter {
     fn write_all(&mut self, mut bytes: &[u8]) -> bun_io::Result<()> {
-        #[cfg(windows)]
-        {
-            // On Windows this is `GetStdHandle(STD_ERROR_HANDLE)` + kernel32
-            // `WriteFile`, NOT the CRT. Routing through MSVCRT `_write(2,…)`
-            // would (1) text-mode-translate `\n`→`\r\n` and (2) take the CRT
-            // per-fd lock, which can self-deadlock when the VEH crash handler
-            // fires on a thread that faulted *inside* CRT stdio. WriteFile is
-            // lock-free at the kernel32 layer.
-            let h = bun_sys::windows::kernel32::GetStdHandle(bun_sys::windows::STD_ERROR_HANDLE);
-            while !bytes.is_empty() {
-                let mut written: u32 = 0;
-                // SAFETY: `h` is the cached stderr HANDLE (or INVALID_HANDLE_VALUE,
-                // in which case WriteFile fails harmlessly); `bytes` is valid for
-                // reads of `len`; `written` is a valid out-pointer; lpOverlapped
-                // is null for synchronous I/O.
-                let ok = unsafe {
-                    bun_sys::windows::kernel32::WriteFile(
-                        h,
-                        bytes.as_ptr(),
-                        u32::try_from(bytes.len()).unwrap_or(u32::MAX),
-                        &mut written,
-                        core::ptr::null_mut(),
-                    )
-                };
-                if ok == 0 || written == 0 {
-                    break;
-                }
-                bytes = &bytes[written as usize..];
-            }
-        }
         #[cfg(not(windows))]
-        {
-            // Everything here is async-signal-safe: write(2) and poll(2), and
-            // `bun_sys::Error` carries no allocation.
-            let stderr = bun_sys::Fd::stderr();
-            while !bytes.is_empty() {
-                match bun_sys::write(stderr, bytes) {
-                    Ok(0) => break,
-                    Ok(n) => bytes = &bytes[n..],
-                    Err(err) => match err.get_errno() {
-                        bun_sys::E::EINTR => {}
-                        // fd 2 is O_NONBLOCK once `process.stderr` has touched a
-                        // pipe (the flag is on the open file description, so it is
-                        // inherited too). A full pipe only means the reader is
-                        // behind: wait for it, as a blocking stderr would, instead
-                        // of dropping the rest of the report.
-                        bun_sys::E::EAGAIN => {
-                            let mut pfd = [bun_sys::posix::PollFd {
-                                fd: stderr.native(),
-                                events: bun_sys::posix::POLL_OUT,
-                                revents: 0,
-                            }];
-                            if bun_sys::posix::poll(&mut pfd, -1).is_err() {
-                                break;
-                            }
+        let stderr = bun_sys::Fd::stderr();
+        // Looked up live rather than through `Fd::stderr()`: the cache behind
+        // that is filled by `Output`'s stdio init, which runs after the crash
+        // handler is installed, and crashes in between still have to print.
+        #[cfg(windows)]
+        let Some(stderr) = bun_sys::windows::GetStdHandle(bun_sys::windows::STD_ERROR_HANDLE)
+            .map(bun_sys::Fd::from_system)
+        else {
+            return Ok(());
+        };
+        while !bytes.is_empty() {
+            match bun_sys::write(stderr, bytes) {
+                Ok(0) => break,
+                Ok(n) => bytes = &bytes[n..],
+                Err(err) => match err.get_errno() {
+                    // `bun_sys::write` retries EINTR itself on Linux, but not on
+                    // macOS (`write$NOCANCEL` is issued once).
+                    #[cfg(unix)]
+                    bun_sys::E::EINTR => {}
+                    // fd 2 is O_NONBLOCK once `process.stderr` has touched a
+                    // pipe (the flag is on the open file description, so it is
+                    // inherited too). A full pipe only means the reader is
+                    // behind: wait for it, as a blocking stderr would, instead
+                    // of dropping the rest of the report.
+                    #[cfg(unix)]
+                    bun_sys::E::EAGAIN => {
+                        let mut pfd = [bun_sys::posix::PollFd {
+                            fd: stderr.native(),
+                            events: bun_sys::posix::POLL_OUT,
+                            revents: 0,
+                        }];
+                        if bun_sys::posix::poll(&mut pfd, -1).is_err() {
+                            break;
                         }
-                        _ => break,
-                    },
-                }
+                    }
+                    _ => break,
+                },
             }
         }
         Ok(())

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -400,16 +400,11 @@ pub use bun_io::{FmtAdapter, Write};
 /// Only impls `bun_io::Write` — `write!` resolves to `bun_io::Write::write_fmt`
 /// (alloc-free stack `Bridge`, async-signal-safe).
 ///
-/// Never returns `Err`: callers `abort()` on error, which would also skip the
-/// report upload and the re-raise of the original signal, so a closed stderr
-/// or a vanished reader silently drops the bytes. A full stderr is waited for.
-///
-/// Everything below is async-signal-safe: `bun_sys::write` is a bare
-/// `write(2)` (a bare kernel32 `WriteFile` on Windows, which matters there
-/// too: the CRT's `_write` takes a per-fd lock that the VEH handler would
-/// self-deadlock on when the faulting thread was inside CRT stdio),
-/// `bun_sys::posix::poll` is a bare `poll(2)`, and `bun_sys::Error` does not
-/// allocate.
+/// Waits for a full stderr but never returns `Err` for an unwritable one:
+/// callers `abort()` on `Err`, skipping the report upload and signal re-raise.
+/// Signal-safe: `bun_sys::write`/`posix::poll` are bare syscalls (on Windows a
+/// bare `WriteFile`, not the CRT, whose per-fd lock a VEH handler can deadlock
+/// on) and `bun_sys::Error` does not allocate.
 pub(crate) struct StderrWriter;
 pub(crate) fn stderr_writer() -> StderrWriter {
     StderrWriter
@@ -418,9 +413,8 @@ impl Write for StderrWriter {
     fn write_all(&mut self, mut bytes: &[u8]) -> bun_io::Result<()> {
         #[cfg(not(windows))]
         let stderr = bun_sys::Fd::stderr();
-        // Looked up live rather than through `Fd::stderr()`: the cache behind
-        // that is filled by `Output`'s stdio init, which runs after the crash
-        // handler is installed, and crashes in between still have to print.
+        // Not `Fd::stderr()`: its cache is filled by `Output`'s stdio init,
+        // which runs after the crash handler is installed.
         #[cfg(windows)]
         let Some(stderr) = bun_sys::windows::GetStdHandle(bun_sys::windows::STD_ERROR_HANDLE)
             .map(bun_sys::Fd::from_system)
@@ -432,15 +426,14 @@ impl Write for StderrWriter {
                 Ok(0) => break,
                 Ok(n) => bytes = &bytes[n..],
                 Err(err) => match err.get_errno() {
-                    // `bun_sys::write` retries EINTR itself on Linux, but not on
-                    // macOS (`write$NOCANCEL` is issued once).
+                    // `bun_sys::write` only retries EINTR on Linux; macOS issues
+                    // `write$NOCANCEL` once.
                     #[cfg(unix)]
                     bun_sys::E::EINTR => {}
-                    // fd 2 is O_NONBLOCK once `process.stderr` has touched a
-                    // pipe (the flag is on the open file description, so it is
-                    // inherited too). A full pipe only means the reader is
-                    // behind: wait for it, as a blocking stderr would, instead
-                    // of dropping the rest of the report.
+                    // A piped fd 2 is O_NONBLOCK once `process.stderr` has used
+                    // it (the flag is on the shared open file description).
+                    // Full only means the reader is behind: wait like a blocking
+                    // stderr would instead of dropping the report.
                     #[cfg(unix)]
                     bun_sys::E::EAGAIN => {
                         let mut pfd = [bun_sys::posix::PollFd {

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -1,7 +1,8 @@
 import { crash_handler } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, isDebug, isLinux, isPosix, isWindows, mergeWindowEnvs, tempDir } from "harness";
-import { rmSync } from "node:fs";
+import { mkfifo } from "mkfifo";
+import { closeSync, constants, openSync, rmSync, writeSync } from "node:fs";
 import path from "path";
 const { getMachOImageZeroOffset } = crash_handler;
 
@@ -126,6 +127,88 @@ describe.if(isPosix)("terminal signal reflects the crash cause", () => {
     expect(proc.signalCode).toBe(expectedSignal);
     expect(exitCode).not.toBe(0);
     void stdout;
+  });
+});
+
+// The report is written to fd 2 with many small raw write(2) calls. fd 2 is
+// often O_NONBLOCK: Bun puts the flag on a piped stderr as soon as
+// process.stderr is used, and since it lives on the open file description a
+// parent can hand down an fd that already has it. If the reader is behind at
+// that moment every write fails with EAGAIN, and the handler used to drop the
+// bytes and carry on, so the process died without printing anything. It has
+// to wait for the reader instead, like a blocking stderr would.
+describe.if(isPosix)("crash report reaches a full non-blocking stderr", () => {
+  const reportHeader = Buffer.alloc(60, "=").toString() + "\n";
+
+  test.concurrent.each([
+    ["panic", "invoked crashByPanic() handler", "SIGABRT"],
+    ["segfault", "Segmentation fault at address 0xDEADBEEF", "SIGSEGV"],
+  ] as const)("%s", async (approach, expectedReason, expectedSignal) => {
+    using dir = tempDir("crash-stderr-full", {});
+    // A fifo is a pipe whose read end this process holds without Bun.spawn
+    // draining it: the child's stderr has to stay full until the crash handler
+    // has tried to write to it.
+    const fifo = path.join(String(dir), "stderr");
+    mkfifo(fifo);
+    const readEnd = openSync(fifo, constants.O_RDONLY | constants.O_NONBLOCK);
+    let writeEnd: number | undefined = openSync(fifo, constants.O_WRONLY | constants.O_NONBLOCK);
+    try {
+      const fill = Buffer.alloc(64 * 1024, "f");
+      let filled = 0;
+      let fillStoppedBy: string | undefined;
+      while (fillStoppedBy === undefined) {
+        try {
+          filled += writeSync(writeEnd, fill);
+        } catch (e) {
+          fillStoppedBy = (e as NodeJS.ErrnoException).code;
+        }
+      }
+      expect({ fillStoppedBy, filled: filled > 0 }).toEqual({ fillStoppedBy: "EAGAIN", filled: true });
+
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "--debug-crash-handler-use-trace-string",
+          "-e",
+          // Both requires come first: loading bun:internal-for-testing takes
+          // over a second in debug builds, and the marker has to be as close
+          // as possible to the crash itself.
+          `const { crash_handler } = require("bun:internal-for-testing");
+           const { writeSync } = require("node:fs");
+           writeSync(1, "crashing\\n");
+           crash_handler.${approach}();`,
+        ],
+        env: noReportEnv,
+        stdio: ["ignore", "pipe", writeEnd],
+      });
+      // The child now holds the only write end, so EOF on the fifo means it died.
+      closeSync(writeEnd);
+      writeEnd = undefined;
+
+      const { value: marker } = await proc.stdout.getReader().read();
+      expect(new TextDecoder().decode(marker)).toBe("crashing\n");
+
+      // The child crashes right after the marker and has its whole report
+      // written (or, before the fix, dropped) within a millisecond or so.
+      // Nothing observable separates "still formatting" from "waiting in
+      // poll(2) for us", so give it a moment before draining the fifo: without
+      // the fix the child exits on its own, with it the race times out.
+      await Promise.race([proc.exited, Bun.sleep(1_000)]);
+
+      // Draining the fill unblocks the child; whatever follows it is the report.
+      const report = (await Bun.file(readEnd).text()).slice(filled);
+      await proc.exited;
+
+      expect(report).toStartWith(reportHeader);
+      expect(report).toContain(`panic(main thread): ${expectedReason}\n`);
+      expect(report).toContain("oh no: Bun has crashed. This indicates a bug in Bun, not your code.\n");
+      expect(report.trimEnd().split("\n").at(-1)).toMatch(/^ \/\d+\.\d+\.\d+\/\S+$/);
+      expect(report).toEndWith("\n\n");
+      expect(proc.signalCode).toBe(expectedSignal);
+    } finally {
+      if (writeEnd !== undefined) closeSync(writeEnd);
+      closeSync(readEnd);
+    }
   });
 });
 

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -188,12 +188,19 @@ describe.if(isPosix)("crash report reaches a full non-blocking stderr", () => {
       const { value: marker } = await proc.stdout.getReader().read();
       expect(new TextDecoder().decode(marker)).toBe("crashing\n");
 
-      // The child crashes right after the marker and has its whole report
-      // written (or, before the fix, dropped) within a millisecond or so.
-      // Nothing observable separates "still formatting" from "waiting in
-      // poll(2) for us", so give it a moment before draining the fifo: without
-      // the fix the child exits on its own, with it the race times out.
-      await Promise.race([proc.exited, Bun.sleep(1_000)]);
+      // The child crashes right after the marker and every report write hits
+      // the full fifo within about a millisecond of it (measured on release and
+      // debug ASAN builds). A handler that waits is then blocked in poll(2),
+      // which nothing outside the process can observe, so the only evidence
+      // that it is waiting rather than dead is that it is still alive well
+      // after that point; a handler that dropped the report is gone within a
+      // few hundred milliseconds. The sleep is that margin, not a wait for the
+      // child to get going.
+      const exitedWithoutReader = await Promise.race([
+        proc.exited.then(() => true),
+        Bun.sleep(1_000).then(() => false),
+      ]);
+      expect(exitedWithoutReader, "crash handler gave up on stderr instead of waiting for the reader").toBe(false);
 
       // Draining the fill unblocks the child; whatever follows it is the report.
       const report = (await Bun.file(readEnd).text()).slice(filled);


### PR DESCRIPTION
### Problem
- When Bun crashes while fd 2 is a non-blocking pipe or socket whose buffer is full at that moment, the crash report (metadata, the `panic(main thread): ...` line, `oh no: Bun has crashed...`, the bun.report trace string) is silently lost, in whole or in part. The process dies with nothing on stderr.
- Cause: `StderrWriter::write_all` in `src/crash_handler/lib.rs` did a single `libc::write(2, ...)` per formatted piece and ignored the result. On a full `O_NONBLOCK` fd every piece fails with `EAGAIN`; a short write or `EINTR` drops the tail of a piece the same way.
- fd 2 is non-blocking more often than it looks: Bun sets `O_NONBLOCK` on a piped stderr as soon as `process.stderr` is used (`/proc/self/fdinfo/2` goes from `flags: 02` to `04002`), and since the flag lives on the open file description it is also inherited from a parent that did the same to a shared pipe. `require("bun:internal-for-testing")` alone flips it, so every child in `run-crash-handler.test.ts` was exposed whenever the reader fell behind.
- The same writer serves `crash_handler()`, `rust_panic_hook`, `dump_stack_trace` and `dump_current_stack_trace_from_core`, so all of them lost output the same way.

### Fix
- `StderrWriter::write_all` is now one loop over `bun_sys::write` on both platforms: it continues after a short write, retries on `EINTR`, and on `EAGAIN` waits in `poll(2)` for `POLLOUT` on fd 2, then retries. The platforms differ only in how the fd is obtained.
- Why waiting (with no timeout) is right: a full pipe only means the reader has not caught up yet, and printing the report is the last thing the process does, so waiting costs nothing and dropping loses the only record of the crash. It is exactly what a blocking stderr does, and it is the semantic #37128 gives Bun's own console writer: its `fd_write_all_quiet` waits for `POLLOUT` with `poll(..., -1)` on `EAGAIN`. The one behavior change is that a reader which never drains the pipe now holds the crashing process until it does, the same as it would hold any program with a blocking stderr.
- The loop is not shared with the console writer yet: #37128 adds a hook-free `bun_sys::write_retrying` with this exact shape, and once it lands this function collapses into a call to it. It is not merged, so this PR does not add a competing copy of that primitive to `bun_sys`; the loop here is the ~20 lines in the crash handler. (#37128's `write_all_retrying` is not usable here either way: it first runs the stdio write hook, which flushes the JS thread's `process.stderr` sink.)
- Every other error (`EPIPE`, `EBADF`, `poll` failing) still drops the bytes and returns `Ok`. Callers `abort()` on `Err`, which would skip the upload in `report()` and the re-raise of the original signal in `crash()`, so a closed stderr keeps its current behavior.
- On POSIX this runs inside the fault signal handler, so it only uses async-signal-safe calls: `write(2)` and `poll(2)` through `bun_sys::write` and `bun_sys::posix::poll` (`bun_sys::Error` does not allocate). `bun_sys::write` already retries `EINTR` on Linux; the explicit arm is for macOS, where it is a single `write$NOCANCEL`.
- Windows: `bun_sys::write` on a system-kind `Fd` is a bare `kernel32::WriteFile`, so the reason the old code avoided the CRT (its per-fd lock can deadlock a VEH handler whose faulting thread was inside CRT stdio) still holds, and the local `WriteFile` extern is gone. The handle is still looked up live through the `GetStdHandle` wrapper (which filters null and `INVALID_HANDLE_VALUE`) rather than `Fd::stderr()`, whose cache is only filled by `Output`'s stdio init, after the crash handler is installed. The `EINTR`/`EAGAIN` arms are `cfg(unix)`; on Windows any error gives up, as before.
- Not directly tested: the short-write and `EINTR` arms. Report pieces are a few dozen bytes, so a short write needs a pipe with less than one piece of free space at exactly the right instant, and `EINTR` needs a signal to land inside the write. Both go through the same loop as the tested `EAGAIN` path.
- Test: `test/cli/run/run-crash-handler.test.ts`, `crash report reaches a full non-blocking stderr` (panic and segfault). The parent creates a fifo, fills the write end until `write` fails with `EAGAIN`, and passes that write end to the child as fd 2, so the child's stderr is full and non-blocking before it starts (a fifo because the read end has to be held without `Bun.spawn` draining it). The child loads its modules, writes a marker to stdout and crashes; its report writes all hit the full fifo within about a millisecond of the marker (measured on release and debug ASAN builds). The parent then asserts that the child is still alive one second later (a handler that dropped the report is gone within a few hundred milliseconds; one that waits is blocked in `poll(2)`, which nothing outside the process can observe, so being alive well past the crash is the only available evidence), drains the fifo, and checks that what follows the fill is a complete report: `====` header, reason line, `oh no` line, a trailing trace-string line, and the expected terminal signal. The second is a margin on the unfixed build's timing, not a readiness wait: on the fixed build the drain itself unblocks the child, so the pass direction does not depend on timing.
- Verified: the tests fail on the released bun (`USE_SYSTEM_BUN=1`: `crash handler gave up on stderr instead of waiting for the reader`) and on an unfixed debug build (`src/` stashed and rebuilt, 5/5 runs for both variants failed with an empty report), and pass on the fixed debug build; the rest of `run-crash-handler.test.ts` and `crash-report-command-char.test.ts` pass. `cargo check -p bun_crash_handler` passes for linux-gnu, linux-musl, freebsd, aarch64 darwin and both windows-msvc targets; `cargo fmt --check` and `cargo clippy` are clean for the crate.

### Background
- Crash report: on a crash Bun prints a header, metadata, a reason line and a trace string, a URL-shaped encoding of the stack that bun.report decodes. In release builds the trace string is the only stack information there is. `--debug-crash-handler-use-trace-string` makes debug builds take the same path.
- `StderrWriter`: the crash handler's own raw writer for fd 2. It bypasses Bun's buffered `Output`, which may be unusable mid-crash, and has to be async-signal-safe because on POSIX the handler runs inside the `SIGSEGV`/`SIGBUS`/... signal handler. `write!` turns every literal and every formatted argument into its own `write_all` call, which is why one report is dozens of small writes.
- `O_NONBLOCK`: with this flag, `write(2)` to a full pipe or socket fails with `EAGAIN` instead of blocking until the reader drains it. The flag belongs to the open file description, which is shared across `dup`, across spawn inheritance and across every process holding an fd to the same pipe, so one process setting it changes what all of them see.
- `poll(2)` with `POLLOUT` blocks until the fd can take data again, or until it reports an error, in which case the retried `write` fails with `EPIPE`/`EBADF` and the loop gives up. Like `write`, it is on the POSIX async-signal-safe list.

<details>
<summary>Repro on the released bun 1.4.0 and timing note</summary>

Child whose fd 2 is a fifo the parent filled to `EAGAIN`, crashing via `crash_handler.panic()`; the parent reads the fifo after the child exits:

```
{ filled: 8192, fillErrorCode: "EAGAIN" }
{ exitCode: 134, signalCode: "SIGABRT", fillIntact: true, reportLen: 0, hasPanicLine: false, hasOhNo: false, hasTrace: false }
```

With the fix the same child delivers the whole report after the fill, from the `====` header to the trace-string line.

The test loads `bun:internal-for-testing` before writing its stdout marker: measured with a piped stderr, marker to first crash-handler `write(2)` is under 1 ms on both the release and the debug ASAN build when the module is loaded first, and about 1.25 s on the debug build when the require comes after the marker.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/run-crash-handler.test.ts

<!-- robobun:evidence:end -->
