### PR TITLE
Bun.plugin: honor the json, toml, yaml and xml loaders for onLoad and build.module() results

### DIFF
--- a/docs/bundler/plugins.mdx
+++ b/docs/bundler/plugins.mdx
@@ -293,7 +293,7 @@ plugin({
 
       // Emit JSON containing the stats of each import
       return {
-        contents: `export default ${JSON.stringify(trackedImports)}`,
+        contents: JSON.stringify(trackedImports),
         loader: "json",
       };
     });

--- a/docs/runtime/plugins.mdx
+++ b/docs/runtime/plugins.mdx
@@ -286,7 +286,7 @@ plugin({
 
       // Emit JSON containing the stats of each import
       return {
-        contents: `export default ${JSON.stringify(trackedImports)}`,
+        contents: JSON.stringify(trackedImports),
         loader: "json",
       };
     });

--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -144,6 +144,70 @@ static JSC::SyntheticSourceProvider::LazySyntheticSourceGenerator generateIntern
     };
 }
 
+// Loaders whose transpile result is a value rather than JavaScript source text
+// (see transpile_source_code_inner in src/runtime/jsc_hooks.rs): the json loader
+// hands back the raw JSON bytes (JSONForObjectLoader); jsonc/toml/yaml/json5/xml
+// hand back the parsed value (ExportsObject); css/html/file hand back the value
+// to expose as the sole default export (ExportDefaultObject).
+static bool isExportValueSource(const ResolvedSource& source)
+{
+    switch (source.tag) {
+    case SyntheticModuleType::JSONForObjectLoader:
+    case SyntheticModuleType::ExportsObject:
+    case SyntheticModuleType::ExportDefaultObject:
+        return true;
+    default:
+        return false;
+    }
+}
+
+// The JSONForObjectLoader tag is source code returned from Bun that needs
+// to go through the JSON parser in JSC.
+//
+// We don't use JSON.parse directly in JS because we want the top-level keys of the JSON
+// object to be accessible as named imports.
+//
+// We don't use Bun's JSON parser because JSON.parse is faster and
+// handles stack overflow better.
+//
+// When parsing tsconfig.*.json or jsconfig.*.json, we go through Bun's JSON
+// parser instead to support comments and trailing commas.
+//
+// Throws and returns an empty JSValue on failure.
+static JSC::JSValue exportValueFromSource(Zig::GlobalObject* globalObject, const ResolvedSource& source)
+{
+    ASSERT(isExportValueSource(source));
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (source.tag == SyntheticModuleType::JSONForObjectLoader) {
+        WTF::String jsonSource = source.source_code.toWTFString(BunString::NonNull);
+        RELEASE_AND_RETURN(scope, JSC::JSONParseWithException(globalObject, jsonSource));
+    }
+
+    JSC::JSValue value = JSC::JSValue::decode(source.jsvalue_for_export);
+    if (!value) {
+        throwException(globalObject, scope, JSC::createSyntaxError(globalObject, "Failed to parse Object"_s));
+        return {};
+    }
+    return value;
+}
+
+// ESM view of an export value. The value is the default export; for
+// JSONForObjectLoader / ExportsObject an object's top-level keys are named
+// exports as well (a non-object value such as `123` only gets the default export).
+static JSC::JSSourceCode* createExportValueModuleSourceCode(Zig::GlobalObject* globalObject, const ResolvedSource& source, JSC::JSValue value, BunString* specifier)
+{
+    auto function = source.tag == SyntheticModuleType::ExportDefaultObject
+        ? generateJSValueExportDefaultObjectSourceCode(globalObject, value)
+        : generateJSValueModuleSourceCode(globalObject, value);
+    auto sourceCode = JSC::SourceCode(
+        JSC::SyntheticSourceProvider::create(WTF::move(function),
+            JSC::SourceOrigin(), specifier->toWTFString(BunString::ZeroCopy)));
+    JSC::ensureStillAliveHere(value);
+    return JSC::JSSourceCode::create(globalObject->vm(), WTF::move(sourceCode));
+}
+
 static OnLoadResult handleOnLoadObjectResult(Zig::GlobalObject* globalObject, JSC::JSObject* object)
 {
     OnLoadResult result {};
@@ -407,6 +471,22 @@ static JSValue handleVirtualModuleResult(
         Bun__transpileVirtualModule(globalObject, specifier, referrer, &onLoadResult.value.sourceText.string, onLoadResult.value.sourceText.loader, res);
         if (!res->success) {
             RELEASE_AND_RETURN(scope, reject(JSValue::decode(res->result.err.value)));
+        }
+
+        if (isExportValueSource(res->result.value)) {
+            JSValue value = exportValueFromSource(globalObject, res->result.value);
+            if (auto* exception = scope.exception()) [[unlikely]] {
+                (void)scope.tryClearException();
+                RELEASE_AND_RETURN(scope, reject(exception));
+            }
+
+            if (commonJSModule) {
+                commonJSModule->setExportsObject(value);
+                commonJSModule->hasEvaluated = true;
+                return commonJSModule;
+            }
+
+            return resolve(createExportValueModuleSourceCode(globalObject, res->result.value, value, specifier));
         }
 
         auto provider = Zig::SourceProvider::create(globalObject, res->result.value);
@@ -853,39 +933,16 @@ JSValue fetchCommonJSModuleNonBuiltin(
         RELEASE_AND_RETURN(scope, {});
     }
 
-    // The JSONForObjectLoader tag is source code returned from Bun that needs
-    // to go through the JSON parser in JSC.
-    //
-    // We don't use JSON.parse directly in JS because we want the top-level keys of the JSON
-    // object to be accessible as named imports.
-    //
-    // We don't use Bun's JSON parser because JSON.parse is faster and
-    // handles stack overflow better.
-    //
-    // When parsing tsconfig.*.json or jsconfig.*.json, we go through Bun's JSON
-    // parser instead to support comments and trailing commas.
-    if (res->result.value.tag == SyntheticModuleType::JSONForObjectLoader) {
-        WTF::String jsonSource = res->result.value.source_code.toWTFString(BunString::NonNull);
-        JSC::JSValue value = JSC::JSONParseWithException(globalObject, jsonSource);
+    if (isExportValueSource(res->result.value)) {
+        JSC::JSValue value = exportValueFromSource(globalObject, res->result.value);
         RETURN_IF_EXCEPTION(scope, {});
 
-        target->putDirect(vm, WebCore::clientData(vm)->builtinNames().exportsPublicName(), value, 0);
+        target->setExportsObject(value);
         target->hasEvaluated = true;
         RELEASE_AND_RETURN(scope, target);
-
     }
-    // TOML and JSONC may go through here
-    else if (res->result.value.tag == SyntheticModuleType::ExportsObject || res->result.value.tag == SyntheticModuleType::ExportDefaultObject) {
-        JSC::JSValue value = JSC::JSValue::decode(res->result.value.jsvalue_for_export);
-        if (!value) {
-            JSC::throwException(globalObject, scope, JSC::createSyntaxError(globalObject, "Failed to parse Object"_s));
-            RELEASE_AND_RETURN(scope, {});
-        }
 
-        target->putDirect(vm, WebCore::clientData(vm)->builtinNames().exportsPublicName(), value, 0);
-        target->hasEvaluated = true;
-        RELEASE_AND_RETURN(scope, target);
-    } else if (res->result.value.tag == SyntheticModuleType::CommonJSCustomExtension) {
+    if (res->result.value.tag == SyntheticModuleType::CommonJSCustomExtension) {
         if constexpr (isExtension) {
             ASSERT_NOT_REACHED();
             JSC::throwException(globalObject, scope, JSC::createSyntaxError(globalObject, "Recursive extension. This is a bug in Bun"_s));
@@ -1149,67 +1206,14 @@ static JSValue fetchESMSourceCode(
         RELEASE_AND_RETURN(scope, reject(exception));
     }
 
-    // The JSONForObjectLoader tag is source code returned from Bun that needs
-    // to go through the JSON parser in JSC.
-    //
-    // We don't use JSON.parse directly in JS because we want the top-level keys of the JSON
-    // object to be accessible as named imports.
-    //
-    // We don't use Bun's JSON parser because JSON.parse is faster and
-    // handles stack overflow better.
-    //
-    // When parsing tsconfig.*.json or jsconfig.*.json, we go through Bun's JSON
-    // parser instead to support comments and trailing commas.
-    if (res->result.value.tag == SyntheticModuleType::JSONForObjectLoader) {
-        WTF::String jsonSource = res->result.value.source_code.toWTFString(BunString::NonNull);
-        JSC::JSValue value = JSC::JSONParseWithException(globalObject, jsonSource);
-        if (scope.exception()) [[unlikely]] {
-            auto* exception = scope.exception();
+    if (isExportValueSource(res->result.value)) {
+        JSC::JSValue value = exportValueFromSource(globalObject, res->result.value);
+        if (auto* exception = scope.exception()) [[unlikely]] {
             (void)scope.tryClearException();
             RELEASE_AND_RETURN(scope, reject(exception));
         }
 
-        // JSON can become strings, null, numbers, booleans so we must handle "export default 123"
-        auto function = generateJSValueModuleSourceCode(
-            globalObject,
-            value);
-        auto source = JSC::SourceCode(
-            JSC::SyntheticSourceProvider::create(WTF::move(function),
-                JSC::SourceOrigin(), specifier->toWTFString(BunString::ZeroCopy)));
-        JSC::ensureStillAliveHere(value);
-        RELEASE_AND_RETURN(scope, rejectOrResolve(JSSourceCode::create(globalObject->vm(), WTF::move(source))));
-    }
-    // TOML and JSONC may go through here
-    else if (res->result.value.tag == SyntheticModuleType::ExportsObject) {
-        JSC::JSValue value = JSC::JSValue::decode(res->result.value.jsvalue_for_export);
-        if (!value) {
-            RELEASE_AND_RETURN(scope, reject(JSC::createSyntaxError(globalObject, "Failed to parse Object"_s)));
-        }
-
-        // JSON can become strings, null, numbers, booleans so we must handle "export default 123"
-        auto function = generateJSValueModuleSourceCode(
-            globalObject,
-            value);
-        auto source = JSC::SourceCode(
-            JSC::SyntheticSourceProvider::create(WTF::move(function),
-                JSC::SourceOrigin(), specifier->toWTFString(BunString::ZeroCopy)));
-        JSC::ensureStillAliveHere(value);
-        RELEASE_AND_RETURN(scope, rejectOrResolve(JSSourceCode::create(globalObject->vm(), WTF::move(source))));
-    } else if (res->result.value.tag == SyntheticModuleType::ExportDefaultObject) {
-        JSC::JSValue value = JSC::JSValue::decode(res->result.value.jsvalue_for_export);
-        if (!value) {
-            RELEASE_AND_RETURN(scope, reject(JSC::createSyntaxError(globalObject, "Failed to parse Object"_s)));
-        }
-
-        // JSON can become strings, null, numbers, booleans so we must handle "export default 123"
-        auto function = generateJSValueExportDefaultObjectSourceCode(
-            globalObject,
-            value);
-        auto source = JSC::SourceCode(
-            JSC::SyntheticSourceProvider::create(WTF::move(function),
-                JSC::SourceOrigin(), specifier->toWTFString(BunString::ZeroCopy)));
-        JSC::ensureStillAliveHere(value);
-        RELEASE_AND_RETURN(scope, rejectOrResolve(JSSourceCode::create(globalObject->vm(), WTF::move(source))));
+        RELEASE_AND_RETURN(scope, rejectOrResolve(createExportValueModuleSourceCode(globalObject, res->result.value, value, specifier)));
     }
 
     auto provider = Zig::SourceProvider::create(globalObject, res->result.value);

--- a/test/cli/run/preload-test.test.js
+++ b/test/cli/run/preload-test.test.js
@@ -38,7 +38,7 @@ process.exit(0);
 const bunfig = `preload = ["./preload.js"]`;
 
 describe("preload", () => {
-  test.todo("works", async () => {
+  test("works", async () => {
     const preloadDir = join(realpathSync(tmpdir()), "bun-preload-test");
     mkdirSync(preloadDir, { recursive: true });
     const preloadPath = join(preloadDir, "preload.js");
@@ -68,7 +68,7 @@ describe("preload", () => {
     }
   });
 
-  test.todo("works from CLI", async () => {
+  test("works from CLI", async () => {
     const preloadDir = join(realpathSync(tmpdir()), "bun-preload-test4");
     mkdirSync(preloadDir, { recursive: true });
     const preloadPath = join(preloadDir, "preload.js");

--- a/test/js/bun/plugin/plugins.d.ts
+++ b/test/js/bun/plugin/plugins.d.ts
@@ -11,3 +11,5 @@ declare module "delay:*";
 declare module "./*.svelte";
 declare module "rejected-promise:*";
 declare module "rejected-promise2:*";
+declare module "value-loader:*";
+declare module "value-loader-module-json/*";

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -1,5 +1,5 @@
 /// <reference types="./plugins" />
-import { plugin } from "bun";
+import { Loader, plugin } from "bun";
 import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import { resolve } from "path";
@@ -197,6 +197,46 @@ plugin({
   },
 });
 
+// Loaders whose result is a parsed value rather than JavaScript source.
+const valueLoaderContents: Record<string, { contents: string; loader?: Loader }> = {
+  "json-object": { contents: `{"hello": "world", "nested": {"n": 1}}`, loader: "json" },
+  "json-string": { contents: `"hello world"`, loader: "json" },
+  "json-array": { contents: `[1, 2, 3]`, loader: "json" },
+  "json-invalid": { contents: `{"hello":`, loader: "json" },
+  "toml": { contents: `hello = "world"\n[nested]\nn = 1`, loader: "toml" },
+  "yaml": { contents: `hello: world\nnested:\n  n: 1`, loader: "yaml" },
+  "xml": { contents: `<root><hello>world</hello></root>`, loader: "xml" },
+  // No loader: Bun picks it from the specifier's extension.
+  "by-extension.json": { contents: `{"hello": "json"}` },
+  "by-extension.toml": { contents: `hello = "toml"` },
+  "by-extension.yaml": { contents: `hello: yaml` },
+};
+
+plugin({
+  name: "value loaders",
+  setup(builder) {
+    builder.onResolve({ filter: /.*/, namespace: "value-loader" }, ({ path }) => ({
+      path,
+      namespace: "value-loader",
+    }));
+    // The specifier is "value-loader:<how>/<name>". <how> only keeps the specifiers
+    // distinct so that every test loads a fresh module; "async/..." returns a promise.
+    builder.onLoad({ filter: /.*/, namespace: "value-loader" }, ({ path }) => {
+      const [how, name] = path.split("/");
+      const result = valueLoaderContents[name];
+      if (!result) throw new Error("no contents registered for " + path);
+      return how === "async" ? Promise.resolve(result) : result;
+    });
+
+    for (const how of ["import", "require"]) {
+      builder.module(`value-loader-module-json/${how}`, () => ({
+        contents: `{"hello": "from build.module()"}`,
+        loader: "json",
+      }));
+    }
+  },
+});
+
 // This is to test that it works when imported from a separate file
 import { tempDir } from "harness";
 import { render as svelteRender } from "svelte/server";
@@ -341,6 +381,69 @@ export default Hello;
     const { body } = svelteRender(SvelteApp);
 
     expect(body).toBe("<!--[--><h1>Hello world!</h1><!--]-->");
+  });
+});
+
+// These loaders must behave exactly like the same contents in a file on disk:
+// import gets the value as the default export (plus an object's keys as named
+// exports) and require() gets the value itself.
+describe("json, toml, yaml and xml loaders", () => {
+  const objectExports = { default: { hello: "world", nested: { n: 1 } }, hello: "world", nested: { n: 1 } };
+
+  it.each(["json-object", "toml", "yaml"])("%s: import() exposes the value and its keys", async name => {
+    expect({ ...(await import(`value-loader:import/${name}`)) }).toEqual(objectExports);
+  });
+
+  it.each(["json-object", "toml", "yaml"])("%s: require() returns the value", name => {
+    expect(require(`value-loader:require/${name}`)).toEqual({ hello: "world", nested: { n: 1 } });
+  });
+
+  it("xml: import() and require()", async () => {
+    const xml = { root: { hello: "world" } };
+    expect({ ...(await import("value-loader:import/xml")) }).toEqual({ default: xml, ...xml });
+    expect(require("value-loader:require/xml")).toEqual(xml);
+  });
+
+  it("json string: import() default export is the string", async () => {
+    expect({ ...(await import("value-loader:import/json-string")) }).toEqual({
+      __esModule: true,
+      default: "hello world",
+    });
+  });
+
+  it("json string: require() returns the string", () => {
+    expect(require("value-loader:require/json-string")).toBe("hello world");
+  });
+
+  it("json array: import() default export is the array, require() returns it", async () => {
+    expect({ ...(await import("value-loader:import/json-array")) }).toEqual({ __esModule: true, default: [1, 2, 3] });
+    expect(require("value-loader:require/json-array")).toEqual([1, 2, 3]);
+  });
+
+  it.each(["json", "toml", "yaml"])("loader defaults to the one for the .%s extension", async ext => {
+    expect({ ...(await import(`value-loader:import/by-extension.${ext}`)) }).toEqual({
+      default: { hello: ext },
+      hello: ext,
+    });
+    expect(require(`value-loader:require/by-extension.${ext}`)).toEqual({ hello: ext });
+  });
+
+  it.each(["json-object", "toml", "yaml"])("%s: works when onLoad returns a promise", async name => {
+    expect({ ...(await import(`value-loader:async/${name}`)) }).toEqual(objectExports);
+  });
+
+  it("works for build.module()", async () => {
+    expect({ ...(await import("value-loader-module-json/import")) }).toEqual({
+      default: { hello: "from build.module()" },
+      hello: "from build.module()",
+    });
+    expect(require("value-loader-module-json/require")).toEqual({ hello: "from build.module()" });
+  });
+
+  it("invalid json is reported by the JSON parser", async () => {
+    await expect(import("value-loader:import/json-invalid")).rejects.toThrow("JSON Parse error");
+    await expect(import("value-loader:async/json-invalid")).rejects.toThrow("JSON Parse error");
+    expect(() => require("value-loader:require/json-invalid")).toThrow("JSON Parse error");
   });
 });
 
@@ -801,5 +904,75 @@ it.concurrent("a no-op onResolve that returns args.path unchanged is transparent
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout.trim() || stderr).toBe("entry ran:dep");
+  expect(exitCode).toBe(0);
+});
+
+it.concurrent("onLoad can replace the contents of .json, .toml, .yaml and .css files on disk", async () => {
+  using dir = tempDir("plugin-onload-value-loaders", {
+    "preload.js": `
+      Bun.plugin({
+        name: "replace contents",
+        setup(build) {
+          build.onLoad({ filter: /\\.json$/ }, () => ({ contents: '{"from": "plugin", "kind": "json"}' }));
+          build.onLoad({ filter: /\\.toml$/ }, () => ({ contents: 'from = "plugin"\\nkind = "toml"' }));
+          build.onLoad({ filter: /\\.yaml$/ }, () => ({ contents: 'from: plugin\\nkind: yaml' }));
+          build.onLoad({ filter: /\\.css$/ }, () => ({ contents: 'a { color: red }' }));
+        },
+      });
+    `,
+    "data.json": `{"from": "disk"}`,
+    "data.toml": `from = "disk"`,
+    "data.yaml": `from: disk`,
+    "style.css": `a { color: blue }`,
+    "entry.js": `
+      import json, { kind as jsonKind } from "./data.json";
+      import toml, { kind as tomlKind } from "./data.toml";
+      import yaml, { kind as yamlKind } from "./data.yaml";
+      import css from "./style.css";
+
+      console.log(
+        JSON.stringify({
+          imported: { json, jsonKind, toml, tomlKind, yaml, yamlKind, css },
+          required: {
+            json: require("./required.json"),
+            toml: require("./required.toml"),
+            yaml: require("./required.yaml"),
+            css: require("./required.css"),
+          },
+        }),
+      );
+    `,
+    "required.json": `{"from": "disk"}`,
+    "required.toml": `from = "disk"`,
+    "required.yaml": `from: disk`,
+    "required.css": `a { color: blue }`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--preload", "./preload.js", "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim() ? JSON.parse(stdout) : { stderr }).toEqual({
+    imported: {
+      json: { from: "plugin", kind: "json" },
+      jsonKind: "json",
+      toml: { from: "plugin", kind: "toml" },
+      tomlKind: "toml",
+      yaml: { from: "plugin", kind: "yaml" },
+      yamlKind: "yaml",
+      // The runtime css loader exports an empty object, like it does without a plugin.
+      css: {},
+    },
+    required: {
+      json: { from: "plugin", kind: "json" },
+      toml: { from: "plugin", kind: "toml" },
+      yaml: { from: "plugin", kind: "yaml" },
+      css: {},
+    },
+  });
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
### Problem

- A runtime plugin (`Bun.plugin` / `--preload`) whose `onLoad` or `build.module()` callback returns `{ contents, loader: "json" }` evaluates the JSON text as JavaScript: `import x from "./x.txt"` fails with `SyntaxError: Unexpected token ':'`, and `"hello world"` as JSON contents gives `SyntaxError: Missing 'default' export in module '.../x.txt'`.
- `loader: "toml"`, `"yaml"` and `"xml"` produce an empty module: `import` fails with the same `Missing 'default' export` error and `require()` returns `{}`.
- The same happens when the loader is left out and Bun infers it from the extension, so an `onLoad` that rewrites the contents of a real `.json` / `.toml` / `.yaml` / `.css` file is broken too.
- Cause: `handleVirtualModuleResult`, `OnLoadResultTypeCode` arm (`src/jsc/bindings/ModuleLoader.cpp`), wraps whatever `Bun__transpileVirtualModule` returned in a `Zig::SourceProvider` and evaluates it as JS, ignoring `ResolvedSource.tag`. For these loaders the transpiler does not return JS: the json loader returns the raw JSON text tagged `JSONForObjectLoader`, and jsonc/toml/yaml/json5/xml (`ExportsObject`) and css/html/file (`ExportDefaultObject`) return the already parsed value in `jsvalue_for_export` with an empty `source_code` (`transpile_source_code_inner` in `src/runtime/jsc_hooks.rs`). The file-on-disk paths, `fetchESMSourceCode` and `fetchCommonJSModuleNonBuiltin`, already dispatch on these tags; the plugin path never did. `test/cli/run/preload-test.test.js` has carried two `test.todo`s for exactly this since the plugin API was added.

### Fix

- The tag dispatch from `fetchESMSourceCode` / `fetchCommonJSModuleNonBuiltin` is factored into `isExportValueSource`, `exportValueFromSource` (JSON.parse for `JSONForObjectLoader`, `jsvalue_for_export` otherwise) and `createExportValueModuleSourceCode` (the synthetic module), and both existing callers now use the helpers. This is a pure refactor of those two paths: same parser, same generators, same errors.
- The fixing hunk is the new block in `handleVirtualModuleResult`: when the transpile result carries one of these tags, `import` gets the same synthetic module a file on disk gets, and `require()` (the `commonJSModule` argument is set) gets the value as `module.exports` and returns the module, which is what `fetchCommonJSModuleNonBuiltin` does for `require("./x.json")`. Other results (js/jsx/ts/tsx/md, and CommonJS output, which #34112 handles) still take the `Zig::SourceProvider` path unchanged.
- Why this is correct: the plugin's `contents` go through the same transpiler entry point as a file on disk, so the result must be consumed the same way the on-disk paths consume it. With the change, plugin-provided contents produce byte-for-byte the same `import` namespace and `require()` value as the same contents saved to a file (checked for json object / string / array, toml, yaml, xml, css; see details). The synchronous and the promise-returning `onLoad` forms share this arm (`allowPromise` true/false instantiations), so both are covered.
- The `.defer()` example in `docs/runtime/plugins.mdx` and `docs/bundler/plugins.mdx` returned `export default {...}` with `loader: "json"`. It only worked at runtime because of this bug and fails under `Bun.build` today (`Unexpected export`); it now returns JSON.
- Verified:
  - `test/js/bun/plugin/plugins.test.ts`: new `json, toml, yaml and xml loaders` block (import and require of objects, a JSON string and array, loader inferred from the extension, promise-returning onLoad, `build.module()`, invalid JSON surfacing the JSON parser's error from import, async import and require) plus a subprocess test where `--preload` rewrites real `.json` / `.toml` / `.yaml` / `.css` files. 19 tests, all fail on the unfixed build (`USE_SYSTEM_BUN=1`), all pass with `bun bd test`.
  - `test/cli/run/preload-test.test.js`: `preload > works` and `preload > works from CLI` flipped from `test.todo` to `test`; they fail unfixed and pass fixed. (`as entry point > works from CLI` is a different bug and stays todo.)
  - `bun bd test` on `test/js/bun/resolve/{toml,yaml,xml,json5}`, `jsonc.test.ts`, `png`, `require.test.ts`, `import-empty.test.js`, `esModule.test.ts`, `import-query.test.ts`, `require-and-import-trailing.test.ts`, `test/js/bun/test/mock/mock-module*.test.ts`: pass (the refactored on-disk paths).

### Background

- A runtime plugin's `onLoad` / `build.module()` result with `contents` is a "virtual module": `handleVirtualModuleResult` hands the contents and loader to `Bun__transpileVirtualModule`, which runs the same `transpile_source_code_inner` that files on disk go through and fills in a `ResolvedSource`.
- `ResolvedSource` is the struct the transpiler returns to C++. For JS-like loaders it holds source text to evaluate. Its `tag` says when it holds something else: `JSONForObjectLoader` (raw JSON text, parsed with JSC's JSON parser so that the object's keys become named exports and the parse is fast and stack-overflow safe), `ExportsObject` (a parsed value; an object's keys become named exports plus `default`) and `ExportDefaultObject` (a value exposed only as `default`).
- `generateJSValueModuleSourceCode` / `generateJSValueExportDefaultObjectSourceCode` (`src/jsc/modules/ObjectModule.cpp`) turn such a value into a JSC synthetic module, which is how `import data from "./data.json"` works for files on disk.
- `require()` of a virtual module also goes through `handleVirtualModuleResult` (from `fetchCommonJSModule`), passing the `JSCommonJSModule` being filled in; returning that module with `exports` set and `hasEvaluated = true` is the existing convention in this function for "already evaluated" results.
- #34112 (open) fixes the sibling problem in the same arm for contents that transpile to CommonJS (`isCommonJSModule`); the two changes are independent. #9987 looks similar from the error message but is about `loader: "object"` and is not changed here.

<details>
<summary>Parity check: plugin contents vs the same contents on disk (debug build with this change)</summary>

```
plugin, loader json   '{"a": 1, "b": "two"}'  import -> {"a":1,"b":"two"} keys a,b,default   require -> {"a":1,"b":"two"}
on disk  obj.json                              import -> {"a":1,"b":"two"} keys a,b,default   require -> {"a":1,"b":"two"}
plugin, loader json   '"hello world"'          import -> "hello world" keys __esModule,default require -> "hello world"
on disk  str.json                              import -> "hello world" keys __esModule,default require -> "hello world"
plugin, loader toml   'a = 1\n[b]\nc = "d"'    import -> {"a":1,"b":{"c":"d"}} keys a,b,default require -> {"a":1,"b":{"c":"d"}}
on disk  x.toml                                import -> {"a":1,"b":{"c":"d"}} keys a,b,default require -> {"a":1,"b":{"c":"d"}}
plugin, loader yaml   'a: 1\nb:\n  c: d'       import -> {"a":1,"b":{"c":"d"}} keys a,b,default require -> {"a":1,"b":{"c":"d"}}
on disk  x.yaml                                import -> {"a":1,"b":{"c":"d"}} keys a,b,default require -> {"a":1,"b":{"c":"d"}}
plugin, loader xml    '<root><a>1</a></root>'  import -> {"root":{"a":"1"}} keys default,root  require -> {"root":{"a":"1"}}
on disk  x.xml                                 import -> {"root":{"a":"1"}} keys default,root  require -> {"root":{"a":"1"}}
plugin, .css inferred 'a { b: c }'             import -> {} keys __esModule,default            require -> {}
on disk  x.css                                 import -> {} keys __esModule,default            require -> {}
plugin, loader json   '{oops'                  import -> SyntaxError: JSON Parse error: Expected '}'   require -> same
```

Before the change, on main (`732491c9f`, debug build and the 1.4.0 canary):

```
json object -> SyntaxError: Unexpected token ':'
json string -> SyntaxError: Missing 'default' export in module '/tmp/repro/hey.txt'.   require -> {}
toml        -> SyntaxError: Missing 'default' export in module '/tmp/repro/hey.txt'.   require -> {}
yaml        -> SyntaxError: Missing 'default' export in module '/tmp/repro/hey.txt'.   require -> {}
onLoad on a real .json/.toml/.yaml file without a loader -> same three failures
```

</details>
