### PR TITLE
react_compiler: keep an own __proto__ object key an own property

### DIFF
--- a/src/react_compiler/lowering/build_hir/expr.rs
+++ b/src/react_compiler/lowering/build_hir/expr.rs
@@ -146,9 +146,22 @@ pub(crate) fn lower_expression(
                     .as_ref()
                     .ok_or_else(|| cold_todo("object property without key", loc))?;
                 let computed = prop.flags.contains(PF::IsComputed);
-                let key = match lower_object_property_key(builder, key_expr, computed)? {
-                    Some(k) => k,
-                    None => continue,
+                // `{["__proto__"]: v}` and `{__proto__}` define an own property; the
+                // static key they would otherwise lower to is emitted as
+                // `__proto__: v`, which sets the prototype instead. Complement of the
+                // parser's prototype-setter predicate in visit_expr.rs (methods were
+                // diverted above and are never setters).
+                let own_proto_key = (computed || prop.flags.contains(PF::WasShorthand))
+                    && matches!(&key_expr.data, Data::EString(s) if s.eql_comptime(b"__proto__"));
+                let key = if own_proto_key {
+                    ObjectPropertyKey::Computed {
+                        name: lower_expression_to_temporary(builder, key_expr)?,
+                    }
+                } else {
+                    match lower_object_property_key(builder, key_expr, computed)? {
+                        Some(k) => k,
+                        None => continue,
+                    }
                 };
                 let value_expr = prop
                     .value

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -1063,4 +1063,55 @@ describe("bundler", () => {
       expect(out).toMatch(/__MEMO_CACHE_SENTINEL\)\s*\{[^}]*globalFn\(\)/);
     },
   });
