### PR TITLE
test(ffi): speed up ffi.test.js and tighten its assertions

### DIFF
--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -29,48 +29,24 @@ try {
 }
 
 it("ffi print", async () => {
-  await Bun.write(
-    import.meta.dir + "/ffi.test.fixture.callback.c",
-    viewSource(
-      {
-        returns: "bool",
-        args: ["ptr"],
-      },
-      true,
-    ),
-  );
-  await Bun.write(
-    import.meta.dir + "/ffi.test.fixture.receiver.c",
-    viewSource(
-      {
-        not_a_callback: {
-          returns: "float",
-          args: ["float"],
-        },
-      },
-      false,
-    )[0],
-  );
-  expect(
-    viewSource(
-      {
-        returns: "int8_t",
-        args: [],
-      },
-      true,
-    ).length > 0,
-  ).toBe(true);
-  expect(
-    viewSource(
-      {
-        a: {
-          returns: "int8_t",
-          args: [],
-        },
-      },
-      false,
-    ).length > 0,
-  ).toBe(true);
+  const callbackSource = viewSource({ returns: "bool", args: ["ptr"] }, true);
+  const [receiverSource] = viewSource({ not_a_callback: { returns: "float", args: ["float"] } }, false);
+  await Bun.write(import.meta.dir + "/ffi.test.fixture.callback.c", callbackSource);
+  await Bun.write(import.meta.dir + "/ffi.test.fixture.receiver.c", receiverSource);
+
+  // Callbacks are compiled by the engine, so their "source" is a fixed notice regardless of signature.
+  expect(callbackSource).toBeString();
+  expect(viewSource({ returns: "int8_t", args: [] }, true)).toBe(callbackSource);
+
+  expect(receiverSource).toContain("#define HAS_ARGUMENTS");
+  expect(receiverSource).toContain("#define USES_FLOAT 1");
+  expect(receiverSource).toContain("float not_a_callback(float arg0);");
+  expect(receiverSource).toContain("JSVALUE_TO_FLOAT(arg0)");
+
+  const receivers = viewSource({ a: { returns: "int8_t", args: [] } }, false);
+  expect(receivers).toHaveLength(1);
+  expect(receivers[0]).toContain("int8_t a();");
+  expect(receivers[0]).not.toContain("#define HAS_ARGUMENTS");
 });
 
 function getTypes(fast) {
@@ -485,8 +461,8 @@ function ffiRunner(fast) {
       Bun.gc(true);
       expect(is_null(null)).toBe(true);
       const cptr = ptr_should_point_to_42_as_int32_t();
-      expect(cptr != 0).toBe(true);
-      expect(typeof cptr === "number").toBe(true);
+      expect(typeof cptr).toBe("number");
+      expect(cptr).toBeGreaterThan(0);
       expect(does_pointer_equal_42_as_int32_t(cptr)).toBe(true);
       {
         // No finalizer: both views borrow `cptr` (static storage in the fixture),
@@ -538,95 +514,168 @@ function ffiRunner(fast) {
           args: ["bool"],
         },
       );
-      expect(toClose.ptr > 0).toBe(true);
+      expect(typeof toClose.ptr).toBe("number");
+      expect(toClose.ptr).toBeGreaterThan(0);
       toClose.close();
-      expect(toClose.ptr === null).toBe(true);
+      expect(toClose.ptr).toBeNull();
     });
 
     describe("callbacks", () => {
       // Return types, 1 argument
       for (let [returnName, returnValue] of Object.entries(typeMap)) {
         it("fn(" + returnName + ") " + returnName, () => {
-          var roundtripFunction = new CFunction({
-            ptr: new JSCallback(
-              input => {
-                return input;
-              },
-              {
-                returns: returnName,
-                args: [returnName],
-              },
-            ).ptr,
-            returns: returnName,
-            args: [returnName],
-          });
-          expect(roundtripFunction(returnValue)).toBe(returnValue);
+          const callback = new JSCallback(input => input, { returns: returnName, args: [returnName] });
+          try {
+            const roundtripFunction = new CFunction({ ptr: callback.ptr, returns: returnName, args: [returnName] });
+            expect(roundtripFunction(returnValue)).toBe(returnValue);
+          } finally {
+            callback.close();
+          }
         });
       }
       // Return types, no args
       for (let [name, value] of Object.entries(typeMap)) {
         it("fn() " + name, () => {
-          var roundtripFunction = new CFunction({
-            ptr: new JSCallback(() => value, {
-              returns: name,
-            }).ptr,
-            returns: name,
-          });
-          expect(roundtripFunction()).toBe(value);
+          const callback = new JSCallback(() => value, { returns: name });
+          try {
+            const roundtripFunction = new CFunction({ ptr: callback.ptr, returns: name });
+            expect(roundtripFunction()).toBe(value);
+          } finally {
+            callback.close();
+          }
         });
       }
     });
 
