### PR TITLE
WebSocket client: ping(undefined) and pong(undefined) send an empty frame

### DIFF
--- a/src/jsc/bindings/webcore/JSWebSocket.cpp
+++ b/src/jsc/bindings/webcore/JSWebSocket.cpp
@@ -830,6 +830,8 @@ static inline JSC::EncodedJSValue jsWebSocketPrototypeFunction_pingOverloadDispa
         RELEASE_AND_RETURN(throwScope, (jsWebSocketPrototypeFunction_ping1Body(lexicalGlobalObject, callFrame, castedThis)));
     } else if (argsCount == 1) {
         JSValue distinguishingArg = callFrame->uncheckedArgument(0);
+        if (distinguishingArg.isUndefined())
+            RELEASE_AND_RETURN(throwScope, (jsWebSocketPrototypeFunction_ping1Body(lexicalGlobalObject, callFrame, castedThis)));
         if (distinguishingArg.isObject() && asObject(distinguishingArg)->inherits<JSArrayBuffer>())
             RELEASE_AND_RETURN(throwScope, (jsWebSocketPrototypeFunction_ping2Body(lexicalGlobalObject, callFrame, castedThis)));
         if (distinguishingArg.isObject() && asObject(distinguishingArg)->inherits<JSArrayBufferView>())
@@ -909,6 +911,8 @@ static inline JSC::EncodedJSValue jsWebSocketPrototypeFunction_pongOverloadDispa
         RELEASE_AND_RETURN(throwScope, (jsWebSocketPrototypeFunction_pong1Body(lexicalGlobalObject, callFrame, castedThis)));
     } else if (argsCount == 1) {
         JSValue distinguishingArg = callFrame->uncheckedArgument(0);
+        if (distinguishingArg.isUndefined())
+            RELEASE_AND_RETURN(throwScope, (jsWebSocketPrototypeFunction_pong1Body(lexicalGlobalObject, callFrame, castedThis)));
         if (distinguishingArg.isObject() && asObject(distinguishingArg)->inherits<JSArrayBuffer>())
             RELEASE_AND_RETURN(throwScope, (jsWebSocketPrototypeFunction_pong2Body(lexicalGlobalObject, callFrame, castedThis)));
         if (distinguishingArg.isObject() && asObject(distinguishingArg)->inherits<JSArrayBufferView>())

--- a/test/js/web/websocket/websocket-client.test.ts
+++ b/test/js/web/websocket/websocket-client.test.ts
@@ -153,6 +153,27 @@ describe("WebSocket", () => {
       });
       ws.addEventListener("ping", ({ data }) => {
         expect(data).toBeInstanceOf(Buffer);
+        expect(data).toEqual(Buffer.alloc(0));
+        done();
+      });
+    });
+    // The payload is optional, so an explicit undefined means "no payload" (unlike
+    // send(), whose required argument stringifies undefined to "undefined").
+    test("(explicit undefined)", (ws, done) => {
+      ws.addEventListener("open", () => {
+        ws.ping(undefined);
+      });
+      ws.addEventListener("ping", ({ data }) => {
+        expect(data).toEqual(Buffer.alloc(0));
+        done();
+      });
+    });
+    test('(the string "undefined")', (ws, done) => {
+      ws.addEventListener("open", () => {
+        ws.ping("undefined");
+      });
+      ws.addEventListener("ping", ({ data }) => {
+        expect(data).toEqual(Buffer.from("undefined"));
         done();
       });
     });
@@ -175,6 +196,25 @@ describe("WebSocket", () => {
       });
       ws.addEventListener("pong", ({ data }) => {
         expect(data).toBeInstanceOf(Buffer);
+        expect(data).toEqual(Buffer.alloc(0));
+        done();
+      });
+    });
+    test("(explicit undefined)", (ws, done) => {
+      ws.addEventListener("open", () => {
+        ws.pong(undefined);
+      });
+      ws.addEventListener("pong", ({ data }) => {
+        expect(data).toEqual(Buffer.alloc(0));
+        done();
+      });
+    });
+    test('(the string "undefined")', (ws, done) => {
+      ws.addEventListener("open", () => {
+        ws.pong("undefined");
+      });
+      ws.addEventListener("pong", ({ data }) => {
+        expect(data).toEqual(Buffer.from("undefined"));
         done();
       });
     });


### PR DESCRIPTION
### Problem
- On the client `WebSocket`, `ws.ping()` sends an empty ping frame but `ws.ping(undefined)` sends a ping whose payload is the 9-byte string `"undefined"`. `ws.pong(undefined)` does the same.
- bun-types declares both as `ping(data?: ...)` / `pong(data?: ...)`, so `ws.ping(maybePayload)` with an unset variable type-checks and silently puts `"undefined"` on the wire.
- Cause: `jsWebSocketPrototypeFunction_pingOverloadDispatcher` and `..._pongOverloadDispatcher` in `src/jsc/bindings/webcore/JSWebSocket.cpp` branch on `argumentCount()`. An explicit `undefined` counts as one argument, is not an ArrayBuffer / ArrayBufferView / Blob, and so falls through to the USVString overload, which stringifies it.

### Fix
- In both dispatchers, route an `undefined` distinguishing argument to the no-argument overload before the type checks (one line each).
- Why this is right: the payload of `ping()` / `pong()` is optional, and the WebIDL overload resolution these dispatchers are modeled on treats an explicitly passed `undefined` at an optional position as omitted. The constructor dispatcher in the same file already does exactly this for its optional `protocols` argument, `Bun.serve`'s `ServerWebSocket.ping(undefined)` already sends an empty frame, and the `ws` package these methods mirror does as well.
- `send(undefined)` is unchanged: its argument is required, so stringifying to `"undefined"` is the specified behavior there. `ping(null)` / `pong(null)` are also unchanged (still stringified, like `send(null)` and `close(code, null)`). The `require("ws")` wrapper special-cases `undefined` itself and is unaffected.
- Tests: `test/js/web/websocket/websocket-client.test.ts` gains `(explicit undefined)` cases for `ping()` and `pong()` (expect an empty payload echoed back) and `(the string "undefined")` cases (a real string still sends those 9 bytes); the existing `(no argument)` cases now also assert the echoed payload is empty. The two `(explicit undefined)` tests fail on Bun 1.4.0 (payload comes back as `"undefined"`) and pass with this change.
- Also ran `websocket-blob.test.ts`, `websocket.test.js`, and `test/js/first_party/ws/ws.test.ts` with the debug build; the only failures were the `websocket.test.js` cases that need `ws.postman-echo.com`, which is unreachable here.

### Background
- `ping()` / `pong()` on the client `WebSocket` are Bun extensions (not in the WHATWG interface), implemented as hand-written WebKit-style overload dispatchers in `JSWebSocket.cpp`: the dispatcher inspects the first argument to pick between the ArrayBuffer, ArrayBufferView, Blob, and USVString overloads, with a separate zero-argument overload that sends an empty frame.
- A WebSocket ping or pong is a control frame with an optional application payload; the peer echoes a ping's payload back in its pong, which is how the test observes what was sent (the echo server reflects ping and pong payloads).
