### PR TITLE
bun test --parallel: include snapshot counts in the run summary

### DIFF
--- a/src/runtime/cli/test/parallel/Coordinator.rs
+++ b/src/runtime/cli/test/parallel/Coordinator.rs
@@ -453,6 +453,7 @@ impl<'a> Coordinator<'a> {
                     files,
                     unhandled,
                 ] = nums;
+                let snapshot_counts = rd.counts();
 
                 self.flush_captured(w);
                 if self.last_header_idx == Some(idx) {
@@ -482,6 +483,10 @@ impl<'a> Coordinator<'a> {
                     summary.files += files;
                 }
                 self.reporter.jest.unhandled_errors_between_tests += unhandled;
+                self.reporter
+                    .jest
+                    .snapshots
+                    .add_summary_counts(snapshot_counts);
                 self.record_timing(idx, w.dispatched_at);
 
                 w.inflight = None;
@@ -526,6 +531,9 @@ impl<'a> Coordinator<'a> {
                 if !chunk.is_empty() {
                     self.coverage_chunks.push(Box::<[u8]>::from(chunk));
                 }
+            }
+            frame::Kind::SnapshotCounts => {
+                self.reporter.jest.snapshots.add_summary_counts(rd.counts());
             }
             frame::Kind::Run | frame::Kind::Shutdown => {}
         }

--- a/src/runtime/cli/test/parallel/Frame.rs
+++ b/src/runtime/cli/test/parallel/Frame.rs
@@ -12,7 +12,8 @@ pub enum Kind {
     FileStart,
     /// u32 file_idx, str formatted_line (ANSI included; printed verbatim)
     TestDone,
-    /// 9 × u32: file_idx, pass, fail, skip, todo, expectations, skipped_label, files, unhandled
+    /// 9 × u32: file_idx, pass, fail, skip, todo, expectations, skipped_label, files, unhandled;
+    /// then the file's deltas of `Snapshots::summary_counts` (4 × u32, same order)
     FileDone,
     /// 3 × str: failures, skips, todos (verbatim repeat-buffer bytes)
     RepeatBufs,
@@ -29,6 +30,10 @@ pub enum Kind {
     /// str lcov — this worker's coverage data, sent at exit; the coordinator
     /// merges every worker's into the one report it writes.
     CoverageChunk,
+    /// 4 × u32 — deltas of `Snapshots::summary_counts` accrued after this
+    /// worker's last FileDone: inline snapshots only count as added once the
+    /// worker writes them into the test files, which it does at exit.
+    SnapshotCounts,
 }
 
 impl TryFrom<u8> for Kind {
@@ -45,6 +50,7 @@ impl TryFrom<u8> for Kind {
             6 => Kind::Shutdown,
             7 => Kind::JunitChunk,
             8 => Kind::CoverageChunk,
+            9 => Kind::SnapshotCounts,
             _ => return Err(()),
         })
     }
