### PR TITLE
Report a failed allocation inside ICU as out of memory instead of crashing inside ICU

### DIFF
--- a/src/bun_bin/c_abi_exports.rs
+++ b/src/bun_bin/c_abi_exports.rs
@@ -21,8 +21,9 @@ extern "C" fn Bun__panic(msg: *const u8, len: usize) -> ! {
     bun_core::output::panic(format_args!("{}", bstr::BStr::new(bytes)));
 }
 
-/// Out-of-memory entry point for C callers (bun-usockets) that cannot
-/// propagate an allocation failure. Same crash report as `handle_oom`.
+/// Out-of-memory entry point for C/C++ callers (bun-usockets, the ICU heap
+/// hook in `bun_icu_memory.cpp`) that cannot propagate an allocation failure.
+/// Same crash report as `handle_oom`.
 #[unsafe(no_mangle)]
 extern "C" fn Bun__outOfMemory() -> ! {
     bun_core::out_of_memory()

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -3319,6 +3319,13 @@ mod draft {
         }
     }
 
+    /// `suppress_core_dumps_if_necessary` for the C++ test hooks that crash on
+    /// purpose (`failICUAllocationForTesting` in `bun_icu_memory.cpp`).
+    #[unsafe(no_mangle)]
+    extern "C" fn CrashHandler__suppressCoreDumps() {
+        suppress_core_dumps_if_necessary();
+    }
+
     /// From now on, prevent crashes from being reported to bun.report or the URL overridden in
     /// BUN_CRASH_REPORT_URL. Should only be used for tests that are going to intentionally crash,
     /// so that they do not fail CI due to having a crash reported. And those cases should guard behind

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -3319,8 +3319,7 @@ mod draft {
         }
     }
 
