### PR TITLE
StrongRootBlock: relink blocks without the cell-validating write barrier

### DIFF
--- a/src/jsc/bindings/StrongRootBlock.h
+++ b/src/jsc/bindings/StrongRootBlock.h
@@ -83,7 +83,18 @@ public:
     }
 
     StrongRootBlock* next() const { return m_next.get(); }
-    void setNext(JSC::VM& vm, StrongRootBlock* next) { m_next.setMayBeNull(vm, this, next); }
+
+    // Reached from Bun__StrongRef__delete, which finalizers call while JSC is
+    // sweeping; WriteBarrier::setMayBeNull would validate `next` through
+    // classInfo(), which asserts during a sweep. The barrier itself is still
+    // required: acquire() links the reused (old) spare ahead of blocks
+    // allocated since the last collection, and the slot store that follows only
+    // remembers the block when the value is a cell.
+    void setNext(JSC::VM& vm, StrongRootBlock* next)
+    {
+        m_next.setWithoutWriteBarrier(next);
+        vm.writeBarrier(this, next);
+    }
 
     static StrongRootBlock* acquire(WebCore::JSVMClientData* clientData, JSC::VM& vm, unsigned& outFreeSlot);
     static void release(WebCore::JSVMClientData* clientData, JSC::VM& vm, StrongRootBlock* block);

--- a/src/jsc/bindings/StrongRootBlock.h
+++ b/src/jsc/bindings/StrongRootBlock.h
@@ -84,12 +84,8 @@ public:
 
     StrongRootBlock* next() const { return m_next.get(); }
 
