### PR TITLE
event loop: run the rest of a setImmediate batch from a tick nested inside one of its callbacks

### DIFF
--- a/src/event_loop/README.md
+++ b/src/event_loop/README.md
@@ -16,10 +16,10 @@ A tagged pointer union containing various async task types (file I/O, network re
 
 Two separate queues for `setImmediate()`:
 
-- **`immediate_tasks`**: Tasks to run on the current tick
-- **`next_immediate_tasks`**: Tasks to run on the next tick
+- **`immediate_tasks`**: What `setImmediate()` queued since the last immediates phase
+- **`immediate_batch`** (+ `immediate_batch_next`): The batch the current immediates phase is running
 
-This prevents infinite loops when `setImmediate` is called within a `setImmediate` callback.
+Each `tickImmediateTasks()` swaps the queued callbacks into the batch and runs the batch, so a `setImmediate` called from a `setImmediate` callback waits for the next loop iteration instead of extending the current phase forever. The batch lives on the loop so that a callback which runs the loop itself (`expect().resolves`, `waitForPromise`) continues the same batch: the callbacks queued alongside it still run while it waits.
 
 ### 3. Concurrent Task Queue (`event_loop.rs:17`)
 

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1214,10 +1214,8 @@ impl VirtualMachine {
     }
 
     pub fn is_event_loop_alive(&self) -> bool {
-        let el = self.event_loop_shared();
         self.is_event_loop_alive_excluding_immediates()
-            || !el.immediate_tasks.is_empty()
-            || !el.next_immediate_tasks.is_empty()
+            || self.event_loop_shared().has_pending_immediates()
     }
 
     pub fn wakeup(&mut self) {

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -50,22 +50,31 @@ pub struct EventLoop {
     /// releases instead of parking (nothing will tick this loop again).
     closed_for_tasks: bool,
 
-    /// setImmediate() gets it's own two task queues
-    /// When you call `setImmediate` in JS, it queues to the start of the next tick
-    /// This is confusing, but that is how it works in Node.js.
+    /// setImmediate() gets its own two task queues.
     ///
-    /// So we have two queues:
-    ///   - next_immediate_tasks: tasks that will run on the next tick
-    ///   - immediate_tasks: tasks that will run on the current tick
+    /// `setImmediate` pushes onto `immediate_tasks`; each loop iteration
+    /// (`tick_immediate_tasks`) moves everything queued so far into
+    /// `immediate_batch` and runs that batch, so what the callbacks queue waits
+    /// for the next iteration, as in Node.js (and a `setImmediate` inside a
+    /// `setImmediate` callback cannot keep the iteration going forever).
     ///
-    /// Having two queues avoids infinite loops creating by calling `setImmediate` in a `setImmediate` callback.
+    /// The batch lives on the loop, not on the ticking frame's stack, because
+    /// a callback can tick the loop itself (`wait_for_promise` under
+    /// `expect(..).resolves`, an async `Bun.build` plugin setup, ...): that
+    /// nested tick continues this batch from `immediate_batch_next`, so the
+    /// callbacks queued alongside the waiting one (the ones that settle what
+    /// it waits for) run instead of sitting behind it until it returns. Between
+    /// ticks the batch is empty.
     ///
     /// Note (§Dispatch): payload is `*mut ()` — the real
     /// `bun_runtime::timer::ImmediateObject` lives in the higher-tier crate
     /// (cycle). Low tier stores the erased pointer; the high-tier hook
     /// (link-time `__bun_run_immediate_task`) casts it back.
-    pub immediate_tasks: Vec<*mut ()>,
-    pub next_immediate_tasks: Vec<*mut ()>,
+    immediate_tasks: Vec<*mut ()>,
+    immediate_batch: Vec<*mut ()>,
+    /// Index into `immediate_batch` of the next callback to run; the ones
+    /// before it have run (or are running, further up the stack).
+    immediate_batch_next: usize,
     /// Tasks that asked to run on the *next* loop iteration — after I/O and
     /// timers have had a turn — rather than in the current drain, which runs
     /// until the queue is empty (a task that re-posts itself there never lets
@@ -120,7 +129,8 @@ impl Default for EventLoop {
             tasks: Queue::init(),
             closed_for_tasks: false,
             immediate_tasks: Vec::new(),
-            next_immediate_tasks: Vec::new(),
+            immediate_batch: Vec::new(),
+            immediate_batch_next: 0,
             yield_tasks: Vec::new(),
             concurrent_tasks: ConcurrentQueue::default(),
             isolated_poster: None,
@@ -814,13 +824,21 @@ impl EventLoop {
     /// immediate's keep-alive on this loop, so the loop must still exist.
     fn release_pending_immediates(&mut self) {
         let pending = core::mem::take(&mut self.immediate_tasks);
-        let next = core::mem::take(&mut self.next_immediate_tasks);
-        if !pending.is_empty() || !next.is_empty() {
-            let vm = self.vm();
-            for task in pending.into_iter().chain(next) {
-                // SAFETY: `task` came from `enqueue_immediate_task`; `vm` is the live per-thread VM.
-                unsafe { __bun_cancel_pending_immediate(task, vm) };
-            }
+        // Teardown entered from a callback of the batch being run
+        // (`process.exit()` inside a setImmediate): the rest of that batch is
+        // pending too, and taking the batch ends the tick further up the stack.
+        let mut batch = core::mem::take(&mut self.immediate_batch);
+        let next = core::mem::take(&mut self.immediate_batch_next);
+        if pending.is_empty() && next >= batch.len() {
+            // Nothing to cancel; also the state of a loop nothing was ever queued
+            // on (the macro loop, normally), which has no `vm()` backref to read.
+            return;
+        }
+        let vm = self.vm();
+        for task in pending.into_iter().chain(batch.drain(next..)) {
+            // SAFETY: `task` came from `enqueue_immediate_task` and has not been
+            // handed to `__bun_run_immediate_task`; `vm` is the live per-thread VM.
+            unsafe { __bun_cancel_pending_immediate(task, vm) };
         }
     }
 
@@ -833,7 +851,7 @@ impl EventLoop {
             "queued tasks must be released (release_queued_tasks) before the loop is destroyed"
         );
         debug_assert!(
-            self.immediate_tasks.is_empty() && self.next_immediate_tasks.is_empty(),
+            self.immediate_tasks.is_empty() && self.immediate_batch.is_empty(),
             "pending immediates must be released (release_queued_tasks) while the loop is alive"
         );
         self.tasks = Queue::init();
@@ -849,6 +867,13 @@ impl EventLoop {
     /// `*mut bun_runtime::timer::ImmediateObject` — see [`RunImmediateFn`].
     pub fn enqueue_immediate_task(&mut self, task: *mut ()) {
         self.immediate_tasks.push(task);
+    }
+
+    /// Whether a `tick_immediate_tasks` has callbacks to run: queued for the
+    /// next iteration, or left of the batch a tick up the stack is running.
+    /// A poll before it must not block.
+    pub fn has_pending_immediates(&self) -> bool {
+        !self.immediate_tasks.is_empty() || self.immediate_batch_next < self.immediate_batch.len()
     }
 
     /// See [`EventLoop::yield_tasks`].
@@ -871,16 +896,20 @@ impl EventLoop {
         true
     }
 
-    /// `tickImmediateTasks` — swaps the two
-    /// immediate queues, drains the now-current batch, then recycles the
-    /// drained Vec as the next-tick buffer.
+    /// `tickImmediateTasks` — the immediates phase of one loop iteration: runs
+    /// one batch (see `immediate_tasks`) and returns with it empty.
+    ///
+    /// The batch is what `setImmediate` queued before this call, unless a tick
+    /// further up the stack is still running one (a callback of it ticked the
+    /// loop: `wait_for_promise`): then this call runs the rest of that batch,
+    /// in queue order, and the outer tick finds nothing left when its callback
+    /// returns. Either way what the callbacks queue runs on a later iteration,
+    /// and the poll that follows does not block while any of it is queued
+    /// ([`Self::has_pending_immediates`]).
     ///
     /// Note: the real `ImmediateObject` lives in `bun_runtime` (cycle), so
     /// the per-task body dispatches through `__bun_run_immediate_task` (link-
-    /// time, definer in `bun_runtime`). The swap always happens — this is
-    /// load-bearing for `auto_tick`'s `has_pending_immediate` read, which must
-    /// observe the post-swap `immediate_tasks` (next-tick immediates), not the
-    /// un-drained current batch (busy-spin hazard).
+    /// time, definer in `bun_runtime`).
     ///
     /// # Safety
     /// `virtual_machine` must be the live per-thread VM that owns this `EventLoop`.
@@ -890,29 +919,48 @@ impl EventLoop {
         // the only thing reaching the `__bun_run_immediate_task` extern call is
         // `virtual_machine` — a *separate* pointer parameter that LLVM is told
         // does NOT alias `*self` (even though `EventLoop` is a value field of
-        // `*virtual_machine`). JS re-enters via `setImmediate` →
-        // `enqueue_immediate_task` and pushes onto `self.next_immediate_tasks`.
-        // Without the launder, LLVM may forward the post-`take` empty
-        // `next_immediate_tasks` past the loop into the `.capacity() > 0`
-        // recursion check and the trailing `= to_run_now` store, dropping any
-        // immediates JS queued during this tick. ASM-verified PROVEN_CACHED.
-        let this: *mut Self = core::hint::black_box(core::ptr::from_mut(self));
-        // SAFETY: `this` is the unique live `EventLoop`; each access below is a
-        // short-lived `&mut` that does not overlap re-entry.
-        let mut to_run_now = core::mem::take(unsafe { &mut (*this).immediate_tasks });
-        // SAFETY: as above.
-        unsafe { (*this).immediate_tasks = core::mem::take(&mut (*this).next_immediate_tasks) };
+        // `*virtual_machine`). Through it the callback re-enters this loop:
+        // `setImmediate` pushes onto `immediate_tasks`, and a nested tick
+        // advances `immediate_batch_next` or replaces `immediate_batch`. Every
+        // read below must observe that, so all of them go through the
+        // laundered `this`, re-laundered after each callback so nothing read
+        // before it is carried across.
+        let mut this: *mut Self = core::hint::black_box(core::ptr::from_mut(self));
+
+        // SAFETY: `this` is the live `EventLoop`; the borrow ends before any
+        // callback runs.
+        unsafe {
+            let el = &mut *this;
+            if el.immediate_batch_next >= el.immediate_batch.len() {
+                // Nothing left of a batch up the stack (at most the callback we
+                // are inside of, already handed out): this iteration's batch is
+                // everything queued so far, and the cleared batch buffer becomes
+                // the queue for what its callbacks queue.
+                el.immediate_batch.clear();
+                core::mem::swap(&mut el.immediate_batch, &mut el.immediate_tasks);
+                el.immediate_batch_next = 0;
+            }
+        }
 
         let mut exception_thrown = false;
-        for task in to_run_now.iter() {
+        loop {
+            // SAFETY: as above.
+            let task = unsafe {
+                let el = &mut *this;
+                let Some(&task) = el.immediate_batch.get(el.immediate_batch_next) else {
+                    break;
+                };
+                el.immediate_batch_next += 1;
+                task
+            };
             // SAFETY: ImmediateObject pointers are kept alive by the JS heap
-            // until `__bun_run_immediate_task` consumes them; `virtual_machine` is the
-            // live owning VM per caller contract.
-            exception_thrown = unsafe { __bun_run_immediate_task(*task, virtual_machine) };
+            // until `__bun_run_immediate_task` consumes them, and each batch entry
+            // is handed to it exactly once (the index advanced above, before the
+            // callback could tick the loop); `virtual_machine` is the live owning
+            // VM per caller contract.
+            exception_thrown = unsafe { __bun_run_immediate_task(task, virtual_machine) };
+            this = core::hint::black_box(this);
         }
-        // Re-escape `this` after the re-entrant loop so nothing about `*this`
-        // is carried across it.
-        let this: *mut Self = core::hint::black_box(this);
 
         // make sure microtasks are drained if the last task had an exception
         if exception_thrown {
@@ -920,26 +968,19 @@ impl EventLoop {
             let _ = unsafe { (*this).maybe_drain_microtasks() };
         }
 
-        // SAFETY: as above; this read MUST observe pushes JS made during the
-        // loop (the recursion check).
-        if unsafe { (*this).next_immediate_tasks.capacity() } > 0 {
-            // this would only occur if we were recursively running tickImmediateTasks.
-            bun_core::hint::cold();
-            // SAFETY: as above.
-            let next = core::mem::take(unsafe { &mut (*this).next_immediate_tasks });
-            // SAFETY: as above.
-            unsafe { (*this).immediate_tasks.extend_from_slice(&next) };
-        }
-
-        if to_run_now.capacity() > 1024 * 128 {
-            // once in a while, deinit the array to free up memory
-            to_run_now = Vec::new();
-        } else {
-            to_run_now.clear();
-        }
-
+        // The batch is done (by this tick, or a nested one that ran the rest of
+        // it and already emptied it). Keep the buffer for the next swap.
         // SAFETY: as above.
-        unsafe { (*this).next_immediate_tasks = to_run_now };
+        unsafe {
+            let el = &mut *this;
+            if el.immediate_batch.capacity() > 1024 * 128 {
+                // once in a while, deinit the array to free up memory
+                el.immediate_batch = Vec::new();
+            } else {
+                el.immediate_batch.clear();
+            }
+            el.immediate_batch_next = 0;
+        }
     }
 
     pub fn ensure_waker(&mut self) {

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -50,30 +50,20 @@ pub struct EventLoop {
     /// releases instead of parking (nothing will tick this loop again).
     closed_for_tasks: bool,
 
-    /// setImmediate() gets its own two task queues.
-    ///
-    /// `setImmediate` pushes onto `immediate_tasks`; each loop iteration
-    /// (`tick_immediate_tasks`) moves everything queued so far into
-    /// `immediate_batch` and runs that batch, so what the callbacks queue waits
-    /// for the next iteration, as in Node.js (and a `setImmediate` inside a
-    /// `setImmediate` callback cannot keep the iteration going forever).
-    ///
-    /// The batch lives on the loop, not on the ticking frame's stack, because
-    /// a callback can tick the loop itself (`wait_for_promise` under
-    /// `expect(..).resolves`, an async `Bun.build` plugin setup, ...): that
-    /// nested tick continues this batch from `immediate_batch_next`, so the
-    /// callbacks queued alongside the waiting one (the ones that settle what
-    /// it waits for) run instead of sitting behind it until it returns. Between
-    /// ticks the batch is empty.
+    /// `setImmediate` queues here; `tick_immediate_tasks` swaps the queue into
+    /// `immediate_batch` and runs the batch, so what a callback queues runs on
+    /// the next iteration, as in Node.js.
     ///
     /// Note (§Dispatch): payload is `*mut ()` — the real
     /// `bun_runtime::timer::ImmediateObject` lives in the higher-tier crate
     /// (cycle). Low tier stores the erased pointer; the high-tier hook
     /// (link-time `__bun_run_immediate_task`) casts it back.
     immediate_tasks: Vec<*mut ()>,
+    /// The batch being run, `immediate_batch_next` being the next entry to run.
+    /// On the loop rather than on the ticking frame's stack so that a callback
+    /// which ticks the loop itself (`wait_for_promise`) runs the rest of its
+    /// batch. Empty between ticks.
     immediate_batch: Vec<*mut ()>,
-    /// Index into `immediate_batch` of the next callback to run; the ones
-    /// before it have run (or are running, further up the stack).
     immediate_batch_next: usize,
     /// Tasks that asked to run on the *next* loop iteration — after I/O and
     /// timers have had a turn — rather than in the current drain, which runs
@@ -824,20 +814,18 @@ impl EventLoop {
     /// immediate's keep-alive on this loop, so the loop must still exist.
     fn release_pending_immediates(&mut self) {
         let pending = core::mem::take(&mut self.immediate_tasks);
-        // Teardown entered from a callback of the batch being run
-        // (`process.exit()` inside a setImmediate): the rest of that batch is
-        // pending too, and taking the batch ends the tick further up the stack.
+        // The batch is non-empty when teardown was entered from one of its
+        // callbacks (`process.exit()` inside a setImmediate).
         let mut batch = core::mem::take(&mut self.immediate_batch);
         let next = core::mem::take(&mut self.immediate_batch_next);
         if pending.is_empty() && next >= batch.len() {
-            // Nothing to cancel; also the state of a loop nothing was ever queued
-            // on (the macro loop, normally), which has no `vm()` backref to read.
+            // An unused loop (the macro loop) has no `vm()` backref.
             return;
         }
         let vm = self.vm();
         for task in pending.into_iter().chain(batch.drain(next..)) {
-            // SAFETY: `task` came from `enqueue_immediate_task` and has not been
-            // handed to `__bun_run_immediate_task`; `vm` is the live per-thread VM.
+            // SAFETY: `task` came from `enqueue_immediate_task` and was never run;
+            // `vm` is the live per-thread VM.
             unsafe { __bun_cancel_pending_immediate(task, vm) };
         }
     }
@@ -869,9 +857,8 @@ impl EventLoop {
         self.immediate_tasks.push(task);
     }
 
-    /// Whether a `tick_immediate_tasks` has callbacks to run: queued for the
-    /// next iteration, or left of the batch a tick up the stack is running.
-    /// A poll before it must not block.
+    /// Whether the next `tick_immediate_tasks` has callbacks to run (queued, or
+    /// left of a batch a tick up the stack is running): a poll must not block.
     pub fn has_pending_immediates(&self) -> bool {
         !self.immediate_tasks.is_empty() || self.immediate_batch_next < self.immediate_batch.len()
     }
@@ -896,16 +883,9 @@ impl EventLoop {
         true
     }
 
-    /// `tickImmediateTasks` — the immediates phase of one loop iteration: runs
-    /// one batch (see `immediate_tasks`) and returns with it empty.
-    ///
-    /// The batch is what `setImmediate` queued before this call, unless a tick
-    /// further up the stack is still running one (a callback of it ticked the
-    /// loop: `wait_for_promise`): then this call runs the rest of that batch,
-    /// in queue order, and the outer tick finds nothing left when its callback
-    /// returns. Either way what the callbacks queue runs on a later iteration,
-    /// and the poll that follows does not block while any of it is queued
-    /// ([`Self::has_pending_immediates`]).
+    /// `tickImmediateTasks` — runs the batch a tick up the stack is still in
+    /// (a callback of it ticked the loop: `wait_for_promise`), else everything
+    /// `setImmediate` has queued. Returns with the batch empty either way.
     ///
     /// Note: the real `ImmediateObject` lives in `bun_runtime` (cycle), so
     /// the per-task body dispatches through `__bun_run_immediate_task` (link-
@@ -919,23 +899,16 @@ impl EventLoop {
         // the only thing reaching the `__bun_run_immediate_task` extern call is
         // `virtual_machine` — a *separate* pointer parameter that LLVM is told
         // does NOT alias `*self` (even though `EventLoop` is a value field of
-        // `*virtual_machine`). Through it the callback re-enters this loop:
-        // `setImmediate` pushes onto `immediate_tasks`, and a nested tick
-        // advances `immediate_batch_next` or replaces `immediate_batch`. Every
-        // read below must observe that, so all of them go through the
-        // laundered `this`, re-laundered after each callback so nothing read
-        // before it is carried across.
+        // `*virtual_machine`). The callback reaches this loop through it
+        // (`setImmediate`, a nested tick), so every field is re-read through the
+        // laundered `this`, re-laundered after each callback.
         let mut this: *mut Self = core::hint::black_box(core::ptr::from_mut(self));
 
-        // SAFETY: `this` is the live `EventLoop`; the borrow ends before any
-        // callback runs.
+        // SAFETY: `this` is the live `EventLoop`; no borrow of it spans a callback.
         unsafe {
             let el = &mut *this;
             if el.immediate_batch_next >= el.immediate_batch.len() {
-                // Nothing left of a batch up the stack (at most the callback we
-                // are inside of, already handed out): this iteration's batch is
-                // everything queued so far, and the cleared batch buffer becomes
-                // the queue for what its callbacks queue.
+                // Not nested (or the outer tick is on its last entry: us).
                 el.immediate_batch.clear();
                 core::mem::swap(&mut el.immediate_batch, &mut el.immediate_tasks);
                 el.immediate_batch_next = 0;
@@ -953,11 +926,9 @@ impl EventLoop {
                 el.immediate_batch_next += 1;
                 task
             };
-            // SAFETY: ImmediateObject pointers are kept alive by the JS heap
-            // until `__bun_run_immediate_task` consumes them, and each batch entry
-            // is handed to it exactly once (the index advanced above, before the
-            // callback could tick the loop); `virtual_machine` is the live owning
-            // VM per caller contract.
+            // SAFETY: the index was advanced before the callback can tick the loop,
+            // so each ImmediateObject (alive until run) is run exactly once;
+            // `virtual_machine` is the live owning VM per caller contract.
             exception_thrown = unsafe { __bun_run_immediate_task(task, virtual_machine) };
             this = core::hint::black_box(this);
         }
@@ -968,8 +939,6 @@ impl EventLoop {
             let _ = unsafe { (*this).maybe_drain_microtasks() };
         }
 
-        // The batch is done (by this tick, or a nested one that ran the rest of
-        // it and already emptied it). Keep the buffer for the next swap.
         // SAFETY: as above.
         unsafe {
             let el = &mut *this;

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -967,8 +967,8 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
     let loop_ = unsafe { (*el).usockets_loop() };
 
     // ── tick_immediate_tasks ────────────────────────────────────────────
-    // After this call only next-iteration immediates are pending, which is
-    // what the `has_pending_immediate` read below must reflect.
+    // `has_pending_immediate` below is read after this, so it covers what the
+    // batch queued.
     // SAFETY: `el` is the live per-thread event loop; `vm` per fn contract.
     unsafe { (*el).tick_immediate_tasks(vm) };
     // SAFETY: as above.
@@ -1033,8 +1033,6 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
     // due `WTFTimer` heap entries), so it must stay guarded by `is_active()`
     // rather than running unconditionally.
     {
-        // Read AFTER `tick_immediate_tasks` above, so this reflects the
-        // immediates queued during it (which run on the next iteration).
         // SAFETY: `el` is the live per-thread event loop.
         let has_pending_immediate = has_yielded_tasks
             || unsafe { &*el }.has_pending_immediates()

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -967,14 +967,14 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
     let loop_ = unsafe { (*el).usockets_loop() };
 
     // ── tick_immediate_tasks ────────────────────────────────────────────
-    // After this call `immediate_tasks` reflects next-tick immediates, so
-    // the `has_pending_immediate` read below is correct.
+    // After this call only next-iteration immediates are pending, which is
+    // what the `has_pending_immediate` read below must reflect.
     // SAFETY: `el` is the live per-thread event loop; `vm` per fn contract.
     unsafe { (*el).tick_immediate_tasks(vm) };
     // SAFETY: as above.
     let has_yielded_tasks = unsafe { (*el).promote_yield_tasks() };
     #[cfg(windows)]
-    if has_yielded_tasks || !unsafe { &*el }.immediate_tasks.is_empty() {
+    if has_yielded_tasks || unsafe { &*el }.has_pending_immediates() {
         // SAFETY: `el` is the live per-thread event loop.
         unsafe { (*el).wakeup() };
     }
@@ -1033,13 +1033,11 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
     // due `WTFTimer` heap entries), so it must stay guarded by `is_active()`
     // rather than running unconditionally.
     {
-        // Read `immediate_tasks` AFTER
-        // `tickImmediateTasks` swaps `next_immediate_tasks` in, so this
-        // reflects next-tick immediates (queued during the drain above).
-        // SAFETY: `el` is the live per-thread event loop.
+        // Read AFTER `tick_immediate_tasks` above, so this reflects the
+        // immediates queued during it (which run on the next iteration).
         // SAFETY: `el` is the live per-thread event loop.
         let has_pending_immediate = has_yielded_tasks
-            || !unsafe { &*el }.immediate_tasks.is_empty()
+            || unsafe { &*el }.has_pending_immediates()
             || unsafe { &*el }.has_pending_tasks();
         // Fold the QUIC deadline into the poll timeout.
         // SAFETY: `loop_` is the live per-thread uws loop.
@@ -1135,7 +1133,7 @@ unsafe fn auto_tick_active(vm: *mut VirtualMachine) {
     // SAFETY: as above.
     let has_yielded_tasks = unsafe { (*el).promote_yield_tasks() };
     #[cfg(windows)]
-    if has_yielded_tasks || !unsafe { &*el }.immediate_tasks.is_empty() {
+    if has_yielded_tasks || unsafe { &*el }.has_pending_immediates() {
         // SAFETY: `el` is the live per-thread event loop.
         unsafe { (*el).wakeup() };
     }
@@ -1175,9 +1173,8 @@ unsafe fn auto_tick_active(vm: *mut VirtualMachine) {
 
     {
         // SAFETY: `el` is the live per-thread event loop.
-        // SAFETY: `el` is the live per-thread event loop.
         let has_pending_immediate = has_yielded_tasks
-            || !unsafe { &*el }.immediate_tasks.is_empty()
+            || unsafe { &*el }.has_pending_immediates()
             || unsafe { &*el }.has_pending_tasks();
         // SAFETY: `loop_` is the live per-thread uws loop.
         let quic_next_tick_us = unsafe {

--- a/src/runtime/timer/mod.rs
+++ b/src/runtime/timer/mod.rs
@@ -961,7 +961,7 @@ impl All {
     ///
     /// Note (b2): `vm` is erased per §Dispatch (the caller is in
     /// `bun_jsc::event_loop` which can't name `bun_runtime`). The two reads
-    /// it needs — `event_loop.immediate_tasks.len()` and the QUIC tick — are
+    /// it needs — `event_loop.has_pending_immediates()` and the QUIC tick — are
     /// passed in pre-computed until the cycle is broken.
     ///
     /// # Safety

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -3,7 +3,7 @@ import { spawn, spawnSync } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, test } from "bun:test";
 import { copyFileSync, mkdirSync, realpathSync, rmSync, writeFileSync } from "fs";
 import { rm, writeFile } from "fs/promises";
-import { bunEnv, bunExe, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir, tmpdirSync } from "harness";
 import { tmpdir } from "os";
 import { dirname, join } from "path";
 
@@ -748,4 +748,88 @@ test("my-test", () => {
       expect(output).toContain("Ran 1 test across 1 file");
     });
   }
+});
+
+// The matchers that wait for a promise do so by running the event loop from
+// inside the caller. Called from a setImmediate callback, they must still see
+// the callbacks queued in the same batch, which is what settles the promise.
+test("a matcher waiting on a promise inside setImmediate sees the sibling immediate that settles it", async () => {
+  const code = /*ts*/ `
+import { expect, test } from "bun:test";
+
+expect.extend({
+  async toEventuallyBe(received: Promise<unknown>, expected: unknown) {
+    const value = await received;
+    return { pass: value === expected, message: () => \`expected \${String(value)} to be \${String(expected)}\` };
+  },
+});
+
+// Queues two immediates in one batch: the first blocks on the matcher, the
+// second is the only thing that settles the promise the matcher waits for.
+// Resolves, once the matcher has returned, with the order the callbacks ran in.
+function matcherSettledBySiblingImmediate(
+  matcher: (promise: Promise<string>) => void,
+  settle: (p: PromiseWithResolvers<string>) => void,
+): Promise<string[]> {
+  const pending = Promise.withResolvers<string>();
+  const order: string[] = [];
+  return new Promise(finish => {
+    setImmediate(() => {
+      order.push("matcher:start");
+      matcher(pending.promise);
+      order.push("matcher:end");
+      finish(order);
+    });
+    setImmediate(() => {
+      order.push("sibling");
+      settle(pending);
+    });
+  });
+}
+
+const cases: Record<string, [(promise: Promise<string>) => void, (p: PromiseWithResolvers<string>) => void]> = {
+  ".resolves": [promise => expect(promise).resolves.toBe("x"), p => p.resolve("x")],
+  ".rejects": [promise => expect(promise).rejects.toThrow("nope"), p => p.reject(new Error("nope"))],
+  "toThrow() on a function returning a promise": [
+    promise => expect(() => promise).toThrow("nope"),
+    p => p.reject(new Error("nope")),
+  ],
+  "async expect.extend matcher": [promise => expect(promise).toEventuallyBe("x"), p => p.resolve("x")],
+  "expect.resolvesTo": [
+    promise => expect({ promise }).toEqual({ promise: expect.resolvesTo.stringContaining("x") }),
+    p => p.resolve("x"),
+  ],
+};
+
+for (const [name, [matcher, settle]] of Object.entries(cases)) {
+  test(name, async () => {
+    expect(await matcherSettledBySiblingImmediate(matcher, settle)).toEqual(["matcher:start", "sibling", "matcher:end"]);
+  });
+}
+`;
+  using dir = tempDir("matcher-inside-immediate", { "matchers.test.ts": code });
+  await using proc = spawn({
+    cmd: [bunExe(), "test", "matchers.test.ts"],
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+    env: bunEnv,
+    // A broken build blocks inside the first callback of each test forever
+    // (the test's own timeout fires in there, but the matcher keeps waiting).
+    timeout: 30_000,
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  expect(
+    normalizeBunSnapshot(stderr)
+      .split("\n")
+      .filter(line => line.startsWith("(pass)") || line.startsWith("(fail)")),
+  ).toEqual([
+    "(pass) .resolves",
+    "(pass) .rejects",
+    "(pass) toThrow() on a function returning a promise",
+    "(pass) async expect.extend matcher",
+    "(pass) expect.resolvesTo",
+  ]);
+  expect(stderr).toContain("5 pass");
+  expect(exitCode).toBe(0);
 });

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -818,7 +818,8 @@ for (const [name, [matcher, settle]] of Object.entries(cases)) {
     // (the test's own timeout fires in there, but the matcher keeps waiting).
     timeout: 30_000,
   });
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe(`bun test ${Bun.version_with_sha}\n`);
   expect(
     normalizeBunSnapshot(stderr)
       .split("\n")

--- a/test/js/node/timers/node-timers.test.ts
+++ b/test/js/node/timers/node-timers.test.ts
@@ -1,6 +1,6 @@
 import jsc from "bun:jsc";
 import { describe, expect, it, mock, test } from "bun:test";
-import { bunEnv, bunExe, bunRun, isWindows } from "harness";
+import { bunEnv, bunExe, bunRun, isWindows, tempDir } from "harness";
 import path from "node:path";
 import { clearInterval, clearTimeout, promises, setImmediate, setInterval, setTimeout } from "node:timers";
 import { promisify } from "util";
@@ -317,4 +317,81 @@ describe.each(["with", "without"])("setImmediate %s timers running", mode => {
 
 it("should defer microtasks when an exception is thrown in an immediate", async () => {
   expect(await bunRun(["run", path.join(import.meta.dir, "timers-immediate-exception-fixture.js")])).toSpawn();
+});
+
+it("runs the rest of a setImmediate batch while one of its callbacks is blocked running the event loop", async () => {
+  using dir = tempDir("immediate-batch-nested-loop", {
+    "entry.ts": "export {};",
+    "main.ts": `
+      const order = [];
+      const first = Promise.withResolvers();
+      const second = Promise.withResolvers();
+      // Bun.build() runs the event loop, from inside the caller, until an async
+      // plugin setup() settles (expect().resolves does the same in bun:test).
+      const runEventLoopUntil = promise =>
+        Bun.build({ entrypoints: ["./entry.ts"], plugins: [{ name: "wait", setup: () => promise }] });
+
+      // All four are queued before the loop runs any of them: one batch.
+      setImmediate(() => {
+        order.push("1:start");
+        setImmediate(() => order.push("queued by 1"));
+        runEventLoopUntil(first.promise);
+        order.push("1:end");
+      });
+      setImmediate(() => {
+        order.push("2:start");
+        runEventLoopUntil(second.promise);
+        order.push("2:end");
+      });
+      setImmediate(() => {
+        order.push("3");
+        second.resolve();
+      });
+      setImmediate(() => {
+        order.push("4");
+        first.resolve();
+      });
+      process.on("exit", () => console.log(order.join(",")));
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+    // A broken build never gets past callback 1: it waits for callback 4, which
+    // is queued behind it in the same batch.
+    timeout: 30_000,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  // The loop run from inside 1 runs the rest of the batch (2, whose own nested
+  // run then runs 3 and 4); nothing runs twice; what the batch queued runs on
+  // the next iteration, as usual.
+  expect(stdout.trim().split(",")).toEqual(["1:start", "2:start", "3", "4", "2:end", "1:end", "queued by 1"]);
+  expect(exitCode).toBe(0);
+});
+
+it("releases the rest of a setImmediate batch when the process exits from inside it", async () => {
+  // process.exit() tears the VM down (BUN_DESTRUCT_VM_ON_EXIT, as on the ASAN
+  // lanes) from inside the first callback, with the rest of its batch pending.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      setImmediate(() => { console.log("1"); process.exit(0); });
+      setImmediate(() => console.log("2"));
+      setImmediate(() => console.log("3"));
+      `,
+    ],
+    env: { ...bunEnv, BUN_DESTRUCT_VM_ON_EXIT: "1" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("1\n");
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
### Problem

- A `bun:test` matcher that waits for a promise (`expect(p).resolves` / `.rejects`, `toThrow()` on a function returning a promise, an async `expect.extend` matcher, `expect.resolvesTo`) hangs forever when it is called inside a `setImmediate` callback and the promise is settled by another `setImmediate` callback queued in the same batch. The process sits in `epoll_wait`; the test's own timeout is reported but the process never exits. The same code with `setTimeout(fn, 0)` passes in ~2ms.
- Not specific to the test runner: `Bun.build()` with a plugin whose `setup()` returns a promise waits the same way, so this hangs `bun run` too (`timeout 10 bun run x.ts` exits 124):
  ```ts
  const { promise, resolve } = Promise.withResolvers();
  setImmediate(() => Bun.build({ entrypoints: ["./a.ts"], plugins: [{ name: "p", setup: () => promise }] }));
  setImmediate(resolve);
  ```
- Cause: `EventLoop::tick_immediate_tasks` (`src/jsc/event_loop.rs`) did `to_run_now = mem::take(&mut self.immediate_tasks)` and iterated that local `Vec`. While callback 1 was blocked in `wait_for_promise`, the nested `auto_tick` -> `tick_immediate_tasks` only saw the (empty) queue of immediates added since, so callback 2, the one that settles the promise, could not run until callback 1 returned, and callback 1 was waiting for it. Timers do not have this problem because `drain_timers` pops the shared heap one entry at a time.

### Fix

- The batch being run now lives on the `EventLoop` (`immediate_batch` plus `immediate_batch_next`, the index of the next callback to run) instead of on the ticking frame's stack. A `tick_immediate_tasks` entered while a batch is in progress continues that batch from the index; otherwise it swaps the queued immediates in as a new batch. Every tick returns with the batch empty.
- Why this is correct:
  - Each entry is handed out exactly once: the index is advanced before the callback runs, and both the outer and the nested tick read it through the loop, so when the nested tick has run the rest of the batch the outer tick finds nothing left.
  - Queue order is kept: the nested tick runs the remainder of the current batch before it ever starts a new one, and it starts one only when nothing of the current batch is left.
  - The Node semantic is unchanged: `setImmediate` still pushes onto `immediate_tasks`, which is never the batch being run, so callbacks queued during a batch run on a later iteration (a self-requeuing immediate still cannot extend the phase forever). For non-nested ticks the sequence of callbacks run is identical to before.
  - `has_pending_immediates()` (queued, or left of a batch up the stack) replaces the direct reads of the queue in `auto_tick` / `auto_tick_active` (poll must not block) and `is_event_loop_alive()`, so nothing reads one queue and misses the other.
  - Teardown entered from inside a batch (`process.exit()` in a `setImmediate` with the VM torn down on exit) cancels the unrun rest of the batch too; before, that remainder sat in the tick's local and was never released. `release_pending_immediates` keeps its "nothing queued" early return, which is load-bearing: the macro loop has no VM backref until macro mode is enabled.
  - The second swap buffer (`next_immediate_tasks`) was only recycling storage (nothing pushed to it), so the two buffers now alternate between "queue" and "batch" roles via `mem::swap`; the large-capacity release is kept.
- After the fix the blocked matcher returns as soon as the nested immediates phase has run the sibling, with the same latency as the non-nested case (a promise settled by an immediate queued before the wait started).
- Verified:
  - `test/js/bun/test/test-test.test.ts` ("a matcher waiting on a promise inside setImmediate sees the sibling immediate that settles it"): spawns `bun test` on a file covering the five matcher paths; hangs (killed, exit 143) without the fix, passes with it.
  - `test/js/node/timers/node-timers.test.ts` ("runs the rest of a setImmediate batch while ..."): plain `bun` with `Bun.build` plugin waits nested two deep; asserts the exact order `1:start, 2:start, 3, 4, 2:end, 1:end, queued by 1` (rest of batch runs in order, nothing twice, callbacks queued during the batch run on the next iteration); times out without the fix.
  - `test/js/node/timers/node-timers.test.ts` ("releases the rest of a setImmediate batch when the process exits from inside it"): the teardown path, with `BUN_DESTRUCT_VM_ON_EXIT=1`; also exercises the macro loop's empty release (an earlier version of this change without the early return hit the `unwrap_unchecked` debug check there).
  - Both files pass in full with `bun bd test`; node's `test/js/node/test/parallel/test-timers-immediate*.js`, `test-timers-clearImmediate*.js`, `test-microtask-queue-run-immediate.js`, `test-timers-setimmediate-infinite-loop.js` pass with the debug build.
- Relation to the de-blocking work (#33261): #33289 (matchers return real promises) and #33271 (`Bun.build` async setup) remove two of the call sites that re-enter the loop; this PR changes what the loop does when it is re-entered from an immediate callback, which the remaining call sites still do. #33289 explicitly keeps the synchronous wait for multi-test concurrent groups, `expect.resolvesTo` / `rejectsTo` and `expect()` outside bun:test, and all of those hit this hang from inside `setImmediate`. `tick_immediate_tasks` already had a branch for the nested case (`next_immediate_tasks.capacity() > 0`, "this would only occur if we were recursively running tickImmediateTasks"), which never made the outer batch reachable; this replaces it. Whether the loop should accommodate nested ticks at all is the call #33261 makes; if the answer is no, this is the immediates-phase analog of #32233 and can be closed on the same grounds.
- Complementary to #39089 (a matcher wait gives up at the test timeout): with this change the wait in this scenario completes, since the immediate that settles it now runs.

### Background

- Immediates phase: once per loop iteration, `auto_tick` calls `tick_immediate_tasks`, which runs every `setImmediate` callback queued so far (one "batch"), then computes the poll deadline (zero if anything is pending) and polls, then runs due timers. Callbacks queued by the batch wait for the next iteration, as in Node.
- Nested tick: `EventLoop::wait_for_promise` runs `tick()` + `auto_tick()` in a loop until a promise settles, from inside whatever JS called it. `bun:test`'s promise matchers, `Bun.build`'s async plugin setup, macros and bake use it. So a full loop iteration, including an immediates phase, can run in the middle of a callback of the outer immediates phase.
- `__bun_run_immediate_task` is the link-time hook that runs one `ImmediateObject` (it lives in the higher-tier `bun_runtime` crate); the loop stores the objects as erased pointers. Cancelling one (`__bun_cancel_pending_immediate`) drops the loop's ref on it without running it.
- The `black_box` laundering in `tick_immediate_tasks` is pre-existing: `&mut self` is `noalias`, but the callback re-enters this loop through the separate `virtual_machine` pointer, so every read has to go through the laundered pointer. The change adds more such reads (the index and the batch are re-read after each callback), which is why the pointer is re-laundered inside the loop.
