### PR TITLE
bake: free the dev server's JS-thread bundle allocations with the bundle

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -4,7 +4,9 @@
 // bodies live in the `bv2_impl` module below.
 // ══════════════════════════════════════════════════════════════════════════
 
+use core::cell::Cell;
 use core::ptr::NonNull;
+use std::rc::Rc;
 
 use bun_alloc::ast_alloc::{self, AstAllocState};
 use bun_collections::{ArrayHashMap, StringHashMap};
@@ -142,9 +144,9 @@ pub struct BundleV2<'a> {
     /// (the main-thread parse-phase throughput limiter).
     pub(crate) requested_exports: Vec<Option<RequestedExports>>,
 
-    /// Declared last: `graph` / `linker` hold `AstVec`s backed by this state's
-    /// inline chunk, so it must drop after them.
-    pub(crate) async_ast_alloc: AsyncAstAlloc,
+    /// Declared last: `graph` / `linker` hold `AstVec`s backed by the parked
+    /// state's inline chunk, so it must drop after them.
+    pub(crate) async_ast_alloc: Rc<AsyncAstAlloc>,
 }
 
 /// The `AstAllocState` of an `asynchronous` (dev server) bundle, spilling
@@ -152,8 +154,11 @@ pub struct BundleV2<'a> {
 /// which would otherwise run with no state installed and leak every `AstAlloc`
 /// allocation on the global heap; each callback installs this one for its
 /// duration ([`BundleV2::enter_async_ast_scope`]).
+///
+/// Shared (`Rc`) with the guard of the callback that completes the bundle,
+/// since that frees the `BundleV2` before the guard drops.
 #[derive(Default)]
