### PR TITLE
node:buffer: match Node's input handling in isUtf8() and isAscii()

### DIFF
--- a/src/jsc/modules/NodeBufferModule.h
+++ b/src/jsc/modules/NodeBufferModule.h
@@ -44,7 +44,6 @@ static JSC::EncodedJSValue validateBytesOf(JSC::JSGlobalObject* globalObject, JS
     return JSValue::encode(jsBoolean(validate(reinterpret_cast<const char*>(bytes.data()), bytes.size())));
 }
 
-// TODO: Add DOMJIT fast path
 JSC_DEFINE_HOST_FUNCTION(jsBufferConstructorFunction_isUtf8,
     (JSC::JSGlobalObject * lexicalGlobalObject,
         JSC::CallFrame* callframe))
@@ -54,7 +53,6 @@ JSC_DEFINE_HOST_FUNCTION(jsBufferConstructorFunction_isUtf8,
     });
 }
 
-// TODO: Add DOMJIT fast path
 JSC_DEFINE_HOST_FUNCTION(jsBufferConstructorFunction_isAscii,
     (JSC::JSGlobalObject * lexicalGlobalObject,
         JSC::CallFrame* callframe))

--- a/src/jsc/modules/NodeBufferModule.h
+++ b/src/jsc/modules/NodeBufferModule.h
@@ -14,58 +14,44 @@ namespace Zig {
 using namespace WebCore;
 using namespace JSC;
 
+// Shared by buffer.isUtf8() and buffer.isAscii(). Node accepts a TypedArray (so not a
+// DataView), an ArrayBuffer or a SharedArrayBuffer and throws ERR_INVALID_ARG_TYPE for
+// anything else; only a detached ArrayBuffer is ERR_INVALID_STATE, a view whose buffer
+// was detached has a byteLength of 0 and validates like any other empty input.
+// https://github.com/nodejs/node/blob/v26.3.0/lib/buffer.js#L1415-L1429
+// https://github.com/nodejs/node/blob/v26.3.0/src/node_buffer.cc#L1305-L1333
+template<typename Validate>
+static JSC::EncodedJSValue validateBytesOf(JSC::JSGlobalObject* globalObject, JSC::JSValue input, Validate validate)
+{
+    auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
+
+    std::span<const uint8_t> bytes;
+    if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(input); view && isTypedArrayType(view->type())) {
+        bytes = view->span();
+    } else if (auto* arrayBuffer = dynamicDowncast<JSC::JSArrayBuffer>(input)) {
+        if (arrayBuffer->impl()->isDetached()) [[unlikely]] {
+            // Thrown from C++ in Node too, so without the "Invalid state: " prefix Bun::ERR::INVALID_STATE adds.
+            return Bun::throwError(globalObject, scope, Bun::ErrorCode::ERR_INVALID_STATE, "Cannot validate on a detached buffer"_s);
+        }
+        bytes = arrayBuffer->impl()->span();
+    } else {
+        return Bun::ERR::INVALID_ARG_INSTANCE(scope, globalObject, "input"_s, "ArrayBuffer, Buffer, or TypedArray"_s, input);
+    }
+
+    if (bytes.empty())
+        return JSValue::encode(jsBoolean(true));
+
+    return JSValue::encode(jsBoolean(validate(reinterpret_cast<const char*>(bytes.data()), bytes.size())));
+}
+
 // TODO: Add DOMJIT fast path
 JSC_DEFINE_HOST_FUNCTION(jsBufferConstructorFunction_isUtf8,
     (JSC::JSGlobalObject * lexicalGlobalObject,
         JSC::CallFrame* callframe))
 {
-    auto throwScope = DECLARE_THROW_SCOPE(lexicalGlobalObject->vm());
-
-    auto buffer = callframe->argument(0);
-    auto* bufferView = dynamicDowncast<JSC::JSArrayBufferView>(buffer);
-    const char* ptr = nullptr;
-    size_t byteLength = 0;
-    if (bufferView) {
-        if (bufferView->isDetached()) [[unlikely]] {
-            throwTypeError(lexicalGlobalObject, throwScope,
-                "ArrayBufferView is detached"_s);
-            return {};
-        }
-
-        byteLength = bufferView->byteLength();
-
-        if (byteLength == 0) {
-            return JSValue::encode(jsBoolean(true));
-        }
-
-        ptr = reinterpret_cast<const char*>(bufferView->vector());
-    } else if (auto* arrayBuffer = dynamicDowncast<JSC::JSArrayBuffer>(buffer)) {
-        auto* impl = arrayBuffer->impl();
-
-        if (!impl) {
-            return JSValue::encode(jsBoolean(true));
-        }
-
-        if (impl->isDetached()) [[unlikely]] {
-            return Bun::ERR::INVALID_STATE(throwScope, lexicalGlobalObject,
-                "Cannot validate on a detached buffer"_s);
-        }
-
-        byteLength = impl->byteLength();
-
-        if (byteLength == 0) {
-            return JSValue::encode(jsBoolean(true));
-        }
-
-        ptr = reinterpret_cast<const char*>(impl->data());
-    } else {
-        Bun::throwError(lexicalGlobalObject, throwScope,
-            Bun::ErrorCode::ERR_INVALID_ARG_TYPE,
-            "First argument must be an ArrayBufferView"_s);
-        return {};
-    }
-
-    RELEASE_AND_RETURN(throwScope, JSValue::encode(jsBoolean(simdutf::validate_utf8(ptr, byteLength))));
+    return validateBytesOf(lexicalGlobalObject, callframe->argument(0), [](const char* data, size_t length) {
+        return simdutf::validate_utf8(data, length);
+    });
 }
 
 // TODO: Add DOMJIT fast path
