### PR TITLE
Pin follow-ups: init `pinned` in asBunArrayBuffer, release zlib async-write pins, sync borrow docs

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -7266,4 +7266,5 @@ extern "C" void JSC__ArrayBuffer__asBunArrayBuffer(JSC::ArrayBuffer* self, Bun__
     out->cell_type = JSC::JSType::ArrayBufferType;
     out->shared = self->isShared();
     out->resizable = self->isResizableOrGrowableShared();
+    out->pinned = false;
 }

--- a/src/runtime/image/Image.rs
+++ b/src/runtime/image/Image.rs
@@ -129,9 +129,9 @@ pub enum Source {
 unsafe extern "C" {
     fn JSC__JSValue__unpinArrayBuffer(v: JSValue);
     /// 0 = detached/null, 1 = FastTypedArray (≤~1 KB, GC-movable — dupe),
-    /// 2 = pinned ArrayBuffer (caller must unpin). For OversizeTypedArray the
-    /// helper adopts the storage in-place (createAdopted — no byte copy) and
-    /// pins; once adopted it's detachable, so it MUST be pinned, not borrowed.
+    /// 2 = pinned an existing ArrayBuffer (caller must unpin). 3 = held a
+    /// bufferless OversizeTypedArray: valid for the op, nothing to unpin (the
+    /// caller roots the value as it does for 2).
     fn JSC__JSValue__borrowBytesForOffThread(
         v: JSValue,
         out_ptr: *mut *const u8,
@@ -758,11 +758,8 @@ impl Image {
                             ))
                         }
                     }
-                    // Oversize/Wasteful/DataView/JSArrayBuffer: pinned by the
-                    // helper. For Oversize, possiblySharedBuffer() adopts the
-                    // existing fastMalloc storage in-place (zero byte copy);
-                    // pinning then keeps it alive even if JS does `.buffer` →
-                    // `transfer()` while the worker reads.
+                    // 2: Wasteful/DataView/JSArrayBuffer, pinned by the helper (unpin when done).
+                    // 3: OversizeTypedArray held without adopting an ArrayBuffer; nothing to unpin.
                     kind @ (2 | 3) => {
                         if len == 0 {
                             if kind == 2 {

--- a/src/runtime/node/node_zlib_binding.rs
+++ b/src/runtime/node/node_zlib_binding.rs
@@ -512,10 +512,6 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
         ticket.post(ConcurrentTask::create(Task::init(this)));
     }
 
-    /// VM teardown, JS thread, heap alive: a completion that was queued but
-    /// will not run. The cleanup half of `run_from_js_thread`, no callbacks.
-    ///
-    /// # Safety
     /// Releases the pins `write()` took; the cached slots keep rooting the values either way.
     fn unpin_pending_buffers(this: &T, this_value: JSValue) {
         let pinned = this.pinned_buffers().replace(0);
@@ -531,6 +527,10 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
         }
     }
 
+    /// VM teardown, JS thread, heap alive: a completion that was queued but
+    /// will not run. The cleanup half of `run_from_js_thread`, no callbacks.
+    ///
+    /// # Safety
     /// As [`run_from_js_thread`](Self::run_from_js_thread).
     pub(crate) unsafe fn release_unrun(this_ptr: *mut T) {
         let this = ParentRef::from(NonNull::new(this_ptr).expect("release_unrun: this"));

--- a/src/runtime/node/node_zlib_binding.rs
+++ b/src/runtime/node/node_zlib_binding.rs
@@ -236,6 +236,7 @@ pub(crate) trait CompressionStreamImpl: Sized + Taskable + 'static {
     fn this_value(&self) -> &JsCell<StrongOptional>;
     fn task(&self) -> &JsCell<WorkPoolTask>;
     fn write_in_progress(&self) -> &Cell<bool>;
+    fn pinned_buffers(&self) -> &Cell<u8>;
     fn pending_close(&self) -> &Cell<bool>;
     fn closed(&self) -> &Cell<bool>;
 
@@ -441,6 +442,9 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
             }
             return Err(global_this.throw_out_of_memory());
         };
+        this.pinned_buffers().set(
+            u8::from(in_buf.as_ref().is_some_and(|b| b.pinned)) | (u8::from(out_buf.pinned) << 1),
+        );
         let out: Option<&mut [u8]> = Some(
             &mut out_buf.byte_slice_mut()[out_off as usize..out_off as usize + out_len as usize],
         );
@@ -512,6 +516,21 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
     /// will not run. The cleanup half of `run_from_js_thread`, no callbacks.
     ///
     /// # Safety
