### PR TITLE
zstd: throw instead of aborting when the output buffer cannot be allocated

### DIFF
--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -2752,29 +2752,25 @@ pub mod JSZstd {
         let buffer = coerce_compress_buffer(global_this, buffer_value)?;
         let input = buffer.slice();
 
-        // Calculate max compressed size
+        // The output bound is sized by the caller's input, so a failed
+        // allocation is thrown rather than aborting the process.
         let max_size = bun_zstd::compress_bound(input.len());
-        // The zero-fill
-        // here is output-irrelevant (zstd overwrites the prefix it reports).
-        // PERF: use Box::new_uninit_slice — profile if hot.
-        let mut output = vec![0u8; max_size];
-
-        // Perform compression with context
-        let compressed_size = match bun_zstd::compress(&mut output, input, Some(level)) {
-            bun_zstd::Result::Success(size) => size,
-            bun_zstd::Result::Err(err) => {
-                drop(output);
-                return Err(global_this
-                    .err(jsc::ErrCode::ZSTD, format_args!("{}", bstr::BStr::new(err)))
-                    .throw());
-            }
-        };
-
-        // Resize to actual compressed size
-        if compressed_size < output.len() {
-            output.truncate(compressed_size);
-            output.shrink_to_fit();
+        let mut output: Vec<u8> = Vec::new();
+        if output.try_reserve_exact(max_size).is_err() {
+            return Err(global_this.throw_out_of_memory());
         }
+
+        if let bun_zstd::Result::Err(err) =
+            bun_zstd::compress_append(&mut output, input, Some(level))
+        {
+            drop(output);
+            return Err(global_this
+                .err(jsc::ErrCode::ZSTD, format_args!("{}", bstr::BStr::new(err)))
+                .throw());
+        }
+
+        // Release the slack between the compressed size and the bound.
+        output.shrink_to_fit();
 
         JSValue::create_buffer(global_this, output.leak())
     }
@@ -2827,33 +2823,22 @@ pub mod JSZstd {
             let input = this.buffer.slice();
 
             if this.is_compress {
+                // Surface OOM as a rejected promise instead of aborting.
                 let max_size = bun_zstd::compress_bound(input.len());
-                // Surface OOM as a rejected promise instead of aborting. The
-                // zero-fill is output-irrelevant (zstd overwrites the prefix it reports).
-                let mut output: Vec<u8> = Vec::new();
-                if output.try_reserve_exact(max_size).is_err() {
+                if this.output.try_reserve_exact(max_size).is_err() {
                     this.error_message = Some(b"Out of memory");
                     return Some(done);
                 }
-                output.resize(max_size, 0);
-                this.output = output;
 
-                this.output = match bun_zstd::compress(&mut this.output, input, Some(this.level)) {
-                    bun_zstd::Result::Success(size) => 'blk: {
-                        if size < this.output.len() {
-                            let mut out = core::mem::take(&mut this.output);
-                            out.truncate(size);
-                            out.shrink_to_fit();
-                            break 'blk out;
-                        }
-                        break 'blk core::mem::take(&mut this.output);
-                    }
-                    bun_zstd::Result::Err(err) => {
-                        this.output = Vec::new();
-                        this.error_message = Some(err);
-                        return Some(done);
-                    }
-                };
+                if let bun_zstd::Result::Err(err) =
+                    bun_zstd::compress_append(&mut this.output, input, Some(this.level))
+                {
+                    this.output = Vec::new();
+                    this.error_message = Some(err);
+                    return Some(done);
+                }
+
+                this.output.shrink_to_fit();
             } else {
                 this.output = match bun_zstd::decompress_alloc(input) {
                     Ok(v) => v,

--- a/src/zstd/lib.rs
+++ b/src/zstd/lib.rs
@@ -188,6 +188,10 @@ pub enum Result {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, strum::IntoStaticStr)]
 pub enum ZstdError {
+    /// The output buffer could not be allocated or grown. The output is
+    /// sized by the input's (possibly hostile) decompressed size, so this is
+    /// reported to the caller instead of aborting the process.
+    OutOfMemory,
     InvalidZstdData,
     DecompressionFailed,
     ZstdFailedToCreateInstance,
@@ -290,10 +294,35 @@ pub fn decompress(dest: &mut [u8], src: &[u8]) -> Result {
     Result::Success(result)
 }
 
+/// [`decompress`] into `out`'s spare capacity (append mode). On success
+/// `out.len()` is advanced by the decompressed size. The spare capacity is
+/// the output bound; zstd reports an error when the frames do not fit.
+fn decompress_append(out: &mut Vec<u8>, src: &[u8]) -> Result {
+    let spare = out.spare_capacity_mut();
+    // SAFETY: spare/src are valid for their lengths; ZSTD_decompress reads src
+    // and writes into spare.
+    let rc = unsafe {
+        c::ZSTD_decompress(
+            spare.as_mut_ptr().cast::<c_void>(),
+            spare.len(),
+            src.as_ptr().cast::<c_void>(),
+            src.len(),
+        )
+    };
+    if c::ZSTD_isError(rc) != 0 {
+        // SAFETY: ZSTD_getErrorName returns a static NUL-terminated string.
+        return Result::Err(unsafe { ZStr::from_c_ptr(c::ZSTD_getErrorName(rc)) });
+    }
+    // SAFETY: zstd has initialized `rc` bytes at the start of spare.
+    unsafe { bun_core::vec::commit_spare(out, rc) };
+    Result::Success(rc)
+}
+
 /// Decompress data, automatically allocating the output buffer.
 /// Returns owned slice that must be freed by the caller.
 /// Handles both frames with known and unknown content sizes.
 /// For safety, if the reported decompressed size exceeds 16MB, streaming decompression is used instead.
+/// A failed output allocation is reported as [`ZstdError::OutOfMemory`].
 pub fn decompress_alloc(src: &[u8]) -> core::result::Result<Vec<u8>, ZstdError> {
     let size = get_decompressed_size(src);
 
@@ -318,14 +347,14 @@ pub fn decompress_alloc(src: &[u8]) -> core::result::Result<Vec<u8>, ZstdError> 
     }
 
     // Fast path: size is known and within reasonable limits
-    let mut output = vec![0u8; size];
+    let mut output: Vec<u8> = Vec::new();
+    output
+        .try_reserve_exact(size)
+        .map_err(|_| ZstdError::OutOfMemory)?;
 
-    match decompress(&mut output, src) {
-        Result::Success(actual_size) => {
-            output.truncate(actual_size);
-            Ok(output)
-        }
-        // `output` is freed by Drop above.
+    match decompress_append(&mut output, src) {
+        Result::Success(_) => Ok(output),
+        // `output` is freed by Drop.
         Result::Err(_) => Err(ZstdError::DecompressionFailed),
     }
 }
@@ -423,9 +452,11 @@ impl<'a> ZstdReaderArrayList<'a> {
                 return Err(ZstdError::ZstdDecompressionError);
             }
 
-            // SAFETY: write-only spare; ZSTD_decompressStream initializes the
-            // first `out_buf.pos` bytes.
-            let spare = unsafe { bun_core::vec::reserve_spare_bytes(self.list_ptr, 4096) };
+            if self.list_ptr.try_reserve(4096).is_err() {
+                self.state = State::Error;
+                return Err(ZstdError::OutOfMemory);
+            }
+            let spare = self.list_ptr.spare_capacity_mut();
             let mut in_buf = c::ZSTD_inBuffer {
                 src: next_in.as_ptr().cast::<c_void>(),
                 size: next_in.len(),
@@ -573,7 +604,10 @@ impl StreamingDecoder {
                 return Err(ZstdError::ZstdDecompressionError);
             }
 
-            out.reserve(4096);
+            if out.try_reserve(4096).is_err() {
+                self.state = State::Error;
+                return Err(ZstdError::OutOfMemory);
+            }
             let spare = out.spare_capacity_mut();
             let mut in_buf = c::ZSTD_inBuffer {
                 src: next_in.as_ptr().cast::<c_void>(),

--- a/test/js/bun/util/zstd.test.ts
+++ b/test/js/bun/util/zstd.test.ts
@@ -9,7 +9,7 @@ import {
   zstdDecompressSync,
 } from "bun";
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, rss } from "harness";
+import { bunEnv, bunExe, isASAN, rss } from "harness";
 import path from "path";
 
 describe("Zstandard compression", async () => {
@@ -531,5 +531,176 @@ describe.concurrent("Zstandard HTTP compression", () => {
     expect(response.headers.get("Content-Encoding")).toBe("zstd");
     const echoed = await response.text();
     expect(echoed).toBe(testString);
+  });
+});
+
+// The output buffers are sized by the input: the compression bound of the
+// caller's data, or whatever the (possibly hostile) frames decompress to. When
+// that allocation fails the call has to throw, not abort the process. ASAN's
+// per-allocation cap makes the failure deterministic: the JS Buffers are
+// allocated by JSC and are not subject to it, while every native reservation
+// above CAP_MB fails.
+describe.skipIf(!isASAN)("a failed output buffer allocation throws instead of aborting", () => {
+  const MiB = 1024 * 1024;
+  const CAP_MB = 8;
+  const env = {
+    ...bunEnv,
+    // detect_leaks=0: natives owned only by a JSC cell are invisible to
+    // LeakSanitizer's reachability scan and would be reported at exit.
+    ASAN_OPTIONS: [
+      bunEnv.ASAN_OPTIONS,
+      "allocator_may_return_null=1",
+      `max_allocation_size_mb=${CAP_MB}`,
+      "detect_leaks=0",
+    ]
+      .filter(Boolean)
+      .join(":"),
+  };
+
+  // Built here, uncapped; the children only decompress them. Each decompresses
+  // to more than the cap, and each reaches the failing allocation differently:
+  //   knownSize:           the frame header carries the content size and it is
+  //                        under the 16 MiB preallocation limit, so the whole
+  //                        output is allocated up front
+  //   knownSizeAboveLimit: the content size is above that limit, so the output
+  //                        is decompressed in a stream and grown as it fills
+  //   unknownSize:         the header carries no content size (streaming
+  //                        compressor), same growth
+  const frameSizes = { knownSize: 12 * MiB, knownSizeAboveLimit: 32 * MiB, unknownSize: 12 * MiB };
+  let prelude: string;
+  beforeAll(async () => {
+    const frames = {
+      knownSize: zstdCompressSync(Buffer.alloc(frameSizes.knownSize)),
+      knownSizeAboveLimit: zstdCompressSync(Buffer.alloc(frameSizes.knownSizeAboveLimit)),
+      unknownSize: await new Response(
+        new Response(Buffer.alloc(frameSizes.unknownSize)).body!.pipeThrough(new CompressionStream("zstd")),
+      ).bytes(),
+    };
+    // RFC 8878 3.1.1.1.1: bits 7-6 of the Frame_Header_Descriptor are the
+    // Frame_Content_Size_flag; with bit 5 (Single_Segment_flag) also clear the
+    // header has no content size field at all.
+    const headerHasContentSize = Object.fromEntries(
+      Object.entries(frames).map(([name, frame]) => [name, (frame[4] & 0xe0) !== 0]),
+    );
+    expect(headerHasContentSize).toEqual({ knownSize: true, knownSizeAboveLimit: true, unknownSize: false });
+    const decompressedSizes = Object.fromEntries(
+      Object.entries(frames).map(([name, frame]) => [name, zstdDecompressSync(frame).byteLength]),
+    );
+    expect(decompressedSizes).toEqual(frameSizes);
+
+    const framesBase64 = Object.fromEntries(
+      Object.entries(frames).map(([name, frame]) => [name, Buffer.from(frame).toString("base64")]),
+    );
+    prelude = /* js */ `
+      const MiB = 1024 * 1024;
+      const frames = Object.fromEntries(
+        Object.entries(${JSON.stringify(framesBase64)}).map(([name, b64]) => [name, Buffer.from(b64, "base64")]),
+      );
+      // compress_bound(16 MiB) is a little over 16 MiB, twice the cap.
+      const big = Buffer.alloc(${2 * CAP_MB} * MiB);
+      const describeError = e => ({ name: e.name, code: e.code, message: e.message });
+      const results = {};
+    `;
+  });
+
+  async function runChild(script: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", prelude + script],
+      env,
+      stdout: "pipe",
+      // ASAN prints a warning for every refused allocation; drain it, don't assert on it.
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { results: JSON.parse(stdout.trim() || JSON.stringify({ stdout, stderr, exitCode })), exitCode };
+  }
+
+  const outOfMemory = { name: "RangeError", message: "Out of memory" };
+  const zstdError = (message: string) => ({ name: "Error", code: "ERR_ZSTD", message });
+
+  it.concurrent("zstdCompressSync", async () => {
+    const { results, exitCode } = await runChild(/* js */ `
+      try { results.big = Bun.zstdCompressSync(big).byteLength; } catch (e) { results.big = describeError(e); }
+      results.afterwards = Bun.zstdDecompressSync(Bun.zstdCompressSync("still works")).toString();
+      console.log(JSON.stringify(results));
+    `);
+    expect(results).toEqual({ big: outOfMemory, afterwards: "still works" });
+    expect(exitCode).toBe(0);
+  });
+
+  it.concurrent("zstdCompress", async () => {
+    const { results, exitCode } = await runChild(/* js */ `
+      results.big = await Bun.zstdCompress(big).then(out => out.byteLength, describeError);
+      results.afterwards = Bun.zstdDecompressSync(await Bun.zstdCompress("still works")).toString();
+      console.log(JSON.stringify(results));
+    `);
+    expect(results).toEqual({ big: zstdError("Out of memory"), afterwards: "still works" });
+    expect(exitCode).toBe(0);
+  });
+
+  it.concurrent("zstdDecompressSync", async () => {
+    const { results, exitCode } = await runChild(/* js */ `
+      for (const [name, frame] of Object.entries(frames)) {
+        try { results[name] = Bun.zstdDecompressSync(frame).byteLength; } catch (e) { results[name] = describeError(e); }
+      }
+      results.afterwards = Bun.zstdDecompressSync(Bun.zstdCompressSync("still works")).toString();
+      console.log(JSON.stringify(results));
+    `);
+    const error = zstdError("Decompression failed: OutOfMemory");
+    expect(results).toEqual({
+      knownSize: error,
+      knownSizeAboveLimit: error,
+      unknownSize: error,
+      afterwards: "still works",
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  it.concurrent("zstdDecompress", async () => {
+    const { results, exitCode } = await runChild(/* js */ `
+      for (const [name, frame] of Object.entries(frames)) {
+        results[name] = await Bun.zstdDecompress(frame).then(out => out.byteLength, describeError);
+      }
+      results.afterwards = (await Bun.zstdDecompress(Bun.zstdCompressSync("still works"))).toString();
+      console.log(JSON.stringify(results));
+    `);
+    const error = zstdError("Decompression failed");
+    expect(results).toEqual({
+      knownSize: error,
+      knownSizeAboveLimit: error,
+      unknownSize: error,
+      afterwards: "still works",
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  // fetch() decodes Content-Encoding: zstd with the streaming decoder, whose
+  // output grows the same way; the body read rejects and the process goes on
+  // serving.
+  it.concurrent("fetch() of a zstd-encoded response", async () => {
+    const { results, exitCode } = await runChild(/* js */ `
+      const bodies = { ...frames, afterwards: Bun.zstdCompressSync("still works") };
+      using server = Bun.serve({
+        port: 0,
+        fetch: req => new Response(bodies[new URL(req.url).pathname.slice(1)], { headers: { "Content-Encoding": "zstd" } }),
+      });
+      for (const name of Object.keys(bodies)) {
+        const response = await fetch(new URL(name, server.url));
+        results[name] = await response.text().then(text => text, describeError);
+      }
+      console.log(JSON.stringify(results));
+    `);
+    const error = {
+      name: "TypeError",
+      code: "OutOfMemory",
+      message: expect.stringMatching(/^OutOfMemory fetching "http:\/\/localhost:\d+\//),
+    };
+    expect(results).toEqual({
+      knownSize: error,
+      knownSizeAboveLimit: error,
+      unknownSize: error,
+      afterwards: "still works",
+    });
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
### Problem
- `Bun.zstdCompressSync`, `Bun.zstdDecompressSync` and `Bun.zstdDecompress` abort the whole process when their output buffer cannot be allocated: `memory allocation of 16842752 bytes failed`, then `panic(main thread): abort() called` and a crash report. The async `Bun.zstdCompress` already rejects in that case, and all four threw before the Rust port.
- The sizes come from the input. `compress_sync` allocates `compress_bound(input.len())` with `vec![0u8; max_size]` (`src/runtime/api/BunObject.rs:2760`). Both decompress entry points call `bun_zstd::decompress_alloc`, which allocates the content size declared by the frame with `vec![0u8; size]` (`src/zstd/lib.rs:321`) and, for frames declaring more than 16 MiB or no size at all, grows the output with the infallible `reserve_spare_bytes` in `ZstdReaderArrayList::read_all` (`src/zstd/lib.rs:428`) until the input is exhausted. `StreamingDecoder::decompress`, the same loop as used by `fetch()` for `Content-Encoding: zstd`, has the same `out.reserve(4096)` (`src/zstd/lib.rs:576`). So a zstd stream that decompresses to more than the allocator will give out kills the process instead of failing the call.

### Fix
- `ZstdError` gains `OutOfMemory`. `decompress_alloc` reserves the declared size with `try_reserve_exact` and decompresses into the spare capacity (`decompress_append`, the counterpart of the existing `compress_append`); both streaming loops grow the output with `try_reserve` and return `OutOfMemory` when it fails. `try_reserve` grows exactly like `reserve`, and the reader's `Drop` still frees the `ZSTD_DStream` on the new return, so the paths only differ on the failing allocation.
- `compress_sync` reserves the bound with `try_reserve_exact` and throws the out of memory error (`throw_out_of_memory`, what the pre-port `try allocator.alloc` produced and what the sync zlib functions in this file do) when it fails. Both compress entry points now write through `compress_append`; the async twin keeps its `try_reserve_exact` and "Out of memory" rejection and only stops zero-filling the bound-sized buffer zstd overwrites anyway.
- No caller needs a new case: `Bun.zstdDecompressSync` throws `ERR_ZSTD` "Decompression failed: OutOfMemory" (`ZstdError` displays its variant name; this is the exact pre-port message), `Bun.zstdDecompress` rejects with `ERR_ZSTD` "Decompression failed" as for any decode failure, and a `fetch()` body read rejects with code `OutOfMemory` the same way it rejects with `ZstdDecompressionError` for a corrupt body today. The other `decompress_alloc` callers decompress data embedded in the binary and `expect()` the result, so the variant changes nothing for them.
- Why an error rather than a crash: the allocation is sized by one caller's data (or by an untrusted stream), not by anything the runtime needs to keep working, so it is that call's failure. That is how the pre-port code, the async compress twin and `ZlibError::OutOfMemory` already treat it, and it is what lets a process decompressing untrusted input survive a bomb. The equivalent growth sites in the zlib and brotli crates are deliberately not touched here; they are a separate change.
- Verified with the new block in `test/js/bun/util/zstd.test.ts` ("a failed output buffer allocation throws instead of aborting"): five concurrent children, one per entry point (`zstdCompressSync`, `zstdCompress`, `zstdDecompressSync`, `zstdDecompress`, `fetch()` of a zstd response), run with ASAN's `max_allocation_size_mb=8`. The decompress children each feed three frames that reach the failing allocation through a different path (declared size under the 16 MiB preallocation limit, declared size above it, no declared size), assert the exact error per frame, then round-trip a small payload to show the process is still usable. It is `skipIf(!isASAN)` because it needs the allocation cap. On the unfixed debug build four of the five children abort (below); with the fix the whole file (88 tests), `test/regression/issue/23314/`, `fetch-compress.test.ts`, `streams/compression.test.ts` and the node zstd tests pass.

### Background
- `ZSTD_compressBound(n)` is the most output `ZSTD_compress` can produce for `n` input bytes (a little over `n`); the one-shot API needs that much buffer before it starts, so compressing a 16 MiB buffer first needs a 16.06 MiB allocation.
- A zstd frame header may declare the decompressed size; one-shot compressors write it, streaming compressors usually do not, and an attacker can write anything. `decompress_alloc` trusts it up to 16 MiB; above that, or without one, it goes through `ZSTD_decompressStream`, appending to a `Vec` that doubles as it fills, so the output stops growing only when the input runs out.
- `Vec::reserve` calls the global allocation error handler when the allocator refuses, which in Bun aborts with the `memory allocation of N bytes failed` message above. `try_reserve` / `try_reserve_exact` grow the same way but return an error; they are what the runtime uses for buffers whose size the user controls (the async compress twin, `PBKDF2`, `randomFill`, ...).
- ASAN's `max_allocation_size_mb` plus `allocator_may_return_null=1` makes every native allocation above the cap fail deterministically, while JS `Buffer`s come from JSC's own allocator and are unaffected; that is what lets the children build 16 MiB inputs while every native output reservation fails. Same recipe as the existing fs and TextEncoderStream OOM tests.

Related but distinct: #35856 and #35866 add a 4 GiB cap on the decompressed size; this PR handles the allocator refusing a request of any size.

<details>
<summary>Fail-before on the unfixed debug (ASAN) build</summary>

Each failing child exits 134; the allocation it died on is the one named in the Problem section:

```
(pass) zstdCompress                          already rejected before this change
(fail) zstdCompressSync                      memory allocation of 16842752 bytes failed   (compress_bound(16 MiB))
(fail) zstdDecompressSync                    memory allocation of 12582912 bytes failed   (declared 12 MiB, one-shot path)
(fail) zstdDecompress                        memory allocation of 12582912 bytes failed   (same, off the JS thread)
(fail) fetch() of a zstd-encoded response    memory allocation of 16777216 bytes failed   (doubling step after 8 MiB of streamed output)
 1 pass
 4 fail
```

Fed individually to `Bun.zstdDecompressSync` on the unfixed build, the two streamed frames (declared 32 MiB, and 12 MiB without a declared size) abort with the 16777216-byte allocation instead, i.e. in the `read_all` growth; so each decompress child covers both the one-shot and the streaming allocation.

With the fix the same children print, and exit 0:

```
zstdCompressSync    {"name":"RangeError","message":"Out of memory"}
zstdCompress        {"name":"Error","code":"ERR_ZSTD","message":"Out of memory"}
zstdDecompressSync  {"name":"Error","code":"ERR_ZSTD","message":"Decompression failed: OutOfMemory"}   x3 frames
zstdDecompress      {"name":"Error","code":"ERR_ZSTD","message":"Decompression failed"}                x3 frames
fetch()             {"name":"TypeError","code":"OutOfMemory","message":"OutOfMemory fetching \"http://localhost:PORT/\". ..."}
```

</details>
