### PR TITLE
glob: treat a `**` that ends a brace branch as a globstar in match()

### DIFF
--- a/src/glob/matcher.rs
+++ b/src/glob/matcher.rs
@@ -133,7 +133,9 @@ struct Wildcard {
 /// "**"
 ///     Matches zero or more characters, including path separators.
 ///     Must match a complete path segment, i.e. followed by a path separator or
-///     at the end of the pattern.
+///     at the end of the pattern. A "**" that ends a brace branch qualifies when
+///     the brace group itself is followed by a separator or ends the pattern, so
+///     "a/{**,b}/c" means "a/**/c" or "a/b/c".
 /// "[ab]"
 ///     Matches one of the characters contained in the brackets.
 ///     Character ranges (e.g. "[a-z]") are also supported.
@@ -220,14 +222,15 @@ fn glob_match_impl(
                             if is_globstar {
                                 state.glob_index += 2;
 
-                                let is_end_invalid = (state.glob_index as usize) < glob.len();
+                                let rest = globstar_continuation(state, glob, brace_stack);
+                                let is_end_invalid = (rest.glob_index as usize) < glob.len();
 
                                 // FIXME: explain this bug fix
                                 if is_end_invalid
                                     && state.path_index as usize == path.len()
-                                    && glob.len() - state.glob_index as usize == 2
-                                    && is_separator(glob[state.glob_index as usize])
-                                    && glob[state.glob_index as usize + 1] == b'*'
+                                    && glob.len() - rest.glob_index as usize == 2
+                                    && is_separator(glob[rest.glob_index as usize])
+                                    && glob[rest.glob_index as usize + 1] == b'*'
                                 {
                                     continue 'main_loop;
                                 }
@@ -237,8 +240,10 @@ fn glob_match_impl(
                                 // if we start at index 6 (start of **/b pattern), we don't want to index into the pattern before it
                                 if (state.glob_index.saturating_sub(glob_start) < 3
                                     || glob[state.glob_index as usize - 3] == b'/')
-                                    && (!is_end_invalid || glob[state.glob_index as usize] == b'/')
+                                    && (!is_end_invalid || glob[rest.glob_index as usize] == b'/')
                                 {
+                                    state.glob_index = rest.glob_index;
+                                    state.brace_depth = rest.brace_depth;
                                     if is_end_invalid {
                                         state.glob_index += 1;
                                     }
@@ -569,6 +574,22 @@ fn skip_branch(state: &mut State, glob: &[u8], brace_stack: &BraceStack) -> bool
         }
     }
     false
+}
+
+/// `state` has just stepped over a `**`; returns a copy of it moved to where the
+/// pattern continues. When the `**` ends a brace branch, that is after the group's
+/// `}` (and after the `}` of every enclosing group the `**` also ends), i.e. where
+/// [`skip_branch`] would resume matching. Deciding "is this `**` a whole segment"
+/// there gives `a/{**,b}/c` the meaning of its expansion `a/**/c`; decided at the
+/// `,` itself, the `**` would be demoted to a plain `*`.
+#[inline(always)]
+fn globstar_continuation(state: &State, glob: &[u8], brace_stack: &BraceStack) -> State {
+    let mut rest = *state;
+    while rest.brace_depth > 0
+        && matches!(glob.get(rest.glob_index as usize), Some(b',' | b'}'))
+        && skip_branch(&mut rest, glob, brace_stack)
+    {}
+    rest
 }
 
 /// Index of the `}` matching the `{` at `open_idx`, or `glob.len()` if unterminated.

--- a/test/js/bun/glob/match.test.ts
+++ b/test/js/bun/glob/match.test.ts
@@ -413,6 +413,75 @@ describe("Glob.match", () => {
     expect(new Glob("{a,b},x").match("b,x")).toBeTrue();
   });
 
+  test("`**` that ends a brace branch is a globstar", () => {
+    // A brace group matches one of its branches, so each pattern below must
+    // match exactly what the brace-free patterns in its comment match. The `**`
+    // used to be demoted to a single-segment `*` whenever the byte after it was
+    // the `,` or `}` of the group instead of `/` or the end of the pattern.
+    const cases: [pattern: string, matches: string[], rejects: string[]][] = [
+      // a/** | a/b
+      ["a/{**,b}", ["a/x", "a/x/y", "a/x/y/z", "a/b", "a/b/c", "a/"], ["a", "ab", "c/x/y"]],
+      // a/b | a/**  (branch closed by `}` rather than `,`)
+      ["a/{b,**}", ["a/b", "a/x/y"], ["a", "b/x"]],
+      // a/** | a/   (empty branch)
+      ["a/{**,}", ["a/x/y", "a/"], ["a"]],
+      ["a/{,**}", ["a/x/y", "a/"], ["a"]],
+      // a/** | b    (the `**` follows a `/` inside the branch)
+      ["{a/**,b}", ["a/", "a/x", "a/x/y", "b"], ["a", "b/x", "c/x"]],
+      // ** | b      (the group is the whole pattern)
+      ["{**,b}", ["x", "x/", "x/y/z", "b"], []],
+      // a/**/c | a/b/c
+      ["a/{**,b}/c", ["a/c", "a/x/c", "a/x/y/c", "a/b/c", "a/b/x/c"], ["a/x/y/d", "a/x/y/c/d", "a/bc", "c"]],
+      // test/foo/**/baz | test/bar/baz
+      ["test/{foo/**,bar}/baz", ["test/foo/baz", "test/foo/x/y/baz", "test/bar/baz"], ["test/bar/x/baz", "test/baz"]],
+      // **/c | b/c
+      ["{**,b}/c", ["c", "x/c", "x/y/c", "b/x/c"], ["x/y/d", "cc"]],
+      // a/**/c | a/**/d | a/b/c | a/b/d  (a later group backtracks into the globstar)
+      ["a/{**,b}/{c,d}", ["a/c", "a/d", "a/x/y/c", "a/x/y/d", "a/b/x/d"], ["a/x/y/e", "a/x/y", "a/cd"]],
+      // a/**/* | a/b/*  (the trailing `/*` still needs a non-empty final segment)
+      ["a/{**,b}/*", ["a/x", "a/x/y", "a/b/z"], ["a/x/", "a/", "a"]],
+      // src/**/*.ts | src/lib/*.ts
+      ["src/{**,lib}/*.ts", ["src/a.ts", "src/x/a.ts", "src/x/y/a.ts", "src/lib/a.ts"], ["src/x/y/a.js", "lib/a.ts"]],
+      // x/**/y/** | x/**/y/c | x/b/y/** | x/b/y/c  (two such groups in one pattern)
+      ["x/{**,b}/y/{**,c}", ["x/1/2/y/3/4", "x/y/", "x/y/3", "x/b/y/c", "x/1/y/c/2"], ["x/y", "x/1/z/3"]],
+      // **/**/b | **/a/b  (a globstar before the group)
+      ["**/{**,a}/b", ["b", "x/b", "x/y/b", "x/a/b"], ["x/y/c", "bb"]],
+      // a/c | a/** | a/d  (nested: the `**` ends the inner branch and the outer one)
+      ["a/{c,{**,d}}", ["a/c", "a/d", "a/x/y", "a/"], ["a", "b/x"]],
+      // a/c/e | a/**/e | a/d/e
+      ["a/{c,{**,d}}/e", ["a/e", "a/c/e", "a/x/y/e", "a/c/x/e"], ["a/x/y/f", "a/x/y"]],
+      // a/**/d | a/c/d | a/b/d
+      ["a/{{**,c},b}/d", ["a/d", "a/x/y/d", "a/b/x/d"], ["a/x/y", "a/x/y/e"]],
+      // !(a/** | a/b)
+      ["!a/{**,b}", ["a", "c/x/y"], ["a/x/y", "a/b"]],
+
+      // The group continues with something other than `/`: `a/**x` is not a
+      // whole segment, so the `**` stays a single-segment `*` there.
+      // a/**x | a/bx
+      ["a/{**,b}x", ["a/yx", "a/bx", "a/x"], ["a/y/zx"]],
+      // a/c | a/**x | a/dx  (the inner group closes but the outer branch continues)
+      ["a/{c,{**,d}x}", ["a/c", "a/yx", "a/dx"], ["a/y/zx"]],
+      // a/**c | a/**d | a/bc | a/bd
+      ["a/{**,b}{c,d}", ["a/c", "a/yd", "a/bc"], ["a/x/yc"]],
+      // A `**` that does not start the segment is a `*` no matter what follows it.
+      // a/x** | a/b
+      ["a/{x**,b}", ["a/xy", "a/b"], ["a/x/y"]],
+      // A `,` or `}` outside any brace group is a literal, not the end of a branch.
+      ["**,x", ["a,x"], ["a/b,x"]],
+      ["{a,b}/**,x", ["a/c,x", "b/,x"], ["a/c/d,x", "a/c"]],
+    ];
+
+    for (const [pattern, matches, rejects] of cases) {
+      const glob = new Glob(pattern);
+      for (const path of matches) {
+        expect(glob.match(path), `${JSON.stringify(pattern)} should match ${JSON.stringify(path)}`).toBeTrue();
+      }
+      for (const path of rejects) {
+        expect(glob.match(path), `${JSON.stringify(pattern)} should not match ${JSON.stringify(path)}`).toBeFalse();
+      }
+    }
+  });
+
   // Most of the potential bugs when dealing with non-ASCII patterns is when the
   // pattern matching algorithm wants to deal with single chars, for example
   // using the `[...]` syntax, it tries to match each char in the brackets. With


### PR DESCRIPTION
### Problem

- A `**` that is the last thing in a brace branch behaves like a single-segment `*` in `Glob.match()` (and in the other users of `bun_glob::match`: `bun test` path filters, `--filter` workspace globs, bundler `allowUnresolved` patterns):
  ```js
  new Bun.Glob("a/{**,b}").match("a/x")                           // true
  new Bun.Glob("a/{**,b}").match("a/x/y")                         // false, expected true
  new Bun.Glob("src/{**,lib}/*.ts").match("src/x/y/a.ts")         // false, expected true
  new Bun.Glob("test/{foo/**,bar}/baz").match("test/foo/x/y/baz") // false, expected true
  new Bun.Glob("{**/x,y}").match("a/b/x")                         // true (control: `**` followed by `/` inside a branch works)
  ```
- Cause: the `*` arm of `glob_match_impl` (`src/glob/matcher.rs:240` on main) promotes `**` to a globstar only when the byte right after it is `/` or the end of the whole pattern. When the `**` ends a branch that byte is the group's `,` or `}`, so it takes the plain `*` path even though, per the rule documented on `match` and per what brace expansion of the pattern gives (`a/**` or `a/b`), it is a whole segment.

### Fix

- Before deciding, compute where the pattern continues after the `**` (`globstar_continuation`): while the next byte is the `,`/`}` of a group we are inside, step past that group's `}` with the existing `skip_branch`, i.e. land exactly where matching would resume anyway. The `/` / end-of-pattern test, the existing trailing-`/*` special case, and the globstar bookkeeping (`skip_to_separator`) are then all applied at that position, and matching continues from there.
- Why this is correct: a brace group means "one of these branches", so `a/{**,b}/c` has to match the union of `a/**/c` and `a/b/c`. For the `**` branch the text that follows the `**` in the expansion is whatever follows the group, which is the position this change looks at. Using `skip_branch` for the lookahead means the decision agrees with how the `,`/`}` would have been consumed one iteration later (literal `,`/`}` outside a group, unterminated groups, nested and sequential groups all behave as they do today); the only new behaviour is that the `**` keeps globstar semantics when that position is `/` or the end of the pattern. Backtracking is unchanged: the saved wildcard still points at the `**` with the inside-the-branch `brace_depth`, so re-entering it exits the group again the same way.
- Unchanged on purpose: a group followed by anything else (`a/{**,b}x` is `a/**x`, not a whole segment) still demotes the `**` to `*`; patterns without braces never enter the new loop (`brace_depth` is 0), so they are byte-for-byte the same decision as before. `scan()` is unaffected as well: it matches per path component, so a component like `{**,b}` never spans a `/` (#32599 is what makes `scan()` expand such groups; this change is what makes `match()` agree with it).
- Tests: new `` `**` that ends a brace branch is a globstar `` block in `test/js/bun/glob/match.test.ts`, a table of 24 patterns / 125 assertions each annotated with the brace-free patterns it must be equivalent to: trailing and non-trailing groups, the `**` in the first / last / an empty branch, nested groups (`a/{c,{**,d}}/e`), a following group that backtracks into the globstar (`a/{**,b}/{c,d}`), two such groups in one pattern, a `**` before the group, negation, plus the boundaries that must stay as they are (`a/{**,b}x`, `a/{x**,b}`, literal `,` outside a group, `a/{**,b}/*` vs `a/x/`). Every expectation was cross-checked against the union of the pattern's brace expansions evaluated by the released bun. 18 of the 24 rows fail on bun 1.4.0 (the test also fails on a debug build of main), all pass with this change.
- Other runs: `test/js/bun/glob/{match,scan,stress,proto,path-length}.test.ts` pass with the debug build (the only failures seen were the fixture `braces` test and the `scan` tests that walk `test/node_modules`, which time out identically on an unmodified debug build on this loaded box; `braces` has been reported separately). Interleaved A/B of the fixture workload (13 patterns x 7895 paths) on debug builds with and without the change: 3832 ms vs 3872 ms best-of-6, i.e. noise; with no brace group open the helper stops at its `brace_depth` check.
- Related, not overlapping: #39004 and #38996 both change the other half of the whole-segment rule (what may precede the `**`) in the same arm and leave the `/`-or-end lookahead as is, so this is independent of both; whichever lands later needs a mechanical rebase of this hunk.

### Background

- Matcher structure: `glob_match_impl` walks pattern and path together. On `{` it calls `match_brace`, which tries each branch by recursing into `glob_match_impl` at the branch's start with a `Brace` frame (open index, branch index, close index) pushed on `brace_stack`; when a branch's text is exhausted the `,`/`}` arm calls `skip_branch`, which jumps past the enclosing group's `}` and decrements `brace_depth`, so the rest of the pattern after the group is matched by the same recursive call.
- Globstar bookkeeping: for a globstar the arm records a backtrack point (`wildcard`, pointing at the `**`) and calls `skip_to_separator`, which makes each later backtrack hand one more path segment to the `**`. `is_end_invalid` is the existing name for "there is more pattern after this `**`": it selects between the `**/rest` form (skip the `/`, keep matching `rest`) and the trailing-`**` form (only a fully consumed path is a match). With this change both forms are driven by the position after the group rather than the byte after the `**`.
- The `glob.len() - idx == 2 && "/*"` block above the promotion is a pre-existing special case that keeps `**/*` from matching a path whose last segment is empty (`""`, `"x/"`); it is moved to the same position so `{**,b}/*` behaves like `**/*` for those paths (covered by the `a/{**,b}/*` row).

<details>
<summary>Differential check against brace expansion (not part of the PR)</summary>

Generated 39,412 distinct (braced pattern, path) pairs from the alphabet `a b c * ** a* *b ? / { , }` with up to three levels of nesting and compared `match()` of the braced pattern with the union of `match()` over its brace-free expansions on the same binary (expansions contain no braces, so they are unaffected by this change).

- Patterns whose groups are whole path segments (`{` preceded by `/`, `,`, `{` or the pattern start; `}` followed by `/`, `,`, `}` or the end): 1043 disagreements on the released build, 33 with this change. The remaining 33 are all instances of the pre-existing `**/*`-vs-empty-last-segment special case applied inside a group (`**/{*,x}` against `""`), which disagree the same way on the released build.
- Disagreements that do not involve a `**` directly before `,`/`}` are the same 297 before and after (byte-identical list), i.e. nothing outside the targeted construct changed.
- Groups glued to other text (`a{**,b}`, `{a,b}{**,c}`): the `**` opens a brace branch and is therefore treated as segment-initial by the existing (and, in #39004/#38996, retained) rule, so with this change it is a globstar there too. That matches how bun already treats `a{**/y,b}` and how picomatch compiles `a{**,b}`; textual expansion (`a**`) would say otherwise. Not asserted either way in the tests.
</details>
