### PR TITLE
js_parser: store string enum members flat so template folding cannot append to them

### DIFF
--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -2041,6 +2041,10 @@ impl EString {
     /// `other` MUST be Store/arena-allocated (callers pass
     /// `Expr::init(EString, ...).data.e_string_mut()` or a freshly
     /// `Store::append`ed node); its address is captured as a `StoreRef`.
+    ///
+    /// `other`'s own chain becomes part of this rope and the next push appends
+    /// at its tail, so neither chain may still be reachable from another
+    /// expression (inlined enum members are stored flat for this reason).
     pub(crate) fn push(&mut self, other: &mut EString) {
         debug_assert!(self.is_utf8());
         debug_assert!(other.is_utf8());

--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -2041,10 +2041,7 @@ impl EString {
     /// `other` MUST be Store/arena-allocated (callers pass
     /// `Expr::init(EString, ...).data.e_string_mut()` or a freshly
     /// `Store::append`ed node); its address is captured as a `StoreRef`.
-    ///
-    /// `other`'s own chain becomes part of this rope and the next push appends
-    /// at its tail, so neither chain may still be reachable from another
-    /// expression (inlined enum members are stored flat for this reason).
+    /// Both chains are mutated in place, so no other expression may reach them.
     pub(crate) fn push(&mut self, other: &mut EString) {
         debug_assert!(self.is_utf8());
         debug_assert!(other.is_utf8());

--- a/src/ast/fold_string_addition.rs
+++ b/src/ast/fold_string_addition.rs
@@ -1,57 +1,18 @@
 use crate::expr::{Data, PrimitiveType, data};
-use crate::{E, Expr, StoreRef, e};
+use crate::{E, Expr, e};
 use bun_alloc::Arena; // bumpalo::Bump re-export
 
-// ── local rope helpers ─────────────────────────────────────────────────────
-// `EString` has no `push` inherent method taking a `StoreRef` yet; provide the
-// minimal surface here.
-
-#[inline]
-fn store_append_string(s: E::EString) -> StoreRef<E::EString> {
-    data::Store::append(s)
-}
-
-/// Link `other` onto `lhs`'s rope tail.
-fn estring_push(lhs: &mut E::EString, mut other: StoreRef<E::EString>) {
-    debug_assert!(lhs.is_utf8());
-    debug_assert!(other.is_utf8());
-
-    // `other` is a freshly Store-appended node; mutate via `StoreRef::DerefMut`.
-    if other.rope_len == 0 {
-        other.rope_len = other.data.len() as u32;
-    }
-    if lhs.rope_len == 0 {
-        lhs.rope_len = lhs.data.len() as u32;
-    }
-    lhs.rope_len += other.rope_len;
-
-    if lhs.next.is_none() {
-        lhs.next = Some(other);
-        lhs.end = Some(other);
-    } else {
-        let mut end = lhs.end.unwrap();
-        while end.get().next.is_some() {
-            end = end.get().end.unwrap();
-        }
-        // `end` points into the live Store; rope nodes are mutated in place
-        // via `StoreRef::DerefMut` (single-threaded visitor).
-        end.next = Some(other);
-        lhs.end = Some(other);
-    }
-}
-
-/// Concatenate two `E::String`s. The rope chains of BOTH inputs are linked into
-/// the result and later folds append to them in place. That is only sound
-/// because a string reachable from more than one expression is always flat
-/// (`can_be_const_value` rejects ropes, the enum visitor flattens member
-/// values), and the one node such a string does have is copied here, never
-/// mutated.
+/// Concatenate two `E::String`s. Both inputs' rope chains end up in the result
+/// (see `EString::push` for the ownership rule this relies on); a string that
+/// several expressions share is always flat (`can_be_const_value` rejects
+/// ropes, the enum visitor flattens member values), and its one node is copied
+/// here rather than linked in.
 fn join_strings(left: &E::EString, right: &E::EString) -> E::EString {
     let mut new = left.shallow_clone();
-    let rhs_clone = store_append_string(right.shallow_clone());
+    let mut rhs = data::Store::append(right.shallow_clone());
 
-    estring_push(&mut new, rhs_clone);
-    new.prefer_template = new.prefer_template || rhs_clone.get().prefer_template;
+    new.push(&mut *rhs);
+    new.prefer_template = new.prefer_template || right.prefer_template;
 
     new
 }

--- a/src/ast/fold_string_addition.rs
+++ b/src/ast/fold_string_addition.rs
@@ -3,8 +3,8 @@ use crate::{E, Expr, StoreRef, e};
 use bun_alloc::Arena; // bumpalo::Bump re-export
 
 // ── local rope helpers ─────────────────────────────────────────────────────
-// `EString` has no `push` / `clone_rope_nodes` inherent methods yet;
-// provide the minimal surface here.
+// `EString` has no `push` inherent method taking a `StoreRef` yet; provide the
+// minimal surface here.
 
 #[inline]
 fn store_append_string(s: E::EString) -> StoreRef<E::EString> {
@@ -40,69 +40,15 @@ fn estring_push(lhs: &mut E::EString, mut other: StoreRef<E::EString>) {
     }
 }
 
-/// Deep-copy the `next` chain into fresh Store nodes so mutating the result
-/// can't alias an inlined-enum's string.
-fn clone_rope_nodes(s: &E::EString) -> E::EString {
-    let mut root = s.shallow_clone();
-    if let Some(first) = root.next {
-        // Clone the first link, then walk the freshly-cloned chain via
-        // `StoreRef` (safe `Deref`/`DerefMut`) instead of a raw `*mut`
-        // cursor. Each cloned node's `next` still points at the original
-        // chain (shallow clone), so re-clone link-by-link.
-        let mut tail: StoreRef<E::EString> = store_append_string(first.get().shallow_clone());
-        root.next = Some(tail);
-        while let Some(next) = tail.next {
-            let cloned = store_append_string(next.get().shallow_clone());
-            tail.next = Some(cloned);
-            tail = cloned;
-        }
-        root.end = Some(tail);
-    }
-    root
-}
-
-/// Concatenate two `E::String`s, mutating BOTH inputs
-/// unless `has_inlined_enum_poison` is set.
-///
-/// Currently inlined enum poison refers to where mutation would cause output
-/// bugs due to inlined enum values sharing `E::String`s. If a new use case
-/// besides inlined enums comes up to set this to true, please rename the
-/// variable and document it.
-fn join_strings(
-    left: &E::EString,
-    right: &E::EString,
-    has_inlined_enum_poison: bool,
-) -> E::EString {
-    let mut new = if has_inlined_enum_poison {
-        // Inlined enums can be shared by multiple call sites. In
-        // this case, we need to ensure that the ENTIRE rope is
-        // cloned. In other situations, the lhs doesn't have any
-        // other owner, so it is fine to mutate `lhs.data.end.next`.
-        //
-        // Consider the following case:
-        //   const enum A {
-        //     B = "a" + "b",
-        //     D = B + "d",
-        //   };
-        //   console.log(A.B, A.D);
-        clone_rope_nodes(left)
-    } else {
-        left.shallow_clone()
-    };
-
-    // Similarly, the right side has to be cloned for an enum rope too.
-    //
-    // Consider the following case:
-    //   const enum A {
-    //     B = "1" + "2",
-    //     C = ("3" + B) + "4",
-    //   };
-    //   console.log(A.B, A.C);
-    let rhs_clone = store_append_string(if has_inlined_enum_poison {
-        clone_rope_nodes(right)
-    } else {
-        right.shallow_clone()
-    });
+/// Concatenate two `E::String`s. The rope chains of BOTH inputs are linked into
+/// the result and later folds append to them in place. That is only sound
+/// because a string reachable from more than one expression is always flat
+/// (`can_be_const_value` rejects ropes, the enum visitor flattens member
+/// values), and the one node such a string does have is copied here, never
+/// mutated.
+fn join_strings(left: &E::EString, right: &E::EString) -> E::EString {
+    let mut new = left.shallow_clone();
+    let rhs_clone = store_append_string(right.shallow_clone());
 
     estring_push(&mut new, rhs_clone);
     new.prefer_template = new.prefer_template || rhs_clone.get().prefer_template;
@@ -179,11 +125,8 @@ pub fn fold_string_addition(
                     // "bar" + "baz" => "barbaz"
                     Data::EString(right) => {
                         if right.is_utf8() {
-                            let has_inlined_enum_poison = matches!(l.data, Data::EInlinedEnum(_))
-                                || matches!(r.data, Data::EInlinedEnum(_));
-
                             return Some(Expr::init(
-                                join_strings(left.get(), right.get(), has_inlined_enum_poison),
+                                join_strings(left.get(), right.get()),
                                 lhs.loc,
                             ));
                         }
@@ -198,7 +141,6 @@ pub fn fold_string_addition(
                                     head: e::TemplateContents::Cooked(join_strings(
                                         left.get(),
                                         right.head.cooked(),
-                                        matches!(l.data, Data::EInlinedEnum(_)),
                                     )),
                                 },
                                 l.loc,
@@ -250,17 +192,12 @@ pub fn fold_string_addition(
                                     let new_tail = e::TemplateContents::Cooked(join_strings(
                                         last_tail.cooked(),
                                         right.get(),
-                                        matches!(r.data, Data::EInlinedEnum(_)),
                                     ));
                                     left.parts_mut()[i].tail = new_tail;
                                     return Some(lhs);
                                 }
                             } else if left.head.is_utf8() {
-                                let new_head = join_strings(
-                                    left.head.cooked(),
-                                    right.get(),
-                                    matches!(r.data, Data::EInlinedEnum(_)),
-                                );
+                                let new_head = join_strings(left.head.cooked(), right.get());
                                 left.head = e::TemplateContents::Cooked(new_head);
                                 return Some(lhs);
                             }
@@ -276,7 +213,6 @@ pub fn fold_string_addition(
                                     let new_tail = e::TemplateContents::Cooked(join_strings(
                                         last_tail.cooked(),
                                         right.head.cooked(),
-                                        matches!(r.data, Data::EInlinedEnum(_)),
                                     ));
                                     left.parts_mut()[i].tail = new_tail;
 
@@ -289,11 +225,8 @@ pub fn fold_string_addition(
                                     return Some(lhs);
                                 }
                             } else if left.head.is_utf8() && right.head.is_utf8() {
-                                let new_head = join_strings(
-                                    left.head.cooked(),
-                                    right.head.cooked(),
-                                    matches!(r.data, Data::EInlinedEnum(_)),
-                                );
+                                let new_head =
+                                    join_strings(left.head.cooked(), right.head.cooked());
                                 left.head = e::TemplateContents::Cooked(new_head);
                                 left.parts = right.parts;
                                 return Some(lhs);

--- a/src/ast/fold_string_addition.rs
+++ b/src/ast/fold_string_addition.rs
@@ -2,11 +2,8 @@ use crate::expr::{Data, PrimitiveType, data};
 use crate::{E, Expr, e};
 use bun_alloc::Arena; // bumpalo::Bump re-export
 
-/// Concatenate two `E::String`s. Both inputs' rope chains end up in the result
-/// (see `EString::push` for the ownership rule this relies on); a string that
-/// several expressions share is always flat (`can_be_const_value` rejects
-/// ropes, the enum visitor flattens member values), and its one node is copied
-/// here rather than linked in.
+/// Concatenate two `E::String`s. Only the root nodes are copied; the rope
+/// chains behind them are linked into the result (see `EString::push`).
 fn join_strings(left: &E::EString, right: &E::EString) -> E::EString {
     let mut new = left.shallow_clone();
     let mut rhs = data::Store::append(right.shallow_clone());

--- a/src/ast/fold_string_addition.rs
+++ b/src/ast/fold_string_addition.rs
@@ -2,8 +2,7 @@ use crate::expr::{Data, PrimitiveType, data};
 use crate::{E, Expr, e};
 use bun_alloc::Arena; // bumpalo::Bump re-export
 
-/// Concatenate two `E::String`s. Only the root nodes are copied; the rope
-/// chains behind them are linked into the result (see `EString::push`).
+/// Concatenate two `E::String`s into a rope (see `EString::push`).
 fn join_strings(left: &E::EString, right: &E::EString) -> E::EString {
     let mut new = left.shallow_clone();
     let mut rhs = data::Store::append(right.shallow_clone());

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -7083,6 +7083,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     #[cold]
     #[inline(never)]
     pub(crate) fn wrap_inlined_enum(&mut self, value: Expr, comment: &'a [u8]) -> Expr {
+        debug_assert!(
+            value
+                .data
+                .as_e_string()
+                .is_none_or(|str_| str_.next.is_none()),
+            "inlined enum strings must be flat, string folding appends to rope chains in place"
+        );
         if strings::contains(comment, b"*/") {
             // Don't wrap with a comment
             return value;

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -2268,8 +2268,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
                         next_numeric_value = Some(num.value() + 1.0);
                     }
-                    js_ast::ExprData::EString(str_) => {
+                    js_ast::ExprData::EString(mut str_) => {
                         has_string_value = true;
+
+                        // Every inlined use of this member is a copy of this node that
+                        // still points at its rope chain, and string folding appends to
+                        // that chain in place. Flatten it so there is nothing to share.
+                        str_.resolve_rope_if_needed(p.arena);
 
                         exported_members.get_ptr_mut(name).unwrap().data =
                             js_ast::ts::Data::EnumString(str_);

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -2271,8 +2271,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     js_ast::ExprData::EString(mut str_) => {
                         has_string_value = true;
 
-                        // Inlined uses copy this node and string folding appends to rope
-                        // chains in place, so the stored value must not have a chain.
+                        // Inlined uses copy this node, so store it flat.
                         str_.resolve_rope_if_needed(p.arena);
 
                         exported_members.get_ptr_mut(name).unwrap().data =

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -2271,9 +2271,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     js_ast::ExprData::EString(mut str_) => {
                         has_string_value = true;
 
-                        // Every inlined use of this member is a copy of this node that
-                        // still points at its rope chain, and string folding appends to
-                        // that chain in place. Flatten it so there is nothing to share.
+                        // Inlined uses copy this node and string folding appends to rope
+                        // chains in place, so the stored value must not have a chain.
                         str_.resolve_rope_if_needed(p.arena);
 
                         exported_members.get_ptr_mut(name).unwrap().data =

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -1435,6 +1435,49 @@ describe("bundler", () => {
       stdout: "12 312\n12 3124",
     },
   });
+  // A member initialized with a concatenation is stored as a rope. Folding a
+  // template literal that inlines it used to append the template's text onto
+  // that rope, changing the member everywhere: its declaration, every inlined
+  // use in the same file and every cross-module use.
+  itBundled("edgecase/EnumInliningRopeStringTemplateLiteral", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import { Routes, users } from "./routes";
+        enum Local {
+          X = "x" + "y",
+        }
+        function tail(prefix: string) {
+          return \`\${prefix}-\${Local.X}-z\`;
+        }
+        console.log(users);
+        console.log(Routes.Base);
+        console.log(\`\${Routes.Base}/posts\`);
+        console.log(JSON.stringify(Routes));
+        console.log(tail("p"));
+        console.log(Local.X);
+        console.log(JSON.stringify(Local));
+      `,
+      "/routes.ts": /* ts */ `
+        export enum Routes {
+          Base = "/api" + "/v1",
+          Health = "/health",
+        }
+        export const users = \`\${Routes.Base}/users\`;
+      `,
+    },
+    minifySyntax: true,
+    run: {
+      stdout: `
+        /api/v1/users
+        /api/v1
+        /api/v1/posts
+        {"Base":"/api/v1","Health":"/health"}
+        p-xy-z
+        xy
+        {"X":"xy"}
+      `,
+    },
+  });
   itBundled("edgecase/ProtoNullProtoInlining", {
     files: {
       "/entry.ts": `

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -267,6 +267,85 @@ describe("Bun.Transpiler", () => {
       expect(lastLine(ts.parsedMin(pre + 'export let y = Foo?.["A"];', false))).toBe("export let y = Foo?.A;");
       expect(lastLine(ts.parsedMin(pre + 'export let y = Bar?.["a-b"];', false))).toBe('export let y = Bar?.["a-b"];');
     });
+
+    // `B = "a" + "b"` is folded into a rope, and every inlined `A.B` pointed at
+    // that rope. Folding a template literal around it used to append the
+    // template's text onto the rope itself, so the member's declaration and all
+    // of its other uses changed too.
+    describe("template literal around an inlined string enum member", () => {
+      const pre = 'enum A { B = "a" + "b", C = B + "c" }\n';
+      const decl = 'var A;\n((A) => {\n  A.B = "ab";\n  A.C = "abc";\n})(A ||= {});\n';
+
+      it("member as the first part of the literal", () => {
+        expect(ts.parsedMin(pre + "console.log(`${A.B}-x`, A.B);", false)).toBe(
+          decl + 'console.log("ab-x", "ab" /* B */);\n',
+        );
+      });
+      it("member after a part that cannot be folded", () => {
+        expect(ts.parsedMin(pre + "console.log(`${y}${A.B}-x`, A.B);", false)).toBe(
+          decl + 'console.log(`${y}ab-x`, "ab" /* B */);\n',
+        );
+      });
+      it("member derived from another rope member", () => {
+        expect(ts.parsedMin(pre + "console.log(`${A.C}-x`, A.C);", false)).toBe(
+          decl + 'console.log("abc-x", "abc" /* C */);\n',
+        );
+      });
+      it("template inside the enum body, which folds even without minification", () => {
+        expect(ts.parsed('enum A { B = "a" + "b", C = `${B}-c`, D = `${B}` }\nconsole.log(A.B);', false)).toBe(
+          'var A;\n((A) => {\n  A["B"] = "ab";\n  A["C"] = "ab-c";\n  A["D"] = "ab";\n})(A ||= {});\nconsole.log("ab" /* B */);\n',
+        );
+      });
+      it("at runtime, including the same member in several templates", async () => {
+        // Not concurrent: before the fix the second template crashed the
+        // transpiler and the fourth one made it loop forever, and the test
+        // runner only kills a dangling child of a non-concurrent test.
+        await using proc = Bun.spawn({
+          cmd: [
+            bunExe(),
+            "-e",
+            `enum Routes {
+              Base = "/api" + "/v1",
+              Users = Base + "/users",
+              Health = "/health",
+            }
+            function tail(prefix: string) {
+              return \`\${prefix}\${Routes.Base}/y\`;
+            }
+            console.log(
+              [
+                \`\${Routes.Base}/posts\`,
+                tail("q"),
+                \`\${Routes.Users}!\`,
+                \`\${Routes.Base}\${Routes.Base}\`,
+                Routes.Base,
+                Routes.Users,
+                Routes.Health,
+                JSON.stringify(Routes),
+              ].join("\\n"),
+            );`,
+          ],
+          env: bunEnv,
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect({ stdout, stderr, exitCode }).toEqual({
+          stdout: [
+            "/api/v1/posts",
+            "q/api/v1/y",
+            "/api/v1/users!",
+            "/api/v1/api/v1",
+            "/api/v1",
+            "/api/v1/users",
+            "/health",
+            '{"Base":"/api/v1","Users":"/api/v1/users","Health":"/health"}',
+            "",
+          ].join("\n"),
+          stderr: "",
+          exitCode: 0,
+        });
+      });
+    });
   });
 
   describe("TypeScript", () => {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -345,6 +345,66 @@ describe("Bun.Transpiler", () => {
           exitCode: 0,
         });
       });
+
+      // The remaining cases hand out the stored member string through other
+      // paths than the `/* name */` wrapper and fold it through other consumers
+      // than a template literal. Same rules as above for staying sequential.
+      async function run(src) {
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "-e", src],
+          env: bunEnv,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        return { stdout, stderr, exitCode };
+      }
+
+      it("at runtime, .length, ===, computed keys and switch cases of the other uses", async () => {
+        const result = await run(`
+          enum T { C = "a" + "b" }
+          const x = \`\${T.C}c\`;
+          console.log(JSON.stringify([x, T.C, T.C.length, T.C === "ab", { [T.C]: 1 }]));
+          switch ("ab") {
+            case T.C:
+              console.log("matched");
+              break;
+            default:
+              console.log("unmatched");
+          }
+        `);
+        expect(result).toEqual({ stdout: '["abc","ab",2,true,{"ab":1}]\nmatched\n', stderr: "", exitCode: 0 });
+      });
+
+      it("at runtime, a member whose name contains */ and a member propagated through a const", async () => {
+        // A name containing "*/" is inlined without the comment wrapper, and a
+        // const initialized from a member is propagated to each of its uses.
+        const result = await run(`
+          enum E { "a*/b" = "v" + "w" }
+          console.log(E["a*/b"] + "x", E["a*/b"] + "y", E["a*/b"]);
+          enum G { A = "v" + "w" }
+          const k = G.A;
+          console.log(\`\${k}x\`, \`\${k}y\`, k + k, k);
+        `);
+        expect(result).toEqual({ stdout: "vwx vwy vw\nvwx vwy vwvw vw\n", stderr: "", exitCode: 0 });
+      });
+
+      it("Bun.Transpiler with inline: true prints every use with the member's own value", () => {
+        const transpiler = new Bun.Transpiler({ loader: "ts", inline: true });
+        const out = transpiler.transformSync(
+          'enum T { C = "a" + "b" }\nexport const x = `${T.C}c`;\nexport const y = [T.C, T.C.length, T.C === "ab"];',
+        );
+        expect(out.trim()).toBe(
+          [
+            `var T;`,
+            `((T) => {`,
+            `  T["C"] = "ab";`,
+            `})(T ||= {});`,
+            `export const x = "abc";`,
+            `export const y = ["ab" /* C */, "ab" /* C */.length, true];`,
+          ].join("\n"),
+        );
+      });
     });
   });
 


### PR DESCRIPTION
### Problem

- A string enum member whose initializer is a concatenation changes value once it is interpolated into a template literal anywhere in the file: with `enum A { B = "a" + "b" }` and `` `${A.B}c` ``, `A.B` becomes `"abc"` in the declaration, in every inlined use, and in cross-module uses of the enum (tsc: `"ab"`).
- Interpolating the member a second time crashes or hangs the transpiler instead: a second template literal panics with `called `Option::unwrap()` on a `None` value` (`Crashed while visiting`), and `` `${A.B}${A.B}` `` links the string onto itself and loops forever while resolving it.
- Reached by plain `bun run file.ts` (the bun target enables syntax minification), `bun build --minify-syntax`, `Bun.Transpiler` with `minify.syntax`, and with no flags at all when the template literal is itself an enum initializer. Reproduces on 1.4.0 and main; the Zig code this was ported from had the same shape.
- Cause: enum initializers are folded eagerly, so `"a" + "b"` is stored as a rope (an `E::String` root whose `next` chain holds the other pieces) and `ts::Data::EnumString` points at that node (`src/js_parser/visit/visit_stmt.rs:2223`). Each inlined use copies only the root (`new_expr(&*str_ptr)`, `src/js_parser/p.rs:1564`), so the declaration and every use share the chain. `Template::fold` (`src/ast/e.rs:2231`, `:2275`) pushes a copy of the inlined value onto the text accumulated so far and then pushes the text that follows it; that second `EString::push` (`src/ast/e.rs:2020`) walks to the last node of the shared chain and sets its `next`, so the member itself grows. A later interpolation walks through that node again (its `end` was never set: the unwrap panic) or links the chain to itself (the hang).
- `fold_string_addition` guarded against this per consumer (`has_inlined_enum_poison` + `clone_rope_nodes`); `Template::fold` did not, and the guard could not see values that `wrap_inlined_enum` returns unwrapped (member names containing `*/`).

### Fix

- The fix is the `str_.resolve_rope_if_needed(p.arena)` line in `s_enum` (`visit_stmt.rs`): the member's string is flattened before it is stored as the enum value, so it is a single node. Inlined uses still copy that node, and both folds only ever mutate their own copy, so there is nothing shared left to append to. This covers every consumer (`Template::fold`, `fold_string_addition`, the printer's cross-module substitution) and the unwrapped case, at the one place where the sharing starts. `EnumString` is constructed only here.
- This is the value the declaration prints anyway (`A.B = "ab"`); it is now resolved once, in the parser arena that owns the rest of the AST, instead of once per inlined use at print time. esbuild also stores enum string values flat.
- `resolve_rope_if_needed` leaves `rope_len` (still the string's length, which is what `len()` and `.length` folding read) and the stale `end` pointer behind; `end` is only read from a node whose `next` is set, and a push onto a copy of a flat node assigns both. The printer's in-place resolve leaves nodes in this exact state today.
- `fold_string_addition.rs`: `has_inlined_enum_poison` and `clone_rope_nodes` can no longer do anything, so they are deleted and `join_strings` documents the ownership rule it relies on. The existing `edgecase/EnumInliningRopeStringPoison` test covers the scenarios those comments described and still passes.
- `p.rs`: `wrap_inlined_enum` gets a `debug_assert!` that the inlined string is flat, so a future construction site that stores a rope fails in debug builds instead of producing wrong output. `e.rs`: `EString::push` documents that both chains have to be exclusively owned.
- Tests: `test/bundler/transpiler/transpiler.test.js` ("template literal around an inlined string enum member": member first in the literal, member after a non-constant part, member derived from another rope member, template literal inside the enum body without minification, and a `bun -e` run that uses one member in four template literals) and `test/bundler/bundler_edgecase.test.ts` (`edgecase/EnumInliningRopeStringTemplateLiteral`: declaration, same-file and cross-module uses, tail path). All six fail with `USE_SYSTEM_BUN=1` (wrong values; the `bun -e` one with the panic) and pass with `bun bd test`.
- Also run on the debug build: `test/bundler/esbuild/ts.test.ts`, `esbuild/dce.test.ts`, `esbuild/default.test.ts`, `bundler_minify.test.ts`, `bundler_regressions.test.ts`, `bundler_edgecase.test.ts`, `transpiler/transpiler.test.js`, `transpiler/ts-enum-redecl-panic.test.ts`.

### Background

- Rope: folding `"a" + "b"` does not copy bytes. The right operand is linked onto the left as a chain of `E::String` nodes (`next`, `end`, `rope_len`), later folds append further nodes to the chain in place, and the printer (`resolve_rope_if_needed`) flattens the chain into one buffer when the value is needed. Appending in place is only correct while exactly one expression owns the chain; `can_be_const_value` already refuses to share ropes for the same reason.
- Enum inlining: while a file is visited, `A.B` is replaced by an `E::InlinedEnum` wrapping a copy of the member's stored string, so folds such as `Template::fold` and `fold_string_addition` see a plain string literal. For an enum imported from another module, the bundler's printer substitutes the stored node itself.
- `Template::fold`: with syntax minification (or inside enum initializers) `` `x${"y"}z` `` is folded into `"xyz"` by pushing each constant piece onto the template's text with `EString::push`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bundler_edgecase.test.ts

<!-- robobun:evidence:end -->