### PR TITLE
runner: kill the crash remap server on exit instead of beforeExit, which never fires

### DIFF
--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -62,6 +62,7 @@ import {
   isMacOS,
   isWindows,
   isX64,
+  killOnExit,
   markBuildkiteStepReported,
   printEnvironment,
   reportAnnotationToBuildKite,
@@ -559,7 +560,7 @@ async function runTests() {
       env: { ...process.env, BUN_DOCKER_COORDINATOR_SOCKET: coordinatorSocket },
     });
     coordinator.on("error", err => console.warn("docker coordinator spawn failed:", err.message));
-    process.once("exit", () => coordinator.kill());
+    killOnExit(coordinator);
 
     // Don't point tests at the socket until it's actually listening; if the
     // coordinator never gets there, tests use the direct-compose fallback.
@@ -794,7 +795,6 @@ async function runTests() {
       const { promise: portPromise, resolve: portResolve } = Promise.withResolvers();
       const { promise: errorPromise, resolve: errorResolve } = Promise.withResolvers();
       console.log("run in", cwd);
-      let exiting = false;
 
       const server = spawn(execPath, ["run", "--silent", "ci-remap-server", execPath, cwd, getCommit()], {
         stdio: ["ignore", "pipe", "inherit"],
@@ -802,17 +802,15 @@ async function runTests() {
         env: { ...process.env, BUN_DEBUG_QUIET_LOGS: "1", NO_COLOR: "1" },
       });
       server.unref();
+      // kill()'s SIGTERM is deliberate: on Linux `bun run` stays alive as the
+      // parent of the ci-remap-server script and forwards SIGTERM to it, while
+      // SIGKILL would stop at the wrapper and leave the script, which holds our
+      // inherited stderr open, running.
+      killOnExit(server);
       server.on("error", errorResolve);
       server.on("exit", (code, signal) => {
-        if (!exiting && (code !== 0 || signal !== null)) errorResolve(signal ? signal : "code " + code);
+        if (code !== 0 || signal !== null) errorResolve(signal ? signal : "code " + code);
       });
-      function onBeforeExit() {
-        exiting = true;
-        server.off("error");
-        server.off("exit");
-        server.kill?.();
-      }
-      process.once("beforeExit", onBeforeExit);
       const lines = createInterface(server.stdout);
       lines.on("line", line => {
         portResolve({ port: parseInt(line) });
@@ -820,7 +818,6 @@ async function runTests() {
 
       const result = await Promise.race([portPromise, errorPromise.catch(e => e), setTimeoutPromise(5000, "timeout")]);
       if (typeof result?.port != "number") {
-        process.off("beforeExit", onBeforeExit);
         server.kill?.();
         console.warn("ci-remap server did not start:", result);
       } else {

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -441,6 +441,17 @@ export function spawnSyncSafe(command, options = {}) {
 }
 
 /**
+ * Kills `child` when this process exits. The hook is "exit", which fires for
+ * process.exit() (how the runner leaves on every path, its signal handlers
+ * included) and for an uncaught exception; "beforeExit" fires for neither, so
+ * a helper process hooked on it outlives the runner.
+ * @param {import("node:child_process").ChildProcess} child
+ */
+export function killOnExit(child) {
+  process.once("exit", () => child.kill());
+}
+
+/**
  * @param {number} exitCode
  * @returns {string | undefined}
  */

--- a/test/internal/runner-kill-on-exit.test.ts
+++ b/test/internal/runner-kill-on-exit.test.ts
@@ -1,0 +1,132 @@
+/**
+ * killOnExit() (scripts/utils.mjs) ties the helper processes that
+ * scripts/runner.node.mjs starts (the crash-report remap server, the docker
+ * coordinator) to the runner's lifetime. The runner never drains its event
+ * loop: main(), --bail and its signal handlers all end in process.exit(), and a
+ * bug in it ends it with an uncaught exception. None of those emit
+ * "beforeExit", which the remap server used to be hooked on (so it outlived
+ * every CI run); the hook has to fire from "exit".
+ *
+ * The fixture's helper inherits the fixture's stdout the way the remap server
+ * inherits the runner's stderr: stdout reaching EOF proves the helper is dead,
+ * and while it lives the pipe stays open, which is how the leak showed up
+ * (whatever captured the runner's output kept waiting on the orphan).
+ */
+import { afterAll, describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, nodeExe, tempDir } from "harness";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const utils = pathToFileURL(join(import.meta.dir, "../../scripts/utils.mjs")).href;
+
+const fixture = tempDir("runner-kill-on-exit", {
+  "fixture.mjs": `
+    import { spawn } from "node:child_process";
+    import { writeSync } from "node:fs";
+    import { killOnExit } from ${JSON.stringify(utils)};
+
+    const [mode] = process.argv.slice(2);
+
+    async function main() {
+      // Idles until it is killed, holding the stdout it inherits from us.
+      const helper = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+        stdio: ["ignore", "inherit", "ignore"],
+      });
+      helper.unref();
+      if (mode !== "leak") killOnExit(helper);
+      // Synchronous so that process.exit() below cannot discard it.
+      writeSync(2, "helper pid " + helper.pid + "\\n");
+
+      switch (mode) {
+        case "exit":
+        case "leak":
+          process.exit(0);
+        case "throw":
+          throw new Error("runner bug");
+        case "signal":
+          process.on("SIGTERM", () => process.exit(3));
+          process.kill(process.pid, "SIGTERM");
+          setInterval(() => {}, 1000);
+      }
+    }
+
+    await main();
+  `,
+});
+
+const env = { ...bunEnv };
+// With this set, a bun helper dies with its parent by itself and would hide a missing hook.
+delete env.BUN_FEATURE_FLAG_NO_ORPHANS;
+
+// Helpers whose death has not been observed yet; only a failing test leaves any behind.
+const liveHelpers = new Set<number>();
+afterAll(() => {
+  for (const pid of liveHelpers) {
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {}
+  }
+});
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function runFixture(exe: string, mode: string) {
+  await using proc = Bun.spawn({
+    cmd: [exe, join(String(fixture), "fixture.mjs"), mode],
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  // stdout is shared with the helper and reaches EOF only once both are gone;
+  // stderr is the fixture's alone and reaches EOF when it exits.
+  const stdoutEof = proc.stdout.text();
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  const helperPid = Number(/^helper pid (\d+)$/m.exec(stderr)?.[1]);
+  if (!helperPid) throw new Error(`fixture did not start its helper:\n${stderr}`);
+  liveHelpers.add(helperPid);
+  stdoutEof.then(() => liveHelpers.delete(helperPid));
+  return { exitCode, helperPid, stdoutEof };
+}
+
+function isStillOpen(stdoutEof: Promise<string>): Promise<boolean> {
+  return Promise.race([
+    stdoutEof.then(() => false),
+    new Promise<boolean>(resolve => setImmediate(() => resolve(true))),
+  ]);
+}
+
+// The runner runs under node; bun is the runtime this suite is about and
+// implements the same "exit" semantics. The runner only starts these helpers
+// on non-Windows platforms.
+for (const [runtime, exe] of [
+  ["node", nodeExe()],
+  ["bun", bunExe()],
+] as const) {
+  describe.skipIf(isWindows || !exe)(`under ${runtime}`, () => {
+    test.concurrent.each([
+      ["process.exit()", "exit", 0],
+      ["an uncaught exception", "throw", 1],
+      ["a signal handler calling process.exit()", "signal", 3],
+    ])("the helper is killed when the parent leaves through %s", async (_, mode, expectedExitCode) => {
+      const { exitCode, stdoutEof } = await runFixture(exe!, mode);
+      expect(exitCode).toBe(expectedExitCode);
+      await stdoutEof;
+    });
+
+    test.concurrent("control: without the hook the helper outlives the parent and holds its stdout open", async () => {
+      const { exitCode, helperPid, stdoutEof } = await runFixture(exe!, "leak");
+      expect(exitCode).toBe(0);
+      expect(isAlive(helperPid)).toBe(true);
+      expect(await isStillOpen(stdoutEof)).toBe(true);
+      process.kill(helperPid, "SIGKILL");
+      await stdoutEof;
+    });
+  });
+}


### PR DESCRIPTION
### Problem
- Every CI-mode run of `scripts/runner.node.mjs` (Linux and macOS lanes) leaves its crash-report remap server behind: a `bun run --silent ci-remap-server ...` process plus the `bun node_modules/.bin/ci-remap-server ...` script it wraps, both reparented to PID 1. On persistent agents these pile up one pair per job.
- The orphan inherits the runner's stderr (`stdio: ["ignore", "pipe", "inherit"]`), so anything capturing the runner's output through a pipe keeps waiting after the runner has exited. Locally, `node scripts/runner.node.mjs ... 2>&1 | cat` was still blocked 5s after the runner exited; killing the orphan released it.
- Cause: `server.kill()` was only called from a `process.once("beforeExit", ...)` handler (`scripts/runner.node.mjs:809-815`), and the runner never exits in a way that emits `beforeExit`. `main()` ends in `process.exit()` (`:3431`), so do `--bail` (`:753`) and the SIGINT/SIGTERM/SIGHUP handler (`:3076`), and an uncaught exception does not emit it either.
- Even if `beforeExit` had fired, the handler called `server.off("error")` / `server.off("exit")` without a listener, which throws `ERR_INVALID_ARG_TYPE` before reaching `server.kill()`.
- The docker coordinator started a few lines earlier already used `process.once("exit", () => coordinator.kill())` and was cleaned up on the same runs, which is what pointed at the event.

### Fix
- Add `killOnExit(child)` to `scripts/utils.mjs`: `process.once("exit", () => child.kill())`. Use it for the remap server and for the docker coordinator (same behavior as its inline hook).
- Why `exit` is the right event: Node emits `exit` both from `process.exit()` and after an uncaught exception, which together are every way the runner ends; `beforeExit` is emitted only when the event loop drains, which never happens here. `exit` listeners must be synchronous, and `kill()` is.
- Why `kill()`'s default SIGTERM, rather than SIGKILL, is enough for the two-process tree: on Linux `bun run` stays alive as the parent of the script and forwards SIGTERM to it, then exits itself; SIGKILL is not forwarded and would orphan the script. Checked against the real tree: SIGTERM to the wrapper took both processes down and released the pipe. On macOS `bun run --silent` execs the script in place, so there is only one process. The comment at the call site records this so nobody "hardens" it to SIGKILL.
- The `exiting` flag and the `off()` calls existed only to serve the removed handler; the `did not start` branch no longer unregisters anything since a second `kill()` on a dead child is a no-op.
- Test: `test/internal/runner-kill-on-exit.test.ts`. A fixture spawns a helper that inherits the fixture's stdout (as the remap server inherits the runner's stderr), hooks it with `killOnExit`, and leaves via `process.exit()`, an uncaught exception from `await main()`, or a SIGTERM handler that calls `process.exit()`; stdout reaching EOF is the proof the helper died. A control case without the hook checks the helper survives and keeps the pipe open, so the EOF signal is not vacuous. Runs under node (what the runner uses) and under bun.
- `bun bd test test/internal/runner-kill-on-exit.test.ts`: 8 pass.
- With `scripts/` stashed: 8 fail (no export). With `killOnExit` temporarily hooked on `beforeExit` instead: the 6 positive cases time out waiting for the pipe, the 2 controls pass.
- Real runner, before and after, each of the three exit paths (normal, uncaught exception, SIGTERM): before, 2 `ci-remap-server` processes left behind every time; after, 0, and a reader on the runner's output got EOF 4ms after the runner exited (log below).

### Background
- The remap server: in CI the runner starts `ci-remap-server` (from the `bun-tracestrings` package) once per shard and points every test process at it with `BUN_CRASH_REPORT_URL`, so crash trace strings from tests get symbolicated and attached to the failure output. It is meant to live exactly as long as the runner.
- `beforeExit` vs `exit` in Node: `beforeExit` fires when the event loop has no more work and the process would exit on its own; it is not emitted for `process.exit()` or for a fatal error. `exit` is emitted in both of those cases as well, and its listeners run synchronously right before the process ends.
- `bun run <bin>` on Linux spawns the bin as a child and waits for it, forwarding catchable signals it receives (SIGTERM, SIGINT, SIGHUP, ...) to that child; with `--silent` on macOS it execs the bin in place instead.

<details>
<summary>Runner probes (this container, GITHUB_ACTIONS=true, one test file)</summary>

Before, normal exit:

```
runner exited with 0 at 1786786303.289
reader: still blocked 5s after the runner exited
   6918       1  /workspace/bun/build/release/bun run --silent ci-remap-server /workspace/bun/build/release/bun /workspace/bun c1ae5ca1...
   6920    6918  bun /workspace/bun/node_modules/.bin/ci-remap-server /workspace/bun/build/release/bun /workspace/bun c1ae5ca1...
(SIGTERM sent to 6918)
reader: got EOF
no ci-remap-server processes left
```

Before, SIGTERM to the runner:

```
::group::Received SIGTERM, exiting...
remap processes after exit: 2
coordinator processes after exit: 0
```

After, normal exit:

```
runner exited with 0 at 1786786902.4616
reader got EOF at 1786786902.4655
```

After, uncaught exception (GITHUB_REPOSITORY unset makes the runner throw after starting the server) and SIGTERM:

```
server started: 1
Error: Environment variable is missing: GITHUB_REPOSITORY
remap processes after exit: 0

::group::Received SIGTERM, exiting...
remap processes after exit: 0
```

</details>
