### PR TITLE
types: declare the global onmessage and onerror handlers

### DIFF
--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -498,6 +498,49 @@ declare function removeEventListener(
   options?: boolean | Bun.EventListenerOptions,
 ): void;
 
+// `onmessage` must stay declared, whatever its type: @types/node (web-globals/*.d.ts) checks
+// `typeof globalThis extends { onmessage: any }` to tell that the environment brings its own
+// Request, Response, MessageEvent, ErrorEvent, ... and declares Node's versions of them otherwise.
+/**
+ * Handler for the `"message"` events a worker thread receives from
+ * `worker.postMessage()` in its parent. Same as `addEventListener("message", handler)`.
+ *
+ * Only useful in a worker thread; the main thread never dispatches `"message"`
+ * events on its global scope. `null` until assigned.
+ *
+ * @example
+ * ```ts
+ * // worker.ts
+ * onmessage = event => {
+ *   postMessage(event.data);
+ * };
+ * ```
+ */
+declare var onmessage: Bun.__internal.UseLibDomIfAvailable<"onmessage", ((event: MessageEvent) => any) | null>;
+
+/**
+ * Handler for the `"error"` event a worker thread dispatches on its own global
+ * scope when an exception or promise rejection in that thread goes unhandled,
+ * before the error is reported to the parent's `Worker` object. Same as
+ * `addEventListener("error", handler)`.
+ *
+ * The handler receives the `ErrorEvent` itself as its only argument. Bun does not
+ * spread it into the `(message, source, lineno, colno, error)` arguments that
+ * browsers pass to `onerror`.
+ *
+ * Only useful in a worker thread; the main thread never dispatches `"error"`
+ * events on its global scope. `null` until assigned.
+ *
+ * @example
+ * ```ts
+ * // worker.ts
+ * onerror = event => {
+ *   console.error(event.message, event.error);
+ * };
+ * ```
+ */
+declare var onerror: Bun.__internal.UseLibDomIfAvailable<"onerror", ((event: ErrorEvent) => any) | null>;
+
 /**
  * An event that provides information about an error in a script or in a file.
  */

--- a/packages/bun-types/index.d.ts
+++ b/packages/bun-types/index.d.ts
@@ -26,7 +26,3 @@
 /// <reference path="./bundle.d.ts" />
 
 /// <reference path="./bun.ns.d.ts" />
-
-// Must disable this so it doesn't conflict with the DOM onmessage type, but still
-// allows us to declare our own globals that Node's types can "see" and not conflict with
-declare var onmessage: Bun.__internal.UseLibDomIfAvailable<"onmessage", never>;

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -400,6 +400,58 @@ describe("@types/bun integration test", () => {
     });
   });
 
