### PR TITLE
Report globalThis as the target of events dispatched on the global scope

### DIFF
--- a/src/jsc/bindings/webcore/EventTargetFactory.cpp
+++ b/src/jsc/bindings/webcore/EventTargetFactory.cpp
@@ -46,7 +46,11 @@ JSC::JSValue toJS(JSC::JSGlobalObject* state, JSDOMGlobalObject* globalObject, E
     case BunWebViewEventTargetInterfaceType:
         return Bun::toJS(state, globalObject, static_cast<Bun::WebViewEventTarget&>(impl));
     case DOMWindowEventTargetInterfaceType:
-        return globalObject;
+        // GlobalEventScope is the EventTarget behind globalThis.addEventListener(). Script sees the
+        // global as its JSGlobalProxy, so event.target / currentTarget / listener `this` must be
+        // that proxy; the JSGlobalObject cell itself is never === globalThis and JSValue::toThis
+        // turns it into undefined in strict-mode listeners.
+        return globalObject->globalThis();
     case MessagePortEventTargetInterfaceType:
         return toJS(state, globalObject, static_cast<MessagePort&>(impl));
     case WebSocketEventTargetInterfaceType:

--- a/test/js/web/web-globals.test.js
+++ b/test/js/web/web-globals.test.js
@@ -84,6 +84,69 @@ for (const [Constructor, name, eventName, prop] of globalSetters) {
   });
 }
 
+// An event dispatched on the global scope reports globalThis (the global proxy, the only form of
+// the global that script can hold) as its target, and listeners are called with it as `this`.
+// This file is a module, so a `this` of the bare global object cell would show up as undefined.
+function describeGlobalEvent(thisValue, event) {
+  return {
+    this: thisValue === globalThis,
+    target: event.target === self,
+    currentTarget: event.currentTarget === globalThis,
+    srcElement: event.srcElement === globalThis,
+    composedPath: event.composedPath().map(node => node === globalThis),
+  };
+}
+
+test("addEventListener on the global scope: target, currentTarget and this are globalThis", () => {
+  const seen = [];
+  const listener = function (event) {
+    seen.push(describeGlobalEvent(this, event));
+  };
+  const event = new Event("global-target");
+  try {
+    addEventListener("global-target", listener);
+    dispatchEvent(event);
+  } finally {
+    removeEventListener("global-target", listener);
+  }
+  expect(seen).toEqual([{ this: true, target: true, currentTarget: true, srcElement: true, composedPath: [true] }]);
+  // After dispatch, currentTarget and the path are cleared but target is kept.
+  expect([event.target === globalThis, event.currentTarget, event.composedPath()]).toEqual([true, null, []]);
+});
+
+test("addEventListener on the global scope with a handleEvent object: this is the object, currentTarget is globalThis", () => {
+  const seen = [];
+  const listener = {
+    handleEvent(event) {
+      seen.push({ thisIsListener: this === listener, ...describeGlobalEvent(globalThis, event) });
+    },
+  };
+  try {
+    addEventListener("global-target", listener);
+    dispatchEvent(new Event("global-target"));
+  } finally {
+    removeEventListener("global-target", listener);
+  }
+  expect(seen).toEqual([
+    { thisIsListener: true, this: true, target: true, currentTarget: true, srcElement: true, composedPath: [true] },
+  ]);
+});
+
+for (const [Constructor, name, eventName] of globalSetters) {
+  test(`self.${name}: target, currentTarget and this are globalThis`, () => {
+    const seen = [];
+    try {
+      globalThis[name] = function (event) {
+        seen.push(describeGlobalEvent(this, event));
+      };
+      dispatchEvent(new Constructor(eventName));
+    } finally {
+      globalThis[name] = null;
+    }
+    expect(seen).toEqual([{ this: true, target: true, currentTarget: true, srcElement: true, composedPath: [true] }]);
+  });
+}
+
 // Assigning onmessage/onerror through a receiver that is not the global object
 // (e.g. a Proxy of globalThis) used to crash with a type confusion.
 test.concurrent("onmessage/onerror assignment through a Proxy of globalThis", async () => {

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -371,6 +371,73 @@ describe("web worker", () => {
     });
   });
 
