### PR TITLE
install: bind an unsatisfiable peer to the copy bun.lock nests under its dependent

### DIFF
--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -1708,6 +1708,18 @@ impl<T> PkgMap<T> {
         self.map.contains_key(path)
     }
 
+    /// The entry printed inside `pkg_path`'s own `node_modules`: the first probe of `find_resolution`.
+    fn get_nested(&self, pkg_path: &[u8], dep_name: &[u8], path_buf: &mut [u8]) -> Option<&T> {
+        let len = pkg_path.len() + 1 + dep_name.len();
+        if len > path_buf.len() {
+            return None;
+        }
+        path_buf[..pkg_path.len()].copy_from_slice(pkg_path);
+        path_buf[pkg_path.len()] = b'/';
+        path_buf[pkg_path.len() + 1..len].copy_from_slice(dep_name);
+        self.get(&path_buf[..len])
+    }
+
     fn find_resolution(
         &self,
         pkg_path: &[u8],
@@ -3088,6 +3100,7 @@ pub(crate) fn parse_into_binary_lockfile(
                 let dep_id: DependencyID = _dep_id;
                 let dep = &mut dependencies[dep_id as usize];
 
+                // Every entry at the root level is a hoisted one, so none of them is a recorded peer binding.
                 let peer_res_id = resolve_peer_dep_version_based(
                     dep,
                     catalogs,
@@ -3095,6 +3108,7 @@ pub(crate) fn parse_into_binary_lockfile(
                     overrides,
                     pkg_resolutions,
                     string_buf,
+                    || None,
                 );
                 let Some(res_id) =
                     peer_res_id.or_else(|| pkg_map.get(dep.name.slice(string_buf)).copied())
@@ -3177,6 +3191,7 @@ pub(crate) fn parse_into_binary_lockfile(
                         overrides,
                         pkg_resolutions,
                         string_buf,
+                        || pkg_map.get(workspace_node_modules).copied(),
                     );
                     let Some(res_id) = peer_res_id.or_else(|| {
                         pkg_map
@@ -3241,6 +3256,7 @@ pub(crate) fn parse_into_binary_lockfile(
                     continue 'deps;
                 }
 
+                let dep_name = dep.name.slice(string_buf);
                 let peer_res_id = resolve_peer_dep_version_based(
                     dep,
                     catalogs,
@@ -3248,6 +3264,11 @@ pub(crate) fn parse_into_binary_lockfile(
                     overrides,
                     pkg_resolutions,
                     string_buf,
+                    || {
+                        pkg_map
+                            .get_nested(pkg_path, dep_name, &mut path_buf[..])
+                            .copied()
+                    },
                 );
                 let res_id = match peer_res_id {
                     Some(id) => id,
@@ -3336,13 +3357,23 @@ fn deferred_peer_range<'a>(
 /// `install_peer`): scan the package ids recorded for the dependency's
 /// name — `package_index` lists are kept ordered by descending
 /// `Resolution::order` — and take the first whose resolution satisfies
-/// the range. When nothing satisfies, fall back to the highest-ordered
-/// candidate, and only when it is the same kind as the dependency (the
-/// "incorrect peer dependency" case; the fresh resolver inspects only
-/// `list[0]` there, and reproducing its choice exactly is the point of
-/// this helper). Returns `None` when no package with the name exists
-/// or the fallback is a different kind; the caller then falls back to
-/// the path walk. Edges `deferred_peer_range` rejects also return `None`.
+/// the range. When nothing satisfies, the binding is `nested()`, the entry
+/// the printed tree has inside the dependent's own `node_modules`, if any:
+/// the hoister nests a peer under its dependent exactly when nothing
+/// enclosing satisfies it, so that entry is the binding the file records
+/// (1.3.x bound every peer by path and wrote many such entries), and it is
+/// also what node resolves from the dependent; binding anything else would
+/// leave it without a dependent and drop it from the lockfile on the next
+/// save. A tree written by this version has the fallback candidate there,
+/// nothing, or a copy a dependency of the dependent could not hoist any
+/// further, which node resolves from the dependent as well. Without such
+/// an entry, fall back to the highest-ordered candidate, and only when it is
+/// the same kind as the dependency (the "incorrect peer dependency" case;
+/// the fresh resolver inspects only `list[0]` there, and reproducing its
+/// choice exactly is the point of this helper). Returns `None` when no
+/// package with the name exists or the fallback is a different kind; the
+/// caller then falls back to the path walk. Edges `deferred_peer_range`
+/// rejects also return `None`.
 ///
 /// Peer edges cannot be resolved from the printed tree the way regular
 /// edges are: a peer never materializes its own `node_modules` path when
@@ -3367,6 +3398,7 @@ pub(crate) fn resolve_peer_dep_version_based(
     overrides: &OverrideMap,
     pkg_resolutions: &[Resolution],
     string_buf: &[u8],
+    nested: impl FnOnce() -> Option<PackageID>,
 ) -> Option<PackageID> {
     let range = deferred_peer_range(dep, catalogs, string_buf)?;
     // `package_index` is keyed by real package names; `range` (not `dep.name`) carries them for aliases.
@@ -3415,6 +3447,10 @@ pub(crate) fn resolve_peer_dep_version_based(
         {
             return Some(id);
         }
+    }
+
+    if let Some(id) = nested() {
+        return Some(id);
     }
 
     let &first = candidates.first()?;

--- a/src/install/pnpm.rs
+++ b/src/install/pnpm.rs
@@ -139,6 +139,8 @@ fn resolve_peer_like_bun_lock(lockfile: &Lockfile, dep: &Dependency) -> Option<P
         &lockfile.overrides,
         lockfile.packages.items_resolution(),
         string_bytes!(lockfile),
+        // No printed tree yet; whatever this binds is what the first save nests.
+        || None,
     )
 }
 

--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -1450,6 +1450,56 @@ it("--frozen-lockfile keeps a package that an older lockfile lists only as an op
   expect(await exists(join(packageDir, "node_modules", "no-deps", "package.json"))).toBeTrue();
 });
 
+// bun 1.3.x bound every peer to the entry the tree placed next to it, so a
+// bun.lock it wrote can nest a copy under a dependent whose peer range no
+// version in the lockfile satisfies. Loading has to bind the peer to that copy,
+// as 1.3.x did: bound to the hoisted version instead, the copy is not installed
+// and has no dependent left, so the next save drops it.
+it("installs and keeps the copy an older lockfile nests under a dependent whose peer range nothing satisfies", async () => {
+  const { packageDir, packageJson } = await registry.createTestDir({
+    bunfigOpts: { saveTextLockfile: true, linker: "hoisted" },
+  });
+  const run = makeInstallRunner(packageDir);
+  const dependencies = { "one-dep": "1.0.0", "strict-peer-dep": "1.0.0" };
+  const nestedEntry = '"strict-peer-dep/no-deps": ["no-deps@1.0.0"';
+  await Promise.all([
+    write(packageJson, JSON.stringify({ name: "foo", dependencies })),
+    write(
+      join(packageDir, "bun.lock"),
+      JSON.stringify({
+        lockfileVersion: 1,
+        configVersion: 1,
+        workspaces: { "": { name: "foo", dependencies } },
+        packages: {
+          "no-deps": ["no-deps@1.0.1", "", {}, ""],
+          "one-dep": ["one-dep@1.0.0", "", { dependencies: { "no-deps": "1.0.1" } }, ""],
+          // strict-peer-dep wants no-deps@^2.0.0; neither copy satisfies it, and
+          // this nested one is the binding an earlier install recorded.
+          "strict-peer-dep": ["strict-peer-dep@1.0.0", "", { peerDependencies: { "no-deps": "^2.0.0" } }, ""],
+          "strict-peer-dep/no-deps": ["no-deps@1.0.0", "", {}, ""],
+        },
+      }),
+    ),
+  ]);
+
+  await run(["install", "--frozen-lockfile"]);
+  const installedVersion = (...segments: string[]) =>
+    file(join(packageDir, "node_modules", ...segments, "package.json"))
+      .json()
+      .then(({ version }) => version)
+      .catch(() => null);
+  expect(
+    await Promise.all([installedVersion("no-deps"), installedVersion("strict-peer-dep", "node_modules", "no-deps")]),
+  ).toEqual(["1.0.1", "1.0.0"]);
+
+  await run(["install", "--lockfile-only"]);
+  const saved = await file(join(packageDir, "bun.lock")).text();
+  expect(saved).toContain(nestedEntry);
+
+  await run(["install", "--frozen-lockfile"]);
+  expect(await file(join(packageDir, "bun.lock")).text()).toBe(saved);
+});
+
 // The optional-peer-hoist-* fixtures are described in
 // registry/packages/create-optional-peer-hoist-packages.ts. In short: consumer
 // has an optional peer on target, and deep -> deep-child reaches target@1.0.0


### PR DESCRIPTION
### Problem
- A `bun.lock` written by bun 1.3.x can nest a copy of a peer under a dependent whose peer range no version in the file satisfies. activepieces/activepieces (HEAD, also at ec27c2f2) commits `react-json-view/react`, `react-json-view/react-dom` (`react@18.3.1`, `react-dom@18.3.1`; `react-json-view` declares `react: ^17 || ^16.3 || ^15.5.4`, the root holds `react@19.2.5`), `flux/react` and `react-json-view/react-dom/scheduler`. 1.3.14 installs that file as written and re-saves it byte-identically.
- On main, loading the file binds those peers to `react@19.2.5` / `react-dom@19.2.5`: `resolve_peer_dep_version_based` (`src/install/lockfile/bun.lock.rs`, from #32182) binds a ranged peer by version and, when nothing satisfies the range, takes the highest candidate. The nested copies are then not installed (`react-json-view` gets React 19), `react-dom@18.3.1` has no dependent left, and a plain `bun install` on the untouched checkout deletes the four entries (`Clean lockfile: 4069 -> 4068`). Until #38870 this also failed `--frozen-lockfile`; now the frozen install succeeds but lays out a different tree than 1.3.14 does from the same file. Part of the 1.3 to 1.4 lockfile ledger (the other four repos there are the optional-peer case: #38853 for frozen installs, #39002 for the rest).

### Fix
- When no candidate satisfies the range, bind the entry printed directly inside the dependent's own `node_modules` (`PkgMap::get_nested`, passed to the helper as a lazy closure) before falling back to the highest candidate. The hoister nests a peer under its dependent exactly when nothing enclosing satisfies it, so that entry is the binding the file records, and it is what node resolves from the dependent. Binding it makes the file a fixed point: the copy is placed nested again, installed, and written back.
- Files written by this version bind the same as before: a fresh resolve puts the fallback candidate there or nothing. Satisfied ranges, optional peers, `*` peers and overridden names are untouched. The root loop passes `|| None` (root-level entries are hoisted ones, not bindings); the pnpm migration passes `|| None` (no printed tree yet). One hash lookup, only on the nothing-satisfies path.
- #38767 and #38768 add callers of this helper; whichever lands second passes the extra argument (`|| None` for #38768's placed-package scan; for #38767's pass over already bound edges the natural value is the edge's current target, so a recorded nothing-satisfies binding is kept rather than re-derived).
- Verified:
  - `test/cli/install/bun-lock.test.ts`, "installs and keeps the copy an older lockfile nests under a dependent whose peer range nothing satisfies": a hand-written 1.3-shaped lockfile on the registry fixtures (`strict-peer-dep` wants `no-deps@^2.0.0`; `one-dep` hoists `no-deps@1.0.1`; `strict-peer-dep/no-deps` is `1.0.0`). Rebuilt with main's `src/install` it fails (`strict-peer-dep/node_modules/no-deps` is not installed: received `null`, expected `"1.0.0"`); with this change it passes, `--lockfile-only` keeps the nested entry and `--frozen-lockfile` accepts the re-saved file.
  - activepieces at HEAD with this build: `--frozen-lockfile` exits 0 and a plain install no longer touches the four entries (the remaining diff there is the optional-peer case above).
  - Debug build: bun-lock (41), migration/migrate (125, snapshots unchanged), the pnpm-lock-v9 peer group, and isolated-install's `across installs from bun.lock` tests (#32182) pass. Full isolated-install / pnpm-lock-v9 runs on this box hit `ConnectionRefused` from the test registry under load (load average above 200) on varying tests; the same tests pass when re-run. isolated-install's "ranged peer dependency resolution is stable" is intermittent on its fresh-install assertion (line 1202, before any lockfile is loaded; the arrival-order dependence #38767 describes), with or without this change.

### Background
- `bun.lock` keys each package by the `node_modules` path the hoister gave it and stores no target for peer edges. On load, ordinary edges are re-bound by walking up those paths; since #32182 required ranged peers are re-bound by version instead, because a peer whose range is satisfied by a version hoisted above it has no path of its own, and the walk rebound it to that version (re-keying isolated store entries on every warm install).
- When a peer's bound target is not satisfied by anything enclosing, `Tree::hoist_dependency` cannot dedupe it and places it under the dependent, which is the `dependent/name` entry this change reads back. 1.3.x bound every peer by path, so it produced and preserved such entries whenever a project's peer ranges fell behind the versions it installed.
- `clean_with_logger` rebuilds the lockfile from the packages the edges reach; a package no edge points at is dropped, which is how rebinding the peer deletes the nested copy on the next save.
