### PR TITLE
inspect: print symbol keys after string keys on the fast property walk

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5527,7 +5527,7 @@ restart:
         // slots mark prototype properties that are fetched after the walk.
         MarkedArgumentBuffer snapshotValues;
 
-        structure->forEachProperty(vm, [&](const PropertyTableEntry& entry) -> bool {
+        auto snapshotProperty = [&](const PropertyTableEntry& entry) -> bool {
             if ((entry.attributes() & (PropertyAttribute::Function)) == 0 && (entry.attributes() & (PropertyAttribute::Builtin)) != 0) {
                 return true;
             }
@@ -5556,7 +5556,27 @@ restart:
             snapshot.append({ Identifier::fromUid(vm, prop), entry.attributes() });
             snapshotValues.appendWithCrashOnOverflow(propertyValue);
             return true;
+        };
+
+        // The property table is in insertion order with string and symbol keys
+        // interleaved. Emit string keys first and symbols after them, which is the
+        // OrdinaryOwnPropertyKeys order that getOwnPropertyNames (the slow path
+        // below) and node's util.inspect use.
+        bool hasSymbolKeys = false;
+        structure->forEachProperty(vm, [&](const PropertyTableEntry& entry) -> bool {
+            if (entry.key()->isSymbol()) {
+                hasSymbolKeys = true;
+                return true;
+            }
+            return snapshotProperty(entry);
         });
+        if (hasSymbolKeys) {
+            structure->forEachProperty(vm, [&](const PropertyTableEntry& entry) -> bool {
+                if (!entry.key()->isSymbol())
+                    return true;
+                return snapshotProperty(entry);
+            });
+        }
 
         for (size_t i = 0; i < snapshot.size(); i++) {
             const auto& snapshotted = snapshot[i];

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -687,6 +687,61 @@ it("Symbol", () => {
   expect(Bun.inspect(Symbol(""))).toBe("Symbol()");
 });
 
+// Symbol keys are printed after the string keys (OrdinaryOwnPropertyKeys order, what
+// node prints) regardless of insertion order. The formatter walks an object with no
+// accessors straight off its Structure, which stores keys in insertion order; an
+// object with a getter goes through getOwnPropertyNames instead. Each case is
+// formatted both ways and must print the same thing.
+describe("symbol keys print after string keys", () => {
+  const s = Symbol("s");
+  const t = Symbol("t");
+
+  it("object literal", () => {
+    expect(Bun.inspect({ [s]: 1, a: 2 })).toBe("{\n  a: 2,\n  [Symbol(s)]: 1,\n}");
+    expect(Bun.inspect({ [s]: 1, a: 2, get g() {} })).toBe("{\n  a: 2,\n  g: [Getter],\n  [Symbol(s)]: 1,\n}");
+  });
+
+  it.each([
+    ["symbol inserted first", () => ({ [s]: 1, a: 2, b: 3 }), "{ a: 2, b: 3, [Symbol(s)]: 1 }"],
+    ["symbol inserted in the middle", () => ({ a: 2, [s]: 1, b: 3 }), "{ a: 2, b: 3, [Symbol(s)]: 1 }"],
+    [
+      "symbols keep their insertion order among themselves",
+      () => ({ [t]: 1, a: 2, [s]: 3, b: 4 }),
+      "{ a: 2, b: 4, [Symbol(t)]: 1, [Symbol(s)]: 3 }",
+    ],
+    ["only symbol keys", () => ({ [t]: 1, [s]: 2 }), "{ [Symbol(t)]: 1, [Symbol(s)]: 2 }"],
+    [
+      "class fields",
+      () =>
+        new (class Foo {
+          [s] = 1;
+          a = 2;
+        })(),
+      "Foo { a: 2, [Symbol(s)]: 1 }",
+    ],
+    ["nested object", () => ({ [s]: { [t]: 1, x: 2 }, a: 3 }), "{ a: 3, [Symbol(s)]: { x: 2, [Symbol(t)]: 1 } }"],
+    [
+      "own properties first, then the prototype's, symbols last within each",
+      () => {
+        const obj = Object.create({ [t]: 1, p: 2 });
+        obj[s] = 3;
+        obj.a = 4;
+        return obj;
+      },
+      "{ a: 4, [Symbol(s)]: 3, p: 2, [Symbol(t)]: 1 }",
+    ],
+    ["no own properties, only the prototype's", () => Object.create({ [t]: 1, p: 2 }), "{ p: 2, [Symbol(t)]: 1 }"],
+  ])("%s", (_, init, expected) => {
+    expect(Bun.inspect(init(), { compact: true })).toBe(expected);
+
+    const withGetter = init();
+    Object.defineProperty(withGetter, "getter", { get: () => 0, enumerable: true });
+    const printed = Bun.inspect(withGetter, { compact: true });
+    expect(printed).toContain("getter: [Getter], ");
+    expect(printed.replace("getter: [Getter], ", "")).toBe(expected);
+  });
+});
+
 it("CloseEvent", () => {
   const closeEvent = new CloseEvent("close", {
     code: 1000,


### PR DESCRIPTION
### Problem
- `console.log` / `Bun.inspect` print symbol-keyed properties in a position that depends on which property walk the formatter happens to take:
  ```js
  const s = Symbol("s");
  console.log({ [s]: 1, a: 2 });                      // { [Symbol(s)]: 1, a: 2 }
  console.log({ [s]: 1, a: 2, get g() { return 1 } }); // { a: 2, g: [Getter], [Symbol(s)]: 1 }
  ```
- Node prints `{ a: 2, Symbol(s): 1 }` for both: string keys in insertion order, then symbols.
- Cause: `JSC__JSValue__forEachPropertyImpl` (`src/jsc/bindings/bindings.cpp`) has two walks. The fast walk iterates `structure->forEachProperty(...)`, which yields the property table in insertion order with symbols interleaved. The slow walk (taken when the object has an accessor, indexed properties, etc.) uses `getOwnPropertyNames`, which lists string keys first and symbols afterwards. The same inconsistency shows up on every level of the fast walk's prototype chain visit.

### Fix
- The fast walk now collects its snapshot in two passes over the property table: string keys, then (only if one was seen) symbol keys. The filter/snapshot logic is unchanged and shared by both passes; the emit loop is untouched.
- Correct because it is the order the spec defines for `OrdinaryOwnPropertyKeys`, the order the slow walk already produces, and the order node's `util.inspect` prints; JSC's own `Structure::getPropertyNamesFromStructure` uses the identical two-pass scheme to get there. Symbols keep their insertion order among themselves; the set of printed properties does not change.
- Cost: one `isSymbol()` flag check per property for objects without symbol keys; a second read-only table walk only when the object has one.
- Verified with `test/js/bun/util/inspect.test.js` ("symbol keys print after string keys"): each case is formatted through both walks (the second time with an added getter) and must match the expected string. Covers symbol first / in the middle / several symbols / only symbols, class fields, nested objects, and both prototype-walk shapes of the fast path (own + prototype properties, and an object with no own properties). 8 of the 9 cases fail on the current release; all pass with this change.
- Also ran `test/js/web/console`, `test/js/bun/console`, `test/js/node/util/bun-inspect.test.ts`, `test/js/node/util/custom-inspect.test.js`: no changes in behaviour. No existing expectation depended on the old interleaved order.

### Background
- `OrdinaryOwnPropertyKeys` is the spec order used by `Reflect.ownKeys`, `getOwnPropertyNames` + `getOwnPropertySymbols`, and node's `util.inspect`: integer-like keys ascending, then string keys in insertion order, then symbol keys in insertion order.
- A JSC `Structure` is the object's hidden class; its property table stores every named property (strings and symbols alike) in insertion order. `getOwnPropertyNames` reorders that table into spec order; walking the table directly does not.
- The fast walk in `forEachPropertyImpl` is only used when the structure has no accessors, no indexed properties and no custom property lookup, so integer-like keys never reach it (they live in indexed storage and force the slow walk); string-vs-symbol ordering was the only difference between the two walks.
- The only caller of this walk is the `console.log` / `Bun.inspect` formatter (`ConsoleObject.rs`). `Bun.inspect(..., { sorted: true })` and bun:test's diff/snapshot printer use `forEachPropertyOrdered`, which sorts by name and is unaffected. `node:util.inspect` is implemented in JS and was already correct.
