### PR TITLE
test(harness): make isGlibcVersionAtLeast work with glibc's two-component version

### DIFF
--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1685,7 +1685,9 @@ export function isGlibcVersionAtLeast(version: string): boolean {
   if (!glibcVersion) {
     return false;
   }
-  return Bun.semver.satisfies(glibcVersion, `>=${version}`);
+  // glibc reports "major.minor" (e.g. "2.41"), which semver rejects as a version; pad it to three components.
+  const [major, minor = "0", patch = "0"] = glibcVersion.split(".");
+  return Bun.semver.satisfies(`${major}.${minor}.${patch}`, `>=${version}`);
 }
 
 let macOSVersion: string | undefined;

--- a/test/internal/harness.test.ts
+++ b/test/internal/harness.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { getGlibcVersion, isGlibc, isGlibcVersionAtLeast } from "harness";
+
+describe("isGlibcVersionAtLeast", () => {
+  // gnu_get_libc_version() reports two components ("2.41"), while callers pass "2.36.0".
+  test.if(isGlibc)("compares against the major.minor version glibc reports", () => {
+    const version = getGlibcVersion()!;
+    expect(version).toMatch(/^\d+\.\d+/);
+    const [major, minor] = version.split(".").map(Number);
+
+    expect({
+      olderMajor: isGlibcVersionAtLeast(`${major - 1}.0.0`),
+      same: isGlibcVersionAtLeast(`${major}.${minor}`),
+      sameWithPatch: isGlibcVersionAtLeast(`${major}.${minor}.0`),
+      newerMinor: isGlibcVersionAtLeast(`${major}.${minor + 1}.0`),
+      newerMajor: isGlibcVersionAtLeast(`${major + 1}.0.0`),
+    }).toEqual({
+      olderMajor: true,
+      same: true,
+      sameWithPatch: true,
+      newerMinor: false,
+      newerMajor: false,
+    });
+  });
+
+  test.if(!isGlibc)("is false when the runtime libc is not glibc", () => {
+    expect(getGlibcVersion()).toBeUndefined();
+    expect(isGlibcVersionAtLeast("2.0.0")).toBe(false);
+  });
+});

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -1060,11 +1060,14 @@ it("JSCallback tolerates worker.terminate() arriving inside the callback", async
   });
 });
 
+// Keyed on the running architecture rather than probing both paths: the aarch64 CI image also has an amd64 libc
+// installed, which exists on disk but cannot be dlopen'd.
+const glibcPath = { x64: "/lib/x86_64-linux-gnu/libc.so.6", arm64: "/lib/aarch64-linux-gnu/libc.so.6" }[process.arch];
 const libPath =
   platform() === "darwin"
     ? "/usr/lib/libSystem.B.dylib"
