### PR TITLE
WebSocket client: throw on file- or S3-backed Blobs in send(), ping() and pong() instead of sending an empty frame

### DIFF
--- a/src/jsc/bindings/blob.h
+++ b/src/jsc/bindings/blob.h
@@ -10,6 +10,9 @@ extern "C" void* Blob__dupeFromJS(JSC::EncodedJSValue impl);
 extern "C" void* Blob__dupe(void* impl);
 extern "C" void* Blob__getDataPtr(JSC::EncodedJSValue blob);
 extern "C" size_t Blob__getSize(JSC::EncodedJSValue blob);
+// True for Bun.file() / Bun.s3() blobs, whose bytes are not in memory: Blob__getDataPtr and
+// Blob__getSize describe them as empty.
+extern "C" bool Blob__needsAsyncRead(JSC::EncodedJSValue blob);
 extern "C" void* Blob__fromBytes(JSC::JSGlobalObject* globalThis, const void* ptr, size_t len);
 extern "C" void Blob__ref(void* impl);
 extern "C" void Blob__deref(void* impl);

--- a/src/jsc/bindings/webcore/WebSocket.cpp
+++ b/src/jsc/bindings/webcore/WebSocket.cpp
@@ -103,6 +103,12 @@ static Exception controlFramePayloadTooLargeException(size_t length)
     return Exception { RangeError, makeString("The data size must not be greater than "_s, maxControlFramePayloadSize, " bytes. Received "_s, length, " bytes."_s) };
 }
 
+// Same message as ServerWebSocket: the send paths on both sides are synchronous.
+static Exception blobNeedsAsyncReadException(ASCIILiteral functionName)
+{
+    return Exception { TypeError, makeString(functionName, " cannot send a file- or S3-backed Blob synchronously; await blob.bytes() first"_s) };
+}
+
 // Close codes an endpoint may put on the wire (RFC 6455 7.4 + the IANA registry).
 // Deliberately the RFC endpoint set, not the browser's "1000 or 3000-4999":
 // non-browser clients legitimately send 1001 or 1011, and `ws` accepts the same set.
@@ -734,6 +740,9 @@ WebCore::ExceptionOr<void> WebCore::WebSocket::send(WebCore::JSBlob* blob)
     if (m_state == CLOSING || m_state == CLOSED) {
         return {};
     }
+
+    if (Blob__needsAsyncRead(JSC::JSValue::encode(blob)))
+        return blobNeedsAsyncReadException("send"_s);
 
     // Get the blob data and send it using existing binary data path
     void* dataPtr = Blob__getDataPtr(JSC::JSValue::encode(blob));
@@ -1775,6 +1784,9 @@ WebCore::ExceptionOr<void> WebCore::WebSocket::ping(WebCore::JSBlob* blob)
         return {};
     }
 
+    if (Blob__needsAsyncRead(JSC::JSValue::encode(blob)))
+        return blobNeedsAsyncReadException("ping"_s);
+
     // Get the blob data and send it using existing binary data path
     void* dataPtr = Blob__getDataPtr(JSC::JSValue::encode(blob));
     size_t dataSize = Blob__getSize(JSC::JSValue::encode(blob));
@@ -1798,6 +1810,9 @@ WebCore::ExceptionOr<void> WebCore::WebSocket::pong(WebCore::JSBlob* blob)
     if (m_state == CLOSING || m_state == CLOSED) {
         return {};
     }
+
+    if (Blob__needsAsyncRead(JSC::JSValue::encode(blob)))
+        return blobNeedsAsyncReadException("pong"_s);
 
     // Get the blob data and send it using existing binary data path
     void* dataPtr = Blob__getDataPtr(JSC::JSValue::encode(blob));

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5997,6 +5997,18 @@ pub(crate) extern "C" fn Blob__getSize(value: JSValue) -> usize {
     unsafe { (*blob).shared_view().len() }
 }
 
+/// `true` for `Bun.file()` / `Bun.s3()` blobs, whose bytes are not in memory:
+/// [`Blob__getDataPtr`] / [`Blob__getSize`] describe them as empty.
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn Blob__needsAsyncRead(value: JSValue) -> bool {
+    let Some(blob) = Blob::from_js(value) else {
+        return false;
+    };
+    // SAFETY: `from_js` returns a non-null pointer to a live JSC-owned Blob.
+    let blob = unsafe { &*blob };
+    blob.needs_to_read_file() || blob.is_s3()
+}
+
 /// # Safety
 /// `[ptr, ptr+len)` must be a valid readable byte range (or `ptr` null / `len` 0).
 #[unsafe(no_mangle)]