-    // Reached from Bun__StrongRef__delete, which finalizers call while JSC is
-    // sweeping; WriteBarrier::setMayBeNull would validate `next` through
-    // classInfo(), which asserts during a sweep. The barrier itself is still
-    // required: acquire() links the reused (old) spare ahead of blocks
-    // allocated since the last collection, and the slot store that follows only
-    // remembers the block when the value is a cell.
+    // Not setMayBeNull(): its GC-validation path reads next->classInfo(), which
+    // JSC forbids while sweeping, and finalizers release Strongs mid-sweep.
     void setNext(JSC::VM& vm, StrongRootBlock* next)
     {
         m_next.setWithoutWriteBarrier(next);

--- a/src/jsc/bindings/StrongRootBlock.h
+++ b/src/jsc/bindings/StrongRootBlock.h
@@ -84,8 +84,7 @@ public:
 
     StrongRootBlock* next() const { return m_next.get(); }
 
-    // Not setMayBeNull(): its GC-validation path reads next->classInfo(), which
-    // JSC forbids while sweeping, and finalizers release Strongs mid-sweep.
+    // Not setMayBeNull(): its GC validation reads next->classInfo(), which JSC forbids during the sweep that finalizers release Strongs from.
     void setNext(JSC::VM& vm, StrongRootBlock* next)
     {
         m_next.setWithoutWriteBarrier(next);

--- a/test/js/web/timers/timer-gc-roots.test.ts
+++ b/test/js/web/timers/timer-gc-roots.test.ts
@@ -44,6 +44,105 @@ describe.concurrent("Strong handles are backed by StrongRootBlock", () => {
     expect(exitCode).toBe(0);
   });
 
+  // The two tests below lay blocks out exactly, which relies on CAP matching
+  // StrongRootBlock::capacity and on a fresh process holding no Strongs; both
+  // are checked through the block counts they print.
+  const CAP = 960;
+
+  test("a Strong released from a GC finalizer can unlink a block from the middle of the list", async () => {
+    // Listener.stop() empties its `data` Strong but keeps the slot allocated, so
+    // the slot is released when the wrapper is finalized, i.e. while JSC is
+    // sweeping. `older` fills three blocks exactly, so `data` opens a block of
+    // its own ("M"), which the first CAP-1 `newer` timers then fill; the rest of
+    // `newer` goes into two blocks linked ahead of it. Clearing the timers that
+    // share M leaves `data` as its only occupant, with live blocks on both sides,
+    // so releasing it during the sweep has to relink M's neighbours.
+    const src = `
+      const { heapStats } = require("bun:jsc");
+      const older = [];
+      for (let i = 0; i < 3 * ${CAP}; i++) older.push(setTimeout(() => {}, 600000));
+      (function () {
+        const listener = Bun.listen({ hostname: "127.0.0.1", port: 0, data: {}, socket: { data() {} } });
+        listener.stop();
+      })();
+      const newer = [];
+      for (let i = 0; i < 2 * ${CAP}; i++) newer.push(setTimeout(() => {}, 600000));
+      for (const t of newer.splice(0, ${CAP} - 1)) clearTimeout(t);
+      const blocksArmed = heapStats().objectTypeCounts.StrongRootBlock || 0;
+      await new Promise(r => setTimeout(r, 0));
+      Bun.gc(true);
+      await new Promise(r => setTimeout(r, 0));
+      Bun.gc(true);
+      const protectedTimeouts = heapStats().protectedObjectTypeCounts.Timeout || 0;
+      console.log(JSON.stringify({ blocksArmed, protectedTimeouts }));
+      for (const t of older) clearTimeout(t);
+      for (const t of newer) clearTimeout(t);
+    `;
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", src], env: bunEnv, stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      // three `older` blocks, M, two `newer` blocks
+      blocksArmed: 6,
+      // protectedObjectTypeCounts walks the list from the head, so this only
+      // adds up if unlinking M left the blocks on both sides of it connected.
+      protectedTimeouts: 3 * CAP + (CAP + 1),
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test("re-linking an old block ahead of new blocks keeps them alive across an eden GC", async () => {
+    // A block that survived a collection is skipped by the next eden GC unless a
+    // write barrier put it back in the remembered set. When acquire() re-links
+    // the parked spare (old) ahead of blocks allocated since the last
+    // collection, the m_next store has to be that barrier: the slot store that
+    // follows it does not remember the block when the value is not a cell,
+    // which is what `listener.data = 1` arms.
+    //
+    // `a` is exactly blocks A1+A2 (old after the full GC). The unreferenced
+    // timers are exactly three new blocks, and their Timeouts are rooted only
+    // through those blocks' slots. Clearing `a` parks A1 as the spare and
+    // leaves the list exactly full, so `listener.data = 1` re-links A1 ahead of
+    // the new blocks.
+    const src = `
+      const { heapStats, edenGC } = require("bun:jsc");
+      const blocks = () => heapStats().objectTypeCounts.StrongRootBlock || 0;
+      const protectedTimeouts = () => heapStats().protectedObjectTypeCounts.Timeout || 0;
+      const blocksAtStart = blocks();
+      const listener = Bun.listen({ hostname: "127.0.0.1", port: 0, socket: { data() {} } });
+      listener.stop();
+      const a = [];
+      for (let i = 0; i < 2 * ${CAP}; i++) a.push(setTimeout(() => {}, 600000));
+      Bun.gc(true);
+      const blocksOld = blocks();
+      for (let i = 0; i < 3 * ${CAP}; i++) setTimeout(() => {}, 600000);
+      const blocksNew = blocks();
+      for (const t of a) clearTimeout(t);
+      listener.data = 1;
+      const beforeEden = protectedTimeouts();
+      edenGC();
+      // Allocate Timeout cells so that anything the eden GC failed to keep alive
+      // is swept, releasing its slot, before counting again.
+      for (let i = 0; i < 2 * ${CAP}; i++) setTimeout(() => {}, 0);
+      await new Promise(r => setTimeout(r, 0));
+      console.log(JSON.stringify({ blocksAtStart, blocksOld, blocksNew, beforeEden, afterEden: protectedTimeouts() }));
+      process.exit(0);
+    `;
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", src], env: bunEnv, stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      blocksAtStart: 0,
+      blocksOld: 2,
+      blocksNew: 5,
+      beforeEden: 3 * CAP,
+      // Without the barrier the eden GC frees the three new blocks and every
+      // Timeout they rooted, and this reads 0.
+      afterEden: 3 * CAP,
+    });
+    expect(exitCode).toBe(0);
+  });
+
   for (const kind of ["setTimeout", "setInterval", "setImmediate"] as const) {
     test(`${kind}: callback stays reachable across GC while armed`, async () => {
       const body =


### PR DESCRIPTION
### Problem
- Debug builds abort during GC with `ASSERTION FAILED: vm().currentThreadIsHoldingAPILock() => vm().heap.mutatorState() != MutatorState::Sweeping` (`JSCell::validateIsNotSweeping`, JSCell.cpp:179). Stack: `JSCell::classInfo` <- `validateCell<Bun::StrongRootBlock*>` <- `WriteBarrierBase<StrongRootBlock>::setMayBeNull` <- `StrongRootBlock::setNext` <- `StrongRootBlock::release` <- `Bun__StrongRef__delete` <- `Listener::deinit` <- `Listener::finalize` <- `MarkedBlock::Handle::specializedSweep`.
- A wrapper's finalizer runs inside the sweep and may drop a `bun_jsc::Strong` (`Listener::deinit` drops the `data` slot that `stop()` only emptied; `ByteStream`/`FileReader` keep their `pending_value` slot the same way). When that was the last occupied slot of a block, `StrongRootBlock::release` (src/jsc/bindings/StrongRootBlock.cpp:107) unlinks the block with `prev->setNext(vm, block->next())`.
- `setNext` (src/jsc/bindings/StrongRootBlock.h:86) used `WriteBarrier::setMayBeNull`, whose GC-validation path (`validateCell` -> `ASSERT_GC_OBJECT_INHERITS` -> `classInfo()`) is what JSC forbids during a sweep. It only fires when the successor is non-null, i.e. when the emptied block sits between two live blocks, which is why it is timing dependent in practice (seen on Windows x64 running several socket test files in one debug `bun test` process; not platform specific).
- Only builds with GC validation enabled (debug, `bun bd`) are affected; release builds compile `validateCell` to nothing.

### Fix
- `setNext` stores the link with `setWithoutWriteBarrier` and then calls `vm.writeBarrier(this, next)` itself. This drops only the debug-time type check of `next`; the store and the generational barrier are the same ones `setMayBeNull` performed. Same approach as #37008 takes for a different sweep-time `classInfo()` caller.
- The type check is redundant: `next` is always a block taken from this list or the parked spare, and every cell touched (`prev`, `block`, `next`) is live, since the list and spare are rooted by the "Srb" marking constraint.
- Running the barrier during a sweep is not new: `setMayBeNull` is `validateCell` followed by the same raw store and the same `vm.writeBarrier(owner, value)` (WriteBarrierInlines.h:43-55), so release builds on main already execute exactly this sequence from `release()` inside the sweep. `Heap::writeBarrier` reads structure pointers and the cell state and, on the slow path, pushes the cell onto `m_mutatorMarkStack`, which `MarkStackMergingConstraint` folds into the next collection; it never reads `classInfo()`. The first test below drives that slow path under a debug JSC (`prev` was marked by the collection being swept) with JSC's own assertions on.
- The barrier cannot be dropped as well: `acquire()` links the reused spare, which survived a collection and so is old, ahead of blocks allocated since the last collection. The slot store that follows only remembers the block when the value is a cell, so for a non-cell value (`listener.data = 1`) the `m_next` barrier is the only thing that keeps the new blocks, and everything they root, alive across the next eden collection. A build with the barrier removed loses all 2880 Timeouts in the second test below.
- Verified with `bun bd test test/js/web/timers/timer-gc-roots.test.ts` (the existing StrongRootBlock test file):
  - "a Strong released from a GC finalizer can unlink a block from the middle of the list": fills three blocks with timers, arms a stopped `Bun.listen` whose `data` slot opens a fourth block, fills two more blocks, clears the timers sharing the listener's block, then `Bun.gc(true)`. Unfixed debug build: aborts with the assertion above (5/5 runs); fixed: passes, and `protectedObjectTypeCounts` still reaches every block on both sides of the unlinked one. With the listener's block at the head of the list instead, the unfixed build does not assert, confirming the middle-block relink is the trigger.
  - "re-linking an old block ahead of new blocks keeps them alive across an eden GC": passes on main and with this fix, reads `afterEden: 0` on a build whose `setNext` omits the barrier.
  - Related files pass on the fixed build (`test/js/bun/net/socket-retention.test.ts`, `test/js/bun/jsc/bun-jsc.test.ts`, `test/js/web/timers/clearImmediate-gc.test.ts`).
- #37842 removes `StrongRootBlock` altogether but depends on a WebKit bump; this keeps debug builds usable on the current pin and is independent of it.

### Background
- `bun_jsc::Strong` is the Rust handle that roots a JS value. Since #35849 each handle is one slot in a `StrongRootBlock`, a JS cell holding 960 slots. Active blocks form a singly linked list through `m_next`; the head, the one parked spare block and the blocks' structure are rooted by a marking constraint, so blocks and everything in their slots stay alive. Releasing the last slot of a block unlinks it (`release`), and a new handle that finds every block full re-links the spare at the head (`acquire`).
- JSC sweeps lazily on the mutator thread: after marking, dead cells are destroyed block by block, and each block's destructors (Bun wrappers' `finalize`/`deinit`) run with the heap in `MutatorState::Sweeping`. Because a Structure may already have been swept by then, `JSCell::classInfo()` asserts it is not called in that state. `WriteBarrier<T>::set`/`setMayBeNull` call `classInfo()` on the value in builds with `ENABLE(GC_VALIDATION)` (debug); `WriteBarrier<Unknown>` (the slots themselves) does not, which is why only the `m_next` link was affected.
- JSC's GC is generational. An eden collection only visits cells allocated since the last collection plus old cells in the remembered set, which is what a write barrier adds a cell to when a pointer to a new cell is stored into it. An old cell that gets such a pointer without a barrier keeps pointing at a cell the eden collection will free.

