### PR TITLE
bun test --parallel: act on SIGINT/SIGTERM immediately instead of at the next housekeeping timer

### DIFF
--- a/src/runtime/cli/test/parallel/Coordinator.rs
+++ b/src/runtime/cli/test/parallel/Coordinator.rs
@@ -7,7 +7,7 @@
 use core::ffi::c_void;
 #[cfg(unix)]
 use core::mem::MaybeUninit;
-use core::sync::atomic::{AtomicBool, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
 use std::io::Write as _;
 
 use bun_core::strings;
@@ -922,14 +922,35 @@ fn describe_status<'b>(buf: &'b mut [u8; 32], status: &SpawnStatus) -> &'b [u8] 
 }
 
 /// Coordinator-side SIGINT/SIGTERM handling. The signal handler only sets a
-/// flag; `Coordinator::drive` checks it and tears down workers itself so we
-/// don't do non-signal-safe work in the handler. Linux PDEATHSIG and the
-/// Windows Job Object are the safety net for when the coordinator can't run
-/// this (SIGKILL).
+/// flag and wakes the event loop; `Coordinator::drive` checks the flag and
+/// tears down workers itself so we don't do non-signal-safe work in the
+/// handler. Linux PDEATHSIG and the Windows Job Object are the safety net for
+/// when the coordinator can't run this (SIGKILL).
 pub(crate) mod abort_handler {
     use super::*;
 
     pub(crate) static SHOULD_ABORT: AtomicBool = AtomicBool::new(false);
+
+    /// The loop `Coordinator::drive` parks in. Published by `install`, cleared
+    /// by `uninstall`; the loop itself lives until process exit.
+    static LOOP: AtomicPtr<bun_uws::Loop> = AtomicPtr::new(core::ptr::null_mut());
+
+    /// Signal context on POSIX, the console control thread on Windows. The flag
+    /// alone is not enough: `drive` reads it between polls and the poll retries
+    /// on EINTR, so an idle coordinator would only notice it when the next
+    /// housekeeping timer (~1s) fired. `us_wakeup_loop` is an atomic add plus an
+    /// eventfd write / mach_msg / kevent / uv_async_send, so it is safe to call
+    /// from here and makes the poll return immediately.
+    fn request_abort() {
+        SHOULD_ABORT.store(true, Ordering::Release);
+        let loop_ = LOOP.load(Ordering::Acquire);
+        if !loop_.is_null() {
+            // SAFETY: `install` published the live per-process uws loop, which
+            // outlives the coordinator; the raw extern forms no `&mut Loop`, so
+            // it cannot alias the tick the main thread is inside of.
+            unsafe { bun_uws::us_wakeup_loop(loop_) };
+        }
+    }
 
     // PORTING.md §Global mutable state: written once in `install()` (single
     // call site), read once in `uninstall()`. RacyCell — `sigaction` is POD,
@@ -943,7 +964,7 @@ pub(crate) mod abort_handler {
 
     #[cfg(unix)]
     extern "C" fn posix_handler(_: i32, _: *const libc::siginfo_t, _: *const c_void) {
-        SHOULD_ABORT.store(true, Ordering::Release);
+        request_abort();
     }
 
     #[cfg(windows)]
@@ -953,7 +974,7 @@ pub(crate) mod abort_handler {
         use bun_sys::windows;
         match ctrl {
             windows::CTRL_C_EVENT | windows::CTRL_BREAK_EVENT | windows::CTRL_CLOSE_EVENT => {
-                SHOULD_ABORT.store(true, Ordering::Release);
+                request_abort();
                 windows::TRUE
             }
             _ => windows::FALSE,
@@ -971,7 +992,10 @@ pub(crate) mod abort_handler {
         }
     }
 
-    pub(crate) fn install() -> Guard {
+    /// `loop_` is the loop `Coordinator::drive` will tick; it must already be
+    /// set up (`EventLoop::ensure_waker`) so the handler has something to wake.
+    pub(crate) fn install(loop_: *mut bun_uws::Loop) -> Guard {
+        LOOP.store(loop_, Ordering::Release);
         #[cfg(unix)]
         {
             // SAFETY: signal handler installation; PREV_* are written before
@@ -1031,5 +1055,6 @@ pub(crate) mod abort_handler {
                 bun_sys::windows::FALSE,
             );
         }
+        LOOP.store(core::ptr::null_mut(), Ordering::Release);
     }
 }

--- a/src/runtime/cli/test/parallel/Coordinator.rs
+++ b/src/runtime/cli/test/parallel/Coordinator.rs
@@ -922,12 +922,9 @@ fn describe_status<'b>(buf: &'b mut [u8; 32], status: &SpawnStatus) -> &'b [u8] 
 }
 
 /// Coordinator-side SIGINT/SIGTERM handling. The handler sets a flag and wakes
-/// the event loop; `Coordinator::drive` checks the flag between polls and tears
-/// down workers itself, so nothing non-signal-safe runs in the handler. The
-/// wakeup is what makes the flag visible promptly: the poll retries on EINTR,
-/// so without it an idle coordinator sees the flag only at its next
-/// housekeeping timer, up to ~1s later. Linux PDEATHSIG and the Windows Job
-/// Object are the safety net for when the coordinator can't run this (SIGKILL).
+/// the loop (the poll retries on EINTR, so the flag alone would wait for the
+/// next ~1s housekeeping timer); `Coordinator::drive` does the teardown. Linux
+/// PDEATHSIG and the Windows Job Object cover the case where it can't (SIGKILL).
 pub(crate) mod abort_handler {
     use super::*;
 

--- a/src/runtime/cli/test/parallel/Coordinator.rs
+++ b/src/runtime/cli/test/parallel/Coordinator.rs
@@ -921,33 +921,28 @@ fn describe_status<'b>(buf: &'b mut [u8; 32], status: &SpawnStatus) -> &'b [u8] 
     }
 }
 
