### PR TITLE
install: read file: tarballs relative to the file: folder package that declares them

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1965,23 +1965,20 @@ fn enqueue_local_tarball(
     unsafe { &raw mut (*task).threadpool_task }
 }
 
-/// The directory `path` is relative to when that is not the top-level dir: the workspace or
-/// `file:` folder package whose package.json wrote it. An edge whose own specifier is not
-/// `path` got it from the root's overrides / resolutions / catalogs, so it stays relative
-/// to the top-level dir.
+/// The workspace or `file:` folder directory that `path` is relative to; `None` is the top-level dir.
 fn local_tarball_base_dir<'a>(
     lockfile: &'a Lockfile::Lockfile,
     dependency_id: DependencyID,
     path: &[u8],
 ) -> Option<&'a [u8]> {
     let declared = &lockfile.buffers.dependencies[dependency_id as usize].version;
-    if declared.tag != dependency::version::Tag::Tarball {
-        return None;
-    }
-    let dependency::tarball::Uri::Local(declared_path) = &declared.tarball().uri else {
-        return None;
-    };
-    if lockfile.str(declared_path) != path {
+    let declared_by_parent = declared.tag == dependency::version::Tag::Tarball
+        && matches!(
+            &declared.tarball().uri,
+            dependency::tarball::Uri::Local(declared_path) if lockfile.str(declared_path) == path
+        );
+    if !declared_by_parent {
+        // Overrides, resolutions and catalogs are all written in the root package.json.
         return None;
     }
 

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1965,13 +1965,10 @@ fn enqueue_local_tarball(
     unsafe { &raw mut (*task).threadpool_task }
 }
 
-/// A local tarball path is relative to the package.json that wrote it. When that is a
-/// workspace or a `file:` folder package, returns its directory relative to the top-level
-/// dir. `None` means the top-level dir itself: the root wrote the path, either as its own
-/// dependency or as an override / resolutions / catalog entry substituted for whatever the
-/// declaring package asked for (those only exist in the root package.json, so the declared
-/// specifier is then not this path), or the declaring package was extracted from the cache
-/// and has no directory in the project.
+/// The directory `path` is relative to when that is not the top-level dir: the workspace or
+/// `file:` folder package whose package.json wrote it. An edge whose own specifier is not
+/// `path` got it from the root's overrides / resolutions / catalogs, so it stays relative
+/// to the top-level dir.
 fn local_tarball_base_dir<'a>(
     lockfile: &'a Lockfile::Lockfile,
     dependency_id: DependencyID,

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1903,31 +1903,18 @@ fn enqueue_local_tarball(
     // other dependencies (e.g. `appendPackage` / `StringBuilder.allocate`
     // in `Package.fromNPM`).
     let mut abs_buf = PathBuffer::uninit();
-    let (tarball_path, normalize): (&[u8], bool) = 'tarball_path: {
-        let workspace_pkg_id = this
-            .lockfile
-            .get_workspace_pkg_if_workspace_dep(dependency_id);
-        if workspace_pkg_id == invalid_package_id {
-            break 'tarball_path (path, true);
-        }
-
-        let workspace_res = this.lockfile.packages.items_resolution()[workspace_pkg_id as usize];
-        if workspace_res.tag != ResolutionTag::Workspace {
-            break 'tarball_path (path, true);
-        }
-
-        // Construct an absolute path to the tarball.
-        // Normally tarball paths are always relative to the root directory, but if a
-        // workspace depends on a tarball path, it should be relative to the workspace.
-        let workspace_str = *workspace_res.workspace();
-        let workspace_path = workspace_str.slice(this.lockfile.buffers.string_bytes.as_slice());
-        let joined = Path::resolve_path::join_abs_string_buf::<Path::platform::Auto>(
-            FileSystem::instance().top_level_dir(),
-            &mut abs_buf,
-            &[workspace_path, path],
-        );
-        break 'tarball_path (joined, false);
-    };
+    let (tarball_path, normalize): (&[u8], bool) =
+        match local_tarball_base_dir(&this.lockfile, dependency_id, path) {
+            None => (path, true),
+            Some(base_dir) => (
+                Path::resolve_path::join_abs_string_buf::<Path::platform::Auto>(
+                    FileSystem::instance().top_level_dir(),
+                    &mut abs_buf,
+                    &[base_dir, path],
+                ),
+                false,
+            ),
+        };
 
     // Build the `Task` value *before* claiming a hive slot — the `.expect()`s
     // below can unwind, and `Task` carries drop glue. See `enqueue_git_clone`.
@@ -1976,6 +1963,39 @@ fn enqueue_local_tarball(
     let task = this.preallocated_resolve_tasks.get_init(value).as_ptr();
     // SAFETY: `get_init` just fully initialized the slot.
     unsafe { &raw mut (*task).threadpool_task }
+}
+
+/// A local tarball path is relative to the package.json that wrote it. When that is a
+/// workspace or a `file:` folder package, returns its directory relative to the top-level
+/// dir. `None` means the top-level dir itself: the root wrote the path, either as its own
+/// dependency or as an override / resolutions / catalog entry substituted for whatever the
+/// declaring package asked for (those only exist in the root package.json, so the declared
+/// specifier is then not this path), or the declaring package was extracted from the cache
+/// and has no directory in the project.
+fn local_tarball_base_dir<'a>(
+    lockfile: &'a Lockfile::Lockfile,
+    dependency_id: DependencyID,
+    path: &[u8],
+) -> Option<&'a [u8]> {
+    let declared = &lockfile.buffers.dependencies[dependency_id as usize].version;
+    if declared.tag != dependency::version::Tag::Tarball {
+        return None;
+    }
+    let dependency::tarball::Uri::Local(declared_path) = &declared.tarball().uri else {
+        return None;
+    };
+    if lockfile.str(declared_path) != path {
+        return None;
+    }
+
+    let declarer = lockfile.get_parent_pkg_of_dependency(dependency_id)?;
+    let declarer_res = &lockfile.packages.items_resolution()[declarer as usize];
+    let base_dir = match declarer_res.tag {
+        ResolutionTag::Workspace => declarer_res.workspace(),
+        ResolutionTag::Folder => declarer_res.folder(),
+        _ => return None,
+    };
+    Some(lockfile.str(base_dir))
 }
 
 fn update_name_and_name_hash_from_version_replacement(

--- a/src/install/PackageManagerTask.rs
+++ b/src/install/PackageManagerTask.rs
@@ -699,14 +699,10 @@ pub struct GitCheckoutRequest {
 
 pub struct LocalTarballRequest {
     pub(crate) tarball: ExtractTarball,
-    /// Path to read the tarball from. May be the same as `tarball.url` (when
-    /// `normalize` is true) or an absolute path joined with the directory of
-    /// the workspace or `file:` folder package that declared it
-    /// (`local_tarball_base_dir`). Computed on the main thread in
-    /// `enqueueLocalTarball` because resolving it requires reading
-    /// `lockfile.packages` / `string_bytes`, which can be reallocated
-    /// concurrently by the main thread while this task runs on a ThreadPool
-    /// worker.
+    /// `tarball.url` itself (`normalize` set) or the absolute path it was joined
+    /// into (`local_tarball_base_dir`). Computed on the main thread: resolving it
+    /// reads `lockfile.packages` / `string_bytes`, which the main thread may
+    /// reallocate while this task runs on a ThreadPool worker.
     pub(crate) tarball_path: StringOrTinyString,
     /// When true, `tarball_path` is a user-provided path resolved relative to
     /// cwd. When false, it is already an absolute path.

--- a/src/install/PackageManagerTask.rs
+++ b/src/install/PackageManagerTask.rs
@@ -700,11 +700,13 @@ pub struct GitCheckoutRequest {
 pub struct LocalTarballRequest {
     pub(crate) tarball: ExtractTarball,
     /// Path to read the tarball from. May be the same as `tarball.url` (when
-    /// `normalize` is true) or an absolute path joined with a workspace
-    /// directory. Computed on the main thread in `enqueueLocalTarball` because
-    /// resolving it requires reading `lockfile.packages` / `string_bytes`,
-    /// which can be reallocated concurrently by the main thread while this
-    /// task runs on a ThreadPool worker.
+    /// `normalize` is true) or an absolute path joined with the directory of
+    /// the workspace or `file:` folder package that declared it
+    /// (`local_tarball_base_dir`). Computed on the main thread in
+    /// `enqueueLocalTarball` because resolving it requires reading
+    /// `lockfile.packages` / `string_bytes`, which can be reallocated
+    /// concurrently by the main thread while this task runs on a ThreadPool
+    /// worker.
     pub(crate) tarball_path: StringOrTinyString,
     /// When true, `tarball_path` is a user-provided path resolved relative to
     /// cwd. When false, it is already an absolute path.

--- a/src/install/PackageManagerTask.rs
+++ b/src/install/PackageManagerTask.rs
@@ -699,8 +699,7 @@ pub struct GitCheckoutRequest {
 
 pub struct LocalTarballRequest {
     pub(crate) tarball: ExtractTarball,
-    /// `tarball.url` itself (`normalize` set) or the absolute path `enqueue_local_tarball`
-    /// resolved it to on the main thread; the worker must not read the lockfile for this.
+    /// Resolved by `enqueue_local_tarball` on the main thread; the worker must not read the lockfile.
     pub(crate) tarball_path: StringOrTinyString,
     /// When true, `tarball_path` is a user-provided path resolved relative to
     /// cwd. When false, it is already an absolute path.

--- a/src/install/PackageManagerTask.rs
+++ b/src/install/PackageManagerTask.rs
@@ -699,10 +699,8 @@ pub struct GitCheckoutRequest {
 
 pub struct LocalTarballRequest {
     pub(crate) tarball: ExtractTarball,
-    /// `tarball.url` itself (`normalize` set) or the absolute path it was joined
-    /// into (`local_tarball_base_dir`). Computed on the main thread: resolving it
-    /// reads `lockfile.packages` / `string_bytes`, which the main thread may
-    /// reallocate while this task runs on a ThreadPool worker.
+    /// `tarball.url` itself (`normalize` set) or the absolute path `enqueue_local_tarball`
+    /// resolved it to on the main thread; the worker must not read the lockfile for this.
     pub(crate) tarball_path: StringOrTinyString,
     /// When true, `tarball_path` is a user-provided path resolved relative to
     /// cwd. When false, it is already an absolute path.

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -782,6 +782,16 @@ impl Lockfile {
         self.get_workspace_pkg_if_workspace_dep(id) != invalid_package_id
     }
 
+    /// `None` for the edges `enqueue_dependency_to_root` appends outside of any package.
+    pub(crate) fn get_parent_pkg_of_dependency(&self, id: DependencyID) -> Option<PackageID> {
+        for (pkg_id, dependencies) in self.packages.items_dependencies().iter().enumerate() {
+            if dependencies.contains(id) {
+                return Some(PackageID::try_from(pkg_id).expect("int cast"));
+            }
+        }
+        None
+    }
+
     pub(crate) fn get_workspace_pkg_if_workspace_dep(&self, id: DependencyID) -> PackageID {
         let packages = self.packages.slice();
         let resolutions = packages.items_resolution();

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -10571,6 +10571,111 @@ it("fails when a transitive file: dependency's folder does not exist", async () 
   expect(exitCode).toBe(1);
 });
 
+describe.concurrent("file: tarball declared by a file: folder dependency", () => {
+  // `bar-0.0.2.tgz` is planted at the path the declaration means and
+  // `baz-0.0.3.tgz` at the other candidate path, so reading the tarball
+  // relative to the wrong directory installs `baz` instead of failing with ENOENT.
+  const expected = readFileSync(join(import.meta.dir, "bar-0.0.2.tgz"));
+  const decoy = readFileSync(join(import.meta.dir, "baz-0.0.3.tgz"));
+
+  const fixture = (root: object, lib: object, tarballs: Record<string, Buffer>) => ({
+    "package.json": JSON.stringify({
+      name: "my-app",
+      version: "1.0.0",
+      dependencies: { lib: "file:./vendor/lib" },
+      ...root,
+    }),
+    "vendor/lib/package.json": JSON.stringify({ name: "lib", version: "1.0.0", main: "index.js", ...lib }),
+    "vendor/lib/index.js": `const pkg = require("tool/package.json"); module.exports = pkg.name + "@" + pkg.version;`,
+    ...tarballs,
+  });
+
+  // The first install resolves `tool` from vendor/lib/package.json and reads
+  // the tarball in the process. The second one starts from the lockfile with
+  // an empty cache, so it has to read the tarball again from the path recorded
+  // there; both have to pick the same file.
+  async function installAndRequireLib(projectDir: string, linker: "hoisted" | "isolated") {
+    const cacheDir = join(projectDir, ".bun-cache");
+    const installed: string[] = [];
+
+    for (const args of [["install"], ["install", "--frozen-lockfile"]]) {
+      await Promise.all([
+        rm(join(projectDir, "node_modules"), { recursive: true, force: true }),
+        rm(cacheDir, { recursive: true, force: true }),
+      ]);
+
+      await using install = spawn({
+        cmd: [bunExe(), ...args, `--linker=${linker}`],
+        cwd: projectDir,
+        stdout: "pipe",
+        stderr: "pipe",
+        env: { ...env, BUN_INSTALL_CACHE_DIR: cacheDir },
+      });
+      const [installErr, installOut, installExit] = await Promise.all([
+        install.stderr.text(),
+        install.stdout.text(),
+        install.exited,
+      ]);
+      expect(installErr).not.toContain("error:");
+      expect(installOut).toContain("2 packages installed");
+      expect(installExit).toBe(0);
+
+      await using run = spawn({
+        cmd: [bunExe(), "-e", `console.log(require("lib"))`],
+        cwd: projectDir,
+        stdout: "pipe",
+        stderr: "pipe",
+        env,
+      });
+      const [runErr, runOut, runExit] = await Promise.all([run.stderr.text(), run.stdout.text(), run.exited]);
+      expect(runErr).toBe("");
+      expect(runExit).toBe(0);
+      installed.push(runOut.trim());
+    }
+
+    return { installed, lockfile: await file(join(projectDir, "bun.lock")).text() };
+  }
+
+  for (const linker of ["hoisted", "isolated"] as const) {
+    it(`is read relative to the folder (${linker} linker)`, async () => {
+      using dir = tempDir(
+        "folder-dep-tarball",
+        fixture(
+          {},
+          { dependencies: { tool: "file:./tool.tgz" } },
+          { "vendor/lib/tool.tgz": expected, "tool.tgz": decoy },
+        ),
+      );
+
+      const { installed, lockfile } = await installAndRequireLib(String(dir), linker);
+      expect(installed).toEqual(["bar@0.0.2", "bar@0.0.2"]);
+      // The lockfile records the path as declared; the name in front of it is
+      // read from the tarball that was extracted.
+      expect(lockfile).toContain('"lib": ["lib@file:vendor/lib", { "dependencies": { "tool": "file:./tool.tgz" } }]');
+      expect(lockfile).toContain('"tool": ["bar@./tool.tgz", {}, "sha512-');
+    });
+  }
+
+  it("is read relative to the project when a root override supplies the path", async () => {
+    // `overrides` can only be written in the root package.json, so the path it
+    // contains means the project directory even though the dependency it is
+    // applied to is declared by vendor/lib/package.json.
+    using dir = tempDir(
+      "folder-dep-tarball-override",
+      fixture(
+        { overrides: { tool: "file:./tool.tgz" } },
+        { dependencies: { tool: "^1.0.0" } },
+        { "tool.tgz": expected, "vendor/lib/tool.tgz": decoy },
+      ),
+    );
+
+    const { installed, lockfile } = await installAndRequireLib(String(dir), "hoisted");
+    expect(installed).toEqual(["bar@0.0.2", "bar@0.0.2"]);
+    expect(lockfile).toContain('"lib": ["lib@file:vendor/lib", { "dependencies": { "tool": "^1.0.0" } }]');
+    expect(lockfile).toContain('"tool": ["bar@./tool.tgz", {}, "sha512-');
+  });
+});
+
 it("does not extract a local file: tarball outside the temp dir for a dependency alias containing '..' path segments", async () => {
   // For `file:` tarball dependencies, the dependency alias (the key in
   // `dependencies`) is used to derive the temporary extraction folder name.

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -734,51 +734,47 @@ describe("relative tarballs", async () => {
       },
     });
   });
-  test.concurrent("from a root override applied to a workspace dependency", async () => {
-    using ctx = await setupTest();
-    const { packageDir, env } = ctx;
-    // The path comes from the root package.json, so it is relative to the root
-    // even though the dependency it replaces is declared by the workspace. The
-    // workspace gets a different tarball at the same relative path so reading
-    // it relative to the workspace installs `baz` instead of failing.
-    await Promise.all([
-      write(
-        join(packageDir, "package.json"),
-        JSON.stringify({
-          name: "foo",
-          workspaces: ["pkgs/*"],
-          overrides: { bar: "file:./bar.tgz" },
-        }),
-      ),
-      write(
-        join(packageDir, "pkgs", "pkg1", "package.json"),
-        JSON.stringify({
-          name: "pkg1",
-          dependencies: { bar: "^0.0.2" },
-        }),
-      ),
-      cp(join(import.meta.dir, "bar-0.0.2.tgz"), join(packageDir, "bar.tgz")),
-    ]);
-    await cp(join(import.meta.dir, "baz-0.0.3.tgz"), join(packageDir, "pkgs", "pkg1", "bar.tgz"));
-
-    // The second install starts from the lockfile and an empty cache, so it
-    // reads the tarball again from the path recorded there.
-    for (const frozenLockfile of [false, true]) {
+  // The tarball path is written in the root package.json, so it is relative to
+  // the root even though the dependency it ends up satisfying is declared by
+  // the workspace (#25835 for overrides, #25752 for catalogs). The workspace
+  // gets a different tarball at the same relative path, so reading it relative
+  // to the workspace installs `baz` instead of failing.
+  for (const [source, root, specifier] of [
+    ["override", { overrides: { bar: "file:./bar.tgz" } }, "^0.0.2"],
+    ["catalog entry", { catalogs: { vendored: { bar: "file:./bar.tgz" } } }, "catalog:vendored"],
+  ] as const) {
+    test.concurrent(`from a root ${source} applied to a workspace dependency`, async () => {
+      using ctx = await setupTest();
+      const { packageDir, env } = ctx;
       await Promise.all([
-        rm(join(packageDir, "node_modules"), { recursive: true, force: true }),
-        rm(env.BUN_INSTALL_CACHE_DIR, { recursive: true, force: true }),
+        write(join(packageDir, "package.json"), JSON.stringify({ name: "foo", workspaces: ["pkgs/*"], ...root })),
+        write(
+          join(packageDir, "pkgs", "pkg1", "package.json"),
+          JSON.stringify({ name: "pkg1", dependencies: { bar: specifier } }),
+        ),
+        cp(join(import.meta.dir, "bar-0.0.2.tgz"), join(packageDir, "bar.tgz")),
       ]);
+      await cp(join(import.meta.dir, "baz-0.0.3.tgz"), join(packageDir, "pkgs", "pkg1", "bar.tgz"));
 
-      await runBunInstall(env, packageDir, { frozenLockfile });
+      // The second install starts from the lockfile and an empty cache, so it
+      // reads the tarball again from the path recorded there.
+      for (const frozenLockfile of [false, true]) {
+        await Promise.all([
+          rm(join(packageDir, "node_modules"), { recursive: true, force: true }),
+          rm(env.BUN_INSTALL_CACHE_DIR, { recursive: true, force: true }),
+        ]);
 
-      expect(await file(join(packageDir, "node_modules", "bar", "package.json")).json()).toEqual({
-        name: "bar",
-        version: "0.0.2",
-      });
-    }
+        await runBunInstall(env, packageDir, { frozenLockfile });
 
-    expect(await file(join(packageDir, "bun.lock")).text()).toContain('"bar": ["bar@./bar.tgz", {}, "sha512-');
-  });
+        expect(await file(join(packageDir, "node_modules", "bar", "package.json")).json()).toEqual({
+          name: "bar",
+          version: "0.0.2",
+        });
+      }
+
+      expect(await file(join(packageDir, "bun.lock")).text()).toContain('"bar": ["bar@./bar.tgz", {}, "sha512-');
+    });
+  }
 
   // Regression test for a data race where the `.local_tarball` task callback
   // (running on a ThreadPool worker) read `lockfile.packages` and

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -734,6 +734,51 @@ describe("relative tarballs", async () => {
       },
     });
   });
+  test.concurrent("from a root override applied to a workspace dependency", async () => {
+    using ctx = await setupTest();
+    const { packageDir, env } = ctx;
+    // The path comes from the root package.json, so it is relative to the root
+    // even though the dependency it replaces is declared by the workspace. The
+    // workspace gets a different tarball at the same relative path so reading
+    // it relative to the workspace installs `baz` instead of failing.
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "foo",
+          workspaces: ["pkgs/*"],
+          overrides: { bar: "file:./bar.tgz" },
+        }),
+      ),
+      write(
+        join(packageDir, "pkgs", "pkg1", "package.json"),
+        JSON.stringify({
+          name: "pkg1",
+          dependencies: { bar: "^0.0.2" },
+        }),
+      ),
+      cp(join(import.meta.dir, "bar-0.0.2.tgz"), join(packageDir, "bar.tgz")),
+    ]);
+    await cp(join(import.meta.dir, "baz-0.0.3.tgz"), join(packageDir, "pkgs", "pkg1", "bar.tgz"));
+
+    // The second install starts from the lockfile and an empty cache, so it
+    // reads the tarball again from the path recorded there.
+    for (const frozenLockfile of [false, true]) {
+      await Promise.all([
+        rm(join(packageDir, "node_modules"), { recursive: true, force: true }),
+        rm(env.BUN_INSTALL_CACHE_DIR, { recursive: true, force: true }),
+      ]);
+
+      await runBunInstall(env, packageDir, { frozenLockfile });
+
+      expect(await file(join(packageDir, "node_modules", "bar", "package.json")).json()).toEqual({
+        name: "bar",
+        version: "0.0.2",
+      });
+    }
+
+    expect(await file(join(packageDir, "bun.lock")).text()).toContain('"bar": ["bar@./bar.tgz", {}, "sha512-');
+  });
 
   // Regression test for a data race where the `.local_tarball` task callback
   // (running on a ThreadPool worker) read `lockfile.packages` and


