### PR TITLE
node:net: reset the stream state when connect() reuses a half-closed socket

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -2133,8 +2133,7 @@ Socket.prototype.connect = function connect(...args) {
   if (!this._handle) {
     this._handle = newDetachedSocket(typeof this[bunTlsSymbol] === "function");
   }
-  // Also for a reused handle: doConnect replaces the connection it still
-  // carries, so the stream state of that connection has to go with it.
+  // A reused handle gets a new connection from doConnect, so it is reset as well.
   initSocketHandle(this);
 
   if (!pipe) {

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -2122,8 +2122,6 @@ Socket.prototype.connect = function connect(...args) {
   }
   if (this.destroyed) {
     this._handle = null;
-    this._peername = null;
-    this._sockname = null;
   }
 
   this.connecting = true;

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -2134,8 +2134,15 @@ Socket.prototype.connect = function connect(...args) {
 
   if (!this._handle) {
     this._handle = newDetachedSocket(typeof this[bunTlsSymbol] === "function");
-    initSocketHandle(this);
   }
+  // Unlike node (where connecting a handle that is still connected fails with
+  // EISCONN), a handle whose previous connection is still open or half-closed is
+  // reused: doConnect closes that connection and connects the same handle again.
+  // The stream state has to be re-initialized for it as well, otherwise a
+  // connect() issued after end() but before the previous connection finished
+  // closing keeps its ended/finished state and the first write on the new
+  // connection fails with ERR_STREAM_WRITE_AFTER_END.
+  initSocketHandle(this);
 
   if (!pipe) {
     lookupAndConnect(this, options);
@@ -4261,10 +4268,13 @@ function normalizeArgs(args: unknown[]): [options: Record<PropertyKey, any>, cb:
   return arr;
 }
 
-// Called when creating new Socket, or when re-using a closed Socket
+// Called before every connect(): on a new Socket, and whenever a Socket is
+// re-used for another connection (after a close, or while the previous
+// connection is still being torn down).
 function initSocketHandle(self) {
   self._undestroy();
   self._sockname = null;
+  self._peername = null;
   self[kclosed] = false;
   self[kended] = false;
 

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -2133,13 +2133,8 @@ Socket.prototype.connect = function connect(...args) {
   if (!this._handle) {
     this._handle = newDetachedSocket(typeof this[bunTlsSymbol] === "function");
   }
-  // Unlike node (where connecting a handle that is still connected fails with
-  // EISCONN), a handle whose previous connection is still open or half-closed is
-  // reused: doConnect closes that connection and connects the same handle again.
-  // The stream state has to be re-initialized for it as well, otherwise a
-  // connect() issued after end() but before the previous connection finished
-  // closing keeps its ended/finished state and the first write on the new
-  // connection fails with ERR_STREAM_WRITE_AFTER_END.
+  // Also for a reused handle: doConnect replaces the connection it still
+  // carries, so the stream state of that connection has to go with it.
   initSocketHandle(this);
 
   if (!pipe) {
@@ -4266,9 +4261,7 @@ function normalizeArgs(args: unknown[]): [options: Record<PropertyKey, any>, cb:
   return arr;
 }
 
-// Called before every connect(): on a new Socket, and whenever a Socket is
-// re-used for another connection (after a close, or while the previous
-// connection is still being torn down).
+// Called on every connect(): a new Socket, or one re-used for another connection.
 function initSocketHandle(self) {
   self._undestroy();
   self._sockname = null;

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -463,33 +463,217 @@ describe("net.Socket write", () => {
     }),
   );
 
+  function listen(server: Server) {
+    return new Promise<number>(resolve =>
+      server.listen(0, "127.0.0.1", () => resolve((server.address() as import("node:net").AddressInfo).port)),
+    );
+  }
+
   it("should allow reconnecting after end()", async () => {
-    const server = new Server(socket => socket.end());
-    const port = await new Promise(resolve => {
-      server.once("listening", () => resolve(server.address().port));
-      server.listen();
+    // #7325: the same net.Socket is reconnected from end()'s callback. That
+    // callback runs before the peer's FIN has been read, so the socket is not
+    // destroyed yet and connect() reuses the handle of the half-closed
+    // connection. (This used to reconnect 3ms after the callback instead, which
+    // only passed when the previous connection had finished closing by then.)
+    const iterations = 10;
+    const connections: Socket[] = [];
+    const server = createServer(c => {
+      connections.push(c);
+      c.on("error", () => {});
+      c.end();
+    });
+    const socket = new Socket();
+    const errors: Error[] = [];
+    socket.on("error", err => errors.push(err));
+    socket.resume();
+    const results: unknown[] = [];
+    try {
+      const port = await listen(server);
+      for (let i = 0; i < iterations; i++) {
+        socket.connect(port, "127.0.0.1");
+        await once(socket, "connect");
+        const readyState = socket.readyState;
+        const writeError = await new Promise<Error | null | undefined>(resolve => socket.write("script\n", resolve));
+        const endError = await new Promise<Error | null | undefined>(resolve => socket.end(resolve));
+        results.push({ readyState, writeError: writeError?.message ?? null, endError: endError?.message ?? null });
+      }
+      expect(results).toEqual(Array(iterations).fill({ readyState: "open", writeError: null, endError: null }));
+      expect(errors).toEqual([]);
+    } finally {
+      socket.destroy();
+      for (const c of connections) c.destroy();
+      server.close();
+    }
+  });
+
+  describe("connect() while the previous connection is half-closed", () => {
+    // connect() on a socket that has not been destroyed replaces the connection
+    // underneath the same handle; the per-connection stream state has to start
+    // over with it. One side of each connection stays open (allowHalfOpen on
+    // the server, or on the client) so that the client socket is still not
+    // destroyed when it is reconnected.
+    it("re-opens the writable side after end()", async () => {
+      const connections: Socket[] = [];
+      const received: { connection: number; data: string }[] = [];
+      let onData: ((data: string) => void) | undefined;
+      const server = createServer({ allowHalfOpen: true }, c => {
+        connections.push(c);
+        const connection = connections.length;
+        c.on("error", () => {});
+        c.setEncoding("utf8");
+        c.on("data", (data: string) => {
+          received.push({ connection, data });
+          onData?.(data);
+        });
+      });
+      const socket = new Socket();
+      const errors: Error[] = [];
+      socket.on("error", err => errors.push(err));
+      function writeAndWaitForServer(data: string) {
+        const { promise, resolve } = Promise.withResolvers<string>();
+        onData = resolve;
+        socket.write(data);
+        return promise;
+      }
+      try {
+        const port = await listen(server);
+
+        socket.connect(port, "127.0.0.1");
+        await once(socket, "connect");
+        await writeAndWaitForServer("first");
+        socket.end();
+        await once(socket, "finish");
+        expect({
+          destroyed: socket.destroyed,
+          writableEnded: socket.writableEnded,
+          readyState: socket.readyState,
+        }).toEqual({ destroyed: false, writableEnded: true, readyState: "readOnly" });
+
+        socket.connect(port, "127.0.0.1");
+        await once(socket, "connect");
+        expect({
+          writableEnded: socket.writableEnded,
+          writableFinished: socket.writableFinished,
+          readyState: socket.readyState,
+        }).toEqual({ writableEnded: false, writableFinished: false, readyState: "open" });
+        await writeAndWaitForServer("second");
+        expect(received).toEqual([
+          { connection: 1, data: "first" },
+          { connection: 2, data: "second" },
+        ]);
+        expect(errors).toEqual([]);
+      } finally {
+        socket.destroy();
+        for (const c of connections) c.destroy();
+        server.close();
+      }
     });
 
-    const socket = new Socket();
-    socket.on("data", data => console.log(data.toString()));
-    socket.on("error", err => console.error(err));
-
-    async function run() {
-      return new Promise((resolve, reject) => {
-        socket.once("connect", (...args) => {
-          socket.write("script\n", err => {
-            if (err) return reject(err);
-            socket.end(() => setTimeout(resolve, 3));
-          });
-        });
-        socket.connect(port, "127.0.0.1");
+    it("re-opens the writable side after end() (unix socket path)", async () => {
+      const connections: Socket[] = [];
+      const server = createServer({ allowHalfOpen: true }, c => {
+        connections.push(c);
+        c.on("error", () => {});
       });
-    }
+      const socketPath = join(socket_domain, "reconnect.sock");
+      const socket = new Socket();
+      const errors: Error[] = [];
+      socket.on("error", err => errors.push(err));
+      try {
+        await new Promise<void>(r => server.listen(socketPath, r));
 
-    for (let i = 0; i < 10; i++) {
-      await run();
-    }
-    server.close();
+        socket.connect(socketPath);
+        await once(socket, "connect");
+        socket.end();
+        await once(socket, "finish");
+
+        socket.connect(socketPath);
+        await once(socket, "connect");
+        const writeError = await new Promise<Error | null | undefined>(resolve => socket.write("again", resolve));
+        expect({ readyState: socket.readyState, writeError: writeError?.message ?? null }).toEqual({
+          readyState: "open",
+          writeError: null,
+        });
+        expect(errors).toEqual([]);
+      } finally {
+        socket.destroy();
+        for (const c of connections) c.destroy();
+        server.close();
+      }
+    });
+
+    it("re-opens the readable side after the peer ended an allowHalfOpen socket", async () => {
+      const connections: Socket[] = [];
+      const server = createServer(c => {
+        connections.push(c);
+        c.on("error", () => {});
+        c.end();
+      });
+      const socket = new Socket({ allowHalfOpen: true });
+      const errors: Error[] = [];
+      socket.on("error", err => errors.push(err));
+      socket.resume();
+      try {
+        const port = await listen(server);
+
+        socket.connect(port, "127.0.0.1");
+        await once(socket, "end");
+        expect({
+          destroyed: socket.destroyed,
+          readableEnded: socket.readableEnded,
+          readyState: socket.readyState,
+        }).toEqual({ destroyed: false, readableEnded: true, readyState: "writeOnly" });
+
+        const endedAgain = once(socket, "end");
+        socket.connect(port, "127.0.0.1");
+        await once(socket, "connect");
+        expect({ readableEnded: socket.readableEnded, readyState: socket.readyState }).toEqual({
+          readableEnded: false,
+          readyState: "open",
+        });
+        // The new connection's FIN is reported as a fresh 'end'.
+        await endedAgain;
+        expect(connections).toHaveLength(2);
+        expect(errors).toEqual([]);
+      } finally {
+        socket.destroy();
+        for (const c of connections) c.destroy();
+        server.close();
+      }
+    });
+
+    it("reports the address of the new peer", async () => {
+      const connections: Socket[] = [];
+      const onConnection = (c: Socket) => {
+        connections.push(c);
+        c.on("error", () => {});
+      };
+      const server1 = createServer({ allowHalfOpen: true }, onConnection);
+      const server2 = createServer({ allowHalfOpen: true }, onConnection);
+      const socket = new Socket();
+      const errors: Error[] = [];
+      socket.on("error", err => errors.push(err));
+      try {
+        const port1 = await listen(server1);
+        const port2 = await listen(server2);
+
+        socket.connect(port1, "127.0.0.1");
+        await once(socket, "connect");
+        expect(socket.remotePort).toBe(port1);
+        socket.end();
+        await once(socket, "finish");
+
+        socket.connect(port2, "127.0.0.1");
+        await once(socket, "connect");
+        expect(socket.remotePort).toBe(port2);
+        expect(errors).toEqual([]);
+      } finally {
+        socket.destroy();
+        for (const c of connections) c.destroy();
+        server1.close();
+        server2.close();
+      }
+    });
   });
 
   // Client-mode `Handlers.markInactive()` frees the per-connection Handlers

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -464,9 +464,10 @@ describe("net.Socket write", () => {
   );
 
   function listen(server: Server) {
-    return new Promise<number>(resolve =>
-      server.listen(0, "127.0.0.1", () => resolve((server.address() as import("node:net").AddressInfo).port)),
-    );
+    return new Promise<number>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => resolve((server.address() as import("node:net").AddressInfo).port));
+    });
   }
 
   it("should allow reconnecting after end()", async () => {
@@ -580,7 +581,10 @@ describe("net.Socket write", () => {
       const errors: Error[] = [];
       socket.on("error", err => errors.push(err));
       try {
-        await new Promise<void>(r => server.listen(socketPath, r));
+        await new Promise<void>((resolve, reject) => {
+          server.once("error", reject);
+          server.listen(socketPath, resolve);
+        });
 
         socket.connect(socketPath);
         await once(socket, "connect");


### PR DESCRIPTION
### Problem
- `net.Socket#connect()` on a socket whose previous connection is still being torn down (after `end()`, or after the peer's FIN on an `allowHalfOpen` socket) emits `connect` for the new connection, but the first write on it fails with `error: write after end` / `code: "ERR_STREAM_WRITE_AFTER_END"`; a readable side that had ended never emits `end` again, and `remoteAddress`/`remotePort` keep describing the old peer.
- `test/js/node/net/node-net.test.ts` "net.Socket write > should allow reconnecting after end()" hits exactly this: it reconnected 3ms after `end()`'s callback, which only works when the previous connection has finished closing by then. On a Windows debug build it failed about half the time with the error above.
- Cause: `Socket.prototype.connect` (`src/js/node/net.ts`) only called `initSocketHandle()` (which `_undestroy()`s the Duplex) when it created a new handle, i.e. for a fresh socket or one that had already been destroyed. A socket that is not destroyed yet keeps its handle; since #32739 the native connect tears the previous connection down and connects that handle again (`connect_finish` -> `detach_for_reconnect` in `src/runtime/socket/`), but nothing reset the stream state that went with the previous connection.

### Fix
- `connect()` runs `initSocketHandle()` whether or not it had to create the handle, and `initSocketHandle()` also clears the cached `_peername` (it already cleared `_sockname`). The `_peername`/`_sockname` clears in `connect()`'s `if (this.destroyed)` block are deleted since `initSocketHandle()` now covers them; only `_handle = null` stays.
- Why this is right: the native side already gives the reused handle a fresh connection, so the Duplex has to start over at the same point, exactly as it does for a fresh handle; `initSocketHandle` is node's own reset for that situation (`_undestroy` + clearing the cached names). It is a no-op on the paths that already ran it (fresh socket, destroyed socket, autoSelectFamily retry), so only the reuse case changes.
- Node for comparison: `connect()` on a socket that was `end()`ed but not destroyed fails with `connect EISCONN` (the kernel rejects `connect(2)` on the still-connected fd), so the pattern only works there once the socket has been destroyed. Bun chose in #32739 to replace the connection instead; this makes that work at the stream layer too, so reconnecting after `end()` no longer depends on whether the peer's FIN happened to be processed first.
- Tests, all in `test/js/node/net/node-net.test.ts` and all failing before / passing after the change with `bun bd test`:
  - "should allow reconnecting after end()" now reconnects from `end()`'s callback (deterministically before the peer's FIN is read), checks that every `write()`/`end()` succeeds and that no `error` is emitted. Before the change it fails on the second iteration with `write after end`.
  - "connect() while the previous connection is half-closed": writable side re-opened (TCP and unix socket path, data delivered on the new connection), readable side re-opened on an `allowHalfOpen` socket (`end` emitted again), `remotePort` reports the new peer.
- Also run with the change: the rest of `node-net.test.ts` (its remaining failures in this environment, e.g. `www.example.com` lookups and `localhost` binding to `::1`, are identical without the change), `socket-reconnect-live.test.ts`, `double-connect.test.ts`, `connect-autoselectfamily-stale-timer.test.ts`, `node-net-allowHalfOpen.test.js`, `handle-leak.test.ts`, and the Node `test-net-*.js` / `test-tls-*.js` suites in `test/js/node/test/parallel` (including `test-net-reconnect.js`, the reconnect-after-`close` path, and the remote/local address tests).

### Background
- `net.Socket` is a `Duplex` stream over a native handle (`socket._handle`). Ending the writable side (`end()`) and the peer ending the readable side (`end` event) are recorded as flags on the stream's writable/readable state; `write()` on a stream whose writable state is ended throws `ERR_STREAM_WRITE_AFTER_END` regardless of what the handle underneath is doing.
- `_undestroy()` is the streams-internal routine that clears those flags (ended/ending/finished, endEmitted, destroyed, errored, ...) so a stream object can be used for a new session. Node's `initSocketHandle()` calls it and clears the socket's cached address, and node calls it whenever `connect()` attaches a handle to the socket; this change calls it on the reused handle as well.
- A socket is "half-closed" when one direction has been shut down. With the default `allowHalfOpen: false`, a `net.Socket` destroys itself once both directions are done, so between `end()` and the arrival of the peer's FIN (or, with `allowHalfOpen: true`, indefinitely) the socket is half-closed and `socket.destroyed` is `false`. That is the window in which `connect()` took the reuse path.
- Reconnecting a socket that is still connecting is a different case (#32812 is about that one) and is not changed here. Reconnecting a `tls.connect()` socket in this state throws a `TypeError` before reaching this code and is also a separate issue.
