### PR TITLE
highway: check the output length in copy_u16_to_u8 and fill_with_skip_mask

### DIFF
--- a/src/codegen/generate-js2native.ts
+++ b/src/codegen/generate-js2native.ts
@@ -85,6 +85,7 @@ const rustIdentifierPaths: Record<string, string> = {
   "patch.rs": "patch/patch.rs",
   "postgres.rs": "sql_jsc/postgres.rs",
   "runtime/dns_jsc/dns.rs": "runtime/dns_jsc/dns.rs",
+  "runtime/highway_testing.rs": "runtime/highway_testing.rs",
   "runtime/node/types.rs": "runtime/node/types.rs",
   "runtime/socket/socket.rs": "runtime/socket/socket.rs",
   "runtime/timer/Timer.rs": "runtime/timer/Timer.rs",

--- a/src/highway/lib.rs
+++ b/src/highway/lib.rs
@@ -596,12 +596,23 @@ pub fn last_index_of_any_char(haystack: &[u8], chars: &[u8]) -> Option<usize> {
     found
 }
 
-// `&[u16]` requires
-// 2-byte alignment. Callers with unaligned data must go through the raw extern.
+/// Truncates each code unit to its low byte, writing exactly `input.len()`
+/// bytes to `output`; panics if `output` is shorter (the kernel is never told
+/// its length). `&[u16]` requires 2-byte alignment; callers with unaligned
+/// data must go through the raw extern.
 #[inline(always)]
 pub fn copy_u16_to_u8(input: &[u16], output: &mut [u8]) {
-    // SAFETY: input.ptr/len readable, output.ptr writable for at least input.len() bytes
-    // (caller contract: output.len() >= input.len()).
+    // Runtime check (not just debug): this is a safe wrapper around an FFI
+    // write, so a too-small `output` must panic instead of corrupting memory.
+    assert!(
+        output.len() >= input.len(),
+        "copy_u16_to_u8: output too small ({} bytes for {} input code units)",
+        output.len(),
+        input.len()
+    );
+    // SAFETY: `input` is readable for `input.len()` code units and `output`
+    // is writable for at least that many bytes (asserted above); the kernel
+    // writes exactly `input.len()` bytes and the slices cannot overlap (`&`/`&mut`).
     unsafe { highway_copy_u16_to_u8(input.as_ptr(), input.len(), output.as_mut_ptr()) }
 }
 
@@ -681,13 +692,27 @@ pub fn decode_hex_u16(src: &[u16], dst: &mut [u8]) -> usize {
 
 /// Apply a WebSocket mask to data using SIMD acceleration
 /// If skip_mask is true, data is copied without masking
+///
+/// Writes exactly `input.len()` bytes to `output`; panics if `output` is
+/// shorter (the kernel is never told its length).
 #[inline(always)]
 pub fn fill_with_skip_mask(mask: [u8; 4], output: &mut [u8], input: &[u8], skip_mask: bool) {
+    // Runtime check (not just debug): this is a safe wrapper around an FFI
+    // write, so a too-small `output` must panic instead of corrupting memory.
+    assert!(
+        output.len() >= input.len(),
+        "fill_with_skip_mask: output too small ({} bytes for {} input bytes)",
+        output.len(),
+        input.len()
+    );
     if input.is_empty() {
         return;
     }
 
-    // SAFETY: mask is 4 bytes; input.ptr/len readable; output.ptr writable for input.len() bytes.
+    // SAFETY: mask is 4 readable bytes; `input` is readable for `input.len()`
+    // bytes and `output` is writable for at least that many (asserted above);
+    // the kernel writes exactly `input.len()` bytes and the slices cannot
+    // overlap (`&`/`&mut`).
     unsafe {
         highway_fill_with_skip_mask(
             mask.as_ptr(),

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -41,6 +41,23 @@ export const highwayStringsForTesting: (
   arg: number | Uint8Array,
 ) => number = $newCppFunction("highway_strings_testing.cpp", "Bun__highwayStringsForTesting", 3);
 
+// The bun_highway wrappers (src/highway/lib.rs) that write into an output slice
+// the kernel is never told the length of, called with arguments of the test's
+// choosing (src/runtime/highway_testing.rs). Each returns what `output` holds
+// afterwards; a too-short `output` must panic.
+export const highwayOutputProbes = {
+  copyU16ToU8: $newRustFunction("runtime/highway_testing.rs", "copyU16ToU8Probe", 2) as (
+    input: Uint16Array,
+    output: Uint8Array,
+  ) => Uint8Array,
+  fillWithSkipMask: $newRustFunction("runtime/highway_testing.rs", "fillWithSkipMaskProbe", 4) as (
+    mask: Uint8Array,
+    output: Uint8Array,
+    input: Uint8Array,
+    skipMask: boolean,
+  ) => Uint8Array,
+};
+
 export const SQL = $cpp("JSSQLStatement.cpp", "createJSSQLStatementConstructor");
 
 export const patchInternals = {

--- a/src/runtime/highway_testing.rs
+++ b/src/runtime/highway_testing.rs
@@ -1,0 +1,63 @@
+//! `bun:internal-for-testing` probes for the `bun_highway` wrappers that write
+//! into a caller-supplied output slice, for test/internal/highway-output-bounds.test.ts.
+//!
+//! Each probe takes the same arguments as the wrapper it names, as typed arrays,
+//! copies `output` into a `Vec` of the length the test chose, runs the wrapper
+//! on the copy and returns it. A `Vec` rather than the JS buffer itself so that
+//! a wrapper missing its length check overflows a heap allocation ASAN reports,
+//! instead of silently corrupting the JS heap.
+
+use bun_jsc::{ArrayBuffer, CallFrame, JSGlobalObject, JSValue, JsResult};
+
+fn typed_array_argument(
+    global: &JSGlobalObject,
+    frame: &CallFrame,
+    index: usize,
+    name: &str,
+) -> JsResult<Vec<u8>> {
+    match frame.argument(index).as_array_buffer(global) {
+        Some(buffer) => Ok(buffer.byte_slice().to_vec()),
+        None => Err(global.throw(format_args!("{name} must be a typed array"))),
+    }
+}
+
+/// The probes exist to hit the wrappers' length checks; that panic must not
+/// leave a core dump behind in CI.
+fn expect_panic_if_too_short(output_len: usize, input_len: usize) {
+    if output_len < input_len {
+        bun_crash_handler::suppress_core_dumps_if_necessary();
+    }
+}
+
+/// `copyU16ToU8Probe(input: Uint16Array, output: Uint8Array): Uint8Array`
+pub(crate) fn copy_u16_to_u8_probe(
+    global: &JSGlobalObject,
+    frame: &CallFrame,
+) -> JsResult<JSValue> {
+    let input: Vec<u16> = typed_array_argument(global, frame, 0, "input")?
+        .chunks_exact(2)
+        .map(|unit| u16::from_ne_bytes([unit[0], unit[1]]))
+        .collect();
+    let mut output = typed_array_argument(global, frame, 1, "output")?;
+
+    expect_panic_if_too_short(output.len(), input.len());
+    bun_highway::copy_u16_to_u8(&input, &mut output);
+    ArrayBuffer::create_uint8_array(global, &output)
+}
+
+/// `fillWithSkipMaskProbe(mask: Uint8Array, output: Uint8Array, input: Uint8Array, skipMask: boolean): Uint8Array`
+pub(crate) fn fill_with_skip_mask_probe(
+    global: &JSGlobalObject,
+    frame: &CallFrame,
+) -> JsResult<JSValue> {
+    let Ok(mask) = <[u8; 4]>::try_from(typed_array_argument(global, frame, 0, "mask")?) else {
+        return Err(global.throw(format_args!("mask must be 4 bytes")));
+    };
+    let mut output = typed_array_argument(global, frame, 1, "output")?;
+    let input = typed_array_argument(global, frame, 2, "input")?;
+    let skip_mask = frame.argument(3).to_boolean();
+
+    expect_panic_if_too_short(output.len(), input.len());
+    bun_highway::fill_with_skip_mask(mask, &mut output, &input, skip_mask);
+    ArrayBuffer::create_uint8_array(global, &output)
+}

--- a/src/runtime/lib.rs
+++ b/src/runtime/lib.rs
@@ -38,6 +38,7 @@ pub mod shell;
 #[path = "api.rs"]
 pub mod api;
 pub mod dispatch;
+pub mod highway_testing;
 pub mod hw_exports;
 pub mod ipc;
 pub mod ipc_host;

--- a/test/internal/highway-output-bounds.test.ts
+++ b/test/internal/highway-output-bounds.test.ts
@@ -1,0 +1,100 @@
+/**
+ * `bun_highway::copy_u16_to_u8` and `bun_highway::fill_with_skip_mask`
+ * (src/highway/lib.rs) are safe functions that hand C++ their `output` slice as
+ * a bare pointer; the kernel then writes `input.len()` bytes without ever
+ * seeing `output.len()`, so the length check in each wrapper is all that keeps
+ * a too-short `output` from becoming a heap overflow. Both in-tree callers slice
+ * their buffers to the input length first, so no JS API reaches the checks;
+ * `highwayOutputProbes` (src/runtime/highway_testing.rs) calls the wrappers with
+ * buffers of the test's choosing. The too-short cases run against the built
+ * binary, which on release builds also pins the checks to `assert!`: a
+ * `debug_assert!` compiles out there and the kernel writes past `output`
+ * instead of panicking.
+ */
+import { highwayOutputProbes } from "bun:internal-for-testing";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Straddles the 16/32/64-lane vector loops of both kernels and their scalar tails.
+const LENGTHS = [0, 1, 3, 15, 16, 17, 31, 32, 33, 63, 64, 65, 100];
+
+// Neither kernel produces this byte from the inputs below, so an untouched byte is recognizable.
+const UNTOUCHED = 0xee;
+
+const mask = Uint8Array.of(0x12, 0x34, 0x56, 0x78);
+const inputBytes = (length: number) => Uint8Array.from({ length }, (_, i) => i & 0x7f);
+const maskedBytes = (length: number) => inputBytes(length).map((byte, i) => byte ^ mask[i & 3]);
+// Every code unit has a non-zero high byte, so the output only matches if it was truncated.
+const inputUnits = (length: number) => Uint16Array.from({ length }, (_, i) => 0xab00 | (i & 0x7f));
+
+const fill = (length: number) => new Uint8Array(length).fill(UNTOUCHED);
+const padded = (written: Uint8Array) => Uint8Array.of(...written, ...fill(3));
+
+describe("copy_u16_to_u8", () => {
+  test("an output of exactly the input length receives the low byte of every code unit", () => {
+    expect(LENGTHS.map(n => highwayOutputProbes.copyU16ToU8(inputUnits(n), fill(n)))).toEqual(
+      LENGTHS.map(n => inputBytes(n)),
+    );
+  });
+
+  test("a longer output is only written up to the input length", () => {
+    expect(LENGTHS.map(n => highwayOutputProbes.copyU16ToU8(inputUnits(n), fill(n + 3)))).toEqual(
+      LENGTHS.map(n => padded(inputBytes(n))),
+    );
+  });
+});
+
+describe.each([
+  ["masking", false, maskedBytes],
+  ["skipping the mask", true, inputBytes],
+])("fill_with_skip_mask %s", (_name, skipMask, expected) => {
+  test("an output of exactly the input length receives every byte", () => {
+    expect(LENGTHS.map(n => highwayOutputProbes.fillWithSkipMask(mask, fill(n), inputBytes(n), skipMask))).toEqual(
+      LENGTHS.map(n => expected(n)),
+    );
+  });
+
+  test("a longer output is only written up to the input length", () => {
+    expect(LENGTHS.map(n => highwayOutputProbes.fillWithSkipMask(mask, fill(n + 3), inputBytes(n), skipMask))).toEqual(
+      LENGTHS.map(n => padded(expected(n))),
+    );
+  });
+});
+
+// The panic aborts the process, so each too-short call gets a child of its own.
+// The skip-mask call is a plain memcpy inside the kernel; it must be stopped by the same check.
+test.concurrent.each([
+  [
+    "copyU16ToU8(new Uint16Array(2), new Uint8Array(1))",
+    "copy_u16_to_u8: output too small (1 bytes for 2 input code units)",
+  ],
+  [
+    "fillWithSkipMask(new Uint8Array(4), new Uint8Array(4), new Uint8Array(5), false)",
+    "fill_with_skip_mask: output too small (4 bytes for 5 input bytes)",
+  ],
+  [
+    "fillWithSkipMask(new Uint8Array(4), new Uint8Array(4), new Uint8Array(5), true)",
+    "fill_with_skip_mask: output too small (4 bytes for 5 input bytes)",
+  ],
+])("%s panics instead of writing past the output", async (call, message) => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `console.log(JSON.stringify(require("bun:internal-for-testing").highwayOutputProbes.${call}));`,
+      // Skips the symbolized backtrace debug builds otherwise print, which takes seconds.
+      "--debug-crash-handler-use-trace-string",
+    ],
+    // The panic is the expected outcome; it must not be reported as a crash.
+    env: { ...bunEnv, BUN_CRASH_REPORT_URL: "", BUN_ENABLE_CRASH_REPORTING: "0" },
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({
+    stdout,
+    stderr: stderr.includes(message) ? message : stderr,
+    exitCode: exitCode === 0 ? 0 : "non-zero",
+  }).toEqual({ stdout: "", stderr: message, exitCode: "non-zero" });
+});


### PR DESCRIPTION
### Problem
- `bun_highway::copy_u16_to_u8(input, output)` and `bun_highway::fill_with_skip_mask(mask, output, input, skip_mask)` (src/highway/lib.rs) are safe functions that pass `output.as_mut_ptr()` and `input.len()` to the C++ kernels. The kernels write `input.len()` bytes; neither they nor the wrappers ever look at `output.len()`.
- So any safe caller with a shorter `output` overflows it, in release and debug alike. The only guard was a comment on `copy_u16_to_u8` ("caller contract: output.len() >= input.len()"); `fill_with_skip_mask` had none. Same shape as the simdutf base64 encoder in #38932, found while fixing that.
- Both current callers happen to slice their buffers to the input length first (`copy_u16_into_u8` in src/bun_core/string/immutable/unicode.rs, `Mask::fill` in src/http_jsc/websocket_client.rs), so nothing reachable from JS overflows today. The defect is that the safe signatures do not enforce the length they rely on.
- Without the check, calling either wrapper with a one-byte-short `output` is reported by ASAN as `heap-buffer-overflow ... WRITE of size 1 in CopyU16ToU8Impl highway_strings.cpp:567` and `... in FillWithSkipMaskImpl highway_strings.cpp:2174` (masking) / `__asan_memcpy ... highway_strings.cpp:2143` (skip_mask); reports in the details block below.

### Fix
- `assert!(output.len() >= input.len(), ...)` in both wrappers before the FFI call; the SAFETY comments now point at the assert instead of at a caller contract.
- Correct because both kernels write exactly `input.len()` bytes (`CopyU16ToU8Impl` and `FillWithSkipMaskImpl` loop to their count argument, which the wrappers pass as `input.len()`), so `output.len() >= input.len()` is exactly the condition under which the write stays inside `output`. `>=` rather than `==` keeps the wrappers' existing contract and both callers unchanged.
- A release `assert!`, not `debug_assert!`: continuing past it corrupts memory, and release builds compile `debug_assert!` out (`[profile.release]` leaves debug-assertions off; only the asan/assertions profiles turn them on). `encode_hex_lower` in the same file already does this; the other output-taking wrappers there (`copy_ascii_prefix`, `decode_hex`, `decode_hex_u16`, `fill_with_skip_mask_inplace`, the structural-index ones) already `min()` or `assert!` their lengths, so these two were the only sites of this shape in the crate. (The simdutf `convert::*` wrappers are the same shape in another crate and are being handled separately.)
- Cost: one compare in front of a SIMD kernel call. `fill_with_skip_mask` is on the WebSocket send path, where the caller already performs the same compare to build its sub-slice.
- Test: test/internal/highway-output-bounds.test.ts, through a new `bun:internal-for-testing` probe (src/runtime/highway_testing.rs, same arrangement as linear_fifo_testing.rs). No JS API can reach the wrappers with a short output, so the probe calls them with buffers of the test's choosing; it copies `output` into a `Vec` so that a missing check is a heap overflow ASAN reports rather than silent JS-heap corruption. The test sweeps exact-length and longer outputs across lengths straddling the 16/32/64-lane loops of both kernels (and both `skip_mask` values), and requires a one-byte-short output to panic with the new message for each wrapper and each `skip_mask` path (one child process per case, since the panic aborts). It runs against the built binary, so on the release CI lanes it also pins the checks to `assert!`.
- Verified: `bun bd test test/internal/highway-output-bounds.test.ts`, 9 pass. With src/highway/lib.rs at main and the probe kept, the 6 sweep tests pass and the 3 short-output tests fail (the children die with the ASAN reports below). `USE_SYSTEM_BUN=1 bun test` on the file fails (no probe in the released binary). test/internal/source-lints: 166 pass. WebSocket client tests: only the postman-echo.com cases fail (no network in this environment).
- No `#[test]`s in bun_highway itself: `cargo test -p bun_highway` cannot link the kernels today (#37599 is adding that), and the probe exercises the same lines in the real binary on every lane.

### Background
- The `highway_*` `extern "C"` declarations in src/highway/lib.rs are Google Highway SIMD kernels implemented in src/jsc/bindings/highway_strings.cpp and dispatched at runtime to the widest instruction set the CPU has. The Rust functions in lib.rs are the safe API over them; `bun_core::strings` and friends are built on those.
- `copy_u16_to_u8` narrows UTF-16 code units to their low byte (used once a UTF-16 string is known to fit in Latin-1). `fill_with_skip_mask` XORs an outgoing WebSocket client frame with its 4-byte mask into the output buffer; `skip_mask` makes it a plain copy, for the all-zero mask.
- `bun:internal-for-testing` is a module only Bun's own tests can import. A `$newRustFunction("runtime/<file>.rs", "<name>", argc)` entry in src/js/internal-for-testing.ts is wired by src/codegen/generate-js2native.ts to `bun_runtime::<file>::<snake_case name>`, which is why the probe lives in bun_runtime and the codegen table gains one line.

<details>
<summary>ASAN reports from the probe with the checks removed (src/highway/lib.rs at main, debug build)</summary>

`copyU16ToU8(new Uint16Array(2), new Uint8Array(1))`:

```
ERROR: AddressSanitizer: heap-buffer-overflow on address 0x77efe66859b1 ...
WRITE of size 1 at 0x77efe66859b1 thread T0
    #0 in bun::N_AVX3_DL::CopyU16ToU8Impl(unsigned short const*, unsigned long, unsigned char*) src/jsc/bindings/highway_strings.cpp:567:19
    #1 in bun::highway_copy_u16_to_u8_impl(...) src/jsc/bindings/highway_strings.cpp:2275:12
    #2 in highway_copy_u16_to_u8 src/jsc/bindings/highway_strings.cpp:2304:9
    #3 in bun_highway::copy_u16_to_u8 src/highway/lib.rs:605:14
    #4 in bun_runtime::highway_testing::copy_u16_to_u8_probe src/runtime/highway_testing.rs:44:5
```

`fillWithSkipMask(new Uint8Array(4), new Uint8Array(4), new Uint8Array(5), false)`:

```
ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6ea511e659b4 ...
WRITE of size 1 at 0x6ea511e659b4 thread T0
    #0 in bun::N_AVX3_DL::FillWithSkipMaskImpl(...) src/jsc/bindings/highway_strings.cpp:2174:19
    #1 in highway_fill_with_skip_mask src/jsc/bindings/highway_strings.cpp:2418:5
    #2 in bun_highway::fill_with_skip_mask src/highway/lib.rs:692:9
    #3 in bun_runtime::highway_testing::fill_with_skip_mask_probe src/runtime/highway_testing.rs:61:5
```

`fillWithSkipMask(new Uint8Array(4), new Uint8Array(4), new Uint8Array(5), true)`:

```
ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6cc96e8e59b4 ...
WRITE of size 5 at 0x6cc96e8e59b4 thread T0
    #0 in __asan_memcpy
    #1 in bun::N_AVX3_DL::FillWithSkipMaskImpl(...) src/jsc/bindings/highway_strings.cpp:2143:9
    #2 in highway_fill_with_skip_mask src/jsc/bindings/highway_strings.cpp:2418:5
    #3 in bun_highway::fill_with_skip_mask src/highway/lib.rs:692:9
    #4 in bun_runtime::highway_testing::fill_with_skip_mask_probe src/runtime/highway_testing.rs:61:5
```

With the checks in place the same three calls print `panic: copy_u16_to_u8: output too small (1 bytes for 2 input code units)` and `panic: fill_with_skip_mask: output too small (4 bytes for 5 input bytes)` and abort before the kernel is called.
</details>
