### PR TITLE
ci(binary-size): find the baseline through Buildkite and fail PR builds that have nothing to compare against

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -959,8 +959,9 @@ function getWindowsSignStep(windowsPlatforms, options) {
 /**
  * Aggregates stripped-binary sizes from every release build, compares them
  * against the latest main build's binary-sizes.json, and fails if any grew
- * past the threshold. Runs on PR builds (comparison) and main (record-only,
- * to produce the baseline artifact).
+ * past the threshold, or if no main build with a binary-sizes.json could be
+ * found (a comparison that did not happen is not a pass). Runs on PR builds
+ * (comparison) and main (record-only, to produce the baseline artifact).
  *
  * @param {Platform[]} releasePlatforms
  * @param {PipelineOptions} options

--- a/scripts/binary-size.ts
+++ b/scripts/binary-size.ts
@@ -1,5 +1,5 @@
 // Measure stripped binary sizes for every release platform and compare them
-// against the latest finished `main` build ("canary").
+// against the newest `main` build that recorded its own ("canary").
 //
 // CI mode (invoked from .buildkite/ci.mjs after all *-build-bun jobs finish):
 //   bun scripts/binary-size.ts \
@@ -8,10 +8,19 @@
 //     [--no-fail] [--release]
 //
 //   Always posts an annotation with sizes and deltas. On PR builds it fails if
-//   any binary grew by more than --threshold-mb vs canary; on main it never
-//   fails (--no-fail) but still shows the comparison against the previous main
+//   any binary grew by more than --threshold-mb vs canary, and also if no
+//   canary baseline could be found: this step is the only size gate, so a run
+//   that compared nothing must not pass as if it had. On main it never fails
+//   (--no-fail) but still shows the comparison against the previous main
 //   build. Escape hatch: put `[skip size check]` in the commit message, which
 //   makes ci.mjs set soft_fail on this step (it still runs and annotates).
+//
+//   The baseline comes from Buildkite alone: the pipeline's public build list
+//   names the recent main builds, and buildkite-agent downloads the
+//   binary-sizes.json this step uploaded on the newest usable one. (It used to
+//   map main commits to builds through the GitHub API; CI shares that token,
+//   and every time it was rate limited this step had nothing to compare
+//   against and passed anyway.)
 //
 // Local mode (no args):
 //   bun scripts/binary-size.ts
@@ -52,18 +61,15 @@ const org = process.env.BUILDKITE_ORGANIZATION_SLUG || "bun";
 const pipeline = process.env.BUILDKITE_PIPELINE_SLUG || "bun";
 const buildNumber = process.env.BUILDKITE_BUILD_NUMBER;
 const branch = process.env.BUILDKITE_BRANCH;
+// https://buildkite.com/<org>/<pipeline>/builds/<n> -> https://buildkite.com/<org>/<pipeline>
+const pipelineUrl =
+  process.env.BUILDKITE_BUILD_URL?.replace(/\/builds\/.*$/, "") || `https://buildkite.com/${org}/${pipeline}`;
 
 function agent(args: string[], opts: { quiet?: boolean } = {}): string | undefined {
   const { exitCode, stdout } = Bun.spawnSync(["buildkite-agent", ...args], {
     stderr: opts.quiet ? "ignore" : "inherit",
   });
   return exitCode === 0 ? stdout.toString().trim() : undefined;
-}
-
-async function getSecret(name: string): Promise<string | undefined> {
-  const { exitCode, stdout } = Bun.spawnSync(["buildkite-agent", "secret", "get", name], { stderr: "ignore" });
-  if (exitCode !== 0) return undefined;
-  return stdout.toString().trim() || undefined;
 }
 
 // ─── Collect current build's sizes from meta-data ───
@@ -88,72 +94,94 @@ await Bun.write(
 );
 agent(["artifact", "upload", "binary-sizes.json"]);
 
-// ─── Baselines ───
+// ─── Baseline: the newest main build with a usable binary-sizes.json ───
 
-type Baseline = { label: string; href?: string; sizes: Sizes };
+type Baseline = { label: string; href: string; sizes: Sizes };
 
-const ghToken = (await getSecret("GITHUB_TOKEN")) ?? process.env.GITHUB_TOKEN;
-const ghHeaders: Record<string, string> = ghToken ? { Authorization: `Bearer ${ghToken}` } : {};
+// A main build superseded by the next push is canceled before its build-bun
+// jobs finish and records nothing; merge bursts produce 20+ such builds in a
+// row, so look well past one page of the build list. Without credentials the
+// list ends after page 4 (80 builds; HTTP 403 beyond that).
+const MAX_MAIN_BUILDS_TO_TRY = 60;
 
-async function githubJson<T>(path: string): Promise<T> {
-  const res = await fetch(`https://api.github.com/repos/oven-sh/bun/${path}`, { headers: ghHeaders });
-  if (!res.ok) throw new Error(`github ${path}: ${res.status}`);
-  return res.json() as Promise<T>;
+// Numbers of the recent main builds, newest first, from the pipeline's public
+// build list (HTML, 20 builds per page, no credentials). Ends after the last
+// page, or sooner if the list stops linking to builds.
+async function* recentMainBuilds(): AsyncGenerator<number> {
+  const buildLink = new RegExp(`${RegExp.escape(new URL(pipelineUrl).pathname)}/builds/(\\d+)`, "g");
+  const seen = new Set<number>();
+  for (let page = 1; ; page++) {
+    const url = `${pipelineUrl}/builds?branch=main&page=${page}`;
+    const res = await fetch(url, { headers: { Accept: "text/html" } });
+    if (!res.ok) throw new Error(`${url}: HTTP ${res.status}`);
+    const linked = Array.from((await res.text()).matchAll(buildLink), m => parseInt(m[1], 10));
+    const numbers = [...new Set(linked)].filter(n => !seen.has(n));
+    if (numbers.length === 0) return;
+    for (const n of numbers) seen.add(n);
+    yield* numbers.sort((a, b) => b - a);
+  }
 }
 
-async function buildNumberForCommit(sha: string): Promise<number | undefined> {
-  const { statuses } = await githubJson<{ statuses: { context: string; target_url: string }[] }>(
-    `commits/${sha}/status`,
-  );
-  const bk = statuses.find(s => s.context.startsWith("buildkite/"));
-  const m = bk?.target_url.match(/\/builds\/(\d+)/);
-  return m ? parseInt(m[1], 10) : undefined;
-}
-
-async function sizesFromBuild(n: number): Promise<{ sizes: Sizes; release?: boolean } | undefined> {
-  const res = await fetch(`https://buildkite.com/${org}/${pipeline}/builds/${n}.json`);
-  if (!res.ok) return;
-  const { id } = (await res.json()) as { id: string };
+// The sizes this step recorded on main build `n`, or undefined (with the reason
+// logged) if that build has nothing this build can be compared against.
+async function baselineSizes(n: number): Promise<Sizes | undefined> {
+  const skip = (why: string) => {
+    console.log(`  main #${n} ${why}`);
+    return undefined;
+  };
+  const res = await fetch(`${pipelineUrl}/builds/${n}.json`);
+  if (!res.ok) return skip(`could not be read: HTTP ${res.status}`);
+  const { id, branch_name } = (await res.json()) as { id: string; branch_name?: string };
+  // The list was filtered by branch; this only matters if its markup changes.
+  if (branch_name !== "main") return skip(`is not a main build (branch: ${branch_name})`);
   const dir = "binary-size-tmp";
   rmSync(dir, { recursive: true, force: true });
   mkdirSync(dir, { recursive: true });
-  const ok = agent(["artifact", "download", "binary-sizes.json", dir, "--build", id], { quiet: true });
-  if (ok === undefined) return;
-  return (await Bun.file(`${dir}/binary-sizes.json`).json()) as { sizes: Sizes; release?: boolean };
-}
-
-async function baselineFromCommit(sha: string, label: (n: number) => string): Promise<Baseline | undefined> {
-  const n = await buildNumberForCommit(sha);
-  if (!n || String(n) === String(buildNumber)) return;
-  const record = await sizesFromBuild(n);
-  if (!record) return;
+  if (agent(["artifact", "download", "binary-sizes.json", dir, "--build", id], { quiet: true }) === undefined) {
+    return skip("has no binary-sizes.json (its binary-size step did not run)");
+  }
+  const record = (await Bun.file(`${dir}/binary-sizes.json`).json()) as { sizes?: Sizes; release?: boolean };
   // Only compare like-for-like: canary builds against canary baselines, release
   // against release. Windows binaries differ by several MB between the two, so
   // a release build on main would otherwise trip every PR's threshold.
-  if ((record.release ?? false) !== isRelease) return;
-  return { label: label(n), href: `https://buildkite.com/${org}/${pipeline}/builds/${n}`, sizes: record.sizes };
+  if ((record.release ?? false) !== isRelease) return skip(`is a ${record.release ? "release" : "canary"} build`);
+  // An all-targets build failure on main uploads a record with no sizes;
+  // comparing against it would compare nothing.
+  if (!targets.some(({ triplet }) => record.sizes?.[triplet])) return skip("recorded no sizes for these targets");
+  return record.sizes;
 }
 
-// Canary: walk recent main commits until one whose build has a matching
-// (canary vs release) binary-sizes.json.
-console.log(`--- Fetching ${buildKind} baseline`);
-let canaryNote = "";
-const canary: Baseline | undefined = await (async () => {
-  const commits = await githubJson<{ sha: string }[]>("commits?sha=main&per_page=15");
-  for (const { sha } of commits) {
-    const b = await baselineFromCommit(sha, n => `main #${n}`);
-    if (b) return b;
+console.log(`--- Looking for the newest main build with ${buildKind} sizes`);
+let baseline: Baseline | undefined;
+let baselineNote = "";
+try {
+  let unusable = 0;
+  for await (const n of recentMainBuilds()) {
+    if (String(n) === buildNumber) continue;
+    const sizes = await baselineSizes(n);
+    if (sizes) {
+      baseline = { label: `main #${n}`, href: `${pipelineUrl}/builds/${n}`, sizes };
+      break;
+    }
+    if (++unusable === MAX_MAIN_BUILDS_TO_TRY) break;
   }
-  canaryNote = `no recent main ${buildKind} build has binary-sizes.json yet`;
-})().catch(e => ((canaryNote = String(e?.message || e)), undefined));
-console.log(canary ? `  ${canary.label}` : `  unavailable: ${canaryNote}`);
+  if (!baseline) {
+    baselineNote =
+      unusable === 0
+        ? `no main builds listed at ${pipelineUrl}/builds?branch=main`
+        : `the last ${unusable} main build(s) recorded no ${buildKind} sizes`;
+  }
+} catch (e: any) {
+  baselineNote = String(e?.message || e);
+}
+console.log(baseline ? `  ${baseline.label}: ${baseline.href}` : `  none: ${baselineNote}`);
 
 // ─── Compare & annotate ───
 
 console.log("--- Results");
 
 type Delta = { base: number; bytes: number };
-type Row = { triplet: string; now: number; canary?: Delta };
+type Row = { triplet: string; now: number; delta?: Delta };
 
 function delta(now: number, base: number | undefined): Delta | undefined {
   if (!base) return undefined;
@@ -166,14 +194,16 @@ const rows: Row[] = targets
   .map(({ triplet }) => ({
     triplet,
     now: sizes[triplet],
-    canary: delta(sizes[triplet], canary?.sizes[triplet]),
+    delta: delta(sizes[triplet], baseline?.sizes[triplet]),
   }));
 
-const overThreshold = rows.filter(r => r.canary && r.canary.bytes > thresholdBytes);
-const failed = !noFail && overThreshold.length > 0;
-
-const link = (b: Baseline | undefined, fallback: string) =>
-  b?.href ? `<a href="${b.href}">${b.label}</a>` : (b?.label ?? `${fallback} (n/a)`);
+const overThreshold = rows.filter(r => r.delta && r.delta.bytes > thresholdBytes);
+// Built binaries with nothing to compare them against fail the step (see the
+// header comment), with two exceptions: a release baseline only exists for a
+// while after a release ran on main, and a build that produced no binaries is
+// already red from its build-bun jobs.
+const blind = !baseline && rows.length > 0 && !isRelease;
+const failed = !noFail && (overThreshold.length > 0 || blind);
 
 const deltaCells = (d: Delta | undefined, over: boolean) => {
   if (!d) return `<td align="right">—</td><td align="right">—</td>`;
@@ -185,11 +215,11 @@ const deltaCells = (d: Delta | undefined, over: boolean) => {
 
 const tableRows = rows
   .map(r => {
-    const over = !!r.canary && r.canary.bytes > thresholdBytes;
+    const over = !!r.delta && r.delta.bytes > thresholdBytes;
     return (
       `<tr><td>${over ? "❌ " : ""}<code>${r.triplet}</code></td>` +
       `<td align="right">${fmtBytes(r.now)}</td>` +
-      deltaCells(r.canary, over) +
+      deltaCells(r.delta, over) +
       `</tr>`
     );
   })
@@ -199,9 +229,19 @@ const limit = fmtBytes(thresholdBytes);
 const header =
   overThreshold.length > 0
     ? `<b>${overThreshold.length}</b> over ${limit}`
-    : canary
-      ? `all within ${limit}`
-      : `no ${buildKind} comparison (${canaryNote})`;
+    : rows.length === 0
+      ? "nothing to measure, no build-bun job recorded a size"
+      : baseline
+        ? `all within ${limit}`
+        : `no ${buildKind} baseline, nothing compared (${Bun.escapeHTML(baselineNote)})`;
+const style = failed ? "error" : baseline && rows.length > 0 ? "info" : "warning";
+
+const advice = !failed
+  ? ""
+  : blind
+    ? `<p>This step fails rather than pass without comparing anything. Retry it if buildkite.com was unavailable; ` +
+      `otherwise its log lists the main builds it tried.</p>`
+    : `<p>Add <code>[skip size check]</code> to the commit message if this increase is intentional.</p>`;
 
 const annotation = `
 <details${failed ? " open" : ""}>
@@ -209,35 +249,30 @@ const annotation = `
 <table>
 <tr>
   <th rowspan="2">target</th><th rowspan="2">this build</th>
-  <th colspan="2">${buildKind}: ${link(canary, "main")}</th>
+  <th colspan="2">${buildKind}: ${baseline ? `<a href="${baseline.href}">${baseline.label}</a>` : "main (n/a)"}</th>
 </tr>
 <tr><th>size</th><th>Δ</th></tr>
 ${tableRows}
 </table>
-${failed ? `<p>Add <code>[skip size check]</code> to the commit message if this increase is intentional.</p>` : ""}
+${advice}
 </details>`;
 
 Bun.spawnSync(
-  [
-    "buildkite-agent",
-    "annotate",
-    "--style",
-    failed ? "error" : "info",
-    "--context",
-    "binary-size",
-    "--priority",
-    failed ? "5" : "2",
-  ],
+  ["buildkite-agent", "annotate", "--style", style, "--context", "binary-size", "--priority", failed ? "5" : "2"],
   { stdin: new Blob([annotation]), stderr: "inherit" },
 );
 
 for (const r of rows) {
-  const c = r.canary ? `  ${buildKind} ${fmtDelta(r.canary.bytes).padStart(10)}` : "";
+  const c = r.delta ? `  ${buildKind} ${fmtDelta(r.delta.bytes).padStart(10)}` : "";
   console.log(`  ${r.triplet.padEnd(30)} ${fmtBytes(r.now).padStart(10)}${c}`);
 }
 
 if (failed) {
-  console.error(`\nerror: ${overThreshold.length} target(s) exceeded ${limit} vs ${buildKind}`);
+  console.error(
+    blind
+      ? `\nerror: nothing to compare against: ${baselineNote}`
+      : `\nerror: ${overThreshold.length} target(s) exceeded ${limit} vs ${buildKind}`,
+  );
   // Suppress the generic fallback in .buildkite/hooks/pre-exit; this script
   // owns its failure annotation.
   markBuildkiteStepReported();

--- a/test/internal/binary-size.test.ts
+++ b/test/internal/binary-size.test.ts
@@ -1,0 +1,274 @@
+/**
+ * scripts/binary-size.ts is the CI step that fails a PR build when a shipped
+ * binary grew past the threshold compared with the newest main build that
+ * recorded its sizes. Everything it talks to is replaced here: buildkite.com
+ * (the public build list and per-build .json, reached through
+ * BUILDKITE_BUILD_URL) by a local server, and buildkite-agent (meta-data of
+ * this build, the binary-sizes.json artifacts of main builds, the annotation)
+ * by a shell script on PATH that reads and writes files under FAKE_DIR.
+ * Shell-script fakes don't resolve as executables on Windows, hence the skip;
+ * the real step only runs on Linux anyway.
+ *
+ * Every run loads the script (and scripts/utils.mjs) in a fresh debug-build
+ * process, which takes a couple of seconds, hence the per-test timeouts and
+ * scenarios that each pack in as much as they can.
+ */
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { chmodSync } from "node:fs";
+import { join } from "node:path";
+
+const script = join(import.meta.dir, "..", "..", "scripts", "binary-size.ts");
+
+const fakeAgent = [
+  "#!/bin/sh",
+  'case "$1 $2" in',
+  '  "meta-data get") cat "$FAKE_DIR/meta/$3" 2>/dev/null ;;',
+  '  "artifact upload") exit 0 ;;',
+  // artifact download binary-sizes.json <dir> --build <build uuid>
+  '  "artifact download") [ "$5" = --build ] && cp "$FAKE_DIR/artifacts/$6.json" "$4/$3" 2>/dev/null ;;',
+  '  "annotate "*) shift; echo "$*" > "$FAKE_DIR/annotation.args"; cat > "$FAKE_DIR/annotation.html" ;;',
+  "  *) exit 1 ;;",
+  "esac",
+  "",
+].join("\n");
+
+type Sizes = Record<string, number>;
+
+interface MainBuild {
+  number: number;
+  /** What that build's binary-size step uploaded; absent when the step never ran there. */
+  record?: { release?: boolean; sizes: Sizes };
+  /** `branch_name` in the build's .json. */
+  branch?: string;
+}
+
+interface Scenario {
+  /** `binary-size:<triplet>` meta-data of the build under test. */
+  sizes: Sizes;
+  /** Main builds in the order the build list shows them, 20 per page. */
+  main: MainBuild[];
+  /** Answer the build list with this status instead of a page. */
+  listStatus?: number;
+  args?: string[];
+}
+
+const TARGETS = ["bun-linux-x64", "bun-darwin-aarch64"];
+const BASE: Sizes = { "bun-linux-x64": 80_000_000, "bun-darwin-aarch64": 60_000_000 };
+const BUILD_NUMBER = "999";
+
+async function runBinarySize({ sizes, main, listStatus, args = [] }: Scenario) {
+  using server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname === "/bun/bun/builds" && url.searchParams.get("branch") === "main") {
+        if (listStatus) return new Response("", { status: listStatus });
+        const page = Number(url.searchParams.get("page") ?? 1);
+        // Like buildkite.com, every row links to its build and lazy-loads the
+        // build's steps from a sub-path, so each number appears twice.
+        const rows = main
+          .slice((page - 1) * 20, page * 20)
+          .map(
+            ({ number }) =>
+              `<a href="/bun/bun/builds/${number}">#${number}</a>` +
+              `<turbo-frame src="/bun/bun/builds/${number}/steps_turbo"></turbo-frame>`,
+          );
+        return new Response(`<html><body>${rows.join("\n")}</body></html>`, {
+          headers: { "content-type": "text/html" },
+        });
+      }
+      const build = main.find(b => url.pathname === `/bun/bun/builds/${b.number}.json`);
+      if (build) return Response.json({ id: `uuid-${build.number}`, branch_name: build.branch ?? "main" });
+      return new Response("", { status: 404 });
+    },
+  });
+  const pipelineUrl = `http://127.0.0.1:${server.port}/bun/bun`;
+
+  const files: Record<string, string> = { "fake/bin/buildkite-agent": fakeAgent };
+  for (const [triplet, bytes] of Object.entries(sizes)) files[`fake/meta/binary-size:${triplet}`] = String(bytes);
+  for (const { number, record } of main)
+    if (record) files[`fake/artifacts/uuid-${number}.json`] = JSON.stringify(record);
+  using dir = tempDir("binary-size", files);
+  const fake = join(String(dir), "fake");
+  chmodSync(join(fake, "bin", "buildkite-agent"), 0o755);
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), script, "--targets", JSON.stringify(TARGETS.map(triplet => ({ triplet }))), ...args],
+    cwd: String(dir),
+    env: {
+      ...bunEnv,
+      PATH: `${join(fake, "bin")}:${bunEnv.PATH}`,
+      FAKE_DIR: fake,
+      BUILDKITE_BUILD_URL: `${pipelineUrl}/builds/${BUILD_NUMBER}`,
+      BUILDKITE_BUILD_NUMBER: BUILD_NUMBER,
+      BUILDKITE_BRANCH: "some-pr-branch",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [annotation, annotateArgs] = await Promise.all([
+    Bun.file(join(fake, "annotation.html")).text(),
+    Bun.file(join(fake, "annotation.args")).text(),
+  ]);
+  return {
+    stdout,
+    stderr,
+    exitCode,
+    pipelineUrl,
+    /** The `main #<n> ...` log lines: which main builds were tried, in order, and why each was skipped. */
+    tried: stdout.split("\n").filter(line => line.startsWith("  main #")),
+    summary: annotation.match(/<summary>(.*)<\/summary>/)![1],
+    annotation,
+    annotateArgs: annotateArgs.trim(),
+  };
+}
+
+describe.skipIf(isWindows)("scripts/binary-size.ts", () => {
+  test.concurrent(
+    "compares against the newest usable main build and fails a target over the threshold",
+    async () => {
+      const r = await runBinarySize({
+        sizes: {
+          "bun-linux-x64": BASE["bun-linux-x64"] + 600_000,
+          "bun-darwin-aarch64": BASE["bun-darwin-aarch64"] - 2048,
+        },
+        // Deliberately not newest-first: the script must try builds by number.
+        main: [
+          { number: 280, record: { sizes: {} } },
+          { number: 300 },
+          { number: 265, record: { sizes: BASE } },
+          { number: 290, record: { release: true, sizes: BASE } },
+          { number: 270, record: { sizes: BASE } },
+        ],
+      });
+      expect(r.tried).toEqual([
+        "  main #300 has no binary-sizes.json (its binary-size step did not run)",
+        "  main #290 is a release build",
+        "  main #280 recorded no sizes for these targets",
+        `  main #270: ${r.pipelineUrl}/builds/270`,
+      ]);
+      expect(r.summary).toBe("📦 Binary size — <b>1</b> over 0.50 MB");
+      expect(r.annotation).toContain(`<a href="${r.pipelineUrl}/builds/270">main #270</a>`);
+      expect(r.annotation).toContain(`❌ <code>bun-linux-x64</code></td><td align="right">76.87 MB</td>`);
+      expect(r.annotation).toContain(`<td align="right">76.29 MB</td><td align="right"><b>+585.9 KB</b></td>`);
+      expect(r.annotation).toContain(`<code>bun-darwin-aarch64</code></td><td align="right">57.22 MB</td>`);
+      expect(r.annotation).toContain(`<td align="right">57.22 MB</td><td align="right">-2.0 KB</td>`);
+      expect(r.annotation).toContain("[skip size check]");
+      expect(r.annotateArgs).toBe("--style error --context binary-size --priority 5");
+      expect(r.stderr).toBe("\nerror: 1 target(s) exceeded 0.50 MB vs canary\n");
+      expect(r.exitCode).toBe(1);
+    },
+    30_000,
+  );
+
+  test.concurrent(
+    "looks past a whole page of builds that recorded nothing and passes a build within the threshold",
+    async () => {
+      // A merge burst: main builds canceled by the next push before their
+      // build-bun jobs finished. One entry claims to be main in the list but its
+      // .json says otherwise; it must be ignored even though it has sizes.
+      const burst: MainBuild[] = Array.from({ length: 19 }, (_, i) => ({ number: 500 - i }));
+      const r = await runBinarySize({
+        sizes: { "bun-linux-x64": BASE["bun-linux-x64"] + 16_384, "bun-darwin-aarch64": BASE["bun-darwin-aarch64"] },
+        main: [
+          ...burst,
+          { number: 481, branch: "gh-readonly-queue/main/pr-1", record: { sizes: { "bun-linux-x64": 1 } } },
+          { number: 470, record: { sizes: BASE } },
+        ],
+      });
+      expect(r.tried).toHaveLength(21);
+      expect(r.tried).toContain("  main #481 is not a main build (branch: gh-readonly-queue/main/pr-1)");
+      expect(r.tried.at(-1)).toBe(`  main #470: ${r.pipelineUrl}/builds/470`);
+      expect(r.summary).toBe("📦 Binary size — all within 0.50 MB");
+      expect(r.annotation).toContain(`<a href="${r.pipelineUrl}/builds/470">main #470</a>`);
+      expect(r.annotation).toContain(`<td align="right">+16.0 KB</td>`);
+      expect(r.annotateArgs).toBe("--style info --context binary-size --priority 2");
+      expect(r.stderr).toBe("");
+      expect(r.exitCode).toBe(0);
+    },
+    30_000,
+  );
+
+  // The bug this guards against: the baseline lookup failed (the GitHub API
+  // this used to go through was rate limited about half the time) and the step
+  // passed with nothing compared, letting +2 MB through the 0.5 MB gate.
+  const noBaseline: [how: string, scenario: Partial<Scenario>, note: string][] = [
+    ["the build list cannot be fetched", { listStatus: 503 }, "builds?branch=main&amp;page=1: HTTP 503"],
+    [
+      "no listed main build recorded sizes",
+      { main: [{ number: 300 }, { number: 290 }] },
+      "the last 2 main build(s) recorded no canary sizes",
+    ],
+    ["the build list is empty", { main: [] }, "no main builds listed at "],
+  ];
+  for (const [how, scenario, note] of noBaseline) {
+    test.concurrent(
+      `fails a PR build instead of passing without a comparison when ${how}`,
+      async () => {
+        const r = await runBinarySize({ sizes: BASE, main: [], ...scenario });
+        expect(r.summary).toStartWith("📦 Binary size — no canary baseline, nothing compared (");
+        expect(r.summary).toContain(note);
+        expect(r.annotation).toContain("This step fails rather than pass without comparing anything.");
+        expect(r.annotation).toContain(`<code>bun-linux-x64</code></td><td align="right">76.29 MB</td>`);
+        expect(r.annotateArgs).toBe("--style error --context binary-size --priority 5");
+        expect(r.stderr).toStartWith("\nerror: nothing to compare against: ");
+        expect(r.exitCode).toBe(1);
+      },
+      30_000,
+    );
+  }
+
+  test.concurrent(
+    "--no-fail (main) reports a missing baseline as a warning and still exits 0",
+    async () => {
+      // On main the list includes the build under test itself (#999), which is
+      // never a baseline for itself.
+      const r = await runBinarySize({
+        sizes: BASE,
+        main: [{ number: Number(BUILD_NUMBER), record: { sizes: BASE } }, { number: 300 }],
+        args: ["--no-fail"],
+      });
+      expect(r.tried).toEqual(["  main #300 has no binary-sizes.json (its binary-size step did not run)"]);
+      expect(r.summary).toBe(
+        "📦 Binary size — no canary baseline, nothing compared (the last 1 main build(s) recorded no canary sizes)",
+      );
+      expect(r.annotateArgs).toBe("--style warning --context binary-size --priority 2");
+      expect(r.stderr).toBe("");
+      expect(r.exitCode).toBe(0);
+    },
+    30_000,
+  );
+
+  test.concurrent(
+    "--release compares only against release builds and stays informational without one",
+    async () => {
+      const r = await runBinarySize({
+        sizes: BASE,
+        main: [{ number: 300, record: { sizes: BASE } }],
+        args: ["--release"],
+      });
+      expect(r.tried).toEqual(["  main #300 is a canary build"]);
+      expect(r.summary).toBe(
+        "📦 Binary size — no release baseline, nothing compared (the last 1 main build(s) recorded no release sizes)",
+      );
+      expect(r.annotateArgs).toBe("--style warning --context binary-size --priority 2");
+      expect(r.stderr).toBe("");
+      expect(r.exitCode).toBe(0);
+    },
+    30_000,
+  );
+
+  test.concurrent(
+    "a build whose build-bun jobs recorded nothing has nothing to gate and only warns",
+    async () => {
+      const r = await runBinarySize({ sizes: {}, main: [{ number: 300, record: { sizes: BASE } }] });
+      expect(r.summary).toBe("📦 Binary size — nothing to measure, no build-bun job recorded a size");
+      expect(r.annotateArgs).toBe("--style warning --context binary-size --priority 2");
+      expect(r.stderr).toBe("");
+      expect(r.exitCode).toBe(0);
+    },
+    30_000,
+  );
+});


