### PR TITLE
node:buffer: writing into a detached Buffer returns 0 like Node instead of aborting

### DIFF
--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -2422,13 +2422,8 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_writeEncodingBody(JSC::VM& 
         }
     }
 
-    // Re-check if detached after potential JS execution
-    if (castedThis->isDetached()) [[unlikely]] {
-        throwTypeError(lexicalGlobalObject, scope, "ArrayBufferView is detached"_s);
-        return {};
-    }
-
-    // Now safe to cache byteLength after all JS calls
+    // Now safe to cache byteLength after all JS calls. A detached view reports 0, so it
+    // goes through the same bounds checks as an empty buffer and writes nothing, as in node.
     size_t byteLength = castedThis->byteLength();
 
     // Node.js JS wrapper checks: if (offset < 0 || offset > this.byteLength)
@@ -2480,11 +2475,6 @@ static JSC::EncodedJSValue jsBufferPrototypeFunctionWriteWithEncoding(JSC::JSGlo
 
     if (!castedThis) [[unlikely]] {
         throwTypeError(lexicalGlobalObject, scope, "Expected ArrayBufferView"_s);
-        return {};
-    }
-
-    if (castedThis->isDetached()) [[unlikely]] {
-        throwTypeError(lexicalGlobalObject, scope, "ArrayBufferView is detached"_s);
         return {};
     }
 

--- a/src/runtime/webcore/encoding.rs
+++ b/src/runtime/webcore/encoding.rs
@@ -1,8 +1,6 @@
 //! Contains helpers for C++ to do TextEncoder/Decoder like operations.
 //! Also contains the code used by `bun.String.encode` and `bun.String.encodeInto`
 
-use core::slice;
-
 use crate::node::types::Encoding;
 use crate::webcore::jsc::{JSGlobalObject, JSValue, JsResult, StringJsc as _};
 use bun_core::String as BunString;
@@ -589,15 +587,17 @@ fn byte_length_u8<const ENCODING: u8>(input: &[u8]) -> usize {
 
 /// # Safety
 /// `input` must be valid for reading `len` `u16`s and `to` must be valid for
-/// writing `to_len` bytes. For `Ucs2`/`Utf16le` the ranges may overlap (memmove
-/// semantics); for all other encodings they must not.
+/// writing `to_len` bytes; either pointer may be null when its length is 0 (a
+/// detached `ArrayBufferView` has a null vector and a byte length of 0). For
+/// `Ucs2`/`Utf16le` the ranges may overlap (memmove semantics); for all other
+/// encodings they must not.
 pub(crate) unsafe fn write_u16<const ENCODING: u8, const ALLOW_PARTIAL_WRITE: bool>(
     input: *const u16,
     len: usize,
     to: *mut u8,
     to_len: usize,
 ) -> Result<usize, crate::Error> {
-    if len == 0 {
+    if len == 0 || to_len == 0 {
         return Ok(0);
     }
 
@@ -615,7 +615,7 @@ pub(crate) unsafe fn write_u16<const ENCODING: u8, const ALLOW_PARTIAL_WRITE: bo
             let (input_slice, to_slice) = unsafe {
                 (
                     bun_core::ffi::slice(input, len),
-                    slice::from_raw_parts_mut(to, to_len),
+                    bun_core::ffi::slice_mut(to, to_len),
                 )
             };
             Ok(
@@ -630,7 +630,7 @@ pub(crate) unsafe fn write_u16<const ENCODING: u8, const ALLOW_PARTIAL_WRITE: bo
             let (input_slice, to_slice) = unsafe {
                 (
                     bun_core::ffi::slice(input, out),
-                    slice::from_raw_parts_mut(to, to_len),
+                    bun_core::ffi::slice_mut(to, to_len),
                 )
             };
             strings::copy_u16_into_u8(to_slice, input_slice);
@@ -666,7 +666,7 @@ pub(crate) unsafe fn write_u16<const ENCODING: u8, const ALLOW_PARTIAL_WRITE: bo
             let (input_slice, to_slice) = unsafe {
                 (
                     bun_core::ffi::slice(input, len),
-                    slice::from_raw_parts_mut(to, to_len),
+                    bun_core::ffi::slice_mut(to, to_len),
                 )
             };
             Ok(strings::decode_hex_to_bytes_truncate(to_slice, input_slice))

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -4461,6 +4461,103 @@ describe("raw <enc>Slice / <enc>Write bindings match Node", () => {
         exitCode: 0,
       });
     });
+
+    // Node treats a detached buffer as empty: every writer returns 0, and offset/length
+    // are range-checked against its byteLength of 0 like for any other buffer.
+    describe("on a detached buffer", () => {
+      const detached = () => {
+        const ab = new ArrayBuffer(9);
+        const buf = Buffer.from(ab);
+        structuredClone(ab, { transfer: [ab] });
+        return buf;
+      };
+      // Latin-1 and UTF-16 strings go through different native encoders, so cover both.
+      const inputs = method => [source[method], source[method] + "\u00e9\u4e2d"];
+
+      it.each(strict)("%s returns 0", method => {
+        for (const str of inputs(method)) {
+          expect([
+            detached()[method](str),
+            detached()[method](str, 0),
+            detached()[method](str, 0, 0),
+            detached()[method](str, NaN),
+            detached()[method](str, 0, NaN),
+          ]).toEqual([0, 0, 0, 0, 0]);
+        }
+      });
+
+      it.each(strict)("%s reports an offset or length past the end as ERR_BUFFER_OUT_OF_BOUNDS", method => {
+        for (const str of inputs(method)) {
+          expect(() => detached()[method](str, 1)).toThrow(OUT_OF_BOUNDS);
+          expect(() => detached()[method](str, -1)).toThrow(OUT_OF_BOUNDS);
+          expect(() => detached()[method](str, 0, 1)).toThrow(OUT_OF_BOUNDS);
+        }
+      });
+
+      it.each(clamping)("%s returns 0 and still rejects an offset past the end", method => {
+        for (const str of inputs(method)) {
+          expect([detached()[method](str), detached()[method](str, 0, 1)]).toEqual([0, 0]);
+          expect(() => detached()[method](str, 1)).toThrow(OUT_OF_BOUNDS);
+        }
+      });
+
+      // Detaching from inside the offset/length coercion ends up in the same place: the
+      // byteLength read after coercion is 0, so the arguments are checked against that.
+      it.each(strict)("%s detached by an offset or length valueOf is checked against the empty buffer", method => {
+        const write = argsFor => {
+          const ab = new ArrayBuffer(9);
+          const buf = Buffer.from(ab);
+          const detaching = value => ({
+            valueOf() {
+              if (!ab.detached) structuredClone(ab, { transfer: [ab] });
+              return value;
+            },
+          });
+          return buf[method](source[method], ...argsFor(detaching));
+        };
+        expect(() => write(detaching => [detaching(5)])).toThrow(OUT_OF_BOUNDS);
+        expect(() => write(detaching => [0, detaching(5)])).toThrow(OUT_OF_BOUNDS);
+        expect(write(detaching => [detaching(0), 0])).toBe(0);
+        expect(write(detaching => [0, detaching(0)])).toBe(0);
+      });
+
+      // A detached view hands the native encoder a null destination pointer with length 0.
+      // Run the 16-bit string cases in a child process so a native abort in the encoder
+      // shows up as a non-zero exit code instead of taking down the test run.
+      it("write() and <enc>Write of a 16-bit string exit cleanly", async () => {
+        await using proc = Bun.spawn({
+          cmd: [
+            bunExe(),
+            "-e",
+            `const detached = () => {
+               const ab = new ArrayBuffer(9);
+               const buf = Buffer.from(ab);
+               structuredClone(ab, { transfer: [ab] });
+               return buf;
+             };
+             const str = "h\\u00e9llo \\u4e2d";
+             console.log(JSON.stringify([
+               detached().write(str),
+               detached().write(str, 0),
+               detached().write(str, 0, 0),
+               detached().utf8Write(str),
+               detached().latin1Write(str),
+               detached().asciiWrite(str),
+               detached().utf8Write(str, NaN),
+               detached().write("hello"),
+             ]));`,
+          ],
+          env: bunEnv,
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+          stdout: "[0,0,0,0,0,0,0,0]",
+          stderr: expect.any(String),
+          exitCode: 0,
+        });
+      });
+    });
   });
 });
 


