### PR TITLE
mimalloc: take destroyed blocks back off the malloc_* statistics in mi_heap_destroy

### DIFF
--- a/patches/mimalloc/heap-destroy-malloc-stats.patch
+++ b/patches/mimalloc/heap-destroy-malloc-stats.patch
@@ -1,0 +1,46 @@
+mi_heap_destroy: undo the allocation statistics of the blocks it destroys.
+
+Every block allocation bumps malloc_normal (and, with MI_STAT>1, its
+malloc_bins entry) or malloc_huge, and mi_free takes it back off again in
+free.c:mi_stat_free. A block that is still in use when its heap is destroyed
+is freed along with its page in arena.c:mi_heap_delete_page and never goes
+through mi_free, so its increment stayed in the heap's stats forever and was
+merged into the main heap's stats when the destroyed heap was freed. With a
+short-lived heap per unit of work (bun_alloc::MimallocArena: one per
+transpile, per bundle, per parse) heapStats().mimalloc.malloc_normal.current
+grew by every destroyed heap's live bytes even though the memory was freed.
+Upstream dev3 has the same gap; the v2 destroy path (_mi_heap_page_destroy)
+did adjust these counters. This belongs in the oven-sh/mimalloc fork; it is
+a patch here until the pin is bumped.
+
+--- a/src/arena.c
++++ b/src/arena.c
+@@ -2715,6 +2715,28 @@
+     #if MI_GUARDED
+     _mi_page_unguard_all(page);          // remove potential interior guard pages 
+     #endif
++    #if (MI_STAT>0)
++    // The blocks still in use are destroyed along with the page and never go through `mi_free`
++    // (`free.c:mi_stat_free`), so undo their allocation statistics here (the mirror image of
++    // `alloc.c:mi_page_malloc_zero` and `page.c:mi_huge_page_alloc`). Blocks that were free'd
++    // from other threads but not yet collected were already accounted for by `mi_stat_free`,
++    // so collect first to get an accurate `used` count. The theaps of this heap are already
++    // freed and merged at this point (`heap.c:mi_heap_free_theaps`), so update the heap statistics directly.
++    _mi_page_free_collect_no_unpurge(page, false);
++    const size_t inuse = page->used;
++    if (inuse > 0) {
++      const size_t bsize = mi_page_usable_block_size(page);
++      if (bsize <= MI_LARGE_MAX_OBJ_SIZE) {
++        mi_heap_stat_decrease((mi_heap_t*)heap, malloc_normal, bsize * inuse);
++        #if (MI_STAT>1)
++        mi_heap_stat_decrease((mi_heap_t*)heap, malloc_bins[_mi_bin(bsize)], inuse);
++        #endif
++      }
++      else {
++        mi_heap_stat_decrease((mi_heap_t*)heap, malloc_huge, mi_page_block_size(page) * inuse);
++      }
++    }
++    #endif
+     // destroy the page
+     page->used=0;                        // note: invariant `|local_free| + |free| == reserved - used`  does not hold in this case
+     _mi_arenas_page_free(page, theap);

--- a/scripts/build/deps/mimalloc.ts
+++ b/scripts/build/deps/mimalloc.ts
@@ -24,6 +24,12 @@ export const mimalloc: Dependency = {
     commit: MIMALLOC_COMMIT,
   }),
 
