### PR TITLE
js_parser: keep a literal division that yields Infinity on the right of equality comparisons

### DIFF
--- a/src/js_parser/scan/scan_side_effects.rs
+++ b/src/js_parser/scan/scan_side_effects.rs
@@ -104,18 +104,25 @@ impl SideEffects {
     }
 
     pub(crate) fn is_primitive_to_reorder(data: &ExprData) -> bool {
-        matches!(
-            data,
+        match data {
             ExprData::ENull(_)
-                | ExprData::EUndefined(_)
-                | ExprData::EString(_)
-                | ExprData::EBoolean(_)
-                | ExprData::EBranchBoolean(_)
-                | ExprData::ENumber(_)
-                | ExprData::EBigInt(_)
-                | ExprData::EInlinedEnum(_)
-                | ExprData::ERequireMain
-        )
+            | ExprData::EUndefined(_)
+            | ExprData::EString(_)
+            | ExprData::EBoolean(_)
+            | ExprData::EBranchBoolean(_)
+            | ExprData::ENumber(_)
+            | ExprData::EBigInt(_)
+            | ExprData::EInlinedEnum(_)
+            | ExprData::ERequireMain => true,
+            // `print_number` spells an infinite number as `1 / 0` (`Infinity` may be shadowed) and
+            // only minify_syntax folds that back, so it has to count as the literal it stands for:
+            // otherwise `"a" != Infinity` transpiles to `"a" != 1 / 0`, and that to `1 / 0 != "a"`.
+            ExprData::EBinary(e) if e.op == Op::Code::BinDiv => {
+                Expr::extract_numeric_values(&e.left.data, &e.right.data)
+                    .is_some_and(|[dividend, divisor]| (dividend / divisor).is_infinite())
+            }
+            _ => false,
+        }
     }
 
     pub(crate) fn simplify_unused_expr<'a, const TS: bool, const SCAN: bool>(

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -5399,6 +5399,74 @@ describe("numeric property keys that overflow to Infinity", () => {
   });
 });
 
