### PR TITLE
install: keep linking the remaining bins when one bin or one dependency's bins fail to link

### DIFF
--- a/src/install/bin.rs
+++ b/src/install/bin.rs
@@ -831,6 +831,8 @@ pub struct Linker<'a> {
     pub abs_dest_buf: &'a mut [u8],
     pub rel_buf: &'a mut [u8],
 
+    /// First error hit while linking this package's bins. The bins after the
+    /// failing one are still linked.
     pub err: Option<Error>,
     pub skipped_due_to_missing_bin: bool,
 }
@@ -925,29 +927,38 @@ impl<'a> Linker<'a> {
 
         bun_core::analytics::Features::binlinks_inc();
 
+        #[cfg(windows)]
+        let target = match sys::File::openat(Fd::cwd(), abs_target, sys::O::RDONLY, 0) {
+            Ok(f) => f,
+            Err(err) => {
+                let err: crate::Error = err.into();
+                if err != crate::Error::Sys(bun_errno::SystemErrno::EISDIR) {
+                    // ignore directories, creating a shim for one won't do anything
+                    self.err = Some(err);
+                }
+                return;
+            }
+        };
+
+        // Only this bin's outcome decides whether the link just made is kept.
+        let prior_err = self.err.take();
         #[cfg(not(windows))]
         {
             self.create_symlink(abs_target, abs_dest, global);
         }
         #[cfg(windows)]
         {
-            let target = match sys::File::openat(Fd::cwd(), abs_target, sys::O::RDONLY, 0) {
-                Ok(f) => f,
-                Err(err) => {
-                    let err: crate::Error = err.into();
-                    if err != crate::Error::Sys(bun_errno::SystemErrno::EISDIR) {
-                        // ignore directories, creating a shim for one won't do anything
-                        self.err = Some(err);
-                    }
-                    return;
-                }
-            };
             self.create_windows_shim(&target, abs_target, abs_dest, global);
         }
+        let err = self.err;
+        self.err = prior_err.or(err);
 
-        if self.err.is_some() {
+        if err.is_some() {
             // cleanup on error just in case
             Self::unlink_bin_or_shim(abs_dest);
+            if let Some(seen) = self.seen.as_deref_mut() {
+                seen.remove(abs_dest.as_bytes());
+            }
             return;
         }
 

--- a/src/install/bin.rs
+++ b/src/install/bin.rs
@@ -831,8 +831,6 @@ pub struct Linker<'a> {
     pub abs_dest_buf: &'a mut [u8],
     pub rel_buf: &'a mut [u8],
 
-    /// First error hit while linking this package's bins. The bins after the
-    /// failing one are still linked.
     pub err: Option<Error>,
     pub skipped_due_to_missing_bin: bool,
 }
@@ -927,19 +925,6 @@ impl<'a> Linker<'a> {
 
         bun_core::analytics::Features::binlinks_inc();
 
-        #[cfg(windows)]
-        let target = match sys::File::openat(Fd::cwd(), abs_target, sys::O::RDONLY, 0) {
-            Ok(f) => f,
-            Err(err) => {
-                let err: crate::Error = err.into();
-                if err != crate::Error::Sys(bun_errno::SystemErrno::EISDIR) {
-                    // ignore directories, creating a shim for one won't do anything
-                    self.err = Some(err);
-                }
-                return;
-            }
-        };
-
         // Only this bin's outcome decides whether the link just made is kept.
         let prior_err = self.err.take();
         #[cfg(not(windows))]
@@ -948,7 +933,16 @@ impl<'a> Linker<'a> {
         }
         #[cfg(windows)]
         {
-            self.create_windows_shim(&target, abs_target, abs_dest, global);
+            match sys::File::openat(Fd::cwd(), abs_target, sys::O::RDONLY, 0) {
+                Ok(target) => self.create_windows_shim(&target, abs_target, abs_dest, global),
+                Err(err) => {
+                    let err: crate::Error = err.into();
+                    // ignore directories, creating a shim for one won't do anything
+                    if err != crate::Error::Sys(bun_errno::SystemErrno::EISDIR) {
+                        self.err = Some(err);
+                    }
+                }
+            }
         }
         let err = self.err;
         self.err = prior_err.or(err);

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -1878,6 +1878,8 @@ impl Task {
                         bin_linker.target_node_modules_path = bin_linker.node_modules_path;
                         bin_linker.target_package_name =
                             strings::StringOrTinyString::init(dep_name);
+                        bin_linker.err = None;
+                        bin_linker.skipped_due_to_missing_bin = false;
 
                         if manager_ref.options.log_level.is_verbose() {
                             bun_core::pretty_errorln!(
@@ -2443,6 +2445,8 @@ impl<'a> Installer<'a> {
             {
                 bin_linker.target_node_modules_path = bin_linker.node_modules_path;
                 bin_linker.target_package_name = package_name;
+                bin_linker.err = None;
+                bin_linker.skipped_due_to_missing_bin = false;
 
                 if self.manager().options.log_level.is_verbose() {
                     bun_core::pretty_errorln!(

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -701,8 +701,6 @@ pub struct DownloadError {
     pub(crate) url: Box<[u8]>,
 }
 
-/// One dependency whose bins could not be linked into the failing entry's
-/// `node_modules/.bin`.
 #[derive(Clone, Copy)]
 pub struct DependencyBinariesError {
     pub(crate) dep_entry_id: StoreEntryId,
@@ -713,11 +711,7 @@ pub enum TaskError {
     LinkPackage(sys::Error),
     SymlinkDependencies(sys::Error),
     RunScripts(crate::Error),
-    /// The entry's own bins (`Step::Binaries`).
     Binaries(crate::Error),
-    /// Bins of the entry's dependencies (`Step::SymlinkDependencyBinaries`).
-    /// Every dependency is attempted before the step fails, so this holds
-    /// one error per dependency that failed; never empty.
     DependencyBinaries(Box<[DependencyBinariesError]>),
     Patching(Log),
     Download(DownloadError),
@@ -2335,9 +2329,6 @@ impl<'a> Installer<'a> {
         Ok(changed)
     }
 
-    /// Links the bins of every dependency of `parent_entry_id` into its
-    /// `node_modules/.bin`. A dependency that fails does not stop the rest from
-    /// being linked; the failures are returned together afterwards.
     pub(crate) fn link_dependency_bins(
         &self,
         parent_entry_id: StoreEntryId,

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -375,6 +375,23 @@ impl<'a> Installer<'a> {
                     ),
                 );
             }
+            TaskError::DependencyBinaries(dep_errs) => {
+                for dep_err in dep_errs.iter() {
+                    let dep_node_id = entry_node_ids[dep_err.dep_entry_id.get() as usize];
+                    let dep_pkg_id = node_pkg_ids[dep_node_id.get() as usize];
+                    Output::err(
+                        dep_err.err,
+                        "failed to link binaries of dependency {}@{} for package: {}@{}",
+                        (
+                            bstr::BStr::new(pkg_names[dep_pkg_id as usize].slice(string_buf)),
+                            pkg_resolutions[dep_pkg_id as usize]
+                                .fmt(string_buf, bun_core::fmt::PathSep::Auto),
+                            bstr::BStr::new(pkg_name.slice(string_buf)),
+                            pkg_res.fmt(string_buf, bun_core::fmt::PathSep::Auto),
+                        ),
+                    );
+                }
+            }
             TaskError::Download(dl) => {
                 Output::err_generic(
                     "failed to download <b>{}@{}<r>: {}\n  <d>{}<r>",
@@ -684,11 +701,24 @@ pub struct DownloadError {
     pub(crate) url: Box<[u8]>,
 }
 
+/// One dependency whose bins could not be linked into the failing entry's
+/// `node_modules/.bin`.
+#[derive(Clone, Copy)]
+pub struct DependencyBinariesError {
+    pub(crate) dep_entry_id: StoreEntryId,
+    pub(crate) err: crate::Error,
+}
+
 pub enum TaskError {
     LinkPackage(sys::Error),
     SymlinkDependencies(sys::Error),
     RunScripts(crate::Error),
+    /// The entry's own bins (`Step::Binaries`).
     Binaries(crate::Error),
+    /// Bins of the entry's dependencies (`Step::SymlinkDependencyBinaries`).
+    /// Every dependency is attempted before the step fails, so this holds
+    /// one error per dependency that failed; never empty.
+    DependencyBinaries(Box<[DependencyBinariesError]>),
     Patching(Log),
     Download(DownloadError),
 }
@@ -699,6 +729,7 @@ impl TaskError {
             TaskError::LinkPackage(err) => TaskError::LinkPackage(err.clone()),
             TaskError::SymlinkDependencies(err) => TaskError::SymlinkDependencies(err.clone()),
             TaskError::Binaries(err) => TaskError::Binaries(*err),
+            TaskError::DependencyBinaries(errs) => TaskError::DependencyBinaries(errs.clone()),
             TaskError::RunScripts(err) => TaskError::RunScripts(*err),
             TaskError::Patching(_log) => {
                 // `bun_ast::Log` is non-Clone; the only caller of
@@ -1555,7 +1586,7 @@ impl Task {
                 Step::SymlinkDependencyBinaries => {
                     let current_step = Step::SymlinkDependencyBinaries;
                     if let Err(err) = installer.link_dependency_bins(self.entry_id) {
-                        return Ok(Yield::failure(TaskError::Binaries(err)));
+                        return Ok(Yield::failure(err));
                     }
 
                     match pkg_res.tag {
@@ -2304,7 +2335,13 @@ impl<'a> Installer<'a> {
         Ok(changed)
     }
 
-    pub(crate) fn link_dependency_bins(&self, parent_entry_id: StoreEntryId) -> crate::Result<()> {
+    /// Links the bins of every dependency of `parent_entry_id` into its
+    /// `node_modules/.bin`. A dependency that fails does not stop the rest from
+    /// being linked; the failures are returned together afterwards.
+    pub(crate) fn link_dependency_bins(
+        &self,
+        parent_entry_id: StoreEntryId,
+    ) -> core::result::Result<(), TaskError> {
         let lockfile = self.lockfile();
         let store = self.store;
 
@@ -2331,6 +2368,7 @@ impl<'a> Installer<'a> {
         let mut link_rel_buf = paths::path_buffer_pool::get();
 
         let mut seen: StringHashMap<()> = StringHashMap::default();
+        let mut failed: Vec<DependencyBinariesError> = Vec::new();
 
         let mut node_modules_path = DefaultAbsPath::init_top_level_dir();
         self.append_real_store_node_modules_path(
@@ -2427,11 +2465,17 @@ impl<'a> Installer<'a> {
             }
 
             if let Some(err) = bin_linker.err {
-                return Err(err);
+                failed.push(DependencyBinariesError {
+                    dep_entry_id: dep.entry_id,
+                    err,
+                });
             }
         }
 
-        Ok(())
+        if failed.is_empty() {
+            return Ok(());
+        }
+        Err(TaskError::DependencyBinaries(failed.into_boxed_slice()))
     }
 
     /// True when this entry should live in the shared global virtual store

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -2521,6 +2521,40 @@ test("--production without a lockfile will install and not save lockfile", async
 });
 
 describe("binaries", () => {
+  test("a bin that fails to link does not stop the remaining bins of the package from being linked", async () => {
+    // Longer than a file name may be, so creating the link itself fails. It is
+    // the first of the package's bins, both as declared and sorted.
+    const longBinName = Buffer.alloc(300, "a").toString();
+    await Promise.all([
+      write(packageJson, JSON.stringify({ name: "foo", dependencies: { "multi-bin": "file:./multi-bin" } })),
+      write(
+        join(packageDir, "multi-bin", "package.json"),
+        JSON.stringify({
+          name: "multi-bin",
+          version: "1.0.0",
+          bin: { [longBinName]: "cli.js", "multi-b": "cli.js", "multi-c": "cli.js" },
+        }),
+      ),
+      write(join(packageDir, "multi-bin", "cli.js"), "#!/usr/bin/env node\nconsole.log('multi');\n"),
+    ]);
+
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(await readdirSorted(join(packageDir, "node_modules", ".bin"))).toEqual(
+      isWindows ? ["multi-b.bunx", "multi-b.exe", "multi-c.bunx", "multi-c.exe"] : ["multi-b", "multi-c"],
+    );
+    expect(join(packageDir, "node_modules", ".bin", "multi-b")).toBeValidBin(join("..", "multi-bin", "cli.js"));
+    expect(stderr).toContain(`error: Failed to link multi-bin: ${isWindows ? "ENOENT" : "ENAMETOOLONG"}`);
+    expect(exitCode).toBe(1);
+  });
+
   for (const global of [false, true]) {
     describe(`existing destinations${global ? " (global)" : ""}`, () => {
       test("existing non-symlink", async () => {

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -2,7 +2,7 @@ import { file, spawn, write } from "bun";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { existsSync, lstatSync, readlinkSync, statSync } from "fs";
 import { mkdir, readlink, rm, symlink } from "fs/promises";
-import { VerdaccioRegistry, bunEnv, bunExe, readdirSorted, runBunInstall, tempDir } from "harness";
+import { VerdaccioRegistry, bunEnv, bunExe, isWindows, readdirSorted, runBunInstall, tempDir } from "harness";
 import { createRequire } from "module";
 import { dirname, join } from "path";
 
@@ -365,6 +365,77 @@ test("can install folder dependencies on root package", async () => {
     join("..", "..", "..", "node_modules", ".bun", "root-file-dep@root", "node_modules", "root-file-dep"),
     await file(packageJson).json(),
   ]);
+});
+
+test("a dependency whose bins fail to link does not stop its siblings' bins from being linked", async () => {
+  // `directories.bin` names a file, so opening it as a directory fails with
+  // ENOTDIR (a missing directory would be skipped silently).
+  const badBinDir = (name: string) => JSON.stringify({ name, version: "1.0.0", directories: { bin: "package.json" } });
+  const { packageDir } = await registry.createTestDir({
+    bunfigOpts: { linker: "isolated" },
+    files: {
+      "package.json": JSON.stringify({
+        name: "test-pkg-bin-link-errors",
+        workspaces: ["packages/*"],
+        dependencies: {
+          "a-bin": "file:./deps/a-bin",
+          "bad-bin-dir-1": "file:./deps/bad-bin-dir-1",
+          "bad-bin-dir-2": "file:./deps/bad-bin-dir-2",
+          "z-bin": "file:./deps/z-bin",
+        },
+      }),
+      "packages/ws/package.json": JSON.stringify({
+        name: "ws",
+        dependencies: {
+          "bad-bin-dir-1": "file:../../deps/bad-bin-dir-1",
+          "z-bin": "file:../../deps/z-bin",
+        },
+      }),
+      "deps/a-bin/package.json": JSON.stringify({ name: "a-bin", version: "1.0.0", bin: { "a-cli": "cli.js" } }),
+      "deps/a-bin/cli.js": "#!/usr/bin/env node\nconsole.log('a');\n",
+      "deps/z-bin/package.json": JSON.stringify({ name: "z-bin", version: "1.0.0", bin: { "z-cli": "cli.js" } }),
+      "deps/z-bin/cli.js": "#!/usr/bin/env node\nconsole.log('z');\n",
+      "deps/bad-bin-dir-1/package.json": badBinDir("bad-bin-dir-1"),
+      "deps/bad-bin-dir-2/package.json": badBinDir("bad-bin-dir-2"),
+    },
+  });
+
+  await using proc = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: packageDir,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  const linkedBin = (dir: string, name: string) =>
+    existsSync(join(dir, "node_modules", ".bin", isWindows ? `${name}.bunx` : name));
+  expect({
+    "root a-cli": linkedBin(packageDir, "a-cli"),
+    "root z-cli": linkedBin(packageDir, "z-cli"),
+    "ws z-cli": linkedBin(join(packageDir, "packages", "ws"), "z-cli"),
+  }).toEqual({
+    "root a-cli": true,
+    "root z-cli": true,
+    "ws z-cli": true,
+  });
+
+  // Every failing dependency is reported, attributed to the package whose
+  // `.bin` it could not be linked into. Tasks run in parallel, so sort.
+  const binErrors = stderr
+    .split("\n")
+    .filter(line => line.includes("failed to link binaries"))
+    .map(line => line.replaceAll("\\", "/"))
+    .sort();
+  expect(binErrors).toEqual([
+    "ENOTDIR: failed to link binaries for package: bad-bin-dir-1@deps/bad-bin-dir-1",
+    "ENOTDIR: failed to link binaries for package: bad-bin-dir-2@deps/bad-bin-dir-2",
+    "ENOTDIR: failed to link binaries of dependency bad-bin-dir-1@deps/bad-bin-dir-1 for package: test-pkg-bin-link-errors@",
+    "ENOTDIR: failed to link binaries of dependency bad-bin-dir-1@deps/bad-bin-dir-1 for package: ws@workspace:packages/ws",
+    "ENOTDIR: failed to link binaries of dependency bad-bin-dir-2@deps/bad-bin-dir-2 for package: test-pkg-bin-link-errors@",
+  ]);
+  expect(exitCode).toBe(1);
 });
 
 describe("isolated workspaces", () => {

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -407,7 +407,7 @@ test("a dependency whose bins fail to link does not stop its siblings' bins from
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   const linkedBin = (dir: string, name: string) =>
     existsSync(join(dir, "node_modules", ".bin", isWindows ? `${name}.bunx` : name));

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -367,10 +367,14 @@ test("can install folder dependencies on root package", async () => {
   ]);
 });
 
-test("a dependency whose bins fail to link does not stop its siblings' bins from being linked", async () => {
+test("a bin that fails to link does not stop the remaining bins of the package or of its siblings from being linked", async () => {
   // `directories.bin` names a file, so opening it as a directory fails with
   // ENOTDIR (a missing directory would be skipped silently).
   const badBinDir = (name: string) => JSON.stringify({ name, version: "1.0.0", directories: { bin: "package.json" } });
+  // Longer than a file name may be, so creating the link itself fails. It is
+  // the first of the package's bins, both as declared and sorted.
+  const longBinName = Buffer.alloc(300, "a").toString();
+  const longBinNameError = isWindows ? "ENOENT" : "ENAMETOOLONG";
   const { packageDir } = await registry.createTestDir({
     bunfigOpts: { linker: "isolated" },
     files: {
@@ -381,6 +385,7 @@ test("a dependency whose bins fail to link does not stop its siblings' bins from
           "a-bin": "file:./deps/a-bin",
           "bad-bin-dir-1": "file:./deps/bad-bin-dir-1",
           "bad-bin-dir-2": "file:./deps/bad-bin-dir-2",
+          "multi-bin": "file:./deps/multi-bin",
           "z-bin": "file:./deps/z-bin",
         },
       }),
@@ -397,6 +402,12 @@ test("a dependency whose bins fail to link does not stop its siblings' bins from
       "deps/z-bin/cli.js": "#!/usr/bin/env node\nconsole.log('z');\n",
       "deps/bad-bin-dir-1/package.json": badBinDir("bad-bin-dir-1"),
       "deps/bad-bin-dir-2/package.json": badBinDir("bad-bin-dir-2"),
+      "deps/multi-bin/package.json": JSON.stringify({
+        name: "multi-bin",
+        version: "1.0.0",
+        bin: { [longBinName]: "cli.js", "multi-b": "cli.js", "multi-c": "cli.js" },
+      }),
+      "deps/multi-bin/cli.js": "#!/usr/bin/env node\nconsole.log('multi');\n",
     },
   });
 
@@ -409,32 +420,40 @@ test("a dependency whose bins fail to link does not stop its siblings' bins from
   });
   const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  const linkedBin = (dir: string, name: string) =>
-    existsSync(join(dir, "node_modules", ".bin", isWindows ? `${name}.bunx` : name));
+  const binDir = async (dir: string) => {
+    const path = join(dir, "node_modules", ".bin");
+    return existsSync(path) ? await readdirSorted(path) : [];
+  };
+  const bins = (...names: string[]) => (isWindows ? names.flatMap(n => [`${n}.bunx`, `${n}.exe`]) : names).sort();
   expect({
-    "root a-cli": linkedBin(packageDir, "a-cli"),
-    "root z-cli": linkedBin(packageDir, "z-cli"),
-    "ws z-cli": linkedBin(join(packageDir, "packages", "ws"), "z-cli"),
+    root: await binDir(packageDir),
+    ws: await binDir(join(packageDir, "packages", "ws")),
+    "multi-bin's own": await binDir(join(packageDir, "node_modules", ".bun", "multi-bin@file+deps+multi-bin")),
   }).toEqual({
-    "root a-cli": true,
-    "root z-cli": true,
-    "ws z-cli": true,
+    root: bins("a-cli", "multi-b", "multi-c", "z-cli"),
+    ws: bins("z-cli"),
+    "multi-bin's own": bins("multi-b", "multi-c"),
   });
 
-  // Every failing dependency is reported, attributed to the package whose
-  // `.bin` it could not be linked into. Tasks run in parallel, so sort.
+  // Every failing package is reported once for its own `.bin` and once per
+  // package whose `.bin` it could not be linked into. Tasks run in parallel,
+  // so sort.
   const binErrors = stderr
     .split("\n")
     .filter(line => line.includes("failed to link binaries"))
     .map(line => line.replaceAll("\\", "/"))
     .sort();
-  expect(binErrors).toEqual([
-    "ENOTDIR: failed to link binaries for package: bad-bin-dir-1@deps/bad-bin-dir-1",
-    "ENOTDIR: failed to link binaries for package: bad-bin-dir-2@deps/bad-bin-dir-2",
-    "ENOTDIR: failed to link binaries of dependency bad-bin-dir-1@deps/bad-bin-dir-1 for package: test-pkg-bin-link-errors@",
-    "ENOTDIR: failed to link binaries of dependency bad-bin-dir-1@deps/bad-bin-dir-1 for package: ws@workspace:packages/ws",
-    "ENOTDIR: failed to link binaries of dependency bad-bin-dir-2@deps/bad-bin-dir-2 for package: test-pkg-bin-link-errors@",
-  ]);
+  expect(binErrors).toEqual(
+    [
+      "ENOTDIR: failed to link binaries for package: bad-bin-dir-1@deps/bad-bin-dir-1",
+      "ENOTDIR: failed to link binaries for package: bad-bin-dir-2@deps/bad-bin-dir-2",
+      `${longBinNameError}: failed to link binaries for package: multi-bin@deps/multi-bin`,
+      "ENOTDIR: failed to link binaries of dependency bad-bin-dir-1@deps/bad-bin-dir-1 for package: test-pkg-bin-link-errors@",
+      "ENOTDIR: failed to link binaries of dependency bad-bin-dir-1@deps/bad-bin-dir-1 for package: ws@workspace:packages/ws",
+      "ENOTDIR: failed to link binaries of dependency bad-bin-dir-2@deps/bad-bin-dir-2 for package: test-pkg-bin-link-errors@",
+      `${longBinNameError}: failed to link binaries of dependency multi-bin@deps/multi-bin for package: test-pkg-bin-link-errors@`,
+    ].sort(),
+  );
   expect(exitCode).toBe(1);
 });
 


### PR DESCRIPTION
### Problem
Found by reading the bin linking code while fixing #38954; there is no user report. Two places stop linking bins after the first failure and take the bins that come after it down with the failing one:

- Isolated linker, across dependencies: `Installer::link_dependency_bins` (src/install/isolated_install/Installer.rs) runs one `bin::Linker` per dependency of an entry and returned on the first linker error, so every dependency after the failing one got no link in that entry's `node_modules/.bin`. In the test below the project ends up with `a-cli` only and the workspace with no `.bin` at all. The error was reported as `ENOTDIR: failed to link binaries for package: root@`, naming the parent and not the dependency whose bins failed. The hoisted linker reports the bad package and links the rest (`PackageInstaller::link_tree_bins`).
- Both linkers, within one package: `bin::Linker::err` (src/install/bin.rs) is the error reported for the package, and `link_bin_or_create_shim` also used it, after every bin, to decide whether the link it just created should be kept. Once one bin of a `bin` map or `directories.bin` failed, each later bin of that package was created, skipped by the chmod, and unlinked again, and on a reinstall a bin that had been linked correctly before was deleted. A package with `bin: {<bad>, multi-b, multi-c}` links nothing with either linker.

### Fix
- `link_dependency_bins` attempts every dependency and collects the failures. If there were any it returns the new `TaskError::DependencyBinaries`, one `(dependency entry, error)` per failed dependency, and `on_task_fail` prints one line per entry: `ENOTDIR: failed to link binaries of dependency bad-bin-dir-1@deps/bad-bin-dir-1 for package: root@`. Continuing the loop is safe: the linker restores `node_modules_path` after appending to it, the path buffers are rebuilt by every `link()` call, and the `seen` map is per `.bin` directory on purpose. A failure of the `.bin` directory itself (say EACCES) is now reported once per dependency that has bins, which is what the hoisted linker prints too.
- The entry's task still fails after the loop, as it did before, so the isolated model is unchanged: an entry whose `.bin` is incomplete is not committed to the global store (its staging directory is removed in `on_task_fail`), the error shows up again on the next install instead of being hidden by the warm-hit path, and the install exits 1. Only the aggregation and the attribution change. `symlink_dependencies` (the `node_modules/<dep>` links) keeps failing on the first error: a package missing one of its dependencies is broken either way, and retrying the rest would not make the entry usable.
- `link_bin_or_create_shim` takes `err` out of the linker before creating the link and merges it back afterwards (the first error of the package is what stays reported), so the unlink and the chmod only look at the bin that was just attempted (on Windows this scope includes opening the target, whose failure is the other error path of the same bin). A bin that failed is also removed from `seen` and its destination unlinked, so a later package providing the same name, or the retry without the native bin link, can still create it. The two isolated retries reset `err` and `skipped_due_to_missing_bin` before calling `link()` again, which is what the hoisted linker already does by building a fresh linker for the retry; without the reset the first attempt's error would now survive a successful retry.
- Not changed: the two `return`s in the `bin` map and `directories.bin` loops for a bin name longer than the path buffer (several KiB); those lines are being reworked by #38954.
- Tests:
  - `test/cli/install/isolated-install.test.ts`: a root depending on `a-bin`, two packages whose `directories.bin` points at a file, `multi-bin` (first bin name longer than a file name may be, then `multi-b` and `multi-c`) and `z-bin`, plus a workspace depending on one bad package and `z-bin`. Asserts the full `.bin` listings of the root, the workspace and `multi-bin`'s own store entry, the seven error lines, and exit code 1. On the released build the root has `a-cli` only and the other two listings are empty.
  - `test/cli/install/bun-install-registry.test.ts` ("binaries"): the same `multi-bin` package with the hoisted linker links `multi-b` and `multi-c`, still reports `Failed to link multi-bin`, and exits 1. On the released build `.bin` is empty.
  - Both pass with this change on Linux and on Windows (where the over-long name fails with ENOENT instead of ENAMETOOLONG); the `binaries` block of the registry tests, `isolated-relink.test.ts` and `bun-install-native-binlink.test.ts` (the retry paths) pass with the debug build.

### Background
- Isolated linker layout: every package gets a store entry under `node_modules/.bun/<name>@<version>/node_modules/`, and its dependencies are symlinked into that directory. The root project and each workspace are entries too; their store `node_modules` is their own `node_modules`.
- Each entry is installed by a `Task` walking `Step`s on the thread pool. `Step::SymlinkDependencyBinaries` links the bins of the entry's dependencies into the entry's `node_modules/.bin` (for the root entry, the project's `node_modules/.bin`); `Step::Binaries` links the entry's own bins into the same directory. A step that fails returns a `TaskError`; the main thread prints it in `on_task_fail`, counts the entry as failed, and the entry's later steps (lifecycle scripts, committing a global-store entry) do not run.
- `bin::Linker` is the bin linker shared by both installers, `bun link` and `bun unlink`. One instance links one package's bins (a single file, a `bin` map, or every file of `directories.bin`) into one `.bin` directory; callers read its `err` field once afterwards. `seen` is the set of `.bin` names already claimed in that directory, so the first package providing a name wins, like npm. `directories.bin` pointing at a missing directory is skipped silently (npm does the same); any other failure to open it is an error.
- Native bin link: for packages such as esbuild the first attempt links the bin straight to the platform package; if that attempt skipped or failed, the same linker is run again against the package itself.

<details>
<summary>Repro on the released build (bun 1.4.0-canary.1)</summary>

```
deps/a-bin         bin: { "a-cli": "cli.js" }
deps/bad-bin-dir-1 directories: { bin: "package.json" }   (a file: opening it fails with ENOTDIR)
deps/bad-bin-dir-2 directories: { bin: "package.json" }
deps/multi-bin     bin: { "<300 x a>": "cli.js", "multi-b": "cli.js", "multi-c": "cli.js" }
deps/z-bin         bin: { "z-cli": "cli.js" }
package.json       depends on all five as file: deps, workspaces: ["packages/*"]
packages/ws        depends on bad-bin-dir-1 and z-bin

$ bun install --linker=isolated
ENOTDIR: failed to link binaries for package: bad-bin-dir-1@deps/bad-bin-dir-1
ENOTDIR: failed to link binaries for package: bad-bin-dir-2@deps/bad-bin-dir-2
ENAMETOOLONG: failed to link binaries for package: multi-bin@deps/multi-bin
ENOTDIR: failed to link binaries for package: ws@workspace:packages/ws
ENOTDIR: failed to link binaries for package: root@
$ ls node_modules/.bin
a-cli
$ ls packages/ws/node_modules/.bin
ls: cannot access 'packages/ws/node_modules/.bin': No such file or directory

$ bun install --linker=hoisted      (multi-bin alone)
error: Failed to link multi-bin: ENAMETOOLONG
$ ls node_modules/.bin
(empty)
```

With this change:

```
$ bun install --linker=isolated
ENOTDIR: failed to link binaries for package: bad-bin-dir-1@deps/bad-bin-dir-1
ENOTDIR: failed to link binaries for package: bad-bin-dir-2@deps/bad-bin-dir-2
ENAMETOOLONG: failed to link binaries for package: multi-bin@deps/multi-bin
ENOTDIR: failed to link binaries of dependency bad-bin-dir-1@deps/bad-bin-dir-1 for package: ws@workspace:packages/ws
ENOTDIR: failed to link binaries of dependency bad-bin-dir-1@deps/bad-bin-dir-1 for package: root@
ENOTDIR: failed to link binaries of dependency bad-bin-dir-2@deps/bad-bin-dir-2 for package: root@
ENAMETOOLONG: failed to link binaries of dependency multi-bin@deps/multi-bin for package: root@
$ ls node_modules/.bin
a-cli  multi-b  multi-c  z-cli
$ ls packages/ws/node_modules/.bin
z-cli

$ bun install --linker=hoisted      (multi-bin alone)
error: Failed to link multi-bin: ENAMETOOLONG
$ ls node_modules/.bin
multi-b  multi-c
```
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install-registry.test.ts test/cli/install/isolated-install.test.ts

<!-- robobun:evidence:end -->