--- a/test/js/web/websocket/websocket-blob.test.ts
+++ b/test/js/web/websocket/websocket-blob.test.ts
@@ -1,4 +1,6 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import { tempDir } from "harness";
+import path from "node:path";
 
 test("WebSocket should send Blob data", async () => {
   await using server = Bun.serve({
@@ -209,4 +211,126 @@ test("WebSocket should ping with Blob", async () => {
   };
 
   await promise;
+});
+
+// Bun.file() and S3 blobs keep no bytes in memory. The client send paths are
+// synchronous, so (like ServerWebSocket) they must throw instead of putting an
+// empty frame on the wire in place of the payload.
+describe("WebSocket client with a file- or S3-backed Blob", () => {
+  const rejection = (fn: string) => ({
+    name: "TypeError",
+    message: `${fn} cannot send a file- or S3-backed Blob synchronously; await blob.bytes() first`,
+  });
+
+  // Records every frame the server receives, so a test can prove that a rejected
+  // payload did not go out as an empty frame. The server closes the connection
+  // once it receives the "done" text message.
+  function serveRecordingFrames() {
+    const received: string[] = [];
+    const server = Bun.serve({
+      port: 0,
+      websocket: {
+        message(ws, message) {
+          received.push(typeof message === "string" ? `text:${message}` : `binary:${message.length}`);
+          if (message === "done") ws.close();
+        },
+        ping(_ws, data) {
+          received.push(`ping:${data.length}`);
+        },
+        pong(_ws, data) {
+          received.push(`pong:${data.length}`);
+        },
+      },
+      fetch(req, server) {
+        if (server.upgrade(req)) return undefined;
+        return new Response("Upgrade failed", { status: 500 });
+      },
+    });
+    return { server, received };
+  }
+
+  function connect(server: Bun.Server<undefined>) {
+    const ws = new WebSocket(`ws://localhost:${server.port}`);
+    const opened = Promise.withResolvers<void>();
+    const closed = Promise.withResolvers<void>();
+    ws.onopen = () => opened.resolve();
+    ws.onerror = event => opened.reject((event as ErrorEvent).error ?? new Error("WebSocket error"));
+    ws.onclose = () => closed.resolve();
+    return { ws, opened: opened.promise, closed: closed.promise };
+  }
+
+  function thrownBy(fn: () => void): { name: string; message: string } | undefined {
+    try {
+      fn();
+    } catch (error) {
+      const { name, message } = error as Error;
+      return { name, message };
+    }
+    return undefined;
+  }
+
+  const blobKinds: [description: string, makeBlob: (dir: string) => Blob][] = [
+    ["Bun.file()", dir => Bun.file(path.join(dir, "payload.bin"))],
+    ["Bun.file().slice()", dir => Bun.file(path.join(dir, "payload.bin")).slice(0, 4)],
+    [
+      "S3Client.file()",
+      () =>
+        new Bun.S3Client({
+          accessKeyId: "test",
+          secretAccessKey: "test",
+          region: "us-east-1",
+          bucket: "my-bucket",
+          endpoint: "http://localhost:1",
+        }).file("payload.bin"),
+    ],
+  ];
+
+  test.concurrent.each(blobKinds)("%s: send(), ping() and pong() throw and send nothing", async (_, makeBlob) => {
+    using dir = tempDir("ws-client-file-blob", { "payload.bin": "file-bytes" });
+    const blob = makeBlob(String(dir));
+    const recording = serveRecordingFrames();
+    await using server = recording.server;
+    const { ws, opened, closed } = connect(server);
+    await opened;
+
+    expect([thrownBy(() => ws.send(blob)), thrownBy(() => ws.ping(blob)), thrownBy(() => ws.pong(blob))]).toEqual([
+      rejection("send"),
+      rejection("ping"),
+      rejection("pong"),
+    ]);
+
+    // The connection is still usable, and nothing went out in place of the rejected payloads.
+    expect(ws.readyState).toBe(WebSocket.OPEN);
+    ws.send("done");
+    await closed;
+    expect(recording.received).toEqual(["text:done"]);
+  });
+
+  test.concurrent("the readyState checks still come first", async () => {
+    using dir = tempDir("ws-client-file-blob", { "payload.bin": "file-bytes" });
+    const blob = Bun.file(path.join(String(dir), "payload.bin"));
+    const recording = serveRecordingFrames();
+    await using server = recording.server;
+    const { ws, opened, closed } = connect(server);
+
+    // While CONNECTING every payload type throws InvalidStateError.
+    expect(ws.readyState).toBe(WebSocket.CONNECTING);
+    expect(thrownBy(() => ws.send(blob))).toEqual({
+      name: "InvalidStateError",
+      message: "The object is in an invalid state.",
+    });
+
+    await opened;
+    ws.send("done");
+    await closed;
+
+    // Once closed, every payload type is dropped without throwing.
+    expect(ws.readyState).toBe(WebSocket.CLOSED);
+    expect([thrownBy(() => ws.send(blob)), thrownBy(() => ws.ping(blob)), thrownBy(() => ws.pong(blob))]).toEqual([
+      undefined,
+      undefined,
+      undefined,
+    ]);
+    expect(recording.received).toEqual(["text:done"]);
+  });
 });


### PR DESCRIPTION
### Problem
- On the client `WebSocket`, `ws.send(Bun.file("payload.bin"))` puts an empty binary frame on the wire and reports nothing: the server's `message` handler receives a 0-byte message. `ws.ping(...)` and `ws.pong(...)` do the same with an empty ping/pong, and S3 blobs (`s3.file(...)`) and slices of `Bun.file()` behave the same way.
- `ServerWebSocket.send(Bun.file(...))` throws `send cannot send a file- or S3-backed Blob synchronously; await blob.bytes() first` for the same input (since #36032), so the two sides of the same API disagree, and the client side loses data silently.
- Cause: `WebSocket::send(JSBlob*)`, `ping(JSBlob*)` and `pong(JSBlob*)` in `src/jsc/bindings/webcore/WebSocket.cpp` read the payload with `Blob__getDataPtr` / `Blob__getSize` (`src/runtime/webcore/Blob.rs`), which return the blob's in-memory view. A file- or S3-backed blob has no in-memory bytes, so that view is empty and the overloads take their "empty blob" branch, which deliberately sends a 0-byte frame. Nothing distinguishes "empty blob" from "bytes not in memory".

### Fix
- Adds `Blob__needsAsyncRead` (`Blob.rs`, declared in `blob.h`): true when the blob's store is file- or S3-backed, the same predicate `ServerWebSocket`'s `blob_payload` uses.
- The three client Blob overloads throw a `TypeError` with the server's message (`send`/`ping`/`pong` prefix) when it is true. The check sits after the existing readyState checks, so CONNECTING still throws `InvalidStateError` and CLOSING/CLOSED is still a silent no-op, exactly as for every other payload type (and as `ServerWebSocket`, which returns 0 when closed before validating the blob).
- Why throwing is the right fix: these send paths are synchronous, and making `send(Bun.file())` actually deliver the bytes would need an ordered send queue in the client (every later `send`/`ping`/`pong`/`close` has to wait behind the read) plus async failure reporting for the 125-byte ping/pong limit. That is a feature; the bug here is silent data loss, and the merged server-side API already resolved the same question by refusing loudly with a message that says what to do instead. In-memory blobs (including empty ones) are unaffected; the `require("ws")` client wrapper passes blobs straight through, so with a callback it now reports the error there instead of sending an empty frame.
- Verified with `test/js/web/websocket/websocket-blob.test.ts`: three new cases (`Bun.file()`, `Bun.file().slice()`, `S3Client.file()`) assert that `send`, `ping` and `pong` each throw the expected `TypeError` and that the server received nothing but the trailing sentinel message; a fourth case pins the readyState ordering. The three Blob cases fail on the current release (`undefined` thrown, `binary:0` / `ping:0` / `pong:0` received) and pass with this change.
- Also run: `test/js/web/websocket/websocket-client.test.ts` (37 pass) and the Blob / publish tests in `test/js/bun/websocket/websocket-server.test.ts` (34 pass) against the debug build.

### Background
- `Blob` in Bun is backed by a `Store`, which is one of `Bytes` (in memory), `File` (`Bun.file()`: a path or fd, read on demand) or `S3` (an object key, fetched on demand). `shared_view()` returns the in-memory bytes and is empty for the last two; `needs_to_read_file()` / `is_s3()` identify them. `S3File` is a `JSBlob` subclass on the C++ side, so it reaches the same Blob overloads.
- The client `WebSocket` is WebCore's C++ class; its methods return `ExceptionOr<void>`, and the bindings turn a returned `Exception { TypeError, message }` into a thrown JS `TypeError`. That is how the existing 125-byte `RangeError` for ping/pong payloads is produced, and this change follows the same pattern.
