### PR TITLE
bun test: report over-long coverage dir, JUnit outfile and bunfig root instead of panicking

### DIFF
--- a/src/runtime/cli/test/parallel/aggregate.rs
+++ b/src/runtime/cli/test/parallel/aggregate.rs
@@ -9,9 +9,9 @@ use bun_collections::{ArrayHashMap, StringArrayHashMap};
 use bun_core::strings;
 use bun_core::{self, Output, ZBox};
 use bun_options_types::code_coverage_options::{CodeCoverageOptions, Fraction as CoverageFraction};
-use bun_paths::{self, PathBuffer};
+use bun_paths::AutoAbsPathChecked;
 use bun_sourcemap_jsc::code_coverage::text as CoverageReportText;
-use bun_sys::{self, Fd, File, O};
+use bun_sys::{self, E, Fd, File, O, Tag};
 
 use crate::cli::test::parallel::coordinator::Coordinator;
 use crate::node::PathLike;
@@ -215,18 +215,26 @@ pub(crate) fn merge_coverage_fragments<const ENABLE_COLORS: bool>(
             always_return_none: true,
             ..Default::default()
         });
-        let mut path_buf = PathBuffer::uninit();
-        let out_path = bun_paths::resolve_path::join_abs_string_buf_z::<bun_paths::platform::Auto>(
-            bun_paths::fs::FileSystem::instance().top_level_dir(),
-            &mut path_buf.0,
-            &[&opts.reports_directory, b"lcov.info"],
-        );
-        match File::openat(
-            Fd::cwd(),
-            out_path,
-            O::CREAT | O::WRONLY | O::TRUNC | O::CLOEXEC,
-            0o644,
-        ) {
+        // `reports_directory` is unbounded CLI/bunfig input, so use the
+        // length-checked join.
+        let mut out_path = AutoAbsPathChecked::init_top_level_dir();
+        let file = if out_path
+            .join(&[&opts.reports_directory, b"lcov.info"])
+            .is_err()
+        {
+            bun_sys::Result::Err(
+                bun_sys::Error::from_code(E::ENAMETOOLONG, Tag::open)
+                    .with_path(&opts.reports_directory),
+            )
+        } else {
+            File::openat(
+                Fd::cwd(),
+                out_path.slice(),
+                O::CREAT | O::WRONLY | O::TRUNC | O::CLOEXEC,
+                0o644,
+            )
+        };
+        match file {
             bun_sys::Result::Err(e) => Output::err(
                 crate::Error::lcovCoverageError,
                 "Failed to write merged lcov.info\n{}",

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -18,9 +18,9 @@ use bun_core::ZigStringSlice;
 use bun_core::strings;
 use bun_jsc::zig_string::ZigString;
 use bun_options_types::code_coverage_options::CodeCoverageOptions;
+use bun_paths as bun_path;
 use bun_paths::resolve_path;
 use bun_paths::string_paths::without_leading_path_separator;
-use bun_paths::{self as bun_path, PathBuffer};
 use bun_ptr::Interned;
 use bun_resolver::fs::FileSystem;
 use bun_sys::{self, Fd, File};
@@ -877,16 +877,9 @@ impl JunitReporter {
             self.contents.extend_from_slice(b"</testsuites>\n");
         }
 
-        let mut junit_path_buf = PathBuffer::uninit();
-
-        junit_path_buf[..path.len()].copy_from_slice(path);
-        junit_path_buf[path.len()] = 0;
-
-        // SAFETY: junit_path_buf[path.len()] == 0 written above
-        let zpath = bun_core::ZStr::from_buf(&junit_path_buf[..], path.len());
         match File::openat(
             Fd::cwd(),
-            zpath,
+            path,
             bun_sys::O::WRONLY | bun_sys::O::CREAT | bun_sys::O::TRUNC,
             0o664,
         ) {
@@ -1806,84 +1799,100 @@ impl CommandLineReporter {
         // --- Text ---
 
         // --- LCOV ---
-        let mut lcov_name_buf = PathBuffer::uninit();
-        let mut lcov_state: Option<(File, &bun_core::ZStr, /*buffered*/ Vec<u8>)> =
-            if REPORTERS_LCOV {
-                'brk: {
-                    // Ensure the directory exists
-                    let mut fs = crate::node::fs::NodeFS::default();
-                    let _ = fs.mkdir_recursive(&crate::node::fs::args::Mkdir {
-                        path: crate::node::PathLike::EncodedSlice(
-                            ZigStringSlice::from_utf8_never_free(&opts.reports_directory),
-                        ),
-                        always_return_none: true,
-                        recursive: true,
-                        ..Default::default()
-                    });
+        /// `contents` is written to `tmp_path`, which is then renamed onto `path`.
+        struct LcovOutput {
+            file: File,
+            tmp_path: bun_path::AutoAbsPathChecked,
+            path: bun_path::AutoAbsPathChecked,
+            contents: Vec<u8>,
+        }
+        let mut lcov_state: Option<LcovOutput> = if REPORTERS_LCOV {
+            'brk: {
+                // Ensure the directory exists
+                let mut fs = crate::node::fs::NodeFS::default();
+                let _ = fs.mkdir_recursive(&crate::node::fs::args::Mkdir {
+                    path: crate::node::PathLike::EncodedSlice(
+                        ZigStringSlice::from_utf8_never_free(&opts.reports_directory),
+                    ),
+                    always_return_none: true,
+                    recursive: true,
+                    ..Default::default()
+                });
 
-                    // Write the lcov.info file to a temporary file we atomically rename to the final name after it succeeds
-                    let mut base64_bytes = [0u8; 8];
-                    let mut shortname_buf = [0u8; 512];
-                    bun_boringssl_sys::rand_bytes(&mut base64_bytes);
-                    // Temp name: `.lcov.info.<lowercase hex of 8 random bytes>.tmp`.
-                    let tmpname = {
-                        use std::io::Write as _;
-                        let mut cursor = &mut shortname_buf[..];
-                        let _ = cursor.write_all(b".lcov.info.");
-                        let _ = write!(cursor, "{}", bun_core::fmt::hex_lower(&base64_bytes));
-                        let _ = cursor.write_all(b".tmp\0");
-                        let s = bun_core::slice_to_nul(&shortname_buf);
-                        // NUL written above; `slice_to_nul` returns the prefix before it.
-                        bun_core::ZStr::from_buf(&shortname_buf[..], s.len())
-                    };
-                    let path = resolve_path::join_abs_string_buf_z::<bun_path::platform::Auto>(
-                        relative_dir,
-                        &mut lcov_name_buf,
-                        &[&opts.reports_directory, tmpname.as_bytes()],
-                    );
-                    let file = File::openat(
+                // Write the lcov.info file to a temporary file we atomically rename to the final name after it succeeds
+                let mut base64_bytes = [0u8; 8];
+                let mut shortname_buf = [0u8; 512];
+                bun_boringssl_sys::rand_bytes(&mut base64_bytes);
+                // Temp name: `.lcov.info.<lowercase hex of 8 random bytes>.tmp`.
+                let tmpname = {
+                    use std::io::Write as _;
+                    let mut cursor = &mut shortname_buf[..];
+                    let _ = cursor.write_all(b".lcov.info.");
+                    let _ = write!(cursor, "{}", bun_core::fmt::hex_lower(&base64_bytes));
+                    let _ = cursor.write_all(b".tmp\0");
+                    let s = bun_core::slice_to_nul(&shortname_buf);
+                    // NUL written above; `slice_to_nul` returns the prefix before it.
+                    bun_core::ZStr::from_buf(&shortname_buf[..], s.len())
+                };
+                // `reports_directory` is unbounded CLI/bunfig input, so use the
+                // length-checked joins.
+                let mut tmp_path = bun_path::AutoAbsPathChecked::init_top_level_dir();
+                let mut path = bun_path::AutoAbsPathChecked::init_top_level_dir();
+                let file = if tmp_path
+                    .join(&[&opts.reports_directory, tmpname.as_bytes()])
+                    .is_err()
+                    || path.join(&[&opts.reports_directory, b"lcov.info"]).is_err()
+                {
+                    bun_sys::Result::Err(
+                        bun_sys::Error::from_code(bun_sys::E::ENAMETOOLONG, bun_sys::Tag::open)
+                            .with_path(&opts.reports_directory),
+                    )
+                } else {
+                    File::openat(
                         Fd::cwd(),
-                        path,
+                        tmp_path.slice(),
                         bun_sys::O::CREAT
                             | bun_sys::O::WRONLY
                             | bun_sys::O::TRUNC
                             | bun_sys::O::CLOEXEC,
                         0o644,
-                    );
+                    )
+                };
 
-                    match file {
-                        bun_sys::Result::Err(err) => {
-                            Output::err(
-                                crate::Error::lcovCoverageError,
-                                "Failed to create lcov file",
-                                (),
-                            );
-                            Output::print_error(format_args!("\n{}", err));
-                            Global::exit(1);
-                        }
-                        bun_sys::Result::Ok(f) => {
-                            // Accumulate in a `Vec<u8>` (impl `bun_io::Write`)
-                            // and flush to the fd via `write_all` on success
-                            // below.
-                            let buffered: Vec<u8> = Vec::with_capacity(64 * 1024);
-                            break 'brk Some((f, path, buffered));
-                        }
+                match file {
+                    bun_sys::Result::Err(err) => {
+                        Output::err(
+                            crate::Error::lcovCoverageError,
+                            "Failed to create lcov file",
+                            (),
+                        );
+                        Output::print_error(format_args!("\n{}", err));
+                        Global::exit(1);
+                    }
+                    bun_sys::Result::Ok(file) => {
+                        break 'brk Some(LcovOutput {
+                            file,
+                            tmp_path,
+                            path,
+                            contents: Vec::with_capacity(64 * 1024),
+                        });
                     }
                 }
-            } else {
-                None
-            };
-        let mut lcov_guard = scopeguard::guard(
-            &mut lcov_state,
-            |s: &mut Option<(File, &bun_core::ZStr, Vec<u8>)>| {
-                if REPORTERS_LCOV {
-                    if let Some((file, name, _)) = s.take() {
-                        let _ = file.close(); // close error is non-actionable
-                        let _ = bun_sys::unlink(name);
-                    }
+            }
+        } else {
+            None
+        };
+        let mut lcov_guard = scopeguard::guard(&mut lcov_state, |s: &mut Option<LcovOutput>| {
+            if REPORTERS_LCOV {
+                if let Some(LcovOutput {
+                    file, mut tmp_path, ..
+                }) = s.take()
+                {
+                    let _ = file.close(); // close error is non-actionable
+                    let _ = bun_sys::unlink(tmp_path.slice_z());
                 }
-            },
-        );
+            }
+        });
         // --- LCOV ---
 
         for entry in byte_ranges.iter_mut() {
@@ -1937,8 +1946,10 @@ impl CommandLineReporter {
             }
 
             if REPORTERS_LCOV {
-                if let Some((_, _, buffered)) = lcov_guard.as_mut() {
-                    if coverage::Lcov::write_format(&report, relative_dir, buffered).is_err() {
+                if let Some(lcov) = lcov_guard.as_mut() {
+                    if coverage::Lcov::write_format(&report, relative_dir, &mut lcov.contents)
+                        .is_err()
+                    {
                         continue;
                     }
                 }
@@ -2012,26 +2023,25 @@ impl CommandLineReporter {
         if REPORTERS_LCOV {
             // `try lcov_writer.flush()` — keep the errdefer guard armed across the
             // write so an error here still closes + unlinks the temp file.
-            if let Some((lcov_file, _, buffered)) = &mut **lcov_guard {
-                if let bun_sys::Result::Err(e) = lcov_file.write_all(buffered) {
+            if let Some(lcov) = &**lcov_guard {
+                if let bun_sys::Result::Err(e) = lcov.file.write_all(&lcov.contents) {
                     // `lcov_guard` drops on this early return → close + unlink.
                     return Err(crate::Error::from(e));
                 }
             }
             // Flush succeeded — disarm the errdefer cleanup.
             let state = scopeguard::ScopeGuard::into_inner(lcov_guard);
-            if let Some((lcov_file, lcov_name, _)) = state.take() {
-                let _ = lcov_file.close();
+            if let Some(LcovOutput {
+                file,
+                mut tmp_path,
+                mut path,
+                ..
+            }) = state.take()
+            {
+                let _ = file.close();
                 let cwd = Fd::cwd();
-                if let Err(err) = bun_sys::move_file_z(
-                    cwd,
-                    lcov_name,
-                    cwd,
-                    resolve_path::join_abs_string_z::<bun_path::platform::Auto>(
-                        relative_dir,
-                        &[&opts.reports_directory, b"lcov.info"],
-                    ),
-                ) {
+                if let Err(err) = bun_sys::move_file_z(cwd, tmp_path.slice_z(), cwd, path.slice_z())
+                {
                     Output::err(err, "Failed to save lcov.info file", ());
                     Global::exit(1);
                 }
@@ -2465,20 +2475,33 @@ impl TestCommand {
 
             // Own the joined path in a hoisted buffer and borrow from it.
             let dir_to_scan_owned: Vec<u8>;
-            let dir_to_scan: &[u8] = 'brk: {
-                if !ctx.debug.test_directory.is_empty() {
-                    dir_to_scan_owned = resolve_path::join_abs::<bun_path::platform::Auto>(
+            let (dir_to_scan, scanned): (&[u8], Result<(), scanner::ScanError>) =
+                if ctx.debug.test_directory.is_empty() {
+                    let dir = scanner.fs().top_level_dir;
+                    (dir, scanner.scan(dir))
+                } else {
+                    // The bunfig `root` is unbounded. A root that does not fit a
+                    // path buffer together with its NUL cannot be opened either,
+                    // so it is reported like a root that does not exist.
+                    let mut buf = bun_path::path_buffer_pool::get();
+                    let buf_len = buf.len();
+                    match resolve_path::join_abs_string_buf_checked::<bun_path::platform::Auto>(
                         scanner.fs().top_level_dir,
-                        &ctx.debug.test_directory,
-                    )
-                    .into();
-                    break 'brk &dir_to_scan_owned;
-                }
+                        &mut buf[..buf_len - 1],
+                        &[&ctx.debug.test_directory],
+                    ) {
+                        Some(joined) => {
+                            dir_to_scan_owned = joined.into();
+                            (&dir_to_scan_owned[..], scanner.scan(&dir_to_scan_owned))
+                        }
+                        None => (
+                            &ctx.debug.test_directory[..],
+                            Err(scanner::ScanError::DoesNotExist),
+                        ),
+                    }
+                };
 
-                break 'brk scanner.fs().top_level_dir;
-            };
-
-            match scanner.scan(dir_to_scan) {
+            match scanned {
                 Ok(()) => {}
                 Err(scanner::ScanError::OutOfMemory) => bun::out_of_memory(),
                 Err(scanner::ScanError::DoesNotExist) => {

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "bun";
 import { beforeAll, describe, expect, it, test } from "bun:test";
-import { bunEnv, bunExe, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 
@@ -1882,4 +1882,80 @@ describe.concurrent("test file discovery (scanner)", () => {
     expect(stderr).toContain(" 1 pass");
     expect(exitCode).toBe(0);
   });
+});
+
+describe.concurrent("bunfig [test] root", () => {
+  const passingTest = (name: string) => `import { test } from "bun:test"; test(${JSON.stringify(name)}, () => {});`;
+
+  test("only scans the configured directory", async () => {
+    using dir = tempDir("bunfig-root", {
+      "bunfig.toml": `[test]\nroot = "sub"\n`,
+      "top.test.ts": passingTest("top"),
+      "sub/inner.test.ts": passingTest("inner"),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain("inner.test.ts:");
+    expect(stderr).not.toContain("top.test.ts:");
+    expect(stderr).toContain("Ran 1 test across 1 file.");
+    expect(exitCode).toBe(0);
+  });
+
+  test("a directory that does not exist is reported by its absolute path", async () => {
+    using dir = tempDir("bunfig-root-missing", {
+      "bunfig.toml": `[test]\nroot = "missing"\n`,
+      "top.test.ts": passingTest("top"),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain("Failed to scan non-existent root directory for tests:");
+    expect(stderr).toContain(join(String(dir), "missing"));
+    expect(proc.signalCode).toBeNull();
+    expect(exitCode).toBe(1);
+  });
+
+  // The root is joined onto the cwd in a buffer of MAX_PATH_BYTES (4096 on
+  // Linux, 1024 on macOS, 98302 on Windows), and bunfig can hold a value of
+  // any length. 100000 bytes overflows the buffer on every platform; 5000
+  // bytes still fits on Windows, where it is simply a directory that does not
+  // exist.
+  for (const length of [5000, 100_000]) {
+    test.skipIf(isWindows && length < 98302)(
+      `a root of ${length} bytes is reported like a directory that does not exist instead of crashing`,
+      async () => {
+        const root = Buffer.alloc(length, "r").toString();
+        using dir = tempDir("bunfig-root-too-long", {
+          "bunfig.toml": `[test]\nroot = "${root}"\n`,
+          "top.test.ts": passingTest("top"),
+        });
+
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "test"],
+          env: bunEnv,
+          cwd: String(dir),
+          stderr: "pipe",
+        });
+        const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+        expect(stderr).toContain("Failed to scan non-existent root directory for tests:");
+        expect(stderr).toContain(root);
+        expect(proc.signalCode).toBeNull();
+        expect(exitCode).toBe(1);
+      },
+    );
+  }
 });

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -1,5 +1,5 @@
-import { expect, test } from "bun:test";
-import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, normalizeBunSnapshot, tempDir } from "harness";
 import { readFileSync } from "node:fs";
 import path from "path";
 
@@ -588,4 +588,56 @@ All files  |    0.00 |    0.00 |
 Ran 1 test across 1 file."
 `);
   expect(result.exitCode).toBe(0);
+});
+
+describe.concurrent("lcov reporter with a coverage directory longer than the path buffer", () => {
+  // The lcov.info path is built in a buffer of MAX_PATH_BYTES: 4096 on Linux,
+  // 1024 on macOS and 98302 on Windows. A command line cannot carry a value
+  // that long on Windows, but bunfig can hold a value of any length anywhere.
+  const files = {
+    "lib.ts": `export const covered = () => 1;`,
+    "covered.test.ts": `
+      import { test, expect } from "bun:test";
+      import { covered } from "./lib";
+      test("covered", () => { expect(covered()).toBe(1); });
+    `,
+  };
+
+  for (const [source, length] of [
+    ["--coverage-dir", 5000],
+    ["bunfig coverageDir", 100_000],
+  ] as const) {
+    test.skipIf(isWindows && length < 98302)(
+      `${source} of ${length} bytes is reported as an error instead of crashing`,
+      async () => {
+        const coverageDir = Buffer.alloc(length, "c").toString();
+        const viaBunfig = source === "bunfig coverageDir";
+        using dir = tempDir("coverage-dir-too-long", {
+          ...files,
+          ...(viaBunfig ? { "bunfig.toml": `[test]\ncoverageDir = "${coverageDir}"\n` } : {}),
+        });
+
+        await using proc = Bun.spawn({
+          cmd: [
+            bunExe(),
+            "test",
+            "--coverage",
+            "--coverage-reporter=lcov",
+            ...(viaBunfig ? [] : ["--coverage-dir", coverageDir]),
+          ],
+          env: bunEnv,
+          cwd: String(dir),
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+        expect(stderr).toContain("(pass) covered");
+        expect(stderr).toContain("Failed to create lcov file");
+        expect(stderr).toContain("ENAMETOOLONG");
+        expect(proc.signalCode).toBeNull();
+        expect(exitCode).toBe(1);
+      },
+    );
+  }
 });

--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -594,6 +594,37 @@ test("--parallel --coverage merges LCOV across workers", async () => {
   expect(exitCode).toBe(0);
 });
 
+test("--parallel --coverage reports a coverage directory longer than the path buffer instead of crashing", async () => {
+  // The merged lcov.info path is built in a buffer of MAX_PATH_BYTES (98302 on
+  // Windows, less elsewhere); a bunfig value can be longer than that on every
+  // platform, where a command-line argument cannot.
+  const coverageDir = Buffer.alloc(100_000, "c").toString();
+  using dir = tempDir("parallel-coverage-dir-too-long", {
+    "bunfig.toml": `[test]\ncoverageDir = "${coverageDir}"\n`,
+    "shared.js": `export function hit() { return 1; }\n`,
+    "a.test.js": `import {test,expect} from "bun:test"; import {hit} from "./shared.js"; test("a",()=>expect(hit()).toBe(1));`,
+    "b.test.js": `import {test,expect} from "bun:test"; import {hit} from "./shared.js"; test("b",()=>expect(hit()).toBe(1));`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--parallel=2", "--coverage", "--coverage-reporter=lcov"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain("PARALLEL");
+  expect(stderr).toContain("Failed to write merged lcov.info");
+  expect(stderr).toContain("ENAMETOOLONG");
+  expect(stderr).toContain("2 pass");
+  expect(proc.signalCode).toBeNull();
+  // Like any other failure to open the merged report, this is reported
+  // without failing the run.
+  expect(exitCode).toBe(0);
+});
+
 test("--parallel --coverage prints merged text table", async () => {
   using dir = tempDir("parallel-coverage-text", {
     "lib-a.js": `export function used() { return 1; }\nexport function unused() { return 2; }\n`,

--- a/test/js/junit-reporter/junit.test.js
+++ b/test/js/junit-reporter/junit.test.js
@@ -1,6 +1,6 @@
 import { file, spawn } from "bun";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { join } from "node:path";
 
 const xml2js = require("xml2js");
@@ -554,6 +554,50 @@ describe("junit reporter", () => {
     expect(xmlContent).not.toMatch(/\[[\d;]*[A-HJKSTfm]/);
     expect(exitCode).toBe(1);
   });
+
+  // The outfile is opened through a buffer of MAX_PATH_BYTES: 4096 on Linux,
+  // 1024 on macOS and 98302 on Windows. A command line cannot carry a value
+  // that long on Windows, but bunfig can hold a value of any length anywhere.
+  for (const [source, length] of [
+    ["--reporter-outfile", 5000],
+    ["bunfig test.reporter.junit", 100_000],
+  ]) {
+    it.skipIf(isWindows && length < 98302)(
+      `${source} of ${length} bytes reports the failed write instead of crashing`,
+      async () => {
+        const outfile = Buffer.alloc(length, "j").toString();
+        const viaBunfig = source !== "--reporter-outfile";
+        await using tmpDir = tempDir("junit-outfile-too-long", {
+          "package.json": "{}",
+          ...(viaBunfig ? { "bunfig.toml": `[test.reporter]\njunit = "${outfile}"\n` } : {}),
+          "passing.test.js": `
+            import { test } from "bun:test";
+            test("passes", () => {});
+          `,
+        });
+
+        await using proc = spawn(
+          [bunExe(), "test", ...(viaBunfig ? [] : ["--reporter=junit", "--reporter-outfile", outfile])],
+          {
+            cwd: tmpDir,
+            env: bunEnv,
+            stdout: "pipe",
+            stderr: "pipe",
+          },
+        );
+        const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+        expect(stderr).toContain(" 1 pass");
+        expect(stderr).toContain(`Failed to write JUnit report to ${outfile}`);
+        // The errno comes from bun_sys's own length check, which Windows does
+        // not label as ENAMETOOLONG yet.
+        if (!isWindows) expect(stderr).toContain("ENAMETOOLONG");
+        expect(proc.signalCode).toBeNull();
+        // A report that could not be written is reported; the tests decide the exit code.
+        expect(exitCode).toBe(0);
+      },
+    );
+  }
 });
 
 function filterJunitXmlOutput(xmlContent) {


### PR DESCRIPTION
### Problem
- `bun test --coverage --coverage-reporter=lcov --coverage-dir <5000 bytes>` runs the tests and then aborts with `panic: range end index 5015 out of range for slice of length 4095` (exit 134). The same happens with `coverageDir` in bunfig, and with `--parallel`.
- `bun test --reporter=junit --reporter-outfile <5000 bytes>` runs the whole suite, then aborts with `panic: range end index 5000 out of range for slice of length 4096`; the report is lost. Same for `[test.reporter] junit` in bunfig.
- A bunfig `[test] root` of 5000 bytes aborts with `panic: range end index 5021 out of range for slice of length 4095` before any test runs.
- All four values are user input of unbounded length that was copied or joined into a fixed path buffer without a length check:
  - `src/runtime/cli/test_command.rs` `JunitReporter::write_to_file`: copied the outfile into a `PathBuffer`.
  - `src/runtime/cli/test_command.rs` `print_code_coverage`: `join_abs_string_buf_z` of the coverage dir and temp name into a `PathBuffer`, and `join_abs_string_z` of the final `lcov.info` name into the 4096 byte thread-local buffer.
  - `src/runtime/cli/test/parallel/aggregate.rs` `merge_coverage_fragments`: the same join for the merged `lcov.info`.
  - `src/runtime/cli/test_command.rs` `TestCommand::exec`: `join_abs` of the bunfig root into the 4096 byte thread-local buffer.
- The limit is 4096 bytes on Linux and 1024 on macOS, so the macOS reports of this family (#35728) hit it at about 1000 bytes. Same class as #35863, which covers the test scanner; these sites are outside that PR's scope.

### Fix
- JUnit: the outfile is passed straight to `File::openat`. It already copies the path into its own buffer and returns `ENAMETOOLONG` when it does not fit, so the existing `Failed to write JUnit report to ...` message now prints that error, and the exit code stays the run's own result. This is exactly what the `--parallel` JUnit merge already did for the same input.
- lcov (serial and `--parallel`): the temp and final paths are built with `AutoAbsPathChecked`, whose `join` fails instead of overflowing; that failure is fed into the existing open-failure error arm as `ENAMETOOLONG` with the configured directory, so the serial path prints `Failed to create lcov file` and exits 1, and the coordinator prints `Failed to write merged lcov.info`, as they do for any other unwritable directory. The serial writer now joins both names before creating anything, so the rename at the end no longer joins at all. The path state held across the report is a small struct instead of a tuple, since it now carries two paths.
- bunfig root: joined with `join_abs_string_buf_checked` into a pooled path buffer, leaving room for the NUL, and a root that does not fit is reported through the existing `Failed to scan non-existent root directory for tests:` arm with the configured value, exit 1. Output for every root that fits is byte for byte what it was before (including a trailing slash), because the checked join is the same join with a size check in front.
- Reporting these as `ENAMETOOLONG` / non-existent is correct because the buffers are sized to the OS limit (`PATH_MAX`): any path the check rejects is one the OS would refuse to open with `ENAMETOOLONG` anyway, so the only behavior that changes is the abort.
- Verified with:
  - `test/cli/test/coverage.test.ts`: `--coverage-dir` of 5000 bytes and bunfig `coverageDir` of 100000 bytes.
  - `test/cli/test/parallel.test.ts`: bunfig `coverageDir` of 100000 bytes with `--parallel=2`.
  - `test/js/junit-reporter/junit.test.js`: `--reporter-outfile` of 5000 bytes and bunfig `test.reporter.junit` of 100000 bytes.
  - `test/cli/test/bun-test.test.ts`: bunfig root of 5000 and 100000 bytes, plus a root that works and a root that does not exist (the latter two also pass before this change; they pin the behavior the root change must preserve).
  - All seven over-long cases abort with the panics above on the unfixed build (`USE_SYSTEM_BUN=1`) and pass with the fix; the four files pass in full with `bun bd test` (except four timing-based `--parallel` scaling tests in `parallel.test.ts` that also fail without this change on this machine under ASAN).
  - `cargo fmt` and `cargo clippy -p bun_runtime` are clean.
- The 5000 byte variants are skipped on Windows, where the buffer is 98302 bytes and a command line cannot exceed it; the 100000 byte bunfig variants run everywhere. The JUnit test only checks the errno name off Windows, where `bun_sys`'s length check currently labels it differently (tracked separately).

### Background
- `PathBuffer` is bun's stack/pool buffer for path syscalls, `MAX_PATH_BYTES` long: 4096 on Linux, 1024 on macOS, 98302 on Windows. `join_abs_string_buf` / `join_abs` resolve parts against a base directory and normalize straight into such a buffer (or a 4096 byte thread-local one) and assume the result fits; a longer result indexes past the buffer, which is the panic.
- `join_abs_string_buf_checked` is the same join that returns `None` when the normalized result does not fit. `AutoAbsPathChecked` (added for the same bug in `--cpu-prof-dir`, #36881) is a path builder over a pooled `PathBuffer` that starts from the project root and whose `join` returns `Err(MaxPathExceeded)` instead; `slice_z()` gives the NUL-terminated form that `unlink` / `move_file_z` need.
- `File::openat(dir, &[u8])` copies the path into a `PathBuffer` to NUL-terminate it and returns `ENAMETOOLONG` if it does not fit, which is why the JUnit writer does not need a buffer of its own.
- The lcov writer writes into a temp file in the coverage directory and renames it onto `lcov.info` once the whole report has been written; the `--parallel` coordinator instead receives each worker's lcov text over IPC and writes the merged file directly.
