### PR TITLE
bun-types: make Bun.MessageEvent the instance type when lib.dom is loaded

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -54,6 +54,10 @@ declare module "bun" {
      *
      * Some symbols can't be declared in a way that satisfies both \@types/bun and lib.dom.d.ts,
      * so when lib.dom.d.ts is loaded, its definition wins.
+     *
+     * This is the type of the global *value*, so for a class it is the constructor type: use it for
+     * `declare var`. A global instance interface instead extends a `LibEmptyOr*` helper (globals.d.ts)
+     * so that Bun's members only apply when lib.dom.d.ts is not loaded.
      */
     type UseLibDomIfAvailable<GlobalThisKeyName extends PropertyKey, Otherwise> =
       // `onabort` is defined in lib.dom.d.ts, so we can check to see if lib dom is loaded by checking if `onabort` is defined
@@ -128,7 +132,13 @@ declare module "bun" {
     detail?: T;
   }
 
-  /** A message received by a target object. */
+  /**
+   * A message received by a target object.
+   *
+   * Bun's declaration of the global `MessageEvent` interface, which extends it unless lib.dom.d.ts
+   * is loaded (see globals.d.ts). Refer to message events as {@link MessageEvent Bun.MessageEvent},
+   * which is the global interface either way.
+   */
   interface BunMessageEvent<T = any> extends Event {
     /** Returns the data of the message. */
     readonly data: T;
@@ -141,7 +151,11 @@ declare module "bun" {
     readonly source: Bun.MessageEventSource | null;
   }
 
-  type MessageEvent<T = any> = Bun.__internal.UseLibDomIfAvailable<"MessageEvent", BunMessageEvent<T>>;
+  /**
+   * The global `MessageEvent` interface (an instance, not the constructor): lib.dom.d.ts's when it
+   * is loaded, otherwise {@link BunMessageEvent}.
+   */
+  type MessageEvent<T = any> = globalThis.MessageEvent<T>;
 
   interface ReadableStreamDefaultReadManyResult<T> {
     done: boolean;

--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -9,6 +9,7 @@ declare module "bun" {
 
     type LibWorkerOrBunWorker = LibDomIsLoaded extends true ? {} : Bun.Worker;
     type LibEmptyOrBunWebSocket = LibDomIsLoaded extends true ? {} : Bun.WebSocket;
+    type LibEmptyOrBunMessageEvent<T> = LibDomIsLoaded extends true ? {} : Bun.BunMessageEvent<T>;
 
     type LibEmptyOrNodeStreamWebCompressionStream = LibDomIsLoaded extends true
       ? {}
@@ -529,7 +530,7 @@ declare var CloseEvent: {
   new (type: string, eventInitDict?: Bun.CloseEventInit): CloseEvent;
 };
 
-interface MessageEvent<T = any> extends Bun.MessageEvent<T> {}
+interface MessageEvent<T = any> extends Bun.__internal.LibEmptyOrBunMessageEvent<T> {}
 declare var MessageEvent: Bun.__internal.UseLibDomIfAvailable<
   "MessageEvent",
   {

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -138,6 +138,48 @@ function typeTest(name: string, config: TypeTestConfig) {
   });
 }
 
+let tscCheckCounter = 0;
+
+/**
+ * Type-checks `files` against the packed bun-types with the `bun init` tsconfig (plus
+ * `compilerOptions`) by spawning tsc. Unlike {@link typeTest} this runs on debug builds too:
+ * tsc over a file or two is cheap, unlike the in-process LanguageService runs over the whole
+ * fixture directory.
+ */
+function tscTest(name: string, files: Record<string, string>, compilerOptions: Record<string, unknown> = {}) {
+  test.concurrent(name, async () => {
+    const checkDir = join(TEMP_DIR, `tsc-check-${tscCheckCounter++}`);
+    const tsconfig = structuredClone(sourceTsconfig);
+    tsconfig.include = Object.keys(files);
+    tsconfig.compilerOptions = {
+      ...tsconfig.compilerOptions,
+      typeRoots: [join(BASE_FIXTURE_DIR, "node_modules", "@types")],
+      ...compilerOptions,
+    };
+    await mkdir(checkDir, { recursive: true });
+    await makeTree(checkDir, { ...files, "tsconfig.json": JSON.stringify(tsconfig, null, 2) });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(BASE_FIXTURE_DIR, "node_modules", "typescript", "bin", "tsc"), "-p", "."],
+      env: bunEnv,
+      cwd: checkDir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr.trim()).toBe("");
+    expect(stdout.trim()).toBe("");
+    expect(exitCode).toBe(0);
+  });
+}
+
+/** The named files from `fixture/`, for re-checking them with {@link tscTest} under another tsconfig. */
+function fixtureFiles(...names: string[]): Record<string, string> {
+  return Object.fromEntries(names.map(name => [name, readFileSync(join(FIXTURE_SOURCE_DIR, name), "utf8")]));
+}
+
 async function diagnose(
   fixtureDir: string,
   config: {
@@ -367,36 +409,24 @@ describe("@types/bun integration test", () => {
     });
   });
 
-  // Runs on debug builds too: spawning tsc over a single file is cheap,
-  // unlike the in-process LanguageService runs above.
   describe("Bun.mmap", () => {
-    test("MMapOptions accepts offset and size", async () => {
-      const checkDir = join(TEMP_DIR, "mmap-options-check");
-      const tsconfig = structuredClone(sourceTsconfig);
-      tsconfig.include = ["mmap-options.ts"];
-      tsconfig.compilerOptions.typeRoots = [join(BASE_FIXTURE_DIR, "node_modules", "@types")];
-      await mkdir(checkDir, { recursive: true });
-      await makeTree(checkDir, {
-        "tsconfig.json": JSON.stringify(tsconfig, null, 2),
-        "mmap-options.ts": `const view = Bun.mmap("./data.bin", { shared: true, sync: false, offset: 4096, size: 1024 });
+    tscTest("MMapOptions accepts offset and size", {
+      "mmap-options.ts": `const view = Bun.mmap("./data.bin", { shared: true, sync: false, offset: 4096, size: 1024 });
            view satisfies Uint8Array<ArrayBuffer>;
            Bun.mmap("./data.bin", { offset: 4096 }) satisfies Uint8Array<ArrayBuffer>;
            Bun.mmap("./data.bin", { size: 1024 }) satisfies Uint8Array<ArrayBuffer>;`,
-      });
+    });
+  });
 
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), join(BASE_FIXTURE_DIR, "node_modules", "typescript", "bin", "tsc"), "-p", "."],
-        env: bunEnv,
-        cwd: checkDir,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
+  // The typeTest runs over the fixture directory already cover message-event.ts on release builds;
+  // this covers it on debug builds too. Loading lib.dom.d.ts is the case that used to break:
+  // Bun.MessageEvent resolved to lib.dom's MessageEvent constructor type instead of the instance.
+  describe("MessageEvent", () => {
+    const files = fixtureFiles("message-event.ts", "utilities.ts");
 
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-      expect(stderr.trim()).toBe("");
-      expect(stdout.trim()).toBe("");
-      expect(exitCode).toBe(0);
+    tscTest("Bun.MessageEvent is the instance type without lib.dom.d.ts", files);
+    tscTest("Bun.MessageEvent is the instance type with lib.dom.d.ts", files, {
+      lib: ["ESNext", "DOM", "DOM.Iterable", "DOM.AsyncIterable"],
     });
   });
 

--- a/test/integration/bun-types/fixture/message-event.ts
+++ b/test/integration/bun-types/fixture/message-event.ts
@@ -1,0 +1,52 @@
+// Checked with and without lib.dom.d.ts (bun-types.test.ts also re-checks this file via spawned
+// tsc so debug builds cover it). Bun.MessageEvent must be the instance type of whichever global
+// MessageEvent is in effect; with lib.dom.d.ts loaded it used to be lib.dom's constructor type.
+import { expectType } from "./utilities";
+
+expectType<Bun.MessageEvent>().is<MessageEvent>();
+expectType<Bun.MessageEvent<string>>().is<MessageEvent<string>>();
+
+declare const event: MessageEvent<string>;
+expectType(event.data).is<string>();
+expectType(event.lastEventId).is<string>();
+expectType(event.origin).is<string>();
+expectType(event.ports).is<readonly MessagePort[]>();
+event.initMessageEvent;
+// @ts-expect-error only the constructor has a prototype
+event.prototype;
+// @ts-expect-error an instance is not constructable
+new event("message");
+
+declare const bunEvent: Bun.MessageEvent<string>;
+expectType(bunEvent.data).is<string>();
+// @ts-expect-error only the constructor has a prototype
+bunEvent.prototype;
+
+new MessageEvent("message", { data: "hi" }) satisfies MessageEvent;
+
+// Everything in bun-types that is declared in terms of Bun.MessageEvent
+expectType<Bun.WebSocketEventMap["message"]>().is<MessageEvent>();
+expectType<Bun.WorkerEventMap["message"]>().is<MessageEvent>();
+expectType<Bun.WorkerEventMap["messageerror"]>().is<MessageEvent>();
+expectType<Bun.EventSourceEventMap["message"]>().is<MessageEvent>();
+expectType<Bun.EventMap["message"]>().is<MessageEvent>();
+expectType<Bun.EventMap["messageerror"]>().is<MessageEvent>();
+
+declare const ws: Bun.WebSocket;
+ws.onmessage = e => expectType(e).is<MessageEvent>();
+ws.addEventListener("message", e => expectType(e).is<MessageEvent>());
+
+declare const worker: Bun.Worker;
+worker.onmessage = e => expectType(e).is<MessageEvent>();
+worker.onmessageerror = e => expectType(e).is<MessageEvent>();
+worker.addEventListener("messageerror", e => expectType(e).is<MessageEvent>());
+
+declare const eventSource: Bun.EventSource;
+eventSource.onmessage = e => expectType(e).is<MessageEvent>();
+
+// CDP events carry their params as `data` (the example in its JSDoc reads `e.data.response`)
+declare const view: Bun.WebView;
+view.addEventListener("Network.responseReceived", e => expectType(e).is<MessageEvent<unknown>>());
+view.addEventListener<{ response: { status: number } }>("Network.responseReceived", e =>
+  expectType(e.data.response.status).is<number>(),
+);


### PR DESCRIPTION
Types only, no runtime change.

### Problem

- With `lib.dom` in the compilation (`lib: ["ESNext", "DOM"]` plus bun-types), `Bun.MessageEvent<T>` is the `MessageEvent` constructor type, not an event. Reading `e.data` on anything bun-types declares in terms of it fails with `error TS2339: Property 'data' does not exist on type '{ new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }'`. That covers `Bun.WebSocket`'s `onmessage` / `"message"` listeners, `Bun.Worker`'s `onmessage` / `onmessageerror`, `Bun.EventSource.onmessage`, the `message` entries of `Bun.WebSocketEventMap` / `WorkerEventMap` / `EventSourceEventMap` / `EventMap`, and `Bun.WebView.addEventListener`, whose own JSDoc example (`e.data.response.status`) does not type-check in that configuration.
- The same alias is the base of the global interface (`packages/bun-types/globals.d.ts:532`, `interface MessageEvent<T> extends Bun.MessageEvent<T> {}`), so with `lib.dom` every `MessageEvent` instance also gets a `prototype` property and a construct signature: `e.prototype` and `new e("x")` on an instance are accepted.
- Cause: `packages/bun-types/bun.d.ts:144` defined the alias as `UseLibDomIfAvailable<"MessageEvent", BunMessageEvent<T>>`. That helper infers the type of `globalThis.MessageEvent`, which is the constructor. It is correct at every other use in bun-types because those are all `declare var`; this alias was the one use of it in a type position.
- Without `lib.dom` nothing is wrong, which is why no fixture caught it: the existing `MessageEvent` fixture lines go through the global `WebSocket` / `Worker`, which are `lib.dom`'s in that run.

### Fix

- `globals.d.ts`: the global `interface MessageEvent<T>` now extends a new `LibEmptyOrBunMessageEvent<T>` (`{}` with `lib.dom`, `Bun.BunMessageEvent<T>` without), the same pattern the global `WebSocket` and `Worker` interfaces already use (`LibEmptyOrBunWebSocket`, `LibWorkerOrBunWorker`). This is the line that removes the `prototype` / construct-signature pollution.
- `bun.d.ts`: `Bun.MessageEvent<T>` becomes `globalThis.MessageEvent<T>`. This is the line that fixes every declaration listed above at once, since they are all written in terms of the alias.
- Why this is right: the alias was always meant to be "lib.dom's `MessageEvent` when loaded, Bun's otherwise" (the helper's documented purpose); it just picked up the value side of the global instead of the instance side. Pointing it at the global interface gives exactly that in both configurations: with `lib.dom` the global interface is `lib.dom`'s, without it the global interface is made of `BunMessageEvent` (so `Bun.MessageEvent` is structurally what it was before, and additionally picks up user augmentations of the global). Neither side can reference the other's alias any more, so there is no circular base type. `BunMessageEvent` stays as is (`deprecated.d.ts` augments it, and it remains reachable as `Bun.BunMessageEvent`).
- The `UseLibDomIfAvailable` JSDoc now says it yields the constructor type and that instance interfaces use the `LibEmptyOr*` pattern, so the same mistake is harder to repeat.
- Tests: `test/integration/bun-types/fixture/message-event.ts` asserts `Bun.MessageEvent<T>` is identical to the global `MessageEvent<T>`, that instances have `data` / `lastEventId` / `origin` / `ports` and no `prototype` or construct signature, and that each declaration listed under Problem yields `MessageEvent`. The fixture directory is type-checked with and without `lib.dom` by the existing in-process cases; since those are release-only, a new `MessageEvent` block in `bun-types.test.ts` re-checks the same file under both lib settings by spawning tsc, which also runs under `bun bd test`. The one-off tsc spawn that `Bun.mmap` used becomes a `tscTest` helper so the three cases share it.
- Verified: `bun test test/integration/bun-types/bun-types.test.ts` passes 17/17 on this branch. With the two `.d.ts` changes reverted, the spawned `with lib.dom.d.ts` case and the in-process `checks with lib.dom.d.ts` case fail on 20 lines of `message-event.ts` (identity checks, unused `@ts-expect-error` directives on `prototype` / `new`, and the `data` reads), while every no-`lib.dom` case still passes. Under the debug binary the same file runs 5 pass / 12 skipped with the fix and 4 pass / 1 fail without it. Expected empty-interface sets and the `lib.dom` diagnostics list are unchanged.

### Background

- bun-types is type-checked both with and without `lib.dom.d.ts`, and `lib.dom` must win for globals it declares. `Bun.__internal.LibDomIsLoaded` detects it; `UseLibDomIfAvailable<Name, Fallback>` reads `typeof globalThis` for `Name` when it is loaded, which for a class global is the constructor object, and is used to redeclare `declare var X` without conflicting. The `LibEmptyOr*` helpers in `globals.d.ts` are the instance-side counterpart: `interface X extends LibEmptyOrBunX {}` contributes Bun's members to the global interface only when `lib.dom` is absent, so the interface merge with `lib.dom`'s declaration stays empty and conflict-free.
- Inside `declare module "bun"`, an unqualified `MessageEvent` is the module's own alias, so the global interface is reached as `globalThis.MessageEvent<T>`. Every bun-types declaration in that module (`WebSocketEventMap`, `Worker.onmessage`, `WebView.addEventListener`, ...) names the alias, which is why one line fixes all of them.
- `bun-types.test.ts` packs bun-types and type-checks `fixture/` in-process with and without `lib.dom`; the `lib.dom` run asserts an exact `file:line:col` list of diagnostics, which is why the new assertions live in a new fixture file rather than in an existing one. Those in-process cases are `skipIf(isDebug)`, so cases that must also run on debug builds spawn tsc over individual files instead.

<details>
<summary>Repro (tsc 6.0.2, lib ESNext + DOM, bun-types on main)</summary>

```ts
declare const e: MessageEvent;
e.prototype;   // accepted, should be TS2339
new e("x");    // accepted, should be TS2351

declare const b: Bun.MessageEvent<string>;
b.data;        // TS2339: Property 'data' does not exist on type '{ new <T>(...): MessageEvent<T>; prototype: MessageEvent<any>; }'

declare const ws: Bun.WebSocket;
ws.onmessage = ev => ev.data;   // same TS2339

declare const view: Bun.WebView;
view.addEventListener("Network.responseReceived", ev => ev.data);   // same TS2339
```

All of these are correct with `lib: ["ESNext"]`, and all are correct in both configurations on this branch.

</details>