### PR DESCRIPTION
### Problem
- The `binary-size` CI step (`scripts/binary-size.ts`, run after the `*-build-bun` jobs) is the only check that a PR does not grow the shipped binaries by more than 0.5 MB. It passes without comparing anything whenever its baseline lookup fails: the annotation reads `Binary size - no canary comparison (github commits?sha=main&per_page=15: 403)` and the step exits 0.
- Cause: the baseline was found through the GitHub API (`githubJson("commits?sha=main...")`, then `commits/<sha>/status` per commit, to map main commits to Buildkite builds). The token is shared with the rest of CI and is regularly rate limited; the `.catch` at the end of the lookup turned any error into a note, `overThreshold` was empty, and `failed` stayed false.
- Impact: [build 97574](https://buildkite.com/bun/bun/builds/97574) (PR #38930) passed this step with the 403 note while `bun-linux-aarch64` went from 75.80 MB (main [#97480](https://buildkite.com/bun/bun/builds/97480)) to 77.99 MB (`-musl` +2.19 MB, `freebsd-aarch64` +1.87 MB, `windows-aarch64` +0.98 MB); the following main builds (e.g. [#97683](https://buildkite.com/bun/bun/builds/97683)) were blind the same way and now serve the grown sizes as the baseline. Of the 60 most recent builds with a binary-size annotation at the time, 18 carried that 403 note and 15 actually compared.

### Fix
- Baseline discovery no longer touches GitHub. `recentMainBuilds()` reads the pipeline's own build list for main (`https://buildkite.com/bun/bun/builds?branch=main&page=N`, anonymous, 20 builds per page, newest first) and takes the build numbers out of the `/bun/bun/builds/<n>` links; each candidate's public `builds/<n>.json` (the endpoint the script already used) supplies the build UUID for `buildkite-agent artifact download` and confirms `branch_name` is main. Everything the step needs is served by Buildkite itself, so there is no quota shared with anything else; the build list is the same public surface as the per-build `.json`, which has been working from this step all along.
- `baselineSizes()` keeps the existing skip rules (no artifact, canary vs release mismatch) and adds one: a record with no sizes for any current target (a main build where every build-bun job failed uploads `sizes: {}`) is skipped too, because comparing against it also compares nothing. Up to 60 builds are tried: the last 16 days of main had runs of 21, 9, 9 and 8 consecutive builds with nothing recorded (merge bursts, each build canceled by the next push), and anonymous access to the list stops after page 4, so 60 is past the observed worst case and inside the limit.
- The fixing lines for the vacuous pass are `const blind = !baseline && rows.length > 0 && !isRelease;` and `failed = !noFail && (overThreshold.length > 0 || blind)`: a threshold-enforcing build that measured binaries but has no baseline exits 1 with an error annotation naming the reason (HTTP status of the list, or how many builds were tried). Record-only main builds (`--no-fail`) annotate a warning instead of info. Two cases stay informational: release-mode builds (`[release build]` PRs), because a release baseline only exists for a short while after a release ran on main, and builds where no build-bun job recorded a size, which are already red from those jobs; their annotation header now says so instead of `all within`.
- Why failing is right here: `.buildkite/ci.mjs` already gives this step two automatic retries and a `[skip size check]` soft-fail escape hatch, so a transient Buildkite problem retries itself and a persistent one blocks visibly instead of silently disabling the gate; with GitHub out of the path, the recurring cause of a missing baseline is gone.
- Verified with `bun bd test test/internal/binary-size.test.ts` (8 scenarios: baseline found through the list with the skip rules and ordering, pagination past a full page of empty builds plus a non-main entry, the three no-baseline failures, `--no-fail`, `--release`, nothing measured). All 8 fail against the previous script, which in this environment reproduces the production annotation verbatim (`no canary comparison (github commits?sha=main&per_page=15: 403)`, exit 0), and pass with this one.
- Also ran the new script against live buildkite.com with a stub agent: it listed the same 60 main builds as the REST API (3 pages) and, with a record supplied for main #97844, skipped #98020 and compared against #97844. This PR's own CI run exercises the real step end to end.
- Related: #35906 (per-target, merge-base baselines) changes which builds' sizes are used and also edits this file; it fixes a different symptom (stale baselines failing every PR) and still goes through GitHub. This PR only changes how main builds are found and what happens when none is usable, so the two are independent, though they will need a trivial rebase against each other.

### Background
- The step runs on every PR build (enforcing) and every main build (`--no-fail`, record-only). Each `*-build-bun` job stores its stripped size in build meta-data (`binary-size:<triplet>`); this step collects them, uploads them as a `binary-sizes.json` artifact so later builds can use this build as a baseline, then looks for the newest main build's artifact to compare against.
- Main builds are frequently canceled: a push to main cancels the previous in-flight main build, so during merge bursts many consecutive main builds never get their build-bun jobs to finish and never upload the artifact. About half of recent main builds have one. This is why the lookup has to walk back over several builds rather than take the latest one.
- The Buildkite REST API needs a token; the Linux agents' environment hook (`scripts/bootstrap.sh`) exports none, so the script uses the unauthenticated web endpoints, as `scripts/build/ci.ts` already does to inherit symbol-order files (`builds/latest` redirect plus per-build `.json`). The branch-filtered build list is used here instead of probing build numbers downwards because main builds are sparse among build numbers (gaps of up to 578 in the last 16 days), which makes a number probe either expensive or blind during quiet periods.

<details>
<summary>Data behind the constants (Buildkite API, 500 most recent main builds, 2026-07-30 to 2026-08-15)</summary>

```
fraction of main builds whose binary-size step ran:           0.51
longest runs of consecutive main builds without the artifact: 21, 9, 9, 8
largest build-number gaps between consecutive main builds:    578, 490, 487, 318, 257
anonymous build list: pages 1-4 return 20 builds each, page 5+ returns HTTP 403
```

Skip lines the step now logs while walking, from the live run:

```
--- Looking for the newest main build with canary sizes
  main #98020 has no binary-sizes.json (its binary-size step did not run)
  main #97844: https://buildkite.com/bun/bun/builds/97844
```

</details>
