### PR TITLE
glob: judge a `**` by its own surroundings, not by the brace branch being matched

### DIFF
--- a/src/glob/matcher.rs
+++ b/src/glob/matcher.rs
@@ -132,8 +132,9 @@ struct Wildcard {
 ///     Matches zero or more characters, except for path separators ('/' or '\').
 /// "**"
 ///     Matches zero or more characters, including path separators.
-///     Must match a complete path segment, i.e. followed by a path separator or
-///     at the end of the pattern.
+///     Must be a complete path segment, i.e. preceded by a path separator (or the
+///     start of the pattern or of a brace branch) and followed by one (or the end
+///     of the pattern). Anywhere else (`a**`, `**b`) it behaves like "*".
 /// "[ab]"
 ///     Matches one of the characters contained in the brackets.
 ///     Character ranges (e.g. "[a-z]") are also supported.
@@ -150,28 +151,19 @@ struct Wildcard {
 ///     Used to escape any of the special characters above.
 // TODO: consider just taking arena and resetting to initial state,
 // all usages of this function pass in Arena.arena()
-pub fn r#match(glob: &[u8], path: &[u8]) -> MatchResult {
-    let mut state = State::default();
-
+pub fn r#match(mut glob: &[u8], path: &[u8]) -> MatchResult {
+    // Strip the `!` prefix so that index 0 of `glob` is the start of the pattern
+    // proper, which is what `is_segment_start` checks a leading `**` against.
     let mut negated = false;
-    while (state.glob_index as usize) < glob.len() && glob[state.glob_index as usize] == b'!' {
+    while let [b'!', rest @ ..] = glob {
         negated = !negated;
-        state.glob_index += 1;
+        glob = rest;
     }
 
+    let mut state = State::default();
     let mut brace_stack = BraceStack::default();
     let mut brace_budget = BRACE_BRANCH_BUDGET;
-    // glob_start must point past the consumed `!` prefix so that a pattern-initial
-    // `**` is still recognized as being at the start of a path segment.
-    let glob_start = state.glob_index;
-    let matched = glob_match_impl(
-        &mut state,
-        glob,
-        glob_start,
-        path,
-        &mut brace_stack,
-        &mut brace_budget,
-    );
+    let matched = glob_match_impl(&mut state, glob, path, &mut brace_stack, &mut brace_budget);
 
     MatchResult {
         matches: matched != negated,
@@ -179,13 +171,11 @@ pub fn r#match(glob: &[u8], path: &[u8]) -> MatchResult {
     }
 }
 
-// `glob_start` is the index where the glob pattern starts
 #[inline(always)]
 // PERF: `inline(always)` on a fn that recurses through match_brace_branch — profile if hot.
 fn glob_match_impl(
     state: &mut State,
     glob: &[u8],
-    glob_start: u32,
     path: &[u8],
     brace_stack: &mut BraceStack,
     brace_budget: &mut u32,
@@ -199,8 +189,12 @@ fn glob_match_impl(
                 'to_else: {
                     match ch {
                         b'*' => {
+                            // A `**` that does not begin a path segment (`a**`) is two
+                            // ordinary `*`s: it must neither swallow the `/**` segments
+                            // after it nor take the globstar path below.
                             let is_globstar = (state.glob_index as usize) + 1 < glob.len()
-                                && glob[state.glob_index as usize + 1] == b'*';
+                                && glob[state.glob_index as usize + 1] == b'*'
+                                && is_segment_start(glob, brace_stack, state.glob_index);
                             if is_globstar {
                                 skip_globstars(glob, &mut state.glob_index);
                             }
@@ -232,13 +226,7 @@ fn glob_match_impl(
                                     continue 'main_loop;
                                 }
 
-                                // subtract glob_start from glob index before checking if length is less than 3. Given the pattern:
-                                // {**/a,**/b}
-                                // if we start at index 6 (start of **/b pattern), we don't want to index into the pattern before it
-                                if (state.glob_index.saturating_sub(glob_start) < 3
-                                    || glob[state.glob_index as usize - 3] == b'/')
-                                    && (!is_end_invalid || glob[state.glob_index as usize] == b'/')
-                                {
+                                if !is_end_invalid || glob[state.glob_index as usize] == b'/' {
                                     if is_end_invalid {
                                         state.glob_index += 1;
                                     }
@@ -533,14 +521,7 @@ fn match_brace_branch(
     branch_state.glob_index = branch_index;
     branch_state.brace_depth = u8::try_from(brace_stack.len()).expect("int cast");
 
-    let matched = glob_match_impl(
-        &mut branch_state,
-        glob,
-        branch_index,
-        path,
-        brace_stack,
-        brace_budget,
-    );
+    let matched = glob_match_impl(&mut branch_state, glob, path, brace_stack, brace_budget);
 
     let _ = brace_stack.pop();
 
@@ -673,6 +654,25 @@ fn get_unicode(c: &mut u32, clen: &mut u8, glob: &[u8], glob_index: &mut u32) ->
     }
 
     true
+}
+
+/// Does the `**` at `glob_index` begin a path segment (`a/**/b`, `{**/a,b}`), as
+/// opposed to continuing one (`a**/b`)? The caller checks the other half of the
+/// whole-segment rule, that a `/` or the end of the pattern follows.
+///
+/// This is decided from the `**`'s own surroundings rather than from where the current
+/// `glob_match_impl` call started, because backtracking into an enclosing globstar from
+/// inside a brace branch re-runs the pattern from before the group. The branches we
+/// are inside are the frames on `brace_stack`, so a `**` opening one of them is found
+/// there instead of by looking at the `{` or `,` before it, which may be a literal.
+#[inline(always)]
+fn is_segment_start(glob: &[u8], brace_stack: &BraceStack, glob_index: u32) -> bool {
+    glob_index == 0
+        || glob[glob_index as usize - 1] == b'/'
+        || brace_stack
+            .as_slice()
+            .iter()
+            .any(|brace| brace.branch_idx == glob_index)
 }
 
 #[inline(always)]

--- a/test/js/bun/glob/match.test.ts
+++ b/test/js/bun/glob/match.test.ts
@@ -105,6 +105,80 @@ describe("Glob.match", () => {
     expect(new Glob("**/*/c.js").match("a/b/c.js")).toBeTrue();
   });
 
+  describe("a `**` that is not a whole segment behaves like `*`", () => {
+    test("after a failed brace branch backtracks into an enclosing globstar", () => {
+      // Re-matching `a**` after the backtrack used to treat it as a globstar,
+      // so `**/a**/{x,y}` matched "ab/ay" as `**/a` + `**/` (empty) + `y`.
+      expect(new Glob("**/a**/{x,y}").match("ab/ay")).toBeFalse();
+      expect(new Glob("**/a**/{x,y}").match("ab/ax")).toBeFalse();
+      expect(new Glob("**/a**/{x}").match("ab/ax")).toBeFalse();
+      expect(new Glob("**/a**/{x,y}/c").match("ab/ay/c")).toBeFalse();
+      expect(new Glob("**/a**/{x,{y,z}}").match("ab/az")).toBeFalse();
+      expect(new Glob("**/{a,b}**/{x,y}").match("q/bz/bx")).toBeFalse();
+      expect(new Glob("!**/a**/{x,y}").match("ab/ay")).toBeTrue();
+
+      // the same patterns still match what `**/a*/{x,y}` matches
+      expect(new Glob("**/a**/{x,y}").match("ab/y")).toBeTrue();
+      expect(new Glob("**/a**/{x,y}").match("ab/ay/y")).toBeTrue();
+      expect(new Glob("**/a**/{x,y}").match("q/ab/x")).toBeTrue();
+      expect(new Glob("**/a**/{x,y}").match("ab/aq")).toBeFalse();
+      expect(new Glob("**/a**/{x,y}").match("zz/ay")).toBeFalse();
+      expect(new Glob("**/a**/{x,y}/c").match("ab/y/c")).toBeTrue();
+      expect(new Glob("**/a**/{x,{y,z}}").match("ab/z")).toBeTrue();
+      expect(new Glob("**/{a,b}**/{x,y}").match("q/bz/x")).toBeTrue();
+      expect(new Glob("!**/a**/{x,y}").match("ab/y")).toBeFalse();
+
+      // `**` that does begin a segment keeps working across the same backtrack
+      expect(new Glob("**/a/**/{x,y}").match("q/a/b/c/y")).toBeTrue();
+      expect(new Glob("**/a/**/{x,y}").match("q/a/y")).toBeTrue();
+      expect(new Glob("**/a/**/{x,y}").match("q/a/b/z")).toBeFalse();
+      expect(new Glob("**/{**/x,y}").match("a/b/x")).toBeTrue();
+      expect(new Glob("**/{**/x,y}").match("a/b/y")).toBeTrue();
+      expect(new Glob("**/{**/x,y}").match("a/b/z")).toBeFalse();
+      expect(new Glob("**/a/{b/**/x,y}").match("q/a/b/c/d/x")).toBeTrue();
+      expect(new Glob("**/a/{b/**/x,y}").match("q/a/b/c/d/z")).toBeFalse();
+
+      // controls: each of the three ingredients removed
+      expect(new Glob("**/a*/{x,y}").match("ab/ay")).toBeFalse();
+      expect(new Glob("**/a**/y").match("ab/ay")).toBeFalse();
+      expect(new Glob("a**/{x,y}").match("ab/ay")).toBeFalse();
+      expect(new Glob("*/a**/{x,y}").match("ab/ay")).toBeFalse();
+    });
+
+    test("does not absorb the `/**` segments that follow it", () => {
+      // `x**/**` used to be collapsed into a single trailing globstar,
+      // i.e. `x**`, which no longer requires the `/`.
+      expect(new Glob("x**/**").match("x")).toBeFalse();
+      expect(new Glob("x**/**").match("xy")).toBeFalse();
+      expect(new Glob("x**/**").match("x/")).toBeTrue();
+      expect(new Glob("x**/**").match("xy/")).toBeTrue();
+      expect(new Glob("x**/**").match("xy/z")).toBeTrue();
+      expect(new Glob("x**/**").match("x/y/z")).toBeTrue();
+      expect(new Glob("x**/**").match("ax/")).toBeFalse();
+
+      expect(new Glob("x**/**/y").match("xy")).toBeFalse();
+      expect(new Glob("x**/**/y").match("x/y")).toBeTrue();
+      expect(new Glob("x**/**/y").match("xq/y")).toBeTrue();
+      expect(new Glob("x**/**/y").match("xq/a/b/y")).toBeTrue();
+      expect(new Glob("x**/**/y").match("x/a/y")).toBeTrue();
+
+      expect(new Glob("**/a**/**").match("q/ab")).toBeFalse();
+      expect(new Glob("**/a**/**").match("q/ab/")).toBeTrue();
+      expect(new Glob("**/a**/**").match("q/ab/c")).toBeTrue();
+      expect(new Glob("**/a**/**").match("q/b/c")).toBeFalse();
+
+      // controls: the single-star spellings, and a `**` that does begin a segment
+      expect(new Glob("x*/**").match("x")).toBeFalse();
+      expect(new Glob("x*/**").match("xy/z")).toBeTrue();
+      expect(new Glob("x/**/**").match("x")).toBeFalse();
+      expect(new Glob("x/**/**").match("x/")).toBeTrue();
+      expect(new Glob("x/**/**").match("x/y/z")).toBeTrue();
+      expect(new Glob("**/**").match("x")).toBeTrue();
+      expect(new Glob("**/**/y").match("y")).toBeTrue();
+      expect(new Glob("**/**/y").match("a/b/y")).toBeTrue();
+    });
+  });
+
   test("braces", async () => {
     let glob: Glob;
 


### PR DESCRIPTION
### Problem

- `new Bun.Glob("**/a**/{x,y}").match("ab/ay")` returns `true`. The segment `ay` is neither `x` nor `y`; `**/a*/{x,y}` (which is what `a**` is documented to mean) correctly returns `false`, and so do picomatch, micromatch and bash. Same for `**/a**/{x}` vs `ab/ax`, `**/a**/{x,y}/c` vs `ab/ay/c`, `**/{a,b}**/{x,y}` vs `q/bz/bx`, and `!**/a**/{x,y}` gives the inverse wrong answer. Found by a Bun.Glob-vs-picomatch differential fuzzer.
- It takes all three ingredients: a real globstar earlier in the pattern, a later segment ending in a `**` that is not a whole segment, and a brace group after it. `a**/{x,y}`, `*/a**/{x,y}` and `**/a**/y` are all correct against `ab/ay`.
- Cause, `src/glob/matcher.rs`, `b'*'` arm of `glob_match_impl`: whether a `**` starts a segment was checked with `state.glob_index.saturating_sub(glob_start) < 3 || glob[glob_index - 3] == b'/'`, where `glob_start` is the index the current `glob_match_impl` call began at: 0 at top level, but the start of the branch when matching a brace alternative (so that `{**/a,**/b}` works). When a branch fails, it backtracks into the enclosing globstar, which re-runs the part of the pattern that precedes the group inside the branch's call. Every index there is below `glob_start`, the subtraction saturates to 0, and every `**` re-matched on the way back qualifies as a globstar. `**/a**/{x,y}` is then matched against `ab/ay` as `**/` = `ab/`, `a` = `a`, an empty `**/`, and `y` = `y`.
- The same check also ran only after `skip_globstars` had folded any `/**` segments following the `**` into it, so `x**/**` was matched as one trailing globstar and matched `x` and `xy` (#38996 fixes this shape on its own; see the note below).

### Fix

- `is_segment_start()` decides from the `**`'s own neighbourhood whether it begins a segment: it is at index 0 of the pattern, follows a `/`, or is the `branch_idx` of a frame on `brace_stack`. That result gates both `skip_globstars` and the globstar path; a `**` that fails it goes through the `*` arm twice, which is exactly what `a*` does. Only the "followed by `/` or end of pattern" half of the rule is still checked after the collapse.
- Why this is the right rule: the matcher's own definition of a globstar is a `**` that is a whole segment, and which position a `**` sits at does not depend on which brace branch is being tried, so the answer must not depend on `glob_start`. The brace stack holds exactly the branches we are currently inside (`match_brace_branch` pushes before matching the branch plus the rest of the pattern and pops after), so `branch_idx` identifies a branch-leading `**` wherever we arrive at it from, including by backtracking, and a literal `,` or `{` (`a,**/b`) does not qualify. For a `**` that does begin a segment nothing changes: a pattern-start `**` is index 0 (the `!` prefix is sliced off up front, which is what let the `glob_start` parameter go away), a branch-leading `**` is on the stack, and every `**` reached by the collapse is preceded by `/`.
- Test: `test/js/bun/glob/match.test.ts`, the new `describe("a \`**\` that is not a whole segment behaves like \`*\`")`. 11 of its 61 assertions fail on the unfixed binary (7 brace-backtracking shapes, 4 `x**/**` shapes); the other 50 are controls that pass before and after: the same patterns against paths they should match, real globstars across the same backtrack (`**/a/**/{x,y}`, `**/{**/x,y}`, `**/a/{b/**/x,y}`), and each of the three ingredients removed.
- `match.test.ts` (31 tests, 1582 assertions, including the ported bash/micromatch star, globstar and brace suites) and the ported `node` `fs.glob` suite (448 tests) pass with the debug build; all 61 new assertions agree with brace-expansion + picomatch.
- Differential check, fixed debug build against the current release: 4000 generated patterns (tokens mixing real globstars, brace groups with and without leading `**`, and `a**`/`**b`/`{a,b}**`/`a,**` shapes) x 40 paths. For every pattern P, fixed(P) equals unfixed(P with each non-segment `**` spelled `*`), and the 1558 patterns with no non-segment `**` are unchanged; 21 results across 12 patterns changed, all spurious matches of a non-segment `**`.
- `scan()` is unaffected: it matches one `/`-separated component at a time, so a component never backtracks into another one.
- Overlap with #38996: that PR moves the start-of-segment check ahead of the collapse but keeps it expressed as `glob_index <= glob_start`, which is what this bug needs replaced. Whichever lands second rebases to a small delta; on top of #38996 this PR is the `is_segment_start` rule plus the brace-backtracking tests.
- Not changed here: a `**` whose segment boundary is brace syntax rather than `/` (`a/{**,b}`, `{foo/**,bar}/baz`) is still matched as `*`. That is a pre-existing false negative and is tracked separately.

### Background

- The matcher (`src/glob/matcher.rs`, ported from the `glob-match` crate) is a backtracking matcher over the raw pattern bytes; braces are not expanded up front. Every `*` records a `wildcard` resume point; a qualifying `**` also records a `globstar` resume point, and a later failure resumes there to let the globstar eat one more segment and re-match everything after it.
- A brace group is matched by `match_brace`, which calls `match_brace_branch` per alternative; that pushes a `Brace { open_brace_idx, branch_idx, close_brace_idx }` frame and recursively runs `glob_match_impl` starting at the branch, over the rest of the whole pattern. The recursive call inherits the resume points, so a failure inside the branch can resume at a globstar that precedes the group and walk back through the pattern prefix while the branch's frame is still on the stack.
- "Globstar" means a `**` that is a whole path segment; any other `**` (`a**`, `**b`) is documented to behave like `*` (the `a**c`, `foo**bar`, `foo**` cases in `match.test.ts`). `skip_globstars` is the optimization that folds `**/**/**` into one globstar so the matcher does not backtrack through equivalent segments.
