### PR TITLE
bun test --parallel: kill a worker whose IPC stream is corrupt on Windows too, and report the cause

### DIFF
--- a/src/runtime/cli/test/parallel/Channel.rs
+++ b/src/runtime/cli/test/parallel/Channel.rs
@@ -62,6 +62,12 @@ pub struct Channel<Owner> {
     /// Outgoing bytes the kernel didn't accept yet.
     pub out: JsCell<Vec<u8>>,
     pub(crate) done: Cell<bool>,
+    /// The peer's byte stream stopped decoding as frames, i.e. something in
+    /// the peer wrote straight to fd 3: a length `ingest` rejected, or on
+    /// Windows a read error from libuv's own IPC framing underneath ours. Set
+    /// together with `done`, transport still attached. The coordinator kills
+    /// such a worker and reports this rather than the exit status it caused.
+    pub(crate) corrupt_frame: Cell<bool>,
 
     pub(crate) backend: Backend,
 
@@ -81,6 +87,7 @@ impl<Owner> Default for Channel<Owner> {
             r#in: JsCell::new(Vec::new()),
             out: JsCell::new(Vec::new()),
             done: Cell::new(false),
+            corrupt_frame: Cell::new(false),
             backend: Backend::default(),
             root: Cell::new(core::ptr::null_mut()),
             _owner: PhantomData,
@@ -414,8 +421,8 @@ impl<Owner: ChannelOwner> Channel<Owner> {
     }
 
     /// True while the underlying socket/pipe is still open. When `done` is set
-    /// with the transport still attached, it was a protocol error (corrupt
-    /// frame), not a clean close.
+    /// with the transport still attached, it was not a clean close: a corrupt
+    /// frame (`corrupt_frame`) or, on Windows, a failed write.
     pub(crate) fn is_attached(&self) -> bool {
         #[cfg(windows)]
         {
@@ -523,7 +530,7 @@ impl<Owner: ChannelOwner> Channel<Owner> {
         while buf.len() - head >= 5 {
             let len = u32::from_le_bytes(buf[head..][..4].try_into().unwrap());
             if len > frame::MAX_PAYLOAD {
-                self.mark_done();
+                self.mark_corrupt();
                 return;
             }
             if buf.len() - head < 5usize + len as usize {
@@ -560,6 +567,13 @@ impl<Owner: ChannelOwner> Channel<Owner> {
         self.done.set(true);
         // SAFETY: see `owner_ptr()`.
         unsafe { (*self.owner_ptr()).on_channel_done() };
+    }
+
+    /// `mark_done` for an undecodable stream; the transport is left attached
+    /// so the owner's `on_channel_done` sees it as a protocol error.
+    fn mark_corrupt(&self) {
+        self.corrupt_frame.set(true);
+        self.mark_done();
     }
 }
 
@@ -681,10 +695,16 @@ impl<Owner: ChannelOwner> WindowsHandlers<Owner> {
         let buf: &mut [u8; 16 * 1024] = unsafe { &mut *self_.backend.read_chunk.as_ptr() };
         &mut buf[..]
     }
-    fn on_error(self_: &Channel<Owner>, _err: bun_sys::E) {
-        // Mirror the POSIX on_close path: detach the transport before
-        // signalling done so the owner can tell EOF apart from a protocol
-        // error (where the pipe is still attached).
+    fn on_error(self_: &Channel<Owner>, err: bun_sys::E) {
+        // libuv frames this pipe itself (ipc=1), so bytes the peer writes
+        // straight to fd 3 fail its frame-header check and surface here as a
+        // read error instead of reaching `ingest`; report it the way `ingest`
+        // reports a bad frame, before detaching. EOF is the peer closing its
+        // end: mirror the POSIX on_close path and detach first so it reads as
+        // a clean close.
+        if err != bun_sys::E::EOF {
+            self_.mark_corrupt();
+        }
         let p = self_.backend.pipe.replace(core::ptr::null_mut());
         if !p.is_null() {
             // SAFETY: Box-allocated; close_and_destroy reclaims via heap::take.

--- a/src/runtime/cli/test/parallel/Coordinator.rs
+++ b/src/runtime/cli/test/parallel/Coordinator.rs
@@ -587,13 +587,29 @@ impl<'a> Coordinator<'a> {
             // Bun or addon bug and must not be
             // masked by the rest of the suite passing: abort the whole run so
             // the exit status reflects the crash. SIGKILL is treated as a
-            // regular failure (commonly the OOM killer or the user).
+            // regular failure (commonly the OOM killer or the user). When the
+            // kill was ours (`Worker::on_channel_done`, corrupt IPC stream),
+            // the status says nothing the user can act on; report the cause.
             let panicked = is_panic_status(status);
             if self.stop_reason == Some(StopReason::WorkerPanicked) && !panicked {
                 self.account_unfinished(idx, b"aborted: sibling worker panicked");
             } else {
                 self.record_timing(idx, w.dispatched_at);
-                self.account_crash(idx, status);
+                if w.ipc.corrupt_frame.get() && !panicked {
+                    self.account_crash(
+                        idx,
+                        format_args!("worker killed: corrupt IPC frame, something wrote to fd 3"),
+                    );
+                } else {
+                    let mut buf = [0u8; 32];
+                    self.account_crash(
+                        idx,
+                        format_args!(
+                            "worker crashed: {}",
+                            bstr::BStr::new(describe_status(&mut buf, status))
+                        ),
+                    );
+                }
             }
             Output::flush();
             // SAFETY: fresh root derivation — `account_crash` can reach `bail_out`, which retags the slots.
@@ -661,13 +677,12 @@ impl<'a> Coordinator<'a> {
         self.files_done += 1;
     }
 
-    fn account_crash(&mut self, file_idx: u32, status: &SpawnStatus) {
+    fn account_crash(&mut self, file_idx: u32, detail: core::fmt::Arguments<'_>) {
         self.break_dots();
-        let mut buf = [0u8; 32];
         bun_core::pretty_error!(
-            "<r><red>✗<r> <b>{}<r> <d>(worker crashed: {})<r>\n",
+            "<r><red>✗<r> <b>{}<r> <d>({})<r>\n",
             bstr::BStr::new(self.rel_path(file_idx)),
-            bstr::BStr::new(describe_status(&mut buf, status)),
+            detail,
         );
         self.reporter.summary().fail += 1;
         self.reporter.summary().files += 1;

--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -983,11 +983,18 @@ test("--parallel: back-to-back huge result lines drain in linear time without co
   expect(exitCode).toBe(1);
 }, 90_000);
 
-test("--parallel: a test writing garbage to fd 3 does not hang the coordinator", async () => {
+test("--parallel: a test writing garbage to fd 3 gets its worker killed and the run continues", async () => {
+  const passing = (name: string) =>
+    `import {test,expect} from "bun:test"; test(${JSON.stringify(name)},()=>expect(1).toBe(1));`;
+  // Files are dispatched in sorted order: a-bad goes out first, so a-next is
+  // still undispatched when its worker is killed and only runs if the run
+  // carries on (respawn or a steal by the other worker).
   using dir = tempDir("parallel-hostile-fd3", {
-    "ok.test.js": `import {test,expect} from "bun:test"; test("ok",()=>expect(1).toBe(1));`,
-    "bad.test.js": `import {test} from "bun:test"; import {writeSync} from "fs";
+    "a-bad.test.js": `import {test} from "bun:test"; import {writeSync} from "fs";
       test("bad",()=>{ writeSync(3, Buffer.from([0xff,0xff,0xff,0xff,0x42])); });`,
+    "a-next.test.js": passing("next"),
+    "b1.test.js": passing("b1"),
+    "b2.test.js": passing("b2"),
   });
   await using proc = Bun.spawn({
     cmd: [bunExe(), "test", "--parallel=2"],
@@ -996,19 +1003,24 @@ test("--parallel: a test writing garbage to fd 3 does not hang the coordinator",
     stderr: "pipe",
     stdout: "pipe",
   });
-  const result = await Promise.race([
-    Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]),
-    Bun.sleep(15000).then(() => "TIMEOUT" as const),
-  ]);
-  expect(result).not.toBe("TIMEOUT");
-  const [stdout, stderr, exitCode] = result as [string, string, number];
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stdout).toContain("PARALLEL");
-  // ok.test.js's pass survives; bad.test.js's worker is treated as crashed
-  // once its IPC pipe is dropped — no retry, so the run is deterministically
-  // 1 pass / 1 fail. The coordinator kill(9)s the hostile worker, which on
-  // POSIX surfaces as SIGKILL (non-panic → no whole-run abort).
+  // fd 3 is the worker's IPC channel. On POSIX the coordinator's own frame
+  // decoder rejects the bytes; on Windows they break libuv's IPC framing
+  // underneath it and surface as a read error. Both must end the same way:
+  // the coordinator kills that worker and says so, rather than printing the
+  // status the kill produced (SIGKILL) or, when the kill was skipped, the
+  // "exit code 0" of a worker that later shut itself down. Writing to the
+  // channel is not a Bun crash, so the rest of the run still completes.
+  expect(stderr).toContain("a-bad.test.js (worker killed: corrupt IPC frame, something wrote to fd 3)");
+  expect(stderr).not.toContain("worker crashed");
+  expect(stderr).not.toContain("Aborting");
   expect(stderr).not.toContain("retrying");
-  expect(stderr).toContain("Ran ");
+  expect(stderr).toContain("(pass) next");
+  expect(stderr).toContain("(pass) b1");
+  expect(stderr).toContain("(pass) b2");
+  expect(stderr).toContain("\n 3 pass\n 1 fail\n");
+  expect(stderr).toContain("Ran 4 tests across 4 files.");
   expect(exitCode).toBe(1);
 });
 


### PR DESCRIPTION
### Problem
- `bun test --parallel` on Windows reports a file whose test wrote to fd 3 as `✗ bad.test.js (worker crashed: exit code 0)`. POSIX reports the same scenario as `(worker crashed: SIGKILL)`. The run is still counted as failed on both; this is the reporting of it.
- On Windows no kill happens at all. The fd 3 pipe is a libuv IPC pipe, so the raw bytes fail libuv's own frame check and reach the coordinator as a read error, never as data for `Channel::ingest`. `WindowsHandlers::on_error` (`src/runtime/cli/test/parallel/Channel.rs`) detached the pipe before signalling done, which is the shape of a clean EOF, so `Worker::on_channel_done` (`Worker.rs`, the `is_attached()` check) skipped the `kill(9)`. The coordinator then closed its end, the worker saw EOF between files and exited 0 on its own, and `reap_worker` printed that exit code.
- On POSIX the kill happens, but the line prints the status of the coordinator's own kill. `SIGKILL` reads as the OOM killer and says nothing about the actual cause.

### Fix
- `Channel` records `corrupt_frame` whenever the peer's stream stops decoding: the existing `MAX_PAYLOAD` rejection in `ingest`, plus (Windows) any non-EOF read error in `on_error`, which now signals done before detaching, the same way `ingest` does. EOF keeps the old order, detach then done, so a worker that exits on its own is still reported with its real status.
- `reap_worker` prints `(worker killed: corrupt IPC frame, something wrote to fd 3)` for such a worker instead of `(worker crashed: <status>)`. Accounting is unchanged (one failure, listed in the JUnit synthetic suite, bail still honored); a fatal signal / NTSTATUS still takes precedence and aborts the run as before.
- Why this is right: the kill decision was already keyed on "done while the transport is still attached" as the protocol-error signal. libuv rejecting a frame underneath us is the same event as our decoder rejecting one, so it has to arrive in the same shape. Once both platforms kill, the status is always one we caused, so the only useful thing to print is the cause; that also makes the output identical on every platform. `MAX_PAYLOAD`'s own doc comment names `fs.writeSync(3, ...)` from test code as the way this happens, which is what the message points at.
- Verified: `test/cli/test/parallel.test.ts` ("a test writing garbage to fd 3 gets its worker killed and the run continues"). Fails on the released build on Linux (prints `worker crashed: SIGKILL`) and on Windows (prints `worker crashed: exit code 0`, run against the canary at this PR's base commit); passes with this change on both (`bun bd test` on Linux x64 and on Windows Server 2019 x64). The test also covers that the run finishes the remaining files after the kill.
- Also run: the rest of `parallel.test.ts` on both platforms. The `exit code 7`, `--bail` crash, panic banner, fatal NTSTATUS and JUnit crashed-suite tests pass, which covers the EOF path (real status still reported) and the panic precedence. Remaining failures were unrelated to this diff: two duration-based tests on a heavily loaded Linux box, and on the Windows debug build the four tests that see the pre-existing `currentThreadIsHoldingAPILock` assertion from the worker's exit path (#37135).
- #39059 rewrites this test file; its version of this test keeps a looser Windows-only branch for the crash line, which can become the single assertion above once both land.

### Background
- `bun test --parallel` runs test files in worker processes. The coordinator talks to each worker over fd 3 with a small length-prefixed frame protocol (`Frame.rs`), carried by a `Channel` (`Channel.rs`): a usockets socketpair on POSIX, a libuv pipe on Windows.
- The Windows pipe is opened in libuv's IPC mode on both ends, so libuv wraps every write in its own frame header. Bun's frames ride inside that and pass through unchanged; bytes written to fd 3 by anything else are not wrapped and fail libuv's header validation on the reading side, which libuv reports as a read error.
- `Worker::on_channel_done` is the coordinator's hook for the channel ending. It decides between two cases: the worker is exiting (channel detached first, wait for the real exit status) or the worker is still alive but its channel is unusable (channel still attached, kill it). `reap_worker` later prints one line for the file that was running on that worker.
