### PR TITLE
test: add seeded differential fuzz oracles for node:path, Bun.Glob, source maps and the transpiler

### DIFF
--- a/test/_util/fuzz.ts
+++ b/test/_util/fuzz.ts
@@ -64,13 +64,20 @@ export interface Fuzz {
   readonly iters: number;
   /** Appended to the test name so a failure line shows the seed it ran with. */
   readonly label: string;
+  /**
+   * Third argument for `test()`: undefined (the runner's own per-test timeout)
+   * unless the iteration count was raised for a soak, in which case the default
+   * budget is scaled up with it.
+   */
+  readonly timeout: number | undefined;
   /** Replay instructions for a failure message. */
   repro(iteration: number): string;
 }
 
 /**
  * Reads `${prefix}_SEED` and `${prefix}_ITERS` (for example `BUN_GLOB_FUZZ_SEED`
- * and `BUN_GLOB_FUZZ_ITERS`), falling back to the given defaults.
+ * and `BUN_GLOB_FUZZ_ITERS`), falling back to the given defaults. The default
+ * iteration count is sized so the test takes a few seconds on a debug build.
  */
 export function fuzzEnv(prefix: string, defaultSeed: number, defaultIters: number): Fuzz {
   const seedName = `${prefix}_SEED`;
@@ -80,6 +87,7 @@ export function fuzzEnv(prefix: string, defaultSeed: number, defaultIters: numbe
     seed,
     iters,
     label: `(seed=${seed}, iters=${iters})`,
+    timeout: iters > defaultIters ? Math.ceil(iters / defaultIters) * 5_000 : undefined,
     repro(iteration: number): string {
       return `seed=${seed} iteration=${iteration} (replay with ${seedName}=${seed})`;
     },

--- a/test/_util/fuzz.ts
+++ b/test/_util/fuzz.ts
@@ -1,17 +1,19 @@
 /**
  * Shared plumbing for the seeded differential fuzz tests (Bun.JSONC.parse vs
- * JSON.parse, node:path vs node, Bun.Glob vs picomatch, Bun.build sourcemaps vs
- * the `source-map` decoder, the transpiler printer vs acorn).
+ * JSON.parse, node:path vs node, Bun.Glob vs picomatch, Bun.build source maps
+ * vs the `source-map` decoder, the transpiler vs acorn and itself).
  *
- * Every oracle is deterministic for a seed, runs a few hundred iterations by
- * default, and puts the seed and iteration into each failure message, so a CI
- * failure replays locally and a long soak is one environment variable away:
+ * Every oracle generates its cases from one seeded generator, so case N is the
+ * same however many cases a run asks for, and every failure message carries the
+ * seed and the case number. A CI failure therefore replays locally with the two
+ * environment variables it prints, and a long soak is one variable away:
  *
- *     BUN_PATH_FUZZ_SEED=1234 bun bd test path-differential-fuzz
+ *     BUN_PATH_FUZZ_SEED=1234 BUN_PATH_FUZZ_ITERS=57 bun bd test path-differential-fuzz
  *     BUN_PATH_FUZZ_ITERS=20000 bun bd test path-differential-fuzz
  */
+import { isDebug } from "harness";
 
-/** mulberry32: a 32-bit seed is enough state, and it is fast under a debug JSC. */
+/** mulberry32: 32 bits of state is plenty, and it stays fast under a debug JSC. */
 export class Rng {
   private a: number;
   constructor(seed: number) {
@@ -62,34 +64,37 @@ export function envIters(name: string, fallback: number): number {
 export interface Fuzz {
   readonly seed: number;
   readonly iters: number;
-  /** Appended to the test name so a failure line shows the seed it ran with. */
+  /** Appended to the test name, so a failure line shows what the run used. */
   readonly label: string;
   /**
    * Third argument for `test()`: undefined (the runner's own per-test timeout)
    * unless the iteration count was raised for a soak, in which case the default
-   * budget is scaled up with it.
+   * run's budget is scaled up with it.
    */
   readonly timeout: number | undefined;
-  /** Replay instructions for a failure message. */
+  /** Replay instructions, for the failure message of case `iteration` (0-based). */
   repro(iteration: number): string;
 }
 
 /**
  * Reads `${prefix}_SEED` and `${prefix}_ITERS` (for example `BUN_GLOB_FUZZ_SEED`
- * and `BUN_GLOB_FUZZ_ITERS`), falling back to the given defaults. The default
- * iteration count is sized so the test takes a few seconds on a debug build.
+ * and `BUN_GLOB_FUZZ_ITERS`). The default iteration counts are sized for a few
+ * seconds of test time; a debug build's JavaScriptCore runs the generators and
+ * the reference implementations far slower, so it gets its own, smaller default.
  */
-export function fuzzEnv(prefix: string, defaultSeed: number, defaultIters: number): Fuzz {
+export function fuzzEnv(prefix: string, defaultSeed: number, defaultIters: { release: number; debug: number }): Fuzz {
   const seedName = `${prefix}_SEED`;
+  const itersName = `${prefix}_ITERS`;
   const seed = envSeed(seedName, defaultSeed);
-  const iters = envIters(`${prefix}_ITERS`, defaultIters);
+  const budget = isDebug ? defaultIters.debug : defaultIters.release;
+  const iters = envIters(itersName, budget);
   return {
     seed,
     iters,
     label: `(seed=${seed}, iters=${iters})`,
-    timeout: iters > defaultIters ? Math.ceil(iters / defaultIters) * 5_000 : undefined,
+    timeout: iters > budget ? Math.ceil(iters / budget) * 5_000 : undefined,
     repro(iteration: number): string {
-      return `seed=${seed} iteration=${iteration} (replay with ${seedName}=${seed})`;
+      return `seed=${seed} iteration=${iteration} (replay: ${seedName}=${seed} ${itersName}=${iteration + 1})`;
     },
   };
 }

--- a/test/_util/fuzz.ts
+++ b/test/_util/fuzz.ts
@@ -6,10 +6,15 @@
  * Every oracle generates its cases from one seeded generator, so case N is the
  * same however many cases a run asks for, and every failure message carries the
  * seed and the case number. A CI failure therefore replays locally with the two
- * environment variables it prints, and a long soak is one variable away:
+ * environment variables it prints, and a long soak is one variable away (plus
+ * a test timeout to match, since the defaults are sized for a few seconds):
  *
  *     BUN_PATH_FUZZ_SEED=1234 BUN_PATH_FUZZ_ITERS=57 bun bd test path-differential-fuzz
- *     BUN_PATH_FUZZ_ITERS=20000 bun bd test path-differential-fuzz
+ *     BUN_PATH_FUZZ_ITERS=20000 bun bd test path-differential-fuzz --timeout=600000
+ *
+ * Each oracle also pins the divergences it found on main with `test.failing`
+ * next to the generator exclusion that works around them, so the fix that makes
+ * a pin pass is also told which exclusion to delete.
  */
 import { isDebug } from "harness";
 
@@ -66,12 +71,6 @@ export interface Fuzz {
   readonly iters: number;
   /** Appended to the test name, so a failure line shows what the run used. */
   readonly label: string;
-  /**
-   * Third argument for `test()`: undefined (the runner's own per-test timeout)
-   * unless the iteration count was raised for a soak, in which case the default
-   * run's budget is scaled up with it.
-   */
-  readonly timeout: number | undefined;
   /** Replay instructions, for the failure message of case `iteration` (0-based). */
   repro(iteration: number): string;
 }
@@ -86,13 +85,11 @@ export function fuzzEnv(prefix: string, defaultSeed: number, defaultIters: { rel
   const seedName = `${prefix}_SEED`;
   const itersName = `${prefix}_ITERS`;
   const seed = envSeed(seedName, defaultSeed);
-  const budget = isDebug ? defaultIters.debug : defaultIters.release;
-  const iters = envIters(itersName, budget);
+  const iters = envIters(itersName, isDebug ? defaultIters.debug : defaultIters.release);
   return {
     seed,
     iters,
     label: `(seed=${seed}, iters=${iters})`,
-    timeout: iters > budget ? Math.ceil(iters / budget) * 5_000 : undefined,
     repro(iteration: number): string {
       return `seed=${seed} iteration=${iteration} (replay: ${seedName}=${seed} ${itersName}=${iteration + 1})`;
     },

--- a/test/_util/fuzz.ts
+++ b/test/_util/fuzz.ts
@@ -1,0 +1,87 @@
+/**
+ * Shared plumbing for the seeded differential fuzz tests (Bun.JSONC.parse vs
+ * JSON.parse, node:path vs node, Bun.Glob vs picomatch, Bun.build sourcemaps vs
+ * the `source-map` decoder, the transpiler printer vs acorn).
+ *
+ * Every oracle is deterministic for a seed, runs a few hundred iterations by
+ * default, and puts the seed and iteration into each failure message, so a CI
+ * failure replays locally and a long soak is one environment variable away:
+ *
+ *     BUN_PATH_FUZZ_SEED=1234 bun bd test path-differential-fuzz
+ *     BUN_PATH_FUZZ_ITERS=20000 bun bd test path-differential-fuzz
+ */
+
+/** mulberry32: a 32-bit seed is enough state, and it is fast under a debug JSC. */
+export class Rng {
+  private a: number;
+  constructor(seed: number) {
+    this.a = seed >>> 0;
+  }
+  /** Uniform in [0, 1). */
+  next(): number {
+    this.a = (this.a + 0x6d2b79f5) | 0;
+    let t = Math.imul(this.a ^ (this.a >>> 15), 1 | this.a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  }
+  /** Integer in [0, n). */
+  int(n: number): number {
+    return Math.floor(this.next() * n);
+  }
+  /** Integer in [lo, hi], inclusive on both ends. */
+  range(lo: number, hi: number): number {
+    return lo + this.int(hi - lo + 1);
+  }
+  chance(p: number): boolean {
+    return this.next() < p;
+  }
+  pick<T>(arr: readonly T[]): T {
+    return arr[this.int(arr.length)];
+  }
+  /** `count` picks from `alphabet`, concatenated. */
+  string(alphabet: readonly string[] | string, count: number): string {
+    let s = "";
+    for (let i = 0; i < count; i++) s += alphabet[this.int(alphabet.length)];
+    return s;
+  }
+}
+
+export function envSeed(name: string, fallback: number): number {
+  const raw = process.env[name];
+  return raw === undefined ? fallback >>> 0 : Number(raw) >>> 0;
+}
+
+/** A positive integer from the environment, else `fallback`. */
+export function envIters(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined) return fallback;
+  const n = Number(raw) | 0;
+  return n > 0 ? n : fallback;
+}
+
+export interface Fuzz {
+  readonly seed: number;
+  readonly iters: number;
+  /** Appended to the test name so a failure line shows the seed it ran with. */
+  readonly label: string;
+  /** Replay instructions for a failure message. */
+  repro(iteration: number): string;
+}
+
+/**
+ * Reads `${prefix}_SEED` and `${prefix}_ITERS` (for example `BUN_GLOB_FUZZ_SEED`
+ * and `BUN_GLOB_FUZZ_ITERS`), falling back to the given defaults.
+ */
+export function fuzzEnv(prefix: string, defaultSeed: number, defaultIters: number): Fuzz {
+  const seedName = `${prefix}_SEED`;
+  const seed = envSeed(seedName, defaultSeed);
+  const iters = envIters(`${prefix}_ITERS`, defaultIters);
+  return {
+    seed,
+    iters,
+    label: `(seed=${seed}, iters=${iters})`,
+    repro(iteration: number): string {
+      return `seed=${seed} iteration=${iteration} (replay with ${seedName}=${seed})`;
+    },
+  };
+}

--- a/test/bun.lock
+++ b/test/bun.lock
@@ -68,6 +68,7 @@
         "pg": "8.11.1",
         "pg-connection-string": "2.6.1",
         "pg-gateway": "0.3.0-beta.4",
+        "picomatch": "4.0.4",
         "pino": "9.4.0",
         "pino-pretty": "11.2.2",
         "postgres": "3.3.5",

--- a/test/bundler/sourcemap-differential-fuzz.test.ts
+++ b/test/bundler/sourcemap-differential-fuzz.test.ts
@@ -1,0 +1,380 @@
+// Seeded fuzz of the source maps Bun.build emits, decoded by the independent
+// `source-map` library. Random small programs (an entry plus the modules it
+// imports, with random layout, comments and non-ASCII text shifting columns)
+// are bundled, then every identifier in the output that has a mapping must map
+// to that same identifier in the original file, and every mapping must land
+// inside its original file. Replay a failure with BUN_SOURCEMAP_FUZZ_SEED=<seed>;
+// soak with BUN_SOURCEMAP_FUZZ_ITERS=<n> (one iteration is one program).
+import { fuzzEnv, Rng } from "_util/fuzz";
+import { expect, test } from "bun:test";
+import { tempDir } from "harness";
+import { join } from "node:path";
+import { SourceMapConsumer } from "source-map";
+
+const PROGRAMS_PER_BUILD = 4;
+/** Each build takes the next of these in turn, so the default run covers every one once. */
+const BUILD_OPTIONS: Partial<Parameters<typeof Bun.build>[0]>[] = [
+  { format: "esm" },
+  { format: "iife" },
+  { format: "cjs" },
+  // Whitespace minification puts several modules on one generated line.
+  { format: "esm", minify: { whitespace: true } },
+  { format: "iife", minify: { whitespace: true } },
+];
+const fuzz = fuzzEnv("BUN_SOURCEMAP_FUZZ", 0x736d6170, PROGRAMS_PER_BUILD * BUILD_OPTIONS.length);
+
+/** Text that never contains an identifier: comments and strings are built from it. */
+const FILLER = ["日本語", "🎉", "é", "...", "1 + 1", "*", "'", '"', "\\u00e9", "中文 text", "ñ"];
+const IDENTIFIERS = /[A-Za-z_$][\w$]*/g;
+const IDENTIFIER_AT = /[A-Za-z_$][\w$]*/y;
+
+interface Module {
+  /** Path relative to the build root, e.g. "p3/dep0.js"; also how the map must name it. */
+  file: string;
+  source: string;
+}
+
+interface Program {
+  entry: string;
+  modules: Module[];
+  /** Identifiers this program declares or references; all unique across the run. */
+  words: Set<string>;
+}
+
+/** Everything declared so far in one module (plus its imports), to build expressions from. */
+interface Scope {
+  values: string[];
+  functions: { name: string; arity: number }[];
+  objects: { name: string; keys: string[] }[];
+  classes: { name: string; method: string }[];
+}
+
+class ProgramGenerator {
+  private counter = 0;
+  constructor(private rng: Rng) {}
+
+  private name(prefix: string, words: Set<string>): string {
+    const name = `${prefix}${this.counter++}`;
+    words.add(name);
+    return name;
+  }
+
+  /** Whitespace between tokens: usually a space, sometimes a comment or a line break. */
+  private gap(): string {
+    const rng = this.rng;
+    if (rng.chance(0.1)) return ` /* ${rng.pick(FILLER)} */ `;
+    if (rng.chance(0.05)) return "\n" + rng.string(["  ", "\t", ""], rng.range(1, 3));
+    return rng.chance(0.1) ? "  " : " ";
+  }
+
+  private stringLiteral(): string {
+    const rng = this.rng;
+    const body = rng.pick(FILLER).replaceAll("\\", "\\\\").replaceAll("'", "\\'").replaceAll('"', '\\"');
+    switch (rng.int(3)) {
+      case 0:
+        return `"${body}"`;
+      case 1:
+        return `'${body}'`;
+      default:
+        return "`" + body + "`";
+    }
+  }
+
+  private expr(scope: Scope, depth: number): string {
+    const rng = this.rng;
+    const g = () => this.gap();
+    const sub = () => this.expr(scope, depth - 1);
+    const choice = depth > 0 ? rng.int(9) : rng.int(3);
+    switch (choice) {
+      case 0:
+        return String(rng.int(1000));
+      case 1:
+        return this.stringLiteral();
+      case 2:
+        return scope.values.length > 0 ? rng.pick(scope.values) : String(rng.int(10));
+      case 3:
+        return `${sub()}${g()}+${g()}${sub()}`;
+      case 4: {
+        if (scope.functions.length === 0) return sub();
+        const fn = rng.pick(scope.functions);
+        const args: string[] = [];
+        for (let i = 0; i < fn.arity; i++) args.push(sub());
+        return `${fn.name}(${args.join("," + g())})`;
+      }
+      case 5: {
+        if (scope.objects.length === 0) return sub();
+        const obj = rng.pick(scope.objects);
+        return `${obj.name}${rng.chance(0.1) ? g() : ""}.${rng.pick(obj.keys)}`;
+      }
+      case 6: {
+        if (scope.classes.length === 0) return sub();
+        const cls = rng.pick(scope.classes);
+        return `new ${cls.name}().${cls.method}(${sub()})`;
+      }
+      case 7:
+        return `[${sub()},${g()}${sub()}]`;
+      default:
+        return `(${sub()}${g()}?${g()}${sub()}${g()}:${g()}${sub()})`;
+    }
+  }
+
+  /** One top-level declaration; returns its source and registers it in `scope`. */
+  private declaration(scope: Scope, words: Set<string>, exported: boolean): { code: string; name: string } {
+    const rng = this.rng;
+    const g = () => this.gap();
+    const prefix = exported ? "export" + g() : "";
+    switch (rng.int(5)) {
+      case 0:
+      case 1: {
+        const name = this.name("v", words);
+        const code = `${prefix}${rng.pick(["const", "let", "var"])} ${name}${g()}=${g()}${this.expr(scope, 2)};`;
+        scope.values.push(name);
+        return { code, name };
+      }
+      case 2: {
+        const name = this.name("fn", words);
+        const arity = rng.int(3);
+        const params: string[] = [];
+        for (let i = 0; i < arity; i++) params.push(this.name("p", words));
+        const inner: Scope = { ...scope, values: scope.values.concat(params) };
+        let body = "";
+        if (rng.chance(0.4)) {
+          const local = this.name("v", words);
+          body += `${g()}const ${local}${g()}=${g()}${this.expr(inner, 1)};\n`;
+          inner.values = inner.values.concat(local);
+        }
+        body += `${g()}return ${this.expr(inner, 2)};`;
+        const code = `${prefix}function ${name}(${params.join("," + g())})${g()}{\n${body}\n}`;
+        scope.functions.push({ name, arity });
+        return { code, name };
+      }
+      case 3: {
+        const name = this.name("o", words);
+        const keys: string[] = [];
+        const count = rng.range(1, 3);
+        let code = `${prefix}const ${name}${g()}=${g()}{`;
+        for (let i = 0; i < count; i++) {
+          if (i > 0) code += ",";
+          if (scope.values.length > 0 && rng.chance(0.15)) {
+            // Shorthand property: the key is a value declared earlier.
+            const value = rng.pick(scope.values);
+            keys.push(value);
+            code += `${g()}${value}`;
+          } else {
+            const key = this.name("k", words);
+            keys.push(key);
+            code += `${g()}${key}:${g()}${this.expr(scope, 1)}`;
+          }
+        }
+        code += `${g()}};`;
+        scope.objects.push({ name, keys });
+        return { code, name };
+      }
+      default: {
+        const name = this.name("C", words);
+        const field = this.name("f", words);
+        const method = this.name("m", words);
+        const param = this.name("p", words);
+        const inner: Scope = { ...scope, values: scope.values.concat(param) };
+        const code =
+          `${prefix}class ${name}${g()}{\n` +
+          `${g()}${field}${g()}=${g()}${this.expr(scope, 1)};\n` +
+          `${g()}${method}(${param})${g()}{\n` +
+          `${g()}return this.${field}${g()}+${g()}${this.expr(inner, 1)};\n` +
+          `${g()}}\n}`;
+        scope.classes.push({ name, method });
+        return { code, name };
+      }
+    }
+  }
+
+  private module(
+    scope: Scope,
+    words: Set<string>,
+    imports: { file: string; names: string[] }[],
+    exportAll: boolean,
+  ): { source: string; exported: string[] } {
+    const rng = this.rng;
+    const statements: string[] = imports.map(
+      ({ file, names }) => `import {${this.gap()}${names.join("," + this.gap())}${this.gap()}} from "./${file}";`,
+    );
+    const exported: string[] = [];
+    const declared: string[] = [];
+    const count = rng.range(1, 5);
+    for (let i = 0; i < count; i++) {
+      const isExported = exportAll || rng.chance(0.2);
+      const { code, name } = this.declaration(scope, words, isExported);
+      statements.push(code);
+      declared.push(name);
+      if (isExported) exported.push(name);
+    }
+    // Using every name keeps all of it, and everything it imports, out of the tree shaker's reach.
+    const used = declared.concat(imports.flatMap(i => i.names));
+    statements.push(`console.log(${used.join("," + this.gap())});`);
+    words.add("console").add("log");
+
+    const eol = rng.chance(0.2) ? "\r\n" : "\n";
+    let source = "";
+    for (const statement of statements) {
+      source += rng.pick(["", " ", "  ", "    ", "\t"]) + statement.replaceAll("\n", eol) + eol;
+      if (rng.chance(0.3)) source += eol;
+      if (rng.chance(0.1)) source += `// ${rng.pick(FILLER)}${eol}`;
+    }
+    return { source, exported };
+  }
+
+  program(dir: string): Program {
+    const words = new Set<string>();
+    const modules: Module[] = [];
+    const imports: { file: string; names: string[] }[] = [];
+    const entryScope: Scope = { values: [], functions: [], objects: [], classes: [] };
+    const depCount = this.rng.int(3);
+    for (let i = 0; i < depCount; i++) {
+      const depScope: Scope = { values: [], functions: [], objects: [], classes: [] };
+      const { source, exported } = this.module(depScope, words, [], true);
+      const file = `dep${i}.js`;
+      modules.push({ file: `${dir}/${file}`, source });
+      imports.push({ file, names: exported });
+      // Whatever the dependency declared is usable from the entry under the same name.
+      entryScope.values.push(...depScope.values);
+      entryScope.functions.push(...depScope.functions);
+      entryScope.objects.push(...depScope.objects);
+      entryScope.classes.push(...depScope.classes);
+    }
+    const entry = `${dir}/entry.js`;
+    modules.push({ file: entry, source: this.module(entryScope, words, imports, false).source });
+    return { entry, modules, words };
+  }
+}
+
+/** 1-based line and 0-based column, as `source-map` reports both sides of a mapping. */
+function inRange(lines: string[], line: number, column: number): boolean {
+  return line >= 1 && line <= lines.length && column >= 0 && column <= lines[line - 1].length;
+}
+
+/** The identifier starting exactly at `column`, if any. */
+function identifierAt(text: string, column: number): string | null {
+  IDENTIFIER_AT.lastIndex = column;
+  return IDENTIFIER_AT.exec(text)?.[0] ?? null;
+}
+
+interface Stats {
+  mappings: number;
+  identifiers: number;
+}
+
+interface Original {
+  file: string;
+  line: number;
+  column: number;
+  name: string | null;
+}
+
+async function checkProgram(program: Program, generated: string, map: any, stats: Stats, repro: string): Promise<void> {
+  const originals = new Map<string, string[]>();
+  for (const module of program.modules) originals.set(module.file, module.source.split(/\r?\n/));
+  // The map names sources relative to the build root; consumer.sources may
+  // prefix them differently from map.sources, so both are matched by suffix.
+  const fileOfSource = (source: string): string => {
+    for (const file of originals.keys()) {
+      if (source === file || source.endsWith("/" + file)) return file;
+    }
+    throw new Error(`map names source ${JSON.stringify(source)}, which is not one of ${[...originals.keys()]}. ${repro}`);
+  };
+
+  for (let i = 0; i < map.sources.length; i++) {
+    const file = fileOfSource(map.sources[i]);
+    expect(map.sourcesContent[i], `sourcesContent for ${file}. ${repro}`).toBe(
+      program.modules.find(m => m.file === file)!.source,
+    );
+  }
+
+  const generatedLines = generated.split("\n");
+  await SourceMapConsumer.with(map, null, consumer => {
+    const fileOf = new Map<string, string>(consumer.sources.map(source => [source, fileOfSource(source)]));
+    const atGenerated = new Map<string, Original>();
+    consumer.eachMapping(m => {
+      stats.mappings++;
+      const file = fileOf.get(m.source);
+      const where = () =>
+        `mapping ${m.generatedLine}:${m.generatedColumn} -> ${m.source}:${m.originalLine}:${m.originalColumn}. ${repro}`;
+      if (file === undefined) throw new Error(`unknown source in ${where()}`);
+      if (!inRange(generatedLines, m.generatedLine, m.generatedColumn)) {
+        throw new Error(`generated position is outside the output (${generatedLines.length} lines): ${where()}`);
+      }
+      if (!inRange(originals.get(file)!, m.originalLine, m.originalColumn)) {
+        throw new Error(`original position is outside ${file} (${originals.get(file)!.length} lines): ${where()}`);
+      }
+      const key = `${m.generatedLine}:${m.generatedColumn}`;
+      const previous = atGenerated.get(key);
+      if (previous !== undefined && (previous.file !== file || previous.line !== m.originalLine || previous.column !== m.originalColumn)) {
+        throw new Error(`same generated position also maps to ${previous.file}:${previous.line}:${previous.column}: ${where()}`);
+      }
+      atGenerated.set(key, { file, line: m.originalLine, column: m.originalColumn, name: m.name });
+    });
+
+    for (let lineNumber = 1; lineNumber <= generatedLines.length; lineNumber++) {
+      for (const match of generatedLines[lineNumber - 1].matchAll(IDENTIFIERS)) {
+        const word = match[0];
+        if (!program.words.has(word)) continue;
+        const mapping = atGenerated.get(`${lineNumber}:${match.index}`);
+        if (mapping === undefined) continue;
+        stats.identifiers++;
+        const originalLine = originals.get(mapping.file)![mapping.line - 1];
+        const original = identifierAt(originalLine, mapping.column);
+        if (original !== word) {
+          throw new Error(
+            `generated ${lineNumber}:${match.index} is \`${word}\` but maps to ${mapping.file}:${mapping.line}:${mapping.column}, ` +
+              `which is ${original === null ? JSON.stringify(originalLine.slice(mapping.column, mapping.column + 20)) : "`" + original + "`"}. ${repro}`,
+          );
+        }
+        // Bun does not emit names today; if it starts to, the name must be this identifier.
+        if (mapping.name !== null) expect(mapping.name, `name of mapping at ${lineNumber}:${match.index}. ${repro}`).toBe(word);
+      }
+    }
+  });
+}
+
+test(`Bun.build source maps point every mapped identifier back at itself ${fuzz.label}`, async () => {
+  const rng = new Rng(fuzz.seed);
+  const generator = new ProgramGenerator(rng);
+  const stats: Stats = { mappings: 0, identifiers: 0 };
+
+  for (let first = 0; first < fuzz.iters; first += PROGRAMS_PER_BUILD) {
+    const options = BUILD_OPTIONS[(first / PROGRAMS_PER_BUILD) % BUILD_OPTIONS.length];
+    const programs: Program[] = [];
+    const files: Record<string, string> = {};
+    for (let i = first; i < Math.min(first + PROGRAMS_PER_BUILD, fuzz.iters); i++) {
+      const program = generator.program(`p${i}`);
+      programs.push(program);
+      for (const module of program.modules) files[module.file] = module.source;
+    }
+    using dir = tempDir("sourcemap-fuzz", files);
+
+    const build = await Bun.build({
+      ...options,
+      entrypoints: programs.map(p => join(String(dir), p.entry)),
+      root: String(dir),
+      sourcemap: "external",
+    });
+
+    for (const [offset, program] of programs.entries()) {
+      const iteration = first + offset;
+      const repro = `${fuzz.repro(iteration)} options=${JSON.stringify(options)}`;
+      const js = build.outputs.find(o => o.kind === "entry-point" && o.path.replace(/^\.\//, "") === program.entry);
+      expect(js, `no output for ${program.entry} in ${build.outputs.map(o => o.path)}. ${repro}`).toBeDefined();
+      // Paired by path rather than through `js.sourcemap`, which with several
+      // entrypoints currently points at the wrong artifact (handed off separately).
+      const map = build.outputs.find(o => o.kind === "sourcemap" && o.path === js!.path + ".map");
+      expect(map, `no source map for ${js!.path} in ${build.outputs.map(o => o.path)}. ${repro}`).toBeDefined();
+      await checkProgram(program, await js!.text(), await map!.json(), stats, repro);
+    }
+  }
+
+  console.log(
+    `sourcemap-differential-fuzz: ${fuzz.iters} programs, ${stats.mappings} mappings in range, ${stats.identifiers} identifiers mapped to themselves`,
+  );
+  // Guards against the check silently going vacuous: every program has at least
+  // a console.log line worth of mapped identifiers.
+  expect(stats.identifiers).toBeGreaterThan(fuzz.iters * 4);
+}, fuzz.timeout);

--- a/test/bundler/sourcemap-differential-fuzz.test.ts
+++ b/test/bundler/sourcemap-differential-fuzz.test.ts
@@ -350,50 +350,60 @@ function outputName(path: string): string {
   return path.replaceAll("\\", "/").replace(/^\.\//, "");
 }
 
-test(
-  `Bun.build source maps point every mapped identifier back at itself ${fuzz.label}`,
-  async () => {
-    const rng = new Rng(fuzz.seed);
-    const generator = new ProgramGenerator(rng);
-    const stats: Stats = { mappings: 0, identifiers: 0 };
+test(`Bun.build source maps point every mapped identifier back at itself ${fuzz.label}`, async () => {
+  const rng = new Rng(fuzz.seed);
+  const generator = new ProgramGenerator(rng);
+  const stats: Stats = { mappings: 0, identifiers: 0 };
 
-    for (let first = 0; first < fuzz.iters; first += PROGRAMS_PER_BUILD) {
-      const options = BUILD_OPTIONS[(first / PROGRAMS_PER_BUILD) % BUILD_OPTIONS.length];
-      const programs: Program[] = [];
-      const files: Record<string, string> = {};
-      for (let i = first; i < Math.min(first + PROGRAMS_PER_BUILD, fuzz.iters); i++) {
-        const program = generator.program(`p${i}`);
-        programs.push(program);
-        for (const module of program.modules) files[module.file] = module.source;
-      }
-      using dir = tempDir("sourcemap-fuzz", files);
-
-      const build = await Bun.build({
-        ...options,
-        entrypoints: programs.map(p => join(String(dir), p.entry)),
-        root: String(dir),
-        sourcemap: "external",
-      });
-
-      for (const [offset, program] of programs.entries()) {
-        const iteration = first + offset;
-        const repro = `${fuzz.repro(iteration)} options=${JSON.stringify(options)}`;
-        const js = build.outputs.find(o => o.kind === "entry-point" && outputName(o.path) === program.entry);
-        expect(js, `no output for ${program.entry} in ${build.outputs.map(o => o.path)}. ${repro}`).toBeDefined();
-        // Paired by path rather than through `js.sourcemap`, which with several
-        // entrypoints currently points at the wrong artifact (handed off separately).
-        const map = build.outputs.find(o => o.kind === "sourcemap" && o.path === js!.path + ".map");
-        expect(map, `no source map for ${js!.path} in ${build.outputs.map(o => o.path)}. ${repro}`).toBeDefined();
-        await checkProgram(program, await js!.text(), await map!.json(), stats, repro);
-      }
+  for (let first = 0; first < fuzz.iters; first += PROGRAMS_PER_BUILD) {
+    const options = BUILD_OPTIONS[(first / PROGRAMS_PER_BUILD) % BUILD_OPTIONS.length];
+    const programs: Program[] = [];
+    const files: Record<string, string> = {};
+    for (let i = first; i < Math.min(first + PROGRAMS_PER_BUILD, fuzz.iters); i++) {
+      const program = generator.program(`p${i}`);
+      programs.push(program);
+      for (const module of program.modules) files[module.file] = module.source;
     }
+    using dir = tempDir("sourcemap-fuzz", files);
 
-    console.log(
-      `sourcemap-differential-fuzz: ${fuzz.iters} programs, ${stats.mappings} mappings in range, ${stats.identifiers} identifiers mapped to themselves`,
-    );
-    // Guards against the check silently going vacuous: every program has at least
-    // a console.log line worth of mapped identifiers.
-    expect(stats.identifiers).toBeGreaterThan(fuzz.iters * 4);
-  },
-  fuzz.timeout,
-);
+    const build = await Bun.build({
+      ...options,
+      entrypoints: programs.map(p => join(String(dir), p.entry)),
+      root: String(dir),
+      sourcemap: "external",
+    });
+
+    for (const [offset, program] of programs.entries()) {
+      const iteration = first + offset;
+      const repro = `${fuzz.repro(iteration)} options=${JSON.stringify(options)}`;
+      const js = build.outputs.find(o => o.kind === "entry-point" && outputName(o.path) === program.entry);
+      expect(js, `no output for ${program.entry} in ${build.outputs.map(o => o.path)}. ${repro}`).toBeDefined();
+      // Known divergence (pinned below): with several entrypoints `js.sourcemap`
+      // is the wrong artifact, so the map is paired by path instead.
+      const map = build.outputs.find(o => o.kind === "sourcemap" && o.path === js!.path + ".map");
+      expect(map, `no source map for ${js!.path} in ${build.outputs.map(o => o.path)}. ${repro}`).toBeDefined();
+      await checkProgram(program, await js!.text(), await map!.json(), stats, repro);
+    }
+  }
+
+  console.log(
+    `sourcemap-differential-fuzz: ${fuzz.iters} programs, ${stats.mappings} mappings in range, ${stats.identifiers} identifiers mapped to themselves`,
+  );
+  // Guards against the check silently going vacuous: every program has at least
+  // a console.log line worth of mapped identifiers.
+  expect(stats.identifiers).toBeGreaterThan(fuzz.iters * 4);
+});
+
+// A fix is in flight. Once this passes, delete it and read each program's map
+// through `js.sourcemap` above, so the fuzz covers that link as well.
+test.failing("known divergence: BuildArtifact.sourcemap with several entrypoints", async () => {
+  using dir = tempDir("sourcemap-fuzz-link", { "a.js": "console.log(1);\n", "b.js": "console.log(2);\n" });
+  const build = await Bun.build({
+    entrypoints: [join(String(dir), "a.js"), join(String(dir), "b.js")],
+    root: String(dir),
+    sourcemap: "external",
+  });
+  for (const js of build.outputs.filter(o => o.kind === "entry-point")) {
+    expect(js.sourcemap?.path).toBe(js.path + ".map");
+  }
+});

--- a/test/bundler/sourcemap-differential-fuzz.test.ts
+++ b/test/bundler/sourcemap-differential-fuzz.test.ts
@@ -11,8 +11,8 @@ import { tempDir } from "harness";
 import { join } from "node:path";
 import { SourceMapConsumer } from "source-map";
 
-const PROGRAMS_PER_BUILD = 4;
-/** Each build takes the next of these in turn, so the default run covers every one once. */
+const PROGRAMS_PER_BUILD = 2;
+/** Each build takes the next of these in turn; the defaults below are multiples of a full rotation. */
 const BUILD_OPTIONS: Partial<Parameters<typeof Bun.build>[0]>[] = [
   { format: "esm" },
   { format: "iife" },
@@ -21,15 +21,16 @@ const BUILD_OPTIONS: Partial<Parameters<typeof Bun.build>[0]>[] = [
   { format: "esm", minify: { whitespace: true } },
   { format: "iife", minify: { whitespace: true } },
 ];
-const fuzz = fuzzEnv("BUN_SOURCEMAP_FUZZ", 0x736d6170, PROGRAMS_PER_BUILD * BUILD_OPTIONS.length);
+const ROTATION = PROGRAMS_PER_BUILD * BUILD_OPTIONS.length;
+const fuzz = fuzzEnv("BUN_SOURCEMAP_FUZZ", 0x736d6170, { release: ROTATION * 5, debug: ROTATION });
 
-/** Text that never contains an identifier: comments and strings are built from it. */
+/** Comment and string contents; must not contain any generated identifier (or `console`/`log`). */
 const FILLER = ["日本語", "🎉", "é", "...", "1 + 1", "*", "'", '"', "\\u00e9", "中文 text", "ñ"];
 const IDENTIFIERS = /[A-Za-z_$][\w$]*/g;
 const IDENTIFIER_AT = /[A-Za-z_$][\w$]*/y;
 
 interface Module {
-  /** Path relative to the build root, e.g. "p3/dep0.js"; also how the map must name it. */
+  /** Path relative to the build root, e.g. "p3/dep0.js"; the map's `sources` entry for it ends with this. */
   file: string;
   source: string;
 }
@@ -279,7 +280,9 @@ async function checkProgram(program: Program, generated: string, map: any, stats
     for (const file of originals.keys()) {
       if (source === file || source.endsWith("/" + file)) return file;
     }
-    throw new Error(`map names source ${JSON.stringify(source)}, which is not one of ${[...originals.keys()]}. ${repro}`);
+    throw new Error(
+      `map names source ${JSON.stringify(source)}, which is not one of ${[...originals.keys()]}. ${repro}`,
+    );
   };
 
   for (let i = 0; i < map.sources.length; i++) {
@@ -307,8 +310,13 @@ async function checkProgram(program: Program, generated: string, map: any, stats
       }
       const key = `${m.generatedLine}:${m.generatedColumn}`;
       const previous = atGenerated.get(key);
-      if (previous !== undefined && (previous.file !== file || previous.line !== m.originalLine || previous.column !== m.originalColumn)) {
-        throw new Error(`same generated position also maps to ${previous.file}:${previous.line}:${previous.column}: ${where()}`);
+      if (
+        previous !== undefined &&
+        (previous.file !== file || previous.line !== m.originalLine || previous.column !== m.originalColumn)
+      ) {
+        throw new Error(
+          `same generated position also maps to ${previous.file}:${previous.line}:${previous.column}: ${where()}`,
+        );
       }
       atGenerated.set(key, { file, line: m.originalLine, column: m.originalColumn, name: m.name });
     });
@@ -329,52 +337,57 @@ async function checkProgram(program: Program, generated: string, map: any, stats
           );
         }
         // Bun does not emit names today; if it starts to, the name must be this identifier.
-        if (mapping.name !== null) expect(mapping.name, `name of mapping at ${lineNumber}:${match.index}. ${repro}`).toBe(word);
+        if (mapping.name !== null)
+          expect(mapping.name, `name of mapping at ${lineNumber}:${match.index}. ${repro}`).toBe(word);
       }
     }
   });
 }
 
-test(`Bun.build source maps point every mapped identifier back at itself ${fuzz.label}`, async () => {
-  const rng = new Rng(fuzz.seed);
-  const generator = new ProgramGenerator(rng);
-  const stats: Stats = { mappings: 0, identifiers: 0 };
+test(
+  `Bun.build source maps point every mapped identifier back at itself ${fuzz.label}`,
+  async () => {
+    const rng = new Rng(fuzz.seed);
+    const generator = new ProgramGenerator(rng);
+    const stats: Stats = { mappings: 0, identifiers: 0 };
 
-  for (let first = 0; first < fuzz.iters; first += PROGRAMS_PER_BUILD) {
-    const options = BUILD_OPTIONS[(first / PROGRAMS_PER_BUILD) % BUILD_OPTIONS.length];
-    const programs: Program[] = [];
-    const files: Record<string, string> = {};
-    for (let i = first; i < Math.min(first + PROGRAMS_PER_BUILD, fuzz.iters); i++) {
-      const program = generator.program(`p${i}`);
-      programs.push(program);
-      for (const module of program.modules) files[module.file] = module.source;
+    for (let first = 0; first < fuzz.iters; first += PROGRAMS_PER_BUILD) {
+      const options = BUILD_OPTIONS[(first / PROGRAMS_PER_BUILD) % BUILD_OPTIONS.length];
+      const programs: Program[] = [];
+      const files: Record<string, string> = {};
+      for (let i = first; i < Math.min(first + PROGRAMS_PER_BUILD, fuzz.iters); i++) {
+        const program = generator.program(`p${i}`);
+        programs.push(program);
+        for (const module of program.modules) files[module.file] = module.source;
+      }
+      using dir = tempDir("sourcemap-fuzz", files);
+
+      const build = await Bun.build({
+        ...options,
+        entrypoints: programs.map(p => join(String(dir), p.entry)),
+        root: String(dir),
+        sourcemap: "external",
+      });
+
+      for (const [offset, program] of programs.entries()) {
+        const iteration = first + offset;
+        const repro = `${fuzz.repro(iteration)} options=${JSON.stringify(options)}`;
+        const js = build.outputs.find(o => o.kind === "entry-point" && o.path.replace(/^\.\//, "") === program.entry);
+        expect(js, `no output for ${program.entry} in ${build.outputs.map(o => o.path)}. ${repro}`).toBeDefined();
+        // Paired by path rather than through `js.sourcemap`, which with several
+        // entrypoints currently points at the wrong artifact (handed off separately).
+        const map = build.outputs.find(o => o.kind === "sourcemap" && o.path === js!.path + ".map");
+        expect(map, `no source map for ${js!.path} in ${build.outputs.map(o => o.path)}. ${repro}`).toBeDefined();
+        await checkProgram(program, await js!.text(), await map!.json(), stats, repro);
+      }
     }
-    using dir = tempDir("sourcemap-fuzz", files);
 
-    const build = await Bun.build({
-      ...options,
-      entrypoints: programs.map(p => join(String(dir), p.entry)),
-      root: String(dir),
-      sourcemap: "external",
-    });
-
-    for (const [offset, program] of programs.entries()) {
-      const iteration = first + offset;
-      const repro = `${fuzz.repro(iteration)} options=${JSON.stringify(options)}`;
-      const js = build.outputs.find(o => o.kind === "entry-point" && o.path.replace(/^\.\//, "") === program.entry);
-      expect(js, `no output for ${program.entry} in ${build.outputs.map(o => o.path)}. ${repro}`).toBeDefined();
-      // Paired by path rather than through `js.sourcemap`, which with several
-      // entrypoints currently points at the wrong artifact (handed off separately).
-      const map = build.outputs.find(o => o.kind === "sourcemap" && o.path === js!.path + ".map");
-      expect(map, `no source map for ${js!.path} in ${build.outputs.map(o => o.path)}. ${repro}`).toBeDefined();
-      await checkProgram(program, await js!.text(), await map!.json(), stats, repro);
-    }
-  }
-
-  console.log(
-    `sourcemap-differential-fuzz: ${fuzz.iters} programs, ${stats.mappings} mappings in range, ${stats.identifiers} identifiers mapped to themselves`,
-  );
-  // Guards against the check silently going vacuous: every program has at least
-  // a console.log line worth of mapped identifiers.
-  expect(stats.identifiers).toBeGreaterThan(fuzz.iters * 4);
-}, fuzz.timeout);
+    console.log(
+      `sourcemap-differential-fuzz: ${fuzz.iters} programs, ${stats.mappings} mappings in range, ${stats.identifiers} identifiers mapped to themselves`,
+    );
+    // Guards against the check silently going vacuous: every program has at least
+    // a console.log line worth of mapped identifiers.
+    expect(stats.identifiers).toBeGreaterThan(fuzz.iters * 4);
+  },
+  fuzz.timeout,
+);

--- a/test/bundler/sourcemap-differential-fuzz.test.ts
+++ b/test/bundler/sourcemap-differential-fuzz.test.ts
@@ -277,8 +277,9 @@ async function checkProgram(program: Program, generated: string, map: any, stats
   // The map names sources relative to the build root; consumer.sources may
   // prefix them differently from map.sources, so both are matched by suffix.
   const fileOfSource = (source: string): string => {
+    const normalized = source.replaceAll("\\", "/");
     for (const file of originals.keys()) {
-      if (source === file || source.endsWith("/" + file)) return file;
+      if (normalized === file || normalized.endsWith("/" + file)) return file;
     }
     throw new Error(
       `map names source ${JSON.stringify(source)}, which is not one of ${[...originals.keys()]}. ${repro}`,
@@ -344,6 +345,11 @@ async function checkProgram(program: Program, generated: string, map: any, stats
   });
 }
 
+/** An in-memory artifact's path ("./p3/entry.js", or with the host's separators) as a build-root relative name. */
+function outputName(path: string): string {
+  return path.replaceAll("\\", "/").replace(/^\.\//, "");
+}
+
 test(
   `Bun.build source maps point every mapped identifier back at itself ${fuzz.label}`,
   async () => {
@@ -372,7 +378,7 @@ test(
       for (const [offset, program] of programs.entries()) {
         const iteration = first + offset;
         const repro = `${fuzz.repro(iteration)} options=${JSON.stringify(options)}`;
-        const js = build.outputs.find(o => o.kind === "entry-point" && o.path.replace(/^\.\//, "") === program.entry);
+        const js = build.outputs.find(o => o.kind === "entry-point" && outputName(o.path) === program.entry);
         expect(js, `no output for ${program.entry} in ${build.outputs.map(o => o.path)}. ${repro}`).toBeDefined();
         // Paired by path rather than through `js.sourcemap`, which with several
         // entrypoints currently points at the wrong artifact (handed off separately).

--- a/test/bundler/transpiler/transpiler-differential-fuzz.test.ts
+++ b/test/bundler/transpiler/transpiler-differential-fuzz.test.ts
@@ -1,0 +1,535 @@
+// Seeded fuzz of the transpiler's parser and printer on random valid programs.
+// For every program, Bun.Transpiler's output (plain and whitespace-minified)
+// must (1) parse with acorn, (2) be a fixed point (transpiling it again
+// reproduces it byte for byte) and (3) behave like the input: both are run and
+// everything they push to `__out` is compared. Replay a failure with
+// BUN_TRANSPILER_FUZZ_SEED=<seed>; soak with BUN_TRANSPILER_FUZZ_ITERS=<n>.
+//
+// The generator parenthesizes every compound expression, so the printer has to
+// decide on its own which parentheses the output needs; that is where (1) and
+// (3) bite. Programs are strict-mode clean, always terminate, only `throw`
+// inside a `try`, and only use names after they are initialized, so (3) compares
+// values rather than exception names.
+import { fuzzEnv, Rng } from "_util/fuzz";
+import * as acorn from "acorn";
+import { expect, test } from "bun:test";
+
+// A debug build spends most of each iteration running acorn and the program itself.
+const fuzz = fuzzEnv("BUN_TRANSPILER_FUZZ", 0x78706c72, { release: 300, debug: 10 });
+
+// logLevel "error": transformSync otherwise also throws on lint-style warnings
+// (comparing against NaN, for instance), which are deliberate and not under test.
+const printer = new Bun.Transpiler({ loader: "js", logLevel: "error" });
+const minifier = new Bun.Transpiler({ loader: "js", logLevel: "error", minifyWhitespace: true });
+
+// Every entry is source text for one string literal.
+const STRINGS = [
+  `"plain"`,
+  `'single \\' quote'`,
+  `"double \\" quote"`,
+  `"both ' and \\" quotes"`,
+  `"new\\nline"`,
+  `"tab\\tand\\\\backslash"`,
+  `"\\u00e9 é 日本 🎉"`,
+  `"\\u2028 separator"`,
+  `"\\0 nul \\x7f"`,
+  `"lone \\uD800 surrogate"`,
+  "`back\\`tick and \\${not} a substitution`",
+  `"</script>"`,
+  `""`,
+  `"0"`,
+  `"1e3"`,
+  `"-0"`,
+];
+
+const NUMBERS = [
+  "0",
+  "1",
+  "2",
+  "7",
+  "255",
+  "0.5",
+  "0.1",
+  ".25",
+  "1e3",
+  "1.5e-7",
+  "1e21",
+  "1e22",
+  "123456789012345680000",
+  "0xff",
+  "0o17",
+  "0b101",
+  "1_000_000",
+  "9007199254740993",
+  "4294967296",
+  "NaN",
+  // Known divergence, found by this fuzzer and handed off separately: an
+  // infinite value is printed as `1 / 0`, which the next pass no longer treats
+  // as a primitive, so `"a" != Infinity` prints as `"a" != 1 / 0` and reprints
+  // as `1 / 0 != "a"`. Add "Infinity" and "1e999" here once that is fixed.
+];
+
+// `+` is repeated to weight it: it is the operator with the most printing rules
+// (string concatenation, `+ +x`, `++`).
+const BINARY_OPERATORS = "+ + + - * / % ** == != === !== < > <= >= && || ?? & | ^ << >> >>>".split(" ");
+const UNARY_OPERATORS = "- - ! typeof void + ~".split(" ");
+
+const IDENTIFIER = /^\w+$/;
+
+interface Fn {
+  name: string;
+  arity: number;
+}
+
+interface Scope {
+  /** Expressions that can be read; identifiers except for `this.v` inside methods. */
+  values: string[];
+  /** `let` and `var` bindings that may be assigned to. */
+  mutable: string[];
+  functions: Fn[];
+  /** Constructed as `new K(x)`; every instance has `.v` and `.m(y)`, every class has `K.s(y)`. */
+  classes: string[];
+  /** Block nesting, used to bound the program's size. */
+  depth: number;
+  inLoop: boolean;
+  /** Whether a `throw` here is caught by an enclosing `try`. */
+  inTry: boolean;
+}
+
+/** A nested scope: declarations made in it do not leak back out. */
+function child(scope: Scope, changes: Partial<Scope> = {}): Scope {
+  return {
+    ...scope,
+    values: scope.values.slice(),
+    mutable: scope.mutable.slice(),
+    functions: scope.functions.slice(),
+    classes: scope.classes.slice(),
+    depth: scope.depth + 1,
+    ...changes,
+  };
+}
+
+/** Scope for code that runs as its own function: loops and try blocks around it no longer apply. */
+function functionScope(scope: Scope, params: readonly string[]): Scope {
+  return child(scope, { values: scope.values.concat(params), inLoop: false, inTry: false });
+}
+
+/** Scope for code inside a non-arrow function, where `this.v` would no longer mean the instance. */
+function rebindsThis(scope: Scope): Scope {
+  return { ...scope, values: scope.values.filter(value => IDENTIFIER.test(value)) };
+}
+
+class ProgramGenerator {
+  private counter = 0;
+  /**
+   * Known divergence, found by this fuzzer and handed off separately: the
+   * unused-expression simplifier turns `(a, b) ? f() : 0;` into `a, b && f();`
+   * and only drops the `a,` on the next pass, so an expression statement
+   * (whose value is unused) gets no comma operators until that is fixed.
+   */
+  private noComma = false;
+  constructor(private rng: Rng) {}
+
+  private fresh(): string {
+    return `a${this.counter++}`;
+  }
+
+  private list(n: number, make: () => string): string[] {
+    const out: string[] = [];
+    for (let i = 0; i < n; i++) out.push(make());
+    return out;
+  }
+
+  private leaf(scope: Scope): string {
+    const rng = this.rng;
+    if (scope.values.length > 0 && rng.chance(0.45)) return rng.pick(scope.values);
+    switch (rng.int(6)) {
+      case 0:
+        return rng.pick(STRINGS);
+      case 1:
+        return rng.pick(["true", "false", "null", "undefined"]);
+      default:
+        return rng.pick(NUMBERS);
+    }
+  }
+
+  /** An expression; anything with operator precedence of its own comes back parenthesized. */
+  private expr(scope: Scope, depth: number): string {
+    const rng = this.rng;
+    if (depth <= 0) return this.leaf(scope);
+    const sub = () => this.expr(scope, depth - 1);
+    switch (rng.int(21)) {
+      case 0:
+      case 1:
+      case 2:
+        return this.leaf(scope);
+      case 3:
+      case 4:
+      case 5:
+        return `(${sub()} ${rng.pick(BINARY_OPERATORS)} ${sub()})`;
+      case 6:
+        return `(${rng.pick(UNARY_OPERATORS)} ${sub()})`;
+      case 7:
+        return `(${sub()} ? ${sub()} : ${sub()})`;
+      case 8:
+        return this.noComma ? sub() : `(${sub()}, ${sub()})`;
+      case 9: {
+        if (scope.functions.length === 0) return sub();
+        const fn = rng.pick(scope.functions);
+        const args = this.list(fn.arity, sub);
+        if (rng.chance(0.15)) args.push(`...[${sub()}]`);
+        return `${fn.name}${rng.chance(0.1) ? "?." : ""}(${args.join(", ")})`;
+      }
+      case 10: {
+        if (scope.classes.length === 0) return sub();
+        const cls = rng.pick(scope.classes);
+        switch (rng.int(3)) {
+          case 0:
+            return `new ${cls}(${sub()}).v`;
+          case 1:
+            return `new ${cls}(${sub()}).m(${sub()})`;
+          default:
+            return `${cls}.s(${sub()})`;
+        }
+      }
+      case 11: {
+        if (scope.mutable.length === 0) return sub();
+        const target = rng.pick(scope.mutable);
+        if (rng.chance(0.3)) return `(${rng.chance(0.5) ? target + "++" : "--" + target})`;
+        return `(${target} ${rng.pick(["=", "+=", "-=", "??=", "||="])} ${sub()})`;
+      }
+      case 12: {
+        const items = this.list(rng.int(4), sub);
+        if (rng.chance(0.3)) items.splice(rng.int(items.length + 1), 0, ""); // a hole
+        if (rng.chance(0.2)) items.push(`...[${sub()}]`);
+        const array = `[${items.join(", ")}]`;
+        return rng.chance(0.3) ? `${array}.length` : array;
+      }
+      case 13: {
+        const props = this.list(rng.int(3), () => `${this.fresh()}: ${sub()}`);
+        // One key that has to stay quoted and one the printer may unquote.
+        if (rng.chance(0.2)) props.push(`"quoted-key": ${sub()}`);
+        if (rng.chance(0.2)) props.push(`'${this.fresh()}': ${sub()}`);
+        if (rng.chance(0.2)) props.push(`[${sub()}]: ${sub()}`);
+        if (rng.chance(0.2))
+          props.push(`get ${this.fresh()}() { return ${this.expr(rebindsThis(scope), depth - 1)}; }`);
+        if (rng.chance(0.15)) props.push(`...${sub()}`);
+        const shorthand = scope.values.filter(v => IDENTIFIER.test(v));
+        if (shorthand.length > 0 && rng.chance(0.3)) props.push(rng.pick(shorthand));
+        return `({ ${props.join(", ")} })`;
+      }
+      case 14:
+        return `\`${rng.pick(["", "x ", "é "])}\${${sub()}}${rng.pick(["", " y", " $", " \\`", " \\${"])}\``;
+      case 15:
+        return `${sub()}?.${rng.pick(["length", "v", "[0]"])}`;
+      case 16: {
+        const param = this.fresh();
+        const inner = functionScope(scope, [param]);
+        const body = rng.chance(0.3)
+          ? `({ ${this.fresh()}: ${this.expr(inner, depth - 1)} })`
+          : this.expr(inner, depth - 1);
+        return `((${param}) => ${body})(${sub()})`;
+      }
+      case 17: {
+        const inner = rebindsThis(scope);
+        const yielded = () => this.expr(inner, depth - 1);
+        return `[...(function* () { yield ${yielded()}; yield ${yielded()}; })()]`;
+      }
+      case 18:
+        switch (rng.int(4)) {
+          case 0:
+            return `/a+b/i.test(String(${sub()}))`;
+          case 1:
+            return `String(${sub()})`;
+          case 2:
+            return `Number(${sub()})`;
+          default:
+            return `Math.max(${sub()}, ${sub()})`;
+        }
+      case 19:
+        return `(${sub()} ${rng.pick(["&&", "||"])} ${sub()} ${rng.pick(["&&", "||"])} ${sub()})`;
+      default:
+        return `(${sub()} ?? ${sub()})`;
+    }
+  }
+
+  /** Expression depth for statements: mostly 2, so that programs stay readable when they fail. */
+  private depth(): number {
+    return this.rng.chance(0.15) ? 3 : this.rng.range(1, 2);
+  }
+
+  private block(scope: Scope, changes: Partial<Scope> = {}): string {
+    const inner = child(scope, changes);
+    return `{\n${this.list(this.rng.range(1, 2), () => this.statement(inner)).join("\n")}\n}`;
+  }
+
+  /** A function body in its own scope, ending in a return. */
+  private body(scope: Scope, params: readonly string[]): string {
+    const inner = functionScope(scope, params);
+    const statements = this.list(this.rng.int(3), () => this.statement(inner));
+    statements.push(`return ${this.expr(inner, this.depth())};`);
+    return `{\n${statements.join("\n")}\n}`;
+  }
+
+  /** An expression statement: its value is unused, so the simplifier gets to work on it. */
+  private unusedExpression(scope: Scope): string {
+    this.noComma = true;
+    try {
+      return `${this.expr(scope, this.depth())};`;
+    } finally {
+      this.noComma = false;
+    }
+  }
+
+  private declaration(scope: Scope): string {
+    const name = this.fresh();
+    const kind = this.rng.pick(["const", "let", "let", "var"]);
+    const code = `${kind} ${name} = ${this.expr(scope, this.depth())};`;
+    scope.values.push(name);
+    if (kind !== "const") scope.mutable.push(name);
+    return code;
+  }
+
+  private statement(scope: Scope): string {
+    const rng = this.rng;
+    const e = () => this.expr(scope, this.depth());
+    const push = () => `__out.push(${this.list(rng.range(1, 3), e).join(", ")});`;
+    // Deep nesting only gets statements that cannot nest further.
+    const kinds = scope.depth > 3 ? 4 : 16;
+    switch (rng.int(kinds)) {
+      case 0:
+      case 1:
+        return this.declaration(scope);
+      case 2: {
+        if (scope.mutable.length === 0) return this.unusedExpression(scope);
+        const target = rng.pick(scope.mutable);
+        return rng.chance(0.2) ? `${target}++;` : `${target} ${rng.pick(["=", "+=", "*="])} ${e()};`;
+      }
+      case 3:
+        return push();
+      case 4:
+        return this.unusedExpression(scope);
+      case 5: {
+        let code = `if (${e()}) ${this.block(scope)}`;
+        if (rng.chance(0.3)) code += ` else if (${e()}) ${this.block(scope)}`;
+        if (rng.chance(0.5)) code += ` else ${this.block(scope)}`;
+        return code;
+      }
+      case 6: {
+        const i = this.fresh();
+        const loopBody = { values: scope.values.concat(i), inLoop: true };
+        if (rng.chance(0.4))
+          return `for (const ${i} of [${this.list(rng.int(4), e).join(", ")}]) ${this.block(scope, loopBody)}`;
+        return `for (let ${i} = 0; ${i} < ${rng.int(4)}; ${i}++) ${this.block(scope, loopBody)}`;
+      }
+      case 7:
+        return scope.inLoop ? `if (${e()}) ${rng.pick(["break", "continue"])};` : push();
+      case 8:
+        return scope.inTry ? `throw ${e()};` : push();
+      case 9: {
+        // Without a catch clause the try block only runs a finally, so a throw
+        // in it would escape.
+        const hasCatch = rng.chance(0.85);
+        let code = `try ${this.block(scope, { inTry: hasCatch || scope.inTry })}`;
+        if (hasCatch) {
+          const caught = this.fresh();
+          code += rng.chance(0.2)
+            ? ` catch ${this.block(scope)}`
+            : ` catch (${caught}) ${this.block(scope, { values: scope.values.concat(caught) })}`;
+        }
+        if (!hasCatch || rng.chance(0.3)) code += ` finally ${this.block(scope)}`;
+        return code;
+      }
+      case 10: {
+        // Each case gets its own scope: a binding declared in one case is in
+        // its temporal dead zone when the switch jumps straight to another.
+        const clause = (label: string) =>
+          `${label}:\n${this.statement(child(scope))}${rng.chance(0.7) ? "\nbreak;" : ""}`;
+        const clauses = this.list(rng.range(1, 3), () => clause(`case ${this.expr(scope, 2)}`));
+        if (rng.chance(0.6)) clauses.splice(rng.int(clauses.length + 1), 0, clause("default"));
+        return `switch (${e()}) {\n${clauses.join("\n")}\n}`;
+      }
+      case 11: {
+        // Function declarations stay at the top level: inside a block, sloppy
+        // and strict code hoist them differently.
+        if (scope.depth > 0) return push();
+        const name = this.fresh();
+        const names = this.list(rng.int(3), () => this.fresh());
+        const params = names.slice();
+        // Callers pass only the plain parameters, so a default or rest parameter gets exercised.
+        const arity = params.length;
+        if (rng.chance(0.2)) {
+          names.push(this.fresh());
+          params.push(`${names.at(-1)} = ${this.expr(scope, 1)}`);
+        }
+        if (rng.chance(0.15)) {
+          names.push(this.fresh());
+          params.push(`...${names.at(-1)}`);
+        }
+        const code = `function ${name}(${params.join(", ")}) ${this.body(scope, names)}`;
+        scope.functions.push({ name, arity });
+        return code;
+      }
+      case 12: {
+        const name = this.fresh();
+        const params = this.list(rng.int(3), () => this.fresh());
+        const head = params.length === 1 && rng.chance(0.5) ? params[0] : `(${params.join(", ")})`;
+        const body = rng.chance(0.5) ? this.body(scope, params) : this.expr(functionScope(scope, params), 2);
+        scope.functions.push({ name, arity: params.length });
+        return `const ${name} = ${head} => ${body};`;
+      }
+      case 13: {
+        const name = this.fresh();
+        const [x, y, z] = [this.fresh(), this.fresh(), this.fresh()];
+        const inConstructor = functionScope(scope, [x]);
+        const inMethod = functionScope(scope, ["this.v", y]);
+        const inStatic = functionScope(scope, [z]);
+        const code =
+          `class ${name} {\n` +
+          (rng.chance(0.5) ? `${this.fresh()} = ${this.expr(functionScope(scope, []), 1)};\n` : "") +
+          `constructor(${x}) { this.v = ${this.expr(inConstructor, 2)}; }\n` +
+          `m(${y}) { return ${this.expr(inMethod, 2)}; }\n` +
+          (rng.chance(0.4) ? `get ${this.fresh()}() { return this.v; }\n` : "") +
+          `static s(${z}) { return ${this.expr(inStatic, 2)}; }\n` +
+          `}`;
+        scope.classes.push(name);
+        return code;
+      }
+      case 14: {
+        const [p, q, rest] = [this.fresh(), this.fresh(), this.fresh()];
+        const code = rng.chance(0.5)
+          ? `const [${p}, , ${q} = ${e()}, ...${rest}] = [${this.list(rng.range(1, 4), e).join(", ")}];`
+          : `const { k: ${p}, j: ${q} = ${e()}, ...${rest} } = { k: ${e()}${rng.chance(0.5) ? `, j: ${e()}` : ""}, n: ${e()} };`;
+        scope.values.push(p, q, rest);
+        return code;
+      }
+      default:
+        return this.declaration(scope);
+    }
+  }
+
+  program(): string {
+    const scope: Scope = { values: [], mutable: [], functions: [], classes: [], depth: 0, inLoop: false, inTry: false };
+    const statements = this.list(this.rng.range(2, 7), () => this.statement(scope));
+    if (scope.values.length > 0) statements.push(`__out.push(${scope.values.join(", ")});`);
+    return statements.join("\n") + "\n";
+  }
+}
+
+/** Serializes a value the program produced; -0, holes and key order are all significant. */
+function show(value: unknown, depth = 0): string {
+  switch (typeof value) {
+    case "number":
+      return Object.is(value, -0) ? "-0" : String(value);
+    case "string":
+      return JSON.stringify(value);
+    case "function":
+      return "[function]";
+    case "object": {
+      if (value === null) return "null";
+      // A getter can return the object that holds it, so nesting is capped.
+      if (depth > 8) return "<deep>";
+      if (Array.isArray(value)) {
+        const items: string[] = [];
+        for (let i = 0; i < value.length; i++) items.push(i in value ? show(value[i], depth + 1) : "<hole>");
+        return `[${items.join(", ")}]`;
+      }
+      const record = value as Record<string, unknown>;
+      return `{${Object.keys(record)
+        .map(key => `${JSON.stringify(key)}: ${show(record[key], depth + 1)}`)
+        .join(", ")}}`;
+    }
+    default:
+      return String(value);
+  }
+}
+
+const UNCAUGHT = " then uncaught ";
+
+/** Runs a program and returns what it pushed to `__out`, plus the class of any exception that escaped. */
+function run(code: string): string {
+  const out: unknown[] = [];
+  try {
+    new Function("__out", code)(out);
+  } catch (error: any) {
+    return `${show(out)}${UNCAUGHT}${error?.constructor?.name ?? show(error)}`;
+  }
+  return show(out);
+}
+
+function failure(message: string, sections: Record<string, string>): Error {
+  let text = message;
+  for (const [title, content] of Object.entries(sections)) text += `\n--- ${title} ---\n${content.trimEnd()}`;
+  return new Error(text);
+}
+
+/** The first line on which two texts differ, for the top of a failure message. */
+function firstDifference(a: string, b: string): string {
+  const as = a.split("\n");
+  const bs = b.split("\n");
+  for (let i = 0; i < Math.max(as.length, bs.length); i++) {
+    if (as[i] !== bs[i]) return `line ${i + 1}:\n  ${as[i] ?? "<missing>"}\n  ${bs[i] ?? "<missing>"}`;
+  }
+  return "(identical)";
+}
+
+/** The three checks for one transpiler configuration; `expected` is what the source itself produced. */
+function check(
+  transpiler: Bun.Transpiler,
+  title: string,
+  source: string,
+  expected: string,
+  sections: Record<string, string>,
+) {
+  let output: string;
+  try {
+    output = transpiler.transformSync(source);
+  } catch (error) {
+    throw failure(`${title}: transformSync rejected a generated program: ${error}`, sections);
+  }
+  try {
+    acorn.parse(output, { ecmaVersion: "latest", sourceType: "module" });
+  } catch (error) {
+    throw failure(`${title} output does not parse: ${error}`, { ...sections, [title]: output });
+  }
+  const again = transpiler.transformSync(output);
+  if (again !== output) {
+    throw failure(`transpiling the ${title} output changed it, first at ${firstDifference(output, again)}`, {
+      ...sections,
+      [title]: output,
+      [`${title} again`]: again,
+    });
+  }
+  const actual = run(output);
+  if (actual !== expected) {
+    throw failure(`the ${title} output behaves differently`, {
+      ...sections,
+      [title]: output,
+      "source produced": expected,
+      [`${title} produced`]: actual,
+    });
+  }
+}
+
+test(
+  `transpiler output parses, is a fixed point and behaves like its input ${fuzz.label}`,
+  () => {
+    const generator = new ProgramGenerator(new Rng(fuzz.seed));
+    let completed = 0;
+    for (let i = 0; i < fuzz.iters; i++) {
+      const source = generator.program();
+      const sections = { source, repro: fuzz.repro(i) };
+      const expected = run(source);
+      if (!expected.includes(UNCAUGHT)) completed++;
+      check(printer, "printed", source, expected, sections);
+      check(minifier, "minified", source, expected, sections);
+    }
+    console.log(
+      `transpiler-differential-fuzz: ${fuzz.iters} programs checked, ${completed} ran without an uncaught exception`,
+    );
+    // An escaping exception is compared too, but it cuts the program's output
+    // short; the generator is meant to keep programs from throwing at all.
+    expect(completed).toBeGreaterThan(fuzz.iters * 0.9);
+  },
+  fuzz.timeout,
+);

--- a/test/bundler/transpiler/transpiler-differential-fuzz.test.ts
+++ b/test/bundler/transpiler/transpiler-differential-fuzz.test.ts
@@ -63,10 +63,9 @@ const NUMBERS = [
   "9007199254740993",
   "4294967296",
   "NaN",
-  // Known divergence, found by this fuzzer and handed off separately: an
-  // infinite value is printed as `1 / 0`, which the next pass no longer treats
-  // as a primitive, so `"a" != Infinity` prints as `"a" != 1 / 0` and reprints
-  // as `1 / 0 != "a"`. Add "Infinity" and "1e999" here once that is fixed.
+  // Known divergence (pinned at the bottom of the file): infinite values are
+  // printed as `1 / 0`, which the next pass no longer treats as a primitive.
+  // Add "Infinity" and "1e999" here when the pin flips.
 ];
 
 // `+` is repeated to weight it: it is the operator with the most printing rules
@@ -122,10 +121,10 @@ function rebindsThis(scope: Scope): Scope {
 class ProgramGenerator {
   private counter = 0;
   /**
-   * Known divergence, found by this fuzzer and handed off separately: the
-   * unused-expression simplifier turns `(a, b) ? f() : 0;` into `a, b && f();`
-   * and only drops the `a,` on the next pass, so an expression statement
-   * (whose value is unused) gets no comma operators until that is fixed.
+   * Known divergence (pinned at the bottom of the file): the unused-expression
+   * simplifier needs two passes for a comma inside an unused ternary, so an
+   * expression statement (whose value is unused) gets no comma operators.
+   * Remove this flag when the pin flips.
    */
   private noComma = false;
   constructor(private rng: Rng) {}
@@ -511,25 +510,39 @@ function check(
   }
 }
 
-test(
-  `transpiler output parses, is a fixed point and behaves like its input ${fuzz.label}`,
-  () => {
-    const generator = new ProgramGenerator(new Rng(fuzz.seed));
-    let completed = 0;
-    for (let i = 0; i < fuzz.iters; i++) {
-      const source = generator.program();
-      const sections = { source, repro: fuzz.repro(i) };
-      const expected = run(source);
-      if (!expected.includes(UNCAUGHT)) completed++;
-      check(printer, "printed", source, expected, sections);
-      check(minifier, "minified", source, expected, sections);
-    }
-    console.log(
-      `transpiler-differential-fuzz: ${fuzz.iters} programs checked, ${completed} ran without an uncaught exception`,
-    );
-    // An escaping exception is compared too, but it cuts the program's output
-    // short; the generator is meant to keep programs from throwing at all.
-    expect(completed).toBeGreaterThan(fuzz.iters * 0.9);
-  },
-  fuzz.timeout,
-);
+test(`transpiler output parses, is a fixed point and behaves like its input ${fuzz.label}`, () => {
+  const generator = new ProgramGenerator(new Rng(fuzz.seed));
+  let completed = 0;
+  for (let i = 0; i < fuzz.iters; i++) {
+    const source = generator.program();
+    const sections = { source, repro: fuzz.repro(i) };
+    const expected = run(source);
+    if (!expected.includes(UNCAUGHT)) completed++;
+    check(printer, "printed", source, expected, sections);
+    check(minifier, "minified", source, expected, sections);
+  }
+  console.log(
+    `transpiler-differential-fuzz: ${fuzz.iters} programs checked, ${completed} ran without an uncaught exception`,
+  );
+  // An escaping exception is compared too, but it cuts the program's output
+  // short; the generator is meant to keep programs from throwing at all.
+  expect(completed).toBeGreaterThan(fuzz.iters * 0.9);
+});
+
+// The programs the generator steers around, put through the same checks. Each
+// has a fix in flight; when a pin starts passing, delete it and undo the
+// exclusion it names.
+function pin(source: string): void {
+  const sections = { source };
+  const expected = run(source);
+  check(printer, "printed", source, expected, sections);
+  check(minifier, "minified", source, expected, sections);
+}
+
+test.failing("known divergence: comparing against an infinite value is not a fixed point (NUMBERS)", () => {
+  pin('__out.push("a" != Infinity);\n');
+});
+
+test.failing("known divergence: an unused ternary with a comma test takes two passes to simplify (noComma)", () => {
+  pin("let a = 1, b = 2;\nconst f = () => __out.push(a);\n(a, b) ? f() : 0;\n");
+});

--- a/test/js/bun/glob/__snapshots__/scan.test.ts.snap
+++ b/test/js/bun/glob/__snapshots__/scan.test.ts.snap
@@ -392,6 +392,7 @@ exports[`fast-glob e2e tests patterns regular cwd **/{nested,file.md}/*: **/{nes
 
 exports[`fast-glob e2e tests patterns regular relative cwd ./*: ./* 1`] = `
 [
+  "./glob-differential-fuzz.test.ts",
   "./leak.test.ts",
   "./match.test.ts",
   "./path-length.test.ts",

--- a/test/js/bun/glob/glob-differential-fuzz.test.ts
+++ b/test/js/bun/glob/glob-differential-fuzz.test.ts
@@ -285,4 +285,4 @@ test(`Bun.Glob#match agrees with picomatch ${fuzz.label}`, () => {
   console.log(`glob-differential-fuzz: ${fuzz.iters} patterns, ${compared} paths compared, ${matched} matched`);
   expect(matched).toBeGreaterThan(0);
   expect(matched).toBeLessThan(compared);
-});
+}, fuzz.timeout);

--- a/test/js/bun/glob/glob-differential-fuzz.test.ts
+++ b/test/js/bun/glob/glob-differential-fuzz.test.ts
@@ -13,8 +13,10 @@
 //   - Bun's negated classes `[!x]` / `[^x]` match `/` ("anything except the
 //     characters", docs/runtime/glob.mdx); picomatch's never cross a separator.
 //   - picomatch turns `{a}` / `{}` into literals and `{1..3}` into a range; Bun
-//     braces always group and never expand ranges. `**` touching a brace group
-//     (`**{a,b}`, `{**/a,b}`) is a globstar for one matcher and `*` for the other.
+//     braces always group and never expand ranges. A `**` inside or touching a
+//     brace group is read differently too: picomatch lets it cross separators
+//     even in `**{a,b}` and `a/{b,**}x`, where Bun (expanding the group like
+//     bash) sees `*`, while `{**/a,b}` is a globstar for Bun only.
 //   - Inside braces picomatch gives a `.` followed by `*` the guard it normally
 //     reserves for the start of a segment, so `x{?.*,b}` does not match "x.."
 //     although `x?.*` does; Bun expands braces like bash and matches both.
@@ -183,13 +185,11 @@ function deriveSegment(rng: Rng, text: string, shape: Shape, inBraces: boolean):
 function derivePattern(rng: Rng, path: string[]): string {
   const braces = rng.int(3);
   const globstarSegments = rng.chance(0.75);
-  // Known divergences, found by this fuzzer and handed off separately: a `**`
-  // that is only part of a segment is documented to mean `*`, but
-  // src/glob/matcher.rs still runs some of its globstar logic for it, so
-  // `a**/**` matches "ab" (`a*/**` does not) and `**/a**/{x,y}` matches
-  // "ab/ay" (`**/a*/{x,y}` does not). Until both are fixed, partial globstars
-  // only appear in patterns without globstar segments or braces; afterwards
-  // this can become an independent coin flip.
+  // Known divergences (pinned by PARTIAL_GLOBSTAR_BUGS below): a `**` that is
+  // only part of a segment is documented to mean `*`, but src/glob/matcher.rs
+  // still runs some of its globstar logic for it. Until the pin flips, partial
+  // globstars only appear in patterns without globstar segments or braces;
+  // afterwards this becomes an independent coin flip.
   const shape: Shape = { braces, globstarSegments, partialGlobstar: braces === 0 && !globstarSegments };
 
   const segments: string[] = [];
@@ -253,40 +253,52 @@ function mutatePath(rng: Rng, path: string[]): string[] {
   return out;
 }
 
-test(
-  `Bun.Glob#match agrees with picomatch ${fuzz.label}`,
-  () => {
-    const rng = new Rng(fuzz.seed);
-    let compared = 0;
-    let matched = 0;
-    for (let i = 0; i < fuzz.iters; i++) {
-      const basePath = genPath(rng);
-      const pattern = derivePattern(rng, basePath);
-      const reference = picomatch(pattern, PICOMATCH_OPTIONS);
-      const glob = new Glob(pattern);
+test(`Bun.Glob#match agrees with picomatch ${fuzz.label}`, () => {
+  const rng = new Rng(fuzz.seed);
+  let compared = 0;
+  let matched = 0;
+  for (let i = 0; i < fuzz.iters; i++) {
+    const basePath = genPath(rng);
+    const pattern = derivePattern(rng, basePath);
+    const reference = picomatch(pattern, PICOMATCH_OPTIONS);
+    const glob = new Glob(pattern);
 
-      const paths = [basePath];
-      while (paths.length < PATHS_PER_PATTERN) {
-        paths.push(rng.chance(0.7) ? mutatePath(rng, rng.pick(paths)) : genPath(rng));
-      }
-      for (const segments of paths) {
-        const path = segments.join("/");
-        if (path === pattern) continue;
-        const expected = reference(path);
-        const actual = glob.match(path);
-        compared++;
-        if (expected) matched++;
-        if (actual !== expected) {
-          throw new Error(
-            `new Bun.Glob(${JSON.stringify(pattern)}).match(${JSON.stringify(path)}) returned ${actual}, ` +
-              `picomatch says ${expected}. ${fuzz.repro(i)}`,
-          );
-        }
+    const paths = [basePath];
+    while (paths.length < PATHS_PER_PATTERN) {
+      paths.push(rng.chance(0.7) ? mutatePath(rng, rng.pick(paths)) : genPath(rng));
+    }
+    for (const segments of paths) {
+      const path = segments.join("/");
+      if (path === pattern) continue;
+      const expected = reference(path);
+      const actual = glob.match(path);
+      compared++;
+      if (expected) matched++;
+      if (actual !== expected) {
+        throw new Error(
+          `new Bun.Glob(${JSON.stringify(pattern)}).match(${JSON.stringify(path)}) returned ${actual}, ` +
+            `picomatch says ${expected}. ${fuzz.repro(i)}`,
+        );
       }
     }
-    console.log(`glob-differential-fuzz: ${fuzz.iters} patterns, ${compared} paths compared, ${matched} matched`);
-    expect(matched).toBeGreaterThan(0);
-    expect(matched).toBeLessThan(compared);
-  },
-  fuzz.timeout,
-);
+  }
+  console.log(`glob-differential-fuzz: ${fuzz.iters} patterns, ${compared} paths compared, ${matched} matched`);
+  expect(matched).toBeGreaterThan(0);
+  expect(matched).toBeLessThan(compared);
+});
+
+// The cases derivePattern() steers around (`a*/**` and `**/a*/{x,y}` agree).
+// Each has a fix in flight; when the last one lands this starts passing, and
+// then it should be deleted together with the partialGlobstar gating.
+const PARTIAL_GLOBSTAR_BUGS: [pattern: string, path: string][] = [
+  ["a**/**", "ab"],
+  ["**/a**/{x,y}", "ab/ay"],
+];
+
+test.failing("known divergences: a `**` that is only part of a segment still acts as a globstar", () => {
+  for (const [pattern, path] of PARTIAL_GLOBSTAR_BUGS) {
+    expect(new Glob(pattern).match(path), `${pattern} against ${path}`).toBe(
+      picomatch(pattern, PICOMATCH_OPTIONS)(path),
+    );
+  }
+});

--- a/test/js/bun/glob/glob-differential-fuzz.test.ts
+++ b/test/js/bun/glob/glob-differential-fuzz.test.ts
@@ -31,7 +31,7 @@ import { Glob } from "bun";
 import { expect, test } from "bun:test";
 import picomatch from "picomatch";
 
-const fuzz = fuzzEnv("BUN_GLOB_FUZZ", 0x676c6f62, 300);
+const fuzz = fuzzEnv("BUN_GLOB_FUZZ", 0x676c6f62, { release: 2000, debug: 200 });
 const PATHS_PER_PATTERN = 3;
 
 const PICOMATCH_OPTIONS = {
@@ -253,36 +253,40 @@ function mutatePath(rng: Rng, path: string[]): string[] {
   return out;
 }
 
-test(`Bun.Glob#match agrees with picomatch ${fuzz.label}`, () => {
-  const rng = new Rng(fuzz.seed);
-  let compared = 0;
-  let matched = 0;
-  for (let i = 0; i < fuzz.iters; i++) {
-    const basePath = genPath(rng);
-    const pattern = derivePattern(rng, basePath);
-    const reference = picomatch(pattern, PICOMATCH_OPTIONS);
-    const glob = new Glob(pattern);
+test(
+  `Bun.Glob#match agrees with picomatch ${fuzz.label}`,
+  () => {
+    const rng = new Rng(fuzz.seed);
+    let compared = 0;
+    let matched = 0;
+    for (let i = 0; i < fuzz.iters; i++) {
+      const basePath = genPath(rng);
+      const pattern = derivePattern(rng, basePath);
+      const reference = picomatch(pattern, PICOMATCH_OPTIONS);
+      const glob = new Glob(pattern);
 
-    const paths = [basePath];
-    while (paths.length < PATHS_PER_PATTERN) {
-      paths.push(rng.chance(0.7) ? mutatePath(rng, rng.pick(paths)) : genPath(rng));
-    }
-    for (const segments of paths) {
-      const path = segments.join("/");
-      if (path === pattern) continue;
-      const expected = reference(path);
-      const actual = glob.match(path);
-      compared++;
-      if (expected) matched++;
-      if (actual !== expected) {
-        throw new Error(
-          `new Bun.Glob(${JSON.stringify(pattern)}).match(${JSON.stringify(path)}) returned ${actual}, ` +
-            `picomatch says ${expected}. ${fuzz.repro(i)}`,
-        );
+      const paths = [basePath];
+      while (paths.length < PATHS_PER_PATTERN) {
+        paths.push(rng.chance(0.7) ? mutatePath(rng, rng.pick(paths)) : genPath(rng));
+      }
+      for (const segments of paths) {
+        const path = segments.join("/");
+        if (path === pattern) continue;
+        const expected = reference(path);
+        const actual = glob.match(path);
+        compared++;
+        if (expected) matched++;
+        if (actual !== expected) {
+          throw new Error(
+            `new Bun.Glob(${JSON.stringify(pattern)}).match(${JSON.stringify(path)}) returned ${actual}, ` +
+              `picomatch says ${expected}. ${fuzz.repro(i)}`,
+          );
+        }
       }
     }
-  }
-  console.log(`glob-differential-fuzz: ${fuzz.iters} patterns, ${compared} paths compared, ${matched} matched`);
-  expect(matched).toBeGreaterThan(0);
-  expect(matched).toBeLessThan(compared);
-}, fuzz.timeout);
+    console.log(`glob-differential-fuzz: ${fuzz.iters} patterns, ${compared} paths compared, ${matched} matched`);
+    expect(matched).toBeGreaterThan(0);
+    expect(matched).toBeLessThan(compared);
+  },
+  fuzz.timeout,
+);

--- a/test/js/bun/glob/glob-differential-fuzz.test.ts
+++ b/test/js/bun/glob/glob-differential-fuzz.test.ts
@@ -1,0 +1,288 @@
+// Seeded differential fuzz of Bun.Glob#match against picomatch. Replay a
+// failure with BUN_GLOB_FUZZ_SEED=<seed>; soak with BUN_GLOB_FUZZ_ITERS=<n>.
+//
+// The generator only emits the dialect both matchers define identically. Each
+// exclusion below is a documented difference between the two dialects, so it is
+// kept out of the generator rather than tolerated in the comparison:
+//   - picomatch rejects "" as a path and as a pattern, and short-circuits
+//     `path === pattern` to true; Bun matches both structurally.
+//   - picomatch never matches a `.` or `..` segment or an empty segment
+//     (leading, doubled or trailing `/`), and strips a leading `./` from the
+//     pattern; Bun.Glob treats all of those as literal text. Dotfiles agree
+//     once picomatch gets dot:true.
+//   - Bun's negated classes `[!x]` / `[^x]` match `/` ("anything except the
+//     characters", docs/runtime/glob.mdx); picomatch's never cross a separator.
+//   - picomatch turns `{a}` / `{}` into literals and `{1..3}` into a range; Bun
+//     braces always group and never expand ranges. `**` touching a brace group
+//     (`**{a,b}`, `{**/a,b}`) is a globstar for one matcher and `*` for the other.
+//   - Inside braces picomatch gives a `.` followed by `*` the guard it normally
+//     reserves for the start of a segment, so `x{?.*,b}` does not match "x.."
+//     although `x?.*` does; Bun expands braces like bash and matches both.
+//   - After a `**` segment, picomatch lets a final segment that can match the
+//     empty string (`a/**/{,b}` against "a") stand in for no segment at all;
+//     Bun, like bash, still requires the `/`.
+//   - `( ) | + @ "` are extglob / regex syntax in picomatch and plain text in
+//     Bun; `\` before a letter is a regex class in picomatch (`\d`, `\b`) and a
+//     plain letter in Bun; a run of three or more stars is rebuilt differently.
+//   - On Windows Bun.Glob#match also treats `\` in the *path* as a separator, so
+//     paths contain no backslashes (pattern escapes behave the same everywhere).
+import { fuzzEnv, Rng } from "_util/fuzz";
+import { Glob } from "bun";
+import { expect, test } from "bun:test";
+import picomatch from "picomatch";
+
+const fuzz = fuzzEnv("BUN_GLOB_FUZZ", 0x676c6f62, 300);
+const PATHS_PER_PATTERN = 3;
+
+const PICOMATCH_OPTIONS = {
+  dot: true, // Bun.Glob#match has no dotfile rule
+  strictSlashes: true, // `a/**` must not match "a"; a trailing `/` is significant
+  posix: true,
+  literalBrackets: false, // `[ab]` must not also match the literal text "[ab]"
+  fastpaths: false,
+  noextglob: true,
+  regex: false,
+  windows: false,
+};
+
+const PLAIN = [..."abcxyzAB019._-"];
+// Glob syntax characters: literal text in paths, always escaped in patterns.
+const META = [..."*?[]{}!,"];
+const CLASSABLE = "abcxyz019";
+
+function genSegment(rng: Rng): string {
+  let s: string;
+  do {
+    const n = rng.range(1, 4);
+    s = "";
+    for (let i = 0; i < n; i++) s += rng.chance(0.08) ? rng.pick(META) : rng.pick(PLAIN);
+  } while (s === "." || s === "..");
+  return s;
+}
+
+function genPath(rng: Rng): string[] {
+  const segments: string[] = [];
+  const n = rng.range(1, 4);
+  for (let i = 0; i < n; i++) segments.push(genSegment(rng));
+  return segments;
+}
+
+function literal(ch: string): string {
+  return META.includes(ch) ? "\\" + ch : ch;
+}
+
+function genClass(rng: Rng, ch: string): string {
+  if (rng.chance(0.5)) {
+    const at = CLASSABLE.indexOf(ch);
+    const lo = at - rng.int(3);
+    const hi = at + rng.int(3);
+    // CLASSABLE is not in code point order across the letter/digit boundary,
+    // and a reversed range is invalid for both matchers.
+    if (lo >= 0 && hi < CLASSABLE.length && CLASSABLE.charCodeAt(lo) < CLASSABLE.charCodeAt(hi)) {
+      return `[${CLASSABLE[lo]}-${CLASSABLE[hi]}]`;
+    }
+  }
+  let members = ch;
+  const extra = rng.int(3);
+  for (let i = 0; i < extra; i++) members += rng.pick([...CLASSABLE]);
+  return `[${members}]`;
+}
+
+/** Per-pattern choices; decided up front so every segment of one pattern agrees. */
+interface Shape {
+  /** Brace groups this pattern may still open. */
+  braces: number;
+  /** Whether whole `**` segments may be emitted. */
+  globstarSegments: boolean;
+  /** Whether a `**` that is only part of a segment (`**.js`, `a**b`, both meaning `*`) may be emitted. */
+  partialGlobstar: boolean;
+}
+
+interface SegmentPattern {
+  text: string;
+  /** Whether the pattern can match "" (only stars and braces with such an alternative). */
+  canBeEmpty: boolean;
+}
+
+/** A pattern for one segment, mostly matching `text`, sometimes deliberately not. */
+function deriveSegment(rng: Rng, text: string, shape: Shape, inBraces: boolean): SegmentPattern {
+  let out = "";
+  let canBeEmpty = true;
+  let lastWasStar = false;
+  const chars = [...text];
+  for (let i = 0; i < chars.length; i++) {
+    const ch = chars[i];
+    const roll = rng.next();
+    if (roll < 0.45) {
+      out += literal(rng.chance(0.06) ? rng.pick(PLAIN) : ch);
+      canBeEmpty = false;
+      lastWasStar = false;
+    } else if (roll < 0.65) {
+      if (lastWasStar) {
+        out += "?";
+        canBeEmpty = false;
+        lastWasStar = false;
+        continue;
+      }
+      const swallowed = rng.int(3); // the star stands in for some of the following characters too
+      // A `**` that is the entire segment would be a real globstar, so a partial
+      // one needs text on at least one side of it.
+      const wholeSegment = out === "" && i + swallowed >= chars.length - 1;
+      out += shape.partialGlobstar && !inBraces && !wholeSegment && rng.chance(0.3) ? "**" : "*";
+      i += swallowed;
+      lastWasStar = true;
+    } else if (roll < 0.78) {
+      out += "?";
+      canBeEmpty = false;
+      lastWasStar = false;
+    } else if (roll < 0.9 && CLASSABLE.includes(ch)) {
+      out += genClass(rng, ch);
+      canBeEmpty = false;
+      lastWasStar = false;
+    } else if (shape.braces > 0 && out !== "**") {
+      // (`**{a,b}` is the brace adjacency case from the header.)
+      shape.braces--;
+      const span = chars.slice(i, i + rng.range(1, 3)).join("");
+      const alternatives = [deriveSegment(rng, span, shape, true)];
+      const n = rng.range(1, 2);
+      for (let k = 0; k < n; k++) {
+        alternatives.push(
+          rng.chance(0.2)
+            ? { text: "", canBeEmpty: true }
+            : deriveSegment(rng, rng.string(PLAIN, rng.range(1, 3)), shape, true),
+        );
+      }
+      // Move the alternative derived from the real text to a random slot.
+      const at = rng.int(alternatives.length);
+      [alternatives[0], alternatives[at]] = [alternatives[at], alternatives[0]];
+      if (alternatives.some(a => a.text.includes("..") || a.text.includes(".*"))) {
+        // `..` would be a picomatch range and `.*` gets the dotfile guard
+        // (header); keep this character literal instead of opening the group.
+        out += literal(ch);
+        canBeEmpty = false;
+      } else {
+        out += `{${alternatives.map(a => a.text).join(",")}}`;
+        if (!alternatives.some(a => a.canBeEmpty)) canBeEmpty = false;
+        i += span.length - 1;
+      }
+      lastWasStar = false;
+    } else {
+      out += literal(ch);
+      canBeEmpty = false;
+      lastWasStar = false;
+    }
+  }
+  if (!inBraces && (out === "." || out === "..")) {
+    // Same rule as genSegment: a whole segment is never `.` or `..` (header).
+    out += "?";
+    canBeEmpty = false;
+  }
+  return { text: out, canBeEmpty };
+}
+
+function derivePattern(rng: Rng, path: string[]): string {
+  const braces = rng.int(3);
+  const globstarSegments = rng.chance(0.75);
+  // Known divergences, found by this fuzzer and handed off separately: a `**`
+  // that is only part of a segment is documented to mean `*`, but
+  // src/glob/matcher.rs still runs some of its globstar logic for it, so
+  // `a**/**` matches "ab" (`a*/**` does not) and `**/a**/{x,y}` matches
+  // "ab/ay" (`**/a*/{x,y}` does not). Until both are fixed, partial globstars
+  // only appear in patterns without globstar segments or braces; afterwards
+  // this can become an independent coin flip.
+  const shape: Shape = { braces, globstarSegments, partialGlobstar: braces === 0 && !globstarSegments };
+
+  const segments: string[] = [];
+  const push = (segment: SegmentPattern) => {
+    // An empty-matchable brace segment right after a globstar is the
+    // `a/**/{,b}` case from the header; a `?` makes it need a character.
+    if (segment.canBeEmpty && segment.text.includes("{") && segments.at(-1) === "**") segment.text += "?";
+    segments.push(segment.text);
+  };
+  for (let i = 0; i < path.length; i++) {
+    const roll = rng.next();
+    if (roll < 0.2) {
+      if (shape.globstarSegments) {
+        segments.push("**");
+        // The globstar stands in for zero or more of the path's segments; when
+        // it stands in for zero, segment i is derived by the next iteration.
+        i += rng.int(path.length - i + 1) - 1;
+      } else {
+        push(deriveSegment(rng, path[i], shape, false));
+      }
+    } else if (roll < 0.25) {
+      // Drop the segment, or swap in an unrelated one: a likely non-match.
+      if (rng.chance(0.5)) push(deriveSegment(rng, genSegment(rng), shape, false));
+    } else {
+      push(deriveSegment(rng, path[i], shape, false));
+    }
+  }
+  if (shape.globstarSegments && (segments.length === 0 || rng.chance(0.08))) segments.push("**");
+  if (segments.length === 0) segments.push("*");
+  let pattern = segments.join("/");
+  if (rng.chance(0.12)) pattern = "!" + pattern;
+  if (rng.chance(0.03)) pattern = "!" + pattern;
+  return pattern;
+}
+
+function mutatePath(rng: Rng, path: string[]): string[] {
+  const out = path.slice();
+  const i = rng.int(out.length);
+  switch (rng.int(5)) {
+    case 0:
+      out.splice(rng.int(out.length + 1), 0, genSegment(rng));
+      break;
+    case 1:
+      if (out.length > 1) out.splice(i, 1);
+      else out[0] = genSegment(rng);
+      break;
+    case 2: {
+      const chars = [...out[i]];
+      chars[rng.int(chars.length)] = rng.pick(PLAIN);
+      const s = chars.join("");
+      out[i] = s === "." || s === ".." ? s + "x" : s;
+      break;
+    }
+    case 3:
+      out[i] = rng.chance(0.5) ? out[i] + rng.pick(PLAIN) : "." + out[i];
+      break;
+    default:
+      out[i] = out[i] === out[i].toUpperCase() ? out[i].toLowerCase() : out[i].toUpperCase();
+      break;
+  }
+  return out;
+}
+
+test(`Bun.Glob#match agrees with picomatch ${fuzz.label}`, () => {
+  const rng = new Rng(fuzz.seed);
+  let compared = 0;
+  let matched = 0;
+  for (let i = 0; i < fuzz.iters; i++) {
+    const basePath = genPath(rng);
+    const pattern = derivePattern(rng, basePath);
+    const reference = picomatch(pattern, PICOMATCH_OPTIONS);
+    const glob = new Glob(pattern);
+
+    const paths = [basePath];
+    while (paths.length < PATHS_PER_PATTERN) {
+      paths.push(rng.chance(0.7) ? mutatePath(rng, rng.pick(paths)) : genPath(rng));
+    }
+    for (const segments of paths) {
+      const path = segments.join("/");
+      if (path === pattern) continue;
+      const expected = reference(path);
+      const actual = glob.match(path);
+      compared++;
+      if (expected) matched++;
+      if (actual !== expected) {
+        throw new Error(
+          `new Bun.Glob(${JSON.stringify(pattern)}).match(${JSON.stringify(path)}) returned ${actual}, ` +
+            `picomatch says ${expected}. ${fuzz.repro(i)}`,
+        );
+      }
+    }
+  }
+  console.log(`glob-differential-fuzz: ${fuzz.iters} patterns, ${compared} paths compared, ${matched} matched`);
+  expect(matched).toBeGreaterThan(0);
+  expect(matched).toBeLessThan(compared);
+});

--- a/test/js/bun/jsonc/json-differential-fuzz.test.ts
+++ b/test/js/bun/jsonc/json-differential-fuzz.test.ts
@@ -1,44 +1,11 @@
 // Seeded differential fuzz of Bun.JSONC.parse against JSON.parse; replay a
 // failure with BUN_JSON_FUZZ_SEED=<seed> (and BUN_JSON_FUZZ_ITERS for a soak).
+import { envIters, envSeed, Rng } from "_util/fuzz";
 import { expect, test } from "bun:test";
 
-const DEFAULT_SEED = 0x6a736f6e;
-const SEED = process.env.BUN_JSON_FUZZ_SEED !== undefined ? Number(process.env.BUN_JSON_FUZZ_SEED) >>> 0 : DEFAULT_SEED;
-
-function envIters(name: string, fallback: number): number {
-  const raw = process.env[name];
-  if (raw === undefined) return fallback;
-  const n = Number(raw) | 0;
-  return n > 0 ? n : fallback;
-}
-
+const SEED = envSeed("BUN_JSON_FUZZ_SEED", 0x6a736f6e);
 const DOC_ITERS = envIters("BUN_JSON_FUZZ_ITERS", 400);
 const MUTATION_ITERS = envIters("BUN_JSON_FUZZ_ITERS", 1500);
-
-class Rng {
-  private a: number;
-  constructor(seed: number) {
-    this.a = seed >>> 0;
-  }
-  next(): number {
-    this.a = (this.a + 0x6d2b79f5) | 0;
-    let t = Math.imul(this.a ^ (this.a >>> 15), 1 | this.a);
-    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  }
-  int(n: number): number {
-    return Math.floor(this.next() * n);
-  }
-  range(lo: number, hi: number): number {
-    return lo + this.int(hi - lo + 1);
-  }
-  chance(p: number): boolean {
-    return this.next() < p;
-  }
-  pick<T>(arr: readonly T[]): T {
-    return arr[this.int(arr.length)];
-  }
-}
 
 const PLAIN_STRING_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 _-./:'<>!@#$%^&*()=~|;?";
 const STRING_ESCAPES = ["\\n", "\\t", "\\r", "\\b", "\\f", "\\\\", '\\"', "\\/", "\\u0000", "\\u001f", "\\uffff"];

--- a/test/js/node/path/path-differential-fuzz.test.ts
+++ b/test/js/node/path/path-differential-fuzz.test.ts
@@ -1,0 +1,314 @@
+// Seeded differential fuzz of node:path (src/runtime/node/path.rs) against the
+// installed Node.js: random paths through path.posix.* and path.win32.*, the
+// whole batch evaluated by one node child and compared call for call.
+// Replay with BUN_PATH_FUZZ_SEED=<seed>; soak with BUN_PATH_FUZZ_ITERS=<n>.
+//
+// Every call is independent of the cwd and of the host platform: resolve()
+// starts from an absolute base, relative() and win32 toNamespacedPath() only
+// see paths carrying their own device, and a win32 drive-relative argument
+// (`c:foo`) only ever names the base's drive (any other drive resolves against
+// the cwd or the `=D:` environment variable).
+//
+// Not generated, because node:path on main predates their handling in Node's
+// lib/path.js (oven-sh/bun#37305 brings them in; widen the generator then):
+//   - win32 reserved device names (CON, NUL, COM1, ...) and a `:` anywhere but
+//     in a drive prefix at the start of the path (CVE-2024-36139 `.\` prefixing);
+//   - `\\.\` and `\\?\` device roots;
+//   - upper-case non-ASCII letters (win32.relative folds them; main folds ASCII only);
+//   - lone surrogates (main transcodes them to U+FFFD).
+import { fuzzEnv, Rng } from "_util/fuzz";
+import { expect, test } from "bun:test";
+import { bunEnv, nodeExe } from "harness";
+import path from "node:path";
+
+/** Each iteration is 24 calls (12 per namespace, see genCases). */
+const fuzz = fuzzEnv("BUN_PATH_FUZZ", 0x70617468, 150);
+/** Iterations evaluated by one node child; a soak spawns one child per chunk. */
+const ITERS_PER_CHILD = 1000;
+
+type Namespace = "posix" | "win32";
+
+interface Case {
+  ns: Namespace;
+  /** A method of path.posix / path.win32, or "format(parse())" for the round trip. */
+  fn: string;
+  args: string[];
+}
+
+/**
+ * Evaluates one case to a comparable string. Runs both in this process and,
+ * embedded through Function#toString, in the node child, so it must only use
+ * its parameters and globals.
+ */
+function evaluate(ns: path.PlatformPath, c: { fn: string; args: string[] }): string {
+  try {
+    if (c.fn === "format(parse())") return JSON.stringify(ns.format(ns.parse(c.args[0])));
+    return JSON.stringify((ns as any)[c.fn](...c.args));
+  } catch (e: any) {
+    return `throws ${e?.code ?? e?.name ?? e}`;
+  }
+}
+
+const NODE_SCRIPT = `
+const path = require("node:path");
+const evaluate = ${evaluate.toString()};
+let input = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", chunk => (input += chunk));
+process.stdin.on("end", () => {
+  const results = JSON.parse(input).map(c => evaluate(path[c.ns], c));
+  process.stdout.write(JSON.stringify({ version: process.versions.node, results }));
+});
+`;
+
+async function evaluateInNode(node: string, cases: Case[]): Promise<{ version: string; results: string[] }> {
+  await using proc = Bun.spawn({
+    cmd: [node, "-e", NODE_SCRIPT],
+    env: bunEnv,
+    stdin: new Blob([JSON.stringify(cases)]),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+  return JSON.parse(stdout);
+}
+
+function describeCall({ ns, fn, args }: Case): string {
+  const list = args.map(a => JSON.stringify(a)).join(", ");
+  return fn === "format(parse())" ? `path.${ns}.format(path.${ns}.parse(${list}))` : `path.${ns}.${fn}(${list})`;
+}
+
+// No word spells a reserved device name, contains a `:` or has an upper-case
+// non-ASCII letter (header). "" produces doubled separators; "c\\d" is an
+// ordinary posix file name that happens to contain a backslash.
+const WORDS = [
+  "a",
+  "b",
+  "foo",
+  "bar.js",
+  "x.y",
+  "x.y.z",
+  ".hidden",
+  "..x",
+  "x..",
+  "file.",
+  "a b",
+  "index.d.ts",
+  "日本",
+  "é",
+  "𝟘",
+  "-",
+  "c\\d",
+  ".",
+  "..",
+  "",
+];
+const POSIX_SEPARATORS = ["/"];
+const WIN32_SEPARATORS = ["\\", "/"];
+const DRIVES = ["C", "c", "D", "z"];
+const UNC_SERVERS = ["server", "srv", "日本"];
+const UNC_SHARES = ["share", "s", "c$"];
+
+function genSeparators(rng: Rng, separators: readonly string[]): string {
+  return rng.string(separators, rng.chance(0.8) ? 1 : rng.range(2, 3));
+}
+
+function genWords(rng: Rng): string[] {
+  const words: string[] = [];
+  const n = rng.int(5);
+  for (let i = 0; i < n; i++) words.push(rng.pick(WORDS));
+  return words;
+}
+
+/** The words joined by separator runs, sometimes with a trailing run. */
+function joinWords(rng: Rng, words: readonly string[], separators: readonly string[]): string {
+  let s = "";
+  for (let i = 0; i < words.length; i++) {
+    if (i > 0) s += genSeparators(rng, separators);
+    s += words[i];
+  }
+  if (rng.chance(0.2)) s += genSeparators(rng, separators);
+  return s;
+}
+
+function genBody(rng: Rng, separators: readonly string[]): string {
+  return joinWords(rng, genWords(rng), separators);
+}
+
+function genPosixPath(rng: Rng, absolute: boolean = rng.chance(0.5)): string {
+  return (absolute ? genSeparators(rng, POSIX_SEPARATORS) : "") + genBody(rng, POSIX_SEPARATORS);
+}
+
+type Win32Root = "relative" | "rooted" | "drive-relative" | "drive" | "unc" | "unc-server-only";
+const ANY_ROOT: readonly Win32Root[] = ["relative", "rooted", "drive-relative", "drive", "unc", "unc-server-only"];
+/** Roots that do not start with a drive letter, so they never put a `:` after the start of a joined path. */
+const COLON_FREE_ROOTS: readonly Win32Root[] = ["relative", "relative", "rooted", "unc", "unc-server-only"];
+/** Roots that resolve() can complete without consulting the cwd. */
+const ROOTS_WITH_DEVICE: readonly Win32Root[] = ["drive", "unc"];
+
+function genWin32Root(rng: Rng, kind: Win32Root, drives: readonly string[]): string {
+  switch (kind) {
+    case "relative":
+      return "";
+    case "rooted":
+      return rng.pick(WIN32_SEPARATORS);
+    case "drive-relative":
+      return rng.pick(drives) + ":";
+    case "drive":
+      return rng.pick(drives) + ":" + genSeparators(rng, WIN32_SEPARATORS);
+    case "unc":
+      return (
+        rng.string(WIN32_SEPARATORS, 2) +
+        rng.pick(UNC_SERVERS) +
+        genSeparators(rng, WIN32_SEPARATORS) +
+        rng.pick(UNC_SHARES) +
+        (rng.chance(0.7) ? genSeparators(rng, WIN32_SEPARATORS) : "")
+      );
+    case "unc-server-only":
+      return rng.string(WIN32_SEPARATORS, 2) + rng.pick(UNC_SERVERS) + (rng.chance(0.5) ? rng.pick(WIN32_SEPARATORS) : "");
+  }
+}
+
+function genWin32Path(rng: Rng, kinds: readonly Win32Root[] = ANY_ROOT, drives: readonly string[] = DRIVES): string {
+  let s: string;
+  do {
+    s = genWin32Root(rng, rng.pick(kinds), drives) + genBody(rng, WIN32_SEPARATORS);
+    // The words "" and "." after a bare separator spell the `\\.\` device root
+    // (`\\.` alone becomes one once join() appends the next argument).
+  } while (/^[\\/]{2}[.?](?:[\\/]|$)/.test(s));
+  return s;
+}
+
+function genSuffix(rng: Rng, p: string, ns: path.PlatformPath): string {
+  let suffix: string;
+  switch (rng.int(4)) {
+    case 0:
+      suffix = ns.extname(p);
+      break;
+    case 1:
+      suffix = ns.basename(p);
+      break;
+    default:
+      suffix = rng.pick([".js", ".d.ts", "js", ".", "", "x", "日本", "é"]);
+  }
+  // Known divergence, found by this fuzzer; oven-sh/bun#37305 fixes it: node
+  // takes basename()'s suffix branch when the suffix has no more UTF-16 units
+  // than the path, main compares UTF-8 byte lengths, so on a path made only of
+  // separators basename("//", "日本") is "//" in node and "" on main. Skip the
+  // suffixes for which the two length checks disagree; delete this once it lands.
+  if (suffix.length <= p.length && Buffer.byteLength(suffix) > Buffer.byteLength(p)) return ".js";
+  return suffix;
+}
+
+/**
+ * Arguments for relative(): both carry a device (or `/`), and `to` usually
+ * shares the root and some leading words with `from`, joined by separator runs
+ * of its own.
+ */
+function genRelativeArgs(rng: Rng, win32: boolean): [from: string, to: string] {
+  const separators = win32 ? WIN32_SEPARATORS : POSIX_SEPARATORS;
+  const genRoot = win32
+    ? () => genWin32Root(rng, rng.pick(ROOTS_WITH_DEVICE), DRIVES)
+    : () => genSeparators(rng, POSIX_SEPARATORS);
+  const root = genRoot();
+  const words = genWords(rng);
+  const from = root + joinWords(rng, words, separators);
+
+  let toWords: string[];
+  switch (rng.int(4)) {
+    case 0:
+      toWords = words;
+      break;
+    case 1:
+      toWords = genWords(rng);
+      break;
+    case 2:
+      toWords = words.slice(0, rng.int(words.length + 1)).concat(genWords(rng));
+      break;
+    default:
+      toWords = words.concat(genWords(rng));
+  }
+  let to = (rng.chance(0.7) ? root : genRoot()) + joinWords(rng, toWords, separators);
+  // win32.relative compares case-insensitively (ASCII only here, see the header).
+  if (win32 && rng.chance(0.25)) to = to.replace(/[a-z]+/g, m => m.toUpperCase());
+  return [from, to];
+}
+
+const UNARY = ["normalize", "dirname", "basename", "extname", "parse", "isAbsolute", "format(parse())"];
+
+function genCases(rng: Rng, ns: Namespace): Case[] {
+  const cases: Case[] = [];
+  const add = (fn: string, ...args: string[]) => cases.push({ ns, fn, args });
+  const win32 = ns === "win32";
+  const genPath = win32 ? () => genWin32Path(rng) : () => genPosixPath(rng);
+
+  for (const fn of UNARY) add(fn, genPath());
+  const p = genPath();
+  add("basename", p, genSuffix(rng, p, path[ns]));
+
+  const joinArgs: string[] = [];
+  const joinCount = rng.int(5);
+  for (let i = 0; i < joinCount; i++) {
+    if (rng.chance(0.15)) joinArgs.push("");
+    else joinArgs.push(win32 && i > 0 ? genWin32Path(rng, COLON_FREE_ROOTS) : genPath());
+  }
+  add("join", ...joinArgs);
+
+  const resolveArgs = [win32 ? rng.pick(["C:\\base\\dir", "c:/base", "C:\\"]) : rng.pick(["/base/dir", "/", "//base"])];
+  const resolveCount = rng.int(4);
+  for (let i = 0; i < resolveCount; i++) {
+    if (!win32) resolveArgs.push(genPosixPath(rng, rng.chance(0.2)));
+    else if (rng.chance(0.2)) resolveArgs.push(genWin32Path(rng, ["drive-relative"], ["C", "c"]));
+    else resolveArgs.push(genWin32Path(rng, [...COLON_FREE_ROOTS, "drive"]));
+  }
+  add("resolve", ...resolveArgs);
+
+  add("relative", ...genRelativeArgs(rng, win32));
+  add("toNamespacedPath", win32 ? genWin32Path(rng, ROOTS_WITH_DEVICE) : genPath());
+  return cases;
+}
+
+const node = nodeExe();
+// Bun implements the node:path of the Node release it reports, so only that
+// major is a meaningful oracle (the CI images install exactly that release).
+const wantedMajor = process.versions.node.split(".")[0];
+const nodeMajor =
+  node && Bun.spawnSync({ cmd: [node, "-p", "process.versions.node.split('.')[0]"], env: bunEnv }).stdout.toString().trim();
+
+test.skipIf(nodeMajor !== wantedMajor)(`node:path agrees with node ${fuzz.label}`, async () => {
+  const rng = new Rng(fuzz.seed);
+  let compared = 0;
+  for (let start = 0; start < fuzz.iters; start += ITERS_PER_CHILD) {
+    const cases: Case[] = [];
+    const iterationOf: number[] = [];
+    for (let i = start; i < Math.min(start + ITERS_PER_CHILD, fuzz.iters); i++) {
+      for (const ns of ["posix", "win32"] as const) {
+        for (const c of genCases(rng, ns)) {
+          cases.push(c);
+          iterationOf.push(i);
+        }
+      }
+    }
+
+    const bunResults = cases.map(c => evaluate(path[c.ns], c));
+    const { version, results: nodeResults } = await evaluateInNode(node!, cases);
+    expect(nodeResults).toHaveLength(cases.length);
+
+    const mismatches: string[] = [];
+    for (let k = 0; k < cases.length && mismatches.length < 10; k++) {
+      if (bunResults[k] !== nodeResults[k]) {
+        mismatches.push(
+          `${describeCall(cases[k])}\n    bun:  ${bunResults[k]}\n    node: ${nodeResults[k]}\n    ${fuzz.repro(iterationOf[k])}`,
+        );
+      }
+    }
+    if (mismatches.length > 0) {
+      throw new Error(`node:path disagrees with node v${version} (first ${mismatches.length}):\n  ${mismatches.join("\n  ")}`);
+    }
+    compared += cases.length;
+  }
+  console.log(`path-differential-fuzz: ${compared} calls agree with node (${fuzz.iters} iterations)`);
+  expect(compared).toBeGreaterThan(0);
+});

--- a/test/js/node/path/path-differential-fuzz.test.ts
+++ b/test/js/node/path/path-differential-fuzz.test.ts
@@ -10,7 +10,10 @@
 // the cwd or the `=D:` environment variable).
 //
 // Not generated, because node:path on main predates their handling in Node's
-// lib/path.js (oven-sh/bun#37305 brings them in; widen the generator then):
+// lib/path.js. oven-sh/bun#37305 brings them in; the test.failing pin at the
+// bottom of this file starts passing with it, which is the cue to widen the
+// generator to these (#37305's recorded node-path-parity corpus covers them
+// as fixed cases; this file is the soakable, live-node counterpart):
 //   - win32 reserved device names (CON, NUL, COM1, ...) and a `:` anywhere but
 //     in a drive prefix at the start of the path (CVE-2024-36139 `.\` prefixing);
 //   - `\\.\` and `\\?\` device roots;
@@ -195,11 +198,9 @@ function genSuffix(rng: Rng, p: string, ns: typeof path.posix): string {
     default:
       suffix = rng.pick([".js", ".d.ts", "js", ".", "", "x", "日本", "é"]);
   }
-  // Known divergence, found by this fuzzer; oven-sh/bun#37305 fixes it: node
-  // takes basename()'s suffix branch when the suffix has no more UTF-16 units
-  // than the path, main compares UTF-8 byte lengths, so on a path made only of
-  // separators basename("//", "日本") is "//" in node and "" on main. Skip the
-  // suffixes for which the two length checks disagree; delete this once it lands.
+  // Known divergence (pinned below): node takes basename()'s suffix branch when
+  // the suffix has no more UTF-16 units than the path, main compares UTF-8 byte
+  // lengths. Skip the suffixes on which the two length checks disagree.
   if (suffix.length <= p.length && Buffer.byteLength(suffix) > Buffer.byteLength(p)) return ".js";
   return suffix;
 }
@@ -282,44 +283,48 @@ const nodeMajor =
     .stdout.toString()
     .trim();
 
-test.skipIf(nodeMajor !== wantedMajor)(
-  `node:path agrees with node ${fuzz.label}`,
-  async () => {
-    const rng = new Rng(fuzz.seed);
-    let compared = 0;
-    for (let start = 0; start < fuzz.iters; start += ITERS_PER_CHILD) {
-      const cases: Case[] = [];
-      const iterationOf: number[] = [];
-      for (let i = start; i < Math.min(start + ITERS_PER_CHILD, fuzz.iters); i++) {
-        for (const ns of ["posix", "win32"] as const) {
-          for (const c of genCases(rng, ns)) {
-            cases.push(c);
-            iterationOf.push(i);
-          }
+test.skipIf(nodeMajor !== wantedMajor)(`node:path agrees with node ${fuzz.label}`, async () => {
+  const rng = new Rng(fuzz.seed);
+  let compared = 0;
+  for (let start = 0; start < fuzz.iters; start += ITERS_PER_CHILD) {
+    const cases: Case[] = [];
+    const iterationOf: number[] = [];
+    for (let i = start; i < Math.min(start + ITERS_PER_CHILD, fuzz.iters); i++) {
+      for (const ns of ["posix", "win32"] as const) {
+        for (const c of genCases(rng, ns)) {
+          cases.push(c);
+          iterationOf.push(i);
         }
       }
+    }
 
-      const bunResults = cases.map(c => evaluate(path[c.ns], c));
-      const { version, results: nodeResults } = await evaluateInNode(node!, cases);
-      expect(nodeResults).toHaveLength(cases.length);
+    const bunResults = cases.map(c => evaluate(path[c.ns], c));
+    const { version, results: nodeResults } = await evaluateInNode(node!, cases);
+    expect(nodeResults).toHaveLength(cases.length);
 
-      const mismatches: string[] = [];
-      for (let k = 0; k < cases.length && mismatches.length < 10; k++) {
-        if (bunResults[k] !== nodeResults[k]) {
-          mismatches.push(
-            `${describeCall(cases[k])}\n    bun:  ${bunResults[k]}\n    node: ${nodeResults[k]}\n    ${fuzz.repro(iterationOf[k])}`,
-          );
-        }
-      }
-      if (mismatches.length > 0) {
-        throw new Error(
-          `node:path disagrees with node v${version} (first ${mismatches.length}):\n  ${mismatches.join("\n  ")}`,
+    const mismatches: string[] = [];
+    for (let k = 0; k < cases.length && mismatches.length < 10; k++) {
+      if (bunResults[k] !== nodeResults[k]) {
+        mismatches.push(
+          `${describeCall(cases[k])}\n    bun:  ${bunResults[k]}\n    node: ${nodeResults[k]}\n    ${fuzz.repro(iterationOf[k])}`,
         );
       }
-      compared += cases.length;
     }
-    console.log(`path-differential-fuzz: ${compared} calls agree with node (${fuzz.iters} iterations)`);
-    expect(compared).toBeGreaterThan(0);
-  },
-  fuzz.timeout,
-);
+    if (mismatches.length > 0) {
+      throw new Error(
+        `node:path disagrees with node v${version} (first ${mismatches.length}):\n  ${mismatches.join("\n  ")}`,
+      );
+    }
+    compared += cases.length;
+  }
+  console.log(`path-differential-fuzz: ${compared} calls agree with node (${fuzz.iters} iterations)`);
+  expect(compared).toBeGreaterThan(0);
+});
+
+// What genSuffix() steers around; these are node's answers. oven-sh/bun#37305
+// makes this pass: delete it and the length check in genSuffix then, and widen
+// the generator to the classes listed in the header while at it.
+test.failing("known divergence: basename() measures the suffix in UTF-16 units", () => {
+  expect(path.posix.basename("//", "日本")).toBe("//");
+  expect(path.win32.basename("z:/", "日本")).toBe("/");
+});

--- a/test/js/node/path/path-differential-fuzz.test.ts
+++ b/test/js/node/path/path-differential-fuzz.test.ts
@@ -311,4 +311,4 @@ test.skipIf(nodeMajor !== wantedMajor)(`node:path agrees with node ${fuzz.label}
   }
   console.log(`path-differential-fuzz: ${compared} calls agree with node (${fuzz.iters} iterations)`);
   expect(compared).toBeGreaterThan(0);
-});
+}, fuzz.timeout);

--- a/test/js/node/path/path-differential-fuzz.test.ts
+++ b/test/js/node/path/path-differential-fuzz.test.ts
@@ -22,7 +22,7 @@ import { bunEnv, nodeExe } from "harness";
 import path from "node:path";
 
 /** Each iteration is 24 calls (12 per namespace, see genCases). */
-const fuzz = fuzzEnv("BUN_PATH_FUZZ", 0x70617468, 150);
+const fuzz = fuzzEnv("BUN_PATH_FUZZ", 0x70617468, { release: 1000, debug: 100 });
 /** Iterations evaluated by one node child; a soak spawns one child per chunk. */
 const ITERS_PER_CHILD = 1000;
 
@@ -40,7 +40,7 @@ interface Case {
  * embedded through Function#toString, in the node child, so it must only use
  * its parameters and globals.
  */
-function evaluate(ns: path.PlatformPath, c: { fn: string; args: string[] }): string {
+function evaluate(ns: typeof path.posix, c: { fn: string; args: string[] }): string {
   try {
     if (c.fn === "format(parse())") return JSON.stringify(ns.format(ns.parse(c.args[0])));
     return JSON.stringify((ns as any)[c.fn](...c.args));
@@ -167,7 +167,9 @@ function genWin32Root(rng: Rng, kind: Win32Root, drives: readonly string[]): str
         (rng.chance(0.7) ? genSeparators(rng, WIN32_SEPARATORS) : "")
       );
     case "unc-server-only":
-      return rng.string(WIN32_SEPARATORS, 2) + rng.pick(UNC_SERVERS) + (rng.chance(0.5) ? rng.pick(WIN32_SEPARATORS) : "");
+      return (
+        rng.string(WIN32_SEPARATORS, 2) + rng.pick(UNC_SERVERS) + (rng.chance(0.5) ? rng.pick(WIN32_SEPARATORS) : "")
+      );
   }
 }
 
@@ -181,7 +183,7 @@ function genWin32Path(rng: Rng, kinds: readonly Win32Root[] = ANY_ROOT, drives: 
   return s;
 }
 
-function genSuffix(rng: Rng, p: string, ns: path.PlatformPath): string {
+function genSuffix(rng: Rng, p: string, ns: typeof path.posix): string {
   let suffix: string;
   switch (rng.int(4)) {
     case 0:
@@ -275,40 +277,49 @@ const node = nodeExe();
 // major is a meaningful oracle (the CI images install exactly that release).
 const wantedMajor = process.versions.node.split(".")[0];
 const nodeMajor =
-  node && Bun.spawnSync({ cmd: [node, "-p", "process.versions.node.split('.')[0]"], env: bunEnv }).stdout.toString().trim();
+  node &&
+  Bun.spawnSync({ cmd: [node, "-p", "process.versions.node.split('.')[0]"], env: bunEnv })
+    .stdout.toString()
+    .trim();
 
-test.skipIf(nodeMajor !== wantedMajor)(`node:path agrees with node ${fuzz.label}`, async () => {
-  const rng = new Rng(fuzz.seed);
-  let compared = 0;
-  for (let start = 0; start < fuzz.iters; start += ITERS_PER_CHILD) {
-    const cases: Case[] = [];
-    const iterationOf: number[] = [];
-    for (let i = start; i < Math.min(start + ITERS_PER_CHILD, fuzz.iters); i++) {
-      for (const ns of ["posix", "win32"] as const) {
-        for (const c of genCases(rng, ns)) {
-          cases.push(c);
-          iterationOf.push(i);
+test.skipIf(nodeMajor !== wantedMajor)(
+  `node:path agrees with node ${fuzz.label}`,
+  async () => {
+    const rng = new Rng(fuzz.seed);
+    let compared = 0;
+    for (let start = 0; start < fuzz.iters; start += ITERS_PER_CHILD) {
+      const cases: Case[] = [];
+      const iterationOf: number[] = [];
+      for (let i = start; i < Math.min(start + ITERS_PER_CHILD, fuzz.iters); i++) {
+        for (const ns of ["posix", "win32"] as const) {
+          for (const c of genCases(rng, ns)) {
+            cases.push(c);
+            iterationOf.push(i);
+          }
         }
       }
-    }
 
-    const bunResults = cases.map(c => evaluate(path[c.ns], c));
-    const { version, results: nodeResults } = await evaluateInNode(node!, cases);
-    expect(nodeResults).toHaveLength(cases.length);
+      const bunResults = cases.map(c => evaluate(path[c.ns], c));
+      const { version, results: nodeResults } = await evaluateInNode(node!, cases);
+      expect(nodeResults).toHaveLength(cases.length);
 
-    const mismatches: string[] = [];
-    for (let k = 0; k < cases.length && mismatches.length < 10; k++) {
-      if (bunResults[k] !== nodeResults[k]) {
-        mismatches.push(
-          `${describeCall(cases[k])}\n    bun:  ${bunResults[k]}\n    node: ${nodeResults[k]}\n    ${fuzz.repro(iterationOf[k])}`,
+      const mismatches: string[] = [];
+      for (let k = 0; k < cases.length && mismatches.length < 10; k++) {
+        if (bunResults[k] !== nodeResults[k]) {
+          mismatches.push(
+            `${describeCall(cases[k])}\n    bun:  ${bunResults[k]}\n    node: ${nodeResults[k]}\n    ${fuzz.repro(iterationOf[k])}`,
+          );
+        }
+      }
+      if (mismatches.length > 0) {
+        throw new Error(
+          `node:path disagrees with node v${version} (first ${mismatches.length}):\n  ${mismatches.join("\n  ")}`,
         );
       }
+      compared += cases.length;
     }
-    if (mismatches.length > 0) {
-      throw new Error(`node:path disagrees with node v${version} (first ${mismatches.length}):\n  ${mismatches.join("\n  ")}`);
-    }
-    compared += cases.length;
-  }
-  console.log(`path-differential-fuzz: ${compared} calls agree with node (${fuzz.iters} iterations)`);
-  expect(compared).toBeGreaterThan(0);
-}, fuzz.timeout);
+    console.log(`path-differential-fuzz: ${compared} calls agree with node (${fuzz.iters} iterations)`);
+    expect(compared).toBeGreaterThan(0);
+  },
+  fuzz.timeout,
+);

--- a/test/package.json
+++ b/test/package.json
@@ -70,6 +70,7 @@
     "pg": "8.11.1",
     "pg-connection-string": "2.6.1",
     "pg-gateway": "0.3.0-beta.4",
+    "picomatch": "4.0.4",
     "pino": "9.4.0",
     "pino-pretty": "11.2.2",
     "postgres": "3.3.5",


### PR DESCRIPTION
### Problem
- The differential fuzz scripts that found bugs during the Rust rewrite (#30412) never made it into the tree; on main the only seeded oracle CI runs is `test/js/bun/jsonc/json-differential-fuzz.test.ts`.
- `node:path`, `Bun.Glob`, source map generation and the transpiler printer were all rewritten and only have example-based tests.
- Writing the oracles below found five divergences on main straight away (list under Fix).

### Fix
- `test/_util/fuzz.ts`: the seed/iteration plumbing lifted out of the JSON fuzz (`Rng`, `envSeed`, `envIters`, `fuzzEnv`); `json-differential-fuzz.test.ts` imports it, same seed and counts as before.
  - every oracle reads `BUN_<NAME>_FUZZ_SEED` / `BUN_<NAME>_FUZZ_ITERS`; case N is the same however many cases a run asks for, and each failure message prints the two variables that replay it. A soak is the `ITERS` variable plus `--timeout` (documented in the helper); the tests themselves set no timeouts.
  - debug builds get a smaller default count (a debug JSC runs the generators and reference implementations 20-40x slower); release and ASAN lanes run the larger one.
- `test/js/node/path/path-differential-fuzz.test.ts`: random posix and win32 paths (`.`/`..`, repeated, trailing and mixed separators, empty segments, drive letters, UNC roots, non-ASCII) through `normalize`, `join`, `resolve` from fixed absolute bases, `relative`, `dirname`, `basename` with and without suffix, `extname`, `parse`, `format(parse())`, `isAbsolute`, `toNamespacedPath`, compared call for call with `nodeExe()`.
  - one node child per run, cases batched as JSON over stdin/stdout, the evaluator shared through `Function#toString`; skipped when node is missing or not the major Bun reports (CI images install exactly that release; `nodeExeMatchingAbi()` was not used because it may download a node).
  - every input is cwd-independent; the header lists the rules, and the classes left out because main's `node:path` predates their handling in Node (device names, CVE-2024-36139 `.\` prefixing, `\\.\` roots, Unicode folding in `win32.relative`, lone surrogates).
  - relationship to #37305, which rewrites `node:path` and adds a recorded 1540-case node parity corpus: the two are complementary (a fixed corpus that runs without node vs a soakable live oracle), and this file passes unchanged on main and, since it only generates behaviour both implement, after #37305. The pin described below tells #37305 which exclusions to drop.
- `test/js/bun/glob/glob-differential-fuzz.test.ts`: patterns derived from a random path (`*`, `?`, classes and ranges, nested braces, escapes, globstar segments, negation) run through `Bun.Glob#match` and `picomatch` against the path, mutations of it and unrelated paths.
  - `picomatch` 4.0.4 is added to `test/package.json`; it was already in the lockfile as a transitive dependency, and the isolated linker only exposes direct ones. `scan.test.ts`'s snapshot of this directory's listing gains the new file.
  - the header documents each dialect difference the generator stays out of (for instance picomatch lets `a/**/{,b}` match `a`, reads a `**` inside or next to a brace group as slash-crossing where Bun's bash-style expansion does not, and gives `.` followed by `*` inside braces its dotfile guard).
- `test/bundler/sourcemap-differential-fuzz.test.ts`: random multi-module programs with random layout, comments, non-ASCII text and `\r\n`, built with `Bun.build({ sourcemap: "external" })` as esm, iife, cjs and whitespace-minified esm/iife, decoded with `source-map` 0.7.4.
  - every mapping must land inside its original file, a generated position may not map to two originals, `sourcesContent` must be verbatim, and every output identifier that has a mapping must map to that same identifier in the original (identifiers are unique across the run, so the check is exact); a `name`, should Bun start emitting them, must be that identifier.
  - a floor on the number of identifiers checked keeps the test from going vacuous.
- `test/bundler/transpiler/transpiler-differential-fuzz.test.ts`: random programs from a small grammar (declarations, functions with default and rest parameters, arrows, classes, destructuring, loops, `try`, `switch`, literals with holes, spread, getters and computed keys, templates, optional chaining, `??`, every operator), with every compound expression parenthesized in the source so the printer has to decide which parentheses the output needs.
  - plain and whitespace-minified output must parse with acorn 8.15, be a fixed point under a second transform, and push the same values to `__out` as the source when run.
  - programs are strict-mode clean, terminate and never throw, so values are compared rather than exception names.
- Divergences found on main while writing these. Each is handed off separately (fixes are in flight for all of them), excluded in the generator, and pinned with a `test.failing` next to the exclusion; the pin starts passing when the fix lands, and its comment says which exclusion to delete, so the generators cannot stay narrowed silently:
  - `Bun.Glob`: `a**/**` matches `"ab"` although `a*/**` does not (`src/glob/matcher.rs` collapses the `/**` before checking that the `**` is a globstar).
  - `Bun.Glob`: `**/a**/{x,y}` matches `"ab/ay"` (same family, different path through the matcher). One pin for both, since the gating can only go once both are fixed.
  - `Bun.build`: with several entrypoints `BuildArtifact.sourcemap` points at the wrong artifact; outputs are `[js0, js1, map0, map1]` but `js_bundle_completion_task.rs` attaches the next output. The oracle pairs maps by path until the pin flips, then should read `js.sourcemap`.
  - transpiler: `"a" != Infinity` prints as `"a" != 1 / 0`, which reprints as `1 / 0 != "a"` (`print_number` plus the constants-on-the-right reordering).
  - transpiler: unused `(a, b) ? f() : 0;` prints as `a, b && f();` and only the next pass drops the `a,` (`simplify_unused_expr`). The two transpiler pins run the excluded programs through the oracle's own `check()`.
  - `node:path`: `basename("//", "日本")` is `"//"` in node and `""` on main (suffix length compared in UTF-8 bytes rather than UTF-16 units); #37305 fixes it, and its pin is the cue to widen the whole generator.
- Additive change: no src edit, so there is no fail-before for the oracles themselves; the pins are the fail-before evidence (each asserts node's / picomatch's / the fixed-point answer and currently fails for exactly the reason listed above).
- Verification: `bun bd test differential-fuzz` runs the five files (15 tests) in about 17 s on this debug+ASAN build, each oracle body 1-3 s; with the release binary the set takes under 2 s. The new files typecheck under `test/tsconfig.json`. CI build for the previous revision was green on every lane for these files.
- Soaks with the release binary after the exclusions, all clean: glob 30 seeds x 20k patterns (1.8M matches); path 20 seeds x 20k iterations (9.6M calls); source maps 20k + 12k programs (about 2.4M mappings, 1M identifiers checked); transpiler 2 x 20k plus 12 runs of 3k-5k programs.

### Background
- A differential oracle generates inputs from a seeded PRNG, runs them through the code under test and through an independent reference, and compares exactly. The references here are node itself, picomatch, the Mozilla `source-map` decoder together with the text the generator wrote, and acorn plus JavaScriptCore running the program. The seed makes any failure reproducible, and the same test doubles as a soak by raising the count.
- Fixed point: transpiling the transpiler's own output must reproduce it byte for byte. Both transpiler divergences are violations of this; harmless to users, but exactly the kind of printer/visitor disagreement that hides real bugs, so the property is asserted.
- `test.failing` (docs/test/writing-tests.mdx) inverts a test: it passes while the body throws and fails once the body passes. It is the repo's way of tracking a known bug so that the fix is noticed; here each pin doubles as the instruction for widening the generator.
- Where two dialects legitimately differ (picomatch's regex semantics vs Bun's bash-like braces, Node versions), the generator does not produce that class of input. The comparison itself is always exact, so nothing can absorb a divergence silently; each exclusion is commented where it is applied.
