### PR TITLE
Free the parked Bun.TOML/YAML/JSON5/JSONC/XML.parse arena when a Worker exits

### DIFF
--- a/src/ast/ast_memory_allocator.rs
+++ b/src/ast/ast_memory_allocator.rs
@@ -26,9 +26,14 @@ use crate::stmt;
 // it here; the next `ASTMemoryAllocator` on this thread reclaims it, reusing
 // its committed pages. The pool holds at most one arena (nested scopes — rare
 // — fall back to a fresh `Arena::new()`). `#[thread_local]` (not the
-// `thread_local!` macro) so there is no destructor: a parked arena at thread
-// exit is reclaimed by mimalloc's own thread-teardown, avoiding an unspecified
-// destructor-ordering hazard with `mi_heap_destroy`.
+// `thread_local!` macro) so there is no destructor racing mimalloc's own
+// thread teardown. mimalloc does NOT destroy a parked heap when its thread
+// exits (heaps are not thread-bound in our fork), so an exiting thread strands
+// one empty `mi_heap_t`. That is acceptable only because the threads that park
+// here (bundler/install pool threads, the bundle thread) live as long as the
+// process; per-thread state on threads that come and go (Worker VMs) must be
+// owned by something torn down with the thread instead, like
+// `RuntimeState::text_format_arena` in `bun_runtime`.
 #[thread_local]
 static ARENA_POOL: Cell<Option<Arena>> = Cell::new(None);
 

--- a/src/ast/ast_memory_allocator.rs
+++ b/src/ast/ast_memory_allocator.rs
@@ -26,14 +26,9 @@ use crate::stmt;
 // it here; the next `ASTMemoryAllocator` on this thread reclaims it, reusing
 // its committed pages. The pool holds at most one arena (nested scopes — rare
 // — fall back to a fresh `Arena::new()`). `#[thread_local]` (not the
-// `thread_local!` macro) so there is no destructor racing mimalloc's own
-// thread teardown. mimalloc does NOT destroy a parked heap when its thread
-// exits (heaps are not thread-bound in our fork), so an exiting thread strands
-// one empty `mi_heap_t`. That is acceptable only because the threads that park
-// here (bundler/install pool threads, the bundle thread) live as long as the
-// process; per-thread state on threads that come and go (Worker VMs) must be
-// owned by something torn down with the thread instead, like
-// `RuntimeState::text_format_arena` in `bun_runtime`.
+// `thread_local!` macro) so no destructor races mimalloc's own thread
+// teardown. mimalloc does not destroy a parked heap at thread exit; that is
+// fine here because the threads that park live as long as the process.
 #[thread_local]
 static ARENA_POOL: Cell<Option<Arena>> = Cell::new(None);
 

