### PR TITLE
Fix abort when a native error message exceeds 1 GiB of non-ASCII UTF-8

### DIFF
--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -483,7 +483,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionJSONLParse, (JSGlobalObject * globalObject, C
                 throwOutOfMemoryError(globalObject, scope);
                 return {};
             }
-            auto str = WTF::String::fromUTF8ReplacingInvalidSequences(std::span { reinterpret_cast<const char8_t*>(data), length });
+            auto str = Zig::convertUTF8ToString(std::span { reinterpret_cast<const unsigned char*>(data), length });
             if (str.isNull()) {
                 throwOutOfMemoryError(globalObject, scope);
                 return {};
@@ -582,7 +582,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionJSONLParseChunk, (JSGlobalObject * globalObje
                 throwOutOfMemoryError(globalObject, scope);
                 return {};
             }
-            auto str = WTF::String::fromUTF8ReplacingInvalidSequences(std::span { reinterpret_cast<const char8_t*>(sliceData), sliceLen });
+            auto str = Zig::convertUTF8ToString(std::span { reinterpret_cast<const unsigned char*>(sliceData), sliceLen });
             if (str.isNull()) {
                 throwOutOfMemoryError(globalObject, scope);
                 return {};

--- a/src/jsc/bindings/BunString.cpp
+++ b/src/jsc/bindings/BunString.cpp
@@ -444,7 +444,7 @@ extern "C" BunString BunString__fromUTF8(const char* bytes, size_t length)
         return { BunStringTag::WTFStringImpl, { .wtf = impl.leakRef() } };
     }
 
-    auto str = WTF::String::fromUTF8ReplacingInvalidSequences(std::span { reinterpret_cast<const Latin1Character*>(bytes), length });
+    auto str = Zig::convertUTF8ToString(std::span { reinterpret_cast<const unsigned char*>(bytes), length });
     if (str.isNull()) [[unlikely]] {
         return { .tag = BunStringTag::Dead };
     }

--- a/src/jsc/bindings/BunString.cpp
+++ b/src/jsc/bindings/BunString.cpp
@@ -100,8 +100,7 @@ extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue BunString__createUT
         return JSValue::encode(jsString(vm, WTF::String(std::span<const Latin1Character>(reinterpret_cast<const Latin1Character*>(ptr), length))));
     }
 
-    auto str = WTF::String::fromUTF8ReplacingInvalidSequences(std::span { reinterpret_cast<const Latin1Character*>(ptr), length });
-    EXCEPTION_ASSERT(str.isNull() == !!scope.exception());
+    auto str = Zig::convertUTF8ToString(std::span { reinterpret_cast<const unsigned char*>(ptr), length });
     if (str.isNull()) [[unlikely]] {
         throwOutOfMemoryError(globalObject, scope);
         return {};

--- a/src/jsc/bindings/decodeURIComponentSIMD.cpp
+++ b/src/jsc/bindings/decodeURIComponentSIMD.cpp
@@ -2,6 +2,7 @@
 #include "root.h"
 
 #include "BunString.h"
+#include "helpers.h"
 #include <wtf/text/WTFString.h>
 #include <wtf/SIMDHelpers.h>
 #include <wtf/SIMDUTF.h>
@@ -28,7 +29,7 @@ ALWAYS_INLINE static void appendLiteralRun(StringBuilder& result, std::span<cons
         result.append(chars);
         return;
     }
-    result.append(WTF::String::fromUTF8ReplacingInvalidSequences(chars));
+    result.append(Zig::convertUTF8ToString(chars));
 }
 
 WTF::String decodeURIComponentSIMD(std::span<const uint8_t> input)
@@ -63,7 +64,7 @@ WTF::String decodeURIComponentSIMD(std::span<const uint8_t> input)
 
     if (inputIsASCII)
         return String(lchar);
