### PR TITLE
webview: make Chrome evaluate() results follow the documented JSON round trip

### DIFF
--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -847,15 +847,18 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
 
     case Method::RuntimeEvaluate: {
         // {"result":{"type":"...","value":...},"exceptionDetails":{...}?}
-        // returnByValue:true + awaitPromise:true → result.value is the
-        // JSON-serialized return. exceptionDetails present → script threw.
+        // exceptionDetails present → the script threw, or its result did
+        // not survive the page-side JSON round trip (see Ops::evaluate).
         auto excDetails = jsonField(result, { "exceptionDetails", 16 });
         if (!excDetails.empty()) {
             settle(g, view, entry.slot, false, errorFromExceptionDetails(g, excDetails));
             return;
         }
-        // result.result.value — the inner result object's value field.
-        // type:"undefined" → no value field → resolve undefined.
+        // result.result.value — the inner result object's value field. The
+        // page already ran the value through JSON.parse(JSON.stringify()),
+        // so it is plain JSON data and returnByValue always emits .value
+        // for it; the only result without one is type:"undefined" (script
+        // resolved to undefined, or to something JSON.stringify drops).
         auto inner = jsonField(result, { "result", 6 });
         auto type = jsonString(jsonField(inner, { "type", 4 }));
         auto valueSlice = jsonField(inner, { "value", 5 });
@@ -864,7 +867,7 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
             return;
         }
         // JSONParse the value slice directly. Same 1-parse as WKWebView's
-        // EvalDone — the slice IS JSON (returnByValue serialized it).
+        // EvalDone — the slice IS the JSON of the final value.
         JSValue v = JSONParse(g, WTF::String::fromUTF8(valueSlice));
         settle(g, view, entry.slot, true, v ? v : jsUndefined());
         return;
@@ -1411,17 +1414,32 @@ JSPromise* navigate(JSGlobalObject* g, JSWebView* view, const WTF::String& url)
             .num("height"_s, static_cast<int32_t>(view->m_height)));
 }
 
-// Runtime.evaluate with returnByValue + awaitPromise. Chrome JSON-serializes
-// the result internally (same mechanism as WKWebView's page-side
-// JSON.stringify but implicit). exceptionDetails present → script threw.
+// Runtime.evaluate with returnByValue + awaitPromise. exceptionDetails
+// present → script threw.
+//
+// returnByValue is not JSON.stringify: NaN/±Infinity/-0 arrive as
+// result.unserializableValue with no .value, functions become {}, a symbol
+// fails the command, BigInt is unserializable, toJSON is ignored. evaluate()
+// is documented as a page-side JSON.stringify + one JSONParse here (which is
+// what the WebKit backend does), so the page runs JSON.parse(JSON.stringify())
+// itself and returnByValue only ever sees plain JSON data, which it
+// serializes faithfully. JSON.stringify throwing (BigInt, cycles) rejects →
+// exceptionDetails, like WKWebView's callAsync rejecting.
 JSPromise* evaluate(JSGlobalObject* g, JSWebView* view, const WTF::String& script)
 {
     auto& t = transport();
     uint32_t id = t.nextId();
     // Same "await (expr)" wrap as WKWebView: forces expression context,
-    // unwraps thenables. Chrome's awaitPromise does the await part; we
-    // just need the paren-wrap for statement-sequence rejection consistency.
-    auto body = makeString("(async()=>{return await ("_s, script, ")})()"_s);
+    // unwraps thenables. The user's expression goes in the thunk argument,
+    // not in the round-trip function, so `r`/`s` are not in scope for it
+    // and page globals with those names still resolve. Parsing page-side
+    // (instead of returning the JSON text) keeps the response's .value
+    // plain JSON: one JSONParse in handleResponse, nothing escaped twice on
+    // the pipe. JSON.stringify yielding undefined stays undefined.
+    auto body = makeString(
+        "(async(r)=>{const s=JSON.stringify(await r());return s===void 0?s:JSON.parse(s)})(async()=>{return await ("_s,
+        script,
+        ")})"_s);
     return sendChromeOp(g, view, view->m_pendingEval, PendingSlot::Evaluate,
         Method::RuntimeEvaluate, id,
         Command(id, "Runtime.evaluate"_s, sidSpan(view->m_sessionId))

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -847,18 +847,14 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
 
     case Method::RuntimeEvaluate: {
         // {"result":{"type":"...","value":...},"exceptionDetails":{...}?}
-        // exceptionDetails present → the script threw, or its result did
-        // not survive the page-side JSON round trip (see Ops::evaluate).
+        // exceptionDetails present → script (or its JSON.stringify) threw.
         auto excDetails = jsonField(result, { "exceptionDetails", 16 });
         if (!excDetails.empty()) {
             settle(g, view, entry.slot, false, errorFromExceptionDetails(g, excDetails));
             return;
         }
-        // result.result.value — the inner result object's value field. The
-        // page already ran the value through JSON.parse(JSON.stringify()),
-        // so it is plain JSON data and returnByValue always emits .value
-        // for it; the only result without one is type:"undefined" (script
-        // resolved to undefined, or to something JSON.stringify drops).
+        // result.result.value — JSON of the round-tripped value (see
+        // Ops::evaluate). Only type:"undefined" has no value field.
         auto inner = jsonField(result, { "result", 6 });
         auto type = jsonString(jsonField(inner, { "type", 4 }));
         auto valueSlice = jsonField(inner, { "value", 5 });
@@ -866,8 +862,7 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
             settle(g, view, entry.slot, true, jsUndefined());
             return;
         }
-        // JSONParse the value slice directly. Same 1-parse as WKWebView's
-        // EvalDone — the slice IS the JSON of the final value.
+        // Same 1-parse as WKWebView's EvalDone.
         JSValue v = JSONParse(g, WTF::String::fromUTF8(valueSlice));
         settle(g, view, entry.slot, true, v ? v : jsUndefined());
         return;
@@ -1414,28 +1409,17 @@ JSPromise* navigate(JSGlobalObject* g, JSWebView* view, const WTF::String& url)
             .num("height"_s, static_cast<int32_t>(view->m_height)));
 }
 
