### PR TITLE
strings: length-check eql_long(.., false) and eql_comptime_ignore_len in release builds

### DIFF
--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -1089,6 +1089,9 @@ pub fn eql_comptime_utf16(self_: &[u16], alt: &[u8]) -> bool {
             .all(|(&u, &b)| u == u16::from(b))
 }
 
+/// `eql_comptime` minus the length test: compares the first `alt.len()` bytes
+/// of `self_`, so a longer `self_` still matches and a shorter one is unequal
+/// rather than read past.
 pub fn eql_comptime_ignore_len(self_: &[u8], alt: &[u8]) -> bool {
     eql_comptime_check_len_with_type::<u8, false>(self_, alt)
 }
@@ -1124,17 +1127,10 @@ pub fn has_suffix_comptime(self_: &[u8], alt: &'static [u8]) -> bool {
 
 fn eql_comptime_check_len_u8(a: &[u8], b: &[u8], check_len: bool) -> bool {
     // Slice equality compiles to memcmp; for short literals LLVM emits
-    // unrolled fixed-size compares.
-    if check_len {
-        return a == b;
-    }
-    debug_assert!(a.len() >= b.len());
-    // SAFETY: when `check_len`, the early-return above gives `a.len()==b.len()`.
-    // When `!check_len`, callers guarantee `a.len() >= b.len()` (debug-asserted
-    // above). LLVM cannot prove the latter, so
-    // a checked slice would emit a real bounds check on this hot path
-    // (lexer keyword/prefix matching) — keep the unchecked index.
-    unsafe { a.get_unchecked(..b.len()) == b }
+    // unrolled fixed-size compares. `starts_with`'s length test folds away at
+    // callers that already sliced or matched the lengths, so an unchecked
+    // index here would save nothing.
+    if check_len { a == b } else { a.starts_with(b) }
 }
 
 fn eql_comptime_check_len_with_known_type<T: crate::NoUninit + Eq, const CHECK_LEN: bool>(
@@ -1225,8 +1221,12 @@ pub fn has_prefix_case_insensitive(str: &[u8], prefix: &[u8]) -> bool {
     has_prefix_case_insensitive_t(str, prefix)
 }
 
-// same rationale as `eql_case_insensitive_ascii` — `check_len` is a runtime
-// 3rd arg to match the dominant call shape (`eql_long(a, b, true)`).
+/// With `check_len`, `a_str == b_str`. Without it, whether `a_str` starts with
+/// `b_str`: a shorter `a_str` compares unequal instead of being read past, so
+/// callers that already matched the lengths skip only the equality test.
+///
+/// Same rationale as `eql_case_insensitive_ascii`: `check_len` is a runtime
+/// 3rd arg to match the dominant call shape (`eql_long(a, b, true)`).
 #[inline]
 pub fn eql_long(a_str: &[u8], b_str: &[u8], check_len: bool) -> bool {
     let len = b_str.len();
@@ -1238,13 +1238,13 @@ pub fn eql_long(a_str: &[u8], b_str: &[u8], check_len: bool) -> bool {
         if a_str.len() != len {
             return false;
         }
-    } else if cfg!(debug_assertions) {
-        debug_assert!(b_str.len() <= a_str.len());
+    } else if a_str.len() < len {
+        return false;
     }
 
-    // SAFETY: a_str.len() >= b_str.len() by contract above (checked when
-    // `check_len`, debug-asserted otherwise), so the word-chunked raw-pointer
-    // walk below never reads past either slice.
+    // SAFETY: both branches above return unless `a_str.len() >= len`, so the
+    // word-chunked raw-pointer walk over `len` bytes below stays inside both
+    // slices whatever the caller passed.
     unsafe {
         let end = b_str.as_ptr().add(len);
         let mut a = a_str.as_ptr();
@@ -2726,6 +2726,8 @@ pub fn glob_length_compare(key_a: &[u8], key_b: &[u8]) -> Ordering {
 
 #[cfg(test)]
 mod tests {
+    use super::{eql_comptime_ignore_len, eql_long};
+
     // Regression guard for 3e7f1dabc079: `crate::strings` is an alias of
     // *this* module, so wrappers here (e.g. `first_non_ascii`) must call
     // `crate::strings_impl::*`, never `crate::strings::*` (self-recursion).
@@ -2753,5 +2755,64 @@ mod tests {
         assert_eq!(out, &[0xD800][..]);
         let out = super::convert_utf8_to_utf16_in_buffer(&mut buf, b"\xC3\xA9\xF0\x9F\x98\x80");
         assert_eq!(out, &[0x00E9, 0xD83D, 0xDE00][..]);
+    }
+
+    // Every strict prefix of every length up to two 8-byte words, so a compare
+    // that walks `long.len()` bytes of `short` over-reads from each step of
+    // `eql_long`'s walk (word loop, 4-, 2- and 1-byte tails) and from the
+    // dangling pointer of an empty slice. `short` is its own exact-size
+    // allocation so that `cargo miri test -p bun_core` reports the over-read
+    // instead of comparing whatever follows the buffer.
+    fn for_each_strict_prefix(mut check: impl FnMut(&[u8], &[u8])) {
+        let bytes: Vec<u8> = (b'a'..=b'q').collect();
+        for long_len in 1..=bytes.len() {
+            let long = &bytes[..long_len];
+            for short_len in 0..long_len {
+                let short = long[..short_len].to_vec();
+                check(&short, long);
+            }
+        }
+    }
+
+    #[test]
+    fn eql_long_rejects_a_shorter_a_str_in_both_modes() {
+        for_each_strict_prefix(|short, long| {
+            assert!(!eql_long(short, long, false), "{short:?} vs {long:?}");
+            assert!(!eql_long(short, long, true), "{short:?} vs {long:?}");
+        });
+    }
+
+    #[test]
+    fn eql_long_without_check_len_compares_a_prefix_of_a_str() {
+        for_each_strict_prefix(|short, long| {
+            assert!(eql_long(long, short, false), "{long:?} vs {short:?}");
+            assert!(!eql_long(long, short, true), "{long:?} vs {short:?}");
+        });
+        let two_words = b"0123456789abcdef";
+        // A copy, so the compare cannot short-circuit on pointer equality.
+        let same_bytes = two_words.to_vec();
+        assert!(eql_long(&same_bytes, two_words, false));
+        assert!(eql_long(&same_bytes, two_words, true));
+        // A mismatch in the second word, then in the 4-, 2- and 1-byte tails.
+        assert!(!eql_long(two_words, b"0123456789abcdeX", false));
+        assert!(!eql_long(two_words, b"0123456789aX", false));
+        assert!(!eql_long(two_words, b"012345678X", false));
+        assert!(!eql_long(two_words, b"01234567X", false));
+    }
+
+    #[test]
+    fn eql_comptime_ignore_len_rejects_a_shorter_input() {
+        for_each_strict_prefix(|short, long| {
+            assert!(
+                !eql_comptime_ignore_len(short, long),
+                "{short:?} vs {long:?}"
+            );
+            assert!(
+                eql_comptime_ignore_len(long, short),
+                "{long:?} vs {short:?}"
+            );
+        });
+        assert!(eql_comptime_ignore_len(b"application", b"application"));
+        assert!(!eql_comptime_ignore_len(b"applicatioN", b"application"));
     }
 }

--- a/test/internal/eql-long.test.ts
+++ b/test/internal/eql-long.test.ts
@@ -1,0 +1,76 @@
+/**
+ * `bun_core::strings::eql_long(a, b, false)` and `eql_comptime_ignore_len`
+ * (src/bun_core/string/immutable.rs) compare `b.len()` bytes of `a`. The
+ * length test that keeps that inside `a` used to be a `debug_assert!`, which
+ * the shipped profile compiles out, so a caller passing a shorter `a` read
+ * past it in release builds; both now return false for a shorter `a`.
+ *
+ * Every in-tree caller matches the lengths before calling, so there is no JS
+ * input that reaches the over-read. The discriminator is the crate's own unit
+ * tests (`mod tests` in immutable.rs, which pass a shorter exact-size
+ * allocation to each helper) interpreted by Miri with debug assertions
+ * compiled out, as in the shipped profile: with a debug-only check the
+ * over-read is reported as undefined behavior, with the real check the tests
+ * pass. bun_core is not in `bun run rust:miri`'s crate set (its other tests
+ * call into libc and simdutf, which Miri cannot interpret), so the relevant
+ * tests are run by name here. Skipped where miri is not installed or the
+ * cargo workspace is not resolvable (test-only lanes run a prebuilt binary
+ * and lack vendor/lolhtml), the same prerequisites as linear-fifo.test.ts.
+ */
+import { expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+const cargoBin = Bun.which("cargo");
+const repoRoot = path.resolve(import.meta.dir, "..", "..");
+const workspaceResolvable =
+  existsSync(path.join(repoRoot, "vendor", "lolhtml", "Cargo.toml")) &&
+  existsSync(path.join(repoRoot, "build", "debug", "codegen", "build_options.rs"));
+const miriAvailable =
+  !!cargoBin &&
+  workspaceResolvable &&
+  Bun.spawnSync({
+    cmd: [cargoBin, "miri", "--version"],
+    cwd: repoRoot,
+    stdout: "ignore",
+    stderr: "ignore",
+    timeout: 30_000,
+  }).exitCode === 0;
+
+const unitTests = [
+  "string::immutable::tests::eql_long_rejects_a_shorter_a_str_in_both_modes",
+  "string::immutable::tests::eql_long_without_check_len_compares_a_prefix_of_a_str",
+  "string::immutable::tests::eql_comptime_ignore_len_rejects_a_shorter_input",
+];
+
+test.skipIf(!miriAvailable)(
+  "eql_long and eql_comptime_ignore_len stay in bounds for a shorter input with debug assertions compiled out",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [cargoBin!, "miri", "test", "--locked", "--lib", "-p", "bun_core", "--", ...unitTests],
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        // Same aliasing model as `bun run rust:miri` (scripts/rust-miri.ts).
+        MIRIFLAGS: "-Zmiri-tree-borrows",
+        // The `test` profile inherits `dev`, which has debug assertions on; a
+        // precondition that is only debug_assert!ed would fail the unit test
+        // as a panic instead of as the release-build over-read under test.
+        CARGO_PROFILE_TEST_DEBUG_ASSERTIONS: "false",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    if (exitCode !== 0) {
+      // Surface miri's diagnostic so the failing read shows up in the log.
+      console.error(stderr || stdout);
+    }
+    expect(stderr).not.toContain("Undefined Behavior");
+    // Each test has to have run and passed: a renamed or stashed test filters
+    // down to "running 0 tests", which also exits 0.
+    expect(unitTests.filter(name => stdout.includes(`test ${name} ... ok`))).toEqual(unitTests);
+    expect(exitCode).toBe(0);
+  },
+  180_000,
+);


### PR DESCRIPTION
### Problem
- `strings::eql_long(a, b, false)` (`src/bun_core/string/immutable.rs`) walks `b.len()` bytes of `a` with raw word reads. The only thing keeping that walk inside `a` was `debug_assert!(b_str.len() <= a_str.len())`, and `[profile.release]` leaves debug assertions off (`scripts/build/rust.ts` turns them on only for debug, asan and assertions builds), so in shipped builds a caller passing a shorter `a` reads past it. The SAFETY comment said "debug-asserted otherwise", which is not a soundness argument for a safe `pub fn`.
- `eql_comptime_check_len_u8(a, b, false)`, reachable through the safe `pub fn eql_comptime_ignore_len`, had the same shape: `debug_assert!(a.len() >= b.len())` followed by `a.get_unchecked(..b.len())`.
- No caller currently violates either contract (the seven `eql_long(.., false)` sites and every `eql_comptime_ignore_len` caller slice or compare the lengths first), so this fixes the API shape, not a known crash: a future caller that gets a length wrong becomes an out-of-bounds read that only a debug build notices.
- Under Miri with debug assertions compiled out, the new unit tests report the old code as:
  ```
  Undefined Behavior: memory access failed: attempting to access 8 bytes, but got alloc69095 which is only 7 bytes from the end of the allocation
      --> src/bun_core/string/immutable.rs:1264
          if a.cast::<usize>().read_unaligned() != b.cast::<usize>().read_unaligned() {
  ```
  and, for `eql_comptime_ignore_len`, `constructing invalid value of type &[u8]: encountered a dangling reference` at the `get_unchecked`.

### Fix
- `eql_long`'s `check_len == false` arm returns `false` when `a_str.len() < b_str.len()`; the SAFETY comment now rests on that compare. `eql_comptime_check_len_u8`'s unchecked arm becomes `a.starts_with(b)`, which is the same compare plus the slice equality it already did, and the `unsafe` block is gone. Both functions get a doc comment stating what the length-agnostic mode means (a prefix compare; a shorter haystack is unequal).
- Returning `false` rather than asserting: a shorter `a` cannot start with `b`, so `false` is the correct answer, and it is the shape `eql_case_insensitive_ascii`'s `check_len == false` arm (which `eql_long`'s comment says it mirrors) already has. An `unsafe fn` split was the alternative; every existing caller would have had to carry a SAFETY comment for a check that costs one compare.
- Cost: none at the callers that exist. Both functions inline, and every current caller has already sliced to `b.len()` (`starts_with`, `has_prefix_comptime`, the rope compare in `ast/e.rs`) or compared the lengths (`eql`, `resolve_path`, `RuntimeTranspilerStore`, the two `eql_comptime` methods in `string/mod.rs`, `MimeType::init`, `BOM::detect`), so LLVM folds the new compare: compiling the `eql` / `starts_with` / `has_prefix_comptime` / length-guarded shapes with the old and new bodies side by side, LLVM emits identical code and merges the old and new versions into aliases (`eql_old = eql_new`, asm in the details below). `SSLContextCache` compares two `[u8; 32]`, also constant-folded.
- Intentionally unchanged: `eql_comptime_check_len_u8`'s old comment claimed the unchecked index avoided a bounds check on the lexer path; the lexer reaches it through `has_prefix_comptime` / `eql_comptime`, whose slicing already makes the length provable, which is what the asm comparison shows. No caller was changed.
- Tests:
  - `src/bun_core/string/immutable.rs` (`mod tests`): for every strict prefix of every length up to two 8-byte words, each helper returns `false` for the shorter slice and `true` with the arguments swapped, plus equal and mismatching inputs that land on the word loop and on each tail. The shorter slice is its own exact-size allocation so Miri sees the over-read.
  - `test/internal/eql-long.test.ts` runs those three tests with `cargo miri test -p bun_core`, with `CARGO_PROFILE_TEST_DEBUG_ASSERTIONS=false` so a debug-only check does not turn the over-read into a panic, and asserts each test ran and passed. With the new unit tests but the old bodies it fails with the Miri reports quoted above; with main's `src/` it fails because the tests are absent; with this change it passes (`bun bd test test/internal/eql-long.test.ts`, about 8s warm). It skips where miri or the cargo workspace is unavailable, like `linear-fifo.test.ts`; `bun_core` cannot join `bun run rust:miri`'s crate set as is because its other tests call `strncasecmp` and simdutf, which is why the tests are run by name.
  - Also run: `cargo fmt --check -p bun_core`, `cargo clippy -p bun_core --lib --tests` (clean apart from two pre-existing findings in `atomic_cell.rs`'s tests), `bun bd test` on `web/fetch/blob`, `bun/resolve/import-meta`, `bun/jsonc/jsonc`, `bundler/transpiler/bun-pragma` (160 pass), and the Rust source lints under `test/internal/source-lints/`.

### Background
- `eql_long(a, b, check_len)` is `bun_core`'s byte-slice equality. `check_len == true` is plain equality; `check_len == false` exists for callers that have already compared the lengths (`eql`, `starts_with`) and only compares the first `b.len()` bytes of `a`, using 8/4/2/1-byte unaligned loads instead of a `memcmp` call. `eql_comptime_ignore_len` is the equivalent for comparisons against a literal, compiled to fixed-size compares.
- `debug_assert!` compiles to nothing unless the `debug-assertions` profile setting is on. In this workspace that is the `dev` profile (debug builds) and the release-asan / release-assertions configurations; the binaries that ship are built with it off.
- Miri interprets a crate's tests and reports any read outside an allocation as undefined behavior at the offending line, which is how an over-read that a normal run would turn into a garbage `bool` becomes a deterministic test failure. `cargo test`'s `test` profile inherits `dev` and so has debug assertions on; `CARGO_PROFILE_TEST_DEBUG_ASSERTIONS=false` overrides that for one invocation so the helpers are interpreted in the configuration the bug is about.

<details>
<summary>Codegen comparison (rustc -O, x86-64): old vs new bodies at the caller shapes in the tree</summary>

`has_prefix_comptime` shape (caller slices to the literal's length), old `get_unchecked` body vs new `starts_with` body; the length-guarded `String::eql_comptime` / `MimeType` shape is the same story:

```
has_prefix_old:                      has_prefix_new:
    cmpq    $7, %rsi                     cmpq    $7, %rsi
    jbe     .LBB2_1                      jbe     .LBB1_1
    movabsq $7957695015192261990, %rax   movabsq $7957695015192261990, %rax
    cmpq    %rax, (%rdi)                 cmpq    %rax, (%rdi)
    sete    %al                          sete    %al
    retq                                 retq
```

`eql` and `starts_with` shapes with the old (debug-assert) and new (`a.len() < b.len()` return) prologues: LLVM's function merging folds them into the same code.

```
eql_old = eql_new
starts_with_old = starts_with_new
```
</details>

<details>
<summary>Miri output for the old bodies with the new unit tests</summary>

```
$ CARGO_PROFILE_TEST_DEBUG_ASSERTIONS=false MIRIFLAGS=-Zmiri-tree-borrows cargo miri test --locked --lib -p bun_core -- eql_long_rejects
test string::immutable::tests::eql_long_rejects_a_shorter_a_str_in_both_modes ... error: Undefined Behavior: memory access failed: attempting to access 1 byte, but got 0x1[noalloc] which is a dangling pointer (it has no provenance)
    --> src/bun_core/string/immutable.rs:1300:30
     |
1300 |         if (len & 1) != 0 && *a != *b {

(with the loop started at a 7-byte prefix instead of the empty one:)
error: Undefined Behavior: memory access failed: attempting to access 8 bytes, but got alloc69095 which is only 7 bytes from the end of the allocation
    --> src/bun_core/string/immutable.rs:1264:20
     |
1264 |                 if a.cast::<usize>().read_unaligned() != b.cast::<usize>().read_unaligned() {

$ ... -- eql_comptime_ignore_len
test string::immutable::tests::eql_comptime_ignore_len_rejects_a_shorter_input ... error: Undefined Behavior: constructing invalid value of type &[u8]: encountered a dangling reference (0x1[noalloc] has no provenance)
    --> src/bun_core/string/immutable.rs:1137:14
     |
1137 |     unsafe { a.get_unchecked(..b.len()) == b }
```

With debug assertions left on, the same tests fail on the old code at the `debug_assert!` instead. With this change both configurations pass:

```
test string::immutable::tests::eql_comptime_ignore_len_rejects_a_shorter_input ... ok
test string::immutable::tests::eql_long_rejects_a_shorter_a_str_in_both_modes ... ok
test string::immutable::tests::eql_long_without_check_len_compares_a_prefix_of_a_str ... ok
```
</details>