-pub(crate) struct AsyncAstAlloc(AsyncAstState);
+pub(crate) struct AsyncAstAlloc(Cell<AsyncAstState>);
 
 #[derive(Default)]
 enum AsyncAstState {
@@ -169,70 +174,72 @@ enum AsyncAstState {
 }
 
 impl AsyncAstAlloc {
-    /// Returns the installed state's identity; null (and a no-op) unless parked.
-    fn enter(&mut self, spill: *mut bun_alloc::mimalloc::Heap) -> *const AstAllocState {
-        let mut state = match core::mem::take(&mut self.0) {
+    fn adopt(&self, state: Box<AstAllocState>) {
+        let previous = self.0.replace(AsyncAstState::Parked(state));
+        debug_assert!(matches!(previous, AsyncAstState::Disabled));
+    }
+
+    /// Installs the parked state; `false` (and a no-op) unless one is parked.
+    fn enter(&self, spill: *mut bun_alloc::mimalloc::Heap) -> bool {
+        let mut state = match self.0.take() {
             AsyncAstState::Parked(state) => state,
             other => {
-                self.0 = other;
-                return core::ptr::null();
+                self.0.set(other);
+                return false;
             }
         };
         state.set_spill_heap(spill);
         let id: *const AstAllocState = &raw const *state;
-        self.0 = AsyncAstState::Installed {
+        self.0.set(AsyncAstState::Installed {
             id,
             displaced: ast_alloc::swap_state(Some(state)),
-        };
-        id
+        });
+        true
     }
 
-    /// Uninstalls and parks the state again; no-op unless installed.
-    fn exit(&mut self) {
-        let (id, displaced) = match core::mem::take(&mut self.0) {
+    /// Uninstalls and parks the state again; no-op unless it is installed and
+    /// still the thread's active state.
+    fn exit(&self) {
+        let (id, displaced) = match self.0.take() {
             AsyncAstState::Installed { id, displaced } => (id, displaced),
             other => {
-                self.0 = other;
+                self.0.set(other);
                 return;
             }
         };
-        debug_assert!(
-            core::ptr::eq(ast_alloc::active_state_id(), id),
-            "AsyncAstAlloc::exit: another AstAllocState is still installed on top of the bundle's"
-        );
-        if let Some(state) = ast_alloc::swap_state(displaced) {
-            self.0 = AsyncAstState::Parked(state);
+        if !core::ptr::eq(ast_alloc::active_state_id(), id) {
+            debug_assert!(
+                false,
+                "AsyncAstAlloc::exit: another AstAllocState is installed on top of the bundle's"
+            );
+            self.0.set(AsyncAstState::Installed { id, displaced });
+            return;
         }
+        let state = ast_alloc::swap_state(displaced)
+            .expect("AsyncAstAlloc::exit: the active state's identity matched");
+        self.0.set(AsyncAstState::Parked(state));
     }
 }
 
 impl Drop for AsyncAstAlloc {
     fn drop(&mut self) {
         self.exit();
+        if let AsyncAstState::Parked(state) = self.0.take() {
+            ast_alloc::release_state(state);
+        }
     }
 }
 
-/// Uninstalls the bundle's state on drop. The callback holding it may complete
-/// the bundle, which frees the `BundleV2` before the callback returns; that
-/// teardown uninstalls the state itself, so `bv2` is only touched while the
-/// state this guard installed is still the active one.
+/// Returned by [`BundleV2::enter_async_ast_scope`]; `Some` only for the guard
+/// that installed the state, which uninstalls it on drop.
 #[must_use = "the state is uninstalled as soon as the guard drops"]
-pub(crate) struct AsyncAstScope {
-    bv2: *mut BundleV2<'static>,
-    /// Null when this guard installed nothing.
-    installed: *const AstAllocState,
-}
+pub(crate) struct AsyncAstScope(Option<Rc<AsyncAstAlloc>>);
 
 impl Drop for AsyncAstScope {
     fn drop(&mut self) {
-        if self.installed.is_null() || !core::ptr::eq(ast_alloc::active_state_id(), self.installed)
-        {
-            return;
+        if let Some(alloc) = &self.0 {
+            alloc.exit();
         }
-        // SAFETY: the state is still installed, so the `BundleV2` owning it has
-        // not been torn down (see the type doc); the callback body's borrows of
-        // `*bv2` have ended by the time its locals drop.
-        unsafe { (*self.bv2).async_ast_alloc.exit() };
     }
 }
 
@@ -366,19 +373,18 @@ impl<'a> BundleV2<'a> {
     /// [`AsyncAstAlloc`].
     pub fn adopt_async_ast_state(&mut self, state: Box<AstAllocState>) {
         debug_assert!(self.asynchronous);
-        debug_assert!(matches!(self.async_ast_alloc.0, AsyncAstState::Disabled));
-        self.async_ast_alloc.0 = AsyncAstState::Parked(state);
+        self.async_ast_alloc.adopt(state);
     }
 
     /// Must be the first local of every event loop callback that works on the
     /// graph, so the state is still installed when a later guard or the body
     /// completes the bundle.
-    pub(crate) fn enter_async_ast_scope(&mut self) -> AsyncAstScope {
-        let installed = self.async_ast_alloc.enter(self.graph.heap.heap_ptr());
-        AsyncAstScope {
-            bv2: std::ptr::from_mut::<BundleV2<'a>>(self).cast::<BundleV2<'static>>(),
-            installed,
-        }
+    pub(crate) fn enter_async_ast_scope(&self) -> AsyncAstScope {
+        AsyncAstScope(
+            self.async_ast_alloc
+                .enter(self.graph.heap.heap_ptr())
+                .then(|| Rc::clone(&self.async_ast_alloc)),
+        )
     }
 
     // draft `on_parse_task_complete` / `deinit_without_freeing_arena`
@@ -2966,7 +2972,7 @@ pub mod bv2_impl {
                 asynchronous: false,
                 has_any_top_level_await_modules: false,
                 requested_exports: Vec::new(),
-                async_ast_alloc: super::AsyncAstAlloc::default(),
+                async_ast_alloc: Default::default(),
             });
             if let Some(bo) = bake_options {
                 // SAFETY: `bo.client_transpiler` is the caller's live, write-capable

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -142,50 +142,34 @@ pub struct BundleV2<'a> {
     /// (the main-thread parse-phase throughput limiter).
     pub(crate) requested_exports: Vec<Option<RequestedExports>>,
 
-    /// See [`AsyncAstAlloc`]. Declared last: the state's inline chunk backs
-    /// small `AstVec`s stored in `graph` / `linker`, so it must outlive their
-    /// drop glue (struct fields drop in declaration order).
+    /// Declared last: `graph` / `linker` hold `AstVec`s backed by this state's
+    /// inline chunk, so it must drop after them.
     pub(crate) async_ast_alloc: AsyncAstAlloc,
 }
 
-/// The `AstAlloc` state of an `asynchronous` (dev server) bundle.
-///
-/// `AstAlloc` allocates through the `AstAllocState` installed on the calling
-/// thread and leaks on the global heap when there is none (`deallocate` is a
-/// no-op). A synchronous bundle (`Bun.build`, the CLI) keeps one installed on
-/// its own thread for the whole pass. A dev server bundle only has one while
-/// `DevServer::start_async_bundle` sets it up; the rest of the graph work
-/// arrives later as JS event loop callbacks (`on_parse_task_complete`,
-/// `on_load`, `on_resolve`, `on_notify_defer`, and `finish_from_bake_dev_server`
-/// reached from them) with nothing installed, so everything those built through
-/// `AstAlloc` (`LinkerGraph::load`'s per-file `resolved_exports`, `clone_ast`,
-/// `InputFile::additional_files`, ...) leaked once per rebuild.
-///
-/// The setup state, which spills into `graph.heap`, is parked here between
-/// callbacks and installed for the duration of each one, so those allocations
-/// die with the bundle heap like everything else the bundle owns.
+/// The `AstAllocState` of an `asynchronous` (dev server) bundle, spilling
+/// into `graph.heap`. The bundle's graph work runs as JS event loop callbacks,
+/// which would otherwise run with no state installed and leak every `AstAlloc`
+/// allocation on the global heap; each callback installs this one for its
+/// duration ([`BundleV2::enter_async_ast_scope`]).
 #[derive(Default)]
 pub(crate) struct AsyncAstAlloc(AsyncAstState);
 
 #[derive(Default)]
 enum AsyncAstState {
-    /// Synchronous bundle: [`BundleV2::enter_async_ast_scope`] is a no-op.
+    /// Synchronous bundle: the owning thread keeps its own state installed.
     #[default]
     Disabled,
-    /// Between callbacks.
     Parked(Box<AstAllocState>),
-    /// During a callback. A nested `enter` is a no-op.
     Installed {
-        /// Identity of the installed box.
         id: *const AstAllocState,
-        /// The thread-local occupant `enter` displaced; reinstated by `exit`.
+        /// Thread-local occupant displaced by `enter`, reinstated by `exit`.
         displaced: Option<Box<AstAllocState>>,
     },
 }
 
 impl AsyncAstAlloc {
-    /// Install the parked state, spilling into `spill`. Returns the installed
-    /// box's identity, or null when nothing was installed.
+    /// Returns the installed state's identity; null (and a no-op) unless parked.
     fn enter(&mut self, spill: *mut bun_alloc::mimalloc::Heap) -> *const AstAllocState {
         let mut state = match core::mem::take(&mut self.0) {
             AsyncAstState::Parked(state) => state,
@@ -203,8 +187,7 @@ impl AsyncAstAlloc {
         id
     }
 
-    /// Uninstall the state, reinstating whatever `enter` displaced, and park it
-    /// again. No-op unless installed.
+    /// Uninstalls and parks the state again; no-op unless installed.
     fn exit(&mut self) {
         let (id, displaced) = match core::mem::take(&mut self.0) {
             AsyncAstState::Installed { id, displaced } => (id, displaced),
@@ -225,21 +208,14 @@ impl AsyncAstAlloc {
 
 impl Drop for AsyncAstAlloc {
     fn drop(&mut self) {
-        // Normally already parked by `deinit_without_freeing_arena`; this keeps
-        // the thread-local from pointing at the freed box otherwise.
         self.exit();
     }
 }
 
-/// Returned by [`BundleV2::enter_async_ast_scope`]; uninstalls the bundle's
-/// state when dropped.
-///
-/// The callback holding this guard may be the one that completes the bundle:
-/// `finish_from_bake_dev_server` → `DevServer::finalize_bundle` frees the
-/// `BundleV2` before returning into the callback. That teardown uninstalls the
-/// state itself (`deinit_without_freeing_arena`, then `AsyncAstAlloc::drop`),
-/// so this guard dereferences `bv2` only while the state it installed is still
-/// the active one, which proves the `BundleV2` is still alive.
+/// Uninstalls the bundle's state on drop. The callback holding it may complete
+/// the bundle, which frees the `BundleV2` before the callback returns; that
+/// teardown uninstalls the state itself, so `bv2` is only touched while the
+/// state this guard installed is still the active one.
 #[must_use = "the state is uninstalled as soon as the guard drops"]
 pub(crate) struct AsyncAstScope {
     bv2: *mut BundleV2<'static>,
@@ -253,11 +229,9 @@ impl Drop for AsyncAstScope {
         {
             return;
         }
-        // SAFETY: the state this guard installed is still active, so the
-        // `BundleV2` owning it has not been torn down (see the type doc). The
-        // guard is a local of a callback running on the bundle's own thread,
-        // and every borrow of `*bv2` taken by the callback body has ended by
-        // the time its locals drop.
+        // SAFETY: the state is still installed, so the `BundleV2` owning it has
+        // not been torn down (see the type doc); the callback body's borrows of
+        // `*bv2` have ended by the time its locals drop.
         unsafe { (*self.bv2).async_ast_alloc.exit() };
     }
 }
@@ -388,20 +362,17 @@ impl<'a> BundleV2<'a> {
         }
     }
 
-    /// Dev server: hand over the `AstAllocState` the bundle was set up under,
-    /// once setup's own scope has exited, so the event loop callbacks that
-    /// finish the bundle allocate through it as well (see [`AsyncAstAlloc`]).
+    /// Dev server: the (uninstalled) state the bundle was set up under; see
+    /// [`AsyncAstAlloc`].
     pub fn adopt_async_ast_state(&mut self, state: Box<AstAllocState>) {
         debug_assert!(self.asynchronous);
         debug_assert!(matches!(self.async_ast_alloc.0, AsyncAstState::Disabled));
         self.async_ast_alloc.0 = AsyncAstState::Parked(state);
     }
 
-    /// Install the bundle's parked `AstAllocState`, if it has one, until the
-    /// returned guard drops. Every JS event loop callback that works on the
-    /// graph declares this as its first local, so the state is still installed
-    /// while anything declared later (or called from the body) completes the
-    /// bundle.
+    /// Must be the first local of every event loop callback that works on the
+    /// graph, so the state is still installed when a later guard or the body
+    /// completes the bundle.
     pub(crate) fn enter_async_ast_scope(&mut self) -> AsyncAstScope {
         let installed = self.async_ast_alloc.enter(self.graph.heap.heap_ptr());
         AsyncAstScope {
@@ -5169,9 +5140,8 @@ pub mod bv2_impl {
                 drop(free);
             }
 
-            // A dev server bundle is torn down from inside the callback that
-            // completed it, i.e. while its state is installed; the heap that
-            // state spills into is destroyed right after this returns.
+            // The dev server tears a bundle down from inside the callback that
+            // completed it, so the state is still installed here.
             self.async_ast_alloc.exit();
         }
 

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -6,6 +6,7 @@
 
 use core::ptr::NonNull;
 
+use bun_alloc::ast_alloc::{self, AstAllocState};
 use bun_collections::{ArrayHashMap, StringHashMap};
 use bun_core::ThreadLock;
 
@@ -140,6 +141,125 @@ pub struct BundleV2<'a> {
     /// dense and this is probed once per import in `on_parse_task_complete`
     /// (the main-thread parse-phase throughput limiter).
     pub(crate) requested_exports: Vec<Option<RequestedExports>>,
+
+    /// See [`AsyncAstAlloc`]. Declared last: the state's inline chunk backs
+    /// small `AstVec`s stored in `graph` / `linker`, so it must outlive their
+    /// drop glue (struct fields drop in declaration order).
+    pub(crate) async_ast_alloc: AsyncAstAlloc,
+}
+
+/// The `AstAlloc` state of an `asynchronous` (dev server) bundle.
+///
+/// `AstAlloc` allocates through the `AstAllocState` installed on the calling
+/// thread and leaks on the global heap when there is none (`deallocate` is a
+/// no-op). A synchronous bundle (`Bun.build`, the CLI) keeps one installed on
+/// its own thread for the whole pass. A dev server bundle only has one while
+/// `DevServer::start_async_bundle` sets it up; the rest of the graph work
+/// arrives later as JS event loop callbacks (`on_parse_task_complete`,
+/// `on_load`, `on_resolve`, `on_notify_defer`, and `finish_from_bake_dev_server`
+/// reached from them) with nothing installed, so everything those built through
+/// `AstAlloc` (`LinkerGraph::load`'s per-file `resolved_exports`, `clone_ast`,
+/// `InputFile::additional_files`, ...) leaked once per rebuild.
+///
+/// The setup state, which spills into `graph.heap`, is parked here between
+/// callbacks and installed for the duration of each one, so those allocations
+/// die with the bundle heap like everything else the bundle owns.
+#[derive(Default)]
+pub(crate) struct AsyncAstAlloc(AsyncAstState);
+
+#[derive(Default)]
+enum AsyncAstState {
+    /// Synchronous bundle: [`BundleV2::enter_async_ast_scope`] is a no-op.
+    #[default]
+    Disabled,
+    /// Between callbacks.
+    Parked(Box<AstAllocState>),
+    /// During a callback. A nested `enter` is a no-op.
+    Installed {
+        /// Identity of the installed box.
+        id: *const AstAllocState,
+        /// The thread-local occupant `enter` displaced; reinstated by `exit`.
+        displaced: Option<Box<AstAllocState>>,
+    },
+}
+
+impl AsyncAstAlloc {
+    /// Install the parked state, spilling into `spill`. Returns the installed
+    /// box's identity, or null when nothing was installed.
+    fn enter(&mut self, spill: *mut bun_alloc::mimalloc::Heap) -> *const AstAllocState {
+        let mut state = match core::mem::take(&mut self.0) {
+            AsyncAstState::Parked(state) => state,
+            other => {
+                self.0 = other;
+                return core::ptr::null();
+            }
+        };
+        state.set_spill_heap(spill);
+        let id: *const AstAllocState = &raw const *state;
+        self.0 = AsyncAstState::Installed {
+            id,
+            displaced: ast_alloc::swap_state(Some(state)),
+        };
+        id
+    }
+
+    /// Uninstall the state, reinstating whatever `enter` displaced, and park it
+    /// again. No-op unless installed.
+    fn exit(&mut self) {
+        let (id, displaced) = match core::mem::take(&mut self.0) {
+            AsyncAstState::Installed { id, displaced } => (id, displaced),
+            other => {
+                self.0 = other;
+                return;
+            }
+        };
+        debug_assert!(
+            core::ptr::eq(ast_alloc::active_state_id(), id),
+            "AsyncAstAlloc::exit: another AstAllocState is still installed on top of the bundle's"
+        );
+        if let Some(state) = ast_alloc::swap_state(displaced) {
+            self.0 = AsyncAstState::Parked(state);
+        }
+    }
+}
+
+impl Drop for AsyncAstAlloc {
+    fn drop(&mut self) {
+        // Normally already parked by `deinit_without_freeing_arena`; this keeps
+        // the thread-local from pointing at the freed box otherwise.
+        self.exit();
+    }
+}
+
+/// Returned by [`BundleV2::enter_async_ast_scope`]; uninstalls the bundle's
+/// state when dropped.
+///
+/// The callback holding this guard may be the one that completes the bundle:
+/// `finish_from_bake_dev_server` → `DevServer::finalize_bundle` frees the
+/// `BundleV2` before returning into the callback. That teardown uninstalls the
+/// state itself (`deinit_without_freeing_arena`, then `AsyncAstAlloc::drop`),
+/// so this guard dereferences `bv2` only while the state it installed is still
+/// the active one, which proves the `BundleV2` is still alive.
+#[must_use = "the state is uninstalled as soon as the guard drops"]
+pub(crate) struct AsyncAstScope {
+    bv2: *mut BundleV2<'static>,
+    /// Null when this guard installed nothing.
+    installed: *const AstAllocState,
+}
+
+impl Drop for AsyncAstScope {
+    fn drop(&mut self) {
+        if self.installed.is_null() || !core::ptr::eq(ast_alloc::active_state_id(), self.installed)
+        {
+            return;
+        }
+        // SAFETY: the state this guard installed is still active, so the
+        // `BundleV2` owning it has not been torn down (see the type doc). The
+        // guard is a local of a callback running on the bundle's own thread,
+        // and every borrow of `*bv2` taken by the callback body has ended by
+        // the time its locals drop.
+        unsafe { (*self.bv2).async_ast_alloc.exit() };
+    }
 }
 
 bun_core::declare_scope!(Bundle, visible);
@@ -265,6 +385,28 @@ impl<'a> BundleV2<'a> {
                 Target::ServerComponentsSsr => &mut *self.ssr_transpiler,
                 _ => &mut *self.transpiler,
             }
+        }
+    }
+
+    /// Dev server: hand over the `AstAllocState` the bundle was set up under,
+    /// once setup's own scope has exited, so the event loop callbacks that
+    /// finish the bundle allocate through it as well (see [`AsyncAstAlloc`]).
+    pub fn adopt_async_ast_state(&mut self, state: Box<AstAllocState>) {
+        debug_assert!(self.asynchronous);
+        debug_assert!(matches!(self.async_ast_alloc.0, AsyncAstState::Disabled));
+        self.async_ast_alloc.0 = AsyncAstState::Parked(state);
+    }
+
+    /// Install the bundle's parked `AstAllocState`, if it has one, until the
+    /// returned guard drops. Every JS event loop callback that works on the
+    /// graph declares this as its first local, so the state is still installed
+    /// while anything declared later (or called from the body) completes the
+    /// bundle.
+    pub(crate) fn enter_async_ast_scope(&mut self) -> AsyncAstScope {
+        let installed = self.async_ast_alloc.enter(self.graph.heap.heap_ptr());
+        AsyncAstScope {
+            bv2: std::ptr::from_mut::<BundleV2<'a>>(self).cast::<BundleV2<'static>>(),
+            installed,
         }
     }
 
@@ -2853,6 +2995,7 @@ pub mod bv2_impl {
                 asynchronous: false,
                 has_any_top_level_await_modules: false,
                 requested_exports: Vec::new(),
+                async_ast_alloc: super::AsyncAstAlloc::default(),
             });
             if let Some(bo) = bake_options {
                 // SAFETY: `bo.client_transpiler` is the caller's live, write-capable
@@ -4408,6 +4551,7 @@ pub mod bv2_impl {
 
     impl<'a> BundleV2<'a> {
         pub(crate) fn on_load(load: &mut jsc_api::JSBundler::Load, this: &mut BundleV2) {
+            let _ast_alloc = this.enter_async_ast_scope();
             this.graph.outstanding_loads.unlink(load);
             load.deferred = false;
             // `Load` is arena-allocated (no Drop); free its owned heap fields on every exit path.
@@ -4607,6 +4751,8 @@ pub mod bv2_impl {
 
     impl<'a> BundleV2<'a> {
         pub(crate) fn on_resolve(resolve: &mut jsc_api::JSBundler::Resolve, this: &mut BundleV2) {
+            // Declared before `_dec_guard`, whose drop may complete the bundle.
+            let _ast_alloc = this.enter_async_ast_scope();
             this.graph.outstanding_resolves.unlink(resolve);
             // RAII guard captures `this`
             // as a raw pointer so it does not hold a unique borrow across the body.
@@ -5022,6 +5168,11 @@ pub mod bv2_impl {
             for free in self.free_list.drain(..) {
                 drop(free);
             }
+
+            // A dev server bundle is torn down from inside the callback that
+            // completed it, i.e. while its state is installed; the heap that
+            // state spills into is destroyed right after this returns.
+            self.async_ast_alloc.exit();
         }
 
         pub fn run_from_js_in_new_thread(
@@ -6917,6 +7068,7 @@ pub mod bv2_impl {
 
     impl<'a> BundleV2<'a> {
         pub fn on_notify_defer(&mut self) {
+            let _ast_alloc = self.enter_async_ast_scope();
             self.thread_lock.assert_locked();
             self.graph.deferred_pending += 1;
             self.decrement_scan_counter();
@@ -6931,6 +7083,7 @@ pub mod bv2_impl {
             parse_result: &mut parse_task::Result,
             this: &mut BundleV2,
         ) {
+            let _ast_alloc = this.enter_async_ast_scope();
             let _trace = crate::perf::trace("Bundler.onParseTaskComplete");
             // Borrowck rejects holding a `&this.graph` alias
             // across the `this.*` method calls below (each takes

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -3259,11 +3259,8 @@ impl DevServer {
             bt
         })?;
         drop(entry_points);
-        // End the AST scope and hand its state to the bundle: the small
-        // `AstVec`s built during setup live in it, and the event loop callbacks
-        // that finish the bundle (`BundleV2::enter_async_ast_scope`) reinstall
-        // it so their `AstAlloc` allocations land in `heap` too instead of
-        // leaking on the global heap once per rebuild.
+        // End the AST scope; the bundle reinstalls its state for the callbacks
+        // that finish the bundle (`BundleV2::enter_async_ast_scope`).
         drop(ast_scope);
         // SAFETY: `ast_memory_store` lives in `heap`; the scope above has
         // exited, so no `&mut` to the allocator is live.

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -238,9 +238,6 @@ pub struct CurrentBundle {
     /// Owns the arena that `bv2.graph.heap` borrows (`'static` self-ref via the
     /// boxed allocation's stable address; same erasure as `bv2` above).
     pub heap: Box<bun_alloc::MimallocArena>,
-    /// Backs the small `AstVec`s built during bundle setup
-    /// (`start_async_bundle`'s AST scope); dropped with the bundle.
-    pub ast_alloc_state: Option<Box<bun_alloc::ast_alloc::AstAllocState>>,
     /// Information BundleV2 needs to finalize the bundle
     pub(crate) start_data: bundler::bundle_v2::DevServerInput,
     /// Started when the bundle was queued
@@ -3169,8 +3166,8 @@ impl DevServer {
         let heap: Box<bun_alloc::MimallocArena> = Box::new(bun_alloc::MimallocArena::new());
         // Borrows `heap`, so AST nodes built during bundle setup
         // live exactly as long as the bundle. The arena-allocated allocator
-        // never runs `Drop`; the `AstAllocState` is taken into `CurrentBundle`
-        // on success and recycled by the guard below on error paths.
+        // never runs `Drop`; the `AstAllocState` is handed to `bv2` on success
+        // and recycled by the guard below on error paths.
         let ast_memory_store: *mut bun_ast::ASTMemoryAllocator =
             heap.alloc(bun_ast::ASTMemoryAllocator::borrowing(&heap));
         struct ReleaseAstState(*mut bun_ast::ASTMemoryAllocator);
@@ -3262,16 +3259,21 @@ impl DevServer {
             bt
         })?;
         drop(entry_points);
-        // End the AST scope and move its state into the bundle so the small
-        // `AstVec`s built during setup stay alive until the bundle completes.
+        // End the AST scope and hand its state to the bundle: the small
+        // `AstVec`s built during setup live in it, and the event loop callbacks
+        // that finish the bundle (`BundleV2::enter_async_ast_scope`) reinstall
+        // it so their `AstAlloc` allocations land in `heap` too instead of
+        // leaking on the global heap once per rebuild.
         drop(ast_scope);
         // SAFETY: `ast_memory_store` lives in `heap`; the scope above has
         // exited, so no `&mut` to the allocator is live.
         let ast_alloc_state = unsafe { (*ast_memory_store).take_ast_state() };
+        bv2.adopt_async_ast_state(
+            ast_alloc_state.unwrap_or_else(bun_alloc::ast_alloc::acquire_state),
+        );
         self.current_bundle = Some(CurrentBundle {
             bv2,
             heap,
-            ast_alloc_state,
             timer,
             start_data,
             had_reload_event,

--- a/test/bake/dev-server-memory.test.ts
+++ b/test/bake/dev-server-memory.test.ts
@@ -38,6 +38,7 @@ test("rebuilding a module does not leak the bundle's allocations", async () => {
           "/live-blocks": () => {
             Bun.gc(true);
             const mainHeap = heapStats({ dump: true }).mimallocDump.heaps.find(heap => heap.seq === 0);
+            if (!mainHeap) throw new Error("heapStats dump has no heap with seq 0");
             return new Response(String(mainHeap.pages.reduce((blocks, page) => blocks + page.used, 0)));
           },
         },
@@ -86,15 +87,16 @@ test("rebuilding a module does not leak the bundle's allocations", async () => {
   const origin = `http://localhost:${Number.parseInt(firstLine, 10)}`;
 
   async function get(path: string) {
+    if (exited) throw exited;
     const response = await fetch(origin + path);
     const body = await response.text();
-    expect(response.status).toBe(200);
+    if (response.status !== 200) throw new Error(`GET ${path} responded with ${response.status}:\n${body}`);
     return body;
   }
 
   async function rebuild(revision: number) {
-    // An exit that happened while nothing was waiting is reported here; one
-    // that happens while waiting rejects the waiter.
+    // An exit while nothing was waiting is reported here; one that happens
+    // while waiting rejects the waiter.
     if (exited) throw exited;
     const { promise, resolve, reject } = Promise.withResolvers<void>();
     waiter = { target: reloads + 1, resolve, reject };

--- a/test/bake/dev-server-memory.test.ts
+++ b/test/bake/dev-server-memory.test.ts
@@ -57,6 +57,7 @@ test("rebuilding a module does not leak the bundle's allocations", async () => {
   // The dev server prints "Reloaded in <n>ms" once per completed rebuild.
   let stderr = "";
   let reloads = 0;
+  let exited: Error | undefined;
   let waiter: { target: number; resolve(): void; reject(err: Error): void } | undefined;
   const stderrClosed = (async () => {
     const decoder = new TextDecoder();
@@ -68,14 +69,18 @@ test("rebuilding a module does not leak the bundle's allocations", async () => {
         waiter = undefined;
       }
     }
-    waiter?.reject(new Error(`dev server exited after ${reloads} reloads:\n${stderr}`));
+    exited = new Error(`dev server exited after ${reloads} reloads:\n${stderr}`);
+    waiter?.reject(exited);
   })();
 
   const stdout = proc.stdout.getReader();
   let firstLine = "";
   while (!firstLine.includes("\n")) {
     const { value, done } = await stdout.read();
-    if (done) throw new Error(`dev server exited before printing its port:\n${stderr}`);
+    if (done) {
+      await stderrClosed;
+      throw exited;
+    }
     firstLine += Buffer.from(value).toString();
   }
   const origin = `http://localhost:${Number.parseInt(firstLine, 10)}`;
@@ -88,6 +93,9 @@ test("rebuilding a module does not leak the bundle's allocations", async () => {
   }
 
   async function rebuild(revision: number) {
+    // An exit that happened while nothing was waiting is reported here; one
+    // that happens while waiting rejects the waiter.
+    if (exited) throw exited;
     const { promise, resolve, reject } = Promise.withResolvers<void>();
     waiter = { target: reloads + 1, resolve, reject };
     await Bun.write(join(String(dir), "mod.ts"), moduleSource(revision));

--- a/test/bake/dev-server-memory.test.ts
+++ b/test/bake/dev-server-memory.test.ts
@@ -1,0 +1,121 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "node:path";
+
+// The graph work that finishes a dev server bundle (parse completions, linking)
+// runs on the JS thread. The `AstAlloc`-backed structures it builds there (among
+// them one entry per export of every re-bundled module) used to land on the
+// global mimalloc heap, where nothing ever frees them, so every rebuild leaked
+// about one block per export. The fixture reports the live block count of that
+// heap (`heapStats({ dump: true })`, heap seq 0), which, unlike RSS, is exact:
+// once the bundle's allocations die with the bundle it stays flat.
+const EXPORTS = 2000;
+const WARMUP_REBUILDS = 3;
+const MEASURED_REBUILDS = 15;
+
+function moduleSource(revision: number) {
+  let source = `export const revision = ${revision};\n`;
+  for (let i = 0; i < EXPORTS; i++) {
+    source += `export const e${i} = ${i};\n`;
+  }
+  return source;
+}
+
+test("rebuilding a module does not leak the bundle's allocations", async () => {
+  using dir = tempDir("dev-server-memory", {
+    "index.html": `<!doctype html><script type="module" src="./script.ts"></script>`,
+    "script.ts": `import * as mod from "./mod.ts";\nconsole.log(Object.keys(mod).length);\n`,
+    "mod.ts": moduleSource(0),
+    "server.ts": `
+      import { heapStats } from "bun:jsc";
+      import index from "./index.html";
+
+      const server = Bun.serve({
+        port: 0,
+        development: true,
+        routes: {
+          "/": index,
+          "/live-blocks": () => {
+            Bun.gc(true);
+            const mainHeap = heapStats({ dump: true }).mimallocDump.heaps.find(heap => heap.seq === 0);
+            return new Response(String(mainHeap.pages.reduce((blocks, page) => blocks + page.used, 0)));
+          },
+        },
+      });
+      console.log(server.port);
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "server.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  // The dev server prints "Reloaded in <n>ms" once per completed rebuild.
+  let stderr = "";
+  let reloads = 0;
+  let waiter: { target: number; resolve(): void; reject(err: Error): void } | undefined;
+  const stderrClosed = (async () => {
+    const decoder = new TextDecoder();
+    for await (const chunk of proc.stderr) {
+      stderr += decoder.decode(chunk, { stream: true });
+      reloads = stderr.match(/Reloaded in /g)?.length ?? 0;
+      if (waiter && reloads >= waiter.target) {
+        waiter.resolve();
+        waiter = undefined;
+      }
+    }
+    waiter?.reject(new Error(`dev server exited after ${reloads} reloads:\n${stderr}`));
+  })();
+
+  const stdout = proc.stdout.getReader();
+  let firstLine = "";
+  while (!firstLine.includes("\n")) {
+    const { value, done } = await stdout.read();
+    if (done) throw new Error(`dev server exited before printing its port:\n${stderr}`);
+    firstLine += Buffer.from(value).toString();
+  }
+  const origin = `http://localhost:${Number.parseInt(firstLine, 10)}`;
+
+  async function get(path: string) {
+    const response = await fetch(origin + path);
+    const body = await response.text();
+    expect(response.status).toBe(200);
+    return body;
+  }
+
+  async function rebuild(revision: number) {
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    waiter = { target: reloads + 1, resolve, reject };
+    await Bun.write(join(String(dir), "mod.ts"), moduleSource(revision));
+    await promise;
+  }
+
+  async function liveBlocks(): Promise<number> {
+    while (true) {
+      const reloadsBefore = reloads;
+      // Page requests are answered once any in-flight bundle has finished.
+      await get("/");
+      const blocks = Number(await get("/live-blocks"));
+      // A write can surface as more than one watcher event; if an extra
+      // rebuild landed while sampling, sample again.
+      if (reloads === reloadsBefore) return blocks;
+    }
+  }
+
+  let revision = 0;
+  await get("/");
+  for (let i = 0; i < WARMUP_REBUILDS; i++) await rebuild(++revision);
+  const before = await liveBlocks();
+  for (let i = 0; i < MEASURED_REBUILDS; i++) await rebuild(++revision);
+  const after = await liveBlocks();
+
+  // Unfixed: at least EXPORTS blocks per rebuild. Fixed: a few hundred at most.
+  expect(after - before).toBeLessThan((EXPORTS * MEASURED_REBUILDS) / 4);
+
+  proc.kill();
+  await Promise.all([proc.exited, stderrClosed]);
+}, 60_000);


### PR DESCRIPTION
### Problem
- A dev server (`Bun.serve({ development: true, routes: { "/": index } })`, or any bake app) grows without bound as files are edited: every rebuild leaks about one mimalloc block per export of each re-bundled module (~170 KB and ~2100 live blocks per rebuild of a 2000-export module, measured with `heapStats({ dump: true })` on both the release canary and a debug build).
- The allocations are the `AstAlloc`-backed graph structures the bundler builds on the JS thread while finishing a dev bundle: `LinkerGraph::load` (`src/bundler/LinkerGraph.rs:838`, one boxed key plus columns per export for each file's `resolved_exports`), `BundleV2::clone_ast`, `InputFile::additional_files` / `secondary_path` / `unique_key_for_additional_file` in `process_resolve_queue` and `on_parse_task_complete`, and so on.
- `AstAlloc` routes through the `AstAllocState` installed on the calling thread and falls back to plain `mi_malloc` when there is none, where its no-op `deallocate` means the block is never freed (`src/bun_alloc/ast_alloc.rs:335`, `:421`). `DevServer::start_async_bundle` (`src/runtime/bake/DevServer.rs`) only installs a state while it sets the bundle up and drops that scope before returning. Everything after that (parse completions, plugin callbacks, `finish_from_bake_dev_server`) runs as event loop callbacks on the JS thread with nothing installed, so it all went to the fallback. `Bun.build` and the CLI are unaffected: they keep an `ASTMemoryAllocator` pushed on their own thread for the whole pass (`src/bundler/BundleThread.rs:277`).

### Fix
- The state the bundle was set up under is handed to the `BundleV2` (`adopt_async_ast_state`) instead of being parked in `CurrentBundle`, and the four JS-thread entry points that work on the graph (`on_parse_task_complete`, `on_load`, `on_resolve`, `on_notify_defer`; `finish_from_bake_dev_server` is only reached through them) install it for their duration via an RAII guard (`enter_async_ast_scope`). The state spills into `graph.heap`, the per-bundle arena, so these allocations now die with the bundle like the ones made on the worker threads already do. For synchronous bundles the guard is a no-op (`AsyncAstState::Disabled`), and a nested `enter` is a no-op too.
- The callback that completes the bundle also tears it down (`finalize_bundle` frees the `BundleV2` and destroys the heap before returning into the callback), so the guard cannot point at the bundle. The state machine lives in an `Rc<AsyncAstAlloc>` (a `Cell` holding `Disabled` / `Parked(box)` / `Installed { id, displaced }`) shared between the `BundleV2` and the guard that installed from it, so a guard that outlives its bundle just finds the slot already parked: `deinit_without_freeing_arena` uninstalls the state before the heap is destroyed, and the last owner's `Drop` uninstalls as a backstop and hands the box to `ast_alloc::release_state`, the same recycler `ASTMemoryAllocator` uses, so the next bundle's setup reuses it. `exit` only swaps the thread-local back if the bundle's state is still the active one (otherwise it leaves everything in place and debug-asserts), and it reinstates whatever state it displaced, so it nests under any scope that happens to be active on the JS thread. Nested `enter` calls and synchronous bundles (`Disabled`) get a guard that owns nothing. The guard is declared before anything else in each callback (`on_resolve`'s decrement-on-drop guard in particular) so the state is still installed when the decrement finishes the bundle.
- Why routing these allocations to the bundle heap is correct: they are bundle-graph data that `deinit_without_freeing_arena` already assumes is reclaimed by destroying the AST heaps (see the comment above its `css` pass); the dev server copies everything it keeps across rebuilds out of the bundle (for example `quoted_source_contents`, `finalize_bundle`), exactly as it must already do for the worker-allocated half of the same structures; and the resolver's `package.json` / `tsconfig.json` caches keep no `AstAlloc` data (they extract owned values from the parsed tape). An installed state while JS runs is also not new: the transpile path installs one around every JS-thread transpile, including macro execution, which is why long-lived AST data has to detach explicitly (`DetachAstHeap`).
- The slot is the last field of `BundleV2`, so when the bundle is the last owner the box is released after the graph columns whose small `AstVec`s live in its inline chunk, the same ordering `CurrentBundle` provided before.
- Test: `test/bake/dev-server-memory.test.ts` rebuilds a 2000-export module 15 times and bounds the growth of the main mimalloc heap's live block count (exact, unlike RSS). Unfixed release canary: 30029 to 32020 blocks of growth across runs (limit 7500); fixed debug/ASAN build: 5 to 10 blocks across three runs.
- Also ran on the fixed build: `test/bake/dev/{plugins,bundle,html,hot,esm,css}.test.ts`, `test/bake/deinitialization.test.ts`, `test/bundler/bundler_plugin.test.ts`, `test/bundler/bun-build-api.test.ts` (all pass; the plugin, hot and deinitialization suites were re-run after the `Rc` rework); `cargo clippy` on `bun_bundler` and `bun_runtime` is clean.

### Background
- `AstAlloc` (`src/bun_alloc/ast_alloc.rs`) is the zero-sized allocator behind the AST's interior `Vec`s and the bundler's per-file maps. It allocates from the `AstAllocState` installed in a thread-local (a 16 KB inline bump chunk plus a "spill" mimalloc heap supplied by whoever installed it) and never frees individual blocks; the owner of the state reclaims everything at once by destroying the spill heap. With no state installed it falls back to global `mi_malloc`, and those blocks are never reclaimed.
- A dev server bundle is asynchronous: `start_async_bundle` creates a per-bundle `MimallocArena` (`CurrentBundle.heap`, which `BundleV2.graph.heap` borrows), enqueues the entry points, and returns. Parse tasks run on the shared work pool, each worker under its own pushed `ASTMemoryAllocator`, and post their results to the JS event loop; the JS thread integrates them in `on_parse_task_complete`, and the completion that brings the pending count to zero links and finalizes the bundle synchronously inside that same callback, ending with `CurrentBundle` (heap included) being dropped.
- The measurements in the original report that used `heapStats().mimalloc.malloc_normal.current` overstate this leak by about 10x: that counter is never decremented when a heap is destroyed (handed off separately), so it also counts every per-bundle arena. The per-page live block count from `heapStats({ dump: true })` is what the test uses.

<details>
<summary>Probe numbers (2000-export module, sampled after <code>Bun.gc(true)</code>, main heap = <code>seq 0</code>)</summary>

Unfixed release canary `eabb96de7`, 10 rebuilds per sample: +5478, +10967, +17380, +19805, +25992, +31608, +40704 live blocks (cumulative), almost all in the 8-byte bin (the export-name key boxes).

Fixed debug build, 5 rebuilds per sample: -3, -1, +14, +4, +3, +7, +12 live blocks (cumulative). RSS in the debug build still grows ~2 MB per rebuild of this module, but that is the ASAN quarantine: with `ASAN_OPTIONS=quarantine_size_mb=8` it flattens out while the live block count stays at zero growth.
</details>
