### PR TITLE
zstd: free the output buffer when Bun.zstdDecompress decodes a content-size-less frame to 0 bytes

### DIFF
--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -2800,7 +2800,9 @@ pub mod JSZstd {
             }
         };
 
-        JSValue::create_buffer(global_this, output.leak())
+        // A 0-byte result decoded via the streaming path still owns its 4 KiB growth
+        // buffer; no deallocator is registered for empty buffers, so shrink it away.
+        JSValue::create_buffer_from_box(global_this, output.into_boxed_slice())
     }
 
     // --- Async versions ---
@@ -2887,8 +2889,9 @@ pub mod JSZstd {
                 return Ok(());
             }
 
-            let output_slice = core::mem::take(&mut this.output);
-            let buffer_value = JSValue::create_buffer(global_this, output_slice.leak());
+            // `into_boxed_slice` for the same reason as in `decompress_sync`.
+            let output = core::mem::take(&mut this.output).into_boxed_slice();
+            let buffer_value = JSValue::create_buffer_from_box(global_this, output);
             promise.settle(global_this, buffer_value)?;
             Ok(())
         }

--- a/test/js/bun/util/zstd.test.ts
+++ b/test/js/bun/util/zstd.test.ts
@@ -87,6 +87,79 @@ describe("Zstandard compression", async () => {
     ).toBeLessThan(10);
   }, 60_000);
 