+  // Runs on debug builds too, like the Bun.mmap test above.
+  describe("global onmessage / onerror", () => {
+    test("take a handler receiving the MessageEvent / ErrorEvent, or null", async () => {
+      const checkDir = join(TEMP_DIR, "global-event-handlers-check");
+      const tsconfig = structuredClone(sourceTsconfig);
+      tsconfig.include = ["global-event-handlers.ts"];
+      tsconfig.compilerOptions.typeRoots = [join(BASE_FIXTURE_DIR, "node_modules", "@types")];
+      await mkdir(checkDir, { recursive: true });
+      await makeTree(checkDir, {
+        "tsconfig.json": JSON.stringify(tsconfig, null, 2),
+        "global-event-handlers.ts": `onmessage satisfies ((event: MessageEvent) => any) | null;
+           onerror satisfies ((event: ErrorEvent) => any) | null;
+
+           // A worker thread's handlers are called with the event as their only argument.
+           onmessage = event => {
+             event satisfies MessageEvent;
+             postMessage(event.data);
+           };
+           onerror = event => {
+             event satisfies ErrorEvent;
+             event.message satisfies string;
+             console.error(event.error);
+           };
+           globalThis.onmessage = event => event.data;
+           globalThis.onerror = event => event.message;
+           onmessage = null;
+           onerror = null;
+
+           // @ts-expect-error the handler receives a MessageEvent, not the posted data
+           onmessage = (data: string) => data;
+           // @ts-expect-error Bun passes the ErrorEvent, not browsers' (message, source, ...) arguments
+           onerror = (message: string, source: string) => message + source;
+           // @ts-expect-error a handler is cleared with null, not undefined
+           onerror = undefined;`,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), join(BASE_FIXTURE_DIR, "node_modules", "typescript", "bin", "tsc"), "-p", "."],
+        env: bunEnv,
+        cwd: checkDir,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr.trim()).toBe("");
+      expect(stdout.trim()).toBe("");
+      expect(exitCode).toBe(0);
+    });
+  });
+
   describe("Test Globals", () => {
     const code = `
       const test_shouldBeAFunction: Function = test;
@@ -868,6 +920,13 @@ describe("@types/bun integration test", () => {
           code: 2339,
           line: "worker.ts:25:11",
           message: "Property 'threadId' does not exist on type 'Worker'.",
+        },
+        {
+          // lib.dom's global onerror is window.onerror, whose first parameter is `Event | string`;
+          // Bun's own declaration (which applies without lib.dom) receives an ErrorEvent.
+          code: 2554,
+          line: "worker.ts:52:25",
+          message: "Expected 2 arguments, but got 0.",
         },
       ],
     });

--- a/test/integration/bun-types/fixture/worker.ts
+++ b/test/integration/bun-types/fixture/worker.ts
@@ -41,6 +41,19 @@ webWorker.onmessage = event => {
 // On the worker thread, `postMessage` is automatically "routed" to the parent thread.
 postMessage({ hello: "world" });
 
+// On the worker thread, the global onmessage / onerror handlers receive the event as their
+// only argument. With lib.dom.d.ts loaded, onerror has window.onerror's `Event | string`
+// parameter instead, so the onerror assertion is an expected diagnostic in bun-types.test.ts.
+onmessage = event => {
+  tsd.expectType(event).is<MessageEvent>();
+  postMessage(event.data);
+};
+onerror = event => {
+  tsd.expectType(event).is<ErrorEvent>();
+};
+onmessage = null;
+onerror = null;
+
 // On the main thread
 nodeWorker.postMessage({ hello: "world" });
 


### PR DESCRIPTION
### Problem
- With the default `bun init` tsconfig (`types: ["bun"]`, no lib.dom), a worker entry file cannot use the global event handler attributes Bun implements:
  ```ts
  onmessage = e => console.log(e.data); // error TS2322: Type '(e: any) => void' is not assignable to type 'never'.
  onerror = e => console.log(e.message); // error TS2552: Cannot find name 'onerror'. Did you mean 'Error'?
  ```
  Even `onmessage = null` fails (`Type 'null' is not assignable to type 'never'`).
- `packages/bun-types/index.d.ts:32` declared `onmessage` as `UseLibDomIfAvailable<"onmessage", never>`. The `never` is a placeholder from the types rewrite in #18024: the declaration only existed so that @types/node sees an `onmessage` global (see below). `onerror` was not declared anywhere in bun-types.
- The runtime has both: `src/jsc/bindings/ZigGlobalObject.cpp:3226-3227` installs `onmessage` / `onerror` accessors on every global object, backed by the global event scope's `message` / `error` handler slots. Checked with bun 1.4.0: both read as `null` until assigned on the main thread and in workers; in a worker, `onmessage` is called with one argument (a `MessageEvent`) when the parent posts, and `onerror` is called with one argument (an `ErrorEvent`, `.error` being the thrown value) for an uncaught exception or unhandled rejection in that thread, before the parent's `Worker` gets its `error` event (`src/jsc/bindings/webcore/Worker.cpp:191-202`). The handlers are plain event listeners (`setEventHandlerAttribute<JSEventListener>`, `ZigGlobalObject.cpp:1187-1211`), so `onerror` does not get the `(message, source, lineno, colno, error)` arguments browsers pass.

### Fix
- `globals.d.ts`: declare `onmessage` as `((event: MessageEvent) => any) | null` and `onerror` as `((event: ErrorEvent) => any) | null`, next to the global `addEventListener` / `removeEventListener`; remove the `never` declaration from `index.d.ts`. `MessageEvent` / `ErrorEvent` are the same types the global `addEventListener("message" | "error", ...)` overloads hand out, and `| null` is the unassigned value.
- Both stay wrapped in `Bun.__internal.UseLibDomIfAvailable`, so with lib.dom loaded they resolve to lib.dom's own `onmessage` / `onerror` types and do not produce TS2403 redeclaration errors. Without lib.dom, bun-types is the only declaration and its fallback applies.
- `onmessage` stays declared (now with a useful type), so @types/node's detection is unchanged: `never` and the new union both satisfy `{ onmessage: any }`. @types/node does not use `onerror` as a detector (only `onmessage` and `onabort`, checked against @types/node 25), and bun-types' own lib.dom detector is `onabort`, so the new `onerror` global changes nothing else.
- No `this` parameter on either handler type: the runtime does not call the handler with the global scope as `this` (it passes the raw global object, which strict-mode code sees as `undefined`; handed off separately), so there is no correct `this` to declare. Arrow-function handlers, the normal usage, are unaffected either way.
- Verified:
  - `test/integration/bun-types/bun-types.test.ts`, new `global onmessage / onerror` case (spawns `tsc` over a file exercising both handlers, `null`, and three rejected shapes via `@ts-expect-error`; runs on debug builds too). Fails on the unfixed types with the two errors above, passes with the fix (`bun bd test`).
  - `test/integration/bun-types/fixture/worker.ts` now assigns both handlers and `null`; the fixture is type-checked with and without lib.dom by the existing cases. With lib.dom, lib.dom's `onerror` is `window.onerror` (first parameter `Event | string`), so the `ErrorEvent` assertion there is added to that case's expected diagnostics.
  - Full file passes on a release build (`USE_SYSTEM_BUN=1 bun test ...`: 16 pass, including the lib.dom case and the tsgo case) and on the debug build (4 pass, 12 skipped as before).

### Background
- bun-types declares the *worker-side* global scope (global `postMessage`, `addEventListener`, `EventMap` with `message`) because TypeScript cannot type the main thread and worker threads differently; `onmessage` / `onerror` are the attribute form of those listeners.
- `Bun.__internal.UseLibDomIfAvailable<Name, Fallback>` (`bun.d.ts:58`) is how bun-types declares a global that lib.dom also declares: if lib.dom is loaded (detected via its `onabort` global) the type is read back from `typeof globalThis`, so the two `declare var`s have identical types and TypeScript accepts them; otherwise `Fallback` is used.
- @types/node uses `typeof globalThis extends { onmessage: any }` (in `web-globals/*.d.ts`) to decide whether the environment already provides `Request`, `Response`, `MessageEvent`, `ErrorEvent`, etc. bun-types relies on that check succeeding so that its own versions of those globals are used instead of Node's, which is why a global `onmessage` declaration has to exist in bun-types regardless of its type.
- `bun-types.test.ts` runs its in-process type-check cases only on release builds; the spawned-`tsc` cases (like the existing `Bun.mmap` one) are the ones that also run on debug builds.
