### PR TITLE
Reject sources of 2 GiB or more before parsing instead of aborting in usize2loc

### DIFF
--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -2310,8 +2310,7 @@ pub fn alloc_print(args: fmt::Arguments<'_>) -> Cow<'static, [u8]> {
     Cow::Owned(v)
 }
 
-/// Aborts past `i32::MAX`: parsers keep their positions in range by rejecting
-/// longer sources up front ([`Source::check_parseable_len`]).
+/// In range for every position in a source that passed [`Source::check_parseable_len`].
 #[inline]
 pub fn usize2loc(loc: usize) -> Loc {
     Loc {
@@ -2559,8 +2558,7 @@ impl LineColumnTracker {
     }
 }
 
-/// The source is longer than [`Source::MAX_PARSEABLE_LEN`]; the error has
-/// already been logged by [`Source::check_parseable_len`].
+/// Returned by [`Source::check_parseable_len`] once it has logged the error.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SourceTooLarge;
 
@@ -2573,19 +2571,15 @@ impl Source {
         &self.contents
     }
 
-    /// The longest source a parser accepts: positions are recorded as [`Loc`]s
-    /// (`i32` byte offsets), so [`usize2loc`] aborts on any position past this.
+    /// Positions are `i32` [`Loc`]s, so no parser can take a longer source.
     pub const MAX_PARSEABLE_LEN: usize = i32::MAX as usize;
 
-    /// Every parser that records positions calls this before reading the
-    /// source, whichever way the source reached it (file loader, bundler
-    /// plugin, JS API). `what` names the input in the error, e.g.
-    /// "TOML document". The error carries no position: locating one would
-    /// scan the oversized source.
+    /// Parsers call this before reading a source, whichever way it reached them.
     pub fn check_parseable_len(&self, log: &mut Log, what: &str) -> Result<(), SourceTooLarge> {
         if self.contents.len() <= Self::MAX_PARSEABLE_LEN {
             return Ok(());
         }
+        // Without a position: finding the line of one would scan the oversized source.
         log.add_error_fmt(
             Some(self),
             Loc::EMPTY,

--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -2310,6 +2310,8 @@ pub fn alloc_print(args: fmt::Arguments<'_>) -> Cow<'static, [u8]> {
     Cow::Owned(v)
 }
 
+/// Aborts past `i32::MAX`: parsers keep their positions in range by rejecting
+/// longer sources up front ([`Source::check_parseable_len`]).
 #[inline]
 pub fn usize2loc(loc: usize) -> Loc {
     Loc {
@@ -2557,6 +2559,11 @@ impl LineColumnTracker {
     }
 }
 
+/// The source is longer than [`Source::MAX_PARSEABLE_LEN`]; the error has
+/// already been logged by [`Source::check_parseable_len`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SourceTooLarge;
+
 impl Source {
     /// Borrowed view of the source bytes. Provided as a method so callers that
     /// were written against a future owning-`contents` shape (`Vec<u8>`/`Cow`)
@@ -2564,6 +2571,27 @@ impl Source {
     #[inline]
     pub fn contents(&self) -> &[u8] {
         &self.contents
+    }
+
+    /// The longest source a parser accepts: positions are recorded as [`Loc`]s
+    /// (`i32` byte offsets), so [`usize2loc`] aborts on any position past this.
+    pub const MAX_PARSEABLE_LEN: usize = i32::MAX as usize;
+
+    /// Every parser that records positions calls this before reading the
+    /// source, whichever way the source reached it (file loader, bundler
+    /// plugin, JS API). `what` names the input in the error, e.g.
+    /// "TOML document". The error carries no position: locating one would
+    /// scan the oversized source.
+    pub fn check_parseable_len(&self, log: &mut Log, what: &str) -> Result<(), SourceTooLarge> {
+        if self.contents.len() <= Self::MAX_PARSEABLE_LEN {
+            return Ok(());
+        }
+        log.add_error_fmt(
+            Some(self),
+            Loc::EMPTY,
+            format_args!("{what} is too large to parse (2 GiB maximum)"),
+        );
+        Err(SourceTooLarge)
     }
 
     pub fn fmt_identifier(&self) -> bun_core::fmt::FormatValidIdentifier<'_> {

--- a/src/js_parser/error.rs
+++ b/src/js_parser/error.rs
@@ -31,6 +31,13 @@ impl Error {
     }
 }
 
+/// Already logged, like every other `SyntaxError`.
+impl From<bun_ast::SourceTooLarge> for Error {
+    fn from(_: bun_ast::SourceTooLarge) -> Self {
+        Error::SyntaxError
+    }
+}
+
 impl bun_core::output::ErrName for Error {
     fn name(&self) -> &[u8] {
         (*self).name().as_bytes()

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -313,6 +313,7 @@ impl<'a> Parser<'a> {
         define: &'a Define,
         bump: &'a Arena,
     ) -> Result<Parser<'a>, Error> {
+        source.check_parseable_len(log, "File")?;
         let mut lexer = js_lexer::Lexer::init_without_reading(log, source, bump);
         // Must be set before the priming `next()` so leading comments are seen.
         lexer.track_comments = options.features.minify_identifiers;

--- a/src/parsers/error.rs
+++ b/src/parsers/error.rs
@@ -37,6 +37,13 @@ impl Error {
     }
 }
 
+/// Already logged, like every other `SyntaxError`.
+impl From<bun_ast::SourceTooLarge> for Error {
+    fn from(_: bun_ast::SourceTooLarge) -> Self {
+        Error::SyntaxError
+    }
+}
+
 impl bun_core::output::ErrName for Error {
     fn name(&self) -> &[u8] {
         (*self).name().as_bytes()

--- a/src/parsers/toml.rs
+++ b/src/parsers/toml.rs
@@ -162,6 +162,7 @@ impl TOML {
         bump: &'a Bump,
         redact_logs: bool,
     ) -> crate::Result<Expr> {
+        source.check_parseable_len(log, "TOML document")?;
         let mut parser = Parser {
             scanner: Scanner {
                 src: source.contents.as_ref(),

--- a/src/parsers/xml.rs
+++ b/src/parsers/xml.rs
@@ -89,8 +89,9 @@ impl XML {
     }
 
     /// [`parse`](Self::parse) for a UTF-16 document (a 16-bit JS string):
-    /// the strings in the result are UTF-16 as well. `source` is only what
-    /// diagnostics are attributed to.
+    /// the strings in the result are UTF-16 as well. `source` holds the same
+    /// `units` as bytes; it is what diagnostics are attributed to and what the
+    /// size limit is checked against.
     pub fn parse_utf16<'a>(
         source: &'a Source,
         units: &'a [u16],
@@ -109,6 +110,7 @@ impl XML {
         bump: &'a Bump,
         options: Options,
     ) -> crate::Result<Expr> {
+        source.check_parseable_len(log, "XML document")?;
         let mut tape = Tape::new_in(bump, core::mem::size_of_val(contents));
         // SAFETY: see `Tape::object_from`.
         unsafe { tape.tape.as_mut() }.encoding = if U::WIDE {

--- a/src/parsers/xml.rs
+++ b/src/parsers/xml.rs
@@ -89,9 +89,8 @@ impl XML {
     }
 
     /// [`parse`](Self::parse) for a UTF-16 document (a 16-bit JS string):
-    /// the strings in the result are UTF-16 as well. `source` holds the same
-    /// `units` as bytes; it is what diagnostics are attributed to and what the
-    /// size limit is checked against.
+    /// the strings in the result are UTF-16 as well. `source` is only what
+    /// diagnostics are attributed to and what the length limit is checked on.
     pub fn parse_utf16<'a>(
         source: &'a Source,
         units: &'a [u16],

--- a/src/parsers/xml_index.rs
+++ b/src/parsers/xml_index.rs
@@ -37,9 +37,7 @@ impl<'c, U: crate::xml::Unit> StructuralIndex<'c, U> {
     }
 
     fn with_producer(contents: &'c [U], use_scalar: bool) -> Self {
-        // Positions and the `len` sentinels are stored as `u32`: the parser
-        // bounds its input to `i32::MAX` units (`Source::check_parseable_len`)
-        // and transcoding it to UTF-8 (from UTF-16 or Latin-1) at most doubles it.
+        // Positions are stored as `u32`; transcoding can double the parser's `i32::MAX` bound.
         debug_assert!(contents.len() <= u32::MAX as usize);
         let win_cap = contents.len().min(REFILL_INPUT) + 64 + SENTINELS + LOOKBEHIND;
         StructuralIndex {

--- a/src/parsers/xml_index.rs
+++ b/src/parsers/xml_index.rs
@@ -37,7 +37,10 @@ impl<'c, U: crate::xml::Unit> StructuralIndex<'c, U> {
     }
 
     fn with_producer(contents: &'c [U], use_scalar: bool) -> Self {
-        debug_assert!(contents.len() <= i32::MAX as usize);
+        // Positions and the `len` sentinels are stored as `u32`: the parser
+        // bounds its input to `i32::MAX` units (`Source::check_parseable_len`)
+        // and transcoding it to UTF-8 (from UTF-16 or Latin-1) at most doubles it.
+        debug_assert!(contents.len() <= u32::MAX as usize);
         let win_cap = contents.len().min(REFILL_INPUT) + 64 + SENTINELS + LOOKBEHIND;
         StructuralIndex {
             contents,

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -43,6 +43,7 @@ impl YAML {
         cyclic_aliases: CyclicAliases,
     ) -> Result<Expr, YamlParseError> {
         bun_core::analytics::Features::yaml_parse_inc();
+        source.check_parseable_len(log, "YAML document")?;
 
         let mut parser: Parser<Utf8> = Parser::init(bump, source.contents(), cyclic_aliases);
 
@@ -88,6 +89,13 @@ pub enum YamlParseError {
 }
 
 bun_core::oom_from_alloc!(YamlParseError);
+
+/// Already logged, like every other `SyntaxError`.
+impl From<bun_ast::SourceTooLarge> for YamlParseError {
+    fn from(_: bun_ast::SourceTooLarge) -> Self {
+        YamlParseError::SyntaxError
+    }
+}
 
 impl From<YamlParseError> for crate::Error {
     fn from(e: YamlParseError) -> Self {

--- a/test/js/bun/transpiler/source-too-large.test.ts
+++ b/test/js/bun/transpiler/source-too-large.test.ts
@@ -1,0 +1,109 @@
+// Every parser records source positions as an i32 byte offset, so a source of
+// 2**31 bytes or more used to abort the process once the parser reached a
+// position past i32::MAX: `panic: int cast: TryFromIntError(PosOverflow)` from
+// the JS lexer, TOML and YAML, and a failed length assertion in the XML indexer.
+// `Bun.TOML.parse` and friends already rejected such inputs at the API boundary;
+// the parsers themselves did not, and they are what `bun build`, `bun run`,
+// `import` and `Bun.Transpiler` feed. They now reject the source by length
+// before reading any of it, so the content below is irrelevant to the behavior
+// under test. It starts with a line that is a syntax error in every format, so
+// a build without the length check fails fast on line 1 (with a different
+// message) instead of scanning the remaining 2 GiB to report its error.
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+import { truncateSync, writeFileSync } from "node:fs";
+import { totalmem } from "node:os";
+import { join } from "node:path";
+
+const SIZE = 2 ** 31;
+const FIRST_LINE = "%\n";
+
+async function run(cmd: string[]) {
+  await using proc = Bun.spawn({ cmd, env: bunEnv, stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout: stdout.trim(), stderr, exitCode };
+}
+
+test("Bun.Transpiler reports the limit for every loader that records positions", async () => {
+  // Only the first line of the Uint8Array is ever written or read; the rest
+  // stays untouched virtual memory, so this costs neither time nor RSS.
+  const { stdout, stderr, exitCode } = await run([
+    bunExe(),
+    "-e",
+    `
+      const input = new Uint8Array(${SIZE});
+      input.set(Buffer.from(${JSON.stringify(FIRST_LINE)}));
+      const transpiler = new Bun.Transpiler();
+      const results = {};
+      for (const loader of ["js", "ts", "toml", "yaml", "xml", "json", "jsonc"]) {
+        try {
+          transpiler.transformSync(input, loader);
+          results[loader] = "no error";
+        } catch (e) {
+          results[loader] = e.name + ": " + e.message;
+        }
+      }
+      console.log(JSON.stringify(results, null, 2));
+    `,
+  ]);
+  expect({ stdout, stderr, exitCode }).toEqual({
+    stdout: JSON.stringify(
+      {
+        js: "BuildMessage: File is too large to parse (2 GiB maximum)",
+        ts: "BuildMessage: File is too large to parse (2 GiB maximum)",
+        toml: "BuildMessage: TOML document is too large to parse (2 GiB maximum)",
+        yaml: "BuildMessage: YAML document is too large to parse (2 GiB maximum)",
+        xml: "BuildMessage: XML document is too large to parse (2 GiB maximum)",
+        json: "BuildMessage: JSON document is too large to parse (2 GiB maximum)",
+        jsonc: "BuildMessage: JSON document is too large to parse (2 GiB maximum)",
+      },
+      null,
+      2,
+    ),
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
+// Each file is sparse: everything past the first line is a hole, so it takes no
+// disk space and reads back as NUL bytes. Reading it costs the child process
+// 2 GiB of memory (and, in debug builds, tens of seconds of allocator
+// bookkeeping), so the block skips on small machines (the gate fs-oom.test.ts
+// uses for its 2 GiB cases) and each entry point gets a single file. `bun build`
+// gets a data-format file because a JS file that fails to parse additionally
+// gets an empty fallback AST whose symbol tables are presized from the source
+// length, which takes over a minute in debug builds.
+describe.skipIf(totalmem() < 10 * 1024 ** 3)("a 2 GiB file", () => {
+  function sparseFile(dir: string, name: string) {
+    const file = join(dir, name);
+    writeFileSync(file, FIRST_LINE);
+    truncateSync(file, SIZE);
+    return file;
+  }
+
+  test("is a build error in bun build", async () => {
+    using dir = tempDir("source-too-large-build", {});
+    const file = sparseFile(String(dir), "big.xml");
+    const { stdout, stderr, exitCode } = await run([bunExe(), "build", file, "--outdir", join(String(dir), "out")]);
+    expect(normalizeBunSnapshot(stderr, String(dir))).toMatchInlineSnapshot(`
+      "error: XML document is too large to parse (2 GiB maximum)
+          at <dir>/big.xml"
+    `);
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  }, 120_000);
+
+  test("is an error instead of running in bun run", async () => {
+    using dir = tempDir("source-too-large-run", {});
+    const file = sparseFile(String(dir), "big.js");
+    const { stdout, stderr, exitCode } = await run([bunExe(), file]);
+    expect(normalizeBunSnapshot(stderr, String(dir))).toMatchInlineSnapshot(`
+      "error: File is too large to parse (2 GiB maximum)
+          at <dir>/big.js
+
+      Bun v<bun-version>"
+    `);
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  }, 120_000);
+});


### PR DESCRIPTION
### Problem
- A source file of 2 GiB or more aborts the process instead of producing an error when it reaches a parser through `bun build`, `bun run`, `import` or `Bun.Transpiler`:
  - JS/TS: `panic: int cast: TryFromIntError(PosOverflow)` / `Crashed while parsing big.js` (`Lexer::loc` -> `bun_ast::usize2loc`, src/ast/lib.rs)
  - TOML: `panic: source length is bounded by i32::MAX: TryFromIntError(PosOverflow)` (`loc_of`, src/parsers/toml.rs); nothing enforced that bound
  - YAML: `panic: int cast: TryFromIntError(PosOverflow)` (`Pos::loc`, src/parsers/yaml.rs)
  - XML: `panic: assertion failed: contents.len() <= i32::MAX as usize` in debug builds (src/parsers/xml_index.rs:40); release builds silently saturate positions
- Cause: every parser records positions as an `i32` `Loc`, and #32764 only added the length check to the `Bun.*.parse` JS entry points (src/runtime/api.rs). The parsers themselves accept any length, and the file-based entry points (src/bundler/ParseTask.rs, src/bundler/transpiler.rs), `bunfig.toml` loading, pnpm migration and `Bun.Transpiler` hand them whatever they read.
- Reproduces on 1.4.0 with a sparse file (`writeFileSync(f, "/*"); truncateSync(f, 2 ** 31); appendFileSync(f, "*/\nx")`, then `bun f.js` or `bun build f.js`), and with 2 GiB of newlines followed by `a = 1` / `a: 1` for TOML and YAML. JSON and JSONC are not affected: their structural indexer already reports `JSON document is too large to parse (2 GiB maximum)`. JSON5 has the same bug and is being fixed in #38936.

### Fix
- `Source::check_parseable_len(log, what)` in bun_ast (next to `Loc` and `usize2loc`, whose precondition it establishes) logs `<what> is too large to parse (2 GiB maximum)` against the source and returns `Err(SourceTooLarge)`. The error is attributed to the file without a position: computing one would scan the oversized file to find the end of its line (that scan is why the existing JSON check, which reports at offset 0, takes seconds on a single-line file).
- Called at the single entry point of each affected parser: `Parser::init` (all JS/TS parsing, including scans and the transpiler API), `TOML::parse`, `YAML::parse` and XML's `parse_units` (both `parse` and `parse_utf16`). The XML indexer's assertion now states the bound it actually relies on, u32: the scanner may transcode UTF-16 or Latin-1 input to UTF-8 after the entry check, which at most doubles it, and positions in transcoded input only ever live in the u32 index (`Scanner::loc` attaches no location to them), so an input under the limit that grows past 2 GiB when transcoded keeps parsing, as it does in release builds today. `SourceTooLarge` converts into each crate's already-logged `SyntaxError` variant, so every existing caller reports it the way it reports any other parse error: `bun build` prints a build error and exits 1, `import` rejects with a `BuildMessage`, `Bun.Transpiler` throws one, bunfig and pnpm report a parse error.
- Why the parsers rather than the file loaders: the `i32` limit is the parsers' own precondition, and they are reached from more places than the two file loaders (bunfig, pnpm, S3 XML responses, test snapshots, `Bun.Transpiler`, bundler plugins returning contents, and XML's Latin-1 to UTF-8 re-parse, whose input can be twice the length the API check measured). Checking at the parser covers all of them and matches what the JSON parser already does. The message wording follows the JSON one.
- Verified:
  - test/js/bun/transpiler/source-too-large.test.ts: `Bun.Transpiler` with a 2 GiB buffer for js, ts, toml, yaml, xml (plus json and jsonc to pin the existing behavior), `bun build` of a 2 GiB .xml, and `bun run` of a 2 GiB .js, both sparse files. Passes with `bun bd test`; with `USE_SYSTEM_BUN=1` (1.4.0) all three fail, and the unfixed debug build aborts on the `bun build` case. The fixtures' first line is a syntax error in every format so that a build without the check fails fast instead of scanning 2 GiB; the crash itself needs parseable content past 2 GiB, which is what the repros above use.
  - `bun bd test` on the toml, xml, yaml, resolve/{toml,yaml,xml,jsonc}, transpiler and bundler_loader suites; `cargo clippy` on bun_ast, bun_parsers, bun_js_parser; the source lints.
- Related: #38825 changes the representation of `Loc`; if it lands first, `MAX_PARSEABLE_LEN` and the `Loc::EMPTY` argument in the helper are the only two lines here that need to follow it. Two things found on the way are left for separate changes: the CSS parser has the same class of casts, and the bundler's empty fallback AST for an unparsable JS file presizes its symbol tables from the source length (correct but slow in debug builds, which is why the `bun build` test case uses a data-format file).

### Background
- `Loc` (bun_ast) is the position type stored in every AST node and diagnostic: an `i32` byte offset into the source. `usize2loc` is the shared conversion from a parser's `usize` cursor; like the parsers' private equivalents it is an `expect`, and the binary builds with `panic = "abort"`, so an offset past `i32::MAX` is a process abort.
- `Source` is the path plus contents handed to every parser, whether the bytes came from a file read, a bundler plugin or a JS string. `Log` collects diagnostics; a parse error is logged and then signalled to the caller with a bare `SyntaxError` value, which is the convention the new error converts into.
- A sparse file (`truncateSync` past the end) takes no disk space and reads back as NUL bytes, which is enough to exercise the length check; the tests use that so the 2 GiB fixtures cost only the memory of reading them.

<details>
<summary>Before and after</summary>

Release 1.4.0, sparse `/*` + 2 GiB hole + `*/` JS file:

```
$ bun block.js
panic: int cast: TryFromIntError(PosOverflow)
Crashed while parsing /tmp/repro/block.js
$ bun build block.js --outdir out
panic: int cast: TryFromIntError(PosOverflow)
Crashed while parsing /tmp/repro/block.js
```

Release 1.4.0, 2 GiB of newlines followed by one line:

```
import('./dense.toml')   ->  panic: source length is bounded by i32::MAX: TryFromIntError(PosOverflow)
import('./dense.yaml')   ->  panic: int cast: TryFromIntError(PosOverflow)
```

Unfixed debug build, any 2 GiB .xml: `panic: assertion failed: contents.len() <= i32::MAX as usize`.

With this change (debug build):

```
$ bun build block.js --outdir out
error: File is too large to parse (2 GiB maximum)
    at /tmp/repro/block.js
$ bun build big.toml --outdir out
error: TOML document is too large to parse (2 GiB maximum)
    at /tmp/repro/big.toml
$ bun -e "import('./block.js').catch(e => console.log(e.name, e.message))"
BuildMessage File is too large to parse (2 GiB maximum)
```

`Bun.Transpiler.transformSync` with a 2 GiB `Uint8Array`, per loader: js/ts `File is too large to parse (2 GiB maximum)`, toml/yaml/xml `<FORMAT> document is too large to parse (2 GiB maximum)`, json/jsonc unchanged (`JSON document is too large to parse (2 GiB maximum)`), each in about a millisecond.
</details>
