### PR TITLE
install: warn when the hoisted tree serves a peer from a root copy outside its range

### DIFF
--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -745,8 +745,7 @@ impl Lockfile {
         self.packages.items_dependencies()[0].contains(id)
     }
 
-    /// The version a semver range can be checked against: `None` for packages that
-    /// have none (git, tarball and folder resolutions, workspaces without a `version`).
+    /// `None` for git, tarball and unversioned workspace packages (no version to compare).
     pub(crate) fn package_version(&self, id: PackageID) -> Option<Semver::Version> {
         let resolution = &self.packages.items_resolution()[id as usize];
         match resolution.tag {

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -745,6 +745,20 @@ impl Lockfile {
         self.packages.items_dependencies()[0].contains(id)
     }
 
+    /// The version a semver range can be checked against: `None` for packages that
+    /// have none (git, tarball and folder resolutions, workspaces without a `version`).
+    pub(crate) fn package_version(&self, id: PackageID) -> Option<Semver::Version> {
+        let resolution = &self.packages.items_resolution()[id as usize];
+        match resolution.tag {
+            ResolutionTag::Npm => Some(resolution.npm().version),
+            ResolutionTag::Workspace => self
+                .workspace_versions
+                .get(&self.packages.items_name_hash()[id as usize])
+                .copied(),
+            _ => None,
+        }
+    }
+
     /// Is this a direct dependency of the workspace the install is taking place in?
     pub(crate) fn is_root_dependency(
         &self,

--- a/src/install/lockfile/OverrideMap.rs
+++ b/src/install/lockfile/OverrideMap.rs
@@ -4,7 +4,6 @@ use core::cmp::Ordering;
 use crate::DependencyID;
 use crate::Error;
 use crate::package_manager::workspace_package_json_cache::{GetJSONOptions, GetResult};
-use crate::resolution::Tag as ResolutionTag;
 use crate::{PackageID, invalid_package_id};
 use bun_collections::{ArrayHashMap, index_sort};
 use bun_install::dependency::{
@@ -249,15 +248,10 @@ impl OverrideMap {
         if owner_id == invalid_package_id {
             return None;
         }
-        let owner_id = owner_id as usize;
-        let owner_name_hash = lockfile.packages.items_name_hash()[owner_id];
-        let resolution = &lockfile.packages.items_resolution()[owner_id];
-        let owner_version = match resolution.tag {
-            ResolutionTag::Npm => Some(resolution.npm().version),
-            ResolutionTag::Workspace => lockfile.workspace_versions.get(&owner_name_hash).copied(),
-            _ => None,
-        };
-        Some((owner_name_hash, owner_version))
+        Some((
+            lockfile.packages.items_name_hash()[owner_id as usize],
+            lockfile.package_version(owner_id),
+        ))
     }
 
     fn owner_package_id(&self, lockfile: &Lockfile, dependency_id: DependencyID) -> PackageID {

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -492,8 +492,7 @@ impl<'a, const METHOD: BuilderMethod> Builder<'a, METHOD> {
         let _ = self.log.add_error_fmt(None, bun_ast::Loc::EMPTY, args);
     }
 
-    /// Same message as the resolver prints when it binds a peer to a version outside its
-    /// range, plus the dependent and the range, which this site knows.
+    /// The resolver's "incorrect peer dependency" message, with the dependent and range added.
     #[cold]
     fn warn_peer_out_of_range(
         &mut self,
@@ -920,8 +919,7 @@ impl Tree {
                     builder.resolutions[dep_id as usize] = res_id;
                 }
                 HoistDependencyResult::HoistedOutOfRange(res_id) => {
-                    // Only the build whose tree is installed reports it: the `Resolvable` build
-                    // also runs on every lockfile load and again when the lockfile is cleaned.
+                    // Resolvable builds also run on load and clean; only the installed tree warns.
                     if METHOD == BuilderMethod::Filter {
                         builder.warn_peer_out_of_range(parent_pkg_id, dependency, res_id);
                     }
@@ -1078,9 +1076,7 @@ impl Tree {
                 // Root dependencies are manually chosen by the user. Allow them
                 // to hoist other peers even if they don't satisfy the version
                 if builder.lockfile().is_workspace_root_dependency(dep_id) {
-                    // Optional peers take whatever the tree offers them (the resolver never binds
-                    // them either), and a copy without a version (git, tarball, unversioned
-                    // workspace) has nothing to check the range against.
+                    // Optional peers take whatever the tree offers, as they do in the resolver.
                     let rejected = !dependency.behavior.is_optional_peer()
                         && peer_range.tag == crate::dependency::VersionTag::Npm
                         && builder

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -4,6 +4,7 @@ use bun_alloc::AllocError;
 use bun_collections::{ArrayHashMap, DynamicBitSet, MultiArrayList};
 use bun_core::Output;
 use bun_core::ZStr;
+use bun_core::fmt::PathSep;
 use bun_paths::{MAX_PATH_BYTES, PathBuffer, SEP};
 
 use crate::lockfile::package::PackageColumns as _;
@@ -137,6 +138,8 @@ enum HoistDependencyResult {
     ResolveLater,
     /// `Hoisted`, plus the optional peer's slot now points at the version it deduplicated onto.
     Rebind(PackageID),
+    /// `Hoisted` onto the root package.json's copy of a peer, whose version the peer's range rejects.
+    HoistedOutOfRange(PackageID),
     Placement(Placement),
 }
 
@@ -487,6 +490,36 @@ impl<'a, const METHOD: BuilderMethod> Builder<'a, METHOD> {
 
     fn maybe_report_error(&mut self, args: core::fmt::Arguments<'_>) {
         let _ = self.log.add_error_fmt(None, bun_ast::Loc::EMPTY, args);
+    }
+
+    /// Same message as the resolver prints when it binds a peer to a version outside its
+    /// range, plus the dependent and the range, which this site knows.
+    #[cold]
+    fn warn_peer_out_of_range(
+        &mut self,
+        dependent_id: PackageID,
+        peer: &Dependency,
+        copy_id: PackageID,
+    ) {
+        let lockfile_ref = self.lockfile;
+        let lockfile: &Lockfile = lockfile_ref.get();
+        let buf = lockfile.buffers.string_bytes.as_slice();
+        let pkg_names = lockfile.packages.items_name();
+        let pkg_resolutions = lockfile.packages.items_resolution();
+        let range = lockfile.catalogs.resolve_range(buf, peer);
+        self.log.add_warning_fmt(
+            None,
+            bun_ast::Loc::EMPTY,
+            format_args!(
+                "incorrect peer dependency \"{}@{}\": \"{}@{}\" requires \"{}@{}\"",
+                pkg_names[copy_id as usize].fmt(buf),
+                pkg_resolutions[copy_id as usize].fmt(buf, PathSep::Posix),
+                pkg_names[dependent_id as usize].fmt(buf),
+                pkg_resolutions[dependent_id as usize].fmt(buf, PathSep::Posix),
+                peer.name.fmt(buf),
+                range.literal.fmt(buf),
+            ),
+        );
     }
 
     fn buf(&self) -> &[u8] {
@@ -886,6 +919,13 @@ impl Tree {
                     debug_assert!(dependency.behavior.is_optional_peer());
                     builder.resolutions[dep_id as usize] = res_id;
                 }
+                HoistDependencyResult::HoistedOutOfRange(res_id) => {
+                    // Only the build whose tree is installed reports it: the `Resolvable` build
+                    // also runs on every lockfile load and again when the lockfile is cleaned.
+                    if METHOD == BuilderMethod::Filter {
+                        builder.warn_peer_out_of_range(parent_pkg_id, dependency, res_id);
+                    }
+                }
                 HoistDependencyResult::ResolveLater => {
                     // `dep_id` is an unresolved optional peer. while hoisting it deduplicated
                     // with another unresolved optional peer. save it so we remember resolve it
@@ -1038,8 +1078,26 @@ impl Tree {
                 // Root dependencies are manually chosen by the user. Allow them
                 // to hoist other peers even if they don't satisfy the version
                 if builder.lockfile().is_workspace_root_dependency(dep_id) {
-                    // TODO: warning about peer dependency version mismatch
-                    return dedupe(); // 1
+                    // Optional peers take whatever the tree offers them (the resolver never binds
+                    // them either), and a copy without a version (git, tarball, unversioned
+                    // workspace) has nothing to check the range against.
+                    let rejected = !dependency.behavior.is_optional_peer()
+                        && peer_range.tag == crate::dependency::VersionTag::Npm
+                        && builder
+                            .lockfile()
+                            .package_version(res_id)
+                            .is_some_and(|copy| {
+                                !peer_range.npm().version.satisfies(
+                                    copy,
+                                    builder.buf(),
+                                    builder.buf(),
+                                )
+                            });
+                    return if rejected {
+                        HoistDependencyResult::HoistedOutOfRange(res_id) // 1
+                    } else {
+                        dedupe() // 1
+                    };
                 }
             }
 

--- a/test/cli/install/hoist.test.ts
+++ b/test/cli/install/hoist.test.ts
@@ -1,5 +1,8 @@
-import { afterAll, beforeAll, test } from "bun:test";
+import { file, write } from "bun";
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { exists } from "fs/promises";
 import { VerdaccioRegistry, bunEnv, runBunInstall } from "harness";
+import { join } from "path";
 
 const registry = new VerdaccioRegistry();
 
@@ -28,3 +31,146 @@ test("should handle resolving optional peer from multiple instances of same pack
   // this shouldn't hit an assertion
   await runBunInstall(bunEnv, packageDir);
 });
+
+// A peer whose own resolution conflicts with the copy the root package.json put
+// at the top of node_modules is served by the root's copy whatever its range
+// says (Tree.hoist_dependency). The install doing that has to say so; the
+// resolver's own `incorrect peer dependency` warning only covers peers it bound
+// out of range itself.
+const peerWarnings = (stderr: string) => stderr.match(/^warn: incorrect peer dependency [^\r\n]*/gm) ?? [];
+const installedVersion = async (packageDir: string, ...path: string[]) =>
+  (await file(join(packageDir, "node_modules", ...path, "package.json")).json()).version;
+const hasOwnNodeModules = (packageDir: string, name: string) =>
+  exists(join(packageDir, "node_modules", name, "node_modules"));
+
+test.concurrent("warns when a workspace member's peer is served by a root dependency outside its range", async () => {
+  const rootPackageJson = (noDeps: string) =>
+    JSON.stringify({ name: "root", workspaces: ["packages/*"], dependencies: { "no-deps": noDeps } });
+  const { packageDir, packageJson } = await registry.createTestDir({
+    bunfigOpts: { linker: "hoisted" },
+    files: {
+      "package.json": rootPackageJson("^1.0.0"),
+      "packages/pkg1/package.json": JSON.stringify({
+        name: "pkg1",
+        version: "1.0.0",
+        peerDependencies: { "no-deps": "^1.0.0" },
+      }),
+    },
+  });
+
+  // The member's peer binds to the root's no-deps@1.1.0: nothing to report.
+  await runBunInstall(bunEnv, packageDir);
+  expect(await installedVersion(packageDir, "no-deps")).toBe("1.1.0");
+
+  // The peer stays bound to 1.1.0, but the tree only has room for the root's
+  // new copy, so pkg1 gets no-deps@2.0.0. Reported once: the tree is also built
+  // while loading and cleaning the lockfile, and those builds stay quiet.
+  await write(packageJson, rootPackageJson("^2.0.0"));
+  const { err } = await runBunInstall(bunEnv, packageDir, { allowWarnings: true });
+  expect(peerWarnings(err)).toEqual([
+    'warn: incorrect peer dependency "no-deps@2.0.0": "pkg1@workspace:packages/pkg1" requires "no-deps@^1.0.0"',
+  ]);
+  expect(await installedVersion(packageDir, "no-deps")).toBe("2.0.0");
+  expect(await hasOwnNodeModules(packageDir, "pkg1")).toBe(false);
+});
+
+test.concurrent(
+  "warns on every install while a dependency's peer is served by a root dependency outside its range",
+  async () => {
+    const { packageDir } = await registry.createTestDir({
+      bunfigOpts: { linker: "hoisted" },
+      files: {
+        "package.json": JSON.stringify({
+          name: "root",
+          dependencies: {
+            // peer-deps-fixed@1.0.0 has a peer on no-deps@^1.0.0.
+            // provides-peer-deps-1-0-0 depends on no-deps@1.0.0, which the
+            // resolver binds that peer to, so the resolver itself has nothing
+            // to warn about.
+            "peer-deps-fixed": "1.0.0",
+            "no-deps": "2.0.0",
+            "provides-peer-deps-1-0-0": "1.0.0",
+          },
+        }),
+      },
+    });
+    const expected =
+      'warn: incorrect peer dependency "no-deps@2.0.0": "peer-deps-fixed@1.0.0" requires "no-deps@^1.0.0"';
+
+    const fresh = await runBunInstall(bunEnv, packageDir, { allowWarnings: true });
+    expect(peerWarnings(fresh.err)).toEqual([expected]);
+    expect(await installedVersion(packageDir, "no-deps")).toBe("2.0.0");
+    expect(await installedVersion(packageDir, "provides-peer-deps-1-0-0", "node_modules", "no-deps")).toBe("1.0.0");
+    expect(await hasOwnNodeModules(packageDir, "peer-deps-fixed")).toBe(false);
+
+    // Nothing changed, so the same tree gets installed again.
+    const again = await runBunInstall(bunEnv, packageDir, { allowWarnings: true, savesLockfile: false });
+    expect(peerWarnings(again.err)).toEqual([expected]);
+  },
+);
+
+test.concurrent.each([
+  [
+    "2.0.0",
+    "warns",
+    [
+      'warn: incorrect peer dependency "no-deps@workspace:packages/no-deps": "peer-deps-fixed@1.0.0" requires "no-deps@^1.0.0"',
+    ],
+  ],
+  ["1.5.0", "is quiet", []],
+])("a workspace package at %s serving a dependency's no-deps@^1.0.0 peer %s", async (version, _, warnings) => {
+  const { packageDir } = await registry.createTestDir({
+    bunfigOpts: { linker: "hoisted" },
+    files: {
+      "package.json": JSON.stringify({
+        name: "root",
+        workspaces: ["packages/*"],
+        dependencies: { "peer-deps-fixed": "1.0.0", "provides-peer-deps-1-0-0": "1.0.0" },
+      }),
+      "packages/no-deps/package.json": JSON.stringify({ name: "no-deps", version }),
+    },
+  });
+
+  const { err } = await runBunInstall(bunEnv, packageDir, { allowWarnings: warnings.length > 0 });
+  expect(peerWarnings(err)).toEqual(warnings);
+  expect(await installedVersion(packageDir, "no-deps")).toBe(version);
+  expect(await hasOwnNodeModules(packageDir, "peer-deps-fixed")).toBe(false);
+});
+
+// one-optional-peer-dep has a peer on no-deps@^1.0.0: required in 1.0.1, optional in 1.0.2.
+test.concurrent.each([
+  [
+    "1.0.1",
+    "is reported",
+    ['warn: incorrect peer dependency "no-deps@2.0.0": "one-optional-peer-dep@1.0.1" requires "no-deps@^1.0.0"'],
+  ],
+  ["1.0.2", "is rebound quietly", []],
+])(
+  "a peer of one-optional-peer-dep@%s left on no-deps@1.0.0 when the root moves to 2.0.0 %s",
+  async (version, _, warnings) => {
+    const rootPackageJson = (noDeps: string) =>
+      JSON.stringify({
+        name: "root",
+        dependencies: {
+          "one-optional-peer-dep": version,
+          "no-deps": noDeps,
+          // Keeps no-deps@1.0.0, and with it the peer's binding to it, in the lockfile after the root moves on.
+          "provides-peer-deps-1-0-0": "1.0.0",
+        },
+      });
+    const { packageDir, packageJson } = await registry.createTestDir({
+      bunfigOpts: { linker: "hoisted" },
+      files: { "package.json": rootPackageJson("1.0.0") },
+    });
+
+    await runBunInstall(bunEnv, packageDir);
+    expect(await installedVersion(packageDir, "no-deps")).toBe("1.0.0");
+
+    await write(packageJson, rootPackageJson("2.0.0"));
+    const { err } = await runBunInstall(bunEnv, packageDir, { allowWarnings: warnings.length > 0 });
+    expect(peerWarnings(err)).toEqual(warnings);
+    expect(await installedVersion(packageDir, "no-deps")).toBe("2.0.0");
+    expect(await installedVersion(packageDir, "provides-peer-deps-1-0-0", "node_modules", "no-deps")).toBe("1.0.0");
+    expect(await hasOwnNodeModules(packageDir, "one-optional-peer-dep")).toBe(false);
+  },
+);

--- a/test/cli/install/hoist.test.ts
+++ b/test/cli/install/hoist.test.ts
@@ -38,6 +38,8 @@ test("should handle resolving optional peer from multiple instances of same pack
 // resolver's own `incorrect peer dependency` warning only covers peers it bound
 // out of range itself.
 const peerWarnings = (stderr: string) => stderr.match(/^warn: incorrect peer dependency [^\r\n]*/gm) ?? [];
+// CI exports BUN_INSTALL_CACHE_DIR, which overrides the harness bunfig's per-test `cache`; concurrent cases sharing one cache race on Windows.
+const installEnv = (dir: string) => ({ ...bunEnv, BUN_INSTALL_CACHE_DIR: join(dir, ".bun-cache") });
 const installedVersion = async (packageDir: string, ...path: string[]) =>
   (await file(join(packageDir, "node_modules", ...path, "package.json")).json()).version;
 const hasOwnNodeModules = (packageDir: string, name: string) =>
@@ -59,14 +61,14 @@ test.concurrent("warns when a workspace member's peer is served by a root depend
   });
 
   // The member's peer binds to the root's no-deps@1.1.0: nothing to report.
-  await runBunInstall(bunEnv, packageDir);
+  await runBunInstall(installEnv(packageDir), packageDir);
   expect(await installedVersion(packageDir, "no-deps")).toBe("1.1.0");
 
   // The peer stays bound to 1.1.0, but the tree only has room for the root's
   // new copy, so pkg1 gets no-deps@2.0.0. Reported once: the tree is also built
   // while loading and cleaning the lockfile, and those builds stay quiet.
   await write(packageJson, rootPackageJson("^2.0.0"));
-  const { err } = await runBunInstall(bunEnv, packageDir, { allowWarnings: true });
+  const { err } = await runBunInstall(installEnv(packageDir), packageDir, { allowWarnings: true });
   expect(peerWarnings(err)).toEqual([
     'warn: incorrect peer dependency "no-deps@2.0.0": "pkg1@workspace:packages/pkg1" requires "no-deps@^1.0.0"',
   ]);
@@ -97,14 +99,17 @@ test.concurrent(
     const expected =
       'warn: incorrect peer dependency "no-deps@2.0.0": "peer-deps-fixed@1.0.0" requires "no-deps@^1.0.0"';
 
-    const fresh = await runBunInstall(bunEnv, packageDir, { allowWarnings: true });
+    const fresh = await runBunInstall(installEnv(packageDir), packageDir, { allowWarnings: true });
     expect(peerWarnings(fresh.err)).toEqual([expected]);
     expect(await installedVersion(packageDir, "no-deps")).toBe("2.0.0");
     expect(await installedVersion(packageDir, "provides-peer-deps-1-0-0", "node_modules", "no-deps")).toBe("1.0.0");
     expect(await hasOwnNodeModules(packageDir, "peer-deps-fixed")).toBe(false);
 
     // Nothing changed, so the same tree gets installed again.
-    const again = await runBunInstall(bunEnv, packageDir, { allowWarnings: true, savesLockfile: false });
+    const again = await runBunInstall(installEnv(packageDir), packageDir, {
+      allowWarnings: true,
+      savesLockfile: false,
+    });
     expect(peerWarnings(again.err)).toEqual([expected]);
   },
 );
@@ -131,7 +136,7 @@ test.concurrent.each([
     },
   });
 
-  const { err } = await runBunInstall(bunEnv, packageDir, { allowWarnings: warnings.length > 0 });
+  const { err } = await runBunInstall(installEnv(packageDir), packageDir, { allowWarnings: warnings.length > 0 });
   expect(peerWarnings(err)).toEqual(warnings);
   expect(await installedVersion(packageDir, "no-deps")).toBe(version);
   expect(await hasOwnNodeModules(packageDir, "peer-deps-fixed")).toBe(false);
@@ -163,11 +168,11 @@ test.concurrent.each([
       files: { "package.json": rootPackageJson("1.0.0") },
     });
 
-    await runBunInstall(bunEnv, packageDir);
+    await runBunInstall(installEnv(packageDir), packageDir);
     expect(await installedVersion(packageDir, "no-deps")).toBe("1.0.0");
 
     await write(packageJson, rootPackageJson("2.0.0"));
-    const { err } = await runBunInstall(bunEnv, packageDir, { allowWarnings: warnings.length > 0 });
+    const { err } = await runBunInstall(installEnv(packageDir), packageDir, { allowWarnings: warnings.length > 0 });
     expect(peerWarnings(err)).toEqual(warnings);
     expect(await installedVersion(packageDir, "no-deps")).toBe("2.0.0");
     expect(await installedVersion(packageDir, "provides-peer-deps-1-0-0", "node_modules", "no-deps")).toBe("1.0.0");

--- a/test/cli/install/hoist.test.ts
+++ b/test/cli/install/hoist.test.ts
@@ -1,5 +1,6 @@
 import { file, write } from "bun";
 import { afterAll, beforeAll, expect, test } from "bun:test";
+import { readFileSync } from "fs";
 import { exists } from "fs/promises";
 import { VerdaccioRegistry, bunEnv, runBunInstall } from "harness";
 import { join } from "path";
@@ -114,33 +115,52 @@ test.concurrent(
   },
 );
 
+// The root provides no-deps as something other than a registry package. A
+// workspace is checked through its own version; a copy with no version in the
+// lockfile (a tarball here, git would be the same) cannot be checked and is
+// never reported.
+const workspaceNoDeps = (version?: string) => ({
+  "packages/no-deps/package.json": JSON.stringify({ name: "no-deps", version }),
+});
+const tarballNoDeps = {
+  "no-deps-2.0.0.tgz": readFileSync(join(registry.packagesPath, "no-deps", "no-deps-2.0.0.tgz")),
+};
 test.concurrent.each([
   [
-    "2.0.0",
+    "a workspace at 2.0.0",
     "warns",
+    workspaceNoDeps("2.0.0"),
+    {},
     [
       'warn: incorrect peer dependency "no-deps@workspace:packages/no-deps": "peer-deps-fixed@1.0.0" requires "no-deps@^1.0.0"',
     ],
+    "2.0.0",
   ],
-  ["1.5.0", "is quiet", []],
-])("a workspace package at %s serving a dependency's no-deps@^1.0.0 peer %s", async (version, _, warnings) => {
-  const { packageDir } = await registry.createTestDir({
-    bunfigOpts: { linker: "hoisted" },
-    files: {
-      "package.json": JSON.stringify({
-        name: "root",
-        workspaces: ["packages/*"],
-        dependencies: { "peer-deps-fixed": "1.0.0", "provides-peer-deps-1-0-0": "1.0.0" },
-      }),
-      "packages/no-deps/package.json": JSON.stringify({ name: "no-deps", version }),
-    },
-  });
+  ["a workspace at 1.5.0", "is quiet", workspaceNoDeps("1.5.0"), {}, [], "1.5.0"],
+  ["a workspace without a version", "is quiet", workspaceNoDeps(), {}, [], undefined],
+  ["a file: tarball of 2.0.0", "is quiet", tarballNoDeps, { "no-deps": "file:./no-deps-2.0.0.tgz" }, [], "2.0.0"],
+])(
+  "root-provided no-deps (%s) serving a dependency's no-deps@^1.0.0 peer %s",
+  async (_, __, files, noDepsDependency, warnings, installed) => {
+    const { packageDir } = await registry.createTestDir({
+      bunfigOpts: { linker: "hoisted" },
+      files: {
+        ...files,
+        "package.json": JSON.stringify({
+          name: "root",
+          workspaces: ["packages/*"],
+          dependencies: { "peer-deps-fixed": "1.0.0", "provides-peer-deps-1-0-0": "1.0.0", ...noDepsDependency },
+        }),
+      },
+    });
 
-  const { err } = await runBunInstall(installEnv(packageDir), packageDir, { allowWarnings: warnings.length > 0 });
-  expect(peerWarnings(err)).toEqual(warnings);
-  expect(await installedVersion(packageDir, "no-deps")).toBe(version);
-  expect(await hasOwnNodeModules(packageDir, "peer-deps-fixed")).toBe(false);
-});
+    const { err } = await runBunInstall(installEnv(packageDir), packageDir, { allowWarnings: warnings.length > 0 });
+    expect(peerWarnings(err)).toEqual(warnings);
+    expect(await installedVersion(packageDir, "no-deps")).toBe(installed);
+    expect(await installedVersion(packageDir, "provides-peer-deps-1-0-0", "node_modules", "no-deps")).toBe("1.0.0");
+    expect(await hasOwnNodeModules(packageDir, "peer-deps-fixed")).toBe(false);
+  },
+);
 
 // one-optional-peer-dep has a peer on no-deps@^1.0.0: required in 1.0.1, optional in 1.0.2.
 test.concurrent.each([


### PR DESCRIPTION
### Problem

- With the hoisted linker, a peer whose own resolution conflicts with the copy the root package.json put at the top of `node_modules` is served by the root's copy even when its range rejects it (`Tree::hoist_dependency`, the `is_workspace_root_dependency` branch in `src/install/lockfile/Tree.rs`, which carried a `// TODO: warning about peer dependency version mismatch`). Nothing is printed, on that install or on any later one.
- Two ways in, both with the registry fixtures (`peer-deps-fixed@1.0.0` has a peer on `no-deps@^1.0.0`):
  - Root `no-deps: ^1.0.0` plus a workspace member with that peer, `bun install`, then change the root entry to `^2.0.0` and install again: the output is `+ no-deps@2.0.0`, exit 0, and the member now gets `no-deps@2.0.0`. The resolver only re-resolves the root's row; `redirect_dependents` leaves the member's peer on 1.1.0 because its range rejects 2.0.0, and it is this dedupe that moves it.
  - Root `no-deps: 2.0.0`, `peer-deps-fixed`, and `provides-peer-deps-1-0-0` (which depends on `no-deps@1.0.0`): a fresh install binds the peer to the nested 1.0.0, so the resolver's own `warn: incorrect peer dependency` never fires, and the tree then serves it 2.0.0 on this and every following install.
- The resolver's warning (`get_or_put_resolved_package`, `PackageManagerEnqueue.rs`) only covers peers the resolver itself bound out of range, so the same package.json warns when installed from scratch and is silent when reached through either sequence above.

### Fix

- The branch returns a new `HoistDependencyResult::HoistedOutOfRange(copy)` instead of `dedupe()` when the peer is required, its range is an npm range, and the copy has a version that the range rejects. Placement is unchanged: `process_subtree` treats the result exactly like `Hoisted`.
- The `Filter` build reports it: `warn: incorrect peer dependency "no-deps@2.0.0": "pkg1@workspace:packages/pkg1" requires "no-deps@^1.0.0"`. That build is the one tree per install that is written to `node_modules` (`install_hoisted_packages`), so the warning prints once per install and describes what was actually installed. The `Resolvable` build also runs on every lockfile load and again in `Cloner::flush`, so reporting from it would print two or three times per install; it stays quiet. (`bun prune` builds a `Filter` tree as well, but never prints the log afterwards, so it stays silent too.)
- Why the conditions: optional peers keep going through `dedupe()`, so the `Resolvable` build still returns `Rebind` for them (#37426) and nothing is reported, matching the resolver, which never binds or warns about optional peers (`enqueue_dependency_with_main_and_success_fn` returns early on them). The copy's version comes from `Lockfile::package_version`, which knows npm versions and versioned workspaces, so a workspace package standing in for an npm name is reported when its version is out of range and not reported when it is in range; git, tarball and unversioned workspace copies have nothing to compare and are not reported.
- Why a warning and not a different tree: serving the root's copy is the documented intent of that branch (the root's choice wins), and the existing resolver path already treats the same situation as a warning. This only closes the gap where the decision is made by the tree instead of the resolver. The loader still binds a peer nothing satisfies to the only remaining copy without a warning, so the first sequence warns on the install that makes the change and is quiet afterwards, like a fresh install is; the second sequence warns on every install because every install makes the decision again.
- `Lockfile::package_version` is the npm/workspace version lookup `OverrideMap::owner_of` had inline; `owner_of` now calls it.
- Tests in `test/cli/install/hoist.test.ts`, hoisted linker, all asserting the exact warning line(s) printed and that the dependent has no nested `node_modules` (it really is served by the root's copy): the workspace member sequence above (one line, printed once); the fresh install with the nested satisfying copy (one line, and again on a reinstall); the root providing `no-deps` as a workspace at 2.0.0 (reported as `"no-deps@workspace:packages/no-deps"`), at 1.5.0 (nothing), without a version (nothing), and as a `file:` tarball of 2.0.0 (nothing, no version to compare; git would take the same `None` arm); and `one-optional-peer-dep` left bound to a surviving `no-deps@1.0.0` when the root moves to 2.0.0, in its required (1.0.1, reported) and optional (1.0.2, nothing) versions. The four reporting cases fail without the `src/` change (nothing is printed); the optional case fails if the optional-peer condition is removed; the quiet cases pin the `None` and in-range arms of the version check.
- Also run with the debug build: `bun-install-registry`, `bun-install`, `bun-lock`, `bun-lockb`, `bun-workspaces`, `bun-update`, `bun-update-transitive`, `bun-update-lockfile-sync`, `bun-add`, `bun-add-catalog`, `bun-add-filter`, `bun-remove`, `bun-dedupe`, `bun-prune`, `bun-audit`, `bun-pm-why`, `bun-pm-licenses`, `catalogs`, `nested-overrides`, `frozen-lockfile-pruned`, `test-dev-peer-dependency-priority`, `isolated-install`, `isolated-relink`, `migrate-bun-lockb-v2` and the migration suites. No existing expectation changed; `bun-install.test.ts` only fails on the tests that need external hosts, the same as without this change.

### Background

- A dependency entry in a package.json is a row (`buffers.dependencies[i]`), and `buffers.resolutions[i]` is the package it is bound to. The root package.json is package 0; its rows include the workspace members.
- The hoisted tree builder (`Tree.rs`) walks rows breadth-first and tries to place each one as high in `node_modules` as possible. When a level already holds a different package under the same name, a regular row nests under its dependent; a peer row is instead deduped onto the existing copy when the copy satisfies its range, or unconditionally when the copy was placed by a root row. A deduped row places nothing, so its own package is left out of the tree and out of `bun.lock`.
- The tree is built several times per install: `Resolvable` builds (every row, for the saved lockfile) when `bun.lock` is loaded and again when the lockfile is cleaned before saving, and one `Filter` build (rows disabled by os/cpu, `--omit` or workspace filters left out) whose tree is what the hoisted installer writes to disk. The isolated linker does not use this tree for installing, so nothing changes for it.
- Optional peers are never resolved by the resolver; the tree binds them to whatever copy it finds, and since #37426 the `Resolvable` build moves that binding (`Rebind`) when it dedupes one, so the saved lockfile and the installed tree agree.

<details>
<summary>Before and after, debug build, registry fixtures</summary>

Workspace member sequence (root `no-deps` `^1.0.0` then `^2.0.0`, member `pkg1` with peer `no-deps@^1.0.0`), second install:

```
# before
Resolving dependencies
Resolved, downloaded and extracted [2]
Saved lockfile

# after
Resolving dependencies
Resolved, downloaded and extracted [2]
warn: incorrect peer dependency "no-deps@2.0.0": "pkg1@workspace:packages/pkg1" requires "no-deps@^1.0.0"
Saved lockfile
```

Fresh install of `peer-deps-fixed@1.0.0`, `no-deps@2.0.0`, `provides-peer-deps-1-0-0@1.0.0`: before, nothing on stderr beyond the progress lines on the first install and nothing at all on the second and on `--frozen-lockfile`; after, `warn: incorrect peer dependency "no-deps@2.0.0": "peer-deps-fixed@1.0.0" requires "no-deps@^1.0.0"` once on each of the three.

Unchanged for comparison, a fresh install of the root `^2.0.0` + `pkg1` package.json files prints the resolver's `warn: incorrect peer dependency "no-deps@2.0.0"` once and is quiet on the following install, before and after.
</details>
