### PR TITLE
strings: size the UTF-16 to UTF-8 append output in the conversion, mark copy_utf16_into_utf8_with_utf8_len unsafe

### DIFF
--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -1666,11 +1666,38 @@ pub(crate) mod strings_impl {
         }
     }
 
-    /// Port of `convertUTF16ToUTF8Append`. Caller must reserve
-    /// `simdutf::length::utf8::from::utf16::le(utf16)` spare bytes for the fast path.
+    /// Port of `convertUTF16ToUTF8Append`: append the UTF-8 form of `utf16` to
+    /// `list`, replacing unpaired surrogates with U+FFFD. Grows `list` as
+    /// needed; [`try_convert_utf16_to_utf8_append`] reports allocation failure
+    /// instead of crashing.
     pub fn convert_utf16_to_utf8_append(list: &mut Vec<u8>, utf16: &[u16]) {
-        // SAFETY: simdutf writes only initialized bytes into the spare slice and
-        // reports the count; on SURROGATE we commit 0 and fall back below.
+        crate::handle_oom(try_convert_utf16_to_utf8_append(list, utf16))
+    }
+
+    /// [`convert_utf16_to_utf8_append`] returning `Err` instead of crashing when
+    /// the output cannot be allocated; nothing is appended in that case.
+    pub fn try_convert_utf16_to_utf8_append(
+        list: &mut Vec<u8>,
+        utf16: &[u16],
+    ) -> core::result::Result<(), ::bun_alloc::AllocError> {
+        if utf16.is_empty() {
+            return Ok(());
+        }
+        // simdutf is not told the output length: it writes the converted
+        // prefix of `utf16` (at most `length::utf8::from::utf16::le(utf16)`
+        // bytes) unconditionally, so the spare capacity must cover that before
+        // the call. The length scan is skipped when the 3-bytes-per-code-unit
+        // worst case already fits.
+        if list.capacity() - list.len() < utf16.len().saturating_mul(3) {
+            let need = simdutf::length::utf8::from::utf16::le(utf16);
+            list.try_reserve(need)
+                .map_err(|_| ::bun_alloc::AllocError)?;
+        }
+        // SAFETY: the spare slice holds at least `utf8_length_from_utf16le(utf16)`
+        // bytes (reserved just above, or implied by the 3x worst case), which
+        // bounds what simdutf writes. On success `count` is the number of bytes
+        // it initialized; on error it is an input position, so commit nothing
+        // and re-encode everything below.
         let r = unsafe {
             crate::vec::fill_spare(list, 0, |spare| {
                 let r = simdutf::simdutf__convert_utf16le_to_utf8_with_errors(
@@ -1678,24 +1705,22 @@ pub(crate) mod strings_impl {
                     utf16.len(),
                     spare.as_mut_ptr(),
                 );
-                (
-                    if r.status == simdutf::Status::SURROGATE {
-                        0
-                    } else {
-                        r.count
-                    },
-                    r,
-                )
+                (if r.is_successful() { r.count } else { 0 }, r)
             })
         };
-        if r.status == simdutf::Status::SURROGATE {
+        if !r.is_successful() {
+            // The replacement encoding spends 3 bytes on each unpaired surrogate
+            // where the length scan above counted 2, so it can exceed what was
+            // reserved; reserving it up front keeps the scalar fallback from
+            // reallocating (and from crashing on OOM).
+            list.try_reserve(element_length_utf16_into_utf8(utf16))
+                .map_err(|_| ::bun_alloc::AllocError)?;
             append_wtf8_from_utf16(list, utf16);
         }
+        Ok(())
     }
 
     pub fn convert_utf16_to_utf8(mut list: Vec<u8>, utf16: &[u16]) -> Vec<u8> {
-        let need = simdutf::length::utf8::from::utf16::le(utf16);
-        list.reserve(need + 16);
         convert_utf16_to_utf8_append(&mut list, utf16);
         list
     }
@@ -1744,8 +1769,6 @@ pub(crate) mod strings_impl {
     }
 
     pub fn to_utf8_append_to_list(list: &mut Vec<u8>, utf16: &[u16]) {
-        let need = simdutf::length::utf8::from::utf16::le(utf16);
-        list.reserve(need + 16);
         convert_utf16_to_utf8_append(list, utf16);
     }
 
@@ -1785,10 +1808,21 @@ pub(crate) mod strings_impl {
         } else {
             element_length_utf16_into_utf8(utf16)
         };
-        copy_utf16_into_utf8_with_utf8_len(buf, utf16, utf8_len)
+        // SAFETY: `utf8_len` is either the exact encoded length of `utf16` or
+        // the 3-bytes-per-code-unit worst case, which the replacement encoding
+        // never exceeds.
+        unsafe { copy_utf16_into_utf8_with_utf8_len(buf, utf16, utf8_len) }
     }
 
-    pub fn copy_utf16_into_utf8_with_utf8_len(
+    /// [`copy_utf16_into_utf8`] for callers that already computed the encoded
+    /// length and want to skip the second length scan.
+    ///
+    /// # Safety
+    /// `utf8_len` must be at least [`element_length_utf16_into_utf8`]`(utf16)`
+    /// (any larger upper bound is fine). Whenever `utf8_len <= buf.len()` the
+    /// whole conversion is written by simdutf, which is not told `buf.len()`,
+    /// so an undersized `utf8_len` lets it write past the end of `buf`.
+    pub unsafe fn copy_utf16_into_utf8_with_utf8_len(
         buf: &mut [u8],
         utf16: &[u16],
         utf8_len: usize,
@@ -1799,7 +1833,9 @@ pub(crate) mod strings_impl {
         }
         // Fast path: if buf can definitely hold the whole conversion, try simdutf.
         if utf8_len > 0 && utf8_len <= buf.len() {
-            // SAFETY: buf has `utf8_len` writable bytes; simdutf reads exactly utf16.len() u16.
+            // SAFETY: by this function's contract `utf8_len` bounds the encoded
+            // length, and `buf` holds `utf8_len` bytes; simdutf reads exactly
+            // `utf16.len()` code units.
             let r = unsafe {
                 simdutf::simdutf__convert_utf16le_to_utf8_with_errors(
                     utf16.as_ptr(),

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -1666,16 +1666,12 @@ pub(crate) mod strings_impl {
         }
     }
 
-    /// Port of `convertUTF16ToUTF8Append`: append the UTF-8 form of `utf16` to
-    /// `list`, replacing unpaired surrogates with U+FFFD. Grows `list` as
-    /// needed; [`try_convert_utf16_to_utf8_append`] reports allocation failure
-    /// instead of crashing.
+    /// Port of `convertUTF16ToUTF8Append`; unpaired surrogates become U+FFFD.
     pub fn convert_utf16_to_utf8_append(list: &mut Vec<u8>, utf16: &[u16]) {
         crate::handle_oom(try_convert_utf16_to_utf8_append(list, utf16))
     }
 
-    /// [`convert_utf16_to_utf8_append`] returning `Err` instead of crashing when
-    /// the output cannot be allocated; nothing is appended in that case.
+    /// [`convert_utf16_to_utf8_append`] that reports allocation failure instead of crashing.
     pub fn try_convert_utf16_to_utf8_append(
         list: &mut Vec<u8>,
         utf16: &[u16],
@@ -1683,21 +1679,17 @@ pub(crate) mod strings_impl {
         if utf16.is_empty() {
             return Ok(());
         }
-        // simdutf is not told the output length: it writes the converted
-        // prefix of `utf16` (at most `length::utf8::from::utf16::le(utf16)`
-        // bytes) unconditionally, so the spare capacity must cover that before
-        // the call. The length scan is skipped when the 3-bytes-per-code-unit
-        // worst case already fits.
         if list.capacity() - list.len() < utf16.len().saturating_mul(3) {
             let need = simdutf::length::utf8::from::utf16::le(utf16);
             list.try_reserve(need)
                 .map_err(|_| ::bun_alloc::AllocError)?;
         }
-        // SAFETY: the spare slice holds at least `utf8_length_from_utf16le(utf16)`
-        // bytes (reserved just above, or implied by the 3x worst case), which
-        // bounds what simdutf writes. On success `count` is the number of bytes
-        // it initialized; on error it is an input position, so commit nothing
-        // and re-encode everything below.
+        // SAFETY: simdutf is not told the output length; it writes at most
+        // `utf8_length_from_utf16le(utf16)` bytes, which the spare capacity now
+        // holds (reserved above, or implied by the 3-bytes-per-code-unit worst
+        // case). `count` is the number of bytes written only on success; on
+        // error it is an input position, so nothing is committed and the
+        // fallback below re-encodes the whole input.
         let r = unsafe {
             crate::vec::fill_spare(list, 0, |spare| {
                 let r = simdutf::simdutf__convert_utf16le_to_utf8_with_errors(
@@ -1709,10 +1701,6 @@ pub(crate) mod strings_impl {
             })
         };
         if !r.is_successful() {
-            // The replacement encoding spends 3 bytes on each unpaired surrogate
-            // where the length scan above counted 2, so it can exceed what was
-            // reserved; reserving it up front keeps the scalar fallback from
-            // reallocating (and from crashing on OOM).
             list.try_reserve(element_length_utf16_into_utf8(utf16))
                 .map_err(|_| ::bun_alloc::AllocError)?;
             append_wtf8_from_utf16(list, utf16);
@@ -1814,14 +1802,9 @@ pub(crate) mod strings_impl {
         unsafe { copy_utf16_into_utf8_with_utf8_len(buf, utf16, utf8_len) }
     }
 
-    /// [`copy_utf16_into_utf8`] for callers that already computed the encoded
-    /// length and want to skip the second length scan.
-    ///
     /// # Safety
-    /// `utf8_len` must be at least [`element_length_utf16_into_utf8`]`(utf16)`
-    /// (any larger upper bound is fine). Whenever `utf8_len <= buf.len()` the
-    /// whole conversion is written by simdutf, which is not told `buf.len()`,
-    /// so an undersized `utf8_len` lets it write past the end of `buf`.
+    /// `utf8_len` must be at least [`element_length_utf16_into_utf8`]`(utf16)`: when it is
+    /// `<= buf.len()`, simdutf writes the whole conversion without being told `buf.len()`.
     pub unsafe fn copy_utf16_into_utf8_with_utf8_len(
         buf: &mut [u8],
         utf16: &[u16],

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -2537,9 +2537,7 @@ fn decode_wtf8_one(s: &[u8]) -> (u32, usize) {
     (cp as u32, take)
 }
 
-/// `strings.toUTF8ListWithType` — append UTF-8 transcoding of `utf16` onto
-/// `list` (unpaired surrogates become U+FFFD) and return the
-/// (possibly-reallocated) list.
+/// `strings.toUTF8ListWithType`: append `utf16` as UTF-8 onto `list` and return it.
 pub fn to_utf8_list_with_type(mut list: Vec<u8>, utf16: &[u16]) -> Result<Vec<u8>, AllocError> {
     try_convert_utf16_to_utf8_append(&mut list, utf16)?;
     Ok(list)

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -2317,6 +2317,7 @@ pub use crate::strings_impl::{
     allocate_latin1_into_utf8_with_list, convert_utf16_to_utf8, convert_utf16_to_utf8_append,
     encode_wtf8_rune, is_all_ascii, latin1_to_codepoint_bytes_assume_not_ascii, narrow_ascii_u16,
     to_utf8_alloc, to_utf8_alloc_from_le_bytes, to_utf8_append_to_list, to_utf8_from_latin1,
+    try_convert_utf16_to_utf8_append,
 };
 
 #[inline]
@@ -2537,22 +2538,10 @@ fn decode_wtf8_one(s: &[u8]) -> (u32, usize) {
 }
 
 /// `strings.toUTF8ListWithType` — append UTF-8 transcoding of `utf16` onto
-/// `list` and return the (possibly-reallocated) list. Always uses the simdutf
-/// path; Bun is built with `FeatureFlags.use_simdutf = true`.
+/// `list` (unpaired surrogates become U+FFFD) and return the
+/// (possibly-reallocated) list.
 pub fn to_utf8_list_with_type(mut list: Vec<u8>, utf16: &[u16]) -> Result<Vec<u8>, AllocError> {
-    if utf16.is_empty() {
-        return Ok(list);
-    }
-    // `convert_utf16_to_utf8_append` writes directly into `spare_capacity_mut()` and
-    // requires the caller to pre-reserve (its doc says so explicitly); without this
-    // reserve a fresh `Vec::new()` has a dangling `0x1` spare pointer and simdutf
-    // segfaults writing to it. The +16 padding gives SIMD over-read slack.
-    let length = simdutf::length::utf8::from::utf16::le(utf16);
-    list.try_reserve(length + 16).map_err(|_| AllocError)?;
-    // Route through
-    // `crate::strings_impl::convert_utf16_to_utf8_append`, which replaces
-    // unpaired surrogates with U+FFFD.
-    crate::strings_impl::convert_utf16_to_utf8_append(&mut list, utf16);
+    try_convert_utf16_to_utf8_append(&mut list, utf16)?;
     Ok(list)
 }
 

--- a/src/collections/vec_ext.rs
+++ b/src/collections/vec_ext.rs
@@ -540,13 +540,7 @@ impl ByteVecExt for Vec<u8> {
     }
     fn write_utf16(&mut self, str: &[u16]) -> Result<u32, AllocError> {
         let initial = self.len();
-        let estimate = if (self.capacity() - self.len()) <= (str.len() * 3 + 2) {
-            bun_simdutf_sys::simdutf::length::utf8::from::utf16::le(str)
-        } else {
-            str.len()
-        };
-        self.reserve(estimate);
-        strings::convert_utf16_to_utf8_append(self, str);
+        strings::try_convert_utf16_to_utf8_append(self, str)?;
         Ok((self.len() - initial) as u32)
     }
     #[inline]

--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -1857,11 +1857,6 @@ impl StreamBuffer {
     }
 
     pub fn write_utf16(&mut self, buffer: &[u16]) -> Result<(), OOM> {
-        // `ByteVecExt::write_utf16` sizes the spare capacity via
-        // `simdutf.length.utf8.from.utf16.le` *before* the simdutf write;
-        // calling
-        // `convert_utf16_to_utf8_append` directly (its old shortcut) handed
-        // simdutf a `Vec::new()` dangling pointer (`0x1`) and segfaulted.
         ByteVecExt::write_utf16(&mut self.list, buffer)?;
         Ok(())
     }

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -735,6 +735,24 @@ export const stringsInternals = {
   toUTF16AllocSentinel: $newRustFunction("string/immutable/unicode.rs", "TestingAPIs.toUTF16AllocSentinel", 1) as (
     bytes: Uint8Array,
   ) => string,
+  /**
+   * Appends `units` (UTF-16 code units) as UTF-8 to a byte vector that already
+   * holds `prefix` and has exactly `spare` bytes of spare capacity, through
+   * `bun.strings.convertUTF16ToUTF8Append` (or `toUTF8ListWithType` when
+   * `fallible`). Returns the whole vector and whether the conversion had to
+   * grow it. The conversion sizes its own output starting from that spare
+   * capacity, which no JS-reachable caller lets a test control.
+   */
+  convertUTF16ToUTF8Append: $newRustFunction(
+    "string/immutable/unicode.rs",
+    "TestingAPIs.convertUTF16ToUTF8Append",
+    4,
+  ) as (
+    units: Uint16Array,
+    prefix: Uint8Array,
+    spare: number,
+    fallible: boolean,
+  ) => { bytes: Uint8Array; reallocated: boolean },
 };
 
 /** Seed the connect-path DNS cache for `hostname` via the real `process_results` interleave; returns family order. */

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -735,14 +735,7 @@ export const stringsInternals = {
   toUTF16AllocSentinel: $newRustFunction("string/immutable/unicode.rs", "TestingAPIs.toUTF16AllocSentinel", 1) as (
     bytes: Uint8Array,
   ) => string,
-  /**
-   * Appends `units` (UTF-16 code units) as UTF-8 to a byte vector that already
-   * holds `prefix` and has exactly `spare` bytes of spare capacity, through
-   * `bun.strings.convertUTF16ToUTF8Append` (or `toUTF8ListWithType` when
-   * `fallible`). Returns the whole vector and whether the conversion had to
-   * grow it. The conversion sizes its own output starting from that spare
-   * capacity, which no JS-reachable caller lets a test control.
-   */
+  /** Appends `units` as UTF-8 to a vector holding `prefix` with exactly `spare` spare bytes (`fallible`: via `toUTF8ListWithType`). */
   convertUTF16ToUTF8Append: $newRustFunction(
     "string/immutable/unicode.rs",
     "TestingAPIs.convertUTF16ToUTF8Append",

--- a/src/jsc/bun_string_jsc.rs
+++ b/src/jsc/bun_string_jsc.rs
@@ -308,4 +308,73 @@ pub mod unicode_testing_apis {
         out.deref();
         js
     }
+
+    /// `stringsInternals.convertUTF16ToUTF8Append(units, prefix, spare, fallible)`
+    /// in `internal-for-testing.ts`: appends `units` (a `Uint16Array`) as UTF-8
+    /// to a `Vec` holding `prefix` with exactly `spare` bytes of spare capacity,
+    /// via `convert_utf16_to_utf8_append` or, when `fallible`,
+    /// `to_utf8_list_with_type`. Returns `{ bytes, reallocated }`: the whole
+    /// `Vec` and whether the conversion had to grow it. The starting spare
+    /// capacity is what the conversion sizes its output from, and no caller
+    /// reachable from JS lets a test choose it.
+    pub fn convert_utf16_to_utf8_append(
+        global: &JSGlobalObject,
+        frame: &CallFrame,
+    ) -> JsResult<JSValue> {
+        let Some(units) = frame.argument(0).as_array_buffer(global) else {
+            return Err(global.throw(format_args!(
+                "convertUTF16ToUTF8Append: expected a Uint16Array"
+            )));
+        };
+        let Some(prefix) = frame.argument(1).as_array_buffer(global) else {
+            return Err(global.throw(format_args!(
+                "convertUTF16ToUTF8Append: expected a Uint8Array"
+            )));
+        };
+        let spare = frame.argument(2).to_int32();
+        if spare < 0 {
+            return Err(global.throw(format_args!(
+                "convertUTF16ToUTF8Append: expected a non-negative spare capacity"
+            )));
+        }
+        let fallible = frame.argument(3).to_boolean();
+
+        // Copy the code units out rather than viewing the array's bytes as
+        // `&[u16]`, which would depend on the view's alignment.
+        let utf16: Vec<u16> = units
+            .byte_slice()
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .map(|unit| u16::from_le_bytes(*unit))
+            .collect();
+        let prefix = prefix.byte_slice();
+
+        let mut list = Vec::with_capacity(prefix.len() + spare as usize);
+        list.extend_from_slice(prefix);
+        let capacity_before = list.capacity();
+
+        let list = if fallible {
+            match strings::to_utf8_list_with_type(list, &utf16) {
+                Ok(list) => list,
+                Err(err) => return Err(global.throw(format_args!("{err}"))),
+            }
+        } else {
+            strings::convert_utf16_to_utf8_append(&mut list, &utf16);
+            list
+        };
+
+        let result = JSValue::create_empty_object(global, 2);
+        result.put(
+            global,
+            b"bytes",
+            crate::ArrayBuffer::create_uint8_array(global, &list)?,
+        );
+        result.put(
+            global,
+            b"reallocated",
+            JSValue::js_boolean(list.capacity() != capacity_before),
+        );
+        Ok(result)
+    }
 }

--- a/src/jsc/bun_string_jsc.rs
+++ b/src/jsc/bun_string_jsc.rs
@@ -309,14 +309,7 @@ pub mod unicode_testing_apis {
         js
     }
 
-    /// `stringsInternals.convertUTF16ToUTF8Append(units, prefix, spare, fallible)`
-    /// in `internal-for-testing.ts`: appends `units` (a `Uint16Array`) as UTF-8
-    /// to a `Vec` holding `prefix` with exactly `spare` bytes of spare capacity,
-    /// via `convert_utf16_to_utf8_append` or, when `fallible`,
-    /// `to_utf8_list_with_type`. Returns `{ bytes, reallocated }`: the whole
-    /// `Vec` and whether the conversion had to grow it. The starting spare
-    /// capacity is what the conversion sizes its output from, and no caller
-    /// reachable from JS lets a test choose it.
+    /// `stringsInternals.convertUTF16ToUTF8Append` in `internal-for-testing.ts`.
     pub fn convert_utf16_to_utf8_append(
         global: &JSGlobalObject,
         frame: &CallFrame,
@@ -345,8 +338,6 @@ pub mod unicode_testing_apis {
         }
         let fallible = frame.argument(3).to_boolean();
 
-        // Copy the code units out rather than viewing the array's bytes as
-        // `&[u16]`, which would depend on the view's alignment.
         let utf16: Vec<u16> = units
             .byte_slice()
             .as_chunks::<2>()

--- a/src/jsc/bun_string_jsc.rs
+++ b/src/jsc/bun_string_jsc.rs
@@ -5,7 +5,7 @@
 use bun_core::{SliceWithUnderlyingString, String, Tag, ZigStringSlice, strings};
 
 use crate::zig_string::{self, ZigString};
-use crate::{CallFrame, JSGlobalObject, JSValue, JsError, JsResult, ZigStringJsc as _};
+use crate::{CallFrame, JSGlobalObject, JSType, JSValue, JsError, JsResult, ZigStringJsc as _};
 
 // ── extern decls ────────────────────────────────────────────────────────────
 // `JSGlobalObject` is an opaque `UnsafeCell`-backed ZST handle and `&String`/
@@ -321,15 +321,21 @@ pub mod unicode_testing_apis {
         global: &JSGlobalObject,
         frame: &CallFrame,
     ) -> JsResult<JSValue> {
-        let Some(units) = frame.argument(0).as_array_buffer(global) else {
-            return Err(global.throw(format_args!(
-                "convertUTF16ToUTF8Append: expected a Uint16Array"
-            )));
+        let units = match frame.argument(0).as_array_buffer(global) {
+            Some(units) if units.typed_array_type == JSType::Uint16Array => units,
+            _ => {
+                return Err(global.throw(format_args!(
+                    "convertUTF16ToUTF8Append: expected a Uint16Array"
+                )));
+            }
         };
-        let Some(prefix) = frame.argument(1).as_array_buffer(global) else {
-            return Err(global.throw(format_args!(
-                "convertUTF16ToUTF8Append: expected a Uint8Array"
-            )));
+        let prefix = match frame.argument(1).as_array_buffer(global) {
+            Some(prefix) if prefix.typed_array_type == JSType::Uint8Array => prefix,
+            _ => {
+                return Err(global.throw(format_args!(
+                    "convertUTF16ToUTF8Append: expected a Uint8Array"
+                )));
+            }
         };
         let spare = frame.argument(2).to_int32();
         if spare < 0 {

--- a/src/runtime/dispatch_js2native.rs
+++ b/src/runtime/dispatch_js2native.rs
@@ -43,6 +43,7 @@ pub use bun_jsc::virtual_machine_exports::Bun__setSyntheticAllocationLimitForTes
 
 pub use bun_jsc::bun_string_jsc::js_escape_reg_exp as string_escape_reg_exp_js_escape_reg_exp;
 pub use bun_jsc::bun_string_jsc::js_escape_reg_exp_for_package_name_matching as string_escape_reg_exp_js_escape_reg_exp_for_package_name_matching;
+pub use bun_jsc::bun_string_jsc::unicode_testing_apis::convert_utf16_to_utf8_append as bun_core_string_immutable_unicode_testing_ap_is_convert_utf16_to_utf8_append;
 pub use bun_jsc::bun_string_jsc::unicode_testing_apis::to_utf16_alloc_sentinel as bun_core_string_immutable_unicode_testing_ap_is_to_utf16_alloc_sentinel;
 
 pub use bun_patch_jsc::testing::patch_apply as patch_patch_testing_ap_is_apply;

--- a/src/runtime/shell/shell_body.rs
+++ b/src/runtime/shell/shell_body.rs
@@ -694,12 +694,7 @@ impl<'a> ShellSrcBuilder<'a> {
     }
 
     pub(crate) fn append_utf16_impl(&mut self, utf16: &[u16]) -> Result<(), bun_alloc::AllocError> {
-        let size = simdutf::length::utf8::from::utf16::le(utf16);
-        self.outbuf.reserve(size);
-        strings::convert_utf16_to_utf8_append(self.outbuf, utf16);
-        // Infallible: invalid UTF-16 takes the WTF-8 fallback inside the
-        // conversion, and Rust aborts on OOM.
-        Ok(())
+        strings::try_convert_utf16_to_utf8_append(self.outbuf, utf16)
     }
 
     pub(crate) fn append_utf8_impl(&mut self, utf8: &[u8]) -> Result<(), bun_alloc::AllocError> {

--- a/src/runtime/webcore/TextEncoder.rs
+++ b/src/runtime/webcore/TextEncoder.rs
@@ -97,8 +97,11 @@ fn encode16_impl(global_this: &JSGlobalObject, slice: &[u16]) -> JSValue {
         return JSValue::ZERO;
     };
     debug_assert!(array_buffer.len == need);
-    let result =
-        strings::copy_utf16_into_utf8_with_utf8_len(array_buffer.byte_slice_mut(), slice, need);
+    // SAFETY: `need` is `element_length_utf16_into_utf8(slice)`, computed above
+    // from the same `slice`.
+    let result = unsafe {
+        strings::copy_utf16_into_utf8_with_utf8_len(array_buffer.byte_slice_mut(), slice, need)
+    };
     if result.written as usize == need && result.read as usize == slice.len() {
         return uint8array;
     }

--- a/test/js/bun/util/convertUTF16ToUTF8Append.test.ts
+++ b/test/js/bun/util/convertUTF16ToUTF8Append.test.ts
@@ -1,0 +1,80 @@
+import { stringsInternals } from "bun:internal-for-testing";
+import { describe, expect, test } from "bun:test";
+
+// `bun.strings.convertUTF16ToUTF8Append` (and `toUTF8ListWithType` on top of
+// it) hands the destination's spare capacity to simdutf, which writes the
+// converted text without being told how much room there is. It used to leave
+// the sizing to its callers: appending to a fresh, empty vector wrote through
+// the vector's dangling pointer and appending to one with too little spare
+// room wrote past its allocation. It now reserves what the conversion needs
+// itself, so this drives it from every interesting starting point: no spare
+// room at all, one byte short, exactly enough, and more than the three bytes
+// per code unit worst case (where it skips the length scan). Without the
+// sizing, the fresh-vector cases crash inside simdutf on the dangling pointer
+// and the others trip the debug assertion that commits simdutf's byte count
+// into the vector.
+//
+// `reallocated` pins the sizing: the vector must grow exactly when the encoded
+// text does not fit in the spare capacity it started with.
+
+const { convertUTF16ToUTF8Append } = stringsInternals;
+
+function units(text: string): Uint16Array {
+  const out = new Uint16Array(text.length);
+  for (let i = 0; i < text.length; i++) out[i] = text.charCodeAt(i);
+  return out;
+}
+
+// Unpaired surrogates are replaced with U+FFFD, which is also what
+// `Buffer.from(text)` does, so it provides the expected bytes.
+const inputs: Record<string, string> = {
+  "empty": "",
+  "ascii": "hello, world",
+  "two-byte": "héllo wörld",
+  "three-byte": "日本語のテキスト",
+  "surrogate pairs": "😀👍🏽🎉",
+  "lone lead surrogate": "\uD800",
+  "lone trail surrogate": "\uDC00",
+  "lone surrogates between text": "a\uD800b\uDC00c😀é",
+  "lone lead surrogate at the end": "abc\uD83D",
+  // simdutf's vector loops need about 28 code units of lookahead, so short
+  // inputs only reach its scalar tail. The 1 and 2 byte mix is the case where
+  // those loops store whole vectors and rely on that lookahead to stay inside
+  // an exactly sized buffer.
+  "long 1 and 2 byte mix": "aé".repeat(50),
+  "long three-byte": "日".repeat(64),
+  "long surrogate pairs": "😀".repeat(40),
+  "long with a lone lead surrogate at the end": "aé".repeat(50) + "\uD800",
+  "long with a lone trail surrogate in the middle": "é".repeat(40) + "\uDC00" + "a".repeat(40),
+};
+
+const prefixes: Record<string, Uint8Array> = {
+  "fresh vector": new Uint8Array(0),
+  "after existing bytes": new Uint8Array(Buffer.from("prefix:")),
+};
+
+describe.each([
+  ["convertUTF16ToUTF8Append", false],
+  ["toUTF8ListWithType", true],
+])("%s", (_entryPoint, fallible) => {
+  describe.each(Object.entries(prefixes))("%s", (_state, prefix) => {
+    test.each(Object.entries(inputs))("%s", (_label, text) => {
+      const input = units(text);
+      const encoded = new Uint8Array(Buffer.from(text, "utf8"));
+      const worstCase = input.length * 3;
+      const spares = [...new Set([0, encoded.length - 1, encoded.length, encoded.length + 1, worstCase, worstCase + 5])]
+        .filter(spare => spare >= 0)
+        .sort((a, b) => a - b);
+      const expectedBytes = Buffer.concat([prefix, encoded]).toString("hex");
+
+      const results = spares.map(spare => {
+        const { bytes, reallocated } = convertUTF16ToUTF8Append(input, prefix, spare, fallible);
+        return { spare, bytes: Buffer.from(bytes).toString("hex"), reallocated };
+      });
+
+      expect(results).toEqual(
+        spares.map(spare => ({ spare, bytes: expectedBytes, reallocated: spare < encoded.length })),
+      );
+    });
+  });
+});

--- a/test/js/bun/util/convertUTF16ToUTF8Append.test.ts
+++ b/test/js/bun/util/convertUTF16ToUTF8Append.test.ts
@@ -78,3 +78,11 @@ describe.each([
     });
   });
 });
+
+test("the probe rejects arguments the table above could get wrong", () => {
+  const bytesAsUnits = new Uint8Array(4) as unknown as Uint16Array;
+  const unitsAsBytes = new Uint16Array(1) as unknown as Uint8Array;
+  expect(() => convertUTF16ToUTF8Append(bytesAsUnits, new Uint8Array(0), 0, false)).toThrow("Uint16Array");
+  expect(() => convertUTF16ToUTF8Append(units("ab"), unitsAsBytes, 0, false)).toThrow("Uint8Array");
+  expect(() => convertUTF16ToUTF8Append(units("ab"), new Uint8Array(0), -1, false)).toThrow("spare capacity");
+});


### PR DESCRIPTION
### Problem

- `bun_core::strings::convert_utf16_to_utf8_append(list, utf16)` (src/bun_core/lib.rs) is a safe function whose soundness depended on its caller: it passed `list`'s spare capacity straight to `simdutf__convert_utf16le_to_utf8_with_errors`, which writes the whole conversion without being told an output length, and never looked at how much spare capacity there was. Its doc comment asked callers to reserve first.
- Called on a `Vec::new()` it writes through the Vec's dangling pointer; called on a Vec with too little spare room it writes past the allocation. Both happened during the Rust port and were patched at the call sites: the comments removed from src/io/PipeWriter.rs and src/bun_core/string/immutable.rs describe the segfault. Every caller on main reserves correctly today, so this is an unsound safe API rather than a crash reachable from JS; it also left five call sites (shell_body.rs, vec_ext.rs, immutable.rs, and two wrappers in lib.rs) each carrying their own copy of the sizing.
- `copy_utf16_into_utf8_with_utf8_len(buf, utf16, utf8_len)` in the same file has the same shape: once `utf8_len <= buf.len()` it hands `buf` to the unchecked converter, so a caller passing an `utf8_len` that is too small for the input (but not larger than `buf`) overflows `buf`. The only guard was a `debug_assert!`, which release builds compile out. Both callers (`copy_utf16_into_utf8` and `TextEncoder.encode` in src/runtime/webcore/TextEncoder.rs) pass a correct length.

### Fix

- `convert_utf16_to_utf8_append` sizes its own output. New `try_convert_utf16_to_utf8_append` holds the implementation: if the spare capacity is below the 3-bytes-per-code-unit worst case it runs simdutf's length scan and `try_reserve`s the result, then converts; if simdutf reports an error (an unpaired surrogate) it reserves the replacement length and runs the existing scalar U+FFFD fallback. The infallible function is `handle_oom` over it. The valid-input path keeps the same `utf8_length_from_utf16le` scan every caller ran before this change; the replacement length is only computed once an unpaired surrogate has actually been found, so nothing gets more expensive for valid text.
- This is correct because the converter's documented contract is that the output needs `utf8_length_from_utf16le(input)` bytes, and on error it stops after the converted prefix. simdutf's vector kernels store whole vectors, but only while at least 12 more code units follow (their `safety_margin`), and every code unit contributes at least one byte to that length, so an exactly sized buffer is within contract; the icelake kernel uses masked stores. The worst case bound holds because that length never exceeds 3 bytes per code unit, and the fallback bound holds because `utf8_length_from_utf16le_with_replacement` is exactly what the scalar fallback writes.
- The exactly sized buffer is not a new assumption: before this change the shell's `append_utf16_impl` and (when the spare capacity was small) `ByteVecExt::write_utf16` already reserved exactly that length, `TextEncoderStreamEncoder::encode` (src/runtime/webcore/TextEncoderStreamEncoder.rs) still does in front of the same `fill_spare` call, `TextEncoder.encode` writes into a Uint8Array of exactly the encoded length, and `convert_utf16_to_utf8_in_buffer` asserts exactly `need <= out.len()`. Only two of the six callers added `+16` on top; that padding is gone.
- Cost: callers that scanned and reserved unconditionally (`convert_utf16_to_utf8`, `to_utf8_append_to_list`, `to_utf8_list_with_type`, shell `append_utf16_impl`) now scan at most once as before and skip it when the worst case already fits; `ByteVecExt::write_utf16` had this exact skip and now just delegates; shell_parser's `with_capacity(3 * len)` scratch buffer still skips the scan.
- `to_utf8_list_with_type`, `ByteVecExt::write_utf16` and the shell's `append_utf16_impl` already returned `AllocError`; they use the `try_` variant, so their `Err` is now reachable instead of the conversion aborting on OOM inside them. bun_collections no longer uses `bun_simdutf_sys` directly; the dependency line is left for a separate cleanup so this change does not touch Cargo.lock.
- `copy_utf16_into_utf8_with_utf8_len` becomes `pub unsafe fn` with a `# Safety` section (`utf8_len >= element_length_utf16_into_utf8(utf16)`). The length cannot be verified without the scan the parameter exists to skip (TextEncoder would otherwise scan large strings twice), so the requirement belongs in the signature. Its two callers get SAFETY comments; behavior is unchanged.
- Relation to #38958 (which makes the `simdutf::convert` slice wrappers `unsafe fn` and lists these two functions as out of its scope): the two PRs are independent. This one keeps calling the `simdutf__convert_utf16le_to_utf8_with_errors` extern directly, which #38958 leaves as is, and #38958's `convert_utf16_to_utf8_in_buffer` calls the safe `copy_utf16_into_utf8`, which stays safe here. Merging #38958's head (419a46f) into this branch is conflict free and `cargo check` of bun_simdutf_sys, bun_core, bun_collections and bun_paths on the result is clean, so they can land in either order. Once both are in, the two extern calls here can move onto the wrappers and the extern can become `pub(crate)`; doing that in either PR now would make it depend on the other.
- Tests: test/js/bun/util/convertUTF16ToUTF8Append.test.ts drives the conversion through a new `stringsInternals.convertUTF16ToUTF8Append` probe in `bun:internal-for-testing` (same shape as the existing `toUTF16AllocSentinel`), because the starting spare capacity is not something any JS-reachable caller lets a test choose. For ASCII, 2 and 3 byte, surrogate pair and lone surrogate inputs, short and long enough to reach the vector kernels, it appends to a fresh Vec and after existing bytes with 0, one short, exact, one over, worst case and above worst case spare bytes, through both entry points, and checks the bytes plus that the Vec grew exactly when the encoded text did not fit. The probe only accepts a `Uint16Array` of units and a `Uint8Array` prefix; one more case covers the rejected shapes.
- Verified:
  - `bun bd test test/js/bun/util/convertUTF16ToUTF8Append.test.ts`: 57 pass. With only the reserve removed from `try_convert_utf16_to_utf8_append` and the probe kept, the fresh-Vec cases die with a SEGV writing to address 0x1 inside `utf16_to_utf8_avx512i`, and the cases with existing bytes trip the `commit_spare` assertion after simdutf wrote past the allocation (trace under details). On the released bun the probe does not exist and every case fails.
  - `bun bd test` on test/js/web/encoding/{text-encoder.test.js,text-encoder-stream.test.ts,encode-bad-chunks.test.ts}, test/js/bun/util/{toUTF16Alloc,arraybuffersink,filesink}.test.ts, test/js/bun/shell/{lex,parse}.test.ts and bunshell.test.ts `-t unicode`, and test/internal/source-lints: all pass.
  - `cargo clippy` on bun_core, bun_collections, bun_jsc: clean. rustfmt and prettier: clean.

### Background

- simdutf's `convert_utf16le_to_utf8_with_errors(input, len, out)` takes no output length. The caller promises `out` holds `utf8_length_from_utf16le(input, len)` bytes (a separate SIMD pass over the input; it counts 1 to 3 bytes per BMP code unit and 2 per surrogate code unit). The function returns either SUCCESS with the number of bytes written, or an error with the input position of the first unpaired surrogate, having written the conversion of everything before it.
- `utf8_length_from_utf16le_with_replacement` (`element_length_utf16_into_utf8` here) is the same count but charging 3 bytes per unpaired surrogate, i.e. the length of the output with U+FFFD substituted. It is at least the plain length, and at most 3 bytes per code unit.
- `bun_core::vec::fill_spare(vec, min_spare, f)` gives `f` the Vec's uninitialized spare capacity as `&mut [u8]` and then advances the length by the byte count `f` returns. Debug builds assert that count fits in the spare capacity, which is what the prefixed test cases tripped without the fix.
- A Rust `unsafe fn` is one whose caller must uphold a condition the compiler cannot check; the `# Safety` section states it and each call site records why it holds. `bun_core::handle_oom` turns an `Err(AllocError)` into Bun's out-of-memory crash, which is how the infallible entry point is built on the fallible one.

<details>
<summary>Failure without the sizing (reserve removed, probe kept), debug ASAN build</summary>

```
==27331==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000001
==27331==The signal is caused by a WRITE memory access.
    #0 simdutf::icelake::(anonymous namespace)::utf16_to_utf8_avx512i<(simdutf::endianness)0> simdutf_impl.cpp.h:24753
    #1 simdutf::icelake::implementation::convert_utf16le_to_utf8_with_errors
    #2 simdutf::convert_utf16le_to_utf8_with_errors
    #3 simdutf__convert_utf16le_to_utf8_with_errors src/simdutf_sys/bun-simdutf.cpp:81
    #4 bun_core::strings_impl::try_convert_utf16_to_utf8_append::{closure#0} src/bun_core/lib.rs
    #5 bun_core::vec::fill_spare
    #6 bun_core::strings_impl::try_convert_utf16_to_utf8_append
    #7 bun_core::strings_impl::convert_utf16_to_utf8_append
    #8 bun_jsc::bun_string_jsc::unicode_testing_apis::convert_utf16_to_utf8_append
```

Running only the "after existing bytes" cases:

```
panic: assertion failed: n <= v.capacity() - v.len()
```

(`bun_core::vec::commit_spare`, reached from `fill_spare` after simdutf wrote the 12 encoded bytes into a 7 byte allocation with no spare capacity.)

</details>

