### PR TITLE
install(hoisted): link a file: override applied to a dependency of an installed package

### DIFF
--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1833,11 +1833,15 @@ impl<'a> PackageInstaller<'a> {
                         // This is a transitive folder dependency. It is installed with a single symlink to the target folder/file,
                         // and is not hoisted.
                         //
-                        // A transitive `Resolution::Folder` declared by a local `file:` package
-                        // is relative to the top-level dir (`Package::parse` normalized it), so
-                        // install it from `installer.cache_dir` (the cwd, set in the switch above).
+                        // A transitive `Resolution::Folder` is relative to the top-level dir when
+                        // a local `file:` package declared it (`Package::parse` normalized it) or
+                        // when a root `overrides`/`resolutions` rule, scoped or not, supplied the
+                        // path, so install it from `installer.cache_dir` (the cwd, set in the
+                        // switch above). Only the unsafe-path check in that switch is limited to
+                        // plain rules (see `OverrideMap::contains_name`).
                         if resolution.tag == resolution::Tag::Folder
-                            && self.lockfile().is_folder_tree_id(self.current_tree_id)
+                            && (self.lockfile().is_folder_tree_id(self.current_tree_id)
+                                || self.lockfile().is_overridden_dependency(dependency_id))
                         {
                             break 'result installer.install(
                                 self.skip_delete,

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -825,6 +825,14 @@ impl Lockfile {
                 == ResolutionTag::Folder
     }
 
+    /// Is there a root `overrides`/`resolutions` rule (plain or scoped) for this dependency?
+    /// Rules are written in the root package.json, so a `file:` path applied through one is
+    /// relative to the top-level dir whichever package declares the dependency.
+    pub(crate) fn is_overridden_dependency(&self, id: DependencyID) -> bool {
+        let dependency = &self.buffers.dependencies[id as usize];
+        self.overrides.get(self, id, dependency.name_hash).is_some()
+    }
+
     /// Returns the package id of the workspace the install is taking place in.
     pub(crate) fn get_workspace_package_id(
         &self,

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -5243,6 +5243,55 @@ describe("transitive file dependencies", () => {
       version: "1.1.1",
     });
   });
+
+  // `file-dep@1.0.0` declares `"files": "file:./the-files"` and ships `the-files/`
+  // (index.js + package.json) in its tarball.
+  test("a root override redirects a registry package's own file: dependency to a folder in the project", async () => {
+    await Promise.all([
+      write(
+        packageJson,
+        JSON.stringify({
+          name: "foo",
+          dependencies: { "file-dep": "1.0.0" },
+          overrides: { files: "file:./vendor/files" },
+        }),
+      ),
+      write(join(packageDir, "vendor", "files", "package.json"), JSON.stringify({ name: "files", version: "9.9.9" })),
+      write(join(packageDir, "vendor", "files", "vendored.js"), ""),
+    ]);
+
+    for (const frozenLockfile of [false, true]) {
+      await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+
+      const { out } = await runBunInstall(env, packageDir, { frozenLockfile });
+
+      expect(out).toContain("2 packages installed");
+      expect(await readdirSorted(join(packageDir, "node_modules", "file-dep", "node_modules", "files"))).toEqual([
+        "package.json",
+        "vendored.js",
+      ]);
+    }
+  });
+
+  test("a scoped override for another dependent leaves a registry package's own file: dependency alone", async () => {
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "foo",
+        dependencies: { "file-dep": "1.0.0" },
+        // Names `files`, but only as a dependency of `other`, which file-dep is not.
+        overrides: { other: { files: "file:./vendor/files" } },
+      }),
+    );
+
+    const { out } = await runBunInstall(env, packageDir);
+
+    expect(out).toContain("2 packages installed");
+    expect(await readdirSorted(join(packageDir, "node_modules", "file-dep", "node_modules", "files"))).toEqual([
+      "index.js",
+      "package.json",
+    ]);
+  });
 });
 
 test("name from manifest is scoped and url encoded", async () => {

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -10205,7 +10205,141 @@ for (const field of ["resolutions", "overrides"]) {
       }"
     `);
   });
+
+  // Unlike `pkg-a` above, the package declaring the overridden dependency is a
+  // registry package here, so the hoisted installer cannot source the folder
+  // relative to a local declarer: the path only makes sense relative to the
+  // project, where the rule was written.
+  const isOddRules: [kind: string, rule: Record<string, unknown>][] = [
+    ["plain", { "is-odd": "file:./vendor/is-odd" }],
+    [
+      "nested",
+      field === "overrides"
+        ? { "is-even": { "is-odd": "file:./vendor/is-odd" } }
+        : { "is-even/is-odd": "file:./vendor/is-odd" },
+    ],
+  ];
+
+  for (const [kind, rule] of isOddRules) {
+    it.concurrent(`links a ${kind} "${field}" file: rule applied to a registry package's dependency`, async () => {
+      await withContext(defaultOpts, async ctx => {
+        const urls: string[] = [];
+        setContextHandler(
+          ctx,
+          dummyRegistryForContext(ctx, urls, { "1.0.0": { dependencies: { "is-odd": "^0.1.2" } } }),
+        );
+        await writeIsEvenProject(ctx.package_dir, { [field]: rule });
+
+        const { out } = await runBunInstall(env, ctx.package_dir, { saveTextLockfile: true });
+        expect(out).toContain("2 packages installed");
+        expect(urls.sort()).toEqual([`${ctx.registry_url}is-even`, `${ctx.registry_url}is-even-1.0.0.tgz`]);
+        expect(await file(join(ctx.package_dir, "bun.lock")).text()).toContain(
+          `"is-even/is-odd": ["is-odd@file:./vendor/is-odd", {}]`,
+        );
+        await expectVendoredIsOddLinked(ctx.package_dir);
+
+        // Installing again on top of the existing node_modules keeps it.
+        await runBunInstall(env, ctx.package_dir, { savesLockfile: false });
+        await expectVendoredIsOddLinked(ctx.package_dir);
+
+        // Installing from the lockfile goes through the installer without re-resolving.
+        await rm(join(ctx.package_dir, "node_modules"), { recursive: true, force: true });
+        await runBunInstall(env, ctx.package_dir, { frozenLockfile: true });
+        await expectVendoredIsOddLinked(ctx.package_dir);
+
+        expect(urls.filter(url => url.includes("is-odd"))).toEqual([]);
+      });
+    });
+
+    if (field !== "overrides") continue;
+
+    // The isolated linker already sources every folder package from the project; pin the parity.
+    it.concurrent(`isolated linker: a ${kind} file: override applied to a registry package's dependency`, async () => {
+      await withContext({ linker: "isolated" }, async ctx => {
+        const urls: string[] = [];
+        setContextHandler(
+          ctx,
+          dummyRegistryForContext(ctx, urls, { "1.0.0": { dependencies: { "is-odd": "^0.1.2" } } }),
+        );
+        await writeIsEvenProject(ctx.package_dir, { [field]: rule });
+
+        await runBunInstall(env, ctx.package_dir);
+        expect(urls.filter(url => url.includes("is-odd"))).toEqual([]);
+        await expectIsEvenUsesVendoredIsOdd(ctx.package_dir);
+      });
+    });
+  }
 }