-    : existsSync("/lib/x86_64-linux-gnu/libc.so.6") && isGlibcVersionAtLeast("2.36.0")
-      ? "/lib/x86_64-linux-gnu/libc.so.6"
+    : glibcPath && existsSync(glibcPath) && isGlibcVersionAtLeast("2.36.0")
+      ? glibcPath
       : null;
 
 const libSymbols = {


### PR DESCRIPTION
### Problem
- `isGlibcVersionAtLeast()` in `test/harness.ts` returns `false` on every glibc host, so the tests gated on it are silently skipped on all Linux glibc CI lanes and only run on macOS.
- `getGlibcVersion()` (test/harness.ts:1668) returns `process.report.getReport().header.glibcVersionRuntime`, which is the `gnu_get_libc_version()` string, e.g. `"2.41"`: two components.
- `isGlibcVersionAtLeast()` (test/harness.ts:1688) passes that straight to `Bun.semver.satisfies("2.41", ">=2.36.0")`. A two-component version is not a valid semver version, so `satisfies` returns `false` (documented behavior, same as node-semver). `"2.41.0"` against the same range returns `true`.
- This has been the case since the helper was added in d105b048b1 (#11477). The affected callers are the only two in the tree:
  - `test/js/bun/ffi/ffi.test.js:1066`: `describe("can open more than 63 symbols via", ...)` (4 tests), skipped on Linux.
  - `test/js/node/stream/node-stream.test.js:340`: `"TTY streams"`, skipped on Linux.
- The ffi block had a second latent bug hidden by the first: it picked `/lib/x86_64-linux-gnu/libc.so.6` whenever that file existed, without looking at `process.arch`. The debian 13 aarch64 CI image has an amd64 libc installed (`scripts/bootstrap.sh` `install_cross_compiler_rt` adds the amd64 dpkg architecture on that image), so once the glibc gate started returning `true` the block ran there and failed with `Failed to open library "/lib/x86_64-linux-gnu/libc.so.6"`.

### Fix
- `isGlibcVersionAtLeast()` pads the reported version to three components (`"2.41"` -> `"2.41.0"`) before calling `Bun.semver.satisfies()`. Missing components default to `"0"`, so a release like `"2.41"` and a development snapshot like `"2.41.9000"` both parse.
- This is the right layer: the version string is produced by glibc and is not semver, so the helper that chose to compare it with semver is the one that has to adapt it. Callers keep passing `"2.36.0"`, and ranges already accept partial versions (`>=2.36` works), so nothing else changes. The non-glibc path (macOS, Windows, musl, FreeBSD) still returns `false` because `getGlibcVersion()` is `undefined` there.
- `ffi.test.js` now selects the libc path by `process.arch` (`x64` -> `/lib/x86_64-linux-gnu/libc.so.6`, `arm64` -> `/lib/aarch64-linux-gnu/libc.so.6`), still gated on the file existing and on glibc >= 2.36. Keying on the architecture, rather than probing both paths, is what keeps a foreign-architecture multiarch libc from being picked; it also enables the block on the aarch64 glibc lanes.
- Added `test/internal/harness.test.ts`: on glibc it reads the reported `major.minor` and asserts `isGlibcVersionAtLeast` is true for `major.minor`, `major.minor.0` and an older major, and false for the next minor and next major; on non-glibc hosts it asserts the helper returns `false`. The glibc case fails on the current helper (all three "at least" checks come back `false`) and passes with this change; the fix and the test both live under `test/`, so to see the failure stash `test/harness.ts` (`git stash push -- test/harness.ts && bun bd test test/internal/harness.test.ts`).
- Verified on Debian 13 x64 (glibc 2.41) with the debug build:
  - `bun bd test test/internal/harness.test.ts`: passes; fails with `test/harness.ts` stashed.
  - `bun bd test test/js/bun/ffi/ffi.test.js -t "can open more than 63 symbols"`: the 4 tests go from skipped to passing (~30ms each).
  - `bun bd test test/js/node/stream/node-stream.test.js`: `"TTY streams"` goes from skipped to passing; the whole file passes (102 pass, 5 todo).
- Expected CI effect: `"TTY streams"` and the ffi block run on the debian 13 and ubuntu 25.04 lanes, x64 and aarch64 (all glibc 2.41). Alpine lanes keep skipping both (no glibc). The aarch64 path cannot be exercised locally here; the first CI run of this PR is what exposed the multiarch case (ffi block failed on debian 13 aarch64 only, `"TTY streams"` passed on every glibc lane).

### Background
- `process.report.getReport().header.glibcVersionRuntime` is set from `gnu_get_libc_version()` (src/jsc/bindings/BunProcess.cpp:2489), which returns glibc's own `major.minor` release string. It is only present when the binary is linked against glibc, which is also how the harness derives `isGlibc` / `isMusl`.
- `Bun.semver.satisfies(version, range)` follows node-semver: the `version` argument must be a full `major.minor.patch` version and anything else yields `false` rather than an error, while the `range` argument may contain partial versions. That asymmetry is why the `">=2.36.0"` side was never the problem and why the bug was silent.
- The glibc 2.36 gate exists because both callers `dlopen` `libc.so.6` and look up symbols (`login_tty`, `login`, `logout`, `openpty`) that lived in `libutil` before glibc merged it into libc in 2.34.
- Debian multiarch installs each architecture's libraries under `/lib/<triplet>/`, so several architectures' `libc.so.6` can coexist on one machine; `dlopen` can only load the one matching the running process.

<details>
<summary>Probe on glibc 2.41 before the change</summary>

```
$ cd test && USE_SYSTEM_BUN=1 bun -e 'import { isGlibcVersionAtLeast, getGlibcVersion } from "./harness";
  console.log(getGlibcVersion(), isGlibcVersionAtLeast("2.36.0"), Bun.semver.satisfies("2.41", ">=2.36.0"), Bun.semver.satisfies("2.41.0", ">=2.36.0"))'
2.41 false false true
```

`bun bd test test/internal/harness.test.ts` with `test/harness.ts` stashed:

```
  {
    "newerMajor": false,
    "newerMinor": false,
-   "olderMajor": true,
-   "same": true,
-   "sameWithPatch": true,
+   "olderMajor": false,
+   "same": false,
+   "sameWithPatch": false,
  }
```

First CI run (harness fix only), debian 13 aarch64:

```
error: Failed to open library "/lib/x86_64-linux-gnu/libc.so.6": /lib/x86_64-linux-gnu/libc.so.6: cannot open shared object file: No such file or directory
      at dlopen (bun:ffi:159:17)
      at <anonymous> (test/js/bun/ffi/ffi.test.js:1349:19)
```
</details>
