### PR TITLE
node:buffer: make Buffer.prototype.toJSON return empty data for a detached or out-of-bounds Buffer

### DIFF
--- a/src/js/builtins/JSBufferPrototype.ts
+++ b/src/js/builtins/JSBufferPrototype.ts
@@ -671,9 +671,15 @@ export function writeDoubleBE(this: BufferExt, value, offset) {
 }
 
 export function toJSON(this: BufferExt) {
-  const type = "Buffer";
-  const data = Array.from(this);
-  return { type, data };
+  // Like Node, read `length` (0 for a detached or out-of-bounds view) instead of
+  // iterating: the %TypedArray% iterator throws on such views.
+  const length = this.length;
+  if (length > 0) {
+    const data = $newArrayWithSize<number>(length);
+    for (let i = 0; i < length; i++) $putByValDirect(data, i, this[i]);
+    return { type: "Buffer", data };
+  }
+  return { type: "Buffer", data: [] };
 }
 
 $getter;

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -4688,6 +4688,103 @@ describe("Buffer.prototype.toString binary-to-text encodings", () => {
   });
 });
 
+// Node reads the view's length (0 once it is detached or out of bounds) and
+// copies by index, so these all serialize as empty instead of throwing.
+describe("Buffer.prototype.toJSON", () => {
+  const empty = { type: "Buffer", data: [] };
+
+  it("serializes a Buffer whose ArrayBuffer was detached as empty", () => {
+    const ab = new ArrayBuffer(4);
+    const buf = Buffer.from(ab);
+    buf.fill(1);
+    expect(buf.toJSON()).toEqual({ type: "Buffer", data: [1, 1, 1, 1] });
+
+    ab.transfer();
+    expect(buf.length).toBe(0);
+    expect(buf.toJSON()).toEqual(empty);
+    expect(JSON.stringify(buf)).toBe('{"type":"Buffer","data":[]}');
+    expect(JSON.stringify({ buf })).toBe('{"buf":{"type":"Buffer","data":[]}}');
+  });
+
+  it("serializes a length-tracking Buffer over a detached resizable ArrayBuffer as empty", () => {
+    const rab = new ArrayBuffer(4, { maxByteLength: 8 });
+    const buf = Buffer.from(rab, 0);
+    buf.fill(2);
+    expect(buf.toJSON()).toEqual({ type: "Buffer", data: [2, 2, 2, 2] });
+
+    rab.transfer();
+    expect(buf.toJSON()).toEqual(empty);
+    expect(JSON.stringify(buf)).toBe('{"type":"Buffer","data":[]}');
+  });
+
+  it("serializes a fixed-length Buffer pushed out of bounds by resize() as empty", () => {
+    const rab = new ArrayBuffer(4, { maxByteLength: 8 });
+    const buf = Buffer.from(rab, 0, 4);
+    buf.fill(3);
+
+    rab.resize(2);
+    expect(buf.length).toBe(0);
+    expect(buf.toJSON()).toEqual(empty);
+    expect(JSON.stringify(buf)).toBe('{"type":"Buffer","data":[]}');
+
+    // Growing the ArrayBuffer again brings the view back in bounds; resize()
+    // keeps the surviving bytes and zero-fills the rest.
+    rab.resize(4);
+    expect(buf.toJSON()).toEqual({ type: "Buffer", data: [3, 3, 0, 0] });
+  });
+
+  it("serializes a length-tracking Buffer whose byteOffset is past the resized end as empty", () => {
+    const rab = new ArrayBuffer(8, { maxByteLength: 8 });
+    const buf = Buffer.from(rab, 4);
+    buf.fill(4);
+    expect(buf.toJSON()).toEqual({ type: "Buffer", data: [4, 4, 4, 4] });
+
+    rab.resize(2);
+    expect(buf.length).toBe(0);
+    expect(buf.toJSON()).toEqual(empty);
+    expect(JSON.stringify(buf)).toBe('{"type":"Buffer","data":[]}');
+  });
+
+  it("serializes a detached Uint8Array receiver as empty", () => {
+    const ab = new ArrayBuffer(4);
+    const view = new Uint8Array(ab).fill(5);
+    expect(Buffer.prototype.toJSON.call(view)).toEqual({ type: "Buffer", data: [5, 5, 5, 5] });
+
+    ab.transfer();
+    expect(Buffer.prototype.toJSON.call(view)).toEqual(empty);
+  });
+
+  it("follows the current length of a length-tracking Buffer that is still in bounds", () => {
+    const rab = new ArrayBuffer(4, { maxByteLength: 8 });
+    const buf = Buffer.from(rab, 0);
+    buf.fill(6);
+
+    rab.resize(2);
+    expect(buf.toJSON()).toEqual({ type: "Buffer", data: [6, 6] });
+
+    rab.resize(0);
+    expect(buf.toJSON()).toEqual(empty);
+
+    rab.resize(3);
+    expect(buf.toJSON()).toEqual({ type: "Buffer", data: [0, 0, 0] });
+  });
+
+  it("copies the bytes of live Buffers by index", () => {
+    expect(Buffer.alloc(0).toJSON()).toEqual(empty);
+    expect(Buffer.from([0, 127, 128, 255]).toJSON()).toEqual({ type: "Buffer", data: [0, 127, 128, 255] });
+    expect(Buffer.from([1, 2, 3, 4, 5]).subarray(1, 4).toJSON()).toEqual({ type: "Buffer", data: [2, 3, 4] });
+    expect(Object.keys(Buffer.from("a").toJSON())).toEqual(["type", "data"]);
+
+    // Like Node, the result comes from length and indexed reads, not from the iterator.
+    const buf = Buffer.from([7, 8, 9]);
+    buf[Symbol.iterator] = function* () {
+      yield 0;
+    };
+    expect(buf.toJSON()).toEqual({ type: "Buffer", data: [7, 8, 9] });
+    expect(JSON.stringify(buf)).toBe('{"type":"Buffer","data":[7,8,9]}');
+  });
+});
+
 // MAX_LENGTH is 2**32 on 64-bit: a buffer of exactly that length must not
 // hit the uint32 truncation path that made toString()/write() see length 0.
 it.skipIf(os.totalmem() < 10 * 1024 ** 3)(


### PR DESCRIPTION
### Problem
- `buf.toJSON()` and `JSON.stringify(buf)` throw `TypeError: Underlying ArrayBuffer has been detached from the view or out-of-bounds` when the Buffer's ArrayBuffer has been detached (for example by `ab.transfer()`) or when a Buffer over a resizable ArrayBuffer has been pushed out of bounds by `resize()`. Node (checked against v26.3.0) returns `{"type":"Buffer","data":[]}` in every one of these cases.
- Reproduces on bun 1.4.0 and on main:
  ```js
  const ab = new ArrayBuffer(8);
  const buf = Buffer.from(ab);
  ab.transfer();
  JSON.stringify(buf); // node: {"type":"Buffer","data":[]}   bun: throws TypeError
  ```
- Cause: `toJSON` in `src/js/builtins/JSBufferPrototype.ts` was `Array.from(this)`. JSC's `Array.from` has no TypedArray fast path, so it calls `%TypedArray%.prototype[Symbol.iterator]`, and that iterator validates the view (`validateTypedArray` in `JSTypedArrayViewPrototype.cpp`) and throws for a detached or out-of-bounds view.

### Fix
- `toJSON` now reads `this.length` and, when it is non-zero, copies the bytes by index into a preallocated array (`$newArrayWithSize` + `$putByValDirect`, the same pattern `internal/fifo.ts` and `CommonJS.ts` use); otherwise it returns `{ type: "Buffer", data: [] }`.
- This matches Node's implementation: `lib/buffer.js` `toJSON` reads `TypedArrayPrototypeGetLength(this)`, which is 0 for a detached or out-of-bounds view, and copies by index. The `%TypedArray%.prototype.length` getter never throws for such views (it returns 0 in JSC as in V8), so the detached, out-of-bounds and empty cases all take the `data: []` branch, and an in-bounds length-tracking view serializes its current bytes like before.
- No change for live Buffers: the result is the same dense `Array` of bytes with the same `{ type, data }` key order. The index copy also does not consult `Symbol.iterator`, which is what Node does.
- The index loop is also faster than going through the iterator: in a quick release-build microbenchmark, building the array took 0.1us vs 0.7us for 16 bytes, 4us vs 41us for 1 KiB and 3.3ms vs 53ms for 1 MiB; `JSON.stringify` of the resulting array costs the same in both shapes.
- Verified with the new `describe("Buffer.prototype.toJSON")` block in `test/js/node/buffer.test.js`: 6 of its 7 tests fail on bun 1.4.0 (the five detached / out-of-bounds tests throw the TypeError above, and the iterator-independence assertion fails), all 7 pass with this change. The expected values were checked against node v26.3.0 with a standalone script. The whole file (626 tests) passes, as do the upstream `test-buffer-tojson`, `test-buffer-alloc`, `test-buffer-resizable`, `test-buffer-fakes`, `test-buffer-inheritance`, `test-buffer-inspect`, `test-buffer-prototype-inspect`, `test-buffer-arraybuffer` and `test-buffer-iterator` tests.

### Background
- Detaching: `ArrayBuffer.prototype.transfer()`, `structuredClone(ab, { transfer })` and `postMessage` transfers detach an ArrayBuffer. Every view over it (Buffers included) keeps existing, but reports `length` 0 and has no bytes.
- Out-of-bounds views: a view over a resizable ArrayBuffer (`new ArrayBuffer(n, { maxByteLength })`) becomes out of bounds when the buffer is shrunk past the view's fixed range or past its `byteOffset`. Such a view also reports `length` 0, and comes back into bounds if the buffer is grown again. A length-tracking view (`Buffer.from(rab, byteOffset)` with no length) that is still in bounds just reports the current length.
- The spec makes `%TypedArray%.prototype.length` return 0 for both states, but makes the TypedArray iterator (and most `%TypedArray%.prototype` methods) throw a TypeError for them. That difference is the whole bug: Node's `toJSON` only uses `length` and indexed reads, bun's used the iterator.
- `src/js/builtins/*.ts` are bundled into JSC builtins at build time. `$newArrayWithSize(n)` creates an `Array` of length `n` and `$putByValDirect(arr, i, v)` stores an own element without consulting prototype setters; they are the tamper-proof equivalents of `new Array(n)` and `arr[i] = v`.

<details>
<summary>Node v26.3.0 vs bun 1.4.0 on the shapes the tests cover</summary>

Each of the following returns `{"type":"Buffer","data":[]}` in Node and threw `TypeError: Underlying ArrayBuffer has been detached from the view or out-of-bounds` in bun 1.4.0 (both `toJSON()` and `JSON.stringify`):

```
Buffer.from(ab) after ab.transfer()
Buffer.from(rab, 0) (length-tracking) after rab.transfer()
Buffer.from(rab, 0, 4) after rab.resize(2)          (fixed-length view out of bounds)
Buffer.from(rab, 4) after rab.resize(2)             (length-tracking view, byteOffset past the end)
Buffer.prototype.toJSON.call(detached Uint8Array)
```

Already consistent with Node before this change and still covered: `Buffer.alloc(0)`, a length-tracking Buffer that was shrunk but is still in bounds (`data` follows the current length, including length 0 after `resize(0)`), a `subarray()` with a non-zero offset, and a Uint8Array receiver.

Not changed by this PR: calling `Buffer.prototype.toJSON` on a non-TypedArray receiver. Node throws a TypeError from the `length` getter there; bun returned whatever `Array.from` produced before and now returns whatever `.length` and indexed reads produce, which is the same result for array-likes.
</details>
