### PR TITLE
ws: send an empty ping/pong frame for a falsy payload

### DIFF
--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -669,9 +669,11 @@ class BunWebSocket extends EventEmitter {
 
     if (typeof data === "number") data = data.toString();
 
-    // npm ws has no try/catch here: Sender.prototype.ping throws RangeError
+    // Like npm ws's `data || EMPTY_BUFFER`: null/false/"" send an empty frame
+    // (the native USVString overload would stringify them to "null"/"false").
+    // No try/catch, as in npm ws: Sender.prototype.ping throws RangeError
     // synchronously for a >125-byte payload and never reaches cb.
-    if (data === undefined) this.#ws.ping();
+    if (!data) this.#ws.ping();
     else this.#ws.ping(data);
 
     if (typeof cb === "function") cb();
@@ -695,7 +697,7 @@ class BunWebSocket extends EventEmitter {
 
     if (typeof data === "number") data = data.toString();
 
-    if (data === undefined) this.#ws.pong();
+    if (!data) this.#ws.pong();
     else this.#ws.pong(data);
 
     if (typeof cb === "function") cb();
@@ -1090,7 +1092,8 @@ class BunWebSocketMocked extends EventEmitter {
 
     if (typeof data === "number") data = data.toString();
 
-    if (data === undefined) this.#ws.ping();
+    // npm ws sends `data || EMPTY_BUFFER`; ServerWebSocket.ping(false) would throw.
+    if (!data) this.#ws.ping();
     else this.#ws.ping(data);
 
     if (typeof cb === "function") cb();
@@ -1114,7 +1117,7 @@ class BunWebSocketMocked extends EventEmitter {
 
     if (typeof data === "number") data = data.toString();
 
-    if (data === undefined) this.#ws.pong();
+    if (!data) this.#ws.pong();
     else this.#ws.pong(data);
 
     if (typeof cb === "function") cb();

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -911,6 +911,76 @@ describe("ping/pong no-arg payload", () => {
   });
 });
 
+// npm ws sends `data || EMPTY_BUFFER`: a falsy payload (null, false, "") goes out as an
+// empty control frame, not as the string "null"/"false". A number is stringified before
+// that check, so 0 is sent as "0".
+describe("ping/pong falsy payload", () => {
+  // Sends one ping(data) and one pong(data) from `sender` and returns the payloads the
+  // other side received. The receiving side never pings, so no auto-pong gets mixed in.
+  async function payloadsReceivedFrom(sender: "client" | "server", data: unknown) {
+    const wss = new WebSocketServer({ port: 0 });
+    const { promise, resolve, reject } = Promise.withResolvers<{ ping: string; pong: string }>();
+    const received: { ping?: string; pong?: string } = {};
+    const record = (kind: "ping" | "pong") => (payload: Buffer) => {
+      received[kind] ??= payload.toString();
+      if (received.ping !== undefined && received.pong !== undefined) {
+        resolve({ ping: received.ping, pong: received.pong });
+      }
+    };
+    const sendBoth = (ws: WebSocket) => {
+      try {
+        ws.ping(data as never);
+        ws.pong(data as never);
+      } catch (e) {
+        reject(e);
+      }
+    };
+
+    if (sender === "client") {
+      wss.on("connection", serverWs => {
+        serverWs.on("ping", record("ping"));
+        serverWs.on("pong", record("pong"));
+      });
+    } else {
+      wss.on("connection", sendBoth);
+    }
+
+    const client = new WebSocket("ws://localhost:" + (wss.address() as AddressInfo).port);
+    client.on("error", reject);
+    if (sender === "client") {
+      client.on("open", () => sendBoth(client));
+    } else {
+      client.on("ping", record("ping"));
+      client.on("pong", record("pong"));
+    }
+
+    try {
+      return await promise;
+    } finally {
+      client.terminate();
+      wss.close();
+    }
+  }
+
+  const cases: [label: string, data: unknown, wire: string][] = [
+    ["null", null, ""],
+    ["undefined", undefined, ""],
+    ["false", false, ""],
+    ['""', "", ""],
+    ["0", 0, "0"],
+  ];
+
+  for (const [label, data, wire] of cases) {
+    it(`client ws.ping(${label}) / ws.pong(${label}) put ${JSON.stringify(wire)} on the wire`, async () => {
+      expect(await payloadsReceivedFrom("client", data)).toEqual({ ping: wire, pong: wire });
+    });
+
+    it(`server ws.ping(${label}) / ws.pong(${label}) put ${JSON.stringify(wire)} on the wire`, async () => {
+      expect(await payloadsReceivedFrom("server", data)).toEqual({ ping: wire, pong: wire });
+    });
+  }
+});
+
 describe("handleUpgrade without an Upgrade header", () => {
   it("responds with 400 Invalid Upgrade header instead of throwing", () => {
     const wss = new WebSocketServer({ noServer: true });


### PR DESCRIPTION
### Problem
- A `require("ws")` client calling `ws.ping(null)` or `ws.pong(null)` puts a 4-byte control frame with the payload `null` on the wire. npm ws sends an empty frame.
- `ws.ping(false)` / `ws.pong(false)` on the client sends the string `false`; the same call on a server-side socket (`wss.on("connection", ws => ws.ping(false))`) throws `ping requires a string, Blob, or BufferSource`. npm ws sends an empty frame in both cases.
- Cause: the four `ping()`/`pong()` methods in `src/js/thirdparty/ws.js` (client class at ~L669-L700, server class at ~L1092-L1120) only special-case `data === undefined`. Every other value is passed through: the client half hands it to the native `WebSocket`, whose USVString overload stringifies `null`/`false`; the server half hands `false` to `ServerWebSocket.ping()` (`src/runtime/server/ServerWebSocket.rs` `send_ping`), which rejects non-string/non-buffer values.
- npm ws's `WebSocket.prototype.ping`/`pong` do `if (typeof data === "number") data = data.toString();` and then `this._sender.ping(data || EMPTY_BUFFER, ...)`, so any falsy payload is an empty frame, while a number is stringified first (`ping(0)` sends `"0"`).

### Fix
- Replace `data === undefined` with `!data` in all four shim methods, after the existing number-to-string step. This is the same check npm ws applies at the same point, so the shim now agrees with npm ws for every input: `null`, `undefined`, `false` and `""` send an empty frame, `0` still sends `"0"`, strings and buffers are unchanged.
- Matches npm ws 8.18.3 under node (checked every value in the table below from both the client and the server side), and makes the client and server halves of the shim agree with each other (the server half already sent an empty frame for `null` because `ServerWebSocket.ping()` treats `null`/`undefined` as no payload).
- The `>125 bytes` RangeError path is unaffected: an oversized payload is truthy and still goes to the native method.
- Tests: `test/js/first_party/ws/ws.test.ts`, new `describe("ping/pong falsy payload")`. It sends one `ping(x)` and one `pong(x)` from the client and, separately, from a server-side socket, and asserts the payload the peer received, for `x` in `null`, `undefined`, `false`, `""`, `0`.
  - Without the fix 3 of the 10 cases fail: client `null` (receives `"null"`), client `false` (receives `"false"`), server `false` (throws). The other 7 pin the behavior that must not change.
  - `bun bd test test/js/first_party/ws/ws.test.ts`: 57 pass.
  - `bun bd test test/js/web/websocket/websocket-client.test.ts -t "ping|pong|payload"`: 19 pass (includes the two `require('ws')` oversized-payload and send-after-close tests).

### Background
- `require("ws")` in Bun does not load the npm package. It resolves to the built-in shim `src/js/thirdparty/ws.js`, which has two classes: `BunWebSocket` wraps the native client `WebSocket` (the one `new WebSocket(url)` gives you), and `BunWebSocketMocked` wraps the `ServerWebSocket` that `Bun.serve` hands to its `websocket` handlers. `WebSocketServer` from the shim creates the latter.
- Control frames: ping and pong are WebSocket control frames that carry an optional payload of up to 125 bytes. "Empty frame" in this PR means a ping/pong whose payload length is 0.
- USVString overload: the native client's `ping(data)` is WebIDL-generated (`jsWebSocketPrototypeFunction_pingOverloadDispatcher` in `src/jsc/bindings/webcore/JSWebSocket.cpp`). Zero arguments selects the overload that sends an empty frame, which is why the shim calls `this.#ws.ping()` with no arguments for the empty case. With one argument, ArrayBuffer, ArrayBufferView and Blob get their own overloads and anything else falls into the string overload, where WebIDL string conversion turns `null` into `"null"` and `false` into `"false"`.

<details>
<summary>Wire payloads per input, before the fix vs npm ws</summary>

Receiving side is the other half of the same library in each column (Bun shim receiving from Bun shim; npm ws receiving from npm ws under node 26).

| `ping(x)` / `pong(x)` | Bun client half (before) | Bun server half (before) | npm ws 8.18.3 (client and server) |
| --- | --- | --- | --- |
| `null` | `"null"` | empty | empty |
| `undefined` | empty | empty | empty |
| `false` | `"false"` | throws | empty |
| `""` | empty | empty | empty |
| `0` | `"0"` | `"0"` | `"0"` |
| `"hi"` | `"hi"` | `"hi"` | `"hi"` |
| `Buffer.from("buf")` | `"buf"` | `"buf"` | `"buf"` |

After the fix both Bun columns match the npm ws column.

</details>
