### PR TITLE
bun test: exit through the VM teardown path when --bail stops a run

### DIFF
--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -309,10 +309,10 @@ fn build_worker_argv(ctx: &Command::ContextData) -> crate::Result<Box<[bun_spawn
     if let Some(seed) = opts.seed {
         argv.push(print_z(format_args!("--seed={}", seed))?);
     }
-    // --bail is intentionally NOT forwarded: workers Global.exit(1) on bail
-    // (see test_command.rs handle_test_completed), which the coordinator would
-    // misread as a crash. Cross-worker bail is handled at file granularity by
-    // the coordinator instead.
+    // --bail is intentionally NOT forwarded: a worker would exit(1) on bail
+    // (see test_command.rs `bail_out`), which the coordinator would misread as
+    // a crash. Cross-worker bail is handled at file granularity by the
+    // coordinator instead.
     if opts.repeat_count > 0 {
         argv.push(print_z(format_args!("--rerun-each={}", opts.repeat_count))?);
     }

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -309,10 +309,9 @@ fn build_worker_argv(ctx: &Command::ContextData) -> crate::Result<Box<[bun_spawn
     if let Some(seed) = opts.seed {
         argv.push(print_z(format_args!("--seed={}", seed))?);
     }
-    // --bail is intentionally NOT forwarded: a worker would exit(1) on bail
-    // (see test_command.rs `bail_out`), which the coordinator would misread as
-    // a crash. Cross-worker bail is handled at file granularity by the
-    // coordinator instead.
+    // --bail is not forwarded: a worker would exit(1) on bail (test_command.rs
+    // `bail_out`), which the coordinator would misread as a crash; the
+    // coordinator bails at file granularity itself.
     if opts.repeat_count > 0 {
         argv.push(print_z(format_args!("--rerun-each={}", opts.repeat_count))?);
     }

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1544,14 +1544,10 @@ impl CommandLineReporter {
         Output::print_start_end(bun::start_time(), bun::time::nano_timestamp());
     }
 
-    /// `--bail` reached its failure count: report, then exit 1 through the same
-    /// teardown as the end of a normal run (`exec`). A bare `Global::exit` here
-    /// would skip the `BUN_DESTRUCT_VM_ON_EXIT` teardown, and the leak-check
-    /// lanes then report every wrapper box the JSC finalizers still own.
-    ///
-    /// Reached mid-file (`handle_test_completed`, with the file's `BunTest`
-    /// still held by `TestCommand::run`) and after a failed module evaluation;
-    /// `process.exit()` inside a test tears the VM down from the same state.
+    /// `--bail` reached its failure count: report, then exit 1 through the
+    /// same VM teardown as the end of a normal run (`exec`). A bare
+    /// `Global::exit` would skip the `BUN_DESTRUCT_VM_ON_EXIT` teardown and
+    /// leave every JSC-finalizer-owned wrapper box for the leak checker.
     pub(crate) fn bail_out(&mut self, vm: &mut VirtualMachine) -> ! {
         self.print_summary();
         pretty_error!(
@@ -1570,11 +1566,9 @@ impl CommandLineReporter {
         // `run_with_api_lock` takes `&self` only, so the closure holds the
         // unique mutable access on this single-threaded path.
         vm.run_with_api_lock(|| unsafe { (*vm_ptr).on_exit() });
-        // Same order as `exec`: exit listeners (user JS) ran above while the
-        // runner was intact; now release the `bun:test` state and unpublish
-        // `RUNNER` so nothing running inside the teardown GC can observe a
-        // half-torn-down `TestRunner`. The reporter itself stays allocated:
-        // both callers still borrow it.
+        // Exit listeners (user JS) ran above while the runner was intact; now
+        // release the `bun:test` GC roots so the teardown GC can't observe a
+        // half-torn-down `TestRunner`.
         self.jest.bun_test_root.deinit_for_exit();
         // SAFETY: `RUNNER` is a `RacyCell` touched only from the single JS
         // thread; no concurrent reader exists on this shutdown path.

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1518,16 +1518,7 @@ impl CommandLineReporter {
                 this.summary().fail += 1;
 
                 if this.summary().fail == this.jest.bail {
-                    this.print_summary();
-                    pretty_error!(
-                        "\nBailed out after {} failure{}<r>\n",
-                        this.jest.bail,
-                        if this.jest.bail == 1 { "" } else { "s" }
-                    );
-                    Output::flush();
-                    this.write_junit_report_if_needed();
-                    this.write_timings_if_needed();
-                    Global::exit(1);
+                    this.bail_out(VirtualMachine::get().as_mut());
                 }
             }
         }
@@ -1551,6 +1542,48 @@ impl CommandLineReporter {
         );
 
         Output::print_start_end(bun::start_time(), bun::time::nano_timestamp());
+    }
+
+    /// `--bail` reached its failure count: report, then exit 1 through the same
+    /// teardown as the end of a normal run (`exec`). A bare `Global::exit` here
+    /// would skip the `BUN_DESTRUCT_VM_ON_EXIT` teardown, and the leak-check
+    /// lanes then report every wrapper box the JSC finalizers still own.
+    ///
+    /// Reached mid-file (`handle_test_completed`, with the file's `BunTest`
+    /// still held by `TestCommand::run`) and after a failed module evaluation;
+    /// `process.exit()` inside a test tears the VM down from the same state.
+    pub(crate) fn bail_out(&mut self, vm: &mut VirtualMachine) -> ! {
+        self.print_summary();
+        pretty_error!(
+            "\nBailed out after {} failure{}<r>\n",
+            self.jest.bail,
+            if self.jest.bail == 1 { "" } else { "s" }
+        );
+        Output::flush();
+        self.write_junit_report_if_needed();
+        self.write_timings_if_needed();
+
+        vm.exit_handler.exit_code = 1;
+        vm.exit_handler.skip_exit_listeners = skip_exit_listeners(self);
+        let vm_ptr: *mut VirtualMachine = vm;
+        // SAFETY: `vm_ptr` reborrows the live `&mut VirtualMachine`;
+        // `run_with_api_lock` takes `&self` only, so the closure holds the
+        // unique mutable access on this single-threaded path.
+        vm.run_with_api_lock(|| unsafe { (*vm_ptr).on_exit() });
+        // Same order as `exec`: exit listeners (user JS) ran above while the
+        // runner was intact; now release the `bun:test` state and unpublish
+        // `RUNNER` so nothing running inside the teardown GC can observe a
+        // half-torn-down `TestRunner`. The reporter itself stays allocated:
+        // both callers still borrow it.
+        self.jest.bun_test_root.deinit_for_exit();
+        // SAFETY: `RUNNER` is a `RacyCell` touched only from the single JS
+        // thread; no concurrent reader exists on this shutdown path.
+        unsafe {
+            jest::Jest::RUNNER.write(None);
+        }
+        // SAFETY: as above; `global_exit()` diverges, so the closure is the
+        // sole mutator.
+        vm.run_with_api_lock(|| unsafe { (*vm_ptr).global_exit() })
     }
 
     /// Like the JUnit report, called before every exit path (including bail) so measured durations aren't lost.
@@ -3296,33 +3329,9 @@ impl TestCommand {
                     reporter.summary().fail += 1;
 
                     if reporter.jest.bail == reporter.summary().fail {
-                        reporter.print_summary();
-                        pretty_error!(
-                            "\nBailed out after {} failure{}<r>\n",
-                            reporter.jest.bail,
-                            if reporter.jest.bail == 1 { "" } else { "s" }
-                        );
-                        reporter.write_junit_report_if_needed();
-                        reporter.write_timings_if_needed();
-
-                        vm.exit_handler.exit_code = 1;
-                        vm.is_shutting_down = true;
-                        // `global_exit()` diverges, so the `exit_file()` defer
-                        // above never fires. Release the active file's
-                        // `Strong`s and the preload-hook scope here so
-                        // `Zig__GlobalObject__destructOnExit()`'s `collectNow()` can reclaim them,
-                        // then clear `RUNNER` so finalizers can't observe a
-                        // partially-torn-down `TestRunner`.
-                        // SAFETY: single-threaded; raw-ptr reborrow mirrors the
-                        // defer's escape.
-                        unsafe {
-                            (*bun_test_root_ptr).deinit_for_exit();
-                            jest::Jest::RUNNER.write(None);
-                        }
-                        let vm_ptr = std::ptr::from_mut::<VirtualMachine>(vm);
-                        // SAFETY: global_exit diverges; `vm_ptr` is a fresh
-                        // raw-ptr reborrow of the exclusive `vm` borrow.
-                        unsafe { (*vm_ptr).run_with_api_lock(|| (&mut *vm_ptr).global_exit()) };
+                        // Diverges, so the `exit_file()` defer above never
+                        // fires; `bail_out` releases the active file itself.
+                        reporter.bail_out(vm);
                     }
 
                     return Ok(());

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "bun";
 import { beforeAll, describe, expect, it, test } from "bun:test";
-import { bunEnv, bunExe, isLinux, isWindows, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isASAN, isLinux, isWindows, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 
@@ -329,6 +329,7 @@ describe("bun test", () => {
             expect(true).toBe(true);
           });
         `,
+        expectExitCode: 1,
       });
       expect(stderr).toContain("Bailed out after 1 failure");
       expect(stderr).not.toContain("test #2");
@@ -352,9 +353,132 @@ describe("bun test", () => {
             expect(true).toBe(true);
           });
         `,
+        expectExitCode: 1,
       });
       expect(stderr).toContain("Bailed out after 3 failures");
       expect(stderr).not.toContain("test #4");
+    });
+
+    // The sanitizer lane (scripts/runner.node.mjs) runs every child with this environment. Bailing
+    // out has to exit through the same VM teardown as the end of a normal run; a bare exit leaves
+    // the objects the bun:test finalizers own allocated, and LeakSanitizer then aborts the process
+    // (exit 134) instead of it exiting 1.
+    describe.concurrent.skipIf(!isASAN)("exits cleanly under LeakSanitizer", () => {
+      const env = {
+        ...bunEnv,
+        BUN_DESTRUCT_VM_ON_EXIT: "1",
+        ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=0:detect_leaks=1:abort_on_error=1",
+        LSAN_OPTIONS: `malloc_context_size=30:print_suppressions=0:suppressions=${join(import.meta.dir, "../../leaksan.supp")}`,
+      };
+
+      /** Runs `bun test --bail` and returns what the test files logged to stdout. */
+      async function runUntilBail(files: Record<string, string>, ...args: string[]): Promise<string[]> {
+        using dir = tempDir("bun-test-bail-leak-check", files);
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "test", "--bail", ...args],
+          env,
+          cwd: String(dir),
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).toContain("Bailed out after 1 failure");
+        expect(stderr).not.toContain("LeakSanitizer");
+        expect({ exitCode, signalCode: proc.signalCode }).toEqual({ exitCode: 1, signalCode: null });
+        // Everything else on stdout is the "bun test vX.Y.Z" banner.
+        return stdout.split("\n").filter(line => line.startsWith("ran: "));
+      }
+
+      test("after a test fails", async () => {
+        const ran = await runUntilBail({
+          "a.test.ts": `
+            import { test, expect } from "bun:test";
+            test("fails", () => {
+              console.log("ran: fails");
+              expect(1).toBe(2);
+            });
+            test("unreachable", () => {
+              console.log("ran: unreachable");
+            });
+          `,
+        });
+        expect(ran).toEqual(["ran: fails"]);
+      });
+
+      // The failure arrives from a promise reaction here, so the exit starts inside a JS frame.
+      test("after an async test fails while a timer is still pending", async () => {
+        const ran = await runUntilBail({
+          "a.test.ts": `
+            import { test, expect } from "bun:test";
+            test("fails", async () => {
+              setTimeout(() => console.log("ran: timer"), 60_000);
+              await Bun.sleep(1);
+              console.log("ran: fails");
+              expect(1).toBe(2);
+            });
+            test("unreachable", () => {
+              console.log("ran: unreachable");
+            });
+          `,
+        });
+        expect(ran).toEqual(["ran: fails"]);
+      });
+
+      test("after a later file fails, with preload hooks registered", async () => {
+        const ran = await runUntilBail(
+          {
+            "preload.ts": `
+              import { afterEach, beforeAll, beforeEach } from "bun:test";
+              beforeAll(() => console.log("ran: preload beforeAll"));
+              beforeEach(() => {});
+              afterEach(() => {});
+            `,
+            "a.test.ts": `
+              import { describe, test, expect } from "bun:test";
+              describe("a", () => {
+                test("passes", () => {
+                  console.log("ran: a");
+                  expect(1).toBe(1);
+                });
+              });
+            `,
+            "b.test.ts": `
+              import { describe, test, expect } from "bun:test";
+              describe("b", () => {
+                test("fails", () => {
+                  console.log("ran: b");
+                  expect(1).toBe(2);
+                });
+              });
+            `,
+          },
+          "--preload=./preload.ts",
+          "./a.test.ts",
+          "./b.test.ts",
+        );
+        expect(ran).toEqual(["ran: preload beforeAll", "ran: a", "ran: b"]);
+      });
+
+      test("after a file fails to load", async () => {
+        const ran = await runUntilBail(
+          {
+            "a.test.ts": `
+              import { test, expect } from "bun:test";
+              test("passes", () => {
+                console.log("ran: a");
+                expect(1).toBe(1);
+              });
+            `,
+            "b.test.ts": `
+              console.log("ran: b (load)");
+              throw new Error("b failed to load");
+            `,
+          },
+          "./a.test.ts",
+          "./b.test.ts",
+        );
+        expect(ran).toEqual(["ran: a", "ran: b (load)"]);
+      });
     });
   });
   describe("--timeout", () => {
@@ -1705,6 +1829,45 @@ describe("bun test", () => {
     test("can fail the run once node:test registered a test, like node's common.mustCall()", async () => {
       const { stderr, exitCode } = await runFile("node-exit-code.test.ts", nodeTestFile(1));
       expect(stderr).toContain("1 pass");
+      expect(exitCode).toBe(1);
+    });
+
+    // --bail exits through the same on_exit() as the end of a run, so the same gate applies.
+    test("are not run when --bail stops a bun:test file", async () => {
+      const { stdout, stderr, exitCode } = await runFiles(
+        {
+          "bail.test.ts": `
+            import { test, expect } from "bun:test";
+            process.on("exit", () => {
+              console.log("exit listener ran");
+              process.exit(7);
+            });
+            test("fails", () => expect(1).toBe(2));
+          `,
+        },
+        "--bail",
+        "bail.test.ts",
+      );
+      expect(stdout).not.toContain("exit listener ran");
+      expect(stderr).toContain("Bailed out after 1 failure");
+      expect(exitCode).toBe(1);
+    });
+
+    test("run when --bail stops a file that registered a node:test test", async () => {
+      const { stdout, stderr, exitCode } = await runFiles(
+        {
+          "node-bail.test.ts": `
+            import { test } from "node:test";
+            import assert from "node:assert";
+            process.on("exit", code => console.log("exit listener ran with", code));
+            test("fails", () => assert.strictEqual(1, 2));
+          `,
+        },
+        "--bail",
+        "node-bail.test.ts",
+      );
+      expect(stdout).toContain("exit listener ran with 1");
+      expect(stderr).toContain("Bailed out after 1 failure");
       expect(exitCode).toBe(1);
     });
 

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -4,6 +4,18 @@ import { bunEnv, bunExe, isASAN, isLinux, isWindows, tempDir, tempDirWithFiles, 
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 
+// The environment the sanitizer lane (scripts/runner.node.mjs) runs test files under, which their
+// bunEnv children inherit. This file is exempted in test/no-validate-leaksan.txt, so the children
+// that need it get it explicitly. Under it, an exit that skips the VM teardown leaves the objects
+// the bun:test finalizers own allocated, and LeakSanitizer aborts the process (exit 134) in place
+// of the exit code the run meant to return.
+const leakCheckEnv = {
+  ...bunEnv,
+  BUN_DESTRUCT_VM_ON_EXIT: "1",
+  ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=0:detect_leaks=1:abort_on_error=1",
+  LSAN_OPTIONS: `malloc_context_size=30:print_suppressions=0:suppressions=${join(import.meta.dir, "../../leaksan.supp")}`,
+};
+
 describe("bun test", () => {
   test("running a non-existent absolute file path is a 1 exit code", () => {
     const spawn = Bun.spawnSync({
@@ -359,24 +371,15 @@ describe("bun test", () => {
       expect(stderr).not.toContain("test #4");
     });
 
-    // The sanitizer lane (scripts/runner.node.mjs) runs every child with this environment. Bailing
-    // out has to exit through the same VM teardown as the end of a normal run; a bare exit leaves
-    // the objects the bun:test finalizers own allocated, and LeakSanitizer then aborts the process
-    // (exit 134) instead of it exiting 1.
+    // Bailing out has to exit through the same VM teardown as the end of a normal run (see
+    // leakCheckEnv), not through a bare exit.
     describe.concurrent.skipIf(!isASAN)("exits cleanly under LeakSanitizer", () => {
-      const env = {
-        ...bunEnv,
-        BUN_DESTRUCT_VM_ON_EXIT: "1",
-        ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=0:detect_leaks=1:abort_on_error=1",
-        LSAN_OPTIONS: `malloc_context_size=30:print_suppressions=0:suppressions=${join(import.meta.dir, "../../leaksan.supp")}`,
-      };
-
       /** Runs `bun test --bail` and returns what the test files logged to stdout. */
       async function runUntilBail(files: Record<string, string>, ...args: string[]): Promise<string[]> {
         using dir = tempDir("bun-test-bail-leak-check", files);
         await using proc = Bun.spawn({
           cmd: [bunExe(), "test", "--bail", ...args],
-          env,
+          env: leakCheckEnv,
           cwd: String(dir),
           stdout: "pipe",
           stderr: "pipe",
@@ -481,6 +484,41 @@ describe("bun test", () => {
       });
     });
   });
+
+  // Without --bail a failing run exits through the end of the run (and, under --parallel, through
+  // the worker's exit path). Printing the failure is what allocates the source map entry the bail
+  // exit used to leak, so these pin down that both paths tear the VM down too.
+  describe.concurrent.skipIf(!isASAN)("a failing run exits 1 cleanly under LeakSanitizer", () => {
+    test.each([
+      ["serial", []],
+      ["--parallel", ["--parallel=2"]],
+    ])("%s", async (_, args) => {
+      using dir = tempDir("bun-test-fail-leak-check", {
+        "a.test.ts": `
+          import { test, expect } from "bun:test";
+          test("fails", () => expect(1).toBe(2));
+        `,
+        "b.test.ts": `
+          import { test, expect } from "bun:test";
+          test("passes", () => expect(1).toBe(1));
+        `,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", ...args],
+        env: leakCheckEnv,
+        cwd: String(dir),
+        stdout: "ignore",
+        stderr: "pipe",
+      });
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      // A --parallel worker aborting does not change the coordinator's exit code; the workers'
+      // stderr is inherited, so the report check is what covers the worker exit path.
+      expect(stderr).not.toContain("LeakSanitizer");
+      expect(stderr).toContain("Ran 2 tests across 2 files.");
+      expect({ exitCode, signalCode: proc.signalCode }).toEqual({ exitCode: 1, signalCode: null });
+    });
+  });
+
   describe("--timeout", () => {
     test("must provide a number timeout", () => {
       const stderr = runTest({

--- a/test/no-validate-leaksan.txt
+++ b/test/no-validate-leaksan.txt
@@ -94,7 +94,6 @@ test/cli/test/bun-test.test.ts
 test/cli/install/bun-install-security-provider.test.ts
 test/js/node/test/parallel/test-tls-fast-writing.js
 test/js/bun/sqlite/sqlite.test.js
-test/regression/issue/12250.test.ts
 test/js/bun/test/parallel/test-http-10177-response.write-with-non-ascii-latin1-should-not-cause-duplicated-character-or-segfault.ts
 test/cli/install/minimum-release-age.test.ts
 


### PR DESCRIPTION
Fixes #32183

### Problem

- `bun test --bail` on a file whose test fails exits 134 under the environment the sanitizer lane gives every child (`BUN_DESTRUCT_VM_ON_EXIT=1`, `ASAN_OPTIONS=...:detect_leaks=1:abort_on_error=1`, `LSAN_OPTIONS=suppressions=test/leaksan.supp`), instead of 1. stderr ends with `ERROR: LeakSanitizer: detected memory leaks` / `SUMMARY: AddressSanitizer: 796 byte(s) leaked in 8 allocation(s)`: the `Expect` box from `Expect::to_js`, the file's `ScopeFunctions` boxes, a `RefData` from `Expect::call`, and a `SavedSourceMap::get_with_content` entry.
- Cause: the bail taken from `CommandLineReporter::handle_test_completed` (src/runtime/cli/test_command.rs:1519) was a bare `Global::exit(1)`. Under ASAN that is libc `exit()`, so LSan's atexit scan runs, but `VirtualMachine::on_exit()` / `global_exit()` never do, and the `BUN_DESTRUCT_VM_ON_EXIT` teardown that frees those objects (`destructOnExit` -> `~VM` -> `lastChanceToFinalize`, plus the VM's source map table) is skipped. Every other exit `bun test` takes once tests have run (end of run in `exec`, `--parallel` workers, and the other bail site, the failed module evaluation in `TestCommand::run`) already goes through `global_exit()` and is clean under the same environment.
- Without `--bail` the same failing file exits 1 with no report. Existing bail tests did not notice because they assert `not.toBe(0)` or only look at stderr, or are listed in `test/no-validate-leaksan.txt`. Under the lane's environment the leak report also takes several seconds to symbolize, which is what put `test/regression/issue/12250.test.ts` on that list (its bail child hits the 5s test timeout).

### Fix

- Both bail sites now call one `CommandLineReporter::bail_out(vm) -> !`. It prints the summary and bail message and writes the junit/timings files exactly as before, then exits the same way `exec`'s tail does: `exit_code = 1`, `skip_exit_listeners` from the same gate (#38442), `on_exit()`, `bun_test_root.deinit_for_exit()`, `RUNNER` cleared, `global_exit()`. The module-evaluation bail site loses its hand-rolled copy of that sequence.
- Why exiting from inside the test-completion callback is fine: `process.exit()` called inside a test reaches `on_exit()` + `global_exit()` from exactly this state (runner published, file mid-execution, JS frames possibly on the stack), and that is exercised on the sanitizer lane today. `destroyVM` clears `vm.entryScope` and drops the outstanding `JSLockHolder` refs for that reason. The file's `BunTest` stays allocated because `TestCommand::run` still holds its strong ref; `deinit_for_exit()` only drops the root's ref, and the test-runner finalizers that run during teardown (`Expect`, `DoneCallback`, `ScopeFunctions`) release a `RefData`/drop a box and do not touch `RUNNER`. So no unwinding of the step loops is needed; the bail still stops synchronously at the same point, and the output is byte-identical to before (checked both sites against an unfixed build).
- Visible differences outside leak checking: the bail exit now runs the end-of-run `on_exit()` (exit listeners stay skipped for bun:test files, and run once a node:test API was used, as at the end of a normal run), and `global_exit()` checkpoints and closes the test's sqlite databases like a normal exit does.
- Verified with a debug (ASAN) build:
  - `test/cli/test/bun-test.test.ts`: new `--bail > exits cleanly under LeakSanitizer` cases (sync failure, failure delivered from a promise reaction with a timer pending, a later file failing with preload hooks registered, a file failing to load) spawn `bun test --bail` with the lane's environment and assert exit 1, no signal, no LeakSanitizer output, and that nothing after the failure ran; the two existing bail tests now assert exit code 1; new `process.on('exit')` cases check listeners stay skipped for a bun:test file on bail and run for a node:test file on bail. Without the src change the three in-test leak cases and the node:test listener case fail; the whole file passes with it (95 pass, 6 todo).
  - Also in `bun-test.test.ts`: `a failing run exits 1 cleanly under LeakSanitizer` (serial and `--parallel=2`, carried over from #32187) pins down the non-bail exit paths, which are already clean on main; both cases report the leak if the teardown is skipped (checked by running them with `BUN_DESTRUCT_VM_ON_EXIT` removed), and the `--parallel` case relies on the inherited worker stderr since a worker abort does not change the coordinator's exit code.
  - `test/regression/issue/12250.test.ts` removed from `test/no-validate-leaksan.txt`; it passes under the lane's environment with this change and times out without it.
  - `test/js/bun/test/test-test.test.ts`, `test/regression/issue/12250.test.ts`, `test/regression/issue/26851.test.ts`, the `--parallel --bail` tests in `test/cli/test/parallel.test.ts` pass.
  - Under the lane's environment, bails reached from a test timeout, a throwing `beforeEach`, `done(err)`, concurrent tests with a 30s sibling and a 60s timer pending, an open `bun:sqlite` database, `--isolate`, `--rerun-each=3`, `--bail=2` across files and `--watch` all exit 1 promptly with no report.
  - This commit cherry-picked onto current main (5448c1e603): the #32183 repro and the leak-check cases from #32180 and #32187, run with the lane's environment, all pass (green serial/`--isolate`/`--parallel`, failing serial/`--parallel`, `--bail` mid-file, `--bail` on a module evaluation failure); on main itself only the `--bail` mid-file case fails.
- Superseded PRs: #32187 fixed the same bail exit with a `bailed` flag that unwinds the run loops, plus a `SavedSourceMap::clear()` for the source map entry a failing run caches; it was stacked on #32180. Both were written against a June main where `bun test`'s exit did not tear the VM down even with `BUN_DESTRUCT_VM_ON_EXIT=1` (`destructOnExit` released only two VM refs, so `~VM` never ran under `exec`'s API lock; fixed by #34346) and did not run `on_exit()` (added by #34444, extended to `--parallel` workers by #38442). On current main every `bun test` exit that goes through `global_exit()` frees those objects and the source map table, so the only remaining case under the lane's environment is the bare exit this PR replaces. #32187 and #32180 are closed in favor of this PR; their extra scenario, leak checking without `BUN_DESTRUCT_VM_ON_EXIT`, is not one the lane uses (a passing run is not clean under it either).
- Other open bail PRs: #35504, #35094, #38265 and #38974 change other things about bail and keep the hard exit; #38974 works around this bug by passing `detect_leaks=0` to its bail children, which becomes unnecessary with this change. They are independent of this PR apart from textual conflicts at the same lines.

### Background

- `BUN_DESTRUCT_VM_ON_EXIT`: opt-in (set by `scripts/runner.node.mjs` on the ASAN lane) that makes `VirtualMachine::global_exit()` tear the JSC VM down before exiting instead of just calling `exit()`. Destroying the VM runs `lastChanceToFinalize`, which runs every live cell's finalizer; that is how the native boxes behind `bun:test` wrapper objects (`Expect`, `ScopeFunctions`, ...) get freed. Without it a bare exit is the normal, fast path, and leak checking is not meaningful in any `bun test` exit (a passing run also reports these objects).
- LeakSanitizer reports a malloc'd block as leaked when no pointer to it is found in its roots (stacks, globals, other malloc'd blocks). Pointers held only inside JSC heap cells are invisible to it, so anything owned solely by a JS wrapper is reported unless its finalizer ran. The test runner's own state (`CommandLineReporter`, `BunTest`) is reachable from `exec`'s stack frame and is not reported either way.
- `on_exit()` is the end-of-process sequence (profilers, `process.on('exit')` dispatch gated by `exit_handler.skip_exit_listeners`, napi cleanup hooks); it also sets `is_shutting_down`, which `global_exit()` asserts. `bun test` runs it at the end of every run and in `--parallel` workers since #38442.
- `BunTestRoot::deinit_for_exit()` drops the active file's root reference, the preload hook scope and the orphaned `pending_then_refs`; `exec` runs it and clears `Jest::RUNNER` right before `global_exit()` so nothing that runs during teardown can see a half-torn-down runner. Its doc comment already describes the bail path as a caller.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/test/bun-test.test.ts

<!-- robobun:evidence:end -->