-    /// `suppress_core_dumps_if_necessary` for the C++ test hooks that crash on
-    /// purpose (`failICUAllocationForTesting` in `bun_icu_memory.cpp`).
+    /// `suppress_core_dumps_if_necessary` for C++ test hooks that crash on purpose.
     #[unsafe(no_mangle)]
     extern "C" fn CrashHandler__suppressCoreDumps() {
         suppress_core_dumps_if_necessary();

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -691,6 +691,19 @@ export const isMemoryPressureWatcherInstalled: () => boolean = $newCppFunction(
   0,
 );
 
+/**
+ * Makes the ICU allocation after the next `skip` (default 0) fail, exactly as
+ * if malloc had returned null inside ICU. The process then dies with Bun's
+ * out-of-memory report, so only call this in a child process, right before
+ * the Intl operation that should hit it. No-op on macOS, which uses the
+ * system ICU.
+ */
+export const failICUAllocationForTesting: (skip?: number) => void = $newCppFunction(
+  "InternalForTesting.cpp",
+  "jsFunction_failICUAllocation",
+  1,
+);
+
 export const getEventLoopStats: () => { activeTasks: number; concurrentRef: number; numPolls: number } =
   $newRustFunction("event_loop.rs", "getActiveTasks", 0);
 

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -692,11 +692,9 @@ export const isMemoryPressureWatcherInstalled: () => boolean = $newCppFunction(
 );
 
 /**
- * Makes the ICU allocation after the next `skip` (default 0) fail, exactly as
- * if malloc had returned null inside ICU. The process then dies with Bun's
- * out-of-memory report, so only call this in a child process, right before
- * the Intl operation that should hit it. No-op on macOS, which uses the
- * system ICU.
+ * Fails the ICU allocation after the next `skip` (default 0) ones, which kills
+ * the process with Bun's out-of-memory report: call it in a child process right
+ * before the Intl operation that should die. No-op on macOS (system ICU).
  */
 export const failICUAllocationForTesting: (skip?: number) => void = $newCppFunction(
   "InternalForTesting.cpp",

--- a/src/jsc/bindings/InternalForTesting.cpp
+++ b/src/jsc/bindings/InternalForTesting.cpp
@@ -125,10 +125,6 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_isMemoryPressureWatcherInstalled, (JSC::JSGl
     return JSValue::encode(jsBoolean(Bun__MemoryPressure__isInstalled(defaultGlobalObject(globalObject))));
 }
 
-// Arms the ICU heap hook (bun_icu_memory.cpp): after `skip` more ICU
-// allocations succeed, the next one fails the way a null from malloc would,
-// so the calling process ends in Bun's out-of-memory report. Tests call this
-// in a child process right before the Intl operation they want to fail.
 JSC_DEFINE_HOST_FUNCTION(jsFunction_failICUAllocation, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     auto& vm = globalObject->vm();

--- a/src/jsc/bindings/InternalForTesting.cpp
+++ b/src/jsc/bindings/InternalForTesting.cpp
@@ -6,6 +6,7 @@
 #include "JavaScriptCore/JSArrayBufferView.h"
 #include "headers-handwritten.h"
 #include "webcore/HTTPHeaderMap.h"
+#include "bun_icu_memory.h"
 #include <wtf/text/StringImpl.h>
 #include <wtf/text/WTFString.h>
 
@@ -122,6 +123,24 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_emitMemoryPressure, (JSC::JSGlobalObject * g
 JSC_DEFINE_HOST_FUNCTION(jsFunction_isMemoryPressureWatcherInstalled, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     return JSValue::encode(jsBoolean(Bun__MemoryPressure__isInstalled(defaultGlobalObject(globalObject))));
+}
+
+// Arms the ICU heap hook (bun_icu_memory.cpp): after `skip` more ICU
+// allocations succeed, the next one fails the way a null from malloc would,
+// so the calling process ends in Bun's out-of-memory report. Tests call this
+// in a child process right before the Intl operation they want to fail.
+JSC_DEFINE_HOST_FUNCTION(jsFunction_failICUAllocation, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+{
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    double skip = callFrame->argument(0).toIntegerOrInfinity(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    if (!(skip >= 0 && skip <= static_cast<double>(INT32_MAX))) {
+        throwRangeError(globalObject, scope, "skip must be a non-negative integer"_s);
+        return {};
+    }
+    failICUAllocationForTesting(static_cast<size_t>(skip));
+    return encodedJSUndefined();
 }
 
 }

--- a/src/jsc/bindings/InternalForTesting.h
+++ b/src/jsc/bindings/InternalForTesting.h
@@ -13,5 +13,6 @@ JSC_DECLARE_HOST_FUNCTION(jsFunction_BunString_toThreadSafeRefCountDelta);
 JSC_DECLARE_HOST_FUNCTION(jsFunction_lowercaseHeaderNameSIMD);
 JSC_DECLARE_HOST_FUNCTION(jsFunction_emitMemoryPressure);
 JSC_DECLARE_HOST_FUNCTION(jsFunction_isMemoryPressureWatcherInstalled);
+JSC_DECLARE_HOST_FUNCTION(jsFunction_failICUAllocation);
 
 }

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -216,6 +216,7 @@
 #include <mutex>
 #include "JSBunRequest.h"
 #include "ServerRouteList.h"
+#include "bun_icu_memory.h"
 
 #if ENABLE(REMOTE_INSPECTOR)
 #include "JavaScriptCore/RemoteInspectorServer.h"
@@ -294,6 +295,7 @@ extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(c
         JSC::Config::enableRestrictedOptions();
 
         std::set_terminate([]() { Zig__GlobalObject__onCrash(); });
+        Bun::installICUMemoryFunctions();
         WTF::initializeMainThread();
 
         // Use JSC::initialize with a callback to set Options during initialization.

--- a/src/jsc/bindings/bun_icu_memory.cpp
+++ b/src/jsc/bindings/bun_icu_memory.cpp
@@ -1,0 +1,90 @@
+// ICU reports a failed allocation through a UErrorCode when it can, but its
+// copy constructors and assignment operators have nowhere to report one, so a
+// null from malloc inside udat_clone / ucal_clone / ubrk_clone (which JSC's
+// Intl.DateTimeFormat and Intl.Segmenter call per format/segment) either
+// segfaults inside ICU or yields a formatter that silently produces wrong
+// output. Routing ICU's heap through these wrappers turns every such failure
+// into Bun's regular out-of-memory crash report instead.
+//
+// The wrappers call the same malloc/realloc/free ICU uses by default
+// (cmemory.cpp), so anything ICU allocated before JSCInitialize installed them
+// is still freed by the matching function. ICU serves zero-byte requests
+// itself and only calls out for non-zero sizes, so a null here is a failure.
+
+#include "root.h"
+#include "bun_icu_memory.h"
+#include "headers-handwritten.h"
+
+#if !OS(DARWIN)
+
+#include <unicode/uclean.h>
+
+#include <atomic>
+#include <cstdlib>
+
+namespace Bun {
+
+// Negative when disarmed; otherwise how many more allocations succeed before
+// one is failed.
+static std::atomic<int64_t> s_allocationsUntilInjectedFailure { -1 };
+
+static bool shouldInjectFailure()
+{
+    if (s_allocationsUntilInjectedFailure.load(std::memory_order_relaxed) < 0) [[likely]]
+        return false;
+    return s_allocationsUntilInjectedFailure.fetch_sub(1, std::memory_order_relaxed) == 0;
+}
+
+static void* checkedICUAllocation(void* ptr)
+{
+    if (!ptr) [[unlikely]]
+        Bun__outOfMemory();
+    return ptr;
+}
+
+static void* U_CALLCONV icuMalloc(const void*, size_t size)
+{
+    return checkedICUAllocation(shouldInjectFailure() ? nullptr : ::malloc(size));
+}
+
+static void* U_CALLCONV icuRealloc(const void*, void* ptr, size_t size)
+{
+    return checkedICUAllocation(shouldInjectFailure() ? nullptr : ::realloc(ptr, size));
+}
+
+static void U_CALLCONV icuFree(const void*, void* ptr)
+{
+    ::free(ptr);
+}
+
+void installICUMemoryFunctions()
+{
+    UErrorCode status = U_ZERO_ERROR;
+    u_setMemoryFunctions(nullptr, icuMalloc, icuRealloc, icuFree, &status);
+    RELEASE_ASSERT(U_SUCCESS(status));
+}
+
+void failICUAllocationForTesting(size_t skip)
+{
+    s_allocationsUntilInjectedFailure.store(static_cast<int64_t>(skip), std::memory_order_relaxed);
+}
+
+} // namespace Bun
+
+#else
+
+// macOS links the SDK's libicucore, which every framework in the process
+// shares, so its allocator is left alone.
+namespace Bun {
+
+void installICUMemoryFunctions()
+{
+}
+
+void failICUAllocationForTesting(size_t)
+{
+}
+
+} // namespace Bun
+
+#endif

--- a/src/jsc/bindings/bun_icu_memory.cpp
+++ b/src/jsc/bindings/bun_icu_memory.cpp
@@ -22,6 +22,8 @@
 #include <atomic>
 #include <cstdlib>
 
+extern "C" void CrashHandler__suppressCoreDumps();
+
 namespace Bun {
 
 // Negative when disarmed; otherwise how many more allocations succeed before
@@ -66,6 +68,9 @@ void installICUMemoryFunctions()
 
 void failICUAllocationForTesting(size_t skip)
 {
+    // The crash this arms is intended, like the crash_handler test hooks'; the
+    // core-dump-collecting CI lanes must not treat its core as a failure.
+    CrashHandler__suppressCoreDumps();
     s_allocationsUntilInjectedFailure.store(static_cast<int64_t>(skip), std::memory_order_relaxed);
 }
 

--- a/src/jsc/bindings/bun_icu_memory.cpp
+++ b/src/jsc/bindings/bun_icu_memory.cpp
@@ -1,15 +1,11 @@
-// ICU reports a failed allocation through a UErrorCode when it can, but its
-// copy constructors and assignment operators have nowhere to report one, so a
-// null from malloc inside udat_clone / ucal_clone / ubrk_clone (which JSC's
-// Intl.DateTimeFormat and Intl.Segmenter call per format/segment) either
-// segfaults inside ICU or yields a formatter that silently produces wrong
-// output. Routing ICU's heap through these wrappers turns every such failure
-// into Bun's regular out-of-memory crash report instead.
+// ICU's copy constructors and clone() have no UErrorCode to report a failed
+// allocation through, so a null from malloc inside udat_format/udat_clone/
+// ucal_clone/ubrk_clone segfaults inside ICU or yields a formatter that prints
+// the wrong thing. These wrappers turn it into Bun's out-of-memory report.
 //
-// The wrappers call the same malloc/realloc/free ICU uses by default
-// (cmemory.cpp), so anything ICU allocated before JSCInitialize installed them
-// is still freed by the matching function. ICU serves zero-byte requests
-// itself and only calls out for non-zero sizes, so a null here is a failure.
+// They call the same malloc/realloc/free ICU defaults to (cmemory.cpp), so the
+// install point does not matter, and ICU serves zero-byte requests itself, so
+// a null here is always a failure.
 
 #include "root.h"
 #include "bun_icu_memory.h"
@@ -26,8 +22,7 @@ extern "C" void CrashHandler__suppressCoreDumps();
 
 namespace Bun {
 
-// Negative when disarmed; otherwise how many more allocations succeed before
-// one is failed.
+// Negative while disarmed.
 static std::atomic<int64_t> s_allocationsUntilInjectedFailure { -1 };
 
 static bool shouldInjectFailure()
@@ -68,8 +63,7 @@ void installICUMemoryFunctions()
 
 void failICUAllocationForTesting(size_t skip)
 {
-    // The crash this arms is intended, like the crash_handler test hooks'; the
-    // core-dump-collecting CI lanes must not treat its core as a failure.
+    // Intended crash: keep the coredump-collecting CI lanes from flagging it.
     CrashHandler__suppressCoreDumps();
     s_allocationsUntilInjectedFailure.store(static_cast<int64_t>(skip), std::memory_order_relaxed);
 }
@@ -78,8 +72,7 @@ void failICUAllocationForTesting(size_t skip)
 
 #else
 
-// macOS links the SDK's libicucore, which every framework in the process
-// shares, so its allocator is left alone.
+// macOS uses the system libicucore, shared with every framework in the process.
 namespace Bun {
 
 void installICUMemoryFunctions()

--- a/src/jsc/bindings/bun_icu_memory.h
+++ b/src/jsc/bindings/bun_icu_memory.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "root.h"
+
+namespace Bun {
+
+// Points ICU's heap functions at malloc/realloc/free wrappers that die through
+// Bun__outOfMemory() instead of handing ICU a null pointer. Called once from
+// JSCInitialize; a no-op on Darwin, where ICU is the system libicucore.
+void installICUMemoryFunctions();
+
+// Test hook: after letting `skip` more ICU allocations succeed, fail the next
+// one exactly as if malloc had returned null.
+void failICUAllocationForTesting(size_t skip);
+
+} // namespace Bun

--- a/src/jsc/bindings/bun_icu_memory.h
+++ b/src/jsc/bindings/bun_icu_memory.h
@@ -4,13 +4,10 @@
 
 namespace Bun {
 
-// Points ICU's heap functions at malloc/realloc/free wrappers that die through
-// Bun__outOfMemory() instead of handing ICU a null pointer. Called once from
-// JSCInitialize; a no-op on Darwin, where ICU is the system libicucore.
+// Makes a failed allocation inside ICU terminate through Bun__outOfMemory(); see the .cpp.
 void installICUMemoryFunctions();
 
-// Test hook: after letting `skip` more ICU allocations succeed, fail the next
-// one exactly as if malloc had returned null.
+// Fails the ICU allocation after the next `skip` ones, as if malloc had returned null.
 void failICUAllocationForTesting(size_t skip);
 
 } // namespace Bun

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -176,6 +176,7 @@ inline constexpr ZigStackFrameCode ZigStackFrameCodeConstructor = 6;
 
 extern "C" void __attribute((__noreturn__)) Bun__panic(const char* message, size_t length);
 #define BUN_PANIC(message) Bun__panic(message, sizeof(message) - 1)
+extern "C" void __attribute((__noreturn__)) Bun__outOfMemory();
 
 typedef struct ZigStackFramePosition {
     int32_t line_zero_based;

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -203,6 +203,37 @@ describe.skipIf(isMacOS)("an allocation failure inside ICU is reported as out of
     if (isPosix) expect(proc.signalCode).toBe("SIGABRT");
     expect(exitCode).not.toBe(0);
   });
+
+  // Like the crash_handler test hooks, arming disables core dumps, so the
+  // intended crash above does not leave a core for the coredump-upload CI
+  // lanes to flag. The shell raises the soft limit as far as the hard limit
+  // allows first (where the hard limit is already 0 there is nothing to
+  // observe), and the failure is armed far enough out that nothing in the
+  // script hits it.
+  test.skipIf(!isLinux).concurrent("arming the failure disables core dumps", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        "/bin/sh",
+        "-c",
+        `ulimit -c "$(ulimit -H -c)" 2>/dev/null; exec "$0" "$@"`,
+        bunExe(),
+        "-e",
+        `const { failICUAllocationForTesting } = require("bun:internal-for-testing");
+         const softCoreLimit = () =>
+           require("fs").readFileSync("/proc/self/limits", "utf8").match(/^Max core file size\\s+(\\S+)/m)[1];
+         const before = softCoreLimit();
+         failICUAllocationForTesting(2 ** 31 - 1);
+         console.log(JSON.stringify({ before, after: softCoreLimit() }));`,
+      ],
+      env: noReportEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ before: expect.any(String), after: "0" });
+    expect(exitCode).toBe(0);
+  });
 });
 
 // POSIX-only: Windows refuses to remove a directory that is any process's cwd.

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -1,6 +1,17 @@
 import { crash_handler } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isDebug, isLinux, isPosix, isWindows, mergeWindowEnvs, tempDir } from "harness";
+import {
+  bunEnv,
+  bunExe,
+  isASAN,
+  isDebug,
+  isLinux,
+  isMacOS,
+  isPosix,
+  isWindows,
+  mergeWindowEnvs,
+  tempDir,
+} from "harness";
 import { rmSync } from "node:fs";
 import path from "path";
 const { getMachOImageZeroOffset } = crash_handler;
@@ -126,6 +137,71 @@ describe.if(isPosix)("terminal signal reflects the crash cause", () => {
     expect(proc.signalCode).toBe(expectedSignal);
     expect(exitCode).not.toBe(0);
     void stdout;
+  });
+});
+
+// ICU can only report a failed allocation when the failing call has a status
+// out-parameter. The clones that udat_format, udat_clone, ucal_clone and
+// ubrk_clone perform internally have none, so a null from malloc there used to
+// segfault inside ICU or hand back a formatter that prints the wrong thing.
+// Bun owns ICU's heap functions (src/jsc/bindings/bun_icu_memory.cpp), so a
+// failed ICU allocation now ends in the ordinary out-of-memory report.
+//
+// Each Intl object is built before the failure is armed so that it is the
+// per-call work, where those clones live, that loses an allocation; which of
+// its allocations fails (the first or the second) must not matter. macOS uses
+// the system ICU, whose allocator Bun leaves alone.
+describe.skipIf(isMacOS)("an allocation failure inside ICU is reported as out of memory", () => {
+  const operations = [
+    [
+      "Intl.DateTimeFormat#format",
+      `const dtf = new Intl.DateTimeFormat("en", { dateStyle: "full", timeStyle: "long", timeZone: "America/Los_Angeles" });
+       const value = new Date(1700000000000);`,
+      `dtf.format(value)`,
+    ],
+    [
+      "Intl.DateTimeFormat#format of a Temporal.PlainDate",
+      `const dtf = new Intl.DateTimeFormat("en", { timeZone: "UTC" });
+       const value = Temporal.PlainDate.from("2023-11-14");`,
+      `dtf.format(value)`,
+    ],
+    [
+      "Intl.DateTimeFormat#formatRange before the Gregorian changeover",
+      `const dtf = new Intl.DateTimeFormat("en", { timeZone: "UTC" });
+       const start = new Date(Date.UTC(1500, 0, 1)), end = new Date(Date.UTC(1500, 0, 2));`,
+      `dtf.formatRange(start, end)`,
+    ],
+    [
+      "Intl.Segmenter#segment",
+      `const segmenter = new Intl.Segmenter("en", { granularity: "word" });`,
+      `[...segmenter.segment("out of memory")].length`,
+    ],
+  ] as const;
+  const cases = operations.flatMap(([name, setup, operation]) =>
+    [1, 2].map(ordinal => [name, ordinal, setup, operation] as const),
+  );
+
+  test.concurrent.each(cases)("%s when its ICU allocation #%i fails", async (_name, ordinal, setup, operation) => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "--debug-crash-handler-use-trace-string",
+        "-e",
+        `const { failICUAllocationForTesting } = require("bun:internal-for-testing");
+         ${setup}
+         failICUAllocationForTesting(${ordinal - 1});
+         console.log("survived:", ${operation});`,
+      ],
+      env: noReportEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain("Bun has run out of memory");
+    expect(stderr).not.toContain("Segmentation fault");
+    expect(stdout).toBe("");
+    if (isPosix) expect(proc.signalCode).toBe("SIGABRT");
+    expect(exitCode).not.toBe(0);
   });
 });
 

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -140,17 +140,12 @@ describe.if(isPosix)("terminal signal reflects the crash cause", () => {
   });
 });
 
