### PR TITLE
install: drop the query string and fragment from a tarball URL's extraction folder name

### DIFF
--- a/src/install/extract_tarball.rs
+++ b/src/install/extract_tarball.rs
@@ -200,9 +200,8 @@ impl ExtractTarball {
         };
         let basename: &[u8] =
             if strings::has_prefix(name, b"https://") || strings::has_prefix(name, b"http://") {
-                // `bun add <url>` names the dependency after the URL until the
-                // tarball's package.json has been read, so the name is not an
-                // alias to validate; the basename only labels the temp dir.
+                // The URL is the placeholder name `bun add <url>` gives a dependency until
+                // its package.json has been read; the basename only labels the temp dir.
                 let mut tmp = name;
                 if let Some(i) = strings::index_of_any(tmp, b"?#") {
                     tmp = &tmp[0..i];

--- a/src/install/extract_tarball.rs
+++ b/src/install/extract_tarball.rs
@@ -198,30 +198,43 @@ impl ExtractTarball {
             debug_assert!(false);
             b"unnamed-package"
         };
-        let basename: &[u8] = 'brk: {
-            let mut tmp = name;
-            if strings::has_prefix(tmp, b"https://") || strings::has_prefix(tmp, b"http://") {
+        let basename: &[u8] =
+            if strings::has_prefix(name, b"https://") || strings::has_prefix(name, b"http://") {
+                // `bun add <url>` names the dependency after the URL until the
+                // tarball's package.json has been read, so the name is not an
+                // alias to validate; the basename only labels the temp dir.
+                let mut tmp = name;
+                if let Some(i) = strings::index_of_any(tmp, b"?#") {
+                    tmp = &tmp[0..i];
+                }
                 tmp = bun_paths::basename(tmp);
                 if strings::ends_with(tmp, b".tgz") {
                     tmp = &tmp[0..tmp.len() - 4];
                 } else if strings::ends_with(tmp, b".tar.gz") {
                     tmp = &tmp[0..tmp.len() - 7];
                 }
-            } else if tmp[0] == b'@' {
-                if let Some(i) = strings::index_of_char(tmp, b'/') {
-                    tmp = &tmp[i as usize + 1..];
+                if bun_install::dependency::is_safe_install_folder_name(tmp) {
+                    tmp
+                } else {
+                    b"package"
                 }
-            }
-
-            #[cfg(windows)]
-            {
-                if let Some(i) = strings::last_index_of_char(tmp, b':') {
-                    tmp = &tmp[i + 1..];
+            } else {
+                let mut tmp = name;
+                if tmp[0] == b'@' {
+                    if let Some(i) = strings::index_of_char(tmp, b'/') {
+                        tmp = &tmp[i as usize + 1..];
+                    }
                 }
-            }
 
-            break 'brk tmp;
-        };
+                #[cfg(windows)]
+                {
+                    if let Some(i) = strings::last_index_of_char(tmp, b':') {
+                        tmp = &tmp[i + 1..];
+                    }
+                }
+
+                tmp
+            };
         (name, basename)
     }
 

--- a/src/install/extract_tarball.rs
+++ b/src/install/extract_tarball.rs
@@ -200,8 +200,7 @@ impl ExtractTarball {
         };
         let basename: &[u8] =
             if strings::has_prefix(name, b"https://") || strings::has_prefix(name, b"http://") {
-                // The URL is the placeholder name `bun add <url>` gives a dependency until
-                // its package.json has been read; the basename only labels the temp dir.
+                // A URL name is the placeholder `bun add <url>` uses until package.json is read.
                 let mut tmp = name;
                 if let Some(i) = strings::index_of_any(tmp, b"?#") {
                     tmp = &tmp[0..i];

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -2672,12 +2672,15 @@ it("should not add duplicate package.json entries when installing the same tarba
 // and the URL's basename labels the directory the tarball is extracted into. The query string and
 // fragment used to end up in that label: `?` cannot appear in a directory name on Windows, and a `:`
 // within the first 32 bytes of the label (it is truncated to that) fails the install folder name
-// check on every platform with "Refusing to install package with invalid name".
+// check on every platform with "Refusing to install package with invalid name". A URL without a path
+// has nothing usable left once the query is gone (its basename is the `host:port`), so the label
+// falls back to "package" instead.
 describe("should add a tarball URL with a query string or fragment", () => {
-  const suffixes = [
-    ["query string", "?token=abc"],
-    ["query string containing a colon", "?expires=12:00"],
-    ["fragment containing a colon", "#ref:main"],
+  const paths = [
+    ["query string", "/qs-pkg-1.0.0.tgz?token=abc"],
+    ["query string containing a colon", "/qs-pkg-1.0.0.tgz?expires=12:00"],
+    ["fragment containing a colon", "/qs-pkg-1.0.0.tgz#ref:main"],
+    ["query string on a URL without a path", "/?file=qs-pkg-1.0.0.tgz"],
   ] as const;
 
   let tarball: Uint8Array;
@@ -2737,9 +2740,9 @@ describe("should add a tarball URL with a query string or fragment", () => {
   }
 
   describe.each(["buffered", "streaming"] as const)("%s extraction", mode => {
-    test.each(suffixes)("%s", async (_, suffix) => {
+    test.each(paths)("%s", async (_, path) => {
       await using server = await serveTarball(mode);
-      const url = `${server.origin}/qs-pkg-1.0.0.tgz${suffix}`;
+      const url = `${server.origin}${path}`;
       await writeFile(join(package_dir, "package.json"), JSON.stringify({ name: "foo", version: "0.0.1" }));
 
       const { stdout, stderr, exited } = spawn({

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -1,8 +1,11 @@
 import type { BunLockFile } from "bun";
 import { file, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, setDefaultTimeout, test } from "bun:test";
+import { randomBytes } from "crypto";
 import { access, appendFile, copyFile, mkdir, readlink, rm, writeFile } from "fs/promises";
 import { bunExe, bunEnv as env, readdirSorted, tmpdirSync, toBeValidBin, toBeWorkspaceLink, toHaveBins } from "harness";
+import { createServer } from "http";
+import type { AddressInfo } from "net";
 import { join, relative, resolve } from "path";
 import {
   check_npm_auth_type,
@@ -2662,6 +2665,113 @@ it("should not add duplicate package.json entries when installing the same tarba
     dependencies: {
       baz: tarball_url,
     },
+  });
+});
+
+// `bun add <url>` names the dependency after the URL until the tarball's package.json has been read,
+// and the URL's basename labels the directory the tarball is extracted into. The query string and
+// fragment used to end up in that label: `?` cannot appear in a directory name on Windows, and a `:`
+// within the first 32 bytes of the label (it is truncated to that) fails the install folder name
+// check on every platform with "Refusing to install package with invalid name".
+describe("should add a tarball URL with a query string or fragment", () => {
+  const suffixes = [
+    ["query string", "?token=abc"],
+    ["query string containing a colon", "?expires=12:00"],
+    ["fragment containing a colon", "#ref:main"],
+  ] as const;
+
+  let tarball: Uint8Array;
+  beforeAll(async () => {
+    tarball = await new Bun.Archive(
+      {
+        "package/package.json": JSON.stringify({ name: "qs-pkg", version: "1.0.0" }),
+        // Incompressible padding so the drip-fed response below arrives in many socket reads, which
+        // is what commits the install to the streaming extractor.
+        "package/pad.bin": randomBytes(256 * 1024),
+      },
+      { compress: "gzip" },
+    ).bytes();
+  });
+
+  // The tarball is extracted either from the fully buffered response body or, when the body is
+  // large enough and arrives in several reads, by the streaming extractor; both pick the extraction
+  // directory name the same way.
+  async function serveTarball(mode: "buffered" | "streaming") {
+    if (mode === "buffered") {
+      const server = Bun.serve({
+        port: 0,
+        fetch: () => new Response(tarball),
+      });
+      return {
+        origin: server.url.origin,
+        [Symbol.asyncDispose]: () => server.stop(true),
+      };
+    }
+
+    // node:http so the response carries a Content-Length and can still be written 1 KiB at a time.
+    const server = createServer((req, res) => {
+      res.setHeader("Content-Type", "application/gzip");
+      res.setHeader("Content-Length", String(tarball.length));
+      req.socket.setNoDelay(true);
+      let offset = 0;
+      const step = () => {
+        if (offset >= tarball.length) {
+          res.end();
+          return;
+        }
+        res.write(tarball.subarray(offset, offset + 1024));
+        offset += 1024;
+        setImmediate(step);
+      };
+      step();
+    });
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as AddressInfo;
+    return {
+      origin: `http://127.0.0.1:${port}`,
+      [Symbol.asyncDispose]: () => {
+        server.closeAllConnections();
+        return new Promise<void>(resolve => server.close(() => resolve()));
+      },
+    };
+  }
+
+  describe.each(["buffered", "streaming"] as const)("%s extraction", mode => {
+    test.each(suffixes)("%s", async (_, suffix) => {
+      await using server = await serveTarball(mode);
+      const url = `${server.origin}/qs-pkg-1.0.0.tgz${suffix}`;
+      await writeFile(join(package_dir, "package.json"), JSON.stringify({ name: "foo", version: "0.0.1" }));
+
+      const { stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "add", url, "--verbose"],
+        cwd: package_dir,
+        stdout: "pipe",
+        stdin: "pipe",
+        stderr: "pipe",
+        env: mode === "streaming" ? { ...env, BUN_INSTALL_STREAMING_MIN_SIZE: "1024" } : env,
+      });
+      const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+      expect(err).not.toContain("error:");
+      // Printed by the streaming extractor only, so each mode is known to have taken its own path.
+      if (mode === "streaming") {
+        expect(err).toContain("Streamed ");
+      } else {
+        expect(err).not.toContain("Streamed ");
+      }
+      expect(out).toContain(`+ qs-pkg@${url}`);
+      expect(exitCode).toBe(0);
+      expect(await file(join(package_dir, "package.json")).json()).toStrictEqual({
+        name: "foo",
+        version: "0.0.1",
+        dependencies: {
+          "qs-pkg": url,
+        },
+      });
+      expect(await file(join(package_dir, "node_modules", "qs-pkg", "package.json")).json()).toEqual({
+        name: "qs-pkg",
+        version: "1.0.0",
+      });
+    });
   });
 });
 


### PR DESCRIPTION
### Problem
- `bun add http://host/pkg-1.0.0.tgz?token=abc` fails on Windows. Any tarball URL with a query string does; the same URL without one installs fine, and so does the same URL declared under a name in package.json:
  ```
  error: ENOENT when create temporary directory named ".2fabfa77918bdd48-1.pkg-1.0.0.tgz?token=abc" (while extracting "http://host/pkg-1.0.0.tgz?token=abc")
  error: InstallFailed extracting tarball from http://host/pkg-1.0.0.tgz?token=abc
  ```
  With the streaming extractor (bodies of 2 MiB or more) the first line is `ENOENT extracting tarball for "<url>"` instead.
- The same URL with a `:` in the query or fragment (`?expires=12:00`, `#ref:main`) fails on every platform with `Refusing to install package with invalid name "<url>"`.
- Cause: `ExtractTarball::name_and_basename` (src/install/extract_tarball.rs:201) derives the label for the extraction temp directory from the placeholder name, which for `bun add <url>` is the URL itself. It takes `bun_paths::basename(url)` and strips `.tgz`, so the query string and fragment stay in the label. `?` is not a legal NTFS file name character, so `mkdir` fails in `extract()`; `is_safe_install_folder_name` (src/install/dependency.rs:561) rejects a `:` in the label, and since the placeholder is a remote tarball both callers (`extract()` and `TarballStream::open_destination`) report that as an invalid package name.

### Fix
- Cut the URL at the first `?` or `#` before taking its basename, so the label is `pkg-1.0.0` for both URLs above.
- If the label is still not a usable folder name (for example a URL with no path, where the basename is `host:port`), use `package` instead of failing. The validation the callers do is meant for dependency aliases, and a name starting with `http(s)://` is never an alias: it is the placeholder `bun add <url>` uses until the tarball's package.json is read, and the label is only used to name the temp directory. The cache folder is named after a hash of the URL (`cached_tarball_folder_name_print`) and is unaffected.
- `name_and_basename` is shared by the buffered extractor and the streaming one, so both paths are fixed by the same change. Aliased dependencies (`"foo": "http://..."`) and npm packages do not take the changed branch and still go through the existing validation.
- Verified with the new cases in test/cli/install/bun-add.test.ts (`?token=abc`, `?expires=12:00`, `#ref:main`, and `/?file=...` on a URL with no path for the `package` fallback, each through the buffered and the streaming extractor; the streaming cases assert the extractor's verbose `Streamed` line so both paths are known to be exercised):
  - Linux, without the fix: the 4 colon cases fail with `Refusing to install package with invalid name`; with the fix all 8 pass.
  - Windows x64, without the fix: the `?token=abc` and `/?file=...` cases fail with the ENOENT errors above; the colon cases pass there only because the Windows branch of this function already cut the label at the last `:`. With the fix all 8 pass there as well.
  - The rest of bun-add.test.ts and bun-install-streaming-extract.test.ts pass with the fix.

### Background
- Tarball extraction: a downloaded tarball is extracted into a fresh directory inside bun's temp directory and then renamed into the install cache. `FileSystem::tmpname` names that directory `.<random>-<counter>.<label>`; the label exists only to make leftover temp directories recognizable.
- Placeholder names: until a URL tarball has been extracted, bun does not know the package's name, so the dependency created by `bun add <url>` is named after the URL literal (`PackageManagerResolution` swaps in the real name afterwards). A dependency declared in package.json as `"foo": "http://..."` is named `foo` instead.
- `is_safe_install_folder_name`: the check applied to dependency names before they are used as directory names (rejects empty, `.`, `..`, `\`, `:` and NUL). The hardening rounds (#31417, #31495) made extraction refuse npm and remote tarball packages whose name fails it, so an untrusted alias cannot pick the directory; git and local tarball packages fall back to the label `package` there.
- Buffered vs streaming extraction: small responses are downloaded in full and extracted by `ExtractTarball::extract`; responses of at least `BUN_INSTALL_STREAMING_MIN_SIZE` (2 MiB by default) that arrive in several reads are extracted while downloading by `TarballStream`. Both call `name_and_basename` to pick the temp directory name; with `--verbose` the streaming path prints a `Streamed ... tarball` line, which the tests use to tell them apart.