--- a/src/runtime/api.rs
+++ b/src/runtime/api.rs
@@ -237,19 +237,15 @@ fn with_text_format_source_encoded<R>(
     use crate::node::{BlobOrStringOrBuffer, StringOrBuffer};
 
     // A private mi_heap costs microseconds to create, more than parsing a
-    // small document: keep one per VM thread (`RuntimeState::text_format_arena`,
-    // destroyed with the VM) and recycle it between calls. The slot is empty
-    // while a call is in flight, so a re-entrant call (the argument's
-    // `toString()` parsing another document) gets its own arena; whichever
-    // parks last wins and the other is destroyed.
+    // small document: keep one per VM thread (`RuntimeState::text_format_arena`)
+    // and recycle it between calls. The slot is empty while a call is in
+    // flight, so a re-entrant call gets its own arena.
     struct Recycle(Option<bun_alloc::Arena>);
     impl Drop for Recycle {
         fn drop(&mut self) {
             let Some(mut arena) = self.0.take() else {
                 return;
             };
-            // Re-fetched rather than captured at entry: if the VM state is
-            // gone by now the arena is simply dropped (`mi_heap_destroy`).
             if let Some(slot) = crate::jsc_hooks::text_format_arena_slot() {
                 arena.reset_retain_with_limit(2 * 1024 * 1024);
                 slot.set(Some(arena));

--- a/src/runtime/api.rs
+++ b/src/runtime/api.rs
@@ -237,22 +237,27 @@ fn with_text_format_source_encoded<R>(
     use crate::node::{BlobOrStringOrBuffer, StringOrBuffer};
 
     // A private mi_heap costs microseconds to create, more than parsing a
-    // small document: keep one per thread and recycle it between calls.
-    // `#[thread_local]` rather than `thread_local!` so there is no
-    // destructor racing mimalloc's own thread teardown (as in
-    // `ast_memory_allocator.rs`); a parked heap is reclaimed with the thread.
-    #[thread_local]
-    static ARENA: core::cell::Cell<Option<bun_alloc::Arena>> = core::cell::Cell::new(None);
+    // small document: keep one per VM thread (`RuntimeState::text_format_arena`,
+    // destroyed with the VM) and recycle it between calls. The slot is empty
+    // while a call is in flight, so a re-entrant call (the argument's
+    // `toString()` parsing another document) gets its own arena; whichever
+    // parks last wins and the other is destroyed.
     struct Recycle(Option<bun_alloc::Arena>);
     impl Drop for Recycle {
         fn drop(&mut self) {
-            if let Some(mut arena) = self.0.take() {
+            let Some(mut arena) = self.0.take() else {
+                return;
+            };
+            // Re-fetched rather than captured at entry: if the VM state is
+            // gone by now the arena is simply dropped (`mi_heap_destroy`).
+            if let Some(slot) = crate::jsc_hooks::text_format_arena_slot() {
                 arena.reset_retain_with_limit(2 * 1024 * 1024);
-                ARENA.set(Some(arena));
+                slot.set(Some(arena));
             }
         }
     }
-    let recycle = Recycle(Some(ARENA.take().unwrap_or_default()));
+    let parked = crate::jsc_hooks::text_format_arena_slot().and_then(core::cell::Cell::take);
+    let recycle = Recycle(Some(parked.unwrap_or_default()));
     let arena = recycle.0.as_ref().expect("set above");
     let mut ast_memory_allocator = bun_ast::ASTMemoryAllocator::borrowing(arena);
     let _ast_scope = ast_memory_allocator.enter();

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -106,11 +106,9 @@ pub(crate) struct RuntimeState {
     /// stop; one ref per entry, released by `CronJob::remove_from_list` /
     /// `clear_all_for_vm`.
     pub(crate) cron_jobs: Vec<bun_ptr::RefPtr<crate::api::cron::CronJob>>,
-    /// Parked `mi_heap` recycled between `Bun.{TOML,YAML,JSON5,JSONC,XML}.parse`
-    /// calls on this thread (see `api::with_text_format_source_encoded`).
-    /// Owned here rather than in a `#[thread_local]` so Worker teardown
-    /// destroys it: mimalloc does not free a `mi_heap_t` when the thread that
-    /// created it exits, so a heap parked in TLS leaks with every Worker.
+    /// Arena recycled between `Bun.{TOML,YAML,JSON5,JSONC,XML}.parse` calls.
+    /// Owned by the VM state, not a `#[thread_local]`: mimalloc does not destroy
+    /// a heap when its creating thread exits, so a TLS-parked one leaked per Worker.
     pub(crate) text_format_arena: Cell<Option<bun_alloc::Arena>>,
 }
 
@@ -259,11 +257,8 @@ pub(crate) fn global_dns_data() -> &'static core::cell::OnceCell<Box<crate::dns_
     unsafe { &(*state).global_dns_data }
 }
 
-/// The slot holding this thread's parked text-format parse arena
-/// ([`RuntimeState::text_format_arena`]), or `None` when no VM state is
-/// installed on this thread (callers then use a throwaway arena). Do not hold
-/// the returned reference across code that can tear the VM down; re-fetch it
-/// instead.
+/// This thread's [`RuntimeState::text_format_arena`] slot, or `None` when no
+/// VM state is installed on this thread.
 #[inline]
 pub(crate) fn text_format_arena_slot() -> Option<&'static Cell<Option<bun_alloc::Arena>>> {
     let state = runtime_state();
@@ -272,8 +267,7 @@ pub(crate) fn text_format_arena_slot() -> Option<&'static Cell<Option<bun_alloc:
     }
     // SAFETY: `state` is the live per-thread `RuntimeState` box; the field
     // address is stable until `deinit_runtime_state`, which nulls
-    // `RUNTIME_STATE` before freeing the box, so a non-null `state` here is
-    // never a freed one. Mutation goes through the `Cell`.
+    // `RUNTIME_STATE` before freeing the box. Mutation goes through the `Cell`.
     Some(unsafe { &(*state).text_format_arena })
 }
 

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -106,6 +106,12 @@ pub(crate) struct RuntimeState {
     /// stop; one ref per entry, released by `CronJob::remove_from_list` /
     /// `clear_all_for_vm`.
     pub(crate) cron_jobs: Vec<bun_ptr::RefPtr<crate::api::cron::CronJob>>,
+    /// Parked `mi_heap` recycled between `Bun.{TOML,YAML,JSON5,JSONC,XML}.parse`
+    /// calls on this thread (see `api::with_text_format_source_encoded`).
+    /// Owned here rather than in a `#[thread_local]` so Worker teardown
+    /// destroys it: mimalloc does not free a `mi_heap_t` when the thread that
+    /// created it exits, so a heap parked in TLS leaks with every Worker.
+    pub(crate) text_format_arena: Cell<Option<bun_alloc::Arena>>,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
@@ -251,6 +257,24 @@ pub(crate) fn global_dns_data() -> &'static core::cell::OnceCell<Box<crate::dns_
     // address is stable for the VM's lifetime and only read (interior
     // mutability via `OnceCell`).
     unsafe { &(*state).global_dns_data }
+}
+
+/// The slot holding this thread's parked text-format parse arena
+/// ([`RuntimeState::text_format_arena`]), or `None` when no VM state is
+/// installed on this thread (callers then use a throwaway arena). Do not hold
+/// the returned reference across code that can tear the VM down; re-fetch it
+/// instead.
+#[inline]
+pub(crate) fn text_format_arena_slot() -> Option<&'static Cell<Option<bun_alloc::Arena>>> {
+    let state = runtime_state();
+    if state.is_null() {
+        return None;
+    }
+    // SAFETY: `state` is the live per-thread `RuntimeState` box; the field
+    // address is stable until `deinit_runtime_state`, which nulls
+    // `RUNTIME_STATE` before freeing the box, so a non-null `state` here is
+    // never a freed one. Mutation goes through the `Cell`.
+    Some(unsafe { &(*state).text_format_arena })
 }
 
 /// Recover the [`RuntimeState`] owned by a specific `vm` (not the calling
@@ -412,6 +436,7 @@ unsafe fn init_runtime_state(
         active_handles: ActiveHandles::default(),
         wake_ctx: None,
         cron_jobs: Vec::new(),
+        text_format_arena: Cell::new(None),
     }));
     RUNTIME_STATE.with(|c| c.set(state));
 

