### PR TITLE
test: build the fs.watch inotify overflow tree on tmpfs and tighten the watch assertions

### DIFF
--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -249,7 +249,7 @@ describe("fs.watch", () => {
     const interval = repeat(() => {
       fs.writeFileSync(filepath, "world");
     });
-  }, 10000);
+  });
 
   test("should error on invalid path", done => {
     try {
@@ -335,7 +335,7 @@ describe("fs.watch", () => {
       clearInterval(interval);
       watchers.forEach(watcher => watcher.close());
     }
-  }, 10000);
+  });
 
   test("should work with url", done => {
     const filepath = path.join(testDir, "url.txt");
@@ -503,30 +503,18 @@ describe("fs.watch", () => {
     const filepath = path.join(testDir, "sym-symlink2.txt");
     await fs.promises.symlink(path.join(testDir, "sym-sync.txt"), filepath);
 
+    const { promise, resolve, reject } = Promise.withResolvers<string>();
+    const watcher = fs.watch(filepath, eventType => resolve(eventType));
+    watcher.once("error", reject);
     const interval = repeat(() => {
       fs.writeFileSync(filepath, "hello");
     });
-
-    const promise = new Promise((resolve, reject) => {
-      let timeout: any = null;
-      const watcher = fs.watch(filepath, event => {
-        clearTimeout(timeout);
-        clearInterval(interval);
-        try {
-          resolve(event);
-        } catch (e: any) {
-          reject(e);
-        } finally {
-          watcher.close();
-        }
-      });
-      setTimeout(() => {
-        clearInterval(interval);
-        watcher?.close();
-        reject("timeout");
-      }, 3000);
-    });
-    expect(promise).resolves.toBe("change");
+    try {
+      expect(await promise).toBe("change");
+    } finally {
+      clearInterval(interval);
+      watcher.close();
+    }
   });
 
   // on windows 0o200 will be readable (match nodejs behavior)
@@ -629,9 +617,14 @@ describe("fs.watch", () => {
     }
   };
   const maxQueuedEvents = isLinux ? inotifySysctl("max_queued_events") : 0;
-  // Enough directories that unregistering one watch per directory overflows
-  // the queue even if the reader thread drains a full 64KB read (4096 events).
-  const overflowDirCount = maxQueuedEvents + 6144;
+  // Closing a recursive watcher unregisters one watch per directory while
+  // holding the manager mutex, and every unregister queues a 16-byte
+  // IN_IGNORED. The reader thread (thread_main in path_watcher.rs) gets at most
+  // one 64KB read() in before it blocks on that mutex, so every later removal
+  // stays queued; once max_queued_events of them are, the next one is dropped
+  // and replaced by IN_Q_OVERFLOW. The rest is margin.
+  const readerDrainEvents = (64 * 1024) / 16;
+  const overflowDirCount = maxQueuedEvents + readerDrainEvents + 512;
   // 16384 is the kernel default; a host tuned above that would need an
   // impractically large directory tree, so skip there.
   const canOverflowInotify =
@@ -640,57 +633,103 @@ describe("fs.watch", () => {
     maxQueuedEvents <= 16384 &&
     inotifySysctl("max_user_watches") >= overflowDirCount + 1024;
 
-  // The directory count is fixed by the kernel (the overflow needs more watch
-  // removals than max_queued_events=16384 plus one 64KB read the reader may
-  // drain), so setup is ~22k syscalls: well past the 5s default under ASAN.
+  // include/uapi/linux/magic.h
+  const TMPFS_MAGIC = 0x01021994;
+  // mkdir + inotify_add_watch + rmdir on ~21k directories takes ~0.3s on tmpfs,
+  // but 10s+ on overlayfs and ~30s on the alpine CI lanes' root filesystem, so
+  // the tree goes on a tmpfs mount when there is one: the test's own tmpdir if
+  // that already is one, else /dev/shm, else the tmpdir anyway.
+  function makeOverflowTree(tmpdir: string): string {
+    let treeDir: string | undefined;
+    for (const base of [tmpdir, "/dev/shm"]) {
+      try {
+        const { type, files, ffree } = fs.statfsSync(base);
+        // files === 0 is a tmpfs mounted without an inode limit.
+        if (type !== TMPFS_MAGIC || (files !== 0 && ffree < overflowDirCount + 1024)) continue;
+        treeDir = fs.mkdtempSync(path.join(base, "fs-watch-overflow-"));
+        break;
+      } catch {}
+    }
+    treeDir ??= fs.mkdtempSync(path.join(tmpdir, "tree-"));
+    // One recursive mkdirSync per chain of `depth` nested directories: a flat
+    // loop is one native call per directory, which dominates in debug builds.
+    const depth = 16;
+    const chain = Array(depth - 1).fill("d");
+    for (let i = 0; i * depth < overflowDirCount; i++) {
+      fs.mkdirSync(path.join(treeDir, "c" + i, ...chain), { recursive: true });
+    }
+    return treeDir;
+  }
+
+  // The timeout is for the non-tmpfs fallback, which takes tens of seconds
+  // under ASAN; on tmpfs the test takes ~0.5s (~3s under ASAN).
   test.skipIf(!canOverflowInotify)(
     "inotify queue overflow is delivered as ('change', null)",
     async () => {
       using dir = tempDir("fs-watch-overflow", { "observed": {} });
-      const root = String(dir);
-      const observedDir = path.join(root, "observed");
-      const treeDir = path.join(root, "tree");
-      fs.mkdirSync(treeDir);
-      for (let i = 0; i < overflowDirCount; i++) fs.mkdirSync(path.join(treeDir, "d" + i));
+      const observedDir = path.join(String(dir), "observed");
+      const treeDir = makeOverflowTree(String(dir));
 
-      const overflow = Promise.withResolvers<[string, string | null]>();
-      const bufferOverflow = Promise.withResolvers<[string, Buffer | null]>();
-      const survived = Promise.withResolvers<[string, string | null]>();
-      // An error or unexpected close on either watcher must reject every pending
-      // promise so the test reports the failure instead of hanging to the
-      // timeout. The no-op catch keeps the not-yet-awaited ones handled.
-      const pending = [overflow, bufferOverflow, survived];
-      for (const p of pending) p.promise.catch(() => {});
-      const fail = (err: unknown) => pending.forEach(p => p.reject(err));
-      const watcher = fs.watch(observedDir, (eventType, filename) => {
-        if (filename === null) overflow.resolve([eventType, filename]);
-        else if (filename === "f.txt") survived.resolve([eventType, filename]);
-      });
-      // The overflow event carries no name to encode, so every encoding gets null.
-      const bufferWatcher = fs.watch(observedDir, { encoding: "buffer" }, (eventType, filename) => {
-        if (filename === null) bufferOverflow.resolve([eventType, filename]);
-      });
+      // Every event both watchers deliver, so the final toEqual also proves the
+      // tree's IN_IGNORED storm stays invisible to watchers of other paths. The
+      // overflow event carries no name to encode, so every encoding gets null.
+      const seen: { utf8: [string, string | null][]; buffer: [string, Buffer | null][] } = { utf8: [], buffer: [] };
+      let failure: unknown;
+      let progressed = () => {};
+      const watchers = [
+        fs.watch(observedDir, (eventType, filename) => {
+          seen.utf8.push([eventType, filename]);
+          progressed();
+        }),
+        fs.watch(observedDir, { encoding: "buffer" }, (eventType, filename) => {
+          seen.buffer.push([eventType, filename]);
+          progressed();
+        }),
+      ];
+      // An error or unexpected close on either watcher fails the pending wait
+      // so the test reports it instead of hanging to the timeout.
+      const fail = (err: unknown) => {
+        failure = err;
+        progressed();
+      };
       let closing = false;
-      for (const w of [watcher, bufferWatcher]) {
+      for (const w of watchers) {
         w.once("error", fail);
         w.once("close", () => {
           if (!closing) fail(new Error("watcher closed unexpectedly"));
         });
       }
+      const bothDelivered = (count: number) =>
+        new Promise<void>((resolve, reject) => {
+          progressed = () => {
+            if (failure !== undefined) reject(failure);
+            else if (seen.utf8.length >= count && seen.buffer.length >= count) resolve();
+          };
+          progressed();
+        });
       try {
-        // Closing the recursive watcher unregisters one inotify watch per
-        // directory in a single critical section; each unregister queues an
-        // IN_IGNORED the blocked reader can't drain, overflowing the queue.
+        // This close() is what overflows the queue; see overflowDirCount.
         fs.watch(treeDir, { recursive: true }, () => {}).close();
-        expect(await overflow.promise).toEqual(["change", null]);
-        expect(await bufferOverflow.promise).toEqual(["change", null]);
-        // Overflow signals lost events; the watcher itself must keep working.
-        fs.writeFileSync(path.join(observedDir, "f.txt"), "x");
-        expect(await survived.promise).toEqual(["rename", "f.txt"]);
+        await bothDelivered(1);
+        // Overflow means events were lost, not that the watchers stopped working.
+        // By the time it reached JS the reader had drained the queue, so this
+        // mkdir (exactly one IN_CREATE) must come through.
+        fs.mkdirSync(path.join(observedDir, "after"));
+        await bothDelivered(2);
+        expect(seen).toEqual({
+          utf8: [
+            ["change", null],
+            ["rename", "after"],
+          ],
+          buffer: [
+            ["change", null],
+            ["rename", Buffer.from("after")],
+          ],
+        });
       } finally {
         closing = true;
-        watcher.close();
-        bufferWatcher.close();
+        for (const w of watchers) w.close();
+        fs.rmSync(treeDir, { recursive: true, force: true });
       }
     },
     90_000,
@@ -777,14 +816,12 @@ describe("fs.watch", () => {
         });
         const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
         expect(stderr).toBe("");
-        const result = JSON.parse(stdout.trim());
-        expect(result.errorEvent).not.toBeNull();
         // internal/fs/watch.ts rewrites EACCES to EPERM for watchpack compat.
-        expect(result.errorEvent.code).toBe("EPERM");
-        expect(result.errorEvent.syscall).toBe("watch");
-        expect(result.errorEvent.path).toContain("locked");
-        expect(result.closed).toBe(false);
-        expect(result.openDelivered).toBe(true);
+        expect(JSON.parse(stdout.trim())).toEqual({
+          errorEvent: { code: "EPERM", syscall: "watch", path: path.join(root, "locked") },
+          closed: false,
+          openDelivered: true,
+        });
         expect(exitCode).toBe(0);
 
         // fs.promises.watch wraps the native watcher in an async iterator with
@@ -985,6 +1022,19 @@ describe("fs.promises.watch", () => {
     expect(exitCode).toBe(0);
   });
 
+  // Repeats `touch` until the watcher yields; returning out of the for-await
+  // closes it.
+  async function firstEvent(target: string, touch: () => void): Promise<[string, string | null]> {
+    const watcher = fs.promises.watch(target);
+    const interval = repeat(touch);
+    try {
+      for await (const event of watcher) return [event.eventType, event.filename];
+    } finally {
+      clearInterval(interval);
+    }
+    throw new Error("watcher ended without an event");
+  }
+
   test("should work with symlink -> symlink -> dir", async () => {
     const filepath = path.join(testDir, "sym-symlink-indirect");
     const dest = path.join(testDir, "sym-symlink-dest");
@@ -996,23 +1046,8 @@ describe("fs.promises.watch", () => {
     const indirect_sym = path.join(testDir, "sym-symlink-to-symlink-dir");
     await fs.promises.symlink(filepath, indirect_sym);
 
-    const watcher = fs.promises.watch(indirect_sym);
-    const interval = setInterval(() => {
-      fs.writeFileSync(path.join(indirect_sym, "hello.txt"), "hello");
-    }, 10);
-
-    const promise = (async () => {
-      try {
-        for await (const event of watcher) {
-          return event.eventType;
-        }
-      } catch {
-        expect.unreachable();
-      } finally {
-        clearInterval(interval);
-      }
-    })();
-    expect(promise).resolves.toBe("rename");
+    const touch = () => fs.writeFileSync(path.join(indirect_sym, "hello.txt"), "hello");
+    expect(await firstEvent(indirect_sym, touch)).toEqual(["rename", "hello.txt"]);
   });
 
   test("should work with symlink dir", async () => {
@@ -1024,46 +1059,17 @@ describe("fs.promises.watch", () => {
     fs.mkdirSync(dest, { recursive: true });
     await fs.promises.symlink(dest, filepath);
 
-    const watcher = fs.promises.watch(filepath);
-    const interval = setInterval(() => {
-      fs.writeFileSync(path.join(filepath, "hello.txt"), "hello");
-    }, 10);
-
-    const promise = (async () => {
-      try {
-        for await (const event of watcher) {
-          return event.eventType;
-        }
-      } catch {
-        expect.unreachable();
-      } finally {
-        clearInterval(interval);
-      }
-    })();
-    expect(promise).resolves.toBe("rename");
+    const touch = () => fs.writeFileSync(path.join(filepath, "hello.txt"), "hello");
+    expect(await firstEvent(filepath, touch)).toEqual(["rename", "hello.txt"]);
   });
 
   test("should work with symlink", async () => {
     const filepath = path.join(testDir, "sym-symlink.txt");
     await fs.promises.symlink(path.join(testDir, "sym.txt"), filepath);
 
-    const watcher = fs.promises.watch(filepath);
-    const interval = repeat(() => {
-      fs.writeFileSync(filepath, "hello");
-    });
-
-    const promise = (async () => {
-      try {
-        for await (const event of watcher) {
-          return event.eventType;
-        }
-      } catch (e: any) {
-        expect.unreachable();
-      } finally {
-        clearInterval(interval);
-      }
-    })();
-    expect(promise).resolves.toBe("change");
+    // Which name a file watch reports through a symlink is backend-specific.
+    const [eventType] = await firstEvent(filepath, () => fs.writeFileSync(filepath, "hello"));
+    expect(eventType).toBe("change");
   });
 
   test("yields events with a null prototype", async () => {
@@ -1120,7 +1126,7 @@ describe("immediately closing", () => {
 // per watcher. Persistent watchers only landed at 0 by accident (start=2, -2).
 describe("closed FSWatcher is collectable", () => {
   for (const persistent of [false, true]) {
-    test(`persistent: ${persistent}`, async () => {
+    test.concurrent(`persistent: ${persistent}`, async () => {
       using dir = tempDir("fswatch-gc", { "f.txt": "x" });
       const watchDir = String(dir);
 
@@ -1406,8 +1412,8 @@ test.skipIf(!isMacOS)("fs.watch(dir) on macOS does not leak the resolved FSEvent
 
   // stderr first so a leak regression surfaces the thrown growth message.
   expect(stderr).toBe("");
-  expect(exitCode).toBe(0);
   expect(stdout).toContain("RSS growth:");
+  expect(exitCode).toBe(0);
 });
 
 // On Windows, fs.watch() registered every watcher into a single process-global

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -622,16 +622,19 @@ describe("fs.watch", () => {
   // IN_IGNORED. The reader thread (thread_main in path_watcher.rs) gets at most
   // one 64KB read() in before it blocks on that mutex, so every later removal
   // stays queued; once max_queued_events of them are, the next one is dropped
-  // and replaced by IN_Q_OVERFLOW. The rest is margin.
+  // and replaced by IN_Q_OVERFLOW.
   const readerDrainEvents = (64 * 1024) / 16;
-  const overflowDirCount = maxQueuedEvents + readerDrainEvents + 512;
+  const overflowMargin = 512;
+  const overflowDirCount = maxQueuedEvents + readerDrainEvents + overflowMargin;
+  // Watches (and tmpfs inodes, below) the rest of this user's processes may hold.
+  const headroom = 1024;
   // 16384 is the kernel default; a host tuned above that would need an
   // impractically large directory tree, so skip there.
   const canOverflowInotify =
     isLinux &&
     maxQueuedEvents > 0 &&
     maxQueuedEvents <= 16384 &&
-    inotifySysctl("max_user_watches") >= overflowDirCount + 1024;
+    inotifySysctl("max_user_watches") >= overflowDirCount + headroom;
 
   // include/uapi/linux/magic.h
   const TMPFS_MAGIC = 0x01021994;
@@ -645,7 +648,7 @@ describe("fs.watch", () => {
       try {
         const { type, files, ffree } = fs.statfsSync(base);
         // files === 0 is a tmpfs mounted without an inode limit.
-        if (type !== TMPFS_MAGIC || (files !== 0 && ffree < overflowDirCount + 1024)) continue;
+        if (type !== TMPFS_MAGIC || (files !== 0 && ffree < overflowDirCount + headroom)) continue;
         onTmpfs = fs.mkdtempSync(path.join(base, "fs-watch-overflow-"));
         break;
       } catch {}

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -639,26 +639,32 @@ describe("fs.watch", () => {
   // but 10s+ on overlayfs and ~30s on the alpine CI lanes' root filesystem, so
   // the tree goes on a tmpfs mount when there is one: the test's own tmpdir if
   // that already is one, else /dev/shm, else the tmpdir anyway.
-  function makeOverflowTree(tmpdir: string): string {
-    let treeDir: string | undefined;
+  function makeOverflowTree(tmpdir: string): { path: string } & Disposable {
+    let onTmpfs: string | undefined;
     for (const base of [tmpdir, "/dev/shm"]) {
       try {
         const { type, files, ffree } = fs.statfsSync(base);
         // files === 0 is a tmpfs mounted without an inode limit.
         if (type !== TMPFS_MAGIC || (files !== 0 && ffree < overflowDirCount + 1024)) continue;
-        treeDir = fs.mkdtempSync(path.join(base, "fs-watch-overflow-"));
+        onTmpfs = fs.mkdtempSync(path.join(base, "fs-watch-overflow-"));
         break;
       } catch {}
     }
-    treeDir ??= fs.mkdtempSync(path.join(tmpdir, "tree-"));
-    // One recursive mkdirSync per chain of `depth` nested directories: a flat
-    // loop is one native call per directory, which dominates in debug builds.
-    const depth = 16;
-    const chain = Array(depth - 1).fill("d");
-    for (let i = 0; i * depth < overflowDirCount; i++) {
-      fs.mkdirSync(path.join(treeDir, "c" + i, ...chain), { recursive: true });
+    const treeDir = onTmpfs ?? fs.mkdtempSync(path.join(tmpdir, "tree-"));
+    const tree = { path: treeDir, [Symbol.dispose]: () => fs.rmSync(treeDir, { recursive: true, force: true }) };
+    try {
+      // One recursive mkdirSync per chain of `depth` nested directories: a flat
+      // loop is one native call per directory, which dominates in debug builds.
+      const depth = 16;
+      const chain = Array(depth - 1).fill("d");
+      for (let i = 0; i * depth < overflowDirCount; i++) {
+        fs.mkdirSync(path.join(treeDir, "c" + i, ...chain), { recursive: true });
+      }
+    } catch (err) {
+      tree[Symbol.dispose]();
+      throw err;
     }
-    return treeDir;
+    return tree;
   }
 
   // The timeout is for the non-tmpfs fallback, which takes tens of seconds
@@ -668,7 +674,7 @@ describe("fs.watch", () => {
     async () => {
       using dir = tempDir("fs-watch-overflow", { "observed": {} });
       const observedDir = path.join(String(dir), "observed");
-      const treeDir = makeOverflowTree(String(dir));
+      using tree = makeOverflowTree(String(dir));
 
       // Every event both watchers deliver, so the final toEqual also proves the
       // tree's IN_IGNORED storm stays invisible to watchers of other paths. The
@@ -709,7 +715,7 @@ describe("fs.watch", () => {
         });
       try {
         // This close() is what overflows the queue; see overflowDirCount.
-        fs.watch(treeDir, { recursive: true }, () => {}).close();
+        fs.watch(tree.path, { recursive: true }, () => {}).close();
         await bothDelivered(1);
         // Overflow means events were lost, not that the watchers stopped working.
         // By the time it reached JS the reader had drained the queue, so this
@@ -729,7 +735,6 @@ describe("fs.watch", () => {
       } finally {
         closing = true;
         for (const w of watchers) w.close();
-        fs.rmSync(treeDir, { recursive: true, force: true });
       }
     },
     90_000,
@@ -1034,6 +1039,12 @@ describe("fs.promises.watch", () => {
     }
     throw new Error("watcher ended without an event");
   }
+  // Re-creating the file on every tick instead of overwriting it keeps the
+  // first delivered event a rename even if the watcher only arms after tick 1.
+  const recreate = (file: string) => () => {
+    fs.rmSync(file, { force: true });
+    fs.writeFileSync(file, "hello");
+  };
 
   test("should work with symlink -> symlink -> dir", async () => {
     const filepath = path.join(testDir, "sym-symlink-indirect");
@@ -1046,7 +1057,7 @@ describe("fs.promises.watch", () => {
     const indirect_sym = path.join(testDir, "sym-symlink-to-symlink-dir");
     await fs.promises.symlink(filepath, indirect_sym);
 
-    const touch = () => fs.writeFileSync(path.join(indirect_sym, "hello.txt"), "hello");
+    const touch = recreate(path.join(indirect_sym, "hello.txt"));
     expect(await firstEvent(indirect_sym, touch)).toEqual(["rename", "hello.txt"]);
   });
 
@@ -1059,7 +1070,7 @@ describe("fs.promises.watch", () => {
     fs.mkdirSync(dest, { recursive: true });
     await fs.promises.symlink(dest, filepath);
 
-    const touch = () => fs.writeFileSync(path.join(filepath, "hello.txt"), "hello");
+    const touch = recreate(path.join(filepath, "hello.txt"));
     expect(await firstEvent(filepath, touch)).toEqual(["rename", "hello.txt"]);
   });
 


### PR DESCRIPTION
### Problem
- `test/js/node/watch/fs.watch.test.ts` takes ~30s on the alpine CI lanes (29957ms median in `test/expected-durations.json`, 32.6s in build 97275) and 1.6s on debian. Both lanes report 45 pass / 5 skip, so they run the same tests.
- The whole gap is `inotify queue overflow is delivered as ('change', null)`. It creates `max_queued_events + 6144` = 22528 directories in the tmpdir, registers a recursive watch over them, closes it and removes them. The overflow itself takes ~3ms; the rest is mkdir + inotify_add_watch + rmdir on 22k directories, whose cost is the filesystem's per-operation cost: ~6us on tmpfs, 200-400us on overlayfs here (release bun). Both lanes keep `/tmp` on the root volume (the job logs print `df`); alpine's root filesystem is the slow one.
- Baseline per test on this container (`bun bd test`, debug + ASAN, `/tmp` on overlayfs; `fs.inotify.max_queued_events=16384`, `max_user_watches=1048576`, `max_user_instances=8192`, so the overflow test ran): overflow test 44591ms, `wrapper reference survives GC` 3245ms, `recursive watch surfaces inotify_add_watch failure` 2894ms, `closed FSWatcher is collectable` 1731ms + 1367ms, the other subprocess tests 1.0-1.6s each, everything else under 200ms; file 69.3s. Release (`USE_SYSTEM_BUN=1`): overflow test 11.5s, every other test under 95ms, file 13.5s.
- The 3-4s deadlines in the subtree-error and Windows overflow fixtures are only reached on the failure path, so they cost nothing in a passing run and are left alone.

### Fix
- The overflow tree is built on tmpfs when there is one: the test's own tmpdir if that is already tmpfs, else `/dev/shm` (`statfsSync` type is `TMPFS_MAGIC` and it has enough free inodes), else the tmpdir as before. Both linux CI lanes mount `/dev/shm` (8GB on alpine, 4GB on debian per the job logs). The tree is removed in the test's `finally`.
- The directory count is derived: `max_queued_events + 4096 + 512`. 4096 is the one 64KB read of 16-byte `IN_IGNORED` events the reader thread can drain before it blocks on the mutex `close()` holds for the whole removal loop; after `max_queued_events` more removals are queued, the next one becomes `IN_Q_OVERFLOW`; 512 is margin (the old +6144 was 4096 plus 2048 of margin). With the count forced to 4096 the test fails by timing out waiting for the overflow, so the overflow is still what it checks.
- The tree is created as chains of 16 nested directories, one recursive `mkdirSync` per chain: the 21k-call flat loop cost 2.9s of the debug build's time on tmpfs, the chains 0.55s. The number of directories, and so of inotify watches, is the same.
- The 90s timeout stays for the non-tmpfs fallback, which still takes tens of seconds under ASAN (the fallback passes: 9.2s in release with the candidate list pointed at a nonexistent path). The two `10000` timeouts on tests that take 20-260ms are dropped; the `30_000` on the GC test stays (3.2s under ASAN).
- After, same machine and sysctls, overflow test confirmed running: debug + ASAN 2956ms for the test and 31.2s for the file (back-to-back before: 46320ms / 73.5s); release 0.41-0.47s and 1.8s (before: 10.5-11.9s / 11.7-13.1s).
- Assertions:
  - The overflow test records every event both watchers deliver and compares the full sequences in one `toEqual` (`[["change", null], ["rename", "after"]]`, Buffer name for the buffer watcher). The old per-event promises could not notice an extra or duplicate event, such as the tree's `IN_IGNORED` storm reaching unrelated watchers. The post-overflow event is a `mkdirSync` in the observed directory, exactly one `IN_CREATE`, so the list is exact (`writeFileSync` emits a create plus a modify).
  - The subtree-error test compares the whole fixture result in one `toEqual`, with the exact error path instead of `toContain("locked")`.
  - The four symlink tests did not await anything: `expect(promise).resolves` was not awaited, the 3s timer was never cleared because its handle was never stored, and the promise variants hid the real error behind `expect.unreachable()` in a `catch`. They now await the event, the two directory cases also assert the filename, and errors propagate. The three promise tests share a `firstEvent` helper whose for-await return closes the watcher.
  - The macOS leak test asserts stdout before the exit code; the two `closed FSWatcher is collectable` subprocess tests (own tmpdir and subprocess each) run concurrently.
  - The expect() count goes from 108 to 101 because of the `toEqual` merges; nothing was removed.
- Left alone on purpose: the callback tests sharing the module-level `testDir` stay sequential, and `custom signal` / the abort tests are being rewritten in #32961. The open PRs that add tests to this file (#33396, #34718, #38360, #32961, #35878, #35873, #33642) all auto-merge cleanly on top of this branch (`git merge-tree`).

### Background
- inotify keeps one event queue per instance, capped at `fs.inotify.max_queued_events` (16384 by default). When it is full the kernel drops the new event and queues a single `IN_Q_OVERFLOW`; Bun reports that as `('change', null)` on every watcher sharing the instance. Bun has one instance per process, drained by one thread (`thread_main` in `src/runtime/node/path_watcher.rs`) that takes the watcher manager mutex to dispatch each 64KB batch it reads.
- `inotify_rm_watch` queues an `IN_IGNORED` for the removed watch. Closing a recursive watcher removes one watch per directory while holding that mutex, which is the only way a test can queue more than `max_queued_events` events while the reader cannot drain them. The test therefore needs that many real directories; only where they live and how they are created is negotiable.
- tmpfs is the in-memory filesystem behind `/dev/shm`. `statfs(2)` reports it as `f_type == TMPFS_MAGIC` (`0x01021994`) and reports `f_files == 0` when the mount has no inode limit. 21k empty directories on it are roughly 20MB of kernel memory for the duration of the test.
