### PR TITLE
test(install): run overrides.test.ts against the local registry

### DIFF
--- a/test/cli/install/overrides.test.ts
+++ b/test/cli/install/overrides.test.ts
@@ -1,247 +1,270 @@
-import { write } from "bun";
-import { expect, setDefaultTimeout, test } from "bun:test";
-import { readFileSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, tmpdirSync } from "harness";
+import { file, write } from "bun";
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { VerdaccioRegistry, bunEnv, bunExe, nodeModulesPackages, normalizeBunSnapshot } from "harness";
 import { join } from "path";
 
-setDefaultTimeout(1000 * 60 * 5);
+// Fixtures from ./registry/packages used below:
+//   no-deps        1.0.0, 1.0.1, 1.1.0 and 2.0.0 (latest), the package the overrides target
+//   one-dep        1.0.0, depends on no-deps@1.0.1
+//   one-range-dep  1.0.0, depends on no-deps@^1.0.0
+//   a-dep          1.0.1 to 1.0.10 (latest), no dependencies
+const registry = new VerdaccioRegistry();
 
-function install(cwd: string, args: string[]) {
-  const exec = Bun.spawnSync({
-    cmd: [bunExe(), ...args, "--linker=hoisted"],
-    cwd,
-    stdout: "inherit",
-    stdin: "inherit",
-    stderr: "inherit",
-    env: bunEnv,
+beforeAll(async () => {
+  await registry.start();
+});
+
+afterAll(() => {
+  registry.stop();
+});
+
+async function project(packageJson: Record<string, unknown>, files: Record<string, string> = {}) {
+  const { packageDir } = await registry.createTestDir({
+    bunfigOpts: { linker: "hoisted" },
+    files: { "package.json": JSON.stringify(packageJson), ...files },
   });
-  if (exec.exitCode !== 0) {
-    throw new Error(`bun install exited with code ${exec.exitCode}`);
-  }
-  return exec;
+  return packageDir;
 }
 
-function installExpectFail(cwd: string, args: string[]) {
-  const exec = Bun.spawnSync({
+// Printed only by installs that had registry work to do; the bracketed task count is not what these tests check.
+const progressLine = /^Resolv(?:ing dependencies|ed, downloaded and extracted \[\d+\])\r?\n?/gm;
+
+async function bun(dir: string, ...args: string[]) {
+  await using proc = Bun.spawn({
     cmd: [bunExe(), ...args],
-    cwd,
-    stdout: "inherit",
-    stdin: "inherit",
-    stderr: "inherit",
-    env: bunEnv,
+    cwd: dir,
+    // CI exports BUN_INSTALL_CACHE_DIR, which overrides the bunfig's per-test `cache`; concurrent tests sharing one cache race on Windows.
+    env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(dir, ".bun-cache") },
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
   });
-  if (exec.exitCode === 0) {
-    throw new Error(`bun install exited with code ${exec.exitCode}, (expected failure)`);
-  }
-  return exec;
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return {
+    stdout: normalizeBunSnapshot(stdout, dir),
+    stderr: normalizeBunSnapshot(stderr.replace(progressLine, ""), dir),
+    exitCode,
+  };
 }
 
-function versionOf(cwd: string, path: string) {
-  const data = readFileSync(join(cwd, path));
-  const json = JSON.parse(data.toString());
-  return json.version;
+const lockfile = (dir: string) => file(join(dir, "bun.lock")).text();
+
+async function editPackageJson(dir: string, edit: (pkg: Record<string, unknown>) => void) {
+  const path = join(dir, "package.json");
+  const pkg = await file(path).json();
+  edit(pkg);
+  await write(path, JSON.stringify(pkg));
 }
 
-function ensureLockfileDoesntChangeOnBunI(cwd: string) {
-  install(cwd, ["install"]);
-  const lockb1 = readFileSync(join(cwd, "bun.lock"));
-  install(cwd, ["install", "--frozen-lockfile"]);
-  install(cwd, ["install", "--force"]);
-  const lockb2 = readFileSync(join(cwd, "bun.lock"));
+// `lock` is the bun.lock written by the install under test. The frozen install checks that bun considers it in sync with
+// package.json; the plain install checks that it is neither re-resolved nor re-saved (each goes through its own comparison).
+async function expectLockfileStable(dir: string, lock: string) {
+  const frozen = await bun(dir, "install", "--frozen-lockfile");
+  expect(frozen.stderr).toBe("");
+  expect(frozen.exitCode).toBe(0);
 
-  expect(lockb1.toString("hex")).toEqual(lockb2.toString("hex"));
+  const plain = await bun(dir, "install");
+  expect(plain.stderr).toBe("");
+  expect(plain.exitCode).toBe(0);
+
+  expect(await lockfile(dir)).toBe(lock);
 }
 
-test("overrides affect your own packages", async () => {
-  const tmp = tmpdirSync();
-  writeFileSync(
-    join(tmp, "package.json"),
-    JSON.stringify({
-      dependencies: {},
-      overrides: {
-        lodash: "4.0.0",
-      },
-    }),
-  );
-  install(tmp, ["install", "lodash"]);
-  expect(versionOf(tmp, "node_modules/lodash/package.json")).toBe("4.0.0");
-  ensureLockfileDoesntChangeOnBunI(tmp);
+test.concurrent("overrides affect your own packages", async () => {
+  const dir = await project({ dependencies: {}, overrides: { "no-deps": "1.0.0" } });
+
+  const { stdout, stderr, exitCode } = await bun(dir, "install", "no-deps", "a-dep");
+
+  expect(stdout).toMatchInlineSnapshot(`
+    "bun add <version> (<revision>)
+
+    installed no-deps@1.0.0
+    installed a-dep@1.0.10
+
+    2 packages installed"
+  `);
+  expect(stderr).toMatchInlineSnapshot(`"Saved lockfile"`);
+  expect(exitCode).toBe(0);
+  expect(nodeModulesPackages(dir)).toMatchInlineSnapshot(`
+    "node_modules/a-dep/a-dep@1.0.10
+    node_modules/no-deps/no-deps@1.0.0"
+  `);
+  await expectLockfileStable(dir, await lockfile(dir));
 });
 
-test("overrides affects all dependencies", async () => {
-  const tmp = tmpdirSync();
-  writeFileSync(
-    join(tmp, "package.json"),
-    JSON.stringify({
-      dependencies: {},
-      overrides: {
-        bytes: "1.0.0",
-      },
-    }),
-  );
-  install(tmp, ["install", "express@4.18.2"]);
-  expect(versionOf(tmp, "node_modules/bytes/package.json")).toBe("1.0.0");
+test.concurrent("overrides affects all dependencies", async () => {
+  const dir = await project({ dependencies: {}, overrides: { "no-deps": "1.0.0" } });
 
-  ensureLockfileDoesntChangeOnBunI(tmp);
+  const { stdout, stderr, exitCode } = await bun(dir, "install", "one-dep", "one-range-dep");
+
+  expect(stdout).toMatchInlineSnapshot(`
+    "bun add <version> (<revision>)
+
+    installed one-dep@1.0.0
+    installed one-range-dep@1.0.0
+
+    3 packages installed"
+  `);
+  expect(stderr).toMatchInlineSnapshot(`"Saved lockfile"`);
+  expect(exitCode).toBe(0);
+  expect(nodeModulesPackages(dir)).toMatchInlineSnapshot(`
+    "node_modules/no-deps/no-deps@1.0.0
+    node_modules/one-dep/one-dep@1.0.0
+    node_modules/one-range-dep/one-range-dep@1.0.0"
+  `);
+  await expectLockfileStable(dir, await lockfile(dir));
 });
 
-test("overrides being set later affects all dependencies", async () => {
-  const tmp = tmpdirSync();
-  writeFileSync(
-    join(tmp, "package.json"),
-    JSON.stringify({
-      dependencies: {},
-    }),
-  );
-  install(tmp, ["install", "express@4.18.2"]);
-  expect(versionOf(tmp, "node_modules/bytes/package.json")).not.toBe("1.0.0");
+test.concurrent("overrides being set later affects all dependencies", async () => {
+  const dir = await project({ dependencies: {} });
+  const add = await bun(dir, "install", "one-dep");
+  expect(add.stderr).toMatchInlineSnapshot(`"Saved lockfile"`);
+  expect(add.exitCode).toBe(0);
+  expect(nodeModulesPackages(dir)).toMatchInlineSnapshot(`
+    "node_modules/no-deps/no-deps@1.0.1
+    node_modules/one-dep/one-dep@1.0.0"
+  `);
+  await expectLockfileStable(dir, await lockfile(dir));
 
-  ensureLockfileDoesntChangeOnBunI(tmp);
+  await editPackageJson(dir, pkg => (pkg.overrides = { "no-deps": "1.0.0" }));
+  const { stdout, stderr, exitCode } = await bun(dir, "install");
 
-  writeFileSync(
-    join(tmp, "package.json"),
-    JSON.stringify({
-      ...JSON.parse(readFileSync(join(tmp, "package.json")).toString()),
-      overrides: {
-        bytes: "1.0.0",
-      },
-    }),
-  );
-  install(tmp, ["install"]);
-  expect(versionOf(tmp, "node_modules/bytes/package.json")).toBe("1.0.0");
+  expect(stdout).toMatchInlineSnapshot(`
+    "bun install <version> (<revision>)
 
-  ensureLockfileDoesntChangeOnBunI(tmp);
+    1 package installed"
+  `);
+  expect(stderr).toMatchInlineSnapshot(`"Saved lockfile"`);
+  expect(exitCode).toBe(0);
+  expect(nodeModulesPackages(dir)).toMatchInlineSnapshot(`
+    "node_modules/no-deps/no-deps@1.0.0
+    node_modules/one-dep/one-dep@1.0.0"
+  `);
+  await expectLockfileStable(dir, await lockfile(dir));
 });
 
-test("overrides to npm specifier", async () => {
-  const tmp = tmpdirSync();
-  writeFileSync(
-    join(tmp, "package.json"),
-    JSON.stringify({
-      dependencies: {},
-      overrides: {
-        bytes: "npm:lodash@4.0.0",
-      },
-    }),
-  );
-  install(tmp, ["install", "express@4.18.2"]);
+test.concurrent("overrides to npm specifier", async () => {
+  const dir = await project({ dependencies: {}, overrides: { "no-deps": "npm:a-dep@1.0.1" } });
 
-  const bytes = JSON.parse(readFileSync(join(tmp, "node_modules/bytes/package.json"), "utf-8"));
+  const { stdout, stderr, exitCode } = await bun(dir, "install", "one-dep");
 
-  expect(bytes.name).toBe("lodash");
-  expect(bytes.version).toBe("4.0.0");
+  expect(stdout).toMatchInlineSnapshot(`
+    "bun add <version> (<revision>)
 
-  ensureLockfileDoesntChangeOnBunI(tmp);
+    installed one-dep@1.0.0
+
+    2 packages installed"
+  `);
+  expect(stderr).toMatchInlineSnapshot(`"Saved lockfile"`);
+  expect(exitCode).toBe(0);
+  expect(nodeModulesPackages(dir)).toMatchInlineSnapshot(`
+    "node_modules/no-deps/a-dep@1.0.1
+    node_modules/one-dep/one-dep@1.0.0"
+  `);
+  await expectLockfileStable(dir, await lockfile(dir));
 });
 
-test("changing overrides makes the lockfile changed, prevent frozen install", async () => {
-  const tmp = tmpdirSync();
-  writeFileSync(
-    join(tmp, "package.json"),
-    JSON.stringify({
-      dependencies: {},
-      overrides: {
-        bytes: "1.0.0",
-      },
-    }),
-  );
-  install(tmp, ["install", "express@4.18.2"]);
+test.concurrent("changing overrides makes the lockfile changed, prevent frozen install", async () => {
+  const dir = await project({ dependencies: {}, overrides: { "no-deps": "1.0.0" } });
+  const add = await bun(dir, "install", "one-dep");
+  expect(add.stderr).toMatchInlineSnapshot(`"Saved lockfile"`);
+  expect(add.exitCode).toBe(0);
+  const lock = await lockfile(dir);
+  const tree = nodeModulesPackages(dir);
+  expect(tree).toMatchInlineSnapshot(`
+    "node_modules/no-deps/no-deps@1.0.0
+    node_modules/one-dep/one-dep@1.0.0"
+  `);
 
-  writeFileSync(
-    join(tmp, "package.json"),
-    JSON.stringify({
-      ...JSON.parse(readFileSync(join(tmp, "package.json")).toString()),
-      overrides: {
-        bytes: "1.0.1",
-      },
-    }),
-  );
+  await editPackageJson(dir, pkg => (pkg.overrides = { "no-deps": "1.1.0" }));
+  const { stdout, stderr, exitCode } = await bun(dir, "install", "--frozen-lockfile");
 
-  installExpectFail(tmp, ["install", "--frozen-lockfile"]);
+  expect(stdout).toMatchInlineSnapshot(`"bun install <version> (<revision>)"`);
+  expect(stderr).toMatchInlineSnapshot(`
+    "error: lockfile had changes, but lockfile is frozen
+    note: overrides in package.json changed since bun.lock was saved
+    note: try re-running without --frozen-lockfile and commit the updated lockfile"
+  `);
+  expect(exitCode).toBe(1);
+  expect(await lockfile(dir)).toBe(lock);
+  expect(nodeModulesPackages(dir)).toBe(tree);
 });
 
-test("overrides reset when removed", async () => {
-  const tmp = tmpdirSync();
-  writeFileSync(
-    join(tmp, "package.json"),
-    JSON.stringify({
-      overrides: {
-        bytes: "1.0.0",
-      },
-    }),
-  );
-  install(tmp, ["install", "express@4.18.2"]);
-  expect(versionOf(tmp, "node_modules/bytes/package.json")).toBe("1.0.0");
+test.concurrent("overrides reset when removed", async () => {
+  const dir = await project({ overrides: { "no-deps": "1.0.0" } });
+  const add = await bun(dir, "install", "one-dep");
+  expect(add.stderr).toMatchInlineSnapshot(`"Saved lockfile"`);
+  expect(add.exitCode).toBe(0);
+  expect(nodeModulesPackages(dir)).toMatchInlineSnapshot(`
+    "node_modules/no-deps/no-deps@1.0.0
+    node_modules/one-dep/one-dep@1.0.0"
+  `);
+  expect(await lockfile(dir)).toContain('"overrides"');
 
-  writeFileSync(
-    join(tmp, "package.json"),
-    JSON.stringify({
-      ...JSON.parse(readFileSync(join(tmp, "package.json")).toString()),
-      overrides: undefined,
-    }),
-  );
-  install(tmp, ["install"]);
-  expect(versionOf(tmp, "node_modules/bytes/package.json")).not.toBe("1.0.0");
+  await editPackageJson(dir, pkg => delete pkg.overrides);
+  const { stdout, stderr, exitCode } = await bun(dir, "install");
 
-  ensureLockfileDoesntChangeOnBunI(tmp);
+  expect(stdout).toMatchInlineSnapshot(`
+    "bun install <version> (<revision>)
+
+    1 package installed"
+  `);
+  expect(stderr).toMatchInlineSnapshot(`"Saved lockfile"`);
+  expect(exitCode).toBe(0);
+  expect(nodeModulesPackages(dir)).toMatchInlineSnapshot(`
+    "node_modules/no-deps/no-deps@1.0.1
+    node_modules/one-dep/one-dep@1.0.0"
+  `);
+  const lock = await lockfile(dir);
+  expect(lock).not.toContain('"overrides"');
+  await expectLockfileStable(dir, lock);
 });
 
-test("overrides do not apply to workspaces", async () => {
-  const tmp = tmpdirSync();
-  await Promise.all([
-    write(
-      join(tmp, "package.json"),
-      JSON.stringify({ name: "monorepo-root", workspaces: ["packages/*"], overrides: { "pkg1": "file:pkg2" } }),
-    ),
-    write(
-      join(tmp, "packages", "pkg1", "package.json"),
-      JSON.stringify({
-        name: "pkg1",
-        version: "1.1.1",
-      }),
-    ),
-    write(
-      join(tmp, "pkg2", "package.json"),
-      JSON.stringify({
-        name: "pkg2",
-        version: "2.2.2",
-      }),
-    ),
-  ]);
+test.concurrent("overrides do not apply to workspaces", async () => {
+  const dir = await project(
+    { name: "monorepo-root", workspaces: ["packages/*"], overrides: { pkg1: "file:pkg2" } },
+    {
+      "packages/pkg1/package.json": JSON.stringify({ name: "pkg1", version: "1.1.1" }),
+      "pkg2/package.json": JSON.stringify({ name: "pkg2", version: "2.2.2" }),
+    },
+  );
 
-  let { exited, stderr } = Bun.spawn({
-    cmd: [bunExe(), "install"],
-    cwd: tmp,
-    env: bunEnv,
-    stderr: "pipe",
-    stdout: "inherit",
+  const { stdout, stderr, exitCode } = await bun(dir, "install");
+
+  expect(stdout).toMatchInlineSnapshot(`
+    "bun install <version> (<revision>)
+
+    1 package installed"
+  `);
+  expect(stderr).toMatchInlineSnapshot(`"Saved lockfile"`);
+  expect(exitCode).toBe(0);
+  // node_modules/pkg1 links to the workspace; the override is recorded but does not redirect it to pkg2.
+  expect(await file(join(dir, "node_modules", "pkg1", "package.json")).json()).toEqual({
+    name: "pkg1",
+    version: "1.1.1",
   });
-
-  expect(await exited).toBe(0);
-  expect(await stderr.text()).toContain("Saved lockfile");
-
-  // --frozen-lockfile works
-  ({ exited, stderr } = Bun.spawn({
-    cmd: [bunExe(), "install", "--frozen-lockfile"],
-    cwd: tmp,
-    env: bunEnv,
-    stderr: "pipe",
-    stdout: "inherit",
-  }));
-
-  expect(await exited).toBe(0);
-  expect(await stderr.text()).not.toContain("Frozen lockfile");
-
-  // lockfile is not changed
-
-  ({ exited, stderr } = Bun.spawn({
-    cmd: [bunExe(), "install"],
-    cwd: tmp,
-    env: bunEnv,
-    stderr: "pipe",
-    stdout: "inherit",
-  }));
-
-  expect(await exited).toBe(0);
-  expect(await stderr.text()).not.toContain("Saved lockfile");
+  const lock = await lockfile(dir);
+  expect(lock).toMatchInlineSnapshot(`
+    "{
+      "lockfileVersion": 2,
+      "configVersion": 1,
+      "workspaces": {
+        "": {
+          "name": "monorepo-root",
+        },
+        "packages/pkg1": {
+          "name": "pkg1",
+          "version": "1.1.1",
+        },
+      },
+      "overrides": {
+        "pkg1": "file:pkg2",
+      },
+      "packages": {
+        "pkg1": ["pkg1@workspace:packages/pkg1"],
+      }
+    }
+    "
+  `);
+  await expectLockfileStable(dir, lock);
 });

--- a/test/no-validate-leaksan.txt
+++ b/test/no-validate-leaksan.txt
@@ -46,7 +46,6 @@ test/cli/install/bunx.test.ts
 test/cli/install/isolated-install.test.ts
 test/cli/install/migration/complex-workspace.test.ts
 test/cli/install/npmrc.test.ts
-test/cli/install/overrides.test.ts
 test/cli/install/test-dev-peer-dependency-priority.test.ts
 test/cli/run/commonjs-invalid.test.ts
 test/cli/run/preload-test.test.js


### PR DESCRIPTION
### Problem
- `test/cli/install/overrides.test.ts` installed `express@4.18.2` (68 packages) or `lodash` from the public npm registry in 6 of its 7 tests, then ran three more installs per test (`install`, `--frozen-lockfile`, `--force`; the last one re-fetches the tree).
- It was the only file in `test/cli/install` not using the local registry. Build 97275 measured it at 26s on the Windows arm64 lane and between 0.4s and 3.3s elsewhere, the spread being network and cache warmth; `setDefaultTimeout(5 minutes)` at the top of the file hid that.
- The `install()` helper inherited stdout/stderr, so nothing bun printed was asserted; each test checked one `version` field.
- The frozen-lockfile test passed for the wrong reason: it changed the override to `bytes@1.0.1`, a version that does not exist on npm, so the non-zero exit it checked came from `error: No version matching "1.0.1" found for specifier "bytes"`, not from the frozen-lockfile check (output below).
- `ensureLockfileDoesntChangeOnBunI` read `bun.lock` only after an extra `bun install`, so a lockfile rewritten by that install would not have been noticed.

### Fix
- The file starts one `VerdaccioRegistry` in `beforeAll` and uses fixtures that already exist in `test/cli/install/registry/packages`, so no fixtures are added: `no-deps` (1.0.0, 1.0.1, 1.1.0, 2.0.0) plays `bytes`/`lodash`, `one-dep` (depends on `no-deps@1.0.1`) and `one-range-dep` (`no-deps@^1.0.0`) play `express`, `a-dep` is the `npm:` alias target and the package an override must leave alone.
- All 7 scenarios are kept (direct dependency, transitive dependency through two parents, override added after the first install, `npm:` specifier, changed override vs `--frozen-lockfile`, override removed, workspaces) and run as `test.concurrent`. Each test owns its directory and its `BUN_INSTALL_CACHE_DIR` (CI exports that variable, so the per-test bunfig `cache` alone would leave concurrent tests sharing one cache).
- Assertions, checked before the exit code:
  - `stdout` and `stderr` of the install under test as `normalizeBunSnapshot` inline snapshots (the two progress lines are stripped; their task count is not what the file tests).
  - The installed tree via the harness `nodeModulesPackages`, one snapshot per state, covering the overridden package and the packages that must not move (e.g. `node_modules/no-deps/a-dep@1.0.1` next to `node_modules/one-dep/one-dep@1.0.0`).
  - The frozen-lockfile test now switches between two published versions and asserts the exact stderr (`error: lockfile had changes, but lockfile is frozen` plus the `overrides in package.json changed since bun.lock was saved` note), and that `bun.lock` and `node_modules` were left alone.
  - Removing the override resolves `no-deps` back to `1.0.1` (the version `one-dep` asks for) and drops `"overrides"` from `bun.lock`.
  - The workspace test asserts that `node_modules/pkg1` is the `1.1.1` workspace and snapshots the whole `bun.lock`: `pkg1@workspace:packages/pkg1`, override recorded, no `pkg2` entry.
- `expectLockfileStable` captures the `bun.lock` text right after the install under test, then requires `--frozen-lockfile` to pass with empty stderr, a plain `bun install` to print nothing to stderr (no `Saved lockfile`), and the text to be unchanged (`toBe` on the text, so a failure prints a line diff). The `--force` step is dropped: it was the re-download, and the re-resolution it exercised is what the "set later" and "reset when removed" scenarios assert directly.
- The 5 minute `setDefaultTimeout` is gone. The file is also removed from `test/no-validate-leaksan.txt`: it passes with the CI LeakSanitizer settings (`BUN_DESTRUCT_VM_ON_EXIT=1`, `detect_leaks=1`, `test/leaksan.supp`), and a `LSAN_OPTIONS=verbosity=1` probe confirmed LSAN runs inside the spawned installs.
- Why the small fixtures are enough: bun applies an override per dependency edge while enqueueing it (`src/install/PackageManager/PackageManagerEnqueue.rs:709-747`), so each scenario needs one package with several published versions plus a parent depending on it; the express tree only added network traffic.
- Verified with `bun bd test test/cli/install/overrides.test.ts`: 7 pass, 26 snapshots. Timings on this machine (public registry reachable through a proxy):

| run | before | after |
| --- | --- | --- |
| `bun bd test` (debug, ASAN), cold install cache | 19.9s, 21.4s | 6.0s to 7.5s over 4 runs |
| `bun bd test`, warm install cache | 15.9s | n/a, the cache is per test |
| release bun, cold install cache | 12.0s and 65.2s (one express download stalled for 56s) | 1.9s |
| public registry unreachable (`HTTP(S)_PROXY` pointed at a closed port) | 6 of 7 fail: `ConnectionRefused downloading package manifest express` | 7 pass |

- About 3.4s of the debug "after" number is the fixed cost of any verdaccio-backed file (a one-test file that only starts the registry takes that long under the debug build); the tests themselves take 1s to 2s each, concurrently. On the lane where the old file hit a warm shared cache (0.4s on linux x64 in `test/expected-durations.json`) the new file will be somewhat slower because of that fixed cost; the gain is on cold or slow-network lanes, and in not depending on the network at all.

### Background
- `VerdaccioRegistry` (`test/harness.ts`) forks a verdaccio server on a random port that serves the packages checked in under `test/cli/install/registry/packages`. Its `verdaccio.yaml` has the npm uplink proxy commented out, so a package missing from that directory is a 404, never a network request. `createTestDir` makes a `tempDir` whose `bunfig.toml` points `install.registry` at the server and `install.cache` inside the directory.
- `overrides` (npm) / `resolutions` (yarn) in the root `package.json` replace the version that every dependency edge to a given name asks for. bun applies them while enqueueing each dependency, skipping workspace edges and explicit `npm:` aliases, and writes them into `bun.lock` so that `--frozen-lockfile` can tell when they changed.
- `nodeModulesPackages(dir)` from the harness lists every `package.json` found under `node_modules` as `path/name@version`, so one snapshot shows what each name resolved to and whether any nested copies were installed.

<details>
<summary>Frozen-lockfile test on main: resolution error, not a frozen-lockfile error</summary>

```
bun install v1.4.0-debug (732491c9f)
error: No version matching "1.0.1" found for specifier "bytes" (but package exists)
error: bytes@3.1.2 failed to resolve
(pass) changing overrides makes the lockfile changed, prevent frozen install
```

</details>

<details>
<summary>Old file with the public registry unreachable</summary>

```
error: ConnectionRefused downloading package manifest lodash
(fail) overrides affect your own packages
error: ConnectionRefused downloading package manifest express
(fail) overrides affects all dependencies
(fail) overrides being set later affects all dependencies
(fail) overrides to npm specifier
(fail) changing overrides makes the lockfile changed, prevent frozen install
(fail) overrides reset when removed
(pass) overrides do not apply to workspaces
 1 pass
 6 fail
```

</details>