### PR DESCRIPTION
### Problem
- `buf.write(str)` on a Buffer whose ArrayBuffer has been detached aborts a debug build when `str` is a 16-bit (non-Latin-1) string. Release builds return 0, but run the same undefined behavior. Node returns 0.
  ```
  panic: unsafe precondition(s) violated: slice::from_raw_parts_mut requires the pointer to be aligned and non-null, and the total size of the slice not to exceed `isize::MAX`
  core::slice::raw::from_raw_parts_mut::<u8>
  bun_runtime::webcore::encoding::write_u16::<0, false>      src/runtime/webcore/encoding.rs:618
  Bun__encoding__writeUTF16                                   src/runtime/webcore/encoding.rs:146
  WebCore::writeToBuffer                                      src/jsc/bindings/JSBuffer.cpp:456
  WebCore::jsBufferPrototypeFunction_writeBody
  ```
- Cause: JSC gives a detached view a null vector and a byte length of 0, so `writeToBuffer` (`src/jsc/bindings/JSBuffer.cpp:421-456`) calls the encoder with the destination `(nullptr, 0)`. `write_u16` builds its output slice with a bare `slice::from_raw_parts_mut(to, to_len)` in its utf8, latin1/ascii and hex arms (`src/runtime/webcore/encoding.rs:618`, `:633`, `:669` on main), and `from_raw_parts_mut` requires a non-null pointer even for a zero-length slice. The Latin-1 entry point (`Bun__encoding__writeLatin1`) and the base64 arm of `write_u16` already go through `bun_core::ffi::slice_mut`, which is why `buf.write("ab")` on the same detached buffer returns 0.
- Related: `utf8Write`, `latin1Write` and `asciiWrite` on a detached Buffer throw a bare `TypeError: ArrayBufferView is detached` (`JSBuffer.cpp:2426` and `:2486` on main). Node returns 0, or throws `ERR_BUFFER_OUT_OF_BOUNDS` when an offset or length is given that does not fit in the now empty buffer. `hexWrite`/`ucs2Write`/`base64Write`/`base64urlWrite` already match Node here (they return before reaching the encoder when no space is left).

