### PR TITLE
webview: size the Chrome page viewport with a device metrics override instead of the window

### DIFF
--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -594,6 +594,24 @@ static std::span<const char> sidSpan(const WTF::String& s)
     return { reinterpret_cast<const char*>(span.data()), span.size() };
 }
 
+// Emulation.setDeviceMetricsOverride pinning the page's viewport to the
+// view's m_width x m_height. This is the only thing that sizes the page: sent
+// once when the page session is attached (before the first Page.navigate;
+// the override persists across navigations) and again by resize(). Sizing
+// the window instead (Target.createTarget width/height) is not the same
+// thing: chrome-headless-shell gives the page the whole window, but full
+// Chrome's headless mode keeps ~87px of it for its invisible browser UI and
+// clamps to a minimum window size, so innerHeight and screenshots came out
+// short of the requested size. Same approach as puppeteer/playwright.
+static Command deviceMetricsOverride(uint32_t id, JSWebView* view, std::span<const char> sid)
+{
+    return Command(id, "Emulation.setDeviceMetricsOverride"_s, sid)
+        .num("width"_s, static_cast<int32_t>(view->m_width))
+        .num("height"_s, static_cast<int32_t>(view->m_height))
+        .num("deviceScaleFactor"_s, 1)
+        .boolean("mobile"_s, false);
+}
+
 // Bun click button → CDP button enum string. CDP's Input.dispatchMouseEvent
 // takes a string: "none", "left", "middle", "right".
 static constexpr ASCIILiteral cdpButton(uint8_t b)
@@ -745,10 +763,16 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         m_sessions.add(view->m_sessionId, entry.viewId);
         updateKeepAlive();
 
-        // Page.enable lets us receive frameNavigated / loadEventFired.
         // sessionId now available — the remaining chain goes to the page.
         auto ss = view->m_sessionId.utf8();
         std::span<const char> sidSpan(ss.data(), ss.length());
+
+        // Viewport first, fire-and-forget (untracked, like Runtime.enable).
+        // CDP handles a session's commands in order, so it is applied
+        // before the Page.navigate sent from the PageEnable arm.
+        send(0, deviceMetricsOverride(nextId(), view, sidSpan));
+
+        // Page.enable lets us receive frameNavigated / loadEventFired.
         uint32_t cid = nextId();
         m_pending.add(cid, Pending { Method::PageEnable, entry.slot, entry.viewId });
         send(cid, Command(cid, "Page.enable"_s, sidSpan));
@@ -1396,19 +1420,23 @@ JSPromise* navigate(JSGlobalObject* g, JSWebView* view, const WTF::String& url)
     // Page.loadEventFired. The chain carries the same Weak<view> forward
     // so the pending activity count keeps this object rooted the whole time.
     //
-    // newWindow:true is required for width/height — without it Chrome
-    // reuses an existing window and rejects position params. Headless has
-    // no visible window either way; "new window" just means "new top-level
-    // browsing context".
+    // newWindow:true gives every view its own (headless, invisible) window.
+    // Without it each new view opens as a tab of the existing window and
+    // the views already open become background tabs: their
+    // document.visibilityState flips to "hidden", rAF stops and screenshots
+    // never return. The window is left at Chrome's default size on purpose:
+    // createTarget's width/height size the window, not the page (see
+    // deviceMetricsOverride), and a window smaller than Chrome's minimum
+    // comes up hidden (0x0, no frames). The viewport is set once the session
+    // is attached, and Chrome renders, screenshots and maps input for a
+    // viewport of any size independent of the window it sits in.
     view->m_pendingChromeNavigateUrl = url;
     uint32_t id = t.nextId();
     return sendChromeOp(g, view, view->m_pendingNavigate, PendingSlot::Navigate,
         Method::TargetCreateTarget, id,
         Command(id, "Target.createTarget"_s)
             .str("url"_s, "about:blank"_s)
-            .boolean("newWindow"_s, true)
-            .num("width"_s, static_cast<int32_t>(view->m_width))
-            .num("height"_s, static_cast<int32_t>(view->m_height)));
+            .boolean("newWindow"_s, true));
 }
 
 // Runtime.evaluate with returnByValue + awaitPromise. Chrome JSON-serializes
