### PR TITLE
event loop: park on the next timer deadline when nothing refs the loop

### DIFF
--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -989,7 +989,9 @@ impl EventLoop {
 
     /// `eventLoop().autoTick()` — bounces through `VirtualMachine::auto_tick`,
     /// which dispatches to the `bun_runtime` hook (needs `Timer::All` for the
-    /// poll timeout). The body lives in `bun_runtime::jsc_hooks::auto_tick`.
+    /// poll timeout). Parks while the loop has active handles, or until the
+    /// next timer deadline when it has none; returns at once when there is
+    /// neither. The body lives in `bun_runtime::jsc_hooks::auto_tick`.
     #[inline]
     pub fn auto_tick(&mut self) {
         self.vm_ref().as_mut().auto_tick();

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -949,8 +949,11 @@ unsafe fn ensure_debugger(vm: *mut VirtualMachine, block_until_connected: bool) 
     }
 }
 
-/// `eventLoop().autoTick()`. Needs
-/// `timer::All` for the poll-timeout calculation, hence dispatched here.
+/// `eventLoop().autoTick()`: one poll of the I/O loop for the `tick();
+/// auto_tick();` wait loops (`wait_for_promise`, the test runner). Parks while
+/// the loop has active handles, or until the next timer deadline when it has
+/// none; returns at once when neither exists. Needs `timer::All` for the
+/// poll-timeout calculation, hence dispatched here.
 ///
 /// PERF: the one fn-ptr indirection is dwarfed by the kqueue/epoll syscall it
 /// gates.
@@ -1028,15 +1031,10 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
         return;
     }
 
-    // Call `ctx.timer.getTimeout(..)` ONLY inside
-    // `if (loop.isActive())` — `get_timeout` has side effects (pops + fires
-    // due `WTFTimer` heap entries), so it must stay guarded by `is_active()`
-    // rather than running unconditionally.
     {
         // Read `immediate_tasks` AFTER
         // `tickImmediateTasks` swaps `next_immediate_tasks` in, so this
         // reflects next-tick immediates (queued during the drain above).
-        // SAFETY: `el` is the live per-thread event loop.
         // SAFETY: `el` is the live per-thread event loop.
         let has_pending_immediate = has_yielded_tasks
             || !unsafe { &*el }.immediate_tasks.is_empty()
@@ -1051,44 +1049,67 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
                 Some(ild.quic_next_tick_us)
             }
         };
