### PR TITLE
usockets: evict the DNS cache entry when a connect from a single-address cache hit fails

### DIFF
--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -370,6 +370,7 @@ static void us_internal_init_listen_socket(struct us_listen_socket_t *ls,
     s->prev = 0;
     s->connect_state = NULL;
     s->connect_next = NULL;
+    s->connect_addrinfo_req = NULL;
 
     ls->accept_group = group;
     ls->accept_kind = kind;
@@ -548,6 +549,7 @@ static inline void us_internal_init_connect_socket(struct us_socket_t *s,
     s->fin_deferred = 0;
     s->connect_state = NULL;
     s->connect_next = NULL;
+    s->connect_addrinfo_req = NULL;
 }
 
 struct us_socket_t *us_socket_group_connect_resolved_dns(struct us_socket_group_t *group,
@@ -634,7 +636,15 @@ void *us_socket_group_connect(struct us_socket_group_t *group, unsigned char kin
                 init_addr_with_port(&entries->info, port, &a);
                 *has_dns_resolved = 1;
                 struct us_socket_t *s = us_socket_group_connect_resolved_dns(group, kind, ssl_ctx, &a, local_addr, options, socket_ext_size);
-                Bun__addrinfo_freeRequest(ai_req, s == NULL);
+                if (s == NULL) {
+                    Bun__addrinfo_freeRequest(ai_req, 1);
+                    return NULL;
+                }
+                /* connect() is still in flight; the socket holds the request
+                 * until us_internal_socket_after_open knows whether this one
+                 * address is dead, as us_connecting_socket_t does for
+                 * multi-address results. */
+                s->connect_addrinfo_req = ai_req;
                 return s;
             }
         }
@@ -821,6 +831,9 @@ void us_internal_socket_after_open(struct us_socket_t *s, int error) {
                 }
             }
         } else {
+            /* The one address the cache had for this host is dead: evict it
+             * before the handler runs so a retry from inside it re-resolves. */
+            us_internal_socket_release_addrinfo(s, 1);
             us_dispatch_connect_error(s, error);
             // It's expected that close is called by the caller
         }
@@ -843,6 +856,8 @@ void us_internal_socket_after_open(struct us_socket_t *s, int error) {
             Bun__addrinfo_freeRequest(c->addrinfo_req, 0);
             us_connecting_socket_free(c);
             s->connect_state = NULL;
+        } else {
+            us_internal_socket_release_addrinfo(s, 0);
         }
 
         if (s->ssl) {

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -341,11 +341,30 @@ struct us_socket_t {
   struct us_socket_t *prev, *next;
   struct us_socket_t *connect_next;
   struct us_connecting_socket_t *connect_state;
+  /* Set only on a socket connected straight from a completed DNS cache hit
+   * (us_socket_group_connect's single-address path, which has no
+   * us_connecting_socket_t to own the request). Held until the connect outcome
+   * is known so a failure can evict the entry; released by
+   * us_internal_socket_release_addrinfo from after_open or close_raw. Fits in
+   * the alignas(16) tail padding on epoll/kqueue. */
+  struct addrinfo_request *connect_addrinfo_req;
 };
 
 #if defined(LIBUS_USE_EPOLL) || defined(LIBUS_USE_KQUEUE)
 _Static_assert(sizeof(struct us_socket_flags) == 1, "us_socket_flags grew");
+_Static_assert(sizeof(struct us_socket_t) == 80, "us_socket_t grew");
 #endif
+
+/* Drop the socket's hold on the DNS cache entry its address came from, if any.
+ * `failed` invalidates the entry (mirrors the ECONNREFUSED path in
+ * us_connecting_socket_close); a close before the outcome is known is a caller
+ * abort and keeps it, like ECONNABORTED does there. */
+static inline void us_internal_socket_release_addrinfo(struct us_socket_t *s, int failed) {
+    if (s->connect_addrinfo_req) {
+        Bun__addrinfo_freeRequest(s->connect_addrinfo_req, failed);
+        s->connect_addrinfo_req = NULL;
+    }
+}
 
 /* us_socket_adopt relocates a socket whose ext grows and retires the old block
  * (is_closed + adopted, prev -> replacement; freed by the outermost tick's

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -532,6 +532,7 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                         s->kind = listen_socket->accept_kind;
                         s->ssl = NULL;
                         s->connect_state = NULL;
+                        s->connect_addrinfo_req = NULL;
                         s->timeout = 255;
                         s->long_timeout = 255;
                         s->flags.low_prio_state = 0;

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -330,11 +330,16 @@ struct us_socket_t *us_internal_socket_close_raw(struct us_socket_t *s, int code
         if (!(us_internal_poll_type(&s->p) & POLL_TYPE_SEMI_SOCKET)) {
             res = s->ssl ? us_internal_ssl_on_close(s, code, reason)
                          : us_dispatch_close(s, code, reason);
+        } else {
+            /* SEMI_SOCKET: never-opened connect — owner is notified via
+             * on_connect_error from the connect path (after_open / close_all),
+             * not here. Dispatching here would double-fire on the natural path
+             * (after_open → handler.close → close_raw).
+             * The DNS request is still held only if after_open never ran, i.e.
+             * the owner gave up before the connect had an outcome; that says
+             * nothing about the host, so the cache entry stays. */
+            us_internal_socket_release_addrinfo(s, 0);
         }
