### PR TITLE
strings: bounds-check the cursor in lexer_step::next_codepoint_multibyte

### DIFF
--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -211,9 +211,9 @@ pub mod lexer_step {
     #[cold]
     #[inline(never)]
     pub fn next_codepoint_multibyte(contents: &[u8], current: &mut usize, first: u8) -> CodePoint {
-        let len = contents.len();
+        let tail = &contents[*current..];
+        debug_assert_eq!(tail.first(), Some(&first));
         let cp_len = wtf8_byte_sequence_length_with_invalid(first) as usize;
-        let avail = len - *current;
 
         // The ASCII fast path above handled `first < 0x80`; here `first >= 0x80` but `cp_len`
         // may still be 1 for invalid lead bytes (0x80-0xBF, 0xF8-0xFF) — those must yield the
@@ -221,23 +221,13 @@ pub mod lexer_step {
         // arm instead of silently emitting TEndOfFile mid-stream.
         let code_point: CodePoint = if cp_len == 1 {
             first as CodePoint
-        } else if avail < cp_len {
+        } else if let Some(sequence) = tail.get(..cp_len) {
+            let mut quad = [0u8; 4];
+            quad[..cp_len].copy_from_slice(sequence);
+            decode_wtf8_rune_t_multibyte(quad, cp_len as u8, UNICODE_REPLACEMENT as CodePoint)
+        } else {
             // truncated multibyte at EOF
             -1
-        } else {
-            let mut quad = [0u8; 4];
-            // SAFETY: `*current < len` (checked by caller), `cp_len ∈ 2..=4`, and
-            // `avail >= cp_len`, so `contents[current..current + cp_len]` is in-bounds.
-            // `decode_wtf8_rune_t_multibyte` only dereferences `p[0..len]`; pad bytes are
-            // never read.
-            unsafe {
-                core::ptr::copy_nonoverlapping(
-                    contents.as_ptr().add(*current),
-                    quad.as_mut_ptr(),
-                    cp_len,
-                );
-            }
-            decode_wtf8_rune_t_multibyte(quad, cp_len as u8, UNICODE_REPLACEMENT as CodePoint)
         };
 
         *current += if code_point != UNICODE_REPLACEMENT as CodePoint {
@@ -2753,5 +2743,61 @@ mod tests {
         assert_eq!(out, &[0xD800][..]);
         let out = super::convert_utf8_to_utf16_in_buffer(&mut buf, b"\xC3\xA9\xF0\x9F\x98\x80");
         assert_eq!(out, &[0x00E9, 0xD83D, 0xDE00][..]);
+    }
+
+    // `lexer_step` is pure Rust, so unlike the simdutf-backed test above these run under
+    // `cargo miri test -p bun_core -- lexer_step` (the native test target does not link).
+
+    /// Steps once from `at`, as the lexer does after reading the non-ASCII byte there.
+    /// Returns the code point and where the cursor was left.
+    fn lexer_step(contents: &[u8], at: usize) -> (super::CodePoint, usize) {
+        let mut current = at;
+        let code_point =
+            super::lexer_step::next_codepoint_multibyte(contents, &mut current, contents[at]);
+        (code_point, current)
+    }
+
+    #[test]
+    fn lexer_step_decodes_a_well_formed_sequence_and_steps_over_it() {
+        assert_eq!(lexer_step(b"\xC3\xA9", 0), (0xE9, 2));
+        assert_eq!(lexer_step(b"\xE2\x82\xAC;", 0), (0x20AC, 3));
+        assert_eq!(lexer_step(b"a=\xF0\x9F\x98\x80", 2), (0x1F600, 6));
+        // WTF-8: an encoded surrogate is a code point of its own.
+        assert_eq!(lexer_step(b"\xED\xA0\x80", 0), (0xD800, 3));
+    }
+
+    #[test]
+    fn lexer_step_yields_a_byte_that_cannot_lead_a_sequence_as_itself() {
+        assert_eq!(lexer_step(b"\x80", 0), (0x80, 1));
+        assert_eq!(lexer_step(b"a\xFF", 1), (0xFF, 2));
+    }
+
+    #[test]
+    fn lexer_step_replaces_an_ill_formed_sequence_and_steps_over_its_lead_byte_only() {
+        assert_eq!(lexer_step(b"\xC3A", 0), (0xFFFD, 1));
+        assert_eq!(lexer_step(b"\xE2\x82A", 0), (0xFFFD, 1));
+        assert_eq!(lexer_step(b"\xC0\x80", 0), (0xFFFD, 1));
+        assert_eq!(lexer_step(b"a\xF4\x90\x80\x80", 1), (0xFFFD, 2));
+    }
+
+    #[test]
+    fn lexer_step_reports_eof_for_a_sequence_cut_off_by_the_end_of_input() {
+        for (contents, at) in [(&b"\xC3"[..], 0), (b"\xE2\x82", 0), (b"a\xF0\x9F\x98", 1)] {
+            let (code_point, current) = lexer_step(contents, at);
+            assert_eq!(code_point, -1, "{contents:?}");
+            // The lexer's next step must then see EOF rather than step again.
+            assert!(current >= contents.len(), "{contents:?}");
+        }
+    }
+
+    // The slice bounds check is what keeps this safe fn memory-safe for any caller, so it
+    // has to be the thing that fires (it survives release builds; arithmetic overflow
+    // checks do not).
+    #[test]
+    #[should_panic(expected = "out of range for slice")]
+    fn lexer_step_rejects_a_cursor_past_the_end_of_input() {
+        let contents = b"\xF0\x9F\x98\x80";
+        let mut current = contents.len() + 1;
+        super::lexer_step::next_codepoint_multibyte(contents, &mut current, contents[0]);
     }
 }

--- a/test/internal/lexer-step.test.ts
+++ b/test/internal/lexer-step.test.ts
@@ -1,0 +1,83 @@
+/**
+ * `strings::lexer_step::next_codepoint_multibyte` (src/bun_core/string/immutable.rs)
+ * is the out-of-line non-ASCII tail of the JS lexer's `step()`. It is a safe
+ * `pub fn`, but it used to copy the sequence out of `contents` with an unchecked
+ * `copy_nonoverlapping` and relied on its caller (in another crate) having
+ * checked that the cursor was inside `contents`: with the cursor past the end,
+ * `len - current` wraps in the shipped profile and the copy reads past the
+ * slice. It now slices `contents[current..]`, so the bounds check is its own.
+ *
+ * The lexer never passes a cursor past the end, so no JS input reaches this;
+ * the behavior is pinned by the unit tests next to the function. Those are run
+ * here through `cargo miri test` with the shipped profile's debug assertions and
+ * overflow checks compiled out, so an unchecked cursor shows up as the
+ * out-of-bounds read Miri reports rather than as an overflow panic (bun_core's
+ * test binary does not link natively, and the crate is not in `bun run
+ * rust:miri`'s set because its other tests call into C). Each test has to be
+ * reported as passed. Skipped where miri is not installed or the cargo
+ * workspace is not resolvable (test-only CI lanes run a prebuilt binary), the
+ * same prerequisites as linear-fifo.test.ts.
+ */
+import { expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+const cargoBin = Bun.which("cargo");
+const repoRoot = path.resolve(import.meta.dir, "..", "..");
+const workspaceResolvable =
+  existsSync(path.join(repoRoot, "vendor", "lolhtml", "Cargo.toml")) &&
+  existsSync(path.join(repoRoot, "build", "debug", "codegen", "build_options.rs"));
+const miriAvailable =
+  !!cargoBin &&
+  workspaceResolvable &&
+  Bun.spawnSync({
+    cmd: [cargoBin, "miri", "--version"],
+    cwd: repoRoot,
+    stdout: "ignore",
+    stderr: "ignore",
+    timeout: 30_000,
+  }).exitCode === 0;
+
+const expectedResults = {
+  "string::immutable::tests::lexer_step_decodes_a_well_formed_sequence_and_steps_over_it": "ok",
+  "string::immutable::tests::lexer_step_yields_a_byte_that_cannot_lead_a_sequence_as_itself": "ok",
+  "string::immutable::tests::lexer_step_replaces_an_ill_formed_sequence_and_steps_over_its_lead_byte_only": "ok",
+  "string::immutable::tests::lexer_step_reports_eof_for_a_sequence_cut_off_by_the_end_of_input": "ok",
+  "string::immutable::tests::lexer_step_rejects_a_cursor_past_the_end_of_input": "ok",
+};
+
+test.skipIf(!miriAvailable)(
+  "lexer_step::next_codepoint_multibyte bounds-checks the cursor itself and decodes as before",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [cargoBin!, "miri", "test", "--locked", "--lib", "-p", "bun_core", "--", "lexer_step"],
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        // Same aliasing model as `bun run rust:miri` (scripts/rust-miri.ts).
+        MIRIFLAGS: "-Zmiri-tree-borrows",
+        // The `test` profile inherits `dev`; these are the release profile's settings.
+        CARGO_PROFILE_TEST_DEBUG_ASSERTIONS: "false",
+        CARGO_PROFILE_TEST_OVERFLOW_CHECKS: "false",
+        CARGO_TERM_COLOR: "never",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    if (exitCode !== 0) {
+      // Miri's diagnostic (stderr) names the out-of-bounds access it stopped at;
+      // libtest's own failure details are on stdout.
+      console.error(stderr, stdout);
+    }
+
+    // libtest prints one line per test: `test <name>[ - should panic] ... ok`.
+    const results: Record<string, string> = {};
+    for (const [, name, status] of stdout.matchAll(/^test (\S+)(?: - should panic)? \.\.\. (\w+)$/gm)) {
+      if (name in expectedResults) results[name] = status;
+    }
+    expect({ results, exitCode }).toEqual({ results: expectedResults, exitCode: 0 });
+  },
+  // Compiles bun_core and its dependencies for miri on the first run; the tests themselves are instant.
+  300_000,
+);


### PR DESCRIPTION
### Problem

- `strings::lexer_step::next_codepoint_multibyte(contents, current, first)` (src/bun_core/string/immutable.rs:213) is a safe `pub fn` whose `unsafe` block is only sound if the caller has already checked `*current < contents.len()`. The SAFETY comment says "checked by caller"; the function itself does not check it, not even with a `debug_assert!`.
- With the cursor past the end, `let avail = len - *current` panics in a debug build but wraps in the shipped profile (`[profile.release]` has overflow checks off), `avail < cp_len` is then false, and `copy_nonoverlapping(contents.as_ptr().add(*current), ..)` reads 2 to 4 bytes past the slice. Miri on the current body, with overflow checks compiled out as they are in release, and the cursor one past the end of a 4 byte input:
  ```
  error: Undefined Behavior: in-bounds pointer arithmetic failed: attempting to offset pointer by 5 bytes, but got alloc6441 which is only 4 bytes from the end of the allocation
     --> src/bun_core/string/immutable.rs:235:21
  235 |                     contents.as_ptr().add(*current),
  ```
- Not a live bug today: the only caller, `Lexer::next_codepoint_with` (src/js_parser/lexer.rs:1096), returns at `self.current >= len` before calling it. The problem is the shape: a safe function exported from bun_core whose memory safety depends on an unchecked contract with a caller in another crate. Found while fixing `eql_long` (#39032), which is the same shape elsewhere in this file.

### Fix

- The body slices `contents[*current..]` and takes the sequence with `tail.get(..cp_len)` / `copy_from_slice`, so the function bounds-checks the cursor itself and contains no `unsafe`. A cursor past the end is a slice-index panic in every profile. `first` (the byte the caller already loaded) is still passed in so the invalid-lead-byte arm does not touch memory; a `debug_assert_eq!` pins it to `contents[*current]`.
- Behavior is unchanged for every in-range input: same `cp_len` table, same decoder, same results for well-formed sequences (advance `cp_len`), bytes that cannot lead a sequence (returned as themselves), ill-formed sequences (U+FFFD, advance 1) and sequences cut off by EOF (`-1`). The four decode unit tests below pass against both the old and the new body.
- Why a check inside rather than `unsafe fn`: the function is `#[cold] #[inline(never)]` precisely so that nothing in it affects the ASCII path that inlines into every `step()` site (see its doc comment, which still holds; the change is inside the out-of-line body). The only cost is one compare on the non-ASCII path, and `CodepointIterator::next` 80 lines above, which is `#[inline(always)]` and per-byte hot in the printer, already uses this exact safe shape. There is nothing to buy with `unsafe` here, so the contract does not need to exist.
- Tests:
  - `mod tests` in immutable.rs: four tests pinning the decode behavior above, and `lexer_step_rejects_a_cursor_past_the_end_of_input`, which requires the slice bounds check to be what fires for a cursor past the end (`should_panic(expected = "out of range for slice")`). On the old body that test fails in both configurations: with overflow checks on, the panic is `attempt to subtract with overflow`; with them off, Miri reports the out-of-bounds offset quoted above.
  - test/internal/lexer-step.test.ts runs those five through `cargo miri test --lib -p bun_core -- lexer_step` with the release profile's debug assertions and overflow checks compiled out, and requires each to be reported as passed (same shape as linear-fifo.test.ts and #39032's eql-long.test.ts; bun_core's test binary does not link natively and is not in `rust:miri`'s crate set because its other tests call into C). Skipped where miri or the cargo workspace is unavailable.
- Verified:
  - `bun bd test test/internal/lexer-step.test.ts`: passes. With src/ stashed it fails (no tests to run); with the old body and the new tests it fails with the Miri report in the log.
  - `cargo miri test -p bun_core -- lexer_step` under Tree Borrows, Stacked Borrows, and with debug assertions and overflow checks off: 5 pass.
  - `bun bd test` on test/js/bun/transpiler/transpiler-truncated-utf8.test.ts (lexes truncated sequences placed directly before a PROT_NONE page, so it covers the EOF arm of the new body through the real lexer), test/bundler/transpiler/transpiler.test.js, property.test.ts, template-literal.test.ts and test/bundler/bundler_string.test.ts: all pass. The debug build also bundles and runs sources with non-ASCII identifiers, strings, templates, comments, regexes, JSX and JSON without tripping the new `debug_assert_eq!`.
  - `cargo clippy -p bun_core` and `cargo fmt --check`: clean.
- Related: #39032 fixes `eql_long` / `eql_comptime_ignore_len` in this file and also appends to the same `mod tests`, so whichever lands second has a trivial conflict there. #38262 replaces this function's body for a behavior change (ill-formed UTF-8 as U+FFFD) and slices safely as well; this PR is independent of that decision and is the minimal change for the current behavior.

### Background

- `step()` is the JS lexer's advance-one-code-point primitive. It is inlined at every call site in the tokenizer, so its body is kept to an ASCII fast path plus a call to this out-of-line, `#[cold]` function for any byte `>= 0x80`.
- The lexer decodes source as WTF-8 (UTF-8 that also allows encoded surrogates). `wtf8_byte_sequence_length_with_invalid(first)` gives the sequence length implied by a lead byte (1 for bytes that cannot lead a sequence), and `decode_wtf8_rune_t_multibyte` decodes a 2 to 4 byte sequence from a 4 byte buffer, returning the supplied replacement value for ill-formed input.
- A safe Rust function is expected to be memory-safe for every argument a caller can pass; if it can only be safe under a condition the caller must uphold, it has to be declared `unsafe fn` so that callers are made to state that condition. Miri is the interpreter the repo's `rust:miri` CI job uses to detect out-of-bounds accesses and other undefined behavior in unit tests; it honors the normal cargo profile settings, which is how the test reproduces the release-profile behavior.

<details>
<summary>Miri output on the old body, both configurations</summary>

Default `test` profile (overflow checks on):

```
test string::immutable::tests::lexer_step_rejects_a_cursor_past_the_end_of_input - should panic ... FAILED
thread '...' panicked at src/bun_core/string/immutable.rs:216:21:
attempt to subtract with overflow
note: panic did not contain expected string
      panic message: "attempt to subtract with overflow"
 expected substring: "out of range for slice"
```

`CARGO_PROFILE_TEST_OVERFLOW_CHECKS=false` (what test/internal/lexer-step.test.ts sets):

```
test string::immutable::tests::lexer_step_rejects_a_cursor_past_the_end_of_input - should panic ... error: Undefined Behavior: in-bounds pointer arithmetic failed: attempting to offset pointer by 5 bytes, but got alloc6441 which is only 4 bytes from the end of the allocation
   --> src/bun_core/string/immutable.rs:235:21
    |
235 |                     contents.as_ptr().add(*current),
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
    = note: stack backtrace:
            0: string::immutable::lexer_step::next_codepoint_multibyte
            1: string::immutable::tests::lexer_step_rejects_a_cursor_past_the_end_of_input
```

The other four `lexer_step_*` tests pass on the old body in both configurations.

</details>
