### PR TITLE
types: type the global "error" event as ErrorEvent

### DIFF
--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -565,6 +565,13 @@ interface FetchEvent extends Event {
 }
 
 interface EventMap {
+  /**
+   * Dispatched on a `Worker`'s own global scope for an uncaught exception or
+   * unhandled rejection in that worker, before the parent's `Worker` object
+   * receives it. `error` is the thrown value, `message` its formatted text.
+   * Bun does not dispatch this on the main thread's global scope.
+   */
+  error: ErrorEvent;
   fetch: FetchEvent;
   message: MessageEvent;
   messageerror: MessageEvent;

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -400,6 +400,45 @@ describe("@types/bun integration test", () => {
     });
   });
 
+  // Runs on debug builds too, like the Bun.mmap test above.
+  describe("global addEventListener", () => {
+    test('"error" listeners receive an ErrorEvent', async () => {
+      const checkDir = join(TEMP_DIR, "global-error-event-check");
+      const tsconfig = structuredClone(sourceTsconfig);
+      tsconfig.include = ["global-error-event.ts"];
+      tsconfig.compilerOptions.typeRoots = [join(BASE_FIXTURE_DIR, "node_modules", "@types")];
+      await mkdir(checkDir, { recursive: true });
+      await makeTree(checkDir, {
+        "tsconfig.json": JSON.stringify(tsconfig, null, 2),
+        "global-error-event.ts": `addEventListener("error", event => {
+             event satisfies ErrorEvent;
+             event.message satisfies string;
+             console.log(event.error);
+           });
+           removeEventListener("error", event => {
+             event satisfies ErrorEvent;
+           });
+           const onError = (event: ErrorEvent) => console.log(event.error);
+           addEventListener("error", onError, { once: true });
+           removeEventListener("error", onError);`,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), join(BASE_FIXTURE_DIR, "node_modules", "typescript", "bin", "tsc"), "-p", "."],
+        env: bunEnv,
+        cwd: checkDir,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr.trim()).toBe("");
+      expect(stdout.trim()).toBe("");
+      expect(exitCode).toBe(0);
+    });
+  });
+
   describe("Test Globals", () => {
     const code = `
       const test_shouldBeAFunction: Function = test;

--- a/test/integration/bun-types/fixture/worker.ts
+++ b/test/integration/bun-types/fixture/worker.ts
@@ -48,6 +48,28 @@ nodeWorker.postMessage({ hello: "world" });
 
 await nodeWorker.terminate();
 
+// Inside a worker, an uncaught error is dispatched to the worker's own global
+// scope as an ErrorEvent, so the global EventMap types "error" as ErrorEvent.
+{
+  addEventListener("error", event => {
+    tsd.expectType(event).is<ErrorEvent>();
+    tsd.expectType(event.message).is<string>();
+    tsd.expectType(event.error).is<any>();
+  });
+  globalThis.addEventListener("error", event => {
+    tsd.expectType(event).is<ErrorEvent>();
+  });
+  removeEventListener("error", event => {
+    tsd.expectType(event).is<ErrorEvent>();
+  });
+
+  const onError = (event: ErrorEvent) => event.error;
+  addEventListener("error", onError);
+  removeEventListener("error", onError);
+  addEventListener("error", onError, { once: true });
+  removeEventListener("error", onError, { capture: false });
+}
+
 // Bun.pathToFileURL
 const _worker3 = new Worker(new URL("worker.ts", "/path/to/").href, {
   ref: true,


### PR DESCRIPTION
### Problem

- Inside a `Worker`, `addEventListener("error", event => event.message)` does not type-check: `event` is inferred as a plain `Event`, so `event.message` and `event.error` are `TS2339`. A listener declared as `(event: ErrorEvent) => void` is rejected by both `addEventListener` and `removeEventListener` (`TS2769`).
- Cause: the global `interface EventMap` in `packages/bun-types/globals.d.ts:567` only has `fetch`, `message` and `messageerror`, so `"error"` falls through to the `type: string` overload (`globals.d.ts:485`), whose listener type is `EventListener` (`(evt: Event) => void`).
- The runtime does dispatch this event: `WebWorker__dispatchError` (`src/jsc/bindings/webcore/Worker.cpp:191-201`) creates an `ErrorEvent` with `message` and `error` set and dispatches it on the worker's own `globalEventScope` before reporting to the parent's `Worker` object. Both uncaught exceptions and unhandled rejections in a worker reach it (`src/jsc/web_worker.rs`, `on_unhandled_rejection` and `flush_logs`). Verified with a worker that throws and one that rejects: the worker-side listener receives `ErrorEvent` with `error` set to the thrown value. The main thread never dispatches it.
- This also affects projects that load `lib.dom.d.ts`: the merged global `addEventListener` tries bun-types' `type: string` overload before lib.dom's `WindowEventMap` overload, so the inferred parameter is still `Event` there (pre-fix tsc output for both configurations is in the details block below).

### Fix

- Add `error: ErrorEvent` to the global `EventMap`, with a JSDoc note saying when Bun dispatches it (worker global scope only).
- Correct because it mirrors what the runtime dispatches (`ErrorEvent::create(eventNames().errorEvent, ...)` in `Worker.cpp:200`), and it is the same type bun-types already uses for the parent side (`AbstractWorkerEventMap.error`, `bun.d.ts`) and that `lib.dom.d.ts` / `lib.webworker.d.ts` use for the global `error` event.
- Only `addEventListener` / `removeEventListener` are affected by the change; nothing else reads `EventMap`. The global `onerror` / `onmessage` attributes and the global `dispatchEvent` function are separate gaps in bun-types and are intentionally left alone here.
- Verified:
  - `test/integration/bun-types/fixture/worker.ts`: new block asserting the inferred parameter of `addEventListener` / `globalThis.addEventListener` / `removeEventListener` is exactly `ErrorEvent`, and that an explicitly typed `ErrorEvent` listener is accepted by both, with and without options. It is type-checked by every existing `typeTest` case, i.e. with and without `lib.dom.d.ts`, and by the tsgo case; it adds no entries to the expected diagnostics of the lib.dom case.
  - `test/integration/bun-types/bun-types.test.ts`: new `global addEventListener` case that spawns `tsc` over one file, in the shape of the existing `Bun.mmap` case, because the `typeTest` cases are skipped on debug builds.
  - `bun test test/integration/bun-types/bun-types.test.ts` (the documented command for types-only changes): 16 pass with the fix; with `packages/` stashed, 10 fail: the new case, the tsgo case, and the 8 `typeTest` cases that assert the whole fixture's diagnostics (the 3 `bun:bundle` cases only look at their own file), all with the diagnostics below.

### Background

- bun-types declares the global `addEventListener` / `removeEventListener` as two overloads: one keyed on `interface EventMap` (`globals.d.ts:480`), which gives the listener a precise event type per event name, and a fallback taking any `string` with a listener typed `(evt: Event) => void`. Event names missing from `EventMap` silently get the fallback.
- Each Bun global object (main thread or worker) owns a `globalEventScope`, the `EventTarget` behind the global `addEventListener`. `WebWorker__dispatchError` is the only place the runtime dispatches `"error"` on it.
- The bun-types integration test packs `packages/bun-types`, installs it into a fixture project and type-checks `test/integration/bun-types/fixture/*.ts` under several tsconfigs; the lib.dom case asserts an exact list of expected diagnostics. Those cases only run on release builds, which is why the PR also adds a one-file `tsc` case that runs on debug builds too.

<details>
<summary>Pre-fix tsc output for the usage added in this PR</summary>

Without lib.dom (default `bun init` tsconfig):

```
global-error-event.ts(2,9): error TS1360: Type 'Event' does not satisfy the expected type 'ErrorEvent'.
  Type 'Event' is missing the following properties from type 'ErrorEvent': colno, error, filename, lineno, message
global-error-event.ts(3,9): error TS2339: Property 'message' does not exist on type 'Event'.
global-error-event.ts(4,21): error TS2339: Property 'error' does not exist on type 'Event'.
global-error-event.ts(10,1): error TS2769: No overload matches this call.
  Overload 1 of 2, '(type: keyof EventMap, listener: (this: object, ev: FetchEvent | MessageEvent<any>) => any, ...): void', gave the following error.
    Argument of type '"error"' is not assignable to parameter of type 'keyof EventMap'.
  Overload 2 of 2, '(type: string, listener: EventListenerOrEventListenerObject, ...): void', gave the following error.
    Argument of type '(event: ErrorEvent) => void' is not assignable to parameter of type 'EventListenerOrEventListenerObject'.
global-error-event.ts(11,1): error TS2769: No overload matches this call.   (removeEventListener, same two overload failures)
```

With `lib: ["ESNext", "DOM"]` added (explicitly typed listeners pass through lib.dom's overload, the inferred ones still degrade to `Event`):

```
global-error-event.ts(2,9): error TS1360: Type 'Event' does not satisfy the expected type 'ErrorEvent'.
global-error-event.ts(3,9): error TS2339: Property 'message' does not exist on type 'Event'.
global-error-event.ts(4,21): error TS2339: Property 'error' does not exist on type 'Event'.
global-error-event.ts(7,9): error TS1360: Type 'Event' does not satisfy the expected type 'ErrorEvent'.
global-error-event.ts(13,9): error TS1360: Type 'Event' does not satisfy the expected type 'ErrorEvent'.
```

Runtime check (worker side), `bun 1.4.0`:

```js
// child.js
addEventListener("error", e => console.log(e.constructor.name, e.error.message));
Promise.reject(new Error("rejected-in-worker")); // or: throw new Error(...)
// prints: ErrorEvent rejected-in-worker
```

</details>
