### PR TITLE
test(cluster): raise the file's default test timeout under debug builds

### DIFF
--- a/test/js/node/cluster.test.ts
+++ b/test/js/node/cluster.test.ts
@@ -1,8 +1,9 @@
-import { expect, test } from "bun:test";
+import { expect, setDefaultTimeout, test } from "bun:test";
 import {
   bunEnv,
   bunExe,
   bunRun,
+  isDebug,
   isIPv6,
   isLinux,
   isWindows,
@@ -12,6 +13,11 @@ import {
   tls as tlsCerts,
 } from "harness";
 import net from "node:net";
+
+// Every fixture here forks cluster workers, and a debug build spends about a second per process
+// just evaluating node:cluster/net/tls, so the tests take 2-7s against the 5s default when run
+// with `bun bd test`. CI passes its own --timeout and is left alone.
+if (isDebug) setDefaultTimeout(30_000);
 
 test.concurrent("cloneable and transferable equals", async () => {
   const dir = tempDirWithFiles("bun-test", {


### PR DESCRIPTION
### Problem
- `bun bd test test/js/node/cluster.test.ts` fails on main: `(fail) TLS worker listening on a key already owned by a round-robin handle fails with EINVAL [5006.07ms] ^ this test timed out after 5000ms.` The timeout also leaves an "Unhandled error between tests" behind, because `bunRun` resolves with empty stdout once the runner kills the fixture.
- Nothing in the product is slow. Every fixture in this file forks cluster workers, and a debug build spends about a second per process evaluating `node:cluster`, `node:net` and `node:tls` (per-phase numbers below). The failing test starts three processes one after another and takes 5.2s to 7.3s here; the same run takes 145ms on a release build.
- It is a property of the file, not of that one test: across several full-file debug runs here, the 23 tests without a per-test timeout took up to 4.4s against the same 5s default (most of them 2.6s to 3.9s; the dgram adopt-fail and `listen({fd:2})` tests reached 4.4s and 4.1s in one run). The 9 tests that do carry `30_000` were given it when the file was written (#31829), and this one was missed.
- CI never sees any of this: `scripts/runner.node.mjs` passes its own `--timeout` (90s, 270s under ASAN). It only hits `bun bd test` runs of the file, which is what every PR touching it (about ten are open) is checked with locally.

### Fix
- `if (isDebug) setDefaultTimeout(30_000);` at the top of the file, so every test in it gets the budget the three-process ones already have, but only on a debug build.
- Correct because:
  - it is a budget for evaluating built-in modules in a debug JSC, which is the only thing that differs between the failing and passing runs of the same fixture;
  - the `isDebug` gate makes it invisible to CI. `setDefaultTimeout()` takes precedence over `--timeout` (src/runtime/test_runner/ScopeFunctions.rs:746), so an ungated value, or a per-test literal, would have lowered this file's CI budget from 90s/270s to 30s. `isDebug` is `Bun.version.includes("debug")` (test/harness.ts:29), false for the release and ASAN binaries CI runs;
  - the workload cannot be shrunk instead: a round-robin handle only exists once a worker has asked the primary for one (src/js/internal/cluster/primary.ts:281), the EINVAL branch only fires for a handle held by a different worker (primary.ts:231 skips a handle the asking worker already holds), and the second worker has to ask after the first one is listening. Trimming the unneeded `require("node:tls")` calls in the fixture saves about 170ms of 4.8s;
  - a file-level debug-only default is how test/js/node/worker_threads/worker_threads.test.ts:28 handles the same thing, and it is the smallest unit that covers the other 23 tests instead of bumping them one at a time.
- The existing per-test `30_000` values are left as they are, and the line the failing test ends on is untouched, so #37815 (which changes that line to `}, 30_000);` as part of a Windows fix) and #37896 (which restructures the test) still apply unchanged. Neither of those covers the rest of the file.
- Making `bun bd test` itself pass a CI-like `--timeout` would remove the class for every file, but it changes the local default for the whole suite and is a separate decision; this PR only fixes the file that fails today.
- Verified with test/js/node/cluster.test.ts:
  - main, `bun bd test test/js/node/cluster.test.ts -t "TLS worker listening on a key already owned by a round-robin handle"`: 3/3 runs fail at 5000ms (the reporter saw 4/4 on another machine; one full-file run here passed at 4787ms)
  - this branch, same command: 3/3 pass, at 5217ms, 5443ms and 5917ms, so each of them would have timed out without the change
  - this branch, `bun bd test test/js/node/cluster.test.ts`: 32 pass
  - this branch, `USE_SYSTEM_BUN=1 bun test test/js/node/cluster.test.ts`: 32 pass in 5.2s total, `isDebug` is false there

### Background
- `bun bd` builds bun in debug mode against a debug, ASAN-instrumented JSC. JavaScript runs roughly two orders of magnitude slower than on a release build (a 3e6-iteration empty loop takes about 1s), so a test's cost there is dominated by how many processes it starts and how much built-in JS each one evaluates: `require("node:net")` alone is 0.4s to 0.7s per process.
- Timeout precedence in `bun test`: a test's own third argument, then `setDefaultTimeout()` from the file (reset between files), then `--timeout` or the built-in 5s. CI supplies `--timeout`; a local `bun bd test` supplies nothing, so it runs the slowest binary against the tightest default.

<details>
<summary>Previous shape of this PR</summary>

The first version added `, 30_000` to the one failing test. A review pass pointed out that #37815 already carries that exact line, that the trailing comment added here would turn #37815's otherwise identical hunk into a conflict, and that the rest of the file sits close enough to the 5s default that more of the same bumps would follow. The file-level debug-only default above replaces it; the per-test line is back to what main has.
</details>

<details>
<summary>Per-phase timing of the failing fixture under the debug build</summary>

Instrumented copy of the fixture (ms since each process started):

```
primary: cluster loaded at 399
primary: forked net at 701
primary: net online at 1242
net worker: cluster loaded 423ms, net loaded +418ms, listening +1146ms (primary lazily loads node:net and the round-robin handle on the first queryServer)
primary: net listening at 2823
primary: forked tls at 2842
primary: tls online at 3386
tls worker: cluster loaded at 432ms, net +411ms, tls +86ms, createServer +405ms, listen() +39ms, error event +366ms
primary: tls error received at 4711 EINVAL
```

Module evaluation cost in one debug process, cumulative: `events` 169ms, `util` 403ms, `stream` 372ms, `net` 169ms, `tls` 85ms, `cluster` 46ms, `child_process` 100ms.

Full-file debug durations here: the three-process tests that already had `30_000` took 4.3s to 6.8s depending on the run; the others took 0.6s to 4.4s, most of them between 2.6s and 3.9s.
</details>