-    return String::fromUTF8ReplacingInvalidSequences(lchar);
+    return Zig::convertUTF8ToString(lchar);
 
 slow_path:
     while (cursor < end && *cursor != '%') {

--- a/src/jsc/bindings/helpers.h
+++ b/src/jsc/bindings/helpers.h
@@ -72,14 +72,10 @@ static void free_global_string(void* str, void* ptr, unsigned len)
     ZigString__freeGlobal(reinterpret_cast<const unsigned char*>(ptr), len);
 }
 
-// WTF::String::fromUTF8ReplacingInvalidSequences sizes its intermediate
-// Vector<char16_t> by the UTF-8 *byte* count, and Vector CRASH()es past
-// isValidCapacityForVector<char16_t> (~2^30) elements, so a 1-2 GiB
-// non-ASCII string aborts the process even when the resulting UTF-16
-// string would fit in a WTF::String. Convert oversized input with an
-// exact-size allocation instead (the BunString__fromUTF8 idiom);
-// oversized invalid UTF-8 yields the null string, matching the other
-// "too long" paths in this file.
+// fromUTF8ReplacingInvalidSequences sizes an intermediate Vector<char16_t> by
+// the UTF-8 byte count, which Vector CRASH()es past ~2^30 entries, so above
+// that cap convert with an exact-size allocation instead (returning null on
+// overflow like the other too-long paths here).
 static WTF::String convertUTF8ToString(std::span<const unsigned char> bytes)
 {
     if (WTF::isValidCapacityForVector<char16_t>(bytes.size())) [[likely]]
@@ -89,10 +85,8 @@ static WTF::String convertUTF8ToString(std::span<const unsigned char> bytes)
     if (!simdutf::validate_utf8(data, bytes.size())) [[unlikely]]
         return {};
     size_t utf16Length = simdutf::utf16_length_from_utf8(data, bytes.size());
-    if (utf16Length == bytes.size()) {
-        // Every byte is one UTF-16 unit, i.e. all-ASCII: keep it 8-bit.
-        return WTF::StringImpl::create(bytes);
-    }
+    if (utf16Length == bytes.size())
+        return WTF::StringImpl::create(bytes); // all-ASCII: stays 8-bit
     if (utf16Length > WTF::String::MaxLength) [[unlikely]]
         return {};
     std::span<char16_t> out;

--- a/src/jsc/bindings/helpers.h
+++ b/src/jsc/bindings/helpers.h
@@ -72,12 +72,10 @@ static void free_global_string(void* str, void* ptr, unsigned len)
     ZigString__freeGlobal(reinterpret_cast<const unsigned char*>(ptr), len);
 }
 
-// fromUTF8ReplacingInvalidSequences sizes an intermediate Vector<char16_t> by
-// the UTF-8 byte count, which Vector CRASH()es past ~2^30 entries, so above
-// that cap convert with an exact-size allocation instead (returning null on
-// overflow like the other too-long paths here).
 static WTF::String convertUTF8ToString(std::span<const unsigned char> bytes)
 {
+    // fromUTF8ReplacingInvalidSequences CRASH()es past a ~2^30-byte input
+    // (it sizes an intermediate Vector<char16_t> by byte count).
     if (WTF::isValidCapacityForVector<char16_t>(bytes.size())) [[likely]]
         return WTF::String::fromUTF8ReplacingInvalidSequences(bytes);
 
@@ -85,10 +83,17 @@ static WTF::String convertUTF8ToString(std::span<const unsigned char> bytes)
     if (!simdutf::validate_utf8(data, bytes.size())) [[unlikely]]
         return {};
     size_t utf16Length = simdutf::utf16_length_from_utf8(data, bytes.size());
-    if (utf16Length == bytes.size())
-        return WTF::StringImpl::create(bytes); // all-ASCII: stays 8-bit
     if (utf16Length > WTF::String::MaxLength) [[unlikely]]
         return {};
+    if (utf16Length == bytes.size()) {
+        // all-ASCII: stays 8-bit
+        std::span<Latin1Character> out;
+        auto impl = WTF::StringImpl::tryCreateUninitialized(bytes.size(), out);
+        if (!impl) [[unlikely]]
+            return {};
+        memcpy(out.data(), bytes.data(), bytes.size());
+        return WTF::String(WTF::move(impl));
+    }
     std::span<char16_t> out;
     auto impl = WTF::StringImpl::tryCreateUninitialized(utf16Length, out);
     if (!impl) [[unlikely]]

--- a/src/jsc/bindings/helpers.h
+++ b/src/jsc/bindings/helpers.h
@@ -72,6 +72,37 @@ static void free_global_string(void* str, void* ptr, unsigned len)
     ZigString__freeGlobal(reinterpret_cast<const unsigned char*>(ptr), len);
 }
 
