### PR TITLE
JSValue::from_entries: check the key/value lengths in release builds too

### DIFF
--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -683,15 +683,25 @@ impl JSValue {
     /// `JSValue.fromEntries` — build a plain object from
     /// parallel `keys`/`values` `ZigString` arrays. When `clone` is true the
     /// C++ side copies the string bytes (caller may free `keys`/`values`).
+    ///
+    /// # Panics
+    /// If the two slices differ in length. The binding is only told
+    /// `keys.len()` and reads that many entries from both arrays, so a shorter
+    /// `values` would be read out of bounds.
     pub fn from_entries(
         global: &JSGlobalObject,
         keys: &mut [bun_core::ZigString],
         values: &mut [bun_core::ZigString],
         clone: bool,
     ) -> JSValue {
-        debug_assert_eq!(keys.len(), values.len());
-        // SAFETY: `global` is live; `keys`/`values` are valid for `keys.len()`
-        // elements; the C++ binding only reads (and optionally clones) them.
+        assert!(
+            keys.len() == values.len(),
+            "from_entries: keys.len() ({}) != values.len() ({})",
+            keys.len(),
+            values.len(),
+        );
+        // SAFETY: `global` is live; both slices hold `keys.len()` elements
+        // (asserted above); the C++ binding only reads (and optionally clones) them.
         unsafe {
             JSC__JSValue__fromEntries(
                 global,
@@ -2965,4 +2975,38 @@ unsafe extern "C" {
         other: JSValue,
     ) -> bool;
     safe fn JSC__JSValue__toMatch(this: JSValue, global: &JSGlobalObject, other: JSValue) -> bool;
+}
+
+// Run by test/internal/jsvalue-from-entries-length.test.ts under
+// `cargo miri test` with debug assertions disabled: reaching
+// `JSC__JSValue__fromEntries` fails the test there, so a length mismatch has
+// to be rejected before the call in a release build too. Equal lengths reach
+// C++ and are covered by the `FileSystemRouter#routes` tests in
+// test/js/bun/util/filesystem_router.test.ts.
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bun_core::ZigString;
+
+    // `from_entries` must panic before it touches the global, so a dangling
+    // pointer to the zero-sized handle is all these tests need.
+    fn unused_global() -> &'static JSGlobalObject {
+        JSGlobalObject::opaque_ref(core::ptr::NonNull::<JSGlobalObject>::dangling().as_ptr())
+    }
+
+    #[test]
+    #[should_panic(expected = "from_entries: keys.len() (2) != values.len() (1)")]
+    fn from_entries_panics_when_values_is_shorter_than_keys() {
+        let mut keys = [ZigString::static_("a"), ZigString::static_("b")];
+        let mut values = [ZigString::static_("1")];
+        JSValue::from_entries(unused_global(), &mut keys, &mut values, true);
+    }
+
+    #[test]
+    #[should_panic(expected = "from_entries: keys.len() (1) != values.len() (2)")]
+    fn from_entries_panics_when_keys_is_shorter_than_values() {
+        let mut keys = [ZigString::static_("a")];
+        let mut values = [ZigString::static_("1"), ZigString::static_("2")];
+        JSValue::from_entries(unused_global(), &mut keys, &mut values, false);
+    }
 }

--- a/test/internal/jsvalue-from-entries-length.test.ts
+++ b/test/internal/jsvalue-from-entries-length.test.ts
@@ -1,0 +1,91 @@
+/**
+ * `JSValue::from_entries` (src/jsc/JSValue.rs) is a safe fn that hands
+ * `JSC__JSValue__fromEntries` the two `ZigString` slices as bare pointers plus
+ * a single count, `keys.len()`, and C++ reads that many entries from BOTH
+ * arrays. The length check in the wrapper is all that keeps a shorter `values`
+ * slice from being read past its end. It used to be a `debug_assert`, which
+ * release builds compile out. The only caller (`FileSystemRouter#routes`)
+ * fills both halves of one Vec, so no JS API reaches the mismatch; the
+ * contract is pinned by `#[should_panic]` unit tests next to the function.
+ *
+ * Those unit tests are run with debug assertions disabled
+ * (`CARGO_PROFILE_TEST_DEBUG_ASSERTIONS=false`), i.e. in the configuration
+ * shipped builds use, where only a release-mode check can make them pass.
+ * bun_jsc's test binary references C++ symbols that only exist in the full bun
+ * link, so plain `cargo test` cannot link it; `cargo miri test` interprets it
+ * instead, and without the check it stops each test at the foreign call the
+ * mismatched slices were about to be passed to. This test requires both unit
+ * tests to have run and passed, so deleting them fails it too.
+ *
+ * bun_jsc is not in scripts/rust-miri.ts's crate list: its build script needs
+ * the codegen output of a `bun bd`, which that lane does not produce, and the
+ * default profile there has debug assertions on, which is not the
+ * configuration this contract is about. Skipped where miri is not installed or
+ * the cargo workspace is not resolvable (test-only CI lanes run a prebuilt
+ * binary; same prerequisite check as linear-fifo.test.ts).
+ */
+import { expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+const cargoBin = Bun.which("cargo");
+const repoRoot = path.resolve(import.meta.dir, "..", "..");
+const codegenDir = path.join(repoRoot, "build", "debug", "codegen");
+const workspaceResolvable =
+  existsSync(path.join(repoRoot, "vendor", "lolhtml", "Cargo.toml")) &&
+  existsSync(path.join(codegenDir, "build_options.rs")) &&
+  // src/jsc/build.rs additionally include!()s this.
+  existsSync(path.join(codegenDir, "cpp.rs"));
+const miriAvailable =
+  !!cargoBin &&
+  workspaceResolvable &&
+  Bun.spawnSync({
+    cmd: [cargoBin, "miri", "--version"],
+    cwd: repoRoot,
+    stdout: "ignore",
+    stderr: "ignore",
+    timeout: 30_000,
+  }).exitCode === 0;
+
+// One test per direction of the mismatch, each asserting on the panic message
+// with both lengths in it.
+const expectedResults = {
+  "js_value::tests::from_entries_panics_when_values_is_shorter_than_keys": "ok",
+  "js_value::tests::from_entries_panics_when_keys_is_shorter_than_values": "ok",
+};
+
+test.skipIf(!miriAvailable)(
+  "JSValue::from_entries rejects mismatched key/value lengths with debug assertions disabled",
+  async () => {
+    await using proc = Bun.spawn({
+      // `--lib`: rustdoc does not get the profile's debug-assertions setting,
+      // so the doctest pass would not compile against the deps built below.
+      cmd: [cargoBin!, "miri", "test", "--locked", "--lib", "-p", "bun_jsc", "--", "js_value::tests::from_entries"],
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        CARGO_PROFILE_TEST_DEBUG_ASSERTIONS: "false",
+        // One-shot build of ~60 crates: incremental state would be several
+        // times the size of the artifacts themselves and never reused.
+        CARGO_INCREMENTAL: "0",
+        MIRIFLAGS: "-Zmiri-tree-borrows",
+        CARGO_TERM_COLOR: "never",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    if (exitCode !== 0) {
+      // Miri's diagnostic names the foreign call that was reached.
+      console.error(stderr);
+    }
+
+    // libtest prints one line per test: `test <name>[ - should panic] ... ok`.
+    const results: Record<string, string> = {};
+    for (const [, name, status] of stdout.matchAll(/^test (\S+)(?: - should panic)? \.\.\. (\w+)$/gm)) {
+      if (name in expectedResults) results[name] = status;
+    }
+    expect({ results, exitCode }).toEqual({ results: expectedResults, exitCode: 0 });
+  },
+  300_000,
+);


### PR DESCRIPTION
### Problem
- `JSValue::from_entries` (src/jsc/JSValue.rs:691) is a safe `pub fn` taking `keys: &mut [ZigString]` and `values: &mut [ZigString]`. It passes a single count, `keys.len()`, to `JSC__JSValue__fromEntries`, and the C++ side (src/jsc/bindings/bindings.cpp:3359) reads `keys[i]` and `values[i]` for every `i < count`.
- The only guard was `debug_assert_eq!(keys.len(), values.len())`. Release builds compile that out (scripts/build/rust.ts only turns debug assertions on for debug and ASAN builds), so in a shipped binary a safe caller passing a shorter `values` makes C++ read past the end of the slice.
- Latent, not a live crash: the one caller, `FileSystemRouter#routes` (src/runtime/api/filesystem_router.rs:675), splits a single `Vec` of `2 * names.len()` entries into two equal halves. Found while reviewing safe FFI wrappers (same shape as the simdutf base64 wrapper in #38932).

### Fix
- Replace the `debug_assert_eq!` with an `assert!` whose message carries both lengths, and document the panic on the function.
- Why this is right: the check is what makes the safe signature sound, so it has to exist in every build the function ships in. The same crate already applies this rule to the same kind of precondition (`bun_opaque::opaque_deref` asserts non-null in release for exactly this reason). The cost is one integer compare on a getter that builds a JS object per route, and continuing past a mismatch is an out-of-bounds read, so a panic is the right outcome (REVIEW.md: debug assertions compile out; new checks are release-mode when continuing would corrupt memory). Taking `min` of the two lengths would instead silently drop entries on a caller bug; a slice of pairs would not match the two-array C ABI without an extra copy.
- No JS-reachable behavior changes: the caller always passes equal lengths. test/js/bun/util/filesystem_router.test.ts still passes (33 tests) against the debug build with this change.
- Tests:
  - Two `#[should_panic]` unit tests next to the function (`js_value::tests::from_entries_panics_when_*`), one per direction of the mismatch, each asserting on the message with both lengths.
  - test/internal/jsvalue-from-entries-length.test.ts runs them with `cargo miri test --lib -p bun_jsc` and `CARGO_PROFILE_TEST_DEBUG_ASSERTIONS=false`, and requires both to have passed. bun_jsc's test binary cannot be linked (it references C++ symbols that only exist in the full bun link), so Miri interprets it instead; with debug assertions disabled and the old `debug_assert_eq!`, both tests reach the foreign call and Miri stops them there (output below). `--lib` because rustdoc does not receive the profile override, so the doctest pass would not compile against the dependencies built with it. It skips where miri or the cargo workspace is unavailable, like test/internal/linear-fifo.test.ts, so it runs locally and in the gate rather than on the prebuilt-binary CI lanes.
- Verified: `bun bd test test/internal/jsvalue-from-entries-length.test.ts` passes with the change and fails with `src/` stashed (the unit tests are absent, so the required results are missing); with the unit tests kept but the wrapper reverted to `debug_assert_eq!`, the same command fails at the foreign call; `cargo clippy -p bun_jsc --tests` and rustfmt are clean.

### Background
- `ZigString` is a `#[repr(C)]` pointer + length pair shared with C++; `from_entries` builds a plain JS object from two parallel arrays of them, one array of property names and one of values, with a single element count for both, which is why the Rust wrapper has to establish that the arrays are the same length.
- `debug_assert!` is a check that only exists when the `debug_assertions` cfg is on. Cargo turns it on for the `dev` profile (what `bun bd` builds) and off for `release`; bun's build additionally turns it on for ASAN builds. Shipped bun binaries have it off.
- Miri is the Rust interpreter that ships with the toolchain (`cargo miri test`). It runs a crate's tests without linking them, and aborts a test that calls a foreign (C/C++) function it has no shim for. That is what lets a crate whose tests cannot be linked still pin down "panics before the FFI call".
- `CARGO_PROFILE_TEST_DEBUG_ASSERTIONS=false` is cargo's environment override for the `debug-assertions` setting of the profile `cargo test` uses, so the unit tests are compiled the way release code is as far as this check is concerned.

<details>
<summary>Miri output with the wrapper reverted to debug_assert_eq! and debug assertions disabled</summary>

```
test js_value::tests::from_entries_panics_when_keys_is_shorter_than_values - should panic ... error: unsupported operation: can't call foreign function `JSC__JSValue__fromEntries` on OS `linux`
   --> src/jsc/JSValue.rs:701:13
    |
701 | /             JSC__JSValue__fromEntries(
702 | |                 global,
703 | |                 keys.as_mut_ptr(),
704 | |                 values.as_mut_ptr(),
705 | |                 keys.len(),
706 | |                 clone,
707 | |             )
    | |_____________^ unsupported operation occurred here
    = note: this is on thread `js_value::tests`
    = note: stack backtrace:
            0: js_value::JSValue::from_entries
            1: js_value::tests::from_entries_panics_when_keys_is_shorter_than_values
error: test failed, to rerun pass `-p bun_jsc --lib`
```

For comparison, with debug assertions left on, the reverted wrapper does panic and the two tests fail only on the message (`assertion `left == right` failed` instead of the new message), which is why the runner disables them: that is the configuration in which the check's existence, not its wording, is what the tests observe.

</details>
