### PR TITLE
build: do not replace the prebuilt tree a concurrent fetch already published

### DIFF
--- a/scripts/build/download.ts
+++ b/scripts/build/download.ts
@@ -34,6 +34,26 @@
  * interrupted (ctrl-c, network drop, OOM), no partial file claims to be
  * complete. Next build retries from scratch.
  *
+ * ## Publishing into a shared cache
+ *
+ * Extracted trees (`fetchPrebuilt`, `tryPrefetchExtracted`, and the macOS SDK
+ * in macos-sdk.ts) land in `cfg.cacheDir`, which local builds share across
+ * every checkout on the machine (and, when it is a mount, across containers).
+ * Builds that all found an entry missing fetch it at the same time, and by the
+ * time the slower ones are ready to publish, the fastest has published and
+ * every build that looked since is compiling and linking against its tree.
+ *
+ * So each fetch extracts into scratch of its own and publishes it with a
+ * single rename (`publishTree`). A rename cannot replace a non-empty
+ * directory on any platform, so the first publisher claims the path and each
+ * later one finds the published tree in the way, recognizes it by its stamp
+ * and discards its own copy. The published tree is never removed or
+ * re-published: removing it is thousands of unlinks (WebKit) during which the
+ * compiles and links reading it fail, and re-publishing identical content
+ * moves every lib and header mtime forward, which makes ninja rebuild
+ * everything downstream in every build sharing the cache. Only a tree with
+ * some other content (a different identity at the same path) is replaced.
+ *
  * ## Streaming to disk
  *
  * Response body is piped to the temp file via `pipeline()` rather than
