### PR TITLE
url: parse the host of a protocol-relative URL instead of leaving the authority in the path

### DIFF
--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -592,9 +592,9 @@ impl<'a> URL<'a> {
                 offset += url.parse_host(base).unwrap_or(0);
             }
             b'/' | b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'-' | b'_' | b':' => {
-                let is_protocol_relative = base.len() > 1 && base[1] == b'/';
+                let is_protocol_relative = base.starts_with(b"//");
                 if is_protocol_relative {
-                    offset += 1;
+                    offset += 2;
                 } else {
                     offset += url.parse_protocol(&base[offset as usize..]).unwrap_or(0);
                 }
@@ -700,7 +700,8 @@ impl<'a> URL<'a> {
             url.pathname = &url.pathname[1..];
         }
 
-        url.origin = strings::trim(url.origin, b"/ ?#");
+        // Only the right side: a protocol-relative origin keeps its leading `//`.
+        url.origin = strings::trim_right(url.origin, b"/ ?#");
         url
     }
 

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -603,6 +603,65 @@ registry=https://somehost.com/org1/npm/registry/
     });
   });
 
+  describe("protocol-relative registry value", () => {
+    // `registry=//host/path/` is kept as written and matched against the credential
+    // keys by host and pathname. It used to parse with an empty host and `/host/path/`
+    // as its pathname, so no key could match it.
+    test.each([
+      ["host only", "//registry.example.com/", "//registry.example.com/"],
+      ["host with a port and a path", "//registry.example.com:8080/npm/", "//registry.example.com:8080/npm/"],
+      ["key without the trailing slash", "//registry.example.com:8080/npm/", "//registry.example.com:8080/npm"],
+    ])("_authToken is applied: %s", (_, registryUrl, key) => {
+      expect(loadNpmrc(`registry=${registryUrl}\n${key}:_authToken=rel-token\n`)).toEqual({
+        default_registry_url: registryUrl,
+        default_registry_token: "rel-token",
+        default_registry_username: "",
+        default_registry_password: "",
+        default_registry_email: "",
+      });
+    });
+
+    test.each([
+      ["a different port", "//registry.example.com:9090/npm/"],
+      ["a different host", "//other.example.com:8080/npm/"],
+      ["the host without the path", "//registry.example.com:8080/"],
+    ])("a key for %s is not applied", (_, key) => {
+      const result = loadNpmrc(`registry=//registry.example.com:8080/npm/\n${key}:_authToken=rel-token\n`);
+      expect(result.default_registry_url).toBe("//registry.example.com:8080/npm/");
+      expect(result.default_registry_token).toBe("");
+    });
+
+    test.each(["http://", "//"])("credentials embedded in a %sregistry value are split out of the URL", prefix => {
+      expect(loadNpmrc(`registry=${prefix}:embedded-token@registry.example.com/npm/\n`)).toEqual({
+        default_registry_url: "http://registry.example.com/npm/",
+        default_registry_token: "embedded-token",
+        default_registry_username: "",
+        default_registry_password: "",
+        default_registry_email: "",
+      });
+
+      expect(loadNpmrc(`registry=${prefix}embedded-user:embedded-password@registry.example.com/npm/\n`)).toEqual({
+        default_registry_url: "http://registry.example.com/npm/",
+        default_registry_token: "",
+        default_registry_username: "embedded-user",
+        default_registry_password: "embedded-password",
+        default_registry_email: "",
+      });
+    });
+  });
+
+  test.each(["a", "ab"])("a credential key for the host %j is applied to registry=http://<host>/", host => {
+    // The `//a/` key is stripped to `a/` before it is parsed. A second byte of `/` used to
+    // be taken as the start of a protocol-relative URL, leaving the key with an empty host.
+    expect(loadNpmrc(`registry=http://${host}/\n//${host}/:_authToken=${host}-token\n`)).toEqual({
+      default_registry_url: `http://${host}/`,
+      default_registry_token: `${host}-token`,
+      default_registry_username: "",
+      default_registry_password: "",
+      default_registry_email: "",
+    });
+  });
+
   it("does not print an undecodable _password value", async () => {
     const secret = "s!ecret!pass";
     using dir = tempDir("npmrc-password-decode", {
@@ -770,6 +829,47 @@ describe("--registry override", () => {
     expect(reqsB.map(r => r.auth)).toEqual(reqsB.map(() => null));
     expect(stdout).toContain("+ no-deps@1.0.0");
     expect(exitCode).toBe(0);
+  });
+});
+
+describe("protocol-relative registry", () => {
+  test("bun install rejects registry=//host:port/path/ instead of requesting http://localhost/host/", async () => {
+    // The `:port` used to be taken for a `:option=value` suffix of the pathname and the
+    // value rewritten to http://localhost/127.0.0.1/, so the manifest was requested from
+    // a different host on port 80. A scheme-less registry is not usable either way; the
+    // server only exists to show that the host actually named in the value is not hit.
+    let hits = 0;
+    await using named = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch() {
+        hits++;
+        return new Response("not found", { status: 404 });
+      },
+    });
+    const registryUrl = `//127.0.0.1:${named.port}/npm/`;
+
+    using dir = tempDir("npmrc-protocol-relative-registry", {
+      ".npmrc": `registry=${registryUrl}\n`,
+      "package.json": JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        dependencies: { "no-deps": "1.0.0" },
+      }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install", "--no-cache"],
+      cwd: String(dir),
+      env: { ...env, http_proxy: "", https_proxy: "", HTTP_PROXY: "", HTTPS_PROXY: "" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain(`Failed to join registry "${registryUrl}" and package "no-deps" URLs`);
+    expect(hits).toBe(0);
+    expect(exitCode).toBe(1);
   });
 });
 

--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -314,6 +314,42 @@ it("assetPrefix, src, and origin", async () => {
   }
 });
 
+it("src keeps a protocol-relative origin and a one-character host", () => {
+  using dir = tempDir("fsr-origin", {
+    "pages/index.tsx": "export default 1;",
+    "pages/posts/[id].tsx": "export default 1;",
+  });
+
+  const srcFor = (origin: string) =>
+    new Bun.FileSystemRouter({
+      dir: path.join(String(dir), "pages"),
+      style: "nextjs",
+      assetPrefix: "/_next/static/",
+      origin,
+    }).match("/posts/hello-world")!.src;
+
+  // `//host` used to parse with an empty host, and so did `a/` (any second byte
+  // of `/` was taken as the start of a protocol-relative URL). Both silently
+  // dropped the origin and the assetPrefix from `src`.
+  expect({
+    "//nextjs.org": srcFor("//nextjs.org"),
+    "//nextjs.org:8080": srcFor("//nextjs.org:8080"),
+    "//nextjs.org/ignored": srcFor("//nextjs.org/ignored"),
+    "a/": srcFor("a/"),
+    "https://nextjs.org/ignored": srcFor("https://nextjs.org/ignored"),
+    "nextjs.org:8080": srcFor("nextjs.org:8080"),
+    "ab/": srcFor("ab/"),
+  }).toEqual({
+    "//nextjs.org": "//nextjs.org/_next/static/posts/[id].tsx",
+    "//nextjs.org:8080": "//nextjs.org:8080/_next/static/posts/[id].tsx",
+    "//nextjs.org/ignored": "//nextjs.org/_next/static/posts/[id].tsx",
+    "a/": "a/_next/static/posts/[id].tsx",
+    "https://nextjs.org/ignored": "https://nextjs.org/_next/static/posts/[id].tsx",
+    "nextjs.org:8080": "nextjs.org:8080/_next/static/posts/[id].tsx",
+    "ab/": "ab/_next/static/posts/[id].tsx",
+  });
+});
+
 it(".query works", () => {
   // set up the test
   const { dir } = make(["posts.tsx"]);


### PR DESCRIPTION
### Problem

- `bun_url::URL::parse(b"//localhost:4873/npm/")` returns host `""`, port `""` and pathname `/localhost:4873/npm/`: the `is_protocol_relative` branch in `parse` (`src/url/lib.rs:595`) advances one byte past the `//`, so `parse_host` is handed `/localhost:4873/npm/`, stops at its first byte and returns an empty host. It has done this since the branch was added (a4b67ccbff), so no `//host` input has ever produced a host.
- The branch is also entered for any input whose second byte is `/` (`base[1] == b'/'`, without looking at `base[0]`), so a one-character host followed by a path (`a/`) loses its host the same way while `ab/` parses normally.
- Visible results (release 1.4.0):
  - `.npmrc` `registry=//127.0.0.1:4873/npm/`: `Scope::from_api` (`src/install/npm.rs:373`) takes the `:4873/npm/` left in the pathname for a `:option=value` suffix and rewrites the registry to `http://localhost/127.0.0.1/`, so `bun install` requests `GET http://localhost/127.0.0.1/<pkg>` on port 80 (captured with a listener on :80). A `//127.0.0.1:4873/npm/:_authToken=` line never matches the value either (`RegistryAuth::matches`, `src/ini/lib.rs:1169`).
  - `registry=http://a/` plus `//a/:_authToken=tok`: the key is stripped to `a/` before parsing (`src/ini/lib.rs:1060`) and gets an empty host, so the token is not applied. The same two lines with host `ab` work.
  - `new Bun.FileSystemRouter({ origin: "//cdn.example.com", assetPrefix: "/_next/static/" })`: `src` is `posts/[id].tsx`, with origin and assetPrefix both dropped because `is_absolute()` is false. Same for `origin: "a/"`.
  - `Bun.serve({ baseURI: "//host/app" })` throws `baseURI must have a hostname`, `new S3Client({ endpoint: "//host:9000" })` throws `ERR_INVALID_ARG_TYPE`, `http_proxy=//proxy:8080` connects to an empty hostname. The same strings without the two slashes (`host:9000`, `proxy:8080`) already work.

### Fix

- Take the branch only when the input starts with `//` and skip both slashes; the existing userinfo and host parsing then runs on the authority. `//host:port/path` now yields the same host, hostname, port, pathname (and username/password for `//user:pw@host/`) as `http://host:port/path`; `protocol` stays empty. `a/` now parses like `ab/`.
- Trim only the trailing side of `origin`. The leading side of that trim can only ever act on protocol-relative input (every other arm leaves `origin` empty or starting with a scheme or host byte). Keeping it would turn the origin of `//cdn.example.com` into `cdn.example.com`, and `join_write` would then emit the relative path `cdn.example.com/x.js` instead of `//cdn.example.com/x.js`.
- Why this is the right reading of the input: `//host/path` is the standard scheme-less URL form (a network-path reference in RFC 3986; what browsers resolve; the form npm uses for `.npmrc` credential keys), and Bun already reads it that way outside this function: the http client prepends the current scheme to a `//host` `Location` (`src/http/lib.rs:5102`), and `DirectoryRoute` refuses to emit a `//` redirect because clients would take it as a host (CVE-2024-43799). `URL::parse` is the lenient splitter for config strings and already accepts `host/path` and, since #38828, `[::1]:port`; this makes the `//` spelling behave like them, which is what the branch was written for.
- Blast radius: I went through all 56 `URL::parse` call sites plus `OwnedURL::url()` (notes below). `protocol` is still empty for these inputs, so every check keyed on it is unchanged: tarball credentials are still only sent when the protocol matches (`src/install/NetworkTask.rs:805`), publish `doneUrl`/`authUrl` and `--fetch-preconnect` still require http(s), a redirect from such a URL still counts as cross-origin, S3 stays https, proxies stay plain http. The sites whose output changes are the config surfaces listed above, each of which now treats `//x` the way it already treats `x`. `bun install` with `registry=//host:port/` now fails with `Failed to join registry "//host:port/"` instead of requesting from `localhost:80`; scheme-less registries without the slashes already fail the same way.
- One change that is not an improvement: `server.fetch("//x/y")` used to be joined onto the server's base as `/x/y` because its hostname parsed empty; it is now passed through, as `server.fetch("ab/c")` already is. Nothing in tests or docs uses it; `server.fetch("/x/y")` is unchanged.
- Tests:
  - `test/js/bun/util/filesystem_router.test.ts`: `src` for origins `//nextjs.org`, `//nextjs.org:8080`, `//nextjs.org/ignored` and `a/`, alongside the unchanged `https://...`, `host:port` and `ab/` forms.
  - `test/cli/install/npmrc.test.ts`: `loadNpmrc` with a protocol-relative `registry=` value (`_authToken` keys matching by host, port and path, and not matching on a different port, host or path), `//:tok@host/npm/` and `//user:pw@host/npm/` splitting credentials exactly like the `http://` spellings, a credential key for a one-character host, and an end-to-end `bun install` with `registry=//127.0.0.1:<port>/npm/` asserting the configured value is reported and the named port is never contacted.
  - Before the fix the FileSystemRouter test fails on its four fixed entries and 6 of the 11 new npmrc tests fail (the other 5 are the `http://`/`ab` controls and the non-matching keys). With the fix both files pass in full (34 and 51 tests); `config-precedence`, `redacted-config-logs` and the presign-based S3 tests pass as well.

### Background

- `bun_url::URL::parse` is Bun's allocation-free splitter for configuration strings (registry, proxy, S3 endpoint, `--origin`, `baseURI`), separate from the WHATWG parser behind `new URL()`. It never fails: it dispatches on the first byte, optionally consumes `scheme://`, optionally consumes `user:pass@`, then `parse_host` takes everything up to the first `/` or `?` as `host` (split into `hostname` and `port` at the colon) and the rest is the path. With no scheme the leading run is taken as the host, which is why `localhost:4873/` works as a registry value; `display_protocol()` fills in `http` for such URLs.
- A protocol-relative URL (RFC 3986 "network-path reference") is `//host[:port]/path`: an authority whose scheme is inherited from context.
- `origin` in this struct is the part of the input before the path (`http://host:port`, or `host:port` without a scheme). `join_write` builds asset URLs as `origin + "/" + path`; FileSystemRouter's `src` and the runtime `--origin` option go through it, and `is_absolute()` (a hostname is present) decides whether an origin is applied at all.
- `.npmrc` credentials are keyed by what npm calls a nerf dart: `//host[:port]/path/:_authToken=...`. Bun strips the `//` off the key, parses the rest with `URL::parse`, and matches host and pathname against the parsed `registry=` value.

<details>
<summary>Call-site notes</summary>

Unaffected because the input is already scheme-ful (WHATWG-normalized, built from a constant, or gated on an `http(s)://` prefix before the call): `fetch()` and `fetch.preconnect` (`src/runtime/webcore/fetch.rs`), http redirects (`src/http/lib.rs:5089`, `:5144`, `:5166`), S3 request URLs (`src/runtime/webcore/s3/*`, built by the signer), `NetworkTask` manifest/tarball URLs (`:498` and `:772` require `http(s)://`), `--registry` and the registry env vars (`PackageManagerOptions.rs:608`, `CommandLineArguments.rs`), `create`/`upgrade` API URLs and `create`'s tarball URL (`create_command.rs:2111`), `run_command.rs:849` and `:3185`, `StandaloneModuleGraph.rs:1746`, `filesystem_router.rs:583` (only for `http://`, `https://`, `file://` input), `webcore_types.rs:856` (`s3_path` only reads `protocol`/`href`), every `OwnedURL` whose href came from `URL::from_string`.

Unchanged because they are keyed on `protocol`, which stays empty: tarball credential check (`NetworkTask.rs:805`), publish `authUrl`/`doneUrl` (`publish_command.rs:1160`, `:1171`), `--fetch-preconnect` (`run_command.rs:851`), redirect same-origin comparison (`http/lib.rs:5090`, still unequal, so credential headers are still stripped), S3 `insecure_http` (`credentials_jsc.rs:127`), proxy TLS (`http/lib.rs:2716`).

Output changes, all for input spelled `//...` (or `X/...` with a one-character first segment):

| Site | Before | After |
| --- | --- | --- |
| `.npmrc`/bunfig `registry=` value, `RegistryAuth::matches` (`ini/lib.rs:1169`) | never matches a credential key | matches by host and pathname |
| `parse_registry_url_string_impl` (`api/lib.rs:41`) with `//user:pw@host/` | credentials left inside the stored URL | split out, URL becomes `http://host/...` exactly as for `http://user:pw@host/` |
| `Scope::from_api` (`install/npm.rs:358`) with `//host:port/` | rewritten to `http://localhost/host/`, requests go to port 80 | kept as written, `bun install` reports `Failed to join registry` |
| credential keys for one-character hosts (`ini/lib.rs:1160`) | empty host, never match | match |
| `PackageManagerOptions.rs:612`/`:691` credential retention when `--registry`/env overrides a `//host/` scope | host `""` never equals the override's host | compared by host, same as a scheme-less `host/` scope today |
| `Bun.serve` `baseURI` / runtime `--origin` (`ServerConfig.rs:1481`) | throws `baseURI must have a hostname` | accepted, rebuilt as `http://host:<port>/path` like a scheme-less value |
| `server.fetch("//x/y")` (`server_body.rs:2476`) | joined onto the base as `/x/y` | passed through (as `ab/c` is today) |
| FileSystemRouter `origin` (`filesystem_router.rs:938`) | origin and assetPrefix dropped | `//host/<assetPrefix>/<file>` |
| S3 `endpoint` option and `S3_ENDPOINT` (`credentials_jsc.rs:119`, `env_loader.rs:281`) | `ERR_INVALID_ARG_TYPE` / silently ignored | `host:port[/path]` over https, as `host:port` is today |
| `http_proxy`/`https_proxy` env (`env_loader.rs:355`, `http/lib.rs:2708`, `FetchTasklet.rs:1982`) | connect to an empty hostname | connect to the named proxy over plain http, as `proxy:8080` does today (#38043 moves this to the WHATWG parser) |
| `Bun.listen`/`Bun.connect` `hostname: "//h:1"` without `port` (`Handlers.rs:561`) | `Missing "port"` | port 1 taken from the string; the connect then fails on the literal hostname, as `hostname: "h:1"` does today |
| `upgrade_command.rs:637` if the GitHub release asset URL were `//...` | download fails | downloaded; the response already controls the full URL today |
</details>
