### PR TITLE
worker_threads: don't build the process object's lazy properties during worker startup

### DIFF
--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -461,10 +461,8 @@ function setupWorkerStdio(stdio) {
   const stdoutStream = makePortWritable(stdout);
   const stderrStream = makePortWritable(stderr);
   const proc: any = process;
-  // Plain assignment, not Object.defineProperty: process.stdout/stderr/stdin are
-  // lazy native properties. Assigning replaces one unbuilt; defineProperty first
-  // builds the fd-backed stream it is about to discard (loading tty/net/fs to do
-  // so). Either way the result is a writable, enumerable, configurable own property.
+  // Assignment replaces the lazy native stdio properties without building them;
+  // Object.defineProperty would construct the fd-backed streams first.
   proc.stdout = stdoutStream;
   proc.stderr = stderrStream;
   // node always replaces a worker's process.stdin: port-backed when { stdin: true },
@@ -854,10 +852,8 @@ function fakeParentPort() {
 if (!isMainThread && _isNodeWorker) {
   applyWorkerProcessOverrides();
 }
-// Only ever assigns or defines individual properties: `delete process.x` makes JSC
-// reify every lazy property of the process object (stdio streams, env, versions,
-// ...). The main-only internals node deletes in workers (process._debugProcess & co.)
-// are therefore never defined on a worker's process to begin with (BunProcess.cpp).
+// Never `delete` from process here: that builds every lazy process property. The
+// main-only internals node deletes in workers are not defined on worker VMs (BunProcess.cpp).
 function applyWorkerProcessOverrides() {
   const proc: any = process;
   // node defaults debugPort to 9229 in workers (still settable). Per-object property:

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -460,33 +460,23 @@ function setupWorkerStdio(stdio) {
   const { stdin, stdout, stderr } = stdio;
   const stdoutStream = makePortWritable(stdout);
   const stderrStream = makePortWritable(stderr);
-  Object.defineProperty(process, "stdout", {
-    value: stdoutStream,
-    writable: true,
-    configurable: true,
-    enumerable: true,
-  });
-  Object.defineProperty(process, "stderr", {
-    value: stderrStream,
-    writable: true,
-    configurable: true,
-    enumerable: true,
-  });
+  const proc: any = process;
+  // Plain assignment, not Object.defineProperty: process.stdout/stderr/stdin are
+  // lazy native properties. Assigning replaces one unbuilt; defineProperty first
+  // builds the fd-backed stream it is about to discard (loading tty/net/fs to do
+  // so). Either way the result is a writable, enumerable, configurable own property.
+  proc.stdout = stdoutStream;
+  proc.stderr = stderrStream;
   // node always replaces a worker's process.stdin: port-backed when { stdin: true },
   // otherwise an immediately-EOF'd stream — never the process-wide fd 0, which
   // would race the main thread (and hang on a TTY).
-  Object.defineProperty(process, "stdin", {
-    value: stdin
-      ? makePortReadable(stdin, true)
-      : new Readable({
-          read() {
-            this.push(null);
-          },
-        }),
-    writable: true,
-    configurable: true,
-    enumerable: true,
-  });
+  proc.stdin = stdin
+    ? makePortReadable(stdin, true)
+    : new Readable({
+        read() {
+          this.push(null);
+        },
+      });
   // node routes console.log through process.stdout/stderr; Bun's global console
   // writes the fd directly, so rebind it to the port-backed streams.
   const { Console } = require("node:console");
@@ -864,6 +854,10 @@ function fakeParentPort() {
 if (!isMainThread && _isNodeWorker) {
   applyWorkerProcessOverrides();
 }
+// Only ever assigns or defines individual properties: `delete process.x` makes JSC
+// reify every lazy property of the process object (stdio streams, env, versions,
+// ...). The main-only internals node deletes in workers (process._debugProcess & co.)
+// are therefore never defined on a worker's process to begin with (BunProcess.cpp).
 function applyWorkerProcessOverrides() {
   const proc: any = process;
   // node defaults debugPort to 9229 in workers (still settable). Per-object property:
@@ -871,12 +865,6 @@ function applyWorkerProcessOverrides() {
   try {
     Object.defineProperty(proc, "debugPort", { value: 9229, writable: true, configurable: true, enumerable: true });
   } catch {}
-  // These main-only internals are absent on a worker's process.
-  for (const k of ["_startProfilerIdleNotifier", "_stopProfilerIdleNotifier", "_debugProcess", "_debugEnd"]) {
-    try {
-      delete proc[k];
-    } catch {}
-  }
   // process.umask(setMask) is unsupported in workers; the getter still works.
   const realUmask = proc.umask;
   function umask(mask?: unknown) {

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -461,8 +461,7 @@ function setupWorkerStdio(stdio) {
   const stdoutStream = makePortWritable(stdout);
   const stderrStream = makePortWritable(stderr);
   const proc: any = process;
-  // Assignment replaces the lazy native stdio properties without building them;
-  // Object.defineProperty would construct the fd-backed streams first.
+  // Assignment, unlike Object.defineProperty, does not build the lazy fd-backed streams first.
   proc.stdout = stdoutStream;
   proc.stderr = stderrStream;
   // node always replaces a worker's process.stdin: port-backed when { stdin: true },
@@ -852,8 +851,7 @@ function fakeParentPort() {
 if (!isMainThread && _isNodeWorker) {
   applyWorkerProcessOverrides();
 }
-// Never `delete` from process here: that builds every lazy process property. The
-// main-only internals node deletes in workers are not defined on worker VMs (BunProcess.cpp).
+// Never `delete` from process here (it builds every lazy property); worker VMs lack the main-only internals.
 function applyWorkerProcessOverrides() {
   const proc: any = process;
   // node defaults debugPort to 9229 in workers (still settable). Per-object property:

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1801,8 +1801,7 @@ static JSValue constructLoadEnvFile(VM& vm, JSObject* processObject)
 }
 
 // Lazy PropertyCallback builders that enter JS. reifyAllStaticProperties wraps these in
-// DeferTerminationForAWhile; a non-termination throw is cleared+reported so the worker's
-// reifyAllStaticProperties (node:worker_threads preload) doesn't leave a pending exception.
+// DeferTerminationForAWhile; a non-termination throw is cleared+reported so a reify-all (`delete process.x`, `Object.entries(process)`) doesn't leave a pending exception.
 static JSValue callLazyProcessBuilder(VM& vm, JSC::JSGlobalObject* globalObject, JSC::FunctionExecutable* (*generator)(VM&), const JSC::ArgList& args)
 {
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -4967,11 +4967,8 @@ void Process::finishCreation(JSC::VM& vm)
     putDirect(vm, vm.propertyNames->toStringTagSymbol, jsString(vm, String("process"_s)), 0);
     putDirect(vm, Identifier::fromString(vm, "_exiting"_s), jsBoolean(false), 0);
 
-    // Node's worker threads have no process._debugProcess & co. These are own
-    // properties rather than processObjectTable entries because deleting a
-    // static-table property makes JSC reify every lazy property in the table
-    // (the stdio streams, env, versions, config, ...): exactly the work a
-    // worker's startup is supposed to skip.
+    // Main-thread-only in node. Own properties, not processObjectTable entries:
+    // deleting a table entry in workers would reify every lazy property of process.
     if (!WebCore::clientData(vm)->isWorkerVM()) {
         auto* globalObject = this->globalObject();
         for (auto name : { "_debugProcess"_s, "_debugEnd"_s, "_startProfilerIdleNotifier"_s, "_stopProfilerIdleNotifier"_s })

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -4840,8 +4840,6 @@ extern "C" void Process__emitErrorEvent(Zig::GlobalObject* global, EncodedJSValu
 
 /* Source for Process.lut.h
 @begin processObjectTable
-  _debugEnd                        Process_stubEmptyFunction                           Function 0
-  _debugProcess                    Process_stubEmptyFunction                           Function 0
   _eval                            processGetEval                                      CustomAccessor
   _getActiveHandles                Process_stubFunctionReturningArray                  Function 0
   _getActiveRequests               Process_stubFunctionReturningArray                  Function 0
@@ -4849,8 +4847,6 @@ extern "C" void Process__emitErrorEvent(Zig::GlobalObject* global, EncodedJSValu
   _linkedBinding                   Process_stubEmptyFunction                           Function 0
   _preload_modules                 Process_stubEmptyArray                              PropertyCallback
   _rawDebug                        constructRawDebug                                   PropertyCallback
-  _startProfilerIdleNotifier       Process_stubEmptyFunction                           Function 0
-  _stopProfilerIdleNotifier        Process_stubEmptyFunction                           Function 0
   _tickCallback                    Process_stubEmptyFunction                           Function 0
   abort                            Process_functionAbort                               Function 1
   allowedNodeEnvironmentFlags      constructAllowedNodeEnvironmentFlags                PropertyCallback
@@ -4970,6 +4966,18 @@ void Process::finishCreation(JSC::VM& vm)
 
     putDirect(vm, vm.propertyNames->toStringTagSymbol, jsString(vm, String("process"_s)), 0);
     putDirect(vm, Identifier::fromString(vm, "_exiting"_s), jsBoolean(false), 0);
+
+    // Node's worker threads have no process._debugProcess & co. These are own
+    // properties rather than processObjectTable entries because deleting a
+    // static-table property makes JSC reify every lazy property in the table
+    // (the stdio streams, env, versions, config, ...): exactly the work a
+    // worker's startup is supposed to skip.
+    if (!WebCore::clientData(vm)->isWorkerVM()) {
+        auto* globalObject = this->globalObject();
+        for (auto name : { "_debugProcess"_s, "_debugEnd"_s, "_startProfilerIdleNotifier"_s, "_stopProfilerIdleNotifier"_s })
+            putDirectNativeFunction(vm, globalObject, Identifier::fromString(vm, name), 0, Process_stubEmptyFunction, ImplementationVisibility::Public, NoIntrinsic, 0);
+    }
+
     // Node's addReadOnlyProcessAlias: read-only so `process.noDeprecation = false`
     // is ignored, but a per-Process property — a Worker must not flip the main
     // thread. Unflagged it stays an ordinary undefined slot user code can set.

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -4967,8 +4967,7 @@ void Process::finishCreation(JSC::VM& vm)
     putDirect(vm, vm.propertyNames->toStringTagSymbol, jsString(vm, String("process"_s)), 0);
     putDirect(vm, Identifier::fromString(vm, "_exiting"_s), jsBoolean(false), 0);
 
-    // Main-thread-only in node. Own properties, not processObjectTable entries:
-    // deleting a table entry in workers would reify every lazy property of process.
+    // Main-thread-only in node; not table entries because deleting one in a worker would reify every lazy property.
     if (!WebCore::clientData(vm)->isWorkerVM()) {
         auto* globalObject = this->globalObject();
         for (auto name : { "_debugProcess"_s, "_debugEnd"_s, "_startProfilerIdleNotifier"_s, "_stopProfilerIdleNotifier"_s })

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1995,11 +1995,8 @@ test.skipIf(isWindows)(
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ fdsAliasingStdioCreatedByTheWorker: JSON.parse(stdout), stderr, exitCode }).toEqual({
-      fdsAliasingStdioCreatedByTheWorker: [],
-      stderr: "",
-      exitCode: 0,
-    });
+    // stdout is the JSON list of fds the worker created that alias fd 1 or 2.
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "[]", stderr: "", exitCode: 0 });
   },
 );
 

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -2003,6 +2003,23 @@ test.skipIf(isWindows)(
   },
 );
 
+// A user-visible consequence of the reify-all: process.mainModule is built from the require
+// map when it is first read. Built during the bootstrap, before the entry module exists, it
+// was permanently undefined in every worker; built on first read it is the entry module, as
+// in node (and as it was before the bootstrap reified it).
+test("process.mainModule in a worker is the worker's entry module, like node", async () => {
+  using dir = tempDir("worker-main-module", {
+    "entry.js": `require("worker_threads").parentPort.postMessage({
+      mainModuleIsEntry: process.mainModule === module,
+      requireMainIsEntry: require.main === module,
+    });`,
+  });
+  const worker = new Worker(join(String(dir), "entry.js"));
+  const [result] = await once(worker, "message");
+  await worker.terminate();
+  expect(result).toEqual({ mainModuleIsEntry: true, requireMainIsEntry: true });
+});
+
 // Founding a SHARE_ENV tree replaces the founding thread's process.env object. If the
 // replacement were orphaned, the founder's later writes would go nowhere. child_process
 // enumerates the JS process.env (a var deleted from the map is invisible to the child),

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, setDefaultTimeout, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isDebug, isWindows, tempDir, tmpdirSync } from "harness";
 import { once } from "node:events";
 import fs from "node:fs";
 import { join, relative, resolve } from "node:path";
@@ -1924,6 +1924,84 @@ test("process.debugPort defaults to 9229 on the main thread", async () => {
   expect(stdout.trim()).toBe("9229");
   expect(exitCode).toBe(0);
 });
+
+// The worker bootstrap rebinds process.stdout/stderr/stdin and removes/replaces a few
+// process methods. It must do so without building the process object's lazy native
+// properties: Object.defineProperty over one constructs the fd-backed stdio stream it is
+// about to replace, and `delete` makes JSC reify every lazy property (env, versions,
+// config, the stdio streams, ...). Constructing all of that was most of a worker's
+// startup. Same invariant test/js/bun/util/BunObject.test.ts holds for the Bun object.
+test("the worker bootstrap leaves the process object's lazy properties unbuilt", async () => {
+  const mainOnlyInternals = ["_debugProcess", "_debugEnd", "_startProfilerIdleNotifier", "_stopProfilerIdleNotifier"];
+  const worker = new Worker(
+    `const { hasNonReifiedStatic } = require("bun:internal-for-testing");
+     const lazy = hasNonReifiedStatic(process);
+     const shape = name => {
+       const { value, writable, enumerable, configurable } = Object.getOwnPropertyDescriptor(process, name);
+       return [value.constructor.name, writable, enumerable, configurable];
+     };
+     require("worker_threads").parentPort.postMessage({
+       lazy,
+       stdout: shape("stdout"),
+       stderr: shape("stderr"),
+       stdin: shape("stdin"),
+       presentInternals: ${JSON.stringify(mainOnlyInternals)}.filter(name => name in process),
+     });`,
+    { eval: true },
+  );
+  const [result] = await once(worker, "message");
+  await worker.terminate();
+  expect(result).toEqual({
+    lazy: true,
+    // The same own data properties the main thread ends up with once it touches them.
+    stdout: ["Writable", true, true, true],
+    stderr: ["Writable", true, true, true],
+    stdin: ["Readable", true, true, true],
+    presentInternals: [],
+  });
+  // ...while the main thread still has node's no-op stubs.
+  expect(mainOnlyInternals.map(name => typeof process[name])).toEqual(["function", "function", "function", "function"]);
+});
+
+// The previous test cannot see the stdio streams themselves being built, because building
+// a single lazy property does not count as reifying the table. Building the fd-backed
+// stdout/stderr streams of a piped stdio dups fd 1 and 2, so an fd aliasing either of them
+// that did not exist before the worker was created is the streams having been built and
+// thrown away. A child process is used so that stdio is piped whatever the test runner's is.
+test.skipIf(isWindows)(
+  "the worker bootstrap does not build (and dup the fds of) the stdio streams it replaces",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { Worker } = require("worker_threads");
+       // Self-contained: its source is also evaluated inside the worker.
+       const aliasesOfStdio = () => {
+         const fs = require("fs");
+         const id = fd => { try { const { dev, ino } = fs.fstatSync(fd); return dev + ":" + ino; } catch { return null; } };
+         const stdio = [id(1), id(2)], out = [];
+         for (let fd = 3; fd < 256; fd++) if (stdio.includes(id(fd))) out.push(fd);
+         return out;
+       };
+       const worker = new Worker(
+         "const wt = require('worker_threads'); wt.parentPort.postMessage((" + aliasesOfStdio + ")().filter(fd => !wt.workerData.includes(fd)));",
+         { eval: true, workerData: aliasesOfStdio() },
+       );
+       worker.on("message", created => { console.log(JSON.stringify(created)); worker.terminate(); });`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ fdsAliasingStdioCreatedByTheWorker: JSON.parse(stdout), stderr, exitCode }).toEqual({
+      fdsAliasingStdioCreatedByTheWorker: [],
+      stderr: "",
+      exitCode: 0,
+    });
+  },
+);
 
 // Founding a SHARE_ENV tree replaces the founding thread's process.env object. If the
 // replacement were orphaned, the founder's later writes would go nowhere. child_process


### PR DESCRIPTION
### Problem
- Every `node:worker_threads` Worker spends a large part of its startup building `process` properties that are thrown away immediately. Two lines of the worker-side bootstrap in `src/js/node/worker_threads.ts` were responsible:
  - `setupWorkerStdio` replaced `process.stdout` / `stderr` / `stdin` with `Object.defineProperty`. `[[DefineOwnProperty]]` reads the current property first, and these are lazy native properties, so the fd-backed streams were built just to be replaced: this loads `node:tty`, `node:net`, `node:fs` and the stream internals into the worker, dups fd 1 and fd 2 when stdio is piped (the dups stay open until the orphaned streams are collected), and on a tty leaves two `SIGWINCH` listeners on the worker's `process`.
  - `applyWorkerProcessOverrides` ran `delete process._debugProcess` (plus three more). Deleting a static-table property makes JSC reify the whole table (`JSObject::deleteProperty` -> `reifyAllStaticProperties`): every remaining lazy `process` property (`env`, `versions`, `config`, `release`, `report`, `allowedNodeEnvironmentFlags`, ...) is built, and `process` is switched to dictionary mode for the rest of the worker's life.
  - Building everything at that point also has a visible result: `process.mainModule` is built from the require map, and during the bootstrap the entry module is not in it yet, so it has been `undefined` in every worker since #31216 (node, and Bun 1.3: the worker's entry module).
- Cost, for a worker whose entry just posts one message (median of 21, local release build): 31-36 ms per worker. Debug build: ~2.2 s wall / 2.55 s CPU per worker, of which the stdio construction alone is ~1 s (measured by instrumenting the built `worker_threads.js`). This is where most of the time of the worker-spawning tests on the debug/ASAN lanes goes.

### Fix
- `setupWorkerStdio` assigns the streams. `JSObject::put` on an unreified lazy entry stores the new value directly without building the old one; the own property it produces is `{ writable, enumerable, configurable }`, the same shape `defineProperty` produced (asserted by the test).
- `_debugProcess`, `_debugEnd`, `_startProfilerIdleNotifier`, `_stopProfilerIdleNotifier` leave `processObjectTable`; `Process::finishCreation` defines them as own properties unless `clientData(vm)->isWorkerVM()`, with the same function, name, length and attributes the table gave them. A worker's `process` never has them, so the bootstrap has nothing to delete. (Web `Worker`s lose the four no-op stubs too; node only has them on the main thread.)
- Why this is the right fix: the observable results are node's (a worker's `process` has no `_debugProcess` & co., its stdio properties are the port-backed streams, `process.mainModule` is the entry module), the only work removed is the construction of objects nothing could reach afterwards, and `process` stays a lazy, non-dictionary object in workers like it is on the main thread.
- Effect: release 31-36 ms -> 20-25 ms wall per worker (41-43 -> 27-33 ms CPU; 3 interleaved rounds of 21 workers, before/after binaries). Debug build: 2.1-2.3 s -> 1.5-1.6 s per worker; `test/js/node/worker_threads/worker_threads.test.ts` (133 tests) went from 439 s to 306 s on the same machine.
- Tests, in `test/js/node/worker_threads/worker_threads.test.ts`, each failing on main as noted:
  - inside a worker, `hasNonReifiedStatic(process)` (the invariant `test/js/bun/util/BunObject.test.ts` keeps for `Bun`) is true, the stdio descriptors have the previous shape, the four internals are absent, and they are still functions on the main thread (main: `lazy: false`);
  - POSIX: a worker started in a child process with piped stdio creates no fd aliasing fd 1 or 2 (main: `[9, 10]`). This is the part the first test cannot see, since building a single property does not reify the table;
  - `process.mainModule` in a file worker is the entry module (main: `undefined`).
- Also run: the whole `worker_threads.test.ts` and `process/process.test.js` on the debug and release builds, `test/js/web/workers` (release: all pass; debug: the same load-dependent timeouts as an unmodified build), the vendored `test-worker-*.js` node tests (110 files) on the debug build, `test-worker-unsupported-things.js` (the four internals are absent in a worker), and a worker writing to stdout/stderr under a pty.

### Related PRs
- #37128 rewrites `setupWorkerStdio` and already switches it to assignment for the same reason; whichever of the two lands second gets a trivial conflict in that function. The `delete` removal and the table change here are independent of it.
- #34345 (robobun, currently unmergeable) switches the stdio part to assignment as well but keeps the `delete`, so `process` still ends up fully reified there; it additionally defers stream/Console construction behind accessors, which this PR does not do.
- #37336 gives `_debugProcess` a real implementation; on top of this change that function would be installed from the same place in `finishCreation` (node has no `_debugProcess` in workers either).

### Background
- `process` is a JSC object whose properties come from a generated static hash table (`processObjectTable` in `BunProcess.cpp`). A `PropertyCallback` entry is built the first time it is read ("reified") and then stored as an ordinary own property, so an untouched property costs nothing. A few operations cannot be answered from the table, and JSC handles them by reifying every entry and converting the object to dictionary mode: `delete` of a table entry is one of them (`Object.entries` and spread are others). `hasNonReifiedStatic` from `bun:internal-for-testing` reports whether an object's table is still unreified.
- Assignment versus `defineProperty` on such an entry: `[[Set]]` replaces the entry with the new value directly; `[[DefineOwnProperty]]` first asks for the current descriptor, which builds the entry.
- `JSVMClientData::isWorkerVM()` is set when a global is created for a Worker thread of either kind; it is false for the main thread's VM.
