### PR TITLE
node:buffer: return an empty Buffer from new Buffer(dataView) like Node

### DIFF
--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -3493,7 +3493,6 @@ static JSC::EncodedJSValue createJSBufferFromJS(JSC::JSGlobalObject* lexicalGlob
             RELEASE_AND_RETURN(throwScope, JSC::JSValue::encode(uint8Array));
             break;
         }
-        case DataViewType:
         case Uint8ArrayType:
         case Uint8ClampedArrayType: {
             // byteOffset and byteLength are ignored in this case, which is consitent with Node.js and new Uint8Array()
@@ -3513,6 +3512,9 @@ static JSC::EncodedJSValue createJSBufferFromJS(JSC::JSGlobalObject* lexicalGlob
             return constructBufferFromArrayBuffer(throwScope, lexicalGlobalObject, args.size(), distinguishingArg, args.at(1), args.at(2));
         }
         default: {
+            // This includes DataViewType: a DataView has no `length`, so Node's
+            // Buffer.from() (and Bun's) gives an empty Buffer, which is what the
+            // array-like path below produces too.
             break;
         }
         }

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -279,6 +279,50 @@ for (let withOverridenBufferWrite of [false, true]) {
         }
       });
 
+      // A DataView has no `length`, so Node's Buffer.from(dataView), and therefore
+      // new Buffer(dataView) / Buffer(dataView), return an empty Buffer instead of
+      // copying the bytes the view covers.
+      it("creating a Buffer from a DataView gives an empty Buffer (old constructor too)", () => {
+        const ab = new Uint8Array([0x61, 0x62, 0x63, 0x64]).buffer;
+        const results = Object.fromEntries(
+          [
+            ["new Buffer(dv)", () => new Buffer(new DataView(ab))],
+            ["Buffer(dv)", () => Buffer(new DataView(ab))],
+            ["Buffer.from(dv)", () => Buffer.from(new DataView(ab))],
+            ["new Buffer(dv, encoding)", () => new Buffer(new DataView(ab), "latin1")],
+            ["new Buffer(sub-range dv)", () => new Buffer(new DataView(ab, 1, 2))],
+            ["Buffer(sub-range dv)", () => Buffer(new DataView(ab, 1, 2))],
+            [
+              "new Buffer(detached dv)",
+              () => {
+                const detachable = new Uint8Array([1, 2, 3]).buffer;
+                const dv = new DataView(detachable);
+                detachable.transfer();
+                return new Buffer(dv);
+              },
+            ],
+          ].map(([name, make]) => {
+            try {
+              const buf = make();
+              return [name, { isBuffer: Buffer.isBuffer(buf), bytes: Array.from(buf) }];
+            } catch (e) {
+              return [name, `${e.constructor.name}: ${e.message}`];
+            }
+          }),
+        );
+        expect(results).toEqual({
+          "new Buffer(dv)": { isBuffer: true, bytes: [] },
+          "Buffer(dv)": { isBuffer: true, bytes: [] },
+          "Buffer.from(dv)": { isBuffer: true, bytes: [] },
+          "new Buffer(dv, encoding)": { isBuffer: true, bytes: [] },
+          "new Buffer(sub-range dv)": { isBuffer: true, bytes: [] },
+          "Buffer(sub-range dv)": { isBuffer: true, bytes: [] },
+          "new Buffer(detached dv)": { isBuffer: true, bytes: [] },
+        });
+        // The source bytes are untouched and still reachable through a real view.
+        expect(new Buffer(new Uint8Array(ab))).toEqual(Buffer.from("abcd"));
+      });
+
       it("invalid encoding", () => {
         const b = Buffer.allocUnsafe(64);
         // Test invalid encoding for Buffer.toString


### PR DESCRIPTION
### Problem
- `new Buffer(dataView)` and `Buffer(dataView)` copy the bytes the DataView covers. Node (checked against v26.3.0) returns an empty Buffer, and so does Bun's own `Buffer.from(dataView)`, so the deprecated constructor disagrees with both.
- A detached DataView makes the same two forms throw `RangeError: Buffer is detached`; Node returns an empty Buffer there too.
- Cause: the type switch in `createJSBufferFromJS` (`src/jsc/bindings/JSBuffer.cpp`) lists `case DataViewType:` in the `Uint8ArrayType` / `Uint8ClampedArrayType` copy arm. The arm's comment says it matches Node, which is true for the typed arrays but not for DataView.
- Reproduces on bun 1.4.0:
  ```js
  const ab = new Uint8Array([0x61, 0x62, 0x63, 0x64]).buffer;
  new Buffer(new DataView(ab));  // bun: <Buffer 61 62 63 64>   node: <Buffer >
  Buffer(new DataView(ab));      // bun: <Buffer 61 62 63 64>   node: <Buffer >
  Buffer.from(new DataView(ab)); // bun: <Buffer >              node: <Buffer >
  ```

### Fix
- Removes `DataViewType` from that arm, so a DataView reaches the `default` path (`constructBufferFromArray`) like any other non-TypedArray object.
- Matches Node: `Buffer()` delegates to `Buffer.from()`, and `fromObject()` in `lib/buffer.js` returns `new FastBuffer()` for an object whose `.length` is not a number. A DataView has `byteLength` but no `length`, so that is the branch it takes, detached or not.
- The fallback produces the same result: `constructBufferFromArray` hands a non-array object to the Uint8Array constructor, which treats an object that is not a TypedArray as array-like, reads its missing `length` as 0 and builds an empty Buffer (so `new Uint8Array(dataView)` is already empty in both runtimes). It never reads the DataView's memory, which is why the detached case stops throwing as well.
- `Buffer.from(dataView)` is unchanged: it is implemented in `src/js/builtins/JSBufferConstructor.ts`, where `$isTypedArrayView` excludes DataView, so it never reached the removed arm. Nothing in `src/js` passes a DataView to the native constructor, and `Buffer.byteLength(dataView)` is a separate path that still returns the view's byte length.
- Verified with the new test in `test/js/node/buffer.test.js` ("creating a Buffer from a DataView gives an empty Buffer (old constructor too)"): fails on bun 1.4.0 (bytes copied, detached form throws), passes with this change. The expected values in the test are what node v26.3.0 prints for the same expressions.
- The rest of `test/js/node/buffer.test.js` passes (620 tests), as do the upstream `test-buffer-from`, `test-buffer-new`, `test-buffer-arraybuffer`, `test-buffer-fakes`, `test-buffer-inheritance`, `test-buffer-alloc`, `test-buffer-resizable`, `test-buffer-bytelength`, `test-buffer-sharedarraybuffer` and `test-buffer-parent-property` tests.
- Related: #38928 removes the detached-view throws from the same switch (for TypedArrays) and keeps DataView in the copy arm; its DataView assertions (empty Buffer) also hold with this change. The two touch adjacent lines, so whichever lands second needs a trivial rebase.

### Background
- `Buffer(...)` / `new Buffer(...)` is the deprecated constructor form. In Node it is a thin wrapper: a number goes to `Buffer.alloc()`, everything else to `Buffer.from()`. In Bun the constructor is native (`createJSBufferFromJS`) and `Buffer.from()` is a JS builtin that calls the native constructor for the inputs it recognizes, so the two can diverge for an input that only one of them special-cases, which is what happened here.
- A DataView is an ArrayBuffer view but not a TypedArray: it has `buffer`, `byteOffset` and `byteLength`, but no `length` and no indexed elements. Node's `Buffer.from()` only copies from objects that have a numeric `length`, so every TypedArray copies and a DataView does not.
- `constructBufferFromArray` is the constructor's fallback for anything that is not a string, number, ArrayBuffer or TypedArray. It invokes the Uint8Array constructor with `Buffer` as the new target, which is how `new Buffer([1, 2, 3])` and `new Buffer({ length: 2 })` are built today.