-        let mut timespec = bun_core::Timespec { sec: 0, nsec: 0 };
+        // Before `get_timeout`: the first call arms the idle GC timer, and a
+        // timer armed after the poll deadline is computed is not in that deadline.
+        // SAFETY: `el` is the live per-thread event loop.
+        unsafe { (*el).process_gc_timer() };
+        // Computed whether or not the loop is active: the idle branch below
+        // parks on the deadline too. `get_timeout` also fires the due
+        // `WTFTimer`s, which the timer drain after the poll would otherwise
+        // fire a moment later, so for an idle loop that only moves them earlier.
+        // Note (§Forbidden aliased-&mut): `get_timeout` may fire a
+        // `WTFTimer` JS callback.
+        // A re-entrant `setTimeout`/`clearTimeout` reaches
+        // `timer::All::insert`/`remove` via `runtime_state()` and would
+        // mint a second `&mut timer` if we held `&mut (*state).timer`
+        // across the call. Pass the raw `*mut Self` instead;
+        // `timer::All::get_timeout` forms short-lived `&mut` only around
+        // heap ops that cannot re-enter JS, releasing the borrow before
+        // invoking `fire()`.
+        // `get_timeout` reads CLOCK_MONOTONIC to compare against the timer heap; hand that
+        // same reading to the tick for the park hook's idle-sweep rate limit. It is lazy,
+        // and so is the hook: NOW_NS_UNKNOWN means it took none.
+        let mut timespec = bun_core::Timespec::EPOCH;
+        let mut now: Option<bun_core::Timespec> = None;
+        // SAFETY: `state` is the live per-thread `RuntimeState`; the
+        // `timer` field address is stable for the VM lifetime.
+        let have_timeout = unsafe {
+            timer::All::get_timeout(
+                &mut (*state).timer,
+                &mut timespec,
+                has_pending_immediate,
+                quic_next_tick_us,
+                vm.cast(),
+                &mut now,
+            )
+        };
+        let now_ns = now.map_or(bun_uws::NOW_NS_UNKNOWN, |t| t.ns());
         // SAFETY: `loop_` is the live per-thread uws loop.
         if unsafe { (*loop_).is_active() } {
-            // Before `get_timeout`: the first call arms the idle GC timer, and a
-            // timer armed after the poll deadline is computed is not in that deadline.
-            // SAFETY: `el` is the live per-thread event loop.
-            unsafe { (*el).process_gc_timer() };
-            // Note (§Forbidden aliased-&mut): `get_timeout` may fire a
-            // `WTFTimer` JS callback.
-            // A re-entrant `setTimeout`/`clearTimeout` reaches
-            // `timer::All::insert`/`remove` via `runtime_state()` and would
-            // mint a second `&mut timer` if we held `&mut (*state).timer`
-            // across the call. Pass the raw `*mut Self` instead;
-            // `timer::All::get_timeout` forms short-lived `&mut` only around
-            // heap ops that cannot re-enter JS, releasing the borrow before
-            // invoking `fire()`.
-            // `get_timeout` reads CLOCK_MONOTONIC to compare against the timer heap; hand that
-            // same reading to the tick for the park hook's idle-sweep rate limit. It is lazy,
-            // and so is the hook: NOW_NS_UNKNOWN means it took none.
-            let mut now: Option<bun_core::Timespec> = None;
-            // SAFETY: `state` is the live per-thread `RuntimeState`; the
-            // `timer` field address is stable for the VM lifetime.
-            let have_timeout = unsafe {
-                timer::All::get_timeout(
-                    &mut (*state).timer,
-                    &mut timespec,
-                    has_pending_immediate,
-                    quic_next_tick_us,
-                    vm.cast(),
-                    &mut now,
-                )
-            };
-            let now_ns = now.map_or(bun_uws::NOW_NS_UNKNOWN, |t| t.ns());
             // SAFETY: `loop_` is the live per-thread uws loop.
             unsafe {
                 (*loop_)
                     .tick_with_timeout(if have_timeout { Some(&timespec) } else { None }, now_ns)
             };
+        } else if have_timeout && !has_pending_immediate && timespec != bun_core::Timespec::EPOCH {
+            // Nothing refs the loop, but a timer that does not ref it is armed
+            // (an unref'd setTimeout, the bun:test per-test timeout, the idle GC
+            // timer), and its deadline is the next thing that can move whatever
+            // the caller's `tick(); auto_tick();` loop waits on. Park until then:
+            // returning at once makes that loop spin for the whole wait.
+            // `inc`/`dec` keep the tick from early-returning on an empty poll set
+            // (`num_polls == 0`; no live handle on Windows), as
+            // `MiniEventLoop::tick_once` does; a wakeup or I/O still ends the
+            // park early. Windows ignores `timespec` and parks until any event,
+            // hence the explicit pending-work check. With no deadline the caller
+            // still gets control back at once, so a wait that nothing will ever
+            // wake does not turn into a park forever.
+            // SAFETY: `loop_` is the live per-thread uws loop.
+            unsafe {
+                (*loop_).inc();
+                (*loop_).tick_with_timeout(Some(&timespec), now_ns);
+                (*loop_).dec();
+            }
         } else {
             // SAFETY: `loop_` is the live per-thread uws loop.
             unsafe { (*loop_).tick_without_idle() };
@@ -1116,10 +1137,11 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
 }
 
 /// `eventLoop().autoTickActive()`. Same shape as
-/// [`auto_tick`] but: no `runImminentGCTimer`, no `handleRejectedPromises` at
-/// the tail, and no debug sleep-timer logging. Used by `bun_main` /
-/// `on_before_exit` drain loops where blocking when the loop is idle would
-/// hang shutdown.
+/// [`auto_tick`] but: parks only while the loop has active handles (never for
+/// a bare timer deadline), no `runImminentGCTimer`, no
+/// `handleRejectedPromises` at the tail, and no debug sleep-timer logging.
+/// Used by `bun_main` / `on_before_exit` drain loops where blocking when the
+/// loop is idle would hang shutdown.
 ///
 /// # Safety
 /// `vm` is the live per-thread VM.

