### PR TITLE
js_parser: simplify the comma operands hoisted out of an unused ternary

### DIFF
--- a/src/js_parser/scan/scan_side_effects.rs
+++ b/src/js_parser/scan/scan_side_effects.rs
@@ -179,7 +179,8 @@ impl SideEffects {
 
                 // "foo() ? 1 : bar()" => "foo() || bar()"
                 if ternary.yes.is_empty() {
-                    return Some(Expr::join_with_left_associative_op(
+                    return Some(Self::join_unused_test_with_branch(
+                        p,
                         Op::Code::BinLogicalOr,
                         ternary.test,
                         ternary.no,
@@ -188,7 +189,8 @@ impl SideEffects {
 
                 // "foo() ? bar() : 2" => "foo() && bar()"
                 if ternary.no.is_empty() {
-                    return Some(Expr::join_with_left_associative_op(
+                    return Some(Self::join_unused_test_with_branch(
+                        p,
                         Op::Code::BinLogicalAnd,
                         ternary.test,
                         ternary.yes,
@@ -492,6 +494,32 @@ impl SideEffects {
         } else {
             Some(result)
         }
+    }
+
+    /// `Expr::join_with_left_associative_op` for the test of an unused ternary
+    /// whose other branch was removed: "(a, b) ? c() : 0" => "a, b && c()".
+    ///
+    /// Hoisting the comma operands out of the operator turns them into unused
+    /// expressions of their own (only the last operand is still used, by the
+    /// operator), so they are simplified like any other unused expression:
+    /// "(0, b) ? c() : 0" => "b && c()", not "0, b && c()", which a second
+    /// transpile would simplify further.
+    fn join_unused_test_with_branch<'a, const TS: bool, const SCAN: bool>(
+        p: &mut P<'a, TS, SCAN>,
+        op: Op::Code,
+        mut test: Expr,
+        branch: Expr,
+    ) -> Expr {
+        let mut hoisted = test.to_empty();
+        while let ExprData::EBinary(comma) = test.data
+            && comma.op == Op::Code::BinComma
+        {
+            if let Some(left) = Self::simplify_unused_expr(p, comma.left) {
+                hoisted = hoisted.join_with_comma(left);
+            }
+            test = comma.right;
+        }
+        hoisted.join_with_comma(Expr::join_with_left_associative_op(op, test, branch))
     }
 
     ///

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -5006,6 +5006,38 @@ it("does not duplicate the branch when simplifying an unused ternary with a comm
   expect(transpiler.transformSync("(f(), g()) ? h() : 1;").trim()).toBe("f(), g() && h();");
 });
 
+describe("simplifying an unused ternary with a comma test drops the comma operands that have no side effects", () => {
+  const transpiler = new Bun.Transpiler({ loader: "js" });
+
+  // Hoisting the comma operands out of the ternary ("(a, b) ? f() : 0" => "a, b && f()")
+  // leaves them unused, so the ones without side effects go away in the same pass.
+  // `u`, `b` and `c` are never declared, so reading them can throw and they must stay.
+  it.each([
+    ["let a = 1, b = 2; (a, b) ? f() : 0;", "let a = 1, b = 2;\nb && f();"],
+    ["let a = 1, b = 2; (a, b) ? 0 : f();", "let a = 1, b = 2;\nb || f();"],
+    ["(0, b) ? f() : 0;", "b && f();"],
+    ["(0, b) ? 0 : f();", "b || f();"],
+    ["(0, 1, b) ? f() : 0;", "b && f();"],
+    ["(0, (1, b)) ? f() : 0;", "b && f();"],
+    ["([0], { x: 1 }, b) ? 0 : f();", "b || f();"],
+    ["(0, b) ? (1, f()) : 0;", "b && f();"],
+    ["(g(), 0, b) ? f() : 0;", "g(), b && f();"],
+    ["(0, g(), b) ? f() : 0;", "g(), b && f();"],
+    ["(0, (g(), b)) ? f() : 0;", "g(), b && f();"],
+    ["(u, b) ? f() : 0;", "u, b && f();"],
+    ["(0, b, c) ? f() : 0;", "b, c && f();"],
+    ["[(0, b) ? f() : 0];", "b && f();"],
+    ["!((0, b) ? f() : 0);", "b && f();"],
+    ["(0, b) ? ((1, c) ? f() : 0) : 0;", "b && c && f();"],
+    ["let a = 1, b = 2, c = 3; a && ((b, c) ? f() : 0);", "let a = 1, b = 2, c = 3;\na && (c && f());"],
+  ])("%s", (input, expected) => {
+    const output = transpiler.transformSync(input).trim();
+    expect(output).toBe(expected);
+    // The output is fully simplified: transpiling it again prints it unchanged.
+    expect(transpiler.transformSync(output).trim()).toBe(expected);
+  });
+});
+
 describe("arrow function parsing after const declaration (scope mismatch bug)", () => {
   const transpiler = new Bun.Transpiler({ loader: "tsx" });
 


### PR DESCRIPTION
### Problem

- `new Bun.Transpiler({ loader: "js" }).transformSync("(0, b) ? f() : 0;")` prints `0, b && f();`. Transpiling that output again prints `b && f();`, so the output of one pass is not a fixed point. Same for `(0, b) ? 0 : f();` (`0, b || f();`), for longer or nested comma chains (`(0, 1, b)`, `(0, (1, b))`), for declared variables in place of the literal, and for the ternary nested in another unused expression (`[... ]`, `!`, `void`, the right side of `&&`).
- Cause: the `EIf` arm of `SideEffects::simplify_unused_expr` (src/js_parser/scan/scan_side_effects.rs:180-196) rewrites an unused `test ? yes : <removed>` with `Expr::join_with_left_associative_op`, which hoists a comma test out of the operator: `(a, b) && f()` becomes `a, (b && f())`. The hoisted `a` is an unused expression from that point on, but nothing simplifies it. The second transpile sees it as the left operand of an unused comma statement (`simplify_unused_binary_comma_expr`) and drops it.
- Only the default mode (dead code elimination on, minify syntax off) is affected. With `minify: { syntax: true }` the visitor already simplifies comma left operands while visiting the comma (src/js_parser/visit/visit_binary.rs:201). That is also why the esbuild code this arm was ported from does not need to do anything here: esbuild only runs this simplification when minifying.
- Found by the transpiler fixed-point fuzzer in #39006, which currently keeps comma expressions out of unused expression statements because of this; that exclusion can go once this lands.

### Fix

- The `EIf` arm joins the test and the surviving branch through a new `join_unused_test_with_branch`. It walks the comma chain of the test, passes each hoisted operand through `simplify_unused_expr` (dropping it on `None`), and joins the last operand, the only one whose value is still used, with the branch via `join_with_left_associative_op` exactly as before. A test that is not a comma takes the same path as before.
- This is correct because nothing about evaluation changes: in `x1, ..., xn ? yes : <removed>` the operands `x1..xn-1` are evaluated only for their effects, and keeping exactly the effects of an unused expression is what `simplify_unused_expr` does (so `(u, b) ? f() : 0` with an undeclared `u` still prints `u, b && f()`, since reading `u` can throw). `xn` feeds the `&&` / `||` and is left alone.
- The result is fully simplified in one pass, and for these inputs it is byte for byte what `minify: { syntax: true }` and `esbuild --minify-syntax` already print (`b && f()`, `g(), b && f()`, `b, c && f()`, `b && c && f()`, `a && (c && f())`).
- Verified with the new cases in test/bundler/transpiler/transpiler.test.js, which assert the one-pass output and that transpiling that output again leaves it unchanged: 16 of the 17 cases fail on the released build (the 17th is the must-keep `u` case), all pass with the fix.
- Random probe (details below): with the fix, 0 non-fixed-point programs and 0 side-effect differences between the source, the once- and the twice-transpiled program over 3 x 3000 generated programs in both modes; the released build has 23-24 non-fixed-point programs per 2000 in the default mode.
- test/bundler/transpiler/transpiler.test.js, test/bundler/esbuild/dce.test.ts, test/bundler/bundler_minify.test.ts and test/bundler/bundler_edgecase.test.ts pass with the debug build.

### Background

- `simplify_unused_expr(expr)` takes an expression whose value is not used (an expression statement, the branch of an unused ternary, an item of an unused array literal, ...) and returns an expression that performs the same side effects and nothing else, or `None` when there are none. It drops literals and reads of declared variables and keeps calls, assignments and reads of undeclared identifiers (those can throw). It runs on every expression statement whenever dead code elimination is enabled, which is the default for `Bun.Transpiler`, `bun build` and the runtime, not only when minifying.
- `Expr::join_with_left_associative_op(op, a, b)` builds `a op b` while rotating the tree so that the printer needs no parentheses: a comma on the left is hoisted out (`(x, y) op b` becomes `x, (y op b)`) and the same operator on the right is re-associated (`a op (b op c)` becomes `(a op b) op c`). The hoisting is what creates the new unused operands this PR simplifies.
- Fixed point: transpiling the transpiler's own output should print it unchanged. A violation is harmless on its own, but it means a pass left simplification work behind, and the fuzzer in #39006 asserts the property to catch printer and simplifier disagreements.

<details>
<summary>Random probe</summary>

Programs are one unused expression statement built from commas, ternaries, `&&`, `||`, array literals and `!` over literals, declared variables, an undeclared identifier and three logging calls. Each program is transpiled twice; the test checks `p1 === p2` and runs the source, `p1` and `p2`, comparing the call logs (or the thrown error class).

```
system bun 1.4.0, default mode:       programs=2000 notFixedPoint=24 semanticDiffs=0  (x3 seeds: 24, 24, 23)
this branch, default mode:            programs=3000 notFixedPoint=0  semanticDiffs=0  (x3 seeds)
this branch, minify: { syntax: true }: programs=3000 notFixedPoint=0  semanticDiffs=0  (x3 seeds)
```

The only minify-mode divergence the probe finds is identical before and after this change (`!(a, "s")` printing as `(a, !"s")`, a missing string case in `Expr::maybe_simplify_not`) and is tracked separately.

</details>