+// WTF::String::fromUTF8ReplacingInvalidSequences sizes its intermediate
+// Vector<char16_t> by the UTF-8 *byte* count, and Vector CRASH()es past
+// isValidCapacityForVector<char16_t> (~2^30) elements, so a 1-2 GiB
+// non-ASCII string aborts the process even when the resulting UTF-16
+// string would fit in a WTF::String. Convert oversized input with an
+// exact-size allocation instead (the BunString__fromUTF8 idiom);
+// oversized invalid UTF-8 yields the null string, matching the other
+// "too long" paths in this file.
+static WTF::String convertUTF8ToString(std::span<const unsigned char> bytes)
+{
+    if (WTF::isValidCapacityForVector<char16_t>(bytes.size())) [[likely]]
+        return WTF::String::fromUTF8ReplacingInvalidSequences(bytes);
+
+    const char* data = reinterpret_cast<const char*>(bytes.data());
+    if (!simdutf::validate_utf8(data, bytes.size())) [[unlikely]]
+        return {};
+    size_t utf16Length = simdutf::utf16_length_from_utf8(data, bytes.size());
+    if (utf16Length == bytes.size()) {
+        // Every byte is one UTF-16 unit, i.e. all-ASCII: keep it 8-bit.
+        return WTF::StringImpl::create(bytes);
+    }
+    if (utf16Length > WTF::String::MaxLength) [[unlikely]]
+        return {};
+    std::span<char16_t> out;
+    auto impl = WTF::StringImpl::tryCreateUninitialized(utf16Length, out);
+    if (!impl) [[unlikely]]
+        return {};
+    RELEASE_ASSERT(simdutf::convert_utf8_to_utf16(data, bytes.size(), out.data()) == utf16Length);
+    return WTF::String(WTF::move(impl));
+}
+
 // Switching to AtomString doesn't yield a perf benefit because we're recreating it each time.
 static const WTF::String toString(ZigString str)
 {
@@ -92,7 +123,7 @@ static const WTF::String toString(ZigString str)
                 return {};
             }
         }
-        return WTF::String::fromUTF8ReplacingInvalidSequences(std::span { untag(str.ptr), str.len });
+        return convertUTF8ToString(std::span { untag(str.ptr), str.len });
     }
 
     if (isTaggedExternalPtr(str.ptr)) [[unlikely]] {
@@ -132,7 +163,7 @@ static const WTF::String toString(ZigString str, StringPointer ptr)
                 return {};
             }
         }
-        return WTF::String::fromUTF8ReplacingInvalidSequences(std::span { &untag(str.ptr)[ptr.off], ptr.len });
+        return convertUTF8ToString(std::span { &untag(str.ptr)[ptr.off], ptr.len });
     }
 
     // This will fail if the string is too long. Let's make it explicit instead of an ASSERT.
@@ -160,7 +191,7 @@ static const WTF::String toStringCopy(ZigString str, StringPointer ptr)
                 return {};
             }
         }