--- a/test/js/bun/test/test-timers.test.ts
+++ b/test/js/bun/test/test-timers.test.ts
@@ -1,4 +1,4 @@
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import path from "node:path";
 
 test("we can go back in time", () => {
@@ -113,4 +113,86 @@ test("real timer heap is ticked against the real clock under useFakeTimers", asy
   // null => exited on its own; non-null => killed by the spawn timeout (spun).
   expect(proc.signalCode).toBeNull();
   expect(exitCode).toBe(0);
+});
+
+// Every fixture below waits on a timer that does not keep the event loop alive
+// (an unref'd setTimeout, or the per-test timeout) with nothing else ref'ing
+// the loop, and prints how much CPU the process burned while waiting. The loop
+// has to sleep until the deadline: it used to return from every poll at once
+// while nothing ref'd it, so each of these waits spun at 100% CPU for its whole
+// duration. The fixtures cover each wait loop that polls this way: the test
+// runner's own loop, the nested wait behind `expect().resolves`, and `bun run`
+// waiting for a top-level await.
+const IDLE_MS = 1000;
+
+const idleLoopFixtures = {
+  "idle-window.ts": `
+    export function startIdleWindow() {
+      const cpu0 = process.cpuUsage();
+      const t0 = performance.now();
+      return () => {
+        const cpu = process.cpuUsage(cpu0);
+        console.log(JSON.stringify({ cpuMs: (cpu.user + cpu.system) / 1000, wallMs: performance.now() - t0 }));
+      };
+    }
+  `,
+  "per-test-timeout.test.ts": `
+    import { afterAll, test } from "bun:test";
+    import { startIdleWindow } from "./idle-window";
+    let endIdleWindow: () => void;
+    afterAll(() => endIdleWindow());
+    test("never settles; the per-test timeout ends it", async () => {
+      endIdleWindow = startIdleWindow();
+      await new Promise(() => {});
+    }, ${IDLE_MS});
+  `,
+  "unref-timer.test.ts": `
+    import { test } from "bun:test";
+    import { startIdleWindow } from "./idle-window";
+    test("awaits an unref'd timer", async () => {
+      const endIdleWindow = startIdleWindow();
+      await new Promise(resolve => setTimeout(resolve, ${IDLE_MS}).unref());
+      endIdleWindow();
+    });
+  `,
+  "expect-resolves.test.ts": `
+    import { expect, test } from "bun:test";
+    import { startIdleWindow } from "./idle-window";
+    test("expect().resolves waits for an unref'd timer", async () => {
+      const endIdleWindow = startIdleWindow();
+      await expect(new Promise(resolve => setTimeout(() => resolve(1), ${IDLE_MS}).unref())).resolves.toBe(1);
+      endIdleWindow();
+    });
+  `,
+  "top-level-await.ts": `
+    import { startIdleWindow } from "./idle-window";
+    const endIdleWindow = startIdleWindow();
+    await new Promise(resolve => setTimeout(resolve, ${IDLE_MS}).unref());
+    endIdleWindow();
+  `,
+};
+
+test.concurrent.each([
+  ["bun test waiting for the per-test timeout", ["test", "per-test-timeout.test.ts"], 1],
+  ["bun test waiting for an unref'd setTimeout", ["test", "unref-timer.test.ts"], 0],
+  ["expect().resolves waiting for an unref'd setTimeout", ["test", "expect-resolves.test.ts"], 0],
+  ["bun run waiting for a top-level await on an unref'd setTimeout", ["run", "top-level-await.ts"], 0],
+])("%s sleeps instead of spinning", async (_, args, expectedExitCode) => {
+  using dir = tempDir("idle-loop", idleLoopFixtures);
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), ...args],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const report = stdout.split("\n").find(line => line.startsWith("{"));
+  expect(report, stdout + stderr).toBeDefined();
+  const { cpuMs, wallMs } = JSON.parse(report!);
+  expect(wallMs).toBeGreaterThanOrEqual(IDLE_MS * 0.9);
+  // Spinning costs about IDLE_MS of CPU; sleeping costs a few ms (tens under
+  // debug + ASAN, mostly the idle GC timer firing once).
+  expect(cpuMs).toBeLessThan(IDLE_MS / 2);
+  expect(exitCode).toBe(expectedExitCode);
 });


### PR DESCRIPTION
### Problem
- `bun test` spins at 100% CPU while it waits for a test that nothing will settle: `time bun test e.test.ts --timeout 1000` on `test("t", async () => { await new Promise(() => {}); })` reports `user 1.00s` for `real 1.02s`. The same spin happens for a test awaiting an unref'd `setTimeout`, for `expect(p).resolves` while `p` waits on one, and for `bun run` of a file whose top-level await waits on one (all measured at ~1000 ms of CPU per 1000 ms of waiting on the release binary).
- Cause: `auto_tick` (`src/runtime/jsc_hooks.rs`, the `if (*loop_).is_active()` branch) only sleeps in the poll while the uws loop has active handles; otherwise it calls `tick_without_idle()`, which returns immediately. Timers never ref the loop: the bun:test timeout (`BunTest::update_min_timeout` -> `timer::All::insert`), an unref'd `TimeoutObject`, the idle GC timer. So every wait loop built on `tick(); auto_tick();` (`test_command.rs` while `phase != Done`, `EventLoop::wait_for_promise` used by `expect().resolves` / `.rejects` and `load_entry_point`, `AnyEventLoop::tick_raw`) polls non-stop until the deadline arrives.