@@ -1659,11 +1687,7 @@ JSPromise* resize(JSGlobalObject* g, JSWebView* view, uint32_t width, uint32_t h
     uint32_t id = t.nextId();
     return sendChromeOp(g, view, view->m_pendingMisc, PendingSlot::Misc,
         Method::EmulationSetDeviceMetricsOverride, id,
-        Command(id, "Emulation.setDeviceMetricsOverride"_s, sidSpan(view->m_sessionId))
-            .num("width"_s, static_cast<int32_t>(width))
-            .num("height"_s, static_cast<int32_t>(height))
-            .num("deviceScaleFactor"_s, 1)
-            .boolean("mobile"_s, false));
+        deviceMetricsOverride(id, view, sidSpan(view->m_sessionId)));
 }
 
 // Page.getNavigationHistory → Page.navigateToHistoryEntry chain. Playwright

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -79,8 +79,9 @@ public:
 
     // WebKit: viewId routes frames to the host. Chrome: 0.
     uint32_t m_viewId = 0;
-    // Chrome: target creation width/height for the first navigate() which
-    // does Target.createTarget. WebKit: held in the child.
+    // Chrome: the viewport size, applied with Emulation.setDeviceMetricsOverride
+    // when the first navigate()'s attach chain reaches the page session and
+    // updated by resize(). WebKit: held in the child.
     uint32_t m_width = 0, m_height = 0;
     bool m_closed = false;
     // Updated from NavDone replies / Page.frameNavigated — the getters are
@@ -186,7 +187,7 @@ public:
 #endif
 
     // Chrome constructor. Lazy-spawns Chrome; stores width/height for the
-    // Target.createTarget that the first navigate() sends. path overrides
+    // viewport override the first navigate()'s attach chain sends. path overrides
     // auto-detection; extraArgv appends to the built-in flags. Works on
     // all platforms where Chrome runs (not just Darwin). Returns nullptr
     // if Chrome spawn failed.

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -113,6 +113,10 @@ const chromePath = findChrome();
 const chromeBroken = isCI && isMacOS && !isMacOSVersionAtLeast(15);
 const it = chromePath && !chromeBroken ? test : test.todo;
 
+// Chrome refuses to start as root unless its sandbox is disabled
+// (crbug.com/638180), which is how this file runs inside containers.
+const chromeArgv: string[] = process.getuid?.() === 0 ? ["--no-sandbox"] : [];
+
 // url:false forces spawn-mode — skips DevToolsActivePort auto-detect
 // which would connect to the dev's running Chrome, pop the "Allow remote
 // debugging?" dialog on every test, and create visible tabs. The
@@ -121,7 +125,9 @@ const it = chromePath && !chromeBroken ? test : test.todo;
 // WebSocket-transport tests live in webview-chrome-ws.test.ts — the
 // Transport singleton means you can't mix pipe-mode (this file) and
 // connect-mode in one process.
-const chrome = { type: "chrome" as const, url: false as const };
+const chrome = { type: "chrome" as const, url: false as const, argv: chromeArgv };
+// Same backend for the subprocess-isolated tests below, inlined into their -e scripts.
+const chromeJson = JSON.stringify(chrome);
 
 const html = (h: string) => "data:text/html," + encodeURIComponent(h);
 