--- a/test/js/node/worker_threads/worker-heap-leak-fixture.js
+++ b/test/js/node/worker_threads/worker-heap-leak-fixture.js
@@ -1,0 +1,34 @@
+// Several APIs give the calling thread a private mimalloc heap and keep it around for the next call:
+// Bun.{TOML,YAML,JSON5,JSONC,XML}.parse park one between calls, the module loader keeps one per VM for
+// transpiling. mimalloc does not destroy such heaps when their thread exits, so unless the Worker's VM
+// teardown frees them, every Worker that used one of these APIs leaks a heap plus whatever pages it
+// still holds. heapStats({ dump: true }) lists every live heap in the process, so the count must not
+// grow with the number of Workers that have come and gone.
+const { Worker, isMainThread } = require("node:worker_threads");
+
+if (!isMainThread) {
+  Bun.TOML.parse("a = 1");
+  Bun.YAML.parse("a: 1");
+  Bun.JSON5.parse("{ a: 1 }");
+  Bun.JSONC.parse('{ /* a */ "a": 1 }');
+  Bun.XML.parse("<a>1</a>");
+  new Bun.Transpiler().transformSync("export const b = 2;");
+  await import("data:text/javascript,export default 1");
+} else {
+  const { heapStats } = require("bun:jsc");
+  const liveHeaps = () => heapStats({ dump: true }).mimallocDump.heaps.length;
+
+  const runWorker = () =>
+    new Promise((resolve, reject) => {
+      const worker = new Worker(__filename);
+      worker.on("error", reject);
+      worker.on("exit", code => (code === 0 ? resolve() : reject(new Error(`worker exited with ${code}`))));
+    });
+
+  // Whatever the process sets up lazily for its first Worker is part of the baseline.
+  await runWorker();
+  const before = liveHeaps();
+  const workers = 3;
+  for (let i = 0; i < workers; i++) await runWorker();
+  console.log(JSON.stringify({ workers, leaked: liveHeaps() - before }));
+}