+    /// Releases the pins `write()` took; the cached slots keep rooting the values either way.
+    fn unpin_pending_buffers(this: &T, this_value: JSValue) {
+        let pinned = this.pinned_buffers().replace(0);
+        if pinned & 1 != 0 {
+            if let Some(value) = T::pending_input_get_cached(this_value) {
+                value.unpin_array_buffer();
+            }
+        }
+        if pinned & 2 != 0 {
+            if let Some(value) = T::pending_output_get_cached(this_value) {
+                value.unpin_array_buffer();
+            }
+        }
+    }
+
     /// As [`run_from_js_thread`](Self::run_from_js_thread).
     pub(crate) unsafe fn release_unrun(this_ptr: *mut T) {
         let this = ParentRef::from(NonNull::new(this_ptr).expect("release_unrun: this"));
@@ -519,19 +538,7 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
         let vm = global.bun_vm();
         this.write_in_progress().set(false);
         if let Some(this_value) = this.this_value().with_mut(|v| v.try_swap()) {
-            for pinned in [
-                T::pending_input_get_cached(this_value),
-                T::pending_output_get_cached(this_value),
-            ]
-            .into_iter()
-            .flatten()
-            {
-                if pinned.is_cell() {
-                    if let Some(buf) = pinned.as_array_buffer(global) {
-                        buf.unpin();
-                    }
-                }
-            }
+            Self::unpin_pending_buffers(&this, this_value);
         }
         this.poll_ref().with_mut(|p| p.unref(vm));
         // SAFETY: fn contract — the write's ref.
@@ -574,19 +581,7 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
 
         this_value.ensure_still_alive();
 
-        for pinned in [
-            T::pending_input_get_cached(this_value),
-            T::pending_output_get_cached(this_value),
-        ]
-        .into_iter()
-        .flatten()
-        {
-            if pinned.is_cell() {
-                if let Some(buf) = pinned.as_array_buffer(global) {
-                    buf.unpin();
-                }
-            }
-        }
+        Self::unpin_pending_buffers(&this, this_value);
         T::pending_input_set_cached(this_value, global, JSValue::ZERO);
         T::pending_output_set_cached(this_value, global, JSValue::ZERO);
 
@@ -1055,6 +1050,7 @@ macro_rules! __impl_compression_stream {
             #[inline] fn this_value(&self) -> &::bun_jsc::JsCell<::bun_jsc::StrongOptional> { &self.this_value }
             #[inline] fn task(&self) -> &::bun_jsc::JsCell<::bun_jsc::WorkPoolTask> { &self.task }
             #[inline] fn write_in_progress(&self) -> &::core::cell::Cell<bool> { &self.write_in_progress }
+            #[inline] fn pinned_buffers(&self) -> &::core::cell::Cell<u8> { &self.pinned_buffers }
             #[inline] fn pending_close(&self) -> &::core::cell::Cell<bool> { &self.pending_close }
             #[inline] fn closed(&self) -> &::core::cell::Cell<bool> { &self.closed }
 

--- a/src/runtime/node/zlib/NativeBrotli.rs
+++ b/src/runtime/node/zlib/NativeBrotli.rs
@@ -92,6 +92,8 @@ mod _impl {
         // TODO: Strong self-ref on the wrapper → JsRef per PORTING.md §JSC (Strong back-ref to own wrapper leaks)
         pub this_value: JsCell<StrongOptional>, // Strong.Optional — empty-initialised
         pub write_in_progress: Cell<bool>,
+        /// bit 0: the pending input's ArrayBuffer is pinned; bit 1: the pending output's. A held bufferless view sets neither.
+        pub pinned_buffers: Cell<u8>,
         pub pending_close: Cell<bool>,
         pub closed: Cell<bool>,
         pub task: JsCell<WorkPoolTask>,
@@ -154,6 +156,7 @@ mod _impl {
                 poll_ref: JsCell::new(CountedKeepAlive::default()),
                 this_value: JsCell::new(StrongOptional::empty()),
                 write_in_progress: Cell::new(false),
+                pinned_buffers: Cell::new(0),
                 pending_close: Cell::new(false),
                 closed: Cell::new(false),
                 // .callback = undefined — overwritten before WorkPool::schedule()

--- a/src/runtime/node/zlib/NativeZlib.rs
+++ b/src/runtime/node/zlib/NativeZlib.rs
@@ -48,6 +48,8 @@ mod _impl {
         pub poll_ref: JsCell<CountedKeepAlive>,
         pub this_value: JsCell<StrongOptional>, // jsc.Strong.Optional
         pub write_in_progress: Cell<bool>,
+        /// bit 0: the pending input's ArrayBuffer is pinned; bit 1: the pending output's. A held bufferless view sets neither.
+        pub pinned_buffers: Cell<u8>,
         pub pending_close: Cell<bool>,
         pub closed: Cell<bool>,
         pub task: JsCell<WorkPoolTask>,
@@ -102,6 +104,7 @@ mod _impl {
                 poll_ref: JsCell::new(CountedKeepAlive::default()),
                 this_value: JsCell::new(StrongOptional::empty()),
                 write_in_progress: Cell::new(false),
+                pinned_buffers: Cell::new(0),
                 pending_close: Cell::new(false),
                 closed: Cell::new(false),
                 task: JsCell::new(WorkPoolTask {

--- a/src/runtime/node/zlib/NativeZstd.rs
+++ b/src/runtime/node/zlib/NativeZstd.rs
@@ -47,6 +47,8 @@ mod _impl {
         pub poll_ref: JsCell<CountedKeepAlive>,
         pub this_value: JsCell<StrongOptional>, // jsc.Strong.Optional
         pub write_in_progress: Cell<bool>,
+        /// bit 0: the pending input's ArrayBuffer is pinned; bit 1: the pending output's. A held bufferless view sets neither.
+        pub pinned_buffers: Cell<u8>,
         pub pending_close: Cell<bool>,
         pub closed: Cell<bool>,
         pub task: JsCell<WorkPoolTask>,
@@ -115,6 +117,7 @@ mod _impl {
                 poll_ref: JsCell::new(CountedKeepAlive::default()),
                 this_value: JsCell::new(StrongOptional::empty()),
                 write_in_progress: Cell::new(false),
+                pinned_buffers: Cell::new(0),
                 pending_close: Cell::new(false),
                 closed: Cell::new(false),
                 // WorkPoolTask { callback: undefined } — callback is overwritten by

--- a/src/sql_jsc/mysql/MySQLValue.rs
+++ b/src/sql_jsc/mysql/MySQLValue.rs
@@ -823,7 +823,8 @@ unsafe extern "C" {
     /// No caller-side preconditions → `safe fn`.
     safe fn JSC__JSValue__unpinArrayBuffer(v: JSValue);
     /// 0 = detached/null, 1 = FastTypedArray (GC-movable — caller should dupe;
-    /// no unpin needed), 2 = pinned ArrayBuffer (caller must `unpinArrayBuffer`).
+    /// no unpin needed), 2 = pinned an existing ArrayBuffer (caller must
+    /// `unpinArrayBuffer`), 3 = held a bufferless OversizeTypedArray (nothing to unpin; root it as for 2).
     /// Out-params are `&mut` (same ABI as `*mut`), so the only obligation left
     /// is on the *returned* slice, not the call itself → `safe fn`.
     safe fn JSC__JSValue__borrowBytesForOffThread(

--- a/test/js/node/zlib/zlib.test.js
+++ b/test/js/node/zlib/zlib.test.js
@@ -725,6 +725,35 @@ describe("async write buffer lifetime", () => {
   });
 });
 
+describe("async write pins are released", () => {
+  it("transfer() detaches once several async writes through the same buffers have completed", async () => {
+    const deflate = zlib.createDeflate();
+    try {
+      const handle = deflate._handle;
+      const input = new Uint8Array(new ArrayBuffer(64)).fill(97);
+      const out = new Uint8Array(new ArrayBuffer(4096));
+      for (let i = 0; i < 5; i++) {
+        const { promise, resolve } = Promise.withResolvers();
+        handle.buffer = input;
+        handle.cb = resolve;
+        handle.availOutBefore = out.byteLength;
+        handle.availInBefore = input.byteLength;
+        handle.inOff = 0;
+        handle.flushFlag = zlib.constants.Z_NO_FLUSH;
+        handle.write(zlib.constants.Z_NO_FLUSH, input, 0, input.byteLength, out, 0, out.byteLength);
+        await promise;
+      }
+      // Every write pinned both buffers; every completion must have unpinned them, or they stay undetachable.
+      out.buffer.transfer();
+      input.buffer.transfer();
+      expect(out.buffer.detached).toBe(true);
+      expect(input.buffer.detached).toBe(true);
+    } finally {
+      deflate.close();
+    }
+  });
+});
+
 describe("dictionary buffer lifetime", () => {
   it("decompresses correctly when the dictionary's ArrayBuffer is detached after stream creation", async () => {
     const dictText = "hello hello hello world world world ";


### PR DESCRIPTION
Three review findings on #38886 that landed after merge; all real.

- **`JSC__ArrayBuffer__asBunArrayBuffer` didn't write `out->pinned`** — its Rust caller builds the out-param with `MaybeUninit` and `assume_init()`s it, so the new `bool` was uninitialized (reachable via TLS options passed as `ArrayBuffer`s). Now set to `false` like the sibling producer.
- **`node:zlib` async writes leaked their pins.** `write()` pins input/output with `as_pinned_arraybuffer`, but both completion paths rebuilt them with `as_array_buffer()` — whose `pinned = false` turned `unpin()` into a no-op after #38886 gated it. Each async write left `m_pinCount` one higher, so those buffers could never be `transfer()`ed/`postMessage`d again (they copied forever). The stream now records which of the two buffers were actually pinned at write time and unpins exactly those on completion (a held bufferless view is rooted by the cached slot but has nothing to unpin). Test added: five async writes through the same buffers, then `transfer()` must detach — fails on main, passes here.
- Rust-side docs for `borrowBytesForOffThread` (Image, MySQL) now describe code 3 (held `OversizeTypedArray`, nothing to unpin) to match bindings.cpp.