### PR TITLE
install: redact credentials in tarball and git URLs printed as resolutions and specifiers

### DIFF
--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -282,6 +282,25 @@ pub fn redacted_npm_url(str: &[u8]) -> RedactedNpmUrlFormatter<'_> {
     RedactedNpmUrlFormatter { url: str }
 }
 
+/// [`redacted_npm_url`] for a value that only exists as a `Display` impl: a
+/// lockfile resolution or a dependency specifier, which is the tarball or git
+/// URL written in package.json when the package came from one.
+pub struct Redacted<T>(T);
+
+impl<T: Display> Display for Redacted<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        // Rendered in full first: the inner impl may write in pieces, and the
+        // password scan is anchored at the start of the whole value.
+        let mut text = String::new();
+        write!(text, "{}", self.0)?;
+        redacted_npm_url(text.as_bytes()).fmt(f)
+    }
+}
+
+pub fn redacted<T: Display>(value: T) -> Redacted<T> {
+    Redacted(value)
+}
+
 // ───────────────────────────────────────────────────────────────────────────
 // RedactedSourceFormatter
 // ───────────────────────────────────────────────────────────────────────────

--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -284,7 +284,10 @@ pub fn redacted_npm_url(str: &[u8]) -> RedactedNpmUrlFormatter<'_> {
 
 /// [`redacted_npm_url`] for a value that only exists as a `Display` impl: a
 /// lockfile resolution or a dependency specifier, which is the tarball or git
-/// URL written in package.json when the package came from one.
+/// URL written in package.json when the package came from one. Anything that
+/// does not contain a URL (a version, a path, a `github:` specifier) is written
+/// unchanged: the token and UUID masks are meant for URLs, and a version whose
+/// pre-release tag happens to look like one must not be masked.
 pub struct Redacted<T>(T);
 
 impl<T: Display> Display for Redacted<T> {
@@ -293,6 +296,9 @@ impl<T: Display> Display for Redacted<T> {
         // password scan is anchored at the start of the whole value.
         let mut text = String::new();
         write!(text, "{}", self.0)?;
+        if !strings::contains(text.as_bytes(), b"://") {
+            return f.write_str(&text);
+        }
         redacted_npm_url(text.as_bytes()).fmt(f)
     }
 }

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -2140,17 +2140,23 @@ pub(crate) mod strings_impl {
 
     /// Port of `bun.fmt.URLFormatter.findUrlPassword` — returns
     /// `(offset, len)` of the password segment, or None.
-    /// Only matches http:// and https:// schemes and rejects empty pw.
+    /// `s` must start with a URL (`https://`, `git+ssh://`, ...); rejects an
+    /// empty password.
     pub(crate) fn find_url_password(s: &[u8]) -> Option<(usize, usize)> {
-        // Case-sensitive prefix match; the search region is truncated at the
-        // first '\n' and at the end of the authority before scanning for '@'/':'.
-        let scheme_end = if s.starts_with(b"http://") {
-            7
-        } else if s.starts_with(b"https://") {
-            8
-        } else {
+        // RFC 3986 scheme (`git+https` is one scheme) followed by `://`; the
+        // search region is truncated at the first '\n' and at the end of the
+        // authority before scanning for '@'/':'.
+        if !s.first().is_some_and(u8::is_ascii_alphabetic) {
             return None;
-        };
+        }
+        let scheme_len = s
+            .iter()
+            .take_while(|&&b| b.is_ascii_alphanumeric() || matches!(b, b'+' | b'-' | b'.'))
+            .count();
+        if !s[scheme_len..].starts_with(b"://") {
+            return None;
+        }
+        let scheme_end = scheme_len + b"://".len();
         let mut rest = &s[scheme_end..];
         if let Some(nl) = crate::strings::index_of_char_usize(rest, b'\n') {
             rest = &rest[..nl];

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1,7 +1,7 @@
 use core::sync::atomic::Ordering;
 
 use bun_collections::{ArrayHashMap, DynamicBitSet, StringHashMap};
-use bun_core::fmt::PathSep;
+use bun_core::fmt::{PathSep, redacted};
 use bun_core::{Global, Output};
 use bun_core::{ZStr, strings};
 use bun_paths::resolve_path::{dirname, join_abs_string_z, join_z_buf};
@@ -2057,7 +2057,7 @@ impl<'a> PackageInstaller<'a> {
                                             "Blocked {} scripts for: {}@{}\n",
                                             count,
                                             bstr::BStr::new(alias.slice(string_buf!())),
-                                            resolution.fmt(string_buf!(), PathSep::Posix),
+                                            redacted(resolution.fmt(string_buf!(), PathSep::Posix)),
                                         );
                                     }
                                     let entry = self

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2316,10 +2316,10 @@ fn get_or_put_resolved_package(
                                     existing_package
                                         .name
                                         .fmt(this.lockfile.buffers.string_bytes.as_slice()),
-                                    existing_package.resolution.fmt(
+                                    bun_fmt::redacted(existing_package.resolution.fmt(
                                         this.lockfile.buffers.string_bytes.as_slice(),
                                         bun_fmt::PathSep::Auto
-                                    ),
+                                    )),
                                 ),
                             );
                             success_fn(this, dependency_id, existing_id);
@@ -2367,10 +2367,10 @@ fn get_or_put_resolved_package(
                                     existing_package
                                         .name
                                         .fmt(this.lockfile.buffers.string_bytes.as_slice()),
-                                    existing_package.resolution.fmt(
+                                    bun_fmt::redacted(existing_package.resolution.fmt(
                                         this.lockfile.buffers.string_bytes.as_slice(),
                                         bun_fmt::PathSep::Auto
-                                    ),
+                                    )),
                                 ),
                             );
                             success_fn(this, dependency_id, list[0]);

--- a/src/install/PackageManager/PackageManagerResolution.rs
+++ b/src/install/PackageManager/PackageManagerResolution.rs
@@ -2,6 +2,7 @@ use crate::lockfile::package::PackageColumns as _;
 use core::mem::ManuallyDrop;
 
 use bun_core::Output;
+use bun_core::fmt::redacted;
 use bun_core::strings;
 use bun_paths::PathBuffer;
 use bun_semver as semver;
