### PR TITLE
bundler: keep deep CSS, export star, composes and chunk graphs from overflowing the linker's stack

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2406,73 +2406,54 @@ impl<'a> LinkerContext<'a> {
         }
     }
 
+    /// Mixes into `hash` the isolated hash of chunk `index` and of every chunk
+    /// it transitively depends on (plus the paths of the assets they reference),
+    /// in depth-first postorder.
+    ///
+    /// Explicit-stack DFS (was per-edge recursive, one call per imported
+    /// chunk). `Enter` pushes a chunk's contributions in the order the
+    /// recursion made them (imported chunks, then what its output pieces
+    /// reference, then its own hash) and reverses that tail so they pop, and
+    /// are hashed, in that order.
     pub(crate) fn append_isolated_hashes_for_imported_chunks(
         &self,
         hash: &mut ContentHasher,
-        chunks: &mut [Chunk],
+        chunks: &[Chunk],
         index: u32,
         chunk_visit_map: &mut AutoBitSet,
     ) {
-        // Only visit each chunk at most once. This is important because there may be
-        // cycles in the chunk import graph. If there's a cycle, we want to include
-        // the hash of every chunk involved in the cycle (along with all of their
-        // dependencies). This depth-first traversal will naturally do that.
-        if chunk_visit_map.is_set(index as usize) {
-            return;
+        enum Frame {
+            Enter(u32),
+            /// An asset referenced from the output of the given chunk.
+            Asset {
+                chunk_index: u32,
+                source_index: u32,
+            },
+            Leave(u32),
         }
-        chunk_visit_map.set(index as usize);
+        let mut stack = vec![Frame::Enter(index)];
 
-        // Visit the other chunks that this chunk imports before visiting this chunk
-        // Note: reshaped for borrowck — collect imports first to avoid aliasing &chunks[index] with recursive &mut chunks
-        let cross_chunk_imports: Vec<u32> = chunks[index as usize]
-            .cross_chunk_imports
-            .slice()
-            .iter()
-            .map(|import| import.chunk_index)
-            .collect();
-        for chunk_index in cross_chunk_imports {
-            self.append_isolated_hashes_for_imported_chunks(
-                hash,
-                chunks,
-                chunk_index,
-                chunk_visit_map,
-            );
-        }
-
-        // Mix in hashes for content referenced via output pieces. JS chunks
-        // express cross-chunk dependencies via `cross_chunk_imports` above, but
-        // HTML (and CSS) chunks only reference other chunks through pieces, so
-        // recurse on those too.
-        // Note: reshaped for borrowck — collect piece queries first so the
-        // `&chunks[index]` borrow is dropped before the recursive `&mut chunks`
-        // calls in the Chunk/Scb arms below. `final_rel_path` is re-indexed per
-        // Asset arm (not hoisted) because it is now `Box<[u8]>` (not `Copy`).
-        let piece_queries: Vec<(crate::chunk::QueryKind, u32)> =
-            if let crate::chunk::IntermediateOutput::Pieces(pieces) =
-                &chunks[index as usize].intermediate_output
-            {
-                pieces
-                    .slice()
-                    .iter()
-                    .map(|p| (p.query.kind(), p.query.index()))
-                    .collect()
-            } else {
-                Vec::new()
-            };
-
-        for (kind, piece_index) in piece_queries {
-            match kind {
-                crate::chunk::QueryKind::Asset => {
+        while let Some(frame) = stack.pop() {
+            let index = match frame {
+                Frame::Enter(index) => index,
+                Frame::Leave(index) => {
+                    // Mix in the hash for this chunk
+                    hash.write(&chunks[index as usize].isolated_hash.to_ne_bytes());
+                    continue;
+                }
+                Frame::Asset {
+                    chunk_index,
+                    source_index,
+                } => {
                     let mut from_chunk_dir = bun_paths::resolve_path::dirname::<
                         bun_paths::resolve_path::platform::Posix,
                     >(
-                        &chunks[index as usize].final_rel_path
+                        &chunks[chunk_index as usize].final_rel_path
                     );
                     if from_chunk_dir == b"." {
                         from_chunk_dir = b"";
                     }
 
-                    let source_index = piece_index;
                     let parse_graph = self.parse_graph();
                     let additional_files: &[AdditionalFile] =
                         parse_graph.input_files.items_additional_files()[source_index as usize]
@@ -2490,30 +2471,53 @@ impl<'a> LinkerContext<'a> {
                         }
                         AdditionalFile::SourceIndex(_) => {}
                     }
+                    continue;
                 }
-                crate::chunk::QueryKind::Chunk => {
-                    self.append_isolated_hashes_for_imported_chunks(
-                        hash,
-                        chunks,
-                        piece_index,
-                        chunk_visit_map,
-                    );
-                }
-                crate::chunk::QueryKind::Scb => {
-                    self.append_isolated_hashes_for_imported_chunks(
-                        hash,
-                        chunks,
-                        self.graph.files.items_entry_point_chunk_index()[piece_index as usize],
-                        chunk_visit_map,
-                    );
-                }
-                crate::chunk::QueryKind::None | crate::chunk::QueryKind::HtmlImport => {}
-            }
-        }
+            };
 
-        // Mix in the hash for this chunk
-        let chunk = &chunks[index as usize];
-        hash.write(&chunk.isolated_hash.to_ne_bytes());
+            // Only visit each chunk at most once. This is important because there may be
+            // cycles in the chunk import graph. If there's a cycle, we want to include
+            // the hash of every chunk involved in the cycle (along with all of their
+            // dependencies). This depth-first traversal will naturally do that.
+            if chunk_visit_map.is_set(index as usize) {
+                continue;
+            }
+            chunk_visit_map.set(index as usize);
+
+            let chunk = &chunks[index as usize];
+            let mark = stack.len();
+
+            // Visit the other chunks that this chunk imports before visiting this chunk
+            for import in chunk.cross_chunk_imports.slice() {
+                stack.push(Frame::Enter(import.chunk_index));
+            }
+
+            // Mix in hashes for content referenced via output pieces. JS chunks
+            // express cross-chunk dependencies via `cross_chunk_imports` above, but
+            // HTML (and CSS) chunks only reference other chunks through pieces, so
+            // follow those too.
+            if let crate::chunk::IntermediateOutput::Pieces(pieces) = &chunk.intermediate_output {
+                for piece in pieces.slice() {
+                    match piece.query.kind() {
+                        crate::chunk::QueryKind::Asset => stack.push(Frame::Asset {
+                            chunk_index: index,
+                            source_index: piece.query.index(),
+                        }),
+                        crate::chunk::QueryKind::Chunk => {
+                            stack.push(Frame::Enter(piece.query.index()));
+                        }
+                        crate::chunk::QueryKind::Scb => stack.push(Frame::Enter(
+                            self.graph.files.items_entry_point_chunk_index()
+                                [piece.query.index() as usize],
+                        )),
+                        crate::chunk::QueryKind::None | crate::chunk::QueryKind::HtmlImport => {}
+                    }
+                }
+            }
+
+            stack.push(Frame::Leave(index));
+            stack[mark..].reverse();
+        }
     }
 
     // Sort cross-chunk exports by chunk name for determinism

--- a/src/bundler/linker_context/StaticRouteVisitor.rs
+++ b/src/bundler/linker_context/StaticRouteVisitor.rs
@@ -14,6 +14,14 @@ pub(crate) struct StaticRouteVisitor<'a> {
     pub(crate) c: &'a LinkerContext<'a>,
     pub(crate) cache: ArrayHashMap</* Index::Int */ u32, bool>,
     pub(crate) visited: AutoBitSet,
+    pub(crate) stack: Vec<Frame>,
+}
+
+/// A file whose imports are being checked, and how many of its import
+/// records have been looked at so far.
+pub(crate) struct Frame {
+    source_index: Index,
+    next_record: usize,
 }
 
 impl<'a> StaticRouteVisitor<'a> {
@@ -53,11 +61,18 @@ impl<'a> StaticRouteVisitor<'a> {
     }
 
     /// 1. Get AST for `source_index`
-    /// 2. Recursively traverse its imports in import records
+    /// 2. Traverse its imports in import records, depth-first
     /// 3. If any of the imports match any item in
     ///    `referenced_source_indices` which has `use_directive ==
     ///    .client`, then we know `source_index` is NOT fully
     ///    static.
+    ///
+    /// Explicit-stack DFS (was recursive, one call per import). `result` is
+    /// the answer the most recently finished file (or cache hit) gave to the
+    /// file below it on the stack: `true` finishes that file as well, so it
+    /// propagates down through every file on the stack, caching `true` for
+    /// each, the way the recursive form's early returns did; `false` lets the
+    /// file go on to its next import.
     fn has_transitive_use_client_impl(
         &mut self,
         all_import_records: &[import_record::List<'_>],
@@ -65,51 +80,67 @@ impl<'a> StaticRouteVisitor<'a> {
         use_directives: &[UseDirective],
         source_index: Index,
     ) -> bool {
-        if let Some(result) = self.cache.get(&source_index.get()) {
-            return *result;
+        debug_assert!(self.stack.is_empty());
+        if let Some(known) = self.enter(source_index) {
+            return known;
         }
-        if self.visited.is_set(source_index.get() as usize) {
-            return false;
-        }
-        self.visited.set(source_index.get() as usize);
 
-        let import_records = &all_import_records[source_index.get() as usize];
-
-        let result = 'result: {
-            for import_record in import_records.as_slice() {
-                if !import_record.source_index.is_valid() {
-                    continue;
-                }
-
-                // check if this import is a client boundary
-                debug_assert_eq!(referenced_source_indices.len(), use_directives.len());
-                for (referenced_source_index, use_directive) in
-                    referenced_source_indices.iter().zip(use_directives)
-                {
-                    if *use_directive != UseDirective::Client {
-                        continue;
-                    }
-                    // it's a client boundary
-                    if *referenced_source_index == import_record.source_index.get() {
-                        break 'result true;
-                    }
-                }
-
-                // otherwise check its children
-                if self.has_transitive_use_client_impl(
-                    all_import_records,
-                    referenced_source_indices,
-                    use_directives,
-                    import_record.source_index,
-                ) {
-                    break 'result true;
-                }
+        let mut result = false;
+        while let Some(frame) = self.stack.last_mut() {
+            if result {
+                let finished = self.stack.pop().expect("stack is non-empty");
+                self.cache.insert(finished.source_index.get(), true);
+                continue;
             }
-            false
-        };
 
-        self.cache.insert(source_index.get(), result);
+            let import_records = &all_import_records[frame.source_index.get() as usize];
+            let Some(import_record) = import_records.as_slice().get(frame.next_record) else {
+                let finished = self.stack.pop().expect("stack is non-empty");
+                self.cache.insert(finished.source_index.get(), false);
+                continue;
+            };
+            frame.next_record += 1;
+
+            if !import_record.source_index.is_valid() {
+                continue;
+            }
+
+            // check if this import is a client boundary
+            debug_assert_eq!(referenced_source_indices.len(), use_directives.len());
+            if referenced_source_indices.iter().zip(use_directives).any(
+                |(referenced_source_index, use_directive)| {
+                    *use_directive == UseDirective::Client
+                        && *referenced_source_index == import_record.source_index.get()
+                },
+            ) {
+                result = true;
+                continue;
+            }
+
+            // otherwise check its children
+            if let Some(known) = self.enter(import_record.source_index) {
+                result = known;
+            }
+        }
 
         result
+    }
+
+    /// Starts checking `source_index`'s imports unless the answer is already
+    /// known: cached by an earlier walk, or `false` for a file that is already
+    /// being checked further down the stack (a cycle).
+    fn enter(&mut self, source_index: Index) -> Option<bool> {
+        if let Some(result) = self.cache.get(&source_index.get()) {
+            return Some(*result);
+        }
+        if self.visited.is_set(source_index.get() as usize) {
+            return Some(false);
+        }
+        self.visited.set(source_index.get() as usize);
+        self.stack.push(Frame {
+            source_index,
+            next_record: 0,
+        });
+        None
     }
 }

--- a/src/bundler/linker_context/findImportedFilesInCSSOrder.rs
+++ b/src/bundler/linker_context/findImportedFilesInCSSOrder.rs
@@ -2,9 +2,9 @@ use crate::mal_prelude::*;
 use bstr::BStr;
 
 use bun_alloc::Arena;
-use bun_ast::{ImportKind, ImportRecord, ImportRecordFlags};
+use bun_ast::{ImportKind, ImportRecord, ImportRecordFlags, Range};
 use bun_collections::{ArrayHashMap, StringArrayHashMap, VecExt};
-use bun_core::handle_oom;
+use bun_core::{StackCheck, handle_oom};
 
 use crate::Graph::Graph;
 use crate::bun_css::css_parser::BundlerCssRule;
@@ -72,6 +72,10 @@ fn memcpy_and_reset(order: &mut Vec<CssImportOrder>, wip: &mut Vec<CssImportOrde
 /// as far as "@layer" is concerned. So we may in some cases keep both the
 /// first and last locations and only write out the "@layer" information
 /// for the first location.
+///
+/// The traversal recurses once per `@import`, so an import chain deeper than
+/// the thread's stack allows is reported as an error on the bundler log and
+/// yields an empty order.
 pub(crate) fn find_imported_files_in_css_order<'a>(
     this: &'a mut LinkerContext,
     temp_arena: &'a Arena,
@@ -96,6 +100,18 @@ pub(crate) fn find_imported_files_in_css_order<'a>(
         has_external_import: bool,
         visited: Vec<Index>,
         order: Vec<CssImportOrder>,
+
+        stack_check: StackCheck,
+        /// The `@import` that could not be followed because `visit` recurses
+        /// once per `@import` and the thread's stack was nearly exhausted.
+        /// Once set, the walk unwinds without visiting anything else.
+        too_deep: Option<TooDeep>,
+    }
+
+    struct TooDeep {
+        importer: Index,
+        range: Range,
+        kind: ImportKind,
     }
 
     impl<'a> Visitor<'a> {
@@ -103,6 +119,32 @@ pub(crate) fn find_imported_files_in_css_order<'a>(
         fn input_file_pretty(&self, source_index: Index) -> &BStr {
             let sources = self.parse_graph.input_files.items_source();
             BStr::new(&sources[source_index.get() as usize].path.pretty)
+        }
+
+        /// Visits the file `record` (an `@import` or `composes` in `importer`)
+        /// resolved to. Returns false if the walk has been abandoned, in which
+        /// case the caller returns as well.
+        fn visit_import(
+            &mut self,
+            importer: Index,
+            record: &ImportRecord,
+            wrapping_conditions: &mut Vec<ImportConditions>,
+            wrapping_import_records: &mut Vec<ImportRecord>,
+        ) -> bool {
+            if !self.stack_check.is_safe_to_recurse() {
+                self.too_deep = Some(TooDeep {
+                    importer,
+                    range: record.range,
+                    kind: record.kind,
+                });
+                return false;
+            }
+            self.visit(
+                record.source_index,
+                wrapping_conditions,
+                wrapping_import_records,
+            );
+            self.too_deep.is_none()
         }
 
         fn visit(
@@ -157,7 +199,8 @@ pub(crate) fn find_imported_files_in_css_order<'a>(
             // }
 
             // `visited.pop()` happens at the end of this function; the early
-            // return above intentionally skips it.
+            // return above intentionally skips it, and the `too_deep` returns
+            // below don't need it because the whole walk is discarded.
 
             // Iterate over the top-level "@import" rules
             let mut import_record_idx: usize = 0;
@@ -189,8 +232,9 @@ pub(crate) fn find_imported_files_in_css_order<'a>(
                                     &mut nested_import_records,
                                 ),
                             );
-                            self.visit(
-                                record.source_index,
+                            let followed = self.visit_import(
+                                source_index,
+                                record,
                                 &mut nested_conditions,
                                 wrapping_import_records,
                             );
@@ -198,14 +242,20 @@ pub(crate) fn find_imported_files_in_css_order<'a>(
                             // outer `wrapping_import_records` is), so it is uniquely
                             // owned here — drop it normally to free the buffer.
                             drop(nested_import_records);
+                            if !followed {
+                                return;
+                            }
                             import_record_idx += 1;
                             continue;
                         }
-                        self.visit(
-                            record.source_index,
+                        if !self.visit_import(
+                            source_index,
+                            record,
                             wrapping_conditions,
                             wrapping_import_records,
-                        );
+                        ) {
+                            return;
+                        }
                         import_record_idx += 1;
                         continue;
                     }
@@ -264,12 +314,16 @@ pub(crate) fn find_imported_files_in_css_order<'a>(
             // matter for these because the output order is explicitly undfened
             // in the specification.
             for record in self.all_import_records[source_index.get() as usize].as_slice() {
-                if record.kind == ImportKind::Composes && record.source_index.is_valid() {
-                    self.visit(
-                        record.source_index,
+                if record.kind == ImportKind::Composes
+                    && record.source_index.is_valid()
+                    && !self.visit_import(
+                        source_index,
+                        record,
                         wrapping_conditions,
                         wrapping_import_records,
-                    );
+                    )
+                {
+                    return;
                 }
             }
 
@@ -313,6 +367,8 @@ pub(crate) fn find_imported_files_in_css_order<'a>(
         all_import_records: all_import_records_slice,
         has_external_import: false,
         order: Vec::new(),
+        stack_check: StackCheck::init(),
+        too_deep: None,
     };
     let mut wrapping_conditions: Vec<ImportConditions> = Vec::new();
     let mut wrapping_import_records: Vec<ImportRecord> = Vec::new();
@@ -323,6 +379,33 @@ pub(crate) fn find_imported_files_in_css_order<'a>(
             &mut wrapping_conditions,
             &mut wrapping_import_records,
         );
+        if visitor.too_deep.is_some() {
+            break;
+        }
+    }
+
+    if let Some(TooDeep {
+        importer,
+        range,
+        kind,
+    }) = visitor.too_deep
+    {
+        let importer = &this.parse_graph().input_files.items_source()[importer.get() as usize];
+        // Split-borrow (see `LinkerContext::log_disjoint`). `link()` fails the
+        // build once `compute_chunks` returns.
+        this.log_disjoint().add_range_error_fmt(
+            Some(importer),
+            range,
+            format_args!(
+                "Maximum call stack size exceeded while following this \"{}\" chain",
+                if kind == ImportKind::Composes {
+                    "composes"
+                } else {
+                    "@import"
+                }
+            ),
+        );
+        return Vec::new();
     }
 
     let has_external_import = visitor.has_external_import;

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -623,6 +623,7 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
         c: unsafe { bun_ptr::detach_lifetime_ref::<LinkerContext>(c) },
         cache: bun_collections::ArrayHashMap::default(),
         visited: AutoBitSet::init_empty(c.graph.files.len()).expect("oom"),
