### PR TITLE
Bun.gzipSync/deflateSync/gunzipSync/inflateSync: throw instead of aborting when an output buffer cannot be allocated

### DIFF
--- a/src/libdeflate_sys/libdeflate.rs
+++ b/src/libdeflate_sys/libdeflate.rs
@@ -3,6 +3,8 @@ use core::mem::MaybeUninit;
 use core::ptr::NonNull;
 use std::sync::Once;
 
+use bun_alloc::AllocError;
+
 /// Valid `compression_level` range for `libdeflate_alloc_compressor`. Values
 /// outside this range make the allocator return NULL (indistinguishable from OOM),
 /// so callers must range-check first.
@@ -441,21 +443,26 @@ impl Decompressor {
     /// [`Status::InsufficientSpace`] — clamped at `max_capacity` — until
     /// success, hard error, or `out.capacity() >= max_capacity` (returned as
     /// the final `InsufficientSpace`). On success, `out.len() == result.written`.
+    ///
+    /// The output size is dictated by the (untrusted) input, so a capacity
+    /// step the allocator refuses is reported as `Err(AllocError)` rather
+    /// than aborting the process; `out` is left empty with its last capacity.
     pub fn decompress_to_vec_grow(
         &mut self,
         input: &[u8],
         out: &mut Vec<u8>,
         encoding: Encoding,
         max_capacity: usize,
-    ) -> Result {
+    ) -> core::result::Result<Result, AllocError> {
         loop {
             out.clear();
             let result = self.decompress_to_vec(input, out, encoding);
             if result.status != Status::InsufficientSpace || out.capacity() >= max_capacity {
-                return result;
+                return Ok(result);
             }
             let new_cap = out.capacity().max(1).saturating_mul(2).min(max_capacity);
-            out.reserve_exact(new_cap.saturating_sub(out.len()));
+            out.try_reserve_exact(new_cap.saturating_sub(out.len()))
+                .map_err(|_| AllocError)?;
         }
     }
 }

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -2432,29 +2432,37 @@ pub mod JSZlib {
         let buffer = coerce_compress_buffer(global_this, buffer_value)?;
         let compressed = buffer.slice();
 
-        let mut list: Vec<u8> = 'brk: {
-            if is_gzip && compressed.len() > 64 {
-                //   0   1   2   3   4   5   6   7
-                //  +---+---+---+---+---+---+---+---+
-                //  |     CRC32     |     ISIZE     |
-                //  +---+---+---+---+---+---+---+---+
-                let estimated_size: u32 = u32::from_le_bytes(
-                    compressed[compressed.len() - 4..][..4]
-                        .try_into()
-                        .expect("infallible: size matches"),
-                );
-                // If it's > 256 MB, let's rely on dynamic allocation to minimize the risk of OOM.
-                if estimated_size > 0 && estimated_size < 256 * 1024 * 1024 {
-                    break 'brk Vec::with_capacity((estimated_size as usize).max(64));
-                }
+        let mut estimated_size: Option<usize> = None;
+        if is_gzip && compressed.len() > 64 {
+            //   0   1   2   3   4   5   6   7
+            //  +---+---+---+---+---+---+---+---+
+            //  |     CRC32     |     ISIZE     |
+            //  +---+---+---+---+---+---+---+---+
+            let trailer_size: u32 = u32::from_le_bytes(
+                compressed[compressed.len() - 4..][..4]
+                    .try_into()
+                    .expect("infallible: size matches"),
+            );
+            // If it's > 256 MB, let's rely on dynamic allocation to minimize the risk of OOM.
+            if trailer_size > 0 && trailer_size < 256 * 1024 * 1024 {
+                estimated_size = Some((trailer_size as usize).max(64));
             }
+        }
 
-            break 'brk Vec::with_capacity(if compressed.len() > 512 {
+        let mut list: Vec<u8> = Vec::new();
+        // The trailer is untrusted input and only sizes this up-front reservation: when
+        // the allocator refuses it, decompress into the default buffer and grow instead.
+        let reserved = estimated_size.is_some_and(|size| list.try_reserve_exact(size).is_ok());
+        if !reserved {
+            let initial_capacity = if compressed.len() > 512 {
                 compressed.len()
             } else {
                 32
-            });
-        };
+            };
+            if list.try_reserve_exact(initial_capacity).is_err() {
+                return Err(global_this.throw_out_of_memory());
+            }
+        }
 
         match library {
             Library::Zlib => {
@@ -2480,10 +2488,16 @@ pub mod JSZlib {
                     }
                 };
 
-                if reader.read_all(true).is_err() {
-                    let msg = reader.error_message().unwrap_or(b"Zlib returned an error");
-                    return Err(global_this
-                        .throw_value(ZigString::init(msg).to_error_instance(global_this)));
+                match reader.read_all(true) {
+                    Ok(()) => {}
+                    Err(zlib::ZlibError::OutOfMemory) => {
+                        return Err(global_this.throw_out_of_memory());
+                    }
+                    Err(_) => {
+                        let msg = reader.error_message().unwrap_or(b"Zlib returned an error");
+                        return Err(global_this
+                            .throw_value(ZigString::init(msg).to_error_instance(global_this)));
+                    }
                 }
                 // NOTE: the reader *borrows* `list_ptr`,
                 // so drop the reader to release the borrow, then leak the owned
@@ -2503,8 +2517,12 @@ pub mod JSZlib {
                     bun_libdeflate::Encoding::Deflate
                 };
                 let max_output = ArrayBuffer::MAX_SIZE as usize;
-                let result = decompressor
-                    .decompress_to_vec_grow(compressed, &mut list, encoding, max_output);
+                let Ok(result) = decompressor
+                    .decompress_to_vec_grow(compressed, &mut list, encoding, max_output)
+                else {
+                    drop(list);
+                    return Err(global_this.throw_out_of_memory());
+                };
                 match result.status {
                     bun_libdeflate::Status::Success if list.len() <= max_output => {}
                     bun_libdeflate::Status::Success | bun_libdeflate::Status::InsufficientSpace => {
@@ -2596,11 +2614,9 @@ pub mod JSZlib {
 
         match library {
             Library::Zlib => {
-                let mut list: Vec<u8> = Vec::with_capacity(if compressed.len() > 512 {
-                    compressed.len()
-                } else {
-                    32
-                });
+                // `init` reserves `deflateBound(input)` and reports `OutOfMemory` if
+                // it cannot, which `throw_error` below turns into a JS OOM error.
+                let mut list: Vec<u8> = Vec::new();
 
                 let mut reader = match zlib::ZlibCompressorArrayList::init(
                     compressed,
@@ -2625,10 +2641,16 @@ pub mod JSZlib {
                     }
                 };
 
-                if reader.read_all().is_err() {
-                    let msg = reader.error_message().unwrap_or(b"Zlib returned an error");
-                    return Err(global_this
-                        .throw_value(ZigString::init(msg).to_error_instance(global_this)));
+                match reader.read_all() {
+                    Ok(()) => {}
+                    Err(zlib::ZlibError::OutOfMemory) => {
+                        return Err(global_this.throw_out_of_memory());
+                    }
+                    Err(_) => {
+                        let msg = reader.error_message().unwrap_or(b"Zlib returned an error");
+                        return Err(global_this
+                            .throw_value(ZigString::init(msg).to_error_instance(global_this)));
+                    }
                 }
                 // NOTE: see gunzip path — reader borrows `list`, so drop
                 // it before leaking `list` into the ArrayBuffer.
@@ -2655,10 +2677,14 @@ pub mod JSZlib {
                     bun_libdeflate::Encoding::Deflate
                 };
 
-                let mut list: Vec<u8> = Vec::with_capacity(
-                    // This allocation size is unfortunate, but it's not clear how to avoid it with libdeflate.
-                    compressor.max_bytes_needed(compressed, encoding),
-                );
+                let mut list: Vec<u8> = Vec::new();
+                // This allocation size is unfortunate, but it's not clear how to avoid it with libdeflate.
+                if list
+                    .try_reserve_exact(compressor.max_bytes_needed(compressed, encoding))
+                    .is_err()
+                {
+                    return Err(global_this.throw_out_of_memory());
+                }
 
                 let result = compressor.compress_to_vec(compressed, &mut list, encoding);
                 if result.status != bun_libdeflate::Status::Success {

--- a/src/zlib/lib.rs
+++ b/src/zlib/lib.rs
@@ -335,11 +335,16 @@ impl<'a> ZlibReaderArrayList<'a> {
                         self.state = ZlibReaderArrayListState::Error;
                         return Err(ZlibError::ZlibError);
                     }
+                    if self
+                        .list_ptr
+                        .try_reserve(remaining_budget.min(4096))
+                        .is_err()
+                    {
+                        self.state = ZlibReaderArrayListState::Error;
+                        return Err(ZlibError::OutOfMemory);
+                    }
                     // SAFETY: zlib writes the tail; len is truncated to `total_out` before any read.
-                    let (next_out, avail_out) = unsafe {
-                        self.list_ptr
-                            .reserve_expand_tail(remaining_budget.min(4096))
-                    };
+                    let (next_out, avail_out) = unsafe { self.list_ptr.reserve_expand_tail(0) };
                     self.zlib.next_out = next_out;
                     // Clamp so a single inflate call cannot write past `max_output_size`.
                     self.zlib.avail_out = avail_out.min(remaining_budget) as uInt;
@@ -780,9 +785,14 @@ impl<'a> ZlibCompressorArrayList<'a> {
                         uLong::try_from(input.len()).expect("int cast"),
                     )
                 };
-                // ensureTotalCapacityPrecise → reserve_exact
+                // ensureTotalCapacityPrecise → try_reserve_exact; the bound scales
+                // with the caller's input, so a refused reservation is reported
+                // rather than aborting. Dropping `zlib_reader` runs `deflateEnd`.
                 let need = (bound as usize).saturating_sub(zlib_reader.list_ptr.len());
-                zlib_reader.list_ptr.reserve_exact(need);
+                if zlib_reader.list_ptr.try_reserve_exact(need).is_err() {
+                    drop(zlib_reader);
+                    return Err(ZlibError::OutOfMemory);
+                }
                 zlib_reader.zlib.avail_out = zlib_reader.list_ptr.capacity() as uInt;
                 zlib_reader.zlib.next_out = zlib_reader.list_ptr.as_mut_ptr();
 
@@ -846,8 +856,13 @@ impl<'a> ZlibCompressorArrayList<'a> {
                 //   flush parameter).
 
                 if self.zlib.avail_out == 0 {
+                    if self.list_ptr.try_reserve(4096).is_err() {
+                        self.end();
+                        self.state = ZlibCompressorArrayListState::Error;
+                        return Err(ZlibError::OutOfMemory);
+                    }
                     // SAFETY: zlib writes the tail; len is truncated to `total_out` before any read.
-                    let (next_out, avail_out) = unsafe { self.list_ptr.reserve_expand_tail(4096) };
+                    let (next_out, avail_out) = unsafe { self.list_ptr.reserve_expand_tail(0) };
                     self.zlib.next_out = next_out;
                     self.zlib.avail_out = avail_out as uInt;
                 }

--- a/test/js/bun/util/zstd.test.ts
+++ b/test/js/bun/util/zstd.test.ts
@@ -9,7 +9,7 @@ import {
   zstdDecompressSync,
 } from "bun";
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, rss } from "harness";
+import { bunEnv, bunExe, isASAN, rss } from "harness";
 import path from "path";
 
 describe("Zstandard compression", async () => {
@@ -364,6 +364,124 @@ describe("sync compression argument handling", () => {
     });
     expect(exitCode).toBe(0);
   }, 60_000);
+});
+
+// The sync gzip/deflate APIs size their output buffers from the caller's input:
+// the compressors reserve the worst-case compressed size up front, the
+// decompressors reserve a guess (the gzip trailer's ISIZE field, else the input
+// size) and then grow as the stream decodes. Every one of those reservations
+// used to be infallible, so refusing any of them aborted the process instead of
+// throwing. ASAN's per-allocation cap makes each refusal deterministic: the JS
+// Buffers passed in are allocated by JSC and are not subject to the cap, while
+// every native reservation above CAP_MB is. Each case below is shaped so that a
+// different reservation is the one refused.
+describe.skipIf(!isASAN)("gzip/deflate sync APIs throw when an output buffer cannot be allocated", () => {
+  const CAP_MB = 8;
+  const env = {
+    ...bunEnv,
+    ASAN_OPTIONS: [
+      bunEnv.ASAN_OPTIONS,
+      "allocator_may_return_null=1",
+      `max_allocation_size_mb=${CAP_MB}`,
+      // Last wins: buffers handed to JSC are still alive at exit, and the CI
+      // lanes that opt into leak detection would report them.
+      "detect_leaks=0",
+    ]
+      .filter(Boolean)
+      .join(":"),
+  };
+  const outOfMemory = { name: "RangeError", message: "Out of memory" };
+  const expected = {
+    // Compressors: the deflateBound() / libdeflate bound reservation, which is
+    // a little above the 16 MiB input, is refused.
+    "gzipSync zlib": outOfMemory,
+    "deflateSync zlib": outOfMemory,
+    "gzipSync libdeflate": outOfMemory,
+    "deflateSync libdeflate": outOfMemory,
+    // Decompressors: the input-sized initial reservation is refused.
+    "inflateSync zlib, input-sized buffer": outOfMemory,
+    "inflateSync libdeflate, input-sized buffer": outOfMemory,
+    // The initial reservation fits (the compressed payload is ~12 KiB) and the
+    // doubling growth step that crosses the cap is refused.
+    "inflateSync zlib, growth": outOfMemory,
+    "inflateSync libdeflate, growth": outOfMemory,
+    // A truthful 12 MiB ISIZE is refused, so decoding falls back to the
+    // input-sized buffer and then fails while growing.
+    "gunzipSync zlib, trailer size": outOfMemory,
+    "gunzipSync libdeflate, trailer size": outOfMemory,
+    // The bytes after the member claim a 100 MiB size; that reservation is
+    // refused but only ever was a hint, so the 256-byte member still decodes.
+    "gunzipSync zlib, unallocatable trailer size": { length: 256 },
+    "gunzipSync libdeflate, unallocatable trailer size": { length: 256 },
+    afterwards: "round trip ok",
+  };
+
+  it("reports RangeError: Out of memory and the process keeps running", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        /* js */ `
+        const zlib = require("node:zlib");
+        const MiB = 1024 * 1024;
+        const libdeflate = { library: "libdeflate" };
+        const big = Buffer.alloc(2 * ${CAP_MB} * MiB);
+        // node:zlib streams through chunk-sized buffers, so producing the 12 MiB
+        // payloads needs no native reservation above the cap.
+        const payload = Buffer.alloc(12 * MiB);
+        const deflated = zlib.deflateRawSync(payload);
+        const gzipped = zlib.gzipSync(payload);
+        // Stored (level 0) so the member is longer than the 64 bytes below which
+        // the size field is not consulted. The trailing bytes are not a gzip
+        // header, so both backends ignore them, as node does.
+        const member = Bun.gzipSync(Buffer.alloc(256, "a"), { level: 0 });
+        const trailing = Buffer.alloc(8);
+        trailing.writeUInt32LE(100 * MiB, 4);
+        const claimed = Buffer.concat([member, trailing]);
+        const cases = {
+          "gzipSync zlib": () => Bun.gzipSync(big),
+          "deflateSync zlib": () => Bun.deflateSync(big),
+          "gzipSync libdeflate": () => Bun.gzipSync(big, libdeflate),
+          "deflateSync libdeflate": () => Bun.deflateSync(big, libdeflate),
+          "inflateSync zlib, input-sized buffer": () => Bun.inflateSync(big),
+          "inflateSync libdeflate, input-sized buffer": () => Bun.inflateSync(big, libdeflate),
+          "inflateSync zlib, growth": () => Bun.inflateSync(deflated),
+          "inflateSync libdeflate, growth": () => Bun.inflateSync(deflated, libdeflate),
+          "gunzipSync zlib, trailer size": () => Bun.gunzipSync(gzipped),
+          "gunzipSync libdeflate, trailer size": () => Bun.gunzipSync(gzipped, libdeflate),
+          "gunzipSync zlib, unallocatable trailer size": () => Bun.gunzipSync(claimed),
+          "gunzipSync libdeflate, unallocatable trailer size": () => Bun.gunzipSync(claimed, libdeflate),
+        };
+        // One line per case, so an abort still shows which case it was in.
+        for (const [name, run] of Object.entries(cases)) {
+          let outcome;
+          try {
+            outcome = { length: run().length };
+          } catch (e) {
+            outcome = { name: e.name, message: e.message };
+          }
+          console.log(JSON.stringify([name, outcome]));
+        }
+        const text = "round trip ok";
+        console.log(JSON.stringify(["afterwards", Buffer.from(Bun.gunzipSync(Bun.gzipSync(text))).toString()]));
+        `,
+      ],
+      env,
+      stdout: "pipe",
+      // ASAN prints a WARNING line for every refused allocation; not asserted on.
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const results = Object.fromEntries(
+      stdout
+        .trim()
+        .split("\n")
+        .filter(Boolean)
+        .map(line => JSON.parse(line)),
+    );
+    // An abort leaves `results` ending at the case that died; stderr then has the allocator message.
+    expect({ results, exitCode }, stderr).toEqual({ results: expected, exitCode: 0 });
+  });
 });
 
 describe.concurrent("Zstandard HTTP compression", () => {


### PR DESCRIPTION
### Problem
- `Bun.gzipSync`, `Bun.deflateSync`, `Bun.gunzipSync` and `Bun.inflateSync` abort the whole process when the output buffer they allocate cannot be obtained: `memory allocation of 314572800 bytes failed`, then `panic(main thread): abort() called` and a crash report (exit 134). Before the port to Rust these threw a JS out-of-memory error (`try ...initCapacity(...)` in the Zig version).
- Every output reservation in these functions is infallible (`Vec::with_capacity` / `reserve_exact` / `reserve`), and all of them are sized by the caller's data:
  - `src/runtime/api/BunObject.rs` `gunzip_or_inflate_sync`: the gzip trailer's ISIZE field (any value below 256 MiB is honored, so 8 bytes of untrusted input pick the size), else the input length.
  - `src/runtime/api/BunObject.rs` `gzip_or_deflate_sync`: the input length, then libdeflate's compression bound.
  - `src/zlib/lib.rs` `ZlibCompressorArrayList::init`: `deflateBound(input)`; `ZlibReaderArrayList::read_all` / `ZlibCompressorArrayList::read_all`: the growth step taken whenever zlib fills the buffer.
  - `src/libdeflate_sys/libdeflate.rs` `decompress_to_vec_grow`: the doubling step on `InsufficientSpace`.
- Repro on the release build: `ulimit -v 1048576`, then `Bun.gunzipSync` / `gzipSync` / `inflateSync` of a 300 MiB buffer (with either `library`) aborts instead of throwing. For `gunzipSync` the requested size can also come from the trailer of a gzip a few hundred bytes long (anything up to 256 MiB), so whether untrusted gzip data takes the process down depends only on the host's headroom.

### Fix
- Each of those reservations goes through `try_reserve` / `try_reserve_exact`. In `BunObject.rs` a refusal becomes `global.throw_out_of_memory()` (the same `RangeError: Out of memory` JSC throws for its own failed allocations, and what the zstd async path and #33014 / #38941 already do for the same class of bug). The growth loops report the refusal to their caller instead: `ZlibError::OutOfMemory` from the zlib array lists (`init` errors already reach `throw_error`, which maps that variant to the OOM error; `read_all` errors now distinguish it from zlib data errors), and `Result<_, AllocError>` from `decompress_to_vec_grow`, whose only caller is this file.
- The ISIZE reservation is only an estimate read from untrusted bytes, so when it is refused the decompressor falls back to the input-sized buffer and grows from there, as it already does for sizes above 256 MiB. The real output size then decides the outcome: a payload that is genuinely too large fails while growing, while a member followed by bytes that happen to claim a huge size still decodes. Only a refused fallback buffer throws.
- The zlib compressor's input-sized initial buffer is gone: `ZlibCompressorArrayList::init` immediately re-reserves it to `deflateBound`, so that `deflateBound` reservation is now the single (fallible) allocation. The final buffer is unchanged since the result is shrunk to fit before it is handed to JSC.
- Why this is the right shape: how large a buffer these calls may ask for depends on the host, not on any fixed limit, so the allocator has to be asked and its answer reported to the caller like every other per-call failure. Nothing changes while allocations succeed (`try_reserve` grows a `Vec` exactly like `reserve` does), and a refused allocation previously aborted, so no existing result is altered. The small fixed-size allocations (the boxed zlib stream, libdeflate's own state) keep the existing crash-on-OOM policy; this change is about the buffers whose size the caller's data controls.
- Verified with `test/js/bun/util/zstd.test.ts` (new block `gzip/deflate sync APIs throw when an output buffer cannot be allocated`): one child under ASAN's per-allocation cap runs twelve cases, one per refused reservation (both libraries: the compression bounds, the input-sized decompression buffer, the zlib and libdeflate growth steps, a truthful ISIZE that falls back and then fails while growing, and a claimed size after a small member that falls back and decodes), checks each throws `RangeError: Out of memory` (or decodes, for the last pair) and that the process still round-trips afterwards. Without the fix the child aborts at the first case (exit 134); with it the test passes.
- Also run: the rest of `zstd.test.ts`, `test/js/node/zlib/zlib.test.js` (round trips both libraries), `test/js/web/fetch/fetch-gzip.test.ts`, the gzip regression tests under `test/regression/issue/`, an ad-hoc script round-tripping 1008 combinations of sizes (0 to 3 MiB, including stored level 0 where the output exceeds the input), levels and library pairs on the debug build, and `cargo clippy` on `bun_zlib`, `bun_libdeflate_sys` and `bun_runtime`.
- The zstd functions in the same file have the same bug; that is #39038, which touches only the zstd code and a different part of the same test file.

### Background
- `Vec::with_capacity`, `reserve` and `reserve_exact` call Rust's allocation error handler when the allocator returns null, which prints `memory allocation of N bytes failed` and aborts; the `try_` variants return `Err` instead and leave the `Vec` as it was. Both families grow a `Vec` by the same policy, so swapping them changes nothing when the allocation succeeds.
- `deflateBound` (zlib) and `libdeflate_*_compress_bound` give the most output a compressor can produce for an input of a given size, slightly more than the input itself. Both backends here compress in one shot into a buffer of that size.
- A gzip member ends with an 8-byte trailer: the CRC-32 of the uncompressed data and ISIZE, its length modulo 2^32. `gunzipSync` reads the last 4 bytes of whatever it is given as a guess for the output size. Both backends here decode one member and ignore whatever follows it (node also ignores trailing bytes that do not start another member, which is what the test appends), so those 4 bytes need not describe the data that gets decoded.
- `ZlibReaderArrayList` / `ZlibCompressorArrayList` (`src/zlib/lib.rs`) drive zlib over a borrowed `Vec<u8>`: whenever zlib reports the buffer full (`avail_out == 0`) they grow the `Vec` and point zlib at the new spare capacity. `reserve_expand_tail(0)` is the existing helper for exposing already-reserved capacity to C. libdeflate has no streaming decode, so `decompress_to_vec_grow` instead retries from scratch with a buffer twice as large each time.
- The test relies on ASAN's `max_allocation_size_mb` with `allocator_may_return_null=1`: under the debug/ASAN build every Rust allocation goes through ASAN's malloc, which refuses anything above the cap, while the `Buffer`s the script creates are allocated by JSC's own allocator and are unaffected. That makes the failing allocation deterministic and cheap, so the block is `describe.skipIf(!isASAN)`. The 12 MiB payloads are produced with `node:zlib`, which streams through chunk-sized buffers and so works under the cap.
