### PR TITLE
js_parser: fold the unary produced by distributing it over a comma operand

### DIFF
--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -1251,23 +1251,6 @@ impl Expr {
         Expr::init(t, self.loc)
     }
 
-    // Wraps the provided expression in the "!" prefix operator. The expression
-    // will potentially be simplified to avoid generating unnecessary extra "!"
-    // operators. For example, calling this with "!!x" will return "!x" instead
-    // of returning "!!!x".
-    pub(crate) fn not(&self, bump: &Bump) -> Expr {
-        self.maybe_simplify_not(bump).unwrap_or_else(|| {
-            Expr::init(
-                E::Unary {
-                    op: crate::OpCode::UnNot,
-                    value: *self,
-                    flags: E::UnaryFlags::empty(),
-                },
-                self.loc,
-            )
-        })
-    }
-
     #[inline]
     pub fn has_value_for_this_in_call(&self) -> bool {
         matches!(self.data, Data::EDot(_) | Data::EIndex(_))
@@ -1275,10 +1258,12 @@ impl Expr {
 
     /// The given "expr" argument should be the operand of a "!" prefix operator
     /// (i.e. the "x" in "!x"). This returns a simplified expression for the
-    /// whole operator (i.e. the "!x") if it can be simplified, or false if not.
-    /// It's separate from "Not()" above to avoid allocation on failure in case
-    /// that is undesired.
-    pub fn maybe_simplify_not(&self, bump: &Bump) -> Option<Expr> {
+    /// whole operator (i.e. the "!x") if it can be simplified, or None if not.
+    ///
+    /// "!(a, b)" is not handled here: the visitor distributes every unary
+    /// operator over a comma operand and then folds the new unary with the
+    /// side-effect information only it has.
+    pub fn maybe_simplify_not(&self) -> Option<Expr> {
         let expr = self;
         match expr.data {
             Data::ENull(_) | Data::EUndefined(_) => {
@@ -1296,6 +1281,11 @@ impl Expr {
                 if let Some(equal) = E::BigInt::check_equality(&b.value, b"0") {
                     return Some(expr.at(E::Boolean { value: equal }));
                 }
+            }
+            Data::EString(s) => {
+                return Some(expr.at(E::Boolean {
+                    value: s.is_blank(),
+                }));
             }
             Data::EFunction(_) | Data::EArrow(_) | Data::ERegExp(_) => {
                 return Some(expr.at(E::Boolean { value: false }));
@@ -1338,16 +1328,11 @@ impl Expr {
                         ex.op = crate::OpCode::BinStrictEq;
                         return Some(*expr);
                     }
-                    crate::OpCode::BinComma => {
-                        // "!(a, b)" => "a, !b"
-                        ex.right = ex.right.not(bump);
-                        return Some(*expr);
-                    }
                     _ => {}
                 }
             }
             Data::EInlinedEnum(inlined) => {
-                return inlined.value.maybe_simplify_not(bump);
+                return inlined.value.maybe_simplify_not();
             }
             _ => {}
         }

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1235,107 +1235,101 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         ..Default::default()
                     },
                 );
+                Self::fold_unary(p, e);
+            }
+        }
+    }
 
