### PR TITLE
dns: free connect-path lookups the full cache had no room for

### DIFF
--- a/src/codegen/generate-js2native.ts
+++ b/src/codegen/generate-js2native.ts
@@ -297,6 +297,9 @@ export function getJS2NativeRust() {
     "JS2Rust___src_runtime_dns_jsc_dns_rs__Resolver_getRuntimeDefaultResultOrderOption",
     "JS2Rust___src_runtime_dns_jsc_dns_rs__Resolver_newResolver",
     "JS2Rust___src_runtime_dns_jsc_dns_rs__internal_seedCacheForTesting",
+    "JS2Rust___src_runtime_dns_jsc_dns_rs__internal_liveRequestsForTesting",
+    "JS2Rust___src_runtime_dns_jsc_dns_rs__internal_acquireCacheEntryForTesting",
+    "JS2Rust___src_runtime_dns_jsc_dns_rs__internal_releaseCacheEntryForTesting",
   ]);
 
   const srcRoot = path.resolve(import.meta.dir, "..");

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -743,6 +743,26 @@ export const dnsCacheSeed = $newRustFunction("runtime/dns_jsc/dns.rs", "internal
   addresses: string[],
 ) => number[];
 
+export const dnsCacheInternals = {
+  /**
+   * Connect-path DNS requests currently allocated: the cached entries plus any
+   * lookup the (full) cache had no room for that is still referenced.
+   * `Bun.dns.getCacheStats().size` only counts the former.
+   */
+  liveRequests: $newRustFunction("runtime/dns_jsc/dns.rs", "internal.liveRequestsForTesting", 0) as () => number,
+  /**
+   * Hold a reference on the cache entry for `hostname`, as a connect does from
+   * its lookup until it settles. A referenced entry cannot be evicted.
+   */
+  acquire: $newRustFunction("runtime/dns_jsc/dns.rs", "internal.acquireCacheEntryForTesting", 1) as (
+    hostname: string,
+  ) => void,
+  /** Drop a reference taken by `acquire`, through the same path a settled connect releases its entry. */
+  release: $newRustFunction("runtime/dns_jsc/dns.rs", "internal.releaseCacheEntryForTesting", 1) as (
+    hostname: string,
+  ) => void,
+};
+
 export const fetchH2Internals = {
   liveCounts: $newRustFunction("http/H2Client.rs", "TestingAPIs.liveCounts", 0) as () => {
     sessions: number;

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -2204,6 +2204,9 @@ pub mod internal {
         /// Not a precise timestamp.
         pub(crate) created_at: u32,
 
+        /// Cleared once `get()` must no longer hand this request out: it
+        /// expired, a connect to its addresses failed, or it never fit in the
+        /// cache. From then on it is freed as soon as `refcount` drops to zero.
         pub(crate) valid: bool,
 
         #[cfg(target_os = "macos")]
@@ -2212,6 +2215,7 @@ pub mod internal {
 
     impl Request {
         pub(crate) fn new(key: RequestKeyOwned, refcount: u32, created_at: u32) -> *mut Self {
+            LIVE_REQUESTS.fetch_add(1, Ordering::Relaxed);
             bun_core::heap::into_raw(Box::new(Self {
                 key,
                 result: None,
@@ -2259,6 +2263,7 @@ pub mod internal {
                 // `result_buf` (Box<[ResultEntry]>) and `key.host` freed by Drop.
                 drop(bun_core::heap::take(this));
             }
+            LIVE_REQUESTS.fetch_sub(1, Ordering::Relaxed);
         }
     }
 
@@ -2616,10 +2621,11 @@ pub mod internal {
     }
 
     fn after_result_entries(req: *mut Request, results: Option<Box<[ResultEntry]>>, err: c_int) {
-        let guard = global_cache().lock();
+        let mut guard = global_cache().lock();
 
-        // SAFETY: `req` is the heap-allocated cache entry; its mutable fields are
-        // only touched under `global_cache().lock()`, which is held here.
+        // SAFETY: `req` is the heap-allocated request whose lookup just finished;
+        // its mutable fields are only touched under `global_cache().lock()`,
+        // which is held here.
         let notify = unsafe {
             // Park the owning Box on `Request.result_buf`; `RequestResult.info`
             // borrows its first element as a thin pointer for the C side.
@@ -2631,6 +2637,14 @@ pub mod internal {
             (*req).result = Some(RequestResult { info, err });
             let notify = core::mem::take(&mut (*req).notify);
             (*req).refcount -= 1;
+            if (*req).refcount == 0 && !(*req).valid {
+                // The lookup held the last reference, so no `freeaddrinfo` call
+                // is coming to apply this rule; `get()` never serves it either.
+                debug_assert!(notify.is_empty());
+                guard.remove(req);
+                Request::deinit(req);
+                return;
+            }
             notify
         };
 
@@ -2831,6 +2845,11 @@ pub mod internal {
     static DNS_CACHE_MISSES: AtomicUsize = AtomicUsize::new(0);
     static DNS_CACHE_ERRORS: AtomicUsize = AtomicUsize::new(0);
     static GETADDRINFO_CALLS: AtomicUsize = AtomicUsize::new(0);
+    /// `Request`s allocated and not yet freed. `DNS_CACHE_SIZE` only counts
+    /// the ones stored in the cache; this also counts the ones it had no room
+    /// for, so a test (via `bun:internal-for-testing`) can tell a freed request
+    /// from a leaked one.
+    static LIVE_REQUESTS: AtomicUsize = AtomicUsize::new(0);
 
     #[host_fn]
     pub(crate) fn get_dns_cache_stats(
@@ -2972,6 +2991,79 @@ pub mod internal {
         Ok(out)
     }
 
+    /// `bun:internal-for-testing`: see [`LIVE_REQUESTS`].
+    pub(crate) fn live_requests_for_testing(
+        _global: &JSGlobalObject,
+        _frame: &CallFrame,
+    ) -> JsResult<JSValue> {
+        let live = LIVE_REQUESTS.load(Ordering::Relaxed);
+        Ok(JSValue::js_number(live as f64))
+    }
+
+    fn hostname_argument_for_testing(
+        global: &JSGlobalObject,
+        frame: &CallFrame,
+    ) -> JsResult<bun::ZBox> {
+        let hostname = frame.argument(0);
+        if !hostname.is_string() {
+            return Err(global.throw_invalid_arguments(format_args!("expected (hostname: string)")));
+        }
+        let hostname_slice = hostname.to_slice(global)?;
+        Ok(bun::ZBox::from_bytes(hostname_slice.slice()))
+    }
+
+    /// `bun:internal-for-testing`: hold a reference on the cache entry for
+    /// `hostname`, as a connect does from its lookup until it settles. A
+    /// referenced entry cannot be evicted, so once every slot holds one the
+    /// next lookup for another name gets a request the cache has no room for.
+    /// Balance with [`release_cache_entry_for_testing`].
+    pub(crate) fn acquire_cache_entry_for_testing(
+        global: &JSGlobalObject,
+        frame: &CallFrame,
+    ) -> JsResult<JSValue> {
+        let hostname = hostname_argument_for_testing(global, frame)?;
+        let key = RequestKey::init(Some(hostname.as_zstr()), 0);
+        let mut guard = global_cache().lock();
+        let mut timestamp_to_store: u32 = 0;
+        let Some(entry) = guard.get(&key, &mut timestamp_to_store) else {
+            drop(guard);
+            return Err(global.throw_invalid_arguments(format_args!(
+                "{} is not in the DNS cache",
+                bstr::BStr::new(hostname.as_bytes())
+            )));
+        };
+        // SAFETY: `entry` is a live cache slot; refcount is only mutated under the held lock.
+        unsafe { (*entry).refcount += 1 };
+        Ok(JSValue::UNDEFINED)
+    }
+
+    /// `bun:internal-for-testing`: drop a reference taken by
+    /// [`acquire_cache_entry_for_testing`] through the path a settled connect
+    /// uses (`Bun__addrinfo_freeRequest`). The reference being dropped is what
+    /// keeps the entry alive between the lookup and the release.
+    pub(crate) fn release_cache_entry_for_testing(
+        global: &JSGlobalObject,
+        frame: &CallFrame,
+    ) -> JsResult<JSValue> {
+        let hostname = hostname_argument_for_testing(global, frame)?;
+        let key = RequestKey::init(Some(hostname.as_zstr()), 0);
+        let mut guard = global_cache().lock();
+        let mut timestamp_to_store: u32 = 0;
+        let entry = guard
+            .get(&key, &mut timestamp_to_store)
+            // SAFETY: `entry` is a live cache slot; refcount is only read under the held lock.
+            .filter(|entry| unsafe { (**entry).refcount > 0 });
+        drop(guard);
+        let Some(entry) = entry else {
+            return Err(global.throw_invalid_arguments(format_args!(
+                "{} has no referenced DNS cache entry",
+                bstr::BStr::new(hostname.as_bytes())
+            )));
+        };
+        freeaddrinfo(entry, 0);
+        Ok(JSValue::UNDEFINED)
+    }
+
     pub(crate) fn getaddrinfo(
         loop_: *mut Loop,
         host: Option<&ZStr>,
@@ -3033,7 +3125,13 @@ pub mod internal {
             },
         );
 
-        let _ = guard.try_push(req);
+        if !guard.try_push(req) {
+            // Every entry is referenced, so there is nothing to evict for this
+            // one. The lookup still runs for this caller, but `get()` will never
+            // find the request, so it has to go with its last reference.
+            // SAFETY: `req` was just allocated and nothing else has seen it yet.
+            unsafe { (*req).valid = false };
+        }
         DNS_CACHE_MISSES.fetch_add(1, Ordering::Relaxed);
         DNS_CACHE_SIZE.store(guard.len, Ordering::Relaxed);
         drop(guard);
@@ -6122,4 +6220,16 @@ export_host_fn!(
 export_host_fn!(
     internal::seed_cache_for_testing,
     "JS2Rust___src_runtime_dns_jsc_dns_rs__internal_seedCacheForTesting"
+);
+export_host_fn!(
+    internal::live_requests_for_testing,
+    "JS2Rust___src_runtime_dns_jsc_dns_rs__internal_liveRequestsForTesting"
+);
+export_host_fn!(
+    internal::acquire_cache_entry_for_testing,
+    "JS2Rust___src_runtime_dns_jsc_dns_rs__internal_acquireCacheEntryForTesting"
+);
+export_host_fn!(
+    internal::release_cache_entry_for_testing,
+    "JS2Rust___src_runtime_dns_jsc_dns_rs__internal_releaseCacheEntryForTesting"
 );

--- a/test/js/bun/dns/dns-prefetch.test.ts
+++ b/test/js/bun/dns/dns-prefetch.test.ts
@@ -72,3 +72,75 @@ describe("dns.prefetch", () => {
     expect(newStats2.cacheHitsCompleted).toBeGreaterThan(currentStats.cacheHitsCompleted);
   });
 });
+
+// The cache has a fixed number of slots and can only evict entries nothing
+// references. Once every slot is referenced, a lookup for another name still
+// runs, but its request never becomes an entry, and only entries used to get
+// freed: such a request leaked as soon as its last reference went away. Runs in
+// its own process because filling the cache is process-global.
+test("a lookup the full cache has no room for is freed once nothing references it", async () => {
+  const script = /* js */ `
+    const { dnsCacheSeed, dnsCacheInternals } = require("bun:internal-for-testing");
+    const { liveRequests, acquire, release } = dnsCacheInternals;
+    const misses = () => Bun.dns.getCacheStats().cacheMisses;
+    const size = () => Bun.dns.getCacheStats().size;
+
+    // Reference every entry the way a connect that has not settled yet does,
+    // until seeding (which stores entries the way a lookup does) finds nothing
+    // left to evict.
+    const held = [];
+    for (;;) {
+      const host = "held-" + held.length + ".test";
+      try {
+        dnsCacheSeed(host, ["127.0.0.1"]);
+      } catch (e) {
+        if (!e.message.includes("full")) throw e;
+        break;
+      }
+      acquire(host);
+      held.push(host);
+    }
+    const out = { held: held.length, size: { full: size() } };
+
+    // Nothing but its own lookup references a prefetch, so its request has to
+    // go as soon as the lookup lands (on the work pool, hence the wait).
+    let live = liveRequests();
+    let missed = misses();
+    Bun.dns.prefetch("localhost");
+    const deadline = Date.now() + 2_000;
+    while (liveRequests() !== live && Date.now() < deadline) await Bun.sleep(1);
+    out.prefetch = { misses: misses() - missed, leaked: liveRequests() - live };
+
+    // A connect references its request until it settles. Let it settle once the
+    // held entries have been released: the cache is then back under its
+    // high-water mark, which is when a settled request that IS an entry is kept.
+    using listener = Bun.listen({ hostname: "127.0.0.1", port: 0, socket: { data() {} } });
+    live = liveRequests();
+    missed = misses();
+    const connecting = Bun.connect({ hostname: "localhost", port: listener.port, socket: { data() {} } });
+    out.connect = { misses: misses() - missed, pending: liveRequests() - live };
+    for (const host of held) release(host);
+    out.size.released = size();
+    using socket = await connecting;
+    out.connect.leaked = liveRequests() - size() - out.prefetch.leaked;
+    console.log(JSON.stringify(out));
+  `;
+  await using proc = Bun.spawn({ cmd: [bunExe(), "-e", script], env: bunEnv, stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ out: JSON.parse(stdout.trim() || "null"), stderr, exitCode }).toEqual({
+    out: {
+      // MAX_ENTRIES in dns.rs.
+      held: 256,
+      // Releasing drops entries until the cache is under 80% full and keeps
+      // the rest.
+      size: { full: 256, released: 204 },
+      // Each lookup missed (so it allocated a request) with the cache full.
+      // Without the fix both `leaked` are 1: the prefetch's request once its
+      // lookup landed, the connect's once the connect settled.
+      prefetch: { misses: 1, leaked: 0 },
+      connect: { misses: 1, pending: 1, leaked: 0 },
+    },
+    stderr: "",
+    exitCode: 0,
+  });
+});


### PR DESCRIPTION
### Problem
- `internal::getaddrinfo()` ignores the result of `GlobalCache::try_push` (`let _ = guard.try_push(req);`, src/runtime/dns_jsc/dns.rs:3036 on main). The push fails when all 256 slots hold entries with `refcount > 0`, i.e. 256 distinct hosts each with a lookup or connect still unsettled (dns.rs:2353). The lookup still runs for the caller, but its `Request` is not in the cache.
- Only cache entries were ever freed, so such a request leaked (the `Request` box, its `result_buf` and the copied hostname) once its last reference went away:
  - `dns.prefetch()` (also used by `bun install` for registry hosts): the lookup itself holds the only reference. `after_result_entries` drops it (dns.rs:2633) and never frees anything. Same for a connect that was closed before its lookup landed.
  - `fetch()` / `Bun.connect()`: the socket releases the request through `freeaddrinfo` (dns.rs:3236), which frees an unreferenced request only while the cache is at least 80% full or the request is invalid. Otherwise the request is "kept", which for a request that is not an entry means leaked. (While the cache is still nearly full this path did free it, so the socket case is narrower than the report assumed.)
- Low severity: it takes 256 hosts referenced at the same moment, and then one small allocation leaks per lookup for as long as that lasts.

### Fix
- `getaddrinfo()` marks a request `try_push` could not store as `valid = false`. `valid == false` already means "`get()` must not serve this again; free it as soon as nothing references it" (expired entries, entries whose connect failed), and a request the cache never stored is exactly that. `freeaddrinfo` then frees it unchanged (`remove()` finds nothing, which is fine).
- `after_result_entries` applies the same rule when the lookup's own reference was the last one. That is the only point where such a request can be freed: nobody holds a reference, so no `freeaddrinfo` call is coming. With `refcount == 0` the notify list is necessarily empty (every registered waiter holds a reference until it is notified or cancels); asserted in debug builds.
- This means a prefetch's request can already be gone when `getaddrinfo()` returns to `prefetch()`. Nothing touches the pointer after the lookup is scheduled (`prefetch` discards it; `work_pool_callback`, `dns_sd_complete` and `close_for_terminate` return right after handing off to `after_result_entries`), and before this change a waiter on another thread could already free an entry at that same point through `freeaddrinfo`, so no new hazard is introduced.
- Everything else is unchanged: valid entries are still kept when their refcount reaches zero (that is what makes prefetch useful), eviction, expiry and `getCacheStats()` behave as before.
- Shape considered and not taken: a separate "is in the cache" flag set by `try_push` and checked at both release sites. It needs a second field and a third clause in `freeaddrinfo`'s condition to express the same rule `valid` already carries, so this reuses `valid` and documents that meaning on the field. Skipping the lookup outright for a prefetch that cannot be stored would also work for that caller, but the closed-before-landing connect case still needs the `after_result_entries` change, so it would be a third path rather than a replacement.
- Test hooks in `bun:internal-for-testing`, following `dnsCacheSeed` and `fetchH2Internals.liveCounts`: `dnsCacheInternals.liveRequests()` counts allocated `Request`s (cached or not), `acquire(host)` / `release(host)` take and drop a reference on an entry the way an unsettled connect holds one. Nothing else observable from JS distinguishes a leaked request from a freed one, and filling the cache needs 256 referenced entries.
- Verified:
  - test/js/bun/dns/dns-prefetch.test.ts, "a lookup the full cache has no room for is freed once nothing references it": fills the cache with 256 acquired entries, then runs a prefetch and a connect for `localhost`, releasing the held entries before the connect settles so the cache is under the 80% mark at that point. With the hooks but without the two fix hunks it reports `prefetch.leaked: 1, connect.leaked: 1`; with them it passes (3 of 3 runs, about 2s each on a debug build, almost all of it loading `bun:internal-for-testing`).
  - `bun bd test test/js/bun/dns/`: no other change (resolve-dns's `example.com` lookups fail the same way on the released binary in this container, which has no network).
  - test/internal/source-lints: all pass. `cargo clippy -p bun_runtime`: clean.

### Background
- The connect-path DNS cache is `mod internal` in src/runtime/dns_jsc/dns.rs. usockets calls `Bun__addrinfo_get` to look a host up (a miss allocates a `Request` and starts `getaddrinfo(3)` on the work pool, or a dns_sd query on macOS), `Bun__addrinfo_set` to be notified when the result lands, and `Bun__addrinfo_freeRequest` once the connect has settled. `dns.prefetch()` is a lookup with no waiter.
- The cache is a fixed array of 256 `*mut Request`. A new request is appended, or replaces an entry whose `refcount` is 0, or, in the case fixed here, is stored nowhere.
- `refcount` counts who holds the request: the in-flight lookup itself, plus each socket or QUIC connect that obtained it. `after_result_entries` drops the lookup's share when the result lands; `freeaddrinfo` drops a holder's share.
- `valid` is cleared when an entry must no longer be served (expired, or a connect to its addresses failed); an invalid entry is freed as soon as it is unreferenced. `freeaddrinfo` additionally drops unreferenced entries while the cache is at least 80% full, otherwise it keeps them for later lookups.