@@ -388,14 +389,14 @@ impl PackageManager {
                     {
                         Output::err_generic(
                             "<b>{}<r><d> failed to resolve<r>",
-                            (failed_dep.version.literal.fmt(string_buf),),
+                            (redacted(failed_dep.version.literal.fmt(string_buf)),),
                         );
                     } else {
                         Output::err_generic(
                             "<b>{}<r><d>@<b>{}<r><d> failed to resolve<r>",
                             (
                                 bstr::BStr::new(failed_dep.name.slice(string_buf)),
-                                failed_dep.version.literal.fmt(string_buf),
+                                redacted(failed_dep.version.literal.fmt(string_buf)),
                             ),
                         );
                     }

--- a/src/install/PackageManager/processDependencyList.rs
+++ b/src/install/PackageManager/processDependencyList.rs
@@ -1,5 +1,6 @@
 use core::cell::Cell;
 
+use bun_core::fmt::redacted;
 use bun_core::{Global, Output};
 use bun_paths::dirname;
 use bun_paths::platform;
@@ -164,7 +165,7 @@ impl PackageManager {
                                 Output::err(
                                     err,
                                     "failed to parse package.json for <b>{}<r>",
-                                    format_args!("{}", resolution.fmt_url(string_buf)),
+                                    format_args!("{}", redacted(resolution.fmt_url(string_buf))),
                                 );
                             }
                             Global::crash();
@@ -260,7 +261,7 @@ impl PackageManager {
                         let string_buf = self.lockfile.buffers.string_bytes.as_slice();
                         bun_core::pretty_errorln!(
                             "<r><red>error:<r> expected package.json in <b>{}<r> to be a JSON file: {}\n",
-                            resolution.fmt_url(string_buf),
+                            redacted(resolution.fmt_url(string_buf)),
                             err.name(),
                         );
                     }
@@ -312,7 +313,7 @@ impl PackageManager {
                                 let string_buf = self.lockfile.buffers.string_bytes.as_slice();
                                 bun_core::pretty_errorln!(
                                     "<r><red>error:<r> expected package.json in <b>{}<r> to be a JSON file: {}\n",
-                                    resolution.fmt_url(string_buf),
+                                    redacted(resolution.fmt_url(string_buf)),
                                     err.name(),
                                 );
                             }

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -28,7 +28,7 @@ use crate::isolated_install::store::{EntryColumns as _, NodeColumns as _};
 use crate::lifecycle_script_runner::InstallCtx;
 use crate::network_task::{Authorization, ForTarballError};
 use crate::package_manifest_map::Value as ManifestEntry;
-use bun_core::fmt::PathSep;
+use bun_core::fmt::{PathSep, redacted};
 use bun_install::lockfile::Package;
 use bun_install::package_manager_task as Task;
 // Import the *module* under the `Options` name so `Options::LogLevel` resolves as a path
@@ -677,9 +677,11 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                                 "<r><yellow>warn:<r> {} downloading tarball <b>{}@{}<r>. Retrying {}/{}...",
                                 bstr::BStr::new(err.name().as_bytes()),
                                 bstr::BStr::new(extract.name.slice()),
-                                extract
-                                    .resolution
-                                    .fmt(&manager.lockfile.buffers.string_bytes, PathSep::Auto,),
+                                redacted(
+                                    extract
+                                        .resolution
+                                        .fmt(&manager.lockfile.buffers.string_bytes, PathSep::Auto),
+                                ),
                                 task.retried,
                                 manager.options.max_retry_count,
                             );
@@ -747,9 +749,11 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                             "{} downloading tarball <b>{}@{}<r>",
                             err.name(),
                             bstr::BStr::new(extract.name.slice()),
-                            extract
-                                .resolution
-                                .fmt(&manager.lockfile.buffers.string_bytes, PathSep::Auto,),
+                            redacted(
+                                extract
+                                    .resolution
+                                    .fmt(&manager.lockfile.buffers.string_bytes, PathSep::Auto),
+                            ),
                         );
                     } else {
                         bun_ast::add_warning_pretty!(
@@ -759,9 +763,11 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                             "{} downloading tarball <b>{}@{}<r>",
                             err.name(),
                             bstr::BStr::new(extract.name.slice()),
-                            extract
-                                .resolution
-                                .fmt(&manager.lockfile.buffers.string_bytes, PathSep::Auto,),
+                            redacted(
+                                extract
+                                    .resolution
+                                    .fmt(&manager.lockfile.buffers.string_bytes, PathSep::Auto),
+                            ),
                         );
                     }
                     if manager.subcommand != Subcommand::Remove {

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -2537,7 +2537,9 @@ pub(crate) fn install_isolated_packages(
                                         "failed to enqueue tarball for download: {}@{}",
                                         (
                                             BStr::new(pkg_name.slice(string_buf)),
-                                            pkg_res.fmt(string_buf, bun_fmt::PathSep::Auto),
+                                            bun_fmt::redacted(
+                                                pkg_res.fmt(string_buf, bun_fmt::PathSep::Auto),
+                                            ),
                                         ),
                                     );
                                     Output::flush();

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -3,6 +3,7 @@ use std::io::Write as _;
 
 use bun_ast::Log;
 use bun_collections::{ArrayHashMap, DynamicBitSet, StringHashMap};
+use bun_core::fmt::redacted;
 use bun_core::{Environment, Global, Output};
 use bun_core::{ZStr, strings};
 use bun_paths::{self as paths, AbsPath, AutoAbsPath, AutoRelPath};
@@ -269,7 +270,7 @@ impl<'a> Installer<'a> {
                 "failed to download <b>{}@{}<r>: {}\n  <d>{}<r>",
                 (
                     bstr::BStr::new(name),
-                    resolution.fmt(string_buf, bun_core::fmt::PathSep::Auto),
+                    redacted(resolution.fmt(string_buf, bun_core::fmt::PathSep::Auto)),
                     bstr::BStr::new(download_error_reason(err)),
                     bstr::BStr::new(url),
                 ),
@@ -341,7 +342,7 @@ impl<'a> Installer<'a> {
                     "failed to link package: {}@{}",
                     (
                         bstr::BStr::new(pkg_name.slice(string_buf)),
-                        pkg_res.fmt(string_buf, bun_core::fmt::PathSep::Auto),
+                        redacted(pkg_res.fmt(string_buf, bun_core::fmt::PathSep::Auto)),
                     ),
                 );
             }
@@ -351,7 +352,7 @@ impl<'a> Installer<'a> {
                     "failed to symlink dependencies for package: {}@{}",
                     (
                         bstr::BStr::new(pkg_name.slice(string_buf)),
-                        pkg_res.fmt(string_buf, bun_core::fmt::PathSep::Auto),
+                        redacted(pkg_res.fmt(string_buf, bun_core::fmt::PathSep::Auto)),
                     ),
                 );
             }