+  describe("frames without a content size in the header", () => {
+    // Such frames take the streaming path of bun_zstd::decompress_alloc, which grows the output in
+    // 4 KiB steps before knowing how much (if anything) the frame decodes to.
+    function frameWithoutContentSize(payload: Buffer) {
+      //   28 B5 2F FD - magic
+      //   00          - Frame_Header_Descriptor: FCS_flag=0, Single_Segment=0 → content size not present
+      //   58          - Window_Descriptor
+      // followed by a single raw (uncompressed) block marked as the last one:
+      // a 3-byte little-endian header of Block_Size << 3 | Last_Block, then the payload.
+      const block = Buffer.alloc(3);
+      block.writeUIntLE((payload.length << 3) | 1, 0, 3);
+      return Buffer.concat([Buffer.from([0x28, 0xb5, 0x2f, 0xfd, 0x00, 0x58]), block, payload]);
+    }
+    const emptyFrame = frameWithoutContentSize(Buffer.alloc(0));
+    const payload = Buffer.from("decoded without a content size");
+    const payloadFrame = frameWithoutContentSize(payload);
+
+    it("decompress to the frame's content", async () => {
+      expect(zstdDecompressSync(emptyFrame)).toEqual(Buffer.alloc(0));
+      expect(zstdDecompressSync(payloadFrame)).toEqual(payload);
+      expect(await zstdDecompress(emptyFrame)).toEqual(Buffer.alloc(0));
+      expect(await zstdDecompress(payloadFrame)).toEqual(payload);
+    });
+
+    // Without the fix, every decompression of a frame that decodes to 0 bytes leaked the 4 KiB
+    // output buffer (no deallocator is registered for an empty result), so each batch below grew
+    // RSS by ~40 MiB and the growth never converged.
+    const iterations = 10000;
+    const maxGrowthMiB = 10;
+    async function rssGrowthAfterWarmupMiB(batch: () => Promise<void> | void) {
+      async function measure() {
+        await batch();
+        Bun.gc(true);
+        return rss();
+      }
+      // Warm up until RSS stabilizes (allocator / ASAN quarantine reach steady state).
+      let prev = await measure();
+      let growthMiB = Infinity;
+      for (let round = 0; round < 5; round++) {
+        const cur = await measure();
+        growthMiB = (cur - prev) / 1024 / 1024;
+        prev = cur;
+        if (growthMiB < maxGrowthMiB) break;
+      }
+      return growthMiB;
+    }
+
+    it("zstdDecompressSync does not leak when the frame decompresses to 0 bytes", async () => {
+      const growthMiB = await rssGrowthAfterWarmupMiB(() => {
+        for (let i = 0; i < iterations; i++) {
+          zstdDecompressSync(emptyFrame);
+        }
+      });
+      expect(
+        growthMiB,
+        `RSS grew by ${growthMiB.toFixed(1)} MiB over ${iterations} empty zstdDecompressSync results after warmup`,
+      ).toBeLessThan(maxGrowthMiB);
+    }, 60_000);
+
+    it("zstdDecompress does not leak when the frame decompresses to 0 bytes", async () => {
+      const concurrency = 250;
+      const growthMiB = await rssGrowthAfterWarmupMiB(async () => {
+        for (let i = 0; i < iterations; i += concurrency) {
+          await Promise.all(Array.from({ length: concurrency }, () => zstdDecompress(emptyFrame)));
+        }
+      });
+      expect(
+        growthMiB,
+        `RSS grew by ${growthMiB.toFixed(1)} MiB over ${iterations} empty zstdDecompress results after warmup`,
+      ).toBeLessThan(maxGrowthMiB);
+    }, 60_000);
+  });
+
   // Test with known zstd-compressed data
   describe("zstd CLI compatibility", () => {
     for (const { name, compressed, original } of [


### PR DESCRIPTION
### Problem
- Every `Bun.zstdDecompressSync` / `Bun.zstdDecompress` call on a frame that has no content size in its header and decodes to 0 bytes leaks about 4 KiB. 50k calls grow RSS from 37 MiB to 236 MiB on bun 1.4.0; the process never gets the memory back.
- Such frames go through the streaming path of `bun_zstd::decompress_alloc` (`src/zstd/lib.rs:311`), whose reader reserves 4096 bytes of output before the first `ZSTD_decompressStream` call (`src/zstd/lib.rs:428`). When the frame produces nothing, the `Vec` comes back with `len 0, capacity 4096`.
- Both entry points, `JSZstd::decompress_sync` and `ZstdJob::then` (`src/runtime/api/BunObject.rs`), then passed `output.leak()` to `JSValue::create_buffer`, which registers no deallocator for an empty slice (`src/jsc/JSValue.rs:594`), so the 4 KiB block is never freed.
- The known-size empty frame that `Bun.zstdCompressSync(new Uint8Array(0))` produces takes the preallocating path with a capacity-0 `Vec` and does not leak; only the streaming path is affected.

### Fix
- Both entry points now hand the result to `JSValue::create_buffer_from_box(global, output.into_boxed_slice())`.
- Why this is correct: `create_buffer` cannot fix this itself, since a `&mut [u8]` of length 0 does not say whether its pointer is a live allocation or the dangling pointer of a capacity-0 `Vec` (the existing "collecting empty decompression results does not free a dangling pointer" test covers the second case, where registering a deallocator would be an invalid free). `Box<[u8]>` carries that distinction in the type: `into_boxed_slice` frees the allocation of an empty `Vec` and trims the spare capacity of a non-empty one, so `create_buffer_from_box` always has exactly the bytes it is handed and nothing else. This is the hand-off `create_buffer_from_box` documents as the preferred one and what `Archive.rs` and `NodeHTTPResponse.rs` already use; the zlib twins in this file (`leak_list_into_uint8array`) get the same effect from `shrink_to_fit`.
- Fixing it at the hand-off rather than inside `decompress_alloc` keeps it independent of how the `Vec` gets filled: the other callers of `decompress_alloc` only read the `Vec`, and the in-flight rewrites of its internals (#37555 moves it to `StreamingDecoder`, #39038 makes its growth fallible) both still return a `Vec` with spare capacity.
- Side effect: a non-empty streamed result (no content size, or a declared size over 16 MiB) no longer keeps the `Vec`'s doubling slack alive for the lifetime of the returned `Buffer`. That costs one `realloc` per streamed decompression; the compress entry points already pay the same `shrink_to_fit`.
- `zstdCompressSync` / `zstdCompress` are deliberately unchanged: a compressed frame is never empty and both already `shrink_to_fit`, so there is nothing to leak there (and #39038 rewrites those lines).
- Verified with the new `frames without a content size in the header` block in `test/js/bun/util/zstd.test.ts`: a hand-built frame (no content size, one empty raw block) decodes to an empty `Buffer` on both entry points, and 10k decompressions per batch must stop growing RSS after warmup (same shape as the neighbouring streaming-error leak test). Before the fix each batch grows RSS by 38 to 39 MiB on bun 1.4.0 and by 52 to 56 MiB on the unfixed debug (ASAN) build; with the fix the growth is under 5 MiB in the first round and around 0 afterwards. A non-empty content-size-less frame still round-trips on both entry points.
- The whole of `test/js/bun/util/zstd.test.ts` (86 tests) and `test/regression/issue/23314/` (which streams a 20 MiB declared-size frame through the now-shrunk path) pass on the debug build.

Related but distinct: #35856 adds a size check on these same lines; #29857 fixed the error path of the same streaming reader, this is its success path.

### Background
- A zstd frame header may carry the decompressed size. One-shot compressors write it; streaming compressors usually do not, and it can be absent or wrong in hostile input. `decompress_alloc` preallocates exactly the declared size when it is present and at most 16 MiB, and otherwise decodes through `ZSTD_decompressStream`, appending to a `Vec` that it grows in 4 KiB steps (so the `Vec` normally ends with spare capacity).
- `JSValue::create_buffer` wraps a mimalloc allocation in a Node `Buffer` without copying and registers `MarkedArrayBuffer_deallocator` to free it when the `Buffer` is collected. A `Vec` with `len 0` may point at a live allocation (capacity > 0) or at a dangling sentinel (capacity 0), and a slice does not distinguish them, so `create_buffer` registers nothing for empty slices. `Vec::into_boxed_slice` shrinks the allocation to `len`, which for `len 0` means freeing it, so an empty `Box<[u8]>` never owns memory.

<details>
<summary>Repro and measurements</summary>

```js
// magic, Frame_Header_Descriptor 0x00 (no content size), Window_Descriptor, one empty raw last block
const frame = Buffer.from([0x28, 0xb5, 0x2f, 0xfd, 0x00, 0x58, 0x01, 0x00, 0x00]);
console.log(Bun.zstdDecompressSync(frame).length); // 0
const rss = () => (process.memoryUsage.rss() / 1048576).toFixed(0);
for (let i = 0; i < 2000; i++) Bun.zstdDecompressSync(frame);
Bun.gc(true); const before = rss();
for (let i = 0; i < 50000; i++) Bun.zstdDecompressSync(frame);
Bun.gc(true); console.log(before, rss());
```

| build | entry point | calls | RSS |
| --- | --- | --- | --- |
| bun 1.4.0 | `zstdDecompressSync` | 50k | 37 MiB -> 236 MiB |
| bun 1.4.0 | `zstdDecompress` | 20k | 34 MiB -> 117 MiB |
| debug (ASAN), unfixed | `zstdDecompressSync` | 10k | +56 MiB |
| debug (ASAN), unfixed | `zstdDecompress` | 5k | +28 MiB |

Per-round RSS growth of the new test's batches (10k calls each) on the fixed debug (ASAN) build, three runs each; the test passes as soon as a round grows by less than 10 MiB:

```
sync:  4.8 1.2 0.0 -0.8 1.7 -0.2 -2.1 1.1
sync:  3.9 1.3 0.8 -1.5 -2.6 1.2 -1.4 0.5
sync:  4.2 -0.6 0.2 -1.8 3.0 1.4 -1.7 0.7
async: 2.7 1.0 -3.3 10.0 3.3 -1.5 0.9 -2.0
async: 3.2 -0.1 -0.9 9.3 2.3 0.8 -2.3 -2.3
async: 2.7 -1.2 -1.1 0.6 11.5 0.2 -1.0 0.7
```

Final RSS after 90k and after 180k fixed calls is the same to within a few MiB (sync 368-372 vs 374 MiB, async 390-392 vs 395 MiB), so the isolated async spikes are one-time heap growth, not a slower leak. On the unfixed debug build every round grows by 52 to 56 MiB.

</details>
