### PR TITLE
node:wasi: write 32-byte poll_oneoff event records

### DIFF
--- a/src/js/node/wasi.ts
+++ b/src/js/node/wasi.ts
@@ -1508,6 +1508,7 @@ var require_wasi = __commonJS({
               const type = this.view.getUint8(sin);
               sin += 1;
               sin += 7;
+              let e;
               switch (type) {
                 case constants_1.WASI_EVENTTYPE_CLOCK: {
                   const clockid = this.view.getUint32(sin, true);
@@ -1523,7 +1524,7 @@ var require_wasi = __commonJS({
                   if (!absolute) {
                     fd_timeout_ms = timeout / BigInt(1e6);
                   }
-                  let e = constants_1.WASI_ESUCCESS;
+                  e = constants_1.WASI_ESUCCESS;
                   const t = now(clockid);
                   if (t == null) {
                     e = constants_1.WASI_EINVAL;
@@ -1535,14 +1536,6 @@ var require_wasi = __commonJS({
                       waitTimeNs = waitNs;
                     }
                   }
-                  this.view.setBigUint64(sout, userdata, true);
-                  sout += 8;
-                  this.view.setUint16(sout, e, true);
-                  sout += 2;
-                  this.view.setUint8(sout, constants_1.WASI_EVENTTYPE_CLOCK);
-                  sout += 1;
-                  sout += 5;
-                  nevents += 1;
                   break;
                 }
                 case constants_1.WASI_EVENTTYPE_FD_READ:
@@ -1551,14 +1544,7 @@ var require_wasi = __commonJS({
                   fd_type = type == constants_1.WASI_EVENTTYPE_FD_READ ? "read" : "write";
                   sin += 4;
                   sin += 28;
-                  this.view.setBigUint64(sout, userdata, true);
-                  sout += 8;
-                  this.view.setUint16(sout, constants_1.WASI_ENOSYS, true);
-                  sout += 2;
-                  this.view.setUint8(sout, type);
-                  sout += 1;
-                  sout += 5;
-                  nevents += 1;
+                  e = constants_1.WASI_ENOSYS;
                   if (fd == constants_1.WASI_STDIN_FILENO && constants_1.WASI_EVENTTYPE_FD_READ == type) {
                     this.shortPause();
                   }
@@ -1567,6 +1553,15 @@ var require_wasi = __commonJS({
                 default:
                   return constants_1.WASI_EINVAL;
               }
+              // event: userdata u64 @0, error u16 @8, type u8 @10,
+              // fd_readwrite { nbytes u64 @16, flags u16 @24 }; 32 bytes per event.
+              this.view.setBigUint64(sout, userdata, true);
+              this.view.setUint16(sout + 8, e, true);
+              this.view.setUint8(sout + 10, type);
+              this.view.setBigUint64(sout + 16, BigInt(0), true);
+              this.view.setUint16(sout + 24, 0, true);
+              sout += 32;
+              nevents += 1;
               if (sin - last_sin != 48) {
                 console.warn("*** BUG in wasi-js in poll_oneoff ", {
                   i,

--- a/test/js/bun/wasm/wasi.test.js
+++ b/test/js/bun/wasm/wasi.test.js
@@ -163,3 +163,76 @@ it("path_* syscalls cannot escape the preopened directory", () => {
   );
   expect(wasi.FD_MAP.has(4)).toBe(true);
 });
+
+it("poll_oneoff writes one 32-byte preview1 event record per subscription", () => {
+  // A preview1 `event` is 32 bytes (userdata u64 @0, error u16 @8, type u8 @10,
+  // fd_readwrite { nbytes u64 @16, flags u16 @24 }) and guests read events[i] from
+  // out + 32 * i. The records used to be packed 16 bytes apart, so as soon as there
+  // was more than one subscription (wasi-libc's poll() adds a clock subscription
+  // for its timeout) events[1] landed inside events[0].fd_readwrite and the memory
+  // of events[1] itself was never written.
+  const WASI_ESUCCESS = 0;
+  const WASI_EINVAL = 28;
+  const WASI_ENOSYS = 52;
+  const WASI_EVENTTYPE_CLOCK = 0;
+  const WASI_EVENTTYPE_FD_READ = 1;
+  const WASI_EVENTTYPE_FD_WRITE = 2;
+  const WASI_CLOCK_MONOTONIC = 1;
+  const WASI_STDIN_FILENO = 0;
+  const WASI_STDOUT_FILENO = 1;
+  const SUBSCRIPTION_SIZE = 48;
+  const EVENT_SIZE = 32;
+  const sin = 512;
+  const sout = 1024;
+  const neventsPtr = 128;
+
+  // poll_oneoff pauses through `sleep` when asked about stdin; a no-op keeps the test fast.
+  const wasi = new WASI({ version: "preview1", sleep() {} });
+  wasi.setMemory(new WebAssembly.Memory({ initial: 1 }));
+  const view = new DataView(wasi.memory.buffer);
+  const bytes = new Uint8Array(wasi.memory.buffer);
+
+  const subscriptions = [
+    { userdata: 1n, type: WASI_EVENTTYPE_FD_READ, fd: WASI_STDIN_FILENO },
+    { userdata: 2n, type: WASI_EVENTTYPE_CLOCK, clockid: WASI_CLOCK_MONOTONIC },
+    { userdata: 3n, type: WASI_EVENTTYPE_FD_WRITE, fd: WASI_STDOUT_FILENO },
+    { userdata: 4n, type: WASI_EVENTTYPE_CLOCK, clockid: 1234 },
+  ];
+  subscriptions.forEach((subscription, i) => {
+    const at = sin + i * SUBSCRIPTION_SIZE;
+    view.setBigUint64(at, subscription.userdata, true);
+    view.setUint8(at + 8, subscription.type);
+    if (subscription.type === WASI_EVENTTYPE_CLOCK) {
+      view.setUint32(at + 16, subscription.clockid, true);
+      view.setBigUint64(at + 24, 0n, true); // relative timeout of 0ns, so nothing waits
+    } else {
+      view.setUint32(at + 16, subscription.fd, true);
+    }
+  });
+
+  // Fill the event buffer plus one spare record, so that both a field poll_oneoff
+  // fails to write and a write past the last event show up.
+  bytes.fill(0xaa, sout, sout + (subscriptions.length + 1) * EVENT_SIZE);
+
+  expect(wasi.wasiImport.poll_oneoff(sin, sout, subscriptions.length, neventsPtr)).toBe(WASI_ESUCCESS);
+  expect(view.getUint32(neventsPtr, true)).toBe(subscriptions.length);
+
+  const events = subscriptions.map((_, i) => {
+    const at = sout + i * EVENT_SIZE;
+    return {
+      userdata: view.getBigUint64(at, true),
+      error: view.getUint16(at + 8, true),
+      type: view.getUint8(at + 10),
+      nbytes: view.getBigUint64(at + 16, true),
+      flags: view.getUint16(at + 24, true),
+    };
+  });
+  expect(events).toEqual([
+    { userdata: 1n, error: WASI_ENOSYS, type: WASI_EVENTTYPE_FD_READ, nbytes: 0n, flags: 0 },
+    { userdata: 2n, error: WASI_ESUCCESS, type: WASI_EVENTTYPE_CLOCK, nbytes: 0n, flags: 0 },
+    { userdata: 3n, error: WASI_ENOSYS, type: WASI_EVENTTYPE_FD_WRITE, nbytes: 0n, flags: 0 },
+    { userdata: 4n, error: WASI_EINVAL, type: WASI_EVENTTYPE_CLOCK, nbytes: 0n, flags: 0 },
+  ]);
+  const spare = sout + subscriptions.length * EVENT_SIZE;
+  expect(bytes.subarray(spare, spare + EVENT_SIZE)).toEqual(new Uint8Array(EVENT_SIZE).fill(0xaa));
+});


### PR DESCRIPTION
### Problem
- `node:wasi`'s `poll_oneoff` writes each event as userdata (8) + errno (2) + type (1) + 5 bytes of padding and advances the output pointer by 16 (`src/js/node/wasi.ts`, the `sout += 8/2/1/5` sequences in both the clock arm and the fd_read/fd_write arm, lines 1538 to 1560 on main).
- A preview1 `event` is 32 bytes, so the guest reads `events[i]` from `out + 32 * i`. With two or more subscriptions, event 1 is written at `out + 16`, which is `events[0].fd_readwrite`, and the memory of `events[1]` is never written: the guest sees whatever was there before.
- Two or more subscriptions is the normal case: wasi-libc's `poll()` and `select()` submit the fd subscriptions plus one clock subscription for the timeout. A single subscription (`sleep()`) hides the bug, which is why `hello-wasi.wasm` style tests never caught it.
- Subscriptions are already read with the correct 48-byte stride; only the event records are wrong.

### Fix
- The two arms of the subscription `switch` now only compute the errno for the event; one block after the `switch` writes the whole record (userdata @0, errno @8, type @10, `fd_readwrite.nbytes` @16 and `.flags` @24, both zero) and advances `sout` by 32.
- 32 is the size of `event` in the preview1 ABI (`sizeof(__wasi_event_t) == 32` in wasi-libc, `UVWASI_SERDES_SIZE_event_t == 32` in the uvwasi serdes Node uses to write these records), so this is also what Node's `node:wasi` produces.
- Zeroing `fd_readwrite` matches what uvwasi reports for an fd event that carries an errno (this implementation always reports fd events as `ENOSYS`); clock events ignore the field, so zeroing it there only makes the output deterministic.
- Writing the record once after the `switch` is behavior preserving: both arms wrote userdata, errno and type and bumped `nevents`, and the clock arm's type byte was the `case` label, i.e. `type`. It also leaves one place that encodes the record layout.
- Test: `test/js/bun/wasm/wasi.test.js`, "poll_oneoff writes one 32-byte preview1 event record per subscription". Four subscriptions (fd_read, clock, fd_write, clock with an invalid clockid) cover both arms and the `EINVAL` clock path; the event area plus one spare record is pre-filled with `0xaa`, then the four decoded records are compared with one `toEqual` and the spare record is checked to still be `0xaa`. Fails on the released build (event 0 reports `nbytes: 2n`, slots 2 and 3 are still `0xaa`), passes with this change.
- Also checked end to end with a freestanding wasm guest that submits an fd_read plus clock subscription and dumps the event buffer: fixed build puts event 1 at +32 with `fd_readwrite` zeroed (output below).
- The `waitTimeNs -= Bun.nanoseconds() - timeOrigin` BigInt `TypeError` a few lines further down is a separate bug, fixed in #34470; this change does not touch those lines. #35709 (a larger `node:wasi` rework, currently a draft against a non-main branch) contains the same stride fix as part of its diff.

### Background
- WASI preview1 (`wasi_snapshot_preview1`) is the syscall ABI that wasm programs built with wasi-libc, Rust's `wasm32-wasip1` target, etc. import; `node:wasi` implements those imports on top of the host. Structs are passed through the guest's linear memory at fixed little-endian offsets, so the host has to write exactly the layout the guest's C headers describe.
- `poll_oneoff(in, out, nsubscriptions, nevents)` is the one blocking primitive in preview1: `in` points at `nsubscriptions` 48-byte `subscription` records (userdata u64, type u8, then a clock or fd payload), `out` at a guest-allocated array of `nsubscriptions` 32-byte `event` records (userdata u64 @0, errno u16 @8, type u8 @10, `fd_readwrite { nbytes u64 @16, flags u16 @24 }`), and the host stores the number of records it filled in through `nevents`. wasi-libc builds `sleep()`, `poll()` and `select()` on top of it.
- Bun's implementation reports every subscription as an event immediately: clock subscriptions as success (sleeping for the longest timeout afterwards), fd subscriptions as `ENOSYS`. This PR does not change that; it only fixes the shape of what gets written.

<details>
<summary>Freestanding wasm guest (fd_read on fd 0 + monotonic clock, timeout 0), event buffer pre-filled with 0xaa</summary>

Released 1.4.0:

```
nevents: 2
event[0] @+0:  { userdata: 1n, error: 52, type: 1, nbytes: 2n, flags: 0 }
event[1] @+32: { userdata: 12297829382473034410n, error: 43690, type: 170, nbytes: 12297829382473034410n, flags: 43690 }
```

With this change:

```
nevents: 2
event[0] @+0:  { userdata: 1n, error: 52, type: 1, nbytes: 0n, flags: 0 }
event[1] @+32: { userdata: 2n, error: 0, type: 0, nbytes: 0n, flags: 0 }
```

Node 26 running the same guest also lays its records out 32 bytes apart (it reports only the clock event, since uvwasi actually polls the fd; that difference is pre-existing and out of scope here).

</details>
