### PR TITLE
webview: unwrap null and non-JSON numbers in the Chrome console callback

### DIFF
--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -26,6 +26,7 @@
 #include <wtf/text/Base64.h>
 
 #include <errno.h>
+#include <limits>
 #include <mutex>
 #include <stdio.h>
 #include <stdlib.h>
@@ -1153,12 +1154,24 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         auto remoteToJS = [&](RefPtr<JSON::Object> ao) -> JSValue {
             auto t = ao->getString("type"_s);
             if (t == "string"_s) return jsString(vm, ao->getString("value"_s));
-            if (t == "number"_s) return jsNumber(ao->getDouble("value"_s).value_or(0));
+            if (t == "number"_s) {
+                if (auto d = ao->getDouble("value"_s)) return jsNumber(*d);
+                // NaN, Infinity, -Infinity and -0 have no JSON form: V8 omits
+                // .value and sends .unserializableValue holding that name.
+                auto u = ao->getString("unserializableValue"_s);
+                if (u == "-0"_s) return jsNumber(-0.0);
+                if (u == "Infinity"_s) return jsNumber(std::numeric_limits<double>::infinity());
+                if (u == "-Infinity"_s) return jsNumber(-std::numeric_limits<double>::infinity());
+                return jsNaN();
+            }
             if (t == "boolean"_s) return jsBoolean(ao->getBoolean("value"_s).value_or(false));
             if (t == "undefined"_s) return jsUndefined();
             if (t == "bigint"_s || t == "symbol"_s)
                 // No .value — .description is "42n" / "Symbol(foo)".
                 return jsString(vm, ao->getString("description"_s));
+            // CDP encodes null as {type:"object", subtype:"null"}. It is a
+            // primitive to the user, so it unwraps like the cases above.
+            if (t == "object"_s && ao->getString("subtype"_s) == "null"_s) return jsNull();
             // object / function. JSONParse the whole RemoteObject so the
             // caller can inspect preview.properties. toJSONString round-
             // trips the WTF::JSON tree back to a string; JSC::JSONParse

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -926,6 +926,30 @@ it("chrome: console callback receives (type, ...args)", async () => {
   expect(calls[2]).toEqual(["error", "boom"]);
 });
 
+it("chrome: console callback unwraps args whose RemoteObject has no value field", async () => {
+  const calls: unknown[][] = [];
+  await using view = new Bun.WebView({
+    backend: chrome,
+    width: 200,
+    height: 200,
+    console: (...call: unknown[]) => calls.push(call),
+  });
+  await view.navigate(html("<body></body>"));
+  // CDP encodes null as {type:"object", subtype:"null"} and the numbers JSON
+  // can't carry as {type:"number", unserializableValue:"NaN"} with no value
+  // field. The callback still has to receive the primitive itself.
+  await view.evaluate("console.log(null, NaN, Infinity, -Infinity, -0)");
+  // bigint and symbol have no value field either; they arrive as their
+  // description string.
+  await view.evaluate("console.log(undefined, 1n, Symbol('q'))");
+
+  expect(calls).toEqual([
+    ["log", null, NaN, Infinity, -Infinity, -0],
+    ["log", undefined, "1n", "Symbol(q)"],
+  ]);
+  expect(Object.is(calls[0][5], -0)).toBe(true);
+});
+
 it("chrome: console: globalThis.console forwards to parent's stdout", async () => {
   // Subprocess so stdout capture is clean and the globalThis.console
   // identity check hits the subprocess's own console.
@@ -940,6 +964,7 @@ it("chrome: console: globalThis.console forwards to parent's stdout", async () =
       });
       await view.navigate("data:text/html,<body></body>");
       await view.evaluate("console.log('from page', 1, 2)");
+      await view.evaluate("console.log(null, NaN, Infinity, -Infinity, -0)");
       await view.evaluate("console.error('page error')");
       view.close();
       `,
@@ -950,10 +975,9 @@ it("chrome: console: globalThis.console forwards to parent's stdout", async () =
   });
   const [stdout, stderr, exit] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   // ConsoleClient::logWithLevel — Bun's formatter applies. Log → stdout,
-  // Error → stderr. The args forward with Bun's util.inspect formatting.
-  expect(stdout).toContain("from page");
-  expect(stdout).toContain("1");
-  expect(stdout).toContain("2");
+  // Error → stderr. The args forward with Bun's util.inspect formatting, so
+  // the second line reads exactly as a local console.log of those values.
+  expect(stdout).toBe("from page 1 2\nnull NaN Infinity -Infinity -0\n");
   expect(stderr).toContain("page error");
   expect(exit).toBe(0);
 });


### PR DESCRIPTION
### Problem
- `new Bun.WebView({ backend: "chrome", console: (type, ...args) => ... })`: a page-side `console.log(null)` hands the callback `{ type: "object", subtype: "null", value: null }` instead of `null`.
- Same callback: `console.log(NaN, Infinity, -Infinity, -0)` in the page arrives as `0, 0, 0, 0`.
- `console: globalThis.console` is affected the same way, since it shares the conversion: the parent prints the null wrapper as an object and the four numbers as `0`.
- The `console` option is documented (`docs/runtime/webview.mdx`, `ConsoleCapture` in `packages/bun-types/bun.d.ts`) as unwrapping primitive arguments to their raw values; only objects are supposed to arrive as the CDP descriptor.
- Cause: `remoteToJS` in the `Runtime.consoleAPICalled` handler (`src/runtime/webview/ChromeBackend.cpp`, `Transport::handleEvent`) only looks at `RemoteObject.type` and `RemoteObject.value`. CDP encodes `null` as `type: "object"` with `subtype: "null"`, so it fell into the object branch; and for numbers JSON cannot represent V8 omits `value` and sends `unserializableValue` instead, so `getDouble("value").value_or(0)` produced `0`.

### Fix
- `type: "number"` without a `value` field now maps `unserializableValue` `"-0"` / `"Infinity"` / `"-Infinity"` to those numbers and anything else (`"NaN"`) to NaN.
- `type: "object"` with `subtype: "null"` now returns `null` before the generic object branch.
- This is the behavior the option documents, and it is what the WebKit backend already does for `null` (its arguments travel through `JSON.stringify`, so `null` round-trips as `null`). Regular numbers, strings, booleans, `undefined`, the bigint/symbol description strings, and object descriptors are unchanged.
- `evaluate()` decodes `Runtime.evaluate` results in a separate code path (`Method::RuntimeEvaluate`) and has a different documented contract (a JSON round trip), so it is intentionally not touched here; its handling of these numbers is tracked separately.
- Tests, in `test/js/bun/webview/webview-chrome.test.ts`:
  - new `chrome: console callback unwraps args whose RemoteObject has no value field` asserts the whole callback argument list for `null, NaN, Infinity, -Infinity, -0` (plus `undefined`, bigint and symbol, which share the "no value field" shape) and checks `-0` with `Object.is`.
  - `chrome: console: globalThis.console forwards to parent's stdout` additionally logs the same values and now asserts the exact stdout (`null NaN Infinity -Infinity -0`), covering the `ConsoleClient` dispatch path.
  - Before the fix both fail (`null` arrives as the wrapper object, the numbers as `0`); with the fix the whole file passes (52 tests). The container runs as root, so the runs used `BUN_CHROME_PATH` pointing at a wrapper that adds `--no-sandbox`; both the runtime and the test file's `findChrome()` honor that variable.
  - Also ran the console tests with `BUN_JSC_validateExceptionChecks=1`, clean.

### Background
- CDP (Chrome DevTools Protocol) is the JSON protocol the Chrome backend speaks to the browser. `Runtime.consoleAPICalled` is the event Chrome emits for each page-side `console.*` call; its `args` are `RemoteObject`s, not the values themselves.
- A `RemoteObject` describes a value: `type` (`string`, `number`, `boolean`, `undefined`, `bigint`, `symbol`, `object`, `function`), an optional `subtype` for objects (`null`, `array`, `date`, ...), and for primitives either `value` (when JSON can carry it) or `unserializableValue` (a string naming a value JSON cannot carry: `"NaN"`, `"Infinity"`, `"-Infinity"`, `"-0"`, or a bigint literal such as `"1n"`). JavaScript `null` is the one primitive CDP reports with `type: "object"`.
- `remoteToJS` is the Chrome backend's conversion from a `RemoteObject` to the JS value passed to the user's callback (or to Bun's console when the option is `globalThis.console`).