@@ -518,7 +524,7 @@ it("chrome: closeAll() kills the subprocess and pending promises reject", async 
       bunExe(),
       "-e",
       `
-        const view = new Bun.WebView({ backend: {type:"chrome", url:false}, width: 200, height: 200 });
+        const view = new Bun.WebView({ backend: ${chromeJson}, width: 200, height: 200 });
         await view.navigate("data:text/html,<body>test</body>");
         const p = view.evaluate("new Promise(() => {})"); // never resolves
         Bun.WebView.closeAll();
@@ -549,7 +555,7 @@ it("chrome: backend.stderr defaults to ignore (Chrome noise hidden)", async () =
       bunExe(),
       "-e",
       `
-        const view = new Bun.WebView({ backend: {type:"chrome", url:false}, width: 200, height: 200 });
+        const view = new Bun.WebView({ backend: ${chromeJson}, width: 200, height: 200 });
         await view.navigate("data:text/html,<body>test</body>");
         view.close();
       `,
@@ -589,7 +595,11 @@ it("backend: { type: 'chrome' } object form works", async () => {
   // path forces spawn-mode — without it, the bare object form would
   // auto-detect DevToolsActivePort and connect to the dev's Chrome,
   // locking the singleton into WS mode for subsequent tests.
-  await using view = new Bun.WebView({ backend: { type: "chrome", path: chromePath }, width: 200, height: 200 });
+  await using view = new Bun.WebView({
+    backend: { type: "chrome", path: chromePath, argv: chromeArgv },
+    width: 200,
+    height: 200,
+  });
   await view.navigate(html("<body>obj</body>"));
   expect(await view.evaluate("document.body.textContent")).toBe("obj");
 });
@@ -604,7 +614,7 @@ it("backend.argv appends after core flags", async () => {
       "-e",
       `
       const view = new Bun.WebView({
-        backend: { type: "chrome", argv: ["--user-agent=BunWebViewTest/1.0"] },
+        backend: { type: "chrome", argv: ${JSON.stringify([...chromeArgv, "--user-agent=BunWebViewTest/1.0"])} },
         width: 200, height: 200,
       });
       await view.navigate("data:text/html,<body></body>");
@@ -752,6 +762,116 @@ it("chrome: scrollTo with block: start aligns top", async () => {
   // block: start → target's top aligns with viewport top.
   const top = await view.evaluate("document.getElementById('t').getBoundingClientRect().top");
   expect(Math.abs(top)).toBeLessThan(2);
+});
+
+// --- Viewport size ---------------------------------------------------------
+// The constructor's width/height are applied with Emulation.setDeviceMetrics-
+// Override while the first navigate() attaches to the page, the same way
+// resize() applies a new size. They used to be passed to Target.createTarget
+// instead, which sizes the window: chrome-headless-shell gives the page the
+// whole window, but full Chrome's headless mode (what CI installs) keeps
+// ~87px of it for its invisible browser UI, so until the first resize() the
+// page and its screenshots were that much shorter than requested. These
+// tests only tell the two apart on full Chrome; on headless-shell both
+// approaches happen to agree.
+
+// PNG: 8-byte signature, then the IHDR chunk (4-byte length, "IHDR",
+// big-endian width, big-endian height).
+async function pngDimensions(blob: Blob) {
+  const png = Buffer.from(await blob.arrayBuffer());
+  expect(png.toString("latin1", 12, 16)).toBe("IHDR");
+  return { w: png.readUInt32BE(16), h: png.readUInt32BE(20) };
+}
+
+const viewportJs = "({w: innerWidth, h: innerHeight})";
+
+it("chrome: the page viewport is the constructor width/height before any resize()", async () => {
+  await using view = new Bun.WebView({ backend: chrome, width: 320, height: 240 });
+  await view.navigate(html("<body></body>"));
+  expect(await view.evaluate(viewportJs)).toEqual({ w: 320, h: 240 });
+  expect(await pngDimensions(await view.screenshot())).toEqual({ w: 320, h: 240 });
+  // The override is session state, so later navigations keep the size.
+  await view.navigate(html("<body>second</body>"));
+  expect(await view.evaluate(viewportJs)).toEqual({ w: 320, h: 240 });
+});
+
+it("chrome: the url constructor option sizes the viewport like navigate() does", async () => {
+  // Subprocess: the constructor's own navigate() promise is internal, and
+  // close()-ing the view before its load event settles it rejects that
+  // promise with nothing to catch it. Exiting the process instead skips
+  // close(). onNavigated (Page.frameNavigated) is the earliest point at
+  // which the session exists for evaluate().
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const view = new Bun.WebView({ backend: ${chromeJson}, width: 320, height: 240, url: "data:text/html,<body></body>" });
+        const { promise, resolve } = Promise.withResolvers();
+        view.onNavigated = resolve;
+        await promise;
+        console.log(JSON.stringify(await view.evaluate(${JSON.stringify(viewportJs)})));
+        process.exit(0);
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: '{"w":320,"h":240}', stderr: "", exitCode: 0 });
+});
+
+it("chrome: views attached to the same Chrome each get their own size", async () => {
+  await using a = new Bun.WebView({ backend: chrome, width: 320, height: 240 });
+  await using b = new Bun.WebView({ backend: chrome, width: 480, height: 160 });
+  await Promise.all([a.navigate(html("<body>a</body>")), b.navigate(html("<body>b</body>"))]);
+  expect(await Promise.all([a.evaluate(viewportJs), b.evaluate(viewportJs)])).toEqual([
+    { w: 320, h: 240 },
+    { w: 480, h: 160 },
+  ]);
+});
+
+it("chrome: a view shorter than Chrome's minimum window height renders and scrolls", async () => {
+  // Sizing the window to this used to leave full Chrome with a page that
+  // was 0px tall or hidden outright (no frames, so rAF never fired and
+  // screenshots hung). scroll() fires its wheel event at (width / 2,
+  // height / 2) of the constructor size, which then had no page under it.
+  await using view = new Bun.WebView({ backend: chrome, width: 300, height: 60 });
+  await view.navigate(html("<body style='margin:0;height:5000px'></body>"));
+  expect(await view.evaluate(viewportJs)).toEqual({ w: 300, h: 60 });
+  await view.scroll(0, 100);
+  // The compositor applies the wheel scroll asynchronously; rAF-poll for it
+  // (same as "scroll dispatches wheel event" above).
+  const y = await view.evaluate(`
+    new Promise((resolve, reject) => {
+      const deadline = performance.now() + 2000;
+      requestAnimationFrame(function tick() {
+        if (scrollY > 0) return resolve(scrollY);
+        if (performance.now() > deadline) return reject("scrollY never moved");
+        requestAnimationFrame(tick);
+      });
+    })
+  `);
+  expect(y).toBeGreaterThan(0);
+});
+
+it("chrome: a viewport larger than Chrome's default window renders, screenshots and takes input at full size", async () => {
+  // The window stays at Chrome's default size (800x600 headless); only the
+  // emulated viewport is 1600x1200. Screenshots must cover all of it and
+  // click() coordinates must still be viewport CSS pixels, so a click in
+  // the far corner lands on the element pinned there.
+  await using view = new Bun.WebView({ backend: chrome, width: 1600, height: 1200 });
+  await view.navigate(
+    html(
+      `<body style="margin:0">
+        <button style="position:fixed;right:0;bottom:0;width:40px;height:40px" onclick="window.__hit=1"></button>
+      </body>`,
+    ),
+  );
+  expect(await view.evaluate(viewportJs)).toEqual({ w: 1600, h: 1200 });
+  expect(await pngDimensions(await view.screenshot())).toEqual({ w: 1600, h: 1200 });
+  await view.click(1580, 1180);
+  expect(await view.evaluate("window.__hit")).toBe(1);
 });
 
 // --- Lifecycle -------------------------------------------------------------