### Fix
- `auto_tick` now computes the poll deadline (`timer::All::get_timeout`) whether or not the loop is active. When it is idle but a timer is armed and no task or immediate is queued, it parks in the poll until that deadline, bracketing the tick with `inc()`/`dec()` so `us_loop_run_bun_tick` does not early-return on `num_polls == 0` (on Windows: so `uv_run` sees a live handle). This is the shape `MiniEventLoop::tick_once` already uses to park.
- Why this is correct: with nothing ref'd, the only events that can move what the caller is waiting on are a timer firing, I/O on a registered fd, or another thread posting work. The poll wakes for all three: the deadline is the poll timeout, fds stay in the set regardless of ref state, and every cross-thread post (`VmHandle::deliver`, `add_keep_alive`, `request_termination`, JSC deferred work via `JSCTaskScheduler`) already calls `wakeup()`, which the active branch has always relied on. Same-thread work queued before the poll makes `get_timeout` return a zero timeout, which is excluded from parking. With no armed timer the idle branch still returns at once, so a wait that nothing will ever wake keeps its old behavior rather than parking forever.
- `auto_tick_active` (the `bun run` / `on_before_exit` run-to-completion loops) is unchanged; those must return as soon as the loop is idle. `get_timeout` running for an idle loop only fires due `WTFTimer`s before the poll instead of in the timer drain right after it.
- Test: `test/js/bun/test/test-timers.test.ts`, four fixtures (per-test timeout, unref'd timer in a test, `expect().resolves` on one, top-level await on one in `bun run`) each wait 1 s and report `process.cpuUsage()` over the wait; assert under 500 ms. Unfixed debug build of main: ~975-1000 ms each (all four fail). Fixed debug (ASAN) build: 26-40 ms each.
- `bun bd test test/cli/test/ test/js/bun/test/ test/js/web/timers/ test/js/bun/test/expect/ test/bundler/bundler_plugin*.test.ts test/js/bun/repl/repl.test.ts test/cli/run/run-eval.test.ts` and a few more: the remaining failures (parallel/randomize timeouts, RSS leak fixtures, `spawn_waiter_thread`) fail identically on a debug build of unmodified main in this container.
- Wake-up latency is unchanged: with the loop idle, `import()`, `Bun.file().text()`, `WebAssembly.instantiate`, zlib, subtle crypto, `Bun.spawn` exit, workers and immediates complete in the same time as with the loop held active (details below).
- #38378 reworks these drivers but keeps the idle branch as `tick_without_idle()`, so it would still spin; this change is the `else` branch of the same poll and carries over.

### Background
- uws loop "active" count: Bun-side handles that should keep the process alive (`KeepAlive`, ref'd timers via `increment_timer_ref`, sockets, subprocesses) `ref()` the uws loop. `is_active()` is what `bun run` uses to decide the program is done, which is why unref'd and internal timers deliberately do not count. `num_polls` is a second counter (ref'd handles plus registered fds); `us_loop_run_bun_tick` returns without polling when it is 0, so parking needs it non-zero, hence `inc()`/`dec()`.
- `auto_tick` vs `auto_tick_active`: both do one poll of the I/O loop. `auto_tick` serves loops waiting for a condition (promise settled, test file done); `auto_tick_active` serves loops that exit when the loop goes idle.
- `timer::All::get_timeout` returns the time until the soonest entry of the JS timer heap and the JSC (`WTFTimer`) heap, zero if work is already queued, and `false` when both heaps are empty.
- On Windows `tick_with_timeout` ignores the timespec and runs `uv_run(UV_RUN_ONCE)`; libuv derives the sleep from its own timer, which `timer::All::insert` arms for the heap's soonest deadline (`ensure_uv_timer`), and `inc()` is the virtual handle that lets `uv_run` block at all. That is why the idle branch also checks for pending work explicitly instead of relying on the zero timespec.

<details>
<summary>Probe numbers (debug ASAN build with the fix, same binary, loop idle vs held active by a ref'd timer)</summary>

```
inactive: import():           wall 14.7ms/op, cpu 11.0ms/op
active:   import():           wall 18.5ms/op, cpu  9.6ms/op
inactive: Bun.file().text():  wall  1.8ms/op, cpu  1.8ms/op
active:   Bun.file().text():  wall  0.8ms/op, cpu  1.1ms/op
unref'd setTimeout(50):       wall 52.7ms/op, cpu  5.5ms/op   (parks, wakes on the deadline)
expect().resolves on unref'd setTimeout(5): wall 6.7ms/op
WebAssembly.instantiate at top level: 6.6-14.3ms (unmodified main debug build: 13.4-16.6ms)
zlib.gzip / Bun.build / Worker round trip: wall ~= cpu (compute bound, no parking)
```

Release binary before the fix, CPU burned during a 1000 ms wait, per fixture in the new test: 1000.2 / 998.1 / 998.5 / 1001.6 ms. Fixed debug build: 26.5 / 40.3 / 35.3 / 32.0 ms.
</details>
