### PR TITLE
Bun.password: report an argon2 memory cost that cannot be allocated as OutOfMemory instead of aborting

### DIFF
--- a/src/runtime/crypto/pwhash.rs
+++ b/src/runtime/crypto/pwhash.rs
@@ -96,6 +96,19 @@ pub mod argon2 {
     #[derive(Copy, Clone, Default)]
     pub(crate) struct VerifyOptions;
 
+    /// rust-argon2 allocates its `m` KiB block matrix infallibly (`Memory::new`), so
+    /// reserve that much fallibly first and report `OutOfMemory` instead of aborting.
+    pub(crate) fn check_memory_is_allocatable(mem_cost_kib: u32) -> Result<(), Error> {
+        let bytes = (mem_cost_kib as usize)
+            .checked_mul(1024)
+            .ok_or(bun_alloc::AllocError)?;
+        let mut probe: Vec<u8> = Vec::new();
+        probe
+            .try_reserve_exact(bytes)
+            .map_err(|_| bun_alloc::AllocError)?;
+        Ok(())
+    }
+
     fn map_err(e: &vendor::Error) -> Error {
         use vendor::Error as E;
         match e {
@@ -152,6 +165,7 @@ pub mod argon2 {
             version: vendor::Version::Version13,
         };
 
+        check_memory_is_allocatable(config.mem_cost)?;
         let encoded = vendor::hash_encoded(password, &salt, &config).map_err(|e| map_err(&e))?;
         let bytes = encoded.as_bytes();
 
@@ -211,6 +225,7 @@ pub mod argon2 {
             }
         };
 
+        let mut memory_cost: Option<u32> = None;
         if let Some(after_dollar) = normalised.as_bytes().strip_prefix(b"$") {
             if let Some(sep) = strings::index_of_char_usize(after_dollar, b'$') {
                 let mut rest = &after_dollar[sep + 1..];
@@ -244,8 +259,15 @@ pub mod argon2 {
                     if value > limit {
                         return Err(crate::Error::WeakParameters);
                     }
+                    if key == b"m" {
+                        memory_cost = Some(value);
+                    }
                 }
             }
+        }
+        // Strings without exactly one `m=` fail to decode below, before allocating.
+        if let Some(memory_cost) = memory_cost {
+            check_memory_is_allocatable(memory_cost)?;
         }
 
         match vendor::verify_encoded(&normalised, password) {

--- a/test/js/bun/util/password.test.ts
+++ b/test/js/bun/util/password.test.ts
@@ -1,6 +1,6 @@
 import { password } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isDebug } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, isLinux } from "harness";
 
 const placeholder = "hey";
 
@@ -502,6 +502,86 @@ test("verify rejects encoded argon2 hashes with cost parameters above the suppor
   const junkMemory = hashed.replace("$m=8,", "$m=8x,");
   expect(() => password.verifySync("correct horse", junkMemory)).toThrow("InvalidEncoding");
   await expect(password.verify("correct horse", junkMemory)).rejects.toThrow("InvalidEncoding");
+});
+
+// argon2 allocates memoryCost KiB up front. When the system refuses that
+// allocation (memoryCost can go up to 4 TiB, and verify takes it from the
+// encoded hash) the result has to be the same error every other argon2 failure
+// produces, not a process abort. Both variants below run the same script in a
+// child whose allocations are made to fail: under ASAN through its
+// per-allocation cap, and on Linux release builds through a real address-space
+// limit, which makes mimalloc itself return null.
+describe("argon2 memory that cannot be allocated", () => {
+  const script = (memoryCost: number) => /* js */ `
+    const { password } = Bun;
+    const describeError = e => ({ name: e.name, code: e.code, message: e.message });
+    const options = { algorithm: "argon2id", memoryCost: ${memoryCost}, timeCost: 1 };
+    const small = { algorithm: "argon2id", memoryCost: 8, timeCost: 1 };
+    // A well-formed argon2id hash whose m= claims the unallocatable cost.
+    const encoded = password.hashSync("hunter2", small).replace("$m=8,", "$m=${memoryCost},");
+    const results = {};
+    try {
+      password.hashSync("hunter2", options);
+      results.hashSync = "resolved";
+    } catch (e) {
+      results.hashSync = describeError(e);
+    }
+    results.hash = await password.hash("hunter2", options).then(() => "resolved", describeError);
+    try {
+      results.verifySync = password.verifySync("hunter2", encoded);
+    } catch (e) {
+      results.verifySync = describeError(e);
+    }
+    results.verify = await password.verify("hunter2", encoded).then(v => v, describeError);
+    // Costs that do fit still work in this process afterwards.
+    results.afterwards = await password.verify("hunter2", await password.hash("hunter2", small));
+    console.log(JSON.stringify(results));
+  `;
+  const outOfMemory = (verb: string) => ({
+    name: "Error",
+    code: "PASSWORD_OUT_OF_MEMORY",
+    message: `Password ${verb} failed with error "OutOfMemory"`,
+  });
+  const expected = {
+    hashSync: outOfMemory("hashing"),
+    hash: outOfMemory("hashing"),
+    verifySync: outOfMemory("verification"),
+    verify: outOfMemory("verification"),
+    afterwards: true,
+  };
+
+  async function runChild(cmd: string[], env: NodeJS.Dict<string>) {
+    await using proc = Bun.spawn({ cmd, env, stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // stderr is only informational: ASAN warns about every refused allocation.
+    return { result: JSON.parse(stdout.trim() || JSON.stringify({ stdout, stderr, exitCode })), exitCode };
+  }
+
+  test.skipIf(!isASAN)("is reported as PASSWORD_OUT_OF_MEMORY (ASAN allocation cap)", async () => {
+    // 65536 KiB (64 MiB) is also the default memoryCost; the cap refuses it.
+    const { result, exitCode } = await runChild([bunExe(), "-e", script(65536)], {
+      ...bunEnv,
+      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "allocator_may_return_null=1", "max_allocation_size_mb=32"]
+        .filter(Boolean)
+        .join(":"),
+    });
+    expect(result).toEqual(expected);
+    expect(exitCode).toBe(0);
+  });
+
+  test.skipIf(isASAN || !isLinux)("is reported as PASSWORD_OUT_OF_MEMORY (address-space limit)", async () => {
+    // A 4 GiB block (the largest cost verify accepts) can never fit in a process
+    // whose whole address space is limited to 4 GiB, while bun itself starts fine
+    // with far less. The limit applies before any page is touched, so nothing is
+    // actually consumed; an ASAN build cannot start under it, hence the skip.
+    const gib = 1024 * 1024; // in KiB, the unit of both ulimit -v and memoryCost
+    const { result, exitCode } = await runChild(
+      ["/bin/sh", "-c", `ulimit -v ${4 * gib} && exec "$0" "$@"`, bunExe(), "-e", script(4 * gib)],
+      bunEnv,
+    );
+    expect(result).toEqual(expected);
+    expect(exitCode).toBe(0);
+  });
 });
 
 test("verifySync reads the password buffer only after every argument has been coerced", () => {


### PR DESCRIPTION
### Problem
- `Bun.password.hash` / `hashSync` accept `memoryCost` up to 4294967295 KiB (4 TiB), and `verify` / `verifySync` take `m=` from the encoded hash (the existing prescan caps it at 4 GiB). `pwhash::argon2::str_hash` / `str_verify` (`src/runtime/crypto/pwhash.rs`) hand the cost to rust-argon2, whose `Memory::new` allocates the block matrix with `vec![Block::zero(); n]` (rust-argon2 3.0.0 `memory.rs:36`, reached from `run()` for both hashing and verifying). When that allocation fails the process aborts: `memory allocation of N bytes failed`, `panic(main thread): abort() called`, and a "Bun has crashed" report, for a value the caller passed in (or, for verify, for a hash string somebody else produced).
- Reproduced on the current release build: `sh -c 'ulimit -v 4194304; exec bun -e "Bun.password.hashSync(\"pw\", { algorithm: \"argon2id\", memoryCost: 4194304 })"'` aborts with `memory allocation of 4294967296 bytes failed`; a 512 MiB cost under a 1 GB limit aborts the same way, and so does the 4 TiB maximum on a machine with Linux's default overcommit setting (the request exceeds RAM plus swap, so `mmap` refuses it).
- Before the Rust port, Zig's `std.crypto.pwhash.argon2` took an allocator and returned `error.OutOfMemory`, which `PasswordObject.zig` reported like every other hash failure: `Password hashing failed with error "OutOfMemory"` with `code: "PASSWORD_OUT_OF_MEMORY"`.

### Fix
- `check_memory_is_allocatable(m)` reserves `m * 1024` bytes with `try_reserve_exact`, drops the probe, and returns `Error::Alloc` on failure. `str_hash` calls it right before `hash_encoded`; `str_verify` records `m` in the prescan it already runs over the cost fields and calls it right before `verify_encoded` (the decoder only accepts strings with exactly one `m=`, so this is the cost it would allocate for; anything else fails to decode before allocating).
- `Error::Alloc` names itself `OutOfMemory`, so the unchanged `password_error_instance` in `PasswordObject.rs` produces exactly the pre-port error, on both the sync path and the work-pool path: `Password hashing failed with error "OutOfMemory"` / `Password verification failed with error "OutOfMemory"`, `code: "PASSWORD_OUT_OF_MEMORY"`.
- Where this changes behavior: wherever the allocation itself fails. That is every Windows machine without the commit charge to spare (Windows does not overcommit), Linux with the default overcommit heuristic whenever the cost exceeds RAM plus swap (for example a cost given in bytes or MiB instead of KiB, or the `m=` of a hash string an attacker controls), and any address-space or commit limit. It deliberately changes nothing when the allocation succeeds and the machine later runs out of memory while argon2 touches the blocks (`overcommit_memory=1`, cgroup limits); that is the OOM killer's domain, as before.
- Why a probe: rust-argon2 has no API that takes caller-provided memory or fails on allocation, and the two ways to change that (patching the crate, which #33153 is the open infrastructure for, or switching to RustCrypto's `argon2`, which changes the PHC codec and the verify semantics) are much larger changes than this needs. The probe is best effort by construction (another thread can take the memory between the probe and the crate's allocation, and the crate rounds the cost down to a multiple of 4 blocks), which is acceptable: it cannot make anything that works today fail, and it converts every deterministic failure into the error. It costs one untouched reservation and release per call, microseconds next to the hash itself. The function is `pub(crate)` so the `node:crypto` argon2 binding proposed in #37015, which drives the same crate, can use the same check.
- Not changed here: the `memoryCost` ceiling for `hash`. #33865 proposes capping it at verify's 4 GiB; that is compatible with this and does not replace it, since the costs that fail to allocate in practice (64 MiB default, 4 GiB maximum) are well inside any plausible ceiling. #32314 edits the same prescan loop; whichever lands second has a three-line conflict.
- Verified with `test/js/bun/util/password.test.ts`: the same child script runs `hashSync`, `hash`, `verifySync` and `verify` against an unallocatable cost and checks an allocatable one still works afterwards, in two variants. Under ASAN (`test.skipIf(!isASAN)`) with `allocator_may_return_null=1:max_allocation_size_mb=32` and the default 64 MiB cost: fails on main with `memory allocation of 67108864 bytes failed`, passes here. On Linux release builds (`test.skipIf(isASAN || !isLinux)`; ASAN builds cannot start under an address-space limit) with `ulimit -v 4194304` and a 4 GiB cost, which can never fit while bun itself starts in about 0.35 GB: fails against the current release build with `memory allocation of 4294967296 bytes failed` (output below); its passing side runs on CI's Linux release lanes, since the local debug build is ASAN. The rest of the file: 72 pass, 9 debug-only skips.
- This was split out of #38941 (the `TextEncoderStream` half of the same port regression), which shares no code with it.

### Background
- argon2's memory cost `m` is in KiB: the algorithm fills a matrix of `m` one-kibibyte blocks, allocated up front in one piece, and reads it back while hashing, so it is the dominant allocation of a hash or verify call. `verify` gets it from the PHC string it is given (`$argon2id$v=19$m=65536,t=2,p=1$salt$hash`), so it is input, not configuration.
- `Vec::try_reserve_exact` returns `Err` when the allocator returns null, where the crate's `vec!` calls `handle_alloc_error` and aborts. Reserving without writing touches no pages, so the probe costs the allocator a reservation and a release and nothing else.
- `Error::Alloc(AllocError)` is the runtime crate's out-of-memory variant; `Error::name()` reports it as `OutOfMemory`, and `Bun.password` builds both the message and the `PASSWORD_*` code from that name, which is also how the Zig implementation formatted `error.OutOfMemory`.
- Under ASAN the global allocator is libc's, and `ASAN_OPTIONS=allocator_may_return_null=1:max_allocation_size_mb=N` makes any single allocation above N MiB return null; `ulimit -v` (RLIMIT_AS) makes `mmap` fail once the process's address space would exceed the limit, which is how mimalloc ends up returning null in the release variant.

<details>
<summary>Release build, without the fix, address-space variant of the test</summary>

```
memory allocation of 4294967296 bytes failed
...
RSS: 29.65 MB | Peak: 0.35 GB | Commit: 25.10 MB | Faults: 0 | Machine: 34.36 GB

panic(main thread): abort() called
oh no: Bun has crashed. This indicates a bug in Bun, not your code.
```

With the fix, all four entry points report
`{"name":"Error","code":"PASSWORD_OUT_OF_MEMORY","message":"Password hashing failed with error \"OutOfMemory\""}`
(`verification` for the verify pair) and a hash with `memoryCost: 8` still round-trips afterwards.

</details>