@@ -360,7 +361,7 @@ impl<'a> Installer<'a> {
                     "failed to patch package: {}@{}",
                     (
                         bstr::BStr::new(pkg_name.slice(string_buf)),
-                        pkg_res.fmt(string_buf, bun_core::fmt::PathSep::Auto),
+                        redacted(pkg_res.fmt(string_buf, bun_core::fmt::PathSep::Auto)),
                     ),
                 );
                 let _ = patch_log.print(std::ptr::from_mut(Output::error_writer()));
@@ -371,7 +372,7 @@ impl<'a> Installer<'a> {
                     "failed to link binaries for package: {}@{}",
                     (
                         bstr::BStr::new(pkg_name.slice(string_buf)),
-                        pkg_res.fmt(string_buf, bun_core::fmt::PathSep::Auto),
+                        redacted(pkg_res.fmt(string_buf, bun_core::fmt::PathSep::Auto)),
                     ),
                 );
             }
@@ -380,7 +381,7 @@ impl<'a> Installer<'a> {
                     "failed to download <b>{}@{}<r>: {}\n  <d>{}<r>",
                     (
                         bstr::BStr::new(pkg_name.slice(string_buf)),
-                        pkg_res.fmt(string_buf, bun_core::fmt::PathSep::Auto),
+                        redacted(pkg_res.fmt(string_buf, bun_core::fmt::PathSep::Auto)),
                         bstr::BStr::new(download_error_reason(dl.err)),
                         bstr::BStr::new(&dl.url),
                     ),

--- a/src/install/lockfile/Package/Scripts.rs
+++ b/src/install/lockfile/Package/Scripts.rs
@@ -1,7 +1,7 @@
 use bstr::BStr;
 
 use bun_core::ZBox;
-use bun_core::fmt::PathSep;
+use bun_core::fmt::{PathSep, redacted};
 use bun_core::strings;
 use bun_install::lockfile::Lockfile;
 use bun_install::lockfile::Scripts as LockfileScripts;
@@ -427,6 +427,7 @@ impl List {
         format_type: PrintFormat,
     ) {
         let needle = bun_paths::NODE_MODULES_NEEDLE;
+        let resolution = redacted(resolution.fmt(resolution_buf, PathSep::Posix));
         if let Some(i) = strings::index_of(self.cwd.as_bytes(), needle) {
             bun_core::pretty!(
                 "<d>.{s}{s} @{f}<r>\n",
@@ -434,13 +435,13 @@ impl List {
                 BStr::new(strings::without_trailing_slash(
                     &self.cwd.as_bytes()[i + 1..]
                 )),
-                resolution.fmt(resolution_buf, PathSep::Posix),
+                resolution,
             );
         } else {
             bun_core::pretty!(
                 "<d>{s} @{f}<r>\n",
                 BStr::new(strings::without_trailing_slash(self.cwd.as_bytes())),
-                resolution.fmt(resolution_buf, PathSep::Posix),
+                resolution,
             );
         }
 

--- a/src/install/lockfile/printer/tree_printer.rs
+++ b/src/install/lockfile/printer/tree_printer.rs
@@ -4,7 +4,7 @@ use bun_semver as semver;
 
 use crate::lockfile_real::package::PackageColumns as _;
 use crate::package_manager_real::TrackInstalledBin;
-use bun_core::fmt::PathSep;
+use bun_core::fmt::{PathSep, redacted};
 use bun_install::lockfile::{Printer, package::Meta as PackageMeta};
 use bun_install::{
     self as install, Bin, Dependency, DependencyID, INVALID_PACKAGE_ID, PackageID, PackageManager,
@@ -467,6 +467,7 @@ where
     let packages_slice = this.lockfile.packages.slice();
     let resolution: Resolution = packages_slice.items_resolution()[package_id as usize];
     let name = dependency.name.slice(string_buf);
+    let version = redacted(resolution.fmt(string_buf, PathSep::Posix));
 
     let package_name = packages_slice.items_name()[package_id as usize].slice(string_buf);
     if let Some(later_version_fmt) =
@@ -480,7 +481,7 @@ where
                     true
                 ),
                 bstr::BStr::new(name),
-                resolution.fmt(string_buf, PathSep::Posix),
+                version,
                 later_version_fmt,
             )?;
         } else {
@@ -488,7 +489,7 @@ where
                 writer,
                 bun_core::pretty_fmt!("<r>+ {s}<r><d>@{f}<r> <d>(v{f} available)<r>\n", false),
                 bstr::BStr::new(name),
-                resolution.fmt(string_buf, PathSep::Posix),
+                version,
                 later_version_fmt,
             )?;
         }
@@ -501,14 +502,14 @@ where
             writer,
             bun_core::pretty_fmt!("<r><green>+<r> <b>{s}<r><d>@{f}<r>\n", true),
             bstr::BStr::new(name),
-            resolution.fmt(string_buf, PathSep::Posix),
+            version,
         )?;
     } else {
         write!(
             writer,
             bun_core::pretty_fmt!("<r>+ {s}<r><d>@{f}<r>\n", false),
             bstr::BStr::new(name),
-            resolution.fmt(string_buf, PathSep::Posix),
+            version,
         )?;
     }
 
@@ -545,7 +546,7 @@ where
         writer,
         ENABLE_ANSI_COLORS,
         "<d>@{f}<r>",
