### PR TITLE
install: redact the registry URL in the manifest/tarball URL errors and keep namedRegistries credentials out of bun.lock

### DIFF
--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -4,14 +4,15 @@ use core::sync::atomic::Ordering;
 
 use crate::bun_fs::{FileSystem, FilenameStore};
 use bun_collections::HashMap;
-use bun_core::{self, fmt::quote};
-use bun_core::{MutableString, strings};
+use bun_core::fmt::{quote, redacted_npm_url};
+use bun_core::{self, MutableString, strings};
 use bun_http::{
     self as http, AsyncHTTP, HTTPClientResult, HTTPClientResultCallback, HTTPVerboseLevel,
     HeaderBuilder, async_http::Options as AsyncHTTPOptions,
 };
 use bun_threading::thread_pool::Batch;
 use bun_url::URL;
+use std::io::Write as _;
 
 use crate::extract_tarball;
 use crate::npm::{self as npm, PackageManifest};
@@ -435,6 +436,13 @@ impl bun_core::output::ErrName for ForManifestError {
     }
 }
 
+/// Redacted before `quote()`: the password scan only recognizes an unquoted URL.
+fn redacted_url(url: &[u8]) -> Vec<u8> {
+    let mut out: Vec<u8> = Vec::new();
+    let _ = write!(out, "{}", redacted_npm_url(url));
+    out
+}
+
 impl NetworkTask {
     pub(crate) fn for_manifest(
         &mut self,
@@ -471,13 +479,14 @@ impl NetworkTask {
             ));
 
             if tmp.tag() == bun_core::Tag::Dead {
+                let redacted_registry = redacted_url(scope.url.href());
                 if !is_optional {
                     log.add_error_fmt(
                         None,
                         bun_ast::Loc::EMPTY,
                         format_args!(
                             "Failed to join registry {} and package {} URLs",
-                            quote(scope.url.href()),
+                            quote(&redacted_registry),
                             quote(name),
                         ),
                     );
@@ -487,31 +496,8 @@ impl NetworkTask {
                         bun_ast::Loc::EMPTY,
                         format_args!(
                             "Failed to join registry {} and package {} URLs",
-                            quote(scope.url.href()),
+                            quote(&redacted_registry),
                             quote(name),
-                        ),
-                    );
-                }
-                return Err(ForManifestError::InvalidURL);
-            }
-
-            if !(tmp.has_prefix_comptime(b"https://") || tmp.has_prefix_comptime(b"http://")) {
-                if !is_optional {
-                    log.add_error_fmt(
-                        None,
-                        bun_ast::Loc::EMPTY,
-                        format_args!(
-                            "Registry URL must be http:// or https://\nReceived: \"{}\"",
-                            *tmp
-                        ),
-                    );
-                } else {
-                    log.add_warning_fmt(
-                        None,
-                        bun_ast::Loc::EMPTY,
-                        format_args!(
-                            "Registry URL must be http:// or https://\nReceived: \"{}\"",
-                            *tmp
                         ),
                     );
                 }
@@ -520,6 +506,30 @@ impl NetworkTask {
 
             // This actually duplicates the string! So we defer deref the WTF managed one above.
             let url_bytes = tmp.to_owned_slice().into_boxed_slice();
+
+            if !(tmp.has_prefix_comptime(b"https://") || tmp.has_prefix_comptime(b"http://")) {
+                let redacted_manifest_url = redacted_url(&url_bytes);
+                if !is_optional {
+                    log.add_error_fmt(
+                        None,
+                        bun_ast::Loc::EMPTY,
+                        format_args!(
+                            "Registry URL must be http:// or https://\nReceived: {}",
+                            quote(&redacted_manifest_url)
+                        ),
+                    );
+                } else {
+                    log.add_warning_fmt(
+                        None,
+                        bun_ast::Loc::EMPTY,
+                        format_args!(
+                            "Registry URL must be http:// or https://\nReceived: {}",
+                            quote(&redacted_manifest_url)
+                        ),
+                    );
+                }
+                return Err(ForManifestError::InvalidURL);
+            }
 
             {
                 let joined = URL::parse(&url_bytes);
@@ -532,6 +542,8 @@ impl NetworkTask {
                     || joined.get_port_auto() != registry.get_port_auto()
                     || !joined.pathname.starts_with(registry_dir)
                 {
+                    let redacted_manifest_url = redacted_url(&url_bytes);
+                    let redacted_registry = redacted_url(scope.url.href());
                     if !is_optional {
                         log.add_error_fmt(
                             None,
@@ -539,8 +551,8 @@ impl NetworkTask {
                             format_args!(
                                 "Invalid package name {}: manifest URL {} is not on registry {}",
                                 quote(name),
-                                quote(&url_bytes),
-                                quote(scope.url.href()),
+                                quote(&redacted_manifest_url),
+                                quote(&redacted_registry),
                             ),
                         );
                     } else {
@@ -550,8 +562,8 @@ impl NetworkTask {
                             format_args!(
                                 "Invalid package name {}: manifest URL {} is not on registry {}",
                                 quote(name),
-                                quote(&url_bytes),
-                                quote(scope.url.href()),
+                                quote(&redacted_manifest_url),
+                                quote(&redacted_registry),
                             ),
                         );
                     }
@@ -770,6 +782,7 @@ impl NetworkTask {
         };
 
         if !(self.url_buf.starts_with(b"https://") || self.url_buf.starts_with(b"http://")) {
+            let redacted_tarball_url = redacted_url(&self.url_buf);
             // SAFETY: `pm.log` is the long-lived `*mut Log` the package
             // manager was constructed with.
             pm.log_mut().add_error_fmt(
@@ -777,7 +790,7 @@ impl NetworkTask {
                 bun_ast::Loc::EMPTY,
                 format_args!(
                     "Expected tarball URL to start with https:// or http://, got {} while fetching package {}",
-                    quote(&self.url_buf),
+                    quote(&redacted_tarball_url),
                     quote(tarball.name.slice()),
                 ),
             );

--- a/src/install/pnpm.rs
+++ b/src/install/pnpm.rs
@@ -242,7 +242,9 @@ fn read_named_registries(
                     let key = prop.key.as_ref().expect("infallible: prop has key");
                     let value = prop.value.as_ref().expect("infallible: prop has value");
                     if let (Some(name_str), Some(url_str)) = (as_string(key), as_string(value)) {
-                        registries.put(name_str, Box::from(url_str))?;
+                        // Without its credentials: this URL is recorded in bun.lock as the tarball base.
+                        let url = crate::bun_schema::api::NpmRegistry::from_url(url_str).url;
+                        registries.put(name_str, url)?;
                     }
                 }
             }
@@ -1310,7 +1312,7 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
                                         bun_core::warn!(
                                             "fetching pnpm registry \"{}\" packages from {}; add it to bunfig.toml or .npmrc if it needs authentication",
                                             bstr::BStr::new(registry_name),
-                                            bstr::BStr::new(url)
+                                            bun_core::fmt::redacted_npm_url(url)
                                         );
                                     }
                                     &**url

--- a/test/cli/install/migration/pnpm-lock-v9.test.ts
+++ b/test/cli/install/migration/pnpm-lock-v9.test.ts
@@ -387,6 +387,65 @@ snapshots:
       `);
     });
 
+    test("credentials in a namedRegistries URL stay out of bun.lock and a token in its path is masked in the warning", async () => {
+      const password = "s3cret";
+      const token = "npm_" + "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8";
+      const { packageDir } = await verdaccio.createTestDir({
+        bunfigOpts: { linker: "hoisted" },
+        files: {
+          "package.json": JSON.stringify({ name: "named-registry-secrets", dependencies: { "no-deps": "^1.0.0" } }),
+          "pnpm-workspace.yaml": `namedRegistries:\n  work: http://carol:${password}@127.0.0.1:1/${token}/\n`,
+          "pnpm-lock.yaml": registryQualifiedNoDepsLockfile("work"),
+        },
+      });
+
+      const { stderr, exitCode } = await migrate(packageDir);
+
+      expect(stderr).toContain(
+        'warn: fetching pnpm registry "work" packages from http://127.0.0.1:1/***/; add it to bunfig.toml or .npmrc if it needs authentication',
+      );
+      expect(stderr).not.toContain(password);
+      expect(stderr).not.toContain(token);
+      expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
+      expect(exitCode).toBe(0);
+
+      // The token is part of the tarball location; the credentials are not.
+      const bunLock = await bunLockOf(packageDir);
+      expect(bunLock).toContain(
+        `["no-deps@1.0.1", "http://127.0.0.1:1/${token}/no-deps/-/no-deps-1.0.1.tgz", {}, "${NO_DEPS_1_0_1_INTEGRITY}"]`,
+      );
+      expect(bunLock).not.toContain(password);
+    });
+
+    test("namedRegistries entry naming the configured registry with credentials in the URL needs no warning", async () => {
+      const { packageDir } = await verdaccio.createTestDir({
+        bunfigOpts: { linker: "hoisted" },
+        files: {
+          "package.json": JSON.stringify({ name: "named-registry-same-creds", dependencies: { "no-deps": "^1.0.0" } }),
+          "pnpm-workspace.yaml": `namedRegistries:\n  work: ${verdaccio.registryUrl().replace("http://", "http://carol:s3cret@")}\n`,
+          "pnpm-lock.yaml": registryQualifiedNoDepsLockfile("work"),
+        },
+      });
+
+      const { stderr, exitCode } = await migrate(packageDir);
+
+      expect(stderr).not.toContain("pnpm registry");
+      expect(stderr).not.toContain("warn:");
+      expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
+      expect(exitCode).toBe(0);
+
+      const bunLock = await bunLockOf(packageDir);
+      expect(bunLock).toContain(`"no-deps@1.0.1"`);
+      expect(bunLock).not.toContain("s3cret");
+      expect(bunLock).not.toContain("work:");
+
+      const install = await run(packageDir, "install", "--frozen-lockfile");
+
+      expect(install.stderr).not.toContain("error:");
+      expect(install.exitCode).toBe(0);
+      expect(nodeModulesPackages(packageDir)).toMatchInlineSnapshot(`"node_modules/no-deps/no-deps@1.0.1"`);
+    });
+
     test("two packages from one unknown registry warn once", async () => {
       const { packageDir } = await verdaccio.createTestDir({
         bunfigOpts: { linker: "hoisted" },

--- a/test/cli/install/redacted-config-logs.test.ts
+++ b/test/cli/install/redacted-config-logs.test.ts
@@ -141,6 +141,108 @@ test("bunfig password value is masked in config error output", async () => {
   expect(coloredExit).toBe(1);
 });
 
+// The config loaders split user:password@ off a registry URL, but a token
+// written as a path segment stays part of it, and these messages echo that
+// URL (or the manifest / tarball URL built from it) when no request can be
+// made out of it. None of the cases below sends a request.
+describe.concurrent("bun install masks the configured registry URL in the messages that echo it", () => {
+  const token = "npm_" + "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8";
+  const packageJson = (deps: Record<string, Record<string, string>>) => JSON.stringify({ name: "app", ...deps });
+
+  const cases: {
+    title: string;
+    registry: string;
+    files: Record<string, string>;
+    expected: string;
+    exitCode: number;
+  }[] = [
+    {
+      title: "registry URL that is not a valid base URL (dependency)",
+      registry: `http://ex ample.org/${token}/`,
+      files: { "package.json": packageJson({ dependencies: { notapackage: "1.0.0" } }) },
+      expected: `error: Failed to join registry "http://ex ample.org/***/" and package "notapackage" URLs\n`,
+      exitCode: 1,
+    },
+    {
+      title: "registry URL that is not a valid base URL (optional dependency)",
+      registry: `http://ex ample.org/${token}/`,
+      files: { "package.json": packageJson({ optionalDependencies: { notapackage: "1.0.0" } }) },
+      expected: `warn: Failed to join registry "http://ex ample.org/***/" and package "notapackage" URLs\n`,
+      exitCode: 0,
+    },
+    // The alias makes ".." the name the manifest is requested for. It joins to
+    // the registry's parent directory, so the manifest URL no longer contains
+    // the token segment; the registry URL printed next to it does.
+    {
+      title: "manifest URL outside the registry directory (dependency)",
+      registry: `http://127.0.0.1:1/${token}/`,
+      files: { "package.json": packageJson({ dependencies: { innocent: "npm:..@1.0.0" } }) },
+      expected: `error: Invalid package name "..": manifest URL "http://127.0.0.1:1/" is not on registry "http://127.0.0.1:1/***/"\n`,
+      exitCode: 1,
+    },
+    {
+      title: "manifest URL outside the registry directory (optional dependency)",
+      registry: `http://127.0.0.1:1/${token}/`,
+      files: { "package.json": packageJson({ optionalDependencies: { innocent: "npm:..@1.0.0" } }) },
+      expected: `warn: Invalid package name "..": manifest URL "http://127.0.0.1:1/" is not on registry "http://127.0.0.1:1/***/"\n`,
+      exitCode: 0,
+    },
+    {
+      title: "registry URL with a non-http scheme (dependency)",
+      registry: `htp://127.0.0.1:1/${token}/`,
+      files: { "package.json": packageJson({ dependencies: { notapackage: "1.0.0" } }) },
+      expected: `error: Registry URL must be http:// or https://\nReceived: "htp://127.0.0.1:1/***/notapackage"\n`,
+      exitCode: 1,
+    },
+    {
+      title: "registry URL with a non-http scheme (optional dependency)",
+      registry: `htp://127.0.0.1:1/${token}/`,
+      files: { "package.json": packageJson({ optionalDependencies: { notapackage: "1.0.0" } }) },
+      expected: `warn: Registry URL must be http:// or https://\nReceived: "htp://127.0.0.1:1/***/notapackage"\n`,
+      exitCode: 0,
+    },
+    {
+      title: "tarball URL built from a registry URL with a non-http scheme",
+      registry: `htp://127.0.0.1:1/${token}/`,
+      files: {
+        "package.json": packageJson({ dependencies: { pkg: "1.0.0" } }),
+        // An empty URL in bun.lock stands for the configured registry's
+        // default tarball location, so no manifest is fetched first.
+        "bun.lock": JSON.stringify({
+          lockfileVersion: 1,
+          workspaces: { "": { name: "app", dependencies: { pkg: "1.0.0" } } },
+          packages: { pkg: ["pkg@1.0.0", "", {}, ""] },
+        }),
+      },
+      expected: `error: Expected tarball URL to start with https:// or http://, got "htp://127.0.0.1:1/***/pkg/-/pkg-1.0.0.tgz" while fetching package "pkg"\n`,
+      exitCode: 1,
+    },
+  ];
+
+  for (const { title, registry, files, expected, exitCode } of cases) {
+    test(title, async () => {
+      using dir = tempDir("redacted-registry-token", {
+        ...files,
+        "bunfig.toml": `[install]\nregistry = ${JSON.stringify(registry)}\n`,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "install"],
+        cwd: String(dir),
+        env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache") },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [out, err, exited] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(err).toContain(expected);
+      expect(err).not.toContain(token);
+      expect(out).not.toContain(token);
+      expect(exited).toBe(exitCode);
+    });
+  }
+});
+
 describe.concurrent("redact", async () => {
   const tests = [
     {


### PR DESCRIPTION
### Problem
- When `bun install` cannot turn the configured registry URL into a request URL, the message it prints contains that URL verbatim. A token written into the registry URL as a path segment (`https://host/npm_a1b2.../`) ends up on stderr:
  - `error: Failed to join registry "http://ex ample.org/npm_a1b2.../" and package "notapackage" URLs`
  - `error: Invalid package name "..": manifest URL "http://127.0.0.1:1/" is not on registry "http://127.0.0.1:1/npm_a1b2.../"`
  - `Registry URL must be http:// or https://` / `Received: "htp://127.0.0.1:1/npm_a1b2.../notapackage"` and `Expected tarball URL to start with https:// or http://, got "htp://127.0.0.1:1/npm_a1b2.../pkg/-/pkg-1.0.0.tgz" ...` for a registry URL with a mistyped scheme
  - each manifest message has an error and a warning (optional dependency) variant
- The pnpm migration prints a `namedRegistries` URL from `pnpm-workspace.yaml` the same way: `warn: fetching pnpm registry "work" packages from http://carol:s3cret@127.0.0.1:1/npm_a1b2.../; ...`. That URL is also stored as written, so `user:password@` in it was additionally copied into every tarball URL the migration records in bun.lock, although bun never sends URL credentials (the HTTP client only reads them from a proxy URL). A named registry that is the configured registry spelled with credentials was also not recognized as such, so it got the warning and its own tarball URLs instead of the configured registry's.
- Cause: the seven message sites in `src/install/NetworkTask.rs` (`for_manifest`, `for_tarball`) format the URL with `quote()` or the plain string and `src/install/pnpm.rs` with `BStr::new`, none of which redact; `read_named_registries` in `src/install/pnpm.rs` stores the YAML value verbatim, while every other registry URL source goes through `NpmRegistry::from_url`, which splits credentials off the URL.

### Fix
- Format the URL operand of the eight messages through `bun_core::fmt::redacted_npm_url`. The `NetworkTask` messages keep their quoting: a small helper renders the redacted URL into a buffer and that buffer goes through `quote()` as before. Redaction has to run first because the formatter's password scan only recognizes a string that starts with the URL; `Received: "{}"` now also uses `quote()` instead of literal quotes, so it prints like its siblings (identical output for a plain URL).
- `read_named_registries` stores `NpmRegistry::from_url(value).url`, the same splitting the bunfig, .npmrc, `--registry` and env var sources use. A URL without credentials is stored byte for byte as before; the credentials of one with them are dropped, which changes nothing about the requests (they were never sent) and keeps them out of bun.lock. The warning still tells the user to configure auth for that registry in bunfig.toml or .npmrc. A token in the path stays, since it is part of where the tarballs are; it is masked in the warning and recorded in bun.lock like any other tarball URL.
- Correct because `redacted_npm_url` is what bun already uses when it prints a registry or request URL (registry response errors, the verbose request trace, `bun pm whoami`, the `bun audit` lines from #38183, the `GET <url> - <status>` lines in #38817); these were the remaining install-side sites. A URL with no password, UUID or `npm_` token prints byte for byte as before, and the existing tests asserting on these messages pass unchanged.
- Not folded into #38817 or #38977: those redact other print sites (the request lines, and resolutions / specifiers), touch neither of these two source files, and merge cleanly with this branch in either order; the three add tests to the same file in non-overlapping places.
- Verified:
  - `test/cli/install/redacted-config-logs.test.ts`: new block with one case per `NetworkTask` message (error and warning variants; the tarball one through a `bun.lock`). The registry URLs carry the token only: since #38796 and #38824 the config sources split `user:password@` off before these messages see the URL (`$VAR` registries, #38834, are the remaining exception), so the token is what reaches them from every source. All 7 fail without the change (the token is on stderr) and pass with it; the whole file passes (23 tests).
  - `test/cli/install/migration/pnpm-lock-v9.test.ts`: two new named-registries tests. One asserts the warning shows `http://127.0.0.1:1/***/` and that bun.lock records the tarball URL with the token and without the password; the other that the configured registry written with credentials gets no warning and installs from the configured registry. Both fail without the change (credentials in the warning and in bun.lock; the warning is printed for the configured registry) and pass with it; the whole file passes (83 tests).
  - The existing tests asserting on these messages (`bun-install.test.ts` "Registry URLs", "providing invalid url in lockfile", the canonical registry URL tests; `bun-install-registry.test.ts` "different host than the registry") and the rest of the named-registries tests pass.
  - `cargo fmt -p bun_install -- --check` is clean.

### Background
- `redacted_npm_url` (`src/bun_core/fmt.rs`) is a `Display` adapter over the bytes of a URL: it replaces the password of `scheme://user:password@host` with one `*` per character, and any UUID or `npm_` / `npms_` token anywhere in the string with `***`; everything else is written through unchanged.
- `quote()` (`bun_core::fmt`) wraps bytes in double quotes and JSON-escapes them if they contain a quote, a control character or non-ASCII. These messages have always used it for the package name and the URLs, and existing tests assert the quoted form.
- `NpmRegistry::from_url` (`src/options_types/schema.rs`) is how a registry URL string becomes a registry config: `user:password@` or `:token@` in the URL are moved into the username / password / token fields and the URL is stored without them. `Scope` (`src/install/npm.rs`) then holds the URL that requests are built from; `scope.url.href()` is what these messages print.
- `NetworkTask::for_manifest` builds a package's manifest URL by joining the package name onto the registry URL and refuses to send the request when the join fails, when the result is not http(s), or when it lands outside the registry's origin or directory (a name of `..` does that). `for_tarball` builds the tarball URL from the same registry URL when the lockfile carries no explicit one. The messages above are those refusals.
- `pnpm-workspace.yaml` can name registries (`namedRegistries:`) that `pnpm-lock.yaml` entries refer to as `work:1.0.0`. When the named URL is not the configured registry, the migration records tarball URLs under it (`<url><name>/-/<name>-<version>.tgz`) and prints the warning once per registry; when it is, the packages are recorded against the configured registry. The comparison is a prefix match on the stored URL strings, which is why credentials left in the URL also defeated it.

<details>
<summary>Earlier revision of this PR</summary>

The first revision was based on a main that predated #38796 and #38824, where the bunfig object form, `--registry` and the registry env vars still stored `user:password@` in the URL; its tests put a password and a token in the registry URL and accepted the credentials either masked or absent. Review pointed out that on current main only the token reaches these messages, and that the pnpm test was pinning the credentials being written into bun.lock. This revision switches the NetworkTask tests to token-only registry URLs and adds the `read_named_registries` change with its two tests; the message changes are unchanged.

Output before / after for the pnpm case (`work: http://carol:s3cret@127.0.0.1:1/npm_a1b2.../` in pnpm-workspace.yaml):

```
warn: fetching pnpm registry "work" packages from http://carol:s3cret@127.0.0.1:1/npm_a1b2.../; add it to bunfig.toml or .npmrc if it needs authentication
bun.lock: "http://carol:s3cret@127.0.0.1:1/npm_a1b2.../no-deps/-/no-deps-1.0.1.tgz"
```

```
warn: fetching pnpm registry "work" packages from http://127.0.0.1:1/***/; add it to bunfig.toml or .npmrc if it needs authentication
bun.lock: "http://127.0.0.1:1/npm_a1b2.../no-deps/-/no-deps-1.0.1.tgz"
```
</details>