### PR TITLE
install: refuse local tarball dependencies declared by packages installed from the cache

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1517,6 +1517,18 @@ pub fn enqueue_dependency_with_main_and_success_fn(
         }
         dependency::version::Tag::Tarball => {
             let tarball = version.tarball();
+            if matches!(tarball.uri, dependency::tarball::Uri::Local(_))
+                && !version_was_replaced
+                && let Some(declarer) = this.lockfile.get_parent_pkg_of_dependency(id)
+                && !this.lockfile.packages.items_resolution()[declarer as usize]
+                    .tag
+                    .is_local_package()
+            {
+                if dependency.behavior.is_required() {
+                    reject_local_tarball_of_remote_package(this, declarer, dependency);
+                }
+                return Ok(());
+            }
             let res: Resolution = match &tarball.uri {
                 dependency::tarball::Uri::Local(path) => {
                     Resolution::init(ResolutionTagged::LocalTarball(*path))
@@ -1657,6 +1669,32 @@ fn warn_unmet_peer_dependency(
         "No version matching \"{}\" found for peer dependency \"{}\"<r> <d>(but package exists)<r>",
         bstr::BStr::new(this.lockfile.str(&version.literal)),
         bstr::BStr::new(this.lockfile.str(&name)),
+    );
+}
+
+/// `enqueue_local_tarball` reads the path relative to the project, which is what
+/// a manifest in the project means by it. A package extracted from the cache
+/// meant a file of its own, so its path must not be applied to the project;
+/// the project can still supply the dependency through `overrides`.
+#[cold]
+#[inline(never)]
+fn reject_local_tarball_of_remote_package(
+    this: &PackageManager,
+    declarer: PackageID,
+    dependency: &Dependency,
+) {
+    let buf = this.lockfile.buffers.string_bytes.as_slice();
+    let packages = this.lockfile.packages.slice();
+    this.log_mut().add_error_fmt(
+        None,
+        bun_ast::Loc::EMPTY,
+        format_args!(
+            "refusing to resolve \"{}@{}\" declared by {}@{}: local tarball dependencies are only allowed in the package.json files of this project",
+            bstr::BStr::new(dependency.name.slice(buf)),
+            bstr::BStr::new(dependency.version.literal.slice(buf)),
+            bstr::BStr::new(packages.items_name()[declarer as usize].slice(buf)),
+            packages.items_resolution()[declarer as usize].fmt(buf, bun_fmt::PathSep::Posix),
+        ),
     );
 }
 

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1672,10 +1672,7 @@ fn warn_unmet_peer_dependency(
     );
 }
 
-/// `enqueue_local_tarball` reads the path relative to the project, which is what
-/// a manifest in the project means by it. A package extracted from the cache
-/// meant a file of its own, so its path must not be applied to the project;
-/// the project can still supply the dependency through `overrides`.
+/// `enqueue_local_tarball` would read the path relative to the project, not to the declarer.
 #[cold]
 #[inline(never)]
 fn reject_local_tarball_of_remote_package(

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1523,6 +1523,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                 && !this.lockfile.packages.items_resolution()[declarer as usize]
                     .tag
                     .is_local_package()
+                && !this.lockfile.has_equal_root_dependency(dependency)
             {
                 if dependency.behavior.is_required() {
                     reject_local_tarball_of_remote_package(this, declarer, dependency);
@@ -1682,14 +1683,21 @@ fn reject_local_tarball_of_remote_package(
 ) {
     let buf = this.lockfile.buffers.string_bytes.as_slice();
     let packages = this.lockfile.packages.slice();
-    this.log_mut().add_error_fmt(
+    let name = bstr::BStr::new(dependency.name.slice(buf));
+    let literal = bstr::BStr::new(dependency.version.literal.slice(buf));
+    let declarer_name = bstr::BStr::new(packages.items_name()[declarer as usize].slice(buf));
+    this.log_mut().add_range_error_fmt_with_notes(
         None,
-        bun_ast::Loc::EMPTY,
+        bun_ast::Range::NONE,
+        Box::new([bun_ast::range_data(
+            None,
+            bun_ast::Range::NONE,
+            bun_ast::alloc_print(format_args!(
+                "add \"{name}\": \"{literal}\" to the root package.json to install that tarball for {declarer_name} as well",
+            )),
+        )]),
         format_args!(
-            "refusing to resolve \"{}@{}\" declared by {}@{}: local tarball dependencies are only allowed in the package.json files of this project",
-            bstr::BStr::new(dependency.name.slice(buf)),
-            bstr::BStr::new(dependency.version.literal.slice(buf)),
-            bstr::BStr::new(packages.items_name()[declarer as usize].slice(buf)),
+            "refusing to resolve \"{name}@{literal}\" declared by {declarer_name}@{}: local tarball dependencies are only allowed in the package.json files of this project",
             packages.items_resolution()[declarer as usize].fmt(buf, bun_fmt::PathSep::Posix),
         ),
     );

--- a/src/install/PackageManager/PackageManagerResolution.rs
+++ b/src/install/PackageManager/PackageManagerResolution.rs
@@ -330,11 +330,10 @@ impl PackageManager {
                     continue;
                 }
 
-                let features = match pkg_resolutions[parent_id].tag {
-                    ResolutionTag::Root | ResolutionTag::Workspace | ResolutionTag::Folder => {
-                        self.options.local_package_features
-                    }
-                    _ => self.options.remote_package_features,
+                let features = if pkg_resolutions[parent_id].tag.is_local_package() {
+                    self.options.local_package_features
+                } else {
+                    self.options.remote_package_features
                 };
                 // even if optional dependencies are enabled, it's still allowed to fail
                 if failed_dep.behavior.is_optional() || !failed_dep.behavior.is_enabled(features) {

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -782,8 +782,7 @@ impl Lockfile {
         self.get_workspace_pkg_if_workspace_dep(id) != invalid_package_id
     }
 
-    /// The package whose dependency list `id` belongs to. `None` for the
-    /// dependencies `enqueue_dependency_to_root` appends outside of any package.
+    /// `None` for the edges `enqueue_dependency_to_root` appends outside of any package.
     pub(crate) fn get_parent_pkg_of_dependency(&self, id: DependencyID) -> Option<PackageID> {
         for (pkg_id, dependencies) in self.packages.items_dependencies().iter().enumerate() {
             if dependencies.contains(id) {

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -782,6 +782,17 @@ impl Lockfile {
         self.get_workspace_pkg_if_workspace_dep(id) != invalid_package_id
     }
 
+    /// The package whose dependency list `id` belongs to. `None` for the
+    /// dependencies `enqueue_dependency_to_root` appends outside of any package.
+    pub(crate) fn get_parent_pkg_of_dependency(&self, id: DependencyID) -> Option<PackageID> {
+        for (pkg_id, dependencies) in self.packages.items_dependencies().iter().enumerate() {
+            if dependencies.contains(id) {
+                return Some(PackageID::try_from(pkg_id).expect("int cast"));
+            }
+        }
+        None
+    }
+
     pub(crate) fn get_workspace_pkg_if_workspace_dep(&self, id: DependencyID) -> PackageID {
         let packages = self.packages.slice();
         let resolutions = packages.items_resolution();

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -37,8 +37,8 @@ use crate::update_request::UpdateRequest;
 use crate::{
     self as Install, DependencyID, ExternalSlice, Features, PackageID, PackageManager,
     PackageNameAndVersionHash, PackageNameHash, TruncatedPackageNameHash, dependency,
-    dependency::Dependency, initialize_store, invalid_dependency_id, invalid_package_id,
-    npm as Npm,
+    dependency::Dependency, dependency::DependencyExt as _, initialize_store,
+    invalid_dependency_id, invalid_package_id, npm as Npm,
 };
 use bun_install_types::NodeLinker::NodeLinker;
 
@@ -790,6 +790,15 @@ impl Lockfile {
             }
         }
         None
+    }
+
+    /// Does the root package.json declare the same dependency (name and specifier) itself?
+    pub(crate) fn has_equal_root_dependency(&self, dependency: &Dependency) -> bool {
+        let buf = self.buffers.string_bytes.as_slice();
+        self.packages.items_dependencies()[0]
+            .get(self.buffers.dependencies.as_slice())
+            .iter()
+            .any(|root_dependency| root_dependency.eql(dependency, buf, buf))
     }
 
     pub(crate) fn get_workspace_pkg_if_workspace_dep(&self, id: DependencyID) -> PackageID {

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -600,11 +600,10 @@ pub(crate) fn is_filtered_dependency_or_workspace(
         return true;
     }
 
-    let dep_features = match parent_res.tag {
-        crate::resolution::Tag::Root
-        | crate::resolution::Tag::Workspace
-        | crate::resolution::Tag::Folder => manager.options.local_package_features,
-        _ => manager.options.remote_package_features,
+    let dep_features = if parent_res.tag.is_local_package() {
+        manager.options.local_package_features
+    } else {
+        manager.options.remote_package_features
     };
 
     if !dep.behavior.is_enabled(dep_features) {

--- a/src/install/resolution.rs
+++ b/src/install/resolution.rs
@@ -965,6 +965,12 @@ impl Tag {
         self == Tag::Git || self == Tag::Github
     }
 
+    /// Packages whose package.json is read from the project (the root, its
+    /// workspaces and `file:` folders) rather than extracted into the cache.
+    pub(crate) fn is_local_package(self) -> bool {
+        self == Tag::Root || self == Tag::Workspace || self == Tag::Folder
+    }
+
     pub(crate) fn can_enqueue_install_task(self) -> bool {
         self == Tag::Npm
             || self == Tag::LocalTarball

--- a/src/install/resolution.rs
+++ b/src/install/resolution.rs
@@ -965,8 +965,7 @@ impl Tag {
         self == Tag::Git || self == Tag::Github
     }
 
-    /// Packages whose package.json is read from the project (the root, its
-    /// workspaces and `file:` folders) rather than extracted into the cache.
+    /// The package.json is read from the project rather than extracted into the cache.
     pub(crate) fn is_local_package(self) -> bool {
         self == Tag::Root || self == Tag::Workspace || self == Tag::Folder
     }

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -10043,11 +10043,17 @@ describe.concurrent("file: tarballs declared by a package installed from the cac
   }
 
   // <root>/project depends on `bar@0.0.2` from the dummy registry, whose manifest
-  // for it carries `barManifest`. Returns the URLs the registry gets asked for.
-  async function writeRegistryProject(ctx: TestContext, root: string, barManifest: object, rootExtra: object = {}) {
+  // for it carries `barManifest`, plus whatever `root` adds to its package.json.
+  // Returns the URLs the registry gets asked for.
+  async function writeRegistryProject(
+    ctx: TestContext,
+    root: string,
+    barManifest: object,
+    { dependencies = {}, ...rootExtra }: { dependencies?: Record<string, string>; [field: string]: unknown } = {},
+  ) {
     const urls: string[] = [];
     setContextHandler(ctx, dummyRegistryForContext(ctx, urls, { "0.0.2": barManifest }));
-    await write(join(root, "project", "package.json"), rootPackageJson({ bar: "0.0.2" }, rootExtra));
+    await write(join(root, "project", "package.json"), rootPackageJson({ bar: "0.0.2", ...dependencies }, rootExtra));
     await write(join(root, "project", "bunfig.toml"), `[install]\nregistry = "${ctx.registry_url}"\n`);
     return urls;
   }
@@ -10079,14 +10085,18 @@ describe.concurrent("file: tarballs declared by a package installed from the cac
     return { err, out, exitCode };
   }
 
-  // `declarer` is how bun prints the package declaring the tarball.
+  // What bun prints for an edge it refuses. The declaring package is always named
+  // `bar` here; `declarer` is how bun prints it, which depends on where it came from.
   function refusal(name: string, spec: string, declarer: string) {
-    return `error: refusing to resolve "${name}@${spec}" declared by ${declarer}: local tarball dependencies are only allowed in the package.json files of this project`;
+    return [
+      `error: refusing to resolve "${name}@${spec}" declared by ${declarer}: local tarball dependencies are only allowed in the package.json files of this project`,
+      `note: add "${name}": "${spec}" to the root package.json to install that tarball for bar as well`,
+    ];
   }
 
   // The rest of stderr is progress output ("Resolving dependencies", ...).
-  function errorLines(stderr: string) {
-    return stderr.split(/\r?\n/).filter(line => line.startsWith("error:"));
+  function diagnostics(stderr: string) {
+    return stderr.split(/\r?\n/).filter(line => line.startsWith("error:") || line.startsWith("note:"));
   }
 
   async function expectRejected(root: string, declarer: string) {
@@ -10094,12 +10104,12 @@ describe.concurrent("file: tarballs declared by a package installed from the cac
 
     const rejected = Object.entries(declaredTarballs(root));
     const expected = [
-      ...rejected.map(([name, spec]) => refusal(name, spec, declarer)),
+      ...rejected.flatMap(([name, spec]) => refusal(name, spec, declarer)),
       ...rejected.map(([name, spec]) => `error: ${name}@${spec} failed to resolve`),
     ];
     // The dependencies are reported in the declaring package's dependency order,
     // which differs between a registry manifest and a package.json.
-    expect(errorLines(err).sort()).toEqual(expected.sort());
+    expect(diagnostics(err).sort()).toEqual(expected.sort());
     expect(err).not.toContain("Saved lockfile");
     expect(out).not.toContain("installed");
     expect(await exists(join(root, "project", "node_modules"))).toBe(false);
@@ -10160,12 +10170,73 @@ describe.concurrent("file: tarballs declared by a package installed from the cac
       await cp(planted, join(root, "project", "inside.tgz"));
 
       const { err, exitCode } = await install(root);
-      expect(errorLines(err)).toEqual([refusal("inside", "file:./inside.tgz", "bar@0.0.2")]);
+      expect(diagnostics(err)).toEqual(refusal("inside", "file:./inside.tgz", "bar@0.0.2"));
       expect(await exists(join(root, "project", "node_modules", "inside"))).toBe(false);
       expect(await exists(join(root, "project", "bun.lock"))).toBe(false);
       expect(exitCode).toBe(1);
     });
   });
+
+  // The remedy the note describes: a tarball the root package.json itself depends
+  // on, under the same name, is the project's own, so a registry package asking
+  // for that exact dependency gets it too.
+  it("installs the one the root package.json declares as well", async () => {
+    await withContext(defaultOpts, async ctx => {
+      using dir = tempDir("root-declared-local-tarball-of-registry-dep", {});
+      const root = String(dir);
+      await writeRegistryProject(
+        ctx,
+        root,
+        { dependencies: { inside: "file:./inside.tgz" } },
+        { dependencies: { inside: "file:./inside.tgz" } },
+      );
+      await cp(planted, join(root, "project", "inside.tgz"));
+
+      const { err, out, exitCode } = await install(root);
+      expect(diagnostics(err)).toEqual([]);
+      expect(out).toContain("2 packages installed");
+      expect(await readdirSorted(join(root, "project", "node_modules"))).toEqual([".bin", "bar", "inside"]);
+      expect(await file(join(root, "project", "node_modules", "inside", "package.json")).json()).toEqual(
+        plantedManifest,
+      );
+      const lockfile = await file(join(root, "project", "bun.lock")).text();
+      expect(lockfile).toContain('"inside": ["baz@./inside.tgz"');
+      expect(lockfile).not.toContain('"bar/inside"');
+      expect(exitCode).toBe(0);
+    });
+  });
+
+  // Only the identical dependency counts: neither the name nor the path alone.
+  for (const [what, rootDependencies] of [
+    ["another tarball under the same name", { inside: "file:./vendored.tgz" }],
+    ["the same tarball under another name", { vendored: "file:./inside.tgz" }],
+  ] as const) {
+    it(`still rejects it when the root package.json declares ${what}`, async () => {
+      await withContext(defaultOpts, async ctx => {
+        using dir = tempDir("similar-root-local-tarball-of-registry-dep", {});
+        const root = String(dir);
+        await writeRegistryProject(
+          ctx,
+          root,
+          { dependencies: { inside: "file:./inside.tgz" } },
+          { dependencies: rootDependencies },
+        );
+        await Promise.all([
+          cp(planted, join(root, "project", "inside.tgz")),
+          cp(planted, join(root, "project", "vendored.tgz")),
+        ]);
+
+        const { err, exitCode } = await install(root);
+        expect(diagnostics(err)).toEqual([
+          ...refusal("inside", "file:./inside.tgz", "bar@0.0.2"),
+          "error: inside@file:./inside.tgz failed to resolve",
+        ]);
+        expect(await exists(join(root, "project", "node_modules"))).toBe(false);
+        expect(await exists(join(root, "project", "bun.lock"))).toBe(false);
+        expect(exitCode).toBe(1);
+      });
+    });
+  }
 
   it("leaves the one a registry package declares as optional uninstalled", async () => {
     await withContext(defaultOpts, async ctx => {

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -10009,6 +10009,214 @@ it("does not install transitive file: dependencies with overlong folder targets"
   expect(exitCode).toBe(1);
 });
 
+// The tarball form of the above. A `file:` tarball path is read relative to the
+// project (or to the workspace declaring it), which is only meaningful for the
+// package.json files that are part of the project. The same path declared by a
+// package bun extracts from the cache (registry, git, tarball) used to be read
+// from the project too, so a published package declaring `"x": "file:./x.tgz"`
+// got whatever `x.tgz` the project directory held, and with `file:../x.tgz` or
+// an absolute path any tarball on the machine, installed under its name.
+describe.concurrent("file: tarballs declared by a package installed from the cache", () => {
+  // Copied to every path the declaring package names; installing it is the bug.
+  const planted = join(import.meta.dir, "baz-0.0.3.tgz");
+  const plantedManifest = { name: "baz", version: "0.0.3", bin: { "baz-run": "index.js" } };
+
+  // The project is <root>/project so that `../outside.tgz` stays inside the temp dir.
+  function declaredTarballs(root: string): Record<string, string> {
+    return {
+      inside: "file:./inside.tgz",
+      outside: "file:../outside.tgz",
+      absolute: `file:${join(root, "absolute.tgz").replaceAll("\\", "/")}`,
+    };
+  }
+
+  function plantDeclaredTarballs(root: string) {
+    return Promise.all([
+      cp(planted, join(root, "project", "inside.tgz")),
+      cp(planted, join(root, "outside.tgz")),
+      cp(planted, join(root, "absolute.tgz")),
+    ]);
+  }
+
+  function rootPackageJson(dependencies: Record<string, string>, extra: object = {}) {
+    return JSON.stringify({ name: "my-app", version: "1.0.0", dependencies, ...extra });
+  }
+
+  // <root>/project depends on `bar@0.0.2` from the dummy registry, whose manifest
+  // for it carries `barManifest`. Returns the URLs the registry gets asked for.
+  async function writeRegistryProject(ctx: TestContext, root: string, barManifest: object, rootExtra: object = {}) {
+    const urls: string[] = [];
+    setContextHandler(ctx, dummyRegistryForContext(ctx, urls, { "0.0.2": barManifest }));
+    await write(join(root, "project", "package.json"), rootPackageJson({ bar: "0.0.2" }, rootExtra));
+    await write(join(root, "project", "bunfig.toml"), `[install]\nregistry = "${ctx.registry_url}"\n`);
+    return urls;
+  }
+
+  // Packs `manifest` as the package.json of an otherwise empty package into `tarball`.
+  async function packManifest(tarball: string, manifest: object) {
+    using work = tempDir("pack-manifest", { "package/package.json": JSON.stringify(manifest) });
+    await using tar = spawn({
+      cmd: ["tar", "-czf", tarball, "-C", String(work), "package"],
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+    const [tarStderr, tarExitCode] = await Promise.all([tar.stderr.text(), tar.exited]);
+    if (tarExitCode !== 0) {
+      throw new Error(`tar exited with ${tarExitCode}: ${tarStderr}`);
+    }
+  }
+
+  async function install(root: string) {
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: join(root, "project"),
+      env: { ...env, BUN_INSTALL_CACHE_DIR: join(root, "cache") },
+      stdout: "pipe",
+      stdin: "ignore",
+      stderr: "pipe",
+    });
+    const [err, out, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+    return { err, out, exitCode };
+  }
+
+  // `declarer` is how bun prints the package declaring the tarballs.
+  async function expectRejected(root: string, declarer: string) {
+    const { err, out, exitCode } = await install(root);
+
+    const rejected = Object.entries(declaredTarballs(root));
+    const expected = [
+      ...rejected.map(
+        ([name, spec]) =>
+          `error: refusing to resolve "${name}@${spec}" declared by ${declarer}: local tarball dependencies are only allowed in the package.json files of this project`,
+      ),
+      ...rejected.map(([name, spec]) => `error: ${name}@${spec} failed to resolve`),
+    ];
+    // The rest of stderr is progress output ("Resolving dependencies", ...). The
+    // dependencies are reported in the declaring package's dependency order,
+    // which differs between a registry manifest and a package.json.
+    const errors = err.split(/\r?\n/).filter(line => line.startsWith("error:"));
+    expect(errors.sort()).toEqual(expected.sort());
+    expect(err).not.toContain("Saved lockfile");
+    expect(out).not.toContain("installed");
+    expect(await exists(join(root, "project", "node_modules"))).toBe(false);
+    expect(await exists(join(root, "project", "bun.lock"))).toBe(false);
+    expect(exitCode).toBe(1);
+  }
+
+  it("rejects the ones declared by a tarball dependency", async () => {
+    using dir = tempDir("local-tarballs-of-tarball-dep", {
+      "project/package.json": rootPackageJson({ bar: "file:./bar.tgz" }),
+    });
+    const root = String(dir);
+    await plantDeclaredTarballs(root);
+    await packManifest(join(root, "project", "bar.tgz"), {
+      name: "bar",
+      version: "0.0.2",
+      dependencies: declaredTarballs(root),
+    });
+
+    await expectRejected(root, "bar@./bar.tgz");
+  });
+
+  it("rejects the ones declared by a git dependency", async () => {
+    using dir = tempDir("local-tarballs-of-git-dep", {});
+    const root = String(dir);
+    await write(
+      join(root, "work", "package.json"),
+      JSON.stringify({ name: "bar", version: "0.0.2", dependencies: declaredTarballs(root) }),
+    );
+    const sha = await createDumbHttpGitRepo(root, {});
+    using server = serveDirectory(root);
+    const repo = `git+http://localhost:${server.port}/repo.git`;
+    await write(join(root, "project", "package.json"), rootPackageJson({ bar: repo }));
+    await plantDeclaredTarballs(root);
+
+    await expectRejected(root, `bar@${repo}#${sha}`);
+  });
+
+  it("rejects the ones declared by a registry package", async () => {
+    await withContext(defaultOpts, async ctx => {
+      using dir = tempDir("local-tarballs-of-registry-dep", {});
+      const root = String(dir);
+      await writeRegistryProject(ctx, root, { dependencies: declaredTarballs(root) });
+      await plantDeclaredTarballs(root);
+
+      await expectRejected(root, "bar@0.0.2");
+    });
+  });
+
+  it("leaves the one a registry package declares as optional uninstalled", async () => {
+    await withContext(defaultOpts, async ctx => {
+      using dir = tempDir("optional-local-tarball-of-registry-dep", {});
+      const root = String(dir);
+      await writeRegistryProject(ctx, root, { optionalDependencies: { inside: "file:./inside.tgz" } });
+      await cp(planted, join(root, "project", "inside.tgz"));
+
+      const { err, out, exitCode } = await install(root);
+      expect(err).not.toContain("error:");
+      expect(out).toContain("1 package installed");
+      expect(await readdirSorted(join(root, "project", "node_modules"))).toEqual(["bar"]);
+      const lockfile = await file(join(root, "project", "bun.lock")).text();
+      expect(lockfile).toContain('"bar": ["bar@0.0.2"');
+      expect(lockfile).not.toContain("baz@./inside.tgz");
+      expect(exitCode).toBe(0);
+    });
+  });
+
+  // `overrides` / `resolutions` are written in the root package.json, so a tarball
+  // path coming from there is the project's own even when it replaces the
+  // dependency of a registry package.
+  for (const field of ["resolutions", "overrides"]) {
+    it(`installs the one a root "${field}" entry puts on a registry package's dependency`, async () => {
+      await withContext(defaultOpts, async ctx => {
+        using dir = tempDir(`${field}-local-tarball-on-registry-dep`, {});
+        const root = String(dir);
+        const urls = await writeRegistryProject(
+          ctx,
+          root,
+          { dependencies: { vendored: "0.0.1" } },
+          { [field]: { vendored: "file:./vendored.tgz" } },
+        );
+        await cp(planted, join(root, "project", "vendored.tgz"));
+
+        const { err, out, exitCode } = await install(root);
+        expect(err).not.toContain("error:");
+        expect(out).toContain("2 packages installed");
+        expect(await file(join(root, "project", "node_modules", "vendored", "package.json")).json()).toEqual(
+          plantedManifest,
+        );
+        expect(urls.sort()).toEqual([`${ctx.registry_url}bar`, `${ctx.registry_url}bar-0.0.2.tgz`]);
+        expect(exitCode).toBe(0);
+      });
+    });
+  }
+
+  // A `file:` folder's package.json is part of the project like a workspace's, so
+  // it may declare local tarballs. The tarball is planted in both directories the
+  // path could be taken relative to; which one bun reads is not what this pins.
+  it("installs the one declared by a file: folder dependency", async () => {
+    using dir = tempDir("local-tarball-of-folder-dep", {
+      "project/package.json": rootPackageJson({ lib: "file:./vendor/lib" }),
+      "project/vendor/lib/package.json": JSON.stringify({
+        name: "lib",
+        version: "1.0.0",
+        dependencies: { tool: "file:./tool.tgz" },
+      }),
+    });
+    const root = String(dir);
+    await Promise.all([
+      cp(planted, join(root, "project", "tool.tgz")),
+      cp(planted, join(root, "project", "vendor", "lib", "tool.tgz")),
+    ]);
+
+    const { err, out, exitCode } = await install(root);
+    expect(err).not.toContain("error:");
+    expect(out).toContain("2 packages installed");
+    expect(await file(join(root, "project", "node_modules", "tool", "package.json")).json()).toEqual(plantedManifest);
+    expect(exitCode).toBe(0);
+  });
+});
+
 for (const field of ["resolutions", "overrides"]) {
   it(`installs a file: dependency pointing outside the project when it came from root package.json "${field}"`, async () => {
     // `overrides` / `resolutions` can only be declared in the root package.json,

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -10079,23 +10079,27 @@ describe.concurrent("file: tarballs declared by a package installed from the cac
     return { err, out, exitCode };
   }
 
-  // `declarer` is how bun prints the package declaring the tarballs.
+  // `declarer` is how bun prints the package declaring the tarball.
+  function refusal(name: string, spec: string, declarer: string) {
+    return `error: refusing to resolve "${name}@${spec}" declared by ${declarer}: local tarball dependencies are only allowed in the package.json files of this project`;
+  }
+
+  // The rest of stderr is progress output ("Resolving dependencies", ...).
+  function errorLines(stderr: string) {
+    return stderr.split(/\r?\n/).filter(line => line.startsWith("error:"));
+  }
+
   async function expectRejected(root: string, declarer: string) {
     const { err, out, exitCode } = await install(root);
 
     const rejected = Object.entries(declaredTarballs(root));
     const expected = [
-      ...rejected.map(
-        ([name, spec]) =>
-          `error: refusing to resolve "${name}@${spec}" declared by ${declarer}: local tarball dependencies are only allowed in the package.json files of this project`,
-      ),
+      ...rejected.map(([name, spec]) => refusal(name, spec, declarer)),
       ...rejected.map(([name, spec]) => `error: ${name}@${spec} failed to resolve`),
     ];
-    // The rest of stderr is progress output ("Resolving dependencies", ...). The
-    // dependencies are reported in the declaring package's dependency order,
+    // The dependencies are reported in the declaring package's dependency order,
     // which differs between a registry manifest and a package.json.
-    const errors = err.split(/\r?\n/).filter(line => line.startsWith("error:"));
-    expect(errors.sort()).toEqual(expected.sort());
+    expect(errorLines(err).sort()).toEqual(expected.sort());
     expect(err).not.toContain("Saved lockfile");
     expect(out).not.toContain("installed");
     expect(await exists(join(root, "project", "node_modules"))).toBe(false);
@@ -10142,6 +10146,24 @@ describe.concurrent("file: tarballs declared by a package installed from the cac
       await plantDeclaredTarballs(root);
 
       await expectRejected(root, "bar@0.0.2");
+    });
+  });
+
+  // Peers are installed too, so the same refusal applies; unlike a regular
+  // dependency, an unresolved peer is not reported a second time as
+  // "failed to resolve".
+  it("rejects the one a registry package declares as a peer dependency", async () => {
+    await withContext(defaultOpts, async ctx => {
+      using dir = tempDir("peer-local-tarball-of-registry-dep", {});
+      const root = String(dir);
+      await writeRegistryProject(ctx, root, { peerDependencies: { inside: "file:./inside.tgz" } });
+      await cp(planted, join(root, "project", "inside.tgz"));
+
+      const { err, exitCode } = await install(root);
+      expect(errorLines(err)).toEqual([refusal("inside", "file:./inside.tgz", "bar@0.0.2")]);
+      expect(await exists(join(root, "project", "node_modules", "inside"))).toBe(false);
+      expect(await exists(join(root, "project", "bun.lock"))).toBe(false);
+      expect(exitCode).toBe(1);
     });
   });
 


### PR DESCRIPTION
### Problem

- A package that `bun install` extracts from the cache (a registry, git or tarball dependency) can declare a local tarball dependency: `"other": "file:./other.tgz"`, `"x": "file:../x.tgz"`, or an absolute path. bun read that path relative to the project directory, exactly like a `file:` tarball written in the project's own package.json, without looking at who declared it (released 1.4.0 canary and main, both linkers, `dependencies`, `peerDependencies` and `optionalDependencies` alike).
- So a published package gets whatever `other.tgz` the project directory happens to contain installed and linked as `other`, and with `../` or an absolute path any `.tgz` on the installing machine; `bun.lock` records it as `"other": ["evil-other@./other.tgz", ...]`. Found by inspection, not from a report. The impact is bounded: the tarball bytes are the victim's own and lifecycle scripts of such a package stay untrusted, so what the package gains is having a tarball of the victim's choosing installed under a name of the package's choosing. The directory form of the same declaration is already refused when it leaves the declaring package (Folder arm of `get_or_put_resolved_package`, `bin_target_escapes_package_dir`).
- The only setups this behaviour makes work are the ones where the project keeps a tarball at the path the package names (otherwise the install fails with `error: ENOENT extracting tarball from other`). No other package manager installs that shape (npm and pnpm resolve the path relative to the declaring package, which is not on disk yet), so this PR stops honouring it and gives such a project an explicit way to say what it wants (below).
- Cause: `enqueue_local_tarball` (`src/install/PackageManager/PackageManagerEnqueue.rs`) chooses the base directory: the workspace directory when a workspace declared the edge, otherwise the project. Nothing before it looks at the declaring package, so the Tarball arm of `enqueue_dependency_with_main_and_success_fn` enqueues the read for every declarer.

### Fix

- The Tarball arm now fails a local tarball edge unless the project stands behind it, which is any of: the declaring package is itself read from the project (`resolution::Tag::is_local_package`: root, workspace, `file:` folder); the specifier was substituted from the root package.json (`version_was_replaced`: overrides, resolutions, catalogs); the root package.json declares the same dependency itself (`Lockfile::has_equal_root_dependency`: same name and tarball path, via the existing `Dependency::eql`); or the edge belongs to no package at all (the edges `enqueue_dependency_to_root` appends for auto-install, which the parent lookup does not find).
- The check runs before the edge is matched against the task queue or existing packages, so a refused edge cannot attach itself to anything. A root-declared equal edge is honoured by letting the edge through to exactly that matching: the root's edge is enqueued first, so the cached package's edge binds to the root's extraction (and if the root edge is not enqueued at all, say a devDependency under `--production`, it is read from the same directory the root's would be). That is the same thing the package would get by depending on the root's `other` with a range and being hoisted, so it adds no capability; it is the opt-in for a project that really wants to supply such a tarball, and the error names it:
  ```
  error: refusing to resolve "other@file:./other.tgz" declared by tb@./tb.tgz: local tarball dependencies are only allowed in the package.json files of this project

  note: add "other": "file:./other.tgz" to the root package.json to install that tarball for tb as well
  error: other@file:./other.tgz failed to resolve
  ```
  exit 1, nothing written. Optional edges are skipped silently like optional folder edges (before, they failed the install with the ENOENT error); peer edges take the error path like regular ones, as they already failed today and as the directory form's `MissingPackageJSON` branch does.
- Why refuse outright rather than apply the directory form's containment rule: a contained directory path still means something after the fix, because the installer resolves it inside the installed declaring package. A tarball is read while resolving, from the project, so there is no path a cached package could name that would mean what it wrote; reading it out of the declaring package would need the package on disk at resolve time, which a registry package is not. Since no row is ever written for a refused edge, `bun.lock` can only contain local tarball rows the project produced, and the install-from-lockfile path (`enqueue_tarball_for_reading`, same `enqueue_local_tarball`) is left alone; a lockfile written by an older bun keeps installing its rows.
- `overrides` / `resolutions` are exempt and tested, but today they only reach an edge whose declared specifier is a range: bun looks overrides up by `realname()`, which is empty for edges declared with a tarball or git specifier. That is a separate bug with its own session; once it lands, the exemption here covers those edges too, which is why the root-declared remedy above does not depend on it.
- `is_local_package` replaces the two hand-written `Root | Workspace | Folder` matches that already encode this split (`Tree.rs`, `verify_resolutions`). `get_parent_pkg_of_dependency` is the scan `get_workspace_pkg_if_workspace_dep` already does without its tag filter; both run only for local tarball edges. #33106 adds helpers with these same names for the directory form; whichever lands second drops its copy.
- Same class, not in this PR: `link:../dir` declared by a cached package is resolved against the project by the Symlink arm of the same function (a separate session owns it; it can reuse `get_parent_pkg_of_dependency` / `is_local_package`), and a local `file:` folder package's own `file:` tarballs are read relative to the project instead of the folder (also handed off; unchanged here, and the folder test below plants the tarball in both places so it does not pin either base).
- Verified with `test/cli/install/bun-install.test.ts`, block "file: tarballs declared by a package installed from the cache" (11 tests): a tarball, a git and a registry declarer, each declaring a project-relative, a `../` and an absolute tarball that all exist (exact error and note lines, no `node_modules`, no `bun.lock`, exit 1); the same as a peer dependency (refused) and as an optional one (skipped, `bar` installed); the root declaring the identical dependency (installed once, bound to both); the root declaring another tarball under that name, or that tarball under another name (still refused); root `overrides` / `resolutions` pointing a registry package's range dependency at a project tarball (installed); a `file:` folder package declaring one (installed). Seven fail on the released build; the four that pass before and after pin the exemptions, and removing any one clause of the check fails at least one of them.
- Also run on this branch rebased onto main: `bun-install.test.ts -t "tarball|file:|folder"` (49 pass; the one failure downloads from an external host and fails the same way on the released build), `bun-workspaces -t tarball` (workspace-relative tarballs), `overrides`, `bun-add -t tarball`; earlier revisions also ran `nested-overrides`, `isolated-install -t file`, `bun-lock` and `catalogs` with no failures beyond load-related timeouts that pass alone. `cargo clippy -p bun_install` is clean.

### Background

- A `file:` dependency on a directory is a `Tag::Folder` dependency. One on a `.tgz` is a `Tag::Tarball` dependency with a local URI; it resolves to `Resolution::LocalTarball(<path as written>)`, is extracted into the cache like a downloaded tarball, and the path string is the package's identity in `bun.lock` (`other@./other.tgz`) and the key the resolver dedupes concurrent reads of the same path on.
- bun reads the package.json of the root, of workspace members and of `file:` folder dependencies from disk (`Package::parse`); these are the packages `is_local_package` names. Every other package comes from the cache: registry packages get their dependency list from the manifest (`Package::from_npm`), git and tarball packages from the package.json extracted into the cache. All of them store local tarball paths exactly as declared.
- Dependency edges live in one flat buffer and each package owns a contiguous slice of it, which is how the declaring package of an edge is found; package 0 is always the root. `Dependency::eql` compares two edges by name and specifier (for tarballs, the path).
- `version_was_replaced` is set in `enqueue_dependency_with_main_and_success_fn` when an edge's specifier was swapped for one from the root package.json (overrides, resolutions, catalogs) before resolution.