@@ -76,6 +82,14 @@ impl Frame {
 
     pub(crate) fn u32(&mut self, v: u32) {
         self.buf.extend_from_slice(&v.to_le_bytes());
+    }
+
+    /// How much each of N monotonic counters grew between two readings, one
+    /// u32 per counter; `Reader::counts` is the inverse.
+    pub(crate) fn count_deltas<const N: usize>(&mut self, after: [usize; N], before: [usize; N]) {
+        for (after, before) in after.into_iter().zip(before) {
+            self.u32(u32::try_from(after - before).unwrap_or(u32::MAX));
+        }
     }
 
     pub(crate) fn str(&mut self, s: &[u8]) {
@@ -131,6 +145,10 @@ impl<'a> Reader<'a> {
         let v = u32::from_le_bytes(self.p[0..4].try_into().unwrap());
         self.p = &self.p[4..];
         v
+    }
+
+    pub(crate) fn counts<const N: usize>(&mut self) -> [usize; N] {
+        core::array::from_fn(|_| self.u32() as usize)
     }
 
     pub(crate) fn str(&mut self) -> &'a [u8] {

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -557,6 +557,7 @@ impl<'a> WorkerLoop<'a> {
 
             let before = *self.reporter.summary();
             let before_unhandled = self.reporter.jest.unhandled_errors_between_tests;
+            let before_snapshots = self.reporter.jest.snapshots.summary_counts();
 
             // A worker never knows which file is its last, so preload-level hooks wrap every file (with or without --isolate).
             if let Err(err) = TestCommand::run(
@@ -611,6 +612,10 @@ impl<'a> WorkerLoop<'a> {
             ] {
                 wf.u32(v);
             }
+            wf.count_deltas(
+                self.reporter.jest.snapshots.summary_counts(),
+                before_snapshots,
+            );
             self.cmds.send(wf.finish());
         }
     }
@@ -703,13 +708,17 @@ fn worker_flush_aggregates(
 ) {
     // Snapshots flush lazily when the next file opens its snapshot file; the
     // last file each worker ran has no successor to trigger that.
-    if let Some(runner) = crate::test_runner::jest::Jest::runner() {
-        let _ = runner.snapshots.write_inline_snapshots().unwrap_or(false);
-        let _ = runner.snapshots.write_snapshot_file();
-    }
+    let snapshots = &mut reporter.jest.snapshots;
+    let counts_before_flush = snapshots.summary_counts();
+    let _ = snapshots.write_inline_snapshots();
+    let _ = snapshots.write_snapshot_file();
 
     // SAFETY: single-threaded worker; WORKER_FRAME is a process-global scratch buffer
     let wf = unsafe { &mut *WORKER_FRAME.get() };
+
+    wf.begin(frame::Kind::SnapshotCounts);
+    wf.count_deltas(snapshots.summary_counts(), counts_before_flush);
+    cmds.send(wf.finish());
 
     wf.begin(frame::Kind::RepeatBufs);
     wf.str(reporter.failures_to_repeat_buf.as_slice());

--- a/src/runtime/test_runner/snapshot.rs
+++ b/src/runtime/test_runner/snapshot.rs
@@ -69,6 +69,21 @@ impl Snapshots {
             last_error_snapshot_name: None,
         }
     }
+
+    /// The counters behind the run summary's "snapshots:" line. A `--parallel`
+    /// worker ships deltas of these to the coordinator, whose own `Snapshots`
+    /// (no test runs there) folds them in with `add_summary_counts` and is
+    /// what the summary is printed from.
+    pub(crate) fn summary_counts(&self) -> [usize; 4] {
+        [self.total, self.added, self.passed, self.failed]
+    }
+
+    pub(crate) fn add_summary_counts(&mut self, [total, added, passed, failed]: [usize; 4]) {
+        self.total += total;
+        self.added += added;
+        self.passed += passed;
+        self.failed += failed;
+    }
 }
 
 // hoisted out of `impl Snapshots` — inherent associated types are unstable.

--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -903,6 +903,58 @@ test("--parallel writes new snapshots from every worker", async () => {
   expect(code2).toBe(0);
 });
 
+test("--parallel summary reports the same snapshot counts as a serial run", async () => {
+  // Two file snapshots plus one inline snapshot. The inline one is only
+  // counted as added when the worker writes it back into c.test.js at exit,
+  // after the file itself has been reported done, so it covers the path the
+  // per-file counters can't. (Block bodies: an inline snapshot taken as an
+  // arrow's tail call can't locate its caller to write itself back.)
+  const fixture = {
+    "a.test.js": `import {test,expect} from "bun:test"; test("a",()=>{ expect("value-a").toMatchSnapshot(); });`,
+    "b.test.js": `import {test,expect} from "bun:test"; test("b",()=>{ expect(process.env.B_VALUE ?? "value-b").toMatchSnapshot(); });`,
+    "c.test.js": `import {test,expect} from "bun:test"; test("c",()=>{ expect("value-c").toMatchInlineSnapshot(); });`,
+  };
+  using serialDir = tempDir("serial-snapshot-summary", fixture);
+  using parallelDir = tempDir("parallel-snapshot-summary", fixture);
+
+  // The summary's snapshot line and, when printed separately, the expect() line after it.
+  const snapshotSummary = (stderr: string) =>
+    stderr.split(/\r?\n/).filter(line => /^(snapshots:|\s+\d+ snapshots,|\s+\d+ expect\(\) calls)/.test(line));
+
+  async function run(dir: string, args: string[], env: Record<string, string> = {}) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", ...args],
+      env: { ...bunEnv, BUN_TEST_PARALLEL_SCALE_MS: "0", CI: "false", ...env },
+      cwd: dir,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  // First run writes all three snapshots.
+  const [serial, created] = await Promise.all([run(String(serialDir), []), run(String(parallelDir), ["--parallel=3"])]);
+  expect(snapshotSummary(serial.stderr)).toEqual(["snapshots: +3 added", " 3 expect() calls"]);
+  expect(serial.exitCode).toBe(0);
+  expect(created.stdout).toContain("PARALLEL");
+  expect(snapshotSummary(created.stderr)).toEqual(snapshotSummary(serial.stderr));
+  expect(created.exitCode).toBe(0);
+
+  // Second run matches them: the snapshot count folds into the expect() line.
+  const matched = await run(String(parallelDir), ["--parallel=3"]);
+  expect(matched.stdout).toContain("PARALLEL");
+  expect(snapshotSummary(matched.stderr)).toEqual([" 3 snapshots, 3 expect() calls"]);
+  expect(matched.exitCode).toBe(0);
+
+  // b's value changed, so one of the three fails.
+  const failed = await run(String(parallelDir), ["--parallel=3"], { B_VALUE: "changed" });
+  expect(failed.stdout).toContain("PARALLEL");
+  expect(snapshotSummary(failed.stderr)).toEqual(["snapshots: 2 passed, 1 failed", " 3 expect() calls"]);
+  expect(failed.stderr).toContain("1 fail");
+  expect(failed.exitCode).toBe(1);
+});
+
 test("--parallel: a test producing a >64MB result line is truncated, not treated as a crash", async () => {
   // Test name just over the 64MB IPC frame limit → the per-test status line
   // itself exceeds it. The encoder must truncate so the receiver doesn't drop


### PR DESCRIPTION
### Problem
- `bun test --parallel=N` (two or more files, so the worker pool is used) leaves the snapshot counts out of the run summary. With two files that each take one snapshot, serial `bun test` ends with `snapshots: +2 added` on the first run and ` 2 snapshots, 2 expect() calls` on the next; `--parallel=2` prints ` 2 expect() calls` both times. Failing snapshots (`snapshots: 1 passed, 1 failed` in serial) disappear from the summary the same way.
- The summary printer (`src/runtime/cli/test_command.rs:2945`) reads `reporter.jest.snapshots.{total,added,passed,failed}`. Under `--parallel` the tests run in worker processes, and the `FileDone` frame a worker sends per file (`src/runtime/cli/test/parallel/runner.rs:600`) carries pass/fail/skip/todo/expectations/filtered/files/unhandled but none of the four snapshot counters, so the coordinator's `Snapshots` stays at zero and `total > 0` is never true.

### Fix
- `FileDone` now also carries the file's deltas of the four snapshot counters (`Snapshots::summary_counts`, new in `snapshot.rs`); `Coordinator::on_frame` folds them into its own `Snapshots` with `add_summary_counts`, under the same inflight check as the other counters, so a file whose worker crashed drops its snapshot counts together with its expect() counts rather than only one of them.
- Inline snapshots are counted as added only when `write_inline_snapshots` writes them into the test files, which a worker does once at exit (`worker_flush_aggregates`), after its last `FileDone`. The worker therefore sends one more frame at exit, `SnapshotCounts`, with whatever the counters grew by during that flush; the coordinator adds it the same way.
- Why this is the right shape: the coordinator already reuses the serial summary printer and runs no tests itself, so its `Snapshots` counters are free to hold the sums, and the sums of per-file deltas plus the exit-time deltas are exactly the numbers a single process accumulates when it runs the same files. Per-file deltas rather than one total at worker exit keep the snapshot counts in step with the expect() count when a worker dies part-way through its files (the files it finished stay counted, as they do today for expect()).
- Test: `test/cli/test/parallel.test.ts`, `--parallel summary reports the same snapshot counts as a serial run`: two file snapshots and one inline snapshot, first run compared line-for-line against a serial run of the same fixture (`snapshots: +3 added`; the `+3` needs the exit-time frame), then a matching run (` 3 snapshots, 3 expect() calls`) and a run with one changed value (`snapshots: 2 passed, 1 failed`). Fails on the current release and on an unfixed debug build (parallel prints only ` 3 expect() calls`), passes with this change.
- Also ran `test/cli/test/parallel.test.ts` in full with the change; the only failures were three timing-based tests (`lazily scales workers`, `work-stealing balances`, `--experimental-http2-fetch` timeout) that fail identically on the unfixed build on this heavily loaded machine. Checked by hand that `--update-snapshots` (`snapshots: 1 passed, 2 added`) and a run where a worker exits mid-run after finishing two snapshot files (` 2 snapshots, 2 expect() calls`) match the serial output as well.

### Background
- `bun test --parallel`: the main process (coordinator) spawns worker `bun` processes and hands each one test file at a time; a worker runs the file and reports back over an fd 3 pipe using the length-prefixed frames defined in `src/runtime/cli/test/parallel/Frame.rs`. Both ends are the same binary, so the frame layout can change freely. The coordinator prints per-test lines as they arrive and, when every worker has exited, falls through to the same summary code the serial runner uses.
- `Snapshots` (`src/runtime/test_runner/snapshot.rs`) is the per-process snapshot state: the currently open `.snap` file plus the four run-wide counters `total` (snapshot matchers run), `added` (snapshots written), `passed` and `failed`. The summary prints ` N snapshots, M expect() calls` when nothing was added or failed, otherwise a `snapshots: ...` line followed by the expect() line.
- Inline snapshots (`toMatchInlineSnapshot()` with no argument) are queued while tests run and written into the test source files by `write_inline_snapshots` at the end of the run; that is where their `added` increments happen, which in a worker is after the last file has been reported.
