### PR TITLE
webview: close the views orphaned by a browser death

### DIFF
--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -1304,8 +1304,10 @@ void Transport::rejectAllAndMarkDead(const WTF::String& reason)
     auto* g = m_global;
     JSValue err = createError(g, reason);
     for (auto& weak : views.values()) {
-        if (JSWebView* v = weak.get())
-            rejectViewSlots(g, v, err);
+        JSWebView* v = weak.get();
+        if (!v) continue;
+        rejectViewSlots(g, v, err);
+        v->m_closed = true;
     }
     updateKeepAlive();
 }
@@ -1369,9 +1371,9 @@ static JSPromise* sendChromeOp(JSGlobalObject* g, JSWebView* v,
     auto& vm = g->vm();
     auto& t = transport();
     auto* promise = JSPromise::create(vm, g->promiseStructure());
-    // m_mode == None means neither ensureSpawned nor ensureConnected ran
-    // (constructor already called one, so this is unreachable unless
-    // rejectAllAndMarkDead reset it). WebSocket mode doesn't need
+    // Unreachable: the constructor spawned or connected, and the paths that
+    // kill or release the transport afterwards (rejectAllAndMarkDead,
+    // updateKeepAlive) leave no open view behind. WebSocket mode doesn't need
     // m_wsOpen here — send() queues until onOpen fires.
     if (t.m_dead || t.m_mode == TransportMode::None) {
         promise->reject(vm, createError(g, "Chrome connection is not available"_s));

--- a/src/runtime/webview/WebKitBackend.cpp
+++ b/src/runtime/webview/WebKitBackend.cpp
@@ -474,6 +474,7 @@ void HostClient::rejectAllAndMarkDead(const WTF::String& reason)
         settleSlot(g, v, v->m_pendingEval, false, err);
         settleSlot(g, v, v->m_pendingScreenshot, false, err);
         settleSlot(g, v, v->m_pendingMisc, false, err);
+        v->m_closed = true;
     }
     viewsById.clear();
     updateKeepAlive();

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -633,6 +633,112 @@ it("chrome: a new WebView respawns Chrome after the previous one died", async ()
   expect(exitCode).toBe(0);
 });
 