-/// Coordinator-side SIGINT/SIGTERM handling. The signal handler only sets a
-/// flag and wakes the event loop; `Coordinator::drive` checks the flag and
-/// tears down workers itself so we don't do non-signal-safe work in the
-/// handler. Linux PDEATHSIG and the Windows Job Object are the safety net for
-/// when the coordinator can't run this (SIGKILL).
+/// Coordinator-side SIGINT/SIGTERM handling. The handler sets a flag and wakes
+/// the event loop; `Coordinator::drive` checks the flag between polls and tears
+/// down workers itself, so nothing non-signal-safe runs in the handler. The
+/// wakeup is what makes the flag visible promptly: the poll retries on EINTR,
+/// so without it an idle coordinator sees the flag only at its next
+/// housekeeping timer, up to ~1s later. Linux PDEATHSIG and the Windows Job
+/// Object are the safety net for when the coordinator can't run this (SIGKILL).
 pub(crate) mod abort_handler {
     use super::*;
 
     pub(crate) static SHOULD_ABORT: AtomicBool = AtomicBool::new(false);
 
-    /// The loop `Coordinator::drive` parks in. Published by `install`, cleared
-    /// by `uninstall`; the loop itself lives until process exit.
+    /// Set by `install`, cleared by `uninstall`. The uws loop is process-lifetime.
     static LOOP: AtomicPtr<bun_uws::Loop> = AtomicPtr::new(core::ptr::null_mut());
 
-    /// Signal context on POSIX, the console control thread on Windows. The flag
-    /// alone is not enough: `drive` reads it between polls and the poll retries
-    /// on EINTR, so an idle coordinator would only notice it when the next
-    /// housekeeping timer (~1s) fired. `us_wakeup_loop` is an atomic add plus an
-    /// eventfd write / mach_msg / kevent / uv_async_send, so it is safe to call
-    /// from here and makes the poll return immediately.
+    /// Signal context on POSIX; the console control thread on Windows.
     fn request_abort() {
         SHOULD_ABORT.store(true, Ordering::Release);
         let loop_ = LOOP.load(Ordering::Acquire);
         if !loop_.is_null() {
-            // SAFETY: `install` published the live per-process uws loop, which
-            // outlives the coordinator; the raw extern forms no `&mut Loop`, so
-            // it cannot alias the tick the main thread is inside of.
+            // SAFETY: the loop is process-lifetime, and the raw extern is the
+            // thread-safe entry point (no `&mut Loop` formed off the main thread).
             unsafe { bun_uws::us_wakeup_loop(loop_) };
         }
     }
@@ -992,8 +987,7 @@ pub(crate) mod abort_handler {
         }
     }
 
