### PR TITLE
node:tls: honor setServername() called before connect()

### DIFF
--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -694,6 +694,10 @@ const ksecureContext = Symbol("ksecureContext");
 const ksharedCredsOptions = Symbol("ksharedCredsOptions");
 const kcheckServerIdentity = Symbol("kcheckServerIdentity");
 const ksession = Symbol("ksession");
+// The name passed to setServername(). Kept separately from `servername`
+// because Socket.prototype.connect resets `servername` from its own options on
+// every connect(), which would drop a name set while the socket had no handle.
+const kservername = Symbol("kservername");
 const krenegotiationDisabled = Symbol("renegotiationDisabled");
 
 const buntls = Symbol.for("::buntls::");
@@ -708,6 +712,7 @@ function TLSSocket(socket?, options?) {
   this.ALPNProtocols = undefined;
   this[kcheckServerIdentity] = undefined;
   this[ksession] = undefined;
+  this[kservername] = undefined;
   this.alpnProtocol = null;
   this._secureEstablished = false;
   this._rejectUnauthorized = false;
@@ -1034,7 +1039,7 @@ TLSSocket.prototype.setServername = function setServername(name) {
   if (this.isServer) {
     throw $ERR_TLS_SNI_FROM_SERVER();
   }
-  // if the socket is detached we can't set the servername but we set this property so when open will auto set to it
+  this[kservername] = name;
   this.servername = name;
   this._handle?.setServername?.(name);
 };
@@ -1113,7 +1118,10 @@ TLSSocket.prototype[buntls] = function (port, host) {
   // RFC 6066 forbids IP literals in SNI. Match Node.js: only default servername to host
   // when host is not an IP. For IP hosts, pass "" so the native layer skips SNI instead of
   // falling back to the connection host.
-  let servername = this.servername || ctx?.servername;
+  // `servername` is whatever the current connect() chose so far (its
+  // options.servername, or the name a previous call of this function returned);
+  // a setServername() name applies when it chose nothing.
+  let servername = this.servername || this[kservername] || ctx?.servername;
   if (servername === undefined) {
     servername = host && !net.isIP(host) ? host : "";
   }

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1426,3 +1426,109 @@ describe("throwing 'secureConnect' listener", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+describe.concurrent("setServername() before connect()", () => {
+  // A client TLSSocket in node owns its handle from construction, so a name set
+  // with setServername() before connect() is the SNI of the handshake and is
+  // what socket.servername reports once the handshake is done (node v26.3.0).
+  // Socket.prototype.connect used to reset servername from its own options and
+  // the name was lost on every connect form below.
+  const NAME = "set.before.connect";
+
+  // The server records the SNI of every connection it accepts, then hangs up.
+  async function listen(seen: unknown[]) {
+    const server = tls.createServer(COMMON_CERT_, socket => {
+      seen.push(socket.servername);
+      socket.end();
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    return server;
+  }
+
+  function client() {
+    return new TLSSocket(undefined as any, { rejectUnauthorized: false });
+  }
+
+  // Resolves with the client's servername once the server has hung up, i.e.
+  // after its connection listener recorded what the client sent.
+  async function handshake(socket: TLSSocket) {
+    await once(socket, "secureConnect");
+    const { servername } = socket;
+    await once(socket, "close");
+    return servername;
+  }
+
+  it("is sent on a host/port connect and kept in socket.servername", async () => {
+    const seen: unknown[] = [];
+    await using server = await listen(seen);
+    const socket = client();
+    socket.setServername(NAME);
+    socket.connect((server.address() as AddressInfo).port, "127.0.0.1");
+    expect({ client: await handshake(socket), server: seen }).toEqual({ client: NAME, server: [NAME] });
+  });
+
+  it("is sent on an autoSelectFamily connect instead of the name derived from the host", async () => {
+    const seen: unknown[] = [];
+    await using server = await listen(seen);
+    const socket = client();
+    socket.setServername(NAME);
+    socket.connect({
+      port: (server.address() as AddressInfo).port,
+      host: "derived.from.host",
+      autoSelectFamily: true,
+      // Two candidates put the connect on the per-address attempt path; the
+      // first candidate is the server, so the second is never tried.
+      lookup: (_host, _opts, cb) =>
+        cb(null, [
+          { address: "127.0.0.1", family: 4 },
+          { address: "::1", family: 6 },
+        ]),
+    } as any);
+    expect({ client: await handshake(socket), server: seen }).toEqual({ client: NAME, server: [NAME] });
+  });
+
+  it("is sent when connect() upgrades an existing net.Socket", async () => {
+    const seen: unknown[] = [];
+    await using server = await listen(seen);
+    const raw = net.connect((server.address() as AddressInfo).port, "127.0.0.1");
+    await once(raw, "connect");
+    const socket = client();
+    socket.setServername(NAME);
+    socket.connect({ socket: raw } as any);
+    expect({ client: await handshake(socket), server: seen }).toEqual({ client: NAME, server: [NAME] });
+  });
+
+  it("yields to a servername passed to connect() itself", async () => {
+    const seen: unknown[] = [];
+    await using server = await listen(seen);
+    const socket = client();
+    socket.setServername(NAME);
+    socket.connect({
+      port: (server.address() as AddressInfo).port,
+      host: "127.0.0.1",
+      servername: "from.connect.options",
+    } as any);
+    expect({ client: await handshake(socket), server: seen }).toEqual({
+      client: "from.connect.options",
+      server: ["from.connect.options"],
+    });
+  });
+
+  it("does not make a name derived from one host stick to a reconnect to another", async () => {
+    // Only setServername() survives across connects; the host-derived default
+    // is recomputed for each connect.
+    const seen: unknown[] = [];
+    await using server = await listen(seen);
+    const { port } = server.address() as AddressInfo;
+    const lookup = (_host, _opts, cb) => cb(null, "127.0.0.1", 4);
+    const socket = client();
+    socket.connect({ port, host: "first.test", lookup, autoSelectFamily: false } as any);
+    const first = await handshake(socket);
+    socket.connect({ port, host: "second.test", lookup, autoSelectFamily: false } as any);
+    const second = await handshake(socket);
+    expect({ client: [first, second], server: seen }).toEqual({
+      client: ["first.test", "second.test"],
+      server: ["first.test", "second.test"],
+    });
+  });
+});


### PR DESCRIPTION
### Problem
- `setServername(name)` on a client `tls.TLSSocket` that is not connected yet has no effect: the handshake carries no SNI and `socket.servername` is `""` afterwards. Node v26.3.0 sends `name` and reports it as `socket.servername` once the handshake is done.
- `TLSSocket.prototype.setServername` (src/js/node/tls.ts:1032) has no handle to apply the name to at that point, so all it can do is store it in `this.servername`.
- `Socket.prototype.connect` (src/js/node/net.ts:1905) begins with `this.servername = options.servername` (`undefined` unless the caller passed one) and only then calls `TLSSocket.prototype[buntls]` (tls.ts:1111), which reads `this.servername` to build the native connect options. The stored name is gone by then and `[buntls]` falls back to the secure context's servername or the host-derived default.
- Every connect form loses it (host/port, `autoSelectFamily`, `connect({ socket })`). `tls.connect({ servername })` is unaffected because it passes the name through the connect options.

### Fix
- `setServername()` also records the name in a per-socket slot (`kservername`, the counterpart of the `ksession` slot `setSession()` uses), and `[buntls]` reads that slot when `this.servername` is empty, ahead of the secure context's servername and the host-derived default. net.ts is unchanged.
- Why a second slot rather than not resetting `this.servername`: `this.servername` is also the working value of the connect() in progress. net.ts:1905 seeds it from the options, net.ts:1962 stores the name `[buntls]` picked (possibly derived from the host), and `internalConnect` calls `[buntls]` again and must get the same answer. It therefore has to be reset on every connect(), otherwise a name derived from one host would be sent on a reconnect to a different host. The name the caller set explicitly is the one thing that should outlive that reset, so it gets its own field.
- Precedence is unchanged, the most recent instruction wins: a `servername` given to `connect()` itself is the later call and still takes priority (net.ts:1905 puts it in `this.servername`), and a `setServername()` made after `tls.connect()` returned still overrides the options as before, since it writes both fields. (Node's `net.Socket#connect` ignores a `servername` option entirely; honoring it is bun's own extension, which bun's `tls.connect()` is built on.)
- `socket.servername` ends up as the set name through the existing net.ts:1962 assignment, which is what Node reports from `getServername()` after the handshake.
- Tests: `test/js/node/tls/node-tls-connect.test.ts`, `describe("setServername() before connect()")`. A local server records the SNI of each connection and the client reports `socket.servername`. Three cases fail without the fix: host/port connect and `connect({ socket })` (received `""` on the client and no SNI on the server) and an `autoSelectFamily` connect, which goes through the per-address attempt path and used to send the host-derived name. Two controls pass before and after and pin the constraints above: a `servername` in the connect options takes precedence, and a host-derived name is recomputed on a reconnect to another host.
- Also run with the fix: the rest of `test/js/node/tls` (its two failures, `node-tls-server.test.ts` "SNICallback runs even when the requested servername matches the bind hostname" and `node-tls-root-certs-concurrent-init.test.ts`, fail identically without this change in this environment: localhost resolution, and a 5s timeout under the debug build), plus 23 vendored node tests (`test-tls-sni-*`, `test-tls-error-servername`, `test-tls-ip-servername-forbidden`, `test-https-agent-servername`, `test-tls-connect-*`, `test-tls-client-resume*`, `test-tls-socket-*`, `test-http2-connect*`), all passing. The script from the report prints the same as node.

### Background
- SNI (server name indication) is the host name a TLS client puts in its ClientHello so that a server holding several certificates can pick one. `tls.Server` exposes the received name as `socket.servername` in its connection listener, which is how the tests observe what the client sent.
- In bun a client `TLSSocket` gets its native handle only when `connect()` runs. `Socket.prototype.connect` (net.ts) calls the `[buntls]` method `TLSSocket` defines (tls.ts) to turn the socket's TLS state (secure context, ALPN, session, servername, ...) into the options object handed to the native connect or upgrade. Node's client `TLSSocket` creates its handle in the constructor instead, so `setServername()` there applies to the SSL object on the spot and nothing needs to be carried over to connect time.
- `ksession` is the existing per-socket slot that `setSession()` and the constructor store the TLS session in; `[buntls]` copies it into the options the same way it now consults `kservername`.

<details>
<summary>Repro (from the report) before and after</summary>

```js
const tls = require("node:tls");
const server = tls.createServer({ cert, key }, s => { console.log("server saw:", s.servername); s.end(); });
server.listen(0, "127.0.0.1", () => {
  const t = new tls.TLSSocket(undefined, { rejectUnauthorized: false });
  t.setServername("set.before.connect");
  t.connect(server.address().port, "127.0.0.1");
  t.on("secure", () => console.log("client:", JSON.stringify(t.servername)));
  t.on("close", () => server.close());
});
```

```
node v26.3.0:   server saw: set.before.connect   client: "set.before.connect"
bun (main):     server saw: undefined            client: ""
bun (this PR):  server saw: set.before.connect   client: "set.before.connect"
```
</details>