+it("chrome: views orphaned by a Chrome death are closed, even after a new view respawns Chrome", async () => {
+  // Subprocess-isolated for the same reason as the closeAll() test above.
+  // Three views die with Chrome: one with an op in flight, one idle (so
+  // it has no pending entry in the transport), one never navigated (no
+  // target yet). All three must end up closed. Without that, once a new
+  // view respawns Chrome, an op on an old view is sent to the new Chrome
+  // with a stale session and its reply is dropped, so the promise never
+  // settles and the slot it occupies is never freed.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        // Spawn args come from whichever construction spawns Chrome, so every
+        // view passes them: the one constructed after closeAll() spawns the
+        // second Chrome. --no-sandbox: Chrome refuses to start as root
+        // (containers) otherwise.
+        const backend = { type: "chrome", url: false, argv: ["--no-sandbox"] };
+        const open = () => new Bun.WebView({ backend, width: 200, height: 200 });
+        // An op on a dead view must throw synchronously, not hand back a
+        // promise. The catch handler keeps an unfixed build's promise from
+        // surfacing as an unhandled rejection, so its exit code stays 0
+        // and the comparison below is what fails.
+        const probe = fn => {
+          try {
+            fn().catch(() => {});
+            return "returned a promise";
+          } catch (e) {
+            return e.code;
+          }
+        };
+
+        const busy = open();
+        const idle = open();
+        const blank = open();
+        await busy.navigate("data:text/html,<body>busy</body>");
+        await idle.navigate("data:text/html,<body>idle</body>");
+        const inFlight = busy.evaluate("new Promise(() => {})");
+        Bun.WebView.closeAll();
+        const death = await inFlight.then(() => "resolved", e => e.message);
+
+        const whileDead = {
+          busy: probe(() => busy.evaluate("1")),
+          idle: probe(() => idle.evaluate("1")),
+          blank: probe(() => blank.navigate("data:text/html,<body>blank</body>")),
+        };
+
+        // Construction fails until the dead Chrome has been reaped (see the
+        // respawn test above), hence the retry.
+        let fresh;
+        for (;;) {
+          try {
+            fresh = open();
+            break;
+          } catch (e) {
+            if (!/Failed to spawn Chrome/.test(e.message)) throw e;
+            await Bun.sleep(1);
+          }
+        }
+        await fresh.navigate("data:text/html,<body>fresh</body>");
+        const freshBody = await fresh.evaluate("document.body.textContent");
+
+        const afterRespawn = {
+          evaluate: probe(() => busy.evaluate("1")),
+          navigate: probe(() => busy.navigate("data:text/html,<body>again</body>")),
+          screenshot: probe(() => busy.screenshot()),
+          click: probe(() => busy.click(1, 1)),
+          cdp: probe(() => busy.cdp("Runtime.evaluate", { expression: "1" })),
+          idle: probe(() => idle.evaluate("1")),
+          blank: probe(() => blank.navigate("data:text/html,<body>blank</body>")),
+        };
+        // close() must still be safe to call on the views that died.
+        busy.close();
+        idle.close();
+        blank.close();
+        fresh.close();
+        console.log(JSON.stringify({ death, whileDead, freshBody, afterRespawn }));
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout, stderr).toEndWith("}\n");
+  expect(JSON.parse(stdout)).toEqual({
+    // Pipe EOF and the exit notification race; the wording follows the winner.
+    death: expect.stringMatching(/^Chrome (killed by signal \d+|process closed the pipe|exited)$/),
+    whileDead: {
+      busy: "ERR_INVALID_STATE",
+      idle: "ERR_INVALID_STATE",
+      blank: "ERR_INVALID_STATE",
+    },
+    freshBody: "fresh",
+    afterRespawn: {
+      evaluate: "ERR_INVALID_STATE",
+      navigate: "ERR_INVALID_STATE",
+      screenshot: "ERR_INVALID_STATE",
+      click: "ERR_INVALID_STATE",
+      cdp: "ERR_INVALID_STATE",
+      idle: "ERR_INVALID_STATE",
+      blank: "ERR_INVALID_STATE",
+    },
+  });
+  expect(exitCode, stderr).toBe(0);
+});
+
 it("chrome: backend.stderr defaults to ignore (Chrome noise hidden)", async () => {
   // Subprocess-isolated — first spawn's stdio config wins for the shared
   // Chrome. Chrome prints GCM/updater/policy noise to stderr on launch;

--- a/test/js/bun/webview/webview.test.ts
+++ b/test/js/bun/webview/webview.test.ts
@@ -970,6 +970,107 @@ it("WebView.closeAll() kills the host subprocess and pending promises reject", a
   expect(exitCode).toBe(0);
 });
 
+it("views orphaned by a host death are closed, even after a new view respawns the host", async () => {
+  // Subprocess-isolated for the same reason as the closeAll() test above.
+  // Three views die with the host: one with an op in flight, one idle, one
+  // never navigated. All three must end up closed. Without that, once a
+  // new view respawns the host, an op on an old view is written to the
+  // new host with a viewId it has never seen and the failure reply is
+  // dropped, so the promise never settles and its slot is never freed.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const html = h => "data:text/html," + encodeURIComponent(h);
+        const open = () => new Bun.WebView({ width: 200, height: 200 });
+        // An op on a dead view must throw synchronously, not hand back a
+        // promise. The catch handler keeps an unfixed build's promise from
+        // surfacing as an unhandled rejection, so its exit code stays 0
+        // and the comparison below is what fails.
+        const probe = fn => {
+          try {
+            fn().catch(() => {});
+            return "returned a promise";
+          } catch (e) {
+            return e.code;
+          }
+        };
+
+        const busy = open();
+        const idle = open();
+        const blank = open();
+        await busy.navigate(html("<body>busy</body>"));
+        await idle.navigate(html("<body>idle</body>"));
+        const inFlight = busy.evaluate("new Promise(() => {})");
+        Bun.WebView.closeAll();
+        const death = await inFlight.then(() => "resolved", e => e.message);
+
+        const whileDead = {
+          busy: probe(() => busy.evaluate("1")),
+          idle: probe(() => idle.evaluate("1")),
+          blank: probe(() => blank.navigate(html("<body>blank</body>"))),
+        };
+
+        // The client is marked dead as soon as the event loop sees the
+        // socket EOF or the exit notification, whichever comes first; a
+        // respawn is refused until the exit has been reaped, so the
+        // constructor can throw briefly after closeAll(). Retry.
+        let fresh;
+        for (let attempt = 0; ; attempt++) {
+          try {
+            fresh = open();
+            break;
+          } catch (e) {
+            if (attempt === 500) throw e;
+            await Bun.sleep(10);
+          }
+        }
+        await fresh.navigate(html("<body>fresh</body>"));
+        const freshBody = await fresh.evaluate("document.body.textContent");
+
+        const afterRespawn = {
+          evaluate: probe(() => busy.evaluate("1")),
+          navigate: probe(() => busy.navigate(html("<body>again</body>"))),
+          screenshot: probe(() => busy.screenshot()),
+          click: probe(() => busy.click(1, 1)),
+          idle: probe(() => idle.evaluate("1")),
+          blank: probe(() => blank.navigate(html("<body>blank</body>"))),
+        };
+        // close() must still be safe to call on the views that died.
+        busy.close();
+        idle.close();
+        blank.close();
+        fresh.close();
+        console.log(JSON.stringify({ death, whileDead, freshBody, afterRespawn }));
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout, stderr).toEndWith("}\n");
+  expect(JSON.parse(stdout)).toEqual({
+    // Socket EOF and the exit notification race; the wording follows the winner.
+    death: expect.stringMatching(/^WebView host process (died|killed by signal \d+|exited)$/),
+    whileDead: {
+      busy: "ERR_INVALID_STATE",
+      idle: "ERR_INVALID_STATE",
+      blank: "ERR_INVALID_STATE",
+    },
+    freshBody: "fresh",
+    afterRespawn: {
+      evaluate: "ERR_INVALID_STATE",
+      navigate: "ERR_INVALID_STATE",
+      screenshot: "ERR_INVALID_STATE",
+      click: "ERR_INVALID_STATE",
+      idle: "ERR_INVALID_STATE",
+      blank: "ERR_INVALID_STATE",
+    },
+  });
+  expect(exitCode, stderr).toBe(0);
+});
+
 it("reload() fires onNavigated", async () => {
   await using view = new Bun.WebView({ width: 200, height: 200 });
   await view.navigate("data:text/html," + encodeURIComponent("<body>hi</body>"));


### PR DESCRIPTION
### Problem

- `Bun.WebView`, both backends: after the browser process dies (`Bun.WebView.closeAll()`, a crash, pipe or WebSocket EOF), the views that belonged to it stay open. As soon as a later `new Bun.WebView()` respawns the browser, an operation on one of the old views returns a promise that never settles, and the slot it occupies is never freed (a second call of the same kind throws "already pending" until the view is closed).
- Chrome: `Transport::rejectAllAndMarkDead` (`src/runtime/webview/ChromeBackend.cpp`) drops every view from `m_views` / `m_sessions` but never sets `m_closed` on them. After the respawn, `sendChromeOp` sends the command with the dead session id; Chrome answers with an error, and `handleResponse` drops the reply because `viewFor(entry.viewId)` no longer finds the view. The promise is never settled and `m_pendingActivityCount` is never decremented. The WebSocket transport (`wsOnClose`) ends up in the same function.
- WebKit: `HostClient::rejectAllAndMarkDead` (`WebKitBackend.cpp`) has the same shape: it clears `viewsById` but leaves the views open. After a host respawn the new host answers the unknown viewId with a failure reply that `handleReply` drops.
- While the browser is still dead the ops do fail, but as rejected promises, not the synchronous throw the docs promise ("Further operations on those views throw", docs/runtime/webview.mdx, Subprocess death).
- The single-page death path already does the right thing: the `Target.detachedFromTarget` handler rejects the view's slots and sets `m_closed`. The whole-browser death path was the only one that forgot to.

### Fix

- Both `rejectAllAndMarkDead`s set `v->m_closed = true` on every live view after rejecting its slots (Chrome: after the `rejectViewSlots` call that #39081 added; WebKit: after its existing `settleSlot` calls). `unwrapThis` then throws `ERR_INVALID_STATE` for every method on those views, before and after a respawn, and `close()` on them is a no-op, exactly as after `close()` or a page crash.
- Correct because a view whose browser is gone can never be used again: its target / WKWebView died with the process, and the respawned browser has never heard of it. Closing it is the state the code base already uses for that situation (`Target.detachedFromTarget`), and it is the behavior the docs state for both `close()` and subprocess death. It also restores the invariant `sendChromeOp` relies on: an open view is always registered, so its reply can be routed. The comment on its `m_dead || m_mode == None` check is updated for that; its "unless rejectAllAndMarkDead reset it" clause is no longer a reachable case.
- `~JSWebView` returns early for closed views; that is fine here because both functions have already removed the views from their tables, and view ids are never reused across respawns in either backend.
- Verified with:
  - `test/js/bun/webview/webview-chrome.test.ts` ("views orphaned by a Chrome death are closed, even after a new view respawns Chrome"): three views die with Chrome (one with an op in flight, one idle, one never navigated); a fourth view respawns Chrome and works; every op on the three old views throws `ERR_INVALID_STATE` both while Chrome is dead and after the respawn. Fails on the unfixed binary (every probe reports "returned a promise", re-checked after the rebase with `USE_SYSTEM_BUN=1`), passes with `bun bd test`. The child passes `--no-sandbox` so it also runs as root: in the root container used here, every other Chrome-launching test in this file fails at Chrome startup for lack of that flag (48 of 58; they pass in CI, which runs as a normal user), so this test is the only real-Chrome test in the file that could be run locally. Making the rest of the file root-tolerant is filed separately.
  - `test/js/bun/webview/webview.test.ts`: the same scenario for the WebKit backend. macOS only, so it relies on the macOS CI lanes; it was not run locally.
  - After the rebase: `bun bd test` on `webview-chrome-disconnect.test.ts` (#39081's tests for the same loop), `webview-chrome-pipe.test.ts` and `webview-chrome-ws.test.ts`: 14 pass, 0 fail (the rest are skipped or todo on Linux).
  - Manually (before the rebase), the WebSocket transport variant: two Chromes started with `--remote-debugging-port`, connect to the first, kill it, connect a new view to the second. Old views throw `ERR_INVALID_STATE` with the fix, return promises without it.

### Background

- Each `JSWebView` has one promise slot per kind of operation (`m_pendingNavigate`, `m_pendingEval`, ...). A call stores its promise in the slot and bumps `m_pendingActivityCount`; the reply from the browser settles the slot. While a slot is set, a second call of that kind throws "already pending".
- Both backends are process-wide singletons talking to one browser process: `CDP::Transport` speaks the Chrome DevTools Protocol to a Chrome (over a pipe to one it spawned, or a WebSocket to an existing one); `WK::HostClient` speaks a binary frame protocol to a helper process hosting the WKWebViews. Each keeps a table of live views (`m_views` / `viewsById`, weak references keyed by view id) that replies and events are routed through; a reply for an id that is not in the table is dropped.
- `rejectAllAndMarkDead` is the single "browser is gone" entry point for each backend (pipe or socket EOF, process exit watcher, WebSocket close). The next constructor call notices the dead flag and spawns or connects to a new browser, which starts with an empty view table on the browser side.
- `m_closed` is the flag `close()` sets; every prototype method checks it first (`unwrapThis`) and throws `ERR_INVALID_STATE`, and `close()` returns early when it is set.

<details>
<summary>Before the rebase onto #39081</summary>

The first version of this PR also had to switch the Chrome loop from walking `m_pending` to walking `m_views` (an idle view has no pending entry but is just as dead) and to move the tables out with `std::exchange` before settling, because `settle()` allocates and `~JSWebView` of an already collected view removes itself from `m_views`. #39081 landed both of those on main for its own bug (a committed `navigate()` left pending on Chrome death) via `rejectViewSlots`, so after the rebase this PR's Chrome side is reduced to the `m_closed` line. The WebKit loop already walked `viewsById`; it is a `std::unordered_map`, where erasing other elements during iteration is allowed, so it only gains the `m_closed` line. Main's new "a new WebView respawns Chrome after the previous one died" test (#39423) and the test added here both stayed; they sit next to each other in `webview-chrome.test.ts`.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/webview/webview-chrome.test.ts test/js/bun/webview/webview.test.ts

<!-- robobun:evidence:end -->