### PR TITLE
bun test --parallel: exit 1 when a worker fails to write its snapshots

### DIFF
--- a/src/runtime/cli/test/parallel/Coordinator.rs
+++ b/src/runtime/cli/test/parallel/Coordinator.rs
@@ -527,6 +527,9 @@ impl<'a> Coordinator<'a> {
                     self.coverage_chunks.push(Box::<[u8]>::from(chunk));
                 }
             }
+            frame::Kind::SnapshotWriteFailed => {
+                self.reporter.worker_snapshot_write_failed = true;
+            }
             frame::Kind::Run | frame::Kind::Shutdown => {}
         }
     }

--- a/src/runtime/cli/test/parallel/Frame.rs
+++ b/src/runtime/cli/test/parallel/Frame.rs
@@ -29,6 +29,11 @@ pub enum Kind {
     /// str lcov — this worker's coverage data, sent at exit; the coordinator
     /// merges every worker's into the one report it writes.
     CoverageChunk,
+    /// (empty) — sent at exit when the worker could not write the inline
+    /// snapshots or the `.snap` file of the files it ran. The worker prints
+    /// the error itself; the coordinator only has to fail the run, as the
+    /// serial runner does when its own write fails.
+    SnapshotWriteFailed,
 }
 
 impl TryFrom<u8> for Kind {
@@ -45,6 +50,7 @@ impl TryFrom<u8> for Kind {
             6 => Kind::Shutdown,
             7 => Kind::JunitChunk,
             8 => Kind::CoverageChunk,
+            9 => Kind::SnapshotWriteFailed,
             _ => return Err(()),
         })
     }

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -702,14 +702,30 @@ fn worker_flush_aggregates(
     cmds: &mut WorkerCommands,
 ) {
     // Snapshots flush lazily when the next file opens its snapshot file; the
-    // last file each worker ran has no successor to trigger that.
-    if let Some(runner) = crate::test_runner::jest::Jest::runner() {
-        let _ = runner.snapshots.write_inline_snapshots().unwrap_or(false);
-        let _ = runner.snapshots.write_snapshot_file();
+    // last file each worker ran has no successor to trigger that. A failed
+    // write exits 1 in serial mode; the coordinator ignores the exit status of
+    // a worker whose files are all done, so here it has to go over IPC.
+    let snapshots = &mut reporter.jest.snapshots;
+    let mut snapshots_written = match snapshots.write_inline_snapshots() {
+        // `false` has already printed a diagnostic per snapshot it could not write.
+        Ok(written) => written,
+        Err(err) => {
+            Output::err(err, "Failed to write inline snapshots", ());
+            false
+        }
+    };
+    if let Err(err) = snapshots.write_snapshot_file() {
+        Output::err(err, "Failed to write snapshot file", ());
+        snapshots_written = false;
     }
 
     // SAFETY: single-threaded worker; WORKER_FRAME is a process-global scratch buffer
     let wf = unsafe { &mut *WORKER_FRAME.get() };
+
+    if !snapshots_written {
+        wf.begin(frame::Kind::SnapshotWriteFailed);
+        cmds.send(wf.finish());
+    }
 
     wf.begin(frame::Kind::RepeatBufs);
     wf.str(reporter.failures_to_repeat_buf.as_slice());

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -940,6 +940,11 @@ pub struct CommandLineReporter {
     /// is sent over the IPC pipe instead of to stderr; the coordinator owns
     /// the terminal.
     pub(crate) worker_ipc_file_idx: Option<u32>,
+    /// When running as the `--parallel` coordinator: a worker reported that it
+    /// could not write the snapshots of the files it ran (it printed the
+    /// error). Fails the run like `write_inline_snapshots()` returning false
+    /// does in a serial run.
+    pub(crate) worker_snapshot_write_failed: bool,
 
     pub(crate) failures_to_repeat_buf: Vec<u8>,
     pub(crate) skips_to_repeat_buf: Vec<u8>,
@@ -2227,6 +2232,7 @@ impl TestCommand {
             repeat_count: 1,
             last_printed_dot: core::cell::Cell::new(false),
             worker_ipc_file_idx: None,
+            worker_snapshot_write_failed: false,
             failures_to_repeat_buf: Vec::new(),
             skips_to_repeat_buf: Vec::new(),
             todos_to_repeat_buf: Vec::new(),
@@ -3032,6 +3038,7 @@ impl TestCommand {
                 && coverage_options.fractions.failing
                 && coverage_options.fail_on_low_coverage)
             || !write_snapshots_success
+            || reporter.worker_snapshot_write_failed
             || reporter.jest.unhandled_errors_between_tests > 0
         {
             vm.exit_handler.exit_code = 1;

--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isDebug, isWindows, normalizeBunSnapshot, tempDir, tls } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, isLinux, isWindows, normalizeBunSnapshot, tempDir, tls } from "harness";
+import { symlinkSync } from "node:fs";
+import { join } from "node:path";
 
 test("--parallel: each worker has a unique JEST_WORKER_ID and BUN_TEST_WORKER_ID", async () => {
   // Sleep so worker 0 is busy when workers 1/2 come online and pick up the
@@ -901,6 +903,79 @@ test("--parallel writes new snapshots from every worker", async () => {
   expect(stderr2).toContain("4 pass");
   expect(stderr2).toContain("0 fail");
   expect(code2).toBe(0);
+});
+
+// Workers write the snapshots of the files they ran when they exit, after
+// every test has already been reported as passing. If that write fails, the
+// only thing left to get wrong is the exit code: the serial runner exits 1 in
+// each of these situations, so --parallel must too. The second file exists so
+// the run actually uses the worker pool (one file falls back to serial).
+const passingFile = `import {test,expect} from "bun:test"; test("b",()=>expect(1).toBe(1));`;
+
+async function runParallel(dir: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--parallel=2"],
+    env: { ...bunEnv, BUN_TEST_PARALLEL_SCALE_MS: "0", CI: "false" },
+    cwd: dir,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toContain("PARALLEL");
+  return { stderr, exitCode };
+}
+
+test("--parallel exits 1 when a worker cannot update an inline snapshot", async () => {
+  using dir = tempDir("parallel-inline-snapshot-conflict", {
+    // Two different values recorded for one call site cannot both be written;
+    // the worker reports it when it goes to update the file.
+    "a.test.js": `import {test,expect} from "bun:test";
+      test("inline", () => { for (const v of ["one", "two"]) expect(v).toMatchInlineSnapshot(); });`,
+    "b.test.js": passingFile,
+  });
+  const { stderr, exitCode } = await runParallel(String(dir));
+  expect(stderr).toContain(
+    "Failed to update inline snapshot: Multiple inline snapshots on the same line must all have the same value",
+  );
+  expect(stderr).toContain("2 pass");
+  expect(stderr).toContain("0 fail");
+  expect(exitCode).toBe(1);
+});
+
+test("--parallel exits 1 when a worker errors while writing inline snapshots", async () => {
+  using dir = tempDir("parallel-inline-snapshot-error", {
+    // The test rewrites its own call site into unparseable source after the
+    // snapshot was recorded, so the write at worker exit fails outright
+    // instead of skipping the file with a diagnostic like the test above.
+    "a.test.js": `import {test,expect} from "bun:test"; import {readFileSync,writeFileSync} from "fs";
+      test("inline", () => {
+        expect("value").toMatchInlineSnapshot();
+        writeFileSync(import.meta.path, readFileSync(import.meta.path, "utf8").replace(/toMatchInlineSnapshot\\(\\)/, 'toMatchInlineSnapshot("'));
+      });`,
+    "b.test.js": passingFile,
+  });
+  const { stderr, exitCode } = await runParallel(String(dir));
+  expect(stderr).toContain("Failed to write inline snapshots");
+  expect(stderr).toContain("2 pass");
+  expect(stderr).toContain("0 fail");
+  expect(exitCode).toBe(1);
+});
+
+test.skipIf(!isLinux)("--parallel exits 1 when a worker cannot write a .snap file", async () => {
+  using dir = tempDir("parallel-snap-file-unwritable", {
+    "a.test.js": `import {test,expect} from "bun:test"; test("snap",()=>expect("value").toMatchSnapshot());`,
+    "b.test.js": passingFile,
+    "__snapshots__": {},
+  });
+  // Opening the file succeeds, so the test itself passes; every write to
+  // /dev/full fails with ENOSPC, and the worker only writes when it exits.
+  // Works as root too, unlike a read-only file.
+  symlinkSync("/dev/full", join(String(dir), "__snapshots__", "a.test.js.snap"));
+  const { stderr, exitCode } = await runParallel(String(dir));
+  expect(stderr).toContain("Failed to write snapshot file");
+  expect(stderr).toContain("2 pass");
+  expect(stderr).toContain("0 fail");
+  expect(exitCode).toBe(1);
 });
 
 test("--parallel: a test producing a >64MB result line is truncated, not treated as a crash", async () => {


### PR DESCRIPTION
### Problem
- `bun test --parallel` exits 0 when a worker fails to write its snapshots. The same run without `--parallel` exits 1.
- Inline snapshots: the worker's diagnostic is relayed (`error: Failed to update inline snapshot: Failed to open file: EACCES`, or `... Multiple inline snapshots on the same line must all have the same value`) but the exit code is 0. Serial prints the same and exits 1 (asserted by `test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts`).
- `.snap` files: when the write at worker exit fails (`FailedToWriteSnapshotFile`), nothing is printed and the run exits 0, leaving the snapshot file empty. Serial prints `error: An internal error occurred (FailedToWriteSnapshotFile)` and exits 1.
- Cause: `worker_flush_aggregates()` in `src/runtime/cli/test/parallel/runner.rs` discarded the `bool` from `write_inline_snapshots()` and the `Result` of both writes, and nothing else carries the failure: the coordinator's own `write_inline_snapshots()` call in `TestCommand::exec` (`src/runtime/cli/test_command.rs`) has nothing queued and returns true, and `Coordinator::reap_worker` only looks at a worker's exit status while one of its files is in flight (the worker exits 0 regardless).

### Fix
- The worker prints an `Err` from either write with `Output::err` (`Ok(false)` from `write_inline_snapshots()` has already printed a diagnostic per snapshot) and sends a new `SnapshotWriteFailed` frame if either write failed. The coordinator sets `CommandLineReporter::worker_snapshot_write_failed`; the exit code check in `TestCommand::exec` fails the run on it, next to the `!write_snapshots_success` check that does this for the serial runner.
- Correct because the serial runner already fails the run in exactly these cases (that check, plus the `?` on both calls), and under `--parallel` the workers are the only processes that perform these writes. The frame is the only channel available: the coordinator ignores the exit status of a worker that is between files on purpose (a crash during teardown after all results are in is not a test failure).
- The frame is only sent on failure and the flag is sticky, so a lost frame or a frame forged by test code writing to fd 3 can only make a run fail, never hide a failure. The success path sends nothing; the existing `--parallel writes new snapshots from every worker` test covers it.
- `worker_flush_aggregates` reaches the snapshots through the `reporter` it already has (`reporter.jest` is the `TestRunner` that `Jest::runner()` returns), which removes the `if let Some` around the writes.
- Tests in `test/cli/test/parallel.test.ts`, one per failure path: two values recorded for one `toMatchInlineSnapshot()` call site (`Ok(false)`), a test that rewrites its own call site into unparseable source (`Err` from `write_inline_snapshots()`), and a `.snap` symlinked to `/dev/full` (`Err` from `write_snapshot_file()`, Linux only). Each uses two files so the run uses the worker pool, and none depends on file permissions, so they fail as root too. All three fail on bun 1.4.0-canary and on the debug build without `src/` (exit 0, message missing), and pass with this change.
- The rest of `test/cli/test/parallel.test.ts` was run with the debug build. `lazily scales workers`, `work-stealing balances` and `forwards --experimental-http2-fetch` fail identically without this change on this (slow) container; they are timing thresholds unrelated to this path.
- Overlaps textually with #39048 (snapshot counts in the `--parallel` summary): both add a frame kind numbered 9, edit the same lines of `worker_flush_aggregates` and add an arm to `Coordinator::on_frame`. They are independent fixes (#39048 still discards the write results); whichever lands second renumbers its frame and keeps both sets of lines.

### Background
- `bun test --parallel=N` runs a coordinator that spawns N worker processes (`bun test --test-worker`) and hands each one test file at a time. Workers report back over length-prefixed frames on fd 3; `src/runtime/cli/test/parallel/Frame.rs` lists the frame kinds and `Coordinator::on_frame` folds them into the coordinator's `CommandLineReporter`, from which `TestCommand::exec` prints the summary and derives the exit code. The coordinator's own `TestRunner` never executes a test.
- Snapshot writes are deferred: `toMatchSnapshot()` buffers the `.snap` contents in memory and `toMatchInlineSnapshot()` queues a source edit; `write_snapshot_file()` and `write_inline_snapshots()` (`src/runtime/test_runner/snapshot.rs`) write them out. The serial runner calls both at the end of the run; a worker calls both in `worker_flush_aggregates()` right before exiting, after it has already reported every test of its files as passed, so the exit code is the only place left where the failure can show.
- `write_inline_snapshots()` returns `Ok(false)` after printing a diagnostic for every snapshot it could not splice in (unwritable file, conflicting values for one call site, ...), and `Err` when reading or re-parsing the test file fails. `write_snapshot_file()` returns `Err` when writing the buffered `.snap` contents fails.
