### PR TITLE
webview: settle every view's pending promises when Chrome dies

### DIFF
--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -646,12 +646,13 @@ static void settle(JSGlobalObject* g, JSWebView* view, PendingSlot slot, bool ok
     settleSlot(g, view, slotFor(view, slot), ok, v);
 }
 
-// The view's page (or all of Chrome) is gone: no further reply or event
-// will arrive for it. Rejects whatever is still awaited by walking the
-// slots themselves, not m_pending: a navigate()/reload()/goBack() whose
-// CDP reply already came back has no m_pending entry (it is waiting on
-// Page.loadEventFired) but its Navigate slot is still set. settleSlot is
-// a no-op on an empty slot. Same contract as HostClient::rejectAllAndMarkDead.
+// Nothing will settle this view's work anymore: it was closed, its page
+// detached, or Chrome itself is gone. Rejects whatever is still awaited by
+// walking the slots themselves, not m_pending: a navigate()/reload()/
+// goBack() whose CDP reply already came back has no m_pending entry (it is
+// waiting on Page.loadEventFired) but its Navigate slot is still set.
+// settleSlot is a no-op on an empty slot. Same contract as
+// HostClient::rejectAllAndMarkDead.
 static void rejectViewSlots(JSGlobalObject* g, JSWebView* view, JSValue err)
 {
     view->m_loading = false;
@@ -1294,21 +1295,28 @@ void Transport::rejectAllAndMarkDead(const WTF::String& reason)
     m_mode = TransportMode::None;
     m_wsOpen = false;
     m_wsPending.clear();
+    // Detach the routing tables before settling anything. Settling a
+    // promise allocates, and a GC that finalizes inside that allocation
+    // runs ~JSWebView() for any view the user dropped without close(),
+    // which removes the view from m_views: the member map can change
+    // while this function runs, the local one cannot. A view collected
+    // that way is a null Weak here and has nothing pending by definition
+    // (pending activity is what keeps a view alive).
+    m_pending.clear();
+    m_sessions.clear();
+    auto views = std::exchange(m_views, {});
     if (!m_global) return;
     auto* g = m_global;
     JSValue err = createError(g, reason);
-    // Every live view, not just the ones with an entry in m_pending: a
-    // navigation that is past its Page.navigate reply is only reachable
-    // through its slot (see rejectViewSlots). Views that left m_views
-    // earlier (close(), detachedFromTarget) had their slots rejected then,
-    // so any m_pending entries they left behind have nothing to settle.
-    for (auto& weak : m_views.values()) {
+    // Every view that was still registered, not just the ones with an
+    // entry in m_pending: a navigation that is past its Page.navigate
+    // reply is only reachable through its slot (see rejectViewSlots).
+    // Views that left m_views earlier (close(), detachedFromTarget) had
+    // their slots rejected at that point.
+    for (auto& weak : views.values()) {
         if (JSWebView* v = weak.get())
             rejectViewSlots(g, v, err);
     }
-    m_pending.clear();
-    m_sessions.clear();
-    m_views.clear();
     updateKeepAlive();
 }
 
@@ -1715,15 +1723,7 @@ JSPromise* reload(JSGlobalObject* g, JSWebView* view)
 void close(JSWebView* view)
 {
     auto& t = transport();
-    if (t.m_global) {
-        auto* g = t.m_global;
-        JSValue err = createError(g, "WebView closed"_s);
-        settleSlot(g, view, view->m_pendingNavigate, false, err);
-        settleSlot(g, view, view->m_pendingEval, false, err);
-        settleSlot(g, view, view->m_pendingScreenshot, false, err);
-        settleSlot(g, view, view->m_pendingMisc, false, err);
-        settleSlot(g, view, view->m_pendingCdp, false, err);
-    }
+    if (auto* g = t.m_global) rejectViewSlots(g, view, createError(g, "WebView closed"_s));
     // Prune m_pending entries for this view — the attach chain
     // (TargetCreateTarget → TargetAttachToTarget → PageEnable →
     // PageNavigate) holds Weak<view> per step and each step chains to the

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -646,9 +646,8 @@ static void settle(JSGlobalObject* g, JSWebView* view, PendingSlot slot, bool ok
     settleSlot(g, view, slotFor(view, slot), ok, v);
 }
 
-// Rejects everything the view still awaits. Walks the slots, not m_pending:
-// a navigation drops its m_pending entry when Page.navigate replies and
-// then waits for Page.loadEventFired with only its slot set.
+// Slots, not m_pending: a navigation that Chrome has already answered is
+// waiting for Page.loadEventFired and exists only in its slot.
 static void rejectViewSlots(JSGlobalObject* g, JSWebView* view, JSValue err)
 {
     view->m_loading = false;
@@ -1291,12 +1290,9 @@ void Transport::rejectAllAndMarkDead(const WTF::String& reason)
     m_mode = TransportMode::None;
     m_wsOpen = false;
     m_wsPending.clear();
-    // Settling allocates, and a GC in that allocation can run ~JSWebView()
-    // for a view dropped without close(), which removes it from m_views.
-    // Move the map into a local first so that removal never hits the map
-    // being iterated.
     m_pending.clear();
     m_sessions.clear();
+    // ~JSWebView() (a GC while settling) removes from m_views; iterate a local.
     auto views = std::exchange(m_views, {});
     if (!m_global) return;
     auto* g = m_global;

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -646,6 +646,22 @@ static void settle(JSGlobalObject* g, JSWebView* view, PendingSlot slot, bool ok
     settleSlot(g, view, slotFor(view, slot), ok, v);
 }
 
+// The view's page (or all of Chrome) is gone: no further reply or event
+// will arrive for it. Rejects whatever is still awaited by walking the
+// slots themselves, not m_pending: a navigate()/reload()/goBack() whose
+// CDP reply already came back has no m_pending entry (it is waiting on
+// Page.loadEventFired) but its Navigate slot is still set. settleSlot is
+// a no-op on an empty slot. Same contract as HostClient::rejectAllAndMarkDead.
+static void rejectViewSlots(JSGlobalObject* g, JSWebView* view, JSValue err)
+{
+    view->m_loading = false;
+    settleSlot(g, view, view->m_pendingNavigate, false, err);
+    settleSlot(g, view, view->m_pendingEval, false, err);
+    settleSlot(g, view, view->m_pendingScreenshot, false, err);
+    settleSlot(g, view, view->m_pendingMisc, false, err);
+    settleSlot(g, view, view->m_pendingCdp, false, err);
+}
+
 // Build an Error from CDP exceptionDetails. exception.description is V8's
 // Error.prototype.stack formatter:
 //   "Error: msg\n    at functionName (url:line:col)\n    at ..."
@@ -1069,10 +1085,7 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         JSWebView* view = viewFor(vid);
         m_views.remove(vid);
         if (!view) return;
-        // Reject all pending slots. settle() is idempotent on empty slots.
-        auto* err = createError(g, "page detached (crashed or closed)"_s);
-        for (auto s : { PendingSlot::Navigate, PendingSlot::Evaluate, PendingSlot::Screenshot, PendingSlot::Misc, PendingSlot::Cdp })
-            settle(g, view, s, false, err);
+        rejectViewSlots(g, view, createError(g, "page detached (crashed or closed)"_s));
         // Erase stale m_pending entries — replies won't come.
         m_pending.removeIf([vid](auto& kv) { return kv.value.viewId == vid; });
         view->m_closed = true;
@@ -1284,13 +1297,14 @@ void Transport::rejectAllAndMarkDead(const WTF::String& reason)
     if (!m_global) return;
     auto* g = m_global;
     JSValue err = createError(g, reason);
-    // Reject each view's slots via settle(). Multiple pending ids may point
-    // at the same view (different slots); settle() is idempotent on an
-    // already-cleared slot — the first settle for a slot rejects, the rest
-    // find barrier.get() == null and no-op.
-    for (auto& [id, entry] : m_pending) {
-        if (JSWebView* v = viewFor(entry.viewId))
-            settle(g, v, entry.slot, false, err);
+    // Every live view, not just the ones with an entry in m_pending: a
+    // navigation that is past its Page.navigate reply is only reachable
+    // through its slot (see rejectViewSlots). Views that left m_views
+    // earlier (close(), detachedFromTarget) had their slots rejected then,
+    // so any m_pending entries they left behind have nothing to settle.
+    for (auto& weak : m_views.values()) {
+        if (JSWebView* v = weak.get())
+            rejectViewSlots(g, v, err);
     }
     m_pending.clear();
     m_sessions.clear();

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -646,13 +646,9 @@ static void settle(JSGlobalObject* g, JSWebView* view, PendingSlot slot, bool ok
     settleSlot(g, view, slotFor(view, slot), ok, v);
 }
 
-// Nothing will settle this view's work anymore: it was closed, its page
-// detached, or Chrome itself is gone. Rejects whatever is still awaited by
-// walking the slots themselves, not m_pending: a navigate()/reload()/
-// goBack() whose CDP reply already came back has no m_pending entry (it is
-// waiting on Page.loadEventFired) but its Navigate slot is still set.
-// settleSlot is a no-op on an empty slot. Same contract as
-// HostClient::rejectAllAndMarkDead.
+// Rejects everything the view still awaits. Walks the slots, not m_pending:
+// a navigation drops its m_pending entry when Page.navigate replies and
+// then waits for Page.loadEventFired with only its slot set.
 static void rejectViewSlots(JSGlobalObject* g, JSWebView* view, JSValue err)
 {
     view->m_loading = false;
@@ -1295,24 +1291,16 @@ void Transport::rejectAllAndMarkDead(const WTF::String& reason)
     m_mode = TransportMode::None;
     m_wsOpen = false;
     m_wsPending.clear();
-    // Detach the routing tables before settling anything. Settling a
-    // promise allocates, and a GC that finalizes inside that allocation
-    // runs ~JSWebView() for any view the user dropped without close(),
-    // which removes the view from m_views: the member map can change
-    // while this function runs, the local one cannot. A view collected
-    // that way is a null Weak here and has nothing pending by definition
-    // (pending activity is what keeps a view alive).
+    // Settling allocates, and a GC in that allocation can run ~JSWebView()
+    // for a view dropped without close(), which removes it from m_views.
+    // Move the map into a local first so that removal never hits the map
+    // being iterated.
     m_pending.clear();
     m_sessions.clear();
     auto views = std::exchange(m_views, {});
     if (!m_global) return;
     auto* g = m_global;
     JSValue err = createError(g, reason);
-    // Every view that was still registered, not just the ones with an
-    // entry in m_pending: a navigation that is past its Page.navigate
-    // reply is only reachable through its slot (see rejectViewSlots).
-    // Views that left m_views earlier (close(), detachedFromTarget) had
-    // their slots rejected at that point.
     for (auto& weak : views.values()) {
         if (JSWebView* v = weak.get())
             rejectViewSlots(g, v, err);

--- a/test/js/bun/webview/webview-chrome-disconnect.test.ts
+++ b/test/js/bun/webview/webview-chrome-disconnect.test.ts
@@ -1,9 +1,10 @@
 // What happens to a Chrome-backend operation that is still waiting when
-// the browser goes away. The interesting case is a navigation-shaped op
-// (navigate / reload / goBack): once Chrome has answered its command the
-// backend only remembers it through the promise slot on the view, waiting
-// for Page.loadEventFired. Losing Chrome after that point must still
-// settle the promise and clear view.loading.
+// the browser goes away (or, for the last mock cases, just the view's own
+// page). The interesting case is a navigation-shaped op (navigate / reload
+// / goBack): once Chrome has answered its command the backend only
+// remembers it through the promise slot on the view, waiting for
+// Page.loadEventFired. Losing Chrome after that point must still settle
+// the promise and clear view.loading.
 //
 // Most tests here drive the backend from a mock CDP endpoint (a Bun.serve
 // WebSocket speaking just enough of the protocol), so they run without a
@@ -185,7 +186,18 @@ test.concurrent("a dropped connection rejects the committed navigation of every 
   });
 });
 
-test.concurrent("Target.detachedFromTarget during a load rejects navigate() and clears loading", async () => {
+// The connection stays up but the view's own page goes away. The promise
+// was already rejected on these paths; they also have to clear loading.
+test.concurrent.each([
+  ["view.close()", `view.close()`, "WebView closed"],
+  // Browser-level event (no sessionId on the envelope) for the only
+  // view's target, which is the first one the mock handed out.
+  [
+    "Target.detachedFromTarget",
+    `mock.emit("Target.detachedFromTarget", { sessionId: "S1", targetId: "T1" })`,
+    "page detached (crashed or closed)",
+  ],
+])("%s during a load rejects navigate() and clears loading", async (_, takePageAway, reason) => {
   const result = await runScenario(`
     const mock = startMockCDP();
     const view = mock.newView();
@@ -198,18 +210,12 @@ test.concurrent("Target.detachedFromTarget during a load rejects navigate() and 
     await committed.promise;
     const loadingBefore = view.loading;
 
-    // Browser-level event (no sessionId on the envelope): the only view's
-    // target is the first one the mock handed out.
-    mock.emit("Target.detachedFromTarget", { sessionId: "S1", targetId: "T1" });
+    ${takePageAway};
     const navigate = await nav;
     console.log(JSON.stringify({ loadingBefore, navigate, loadingAfter: view.loading }));
     mock.stop();
   `);
-  expect(result).toEqual({
-    loadingBefore: true,
-    navigate: "rejected: page detached (crashed or closed)",
-    loadingAfter: false,
-  });
+  expect(result).toEqual({ loadingBefore: true, navigate: `rejected: ${reason}`, loadingAfter: false });
 });
 
 // Same scenario against a real Chrome over the debugging pipe: closeAll()

--- a/test/js/bun/webview/webview-chrome-disconnect.test.ts
+++ b/test/js/bun/webview/webview-chrome-disconnect.test.ts
@@ -1,0 +1,288 @@
+// What happens to a Chrome-backend operation that is still waiting when
+// the browser goes away. The interesting case is a navigation-shaped op
+// (navigate / reload / goBack): once Chrome has answered its command the
+// backend only remembers it through the promise slot on the view, waiting
+// for Page.loadEventFired. Losing Chrome after that point must still
+// settle the promise and clear view.loading.
+//
+// Most tests here drive the backend from a mock CDP endpoint (a Bun.serve
+// WebSocket speaking just enough of the protocol), so they run without a
+// browser and can leave a navigation committed-but-never-loaded exactly.
+// The last test repeats the scenario against a real Chrome in pipe mode.
+//
+// Every test runs in a subprocess: the CDP transport is a process-wide
+// singleton, so each scenario needs a fresh one, and killing the browser
+// would break any other test sharing it.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows } from "harness";
+
+const mockCDP = /* js */ `
+  function startMockCDP() {
+    let sock;
+    let targets = 0;
+    let loads = 0;
+    let lastUrl = "about:blank";
+    const mock = {
+      // While true, a committed navigation is followed by Page.loadEventFired
+      // so the op resolves. Scenarios turn it off to leave a navigation
+      // committed but never loaded.
+      completeLoads: true,
+      emit(method, params, sessionId) {
+        sock.send(JSON.stringify(sessionId ? { method, params, sessionId } : { method, params }));
+      },
+      // Abrupt connection loss, as if the browser died.
+      drop() {
+        sock.terminate();
+      },
+    };
+    function commit(sessionId, url, loaderId) {
+      lastUrl = url;
+      mock.emit("Page.frameNavigated", { frame: { id: "F", loaderId, url, mimeType: "text/html" }, type: "Navigation" }, sessionId);
+      if (mock.completeLoads) mock.emit("Page.loadEventFired", { timestamp: loads }, sessionId);
+    }
+    const server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req, server) {
+        if (server.upgrade(req)) return;
+        return new Response(null, { status: 400 });
+      },
+      websocket: {
+        open(ws) {
+          sock = ws;
+        },
+        message(ws, raw) {
+          const { id, method, params = {}, sessionId } = JSON.parse(String(raw));
+          const reply = result => ws.send(JSON.stringify(sessionId ? { id, result, sessionId } : { id, result }));
+          switch (method) {
+            case "Target.createTarget":
+              targets++;
+              return reply({ targetId: "T" + targets });
+            case "Target.attachToTarget":
+              return reply({ sessionId: "S" + params.targetId.slice(1) });
+            case "Page.navigate": {
+              const loaderId = "L" + ++loads;
+              reply({ frameId: "F", loaderId });
+              return commit(sessionId, params.url, loaderId);
+            }
+            case "Page.reload":
+              reply({});
+              return commit(sessionId, lastUrl, "L" + ++loads);
+            case "Page.getNavigationHistory":
+              return reply({ currentIndex: 1, entries: [{ id: 1, url: "about:blank" }, { id: 2, url: lastUrl }] });
+            case "Page.navigateToHistoryEntry":
+              reply({});
+              return commit(sessionId, "about:blank", "L" + ++loads);
+            case "Runtime.evaluate":
+              // The backend fetches document.title after every load; answer
+              // that. Any evaluate() a scenario sends itself is deliberately
+              // left unanswered, so it is still waiting for a reply when the
+              // connection goes away.
+              if (params.expression === "document.title") return reply({ result: { type: "string", value: "mock" } });
+              return;
+            default:
+              return reply({});
+          }
+        },
+      },
+    });
+    mock.stop = () => server.stop(true);
+    mock.newView = () =>
+      new Bun.WebView({
+        backend: { type: "chrome", url: "ws://127.0.0.1:" + server.port + "/devtools/browser/mock" },
+        width: 100,
+        height: 100,
+      });
+    return mock;
+  }
+`;
+
+// Runs a scenario after the mock definitions in a fresh bun process and
+// returns the JSON it printed.
+async function runScenario(body: string): Promise<unknown> {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", mockCDP + body],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout, stderr).toEndWith("}\n");
+  expect(exitCode, stderr).toBe(0);
+  return JSON.parse(stdout);
+}
+
+const wsClosed = expect.stringMatching(/^rejected: Chrome WebSocket closed \(code \d+\)$/);
+
+test.concurrent.each([
+  ["navigate", `view.navigate("http://mock/2")`],
+  ["reload", `view.reload()`],
+  ["goBack", `view.goBack()`],
+])("%s() rejects when the connection drops after the document committed", async (_, startOp) => {
+  const result = await runScenario(`
+    const mock = startMockCDP();
+    const view = mock.newView();
+    await view.navigate("http://mock/1");
+
+    mock.completeLoads = false;
+    const committed = Promise.withResolvers();
+    view.onNavigated = () => committed.resolve();
+    let outcome = "pending";
+    ${startOp}.then(() => (outcome = "resolved"), e => (outcome = "rejected: " + e.message));
+    // onNavigated fires on Page.frameNavigated, which the mock sends after
+    // the op's own reply, so by now the backend has consumed that reply and
+    // only the promise slot is waiting (for a load event that never comes).
+    await committed.promise;
+
+    // A request that is still waiting for its reply. It rejects as soon as
+    // the disconnect has been processed, which is how we know when to look
+    // at the op's promise.
+    let unanswered = "pending";
+    const unansweredDone = view.evaluate("1").then(
+      () => (unanswered = "resolved"),
+      e => (unanswered = "rejected: " + e.message),
+    );
+
+    mock.drop();
+    await unansweredDone;
+    console.log(JSON.stringify({ unanswered, outcome, loading: view.loading }));
+    mock.stop();
+  `);
+  expect(result).toEqual({ unanswered: wsClosed, outcome: wsClosed, loading: false });
+});
+
+test.concurrent("a dropped connection rejects the committed navigation of every view", async () => {
+  const result = await runScenario(`
+    const mock = startMockCDP();
+    const a = mock.newView();
+    const b = mock.newView();
+    await Promise.all([a.navigate("http://mock/a1"), b.navigate("http://mock/b1")]);
+
+    mock.completeLoads = false;
+    const committedA = Promise.withResolvers();
+    const committedB = Promise.withResolvers();
+    a.onNavigated = () => committedA.resolve();
+    b.onNavigated = () => committedB.resolve();
+    const nav = { a: "pending", b: "pending" };
+    a.navigate("http://mock/a2").then(() => (nav.a = "resolved"), e => (nav.a = "rejected: " + e.message));
+    b.navigate("http://mock/b2").then(() => (nav.b = "resolved"), e => (nav.b = "rejected: " + e.message));
+    await Promise.all([committedA.promise, committedB.promise]);
+    const loadingBefore = [a.loading, b.loading];
+
+    // Only view a has a request waiting for a reply; view b has nothing in
+    // flight except its committed navigation.
+    const unanswered = a.evaluate("1").catch(() => {});
+    mock.drop();
+    await unanswered;
+    console.log(JSON.stringify({ loadingBefore, nav, loadingAfter: [a.loading, b.loading] }));
+    mock.stop();
+  `);
+  expect(result).toEqual({
+    loadingBefore: [true, true],
+    nav: { a: wsClosed, b: wsClosed },
+    loadingAfter: [false, false],
+  });
+});
+
+test.concurrent("Target.detachedFromTarget during a load rejects navigate() and clears loading", async () => {
+  const result = await runScenario(`
+    const mock = startMockCDP();
+    const view = mock.newView();
+    await view.navigate("http://mock/1");
+
+    mock.completeLoads = false;
+    const committed = Promise.withResolvers();
+    view.onNavigated = () => committed.resolve();
+    const nav = view.navigate("http://mock/2").then(() => "resolved", e => "rejected: " + e.message);
+    await committed.promise;
+    const loadingBefore = view.loading;
+
+    // Browser-level event (no sessionId on the envelope): the only view's
+    // target is the first one the mock handed out.
+    mock.emit("Target.detachedFromTarget", { sessionId: "S1", targetId: "T1" });
+    const navigate = await nav;
+    console.log(JSON.stringify({ loadingBefore, navigate, loadingAfter: view.loading }));
+    mock.stop();
+  `);
+  expect(result).toEqual({
+    loadingBefore: true,
+    navigate: "rejected: page detached (crashed or closed)",
+    loadingAfter: false,
+  });
+});
+
+// Same scenario against a real Chrome over the debugging pipe: closeAll()
+// SIGKILLs it while a page is committed but still loading. Spawning Chrome
+// is not implemented on Windows; elsewhere this needs a Chrome the runtime
+// finds on its own (BUN_CHROME_PATH or one of the $PATH names it probes),
+// otherwise todo.
+const chromeInstalled =
+  !isWindows &&
+  (!!process.env.BUN_CHROME_PATH ||
+    [
+      "google-chrome-stable",
+      "google-chrome",
+      "chromium-browser",
+      "chromium",
+      "brave-browser",
+      "microsoft-edge",
+      "chrome",
+    ].some(n => Bun.which(n)));
+
+(chromeInstalled ? test.concurrent : test.todo)(
+  "closeAll() rejects a navigate() whose page committed but never finished loading",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        // --no-sandbox: Chrome refuses to start as root otherwise (containers).
+        const view = new Bun.WebView({ backend: { type: "chrome", url: false, argv: ["--no-sandbox"] }, width: 100, height: 100 });
+        await view.navigate("data:text/html,<body></body>");
+
+        // The document commits, but its <img> request is never answered, so
+        // the load event never fires and navigate() stays pending.
+        const server = Bun.serve({
+          port: 0,
+          hostname: "127.0.0.1",
+          fetch(req) {
+            if (new URL(req.url).pathname === "/hang") return new Promise(() => {});
+            return new Response("<img src='/hang'>", { headers: { "content-type": "text/html" } });
+          },
+        });
+        const committed = Promise.withResolvers();
+        view.onNavigated = () => committed.resolve();
+        let navigate = "pending";
+        view.navigate(server.url.href).then(() => (navigate = "resolved"), e => (navigate = "rejected: " + e.message));
+        await committed.promise;
+        const loadingBefore = view.loading;
+
+        // Still waiting for Chrome's reply when it dies; rejects once the
+        // death has been processed.
+        let unanswered = "pending";
+        const unansweredDone = view.evaluate("new Promise(() => {})").then(
+          () => (unanswered = "resolved"),
+          e => (unanswered = "rejected: " + e.message),
+        );
+
+        Bun.WebView.closeAll();
+        await unansweredDone;
+        console.log(JSON.stringify({ loadingBefore, unanswered, navigate, loadingAfter: view.loading }));
+        server.stop(true);
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout, stderr).toEndWith("}\n");
+    // Whichever the event loop sees first, the pipe closing or the process
+    // exit, decides the wording; both must settle everything.
+    const died = expect.stringMatching(/^rejected: Chrome (killed by signal \d+|process closed the pipe|exited)$/);
+    expect(JSON.parse(stdout)).toEqual({ loadingBefore: true, unanswered: died, navigate: died, loadingAfter: false });
+    expect(exitCode, stderr).toBe(0);
+  },
+);


### PR DESCRIPTION
### Problem

- With the Chrome backend, a `navigate()` (also `reload()`, `goBack()`, `goForward()`) never settles and `view.loading` stays `true` forever if Chrome goes away after the document committed but before its `load` event: `Bun.WebView.closeAll()`, a Chrome crash, pipe EOF, or the DevTools WebSocket closing in connect mode.
- `Transport::rejectAllAndMarkDead` (`src/runtime/webview/ChromeBackend.cpp:1291` on main) only rejects promises that still have an entry in `m_pending`. The navigation-shaped ops drop their entry as soon as Chrome answers the command (`Method::PageNavigate` arm at `:786`, `PageReload` at `:800`, `PageNavigateToHistoryEntry` at `:844`) and wait for `Page.loadEventFired`, so from then on the promise is only reachable through the view's `m_pendingNavigate` slot, which that function never looked at.
- If the death arrives before Chrome's reply (for example the document request itself hangs) the entry is still in `m_pending` and the promise is rejected correctly, which is what the existing `closeAll()` test covers.
- Related: the `Target.detachedFromTarget` handler (`:1060`) and `Ops::close()` (`:1701`) reject every slot of the view but leave `m_loading` set, so `view.loading` reads `true` on a page that is gone.

### Fix

- New `rejectViewSlots(view, err)` rejects all five slots (`Navigate`, `Evaluate`, `Screenshot`, `Misc`, `Cdp`) and clears `m_loading`; it replaces the open-coded slot lists in the `detachedFromTarget` handler and `Ops::close()`, and `rejectAllAndMarkDead` now calls it for every registered view instead of walking `m_pending`.
- Walking the views is complete: every promise the backend can still settle lives in a slot of a view in `m_views`. Views removed from `m_views` earlier (`close()`, `detachedFromTarget`) had their slots rejected at that point, so the `m_pending` entries they may have left behind have nothing to settle.
- `rejectAllAndMarkDead` clears `m_pending`/`m_sessions` and moves `m_views` into a local before settling anything. Settling allocates, a GC finalizing inside that allocation can run `~JSWebView()` for a view dropped without `close()`, and that destructor removes the view from `m_views`; iterating the moved map keeps that removal away from the iteration, and such a view shows up as a null `Weak` (it has nothing pending, pending activity is what roots a view).
- This is the contract the docs and types already state for `closeAll()` and browser death ("every pending promise on every view rejects", `loading` is "true while a navigation is in flight") and is what `HostClient::rejectAllAndMarkDead` in `WebKitBackend.cpp:457` has done all along; the Chrome backend now matches it.
- Verified with `test/js/bun/webview/webview-chrome-disconnect.test.ts` (new file): navigate/reload/goBack and a two-view case against a mock CDP endpoint, `view.close()` and `Target.detachedFromTarget` during a load, and the original `closeAll()` repro against a real Chrome. All 7 fail on the unfixed binary (`USE_SYSTEM_BUN=1`: the ops stay `pending` or `loading` stays `true`), all 7 pass with `bun bd test`, stable across repeated runs.
- The mock tests fail the same way on Windows with the unfixed canary build (connect mode works there; spawning does not, so the real-Chrome test is todo on Windows).
- `test/js/bun/webview/webview-chrome.test.ts`: 52/52 pass with the fix. A 24-dropped-views plus 6-live-views disconnect under `BUN_JSC_slowPathAllocsBetweenGCs=5` against the debug build settles everything and exits cleanly.
- The tests live in their own file because the CDP transport is a process-wide singleton: each scenario needs a fresh one (subprocess per test), and the mock endpoint uses connect mode while `webview-chrome.test.ts` locks the process into spawn mode.
- Overlaps textually with #39097 (a different bug, views orphaned by a browser death, that rewrites the same loop and additionally sets `m_closed`): whichever lands second needs a rebase confined to that loop; on top of this PR, #39097's Chrome hunk reduces to one added line.

### Background

- The Chrome backend talks CDP (Chrome DevTools Protocol) to one Chrome per process, either over a pipe to a Chrome it spawned or over a WebSocket to an existing one. Every `view.xxx()` call creates a JS promise, stores it in one of five per-view `WriteBarrier<JSPromise>` slots (`m_pendingNavigate`, `m_pendingEval`, ...), and records the CDP command id in `Transport::m_pending` so the reply can be routed back to the slot.
- For most ops the reply settles the promise. For navigations the reply only means "navigation started"; the handler drops the `m_pending` entry and the promise is resolved later by the `Page.loadEventFired` event (after a `document.title` fetch). Between those two points the slot is the only record of the promise.
- `Transport::m_views` maps view id to a `JSC::Weak<JSWebView>` for every view that has not been closed; it is how replies and events find their view. The Weak's owner only keeps a view alive while it has pending activity, so an idle view the user dropped without `close()` is collected, and `~JSWebView()` removes it from `m_views`. `settleSlot` is a no-op when the slot is empty, so rejecting all slots of a view is safe regardless of which ops are in flight.
- `rejectAllAndMarkDead` runs from every "Chrome is gone" entry point: pipe close/EOF (`Transport::onClose`), process exit (`Bun__Chrome__died`, which is what `closeAll()` leads to) and WebSocket close (`wsOnClose`).

<details>
<summary>Repro (unfixed binary)</summary>

```ts
const view = new Bun.WebView({ backend: { type: "chrome", url: false }, width: 100, height: 100 });
await view.navigate("data:text/html,<body></body>");
using server = Bun.serve({
  port: 0,
  fetch(req) {
    if (new URL(req.url).pathname === "/hang") return new Promise(() => {});
    return new Response("<img src='/hang'>", { headers: { "content-type": "text/html" } });
  },
});
let settled = "pending";
const committed = Promise.withResolvers();
view.onNavigated = () => committed.resolve();
view.navigate(server.url.href).then(() => (settled = "resolved"), e => (settled = "rejected: " + e.message));
await committed.promise;
Bun.WebView.closeAll();
await new Promise(r => setTimeout(r, 500));
console.log(settled, view.loading);
// before: pending true
// after:  rejected: Chrome killed by signal 9 false
```

Closing the tab instead (`view.cdp("Page.close")` while the page is loading) rejected the promise with "page detached (crashed or closed)" on both builds, but `view.loading` stayed `true` before and is `false` after. `view.close()` during the load behaves the same way ("WebView closed").

</details>

<details>
<summary>Earlier revision</summary>

The first push iterated the member `m_views` directly and left `Ops::close()` with its own copy of the slot list; review pointed out the destructor interaction described above and the third copy, both changed in the second push. The later pushes only shortened comments.

</details>