--- a/test/js/node/worker_threads/worker-heap-leak.test.ts
+++ b/test/js/node/worker_threads/worker-heap-leak.test.ts
@@ -5,19 +5,15 @@ import { join } from "path";
 // Allocator heaps that APIs park on the Worker's thread (Bun.TOML.parse and friends, the module
 // loader) must die with the Worker's VM; see the fixture for details. The fixture starts four Workers,
 // which takes well over the default per-test timeout on debug and ASAN builds.
-test(
-  "a Worker that used per-thread allocator heaps does not leak them when it exits",
-  async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), join(import.meta.dir, "worker-heap-leak-fixture.js")],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(JSON.parse(stdout)).toEqual({ workers: 3, leaked: 0 });
-    expect(exitCode).toBe(0);
-  },
-  60_000,
-);
+test("a Worker that used per-thread allocator heaps does not leak them when it exits", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(import.meta.dir, "worker-heap-leak-fixture.js")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({ workers: 3, leaked: 0 });
+  expect(exitCode).toBe(0);
+}, 60_000);

--- a/test/js/node/worker_threads/worker-heap-leak.test.ts
+++ b/test/js/node/worker_threads/worker-heap-leak.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { join } from "path";
+
+// Allocator heaps that APIs park on the Worker's thread (Bun.TOML.parse and friends, the module
+// loader) must die with the Worker's VM; see the fixture for details. The fixture starts four Workers,
+// which takes well over the default per-test timeout on debug and ASAN builds.
+test(
+  "a Worker that used per-thread allocator heaps does not leak them when it exits",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(import.meta.dir, "worker-heap-leak-fixture.js")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ workers: 3, leaked: 0 });
+    expect(exitCode).toBe(0);
+  },
+  60_000,
+);

--- a/test/js/node/worker_threads/worker_destruction.test.ts
+++ b/test/js/node/worker_threads/worker_destruction.test.ts
@@ -70,4 +70,19 @@ describe("Worker destruction", () => {
     expect(stdout).toBe("worker exit 0\n");
     expect(exitCode).toBe(0);
   });
+
+  // Allocator heaps that APIs park on the Worker's thread (Bun.TOML.parse and friends, the module
+  // loader) must die with the Worker's VM; see the fixture for details.
+  test.concurrent("a Worker that used per-thread allocator heaps does not leak them when it exits", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(import.meta.dir, "worker-heap-leak-fixture.js")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ workers: 3, leaked: 0 });
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/node/worker_threads/worker_destruction.test.ts
+++ b/test/js/node/worker_threads/worker_destruction.test.ts
@@ -70,19 +70,4 @@ describe("Worker destruction", () => {
     expect(stdout).toBe("worker exit 0\n");
     expect(exitCode).toBe(0);
   });
-
-  // Allocator heaps that APIs park on the Worker's thread (Bun.TOML.parse and friends, the module
-  // loader) must die with the Worker's VM; see the fixture for details.
-  test.concurrent("a Worker that used per-thread allocator heaps does not leak them when it exits", async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), join(import.meta.dir, "worker-heap-leak-fixture.js")],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(JSON.parse(stdout)).toEqual({ workers: 3, leaked: 0 });
-    expect(exitCode).toBe(0);
-  });
 });


