### PR TITLE
bun:test: diff only the properties the pattern mentions when toMatchObject fails

### DIFF
--- a/src/jsc/bindings/ExpectObjectSubset.cpp
+++ b/src/jsc/bindings/ExpectObjectSubset.cpp
@@ -1,0 +1,149 @@
+// The received side of a failed `toMatchObject` diff: the received object trimmed to the
+// properties the pattern mentions, recursively (jest's `getObjectSubset`). Diffing the whole
+// received value prints every property the pattern does not mention as a `+` line and
+// buries the mismatch; a value with its own print form (a React element, say) turns into
+// a wholesale replacement that shows neither the differing property nor its value.
+
+#include "root.h"
+#include <JavaScriptCore/JSArray.h>
+#include <JavaScriptCore/JSCast.h>
+#include <JavaScriptCore/ObjectConstructor.h>
+#include <JavaScriptCore/PropertyNameArray.h>
+#include <wtf/HashMap.h>
+
+namespace ExpectObjectSubset {
+
+enum class Shape {
+    Leaf,
+    Object,
+    Array,
+};
+
+// Only ordinary objects and same-length arrays are trimmed: the formatter prints those
+// property by property, so a copy holding fewer properties prints as the original minus the
+// dropped lines. Anything else (Date, Map, Error, native classes, asymmetric matchers, arrays
+// whose lengths already differ, ...) has its own print form and is shown whole, as before.
+static Shape shapeOf(JSC::JSValue received, JSC::JSValue pattern)
+{
+    if (!received.isCell() || !pattern.isCell())
+        return Shape::Leaf;
+
+    auto* receivedArray = dynamicDowncast<JSC::JSArray>(received);
+    auto* patternArray = dynamicDowncast<JSC::JSArray>(pattern);
+    if (receivedArray || patternArray)
+        return receivedArray && patternArray && receivedArray->length() == patternArray->length() ? Shape::Array : Shape::Leaf;
+
+    if (received.asCell()->type() == JSC::FinalObjectType && pattern.asCell()->type() == JSC::FinalObjectType)
+        return Shape::Object;
+    return Shape::Leaf;
+}
+
+class Builder {
+public:
+    Builder(JSC::JSGlobalObject* globalObject, JSC::ThrowScope& scope)
+        : m_globalObject(globalObject)
+        , m_scope(scope)
+    {
+    }
+
+    JSC::JSValue trim(Shape shape, JSC::JSValue received, JSC::JSValue pattern)
+    {
+        auto& vm = JSC::getVM(m_globalObject);
+        // Trimming is only presentation: past this depth the rest of the branch is shown
+        // whole rather than failing the matcher with a stack overflow.
+        if (!vm.isSafeToRecurse()) [[unlikely]]
+            return received;
+
+        JSC::JSObject* receivedObject = JSC::asObject(received);
+        JSC::JSObject* patternObject = JSC::asObject(pattern);
+
+        JSC::JSObject* subset;
+        if (shape == Shape::Array) {
+            subset = JSC::constructEmptyArray(m_globalObject, nullptr, uncheckedDowncast<JSC::JSArray>(receivedObject)->length());
+            RETURN_IF_EXCEPTION(m_scope, {});
+        } else {
+            // Same prototype as the received object, so the diff keeps printing its class name.
+            JSC::JSValue prototype = receivedObject->getPrototypeDirect();
+            subset = prototype.isObject()
+                ? JSC::constructEmptyObject(m_globalObject, JSC::asObject(prototype))
+                : JSC::constructEmptyObject(vm, m_globalObject->nullPrototypeObjectStructure());
+        }
+
+        // `m_visited` holds bare pointers: the buffer keeps the three objects alive (and
+        // their addresses unique) for the rest of the walk.
+        m_gcBuffer.append(received);
+        m_gcBuffer.append(pattern);
+        m_gcBuffer.append(subset);
+        m_visited.add({ received.asCell(), pattern.asCell() }, subset);
+
+        // The same enumeration `Bun__deepMatch` compares with, so the subset holds exactly the
+        // values the match looked at, including ones the received object inherits.
+        JSC::PropertyNameArrayBuilder patternProperties(vm, JSC::PropertyNameMode::StringsAndSymbols, JSC::PrivateSymbolMode::Include);
+        patternObject->getPropertyNames(m_globalObject, patternProperties, JSC::DontEnumPropertiesMode::Exclude);
+        RETURN_IF_EXCEPTION(m_scope, {});
+
+        bool copiedAny = false;
+        for (const auto& property : patternProperties) {
+            JSC::JSValue receivedValue = receivedObject->getIfPropertyExists(m_globalObject, property);
+            RETURN_IF_EXCEPTION(m_scope, {});
+            // Left out, so the diff shows the pattern's line as missing.
+            if (receivedValue.isEmpty())
+                continue;
+            JSC::JSValue patternValue = patternObject->get(m_globalObject, property);
+            RETURN_IF_EXCEPTION(m_scope, {});
+            JSC::JSValue value = subsetOf(receivedValue, patternValue);
+            RETURN_IF_EXCEPTION(m_scope, {});
+            subset->putDirectMayBeIndex(m_globalObject, property, value);
+            RETURN_IF_EXCEPTION(m_scope, {});
+            copiedAny = true;
+        }
+
+        // With no property in common, an empty subset would hide what was actually received.
+        return copiedAny ? JSC::JSValue(subset) : received;
+    }
+
+private:
+    JSC::JSValue subsetOf(JSC::JSValue received, JSC::JSValue pattern)
+    {
+        Shape shape = shapeOf(received, pattern);
+        if (shape == Shape::Leaf)
+            return received;
+
+        // A pair comes up again when the pattern shares an object or cycles through one.
+        // Reusing its subset (possibly still being filled) gives the copy the same shape, so a
+        // cycle prints as `[Circular]` on both sides. Keyed on the pair because the same
+        // received object may be trimmed against different branches of the pattern.
+        if (JSC::JSObject* subset = m_visited.get({ received.asCell(), pattern.asCell() }))
+            return subset;
+
+        return trim(shape, received, pattern);
+    }
+
+    JSC::JSGlobalObject* m_globalObject;
+    JSC::ThrowScope& m_scope;
+    JSC::MarkedArgumentBuffer m_gcBuffer;
+    WTF::HashMap<std::pair<JSC::JSCell*, JSC::JSCell*>, JSC::JSObject*> m_visited;
+};
+
+} // namespace ExpectObjectSubset
+
+// `received` and `pattern` are the two (object) arguments of a `toMatchObject` call that did
+// not match. Returns `received` itself when there is nothing to trim.
+extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue Expect__toMatchObjectSubset(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue receivedEncoded, JSC::EncodedJSValue patternEncoded)
+{
+    using namespace ExpectObjectSubset;
+
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSC::JSValue received = JSC::JSValue::decode(receivedEncoded);
+    JSC::JSValue pattern = JSC::JSValue::decode(patternEncoded);
+    Shape shape = shapeOf(received, pattern);
+    if (shape == Shape::Leaf)
+        return receivedEncoded;
+
+    Builder builder(globalObject, scope);
+    JSC::JSValue subset = builder.trim(shape, received, pattern);
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSC::JSValue::encode(subset);
+}