-// Runtime.evaluate with returnByValue + awaitPromise. exceptionDetails
-// present → script threw.
-//
-// returnByValue is not JSON.stringify: NaN/±Infinity/-0 arrive as
-// result.unserializableValue with no .value, functions become {}, a symbol
-// fails the command, BigInt is unserializable, toJSON is ignored. evaluate()
-// is documented as a page-side JSON.stringify + one JSONParse here (which is
-// what the WebKit backend does), so the page runs JSON.parse(JSON.stringify())
-// itself and returnByValue only ever sees plain JSON data, which it
-// serializes faithfully. JSON.stringify throwing (BigInt, cycles) rejects →
-// exceptionDetails, like WKWebView's callAsync rejecting.
+// Runtime.evaluate with returnByValue + awaitPromise. returnByValue is not
+// JSON.stringify (NaN/-0 become unserializableValue, functions {}, toJSON is
+// ignored), so the page applies the documented JSON round trip itself, as the
+// WebKit backend does; a throwing JSON.stringify surfaces as exceptionDetails.
 JSPromise* evaluate(JSGlobalObject* g, JSWebView* view, const WTF::String& script)
 {
     auto& t = transport();
     uint32_t id = t.nextId();
-    // Same "await (expr)" wrap as WKWebView: forces expression context,
-    // unwraps thenables. The user's expression goes in the thunk argument,
-    // not in the round-trip function, so `r`/`s` are not in scope for it
-    // and page globals with those names still resolve. Parsing page-side
-    // (instead of returning the JSON text) keeps the response's .value
-    // plain JSON: one JSONParse in handleResponse, nothing escaped twice on
-    // the pipe. JSON.stringify yielding undefined stays undefined.
+    // Same "await (expr)" wrap as WKWebView. The script is a separate thunk
+    // so `r`/`s` never shadow page globals; parsing page-side keeps .value
+    // plain JSON (one JSONParse in handleResponse, no double escaping).
     auto body = makeString(
         "(async(r)=>{const s=JSON.stringify(await r());return s===void 0?s:JSON.parse(s)})(async()=>{return await ("_s,
         script,

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -108,7 +108,7 @@ let chromePath = findChrome();
 // Chrome refuses to start as root unless its sandbox is turned off, which is
 // how these tests run inside containers. Wrap the binary in a script that adds
 // the flag: in-process views get it through `chrome.path` below, the tests
-// that spawn a second bun through BUN_CHROME_PATH in bunEnv. (The runtime
+// that spawn a second bun through BUN_CHROME_PATH in chromeEnv. (The runtime
 // reads the real environment, so setting process.env here would not reach it.)
 let rootChromeWrapper: string | undefined;
 if (chromePath && process.platform === "linux" && process.getuid?.() === 0 && !process.env.BUN_CHROME_PATH) {
@@ -118,8 +118,8 @@ if (chromePath && process.platform === "linux" && process.getuid?.() === 0 && !p
   afterAll(() => dir[Symbol.dispose]());
   chromePath = rootChromeWrapper = join(String(dir), "chrome");
   chmodSync(chromePath, 0o755);
-  bunEnv.BUN_CHROME_PATH = chromePath;
 }
+const chromeEnv = rootChromeWrapper ? { ...bunEnv, BUN_CHROME_PATH: rootChromeWrapper } : bunEnv;
 
 // TODO: macOS 13/14 aarch64 CI — findChrome() resolves the Playwright
 // chrome-headless-shell, but it either throws ERR_DLOPEN_FAILED at spawn or
@@ -597,7 +597,7 @@ it("chrome: closeAll() kills the subprocess and pending promises reject", async 
         console.log("rejected");
       `,
     ],
-    env: bunEnv,
+    env: chromeEnv,
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
@@ -619,7 +619,7 @@ it("chrome: backend.stderr defaults to ignore (Chrome noise hidden)", async () =
         view.close();
       `,
     ],
-    env: bunEnv,
+    env: chromeEnv,
     stderr: "pipe",
   });
   const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
@@ -679,7 +679,7 @@ it("backend.argv appends after core flags", async () => {
       console.log("ok");
       `,
     ],
-    env: bunEnv,
+    env: chromeEnv,
     stderr: "pipe",
   });
   const [stdout, , exit] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
@@ -1014,7 +1014,7 @@ it("chrome: console: globalThis.console forwards to parent's stdout", async () =
       view.close();
       `,
     ],
-    env: bunEnv,
+    env: chromeEnv,
     stdout: "pipe",
     stderr: "pipe",
   });

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -1,5 +1,5 @@
-import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isCI, isMacOS, isMacOSVersionAtLeast } from "harness";
+import { afterAll, expect, test } from "bun:test";
+import { bunEnv, bunExe, isCI, isMacOS, isMacOSVersionAtLeast, tempDir } from "harness";
 
 // Chrome backend works on any platform with Chrome/Chromium installed.
 // Mark tests todo if no Chrome found (CI may not have it). Mirrors
