### PR TITLE
install: leave URL credentials out of isolated store entry names

### DIFF
--- a/src/install/repository.rs
+++ b/src/install/repository.rs
@@ -13,6 +13,7 @@ use bun_semver::string::Buf as StringBuf;
 use crate::dependency as Dependency;
 use crate::hosted_git_info;
 use crate::install::{self as Install, ExtractData, PackageManager};
+use crate::resolution::fmt_store_url;
 
 // Thread-local scratch buffers. Callers return slices that outlive the access
 // (`try_ssh`/`try_https` hand a slice straight to `download`). `thread_local!`
@@ -1142,7 +1143,11 @@ impl<'a> fmt::Display for StorePathFormatter<'a> {
             writer.write_str("ssh++")?;
         }
 
-        write!(writer, "{}", self.repo.repo.fmt_store_path(self.string_buf))?;
+        write!(
+            writer,
+            "{}",
+            fmt_store_url(self.repo.repo.slice(self.string_buf))
+        )?;
 
         if !self.repo.resolved.is_empty() {
             writer.write_str("+")?; // this would be '#' but it's not valid on windows

--- a/src/install/resolution.rs
+++ b/src/install/resolution.rs
@@ -549,7 +549,7 @@ impl<'a, SemverInt: VersionInt> fmt::Display for StorePathFormatter<'a, SemverIn
                 write!(
                     writer,
                     "{}",
-                    res.remote_tarball().fmt_store_path(string_buf)
+                    fmt_store_url(res.remote_tarball().slice(string_buf))
                 )
             }
             Tag::Folder => write!(writer, "{}", res.folder().fmt_store_path(string_buf)),
@@ -572,6 +572,53 @@ impl<'a, SemverInt: VersionInt> fmt::Display for StorePathFormatter<'a, SemverIn
             }
             _ => Ok(()),
         }
+    }
+}
+
+/// Store path of a tarball or repository URL. The store path becomes a
+/// directory name (realpaths, stack traces, `bun pm` output), so the userinfo
+/// and the query string, which is where credentials go, are left out of it;
+/// when either was present, the hash of the complete URL takes their place so
+/// that URLs differing only in those parts still get separate entries:
+/// `https://user:token@host/pkg.tgz?token=x` becomes
+/// `https+++host+pkg.tgz+<16 hex>`. A URL without either part is spelled out
+/// unchanged.
+pub(crate) struct StoreURLFormatter<'a> {
+    url: &'a [u8],
+}
+
+pub(crate) fn fmt_store_url(url: &[u8]) -> StoreURLFormatter<'_> {
+    StoreURLFormatter { url }
+}
+
+impl fmt::Display for StoreURLFormatter<'_> {
+    fn fmt(&self, writer: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let url = self.url;
+
+        // RFC 3986: the authority follows `scheme://` (or, for an scp-like
+        // `user@host:path`, starts the string) and ends at the first `/`, `?`
+        // or `#`; the userinfo is everything in it up to the last `@`.
+        let authority_start = match strings::index_of_char_usize(url, b':') {
+            Some(colon) if url[colon + 1..].starts_with(b"//") => colon + b"://".len(),
+            _ => 0,
+        };
+        let authority_end = strings::index_of_any(&url[authority_start..], b"/?#")
+            .map_or(url.len(), |i| authority_start + i);
+        let host_start = strings::last_index_of_char(&url[authority_start..authority_end], b'@')
+            .map_or(authority_start, |at| authority_start + at + 1);
+        let query_start = strings::index_of_char_usize(&url[host_start..], b'?')
+            .map_or(url.len(), |i| host_start + i);
+
+        write!(
+            writer,
+            "{}{}",
+            semver::string::fmt_store_path(&url[..authority_start]),
+            semver::string::fmt_store_path(&url[host_start..query_start]),
+        )?;
+        if host_start != authority_start || query_start != url.len() {
+            write!(writer, "+{:016x}", bun_wyhash::hash(url))?;
+        }
+        Ok(())
     }
 }
 