--- a/src/runtime/test_runner/expect/toMatchObject.rs
+++ b/src/runtime/test_runner/expect/toMatchObject.rs
@@ -40,10 +40,18 @@ pub(crate) fn to_match_object(
     }
 
     // handle failure
+    // `.not` only prints the pattern. The positive failure diffs the received object
+    // trimmed to the pattern's properties (jest's `getObjectSubset`), so the properties
+    // `toMatchObject` ignores do not show up as differences.
+    let diff_received = if not {
+        received_object
+    } else {
+        bun_jsc::cpp::Expect__toMatchObjectSubset(global, received_object, property_matchers)?
+    };
     let diff_formatter = DiffFormatter {
         received_string: None,
         expected_string: None,
-        received: Some(received_object),
+        received: Some(diff_received),
         expected: Some(property_matchers),
         global_this: Some(global),
         not,

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -588,6 +588,306 @@ it("expect().toEqual() on objects with property indices doesn't print undefined"
   expect(err).not.toContain("undefined");
 });
 
+describe("expect().toMatchObject() failure diff", () => {
+  // Runs `code` (which ends in a failing assertion) in a child process and returns the
+  // assertion's message; bunEnv disables colors, so the message is the plain diff.
+  async function failureMessage(code: string): Promise<string> {
+    await using proc = spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { expect } = require("bun:test");
+         let message = "did not fail";
+         try { ${code} } catch (e) { message = e.message; }
+         process.stdout.write(message);`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return stdout;
+  }
+
+  test.concurrent("only shows the properties the pattern mentions", async () => {
+    expect(
+      await failureMessage(`
+        expect({ a: 1, b: 2, c: 3, nested: { x: 1, y: 2 } }).toMatchObject({ a: 2, nested: { x: 1 } });
+      `),
+    ).toMatchInlineSnapshot(`
+      "expect(received).toMatchObject(expected)
+
+        {
+      -   "a": 2,
+      +   "a": 1,
+          "nested": {
+            "x": 1,
+          },
+        }
+
+      - Expected  - 1
+      + Received  + 1
+      "
+    `);
+  });
+
+  test.concurrent("diffs a value with its own print form by the properties the pattern mentions", async () => {
+    expect(
+      await failureMessage(`
+        const element = { $$typeof: Symbol.for("react.element"), type: "div", key: null, ref: null, props: { id: "y" } };
+        expect(element).toMatchObject({ props: { id: "x" } });
+      `),
+    ).toMatchInlineSnapshot(`
+      "expect(received).toMatchObject(expected)
+
+        {
+          "props": {
+      -     "id": "x",
+      +     "id": "y",
+          },
+        }
+
+      - Expected  - 1
+      + Received  + 1
+      "
+    `);
+  });
+
+  test.concurrent("shows a property the received object lacks as missing", async () => {
+    expect(
+      await failureMessage(`
+        expect({ a: 1, b: 2 }).toMatchObject({ a: 1, z: 3 });
+      `),
+    ).toMatchInlineSnapshot(`
+      "expect(received).toMatchObject(expected)
+
+        {
+          "a": 1,
+      -   "z": 3,
+        }
+
+      - Expected  - 1
+      + Received  + 0
+      "
+    `);
+  });
+
+  test.concurrent("trims arrays of the same length element by element", async () => {
+    expect(
+      await failureMessage(`
+        expect([{ a: 1, b: 2 }, { a: 3, b: 4 }]).toMatchObject([{ a: 1 }, { a: 9 }]);
+      `),
+    ).toMatchInlineSnapshot(`
+      "expect(received).toMatchObject(expected)
+
+        [
+          {
+            "a": 1,
+          },
+          {
+      -     "a": 9,
+      +     "a": 3,
+          },
+        ]
+
+      - Expected  - 1
+      + Received  + 1
+      "
+    `);
+  });
+
+  test.concurrent("shows an array of a different length whole", async () => {
+    expect(
+      await failureMessage(`
+        expect({ list: [1, 2, 3], other: 1 }).toMatchObject({ list: [1, 2] });
+      `),
+    ).toMatchInlineSnapshot(`
+      "expect(received).toMatchObject(expected)
+
+        {
+          "list": [
+            1,
+            2,
+      +     3,
+          ],
+        }
+
+      - Expected  - 0
+      + Received  + 1
+      "
+    `);
+  });
+
+  test.concurrent("shows a value with its own print form whole when the pattern has one too", async () => {
+    expect(
+      await failureMessage(`
+        expect({ a: 1, when: new Date(0), unrelated: true }).toMatchObject({ a: 2, when: new Date(0) });
+      `),
+    ).toMatchInlineSnapshot(`
+      "expect(received).toMatchObject(expected)
+
+        {
+      -   "a": 2,
+      +   "a": 1,
+          "when": 1970-01-01T00:00:00.000Z,
+        }
+
+      - Expected  - 1
+      + Received  + 1
+      "
+    `);
+  });
+
+  test.concurrent("keeps the class name of the received object", async () => {
+    expect(
+      await failureMessage(`
+        class Foo { a = 1; b = 2; }
+        expect(new Foo()).toMatchObject({ a: 2 });
+      `),
+    ).toMatchInlineSnapshot(`
+      "expect(received).toMatchObject(expected)
+
+      - {
+      -   "a": 2,
+      + Foo {
+      +   "a": 1,
+        }
+
+      - Expected  - 2
+      + Received  + 2
+      "
+    `);
+  });
+
+  test.concurrent("shows the value of a property inherited by the received object", async () => {
+    expect(
+      await failureMessage(`
+        class Foo { own = 1; get computed() { return 42; } }
+        expect(new Foo()).toMatchObject({ computed: 43 });
+      `),
+    ).toMatchInlineSnapshot(`
+      "expect(received).toMatchObject(expected)
+
+      - {
+      -   "computed": 43,
+      + Foo {
+      +   "computed": 42,
+        }
+
+      - Expected  - 2
+      + Received  + 2
+      "
+    `);
+  });
+
+  test.concurrent("includes symbol properties", async () => {
+    expect(
+      await failureMessage(`
+        const s = Symbol("s");
+        expect({ [s]: 1, a: 1, b: 2 }).toMatchObject({ [s]: 2 });
+      `),
+    ).toMatchInlineSnapshot(`
+      "expect(received).toMatchObject(expected)
+
+        {
+      -   [Symbol(s)]: 2,
+      +   [Symbol(s)]: 1,
+        }
+
+      - Expected  - 1
+      + Received  + 1
+      "
+    `);
+  });
+
+  test.concurrent("shows the whole received object when it has none of the pattern's properties", async () => {
+    expect(
+      await failureMessage(`
+        expect({ exitCode: 1, stderr: "boom" }).toMatchObject({ status: 0 });
+      `),
+    ).toMatchInlineSnapshot(`
+      "expect(received).toMatchObject(expected)
+
+        {
+      -   "status": 0,
+      +   "exitCode": 1,
+      +   "stderr": "boom",
+        }
+
+      - Expected  - 1
+      + Received  + 2
+      "
+    `);
+  });
+
+  test.concurrent("trims an object shared by two branches against each branch's pattern", async () => {
+    expect(
+      await failureMessage(`
+        const shared = { x: 1, y: 2, z: 3 };
+        expect({ a: shared, b: shared }).toMatchObject({ a: { x: 2 }, b: { y: 3 } });
+      `),
+    ).toMatchInlineSnapshot(`
+      "expect(received).toMatchObject(expected)
+
+        {
+          "a": {
+      -     "x": 2,
+      +     "x": 1,
+          },
+          "b": {
+      -     "y": 3,
+      +     "y": 2,
+          },
+        }
+
+      - Expected  - 2
+      + Received  + 2
+      "
+    `);
+  });
+
+  test.concurrent("handles a cyclic pattern", async () => {
+    expect(
+      await failureMessage(`
+        const received = { a: 1, b: 2 };
+        received.self = received;
+        const pattern = { a: 2 };
+        pattern.self = pattern;
+        expect(received).toMatchObject(pattern);
+      `),
+    ).toMatchInlineSnapshot(`
+      "expect(received).toMatchObject(expected)
+
+        {
+      -   "a": 2,
+      +   "a": 1,
+          "self": [Circular],
+        }
+
+      - Expected  - 1
+      + Received  + 1
+      "
+    `);
+  });
+
+  test.concurrent(".not still prints the pattern", async () => {
+    expect(
+      await failureMessage(`
+        expect({ a: 1, b: 2 }).not.toMatchObject({ a: 1 });
+      `),
+    ).toMatchInlineSnapshot(`
+      "expect(received).not.toMatchObject(expected)
+
+      Expected: not {
+        "a": 1,
+      }
+      "
+    `);
+  });
+});
+
 it("test --preload supports global lifecycle hooks", () => {
   const preloadedPath = join(tmp, "test-fixture-preload-global-lifecycle-hook-preloaded.js");
   const path = join(tmp, "test-fixture-preload-global-lifecycle-hook-test.test.js");


### PR DESCRIPTION
### Problem
- When `expect(received).toMatchObject(pattern)` fails, the diff formats the whole received value, so every property the pattern does not mention prints as a received-only `+` line and the actual mismatch is buried. `expect({ a: 1, b: 2, c: 3, nested: { x: 1, y: 2 } }).toMatchObject({ a: 2, nested: { x: 1 } })` prints `a`, `b`, `c` and `nested.y` as differences (`- Expected - 1 / + Received + 4`); only `a` is one.
- A received value with its own print form degrades further: `expect(reactElement).toMatchObject({ props: { id: "x" } })` prints the pattern as removed and `<div id="y" />` as added, which shows neither the property that differs nor what it holds.
- Cause: `src/runtime/test_runner/expect/toMatchObject.rs:43` hands the full received value to `DiffFormatter`, and `src/runtime/test_runner/diff_format.rs:47` formats each side independently and line-diffs the text, so whatever is handed in decides what the diff shows. Jest diffs `getObjectSubset(received, expected)`: the received value trimmed to the pattern's properties.

### Fix
- New `src/jsc/bindings/ExpectObjectSubset.cpp` (`Expect__toMatchObjectSubset`) builds the received side of the diff: it walks the pattern's properties with the same enumeration `Bun__deepMatch` uses, copies the received object's value for each of them into a new object that has the received object's prototype, and recurses where both values are ordinary objects or arrays of the same length. `toMatchObject.rs` diffs that object on the positive failure path; `.not` still prints only the pattern.
- Matches jest and vitest, whose `toMatchObject` diffs `getObjectSubset(received, expected)`.
- The subset contains exactly the values the match compared: it is driven by the same property enumeration as `Bun__deepMatch` and the same prototype-chain lookup, so a property the received object lacks is left out (its pattern line shows as missing) and one it inherits, such as a class getter, is shown with its value. Jest iterates the received object's own keys instead and therefore cannot show an inherited value; this is the one deliberate difference.
- Only pairs of ordinary objects (`FinalObjectType`) and arrays of equal length are trimmed. Those print property by property, so the copy prints as the original minus the dropped lines; everything else (Date, Map, Error, native class instances, asymmetric matchers, functions) is copied as is and keeps the print form it has today, and arrays whose lengths differ are the mismatch, so they are shown whole.
- The copy takes the received object's prototype, so the class-name prefix in the diff (`Foo {`) is unchanged. A received object with none of the pattern's properties is shown whole, as in jest, so an empty `{}` never hides what was received.
- Visited pairs are kept in a map keyed on (received object, pattern object): a cyclic pattern terminates and prints `[Circular]` on both sides, while an object that the received value shares between two branches is trimmed against each branch's own pattern. A `MarkedArgumentBuffer` keeps the objects in the map alive for the walk.
- Trimming is presentation only, so when `vm.isSafeToRecurse()` says the stack is nearly exhausted the rest of that branch is shown untrimmed instead of throwing. Exceptions from getters propagate, as they do from the match itself.
- Asymmetric matchers print exactly as before: the copy holds whatever the received object holds once the match has run, including the matchers `Bun__deepMatch` writes back today, so this composes with #36647 and #35452 in either order. `toHaveBeenCalledWith(expect.objectContaining(...))` is untouched (jest prints the full arguments there too), and the snapshot property-matcher failure, which prints no diff at all, is a separate gap.
- Behavior note for reviewers: tests that put extra properties into the received object so they show up on failure (`expect({ stdout, stderr, exitCode }).toMatchObject({ exitCode: 0 })`, about 70 sites in this repo) no longer get those properties printed, which is also how jest behaves. `expect(value, message)` is the supported way to attach context to a failure.
- Verified with `test/js/bun/test/test-test.test.ts` (`expect().toMatchObject() failure diff`, 13 cases pinning the exact messages; 11 fail on the released binary, the `.not` and nothing-in-common cases pin behavior that must not change).
- `expect.test.js`, `bun-object/deep-match.spec.ts`, `snapshot-tests/bun-snapshots.test.ts`, `jest-extended.test.js`, `spyMatchers.test.ts` and the rest of `test-test.test.ts` pass on the debug build; the edge cases below were also run under `BUN_JSC_validateExceptionChecks=1`.
- A 2000-branch failing `toMatchObject` run under `BUN_JSC_collectContinuously=1` produced the expected 2000 line pairs and nothing else; 1000, 3000 and 10000 branches scale linearly.

### Background
- `toMatchObject` is a subset match: `Bun__deepMatch` (`src/jsc/bindings/bindings.cpp`) enumerates the pattern's enumerable properties, looks each one up on the received object through its prototype chain, recurses when both values are objects, and otherwise compares with SameValue or runs the asymmetric matcher. When a matcher passes it currently writes the matcher into the received object (#3521), which is what makes matched matchers print identically on both sides of the diff.
- `DiffFormatter` (`diff_format.rs`) pretty-prints each side with the test runner's formatter and diffs the resulting lines; it has no notion of which properties the matcher looked at.
- `FinalObjectType` is JSC's type for objects with no exotic behavior: object literals, class instances, `Object.create` results. `JSArray` covers `Array` and its subclasses. The formatter prints both kinds as a list of their properties or elements, which is what makes a trimmed copy print like the original.
- `[[ZIG_EXPORT(zero_is_throw)]]` makes the build generate the `bun_jsc::cpp::Expect__toMatchObjectSubset` wrapper the Rust side calls; returning an empty value signals a pending exception, which the wrapper turns into `Err`.
- `MarkedArgumentBuffer` is a GC root: values appended to it are marked, so objects referenced only from C++ containers during the walk cannot be collected or have their addresses reused. `vm.isSafeToRecurse()` is the stack headroom check JSC's own recursive helpers (and `Bun__deepEquals`) use.

<details>
<summary>Before / after for the two cases in the report</summary>

Plain objects, before:

```
  {
-   "a": 2,
+   "a": 1,
+   "b": 2,
+   "c": 3,
    "nested": {
      "x": 1,
+     "y": 2,
    },
  }

- Expected  - 1
+ Received  + 4
```

after:

```
  {
-   "a": 2,
+   "a": 1,
    "nested": {
      "x": 1,
    },
  }

- Expected  - 1
+ Received  + 1
```

React element (`{ $$typeof: Symbol.for("react.element"), type: "div", key: null, ref: null, props: { id: "y" } }` against `{ props: { id: "x" } }`), before:

```
- {
-   "props": {
-     "id": "x",
-   },
- }
+ <div id="y" />

- Expected  - 5
+ Received  + 1
```

after:

```
  {
    "props": {
-     "id": "x",
+     "id": "y",
    },
  }

- Expected  - 1
+ Received  + 1
```

</details>

<details>
<summary>Other shapes checked by hand (debug build)</summary>

- Missing property: `{ a: 1, b: 2 }` vs `{ a: 1, z: 3 }` prints `"a"` as context and `- "z": 3`.
- Arrays: same length trims element by element; `[1, 2, 3]` vs `[1, 2]` is shown whole (`+ 3`), and the unrelated sibling property is dropped.
- Class instance: `- {` / `+ Foo {` lines as today, unrelated fields gone. Class getter in the pattern: shows `42` vs `43`.
- Symbol keys, index-like keys on plain objects, null-prototype received object, `Object.create(proto)` pattern with an inherited enumerable key.
- Received array vs pattern object and vice versa, and an asymmetric matcher as the whole pattern: unchanged output (nothing is trimmed).
- Shared received object under two pattern branches: each branch trimmed against its own pattern. Cyclic received and pattern: `[Circular]` on both sides.
- Getter that throws on a property after the failing one: the getter's error propagates (the match itself throws it when that property comes first).
- Matched matcher after the failing property, and a fully matching class-instance branch: same flagged lines as today minus the unrelated ones (these are #36647's territory).

</details>