-        resolution.fmt(string_buf, PathSep::Posix),
+        redacted(resolution.fmt(string_buf, PathSep::Posix)),
     )?;
     writer.write_str(if has_binaries {
         " with binaries:\n"
@@ -732,7 +733,7 @@ where
                 ENABLE_ANSI_COLORS,
                 " <r><b>{s}<r><d>@<b>{f}<r>\n",
                 bstr::BStr::new(package_name),
-                resolved[package_id as usize].fmt(string_buf, PathSep::Auto),
+                redacted(resolved[package_id as usize].fmt(string_buf, PathSep::Auto)),
             )?;
         }
     }

--- a/src/install/patch_install.rs
+++ b/src/install/patch_install.rs
@@ -523,7 +523,7 @@ impl PatchTask {
                         &e,
                         format_args!(
                             "failed trying to open temporary dir to apply patch to package: {}",
-                            BStr::new(&resolution_label)
+                            bun_core::fmt::redacted(BStr::new(&resolution_label))
                         ),
                     );
                     return Ok(());

--- a/src/jsc/AsyncModule.rs
+++ b/src/jsc/AsyncModule.rs
@@ -972,9 +972,11 @@ impl AsyncModule {
                 .string_bytes
                 .as_slice(),
         );
-        let resolution_fmt = result
-            .resolution
-            .fmt(string_bytes.slice(), bun_core::fmt::PathSep::Any);
+        let resolution_fmt = bun_core::fmt::redacted(
+            result
+                .resolution
+                .fmt(string_bytes.slice(), bun_core::fmt::PathSep::Any),
+        );
 
         let mut msg: Vec<u8> = Vec::new();
         let e = result.err;
@@ -1040,13 +1042,15 @@ impl AsyncModule {
                 "{} downloading package '{}@{}'",
                 e,
                 bstr::BStr::new(result.name),
-                result.resolution.fmt(
-                    vm.package_manager()
-                        .lockfile
-                        .buffers
-                        .string_bytes
-                        .as_slice(),
-                    bun_core::fmt::PathSep::Any,
+                bun_core::fmt::redacted(
+                    result.resolution.fmt(
+                        vm.package_manager()
+                            .lockfile
+                            .buffers
+                            .string_bytes
+                            .as_slice(),
+                        bun_core::fmt::PathSep::Any,
+                    )
                 )
             );
         }

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -659,8 +659,9 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
                     let name = dependencies[dependency_id as usize]
                         .name
                         .slice(string_bytes);
