### PR TITLE
node:tls: let connect() re-dial a TLSSocket whose connection is still open

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -50,7 +50,7 @@ const ArrayPrototypePush = Array.prototype.push;
 const MathMax = Math.max;
 const MathMin = Math.min;
 
-const { UV_ECANCELED, UV_ENOBUFS, UV_ETIMEDOUT } = process.binding("uv");
+const { UV_ECANCELED, UV_EISCONN, UV_ENOBUFS, UV_ETIMEDOUT } = process.binding("uv");
 const isWindows = process.platform === "win32";
 
 const getDefaultAutoSelectFamily = $rust("node_net_binding.rs", "getDefaultAutoSelectFamily");
@@ -1952,6 +1952,18 @@ Socket.prototype.connect = function connect(...args) {
     const bunTLS = this[bunTlsSymbol];
     var tls: any | undefined = undefined;
     if (typeof bunTLS === "function") {
+      // Only a connection this socket dialed itself can be re-dialed (the
+      // handle-reuse path below, shared with net.Socket). A TLS session that
+      // runs over a transport the caller handed in (tls.connect({ socket }),
+      // new TLSSocket(stream)) has nothing of its own to reconnect, so report
+      // it the way node reports connect() on a connected socket.
+      if (!socket && this[kupgraded] && this._handle && !this.destroyed) {
+        const ex = path
+          ? new ExceptionWithHostPort(UV_EISCONN, "connect", path)
+          : new ExceptionWithHostPort(UV_EISCONN, "connect", host || "localhost", port);
+        process.nextTick(destroyNT, this, ex);
+        return this;
+      }
       tls = bunTLS.$call(this, port, host, true);
       // Client always request Cert
       this._requestCert = true;

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -1117,8 +1117,12 @@ TLSSocket.prototype[buntls] = function (port, host) {
   if (servername === undefined) {
     servername = host && !net.isIP(host) ? host : "";
   }
+  // `new TLSSocket(stream)` parks the stream in _handle until connect() wraps
+  // it. Once connected, _handle is the native handle of the current
+  // connection: connect() re-dials that one, it is not a stream to wrap.
+  const handle = this._handle;
   return {
-    socket: this._handle,
+    socket: handle instanceof Duplex ? handle : undefined,
     ALPNProtocols: this.ALPNProtocols,
     checkServerIdentity: this[kcheckServerIdentity],
     session: this[ksession],

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -796,6 +796,156 @@ it("a write from inside 'data' does not re-enter 'data' on a TLSSocket over a du
   }).toEqual({ nestedDataEvents: 0, payloadIntact: true, tail: "got reply" });
 });
 
+describe("connect() on a TLSSocket whose previous connection is still open", () => {
+  // A socket from tls.connect(port) re-dials like a net.Socket does
+  // (test/js/node/net/socket-reconnect-live.test.ts): the old connection is
+  // dropped and the new one handshakes on the same object. TLSSocket used to
+  // hand its own native handle back to connect() as if it were a stream to
+  // wrap, which failed the net.Socket/Duplex check with a TypeError.
+
+  // Every accepted socket greets with the server's name and echoes what it reads
+  // prefixed with that name, so the client can tell which server it talks to.
+  async function listen(name: string, options: tls.TlsOptions = {}) {
+    const accepted: tls.TLSSocket[] = [];
+    const server = tls.createServer({ ...COMMON_CERT_, ...options }, socket => {
+      accepted.push(socket);
+      // The connection a re-dial abandons is reset, not ended.
+      socket.on("error", () => {});
+      socket.on("data", data => socket.write(`${name}:${data}`));
+      socket.write(name);
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    return {
+      server,
+      accepted,
+      port: (server.address() as AddressInfo).port,
+      async [Symbol.asyncDispose]() {
+        for (const socket of accepted) socket.destroy();
+        server.close();
+        await once(server, "close");
+      },
+    };
+  }
+
+  it("tls.connect(port) socket: re-dials with the new arguments", async () => {
+    await using a = await listen("a");
+    await using b = await listen("b");
+    const client = tls.connect({ port: a.port, host: "127.0.0.1", rejectUnauthorized: false });
+    try {
+      const [, [greetingA]] = await Promise.all([once(client, "secureConnect"), once(client, "data")]);
+
+      const connectedToB = Promise.all([once(client, "secureConnect"), once(client, "data")]);
+      let listenerCalled = false;
+      const returned = client.connect(b.port, "127.0.0.1", () => (listenerCalled = true));
+      const [, [greetingB]] = await connectedToB;
+
+      const reply = once(client, "data");
+      client.write("ping");
+      const [echo] = await reply;
+
+      expect({
+        returned: returned === client,
+        greetingA: String(greetingA),
+        greetingB: String(greetingB),
+        echo: String(echo),
+        listenerCalled,
+        accepted: [a.accepted.length, b.accepted.length],
+      }).toEqual({
+        returned: true,
+        greetingA: "a",
+        greetingB: "b",
+        echo: "b:ping",
+        listenerCalled: true,
+        accepted: [1, 1],
+      });
+    } finally {
+      client.destroy();
+    }
+  });
+
+  it("tls.connect(port) socket: re-dials after end(), while the old connection is still half-open", async () => {
+    // allowHalfOpen keeps the server from answering the client's FIN, so the
+    // socket still holds its first connection when it reconnects.
+    await using a = await listen("a", { allowHalfOpen: true });
+    const client = tls.connect({ port: a.port, host: "127.0.0.1", rejectUnauthorized: false });
+    try {
+      const [, [firstGreeting]] = await Promise.all([once(client, "secureConnect"), once(client, "data")]);
+
+      const reconnected = Promise.all([once(client, "secureConnect"), once(client, "data")]);
+      // 'finish' is the moment end()'s callback runs: the FIN is out, nothing
+      // has come back yet.
+      client.end();
+      await once(client, "finish");
+      client.connect(a.port, "127.0.0.1");
+      const [, [secondGreeting]] = await reconnected;
+
+      expect({
+        greetings: [String(firstGreeting), String(secondGreeting)],
+        accepted: a.accepted.length,
+      }).toEqual({ greetings: ["a", "a"], accepted: 2 });
+    } finally {
+      client.destroy();
+    }
+  });
+
+  // A TLS session running over a transport the caller handed in has no
+  // connection of its own to re-dial. Node reports connect() on a socket that is
+  // already connected as an asynchronous EISCONN that destroys the socket.
+  const wrapped: [name: string, wrap: (raw: net.Socket, port: number) => tls.TLSSocket][] = [
+    ["tls.connect({ socket: net.Socket })", raw => tls.connect({ socket: raw, rejectUnauthorized: false })],
+    [
+      "tls.connect({ socket: Duplex })",
+      raw => tls.connect({ socket: new SocketProxy(raw), rejectUnauthorized: false }),
+    ],
+    [
+      "new TLSSocket(net.Socket).connect(port)",
+      (raw, port) => new TLSSocket(raw, { rejectUnauthorized: false }).connect(port, "127.0.0.1"),
+    ],
+  ];
+  for (const [name, wrap] of wrapped) {
+    it(`${name}: reports EISCONN instead of re-dialing`, async () => {
+      await using a = await listen("a");
+      const raw = net.connect(a.port, "127.0.0.1");
+      raw.on("error", () => {});
+      await once(raw, "connect");
+      const serverSide = once(a.server, "secureConnection");
+      const client = wrap(raw, a.port);
+      try {
+        await Promise.all([once(client, "secureConnect"), serverSide]);
+
+        const errored = once(client, "error");
+        const closed = new Promise<boolean>(resolve => client.once("close", resolve));
+        const returned = client.connect(a.port, "127.0.0.1");
+        const [error] = await errored;
+        const hadError = await closed;
+
+        expect({
+          returned: returned === client,
+          message: error.message,
+          code: error.code,
+          syscall: error.syscall,
+          address: error.address,
+          port: error.port,
+          hadError,
+          accepted: a.accepted.length,
+        }).toEqual({
+          returned: true,
+          message: `connect EISCONN 127.0.0.1:${a.port}`,
+          code: "EISCONN",
+          syscall: "connect",
+          address: "127.0.0.1",
+          port: a.port,
+          hadError: true,
+          accepted: 1,
+        });
+      } finally {
+        client.destroy();
+        raw.destroy();
+      }
+    });
+  }
+});
+
 it("a client and a server TLSSocket connected through a synchronous in-memory duplex pair talk to each other", async () => {
   // Each side's _write pushes straight into the other side, so every reply,
   // including the server's handshake flight, is fed to the engine from inside


### PR DESCRIPTION
### Problem
- `socket.connect(port, host)` on a socket returned by `tls.connect()` throws synchronously while the previous connection is still open (still connected, or half-closed after `end()`):
  `TypeError: socket must be an instance of net.Socket or Duplex` (src/js/node/net.ts:1982 on main). Once the socket has been destroyed the same call reconnects fine, and a plain `net.Socket` re-dials in this situation (#32739).
- Cause: `TLSSocket.prototype[buntls]` returns `socket: this._handle` (src/js/node/tls.ts:1121) so that `new TLSSocket(stream).connect()` can wrap the stream the constructor parked in `_handle`. After a connect, `_handle` is the native handle of the current connection; `Socket.prototype.connect` takes it as the stream to wrap (net.ts:1969) and the `net.Socket`/`Duplex` check rejects it.
- The same TypeError came out of `connect()` on a TLSSocket built over a caller-supplied stream (`tls.connect({ socket: duplex })`, `new TLSSocket(netSocket).connect(port)`); `tls.connect({ socket: netSocket })` instead emitted a bare `Error: Invalid socket` from trying to adopt the same net.Socket a second time.

### Fix
- tls.ts: `[buntls]` only forwards `_handle` as the stream to wrap when it is a `Duplex`. Everything the wrap path accepts is a Duplex (net.Socket included), so `new TLSSocket(stream).connect()` is unchanged; a native handle is simply not offered any more.
- A `tls.connect(port)` socket therefore falls through to the handle-reuse path `net.Socket` already uses (net.ts:2135, `doConnect(this._handle, ...)`): the native side closes the previous connection (`detach_for_reconnect`, src/runtime/socket/socket_body.rs:1299) and dials again on the same wrapper, and `connect()` has already reset the handshake state (net.ts:1986), so the socket emits `secureConnect` (and runs the connect listener) for the new connection. This is the same code that serves TCP since #32739 and that TLS reconnect-after-destroy already goes through; only the misrouting in front of it was TLS specific.
- net.ts: a TLSSocket whose current connection was built over a caller-supplied transport (`this[kupgraded]` set and the handle still live) that is asked to `connect()` without a new `socket` option is destroyed on the next tick with `ExceptionWithHostPort(UV_EISCONN, "connect", host, port)` instead of falling through.
  - The reuse path can only replace a connection the socket dialed itself: for a stream-engine handle `detach_for_reconnect` returns without detaching (no ext slot), which trips `connect_finish`'s `debug_assert!(prev.socket.get().is_detached())` (src/runtime/socket/Listener.rs:1557) and in release would alias two connections onto one wrapper; for an adopted-fd pair it would close the TLS half without the raw twin ever seeing the close (socket_body.rs:2064). Before this PR those sockets never reached that code because of the TypeError; without the guard they would.
  - There is also nothing to re-dial: the transport belongs to the caller. EISCONN is what node emits for `connect()` on a socket that is already connected (async `'error'` with `code: "EISCONN"`, `syscall: "connect"`, then `'close'` with `hadError`), and the object is built the way `internalConnect` builds its connect errors (net.ts:3161), so the three constructions now fail the same way. An explicit `connect({ socket })` on such a socket keeps its current behavior.
- `end()` then reconnect: the reconnect itself works with this PR (`secureConnect`, data from the new connection is readable); the first write on it still fails with `ERR_STREAM_WRITE_AFTER_END` because the writable side was finished. That reset is #38980's (net-level) change; with its net.ts hunk applied on top of this branch the write goes through as well.
- Tests: test/js/node/tls/node-tls-connect.test.ts, `describe("connect() on a TLSSocket whose previous connection is still open")`: re-dial to a second server with the new arguments (greeting from the second server, echo over the new connection, connect listener), re-dial after `end()` against an `allowHalfOpen` server, and EISCONN for `tls.connect({ socket: net.Socket })`, `tls.connect({ socket: Duplex })` and `new TLSSocket(net.Socket).connect(port)`. Without the src change four of them throw the TypeError above and the net.Socket one gets `Invalid socket`; with it all five pass.
- Also run with the change: the rest of node-tls-connect.test.ts (42 pass, 18 skipped network tests); node-tls-upgrade, node-tls-server, node-tls-socket-allow-half-open-option, tls-connect-socket-churn, node-tls-duplex-close-throw-uaf, node-tls-internals, node-tls-context; net socket-reconnect-live, net-mongodb-pattern-leak, double-connect, node-net (its failures here are the localhost/`::1` environment ones and fail identically without this change); and 51 ported node tests (test-tls-connect-*, test-tls-socket-*, test-tls-wrap-econnreset-*, test-tls-starttls-server, test-tls-delayed-attach*, test-https-agent-*, ...), all passing.

### Background
- `[buntls]` (`Symbol.for("::buntls::")`) is the method net.ts's shared `Socket.prototype.connect` calls on a TLSSocket to get the TLS options for an attempt. Its `socket` field is a private channel meaning "run the handshake over this stream instead of dialing"; it exists for `new TLSSocket(stream)`, whose constructor stores the stream in `_handle` until `connect()` wraps it.
- `_handle` is otherwise the native socket wrapper the JS socket owns. `doConnect(handle, opts)` passes it as the previous socket: `connect_finish` closes whatever connection it still holds and connects the same wrapper again. So in bun `connect()` on a live socket replaces the connection, where node re-runs `uv_tcp_connect` on the existing fd and gets EISCONN (on Linux the first retry reports a spurious `'connect'` instead, see details).
- Wrapping a caller's transport produces one of two handle kinds: the TLS half of an adopted-fd pair (`upgradeTLS`; the raw half stays attached to the caller's net.Socket as the TLS half's twin), or a stream-engine handle (`upgradeDuplexToTLS`) that moves bytes through the Duplex. Every such path stores the transport in `kupgraded`, which net.ts already consults in `open()`, `pause()` and `_destroy` to treat these sockets differently.

<details>
<summary>Node v26.3.0 behavior, related open PRs, and observations left as is</summary>

Node, same scripts:
- `tls.connect(port)` socket, `connect()` after `end()`: `'error'` `connect EISCONN 127.0.0.1:port - Local (...)`, then `'close'` with `hadError = true`.
- `connect()` while fully open: on Linux the kernel reports the completion of the earlier non-blocking connect once more, so node emits a second `'connect'` on the same connection (same local port, the server sees one connection); a further `connect()` gets EISCONN. No new connection in either case.
- `tls.connect({ socket: netSocket })` then `connect()`: `ERR_INTERNAL_ASSERTION` in `afterConnect` (Linux quirk above). `tls.connect({ socket: duplex })` then `connect()`: nothing happens, the socket stays `connecting`.

Related open PRs:
- #37664 (constructor wraps upgrade in the constructor) deletes the `socket:` line this PR changes; whichever lands second has a one-line conflict. It does not cover reconnects, and with `tls.socket` gone it would route the transport-backed cases into the reuse path, which is what the net.ts guard here prevents. If it lands first, the `new TLSSocket(net.Socket).connect(port)` case in the new tests becomes a reconnect of an already-wrapped socket (no `secureConnect` for a standalone wrap) and needs to be rewritten in those terms.
- #38980 resets the stream state on reuse (the write-after-`end()` half, see above). #32812 adds EALREADY in `kConnectDispatch`; with this PR a TLS socket reconnected mid-connect reaches that check too. No hunk overlap with either.
- #38007 makes each `connect()` register `onConnectEnd` once. Today every connect registers it twice and the handshake removes one, so a socket re-dialed in a loop keeps one extra inert `'end'` listener per connect and hits `MaxListenersExceededWarning` on the 10th re-dial (pre-existing; before this PR the re-dial threw instead). With #38007's net.ts change applied on top of this branch the loop holds exactly one copy at each `secureConnect` and no warning; it applies without touching this PR's hunks and the tests here still pass, so that fix stays in #38007.

Left as is:
- A server-accepted TLSSocket can now be `connect()`ed as a client (it takes the reuse path), which is what a server-accepted `net.Socket` already does.
- `tls.connect({ socket })` socket destroyed and then `connect(port)`: unchanged, it re-enters the wrap path for the dead transport and never connects (node makes a plain TCP connection there). Not reachable through anything this PR changes.
</details>
