### PR TITLE
inspect: print an own enumerable Symbol.toStringTag and hide the non-enumerable __esModule marker on the fast property walk too

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5525,9 +5525,16 @@ restart:
             }
             auto* prop = entry.key();
 
-            if (prop == propertyNames->constructor
-                || prop == propertyNames->underscoreProto
-                || prop == propertyNames->toStringTagSymbol || (objectToUse != object && prop == propertyNames->__esModule))
+            if (prop == propertyNames->constructor)
+                return true;
+
+            // Same rule as the slow path below: these keys are only hidden when they are the
+            // non-enumerable markers classes and modules brand themselves with. An enumerable
+            // one is ordinary user data and prints like any other key.
+            if ((entry.attributes() & PropertyAttribute::DontEnum) != 0
+                && (prop == propertyNames->underscoreProto
+                    || prop == propertyNames->toStringTagSymbol
+                    || prop == propertyNames->__esModule))
                 return true;
 
             if (builtinNames.bunNativePtrPrivateName() == prop)

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -687,6 +687,104 @@ it("Symbol", () => {
   expect(Bun.inspect(Symbol(""))).toBe("Symbol()");
 });
 
+// Objects made only of data properties are enumerated straight from their Structure (fast
+// path); a getter takes the same object through getOwnPropertyNames (slow path); `sorted`
+// uses a third walker. Which keys get hidden must not depend on the path taken.
+describe("Symbol.toStringTag property", () => {
+  it("prints an own enumerable Symbol.toStringTag on every enumeration path", () => {
+    expect(Bun.inspect({ a: 1, [Symbol.toStringTag]: "Tag" })).toBe(
+      'Tag {\n  a: 1,\n  [Symbol(Symbol.toStringTag)]: "Tag",\n}',
+    );
+    expect(Bun.inspect({ a: 1, get g() {}, [Symbol.toStringTag]: "Tag" })).toBe(
+      'Tag {\n  a: 1,\n  g: [Getter],\n  [Symbol(Symbol.toStringTag)]: "Tag",\n}',
+    );
+    expect(Bun.inspect({ a: 1, [Symbol.toStringTag]: "Tag" }, { sorted: true })).toBe(
+      'Tag {\n  [Symbol(Symbol.toStringTag)]: "Tag",\n  a: 1,\n}',
+    );
+  });
+
+  it("hides an own non-enumerable Symbol.toStringTag on every enumeration path", () => {
+    const data = { a: 1 };
+    Object.defineProperty(data, Symbol.toStringTag, { value: "Tag" });
+    expect(Bun.inspect(data)).toBe("Tag {\n  a: 1,\n}");
+    expect(Bun.inspect(data, { sorted: true })).toBe("Tag {\n  a: 1,\n}");
+
+    const withGetter = { a: 1, get g() {} };
+    Object.defineProperty(withGetter, Symbol.toStringTag, { value: "Tag" });
+    expect(Bun.inspect(withGetter)).toBe("Tag {\n  a: 1,\n  g: [Getter],\n}");
+  });
+
+  it("applies the same enumerability rule to the prototypes it walks", () => {
+    // Non-enumerable, the way classes and builtins brand themselves: hidden.
+    class Branded {
+      a = 1;
+      method() {}
+    }
+    Object.defineProperty(Branded.prototype, Symbol.toStringTag, { value: "Branded" });
+    expect(Bun.inspect(new Branded())).toBe("Branded {\n  a: 1,\n  method: [Function: method],\n}");
+
+    class BrandedByGetter {
+      a = 1;
+      get [Symbol.toStringTag]() {
+        return "BrandedByGetter";
+      }
+    }
+    expect(Bun.inspect(new BrandedByGetter())).toBe("BrandedByGetter {\n  a: 1,\n}");
+
+    // Plain assignment makes it enumerable, and enumerable prototype data is printed,
+    // whether or not the prototype also has a getter.
+    class Assigned {
+      a = 1;
+      method() {}
+    }
+    Assigned.prototype[Symbol.toStringTag] = "Assigned";
+    expect(Bun.inspect(new Assigned())).toBe(
+      'Assigned {\n  a: 1,\n  method: [Function: method],\n  [Symbol(Symbol.toStringTag)]: "Assigned",\n}',
+    );
+
+    class AssignedWithGetter {
+      a = 1;
+      get g() {}
+    }
+    AssignedWithGetter.prototype[Symbol.toStringTag] = "AssignedWithGetter";
+    expect(Bun.inspect(new AssignedWithGetter())).toBe(
+      'AssignedWithGetter {\n  a: 1,\n  g: [Getter],\n  [Symbol(Symbol.toStringTag)]: "AssignedWithGetter",\n}',
+    );
+  });
+});
+
+describe("__esModule property", () => {
+  it("hides the non-enumerable marker compiled CommonJS modules define, with or without re-export getters", () => {
+    // What tsc / babel emit: Object.defineProperty(exports, "__esModule", { value: true })
+    const dataOnly = {};
+    Object.defineProperty(dataOnly, "__esModule", { value: true });
+    dataOnly.foo = 1;
+    expect(Bun.inspect(dataOnly)).toBe("{\n  foo: 1,\n}");
+
+    const withReExport = {};
+    Object.defineProperty(withReExport, "__esModule", { value: true });
+    withReExport.foo = 1;
+    Object.defineProperty(withReExport, "bar", { enumerable: true, get: () => 2 });
+    expect(Bun.inspect(withReExport)).toBe("{\n  foo: 1,\n  bar: [Getter],\n}");
+  });
+
+  it("prints an enumerable __esModule like any other key", () => {
+    expect(Bun.inspect({ __esModule: true, foo: 1 })).toBe("{\n  __esModule: true,\n  foo: 1,\n}");
+    expect(Bun.inspect({ __esModule: true, foo: 1, get g() {} })).toBe(
+      "{\n  __esModule: true,\n  foo: 1,\n  g: [Getter],\n}",
+    );
+
+    // Inherited ones follow the same rule on both paths.
+    const dataOnly = Object.create({ __esModule: true, method() {} });
+    dataOnly.x = 1;
+    expect(Bun.inspect(dataOnly)).toBe("{\n  x: 1,\n  __esModule: true,\n  method: [Function: method],\n}");
+
+    const withGetter = Object.create({ __esModule: true, get g() {} });
+    withGetter.x = 1;
+    expect(Bun.inspect(withGetter)).toBe("{\n  x: 1,\n  __esModule: true,\n  g: [Getter],\n}");
+  });
+});
+
 it("CloseEvent", () => {
   const closeEvent = new CloseEvent("close", {
     code: 1000,


### PR DESCRIPTION
### Problem
- `console.log({ a: 1, [Symbol.toStringTag]: "Tag" })` prints `Tag { a: 1 }`, but adding any getter to the same object makes the key appear: `Tag { a: 1, g: [Getter], [Symbol(Symbol.toStringTag)]: "Tag" }`. `Bun.inspect(obj, { sorted: true })` and node print the key in both cases.
- `console.log(require("./compiled.cjs"))` for a tsc/babel-compiled module prints the non-enumerable `__esModule: true` marker when the module only has data exports, and hides it as soon as the module has a re-export getter. Node hides it in both cases.
- Cause: `JSC__JSValue__forEachPropertyImpl` in `src/jsc/bindings/bindings.cpp` has two enumeration paths that apply different rules to these two keys. The fast path (`structure->forEachProperty` lambda, line 5528 on main) skipped `Symbol.toStringTag` unconditionally and `__esModule` whenever it came from a prototype; the slow path (line 5635) and `forEachPropertyOrdered` (line 5799) skip them only when the property is non-enumerable. Which path an object takes is an implementation detail (a getter or indexed properties, for example, force the slow path), so the output depended on it.

### Fix
- The fast path now hides `__proto__`, `Symbol.toStringTag` and `__esModule` under the same condition as the slow path: only when the entry is `DontEnum`. No other line changes; the `constructor` skip and the slow path are untouched.
- Why non-enumerable is the right line: the non-enumerable form is how classes and builtins brand themselves (`get [Symbol.toStringTag]()` on a class prototype, `Object.defineProperty(prototype, Symbol.toStringTag, ...)`) and how compiled CommonJS marks itself (`Object.defineProperty(exports, "__esModule", { value: true })`). That is the form the skip exists for, and it stays hidden. An enumerable one was put there by a literal or an assignment and is user data; the formatter already prints every other enumerable property, including inherited ones, and two of the three walkers already printed these.
- The `__esModule` rule that is dropped (hide when inherited) was added in #14691 alongside the slow path's `DontEnum` rule, for the `__esModule` accessor bun installs on the prototype of module namespace objects. That accessor is `DontEnum`, so it is still hidden (and namespace objects never take the fast path anyway).
- Output changes only for objects printed through the fast path that own or inherit an enumerable `Symbol.toStringTag` (now printed) or own a non-enumerable `__esModule` (now hidden), which in both cases is what the same object already printed once it had a getter. `{ [Symbol.toStringTag]: "x" }` with no other properties already printed the key (the empty fast walk fell through to the slow path), so the committed `console-log.expected.txt` is unchanged.
- Not changed: `forEachPropertyOrdered` (expect diffs, snapshots, `sorted: true`) never hides `__esModule`; it is a separate walker with a consistent rule of its own, and changing it would alter existing snapshots.
- Verified with `bun bd test test/js/bun/util/inspect.test.js`: the new `Symbol.toStringTag property` and `__esModule property` tests cover the fast, slow (getter) and sorted walkers for own enumerable, own non-enumerable and prototype properties; 4 of the 5 fail on the build without this change, the fifth (non-enumerable stays hidden) guards against over-correcting. `test/js/web/console`, `test/js/bun/console`, `test/cli/run/esm-defineProperty.test.ts`, `test/js/bun/resolve/esModule*.test.*` and the rest of `test/js/bun/util` pass.

### Background
- `console.log` and `Bun.inspect` do not enumerate properties themselves; the Rust formatter calls `JSC__JSValue__forEachProperty`, which lists the object's own properties and then walks up to five prototypes so that class methods are shown. When the object's JSC `Structure` allows it (no accessors, no indexed properties, no custom property lookup) it reads the property table directly (fast path); otherwise it calls `getOwnPropertyNames` and looks each property up (slow path). `forEachPropertyOrdered` is a third walker that lists own properties sorted by name; it backs `sorted: true` and the test runner's diff printer.
- `DontEnum` is JSC's attribute for `enumerable: false`. Class methods and accessors, `Object.defineProperty` defaults and bun's native prototypes use it; object literals and plain assignment create enumerable properties. Both formatters print non-enumerable properties in general (that is how prototype methods show up), which is why hiding the branding keys needs an explicit rule rather than falling out of an enumerable-only listing.

<details>
<summary>Before / after for the shapes the tests cover</summary>

```
                                                    before (fast path)        after
{ a: 1, [Symbol.toStringTag]: "Tag" }               Tag { a: 1 }              Tag { a: 1, [Symbol(Symbol.toStringTag)]: "Tag" }
same object with a getter (slow path)               prints the key            unchanged
defineProperty(obj, Symbol.toStringTag, ...)        Tag { a: 1 }              unchanged
class with get [Symbol.toStringTag]()               K { a: 1 }                unchanged
defineProperty(K.prototype, Symbol.toStringTag)     K { a: 1, method }        unchanged
K.prototype[Symbol.toStringTag] = "K" (enumerable)  K { a: 1, method }        K { a: 1, method, [Symbol(Symbol.toStringTag)]: "K" }
  (same class with a getter already printed the key)

defineProperty(exports, "__esModule", {value:true}) { __esModule: true, foo } { foo }
  (same exports object with a re-export getter already printed { foo, bar: [Getter] })
{ __esModule: true, foo: 1 } (enumerable)           prints the key            unchanged
Object.create({ __esModule: true, method(){} })     { x, method }             { x, __esModule: true, method }
  (same prototype with a getter already printed __esModule)
```
</details>
