### PR TITLE
test: keep node's stdio streams out of the serve-http3 fixtures

### DIFF
--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -27,7 +27,18 @@ const DEAD_PORT_ABORT_MS = 1000;
 // onto the dead conn. us_quic_listen_socket_close() flushes CONNECTION_CLOSE
 // synchronously during stop(true); the trailing setTimeout gives the kernel a
 // tick to deliver the loopback datagram before the process exits.
-const STOP_ON_STDIN_END = `process.stdin.on("end", () => { server.stop(true); setTimeout(() => process.exit(0), 100); });`;
+//
+// stdin is read through Bun.stdin.stream() rather than process.stdin: the first
+// access to process.stdin (or process.stdout) initializes node's stream stack,
+// which takes over a second per fixture, i.e. per test, in a debug build.
+const STDIN_HELPERS = `
+async function readStdin(onChunk = () => {}) {
+  for await (const chunk of Bun.stdin.stream()) onChunk(new TextDecoder().decode(chunk));
+}
+function stopOnStdinEnd(onChunk) {
+  readStdin(onChunk).then(() => { server.stop(true); setTimeout(() => process.exit(0), 100); });
+}
+`;
 
 const fixture = `
 import { serve } from "bun";
@@ -103,8 +114,15 @@ const server = serve({
       });
     }
     if (url.pathname === "/spawn") {
+      // 40 lines of 1000 "x", one pipe write each. Bun.write rather than
+      // process.stdout for the reason given at STDIN_HELPERS: the child is a
+      // second debug-build process, so it would pay that startup cost again.
       const p = Bun.spawn({
-        cmd: [process.execPath, "-e", "for(let i=0;i<40;i++)process.stdout.write('x'.repeat(1000)+String.fromCharCode(10))"],
+        cmd: [
+          process.execPath,
+          "-e",
+          "const line = Buffer.alloc(1001, 'x'); line[1000] = 10; for (let i = 0; i < 40; i++) await Bun.write(Bun.stdout, line);",
+        ],
         stdout: "pipe",
       });
       return new Response(p.stdout, { headers: { "content-type": "text/plain" } });
@@ -161,8 +179,8 @@ const server = serve({
 });
 
 console.error("PORT=" + server.port);
-process.stdin.on("data", () => {});
-${STOP_ON_STDIN_END}
+${STDIN_HELPERS}
+stopOnStdinEnd();
 `;
 
 async function withServer(
@@ -309,7 +327,8 @@ describe("Bun.serve HTTP/3", () => {
       const url = new URL(server.url);
       console.error("URLPORT=" + url.port);
       console.error("ADDR=" + JSON.stringify(server.address));
-      process.stdin.on("data", async () => {
+      ${STDIN_HELPERS}
+      readStdin(async () => {
         await server.stop();
         console.error("STOPPED");
       });
@@ -343,8 +362,8 @@ describe("Bun.serve HTTP/3", () => {
         },
       });
       console.error("PORT=" + server.port);
-      process.stdin.on("data", () => {});
-      ${STOP_ON_STDIN_END}
+      ${STDIN_HELPERS}
+      stopOnStdinEnd();
     `;
     await withCustomServer(script, async port => {
       // 256 KB body via ReadableStream → no Content-Length on the wire.
@@ -402,8 +421,8 @@ describe("Bun.serve HTTP/3", () => {
         fetch: req => new Response("from-fetch:" + req.method),
       });
       console.error("PORT=" + server.port);
-      process.stdin.on("data", () => {});
-      ${STOP_ON_STDIN_END}
+      ${STDIN_HELPERS}
+      stopOnStdinEnd();
     `;
     await withCustomServer(script, async port => {
       expect(await fetchH3(port, "/anything").then(r => r.text())).toBe("from-route");
@@ -870,8 +889,8 @@ describe("Bun.serve HTTP/3 lifecycle", () => {
         fetch: () => new Response("fallback", { status: 404 }),
       });
       console.error("PORT=" + server.port);
-      process.stdin.setEncoding("utf8");
-      process.stdin.on("data", line => {
+      ${STDIN_HELPERS}
+      stopOnStdinEnd(line => {
         if (line.includes("reload")) {
           server.reload({
             routes: { "/new": new Response("new-route") },
@@ -880,7 +899,6 @@ describe("Bun.serve HTTP/3 lifecycle", () => {
           console.error("RELOADED");
         }
       });
-      ${STOP_ON_STDIN_END}
     `;
     await withCustomServer(script, async (port, send, waitForStderr) => {
       expect(await fetchH3(port, "/old").then(r => r.text())).toBe("old-route");
@@ -919,8 +937,8 @@ describe("Bun.serve HTTP/3 lifecycle", () => {
         console.error("PORT=" + server.port);
       };
       start(0);
-      process.stdin.setEncoding("utf8");
-      process.stdin.on("data", async line => {
+      ${STDIN_HELPERS}
+      stopOnStdinEnd(async line => {
         if (line.includes("stop")) {
           // Let the delayed-ACK timer fire so send_ctl has nothing scheduled
           // when listen_socket_close runs; that's the state in which the old
@@ -932,7 +950,6 @@ describe("Bun.serve HTTP/3 lifecycle", () => {
           console.error("RESTARTED");
         }
       });
-      ${STOP_ON_STDIN_END}
     `;
     await withCustomServer(script, async (port, send, waitForStderr) => {
       // Warm the pooled client session.
@@ -976,8 +993,8 @@ describe("Bun.serve HTTP/3 lifecycle", () => {
         fetch: () => new Response("alive"),
       });
       console.error("PORT=" + server.port);
-      process.stdin.setEncoding("utf8");
-      process.stdin.on("data", async line => {
+      ${STDIN_HELPERS}
+      readStdin(async line => {
         if (line.includes("stop")) {
           server.stop(true);
           // give the timer one tick to prove it doesn't deref freed peer_ctx
@@ -1115,8 +1132,8 @@ describe("Bun.serve HTTP/3 lifecycle", () => {
         },
       });
       console.error("PORT=" + server.port);
-      process.stdin.setEncoding("utf8");
-      process.stdin.on("data", line => {
+      ${STDIN_HELPERS}
+      readStdin(line => {
         if (line.includes("stop")) { stopping = true; server.stop(); }
         if (line.includes("exit")) process.exit(0);
       });
@@ -1150,7 +1167,8 @@ describe("Bun.serve HTTP/3 lifecycle", () => {
           fetch: () => new Response("ok"),
         });
         console.error("PORT=" + server.port);
-        process.stdin.once("data", () => server.stop());
+        ${STDIN_HELPERS}
+        readStdin(() => server.stop());
       `,
     });
     const proc = Bun.spawn({
@@ -1197,8 +1215,8 @@ describe("Bun.serve HTTP/3 lifecycle", () => {
         },
       });
       console.error("PORT=" + server.port);
-      process.stdin.on("data", () => {});
-      ${STOP_ON_STDIN_END}
+      ${STDIN_HELPERS}
+      stopOnStdinEnd();
     `;
     await withCustomServer(script, async port => {
       // Warm the QUIC connection so the /hang stream is actually bound
@@ -1290,8 +1308,8 @@ describe("Bun.serve HTTP/3 production", () => {
         },
       });
       console.error("PORT=" + server.port);
-      process.stdin.on("data", () => {});
-      ${STOP_ON_STDIN_END}
+      ${STDIN_HELPERS}
+      stopOnStdinEnd();
     `;
     await withCustomServer(script, async port => {
       const res = await fetchH3(port, "/");


### PR DESCRIPTION
### Problem
- `test/js/bun/http/serve-http3.test.ts` fails under a debug (ASAN) build on a loaded machine with `(fail) Bun.serve HTTP/3 adversarial > Response(subprocess.stdout) streams over H3 [5004.13ms]`, the 5 s default per-test timeout. Reproduced here on unmodified main: 50 pass, 1 fail, the test at 4.06 s, 4.52 s and 4.96 s when run alone.
- The fixture's `/spawn` route (`serve-http3.test.ts:116`) runs a second debug-build `bun -e` child that writes through `process.stdout`. The first access to `process.stdout` initializes node's stream stack, which takes 1.3 to 1.7 s in a debug build here (`bun -e "process.exit(0)"` takes about 0.5 s, `bun -e "process.stdout; process.exit(0)"` about 1.8 to 2.5 s). The child's bun startup itself is about 0.4 s.
- Every fixture in the file pays the same cost once more: each one reads its stop signal through `process.stdin` (`STOP_ON_STDIN_END`), and that initialization runs right after the fixture prints `PORT=`, so the test's first request waits behind it. Measured from the test process: 0.8 to 1.2 s from spawn to `PORT=`, then 1.3 to 1.7 s for the `process.stdin` hookup, against 2 to 34 ms with `Bun.stdin.stream()`. That is why the median test in this file took 2.8 s and the subprocess test, which paid the cost twice, was the one that went over.

### Fix
- The fixtures read stdin through `Bun.stdin.stream()` instead of `process.stdin`. A shared `STDIN_HELPERS` snippet defines `readStdin(onChunk)`, which resolves at EOF, and `stopOnStdinEnd(onChunk)`, which runs the existing `server.stop(true)` + exit sequence at EOF. Each fixture keeps its previous behavior: the plain ones call `stopOnStdinEnd()`, the reload and stop/restart fixtures pass their command handler to it, and the fixtures that did not stop on stdin end (they stop or exit on a command, or exit naturally) call `readStdin(handler)` only.
- The `/spawn` child writes its 40 lines with `Bun.write(Bun.stdout, line)`, one pipe write per line, instead of `process.stdout.write`. The response body the test asserts on (40 lines of 1000 `x`, 40040 bytes) is unchanged.
- This is correct to do because what the file tests is the HTTP/3 server, and the stdin reads and the child's writes are only the fixtures' plumbing. The native APIs give the plumbing the same observable behavior: a pending `Bun.stdin.stream()` read keeps the fixture alive until the test closes stdin (checked directly: a fixture with nothing else running waited 1.5 s for the first chunk, got one chunk per write, and exited on EOF), so every fixture still takes the `stop(true)` path that the comment above `STDIN_HELPERS` explains, and `Bun.write` to a pipe waits for writability rather than dropping data (`src/runtime/webcore/blob/write_file.rs`, `could_block`). `Response(subprocess.stdout)` is still a pipe-backed native stream, so the response still goes through `H3ResponseSink`; the child's output now arrives in a few chunks instead of about 16, which is what it already did under a release build, where the 40 writes finish well inside a millisecond.
- Verified with `bun bd test test/js/bun/http/serve-http3.test.ts` (debug + ASAN, host load average 150 to 250), back to back with the unmodified file: before, 50 pass / 1 fail in 139 s, median test 2.77 s; after, 51 pass in 61 to 65 s across three runs (one of them on a debug build of current main), median 1.06 s, the subprocess test at 1.5 to 1.8 s, and the slowest test apart from the ASAN loop with its own 30 s timeout at 2.1 s (it includes a deliberate 1 s dead-port wait).
- Windows x64 with the release canary of the same main (`USE_SYSTEM_BUN=1 bun test`, three runs): 50 pass / 1 skip before and after, 10.4 s to 9.6 s; every fixture-backed test got 12 to 16 ms faster and none got slower, which also shows each fixture still exits on stdin close rather than hitting the 1 to 2 s kill fallback in `withServer` / `withCustomServer`.
- `h3-only server exits naturally after stop() drains`, the one test whose assertion is about what holds the event loop open, still passes (0.56 to 0.86 s debug, 32 ms release), so the finished stdin read does not keep the process alive.

### Background
- Fixtures in this file are separate `bun` processes started per test. The test signals teardown by closing the fixture's stdin; the fixture answers with `server.stop(true)`, which sends QUIC `CONNECTION_CLOSE` so the test process's pooled HTTP/3 session is dropped instead of lingering on a port a later fixture might reuse. The helpers in `withServer` / `withCustomServer` fall back to killing the fixture after 2 s / 1 s if it does not exit on its own.
- `process.stdin` and `process.stdout` are lazy getters. The first access loads `node:tty`, `node:net` and the `node:stream` implementation behind them. In a release build that is a few tens of milliseconds; in a debug build (no JIT, assertions, ASAN) it is over a second per process.
- `Bun.stdin.stream()` returns a ReadableStream over fd 0 backed by the runtime's native pipe reader, and `Bun.write(Bun.stdout, data)` writes to fd 1 through the native file writer. Neither loads the node stream modules.
