### PR TITLE
bun-types: declare the self global

### DIFF
--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -477,6 +477,20 @@ declare function setInterval(handler: Bun.TimerHandler, interval?: number, ...ar
  */
 declare function setTimeout(handler: Bun.TimerHandler, timeout?: number, ...arguments: any[]): Timer;
 
+/**
+ * The global object, like `self` in browsers and web workers. `self === globalThis`
+ * both on the main thread and inside a `Worker`.
+ *
+ * @example
+ * ```ts
+ * // worker.ts
+ * self.addEventListener("message", event => {
+ *   self.postMessage(event.data);
+ * });
+ * ```
+ */
+declare var self: Bun.__internal.UseLibDomIfAvailable<"self", typeof globalThis>;
+
 declare function addEventListener<K extends keyof EventMap>(
   type: K,
   listener: (this: object, ev: EventMap[K]) => any,

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -138,6 +138,43 @@ function typeTest(name: string, config: TypeTestConfig) {
   });
 }
 
+let tscCheckCounter = 0;
+
+/**
+ * Type-checks `files` against the packed bun-types with the `bun init` tsconfig (plus
+ * `compilerOptions`) by spawning tsc. Unlike {@link typeTest} this runs on debug builds too:
+ * tsc over a file or two is cheap, unlike the in-process LanguageService runs over the whole
+ * fixture directory.
+ */
+function tscTest(name: string, files: Record<string, string>, compilerOptions: Record<string, unknown> = {}) {
+  test.concurrent(name, async () => {
+    const checkDir = join(TEMP_DIR, `tsc-check-${tscCheckCounter++}`);
+    const tsconfig = structuredClone(sourceTsconfig);
+    tsconfig.include = Object.keys(files);
+    tsconfig.compilerOptions = {
+      ...tsconfig.compilerOptions,
+      typeRoots: [join(BASE_FIXTURE_DIR, "node_modules", "@types")],
+      ...compilerOptions,
+    };
+    await mkdir(checkDir, { recursive: true });
+    await makeTree(checkDir, { ...files, "tsconfig.json": JSON.stringify(tsconfig, null, 2) });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(BASE_FIXTURE_DIR, "node_modules", "typescript", "bin", "tsc"), "-p", "."],
+      env: bunEnv,
+      cwd: checkDir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr.trim()).toBe("");
+    expect(stdout.trim()).toBe("");
+    expect(exitCode).toBe(0);
+  });
+}
+
 async function diagnose(
   fixtureDir: string,
   config: {
@@ -367,37 +404,38 @@ describe("@types/bun integration test", () => {
     });
   });
 
