### PR TITLE
node:fs: honor maxRetries and retryDelay in rm and rmSync

### DIFF
--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -207,6 +207,21 @@ async function opendir(dir: string, options) {
   return promise;
 }
 
+// `retryErrorCodes` in node's lib/internal/fs/rimraf.js. rmSync's copy of this
+// set is `rm_error_is_retryable` in src/runtime/node/node_fs.rs.
+function isRmRetryError(code): boolean {
+  switch (code) {
+    case "EBUSY":
+    case "EMFILE":
+    case "ENFILE":
+    case "ENOTEMPTY":
+    case "EPERM":
+      return true;
+    default:
+      return false;
+  }
+}
+
 // Node.js closes a FileHandle's fd in its native finalizer and raises
 // ERR_INVALID_STATE (DEP0137 end-of-life) when collected without close().
 // Mirror that with a FinalizationRegistry so dropped handles don't leak fds.
@@ -358,7 +373,24 @@ const exports = {
         });
       }
     }
-    return fs.rm(path, options);
+    // The binding makes one attempt (and validates maxRetries/retryDelay); the
+    // retries are scheduled from here, like node's rimraf, so that waiting does
+    // not occupy a work-pool thread. rmSync retries inside the binding instead.
+    let retries = 0;
+    for (;;) {
+      try {
+        return await fs.rm(path, options);
+      } catch (err) {
+        if (retries >= (options?.maxRetries ?? 0) || !isRmRetryError(err?.code)) throw err;
+      }
+      retries++;
+      const { promise, resolve } = Promise.withResolvers();
+      setTimeout(resolve, retries * (options.retryDelay ?? 100));
+      await promise;
+      // The failed attempt saw the path; if the next one does not, something
+      // else removed it in between, which counts as success (as in rimraf).
+      options = { ...options, force: true };
+    }
   },
   rmdir: async function rmdir(path, options) {
     // node throws for any defined `recursive`, not just truthy ones

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -7757,7 +7757,30 @@ impl NodeFS {
         .unwrap_or(Ok(()))
     }
 
-    pub(crate) fn rm(&mut self, args: &args::Rm, _: Flavor) -> Maybe<ret::Rm> {
+    pub(crate) fn rm(&mut self, args: &args::Rm, flavor: Flavor) -> Maybe<ret::Rm> {
+        // `fs.promises.rm` retries from JS on a timer (as node's rimraf does)
+        // instead of parking a work-pool thread between attempts.
+        let max_retries = match flavor {
+            Flavor::Sync => args.max_retries,
+            Flavor::Async => 0,
+        };
+        let mut attempt: u32 = 0;
+        loop {
+            // A path that vanishes between attempts was removed by someone
+            // else; like rimraf, that counts as success even without `force`.
+            match self.rm_attempt(args, args.force || attempt > 0) {
+                Err(err) if attempt < max_retries && rm_error_is_retryable(err.get_errno()) => {
+                    attempt += 1;
+                    std::thread::sleep(core::time::Duration::from_millis(
+                        u64::from(attempt) * u64::from(args.retry_delay),
+                    ));
+                }
+                result => return result,
+            }
+        }
+    }
+
+    fn rm_attempt(&mut self, args: &args::Rm, force: bool) -> Maybe<ret::Rm> {
         // We cannot use removefileat() on macOS because it does not handle write-protected files as expected.
         if args.recursive {
             // See the matching comment in `rmdir`: pre-resolve the path on
@@ -7770,7 +7793,7 @@ impl NodeFS {
             let resolved = args.path.slice();
             if let Err(err) = zig_delete_tree(&sys::Dir::cwd(), resolved, sys::FileKind::File) {
                 if matches!(err, crate::Error::FileNotFound) {
-                    if args.force {
+                    if force {
                         return Ok(());
                     }
                     // Node reaches a missing path through the lstat() that
@@ -7809,7 +7832,7 @@ impl NodeFS {
                     args.path.slice(),
                 ) {
                     let e2 = err2.get_errno();
-                    if e2 == E::ENOENT && args.force {
+                    if e2 == E::ENOENT && force {
                         return Ok(());
                     }
                     return Err(sys::Error::from_code(map_rm_errno_narrow(e2), sys::Tag::rm)
@@ -7818,7 +7841,7 @@ impl NodeFS {
                 return Ok(());
             }
             if e1 == E::ENOENT {
-                if args.force {
+                if force {
                     return Ok(());
                 }
                 // See the recursive branch: node's ENOENT for rm comes from the
@@ -9609,6 +9632,16 @@ fn map_rm_errno_narrow(e: E) -> E {
         E::ELOOP | E::ENAMETOOLONG | E::ENOMEM | E::EROFS | E::EBUSY | E::ENOENT => e,
         _ => E::EFAULT,
     }
+}
+
+/// The errors `fs.rm`'s `maxRetries` option retries on: `retryErrorCodes` in
+/// node's lib/internal/fs/rimraf.js. `fs.promises.rm`'s copy of this set is
+/// `isRmRetryError` in src/js/node/fs.promises.ts.
+fn rm_error_is_retryable(e: E) -> bool {
+    matches!(
+        e,
+        E::EBUSY | E::EMFILE | E::ENFILE | E::ENOTEMPTY | E::EPERM
+    )
 }
 
 /// # Safety

--- a/test/js/node/fs/rm-retry-fixture.js
+++ b/test/js/node/fs/rm-retry-fixture.js
@@ -1,0 +1,106 @@
+// Run under a small `ulimit -n`. Recursive rm has to open the directory it is
+// removing, so once this process has used up its fd table every attempt fails
+// with EMFILE, one of the errors fs.rm's `maxRetries` retries on. Unlike a
+// locked directory on Windows, the condition can be created and cleared
+// deterministically from inside the process, on every POSIX platform.
+//
+// argv: <sync|promise|callback> <gives-up|recovers|vanishes> <scratch dir>
+//   gives-up: nothing clears the condition; rm must fail with EMFILE only after
+//             sleeping retryDelay, 2 * retryDelay, ... between the attempts.
+//   recovers: the fds are released while rm is retrying; rm must succeed.
+//   vanishes: the (empty) directory is rmdir'd out from under rm while it is
+//             retrying (rmdir needs no fd); rm must treat the ENOENT of the next
+//             attempt as success even though `force` was not passed.
+//
+// The attempts themselves are not observable from outside rm, so the release
+// can only be scheduled on a timer. RELEASE_DELAY_MS only has to outlast the
+// first attempt, which starts as soon as the release has been scheduled, while
+// the retry schedule below keeps going for over ten seconds, so a late timer
+// cannot turn into a spurious failure.
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { Worker, isMainThread, parentPort } = require("node:worker_threads");
+
+const RELEASE_DELAY_MS = 300;
+
+function release(action, fds, dir) {
+  if (action === "close") {
+    for (const fd of fds) fs.closeSync(fd);
+  } else {
+    fs.rmdirSync(dir);
+  }
+}
+
+if (!isMainThread) {
+  // rmSync blocks the main thread for the whole retry loop, so the release has
+  // to come from another thread. Everything the worker needs is loaded before
+  // it reports ready, because by the time the message arrives no fd is left.
+  parentPort.once("message", ({ action, fds, dir }) => {
+    setTimeout(release, RELEASE_DELAY_MS, action, fds, dir);
+  });
+  parentPort.postMessage("ready");
+} else {
+  main();
+}
+
+async function main() {
+  const [flavor, scenario, scratch] = process.argv.slice(2);
+  const dir = path.join(scratch, "target");
+  fs.mkdirSync(dir);
+  // `vanishes` rmdir's the directory out from under rm, so it has to stay empty.
+  if (scenario !== "vanishes") fs.writeFileSync(path.join(dir, "file.txt"), "x");
+
+  const rm = {
+    sync: options => fs.rmSync(dir, options),
+    promise: options => fs.promises.rm(dir, options),
+    callback: options => {
+      const { promise, resolve, reject } = Promise.withResolvers();
+      fs.rm(dir, options, err => (err ? reject(err) : resolve()));
+      return promise;
+    },
+  }[flavor];
+  const errorCode = async fn => {
+    try {
+      await fn();
+      return "ok";
+    } catch (err) {
+      return err.code;
+    }
+  };
+
+  let worker;
+  if (flavor === "sync" && scenario !== "gives-up") {
+    worker = new Worker(__filename);
+    await new Promise(resolve => worker.once("message", resolve));
+    // Let the process exit once main() is done instead of waiting for the worker.
+    worker.unref();
+  }
+
+  const fds = [];
+  try {
+    for (;;) fds.push(fs.openSync(os.devNull, "r"));
+  } catch (err) {
+    if (err.code !== "EMFILE") throw err;
+  }
+
+  // Proves the condition is in place (and that the default is still no retry)
+  // before the retrying call below is timed.
+  const probe = await errorCode(() => rm({ recursive: true }));
+
+  let options;
+  if (scenario === "gives-up") {
+    options = { recursive: true, maxRetries: 2, retryDelay: 100 };
+  } else {
+    options = { recursive: true, maxRetries: 20, retryDelay: 50 };
+    const action = scenario === "recovers" ? "close" : "rmdir";
+    if (worker) worker.postMessage({ action, fds, dir });
+    else setTimeout(release, RELEASE_DELAY_MS, action, fds, dir);
+  }
+
+  const start = performance.now();
+  const result = await errorCode(() => rm(options));
+  const elapsedMs = performance.now() - start;
+
+  console.log(JSON.stringify({ probe, result, existsAfter: fs.existsSync(dir), elapsedMs }));
+}

--- a/test/js/node/fs/rm-retry.test.ts
+++ b/test/js/node/fs/rm-retry.test.ts
@@ -1,0 +1,142 @@
+// fs.rm's `maxRetries` / `retryDelay` options: every flavor (rmSync, promises.rm
+// and the callback rm, which goes through promises.rm) retries the errors node's
+// rimraf retries (EBUSY, EMFILE, ENFILE, ENOTEMPTY, EPERM), waiting
+// retryDelay * attempt between attempts, and still fails immediately by default.
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { existsSync, promises, rmSync } from "node:fs";
+import { join } from "node:path";
+
+// `ulimit` is the POSIX way to get EMFILE cheaply (bun raises its soft fd limit
+// to the hard one at startup, and `ulimit -n` lowers both); see the fixture.
+describe.skipIf(isWindows)("fs.rm retries EMFILE when asked to", () => {
+  const fixture = join(import.meta.dir, "rm-retry-fixture.js");
+
+  async function runFixture(flavor: string, scenario: string) {
+    using scratch = tempDir("rm-retry", {});
+    await using proc = Bun.spawn({
+      cmd: ["/bin/sh", "-c", `ulimit -n 256; exec "$0" "$@"`, bunExe(), fixture, flavor, scenario, String(scratch)],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+    return JSON.parse(stdout) as { probe: string; result: string; existsAfter: boolean; elapsedMs: number };
+  }
+
+  // The fixture's probe (no retry options) must fail with EMFILE before the
+  // retrying call is made, so a passing result below can only come from retrying.
+  const flavors = ["sync", "promise", "callback"];
+
+  test.concurrent.each(flavors)("%s: gives up with the error after maxRetries, backing off linearly", async flavor => {
+    const { probe, result, existsAfter, elapsedMs } = await runFixture(flavor, "gives-up");
+    expect({ probe, result, existsAfter }).toEqual({ probe: "EMFILE", result: "EMFILE", existsAfter: true });
+    // maxRetries: 2, retryDelay: 100 waits 100ms and then 200ms. Without retries
+    // this takes a few ms; a constant delay would take 200ms. The slack covers
+    // timers rounding down to the millisecond.
+    expect(elapsedMs).toBeGreaterThanOrEqual(250);
+  });
+
+  test.concurrent.each(flavors)("%s: succeeds once the condition clears while retrying", async flavor => {
+    const { probe, result, existsAfter } = await runFixture(flavor, "recovers");
+    expect({ probe, result, existsAfter }).toEqual({ probe: "EMFILE", result: "ok", existsAfter: false });
+  });
+
+  // rimraf treats ENOENT on a retry as "somebody else removed it" even without
+  // `force`, since the path was there when the first attempt ran.
+  test.concurrent.each(["sync", "promise"])(
+    "%s: succeeds when the path is removed by someone else between attempts",
+    async flavor => {
+      const { probe, result, existsAfter } = await runFixture(flavor, "vanishes");
+      expect({ probe, result, existsAfter }).toEqual({ probe: "EMFILE", result: "ok", existsAfter: false });
+    },
+  );
+});
+
+// Errors outside rimraf's retry set are not retried: a retry here would be
+// noticeable as a 5 second wait before the same ENOENT.
+describe("fs.rm does not retry errors that retrying cannot fix", () => {
+  const options = { recursive: true, maxRetries: 1, retryDelay: 5000 };
+
+  test.concurrent("rmSync", () => {
+    using root = tempDir("rm-retry-enoent", {});
+    const missing = join(String(root), "missing");
+    const start = performance.now();
+    let error;
+    try {
+      rmSync(missing, options);
+    } catch (err) {
+      error = err;
+    }
+    expect(error).toMatchObject({ code: "ENOENT" });
+    expect(performance.now() - start).toBeLessThan(2500);
+  });
+
+  test.concurrent("promises.rm", async () => {
+    using root = tempDir("rm-retry-enoent", {});
+    const missing = join(String(root), "missing");
+    const start = performance.now();
+    await expect(promises.rm(missing, options)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(performance.now() - start).toBeLessThan(2500);
+  });
+});
+
+// The case the options exist for: Windows refuses to delete a directory that is
+// some process's working directory, or a file another process has open without
+// FILE_SHARE_DELETE, with EBUSY until that process goes away.
+describe.skipIf(!isWindows)("fs.rm retries EBUSY on Windows when asked to", () => {
+  // Each holder writes "ready" to stderr once it holds the target, keeps it for
+  // about a second and then exits on its own. The rm attempts are not observable
+  // from outside, so there is no signal to release the holder on; the hold only
+  // has to outlast the first attempt, which runs as soon as ready is read, while
+  // the retry schedule below keeps going for 41 seconds.
+  const holders = {
+    // bun running with the directory as its cwd.
+    directory: [bunExe(), "-e", `process.stderr.write("ready\\n"); setTimeout(() => {}, 1000);`],
+    // cmd keeps file.txt open (no FILE_SHARE_DELETE) as the block's stdout.
+    file: ["cmd.exe", "/d", "/c", "(echo ready 1>&2 & ping -n 2 127.0.0.1 >nul) >> file.txt"],
+  };
+
+  async function removeWhileHeld(kind: keyof typeof holders, remove: (target: string) => unknown) {
+    using root = tempDir("rm-retry-busy", { "held/file.txt": "x" });
+    const dir = join(String(root), "held");
+    const target = kind === "directory" ? dir : join(dir, "file.txt");
+    await using holder = Bun.spawn({ cmd: holders[kind], cwd: dir, env: bunEnv, stdout: "pipe", stderr: "pipe" });
+    const stdout = holder.stdout.text();
+    const { value } = await holder.stderr.getReader().read();
+    expect(new TextDecoder().decode(value)).toStartWith("ready");
+
+    // Precondition: with the default maxRetries of 0 the EBUSY surfaces at once.
+    let probe;
+    try {
+      rmSync(target, { recursive: kind === "directory" });
+    } catch (err) {
+      probe = err;
+    }
+    expect(probe).toMatchObject({ code: "EBUSY", syscall: "rm" });
+    expect(existsSync(target)).toBe(true);
+
+    await remove(target);
+    expect(existsSync(target)).toBe(false);
+    expect({ stdout: await stdout, exitCode: await holder.exited }).toEqual({ stdout: "", exitCode: 0 });
+  }
+
+  const retries = { maxRetries: 40, retryDelay: 50 };
+
+  test("rmSync removes a directory that was another process's cwd", async () => {
+    await removeWhileHeld("directory", dir => rmSync(dir, { recursive: true, ...retries }));
+  });
+
+  test("promises.rm removes a directory that was another process's cwd", async () => {
+    await removeWhileHeld("directory", dir => promises.rm(dir, { recursive: true, ...retries }));
+  });
+
+  test("rmSync removes a file another process had open", async () => {
+    await removeWhileHeld("file", file => rmSync(file, retries));
+  });
+
+  test("promises.rm removes a file another process had open", async () => {
+    await removeWhileHeld("file", file => promises.rm(file, retries));
+  });
+});


### PR DESCRIPTION
### Problem
- `fs.rmSync`, `fs.promises.rm` and `fs.rm` accept `maxRetries` / `retryDelay` but never retry: `rmSync(dir, { recursive: true, force: true, maxRetries: 20, retryDelay: 250 })` throws `EBUSY: resource busy or locked, rm '...'` immediately while another process still has `dir` as its cwd (seen cleaning up temp dirs on Windows in `test/cli/run/run-crash-handler.test.ts`).
- Node retries `EBUSY`, `EMFILE`, `ENFILE`, `ENOTEMPTY` and `EPERM` up to `maxRetries` times, waiting `retryDelay * attempt` ms before each retry (`retryErrorCodes` in `lib/internal/fs/rimraf.js`; the C++ `rmSync` uses the same set).
- `args::RmDir::from_js_impl` (`src/runtime/node/node_fs.rs`) parses and validates both options into `max_retries` / `retry_delay`, but `NodeFS::rm` made exactly one attempt for both flavors; the only reader of the fields was the `rm_options_for_testing` hook.

### Fix
- `NodeFS::rm` becomes a loop around the old body (now `rm_attempt`). For `Flavor::Sync` it retries up to `args.max_retries` times while the errno it would report is in node's set (`rm_error_is_retryable`), sleeping `attempt * retry_delay` ms in between, as node's `rmSync` does.
- For `Flavor::Async` the binding still makes one attempt; `fs.promises.rm` in `src/js/node/fs.promises.ts` (which the callback `fs.rm` already goes through) retries on a `setTimeout`, as node's rimraf does. Sleeping inside the pool job instead would park a work pool thread (one per CPU) for the whole backoff of every concurrent `rm`, stalling unrelated `fs.promises` calls, and would hold the job's ticket, which `process.exit()` and `worker.terminate()` wait for. So the retry set is spelled out twice (Rust for sync, TS for async), as it is in node; each copy points at the other.
- Retries run with `force`: the first attempt saw the path, so `ENOENT` on a later one means something else removed it meanwhile, which rimraf reports as success. Without this a retried `rm` without `force` fails with `ENOENT` on a path that is gone.
- Retries are not gated on `recursive`. The docs say the options are ignored without it, but both node implementations retry a non-recursive `rm` too, and a locked file is the common Windows case.
- Not copied from node's current C++ `rmSync`: it truncates the delay to whole seconds (`sleep(i * retryDelay / 1000)`, so the default `retryDelay: 100` sleeps 0 ms) and sleeps once more after the last attempt. This implements the documented schedule, which is what the async rimraf does (node 26 `promises.rm` with `maxRetries: 3, retryDelay: 100` under EMFILE fails after ~605 ms).
- Tests: `test/js/node/fs/rm-retry.test.ts` with `rm-retry-fixture.js`.
  - POSIX: the fixture runs under `ulimit -n` and fills its fd table, so recursive rm fails with `EMFILE`, a retryable error that can be created and cleared in-process. For rmSync, promises.rm and callback rm: the error still surfaces at once by default; with `maxRetries: 2, retryDelay: 100` the same error comes back only after the 100 + 200 ms backoff; rm succeeds when the fds are released during the retries (a worker thread releases them for the blocking rmSync, a main-thread timer for the async flavors, which also shows the async loop yields to the event loop); rm without `force` succeeds when the directory is rmdir'd out from under it between attempts (this case fails with `ENOENT` if either flavor's force-on-retry is removed).
  - All platforms: `ENOENT` with `maxRetries: 1, retryDelay: 5000` still fails immediately.
  - Windows: a directory that is a child process's cwd, and a file `cmd.exe` holds open without `FILE_SHARE_DELETE` (the non-recursive branch), both fail with `EBUSY` at once and are removed by rmSync / promises.rm with retries once the holder exits. On Windows Server 2019: 6 pass with this change, the 4 retrying cases fail with `EBUSY` on the unpatched canary.
  - Linux: the 8 POSIX retry cases fail on unpatched bun (`USE_SYSTEM_BUN=1`), all pass with the change. `fs.test.ts`, `promises.test.js`, node's `test-fs-rm*.js` and `test/internal/source-lints` also pass with the debug build.

### Background
- `NodeFS::rm` is the single implementation behind `rmSync` (called on the JS thread with `Flavor::Sync`) and `fs.promises.rm` (run as an `AsyncFSTask` job on the work pool with `Flavor::Async`); `Flavor` exists so an operation can behave differently per entry point. `args::Rm` is the parsed, validated options, the equivalent of what node's `validateRmOptions` returns.
- The work pool is a fixed set of threads, one per CPU, that runs every `fs.promises.*` call. A job holds a ticket for its VM while it runs, and a VM is torn down only after every ticket is back, so a sleeping job delays exit and worker termination.
- rimraf is node's JS implementation of the async `fs.rm`; its `retryErrorCodes` and linear backoff are the behavior reproduced here. Node's `rmSync` moved to C++ but kept the error set.