-    /// `loop_` is the loop `Coordinator::drive` will tick; it must already be
-    /// set up (`EventLoop::ensure_waker`) so the handler has something to wake.
+    /// `loop_` is the loop `Coordinator::drive` ticks (`ensure_waker` already run).
     pub(crate) fn install(loop_: *mut bun_uws::Loop) -> Guard {
         LOOP.store(loop_, Ordering::Release);
         #[cfg(unix)]

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -191,7 +191,13 @@ pub(crate) fn run_as_coordinator(
         windows_job: Coordinator::create_windows_kill_on_close_job(),
     };
 
-    let _abort_guard = abort_handler::install();
+    // SAFETY: event_loop pointer is valid while vm lives.
+    let uws_loop = unsafe {
+        let event_loop = (*vm_ptr).event_loop();
+        (*event_loop).ensure_waker();
+        (*event_loop).usockets_loop()
+    };
+    let _abort_guard = abort_handler::install(uws_loop);
 
     // Patch the Worker→Coordinator backref now that `coord`'s address is fixed.
     // Access workers through `coord.workers` to avoid a second &mut on the Vec.
@@ -209,8 +215,6 @@ pub(crate) fn run_as_coordinator(
         }
     }
 
-    // SAFETY: event_loop pointer is valid while vm lives.
-    unsafe { (*(*vm_ptr).event_loop()).ensure_waker() };
     // SAFETY: see vm_ptr note above.
     unsafe { &*vm_ptr }.run_with_api_lock(|| coord.drive());
     coord.end_group();

--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -1293,6 +1293,7 @@ test.skipIf(isWindows).concurrent.each(["SIGTERM", "SIGINT"] as const)(
     expect(reactedAfterMs).toBeLessThan(500);
     expect(await proc.exited).toBe(130);
   },