-// ICU can only report a failed allocation when the failing call has a status
-// out-parameter. The clones that udat_format, udat_clone, ucal_clone and
-// ubrk_clone perform internally have none, so a null from malloc there used to
-// segfault inside ICU or hand back a formatter that prints the wrong thing.
-// Bun owns ICU's heap functions (src/jsc/bindings/bun_icu_memory.cpp), so a
-// failed ICU allocation now ends in the ordinary out-of-memory report.
-//
-// Each Intl object is built before the failure is armed so that it is the
-// per-call work, where those clones live, that loses an allocation; which of
-// its allocations fails (the first or the second) must not matter. macOS uses
-// the system ICU, whose allocator Bun leaves alone.
+// The clones inside udat_format, udat_clone, ucal_clone and ubrk_clone cannot
+// report a failed allocation, so a null from malloc there used to segfault in
+// ICU or produce wrong output; src/jsc/bindings/bun_icu_memory.cpp turns it
+// into the out-of-memory report. Each Intl object is built before arming so the
+// per-call work (where the clones are) is what loses an allocation, and which
+// one (first or second) must not matter. macOS uses the system ICU, unhooked.
 describe.skipIf(isMacOS)("an allocation failure inside ICU is reported as out of memory", () => {
   const operations = [
     [


### PR DESCRIPTION
### Problem
- Field report: #32133, `Segmentation fault at address 0x10` in `icu::RuleBasedBreakIterator::BreakCache::reset` <- `ubrk_clone` <- `Intl.Segmenter.prototype.segment`, on Windows, where ICU's `malloc` (the static CRT's) returns null once the process is out of commit. The report reads as a Bun bug; the process was out of memory.
- The Segmenter is not the only shape. Failing each allocation an operation makes in turn, against the ICU 78.3 in the current prebuilt (fault injection, no field reports for these; probe and stacks in the details below):
  - `udat_format` (every `Intl.DateTimeFormat#format`) makes 2 allocations; failing the first segfaults in `icu::Calendar::computeFields` (`calendar.cpp:1412`).
  - `udat_clone` (JSC's Temporal formatting paths, `IntlDateTimeFormat.cpp:2200`, `2228`, `2264`, `2370`) makes 60: 11 crash the process (8 SIGSEGV, e.g. `DecimalFormat::setupFastFormat` via `DateFormat::operator=`; 3 `free(): invalid pointer` aborts in `SimpleNumber::cleanup`), 4 return `U_ZERO_ERROR` with a clone that formats `""` or `","` instead of the date, 1 is reported.
  - `ucal_clone` (`formatRange` before 1582, `IntlDateTimeFormat.cpp:1629`) makes 3; failing the second returns `U_ZERO_ERROR` with a calendar whose time zone is null, which segfaults on first use.
- Cause: ICU can only report a failed allocation when the failing call has a `UErrorCode*`. Copy constructors, `operator=` and `clone()` have none, so `Calendar::operator=` does `fZone = right.fZone->clone()` unchecked, `SimpleDateFormat::operator=` does the same for a dozen members, and the C wrappers (`udat_clone`, `ucal_clone`, `ubrk_clone`) only null-check the outer object. JSC checks every status it is handed (`IntlSegmenter.cpp:131`, the `U_FAILURE` checks after each clone above); in these cases there is nothing to hand it. Four ICU classes show up in this one probe, so fixing ICU one class at a time (what oven-sh/WebKit#441 does for the Segmenter) does not close the hole.
- On Linux the same null comes from the mimalloc override under a hard limit; the realistic population is Windows under memory pressure.

### Fix
- `src/jsc/bindings/bun_icu_memory.cpp`: `JSCInitialize` calls `u_setMemoryFunctions` with wrappers around `malloc`/`realloc`/`free` that call `Bun__outOfMemory()` when the result is null. Every ICU allocation goes through `uprv_malloc`/`uprv_realloc` (ICU's `operator new` included), so a failed allocation anywhere in ICU, including the ones ICU would have swallowed, ends in Bun's ordinary `oh no: Bun has run out of memory` report (SIGABRT plus a trace string pointing at the ICU caller) instead of a segfault, wrong output, or a report blaming Bun. Fixes #32133 in that sense: the crash becomes an out-of-memory report, not a catchable error.
- Relationship to #38963 (WebKit bump carrying oven-sh/WebKit#441): that change makes `ubrk_clone` report the failure so `segment()` throws a `TypeError`. With this hook installed ICU never sees the null, so in Bun that patched path can no longer execute and the two PRs are alternatives, not complements: land this one and close #38963 (its preview also carries WebKit changes that have their own bump PRs, so nothing else is lost), or decide that ICU allocation failures should stay catchable and close this one. Landing both leaves one of them dead.
- Why terminating is the right response: it is what every other allocator in the process already does on a null (`handle_oom` for Rust, `Bun__outOfMemory` in usockets, WTF `fastMalloc` and bmalloc crash), and ICU is the one allocator whose failures were neither reported reliably nor fatal. The cost is that the failures ICU does report today, which JSC turns into a `TypeError`/`RangeError` (the first allocation of `ubrk_clone` or `udat_clone`, most `Intl` constructors), terminate too; by then a small `malloc` has failed, so the next Bun or WTF allocation would have terminated the process anyway, and ICU's state after a swallowed failure is what produced the wrong output above. This is the policy call for the maintainer; the rest of the PR does not change if it goes the other way, it just gets closed.
- Why delegating to plain `malloc` is what makes this safe to install from `JSCInitialize`: ICU's defaults are the unmodified `malloc`/`realloc`/`free` (checked in the prebuilt's `cmemory.o`: its only undefined symbols are `malloc`, `realloc`, `free`, `memset`). ICU is statically linked into the same executable as the hook on every platform this applies to, so ICU's references and the hook's resolve to the one `malloc` that link has (the mimalloc override on Linux, musl and Android, the static UCRT's on Windows, libc's on FreeBSD and in ASAN builds), and anything ICU allocated before the hook went in is freed by the matching function whichever side frees it. `u_setMemoryFunctions` in ICU 78 stores the pointers unconditionally (its only checks are the incoming status and non-null arguments), and ICU serves zero-byte requests itself and only calls the hooks for non-zero sizes, so a null really is a failure. Processes that never initialize JSC (`bun install`) are unchanged.
- macOS is excluded (`!OS(DARWIN)`): Bun links the SDK's `libicucore` there, which every framework in the process shares, so its allocator is left alone and behavior on macOS is unchanged.
- `failICUAllocationForTesting(skip)` (`bun:internal-for-testing`, `InternalForTesting.cpp`) arms the hook to fail the allocation after the next `skip`; a relaxed atomic load per ICU allocation is the only cost when disarmed. Nothing in JS can otherwise make a 32 byte `malloc` inside ICU fail. Like the `crash_handler.*` test hooks, arming calls `suppress_core_dumps_if_necessary()` (exported to C++ as `CrashHandler__suppressCoreDumps`), so the intended crash leaves no core for the coredump-collecting CI lanes to flag.
- Verified:
  - `test/cli/run/run-crash-handler.test.ts`, "an allocation failure inside ICU is reported as out of memory": for `DateTimeFormat#format` (Date and `Temporal.PlainDate`), `formatRange` before 1582 and `Segmenter#segment`, with the first and with the second ICU allocation of the call failing, the child prints the out-of-memory report, no "Segmentation fault", never reaches the line after the call, and dies with SIGABRT. 8 cases, plus one that checks arming drops the soft core limit to 0; all fail on the current release (the knob does not exist) and pass with this change; the whole file passes on the debug ASAN build.
  - `test/js/web/intl/intl.test.ts` passes under the debug ASAN build with the hook installed (33 tests, 6249 assertions, including the 620-locale sweep), so ICU's allocate/free traffic still pairs up.
  - Collator, `toLocaleUpperCase`, `normalize`, IDNA in `URL`, NumberFormat, RelativeTimeFormat, a Japanese-calendar DateTimeFormat, Temporal and a Worker using Intl all still produce the expected output with the hook installed.

### Background
- ICU has no exceptions. A function that takes a `UErrorCode*` sets `U_MEMORY_ALLOCATION_ERROR` when it cannot allocate; anything without one (copy constructors, `operator=`, `clone()`) leaves the object half-built and returns. The `u*_clone` C entry points JSC calls wrap those copy constructors and can only tell whether the outermost object was allocated.
- `u_setMemoryFunctions` (`unicode/uclean.h`) is ICU's supported way to replace the three functions behind `uprv_malloc`/`uprv_realloc`/`uprv_free`, which all ICU allocations, including `new` of ICU objects, go through. It takes a context pointer plus the three functions and is meant to be called once per process.
- `Bun__outOfMemory()` (`src/bun_bin/c_abi_exports.rs`) is the C entry point for Bun's out-of-memory crash report, the same path `handle_oom` takes for Rust allocations; usockets already uses it. The report names the cause as out of memory rather than a Bun bug and its trace string carries the stack, so bun.report groups these by the ICU caller.
- Bun's prebuilt JavaScriptCore from oven-sh/WebKit bundles a static ICU on Linux, musl, Windows, FreeBSD and Android; on macOS it uses the system `libicucore` instead (`USE_APPLE_ICU`), which is why the hook is platform-gated.

<details>
<summary>Probe: failing each allocation of udat_format / udat_clone / ucal_clone against the prebuilt ICU 78.3</summary>

A standalone program linked against `libicui18n.a`/`libicuuc.a`/`libicudata.a` from the current `f0f60fd2` prebuilt installs `u_setMemoryFunctions` with an allocator that returns null for the Nth allocation made after arming, opens an `en_US` pattern formatter for `America/Los_Angeles`, arms, performs one operation, and (when the operation reports success) checks the result. One process per N.

```
udat_format on the existing formatter: 2 allocations
  fail #1 -> SIGSEGV
     icu_78::Calendar::computeFields            calendar.cpp:1412
     icu_78::Calendar::complete / Calendar::get
     icu_78::SimpleDateFormat::subFormat        smpdtfmt.cpp:1513
     icu_78::SimpleDateFormat::_format / format
     icu_78::DateFormat::format                 datefmt.cpp:288
     udat_format_78                             udat.cpp:249
  fail #2 -> OK

udat_clone: 60 allocations
  reported (U_MEMORY_ALLOCATION_ERROR): #1
  process crashes: #8 #10 #15 #16 #20 #26 #34 #59 (SIGSEGV), #50 #51 #56 (free(): invalid pointer -> SIGABRT)
     #8:  icu_78::DecimalFormat::setupFastFormat  decimfmt.cpp:1822
          icu_78::DecimalFormat::touch / DecimalFormat::DecimalFormat / DecimalFormat::clone
          icu_78::DateFormat::operator=            datefmt.cpp:157
          icu_78::SimpleDateFormat::SimpleDateFormat smpdtfmt.cpp:530
          icu_78::SimpleDateFormat::clone          smpdtfmt.cpp:630
          udat_clone_78                            udat.cpp:211
     #50 #51 #56: udat_clone returns U_ZERO_ERROR; formatting with the clone then dies with
          free(): invalid pointer in icu_78::number::SimpleNumber::cleanup  number_simple.cpp:50
          icu_78::SimpleDateFormat::zeroPaddingNumber                         smpdtfmt.cpp:2176
  U_ZERO_ERROR but the clone formats the wrong thing: #9 -> "", #12 #13 #14 -> ","   (expected "Tuesday, November 14, 2023 at 2:13:20 PM")
  tolerated: the remaining 44

ucal_clone: 3 allocations
  reported: #1
  fail #2 -> U_ZERO_ERROR, then SIGSEGV on first use of the clone
     icu_78::UnicodeString::copyFrom            unistr.cpp:544
     icu_78::TimeZone::getID                    (fZone is null)
     ucal_getTimeZoneID_78                      ucal.cpp:237
  fail #3 -> OK
```

The counts differ from the ones in the original report (110 for a style-based formatter with time zone names) because the formatter here is pattern-based; the shape is the same.
</details>

