### PR TITLE
test(serve): speed up serve.test.ts (~34s to ~16s release) and tighten its assertions

### DIFF
--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -340,6 +340,9 @@ describe.todoIf(isBroken && isIntelMacOS)(
             },
             async server => {
               const count = 1000;
+              const batchSize = 64;
+              let completed = 0;
+              const wrongDigests: string[] = [];
               async function callback() {
                 const response = await fetch(server.url, {
                   body: blob,
@@ -353,23 +356,22 @@ describe.todoIf(isBroken && isIntelMacOS)(
                 }
 
                 const digest = Buffer.from(Bun.concatArrayBuffers(chunks)).toString();
+                if (digest !== expected) wrongDigests.push(digest);
 
-                expect(digest).toBe(expected);
-                Bun.gc(false);
+                // Keep collecting while the rest of the batch is in flight, but not once per request:
+                // Bun.gc(false) schedules a full collection, and so does every expect() when the test
+                // runner sets BUN_GARBAGE_COLLECTOR_LEVEL (as CI does), which is why the digests are
+                // checked once at the end instead of here.
+                if (++completed % 4 === 0) Bun.gc(false);
               }
-              {
-                let remaining = count;
-
-                const batchSize = 64;
-                while (remaining > 0) {
-                  const promises = new Array(count);
-                  for (let i = 0; i < batchSize && remaining > 0; i++) {
-                    promises[i] = callback();
-                  }
-                  await Promise.all(promises);
-                  remaining -= batchSize;
+              for (let remaining = count; remaining > 0; remaining -= batchSize) {
+                const batch = [];
+                for (let i = 0; i < Math.min(batchSize, remaining); i++) {
+                  batch.push(callback());
                 }
+                await Promise.all(batch);
               }
+              expect({ completed, wrongDigests }).toEqual({ completed: count, wrongDigests: [] });
 
               Bun.gc(true);
               dumpStats();
@@ -2243,18 +2245,26 @@ it("request body and signal life cycle", async () => {
       },
     });
 
-    for (let j = 0; j < 10; j++) {
-      const batchSize = 64;
+    const batches = 10;
+    const batchSize = 64;
+    let responses = 0;
+    const unexpectedStatuses: number[] = [];
+    for (let j = 0; j < batches; j++) {
       const requests = [];
       for (let i = 0; i < batchSize; i++) {
         requests.push(fetch(server.url.origin));
       }
-      await Promise.all(requests);
+      // The bodies are intentionally never read: the responses get collected with their streams
+      // still open on the server side.
+      for (const response of await Promise.all(requests)) {
+        responses++;
+        if (response.status !== 200) unexpectedStatuses.push(response.status);
+      }
       Bun.gc(true);
     }
 
     await Bun.sleep(10);
-    expect().pass();
+    expect({ responses, unexpectedStatuses }).toEqual({ responses: batches * batchSize, unexpectedStatuses: [] });
   }
 }, 30_000);
 
@@ -2884,25 +2894,30 @@ it.concurrent("we should always send date", async () => {
   }
 });
 
+// uSockets only checks socket timeouts once every 4 seconds (LIBUS_TIMEOUT_GRANULARITY) and arms a
+// timeout in whole sweeps: idleTimeout 1..4 closes a quiet connection at the next sweep, 5..8 at the
+// one after that. Instead of sleeping for a fixed number of seconds, the three timeout tests below
+// leave one request unanswered on purpose and wait for that close; a request opened after the one
+// under test has its timeout armed no earlier, so its close proves the tested request outlived a
+// sweep it would otherwise not have survived.
 it.concurrent(
   "should allow use of custom timeout",
   async () => {
+    const stalledRequestAborted = Promise.withResolvers<void>();
     using server = Bun.serve({
       port: 0,
-      idleTimeout: 8, // uws precision is in seconds, and lower than 4 seconds is not reliable its timer is not that accurate
-      async fetch(req) {
-        const url = new URL(req.url);
+      idleTimeout: 1,
+      fetch(req) {
+        const stall = new URL(req.url).pathname === "/timeout";
+        if (stall) req.signal.addEventListener("abort", () => stalledRequestAborted.resolve(), { once: true });
         return new Response(
           new ReadableStream({
             async pull(controller) {
               controller.enqueue("Hello,");
-              if (url.pathname === "/timeout") {
-                await Bun.sleep(10000);
-              } else {
-                await Bun.sleep(10);
-              }
+              // The stalled response never writes again, so the idle timeout has to close it.
+              if (stall) return stalledRequestAborted.promise;
+              await Bun.sleep(10);
               controller.enqueue(" World!");
-
               controller.close();
             },
           }),
@@ -2910,16 +2925,16 @@ it.concurrent(
         );
       },
     });
-    async function testTimeout(pathname: string, success: boolean) {
-      const res = await fetch(new URL(pathname, server.url.origin));
-      expect(res.status).toBe(200);
-      if (success) {
-        expect(res.text()).resolves.toBe("Hello, World!");
-      } else {
-        expect(res.text()).rejects.toThrow(/The socket connection was closed unexpectedly./);
-      }
-    }
-    await Promise.all([testTimeout("/ok", true), testTimeout("/timeout", false)]);
+
+    const stalled = await fetch(new URL("/timeout", server.url));
+    expect(stalled.status).toBe(200);
+    await expect(stalled.text()).rejects.toMatchObject({ code: "ECONNRESET" });
+    await stalledRequestAborted.promise;
+
+    // The sweep that closed /timeout has just run, so this request has a whole sweep interval to
+    // finish in, and the server must still serve it normally after timing the other request out.
+    const ok = await fetch(new URL("/ok", server.url));
+    expect({ status: ok.status, body: await ok.text() }).toEqual({ status: 200, body: "Hello, World!" });
   },
   15_000,
 );
@@ -2927,33 +2942,37 @@ it.concurrent(
 it.concurrent(
   "should reset timeout after writes",
   async () => {
-    // the default is 10s so we send 15
-    // this test should take 15s at most
-    const CHUNKS = 15;
-    const payload = Buffer.from(`data: ${Date.now()}\n\n`);
+    const payload = Buffer.from("data: tick\n\n");
+    let chunksWritten = 0;
+    let streamAborted = false;
+    const streamStarted = Promise.withResolvers<void>();
+    const stopStreaming = Promise.withResolvers<void>();
     using server = Bun.serve({
+      // Two sweeps: a one-sweep timeout fires at the next sweep whether or not a write re-armed it.
       idleTimeout: 5,
       port: 0,
-      fetch(request, server) {
-        let controller!: ReadableStreamDefaultController;
-        let count = CHUNKS;
-        let interval = setInterval(() => {
-          controller.enqueue(payload);
-          count--;
-          if (count == 0) {
-            clearInterval(interval);
-            interval = null;
-            controller.close();
-            return;
-          }
-        }, 1000);
+      fetch(req) {
+        if (new URL(req.url).pathname === "/canary") {
+          // Never answered, so the idle timeout closes it.
+          return new Promise<Response>(() => {});
+        }
+        req.signal.addEventListener("abort", () => (streamAborted = true), { once: true });
+        let interval: ReturnType<typeof setInterval>;
         return new Response(
           new ReadableStream({
-            start(_controller) {
-              controller = _controller;
+            start(controller) {
+              streamStarted.resolve();
+              interval = setInterval(() => {
+                controller.enqueue(payload);
+                chunksWritten++;
+              }, 100);
+              stopStreaming.promise.then(() => {
+                clearInterval(interval);
+                if (!streamAborted) controller.close();
+              });
             },
-            cancel(controller) {
-              if (interval) clearInterval(interval);
+            cancel() {
+              clearInterval(interval);
             },
           }),
           {
@@ -2965,17 +2984,24 @@ it.concurrent(
         );
       },
     });
-    let received = 0;
-    const response = await fetch(server.url);
-    const stream = response.body.getReader();
-    const decoder = new TextDecoder();
-    while (true) {
-      const { done, value } = await stream.read();
-      received += value?.length || 0;
-      if (done) break;
-    }
 
-    expect(received).toBe(CHUNKS * payload.byteLength);
+    const streaming = fetch(server.url);
+    await streamStarted.promise;
+    // The canary is opened after the stream's timeout was armed, so once the canary has been closed
+    // the stream has outlived the sweep that would have closed it too, had its writes not kept
+    // pushing its timeout back.
+    const canaryError = await fetch(new URL("/canary", server.url)).catch(e => e);
+    stopStreaming.resolve();
+    expect(canaryError).toMatchObject({ code: "ECONNRESET" });
+    expect(streamAborted).toBe(false);
+
+    const response = await streaming;
+    const body = await response.text();
+    expect({ status: response.status, chunksReceived: body.length / payload.byteLength }).toEqual({
+      status: 200,
+      chunksReceived: chunksWritten,
+    });
+    expect(chunksWritten).toBeGreaterThan(0);
   },
   20_000,
 );
@@ -2999,20 +3025,38 @@ it.concurrent("allow requestIP after async operation", async () => {
 it.concurrent(
   "allow custom timeout per request",
   async () => {
+    const longRequestArmed = Promise.withResolvers<void>();
+    const releaseLongRequest = Promise.withResolvers<void>();
+    let longRequestAborted = false;
     using server = Bun.serve({
       idleTimeout: 1,
       port: 0,
       async fetch(req, server) {
+        if (new URL(req.url).pathname === "/canary") {
+          // Never answered and left on the server-wide idleTimeout, so the next sweep closes it.
+          return new Promise<Response>(() => {});
+        }
         server.timeout(req, 60);
-        await Bun.sleep(10000); //uWS precision is not great
-
+        req.signal.addEventListener("abort", () => (longRequestAborted = true), { once: true });
+        longRequestArmed.resolve();
+        await releaseLongRequest.promise;
         return new Response("Hello, World!");
       },
     });
     expect(server.timeout).toBeFunction();
-    const res = await fetch(new URL("/long-timeout", server.url.origin));
-    expect(res.status).toBe(200);
-    expect(res.text()).resolves.toBe("Hello, World!");
+
+    const longRequest = fetch(new URL("/long-timeout", server.url));
+    await longRequestArmed.promise;
+    // The canary is opened after the long request raised its own timeout, so once the canary has
+    // been closed the long request has sat unanswered through a sweep that the server-wide
+    // idleTimeout alone would not have let it survive.
+    const canaryError = await fetch(new URL("/canary", server.url)).catch(e => e);
+    releaseLongRequest.resolve();
+    expect(canaryError).toMatchObject({ code: "ECONNRESET" });
+    expect(longRequestAborted).toBe(false);
+
+    const res = await longRequest;
+    expect({ status: res.status, body: await res.text() }).toEqual({ status: 200, body: "Hello, World!" });
   },
   20_000,
 );
@@ -3196,7 +3240,7 @@ it.concurrent("#20283", async () => {
 // copies the raw bytes and the underlying C socket layer truncates at the first NUL, so
 // `"127.0.0.1\0ignored"` behaves like `"127.0.0.1"` (or at worst surfaces as a catchable JS error).
 // A port that uses CString::new(...).expect(...) would panic and crash the process instead.
-it("Bun.serve hostname with interior NUL byte does not crash the process", async () => {
+it.concurrent("Bun.serve hostname with interior NUL byte does not crash the process", async () => {
   const script = `
     try {
       const server = Bun.serve({
@@ -3234,7 +3278,7 @@ it("Bun.serve hostname with interior NUL byte does not crash the process", async
 // A "[...]" hostname has its brackets stripped before it is handed to the socket layer.
 // That copy used to live in a fixed 1024-byte buffer, so a longer bracketed hostname
 // aborted the process instead of failing to listen like any other bogus hostname.
-it("Bun.serve with a bracketed hostname longer than 1024 bytes throws instead of crashing", async () => {
+it.concurrent("Bun.serve with a bracketed hostname longer than 1024 bytes throws instead of crashing", async () => {
   const script = `
     const hostname = "[" + Buffer.alloc(1100, "a").toString() + "]";
     let server;
@@ -3265,7 +3309,7 @@ it("Bun.serve with a bracketed hostname longer than 1024 bytes throws instead of
   });
 });
 
-it("development error log prints the request pathname verbatim", async () => {
+it.concurrent("development error log prints the request pathname verbatim", async () => {
   const script = `
     const net = require("node:net");
     const server = Bun.serve({
@@ -3302,8 +3346,10 @@ it("development error log prints the request pathname verbatim", async () => {
 // handler tears the connection down from inside the request-body data callback, the
 // parser must stop consuming the rest of the TCP segment instead of routing a request
 // that was pipelined behind the body onto the already-closed socket.
-it("does not dispatch a pipelined request after the connection is destroyed inside the body data callback", async () => {
-  const script = `
+it.concurrent(
+  "does not dispatch a pipelined request after the connection is destroyed inside the body data callback",
+  async () => {
+    const script = `
 const http = require("node:http");
 const net = require("node:net");
 
@@ -3345,21 +3391,22 @@ server.listen(0, "127.0.0.1", () => {
 });
 `;
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", script],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stderr).toBe("");
-  // "/second" arrived in the same TCP segment as the POST body, after the handler had
-  // already torn the connection down. It must never reach the request listener.
-  expect(stdout.trim()).toBe('{"seen":["/first","/after"],"after":200}');
-  expect(exitCode).toBe(0);
-});
+    expect(stderr).toBe("");
+    // "/second" arrived in the same TCP segment as the POST body, after the handler had
+    // already torn the connection down. It must never reach the request listener.
+    expect(stdout.trim()).toBe('{"seen":["/first","/after"],"after":200}');
+    expect(exitCode).toBe(0);
+  },
+);
 
 it("only serves /bun:info to loopback clients in development mode", async () => {
   using server = Bun.serve({
@@ -3575,7 +3622,7 @@ it("resumes a backpressured Response(ReadableStream) once the client drains and 
   }
 });
 
-describe("request body backpressure", () => {
+describe.concurrent("request body backpressure", () => {
   // Raw-socket PUT client: connect, send the request head, then pump `total`
   // bytes of `fill`, pausing on `drain`. Resolves once the client's `sent`
   // counter has plateaued for 12×25 ms (backpressure engaged) or it finished
@@ -4000,7 +4047,7 @@ it("type: direct controller.write() Promise resolves on drain and resumes pull",
 // A handler that proxies an upstream response body to a slow client must
 // pause the upstream socket instead of buffering the rate difference:
 // ByteStream (fetch response) → HttpResponse sink with backpressure.
-it.each(["chunked", "content-length"] as const)(
+it.concurrent.each(["chunked", "content-length"] as const)(
   "bounds memory when proxying a %s fetch response body to a stalled client",
   async encoding => {
     const fixture = `
@@ -4054,7 +4101,7 @@ it.each(["chunked", "content-length"] as const)(
     // client stalls; with it, in-flight bytes are bounded by the socket buffers.
     expect((fixtureMaxRSS - baselineMaxRSS) / 1024 / 1024).toBeLessThan(isASAN || isDebug ? 256 : 96);
   },
-  10_000,
+  15_000,
 );
 
 // Same as the test above but the pull does *not* await flush(true) — it keeps


### PR DESCRIPTION
### Problem
- `test/js/bun/http/serve.test.ts` takes 25-33s on every CI lane (33s on debian x64 ASAN in build 97275, 25s on the aarch64 release lane), so most of the time is waiting, not running.
- Release profile before (34.4s locally): `should reset timeout after writes` 15.0s, `allow custom timeout per request` 10.0s, `should allow use of custom timeout` 6.5-8s. They are in one `it.concurrent` group, so they cost ~15s of wall clock on every lane. Each one slept for a fixed 10-15s on top of uSockets' 4s timeout sweep.
- Next in line: the two `1000 uploads & downloads ... do not leak ReadableStream` cases (2.0s + 2.2s release, 23s + 25s in this container's debug build). Each of their requests asked for a full collection twice: `Bun.gc(false)` and, under the `BUN_GARBAGE_COLLECTOR_LEVEL=1` that the CI runner sets, the per-request `expect()` (every matcher schedules a collection in that mode). That was ~40% of their time; the loop also ran 1024 requests, not the 1000 it asserts on.
- Then the `request body backpressure` describe (6 cases, ~0.4s each, all of it waiting for an upload to plateau), the two proxying RSS cases (1.1s + 0.7s, each a subprocess with a fixed 500ms stall) and four subprocess-only tests right after the timeout group, all running one after another.
- Weak spots in the same tests: `request body and signal life cycle` ended in `expect().pass()`, the timeout tests had unawaited `.resolves` / `.rejects` assertions, and the leak test stopped at the first wrong digest.

### Fix
- Timeout tests: uSockets checks timeouts once every 4s and arms them in whole sweeps (`idleTimeout` 1..4 fires at the next sweep, 5..8 at the one after), so each test now leaves one request unanswered and waits for the server to close it instead of sleeping:
  - `should allow use of custom timeout` (`idleTimeout: 1`): the stalled streaming response must be closed (client sees `ECONNRESET`, server sees `req.signal` abort); `/ok` is then served right after that sweep, so it has a whole sweep interval to complete and also shows the server still works after timing a request out.
  - `should reset timeout after writes` (`idleTimeout: 5`, two sweeps, because a one-sweep timeout fires at the next sweep whether or not a write re-armed it): the stream writes every 100ms; an unanswered canary is opened only after the stream has started, so its timeout is armed no earlier than the stream's. Once the canary is closed, the stream has outlived the sweep that would have closed it without the resets. The test then stops the stream itself and checks status, that the stream request was never aborted, and that the body holds exactly the chunks that were written.
  - `allow custom timeout per request` (`idleTimeout: 1`, `server.timeout(req, 60)`): the canary is opened after the long request has raised its own timeout; once the canary is closed the long request must still be unaborted, and is only then released and checked for status and body.
  - In both canary tests the release is driven from the test body after the client has seen the canary fail. Releasing from the canary's server-side abort event does not work: that event fires inside the sweep, the handler's response is written before the sweep reaches the other socket, and the write re-arms it (verified: that variant passed with `server.timeout()` removed).
  - Each rewritten test was checked against the regression it guards by removing the behaviour under test (stream writes removed; `server.timeout()` call removed): both variants fail at the `toBe(false)` abort assertions, at the same sweep that closes the canary. Output in the details below.
  - The group now takes one or two sweeps: 4-8s depending on the sweep phase (5.9s in the release run below, 0.3s / 1.1s / 4.5s for the three tests in the debug run). The 4s sweep period is the floor for this approach; #38470 does the same for fetch.test.ts. The original per-test timeouts (15s / 20s / 20s) are kept, which also leaves room if #33610 adds a sweep to every timeout.
- Leak test: collects every fourth completed request (so collections still happen while the rest of the batch is in flight), runs exactly `count` requests, and asserts `{ completed, wrongDigests }` once at the end. The post-GC `ReadableStream` count assertion is unchanged. This is where the file's `expect()` count drops (3802 to 1759).
- Concurrency: the four subprocess-only tests after the timeout group are `it.concurrent` and so join that group (they finish inside its sweep wait); `request body backpressure` is `describe.concurrent` (each case has its own server and socket, and a plateau check can only end early if the upload stops, which is the property under test); the RSS pair is `it.concurrent.each` (separate subprocesses, RSS is per process), with its explicit timeout raised from 10s to 15s since the two fixtures now share the CPU. The other plateau tests move 32-128MB each on the test thread, so they were left sequential: concurrently they were not faster in the debug build, only closer to the 5s local default timeout.
- Assertions: life cycle test checks all 640 responses are 200 (bodies are still left unread, which is what the test exercises); timeout tests check status and body via one `toEqual`, the unanswered request's `code: "ECONNRESET"` (also for the stalled stream, matching what #35988 proposes for that line) and that the request under test was not aborted; leak test reports the request count and every wrong digest.
- Verified (this container; debug builds here are several times slower than CI):
  - `bun bd test test/js/bun/http/serve.test.ts`: 141.3s before, 111.6s after. With the CI runner's env (`BUN_GARBAGE_COLLECTOR_LEVEL=1`, `BUN_JSC_randomIntegrityAuditRate=1.0`): 155.1s before, 121.6s after.
  - `USE_SYSTEM_BUN=1 bun test test/js/bun/http/serve.test.ts` (release): 34.4s before, 16.2s and 16.3s after.
  - The tests touched here plus the rest of their concurrent group, 6 runs in a loop on the debug build: green every time (timeout tests landing anywhere between 0.3s and 2.5s / 4.5s and 6.9s depending on sweep phase).
  - The failing set is identical before and after and is this container's environment: `server.requestIP > v6` (no IPv6), `root range port(#7187)` (running as root), `#6583` (`localhost` resolves to the other family than the server bound), `only serves /bun:info to loopback clients` (egress proxy). The release binary additionally fails `reload() that drops the node:http handler`, which needs #38755 and passes on the debug build.
- `it.concurrent(name, fn)` with a title longer than prettier's line width re-indents the `does not dispatch a pipelined request ...` test; `git diff -w` shows the real changes (124 insertions, 77 deletions).
- Of the 54 open PRs that touch this file, 52 still apply on top of this branch exactly as they do on main (checked by applying each PR's serve.test.ts patch to both versions). The two that do not, #33610 and #35988, both edit the assertions of the old `should allow use of custom timeout` test that this PR rewrites; the `code`-based assertion here already covers what #35988 changes that line to.

### Background
- `Bun.serve`'s `idleTimeout` and `server.timeout(req, s)` are uSockets socket timeouts. uSockets only walks its sockets every `LIBUS_TIMEOUT_GRANULARITY` (4) seconds and `us_socket_timeout(s, seconds)` stores `now_tick + ceil(seconds / 4)`, so a 1s timeout fires at the next sweep (0-4s later, exactly 4s when this test's sockets are the ones that start the sweep timer) and a 5s one at the second sweep. Every write to the response re-arms the socket with the same value, which is what `should reset timeout after writes` tests and why it needs a two-sweep value. When a timeout fires uSockets force-closes the socket; a pending request sees `req.signal` abort and Bun's `fetch()` rejects with `code: "ECONNRESET"` (the `ConnectionClosed` mapping in `FetchTasklet.rs`), whether or not the head had been sent.
- A request opened after another one has its timeout armed at the same tick or later, so "request B was closed by its timeout" implies "a sweep ran that would also have closed request A unless A's timeout had been reset or raised". That is the only ordering the rewritten tests rely on; they do not depend on the length of a tick.
- Bun's `fetch()` retries an idempotent request once if a pooled keep-alive connection closes under it, but never on a fresh connection (`allow_retry` is only set when a pooled socket is reused, `HTTPContext.rs`). Each server here is new and its first connection is still busy when the canary is sent, so the canary always uses a fresh connection and its close is reported, not retried.
- `it.concurrent` tests run together with the `it.concurrent` / `describe.concurrent` tests declared directly before and after them; a plain `it` in between is a barrier, and so is the end of a `describe` block (checked with a small probe file: tests declared after a describe block closes start a new batch, `.each` does not). That is why the four subprocess tests, which follow the timeout group at top level, join it, while the backpressure describe and the RSS pair each form their own batch. The CI runner passes `--timeout=90000` (x3 on ASAN), and an explicit per-test timeout overrides that, which is why the only explicit timeout on a newly concurrent test was raised rather than added anywhere else.

<details>
<summary>Simulated regressions, debug build</summary>

Stream writes removed from `should reset timeout after writes`, and `server.timeout(req, 60)` removed from `allow custom timeout per request` (the real tests were run in the same file for comparison):

```
error: expect(received).toBe(expected)
Expected: false
Received: true
(fail) MUTATION per-request (must fail) [4134.84ms]
(pass) allow custom timeout per request [4224.84ms]
(pass) should allow use of custom timeout [4401.60ms]
error: expect(received).toBe(expected)
Expected: false
Received: true
(fail) MUTATION reset (must fail) [8103.94ms]
(pass) should reset timeout after writes [8189.55ms]
```

The earlier variant that released the long request from the canary's server-side abort event passed without `server.timeout()`, which is why the release now comes from the test body after the client has observed the canary's failure.
</details>

<details>
<summary>Release profile after (16.3s total)</summary>

```
5873ms  should reset timeout after writes            (group wall clock; the other two landed at ~1.9s in the same run)
1937ms  1000 uploads ... > direct
1835ms  1000 uploads ... > default
1108ms  bounds memory ... chunked                    (runs together with content-length, 728ms)
1063ms  request body backpressure > Bun.write        (the describe's 6 cases run together)
 349ms  type: direct stream awaiting flush(true) ...
 340ms  resumes a backpressured Response(ReadableStream) ...
 338ms  applies backpressure to a Response(ReadableStream) body ...
```

What is left is the 4-8s sweep floor of the timeout group, ~3.8s of the two leak cases (768KB uploaded and hashed per request; their payload size is what makes the request body arrive in more than one chunk, so it was left alone), and ~4s spread across the remaining ~280 tests.
</details>