@@ -73,54 +59,9 @@ JSC_DEFINE_HOST_FUNCTION(jsBufferConstructorFunction_isAscii,
     (JSC::JSGlobalObject * lexicalGlobalObject,
         JSC::CallFrame* callframe))
 {
-    auto throwScope = DECLARE_THROW_SCOPE(lexicalGlobalObject->vm());
-
-    auto buffer = callframe->argument(0);
-    auto* bufferView = dynamicDowncast<JSC::JSArrayBufferView>(buffer);
-    const char* ptr = nullptr;
-    size_t byteLength = 0;
-    if (bufferView) {
-
-        if (bufferView->isDetached()) [[unlikely]] {
-            return Bun::ERR::INVALID_STATE(throwScope, lexicalGlobalObject,
-                "Cannot validate on a detached buffer"_s);
-        }
-
-        byteLength = bufferView->byteLength();
-
-        if (byteLength == 0) {
-            return JSValue::encode(jsBoolean(true));
-        }
-
-        ptr = reinterpret_cast<const char*>(bufferView->vector());
-    } else if (auto* arrayBuffer = dynamicDowncast<JSC::JSArrayBuffer>(buffer)) {
-        auto* impl = arrayBuffer->impl();
-        if (impl->isDetached()) [[unlikely]] {
-            return Bun::ERR::INVALID_STATE(throwScope, lexicalGlobalObject,
-                "Cannot validate on a detached buffer"_s);
-        }
-
-        if (!impl) {
-            return JSValue::encode(jsBoolean(true));
-        }
-
-        byteLength = impl->byteLength();
-
-        if (byteLength == 0) {
-            return JSValue::encode(jsBoolean(true));
-        }
-
-        ptr = reinterpret_cast<const char*>(impl->data());
-    } else {
-        Bun::throwError(lexicalGlobalObject, throwScope,
-            Bun::ErrorCode::ERR_INVALID_ARG_TYPE,
-            "First argument must be an ArrayBufferView"_s);
-        return {};
-    }
-
-    RELEASE_AND_RETURN(
-        throwScope,
-        JSValue::encode(jsBoolean(simdutf::validate_ascii(ptr, byteLength))));
+    return validateBytesOf(lexicalGlobalObject, callframe->argument(0), [](const char* data, size_t length) {
+        return simdutf::validate_ascii(data, length);
+    });
 }
 
 BUN_DECLARE_HOST_FUNCTION(jsFunctionResolveObjectURL);

