### PR TITLE
Bun.serve: join server.fetch() relative URLs onto the port the listener bound

### DIFF
--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -161,6 +161,34 @@ impl ServerConfig {
 
         cost
     }
+
+    /// The string `server.fetch()` prepends to a relative URL.
+    ///
+    /// `from_js` formats `base_uri` before anything is bound, so a server
+    /// configured with `port: 0` (via the option, `PORT`, or `--port`) carries a
+    /// literal `:0`. Once the listener is up, pass the port it reports and that
+    /// placeholder is replaced; a base URI with any other port is returned as
+    /// written.
+    pub(crate) fn base_url_string_for_joining(&self, listening_port: Option<u16>) -> Box<[u8]> {
+        let base = bun_core::trim(&self.base_uri, b"/");
+        let Some(listening_port) = listening_port else {
+            return Box::from(base);
+        };
+        let port = URL::parse(base).port;
+        if port != b"0" {
+            return Box::from(base);
+        }
+        let Some([start, len]) = bun_alloc::range_of_slice_in_buffer(port, base) else {
+            return Box::from(base);
+        };
+        let (before, rest) = base.split_at(start as usize);
+        let after = &rest[len as usize..];
+        let mut buf: Vec<u8> = Vec::with_capacity(base.len() + 5);
+        buf.extend_from_slice(before);
+        let _ = write!(&mut buf, "{listening_port}");
+        buf.extend_from_slice(after);
+        buf.into_boxed_slice()
+    }
 }
 
 // We need to be able to apply the route to multiple Apps even when there is only one RouteList.

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -1984,6 +1984,10 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             return self.on_listen_failed();
         };
         self.listener = Some(socket);
+        // `None` for a unix socket, which has no port to fill in.
+        if let Some(port) = bun_opaque::opaque_deref_mut(socket).get_local_port() {
+            self.base_url_string_for_joining = self.config.base_url_string_for_joining(Some(port));
+        }
         // SAFETY: `vm_mut()` is the process-static `*mut VirtualMachine` (non-null
         // for the server's lifetime); single-threaded JS context.
         unsafe { (*self.vm_mut()).event_loop_handle = Some(bun_io::Loop::get()) };
@@ -2098,6 +2102,9 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             self.h3_alt_svc = format!("h3=\":{port}\"; ma=86400")
                 .into_bytes()
                 .into_boxed_slice();
+            // The only listener when `http1: false`; otherwise it shares the
+            // TCP listener's port and this repeats what `on_listen` did.
+            self.base_url_string_for_joining = self.config.base_url_string_for_joining(Some(port));
         }
         // An `http3_server` feature counter is not (yet) declared in
         // `bun_analytics`. No-op until it is.