+  // mi_heap_destroy frees the blocks still in use without taking them back off
+  // malloc_normal / malloc_bins / malloc_huge (MI_STAT builds, i.e. debug), so
+  // heapStats().mimalloc.malloc_normal.current grew by every destroyed
+  // MimallocArena's live bytes. Drop once the fix is in the pinned fork commit.
+  patches: ["patches/mimalloc/heap-destroy-malloc-stats.patch"],
+
   build: cfg => {
     // ─── Override behavior (global malloc replacement) ───
     //   ASAN:    OFF — ASAN interceptors must see the real malloc.

--- a/test/js/bun/jsc/heapStats-mimalloc.test.ts
+++ b/test/js/bun/jsc/heapStats-mimalloc.test.ts
@@ -64,6 +64,54 @@ describe("heapStats() mimalloc integration", () => {
     void before;
   });
 
+  // The malloc_* counters are only maintained when mimalloc is built with statistics (MI_STAT, i.e.
+  // debug builds); release builds report 0 for all of them.
+  const tracksMallocStats = heapStats().mimalloc.malloc_normal.total > 0;
+
+  test.skipIf(!tracksMallocStats)("malloc_* counters come back down when a heap is destroyed", () => {
+    // Bun.Transpiler#transformSync allocates everything for the call in a fresh mimalloc heap
+    // (bun_alloc::MimallocArena) and mi_heap_destroy()s it on return, so none of those blocks is
+    // ever passed to mi_free. The exports fill the heap with small blocks (malloc_normal and
+    // malloc_bins); a source this large also makes the call allocate blocks above mimalloc's large
+    // object limit (512 KiB), which are accounted separately in malloc_huge.
+    const source =
+      `/* ${Buffer.alloc(640 * 1024, "x").toString()} */\n` +
+      Array.from({ length: 300 }, (_, i) => `export const e${i} = { a: [${i}, "x"] };`).join("\n");
+    const transpiler = new Bun.Transpiler();
+    const iterations = 10;
+
+    function counters() {
+      // Collect the JS garbage made by the previous heapStats() call so that only the transpiler's
+      // heaps are left in the deltas.
+      Bun.gc(true);
+      const m = heapStats().mimalloc;
+      return {
+        normalBytes: m.malloc_normal.current,
+        hugeBytes: m.malloc_huge.current,
+        binBlocks: m.malloc_bins.reduce((sum: number, bin: any) => sum + bin.current, 0),
+        heapsCreated: m.heaps.total,
+        heapsAlive: m.heaps.current,
+      };
+    }
+
+    transpiler.transformSync(source); // lazily-initialized state (the retained output buffer, ...) must not count
+    const before = counters();
+    for (let i = 0; i < iterations; i++) transpiler.transformSync(source);
+    const after = counters();
+
+    // One heap per call, and none of them survived the call.
+    expect(after.heapsCreated - before.heapsCreated).toBeGreaterThanOrEqual(iterations);
+    expect(after.heapsAlive).toBe(before.heapsAlive);
+
+    // Every destroyed heap used to leave its live blocks in the counters: about 940 KiB in
+    // malloc_normal, 2.25 MiB in malloc_huge and 2,770 blocks in malloc_bins per call (9.6 MB,
+    // 23.6 MB and 27,710 blocks after the loop). Each bound is below what a single call left
+    // behind; the slack is for whatever else the process legitimately keeps across the loop.
+    expect(after.normalBytes - before.normalBytes).toBeLessThan(512 * 1024);
+    expect(after.hugeBytes - before.hugeBytes).toBeLessThan(2 * 1024 * 1024);
+    expect(after.binBlocks - before.binBlocks).toBeLessThan(2000);
+  });
+
   // mimalloc tags its arena mmaps with an app-reserved VM tag (240-255). The old default,
   // 100, is VM_MEMORY_IOACCELERATOR, so profilers reported Bun's heap as GPU memory.
   test.skipIf(!isMacOS)("arena memory is tagged as application memory, not IOAccelerator", async () => {


### PR DESCRIPTION
### Problem

- On debug builds, `require("bun:jsc").heapStats().mimalloc.malloc_normal.current` (and `malloc_bins[i].current`, `malloc_huge.current`) only ever grows in any workload that creates and destroys mimalloc heaps, even though the memory is freed. 10 `Bun.Transpiler#transformSync` calls: `malloc_normal.current` +9,620,240, `malloc_huge.current` +23,592,960, `malloc_bins` +27,710 blocks, while `heaps.current` is unchanged and `heapStats({ dump: true })` shows nothing left alive. Bun destroys a heap per transpile, bundle and parse (`bun_alloc::MimallocArena` drop/reset is `mi_heap_destroy`), so the counter is useless for leak hunting: a dev server leak was measured at +2.2 MB per rebuild with it, of which about 2 MB was this.
- Cause: `mi_heap_destroy` frees every page of the heap through `mi_heap_delete_page` (`vendor/mimalloc/src/arena.c:2714`, the `heap_target == NULL` branch), which sets `page->used = 0` and frees the page. The blocks that were still in use never go through `mi_free`, and `free.c:mi_stat_free` is the only place the increments made at allocation (`alloc.c:mi_page_malloc_zero`, `page.c:mi_huge_page_alloc`) are taken back off. The leftovers stay in `heap->stats`, and `mi_heap_free` merges them into the main heap's stats (`heap.c:207`), which is what `mi_stats_get_json` reports from then on.
- Upstream `dev3` has the same gap; mimalloc v2's destroy path (`_mi_heap_page_destroy`) did adjust these counters.
- Only debug builds are affected: the counters are maintained only when mimalloc is built with statistics (`MI_STAT`, which `MI_DEBUG` turns on); release builds report 0 for them.

### Fix

- `patches/mimalloc/heap-destroy-malloc-stats.patch`, applied to the pinned `oven-sh/mimalloc` commit (`6e891cbe`, the fork's current head) through the existing `patches:` mechanism. I can't push to the fork, so this takes the same route as #34739; the patch is to be dropped when the pin moves to a fork commit that carries the fix (the `patches:` comment says so, and `git apply` will most likely refuse it at that point anyway). Hunk-wise it is independent of #34739 (`arena.c` here, `stats.c` there); only the `patches:` line in `mimalloc.ts` will need a trivial merge.
- The destroy branch now collects the page (`_mi_page_free_collect_no_unpurge`) and then decrements `malloc_normal` by `usable block size * used` and `malloc_bins[bin]` by `used` (or `malloc_huge` by the block size for a huge page) on `heap->stats`.
- Why this is right: it is the exact inverse of what allocation added for each block, using the same sizes and bins as `mi_stat_free`, so each block's increment is now undone exactly once: by `mi_free` if it was freed, by the destroy otherwise. The collect first is what makes `used` mean "never freed": a block freed from another thread sits on the page's thread-free list with `used` still counting it, but `mi_stat_free` already accounted for it on the freeing thread. The adjustment goes to `heap->stats` because the heap's theaps have already been freed and merged into it when the pages are visited (`mi_heap_free_theaps` runs first in `_mi_heap_force_destroy`), which is also where this path already accounts for the page counters (`_mi_arenas_page_free` with `theap == NULL`). The whole addition is under `#if MI_STAT > 0`, like `mi_stat_free`, so release builds compile the same code as before. `malloc_requested` is deliberately left alone: `mi_free` does not decrement it either, it is cumulative by design.
- Test: `test/js/bun/jsc/heapStats-mimalloc.test.ts`, "malloc_* counters come back down when a heap is destroyed". Runs 10 `transformSync` calls, checks via `heaps.total`/`heaps.current` that a heap was created and destroyed per call, and bounds the growth of all three counters below what a single call used to leave behind. Skipped on release builds, where the counters are not compiled in.
- Fail before / pass after, on debug builds of the same source with and without the patch (the release binary cannot show this bug, so `USE_SYSTEM_BUN=1` skips the test instead of failing it):
  - without the patch: `malloc_normal` +9,620,240 (test fails there; the `malloc_huge` +23,592,960 and `malloc_bins` +27,710 assertions fail independently as well), identical across 3 runs
  - with the patch: all three deltas are exactly 0 across 3 runs; the test passes
  - the handoff's repro (`transformSync` x 50): +10.9 MB before, 0 after; a Worker that transpiles and exits: +406 KB per Worker before, flat after
  - `test/js/bun/jsc/` with and without the patch: same results apart from the new test (the remaining failures in both are DOMJIT tests hitting their 5 s timeout on a heavily loaded box)
- Nothing in this PR lives under `src/`, so the stash-based fail-before check has nothing to stash; the proof is the unpatched debug build above.

### Background

- A mimalloc heap (`mi_heap_t`) is a separate set of pages. `mi_heap_destroy` releases all of its pages at once without freeing blocks individually; Bun's `bun_alloc::MimallocArena` wraps one heap and calls it from `Drop` and `reset()`.
- A theap is a thread's view of a heap; allocations update the stats of the allocating thread's theap. When a heap is destroyed its theaps are merged into `heap->stats`, and `heap->stats` into the main heap's stats, which `heapStats().mimalloc` (`mi_stats_get_json`) aggregates.
- `MI_STAT` is mimalloc's compile-time statistics level: 2 in Bun's debug builds (`MI_DEBUG=3` in `scripts/build/deps/mimalloc.ts`), 0 in release. `malloc_normal` and `malloc_huge` are maintained at level 1 and up, `malloc_bins` at level 2.
- `page->used` counts blocks handed out and not yet collected back. A block freed by a thread other than the page's owner is pushed onto the page's thread-free list and only leaves `used` when the owner collects the page; its statistics are adjusted at free time regardless.

<details>
<summary>Numbers behind the test bounds (debug build, 10 calls of the test's source)</summary>

```
unpatched: {"heaps_created":10,"heaps_alive_delta":0,"malloc_normal_delta":9620240,"malloc_huge_delta":23592960,"malloc_bins_blocks_delta":27710}
patched:   {"heaps_created":10,"heaps_alive_delta":0,"malloc_normal_delta":0,"malloc_huge_delta":0,"malloc_bins_blocks_delta":0}
```

Per call that is about 940 KiB of normal blocks, 2.25 MiB of huge blocks and 2,770 blocks; the test bounds are 512 KiB, 2 MiB and 2,000. A JS-only loop with `Bun.gc(true)` before each reading moves none of the three counters, so the slack is only for things the process legitimately keeps across the loop.

Observed along the way and left alone here: `committed.current` goes negative (-1 MB to -27 MB) once `transpiler.test.js` has run in the same process, with and without this patch, which makes the file's first test fail when the two files share a process (CI runs them separately). It is a subproc-level counter this patch does not touch.
</details>