### PR DESCRIPTION
### Problem

- A `file:` folder dependency whose own package.json declares a local tarball fails to install (released 1.4.0 canary and main, both linkers): project package.json `{"dependencies":{"lib":"file:./vendor/lib"}}`, `vendor/lib/package.json` declaring `"tool": "file:./tool.tgz"`, `vendor/lib/tool.tgz` present:
  ```
  error: ENOENT extracting tarball from tool
  error: tool@file:./tool.tgz failed to resolve
  ```
- The path is read as `<project>/tool.tgz`. If that file happens to exist it is installed as `tool` instead of the folder's copy, with no error. The directory form of the same declaration (`"tool": "file:./tool"`) is already resolved relative to `vendor/lib`.
- Cause: `enqueue_local_tarball` (`src/install/PackageManager/PackageManagerEnqueue.rs`) picks the directory a local tarball path is relative to, and the only declarer it looked at was a workspace (`get_workspace_pkg_if_workspace_dep`). Every other declarer, including a `file:` folder package, fell through to the top-level dir.
- The same choice was also wrong in the other direction: a root `overrides` / `resolutions` entry or catalog entry pointing a dependency at `file:./x.tgz` was read relative to the workspace when the dependency it applied to was declared by a workspace member, so `overrides: { bar: "file:./bar.tgz" }` with `bar.tgz` in the project root failed with the same ENOENT as soon as a workspace depended on `bar`. This is #25835 (`overrides`) and #25752 (`catalogs`); both reproduce as reported on the released build and install with this change. The directory form of an override is already resolved relative to the project (`Folder` arm of `get_or_put_resolved_package`).

