### PR TITLE
install: cache file: tarballs under the integrity the lockfile pins

### DIFF
--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -2248,6 +2248,11 @@ impl<'a> PackageInstall<'a> {
         package_id: PackageID,
         resolution_tag: resolution::Tag,
     ) -> bool {
+        // No entry can be named yet (a local tarball whose integrity the
+        // lockfile does not record); extracting it is what names one.
+        if self.cache_dir_subpath.is_empty() {
+            return true;
+        }
         let state = manager.get_preinstall_state(package_id);
         match state {
             crate::PreinstallState::Done => false,

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1117,7 +1117,8 @@ impl<'a> PackageInstaller<'a> {
 
         // If a newly computed integrity hash is available (e.g. for a GitHub
         // tarball) and the lockfile doesn't already have one, persist it so
-        // the lockfile gets re-saved with the hash.
+        // the lockfile gets re-saved with the hash. Must happen before the
+        // callbacks below: a local tarball's cache entry is named after it.
         if data.integrity.tag.is_supported() {
             let pkg_metas = self.lockfile_mut().packages.items_meta_mut();
             if !pkg_metas[package_id as usize].integrity.tag.is_supported() {
@@ -1523,9 +1524,8 @@ impl<'a> PackageInstaller<'a> {
                 }
             }
             resolution::Tag::LocalTarball => {
-                installer.cache_dir_subpath = package_manager::cached_tarball_folder_name(
-                    self.manager_mut(),
-                    *resolution.local_tarball(),
+                installer.cache_dir_subpath = package_manager::cached_local_tarball_folder_name(
+                    &self.metas[package_id as usize].integrity,
                     patch_contents_hash,
                 );
                 installer.cache_dir = package_manager::get_cache_directory(self.manager_mut());

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -203,7 +203,8 @@ use directories::attempt_to_create_package_json_and_open;
 pub use directories::{
     attempt_to_create_package_json, cached_git_folder_name, cached_git_folder_name_print,
     cached_git_folder_name_print_auto, cached_github_folder_name, cached_github_folder_name_print,
-    cached_github_folder_name_print_auto, cached_npm_package_folder_name,
+    cached_github_folder_name_print_auto, cached_local_tarball_folder_name,
+    cached_local_tarball_folder_name_print, cached_npm_package_folder_name,
     cached_npm_package_folder_name_print, cached_npm_package_folder_print_basename,
     cached_tarball_folder_name, cached_tarball_folder_name_print, compute_cache_dir_and_subpath,
     fetch_cache_directory_path, get_cache_directory, get_cache_directory_and_abs_path,

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -11,7 +11,7 @@ use bun_core::{Global, Output, ZBox, env_var, fmt as bun_fmt};
 use bun_dotenv::Loader as DotEnvLoader;
 use bun_install::lockfile::{Format as LockfileFormat, LoadResult, Lockfile};
 use bun_install::resolution::Tag as ResolutionTag;
-use bun_install::{PackageID, Resolution};
+use bun_install::{Integrity, PackageID, Resolution};
 use bun_paths::{self as path, AbsPath, PathBuffer, SEP};
 use bun_semver::{self as Semver, String as SemverString};
 #[cfg(windows)]
@@ -487,6 +487,14 @@ impl<'a> ByteCursor<'a> {
         self.put(bun_fmt::u64_hex_var_lower(&mut tmp, n));
     }
 
+    /// Two lower-hex digits per byte.
+    #[inline(always)]
+    fn put_hex_bytes(&mut self, bytes: &[u8]) {
+        let end = self.at + bytes.len() * 2;
+        bun_fmt::bytes_to_hex_lower(bytes, &mut self.buf[self.at..end]);
+        self.at = end;
+    }
+
     /// `@@@{d}` when set.
     #[inline(always)]
     fn put_cache_version(&mut self, v: Option<usize>) {
@@ -725,6 +733,8 @@ pub fn cached_npm_package_folder_print_basename<'a>(
     w.finish_z()
 }
 
+/// `@T@<hash of the URL>@@@1`, for URL tarballs. `file:` tarballs use
+/// `cached_local_tarball_folder_name_print`.
 pub fn cached_tarball_folder_name_print<'a>(
     buf: &'a mut [u8],
     url: &[u8],
@@ -748,6 +758,43 @@ pub fn cached_tarball_folder_name(
         this.lockfile.str(&url),
         patch_hash,
     )
+}
+
+/// `@T@sha512-<first 16 digest bytes as hex>@@@1`.
+///
+/// A `file:` tarball's resolution is the path as written in package.json
+/// (`pkg.tgz`), which names a different tarball in every project sharing the
+/// cache, so unlike a URL tarball it is cached under the integrity bun.lock
+/// pins for it: the entry is only reused for the bytes it was extracted from.
+///
+/// Empty when the integrity is not known yet (lockfile written before tarball
+/// integrity was recorded). Callers treat that like a cache miss: extracting the
+/// tarball computes the integrity, and the install callbacks record it in the
+/// lockfile before installing from the entry named after it.
+pub fn cached_local_tarball_folder_name_print<'a>(
+    buf: &'a mut [u8],
+    integrity: &Integrity,
+    patch_hash: Option<u64>,
+) -> &'a ZStr {
+    let Some(algorithm) = integrity.tag.name() else {
+        return ZStr::EMPTY;
+    };
+    let digest = integrity.slice();
+    let mut w = ByteCursor::new(buf);
+    w.put(b"@T@");
+    w.put(algorithm.as_bytes());
+    w.put_byte(b'-');
+    w.put_hex_bytes(&digest[..digest.len().min(16)]);
+    w.put_cache_version(Some(CacheVersion::CURRENT));
+    w.put_patch_hash(patch_hash);
+    w.finish_z()
+}
+
+pub fn cached_local_tarball_folder_name(
+    integrity: &Integrity,
+    patch_hash: Option<u64>,
+) -> &'static ZStr {
+    cached_local_tarball_folder_name_print(cached_package_folder_name_buf(), integrity, patch_hash)
 }
 
 pub fn is_folder_in_cache(this: &mut PackageManager, folder_path: &ZStr) -> bool {
@@ -947,6 +994,7 @@ pub fn compute_cache_dir_and_subpath<'a>(
     manager: &mut PackageManager,
     pkg_name: &[u8],
     resolution: &Resolution,
+    integrity: &Integrity,
     folder_path_buf: &'a mut PathBuffer,
     patch_hash: Option<u64>,
 ) -> CacheDirAndSubpath<'a> {
@@ -986,8 +1034,20 @@ pub fn compute_cache_dir_and_subpath<'a>(
             cache_dir = Fd::cwd();
         }
         ResolutionTag::LocalTarball => {
-            let tarball = *resolution.local_tarball();
-            cache_dir_subpath = cached_tarball_folder_name(manager, tarball, patch_hash);
+            cache_dir_subpath = cached_local_tarball_folder_name(integrity, patch_hash);
+            if cache_dir_subpath.is_empty() {
+                Output::err_generic(
+                    "the lockfile does not record an integrity for <b>{}@{}<r>, run <cyan>bun install<r> first",
+                    (
+                        bun_fmt::s(name),
+                        resolution.fmt(
+                            manager.lockfile.buffers.string_bytes.as_slice(),
+                            bun_fmt::PathSep::Posix,
+                        ),
+                    ),
+                );
+                Global::exit(1);
+            }
             cache_dir = get_cache_directory(manager);
         }
         ResolutionTag::RemoteTarball => {

--- a/src/install/PackageManager/PackageManagerLifecycle.rs
+++ b/src/install/PackageManager/PackageManagerLifecycle.rs
@@ -140,9 +140,8 @@ impl PackageManager {
                             patch_hash,
                         )
                     }
-                    ResolutionTag::LocalTarball => directories::cached_tarball_folder_name(
-                        self,
-                        *pkg.resolution.local_tarball(),
+                    ResolutionTag::LocalTarball => directories::cached_local_tarball_folder_name(
+                        &pkg.meta.integrity,
                         patch_hash,
                     ),
                     ResolutionTag::RemoteTarball => directories::cached_tarball_folder_name(

--- a/src/install/PackageManager/patchPackage.rs
+++ b/src/install/PackageManager/patchPackage.rs
@@ -270,8 +270,14 @@ pub fn do_patch_commit(
     // `compute_cache_dir_and_subpath` resolves `pkg.resolution`'s strings against `manager.lockfile`.
     manager.lockfile = lockfile;
     let name = manager.lockfile.str(&pkg.name).to_vec();
-    let cache_result =
-        compute_cache_dir_and_subpath(manager, &name, &pkg.resolution, &mut folder_path_buf, None);
+    let cache_result = compute_cache_dir_and_subpath(
+        manager,
+        &name,
+        &pkg.resolution,
+        &pkg.meta.integrity,
+        &mut folder_path_buf,
+        None,
+    );
     let cache_dir: Fd = cache_result.cache_dir;
     let cache_dir_subpath: &ZStr = cache_result.cache_dir_subpath;
     let changes_dir: &[u8] = &changes_dir;
@@ -858,6 +864,7 @@ pub fn prepare_patch(manager: &mut PackageManager) -> Result<(), crate::Error> {
                     manager,
                     &name,
                     &actual_package.resolution,
+                    &actual_package.meta.integrity,
                     &mut folder_path_buf,
                     existing_patchfile_hash,
                 );
@@ -914,10 +921,12 @@ pub fn prepare_patch(manager: &mut PackageManager) -> Result<(), crate::Error> {
                 };
 
                 let pkg_resolution = pkg.resolution;
+                let pkg_integrity = pkg.meta.integrity;
                 let cache_result = compute_cache_dir_and_subpath(
                     manager,
                     &pkg_name,
                     &pkg_resolution,
+                    &pkg_integrity,
                     &mut folder_path_buf,
                     existing_patchfile_hash,
                 );

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -110,7 +110,11 @@ pub trait RunTasksCallbacks {
     ) {
         unreachable!()
     }
-    fn on_extract_store_installer(_ctx: &mut Self::Ctx, _task_id: Task::Id) {
+    fn on_extract_store_installer(
+        _ctx: &mut Self::Ctx,
+        _task_id: Task::Id,
+        _data: &bun_install::ExtractData,
+    ) {
         unreachable!()
     }
 
@@ -1146,7 +1150,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                             log_level,
                         );
                     } else if C::IS_STORE_INSTALLER {
-                        C::on_extract_store_installer(extract_ctx, task.id);
+                        C::on_extract_store_installer(extract_ctx, task.id, task.data_extract());
                     } else {
                         unreachable!("unexpected context type");
                     }
@@ -1475,7 +1479,11 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                             log_level,
                         );
                     } else if C::IS_STORE_INSTALLER {
-                        C::on_extract_store_installer(extract_ctx, task.id);
+                        C::on_extract_store_installer(
+                            extract_ctx,
+                            task.id,
+                            task.data_git_checkout(),
+                        );
                     } else {
                         unreachable!("unexpected context type");
                     }

--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -1153,12 +1153,14 @@ impl TarballStream {
 
             let (name, basename) = tarball.name_and_basename();
 
+            let integrity = tarball.lockfile_integrity(|| self.hasher.final_());
             let mut result = match tarball.move_to_cache_directory(
                 &mut (*task).log,
                 self.tmpname.as_zstr(),
                 name,
                 basename,
                 self.resolved_github_dirname,
+                &integrity,
             ) {
                 Ok(r) => r,
                 Err(err) => {
@@ -1167,19 +1169,7 @@ impl TarballStream {
                     return;
                 }
             };
-
-            match tarball.resolution.tag {
-                ResolutionTag::Github
-                | ResolutionTag::RemoteTarball
-                | ResolutionTag::LocalTarball => {
-                    if tarball.integrity.tag.is_supported() {
-                        result.integrity = tarball.integrity;
-                    } else {
-                        result.integrity = self.hasher.final_();
-                    }
-                }
-                _ => {}
-            }
+            result.integrity = integrity;
 
             if PackageManager::verbose_install() {
                 bun_core::pretty_errorln!(

--- a/src/install/extract_tarball.rs
+++ b/src/install/extract_tarball.rs
@@ -57,28 +57,30 @@ impl ExtractTarball {
                 return Err(crate::Error::IntegrityCheckFailed);
             }
         }
-        let mut result = self.extract(log, bytes)?;
+        let integrity = self.lockfile_integrity(|| Integrity::for_bytes(bytes));
+        let mut result = self.extract(log, bytes, &integrity)?;
+        result.integrity = integrity;
+        Ok(result)
+    }
 
-        // Compute and store SHA-512 integrity hash for GitHub / URL / local tarballs
-        // so the lockfile can pin the exact tarball content. On subsequent installs
-        // the hash stored in the lockfile is forwarded via this.integrity and verified
-        // above, preventing a compromised server from silently swapping the tarball.
+    /// The integrity the lockfile records for a GitHub / URL / local tarball, so
+    /// later installs verify the same bytes (see `run`). That is the value the
+    /// lockfile already pins (verified before extraction), or else `compute` from
+    /// the bytes on the first install. A local tarball's cache entry is named
+    /// after it (`move_to_cache_directory`), which is why it is settled before
+    /// extracting. Unknown for npm packages, whose integrity comes from the
+    /// registry manifest.
+    pub(crate) fn lockfile_integrity(&self, compute: impl FnOnce() -> Integrity) -> Integrity {
         match self.resolution.tag {
             ResolutionTag::Github | ResolutionTag::RemoteTarball | ResolutionTag::LocalTarball => {
                 if self.integrity.tag.is_supported() {
-                    // Re-installing with an existing lockfile: integrity was already
-                    // verified above, propagate the known value to ExtractData so that
-                    // the lockfile keeps it on re-serialisation.
-                    result.integrity = self.integrity;
+                    self.integrity
                 } else {
-                    // First install (no integrity in the lockfile yet): compute it.
-                    result.integrity = Integrity::for_bytes(bytes);
+                    compute()
                 }
             }
-            _ => {}
+            _ => Integrity::default(),
         }
-
-        Ok(result)
     }
 }
 
@@ -225,7 +227,12 @@ impl ExtractTarball {
         (name, basename)
     }
 
-    fn extract(&self, log: &mut bun_ast::Log, tgz_bytes: &[u8]) -> Result<ExtractData, Error> {
+    fn extract(
+        &self,
+        log: &mut bun_ast::Log,
+        tgz_bytes: &[u8],
+        integrity: &Integrity,
+    ) -> Result<ExtractData, Error> {
         let _tracer = bun_core::perf::trace("ExtractTarball.extract");
 
         let tmpdir = Dir::borrow(&self.temp_dir);
@@ -439,12 +446,16 @@ impl ExtractTarball {
             }
         }
 
-        self.move_to_cache_directory(log, tmpname, name, basename, resolved)
+        self.move_to_cache_directory(log, tmpname, name, basename, resolved, integrity)
     }
 
     /// Rename the freshly-extracted temp directory into the cache, read
     /// `package.json` if required, and build the `ExtractData` result. Shared
     /// between the buffered and streaming extraction paths.
+    ///
+    /// `resolved` (GitHub) and `integrity` (local tarballs, see
+    /// `lockfile_integrity`) name the cache entry for the resolutions whose
+    /// entries are keyed by content rather than by the resolution string.
     pub(crate) fn move_to_cache_directory(
         &self,
         log: &mut bun_ast::Log,
@@ -452,6 +463,7 @@ impl ExtractTarball {
         name: &[u8],
         basename: &[u8],
         resolved: &[u8],
+        integrity: &Integrity,
     ) -> Result<ExtractData, Error> {
         let package_manager = self.package_manager.get();
 
@@ -500,14 +512,18 @@ impl ExtractTarball {
                     )
                     .as_bytes()
                 }
-                ResolutionTag::LocalTarball | ResolutionTag::RemoteTarball => {
-                    directories::cached_tarball_folder_name_print(
-                        &mut bufs.folder_name_buf,
-                        self.url.slice(),
-                        None,
-                    )
-                    .as_bytes()
-                }
+                ResolutionTag::LocalTarball => directories::cached_local_tarball_folder_name_print(
+                    &mut bufs.folder_name_buf,
+                    integrity,
+                    None,
+                )
+                .as_bytes(),
+                ResolutionTag::RemoteTarball => directories::cached_tarball_folder_name_print(
+                    &mut bufs.folder_name_buf,
+                    self.url.slice(),
+                    None,
+                )
+                .as_bytes(),
                 _ => unreachable!(),
             };
             if folder_name.is_empty() || (folder_name.len() == 1 && folder_name[0] == b'/') {

--- a/src/install/integrity.rs
+++ b/src/install/integrity.rs
@@ -243,13 +243,11 @@ impl Integrity {
 
 impl fmt::Display for Integrity {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.tag {
-            Tag::SHA1 => f.write_str("sha1-")?,
-            Tag::SHA256 => f.write_str("sha256-")?,
-            Tag::SHA384 => f.write_str("sha384-")?,
-            Tag::SHA512 => f.write_str("sha512-")?,
-            _ => return Ok(()),
-        }
+        let Some(algorithm) = self.tag.name() else {
+            return Ok(());
+        };
+        f.write_str(algorithm)?;
+        f.write_str("-")?;
 
         let mut base64_buf = [0u8; 512];
         let bytes = self.slice();
@@ -291,6 +289,17 @@ impl Tag {
     #[inline]
     pub fn is_supported(self) -> bool {
         self.0 >= Tag::SHA1.0 && self.0 <= Tag::SHA512.0
+    }
+
+    /// The algorithm part of the SRI string (`sha512` in `sha512-...`); `None` for `UNKNOWN`.
+    pub(crate) fn name(self) -> Option<&'static str> {
+        Some(match self {
+            Tag::SHA1 => "sha1",
+            Tag::SHA256 => "sha256",
+            Tag::SHA384 => "sha384",
+            Tag::SHA512 => "sha512",
+            _ => return None,
+        })
     }
 
     pub(crate) fn parse(buf: &[u8]) -> (Tag, usize) {

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -143,8 +143,12 @@ impl<'a> run_tasks::RunTasksCallbacks for StoreRunTasksCallbacks<'a> {
     const HAS_ON_PACKAGE_DOWNLOAD_ERROR: bool = true;
     const IS_STORE_INSTALLER: bool = true;
 
-    fn on_extract_store_installer(ctx: &mut Self::Ctx, task_id: Task::Id) {
-        ctx.on_package_extracted(task_id);
+    fn on_extract_store_installer(
+        ctx: &mut Self::Ctx,
+        task_id: Task::Id,
+        data: &install::ExtractData,
+    ) {
+        ctx.on_package_extracted(task_id, data);
     }
 
     fn on_package_download_error_store(
@@ -2334,11 +2338,12 @@ pub(crate) fn install_isolated_packages(
                             pkg_res.github(),
                             None,
                         ),
-                        ResolutionTag::LocalTarball => package_manager::cached_tarball_folder_name(
-                            installer.manager(),
-                            *pkg_res.local_tarball(),
-                            None,
-                        ),
+                        ResolutionTag::LocalTarball => {
+                            package_manager::cached_local_tarball_folder_name(
+                                &pkgs.items_meta()[pkg_id as usize].integrity,
+                                None,
+                            )
+                        }
                         ResolutionTag::RemoteTarball => {
                             package_manager::cached_tarball_folder_name(
                                 installer.manager(),
@@ -2353,23 +2358,26 @@ pub(crate) fn install_isolated_packages(
                         installer.manager_mut().get_cache_directory_and_abs_path();
                     let _ = &cache_dir_path; // dropped at scope exit
 
-                    let missing_from_cache = match installer.manager().get_preinstall_state(pkg_id)
-                    {
-                        install::PreinstallState::Done => false,
-                        _ => {
-                            let exists = package_manager::directories::is_package_in_cache_at(
-                                cache_dir,
-                                cache_subpath_z,
-                                pkg_res_tag,
-                            );
-                            if exists {
-                                installer
-                                    .manager_mut()
-                                    .set_preinstall_state(pkg_id, install::PreinstallState::Done);
+                    // An empty name is a local tarball whose integrity the lockfile
+                    // does not record; extracting it is what names its entry.
+                    let missing_from_cache = cache_subpath_z.is_empty()
+                        || match installer.manager().get_preinstall_state(pkg_id) {
+                            install::PreinstallState::Done => false,
+                            _ => {
+                                let exists = package_manager::directories::is_package_in_cache_at(
+                                    cache_dir,
+                                    cache_subpath_z,
+                                    pkg_res_tag,
+                                );
+                                if exists {
+                                    installer.manager_mut().set_preinstall_state(
+                                        pkg_id,
+                                        install::PreinstallState::Done,
+                                    );
+                                }
+                                !exists
                             }
-                            !exists
-                        }
-                    };
+                        };
 
                     if !missing_from_cache {
                         if let installer::PatchInfo::Patch(patch) = &patch_info {

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -36,7 +36,7 @@ use super::symlinker::{self, Symlinker};
 use crate::bun_fs;
 use crate::lockfile_real::package::PackageColumns as _;
 use crate::package_manager_real::directories;
-use crate::package_manager_real::package_manager_options::Do;
+use crate::package_manager_real::package_manager_options::{Do, Enable};
 
 /// The enum lives at module level in `crate::resolution`.
 type ResolutionTag = resolution::Tag;
@@ -70,7 +70,9 @@ pub struct Installer<'a> {
     /// pool and each task derefs this field; a `&'a mut` would assert
     /// exclusivity every concurrent task violates. Mutated only for
     /// `lockfile.trusted_dependencies` (under `trusted_dependencies_mutex`,
-    /// narrowed via `addr_of_mut!`). Never null. Read via `lockfile()`.
+    /// narrowed via `addr_of_mut!`) and, on the main thread, a not-yet-started
+    /// package's `meta.integrity` (`record_extracted_integrity`, one row via
+    /// the raw column pointer). Never null. Read via `lockfile()`.
     pub lockfile: *mut Lockfile,
 
     pub(crate) summary: InstallSummary,
@@ -181,7 +183,11 @@ impl<'a> Installer<'a> {
         self.start_task(entry_id);
     }
 
-    pub(crate) fn on_package_extracted(&mut self, task_id: crate::package_manager_task::Id) {
+    pub(crate) fn on_package_extracted(
+        &mut self,
+        task_id: crate::package_manager_task::Id,
+        data: &install::ExtractData,
+    ) {
         if let Some(removed) = self.manager_mut().task_queue.remove(&task_id) {
             let store = self.store;
 
@@ -205,6 +211,11 @@ impl<'a> Installer<'a> {
 
                 let node_id = entry_node_ids[entry_id.get() as usize];
                 let pkg_id = node_pkg_ids[node_id.get() as usize];
+
+                if data.integrity.tag.is_supported() {
+                    self.record_extracted_integrity(pkg_id, &data.integrity);
+                }
+
                 let pkg_name = pkg_names[pkg_id as usize];
                 let pkg_name_hash = pkg_name_hashes[pkg_id as usize];
                 let pkg_res = &pkg_resolutions[pkg_id as usize];
@@ -228,6 +239,42 @@ impl<'a> Installer<'a> {
                 self.start_task(entry_id);
             }
         }
+    }
+
+    /// Main thread, before the package's tasks start. The counterpart of the
+    /// integrity write-back in `PackageInstaller::install_enqueued_packages_after_extraction`:
+    /// a lockfile written before tarball integrity was recorded has none for the
+    /// package, so the extraction computed it. A local tarball's cache entry is
+    /// named after it (`cached_local_tarball_folder_name`), so the tasks need it
+    /// in place, and the lockfile is re-saved with it.
+    fn record_extracted_integrity(&mut self, pkg_id: PackageID, integrity: &install::Integrity) {
+        let pkgs = self.lockfile().packages.slice();
+        assert!((pkg_id as usize) < pkgs.len());
+        // SAFETY: `items_raw` carries the column's root provenance, so this
+        // field access needs no `&mut Lockfile`. Only a package's own tasks
+        // read its `integrity` (to name the cache entry), and none of this
+        // package's tasks have started: every entry of it waited on the
+        // extraction being reported. Tasks of other packages running on the
+        // pool hold `&[Meta]` over the column but only touch other bytes.
+        // `pkg_id` is in bounds per the assert above.
+        let recorded = unsafe {
+            core::ptr::addr_of_mut!(
+                (*pkgs
+                    .items_raw::<"meta", package::Meta>()
+                    .add(pkg_id as usize))
+                .integrity
+            )
+        };
+        // SAFETY: see above.
+        if unsafe { (*recorded).tag.is_supported() } {
+            return;
+        }
+        // SAFETY: see above.
+        unsafe { recorded.write(*integrity) };
+        self.manager_mut()
+            .options
+            .enable
+            .set(Enable::FORCE_SAVE_LOCKFILE, true);
     }
 
     /// Called from main thread when a tarball download or extraction fails.
@@ -1132,9 +1179,13 @@ impl Task {
                                     patch_info.contents_hash(),
                                 ),
                                 ResolutionTag::LocalTarball => {
-                                    directories::cached_tarball_folder_name(
-                                        manager,
-                                        *pkg_res.local_tarball(),
+                                    // Recorded by the lockfile or by
+                                    // `on_package_extracted` before this task started.
+                                    debug_assert!(
+                                        pkg_metas[pkg_id as usize].integrity.tag.is_supported()
+                                    );
+                                    directories::cached_local_tarball_folder_name(
+                                        &pkg_metas[pkg_id as usize].integrity,
                                         patch_info.contents_hash(),
                                     )
                                 }

--- a/src/install/patch_install.rs
+++ b/src/install/patch_install.rs
@@ -760,16 +760,18 @@ impl PatchTask {
         let pkg_name_slice = pkg_name
             .slice(&pkg_manager.lockfile.buffers.string_bytes)
             .to_vec();
-        // `Resolution` is `Copy`; copy out so the lockfile borrow ends
+        // `Resolution` and `Integrity` are `Copy`; copy out so the lockfile borrow ends
         // before `compute_cache_dir_and_subpath` reborrows `pkg_manager` mutably.
         let resolution_clone: Resolution =
             pkg_manager.lockfile.packages.items_resolution()[pkg_id as usize];
+        let integrity = pkg_manager.lockfile.packages.items_meta()[pkg_id as usize].integrity;
 
         let mut folder_path_buf = PathBuffer::uninit();
         let stuff = package_manager::compute_cache_dir_and_subpath(
             pkg_manager,
             &pkg_name_slice,
             &resolution_clone,
+            &integrity,
             &mut folder_path_buf,
             Some(patch_hash),
         );

--- a/test/cli/install/bun-install-tarball-integrity.test.ts
+++ b/test/cli/install/bun-install-tarball-integrity.test.ts
@@ -493,6 +493,132 @@ describe.concurrent("tarball integrity", () => {
   });
 });
 
+// A `file:` tarball's resolution is the path written in package.json (`pkg.tgz`),
+// which names a different tarball in every project sharing the cache, and an
+// install from a lockfile never reads the tarball itself. So the cache entry is
+// keyed by the integrity the lockfile pins, not by that path: two projects (or two
+// branches of one project) with different tarballs at the same path get separate
+// entries, and a lockfile that does not pin an integrity cannot name an entry and
+// has the tarball read instead.
+describe.concurrent.each(["hoisted", "isolated"] as const)("local tarball cache entries (%s)", linker => {
+  async function tarball(exported: string) {
+    const tgz = await new Bun.Archive(
+      {
+        "package/package.json": JSON.stringify({ name: "pkg", version: "1.0.0" }),
+        "package/index.js": `module.exports = ${JSON.stringify(exported)};\n`,
+      },
+      { compress: "gzip" },
+    ).bytes();
+    const digest = createHash("sha512").update(tgz).digest();
+    return {
+      file: Buffer.from(tgz),
+      integrity: "sha512-" + digest.toString("base64"),
+      cacheEntry: `@T@sha512-${digest.subarray(0, 16).toString("hex")}@@@1`,
+    };
+  }
+
+  function project(tgz: Buffer, extraFiles: Record<string, string> = {}) {
+    return {
+      "package.json": JSON.stringify({ name: "app", dependencies: { pkg: "file:pkg.tgz" } }),
+      "pkg.tgz": tgz,
+      "bunfig.toml": Bun.TOML.stringify({ install: { linker } }),
+      ...extraFiles,
+    };
+  }
+
+  // The projects under `root` share `root/cache`.
+  async function install(root: string, name: string, ...args: string[]) {
+    await using proc = spawn({
+      cmd: [bunExe(), "install", ...args],
+      cwd: join(root, name),
+      env: { ...env, BUN_INSTALL_CACHE_DIR: join(root, "cache") },
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
+  }
+
+  const installedExport = (root: string, name: string) =>
+    file(join(root, name, "node_modules", "pkg", "index.js")).text();
+  const lockfile = (root: string, name: string) => file(join(root, name, "bun.lock")).text();
+  const reinstall = (root: string, name: string, ...args: string[]) =>
+    rm(join(root, name, "node_modules"), { recursive: true }).then(() => install(root, name, ...args));
+  const cacheEntries = async (root: string) =>
+    (await readdirSorted(join(root, "cache"))).filter(entry => entry.startsWith("@T@"));
+
+  it("keeps the tarballs of two projects that both depend on file:pkg.tgz apart", async () => {
+    const one = await tarball("one");
+    const two = await tarball("two");
+    using root = tempDir("local-tarball-two-projects", { one: project(one.file), two: project(two.file) });
+
+    await install(String(root), "one");
+    await install(String(root), "two");
+    expect(await lockfile(String(root), "one")).toContain(one.integrity);
+
+    await reinstall(String(root), "one");
+    expect(await installedExport(String(root), "one")).toBe('module.exports = "one";\n');
+    expect(await installedExport(String(root), "two")).toBe('module.exports = "two";\n');
+    expect(await cacheEntries(String(root))).toEqual([one.cacheEntry, two.cacheEntry].sort());
+  });
+
+  it("installs the tarball the lockfile pins after another build of it was extracted from the same path", async () => {
+    const v1 = await tarball("v1");
+    const v2 = await tarball("v2");
+    using root = tempDir("local-tarball-two-builds", { app: project(v1.file) });
+    const app = join(String(root), "app");
+
+    await install(String(root), "app");
+    const v1Lockfile = await lockfile(String(root), "app");
+    expect(v1Lockfile).toContain(v1.integrity);
+
+    // Like checking out a branch that ships v2: the rebuilt tarball is resolved and extracted.
+    await writeFile(join(app, "pkg.tgz"), v2.file);
+    await rm(join(app, "bun.lock"));
+    await reinstall(String(root), "app");
+    expect(await installedExport(String(root), "app")).toBe('module.exports = "v2";\n');
+    expect(await lockfile(String(root), "app")).toContain(v2.integrity);
+
+    // Back on the v1 branch, pkg.tgz and bun.lock are v1's again.
+    await writeFile(join(app, "pkg.tgz"), v1.file);
+    await writeFile(join(app, "bun.lock"), v1Lockfile);
+    await reinstall(String(root), "app");
+    expect(await installedExport(String(root), "app")).toBe('module.exports = "v1";\n');
+    expect(await cacheEntries(String(root))).toEqual([v1.cacheEntry, v2.cacheEntry].sort());
+  });
+
+  it("reads the tarball when the lockfile does not record its integrity, then records it", async () => {
+    const other = await tarball("other");
+    const mine = await tarball("mine");
+    using root = tempDir("local-tarball-unpinned", {
+      other: project(other.file),
+      app: project(mine.file, {
+        // Written before bun recorded the integrity of tarball packages.
+        "bun.lock": JSON.stringify({
+          lockfileVersion: 1,
+          configVersion: 1,
+          workspaces: { "": { name: "app", dependencies: { pkg: "file:pkg.tgz" } } },
+          packages: { pkg: ["pkg@pkg.tgz", {}] },
+        }),
+      }),
+    });
+
+    await install(String(root), "other");
+    await install(String(root), "app");
+    expect(await installedExport(String(root), "app")).toBe('module.exports = "mine";\n');
+    expect(await lockfile(String(root), "app")).toContain(mine.integrity);
+    expect(await cacheEntries(String(root))).toEqual([mine.cacheEntry, other.cacheEntry].sort());
+
+    // The recorded integrity names the entry that extraction created: this
+    // install is served from it without reading pkg.tgz (which would no longer
+    // match the pin).
+    await writeFile(join(String(root), "app", "pkg.tgz"), other.file);
+    await reinstall(String(root), "app");
+    expect(await installedExport(String(root), "app")).toBe('module.exports = "mine";\n');
+  });
+});
+
 describe.concurrent.each(["hoisted", "isolated"] as const)("tarball integrity mismatch (%s)", linker => {
   // Regression test for #29646 — with the isolated linker, a SHA-512 mismatch
   // during the resolve-phase tarball extract left `task_queue` /


### PR DESCRIPTION
### Problem
- With a `bun.lock` present, a `file:pkg.tgz` dependency is installed from whatever the shared install cache holds under `@T@<hash of "pkg.tgz">@@@1`. Two projects that both depend on `file:pkg.tgz` but ship different tarballs overwrite each other's entry, and the next lockfile install of one project gets the other project's tarball; the same happens to one project switching between branches whose `pkg.tgz` differs. `bun install` reports `1 package installed`, and the integrity in `bun.lock` is never compared against anything.
- Cause: `cached_tarball_folder_name_print` (`src/install/PackageManager/PackageManagerDirectories.rs`) hashes the resolution string, and a local tarball's resolution is the path as written in package.json (relative to the project, or to the workspace), which is not an identity across projects. Only extraction verifies the integrity, and a lockfile install only extracts when the entry is missing (`PackageInstall::package_missing_from_cache`, and the isolated installer's probe in `isolated_install.rs`).

### Fix
- Local tarballs are cached under the integrity recorded for the package: `@T@sha512-<first 16 digest bytes as hex>@@@1` (`cached_local_tarball_folder_name`), so the name equals `sha512sum pkg.tgz | cut -c1-32`. URL tarballs keep their URL-keyed names.
- Extraction names the entry after the integrity it just verified, or computed when the lockfile had none (`ExtractTarball::lockfile_integrity`, passed into `move_to_cache_directory` like the GitHub `resolved` name), which is also the value written to the lockfile. So an entry is only reused for the bytes the lockfile pins, different tarballs at the same path coexist, and identical tarballs in different projects share one entry. This is the same model as git checkouts, which are cached under their commit rather than under the URL they were requested by.
- A lockfile written before bun recorded tarball integrity cannot name an entry: the name is empty, both installers treat that as a cache miss and extract (`package_missing_from_cache`, the isolated probe; `determine_preinstall_state` already treated an empty name this way). The hoisted installer already recorded a computed integrity before re-running the waiting installs; the isolated installer now receives the extraction result (`on_extract_store_installer`) and does the same (`Installer::record_extracted_integrity`), so the entry can be named, the lockfile is re-saved with the integrity, and the next install is a cache hit. Under `--frozen-lockfile` such a lockfile keeps re-extracting the tarball and is left untouched.
- `compute_cache_dir_and_subpath` (`bun patch`, `bun patch --commit`) takes the package's integrity and reports a missing one instead of diffing or copying against the cache root. In the normal flow it is present, because `bun patch` installs first and that install records and saves it.
- `Integrity::Tag::name()` is shared between the folder name and `Display`; the `Display` output is unchanged.
- Verified with `test/cli/install/bun-install-tarball-integrity.test.ts`, `local tarball cache entries` for both linkers: two projects sharing a cache keep their tarballs apart, a project reinstalling from a lockfile after another build of the tarball was extracted from the same path gets the pinned build, and a lockfile without an integrity installs from the tarball, records the integrity, and is then served from the entry it recorded. All six fail on the unfixed build at the installed-contents assertion.
- Also run with the debug build: the rest of that file, `bun-patch.test.ts` (includes the `file:` tarball patch flow, which exercises the patched `..._patch_hash=` entries), `bun-install-patch.test.ts`, `bun-lock.test.ts`, the tarball tests of `bun-install.test.ts` (except the one fetching from the public internet, which fails identically without this change), `bun-add.test.ts` and `isolated-install.test.ts`, and the `file:` tarball migration tests in `migrate.test.ts` and `pnpm-lock-v9.test.ts`. Manually: `--frozen-lockfile` with a lockfile lacking the integrity (correct contents, lockfile untouched), `bun patch` plus `--commit` starting from such a lockfile, workspace-relative `file:` tarballs with both linkers, two aliases of one tarball, and `bun add ./pkg.tgz`. `cargo clippy -p bun_install` is clean.
- Existing caches are unaffected: the old `@T@<path hash>` entries are simply no longer looked up for local tarballs; each local tarball is extracted once more on its next install.

### Background
- Install cache: `~/.bun/install/cache` (or `BUN_INSTALL_CACHE_DIR`) is shared by every project on the machine. Each package is extracted once into a folder there (`name@version@@@1` for npm, `@G@<commit>` for git, `@T@...` for tarballs) and installs copy, hardlink or clone out of it; a cache hit is a directory probe, and the tarball bytes are verified only when the folder is created. `@@@1` is the cache layout version.
- Tarball integrity: for `file:` and URL tarballs bun hashes the tarball on first extraction and stores `sha512-...` as the third element of the package's `bun.lock` entry (`["pkg@pkg.tgz", {}, "sha512-..."]`); later extractions are verified against it. Lockfiles written before this was recorded, and some migrated lockfiles, have no integrity for these packages.
- Install phase callbacks: when a package has to be extracted during the install phase, the installs waiting on it are queued on the extraction task and re-run when it completes (`PackageInstaller::install_enqueued_packages_after_extraction` for the hoisted linker, `Installer::on_package_extracted` for the isolated one). The extraction result (`ExtractData`) carries the integrity that was verified or computed.
- Isolated installer threading: its per-package tasks run on the thread pool holding `&Lockfile` views, so the lockfile is only ever written through narrowed raw pointers from the main thread. `record_extracted_integrity` writes one row through the column's raw pointer (`items_raw`) before any task of that package starts.

<details>
<summary>Reproduction (no network)</summary>

```sh
export BUN_INSTALL_CACHE_DIR=/tmp/tgzcache
for v in one two; do
  mkdir -p $v/src/package
  echo '{"name":"pkg","version":"1.0.0"}' > $v/src/package/package.json
  echo "module.exports = '$v'" > $v/src/package/index.js
  tar -C $v/src -czf $v/pkg.tgz package
  echo '{"name":"app","dependencies":{"pkg":"file:pkg.tgz"}}' > $v/package.json
done
(cd one && bun install && bun -e 'console.log(require("pkg"))')   # one
(cd two && bun install && bun -e 'console.log(require("pkg"))')   # two
(cd one && rm -rf node_modules && bun install && bun -e 'console.log(require("pkg"))')
```

Before: the last line prints `two` (the cache holds one `@T@85f77fa09e18a07f@@@1`, last written by project two). After: `one`, and the cache holds one `@T@sha512-...@@@1` entry per tarball.
</details>