-                    let resolution =
-                        resolutions[package_id as usize].fmt(string_bytes, PathSep::Auto);
+                    let resolution = bun_fmt::redacted(
+                        resolutions[package_id as usize].fmt(string_bytes, PathSep::Auto),
+                    );
 
                     if index < sorted_dependencies.len() - 1 {
                         bun_core::prettyln!(
@@ -814,7 +815,7 @@ fn print_node_modules_folder_structure(
                 &mut resolution_buf,
                 format_args!(
                     "{}",
-                    resolutions[id as usize].fmt(string_bytes, PathSep::Auto)
+                    bun_fmt::redacted(resolutions[id as usize].fmt(string_bytes, PathSep::Auto))
                 ),
             );
             if let Some(j) = strings::index_of(path, b"node_modules") {
@@ -940,7 +941,9 @@ fn print_node_modules_folder_structure(
             &mut resolution_buf,
             format_args!(
                 "{}",
-                resolutions[package_id as usize].fmt(string_bytes, PathSep::Auto)
+                bun_fmt::redacted(
+                    resolutions[package_id as usize].fmt(string_bytes, PathSep::Auto)
+                )
             ),
         );
         bun_core::prettyln!(
@@ -1012,7 +1015,8 @@ fn print_trusted_dependencies_flat(
     for (index, &dep_id) in trusted.iter().enumerate() {
         let package_id = resolutions_buf[dep_id as usize];
         let name = dependencies[dep_id as usize].name.slice(string_bytes);
-        let resolution = resolutions[package_id as usize].fmt(string_bytes, PathSep::Auto);
+        let resolution =
+            bun_fmt::redacted(resolutions[package_id as usize].fmt(string_bytes, PathSep::Auto));
         if index + 1 < trusted.len() {
             bun_core::prettyln!(
                 "<d>├──<r> {}<r><d>@{}<r>\n",

--- a/src/runtime/cli/pm_licenses_command.rs
+++ b/src/runtime/cli/pm_licenses_command.rs
@@ -5,7 +5,7 @@ use std::io::Write as _;
 use bstr::BStr;
 use bun_ast::{Expr, Log, Source};
 use bun_collections::{DynamicBitSet, StringHashMap, index_sort};
-use bun_core::fmt::PathSep;
+use bun_core::fmt::{PathSep, redacted};
 use bun_core::{FileKind, Global, Output, strings};
 use bun_install::isolated_install::store::entry::fmt_store_key;
 use bun_install::lockfile::{Lockfile, package::PackageColumns as _, reachable, tree};
@@ -715,7 +715,7 @@ fn print_text(entries: &[Entry], long: bool, checked: usize) {
                 "<d>{}<r> {}<d>@{}<r>",
                 if last { "└──" } else { "├──" },
                 BStr::new(&entry.name),
-                BStr::new(&entry.version)
+                redacted(BStr::new(&entry.version))
             );
             if entry.dev_only {
                 bun_core::pretty!(" <d>(dev)<r>");
@@ -801,7 +801,8 @@ fn print_json(entries: &[Entry]) {
                 if i > 0 {
                     out.extend_from_slice(b", ");
                 }
-                json_string(&mut out, &entry.version);
+                let version = redacted(BStr::new(&entry.version)).to_string();
+                json_string(&mut out, version.as_bytes());
             }
             out.extend_from_slice(b"],\n      \"paths\": [");
             for (i, entry) in kept.iter().enumerate() {

--- a/src/runtime/cli/why_command.rs
+++ b/src/runtime/cli/why_command.rs
@@ -5,7 +5,7 @@ use std::io::Write as _;
 use bstr::BStr;
 
 use bun_collections::HashMap;
-use bun_core::fmt::PathSep;
+use bun_core::fmt::{PathSep, redacted};
 use bun_core::strings;
 use bun_core::{Global, Output};
 use bun_install::dependency::Behavior;
@@ -477,7 +477,7 @@ impl WhyCommand {
             bun_core::prettyln!(
                 "<b>{}@{}<r>",
                 BStr::new(target_name),
-                BStr::new(&target_version.version)
+                redacted(BStr::new(&target_version.version))
             );
 
             if let Some(dependents) = all_dependents.get(&target_version.pkg_id) {
@@ -552,12 +552,12 @@ fn print_package_with_type(prefix: &[u8], package: &DependentInfo) {
     } else {
         bun_core::pretty!("{}", BStr::new(&package.name));
         if !package.version.is_empty() {
-            bun_core::pretty!("<d>@{}<r>", BStr::new(&package.version));
+            bun_core::pretty!("<d>@{}<r>", redacted(BStr::new(&package.version)));
         }
     }
 
     if !package.spec.is_empty() {
-        bun_core::prettyln!(" <d>(requires {})<r>", BStr::new(&package.spec));
+        bun_core::prettyln!(" <d>(requires {})<r>", redacted(BStr::new(&package.spec)));
     } else {
         bun_core::prettyln!("");
     }

--- a/test/cli/install/redacted-config-logs.test.ts
+++ b/test/cli/install/redacted-config-logs.test.ts
@@ -289,9 +289,10 @@ describe.concurrent("tarball and git URLs declared in package.json are masked wh
   }
 
   type Host = { hostname: string; port: number };
-  const spec = ({ hostname, port }: Host) =>
-    `http://carol:${password}@${hostname}:${port}/cdn/direct-1.0.0.tgz?token=${token}`;
-  const masked = ({ hostname, port }: Host) => `http://carol:******@${hostname}:${port}/cdn/direct-1.0.0.tgz?token=***`;
+  const spec = ({ hostname, port }: Host, query = `?token=${token}`) =>
+    `http://carol:${password}@${hostname}:${port}/cdn/direct-1.0.0.tgz${query}`;
+  const masked = ({ hostname, port }: Host, query = "?token=***") =>
+    `http://carol:******@${hostname}:${port}/cdn/direct-1.0.0.tgz${query}`;
 
   const packageJson = (dependency: string) => JSON.stringify({ name: "app", dependencies: { direct: dependency } });
   // What a previous install of `packageJson(dependency)` writes to bun.lock.
@@ -361,8 +362,11 @@ describe.concurrent("tarball and git URLs declared in package.json are masked wh
     await using server = await startTarballServer();
     using dir = tempDir("redacted-resolution-add", { "package.json": JSON.stringify({ name: "app" }) });
 
-    const { out, err, exitCode } = await run(String(dir), server, ["add", spec(server)]);
-    expect(out).toContain(`installed direct@${masked(server)}\n`);
+    // No query string here: `bun add <url>` names its extraction directory
+    // after the URL's basename, and a `?` in a directory name is rejected on
+    // Windows, so a query string makes the add itself fail there.
+    const { out, err, exitCode } = await run(String(dir), server, ["add", spec(server, "")]);
+    expect(out).toContain(`installed direct@${masked(server, "")}\n`);
     expectNoSecrets(out, err);
     expect(exitCode).toBe(0);
   });

--- a/test/cli/install/redacted-config-logs.test.ts
+++ b/test/cli/install/redacted-config-logs.test.ts
@@ -401,6 +401,28 @@ describe.concurrent("tarball and git URLs declared in package.json are masked wh
     expect(why.exitCode).toBe(0);
   });
 
+  test("an npm version whose pre-release tag looks like a UUID is printed unchanged", async () => {
+    await using server = await startTarballServer();
+    const stamped = "1.0.0-a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+    using dir = tempDir("redacted-resolution-versions", {
+      "package.json": JSON.stringify({ name: "app", dependencies: { direct: spec(server), stamped } }),
+      "bun.lock": JSON.stringify({
+        lockfileVersion: 1,
+        workspaces: { "": { name: "app", dependencies: { direct: spec(server), stamped } } },
+        packages: {
+          direct: [`direct@${spec(server)}`, {}, ""],
+          stamped: [`stamped@${stamped}`, "", {}, ""],
+        },
+      }),
+    });
+
+    const { out, err, exitCode } = await run(String(dir), server, ["pm", "ls"]);
+    expect(out).toContain(`direct@${masked(server)}\n`);
+    expect(out).toContain(`stamped@${stamped}\n`);
+    expectNoSecrets(out, err);
+    expect(exitCode).toBe(0);
+  });
+
   test("download failure: retry warnings, the final error and the unresolved dependency", async () => {
     using server = startClosingServer();
     const url = masked(server);

--- a/test/cli/install/redacted-config-logs.test.ts
+++ b/test/cli/install/redacted-config-logs.test.ts
@@ -243,3 +243,203 @@ describe.concurrent("redact", async () => {
     });
   }
 });
+
+// A dependency declared as a tarball or git URL keeps that URL as its
+// resolution, and bun prints the resolution (or the specifier it was declared
+// with) in the install summary, in error messages and in the listing commands.
+// Any credential in the URL has to be masked at each of those places.
+describe.concurrent("tarball and git URLs declared in package.json are masked wherever bun echoes them", () => {
+  const password = "s3cret";
+  const token = "npm_" + "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8";
+
+  async function startTarballServer() {
+    const tarball = await new Bun.Archive(
+      {
+        "package/package.json": JSON.stringify({
+          name: "direct",
+          version: "1.0.0",
+          license: "MIT",
+          scripts: { postinstall: "echo postinstall" },
+        }),
+      },
+      { compress: "gzip" },
+    ).bytes();
+    return Bun.serve({
+      port: 0,
+      fetch(req) {
+        if (new URL(req.url).pathname === "/cdn/direct-1.0.0.tgz") return new Response(tarball);
+        return new Response("not found", { status: 404 });
+      },
+    });
+  }
+
+  // Every download attempt is met with an immediately closed connection, so
+  // the tarball can never be fetched and bun reports the failure by name.
+  function startClosingServer() {
+    return Bun.listen({
+      hostname: "localhost",
+      port: 0,
+      socket: {
+        open(socket) {
+          socket.end();
+        },
+        data() {},
+      },
+    });
+  }
+
+  type Host = { hostname: string; port: number };
+  const spec = ({ hostname, port }: Host) =>
+    `http://carol:${password}@${hostname}:${port}/cdn/direct-1.0.0.tgz?token=${token}`;
+  const masked = ({ hostname, port }: Host) => `http://carol:******@${hostname}:${port}/cdn/direct-1.0.0.tgz?token=***`;
+
+  const packageJson = (dependency: string) => JSON.stringify({ name: "app", dependencies: { direct: dependency } });
+  // What a previous install of `packageJson(dependency)` writes to bun.lock.
+  const bunLock = (dependency: string) =>
+    JSON.stringify({
+      lockfileVersion: 1,
+      workspaces: { "": { name: "app", dependencies: { direct: dependency } } },
+      packages: { direct: [`direct@${dependency}`, {}, ""] },
+    });
+
+  // None of these installs has anything to ask a registry for; pointing the
+  // registry at the test's own server keeps a stray request off the network.
+  async function run(cwd: string, { hostname, port }: Host, args: string[]) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), ...args],
+      cwd,
+      env: {
+        ...bunEnv,
+        npm_config_registry: `http://${hostname}:${port}/`,
+        BUN_INSTALL_CACHE_DIR: join(cwd, ".bun-cache"),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { out, err, exitCode };
+  }
+
+  function expectNoSecrets(...texts: string[]) {
+    for (const text of texts) {
+      expect(text).not.toContain(password);
+      expect(text).not.toContain(token);
+    }
+  }
+
+  test("install summary, then bun pm untrusted and bun pm licenses", async () => {
+    await using server = await startTarballServer();
+    const url = masked(server);
+    using dir = tempDir("redacted-resolution-install", { "package.json": packageJson(spec(server)) });
+
+    const install = await run(String(dir), server, ["install"]);
+    expect(install.out).toContain(`\n+ direct@${url}\n`);
+    expectNoSecrets(install.out, install.err);
+    expect(install.exitCode).toBe(0);
+
+    // The tarball's postinstall was blocked, so `bun pm untrusted` lists the
+    // package along with its resolution.
+    const untrusted = await run(String(dir), server, ["pm", "untrusted"]);
+    expect(untrusted.out).toContain(`direct @${url}\n`);
+    expectNoSecrets(untrusted.out, untrusted.err);
+    expect(untrusted.exitCode).toBe(0);
+
+    const licenses = await run(String(dir), server, ["pm", "licenses"]);
+    expect(licenses.out).toContain(`direct@${url}\n`);
+    expectNoSecrets(licenses.out, licenses.err);
+    expect(licenses.exitCode).toBe(0);
+
+    const licensesJson = await run(String(dir), server, ["pm", "licenses", "--json"]);
+    expect(JSON.parse(licensesJson.out)).toEqual({
+      MIT: [expect.objectContaining({ name: "direct", versions: [url] })],
+    });
+    expectNoSecrets(licensesJson.out, licensesJson.err);
+    expect(licensesJson.exitCode).toBe(0);
+  });
+
+  test("bun add <url>", async () => {
+    await using server = await startTarballServer();
+    using dir = tempDir("redacted-resolution-add", { "package.json": JSON.stringify({ name: "app" }) });
+
+    const { out, err, exitCode } = await run(String(dir), server, ["add", spec(server)]);
+    expect(out).toContain(`installed direct@${masked(server)}\n`);
+    expectNoSecrets(out, err);
+    expect(exitCode).toBe(0);
+  });
+
+  test("bun install --dry-run", async () => {
+    await using server = await startTarballServer();
+    using dir = tempDir("redacted-resolution-dry-run", { "package.json": packageJson(spec(server)) });
+
+    const { out, err, exitCode } = await run(String(dir), server, ["install", "--dry-run"]);
+    expect(out).toContain(` direct@${masked(server)}\n`);
+    expectNoSecrets(out, err);
+    expect(exitCode).toBe(0);
+  });
+
+  test("bun pm ls and bun why read the resolution back out of bun.lock", async () => {
+    await using server = await startTarballServer();
+    const url = masked(server);
+    using dir = tempDir("redacted-resolution-ls", {
+      "package.json": packageJson(spec(server)),
+      "bun.lock": bunLock(spec(server)),
+    });
+
+    const ls = await run(String(dir), server, ["pm", "ls"]);
+    expect(ls.out).toContain(`└── direct@${url}\n`);
+    expectNoSecrets(ls.out, ls.err);
+    expect(ls.exitCode).toBe(0);
+
+    const why = await run(String(dir), server, ["why", "direct"]);
+    expect(why.out).toContain(`direct@${url}\n`);
+    expect(why.out).toContain(`app (requires ${url})\n`);
+    expectNoSecrets(why.out, why.err);
+    expect(why.exitCode).toBe(0);
+  });
+
+  test("download failure: retry warnings, the final error and the unresolved dependency", async () => {
+    using server = startClosingServer();
+    const url = masked(server);
+    using dir = tempDir("redacted-resolution-download-failure", { "package.json": packageJson(spec(server)) });
+
+    const { out, err, exitCode } = await run(String(dir), server, ["install", "--verbose"]);
+    expect(err).toContain(` downloading tarball direct@${url}. Retrying 1/`);
+    expect(err).toContain(` downloading tarball direct@${url}\n`);
+    expect(err).toContain(`error: direct@${url} failed to resolve\n`);
+    expectNoSecrets(out, err);
+    expect(exitCode).toBe(1);
+  });
+
+  test("download failure with the isolated linker and an existing bun.lock", async () => {
+    using server = startClosingServer();
+    using dir = tempDir("redacted-resolution-isolated-download-failure", {
+      "package.json": packageJson(spec(server)),
+      "bun.lock": bunLock(spec(server)),
+    });
+
+    const { err, exitCode } = await run(String(dir), server, ["install", "--linker", "isolated"]);
+    // Only the resolution in the message is asserted: the request URL bun
+    // prints on the following line is a separate operand of this message.
+    expect(err).toContain(`error: failed to download direct@${masked(server)}: `);
+    expect(exitCode).toBe(1);
+  });
+
+  test("git URL specifier", async () => {
+    // The clone fails at once (the connection is closed before TLS starts);
+    // what is being tested is how the specifier is echoed afterwards.
+    using server = startClosingServer();
+    using dir = tempDir("redacted-resolution-git", {
+      "package.json": JSON.stringify({
+        name: "app",
+        dependencies: { repo: `git+https://carol:${password}@${server.hostname}:${server.port}/org/repo.git` },
+      }),
+    });
+
+    const { out, err, exitCode } = await run(String(dir), server, ["install"]);
+    expect(err).toContain(
+      `error: repo@git+https://carol:******@${server.hostname}:${server.port}/org/repo.git failed to resolve\n`,
+    );
+    expectNoSecrets(out, err);
+    expect(exitCode).toBe(1);
+  });
+});

--- a/test/js/bun/util/highlighter.test.ts
+++ b/test/js/bun/util/highlighter.test.ts
@@ -53,6 +53,20 @@ test("redacting highlighter still redacts values", () => {
   expect(out).toContain("*");
 });
 
+// The password of a URL is masked whatever the scheme is: dependency
+// specifiers are `git+https://` and `git+ssh://` URLs as often as `https://`.
+test.each([
+  ["https://user:hunter2@host/repo.git", "https://user:*******@host/repo.git"],
+  ["git+https://user:hunter2@host/repo.git", "git+https://user:*******@host/repo.git"],
+  ["git+ssh://user:hunter2@host:22/repo.git", "git+ssh://user:*******@host:22/repo.git"],
+  // scp-like: the `:` after the host is a path separator, not a password.
+  ["git+ssh://git@host:org/repo.git", "git+ssh://git@host:org/repo.git"],
+  // No scheme, so nothing is treated as a URL.
+  ["user:hunter2@host/repo.git", "user:hunter2@host/repo.git"],
+])("redacting highlighter masks the password in %p", (input, expected) => {
+  expect(highlighterRedacted(`x = "${input}"`)).toContain(`"${expected}"`);
+});
+
 // End-to-end: an error in bunfig.toml whose source line ends with an
 // unterminated template interpolation is printed through the redacting syntax
 // highlighter. This used to panic while printing the error message.


### PR DESCRIPTION
### Problem
- A dependency declared in package.json as a tarball or git URL with credentials, e.g. `"direct": "http://carol:s3cret@host/direct-1.0.0.tgz?token=npm_..."`, has that URL printed verbatim, password and token included, by every line that prints the package's resolution or the specifier it was declared with. On the 1.4.0 release:
  - `+ direct@http://carol:s3cret@...?token=npm_...` in the summary of every `bun install` that installs it (so every fresh CI run), `installed direct@...` after `bun add <url>`, and the `--dry-run` listing
  - `error: direct@http://carol:s3cret@... failed to resolve`, `error: ConnectionRefused downloading tarball direct@http://carol:s3cret@...` and its `--verbose` retry warnings, and the isolated linker's `error: failed to download direct@http://carol:s3cret@...: 404 Not Found` (plus its link, symlink, patch and binary failure messages)
  - `bun pm ls`, `bun why` (both the `name@resolution` lines and the `(requires <specifier>)` suffix), `bun pm untrusted`, `bun pm licenses` (text and `--json` `versions`), and the `--verbose` `Blocked N scripts for: direct@...` line
  - the same for git specifiers: `error: repo@git+https://carol:s3cret@host/org/repo.git failed to resolve`
- Cause: these sites format the lockfile `Resolution` (`src/install/resolution.rs`, `Formatter` writes a remote tarball URL as is; a git resolution goes through `src/install/repository.rs` `Formatter`, likewise) or the dependency's version literal directly. Only the request-URL operands of some of these messages go through `redacted_npm_url` (#36165, and #38817 for the remaining ones); the resolution and literal operands never did.
- `redacted_npm_url` alone would also not have handled git specifiers: `find_url_password` (`src/bun_core/lib.rs`) only recognized a URL starting with `http://` or `https://`, so `git+https://user:pw@...` was not a URL to it. The same gap shows in the config-file highlighter: `highlightJavaScriptRedacted('x = "git+https://user:pw@host/r.git"')` left the password in.

### Fix
- `src/bun_core/fmt.rs`: `redacted(value)`, a `Display` adapter that renders `value` and writes the result out through `redacted_npm_url` (password of the leading URL replaced with one `*` per character, UUIDs and `npm_` tokens with `***`). It renders first because the password scan is anchored at the start of the whole value and the inner formatter may write it in pieces (`git+`, then the repository). A rendered value with no `://` in it (an npm version, a folder or workspace path, a `github:` specifier) is written unchanged: the UUID and token masks are meant for URLs, and without that gate a version such as `1.0.0-a1b2c3d4-e5f6-7890-abcd-ef1234567890` (valid semver, the shape a CI build id produces) would print as `1.0.0-***` at every wrapped site. So for everything that is not a URL dependency the output of the wrapped sites is byte for byte what it was.
- `src/bun_core/lib.rs` `find_url_password`: the scheme is now any RFC 3986 scheme (`[A-Za-z][A-Za-z0-9+.-]*`) followed by `://`, so `git+https://`, `git+ssh://`, `ssh://` and the like are handled; `http`/`https` behave exactly as before. This is the one behavioral change to existing redaction code; its other two callers (`redacted_npm_url` for registry URLs, and the bunfig/.npmrc highlighter) only gain the extra schemes. An scp-style `git+ssh://git@host:org/repo.git` is not affected: its authority has no `:` before the `@`.
- Every site that prints a `Resolution` or a version literal for a human now wraps that argument in `redacted(..)`, and nothing else about the line changes: `tree_printer.rs` (install summary, `bun add` line, `--dry-run` listing), `PackageManagerResolution.rs` (`failed to resolve`, both forms), `runTasks.rs` (`downloading tarball` error, warning and retry warning), `isolated_install/Installer.rs` (all six `failed to ... name@resolution` reports), `isolated_install.rs` (`failed to enqueue tarball`), `processDependencyList.rs` (the three `package.json` errors that print `fmt_url`), `PackageManagerEnqueue.rs` (the `incorrect peer dependency` warning: its condition has a git arm, so it is wrapped even though both of its callers only pass npm, folder, workspace and link specifiers today, which is also why no test can reach it with a URL), `PackageInstaller.rs` (`Blocked N scripts`), `Package/Scripts.rs` (`bun pm untrusted` / `bun pm trust` header), `patch_install.rs`, `package_manager_command.rs` (`bun pm ls`, `--all`, `--trusted`), `why_command.rs`, `pm_licenses_command.rs` (text line and the JSON `versions` field; redacted at the print, not where the version string is built, because that string is also compared against the installed package.json), and `src/jsc/AsyncModule.rs` (the runtime auto-installer's download error message, which formats the same resolution into the thrown error; today only registry packages reach it, since a tarball or git dependency taken from package.json fails earlier on that path, so like the peer warning it is wrapped because the code is generic rather than because a test can reach it with a URL).
- Why a wrapper at the print sites rather than inside the `Resolution` formatter: the same formatter builds keys that must stay byte-exact (the patched-dependency `name@version` keys in `bun.lock.rs`, `pnpm.rs`, `PackageInstaller.rs` and `patch_install.rs`, the lockfile meta-hash in `lockfile.rs`, the `bun patch` argument matching in `patchPackage.rs`). Redacting there would silently change those keys for exactly the URLs this is about; a print site that is missed, by contrast, just keeps today's behavior. The other shape considered was to finish the split `resolution.rs` already describes (`Display` for terminals, `write_to` for persisted output): move those key and hash builders off `Display` and then redact (and escape) once inside the `Resolution` and `Repository` `Display` impls. That removes the per-site wrappers, but its failure mode is the one above (a key builder left on `Display` silently changes lockfile hashes and patch keys for credentialed URLs), and the meta-hash and patch-key sites would need their own byte-exact formatter first, so it is a separate refactor rather than this fix. Per-site wrapping is also the shape #36165 / #38796 / #38817 use for URL operands and #38631 uses for control-character escaping at these same sites.
- Left as they are, on purpose: `Resolution` prints inside match arms that can only hold an npm version, a folder, workspace or link path, or a `github:owner/repo` (`PackageManagerEnqueue.rs`'s two `--verbose` resolve-trace lines, the npm and github `failed to enqueue` arms in `isolated_install.rs`); the candidate list `bun patch <name>` prints when the name is ambiguous, since the user is told to paste one of those entries back; `bun pm hash-string` and the `--verbose` copy of it, which print the exact bytes that were hashed; the request-URL operands (`GET <url> - 404`, the URL line under the isolated `failed to download` message), which #38817 converts. The placeholder *name* a failed `bun add <url>` leaves behind (`Invalid dependency name "<url>"`) and the isolated store directory name, which embeds the URL, are different mechanisms and are tracked separately.
- Overlap with the open escaping work, and why this is based on main rather than stacked on it: #38631 wraps most of the same arguments in `EscapeControlChars(..)` (#38525 hoists the same `Scripts.rs` line, #38615 rewrites the two `failed to resolve` arguments to the byte-slice escaper), and it is itself behind main at the moment, so stacking would tie a small hygiene fix to its rebase schedule without removing any work: whichever side lands second resolves each of these lines by composition, which is mechanical in either order. The rule is redact inside, escape outside, because the password scan stops at a newline and must see the raw text: `EscapeControlChars(redacted(x.fmt(..)))`, or `EscapeControlChars(redacted(BStr::new(bytes)))` where a site was converted to `escape_control_chars(bytes)`. #38817 converts the request-URL operands of the same messages and carries a `test.todo` placeholder for the lines this PR changes; the block added here is that test, so whichever of the two rebases second drops the todo.
- Verified with `test/cli/install/redacted-config-logs.test.ts` (new block, 8 tests: install summary plus `pm untrusted` / `pm licenses` / `pm licenses --json`, `bun add <url>` (without a query string: `bun add <url>` names its extraction directory after the URL's basename, and Windows rejects the `?`, which is a pre-existing bug tracked separately), `--dry-run`, `pm ls` and `why` from a bun.lock, the download failure with its `--verbose` retry warnings and `failed to resolve`, the isolated linker's `failed to download` line, a `git+https://` specifier, and a bun.lock holding both a credentialed tarball and an npm package at a UUID-shaped version, where `bun pm ls` must mask the first and print the second unchanged) and `test/js/bun/util/highlighter.test.ts` (password behind `https://`, `git+https://` and `git+ssh://` is masked; scp-style and scheme-less strings are untouched). All 8 install tests and the two `git+` highlighter rows fail on the unfixed build with the raw URL in the output (the UUID one would also fail on an ungated adapter, with `stamped@1.0.0-***`); the whole of both files passes with this change.
- Also ran `bun-pm`, `bun-pm-why`, `bun-pm-licenses`, `bun-add`, `bun-install-retry`, `isolated-install` and the trust/untrusted cases of `bun-install-lifecycle-scripts` (output for ordinary versions and URLs is byte for byte unchanged), `cargo clippy` on `bun_core`, `bun_install`, `bun_runtime`, `cargo fmt`, and the byte-search and pub-exports source lints.

### Background
- A package's *resolution* is how bun records where it came from: for a registry package it prints as the version (`pkg@1.0.0`); for a dependency declared as a tarball or git URL it prints as that URL (git ones as `git+<url>#<commit>`). The *version literal* is the specifier string as written in the declaring package.json, which for these dependencies is the same URL. The resolution formatter is used both for output and to build lookup keys, which is why this change does not touch it.
- `redacted_npm_url` (`src/bun_core/fmt.rs`) is the existing `Display` adapter over URL bytes used for registry URLs in error output; `redacted` is the same masking for values that only exist as a `Display` impl.
- In RFC 3986 a scheme is `ALPHA *(ALPHA / DIGIT / "+" / "-" / ".")`, so `git+https` is a single scheme; the `user:password@host` authority syntax is the same for every scheme, which is what the generalized `find_url_password` relies on.
- With `--linker isolated`, a tarball still missing at install time is downloaded by the store installer, whose failures are reported through `Installer.rs` (`failed to download name@resolution: reason`, then the request URL on its own line); the hoisted linker reports the same failure from `runTasks.rs` (`<error> downloading tarball name@resolution`, or `GET <url> - <status>` for an HTTP error status), followed by `name@literal failed to resolve`.


