### PR TITLE
bun test: stop truncating .snap files on open, write them per file and on --bail

### DIFF
--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -701,8 +701,7 @@ fn worker_flush_aggregates(
     ctx: &Command::ContextData,
     cmds: &mut WorkerCommands,
 ) {
-    // Each file's `.snap` is written when the file finishes (`TestCommand::run`);
-    // inline snapshots are only written here, once per worker.
+    // Inline snapshots are written once per process; each `.snap` was written as its file finished.
     if let Some(runner) = crate::test_runner::jest::Jest::runner() {
         let _ = runner.snapshots.write_inline_snapshots().unwrap_or(false);
         let _ = runner.snapshots.write_snapshot_file();

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -701,8 +701,8 @@ fn worker_flush_aggregates(
     ctx: &Command::ContextData,
     cmds: &mut WorkerCommands,
 ) {
-    // Snapshots flush lazily when the next file opens its snapshot file; the
-    // last file each worker ran has no successor to trigger that.
+    // Each file's `.snap` is written when the file finishes (`TestCommand::run`);
+    // inline snapshots are only written here, once per worker.
     if let Some(runner) = crate::test_runner::jest::Jest::runner() {
         let _ = runner.snapshots.write_inline_snapshots().unwrap_or(false);
         let _ = runner.snapshots.write_snapshot_file();

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -3417,6 +3417,11 @@ impl TestCommand {
             }
             junit.current_file = Box::default();
         }
+        // Per file, so this file's snapshots are on disk however a later file ends.
+        if let Err(err) = reporter.jest.snapshots.write_snapshot_file() {
+            Output::err(err.name(), "Failed to write snapshot file", ());
+            return Err(err);
+        }
         Ok(())
     }
 }

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1553,8 +1553,6 @@ impl CommandLineReporter {
         Output::print_start_end(bun::start_time(), bun::time::nano_timestamp());
     }
 
-    /// Like the JUnit report, called on the bail exits: snapshots are otherwise only written
-    /// when the run ends, and under `--update-snapshots` the open `.snap` is already truncated.
     pub(crate) fn write_snapshots_before_bail(&mut self) {
         if let Err(err) = self.jest.snapshots.write_inline_snapshots() {
             Output::err(err, "Failed to write inline snapshots", ());

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1524,6 +1524,7 @@ impl CommandLineReporter {
                         if this.jest.bail == 1 { "" } else { "s" }
                     );
                     Output::flush();
+                    this.write_snapshots_before_bail();
                     this.write_junit_report_if_needed();
                     this.write_timings_if_needed();
                     Global::exit(1);
@@ -1550,6 +1551,20 @@ impl CommandLineReporter {
         );
 
         Output::print_start_end(bun::start_time(), bun::time::nano_timestamp());
+    }
+
+    /// Snapshots are otherwise only written back when the next file opens its
+    /// own `.snap` or when the whole run ends, so a bail exit has to flush them
+    /// itself: the open `.snap` was created (and, under `--update-snapshots`,
+    /// truncated) when it was opened and would be left empty on disk, and
+    /// pending inline snapshots would be dropped.
+    pub(crate) fn write_snapshots_before_bail(&mut self) {
+        if let Err(err) = self.jest.snapshots.write_inline_snapshots() {
+            Output::err(err, "Failed to write inline snapshots", ());
+        }
+        if let Err(err) = self.jest.snapshots.write_snapshot_file() {
+            Output::err(err, "Failed to write snapshot file", ());
+        }
     }
 
     /// Like the JUnit report, called before every exit path (including bail) so measured durations aren't lost.
@@ -3300,6 +3315,7 @@ impl TestCommand {
                             reporter.jest.bail,
                             if reporter.jest.bail == 1 { "" } else { "s" }
                         );
+                        reporter.write_snapshots_before_bail();
                         reporter.write_junit_report_if_needed();
                         reporter.write_timings_if_needed();
 

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1553,11 +1553,8 @@ impl CommandLineReporter {
         Output::print_start_end(bun::start_time(), bun::time::nano_timestamp());
     }
 
-    /// Snapshots are otherwise only written back when the next file opens its
-    /// own `.snap` or when the whole run ends, so a bail exit has to flush them
-    /// itself: the open `.snap` was created (and, under `--update-snapshots`,
-    /// truncated) when it was opened and would be left empty on disk, and
-    /// pending inline snapshots would be dropped.
+    /// Like the JUnit report, called on the bail exits: snapshots are otherwise only written
+    /// when the run ends, and under `--update-snapshots` the open `.snap` is already truncated.
     pub(crate) fn write_snapshots_before_bail(&mut self) {
         if let Err(err) = self.jest.snapshots.write_inline_snapshots() {
             Output::err(err, "Failed to write inline snapshots", ());

--- a/src/runtime/test_runner/snapshot.rs
+++ b/src/runtime/test_runner/snapshot.rs
@@ -346,8 +346,11 @@ impl Snapshots {
 
     pub(crate) fn write_snapshot_file(&mut self) -> Result<(), Error> {
         if let Some(file) = self._current_file.take() {
+            // The file was not truncated when it was opened (see `get_snapshot_file`), so cut
+            // off whatever the previous contents had past the new length.
             file.file
-                .write_all(&self.file_buf)
+                .pwrite_all(&self.file_buf, 0)
+                .and_then(|()| bun_sys::ftruncate(file.file.handle, self.file_buf.len() as i64))
                 .map_err(|_| crate::Error::FailedToWriteSnapshotFile)?;
             let _ = file.file.close();
             self.file_buf.clear();
@@ -886,10 +889,9 @@ impl Snapshots {
             // SAFETY: buf[pos] == 0 written above
             let snapshot_file_path = ZStr::from_buf(&buf[..], pos);
 
-            let mut flags: i32 = bun_sys::O::CREAT | bun_sys::O::RDWR;
-            if self.update_snapshots {
-                flags |= bun_sys::O::TRUNC;
-            }
+            // Not O_TRUNC, even with --update-snapshots: the previous contents stay on disk
+            // until `write_snapshot_file` replaces them, so an exit before then keeps them.
+            let flags: i32 = bun_sys::O::CREAT | bun_sys::O::RDWR;
             let fd = match bun_sys::open(snapshot_file_path, flags, 0o644) {
                 bun_sys::Result::Ok(fd) => fd,
                 bun_sys::Result::Err(err) => return Ok(bun_sys::Result::Err(err)),
@@ -909,10 +911,6 @@ impl Snapshots {
                 } else {
                     let mut tmp = vec![0u8; length];
                     let _ = file.file.pread_all(&mut tmp, 0).map_err(Error::from)?;
-                    #[cfg(windows)]
-                    {
-                        file.file.seek_to(0).map_err(Error::from)?;
-                    }
                     self.file_buf.extend_from_slice(&tmp);
                 }
             }

--- a/src/runtime/test_runner/snapshot.rs
+++ b/src/runtime/test_runner/snapshot.rs
@@ -346,8 +346,7 @@ impl Snapshots {
 
     pub(crate) fn write_snapshot_file(&mut self) -> Result<(), Error> {
         if let Some(file) = self._current_file.take() {
-            // The file was not truncated when it was opened (see `get_snapshot_file`), so cut
-            // off whatever the previous contents had past the new length.
+            // The open in `get_snapshot_file` does not truncate, so drop the old tail here.
             file.file
                 .pwrite_all(&self.file_buf, 0)
                 .and_then(|()| bun_sys::ftruncate(file.file.handle, self.file_buf.len() as i64))
@@ -889,8 +888,7 @@ impl Snapshots {
             // SAFETY: buf[pos] == 0 written above
             let snapshot_file_path = ZStr::from_buf(&buf[..], pos);
 
-            // Not O_TRUNC, even with --update-snapshots: the previous contents stay on disk
-            // until `write_snapshot_file` replaces them, so an exit before then keeps them.
+            // Never O_TRUNC: the old contents stay on disk until `write_snapshot_file` replaces them.
             let flags: i32 = bun_sys::O::CREAT | bun_sys::O::RDWR;
             let fd = match bun_sys::open(snapshot_file_path, flags, 0o644) {
                 bun_sys::Result::Ok(fd) => fd,

--- a/test/js/bun/test/snapshot-tests/new-snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/new-snapshot.test.ts
@@ -58,11 +58,18 @@ describe("--bail", () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "test", "--bail", ...args],
       cwd: String(dir),
-      env: { ...bunEnv, CI: "false" },
+      env: {
+        ...bunEnv,
+        CI: "false",
+        // Bailing on a failed test exits the process without tearing the VM down, so the
+        // test runner's JSC-owned objects show up as leaks. These tests cover what reaches
+        // disk before that exit, so keep ASAN on but leave LSAN off for the child.
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
+      },
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toContain("Bailed out after 1 failure");
     expect(exitCode).toBe(1);
   }

--- a/test/js/bun/test/snapshot-tests/new-snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/new-snapshot.test.ts
@@ -29,47 +29,92 @@ test("it will create a snapshot file and directory if they don't exist", () => {
   expect(fs.existsSync(tempDir + "/__snapshots__/new-snapshot.test.ts.snap")).toBe(true);
 });
 
-describe("--bail", () => {
-  // Snapshots are buffered in memory while a file runs and written back later. Bailing out must
-  // still write them: the .snap file is created (and truncated under -u) as soon as it is opened.
-  const header = "// Bun Snapshot v1, https://bun.sh/docs/test/snapshots\n";
-  const snapEntry = (value: string) => "\nexports[`snap 1`] = `" + value + "`;\n";
+const header = "// Bun Snapshot v1, https://bun.sh/docs/test/snapshots\n";
+const snapEntry = (value: string) => "\nexports[`snap 1`] = `" + value + "`;\n";
+const writtenSnap = header + snapEntry('"value"');
+// Longer than what a run of the fixtures below writes, so a rewrite has to shrink the file.
+const staleSnap = header + snapEntry('"stale"') + '\nexports[`gone 1`] = `"stale"`;\n';
 
-  const snapTest = /*js*/ `
-    import { test, expect } from "bun:test";
-    test("snap", () => { expect("value").toMatchSnapshot(); });
-  `;
-  const failingTest = /*js*/ `
-    import { test, expect } from "bun:test";
-    test("fails", () => { expect(1).toBe(2); });
-  `;
-  const snapThenFailingTest = /*js*/ `
-    import { test, expect } from "bun:test";
-    test("snap", () => { expect("value").toMatchSnapshot(); });
-    test("fails", () => { expect(1).toBe(2); });
-  `;
-  const inlineSnap = (snapshot: string) => /*js*/ `
-    import { test, expect } from "bun:test";
-    test("inline", () => { expect("value").toMatchInlineSnapshot(${snapshot}); });
-    test("fails", () => { expect(1).toBe(2); });
-  `;
+const snapTest = /*js*/ `
+  import { test, expect } from "bun:test";
+  test("snap", () => { expect("value").toMatchSnapshot(); });
+`;
+const snapThenFailingTest = /*js*/ `
+  import { test, expect } from "bun:test";
+  test("snap", () => { expect("value").toMatchSnapshot(); });
+  test("fails", () => { expect(1).toBe(2); });
+`;
+const snapThenExitTest = /*js*/ `
+  import { test, expect } from "bun:test";
+  test("snap", () => { expect("value").toMatchSnapshot(); process.exit(0); });
+`;
+const failingTest = /*js*/ `
+  import { test, expect } from "bun:test";
+  test("fails", () => { expect(1).toBe(2); });
+`;
+const inlineTest = (snapshot: string) => /*js*/ `
+  import { test, expect } from "bun:test";
+  test("inline", () => { expect("value").toMatchInlineSnapshot(${snapshot}); });
+`;
+const inlineThenFailingTest = (snapshot: string) => /*js*/ `
+  import { test, expect } from "bun:test";
+  test("inline", () => { expect("value").toMatchInlineSnapshot(${snapshot}); });
+  test("fails", () => { expect(1).toBe(2); });
+`;
 
-  async function runUntilBail(dir: string, ...args: string[]) {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "test", "--bail", ...args],
-      cwd: String(dir),
-      env: {
-        ...bunEnv,
-        CI: "false",
-        // Bailing on a failed test exits the process without tearing the VM down, so the
-        // test runner's JSC-owned objects show up as leaks. These tests cover what reaches
-        // disk before that exit, so keep ASAN on but leave LSAN off for the child.
-        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
-      },
-      stdout: "pipe",
-      stderr: "pipe",
+async function runBunTest(dir: string, args: string[], env: Record<string, string> = {}) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", ...args],
+    cwd: String(dir),
+    env: { ...bunEnv, CI: "false", ...env },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stderr, exitCode };
+}
+
+describe("writing the .snap file", () => {
+  test.concurrent("--update-snapshots keeps the existing file until the new contents are written", async () => {
+    using dir = tempDir("snapshot-exit-before-write", {
+      "a.test.ts": snapThenExitTest,
+      "__snapshots__": { "a.test.ts.snap": staleSnap },
     });
-    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const { exitCode } = await runBunTest(dir, ["--update-snapshots", "./a.test.ts"]);
+    expect(fs.readFileSync(`${dir}/__snapshots__/a.test.ts.snap`, "utf8")).toBe(staleSnap);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("--update-snapshots removes what the existing file had beyond the new contents", async () => {
+    using dir = tempDir("snapshot-update-shrinks", {
+      "a.test.ts": snapTest,
+      "__snapshots__": { "a.test.ts.snap": staleSnap },
+    });
+    const { stderr, exitCode } = await runBunTest(dir, ["--update-snapshots", "./a.test.ts"]);
+    expect(fs.readFileSync(`${dir}/__snapshots__/a.test.ts.snap`, "utf8")).toBe(writtenSnap);
+    expect(stderr).toContain("1 pass");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("a file's snapshots are written when it finishes, not when the run ends", async () => {
+    using dir = tempDir("snapshot-written-per-file", {
+      "a.test.ts": snapTest,
+      "b.test.ts": `process.exit(1);`,
+    });
+    const { exitCode } = await runBunTest(dir, ["./a.test.ts", "./b.test.ts"]);
+    expect(fs.readFileSync(`${dir}/__snapshots__/a.test.ts.snap`, "utf8")).toBe(writtenSnap);
+    expect(exitCode).toBe(1);
+  });
+});
+
+describe("--bail", () => {
+  async function runUntilBail(dir: string, ...args: string[]) {
+    const { stderr, exitCode } = await runBunTest(dir, ["--bail", ...args], {
+      // Bailing on a failed test exits the process without tearing the VM down, so the
+      // test runner's JSC-owned objects show up as leaks. These tests cover what reaches
+      // disk before that exit, so keep ASAN on but leave LSAN off for the child.
+      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
+    });
     expect(stderr).toContain("Bailed out after 1 failure");
     expect(exitCode).toBe(1);
   }
@@ -77,36 +122,48 @@ describe("--bail", () => {
   test.concurrent("writes the snapshots recorded in the file that bailed", async () => {
     using dir = tempDir("snapshot-bail", { "a.test.ts": snapThenFailingTest });
     await runUntilBail(dir, "./a.test.ts");
-    expect(fs.readFileSync(`${dir}/__snapshots__/a.test.ts.snap`, "utf8")).toBe(header + snapEntry('"value"'));
+    expect(fs.readFileSync(`${dir}/__snapshots__/a.test.ts.snap`, "utf8")).toBe(writtenSnap);
   });
 
-  test.concurrent("--update-snapshots writes the updated snapshots instead of leaving the file empty", async () => {
+  test.concurrent("--update-snapshots replaces the existing file with the snapshots recorded so far", async () => {
     using dir = tempDir("snapshot-bail-update", {
       "a.test.ts": snapThenFailingTest,
-      "__snapshots__": { "a.test.ts.snap": header + snapEntry('"stale"') },
+      "__snapshots__": { "a.test.ts.snap": staleSnap },
     });
     await runUntilBail(dir, "--update-snapshots", "./a.test.ts");
-    expect(fs.readFileSync(`${dir}/__snapshots__/a.test.ts.snap`, "utf8")).toBe(header + snapEntry('"value"'));
+    expect(fs.readFileSync(`${dir}/__snapshots__/a.test.ts.snap`, "utf8")).toBe(writtenSnap);
   });
 
-  test.concurrent("writes the snapshots of an earlier file when a later file's test fails", async () => {
+  test.concurrent("writes the pending inline snapshots of the file that bailed", async () => {
+    using dir = tempDir("snapshot-bail-inline", { "a.test.ts": inlineThenFailingTest("") });
+    await runUntilBail(dir, "./a.test.ts");
+    expect(fs.readFileSync(`${dir}/a.test.ts`, "utf8")).toBe(inlineThenFailingTest('`"value"`'));
+  });
+
+  test.concurrent("keeps the snapshots of an earlier file when a later file's test fails", async () => {
     using dir = tempDir("snapshot-bail-earlier-file", { "a.test.ts": snapTest, "b.test.ts": failingTest });
     await runUntilBail(dir, "./a.test.ts", "./b.test.ts");
-    expect(fs.readFileSync(`${dir}/__snapshots__/a.test.ts.snap`, "utf8")).toBe(header + snapEntry('"value"'));
+    expect(fs.readFileSync(`${dir}/__snapshots__/a.test.ts.snap`, "utf8")).toBe(writtenSnap);
   });
 
-  test.concurrent("writes the snapshots of an earlier file when a later file fails to load", async () => {
+  test.concurrent("keeps the snapshots of an earlier file when a later file fails to load", async () => {
     using dir = tempDir("snapshot-bail-load-error", {
       "a.test.ts": snapTest,
       "b.test.ts": `throw new Error("failed to load");`,
     });
     await runUntilBail(dir, "./a.test.ts", "./b.test.ts");
-    expect(fs.readFileSync(`${dir}/__snapshots__/a.test.ts.snap`, "utf8")).toBe(header + snapEntry('"value"'));
+    expect(fs.readFileSync(`${dir}/__snapshots__/a.test.ts.snap`, "utf8")).toBe(writtenSnap);
   });
 
-  test.concurrent("writes pending inline snapshots", async () => {
-    using dir = tempDir("snapshot-bail-inline", { "a.test.ts": inlineSnap("") });
-    await runUntilBail(dir, "./a.test.ts");
-    expect(fs.readFileSync(`${dir}/a.test.ts`, "utf8")).toBe(inlineSnap('`"value"`'));
-  });
+  test.concurrent(
+    "writes the pending inline snapshots of an earlier file when a later file fails to load",
+    async () => {
+      using dir = tempDir("snapshot-bail-load-error-inline", {
+        "a.test.ts": inlineTest(""),
+        "b.test.ts": `throw new Error("failed to load");`,
+      });
+      await runUntilBail(dir, "./a.test.ts", "./b.test.ts");
+      expect(fs.readFileSync(`${dir}/a.test.ts`, "utf8")).toBe(inlineTest('`"value"`'));
+    },
+  );
 });

--- a/test/js/bun/test/snapshot-tests/new-snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/new-snapshot.test.ts
@@ -1,6 +1,6 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, tmpdirSync } from "harness";
+import { bunEnv, bunExe, tempDir, tmpdirSync } from "harness";
 
 test("it will create a snapshot file and directory if they don't exist", () => {
   const tempDir = tmpdirSync();
@@ -27,4 +27,79 @@ test("it will create a snapshot file and directory if they don't exist", () => {
 
   expect(exitCode2).toBe(0);
   expect(fs.existsSync(tempDir + "/__snapshots__/new-snapshot.test.ts.snap")).toBe(true);
+});
+
+describe("--bail", () => {
+  // Snapshots are buffered in memory while a file runs and written back later. Bailing out must
+  // still write them: the .snap file is created (and truncated under -u) as soon as it is opened.
+  const header = "// Bun Snapshot v1, https://bun.sh/docs/test/snapshots\n";
+  const snapEntry = (value: string) => "\nexports[`snap 1`] = `" + value + "`;\n";
+
+  const snapTest = /*js*/ `
+    import { test, expect } from "bun:test";
+    test("snap", () => { expect("value").toMatchSnapshot(); });
+  `;
+  const failingTest = /*js*/ `
+    import { test, expect } from "bun:test";
+    test("fails", () => { expect(1).toBe(2); });
+  `;
+  const snapThenFailingTest = /*js*/ `
+    import { test, expect } from "bun:test";
+    test("snap", () => { expect("value").toMatchSnapshot(); });
+    test("fails", () => { expect(1).toBe(2); });
+  `;
+  const inlineSnap = (snapshot: string) => /*js*/ `
+    import { test, expect } from "bun:test";
+    test("inline", () => { expect("value").toMatchInlineSnapshot(${snapshot}); });
+    test("fails", () => { expect(1).toBe(2); });
+  `;
+
+  async function runUntilBail(dir: string, ...args: string[]) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--bail", ...args],
+      cwd: String(dir),
+      env: { ...bunEnv, CI: "false" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("Bailed out after 1 failure");
+    expect(exitCode).toBe(1);
+  }
+
+  test.concurrent("writes the snapshots recorded in the file that bailed", async () => {
+    using dir = tempDir("snapshot-bail", { "a.test.ts": snapThenFailingTest });
+    await runUntilBail(dir, "./a.test.ts");
+    expect(fs.readFileSync(`${dir}/__snapshots__/a.test.ts.snap`, "utf8")).toBe(header + snapEntry('"value"'));
+  });
+
+  test.concurrent("--update-snapshots writes the updated snapshots instead of leaving the file empty", async () => {
+    using dir = tempDir("snapshot-bail-update", {
+      "a.test.ts": snapThenFailingTest,
+      "__snapshots__": { "a.test.ts.snap": header + snapEntry('"stale"') },
+    });
+    await runUntilBail(dir, "--update-snapshots", "./a.test.ts");
+    expect(fs.readFileSync(`${dir}/__snapshots__/a.test.ts.snap`, "utf8")).toBe(header + snapEntry('"value"'));
+  });
+
+  test.concurrent("writes the snapshots of an earlier file when a later file's test fails", async () => {
+    using dir = tempDir("snapshot-bail-earlier-file", { "a.test.ts": snapTest, "b.test.ts": failingTest });
+    await runUntilBail(dir, "./a.test.ts", "./b.test.ts");
+    expect(fs.readFileSync(`${dir}/__snapshots__/a.test.ts.snap`, "utf8")).toBe(header + snapEntry('"value"'));
+  });
+
+  test.concurrent("writes the snapshots of an earlier file when a later file fails to load", async () => {
+    using dir = tempDir("snapshot-bail-load-error", {
+      "a.test.ts": snapTest,
+      "b.test.ts": `throw new Error("failed to load");`,
+    });
+    await runUntilBail(dir, "./a.test.ts", "./b.test.ts");
+    expect(fs.readFileSync(`${dir}/__snapshots__/a.test.ts.snap`, "utf8")).toBe(header + snapEntry('"value"'));
+  });
+
+  test.concurrent("writes pending inline snapshots", async () => {
+    using dir = tempDir("snapshot-bail-inline", { "a.test.ts": inlineSnap("") });
+    await runUntilBail(dir, "./a.test.ts");
+    expect(fs.readFileSync(`${dir}/a.test.ts`, "utf8")).toBe(inlineSnap('`"value"`'));
+  });
 });


### PR DESCRIPTION
### Problem
- `bun test -u` truncates a test file's committed `__snapshots__/<file>.snap` to 0 bytes the moment the file's first snapshot assertion runs, and only writes the new contents back much later. Any exit in between destroys the committed snapshots: `bun test -u --bail` with a failing test, `process.exit()` inside a test, a crash, or a later file that throws while loading all leave the file at 0 bytes (all reproduced on 1.4.0).
- Without `-u`, snapshots recorded during the run are lost the same way: `.snap` files are written back only when the next file opens its own `.snap` or when the whole run ends, so `--bail` (or a later file calling `process.exit()`) loses the snapshots of the file that was running and of every fully passing file before it whose `.snap` had not been written yet; pending `toMatchInlineSnapshot()` writes are dropped on `--bail` too.
- Cause: `Snapshots::get_snapshot_file()` (`src/runtime/test_runner/snapshot.rs`) opens the `.snap` with `O_CREAT | O_RDWR`, plus `O_TRUNC` under `-u`, and buffers the contents in memory; `write_snapshot_file()` / `write_inline_snapshots()` run only on the next file's open and at the end of `TestCommand::exec`. Both `--bail` exits in `src/runtime/cli/test_command.rs` (`handle_test_completed` when the failure count reaches the bail count, and the rejected entry point branch of `TestCommand::run`) exit before either runs.

### Fix
- `snapshot.rs`: the `.snap` is no longer truncated when it is opened. `write_snapshot_file()` writes the buffer at offset 0 and `ftruncate`s to its length, so the file is only ever replaced by complete contents and whatever exit happens before that leaves the committed file intact. The Windows-only `seek_to(0)` after the initial read goes away because the write is positional now. (A `.snap` that did not exist yet can still be left as an empty file by an abnormal exit; an empty file is treated as absent on the next run, so nothing is lost.)
- `TestCommand::run`: each file's `.snap` is written when the file finishes (serial runner and `--parallel` workers both go through `run`), so however a later file ends, the finished files' snapshots are on disk. The writes at the next file's open and at the end of the run remain as no-ops. Inline snapshots stay end-of-run: `write_inline_snapshots()` is written to run once per process.
- `--bail`: `CommandLineReporter::write_snapshots_before_bail()` writes the pending inline snapshots and the `.snap` of the file that was running, called on both bail exits next to the JUnit and timings writes that already exist there. This persists what the run had recorded, the same as a run without `--bail` persists the snapshots of a test that fails later; `--bail` decides when the process stops, not what is kept. Under `-u` that is the snapshots of the tests that ran, which is what `-u` already writes for any partial run (for example `-u -t name`).
- Correctness of the ordering: in `TestCommand::run` the call happens before `Jest::RUNNER` is cleared, which `write_inline_snapshots()` reads; the new inline test on that path covers it.
- Tests: `test/js/bun/test/snapshot-tests/new-snapshot.test.ts`. "writing the .snap file": `-u` with `process.exit()` before the write keeps the committed file; `-u` shrinks a longer existing file; a file's `.snap` is written before a later file `process.exit()`s. "--bail": the bailing file's `.snap`, `-u` over a longer existing `.snap`, the bailing file's inline snapshots, an earlier file's `.snap` when a later file fails or fails to load, and an earlier file's inline snapshots when a later file fails to load. 8 of the 9 fail on 1.4.0 (0 byte `.snap` / unmodified source); the shrink test passes before and after and pins the `ftruncate`. All pass with the debug build, also under the ASAN lane's LSAN environment.
- The bail children run with `detect_leaks=0` (ASAN stays on): bailing on a failed test exits without tearing the VM down, so LSAN reports the runner's JSC-owned objects and the child exits 134 instead of 1 regardless of this change. Reported separately; same precedent as other tests whose child exits without teardown.
- Also run with the debug build: `test/js/bun/test/snapshot-tests/` (all files), `test/cli/test/bun-test.test.ts -t bail`, `test/cli/test/parallel.test.ts -t bail`, `test/regression/issue/26851.test.ts`, `test/regression/issue/12250.test.ts`.
- Overlap with open PRs: #36679 (flush before `afterAll`) also drops `O_TRUNC`; whichever lands second drops that part. #38265 (coverage), #35504 (afterAll) and #35094 (`--watch`) rework the two bail exits; the one `write_snapshots_before_bail()` call per exit moves into whatever replaces them.

### Background
- `.snap` lifecycle: on a test file's first snapshot assertion, `get_snapshot_file()` opens `__snapshots__/<file>.snap`, loads the existing entries into `file_buf` (under `-u` it starts from the header instead) and appends new entries to `file_buf` as tests run; `write_snapshot_file()` writes `file_buf` back and closes the file. Until it runs, the file on disk is the previous contents (new behaviour) rather than empty.
- Inline snapshots (`toMatchInlineSnapshot()`) are queued in `inline_snapshots_to_write` and spliced into the test sources by `write_inline_snapshots()` at the end of the run.
- `--bail[=N]` stops the run after N failures. In the serial runner this is a direct process exit from the reporter callback or from the file loader, so artifacts that are normally written at the end of the run (JUnit, timings, now snapshots) are written on those paths explicitly. `--parallel` workers do not get `--bail`; the coordinator stops dispatching files and waits for them.

<details>
<summary>Earlier version of this PR (bail-only flush)</summary>

The first version only added the flush on the two bail exits. Self-review pointed out that the destructive part (`-u` truncating on open) has the same effect on every other abnormal exit and that earlier files' snapshots depended on the lazy write, so the PR was reshaped to fix those in `snapshot.rs` / per file, keeping the bail flush for the file that was running.

</details>