+
+/**
+ * `is-even@1.0.0` (served by the dummy registry from the fixture tarball) does
+ * `require("is-odd")`. `vendor/is-odd` is what the override rules above point it at;
+ * it is recognizable at runtime by the line it prints.
+ */
+async function writeIsEvenProject(projectDir: string, rootPackageJsonFields: Record<string, unknown>) {
+  await Promise.all([
+    write(
+      join(projectDir, "package.json"),
+      JSON.stringify({
+        name: "foo",
+        version: "0.0.1",
+        dependencies: { "is-even": "1.0.0" },
+        ...rootPackageJsonFields,
+      }),
+    ),
+    write(join(projectDir, "vendor", "is-odd", "package.json"), JSON.stringify({ name: "is-odd", version: "9.9.9" })),
+    write(
+      join(projectDir, "vendor", "is-odd", "index.js"),
+      `module.exports = function isOdd() { console.log("vendored is-odd"); return true; };`,
+    ),
+  ]);
+}
+
+async function expectIsEvenUsesVendoredIsOdd(projectDir: string) {
+  await using proc = spawn({
+    cmd: [bunExe(), "-e", `console.log(require("is-even")(2))`],
+    cwd: projectDir,
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(err).toBe("");
+  expect(out).toBe("vendored is-odd\nfalse\n");
+  expect(exitCode).toBe(0);
+}
+
+async function expectVendoredIsOddLinked(projectDir: string) {
+  // Folder dependencies are never hoisted: the rule's target is linked inside is-even.
+  expect(await readdirSorted(join(projectDir, "node_modules", "is-even", "node_modules"))).toEqual(["is-odd"]);
+  expect(await readdirSorted(join(projectDir, "node_modules", "is-even", "node_modules", "is-odd"))).toEqual([
+    "index.js",
+    "package.json",
+  ]);
+  await expectIsEvenUsesVendoredIsOdd(projectDir);
+}
+
+it.concurrent("fails when a file: override for a registry package's dependency names a missing folder", async () => {
+  await withContext(defaultOpts, async ctx => {
+    const urls: string[] = [];
+    setContextHandler(ctx, dummyRegistryForContext(ctx, urls, { "1.0.0": { dependencies: { "is-odd": "^0.1.2" } } }));
+    await write(
+      join(ctx.package_dir, "package.json"),
+      JSON.stringify({
+        name: "foo",
+        version: "0.0.1",
+        dependencies: { "is-even": "1.0.0" },
+        overrides: { "is-odd": "file:./vendor/is-odd" },
+      }),
+    );
+
+    const { out, err } = await runBunInstall(env, ctx.package_dir, { allowErrors: true, expectedExitCode: 1 });
+
+    expect(err).toContain('Could not find folder "file:./vendor/is-odd" for dependency "is-odd"');
+    expect(out).toContain("Failed to install 1 package");
+    expect(await readdirSorted(join(ctx.package_dir, "node_modules", "is-even", "node_modules"))).toEqual([]);
+  });
+});
 
 it("installs the transitive file: dependency of a file: dependency", async () => {
   using dir = tempDir("transitive-file-dep", {


### PR DESCRIPTION
### Problem

- With the hoisted linker, a root `overrides` / `resolutions` rule such as `"sub": "file:./vendor/sub"` applied to a dependency of a registry, tarball or git package is silently not installed: `bun install` exits 0 and reports the package installed, `node_modules/<pkg>/node_modules/` stays empty, and `require("<pkg>")` fails with `Cannot find package 'sub'`. `bun.lock` is right (`"pkg/sub": ["sub@file:./vendor/sub", {}]`), and the isolated linker installs the same project correctly. Reproduces on 1.4.0 and main; nested rules (`{"pkg": {"sub": "file:..."}}`, `"pkg/sub"`, `"sub@^1"`) behave the same.
- Cause: `src/install/PackageInstaller.rs`, transitive folder branch. A `Resolution::Folder` string has one of two bases (see Background), and the installer picks the base from the tree it is installing into: the project dir when the declaring package is a local `file:` package (#33159), otherwise the declaring package's own directory, where an ENOENT is rewritten to `InstallResult::Success` because published packages may declare folders they do not ship. An override's path is written in the root package.json, so it is project-relative whatever package declares the dependency; under an installed package the installer opened `node_modules/pkg/./vendor/sub`, got ENOENT, and counted the row as installed. The resolver already classifies these rows as root-authored (`PackageManagerEnqueue.rs`, Folder arm, lets them through the escape check), so they reach the installer.
- This is the "override rows under an installed package" case #38990 lists as not addressed there.

### Fix

- `Lockfile::is_overridden_dependency(id)`: is there a root rule, plain or scoped, for this dependency edge (`OverrideMap::get`, the lookup the resolver applied to it).
- The installer installs a transitive folder row from the top-level dir when the declaring package is a local folder (unchanged) or when the row is selected by a rule (new); the declaring-package base and its ENOENT tolerance stay for rows declared by installed packages only. A rule target that does not exist now fails the install with the existing `Could not find folder "file:./vendor/sub" for dependency "sub"` error instead of exiting 0.
- Why this is correct: the base of the path is a property of who wrote it, and for these rows that is the root package.json, the same base the resolver and the isolated linker already use for them. The predicate is per edge, so a scoped rule does not touch another package's own `file:` dependency of the same name (pinned by a test); a `file:` path can only be a transitive Folder row through the declaring package itself or through a rule, so a rule on the edge means the rule wrote the path. `OverrideMap::contains_name` (plain rules only) is not used here because it answers the trust question for the escape check at the name level; the path base question is per edge and has no trust component, since an escaping path from a scoped rule is rejected while resolving.
- A `node_modules` produced by the old behavior is repaired by the next `bun install`: the row verifies by the presence of its directory, which the old build never created.
- Verified with:
  - `test/cli/install/bun-install.test.ts`, in the existing `resolutions` / `overrides` loop: `links a <plain|nested> "<field>" file: rule applied to a registry package's dependency` (dummy-registry `is-even` requiring `is-odd`, rule pointing `is-odd` at `vendor/is-odd`; asserts the registry is never asked for `is-odd`, the lockfile row, the layout under `is-even/node_modules`, and that `require("is-even")` runs the vendored copy, after a fresh resolve, an install on top of it, and a `--frozen-lockfile` install from the lockfile), `fails when a file: override for a registry package's dependency names a missing folder` (error text, exit 1, nothing linked), and `isolated linker: ...` for both rule shapes, which pass before and after and pin the parity. The four hoisted tests and the missing-folder test fail on main (`[]` where `["is-odd"]` is expected; exit 0 where 1 is expected).
  - `test/cli/install/bun-install-registry.test.ts`, `transitive file dependencies`: `a root override redirects a registry package's own file: dependency to a folder in the project` (`file-dep@1.0.0` declares `files: file:./the-files`; the override wins and the vendored folder's entries are what gets linked, fresh and frozen; fails on main with ENOENT) and `a scoped override for another dependent leaves a registry package's own file: dependency alone` (passes before and after; guards the per-edge predicate).
  - Also run with the change: `bun-install.test.ts -t "file:|folder|override|resolutions|transitive"` (38 pass), all of `transitive file dependencies` in `bun-install-registry.test.ts`, `nested-overrides.test.ts` (144 pass), `overrides.test.ts`, and the override / `file:` subset of `isolated-install.test.ts`.
- #38816 rewords the comment directly below the changed lines and the `is_folder_tree_id` doc comment above the new helper; whichever lands second needs a trivial rebase. #38856 (isolated linker) currently keys the same base decision on `contains_name`, so under it a nested rule would regress the isolated parity test added here; the per-edge helper from this PR is the drop-in replacement.

### Background

- A `file:` dependency on a directory resolves to `Resolution::Folder`, whose payload is a path string with one of two bases. Manifests that live in the project (root, workspaces, local `file:` packages, and the root's `overrides` / `resolutions`) produce project-relative paths; a registry manifest (`Package::from_npm`) stores the path as declared, relative to the package that declared it, because that folder only exists inside the installed package.
- Folder packages are never hoisted: the tree builder places each one in the `node_modules` of the package that depends on it, which is why the row shows up as `pkg/sub` and why the installer has to know which base a given row uses.
- For a dependency not declared by the root or a workspace, the resolver records a stub package (name plus path, no dependencies) without reading the folder, so a missing target can only be noticed while installing.
- `OverrideMap` holds the root's rules: plain rules (`"sub": ...`, apply to every edge of that name) and scoped rules (`"pkg>sub"`, `{"pkg": {"sub": ...}}`, `"sub@^1"`, apply to some edges). `OverrideMap::get(lockfile, dependency_id, name_hash)` returns the rule the resolver applies to one edge; `contains_name` only reports plain rules and is what the escape checks use to trust a path.
- The hoisted installer installs transitive folder rows as a directory of per-file symlinks into the source folder; `installer.cache_dir` is the directory the source path is opened relative to.

<details>
<summary>Repro (no network, 1.4.0-canary and main)</summary>

```sh
mkdir -p app/vendor/sub app/src/package && cd app
echo '{"name":"app","dependencies":{"pkg":"file:./pkg.tgz"},"overrides":{"sub":"file:./vendor/sub"}}' > package.json
echo '{"name":"pkg","version":"1.0.0","dependencies":{"sub":"^1.0.0"}}' > src/package/package.json
echo 'module.exports = require("sub")' > src/package/index.js
tar -C src -czf pkg.tgz package
echo '{"name":"sub","version":"1.0.0"}' > vendor/sub/package.json
echo 'module.exports = "vendor sub"' > vendor/sub/index.js
bun install --linker hoisted          # exit 0, "2 packages installed", node_modules/pkg/node_modules is empty
bun -e 'console.log(require("pkg"))'  # error: Cannot find package 'sub'
```

With this change the same commands link `node_modules/pkg/node_modules/sub/{index.js,package.json}` to `vendor/sub` and print `vendor sub`; the same holds for `"overrides": {"pkg": {"sub": "file:./vendor/sub"}}`, `"resolutions": {"pkg/sub": ...}` and `"overrides": {"sub@^1.0.0": ...}`, and pointing the rule at a missing folder prints `error: Could not find folder "file:./vendor/missing" for dependency "sub"` and exits 1.
</details>
