### PR TITLE
webview: decode JSON escapes in the Chrome backend's title, url and error messages

### DIFF
--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -228,6 +228,13 @@ std::span<const char> jsonString(std::span<const char> field)
     return { p + 1, static_cast<size_t>(end - p - 2) };
 }
 
+WTF::String jsonStringValue(std::span<const char> field)
+{
+    auto value = JSON::Value::parseJSON(WTF::String::fromUTF8(field));
+    if (!value) return {};
+    return value->asString();
+}
+
 // --- Transport singleton ---------------------------------------------------
 
 Transport& transport()
@@ -712,8 +719,7 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
 
     if (!error.empty()) {
         // {"code":-32000,"message":"..."}
-        auto msgSlice = jsonString(jsonField(error, { "message", 7 }));
-        auto errStr = WTF::String::fromUTF8(std::span<const char>(msgSlice));
+        auto errStr = jsonStringValue(jsonField(error, { "message", 7 }));
         settle(g, view, entry.slot, false,
             createError(g, errStr.isEmpty() ? "CDP error"_s : errStr));
         return;
@@ -791,9 +797,9 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         // pending entry so the event handler can look up the view by
         // sessionId — actually the event handler uses m_sessions, not
         // m_pending, so we just drop here.
-        auto err = jsonString(jsonField(result, { "errorText", 9 }));
-        if (!err.empty())
-            settle(g, view, entry.slot, false, createError(g, WTF::String::fromUTF8(err)));
+        auto err = jsonStringValue(jsonField(result, { "errorText", 9 }));
+        if (!err.isEmpty())
+            settle(g, view, entry.slot, false, createError(g, err));
         // Else: don't settle — Page.loadEventFired does.
         return;
     }
@@ -805,8 +811,7 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         // Runtime.evaluate("document.title") chained from loadEventFired.
         // result.result.value is the string. Set m_title, settle Navigate.
         auto inner = jsonField(result, { "result", 6 });
-        auto value = jsonString(jsonField(inner, { "value", 5 }));
-        view->m_title = WTF::String::fromUTF8(value);
+        view->m_title = jsonStringValue(jsonField(inner, { "value", 5 }));
         settle(g, view, entry.slot, true, jsUndefined());
         return;
     }
