### PR TITLE
install: keep the packages bun.lock holds only through optional peers when an install re-resolves

### DIFF
--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -90,8 +90,9 @@ pub fn install_with_manager(
 
     // Snapshot the loaded-from-lockfile package count so
     // `Lockfile::get_package_id` can tell loaded pins apart from packages
-    // appended by manifest fetches in this resolve session.
-    manager.lockfile.mark_loaded_packages();
+    // appended by manifest fetches in this resolve session, and which loaded
+    // packages a non-peer dependency holds, for `clean_with_logger`.
+    manager.lockfile.mark_loaded_packages()?;
 
     let (config_version, changed_config_version) = load_result.choose_config_version();
     manager.options.config_version = Some(config_version);

--- a/src/install/dedupe.rs
+++ b/src/install/dedupe.rs
@@ -605,7 +605,8 @@ pub(crate) fn effective_version(
     Some(version)
 }
 
-// Optional-peer edges are followed too: with an in-sync package.json `clean` runs with `keep_optional_peer_targets`.
+// Optional-peer edges are followed too: `clean` keeps a target the loaded lockfile held through them alone
+// (`Lockfile::held_at_load`), and a version that survives here keeps every edge it had, so anything else they reach stays held.
 fn reachable(lockfile: &Lockfile, resolutions: &[PackageID]) -> DynamicBitSet {
     crate::lockfile::reachable::packages(
         lockfile,

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -203,6 +203,19 @@ pub struct Lockfile {
     /// Runtime-only — never serialised.
     pub(crate) loaded_package_count: PackageID,
 
+    /// `bit[id] == true` ⇔ a dependency other than an optional peer resolved
+    /// to package `id` in the lockfile as loaded. An optional peer slot never
+    /// keeps such a package alive through `clean_with_logger` (it is bound in
+    /// `Cloner::flush` if something else still reaches it), so a package whose
+    /// last real dependent leaves package.json is dropped. A loaded package
+    /// with the bit unset was held by optional peers alone; 1.3.x wrote such
+    /// entries and they are kept, otherwise every resolve would prune them and
+    /// rewrite the file on any unrelated change. Sized to
+    /// `loaded_package_count`, so packages appended during this resolve read
+    /// as held (a fresh resolve never creates peer-only entries). Set by
+    /// `mark_loaded_packages`; runtime-only — never serialised.
+    pub(crate) held_at_load: DynamicBitSet,
+
     /// `bit[id] == true` ⇔ package `id` was appended for a dependency whose
     /// version range was an exact `=X.Y.Z` (i.e. the user — root or workspace
     /// — pinned this exact version somewhere in the tree). `get_package_id`'s
@@ -969,9 +982,6 @@ impl Lockfile {
 
         let mut package_id_mapping = vec![invalid_package_id; old.packages.len()];
         let clone_queue_ = PendingResolutions::new();
-        // A frozen install never saves, so dropping peer-held targets could only fail its check.
-        let keep_optional_peer_targets =
-            manager.options.enable.frozen_lockfile() || !manager.summary.changes_resolutions();
         // Explicit `&mut *` reborrows so `old`/`manager`/`new` are
         // released back to this scope once `cloner` is dropped.
         let mut cloner = Cloner {
@@ -980,7 +990,6 @@ impl Lockfile {
             mapping: &mut package_id_mapping,
             clone_queue: clone_queue_,
             optional_peers: PendingResolutions::new(),
-            keep_optional_peer_targets,
             log,
             old_preinstall_state,
             manager: &mut *manager,
@@ -1207,7 +1216,6 @@ pub struct Cloner<'a> {
     pub(crate) clone_queue: PendingResolutions,
     /// Bound in `flush`, once `clone_queue` has decided which targets survive.
     pub(crate) optional_peers: PendingResolutions,
-    pub(crate) keep_optional_peer_targets: bool,
     pub lockfile: &'a mut Lockfile,
     pub(crate) old: &'a mut Lockfile,
     pub(crate) mapping: &'a mut [PackageID],
@@ -1986,16 +1994,32 @@ impl Lockfile {
             // session-appended, so the order-independence guard in
             // `get_package_id` applies from id 0.
             loaded_package_count: 0,
+            held_at_load: DynamicBitSet::default(),
             exact_pinned: DynamicBitSet::default(),
         }
     }
 
-    /// Snapshot `packages.len()` as the "loaded from lockfile" watermark.
-    /// Call exactly once after `load_from_cwd` (including npm/pnpm/yarn
-    /// migration) before any manifest-driven `append_package`.
-    #[inline]
-    pub(crate) fn mark_loaded_packages(&mut self) {
-        self.loaded_package_count = self.packages.len() as PackageID;
+    /// Snapshot `packages.len()` as the "loaded from lockfile" watermark and
+    /// which of those packages a non-peer dependency resolves to
+    /// (`held_at_load`). Call exactly once after `load_from_cwd` (including
+    /// npm/pnpm/yarn migration), before the differ, an update or a dedupe
+    /// re-points any resolution and before any manifest-driven
+    /// `append_package`.
+    pub(crate) fn mark_loaded_packages(&mut self) -> Result<(), AllocError> {
+        let packages_len = self.packages.len();
+        self.loaded_package_count = packages_len as PackageID;
+        let mut held = DynamicBitSet::init_empty(packages_len)?;
+        // A load that failed partway leaves `resolutions` shorter than `dependencies`;
+        // that lockfile is replaced by `init_empty` before anything reads the set.
+        let dependencies = self.buffers.dependencies.as_slice();
+        let resolutions = self.buffers.resolutions.as_slice();
+        for (dependency, &package_id) in dependencies.iter().zip(resolutions) {
+            if !dependency.behavior.is_optional_peer() && (package_id as usize) < packages_len {
+                held.set(package_id as usize);
+            }
+        }
+        self.held_at_load = held;
+        Ok(())
     }
 
     /// Record that package `id` was appended via an exact-version dependency

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -616,8 +616,14 @@ impl Package<u64> {
                 resolve_id: new_package.resolutions.off + PackageID::try_from(i).expect("int cast"),
             };
 
-            // Peer slots must not keep their target alive; bound in `Cloner::flush`.
-            if old_dependencies[i].behavior.is_optional_peer() && !cloner.keep_optional_peer_targets
+            // A peer slot must not keep a target alive that something else held
+            // when the lockfile was loaded; it is bound in `Cloner::flush` if that
+            // holder survived. A target the loaded lockfile held through optional
+            // peers alone is cloned like a dependency (see `Lockfile::held_at_load`).
+            if old_dependencies[i].behavior.is_optional_peer()
+                && old
+                    .held_at_load
+                    .is_set_allow_out_of_bound(*old_resolution as usize, true)
             {
                 cloner.optional_peers.push(pending);
                 continue;

--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -1450,6 +1450,51 @@ it("--frozen-lockfile keeps a package that an older lockfile lists only as an op
   expect(await exists(join(packageDir, "node_modules", "no-deps", "package.json"))).toBeTrue();
 });
 
+// Same entries, but the install that re-resolves and saves: a package.json change
+// unrelated to them (here a dependency bun.lock already has) must not prune them
+// either. Only a package whose real dependent leaves is dropped (the tests above).
+it("a re-resolving install keeps the packages an older lockfile holds through optional peers alone", async () => {
+  const { packageDir, packageJson } = await registry.createTestDir({
+    bunfigOpts: { saveTextLockfile: true, linker: "hoisted" },
+  });
+  const run = makeInstallRunner(packageDir);
+  const noDepsEntry = '"no-deps": ["no-deps@1.0.0"';
+  const locked = { "optional-peer-deps": "1.0.0", "uses-a-dep-1": "1.0.0" };
+  await Promise.all([
+    // a-dep is already in bun.lock through uses-a-dep-1, so nothing resolves differently.
+    write(packageJson, JSON.stringify({ name: "foo", dependencies: { ...locked, "a-dep": "1.0.1" } })),
+    write(
+      join(packageDir, "bun.lock"),
+      JSON.stringify({
+        lockfileVersion: 1,
+        configVersion: 1,
+        workspaces: { "": { name: "foo", dependencies: locked } },
+        packages: {
+          "a-dep": ["a-dep@1.0.1", "", {}, ""],
+          // only optional-peer-deps's optional peer refers to this entry
+          "no-deps": ["no-deps@1.0.0", "", {}, ""],
+          "optional-peer-deps": [
+            "optional-peer-deps@1.0.0",
+            "",
+            { peerDependencies: { "no-deps": "*" }, optionalPeers: ["no-deps"] },
+            "",
+          ],
+          "uses-a-dep-1": ["uses-a-dep-1@1.0.0", "", { dependencies: { "a-dep": "1.0.1" } }, ""],
+        },
+      }),
+    ),
+  ]);
+
+  await run(["install"]);
+  const saved = await file(join(packageDir, "bun.lock")).text();
+  expect(saved).toContain('"a-dep": "1.0.1"');
+  expect(saved).toContain(noDepsEntry);
+  expect(await exists(join(packageDir, "node_modules", "no-deps", "package.json"))).toBeTrue();
+
+  await run(["install", "--frozen-lockfile"]);
+  expect(await file(join(packageDir, "bun.lock")).text()).toBe(saved);
+});
+
 // The optional-peer-hoist-* fixtures are described in
 // registry/packages/create-optional-peer-hoist-packages.ts. In short: consumer
 // has an optional peer on target, and deep -> deep-child reaches target@1.0.0


### PR DESCRIPTION
### Problem
- Lockfiles written by bun 1.3.x hold packages that only an optional peer slot points at (1.3.x never dropped a package once an optional peer was bound to it: opencode's `encoding` and `@vitest/coverage-v8` trees, activepieces' `dockerode` tree, ...). Since #35681 `clean_with_logger` drops such packages; #38853 keeps them on a frozen install, so `--frozen-lockfile` passes, but every other install that re-resolves still prunes them (`keep_optional_peer_targets = frozen_lockfile() || !summary.changes_resolutions()`, `src/install/lockfile.rs:973`).
- An install re-resolves on any package.json edit, and on untouched checkouts whose workspaces report a diff on every run (sst/opencode@4643e65 and activepieces/activepieces at HEAD still print `Workspace package "..." has ... updated 1 dependencies` on main today, as they do on 1.3.14). On main, a plain `bun install` on a fresh clone of opencode prints `Clean lockfile: 2711 packages -> 2697 packages`, rewrites the committed `bun.lock` (-36 lines) and installs without those packages; activepieces goes `4069 -> 4063` (-22 lines, measured with #38992 applied, which fixes its other four lines). 1.3.14 re-saves both files byte-identically. So what gets installed from one lockfile depends on whether the install was frozen, and a `bun add` after upgrading carries an unrelated removal of every such package into the diff.

### Fix
- `Lockfile::mark_loaded_packages`, already called once right after load and before the differ, dedupe or an update re-point anything, also records `held_at_load`: the loaded packages some non-optional-peer dependency resolves to (one pass over the dependency rows into a bitset). In `Package::clone` an optional peer slot defers to `Cloner::flush`, and so can release its target, only for a target in that set or one appended during this resolve; a target the loaded file held through optional peers alone is cloned like a dependency. `keep_optional_peer_targets` goes away: frozen and plain installs apply the same rule.
- The #35681 behavior is unchanged: in `bun remove x` or the same edit by hand, `x` was held by a real dependency when the file was loaded, that dependency is gone after the diff, and the slot releases it. A fresh resolve never binds an optional peer to a package nothing else holds, so files written by this version are unaffected; `bun dedupe` keeps its model because a surviving version keeps every edge it had (comment in `dedupe.rs` updated). No snapshot changes (#38853 already updated the arborist fixture this affects; `edit-package-json--removed`, where a real dependent leaves, still exits 1).
- Verified:
  - `test/cli/install/bun-lock.test.ts`, "a re-resolving install keeps the packages an older lockfile holds through optional peers alone": a 1.3-shaped lockfile plus a package.json that gains a dependency the file already has. Rebuilt with main's `src/install` the plain install drops the `no-deps` entry; with this change it keeps it, installs it, and `--frozen-lockfile` accepts the saved file. #38853's frozen test and the three #35681 tests pass unchanged.
  - Debug build: every optional-peer, frozen and #38870 test in bun-lock (14) and migration/migrate (125, snapshots untouched) pass. Full bun-lock and bun-dedupe runs on this box currently fail on `ConnectionRefused` from the test registry (load average above 200) on unrelated tests as well; the same logic on yesterday's base passed bun-lock, bun-dedupe, bun-remove, frozen-lockfile-pruned, bun-update, bun-update-transitive, bun-audit, bun-prune, catalogs, bun-workspaces, isolated-install, bun-install-registry and the migration suites in full.
- Related: #38992 fixes the other shape in the same repos (required peers with a nested copy); independent of this change. #37925 would stop binding optional peers at load, which is what makes these entries reachable at all, so it conflicts with keeping them.

### Background
- An optional peer (`peerDependenciesMeta`) is never installed on its own; when a package of that name is in the tree for another reason the hoister binds the edge to it, and the binding is a resolution slot in the lockfile like any other edge. 1.3.x copied every slot when rebuilding the lockfile, so once bound, such a package stayed in the file after its real dependent left.
- `clean_with_logger` rebuilds the lockfile after resolution by cloning what the edges reach from the root (`Package::clone`, `Cloner::flush`); packages nothing reaches are dropped, and since #37426 optional peer slots are bound afterwards, only to targets something else cloned.
- `DiffSummary::changes_resolutions()` says whether the root or a workspace changed a dependency row against the lockfile; it is what decides whether an install re-resolves, and it is true on every run for some untouched projects (#38853 lists the shapes, #33632 more), which is why tying the pruning to it made the result depend on how the install was invoked.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-lock.test.ts

<!-- robobun:evidence:end -->