--- a/src/jsc/modules/NodeBufferModule.h
+++ b/src/jsc/modules/NodeBufferModule.h
@@ -14,10 +14,7 @@ namespace Zig {
 using namespace WebCore;
 using namespace JSC;
 
-// Shared by buffer.isUtf8() and buffer.isAscii(). Node accepts a TypedArray (so not a
-// DataView), an ArrayBuffer or a SharedArrayBuffer and throws ERR_INVALID_ARG_TYPE for
-// anything else; only a detached ArrayBuffer is ERR_INVALID_STATE, a view whose buffer
-// was detached has a byteLength of 0 and validates like any other empty input.
+// Port of Node's buffer.isUtf8() / buffer.isAscii() argument handling:
 // https://github.com/nodejs/node/blob/v26.3.0/lib/buffer.js#L1415-L1429
 // https://github.com/nodejs/node/blob/v26.3.0/src/node_buffer.cc#L1305-L1333
 template<typename Validate>
@@ -26,6 +23,8 @@ static JSC::EncodedJSValue validateBytesOf(JSC::JSGlobalObject* globalObject, JS
     auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
 
     std::span<const uint8_t> bytes;
+    // isTypedArrayType() excludes DataView, which Node rejects. A view whose buffer was detached
+    // has a byteLength of 0 and validates as empty; Node only throws for the ArrayBuffer itself.
     if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(input); view && isTypedArrayType(view->type())) {
         bytes = view->span();
     } else if (auto* arrayBuffer = dynamicDowncast<JSC::JSArrayBuffer>(input)) {

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -4746,3 +4746,89 @@ it.skipIf(os.totalmem() < 10 * 1024 ** 3)(
     expect(exitCode).toBe(0);
   },
 );
+
+describe.each([
+  ["isUtf8", isUtf8],
+  ["isAscii", isAscii],
+])("buffer.%s() input handling", (name, validate) => {
+  // "ab" followed by "é" in UTF-8: valid UTF-8, not ASCII. 8 bytes so every TypedArray kind can view it.
+  const bytes = [0x61, 0x62, 0x20, 0x20, 0x20, 0x20, 0xc3, 0xa9];
+  const expected = name === "isUtf8";
+  const invalidInput = received =>
+    expect.objectContaining({
+      name: "TypeError",
+      code: "ERR_INVALID_ARG_TYPE",
+      message: `The "input" argument must be an instance of ArrayBuffer, Buffer, or TypedArray. Received ${received}`,
+    });
+
+  // Node types the parameter as TypedArray | ArrayBuffer | Buffer. A DataView is an ArrayBufferView
+  // in JSC as well, but it is not a TypedArray, so it is rejected like any other object.
+  it.each([
+    ["the whole buffer", ab => new DataView(ab)],
+    ["a sub-range", ab => new DataView(ab, 2, 4)],
+    ["zero bytes", () => new DataView(new ArrayBuffer(0))],
+  ])("rejects a DataView over %s", (_, makeView) => {
+    expect(() => validate(makeView(new Uint8Array(bytes).buffer))).toThrow(invalidInput("an instance of DataView"));
+  });
+
+  it.each([
+    ["undefined", undefined, "undefined"],
+    ["null", null, "null"],
+    ["a string", "abc", "type string ('abc')"],
+    ["a number", 1, "type number (1)"],
+    ["a plain object", {}, "an instance of Object"],
+    ["an array of bytes", [0x61], "an instance of Array"],
+  ])("rejects %s with Node's message", (_, input, received) => {
+    expect(() => validate(input)).toThrow(invalidInput(received));
+  });
+
+  it("throws ERR_INVALID_STATE for a detached ArrayBuffer", () => {
+    const ab = new Uint8Array(bytes).buffer;
+    structuredClone(ab, { transfer: [ab] });
+    expect(() => validate(ab)).toThrow(
+      expect.objectContaining({
+        name: "Error",
+        code: "ERR_INVALID_STATE",
+        message: "Cannot validate on a detached buffer",
+      }),
+    );
+  });
+
+  // Node only checks the ArrayBuffer form for detachment; a detached view reports byteLength 0
+  // and validates like any other empty input.
+  it("validates a view whose buffer was detached as empty input", () => {
+    const view = new Uint8Array([0xff, 0xfe]);
+    structuredClone(view.buffer, { transfer: [view.buffer] });
+    expect(view.byteLength).toBe(0);
+    expect(validate(view)).toBe(true);
+  });
+
+  it("accepts every TypedArray kind, Buffer, ArrayBuffer and SharedArrayBuffer", () => {
+    const ab = new Uint8Array(bytes).buffer;
+    const sab = new SharedArrayBuffer(bytes.length);
+    new Uint8Array(sab).set(bytes);
+    const inputs = [
+      new Int8Array(ab),
+      new Uint8Array(ab),
+      new Uint8ClampedArray(ab),
+      new Int16Array(ab),
+      new Uint16Array(ab),
+      new Int32Array(ab),
+      new Uint32Array(ab),
+      new Float16Array(ab),
+      new Float32Array(ab),
+      new Float64Array(ab),
+      new BigInt64Array(ab),
+      new BigUint64Array(ab),
+      Buffer.from(ab),
+      ab,
+      sab,
+      new Uint8Array(sab),
+    ];
+    expect(inputs.map(input => validate(input))).toEqual(inputs.map(() => expected));
+    // The view decides which bytes are looked at: the non-ASCII tail is outside this one.
+    expect(validate(new Uint8Array(ab, 0, 6))).toBe(true);
+    expect(validate(new Uint8Array(0))).toBe(true);
+    expect(validate(new ArrayBuffer(0))).toBe(true);
+  });
+});


### PR DESCRIPTION
### Problem
- `isUtf8(new DataView(ab))` and `isAscii(new DataView(ab))` from `node:buffer` scan the bytes and return a boolean. Node throws `TypeError [ERR_INVALID_ARG_TYPE]: The "input" argument must be an instance of ArrayBuffer, Buffer, or TypedArray. Received an instance of DataView`.
- Cause: both functions start with `dynamicDowncast<JSArrayBufferView>` (`src/jsc/modules/NodeBufferModule.h:25` and `:79` on main). In JSC a `DataView` is a `JSArrayBufferView`, so it takes the "view" branch.
- Same functions, same contract, also off: every other rejected input gets a hand-written `First argument must be an ArrayBufferView` instead of Node's message above; a TypedArray whose buffer was detached throws (a code-less `TypeError` from `isUtf8`, `ERR_INVALID_STATE` from `isAscii`) where Node returns `true`; a detached `ArrayBuffer` throws with the message `Invalid state: Cannot validate on a detached buffer` where Node's is `Cannot validate on a detached buffer`.

```js
const { isUtf8, isAscii } = require("node:buffer");
const ab = new Uint8Array([0x61, 0x62, 0x63, 0x64]).buffer;
isUtf8(new DataView(ab));  // bun 1.4.0: true    node v26.3.0: throws ERR_INVALID_ARG_TYPE
isAscii(new DataView(ab)); // bun 1.4.0: true    node v26.3.0: throws ERR_INVALID_ARG_TYPE
isUtf8({});                // bun 1.4.0: "First argument must be an ArrayBufferView"
                           // node:      'The "input" argument must be an instance of ArrayBuffer, Buffer, or TypedArray. Received an instance of Object'
```

### Fix
- Replace the two copies of the argument handling with one helper, `validateBytesOf`, that each function calls with its simdutf validator. The helper is a port of Node's two layers: the JS check `isTypedArray(input) || isAnyArrayBuffer(input)` ([lib/buffer.js#L1415-L1429](https://github.com/nodejs/node/blob/v26.3.0/lib/buffer.js#L1415-L1429)) and the binding's detached check ([src/node_buffer.cc#L1305-L1333](https://github.com/nodejs/node/blob/v26.3.0/src/node_buffer.cc#L1305-L1333)).
- The fixing condition is `view && isTypedArrayType(view->type())`: `isTypedArrayType` is true for the twelve TypedArray kinds and false for `DataViewType`, which is exactly Node's `isTypedArray`. It is the predicate `BunObject.cpp` and `napi.cpp` already use for this distinction, and the one #35239 uses for the same bug in `Buffer.copyBytesFrom`.
- Rejections go through `Bun::ERR::INVALID_ARG_INSTANCE("input", "ArrayBuffer, Buffer, or TypedArray", value)`, which keeps the `ERR_INVALID_ARG_TYPE` code and renders Node's wording including the `Received ...` suffix. This is the helper the rest of `JSBuffer.cpp` uses for class-instance expectations.
- Detached handling now sits where Node has it. Node's binding only records detachment for the `ArrayBuffer` form ([util-inl.h#L599](https://github.com/nodejs/node/blob/v26.3.0/src/util-inl.h#L599)); a view over a detached buffer reports `byteLength` 0 and validates as empty, so the helper reads `view->span()` (JSC zeroes the length when a view is detached) and only checks `impl()->isDetached()` on the `ArrayBuffer` branch. The `ArrayBuffer` error is thrown with `Bun::throwError(ERR_INVALID_STATE, ...)` rather than `Bun::ERR::INVALID_STATE`, because the latter prepends `Invalid state: ` (Node's JS-side format) and this error comes from C++ in Node; `NodeSqlite.cpp` makes the same distinction. The `impl()` null check the old `isUtf8` copy had is gone: `JSArrayBuffer::finishCreation` dereferences `impl()`, so it is never null for a live wrapper, and `Buffer.byteLength` in `JSBuffer.cpp` already relies on that.
- Node main has since gone one step further: nodejs/node#64504 (landed 2026-08-05, not in any release yet) removes the detached `ArrayBuffer` throw too, so there a detached `ArrayBuffer` and a view over one are both treated as empty. This PR follows v26.3.0, which is what the ported upstream tests in `test/js/node/test/parallel/test-buffer-isutf8.js` and `test-buffer-isascii.js` assert (`ERR_INVALID_STATE` for the `ArrayBuffer` form). When those files are re-ported from a release that contains #64504, the `isDetached()` branch of the helper and the one `ERR_INVALID_STATE` assertion added here are the two things to drop; the detached-view behavior adopted here is the one #64504 codifies.
- `utf-8-validate`'s default export is this same `isUtf8` host function (`UTF8ValidateModule.h`), so it picks up the same argument handling. Its documented argument is a `Buffer`, and `ws` and `crossws` only ever pass one; the `ArrayBuffer` acceptance and `ERR_INVALID_ARG_TYPE` rejections it had before were already `node:buffer` semantics rather than the package's.
- Verified with `test/js/node/buffer.test.js` (`buffer.isUtf8() input handling` / `buffer.isAscii() input handling`): 22 of the 24 new cases fail on bun 1.4.0 (three `DataView` shapes, six rejected inputs with the exact message, the detached `ArrayBuffer` message, and the detached view) and all pass with this build; the two that pass on both are the accepted-kinds controls covering every TypedArray kind, `Buffer`, `ArrayBuffer`, `SharedArrayBuffer`, a view over a `SharedArrayBuffer`, and a sub-range view, with bytes that make `isUtf8` and `isAscii` answer differently.
- `bun bd test test/js/node/buffer.test.js`: 642 pass, 1 skip, 0 fail.
- `bun bd test/js/node/test/parallel/test-buffer-isutf8.js` and `test-buffer-isascii.js` (Node's own tests, already ported): exit 0.
- `bun bd test test/js/first_party/utf-8-validate/utf-8-validate.test.ts`: pass.
- A 49-input probe run through both functions (every TypedArray kind, sub-range views, resizable and growable buffers, out-of-bounds views, detached buffer and view, three `DataView` shapes, and 20 non-buffer values) prints byte-identical output on this build and on node v26.3.0; 50 of its 98 lines differ on bun 1.4.0. Output below.

### Background
- `JSArrayBufferView` is JSC's base class for everything that views an `ArrayBuffer`: the typed arrays and `DataView`. `dynamicDowncast<JSArrayBufferView>` therefore accepts a `DataView`; `JSC::isTypedArrayType(JSType)` is the predicate that excludes it (`isTypedArrayTypeIncludingDataView` is the other variant).
- `JSArrayBufferView::span()` is the view's bytes as `{vector(), byteLength()}`. When a buffer is detached JSC sets every view's length to 0 and clears its vector, and a view that fell out of bounds of a shrunk resizable buffer also reports length 0, so the span is empty in both cases and no memory is read.
- `JSArrayBuffer` wraps both `ArrayBuffer` and `SharedArrayBuffer` (they differ only in `impl()->isShared()`), which is why one downcast covers Node's `isAnyArrayBuffer`. A `SharedArrayBuffer` cannot be detached.
- Node's `ERR_INVALID_ARG_TYPE` picks its wording from the expected names: capitalized class names render as `must be an instance of A, B, or C`. `Bun::ERR::INVALID_ARG_INSTANCE` is the helper that produces that form; `Bun::ERR::INVALID_ARG_TYPE` with a plain string renders `must be of type ...`.
- Node has two flavors of `ERR_INVALID_STATE`: the JS one formats as `Invalid state: %s`, the C++ `THROW_ERR_INVALID_STATE` uses the message verbatim. `Bun::ERR::INVALID_STATE` implements the JS flavor; `Bun::throwError` with the code gives the C++ one.

<details><summary>Probe output (identical on this build and node v26.3.0)</summary>

```
isUtf8(Uint8Array): returns true
isUtf8(Uint8Array ascii slice): returns true
isUtf8(Uint8Array subclass): returns true
isUtf8(Buffer): returns true
isUtf8(Int8Array): returns true
isUtf8(Uint8ClampedArray): returns true
isUtf8(Int16Array): returns true
isUtf8(Uint16Array): returns true
isUtf8(Int32Array): returns true
isUtf8(Uint32Array): returns true
isUtf8(Float16Array): returns true
isUtf8(Float32Array): returns true
isUtf8(Float64Array): returns true
isUtf8(BigInt64Array): returns true
isUtf8(BigUint64Array): returns true
isUtf8(ArrayBuffer): returns true
isUtf8(empty ArrayBuffer): returns true
isUtf8(empty Uint8Array): returns true
isUtf8(resizable ArrayBuffer): returns true
isUtf8(view over shrunk resizable buffer (out of bounds)): returns true
isUtf8(length-tracking view after shrink): returns true
isUtf8(SharedArrayBuffer): returns true
isUtf8(Uint8Array over SharedArrayBuffer): returns true
isUtf8(growable SharedArrayBuffer): returns true
isUtf8(detached ArrayBuffer): throws Error ERR_INVALID_STATE "Cannot validate on a detached buffer"
isUtf8(view over detached buffer): returns true
isUtf8(DataView): throws TypeError ERR_INVALID_ARG_TYPE "The \"input\" argument must be an instance of ArrayBuffer, Buffer, or TypedArray. Received an instance of DataView"
isUtf8(DataView sub-range): throws TypeError ERR_INVALID_ARG_TYPE "The \"input\" argument must be an instance of ArrayBuffer, Buffer, or TypedArray. Received an instance of DataView"
isUtf8(empty DataView): throws TypeError ERR_INVALID_ARG_TYPE "The \"input\" argument must be an instance of ArrayBuffer, Buffer, or TypedArray. Received an instance of DataView"
isUtf8(undefined): throws TypeError ERR_INVALID_ARG_TYPE "The \"input\" argument must be an instance of ArrayBuffer, Buffer, or TypedArray. Received undefined"
isUtf8(null): throws TypeError ERR_INVALID_ARG_TYPE "The \"input\" argument must be an instance of ArrayBuffer, Buffer, or TypedArray. Received null"
isUtf8(string): throws TypeError ERR_INVALID_ARG_TYPE "The \"input\" argument must be an instance of ArrayBuffer, Buffer, or TypedArray. Received type string ('abc')"
isUtf8(long string): throws TypeError ERR_INVALID_ARG_TYPE "The \"input\" argument must be an instance of ArrayBuffer, Buffer, or TypedArray. Received type string ('xxxxxxxxxxxxxxxxxxxxxxxxx...')"
isUtf8(number): throws TypeError ERR_INVALID_ARG_TYPE "The \"input\" argument must be an instance of ArrayBuffer, Buffer, or TypedArray. Received type number (42)"
isUtf8(NaN): throws TypeError ERR_INVALID_ARG_TYPE "The \"input\" argument must be an instance of ArrayBuffer, Buffer, or TypedArray. Received type number (NaN)"
isUtf8(bigint): throws TypeError ERR_INVALID_ARG_TYPE "The \"input\" argument must be an instance of ArrayBuffer, Buffer, or TypedArray. Received type bigint (1n)"
isUtf8(boolean): throws TypeError ERR_INVALID_ARG_TYPE "The \"input\" argument must be an instance of ArrayBuffer, Buffer, or TypedArray. Received type boolean (true)"
isUtf8(symbol): throws TypeError ERR_INVALID_ARG_TYPE "The \"input\" argument must be an instance of ArrayBuffer, Buffer, or TypedArray. Received type symbol (Symbol(s))"
isUtf8(named function): throws TypeError ERR_INVALID_ARG_TYPE "The \"input\" argument must be an instance of ArrayBuffer, Buffer, or TypedArray. Received function named"
isUtf8(anonymous arrow): throws TypeError ERR_INVALID_ARG_TYPE "The \"input\" argument must be an instance of ArrayBuffer, Buffer, or TypedArray. Received function "
isUtf8(class instance): throws TypeError ERR_INVALID_ARG_TYPE "The \"input\" argument must be an instance of ArrayBuffer, Buffer, or TypedArray. Received an instance of Foo"
isUtf8(plain object): throws TypeError ERR_INVALID_ARG_TYPE "The \"input\" argument must be an instance of ArrayBuffer, Buffer, or TypedArray. Received an instance of Object"
isUtf8(object with props): throws TypeError ERR_INVALID_ARG_TYPE "The \"input\" argument must be an instance of ArrayBuffer, Buffer, or TypedArray. Received an instance of Object"
isUtf8(null-prototype object): throws TypeError ERR_INVALID_ARG_TYPE "The \"input\" argument must be an instance of ArrayBuffer, Buffer, or TypedArray. Received [Object: null prototype] {}"
isUtf8(array): throws TypeError ERR_INVALID_ARG_TYPE "The \"input\" argument must be an instance of ArrayBuffer, Buffer, or TypedArray. Received an instance of Array"
isUtf8(Blob): throws TypeError ERR_INVALID_ARG_TYPE "The \"input\" argument must be an instance of ArrayBuffer, Buffer, or TypedArray. Received an instance of Blob"
isUtf8(Date): throws TypeError ERR_INVALID_ARG_TYPE "The \"input\" argument must be an instance of ArrayBuffer, Buffer, or TypedArray. Received an instance of Date"
isUtf8(Promise): throws TypeError ERR_INVALID_ARG_TYPE "The \"input\" argument must be an instance of ArrayBuffer, Buffer, or TypedArray. Received an instance of Promise"
isUtf8(no argument): throws TypeError ERR_INVALID_ARG_TYPE "The \"input\" argument must be an instance of ArrayBuffer, Buffer, or TypedArray. Received undefined"
```

The `isAscii` half is the same except that the eight-byte inputs (which end in the UTF-8 encoding of `é`) return `false`; the ASCII slice, the out-of-bounds and length-tracking views, the empty inputs and the detached view return `true`.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/buffer.test.js

<!-- robobun:evidence:end -->