@@ -1096,8 +1101,7 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
     // now the new document, resources may still be loading.
     if (method.size() == 19 && memcmp(method.data(), "Page.frameNavigated", 19) == 0) {
         auto frame = jsonField(params, { "frame", 5 });
-        auto url = jsonString(jsonField(frame, { "url", 3 }));
-        auto urlStr = WTF::String::fromUTF8(url);
+        auto urlStr = jsonStringValue(jsonField(frame, { "url", 3 }));
         view->m_url = urlStr;
         // m_loading stays true — loadEventFired flips it.
 

--- a/src/runtime/webview/ChromeBackend.h
+++ b/src/runtime/webview/ChromeBackend.h
@@ -61,10 +61,18 @@ std::span<const char> jsonField(std::span<const char> json, std::span<const char
 uint32_t jsonId(std::span<const char> json);
 
 // Slice out the inner string contents (past the quotes, before escapes).
-// The caller must know the field is a string. Does NOT unescape — for
-// sessionId/targetId that's fine (base64-ish, no escapes); for method
-// names it's fine (no escapes in CDP method names).
+// The caller must know the field is a string. Does NOT unescape, so it is
+// only for values Chrome never has to escape: sessionId/targetId
+// (base64-ish/hex), method names, RemoteObject types, screenshot base64.
 std::span<const char> jsonString(std::span<const char> field);
+
+// Decode a JSON string value (the quoted slice jsonField returns) into the
+// text it denotes. Chrome's encoder escapes quotes, backslashes, control
+// characters and every non-ASCII code point (\uXXXX, surrogate pairs for
+// astral), so anything handed to the user (page title, frame url, error
+// messages) goes through this, not jsonString(). Null string if the slice
+// isn't a JSON string.
+WTF::String jsonStringValue(std::span<const char> field);
 
 // --- Command builder -------------------------------------------------------
 // Per-method fixed templates. The builder holds an inline-capacity

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -121,7 +121,14 @@ const it = chromePath && !chromeBroken ? test : test.todo;
 // WebSocket-transport tests live in webview-chrome-ws.test.ts — the
 // Transport singleton means you can't mix pipe-mode (this file) and
 // connect-mode in one process.
-const chrome = { type: "chrome" as const, url: false as const };
+//
+// Chrome exits immediately when launched as root without --no-sandbox
+// (crbug.com/638180), which is how containers run this suite. Spawn flags
+// only take effect on the first launch in a process, so every site that
+// launches Chrome (this object and the subprocess fixtures below) passes
+// chromeArgv.
+const chromeArgv = process.platform !== "win32" && process.getuid!() === 0 ? ["--no-sandbox"] : [];
+const chrome = { type: "chrome" as const, url: false as const, argv: chromeArgv };
 
 const html = (h: string) => "data:text/html," + encodeURIComponent(h);
 
@@ -518,7 +525,7 @@ it("chrome: closeAll() kills the subprocess and pending promises reject", async 
       bunExe(),
       "-e",
       `
-        const view = new Bun.WebView({ backend: {type:"chrome", url:false}, width: 200, height: 200 });
+        const view = new Bun.WebView({ backend: ${JSON.stringify(chrome)}, width: 200, height: 200 });
         await view.navigate("data:text/html,<body>test</body>");
         const p = view.evaluate("new Promise(() => {})"); // never resolves
         Bun.WebView.closeAll();
@@ -549,7 +556,7 @@ it("chrome: backend.stderr defaults to ignore (Chrome noise hidden)", async () =
       bunExe(),
       "-e",
       `
-        const view = new Bun.WebView({ backend: {type:"chrome", url:false}, width: 200, height: 200 });
+        const view = new Bun.WebView({ backend: ${JSON.stringify(chrome)}, width: 200, height: 200 });
         await view.navigate("data:text/html,<body>test</body>");
         view.close();
       `,
@@ -589,7 +596,11 @@ it("backend: { type: 'chrome' } object form works", async () => {
   // path forces spawn-mode — without it, the bare object form would
   // auto-detect DevToolsActivePort and connect to the dev's Chrome,
   // locking the singleton into WS mode for subsequent tests.
-  await using view = new Bun.WebView({ backend: { type: "chrome", path: chromePath }, width: 200, height: 200 });
+  await using view = new Bun.WebView({
+    backend: { type: "chrome", path: chromePath, argv: chromeArgv },
+    width: 200,
+    height: 200,
+  });
   await view.navigate(html("<body>obj</body>"));
   expect(await view.evaluate("document.body.textContent")).toBe("obj");
 });
@@ -604,7 +615,7 @@ it("backend.argv appends after core flags", async () => {
       "-e",
       `
       const view = new Bun.WebView({
-        backend: { type: "chrome", argv: ["--user-agent=BunWebViewTest/1.0"] },
+        backend: { type: "chrome", argv: ${JSON.stringify([...chromeArgv, "--user-agent=BunWebViewTest/1.0"])} },
         width: 200, height: 200,
       });
       await view.navigate("data:text/html,<body></body>");
@@ -824,6 +835,45 @@ it("chrome: url/title getters populated after navigate", async () => {
   expect(view.title).toBe("Second");
 });
 
+// Chrome's CDP encoder escapes quotes, backslashes and every non-ASCII code
+// point (\uXXXX, surrogate pairs for astral) in the JSON it sends. The
+// strings the backend lifts out of that JSON by hand (title, frame url,
+// error messages) have to be decoded; evaluate() already JSON-parses its
+// result, so it doubles as the reference value.
+it("chrome: title getter decodes JSON escapes", async () => {
+  await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
+  const title = 'a"b\\c é 日本 \u{1F600}';
+  // charset=utf-8: without it Chrome decodes the percent-encoded bytes of a
+  // data: URL as windows-1252 and the title itself would be mojibake.
+  await view.navigate("data:text/html;charset=utf-8," + encodeURIComponent(`<title>${title}</title>`));
+  expect(await view.evaluate("document.title")).toBe(title);
+  expect(view.title).toBe(title);
+});
+
+it("chrome: url getter and onNavigated decode JSON escapes", async () => {
+  await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
+  const urls: string[] = [];
+  view.onNavigated = (url: string) => urls.push(url);
+  // The URL parser keeps " and \ verbatim in a data: URL's opaque path, so
+  // the committed URL Chrome reports contains both (as \" and \\ in JSON).
+  await view.navigate('data:text/html,<body>"q"\\b</body>');
+  const href = await view.evaluate("location.href");
+  expect(href).toContain('"q"\\b');
+  expect(view.url).toBe(href);
+  expect(urls.at(-1)).toBe(href);
+});
+
+it("chrome: CDP error messages decode JSON escapes", async () => {
+  await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
+  await view.navigate(html("<body></body>"));
+  // Chrome echoes an unknown method name back in its -32601 message
+  // ("'<method>' wasn't found"), which gets each escape class into
+  // error.message. toThrow(string) is a substring match on the message.
+  for (const method of ['No.such"method', "No.such\\method", "No.such\nmethod"]) {
+    await expect(view.cdp(method)).rejects.toThrow(method);
+  }
+});
+
 it("chrome: onNavigated fires with committed URL", async () => {
   await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
   const urls: string[] = [];
@@ -935,7 +985,7 @@ it("chrome: console: globalThis.console forwards to parent's stdout", async () =
       "-e",
       `
       const view = new Bun.WebView({
-        backend: {type:"chrome", url:false}, width: 200, height: 200,
+        backend: ${JSON.stringify(chrome)}, width: 200, height: 200,
         console: globalThis.console,
       });
       await view.navigate("data:text/html,<body></body>");


### PR DESCRIPTION
### Problem
- With `backend: "chrome"`, `view.title` holds the JSON-escaped form of the title instead of the title. `<title>a"b\c é 日本</title>` gives a `view.title` whose characters are literally `a\"b\\c \u00e9 \u65e5\u672c`; `await view.evaluate("document.title")` on the same page returns `a"b\c é 日本`.
- `view.url` and the argument of `onNavigated` have the same defect when the committed URL contains `"` or `\` (both survive URL serialization in a `data:` URL), and so does the `message` of an error rejected by `cdp()`: `'No.such\"method' wasn't found`.
- Chrome's CDP encoder escapes every non-ASCII code point as `\uXXXX`, so every non-ASCII title is affected, not only titles containing quotes. The WebKit backend is unaffected (the host process sends the strings themselves).
- Cause: `CDP::jsonString()` (`src/runtime/webview/ChromeBackend.cpp:217`) only strips the quotes off the slice `jsonField()` found. That is by design for ids and method names, but it was also used for the four user-visible strings: the `Method::PageTitle` arm (`m_title`), the `Page.frameNavigated` handler (`m_url`, `onNavigated`), the CDP `error.message` path and the `Page.navigate` `errorText` path.

### Fix
- Adds `CDP::jsonStringValue()`, which runs the quoted slice through `WTF::JSON::Value::parseJSON` and returns the string it denotes (the null string when the slice is not a JSON string), and uses it at those four sites.
- `jsonString()` keeps the callers whose values Chrome never has to escape (target/session ids, method names, RemoteObject `type`, screenshot base64); its header comment now says that is its contract.
- Why this is right: the slice is a JSON string token, so a JSON parser is the definition of its value. It handles every escape Chrome emits, including `\uXXXX` surrogate pairs, which decode to exactly the UTF-16 code units a JS string holds, and it also accepts raw UTF-8 should a CDP endpoint send strings unescaped. The same decoder is already used in this file for `exceptionDetails`, console events and navigation history, and the result matches what the WebKit backend and `evaluate()` (which JSON-parses its result) already return. All four sites are cold: one per load, per commit or per error.
- `errorText` is decoded for consistency; Chrome's `net::ERR_*` strings are ASCII, so there is no separate test for it.
- Tests: `test/js/bun/webview/webview-chrome.test.ts` gains three tests: title with `"`, `\`, BMP and astral characters; url and `onNavigated` with `"` and `\`; `cdp()` error messages with `"`, `\` and a newline (Chrome echoes an unknown method name in its error). All three fail on the current build and pass with the fix; the whole file passes (55 tests) with Chrome 151 on Linux x64.
- The test file now passes `--no-sandbox` when it runs as root, which is the case inside containers (Chrome exits at launch otherwise); the shared `chrome` object and the subprocess fixtures all carry the same argv. When not root the argv is empty, so the tests behave as before in CI.

### Background
- The Chrome backend drives Chrome over the DevTools Protocol (CDP): NUL-delimited JSON messages on a pipe. Rather than parsing each envelope, `ChromeBackend.cpp` scans it: `jsonField()` returns the raw slice of one value and `jsonString()` strips the quotes off a string slice without decoding it.
- Chrome's JSON encoder emits pure ASCII: `"`, `\` and control characters are backslash-escaped and any other code point outside printable ASCII becomes `\uXXXX` (two of them for an astral character). A raw slice therefore equals the string only when the string is ASCII without quotes or backslashes.
- `WTF::JSON` is WebKit's JSON parser that builds a C++ value tree without touching the JS heap; it accepts a bare string as a document, which is what `jsonStringValue()` relies on.

<details>
<summary>Repro against the current build (Chrome 151, Linux x64)</summary>

```ts
const view = new Bun.WebView({ backend: { type: "chrome", url: false }, width: 100, height: 100 });
const html = (h: string) => "data:text/html;charset=utf-8," + encodeURIComponent(h);
await view.navigate(html('<title>a"b\\c é 日本 \u{1F600}</title>'));
console.log(JSON.stringify(view.title));
console.log(JSON.stringify(await view.evaluate("document.title")));
await view.navigate('data:text/html,<title>t</title>"q"\\b');
console.log(JSON.stringify(view.url));
console.log(JSON.stringify(await view.evaluate("location.href")));
await view.cdp('No.such"method').catch(e => console.log(JSON.stringify(e.message)));
```

```
"a\\\"b\\\\c \\u00e9 \\u65e5\\u672c \\ud83d\\ude00"
"a\"b\\c é 日本 😀"
"data:text/html,<title>t</title>\\\"q\\\"\\\\b"
"data:text/html,<title>t</title>\"q\"\\b"
"'No.such\\\"method' wasn't found"
```

With this change the first line equals the second, the third equals the fourth, and the last is `"'No.such\"method' wasn't found"`.
</details>