### Fix
- `write_u16` returns 0 for an empty destination, the same early return `write_u8` has, and builds its output slices with `bun_core::ffi::slice_mut` like the rest of the file. The `ffi::slice_mut` change is the line that fixes the abort: it accepts the C convention of `(null, 0)` for an empty range. Either change alone is enough; the early return keeps the two encoders symmetric and skips the base64 arm's temporary allocation when nothing can be written.
- Removes the two `isDetached()` TypeErrors in front of `utf8Write`/`latin1Write`/`asciiWrite` (`jsBufferPrototypeFunctionWriteWithEncoding` and `jsBufferPrototypeFunction_writeEncodingBody`). This is correct because the body reads `byteLength()` after all argument coercion has run and a detached view reports 0 there, so a detached buffer goes through exactly the checks Node's JS wrappers apply to an empty one (`lib/internal/buffer.js`, linked above the function): `offset > 0` or `length > 0` throw `ERR_BUFFER_OUT_OF_BOUNDS`, otherwise the encoder is called with a zero-length destination and returns 0. The removed checks were also the only thing preventing the same abort for `detached.utf8Write("\u00e9")`. A buffer detached from inside an offset/length `valueOf` lands in the same place, since that read happens after coercion; this is the same treatment the function already gives a resizable buffer that is shrunk from inside `valueOf`.
- Not changed here: the `write(str, encoding)` forms still throw the same bare TypeError on a detached buffer; #30138 replaces those guards with Node's re-validation; this change makes the encoder safe for the zero-length writes that approach relies on, whichever of the two lands first. The `hexWrite`-family re-checks that fire only when an object argument detaches the buffer mid-call are left as they are (covered by existing tests in this block).
- Verified with `test/js/node/buffer.test.js`, new `describe("on a detached buffer")` inside the `<enc>Write` block. On the unfixed build, 10 of the 15 tests fail: the `utf8Write`/`latin1Write`/`asciiWrite` tests fail with the bare TypeError on both a release build and a debug build, and the spawned test fails because the child aborts with the panic above on a debug build (it throws the TypeError on release, where the `write()` calls happen to survive). With the fix all 15 pass, as does the rest of `buffer.test.js` (633 tests), the upstream `test-buffer-write.js`, `test-buffer-write-fast.js`, `test-buffer-fill.js`, `test-buffer-alloc.js`, and `buffer-copy-fill-detach.test.ts` / `buffer-indexOf-detach.test.ts` / `buffer-utf16.test.ts`.
- Other callers of the two encoder entry points (`BunStreamConsumers.cpp`, `napi.cpp`) and `Bun__Buffer_fill` only pass non-null destinations, so they are unaffected. The same `from_raw_parts` pattern exists in `TextEncoder.encodeInto` and in `SecureContext.parsePkcs12`; those are different APIs with their own repros and are being fixed separately.

