### PR TITLE
crash_handler: do not report fatal signals sent with kill(2) as crashes

### DIFF
--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -1570,9 +1570,30 @@ mod draft {
 
     #[cfg(unix)]
     extern "C" fn handle_segfault_posix(sig: c_int, info: *mut libc::siginfo_t, ctx: *mut c_void) {
-        // SAFETY: kernel provides a valid siginfo_t; `si_addr` reads the per-platform
-        // sigfault address field.
-        let addr: usize = unsafe { (*info).si_addr() as usize };
+        // SAFETY: registered with SA_SIGINFO, so the kernel passes a valid
+        // siginfo_t; `si_addr` reads the per-platform sigfault address field.
+        let (si_code, addr) = unsafe { ((*info).si_code, (*info).si_addr() as usize) };
+
+        handle_posix_signal(
+            sig,
+            si_code,
+            addr,
+            match fault_context_from_ucontext(ctx) {
+                Some((pc, fp)) => TraceSeed::Fault { pc, fp },
+                None => TraceSeed::None,
+            },
+        )
+    }
+
+    /// Body of `handle_segfault_posix`, taking the two `siginfo_t` fields it
+    /// uses. `pub` so the `bun:internal-for-testing` binding can run it with
+    /// a chosen `si_code`: ASAN builds never install the handler itself
+    /// (`reset_on_posix`).
+    #[cfg(unix)]
+    pub fn handle_posix_signal(sig: c_int, si_code: c_int, addr: usize, seed: TraceSeed<'_>) -> ! {
+        if was_sent_with_kill(si_code) {
+            die_from_signal(sig);
+        }
 
         crash_handler(
             match sig {
@@ -1585,11 +1606,33 @@ mod draft {
                 // we do not register this handler for other signals
                 _ => unreachable!(),
             },
-            match fault_context_from_ucontext(ctx) {
-                Some((pc, fp)) => TraceSeed::Fault { pc, fp },
-                None => TraceSeed::None,
-            },
-        );
+            seed,
+        )
+    }
+
+    /// `kill -SEGV <pid>` / `process.kill(pid, "SIGABRT")` means "die with this
+    /// signal", not that anything in Bun faulted; for these deliveries the
+    /// `si_addr` slot of the siginfo union even holds the sender's pid, which
+    /// the report would print as the fault address.
+    ///
+    /// Linux (sigaction(2)) sets a positive `si_code` on every signal the
+    /// kernel raises itself (`SEGV_MAPERR`, `BUS_ADRERR`, `ILL_*`, `TRAP_*`,
+    /// `SI_KERNEL`), `SI_TKILL` for `tgkill(2)`, which is how libc's `abort()`
+    /// and `raise()` deliver SIGABRT, and `SI_USER` / `SI_QUEUE` for `kill(2)` /
+    /// `sigqueue(3)`. Only the last two are diverted. Other platforms keep
+    /// reporting every delivery: the check relies on the Linux codes (the libc
+    /// crate does not even define `SI_USER` for Apple targets).
+    #[cfg(unix)]
+    fn was_sent_with_kill(si_code: c_int) -> bool {
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        {
+            matches!(si_code, libc::SI_USER | libc::SI_QUEUE)
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
+        {
+            let _ = si_code;
+            false
+        }
     }
 
     #[cfg(unix)]
@@ -2964,56 +3007,7 @@ mod draft {
     fn crash(reason: CrashReason) -> ! {
         #[cfg(not(windows))]
         {
-            let sig = reason.terminal_signal();
-
-            // Install default handler so that the raise below will terminate.
-            // bun_sys::posix has no Sigaction yet — use libc directly (async-signal-safe).
-            // SAFETY: all-zero is a valid sigaction (handler = SIG_DFL = 0, flags = 0).
-            let mut sigact: libc::sigaction = bun_core::ffi::zeroed();
-            sigact.sa_sigaction = libc::SIG_DFL;
-            // SAFETY: sa_mask is a valid out-pointer into a zeroed struct.
-            unsafe {
-                libc::sigemptyset(&raw mut sigact.sa_mask);
-            }
-            for s in [
-                libc::SIGSEGV,
-                libc::SIGILL,
-                libc::SIGBUS,
-                libc::SIGABRT,
-                libc::SIGFPE,
-                libc::SIGHUP,
-                libc::SIGTERM,
-                // Keep SIGTRAP reset so the `core::intrinsics::abort()`
-                // fallback (brk on aarch64) is lethal even when JS installed
-                // a SIGTRAP listener via `process.on("SIGTRAP")` (npm's
-                // `signal-exit` package does).
-                libc::SIGTRAP,
-            ] {
-                // SAFETY: &sigact is a valid sigaction; null oldact is permitted.
-                unsafe {
-                    libc::sigaction(s, &raw const sigact, core::ptr::null_mut());
-                }
-            }
-
-            // We may be running inside the signal handler for `sig`, in which
-            // case the kernel added it to this thread's mask and a re-raise
-            // would sit pending forever. Unblock it so the raise below is
-            // delivered. pthread_sigmask is async-signal-safe.
-            // SAFETY: zeroed sigset is valid; sigemptyset/sigaddset initialize it.
-            unsafe {
-                let mut set: libc::sigset_t = bun_core::ffi::zeroed();
-                libc::sigemptyset(&raw mut set);
-                libc::sigaddset(&raw mut set, sig);
-                libc::pthread_sigmask(libc::SIG_UNBLOCK, &raw const set, core::ptr::null_mut());
-            }
-
-            // SAFETY: raise has no preconditions; with SIG_DFL installed and
-            // the signal unblocked this terminates the process.
-            unsafe {
-                libc::raise(sig);
-            }
-            // If we somehow get here, fall through to a guaranteed-fatal trap.
-            core::intrinsics::abort();
+            die_from_signal(reason.terminal_signal())
         }
         #[cfg(windows)]
         {
@@ -3027,6 +3021,62 @@ mod draft {
             // the CRT `abort() has been called` message, and can invoke WER.
             abort()
         }
+    }
+
+    /// Terminate through `sig`'s default action. Used both after a crash
+    /// report has been printed and for fatal signals that were sent with
+    /// kill(2) (`handle_posix_signal`), which die exactly as they would have
+    /// without our handler installed. Everything here is async-signal-safe.
+    #[cfg(unix)]
+    fn die_from_signal(sig: c_int) -> ! {
+        // Install default handler so that the raise below will terminate.
+        // bun_sys::posix has no Sigaction yet — use libc directly (async-signal-safe).
+        // SAFETY: all-zero is a valid sigaction (handler = SIG_DFL = 0, flags = 0).
+        let mut sigact: libc::sigaction = bun_core::ffi::zeroed();
+        sigact.sa_sigaction = libc::SIG_DFL;
+        // SAFETY: sa_mask is a valid out-pointer into a zeroed struct.
+        unsafe {
+            libc::sigemptyset(&raw mut sigact.sa_mask);
+        }
+        for s in [
+            libc::SIGSEGV,
+            libc::SIGILL,
+            libc::SIGBUS,
+            libc::SIGABRT,
+            libc::SIGFPE,
+            libc::SIGHUP,
+            libc::SIGTERM,
+            // Keep SIGTRAP reset so the `core::intrinsics::abort()`
+            // fallback (brk on aarch64) is lethal even when JS installed
+            // a SIGTRAP listener via `process.on("SIGTRAP")` (npm's
+            // `signal-exit` package does).
+            libc::SIGTRAP,
+        ] {
+            // SAFETY: &sigact is a valid sigaction; null oldact is permitted.
+            unsafe {
+                libc::sigaction(s, &raw const sigact, core::ptr::null_mut());
+            }
+        }
+
+        // We may be running inside the signal handler for `sig`, in which
+        // case the kernel added it to this thread's mask and a re-raise
+        // would sit pending forever. Unblock it so the raise below is
+        // delivered. pthread_sigmask is async-signal-safe.
+        // SAFETY: zeroed sigset is valid; sigemptyset/sigaddset initialize it.
+        unsafe {
+            let mut set: libc::sigset_t = bun_core::ffi::zeroed();
+            libc::sigemptyset(&raw mut set);
+            libc::sigaddset(&raw mut set, sig);
+            libc::pthread_sigmask(libc::SIG_UNBLOCK, &raw const set, core::ptr::null_mut());
+        }
+
+        // SAFETY: raise has no preconditions; with SIG_DFL installed and
+        // the signal unblocked this terminates the process.
+        unsafe {
+            libc::raise(sig);
+        }
+        // If we somehow get here, fall through to a guaranteed-fatal trap.
+        core::intrinsics::abort();
     }
 
     pub static VERBOSE_ERROR_TRACE: AtomicBool = AtomicBool::new(false);

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -125,6 +125,8 @@ export const crash_handler = $rust("crash_handler.rs", "js_bindings.generate") a
   abort: () => void;
   fastfail: () => void;
   trap: () => void;
+  /** Runs the POSIX fatal-signal handler as if `signo` arrived with this `si_code`. No-op on Windows. */
+  handlePosixSignal: (signo: number, siCode: number) => void;
   raiseIgnoringPanicHandler: () => void;
 };
 

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -29,6 +29,7 @@ pub(crate) mod js_bindings {
             ("abort", __jsc_host_js_abort),
             ("fastfail", __jsc_host_js_fastfail),
             ("trap", __jsc_host_js_trap),
+            ("handlePosixSignal", __jsc_host_js_handle_posix_signal),
             (
                 "raiseIgnoringPanicHandler",
                 __jsc_host_js_raise_ignoring_panic_handler,
@@ -195,6 +196,32 @@ pub(crate) mod js_bindings {
         );
         #[allow(unreachable_code)]
         Ok(JSValue::UNDEFINED)
+    }
+
+    /// `handlePosixSignal(signo, si_code)`: runs the fatal-signal handler as
+    /// if the kernel had delivered `signo` with that `si_code`, so the
+    /// kill(2)-vs-fault classification is testable in ASAN builds too (they
+    /// never install the real handler). The fault address is fixed at
+    /// 0xDEADBEEF, like `segfault` above, so tests can assert on it.
+    #[bun_jsc::host_fn]
+    fn js_handle_posix_signal(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+        let signo = frame.argument(0).coerce_to_i32(global)?;
+        let si_code = frame.argument(1).coerce_to_i32(global)?;
+        #[cfg(unix)]
+        {
+            crash_handler::suppress_core_dumps_if_necessary();
+            crash_handler::handle_posix_signal(
+                signo,
+                si_code,
+                0xDEADBEEF,
+                crash_handler::TraceSeed::BeginAddr(crash_handler::debug::return_address()),
+            )
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = (signo, si_code);
+            Ok(JSValue::UNDEFINED)
+        }
     }
 
     #[bun_jsc::host_fn]

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -2,6 +2,7 @@ import { crash_handler } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, isDebug, isLinux, isPosix, isWindows, mergeWindowEnvs, tempDir } from "harness";
 import { rmSync } from "node:fs";
+import { constants as osConstants } from "node:os";
 import path from "path";
 const { getMachOImageZeroOffset } = crash_handler;
 
@@ -385,9 +386,18 @@ test("raise ignoring panic handler does not trigger the panic handler", async ()
   expect(sent).toBe(false);
 });
 
+// For children that terminate via SIG_DFL (rather than via a test hook that
+// calls suppress_core_dumps_if_necessary()): on the --coredump-upload CI lane
+// the runner flags leaked core files as a hard failure. ulimit -c 0 in a shell
+// wrapper is inherited by the bun child; every user is isPosix/isLinux-gated
+// so /bin/sh is available.
+const noCoreCmd = (argv: string[]) => ["/bin/sh", "-c", `ulimit -c 0 && exec "$@"`, "--", ...argv];
+
 // SIGABRT (libc abort(), mimalloc/glibc heap-corruption, std::terminate) and
 // SIGTRAP (WTF CRASH()/RELEASE_ASSERT, __builtin_trap() -> `brk` on aarch64)
-// must route through the crash handler so they are not silently lost.
+// must route through the crash handler so they are not silently lost. Outside
+// ASAN builds the abort/trap hooks raise the real signal, so these also prove
+// the sigaction registration itself.
 describe.if(isPosix)("SIGABRT/SIGTRAP are caught by the crash handler", () => {
   test.concurrent.each([
     ["abort", "SIGABRT", "abort() called"],
@@ -435,37 +445,6 @@ describe.if(isPosix)("SIGABRT/SIGTRAP are caught by the crash handler", () => {
     expect(sent).toBe(true);
   });
 
-  // These two tests terminate via SIG_DFL (not via a test hook that calls
-  // suppress_core_dumps_if_necessary()), so on the --coredump-upload CI lane
-  // the runner would flag leaked core files as a hard failure. ulimit -c 0 in
-  // a shell wrapper is inherited by the bun child; the whole describe is
-  // isPosix-gated so /bin/sh is available.
-  const noCoreCmd = (argv: string[]) => ["/bin/sh", "-c", `ulimit -c 0 && exec "$@"`, "--", ...argv];
-
-  // The above goes via the internal test hook, which under ASAN calls the
-  // handler directly because ASAN owns the fault signals. This case raises the
-  // signal for real to prove the sigaction registration itself; ASAN builds
-  // never install those handlers so skip there.
-  test.skipIf(isASAN).concurrent.each(["SIGABRT", "SIGTRAP"] as const)(
-    "raised %s produces a crash report",
-    async signal => {
-      await using proc = Bun.spawn({
-        cmd: noCoreCmd([
-          bunExe(),
-          "-e",
-          `process.kill(process.pid, "${signal}")`,
-          "--debug-crash-handler-use-trace-string",
-        ]),
-        env: noReportEnv,
-        stdio: ["ignore", "pipe", "pipe"],
-      });
-      const [stderr] = await Promise.all([proc.stderr.text(), proc.exited]);
-
-      expect(stderr).toContain("oh no");
-      expect(proc.signalCode).toBe(signal);
-    },
-  );
-
   // process.abort() is a deliberate user action, not a Bun crash. It must still
   // terminate with SIGABRT but must not print a crash report or upload one.
   test.concurrent("process.abort() does not report a crash", async () => {
@@ -497,6 +476,126 @@ describe.if(isPosix)("SIGABRT/SIGTRAP are caught by the crash handler", () => {
     expect(stderr).not.toContain(server.url.toString());
     expect(proc.signalCode).toBe("SIGABRT");
     expect(sent).toBe(false);
+  });
+});
+
+// The crash handler is registered for SIGSEGV/SIGBUS/SIGILL/SIGFPE/SIGABRT/
+// SIGTRAP, but one of those arriving from kill(2) (`kill -SEGV`, a timeout
+// tool sending SIGABRT, `process.kill(process.pid, child.signal)` mirroring a
+// child's death) is not a fault in Bun. It has to die from the signal exactly
+// like a process without a handler (and like Node) does: no report, no upload.
+// Linux only: the handler tells the two apart with si_code, which only Linux
+// defines usefully (see was_sent_with_kill in src/crash_handler/lib.rs).
+describe.if(isLinux)("fatal signals sent with kill(2) are not reported as crashes", () => {
+  const handledSignals = ["SIGSEGV", "SIGBUS", "SIGILL", "SIGFPE", "SIGABRT", "SIGTRAP"] as const;
+
+  // Real deliveries need the sigaction handler, which ASAN builds leave
+  // uninstalled so that ASAN's own fault diagnostics stay in charge.
+  describe.skipIf(isASAN)("delivered by the kernel", () => {
+    test.concurrent("a signal from another process dies silently, reporting enabled", async () => {
+      let sent = false;
+      using server = Bun.serve({
+        port: 0,
+        fetch() {
+          sent = true;
+          return new Response("OK");
+        },
+      });
+
+      await using proc = Bun.spawn({
+        // Keep the event loop alive; "ready" proves startup (and the crash
+        // handler's sigaction registration) completed before the kill.
+        cmd: noCoreCmd([bunExe(), "-e", `console.log("ready"); setInterval(() => {}, 1 << 30);`]),
+        env: mergeWindowEnvs([
+          bunEnv,
+          {
+            BUN_CRASH_REPORT_URL: server.url.toString(),
+            BUN_ENABLE_CRASH_REPORTING: "1",
+            GITHUB_ACTIONS: undefined,
+            CI: undefined,
+          },
+        ]),
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      const decoder = new TextDecoder();
+      let stdout = "";
+      for await (const chunk of proc.stdout) {
+        stdout += decoder.decode(chunk, { stream: true });
+        if (stdout.includes("ready\n")) break;
+      }
+      expect(stdout).toBe("ready\n");
+
+      proc.kill("SIGSEGV");
+      const [stderr] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+      expect(stderr).toBe("");
+      expect(proc.signalCode).toBe("SIGSEGV");
+      expect(sent).toBe(false);
+    });
+
+    test.concurrent.each(handledSignals)("process.kill(process.pid, %s) dies silently from it", async signal => {
+      await using proc = Bun.spawn({
+        cmd: noCoreCmd([bunExe(), "-e", `process.kill(process.pid, "${signal}")`]),
+        env: noReportEnv,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      const [stderr] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+      expect(stderr).toBe("");
+      expect(proc.signalCode).toBe(signal);
+    });
+  });
+
+  // Same handler body, fed a chosen si_code through the test hook, so the
+  // classification is covered in ASAN builds as well. Values are the Linux
+  // ones from sigaction(2) / <asm-generic/siginfo.h>.
+  describe("classified by si_code", () => {
+    const SI_USER = 0; // kill(2)
+    const SI_QUEUE = -1; // sigqueue(3)
+    const SI_TKILL = -6; // tgkill(2): how glibc and musl deliver abort() and raise()
+    const SI_KERNEL = 0x80; // kernel-raised without a more specific code, e.g. int3 -> SIGTRAP on x86_64
+    const SEGV_MAPERR = 1; // access to an unmapped address
+    const BUS_ADRERR = 2; // access to a nonexistent physical address, e.g. past the end of a truncated mmap'd file
+
+    const runHook = async (signal: (typeof handledSignals)[number], siCode: number) => {
+      await using proc = Bun.spawn({
+        cmd: noCoreCmd([
+          bunExe(),
+          "-e",
+          `require("bun:internal-for-testing").crash_handler.handlePosixSignal(${osConstants.signals[signal]}, ${siCode})`,
+          "--debug-crash-handler-use-trace-string",
+        ]),
+        env: noReportEnv,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      const [stderr] = await Promise.all([proc.stderr.text(), proc.exited]);
+      return { stderr, signalCode: proc.signalCode };
+    };
+
+    test.concurrent.each([
+      ["SIGSEGV", "SI_USER", SI_USER],
+      ["SIGBUS", "SI_USER", SI_USER],
+      ["SIGILL", "SI_USER", SI_USER],
+      ["SIGFPE", "SI_USER", SI_USER],
+      ["SIGABRT", "SI_USER", SI_USER],
+      ["SIGTRAP", "SI_USER", SI_USER],
+      ["SIGSEGV", "SI_QUEUE", SI_QUEUE],
+      ["SIGABRT", "SI_QUEUE", SI_QUEUE],
+    ] as const)("%s with %s dies silently from the signal", async (signal, _name, siCode) => {
+      expect(await runHook(signal, siCode)).toEqual({ stderr: "", signalCode: signal });
+    });
+
+    test.concurrent.each([
+      ["SIGABRT", "SI_TKILL", SI_TKILL, "abort() called"],
+      ["SIGSEGV", "SEGV_MAPERR", SEGV_MAPERR, "Segmentation fault at address 0xDEADBEEF"],
+      ["SIGBUS", "BUS_ADRERR", BUS_ADRERR, "Bus error at address 0xDEADBEEF"],
+      ["SIGTRAP", "SI_KERNEL", SI_KERNEL, "Trap instruction at address 0xDEADBEEF"],
+    ] as const)("%s with %s is still reported as a crash", async (signal, _name, siCode, message) => {
+      const { stderr, signalCode } = await runHook(signal, siCode);
+      expect(stderr).toContain(message);
+      expect(stderr).toContain("oh no: Bun has crashed");
+      expect(signalCode).toBe(signal);
+    });
   });
 });
 


### PR DESCRIPTION
### Problem
- A SIGSEGV/SIGBUS/SIGILL/SIGFPE/SIGABRT/SIGTRAP that reaches bun through `kill(2)` is reported as a bun crash. `BUN_ENABLE_CRASH_REPORTING=0 bun -e 'process.kill(process.pid, "SIGSEGV")'` prints `panic(main thread): Segmentation fault at address 0x150E` followed by `oh no: Bun has crashed. This indicates a bug in Bun, not your code.` and a bun.report link; with reporting enabled (CI) it also uploads. `node -e` with the same line dies from the signal with no output.
- `0x150E` is the pid of the process that sent the signal: for a `kill(2)` delivery the siginfo union holds `si_pid`/`si_uid` in the bytes the handler reads as `si_addr`.
- Cause: `handle_segfault_posix` (src/crash_handler/lib.rs) turned every delivery of those signals into a `CrashReason` without looking at `si_code`, which is where the kernel says whether it raised the signal itself or a process sent it.
- Where this shows up: `scripts/build.ts` re-raises the built binary's death signal on itself (`process.kill(process.pid, child.signal)`), so every `bun bd ...` whose debug binary dies by signal ends with a second, bogus crash report from the outer bun; `bun.spawnSync` forwards SIGABRT/SIGTRAP it receives to the child with `kill(2)`, so a bun child reports a crash; `node:wasi`'s `proc_raise` goes through `process.kill(process.pid, sig)`; any `kill -SEGV`/`kill -ABRT` from a shell or a timeout tool.

### Fix
- On Linux, `handle_posix_signal` checks `si_code` first: `SI_USER` (`kill(2)`) and `SI_QUEUE` (`sigqueue(3)`) deliveries skip the report, restore the terminal, and terminate through the signal's default action. That is the same exit bun's SIGINT/SIGTERM handler takes (`onExitSignal` in c-bindings.cpp: `bun_restore_stdio`, SIG_DFL, re-raise), and what node does.
- Everything else still reports. The kernel attaches a positive `si_code` to every signal it raises itself (`SEGV_MAPERR`, `BUS_ADRERR`, `ILL_ILLOPN`, `FPE_INTDIV`, `TRAP_BRKPT`, `SI_KERNEL` for x86 `int3` and non-canonical-address faults), and glibc and musl implement `abort()`/`raise()` with `tgkill(2)`, which arrives as `SI_TKILL`, so the `abort() called` report added in #34771 keeps firing (probe output below).
- Only the two "a process sent this" codes are diverted rather than everything `<= 0`, so an unexpected code still errs on the side of producing a report.
- Linux only. The check is written against the codes sigaction(2) documents for Linux; the libc crate does not define `SI_USER` for Apple targets, and I could not verify what XNU puts in `si_code` for `kill(2)` versus the `pthread_kill` inside `abort()`, so rather than risk silencing real aborts, non-Linux platforms keep the previous behavior. Windows is unaffected (no signals).
- Intentional behavior changes on Linux, for the record: `kill -ABRT`/`kill -SEGV` on a hung bun now yields a core dump (default action) instead of a one-thread trace string labelled as a crash, and a `bun --watch` process sent one of these signals dies instead of going through the crash handler's auto-restart. In both cases the signal was an explicit request to die; actual crashes behave as before.
- The SIG_DFL reset + unblock + `raise` tail of `crash()` moves into `die_from_signal()` unchanged and is used by both paths, so a kill(2) delivery terminates the same way a crash does after its report (same signal, `WIFSIGNALED` as before; the difference is the missing report and upload).
- Test hook: ASAN builds never install the POSIX handler (`reset_on_posix` returns early so ASAN's own fault diagnostics stay in charge), so the handler body is split into `handle_posix_signal(sig, si_code, addr, seed)` and exposed as `crash_handler.handlePosixSignal(signo, siCode)` in `bun:internal-for-testing`, following the existing `segfault`/`abort`/`trap` hooks that call the handler directly under ASAN.
- Tests, in test/cli/run/run-crash-handler.test.ts:
  - `delivered by the kernel` (skipped under ASAN): the parent sends SIGSEGV to an idle child with crash reporting pointed at a local server (no stderr, no upload, dies from SIGSEGV), and `process.kill(process.pid, X)` for each of the six signals. On the current release build all seven fail with the crash report in stderr.
  - `classified by si_code` (runs everywhere, including ASAN): SI_USER for all six signals and SI_QUEUE die silently; `SIGABRT`+`SI_TKILL` still prints `abort() called`, and `SEGV_MAPERR`/`BUS_ADRERR`/`SI_KERNEL` still print the fault reports with the hook's `0xDEADBEEF` address; a child running in a `Bun.Terminal` pty that puts stdin into raw mode and then takes the SI_USER path leaves the pty with ICANON/ECHO set again.
  - The previous `raised %s produces a crash report` test asserted the old behavior (`process.kill(process.pid, "SIGABRT")` must report) and is removed; its stated purpose, proving the sigaction registration, is already covered by the `abort`/`trap` cases above it, which raise the real signal outside ASAN.
- Verified: `bun bd test test/cli/run/run-crash-handler.test.ts` passes (the kernel-delivery cases skip under ASAN); the same file on the unfixed release build fails all 20 new cases; the release CI lanes of the first push ran the kernel-delivery cases green. `cargo check -p bun_crash_handler` for the darwin, windows, freebsd, musl and android targets and `cargo check -p bun_runtime` for windows pass; run-propagate-sigkill, parallel.test.ts (fastfail), issue 30205 and child_process `signal codes` still pass.
- Not changed: `process.kill(process.pid, fatal)` on macOS still reports. Fixing that would have to happen at the `process._kill` call site (reset the disposition first, the way `process.abort()` already does), and only when the crash handler owns the disposition; left as a follow-up.

### Background
- `si_code` is the field of `siginfo_t` that records the origin of a signal. Kernel-raised signals get a positive, signal-specific code (`SEGV_MAPERR` = unmapped address, `BUS_ADRERR`, `TRAP_BRKPT`, ...) or the generic `SI_KERNEL` (0x80); signals sent by a process get a code `<= 0`: `SI_USER` (0) for `kill(2)`, `SI_QUEUE` (-1) for `sigqueue(3)`, `SI_TKILL` (-6) for `tkill`/`tgkill(2)`. The rest of `siginfo_t` is a union whose layout depends on that origin: the fault address for kernel-raised signals, the sender's pid and uid for sent ones.
- `abort()` in glibc and musl is `raise(SIGABRT)`, and `raise` is implemented with `tgkill(2)` on the calling thread, hence `SI_TKILL`. Diverting that code would silence real aborts, which is why the check names `SI_USER`/`SI_QUEUE` explicitly.
- `bun_restore_stdio` (c-bindings.cpp) writes the termios snapshot taken at startup back to any stdio fd that is a TTY. It is built to run from signal context (it is what the SIGINT/SIGTERM handler calls) and every other signal-death path in bun calls it, which is why the new path does too.
- The handler is installed with `SA_RESETHAND`, and the kernel blocks a signal while its handler runs. Terminating "as if unhandled" therefore means installing SIG_DFL, unblocking the signal, and `raise()`ing it; that is the code that already existed at the end of `crash()` and now lives in `die_from_signal()`.
- ASAN builds skip installing the POSIX handler entirely (`reset_on_posix`), so `bun bd` (ASAN) cannot observe the real handler; that is why the classification has a test hook and the real-delivery tests are `skipIf(isASAN)`.

<details>
<summary>si_code the kernel attaches to each way of getting these signals (Linux 6.17, glibc 2.41, x86_64; small C probe with an SA_SIGINFO handler)</summary>

```
sig=11 si_code=0 si_pid=20090 si_addr=0x4e7a      kill(getpid(), SIGSEGV)        (si_addr is the pid)
sig=6  si_code=0 si_pid=20091 si_addr=0x4e7b      kill(getpid(), SIGABRT)
sig=6  si_code=-1                                 sigqueue(getpid(), SIGABRT)
sig=6  si_code=-6                                 abort()                        (SI_TKILL, still reported)
sig=11 si_code=-6                                 raise(SIGSEGV)                 (SI_TKILL, still reported)
sig=11 si_code=1 si_addr=0x10                     *(int*)0x10 = 1                (SEGV_MAPERR)
sig=11 si_code=128 si_addr=(nil)                  non-canonical address store    (SI_KERNEL)
sig=5  si_code=128                                int3                           (SI_KERNEL)
sig=4  si_code=2                                  __builtin_trap / ud2           (ILL_ILLOPN)
sig=8  si_code=1                                  integer divide by zero         (FPE_INTDIV)
```
</details>

<details>
<summary>Earlier revision</summary>

The first push terminated kill(2) deliveries without restoring the terminal. Self-review pointed out that every other signal-death path in bun (`onExitSignal`, `raise_ignoring_panic_handler`, the crash report path that these deliveries used to take) restores it first, so the second push adds the `bun_restore_stdio` call and the pty test for it.
</details>