Fixes #25835
Fixes #25752

### Fix

- `enqueue_local_tarball` now takes the base directory from `local_tarball_base_dir`: the directory of the declaring package when it is a workspace or a `file:` folder package and that package's own specifier is the tarball path being read; the top-level dir in every other case.
- Why the declaring package: a path in a package.json means a file next to that package.json, which is what npm does for `file:` and what bun already does for workspace declarers and for the directory form. A `file:` folder package is read from the project like a workspace is, and its `Resolution::Folder` payload is its directory relative to the top-level dir (`folder_resolver.rs`, `NewResolver { folder_path: rel }`), the same shape as a workspace's `Resolution::Workspace` payload, so both are joined the same way. The only other `Resolution::Folder` packages are the stubs created for `file:` directories declared by something other than the root or a workspace (`Folder` arm of `get_or_put_resolved_package`); those carry no dependency list, so they are never the declarer of an edge.
- Why the "own specifier" condition: `overrides`, `resolutions` and catalogs are only parsed from the root package.json (`Package.rs`, `FEATURES.is_main`), and applying one leaves the declaring package's stored edge untouched (the replacement is local to `enqueue_dependency_with_main_and_success_fn`). So when the stored edge's specifier is not the path being read, the root wrote the path and the top-level dir is the only directory it can mean. Without this condition, root overrides applied to a folder-declared dependency, which work today only because of the bug, would start being read from the folder.
- Why it is decided from the edge and not from the resolve pass's `version_was_replaced`: `enqueue_local_tarball` is also reached from `enqueue_tarball_for_reading` when a project with a `bun.lock` is installed into an empty cache. The lockfile row keeps the path as declared (`"tool": ["bar@./tool.tgz", ...]` under `"lib": [..., { "dependencies": { "tool": "file:./tool.tgz" } }]`), and the edge's declarer and specifier are available there too, so both passes compute the same directory. Lockfile format is unchanged and existing lockfiles keep working; the path in the row is joined onto a different directory only for declarers that previously failed or installed the wrong file.
- Declarers extracted from the cache (registry, git, tarball packages) still fall through to the top-level dir, as before; #38986 is changing what happens to those separately. `Lockfile::get_parent_pkg_of_dependency` is the same helper that PR adds.
- Left as is: the lockfile identity of a local tarball is still the path as written (`bar@./tool.tgz`), so two project packages declaring the same relative path to two different files still share one row and one read, the limitation workspaces already have. A package.json inside a folder dependency that worked around this bug by writing a project-relative path (`file:./vendor/lib/tool.tgz`) will now need the path relative to itself, which is what npm requires for it as well.
- Verified with `test/cli/install/bun-install.test.ts`, `describe("file: tarball declared by a file: folder dependency")`: the folder's tarball is installed with the hoisted and with the isolated linker, and a root override supplying the path is read from the project. Each test plants a different tarball at the other candidate path and runs a fresh install followed by `--frozen-lockfile` into an emptied cache, so both the resolve pass and the install from `bun.lock` have to read the right file. `test/cli/install/bun-workspaces.test.ts`, `relative tarballs > from a root override / catalog entry applied to a workspace dependency`, covers #25835 and #25752 the same way. The four folder/workspace tests install the wrong tarball without the `src/` change (checked against a debug build of main and against the released build); the override-on-folder test passes before and after and pins that case.
- Also run with this change: `bun-workspaces.test.ts` (74 pass), `overrides.test.ts` + `nested-overrides.test.ts` (151 pass), `bun-lock.test.ts` (40 pass), `bun-install.test.ts -t "tarball|tgz|file:|folder|override|resolutions"` (51 pass; `should treat non-GitHub http(s) URLs as tarballs` fails identically on the released build, it needs network), `isolated-install.test.ts`, `bun-add.test.ts` and `bun-install-registry.test.ts` filtered to tarball/file tests (all pass). `cargo clippy -p bun_install` is clean.

### Background

- A `file:` dependency on a directory is a `Tag::Folder` dependency; one on a `.tgz` is a `Tag::Tarball` dependency with a local URI. The latter resolves to `Resolution::LocalTarball(<path as written>)`; the path string is both the task id for reading it and the package's identity in `bun.lock`.
- bun reads the package.json of the root, of workspace members and of `file:` folder dependencies from disk (`Package::parse`), and stores for each of the latter two a `Resolution::Workspace` / `Resolution::Folder` whose payload is the package directory relative to the top-level dir. Packages from the registry, git or a tarball get their dependency lists from the manifest or the extracted archive instead and have no directory in the project while they resolve.
- Dependency edges live in one flat buffer and every package owns a contiguous slice of it, which is how the package that declared an edge is found. The edge stores the specifier as declared; overrides, resolutions and catalogs replace it only for the duration of resolving that edge.
- `enqueue_local_tarball` is called from two places: the `Tarball` arm of the resolve pass (no lockfile row yet, the tarball is read to learn the package's name and dependencies) and `enqueue_tarball_for_reading` during install (a row exists in `bun.lock`, but the extracted package is missing from the cache). It computes the on-disk path on the main thread and hands it to a thread pool task, which only reads the file.