@@ -7,7 +7,7 @@ import { bunEnv, bunExe, isCI, isMacOS, isMacOSVersionAtLeast } from "harness";
 // paths, then Playwright cache — so the test detects Chrome whenever the
 // runtime would.
 import { dlopen, FFIType, ptr } from "bun:ffi";
-import { accessSync, constants as fsConstants, readdirSync, rmSync } from "node:fs";
+import { accessSync, chmodSync, constants as fsConstants, readdirSync, rmSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -103,7 +103,24 @@ function findChrome(): string | undefined {
   return undefined;
 }
 
-const chromePath = findChrome();
+let chromePath = findChrome();
+
+// Chrome refuses to start as root unless its sandbox is turned off, which is
+// how these tests run inside containers. Wrap the binary in a script that adds
+// the flag: in-process views get it through `chrome.path` below, the tests
+// that spawn a second bun through BUN_CHROME_PATH in bunEnv. (The runtime
+// reads the real environment, so setting process.env here would not reach it.)
+let rootChromeWrapper: string | undefined;
+if (chromePath && process.platform === "linux" && process.getuid?.() === 0 && !process.env.BUN_CHROME_PATH) {
+  const dir = tempDir("webview-chrome-root", {
+    chrome: `#!/bin/sh\nexec "${chromePath}" --no-sandbox "$@"\n`,
+  });
+  afterAll(() => dir[Symbol.dispose]());
+  chromePath = rootChromeWrapper = join(String(dir), "chrome");
+  chmodSync(chromePath, 0o755);
+  bunEnv.BUN_CHROME_PATH = chromePath;
+}
+
 // TODO: macOS 13/14 aarch64 CI — findChrome() resolves the Playwright
 // chrome-headless-shell, but it either throws ERR_DLOPEN_FAILED at spawn or
 // launches and immediately closes the pipe on first navigate. Recent Chromium
@@ -116,12 +133,12 @@ const it = chromePath && !chromeBroken ? test : test.todo;
 // url:false forces spawn-mode — skips DevToolsActivePort auto-detect
 // which would connect to the dev's running Chrome, pop the "Allow remote
 // debugging?" dialog on every test, and create visible tabs. The
-// executable path is still auto-found.
+// executable path is still auto-found (unless running as root, see above).
 //
 // WebSocket-transport tests live in webview-chrome-ws.test.ts — the
 // Transport singleton means you can't mix pipe-mode (this file) and
 // connect-mode in one process.
-const chrome = { type: "chrome" as const, url: false as const };
+const chrome = { type: "chrome" as const, url: false as const, path: rootChromeWrapper };
 
 const html = (h: string) => "data:text/html," + encodeURIComponent(h);
 
@@ -153,6 +170,54 @@ it("chrome: evaluate returns native JS values", async () => {
   expect(await view.evaluate("null")).toBe(null);
   expect(await view.evaluate("undefined")).toBe(undefined);
   expect(await view.evaluate("true")).toBe(true);
+});
+
+it("chrome: evaluate applies the same JSON round trip as the WebKit backend", async () => {
+  await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
+  // `r` and `s` are the bindings evaluate()'s page-side wrapper uses for the
+  // round trip; a script must still see the page's globals of those names.
+  await view.navigate(html("<script>window.r = 'page r'; window.s = 'page s';</script>"));
+  // returnByValue on its own is not JSON.stringify: NaN, ±Infinity and -0
+  // come back as `unserializableValue` with no value (which used to resolve
+  // as undefined), functions and Dates as {}, and a Symbol fails the
+  // command. evaluate() is documented as a JSON.stringify/JSON.parse round
+  // trip, so every case below must match what that round trip produces
+  // (the same table webview.test.ts checks against WKWebView).
+  const scripts = {
+    nan: "NaN",
+    infinity: "Infinity",
+    negativeInfinity: "-Infinity",
+    negativeZero: "-0",
+    fn: "() => 1",
+    symbol: "Symbol('x')",
+    date: "new Date(0)",
+    toJSON: "({ toJSON() { return 'custom' } })",
+    nested: "({ a: NaN, b: -0, c: [Infinity, undefined, () => 1] })",
+    awaited: "Promise.resolve(-0)",
+    r: "r",
+    s: "s",
+  };
+  const results: Record<string, unknown> = {};
+  for (const [name, script] of Object.entries(scripts)) {
+    results[name] = await view.evaluate(script).catch(e => ({ rejected: e.message }));
+  }
+  expect(results).toEqual({
+    nan: null,
+    infinity: null,
+    negativeInfinity: null,
+    negativeZero: 0,
+    fn: undefined,
+    symbol: undefined,
+    date: "1970-01-01T00:00:00.000Z",
+    toJSON: "custom",
+    nested: { a: null, b: 0, c: [null, null, null] },
+    awaited: 0,
+    r: "page r",
+    s: "page s",
+  });
+  // JSON.stringify(-0) is "0", so the sign is dropped, not preserved.
+  expect(Object.is(results.negativeZero, 0)).toBe(true);
+  expect(Object.is(results.awaited, 0)).toBe(true);
 });
 
 it("chrome: evaluate awaits Promises", async () => {
@@ -654,11 +719,16 @@ it("chrome: evaluate() rejected Promise carries rejection reason", async () => {
   await expect(view.evaluate("Promise.reject(new TypeError('bad'))")).rejects.toThrow(/bad/);
 });
 
-it("chrome: evaluate() with circular reference throws", async () => {
+it("chrome: evaluate() rejects when the result has no JSON form", async () => {
   await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
   await view.navigate(html("<body></body>"));
-  // returnByValue can't serialize circular — Chrome throws page-side.
-  await expect(view.evaluate("const a = {}; a.self = a; a")).rejects.toThrow();
+  // The page-side JSON.stringify throws for these, and that TypeError is the
+  // rejection, as on WebKit. (returnByValue alone reports a BigInt as
+  // unserializableValue, which used to resolve as undefined.)
+  await expect(view.evaluate("(() => { const a = {}; a.self = a; return a })()")).rejects.toThrow(/circular/);
+  await expect(view.evaluate("1n")).rejects.toThrow(/BigInt/);
+  // A statement sequence is still a SyntaxError rather than being evaluated.
+  await expect(view.evaluate("const a = 1; a")).rejects.toThrow(/SyntaxError|Unexpected/);
 });
 
 it("chrome: click(selector) rejects on invalid selector syntax", async () => {

--- a/test/js/bun/webview/webview.test.ts
+++ b/test/js/bun/webview/webview.test.ts
@@ -192,6 +192,45 @@ it("evaluate() returns native JS values via page-side JSON.stringify + parent JS
   expect(await view.evaluate("() => 1")).toBeUndefined();
 });
 
+it("evaluate() result is exactly the JSON round trip (same table as the Chrome backend)", async () => {
+  await using view = new Bun.WebView({ width: 200, height: 200 });
+  await view.navigate(html("<body></body>"));
+  // webview-chrome.test.ts checks this same table against Chrome, whose
+  // Runtime.evaluate does not JSON-serialize on its own; both backends must
+  // agree with what the docs promise.
+  const scripts = {
+    nan: "NaN",
+    infinity: "Infinity",
+    negativeInfinity: "-Infinity",
+    negativeZero: "-0",
+    symbol: "Symbol('x')",
+    date: "new Date(0)",
+    toJSON: "({ toJSON() { return 'custom' } })",
+    nested: "({ a: NaN, b: -0, c: [Infinity, undefined, () => 1] })",
+    awaited: "Promise.resolve(-0)",
+  };
+  const results: Record<string, unknown> = {};
+  for (const [name, script] of Object.entries(scripts)) {
+    results[name] = await view.evaluate(script).catch(e => ({ rejected: e.message }));
+  }
+  expect(results).toEqual({
+    nan: null,
+    infinity: null,
+    negativeInfinity: null,
+    negativeZero: 0,
+    symbol: undefined,
+    date: "1970-01-01T00:00:00.000Z",
+    toJSON: "custom",
+    nested: { a: null, b: 0, c: [null, null, null] },
+    awaited: 0,
+  });
+  expect(Object.is(results.negativeZero, 0)).toBe(true);
+  expect(Object.is(results.awaited, 0)).toBe(true);
+  // JSON.stringify throws for these; the TypeError is the rejection.
+  await expect(view.evaluate("1n")).rejects.toThrow(/BigInt/);
+  await expect(view.evaluate("(() => { const a = {}; a.self = a; return a })()")).rejects.toThrow(/cyclic|circular/);
+});
+
 it("evaluate() awaits Promises", async () => {
   await using view = new Bun.WebView({ width: 200, height: 200 });
   await view.navigate(html("<body></body>"));


### PR DESCRIPTION
### Problem
- With `backend: "chrome"`, `await view.evaluate("NaN")`, `"Infinity"`, `"-Infinity"` and `"-0"` all resolve to `undefined`. `evaluate("1n")` resolves to `undefined` too.
- Same backend: `evaluate("() => 1")` and `evaluate("new Date(0)")` resolve to `{}`, `evaluate("Symbol('x')")` rejects with `Object couldn't be returned by value`, `toJSON` is ignored, and a function nested in a result (`[() => 1]`) comes back as `[{}]`.
- `evaluate()` is documented (`docs/runtime/webview.mdx`, the JSDoc in `packages/bun-types/bun.d.ts`) as a `JSON.stringify` in the page plus a `JSON.parse` in Bun, and the WebKit backend implements exactly that (`src/runtime/webview/WebViewHost.cpp`, `evaluateIPC`), so on WebKit the same scripts give `null, null, null, 0`, a rejection for `1n`, `undefined` for the function and the symbol, and the ISO string for the Date.
- Cause: `Ops::evaluate` in `src/runtime/webview/ChromeBackend.cpp` sends the user's expression to `Runtime.evaluate` with `returnByValue: true` and treats V8's serialization as if it were `JSON.stringify`. It is not: for numbers JSON cannot carry, V8 omits `result.value` and sends `result.unserializableValue` (the `Method::RuntimeEvaluate` arm of `Transport::handleResponse` then takes the missing value as `undefined`), a BigInt is reported the same way, functions serialize as `{}`, Dates are not run through `toJSON`, and a Symbol fails the command.

### Fix
- The expression wrapper that `Ops::evaluate` sends now runs the documented round trip in the page: the user's expression is evaluated in a thunk, and a sibling function does `JSON.stringify` followed by `JSON.parse` on the awaited result (passing `undefined` through when `JSON.stringify` yields it). `returnByValue` therefore only ever serializes plain JSON data, which it does faithfully, and a `JSON.stringify` TypeError (BigInt, cycles) rejects the promise through `exceptionDetails` the same way a throwing script does.
- This is correct because it makes the Chrome backend produce, by construction, the value the docs and the types promise and the WebKit backend already produces; there is no table of special cases to keep in sync with V8's serializer.
- The round trip's own bindings live in a function the user's expression is not nested in, so a page global named like one of them is still what the script sees (covered by the test). Parsing in the page rather than returning the JSON text keeps `result.value` as plain JSON: the response handler still does one `JSONParse`, and large results are not escaped a second time on the pipe. The wire format and the Bun-side work are unchanged; the page does one extra stringify/parse of the result.
- `handleResponse` is unchanged apart from its comments: a missing `value` now only ever means `type: "undefined"`.
- Tests:
  - `test/js/bun/webview/webview-chrome.test.ts`: new `evaluate applies the same JSON round trip as the WebKit backend` (NaN, the infinities, `-0` checked with `Object.is`, function, symbol, Date, `toJSON`, nested values, an awaited promise, and the page-global names), and `evaluate() rejects when the result has no JSON form` (cycle, BigInt, statement sequence), which replaces the previous circular-reference test whose expression was a statement sequence and so was rejecting as a SyntaxError. On the unfixed build both fail (NaN and friends arrive as `undefined`, `1n` resolves); with the fix the whole file passes (53 tests), also under `BUN_JSC_validateExceptionChecks=1`.
  - `test/js/bun/webview/webview.test.ts`: the same table against the WebKit backend, so the two backends are held to one contract. Runs on the macOS lanes only.
  - The Chrome test file now also works when run as root (containers): Chrome refuses to start as root without `--no-sandbox`, so the file wraps the detected binary in a one-line script that adds the flag, used for in-process views through `backend.path` and for the tests that spawn a second bun through `BUN_CHROME_PATH` in `bunEnv`. Nothing changes when not running as root.
- No docs or type changes: both already describe the behavior this PR makes the Chrome backend follow.

### Background
- `Bun.WebView` has two backends. WebKit (macOS) talks to a WKWebView host process; Chrome talks to a Chrome/Chromium subprocess over CDP, the Chrome DevTools Protocol (JSON messages over a pipe).
- `Runtime.evaluate` is the CDP command that runs a script in the page. With `returnByValue: true` Chrome serializes the result into the response itself instead of returning a handle to it. That serializer is V8's inspector value serializer, which has its own rules; in particular a primitive that JSON cannot represent (NaN, the infinities, `-0`, any BigInt) is returned as the string field `unserializableValue` with no `value` field, and objects are walked without calling `toJSON`.
- `exceptionDetails` is the part of a `Runtime.evaluate` response that is present when the evaluated script threw or, with `awaitPromise: true`, when its promise rejected; the Chrome backend turns it into the rejection of `evaluate()`.
- `BUN_CHROME_PATH` is the environment variable the runtime consults for the Chrome binary when `backend.path` is not given; the test file's own `findChrome()` honors it too.

<details>
<summary>Before / after on Chrome 151 (Linux)</summary>

```ts
const view = new Bun.WebView({ backend: { type: "chrome", url: false } });
await view.navigate("data:text/html,<body></body>");
for (const s of ["NaN", "Infinity", "-0", "() => 1", "Symbol('x')", "new Date(0)", "1n"])
  console.log(s, "=>", await view.evaluate(s).catch(e => "rejected: " + e.message));
```

Before:

```
NaN => undefined
Infinity => undefined
-0 => undefined
() => 1 => {}
Symbol('x') => rejected: Object couldn't be returned by value
new Date(0) => {}
1n => undefined
```

After (identical to the WebKit backend):

```
NaN => null
Infinity => null
-0 => 0
() => 1 => undefined
Symbol('x') => undefined
new Date(0) => 1970-01-01T00:00:00.000Z
1n => rejected: Do not know how to serialize a BigInt
```

</details>