-        /* SEMI_SOCKET: never-opened connect — owner is notified via
-         * on_connect_error from the connect path (after_open / close_all),
-         * not here. Dispatching here would double-fire on the natural path
-         * (after_open → handler.close → close_raw). */
 
         us_internal_ssl_detach(s);
 
@@ -471,6 +476,7 @@ struct us_socket_t *us_socket_from_fd(struct us_socket_group_t *group, unsigned 
     s->read_eof = 0;
     s->fin_deferred = 0;
     s->connect_state = NULL;
+    s->connect_addrinfo_req = NULL;
 
     /* We always use nodelay */
     bsd_socket_nodelay(fd, 1);

--- a/test/js/bun/dns/dns-prefetch.test.ts
+++ b/test/js/bun/dns/dns-prefetch.test.ts
@@ -40,6 +40,150 @@ test("a failed connect evicts the host's DNS cache entry", async () => {
   });
 });
 
+// The test above always misses the cache, which makes usockets resolve through a
+// us_connecting_socket_t. A completed cache hit whose result is a single
+// address takes a different path (us_socket_group_connect connects to it
+// directly), and that path has to keep the same eviction promise. Each scenario
+// seeds the process-global cache exactly like a real lookup would and runs in
+// its own process. Nothing here ever resolves a name for real: `cacheMisses`
+// staying 0 proves every connect was served by the seeded entry.
+describe.concurrent("eviction through a completed cache hit", () => {
+  async function run(body: string) {
+    const script = `
+      const { dnsCacheSeed } = require("bun:internal-for-testing");
+      const stats = () => {
+        const { cacheHitsCompleted, cacheMisses, size, errors } = Bun.dns.getCacheStats();
+        return { cacheHitsCompleted, cacheMisses, size, errors };
+      };
+      const connect = (hostname, port, tls = false) =>
+        Bun.connect({ hostname, port, tls, socket: { data() {} } }).then(
+          socket => {
+            socket.end();
+            return "connected";
+          },
+          error => error.code,
+        );
+      // A port nothing listens on any more: connects to it are refused.
+      const closed = Bun.listen({ hostname: "127.0.0.1", port: 0, socket: { data() {} } });
+      const refusedPort = closed.port;
+      closed.stop();
+      console.log(JSON.stringify(await (async () => { ${body} })()));
+    `;
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", script], env: bunEnv, stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { result: JSON.parse(stdout.trim() || "null"), stderr, exitCode };
+  }
+
+  // TLS is attached to the socket up front on this path (there is no later
+  // point to do it), so a refused TLS connect is checked as well.
+  test("a refused connect to a single-address entry evicts it", async () => {
+    expect(
+      await run(`
+        dnsCacheSeed("single.test", ["127.0.0.1"]);
+        dnsCacheSeed("single-tls.test", ["127.0.0.1"]);
+        const seeded = stats();
+        const plain = await connect("single.test", refusedPort);
+        const afterPlain = stats();
+        const tls = await connect("single-tls.test", refusedPort, true);
+        return { seeded, plain, afterPlain, tls, afterTls: stats() };
+      `),
+    ).toEqual({
+      result: {
+        seeded: { cacheHitsCompleted: 0, cacheMisses: 0, size: 2, errors: 0 },
+        plain: "ECONNREFUSED",
+        afterPlain: { cacheHitsCompleted: 1, cacheMisses: 0, size: 1, errors: 1 },
+        tls: "ECONNREFUSED",
+        afterTls: { cacheHitsCompleted: 2, cacheMisses: 0, size: 0, errors: 2 },
+      },
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test("a refused connect to a multi-address entry evicts it", async () => {
+    expect(
+      await run(`
+        dnsCacheSeed("multi.test", ["127.0.0.1", "127.0.0.1"]);
+        const code = await connect("multi.test", refusedPort);
+        return { code, after: stats() };
+      `),
+    ).toEqual({
+      result: {
+        code: "ECONNREFUSED",
+        after: { cacheHitsCompleted: 1, cacheMisses: 0, size: 0, errors: 1 },
+      },
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  // The entry must survive a successful connect, and that connect must not
+  // keep a reference behind: once the host goes down, the entry still leaves.
+  test("a successful connect keeps the entry, and it is still evicted once the host goes down", async () => {
+    expect(
+      await run(`
+        const server = Bun.listen({ hostname: "127.0.0.1", port: 0, socket: { data() {} } });
+        dnsCacheSeed("flaky.test", ["127.0.0.1"]);
+        const first = await connect("flaky.test", server.port);
+        const afterSuccess = stats();
+        server.stop(true);
+        const second = await connect("flaky.test", server.port);
+        return { first, afterSuccess, second, afterRefused: stats() };
+      `),
+    ).toEqual({
+      result: {
+        first: "connected",
+        afterSuccess: { cacheHitsCompleted: 1, cacheMisses: 0, size: 1, errors: 0 },
+        second: "ECONNREFUSED",
+        afterRefused: { cacheHitsCompleted: 2, cacheMisses: 0, size: 0, errors: 1 },
+      },
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  // A connect torn down before it has an outcome says nothing about the host.
+  // The worker issues the connect and then never returns to its event loop, so
+  // terminating it is the only thing that closes the still-connecting socket;
+  // terminate() resolves after the worker's sockets are closed. The entry must
+  // stay, and the reference the worker held must be gone, which the refused
+  // connect afterwards shows by still being able to remove the entry.
+  // (Explicit timeout: starting a worker alone takes ~3s in a debug build.)
+  test("a connect abandoned before it completes keeps the entry and drops its reference", async () => {
+    expect(
+      await run(`
+        const { Worker } = require("node:worker_threads");
+        dnsCacheSeed("abandoned.test", ["127.0.0.1"]);
+        const worker = new Worker(
+          'const { parentPort, workerData: port } = require("node:worker_threads");' +
+            'Bun.connect({ hostname: "abandoned.test", port, socket: { data() {} } }).catch(() => {});' +
+            'parentPort.postMessage("connecting");' +
+            "for (;;) {}",
+          { eval: true, workerData: refusedPort },
+        );
+        await new Promise((resolve, reject) => {
+          worker.once("message", resolve);
+          worker.once("error", reject);
+        });
+        const whileConnecting = stats();
+        await worker.terminate();
+        const afterAbandon = stats();
+        const code = await connect("abandoned.test", refusedPort);
+        return { whileConnecting, afterAbandon, code, afterRefused: stats() };
+      `),
+    ).toEqual({
+      result: {
+        whileConnecting: { cacheHitsCompleted: 1, cacheMisses: 0, size: 1, errors: 0 },
+        afterAbandon: { cacheHitsCompleted: 1, cacheMisses: 0, size: 1, errors: 0 },
+        code: "ECONNREFUSED",
+        afterRefused: { cacheHitsCompleted: 2, cacheMisses: 0, size: 0, errors: 1 },
+      },
+      stderr: "",
+      exitCode: 0,
+    });
+  }, 30_000);
+});
+
 describe("dns.prefetch", () => {
   it("should prefetch", async () => {
     // A local server keeps the test off the external network. "localhost" is a


### PR DESCRIPTION
### Problem

- `docs/runtime/networking/dns.mdx` promises that a failed connection removes the host's entry from the connect-path DNS cache. For the most common kind of host, one whose name resolves to a single address, this does not happen once the name is cached: every `fetch()` / `Bun.connect()` to it for the rest of the TTL (30s) is served the dead address as a cache hit, and `Bun.dns.getCacheStats().errors` never moves.
- Cause: `us_socket_group_connect` (`packages/bun-usockets/src/context.c`) has a direct path for a completed cache hit whose result has exactly one address. It issues the non-blocking `connect()` and immediately called `Bun__addrinfo_freeRequest(ai_req, s == NULL)`, i.e. released the entry with `error = 0` before the outcome of the connect was known. When the ECONNREFUSED later arrived in `us_internal_socket_after_open`, the socket had no `connect_state` and nothing left to evict.
- Every other route (a cache miss, a multi-address hit, a cached resolver failure) goes through a `us_connecting_socket_t`, which holds the request until the connect settles and evicts it on failure (#32991). That PR listed this path as intentionally not covered; this PR covers it.

### Fix

- `us_socket_t` gets a `connect_addrinfo_req` field. The single-address path stores the request there instead of releasing it (`context.c`, `us_socket_group_connect`; this is the behavioral change). The existing immediate-failure case (`connect()` itself fails, `s == NULL`) still evicts as before.
- `us_internal_socket_release_addrinfo` (`internal.h`) releases it exactly once, at the point the outcome is known:
  - `us_internal_socket_after_open`, connect error: release with `error = 1`, before `us_dispatch_connect_error`, so a retry issued from the handler re-resolves. This is the same decision the `us_connecting_socket_t` path makes by setting `c->error = ECONNREFUSED` once every address failed.
  - `us_internal_socket_after_open`, success: release with `error = 0`, the counterpart of the `Bun__addrinfo_freeRequest(c->addrinfo_req, 0)` in the `connect_state` branch next to it.
  - `us_internal_socket_close_raw` on a still-connecting (`SEMI_SOCKET`) socket: release with `error = 0`. The request is only still held there if `after_open` never ran, i.e. the owner closed the socket before the connect had an outcome (user close, group `close_all` at VM teardown, a timeout handler), which says nothing about the host; this matches the ECONNABORTED default in `us_connecting_socket_close`. `after_open` clears the field first, so the close that follows a connect error does not release twice.
- Why it is correct to hold the reference: `freeaddrinfo` in `src/runtime/dns_jsc/dns.rs` already implements "invalidate, then drop the ref, remove the entry when the last ref goes" for the connecting-socket path; this PR only moves the fast path's single release to the same moment. Every way a connecting socket can end goes through `after_open` or `close_raw` (a socket closed by `us_connecting_socket_close` has `connect_state` set and never holds this field; `us_socket_adopt` relocates the struct with `memcpy`, so the field moves with it), so the refcount stays balanced. The Rust side is unchanged.
- The field is initialized wherever `connect_state` is (connect, accept, `us_socket_from_fd`, listen sockets), since `us_create_poll` does not zero its allocation.
- Size: `sizeof(struct us_socket_t)` stays 80 on epoll/kqueue (the new pointer lands in the `alignas(16)` tail padding that followed `connect_state` at offset 64; a `_Static_assert` pins this, like the existing one on `us_socket_flags`). On the libuv backend (Windows) it grows from 80 to 96 because `us_poll_t` is 24 bytes there. I preferred a dedicated field over reusing `connect_next` as a union (which would be free everywhere) because misreading that union would hand a `us_socket_t*` to `Bun__addrinfo_freeRequest`; happy to switch if the 16 bytes on Windows matter more.
- Verification: `test/js/bun/dns/dns-prefetch.test.ts`, new `describe("eviction through a completed cache hit")`. Each scenario seeds a single-address entry with `dnsCacheSeed` (the same hook `dns-interleave.test.ts` uses; it stores an entry exactly like a real lookup) and checks `getCacheStats()`:
  - refused connect (plain and TLS) evicts the entry (`size` drops, `errors` increments);
  - a multi-address entry still evicts (the pre-existing path);
  - a successful connect keeps the entry and leaves no reference behind (the entry is still removed when the host later refuses);
  - a connect abandoned before it completes (issued in a worker that never returns to its event loop, then `terminate()`d) keeps the entry and leaves no reference behind.
  - On the unfixed build the single-address, success and abandoned scenarios fail with `errors: 0, size: 1` where `errors: 1, size: 0` is expected; everything else in those scenarios (error codes, the no-eviction checks) already matched, so the diff adds eviction and changes nothing else. `USE_SYSTEM_BUN=1` (1.4.0): 3 fail; `bun bd test`: all pass.
  - Also ran `test/js/bun/dns/`, `test/js/bun/net/{socket,socket-dns-error,socket-retention,localhost-loopback-contract}.test.ts`, `test/js/node/net/{double-connect,socket-reconnect-live,connect-autoselectfamily-stale-timer}.test.ts` and `test/js/web/fetch/{fetch-preconnect,fetch-keepalive,fetch-abort-socket-close-race,client-fetch}.test.ts` with the debug build: the only failures are ones that fail the same way on the unmodified binary in this environment (tests that need network, and tests that listen on `localhost` on a host without a global IPv6 address, which #38818 is about), plus one IP-literal GC test that only exceeds the 5s local default timeout in the debug build.

### Background

- Connect-path DNS cache: `fetch()`, `Bun.connect`, `bun install` etc. resolve names through a process-global cache in `dns.rs` (256 entries, 30s TTL, keyed by hostname). Each in-flight connect holds a reference (`refcount`) on the entry it resolved through and releases it with `Bun__addrinfo_freeRequest(req, error)`; `error != 0` marks the entry invalid so it is removed as soon as the last reference goes and the next lookup misses. `getCacheStats().size` is the number of entries, `errors` the number of releases with `error != 0`.
- `us_connecting_socket_t`: usockets' placeholder for a connect whose name is not resolved yet, or resolved to several addresses. It owns the request, opens up to 4 candidate sockets (happy eyeballs), and `us_connecting_socket_close` releases the request, evicting when `c->error` is ECONNREFUSED.
- Fast path: when the cache already holds a completed result with one address, `us_socket_group_connect` skips the placeholder and returns a plain `us_socket_t` synchronously (`has_dns_resolved = 1`); TLS is attached to it up front because there is no later point to do so. This socket is a `SEMI_SOCKET` until its fd becomes writable, when `us_internal_socket_after_open` reads the connect result.

<details>
<summary>Repro (debug build, before / after)</summary>

```js
const { dnsCacheSeed } = require("bun:internal-for-testing"); // BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING=1
const l = Bun.listen({ hostname: "127.0.0.1", port: 0, socket: { data() {} } });
const port = l.port; l.stop();
const c = host => Bun.connect({ hostname: host, port, socket: { data() {} } }).then(() => "connected", e => e.code);
dnsCacheSeed("one.test", ["127.0.0.1"]);
dnsCacheSeed("two.test", ["127.0.0.1", "127.0.0.1"]);
console.log(await c("one.test"), Bun.dns.getCacheStats());
console.log(await c("one.test"), Bun.dns.getCacheStats());
console.log(await c("two.test"), Bun.dns.getCacheStats());
```

Before (also bun 1.4.0): `one.test` is refused twice, both served as `cacheHitsCompleted`, `size` stays 2, `errors` stays 0; `two.test` is refused once and evicted (`size` 1, `errors` 1).

After: the first `one.test` connect is refused and evicted (`size` 1, `errors` 1); the second one is a cache miss.

</details>
