### PR TITLE
bake: take JSC::JSGlobalObject* in every extern "C" entry point

### DIFF
--- a/.github/workflows/source-lints.yml
+++ b/.github/workflows/source-lints.yml
@@ -14,6 +14,8 @@ on:
     paths:
       - "src/**/*.rs"
       - "src/jsc/bindings/**"
+      - "src/runtime/bake/*.cpp"
+      - "src/runtime/bake/*.h"
       - "scripts/build/**"
       - "scripts/glob-sources.ts"
       - "scripts/utils.mjs"
@@ -29,6 +31,8 @@ on:
     paths:
       - "src/**/*.rs"
       - "src/jsc/bindings/**"
+      - "src/runtime/bake/*.cpp"
+      - "src/runtime/bake/*.h"
       - "scripts/build/**"
       - "scripts/glob-sources.ts"
       - "scripts/utils.mjs"

--- a/.github/workflows/source-lints.yml
+++ b/.github/workflows/source-lints.yml
@@ -14,8 +14,6 @@ on:
     paths:
       - "src/**/*.rs"
       - "src/jsc/bindings/**"
-      - "src/runtime/bake/*.cpp"
-      - "src/runtime/bake/*.h"
       - "scripts/build/**"
       - "scripts/glob-sources.ts"
       - "scripts/utils.mjs"
@@ -31,8 +29,6 @@ on:
     paths:
       - "src/**/*.rs"
       - "src/jsc/bindings/**"
-      - "src/runtime/bake/*.cpp"
-      - "src/runtime/bake/*.h"
       - "scripts/build/**"
       - "scripts/glob-sources.ts"
       - "scripts/utils.mjs"

--- a/src/runtime/bake/BakeGlobalObject.cpp
+++ b/src/runtime/bake/BakeGlobalObject.cpp
@@ -268,9 +268,9 @@ extern "C" GlobalObject* BakeCreateProdGlobal(void* console)
     return global;
 }
 
-extern "C" void BakeGlobalObject__attachPerThreadData(GlobalObject* global, void* perThreadData)
+extern "C" void BakeGlobalObject__attachPerThreadData(JSC::JSGlobalObject* global, void* perThreadData)
 {
-    global->m_perThreadData = perThreadData;
+    uncheckedDowncast<Bake::GlobalObject>(global)->m_perThreadData = perThreadData;
 }
 
 const JSC::ClassInfo Bake::GlobalObject::s_info = { "GlobalObject"_s, &Base::s_info, nullptr, nullptr,

--- a/src/runtime/bake/BakeGlobalObject.h
+++ b/src/runtime/bake/BakeGlobalObject.h
@@ -38,6 +38,6 @@ public:
 };
 
 extern "C" void* BakeGlobalObject__getPerThreadData(JSC::JSGlobalObject* global);
-extern "C" void BakeGlobalObject__attachPerThreadData(GlobalObject* global, void* perThreadData);
+extern "C" void BakeGlobalObject__attachPerThreadData(JSC::JSGlobalObject* global, void* perThreadData);
 
 }; // namespace Kit

--- a/src/runtime/bake/BakeSourceProvider.cpp
+++ b/src/runtime/bake/BakeSourceProvider.cpp
@@ -54,7 +54,7 @@ extern "C" JSC::EncodedJSValue BakeLoadInitialServerCode(JSC::JSGlobalObject* gl
   RELEASE_AND_RETURN(scope, JSC::JSValue::encode(JSC::profiledCall(global, JSC::ProfilingReason::API, fn, callData, JSC::jsUndefined(), args)));
 }
 