-    describe("threadsafe callback", done => {
-      // 1 arg, threadsafe
+    describe("threadsafe callback", () => {
       for (let [name, value] of Object.entries(typeMap)) {
         it("fn(" + name + ") " + name, async () => {
-          const cb = new JSCallback(
-            arg1 => {
-              expect(arg1).toBe(value);
-            },
-            {
-              args: [name],
-              threadsafe: true,
-            },
-          );
-          var roundtripFunction = new CFunction({
-            ptr: cb.ptr,
-            returns: "void",
-            args: [name],
-          });
-          roundtripFunction(value);
-          await 1;
+          const { promise, resolve } = Promise.withResolvers();
+          const callback = new JSCallback(resolve, { args: [name], threadsafe: true });
+          try {
+            expect(callback.threadsafe).toBe(true);
+            const fire = new CFunction({ ptr: callback.ptr, returns: "void", args: [name] });
+            expect(fire(value)).toBeUndefined();
+            // A threadsafe callback is queued on the owning event loop, never run inside the native call.
+            expect(Bun.peek.status(promise)).toBe("pending");
+            expect(await promise).toBe(value);
+          } finally {
+            callback.close();
+          }
         });
       }
     });
 
-    describe("integer identities work for all possible values", () => {
+    it("C code calls back into JS callbacks of every return type", () => {
+      const big = v => (fast ? v : BigInt(v));
+      const cases = {
+        cb_identity_true: [cb_identity_true, "bool", true, true],
+        cb_identity_false: [cb_identity_false, "bool", false, false],
+        cb_identity_42_char: [cb_identity_42_char, "char", 42, 42],
+        cb_identity_42_float: [cb_identity_42_float, "float", 42.5, 42.5],
+        cb_identity_42_double: [cb_identity_42_double, "double", 42.42, 42.42],
+        cb_identity_42_uint8_t: [cb_identity_42_uint8_t, "uint8_t", 42, 42],
+        cb_identity_neg_42_int8_t: [cb_identity_neg_42_int8_t, "int8_t", -42, -42],
+        cb_identity_42_uint16_t: [cb_identity_42_uint16_t, "uint16_t", 42, 42],
+        cb_identity_42_uint32_t: [cb_identity_42_uint32_t, "uint32_t", 42, 42],
+        cb_identity_42_uint64_t: [cb_identity_42_uint64_t, "uint64_t", 42n, big(42)],
+        cb_identity_neg_42_int16_t: [cb_identity_neg_42_int16_t, "int16_t", -42, -42],
+        cb_identity_neg_42_int32_t: [cb_identity_neg_42_int32_t, "int32_t", -42, -42],
+        cb_identity_neg_42_int64_t: [cb_identity_neg_42_int64_t, "int64_t", -42n, big(-42)],
+      };
+      const callbacks = [];
+      try {
+        const results = {};
+        const expected = {};
+        for (const [name, [cFunction, returns, jsReturnValue, expectedResult]] of Object.entries(cases)) {
+          const callback = new JSCallback(() => jsReturnValue, { returns, args: [] });
+          callbacks.push(callback);
+          results[name] = cFunction(callback.ptr);
+          expected[name] = expectedResult;
+        }
+        expect(results).toEqual(expected);
+      } finally {
+        for (const callback of callbacks) callback.close();
+      }
+    });
+
+    // The 8-bit types are checked exhaustively. A stride through a wider range mostly re-proves the
+    // same conversion, so the wider types check the values a conversion can actually get wrong:
+    // both ends of the range, 0 and +-1, every power of two in range with its neighbours (negated
+    // too for signed types), alternating bit patterns, plus a 16-step stride. The values are then
+    // cycled through a loop so the call site is also exercised after it has left the interpreter.
+    describe("integer identities at every width and sign boundary", () => {
       const cases = [
-        { type: "int8_t", min: -128, max: 127, fn: identity_int8_t },
-        { type: "int16_t", min: -32768, max: 32767, fn: identity_int16_t },
-        { type: "int32_t", min: -2147483648, max: 2147483647, fn: identity_int32_t },
-        { type: "int64_t", min: -9223372036854775808n, max: 9223372036854775807n, fn: identity_int64_t },
-        { type: "uint8_t", min: 0, max: 255, fn: identity_uint8_t },
-        { type: "uint16_t", min: 0, max: 65535, fn: identity_uint16_t },
-        { type: "uint32_t", min: 0, max: 4294967295, fn: identity_uint32_t },
-        { type: "uint64_t", min: 0n, max: 18446744073709551615n, fn: identity_uint64_t },
+        { type: "int8_t", bits: 8, signed: true, fn: identity_int8_t },
+        { type: "int16_t", bits: 16, signed: true, fn: identity_int16_t },
+        { type: "int32_t", bits: 32, signed: true, fn: identity_int32_t },
+        { type: "int64_t", bits: 64, signed: true, fn: identity_int64_t },
+        { type: "uint8_t", bits: 8, signed: false, fn: identity_uint8_t },
+        { type: "uint16_t", bits: 16, signed: false, fn: identity_uint16_t },
+        { type: "uint32_t", bits: 32, signed: false, fn: identity_uint32_t },
+        { type: "uint64_t", bits: 64, signed: false, fn: identity_uint64_t },
       ];
 
-      for (const { type, min, max, fn } of cases) {
-        const bigint = typeof min === "bigint";
-        const inc = bigint
-          ? //
-            (max - min) / 32768n
-          : Math.ceil((max - min) / 32768);
-        it(type, () => {
-          expect(bigint ? BigInt(fn(min)) : fn(min)).toBe(min);
-          expect(bigint ? BigInt(fn(max)) : fn(max)).toBe(max);
-          expect(bigint ? BigInt(fn(0n)) : fn(0)).toBe(bigint ? 0n : 0);
+      function valuesFor(bits, signed) {
+        const min = signed ? -(1n << BigInt(bits - 1)) : 0n;
+        const max = (signed ? 1n << BigInt(bits - 1) : 1n << BigInt(bits)) - 1n;
+        if (bits === 8) return Array.from({ length: 256 }, (_, i) => min + BigInt(i));
+        const values = new Set([min, min + 1n, -1n, 0n, 1n, max - 1n, max]);
+        for (let bit = 0; bit < bits; bit++) {
+          const power = 1n << BigInt(bit);
+          for (const v of [power - 1n, power, power + 1n, -power - 1n, -power, -power + 1n]) values.add(v);
+        }
+        for (const pattern of [0x5555_5555_5555_5555n, 0xaaaa_aaaa_aaaa_aaaan]) {
+          values.add(pattern & max);
+          values.add(-(pattern & max));
+        }
+        const stride = (max - min) / 16n;
+        for (let v = min; v <= max; v += stride) values.add(v);
+        return [...values].filter(v => v >= min && v <= max).sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+      }
 
-          for (let i = min; i <= max; i += inc) {
-            expect(bigint ? BigInt(fn(i)) : fn(i)).toBe(i);
+      for (const { type, bits, signed, fn } of cases) {
+        it(type, () => {
+          const is64 = bits === 64;
+          // Below 64 bits the values are plain numbers; i64/u64 take BigInts. The i64_fast/u64_fast
+          // variants return a number when the value is small enough, so normalize through BigInt().
+          const inputs = is64 ? valuesFor(bits, signed) : valuesFor(bits, signed).map(Number);
+          const normalize = is64 && fast ? BigInt : v => v;
+          expect(inputs.map(v => normalize(fn(v)))).toEqual(inputs);
+
+          const mismatches = [];
+          for (let i = 0; i < 10_000; i++) {
+            const input = inputs[i % inputs.length];
+            const output = normalize(fn(input));
+            if (output !== input && mismatches.length < 8) mismatches.push({ iteration: i, input, output });
           }
+          expect(mismatches).toEqual([]);
+        });
+      }
+
+      if (fast) {
+        it("i64_fast / u64_fast return a number for safe integers and a BigInt beyond them", () => {
+          const safe = 2n ** 53n - 2n;
+          const unsafe = 2n ** 53n;
+          expect([
+            identity_int64_t(safe),
+            identity_int64_t(-safe),
+            identity_uint64_t(safe),
+            identity_int64_t(unsafe),
+            identity_int64_t(-unsafe),
+            identity_uint64_t(unsafe),
+            identity_uint64_t(2n ** 64n - 1n),
+            identity_int64_t(-(2n ** 63n)),
+          ]).toEqual([
+            Number(safe),
+            -Number(safe),
+            Number(safe),
+            unsafe,
+            -unsafe,
+            unsafe,
+            2n ** 64n - 1n,
+            -(2n ** 63n),
+          ]);
         });
       }
     });
@@ -683,7 +732,12 @@ it("dlopen throws an error instead of returning it", () => {
   } catch (error) {
     err = error;
   }
-  expect(err).toBeTruthy();
+  expect(err).toBeInstanceOf(Error);
+  expect({ code: err.code, syscall: err.syscall, message: err.message }).toEqual({
+    code: "ERR_DLOPEN_FAILED",
+    syscall: "dlopen",
+    message: expect.stringContaining('Failed to open library "nonexistent"'),
+  });
 });
 
 // Windows: dlopen must accept paths with non-ASCII characters. Previously the
@@ -894,7 +948,12 @@ describe("CFunction", () => {
 
 // Runs in a subprocess: `bun test`'s exit path does not finalize the CFunction's native handle,
 // which the ASan lane's leak checker then reports against this file.
-it("JSCallback exceptions propagate out of the native call", async () => {
+//
+// This test and the ones after it through the toBuffer block are declared back to back and marked
+// concurrent, so bun:test runs them as one batch. The subprocess tests spend their time waiting on a
+// child process; the one in-process test among them (the explicit finalizer) is the only user of the
+// fixture state it reads.
+it.concurrent("JSCallback exceptions propagate out of the native call", async () => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
@@ -928,7 +987,7 @@ it("JSCallback exceptions propagate out of the native call", async () => {
   });
 });
 
-it("worker teardown drops queued threadsafe JSCallback invocations without crashing", async () => {
+it.concurrent("worker teardown drops queued threadsafe JSCallback invocations without crashing", async () => {
   using dir = tempDir("ffi-jscallback-terminate-queued", {
     "main.js": `
       import { join } from "node:path";
@@ -987,7 +1046,7 @@ it("worker teardown drops queued threadsafe JSCallback invocations without crash
 // worker.terminate() delivered inside a threadsafe JSCallback used to trip
 // "ASSERTION FAILED: !isTerminationException(exception) || hasTerminationRequest()"
 // in JSC::VM::setException on the worker thread and re-enter the terminated VM.
-it("JSCallback tolerates worker.terminate() arriving inside the callback", async () => {
+it.concurrent("JSCallback tolerates worker.terminate() arriving inside the callback", async () => {
   using dir = tempDir("ffi-jscallback-terminate", {
     "main.js": `
       import { join } from "node:path";
@@ -1058,6 +1117,110 @@ it("JSCallback tolerates worker.terminate() arriving inside the callback", async
     exitCode: 0,
     signalCode: null,
   });
+});
+
+// oven-sh/bun#35405: toBuffer without a finalizer used to mi_free caller-owned
+// memory on GC. Subprocess because unpatched builds crash.
+describe("toBuffer borrowed-pointer ownership (no bad-free on GC)", () => {
+  async function runsClean(script) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  const gcLoop = `for (let i = 0; i < 20; i++) { Bun.gc(true); Buffer.alloc(1024 * 1024); }`;
+
+  // Drops the borrowed view first, then the owner, so an invalid free shows up as
+  // corrupted caller memory rather than only as a crash.
+  const originalSurvives = (index, expected) => `
+      adopted = null;
+      ${gcLoop}
+      if (original[${index}] !== ${expected}) throw new Error("caller memory corrupted after adopted GC: " + original[${index}]);
+      original[${index}] = 0x55;
+      if (original[${index}] !== 0x55) throw new Error("caller memory not writable after adopted GC");
+      original = null;
+      ${gcLoop}
+  `;
+
+  it.concurrent("toBuffer(ptr(buffer)) does not free caller-owned memory on GC", async () => {
+    expect(
+      await runsClean(`
+      import { ptr, toBuffer } from "bun:ffi";
+      let original = Buffer.alloc(64, 0x41);
+      let adopted = toBuffer(ptr(original), 0, 64);
+      if (adopted[0] !== 0x41) throw new Error("expected a zero-copy view");
+      adopted[0] = 0x42;
+      if (original[0] !== 0x42) throw new Error("expected an aliasing view");
+      ${originalSurvives(0, "0x42")}
+      console.log("survived-gc");
+    `),
+    ).toEqual({ stdout: "survived-gc\n", stderr: "", exitCode: 0 });
+  });
+
+  it.concurrent("toBuffer(ptr(buffer), offset) does not free an interior pointer on GC", async () => {
+    expect(
+      await runsClean(`
+      import { ptr, toBuffer } from "bun:ffi";
+      let original = Buffer.alloc(64, 0x41);
+      let adopted = toBuffer(ptr(original), 8, 48);
+      if (adopted[0] !== 0x41) throw new Error("expected a zero-copy view");
+      adopted[0] = 0x42;
+      if (original[8] !== 0x42) throw new Error("expected a view aliasing original[8]");
+      ${originalSurvives(8, "0x42")}
+      console.log("survived-gc");
+    `),
+    ).toEqual({ stdout: "survived-gc\n", stderr: "", exitCode: 0 });
+  });
+
+  it.concurrent("toBuffer(ptr(typedArray)) does not free caller-owned memory on GC", async () => {
+    expect(
+      await runsClean(`
+      import { ptr, toBuffer } from "bun:ffi";
+      let original = new Uint8Array(64).fill(0x41);
+      let adopted = toBuffer(ptr(original), 0, 64);
+      if (adopted[0] !== 0x41) throw new Error("expected a zero-copy view");
+      adopted[0] = 0x42;
+      if (original[0] !== 0x42) throw new Error("expected an aliasing view");
+      ${originalSurvives(0, "0x42")}
+      console.log("survived-gc");
+    `),
+    ).toEqual({ stdout: "survived-gc\n", stderr: "", exitCode: 0 });
+  });
+
+  // Regression guard: an explicit finalizer still controls disposal and runs exactly
+  // once on GC. getDeallocatorBuffer/getDeallocatorCallback each reset the counter.
+  it.concurrent.skipIf(!FFI_FIXTURE_PATH)(
+    "toBuffer with an explicit finalizer calls the deallocator exactly once on GC",
+    async () => {
+      const {
+        symbols: { getDeallocatorCallback, getDeallocatorBuffer, getDeallocatorCalledCount },
+      } = dlopen(FFI_FIXTURE_PATH, {
+        getDeallocatorCallback: { args: [], returns: "ptr" },
+        getDeallocatorBuffer: { args: [], returns: "ptr" },
+        getDeallocatorCalledCount: { args: [], returns: "int" },
+      });
+      (() => {
+        const bufPtr = getDeallocatorBuffer();
+        let buf = toBuffer(bufPtr, 0, 128, getDeallocatorCallback());
+        expect(buf.length).toBe(128);
+        expect(getDeallocatorCalledCount()).toBe(0);
+        buf = null;
+      })();
+      for (let i = 0; i < 100 && getDeallocatorCalledCount() === 0; i++) {
+        Bun.gc(true);
+        Buffer.alloc(1024 * 1024);
+        await Bun.sleep(0);
+      }
+      expect(getDeallocatorCalledCount()).toBe(1);
+      Bun.gc(true);
+      expect(getDeallocatorCalledCount()).toBe(1);
+    },
+  );
 });
 
 const libPath =
@@ -1347,115 +1510,11 @@ describe.if(!!libPath)("can open more than 63 symbols via", () => {
     it(description, () => {
       const libPath = libFn();
       const lib = dlopen(libPath, libSymbols);
-      expect(Object.keys(lib.symbols).length).toBe(Object.keys(libSymbols).length);
+      expect(Object.keys(lib.symbols).sort()).toEqual(Object.keys(libSymbols).sort());
       expect(lib.symbols.strcasecmp(Buffer.from("ciro\0"), Buffer.from("CIRO\0"))).toBe(0);
       expect(lib.symbols.strlen(Buffer.from("bunbun\0", "ascii"))).toBe(6n);
     });
   }
-});
-
-// oven-sh/bun#35405: toBuffer without a finalizer used to mi_free caller-owned
-// memory on GC. Subprocess because unpatched builds crash.
-describe("toBuffer borrowed-pointer ownership (no bad-free on GC)", () => {
-  async function runsClean(script) {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", script],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    return { stdout, stderr, exitCode };
-  }
-
-  const gcLoop = `for (let i = 0; i < 20; i++) { Bun.gc(true); Buffer.alloc(1024 * 1024); }`;
-
-  // Drops the borrowed view first, then the owner, so an invalid free shows up as
-  // corrupted caller memory rather than only as a crash.
-  const originalSurvives = (index, expected) => `
-      adopted = null;
-      ${gcLoop}
-      if (original[${index}] !== ${expected}) throw new Error("caller memory corrupted after adopted GC: " + original[${index}]);
-      original[${index}] = 0x55;
-      if (original[${index}] !== 0x55) throw new Error("caller memory not writable after adopted GC");
-      original = null;
-      ${gcLoop}
-  `;
-
-  it.concurrent("toBuffer(ptr(buffer)) does not free caller-owned memory on GC", async () => {
-    expect(
-      await runsClean(`
-      import { ptr, toBuffer } from "bun:ffi";
-      let original = Buffer.alloc(64, 0x41);
-      let adopted = toBuffer(ptr(original), 0, 64);
-      if (adopted[0] !== 0x41) throw new Error("expected a zero-copy view");
-      adopted[0] = 0x42;
-      if (original[0] !== 0x42) throw new Error("expected an aliasing view");
-      ${originalSurvives(0, "0x42")}
-      console.log("survived-gc");
-    `),
-    ).toEqual({ stdout: "survived-gc\n", stderr: "", exitCode: 0 });
-  });
-
-  it.concurrent("toBuffer(ptr(buffer), offset) does not free an interior pointer on GC", async () => {
-    expect(
-      await runsClean(`
-      import { ptr, toBuffer } from "bun:ffi";
-      let original = Buffer.alloc(64, 0x41);
-      let adopted = toBuffer(ptr(original), 8, 48);
-      if (adopted[0] !== 0x41) throw new Error("expected a zero-copy view");
-      adopted[0] = 0x42;
-      if (original[8] !== 0x42) throw new Error("expected a view aliasing original[8]");
-      ${originalSurvives(8, "0x42")}
-      console.log("survived-gc");
-    `),
-    ).toEqual({ stdout: "survived-gc\n", stderr: "", exitCode: 0 });
-  });
-
-  it.concurrent("toBuffer(ptr(typedArray)) does not free caller-owned memory on GC", async () => {
-    expect(
-      await runsClean(`
-      import { ptr, toBuffer } from "bun:ffi";
-      let original = new Uint8Array(64).fill(0x41);
-      let adopted = toBuffer(ptr(original), 0, 64);
-      if (adopted[0] !== 0x41) throw new Error("expected a zero-copy view");
-      adopted[0] = 0x42;
-      if (original[0] !== 0x42) throw new Error("expected an aliasing view");
-      ${originalSurvives(0, "0x42")}
-      console.log("survived-gc");
-    `),
-    ).toEqual({ stdout: "survived-gc\n", stderr: "", exitCode: 0 });
-  });
-
-  // Regression guard: an explicit finalizer still controls disposal and runs exactly
-  // once on GC. getDeallocatorBuffer/getDeallocatorCallback each reset the counter.
-  it.skipIf(!FFI_FIXTURE_PATH)(
-    "toBuffer with an explicit finalizer calls the deallocator exactly once on GC",
-    async () => {
-      const {
-        symbols: { getDeallocatorCallback, getDeallocatorBuffer, getDeallocatorCalledCount },
-      } = dlopen(FFI_FIXTURE_PATH, {
-        getDeallocatorCallback: { args: [], returns: "ptr" },
-        getDeallocatorBuffer: { args: [], returns: "ptr" },
-        getDeallocatorCalledCount: { args: [], returns: "int" },
-      });
-      (() => {
-        const bufPtr = getDeallocatorBuffer();
-        let buf = toBuffer(bufPtr, 0, 128, getDeallocatorCallback());
-        expect(buf.length).toBe(128);
-        expect(getDeallocatorCalledCount()).toBe(0);
-        buf = null;
-      })();
-      for (let i = 0; i < 100 && getDeallocatorCalledCount() === 0; i++) {
-        Bun.gc(true);
-        Buffer.alloc(1024 * 1024);
-        await Bun.sleep(0);
-      }
-      expect(getDeallocatorCalledCount()).toBe(1);
-      Bun.gc(true);
-      expect(getDeallocatorCalledCount()).toBe(1);
-    },
-  );
 });
 
 describe.skipIf(!FFI_FIXTURE_PATH)("engine-native FFI (single implementation)", () => {


### PR DESCRIPTION
### Problem
- `test/js/bun/ffi/ffi.test.js` is one of the slowest files in the suite: CI build #97275 took 23.4s on debian x64-asan and 19.6s on alpine x64, against 4.6s on debian x64, and alpine x64 is 18.1-19.6s in every build I looked at (97206, 97275, 97480, 97784), so it is not runner noise.
- The file made 395,627 `expect()` calls, almost all of them in the twelve `integer identities work for all possible values` tests (32768 `expect(fn(i)).toBe(i)` per type per runner). The CI runner sets `BUN_GARBAGE_COLLECTOR_LEVEL=1` for every test process (`scripts/runner.node.mjs`, `spawnBun`), and at that level every matcher call ends in `Expect::post_match` -> `auto_garbage_collect()` -> `mi_collect()` plus a JSC collection request (`src/runtime/test_runner/expect.rs:1735`, `src/jsc/VirtualMachine.rs:1257`). So each of those 395k matcher calls was also a GC cycle: locally the old file goes from ~1.0s to 6.9s just by setting that variable (each sweep 4-20ms -> 300-660ms). Per lane that came to ~2.3s of test time on debian x64, ~14.6s on alpine x64 (the same path is ~6x more expensive per call on the musl build) and ~17s on the ASAN lane, where `expect()` itself is also instrumented bun code. With the debug build here the sweeps were 4-7s each, ~75% of the file, and 5-9 of them exceeded the default 5s per-test timeout on a loaded machine. The FFI calls themselves are not the cost: they run inside release JSC (the 400k-call `CallFFI` tiering test in the same file takes 73ms in debug).
- The rest of the alpine gap is module load: the two `cc -O2` fixture compiles take 3.4-4.7s on that lane against ~2-2.5s on debian (other files that shell out to `cc` show the same lane-specific slowdown: `addr32.test.ts` 0.2s vs 3.3s in `expected-durations.json`, `fs-stat-seccomp-linux.test.ts` 1.7s vs 9.6s and `serve-file-slice-read-error.test.ts` 1.8s vs 6.5s in #97275). Nothing else about musl is slow: over the same build the per-file alpine/debian median is 1.03-1.06, and spawn-, GC- and JIT-heavy files are ~1x there (`jsc-stress.test.ts` runs 83 subprocesses in 0.69s on alpine). The compiles are unchanged by this PR.
- Next largest: the two worker-terminate subprocess tests (3.4-3.6s each in debug, almost all of it debug-build `Worker` startup; 65ms each in release) ran serially, followed separately by the three concurrent `toBuffer` subprocess tests.
- Several assertions were weak: the `threadsafe callback` tests put their `expect()` inside the callback and then `await 1`, but a threadsafe callback is delivered as an event-loop task, so the assertion ran after the test had already passed; `ffi print` only checked `length > 0`; the 13 `cb_identity_*` fixture functions were dlopen'd and destructured but never called; `dlopen` failure only checked truthiness.

### Fix
- Integer identities: the 8-bit types are still checked exhaustively (256 values). Each wider type now round-trips a fixed value set through a single `toEqual`: both range ends and their neighbours, 0 and +-1, every power of two in range with its neighbours (and their negations for signed types), the `0x5555...`/`0xAAAA...` patterns masked to the width, and a 16-step stride. That is 64-394 values per type (106/202/394 for int16/32/64, 64/112/208 for uint16/32/64); it keeps the min/max/0 checks the old test made explicitly and adds the boundaries its stride did not land on (2^31 and 0xAAAAAAAA for u32, 2^32, 2^53-1/2^53 and 2^63 for the 64-bit types, each power of two and its negation for the signed types). The values are then cycled through a 10k-iteration loop that records mismatches instead of calling `expect()` per iteration, so the call site is still exercised after it leaves the interpreter. Each test is now 0.4-1.3ms in release and 20-110ms in debug, and the file makes 1,452 `expect()` calls.
- In the non-fast runner the `toEqual` against BigInt inputs now also asserts that `int64_t`/`uint64_t` return BigInts for every value; the fast runner gets an explicit test that `i64_fast`/`u64_fast` return a number for safe integers and a BigInt beyond them (probes at 2^53-2 and 2^53; `u64_fast` has returned a BigInt for exactly 2^53-1 since the TinyCC-era `UINT64_TO_JSVALUE`, so the probes stay off that one value).
- Subprocess tests: the `toBuffer` block now directly follows the three top-level subprocess tests and all of them (plus the in-process finalizer test, which is the only user of the fixture state it reads) are `concurrent`, so `bun:test` runs the six child processes as one batch. The order is chosen so that the open PRs adding tests to this file (#32055, #32260, #31581 after `read`; #33353 after the Windows dlopen test; #38430 after the `CFunction` block and inside the engine-native block) still apply cleanly.
- Assertions: threadsafe callback tests resolve a promise from the callback, assert `Bun.peek.status` is `pending` right after the native call (queued, not inline, which the worker tests rely on) and `await` the delivered value, then close the callback; new `C code calls back into JS callbacks of every return type` test drives the 13 `cb_identity_*` functions through a `JSCallback` each and compares one result object; `ffi print` checks the generated receiver source (`float not_a_callback(float arg0);`, `USES_FLOAT`, `HAS_ARGUMENTS` present/absent) and that the callback "source" is signature-independent; `dlopen` failure checks `code`/`syscall`/`message` as one object; the 63-symbol test compares the symbol name set instead of its length; pointer checks use `toBeGreaterThan`/`toBeNull`; the roundtrip tests close the callbacks they create; the stray `done` parameter on a `describe` is gone.
- Deliberately left alone: the per-test `dlopen`s in the engine-native and ABI blocks (those tests are 0.04-0.6ms each in release, so hoisting buys nothing and those blocks are where other open PRs add tests); the `setInterval` in the terminate fixture (a keep-alive for a worker that is terminated from outside, not a wait); the `libPath` gate for the libc tests, which is dead on every Linux lane because `isGlibcVersionAtLeast` always returns false there (harness fix in #39030).
- Result on this PR's CI run (#98076), wall clock of the file per lane, before (#97275) -> after: debian x64 4.6s -> 2.7s, ubuntu x64 4.9s -> 3.0s, debian x64-asan 23.4s -> 8.1s (4.1s of tests plus ~4s of LSan at exit, which every file on that lane pays), alpine x64 19.6s -> 5.0s (4.7s of it is still the two compiles), alpine aarch64 7.3s -> 4.0s, ubuntu aarch64 7.7s -> 2.2s. On every lane the part after module load is now 0.2-0.3s (0.8s on ASAN). 149 pass / 5 skip everywhere; the 5 skips are the same as before (Windows-only test, 4 libc tests).
- Verified locally: `bun bd test test/js/bun/ffi/ffi.test.js` 149 pass / 5 skip, 154 tests. 8 of 9 debug runs passed on a box with a load average of 100-245; the one failure was the worker-teardown test reaching the local 5s default timeout at 5.00s during a load spike (it takes 3.1-4.6s per run here in debug; CI passes a much larger per-test timeout, and before this change 6-9 tests per run failed the same way on this box). The libc block was also run once locally with its gate removed, since the darwin lane that normally runs it did not get an agent in this build.

Test count goes from 151 to 154 (the 13-function callback test in each runner, plus the fast-type policy test); nothing was removed or skipped.

### Background
- `BUN_GARBAGE_COLLECTOR_LEVEL=1` is a test-only knob: bun's `bun:test` matchers, `Bun.serve` and a few other host functions call `auto_garbage_collect()` after their work, which at level 1 asks mimalloc to release memory and JSC to start a collection. CI sets it so GC-ordering bugs surface; the side effect is that a matcher call costs microseconds instead of nanoseconds there, which is why expect()-dense tests show up as slow only in CI.
- `bun:test` runs consecutive tests marked `concurrent` as one group (`src/runtime/test_runner/Order.rs`); any non-concurrent test (including a skipped one) between them starts a new group, which is why the blocks have to be adjacent.
- A `threadsafe: true` `JSCallback` never runs inside the native call: the engine hands the invocation to bun, which posts it as a task to the owning event loop (`src/jsc/bindings/JSCFFIBridge.cpp`), so the caller only sees it after an `await` that yields to the loop.
- `i64_fast`/`u64_fast` are the `bun:ffi` 64-bit types that return a JS number when the value fits in a safe integer and a BigInt otherwise; `int64_t`/`uint64_t` always return a BigInt.
- The fixtures (`ffi-test.c`, `ffi-abi-fixture.c`) are compiled once at module load with the system compiler via `compileFixture` from the harness; that is now nearly all of the file's time on every lane.

<details>
<summary>Timings</summary>

CI, wall clock of the file per lane from the Buildkite line timestamps ("load" is until the first test result is printed, i.e. module load including both fixture compiles; "tests" is the rest):

| lane | before (#97275) load / tests / total | after (#98076) load / tests / total |
|---|---|---|
| debian 13 x64 | 2.07s / 2.55s / 4.6s | 2.53s / 0.19s / 2.7s |
| ubuntu 25.04 x64 | 2.12s / 2.79s / 4.9s | 2.74s / 0.22s / 3.0s |
| debian 13 x64-asan | 2.28s / 17.4s / 19.6s (+3.7s exit) | 3.30s / 0.79s / 4.1s (+4.0s exit) |
| alpine 3.23 x64 | 4.66s / 14.9s / 19.6s | 4.71s / 0.26s / 5.0s |
| alpine 3.23 aarch64 | 3.15s / 4.1s / 7.3s | 3.78s / 0.21s / 4.0s |
| ubuntu 25.04 aarch64 | 2.16s / 5.5s / 7.7s | 1.96s / 0.21s / 2.2s |

Alpine x64 in builds 97784 / 97480 / 97206 (old file): 19.0s / 18.1s / 19.0s total, 3.4s / 3.5s / 3.8s of it before the first test result.

Local release build (`USE_SYSTEM_BUN=1`), old file vs new file: plain ~1.0-1.3s vs ~0.55-1.25s (both mostly the fixture compiles); with the CI runner's `BUN_GARBAGE_COLLECTOR_LEVEL=1 BUN_JSC_randomIntegrityAuditRate=1.0` 8.1s vs 0.96s. With only `BUN_GARBAGE_COLLECTOR_LEVEL=1` the old file takes 6.9s and each sweep 300-660ms (4-20ms without it); `BUN_JSC_randomIntegrityAuditRate` alone makes no measurable difference.

Local debug (ASAN) build, back to back on the same machine (12 cores, load average 95-245 during the runs, so absolute numbers are inflated):

| | before | after |
|---|---|---|
| `bun bd test test/js/bun/ffi/ffi.test.js` | 86.2s, 79.6s (6-9 sweeps hit the 5s timeout each run) | 13.8s, 13.2s, 12.8s, 11.1s, 11.4s, 11.3s, 10.9s, 9.2s |
| a trivial test file importing `harness` and compiling both fixtures | 4.1-4.3s | same |
| `integer identities` tests | 3.9-7.4s each (x12) | 20-110ms each |
| worker-terminate tests | 3.6s + 3.4s serial | 3.1-4.6s each, overlapped with the 4 other subprocess tests |
| `expect()` calls | 395,627 | 1,452 |

Slowest tests before (debug build): int64_t 4.8s, int16_t 4.7s, (fast) int32_t 4.4s, uint32_t 4.2s, uint16_t 4.1s, (fast) int16_t 4.0s, int32_t 3.9s, then the remaining sweeps at 5.2-7.4s once they started timing out; worker teardown 3.6s; worker terminate 3.4s; the three toBuffer subprocess tests 1.5s each (concurrent); (fast) primitives 1.1s; JSCallback exceptions subprocess 0.5s. Everything else was under 0.4s.
</details>