--- a/src/semver/lib.rs
+++ b/src/semver/lib.rs
@@ -302,7 +302,7 @@ pub mod semver_string {
 
         #[inline]
         pub fn fmt_store_path<'a>(&'a self, buf: &'a [u8]) -> StorePathFormatter<'a> {
-            StorePathFormatter { buf, str: self }
+            fmt_store_path(self.slice(buf))
         }
 
         #[inline]
@@ -714,13 +714,17 @@ pub mod semver_string {
 
     // ── String.StorePathFormatter ─────────────────────────────────────────
     pub struct StorePathFormatter<'a> {
-        pub(crate) str: &'a String,
-        pub(crate) buf: &'a [u8],
+        bytes: &'a [u8],
+    }
+
+    /// Spells `bytes` as a single path component of the isolated store.
+    pub fn fmt_store_path(bytes: &[u8]) -> StorePathFormatter<'_> {
+        StorePathFormatter { bytes }
     }
 
     impl<'a> fmt::Display for StorePathFormatter<'a> {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            for &c in self.str.slice(self.buf) {
+            for &c in self.bytes {
                 let n = match c {
                     b'/' => b'+',
                     b'\\' => b'+',

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -4,7 +4,7 @@ import { existsSync, lstatSync, readlinkSync, statSync } from "fs";
 import { mkdir, readlink, rm, symlink } from "fs/promises";
 import { VerdaccioRegistry, bunEnv, bunExe, readdirSorted, runBunInstall, tempDir } from "harness";
 import { createRequire } from "module";
-import { dirname, join } from "path";
+import { basename, dirname, join } from "path";
 
 const registry = new VerdaccioRegistry();
 
@@ -23,6 +23,12 @@ function withoutEntryHash(link: string): string {
 // always differ) but the hash suffix is what proves sharing/isolation.
 function entryStoreName(link: string): string {
   return link.slice(link.lastIndexOf("links") + "links".length + 1);
+}
+
+// What a store entry name carries in place of its URL's userinfo and query
+// string (see "store entry names of URL dependencies").
+function urlHash(url: string): string {
+  return Bun.hash(url).toString(16).padStart(16, "0");
 }
 
 beforeAll(async () => {
@@ -2041,6 +2047,8 @@ test("transitive peer deps are resolved when resolution is fully synchronous", a
 // A tarball URL with a query string must not put a literal `?` in the .bun
 // store directory name: module resolution parses `?` as a query-string
 // delimiter (truncating the path), and `?` is invalid in Windows filenames.
+// (The query string is now left out of the name altogether, see "store entry
+// names of URL dependencies" below.)
 test("tarball URL with query string resolves at runtime", async () => {
   const tarball = file(join(import.meta.dir, "registry", "packages", "no-deps", "no-deps-1.0.0.tgz"));
 
@@ -2056,13 +2064,14 @@ test("tarball URL with query string resolves at runtime", async () => {
     },
   });
 
+  const url = `http://localhost:${server.port}/pkg.tgz?x=y`;
   using cacheDir = tempDir("tarball-query-cache-", {});
   using packageDir = tempDir("tarball-query-test-", {
     "bunfig.toml": `[install]\ncache = "${String(cacheDir).replaceAll("\\", "\\\\")}"\nlinker = "isolated"\n`,
     "package.json": JSON.stringify({
       name: "test-tarball-query",
       dependencies: {
-        "no-deps": `http://localhost:${server.port}/pkg.tgz?x=y`,
+        "no-deps": url,
       },
     }),
     "index.mjs": `import pkg from "no-deps";\nconsole.log(pkg.version);`,
@@ -2072,7 +2081,7 @@ test("tarball URL with query string resolves at runtime", async () => {
 
   const bunDir = join(String(packageDir), "node_modules", ".bun");
   const storeEntries = (await readdirSorted(bunDir)).filter(entry => entry !== "node_modules");
-  expect(storeEntries).toEqual([`no-deps@http+++localhost+${server.port}+pkg.tgz+x=y`]);
+  expect(storeEntries).toEqual([`no-deps@http+++localhost+${server.port}+pkg.tgz+${urlHash(url)}`]);
 
   await using proc = spawn({
     cmd: [bunExe(), "index.mjs"],
@@ -2085,6 +2094,217 @@ test("tarball URL with query string resolves at runtime", async () => {
   expect(stderr).toBe("");
   expect(stdout).toBe("1.0.0\n");
   expect(exitCode).toBe(0);
+});
+
+// The store entry of a tarball or git dependency is named after its URL, and
+// that name ends up in every path under the entry (realpaths, stack traces,
+// `bun pm` output). Credentials travel in the userinfo (`user:token@`) or the
+// query string (`?token=`), so those parts are left out of the name; the hash
+// of the complete URL takes their place (see `urlHash`), which also keeps URLs
+// that differ only in those parts in separate entries. A URL without either
+// part keeps the name it always had.
+describe("store entry names of URL dependencies", () => {
+  const installEnv = (dir: string, env: NodeJS.Dict<string> = bunEnv) => ({
+    ...env,
+    BUN_INSTALL_CACHE_DIR: join(dir, ".bun-cache"),
+  });
+
+  async function storeEntries(dir: string): Promise<string[]> {
+    return (await readdirSorted(join(dir, "node_modules", ".bun"))).filter(entry => entry !== "node_modules");
+  }
+
+  async function runIndexMjs(dir: string) {
+    await using proc = spawn({
+      cmd: [bunExe(), "index.mjs"],
+      cwd: dir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  // Serves the registry fixture `no-deps-<v>.tgz` at `/cdn/pkg.tgz?v=<v>`
+  // (1.0.0 without a query string), whatever else the query string contains.
+  function serveTarballs() {
+    return Bun.serve({
+      port: 0,
+      fetch(req) {
+        const { pathname, searchParams } = new URL(req.url);
+        if (pathname !== "/cdn/pkg.tgz") return new Response("not found", { status: 404 });
+        const version = searchParams.get("v") ?? "1.0.0";
+        return new Response(file(join(import.meta.dir, "registry", "packages", "no-deps", `no-deps-${version}.tgz`)));
+      },
+    });
+  }
+
+  // (A username without a password, `http://token@host:port/...`, is covered
+  // by the git cases below: the tarball downloader currently sends such a URL
+  // with the userinfo still in the Host header, which the server rejects.)
+  const tarballCases: [description: string, url: (port: number) => string, hashed: boolean][] = [
+    ["a plain URL", port => `http://127.0.0.1:${port}/cdn/pkg.tgz`, false],
+    ["a password in the URL", port => `http://carol:s3cret@127.0.0.1:${port}/cdn/pkg.tgz`, true],
+    ["a token in the query string", port => `http://127.0.0.1:${port}/cdn/pkg.tgz?token=npm_s3cret`, true],
+    [
+      "credentials in both places",
+      port => `http://carol:s3cret@127.0.0.1:${port}/cdn/pkg.tgz?token=npm_s3cret#fragment`,
+      true,
+    ],
+  ];
+
+  test.concurrent.each(tarballCases)("tarball dependency with %s", async (_, urlFor, hashed) => {
+    using server = serveTarballs();
+    const url = urlFor(server.port);
+    using dir = tempDir("store-name-tarball-", {
+      "bunfig.toml": `[install]\nlinker = "isolated"\n`,
+      "package.json": JSON.stringify({ name: "app", dependencies: { "no-deps": url } }),
+      "index.mjs": `import pkg from "no-deps";\nconsole.log(pkg.version);`,
+    });
+    const env = installEnv(String(dir));
+
+    await runBunInstall(env, String(dir));
+
+    const entry = `no-deps@http+++127.0.0.1+${server.port}+cdn+pkg.tgz${hashed ? `+${urlHash(url)}` : ""}`;
+    expect(await storeEntries(String(dir))).toEqual([entry]);
+    expect(readlinkSync(join(String(dir), "node_modules", "no-deps"))).toBe(
+      join(".bun", entry, "node_modules", "no-deps"),
+    );
+    // Only the directory is named differently; the dependency still resolves
+    // to the URL as written.
+    expect(await file(join(String(dir), "bun.lock")).text()).toContain(`no-deps@${url}`);
+    expect(await runIndexMjs(String(dir))).toEqual({ stdout: "1.0.0\n", stderr: "", exitCode: 0 });
+
+    // The next install derives the same name from the lockfile.
+    await runBunInstall(env, String(dir), { savesLockfile: false });
+    expect(await storeEntries(String(dir))).toEqual([entry]);
+  });
+
+  test.concurrent("tarball URLs that differ only in their query string get separate store entries", async () => {
+    using server = serveTarballs();
+    const base = `http://127.0.0.1:${server.port}/cdn/pkg.tgz`;
+    const urls = { "no-deps-v1": `${base}?v=1.0.0`, "no-deps-v2": `${base}?v=2.0.0` };
+    using dir = tempDir("store-name-tarball-query-", {
+      "bunfig.toml": `[install]\nlinker = "isolated"\n`,
+      "package.json": JSON.stringify({ name: "app", dependencies: urls }),
+      "index.mjs": `import v1 from "no-deps-v1";\nimport v2 from "no-deps-v2";\nconsole.log(v1.version, v2.version);`,
+    });
+
+    await runBunInstall(installEnv(String(dir)), String(dir));
+
+    expect(await storeEntries(String(dir))).toEqual(
+      Object.values(urls)
+        .map(url => `no-deps@http+++127.0.0.1+${server.port}+cdn+pkg.tgz+${urlHash(url)}`)
+        .sort(),
+    );
+    expect(await runIndexMjs(String(dir))).toEqual({ stdout: "1.0.0 2.0.0\n", stderr: "", exitCode: 0 });
+  });
+
+  test.concurrent("the global store entry of a tarball dependency is named the same way", async () => {
+    using server = serveTarballs();
+    const url = `http://carol:s3cret@127.0.0.1:${server.port}/cdn/pkg.tgz?token=npm_s3cret`;
+    using dir = tempDir("store-name-tarball-global-", {
+      "bunfig.toml": `[install]\nlinker = "isolated"\nglobalStore = true\n`,
+      "package.json": JSON.stringify({ name: "app", dependencies: { "no-deps": url } }),
+    });
+
+    await runBunInstall(installEnv(String(dir)), String(dir));
+
+    const entry = `no-deps@http+++127.0.0.1+${server.port}+cdn+pkg.tgz+${urlHash(url)}`;
+    expect(await storeEntries(String(dir))).toEqual([entry]);
+    // `node_modules/.bun/<entry>` links to `<cache>/links/<entry>-<entry hash>`.
+    const target = readlinkSync(join(String(dir), "node_modules", ".bun", entry));
+    expect(basename(dirname(target))).toBe("links");
+    expect(basename(target).slice(0, entry.length)).toBe(entry);
+    expect(basename(target).slice(entry.length)).toMatch(/^-[0-9a-f]{16}$/);
+    expect(await file(join(target, "node_modules", "no-deps", "package.json")).json()).toEqual({
+      name: "no-deps",
+      version: "1.0.0",
+    });
+  });
+
+  describe.skipIf(!gitExecutable)("git dependencies", () => {
+    const gitEnv = {
+      ...bunEnv,
+      GIT_CONFIG_NOSYSTEM: "1",
+      GIT_AUTHOR_NAME: "bun-test",
+      GIT_AUTHOR_EMAIL: "test@bun.sh",
+      GIT_COMMITTER_NAME: "bun-test",
+      GIT_COMMITTER_EMAIL: "test@bun.sh",
+    };
+
+    async function git(cwd: string, ...args: string[]): Promise<string> {
+      await using proc = spawn({ cmd: [gitExecutable!, ...args], cwd, env: gitEnv, stdout: "pipe", stderr: "pipe" });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("fatal:");
+      expect(exitCode).toBe(0);
+      return stdout;
+    }
+
+    // `<root>/repo.git`: a bare repository with one commit of the package
+    // `git-dep`, prepared for git's dumb HTTP protocol (after
+    // `git update-server-info` a bare repository is plain static files).
+    async function createBareRepo(root: string): Promise<{ bare: string; sha: string }> {
+      const src = join(root, "git-src");
+      const bare = join(root, "repo.git");
+      await write(join(src, "package.json"), JSON.stringify({ name: "git-dep", version: "1.0.0" }));
+      await git(src, "init", "-q");
+      await git(src, "add", "package.json");
+      await git(src, "commit", "-q", "-m", "init", "--no-gpg-sign");
+      const sha = (await git(src, "rev-parse", "HEAD")).trim();
+      await git(root, "clone", "-q", "--bare", src, bare);
+      await git(bare, "update-server-info");
+      return { bare, sha };
+    }
+
+    function serveBareRepo(bare: string) {
+      return Bun.serve({
+        port: 0,
+        async fetch(req) {
+          const { pathname } = new URL(req.url);
+          if (!pathname.startsWith("/repo.git/")) return new Response("not found", { status: 404 });
+          const f = file(join(bare, pathname.slice("/repo.git/".length)));
+          return (await f.exists()) ? new Response(f) : new Response("not found", { status: 404 });
+        },
+      });
+    }
+
+    const gitCases: [description: string, repo: (port: number) => string, hashed: boolean][] = [
+      ["a plain URL", port => `http://127.0.0.1:${port}/repo.git`, false],
+      ["a password in the URL", port => `http://carol:s3cret@127.0.0.1:${port}/repo.git`, true],
+      ["a token as the username", port => `http://ghp_s3cret@127.0.0.1:${port}/repo.git`, true],
+    ];
+
+    test.concurrent.each(gitCases)("git dependency with %s", async (_, repoFor, hashed) => {
+      using dir = tempDir("store-name-git-", {});
+      const { bare, sha } = await createBareRepo(String(dir));
+      using server = serveBareRepo(bare);
+      const repo = repoFor(server.port);
+      const project = join(String(dir), "project");
+      await write(
+        join(project, "package.json"),
+        JSON.stringify({ name: "app", dependencies: { "git-dep": `git+${repo}` } }),
+      );
+      await write(join(project, "bunfig.toml"), `[install]\nlinker = "isolated"\n`);
+      const env = installEnv(String(dir), gitEnv);
+
+      await runBunInstall(env, project);
+
+      const entry = `git-dep@git+http+++127.0.0.1+${server.port}+repo.git${hashed ? `+${urlHash(repo)}` : ""}+${sha}`;
+      expect(await storeEntries(project)).toEqual([entry]);
+      expect(readlinkSync(join(project, "node_modules", "git-dep"))).toBe(
+        join(".bun", entry, "node_modules", "git-dep"),
+      );
+      expect(await file(join(project, "node_modules", "git-dep", "package.json")).json()).toEqual({
+        name: "git-dep",
+        version: "1.0.0",
+      });
+      expect(await file(join(project, "bun.lock")).text()).toContain(`git-dep@git+${repo}#${sha}`);
+
+      await runBunInstall(env, project, { savesLockfile: false });
+      expect(await storeEntries(project)).toEqual([entry]);
+    });
+  });
 });
 
 describe("global virtual store", () => {


### PR DESCRIPTION
### Problem

- With `--linker isolated`, a dependency declared as a tarball URL with credentials, e.g. `"direct": "http://carol:s3cret@127.0.0.1:PORT/cdn/direct-1.0.0.tgz?token=npm_a1b2..."`, is installed into a store directory literally named `node_modules/.bun/no-deps@http+++carol+s3cret@127.0.0.1+PORT+cdn+direct-1.0.0.tgz+token=npm_a1b2...` (reproduced on 1.4.0-canary.1 and current main). A git dependency such as `git+https://carol:s3cret@host/org/repo.git` gets `repo@git+https+++carol+s3cret@host+org+repo.git+<commit>`.
- That directory name is part of the realpath of every file in the package, so the password and the token show up in stack traces, `import.meta.url`, `bun pm licenses` paths, the `--verbose` link failure messages, and `ls node_modules/.bun`. The output redaction in #38977 cannot cover this: these paths really exist on disk.
- Cause: the entry name is `<name>@<resolution store path>` (`src/install/isolated_install/Store.rs` `StoreKeyFormatter`). For a remote tarball the store path was the whole URL with `/ \ : # ?` turned into `+` (`src/install/resolution.rs` `StorePathFormatter`, via `bun_semver`'s `String::fmt_store_path` in `src/semver/lib.rs`), and for git it was the whole repository URL plus the commit (`src/install/repository.rs` `StorePathFormatter`). Nothing removed the userinfo or the query string.

### Fix

- `src/install/resolution.rs`: new `fmt_store_url`, used for the remote tarball store path and, in `src/install/repository.rs`, for the repository part of the git store path. It writes the URL without its userinfo and without its query string, and when either of them was present it appends `+<16 hex wyhash of the complete URL>`. The git commit suffix is unchanged and still follows. Examples: `http://carol:s3cret@h/p.tgz?token=x` becomes `no-deps@http+++h+p.tgz+<url hash>`; the same URL without credentials stays `no-deps@http+++h+p.tgz`; a credentialed git URL becomes `repo@git+https+++host+org+repo.git+<url hash>+<commit>`.
- `src/semver/lib.rs`: `String::fmt_store_path` now delegates to a byte-slice `fmt_store_path`, so the two kept pieces of the URL are spelled exactly the way the whole URL was before (one character mapping, no copy of it).
- Why this is correct:
  - The userinfo and the query string are the two places a URL carries credentials (`user:password@`, a bare token as the username, `?token=` / signed URLs); host, path and scheme are not secret, so they stay readable. The userinfo is delimited with RFC 3986's rule, the same one `find_url_password` in `bun_core` uses: the authority runs from `scheme://` (or from the start of an scp-like `user@host:path`) to the first `/`, `?` or `#`, and the userinfo is everything in it up to the last `@`. The whole userinfo goes, not only the password, because `https://TOKEN@host/...` is a documented way of passing tokens. `bun_url::URL::parse` was not used for this because it does not recognize the userinfo of `user@host:port` at all.
  - The name stays a function of the resolution alone, so a second install (whose resolution comes from the lockfile, which still stores the full URL) derives the same name and finds the same entry; the tests check this.
  - Whenever something is removed, the hash of the complete URL is appended, so two resolutions that used to get different names still get different names: `pkg.tgz?v=1` and `pkg.tgz?v=2` are different packages and must not share a directory, and even for git, where the commit usually disambiguates, `resolved` can be empty for packages migrated from pnpm/yarn lockfiles. Without either part there is nothing to disambiguate, so no hash is appended and every existing entry for a plain tarball, `git+file://`, `github:` or registry package keeps its name byte for byte.
  - Entries whose URL has a userinfo or a query string are renamed once by this change (that includes the common `git+ssh://git@host/...` form, whose `git@` is not a secret but cannot be told apart from a token); the next `bun install` links them under the new name and `bun pm prune` removes the old directories, since it removes every store entry the lockfile does not produce. The lockfile itself is untouched.
  - The hash sits inside the resolution part, so the consumers that read names back keep working: `bun pm prune` splits at `@` (`src/install/prune.rs` `split_store_key`; the names now also contain no second `@`), `bun pm licenses` re-derives the name through the same formatter (`src/runtime/cli/pm_licenses_command.rs`), and the global store derives its `links/<name>-<entry hash>` directory from the same name, so it is fixed as well. #38867 (bounding long names) would apply on top of this name.
- Verification, `test/cli/install/isolated-install.test.ts`, describe `store entry names of URL dependencies`:
  - tarball dependencies with a plain URL (name unchanged), a password, a token in the query string, and both plus a fragment: exact entry name computed with `Bun.hash`, the `node_modules` link points into it, `bun.lock` still contains the full URL, the package imports at runtime, and a second install keeps the name
  - two tarball URLs differing only in `?v=` get two entries and each alias resolves to its own version
  - with `install.globalStore`, the `links/` directory name is built from the credential-free name
  - git dependencies served over git's dumb HTTP protocol from a local bare repository: plain URL (name unchanged), password, and a token as the username, each with the exact name including the commit, the lockfile resolution, and a second install
  - the username-only tarball form (`http://token@host:port/x.tgz`) is exercised through the git cases only: the tarball downloader currently sends that URL with the userinfo still in the Host header and gets a 400, which is tracked separately (as is the fact that the downloader never sends URL credentials at all); neither affects this change
  - the existing #36987 test in the same file asserted the old `+x=y` name and now asserts the hashed one; its point (no literal `?` in the name, package resolves at runtime) is unchanged
  - On the released build, 8 of these 10 tests fail with the old names (the two plain URL cases pass by design); all pass with `bun bd test`. Also run with the change: the rest of `isolated-install.test.ts` (75 pass), `bun-pm-licenses.test.ts` (79 pass, it asserts the unchanged name of a plain tarball entry), `bun-prune.test.ts` (109 pass), `bun-install-git-deps.test.ts` (7 pass), `cargo clippy` and `cargo fmt --check` on `bun_install` and `bun_semver`, and `test/internal/source-lints`.

### Background

- Isolated linker: every package is materialized once under `node_modules/.bun/<entry>/node_modules/<name>` and everything that depends on it gets a symlink to that directory. `<entry>` is `<package name>@<store path of the resolution>`, optionally followed by `+<peer hash>`; with `install.globalStore` the entry is itself a symlink into `<cache>/links/<entry>-<entry hash>`.
- Resolution: the lockfile's record of where a package came from. For registry packages it is the version, which is why their entries read `name@1.2.3`; for tarball and git dependencies it is the URL as written in package.json (git: plus the resolved commit), which is what became the directory name here.
- Store path: the spelling of a resolution as one path component, done by replacing `/`, `\`, `:`, `#` and `?` with `+` (`bun_semver`'s `StorePathFormatter`); `http://h/p.tgz` reads `http+++h+p.tgz`.
- Userinfo: the `user:password@` part of a URL's authority (`scheme://userinfo@host:port/path?query#fragment`).
- wyhash: bun's default 64-bit hash (`bun_wyhash::hash`, what `Bun.hash()` computes), which is how the tests compute the expected names; the store already uses it for the peer hash suffix.

<details>
<summary>Reproduction on the released build</summary>

`package.json` with `{"dependencies": {"direct": "http://carol:s3cret@127.0.0.1:PORT/cdn/direct-1.0.0.tgz?token=npm_a1b2c3d4e5f6"}}`, a `Bun.serve` answering that path with a tarball, `bunfig.toml` with `install.linker = "isolated"`:

```
$ bun install        # 1.4.0-canary.1
+ direct@http://carol:s3cret@127.0.0.1:35767/cdn/direct-1.0.0.tgz?token=npm_a1b2c3d4e5f6
$ ls node_modules/.bun
no-deps@http+++carol+s3cret@127.0.0.1+35767+cdn+direct-1.0.0.tgz+token=npm_a1b2c3d4e5f6
node_modules
```

With this change the entry is `no-deps@http+++127.0.0.1+35767+cdn+direct-1.0.0.tgz+<16 hex>`. The cache folder for the same tarball was already credential-free (`@T@<hash>`).

</details>
