### PR TITLE
node:tls: report servername as false on server sockets when the client sent no SNI

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -692,6 +692,14 @@ function SocketEmitEndNT(self, _err?) {
   }
 }
 
+// The native layer reports "the ClientHello carried no SNI" as undefined; node's
+// TLSWrap::GetServername() reports it as false, and that is what reaches users
+// through socket.servername and the ALPNCallback argument.
+// https://github.com/nodejs/node/blob/v26.3.0/src/crypto/crypto_tls.cc#L1359-L1373
+function servernameOrFalse(servername: string | undefined): string | false {
+  return servername ?? false;
+}
+
 // --- SNICallback dispatch helpers (hoisted: no per-handshake closures) ---
 
 // Normalizes non-Error rejections (cb(true), cb("reason"), throw true): the
@@ -782,7 +790,8 @@ const ServerHandlers: SocketHandler<NetSocket> = {
     }
     let result;
     try {
-      result = cb.$call(self, { servername, protocols });
+      // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L243
+      result = cb.$call(self, { servername: servernameOrFalse(servername), protocols });
     } catch (err) {
       // Node: a throwing ALPNCallback refuses the connection (fatal
       // no_application_protocol alert) and surfaces the thrown error as
@@ -933,6 +942,10 @@ const ServerHandlers: SocketHandler<NetSocket> = {
       } else {
         err = tlsHandshakeError(verifyError);
       }
+      // Not servernameOrFalse: node only stores a name the ClientHello did carry
+      // here (TLSWrap::SelectSNIContextCallback); its `false` comes from
+      // _finishInit, which a failed handshake never reaches.
+      // https://github.com/nodejs/node/blob/v26.3.0/src/crypto/crypto_tls.cc#L1396-L1399
       self.servername = socket.getServername();
       self._hadError = true;
       // Node's onerror destroys *with* the error when the handshake never
@@ -947,7 +960,8 @@ const ServerHandlers: SocketHandler<NetSocket> = {
     self._securePending = false;
     self.secureConnecting = false;
     self._secureEstablished = !!success;
-    self.servername = socket.getServername();
+    // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1094-L1096
+    self.servername = servernameOrFalse(socket.getServername());
     self.alpnProtocol = socket.alpnProtocol;
     self[kVerifyError] = verifyError ?? null;
     // The native verifier reports a non-OK code when there is no peer certificate,

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -2333,6 +2333,79 @@ describe("node v26.3.0 tls.Server parity follow-ups", () => {
       server.close();
     }
   });
+
+  // Once the handshake is done node stores TLSWrap::GetServername(), which is
+  // the SNI name or `false` (never undefined) when the ClientHello carried
+  // none; the ALPNCallback argument is built from the same call. Node's own
+  // test-https-agent-sni.js branches on `servername !== false`.
+  // https://github.com/nodejs/node/blob/v26.3.0/src/crypto/crypto_tls.cc#L1359-L1373
+  // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1094-L1096
+  // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L243
+  const sniCases: [label: string, servername: string | undefined, expected: string | false][] = [
+    ["the client sent no SNI", undefined, false],
+    ["the client sent SNI", "sni.example.com", "sni.example.com"],
+  ];
+  // @types/node does not declare the property.
+  const servernameOf = (socket: TLSSocket) => (socket as unknown as { servername: unknown }).servername;
+
+  it.each(sniCases)(
+    "socket.servername and the ALPNCallback servername report what the ClientHello carried (%s)",
+    async (_label, servername, expected) => {
+      let alpnServername: unknown = "ALPNCallback did not run";
+      const server = createServer({
+        ...COMMON_CERT,
+        ALPNCallback: ({ servername: offered, protocols }) => {
+          alpnServername = offered;
+          return protocols[0];
+        },
+      });
+      const observed = Promise.withResolvers<{ socket: unknown; alpn: unknown }>();
+      server.on("secureConnection", socket => {
+        observed.resolve({ socket: servernameOf(socket), alpn: alpnServername });
+        socket.end();
+      });
+      server.on("tlsClientError", observed.reject);
+      let client: TLSSocket | undefined;
+      try {
+        const port = await listen(server);
+        // An IP host gets no SNI of its own: only `servername` adds one.
+        client = connect({ port, host: "127.0.0.1", servername, ALPNProtocols: ["a"], rejectUnauthorized: false });
+        client.on("error", observed.reject);
+        expect(await observed.promise).toEqual({ socket: expected, alpn: expected });
+      } finally {
+        client?.destroy();
+        server.close();
+      }
+    },
+  );
+
+  it.each(sniCases)(
+    "a standalone server-side TLSSocket wrap reports servername after 'secure' (%s)",
+    async (_label, servername, expected) => {
+      const raw = net.createServer();
+      const observed = Promise.withResolvers<unknown>();
+      let secured: TLSSocket | undefined;
+      raw.on("connection", socket => {
+        secured = new TLSSocket(socket, { isServer: true, ...COMMON_CERT });
+        secured.on("error", observed.reject);
+        secured.on("secure", () => {
+          observed.resolve(servernameOf(secured!));
+          secured!.end();
+        });
+      });
+      let client: TLSSocket | undefined;
+      try {
+        const port = await listen(raw as unknown as Server);
+        client = connect({ port, host: "127.0.0.1", servername, rejectUnauthorized: false });
+        client.on("error", observed.reject);
+        expect(await observed.promise).toBe(expected);
+      } finally {
+        client?.destroy();
+        secured?.destroy();
+        raw.close();
+      }
+    },
+  );
 });
 
 describe("throwing 'secureConnection' listener", () => {


### PR DESCRIPTION
### Problem

- In a `tls.createServer()` connection listener, `socket.servername` is `undefined` when the client sent no SNI extension. Node v26.3.0 reports `false`. Same for a standalone `new tls.TLSSocket(raw, { isServer: true })` after `'secure'`.
- The object passed to a server's `ALPNCallback` carries `servername: undefined` in the same case. Node passes `false` there too.
- Node code branches on this value. Node's own `test/parallel/test-https-agent-sni.js` does `if (req.socket.servername !== false) res.setHeader('x-sni', servername)`; on a `tls.Server` socket under Bun that branch is taken with `undefined` and `setHeader` throws.
- Cause: `src/js/node/net.ts` `ServerHandlers.handshake` assigns the native `socket.getServername()` result as is, and `ServerHandlers.alpnCallback` forwards the native SNI argument as is. The native side (`src/runtime/socket/tls_socket_functions.rs` `get_servername`, `src/runtime/socket/socket_body.rs` `select_alpn_callback`) reports a NULL `SSL_get_servername()` as `undefined`.
- The `https` server was already right: `_http_server.ts`'s socket getter normalizes to `false`. Only the `tls.Server` / server-side `TLSSocket` paths were inconsistent.

### Fix

- Adds `servernameOrFalse()` in `net.ts` (`name ?? false`) and applies it at the two sites that produce the node-visible values: the handshake-success assignment of `self.servername` and the `ALPNCallback` argument object. The fixing lines are the two `servernameOrFalse(...)` call sites; the rest is comments.
- Why `false` and why these two sites: both values come from the same node primitive, `TLSWrap::GetServername()`, which returns the SNI name or `false` when `SSL_get_servername()` is NULL ([crypto_tls.cc#L1359-L1373](https://github.com/nodejs/node/blob/v26.3.0/src/crypto/crypto_tls.cc#L1359-L1373)). `_finishInit` stores it on the socket ([wrap.js#L1094-L1096](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1094-L1096)) and `callALPNCallback` passes it to the callback ([wrap.js#L243](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L243)).
- Why `??` and not an empty-string check: BoringSSL rejects an empty SNI host_name at ClientHello parse time (`vendor/boringssl/ssl/handshake_server.cc`, `extract_sni`), so on the server side the native value is either a non-empty name or undefined; `??` mirrors node's NULL check exactly.
- Deliberately unchanged: the handshake-failure assignment a few lines above (the `'tlsClientError'` socket). Node never reaches `_finishInit` on that path; only `SelectSNIContextCallback` writes the property, and only when the ClientHello carried a name ([crypto_tls.cc#L1396-L1399](https://github.com/nodejs/node/blob/v26.3.0/src/crypto/crypto_tls.cc#L1396-L1399)), so a no-SNI failure keeps the property's initial value in node. That matches what Bun does there today; a comment now says why that line differs from the one below it. The client-side value after the handshake (node: `false` without SNI, Bun: `""`) is the subject of #33476 and is not touched here.
- Kept in the `node:` compat layer on purpose: `Bun.Socket#getServername()` is a public Bun API and keeps returning `undefined`.
- Verified: `test/js/node/tls/node-tls-server.test.ts` gains four cases in the v26.3.0 parity block (`tls.Server` socket + `ALPNCallback`, and a standalone server-side wrap, each with and without SNI). On the unfixed build the two no-SNI cases fail (`undefined` received, `false` expected) and the two with-SNI cases pass; all four pass with the fix.
- Also run on the fixed build: the full `test/js/node/tls/` directory (the only failures are `SNICallback runs even when the requested servername matches the bind hostname`, which is the host-dependent ECONNREFUSED that #35160 fixes and fails the same way before this change, and the root-certs worker race test hitting its 5s budget on this debug+ASAN container, also unchanged), plus the vendored `test-tls-sni-*.js`, `test-tls-alpn-server-client.js`, `test-tls-psk-alpn-callback-exception-handling.js`, `test-tls-add-context.js`, `test-tls-empty-sni-context.js`, `test-tls-snicallback-error.js` and `test-https-agent-sni.js`, all exit 0.

### Background

- SNI (Server Name Indication) is the TLS ClientHello extension in which a client names the host it wants to talk to, so one listener can pick a certificate per name. Clients connecting to an IP address send none (RFC 6066 forbids IP literals), which is the case this PR is about.
- `SSL_get_servername()` is the BoringSSL/OpenSSL accessor for that name on a connection; it returns NULL when the ClientHello had no such extension.
- `TLSWrap` is node's native per-connection TLS object; `TLSWrap::GetServername()` is the JS-callable wrapper around `SSL_get_servername()` and is where node's `false` originates.
- `_finishInit` is the node function that runs when a handshake completes; `callALPNCallback` is the one that invokes a server's `ALPNCallback` option while the handshake is still in progress. `ServerHandlers.handshake` and `ServerHandlers.alpnCallback` in `net.ts` are Bun's counterparts, shared by `tls.Server` connections and standalone server-side wraps, which is why one change covers both.

<details>
<summary>node v26.3.0 vs Bun on the affected paths</summary>

Probe: a `tls.createServer` with an `ALPNCallback`, a server expecting TLS 1.3 dialed by a TLS 1.2-only client (to reach `'tlsClientError'`), and a `new TLSSocket(raw, { isServer: true })` wrap; each dialed once without SNI and once with `servername: "sni.example"`.

```
node v26.3.0
secureConnection (no SNI): socket.servername=false alpn.servername=false
tlsClientError (no SNI): socket.servername=null
standalone TLSSocket isServer (no SNI): before=null after=false
secureConnection (SNI=sni.example): socket.servername="sni.example" alpn.servername="sni.example"
standalone TLSSocket isServer (SNI=sni.example): before=null after="sni.example"

bun main (before)
secureConnection (no SNI): socket.servername=undefined alpn.servername=undefined
tlsClientError (no SNI): socket.servername=undefined
standalone TLSSocket isServer (no SNI): before=undefined after=undefined
secureConnection (SNI=sni.example): socket.servername="sni.example" alpn.servername="sni.example"
standalone TLSSocket isServer (SNI=sni.example): before=undefined after="sni.example"

bun with this PR
secureConnection (no SNI): socket.servername=false alpn.servername=false
tlsClientError (no SNI): socket.servername=undefined
standalone TLSSocket isServer (no SNI): before=undefined after=false
secureConnection (SNI=sni.example): socket.servername="sni.example" alpn.servername="sni.example"
standalone TLSSocket isServer (SNI=sni.example): before=undefined after="sni.example"
```

The remaining `undefined` vs `null` before the handshake (and on the failure path) is the `TLSSocket` constructor's initial value, shared with client sockets, and is outside this change.

</details>
