### PR TITLE
test: run the node:inspector child-process tests concurrently and assert their full output

### DIFF
--- a/test/js/node/inspector/inspector.test.ts
+++ b/test/js/node/inspector/inspector.test.ts
@@ -1,6 +1,8 @@
-import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { expect, setDefaultTimeout, test } from "bun:test";
+import { bunEnv, bunExe, isDebug, tempDir } from "harness";
 import inspector from "node:inspector";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 
 test("inspector.url()", () => {
   expect(inspector.url()).toBeUndefined();
@@ -26,98 +28,118 @@ test("inspector.waitForDebugger() throws ERR_INSPECTOR_NOT_ACTIVE when the inspe
   expect(error.message).toBe("Inspector is not active");
 });
 
+// inspector.open() picks an ephemeral port and a random UUID path, like Node.
+const inspectorUrl = /^ws:\/\/127\.0\.0\.1:\d+\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+// Each child-spawning test below gets its own tempDir and ephemeral port, so
+// they run concurrently. Under a debug build, starting the child and its
+// debugger thread takes 2-3s per test on its own and longer once they overlap,
+// which does not reliably fit bun test's 5s local default. CI passes a larger
+// --timeout of its own, which this must not lower, hence the condition.
+if (isDebug) setDefaultTimeout(30_000);
+
+// Fixtures that block until the test acts as their debugger client
+// (waitForDebugger(), a breakpoint) have to be read incrementally, since their
+// output only ends once the test has resumed them.
+function collectOutput(stream: ReadableStream<Uint8Array>) {
+  let text = "";
+  let closed = false;
+  let nextChunk = Promise.withResolvers<void>();
+  const wake = () => {
+    const waiters = nextChunk;
+    nextChunk = Promise.withResolvers();
+    waiters.resolve();
+  };
+  const finished = (async () => {
+    const decoder = new TextDecoder();
+    try {
+      for await (const bytes of stream) {
+        text += decoder.decode(bytes, { stream: true });
+        wake();
+      }
+      return (text += decoder.decode());
+    } finally {
+      closed = true;
+      wake();
+    }
+  })();
+  return {
+    /** The whole stream, once the child closes it. */
+    finished,
+    /** What has arrived so far, for failure messages. */
+    get text() {
+      return text;
+    },
+    /** Resolves as soon as the output received so far matches `pattern`. */
+    async waitFor(pattern: RegExp): Promise<RegExpMatchArray> {
+      for (;;) {
+        const match = text.match(pattern);
+        if (match) return match;
+        if (closed) throw new Error(`stream closed before ${pattern} matched; received: ${JSON.stringify(text)}`);
+        await nextChunk.promise;
+      }
+    },
+  };
+}
+
 // inspector.open() starts a WebSocket server speaking the V8 Chrome DevTools
 // Protocol (translated to JSC's inspector protocol on the debugger thread).
 // The fixture opens the inspector, talks to its own server as a CDP client,
-// and prints one JSON summary line for the assertions below.
+// and prints one JSON summary line for the assertions below. It imports nothing
+// but node:inspector on purpose: Bun's fetch() sends an explicit Host header as
+// given, and loading node:http for that alone used to cost more under
+// debug/ASAN builds than everything the fixture does with the inspector.
 const openInspectorFixture = `
 import inspector from "node:inspector";
-import assert from "node:assert";
-import http from "node:http";
 
-assert.strictEqual(inspector.url(), undefined);
+const urlBeforeOpen = inspector.url() ?? null;
 inspector.open(0, "127.0.0.1", false);
 const url = inspector.url();
 
-let alreadyActivatedError = null;
+let alreadyActivated = null;
 try {
   inspector.open(0, "127.0.0.1", false);
 } catch (error) {
-  alreadyActivatedError = error.message;
+  alreadyActivated = { code: error.code, message: error.message };
 }
 
-const httpBase = "http://" + new URL(url).host;
-const version = await (await fetch(httpBase + "/json/version")).json();
-const list = await (await fetch(httpBase + "/json/list")).json();
+const { host, pathname } = new URL(url);
+const get = (path, hostHeader) => fetch("http://" + host + path, { headers: hostHeader ? { Host: hostHeader } : {} });
+const json = async (path, hostHeader) => (await get(path, hostHeader)).json();
+const status = async (path, hostHeader) => (await get(path, hostHeader)).status;
 
+const version = await json("/json/version");
+const list = await json("/json/list");
 // /json/list reflects a localhost/IP-literal Host header (port-forwards,
 // tunnels), like Node; other hostnames are rejected outright (Node's
-// IsAllowedHost / DNS-rebinding guard).
-function fetchWithHost(path, hostHeader) {
-  return new Promise((resolve, reject) => {
-    http
-      .get(
-        {
-          host: "127.0.0.1",
-          port: Number(new URL(url).port),
-          path,
-          headers: { Host: hostHeader },
-        },
-        response => {
-          let body = "";
-          response.on("data", chunk => (body += chunk));
-          response.on("end", () =>
-            resolve(response.statusCode === 200 ? JSON.parse(body) : { statusCode: response.statusCode }),
-          );
-          response.on("error", reject);
-        },
-      )
-      .on("error", reject);
-  });
-}
-const listWithIpHost = await fetchWithHost("/json/list", "127.0.0.1:19229");
-const listWithMappedIpv6Host = await fetchWithHost("/json/list", "[::ffff:127.0.0.1]:19229");
-const listWithDnsHost = await fetchWithHost("/json/list", "tunnel.example:9229");
-const versionWithDnsHost = await fetchWithHost("/json/version", "tunnel.example:9229");
-// The WS upgrade is gated on the same Host check (Node's HostCheckedForUPGRADE).
-const wsBadHostStatus = await new Promise((resolve, reject) => {
-  const request = http.get(
-    {
-      host: "127.0.0.1",
-      port: Number(new URL(url).port),
-      path: new URL(url).pathname,
-      headers: { Host: "tunnel.example:9229", Connection: "Upgrade", Upgrade: "websocket" },
-    },
-    response => resolve(response.statusCode),
-  );
-  request.on("upgrade", () => resolve("upgraded"));
-  request.on("error", reject);
-});
+// IsAllowedHost / DNS-rebinding guard), and the WebSocket endpoint is gated on
+// the same check (Node's HostCheckedForUPGRADE). A plain GET of the WebSocket
+// path with an acceptable Host gets past that check to the upgrade itself.
+const listWithIpHost = await json("/json/list", "127.0.0.1:19229");
+const listWithMappedIpv6Host = await json("/json/list", "[::ffff:127.0.0.1]:19229");
+const listWithDnsHostStatus = await status("/json/list", "tunnel.example:9229");
+const versionWithDnsHostStatus = await status("/json/version", "tunnel.example:9229");
+const websocketPathWithDnsHostStatus = await status(pathname, "tunnel.example:9229");
+const websocketPathWithoutUpgradeStatus = await status(pathname);
 
 const ws = new WebSocket(url);
 const pending = new Map();
 const events = [];
 let nextId = 1;
-let consoleEventResolve;
-const consoleEventPromise = new Promise(resolve => (consoleEventResolve = resolve));
-const consoleTypeByTag = {};
+const taggedConsoleEvent = Promise.withResolvers();
 ws.onmessage = event => {
   const message = JSON.parse(event.data);
   if (message.id) {
-    pending.get(message.id)?.(message);
+    pending.get(message.id)(message);
     pending.delete(message.id);
-  } else {
-    events.push(message);
-    if (message.method === "Runtime.consoleAPICalled") {
-      const first = message.params.args?.[0]?.value;
-      if (typeof first === "string" && first.startsWith("console-tag:")) {
-        consoleTypeByTag[first.slice("console-tag:".length)] = message.params.type;
-      }
-      if (first === "tagged-console-call") consoleEventResolve(message.params);
-    }
+    return;
+  }
+  events.push(message);
+  if (message.method === "Runtime.consoleAPICalled" && message.params.args[0]?.value === "tagged-console-call") {
+    taggedConsoleEvent.resolve(message.params);
   }
 };
-const send = (method, params) =>
+const send = (method, params = {}) =>
   new Promise(resolve => {
     const id = nextId++;
     pending.set(id, resolve);
@@ -125,17 +147,19 @@ const send = (method, params) =>
   });
 await new Promise(resolve => (ws.onopen = resolve));
 
-await send("Runtime.enable", {});
-const debuggerEnable = await send("Debugger.enable", {});
+const runtimeEnable = await send("Runtime.enable");
+const debuggerEnable = await send("Debugger.enable");
 // Chrome DevTools' Console echoes contextId on every evaluation; JSC's
 // JSGlobalObjectRuntimeAgent rejects it, so the adapter must drop it.
 const evaluate = await send("Runtime.evaluate", { expression: "6 * 7", contextId: 1 });
-const awaitedResolve = await send("Runtime.evaluate", {
+// JSC has no awaitPromise on Runtime.evaluate; the adapter chains
+// Runtime.awaitPromise so DevTools top-level-await works, and a non-promise
+// result is returned as-is.
+const awaitedPromise = await send("Runtime.evaluate", {
   expression: "Promise.resolve(42)",
   awaitPromise: true,
   returnByValue: true,
 });
-// awaitPromise on a non-promise result returns it as-is.
 const awaitedNonPromise = await send("Runtime.evaluate", {
   expression: "6 * 7",
   awaitPromise: true,
@@ -153,38 +177,55 @@ console.error("console-tag:error");
 console.info("console-tag:info");
 console.debug("console-tag:debug");
 console.log("tagged-console-call", { tagged: true });
-const consoleEvent = await consoleEventPromise;
-const unknown = await send("Totally.bogus", {});
+const consoleEvent = await taggedConsoleEvent.promise;
+const unknownMethod = await send("Totally.bogus");
+const debugPort = process.debugPort;
 inspector.close();
+
+const consoleTypeByTag = {};
+for (const { method, params } of events) {
+  const first = method === "Runtime.consoleAPICalled" ? params.args[0]?.value : undefined;
+  if (typeof first === "string" && first.startsWith("console-tag:")) {
+    consoleTypeByTag[first.slice("console-tag:".length)] = params.type;
+  }
+}
 
 console.log(
   JSON.stringify({
+    pid: process.pid,
+    urlBeforeOpen,
     url,
-    alreadyActivatedError,
+    alreadyActivated,
     version,
     list,
-    listWithIpHostUrl: listWithIpHost[0]?.webSocketDebuggerUrl,
-    listWithMappedIpv6HostUrl: listWithMappedIpv6Host[0]?.webSocketDebuggerUrl,
-    listWithDnsHost,
-    versionWithDnsHost,
-    wsBadHostStatus,
-    executionContextCreated: events.some(event => event.method === "Runtime.executionContextCreated"),
-    scriptParsedCount: events.filter(event => event.method === "Debugger.scriptParsed").length,
-    debuggerEnable: debuggerEnable.result,
-    evaluateValue: evaluate.result?.result?.value,
-    awaitedResolveValue: awaitedResolve.result?.result?.value,
-    awaitedNonPromiseValue: awaitedNonPromise.result?.result?.value,
-    callOnGlobalValue: callOnGlobal.result?.result?.value,
-    consoleEventType: consoleEvent.type,
+    listWithIpHost,
+    listWithMappedIpv6Host,
+    listWithDnsHostStatus,
+    versionWithDnsHostStatus,
+    websocketPathWithDnsHostStatus,
+    websocketPathWithoutUpgradeStatus,
+    executionContextCreated: events
+      .filter(event => event.method === "Runtime.executionContextCreated")
+      .map(event => event.params),
+    // Debugger.enable reports the scripts that were already loaded, this
+    // module included, by file URL.
+    thisScriptParsed: events.some(event => event.method === "Debugger.scriptParsed" && event.params.url === import.meta.url),
+    runtimeEnable,
+    debuggerEnable,
+    evaluate,
+    awaitedPromise,
+    awaitedNonPromise,
+    callOnGlobal,
+    consoleEvent,
     consoleTypeByTag,
-    debugPort: process.debugPort,
-    unknownError: unknown.error,
+    unknownMethod,
+    debugPort,
     urlAfterClose: inspector.url() ?? null,
   }),
 );
 `;
 
-test("inspector.open() serves the DevTools protocol and /json discovery endpoints", async () => {
+test.concurrent("inspector.open() serves the DevTools protocol and /json discovery endpoints", async () => {
   using dir = tempDir("inspector-open", {
     "fixture.mjs": openInspectorFixture,
   });
@@ -196,50 +237,95 @@ test("inspector.open() serves the DevTools protocol and /json discovery endpoint
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stderrIfFailed: exitCode === 0 ? "" : stderr, exitCode }).toEqual({ stderrIfFailed: "", exitCode: 0 });
 
-  // Node prints this exact line so debugger frontends can discover the server.
-  expect(stderr).toMatch(/Debugger listening on ws:\/\/127\.0\.0\.1:\d+\/[0-9a-f-]{36}/);
-
-  const lastLine = stdout.trim().split("\n").at(-1)!;
-  const summary = JSON.parse(lastLine);
-
-  expect(summary.url).toStartWith("ws://127.0.0.1:");
-  expect(summary.alreadyActivatedError).toContain("already activated");
-  expect(summary.version).toEqual({ "Browser": expect.stringContaining("Bun/"), "Protocol-Version": "1.1" });
-  expect(summary.list).toEqual([
-    expect.objectContaining({
-      type: "node",
-      webSocketDebuggerUrl: summary.url,
-      devtoolsFrontendUrl: expect.stringContaining("devtools://"),
-    }),
+  // Node prints this exact line so debugger frontends can discover the server;
+  // console output keeps reaching stdio while it is also relayed to the client.
+  const url = stderr.match(/^Debugger listening on (\S+)\n/)?.[1]!;
+  expect(stderr).toBe(`Debugger listening on ${url}\nconsole-tag:warn\nconsole-tag:error\n`);
+  expect(url).toMatch(inspectorUrl);
+  const stdoutLines = stdout.trimEnd().split("\n");
+  const summary = JSON.parse(stdoutLines.pop()!);
+  expect(stdoutLines).toEqual([
+    "console-tag:info",
+    "console-tag:debug",
+    "tagged-console-call {",
+    "  tagged: true,",
+    "}",
   ]);
-  // Node reflects localhost/IP-literal Host headers into /json/list; other
-  // hostnames are rejected (Node's IsAllowedHost / DNS-rebinding guard) for
-  // both discovery and the WebSocket upgrade.
-  expect(summary.listWithIpHostUrl).toBe(`ws://127.0.0.1:19229${new URL(summary.url).pathname}`);
-  expect(summary.listWithMappedIpv6HostUrl).toBe(`ws://[::ffff:127.0.0.1]:19229${new URL(summary.url).pathname}`);
-  expect(summary.listWithDnsHost).toEqual({ statusCode: 400 });
-  expect(summary.versionWithDnsHost).toEqual({ statusCode: 400 });
-  expect(summary.wsBadHostStatus).toBe(400);
-  expect(summary.executionContextCreated).toBe(true);
-  expect(summary.scriptParsedCount).toBeGreaterThan(0);
-  expect(summary.debuggerEnable).toEqual({ debuggerId: expect.any(String) });
-  expect(summary.evaluateValue).toBe(42);
-  // JSC has no awaitPromise on Runtime.evaluate; the adapter chains
-  // Runtime.awaitPromise so DevTools top-level-await works.
-  expect(summary.awaitedResolveValue).toBe(42);
-  expect(summary.awaitedNonPromiseValue).toBe(42);
-  expect(summary.callOnGlobalValue).toBe("number");
-  expect(summary.consoleEventType).toBe("log");
-  // JSC reports warn/error/info/debug as {type:"log", level:...}; the adapter
-  // must emit CDP's type, not flatten them all to "log".
-  expect(summary.consoleTypeByTag).toEqual({ warn: "warning", error: "error", info: "info", debug: "debug" });
-  // Node writes the resolved port back so it's observable after open(0).
-  expect(summary.debugPort).toBe(Number(new URL(summary.url).port));
-  expect(summary.unknownError).toEqual({ code: -32601, message: "'Totally.bogus' wasn't found" });
-  expect(summary.urlAfterClose).toBeNull();
-}, 30_000);
+
+  const { port, pathname } = new URL(url);
+  const target = (hostHeader: string) => ({
+    description: "bun instance",
+    devtoolsFrontendUrl: `devtools://devtools/bundled/js_app.html?experiments=true&v8only=true&ws=${hostHeader}${pathname}`,
+    devtoolsFrontendUrlCompat: `devtools://devtools/bundled/inspector.html?experiments=true&v8only=true&ws=${hostHeader}${pathname}`,
+    faviconUrl: "https://bun.com/favicon.ico",
+    id: pathname.slice(1),
+    title: `bun[${proc.pid}]`,
+    type: "node",
+    url: "file://",
+    webSocketDebuggerUrl: `ws://${hostHeader}${pathname}`,
+  });
+  const fortyTwo = { result: { result: { type: "number", value: 42, description: "42" } } };
+  expect(summary).toEqual({
+    pid: proc.pid,
+    urlBeforeOpen: null,
+    url,
+    alreadyActivated: {
+      code: "ERR_INSPECTOR_ALREADY_ACTIVATED",
+      message: "Inspector is already activated. Close it with inspector.close() before activating it again.",
+    },
+    version: { "Browser": `Bun/${Bun.version}`, "Protocol-Version": "1.1" },
+    list: [target(`127.0.0.1:${port}`)],
+    listWithIpHost: [target("127.0.0.1:19229")],
+    listWithMappedIpv6Host: [target("[::ffff:127.0.0.1]:19229")],
+    listWithDnsHostStatus: 400,
+    versionWithDnsHostStatus: 400,
+    websocketPathWithDnsHostStatus: 400,
+    websocketPathWithoutUpgradeStatus: 426,
+    executionContextCreated: [{ context: { id: 1, origin: "", name: "Bun", uniqueId: "1" } }],
+    thisScriptParsed: true,
+    runtimeEnable: { id: 1, result: {} },
+    debuggerEnable: { id: 2, result: { debuggerId: "(bun)" } },
+    evaluate: { id: 3, ...fortyTwo },
+    awaitedPromise: { id: 4, ...fortyTwo },
+    awaitedNonPromise: { id: 5, ...fortyTwo },
+    callOnGlobal: { id: 6, result: { result: { type: "string", value: "number" } } },
+    consoleEvent: {
+      type: "log",
+      args: [
+        { type: "string", value: "tagged-console-call" },
+        {
+          type: "object",
+          className: "Object",
+          description: "Object",
+          objectId: expect.any(String),
+          preview: expect.any(Object),
+        },
+      ],
+      executionContextId: 1,
+      timestamp: expect.any(Number),
+      stackTrace: {
+        callFrames: [
+          {
+            functionName: "module code",
+            scriptId: expect.any(String),
+            url: pathToFileURL(join(String(dir), "fixture.mjs")).href,
+            lineNumber: expect.any(Number),
+            columnNumber: expect.any(Number),
+          },
+        ],
+      },
+    },
+    // JSC reports warn/error/info/debug as {type:"log", level:...}; the adapter
+    // must emit CDP's type, not flatten them all to "log".
+    consoleTypeByTag: { warn: "warning", error: "error", info: "info", debug: "debug" },
+    unknownMethod: { id: 7, error: { code: -32601, message: "'Totally.bogus' wasn't found" } },
+    // Node writes the resolved port back so it's observable after open(0).
+    debugPort: Number(port),
+    urlAfterClose: null,
+  });
+  expect(exitCode).toBe(0);
+});
 
 // Node supports close() followed by open() again; a second open() while one is
 // active throws ERR_INSPECTOR_ALREADY_ACTIVATED.
@@ -264,19 +350,10 @@ const secondUrl = inspector.url();
 const version = await (await fetch("http://" + new URL(secondUrl).host + "/json/version")).json();
 inspector.close();
 
-console.log(
-  JSON.stringify({
-    firstUrl,
-    alreadyActiveCode,
-    closedUrl,
-    secondUrl,
-    protocolVersion: version["Protocol-Version"],
-    finalUrl: inspector.url() ?? null,
-  }),
-);
+console.log(JSON.stringify({ firstUrl, alreadyActiveCode, closedUrl, secondUrl, version, finalUrl: inspector.url() ?? null }));
 `;
 
-test("inspector.close() followed by inspector.open() starts a new server", async () => {
+test.concurrent("inspector.close() followed by inspector.open() starts a new server", async () => {
   using dir = tempDir("inspector-reopen", {
     "fixture.mjs": reopenInspectorFixture,
   });
@@ -288,16 +365,21 @@ test("inspector.close() followed by inspector.open() starts a new server", async
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stderrIfFailed: exitCode === 0 ? "" : stderr, exitCode }).toEqual({ stderrIfFailed: "", exitCode: 0 });
 
-  const summary = JSON.parse(stdout.trim().split("\n").at(-1)!);
-  expect(summary.firstUrl).toStartWith("ws://127.0.0.1:");
-  expect(summary.alreadyActiveCode).toBe("ERR_INSPECTOR_ALREADY_ACTIVATED");
-  expect(summary.closedUrl).toBeNull();
-  expect(summary.secondUrl).toStartWith("ws://127.0.0.1:");
-  expect(summary.secondUrl).not.toBe(summary.firstUrl);
-  expect(summary.protocolVersion).toBe("1.1");
-  expect(summary.finalUrl).toBeNull();
+  const [firstUrl, secondUrl] = [...stderr.matchAll(/^Debugger listening on (\S+)$/gm)].map(match => match[1]);
+  expect(stderr).toBe(`Debugger listening on ${firstUrl}\nDebugger listening on ${secondUrl}\n`);
+  expect(firstUrl).toMatch(inspectorUrl);
+  expect(secondUrl).toMatch(inspectorUrl);
+  expect(secondUrl).not.toBe(firstUrl);
+  expect(JSON.parse(stdout)).toEqual({
+    firstUrl,
+    alreadyActiveCode: "ERR_INSPECTOR_ALREADY_ACTIVATED",
+    closedUrl: null,
+    secondUrl,
+    version: { "Browser": `Bun/${Bun.version}`, "Protocol-Version": "1.1" },
+    finalUrl: null,
+  });
+  expect(exitCode).toBe(0);
 });
 
 // A failed inspector.open() (port already in use) must print Node's diagnostic
@@ -322,19 +404,10 @@ const version = await (await fetch("http://" + new URL(url).host + "/json/versio
 inspector.close();
 blocker.stop(true);
 
-console.log(
-  JSON.stringify({
-    threw,
-    blockedPort,
-    urlAfterFailure,
-    url,
-    protocolVersion: version["Protocol-Version"],
-    finalUrl: inspector.url() ?? null,
-  }),
-);
+console.log(JSON.stringify({ threw, blockedPort, urlAfterFailure, url, version, finalUrl: inspector.url() ?? null }));
 `;
 
-test("inspector.open() can be retried after a failed start", async () => {
+test.concurrent("inspector.open() can be retried after a failed start", async () => {
   using dir = tempDir("inspector-failed-open", {
     "fixture.mjs": failedOpenRetryFixture,
   });
@@ -346,16 +419,24 @@ test("inspector.open() can be retried after a failed start", async () => {
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stderrIfFailed: exitCode === 0 ? "" : stderr, exitCode }).toEqual({ stderrIfFailed: "", exitCode: 0 });
 
-  const summary = JSON.parse(stdout.trim().split("\n").at(-1)!);
-  // Node: prints one stderr line, does not throw, url() stays undefined.
-  expect(summary.threw).toBe(false);
-  expect(stderr).toContain(`Starting inspector on 127.0.0.1:${summary.blockedPort} failed: address already in use`);
-  expect(summary.urlAfterFailure).toBeNull();
-  expect(summary.url).toStartWith("ws://127.0.0.1:");
-  expect(summary.protocolVersion).toBe("1.1");
-  expect(summary.finalUrl).toBeNull();
+  // Node: the failed open() prints one stderr line, does not throw, and
+  // leaves url() undefined; the retry then announces its server as usual.
+  const blockedPort = Number(stderr.match(/^Starting inspector on 127\.0\.0\.1:(\d+) failed/)?.[1]);
+  const url = stderr.match(/^Debugger listening on (\S+)$/m)?.[1]!;
+  expect(stderr).toBe(
+    `Starting inspector on 127.0.0.1:${blockedPort} failed: address already in use\nDebugger listening on ${url}\n`,
+  );
+  expect(url).toMatch(inspectorUrl);
+  expect(JSON.parse(stdout)).toEqual({
+    threw: false,
+    blockedPort,
+    urlAfterFailure: null,
+    url,
+    version: { "Browser": `Bun/${Bun.version}`, "Protocol-Version": "1.1" },
+    finalUrl: null,
+  });
+  expect(exitCode).toBe(0);
 });
 
 // wait=true refs the event loop before the debugger thread attempts to bind;
@@ -364,12 +445,13 @@ const failedOpenWaitFixture = `
 import inspector from "node:inspector";
 
 const blocker = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: () => new Response("") });
-process.stdout.write(blocker.port + "\\n");
-inspector.open(blocker.port, "127.0.0.1", true);
+const blockedPort = blocker.port;
+inspector.open(blockedPort, "127.0.0.1", true);
 blocker.stop(true);
+console.log(JSON.stringify({ blockedPort, urlAfterFailure: inspector.url() ?? null }));
 `;
 
-test("inspector.open() with wait=true does not hang the process after a bind failure", async () => {
+test.concurrent("inspector.open() with wait=true does not hang the process after a bind failure", async () => {
   using dir = tempDir("inspector-failed-open-wait", {
     "fixture.mjs": failedOpenWaitFixture,
   });
@@ -381,10 +463,11 @@ test("inspector.open() with wait=true does not hang the process after a bind fai
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  const port = stdout.trim();
-  expect(stderr).toContain(`Starting inspector on 127.0.0.1:${port} failed: address already in use`);
-  expect(proc.signalCode).toBeNull();
-  expect(exitCode).toBe(0);
+
+  const blockedPort = Number(stderr.match(/^Starting inspector on 127\.0\.0\.1:(\d+) failed/)?.[1]);
+  expect(stderr).toBe(`Starting inspector on 127.0.0.1:${blockedPort} failed: address already in use\n`);
+  expect(JSON.parse(stdout)).toEqual({ blockedPort, urlAfterFailure: null });
+  expect({ exitCode, signalCode: proc.signalCode }).toEqual({ exitCode: 0, signalCode: null });
 });
 
 // waitForDebugger() must block until a client sends Runtime.runIfWaitingForDebugger,
@@ -402,7 +485,7 @@ inspector.close();
 process.exit(resumedByClient ? 0 : 7);
 `;
 
-test("inspector.waitForDebugger() blocks until a client resumes the process", async () => {
+test.concurrent("inspector.waitForDebugger() blocks until a client resumes the process", async () => {
   using dir = tempDir("inspector-wait", {
     "fixture.mjs": waitForDebuggerFixture,
   });
@@ -413,22 +496,10 @@ test("inspector.waitForDebugger() blocks until a client resumes the process", as
     cwd: String(dir),
     stderr: "pipe",
   });
+  const stderr = collectOutput(proc.stderr);
+  const [, wsUrl] = await stderr.waitFor(/^Debugger listening on (\S+)\nWAITING_FOR_DEBUGGER\n/);
 
-  // Read stderr incrementally: the fixture blocks in waitForDebugger(), so the
-  // stream cannot be awaited to completion before acting as the client.
-  const decoder = new TextDecoder();
-  const reader = proc.stderr.getReader();
-  let stderrText = "";
-  let wsUrl: string | undefined;
-  while (!wsUrl || !stderrText.includes("WAITING_FOR_DEBUGGER")) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    stderrText += decoder.decode(value);
-    wsUrl ??= stderrText.match(/Debugger listening on (ws:\S+)/)?.[1];
-  }
-  expect(wsUrl).toBeDefined();
-
-  const ws = new WebSocket(wsUrl!);
+  const ws = new WebSocket(wsUrl);
   const opened = Promise.withResolvers<void>();
   ws.onopen = () => opened.resolve();
   ws.onerror = error => opened.reject(error);
@@ -444,20 +515,11 @@ test("inspector.waitForDebugger() blocks until a client resumes the process", as
   );
   ws.send(JSON.stringify({ id: 2, method: "Runtime.runIfWaitingForDebugger", params: {} }));
 
-  // Keep draining stderr so the pipe cannot fill while the fixture finishes.
-  const drained = (async () => {
-    for (;;) {
-      const { value, done } = await reader.read();
-      if (done) break;
-      stderrText += decoder.decode(value);
-    }
-  })();
-
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-  await drained;
+  const [stdout, stderrText, exitCode] = await Promise.all([proc.stdout.text(), stderr.finished, proc.exited]);
   ws.close();
 
-  expect(JSON.parse(stdout.trim().split("\n").at(-1)!)).toEqual({ resumedByClient: true });
+  expect(stderrText).toBe(`Debugger listening on ${wsUrl}\nWAITING_FOR_DEBUGGER\n`);
+  expect(JSON.parse(stdout)).toEqual({ resumedByClient: true });
   expect(exitCode).toBe(0);
 });
 
@@ -479,7 +541,7 @@ inspector.close();
 process.exit(0);
 `;
 
-test("inspector.waitForDebugger() blocks again on the second call after a frontend disconnects", async () => {
+test.concurrent("inspector.waitForDebugger() blocks again on the second call after a client disconnects", async () => {
   using dir = tempDir("inspector-wait-twice", {
     "fixture.mjs": waitForDebuggerTwiceFixture,
   });
@@ -490,28 +552,15 @@ test("inspector.waitForDebugger() blocks again on the second call after a fronte
     cwd: String(dir),
     stderr: "pipe",
   });
-
-  const decoder = new TextDecoder();
-  const reader = proc.stderr.getReader();
-  let stderrText = "";
-  const readUntil = async (needle: string) => {
-    while (!stderrText.includes(needle)) {
-      const { value, done } = await reader.read();
-      if (done) throw new Error(`stderr closed before ${JSON.stringify(needle)}; got: ${stderrText}`);
-      stderrText += decoder.decode(value);
-    }
-  };
-
-  await readUntil("READY");
-  const wsUrl = stderrText.match(/Debugger listening on (ws:\S+)/)?.[1];
-  expect(wsUrl).toBeDefined();
+  const stderr = collectOutput(proc.stderr);
+  const [, wsUrl] = await stderr.waitFor(/^Debugger listening on (\S+)\nREADY\n/);
 
   // Close only once the fixture has observably resumed: closing the socket
   // immediately after send() can race the cross-thread dispatch so
   // Inspector.initialized lands but Runtime.evaluate is still queued,
   // leaving __mark undefined.
-  const connectAndResume = async (expression: string, resumedNeedle: string) => {
-    const ws = new WebSocket(wsUrl!);
+  const connectAndResume = async (expression: string, resumed: RegExp) => {
+    const ws = new WebSocket(wsUrl);
     const closed = Promise.withResolvers<void>();
     const opened = Promise.withResolvers<void>();
     ws.onopen = () => opened.resolve();
@@ -523,7 +572,7 @@ test("inspector.waitForDebugger() blocks again on the second call after a fronte
     await opened.promise;
     ws.send(JSON.stringify({ id: 1, method: "Runtime.evaluate", params: { expression } }));
     ws.send(JSON.stringify({ id: 2, method: "Runtime.runIfWaitingForDebugger", params: {} }));
-    await readUntil(resumedNeedle);
+    await stderr.waitFor(resumed);
     ws.close();
     await closed.promise;
   };
@@ -533,24 +582,229 @@ test("inspector.waitForDebugger() blocks again on the second call after a fronte
   // fixture would already have exited if the second call returned immediately.
   // Runtime.evaluate may dispatch after the wait resolves (separate batch), so
   // the mark values are asserted only in the final JSON, not here.
-  await connectAndResume("globalThis.__mark = 1", "FIRST_RESUMED");
-  await connectAndResume("globalThis.__mark2 = 2", "SECOND_RESUMED");
+  await connectAndResume("globalThis.__mark = 1", /FIRST_RESUMED\n/);
+  await connectAndResume("globalThis.__mark2 = 2", /SECOND_RESUMED\n/);
 
-  const drained = (async () => {
-    for (;;) {
-      const { value, done } = await reader.read();
-      if (done) break;
-      stderrText += decoder.decode(value);
-    }
-  })();
+  const [stdout, stderrText, exitCode] = await Promise.all([proc.stdout.text(), stderr.finished, proc.exited]);
 
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-  await drained;
-
-  expect(JSON.parse(stdout.trim().split("\n").at(-1)!)).toEqual({ first: 1, second: 2 });
+  expect(stderrText).toBe(`Debugger listening on ${wsUrl}\nREADY\nFIRST_RESUMED\nSECOND_RESUMED\n`);
+  expect(JSON.parse(stdout)).toEqual({ first: 1, second: 2 });
   expect(exitCode).toBe(0);
 });
 
+// Activating breakpoints on a debugger that was attached at runtime (after the
+// entry module has already been linked) used to crash the inspected process:
+// JSC's clearCode discarded the module's UnlinkedModuleProgramCodeBlock, and
+// the next executeModuleProgram regenerated it under CodeGenerationMode::
+// Debugger with a different module-environment / generator-frame layout, so the
+// resumed top-level-await body wrote past the live JSModuleEnvironment.
+test.concurrent("activating breakpoints on a runtime-attached debugger does not crash module evaluation", async () => {
+  using dir = tempDir("inspector-runtime-attach", {
+    "entry.mjs": `
+let warm = 0;
+for (let i = 0; i < 5; i++) warm += i;
+process.stdout.write("ready\\n");
+await new Promise(resolve => process.stdin.once("data", resolve));
+process.stdout.write("importing\\n");
+const mod = await import("./mod.mjs");
+process.stdout.write(JSON.stringify({ after: mod.after, bump: mod.bump(), warm }) + "\\n");
+process.exit(0);
+`,
+    "mod.mjs": `
+let counter = 0;
+export function bump() { counter++; return counter; }
+let after = counter + 1;
+export { after };
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--inspect=127.0.0.1:0/runtime-attach", "entry.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const stderr = collectOutput(proc.stderr);
+  const stdout = collectOutput(proc.stdout);
+  const [, wsUrl] = await stderr.waitFor(/^  (ws:\/\/127\.0\.0\.1:\d+\/runtime-attach)$/m);
+  await stdout.waitFor(/^ready\n/);
+
+  // Connect a JSC-protocol client and activate breakpoints — this is what
+  // forces the recompileAllJSFunctions() / deleteAllCode() path.
+  const ws = new WebSocket(wsUrl);
+  await new Promise<void>((resolve, reject) => {
+    ws.onopen = () => resolve();
+    ws.onerror = err => reject(err);
+  });
+  let nextId = 1;
+  const pending = new Map<number, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
+  ws.onmessage = event => {
+    const msg = JSON.parse(String(event.data));
+    if (msg.id != null && pending.has(msg.id)) {
+      const p = pending.get(msg.id)!;
+      pending.delete(msg.id);
+      msg.error ? p.reject(new Error(JSON.stringify(msg.error))) : p.resolve(msg.result);
+    }
+  };
+  function send(method: string, params?: unknown) {
+    return new Promise((resolve, reject) => {
+      const id = nextId++;
+      pending.set(id, { resolve, reject });
+      ws.send(JSON.stringify({ id, method, params }));
+    });
+  }
+  await send("Inspector.enable");
+  await send("Debugger.enable");
+  await send("Debugger.setBreakpointsActive", { active: true });
+
+  // FileSink buffers: without the flush the child never sees "go" and both
+  // sides wait on each other until the test times out.
+  proc.stdin.write("go\n");
+  proc.stdin.flush();
+  await stdout.waitFor(/^\{.*\}\n/m);
+  ws.close();
+  const [stdoutText, stderrText, exitCode] = await Promise.all([stdout.finished, stderr.finished, proc.exited]);
+
+  const banner = "--------------------- Bun Inspector ---------------------";
+  expect(stderrText).toBe(
+    `${banner}\nListening:\n  ${wsUrl}\nInspect in browser:\n  https://debug.bun.sh/#${wsUrl.slice("ws://".length)}\n${banner}\n`,
+  );
+  expect(stdoutText).toBe(`ready\nimporting\n${JSON.stringify({ after: 1, bump: 1, warm: 10 })}\n`);
+  expect(exitCode).toBe(0);
+});
+
+// End-to-end pause/resume over the DevTools-protocol server started by
+// inspector.open(): the entry module is a top-level-await module that calls
+// open() at runtime, the client attaches and enables the Debugger domain
+// (which the adapter activates breakpoints for), the entry module then imports
+// a module containing `debugger;`, and the client resumes the pause.
+//
+// One statement per line and no blank lines, so the line Debugger.paused
+// reports for the transpiled module is the line of `debugger;` in this source.
+const debuggerStatementModule = `let counter = 0;
+debugger;
+let after = counter + 1;
+export { after };
+`;
+
+test.concurrent("breakpoints pause and resume over the inspector.open() DevTools server", async () => {
+  using dir = tempDir("inspector-breakpoints", {
+    // wait=true blocks the inspected thread in waitForDebugger()'s tick loop
+    // until Runtime.runIfWaitingForDebugger, so Debugger.enable is guaranteed
+    // to have armed setPauseOnDebuggerStatements before mod.mjs evaluates.
+    "entry.mjs": `
+import inspector from "node:inspector";
+let beforeOpen = 1;
+inspector.open(0, "127.0.0.1", true);
+const mod = await import("./mod.mjs");
+console.log(JSON.stringify({ after: mod.after, beforeOpen }));
+inspector.close();
+process.exit(0);
+`,
+    "mod.mjs": debuggerStatementModule,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const stderr = collectOutput(proc.stderr);
+  const stdout = collectOutput(proc.stdout);
+  const [, wsUrl] = await stderr.waitFor(/^Debugger listening on (\S+)\n/);
+
+  const ws = new WebSocket(wsUrl);
+  await new Promise<void>((resolve, reject) => {
+    ws.onopen = () => resolve();
+    ws.onerror = err => reject(err);
+  });
+  let nextId = 1;
+  let awaiting = "";
+  const pending = new Map<number, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
+  const paused = Promise.withResolvers<unknown>();
+  ws.onmessage = event => {
+    const msg = JSON.parse(String(event.data));
+    if (msg.id != null && pending.has(msg.id)) {
+      const p = pending.get(msg.id)!;
+      pending.delete(msg.id);
+      msg.error ? p.reject(new Error(JSON.stringify(msg.error))) : p.resolve(msg.result);
+    } else if (msg.method === "Debugger.paused") {
+      paused.resolve(msg.params);
+    }
+  };
+  // Every awaited promise must reject on socket loss or child death so the
+  // failure reports where it was stuck instead of silently hitting the suite
+  // timeout with no stack.
+  const abandon = (why: string) => {
+    const err = new Error(`${why} while awaiting ${awaiting}; stderr: ${stderr.text}`);
+    paused.reject(err);
+    for (const p of pending.values()) p.reject(err);
+    pending.clear();
+  };
+  ws.onerror = () => abandon("inspector websocket errored");
+  ws.onclose = () => abandon("inspector websocket closed");
+  proc.exited.then(code => abandon(`child exited (code ${code})`));
+  function send(method: string, params?: unknown) {
+    return new Promise((resolve, reject) => {
+      const id = nextId++;
+      awaiting = method;
+      pending.set(id, { resolve, reject });
+      ws.send(JSON.stringify({ id, method, params }));
+    });
+  }
+  await send("Runtime.enable");
+  await send("Debugger.enable");
+  // The inspected thread is still parked inside open()'s waitForDebugger at
+  // this point; releasing it now is race-free because Debugger.enable's reply
+  // proves the backend already armed breakpoints.
+  await send("Runtime.runIfWaitingForDebugger");
+
+  awaiting = "Debugger.paused";
+  const scope = (type: string) => ({
+    type,
+    object: expect.objectContaining({ type: "object", objectId: expect.any(String) }),
+  });
+  expect(await paused.promise).toEqual({
+    // V8 also reports a `debugger;` statement as "other" (no hitBreakpoints).
+    reason: "other",
+    callFrames: [
+      {
+        callFrameId: expect.any(String),
+        functionName: "module code",
+        location: {
+          scriptId: expect.any(String),
+          lineNumber: debuggerStatementModule.split("\n").indexOf("debugger;"),
+          columnNumber: 0,
+        },
+        url: pathToFileURL(join(String(dir), "mod.mjs")).href,
+        scopeChain: [scope("closure"), scope("script"), scope("global")],
+        this: { type: "undefined" },
+        canBeRestarted: false,
+      },
+    ],
+  });
+  // Do not wait for the resume reply: the inspected thread may reach
+  // process.exit(0) before the debugger thread has relayed it, which closes
+  // the socket first. The JSON on stdout is the real proof the resume landed.
+  ws.send(JSON.stringify({ id: nextId++, method: "Debugger.resume" }));
+  await stdout.waitFor(/^\{.*\}\n/m);
+  ws.close();
+  const [stdoutText, stderrText, exitCode] = await Promise.all([stdout.finished, stderr.finished, proc.exited]);
+
+  expect(stderrText).toBe(`Debugger listening on ${wsUrl}\n`);
+  expect(JSON.parse(stdoutText)).toEqual({ after: 1, beforeOpen: 1 });
+  expect(exitCode).toBe(0);
+});
+
+// The in-process Session tests below stay serial: a Session with Runtime
+// enabled hooks this process's console, and several of them also listen for
+// process "warning" events or tamper with shared prototypes, so they would
+// observe each other's console.log calls if they overlapped.
 test("Runtime.consoleAPICalled is emitted while the Runtime domain is enabled", () => {
   const session = new inspector.Session();
   session.connect();
@@ -768,234 +1022,6 @@ test("a console argument whose toString throws does not break console.log", asyn
     process.off("warning", onWarning);
     session.disconnect();
   }
-});
-
-// Activating breakpoints on a debugger that was attached at runtime (after the
-// entry module has already been linked) used to crash the inspected process:
-// JSC's clearCode discarded the module's UnlinkedModuleProgramCodeBlock, and
-// the next executeModuleProgram regenerated it under CodeGenerationMode::
-// Debugger with a different module-environment / generator-frame layout, so the
-// resumed top-level-await body wrote past the live JSModuleEnvironment.
-test("activating breakpoints with a runtime-attached debugger does not crash module evaluation", async () => {
-  using dir = tempDir("inspector-runtime-attach", {
-    "entry.mjs": `
-let warm = 0;
-for (let i = 0; i < 5; i++) warm += i;
-process.stdout.write("ready\\n");
-await new Promise(resolve => process.stdin.once("data", resolve));
-process.stdout.write("importing\\n");
-const mod = await import("./mod.mjs");
-process.stdout.write(JSON.stringify({ after: mod.after, bump: mod.bump(), warm }) + "\\n");
-process.exit(0);
-`,
-    "mod.mjs": `
-let counter = 0;
-export function bump() { counter++; return counter; }
-let after = counter + 1;
-export { after };
-`,
-  });
-
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "--inspect=127.0.0.1:0/runtime-attach", "entry.mjs"],
-    env: bunEnv,
-    cwd: String(dir),
-    stdin: "pipe",
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const decoder = new TextDecoder();
-  const stderrReader = proc.stderr.getReader();
-  let stderrText = "";
-  let wsUrl: string | undefined;
-  while (!wsUrl) {
-    const { value, done } = await stderrReader.read();
-    if (done) throw new Error(`stderr closed before listening line: ${stderrText}`);
-    stderrText += decoder.decode(value);
-    wsUrl = stderrText.match(/ws:\/\/[\w.:-]+\/runtime-attach/)?.[0];
-  }
-  const stderrDrained = (async () => {
-    for (;;) {
-      const { value, done } = await stderrReader.read();
-      if (done) break;
-      stderrText += decoder.decode(value);
-    }
-  })();
-
-  const stdoutReader = proc.stdout.getReader();
-  let stdoutText = "";
-  async function waitForStdout(marker: string) {
-    while (!stdoutText.includes(marker)) {
-      const { value, done } = await stdoutReader.read();
-      if (done) throw new Error(`stdout closed before "${marker}": ${stdoutText}\n${stderrText}`);
-      stdoutText += decoder.decode(value);
-    }
-  }
-  await waitForStdout("ready");
-
-  // Connect a JSC-protocol client and activate breakpoints — this is what
-  // forces the recompileAllJSFunctions() / deleteAllCode() path.
-  const ws = new WebSocket(wsUrl);
-  await new Promise<void>((resolve, reject) => {
-    ws.onopen = () => resolve();
-    ws.onerror = err => reject(err);
-  });
-  let nextId = 1;
-  const pending = new Map<number, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
-  ws.onmessage = event => {
-    const msg = JSON.parse(String(event.data));
-    if (msg.id != null && pending.has(msg.id)) {
-      const p = pending.get(msg.id)!;
-      pending.delete(msg.id);
-      msg.error ? p.reject(new Error(JSON.stringify(msg.error))) : p.resolve(msg.result);
-    }
-  };
-  function send(method: string, params?: unknown) {
-    return new Promise((resolve, reject) => {
-      const id = nextId++;
-      pending.set(id, { resolve, reject });
-      ws.send(JSON.stringify({ id, method, params }));
-    });
-  }
-  await send("Inspector.enable");
-  await send("Debugger.enable");
-  await send("Debugger.setBreakpointsActive", { active: true });
-
-  // FileSink buffers: without the flush the child never sees "go" and both
-  // sides wait on each other until the test times out.
-  proc.stdin.write("go\n");
-  proc.stdin.flush();
-  await waitForStdout("importing");
-  await waitForStdout("}\n");
-  ws.close();
-
-  expect(JSON.parse(stdoutText.trim().split("\n").at(-1)!)).toEqual({ after: 1, bump: 1, warm: 10 });
-  expect(await proc.exited).toBe(0);
-  await stderrDrained;
-});
-
-// End-to-end pause/resume over the DevTools-protocol server started by
-// inspector.open(): the entry module is a top-level-await module that calls
-// open() at runtime, the client attaches and enables the Debugger domain
-// (which the adapter activates breakpoints for), the entry module then imports
-// a module containing `debugger;`, and the client resumes the pause.
-test("breakpoints pause and resume over the inspector.open() DevTools server", async () => {
-  using dir = tempDir("inspector-breakpoints", {
-    // wait=true blocks the inspected thread in waitForDebugger()'s tick loop
-    // until Runtime.runIfWaitingForDebugger, so Debugger.enable is guaranteed
-    // to have armed setPauseOnDebuggerStatements before mod.mjs evaluates.
-    "entry.mjs": `
-import inspector from "node:inspector";
-let beforeOpen = 1;
-inspector.open(0, "127.0.0.1", true);
-const mod = await import("./mod.mjs");
-console.log(JSON.stringify({ after: mod.after, beforeOpen }));
-inspector.close();
-process.exit(0);
-`,
-    "mod.mjs": `
-let counter = 0;
-debugger;
-let after = counter + 1;
-export { after };
-`,
-  });
-
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "entry.mjs"],
-    env: bunEnv,
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const decoder = new TextDecoder();
-  const stderrReader = proc.stderr.getReader();
-  let stderrText = "";
-  let wsUrl: string | undefined;
-  while (!wsUrl) {
-    const { value, done } = await stderrReader.read();
-    if (done) throw new Error(`stderr closed before listening line: ${stderrText}`);
-    stderrText += decoder.decode(value);
-    wsUrl = stderrText.match(/Debugger listening on (ws:\S+)/)?.[1];
-  }
-  const stderrDrained = (async () => {
-    for (;;) {
-      const { value, done } = await stderrReader.read();
-      if (done) break;
-      stderrText += decoder.decode(value);
-    }
-  })();
-
-  const ws = new WebSocket(wsUrl);
-  await new Promise<void>((resolve, reject) => {
-    ws.onopen = () => resolve();
-    ws.onerror = err => reject(err);
-  });
-  let nextId = 1;
-  let awaiting = "";
-  const pending = new Map<number, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
-  let pausedReason: string | undefined;
-  const paused = Promise.withResolvers<void>();
-  ws.onmessage = event => {
-    const msg = JSON.parse(String(event.data));
-    if (msg.id != null && pending.has(msg.id)) {
-      const p = pending.get(msg.id)!;
-      pending.delete(msg.id);
-      msg.error ? p.reject(new Error(JSON.stringify(msg.error))) : p.resolve(msg.result);
-    } else if (msg.method === "Debugger.paused") {
-      pausedReason = msg.params?.reason;
-      paused.resolve();
-    }
-  };
-  // Every awaited promise must reject on socket loss or child death so the
-  // failure reports where it was stuck instead of silently hitting the suite
-  // timeout with no stack.
-  const abandon = (why: string) => {
-    const err = new Error(`${why} while awaiting ${awaiting}; stderr: ${stderrText}`);
-    paused.reject(err);
-    for (const p of pending.values()) p.reject(err);
-    pending.clear();
-  };
-  ws.onerror = () => abandon("inspector websocket errored");
-  ws.onclose = () => abandon("inspector websocket closed");
-  proc.exited.then(code => abandon(`child exited (code ${code})`));
-  function send(method: string, params?: unknown) {
-    return new Promise((resolve, reject) => {
-      const id = nextId++;
-      awaiting = method;
-      pending.set(id, { resolve, reject });
-      ws.send(JSON.stringify({ id, method, params }));
-    });
-  }
-  await send("Runtime.enable");
-  await send("Debugger.enable");
-  // The inspected thread is still parked inside open()'s waitForDebugger at
-  // this point; releasing it now is race-free because Debugger.enable's reply
-  // proves the backend already armed breakpoints.
-  await send("Runtime.runIfWaitingForDebugger");
-
-  awaiting = "Debugger.paused";
-  await paused.promise;
-  expect(pausedReason).toBe("other");
-  // Do not wait for the resume reply: the inspected thread may reach
-  // process.exit(0) before the debugger thread has relayed it, which closes
-  // the socket first. The JSON on stdout is the real proof the resume landed.
-  ws.send(JSON.stringify({ id: nextId++, method: "Debugger.resume" }));
-
-  const stdoutReader = proc.stdout.getReader();
-  let stdoutText = "";
-  for (;;) {
-    const { value, done } = await stdoutReader.read();
-    if (done) break;
-    stdoutText += decoder.decode(value);
-  }
-  ws.close();
-  await stderrDrained;
-
-  expect(JSON.parse(stdoutText.trim().split("\n").at(-1)!)).toEqual({ after: 1, beforeOpen: 1 });
-  expect(await proc.exited).toBe(0);
 });
 
 test("disconnect does not clobber a console method reassigned by user code", () => {


### PR DESCRIPTION
### Problem
- `test/js/node/inspector/inspector.test.ts` takes 12-20s on the release-asan CI lane (CI build #97275: 19.9s; `test/expected-durations.json` median: 12.1s) against 0.3-0.7s on every release lane.
- Eight of its tests spawn a child that starts the inspector, and they ran one after another. Under a debug build a child that only does `require("node:inspector")` plus `open()`/`close()` costs about 2.1s (plain VM start is 0.3s; loading `node:inspector` and starting the debugger thread's second VM is the rest), and each of the eight tests measured 1.9-3.1s, except the `open()` test at 5.7s.
- The `open()` fixture imported `node:http` and `node:assert` just to send a `Host` header and check one value. Measured with the debug build, those imports plus the first `http.get` accounted for about 2s of that test's 5.7s. That is the only cost found that is not plain startup overhead.
- No stall exists: user CPU time roughly equals wall time for the whole file (28.5s user for 30.2s wall before the change), every read loop in the file is event driven, and in the breakpoint test the child exits about 100ms after `Debugger.resume` is sent, so the 1s safety-net wait in `BunInspectorConnection::runWhilePaused` (`src/jsc/bindings/BunDebugger.cpp:295`) is never hit.

### Fix
- The eight child-spawning tests are `test.concurrent` and contiguous: the two breakpoint tests move up next to the other six (a pure move apart from the changes listed below; `git diff --color-moved` shows it). Contiguity matters because a serial test waits for the concurrent group before it, and ASAN builds cap test concurrency at 5 (`src/options_types/context.rs:506`), so two groups would cost roughly two extra rounds of children.
- The in-process `Session` tests stay serial: a Session with Runtime enabled hooks this process's console and several of them listen for process `warning` events, so they would see each other's output if they overlapped. They take about 0.3s in total.
- The `open()` fixture imports only `node:inspector`. Bun's `fetch()` sends an explicit `Host` header as given (covered by `test/js/web/fetch/fetch.test.ts`, "the explicit Host header is still honored"), so the Host-header probes use it.
- The per-test 30s timeout on the `open()` test becomes `if (isDebug) setDefaultTimeout(30_000)`: overlapping debug children take 3.5-4.8s each on this machine, which does not reliably fit the 5s local default, while CI passes its own larger `--timeout`, which a file-level override must not lower (release-asan is not a debug build, so it is unaffected). A per-test timeout argument on `test.concurrent` makes prettier expand every test body, hence the file-level form.
- Assertions, all verified against the actual payloads:
  - every fixture summary is one `toEqual` against the full expected object: complete `/json/list` targets for the default, IP-literal and IPv4-mapped `Host` headers (built from the announced URL and the child's pid), the exact `ERR_INSPECTOR_ALREADY_ACTIVATED` code and message, `/json/version` including `Browser`, the full CDP responses with their ids (`Runtime.enable`, `Debugger.enable` with `debuggerId: "(bun)"`, the three `Runtime.evaluate` results, `Runtime.callFunctionOn`, the exact `-32601` error object), the `Runtime.executionContextCreated` payload, and the `Runtime.consoleAPICalled` payload (args, `executionContextId`, stack frame pointing at the fixture's file URL; `timestamp` is only checked to be a number because its unit is the subject of the open #35736);
  - every child's stderr is asserted exactly and before its exit code: the `Debugger listening on` line(s) (which must match the URL `inspector.url()` returned), the `Starting inspector on 127.0.0.1:<port> failed: address already in use` diagnostic with the port the fixture actually used, the `--inspect` banner, and the fixtures' own markers; the `open()` fixture's console lines on stdout are asserted too, so console output relayed to the client is shown to still reach stdio;
  - `Debugger.paused` is asserted by value: `reason: "other"`, one frame named `module code` at the `debugger;` line (column 0) of the module's `file://` URL, the `closure`/`script`/`global` scope chain, `this` undefined. The module fixture has one statement per line so the line reported for the transpiled module is the line in the source;
  - the WebSocket path is probed with a rejected `Host` (400) and, as a control, with an accepted one (426 from the upgrade itself), so the 400 is attributable to the Host check; `Debugger.enable` is checked to report the fixture's own module by URL rather than a non-zero script count; the wait=true bind-failure fixture also reports `url()` staying undefined; `exitCode` and `signalCode` are asserted together;
  - the two `waitForDebugger` tests and the two breakpoint tests share one `collectOutput` helper whose `waitFor(pattern)` fails with the output received so far if the child closes the stream first, replacing four hand-written reader loops. Both breakpoint tests close their client only after the child's JSON line has been seen, as before.
- No test was removed or skipped; 23 tests before and after. Two tests are renamed by a word each so their headers fit on one line (`frontend` to `client`, `with a` to `on a`).
- Verification (this container, 12 CPUs):
  - `bun bd test test/js/node/inspector/inspector.test.ts` (debug, ASAN) before: 30.2s, 34.6s, 32.5s; after: 9.7s, 9.1s, 8.5s (about 3s of that is loading the test file itself, the child group is two rounds of up to 5 children, the Session tests 0.3s).
  - `USE_SYSTEM_BUN=1 bun test ...` (release 1.4.0) before: 0.88s, 0.99s; after: 0.34s, 0.60s, 0.82s.
  - The final file passed 3 out of 3 further debug-build runs (23/23 each); the same assertions also passed 6 runs while the layout was being iterated on.
  - This PR's CI run, from the shard logs: 9.04s on debian 13 x64-asan (19.9s in the build that prompted this, 12.1s median), 179ms on debian 13 x64, 157ms on alpine x64, 343ms on windows 2019 x64, 485ms on windows 11 aarch64; 23/23 on every lane. The asan lane's timestamps put the child group at about 8.8s, two rounds of up to 5 children on a box where one of these children cost about 2.4s even when the file was serial, so that lane is now bound by the children's CPU cost rather than by waiting; the same children run in 2.1-2.5s under the debug build here with and without the CI runner's `BUN_DESTRUCT_VM_ON_EXIT` / LeakSanitizer environment, so the exit path adds no wait either.

### Background
- `inspector.open()` starts a second JavaScriptCore VM on a "Debugger" thread that runs `src/js/internal/debugger.ts` and serves the Chrome DevTools Protocol over a WebSocket, translating it to JSC's inspector protocol (`src/js/internal/inspector/cdp.ts`). Under a debug build, starting that second VM is most of a child's cost, which is why each of these tests is startup-bound.
- `test.concurrent` tests in `bun test` overlap with each other; a plain `test()` after them runs only once the group has finished, and `--max-concurrency` (default 20, 5 on ASAN builds) bounds how many run at once.
- A test's own timeout argument beats `setDefaultTimeout()`, which beats the `--timeout` flag (`src/runtime/test_runner/ScopeFunctions.rs:746`). The CI runner passes `--timeout` of 90s, or 270s on the asan lane.
- `Host` header check: like Node, the inspector server reflects localhost/IP-literal `Host` values into `/json/list` (for port forwards) and rejects other hostnames with 400 (DNS-rebinding guard), on the discovery endpoints and on the WebSocket path alike. A GET of the WebSocket path that passes the check reaches `server.upgrade()`, which answers 426 without WebSocket headers.