-extern "C" JSC::JSPromise* BakeLoadModuleByKey(GlobalObject* global, JSC::JSString* key) {
+extern "C" JSC::JSPromise* BakeLoadModuleByKey(JSC::JSGlobalObject* global, JSC::JSString* key) {
   return JSC::loadAndEvaluateModule(global, key->getString(global), nullptr, nullptr);
 }
 

--- a/src/runtime/bake/BakeSourceProvider.cpp
+++ b/src/runtime/bake/BakeSourceProvider.cpp
@@ -58,7 +58,7 @@ extern "C" JSC::JSPromise* BakeLoadModuleByKey(GlobalObject* global, JSC::JSStri
   return JSC::loadAndEvaluateModule(global, key->getString(global), nullptr, nullptr);
 }
 
-extern "C" JSC::EncodedJSValue BakeLoadServerHmrPatch(GlobalObject* global, BunString source) {
+extern "C" JSC::EncodedJSValue BakeLoadServerHmrPatch(JSC::JSGlobalObject* global, BunString source) {
   JSC::VM&vm = global->vm();
   auto scope = DECLARE_THROW_SCOPE(vm);
 
@@ -80,7 +80,7 @@ extern "C" JSC::EncodedJSValue BakeLoadServerHmrPatch(GlobalObject* global, BunS
   return JSC::JSValue::encode(result);
 }
 
-extern "C" JSC::EncodedJSValue BakeLoadServerHmrPatchWithSourceMap(GlobalObject* global, BunString source, const char* sourceMapJSONPtr, size_t sourceMapJSONLength) {
+extern "C" JSC::EncodedJSValue BakeLoadServerHmrPatchWithSourceMap(JSC::JSGlobalObject* global, BunString source, const char* sourceMapJSONPtr, size_t sourceMapJSONLength) {
   JSC::VM&vm = global->vm();
   auto scope = DECLARE_THROW_SCOPE(vm);
 

--- a/test/internal/source-lints/bake-global-object-ffi.test.ts
+++ b/test/internal/source-lints/bake-global-object-ffi.test.ts
@@ -40,6 +40,9 @@ const EXTERN_C_FUNCTION = /extern\s+"C"\s+[^;{}()]*?\b(\w+)\s*\(/g;
 // `Zig::GlobalObject*`, which every global satisfies.
 const BAKE_GLOBAL_PARAM = /(?<![\w:])(?:(?:::)?Bake::)?GlobalObject\s*(?:const\s*)?[*&]/;
 
+// Only the C++ side is comment-stripped (a commented-out declaration is not an
+// entry point). The Rust side is matched as-is because `// HOST_EXPORT(..)`
+// markers are themselves line comments.
 function stripLineComments(source: string): string {
   // `[ \t]*`, not `\s*`, so blank lines survive and line numbers stay right.
   return source.replace(/^[ \t]*\/\/.*$/gm, "");
@@ -52,15 +55,16 @@ function lineOf(source: string, index: number): number {
 function* readSources(dir: string, pattern: string): Generator<{ file: string; source: string }> {
   for (const rel of new Glob(pattern).scanSync({ cwd: path.join(root, dir) })) {
     const file = path.posix.join(dir, rel.replaceAll(path.sep, "/"));
-    yield { file, source: stripLineComments(readFileSync(path.join(root, file), "utf8")) };
+    yield { file, source: readFileSync(path.join(root, file), "utf8") };
   }
 }
 
 // C++ function name -> where it is declared with a `Bake::GlobalObject*` parameter.
 const declaredAt = new Map<string, string[]>();
 let scannedCxx = 0;
-for (const { file, source } of readSources(bakeDir, "*.{cpp,h}")) {
+for (const { file, source: rawSource } of readSources(bakeDir, "*.{cpp,h}")) {
   scannedCxx++;
+  const source = stripLineComments(rawSource);
   for (const m of source.matchAll(EXTERN_C_FUNCTION)) {
     const paramsStart = m.index + m[0].length;
     let depth = 1;

--- a/test/internal/source-lints/bake-global-object-ffi.test.ts
+++ b/test/internal/source-lints/bake-global-object-ffi.test.ts
@@ -3,36 +3,24 @@ import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 
-// `Bake::GlobalObject` (src/runtime/bake/BakeGlobalObject.h) is the global of a
-// `bun build --app` production build: `BakeCreateProdGlobal` is the only thing
-// that creates one, and it adds `m_perThreadData` on top of `Zig::GlobalObject`.
-// The dev server runs inside the ordinary runtime VM, whose global is a plain
-// `Zig::GlobalObject`.
+// `Bake::GlobalObject` (src/runtime/bake/BakeGlobalObject.h) only exists in a
+// `bun build --app` production build; the dev server runs in the ordinary
+// runtime VM, whose global is a plain `Zig::GlobalObject`. Rust binds every bake
+// entry point as `&JSGlobalObject`, so an `extern "C"` parameter typed
+// `GlobalObject*` (`Bake::GlobalObject*` inside `namespace Bake`) is a claim
+// about the caller that nothing checks: `BakeLoadServerHmrPatch` was declared
+// that way while only ever being called by the dev server.
 //
-// An `extern "C"` entry point in src/runtime/bake/ whose parameter is typed
-// `GlobalObject*` (`Bake::GlobalObject*`, since these files sit in
-// `namespace Bake`) therefore claims that every caller passes a production
-// global. Nothing checks that claim at the boundary: the Rust bindings all spell
-// the parameter `&JSGlobalObject`, so a dev-server caller compiles, and the C++
-// body reads a `Zig::GlobalObject` as if it were the larger `Bake::GlobalObject`.
+// The idiom in these files is to take `JSC::JSGlobalObject*` and
+// `uncheckedDowncast<Bake::GlobalObject>` inside the functions that need the
+// production-only fields (`BakeGlobalObject__getPerThreadData`), which asserts
+// the claim in debug builds. This lint keeps the signatures on that idiom.
 //
-// Motivating instance: `BakeLoadServerHmrPatch` and
-// `BakeLoadServerHmrPatchWithSourceMap` (src/runtime/bake/BakeSourceProvider.cpp)
-// took `GlobalObject*` while their only callers were in
-// src/runtime/bake/DevServer.rs. Entry points reachable from the dev server take
-// `JSC::JSGlobalObject*`, like `BakeLoadInitialServerCode` next to them.
-//
-// The lint: every bake `extern "C"` function with a `Bake::GlobalObject*`
-// parameter may only be bound (`fn Name(..)` in an extern block, `#[link_name]`,
-// or a `HOST_EXPORT` marker) from the Rust files listed below, which are the
-// ones whose global really is a production global. Recognized C++ shape: one
-// `extern "C" <ret> Name(...)` declaration or definition per function, which is
-// how every entry point in src/runtime/bake/ is written.
+// Recognized shape: one `extern "C" <ret> Name(...)` declaration or definition
+// per function, which is how every entry point in src/runtime/bake/ is written.
 
 const root = path.resolve(import.meta.dir, "..", "..", "..");
 const bakeDir = "src/runtime/bake";
-
-const PRODUCTION_GLOBAL_RUST_FILES = new Set(["src/runtime/bake/production.rs"]);
 
 const EXTERN_C_FUNCTION = /extern\s+"C"\s+[^;{}()]*?\b(\w+)\s*\(/g;
 // `GlobalObject*`, `Bake::GlobalObject*` or `::Bake::GlobalObject*` (also by
@@ -40,32 +28,18 @@ const EXTERN_C_FUNCTION = /extern\s+"C"\s+[^;{}()]*?\b(\w+)\s*\(/g;
 // `Zig::GlobalObject*`, which every global satisfies.
 const BAKE_GLOBAL_PARAM = /(?<![\w:])(?:(?:::)?Bake::)?GlobalObject\s*(?:const\s*)?[*&]/;
 
-// Only the C++ side is comment-stripped (a commented-out declaration is not an
-// entry point). The Rust side is matched as-is because `// HOST_EXPORT(..)`
-// markers are themselves line comments.
 function stripLineComments(source: string): string {
   // `[ \t]*`, not `\s*`, so blank lines survive and line numbers stay right.
   return source.replace(/^[ \t]*\/\/.*$/gm, "");
 }
 
-function lineOf(source: string, index: number): number {
-  return source.slice(0, index).split("\n").length;
-}
-
-function* readSources(dir: string, pattern: string): Generator<{ file: string; source: string }> {
-  for (const rel of new Glob(pattern).scanSync({ cwd: path.join(root, dir) })) {
-    const file = path.posix.join(dir, rel.replaceAll(path.sep, "/"));
-    yield { file, source: readFileSync(path.join(root, file), "utf8") };
-  }
-}
-
-// C++ function name -> where it is declared with a `Bake::GlobalObject*` parameter.
-const declaredAt = new Map<string, string[]>();
-let scannedCxx = 0;
-for (const { file, source: rawSource } of readSources(bakeDir, "*.{cpp,h}")) {
-  scannedCxx++;
-  const source = stripLineComments(rawSource);
+let externCFunctions = 0;
+const offenders: string[] = [];
+for (const rel of new Glob("*.{cpp,h}").scanSync({ cwd: path.join(root, bakeDir) })) {
+  const file = path.posix.join(bakeDir, rel.replaceAll(path.sep, "/"));
+  const source = stripLineComments(readFileSync(path.join(root, file), "utf8"));
   for (const m of source.matchAll(EXTERN_C_FUNCTION)) {
+    externCFunctions++;
     const paramsStart = m.index + m[0].length;
     let depth = 1;
     let i = paramsStart;
@@ -74,42 +48,18 @@ for (const { file, source: rawSource } of readSources(bakeDir, "*.{cpp,h}")) {
       else if (source[i] === ")") depth--;
     }
     if (!BAKE_GLOBAL_PARAM.test(source.slice(paramsStart, i - 1))) continue;
-    const name = m[1];
-    declaredAt.set(name, [...(declaredAt.get(name) ?? []), `${file}:${lineOf(source, m.index)}`]);
-  }
-}
-
-const names = [...declaredAt.keys()].sort();
-const offenders: string[] = [];
-const boundFromProduction: string[] = [];
-if (names.length > 0) {
-  const alternatives = names.join("|");
-  const RUST_BINDING = new RegExp(
-    String.raw`\bfn\s+(${alternatives})\s*\(|\blink_name\s*=\s*"(${alternatives})"|\bHOST_EXPORT\(\s*(${alternatives})\b`,
-    "g",
-  );
-  for (const { file, source } of readSources("src", "**/*.rs")) {
-    for (const m of source.matchAll(RUST_BINDING)) {
-      const name = m[1] ?? m[2] ?? m[3];
-      const entry = `${file}:${lineOf(source, m.index)}: ${name} (takes Bake::GlobalObject* at ${declaredAt.get(name)!.join(", ")})`;
-      (PRODUCTION_GLOBAL_RUST_FILES.has(file) ? boundFromProduction : offenders).push(entry);
-    }
+    const line = source.slice(0, m.index).split("\n").length;
+    offenders.push(`${file}:${line}: ${m[1]}`);
   }
 }
 offenders.sort();
 
-test("scans the bake C++ sources", () => {
-  expect(scannedCxx).toBeGreaterThan(0);
+test('the pattern still recognizes the bake extern "C" entry points', () => {
+  // Guards against the ban below passing because the declarations changed
+  // shape (or the directory moved) and nothing was scanned.
+  expect(externCFunctions).toBeGreaterThan(0);
 });
 
-test("the pattern still recognizes entry points that take Bake::GlobalObject*", () => {
-  // If this goes empty, either the last such entry point was retyped (then
-  // delete this lint) or the declarations no longer match EXTERN_C_FUNCTION.
-  expect(names).not.toBeEmpty();
-  // Same for the Rust side of the match: the production build binds these.
-  expect(boundFromProduction).not.toBeEmpty();
-});
-
-test("entry points that take Bake::GlobalObject* are only bound by the production build", () => {
+test('bake extern "C" entry points take JSC::JSGlobalObject*, not Bake::GlobalObject*', () => {
   expect(offenders).toEqual([]);
 });

--- a/test/internal/source-lints/bake-global-object-ffi.test.ts
+++ b/test/internal/source-lints/bake-global-object-ffi.test.ts
@@ -1,0 +1,111 @@
+import { Glob } from "bun";
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+// `Bake::GlobalObject` (src/runtime/bake/BakeGlobalObject.h) is the global of a
+// `bun build --app` production build: `BakeCreateProdGlobal` is the only thing
+// that creates one, and it adds `m_perThreadData` on top of `Zig::GlobalObject`.
+// The dev server runs inside the ordinary runtime VM, whose global is a plain
+// `Zig::GlobalObject`.
+//
+// An `extern "C"` entry point in src/runtime/bake/ whose parameter is typed
+// `GlobalObject*` (`Bake::GlobalObject*`, since these files sit in
+// `namespace Bake`) therefore claims that every caller passes a production
+// global. Nothing checks that claim at the boundary: the Rust bindings all spell
+// the parameter `&JSGlobalObject`, so a dev-server caller compiles, and the C++
+// body reads a `Zig::GlobalObject` as if it were the larger `Bake::GlobalObject`.
+//
+// Motivating instance: `BakeLoadServerHmrPatch` and
+// `BakeLoadServerHmrPatchWithSourceMap` (src/runtime/bake/BakeSourceProvider.cpp)
+// took `GlobalObject*` while their only callers were in
+// src/runtime/bake/DevServer.rs. Entry points reachable from the dev server take
+// `JSC::JSGlobalObject*`, like `BakeLoadInitialServerCode` next to them.
+//
+// The lint: every bake `extern "C"` function with a `Bake::GlobalObject*`
+// parameter may only be bound (`fn Name(..)` in an extern block, `#[link_name]`,
+// or a `HOST_EXPORT` marker) from the Rust files listed below, which are the
+// ones whose global really is a production global. Recognized C++ shape: one
+// `extern "C" <ret> Name(...)` declaration or definition per function, which is
+// how every entry point in src/runtime/bake/ is written.
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+const bakeDir = "src/runtime/bake";
+
+const PRODUCTION_GLOBAL_RUST_FILES = new Set(["src/runtime/bake/production.rs"]);
+
+const EXTERN_C_FUNCTION = /extern\s+"C"\s+[^;{}()]*?\b(\w+)\s*\(/g;
+// `GlobalObject*`, `Bake::GlobalObject*` or `::Bake::GlobalObject*` (also by
+// reference). The lookbehind rejects `JSC::JSGlobalObject*` and
+// `Zig::GlobalObject*`, which every global satisfies.
+const BAKE_GLOBAL_PARAM = /(?<![\w:])(?:(?:::)?Bake::)?GlobalObject\s*(?:const\s*)?[*&]/;
+
+function stripLineComments(source: string): string {
+  // `[ \t]*`, not `\s*`, so blank lines survive and line numbers stay right.
+  return source.replace(/^[ \t]*\/\/.*$/gm, "");
+}
+
+function lineOf(source: string, index: number): number {
+  return source.slice(0, index).split("\n").length;
+}
+
+function* readSources(dir: string, pattern: string): Generator<{ file: string; source: string }> {
+  for (const rel of new Glob(pattern).scanSync({ cwd: path.join(root, dir) })) {
+    const file = path.posix.join(dir, rel.replaceAll(path.sep, "/"));
+    yield { file, source: stripLineComments(readFileSync(path.join(root, file), "utf8")) };
+  }
+}
+
+// C++ function name -> where it is declared with a `Bake::GlobalObject*` parameter.
+const declaredAt = new Map<string, string[]>();
+let scannedCxx = 0;
+for (const { file, source } of readSources(bakeDir, "*.{cpp,h}")) {
+  scannedCxx++;
+  for (const m of source.matchAll(EXTERN_C_FUNCTION)) {
+    const paramsStart = m.index + m[0].length;
+    let depth = 1;
+    let i = paramsStart;
+    for (; i < source.length && depth > 0; i++) {
+      if (source[i] === "(") depth++;
+      else if (source[i] === ")") depth--;
+    }
+    if (!BAKE_GLOBAL_PARAM.test(source.slice(paramsStart, i - 1))) continue;
+    const name = m[1];
+    declaredAt.set(name, [...(declaredAt.get(name) ?? []), `${file}:${lineOf(source, m.index)}`]);
+  }
+}
+
+const names = [...declaredAt.keys()].sort();
+const offenders: string[] = [];
+const boundFromProduction: string[] = [];
+if (names.length > 0) {
+  const alternatives = names.join("|");
+  const RUST_BINDING = new RegExp(
+    String.raw`\bfn\s+(${alternatives})\s*\(|\blink_name\s*=\s*"(${alternatives})"|\bHOST_EXPORT\(\s*(${alternatives})\b`,
+    "g",
+  );
+  for (const { file, source } of readSources("src", "**/*.rs")) {
+    for (const m of source.matchAll(RUST_BINDING)) {
+      const name = m[1] ?? m[2] ?? m[3];
+      const entry = `${file}:${lineOf(source, m.index)}: ${name} (takes Bake::GlobalObject* at ${declaredAt.get(name)!.join(", ")})`;
+      (PRODUCTION_GLOBAL_RUST_FILES.has(file) ? boundFromProduction : offenders).push(entry);
+    }
+  }
+}
+offenders.sort();
+
+test("scans the bake C++ sources", () => {
+  expect(scannedCxx).toBeGreaterThan(0);
+});
+
+test("the pattern still recognizes entry points that take Bake::GlobalObject*", () => {
+  // If this goes empty, either the last such entry point was retyped (then
+  // delete this lint) or the declarations no longer match EXTERN_C_FUNCTION.
+  expect(names).not.toBeEmpty();
+  // Same for the Rust side of the match: the production build binds these.
+  expect(boundFromProduction).not.toBeEmpty();
+});
+
+test("entry points that take Bake::GlobalObject* are only bound by the production build", () => {
+  expect(offenders).toEqual([]);
+});


### PR DESCRIPTION
### Problem

- `BakeLoadServerHmrPatch` and `BakeLoadServerHmrPatchWithSourceMap` (src/runtime/bake/BakeSourceProvider.cpp:61 and :83) are defined inside `namespace Bake`, so their `GlobalObject*` parameter is `Bake::GlobalObject*`, the production build's global.
- Their only callers are in the dev server (`mod c` in src/runtime/bake/DevServer.rs). The dev server is created by `Bun.serve` inside the normal runtime VM (src/runtime/server/mod.rs:2222), so what actually arrives is a plain `Zig::GlobalObject`.
- A `Bake::GlobalObject` only exists in `bun build --app` production builds (`BakeCreateProdGlobal`, called from `VirtualMachine::init_bake`).
- Nothing catches the mismatch: Rust declares every bake entry point as `&JSGlobalObject`, and the two bodies happen to use only the `JSGlobalObject` part. Touching `m_perThreadData` in either function would read past the end of the dev server's global.
- Noticed while reviewing #38949, which does not change these two functions.

### Fix

- Every bake `extern "C"` entry point now takes `JSC::JSGlobalObject*`, which is what Rust passes. The two HMR loaders and `BakeLoadModuleByKey` only use `JSGlobalObject` members, so their bodies are unchanged; `BakeGlobalObject__attachPerThreadData`, the one function that writes a production-only field, does `uncheckedDowncast<Bake::GlobalObject>` inside, the way `BakeGlobalObject__getPerThreadData` next to it already does.
- This is correct because the requirement "this caller has a production global" now lives where the production field is used and is asserted there in debug builds (`uncheckedDowncast` asserts `is<Target>`), instead of in a parameter type that the Rust side cannot see. Calls through the retyped signatures compile to the same code as before: `Bake::GlobalObject` derives from `JSGlobalObject` (via `Zig::GlobalObject` and `Bun::GlobalScope`) through single inheritance only, so the pointer value is the same under either type.
- `BakeLoadModuleByKey` overlaps by one line with #38949, which changes the same signature's other parameter and return type. Whichever lands second keeps `JSC::JSGlobalObject*` for the first parameter.
- New lint, test/internal/source-lints/bake-global-object-ffi.test.ts: no `extern "C"` function in src/runtime/bake/*.{cpp,h} may take a `Bake::GlobalObject*` parameter. On main it fails naming the five declarations above (attachPerThreadData twice, once per file); with this change it passes. It also asserts that it still found the directory's `extern "C"` functions, so it cannot pass by matching nothing.
- Verified with `bun bd test test/internal/source-lints/bake-global-object-ffi.test.ts` (fails against main's versions of the three files, passes with them).
- `bun bd test test/bake/dev/production.test.ts` (9 pass with `--timeout 120000`; the debug build needs 6 to 9 s per test) drives `attachPerThreadData` and `BakeLoadModuleByKey` with a real production global, so the new assertion ran and held.
- `bun bd test test/bake/dev/server-sourcemap.test.ts` (5 pass) drives the two retyped HMR loaders.

### Background

- `Zig::GlobalObject` is the `JSGlobalObject` subclass every normal Bun VM uses. `Bake::GlobalObject` (src/runtime/bake/BakeGlobalObject.h) derives from it and adds `m_perThreadData`, a pointer to the production build's module table, attached from src/runtime/bake/production.rs.
- The bake entry points are called from Rust through hand-written `unsafe extern "C"` declarations in which every global is the opaque `JSGlobalObject`, so a narrower C++ parameter type is documentation only.
- `uncheckedDowncast<T>(p)` (WTF TypeCasts.h) is a `static_cast` plus a debug-build assertion that `p` really is a `T`; `downcast` is the release-asserting variant.
- test/internal/source-lints/ holds tests that grep the source tree for invariants like this one. They run against a released bun in the source-lints workflow and in the merge queue, and are excluded from the Buildkite test shards.

<details>
<summary>Earlier revision of this PR</summary>

The first revision retyped only the two HMR loaders and added a lint that allowed `Bake::GlobalObject*` parameters as long as the function was bound only from production.rs, plus trigger paths for the source-lints workflow. Review pointed out that this pinned the two remaining narrow signatures in place, while the directory's own idiom (take `JSC::JSGlobalObject*`, downcast inside) removes the need for an allowlist and checks the invariant at runtime, and that the workflow hunk collides with #38424 and is superseded by #36179. This revision retypes the remaining two functions, reduces the lint to a plain ban, and leaves the workflow alone.

</details>