+// The parser moves literal operands of ==, !=, === and !== to the right-hand side. Since an
+// infinite number is printed as "1 / 0" (see above), that division has to count as a literal too,
+// or transpiling the output a second time swaps the operands again:
+// `"a" != Infinity` -> `"a" != 1 / 0` -> `1 / 0 != "a"`.
+describe("equality comparisons against an infinite number", () => {
+  const plain = new Bun.Transpiler({ loader: "ts" });
+  const minifier = new Bun.Transpiler({ loader: "ts", minifyWhitespace: true });
+
+  function expectStablePrint(transpiler, input, output) {
+    const once = transpiler.transformSync(input);
+    expect(once).toBe(output);
+    expect(transpiler.transformSync(once)).toBe(output);
+  }
+  hideFromStackTrace(expectStablePrint);
+
+  it.each([
+    ['"a" != Infinity', '"a" != 1 / 0', '"a"!=1/0'],
+    ['"a" == -Infinity', '"a" == -1 / 0', '"a"==-1/0'],
+    ['"a" == 1e999', '"a" == 1 / 0', '"a"==1/0'],
+    ['"a" != -1e999', '"a" != -1 / 0', '"a"!=-1/0'],
+    ["1n === Infinity", "1n === 1 / 0", "1n===1/0"],
+    ["1n !== -1e999", "1n !== -1 / 0", "1n!==-1/0"],
+    ["require.main === Infinity", "require.main === 1 / 0", "require.main===1/0"],
+    ["require.main !== -Infinity", "require.main !== -1 / 0", "require.main!==-1/0"],
+    // Non-literal operands still move to the left, no matter how the infinity is spelled.
+    ["Infinity != x", "x != 1 / 0", "x!=1/0"],
+    ["-1e999 === x", "x === -1 / 0", "x===-1/0"],
+    ["1 / 0 != x", "x != 1 / 0", "x!=1/0"],
+    ["-1 / 0 === x", "x === -1 / 0", "x===-1/0"],
+    ['"a" != 1 / 0', '"a" != 1 / 0', '"a"!=1/0'],
+    ['"a" == -1 / 0', '"a" == -1 / 0', '"a"==-1/0'],
+    // Only a division that evaluates to an infinity stands for a number literal.
+    ["1 / 2 == x", "1 / 2 == x", "1/2==x"],
+    ["0 / 0 == x", "0 / 0 == x", "0/0==x"],
+    ["x / 0 == y", "x / 0 == y", "x/0==y"],
+    ['"a" == 1 / 2', '1 / 2 == "a"', '1/2=="a"'],
+    ['"a" == x / 0', 'x / 0 == "a"', 'x/0=="a"'],
+  ])("%s prints the same way on every pass", (input, output, minified) => {
+    expectStablePrint(plain, `y = ${input};`, `y = ${output};\n`);
+    expectStablePrint(minifier, `y = ${input};`, `y=${minified};`);
+  });
+
+  it("holds in a file that declares its own Infinity", () => {
+    expectStablePrint(
+      plain,
+      'function f(Infinity) {}\ny = "a" != 1e999;',
+      'function f(Infinity) {}\ny = "a" != 1 / 0;\n',
+    );
+  });
+
+  it("an inlined enum member whose value is infinite stays on the right", () => {
+    const enumObject = 'var F;\n((F) => {\n  F[F["A"] = 1 / 0] = "A";\n})(F ||= {});\n';
+    const once = plain.transformSync('const enum F { A = 1e999 }\ny = "a" == F.A;');
+    expect(once).toBe(`${enumObject}y = "a" == 1 / 0 /* A */;\n`);
+    // Only the inlining comment goes away on the second pass, not the operand order.
+    expect(plain.transformSync(once)).toBe(`${enumObject}y = "a" == 1 / 0;\n`);
+  });
+
+  it("reordering a division keeps its value", () => {
+    const out = plain.transformSync(`
+      var x = 2;
+      var result = [1 / 0 != x, -1 / 0 === x, 1 / 0 != Infinity, -1 / 0 === -Infinity];
+    `);
+    expect(out).toBe("var x = 2;\nvar result = [x != 1 / 0, x === -1 / 0, 1 / 0 != 1 / 0, -1 / 0 === -1 / 0];\n");
+    expect(new Function(`${out}; return result;`)()).toEqual([true, false, false, true]);
+  });
+});
+
 describe("parse error flood", () => {
   it("reports duplicate-binding floods in linear time", async () => {
     await using proc = Bun.spawn({


### PR DESCRIPTION
### Problem
- `Bun.Transpiler` (and `bun build --no-bundle`) output is not a fixed point when an equality compares a literal with an infinite number: `"a" != Infinity` transpiles to `"a" != 1 / 0`, and transpiling that output again gives `1 / 0 != "a"`.
- Same for `==`, `===` and `!==`, for `-Infinity`, `1e999` and `-1e999`, for string, bigint and `require.main` left operands, and for inlined enum members whose value is infinite. Found by the transpiler fixed-point fuzzer in #39006, which keeps infinities out of its literal pool until this lands.
- Two pieces that do not compose:
  - `print_number` (src/js_printer/lib.rs) prints an infinite `ENumber` as `1 / 0` whenever the symbol renamer has not run, because `Infinity` may be shadowed (#7263).
  - The visit pass moves literal operands of equality comparisons to the right-hand side (src/js_parser/visit/visit_binary.rs, `is_primitive_to_reorder` in src/js_parser/scan/scan_side_effects.rs). Pass 1 sees `EString != ENumber` and leaves it alone; pass 2 parses `1 / 0` as an `EBinary`, which the predicate does not count as a literal, so it swaps.
- Output order only; the values are the same either way.

### Fix
- `is_primitive_to_reorder` also returns true for a division of two number literals whose value is infinite, which is exactly what `print_number` emits. `1 / 0` now takes the same side of a comparison as `Infinity` does: `"a" != 1 / 0` stays as written and `1 / 0 != x` becomes `x != 1 / 0`, the way `Infinity != x` already did. A division with a finite or NaN value (`1 / 2`, `0 / 0`) is not affected, since the printer never produces those for a number.
- Why here rather than folding `1 / 0` back into a number in the visit pass: the bundler prints infinite numbers as `Infinity`, so folding a user's `1 / 0` would rewrite it to `Infinity` in non-minified bundles, and today `export const Infinity = 1e999` already bundles to `var Infinity = Infinity` (#35739 and #36122 reserve the name in the renamer). Folding would also have to track every future change to the folding policy (#30206 makes minify folding size-aware); the reorder predicate is correct whether or not the division was folded.
- Why not print `Infinity`: the transform printer has no scope information, which is why #7263 chose `1 / 0`. #36122 adds file-level shadow tracking, but it still falls back to `1 / 0` in files that declare `Infinity`, so the reorder still has to understand that spelling (covered by the "declares its own Infinity" test).
- Verified:
  - `test/bundler/transpiler/transpiler.test.js`, new `describe("equality comparisons against an infinite number")`: 15 of the 22 cases fail on the released binary and all pass with this change (plain and `minifyWhitespace` output, every operator, both infinities in both spellings, a file shadowing `Infinity`, an inlined enum, the negative cases, and a runtime check of the swapped divisions).
  - The whole of `transpiler.test.js`, `transpiler_constant_fold_eqeq.test.ts`, `bundler_minify.test.ts` and `regression/issue/07263.test.ts` pass with the debug build.
  - The fuzzer from #39006 with `Infinity` and `1e999` added to its number pool: 9000 programs over five seeds pass with this change; three of those seeds fail on the released binary with this swap (details below).

### Background
- The transpiler is parse, visit (the pass that folds and rewrites expressions), print. `Bun.Transpiler` runs that pipeline without the bundler's symbol renamer, so the printer cannot rename a local `Infinity` out of the way and spells the value `1 / 0` instead; the bundler runs the renamer and prints `Infinity`.
- `Infinity`, `NaN` and `undefined` that resolve to the globals are replaced with `ENumber` / `EUndefined` nodes during the visit (src/js_parser/defines_table.rs), which is why `"a" != NaN` round-trips: its printed form reads back as the same node kind.
- The equality reorder exists so later pattern matching (`typeof x === "undefined"`, `x == void 0`, constant comparisons) only has to look at one side. It is unconditional, not a minify-only optimization, so it runs on every pass.
- Arithmetic on literals is only folded when `minify_syntax` or inlining is on (`should_fold_typescript_constant_expressions` in src/js_parser/parse/parse_entry.rs), which is why `1 / 0` stays an `EBinary` in the default transform path.

<details>
<summary>Fuzzer runs and the <code>bun build --no-bundle</code> probe</summary>

Released binary (1.4.0) with `"Infinity"` and `"1e999"` added to `NUMBERS` in the #39006 fuzzer:

```
seed 1: iteration 72    "lone \uD800 surrogate" != 1 / 0        ->  1 / 0 != "lone \uD800 surrogate"
seed 2: iteration 578   -("tab\tand\\backslash" != 1 / 0)       ->  -(1 / 0 != "tab\tand\\backslash")
seed 3: iteration 726   `new...` == 1 / 0 (multi-line template)  ->  1 / 0 == `new...`
seed 4: 1500 programs without hitting the pattern
```

Debug build with this change, same fuzzer: seeds 1 to 4 at 1500 programs each and the default seed at 3000 programs, all pass.

`bun build --no-bundle` on

```js
y = "a" != Infinity;
z = 1 / 0 != x;
```

before: `y = "a" != 1 / 0;` / `z = 1 / 0 != x;`, after: `y = "a" != 1 / 0;` / `z = x != 1 / 0;`. A real bundle of the same input still prints `"a" != Infinity` and the user's `1 / 0` text unchanged, only the operand order of the second line moves, matching how `Infinity != x` was already printed.
</details>