-        return WTF::String::fromUTF8ReplacingInvalidSequences(std::span { &untag(str.ptr)[ptr.off], ptr.len });
+        return convertUTF8ToString(std::span { &untag(str.ptr)[ptr.off], ptr.len });
     }
 
     // This will fail if the string is too long. Let's make it explicit instead of an ASSERT.
@@ -188,7 +219,7 @@ static const WTF::String toStringCopy(ZigString str)
                 return {};
             }
         }
-        return WTF::String::fromUTF8ReplacingInvalidSequences(std::span { untag(str.ptr), str.len });
+        return convertUTF8ToString(std::span { untag(str.ptr), str.len });
     }
 
     if (isTaggedUTF16Ptr(str.ptr)) {
@@ -223,7 +254,7 @@ static void appendToBuilder(ZigString str, WTF::StringBuilder& builder)
                 return;
             }
         }
-        WTF::String converted = WTF::String::fromUTF8ReplacingInvalidSequences(std::span { untag(str.ptr), str.len });
+        WTF::String converted = convertUTF8ToString(std::span { untag(str.ptr), str.len });
         builder.append(converted);
         return;
     }

--- a/src/jsc/bindings/v8/V8String.cpp
+++ b/src/jsc/bindings/v8/V8String.cpp
@@ -1,5 +1,6 @@
 #include "V8String.h"
 #include "V8HandleScope.h"
+#include "helpers.h"
 #include "wtf/SIMDUTF.h"
 #include "v8_compatibility_assertions.h"
 
@@ -37,7 +38,7 @@ MaybeLocal<String> String::NewFromUtf8(Isolate* isolate, char const* data, NewSt
     std::span<const unsigned char> span(reinterpret_cast<const unsigned char*>(data), length);
     JSString* jsString = nullptr;
     // ReplacingInvalidSequences matches how v8 behaves here
-    auto string = WTF::String::fromUTF8ReplacingInvalidSequences(span);
+    auto string = Zig::convertUTF8ToString(span);
     switch (type) {
     case NewStringType::kNormal:
         jsString = JSC::jsString(vm, string);

--- a/src/jsc/bindings/v8/V8String.cpp
+++ b/src/jsc/bindings/v8/V8String.cpp
@@ -39,6 +39,10 @@ MaybeLocal<String> String::NewFromUtf8(Isolate* isolate, char const* data, NewSt
     JSString* jsString = nullptr;
     // ReplacingInvalidSequences matches how v8 behaves here
     auto string = Zig::convertUTF8ToString(span);
+    if (string.isNull() && length > 0) [[unlikely]] {
+        // empty, like the too-long case above
+        return MaybeLocal<String>();
+    }
     switch (type) {
     case NewStringType::kNormal:
         jsString = JSC::jsString(vm, string);

--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -564,7 +564,11 @@ static JSValue convertChunksToText(JSGlobalObject* globalObject, JSValue chunksV
                 throwOutOfMemoryError(globalObject, scope);
                 return {};
             }
-            WTF::String text = WTF::String::fromUTF8ReplacingInvalidSequences(span);
+            WTF::String text = Zig::convertUTF8ToString(span);
+            if (text.isNull() && !span.empty()) [[unlikely]] {
+                throwOutOfMemoryError(globalObject, scope);
+                return {};
+            }
             RELEASE_AND_RETURN(scope, jsString(vm, withoutUTF8BOM(text)));
         }
     }
@@ -730,7 +734,12 @@ static WTF::String finishTextAccumulator(JSC::VM& vm, JSGlobalObject* globalObje
         throwOutOfMemoryError(globalObject, scope);
         return WTF::String();
     }
-    return WTF::String::fromUTF8ReplacingInvalidSequences(bytes.span());
+    WTF::String text = Zig::convertUTF8ToString(bytes.span());
+    if (text.isNull() && !bytes.isEmpty()) [[unlikely]] {
+        throwOutOfMemoryError(globalObject, scope);
+        return WTF::String();
+    }
+    return text;
 }
 
 // reader.read() as a Promise-kind read request.

--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
@@ -299,7 +299,12 @@ static String finishTextSink(JSC::VM& vm, JSGlobalObject* globalObject, JSDirect
         throwOutOfMemoryError(globalObject, scope);
         return String();
     }
-    return String::fromUTF8ReplacingInvalidSequences(bytes.span());
+    String text = Zig::convertUTF8ToString(bytes.span());
+    if (text.isNull() && !bytes.isEmpty()) [[unlikely]] {
+        throwOutOfMemoryError(globalObject, scope);
+        return String();
+    }
+    return text;
 }
 
 static JSValue endTextSink(JSC::VM& vm, JSGlobalObject* globalObject, JSDirectStreamController* controller)