@@ -113,10 +133,9 @@ export function prefetchPathForUrl(url: string, dir = prefetchDir): string | und
 export async function tryPrefetchExtracted(dest: string, stampFile: string, expected: string): Promise<boolean> {
   if (prefetchDir === undefined) return false;
   const src = resolve(prefetchDir, "extracted", basename(dest));
-  const stamp = resolve(src, stampFile);
-  if (!existsSync(stamp) || readFileSync(stamp, "utf8").trim() !== expected) return false;
+  if (readStamp(resolve(src, stampFile)) !== expected) return false;
   console.log(`using prefetch cache: ${src}`);
-  // Stage-then-rename so an interrupted copy doesn't leave a stamped-but-
+  // Stage-then-publish so an interrupted copy doesn't leave a stamped-but-
   // incomplete tree at dest (same publish discipline as fetchPrebuilt).
   const staging = `${dest}.${process.pid}.prefetch`;
   await rm(staging, { recursive: true, force: true });
@@ -127,8 +146,7 @@ export async function tryPrefetchExtracted(dest: string, stampFile: string, expe
     // read-only. Restore u+w on the copy so a future version bump can
     // `rm -rf dest` (force only suppresses ENOENT, not EACCES on a 555 dir).
     await chmodRecursiveWritable(staging);
-    await rm(dest, { recursive: true, force: true });
-    await rename(staging, dest);
+    await publishTree(staging, dest, () => readStamp(resolve(dest, stampFile)) === expected);
   } finally {
     // Best-effort: staging may still have 555 dirs if chmod failed partway.
     await chmodRecursiveWritable(staging).catch(() => {});
@@ -145,6 +163,48 @@ async function chmodRecursiveWritable(root: string): Promise<void> {
   await chmod(root, st.mode | 0o200);
   if (!st.isDirectory()) return;
   for (const e of await readdir(root)) await chmodRecursiveWritable(resolve(root, e));
+}
+
+/** Contents of an identity stamp file, or undefined when there is no such file (or no such tree). */
+function readStamp(path: string): string | undefined {
+  try {
+    return readFileSync(path, "utf8").trim();
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT" || code === "ENOTDIR") return undefined;
+    throw err;
+  }
+}
+
+/**
+ * Move the complete tree at `from` to `dest`. See "Publishing into a shared
+ * cache" above.
+ *
+ * `isPublished()` reports whether what is at `dest` right now is already the
+ * tree `from` would publish (for prebuilts: its stamp matches). It is only
+ * consulted once a rename has found something at `dest`.
+ *
+ * Returns false, leaving both `dest` and `from` untouched, when a concurrent
+ * publisher got there first; the caller removes `from` with the rest of its
+ * scratch. Returns true once `from` has been renamed to `dest`.
+ */
+export async function publishTree(from: string, dest: string, isPublished: () => boolean): Promise<boolean> {
+  try {
+    await rename(from, dest);
+    return true;
+  } catch {
+    if (isPublished()) return false;
+  }
+  // Whatever is there is not what we are publishing (a stale identity at the
+  // same path, or something that is not a tree at all): replace it.
+  await rm(dest, { recursive: true, force: true });
+  try {
+    await rename(from, dest);
+    return true;
+  } catch (err) {
+    if (isPublished()) return false;
+    throw err;
+  }
 }
 
 /** Retry schedule for one download. Sizing rationale: "Retry behavior" above. */
@@ -368,12 +428,12 @@ export async function fetchPrebuilt(
   const stampPath = resolve(dest, ".identity");
 
   // ─── Short-circuit: already at this identity? ───
-  if (existsSync(stampPath)) {
-    const existing = readFileSync(stampPath, "utf8").trim();
-    if (existing === identity) {
-      console.log(`up to date`);
-      return; // restat no-op
-    }
+  const existing = readStamp(stampPath);
+  if (existing === identity) {
+    console.log(`up to date`);
+    return; // restat no-op
+  }
+  if (existing !== undefined) {
     console.log(`identity changed (was ${existing.slice(0, 16)}, now ${identity.slice(0, 16)}), re-fetching`);
   }
 
@@ -415,30 +475,19 @@ export async function fetchPrebuilt(
     const hoistFrom = entries.length === 1 ? resolve(stagingDir, entries[0]!) : stagingDir;
 
     // ─── Post-extract cleanup + stamp (inside staging) ───
-    // Done BEFORE publish so the rename below is the single step that makes
-    // a complete, stamped tree visible at dest.
+    // Done BEFORE publish so the rename in publishTree is the single step
+    // that makes a complete, stamped tree visible at dest.
     for (const p of rmPaths) {
       await rm(resolve(hoistFrom, p), { recursive: true, force: true });
     }
     await writeFile(resolve(hoistFrom, ".identity"), identity + "\n");
 
     // ─── Publish ───
-    // Directory rename can't overwrite on any platform, so rm first. If a
-    // concurrent fetch won the race, our rename fails — treat a matching
-    // stamp at dest as success.
-    try {
-      await rm(dest, { recursive: true, force: true });
-      await rename(hoistFrom, dest);
-    } catch (err) {
-      const landed = existsSync(stampPath) ? readFileSync(stampPath, "utf8").trim() : undefined;
-      if (landed === identity) {
-        console.log(`up to date (concurrent fetch won)`);
-        return;
-      }
-      throw err;
+    if (await publishTree(hoistFrom, dest, () => readStamp(stampPath) === identity)) {
+      console.log(`extracted to ${dest}`);
+    } else {
+      console.log(`up to date (concurrent fetch won)`);
     }
-
-    console.log(`extracted to ${dest}`);
   } finally {
     await rm(stagingDir, { recursive: true, force: true });
     await rm(tarballPath, { force: true });

--- a/scripts/build/macos-sdk.ts
+++ b/scripts/build/macos-sdk.ts
@@ -29,8 +29,9 @@
 
 import { spawnSync } from "node:child_process";
 import { existsSync, readdirSync } from "node:fs";
-import { mkdir, rename, rm } from "node:fs/promises";
+import { mkdir, rm } from "node:fs/promises";
 import { join, resolve } from "node:path";
+import { publishTree } from "./download.ts";
 import { BuildError } from "./error.ts";
 
 /**
@@ -146,9 +147,10 @@ export async function ensureMacosSdk(cfg: {
     `[macos-sdk] Apple's SDK license terms (https://www.apple.com/legal/sla/ — \`bun ${relativeXmac()} license\`).`,
   );
 
-  // Extract into a staging dir, then rename the .sdk into place — same
+  // Extract into a staging dir, then publish the .sdk with publishTree — same
   // discipline as fetchPrebuilt() so an interrupted configure never leaves a
-  // half-extracted tree claiming to be an SDK. The downloaded .pkg itself is
+  // half-extracted tree claiming to be an SDK and a concurrent configure
+  // sharing the cache dir never replaces one. The downloaded .pkg itself is
   // cached separately under <cacheDir>/xmac so a failed/interrupted
   // extraction doesn't re-download ~60 MB.
   const suffix = `.${process.pid}.${Date.now().toString(36)}`;
@@ -199,9 +201,11 @@ export async function ensureMacosSdk(cfg: {
         hint: `Expected MacOSX${MACOS_SDK_VERSION}.sdk inside the Command Line Tools ${MACOS_SDK_CLT_RELEASE} package.`,
       });
     }
-    await rm(expected, { recursive: true, force: true });
-    await rename(extracted, expected);
-    console.log(`[macos-sdk] extracted to ${expected}`);
+    if (await publishTree(extracted, expected, () => isMacosSdk(expected))) {
+      console.log(`[macos-sdk] extracted to ${expected}`);
+    } else {
+      console.log(`[macos-sdk] ${expected} was extracted by a concurrent build`);
+    }
   } finally {
     await rm(staging, { recursive: true, force: true }).catch(() => {});
   }

--- a/test/internal/build-concurrent-publish.test.ts
+++ b/test/internal/build-concurrent-publish.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Local builds share one cache dir (~/.bun/build-cache) across every checkout
+ * on the machine, so when several of them cold-start at once, each one fetches
+ * the prebuilt WebKit and publishes it into the same path. fetchPrebuilt(),
+ * tryPrefetchExtracted() and ensureMacosSdk() (scripts/build/) used to publish
+ * with `rm -rf dest; rename(staging, dest)`, so every build that finished
+ * after the first deleted the tree the first one had published while the
+ * other builds were already compiling and linking against it, and then put an
+ * identical tree with fresh mtimes in its place. These tests stand in for the
+ * build that finishes second: by the time it publishes, another build has
+ * published the same thing, and that tree must be left exactly as it is
+ * (rationale: "Publishing into a shared cache" in scripts/build/download.ts).
+ */
+import { expect, mock, spyOn, test } from "bun:test";
+import { bunRun, isWindows, tempDir } from "harness";
+import { chmodSync, existsSync, readdirSync, readFileSync, renameSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { fetchPrebuilt, publishTree } from "../../scripts/build/download.ts";
+import { ensureMacosSdk, MACOS_SDK_VERSION, macosSdkCachePath } from "../../scripts/build/macos-sdk.ts";
+
+const downloadTs = resolve(import.meta.dir, "../../scripts/build/download.ts");
+
+const entry = "webkit-0123456789abcdef-debug-asan";
+const identity = "0123456789abcdef0123456789abcdef01234567-debug-asan";
+
+/** The tree another build publishes. Its lib content tells it apart from what the tarballs below extract to. */
+const published = { ".identity": `${identity}\n`, lib: { "libJavaScriptCore.a": "published by another build" } };
+
+const layouts = {
+  // What release tarballs look like: one top-level dir that fetchPrebuilt hoists out of its staging dir.
+  "single top-level dir": { "bun-webkit/lib/libJavaScriptCore.a": "ours", "bun-webkit/include/unicode/uchar.h": "" },
+  // Several top-level entries: the staging dir itself is what gets published.
+  "several top-level entries": { "lib/libJavaScriptCore.a": "ours", "include/unicode/uchar.h": "" },
+};
+
+/** Serves `files` as a .tar.gz, running `onRequest` (the other build, in the tests below) before answering. */
+async function tarballServer(files: Record<string, string>, onRequest: () => void = () => {}) {
+  const tarball = await new Bun.Archive(files, { compress: "gzip" }).bytes();
+  let requests = 0;
+  const server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch() {
+      requests++;
+      onRequest();
+      return new Response(tarball);
+    },
+  });
+  return {
+    url: `http://127.0.0.1:${server.port}/${entry}.tar.gz`,
+    get requests() {
+      return requests;
+    },
+    [Symbol.asyncDispose]: () => server.stop(true),
+  };
+}
+
+// The functions under test narrate through console.log; the tests assert on
+// those lines, which is why this file runs its tests serially.
+async function withLogCaptured(fn: () => Promise<void>): Promise<string[]> {
+  const lines: string[] = [];
+  const log = spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+    lines.push(args.join(" "));
+  });
+  try {
+    await fn();
+  } finally {
+    log.mockRestore();
+  }
+  return lines;
+}
+
+test.each(Object.entries(layouts))(
+  "fetchPrebuilt leaves the tree another build published while it was downloading alone (%s)",
+  async (_, files) => {
+    using cache = tempDir("build-cache", { "published.tmp": published });
+    const dest = join(String(cache), entry);
+    let publishedStampMtime = 0;
+    await using server = await tarballServer(files, () => {
+      renameSync(join(String(cache), "published.tmp"), dest);
+      publishedStampMtime = statSync(join(dest, ".identity")).mtimeMs;
+    });
+
+    const lines = await withLogCaptured(() => fetchPrebuilt("WebKit", server.url, dest, identity, ["include/unicode"]));
+
+    expect(readFileSync(join(dest, "lib", "libJavaScriptCore.a"), "utf8")).toBe("published by another build");
+    expect(statSync(join(dest, ".identity")).mtimeMs).toBe(publishedStampMtime);
+    // Its own extraction, tarball and staging dir are gone; the published tree is all that is left.
+    expect(readdirSync(String(cache))).toEqual([entry]);
+    expect(lines).toEqual([`fetching ${server.url}`, "up to date (concurrent fetch won)"]);
+  },
+);
+
+test.each(Object.entries(layouts))("fetchPrebuilt publishes when nothing is there yet (%s)", async (_, files) => {
+  using cache = tempDir("build-cache", {});
+  const dest = join(String(cache), entry);
+  await using server = await tarballServer(files);
+
+  const lines = await withLogCaptured(() => fetchPrebuilt("WebKit", server.url, dest, identity, ["include/unicode"]));
+
+  expect(lines).toEqual([`fetching ${server.url}`, `extracted to ${dest}`]);
+  expect(readFileSync(join(dest, ".identity"), "utf8")).toBe(`${identity}\n`);
+  expect(readFileSync(join(dest, "lib", "libJavaScriptCore.a"), "utf8")).toBe("ours");
+  expect(existsSync(join(dest, "include", "unicode"))).toBe(false);
+  expect(readdirSync(String(cache))).toEqual([entry]);
+});
+
+test("fetchPrebuilt does not download over a tree that is already at this identity", async () => {
+  using cache = tempDir("build-cache", { [entry]: published });
+  const dest = join(String(cache), entry);
+  await using server = await tarballServer(layouts["single top-level dir"]);
+
+  const lines = await withLogCaptured(() => fetchPrebuilt("WebKit", server.url, dest, identity));
+
+  expect(lines).toEqual(["up to date"]);
+  expect(server.requests).toBe(0);
+  expect(readFileSync(join(dest, "lib", "libJavaScriptCore.a"), "utf8")).toBe("published by another build");
+});
+
+test("fetchPrebuilt replaces a tree at another identity", async () => {
+  using cache = tempDir("build-cache", {
+    [entry]: { ".identity": "fedcba9876543210fedcba9876543210fedcba98-debug-asan\n", lib: { "libWTF.a": "stale" } },
+  });
+  const dest = join(String(cache), entry);
+  await using server = await tarballServer(layouts["single top-level dir"]);
+
+  const lines = await withLogCaptured(() => fetchPrebuilt("WebKit", server.url, dest, identity));
+
+  expect(lines).toEqual([
+    "identity changed (was fedcba9876543210, now 0123456789abcdef), re-fetching",
+    `fetching ${server.url}`,
+    `extracted to ${dest}`,
+  ]);
+  expect(readFileSync(join(dest, ".identity"), "utf8")).toBe(`${identity}\n`);
+  expect(readdirSync(join(dest, "lib"))).toEqual(["libJavaScriptCore.a"]);
+  expect(readdirSync(String(cache))).toEqual([entry]);
+});
+
+test("fetchPrebuilt replaces a plain file at the destination path", async () => {
+  using cache = tempDir("build-cache", { [entry]: "not a directory" });
+  const dest = join(String(cache), entry);
+  await using server = await tarballServer(layouts["single top-level dir"]);
+
+  const lines = await withLogCaptured(() => fetchPrebuilt("WebKit", server.url, dest, identity));
+
+  expect(lines).toEqual([`fetching ${server.url}`, `extracted to ${dest}`]);
+  expect(readFileSync(join(dest, ".identity"), "utf8")).toBe(`${identity}\n`);
+  expect(readdirSync(String(cache))).toEqual([entry]);
+});
+
+// tryPrefetchExtracted() reads the prefetch dir from the environment when
+// download.ts is first imported, so it is driven from a child process. It
+// never looks at dest before copying, so a tree published before it is called
+// is the same situation as one published during its copy.
+test("tryPrefetchExtracted leaves the tree another build published alone", async () => {
+  using dir = tempDir("build-prefetch", {
+    prefetch: {
+      extracted: { [entry]: { ".identity": `${identity}\n`, lib: { "libJavaScriptCore.a": "prefetched" } } },
+    },
+    cache: { [entry]: published },
+    "fixture.ts": ({ root }) => `
+      import { tryPrefetchExtracted } from ${JSON.stringify(pathToFileURL(downloadTs).href)};
+      const dest = ${JSON.stringify(join(root, "cache", entry))};
+      console.log(await tryPrefetchExtracted(dest, ".identity", ${JSON.stringify(identity)}));
+    `,
+  });
+  const prefetchDir = join(String(dir), "prefetch");
+  const dest = join(String(dir), "cache", entry);
+  const publishedStampMtime = statSync(join(dest, ".identity")).mtimeMs;
+
+  const result = await bunRun(join(String(dir), "fixture.ts"), { BUN_BUILD_PREFETCH_DIR: prefetchDir });
+
+  expect(result).toSpawn(`using prefetch cache: ${resolve(prefetchDir, "extracted", entry)}\ntrue`);
+  expect(readFileSync(join(dest, "lib", "libJavaScriptCore.a"), "utf8")).toBe("published by another build");
+  expect(statSync(join(dest, ".identity")).mtimeMs).toBe(publishedStampMtime);
+  expect(readdirSync(join(String(dir), "cache"))).toEqual([entry]);
+});
+
+const sdk = `MacOSX${MACOS_SDK_VERSION}.sdk`;
+const sdkTree = (marker: string) => ({ usr: { include: { sys: { "syscall.h": "" } } }, [marker]: "" });
+
+/**
+ * Stands in for `bun xmac.mjs splat ... --output <staging> ...`, which is how
+ * ensureMacosSdk() runs cfg.bun: lays out an SDK under --output and, when
+ * `concurrent` is given, publishes that tree into the cache first, the way
+ * another configure finishing during this extraction does. A shell script,
+ * hence no Windows; the code under test only runs on non-darwin hosts
+ * building for macOS.
+ */
+function fakeXmac(root: string, concurrent?: string): string {
+  const publish =
+    concurrent === undefined
+      ? ""
+      : `mv "${join(root, "cache", concurrent)}" "${macosSdkCachePath(join(root, "cache"))}"`;
+  return `#!/bin/sh
+while [ $# -gt 0 ]; do
+  if [ "$1" = "--output" ]; then out="$2"; fi
+  shift
+done
+mkdir -p "$out/SDKs/${sdk}/usr/include/sys" && : > "$out/SDKs/${sdk}/usr/include/sys/syscall.h" && : > "$out/SDKs/${sdk}/ours"
+${publish}
+`;
+}
+
+async function runEnsureMacosSdk(dir: string): Promise<{ cacheDir: string; lines: string[] }> {
+  chmodSync(join(dir, "xmac"), 0o755);
+  const cacheDir = join(dir, "cache");
+  const lines = await withLogCaptured(() =>
+    ensureMacosSdk({
+      osxSysroot: macosSdkCachePath(cacheDir),
+      cacheDir,
+      darwin: true,
+      bun: join(dir, "xmac"),
+      host: { os: "linux" },
+    }),
+  );
+  return { cacheDir, lines };
+}
+
+test.skipIf(isWindows)(
+  "ensureMacosSdk leaves the SDK another configure published while it was extracting alone",
+  async () => {
+    using dir = tempDir("macos-sdk", {
+      cache: { "published.tmp": sdkTree("published-by-another-configure") },
+      xmac: ({ root }) => fakeXmac(root, "published.tmp"),
+    });
+
+    const { cacheDir, lines } = await runEnsureMacosSdk(String(dir));
+
+    expect(readdirSync(join(cacheDir, sdk)).sort()).toEqual(["published-by-another-configure", "usr"]);
+    expect(readdirSync(cacheDir)).toEqual([sdk]);
+    expect(lines.at(-1)).toBe(`[macos-sdk] ${join(cacheDir, sdk)} was extracted by a concurrent build`);
+  },
+);
+
+test.skipIf(isWindows)("ensureMacosSdk publishes when nothing is there yet", async () => {
+  using dir = tempDir("macos-sdk", { cache: {}, xmac: ({ root }) => fakeXmac(root) });
+
+  const { cacheDir, lines } = await runEnsureMacosSdk(String(dir));
+
+  expect(lines.at(-1)).toBe(`[macos-sdk] extracted to ${join(cacheDir, sdk)}`);
+  expect(readdirSync(join(cacheDir, sdk)).sort()).toEqual(["ours", "usr"]);
+  expect(readdirSync(cacheDir)).toEqual([sdk]);
+});
+
+// The interleaving the tests above cannot produce: what was at dest was some
+// other tree, publishTree removed it, and another build published in between
+// that and the rename. `from` is missing so that the rename fails the way it
+// does when that happens.
+test("publishTree asks again when the rename after replacing another tree fails", async () => {
+  using cache = tempDir("build-cache", { [entry]: { ".identity": "stale\n" } });
+  const isPublished = mock(() => true).mockReturnValueOnce(false);
+
+  await expect(publishTree(join(String(cache), "missing"), join(String(cache), entry), isPublished)).resolves.toBe(
+    false,
+  );
+  expect(isPublished).toHaveBeenCalledTimes(2);
+});
+
+test("publishTree throws a rename failure that no other build explains", async () => {
+  using cache = tempDir("build-cache", { [entry]: { ".identity": "stale\n" } });
+  const isPublished = mock(() => false);
+
+  await expect(
+    publishTree(join(String(cache), "missing"), join(String(cache), entry), isPublished),
+  ).rejects.toMatchObject({
+    code: "ENOENT",
+  });
+  expect(isPublished).toHaveBeenCalledTimes(2);
+});


### PR DESCRIPTION
### Problem
- Several checkouts cold-building at once against the shared local cache dir (`~/.bun/build-cache`, here one host directory mounted into many containers): `bun bd` prints `[WebKit] up to date` and then fails to link with `clang++: error: no such file or directory: '.../build-cache/webkit-f0f60fd2324817da-debug-asan/lib/libWTF.a'` (same for libJavaScriptCore.a, libicu*.a, libbmalloc.a). An immediate retry fails in the PCH with `fatal error: 'JavaScriptCore/JSCJSValue.h' file not found`, a second after `.identity` and `lib/` looked complete. Once the other containers' `webkit-*.staging` dirs were gone the same build succeeded unchanged.
- `fetchPrebuilt()` (scripts/build/download.ts) reads `dest/.identity` only when it starts. Every build that started while the entry was missing downloads and extracts a copy of its own and then publishes it with `rm(dest, { recursive: true })` + `rename(staging, dest)`, unconditionally (lines 429-431 before this change). So each build that finishes after the first deletes the complete, stamped tree the first one published, while the builds that found it are compiling and linking against it; `dest` is missing for the length of the recursive rm, and the re-published tree has new mtimes, so the builds that survive rebuild the PCH and every C++ file next time. The existing `concurrent fetch won` branch was in the catch of that rename, which cannot fail once the rm has run.
- `tryPrefetchExtracted()` (same file, the CI prefetch-cache path) and `ensureMacosSdk()` (scripts/build/macos-sdk.ts, which extracts the macOS SDK into the same cache dir for cross builds) publish the same way and have the same race.

### Fix
- New `publishTree(from, dest, isPublished)` in download.ts, used by all three sites. It renames first. A directory rename cannot replace a non-empty directory on any platform, so the rename succeeds only when nothing is there, and succeeding is what claims the path. When it fails, `isPublished()` (the stamp at `dest` matches what we were about to write; for the SDK, `dest` is an SDK) decides: if so the published tree is left exactly as it is and our copy is discarded by the caller's existing `finally`; otherwise whatever is there is removed and replaced, with the stamp consulted once more if that rename fails too before the error is thrown.
- Why keeping the other build's tree is correct: the paths are keyed by version (`webkit-<sha16>-debug-asan`, `nodejs-headers-<version>`, `MacOSX<version>.sdk`) and the stamp holds the full identity, so a matching tree is the same content we would have published, and it is the content every other build sharing the cache is already using. The case in the report (nothing at `dest` when the fetches start) now has no destructive step at all. What remains is the replace path, which is only reached when a different identity was already sitting at the same path; a tree published between its stamp read and its rm would be replaced by the same content, so the end state is correct there too.
- The losing builds still download and extract into their own scratch before they find out; that costs them time and transient disk but harms nobody, and skipping it would be an optimization, so it is left as it was.
- `readStamp()` replaces the three copies of `existsSync(stamp) ? readFileSync(stamp).trim() : undefined`; ENOENT and ENOTDIR mean no stamp, anything else still throws.
- Deliberately unchanged: `scripts/prefetch-deps.ts` also does rm + rename, but it is the single process that bakes a CI image and nothing reads its output dir while it runs. `winsysroot.ts` has no staging step (xwin splats straight into the destination), so it would need a different change.
- Verified with `test/internal/build-concurrent-publish.test.ts`. For each of the three sites the test is the build that finishes second: another build's tree, with contents that tell it apart from ours, is published while the function under test is downloading (served from a local `Bun.serve`), before it copies, or during its extraction (a stand-in for xmac), and afterwards that tree must be untouched (contents and stamp mtime) with nothing but it left in the cache dir. With main's scripts those four tests fail because `dest` holds our copy; the other six (publishing into an empty cache for both tarball layouts, up to date without a download, replacing a different identity, replacing a plain file, SDK with an empty cache) pass on main as well and pin the paths the refactor touches. Two direct `publishTree` tests cover the replace-then-lose interleaving and error propagation, which the end-to-end tests cannot reach deterministically.
- Also run: the file under `bun bd test` on Linux and on Windows x64 (the two SDK tests use a shell script and skip there), `test/internal/build-download-retry.test.ts`, and `tsc -p scripts/build`, which reports nothing in the two files touched.

### Background
- Prebuilt deps (WebKit, nodejs-headers) are downloaded, not built: `fetch-cli.ts prebuilt` extracts the tarball into a staging dir next to the destination, writes `.identity` (full version plus flavour) into it, and moves the tree into place; a later fetch that finds a matching `.identity` exits with `up to date`. The ninja edge for the fetch lists `.identity` and the libs as its outputs with `restat = 1`, so their mtimes decide whether the PCH and every C++ compile rerun.
- For local builds the destination is in `cfg.cacheDir` = `$BUN_INSTALL/build-cache`, shared by every checkout and profile on the machine (CI uses a cache inside the build dir). Each fetch's tarball and staging dir carry a `<pid>.<time>` suffix, so concurrent fetches only ever meet at the destination path.
- The prefetch cache is a read-only tree of pre-extracted deps baked into CI images; `tryPrefetchExtracted()` copies it into the cache dir through a staging dir of its own. `ensureMacosSdk()` runs at configure time when building for macOS from a Linux host and extracts Apple's SDK into the same cache dir the same way.
