### PR TITLE
CompressionStream: register a chunk's promise before its first codec step

### DIFF
--- a/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.cpp
+++ b/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.cpp
@@ -187,11 +187,11 @@ static CodecOutcome stepChunkHere(JSGlobalObject* globalObject, JSTransformStrea
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     ASSERT(stream->m_nativeStateInUse);
-    bool continuation = !!stream->m_codecPromise;
+    ASSERT(stream->m_codecPromise);
     for (;;) {
         CodecStepResult step = runStepHere(globalObject, stream, coder, input, inputLen, finish);
         RETURN_IF_EXCEPTION(scope, CodecOutcome::Failed);
-        if (continuation && !stream->m_codecPromise)
+        if (!stream->m_codecPromise)
             return CodecOutcome::Pending;
         if (!step.thrown.isEmpty()) {
             thrown = step.thrown;
@@ -236,7 +236,7 @@ static void settleCodecChunk(JSGlobalObject* globalObject, JSTransformStream* st
         resolvePromise(globalObject, promise, jsUndefined());
 }
 
-// Applies the outcome of a step that ran from a later turn to the pending chunk.
+// Applies a round of stepping to the chunk's promise.
 static void settlePendingChunk(JSGlobalObject* globalObject, JSTransformStream* stream, CodecOutcome outcome, JSValue thrown)
 {
     auto& vm = getVM(globalObject);
@@ -265,9 +265,11 @@ static JSPromise* transformChunk(JSGlobalObject* globalObject, JSTransformStream
     ASSERT(!stream->m_codecPromise);
     ASSERT(coder);
 
+    // Registered before the first step: delivering a step can run user code (an enqueue may
+    // resolve a read), and a terminal reached from there abandons the chunk through it.
+    auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
+    stream->m_codecPromise.set(vm, stream, promise);
     if (inputLen > kAsyncCodecThreshold) {
-        auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
-        stream->m_codecPromise.set(vm, stream, promise);
         stream->m_codecChunkOffThread = true;
         dispatchStepOffThread(globalObject, stream, coder, chunk, input, inputLen, finish);
         scope.assertNoException();
@@ -277,23 +279,8 @@ static JSPromise* transformChunk(JSGlobalObject* globalObject, JSTransformStream
     JSValue thrown;
     CodecOutcome outcome = stepChunkHere(globalObject, stream, coder, input, inputLen, finish, thrown);
     RETURN_IF_EXCEPTION(scope, nullptr);
-    switch (outcome) {
-    case CodecOutcome::Done:
-        RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, jsUndefined()));
-    case CodecOutcome::Failed:
-        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, thrown));
-    case CodecOutcome::DoneSinkFull: {
-        auto* ready = JSPromise::create(vm, globalObject->promiseStructure());
-        stream->m_nativeSinkReadyPromise.set(vm, stream, ready);
-        return ready;
-    }
-    case CodecOutcome::Pending: {
-        auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
-        stream->m_codecPromise.set(vm, stream, promise);
-        return promise;
-    }
-    }
-    RELEASE_ASSERT_NOT_REACHED();
+    settlePendingChunk(globalObject, stream, outcome, thrown);
+    return promise;
 }
 
 void nativeCodecContinue(JSGlobalObject* globalObject, JSTransformStream* stream)

--- a/test/js/web/streams/compression.test.ts
+++ b/test/js/web/streams/compression.test.ts
@@ -852,6 +852,39 @@ describe("bounded output per input chunk", () => {
     await expect(writer.closed).rejects.toMatchObject({ name: "AbortError" });
   });
 
+  // Delivering the first piece resolves the pending read(), and resolving a promise
+  // with an object looks up its `then`, so user code can abort from inside the
+  // chunk's very first step, before it has been parked.
+  test("writer.abort() re-entered from the chunk's first step settles the write", async () => {
+    const ds = new DecompressionStream("brotli");
+    const writer = ds.writable.getWriter();
+    const reader = ds.readable.getReader();
+    const read = reader.read();
+
+    let aborted: Promise<void> | undefined;
+    Object.defineProperty(Object.prototype, "then", {
+      configurable: true,
+      get() {
+        delete (Object.prototype as any).then;
+        aborted = writer.abort(new Error("stop"));
+        return undefined;
+      },
+    });
+    let write: Promise<void>;
+    try {
+      write = writer.write(bombs.brotli());
+      expect((await read).value!.byteLength).toBeLessThanOrEqual(kDefaultHighWaterMark);
+    } finally {
+      delete (Object.prototype as any).then;
+    }
+    expect(aborted).toBeDefined();
+
+    expect(await write).toBeUndefined();
+    await aborted;
+    await expect(writer.closed).rejects.toThrow("stop");
+    await expect(reader.read()).rejects.toThrow("stop");
+  });
+
   // An abort during close() is different: the close in progress wins, so a flush
   // being drained keeps going and the reader still gets all of it.
   test("writer.abort() during a multi-step flush does not truncate it", async () => {


### PR DESCRIPTION
Follow-up to #38695, closing the last variant of the abort hang found in its review.

### Problem
- `writer.abort()` (or `reader.cancel()`) issued from inside a chunk's first codec step leaves `write()`, `abort()` and `writer.closed` pending forever. Reaching that point takes an `Object.prototype.then` getter: enqueueing the first piece resolves the pending `read()`, and resolving a promise with an object looks up its `then`, so that getter runs synchronously inside the step loop. Not reachable from ordinary code, so this is about closing the class rather than a user report.
- Cause: `transformChunk` (src/jsc/bindings/webcore/streams/JSCompressionStreamShared.cpp) only created `m_codecPromise` after `stepChunkHere` returned `Pending`. An abandon issued during the first steps (`writableStreamStartErroring`, the source cancel algorithm) found nothing to settle, `stepChunkHere` only checked for that on continuations, and the chunk was then parked on a writable already in `erroring`, which nothing settles unless the user happens to keep reading.

### Fix
- `transformChunk` creates and stores the promise before the first step, for the on-thread path as the thread-pool path already did, and applies the outcome with the existing `settlePendingChunk`. The first call now takes exactly the continuation path: an abandon from inside a delivery resolves the promise and `stepChunkHere` stops, as it already did for later steps; otherwise Done / Failed / DoneSinkFull settle the same promise that used to be created per case, so the separate switch goes away (9 lines added, 22 removed in the file).
- Settling semantics are unchanged: `promiseFulfilledWith` / `promiseRejectedWith` were create-then-fulfill / create-then-reject of a fresh promise, which is what `settleCodecChunk` does to the pre-created one; the sink-full case moves the same promise into `m_nativeSinkReadyPromise` as before.
- Verified: new test `writer.abort() re-entered from the chunk's first step settles the write` in test/js/web/streams/compression.test.ts times out on main (the `write()` never settles; a probe confirms `abort()` was called and the first 64 KiB piece was delivered) and passes with the change; the whole file (66 tests), the vendored WPT streams suite, streams.test.js, the TextEncoderStream/TextDecoderStream tests and the node webstreams compression tests pass under `BUN_JSC_validateExceptionChecks=1`; a re-entrant `reader.cancel()` variant for brotli/gzip/zstd settles cleanly under ASAN.

### Background
- Since #38695 a native `CompressionStream`/`DecompressionStream` emits each input chunk in steps of at most `highWaterMark` bytes. When the consumer is full, the chunk's transform promise (`m_codecPromise`) stays pending, which keeps the write in flight; the consumer's pull (or the native sink's onReady) runs further steps, and whichever side goes away first (writable erroring, readable cancel, sink detach) calls `nativeCodecAbandon`, which resolves that promise so the writable can finish erroring. That protocol assumed the promise exists whenever an abandon can happen; this change makes that true for the first step as well.