--- a/src/jsc/modules/NodeBufferModule.cpp
+++ b/src/jsc/modules/NodeBufferModule.cpp
@@ -2,6 +2,7 @@
 
 #include "BunClientData.h"
 #include "ErrorCode.h"
+#include "helpers.h"
 #include "JSBufferEncodingType.h"
 #include "JSDOMExceptionHandling.h"
 #include "wtf/SIMDUTF.h"
@@ -66,7 +67,7 @@ static void transcodeDecodeToUtf16(std::span<const uint8_t> input, TranscodeEnco
     case TranscodeEncoding::Utf8: {
         // WHATWG-style replacement decode (each maximal ill-formed
         // subsequence becomes one U+FFFD), via WTF's implementation.
-        auto decoded = WTF::String::fromUTF8ReplacingInvalidSequences(std::span { reinterpret_cast<const char8_t*>(input.data()), input.size() });
+        auto decoded = Zig::convertUTF8ToString(std::span { reinterpret_cast<const unsigned char*>(input.data()), input.size() });
         units.grow(decoded.length());
         if (decoded.is8Bit())
             (void)simdutf::convert_latin1_to_utf16le(reinterpret_cast<const char*>(decoded.span8().data()), decoded.length(), units.begin());

--- a/src/jsc/modules/NodeBufferModule.cpp
+++ b/src/jsc/modules/NodeBufferModule.cpp
@@ -43,7 +43,8 @@ static TranscodeEncoding parseTranscodeEncoding(const WTF::String& encoding)
 }
 
 // Decode the source bytes into well-formed UTF-16 for the pivot paths.
-static void transcodeDecodeToUtf16(std::span<const uint8_t> input, TranscodeEncoding fromEncoding, bool replaceTrailingOddByte, WTF::Vector<char16_t>& units)
+// Returns false when the decoded string cannot be allocated.
+static bool transcodeDecodeToUtf16(std::span<const uint8_t> input, TranscodeEncoding fromEncoding, bool replaceTrailingOddByte, WTF::Vector<char16_t>& units)
 {
     const auto* data = reinterpret_cast<const char*>(input.data());
     switch (fromEncoding) {
@@ -68,6 +69,8 @@ static void transcodeDecodeToUtf16(std::span<const uint8_t> input, TranscodeEnco
         // WHATWG-style replacement decode (each maximal ill-formed
         // subsequence becomes one U+FFFD), via WTF's implementation.
         auto decoded = Zig::convertUTF8ToString(std::span { reinterpret_cast<const unsigned char*>(input.data()), input.size() });
+        if (decoded.isNull() && !input.empty()) [[unlikely]]
+            return false;
         units.grow(decoded.length());
         if (decoded.is8Bit())
             (void)simdutf::convert_latin1_to_utf16le(reinterpret_cast<const char*>(decoded.span8().data()), decoded.length(), units.begin());
@@ -90,6 +93,7 @@ static void transcodeDecodeToUtf16(std::span<const uint8_t> input, TranscodeEnco
     default:
         RELEASE_ASSERT_NOT_REACHED();
     }
+    return true;
 }
 
 // Encode well-formed UTF-16 into a single-byte encoding: code points above
@@ -211,7 +215,10 @@ BUN_DEFINE_HOST_FUNCTION(jsBufferTranscode,
     } else {
         // Decode to well-formed UTF-16, then encode to the target.
         WTF::Vector<char16_t> units;
-        transcodeDecodeToUtf16(input, fromEncoding, /* replaceTrailingOddByte */ toEncoding == TranscodeEncoding::Ucs2, units);
+        if (!transcodeDecodeToUtf16(input, fromEncoding, /* replaceTrailingOddByte */ toEncoding == TranscodeEncoding::Ucs2, units)) [[unlikely]] {
+            throwOutOfMemoryError(globalObject, scope);
+            return {};
+        }
 
         switch (toEncoding) {
         case TranscodeEncoding::Latin1:

--- a/test/js/bun/test/expect/huge-failure-message.test.ts
+++ b/test/js/bun/test/expect/huge-failure-message.test.ts
@@ -1,4 +1,6 @@
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import os from "node:os";
 
 // https://github.com/oven-sh/bun/issues/38931
 // Creating a native error whose message exceeds ~2^30 bytes of non-ASCII
@@ -6,24 +8,50 @@ import { expect, test } from "bun:test";
 // ZigString__toErrorInstance sized an intermediate WTF::Vector<char16_t> by
 // the byte count, which CRASH()es past ~2^30 entries. A failing expect
 // matcher with a huge message (or received value) is the userland door into
-// that path. Needs several GB of RAM. The message must be non-ASCII:
-// all-ASCII messages stay 8-bit and never crashed.
-test("expect failure message over 1 GiB of non-ASCII throws instead of aborting", () => {
-  // 540M "\u00e9" chars = 1.08e9 UTF-8 bytes, just past the 2^30 cap.
-  const big = Buffer.alloc(540_000_000, 0xe9).toString("latin1");
-  expect.extend({
-    hugeFailureMessage() {
-      return { pass: false, message: () => big };
-    },
-  });
-  let caught: Error | undefined;
-  try {
-    (expect(1) as any).hugeFailureMessage();
-  } catch (e) {
-    caught = e as Error;
-  }
-  // Never print `caught.message`: it is over a gigabyte.
-  expect(typeof caught?.message).toBe("string");
-  expect(caught!.message.includes(big.slice(0, 64))).toBe(true);
-  expect(caught!.message.length).toBeGreaterThan(540_000_000);
-}, 300_000);
+// that path. The message must be non-ASCII: all-ASCII messages stay 8-bit
+// and never crashed. The crashing input runs in a subprocess so a
+// regression fails this test legibly instead of killing the runner, and
+// the multi-GB peak stays out of the runner; skips on small machines.
+test.skipIf(os.totalmem() < 10 * 1024 ** 3)(
+  "expect failure message over 1 GiB of non-ASCII throws instead of aborting",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { expect } = require("bun:test");
+// 540M "\\u00e9" chars = 1.08e9 UTF-8 bytes, just past the 2^30 cap.
+const big = Buffer.alloc(540_000_000, 0xe9).toString("latin1");
+expect.extend({ hugeFailureMessage() { return { pass: false, message: () => big }; } });
+let caught;
+try { expect(1).hugeFailureMessage(); } catch (e) { caught = e; }
+// Never print caught.message: it is over a gigabyte.
+console.log(JSON.stringify({
+  type: typeof caught?.message,
+  hasPrefix: caught?.message.includes(big.slice(0, 64)),
+  length: caught?.message.length,
+}));`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    let parsed: { type?: string; hasPrefix?: boolean; length?: number };
+    try {
+      parsed = JSON.parse(stdout.trim());
+    } catch {
+      // On a crash there is no JSON; surface the child's signal and stderr.
+      parsed = { stderr: stderr.slice(-500) } as any;
+    }
+    expect({ ...parsed, exitCode, signalCode: proc.signalCode }).toEqual({
+      type: "string",
+      hasPrefix: true,
+      length: expect.any(Number),
+      exitCode: 0,
+      signalCode: null,
+    });
+    expect(parsed.length).toBeGreaterThan(540_000_000);
+  },
+  300_000,
+);

--- a/test/js/bun/test/expect/huge-failure-message.test.ts
+++ b/test/js/bun/test/expect/huge-failure-message.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "bun:test";
+
+// https://github.com/oven-sh/bun/issues/38931
+// Creating a native error whose message exceeds ~2^30 bytes of non-ASCII
+// UTF-8 used to abort the process: the UTF-8 -> UTF-16 conversion behind
+// ZigString__toErrorInstance sized an intermediate WTF::Vector<char16_t> by
+// the byte count, which CRASH()es past ~2^30 entries. A failing expect
+// matcher with a huge message (or received value) is the userland door into
+// that path. Needs several GB of RAM. The message must be non-ASCII:
+// all-ASCII messages stay 8-bit and never crashed.
+test("expect failure message over 1 GiB of non-ASCII throws instead of aborting", () => {
+  // 540M "\u00e9" chars = 1.08e9 UTF-8 bytes, just past the 2^30 cap.
+  const big = Buffer.alloc(540_000_000, 0xe9).toString("latin1");
+  expect.extend({
+    hugeFailureMessage() {
+      return { pass: false, message: () => big };
+    },
+  });
+  let caught: Error | undefined;
+  try {
+    (expect(1) as any).hugeFailureMessage();
+  } catch (e) {
+    caught = e as Error;
+  }
+  // Never print `caught.message`: it is over a gigabyte.
+  expect(typeof caught?.message).toBe("string");
+  expect(caught!.message.includes(big.slice(0, 64))).toBe(true);
+  expect(caught!.message.length).toBeGreaterThan(540_000_000);
+}, 300_000);


### PR DESCRIPTION
### Problem

- `bun test` dies with SIGTRAP (macOS `EXC_BREAKPOINT`) / SIGABRT even though every test passed (#38931). The reporter's crash frames symbolicate to `WTF::VectorBufferBase<char16_t, FastMalloc>::allocateBuffer` hitting `CRASH()` (Vector.h:227), inlined in `WTF::String::fromUTF8ReplacingInvalidSequences`, called from `Zig::getErrorInstance` / `ZigString__toErrorInstance` under a failing `expect().toBeNull()`.
- Cause: `fromUTF8ReplacingInvalidSequences` allocates an intermediate `Vector<char16_t>` sized by the UTF-8 byte count, and `Vector` hard-crashes past 2^30 elements (`isValidCapacityForVector<char16_t>`).
- The callers guard against `WTF::String::MaxLength` (2^31-1 units) but not against the 2^30 intermediate-buffer cap, so converting 1-2 GiB of non-ASCII UTF-8 aborts the process even though the resulting UTF-16 string would fit. All-ASCII input never crashed (it takes an 8-bit path with no intermediate buffer).
- In the reporter's suite the failing expect ran in a detached async continuation seconds after its test finished, so the run printed `310 pass, 0 fail` and then died; WTF `CRASH()` is a breakpoint trap that bypasses bun's macOS crash reporter, hence the silent exit 133.

### Fix

- Add `Zig::convertUTF8ToString` in `helpers.h`: at or below the Vector capacity cap it calls `WTF::String::fromUTF8ReplacingInvalidSequences` exactly as before; above the cap it validates with simdutf, checks `MaxLength`, and converts into an exact-size fallible `StringImpl::tryCreateUninitialized` allocation (the same idiom `BunString__fromUTF8` already uses), keeping all-ASCII input 8-bit. Oversized invalid UTF-8 returns the null string, matching the existing "too long" paths.
- Route every unbounded `fromUTF8ReplacingInvalidSequences` call site through it, with the callers' existing null handling (throw out-of-memory where a throw scope exists):
  - `helpers.h` toString/toStringCopy/appendToBuilder (the error-message path from the issue)
  - `BunString__fromUTF8` invalid-input fallback and `BunString__createUTF8ForJS` (napi_create_string_utf8, WebSocket text frames)
  - `Response`/`ReadableStream` text consumers (`BunStreamConsumers.cpp`, `JSDirectStreamController.cpp`): `.text()` on a >1 GiB non-ASCII body aborted the same way
  - Bun's streaming JSON ArrayBuffer path (`BunObject.cpp`), `buffer.transcode` utf8 decode (`NodeBufferModule.cpp`), `v8::String::NewFromUtf8` (`V8String.cpp`), `decodeURIComponentSIMD.cpp`
- Remaining direct callers (sqlite column names, HTTP method/URL strings, uname fields, X509 OIDs, env var names, napi property names) are bounded far below 2^30 by their producers and left unchanged.
- Behavior at or below the cap is unchanged; above it, conversion now succeeds, or fails as a catchable error where the caller throws on null.
- Verified: `test/js/bun/test/expect/huge-failure-message.test.ts` spawns the crashing input in a subprocess; the child aborts on released bun (same bun.report signature as the issue, test fails showing `signalCode: "SIGABRT"`) and exits 0 with this change on the debug+ASAN build. `expect.test.js` (417), `expect-extend.test.js`, `streams.test.js` (175), `fetch/body.test.ts` (452), `decodeURIComponentSIMD.test.ts` (229), `test-icu-transcode.js`, and napi string tests pass on the debug build.

### Background

- `ZigString` is the FFI string view Rust hands to C++; a pointer tag bit marks its bytes as UTF-8 that must be converted into a `WTF::String` (JSC's string type: 8-bit Latin-1 or UTF-16, max 2^31-1 units).
- Error messages built in native code cross this boundary via `ZigString__toErrorInstance`, which is how a failing expect matcher's rendered message reaches this conversion. The other routed call sites convert user-supplied byte buffers (response bodies, transcode input, addon strings) through the same WTF function and shared the same abort.
- The regression test triggers the path through a custom matcher `message` instead of the issue's `expect(huge).toBeNull()` shape: both reach the identical conversion, but pretty-printing (JSON-escaping) a 1 GiB received value takes ~13 minutes under a debug+ASAN build while the matcher-message shape takes ~2 minutes. The test runs the child under `test.skipIf(os.totalmem() < 10 GiB)` to keep the multi-GB peak off small machines.

<details>
<summary>Reproduction details</summary>

Minimal crash on released bun (exit 134 on Linux, silent 133 on macOS):

```ts
import { test, expect } from "bun:test";
test("crash", () => {
  const s = Buffer.alloc(600_000_000, 0xe9).toString("latin1"); // 1.2e9 UTF-8 bytes
  expect(s).toBeNull();
});
```

Also reproduces without bun:test, e.g. `await new Response(new Uint8Array(1_200_000_000).fill(0xc3)).text()` style bodies through the stream text consumers.

The string must be non-ASCII. The threshold is a UTF-8 byte count above 1,073,741,823; `--smol` does not help because this is a capacity assertion, not OOM.

The reporter's unsymbolicated `.ips` offsets were resolved against the `bun-darwin-aarch64-profile` dSYM for their exact build (1.3.14+0d9b296af): frame 0 is the Vector `CRASH()` in `fromUTF8ReplacingInvalidSequences`, frame 1 `Zig::getErrorInstance` via `ZigString__toErrorInstance`, frame 2 `expect.toBeNull`.

Separate observation, not addressed here: bun's macOS crash handler does not report `EXC_BREAKPOINT` from WTF `CRASH()`, so these aborts are silent on macOS while Linux prints a bun.report link.

</details>
