### PR TITLE
js_parser: fold +, - and ~ of a constant-folded string; stop folding non-ascii strings to NaN

### DIFF
--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -2581,36 +2581,26 @@ impl Data {
         Tag::typeof_(self.tag())
     }
 
-    pub fn to_number(&self) -> Option<f64> {
+    /// The value of `+expr` when it is known at compile time. `bump` is used to
+    /// flatten a string that constant folding left as a rope.
+    pub fn to_number(&self, bump: &Bump) -> Option<f64> {
         match self {
             Data::ENull(_) => Some(0.0),
             Data::EUndefined(_) => Some(f64::NAN),
             Data::EString(str) => {
-                if str.next.is_some() {
-                    return None;
-                }
+                // `StoreRef<EString>` is a Copy pointer; rebind mutably so
+                // `DerefMut` gives `&mut EString` for in-place rope flattening.
+                let mut str = *str;
+                str.resolve_rope_if_needed(bump);
                 if !str.is_utf8() {
                     return None;
                 }
                 // +'1' => 1
-                Some(string_to_equivalent_number_value(str.slice8()))
+                string_to_equivalent_number_value(str.slice8())
             }
             Data::EBoolean(b) | Data::EBranchBoolean(b) => Some(if b.value { 1.0 } else { 0.0 }),
             Data::ENumber(n) => Some(n.value()),
-            Data::EInlinedEnum(inlined) => match &inlined.value.data {
-                Data::ENumber(num) => Some(num.value()),
-                Data::EString(str) => {
-                    if str.next.is_some() {
-                        return None;
-                    }
-                    if !str.is_utf8() {
-                        return None;
-                    }
-                    // +'1' => 1
-                    Some(string_to_equivalent_number_value(str.slice8()))
-                }
-                _ => None,
-            },
+            Data::EInlinedEnum(inlined) => inlined.value.data.to_number(bump),
             _ => None,
         }
     }
@@ -2914,13 +2904,16 @@ pub use data::Store;
 // Helpers
 // ───────────────────────────────────────────────────────────────────────────
 
-fn string_to_equivalent_number_value(str: &[u8]) -> f64 {
+fn string_to_equivalent_number_value(str: &[u8]) -> Option<f64> {
     // +"" -> 0
     if str.is_empty() {
-        return 0.0;
+        return Some(0.0);
     }
+    // `JSC__jsToNumber` reads latin1, so utf-8 input must be ascii. A non-ascii
+    // string is not necessarily NaN (+"\u00a01" is 1: U+00A0 is whitespace to
+    // StringToNumber), so it is left unfolded rather than folded to NaN.
     if !bun_core::is_all_ascii(str) {
-        return f64::NAN;
+        return None;
     }
     unsafe extern "C" {
         // NOT `safe fn`: callee dereferences `ptr` for `len` bytes — caller must
@@ -2930,5 +2923,5 @@ fn string_to_equivalent_number_value(str: &[u8]) -> f64 {
     // SAFETY: `str` is a live `&[u8]`, so `as_ptr()` is non-null and readable for
     // exactly `str.len()` bytes for the duration of this call; the C++ side reads
     // only (no mutation, no retention past return).
-    unsafe { JSC__jsToNumber(str.as_ptr(), str.len()) }
+    Some(unsafe { JSC__jsToNumber(str.as_ptr(), str.len()) })
 }

--- a/src/js_parser/scan/scan_side_effects.rs
+++ b/src/js_parser/scan/scan_side_effects.rs
@@ -95,8 +95,8 @@ impl SideEffects {
 
     // Re-exports of ExprData methods.
     #[inline(always)]
-    pub(crate) fn to_number(data: &ExprData) -> Option<f64> {
-        data.to_number()
+    pub(crate) fn to_number(data: &ExprData, bump: &Bump) -> Option<f64> {
+        data.to_number(bump)
     }
     #[inline(always)]
     pub(crate) fn typeof_(data: &ExprData) -> Option<&'static [u8]> {

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1271,7 +1271,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     }
                     Op::UnCpl => {
                         if p.should_fold_typescript_constant_expressions {
-                            if let Some(value) = SideEffects::to_number(&e_.value.data) {
+                            if let Some(value) = SideEffects::to_number(&e_.value.data, p.arena) {
                                 *e = p.new_expr(
                                     E::Number::new(f64::from(!float_to_int32(value))),
                                     expr.loc,
@@ -1287,13 +1287,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         }
                     }
                     Op::UnPos => {
-                        if let Some(num) = SideEffects::to_number(&e_.value.data) {
+                        if let Some(num) = SideEffects::to_number(&e_.value.data, p.arena) {
                             *e = p.new_expr(E::Number::new(num), expr.loc);
                             return;
                         }
                     }
                     Op::UnNeg => {
-                        if let Some(num) = SideEffects::to_number(&e_.value.data) {
+                        if let Some(num) = SideEffects::to_number(&e_.value.data, p.arena) {
                             *e = p.new_expr(E::Number::new(-num), expr.loc);
                             return;
                         }

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -630,6 +630,48 @@ describe("bundler", () => {
       '+"æ"',
     ],
   });
+  // "1" + "2" is folded into a rope (the pieces linked together, flattened when
+  // printed); +, - and ~ have to read the whole rope.
+  itBundled("minify/ConstantFoldingUnaryOnFoldedString", {
+    files: {
+      "/entry.ts": `
+        capture(+("1" + "2"));
+        capture(-("1" + "2"));
+        capture(~("1" + "2"));
+        capture(+("1" + "2" + "3"));
+        capture(+("" + ""));
+        capture(-(" 0x" + "10 "));
+        capture(+("1" + y));
+        enum E { A = "1" + "2", B = +("3" + "4"), C = -A, D = ~A }
+        capture(+E.A);
+        capture(-E.A);
+        capture(E.B + E.C + E.D);
+      `,
+    },
+    minifySyntax: true,
+    capture: ["12", "-12", "-13", "123", "0", "-16", '+("1" + y)', "12", "-12", "9"],
+  });
+  // Strings from --define are stored as UTF-8. U+00A0 is whitespace to
+  // StringToNumber (+"\u00a01" is 1), so a non-ascii string is left alone
+  // instead of being folded to NaN.
+  itBundled("minify/ConstantFoldingUnaryPlusNonAsciiDefine", {
+    files: {
+      "/entry.js": `
+        capture(+NBSP_ONE);
+        capture(-NBSP_ONE);
+        capture(~NBSP_ONE);
+        capture(+(NBSP_ONE + ""));
+        capture(+SPACE_ONE);
+        capture(+(SPACE_ONE + ""));
+      `,
+    },
+    define: {
+      NBSP_ONE: JSON.stringify("\u00a01"),
+      SPACE_ONE: JSON.stringify(" 1 "),
+    },
+    minifySyntax: true,
+    capture: ['+"\u00a01"', '-"\u00a01"', '~"\u00a01"', '+"\u00a01"', "1", "1"],
+  });
   itBundled("minify/ImportMetaHotTreeShaking", {
     files: {
       "/entry.ts": `

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3563,6 +3563,78 @@ class Foo {
       expectPrinted("a = !(b, c)", "a = (b, !c)");
     });
 
+    it("+, - and ~ fold a string that was itself constant folded", () => {
+      // "1" + "2" is folded into a rope (the pieces linked together, flattened
+      // when printed), not into one flat string literal.
+      // Asserts the output, and that transpiling the output again changes nothing.
+      const expectFixedPoint = (code, out) => {
+        const once = parsed(code, false);
+        expect(once).toBe(out);
+        expect(parsed(once, false)).toBe(out);
+      };
+
+      expectFixedPoint('x = +("1" + "2");', "x = 12;\n");
+      expectFixedPoint('x = -("1" + "2");', "x = -12;\n");
+      expectFixedPoint('x = ~("1" + "2");', "x = -13;\n");
+      expectFixedPoint('x = +("1" + "2" + "3");', "x = 123;\n");
+      expectFixedPoint('x = +("1" + ("2" + "3"));', "x = 123;\n");
+      expectFixedPoint('x = +("1" + `2`);', "x = 12;\n");
+      expectFixedPoint('x = +("1" + 2);', "x = 12;\n");
+      expectFixedPoint('x = +("" + "");', "x = 0;\n");
+      expectFixedPoint('x = +("1" + "e2");', "x = 100;\n");
+      expectFixedPoint('x = -(" 0x" + "10 ");', "x = -16;\n");
+      expectFixedPoint('x = -("1" + "2") * 2;', "x = -24;\n");
+      expectFixedPoint('x = +("1" + "2") === 12;', "x = !0;\n");
+
+      // Only a constant operand folds.
+      expectFixedPoint('x = +("1" + y);', 'x = +("1" + y);\n');
+      expectFixedPoint('x = -(y + "1");', 'x = -(y + "1");\n');
+    });
+
+    it("+, - and ~ fold an enum member whose value was constant folded", () => {
+      // Enum initializers are always folded, so A is stored as a rope and each
+      // use of A is inlined as that rope. This does not depend on minify.
+      const ts = new Bun.Transpiler({ loader: "ts" });
+      expect(ts.transformSync('enum E { A = "1" + "2", B = +("3" + "4"), C = -A, D = ~A }')).toBe(
+        'var E;\n((E) => {\n  E["A"] = "12";\n  E[E["B"] = 34] = "B";\n  E[E["C"] = -12] = "C";\n  E[E["D"] = -13] = "D";\n})(E ||= {});\n',
+      );
+      expect(ts.transformSync('const enum E { A = "1" + "2" }\nx = +E.A;\ny = -E.A;\n')).toBe(
+        'var E;\n((E) => {\n  E["A"] = "12";\n})(E ||= {});\nx = 12;\ny = -12;\n',
+      );
+    });
+
+    it("+, - and ~ do not fold a string containing non-ascii characters", () => {
+      // Source literals with non-ascii characters are stored as UTF-16 and never
+      // folded; strings from `define` are stored as UTF-8 and used to fold to NaN.
+      // U+00A0 is whitespace to StringToNumber: +"\u00a01" is 1 and +"\u00a0" is 0.
+      const defined = new Bun.Transpiler({
+        loader: "js",
+        minify: { syntax: true },
+        define: {
+          NBSP: JSON.stringify("\u00a0"),
+          NBSP_ONE: JSON.stringify("\u00a01"),
+          SPACE_ONE: JSON.stringify(" 1 "),
+        },
+      });
+      const expectPrintedDefined = (code, out) => {
+        const once = defined.transformSync(code);
+        expect(once).toBe(out);
+        expect(defined.transformSync(once)).toBe(out);
+      };
+
+      expectPrintedDefined("x = +NBSP_ONE;", 'x = +"\u00a01";\n');
+      expectPrintedDefined("x = -NBSP_ONE;", 'x = -"\u00a01";\n');
+      expectPrintedDefined("x = ~NBSP_ONE;", 'x = ~"\u00a01";\n');
+      expectPrintedDefined("x = +NBSP;", 'x = +"\u00a0";\n');
+      expectPrintedDefined('x = +(NBSP + "1");', 'x = +"\u00a01";\n');
+      expectPrintedDefined('x = +("1" + NBSP);', 'x = +"1\u00a0";\n');
+
+      // An ascii string from `define` folds, on its own and as part of a rope.
+      expectPrintedDefined("x = +SPACE_ONE;", "x = 1;\n");
+      expectPrintedDefined('x = +(SPACE_ONE + "");', "x = 1;\n");
+      expectPrintedDefined('x = ~(SPACE_ONE + "");', "x = -2;\n");
+    });
+
     it.todo("const inlining", () => {
       var transpiler = new Bun.Transpiler({
         inline: true,


### PR DESCRIPTION
### Problem
- With `minify: { syntax: true }`, `x = +("1" + "2")` is printed as `x = +"12"`; transpiling that output again gives `x = 12`. Same for `-("1" + "2")` (`-"12"`, then `-12`) and `~("1" + "2")` (`~"12"`, then `-13`). A `transform(transform(x)) === transform(x)` check flags it.
- The same thing happens without minify inside enums, where initializers are always folded: `enum E { A = "1" + "2", B = +("3" + "4"), C = -A }` emits `E[E["B"] = +"34"] = "B"` and `E[E["C"] = -"12"] = "C"`, so `B` and `C` are not numeric constants and their uses are not inlined. esbuild emits `34` and `-12`.
- Cause: `"1" + "2"` is folded into a rope (see Background), and `ExprData::to_number` (`src/ast/expr.rs`) returned `None` as soon as the string had a `next` segment, in both its `EString` arm and its `EInlinedEnum` arm. The `+`/`-` folds and the `~` fold in `e_unary` (`src/js_parser/visit/visit_expr.rs`) therefore skipped ropes; the printer flattens the rope, so the second pass saw a plain literal and folded it.
- Second symptom in the same function: `string_to_equivalent_number_value` folded every UTF-8 string containing non-ascii bytes to `NaN`. Non-ascii source literals are stored as UTF-16 and were never folded, but the strings bun injects as UTF-8 (`--define` values, inlined `process.env`) are: with `--define 'X="\u00a01"'` (U+00A0 is whitespace to `StringToNumber`, so the value is `1`), `+X` became `NaN` and, under minify, `~X` became `-1` (the JS values are `1` and `-2`). Flattening ropes on its own would have extended this to `+(X + "1")`, which is left unfolded today.

### Fix
- `to_number` takes the arena and flattens a rope before converting it; `str.resolve_rope_if_needed(bump)` is the fixing line. The `EInlinedEnum` arm recurses into the inlined value instead of carrying a copy of the string arm; an inlined enum value is only ever an `ENumber` or a copy of the member's `EString` (the `EnumNumber` / `EnumString` arms in `p.rs` and `fold.rs`), so the arm folds what it folded before, plus ropes.
- `string_to_equivalent_number_value` returns `None` for a non-ascii string instead of `NaN`; `return None` is the fixing line. `JSC__jsToNumber` reads latin1, so only ascii bytes can be handed to it as-is; declining leaves the expression unfolded, which is what UTF-16 literals already get.
- Why this is right: flattening does not change the string's value, so a rope folds to exactly what the same characters in one literal already folded to. Every ascii operand that folded before folds to the same number; the only operands that stop folding are non-ascii UTF-8 strings, whose folded value was a guess. Flattening rewrites the root node's `data`/`next` only and does not touch the linked segments, which is the in-place flattening `Data::eql` and `extract_string_values` in the same file already perform on these nodes, inlined enum copies included.
- Matches esbuild, whose string folding produces one flat string, so `+("1" + "2")` and the enum members above fold there.
- Callers: `SideEffects::to_number` (`scan_side_effects.rs`) takes the arena too and its three uses in `e_unary` pass `p.arena`; there are no other callers. (#39049 reshuffles the same three lines in `e_unary`; whichever lands second has a one-line conflict per call.)
- Tests: `test/bundler/transpiler/transpiler.test.js` ("simplification": the rope folds and their fixed point, the enum cases, the `define` cases) and `test/bundler/bundler_minify.test.ts` (`minify/ConstantFoldingUnaryOnFoldedString`, `minify/ConstantFoldingUnaryPlusNonAsciiDefine`, through `bun build`). All five fail on bun 1.4.0 (`+"12"`, `E[E["B"] = +"34"]`, `x = NaN`, `E.B + E.C + E.D` left as is) and pass with this change.
- Also ran in full with the debug build: `transpiler.test.js`, `bundler_minify.test.ts`, `bundler_string.test.ts`, `bundler_edgecase.test.ts`, `bundler_regressions.test.ts`, `transpiler_constant_fold_eqeq.test.ts`, `esbuild/ts.test.ts`, `esbuild/dce.test.ts`, `esbuild/default.test.ts`, `transpiler/*`; and `cargo clippy -p bun_ast -p bun_js_parser`.

### Background
- Rope: when constant folding concatenates two string literals, bun does not build the joined string. It links the right operand onto the left operand's `E::String` node (`next` / `end` / `rope_len` in `src/ast/e.rs`, `src/ast/fold_string_addition.rs`) and the printer walks the chain. `resolve_rope_if_needed` replaces the root node's bytes with the concatenation (allocated in the parser's arena, hence the new parameter) and clears `next`. Anything that reads a folded string's bytes has to flatten first or walk the chain; `data` alone is the first piece.
- Inlined enum: in a TypeScript file, a reference to an enum member with a known value is replaced by an `E::InlinedEnum` wrapping a copy of the member's number or string (printed as `12 /* A */`). Enum initializers are folded whatever the minify settings, so a member defined by concatenation is a rope and each use of it is a rope.
- `should_fold_typescript_constant_expressions`: the parser flag under which string addition is folded (so ropes exist at all) and under which `~` folds. It is on under minify syntax and always on inside enum bodies. The `+x` / `-x` folds run unconditionally, which is why the enum case reproduces without minify.
