### PR TITLE
install: refuse link: paths with .. or an absolute path declared by packages installed from the cache

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1408,6 +1408,20 @@ pub fn enqueue_dependency_with_main_and_success_fn(
         dependency::version::Tag::Symlink | dependency::version::Tag::Workspace => {
             let dependency_tag = version.tag;
 
+            if dependency_tag == dependency::version::Tag::Symlink
+                && !version_was_replaced
+                && crate::bin::bin_target_escapes_package_dir(this.lockfile.str(version.symlink()))
+                && let Some(declarer) = this.lockfile.get_parent_pkg_of_dependency(id)
+                && !this.lockfile.packages.items_resolution()[declarer as usize]
+                    .tag
+                    .is_local_package()
+            {
+                if dependency.behavior.is_required() {
+                    reject_escaping_link_of_remote_package(this, declarer, dependency);
+                }
+                return Ok(());
+            }
+
             let _result = match get_or_put_resolved_package(
                 this,
                 name_hash,
@@ -1657,6 +1671,33 @@ fn warn_unmet_peer_dependency(
         "No version matching \"{}\" found for peer dependency \"{}\"<r> <d>(but package exists)<r>",
         bstr::BStr::new(this.lockfile.str(&version.literal)),
         bstr::BStr::new(this.lockfile.str(&name)),
+    );
+}
+
+/// A `link:` target with `..` or an absolute path is resolved against the project
+/// (`normalize_package_json_path`) and linked from the global link dir, so it names a
+/// directory of the installing machine, which only the package.json files read from the
+/// project can mean to do. The `file:` directory form is refused the same way in
+/// `get_or_put_resolved_package`.
+#[cold]
+#[inline(never)]
+fn reject_escaping_link_of_remote_package(
+    this: &PackageManager,
+    declarer: PackageID,
+    dependency: &Dependency,
+) {
+    let buf = this.lockfile.buffers.string_bytes.as_slice();
+    let packages = this.lockfile.packages.slice();
+    this.log_mut().add_error_fmt(
+        None,
+        bun_ast::Loc::EMPTY,
+        format_args!(
+            "refusing to resolve \"{}@{}\" declared by {}@{}: link: paths with \"..\" or an absolute path are only allowed in the package.json files of this project",
+            bstr::BStr::new(dependency.name.slice(buf)),
+            bstr::BStr::new(dependency.version.literal.slice(buf)),
+            bstr::BStr::new(packages.items_name()[declarer as usize].slice(buf)),
+            packages.items_resolution()[declarer as usize].fmt(buf, bun_fmt::PathSep::Posix),
+        ),
     );
 }
 

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1674,11 +1674,7 @@ fn warn_unmet_peer_dependency(
     );
 }
 
-/// A `link:` target with `..` or an absolute path is resolved against the project
-/// (`normalize_package_json_path`) and linked from the global link dir, so it names a
-/// directory of the installing machine, which only the package.json files read from the
-/// project can mean to do. The `file:` directory form is refused the same way in
-/// `get_or_put_resolved_package`.
+/// `normalize_package_json_path` resolves the value against the project, not the declaring package, so only package.json files read from the project may use `..` or an absolute path.
 #[cold]
 #[inline(never)]
 fn reject_escaping_link_of_remote_package(

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -782,6 +782,16 @@ impl Lockfile {
         self.get_workspace_pkg_if_workspace_dep(id) != invalid_package_id
     }
 
+    /// `None` for the edges `enqueue_dependency_to_root` appends outside of any package.
+    pub(crate) fn get_parent_pkg_of_dependency(&self, id: DependencyID) -> Option<PackageID> {
+        for (pkg_id, dependencies) in self.packages.items_dependencies().iter().enumerate() {
+            if dependencies.contains(id) {
+                return Some(PackageID::try_from(pkg_id).expect("int cast"));
+            }
+        }
+        None
+    }
+
     pub(crate) fn get_workspace_pkg_if_workspace_dep(&self, id: DependencyID) -> PackageID {
         let packages = self.packages.slice();
         let resolutions = packages.items_resolution();

--- a/src/install/resolution.rs
+++ b/src/install/resolution.rs
@@ -965,6 +965,11 @@ impl Tag {
         self == Tag::Git || self == Tag::Github
     }
 
+    /// The package.json is read from the project rather than extracted into the cache.
+    pub(crate) fn is_local_package(self) -> bool {
+        self == Tag::Root || self == Tag::Workspace || self == Tag::Folder
+    }
+
     pub(crate) fn can_enqueue_install_task(self) -> bool {
         self == Tag::Npm
             || self == Tag::LocalTarball

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -10437,7 +10437,7 @@ describe.concurrent("link: paths with .. or an absolute path declared by a depen
       cmd: [bunExe(), "pm", "pack", "--destination", join(root, "project")],
       cwd: join(root, "tb-src"),
       env,
-      stdout: "pipe",
+      stdout: "ignore",
       stderr: "pipe",
     });
     const [packErr, packExitCode] = await Promise.all([proc.stderr.text(), proc.exited]);

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -10390,6 +10390,266 @@ it("installs the transitive file: dependency of a file: dependency", async () =>
   }
 });
 
+// The link: form of the file: containment rule tested above. A link: target with
+// ".." or an absolute path names a directory of the machine running the install
+// (bun resolves it against the project and links it from the global link dir),
+// which only the package.json files read from the project can mean to do. A
+// package installed from the cache (registry, git, tarball) declaring one used
+// to get the directory's package.json read and recorded in bun.lock, and, when
+// the path was valid from both base directories, the directory symlinked into
+// node_modules under a name of its choosing.
+describe.concurrent("link: paths with .. or an absolute path declared by a dependency", () => {
+  // The project is <root>/project so that `../outside` stays inside the temp dir.
+  // `climbing` only climbs out after normalization.
+  function declaredLinks(root: string): Record<string, string> {
+    return {
+      outside: "link:../outside",
+      climbing: "link:x/../../climbing",
+      absolute: `link:${join(root, "absolute").replaceAll("\\", "/")}`,
+    };
+  }
+
+  // Every target exists, so resolving one of them is observable in bun.lock.
+  function linkTargets(): Record<string, string> {
+    return {
+      "outside/package.json": JSON.stringify({ name: "outside-dir", version: "1.0.0" }),
+      "climbing/package.json": JSON.stringify({ name: "climbing-dir", version: "1.0.0" }),
+      "absolute/package.json": JSON.stringify({ name: "absolute-dir", version: "1.0.0" }),
+    };
+  }
+
+  function rootPackageJson(dependencies: Record<string, string>, extra: object = {}) {
+    return JSON.stringify({ name: "my-app", version: "1.0.0", dependencies, ...extra });
+  }
+
+  // <root>/project depends on `bar@0.0.2` from the dummy registry, whose manifest
+  // for it carries `barManifest`.
+  async function writeRegistryProject(ctx: TestContext, root: string, barManifest: object, rootExtra: object = {}) {
+    setContextHandler(ctx, dummyRegistryForContext(ctx, [], { "0.0.2": barManifest }));
+    await write(join(root, "project", "package.json"), rootPackageJson({ bar: "0.0.2" }, rootExtra));
+    await write(join(root, "project", "bunfig.toml"), `[install]\nregistry = "${ctx.registry_url}"\n`);
+  }
+
+  // Packs <root>/tb-src into <root>/project/tb-1.0.0.tgz.
+  async function packDeclarer(root: string, manifest: object) {
+    await write(join(root, "tb-src", "package.json"), JSON.stringify({ name: "tb", version: "1.0.0", ...manifest }));
+    await using proc = spawn({
+      cmd: [bunExe(), "pm", "pack", "--destination", join(root, "project")],
+      cwd: join(root, "tb-src"),
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [packErr, packExitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(packErr).not.toContain("error:");
+    expect(packExitCode).toBe(0);
+  }
+
+  async function install(root: string, ...args: string[]) {
+    await using proc = spawn({
+      cmd: [bunExe(), "install", ...args],
+      cwd: join(root, "project"),
+      env: { ...env, BUN_INSTALL_CACHE_DIR: join(root, "cache"), BUN_INSTALL_GLOBAL_DIR: join(root, "global") },
+      stdout: "pipe",
+      stdin: "ignore",
+      stderr: "pipe",
+    });
+    const [err, out, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+    return { err, out, exitCode };
+  }
+
+  // `declarer` is how bun prints the package declaring the dependency.
+  function refusal(name: string, spec: string, declarer: string) {
+    return `error: refusing to resolve "${name}@${spec}" declared by ${declarer}: link: paths with ".." or an absolute path are only allowed in the package.json files of this project`;
+  }
+
+  // The rest of stderr is progress output ("Resolving dependencies", ...).
+  function errorLines(stderr: string) {
+    return stderr.split(/\r?\n/).filter(line => line.startsWith("error:"));
+  }
+
+  async function expectRefused(root: string, declarer: string) {
+    const { err, out, exitCode } = await install(root);
+
+    const refused = Object.entries(declaredLinks(root));
+    const expected = [
+      ...refused.map(([name, spec]) => refusal(name, spec, declarer)),
+      ...refused.map(([name, spec]) => `error: ${name}@${spec} failed to resolve`),
+    ];
+    // Reported in the declaring package's dependency order, which differs between
+    // a registry manifest and a package.json.
+    expect(errorLines(err).sort()).toEqual(expected.sort());
+    expect(err).not.toContain("Saved lockfile");
+    expect(out).not.toContain("installed");
+    expect(await exists(join(root, "project", "bun.lock"))).toBe(false);
+    expect(await exists(join(root, "project", "node_modules"))).toBe(false);
+    expect(exitCode).toBe(1);
+  }
+
+  it("are refused when a tarball dependency declares them", async () => {
+    using dir = tempDir("escaping-links-of-tarball-dep", {
+      ...linkTargets(),
+      "project/package.json": rootPackageJson({ tb: "file:./tb-1.0.0.tgz" }),
+    });
+    const root = String(dir);
+    await packDeclarer(root, { dependencies: declaredLinks(root) });
+
+    await expectRefused(root, "tb@./tb-1.0.0.tgz");
+  });
+
+  it("are refused when a git dependency declares them", async () => {
+    using dir = tempDir("escaping-links-of-git-dep", linkTargets());
+    const root = String(dir);
+    await write(
+      join(root, "work", "package.json"),
+      JSON.stringify({ name: "bar", version: "0.0.2", dependencies: declaredLinks(root) }),
+    );
+    const sha = await createDumbHttpGitRepo(root, {});
+    using server = serveDirectory(root);
+    const repo = `git+http://localhost:${server.port}/repo.git`;
+    await write(join(root, "project", "package.json"), rootPackageJson({ bar: repo }));
+
+    await expectRefused(root, `bar@${repo}#${sha}`);
+  });
+
+  it("are refused when a registry package declares them", async () => {
+    await withContext(defaultOpts, async ctx => {
+      using dir = tempDir("escaping-links-of-registry-dep", linkTargets());
+      const root = String(dir);
+      await writeRegistryProject(ctx, root, { dependencies: declaredLinks(root) });
+
+      await expectRefused(root, "bar@0.0.2");
+    });
+  });
+
+  it("are refused when a registry package declares one as a peer dependency", async () => {
+    await withContext(defaultOpts, async ctx => {
+      using dir = tempDir("escaping-peer-link-of-registry-dep", linkTargets());
+      const root = String(dir);
+      await writeRegistryProject(ctx, root, { peerDependencies: { outside: "link:../outside" } });
+
+      // An unresolved peer is not reported a second time as "failed to resolve"
+      // and does not stop bar itself from being installed; the error still fails
+      // the install before the lockfile is saved.
+      const { err, exitCode } = await install(root);
+      expect(errorLines(err)).toEqual([refusal("outside", "link:../outside", "bar@0.0.2")]);
+      expect(await exists(join(root, "project", "bun.lock"))).toBe(false);
+      expect(await exists(join(root, "project", "node_modules", "outside"))).toBe(false);
+      expect(exitCode).toBe(1);
+    });
+  });
+
+  it("stay uninstalled when a registry package declares one as an optional dependency", async () => {
+    await withContext(defaultOpts, async ctx => {
+      using dir = tempDir("escaping-optional-link-of-registry-dep", linkTargets());
+      const root = String(dir);
+      await writeRegistryProject(ctx, root, { optionalDependencies: { outside: "link:../outside" } });
+
+      const { err, out, exitCode } = await install(root);
+      expect(err).not.toContain("error:");
+      expect(out).toContain("1 package installed");
+      expect(await readdirSorted(join(root, "project", "node_modules"))).toEqual(["bar"]);
+      const lockfile = await file(join(root, "project", "bun.lock")).text();
+      expect(lockfile).toContain('"bar": ["bar@0.0.2"');
+      expect(lockfile).not.toContain("outside-dir");
+      expect(exitCode).toBe(0);
+    });
+  });
+
+  // What stays allowed. These only assert the resolution (`--lockfile-only`):
+  // bun currently creates the link for a target with ".." relative to the global
+  // link dir rather than the directory it resolved the target from, which is a
+  // separate problem of the root-declared form.
+  it("are still resolved when the root package.json or a workspace declares them", async () => {
+    using dir = tempDir("escaping-links-of-root-and-workspace", {
+      ...linkTargets(),
+      "project/package.json": rootPackageJson({ outside: "link:../outside" }, { workspaces: ["packages/*"] }),
+      "project/packages/ws/package.json": JSON.stringify({
+        name: "ws",
+        version: "1.0.0",
+        dependencies: { climbing: "link:../climbing" },
+      }),
+    });
+    const root = String(dir);
+
+    const { err, exitCode } = await install(root, "--lockfile-only");
+    expect(err).not.toContain("error:");
+    const lockfile = await file(join(root, "project", "bun.lock")).text();
+    expect(lockfile).toContain('"outside": ["outside-dir@link:../outside"');
+    expect(lockfile).toContain('"climbing": ["climbing-dir@link:../climbing"');
+    expect(exitCode).toBe(0);
+  });
+
+  // `overrides` / `resolutions` are written in the root package.json, so a link:
+  // path coming from there is the project's own even when it replaces the
+  // dependency of a registry package.
+  for (const field of ["resolutions", "overrides"]) {
+    it(`are still resolved when a root "${field}" entry puts one on a registry package's dependency`, async () => {
+      await withContext(defaultOpts, async ctx => {
+        using dir = tempDir(`${field}-escaping-link-on-registry-dep`, linkTargets());
+        const root = String(dir);
+        await writeRegistryProject(
+          ctx,
+          root,
+          { dependencies: { vendored: "0.0.1" } },
+          { [field]: { vendored: "link:../outside" } },
+        );
+
+        const { err, exitCode } = await install(root, "--lockfile-only");
+        expect(err).not.toContain("error:");
+        const lockfile = await file(join(root, "project", "bun.lock")).text();
+        expect(lockfile).toContain('"vendored": ["outside-dir@link:../outside"');
+        expect(exitCode).toBe(0);
+      });
+    });
+  }
+
+  // A file: directory's package.json is read from the project like a workspace's,
+  // so it may declare one. The target is planted both where bun reads the path
+  // from today (the project) and next to the declaring directory; which of the
+  // two it reads is not what this pins.
+  it("are still resolved when a file: directory dependency declares them", async () => {
+    using dir = tempDir("escaping-link-of-folder-dep", {
+      ...linkTargets(),
+      "project/outside/package.json": linkTargets()["outside/package.json"],
+      "project/package.json": rootPackageJson({ lib: "file:./lib" }),
+      "project/lib/package.json": JSON.stringify({
+        name: "lib",
+        version: "1.0.0",
+        dependencies: { outside: "link:../outside" },
+      }),
+    });
+    const root = String(dir);
+
+    const { err, exitCode } = await install(root, "--lockfile-only");
+    expect(err).not.toContain("error:");
+    expect(await file(join(root, "project", "bun.lock")).text()).toContain('"outside": ["outside-dir@link:');
+    expect(exitCode).toBe(0);
+  });
+
+  // The documented form: `link:<name>` is looked up in the global link dir that
+  // `bun link` populates, whoever declares it.
+  it("do not affect a registry package linking a package by name", async () => {
+    await withContext(defaultOpts, async ctx => {
+      using dir = tempDir("named-link-of-registry-dep", {
+        "global/node_modules/linked-pkg/package.json": JSON.stringify({ name: "linked-pkg", version: "2.0.0" }),
+      });
+      const root = String(dir);
+      await writeRegistryProject(ctx, root, { dependencies: { "linked-pkg": "link:linked-pkg" } });
+
+      const { err, out, exitCode } = await install(root);
+      expect(err).not.toContain("error:");
+      expect(out).toContain("2 packages installed");
+      expect(await readdirSorted(join(root, "project", "node_modules"))).toEqual(["bar", "linked-pkg"]);
+      expect(await file(join(root, "project", "node_modules", "linked-pkg", "package.json")).json()).toEqual({
+        name: "linked-pkg",
+        version: "2.0.0",
+      });
+      expect(exitCode).toBe(0);
+    });
+  });
+});
+
 const fileDepCycleFixture = {
   "package.json": JSON.stringify({
     name: "my-app",


### PR DESCRIPTION
### Problem

- A package that `bun install` takes from the cache (a registry, git or tarball dependency) can declare `"loot": "link:../secret"`. bun resolved that path against the installing project, read `<project>/../secret/package.json`, and wrote the result to `bun.lock` as `"loot": ["secret-dir@link:../secret", {}]`, exactly as if the project's own package.json had declared it (released 1.4.0 canary and main).
- With enough `..` segments the path is valid from both directories bun uses (it resolves against the project but links from the global link dir), and the install completes: with the hoisted linker `node_modules/loot` at the top level of the project becomes a symlink to a directory of the declaring package's choosing anywhere on the machine, exit 0; with the isolated linker the same link is created under the package's store entry (probe below). So a published package can put any directory on the machine that has a `package.json` into the project's `node_modules` under any name that is free, and have its name recorded in `bun.lock`.
- Cause: the `Tag::Symlink` arm of `enqueue_dependency_with_main_and_success_fn` (`src/install/PackageManager/PackageManagerEnqueue.rs`) hands every `link:` value to `FolderResolution::get_or_put` without looking at who declared the edge, and `normalize_package_json_path` (`src/install/resolvers/folder_resolver.rs`) joins any value starting with `.` onto the project directory. The `file:` directory form of the same declaration is already refused when it leaves its base directory (Folder arm of `get_or_put_resolved_package`, `bin_target_escapes_package_dir`).

### Fix

- Before a `link:` edge is resolved, if its value escapes its base directory (`bin_target_escapes_package_dir`: climbs out with `..`, also after normalization such as `x/../../dir`, or is absolute) and the declaring package is not read from the project (`resolution::Tag::is_local_package`: root, workspace, `file:` directory), the edge is left unresolved. Required edges log `refusing to resolve "loot@link:../secret" declared by tb@./tb-1.0.0.tgz: link: paths with ".." or an absolute path are only allowed in the package.json files of this project`, and the install fails as it does for any unresolved dependency (`loot@link:../secret failed to resolve`, exit 1, no lockfile written). Optional edges are skipped silently, as an optional `file:` directory that is refused is today.
- Why refusing is right: such a path names a directory of the machine running the install. The package.json files bun reads from the project can mean that; a package that arrived from a registry, git or a tarball cannot know anything about the machine, so for it the declaration can only ever be an accident or an attempt to read or link arbitrary directories. No working setup is affected: the same value declared this way installed either a dangling link or the hijack above. This is the line the `file:` directory form draws in the neighbouring arm, and the one #38986 draws for `file:` tarballs.
- What is unchanged: name-form `link:<name>` (the documented `bun link` flow) for every declarer; `..` and absolute paths declared by the root, a workspace or a `file:` directory; values substituted from the root's `overrides` / `resolutions` / catalogs (`version_was_replaced`), since the project wrote those; edges that belong to no package (auto-install appends these to the root), since `get_parent_pkg_of_dependency` finds no declarer for them. The row is refused at resolve time, so a `bun.lock` can only carry such rows if an older bun wrote it; the install-from-lockfile path is left alone, like #38986 does for tarballs.
- The two helpers (`Tag::is_local_package`, `Lockfile::get_parent_pkg_of_dependency`) are the same ones #38986 and #33106 add, written identically so the branches merge in either order.
- Verified with `test/cli/install/bun-install.test.ts`, new block "link: paths with .. or an absolute path declared by a dependency": a tarball, a git and a registry declarer each declaring a `../` path, an `x/../../` path and an absolute path whose targets all exist (asserts the exact error lines, no `bun.lock`, no `node_modules`, exit 1); the same declared as a peer dependency (refused) and as an optional dependency (installs without it, target name absent from `bun.lock`). These five fail on the released build (the `../` and `x/../../` edges resolve silently and the optional one is written to `bun.lock`). Five more pin what stays allowed and pass before and after: root and workspace declarers, `resolutions` / `overrides` entries applied to a registry package's dependency, a `file:` directory declarer, and a registry package using name-form `link:` against a populated global link dir (installed under both names).
- Also run with the debug build: `bun-install.test.ts -t "file:|folder|link|override|resolutions|transitive"` (43 pass), the `link` tests of `bun-add-filter`, `bun-add-catalog`, `bun-prune`, `bun-pm-licenses`, `isolated-install` and the pnpm migration suites (pass; in `bun-link.test.ts` the pre-existing "should link dependency without crashing" fails locally on any debug build because of the debug-only stack dump, tracked separately). `cargo clippy -p bun_install` is clean.

### Background

- **`link:` dependencies.** `"dep": "link:<value>"` resolves to a `Resolution::Symlink` row whose package.json is read but whose dependencies are not (`Features::LINK`), and is installed as a symlink. The documented value is a name registered with `bun link`, looked up in the global link dir (`~/.bun/install/global/node_modules`, or `$BUN_INSTALL_GLOBAL_DIR/node_modules`). A value starting with `.` takes a different branch of `normalize_package_json_path` and is resolved against the project directory instead; the installers always join the value onto the global link dir. (#35461, open, is the feature work that makes path values consistent for root-declared dependencies; this PR only stops cache-installed packages from using them.)
- **Local vs. cache-installed packages.** The root, workspaces and `file:` directories are parsed from package.json files on disk at paths the project itself named; everything else (registry, git, tarball) is extracted into the cache, and its manifest is third-party content. A `file:` directory's dependencies are only parsed when the root or a workspace declared it, so every package on the local side of the line was reached through the project's own files. Install already uses this split to decide which dependency groups to install (`local_package_features` / `remote_package_features`).
- **`bin_target_escapes_package_dir`** (`src/install/bin.rs`) walks the components of a relative path and reports whether it ever climbs above its starting directory, or is absolute (including a Windows drive prefix). It is what the `file:` directory arm uses for the same decision.
- **`version_was_replaced`** is set in the enqueue path when the specifier being resolved came from the root package.json's `overrides` / `resolutions` or a catalog rather than from the declaring package's manifest.
- **Unresolved edges.** An edge the enqueue step leaves unresolved is reported by `verify_resolutions` as `<name>@<spec> failed to resolve` and fails the install before the lockfile is saved; optional and peer edges are exempt from that pass (a refused peer still fails the install through the logged error, after the other packages were installed, which the peer test pins).

<details>
<summary>Probe on the released build (1.4.0-canary, eabb96de7): the hijack completing under both linkers</summary>

`tb.tgz` contains only a package.json with `"loot": "link:../../../../../../../../../../../../../../../../tmp/linkrepro2/secret"`; the project depends on `"tb": "file:./tb.tgz"`; `/tmp/linkrepro2/secret/package.json` is `{"name":"secret-dir","main":"index.js"}`. `BUN_INSTALL_GLOBAL_DIR` points at an empty directory.

```
$ bun install
2 packages installed
$ cat bun.lock | grep loot
    "loot": ["secret-dir@link:../../../../../../../../../../../../../../../../tmp/linkrepro2/secret", {}],
$ ls -l node_modules
loot -> ../../secret          (= /tmp/linkrepro2/secret)
tb
$ bun -e 'console.log(require("loot"))'
hijacked

$ bun install --linker=isolated
2 packages installed
$ ls -l node_modules/.bun/tb@.+tb.tgz/node_modules
loot -> ../../../../../../../../../../../../../../../../../../../tmp/linkrepro2/secret
tb
```

With this branch both installs stop at resolution (exit 1, nothing written):

```
error: refusing to resolve "loot@link:../../(...)/tmp/linkrepro2/secret" declared by tb@./tb.tgz: link: paths with ".." or an absolute path are only allowed in the package.json files of this project
error: loot@link:../../(...)/tmp/linkrepro2/secret failed to resolve
```
</details>
