### PR TITLE
bake: load files outside the bundle by their Windows path during prerendering

### DIFF
--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -1318,11 +1318,9 @@ unsafe extern "C" {
     ) -> *mut JSPromise;
 }
 
-/// Called by `bakeModuleLoaderFetch` with the path of a key that missed the
-/// module map, before handing it to the regular module loader to read from
-/// disk. Undoes the key spelling described on `resolve_disk_key`. The result
-/// has to be a plain Win32 path: the loader cuts a specifier at the first `?`
-/// (query string), so a `\\?\` prefixed one would be read as `\\`.
+/// Inverse of the key spelling in `resolve_disk_key`, for the fetch hook to read
+/// the file. Must stay a plain Win32 path: the module loader cuts specifiers at
+/// the first `?`, so a `\\?\` prefixed one was read as `\\`.
 #[unsafe(no_mangle)]
 extern "C" fn BakeToWindowsPath(input: BunString) -> BunString {
     #[cfg(not(windows))]
@@ -1339,9 +1337,7 @@ extern "C" fn BakeToWindowsPath(input: BunString) -> BunString {
     }
 }
 
-/// `/C:/a/b.mjs` -> `C:/a/b.mjs`. UNC keys (`//server/share/b.mjs`) already are
-/// Windows paths and bundle output keys (`/_bun/abc123.js`) have no volume, so
-/// both come back unchanged.
+/// `/C:/a/b.mjs` -> `C:/a/b.mjs`; anything else is returned as is.
 #[cfg(windows)]
 fn key_path_to_disk_path(key_path: &[u8]) -> &[u8] {
     match key_path.strip_prefix(b"/") {
@@ -1350,28 +1346,20 @@ fn key_path_to_disk_path(key_path: &[u8]) -> &[u8] {
     }
 }
 
-/// A fully qualified Windows path (`C:\a`, `C:/a`, `\\server\share\a`), as
-/// opposed to a path inside the bundle's output namespace (`/_bun/abc123.js`).
+/// Drive (`C:\a`, `C:/a`) or UNC (`\\server\share\a`) path, as opposed to a
+/// bundle output path like `/_bun/abc123.js`.
 #[cfg(windows)]
 fn is_disk_path(path: &[u8]) -> bool {
     resolve_path::windows_volume_name_len(path).0 > 0 && bun_paths::is_absolute(path)
 }
 
-/// A module key is `bake:` plus a posix-style absolute path: the output path for
-/// a bundled file (`bake:/_bun/abc123.js`), or the disk path for a file the
-/// bundler never saw (`import(join(import.meta.dir, "x.mjs"))` while rendering),
-/// which the fetch hook reads from disk after the key misses the module map.
-/// The posix join in [`BakeProdResolve`] cannot resolve against a Windows disk
-/// path, so when the referrer or the specifier is one, resolution happens here
-/// with Windows semantics and the result is spelled the way `file:` URLs spell
-/// it: `C:\a\b.mjs` is keyed `bake:/C:/a/b.mjs`, `\\server\share\b.mjs` is
-/// keyed `bake://server/share/b.mjs`. The module loader resolves the returned
-/// key once more (with `bake:/` as the referrer), so both spellings must come
-/// back out of this function unchanged. [`key_path_to_disk_path`] is the inverse.
-///
-/// `None` when neither side is a disk path. A result too long for a path buffer
-/// cannot name a file: that throws and returns a dead string, like the package
-/// path check in `BakeProdResolve`.
+/// Keys are posix-style paths (`bake:/_bun/abc123.js`), but a file imported from
+/// outside the bundle is keyed by its disk path, which the fetch hook reads from
+/// disk. A Windows disk path on either side is resolved here like
+/// `path.win32.resolve(dirname(referrer), specifier)` and spelled the way `file:`
+/// URLs spell it: `bake:/C:/a/b.mjs`, `bake://server/share/b.mjs`. The loader
+/// resolves the returned key once more (referrer `bake:/`), so both spellings
+/// have to come back out of here unchanged. `None` when neither side is on disk.
 #[cfg(windows)]
 fn resolve_disk_key(
     global: &JSGlobalObject,
@@ -1384,8 +1372,6 @@ fn resolve_disk_key(
         return None;
     }
 
-    // When only the specifier is on disk, `dir` is a bundle path; the join
-    // ignores it because the specifier brings its own volume and root.
     let dir = bun_paths::Dirname::dirname(referrer).unwrap_or(referrer);
     let mut buf = bun_paths::path_buffer_pool::get();
     let Some(resolved) = resolve_path::join_abs_string_buf_checked::<platform::Windows>(
@@ -1403,11 +1389,13 @@ fn resolve_disk_key(
     let resolved = &mut buf[..resolved_len];
     resolve_path::slashes_to_posix_in_place(resolved);
 
-    // A UNC path already starts with the separator that keeps the key under
-    // `bake:/`; a drive path needs one added.
-    let root = if resolved.starts_with(b"/") { "" } else { "/" };
+    let slash = if strings::starts_with_windows_drive_letter(resolved) {
+        "/"
+    } else {
+        ""
+    };
     Some(BunString::create_format(format_args!(
-        "bake:{root}{}",
+        "bake:{slash}{}",
         BStr::new(resolved)
     )))
 }

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -1318,21 +1318,98 @@ unsafe extern "C" {
     ) -> *mut JSPromise;
 }
 
+/// Called by `bakeModuleLoaderFetch` with the path of a key that missed the
+/// module map, before handing it to the regular module loader to read from
+/// disk. Undoes the key spelling described on `resolve_disk_key`. The result
+/// has to be a plain Win32 path: the loader cuts a specifier at the first `?`
+/// (query string), so a `\\?\` prefixed one would be read as `\\`.
 #[unsafe(no_mangle)]
 extern "C" fn BakeToWindowsPath(input: BunString) -> BunString {
-    #[cfg(unix)]
+    #[cfg(not(windows))]
     {
         let _ = input;
         panic!("This code should not be called on POSIX systems.");
     }
-    #[cfg(not(unix))]
+    #[cfg(windows)]
     {
         let input_utf8 = input.to_utf8();
-        let input_slice = input_utf8.slice();
-        let mut output = bun_paths::w_path_buffer_pool::get();
-        let output_slice = strings::to_w_path_normalize_auto_extend(&mut output[..], input_slice);
-        BunString::clone_utf16(output_slice.as_slice())
+        let mut path = key_path_to_disk_path(input_utf8.slice()).to_vec();
+        resolve_path::slashes_to_windows_in_place(&mut path);
+        BunString::clone_utf8(&path)
     }
+}
+
+/// `/C:/a/b.mjs` -> `C:/a/b.mjs`. UNC keys (`//server/share/b.mjs`) already are
+/// Windows paths and bundle output keys (`/_bun/abc123.js`) have no volume, so
+/// both come back unchanged.
+#[cfg(windows)]
+fn key_path_to_disk_path(key_path: &[u8]) -> &[u8] {
+    match key_path.strip_prefix(b"/") {
+        Some(rest) if strings::starts_with_windows_drive_letter(rest) => rest,
+        _ => key_path,
+    }
+}
+
+/// A fully qualified Windows path (`C:\a`, `C:/a`, `\\server\share\a`), as
+/// opposed to a path inside the bundle's output namespace (`/_bun/abc123.js`).
+#[cfg(windows)]
+fn is_disk_path(path: &[u8]) -> bool {
+    resolve_path::windows_volume_name_len(path).0 > 0 && bun_paths::is_absolute(path)
+}
+
+/// A module key is `bake:` plus a posix-style absolute path: the output path for
+/// a bundled file (`bake:/_bun/abc123.js`), or the disk path for a file the
+/// bundler never saw (`import(join(import.meta.dir, "x.mjs"))` while rendering),
+/// which the fetch hook reads from disk after the key misses the module map.
+/// The posix join in [`BakeProdResolve`] cannot resolve against a Windows disk
+/// path, so when the referrer or the specifier is one, resolution happens here
+/// with Windows semantics and the result is spelled the way `file:` URLs spell
+/// it: `C:\a\b.mjs` is keyed `bake:/C:/a/b.mjs`, `\\server\share\b.mjs` is
+/// keyed `bake://server/share/b.mjs`. The module loader resolves the returned
+/// key once more (with `bake:/` as the referrer), so both spellings must come
+/// back out of this function unchanged. [`key_path_to_disk_path`] is the inverse.
+///
+/// `None` when neither side is a disk path. A result too long for a path buffer
+/// cannot name a file: that throws and returns a dead string, like the package
+/// path check in `BakeProdResolve`.
+#[cfg(windows)]
+fn resolve_disk_key(
+    global: &JSGlobalObject,
+    referrer_key_path: &[u8],
+    specifier: &[u8],
+) -> Option<BunString> {
+    let referrer = key_path_to_disk_path(referrer_key_path);
+    let specifier = key_path_to_disk_path(specifier);
+    if !is_disk_path(referrer) && !is_disk_path(specifier) {
+        return None;
+    }
+
+    // When only the specifier is on disk, `dir` is a bundle path; the join
+    // ignores it because the specifier brings its own volume and root.
+    let dir = bun_paths::Dirname::dirname(referrer).unwrap_or(referrer);
+    let mut buf = bun_paths::path_buffer_pool::get();
+    let Some(resolved) = resolve_path::join_abs_string_buf_checked::<platform::Windows>(
+        dir,
+        &mut buf[..],
+        &[specifier],
+    ) else {
+        let _ = global.throw(format_args!(
+            "Cannot import {}: the resolved path is too long",
+            bun_core::fmt::quote(specifier),
+        ));
+        return Some(BunString::dead());
+    };
+    let resolved_len = resolved.len();
+    let resolved = &mut buf[..resolved_len];
+    resolve_path::slashes_to_posix_in_place(resolved);
+
+    // A UNC path already starts with the separator that keeps the key under
+    // `bake:/`; a drive path needs one added.
+    let root = if resolved.starts_with(b"/") { "" } else { "/" };
+    Some(BunString::create_format(format_args!(
+        "bake:{root}{}",
+        BStr::new(resolved)
+    )))
 }
 
 #[unsafe(no_mangle)]
@@ -1363,10 +1440,15 @@ extern "C" fn BakeProdResolve(
     }
 
     debug_assert!(strings::has_prefix(referrer.slice(), b"bake:"));
+    let referrer_key_path = &referrer.slice()[5..];
+
+    #[cfg(windows)]
+    if let Some(key) = resolve_disk_key(global, referrer_key_path, specifier.slice()) {
+        return key;
+    }
 
     // dirname semantics: returns None for the root / no-parent.
-    let after_scheme = &referrer.slice()[5..];
-    let dir = bun_paths::Dirname::dirname(after_scheme).unwrap_or(after_scheme);
+    let dir = bun_paths::Dirname::dirname(referrer_key_path).unwrap_or(referrer_key_path);
 
     BunString::create_format(format_args!(
         "bake:{}",

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -1318,9 +1318,8 @@ unsafe extern "C" {
     ) -> *mut JSPromise;
 }
 
-/// Inverse of the key spelling in `resolve_disk_key`, for the fetch hook to read
-/// the file. Must stay a plain Win32 path: the module loader cuts specifiers at
-/// the first `?`, so a `\\?\` prefixed one was read as `\\`.
+/// Inverse of `resolve_disk_key`'s key spelling. Never a `\\?\` path: the module
+/// loader cuts specifiers at the first `?`, which is how this used to read `\\`.
 #[unsafe(no_mangle)]
 extern "C" fn BakeToWindowsPath(input: BunString) -> BunString {
     #[cfg(not(windows))]
@@ -1346,20 +1345,16 @@ fn key_path_to_disk_path(key_path: &[u8]) -> &[u8] {
     }
 }
 
-/// Drive (`C:\a`, `C:/a`) or UNC (`\\server\share\a`) path, as opposed to a
-/// bundle output path like `/_bun/abc123.js`.
+/// Drive or UNC path, as opposed to a bundle output path like `/_bun/abc123.js`.
 #[cfg(windows)]
 fn is_disk_path(path: &[u8]) -> bool {
     resolve_path::windows_volume_name_len(path).0 > 0 && bun_paths::is_absolute(path)
 }
 
-/// Keys are posix-style paths (`bake:/_bun/abc123.js`), but a file imported from
-/// outside the bundle is keyed by its disk path, which the fetch hook reads from
-/// disk. A Windows disk path on either side is resolved here like
-/// `path.win32.resolve(dirname(referrer), specifier)` and spelled the way `file:`
-/// URLs spell it: `bake:/C:/a/b.mjs`, `bake://server/share/b.mjs`. The loader
-/// resolves the returned key once more (referrer `bake:/`), so both spellings
-/// have to come back out of here unchanged. `None` when neither side is on disk.
+/// A file outside the bundle is keyed by its disk path, spelled like a `file:`
+/// URL path: `bake:/C:/a/b.mjs`, `bake://server/share/b.mjs`. The loader resolves
+/// the returned key once more (referrer `bake:/`), so both spellings must come
+/// back out of here unchanged. `None` when neither side is a disk path.
 #[cfg(windows)]
 fn resolve_disk_key(
     global: &JSGlobalObject,

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -603,11 +603,11 @@ export default function IndexPage() {
     // build failed with `EINVAL reading "\\"`.
     const dir = await tempDirWithBakeDeps("bake-production-disk-import", {
       "src/index.tsx": `export default { app: { framework: "react" } };`,
-      "extra/banner.mjs": `import { detail } from "./detail.mjs";
+      "extra/banner.mjs": `import { detail } from "../shared/detail.mjs";
 
 export const banner = "read from disk while rendering";
 export { detail };`,
-      "extra/detail.mjs": `export const detail = "resolved relative to the file on disk";`,
+      "shared/detail.mjs": `export const detail = "resolved relative to the file on disk";`,
       "pages/index.tsx": `import { join } from "node:path";
 
 export default async function IndexPage() {
@@ -630,7 +630,7 @@ export default async function IndexPage() {
       cmd: [bunExe(), "build", "--app", "./src/index.tsx"],
       cwd: dir,
       env: bunEnv,
-      stdout: "pipe",
+      stdout: "ignore",
       stderr: "pipe",
     });
     const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -594,4 +594,52 @@ export default function IndexPage() {
     // Verify NO JavaScript imports are included in the HTML
     expect(htmlContent).not.toContain('<script type="module"');
   });
+
+  test("a route can import a file outside the bundle while rendering", async () => {
+    // import() of a path the bundler never saw is keyed under "bake:" like the bundled
+    // modules, misses the module map, and is read from disk by the regular loader. On
+    // Windows the specifier is a drive path (import.meta.dir is inlined as one), which
+    // used to be joined onto the referrer's bundle path as if it were relative, and the
+    // build failed with `EINVAL reading "\\"`.
+    const dir = await tempDirWithBakeDeps("bake-production-disk-import", {
+      "src/index.tsx": `export default { app: { framework: "react" } };`,
+      "extra/banner.mjs": `import { detail } from "./detail.mjs";
+
+export const banner = "read from disk while rendering";
+export { detail };`,
+      "extra/detail.mjs": `export const detail = "resolved relative to the file on disk";`,
+      "pages/index.tsx": `import { join } from "node:path";
+
+export default async function IndexPage() {
+  // Computed specifiers, so the bundler leaves these import()s to the runtime.
+  // The first is a normalized native path; the second still has the ".." in it
+  // and, on Windows, mixes separators. Both must name the same module.
+  const joined = await import(join(import.meta.dir, "..", "extra", "banner.mjs"));
+  const unnormalized = await import([import.meta.dir, "..", "extra", "banner.mjs"].join("/"));
+  return (
+    <ul>
+      <li>{joined.banner}</li>
+      <li>{joined.detail}</li>
+      <li>{joined === unnormalized ? "one module instance" : "two module instances"}</li>
+    </ul>
+  );
+}`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--app", "./src/index.tsx"],
+      cwd: dir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
+
+    const html = await Bun.file(path.join(dir, "dist", "index.html")).text();
+    expect(html).toContain("<li>read from disk while rendering</li>");
+    expect(html).toContain("<li>resolved relative to the file on disk</li>");
+    expect(html).toContain("<li>one module instance</li>");
+  });
 });


### PR DESCRIPTION
### Problem
- On Windows, `bun build --app` fails to prerender a route that loads a file the bundler did not see, such as `await import(join(import.meta.dir, "../extra/banner.mjs"))` inside a page component. The build prints `error: EINVAL reading "\\"` followed by `Route "pages\index.tsx" cannot be pre-rendered to a static page.` and exits 1. The same project builds on Linux and macOS. Reproduced with the current canary on Windows Server 2019.
- `import.meta.dir` is inlined as the source file's directory, so on Windows the specifier is a drive path (`C:\app\extra\banner.mjs`). `BakeProdResolve` (src/runtime/bake/production.rs) turns every specifier into a key with `join_abs::<Posix>(dirname(referrer key), specifier)`; a drive path is not posix-absolute, so it is appended under the referrer's bundle directory: `bake:/_bun/C:/app/extra/banner.mjs`.
- That key misses the module map, so `bakeModuleLoaderFetch` (src/runtime/bake/BakeGlobalObject.cpp) strips `bake:` and calls `BakeToWindowsPath` (production.rs), which used `to_w_path_normalize_auto_extend` and returned an extended-length path, `\\?\_bun\C:\app\...`. The regular loader cuts a specifier at its first `?` as a query string (`normalize_specifier_for_loader` in src/runtime/jsc_hooks.rs), so the file it tried to read was `\\`. Because of this second defect, fixing the key alone would still have failed.
- Both functions date from the commit that added this escape hatch (#20998) and were carried over unchanged by the Rust port; the hatch has never worked on Windows.

### Fix
- `BakeProdResolve` now resolves with Windows path semantics whenever the referrer's key or the specifier is a disk path (drive-qualified or UNC), using the same `join_abs` the rest of the runtime uses for `path.resolve`, and spells the result into the key namespace the way `file:` URLs do: `C:\app\extra\banner.mjs` becomes `bake:/C:/app/extra/banner.mjs`, `\\server\share\x.mjs` becomes `bake://server/share/x.mjs`. Bundled modules (`bake:/_bun/...`) take the unchanged posix join, and non-Windows builds are unchanged apart from a renamed local (the new code is `#[cfg(windows)]`).
- `BakeToWindowsPath` now inverts that spelling (`/C:/app/...` -> `C:\app\...`, `//server/share/...` -> `\\server\share\...`) and returns a plain Win32 path, which is what the loader can read.
- Why this shape is correct:
  - The module loader resolves the key returned for an `import()` a second time (referrer `bake:/`, specifier = the key's path), so the key spelling must be a fixed point of `BakeProdResolve`. `/C:/...` decodes to a disk path and resolves back to itself; `//server/share/...` is already a UNC path and does the same; bundle paths have no volume and keep taking the posix join. The debug log in the details below shows the keys that come out.
  - Static imports inside the file loaded from disk arrive with its `bake:/C:/...` key as the referrer. Decoding the referrer before taking `dirname` keeps them on disk as well (`./detail.mjs`, `../extra2/sibling.mjs` in the test and log below); with the posix join they would only have worked by accident for drive paths and not at all for UNC.
  - Every key stays under `bake:/`, which is the prefix all three loader hooks dispatch on.
  - A specifier whose resolved form does not fit a path buffer cannot name a file; that throws, in the same way the existing non-relative import check in `BakeProdResolve` does, rather than indexing out of the buffer.
- Verified with the new test in test/bake/dev/production.test.ts ("a route can import a file outside the bundle while rendering"). It builds a page that imports the same out-of-bundle file by a `path.join` specifier and by an unnormalized one (`..` segment, mixed separators on Windows), where that file has a relative import of its own, and checks the rendered HTML shows both exports and that the two `import()`s returned one module instance.
  - Windows x64, current canary: fails with the `EINVAL reading "\\"` output above. Windows x64, debug build of this branch: passes, and the whole file passes (10 tests).
  - Linux (debug, ASAN): the whole file passes with `--timeout 120000` (every full-build test in this file needs more than the 5s local default on a debug build here; CI passes its own timeout). The new test also passes on Linux without the fix: posix disk paths were never affected, so the failing-before evidence for this change is the Windows run, and the CI Windows lanes are what exercise it.
- #38949 skips an equivalent test on Windows and points at this bug; once both land that skip can be removed. #38960 changes how BakeGlobalObject.cpp consumes the strings these functions return; `BakeToWindowsPath` still returns an owned `WTFStringImpl` (`clone_utf8` instead of `clone_utf16`), so that change stays correct on top of this one. Neither touches this hunk of production.rs.

### Background
- `bun build --app` bundles the app's server code into chunks, then prerenders the static routes in a dedicated JS global (`Bake::GlobalObject`, created by `BakeCreateProdGlobal`) whose module loader hooks serve the chunks from memory. Module keys are `bake:` plus a posix-style absolute path; a chunk written to `dist/_bun/abc.js` is the module `bake:/_bun/abc.js`, and imports between chunks are resolved by joining the relative specifier onto the referrer's key.
- The escape hatch: when a key is not in the module map, `bakeModuleLoaderFetch` strips `bake:` and hands the remainder to the regular module loader, which reads it from disk. That is how a route can load a file at render time that the bundler did not see. On POSIX the remainder is already the disk path. `BakeToWindowsPath` exists to convert the remainder into a Windows path before the loader sees it.
- `join_abs` in bun_paths is `path.resolve` parameterized by platform. The Windows variant understands drive letters and UNC volumes (`\\server\share`); the posix variant only treats a leading `/` as absolute, which is what the key namespace needs for bundle paths.
- `\\?\` is the Win32 extended-length path prefix; it is meant for direct file system calls, never for module specifiers, which the loader parses for `?query` suffixes like `?raw`.

<details>
<summary>Keys produced by the debug build on Windows (BUN_DEBUG_production=1), fixture with a drive path, an unnormalized spelling, a lowercase drive letter, and UNC spellings through the C$ admin share</summary>

`pages/index.tsx` imports `extra/banner.mjs` via `join(import.meta.dir, "..", "extra", "banner.mjs")`, via `[import.meta.dir, "..", "extra", "banner.mjs"].join("/")` and via the lowercased join; `pages/unc.tsx` imports it via `\\localhost\C$\tmp\bakefix\extra\banner.mjs` and via `//localhost/C$/tmp/bakefix/extra/../extra/banner.mjs`. `banner.mjs` itself imports `./detail.mjs` and `../extra2/sibling.mjs`.

```
[production] BakeProdLoad: bake:/C:/tmp/bakefix/extra/banner.mjs
[production] BakeProdLoad: bake://localhost/C$/tmp/bakefix/extra/banner.mjs
[production] BakeProdLoad: bake:/C:/tmp/bakefix/extra/detail.mjs
[production] BakeProdLoad: bake:/C:/tmp/bakefix/extra2/sibling.mjs
[production] BakeProdLoad: bake://localhost/C$/tmp/bakefix/extra/detail.mjs
[production] BakeProdLoad: bake://localhost/C$/tmp/bakefix/extra2/sibling.mjs
```

Rendered output (`a === b` and `a === c` are the unnormalized and lowercase spellings; `unc === uncFwd` the two UNC spellings):

```
dist/index.html:     <p>banner from disk | detail from disk | sibling via .. | true | true | C:\tmp\bakefix\pages</p>
dist/unc/index.html: <p>banner from disk | detail from disk | sibling via .. | true</p>
```

The UNC case is not in the committed test because it depends on the administrative share being reachable on the runner.
</details>