+  15000,
 );
 
 test("--parallel --no-isolate: a worker keeps one global and module registry across its files", async () => {

--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isDebug, isWindows, normalizeBunSnapshot, tempDir, tls } from "harness";
+import { readFileSync } from "fs";
+import { bunEnv, bunExe, isASAN, isDebug, isLinux, isWindows, normalizeBunSnapshot, tempDir, tls } from "harness";
 
 test("--parallel: each worker has a unique JEST_WORKER_ID and BUN_TEST_WORKER_ID", async () => {
   // Sleep so worker 0 is busy when workers 1/2 come online and pick up the
@@ -1214,6 +1215,85 @@ test("--parallel: SIGTERM on coordinator kills workers and their grandchildren",
     } catch {}
   expect(outstanding).toEqual([]);
 }, 15000);
+
+// With every worker mid-file, the only thing that wakes the coordinator's poll is
+// its own housekeeping (a burst of timers about once a second). A signal handler
+// that does not wake the poll is therefore acted on at the next burst, 0 to ~1s
+// later, depending on when the signal lands. On Linux, wait for a burst (the main
+// thread's voluntary context switch count moves) and for it to settle, so the
+// signal is sent at the start of the ~1s quiet period and such a coordinator
+// reliably takes ~900ms; one that wakes its poll reacts at once either way.
+async function waitForCoordinatorToPark(pid: number) {
+  const switches = () =>
+    Number(/voluntary_ctxt_switches:\s+(\d+)/.exec(readFileSync(`/proc/${pid}/status`, "utf8"))![1]);
+  const deadline = Date.now() + 3000;
+  const before = switches();
+  while (switches() === before && Date.now() < deadline) await Bun.sleep(1);
+  let last = switches();
+  let quietSince = Date.now();
+  while (Date.now() - quietSince < 100 && Date.now() < deadline) {
+    await Bun.sleep(1);
+    const now = switches();
+    if (now !== last) {
+      last = now;
+      quietSince = Date.now();
+    }
+  }
+}
+
+test.skipIf(isWindows).concurrent.each(["SIGTERM", "SIGINT"] as const)(
+  "--parallel: coordinator acts on %s immediately while every worker is mid-file",
+  async signal => {
+    const fixture = `
+      import { test } from "bun:test";
+      import { appendFileSync } from "fs";
+      test("slow", async () => {
+        appendFileSync(process.env.PIDS, process.pid + "\\n");
+        await Bun.sleep(60000);
+      });
+    `;
+    using dir = tempDir("parallel-abort-latency", { "a.test.ts": fixture, "b.test.ts": fixture });
+    const pids = String(dir) + "/pids.txt";
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--parallel=2", "--parallel-delay=0"],
+      env: { ...bunEnv, PIDS: pids },
+      cwd: String(dir),
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+
+    const workersRunning = () => {
+      try {
+        return readFileSync(pids, "utf8").split("\n").filter(Boolean).length;
+      } catch {
+        return 0;
+      }
+    };
+    while (workersRunning() < 2 && proc.exitCode === null) await Bun.sleep(10);
+    expect(workersRunning()).toBe(2);
+    if (isLinux) await waitForCoordinatorToPark(proc.pid);
+
+    // The "Interrupted" report is the first thing the coordinator does once it
+    // has seen the signal; measure up to that rather than up to exit so process
+    // teardown (slow under ASAN) stays out of the number.
+    const stderr = proc.stderr.getReader();
+    const decoder = new TextDecoder();
+    let seen = "";
+    const start = performance.now();
+    proc.kill(signal);
+    while (!seen.includes("Interrupted")) {
+      const { value, done } = await stderr.read();
+      if (done) break;
+      seen += decoder.decode(value, { stream: true });
+    }
+    const reactedAfterMs = performance.now() - start;
+
+    expect(seen).toContain("Interrupted");
+    expect(reactedAfterMs).toBeLessThan(500);
+    expect(await proc.exited).toBe(130);
+  },
+);
 
 test("--parallel --no-isolate: a worker keeps one global and module registry across its files", async () => {
   const files: Record<string, string> = {


### PR DESCRIPTION
### Problem
- `bun test --parallel` (2+ files, so the process-pool coordinator is in use) takes up to a second to act on Ctrl+C / SIGTERM once every worker is in the middle of a file: measured 950-970 ms from `kill` to exit, 5/5 runs, with the current release build.
- The handler installed by `abort_handler::install` (src/runtime/cli/test/parallel/Coordinator.rs) only stores `SHOULD_ABORT`. `Coordinator::drive` reads the flag between polls, and while it is parked in `auto_tick()` nothing reads it.
- The signal itself does not end the poll either: `bun_epoll_pwait2` / `bun_kevent64_wait` (packages/bun-usockets/src/eventing/epoll_kqueue.c) retry on EINTR for the remaining timeout.
- So the flag is only seen when something else wakes the loop. With workers mid-file there is no I/O; what actually wakes it is the coordinator's housekeeping: the GC repeating timer and the Date header timer (armed because the worker IPC channels are usockets sockets), both on a 1 s period. Hence 0-1 s of latency depending on where in that period the signal lands. The Windows console control handler has the same shape (flag only).

### Fix
- `abort_handler::install` now takes the coordinator's uws loop and publishes it in an `AtomicPtr`; the POSIX signal handler and the Windows control handler set the flag and then call `us_wakeup_loop` on it, so the poll `drive()` is parked in returns at once and the existing flag check runs. `uninstall` clears the pointer.
- `us_wakeup_loop` is an atomic increment plus an `eventfd` write (Linux) / `mach_msg` (macOS) / `kevent` NOTE_TRIGGER (FreeBSD) / `uv_async_send` (Windows): no allocation, no locks, so it is fine in signal context. It is the same primitive `process.on(<signal>)` delivery (`PosixSignalHandle::enqueue`) and every other cross-thread wakeup of this loop already use, called through the raw extern as `HTTPThread::wakeup` and `MiniEventLoop::wakeup` do, so no `&mut Loop` is formed while the main thread is inside the tick.
- No lost-wakeup window: a signal that lands between `drive()`'s flag check and the poll still wakes the poll, because the eventfd / mach port / async is already signalled when the poll is entered (and `pending_wakeups` makes the kqueue path poll non-blocking).
- `ensure_waker()` moves ahead of the handler install in runner.rs, since it is what sets up the loop pointer the handler needs; it used to run a few lines later, before `drive()`.
- Verified: `test/cli/test/parallel.test.ts`, "coordinator acts on SIGTERM/SIGINT immediately while every worker is mid-file". Without the src change it fails with ~901 ms (release) / ~935 ms (debug ASAN); with it the coordinator reports the interruption within a few ms (about 1 ms measured, ~35-65 ms to full exit under ASAN). The existing "SIGTERM on coordinator kills workers and their grandchildren" test still passes.
- Windows, verified by hand since CI cannot synthesize console control events (see the details block): CTRL_BREAK_EVENT aimed at the coordinator's process group, workers keeping themselves alive with a `SIGBREAK` listener. Current canary reports the interruption after 929 / 931 / 530 ms depending on when the event is sent; this branch's debug build after 1 ms in every run.
- The test measures the time until the coordinator's "Interrupted" report rather than until exit so ASAN process teardown stays out of the number, and on Linux it first waits for one housekeeping burst to pass (visible as the coordinator main thread's `voluntary_ctxt_switches` moving, then 100 ms of quiet) so the signal is sent at the start of the quiet period. That turns the unfixed 0-1 s into a reliable ~900 ms instead of a value that passes the assertion some of the time; the fixed coordinator reacts immediately regardless of phase, so the alignment only matters for fail-before. Skipped on Windows, where `proc.kill` is `TerminateProcess` and never reaches the control handler.
- Scope: `bun run --filter` (src/runtime/cli/filter_run.rs) and `bun run --parallel/--sequential` (src/runtime/cli/multi_run.rs) carry their own copies of this flag-only handler and have the same defect in a worse form (their loop has no timers at all, so a SIGINT sent to the parent alone is ignored until a child exits; a terminal Ctrl+C still works there because it also hits the children). Their installers differ on purpose (SIGINT only, SA_RESETHAND so a second Ctrl+C kills immediately during the graceful abort), so this PR stays with the coordinator and the two `bun run` sites are tracked separately rather than folded into a shared module.

### Background
- Coordinator: with `--parallel` and 2+ files, the `bun test` process does not run tests itself; it spawns worker processes, hands them files over an IPC socketpair and streams their results. Its main loop (`Coordinator::drive`) is: check `SHOULD_ABORT`, then block in the event loop (`auto_tick`, i.e. `epoll_pwait2` / `kevent64` / `uv_run` with the next timer deadline as the timeout) until I/O or a timer.
- `us_wakeup_loop`: usockets' cross-thread "make the loop's poll return" primitive. Every loop owns a wakeup async (an eventfd on Linux, a mach port on macOS, an EVFILT_USER on FreeBSD, a `uv_async_t` on Windows) registered in its poll set; signalling it makes the blocked poll return, after which the caller's own loop logic runs again.
- Housekeeping timers: the GC controller re-arms a timer every 1 s (30 s once the heap has been idle for 30 ticks), and the Date header timer re-arms every 1 s while any usockets socket is linked to the loop. Neither has anything to do with signals; they are just what happened to bound the latency before.

<details>
<summary>Measurements</summary>

Release 1.4.0 canary, coordinator + 2 workers parked in `Bun.sleep(60000)`, time from `proc.kill` to exit:

```
SIGTERM: exited 130 after 966ms / 950ms / 972ms
SIGINT:  exited 130 after 966ms / 968ms
BUN_GC_TIMER_INTERVAL=100:            59ms   (GC timer period now bounds it)
BUN_GC_TIMER_INTERVAL=4000:          962ms   (Date header timer still does)
BUN_GC_TIMER_DISABLE=1, 4s in:       937ms
```

Coordinator main-thread wakeups sampled via `/proc/<pid>/status` while parked (release build): one burst at +974 ms, +1975 ms, +2976 ms, nothing in between. gdb on the debug build shows the timers firing in those bursts are `DateHeaderTimer` and `GcRepeating`.

Fixed debug ASAN build, time to first stderr byte ("Interrupted ...") vs exit: 0.4 / 1.0 / 0.8 ms and 40 / 35 / 65 ms. Under a 2x CPU oversubscription the exit figure went up to 350 ms, which is why the test measures the report and not the exit.

Windows (Server 2019 x64). A Python driver starts the coordinator with `CREATE_NEW_PROCESS_GROUP`, waits for both workers to be inside their test (each test file does `process.on("SIGBREAK", () => {})` so the workers, which share the group, survive the event), sends `CTRL_BREAK_EVENT` to the group and times the first stderr byte and the exit:

```
canary bun 1.4.0:          report after 929ms, exit 130 after 935ms
                           report after 931ms, exit 130 after 936ms
  (sent 400ms later)       report after 530ms, exit 130 after 535ms
this branch, debug build:  report after 1ms, exit 130 after 14ms   (x4, including runs sent 400ms and 700ms later)
```
</details>

