### PR TITLE
install: don't issue openat2/fchmodat2 on Android (seccomp SIGSYS)

### DIFF
--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -39,9 +39,8 @@ use crate::ZStr;
 // ──────────────────────────────────────────────────────────────────────────────
 
 new!(pub AGENT: string, "AGENT", {});
-// Set by Android init for every process (Termux shells inherit them). Used to
-// detect an Android kernel at runtime when the `uname -r` release string
-// doesn't carry an "android" marker.
+// Set by Android init for every process; read by bun_sys's runtime Android
+// detection (`is_android_kernel`).
 new!(pub ANDROID_DATA: string, "ANDROID_DATA", {});
 new!(pub ANDROID_ROOT: string, "ANDROID_ROOT", {});
 new!(pub BUN_AGENT_RULE_DISABLED: boolean, "BUN_AGENT_RULE_DISABLED", { default: false });

--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -39,6 +39,11 @@ use crate::ZStr;
 // ──────────────────────────────────────────────────────────────────────────────
 
 new!(pub AGENT: string, "AGENT", {});
+// Set by Android init for every process (Termux shells inherit them). Used to
+// detect an Android kernel at runtime when the `uname -r` release string
+// doesn't carry an "android" marker.
+new!(pub ANDROID_DATA: string, "ANDROID_DATA", {});
+new!(pub ANDROID_ROOT: string, "ANDROID_ROOT", {});
 new!(pub BUN_AGENT_RULE_DISABLED: boolean, "BUN_AGENT_RULE_DISABLED", { default: false });
 new!(pub BUN_COMPILE_TARGET_TARBALL_URL: string, "BUN_COMPILE_TARGET_TARBALL_URL", {});
 new!(pub BUN_CONFIG_DISABLE_COPY_FILE_RANGE: boolean, "BUN_CONFIG_DISABLE_COPY_FILE_RANGE", { default: false });

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -1947,22 +1947,59 @@ mod posix_impl {
             Ok(Fd::from_native(rc))
         }
     }
+    /// Runtime Android detection. Android's app seccomp policy denies
+    /// syscalls outside its allowlist with `SECCOMP_RET_TRAP` — the process
+    /// is killed by SIGSYS instead of seeing ENOSYS — so errno-based
+    /// fallbacks for newer syscalls (`openat2(2)`, `fchmodat2(2)`) never get
+    /// a chance to run. The shipped linux builds run under Termux as plain
+    /// `target_os = "linux"`, so `cfg!(target_os = "android")` alone can't
+    /// catch this; probe the kernel release string (GKI kernels embed
+    /// "android") and the `ANDROID_ROOT`/`ANDROID_DATA` env vars Android
+    /// init sets for every process.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    fn is_android_kernel() -> bool {
+        if cfg!(target_os = "android") {
+            return true;
+        }
+        use core::sync::atomic::{AtomicU8, Ordering};
+        // 0 = unprobed, 1 = not Android, 2 = Android.
+        static CACHED: AtomicU8 = AtomicU8::new(0);
+        match CACHED.load(Ordering::Relaxed) {
+            0 => {}
+            v => return v == 2,
+        }
+        let release = bun_core::ffi::c_field_bytes(&bun_core::ffi::cached_uname().release);
+        let detected = bun_core::strings::contains_case_insensitive_ascii(release, b"android")
+            || (bun_core::env_var::ANDROID_ROOT::get_not_empty().is_some()
+                && bun_core::env_var::ANDROID_DATA::get_not_empty().is_some());
+        CACHED.store(if detected { 2 } else { 1 }, Ordering::Relaxed);
+        detected
+    }
+    /// `openat2(RESOLVE_BENEATH)`. Fails with ENOSYS on Android without
+    /// issuing the syscall (seccomp there kills the process instead of
+    /// returning ENOSYS; see [`is_android_kernel`]) so callers take their
+    /// existing fallback paths.
     #[cfg(any(target_os = "linux", target_os = "android"))]
     pub fn openat2_beneath(dir: impl AsFd, path: &ZStr, flags: i32, mode: Mode) -> Maybe<Fd> {
         let dir = dir.as_fd();
+        if is_android_kernel() {
+            return Err(Error::from_code_int(libc::ENOSYS, Tag::open).with_path(path.as_bytes()));
+        }
         super::linux_syscall::openat2_beneath(dir, path, flags, mode)
             .map_err(|e| Error::from_code_int(e, Tag::open).with_path(path.as_bytes()))
     }
     /// `openat2(RESOLVE_IN_ROOT | RESOLVE_NO_MAGICLINKS)`: resolves `path` as
     /// if `dir` were `/`. Falls back to plain `openat` on kernels without
     /// `openat2` (or when seccomp blocks it), caching the unavailability.