@@ -2153,10 +2160,8 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
     where
         Self: ServerPools<SSL, DEBUG>,
     {
-        let base_url: Box<[u8]> = bun_core::trim(&config.base_uri, b"/")
-            .to_vec()
-            .into_boxed_slice();
-        // `base_url` drops on Err automatically.
+        // Re-derived in `on_listen` / `on_h3_listen` once the bound port is known.
+        let base_url = config.base_url_string_for_joining(None);
 
         let server = bun_core::heap::into_raw(Box::new(Self {
             global_this: std::ptr::from_ref(global),

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -346,6 +346,102 @@ describe.concurrent("Server", () => {
     }
   });
 
+  describe("server.fetch() with a relative URL uses the port the server bound", () => {
+    // Each server is started with port 0, so the base URL built from the config
+    // says ":0" until the listener reports the port the kernel picked.
+    const echoUrl = (req: Request) => new Response(req.url);
+    const fetchRelative = async (server: Server<undefined>, path: string) => {
+      const response = await server.fetch(path);
+      const url = new URL(await response.text());
+      return { protocol: url.protocol, hostname: url.hostname, port: url.port, pathname: url.pathname };
+    };
+
+    test("default hostname", async () => {
+      using server = Bun.serve({ port: 0, fetch: echoUrl });
+      expect(await fetchRelative(server, "/relative?q=1")).toEqual({
+        protocol: "http:",
+        hostname: "0.0.0.0",
+        port: String(server.port),
+        pathname: "/relative",
+      });
+    });
+
+    test("explicit hostname", async () => {
+      using server = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: echoUrl });
+      expect(await fetchRelative(server, "/relative")).toEqual({
+        protocol: "http:",
+        hostname: "127.0.0.1",
+        port: String(server.port),
+        pathname: "/relative",
+      });
+    });
+
+    test("tls", async () => {
+      using server = Bun.serve({ port: 0, hostname: "127.0.0.1", tls, fetch: echoUrl });
+      expect(await fetchRelative(server, "/relative")).toEqual({
+        protocol: "https:",
+        hostname: "127.0.0.1",
+        port: String(server.port),
+        pathname: "/relative",
+      });
+    });
+
+    test("http3 without an http1 listener", async () => {
+      using server = Bun.serve({ port: 0, hostname: "127.0.0.1", tls, http3: true, http1: false, fetch: echoUrl });
+      expect(await fetchRelative(server, "/relative")).toEqual({
+        protocol: "https:",
+        hostname: "127.0.0.1",
+        port: String(server.port),
+        pathname: "/relative",
+      });
+    });
+
+    test("baseURI without a scheme takes the scheme and port from the server", async () => {
+      // @ts-expect-error baseURI is undocumented
+      using server = Bun.serve({ port: 0, baseURI: "example.com/api/", fetch: echoUrl });
+      expect(await fetchRelative(server, "/relative")).toEqual({
+        protocol: "http:",
+        hostname: "example.com",
+        port: String(server.port),
+        pathname: "/api/relative",
+      });
+    });
+
+    test("baseURI with a scheme is used as written", async () => {
+      // @ts-expect-error baseURI is undocumented
+      using server = Bun.serve({ port: 0, baseURI: "https://example.com/api/", fetch: echoUrl });
+      expect(await fetchRelative(server, "/relative")).toEqual({
+        protocol: "https:",
+        hostname: "example.com",
+        port: "",
+        pathname: "/api/relative",
+      });
+    });
+
+    test("bun --port 0", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "--port",
+          "0",
+          "-e",
+          `using server = Bun.serve({ fetch: req => new Response(req.url) });
+           const url = new URL(await (await server.fetch("/relative")).text());
+           console.log(JSON.stringify({ port: server.port, url: { hostname: url.hostname, port: url.port, pathname: url.pathname } }));`,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      const { port, url } = JSON.parse(stdout);
+      expect(port).toBeGreaterThan(0);
+      expect(url).toEqual({ hostname: "localhost", port: String(port), pathname: "/relative" });
+      expect(exitCode).toBe(0);
+    });
+  });
+
   test("server should return a body for a OPTIONS Request", async () => {
     using server = Bun.serve({
       port: 0,


### PR DESCRIPTION
### Problem

- `server.fetch("/x")` on a server started with `port: 0` dispatches a `Request` whose `url` is `http://0.0.0.0:0/x`: the port is the configured `0`, not the one the listener bound. `server.port` and `server.url` report the bound port for the same server.
- Every way of asking for an ephemeral port hits it: `PORT=0` gives `http://0.0.0.0:0/x`, `bun --port 0` gives `http://localhost:0/x`, `hostname: "::1"` gives `http://[::1]:0/x`, the undocumented `baseURI: "example.com/api/"` gives `http://example.com:0/api/x`.
- Cause: `ServerConfig::from_js` formats `base_uri` with the configured port (`src/runtime/server/ServerConfig.rs`, the `base_uri` normalization block at the end of `from_js`; `--port` arrives there already formatted as `transform_options.origin`). `NewServer::init` copies it into `base_url_string_for_joining` (`src/runtime/server/mod.rs`), `on_fetch` prepends that to relative paths (`src/runtime/server/server_body.rs`), and nothing revisits it after `listen()` learns the real port. The `port`/`url` getters ask the listen socket, which is why they are right.
- Has been this way since `server.fetch()` was added, so not a regression.

### Fix

- Adds `ServerConfig::base_url_string_for_joining(listening_port)`: the trimmed `base_uri`, with its port component replaced by `listening_port` when that component is `0`. With no port, or a base whose port component is absent or non-zero, the result is byte-identical to what `init` built before.
- `on_listen` and `on_h3_listen` store the result for the port their listen socket reports; `init` still stores the pre-listen value so the field is always populated.
- Why `:0` is the trigger: `from_js` is what writes the port into that position, so `0` there means "ephemeral", the same thing it means in the `port` option. Keying on the text rather than on which `from_js` branch produced the string is what also covers `--port 0`, whose origin reaches `from_js` already formatted. A user `baseURI` with a real port or no port has nothing to resolve and is left alone.
- Why at listen time: each callback derives from the untouched `config.base_uri`, so the HTTP/3 retry in `listen()` (close the TCP listener and rebind when the matching UDP port is taken) ends on the final port, and the string keeps the bound port after `server.stop()` drops the listen socket. `on_h3_listen` is required for `http1: false`, where it is the only listener; with both enabled it recomputes the same string.
- Unchanged: fixed ports, explicit base URIs, unix sockets (no local port, so `init`'s value stays), `reload()` (never touched this string), and `on_fetch` itself.
- Verified with `bun bd test test/js/bun/http/bun-server.test.ts -t "relative URL uses the port"`: 7 tests (default hostname, explicit hostname, TLS, `http3: true, http1: false`, `baseURI` without a scheme, `baseURI` with a scheme as the unchanged-path guard, `bun --port 0`). Under `USE_SYSTEM_BUN=1` (1.4.0) the 6 ephemeral-port tests fail and the guard passes.
- Related, not overlapping: #33721 wants to use this same string as the fallback authority for requests without a usable Host header; with this change those URLs would get the bound port too.

<details>
<summary>Other test files run with the debug build</summary>

`bun-server.test.ts` (rest of file), `bun-serve-routes`, `bun-serve-fetch-invalid-args`, `serve-listen`, `bun-serve-args`, `server-url-invalid`, `serve-http3`, `serve-protocols`, and `test/internal/source-lints`. Failures seen, none related to this diff:

- three `bun-server.test.ts` tests that connect to `localhost` fail identically on the released binary in this container (the server binds `::1`, the client connects to `127.0.0.1`);
- `leaks-test.test.ts` detects ASAN from the binary name, so a `bun-debug` ASAN build gets the non-ASAN threshold (#36890 fixes that); running the `server.fetch(string)` leak fixture with the ASAN threshold applied gives 347 MB against a 450 MB limit, where a leak would be ~650 MB;
- `serve-http3` "Response(subprocess.stdout) streams over H3" spawns a second debug binary and runs at ~4.8 s against the 5 s timeout; it passes on rerun.

</details>

### Background

- `server.fetch(input)` calls the server's `fetch` handler in-process, without a socket; it exists for tests. A string that parses without a hostname is treated as a path and prepended with `base_url_string_for_joining`; anything else is used as given.
- `base_uri` is the origin `from_js` computes for a server: by default `http(s)://<hostname or 0.0.0.0>:<port>/`, otherwise the undocumented `baseURI` option or the `--origin` CLI flag (which `--port N` sets to `http://localhost:N/`) with any missing scheme and port filled in. This join string is its only consumer.
- `port: 0` asks the kernel to pick a free port at `bind()`. `on_listen` (TCP and unix sockets) and `on_h3_listen` (the QUIC/UDP listener) are the callbacks uWebSockets invokes from inside `listen()` with the resulting listen socket; `get_local_port()` is `getsockname()` on it and is `None` for address families without a port. `on_h3_listen` already formatted the `Alt-Svc` value from the bound port the same way.
- `bun_url::URL::parse` is Bun's lenient byte-slice URL splitter. Every component it returns borrows from the input, which is what lets `bun_alloc::range_of_slice_in_buffer` turn the port component back into an offset to splice at.
