### PR TITLE
install: send Basic auth for a registry URL with a username but no password

### DIFF
--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -478,7 +478,7 @@ pub mod registry {
                     registry.password = env.get_auto(&registry.password).into();
 
                     if !registry.username.is_empty()
-                        && !registry.password.is_empty()
+                        && (!registry.password.is_empty() || registry.credentials_from_url)
                         && auth.is_empty()
                     {
                         let combo_len = registry.username.len() + registry.password.len() + 1;

--- a/src/options_types/schema.rs
+++ b/src/options_types/schema.rs
@@ -150,6 +150,12 @@ pub mod api {
         pub token: Box<[u8]>,
         /// email
         pub email: Box<[u8]>,
+        /// Set by `from_url` when the credentials were written into the URL.
+        /// `Scope::from_api` takes those as complete as written: `http://user@host/`
+        /// authenticates as `user` with an empty password (what npm sends for that
+        /// URL), whereas a `username` configured on its own (`.npmrc` `username`
+        /// without `_password`, bunfig `username` without `password`) sends nothing.
+        pub credentials_from_url: bool,
     }
 
     impl NpmRegistry {
@@ -157,12 +163,15 @@ pub mod api {
             let url = bun_url::URL::parse(str);
             let mut registry = NpmRegistry::default();
 
-            if url.username.is_empty() && !url.password.is_empty() {
-                registry.token = Box::from(url.password);
-                registry.url = url.href_without_auth();
-            } else if !url.username.is_empty() && !url.password.is_empty() {
+            if !url.username.is_empty() {
                 registry.username = Box::from(url.username);
                 registry.password = Box::from(url.password);
+                registry.credentials_from_url = true;
+                registry.url = url.href_without_auth();
+            } else if !url.password.is_empty() {
+                // `http://:token@host/`
+                registry.token = Box::from(url.password);
+                registry.credentials_from_url = true;
                 registry.url = url.href_without_auth();
             } else {
                 // Do not include a trailing slash. There might be parameters at the end.

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -875,6 +875,32 @@ describe.concurrent("credentials in the registry url", () => {
     expect(exitCode).toBe(0);
   });
 
+  // `http://user@host/` is `user` with an empty password (npm publishes with `Basic base64("user:")`);
+  // bun used to stop with "missing authentication". Spelled `user:@` because `user@host:port` does not
+  // get through bun's URL parser yet (#16181); both reach the registry config as a username without a password.
+  test("--registry with user:@ publishes with Basic auth and an empty password", async () => {
+    using mock = registryMock();
+    const packageDir = await packageDirFor("userinfo-no-password-pkg");
+
+    const { out, err, exitCode } = await publish(
+      env,
+      packageDir,
+      "--registry",
+      `http://pubuser:@localhost:${mock.port}/`,
+    );
+    expect(err).not.toContain("error:");
+    expect(out).toContain(`Registry: http://localhost:${mock.port}/\n`);
+    expect(out).toContain(" + userinfo-no-password-pkg@1.0.0");
+    expect(mock.requests).toEqual([
+      {
+        method: "PUT",
+        pathname: "/userinfo-no-password-pkg",
+        authorization: `Basic ${Buffer.from("pubuser:").toString("base64")}`,
+      },
+    ]);
+    expect(exitCode).toBe(0);
+  });
+
   test.each(["npm_config_registry", "NPM_CONFIG_REGISTRY", "BUN_CONFIG_REGISTRY"])(
     "%s with user:pass@ publishes with Basic auth",
     async key => {

--- a/test/cli/install/config-precedence.test.ts
+++ b/test/cli/install/config-precedence.test.ts
@@ -713,6 +713,86 @@ describe.concurrent("bun install config precedence", () => {
     expect(exitCode).toBe(0);
   });
 
+  // A username written into the URL without a password is Basic auth with an empty password, which is
+  // what npm sends for `http://user@host/`; bun used to leave the userinfo in the URL and send nothing.
+  // The URL is spelled `user:@host:port` because `user@host:port` does not get through bun's URL parser
+  // yet (#16181); both spellings reach the registry config as a username with an empty password. The
+  // verdaccio behind the capturing registry accepts any credentials for packages readable by everyone.
+  const emptyPasswordAuth = `Basic ${Buffer.from("config-precedence:").toString("base64")}`;
+  const userOnlyRegistrySources: [
+    source: string,
+    configure: (url: string) => {
+      files?: Record<string, string>;
+      args?: string[];
+      env?: Record<string, string>;
+      dependency?: string;
+    },
+  ][] = [
+    ["bunfig registry string", url => ({ files: { "project/bunfig.toml": bunfig({ registry: url }) } })],
+    ["bunfig registry object", url => ({ files: { "project/bunfig.toml": bunfig({ registry: { url } }) } })],
+    [
+      "bunfig scoped registry",
+      url => ({ files: { "project/bunfig.toml": bunfig({ scopes: { types: url } }) }, dependency: "@types/no-deps" }),
+    ],
+    [".npmrc registry=", url => ({ files: { "project/.npmrc": `registry=${url}\n` } })],
+    [
+      ".npmrc @scope:registry=",
+      url => ({ files: { "project/.npmrc": `@types:registry=${url}\n` }, dependency: "@types/no-deps" }),
+    ],
+    ["--registry", url => ({ args: ["--registry", url] })],
+    ["BUN_CONFIG_REGISTRY", url => ({ env: { BUN_CONFIG_REGISTRY: url } })],
+  ];
+
+  test.each(userOnlyRegistrySources)(
+    "%s with user:@ in the URL sends Basic auth with an empty password",
+    async (_, configure) => {
+      using capture = capturingRegistry();
+      const {
+        files = {},
+        args = [],
+        env = {},
+        dependency = "no-deps",
+      } = configure(withUserinfo(capture, "config-precedence:"));
+      using dir = tempDir("config-precedence", {
+        ...files,
+        "project/package.json": packageJson({ [dependency]: "1.0.0" }),
+      });
+      const { stderr, exitCode } = await install(String(dir), args, env);
+      expect(stderr).not.toContain("error:");
+      expect(new Set(capture.authorizations)).toStrictEqual(new Set([emptyPasswordAuth]));
+      expect(installed(String(dir), ...dependency.split("/"))).toBe(true);
+      expect(exitCode).toBe(0);
+    },
+  );
+
+  // Unlike a username written into the URL, a username configured on its own is not a credential: npm
+  // only uses the `username` / `_password` pair when both are set.
+  test("bunfig registry object with a username key but no password sends no credentials", async () => {
+    using capture = capturingRegistry();
+    using dir = tempDir("config-precedence", {
+      "project/bunfig.toml": bunfig({ registry: { url: capture.url, username: "config-precedence" } }),
+      "project/package.json": packageJson({ "no-deps": "1.0.0" }),
+    });
+    const { stderr, exitCode } = await install(String(dir));
+    expect(stderr).not.toContain("error:");
+    expect(new Set(capture.authorizations)).toStrictEqual(new Set([null]));
+    expect(installed(String(dir), "no-deps")).toBe(true);
+    expect(exitCode).toBe(0);
+  });
+
+  test(".npmrc :username= without :_password= sends no credentials", async () => {
+    using capture = capturingRegistry();
+    using dir = tempDir("config-precedence", {
+      "project/.npmrc": `registry=${capture.url}\n//localhost:${capture.port}/:username=config-precedence\n`,
+      "project/package.json": packageJson({ "no-deps": "1.0.0" }),
+    });
+    const { stderr, exitCode } = await install(String(dir));
+    expect(stderr).not.toContain("error:");
+    expect(new Set(capture.authorizations)).toStrictEqual(new Set([null]));
+    expect(installed(String(dir), "no-deps")).toBe(true);
+    expect(exitCode).toBe(0);
+  });
+
   test("user:pass@ in --registry replaces the .npmrc _authToken for the same host", async () => {
     using capture = capturingRegistry();
     using dir = tempDir("config-precedence", {

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -603,6 +603,38 @@ registry=https://somehost.com/org1/npm/registry/
     });
   });
 
+  describe("credentials written into the registry= URL", () => {
+    // `http://user@host/` is `user` with an empty password (what `new URL()` reports and what npm
+    // authenticates with); it used to be left inside the URL like a URL without credentials.
+    test.each([
+      ["user:pass@ is split into a username and a password", "http://carol:s3cret@example.com/npm/", "carol", "s3cret"],
+      ["user@ is a username with an empty password", "http://carol@example.com/npm/", "carol", ""],
+      ["user:@ is a username with an empty password", "http://carol:@example.com/npm/", "carol", ""],
+    ])("%s", (_, registryUrl, username, password) => {
+      expect(loadNpmrc(`registry=${registryUrl}\n`)).toEqual({
+        default_registry_url: "http://example.com/npm/",
+        default_registry_token: "",
+        default_registry_username: username,
+        default_registry_password: password,
+        default_registry_email: "",
+      });
+    });
+
+    test("a password without a username is a token", () => {
+      expect(loadNpmrc(`registry=http://:s3cret@example.com/npm/\n`)).toEqual({
+        default_registry_url: "http://example.com/npm/",
+        default_registry_token: "s3cret",
+        default_registry_username: "",
+        default_registry_password: "",
+        default_registry_email: "",
+      });
+    });
+
+    test("a URL without credentials is kept as written", () => {
+      expect(loadNpmrc(`registry=http://example.com/npm\n`).default_registry_url).toBe("http://example.com/npm");
+    });
+  });
+
   it("does not print an undecodable _password value", async () => {
     const secret = "s!ecret!pass";
     using dir = tempDir("npmrc-password-decode", {


### PR DESCRIPTION
### Problem
- A registry URL whose userinfo has a username but no password, `registry=http://carol@127.0.0.1:PORT/` in `.npmrc` (same for `http://carol:@...`, and for the bunfig string and object forms, `[install.scopes]`, `@scope:registry=`, `--registry` and `BUN_CONFIG_REGISTRY` / `NPM_CONFIG_REGISTRY` / `npm_config_registry`), sends no `Authorization` header; `bun install` exits 1 and `bun publish` stops with `error: missing authentication`. npm 11 sends `Authorization: Basic Y2Fyb2w6` (base64 of `carol:`) for the same `.npmrc`: a username without a password is a username with an empty password. `http://carol:s3cret@...` (Basic) and `http://:token@...` (Bearer) already work. Found while working on the tarball URL credentials change (#39025); not from a user report.
- Cause: `NpmRegistry::from_url` (`src/options_types/schema.rs`), the one place every registry URL string is split, only handles the `user:pass@` and `:token@` shapes. A username without a password falls into the branch for URLs without credentials, which stores the URL as written (userinfo included) and sets no `username`, so `Scope::from_api` (`src/install/npm.rs`) builds no `auth`, and the userinfo left in the URL is never sent (requests only send `Scope.token` / `Scope.auth`).
- `from_api` has a second reason to drop it: it only encodes the `username` / `password` pair when both are non-empty. That rule is right for credentials configured as separate keys (npm ignores `//host/:username=` without `//host/:_password=`, and a bunfig `password = "$VAR"` that expands to nothing must not turn into a Basic header), so it cannot simply be relaxed.
- Related, not changed here: bun's own URL scanner still reads `user@host:port` (username, no colon, explicit port) as a hostname, #16181, which #38043 fixes. Until that lands, the with-port spelling of this bug is reachable as `user:@host:port` (the tests use it), and `user@host` without a port already reaches `from_url` correctly; with #38043 both spellings arrive here the same way and take the branch added by this PR.

### Fix
- `from_url` splits every URL that carries a username (password possibly empty) into `username` / `password`, strips the userinfo from the stored URL as it already did for the other shapes, and sets a new `NpmRegistry.credentials_from_url` flag (also set for the `:token@` shape, so the flag means "the credentials were taken out of the URL"). `Scope::from_api` encodes the pair when the password is non-empty or the flag is set, so `http://user@host/` produces `Scope.auth = base64("user:")` and the request URL no longer contains the userinfo (`bun pm whoami` keeps printing `user`, now from `Scope.user` instead of from the userinfo left in the URL).
- Why a flag rather than relaxing the pair rule: the same `NpmRegistry` carries credentials that came from config keys, and for those "username without password" must keep meaning "no credentials" (npm parity for `.npmrc`, and the `$VAR` case above). The flag only rides along with credentials `from_url` produced; the bunfig object form already rebuilds the struct from `Default` when `username` / `password` / `token` keys are present, so keys keep the key semantics, and `.npmrc` `//host/` lines are only applied to registries without credentials (`has_credentials`, unchanged), as before.
- Behaviour for every previously working shape is unchanged: `user:pass@` sets the same fields plus the flag, which is irrelevant when the password is non-empty; `:token@` is unchanged apart from the flag, which nothing reads for tokens; URLs without userinfo take the same branch as before.
- Verified:
  - `test/cli/install/config-precedence.test.ts`: `user:@` through each of the seven ways a registry URL reaches bun (bunfig string, bunfig object, bunfig scope, `.npmrc` `registry=`, `.npmrc` `@scope:registry=`, `--registry`, `BUN_CONFIG_REGISTRY`) sends `Basic base64("config-precedence:")` on both the manifest and the tarball request and installs; on the released build all seven fail (no header, install error). Two guards pin that a bunfig `username` key without `password` and an `.npmrc` `:username=` line without `:_password=` still send nothing.
  - `test/cli/install/npmrc.test.ts` (`loadNpmrc`): `registry=http://carol@example.com/npm/` and `http://carol:@.../` (no port, so the brief's exact spelling) yield `username: "carol"`, `password: ""` and `url: "http://example.com/npm/"`; both fail on the released build (URL kept with userinfo, no username). `user:pass@`, `:token@` and a URL without credentials are guards.
  - `test/cli/install/bun-publish.test.ts`: `bun publish --registry http://pubuser:@...` sends one PUT with `Basic base64("pubuser:")` and prints the registry without userinfo; on the released build it fails with `missing authentication`.
  - With the debug build: the whole of `config-precedence.test.ts` (60), `npmrc.test.ts` (45), `redacted-config-logs.test.ts` (16), the `credentials in the registry url` group of `bun-publish.test.ts`, and the `whoami` group of `bun-install-registry.test.ts`; `cargo fmt --check`.
- Overlap with open work: #38834 copies `token` / `username` / `password` out of a `from_url` result inside `from_api` (for `registry = "$VAR"`); once both land, that copy needs to carry `credentials_from_url` too, otherwise `$VAR` pointing at a `user@` URL keeps this bug (I will note it there). #38812 changes `href_without_auth` to emit a single slash for a path-less URL; the tests here use URLs with a path or go through a registry that accepts both, so they pass either way. #37095 moves `NpmRegistry`; the change here is a field and a branch and rebases onto either copy.

### Background
- `NpmRegistry` (`src/options_types/schema.rs`) is the parsed config for one registry: `url` plus `username` / `password` / `token`. Every registry URL string (bunfig string and object `url`, `.npmrc` `registry=` and `@scope:registry=`, `--registry`, the registry env vars) goes through `NpmRegistry::from_url`, which moves credentials written into the URL's userinfo into those fields and stores the URL without them. `.npmrc` `//host/:key=` lines and bunfig `username` / `password` / `token` keys fill the same fields.
- `Scope::from_api` (`src/install/npm.rs`) turns an `NpmRegistry` into the `Scope` the package manager uses: `token` is sent as `Authorization: Bearer`, `auth` (base64 `user:password`, built from the pair) as `Authorization: Basic`; `user` keeps the plain pair for `bun pm whoami`. Requests never read the URL's userinfo, so credentials that stay in the URL are simply not sent.
- Userinfo: the `user:password@` part of a URL. `new URL("http://carol@h/")` reports `username: "carol", password: ""`, and npm's fetch layer turns that into `Basic base64("carol:")`; npm's config layer, by contrast, only uses a `username` / `_password` pair when both are set. This PR gives bun the same two rules.

<details>
<summary>Reproduction with a mock registry that records the Authorization header (released bun 1.4.0)</summary>

`.npmrc` is `registry=http://<userinfo>@127.0.0.1:PORT/`, `package.json` depends on `no-deps@1.0.0`:

```
carol:s3cret@   exit 0   GET /no-deps  authorization=Basic Y2Fyb2w6czNjcmV0   (tarball: same)
:tok@           exit 0   GET /no-deps  authorization=Bearer tok                (tarball: same)
carol:@         exit 1   no request reaches the handler; "no-deps@1.0.0 failed to resolve"
carol@          exit 1   "GET http://carol@127.0.0.1:PORT/no-deps - 400" (#16181: the userinfo ends up in the Host header)
```

With this change, `carol:@` sends `Basic Y2Fyb2w6` on the manifest and the tarball and exits 0; `carol@` with a port additionally needs #38043, and without a port (`loadNpmrc` test) is split correctly.

</details>
