### PR TITLE
glob: stop a non-segment `**` from swallowing the `**` segments after it in match()

### DIFF
--- a/src/glob/matcher.rs
+++ b/src/glob/matcher.rs
@@ -132,9 +132,7 @@ struct Wildcard {
 ///     Matches zero or more characters, except for path separators ('/' or '\').
 /// "**"
 ///     Matches zero or more characters, including path separators.
-///     Must be a complete path segment, i.e. preceded by a path separator (or
-///     the start of the pattern) and followed by one (or the end of the
-///     pattern). Anywhere else ("a**") it behaves like "*".
+///     Must be a whole path segment ("a/**/b"); elsewhere ("a**") it acts like "*".
 /// "[ab]"
 ///     Matches one of the characters contained in the brackets.
 ///     Character ranges (e.g. "[a-z]") are also supported.
@@ -200,18 +198,10 @@ fn glob_match_impl(
                 'to_else: {
                     match ch {
                         b'*' => {
-                            // `**` is a globstar only at the start of a segment: after a `/`
-                            // or at `glob_start` (the pattern or, as in `{**/a,**/b}`, the
-                            // brace branch; `<=` because backtracking out of a branch can
-                            // land before its start). Anywhere else (`a**`) each `*` is a
-                            // plain wildcard, and this must be decided before
-                            // `skip_globstars` folds any following `/**` segments into this
-                            // one: those belong to the rest of the pattern when this `**`
-                            // is not a globstar (`a**/**` means `a*/**`).
+                            // `a**` is `a*`, so only a globstar may absorb the `/**` segments after it.
                             let is_globstar = (state.glob_index as usize) + 1 < glob.len()
                                 && glob[state.glob_index as usize + 1] == b'*'
-                                && (state.glob_index <= glob_start
-                                    || glob[state.glob_index as usize - 1] == b'/');
+                                && starts_segment(glob, glob_start, state.glob_index);
                             if is_globstar {
                                 skip_globstars(glob, &mut state.glob_index);
                             }
@@ -678,6 +668,14 @@ fn get_unicode(c: &mut u32, clen: &mut u8, glob: &[u8], glob_index: &mut u32) ->
     }
 
     true
+}
+
+/// Whether the `**` at `glob_index` begins a path segment: it follows a `/`, or it is
+/// where the pattern (or the brace branch being matched, as in `{**/a,**/b}`) starts.
+#[inline(always)]
+fn starts_segment(glob: &[u8], glob_start: u32, glob_index: u32) -> bool {
+    // `<=`: a failed brace branch backtracks to `**`s that precede the branch.
+    glob_index <= glob_start || glob[glob_index as usize - 1] == b'/'
 }
 
 #[inline(always)]

--- a/src/glob/matcher.rs
+++ b/src/glob/matcher.rs
@@ -132,8 +132,9 @@ struct Wildcard {
 ///     Matches zero or more characters, except for path separators ('/' or '\').
 /// "**"
 ///     Matches zero or more characters, including path separators.
-///     Must match a complete path segment, i.e. followed by a path separator or
-///     at the end of the pattern.
+///     Must be a complete path segment, i.e. preceded by a path separator (or
+///     the start of the pattern) and followed by one (or the end of the
+///     pattern). Anywhere else ("a**") it behaves like "*".
 /// "[ab]"
 ///     Matches one of the characters contained in the brackets.
 ///     Character ranges (e.g. "[a-z]") are also supported.
@@ -199,8 +200,18 @@ fn glob_match_impl(
                 'to_else: {
                     match ch {
                         b'*' => {
+                            // `**` is a globstar only at the start of a segment: after a `/`
+                            // or at `glob_start` (the pattern or, as in `{**/a,**/b}`, the
+                            // brace branch; `<=` because backtracking out of a branch can
+                            // land before its start). Anywhere else (`a**`) each `*` is a
+                            // plain wildcard, and this must be decided before
+                            // `skip_globstars` folds any following `/**` segments into this
+                            // one: those belong to the rest of the pattern when this `**`
+                            // is not a globstar (`a**/**` means `a*/**`).
                             let is_globstar = (state.glob_index as usize) + 1 < glob.len()
-                                && glob[state.glob_index as usize + 1] == b'*';
+                                && glob[state.glob_index as usize + 1] == b'*'
+                                && (state.glob_index <= glob_start
+                                    || glob[state.glob_index as usize - 1] == b'/');
                             if is_globstar {
                                 skip_globstars(glob, &mut state.glob_index);
                             }
@@ -232,13 +243,7 @@ fn glob_match_impl(
                                     continue 'main_loop;
                                 }
 
-                                // subtract glob_start from glob index before checking if length is less than 3. Given the pattern:
-                                // {**/a,**/b}
-                                // if we start at index 6 (start of **/b pattern), we don't want to index into the pattern before it
-                                if (state.glob_index.saturating_sub(glob_start) < 3
-                                    || glob[state.glob_index as usize - 3] == b'/')
-                                    && (!is_end_invalid || glob[state.glob_index as usize] == b'/')
-                                {
+                                if !is_end_invalid || glob[state.glob_index as usize] == b'/' {
                                     if is_end_invalid {
                                         state.glob_index += 1;
                                     }

--- a/test/js/bun/glob/match.test.ts
+++ b/test/js/bun/glob/match.test.ts
@@ -2021,6 +2021,71 @@ describe("Glob.match", () => {
     expect(new Glob("foo/**").match("foo/\u0041\u030A")).toBeTrue(); // "A" with ring
     expect(new Glob("foo/**").match("foo/\u00C5")).toBeTrue(); // "Å" single character
   });
+
+  test("** inside a segment stays a plain * when ** segments follow it", () => {
+    // `a**` is `a*` (see "bash extra_stars" and "trailing globstar patterns"), so
+    // `a**/**` is `a*/**`: the `/**` is its own segment and the path still needs
+    // a `/`. The matcher used to fold the following `**` segments into the inline
+    // `**` before noticing it was not a globstar, which left plain `a*` behind.
+    expect(new Glob("a**/**").match("ab")).toBeFalse();
+    expect(new Glob("a**/**").match("a")).toBeFalse();
+    expect(new Glob("a/b**/**").match("a/b")).toBeFalse();
+    expect(new Glob("?**/**").match("b")).toBeFalse();
+    expect(new Glob("[a]**/**").match("a")).toBeFalse();
+    expect(new Glob("**/a**/**").match("x/ab")).toBeFalse();
+    expect(new Glob("{x,a}**/**").match("ab")).toBeFalse();
+    expect(new Glob("a**/**/**").match("ab")).toBeFalse();
+    expect(new Glob("a**/**/b").match("ab")).toBeFalse();
+    expect(new Glob("a**/**/*.js").match("ab.js")).toBeFalse();
+    expect(new Glob("!a**/**").match("ab")).toBeTrue();
+
+    // With the `/` present, the trailing `**` segments match as usual.
+    expect(new Glob("a**/**").match("a/")).toBeTrue();
+    expect(new Glob("a**/**").match("ab/")).toBeTrue();
+    expect(new Glob("a**/**").match("ab/c")).toBeTrue();
+    expect(new Glob("a**/**").match("ab/c/d")).toBeTrue();
+    expect(new Glob("a**/**/b").match("ab/b")).toBeTrue();
+    expect(new Glob("a**/**/b").match("ab/x/y/b")).toBeTrue();
+    expect(new Glob("a**/**/*.js").match("ab/c/d.js")).toBeTrue();
+    expect(new Glob("**/a**/**").match("x/ab/c")).toBeTrue();
+    expect(new Glob("!a**/**").match("ab/c")).toBeFalse();
+
+    // Every inline form must agree with its `*` spelling on every path.
+    const paths = [
+      "",
+      ..."a ab axb ba a/ ab/ a/b ab/b ab/c ab/c/ ab/c/d ab/x/y/b x/ab x/ab/c ab.js ab/c.js".split(" "),
+    ];
+    const spellings: [inline: string, plain: string][] = [
+      ["a**/**", "a*/**"],
+      ["a**/**/**", "a*/**/**"],
+      ["a**/**/", "a*/**/"],
+      ["a**/**/b", "a*/**/b"],
+      ["a**/**/*", "a*/**/*"],
+      ["a**/**/*.js", "a*/**/*.js"],
+      ["?**/**", "?*/**"],
+      ["[a]**/**", "[a]*/**"],
+      ["**/a**/**", "**/a*/**"],
+      ["{x,a}**/**", "{x,a}*/**"],
+      ["!a**/**", "!a*/**"],
+    ];
+    const matches = (pattern: string) => paths.map(path => ({ path, matches: new Glob(pattern).match(path) }));
+    for (const [inline, plain] of spellings) {
+      expect(matches(inline), `${inline} should match the same paths as ${plain}`).toEqual(matches(plain));
+    }
+
+    // Runs of real globstar segments still collapse into one.
+    expect(new Glob("**/**").match("a")).toBeTrue();
+    expect(new Glob("a/**/**").match("a/")).toBeTrue();
+    expect(new Glob("a/**/**/b").match("a/b")).toBeTrue();
+    expect(new Glob("a/**/**/*").match("a/")).toBeFalse();
+    expect(new Glob("{**/**/a,**/b}").match("x/y/b")).toBeTrue();
+
+    // A failing brace branch backtracks to the pattern-initial `**`, which is
+    // then re-examined from inside the branch and must still be a globstar.
+    expect(new Glob("**/{a,b}").match("x/y/b")).toBeTrue();
+    expect(new Glob("!**/{a,b}").match("x/y/b")).toBeFalse();
+    expect(new Glob("**/{a,b}").match("x/y/c")).toBeFalse();
+  });
 });
 
 function returnError(cb: () => any): Error | undefined {


### PR DESCRIPTION
### Problem

- `new Bun.Glob("a**/**").match("ab")` returns `true`. `a**` means `a*` in Bun (documented in the matcher, covered by the `a**c` / `foo**` tests), so `a**/**` means `a*/**`, which correctly returns `false` for `"ab"` (so do picomatch and bash).
- Same for every shape where a `**` that is part of a larger segment is directly followed by `**` segments: `x**/**` matches `"x"`, `?**/**` matches `"b"`, `{x,a}**/**` matches `"ab"`, `**/a**/**` matches `"x/ab"`, `a**/**/b` matches `"ab"`, and `!a**/**` gives the inverse wrong answer. `a**/b` is unaffected.
- `match()` also disagreed with `scan()`: the walker splits the pattern on `/` and never had this problem, so `a**/**` yields no entry for a file `ay` while `match("ay")` says `true`.
- Cause, `src/glob/matcher.rs`, `b'*'` arm of `glob_match_impl`: as soon as two stars are seen, `skip_globstars` folds the following `/**/` runs and a trailing `/**` into this `**`. Only afterwards does the code check whether the `**` is actually at the start of a segment (preceded by `/`, or at `glob_start`). When that check fails the `**` falls back to plain `*` behaviour, but the `/**` segments it was supposed to leave for the rest of the pattern are already gone, so `a**/**` is matched as `a*`. (Previously the check also looked behind the last `**` of the collapsed run, which is always preceded by `/`, so it passed for the wrong reason.)

### Fix

- Evaluate the segment-start condition (now the `starts_segment` helper) on the first `**` of the run, as part of `is_globstar`, before calling `skip_globstars`. A `**` that does not start a segment is now matched as two ordinary `*`s, and the `/**` segments after it are matched on their own, which is what `a*/**` does. The post-collapse check now only has to look at what follows the run.
- Correct because the collapse is only valid when the whole run is one globstar; the condition is unchanged (`glob_index <= glob_start || glob[glob_index - 1] == '/'` is exactly what the old `glob_index + 2 - glob_start < 3 || glob[glob_index + 2 - 3] == '/'` computed on an uncollapsed `**`), it is just evaluated before the collapse instead of after it. For a `**` that does start a segment nothing changes: every `**` reached by the collapse is preceded by `/`, so the old check was equivalent for them. The `<=` is still needed because a failing brace branch backtracks to a `**` that precedes the branch (`**/{a,b}`), where `glob_index` is below the branch's `glob_start`; the test pins that case.
- Relationship to #39004: that PR fixes a second, separable bug in the same rule (after backtracking out of a brace branch, `glob_start` is the wrong reference point) by replacing the `glob_start` comparison with a lookup in the brace stack, and it is written on top of this change. Either order works: if this lands first, #39004 rebases to the rule swap plus its own tests; if #39004 lands first, this PR is redundant and can be closed.
- Test: `test/js/bun/glob/match.test.ts`, "** inside a segment stays a plain * when ** segments follow it". 11 of its assertions plus each row of the `a**/**` vs `a*/**` table fail on the current release; the controls (with the `/` present, collapsed globstar runs, brace backtracking) pass before and after.
- All 30 tests in `match.test.ts` (1569 assertions, including the ported bash/micromatch star and globstar suites) pass with the debug build.
- Differential check against the previous build: 8612 patterns over an 8-token grammar x 128 paths (1,102,336 results). 438 results across 22 patterns changed, every one of them a pattern with a non-segment `**` followed by `**` segments; within that class agreement with picomatch 4 went from 2884/3328 to 3320/3328, and the 8 remaining are `!pattern` against `""`, where picomatch rejects empty input regardless of the pattern while Bun returns the complement of the un-negated pattern, as its existing negation tests require.
- `scan()` is unchanged: it matches each component separately (`a**` and `**` are separate components), so it was already right and now agrees with `match()`.
- Not changed here: `**` at the end of a brace branch (`a/{**,b}`) is still treated as `*`, and re-scanning a pattern prefix from inside a brace branch still compares against the branch's `glob_start`. Both are pre-existing and independent of this fix.

### Background

- The matcher is a backtracking matcher over the raw pattern bytes (ported from the `glob-match` crate); it does not expand braces or pre-tokenize. Each `*` records a `wildcard` resume point; `**` that qualifies as a globstar additionally records a `globstar` resume point that is allowed to cross `/`.
- "Globstar" here means a `**` that is a whole path segment: preceded by `/` (or the start of the pattern / of the brace branch being tried, which is what `glob_start` is) and followed by `/` (or the end of the pattern). Any other `**`, such as `a**` or `**b`, is defined to behave like `*`; see the `a**c`, `foo**bar` and `foo**` cases in `match.test.ts`.
- `skip_globstars` is the optimization that turns `**/**/**` into a single globstar so the matcher does not have to backtrack through equivalent segments. It is only meaningful when the first `**` of the run is itself a globstar, which is the invariant this change restores.
- `glob_start` is the index at which the current `glob_match_impl` invocation began: the pattern start (after any `!`) at top level, or the branch start when matching a brace alternative, so that `{**/a,**/b}` treats both `**` as segment starts.
