### PR TITLE
bundler: stop an export star ambiguity that loops back into a re-export chain from overflowing the stack

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -1582,6 +1582,9 @@ pub(crate) enum MatchImportKind {
     ProbablyTypescriptType,
     /// The import resolved to multiple symbols via "export * from"
     Ambiguous,
+    /// Tracing the import's "export * from" alternatives would have
+    /// overflowed the stack
+    StackOverflow,
 }
 
 pub struct ChunkMeta {
@@ -3490,7 +3493,12 @@ impl<'a> LinkerContext<'a> {
             //
             // This uses a O(n^2) array scan instead of a O(n) map because the vast
             // majority of cases have one or two elements
-            for prev_tracker in &self.cycle_detector[cycle_detector_top..] {
+            //
+            // The entries below `cycle_detector_top` are the chains of the callers
+            // this is tracing an "export * from" alternative for (`Found` arm); an
+            // alternative leading back into one of them would otherwise recurse
+            // forever.
+            for prev_tracker in &self.cycle_detector {
                 if import_tracker_eq(&tracker, prev_tracker) {
                     result = MatchImport {
                         kind: MatchImportKind::Cycle,
@@ -3723,8 +3731,21 @@ impl<'a> LinkerContext<'a> {
                             [ambiguous_tracker.data.source_index.get() as usize]
                             .contains(&ambiguous_tracker.data.import_ref)
                         {
+                            // One frame per nested alternative; the chain can be as
+                            // long as the input likes.
+                            if !bun_core::StackCheck::init().is_safe_to_recurse() {
+                                result = MatchImport {
+                                    kind: MatchImportKind::StackOverflow,
+                                    ..Default::default()
+                                };
+                                break 'loop_;
+                            }
                             let ambig =
                                 self.match_import_with_export(ambiguous_tracker.data, re_exports);
+                            if ambig.kind == MatchImportKind::StackOverflow {
+                                result = ambig;
+                                break 'loop_;
+                            }
                             ambiguous_results.push(ambig);
                         } else {
                             ambiguous_results.push(MatchImport {
@@ -3782,6 +3803,11 @@ impl<'a> LinkerContext<'a> {
         // Spec `defer`: restore cycle_detector to its entry length now that the
         // loop is done. All remaining exit paths are below this point.
         self.cycle_detector.truncate(cycle_detector_top);
+
+        // Not every alternative was traced, so there is nothing to compare.
+        if result.kind == MatchImportKind::StackOverflow {
+            return result;
+        }
 
         // If there is a potential ambiguity, all results must be the same
         for ambig in &ambiguous_results {
@@ -3912,7 +3938,7 @@ impl<'a> LinkerContext<'a> {
                             ..Default::default()
                         }));
                 }
-                MatchImportKind::Cycle => {
+                MatchImportKind::Cycle | MatchImportKind::StackOverflow => {
                     let source = self.get_source(source_index);
                     let r = lex::range_of_identifier(source, named_import.alias_loc);
                     // SAFETY: arena `*const [u8]` valid for the link pass.
@@ -3920,13 +3946,19 @@ impl<'a> LinkerContext<'a> {
                         .alias
                         .expect("infallible: alias present")
                         .slice();
+                    let what = if result.kind == MatchImportKind::Cycle {
+                        "Detected cycle"
+                    } else {
+                        "Maximum call stack size exceeded"
+                    };
                     // Split-borrow with `named_import` — `log_disjoint` returns
                     // the disjoint `Transpiler.log` backref.
                     self.log_disjoint().add_range_error_fmt(
                         Some(source),
                         r,
                         format_args!(
-                            "Detected cycle while resolving import \"{}\"",
+                            "{} while resolving import \"{}\"",
+                            what,
                             bstr::BStr::new(alias),
                         ),
                     );

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2831,6 +2831,115 @@ describe("bundler", () => {
     },
     120_000,
   );
+  // When a name reaches a file through two different `export *` statements,
+  // the linker traces each alternative to check that they end at the same
+  // symbol; an alternative that is itself a re-export is traced by a recursive
+  // call. These cycles lead straight back into an import that is still being
+  // traced, which used to recurse until the stack overflowed (the recursive
+  // call only checked for cycles within its own chain). esbuild reports the
+  // same error for both graphs. backend: "cli" so that the old crash killed a
+  // child process rather than the test runner.
+  itBundled("edgecase/ExportStarAmbiguityCycleIntoBarrel", {
+    files: {
+      "/entry.js": `import { x } from "./barrel.js"; console.log(x);`,
+      "/barrel.js": `export * from "./a.js"; export * from "./b.js";`,
+      "/a.js": `export const x = 1;`,
+      "/b.js": `export { x } from "./barrel.js";`,
+    },
+    backend: "cli",
+    bundleErrors: {
+      "/b.js": ['Ambiguous import "x" has multiple matching exports'],
+    },
+  });
+  // Here the import being traced is only re-entered two recursive calls down
+  // (b2 -> barrel1 -> b1 -> barrel2 -> b2), so every chain on the stack has to
+  // be checked, not just the caller's.
+  itBundled("edgecase/ExportStarAmbiguityCycleAcrossBarrels", {
+    files: {
+      "/entry.js": `import { x } from "./barrel1.js"; console.log(x);`,
+      "/a.js": `export const x = 1;`,
+      "/barrel1.js": `export * from "./a.js"; export * from "./b1.js";`,
+      "/b1.js": `export { x } from "./barrel2.js";`,
+      "/barrel2.js": `export * from "./a.js"; export * from "./b2.js";`,
+      "/b2.js": `export { x } from "./barrel1.js";`,
+    },
+    backend: "cli",
+    bundleErrors: {
+      "/b2.js": ['Ambiguous import "x" has multiple matching exports'],
+    },
+  });
+  // Alternatives traced one after the other may pass through the same
+  // re-export (both b and c go through shared); that is not a cycle. All
+  // three alternatives end at a.x, so the import is not ambiguous either.
+  itBundled("edgecase/ExportStarAmbiguityAlternativesShareReExport", {
+    files: {
+      "/entry.js": `import { x } from "./barrel.js"; console.log(x);`,
+      "/barrel.js": `export * from "./a.js"; export * from "./b.js"; export * from "./c.js";`,
+      "/a.js": `export const x = 1;`,
+      "/b.js": `export { x } from "./shared.js";`,
+      "/c.js": `export { x } from "./shared.js";`,
+      "/shared.js": `export { x } from "./a.js";`,
+    },
+    run: { stdout: "1" },
+  });
+  // An acyclic version of the above: barrel N's second `export *` leads to a
+  // re-export from barrel N+1, so tracing the alternatives recurses once per
+  // barrel. Bun.build() links on a thread with a 2 MiB stack, which a
+  // debug+ASAN build overflowed a little past 400 barrels (it now stops with a
+  // build error shortly before that); a release build bundles this chain.
+  // Either outcome is fine, what must not happen is the process dying, which
+  // is why the build runs in a child. Mostly spent parsing the 1200 files
+  // under ASAN, hence the timeout.
+  test.concurrent(
+    "edgecase/ExportStarAmbiguityDeepReExportChain",
+    async () => {
+      const depth = 600;
+      using dir = tempDir("export-star-ambiguity-deep-chain", {
+        "a.js": `export const x = 1;\n`,
+        ...Object.fromEntries(
+          Array.from({ length: depth }, (_, i) => [
+            `barrel${i}.js`,
+            `export * from "./a.js";\nexport * from "./b${i}.js";\n`,
+          ]),
+        ),
+        ...Object.fromEntries(
+          Array.from({ length: depth }, (_, i) => [`b${i}.js`, `export { x } from "./barrel${i + 1}.js";\n`]),
+        ),
+        [`barrel${depth}.js`]: `export * from "./a.js";\n`,
+        "entry.js": `import { x } from "./barrel0.js";\nconsole.log(x);\n`,
+        "build-fixture.ts": /* ts */ `
+          const result = await Bun.build({ entrypoints: [import.meta.dir + "/entry.js"], throw: false });
+          console.log(
+            JSON.stringify({
+              success: result.success,
+              logs: result.logs.map(log => log.message),
+              output: result.success ? await result.outputs[0].text() : null,
+            }),
+          );
+        `,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build-fixture.ts"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stderr, exitCode, signalCode: proc.signalCode }).toEqual({ stderr: "", exitCode: 0, signalCode: null });
+      const result = JSON.parse(stdout);
+      if (result.success) {
+        expect(result.logs).toEqual([]);
+        expect(result.output).toContain("var x = 1;");
+      } else {
+        expect(result).toEqual({
+          success: false,
+          logs: ['Maximum call stack size exceeded while resolving import "x"'],
+          output: null,
+        });
+      }
+    },
+    120_000,
+  );
   itBundled("edgecase/NonAsciiPathDerivedWrapperName", {
     files: {
       "/entry.ts": /* js */ `


### PR DESCRIPTION
### Problem

- `bun build` segfaults (`panic(main thread): Segmentation fault`; a debug build reports `AddressSanitizer: stack-overflow` with `LinkerContext::match_import_with_export` calling itself) on a barrel whose `export *` reaches a module that re-exports the same name from the barrel:

  ```js
  // entry.js
  import { x } from "./barrel.js";
  // barrel.js
  export * from "./a.js"; export * from "./b.js";
  // a.js
  export const x = 1;
  // b.js
  export { x } from "./barrel.js";
  ```

  Two barrels whose second `export *` each lead to a re-export from the other barrel crash the same way.
- Cause: when a name reaches a file through two `export *` statements, `match_import_with_export` (src/bundler/LinkerContext.rs) traces each alternative with a recursive call to itself. The cycle check at the top of its loop only scanned the trackers pushed by the current call (`cycle_detector[cycle_detector_top..]`), so the recursive call tracing `b`'s re-export did not see that this same import was already being traced by its caller, followed it into `barrel` again, met the same alternative, and recursed until the stack was gone. esbuild's `matchImportWithExport` scans its whole `cycleDetector`; the frame-local slice dates back to the Zig version of this function.
- The same recursion also grows by one frame per barrel on an acyclic chain of such alternatives, so a long enough chain overflowed the 2 MiB stack of the thread `Bun.build()` links on (an unfixed debug build died at a little over 400 barrels, the released binary somewhere between 4000 and 5000).

### Fix

- Scan the whole `cycle_detector`. Every call still truncates it back to its entry length when it returns (esbuild's save/restore of the detector around the recursive call), so the entries a call sees are exactly the chains currently being traced on the stack; alternatives traced one after another do not see each other's entries.
- Why this is the right result: an alternative whose chain reaches a tracker that is still being traced is a cycle in the re-export graph, and with the old code every such input recursed forever (each recursive call restarted the same chain with an empty window), so the only inputs whose outcome changes are ones that crashed before. The alternative now resolves to `Cycle`, and the existing comparison of the alternatives reports `Ambiguous import "x" has multiple matching exports`, which is what esbuild (0.21.5) prints for both graphs above. (A spec-following module loader would ignore the circular alternative and resolve `x` to `a.x`; esbuild chose to report the ambiguity instead, and this keeps Bun in line with it.)
- Before each recursive call, check the remaining stack with `StackCheck` (as the parser and printer do) and fail the build with `Maximum call stack size exceeded while resolving import "x"` instead of overflowing. A new `MatchImportKind::StackOverflow` carries this out of the recursion: each call in between stops tracing and passes it up, and the outermost call reports it at the import being matched, the way `Cycle` is reported, so the build fails with that one error.
- Tests, all in test/bundler/bundler_edgecase.test.ts:
  - `ExportStarAmbiguityCycleIntoBarrel` and `ExportStarAmbiguityCycleAcrossBarrels`: the two graphs above, expecting the ambiguity error. Before the fix the `bun build` child is killed (SIGSEGV with the released 1.4.0 canary, ASAN stack-overflow with an unfixed debug build).
  - `ExportStarAmbiguityAlternativesShareReExport`: two alternatives that pass through the same re-export one after another must not be taken for a cycle. Passes before and after; it pins the truncate-on-return behavior the fix relies on.
  - `ExportStarAmbiguityDeepReExportChain`: a 600-barrel acyclic chain built with `Bun.build()` in a child process. Unfixed debug build: the child dies. Fixed debug build: the new error. Release builds, where 600 barrels fit on the stack, bundle it; the test accepts either outcome and requires the child to exit normally. Its fail-before is therefore debug-only; the released binary bundles a chain of this length. It takes about 9 to 11 s here under debug+ASAN, almost all of it parsing the 1200 files, hence the explicit timeout (same as the neighbouring deep-chain tests).
- Also ran test/bundler/esbuild/importstar.test.ts, the cycle/ambiguity/export-star tests of test/bundler/esbuild/default.test.ts, and the whole of bundler_edgecase.test.ts against the fixed build: all pass.
- #31667 rewrites the same cycle check (switching it to a hash set past a threshold) and does not change which entries are scanned, so it neither fixes nor is fixed by this; whichever lands second gets a small conflict in this loop. #38966 converts the linker's other recursive walks and leaves this function alone.

### Background

- An import tracker is a (file, import ref) pair identifying one `import {x}` or `export {x} from` statement; `advance_import_tracker` follows it one step to the export it names in the target file, and `match_import_with_export` loops on that until it reaches a real symbol (or a CommonJS file, a missing export, etc.).
- `resolved_exports[file][name]` is computed before imports are matched. When a name reaches a file through several `export *` statements that point at different symbols, the first is stored as the export and the rest are attached to it as `potentially_ambiguous_export_star_refs`. While matching an import, every alternative is traced to its final symbol and the import is ambiguous unless they all agree (`export * from "./c"` next to `export { x } from "./c"` is the legitimate case this exists for, covered by the existing `ReExportStarNameCollisionNotAmbiguousImport` test). Tracing an alternative that is itself a re-export is where the recursion comes from.
- `cycle_detector` is a `Vec` of the trackers on the chains currently being followed. Each call notes its length on entry, pushes the trackers it visits, and truncates back to the noted length when it returns.
- `StackCheck` compares the stack pointer with the stack bounds recorded when the thread started and reports whether more than 128 KiB (256 KiB on Windows) remain. `bun build` links on the main thread; `Bun.build()` links on a dedicated thread with the default 2 MiB stack.

<details>
<summary>Measurements (chain of N barrels, x resolving through all of them)</summary>

Released 1.4.0 canary (unfixed), `Bun.build()` on the bundle thread: N = 4000 bundles, N = 5000 segfaults. `bun build` on the main thread bundles N = 20000.

Unfixed debug+ASAN build, `Bun.build()`: N = 400 bundles, N = 425 dies.

Fixed debug+ASAN build, `Bun.build()`: N = 375 bundles, N = 400 fails with `Maximum call stack size exceeded while resolving import "x"` (the guard keeps 128 KiB in reserve, about 25 frames of this function in a debug build).

esbuild 0.21.5 on the first graph in the description:

```
✘ [ERROR] Ambiguous import "x" has multiple matching exports   b.js:1:9
✘ [ERROR] Ambiguous import "x" has multiple matching exports   entry.js:1:9
```

Bun stops after the first file with an import error, so it reports the `b.js` one.

</details>
