### PR TITLE
bun-types: declare the global dispatchEvent() function

### DIFF
--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -497,6 +497,14 @@ declare function removeEventListener(
   listener: Bun.EventListenerOrEventListenerObject,
   options?: boolean | Bun.EventListenerOptions,
 ): void;
+/**
+ * Dispatches `event` to the listeners registered on the global object with
+ * {@link addEventListener}, invoking them synchronously before returning.
+ *
+ * Returns `false` if `event` is cancelable and a listener called
+ * `event.preventDefault()`, otherwise `true`.
+ */
+declare function dispatchEvent(event: Event): boolean;
 
 /**
  * An event that provides information about an error in a script or in a file.

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -400,6 +400,37 @@ describe("@types/bun integration test", () => {
     });
   });
 
+  // Also runs on debug builds, where the typeTest cases (which check the whole fixture
+  // directory) are skipped: type-checks fixture/globals.ts alone, so the globals it
+  // exercises (timers, atob/btoa, the global addEventListener/removeEventListener/
+  // dispatchEvent, ...) are checked against the packed bun-types on every build type.
+  describe("fixture/globals.ts", () => {
+    test("type-checks on its own", async () => {
+      const checkDir = join(TEMP_DIR, "globals-fixture-check");
+      const tsconfig = structuredClone(sourceTsconfig);
+      tsconfig.files = [join(BASE_FIXTURE_DIR, "globals.ts")];
+      tsconfig.compilerOptions.typeRoots = [join(BASE_FIXTURE_DIR, "node_modules", "@types")];
+      await mkdir(checkDir, { recursive: true });
+      await makeTree(checkDir, {
+        "tsconfig.json": JSON.stringify(tsconfig, null, 2),
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), join(BASE_FIXTURE_DIR, "node_modules", "typescript", "bin", "tsc"), "-p", "."],
+        env: bunEnv,
+        cwd: checkDir,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr.trim()).toBe("");
+      expect(stdout.trim()).toBe("");
+      expect(exitCode).toBe(0);
+    });
+  });
+
   describe("Test Globals", () => {
     const code = `
       const test_shouldBeAFunction: Function = test;

--- a/test/integration/bun-types/fixture/globals.ts
+++ b/test/integration/bun-types/fixture/globals.ts
@@ -318,6 +318,19 @@ clearTimeout(1);
 setImmediate(() => {});
 clearImmediate(1);
 
+// The global object is itself an EventTarget: addEventListener, removeEventListener
+// and dispatchEvent are functions on globalThis (main thread and workers alike).
+{
+  const listener = (event: Event) => event.type;
+  addEventListener("asdf", listener);
+  removeEventListener("asdf", listener);
+  expectType(dispatchEvent(new Event("asdf"))).is<boolean>();
+  expectType(dispatchEvent(new ErrorEvent("error", { message: "asdf" }))).is<boolean>();
+  expectType(globalThis.dispatchEvent(new Event("asdf"))).is<boolean>();
+  // @ts-expect-error dispatchEvent takes an Event instance, not an event type
+  dispatchEvent("asdf");
+}
+
 const err = new Error("test");
 err.cause = "asdf";
 err.cause = new Error("asdf");


### PR DESCRIPTION
### Problem
- With the tsconfig `bun init` generates (`lib: ["ESNext"]`, `types: ["bun"]`, no lib.dom), `dispatchEvent(new Event("x"))` fails to type-check: `error TS2304: Cannot find name 'dispatchEvent'.` `globalThis.dispatchEvent(...)` fails the same way (TS7017).
- The runtime has it: `dispatchEvent` is an own function of every global object (main thread, `Worker`, `worker_threads`), listed next to `addEventListener` and `removeEventListener` in `src/jsc/bindings/ZigGlobalObject.lut.txt:13` and implemented by `jsFunctionDispatchEvent` in `src/jsc/bindings/ZigGlobalObject.cpp`. It takes an `Event` (TypeError otherwise) and returns a boolean.
- `packages/bun-types/globals.d.ts:480-499` declares the global `addEventListener` and `removeEventListener` functions but not `dispatchEvent`; the only `dispatchEvent` in the package is the `EventTarget` interface method, which does not make the bare global name resolve.

### Fix
- Add `declare function dispatchEvent(event: Event): boolean;` after the global `removeEventListener` declarations in `globals.d.ts`.
- The signature is the one the runtime implements, and it is identical to the `declare function dispatchEvent(event: Event): boolean;` in lib.dom.d.ts (and lib.webworker.d.ts), so when lib.dom is also loaded the two declarations merge as identical overloads instead of conflicting. @types/node declares no global `dispatchEvent` (only the `EventTarget` method), so nothing to merge with there. The existing "checks with lib.dom.d.ts" case, which runs with `skipLibCheck: false` and asserts the exact diagnostics list, is unchanged.
- `test/integration/bun-types/fixture/globals.ts` now exercises the three global EventTarget functions (`dispatchEvent` returning `boolean`, `globalThis.dispatchEvent`, and a `@ts-expect-error` for a non-Event argument). The fixture is part of every existing type-check case (with lib.dom, without, no lib at all, and tsgo).
- The `typeTest` cases are skipped on debug builds, so `bun-types.test.ts` gets a `fixture/globals.ts type-checks on its own` test in the shape of the existing `Bun.mmap` one, which spawns tsc over that single fixture file against the packed bun-types and also runs on debug builds. Sibling declarations added to `globals.d.ts` later can reuse it by adding lines to the same fixture.
- Verified with `bun test test/integration/bun-types/bun-types.test.ts` (release, what `.github/workflows/bun-types.yml` runs): without the declaration, `checks without lib.dom.d.ts`, the tsgo case, and the new test fail with the TS2304/TS7017 diagnostics above; with it, all 16 tests pass. Under a debug build the same file runs 4 tests (12 skipped), and the new test is the one that fails without the declaration.

### Background
- bun-types declares Bun's globals as ambient script-scope declarations (`declare function setTimeout(...)`, `declare function postMessage(...)`, ...). A bare call like `dispatchEvent(...)` and the property `globalThis.dispatchEvent` both only exist for TypeScript if such a declaration is present; an interface method (`EventTarget.dispatchEvent`) does not provide either.
- Several `declare function` declarations with the same name, from any number of .d.ts files, merge into one overloaded function. That is how the global `addEventListener` already coexists with lib.dom's, and why a declaration that repeats lib.dom's exact signature is safe to add while one declared as `declare var` would conflict with lib.dom.
- `test/integration/bun-types/bun-types.test.ts` packs `packages/bun-types`, installs it into a copy of `test/integration/bun-types/fixture/`, and type-checks the fixture under several tsconfigs. Those in-process cases are `test.skipIf(isDebug)`; the small spawn-tsc tests (`Bun.mmap`, and now this one) are the ones that also run on debug builds.

<details>
<summary>Repro</summary>

```ts
// dispatch.ts, tsconfig from `bun init` (types: ["bun"], lib: ["ESNext"])
addEventListener("error", e => console.log(e.type));
const ok = dispatchEvent(new ErrorEvent("error", { message: "manual" }));
console.log(ok, typeof dispatchEvent);
```

```
$ bun dispatch.ts
error
true function

$ tsc -p .
dispatch.ts(2,12): error TS2304: Cannot find name 'dispatchEvent'.
```

Runtime behaviour, identical on the main thread, in a `new Worker(...)` and in a `worker_threads` Worker: `dispatchEvent(new Event("ping", { cancelable: true }))` returns `true`, returns `false` once a listener calls `preventDefault()`, and `dispatchEvent({})` throws `TypeError: Argument 1 ('event') to EventTarget.dispatchEvent must be an instance of Event`.
</details>