-  // Runs on debug builds too: spawning tsc over a single file is cheap,
-  // unlike the in-process LanguageService runs above.
   describe("Bun.mmap", () => {
-    test("MMapOptions accepts offset and size", async () => {
-      const checkDir = join(TEMP_DIR, "mmap-options-check");
-      const tsconfig = structuredClone(sourceTsconfig);
-      tsconfig.include = ["mmap-options.ts"];
-      tsconfig.compilerOptions.typeRoots = [join(BASE_FIXTURE_DIR, "node_modules", "@types")];
-      await mkdir(checkDir, { recursive: true });
-      await makeTree(checkDir, {
-        "tsconfig.json": JSON.stringify(tsconfig, null, 2),
-        "mmap-options.ts": `const view = Bun.mmap("./data.bin", { shared: true, sync: false, offset: 4096, size: 1024 });
+    tscTest("MMapOptions accepts offset and size", {
+      "mmap-options.ts": `const view = Bun.mmap("./data.bin", { shared: true, sync: false, offset: 4096, size: 1024 });
            view satisfies Uint8Array<ArrayBuffer>;
            Bun.mmap("./data.bin", { offset: 4096 }) satisfies Uint8Array<ArrayBuffer>;
            Bun.mmap("./data.bin", { size: 1024 }) satisfies Uint8Array<ArrayBuffer>;`,
-      });
-
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), join(BASE_FIXTURE_DIR, "node_modules", "typescript", "bin", "tsc"), "-p", "."],
-        env: bunEnv,
-        cwd: checkDir,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-      expect(stderr.trim()).toBe("");
-      expect(stdout.trim()).toBe("");
-      expect(exitCode).toBe(0);
     });
+  });
+
+  // The runtime defines `self` on every global object (main thread and Web Workers). Without
+  // lib.dom.d.ts nothing but bun-types can declare it; with lib.dom.d.ts loaded, bun-types has
+  // to defer to lib.dom's declaration or tsc reports a conflicting redeclaration (TS2403).
+  describe("self", () => {
+    tscTest("is the global object without lib.dom.d.ts", {
+      "self.ts": `self satisfies typeof globalThis;
+           globalThis satisfies typeof self;
+           self.Bun.version satisfies string;
+           self.addEventListener("message", event => {
+             event satisfies MessageEvent;
+             self.postMessage(event.data);
+           });`,
+    });
+
+    tscTest(
+      "defers to lib.dom.d.ts when it is loaded",
+      {
+        "self.ts": `self satisfies Window & typeof globalThis;
+           self.Bun.version satisfies string;`,
+      },
+      // The redeclaration error would be reported inside bun-types itself, which skipLibCheck hides.
+      { lib: ["ESNext", "DOM", "DOM.Iterable", "DOM.AsyncIterable"], skipLibCheck: false },
+    );
   });
 
   describe("Test Globals", () => {

--- a/test/integration/bun-types/fixture/globals.ts
+++ b/test/integration/bun-types/fixture/globals.ts
@@ -340,3 +340,9 @@ new Error("asdf", {
 // are making sure that .d.ts is a module and that anything top level doesn't
 // leak to userland
 expectType<BunConsumerConvenienceMethods>();
+
+// `self` is the global object, on the main thread as well as inside a Worker
+// (with lib.dom loaded it is lib.dom's `Window & typeof globalThis`).
+expectAssignable<typeof globalThis>(self);
+expectAssignable<typeof globalThis>(self.self);
+expectType<string>(self.Bun.version);

--- a/test/integration/bun-types/fixture/worker.ts
+++ b/test/integration/bun-types/fixture/worker.ts
@@ -41,6 +41,12 @@ webWorker.onmessage = event => {
 // On the worker thread, `postMessage` is automatically "routed" to the parent thread.
 postMessage({ hello: "world" });
 
+// On the worker thread, `self` is the worker's global scope (this is how docs/runtime/workers.mdx uses it).
+self.addEventListener("message", event => {
+  tsd.expectType<MessageEvent>(event);
+  self.postMessage(event.data);
+});
+
 // On the main thread
 nodeWorker.postMessage({ hello: "world" });
 


### PR DESCRIPTION
### Problem
- With the `bun init` tsconfig (`lib: ["ESNext"]`, `types: ["bun"]`, no lib.dom), `self` does not type-check: `self.addEventListener("message", ...)` fails with `error TS2304: Cannot find name 'self'`. docs/runtime/workers.mdx uses `self.addEventListener(...)` / `self.postMessage(...)` in its worker examples.
- The runtime does define it: `bun -e 'console.log(typeof self, self === globalThis)'` prints `object true`, and the same holds inside a `new Worker()`. It is installed as an accessor on every `Zig::GlobalObject` (`src/jsc/bindings/ZigGlobalObject.cpp`, `functionGetSelf` returns `globalObject->globalThis()`; installed in the `putDirectAccessor(... selfPublicName() ...)` call in the "Public Properties" section).
- packages/bun-types declares `postMessage`, `addEventListener`, `onmessage` and the other worker-scope globals, but `self` appears nowhere in it. @types/node does not declare it either (Node has no `self`), so without lib.dom nothing declares it.

### Fix
- `packages/bun-types/globals.d.ts`: `declare var self: Bun.__internal.UseLibDomIfAvailable<"self", typeof globalThis>;`
- `typeof globalThis` is the exact type: the getter returns the global object itself, and Bun uses the same global object class on the main thread and in Web Workers (there is no separate `WorkerGlobalScope`). It is also what @types/node uses for `global`, and it composes: anything declared on the global scope (by bun-types, @types/node or user `declare global`) is reachable as `self.x`, including the global `onmessage`/`onerror` declarations once #39087 lands.
- The `UseLibDomIfAvailable` wrapper is required, not cosmetic: lib.dom.d.ts declares `var self: Window & typeof globalThis`, and a plain `declare var self: typeof globalThis` makes tsc report `TS2403: Subsequent variable declarations must have the same type` inside bun-types whenever lib.dom is loaded (checked: that is exactly what the new lib.dom test reports if the wrapper is removed). With the wrapper, bun-types' declaration resolves to lib.dom's own type, so both declarations agree. Same pattern as `File`, `MessageEvent`, `performance`, `onmessage` and the other lib.dom overlaps in this package.
- Behaviour change to be aware of: a file that is a script (no import/export and no `moduleDetection: "force"`) and contains the `declare var self: Worker;` line the workers docs suggest now gets TS2403, exactly as it already does when lib.dom is loaded. With the `bun init` tsconfig (`moduleDetection: "force"`) that line is module-scoped and keeps shadowing the global, so the documented snippet still type-checks; I verified both. The docs line can be removed once #39087 (global `onmessage` typing) lands, since `self.onmessage = ...` needs that too; left untouched here to avoid a conflicting edit.
- Verified:
  - `test/integration/bun-types/bun-types.test.ts`: new `describe("self")` with two tsc cases. Without lib.dom: `self` is mutually assignable with `typeof globalThis`, `self.Bun`, `self.addEventListener("message")`, `self.postMessage` type-check (fails on main with the TS2304 above). With lib.dom and `skipLibCheck: false`: `self` is `Window & typeof globalThis` and bun-types produces no TS2403 (fails if the wrapper is dropped). The existing Bun.mmap tsc check is moved onto the same `tscTest()` helper (same shape as the one #39079 adds, so whichever lands second rebases mechanically).
  - `test/integration/bun-types/fixture/globals.ts` and `fixture/worker.ts` use `self`, so the release-only `checks without lib.dom.d.ts` and `checks with lib.dom.d.ts` cases cover it too; the latter's exact diagnostics list is unchanged. Before the fix the no-lib.dom case reports 8 `Cannot find name 'self'` diagnostics from these additions.
  - `bun test test/integration/bun-types/bun-types.test.ts` (release bun) and `bun bd test test/integration/bun-types/bun-types.test.ts` (debug; in-process cases skipped, tsc cases run): all pass with the change, the no-lib.dom `self` cases fail without it.
  - bun-types together with lib.webworker (which also declares `self`) is not a supported combination: it already reports 26 TS2403 redeclarations on main (`Blob`, `File`, `navigator`, ...); this adds one more.

### Background
- **bun-types and lib.dom**: `@types/bun` is meant to load with or without TypeScript's lib.dom.d.ts. Two `declare var` declarations of the same global must have identical types (TS2403), so for every global that lib.dom also declares, bun-types uses `Bun.__internal.UseLibDomIfAvailable<Name, Fallback>` (`packages/bun-types/bun.d.ts`): it detects lib.dom via `onabort` on `typeof globalThis`; if present it resolves to `typeof globalThis[Name]`, i.e. lib.dom's type (TypeScript types a variable from its first declaration, and default lib files always come first), otherwise to `Fallback`.
- **`typeof globalThis`**: the type of the global object, made up of every `var`/`function` declared at global scope. `self === globalThis` at runtime, so this is the precise type for it when lib.dom is not around; lib.dom and lib.webworker type `self` as `Window & typeof globalThis` / `WorkerGlobalScope & typeof globalThis`.
- **The two test mechanisms in bun-types.test.ts**: `typeTest()` type-checks the whole `fixture/` directory in-process with the TypeScript API in several lib configurations, but is skipped on debug builds (too slow there); `tscTest()` (previously the one-off Bun.mmap block) spawns tsc over a file or two against the packed types and runs everywhere, which is why the `self` coverage exists in both forms.

<details>
<summary>Repro against the checkout</summary>

```ts
// tsconfig: lib ["ESNext"], moduleDetection force, types []
/// <reference path="packages/bun-types/index.d.ts" />
const g = self;
self.addEventListener("message", event => console.log(event.data));
self.postMessage("hello");
```

main:

```
self.ts(2,11): error TS2304: Cannot find name 'self'.
self.ts(3,1): error TS2304: Cannot find name 'self'.
self.ts(3,34): error TS7006: Parameter 'event' implicitly has an 'any' type.
self.ts(4,1): error TS2304: Cannot find name 'self'.
```

With this change: clean. With lib.dom added and `skipLibCheck: false`: clean, and `self` is `Window & typeof globalThis`. With the wrapper replaced by a plain `declare var self: typeof globalThis` and lib.dom added:

```
globals.d.ts(492,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'self' must be of type 'Window & typeof globalThis', but here has type 'typeof globalThis'.
```

</details>
