### PR TITLE
js_parser: do not fold .length of a folded string with a non-ascii segment

### DIFF
--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -1967,18 +1967,22 @@ impl EString {
         }
     }
 
+    /// The string's JS `.length` (UTF-16 code units), or `None` when it is not
+    /// known without transcoding. `len()` / `rope_len` count bytes for UTF-8
+    /// strings, which is only the JS length while every byte (in every rope
+    /// segment) is ASCII.
     pub fn javascript_length(&self) -> Option<u32> {
-        if self.rope_len > 0 {
-            // We only support ascii ropes for now
-            return Some(self.rope_len);
+        if !self.is_utf8() {
+            return Some(self.slice16().len() as u32);
         }
-        if self.is_utf8() {
-            if !strings::is_all_ascii(&self.data) {
+        let mut part: Option<&EString> = Some(self);
+        while let Some(cur) = part {
+            if !strings::is_all_ascii(&cur.data) {
                 return None;
             }
-            return Some(self.data.len() as u32);
+            part = cur.next.as_ref().map(|r| r.get());
         }
-        Some(self.slice16().len() as u32)
+        Some(self.len() as u32)
     }
 
     // `eql`, split by operand type.

--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -9,31 +9,15 @@ use bun_ast::{self as js_ast, Binding, E, Expr, Flags, G, LocRef, S};
 
 // ── local EString shims ────────────────────────────────────────────────────
 // E.rs currently carries two `impl EString` blocks (live + round-C draft) with
-// overlapping inherent methods, so calls like `EString::init`/`javascript_length`
-// /`eql_bytes` are E0034-ambiguous from here. These thin wrappers go through
-// public fields directly and are removed once E.rs is deduped.
+// overlapping inherent methods, so calls like `EString::init`/`eql_bytes` are
+// E0034-ambiguous from here. These thin wrappers go through public fields
+// directly and are removed once E.rs is deduped.
 #[inline]
 fn e_string_init(data: &[u8]) -> E::EString {
     E::EString {
         data: data.into(),
         ..Default::default()
     }
-}
-
-#[inline]
-fn e_string_javascript_length(s: &E::EString) -> Option<u32> {
-    if s.rope_len > 0 {
-        // We only support ascii ropes for now
-        return Some(s.rope_len);
-    }
-    if !s.is_utf16 {
-        if !s.data.iter().all(|&b| b < 128) {
-            return None;
-        }
-        return Some(s.data.len() as u32);
-    }
-    // UTF-16: `data.len()` stores the u16 element count (see EString::init_utf16).
-    Some(s.data.len() as u32)
 }
 
 #[inline]
@@ -446,7 +430,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     if p.options.features.minify_syntax {
                         // minify "long-string".length to 11
                         if name == b"length" {
-                            if let Some(len) = e_string_javascript_length(&str_) {
+                            if let Some(len) = str_.javascript_length() {
                                 return Some(p.new_expr(E::Number::new(len as f64), loc));
                             }
                         }

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -63,6 +63,29 @@ describe("bundler", () => {
     minifySyntax: true,
     target: "bun",
   });
+  itBundled("minify/StringLengthFoldingNonAsciiDefine", {
+    // Strings injected by --define are stored as UTF-8, so concatenating them
+    // builds a rope whose byte length is not its JS length once a segment is
+    // non-ascii. `.length` must only fold for all-ascii ropes.
+    files: {
+      "/entry.js": /* js */ `
+        capture((ASCII + "x").length);
+        capture(\`\${ASCII}x\`.length);
+        capture((LATIN1 + "x").length);
+        capture(("x" + ASCII + LATIN1).length);
+        capture(\`\${LATIN1}x\`.length);
+        capture(\`x\${EMOJI}\`.length);
+      `,
+    },
+    define: {
+      ASCII: '"ab"',
+      LATIN1: '"é"',
+      EMOJI: '"😋"',
+    },
+    capture: ["3", "3", '"\\xE9x".length', '"xab\\xE9".length', '"\\xE9x".length', '"x\\uD83D\\uDE0B".length'],
+    minifySyntax: true,
+    target: "bun",
+  });
   itBundled("minify/StringAdditionFolding", {
     files: {
       "/entry.js": /* js */ `

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2990,6 +2990,32 @@ export const { dead } = { dead: "hello world!" };
       expectBunPrinted_(`export const foo = ("æ" + "™").length;`, `export const foo = ("æ" + "™").length`);
     });
 
+    it("rewrite string to length with non-ascii utf-8 strings from define", () => {
+      // Unlike non-ascii source literals (stored as UTF-16), define values are
+      // stored as UTF-8, so they do get folded into ropes. The rope tracks its
+      // byte length, which is not the JS length once a segment is non-ascii.
+      const defines = new Bun.Transpiler({
+        loader: "js",
+        platform: "bun",
+        define: { ASCII: '"ab"', LATIN1: '"é"', EMOJI: '"😋"' },
+        minify: { syntax: true },
+      });
+      const expectDefinePrinted = (code, out) => expect(parsed(code, true, false, defines)).toBe(out);
+
+      expectDefinePrinted(`export const foo = (ASCII + "x").length;`, `export const foo = 3`);
+      expectDefinePrinted(`export const foo = \`\${ASCII}x\`.length;`, `export const foo = 3`);
+
+      // "éx".length is 2, but the rope is 3 bytes long
+      expectDefinePrinted(`export const foo = (LATIN1 + "x").length;`, `export const foo = "éx".length`);
+      // the non-ascii segment is not the first one
+      expectDefinePrinted(`export const foo = ("x" + ASCII + LATIN1).length;`, `export const foo = "xabé".length`);
+      // a rope whose only non-empty segment is non-ascii
+      expectDefinePrinted(`export const foo = ("" + LATIN1).length;`, `export const foo = "é".length`);
+      // template literals are folded through the same rope, then flattened
+      expectDefinePrinted(`export const foo = \`\${LATIN1}x\`.length;`, `export const foo = "éx".length`);
+      expectDefinePrinted(`export const foo = \`x\${EMOJI}\`.length;`, `export const foo = "x😋".length`);
+    });
+
     describe("Bun.js", () => {
       it.todo("require -> import.meta.require", () => {
         expectBunPrinted_(


### PR DESCRIPTION
### Problem
- With `--minify-syntax`, `.length` on a constant-folded string concatenation folds to the UTF-8 byte count when one piece is a non-ascii string stored as UTF-8: `bun build --minify-syntax --define 'X="é"'` turns `(X + "x").length` into `3`, and `` `${X}x`.length `` into `3`. The JS value is `2`.
- Non-ascii source literals are stored as UTF-16 and never join a rope, so this only affects strings bun injects as UTF-8 `E::String`s: `--define` values, `.env` / `process.env` inlining, inlined `import.meta.dir/file/path/url`, stringified regexps and bigints.
- Cause: `EString::javascript_length` (`src/ast/e.rs`) returned `rope_len` for any rope, but `rope_len` is the byte total of the segments (`EString::push`, `fold_string_addition.rs`) and nothing makes those bytes ascii. `Template::fold` flattens its rope with `resolve_rope_if_needed`, which leaves `rope_len` set, so a folded template took the same branch with non-ascii `data`.
- `src/js_parser/fold.rs` carried a private copy of the function with the same bug; that copy is what the `.length` rewrite called.

### Fix
- `javascript_length` walks the segments of a UTF-8 string and returns `None` as soon as one contains a non-ascii byte; otherwise the byte length is the JS length. UTF-16 strings are unchanged (they are never ropes and already count code units).
- Correct because a UTF-8 byte count equals the UTF-16 code unit count exactly when every byte is ascii. This is the check the non-rope UTF-8 branch already made, applied to every segment. `None` leaves `.length` in the output, which is what a non-rope non-ascii string already did (`X.length` printed as `"é".length` before this change).
- All-ascii ropes still fold (`("a" + "b").length` -> `2`); for them the walk is the `is_all_ascii` scan the non-rope case already did.
- `fold.rs` calls the method instead of its copy, so there is one implementation.
- Tests: `test/bundler/transpiler/transpiler.test.js` ("rewrite string to length with non-ascii utf-8 strings from define") and `test/bundler/bundler_minify.test.ts` (`minify/StringLengthFoldingNonAsciiDefine`). They cover a non-ascii define segment at the head of the rope, in the tail, the template literal path, a 4-byte (2 code unit) character, and ascii ropes still folding. Both fail on bun 1.4.0 (`3` / `5` printed) and pass with this change.
- Also ran `transpiler.test.js`, `bundler_minify.test.ts` and `bundler_string.test.ts` in full (291 pass), and `cargo clippy -p bun_ast -p bun_js_parser` (clean).

### Background
- Rope: `fold_string_addition` folds `"a" + "b"` by linking the right `E::String` onto the left one through its `next` / `end` pointers instead of copying bytes. `rope_len` caches the byte total of the chain; the printer (or `resolve_rope_if_needed`) flattens it later.
- `E::String` stores its text either as UTF-8 bytes or as UTF-16 code units (`is_utf16`). `len()` is bytes in the first case and code units in the second. Only UTF-8 strings are joined into ropes; the lexer stores any source literal containing non-ascii as UTF-16, while defines and the other synthesized strings go through `EString::init` and stay UTF-8.
- JS `.length` counts UTF-16 code units: `"é"` is 2 bytes of UTF-8 and 1 code unit, `"😋"` is 4 bytes and 2 code units.

<details>
<summary>Repro on bun 1.4.0</summary>

```
$ cat len.ts
console.log((process.env.NONASCII + "x").length);
console.log(process.env.NONASCII + "x");
console.log(`${process.env.NONASCII}x`.length);
console.log(("a" + "b").length);

$ bun build --no-bundle --minify-syntax --target=bun --define 'process.env.NONASCII="é"' len.ts
console.log(3);
console.log("\xE9x");
console.log(3);
console.log(2);
```

With this change:

```
console.log("\xE9x".length);
console.log("\xE9x");
console.log("\xE9x".length);
console.log(2);
```
</details>
