### PR TITLE
require.extensions: do not register a handler the object refused to store

### DIFF
--- a/src/jsc/bindings/JSCommonJSExtensions.cpp
+++ b/src/jsc/bindings/JSCommonJSExtensions.cpp
@@ -145,12 +145,15 @@ extern "C" void NodeModuleModule__onRequireExtensionModifyNonFunction(
     Zig::GlobalObject* globalObject,
     const BunString* key);
 
-void onAssign(Zig::GlobalObject* globalObject, JSC::PropertyName propertyName, JSC::JSValue value)
+static bool isExtensionName(JSC::PropertyName propertyName)
 {
-    if (propertyName.isSymbol()) return;
     auto* name = propertyName.publicName();
-    if (!name->startsWith('.')) return;
-    BunString ext = Bun::toString(name);
+    return name && name->startsWith('.');
+}
+
+static void onAssign(Zig::GlobalObject* globalObject, JSC::PropertyName propertyName, JSC::JSValue value)
+{
+    BunString ext = Bun::toString(propertyName.publicName());
     JSC::CallData callData = JSC::getCallData(value);
     if (callData.type == JSC::CallData::Type::None) {
         return NodeModuleModule__onRequireExtensionModifyNonFunction(globalObject, &ext);
@@ -172,33 +175,47 @@ void onAssign(Zig::GlobalObject* globalObject, JSC::PropertyName propertyName, J
     NodeModuleModule__onRequireExtensionModify(globalObject, &ext, loader, value);
 }
 
-bool JSCommonJSExtensions::defineOwnProperty(JSC::JSObject* object, JSC::JSGlobalObject* globalObject, JSC::PropertyName propertyName, const JSC::PropertyDescriptor& descriptor, bool shouldThrow)
+// require() dispatches on the native table, so the table mirrors this object's own
+// entries. The entry is read back once the base class has applied the operation: a
+// store the object refuses (frozen object, non-writable entry, non-extensible object)
+// or a define that only changes attributes (Object.freeze) leaves the entry as it was,
+// so it leaves the table alone too. That is what Node's require() observes as well,
+// since it reads Module._extensions directly.
+template<typename Operation>
+static bool mutateExtension(JSC::JSObject* object, JSC::JSGlobalObject* globalObject, JSC::PropertyName propertyName, Operation operation)
 {
     if (!isAllowedToMutateExtensions(globalObject)) return true;
-    JSValue value = descriptor.value();
-    if (value) {
-        onAssign(defaultGlobalObject(globalObject), propertyName, value);
-    } else {
-        onAssign(defaultGlobalObject(globalObject), propertyName, JSC::jsUndefined());
+    if (!isExtensionName(propertyName)) return operation();
+
+    JSC::VM& vm = JSC::getVM(globalObject);
+    JSC::JSValue before = object->getDirect(vm, propertyName);
+    if (!operation()) return false;
+    JSC::JSValue after = object->getDirect(vm, propertyName);
+    if (after != before) {
+        onAssign(defaultGlobalObject(globalObject), propertyName, after ? after : JSC::jsUndefined());
     }
-    return Base::defineOwnProperty(object, globalObject, propertyName, descriptor, shouldThrow);
+    return true;
+}
+
+bool JSCommonJSExtensions::defineOwnProperty(JSC::JSObject* object, JSC::JSGlobalObject* globalObject, JSC::PropertyName propertyName, const JSC::PropertyDescriptor& descriptor, bool shouldThrow)
+{
+    return mutateExtension(object, globalObject, propertyName, [&] {
+        return Base::defineOwnProperty(object, globalObject, propertyName, descriptor, shouldThrow);
+    });
 }
 
 bool JSCommonJSExtensions::put(JSC::JSCell* cell, JSC::JSGlobalObject* globalObject, JSC::PropertyName propertyName, JSC::JSValue value, JSC::PutPropertySlot& slot)
 {
-    if (!isAllowedToMutateExtensions(globalObject)) return true;
-    onAssign(defaultGlobalObject(globalObject), propertyName, value);
-    return Base::put(cell, globalObject, propertyName, value, slot);
+    return mutateExtension(uncheckedDowncast<JSCommonJSExtensions>(cell), globalObject, propertyName, [&] {
+        return Base::put(cell, globalObject, propertyName, value, slot);
+    });
 }
 
 bool JSCommonJSExtensions::deleteProperty(JSC::JSCell* cell, JSC::JSGlobalObject* globalObject, JSC::PropertyName propertyName, JSC::DeletePropertySlot& slot)
 {
-    if (!isAllowedToMutateExtensions(globalObject)) return true;
-    bool deleted = Base::deleteProperty(cell, globalObject, propertyName, slot);
-    if (deleted) {
-        onAssign(defaultGlobalObject(globalObject), propertyName, JSC::jsUndefined());
-    }
-    return deleted;
+    return mutateExtension(uncheckedDowncast<JSCommonJSExtensions>(cell), globalObject, propertyName, [&] {
+        return Base::deleteProperty(cell, globalObject, propertyName, slot);
+    });
 }
 
 extern "C" uint32_t JSCommonJSExtensions__appendFunction(Zig::GlobalObject* globalObject, JSC::JSValue value)

--- a/test/js/node/module/require-extensions.test.ts
+++ b/test/js/node/module/require-extensions.test.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 import { expect, mock, test } from "bun:test";
-import { tempDir } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import path from "path";
 
 test("require.extensions shape makes sense", () => {
@@ -191,3 +191,150 @@ test("mutating extensions is banned by some files", () => {
     expect(globalThis.pass).toBe(n);
   }
 });
+test("a store refused by a non-writable entry does not reach the loader", () => {
+  using dir = tempDir("extensions-non-writable", {
+    "mod.locked": `module.exports = "loaded as javascript";`,
+  });
+  const file = require.resolve(path.join(String(dir), "mod.locked"));
+  const load = () => {
+    delete require.cache[file];
+    return require(file);
+  };
+  const held = mock(module => {
+    module.exports = "held";
+  });
+  const refused = mock(module => {
+    module.exports = "refused";
+  });
+
+  require.extensions[".locked"] = held;
+  try {
+    // Only the attributes change here, so the entry has to stay registered.
+    Object.defineProperty(require.extensions, ".locked", { writable: false });
+    expect(load()).toBe("held");
+
+    // This file is a module, so the refused store throws rather than failing silently.
+    expect(() => {
+      require.extensions[".locked"] = refused;
+    }).toThrow(TypeError);
+    expect(Reflect.set(require.extensions, ".locked", refused)).toBe(false);
+    expect(require.extensions[".locked"]).toBe(held);
+    expect(load()).toBe("held");
+    expect(refused).not.toHaveBeenCalled();
+    expect(held).toHaveBeenCalledTimes(2);
+  } finally {
+    // The entry is still configurable, so it can be removed.
+    delete require.extensions[".locked"];
+  }
+  expect(".locked" in require.extensions).toBe(false);
+  expect(load()).toBe("loaded as javascript");
+  delete require.cache[file];
+});
+test.concurrent("stores refused by a frozen require.extensions do not reach the loader", async () => {
+  using dir = tempDir("extensions-frozen", {
+    "index.cjs": `
+      const assert = require("assert");
+      const calls = [];
+      require.extensions[".hooked"] = m => { calls.push("kept"); m.exports = "kept"; };
+      const originalJs = require.extensions[".js"];
+      Object.freeze(require.extensions);
+
+      // This file is sloppy mode, so the frozen object refuses these silently.
+      require.extensions[".js"] = m => { calls.push(".js"); m.exports = "refused .js hook"; };
+      require.extensions[".hooked"] = m => { calls.push(".hooked"); m.exports = "refused .hooked hook"; };
+      require.extensions[".added"] = m => { calls.push(".added"); m.exports = "refused .added hook"; };
+      assert.strictEqual(require.extensions[".js"], originalJs);
+      assert.strictEqual(Object.hasOwn(require.extensions, ".added"), false);
+
+      console.log(JSON.stringify({
+        js: require("./plain.js"),
+        jsx: require("./classic-jsx.js"),
+        hooked: require("./mod.hooked"),
+        added: require("./mod.added"),
+        calls,
+      }));
+    `,
+    "plain.js": `module.exports = "plain";`,
+    // Object.freeze redefines the attributes of every builtin entry. The builtin ".js" entry
+    // must stay builtin afterwards: the default loader for .js files accepts JSX, while an
+    // explicitly registered require.extensions[".js"] handler does not.
+    "classic-jsx.js": `
+      /* @jsxRuntime classic */
+      /* @jsx h */
+      function h(tag) { return "jsx:" + tag; }
+      module.exports = <div />;
+    `,
+    "mod.hooked": `module.exports = "loaded as javascript";`,
+    "mod.added": `module.exports = "loaded as javascript";`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.cjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({
+    js: "plain",
+    jsx: "jsx:div",
+    hooked: "kept",
+    added: "loaded as javascript",
+    calls: ["kept"],
+  });
+  expect(exitCode).toBe(0);
+});
+test.concurrent(
+  "stores refused by a non-configurable entry or a non-extensible require.extensions do not reach the loader",
+  async () => {
+    using dir = tempDir("extensions-non-configurable", {
+      "index.cjs": `
+        const assert = require("assert");
+        const calls = [];
+        const refused = how => m => { calls.push(how); m.exports = "refused " + how; };
+
+        require.extensions[".pinned"] = m => { calls.push("held"); m.exports = "held"; };
+        Object.defineProperty(require.extensions, ".pinned", { configurable: false, writable: false });
+        assert.throws(() => Object.defineProperty(require.extensions, ".pinned", { value: refused("defineProperty") }), TypeError);
+        assert.strictEqual(Reflect.defineProperty(require.extensions, ".pinned", { value: refused("Reflect.defineProperty") }), false);
+        require.extensions[".pinned"] = refused("assignment");
+        assert.strictEqual(delete require.extensions[".pinned"], false);
+
+        Object.preventExtensions(require.extensions);
+        require.extensions[".fresh"] = refused("assignment of a new entry");
+        assert.throws(() => Object.defineProperty(require.extensions, ".defined", { value: refused("defineProperty of a new entry") }), TypeError);
+        assert.strictEqual(Object.hasOwn(require.extensions, ".fresh"), false);
+        assert.strictEqual(Object.hasOwn(require.extensions, ".defined"), false);
+
+        console.log(JSON.stringify({
+          pinned: require("./mod.pinned"),
+          fresh: require("./mod.fresh"),
+          defined: require("./mod.defined"),
+          calls,
+        }));
+      `,
+      "mod.pinned": `module.exports = "loaded as javascript";`,
+      "mod.fresh": `module.exports = "loaded as javascript";`,
+      "mod.defined": `module.exports = "loaded as javascript";`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.cjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      pinned: "held",
+      fresh: "loaded as javascript",
+      defined: "loaded as javascript",
+      calls: ["held"],
+    });
+    expect(exitCode).toBe(0);
+  },
+);


### PR DESCRIPTION
### Problem

- A store to `require.extensions` / `Module._extensions` that the object itself refuses still registers the handler with the loader, so `require()` dispatches to a function that never became an entry of the object. Refused stores that reproduce this on bun 1.4.0 and on main: assignment to a frozen `require.extensions` or to an entry made non-writable (silently refused in sloppy mode, `TypeError` in strict mode), `Reflect.set` returning false, `Object.defineProperty` / `Reflect.defineProperty` on a non-configurable entry, and assignment or `defineProperty` of a new entry on a non-extensible object. Node dispatches to the entry the object actually holds in every one of these cases.
- The same code also handles `defineProperty` calls that only change attributes as an unregister, because the descriptor carries no value. `Object.freeze(require.extensions)` performs exactly such a call for every entry, so on 1.4.0 freezing the object silently drops every custom hook registered before it (a `.hooked` handler registered and then frozen in place is ignored and the file is loaded as JavaScript); `Object.defineProperty(require.extensions, ".x", { writable: false })` drops the `.x` hook the same way.
- Cause: `JSCommonJSExtensions::put` and `JSCommonJSExtensions::defineOwnProperty` (`src/jsc/bindings/JSCommonJSExtensions.cpp`) called `onAssign`, which writes the native table, before `Base::put` / `Base::defineOwnProperty` decided whether the operation is allowed, and ignored the result. `defineOwnProperty` additionally mirrored `descriptor.value()`, which is empty for attribute-only descriptors. `deleteProperty` already did it the other way round.

### Fix

- `put`, `defineOwnProperty` and `deleteProperty` now share one helper: read the object's own value for the key, apply the base class operation, and if it succeeded and the own value is now a different value, mirror that value (or its absence) into the native table.
- Why this is correct: `require()` in Node reads `Module._extensions[ext]` at load time, so what it dispatches on is, by definition, the entry the object holds. Bun dispatches on a native table instead, and the table is only correct while it tracks the entries the object holds. Reading the entry back after the base class has applied the operation makes the table follow the object whatever the outcome: a refused store leaves the entry unchanged and is not mirrored, an attribute-only define leaves the value unchanged and is not mirrored, a delete or an accepted store changes it and is mirrored. Mirroring the assigned value on success would have been enough for refused stores, but `Object.freeze` would then have re-registered every builtin entry as an explicit handler, and an explicitly registered `.js` handler loads files with the JSX-less loader (`test/regression/issue/require-extensions-override.test.ts` pins that), so freezing would have changed how `.js` files load. The read-back keeps freeze a no-op for dispatch, as it is in Node.
- Behavior that is unchanged: accepted stores, restores of a builtin handler, deletes, the packages that are not allowed to mutate the object (`isAllowedToMutateExtensions` still runs first for every key), and accessor descriptors (still mirrored as an unregister, the limitation tracked with the `Module._extensions` work in #35774). Keys that do not start with `.` go straight to the base class as before.
- Independent of #38854 (which makes every execution of an assignment reach `put`; this PR changes what `put` does once reached). The two were built together locally and both test files pass.
- Verified with `test/js/node/module/require-extensions.test.ts`: three new tests. One in-process test makes a custom entry non-writable, checks it stays registered, and checks that a throwing assignment and a false-returning `Reflect.set` do not change what `require()` dispatches to; one spawned sloppy-mode test freezes the object and checks that refused stores to a builtin entry, a custom entry and a new entry are not dispatched to, that the hook registered before the freeze survives it, and that a `.js` file using JSX still loads afterwards; one spawned test covers a non-configurable entry (rejected `defineProperty`, `Reflect.defineProperty`, assignment and delete) and a non-extensible object (rejected assignment and `defineProperty` of new entries). On 1.4.0 all three fail (the refused handlers are dispatched to and the frozen hook is dropped); with this change the file passes 13/13. The fixtures of the two spawned tests print the same values under Node (without the JSX file).
- Also run with the debug build: the rest of `test/js/node/module/`, `test/regression/issue/require-extensions-override.test.ts`, `test/regression/issue/22929-module-extensions-asi.test.ts`, Node's `test-module-multi-extensions.js`, `test-require-extensions-main.js` and `test-module-main-extension-lookup.js`, and the new tests under `BUN_JSC_validateExceptionChecks=1`: all pass.

### Background

- `require.extensions` is one `JSCommonJSExtensions` object per global. Its properties are only a mirror: the table `require()` actually consults is `commonjs_custom_extensions` in `src/jsc/NodeModuleModule.rs`, written through `onAssign` -> `NodeModuleModule__onRequireExtensionModify` / `...NonFunction` and read by `Bun__transpileFile`. Builtin entries are not in the table until someone assigns them; assigning one of the builtin handler functions registers the corresponding fixed loader (the `.js` handler registers the JS loader, while an untouched `.js` entry uses the default loader for `.js` files, which also accepts JSX).
- `put` / `defineOwnProperty` / `deleteProperty` are JSC's per-class hooks for `[[Set]]`, `[[DefineOwnProperty]]` and `[[Delete]]`. The base class versions implement the language rules (non-writable, non-configurable, non-extensible) and return false, or throw when the caller asked for that, when the operation is refused. `getDirect` reads an own property straight out of the object's storage without running any JavaScript, which is why it is safe to call before and after the operation.
- `Object.freeze(obj)` is `[[PreventExtensions]]` followed by a `[[DefineOwnProperty]]` on every own property with `{ configurable: false, writable: false }`, so it reaches `defineOwnProperty` once per entry with a descriptor that has no value.

<details>
<summary>Repro on 1.4.0</summary>

```js
// a.js: module.exports = "builtin";
const original = require.extensions[".js"];
Object.freeze(require.extensions);
let invoked = false;
require.extensions[".js"] = m => { invoked = true; m.exports = "hook"; }; // sloppy mode: silently refused
console.log(require.extensions[".js"] === original);   // true in both
console.log(require("./a.js"), invoked);               // bun 1.4.0: "hook" true    node: "builtin" false
```

```js
// mod.hooked: module.exports = "loaded as javascript";
require.extensions[".hooked"] = m => { m.exports = "kept"; };
Object.freeze(require.extensions);
console.log(require("./mod.hooked"));                  // bun 1.4.0: "loaded as javascript"    node: "kept"
```

</details>
