### PR TITLE
cjs: export non-enumerable data properties of __esModule modules on the slow enumeration path too

### DIFF
--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -1058,7 +1058,9 @@ void populateESMExports(
                 });
             } else {
                 JSC::PropertyNameArrayBuilder properties(vm, JSC::PropertyNameMode::Strings, JSC::PrivateSymbolMode::Exclude);
-                exports->methodTable()->getOwnPropertyNames(exports, globalObject, properties, DontEnumPropertiesMode::Exclude);
+                // Include, like the fast path above: non-enumerable data properties are exports too.
+                // The DontEnum check on each slot below filters out the non-enumerable accessors.
+                exports->methodTable()->getOwnPropertyNames(exports, globalObject, properties, DontEnumPropertiesMode::Include);
                 if (scope.exception()) [[unlikely]] {
                     if (!vm.hasPendingTerminationException()) (void)scope.tryClearException();
                     return;

--- a/test/cli/run/esm-defineProperty.test.ts
+++ b/test/cli/run/esm-defineProperty.test.ts
@@ -1,4 +1,6 @@
 import { expect, test } from "bun:test";
+import { bunRun, tempDir } from "harness";
+import { join } from "path";
 import * as CJSArrayLike from "./cjs-defineProperty-arraylike.cjs";
 import * as CJS from "./cjs-defineProperty-fixture.cjs";
 import * as Self from "./esm-defineProperty.test.ts";
@@ -42,4 +44,73 @@ test("arraylike", () => {
     "4": [Getter],
   },
 }`);
+});
+
+// The namespace of a CommonJS module is built by walking module.exports. An object holding only
+// data properties is walked through its Structure ("fast"); an accessor or an index on it, or a
+// function as module.exports, switches to getOwnPropertyNames ("slow"). With __esModule set, a
+// non-enumerable data property (the "defineProperty" rule above) has to come out the same either way.
+test.concurrent("__esModule: non-enumerable data exports are exported on both enumeration paths", async () => {
+  const esModule = `Object.defineProperty(exports, "__esModule", { value: true });`;
+  const hidden = `Object.defineProperty(exports, "hidden", { value: 2 });`;
+  // What tsc and babel emit for `export { x } from "./x"`.
+  const reexport = `Object.defineProperty(exports, "reexport", { enumerable: true, get: () => 3 });`;
+  using dir = tempDir("cjs-esmodule-dontenum", {
+    "data-fast.cjs": `${esModule} exports.visible = 1; ${hidden}`,
+    "data-slow-getter.cjs": `${esModule} exports.visible = 1; ${hidden} ${reexport}`,
+    "data-slow-indexed.cjs": `${esModule} exports.visible = 1; ${hidden} exports[0] = "zero";`,
+    // Non-enumerable accessors are not exports (see "defineProperty" above); that rule still applies.
+    "accessor-slow.cjs": `${esModule} ${hidden} Object.defineProperty(exports, "hiddenGetter", { get: () => 4 });`,
+    "default-fast.cjs": `${esModule} Object.defineProperty(exports, "default", { value: "own default" });`,
+    "default-slow.cjs": `${esModule} Object.defineProperty(exports, "default", { value: "own default" }); ${reexport}`,
+    "function-slow.cjs": `
+      module.exports = function fn() {};
+      Object.defineProperty(module.exports, "__esModule", { value: true });
+      Object.defineProperty(module.exports, "hidden", { value: 2 });
+    `,
+    "main.mjs": `
+      import * as dataFast from "./data-fast.cjs";
+      import * as dataSlowGetter from "./data-slow-getter.cjs";
+      import * as dataSlowIndexed from "./data-slow-indexed.cjs";
+      import * as accessorSlow from "./accessor-slow.cjs";
+      import * as defaultFast from "./default-fast.cjs";
+      import * as defaultSlow from "./default-slow.cjs";
+      import * as functionSlow from "./function-slow.cjs";
+      for (const [name, ns] of Object.entries({ dataFast, dataSlowGetter, dataSlowIndexed, accessorSlow, defaultFast, defaultSlow })) {
+        const dflt = typeof ns.default === "object" ? "module.exports" : JSON.stringify(ns.default);
+        console.log(name.padEnd(16), JSON.stringify(Object.keys(ns)).padEnd(42), "hidden:", ns.hidden, "default:", dflt);
+      }
+      // A function's own length/name/prototype also show up here, so only the property under test is printed.
+      console.log("functionSlow".padEnd(16), "hidden:", functionSlow.hidden, "default:", typeof functionSlow.default);
+    `,
+  });
+
+  const result = await bunRun(join(String(dir), "main.mjs"));
+  expect(result.stdout).toMatchInlineSnapshot(`
+    "dataFast         ["default","hidden","visible"]             hidden: 2 default: module.exports
+    dataSlowGetter   ["default","hidden","reexport","visible"]  hidden: 2 default: module.exports
+    dataSlowIndexed  ["0","default","hidden","visible"]         hidden: 2 default: module.exports
+    accessorSlow     ["default","hidden"]                       hidden: 2 default: module.exports
+    defaultFast      ["default"]                                hidden: undefined default: "own default"
+    defaultSlow      ["default","reexport"]                     hidden: undefined default: "own default"
+    functionSlow     hidden: 2 default: function"
+  `);
+  expect(result).toSpawn();
+});
+
+test.concurrent("__esModule: named import of a non-enumerable data export enumerated on the slow path", async () => {
+  using dir = tempDir("cjs-esmodule-dontenum-named-import", {
+    "exports.cjs": `
+      Object.defineProperty(exports, "__esModule", { value: true });
+      Object.defineProperty(exports, "hidden", { value: 2 });
+      Object.defineProperty(exports, "reexport", { enumerable: true, get: () => 3 });
+    `,
+    "main.mjs": `
+      import { hidden } from "./exports.cjs";
+      console.log(hidden);
+    `,
+  });
+
+  // Without the export this fails to link: "Export named 'hidden' not found".
+  expect(await bunRun(join(String(dir), "main.mjs"))).toSpawn("2");
 });


### PR DESCRIPTION
### Problem
- Importing a CommonJS module that sets `__esModule` gives a different namespace depending on how `module.exports` gets enumerated. A non-enumerable data property (`Object.defineProperty(exports, "hidden", { value: 1 })`) is a named export when `exports` holds only data properties, but disappears as soon as the object also has an accessor (what tsc and babel emit for `export { x } from`), an index, or is a function. `import { hidden } from "./x.cjs"` then fails to link with `SyntaxError: Export named 'hidden' not found in module`.
- The same applies to a non-enumerable `default` property: on the affected path it is not seen, so the default export falls back to the `module.exports` object instead of the defined value.
- Cause: `populateESMExports` in `src/jsc/bindings/JSCommonJSModule.cpp` has a fast and a slow walk for each of the `__esModule` and non-`__esModule` cases. The `__esModule` slow walk called `getOwnPropertyNames` with `DontEnumPropertiesMode::Exclude` (line 1061), so non-enumerable properties never reached the `DontEnum` check a few lines below it. The other three walks see them: the fast walks read every property off the Structure, and the non-`__esModule` slow walk already passes `Include`.
- The fix for #4432 (9076b369f0) is where this comes from: it removed the enumerability filter from both fast walks and added the per-slot `DontEnum` check to both slow walks, but only switched the non-`__esModule` slow walk to `Include`. The check it added to the `__esModule` slow walk has been unreachable since.
- Reproduces on 1.4.0 and on main. The shape without `__esModule` is already consistent.

### Fix
- Pass `DontEnumPropertiesMode::Include` on the `__esModule` slow walk too, so the existing per-slot check decides on every path: non-enumerable data properties are exported, non-enumerable accessors are skipped.
- This is the rule the fast walk has applied to `__esModule` modules since #4432, so the two walks now agree; which one runs is an engine detail (whether the object has an accessor or an index, or is a function) that should not change the namespace. It also matches Node, which exports a `defineProperty` data export regardless of enumerability.
- The `__esModule` marker itself is usually defined non-enumerable (`Object.defineProperty(exports, "__esModule", { value: true })`). It is now listed by the walk and dropped by the existing `property == esModuleMarker` check; the tests cover that it does not show up as a named export.
- Behavior change outside the repro: a function, class or array used as `module.exports` together with `__esModule` now also gets its own non-enumerable `length`/`name`/`prototype` as named exports, which is what the non-`__esModule` path already does for those shapes today. #33888 removes those intrinsics on all four paths and applies on top of this change.
- Verified with `test/cli/run/esm-defineProperty.test.ts`: the two new tests fail without the src change (snapshot differs on every slow-path line; the named import fails to link) and pass with it.
- Also ran `test/js/bun/resolve/`, `test/js/bun/plugin/plugins.test.ts`, `test/js/bun/import-attributes/`, and the `@azure`, `grpc-js`, `jsonwebtoken`, `comlink`, `yargs`, `body-parser` and `express` third-party suites (tsc and babel output) against the debug build; the only failures are network and timeout ones that fail the same way without this change.

### Background
- When ESM imports a CommonJS module, Bun evaluates the module and then builds the namespace from the resulting `module.exports` object in `populateESMExports`. Node does this differently, by lexing the source for export patterns, which is why Node does not care about enumerability either.
- `__esModule` is the marker tsc and babel put on `exports` of a compiled ES module. When it is set, Bun uses the module's own `default` property as the default export (Babel semantics) instead of the whole `module.exports` object, and does not export the marker itself.
- `populateESMExports` has two ways of listing properties. If the object is a plain object with only data properties, it iterates the JSC Structure directly (fast). Otherwise (own accessor, indexed property, or a type such as a function that customizes property lookup) it goes through `getOwnPropertyNames` (slow). `DontEnumPropertiesMode` is the argument that tells `getOwnPropertyNames` whether to list non-enumerable (`DontEnum`) properties.
- The rule from #4432: a non-enumerable data property on `exports` is an export, a non-enumerable accessor is not. On the slow walks that is implemented by looking at each property's slot after the names have been listed, which only works if the non-enumerable names are listed in the first place.