+
+  // `{ __proto__: v }` sets the prototype, while `{ ["__proto__"]: v }` and the
+  // shorthand `{ __proto__ }` define an own property. Lowering used to turn the
+  // latter two into a static key, which codegen prints in the setter form.
+  itBundled("react-compiler/OwnProtoKeyStaysOwnProperty", {
+    files: {
+      "/entry.tsx": /* tsx */ `
+        function Comp({ id, proto }: { id: string; proto: object }) {
+          const __proto__ = "own";
+          const objects = {
+            computed: { ["__proto__"]: id },
+            template: { [\`__proto__\`]: id },
+            shorthand: { __proto__ },
+            method: { ["__proto__"]() {} },
+            setter: { __proto__: proto },
+            quotedSetter: { "__proto__": proto },
+          };
+          const shapes: Record<string, [string[], boolean]> = {};
+          for (const [name, o] of Object.entries(objects)) {
+            shapes[name] = [Object.keys(o), Object.getPrototypeOf(o) === proto];
+          }
+          return <div>{JSON.stringify(shapes)}</div>;
+        }
+        const proto = {};
+        console.log(Comp({ id: "v", proto }).p.children);
+      `,
+      ...stubReact,
+    },
+    reactCompiler: true,
+    target: "browser",
+    backend: "api",
+    run: {
+      stdout: JSON.stringify({
+        computed: [["__proto__"], false],
+        template: [["__proto__"], false],
+        shorthand: [["__proto__"], false],
+        method: [["__proto__"], false],
+        setter: [[], true],
+        quotedSetter: [[], true],
+      }),
+    },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      // Comp must actually be compiled for the codegen path to be on trial.
+      expect(out).toContain("react.memo_cache_sentinel");
+      // computed, template and shorthand are emitted with a computed key; the
+      // two setters keep the bare key. (The method prints as `__proto__() {`.)
+      expect(out.match(/\[(["'`])__proto__\1\]/g) ?? []).toHaveLength(3);
+      expect(out.match(/(?<!\[)(["']?)__proto__\1\s*:/g) ?? []).toHaveLength(2);
+    },
+  });
 });


### PR DESCRIPTION
### Problem
- With the React Compiler enabled, an object literal in a compiled component or hook that writes `{ ["__proto__"]: v }` is emitted as `{ __proto__: v }`. The source defines an own property named `"__proto__"`; the output sets the object's prototype instead (and does nothing when `v` is not an object), so `Object.keys(o)` goes from `["__proto__"]` to `[]`. The same build without `reactCompiler` prints the key unchanged.
- The shorthand `{ __proto__ }` has the same problem once the value is no longer an identifier named `__proto__`. With `const __proto__ = "own"` the compiler inlines the constant and emits `{ __proto__: "own" }`, which drops the property. The identifier case only survives today because the printer happens to collapse `__proto__: __proto__` back to shorthand.
- Cause: the `EObject` arm of `lower_expression` (`src/react_compiler/lowering/build_hir/expr.rs`) lowers every string key through `lower_object_property_key` (`build_hir/helpers.rs`), which returns `ObjectPropertyKey::String` regardless of the `computed` argument, so the HIR no longer records that the key was computed or shorthand. `codegen_object_expression` (`src/react_compiler/codegen.rs`) only sets `Property::IsComputed` for `ObjectPropertyKey::Computed`, and a bare `__proto__` key is the prototype-setter form. For any other name the two spellings are equivalent; `__proto__` is the one name where they are not.
- Upstream's Babel plugin has the same behavior (`lowerObjectPropertyKey` matches `StringLiteral` before it looks at `computed`), so the fixture suite does not cover it.

### Fix
- In the `EObject` arm of `lower_expression`, a property whose key is the string `__proto__` and which is computed or was written as shorthand is lowered to `ObjectPropertyKey::Computed` (the key literal becomes a string `Primitive` temporary), so codegen emits `["__proto__"]: v`. Everything else still goes through `lower_object_property_key`.
- Correct because the condition is exactly the complement of the parser's own prototype-setter predicate (`visit_expr.rs`, the duplicate `__proto__` check: not computed, not shorthand, not a method). `{ __proto__: v }` and `{ "__proto__": v }` still lower to a static key and still set the prototype; methods take `lower_object_method` and are never setters, so they are untouched.
- The resulting HIR is a shape the compiler already produces and emits: `const k = "__proto__"; ({ [k]: v })` lowers to a computed key whose place is constant-folded to the string, and today's output for it is already `{ ["__proto__"]: v }` (see the upstream fixture `object-expression-computed-key-constant-string`). The emitted computed key is also immune to later symbol renaming in the bundle, unlike a shorthand property.
- Verified with `bun bd test`:
  - `test/bundler/transpiler/react-compiler.test.ts`, `react-compiler/OwnProtoKeyStaysOwnProperty`: one compiled component builds the computed, template-literal, shorthand and method own-property forms plus the identifier and quoted setter forms, and the bundle is run and prints each object's own keys and whether its prototype is the supplied object. It also checks the emitted text: three `["__proto__"]` keys and two bare `__proto__:` keys. On the unfixed build the computed, template and shorthand objects have no own keys and the bundle contains no computed key.
  - The rest of `react-compiler.test.ts` (37 tests) and `react-compiler-fixtures.test.ts` (3293 upstream fixtures, unchanged output) pass.
- Related, not overlapping: #36120 fixes the printer's own shorthand handling of `__proto__` for uncompiled code, #33052 the object literals the bundler itself generates for exports. This PR is about the object literals the React Compiler regenerates from HIR; neither of those changes what the compiler emits.

### Background
- `__proto__` in object literals: per Annex B, `{ __proto__: v }` and `{ "__proto__": v }` set the new object's `[[Prototype]]` to `v` (ignored when `v` is neither an object nor `null`). The computed `{ ["__proto__"]: v }`, the shorthand `{ __proto__ }` and the method `{ __proto__() {} }` forms create an ordinary own property. Bun's AST stores identifier and string keys both as `E::String`; the `IsComputed` and `WasShorthand` property flags are what distinguish the forms.
- React Compiler lowering: `src/react_compiler` rewrites each component or hook by lowering its body to HIR and generating a fresh AST from that HIR, so any distinction that is not carried into HIR is gone from the output. `ObjectPropertyKey` has `String`, `Identifier`, `Number` and `Computed` variants; `Computed` holds a `Place` (an HIR temporary) that codegen prints inside brackets, and a temporary holding a string constant is printed inline as the literal.

<details>
<summary>Repro on the unfixed build</summary>

```console
$ cat proto.tsx
export function P({ id }: { id: string }) {
  const o = { ["__proto__"]: id };
  return <a data-x={Object.keys(o).length}>{id}</a>;
}
$ bun build --react-compiler --external 'react' --external 'react/*' proto.tsx | grep proto__
      __proto__: id

$ bun build --external 'react' --external 'react/*' proto.tsx | grep proto__
  const o = { ["__proto__"]: id };
```

The test's component, bundled with `reactCompiler: true` and run, prints on the unfixed build:

```
{"computed":[[],false],"template":[[],false],"shorthand":[[],false],"method":[["__proto__"],false],"setter":[[],true],"quotedSetter":[[],true]}
```

and with this change:

```
{"computed":[["__proto__"],false],"template":[["__proto__"],false],"shorthand":[["__proto__"],false],"method":[["__proto__"],false],"setter":[[],true],"quotedSetter":[[],true]}
```

Emitted keys after the change: `["__proto__"]: id`, `` [`__proto__`]: id ``, `["__proto__"]: "own"`, `__proto__() {}`, `__proto__: proto`, `__proto__: proto`.

</details>