@@ -935,7 +1055,7 @@ it("chrome: console: globalThis.console forwards to parent's stdout", async () =
       "-e",
       `
       const view = new Bun.WebView({
-        backend: {type:"chrome", url:false}, width: 200, height: 200,
+        backend: ${chromeJson}, width: 200, height: 200,
         console: globalThis.console,
       });
       await view.navigate("data:text/html,<body></body>");


### PR DESCRIPTION
### Problem
- `new Bun.WebView({ backend: "chrome", width: W, height: H })` gives a page whose `innerHeight` is `H - 87` on full Chrome/Chromium (what CI installs, and what `find_chrome` prefers over the Playwright headless shell); `innerWidth` is `W`. Screenshots come out `W x (H - 87)` too. With google-chrome-stable 151 here: 400x300 requested, `{w: 400, h: 213}` reported, PNG 400x213. Only `await view.resize(W, H)` makes the viewport exact.
- Cause: `CDP::Ops::navigate` (src/runtime/webview/ChromeBackend.cpp, first-navigate branch) passed `width`/`height` to `Target.createTarget`, and nothing else sized the page. Those parameters size the window. chrome-headless-shell gives the page the whole window, so it looked right there; full Chrome's headless mode keeps ~87px of the window for its (invisible) browser UI and clamps the window to a minimum size (500px wide here), so the page was short of the requested size.
- Same window sizing also broke small views outright: a view shorter than Chrome's minimum window height came up with a 0x0 or `visibilityState === "hidden"` page (no frames: rAF never fires, `screenshot()` never resolves), and `scroll()`, which fires its wheel event at `(width / 2, height / 2)` of the constructor size, hit nothing. The same happens in `backend.url` (WebSocket) mode.

### Fix
- `Transport::handleResponse`, `Target.attachToTarget` arm: as soon as the page session exists, send `Emulation.setDeviceMetricsOverride` with the view's `m_width`/`m_height` (fire-and-forget, like `Runtime.enable`), ahead of `Page.enable` and the first `Page.navigate`. CDP handles a session's commands in order, so the override is in place before the navigation starts; the override is session state and persists across later navigations. `resize()` now builds the identical command through the same `deviceMetricsOverride()` helper, so construction and `resize()` agree by construction.
- `Target.createTarget` no longer passes `width`/`height`; the window stays at Chrome's default size. `newWindow: true` stays: without it, each new view opens as a tab of the existing window and the already-open views become hidden background tabs.
- Why this is right: the documented contract (`ConstructorOptions.width/height`, docs/runtime/webview.mdx) is the viewport size, and the device metrics override is the CDP mechanism for that; it is what `resize()` already used and what puppeteer and playwright send for every new page. The window size is the wrong knob: it is flavour dependent (headless shell vs full Chrome), clamped, and can produce a hidden page, while Chrome renders, screenshots and maps input for an emulated viewport of any size independently of the window (verified from 300x40 up to 2000x1500 in a default 800x600 window).
- Observable side effect: `outerWidth`/`outerHeight` now report Chrome's default window size instead of tracking the requested size (same as puppeteer); in `backend.url` mode the new window opens at Chrome's default size with the W x H viewport inside it.
- Tests, test/js/bun/webview/webview-chrome.test.ts ("Viewport size" section): viewport and screenshot dimensions equal the constructor size before any `resize()` and survive a second navigation; the `url` constructor option gets the same size; two views attached to one Chrome each get their own size; a 300x60 view renders and `scroll()` works; a 1600x1200 view (bigger than the default window) reports, screenshots and receives a far-corner `click()` at full size. Without the src change these five fail on full Chrome (`h: 153` for 240, `h: 1113` for 1200, `500x153` for 300x60, ...), with it the file passes (57 tests), five runs of the new tests in a row were stable, and the WebSocket transport was checked by hand against a Chrome started with `--remote-debugging-port` (exact before/after numbers in the details below). On chrome-headless-shell the new tests pass with or without the fix, since there the window and the page happen to coincide.
- Test-only: the file now passes `--no-sandbox` when running as root (Chrome refuses to start as root without it, crbug.com/638180), which is how the suite runs inside containers; before this every Chrome test in the file failed there (45 of 52). Non-root runs, i.e. CI, are unaffected. Whether the runtime itself should do something for root users (Playwright disables the sandbox by default, puppeteer leaves it to the caller; today the user only sees "Chrome exited") is a separate question this PR does not take a position on.

### Background
- CDP (Chrome DevTools Protocol) is the JSON command protocol the Chrome backend drives Chrome with. A *target* is a tab; *attaching* to it yields a *session id* that page-level commands (`Page.*`, `Emulation.*`, `Input.*`) are addressed with. Commands sent on one session are processed in order. The first `navigate()` on a view runs the attach chain `Target.createTarget` -> `Target.attachToTarget` -> `Page.enable` -> `Page.navigate`, each step issued from the previous reply in `Transport::handleResponse`; `view.resize()` and every later operation talk to the session directly.
- `Emulation.setDeviceMetricsOverride` makes the page lay out, paint and hit-test as if its viewport were exactly the given CSS size, whatever the window is; it is per session and survives navigations. `Target.createTarget`'s `width`/`height` size the browser window the tab is created in.
- chrome-headless-shell is the stripped headless binary Playwright/puppeteer download; "full Chrome" (`google-chrome-stable`, `chromium`) run with `--headless` keeps a simulated browser window, including the space its UI would occupy and its minimum window size, even though nothing is drawn. Bun's `find_chrome` prefers full Chrome from `$PATH`, and CI's bootstrap installs it.

<details>
<summary>Probe numbers (google-chrome-stable 151.0.7922.137, Debian 13)</summary>

Released bun, pipe transport (`backend: { type: "chrome", url: false }`), `innerWidth x innerHeight` / PNG IHDR after `navigate()`:

```
requested 200x120 -> inner 200x33,   outer 500x120, png 200x33
requested 400x300 -> inner 400x213,  outer 500x300, png 400x213
requested 800x600 -> inner 800x513,  outer 800x600, png 800x513
requested 300x60  -> inner 0x0 / 500x73 / 500x153 (varies per run)
requested 300x40  -> inner 780x493; scroll() never resolved
```

Released bun vs this branch, WebSocket transport (`backend: { type: "chrome", url: "ws://..." }` against a Chrome started with `--remote-debugging-port=0`):

```
            released            this branch
320x240     320x153 / png same  320x240 / png 320x240
300x60      500x153 / png same  300x60  / png 300x60
1600x1200   1600x1113 / same    1600x1200 / png 1600x1200
```

This branch, pipe transport, per size: `innerWidth x innerHeight`, `outerWidth x outerHeight`, whether rAF fires, PNG size, `scrollY` after `scroll(0, 100)`:

```
300x40    -> 300x40    outer 780x580 visible, raf ok, png 300x40,    scrolled 100
300x60    -> 300x60    outer 780x580 visible, raf ok, png 300x60,    scrolled 100
320x240   -> 320x240   outer 780x580 visible, raf ok, png 320x240,   scrolled 100
1600x1200 -> 1600x1200 outer 780x580 visible, raf ok, png 1600x1200, scrolled 100
2000x1500 -> 2000x1500 outer 780x580 visible, raf ok, png 2000x1500, scrolled 100
```

Raw CDP check of `newWindow` with three targets left open (override 320x240 / 400x300 / 500x350): without `newWindow` the first two report `visibilityState` "hidden" and rAF stops firing in them; with `newWindow: true` all three stay visible.
</details>