### PR DESCRIPTION
### Problem
- Every Worker that calls `Bun.TOML.parse`, `Bun.YAML.parse`, `Bun.JSON5.parse`, `Bun.JSONC.parse` or `Bun.XML.parse` leaks one mimalloc heap (`mi_heap_t`) plus whatever pages it still holds (up to 2 MiB of retained blocks) when the Worker exits. 20 Workers each parsing a 2000-table TOML document: 20 heaps left behind, RSS +55 MB vs +14 MB for 20 Workers that parse nothing (debug build; release canary `eabb96de7` shows the same 20 heaps, RSS +40 MB vs +2 MB).
- Cause: `with_text_format_source_encoded` (`src/runtime/api.rs:272`) parks the recycled arena in a `#[thread_local]` and relies on "a parked heap is reclaimed with the thread". That is not how our mimalloc fork behaves: heaps are first-class and not bound to a thread, so thread exit (`mi_thread_theaps_done` in mimalloc's `init.c`) only abandons the thread's theap pages and never destroys heaps created on it. The `mi_heap_t`, its TLS key slot, and every page still holding a retained block outlive the Worker.
- Introduced by #37146 (Aug 7), which replaced the per-call `Arena::new()` with the per-thread cache. `ast_memory_allocator.rs`, which that comment cites as precedent, makes the same claim; it is harmless there only because the threads parking into it (bundler/install pool threads, the bundle thread) live as long as the process.
- LSan cannot catch this class of leak (mimalloc blocks bypass it), which is why nothing flagged it.

### Fix
- The parked arena now lives in `RuntimeState::text_format_arena` (`src/runtime/jsc_hooks.rs`). `RuntimeState` is the per-JS-thread box that already owns the other per-VM allocator state for exactly this reason (`transpiler_arena`, the transpile printer, the AST stores) and is dropped by `deinit_runtime_state` from `VirtualMachine::destroy`, so the heap is destroyed on the Worker's thread before it exits. The main thread's state lives for the process, as before.
- `api.rs` takes the arena out of the slot for the duration of a call and parks it back on exit, re-fetching the slot at park time. Behaviour on a live VM is identical to before (verified with a probe counting live heaps: exactly one parked heap after 150 mixed parse calls, and a re-entrant call made from the argument's `toString()` still ends with one parked heap); with no VM state on the thread the arena is simply dropped.
- The misleading sentence in `ast_memory_allocator.rs` is replaced with what mimalloc actually does and when a TLS-parked heap is acceptable.
- Verification:
  - New `test/js/node/worker_threads/worker-heap-leak.test.ts`, driving `worker-heap-leak-fixture.js`: runs a warm-up Worker, records `heapStats({ dump: true }).mimallocDump.heaps.length`, runs 3 more Workers that exercise all five parsers plus `Bun.Transpiler` and a `data:` import, and expects the live heap count to be unchanged. Fails on the unfixed binary with `leaked: 3`, passes with this change.
  - `bun bd test test/js/node/worker_threads/worker-heap-leak.test.ts` passes; `worker_destruction.test.ts` (the file the fixture pattern comes from) still passes, 6 of 6.
  - Heap-count probe on the fixed debug build: 6 Workers parsing large TOML/YAML documents leave 0 extra heaps and the page count stays flat (was +33 pages per Worker).

### Background
- `bun_alloc::Arena` (`MimallocArena`) wraps one `mi_heap_t`; its `Drop`/`reset()` call `mi_heap_destroy`, which bulk-frees everything allocated from it. The text-format parsers build their AST in one of these and throw the whole thing away per call. `reset_retain_with_limit(2 MiB)` keeps the heap, including its dead blocks, while it is small, to skip `mi_heap_new`/`mi_heap_destroy` on the next call; that is why a parked heap can hold up to 2 MiB of pages.
- `heapStats({ dump: true })` from `bun:jsc` calls `mi_heap_dump_json`, which lists every live `mi_heap_t` in the process regardless of whether it has pages, so the length of `mimallocDump.heaps` is an exact live-heap count and a cheap way to detect this class of leak for any API.
- `RuntimeState` (`src/runtime/jsc_hooks.rs`) is the high-tier per-VM state that `bun_jsc` cannot name directly; `bun_jsc` stores it as an opaque pointer, creates it in `VirtualMachine::init` and reclaims it in `VirtualMachine::destroy`, which runs on the Worker's own thread during shutdown (`web_worker.rs`). Worker threads are the only JS threads that exit while the process keeps running, so anything per-thread that must not outlive the thread belongs there.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 5 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker-heap-leak.test.ts
bun test v1.4.1 (4448a2e21)

test/js/node/worker_threads/worker-heap-leak.test.ts:
12 |     stdout: "pipe",
13 |     stderr: "pipe",
14 |   });
15 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
16 |   expect(stderr).toBe("");
17 |   expect(JSON.parse(stdout)).toEqual({ workers: 3, leaked: 0 });
                                  ^