+        stack: Vec::new(),
     };
     // defer static_route_visitor.deinit() — handled by Drop
 

--- a/src/bundler/linker_context/generateCodeForLazyExport.rs
+++ b/src/bundler/linker_context/generateCodeForLazyExport.rs
@@ -94,10 +94,36 @@ pub(crate) fn generate_code_for_lazy_export(
             // `defer inner_visited.deinit(...)` — handled by Drop.
             let mut composes_visited: ArrayHashMap<Ref, ()> = ArrayHashMap::new();
             // `defer composes_visited.deinit()` — handled by Drop.
+            let mut stack: Vec<Frame> = Vec::new();
+
+            /// A class whose `composes` declarations are being walked, and
+            /// how far along them the walk is.
+            #[derive(Clone, Copy)]
+            struct Frame {
+                idx: IndexInt,
+                css_ref: CssRef,
+                compose_index: usize,
+                name_index: usize,
+                /// Append the class's own name once its `composes` are done.
+                /// False for the root class, whose name the caller appends.
+                append_name: bool,
+            }
+
+            impl Frame {
+                fn next_name(&mut self) {
+                    self.name_index += 1;
+                }
+
+                fn next_compose(&mut self) {
+                    self.compose_index += 1;
+                    self.name_index = 0;
+                }
+            }
 
             struct Visitor<'a> {
                 inner_visited: &'a mut BitSet,
                 composes_visited: &'a mut ArrayHashMap<Ref, ()>,
+                stack: &'a mut Vec<Frame>,
                 parts: &'a mut Vec<E::TemplatePart>,
                 all_import_records: &'a [bun_ast::import_record::List<'a>],
                 // `BundledAst.css` SoA column.
