### PR TITLE
bun test --parallel: print the "All files" coverage row first, like the serial reporter

### DIFF
--- a/src/runtime/cli/test/parallel/aggregate.rs
+++ b/src/runtime/cli/test/parallel/aggregate.rs
@@ -296,6 +296,11 @@ pub(crate) fn merge_coverage_fragments<const ENABLE_COLORS: bool>(
         avg.stmts += frac.stmts;
         avg_n += 1.0;
     }
+    if avg_n > 0.0 {
+        avg.functions /= avg_n;
+        avg.lines /= avg_n;
+        avg.stmts /= avg_n;
+    }
     opts.fractions.failing = failing;
 
     if opts.reporters.text {
@@ -331,7 +336,20 @@ pub(crate) fn merge_coverage_fragments<const ENABLE_COLORS: bool>(
         );
         sep::<ENABLE_COLORS>(console, max_len);
 
+        // Same row order as the serial reporter (test_command.rs
+        // print_code_coverage): the "All files" row, then one row per file.
         let mut body: Vec<u8> = Vec::new();
+        let _ = CoverageReportText::write_format_with_values::<ENABLE_COLORS>(
+            b"All files",
+            max_len,
+            avg,
+            base,
+            failing,
+            &mut body,
+            false,
+        );
+        let _ = body.write_all(Output::pretty_fmt::<ENABLE_COLORS>("<r><d> |<r>\n").as_ref());
+
         debug_assert_eq!(order.len(), fracs.len());
         for (&i, frac) in order.iter().zip(fracs.iter()) {
             let fc = &by_file.values()[i];
@@ -372,26 +390,7 @@ pub(crate) fn merge_coverage_fragments<const ENABLE_COLORS: bool>(
             let _ = body.write_all(b"\n");
         }
 
-        if avg_n > 0.0 {
-            avg.functions /= avg_n;
-            avg.lines /= avg_n;
-            avg.stmts /= avg_n;
-        }
         let _ = console.write_all(&body);
-        // bun_core::io::Writer doesn't impl bun_io::Write — buffer
-        // through a Vec then write_all once.
-        let mut all_files: Vec<u8> = Vec::new();
-        let _ = CoverageReportText::write_format_with_values::<ENABLE_COLORS>(
-            b"All files",
-            max_len,
-            avg,
-            base,
-            failing,
-            &mut all_files,
-            false,
-        );
-        let _ = console.write_all(&all_files);
-        let _ = console.write_all(Output::pretty_fmt::<ENABLE_COLORS>("<r><d> |<r>\n").as_ref());
         sep::<ENABLE_COLORS>(console, max_len);
 
         Output::flush();

--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -596,29 +596,50 @@ test("--parallel --coverage merges LCOV across workers", async () => {
 
 test("--parallel --coverage prints merged text table", async () => {
   using dir = tempDir("parallel-coverage-text", {
+    // The default differs between debug and release builds.
+    "bunfig.toml": `[test]\ncoverageSkipTestFiles = true\n`,
     "lib-a.js": `export function used() { return 1; }\nexport function unused() { return 2; }\n`,
     "lib-b.js": `export function go() { return 3; }\n`,
     "a.test.js": `import {test,expect} from "bun:test"; import {used} from "./lib-a.js"; test("a",()=>expect(used()).toBe(1));`,
     "b.test.js": `import {test,expect} from "bun:test"; import {go} from "./lib-b.js"; test("b",()=>expect(go()).toBe(3));`,
   });
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "test", "--parallel=2", "--coverage", "--coverage-reporter=text"],
-    env: bunEnv,
-    cwd: String(dir),
-    stderr: "pipe",
-    stdout: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const run = async (...flags: string[]) => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", ...flags, "--coverage", "--coverage-reporter=text"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // Keep just the coverage table (top rule through bottom rule): under
+    // --parallel the per-file result lines before it arrive in completion order.
+    const lines = stderr.split("\n");
+    const top = lines.findIndex(line => line.startsWith("---"));
+    const bottom = lines.findLastIndex(line => line.startsWith("---"));
+    return { stdout, table: lines.slice(top, bottom + 1).join("\n"), exitCode };
+  };
 
-  expect(stdout).toContain("PARALLEL");
-  // Table header + both source files present with a numeric % Lines column.
-  expect(stderr).toContain("% Funcs");
-  expect(stderr).toContain("% Lines");
-  expect(stderr).toMatch(/lib-a\.js\s+\|\s+\d+\.\d+\s+\|\s+\d+\.\d+/);
-  expect(stderr).toMatch(/lib-b\.js\s+\|\s+\d+\.\d+\s+\|\s+\d+\.\d+/);
-  expect(stderr).toContain("All files");
-  expect(exitCode).toBe(0);
+  const [parallel, serial] = await Promise.all([run("--parallel=2"), run()]);
+
+  expect(parallel.stdout).toContain("PARALLEL");
+  expect(parallel.table).toMatchInlineSnapshot(`
+    "-----------|---------|---------|-------------------
+    File       | % Funcs | % Lines | Uncovered Line #s
+    -----------|---------|---------|-------------------
+    All files  |   75.00 |  100.00 |
+     lib-a.js  |   50.00 |  100.00 | 
+     lib-b.js  |  100.00 |  100.00 | 
+    -----------|---------|---------|-------------------"
+  `);
+  expect(parallel.exitCode).toBe(0);
+
+  // The merged table is laid out exactly like the one the serial runner prints
+  // (which is also what a --parallel run with a single file falls back to).
+  expect(serial.stdout).not.toContain("PARALLEL");
+  expect(parallel.table).toBe(serial.table);
+  expect(serial.exitCode).toBe(0);
 });
 
 test("--parallel --coverage enforces coverageThreshold with lcov-only reporter", async () => {


### PR DESCRIPTION
### Problem
- `bun test --parallel --coverage` (text reporter) prints the `All files` row as the last row of the coverage table. The serial runner, and the examples in `docs/test/code-coverage.mdx`, print it as the first row, directly under the header. Percentages and per-file rows are otherwise identical.
- The same `--parallel` command produces either layout depending on how many test files it finds: with one file the coordinator falls back to the serial runner (`run_as_coordinator`, `src/runtime/cli/test/parallel/runner.rs:51`), so `All files` moves to the top.
- Cause: `merge_coverage_fragments` (`src/runtime/cli/test/parallel/aggregate.rs:380`) writes the buffered per-file rows to stderr and only then renders the `All files` row. The serial reporter (`print_code_coverage`, `src/runtime/cli/test_command.rs:1973`) renders `All files` before writing its buffered per-file rows. The parallel renderer has had this order since `--parallel` was added; the PR that added it (#29354) describes the output as identical to serial, so the order is an oversight, not a design choice.

### Fix
- `merge_coverage_fragments` now writes the `All files` row into the row buffer before the per-file rows, and the average it needs is computed right after the per-file fractions instead of after the rows are rendered. The separate one-row buffer it used to allocate for `All files` is gone.
- Correct because the serial reporter defines the format: it is what users, the docs, and coverage-parsing regexes (for example the GitLab `coverage:` example in the docs) have seen since `--coverage` shipped, and `--parallel` was specified as producing identical output. With the uncolored output the two tables are now byte-identical for the same fixture.
- Per-file row rendering, the LCOV merge, and threshold enforcement are untouched; only the position of the summary row in the text table changes.
- Verified with `test/cli/test/parallel.test.ts` ("--parallel --coverage prints merged text table"): it now snapshots the merged table and asserts it equals the table a serial run prints for the same fixture. Fails on the released `bun` (snapshot diff shows `All files` moving from last to first), passes with this build.
- The rest of `test/cli/test/parallel.test.ts` passes locally with a debug build, except "--parallel lazily scales workers based on file duration", which also fails without this change (timing-sensitive under debug+ASAN; #34992 reworks that fixture) and does not involve coverage.

### Background
- Under `--parallel`, each worker process runs a subset of the test files and sends its coverage to the coordinator as an LCOV text fragment. The coordinator merges the fragments per source file in `aggregate.rs` and renders the text table and/or `lcov.info` itself, with its own copy of the table-rendering code; the serial runner renders the table from in-process coverage data in `test_command.rs`. The two renderers have to agree by construction, which is what this PR restores for the row order.
- `All files` is the summary row of the text reporter: the average of the per-file function and line percentages.

<details>
<summary>Repro (release 1.4.0, two test files importing one lib.js)</summary>

```
$ bun test --coverage --coverage-reporter=text
-----------|---------|---------|-------------------
File       | % Funcs | % Lines | Uncovered Line #s
-----------|---------|---------|-------------------
All files  |   33.33 |  100.00 |
 lib.js    |   33.33 |  100.00 |
-----------|---------|---------|-------------------

$ bun test --parallel=2 --coverage --coverage-reporter=text
-----------|---------|---------|-------------------
File       | % Funcs | % Lines | Uncovered Line #s
-----------|---------|---------|-------------------
 lib.js    |   33.33 |  100.00 |
All files  |   33.33 |  100.00 |
-----------|---------|---------|-------------------
```

With a single test file, `bun test --parallel=2 --coverage` prints the first layout, because one file is run by the serial path.
</details>
