### PR TITLE
test(dns): serve resolve-dns.test.ts's c-ares cases from a local fake server and overlap its OS resolver lookups

### DIFF
--- a/test/js/bun/dns/resolve-dns.test.ts
+++ b/test/js/bun/dns/resolve-dns.test.ts
@@ -86,19 +86,28 @@ declare module "bun:test" {
   }
 }
 
+type Family = 4 | 6;
 // `address` and `ttl` are either literal values or asymmetric matchers such as expect.any(Number).
-type Answer = { address: any; family: 4 | 6; ttl: any };
-type Host = {
-  name: string;
-  /** The exact answers, or null when they come from a resolver this test does not control. */
-  answers: Answer[] | null;
-};
-type Wanted = 4 | 6 | "both";
+type Answer = { address: any; family: Family; ttl: any };
+type Host =
+  // The addresses come from a resolver this test does not control; only their shape is checked.
+  | { name: string; answers: null }
+  | {
+      name: string;
+      /** The exact answer a lookup restricted to that family returns. */
+      answers: Record<Family, Answer>;
+      /** The families a lookup that does not pick one must return; the other family may come along. */
+      unspecified: Family[];
+    };
+type Wanted = Family | "both";
 
 const LOOPBACK_V4: Answer = { address: "127.0.0.1", family: 4, ttl: expect.any(Number) };
 const LOOPBACK_V6: Answer = { address: "::1", family: 6, ttl: expect.any(Number) };
-const LOCALHOST: Host = { name: "localhost", answers: [LOOPBACK_V4, LOOPBACK_V6] };
-const FAKE_HOST: Host = { name: `host.${FAKE_ZONE}`, answers: [FAKE_V4, FAKE_V6] };
+// A lookup restricted to either family gets that loopback address everywhere, but whether an
+// unrestricted one also yields ::1 depends on the hosts file: Debian's maps ::1 to localhost, Ubuntu's
+// only to ip6-localhost, and the lookup stops at the hosts file's 127.0.0.1 there.
+const LOCALHOST: Host = { name: "localhost", answers: { 4: LOOPBACK_V4, 6: LOOPBACK_V6 }, unspecified: [4] };
+const FAKE_HOST: Host = { name: `host.${FAKE_ZONE}`, answers: { 4: FAKE_V4, 6: FAKE_V6 }, unspecified: [4, 6] };
 const EXAMPLE_COM: Host = { name: "example.com", answers: null };
 const hostsFor = (backend: Backend): Host[] => [LOCALHOST, backend === "c-ares" ? FAKE_HOST : EXAMPLE_COM];
 
@@ -123,7 +132,13 @@ function expectAnswers(result: DNSLookup[], host: Host, wanted: Wanted) {
     (a, b) => a.family - b.family || a.address.localeCompare(b.address),
   );
   if (host.answers !== null) {
-    expect(distinct).toEqual(wanted === "both" ? host.answers : host.answers.filter(a => a.family === wanted));
+    // The required families plus whichever optional one was returned, so a missing required answer
+    // and a wrong or unexpected address both show up in the diff.
+    const families: Family[] =
+      wanted === "both"
+        ? [...new Set([...host.unspecified, ...distinct.map(answer => answer.family)])].sort((a, b) => a - b)
+        : [wanted];
+    expect(distinct).toEqual(families.map(family => host.answers[family]));
     return;
   }
   expect(distinct).not.toBeEmpty();
@@ -159,8 +174,12 @@ const NOT_FOUND = {
 };
 
 // Well-formed, but under the TLD that RFC 6761 reserves for never existing, so a resolver can answer
-// it without asking anyone's authoritative servers.
-const nonexistentHostname = "does-not-exist.invalid";
+// it without asking anyone's authoritative servers. The c-ares backend gets its NXDOMAINs from the
+// fake server instantly, so it also exercises the search-list retries; the OS resolver gets the
+// absolute form (trailing dot), because on the debian CI machines every negative round trip takes
+// about 4s and the search-list retry would make this lookup the file's critical path.
+const nonexistentHostname = (backend: Backend) =>
+  backend === "c-ares" ? "does-not-exist.invalid" : "does-not-exist.invalid.";
 const malformedHostnames = [" ", ".", " .", "localhost:80", "this is not a hostname"];
 
 // getaddrinfo reports malformed names with whatever EAI code the platform picks, and bun maps the
@@ -192,8 +211,8 @@ describe("dns", () => {
       });
     });
 