+  // The events the runtime dispatches on a worker's own global scope report `self` as their
+  // target and call the handler with `self` as `this`, as in browsers. Worker sources are
+  // modules, so a `this` of the bare global object cell would show up as undefined.
+  describe("events dispatched on the worker's global scope", () => {
+    const describeEvent = `
+      function describeEvent(thisValue, event) {
+        return {
+          type: event.type,
+          this: thisValue === self,
+          target: event.target === self,
+          currentTarget: event.currentTarget === globalThis,
+        };
+      }`;
+
+    test("message from the parent's postMessage(): self.onmessage", async () => {
+      const worker = new Worker(
+        URL.createObjectURL(
+          new Blob([
+            `${describeEvent}
+            onmessage = function (event) {
+              postMessage({ ...describeEvent(this, event), data: event.data });
+            };`,
+          ]),
+        ),
+      );
+      worker.postMessage("ping");
+      const [{ data }] = await once(worker, "message");
+      worker.terminate();
+      expect(data).toEqual({ type: "message", this: true, target: true, currentTarget: true, data: "ping" });
+    });
+
+    test("message from the parent's postMessage(): addEventListener", async () => {
+      const worker = new Worker(
+        URL.createObjectURL(
+          new Blob([
+            `${describeEvent}
+            addEventListener("message", function (event) {
+              postMessage({ ...describeEvent(this, event), data: event.data });
+            });`,
+          ]),
+        ),
+      );
+      worker.postMessage("ping");
+      const [{ data }] = await once(worker, "message");
+      worker.terminate();
+      expect(data).toEqual({ type: "message", this: true, target: true, currentTarget: true, data: "ping" });
+    });
+
+    test("error from an uncaught exception in the worker", async () => {
+      const worker = new Worker(
+        URL.createObjectURL(
+          new Blob([
+            `${describeEvent}
+            addEventListener("error", function (event) {
+              postMessage({ ...describeEvent(this, event), error: event.error.message });
+            });
+            throw new Error("boom");`,
+          ]),
+        ),
+      );
+      // The worker's own listener runs first; the error is then reported to this Worker object too.
+      const [[{ data }], [reported]] = await Promise.all([once(worker, "message"), once(worker, "error")]);
+      expect(data).toEqual({ type: "error", this: true, target: true, currentTarget: true, error: "boom" });
+      expect(reported.type).toBe("error");
+    });
+  });
+
   describe("terminate() races and lifecycle edges", () => {
     // A vm timeout inside a worker is a transient termination of that VM; it
     // must not leave the worker unable to run script (parent messages dropped).


### PR DESCRIPTION
### Problem

- Inside a worker, `onmessage = function (e) {}` (same for `addEventListener("message", ...)` and the worker-global `error` event) sees `e.currentTarget !== self`, `e.target !== self`, and `this === undefined` when the worker file is a module. The main thread has the same problem with `dispatchEvent(new Event("x"))` on the global. In browsers all three are `self`.
  ```js
  onmessage = function (e) {
    postMessage([e.currentTarget === self, e.target === self, this === self]);
  };
  // bun: [false, false, false]   browsers: [true, true, true]
  ```
- Cause: `toJS(JSGlobalObject*, JSDOMGlobalObject*, EventTarget&)` in `src/jsc/bindings/webcore/EventTargetFactory.cpp:49` returns `globalObject`, the `JSGlobalObject` cell itself, for `DOMWindowEventTargetInterfaceType`, which is the interface `Bun::GlobalEventScope` declares (`src/jsc/bindings/GlobalEventScope.h:40`). Script never holds that cell: `globalThis`, `self` and `global` are all the global's `JSGlobalProxy` (`functionGetSelf` and `GlobalObject_getGlobalThis` in `ZigGlobalObject.cpp` return `globalThis()`), so identity checks against it fail, and `JSValue::toThis` maps the cell to `undefined` in strict code (to `globalThis` in sloppy code, which is why a `.cjs` worker gets the right `this` but still the wrong `currentTarget`).
- Every JS-visible form of the global's event target goes through that line: `event.target`, `event.currentTarget`, `event.srcElement`, `event.composedPath()` (`JSEvent.cpp`) and the `this` value listeners are called with (`JSEventListener::handleEvent`, `src/jsc/bindings/webcore/JSEventListener.cpp:217`).

### Fix

- Return `globalObject->globalThis()`, the `JSGlobalProxy`, instead of `globalObject` in that case.
- Correct because that proxy is the one object Bun already hands to script as `globalThis` / `self` / `global`, so the target is `===` to them and passes through `toThis` unchanged in both strict and sloppy listeners. It is also what upstream WebKit's factory does for its globals: a `DOMWindow` target converts to its `JSWindowProxy`, a `WorkerGlobalScope` target to the scope wrapper's `proxy()`.
- `globalObject` is the right global to take the proxy from: each `Zig::GlobalObject` owns exactly one `ScriptExecutionContext` and one `GlobalEventScope` (`ZigGlobalObject.cpp:1047-1048`), and both callers pass that global (the `JSEvent` getters pass the event wrapper's global, `JSEventListener` the dispatching target's context global).
- Nothing downcasts the value this returns, and the JS to native direction (`jsEventTargetCast`, `toJSDOMGlobalObject<>()`) already unwraps `GlobalProxyType`, so passing `e.currentTarget` back into `EventTarget.prototype.*` works. `JSEventTarget::toWrapped` (inspector only) matched neither form before and is unchanged.
- Verified:
  - `test/js/web/web-globals.test.js`: `dispatchEvent()` on the main-thread global with a function listener, a `handleEvent` object, and the `onmessage` / `onerror` attributes, checking `this`, `target`, `currentTarget`, `srcElement`, `composedPath()`, and `target` after dispatch. The 4 new tests fail on main and pass with the fix.
  - `test/js/web/workers/worker.test.ts`: the two places the runtime itself dispatches on a worker's global scope, `message` (`WorkerMessagingProxy::drainMessagesToWorkerGlobalScope`, via `onmessage` and via `addEventListener`) and `error` from an uncaught exception (`WebWorker__dispatchError`). The 3 new tests fail on main and pass with the fix.
  - With the fix, also green: `test/js/deno/event/`, `test/js/web/broadcastchannel/`, `workers/message-event.test.ts`, `workers/worker_blob.test.ts`, `bun/util/inspect.test.js`, and node's `test-eventtarget.js`, `test-whatwg-events-*.js`, `test-events-customevent.js`. The pre-existing tests in `worker.test.ts` with 1 s / 30 ms wall-clock budgets timed out on the loaded debug+ASAN machine used here; their fixtures pass when run directly against the fixed build.

### Background

- `JSGlobalProxy`: JSC does not expose a `JSGlobalObject` to script. `JSGlobalObject::init` creates a `JSGlobalProxy` that forwards property access to the global and installs it as the value of `globalThis`; the proxy and the global cell are two distinct objects as far as `===` is concerned.
- `JSValue::toThis` (`JSCJSValueInlines.h`): the conversion JSC applies to the `this` argument of a call. A `JSScope`-derived object, which every `JSGlobalObject` is, becomes `globalThis` in sloppy code and `undefined` in strict code; any other object is passed through as is.
- `GlobalEventScope` (`src/jsc/bindings/GlobalEventScope.h`): the `EventTarget` behind the global's `addEventListener` / `dispatchEvent` / `onmessage` / `onerror`, one per `Zig::GlobalObject`. Worker `message` events (`WorkerMessagingProxy.cpp`) and the worker-global `error` event (`Worker.cpp`) are dispatched on it.
- `EventTargetFactory.cpp`: WebCore's switch from an `EventTarget&` to its JS value by interface type. Bun's trimmed copy uses the `DOMWindow` slot for `GlobalEventScope`.
