### PR TITLE
install: warn instead of failing when minimum-release-age blocks a peer dependency

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -800,7 +800,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                     if let Some(fail) = fail_fn {
                                         fail(this, dependency, id, err);
                                     } else if dependency.behavior.is_peer() {
-                                        warn_unmet_peer_dependency(this, name, &version);
+                                        warn_unmet_peer_dependency(this, name, &version, err);
                                     } else {
                                         this.log_mut()
                     .add_error_fmt(
@@ -822,7 +822,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                     if let Some(fail) = fail_fn {
                                         fail(this, dependency, id, err);
                                     } else if dependency.behavior.is_peer() {
-                                        warn_unmet_peer_dependency(this, name, &version);
+                                        warn_unmet_peer_dependency(this, name, &version, err);
                                     } else {
                                         bun_ast::add_error_pretty!(
                                             this.log_mut(),
@@ -839,6 +839,8 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                 if dependency.behavior.is_required() {
                                     if let Some(fail) = fail_fn {
                                         fail(this, dependency, id, err);
+                                    } else if dependency.behavior.is_peer() {
+                                        warn_unmet_peer_dependency(this, name, &version, err);
                                     } else {
                                         let age_gate_ms =
                                             this.options.minimum_release_age_ms.unwrap_or(0.0);
@@ -1078,19 +1080,13 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                                             find_result.package, min_age_ms,
                                                         )
                                                     {
-                                                        let package_name = this.lockfile.str(&name);
-                                                        let min_age_seconds = min_age_ms / MS_PER_S;
-                                                        let _ = this.log_mut().add_error_fmt(
-                                                            None,
-                                                            bun_ast::Loc::EMPTY,
-                                                            format_args!(
-                                                                "Version \"{}@{}\" was published within minimum release age of {} seconds",
-                                                                bstr::BStr::new(package_name),
-                                                                find_result.version.fmt(this.lockfile.buffers.string_bytes.as_slice()),
-                                                                min_age_seconds,
-                                                            ),
-                                                        );
-                                                        return Ok(());
+                                                        // Reported by the `TooRecentVersion` arm above, like a fresh manifest would be.
+                                                        resolve_result_ =
+                                                            Err(crate::Error::TooRecentVersion);
+                                                        let _ = this
+                                                            .network_dedupe_map
+                                                            .remove(&task_id);
+                                                        continue 'retry_with_new_resolve_result;
                                                     }
                                                 }
                                                 // reshaped for borrowck — `find_result`
@@ -1643,21 +1639,37 @@ pub fn enqueue_dependency_with_main_and_success_fn(
 }
 
 /// Unmet peers stay unresolved instead of failing the install; see `may_stay_unresolved`.
+/// `err` is the `NoMatchingVersion` / `DistTagNotFound` / `TooRecentVersion` the lookup returned.
 #[cold]
 #[inline(never)]
 fn warn_unmet_peer_dependency(
     this: &PackageManager,
     name: SemverString,
     version: &dependency::Version,
+    err: crate::Error,
 ) {
-    bun_ast::add_warning_pretty!(
-        this.log_mut(),
-        None,
-        bun_ast::Loc::EMPTY,
-        "No version matching \"{}\" found for peer dependency \"{}\"<r> <d>(but package exists)<r>",
-        bstr::BStr::new(this.lockfile.str(&version.literal)),
-        bstr::BStr::new(this.lockfile.str(&name)),
-    );
+    let literal = bstr::BStr::new(this.lockfile.str(&version.literal));
+    let name = bstr::BStr::new(this.lockfile.str(&name));
+    if err == crate::Error::TooRecentVersion {
+        bun_ast::add_warning_pretty!(
+            this.log_mut(),
+            None,
+            bun_ast::Loc::EMPTY,
+            "No version matching \"{}\" found for peer dependency \"{}\"<r> <d>(blocked by minimum-release-age: {} seconds)<r>",
+            literal,
+            name,
+            this.options.minimum_release_age_ms.unwrap_or(0.0) / MS_PER_S,
+        );
+    } else {
+        bun_ast::add_warning_pretty!(
+            this.log_mut(),
+            None,
+            bun_ast::Loc::EMPTY,
+            "No version matching \"{}\" found for peer dependency \"{}\"<r> <d>(but package exists)<r>",
+            literal,
+            name,
+        );
+    }
 }
 
 /// Allocate and initialise an `.extract` Task for an npm tarball.
@@ -2552,6 +2564,11 @@ fn get_or_put_resolved_package(
                 Npm::FindVersionResult::Err(err_type) => match err_type {
                     Npm::FindVersionError::TooRecent
                     | Npm::FindVersionError::AllVersionsTooRecent => {
+                        // Deferred like `NotFound` below: the peer pass may still bind the
+                        // peer to a same-named package that is already in the tree.
+                        if behavior.is_peer() && !install_peer {
+                            return Ok(None);
+                        }
                         return Err(crate::Error::TooRecentVersion);
                     }
                     Npm::FindVersionError::NotFound => None, // Handle below with existing logic

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2564,8 +2564,7 @@ fn get_or_put_resolved_package(
                 Npm::FindVersionResult::Err(err_type) => match err_type {
                     Npm::FindVersionError::TooRecent
                     | Npm::FindVersionError::AllVersionsTooRecent => {
-                        // Deferred like `NotFound` below: the peer pass may still bind the
-                        // peer to a same-named package that is already in the tree.
+                        // The peer pass may still bind it to a same-named package in the tree.
                         if behavior.is_peer() && !install_peer {
                             return Ok(None);
                         }

--- a/test/cli/install/minimum-release-age.test.ts
+++ b/test/cli/install/minimum-release-age.test.ts
@@ -2357,16 +2357,18 @@ describe("minimum-release-age", () => {
 
   // A required peer that nothing in the tree provides and that no published
   // version satisfies only warns and stays unresolved (bun-lock.test.ts, "peer
-  // no published version satisfies"). A peer whose only satisfying versions
-  // are blocked by the age gate has to end up the same way, on every path that
-  // can report the blocked lookup.
-  describe("peer dependencies", () => {
+  // no published version satisfies"). A peer whose satisfying versions are all
+  // blocked by the age gate has to end up the same way on every path that can
+  // report the blocked lookup, and each of those paths has to give the other
+  // dependency kinds the same answer as well.
+  describe("every satisfying version blocked", () => {
     const AGE_GATE = 3 * SECONDS_PER_DAY;
+    const blockedSuffix = `(blocked by minimum-release-age: ${AGE_GATE} seconds)`;
     const blockedPeerWarning = (range: string, name = "gated") =>
-      `warn: No version matching "${range}" found for peer dependency "${name}" (blocked by minimum-release-age: ${AGE_GATE} seconds)`;
+      `warn: No version matching "${range}" found for peer dependency "${name}" ${blockedSuffix}`;
 
-    // gated@2.0.0 is the only version the peers below accept and it is inside
-    // the age window; every version of `fresh` is inside it.
+    // gated@2.0.0 is the only version the dependencies below accept and it is
+    // inside the age window; every version of `fresh` is inside it.
     const registryPackages: Record<
       string,
       { time: Record<string, string>; peerDependencies?: Record<string, string> }
@@ -2461,7 +2463,7 @@ describe("minimum-release-age", () => {
       }
     }
 
-    test.concurrent("declared by a registry package", async () => {
+    test.concurrent("peer declared by a registry package", async () => {
       using registry = serveRegistry();
       using dir = createProject(registry.origin, {
         "package.json": JSON.stringify({ name: "app", dependencies: { "needs-gated": "1.0.0" } }),
@@ -2499,7 +2501,7 @@ describe("minimum-release-age", () => {
       expect(await Bun.file(`${dir}/bun.lock`).text()).toBe(lockfile);
     });
 
-    test.concurrent("declared by the root package and a workspace (range, exact pin, dist-tag)", async () => {
+    test.concurrent("peers declared by the root package and a workspace (range, exact pin, dist-tag)", async () => {
       using registry = serveRegistry();
       using dir = createProject(registry.origin, {
         "package.json": JSON.stringify({
@@ -2549,60 +2551,86 @@ describe("minimum-release-age", () => {
       expect(await Bun.file(`${dir}/bun.lock`).text()).toBe(lockfile);
     });
 
-    test.concurrent("exact pin answered from an expired cached manifest", async () => {
+    // An exact pin whose cached manifest has expired is answered from that
+    // manifest instead of being looked up again, which is a separate place the
+    // blocked version gets reported from. BUN_MANIFEST_CACHE=1 keeps writing
+    // the cache but treats everything in it as expired, so the second install
+    // of `gated@2.0.0` (declared as `group`) takes that path; it has to say the
+    // same thing the first install said from the fresh manifest.
+    const staleManifests = { env: { BUN_MANIFEST_CACHE: "1" } };
+    async function expectSameAnswerFromExpiredManifest(
+      group: "dependencies" | "optionalDependencies" | "peerDependencies",
+      expectResult: (result: InstallResult) => void,
+    ) {
       using registry = serveRegistry();
       using dir = createProject(registry.origin, {
-        "package.json": JSON.stringify({ name: "app", peerDependencies: { gated: "2.0.0" } }),
+        "package.json": JSON.stringify({ name: "app", [group]: { gated: "2.0.0" } }),
       });
-      // Keeps writing manifests to the cache but treats every cached one as
-      // expired, which is how an exact pin ends up being answered from the
-      // stale manifest instead of from a fresh lookup.
-      const staleManifests = { env: { BUN_MANIFEST_CACHE: "1" } };
 
-      const expectWarnedAndLeftOut = ({ stderr, exitCode }: InstallResult) => {
-        expect(stderr).toContain(blockedPeerWarning("2.0.0"));
-        expect(stderr).not.toContain("error:");
-        expect(exitCode).toBe(0);
-      };
-
-      await installUntilManifestsCached(String(dir), 1, expectWarnedAndLeftOut, staleManifests);
+      await installUntilManifestsCached(String(dir), 1, expectResult, staleManifests);
       expect(registry.requests).toContain("/gated");
 
       await reResolve(String(dir));
       registry.requests.length = 0;
-      expectWarnedAndLeftOut(await install(String(dir), staleManifests));
+      expectResult(await install(String(dir), staleManifests));
       expect(registry.requests).toEqual([]);
-    });
+    }
 
-    test.concurrent("bound to the version already in the tree, with and without a warm manifest cache", async () => {
-      using registry = serveRegistry();
-      using dir = createProject(registry.origin, {
-        "package.json": JSON.stringify({
-          name: "app",
-          dependencies: { gated: "^1.0.0", "needs-gated": "1.0.0" },
-        }),
-      });
-
-      const expectBoundToInstalledVersion = ({ stderr, exitCode }: InstallResult) => {
-        expect(stderr).toContain('warn: incorrect peer dependency "gated@1.0.0"');
-        expect(stderr).not.toContain("blocked by minimum-release-age");
+    test.concurrent("peer exact pin answered from an expired cached manifest", async () => {
+      await expectSameAnswerFromExpiredManifest("peerDependencies", ({ stderr, exitCode }) => {
+        expect(stderr).toContain(blockedPeerWarning("2.0.0"));
         expect(stderr).not.toContain("error:");
         expect(exitCode).toBe(0);
-      };
-
-      await installUntilManifestsCached(String(dir), 2, expectBoundToInstalledVersion);
-      const lockfile = await Bun.file(`${dir}/bun.lock`).text();
-      expect(lockfile).toContain('"gated@1.0.0"');
-
-      // With both manifests in the cache the peer is looked up synchronously
-      // while regular dependencies are still being resolved, before the pass
-      // that binds peers to what the tree contains.
-      await reResolve(String(dir));
-      registry.requests.length = 0;
-      expectBoundToInstalledVersion(await install(String(dir)));
-      expect(registry.requests).toEqual([]);
-      expect(await Bun.file(`${dir}/bun.lock`).text()).toBe(lockfile);
+      });
     });
+
+    test.concurrent("regular exact pin answered from an expired cached manifest", async () => {
+      await expectSameAnswerFromExpiredManifest("dependencies", ({ stderr, exitCode }) => {
+        expect(stderr).toContain(`error: No version matching`);
+        expect(stderr).toContain(blockedSuffix);
+        expect(exitCode).toBe(1);
+      });
+    });
+
+    test.concurrent("optional exact pin answered from an expired cached manifest", async () => {
+      await expectSameAnswerFromExpiredManifest("optionalDependencies", ({ stderr, exitCode }) => {
+        expect(stderr).not.toContain("error:");
+        expect(exitCode).toBe(0);
+      });
+    });
+
+    test.concurrent(
+      "peer bound to the version already in the tree, with and without a warm manifest cache",
+      async () => {
+        using registry = serveRegistry();
+        using dir = createProject(registry.origin, {
+          "package.json": JSON.stringify({
+            name: "app",
+            dependencies: { gated: "^1.0.0", "needs-gated": "1.0.0" },
+          }),
+        });
+
+        const expectBoundToInstalledVersion = ({ stderr, exitCode }: InstallResult) => {
+          expect(stderr).toContain('warn: incorrect peer dependency "gated@1.0.0"');
+          expect(stderr).not.toContain("blocked by minimum-release-age");
+          expect(stderr).not.toContain("error:");
+          expect(exitCode).toBe(0);
+        };
+
+        await installUntilManifestsCached(String(dir), 2, expectBoundToInstalledVersion);
+        const lockfile = await Bun.file(`${dir}/bun.lock`).text();
+        expect(lockfile).toContain('"gated@1.0.0"');
+
+        // With both manifests in the cache the peer is looked up synchronously
+        // while regular dependencies are still being resolved, before the pass
+        // that binds peers to what the tree contains.
+        await reResolve(String(dir));
+        registry.requests.length = 0;
+        expectBoundToInstalledVersion(await install(String(dir)));
+        expect(registry.requests).toEqual([]);
+        expect(await Bun.file(`${dir}/bun.lock`).text()).toBe(lockfile);
+      },
+    );
   });
 
   describe("clock skew scenarios", () => {

--- a/test/cli/install/minimum-release-age.test.ts
+++ b/test/cli/install/minimum-release-age.test.ts
@@ -1,7 +1,7 @@
 import type { Server } from "bun";
 import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
-import { rm } from "node:fs/promises";
+import { readdir, rm } from "node:fs/promises";
 
 // These tests drive real `bun install` runs against a mock registry, which is
 // slow under the debug/ASAN build — give them the same generous timeout the
@@ -2437,6 +2437,30 @@ describe("minimum-release-age", () => {
       await rm(`${dir}/node_modules`, { recursive: true, force: true });
     }
 
+    type InstallOptions = Parameters<typeof install>[1];
+    type InstallResult = Awaited<ReturnType<typeof install>>;
+
+    // `bun install` writes fetched manifests to the cache from a background
+    // thread and does not wait for that on exit, so a small install can finish
+    // before its manifests are on disk. Resolve from scratch until `manifests`
+    // of them are; every run has to produce the same result.
+    async function installUntilManifestsCached(
+      dir: string,
+      manifests: number,
+      expectResult: (result: InstallResult) => void,
+      options?: InstallOptions,
+    ) {
+      for (let attempt = 0; ; attempt++) {
+        expectResult(await install(dir, options));
+        const cached = (await readdir(`${dir}/.bun-cache`).catch((): string[] => [])).filter(name =>
+          name.endsWith(".npm"),
+        );
+        if (cached.length >= manifests) return;
+        if (attempt === 20) throw new Error(`only ${cached.length} of ${manifests} manifests were cached`);
+        await reResolve(dir);
+      }
+    }
+
     test.concurrent("declared by a registry package", async () => {
       using registry = serveRegistry();
       using dir = createProject(registry.origin, {
@@ -2535,17 +2559,18 @@ describe("minimum-release-age", () => {
       // stale manifest instead of from a fresh lookup.
       const staleManifests = { env: { BUN_MANIFEST_CACHE: "1" } };
 
-      let { stderr, exitCode } = await install(String(dir), staleManifests);
-      expect(stderr).toContain(blockedPeerWarning("2.0.0"));
-      expect(exitCode).toBe(0);
-      expect(registry.requests).toEqual(["/gated"]);
+      const expectWarnedAndLeftOut = ({ stderr, exitCode }: InstallResult) => {
+        expect(stderr).toContain(blockedPeerWarning("2.0.0"));
+        expect(stderr).not.toContain("error:");
+        expect(exitCode).toBe(0);
+      };
+
+      await installUntilManifestsCached(String(dir), 1, expectWarnedAndLeftOut, staleManifests);
+      expect(registry.requests).toContain("/gated");
 
       await reResolve(String(dir));
       registry.requests.length = 0;
-      ({ stderr, exitCode } = await install(String(dir), staleManifests));
-      expect(stderr).toContain(blockedPeerWarning("2.0.0"));
-      expect(stderr).not.toContain("error:");
-      expect(exitCode).toBe(0);
+      expectWarnedAndLeftOut(await install(String(dir), staleManifests));
       expect(registry.requests).toEqual([]);
     });
 
@@ -2558,14 +2583,14 @@ describe("minimum-release-age", () => {
         }),
       });
 
-      const expectBoundToInstalledVersion = ({ stderr, exitCode }: { stderr: string; exitCode: number }) => {
+      const expectBoundToInstalledVersion = ({ stderr, exitCode }: InstallResult) => {
         expect(stderr).toContain('warn: incorrect peer dependency "gated@1.0.0"');
         expect(stderr).not.toContain("blocked by minimum-release-age");
         expect(stderr).not.toContain("error:");
         expect(exitCode).toBe(0);
       };
 
-      expectBoundToInstalledVersion(await install(String(dir)));
+      await installUntilManifestsCached(String(dir), 2, expectBoundToInstalledVersion);
       const lockfile = await Bun.file(`${dir}/bun.lock`).text();
       expect(lockfile).toContain('"gated@1.0.0"');
 

--- a/test/cli/install/minimum-release-age.test.ts
+++ b/test/cli/install/minimum-release-age.test.ts
@@ -1,6 +1,7 @@
 import type { Server } from "bun";
 import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+import { rm } from "node:fs/promises";
 
 // These tests drive real `bun install` runs against a mock registry, which is
 // slow under the debug/ASAN build — give them the same generous timeout the
@@ -2351,6 +2352,231 @@ describe("minimum-release-age", () => {
       expect(lockfile).toContain("regular-package@2.1.0");
       expect(lockfile).toContain("bugfix-package@1.0.0");
       expect(lockfile).toContain("@scope/scoped-package@1.5.0");
+    });
+  });
+
+  // A required peer that nothing in the tree provides and that no published
+  // version satisfies only warns and stays unresolved (bun-lock.test.ts, "peer
+  // no published version satisfies"). A peer whose only satisfying versions
+  // are blocked by the age gate has to end up the same way, on every path that
+  // can report the blocked lookup.
+  describe("peer dependencies", () => {
+    const AGE_GATE = 3 * SECONDS_PER_DAY;
+    const blockedPeerWarning = (range: string, name = "gated") =>
+      `warn: No version matching "${range}" found for peer dependency "${name}" (blocked by minimum-release-age: ${AGE_GATE} seconds)`;
+
+    // gated@2.0.0 is the only version the peers below accept and it is inside
+    // the age window; every version of `fresh` is inside it.
+    const registryPackages: Record<
+      string,
+      { time: Record<string, string>; peerDependencies?: Record<string, string> }
+    > = {
+      gated: { time: { "1.0.0": daysAgo(30), "2.0.0": daysAgo(1) } },
+      fresh: { time: { "1.0.0": daysAgo(1) } },
+      "needs-gated": { time: { "1.0.0": daysAgo(30) }, peerDependencies: { gated: "^2.0.0" } },
+    };
+
+    function serveRegistry() {
+      const requests: string[] = [];
+      const server = Bun.serve({
+        port: 0,
+        fetch(req) {
+          const { origin, pathname } = new URL(req.url);
+          requests.push(pathname);
+          const tarball = pathname.match(/^\/([^/]+)\/-\/\1-(\d+\.\d+\.\d+)\.tgz$/);
+          if (tarball) return new Response(createTarball(tarball[1], tarball[2]));
+          const name = pathname.slice(1);
+          const pkg = registryPackages[name];
+          if (!pkg) return new Response("Not Found", { status: 404 });
+          const versions: Record<string, unknown> = {};
+          for (const version of Object.keys(pkg.time)) {
+            versions[version] = {
+              name,
+              version,
+              dist: { tarball: `${origin}/${name}/-/${name}-${version}.tgz` },
+              peerDependencies: pkg.peerDependencies,
+            };
+          }
+          return Response.json({
+            name,
+            "dist-tags": { latest: Object.keys(pkg.time).at(-1) },
+            versions,
+            time: pkg.time,
+          });
+        },
+      });
+      return {
+        origin: server.url.origin,
+        requests,
+        [Symbol.dispose]() {
+          server.stop(true);
+        },
+      };
+    }
+
+    function createProject(registryOrigin: string, files: Record<string, string>) {
+      return tempDir("age-gated-peer", { ...files, ".npmrc": `registry=${registryOrigin}` });
+    }
+
+    async function install(dir: string, { args = [] as string[], env = {} as Record<string, string> } = {}) {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "install", "--minimum-release-age", `${AGE_GATE}`, ...args],
+        cwd: dir,
+        // One manifest/tarball cache per project, so the second install of a
+        // test sees exactly what its first install cached.
+        env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: `${dir}/.bun-cache`, ...env },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      return { stderr, exitCode };
+    }
+
+    async function reResolve(dir: string) {
+      await rm(`${dir}/bun.lock`, { force: true });
+      await rm(`${dir}/node_modules`, { recursive: true, force: true });
+    }
+
+    test.concurrent("declared by a registry package", async () => {
+      using registry = serveRegistry();
+      using dir = createProject(registry.origin, {
+        "package.json": JSON.stringify({ name: "app", dependencies: { "needs-gated": "1.0.0" } }),
+      });
+
+      let { stderr, exitCode } = await install(String(dir));
+      expect(stderr).toContain(blockedPeerWarning("^2.0.0"));
+      expect(stderr).not.toContain("error:");
+      expect(exitCode).toBe(0);
+      expect(await Bun.file(`${dir}/node_modules/needs-gated/package.json`).exists()).toBeTrue();
+      expect(await Bun.file(`${dir}/node_modules/gated/package.json`).exists()).toBeFalse();
+      const lockfile = await Bun.file(`${dir}/bun.lock`).text();
+      expect(lockfile.replaceAll(registry.origin, "<registry>")).toMatchInlineSnapshot(`
+        "{
+          "lockfileVersion": 1,
+          "configVersion": 1,
+          "workspaces": {
+            "": {
+              "name": "app",
+              "dependencies": {
+                "needs-gated": "1.0.0",
+              },
+            },
+          },
+          "packages": {
+            "needs-gated": ["needs-gated@1.0.0", "<registry>/needs-gated/-/needs-gated-1.0.0.tgz", { "peerDependencies": { "gated": "^2.0.0" } }, ""],
+          }
+        }
+        "
+      `);
+
+      ({ stderr, exitCode } = await install(String(dir), { args: ["--frozen-lockfile"] }));
+      expect(stderr).not.toContain("error:");
+      expect(exitCode).toBe(0);
+      expect(await Bun.file(`${dir}/bun.lock`).text()).toBe(lockfile);
+    });
+
+    test.concurrent("declared by the root package and a workspace (range, exact pin, dist-tag)", async () => {
+      using registry = serveRegistry();
+      using dir = createProject(registry.origin, {
+        "package.json": JSON.stringify({
+          name: "app",
+          workspaces: ["packages/*"],
+          peerDependencies: { gated: "^2.0.0", fresh: "latest" },
+        }),
+        "packages/ws/package.json": JSON.stringify({ name: "ws", peerDependencies: { gated: "2.0.0" } }),
+      });
+
+      let { stderr, exitCode } = await install(String(dir));
+      expect(stderr).toContain(blockedPeerWarning("^2.0.0"));
+      expect(stderr).toContain(blockedPeerWarning("2.0.0"));
+      expect(stderr).toContain(blockedPeerWarning("latest", "fresh"));
+      expect(stderr).not.toContain("error:");
+      expect(exitCode).toBe(0);
+      const lockfile = await Bun.file(`${dir}/bun.lock`).text();
+      expect(lockfile).toMatchInlineSnapshot(`
+        "{
+          "lockfileVersion": 2,
+          "configVersion": 1,
+          "workspaces": {
+            "": {
+              "name": "app",
+              "peerDependencies": {
+                "fresh": "latest",
+                "gated": "^2.0.0",
+              },
+            },
+            "packages/ws": {
+              "name": "ws",
+              "peerDependencies": {
+                "gated": "2.0.0",
+              },
+            },
+          },
+          "packages": {
+            "ws": ["ws@workspace:packages/ws"],
+          }
+        }
+        "
+      `);
+
+      ({ stderr, exitCode } = await install(String(dir), { args: ["--frozen-lockfile"] }));
+      expect(stderr).not.toContain("error:");
+      expect(exitCode).toBe(0);
+      expect(await Bun.file(`${dir}/bun.lock`).text()).toBe(lockfile);
+    });
+
+    test.concurrent("exact pin answered from an expired cached manifest", async () => {
+      using registry = serveRegistry();
+      using dir = createProject(registry.origin, {
+        "package.json": JSON.stringify({ name: "app", peerDependencies: { gated: "2.0.0" } }),
+      });
+      // Keeps writing manifests to the cache but treats every cached one as
+      // expired, which is how an exact pin ends up being answered from the
+      // stale manifest instead of from a fresh lookup.
+      const staleManifests = { env: { BUN_MANIFEST_CACHE: "1" } };
+
+      let { stderr, exitCode } = await install(String(dir), staleManifests);
+      expect(stderr).toContain(blockedPeerWarning("2.0.0"));
+      expect(exitCode).toBe(0);
+      expect(registry.requests).toEqual(["/gated"]);
+
+      await reResolve(String(dir));
+      registry.requests.length = 0;
+      ({ stderr, exitCode } = await install(String(dir), staleManifests));
+      expect(stderr).toContain(blockedPeerWarning("2.0.0"));
+      expect(stderr).not.toContain("error:");
+      expect(exitCode).toBe(0);
+      expect(registry.requests).toEqual([]);
+    });
+
+    test.concurrent("bound to the version already in the tree, with and without a warm manifest cache", async () => {
+      using registry = serveRegistry();
+      using dir = createProject(registry.origin, {
+        "package.json": JSON.stringify({
+          name: "app",
+          dependencies: { gated: "^1.0.0", "needs-gated": "1.0.0" },
+        }),
+      });
+
+      const expectBoundToInstalledVersion = ({ stderr, exitCode }: { stderr: string; exitCode: number }) => {
+        expect(stderr).toContain('warn: incorrect peer dependency "gated@1.0.0"');
+        expect(stderr).not.toContain("blocked by minimum-release-age");
+        expect(stderr).not.toContain("error:");
+        expect(exitCode).toBe(0);
+      };
+
+      expectBoundToInstalledVersion(await install(String(dir)));
+      const lockfile = await Bun.file(`${dir}/bun.lock`).text();
+      expect(lockfile).toContain('"gated@1.0.0"');
+
+      // With both manifests in the cache the peer is looked up synchronously
+      // while regular dependencies are still being resolved, before the pass
+      // that binds peers to what the tree contains.
+      await reResolve(String(dir));
+      registry.requests.length = 0;
+      expectBoundToInstalledVersion(await install(String(dir)));
+      expect(registry.requests).toEqual([]);
+      expect(await Bun.file(`${dir}/bun.lock`).text()).toBe(lockfile);
     });
   });
 

--- a/test/cli/install/minimum-release-age.test.ts
+++ b/test/cli/install/minimum-release-age.test.ts
@@ -2425,7 +2425,7 @@ describe("minimum-release-age", () => {
         // One manifest/tarball cache per project, so the second install of a
         // test sees exactly what its first install cached.
         env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: `${dir}/.bun-cache`, ...env },
-        stdout: "pipe",
+        stdout: "ignore",
         stderr: "pipe",
       });
       const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);


### PR DESCRIPTION
### Problem
- A required `peerDependencies` entry that nothing in the tree provides, and whose only satisfying versions were published inside `--minimum-release-age` (or bunfig `install.minimumReleaseAge`), fails `bun install`: `error: No version matching "gated" found for specifier "^2.0.0" (blocked by minimum-release-age: 259200 seconds)`, exit 1, no lockfile written.
- The same entry with a range that matches nothing at all only warns since #38851 (`warn: No version matching "^3.0.0" found for peer dependency "gated" (but package exists)`), exit 0, and the lockfile loads back. Both are the same situation for a peer: the registry has the package, but nothing the peer accepts can be installed.
- Cause 1, `src/install/PackageManager/PackageManagerEnqueue.rs`, the `TooRecentVersion` arm of `enqueue_dependency_with_main_and_success_fn`: #38851 added the `is_peer()` branch to the `NoMatchingVersion` and `DistTagNotFound` arms but not to this one, and peers count as required, so it reaches `add_error_pretty!`.
- Cause 2, `get_or_put_resolved_package`: during the regular pass a peer lookup that ends in `NotFound` returns `Ok(None)`, which parks the peer for the peer pass; one that ends in `TooRecent` returns the error immediately. So whether a peer is bound to the same-named package already in the tree depends on whether that package's manifest happened to be loaded when the peer was looked up. Repro: `dependencies: { gated: "^1.0.0", "needs-gated": "1.0.0" }` where `needs-gated` has peer `gated@^2.0.0`. A cold install usually binds the peer to `gated@1.0.0` (`warn: incorrect peer dependency "gated@1.0.0"`, exit 0); the next install from scratch, with the manifests cached, fails with the error above.
- Cause 3, the exact-version shortcut in the same function (`// If it's an exact package version already living in the cache`): when the cached manifest is expired it resolves an exact pin without a network round trip, and if that version is inside the age window it logs its own error, `error: Version "gated@2.0.0" was published within minimum release age of 259200 seconds`, regardless of what kind of dependency it is. An exact peer pin (`peerDependencies: { gated: "2.0.0" }`) fails here on every install after the first one. The shortcut also returns without removing the manifest task it had just registered in `network_dedupe_map`, so a later dependency on the same package would attach itself to a task that never runs.
- The argument order in the error text (name and range swapped) is a separate problem fixed by #37895; this PR does not touch those lines.

### Fix
- `TooRecentVersion` arm: peers get the same `else if is_peer()` branch as the two arms beside it. The warning names the gate: `warn: No version matching "^2.0.0" found for peer dependency "gated" (blocked by minimum-release-age: 259200 seconds)`. `warn_unmet_peer_dependency` takes the error to pick the parenthetical; the `(but package exists)` text for the other two arms is unchanged.
- `get_or_put_resolved_package`: a blocked lookup for a peer during the regular pass returns `Ok(None)` under the same `is_peer() && !install_peer` condition the `NotFound` path uses. The peer pass then binds the peer to a same-named package in the tree (satisfying or not) and only consults the manifest, and warns, when there is none. The outcome no longer depends on manifest arrival order or cache state.
- Exact-version shortcut: a blocked version sets `resolve_result_ = Err(TooRecentVersion)` and re-enters the match, the way the shortcut's success path already re-enters with `Ok(Some(..))`, and removes the `network_dedupe_map` entry as that path does. One arm now decides what a blocked version means for every dependency kind, whether the manifest was fresh or came from the expired cache: peers warn, optional dependencies are skipped, runtime root dependencies go through `fail_fn`, and regular dependencies get the same error text they get with a fresh manifest (`No version matching ... (blocked by minimum-release-age: N seconds)`) instead of the `was published within minimum release age` variant, which is deleted. That variant also formatted the version's prerelease tag against the lockfile's string buffer rather than the manifest's.
- Why warning is right: the install leaves the edge unresolved exactly as it does for the `NotFound` shape, and everything downstream already handles that state (`verify_resolutions` skips unresolved peers, the lockfile parser accepts them via `may_stay_unresolved`, both linkers skip them). Failing instead would make a peer that a *stricter* setting cannot satisfy fatal while one that *nothing* can satisfy is not. The age gate still does its job: the blocked version is not installed, and the warning says why it is missing.
- Tests: `test/cli/install/minimum-release-age.test.ts`, new `every satisfying version blocked` block, against an in-process registry with publish dates. Without the `src/` change four of the six fail; with it all pass. Reverting only the deferral hunk fails only "peer bound to the version already in the tree" (the peer is warned about and left unbound although `gated@1.0.0` is installed); reverting only the shortcut hunk fails only the three "answered from an expired cached manifest" tests.
  - "peer declared by a registry package": warning, `gated` not installed, lockfile snapshot, `--frozen-lockfile` passes and leaves the lockfile unchanged.
  - "peers declared by the root package and a workspace": range, exact pin and dist-tag peers all warn, exit 0, lockfile snapshot, `--frozen-lockfile` passes.
  - "peer bound to the version already in the tree": `incorrect peer dependency "gated@1.0.0"` and exit 0 both on a cold install and on a re-resolve that makes no registry request.
  - "peer / regular / optional exact pin answered from an expired cached manifest": the second install makes no registry request and says the same thing as the first: warning, the usual blocked-by-minimum-release-age error (asserted without its argument order, so it holds before and after #37895), nothing at all. Before this change the second install printed the `was published within` error in all three cases, exit 1. These tests reach the shortcut with `BUN_MANIFEST_CACHE=1`, which keeps the manifest cache but treats every entry as expired.
  - The installs that prime the cache are repeated until the manifests are on disk (`installUntilManifestsCached`): `bun install` saves manifests from a background thread and does not wait for it on exit, which made the first version of the exact-pin test flaky on two CI lanes.
  - Also ran locally: the rest of `minimum-release-age.test.ts` (55 pass), `bun-lock.test.ts` (the #38851 tests, 40 pass), the peer tests in `bun-install-registry.test.ts`, `isolated-install.test.ts` and `bun-install.test.ts`, and the age-gate tests in `bun-update-transitive.test.ts`.

### Background
- `--minimum-release-age N` makes the resolver ignore registry versions published less than N seconds ago. When nothing that satisfies a dependency is left, `Npm::PackageManifest::find_best_version_with_filter` / `find_by_dist_tag_with_filter` return `TooRecent` or `AllVersionsTooRecent`, which `get_or_put_resolved_package` turns into `crate::Error::TooRecentVersion`; a range that matches nothing in the first place is `NoMatchingVersion` (or `DistTagNotFound` for a tag). The caller has one arm per error that decides whether to log an error, log a warning, or stay silent depending on the dependency's behavior bits (required, optional, peer).
- Peer resolution runs in two passes. In the regular pass (`install_peer == false`) a peer is only bound if the exact package it would pick is already present; otherwise `Ok(None)` parks it in `peer_dependencies`. After every regular dependency has resolved, `process_peer_dependency_list` re-enqueues the parked peers with `install_peer == true`; that pass first binds the peer to any same-named package in the tree (warning `incorrect peer dependency` if it does not satisfy the range) and only then installs from the registry. An error returned during the regular pass ends the peer's resolution before that second pass happens.
- The manifest cache keeps each registry manifest on disk for 300 seconds after it was fetched. Within that window lookups are answered synchronously from the cache, which is why a second install of the same project takes different code paths from the first. A cached manifest older than that is "expired": the normal lookup ignores it and fetches again, except for the exact-version shortcut, which answers an exact pin from the expired copy to save the round trip. `BUN_MANIFEST_CACHE=1` disables the freshness check while keeping the cache, which the test uses to reach that shortcut deterministically.
- `network_dedupe_map` holds one entry per in-flight manifest download; `has_created_network_task` inserts the entry and dependencies that find it already present attach a callback to the existing task instead of starting another download. A path that inserts the entry and then decides not to download has to remove it again.

<details>
<summary>Manual runs with the released build (1.4.0-canary, registry: gated 1.0.0 thirty days old, 2.0.0 one day old; needs-gated 1.0.0 with peer gated@^2.0.0; gate 259200s)</summary>

```
# package.json: { "peerDependencies": { "gated": "^2.0.0" } }
error: No version matching "gated" found for specifier "^2.0.0" (blocked by minimum-release-age: 259200 seconds)
--- exit: 1

# package.json: { "peerDependencies": { "gated": "^3.0.0" } }   (same shape, NotFound)
--- exit: 0

# package.json: { "dependencies": { "gated": "^1.0.0", "needs-gated": "1.0.0" } }
warn: incorrect peer dependency "gated@1.0.0"
+ gated@1.0.0
+ needs-gated@1.0.0
--- exit: 0
=== rm bun.lock node_modules; install again with the manifests cached:
error: No version matching "gated" found for specifier "^2.0.0" (blocked by minimum-release-age: 259200 seconds)
--- exit: 1

# package.json: { "peerDependencies": { "gated": "2.0.0" } }, BUN_MANIFEST_CACHE=1, second install:
error: Version "gated@2.0.0" was published within minimum release age of 259200 seconds
--- exit: 1
```

</details>