error: expect(received).toEqual(expected)

  {
-   "leaked": 0,
+   "leaked": 3,
    "workers": 3,
  }

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/node/worker_threads/worker-heap-leak.test.ts:17:30)
(fail) a Worker that used per-thread allocator heaps does not leak them when it exits [5414.66ms]

 0 pass
 1 fail
 2 expect() calls
Ran 1 test across 1 file. [7.53s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: all passed
bun test v1.4.1-canary.1 (d62e2d280)

test/js/node/worker_threads/worker-heap-leak.test.ts:
(pass) a Worker that used per-thread allocator heaps does not leak them when it exits [78.80ms]

 1 pass
 0 fail
 3 expect() calls
Ran 1 test across 1 file. [161.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker-heap-leak.test.ts
bun test v1.4.1 (4448a2e21)

test/js/node/worker_threads/worker-heap-leak.test.ts:
(pass) a Worker that used per-thread allocator heaps does not leak them when it exits [5706.00ms]

 1 pass
 0 fail
 3 expect() calls
Ran 1 test across 1 file. [7.89s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 652ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 120 exports (host=5, lazy=10, generic=105, rust=0); 244 extern-C blocks audited
[1/5] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_ast v0.0.0 (/workspace/bun/src/ast)
[1m[92m   Compiling[0m bun_install_types v0.0.0 (/workspace/bun/src/install_types)
[1m[92m   Compiling[0m bun_parsers v0.0.0 (/workspace/bun/src/parsers)
[1m[92m   Compiling[0m bun_react_compiler v0.0.0 (/workspace/bun/src/react_compiler)
[1m[92m   Compiling[0m bun_resolve_builtins v0.0.0 (/workspace/bun/src/resolve_builtins)
[1m[92m   Compiling[0m bun_css v0.0.0 (/workspace/bun/src/css)
[1m[92m   Compiling[0m bun_http v0.0.0 (/workspace/bun/src/http)
[1m[92m   Compiling[0m bun_options_types v0.0.0 (/workspace/bun/src/options_types)
[1m[92m   Compiling[0m bun_api v0.0.0 (/workspace/bun/src/api)

... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ast/ast_memory_allocator.rs                    |  6 ++--
 src/runtime/api.rs                                 | 19 ++++++------
 src/runtime/jsc_hooks.rs                           | 19 ++++++++++++
 .../worker_threads/worker-heap-leak-fixture.js     | 34 ++++++++++++++++++++++
 .../node/worker_threads/worker-heap-leak.test.ts   | 19 ++++++++++++
 5 files changed, 85 insertions(+), 12 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 5

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/ast/ast_memory_allocator.rs                              3      5      0
src/runtime/api.rs                                           3      2      0
src/runtime/jsc_hooks.rs                                     7      7      0
test/js/node/worker_threads/worker-heap-leak-fixture.js      1      2      0
test/js/node/worker_threads/worker-heap-leak.test.ts         0      1      0
```

</details>

<!-- robobun:evidence:end -->