### PR TITLE
cjs: export an own "constructor" property on the slow enumeration path too

### DIFF
--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -1068,10 +1068,6 @@ void populateESMExports(
                     if (property.isEmpty() || property.isNull() || property == esModuleMarker || property.isPrivateName() || property.isSymbol()) [[unlikely]]
                         continue;
 
-                    // ignore constructor
-                    if (property == vm.propertyNames->constructor)
-                        continue;
-
                     JSC::PropertySlot slot(exports, PropertySlot::InternalMethodType::Get);
                     auto has = exports->getPropertySlot(globalObject, property, slot);
                     RETURN_IF_EXCEPTION(scope, );
@@ -1124,10 +1120,6 @@ void populateESMExports(
 
             for (auto property : properties) {
                 if (property.isEmpty() || property.isNull() || property == vm.propertyNames->defaultKeyword || property.isPrivateName() || property.isSymbol()) [[unlikely]]
-                    continue;
-
-                // ignore constructor
-                if (property == vm.propertyNames->constructor)
                     continue;
 
                 JSC::PropertySlot slot(exports, PropertySlot::InternalMethodType::Get);

--- a/test/cli/run/esm-defineProperty.test.ts
+++ b/test/cli/run/esm-defineProperty.test.ts
@@ -1,4 +1,6 @@
 import { expect, test } from "bun:test";
+import { bunRun, tempDir } from "harness";
+import { join } from "path";
 import * as CJSArrayLike from "./cjs-defineProperty-arraylike.cjs";
 import * as CJS from "./cjs-defineProperty-fixture.cjs";
 import * as Self from "./esm-defineProperty.test.ts";
@@ -42,4 +44,69 @@ test("arraylike", () => {
     "4": [Getter],
   },
 }`);
+});
+
+// The namespace for a CommonJS module is built by walking module.exports. A plain object is walked
+// through its Structure ("fast"); an object with a getter is walked with getOwnPropertyNames
+// ("slow"). An own "constructor" property must come out the same either way.
+test.concurrent("an own 'constructor' export is exported on both enumeration paths", async () => {
+  const getter = `get g() { return 2; }`;
+  using dir = tempDir("cjs-constructor-export", {
+    "plain-fast.cjs": `module.exports = { a: 1, constructor: "K" };`,
+    "plain-slow.cjs": `module.exports = { a: 1, constructor: "K", ${getter} };`,
+    "esModule-fast.cjs": `module.exports = { __esModule: true, a: 1, constructor: "K" };`,
+    "esModule-slow.cjs": `module.exports = { __esModule: true, a: 1, constructor: "K", ${getter} };`,
+    // Foo.prototype.constructor is non-enumerable. Non-enumerable data properties are exported
+    // (see "defineProperty" above), so it is exported too, on both paths.
+    "prototype-fast.cjs": `
+      function Foo() {}
+      Foo.prototype.a = 1;
+      module.exports = Foo.prototype;
+    `,
+    "prototype-slow.cjs": `
+      function Foo() {}
+      Foo.prototype.a = 1;
+      Object.defineProperty(Foo.prototype, "g", { enumerable: true, get: () => 2 });
+      module.exports = Foo.prototype;
+    `,
+    "main.mjs": `
+      import * as plainFast from "./plain-fast.cjs";
+      import * as plainSlow from "./plain-slow.cjs";
+      import * as esModuleFast from "./esModule-fast.cjs";
+      import * as esModuleSlow from "./esModule-slow.cjs";
+      import * as prototypeFast from "./prototype-fast.cjs";
+      import * as prototypeSlow from "./prototype-slow.cjs";
+      for (const [name, ns] of Object.entries({ plainFast, plainSlow, esModuleFast, esModuleSlow, prototypeFast, prototypeSlow })) {
+        const value = typeof ns.constructor === "function" ? ns.constructor.name : JSON.stringify(ns.constructor);
+        console.log(name.padEnd(14), JSON.stringify(Object.keys(ns)).padEnd(36), "constructor:", value);
+      }
+    `,
+  });
+
+  const result = await bunRun(join(String(dir), "main.mjs"));
+  expect(result.stdout).toMatchInlineSnapshot(`
+    "plainFast      ["a","constructor","default"]        constructor: "K"
+    plainSlow      ["a","constructor","default","g"]    constructor: "K"
+    esModuleFast   ["a","constructor","default"]        constructor: "K"
+    esModuleSlow   ["a","constructor","default","g"]    constructor: "K"
+    prototypeFast  ["a","constructor","default"]        constructor: Foo
+    prototypeSlow  ["a","constructor","default","g"]    constructor: Foo"
+  `);
+  expect(result).toSpawn();
+});
+
+test.concurrent("named import of a 'constructor' export that was enumerated on the slow path", async () => {
+  using dir = tempDir("cjs-constructor-named-import", {
+    "exports.cjs": `
+      exports.constructor = "K";
+      Object.defineProperty(exports, "g", { enumerable: true, get: () => 2 });
+    `,
+    "main.mjs": `
+      import { constructor } from "./exports.cjs";
+      console.log(constructor);
+    `,
+  });
+
+  // Without the export this fails to link: "Export named 'constructor' not found".
+  expect(await bunRun(join(String(dir), "main.mjs"))).toSpawn("K");
 });


### PR DESCRIPTION
### Problem
- Importing a CommonJS module whose `module.exports` has an own `constructor` property yields a namespace that depends on the shape of the object: `module.exports = { a: 1, constructor: "K" }` exports `a, constructor, default`, but the same object with a getter added exports `a, default, g`. A named import then fails to link on that path only: `SyntaxError: Export named 'constructor' not found in module '/.../x.cjs'.`
- Cause: the two `getOwnPropertyNames` ("slow") branches of `populateESMExports` skip any property named `constructor` (`src/jsc/bindings/JSCommonJSModule.cpp:1071` and `:1129`). The two Structure ("fast") branches have no such check, and neither do the bundler's `__toESM` (`bun build` of the same files exports `constructor` in every case) or Node (`exports.constructor = "K"` next to a getter export gives `a, constructor, default` on Node 26; bun drops `constructor`).
- The check dates from the first native CommonJS loader (#3104), when both branches also excluded non-enumerable properties, and has no stated reason. Since #4432 the slow branches export non-enumerable data properties and drop only non-enumerable accessors, so this name check is the one thing that treats `constructor` differently from any other key.

### Fix
- Delete the name check in both slow branches. The attribute check that follows it now applies to `constructor` as to every other key: exported when it is a data property, dropped when it is a non-enumerable accessor.
- Why this is right: the export set becomes a function of the properties of `module.exports` rather than of which walk ran. The fast branches already export an own `constructor`, both the enumerable kind (`constructor:` in a literal, `exports.constructor = ...`) and the non-enumerable back-reference on `module.exports = Foo.prototype`, and `bun build` and Node agree with them.
- Blast radius: no builtin module's exports object has an own `constructor` property (checked by requiring every entry of `module.builtinModules`), so only user modules with such a property change, and for them the namespace gains a name it already had on the other path.
- Verified with `test/cli/run/esm-defineProperty.test.ts`: the new tests cover plain, `__esModule` and `Foo.prototype` exports objects on both paths plus a named import on the slow path. On the unfixed build the three slow-path rows lack `constructor` and the named import fails to link; both pass with this change.
- Also passing with the change: `test/js/bun/resolve/{esModule,require,star-export-namespace}.test.ts`, `esModule-annotation.test.js`, `test/js/bun/namespace-prototype-pollution.test.ts`, `test/cli/run/{run-cjs,commonjs-no-export,commonjs-invalid}.test.ts`, `test/js/bun/plugin/plugins.test.ts`, `test/js/bun/import-attributes/import-attributes.test.ts`.
- Related: #33888 adds further filters at the same two spots, so whichever of the two lands second needs a small rebase. The `__esModule` slow branch also enumerates with `DontEnumPropertiesMode::Exclude` while its fast branch exports non-enumerable data properties; that affects every non-enumerable data export, not only `constructor`, and is left for a separate change.

### Background
- When ESM imports a CommonJS file, bun evaluates it and calls `populateESMExports` to turn `module.exports` into the export names and values of a synthetic module record. The module namespace is built from that list, and a named import that is not in it is a link-time `SyntaxError`.
- `populateESMExports` lists the properties in one of two ways. If the object's JSC `Structure` (the shape record shared by objects with the same properties) describes it completely (`canPerformFastEnumeration`: no accessors, no indexed properties, not an uncacheable dictionary, no custom property lookup), it walks the Structure directly. Otherwise it calls `getOwnPropertyNames` and reads each property through a `PropertySlot`, which is also where getter values are read and attributes checked. Which branch runs depends only on the shape of the object, so both are meant to produce the same exports.
- `DontEnum` is JSC's name for `enumerable: false`. `Foo.prototype.constructor` is a `DontEnum` data property, which is how `module.exports = Foo.prototype` ends up with an own `constructor`.

<details>
<summary>Probe: Node 26 vs bun 1.4.0 vs bun build</summary>

```
n1:  exports.a = 1; exports.constructor = "K";
n3:  n1 plus Object.defineProperty(exports, "g", { enumerable: true, get })
n4:  n3 plus exports.__esModule = true

            node 26                                   bun 1.4.0                      bun build (run with bun)
n1          a, constructor, default, module.exports   a, constructor, default        a, constructor
n3          a, constructor, default, module.exports   a, default, g                  a, constructor, default, g
n4          __esModule, a, constructor, default, ...  a, default, g                  __esModule, a, constructor, default, g
```

Node's own cjs-module-lexer does not detect `module.exports = { a: 1, constructor: "K" }` at all (non-identifier values), which is why the probe uses the `exports.x =` form; the point is that when Node does see the export it has no name filter. The `module.exports` and `__esModule` columns are pre-existing, unrelated differences.
</details>