+    /// On Android the syscall is never issued at all (seccomp there kills
+    /// the process instead of returning ENOSYS; see [`is_android_kernel`]).
     #[cfg(any(target_os = "linux", target_os = "android"))]
     pub fn openat2_in_root(dir: impl AsFd, path: &ZStr, flags: i32, mode: Mode) -> Maybe<Fd> {
         use core::sync::atomic::{AtomicBool, Ordering};
         static UNAVAILABLE: AtomicBool = AtomicBool::new(false);
 
         let dir = dir.as_fd();
-        if !UNAVAILABLE.load(Ordering::Relaxed) {
+        if !UNAVAILABLE.load(Ordering::Relaxed) && !is_android_kernel() {
             match super::linux_syscall::openat2_in_root(dir, path, flags, mode) {
                 Ok(fd) => return Ok(fd),
                 Err(e @ (libc::ENOSYS | libc::EPERM | libc::EINVAL | libc::E2BIG)) => {
@@ -2835,6 +2872,14 @@ mod posix_impl {
         }
         #[cfg(not(any(target_os = "macos", target_os = "freebsd")))]
         {
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            if is_android_kernel() {
+                // Android seccomp SIGSYS-kills `fchmodat2(2)` instead of
+                // returning ENOSYS, and libc's `fchmodat(.., AT_SYMLINK_
+                // NOFOLLOW)` emulation (current glibc and musl) tries
+                // `fchmodat2(2)` internally first, so neither may be issued.
+                return lchmod_no_fchmodat2(path, mode);
+            }
             const SYS_FCHMODAT2: libc::c_long = 452;
             loop {
                 // SAFETY: `ZStr::as_ptr()` yields a valid NUL-terminated C string.
@@ -2860,6 +2905,49 @@ mod posix_impl {
                 return Ok(());
             }
         }
+    }
+    /// `lchmod` without touching `fchmodat2(2)`: `AT_SYMLINK_NOFOLLOW`
+    /// emulation via `O_PATH` + `chmod("/proc/self/fd/N")`, the same strategy
+    /// musl's fallback uses. Symlinks are rejected with EOPNOTSUPP (symlink
+    /// modes are meaningless on Linux), matching libc behavior.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    fn lchmod_no_fchmodat2(path: &ZStr, mode: Mode) -> Maybe<()> {
+        let fd = match open(path, O::PATH | O::NOFOLLOW | O::CLOEXEC, 0) {
+            Ok(fd) => fd,
+            Err(mut err) => {
+                err.syscall = Tag::lchmod;
+                return Err(err);
+            }
+        };
+        let st = match fstat(fd) {
+            Ok(st) => st,
+            Err(mut err) => {
+                let _ = close(fd);
+                err.syscall = Tag::lchmod;
+                return Err(err.with_path(path.as_bytes()));
+            }
+        };
+        if (st.st_mode as u32 & libc::S_IFMT as u32) == libc::S_IFLNK as u32 {
+            let _ = close(fd);
+            return Err(
+                Error::from_code_int(libc::EOPNOTSUPP, Tag::lchmod).with_path(path.as_bytes())
+            );
+        }
+        let mut proc = [0u8; 32];
+        let n = {
+            use std::io::Write as _;
+            let mut c = std::io::Cursor::new(&mut proc[..]);
+            let _ = write!(c, "/proc/self/fd/{}\0", fd.native());
+            c.position() as usize - 1
+        };
+        // SAFETY: NUL written above.
+        let z = ZStr::from_buf(&proc[..], n);
+        let result = chmod(z, mode);
+        let _ = close(fd);
+        result.map_err(|mut err| {
+            err.syscall = Tag::lchmod;
+            err.with_path(path.as_bytes())
+        })
     }
     pub fn chown(path: &ZStr, uid: u32, gid: u32) -> Maybe<()> {
         check_p!(

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -1947,14 +1947,12 @@ mod posix_impl {
             Ok(Fd::from_native(rc))
         }
     }
-    /// Runtime Android detection. Android's app seccomp policy denies
-    /// syscalls outside its allowlist with `SECCOMP_RET_TRAP` — the process
-    /// is killed by SIGSYS instead of seeing ENOSYS — so errno-based
-    /// fallbacks for newer syscalls (`openat2(2)`, `fchmodat2(2)`) never get
-    /// a chance to run. The shipped linux builds run under Termux as plain
-    /// `target_os = "linux"`, so `cfg!(target_os = "android")` alone can't
-    /// catch this; probe the kernel release string (GKI kernels embed
-    /// "android") and the `ANDROID_ROOT`/`ANDROID_DATA` env vars Android
+    /// Runtime Android detection. Android's app seccomp policy kills the
+    /// process with SIGSYS instead of returning ENOSYS for syscalls outside
+    /// its allowlist, so `openat2(2)`/`fchmodat2(2)` must never be issued
+    /// there, not even as a probe. Shipped linux builds run under Termux as
+    /// plain `target_os = "linux"`, hence runtime detection: the kernel
+    /// release string, or the `ANDROID_ROOT`/`ANDROID_DATA` env vars Android
     /// init sets for every process.
     #[cfg(any(target_os = "linux", target_os = "android"))]
     fn is_android_kernel() -> bool {
@@ -1975,10 +1973,8 @@ mod posix_impl {
         CACHED.store(if detected { 2 } else { 1 }, Ordering::Relaxed);
         detected
     }
-    /// `openat2(RESOLVE_BENEATH)`. Fails with ENOSYS on Android without
-    /// issuing the syscall (seccomp there kills the process instead of
-    /// returning ENOSYS; see [`is_android_kernel`]) so callers take their
-    /// existing fallback paths.
+    /// `openat2(RESOLVE_BENEATH)`; ENOSYS on Android without issuing the
+    /// syscall (see [`is_android_kernel`]).
     #[cfg(any(target_os = "linux", target_os = "android"))]
     pub fn openat2_beneath(dir: impl AsFd, path: &ZStr, flags: i32, mode: Mode) -> Maybe<Fd> {
         let dir = dir.as_fd();
@@ -1991,8 +1987,7 @@ mod posix_impl {
     /// `openat2(RESOLVE_IN_ROOT | RESOLVE_NO_MAGICLINKS)`: resolves `path` as
     /// if `dir` were `/`. Falls back to plain `openat` on kernels without
     /// `openat2` (or when seccomp blocks it), caching the unavailability.
-    /// On Android the syscall is never issued at all (seccomp there kills
-    /// the process instead of returning ENOSYS; see [`is_android_kernel`]).
+    /// Never issued on Android (see [`is_android_kernel`]).
     #[cfg(any(target_os = "linux", target_os = "android"))]
     pub fn openat2_in_root(dir: impl AsFd, path: &ZStr, flags: i32, mode: Mode) -> Maybe<Fd> {
         use core::sync::atomic::{AtomicBool, Ordering};
@@ -2874,10 +2869,8 @@ mod posix_impl {
         {
             #[cfg(any(target_os = "linux", target_os = "android"))]
             if is_android_kernel() {
-                // Android seccomp SIGSYS-kills `fchmodat2(2)` instead of
-                // returning ENOSYS, and libc's `fchmodat(.., AT_SYMLINK_
-                // NOFOLLOW)` emulation (current glibc and musl) tries
-                // `fchmodat2(2)` internally first, so neither may be issued.
+                // libc's `fchmodat(.., AT_SYMLINK_NOFOLLOW)` is no escape
+                // hatch here: current glibc/musl try `fchmodat2(2)` inside it.
                 return lchmod_no_fchmodat2(path, mode);
             }
             const SYS_FCHMODAT2: libc::c_long = 452;
@@ -2906,10 +2899,9 @@ mod posix_impl {
             }
         }
     }
-    /// `lchmod` without touching `fchmodat2(2)`: `AT_SYMLINK_NOFOLLOW`
-    /// emulation via `O_PATH` + `chmod("/proc/self/fd/N")`, the same strategy
-    /// musl's fallback uses. Symlinks are rejected with EOPNOTSUPP (symlink
-    /// modes are meaningless on Linux), matching libc behavior.
+    /// `lchmod` without `fchmodat2(2)`: `O_PATH` + `chmod("/proc/self/fd/N")`,
+    /// musl's own fallback strategy. Symlinks are rejected with EOPNOTSUPP,
+    /// matching libc.
     #[cfg(any(target_os = "linux", target_os = "android"))]
     fn lchmod_no_fchmodat2(path: &ZStr, mode: Mode) -> Maybe<()> {
         let fd = match open(path, O::PATH | O::NOFOLLOW | O::CLOEXEC, 0) {

--- a/test/cli/install/bun-install-android-seccomp.test.ts
+++ b/test/cli/install/bun-install-android-seccomp.test.ts
@@ -1,0 +1,153 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux, tempDir, tempDirWithFiles } from "harness";
+import { spawnSync } from "node:child_process";
+import { existsSync, lstatSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+// Android's app seccomp policy denies openat2(2) and fchmodat2(2) with
+// SECCOMP_RET_TRAP: the process is killed by SIGSYS instead of seeing ENOSYS,
+// so the errno-based fallbacks never run and `bun install` dies while linking
+// package bins (issue #39060, Termux). Bun detects Android at runtime (the
+// ANDROID_ROOT/ANDROID_DATA env vars Android init sets for every process, or
+// an "android" kernel release string) and skips those syscalls entirely.
+// This test reproduces the Android policy with an equivalent seccomp filter.
+const helperSrc = `
+#define _GNU_SOURCE
+#include <errno.h>
+#include <linux/audit.h>
+#include <linux/filter.h>
+#include <linux/seccomp.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/prctl.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#if defined(__x86_64__)
+  #define MY_AUDIT_ARCH AUDIT_ARCH_X86_64
+#elif defined(__aarch64__)
+  #define MY_AUDIT_ARCH AUDIT_ARCH_AARCH64
+#else
+  #define MY_AUDIT_ARCH 0
+#endif
+
+int main(int argc, char **argv) {
+  if (argc < 2) return 2;
+  if (MY_AUDIT_ARCH == 0) return 77; /* unsupported arch, skip */
+
+  struct sock_filter filter[] = {
+    /* arch check */
+    BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, arch)),
+    BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, MY_AUDIT_ARCH, 1, 0),
+    BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+    /* load syscall nr */
+    BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, nr)),
+    /* openat2 (437) and fchmodat2 (452) -> SIGSYS, like Android */
+    BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, 437, 1, 0),
+    BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, 452, 0, 1),
+    BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_TRAP),
+    BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+  };
+  struct sock_fprog prog = {
+    .len = (unsigned short)(sizeof(filter) / sizeof(filter[0])),
+    .filter = filter,
+  };
+
+  if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0) {
+    perror("prctl(PR_SET_NO_NEW_PRIVS)");
+    return 77; /* cannot install filter, skip */
+  }
+  if (syscall(__NR_seccomp, SECCOMP_SET_MODE_FILTER, 0, &prog) != 0) {
+    perror("seccomp");
+    return 77; /* cannot install filter, skip */
+  }
+
+  execvp(argv[1], &argv[1]);
+  perror("execvp");
+  return 127;
+}
+`;
+
+// Compile the seccomp helper. Returns the binary path, or null if the host
+// genuinely can't build it (no cc, missing kernel headers). Any other compile
+// failure throws so a source regression isn't silently hidden as a skip.
+const tryBuild = (): string | null => {
+  const dir = tempDirWithFiles("android-seccomp", {
+    "sigsys_wrap.c": helperSrc,
+  });
+  const src = join(dir, "sigsys_wrap.c");
+  const bin = join(dir, "sigsys_wrap");
+  const compile = spawnSync("cc", ["-O0", "-o", bin, src], { stdio: "pipe" });
+
+  // compiler not on PATH — expected skip
+  if ((compile.error as NodeJS.ErrnoException | undefined)?.code === "ENOENT") return null;
+
+  if (compile.status !== 0) {
+    const stderr = compile.stderr?.toString() ?? "";
+    // missing linux/*.h on the host — expected skip
+    if (/linux\/(seccomp|filter|audit)\.h|sys\/prctl\.h/.test(stderr)) return null;
+    throw new Error(`failed to compile seccomp helper:\n${stderr}`);
+  }
+  if (!existsSync(bin)) {
+    throw new Error("seccomp helper compiled successfully but output binary is missing");
+  }
+  return bin;
+};
+
+// Android env vars are how bun's runtime detection recognizes Android here
+// (the kernel release string of the test host obviously isn't Android's).
+const androidEnv = { ...bunEnv, ANDROID_ROOT: "/system", ANDROID_DATA: "/data" };
+
+test.skipIf(!isLinux)("bun install survives Android-style seccomp (openat2/fchmodat2 SIGSYS)", async () => {
+  const helperBin = tryBuild();
+  if (helperBin == null) {
+    // bun:test has no runtime-skip; log loudly so CI output distinguishes
+    // this from a real pass.
+    console.warn("SKIP bun install android seccomp: cc or seccomp headers not available");
+    return;
+  }
+
+  using dir = tempDir("install-android-seccomp", {
+    "package.json": JSON.stringify({
+      name: "app",
+      version: "1.0.0",
+      dependencies: { dep: "file:./dep" },
+    }),
+    "dep/package.json": JSON.stringify({
+      name: "dep",
+      version: "1.0.0",
+      bin: { dep: "bin/dep.js" },
+    }),
+    // bin in a subdirectory so bin linking validates the parent dir with
+    // openat2(RESOLVE_BENEATH), then chmods the target (fchmodat2).
+    "dep/bin/dep.js": "#!/usr/bin/env node\nconsole.log('ok');\n",
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [helperBin, bunExe(), "install"],
+    cwd: String(dir),
+    env: androidEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  if (exitCode === 77) {
+    console.warn("SKIP bun install android seccomp: seccomp not permitted in this environment");
+    return;
+  }
+
+  // Without the runtime Android detection the install dies with SIGSYS
+  // (exit 159) in bin linking.
+  expect({ stdout, stderr, signalCode: proc.signalCode ?? null, exitCode }).toMatchObject({
+    signalCode: null,
+    exitCode: 0,
+  });
+
+  // The bin link was created and the target was made executable — proving
+  // the lchmod fallback actually chmod'd instead of silently skipping.
+  const binLink = join(String(dir), "node_modules", ".bin", "dep");
+  expect(lstatSync(binLink).isSymbolicLink()).toBe(true);
+  const targetMode = statSync(join(String(dir), "node_modules", "dep", "bin", "dep.js")).mode;
+  expect(targetMode & 0o111).not.toBe(0);
+});


### PR DESCRIPTION
### Problem

- `bun install` is killed by SIGSYS (exit 159, "Bad system call") on Android/Termux while linking package bins (#39060).
- Android's app seccomp policy denies `openat2(2)` and `fchmodat2(2)` with `SECCOMP_RET_TRAP`: the process gets SIGSYS instead of an `ENOSYS` return, so the existing errno-based fallbacks never get a chance to run.
- Call sites: `openat2(RESOLVE_BENEATH)` in bin-target validation (`src/install/bin.rs:1416` via `src/sys/lib.rs`), raw syscall 452 in `sys::lchmod` (`src/sys/lib.rs`) when chmod'ing bin targets, and `openat2(RESOLVE_IN_ROOT)` used by directory routes.
- The syscalls can't be probed safely either: the probe itself would be SIGSYS-killed.

### Fix

- Detect Android at runtime, once, in `bun_sys` (`is_android_kernel`): `cfg!(target_os = "android")`, an "android" kernel release string (`uname -r`, all GKI kernels carry it), or the `ANDROID_ROOT`/`ANDROID_DATA` env vars Android init sets for every process.
- On Android, never issue the two syscalls and use the fallbacks that already exist for old kernels:
  - `openat2_beneath` fails with `ENOSYS`, so bin linking takes its existing realpath containment check (same security property, no `openat2`).
  - `openat2_in_root` goes straight to the existing plain-`openat` fallback.
  - `lchmod` uses an `O_PATH` + `chmod("/proc/self/fd/N")` emulation (musl's own fallback strategy). It cannot call libc's `fchmodat(.., AT_SYMLINK_NOFOLLOW)` instead: current glibc and musl implement that flag by trying `fchmodat2(2)` internally first, which would be SIGSYS-killed.
- Verified with `test/cli/install/bun-install-android-seccomp.test.ts`: compiles a small helper that installs the same seccomp filter Android uses (`SECCOMP_RET_TRAP` for syscalls 437/452) and runs `bun install` of a local dependency with a `bin` entry under it, with `ANDROID_ROOT`/`ANDROID_DATA` set. Fails with SIGSYS before the fix, installs and chmods the bin after.
- Also ran `test/cli/install/bun-install-native-binlink.test.ts` (bin containment checks), `test/js/bun/http/serve-directory-routes.test.ts` (`openat2_in_root` path), and `test/js/node/fs/fs-stat-seccomp-linux.test.ts`: all pass.

### Background

- seccomp is a Linux kernel facility that filters a process's syscalls with a BPF program. A filter decides per syscall: allow, return an errno, or `SECCOMP_RET_TRAP`, which delivers SIGSYS to the process (fatal by default). Android uses the trap action for syscalls outside its allowlist, so "syscall not available" looks like a crash, not an error return.
- `openat2(2)` (Linux 5.6) is `openat` plus resolve flags: `RESOLVE_BENEATH` fails path resolution that escapes the starting directory (bun uses it to validate that a package's bin target stays inside the package), `RESOLVE_IN_ROOT` treats the starting directory as `/` (directory routes). Both uses already have fallbacks for kernels older than 5.6.
- `fchmodat2(2)` (Linux 6.6) is `fchmodat` with a working `AT_SYMLINK_NOFOLLOW`, i.e. `lchmod`: chmod that refuses to follow a final-component symlink. The emulation opens the file with `O_PATH|O_NOFOLLOW` (no permissions needed, does not follow a final symlink) and chmods it through the `/proc/self/fd/N` magic link.
- Bun ships `target_os = "linux"` binaries that Termux runs on the Android kernel, so the detection must happen at runtime; compile-time `cfg` gates can't catch this.

<details>
<summary>Reproduction details</summary>

Reproduced on plain Linux with a seccomp wrapper installing the equivalent filter (`SECCOMP_RET_TRAP` for nrs 437/452), matching the reporter's strace exactly:

```
$ sigsys-wrap bun add fast-deep-equal
bun add v1.4.0-canary.1
Bad system call (core dumped)
exit: 159
```

Blocking each syscall individually kills the install either way, so handling only one of them is not enough. A SIGSYS-handler probe (as used for `close_range` in #30769) was considered and rejected here: these syscalls are first issued from bin linking, where multiple threads run, and a temporarily-installed process-wide SIGSYS handler that `siglongjmp`s is only safe while single-threaded.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install-android-seccomp.test.ts

<!-- robobun:evidence:end -->