-    test(`${nonexistentHostname} rejects with ENOTFOUND`, async () => {
-      expect(await rejectionOf(dns.lookup(nonexistentHostname, { backend }))).toMatchObject(NOT_FOUND);
+    test(`${nonexistentHostname(backend)} rejects with ENOTFOUND`, async () => {
+      expect(await rejectionOf(dns.lookup(nonexistentHostname(backend), { backend }))).toMatchObject(NOT_FOUND);
     });
 
     test.each(malformedHostnames)("%j rejects", async hostname => {

--- a/test/js/bun/dns/resolve-dns.test.ts
+++ b/test/js/bun/dns/resolve-dns.test.ts
@@ -1,142 +1,229 @@
-import { SystemError, dns } from "bun";
-import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isWindows, withoutAggressiveGC } from "harness";
-import { isIP, isIPv4, isIPv6 } from "node:net";
+import { dns, type DNSLookup, type udp } from "bun";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isASAN, isWindows } from "harness";
+import { isIP } from "node:net";
 import { join } from "node:path";
 
-const backends = ["system", "libc", "c-ares"];
-const validHostnames = ["localhost", "example.com"];
-const invalidHostnames = ["adsfa.asdfasdf.asdf.com"]; // known invalid
+type Backend = "system" | "libc" | "c-ares";
+const backends: Backend[] = ["system", "libc", "c-ares"];
+
+// `Bun.dns.setServers()` configures the c-ares channel that the c-ares backend (and resolve(),
+// lookupService(), ...) query, so beforeAll() below points it at this in-process server and the
+// c-ares cases never touch a real resolver. Every name under FAKE_ZONE gets exactly FAKE_V4 and
+// FAKE_V6 (documentation addresses, RFC 5737 / RFC 3849); every other name gets NXDOMAIN.
+//
+// The system and libc backends are the OS resolver (getaddrinfo / mDNSResponder / libuv), which
+// cannot be redirected. They keep resolving localhost (hosts file) and example.com: a real name is
+// the only way to run them against DNS records at all, and the Windows IPv6 behavior asserted
+// below only exists for names that are not in the hosts file.
+const FAKE_ZONE = "resolve-dns.test";
+const FAKE_V4 = { address: "192.0.2.1", family: 4, ttl: 300 } as const;
+const FAKE_V6 = { address: "2001:db8::1", family: 6, ttl: 600 } as const;
+const FAKE_RDATA = {
+  1: { ttl: FAKE_V4.ttl, rdata: Buffer.from([192, 0, 2, 1]) }, // A
+  28: { ttl: FAKE_V6.ttl, rdata: Buffer.from("20010db8000000000000000000000001", "hex") }, // AAAA
+} as Record<number, { ttl: number; rdata: Buffer } | undefined>;
+
+function fakeDnsReply(query: Buffer): Buffer {
+  const labels: string[] = [];
+  let i = 12; // the question section follows the 12 byte header
+  while (query[i] !== 0) {
+    labels.push(query.toString("latin1", i + 1, i + 1 + query[i]));
+    i += query[i] + 1;
+  }
+  const question = query.subarray(12, i + 5); // labels, root label, QTYPE, QCLASS
+  const qtype = query.readUInt16BE(i + 1);
+  const served = labels.join(".").toLowerCase().endsWith(FAKE_ZONE);
+  const record = served ? FAKE_RDATA[qtype] : undefined;
+  const rcode = served ? 0 : 3; // NOERROR (NODATA when the type is not A/AAAA) : NXDOMAIN
+  const header = Buffer.from([query[0], query[1], 0x81, 0x80 | rcode, 0, 1, 0, record ? 1 : 0, 0, 0, 0, 0]);
+  if (!record) return Buffer.concat([header, question]);
+  const rr = Buffer.alloc(10);
+  rr.writeUInt16BE(0xc00c, 0); // name: pointer to the question's name
+  rr.writeUInt16BE(qtype, 2);
+  rr.writeUInt16BE(1, 4); // class IN
+  rr.writeUInt32BE(record.ttl, 6);
+  const rdlength = Buffer.alloc(2);
+  rdlength.writeUInt16BE(record.rdata.length);
+  return Buffer.concat([header, question, rr, rdlength, record.rdata]);
+}
+
+let fakeDns: udp.Socket<"buffer">;
+
+beforeAll(async () => {
+  fakeDns = await Bun.udpSocket({
+    hostname: "127.0.0.1",
+    port: 0,
+    socket: {
+      data(socket, query, port, address) {
+        socket.send(fakeDnsReply(query), port, address);
+      },
+    },
+  });
+  // @ts-expect-error setServers() is not declared in bun-types
+  dns.setServers([[4, "127.0.0.1", fakeDns.port]]);
+});
+
+afterAll(() => {
+  fakeDns.close();
+});
+
+expect.extend({
+  toBeIPOfFamily(received: unknown, family: number) {
+    const pass = (family === 4 || family === 6) && typeof received === "string" && isIP(received) === family;
+    return {
+      pass,
+      message: () => `expected ${Bun.inspect(received)} ${pass ? "not " : ""}to be an IPv${family} address`,
+    };
+  },
+});
+declare module "bun:test" {
+  interface AsymmetricMatchers {
+    toBeIPOfFamily(family: number): void;
+  }
+  interface Matchers<T> {
+    toBeIPOfFamily(family: number): void;
+  }
+}
+
+// `address` and `ttl` are either literal values or asymmetric matchers such as expect.any(Number).
+type Answer = { address: any; family: 4 | 6; ttl: any };
+type Host = {
+  name: string;
+  /** The exact answers, or null when they come from a resolver this test does not control. */
+  answers: Answer[] | null;
+};
+type Wanted = 4 | 6 | "both";
+
+const LOOPBACK_V4: Answer = { address: "127.0.0.1", family: 4, ttl: expect.any(Number) };
+const LOOPBACK_V6: Answer = { address: "::1", family: 6, ttl: expect.any(Number) };
+const LOCALHOST: Host = { name: "localhost", answers: [LOOPBACK_V4, LOOPBACK_V6] };
+const FAKE_HOST: Host = { name: `host.${FAKE_ZONE}`, answers: [FAKE_V4, FAKE_V6] };
+const EXAMPLE_COM: Host = { name: "example.com", answers: null };
+const hostsFor = (backend: Backend): Host[] => [LOCALHOST, backend === "c-ares" ? FAKE_HOST : EXAMPLE_COM];
+
+type LookupOptions = NonNullable<Parameters<typeof dns.lookup>[1]>;
+
+// [options, the family (or families) those options must produce]
+const familyOptions: [LookupOptions, Wanted][] = [
+  [{}, "both"],
+  [{ family: 4 }, 4],
+  [{ family: "IPv4" }, 4],
+  [{ family: 6 }, 6],
+  [{ family: "IPv6" }, 6],
+  [{ family: 0 }, "both"],
+  [{ family: "any" }, "both"],
+];
+
+function expectAnswers(result: DNSLookup[], host: Host, wanted: Wanted) {
+  // Resolvers return the families in whichever order they like (c-ares sorts by reachability), and
+  // glibc's getaddrinfo() answers an IPv4-only lookup of localhost with 127.0.0.1 twice (the
+  // "::1 localhost" hosts line is mapped to it too), so compare the distinct answers in a fixed order.
+  const distinct = [...new Map(result.map(answer => [`${answer.family} ${answer.address}`, answer])).values()].sort(
+    (a, b) => a.family - b.family || a.address.localeCompare(b.address),
+  );
+  if (host.answers !== null) {
+    expect(distinct).toEqual(wanted === "both" ? host.answers : host.answers.filter(a => a.family === wanted));
+    return;
+  }
+  expect(distinct).not.toBeEmpty();
+  expect(distinct).toEqual(
+    distinct.map((answer): Answer => {
+      const family = wanted === "both" ? answer.family : wanted;
+      return { address: expect.toBeIPOfFamily(family), family, ttl: expect.any(Number) };
+    }),
+  );
+}
+
+/**
+ * Resolves to the rejection reason of `promise`; fails the test if it fulfills.
+ *
+ * Not `expect(promise).rejects`: that matcher blocks in a nested event loop until the promise
+ * settles, which keeps the concurrent tests below from overlapping. The slow cases in this file are
+ * the negative lookups the OS resolver takes seconds to answer, so overlapping them is the point.
+ */
+function rejectionOf(promise: Promise<unknown>): Promise<unknown> {
+  return promise.then(
+    value => {
+      throw new Error(`expected a rejection, resolved with ${Bun.inspect(value)}`);
+    },
+    reason => reason,
+  );
+}
+
+const NOT_FOUND = {
+  name: "DNSException",
+  code: "DNS_ENOTFOUND",
+  syscall: "getaddrinfo",
+  message: "getaddrinfo ENOTFOUND",
+};
+
+// Well-formed, but under the TLD that RFC 6761 reserves for never existing, so a resolver can answer
+// it without asking anyone's authoritative servers.
+const nonexistentHostname = "does-not-exist.invalid";
 const malformedHostnames = [" ", ".", " .", "localhost:80", "this is not a hostname"];
 
+// getaddrinfo reports malformed names with whatever EAI code the platform picks, and bun maps the
+// ones it does not know onto DNS_ENOTIMP. The c-ares backend rejects the malformed names itself
+// (ARES_EBADNAME) and gets NXDOMAIN for "." from the fake server, so it is always ENOTFOUND.
+const malformedCodes = (backend: Backend) =>
+  backend === "c-ares" ? /^DNS_ENOTFOUND$/ : /^DNS_(ENOTFOUND|ESERVFAIL|ENOTIMP)$/;
+
 describe("dns", () => {
-  describe.each(backends)("lookup() [backend: %s]", backend => {
-    describe.each(validHostnames)("%s", hostname => {
-      test.each([
-        {
-          options: { backend },
-          address: isIP,
-        },
-        {
-          options: { backend, family: 4 },
-          address: isIPv4,
-          family: 4,
-        },
-        {
-          options: { backend, family: "IPv4" },
-          address: isIPv4,
-          family: 4,
-        },
-        {
-          options: { backend, family: 6 },
-          address: isIPv6,
-          family: 6,
-        },
-        {
-          options: { backend, family: "IPv6" },
-          address: isIPv6,
-          family: 6,
-        },
-        {
-          options: { backend, family: 0 },
-          address: isIP,
-        },
-        {
-          options: { backend, family: "any" },
-          address: isIP,
-        },
-      ])("%j", async ({ options, address: expectedAddress, family: expectedFamily }) => {
-        // this behavior matchs nodejs
-        const expect_to_fail =
-          isWindows &&
-          backend !== "c-ares" &&
-          (options.family === "IPv6" || options.family === 6) &&
-          hostname !== "localhost";
-        if (expect_to_fail) {
-          try {
-            // @ts-expect-error
-            await dns.lookup(hostname, options);
-            expect.unreachable();
-          } catch (err: unknown) {
-            expect(err).toBeDefined();
-            expect((err as SystemError).code).toBe("DNS_ENOTFOUND");
-          }
+  // Every lookup here is independent of the others, and only the slow ones (the OS resolver's
+  // negative answers) decide how long the file takes, so the whole matrix runs concurrently.
+  describe.concurrent.each(backends)("lookup() [backend: %s]", backend => {
+    describe.each(hostsFor(backend))("$name", host => {
+      test.each(familyOptions)("%j", async (options, wanted) => {
+        const lookup = dns.lookup(host.name, { ...options, backend });
+        // Matches node: on Windows, getaddrinfo() does not return AAAA records for names that are not
+        // in the hosts file unless the machine has IPv6 connectivity, which the CI machines do not.
+        if (isWindows && backend !== "c-ares" && wanted === 6 && host.answers === null) {
+          expect(await rejectionOf(lookup)).toMatchObject(NOT_FOUND);
           return;
         }
-        // @ts-expect-error
-        const result = await dns.lookup(hostname, options);
-        expect(result).toBeArray();
-        expect(result.length).toBeGreaterThan(0);
-        withoutAggressiveGC(() => {
-          for (const { family, address, ttl } of result) {
-            expect(address).toBeString();
-            expect(expectedAddress(address)).toBeTruthy();
-            expect(family).toBeInteger();
-            if (expectedFamily !== undefined) {
-              expect(family).toBe(expectedFamily);
-            }
-            expect(ttl).toBeInteger();
-          }
-        });
+        expectAnswers(await lookup, host, wanted);
       });
-    });
-    test.each(validHostnames)("%s [parallel x 10]", async hostname => {
-      const results = await Promise.all(
-        // @ts-expect-error
-        Array.from({ length: 10 }, () => dns.lookup(hostname, { backend })),
-      );
-      const answers = results.flat();
-      expect(answers).toBeArray();
-      expect(answers.length).toBeGreaterThanOrEqual(10);
-      withoutAggressiveGC(() => {
-        for (const { family, address, ttl } of answers) {
-          expect(address).toBeString();
-          expect(isIP(address)).toBeTruthy();
-          expect(family).toBeInteger();
-          expect(ttl).toBeInteger();
-        }
-      });
-    });
-    // These negative lookups are independent (distinct hostname+backend, no shared
-    // state); run them concurrently so the system resolver's ~4s negative-lookup
-    // timeouts overlap instead of stacking.
-    test.concurrent.each(invalidHostnames)("%s", async hostname => {
-      // @ts-expect-error
-      await expect(dns.lookup(hostname, { backend })).rejects.toMatchObject({
-        code: "DNS_ENOTFOUND",
-        name: "DNSException",
+
+      test("10 lookups at once", async () => {
+        const results = await Promise.all(Array.from({ length: 10 }, () => dns.lookup(host.name, { backend })));
+        expect(results).toHaveLength(10);
+        for (const result of results) expectAnswers(result, host, "both");
       });
     });
 
-    test.concurrent.each(malformedHostnames)("'%s'", async hostname => {
-      // @ts-expect-error
-      await expect(dns.lookup(hostname, { backend })).rejects.toMatchObject({
-        code: expect.stringMatching(/^DNS_ENOTFOUND|DNS_ESERVFAIL|DNS_ENOTIMP$/),
+    test(`${nonexistentHostname} rejects with ENOTFOUND`, async () => {
+      expect(await rejectionOf(dns.lookup(nonexistentHostname, { backend }))).toMatchObject(NOT_FOUND);
+    });
+
+    test.each(malformedHostnames)("%j rejects", async hostname => {
+      const error = (await rejectionOf(dns.lookup(hostname, { backend }))) as { code: string };
+      expect(error).toMatchObject({
         name: "DNSException",
+        code: expect.stringMatching(malformedCodes(backend)),
+        syscall: "getaddrinfo",
+        message: `getaddrinfo ${error.code.slice("DNS_".length)}`,
+      });
+    });
+
+    // Hostnames longer than the fixed stack buffer used by the libc/system backends (bun.PathBuffer,
+    // which is MAX_PATH_BYTES: 1024 on macOS, 4096 on Linux, ~98302 on Windows) previously overflowed
+    // when writing the NUL terminator. They must reject cleanly on every backend. 100 000 bytes
+    // exceeds the buffer on every platform so the doLookup guard is what fires.
+    test("oversized hostname rejects", async () => {
+      const long = Buffer.alloc(100_000, "a").toString();
+      expect(await rejectionOf(dns.lookup(long, { backend }))).toMatchObject({
+        ...NOT_FOUND,
+        message: `getaddrinfo ENOTFOUND ${long}`,
+        hostname: long,
       });
     });
   });
 
-  // Hostnames longer than the fixed stack buffer used by the libc/system
-  // backends (bun.PathBuffer, which is MAX_PATH_BYTES: 1024 on macOS, 4096 on
-  // Linux, ~98302 on Windows) previously overflowed when writing the NUL
-  // terminator. They must reject cleanly on every backend. 100 000 bytes
-  // exceeds the buffer on every platform so the doLookup guard is what fires.
-  test.each(backends)("lookup() with oversized hostname rejects [backend: %s]", async backend => {
-    const long = Buffer.alloc(100_000, "a").toString();
-    // @ts-expect-error
-    await expect(dns.lookup(long, { backend })).rejects.toMatchObject({
-      name: "DNSException",
-      code: "DNS_ENOTFOUND",
-      syscall: "getaddrinfo",
-    });
-  });
-
-  test("lookup() with oversized .local hostname rejects via system backend in subprocess", async () => {
-    // A `.local` suffix forces the c-ares backend to fall through to the
-    // system resolver, which is the path that wrote past its stack buffer.
-    // Run in a subprocess so the panic that the unfixed debug build raises on
-    // the worker thread shows up as a non-zero exit instead of aborting the
+  test.concurrent("lookup() with oversized .local hostname rejects via system backend in subprocess", async () => {
+    // A `.local` suffix forces the c-ares backend to fall through to the system resolver, which is
+    // the path that wrote past its stack buffer. Run in a subprocess so the panic that the unfixed
+    // debug build raises on the worker thread shows up as a non-zero exit instead of aborting the
     // whole test file.
     await using proc = Bun.spawn({
       cmd: [
@@ -149,13 +236,7 @@ describe("dns", () => {
             Bun.dns.lookup(long, { backend: "libc" }),
             Bun.dns.lookup(long),
           ]);
-          for (const result of settled) {
-            if (result.status !== "rejected") throw new Error("expected rejection");
-            if (result.reason?.code !== "DNS_ENOTFOUND") {
-              throw new Error("expected DNS_ENOTFOUND, got " + result.reason?.code);
-            }
-          }
-          console.log("ok");
+          console.log(JSON.stringify(settled.map(result => result.status === "rejected" ? result.reason.code : result.value)));
         `,
       ],
       env: bunEnv,
@@ -163,9 +244,11 @@ describe("dns", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(stdout.trim()).toBe("ok");
-    expect(exitCode).toBe(0);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: JSON.stringify(["DNS_ENOTFOUND", "DNS_ENOTFOUND", "DNS_ENOTFOUND"]) + "\n",
+      stderr: "",
+      exitCode: 0,
+    });
   });
 
   // The pending-host-cache slot holds a Box<[u8]> clone of the hostname so
@@ -174,7 +257,7 @@ describe("dns", () => {
   // a libc getaddrinfo is still on the work pool, the Resolver is dropped
   // with that slot still occupied. HiveArray used to skip Drop on its slots,
   // so the hostname Box leaked. Only observable via LSan, so ASAN-only.
-  test.skipIf(!isASAN || isWindows)(
+  test.concurrent.skipIf(!isASAN || isWindows)(
     "pending-cache hostname is freed when VM tears down mid-lookup",
     async () => {
       await using proc = Bun.spawn({
@@ -214,48 +297,19 @@ describe("dns", () => {
     30_000,
   );
 
-  test("lookup with non-object second argument should not crash", async () => {
-    // Non-object cell values (like strings) passed as options should be ignored, not crash.
-    // @ts-expect-error
-    const result = await dns.lookup("localhost", "cat");
-    expect(result).toBeArray();
-    expect(result.length).toBeGreaterThan(0);
-    expect(isIP(result[0].address)).toBeGreaterThan(0);
+  test.concurrent("lookup() ignores a non-object options argument", async () => {
+    // @ts-expect-error a string is not a valid options argument; it used to crash instead of being ignored
+    expectAnswers(await dns.lookup("localhost", "cat"), LOCALHOST, "both");
   });
 
-  test("lookup with null flags treats them as unset", async () => {
+  test.concurrent("lookup() with null flags treats them as unset", async () => {
     // `family: null` already meant unset; `flags: null` must too (node:dns
     // forwards a null `hints` here). https://github.com/oven-sh/bun/issues/37318
-    // @ts-expect-error
-    const result = await dns.lookup("localhost", { flags: null });
-    expect(result).toBeArray();
-    expect(result.length).toBeGreaterThan(0);
-    expect(isIP(result[0].address)).toBeGreaterThan(0);
+    // @ts-expect-error null is not in the declared type of flags
+    expectAnswers(await dns.lookup("localhost", { flags: null }), LOCALHOST, "both");
   });
 
-  describe("setServers", () => {
-    test("triple with non-int32 family (double) throws TypeError", () => {
-      // @ts-expect-error
-      expect(() => dns.setServers([[-9007199254740991, "8.8.8.8", 53]])).toThrow(TypeError);
-    });
-
-    test("triple with missing port (undefined) should not crash", () => {
-      // undefined port coerces to 0, which is a valid int32
-      // @ts-expect-error
-      expect(() => dns.setServers([[4, "8.8.8.8"]])).not.toThrow();
-    });
-
-    test("triple with missing family (undefined) throws TypeError", () => {
-      // @ts-expect-error
-      expect(() => dns.setServers([["8.8.8.8"]])).toThrow(TypeError);
-    });
-
-    test("valid triple should succeed", () => {
-      expect(() => dns.setServers([[4, "8.8.8.8", 53]])).not.toThrow();
-    });
-  });
-
-  describe("UTF-16 string arguments", () => {
+  describe.concurrent("UTF-16 string arguments", () => {
     // Builds a JSString backed by a 16-bit (UTF-16) buffer even though the
     // contents are plain ASCII. Passing such strings used to hit a debug
     // assertion (ZigString::slice() on UTF-16 string) instead of being
@@ -264,31 +318,60 @@ describe("dns", () => {
       new TextDecoder("utf-16le").decode(new Uint8Array([...s].flatMap(c => [c.charCodeAt(0), 0])));
 
     test("lookupService() with a UTF-16 invalid address throws TypeError", () => {
-      // @ts-expect-error
-      expect(() => Bun.dns.lookupService(utf16("1,2,3"), 443)).toThrow(
+      // @ts-expect-error lookupService() is not declared in bun-types
+      expect(() => dns.lookupService(utf16("1,2,3"), 443)).toThrow(
         `The "address" argument is invalid. Received type string ('1,2,3')`,
       );
     });
 
-    test("lookupService() with a UTF-16 valid address does not crash", async () => {
-      // The reverse lookup result is environment-dependent; the assertion is
-      // that the address parses (no synchronous throw) and nothing panics.
-      // @ts-expect-error
-      await Bun.dns.lookupService(utf16("127.0.0.1"), 443).catch(() => {});
+    test("lookupService() with a UTF-16 valid address performs the reverse lookup", async () => {
+      // 192.0.2.1 is in no hosts file, so the PTR query reaches the fake server, which has no answer.
+      // @ts-expect-error lookupService() is not declared in bun-types
+      expect(await rejectionOf(dns.lookupService(utf16("192.0.2.1"), 443))).toMatchObject({
+        name: "DNSException",
+        code: "DNS_ENOTFOUND",
+        syscall: "getnameinfo",
+        message: "getnameinfo ENOTFOUND 192.0.2.1|443",
+      });
     });
 
-    test("resolve() with a UTF-16 record type does not crash", async () => {
-      // A valid record type must be accepted (no synchronous throw); the
-      // query result itself is environment-dependent.
-      // @ts-expect-error
-      await Bun.dns.resolve(utf16("localhost"), utf16("AAAA")).catch(() => {});
+    test("resolve() with a UTF-16 hostname and record type queries that record", async () => {
+      // @ts-expect-error resolve() is not declared in bun-types
+      expect(await dns.resolve(utf16(`utf16.${FAKE_ZONE}`), utf16("AAAA"))).toEqual([
+        { address: FAKE_V6.address, ttl: FAKE_V6.ttl },
+      ]);
     });
 
     test("resolve() with a UTF-16 invalid record type throws TypeError", () => {
-      // @ts-expect-error
-      expect(() => Bun.dns.resolve("localhost", utf16("BOGUS"))).toThrow(
+      // @ts-expect-error resolve() is not declared in bun-types
+      expect(() => dns.resolve("localhost", utf16("BOGUS"))).toThrow(
         `The property "record" is invalid. Expected one of: A, AAAA, ANY, CAA, CNAME, MX, NS, PTR, SOA, SRV, TXT, received type string ('BOGUS')`,
       );
+    });
+  });
+
+  // These reconfigure the shared c-ares channel away from the fake server, so they stay sequential
+  // (which also makes them wait for every concurrent test above) and last.
+  describe("setServers", () => {
+    test("triple with non-int32 family (double) throws TypeError", () => {
+      // @ts-expect-error setServers() is not declared in bun-types
+      expect(() => dns.setServers([[-9007199254740991, "8.8.8.8", 53]])).toThrow(TypeError);
+    });
+
+    test("triple with missing port (undefined) should not crash", () => {
+      // undefined port coerces to 0, which is a valid int32
+      // @ts-expect-error setServers() is not declared in bun-types
+      expect(() => dns.setServers([[4, "8.8.8.8"]])).not.toThrow();
+    });
+
+    test("triple with missing family (undefined) throws TypeError", () => {
+      // @ts-expect-error setServers() is not declared in bun-types
+      expect(() => dns.setServers([["8.8.8.8"]])).toThrow(TypeError);
+    });
+
+    test("valid triple should succeed", () => {
+      // @ts-expect-error setServers() is not declared in bun-types
+      expect(() => dns.setServers([[4, "8.8.8.8", 53]])).not.toThrow();
     });
   });
 });


### PR DESCRIPTION
### Problem
- `test/js/bun/dns/resolve-dns.test.ts` takes 31-32s on the debian 13 lanes (x64, x64-asan, aarch64 in build 97275), against 88ms on ubuntu, 179ms on alpine and 2.1s on windows. ASAN and release taking the same time means the file is waiting on the network.
- On the debian lanes the OS resolver takes about 4s to answer several of the negative names, and the file paid those waits one after another: the three backend blocks are sequential, and the negative lookups marked `test.concurrent` never actually overlapped, because `await expect(p).rejects.toMatchObject()` waits for `p` inside the matcher (`Expect::process_promise`, `src/runtime/test_runner/expect.rs:477`, calls `wait_for_promise`), so the next concurrent test is not started until the current one finishes. The dots in the CI log confirm it: the six negative tests of each glibc backend complete in a strict ~4s staircase. That runner limitation is reported separately; this PR only stops the file from depending on it.
- The c-ares cases resolved `example.com` and a made-up `asdf.com` subdomain through whatever resolver the machine has, which `test/CLAUDE.md` asks tests not to do, and which is also why those cases fail in environments without outbound DNS.
- Most assertions were per-field `toBe` calls in loops, and several only checked that nothing crashed.

### Fix
- `beforeAll` starts a `Bun.udpSocket` on port 0 that answers any name under `resolve-dns.test` with one fixed A and one fixed AAAA record (documentation addresses, TTLs 300 and 600) and NXDOMAIN for everything else, and points the c-ares channel at it with `Bun.dns.setServers()`. The c-ares backend, `resolve()` and `lookupService()` all query that channel, so none of those cases touch a real resolver any more, and their answers are exact. If the redirect ever stopped working, the fake zone would get NXDOMAIN from the real resolver and the cases would fail rather than silently pass against the internet.
- The system and libc backends cannot be redirected (they are getaddrinfo / mDNSResponder / libuv), so they still resolve `localhost` and `example.com`: a real name is the only way to run them against DNS records at all, and the Windows IPv6 assertion only exists for names outside the hosts file. The nonexistent name moves from `adsfa.asdfasdf.asdf.com` to `does-not-exist.invalid` (RFC 6761), so a resolver can answer it without consulting anyone's authoritative servers; the system/libc backends get the absolute form (`does-not-exist.invalid.`), because glibc retries a relative name with the search domain appended and on the debian machines each of those round trips costs ~4s, while the c-ares backend keeps the relative form (its NXDOMAINs come from the fake server) and so still covers the search-list retries.
- The whole lookup matrix runs under `describe.concurrent`, the subprocess tests are `test.concurrent`, and rejections are settled first (`rejectionOf()`) and asserted on afterwards, so the OS resolver's slow negative answers overlap with each other and with everything else. The `setServers` tests, which reconfigure the shared channel, stay sequential and run last. The file's wall time is now bounded by the single slowest OS lookup instead of the sum over backends.
- Assertions: each lookup is one `toEqual` against the whole answer list, sorted and deduplicated (exact addresses and TTLs for the fake zone; for localhost exactly the requested loopback address when a family is given, and otherwise `127.0.0.1` plus `::1` only if the machine returns it, since Ubuntu's hosts file maps `::1` to `ip6-localhost` only and an unrestricted lookup stops at the hosts file there; for `example.com` one entry shape per answer with a small asymmetric `toBeIPOfFamily` matcher, since those addresses are whatever the resolver returns). Deduplication is needed because glibc answers an IPv4-only lookup of `localhost` with `127.0.0.1` twice when the hosts file also has a `::1 localhost` line. Rejections are asserted as `name` + `code` + `syscall` + `message` together (plus `hostname` on the oversized-name path); the c-ares malformed-name cases now require exactly `DNS_ENOTFOUND`, while the system/libc set is unchanged so #37668 still applies on top of this (it becomes a one-line change to `malformedCodes`). The subprocess test prints the three codes and the parent compares `{ stdout, stderr, exitCode }` in one `toEqual`. The two UTF-16 "does not crash" tests now assert the reverse lookup reaches the fake server (`getnameinfo ENOTFOUND 192.0.2.1|443`) and that `resolve()` returns the fake AAAA record.
- No test was removed: the file still has 81 tests covering the same backends, names, family spellings, the parallel coalescing case, the oversized names, the ASAN-only leak test, the options edge cases and `setServers`.
- Timing. This container has no outbound DNS (its resolver answers SERVFAIL instantly, so negative-lookup latency here is ~0 and the 20 system/libc cases that need `example.com` or a real negative answer fail here identically before and after). To measure, I pointed `/etc/resolv.conf` at a local stand-in resolver that answers everything instantly, optionally delaying negative answers by 1s to mimic the debian lanes; all 81 tests pass in that setup before and after. The build host is heavily loaded, so the debug numbers vary a lot between runs (the unmodified file measured anywhere from 5.6s to 21.5s with the instant resolver); the release pairs below were run alternating before/after three times each and were stable to within 0.1s.
  - release, 1s negative delay: 9.3s before, 2.2-2.4s after as first pushed (the relative name's two glibc round trips); with the absolute name the stand-in resolver sees exactly one round trip per backend for it.
  - release, instant resolver: both versions spend about 25ms inside the file (timestamps at module start and in `afterAll`); the 0.2-0.4s totals are process startup and the harness import.
  - `bun bd test` (debug + ASAN), 1s negative delay: 14.7s before, 6.4s after; instant resolver: 5.6s before, 5.5-7.4s after, dominated by the ~3.3s harness import and the ~2s ASAN-only leak-test child.
  - Windows Server 2019 VM with real DNS, canary bun: 2.44s before, 0.90s after (its OS resolver takes ~850ms to answer `.`, which now overlaps with everything else).
  - CI: debian 13 x64 7.3s, x64-asan 7.9s, aarch64 7.4s (from 31-32s; build 98137), ubuntu 130-140ms, alpine 129ms, windows 2019 0.97s (from 2.1s). The first revision (build 98112) had the same debian numbers and failed only the two ubuntu lanes, whose `localhost` failures the second commit fixes (verified locally with an ubuntu-style hosts file and on the Windows VM).
  - What is left on debian is the OS resolver itself: the dots in its logs now show one wave of completions at ~3.7s and a small last one at ~7.5s, so a couple of the negative names take two ~4s round trips inside a single getaddrinfo() call there, and the instant lookups queue behind them on the work pool. The absolute nonexistent name did not change that (it does remove the search-domain round trip, verified against the stand-in resolver), and cutting it further would mean dropping negative names or a backend, which this PR does not do.
- Also verified: `cd test && tsc --noEmit` reports nothing for this file; prettier clean.

### Background
- `Bun.dns.lookup()` has three backends. `c-ares` is bun's bundled resolver library: it reads the server list itself and sends DNS packets, and `Bun.dns.setServers()` replaces that list for the process-wide channel, which is also what `Bun.dns.resolve()` and `lookupService()` use. `libc` is a blocking `getaddrinfo()` on the work pool; `system` is the same thing on Linux, mDNSResponder on macOS and libuv's getaddrinfo on Windows. Those read the OS configuration and cannot be pointed anywhere else by a test.
- bun routes `localhost` to the system backend even when c-ares is requested (`normalize_dns_name` in `src/runtime/dns_jsc/dns.rs`), which is why the localhost cases are asserted as loopback addresses on every backend, and why the fake server needs a name of its own.
- c-ares validates names before sending anything, so `" "`, `"localhost:80"` and similar are rejected locally (`ARES_EBADNAME`, surfaced as `DNS_ENOTFOUND`); `"."` is the only malformed name it actually queries, and the fake server answers it NXDOMAIN. getaddrinfo reports the same names with platform-specific `EAI_*` codes, which bun maps to `DNS_ENOTFOUND` / `DNS_ESERVFAIL` / `DNS_ENOTIMP`, hence the wider accepted set on those backends.
- Concurrent lookups for the same name and options are coalesced through the resolver's pending cache and all receive the same answer, which is what the "10 lookups at once" case exercises.
- A fake DNS reply is the query's id and question section copied back, followed by a resource record whose name is a compression pointer (`0xc00c`) to the question; that is all `fakeDnsReply()` builds.