@@ -116,17 +142,39 @@ pub(crate) fn generate_code_for_lazy_export(
                     self.composes_visited.clear_retaining_capacity();
                 }
 
-                fn visit_name(&mut self, ast: &BundlerStyleSheet, ref_: CssRef, idx: IndexInt) {
+                /// Starts walking a composed class's own `composes` unless it has
+                /// been reached already. Its name is appended when that walk
+                /// completes, after the names it composes.
+                ///
+                /// The class is marked as reached on the way in. The recursive
+                /// form marked it on the way out, which appended the same names
+                /// in the same order whenever it terminated, but recursed forever
+                /// on a `composes` cycle that did not pass through the root class.
+                fn visit_name(&mut self, ref_: CssRef, idx: IndexInt) {
                     debug_assert!(ref_.can_be_composed());
                     let real_ref = ref_.to_real_ref(idx);
-                    let from_this_file = idx == self.source_index;
-                    if (from_this_file && self.inner_visited.is_set(ref_.inner_index() as usize))
-                        || (!from_this_file && self.composes_visited.contains_key(&real_ref))
-                    {
-                        return;
+                    if idx == self.source_index {
+                        if self.inner_visited.is_set(ref_.inner_index() as usize) {
+                            return;
+                        }
+                        self.inner_visited.set(ref_.inner_index() as usize);
+                    } else {
+                        if self.composes_visited.contains_key(&real_ref) {
+                            return;
+                        }
+                        self.composes_visited.insert(real_ref, ());
                     }
 
-                    self.visit_composes(ast, ref_, idx);
+                    self.stack.push(Frame {
+                        idx,
+                        css_ref: ref_,
+                        compose_index: 0,
+                        name_index: 0,
+                        append_name: true,
+                    });
+                }
+
+                fn append_name(&mut self, real_ref: Ref) {
                     self.parts.push(E::TemplatePart {
                         value: Expr::init(
                             E::NameOfSymbol {
@@ -138,12 +186,6 @@ pub(crate) fn generate_code_for_lazy_export(
                         tail: E::TemplateContents::Cooked(E::String::init(b" ")),
                         tail_loc: self.loc,
                     });
-
-                    if from_this_file {
-                        self.inner_visited.set(ref_.inner_index() as usize);
-                    } else {
-                        self.composes_visited.insert(real_ref, ());
-                    }
                 }
 
                 fn warn_non_single_class_composes(
@@ -174,116 +216,137 @@ pub(crate) fn generate_code_for_lazy_export(
                     );
                 }
 
-                fn visit_composes(
-                    &mut self,
-                    ast: &BundlerStyleSheet,
-                    css_ref: CssRef,
-                    idx: IndexInt,
-                ) {
-                    let ref_ = css_ref.to_real_ref(idx);
-                    if ast.composes.count() > 0 {
-                        let Some(composes) = ast.composes.get(&ref_) else {
-                            return;
+                /// Appends the name of every class that `css_ref` (a class in
+                /// the file `idx`, already marked as reached) transitively
+                /// composes, each after the names it composes itself.
+                ///
+                /// Explicit-stack DFS (was recursive, one `visit_composes` and
+                /// `visit_name` call per composed class). Each iteration handles
+                /// one name of one `composes` declaration of the class on top of
+                /// the stack, so the names, the `from global` strings and the
+                /// diagnostics come out in the order the recursion produced them.
+                fn visit_composes(&mut self, css_ref: CssRef, idx: IndexInt) {
+                    debug_assert!(self.stack.is_empty());
+                    self.stack.push(Frame {
+                        idx,
+                        css_ref,
+                        compose_index: 0,
+                        name_index: 0,
+                        append_name: false,
+                    });
+
+                    let all_css_asts = self.all_css_asts;
+                    while let Some(frame) = self.stack.last_mut() {
+                        let idx = frame.idx;
+                        let css_ref = frame.css_ref;
+                        // Every class on the stack was found in a file's CSS AST.
+                        let ast: &BundlerStyleSheet = all_css_asts[idx as usize]
+                            .as_deref()
+                            .expect("composed class comes from a CSS file");
+                        let composes = ast.composes.get(&css_ref.to_real_ref(idx));
+                        let Some(compose) = composes.and_then(|composes| {
+                            composes.composes.slice().get(frame.compose_index)
+                        }) else {
+                            let frame = self.stack.pop().expect("stack is non-empty");
+                            if frame.append_name {
+                                self.append_name(css_ref.to_real_ref(idx));
+                            }
+                            continue;
                         };
                         // while parsing we check that we only allow `composes` on single class selectors
                         debug_assert!(css_ref.tag().contains(CssRefTag::CLASS));
 
-                        for compose in composes.composes.slice() {
-                            match &compose.from {
-                                // it is imported
-                                Some(CssSpecifier::ImportRecordIndex(import_record_idx)) => {
-                                    let import_records = &self.all_import_records[idx as usize];
-                                    let import_record =
-                                        &import_records[*import_record_idx as usize];
-                                    if import_record.source_index.is_valid() {
-                                        let Some(other_file) = self.all_css_asts
-                                            [import_record.source_index.get() as usize]
-                                            .as_deref()
-                                        else {
-                                            self.log.add_error_fmt(
-                                                &self.all_sources[idx as usize],
-                                                compose.loc,
-                                                format_args!(
-                                                    "Cannot use the \"composes\" property with the {} file (it is not a CSS file)",
-                                                    bun_fmt::quote(
-                                                        self.all_sources
-                                                            [import_record.source_index.get() as usize]
-                                                            .path
-                                                            .pretty
-                                                    ),
-                                                ),
-                                            );
-                                            continue;
-                                        };
-                                        for name in compose.names.slice() {
-                                            let name_v = name.v();
-                                            let Some(other_name_entry) =
-                                                other_file.local_scope.get(name_v)
-                                            else {
-                                                continue;
-                                            };
-                                            let other_name_ref = other_name_entry.ref_;
-                                            if !other_name_ref.can_be_composed() {
-                                                self.warn_non_single_class_composes(
-                                                    other_file,
-                                                    other_name_ref,
-                                                    import_record.source_index.get(),
-                                                    compose.loc,
-                                                );
-                                            } else {
-                                                self.visit_name(
-                                                    other_file,
-                                                    other_name_ref,
-                                                    import_record.source_index.get(),
-                                                );
-                                            }
-                                        }
-                                    }
+                        match &compose.from {
+                            // it is imported
+                            Some(CssSpecifier::ImportRecordIndex(import_record_idx)) => {
+                                let import_record = &self.all_import_records[idx as usize]
+                                    [*import_record_idx as usize];
+                                if !import_record.source_index.is_valid() {
+                                    frame.next_compose();
+                                    continue;
                                 }
-                                Some(CssSpecifier::Global) => {
-                                    // E.g.: `composes: foo from global`
-                                    //
-                                    // In this example `foo` is global and won't be rewritten to a locally scoped
-                                    // name, so we can just add it as a string.
-                                    for name in compose.names.slice() {
-                                        let name_v = name.v();
-                                        self.parts.push(E::TemplatePart {
-                                            value: Expr::init(E::String::init(name_v), self.loc),
-                                            tail: E::TemplateContents::Cooked(E::String::init(
-                                                b" ",
-                                            )),
-                                            tail_loc: self.loc,
-                                        });
-                                    }
+                                let other_idx = import_record.source_index.get();
+                                let Some(other_file) = all_css_asts[other_idx as usize].as_deref()
+                                else {
+                                    frame.next_compose();
+                                    self.log.add_error_fmt(
+                                        &self.all_sources[idx as usize],
+                                        compose.loc,
+                                        format_args!(
+                                            "Cannot use the \"composes\" property with the {} file (it is not a CSS file)",
+                                            bun_fmt::quote(
+                                                self.all_sources[other_idx as usize].path.pretty
+                                            ),
+                                        ),
+                                    );
+                                    continue;
+                                };
+                                let Some(name) = compose.names.slice().get(frame.name_index) else {
+                                    frame.next_compose();
+                                    continue;
+                                };
+                                frame.next_name();
+                                let Some(other_name_entry) = other_file.local_scope.get(name.v())
+                                else {
+                                    continue;
+                                };
+                                let other_name_ref = other_name_entry.ref_;
+                                if !other_name_ref.can_be_composed() {
+                                    self.warn_non_single_class_composes(
+                                        other_file,
+                                        other_name_ref,
+                                        other_idx,
+                                        compose.loc,
+                                    );
+                                } else {
+                                    self.visit_name(other_name_ref, other_idx);
                                 }
-                                None => {
-                                    // it is from the current file
-                                    for name in compose.names.slice() {
-                                        let name_v = name.v();
-                                        let Some(name_entry) = ast.local_scope.get(name_v) else {
-                                            self.log.add_error_fmt(
-                                                &self.all_sources[idx as usize],
-                                                compose.loc,
-                                                format_args!(
-                                                    "The name {} never appears in {} as a CSS modules locally scoped class name. Note that \"composes\" only works with single class selectors.",
-                                                    bun_fmt::quote(name_v),
-                                                    bun_fmt::quote(self.all_sources[idx as usize].path.pretty),
-                                                ),
-                                            );
-                                            continue;
-                                        };
-                                        let name_ref = name_entry.ref_;
-                                        if !name_ref.can_be_composed() {
-                                            self.warn_non_single_class_composes(
-                                                ast,
-                                                name_ref,
-                                                idx,
-                                                compose.loc,
-                                            );
-                                        } else {
-                                            self.visit_name(ast, name_ref, idx);
-                                        }
-                                    }
+                            }
+                            Some(CssSpecifier::Global) => {
+                                // E.g.: `composes: foo from global`
+                                //
+                                // In this example `foo` is global and won't be rewritten to a locally scoped
+                                // name, so we can just add it as a string.
+                                frame.next_compose();
+                                for name in compose.names.slice() {
+                                    let name_v = name.v();
+                                    self.parts.push(E::TemplatePart {
+                                        value: Expr::init(E::String::init(name_v), self.loc),
+                                        tail: E::TemplateContents::Cooked(E::String::init(b" ")),
+                                        tail_loc: self.loc,
+                                    });
+                                }
+                            }
+                            None => {
+                                // it is from the current file
+                                let Some(name) = compose.names.slice().get(frame.name_index) else {
+                                    frame.next_compose();
+                                    continue;
+                                };
+                                frame.next_name();
+                                let name_v = name.v();
+                                let Some(name_entry) = ast.local_scope.get(name_v) else {
+                                    self.log.add_error_fmt(
+                                        &self.all_sources[idx as usize],
+                                        compose.loc,
+                                        format_args!(
+                                            "The name {} never appears in {} as a CSS modules locally scoped class name. Note that \"composes\" only works with single class selectors.",
+                                            bun_fmt::quote(name_v),
+                                            bun_fmt::quote(self.all_sources[idx as usize].path.pretty),
+                                        ),
+                                    );
+                                    continue;
+                                };
+                                let name_ref = name_entry.ref_;
+                                if !name_ref.can_be_composed() {
+                                    self.warn_non_single_class_composes(
+                                        ast,
+                                        name_ref,
+                                        idx,
+                                        compose.loc,
+                                    );
+                                } else {
+                                    self.visit_name(name_ref, idx);
                                 }
                             }
                         }
@@ -315,6 +378,7 @@ pub(crate) fn generate_code_for_lazy_export(
                 let mut visitor = Visitor {
                     inner_visited: &mut inner_visited,
                     composes_visited: &mut composes_visited,
+                    stack: &mut stack,
                     source_index,
                     parts: &mut template_parts,
                     all_import_records,
@@ -329,7 +393,7 @@ pub(crate) fn generate_code_for_lazy_export(
                 visitor.clear_all();
                 visitor.inner_visited.set(ref_.inner_index() as usize);
                 if ref_.tag().contains(CssRefTag::CLASS) {
-                    visitor.visit_composes(css_ast, ref_, source_index);
+                    visitor.visit_composes(ref_, source_index);
                 }
 
                 if !template_parts.is_empty() {

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -286,6 +286,7 @@ pub(crate) fn scan_imports_and_exports(
                     export_star_records: &*export_star_import_records,
                     output_format,
                     wrap_stack: Vec::new(),
+                    export_star_stack: Vec::new(),
                 }
             };
             for source_index_ in &reachable {
@@ -303,7 +304,7 @@ pub(crate) fn scan_imports_and_exports(
 
                 if dependency_wrapper.export_star_records[id].len() > 0 {
                     dependency_wrapper.export_star_map.clear();
-                    let _ = dependency_wrapper.has_dynamic_exports_due_to_export_star(source_index);
+                    dependency_wrapper.mark_dynamic_exports_due_to_export_star(source_index);
                 }
 
                 // Even if the output file is CommonJS-like, we may still need to wrap
@@ -350,7 +351,7 @@ pub(crate) fn scan_imports_and_exports(
                             import_records_list,
                             export_star_records: export_star_import_records,
                             imports_to_bind: imports_to_bind_list,
-                            source_index_stack: Vec::with_capacity(32),
+                            stack: Vec::with_capacity(32),
                             exports_kind,
                             named_exports,
                         });
@@ -1150,14 +1151,90 @@ struct DependencyWrapper<'a> {
     export_star_records: &'a [bun_alloc::AstVec<u32>],
     output_format: options::Format,
     wrap_stack: Vec<IndexInt>,
+    export_star_stack: Vec<ExportStarFrame>,
+}
+
+/// One file on the path of an explicit-stack walk over the `export *` graph:
+/// the file and how many of its `export_star_import_records` have been
+/// followed so far.
+struct ExportStarFrame {
+    source_index: IndexInt,
+    next_record: usize,
+}
+
+/// What the recursive form of `mark_dynamic_exports_due_to_export_star`
+/// returned immediately upon entering a file, if anything.
+enum ExportStarEntry {
+    /// The file already has dynamic exports (`true`).
+    Dynamic,
+    /// The file was already visited from this root (`false`).
+    Visited,
+    /// The file's own export stars need to be followed.
+    Pushed,
 }
 
 impl DependencyWrapper<'_> {
-    fn has_dynamic_exports_due_to_export_star(&mut self, source_index: IndexInt) -> bool {
+    /// Marks `source_index` as `EsmWithDynamicFallback` if it transitively
+    /// `export *`s from a file whose exports are not statically analyzable
+    /// (CommonJS, or an unresolved external `export *`), along with every file
+    /// on the `export *` path to that file.
+    ///
+    /// Explicit-stack DFS (was per-edge recursive, one call per `export *`).
+    /// In the recursive form, finding such a file returned `true` through
+    /// every frame on the way back up, and each of those frames marked its
+    /// file: the frames on the stack at that moment are exactly the files to
+    /// mark. A file whose export stars are exhausted without finding one
+    /// returned `false`, which is popping it.
+    fn mark_dynamic_exports_due_to_export_star(&mut self, source_index: IndexInt) {
+        debug_assert!(self.export_star_stack.is_empty());
+        if !matches!(
+            self.enter_export_star(source_index),
+            ExportStarEntry::Pushed
+        ) {
+            return;
+        }
+
+        while let Some(frame) = self.export_star_stack.last_mut() {
+            let source_index = frame.source_index;
+            let Some(&id) = self.export_star_records[source_index as usize].get(frame.next_record)
+            else {
+                self.export_star_stack.pop();
+                continue;
+            };
+            frame.next_record += 1;
+
+            // This file has dynamic exports if the exported imports are from a file
+            // that either has dynamic exports directly or transitively by itself
+            // having an export star from a file with dynamic exports.
+            let kind = self.entry_point_kinds[source_index as usize];
+            let rec_source_index =
+                self.import_records[source_index as usize].as_slice()[id as usize].source_index;
+            let found_dynamic = if rec_source_index.is_invalid() {
+                !kind.is_entry_point() || !self.output_format.keep_es6_import_export_syntax()
+            } else if rec_source_index.get() != source_index {
+                matches!(
+                    self.enter_export_star(rec_source_index.get()),
+                    ExportStarEntry::Dynamic
+                )
+            } else {
+                false
+            };
+            if found_dynamic {
+                for frame in self.export_star_stack.drain(..) {
+                    self.exports_kind[frame.source_index as usize] =
+                        ExportsKind::EsmWithDynamicFallback;
+                }
+                return;
+            }
+        }
+    }
+
+    fn enter_export_star(&mut self, source_index: IndexInt) -> ExportStarEntry {
         // Terminate the traversal now if this file already has dynamic exports
-        let export_kind = self.exports_kind[source_index as usize];
-        match export_kind {
-            ExportsKind::Cjs | ExportsKind::EsmWithDynamicFallback => return true,
+        match self.exports_kind[source_index as usize] {
+            ExportsKind::Cjs | ExportsKind::EsmWithDynamicFallback => {
+                return ExportStarEntry::Dynamic;
+            }
             _ => {}
         }
 
@@ -1167,28 +1244,14 @@ impl DependencyWrapper<'_> {
             .get_or_put(source_index)
             .expect("unreachable");
         if has_visited.found_existing {
-            return false;
+            return ExportStarEntry::Visited;
         }
 
-        for id in self.export_star_records[source_index as usize].iter() {
-            // This file has dynamic exports if the exported imports are from a file
-            // that either has dynamic exports directly or transitively by itself
-            // having an export star from a file with dynamic exports.
-            let kind = self.entry_point_kinds[source_index as usize];
-            let rec_source_index =
-                self.import_records[source_index as usize].as_slice()[*id as usize].source_index;
-            if (rec_source_index.is_invalid()
-                && (!kind.is_entry_point() || !self.output_format.keep_es6_import_export_syntax()))
-                || (rec_source_index.is_valid()
-                    && rec_source_index.get() != source_index
-                    && self.has_dynamic_exports_due_to_export_star(rec_source_index.get()))
-            {
-                self.exports_kind[source_index as usize] = ExportsKind::EsmWithDynamicFallback;
-                return true;
-            }
-        }
-
-        false
+        self.export_star_stack.push(ExportStarFrame {
+            source_index,
+            next_record: 0,
+        });
+        ExportStarEntry::Pushed
     }
 
     fn wrap(&mut self, source_index: IndexInt) {
@@ -1235,7 +1298,7 @@ impl DependencyWrapper<'_> {
 // ──────────────────────────────────────────────────────────────────────────
 struct ExportStarContext<'a> {
     import_records_list: *mut [ImportRecordList<'a>],
-    source_index_stack: Vec<IndexInt>,
+    stack: Vec<ExportStarFrame>,
     exports_kind: *mut [ExportsKind],
     named_exports: *mut [NamedExports],
     imports_to_bind: *mut [RefImportData],
@@ -1243,26 +1306,38 @@ struct ExportStarContext<'a> {
 }
 
 impl<'a> ExportStarContext<'a> {
-    /// Recursively merge re-exports from `source_index` into
-    /// `resolved_exports[target_id]`.
+    /// Merge the re-exports reachable through `source_index`'s `export *`
+    /// statements into `resolved_exports[target_id]`.
+    ///
+    /// Explicit-stack DFS (was per-edge recursive, one call per `export *`).
+    /// `stack` is the chain of files being followed from `source_index`, which
+    /// the recursive form kept as a separate list: a file already on it is a
+    /// cycle and is not entered again, and a real export in any file on it
+    /// shadows the re-exports found below.
     fn add_exports(
         &mut self,
         resolved_exports: *mut [ResolvedExports],
         target_id: usize,
         source_index: IndexInt,
     ) {
-        // Avoid infinite loops due to cycles in the export star graph
-        for i in self.source_index_stack.iter() {
-            if *i == source_index {
-                return;
-            }
-        }
-        self.source_index_stack.push(source_index);
-        let stack_end_pos = self.source_index_stack.len();
+        debug_assert!(self.stack.is_empty());
+        self.stack.push(ExportStarFrame {
+            source_index,
+            next_record: 0,
+        });
 
-        for import_id in col_ref!(self.export_star_records)[source_index as usize].iter() {
+        while let Some(frame) = self.stack.last_mut() {
+            let source_index = frame.source_index;
+            let Some(&import_id) =
+                col_ref!(self.export_star_records)[source_index as usize].get(frame.next_record)
+            else {
+                self.stack.pop();
+                continue;
+            };
+            frame.next_record += 1;
+
             let other_source_index = col_ref!(self.import_records_list)[source_index as usize]
-                .as_slice()[*import_id as usize]
+                .as_slice()[import_id as usize]
                 .source_index
                 .get();
 
@@ -1302,8 +1377,10 @@ impl<'a> ExportStarContext<'a> {
                 }
 
                 // This export star is shadowed if any file in the stack has a matching real named export
-                for prev in &self.source_index_stack[0..stack_end_pos] {
-                    if col_ref!(self.named_exports)[*prev as usize].contains(alias_slice) {
+                for prev in self.stack.iter() {
+                    if col_ref!(self.named_exports)[prev.source_index as usize]
+                        .contains(alias_slice)
+                    {
                         continue 'next_export;
                     }
                 }
@@ -1352,12 +1429,19 @@ impl<'a> ExportStarContext<'a> {
                 }
             }
 
-            // Search further through this file's export stars
-            self.add_exports(resolved_exports, target_id, other_source_index);
+            // Search further through this file's export stars, unless doing so
+            // would loop: avoid infinite loops due to cycles in the export star graph
+            if !self
+                .stack
+                .iter()
+                .any(|frame| frame.source_index == other_source_index)
+            {
+                self.stack.push(ExportStarFrame {
+                    source_index: other_source_index,
+                    next_record: 0,
+                });
+            }
         }
-
-        // Scope-end truncation (no early returns after the push).
-        self.source_index_stack.truncate(stack_end_pos - 1);
     }
 }
 
@@ -1470,9 +1554,18 @@ mod __css_validation {
             range: bun_ast::Range,
         }
 
+        /// A class (`Ref` local to the CSS file `IndexInt`) on the explicit
+        /// stack of `Visitor::visit`.
+        #[derive(Clone, Copy)]
+        enum Frame {
+            Enter(IndexInt, bun_ast::Ref),
+            Leave(IndexInt, bun_ast::Ref),
+        }
+
         struct Visitor<'a, 'bump> {
             visited: ArrayHashMap<bun_ast::Ref, ()>,
             properties: StringArrayHashMap<PropertyInFile>,
+            stack: Vec<Frame>,
             all_import_records: *mut [ImportRecordList<'bump>],
             all_css_asts: *mut [CssCol],
             all_symbols: &'a symbol::Map,
@@ -1567,63 +1660,102 @@ mod __css_validation {
                 self.properties.clear_retaining_capacity();
             }
 
-            fn visit(&mut self, idx: IndexInt, ast: &BundlerStyleSheet, r#ref: bun_ast::Ref) {
-                if self.visited.contains(&r#ref) {
-                    return;
-                }
-                self.visited.put(r#ref, ()).expect("unreachable");
+            /// Every frame names a class of a file that has a CSS AST: the root
+            /// comes from `validate_css_import_composes`, and `Enter` only
+            /// pushes classes it looked up in the composed file's AST.
+            fn css_ast(&self, idx: IndexInt) -> &'a BundlerStyleSheet {
+                col_ref!(self.all_css_asts)[idx as usize]
+                    .as_deref()
+                    .expect("composes walk only reaches files with a CSS AST")
+            }
 
-                // This local name was in a style rule that
-                if let Some(composes) = ast.composes.get(&r#ref) {
-                    for compose in composes.composes.slice_const() {
-                        // is an import
-                        if let Some(from) = compose.from.as_ref() {
-                            if let Specifier::ImportRecordIndex(import_record_idx) = from {
-                                let record = &col_ref!(self.all_import_records)[idx as usize]
-                                    .as_slice()[*import_record_idx as usize];
-                                if record.source_index.is_invalid() {
-                                    continue;
-                                }
-                                // Read-only deref — recursion may revisit the
-                                // same allocation as `ast`, so bind shared.
-                                let Some(other_ast) = col_ref!(self.all_css_asts)
-                                    [record.source_index.get() as usize]
-                                    .as_deref()
-                                else {
-                                    continue;
-                                };
-                                for name in compose.names.slice() {
-                                    let name_v = name.v();
-                                    let Some(other_name) = other_ast.local_scope.get(name_v) else {
+            /// Records the properties of `root` and of everything it
+            /// (transitively) composes, warning when two files contribute the
+            /// same property.
+            ///
+            /// Explicit-stack DFS (was recursive, one call per composed class).
+            /// `Enter` pushes the composed classes in source order followed by
+            /// its own `Leave`, then reverses that tail so they pop in source
+            /// order, each one's subtree completing before the next pops, and
+            /// `Leave` last: the recursion's postorder, which is what decides
+            /// which style rule a conflicting property is first seen in.
+            fn visit(&mut self, idx: IndexInt, root: bun_ast::Ref) {
+                debug_assert!(self.stack.is_empty());
+                self.stack.push(Frame::Enter(idx, root));
+
+                while let Some(frame) = self.stack.pop() {
+                    let (idx, r#ref) = match frame {
+                        Frame::Leave(idx, r#ref) => {
+                            self.record_properties(idx, r#ref);
+                            continue;
+                        }
+                        Frame::Enter(idx, r#ref) => (idx, r#ref),
+                    };
+
+                    if self.visited.contains(&r#ref) {
+                        continue;
+                    }
+                    self.visited.put(r#ref, ()).expect("unreachable");
+
+                    let ast = self.css_ast(idx);
+                    let mark = self.stack.len();
+                    // This local name was in a style rule that
+                    if let Some(composes) = ast.composes.get(&r#ref) {
+                        for compose in composes.composes.slice_const() {
+                            // is an import
+                            if let Some(from) = compose.from.as_ref() {
+                                if let Specifier::ImportRecordIndex(import_record_idx) = from {
+                                    let record = &col_ref!(self.all_import_records)[idx as usize]
+                                        .as_slice()
+                                        [*import_record_idx as usize];
+                                    if record.source_index.is_invalid() {
+                                        continue;
+                                    }
+                                    let other_idx = record.source_index.get();
+                                    // Read-only deref: may be the same
+                                    // allocation as `ast`, so bind shared.
+                                    let Some(other_ast) =
+                                        col_ref!(self.all_css_asts)[other_idx as usize].as_deref()
+                                    else {
                                         continue;
                                     };
-                                    let other_name_ref =
-                                        other_name.ref_.to_real_ref(record.source_index.get());
-                                    self.visit(
-                                        record.source_index.get(),
-                                        other_ast,
-                                        other_name_ref,
-                                    );
+                                    for name in compose.names.slice() {
+                                        let name_v = name.v();
+                                        let Some(other_name) = other_ast.local_scope.get(name_v)
+                                        else {
+                                            continue;
+                                        };
+                                        self.stack.push(Frame::Enter(
+                                            other_idx,
+                                            other_name.ref_.to_real_ref(other_idx),
+                                        ));
+                                    }
+                                } else {
+                                    debug_assert!(matches!(from, Specifier::Global));
+                                    // Otherwise it is composed from the global scope.
+                                    //
+                                    // See comment above for why we are skipping checking this for now.
                                 }
                             } else {
-                                debug_assert!(matches!(from, Specifier::Global));
-                                // Otherwise it is composed from the global scope.
-                                //
-                                // See comment above for why we are skipping checking this for now.
-                            }
-                        } else {
-                            // inside this file
-                            for name in compose.names.slice() {
-                                let name_v = name.v();
-                                let Some(name_entry) = ast.local_scope.get(name_v) else {
-                                    continue;
-                                };
-                                self.visit(idx, ast, name_entry.ref_.to_real_ref(idx));
+                                // inside this file
+                                for name in compose.names.slice() {
+                                    let name_v = name.v();
+                                    let Some(name_entry) = ast.local_scope.get(name_v) else {
+                                        continue;
+                                    };
+                                    self.stack
+                                        .push(Frame::Enter(idx, name_entry.ref_.to_real_ref(idx)));
+                                }
                             }
                         }
                     }
+                    self.stack.push(Frame::Leave(idx, r#ref));
+                    self.stack[mark..].reverse();
                 }
+            }
 
+            fn record_properties(&mut self, idx: IndexInt, r#ref: bun_ast::Ref) {
+                let ast = self.css_ast(idx);
                 let Some(property_usage) = ast.local_properties.get(&r#ref) else {
                     return;
                 };
@@ -1663,6 +1795,7 @@ mod __css_validation {
         let mut visitor = Visitor {
             visited: ArrayHashMap::<bun_ast::Ref, ()>::default(),
             properties: StringArrayHashMap::<PropertyInFile>::default(),
+            stack: Vec::new(),
             all_import_records: import_records_list,
             all_css_asts,
             all_symbols: &this.graph.symbols,
@@ -1673,7 +1806,7 @@ mod __css_validation {
         };
         for local in root_css_ast.local_scope.values() {
             visitor.clear_retaining_capacity();
-            visitor.visit(index, root_css_ast, local.ref_.to_real_ref(index));
+            visitor.visit(index, local.ref_.to_real_ref(index));
         }
     }
 }

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -585,6 +585,296 @@ describe("Bun.build", () => {
     expect(x.logs[0].message).toContain("Maximum call stack size exceeded while generating code for this file");
   });
 
+  // The linker's graph walks run on the bundle thread, which has a 2 MiB
+  // stack. Each walk below used to recurse once per edge and overflowed it on
+  // a long enough chain; the chains here are longer than what overflowed a
+  // debug build. Bun.build() runs in a child process so that an overflow shows
+  // up as a signal exit instead of taking down the test runner. The long
+  // chains build in well under a second on a release build but take 5-20s on
+  // a debug build with ASAN (more when the tests run concurrently), hence the
+  // timeout.
+  const deepGraphTimeout = 120_000;
+  const deepGraphBuildScript = `
+    import { basename } from "path";
+    const { entrypoints, ...options } = JSON.parse(process.argv[2]);
+    const result = await Bun.build({
+      ...options,
+      entrypoints: entrypoints.map(entry => import.meta.dir + "/" + entry),
+      outdir: import.meta.dir + "/out",
+      throw: false,
+    });
+    console.log(
+      JSON.stringify({
+        success: result.success,
+        outputs: result.outputs.length,
+        logs: result.logs.map(log => ({
+          message: log.message,
+          file: log.position && basename(log.position.file),
+          lineText: log.position?.lineText,
+          notes: (log.notes ?? []).map(note => ({
+            message: note.message,
+            file: note.position && basename(note.position.file),
+          })),
+        })),
+        entryText: result.success ? await result.outputs[0].text() : undefined,
+      }),
+    );
+  `;
+
+  interface DeepGraphBuildResult {
+    success: boolean;
+    outputs: number;
+    logs: {
+      message: string;
+      file: string | null;
+      lineText: string | undefined;
+      notes: { message: string; file: string | null }[];
+    }[];
+    entryText: string | undefined;
+  }
+
+  async function buildDeepGraphInChild(
+    dir: string,
+    options: { entrypoints: string[]; splitting?: boolean },
+  ): Promise<DeepGraphBuildResult> {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build-deep-graph.ts", JSON.stringify(options)],
+      cwd: dir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(proc.signalCode).toBeNull();
+    expect(exitCode).toBe(0);
+    return JSON.parse(stdout);
+  }
+
+  function cssImportChain(length: number): Record<string, string> {
+    const files: Record<string, string> = { "build-deep-graph.ts": deepGraphBuildScript };
+    for (let i = 0; i < length; i++) {
+      files[`c${i}.css`] = (i + 1 < length ? `@import "./c${i + 1}.css";\n` : "") + `.c${i} { color: red; }\n`;
+    }
+    return files;
+  }
+
+  function cssRuleOrder(css: string): number[] {
+    return Array.from(css.matchAll(/\.c(\d+) \{/g), match => Number(match[1]));
+  }
+
+  test.concurrent(
+    "bundles a chain of 50 CSS @imports in import order",
+    async () => {
+      using dir = tempDir("build-api-css-import-chain", cssImportChain(50));
+      const result = await buildDeepGraphInChild(String(dir), { entrypoints: ["c0.css"] });
+      expect(result.logs).toEqual([]);
+      expect(result.success).toBe(true);
+      expect(result.outputs).toBe(1);
+      // Depth-first postorder: the deepest file comes first.
+      expect(cssRuleOrder(result.entryText!)).toEqual(Array.from({ length: 50 }, (_, i) => 49 - i));
+    },
+    deepGraphTimeout,
+  );
+
+  test.concurrent(
+    "a chain of 1000 CSS @imports either bundles or fails with a build error",
+    async () => {
+      // `find_imported_files_in_css_order` still recurses per @import, but it
+      // checks the remaining stack first. How deep it gets before giving up
+      // depends on the build (a debug build crashed between 300 and 400 files,
+      // a release build gets past 1000), so both outcomes are valid here; what
+      // is not is the child dying.
+      const length = 1000;
+      using dir = tempDir("build-api-css-import-chain-deep", cssImportChain(length));
+      const result = await buildDeepGraphInChild(String(dir), { entrypoints: ["c0.css"] });
+      if (result.success) {
+        expect(result.logs).toEqual([]);
+        expect(result.outputs).toBe(1);
+        expect(cssRuleOrder(result.entryText!)).toEqual(Array.from({ length }, (_, i) => length - 1 - i));
+      } else {
+        expect(result.outputs).toBe(0);
+        expect(result.logs).toEqual([
+          {
+            message: 'Maximum call stack size exceeded while following this "@import" chain',
+            file: expect.stringMatching(/^c\d+\.css$/),
+            lineText: expect.stringContaining("@import"),
+            notes: [],
+          },
+        ]);
+      }
+    },
+    deepGraphTimeout,
+  );
+
+  test.concurrent(
+    "bundles a chain of 1000 CSS module classes composing each other",
+    async () => {
+      // Both walks over the composes graph (the property conflict check in
+      // `scan_imports_and_exports` and the exports object generation in
+      // `generate_code_for_lazy_export`) used to recurse per composed class; a
+      // debug build crashed between 600 and 900 classes. Every class's export
+      // lists all the classes below it in the chain, so the output is quadratic
+      // in the chain length, which is what keeps this one shorter.
+      const length = 1000;
+      let css = "";
+      for (let i = 0; i < length; i++) {
+        css += i + 1 < length ? `.c${i} { composes: c${i + 1}; }\n` : `.c${i} { color: red; }\n`;
+      }
+      using dir = tempDir("build-api-composes-chain", {
+        "build-deep-graph.ts": deepGraphBuildScript,
+        "styles.module.css": css,
+        "entry.js": `import styles from "./styles.module.css";\nconsole.log(styles.c0);\n`,
+      });
+      const result = await buildDeepGraphInChild(String(dir), { entrypoints: ["entry.js"] });
+      expect(result.logs).toEqual([]);
+      expect(result.success).toBe(true);
+      // The JS chunk and the CSS chunk.
+      expect(result.outputs).toBe(2);
+      // c0's class list has the end of the chain first and c0 itself last.
+      expect(result.entryText).toMatch(new RegExp(`c0: "c${length - 1}_[\\w-]+ ([\\w-]+ ){${length - 2}}c0_[\\w-]+"`));
+    },
+    deepGraphTimeout,
+  );
+
+  test.concurrent(
+    "bundles a composes cycle that does not pass through the class being exported",
+    async () => {
+      // The exports object generation marked a class as visited only after
+      // walking what it composes, so while generating `.x` it went around
+      // `.b` -> `.c` -> `.b` forever (a stack overflow): the only mark set in
+      // advance was `.x`'s, which that cycle never reaches.
+      using dir = tempDir("build-api-composes-cycle", {
+        "build-deep-graph.ts": deepGraphBuildScript,
+        "styles.module.css": `.x { composes: b; }\n.b { composes: c; }\n.c { composes: b; }\n`,
+        "entry.js": `import styles from "./styles.module.css";\nconsole.log(styles.x);\n`,
+      });
+      const result = await buildDeepGraphInChild(String(dir), { entrypoints: ["entry.js"] });
+      expect(result.logs).toEqual([]);
+      expect(result.success).toBe(true);
+      expect(result.entryText).toMatch(/x: "c_[\w-]+ b_[\w-]+ x_[\w-]+"/);
+      expect(result.entryText).toMatch(/b: "c_[\w-]+ b_[\w-]+"/);
+      expect(result.entryText).toMatch(/c: "b_[\w-]+ c_[\w-]+"/);
+    },
+    deepGraphTimeout,
+  );
+
+  test.concurrent(
+    "reports a property set on both ends of a composes chain",
+    async () => {
+      // The walk records a class's properties after those of the classes it
+      // composes, so the class at the end of the chain counts as the first
+      // definition and the conflict is reported on the class composing it.
+      using dir = tempDir("build-api-composes-conflict", {
+        "build-deep-graph.ts": deepGraphBuildScript,
+        "a.module.css": `.a { composes: b from "./b.module.css"; color: red; }\n`,
+        "b.module.css": `.b { composes: c from "./c.module.css"; }\n`,
+        "c.module.css": `.c { color: blue; }\n`,
+        "entry.js": `import styles from "./a.module.css";\nconsole.log(styles.a);\n`,
+      });
+      const result = await buildDeepGraphInChild(String(dir), { entrypoints: ["entry.js"] });
+      expect(result.logs).toEqual([
+        {
+          message: "The value of color in the class a is undefined.",
+          file: "a.module.css",
+          lineText: expect.stringContaining(".a {"),
+          notes: [
+            { message: "The first definition of color is in this style rule:", file: "c.module.css" },
+            {
+              message: expect.stringContaining('The specification of "composes" does not define an order'),
+              file: null,
+            },
+          ],
+        },
+      ]);
+    },
+    deepGraphTimeout,
+  );
+
+  function exportStarChain(length: number, tail: string): Record<string, string> {
+    const files: Record<string, string> = {
+      "build-deep-graph.ts": deepGraphBuildScript,
+      "entry.js": `import { v } from "./m0.js";\nconsole.log(v);\n`,
+    };
+    for (let i = 0; i < length; i++) {
+      files[`m${i}.js`] = i + 1 < length ? `export * from "./m${i + 1}.js";\n` : tail;
+    }
+    return files;
+  }
+
+  async function runBuiltEntry(dir: string): Promise<string> {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(dir, "out", "entry.js")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return stdout;
+  }
+
+  // `ExportStarContext::add_exports` resolved `export *` recursively; a debug
+  // build crashed between 1050 and 1100 files.
+  test.concurrent(
+    "bundles a chain of 1500 `export *` re-exports",
+    async () => {
+      using dir = tempDir("build-api-export-star-chain", exportStarChain(1500, `export const v = "esm tail";\n`));
+      const result = await buildDeepGraphInChild(String(dir), { entrypoints: ["entry.js"] });
+      expect(result.logs).toEqual([]);
+      expect(result.success).toBe(true);
+      expect(await runBuiltEntry(String(dir))).toBe("esm tail\n");
+    },
+    deepGraphTimeout,
+  );
+
+  test.concurrent(
+    "bundles a chain of 1500 `export *` re-exports ending in a CommonJS module",
+    async () => {
+      // Every module in the chain gets dynamic exports from the CommonJS tail,
+      // which `DependencyWrapper` also used to discover recursively.
+      using dir = tempDir(
+        "build-api-export-star-chain-cjs",
+        exportStarChain(1500, `module.exports = { v: "cjs tail" };\n`),
+      );
+      const result = await buildDeepGraphInChild(String(dir), { entrypoints: ["entry.js"] });
+      expect(result.logs).toEqual([]);
+      expect(result.success).toBe(true);
+      expect(await runBuiltEntry(String(dir))).toBe("cjs tail\n");
+    },
+    deepGraphTimeout,
+  );
+
+  test.concurrent(
+    "bundles a chain of 2200 chunks that import each other",
+    async () => {
+      // With splitting, every import() target becomes its own chunk, and each
+      // chunk's hash covers the chunks it imports. That walk
+      // (`append_isolated_hashes_for_imported_chunks`) used to recurse per
+      // imported chunk; a debug build crashed at about 1560 chunks.
+      const length = 2200;
+      const files: Record<string, string> = {
+        "build-deep-graph.ts": deepGraphBuildScript,
+        "entry.js": `import { m0 } from "./m0.js";\nexport const entry = m0;\n`,
+      };
+      for (let i = 0; i < length; i++) {
+        files[`m${i}.js`] =
+          i + 1 < length
+            ? `export const m${i} = () => import("./m${i + 1}.js");\n`
+            : `export const m${i} = () => ${i};\n`;
+      }
+      using dir = tempDir("build-api-chunk-chain", files);
+      const result = await buildDeepGraphInChild(String(dir), { entrypoints: ["entry.js"], splitting: true });
+      expect(result.logs).toEqual([]);
+      expect(result.success).toBe(true);
+      // The entry chunk (with m0 in it), one chunk per import() target (m1 on),
+      // and the chunk with the runtime helpers that every other chunk imports.
+      expect(result.outputs).toBe(1 + (length - 1) + 1);
+    },
+    deepGraphTimeout,
+  );
+
   test.concurrent("warnings do not fail a build", async () => {
     const x = await Bun.build({
       entrypoints: [join(import.meta.dir, "./fixtures/jsx-warning/index.jsx")],


### PR DESCRIPTION
### Problem

- `Bun.build()` on a chain of CSS files where each one `@import`s the next dies with a native stack overflow once the chain is a few hundred files long (debug+ASAN: `AddressSanitizer: stack-overflow` in `find_imported_files_in_css_order::Visitor::visit`, src/bundler/linker_context/findImportedFilesInCSSOrder.rs). Release builds die between 4000 and 8000 files. Bun 1.3.14 built the same project.
- The bundle thread is spawned with Rust's default 2 MiB stack (src/bundler/BundleThread.rs:151; the Zig version had 16 MiB) and several linker walks still recurse once per graph edge. #34554 converted the JS import graph walks; these were left recursive, and each one reproduces on the current debug build (chain length at which it overflowed the 2 MiB thread in parentheses):
  - CSS `@import` order, `Visitor::visit` in findImportedFilesInCSSOrder.rs (between 300 and 400 files)
  - `export *` resolution, `ExportStarContext::add_exports` in scanImportsAndExports.rs (between 1050 and 1100 files); `DependencyWrapper::has_dynamic_exports_due_to_export_star` walks the same graph
  - chunk hashing, `LinkerContext::append_isolated_hashes_for_imported_chunks` (about 1560 chunks, with `splitting` and a chain of `import()`s)
  - CSS modules `composes`: the property conflict check in scanImportsAndExports.rs and the exports object generation in generateCodeForLazyExport.rs (between 600 and 900 classes)
  - `StaticRouteVisitor` (bake production builds) recurses per import of the route's JS import graph
- Found while testing the composes walk: generateCodeForLazyExport.rs marked a class as visited only after walking the classes it composes, so a `composes` cycle that does not pass through the class being exported (`.x { composes: b } .b { composes: c } .c { composes: b }`) recursed forever. That one crashes release builds on a three line file.
- #38862 gave the thread a 16 MiB stack and was closed: that only moves the threshold. This PR follows the direction given there.

### Fix

- `export *` (both walks), chunk hashing, both `composes` walks and `StaticRouteVisitor` become explicit-stack DFS, the pattern #34554 used: a frame per node, successors pushed in discovery order and the pushed tail reversed (or a per-frame cursor advanced one edge at a time), so nodes are visited, hashed, appended and diagnosed in exactly the order the recursion produced. Stack usage is now constant per walk; the depth lives in a `Vec`.
  - `mark_dynamic_exports_due_to_export_star`: the recursive form returned `true` through every frame on the way up and each frame marked its file, so on finding a dynamic file the whole stack is marked and drained.
  - `add_exports`: the frame stack is also the import path the recursive form kept in `source_index_stack`, used for the cycle check and the shadowing check.
  - `append_isolated_hashes_for_imported_chunks`: `Enter` / `Asset` / `Leave` frames keep the hash input byte for byte identical (imported chunks, then what the output pieces reference, then the chunk's own hash), so output hashes do not change. `chunks` is only read, so the parameter becomes `&[Chunk]` and the two per-call `collect()`s go away.
  - `generate_code_for_lazy_export`: a class is now marked on the way in. For every input that terminated before, the appended names are the same in the same order (a class could only be re-entered while still in progress through a cycle avoiding the root, and those inputs never terminated); for those cycles the walk now terminates.
  - `StaticRouteVisitor`: `result` carries a finished file's answer to the file below it; `true` finishes and caches every file on the stack, as the recursive early returns did.
- The CSS `@import` order walk stays recursive but calls `StackCheck::is_safe_to_recurse()` before following each `@import` (or cross-file `composes`) edge. When it fails, the walk is abandoned and `Maximum call stack size exceeded while following this "@import" chain` is logged on the importing file at the import; `link()` already fails the build when the log has errors after `compute_chunks` (src/bundler/LinkerContext.rs:799), so `Bun.build()` reports a `BuildMessage` and `bun build` exits 1 with a code frame. This walk threads arena-backed condition lists through the recursion (the `bitwise_copy` / `ManuallyDrop` invariants in that file), so the explicit-stack rewrite is not worth its risk for a limit that is thousands of files deep in release builds; the check is the fallback #38862's review asked for where a rewrite is impractical.
  - The check works on this thread because `BundleThread::thread_main` calls `configure_named_thread`, which initializes the per-thread stack bounds (`bun_core::output`, `StackCheck::configure_thread`); the CLI's main thread is configured in `bun_bin`. The check leaves 128 KiB (256 KiB on Windows) of headroom, which is far more than one `visit` frame plus what it calls.
  - The dev server uses the same function (`finish_from_bake_dev_server`); there the error lands in `dev.log`, which the dev server prints, and the bundle finishes with an empty order for that stylesheet instead of crashing.
- Verified with test/bundler/bun-build-api.test.ts (eight new tests; each runs `Bun.build()` in a child process so an overflow shows up as a signal). On the debug build without the src changes, six of them fail with `SIGSEGV` (the 1000-file `@import` chain, the 1000-class composes chain, the composes cycle, both 1500-file `export *` chains, the 2200-chunk chain) and the two order guards (50-file `@import` chain, composes conflict through a chain) pass; with the changes all eight pass. The `@import` test accepts either outcome because where the check trips depends on the build: the debug build reports the error at file 287, release builds bundle all 1000.
  - The `export *` tests run the bundled output (`esm tail` / `cjs tail`), the composes chain test checks the generated class list order, the conflict test checks which file is reported as the first definition (postorder), and the cycle test checks the generated class lists.
  - Also green on this build: test/bundler/esbuild/css.test.ts, css/css-modules.test.ts, esbuild/importstar.test.ts, esbuild/importstar_ts.test.ts, esbuild/default.test.ts, esbuild/splitting.test.ts, bundler_splitting.test.ts, bundler_naming.test.ts, bundler_html.test.ts, html-import-manifest.test.ts, bundler_compile_splitting.test.ts, bundler_edgecase.test.ts (includes the #34554 deep chain tests), and the rest of bun-build-api.test.ts.
  - `StaticRouteVisitor` has no new test: it only runs in bake production builds, and test/bake/dev/production.test.ts already covers both answers (a page importing a `"use client"` component gets a script tag, a page without one does not). I also built a page whose client component sits three server components deep with this branch and checked the script tag is emitted, and the all-server variant stays static; the bake production tests take about 10s each on a debug build, so I did not add that fixture to the file.
- Not changed: `add_exports` still scans the current path once per edge for the cycle check, as it did before, so the deep `export *` tests take several seconds on a debug build (the new tests have a 120s timeout; all eight take well under a second each on a release build). Also not changed: `match_import_with_export` recurses once per ambiguous `export *` alternative and loops forever on an ambiguous cycle; that is a separate bug and has been reported separately.

### Background

- **Bundle thread**: `Bun.build()` does not bundle on the JS thread; the work is queued to a single long-lived thread started in src/bundler/BundleThread.rs, and the linker (everything under src/bundler/linker_context/) runs there. `std::thread::Builder` without `stack_size` gives it 2 MiB. `bun build` from the CLI runs the same code on the main thread (8 MiB on Linux), which is why the CLI needs about four times the chain length to fail.
- **`StackCheck`** (src/bun_core/util.rs): captures the current thread's stack end (WTF's `StackBounds`, set up per thread by `configure_thread`) and `is_safe_to_recurse()` compares it with the current stack pointer; it is how the parser, printer and the JSON/TOML/YAML parsers turn deep input into an error instead of a crash. On a thread that never configured it, it always reports safe.
- **Explicit-stack DFS**: replacing recursion with a `Vec` of frames. To keep depth-first postorder (visit everything a node depends on, then the node), a node's `Enter` pushes its successors followed by its own `Leave`, then reverses that slice so the first successor pops first and `Leave` pops last; walks that must interleave side effects with the descent instead keep a cursor in the frame and handle one edge per loop iteration.
- **CSS import order**: CSS files are emitted in depth-first postorder of the `@import` graph (the deepest import first), which is what the order walk computes before the later passes dedupe repeated files. This is the walk that now reports an error when the chain is deeper than the stack allows.
- **`export *` resolution**: for every file, the linker merges the named exports of each `export * from` target (and transitively theirs) into the file's resolved exports, skipping names shadowed by a real export of any file on the path and recording names supplied by two different targets as ambiguous. Files that `export *` from something not statically analyzable (CommonJS, or an unresolved external) are marked `EsmWithDynamicFallback` and re-export at runtime instead; that marking is the first of the two `export *` walks.
- **Isolated hash**: each chunk's content hash must change when any chunk it imports changes, so the final hash of a chunk mixes in the isolated hashes of everything reachable through `cross_chunk_imports` and through the chunk/asset references in its output pieces, in a fixed order. With `splitting`, every `import()` target is its own chunk, so a chain of `import()`s is a chain of chunks.
- **`composes`** (CSS modules): a class's exported value is its own generated name preceded by the names of every class it composes, transitively, across files. The linker walks that graph twice: once to warn when two files composed together set the same property, and once to generate the exports object. Both are walks over classes, so a long chain of classes is enough to make them deep.