-                // Post-process the unary expression
-                match e_.op {
-                    Op::UnNot => {
-                        if p.options.features.minify_syntax {
-                            e_.value = SideEffects::simplify_boolean(p, e_.value);
-                        }
+    /// Post-processes a unary expression whose operand has already been visited.
+    fn fold_unary(p: &mut Self, e: &mut Expr) {
+        let expr = *e;
+        let mut e_ = expr.data.e_unary().expect("infallible: variant checked");
+        match e_.op {
+            Op::UnNot => {
+                if p.options.features.minify_syntax {
+                    e_.value = SideEffects::simplify_boolean(p, e_.value);
+                }
 
-                        if let Some(side_effects) = SideEffects::to_boolean(p, &e_.value.data) {
-                            if side_effects.side_effects == SideEffects::NoSideEffects
-                                || p.expr_can_be_removed_if_unused(&e_.value)
-                            {
-                                *e = p.new_expr(
-                                    E::Boolean {
-                                        value: !side_effects.value,
-                                    },
-                                    expr.loc,
-                                );
-                                return;
-                            }
-                        }
-
-                        if p.options.features.minify_syntax {
-                            if let Some(exp) = Expr::maybe_simplify_not(&e_.value, p.arena) {
-                                *e = exp;
-                                return;
-                            }
-                            if let Data::EImportMetaMain(m) = &mut e_.value.data {
-                                m.inverted = !m.inverted;
-                                *e = e_.value;
-                                return;
-                            }
-                        }
+                if let Some(side_effects) = SideEffects::to_boolean(p, &e_.value.data) {
+                    if side_effects.side_effects == SideEffects::NoSideEffects
+                        || p.expr_can_be_removed_if_unused(&e_.value)
+                    {
+                        *e = p.new_expr(
+                            E::Boolean {
+                                value: !side_effects.value,
+                            },
+                            expr.loc,
+                        );
+                        return;
                     }
-                    Op::UnCpl => {
-                        if p.should_fold_typescript_constant_expressions {
-                            if let Some(value) = SideEffects::to_number(&e_.value.data) {
-                                *e = p.new_expr(
-                                    E::Number::new(f64::from(!float_to_int32(value))),
-                                    expr.loc,
-                                );
-                                return;
-                            }
-                        }
-                    }
-                    Op::UnVoid => {
-                        if p.expr_can_be_removed_if_unused(&e_.value) {
-                            *e = p.new_expr(E::Undefined {}, e_.value.loc);
-                            return;
-                        }
-                    }
-                    Op::UnPos => {
-                        if let Some(num) = SideEffects::to_number(&e_.value.data) {
-                            *e = p.new_expr(E::Number::new(num), expr.loc);
-                            return;
-                        }
-                    }
-                    Op::UnNeg => {
-                        if let Some(num) = SideEffects::to_number(&e_.value.data) {
-                            *e = p.new_expr(E::Number::new(-num), expr.loc);
-                            return;
-                        }
-                    }
-
-                    ////////////////////////////////////////////////////////////////////////////////
-                    Op::UnPreDec => {
-                        // TODO: private fields
-                    }
-                    Op::UnPreInc => {
-                        // TODO: private fields
-                    }
-                    Op::UnPostDec => {
-                        // TODO: private fields
-                    }
-                    Op::UnPostInc => {
-                        // TODO: private fields
-                    }
-                    _ => {}
                 }
 
                 if p.options.features.minify_syntax {
-                    // "-(a, b)" => "a, -b"
-                    if !matches!(e_.op, Op::UnDelete | Op::UnTypeof) {
-                        if let Data::EBinary(comma) = &e_.value.data {
-                            if comma.op == Op::BinComma {
-                                *e = comma.left.join_with_comma(p.new_expr(
-                                    E::Unary {
-                                        op: e_.op,
-                                        value: comma.right,
-                                        flags: e_.flags,
-                                    },
-                                    comma.right.loc,
-                                ));
-                                return;
-                            }
+                    if let Some(exp) = Expr::maybe_simplify_not(&e_.value) {
+                        *e = exp;
+                        return;
+                    }
+                    if let Data::EImportMetaMain(m) = &mut e_.value.data {
+                        m.inverted = !m.inverted;
+                        *e = e_.value;
+                        return;
+                    }
+                }
+            }
+            Op::UnCpl => {
+                if p.should_fold_typescript_constant_expressions {
+                    if let Some(value) = SideEffects::to_number(&e_.value.data) {
+                        *e =
+                            p.new_expr(E::Number::new(f64::from(!float_to_int32(value))), expr.loc);
+                        return;
+                    }
+                }
+            }
+            Op::UnVoid => {
+                if p.expr_can_be_removed_if_unused(&e_.value) {
+                    *e = p.new_expr(E::Undefined {}, e_.value.loc);
+                    return;
+                }
+            }
+            Op::UnPos => {
+                if let Some(num) = SideEffects::to_number(&e_.value.data) {
+                    *e = p.new_expr(E::Number::new(num), expr.loc);
+                    return;
+                }
+            }
+            Op::UnNeg => {
+                if let Some(num) = SideEffects::to_number(&e_.value.data) {
+                    *e = p.new_expr(E::Number::new(-num), expr.loc);
+                    return;
+                }
+            }
+            _ => {}
+        }
+
+        if p.options.features.minify_syntax {
+            // "-(a, b)" => "a, -b"
+            if !matches!(e_.op, Op::UnDelete | Op::UnTypeof) {
+                if let Data::EBinary(comma) = e_.value.data {
+                    if comma.op == Op::BinComma {
+                        if !p.stack_check.is_safe_to_recurse() || p.reported_stack_overflow.get() {
+                            p.report_stack_overflow(expr.loc);
+                            return;
                         }
+                        // This node becomes the "-b", and is folded like any other
+                        // unary so that e.g. "!(a, 'b')" ends up as "a, !1".
+                        e_.value = comma.right;
+                        *e = Expr {
+                            loc: comma.right.loc,
+                            data: expr.data,
+                        };
+                        Self::fold_unary(p, e);
+                        *e = comma.left.join_with_comma(*e);
                     }
                 }
             }
         }
     }
+
     fn e_dot(p: &mut Self, e: &mut Expr, in_: ExprIn) {
         let expr = *e;
         let mut e_ = expr.data.e_dot().expect("infallible: variant checked");

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3560,7 +3560,60 @@ class Foo {
     };
 
     it("unary operator", () => {
-      expectPrinted("a = !(b, c)", "a = (b, !c)");
+      // The output must also be a fixed point: transpiling it again must not
+      // find anything left to fold.
+      const expectPrintedStable = (code, out) => {
+        expectPrinted(code, out);
+        expectPrinted(out, out);
+      };
+
+      expectPrintedStable("a = !(b, c)", "a = (b, !c)");
+      expectPrintedStable("a = !(b, c == d)", "a = (b, c != d)");
+      expectPrintedStable("a = !(b, !!c)", "a = (b, !c)");
+
+      // "!(a, b)" => "a, !b" folds the new "!b" the same way a "!b" written in
+      // the source is folded.
+      expectPrintedStable('a = !(b, "c")', "a = (b, !1)");
+      expectPrintedStable('a = !(b, "")', "a = (b, !0)");
+      expectPrintedStable("a = !(b, `c`)", "a = (b, !1)");
+      expectPrintedStable("a = !(b, typeof c)", "a = (b, !1)");
+      expectPrintedStable("a = !(b, {})", "a = (b, !1)");
+      expectPrintedStable('a = !(b, c && "d")', "a = (b, !c)");
+      expectPrintedStable('a = !(b, (c, "d"))', "a = (b, c, !1)");
+      expectPrintedStable('a = +(b, "3")', "a = (b, 3)");
+      expectPrintedStable("a = -(b, -3)", "a = (b, 3)");
+      expectPrintedStable("a = ~(b, 1)", "a = (b, -2)");
+      expectPrintedStable("a = void (b, 1)", "a = (b, void 0)");
+
+      // Operands with side effects are still kept.
+      expectPrintedStable("a = !(b, typeof c())", "a = (b, !typeof c())");
+      expectPrintedStable("a = !(b, [c])", "a = (b, ![c])");
+      expectPrintedStable("a = void (b, c)", "a = (b, void c)");
+
+      // typeof and delete must not be distributed over the comma at all.
+      expectPrintedStable("a = typeof (b, c)", "a = typeof (b, c)");
+      expectPrintedStable("a = delete (b, c)", "a = delete (b, c)");
+    });
+
+    it("unary operator without dead code elimination", () => {
+      const transpiler = new Bun.Transpiler({
+        loader: "js",
+        minify: { syntax: true },
+        deadCodeElimination: false,
+      });
+      const check = (code, out) => expect(parsed(code, true, true, transpiler)).toBe(out);
+
+      // Literal operands of "!" fold even though the side-effect analysis is
+      // off, strings included.
+      check("a = !null", "a = !0");
+      check('a = !"c"', "a = !1");
+      check('a = !""', "a = !0");
+      check('a = !("c" + "d")', "a = !1");
+      check('a = !("" + "")', "a = !0");
+      check('a = !(b, "c")', "a = (b, !1)");
+      check("a = !(b, c == d)", "a = (b, c != d)");
+      // Needs the side-effect analysis, so it stays as written.
+      check("a = !(b, typeof c)", "a = (b, !typeof c)");
     });
 
     it.todo("const inlining", () => {


### PR DESCRIPTION
### Problem
- With `minify: { syntax: true }`, `x = !(a, "s")` prints as `x = (a, !"s")`. Transpiling that output again gives `x = (a, !1)`, so the output is not a fixed point. Same for `!(a, "")`, `!(a, typeof b)`, `!(a, {})`, `!(a, b && "s")`, `!(a, (b, "s"))`, and for the other prefix operators: `+(a, "3")` prints as `(a, +"3")`, `~(a, 1)` as `(a, ~1)`, `void (a, 1)` as `(a, void 1)`, `-(a, -3)` as `(a, - -3)`. Every one of these folds in a single pass when the comma is not there (`!"s"` is `!1`, `+"3"` is `3`).
- The output is semantically correct in every case, it is just under-simplified. Found by a fixed-point check (`transformSync(transformSync(x)) === transformSync(x)`) during work on another transpiler bug; it also affects the runtime transpiler, which has minify syntax on.
- Cause, `!`: the `"!(a, b)" => "a, !b"` rewrite was the `BinComma` arm of `Expr::maybe_simplify_not` (`src/ast/expr.rs`), which built `!b` with `Expr::not`. That helper only knows the literal arms of `maybe_simplify_not`, and those had no string arm (esbuild's `MaybeSimplifyNot` has one). Everything else the visitor does to a `!x` operand, `SideEffects::to_boolean` plus `expr_can_be_removed_if_unused` (strings, `typeof`, object/array/class literals) and `simplify_boolean` (`&&`/`||`), never ran on the new `!b`.
- Cause, other operators: the visitor's own `"-(a, b)" => "a, -b"` rule at the end of the unary post-processing (`src/js_parser/visit/visit_expr.rs`) allocated the new unary and returned without folding it.

### Fix
- The unary post-processing moves verbatim from the `_` arm of `e_unary` into `P::fold_unary` (review with whitespace changes hidden; the four empty `UnPreDec`/`UnPreInc`/`UnPostDec`/`UnPostInc` arms are dropped since they were identical to the `_ => {}` arm). Its comma rule now re-points the unary node at the comma's right operand, calls `fold_unary` on it again, and joins the left operand back on. `!`, `+`, `-`, `~` and `void` all go through this rule; `typeof` and `delete` are still excluded, as before. The recursion is bounded by the same stack check the rest of the visitor uses; it is one short frame per explicitly nested right-hand comma and the operand's own visit already recursed deeper than that (the deepest nesting that transpiles is unchanged, 617 levels on this debug build with or without the rule).
- The `BinComma` arm of `maybe_simplify_not` and `Expr::not` (whose only caller was that arm) are removed, so `!` reaches the visitor's rule like every other operator, and the now unused `bump` parameter goes with them. `maybe_simplify_not` gains the string arm (`!"s"` is `false`, `!""` is `true`, via `EString::is_blank`, which accounts for folded rope strings); with dead code elimination on, `to_boolean` gets there first, with it off (`deadCodeElimination: false`, `bun -p`) this arm is what folds `!"s"`, matching how the null/number/bigint/function arms already behave in that mode.
- Why this is correct: `op (a, b)` and `(a, op b)` evaluate identically (that rewrite already existed); the only new thing is that `op b` is then folded by exactly the code that folds a source-level `op b`, so every fold it applies is one the transpiler already applies at top level, including its side-effect checks (`!(a, typeof c())` and `!(a, [c])` still keep their operands). A probe comparing the printed `op (a, X)` against the printed top-level `op X` for 5 operators and 78 operands found no difference, and every output is now a fixed point (details below).
- Tests: `test/bundler/transpiler/transpiler.test.js`, "simplification > unary operator" now checks each of the shapes above prints folded and that re-transpiling the output leaves it unchanged, plus the side-effect and `typeof`/`delete` cases that must not change; "unary operator without dead code elimination" covers the string arm on its own. Both tests fail on the released binary and pass with this change.
- Also run with the debug build: the rest of `transpiler.test.js`, `bundler_minify.test.ts`, `transpiler_constant_fold_eqeq.test.ts`, `simplifier-side-effects.test.ts`, `transpiler-stack-overflow.test.ts`, `esbuild/dce.test.ts`, `esbuild/default.test.ts`, `bundler_edgecase.test.ts`, `bundler_regressions.test.ts`, `runtime-transpiler.test.ts`, `regression/issue/21137-minify-typeof-comma.test.ts`, `test/js/bun/transpiler/*`, `test/internal/source-lints`; `cargo clippy -p bun_ast -p bun_js_parser` is clean.
- Not covered here: `+("1" + "2")` prints as `+"12"` because `ExprData::to_number` declines rope strings. That is independent of the comma rule (it reproduces at top level) and is tracked separately.

### Background
- Minify syntax prints `true`/`false` as `!0`/`!1`, so `(a, !1)` in the outputs above is the folded boolean `false`, while `(a, !"s")` is a real `!` operator applied to a string literal.
- `Expr::maybe_simplify_not` (port of esbuild's `MaybeSimplifyNot`) is a pure AST helper: given the operand of a `!`, it returns the folded `!operand` for literals and for `==`/`!=`/`===`/`!==` (which it flips). It has no access to the parser, so it cannot decide whether an operand with unknown contents (`typeof x`, `{}`, `b && "s"`) may be dropped; those folds live in the visitor, which has the symbol table (`expr_can_be_removed_if_unused`).
- `SideEffects::to_boolean` returns the known truthiness of an expression together with whether evaluating it could have side effects; it is gated on the `dead_code_elimination` option, which the REPL and `bun -p` turn off while keeping minify syntax on. That is the mode in which the literal arms of `maybe_simplify_not` are the only `!` folding that happens.
- Folded string additions (`"c" + "d"`) are stored as a rope: an `E::String` whose `next` links to the following segment and whose `rope_len` is the total length. `EString::is_blank()` reads `rope_len`, so it is correct without flattening the rope.
- The operand of a unary has already been visited when the post-processing runs, so the comma's left side has already had removable operands dropped by the binary visitor; the rule only ever sees a left operand that has to stay.

<details>
<summary>Probes (debug build with this change)</summary>

Fixed point on the original shapes and a few more (`x = ` prefix omitted):

```
!(a, "s")          -> (a, !1)
!(a, "")           -> (a, !0)
!(a, typeof b)     -> (a, !1)
!(a, (b, "s"))     -> (a, b, !1)
!(a, "a" + "b")    -> (a, !1)
!(a, `s`)          -> (a, !1)
!(a, {})           -> (a, !1)
!(a, [])           -> (a, !1)
!(a, class {})     -> (a, !1)
!(a, b && "s")     -> (a, !b)
!(a, b || "")      -> (a, !b)
!(a, b == c)       -> (a, b != c)          (unchanged)
!(a, typeof b())   -> (a, !typeof b())     (unchanged, operand has side effects)
!(a, [b])          -> (a, ![b])            (unchanged)
+(a, "3")          -> (a, 3)
+(a, null)         -> (a, 0)
-(a, -3)           -> (a, 3)
~(a, 1)            -> (a, -2)
void (a, 1)        -> (a, void 0)
void (a, b())      -> (a, void b())        (unchanged)
typeof (a, b)      -> typeof (a, b)        (unchanged, not distributed)
```

Differential probe: for each of `!`, `+`, `-`, `~`, `void` and 78 operands `X` (literals, ropes, templates, `typeof`, object/array/class literals with and without side effects, `&&`/`||`/`??`, comparisons, assignments, update expressions, nested commas, `import.meta.main`, `this`, `await`, `yield`, ...), the printed `op (a, X)` equals `(a, <printed top-level op X>)` in all 390 cases, and all 390 outputs are fixed points except the three rope `to_number` cases mentioned above, which behave the same at top level and before this change.

Nesting depth: the deepest `!(a, (a, (a, ... "s")))` that transpiles on this debug build is 617 levels both with and without the unary in front (the parser and visitor recursion is the limit); the released binary handles at least 8192 either way.
</details>