### Background
- Detaching: `ArrayBuffer.prototype.transfer()` and `structuredClone(ab, { transfer })` move an ArrayBuffer's memory elsewhere. JSC then sets every view on it to length 0 and clears its data pointer (`JSArrayBufferView::detachFromArrayBuffer`), so `vector()` is null and `byteLength()` is 0. Views on non-detached buffers, including zero-length ones, keep a non-null pointer, which is why only detached buffers reach this.
- `bun_core::ffi::slice` / `slice_mut`: the repo's constructors for slices built from a raw `(pointer, length)` pair that crossed the C ABI. Unlike `core::slice::from_raw_parts(_mut)`, they return an empty slice for `(null, 0)` instead of invoking undefined behavior; Rust's debug builds turn that UB into the abort quoted above.
- `write_u8` / `write_u16`: the Rust encoders behind `Buffer.prototype.write` and its per-encoding variants. C++ picks one based on whether the JS string is stored as Latin-1 or UTF-16, which is why the 8-bit and 16-bit variants of the same call behaved differently.
- `utf8Write`/`latin1Write`/`asciiWrite` vs `hexWrite`/`ucs2Write`/`base64Write`: in Node the first three go through a JS wrapper that throws `ERR_BUFFER_OUT_OF_BOUNDS` for an offset or length that does not fit, while the others are raw bindings that clamp. Bun implements the two groups as two different C++ functions; only the first group had the detached guards.

<details>
<summary>Node v26.3.0 vs Bun on a detached 9-byte Buffer</summary>

```
detached.write("h\u00e9llo \u4e2d")          node: 0     bun (debug): abort, bun (release): 0
detached.write("h\u00e9llo \u4e2d", 0)       node: 0     bun (debug): abort
detached.write("hello")                      node: 0     bun: 0
detached.utf8Write("hello")                  node: 0     bun: TypeError: ArrayBufferView is detached
detached.utf8Write("hello", NaN)             node: 0     bun: TypeError
detached.utf8Write("hello", 1)               node: RangeError ERR_BUFFER_OUT_OF_BOUNDS   bun: TypeError
detached.utf8Write("hello", 0, 1)            node: RangeError ERR_BUFFER_OUT_OF_BOUNDS   bun: TypeError
(same for latin1Write / asciiWrite)
detached.hexWrite("68656c")                  node: 0     bun: 0
detached.hexWrite("68656c", 1)               node: RangeError ERR_BUFFER_OUT_OF_BOUNDS   bun: same
detached.write("hello", "utf8")              node: 0     bun: TypeError (unchanged here, see #30138)
```

Detach from inside the argument coercion of the strict group (one-shot detach in `valueOf`):

```
utf8Write(s, detaching(5))        node: ERR_BUFFER_OUT_OF_BOUNDS "offset"   bun after: same   bun before: TypeError
utf8Write(s, 0, detaching(5))     node: ERR_BUFFER_OUT_OF_BOUNDS "length"   bun after: same   bun before: TypeError
utf8Write(s, detaching(0), 0)     node: 0                                   bun after: 0      bun before: TypeError
utf8Write(s, 0, detaching(0))     node: 0                                   bun after: 0      bun before: TypeError
utf8Write(s, detaching(0))        node: ERR_BUFFER_OUT_OF_BOUNDS "length"   bun after: 0      bun before: TypeError
```

The last row differs because Node's wrapper computes the default length from the byte length it read before coercing `offset`; Bun's body reads it once after coercion, which is also how it already treats a buffer shrunk from inside `valueOf`. The test does not assert that row.
</details>
