### PR TITLE
bun test: keep the frame of a matcher call made in tail position

### DIFF
--- a/src/ast/transpiler_cache.rs
+++ b/src/ast/transpiler_cache.rs
@@ -17,8 +17,10 @@ pub struct RuntimeTranspilerCache {
     pub input_hash: Option<u64>,
     pub input_byte_length: Option<u64>,
     pub features_hash: Option<u64>,
-    /// Set by `get()`; selects the mode-specific cache filename in `put()`.
+    /// Set by `get()`; stored in the entry metadata by `put()`.
     pub inject_jest_globals: bool,
+    /// Set by the parser after the visit pass; stored in the entry metadata by `put()`.
+    pub uses_test_framework: bool,
     pub exports_kind: ExportsKind,
     /// Set by `put()` / `get()` when a cache hit returns transpiled output.
     /// Bundler/parser only store/read the bytes; T6 owns the string wrapper
@@ -40,6 +42,7 @@ impl Default for RuntimeTranspilerCache {
             input_byte_length: None,
             features_hash: None,
             inject_jest_globals: false,
+            uses_test_framework: false,
             exports_kind: ExportsKind::None,
             output_code: None,
             entry: None,

--- a/src/ast/transpiler_cache.rs
+++ b/src/ast/transpiler_cache.rs
@@ -17,6 +17,8 @@ pub struct RuntimeTranspilerCache {
     pub input_hash: Option<u64>,
     pub input_byte_length: Option<u64>,
     pub features_hash: Option<u64>,
+    /// Set by `get()`; selects the mode-specific cache filename in `put()`.
+    pub inject_jest_globals: bool,
     pub exports_kind: ExportsKind,
     /// Set by `put()` / `get()` when a cache hit returns transpiled output.
     /// Bundler/parser only store/read the bytes; T6 owns the string wrapper
@@ -37,6 +39,7 @@ impl Default for RuntimeTranspilerCache {
             input_hash: None,
             input_byte_length: None,
             features_hash: None,
+            inject_jest_globals: false,
             exports_kind: ExportsKind::None,
             output_code: None,
             entry: None,

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -2139,6 +2139,46 @@ impl<'a> Parser<'a> {
             }
         }
 
+        // `var <tmp>;` for `keep_matcher_call_frame` (visit_stmt.rs). Like the globals above, this
+        // makes the output specific to `bun test`, so it must not be cached either.
+        if let Some(matcher_result) = p.jest.matcher_result {
+            let binding = p.b(
+                B::Identifier {
+                    r#ref: matcher_result,
+                },
+                bun_ast::Loc::EMPTY,
+            );
+            let mut decls = G::DeclList::init_capacity(1);
+            decls.append_assume_capacity(G::Decl {
+                binding,
+                value: None,
+            });
+            let var_stmt = p.s(
+                S::Local {
+                    kind: js_ast::LocalKind::KVar,
+                    decls,
+                    ..Default::default()
+                },
+                bun_ast::Loc::EMPTY,
+            );
+            let part_stmts = p.arena.alloc_slice_fill_with(1, |_| var_stmt);
+            let mut declared_symbols =
+                bun_ast::DeclaredSymbolList::init_capacity(1).expect("unreachable");
+            declared_symbols.append_assume_capacity(DeclaredSymbol {
+                ref_: matcher_result,
+                is_top_level: true,
+            });
+            before.push(js_ast::Part {
+                stmts: part_stmts.into(),
+                declared_symbols,
+                tag: bun_ast::PartTag::BunTest,
+                ..Default::default()
+            });
+            if let Some(cache) = p.options.features.runtime_transpiler_cache_mut() {
+                cache.input_hash = None;
+            }
+        }
+
         if p.has_called_runtime {
             let mut runtime_imports: [u8; RuntimeImports::ALL.len()] =
                 [0; RuntimeImports::ALL.len()];

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -2139,41 +2139,9 @@ impl<'a> Parser<'a> {
             }
         }
 
-        // `var <tmp>;` for `keep_matcher_call_frame` (visit_stmt.rs). Like the globals above, this
-        // makes the output specific to `bun test`, so it must not be cached either.
-        if let Some(matcher_result) = p.jest.matcher_result {
-            let binding = p.b(
-                B::Identifier {
-                    r#ref: matcher_result,
-                },
-                bun_ast::Loc::EMPTY,
-            );
-            let mut decls = G::DeclList::init_capacity(1);
-            decls.append_assume_capacity(G::Decl {
-                binding,
-                value: None,
-            });
-            let var_stmt = p.s(
-                S::Local {
-                    kind: js_ast::LocalKind::KVar,
-                    decls,
-                    ..Default::default()
-                },
-                bun_ast::Loc::EMPTY,
-            );
-            let part_stmts = p.arena.alloc_slice_fill_with(1, |_| var_stmt);
-            let mut declared_symbols =
-                bun_ast::DeclaredSymbolList::init_capacity(1).expect("unreachable");
-            declared_symbols.append_assume_capacity(DeclaredSymbol {
-                ref_: matcher_result,
-                is_top_level: true,
-            });
-            before.push(js_ast::Part {
-                stmts: part_stmts.into(),
-                declared_symbols,
-                tag: bun_ast::PartTag::BunTest,
-                ..Default::default()
-            });
+        // `keep_matcher_call_frame` (visit_stmt.rs) rewrote a returned matcher call. Like the
+        // globals above, this makes the output specific to `bun test`, so it must not be cached.
+        if p.jest.rewrote_matcher_tail_call {
             if let Some(cache) = p.options.features.runtime_transpiler_cache_mut() {
                 cache.input_hash = None;
             }

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -2147,6 +2147,24 @@ impl<'a> Parser<'a> {
             }
         }
 
+        // The entry records whether this file can transpile differently under `bun test`
+        // (`keep_matcher_call_frame`), so the cache read can reject a `bun run` entry for
+        // such a file instead of serving output with the rewrite missing.
+        if let Some(cache) = p.options.features.runtime_transpiler_cache_mut() {
+            cache.uses_test_framework = p.import_records.items().iter().any(|item| {
+                item.path.text == b"bun:test"
+                    || item.path.text == b"@jest/globals"
+                    || item.path.text == b"vitest"
+            }) || p
+                .module_scope()
+                .members
+                .get(b"expect".as_slice())
+                .is_some_and(|member| {
+                    p.symbols[member.ref_.inner_index() as usize].kind
+                        == js_ast::symbol::Kind::Unbound
+                });
+        }
+
         if p.has_called_runtime {
             let mut runtime_imports: [u8; RuntimeImports::ALL.len()] =
                 [0; RuntimeImports::ALL.len()];

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -2148,20 +2148,16 @@ impl<'a> Parser<'a> {
         }
 
         // The entry records whether this file can transpile differently under `bun test`
-        // (`keep_matcher_call_frame`), so the cache read can reject a `bun run` entry for
-        // such a file instead of serving output with the rewrite missing.
+        // (`keep_matcher_call_frame`, the import rewrites above), so the cache read can
+        // reject a `bun run` entry for such a file instead of serving output with the
+        // rewrite missing.
         if let Some(cache) = p.options.features.runtime_transpiler_cache_mut() {
-            cache.uses_test_framework = p.import_records.items().iter().any(|item| {
-                item.path.text == b"bun:test"
-                    || item.path.text == b"@jest/globals"
-                    || item.path.text == b"vitest"
-            }) || p
-                .module_scope()
-                .members
-                .get(b"expect".as_slice())
-                .is_some_and(|member| {
-                    p.symbols[member.ref_.inner_index() as usize].kind
-                        == js_ast::symbol::Kind::Unbound
+            cache.uses_test_framework = p.jest.rewrote_matcher_tail_call
+                || p.jest.returned_matcher_call
+                || p.import_records.items().iter().any(|item| {
+                    item.path.text == b"bun:test"
+                        || item.path.text == b"@jest/globals"
+                        || item.path.text == b"vitest"
                 });
         }
 

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -359,7 +359,7 @@ pub mod Runtime {
         pub(crate) fn hash_for_runtime_transpiler(&self, hasher: &mut Wyhash) {
             debug_assert!(self.runtime_transpiler_cache.is_some());
 
-            let bools: [bool; 17] = [
+            let bools: [bool; 18] = [
                 self.top_level_await,
                 self.auto_import_jsx,
                 self.allow_runtime,
@@ -377,7 +377,11 @@ pub mod Runtime {
                 self.standard_decorators,
                 self.lower_using,
                 self.repl_mode,
-                // note that we do not include .inject_jest_globals, as we bail out of the cache entirely if this is true
+                // `keep_matcher_call_frame` changes the output of a file with an explicit
+                // `bun:test` import, which stays cacheable. The `input_hash = None` bails in
+                // `_parse` only stop the write: the read has already served `Result::Cached`,
+                // so the hash has to separate the two modes.
+                self.inject_jest_globals,
             ];
 
             // `[bool; N]` is N bytes of 0x00/0x01.

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -359,7 +359,7 @@ pub mod Runtime {
         pub(crate) fn hash_for_runtime_transpiler(&self, hasher: &mut Wyhash) {
             debug_assert!(self.runtime_transpiler_cache.is_some());
 
-            let bools: [bool; 18] = [
+            let bools: [bool; 17] = [
                 self.top_level_await,
                 self.auto_import_jsx,
                 self.allow_runtime,
@@ -377,9 +377,9 @@ pub mod Runtime {
                 self.standard_decorators,
                 self.lower_using,
                 self.repl_mode,
-                // `bun test` output differs (`keep_matcher_call_frame`) and uses its own
-                // cache filename (`write_cache_filename`); the hash carries the mode too.
-                self.inject_jest_globals,
+                // `.inject_jest_globals` is not hashed: the modes share entries, and the
+                // one output divergence (`keep_matcher_call_frame`) is rejected at read
+                // time through `Metadata::flags` (RuntimeTranspilerCache.rs).
             ];
 
             // `[bool; N]` is N bytes of 0x00/0x01.

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -377,10 +377,8 @@ pub mod Runtime {
                 self.standard_decorators,
                 self.lower_using,
                 self.repl_mode,
-                // `keep_matcher_call_frame` changes the output of a file with an explicit
-                // `bun:test` import, which stays cacheable. The `input_hash = None` bails in
-                // `_parse` only stop the write: the read has already served `Result::Cached`,
-                // so the hash has to separate the two modes.
+                // `bun test` output differs (`keep_matcher_call_frame`) and uses its own
+                // cache filename (`write_cache_filename`); the hash carries the mode too.
                 self.inject_jest_globals,
             ];
 

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1585,9 +1585,9 @@ pub struct Jest {
     pub(crate) xit: Ref,
     pub(crate) xtest: Ref,
     pub(crate) xdescribe: Ref,
-    /// Module-level temporary that returned matcher calls are assigned to, created by the first
-    /// such return (`P::keep_matcher_call_frame`). Not in `FIELDS`: it is declared, not imported.
-    pub(crate) matcher_result: Option<Ref>,
+    /// `P::keep_matcher_call_frame` rewrote a returned matcher call, so the output is specific
+    /// to `bun test` and must not enter the runtime transpiler cache.
+    pub(crate) rewrote_matcher_tail_call: bool,
 }
 
 impl Jest {
@@ -1630,7 +1630,7 @@ impl Default for Jest {
             xit: Ref::NONE,
             xtest: Ref::NONE,
             xdescribe: Ref::NONE,
-            matcher_result: None,
+            rewrote_matcher_tail_call: false,
         }
     }
 }

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1585,6 +1585,9 @@ pub struct Jest {
     pub(crate) xit: Ref,
     pub(crate) xtest: Ref,
     pub(crate) xdescribe: Ref,
+    /// Module-level temporary that returned matcher calls are assigned to, created by the first
+    /// such return (`P::keep_matcher_call_frame`). Not in `FIELDS`: it is declared, not imported.
+    pub(crate) matcher_result: Option<Ref>,
 }
 
 impl Jest {
@@ -1627,6 +1630,7 @@ impl Default for Jest {
             xit: Ref::NONE,
             xtest: Ref::NONE,
             xdescribe: Ref::NONE,
+            matcher_result: None,
         }
     }
 }

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1590,6 +1590,9 @@ pub struct Jest {
     /// `P::keep_matcher_call_frame` rewrote a returned matcher call, so the output is specific
     /// to `bun test` and must not enter the runtime transpiler cache.
     pub(crate) rewrote_matcher_tail_call: bool,
+    /// `P::returns_matcher_call` found a returned matcher call with the rewrite off, so a
+    /// `bun test` transpile of this file would produce different output.
+    pub(crate) returned_matcher_call: bool,
 }
 
 impl Jest {
@@ -1633,6 +1636,7 @@ impl Default for Jest {
             xtest: Ref::NONE,
             xdescribe: Ref::NONE,
             rewrote_matcher_tail_call: false,
+            returned_matcher_call: false,
         }
     }
 }

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -1619,14 +1619,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     /// `bun test` only. A returned matcher call, which is also what `() => expect(x).toBe(1)` is,
     /// is a proper tail call (test files are modules, so strict mode): JSC replaces the frame that
     /// contains the call with the matcher's own, so a failure has no location to report and an
-    /// inline snapshot has nowhere to be written. `return (tmp = expect(x).toBe(1), tmp)` keeps the
+    /// inline snapshot has nowhere to be written. `return [expect(x).toBe(1)][0]` keeps the
     /// frame. Tail position continues into the branches of `?:` and the right operand of `,`,
     /// `&&`, `||` and `??`.
     fn keep_matcher_call_frame(&mut self, value: &mut Expr) {
         match value.data {
             js_ast::ExprData::ECall(call) => {
                 if self.is_matcher_call(call.target) {
-                    *value = self.assign_to_matcher_result(*value);
+                    *value = self.take_out_of_tail_position(*value);
                 }
             }
             js_ast::ExprData::EIf(mut e) => {
@@ -1678,25 +1678,30 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// `(tmp = call, tmp)`, with `tmp` declared once per module by `_parse`.
-    fn assign_to_matcher_result(&mut self, call: Expr) -> Expr {
-        let ref_ = match self.jest.matcher_result {
-            Some(ref_) => ref_,
-            None => {
-                let ref_ = self.declare_generated_symbol(
-                    js_ast::symbol::Kind::Other,
-                    b"bun_test_matcher_result",
-                );
-                self.jest.matcher_result = Some(ref_);
-                ref_
-            }
-        };
+    /// `[call][0]`. Self-contained on purpose: a generated temporary would turn
+    /// `Function.prototype.toString` output into code with a free identifier, and test code does
+    /// round-trip such text into other modules.
+    fn take_out_of_tail_position(&mut self, call: Expr) -> Expr {
+        self.jest.rewrote_matcher_tail_call = true;
         let loc = call.loc;
-        self.record_usage(ref_);
-        let assigned = self.new_expr(E::Identifier::init(ref_), loc);
-        self.record_usage(ref_);
-        let read = self.new_expr(E::Identifier::init(ref_), loc);
-        Expr::assign(assigned, call).join_with_comma(read)
+        let items = js_ast::ExprNodeList::from_arena_slice(self.arena.alloc_slice_copy(&[call]));
+        let array = self.new_expr(
+            E::Array {
+                items,
+                is_single_line: true,
+                ..Default::default()
+            },
+            loc,
+        );
+        let index = self.new_expr(E::Number::new(0.0), loc);
+        self.new_expr(
+            E::Index {
+                target: array,
+                index,
+                optional_chain: None,
+            },
+            loc,
+        )
     }
 
     fn s_block(

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -1599,8 +1599,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if let Some(val) = data.value.as_mut() {
             p.visit_expr(val);
 
-            if p.options.features.inject_jest_globals && !p.is_control_flow_dead {
-                p.keep_matcher_call_frame(val);
+            if !p.is_control_flow_dead {
+                if p.options.features.inject_jest_globals {
+                    p.keep_matcher_call_frame(val);
+                } else if !p.jest.returned_matcher_call
+                    && p.options.features.runtime_transpiler_cache_mut().is_some()
+                    && p.returns_matcher_call(val)
+                {
+                    p.jest.returned_matcher_call = true;
+                }
             }
 
             // "return undefined;" can safely just always be "return;"
@@ -1645,6 +1652,30 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 self.keep_matcher_call_frame(&mut e.right);
             }
             _ => {}
+        }
+    }
+
+    /// Detection-only mirror of `keep_matcher_call_frame` for when the rewrite is off. The
+    /// transpiler cache entry records the result, so a `bun test` read can reject this file's
+    /// `bun run` output (`Metadata::FLAG_USES_TEST_FRAMEWORK`).
+    fn returns_matcher_call(&self, value: &Expr) -> bool {
+        match value.data {
+            js_ast::ExprData::ECall(call) => self.is_matcher_call(call.target),
+            js_ast::ExprData::EIf(e) => {
+                self.returns_matcher_call(&e.yes) || self.returns_matcher_call(&e.no)
+            }
+            js_ast::ExprData::EBinary(e)
+                if matches!(
+                    e.op,
+                    js_ast::OpCode::BinComma
+                        | js_ast::OpCode::BinLogicalAnd
+                        | js_ast::OpCode::BinLogicalOr
+                        | js_ast::OpCode::BinNullishCoalescing
+                ) =>
+            {
+                self.returns_matcher_call(&e.right)
+            }
+            _ => false,
         }
     }
 

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -1699,6 +1699,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 target: array,
                 index,
                 optional_chain: None,
+                is_import_property_use: false,
             },
             loc,
         )

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -1599,6 +1599,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if let Some(val) = data.value.as_mut() {
             p.visit_expr(val);
 
+            if p.options.features.inject_jest_globals && !p.is_control_flow_dead {
+                p.keep_matcher_call_frame(val);
+            }
+
             // "return undefined;" can safely just always be "return;"
             if let Some(v) = data.value {
                 if matches!(v.data, js_ast::ExprData::EUndefined(_)) {
@@ -1610,6 +1614,89 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         stmts.push(*stmt);
         Ok(())
+    }
+
+    /// `bun test` only. A returned matcher call, which is also what `() => expect(x).toBe(1)` is,
+    /// is a proper tail call (test files are modules, so strict mode): JSC replaces the frame that
+    /// contains the call with the matcher's own, so a failure has no location to report and an
+    /// inline snapshot has nowhere to be written. `return (tmp = expect(x).toBe(1), tmp)` keeps the
+    /// frame. Tail position continues into the branches of `?:` and the right operand of `,`,
+    /// `&&`, `||` and `??`.
+    fn keep_matcher_call_frame(&mut self, value: &mut Expr) {
+        match value.data {
+            js_ast::ExprData::ECall(call) => {
+                if self.is_matcher_call(call.target) {
+                    *value = self.assign_to_matcher_result(*value);
+                }
+            }
+            js_ast::ExprData::EIf(mut e) => {
+                self.keep_matcher_call_frame(&mut e.yes);
+                self.keep_matcher_call_frame(&mut e.no);
+            }
+            js_ast::ExprData::EBinary(mut e)
+                if matches!(
+                    e.op,
+                    js_ast::OpCode::BinComma
+                        | js_ast::OpCode::BinLogicalAnd
+                        | js_ast::OpCode::BinLogicalOr
+                        | js_ast::OpCode::BinNullishCoalescing
+                ) =>
+            {
+                self.keep_matcher_call_frame(&mut e.right);
+            }
+            _ => {}
+        }
+    }
+
+    /// A method call on `expect(...)`, through any chain such as `.not` or `.resolves`, or a call
+    /// to one of the inline snapshot matchers on any receiver.
+    fn is_matcher_call(&self, callee: Expr) -> bool {
+        let Some(dot) = callee.data.e_dot() else {
+            return false;
+        };
+        if dot.name == b"toMatchInlineSnapshot" || dot.name == b"toThrowErrorMatchingInlineSnapshot"
+        {
+            return true;
+        }
+        let mut receiver = dot.target;
+        loop {
+            match receiver.data {
+                js_ast::ExprData::EDot(inner) => receiver = inner.target,
+                js_ast::ExprData::ECall(call) => {
+                    let ref_ = match call.target.data {
+                        js_ast::ExprData::EIdentifier(id) => id.ref_,
+                        js_ast::ExprData::EImportIdentifier(id) => id.ref_,
+                        _ => return false,
+                    };
+                    return self.symbols[ref_.inner_index() as usize]
+                        .original_name
+                        .slice()
+                        == b"expect";
+                }
+                _ => return false,
+            }
+        }
+    }
+
+    /// `(tmp = call, tmp)`, with `tmp` declared once per module by `_parse`.
+    fn assign_to_matcher_result(&mut self, call: Expr) -> Expr {
+        let ref_ = match self.jest.matcher_result {
+            Some(ref_) => ref_,
+            None => {
+                let ref_ = self.declare_generated_symbol(
+                    js_ast::symbol::Kind::Other,
+                    b"bun_test_matcher_result",
+                );
+                self.jest.matcher_result = Some(ref_);
+                ref_
+            }
+        };
+        let loc = call.loc;
+        self.record_usage(ref_);
+        let assigned = self.new_expr(E::Identifier::init(ref_), loc);
+        self.record_usage(ref_);
+        let read = self.new_expr(E::Identifier::init(ref_), loc);
+        Expr::assign(assigned, call).join_with_comma(read)
     }
 
     fn s_block(

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -58,10 +58,9 @@ bun_core::declare_scope!(cache, visible);
 /// Version 28: the define table and `--drop` entries participate in the features hash.
 /// Version 29: `new Array(x, ...spread)` is no longer folded into an array literal.
 /// Version 30: String enum members are stored flat, so folds no longer append onto an inlined member.
-/// Version 31: `inject_jest_globals` participates in the features hash. The
-/// matcher tail-call rewrite changes the output of a file with an explicit
-/// `bun:test` import, which stays cacheable, so `bun run` and `bun test` must
-/// not share entries for it.
+/// Version 31: `Metadata` grows a flags byte (written under `bun test`, uses the
+/// test framework), so the read path can reject the one cross-mode entry whose
+/// output depends on the mode (the matcher tail-call rewrite).
 const EXPECTED_VERSION: u32 = 31;
 
 /// Source files smaller than this are not written to / read from the on-disk
@@ -109,6 +108,9 @@ pub struct Metadata {
     pub(crate) cache_version: u32,
     pub(crate) output_encoding: Encoding,
     pub module_type: ModuleType,
+    /// `FLAG_*` bits. They let the read path reject the one entry whose output
+    /// depends on the mode: see `from_file_with_cache_file_path`.
+    pub(crate) flags: u8,
 
     pub(crate) features_hash: u64,
 
@@ -134,6 +136,7 @@ impl Default for Metadata {
             cache_version: EXPECTED_VERSION,
             output_encoding: Encoding::NONE,
             module_type: ModuleType::None,
+            flags: 0,
             features_hash: 0,
             input_byte_length: 0,
             input_hash: 0,
@@ -151,13 +154,20 @@ impl Default for Metadata {
 }
 
 impl Metadata {
-    // 1×u32 + 2×u8 (enum reprs) + 12×u64 = 4 + 2 + 96 = 102
-    pub(crate) const SIZE: usize = 4 + 1 + 1 + 12 * 8;
+    /// The entry was written with `inject_jest_globals` on (a `bun test` transpile).
+    pub(crate) const FLAG_JEST_MODE: u8 = 1;
+    /// The file imports `bun:test` (or `@jest/globals` / `vitest`), or references an
+    /// unbound `expect`, so its `bun test` output can differ from its `bun run` output.
+    pub(crate) const FLAG_USES_TEST_FRAMEWORK: u8 = 2;
+
+    // 1×u32 + 3×u8 (enum reprs + flags) + 12×u64 = 4 + 3 + 96 = 103
+    pub(crate) const SIZE: usize = 4 + 1 + 1 + 1 + 12 * 8;
 
     pub(crate) fn encode<W: bun_io::Write>(&self, writer: &mut W) -> crate::CrateResult<()> {
         writer.write_int_le::<u32>(self.cache_version)?;
         writer.write_int_le::<u8>(self.module_type as u8)?;
         writer.write_int_le::<u8>(self.output_encoding.0)?;
+        writer.write_int_le::<u8>(self.flags)?;
 
         writer.write_int_le::<u64>(self.features_hash)?;
 
@@ -194,6 +204,7 @@ impl Metadata {
         // holds an out-of-range value.
         let module_type_raw = reader.read_int_le::<u8>()?;
         let output_encoding_raw = reader.read_int_le::<u8>()?;
+        self.flags = reader.read_int_le::<u8>()?;
 
         self.features_hash = reader.read_int_le::<u64>()?;
 
@@ -249,6 +260,7 @@ impl Entry {
         esm_record: &[u8],
         output_code: &BunString,
         exports_kind: ExportsKind,
+        flags: u8,
     ) -> crate::CrateResult<()> {
         let _tracer = bun_core::perf::trace("RuntimeTranspilerCache.save");
 
@@ -279,6 +291,7 @@ impl Entry {
                     input_byte_length,
                     input_hash,
                     features_hash,
+                    flags,
                     module_type: match exports_kind {
                         ExportsKind::Cjs => ModuleType::Cjs,
                         _ => ModuleType::Esm,
@@ -580,18 +593,13 @@ impl RuntimeTranspilerCache {
     pub(crate) fn write_cache_filename(
         buf: &mut [u8],
         input_hash: u64,
-        inject_jest_globals: bool,
     ) -> crate::CrateResult<usize> {
         // Hex-encode the 8 native-endian bytes of `input_hash`.
         let bytes = input_hash.to_ne_bytes();
-        // `bun test` transpiles the same file to different output (the matcher tail-call
-        // rewrite), so the two modes use separate files. A shared filename would make each
-        // mode evict the other's entry through the features-hash check on every switch.
-        let suffix: &[u8] = match (inject_jest_globals, bun_core::env::IS_DEBUG) {
-            (false, false) => b".pile",
-            (false, true) => b".debug.pile",
-            (true, false) => b".jest.pile",
-            (true, true) => b".jest.debug.pile",
+        let suffix: &[u8] = if bun_core::env::IS_DEBUG {
+            b".debug.pile"
+        } else {
+            b".pile"
         };
         let needed = bytes.len() * 2 + suffix.len();
         if buf.len() < needed {
@@ -605,15 +613,11 @@ impl RuntimeTranspilerCache {
     pub(crate) fn get_cache_file_path(
         buf: &mut PathBuffer,
         input_hash: u64,
-        inject_jest_globals: bool,
     ) -> crate::CrateResult<&ZStr> {
         let cache_dir_len = Self::get_cache_dir(buf)?;
         buf[cache_dir_len] = SEP;
-        let cache_filename_len = Self::write_cache_filename(
-            &mut buf[cache_dir_len + 1..],
-            input_hash,
-            inject_jest_globals,
-        )?;
+        let cache_filename_len =
+            Self::write_cache_filename(&mut buf[cache_dir_len + 1..], input_hash)?;
         let total = cache_dir_len + 1 + cache_filename_len;
         buf[total] = 0;
 
@@ -735,14 +739,14 @@ impl RuntimeTranspilerCache {
         let _tracer = bun_core::perf::trace("RuntimeTranspilerCache.fromFile");
 
         let mut cache_file_path_buf = bun_paths::path_buffer_pool::get();
-        let cache_file_path =
-            Self::get_cache_file_path(&mut cache_file_path_buf, input_hash, inject_jest_globals)?;
+        let cache_file_path = Self::get_cache_file_path(&mut cache_file_path_buf, input_hash)?;
         debug_assert!(!cache_file_path.is_empty());
         Self::from_file_with_cache_file_path(
             cache_file_path,
             input_hash,
             feature_hash,
             input_stat_size,
+            inject_jest_globals,
         )
     }
 
@@ -751,6 +755,7 @@ impl RuntimeTranspilerCache {
         input_hash: u64,
         feature_hash: u64,
         input_stat_size: u64,
+        inject_jest_globals: bool,
     ) -> crate::CrateResult<Entry> {
         let mut metadata_bytes_buf = [0u8; Metadata::SIZE];
         // NONBLOCK: a FIFO must not block the open. On Windows it would make the handle overlapped.
@@ -792,6 +797,16 @@ impl RuntimeTranspilerCache {
             return Err(crate::CrateError::MismatchedFeatureHash);
         }
 
+        // A `bun run` entry for a file that uses the test framework misses the matcher
+        // tail-call rewrite `bun test` applies. Keep the file: it stays valid for `bun run`.
+        if inject_jest_globals
+            && entry.metadata.flags & Metadata::FLAG_JEST_MODE == 0
+            && entry.metadata.flags & Metadata::FLAG_USES_TEST_FRAMEWORK != 0
+        {
+            let _ = scopeguard::ScopeGuard::into_inner(unlink_guard);
+            return Err(crate::CrateError::WrongModeForTestFile);
+        }
+
         entry.load(&file, stat_size)?;
 
         let _ = scopeguard::ScopeGuard::into_inner(unlink_guard);
@@ -806,13 +821,12 @@ impl RuntimeTranspilerCache {
         esm_record: &[u8],
         source_code: &BunString,
         exports_kind: ExportsKind,
-        inject_jest_globals: bool,
+        flags: u8,
     ) -> crate::CrateResult<()> {
         let _tracer = bun_core::perf::trace("RuntimeTranspilerCache.toFile");
 
         let mut cache_file_path_buf = bun_paths::path_buffer_pool::get();
-        let cache_file_path =
-            Self::get_cache_file_path(&mut cache_file_path_buf, input_hash, inject_jest_globals)?;
+        let cache_file_path = Self::get_cache_file_path(&mut cache_file_path_buf, input_hash)?;
         bun_core::scoped_log!(
             cache,
             "filename to put into: '{}'",
@@ -856,6 +870,7 @@ impl RuntimeTranspilerCache {
             esm_record,
             source_code,
             exports_kind,
+            flags,
         )
     }
 
@@ -999,6 +1014,15 @@ bun_ast::link_impl_TranspilerCacheImpl! {
             // tag (unmarked 8-bit EncodedSlice -> Encoding::LATIN1, same as clone_latin1),
             // and `output_code_bytes` outlives the synchronous `to_file` call.
             let output_code = BunString::ascii(output_code_bytes);
+            let flags = if this.inject_jest_globals {
+                Metadata::FLAG_JEST_MODE
+            } else {
+                0
+            } | if this.uses_test_framework {
+                Metadata::FLAG_USES_TEST_FRAMEWORK
+            } else {
+                0
+            };
             let result = RuntimeTranspilerCache::to_file(
                 this.input_byte_length.unwrap(),
                 this.input_hash.unwrap(),
@@ -1007,7 +1031,7 @@ bun_ast::link_impl_TranspilerCacheImpl! {
                 esm_record,
                 &output_code,
                 this.exports_kind,
-                this.inject_jest_globals,
+                flags,
             );
             if let Err(err) = result {
                 bun_core::scoped_log!(cache, "put() = {}", err.name());

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -541,6 +541,7 @@ pub struct RuntimeTranspilerCache {
     pub(crate) input_byte_length: Option<u64>,
     pub(crate) features_hash: Option<u64>,
     pub(crate) exports_kind: ExportsKind,
+    pub(crate) inject_jest_globals: bool,
     pub(crate) entry: Option<Entry>,
     // `sourcemap` / `esm_record` are owned `Box<[u8]>` (global mimalloc).
     // The per-call arena that once backed the output code is gone: the UTF-8
@@ -579,13 +580,18 @@ impl RuntimeTranspilerCache {
     pub(crate) fn write_cache_filename(
         buf: &mut [u8],
         input_hash: u64,
+        inject_jest_globals: bool,
     ) -> crate::CrateResult<usize> {
         // Hex-encode the 8 native-endian bytes of `input_hash`.
         let bytes = input_hash.to_ne_bytes();
-        let suffix: &[u8] = if bun_core::env::IS_DEBUG {
-            b".debug.pile"
-        } else {
-            b".pile"
+        // `bun test` transpiles the same file to different output (the matcher tail-call
+        // rewrite), so the two modes use separate files. A shared filename would make each
+        // mode evict the other's entry through the features-hash check on every switch.
+        let suffix: &[u8] = match (inject_jest_globals, bun_core::env::IS_DEBUG) {
+            (false, false) => b".pile",
+            (false, true) => b".debug.pile",
+            (true, false) => b".jest.pile",
+            (true, true) => b".jest.debug.pile",
         };
         let needed = bytes.len() * 2 + suffix.len();
         if buf.len() < needed {
@@ -599,11 +605,15 @@ impl RuntimeTranspilerCache {
     pub(crate) fn get_cache_file_path(
         buf: &mut PathBuffer,
         input_hash: u64,
+        inject_jest_globals: bool,
     ) -> crate::CrateResult<&ZStr> {
         let cache_dir_len = Self::get_cache_dir(buf)?;
         buf[cache_dir_len] = SEP;
-        let cache_filename_len =
-            Self::write_cache_filename(&mut buf[cache_dir_len + 1..], input_hash)?;
+        let cache_filename_len = Self::write_cache_filename(
+            &mut buf[cache_dir_len + 1..],
+            input_hash,
+            inject_jest_globals,
+        )?;
         let total = cache_dir_len + 1 + cache_filename_len;
         buf[total] = 0;
 
@@ -720,11 +730,13 @@ impl RuntimeTranspilerCache {
         input_hash: u64,
         feature_hash: u64,
         input_stat_size: u64,
+        inject_jest_globals: bool,
     ) -> crate::CrateResult<Entry> {
         let _tracer = bun_core::perf::trace("RuntimeTranspilerCache.fromFile");
 
         let mut cache_file_path_buf = bun_paths::path_buffer_pool::get();
-        let cache_file_path = Self::get_cache_file_path(&mut cache_file_path_buf, input_hash)?;
+        let cache_file_path =
+            Self::get_cache_file_path(&mut cache_file_path_buf, input_hash, inject_jest_globals)?;
         debug_assert!(!cache_file_path.is_empty());
         Self::from_file_with_cache_file_path(
             cache_file_path,
@@ -794,11 +806,13 @@ impl RuntimeTranspilerCache {
         esm_record: &[u8],
         source_code: &BunString,
         exports_kind: ExportsKind,
+        inject_jest_globals: bool,
     ) -> crate::CrateResult<()> {
         let _tracer = bun_core::perf::trace("RuntimeTranspilerCache.toFile");
 
         let mut cache_file_path_buf = bun_paths::path_buffer_pool::get();
-        let cache_file_path = Self::get_cache_file_path(&mut cache_file_path_buf, input_hash)?;
+        let cache_file_path =
+            Self::get_cache_file_path(&mut cache_file_path_buf, input_hash, inject_jest_globals)?;
         bun_core::scoped_log!(
             cache,
             "filename to put into: '{}'",
@@ -885,11 +899,13 @@ impl RuntimeTranspilerCache {
         let mut features_hasher = Wyhash::init(SEED);
         parser_options.hash_for_runtime_transpiler(&mut features_hasher, used_jsx);
         self.features_hash = Some(features_hasher.final_());
+        self.inject_jest_globals = parser_options.features.inject_jest_globals;
 
         self.entry = match Self::from_file(
             input_hash,
             self.features_hash.unwrap(),
             source.contents.len() as u64,
+            self.inject_jest_globals,
         ) {
             Ok(e) => Some(e),
             Err(err) => {
@@ -958,6 +974,7 @@ bun_ast::link_impl_TranspilerCacheImpl! {
                 input_byte_length: this.input_byte_length,
                 features_hash: this.features_hash,
                 exports_kind: this.exports_kind,
+                inject_jest_globals: this.inject_jest_globals,
                 entry: None,
             };
             let hit = jsc.get(source, parser_options, used_jsx);
@@ -965,6 +982,7 @@ bun_ast::link_impl_TranspilerCacheImpl! {
             this.input_byte_length = jsc.input_byte_length;
             this.features_hash = jsc.features_hash;
             this.exports_kind = jsc.exports_kind;
+            this.inject_jest_globals = jsc.inject_jest_globals;
             if let Some(entry) = jsc.entry {
                 this.entry = Some(bun_core::heap::into_raw(Box::new(entry)).cast::<()>());
             }
@@ -989,6 +1007,7 @@ bun_ast::link_impl_TranspilerCacheImpl! {
                 esm_record,
                 &output_code,
                 this.exports_kind,
+                this.inject_jest_globals,
             );
             if let Err(err) = result {
                 bun_core::scoped_log!(cache, "put() = {}", err.name());

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -58,7 +58,11 @@ bun_core::declare_scope!(cache, visible);
 /// Version 28: the define table and `--drop` entries participate in the features hash.
 /// Version 29: `new Array(x, ...spread)` is no longer folded into an array literal.
 /// Version 30: String enum members are stored flat, so folds no longer append onto an inlined member.
-const EXPECTED_VERSION: u32 = 30;
+/// Version 31: `inject_jest_globals` participates in the features hash. The
+/// matcher tail-call rewrite changes the output of a file with an explicit
+/// `bun:test` import, which stays cacheable, so `bun run` and `bun test` must
+/// not share entries for it.
+const EXPECTED_VERSION: u32 = 31;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -156,8 +156,9 @@ impl Default for Metadata {
 impl Metadata {
     /// The entry was written with `inject_jest_globals` on (a `bun test` transpile).
     pub(crate) const FLAG_JEST_MODE: u8 = 1;
-    /// The file imports `bun:test` (or `@jest/globals` / `vitest`), or references an
-    /// unbound `expect`, so its `bun test` output can differ from its `bun run` output.
+    /// The file contains a returned matcher call, or imports `bun:test` (or
+    /// `@jest/globals` / `vitest`), so its `bun test` output can differ from its
+    /// `bun run` output.
     pub(crate) const FLAG_USES_TEST_FRAMEWORK: u8 = 2;
 
     // 1×u32 + 3×u8 (enum reprs + flags) + 12×u64 = 4 + 3 + 96 = 103

--- a/src/jsc/error.rs
+++ b/src/jsc/error.rs
@@ -30,6 +30,8 @@ pub enum Error {
     InvalidInputHash,
     #[error("MismatchedFeatureHash")]
     MismatchedFeatureHash,
+    #[error("WrongModeForTestFile")]
+    WrongModeForTestFile,
     #[error("WriteError")]
     WriteError,
     #[error("TranspilerJobGenerationMismatch")]
@@ -105,6 +107,7 @@ impl Error {
             Self::CacheDisabled => "CacheDisabled",
             Self::InvalidInputHash => "InvalidInputHash",
             Self::MismatchedFeatureHash => "MismatchedFeatureHash",
+            Self::WrongModeForTestFile => "WrongModeForTestFile",
             Self::WriteError => "WriteError",
             Self::TranspilerJobGenerationMismatch => "TranspilerJobGenerationMismatch",
             Self::ParseError => "ParseError",

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -506,18 +506,18 @@ test("rejects cached module records containing out-of-range string indices", () 
   // *-default / *-namespace sentinels near u32::MAX) must be rejected.
   //
   // Cache entry layout (src/jsc/RuntimeTranspilerCache.rs, Metadata::encode):
-  //   0: cache_version u32, 4: module_type u8, 5: output_encoding u8,
-  //   then twelve u64 fields; esm_record_byte_offset @ 78,
-  //   esm_record_byte_length @ 86, esm_record_hash @ 94. Payload follows @ 102.
+  //   0: cache_version u32, 4: module_type u8, 5: output_encoding u8, 6: flags u8,
+  //   then twelve u64 fields; esm_record_byte_offset @ 79,
+  //   esm_record_byte_length @ 87, esm_record_hash @ 95. Payload follows @ 103.
   // Serialized module record layout (ModuleInfoStringTable + body, see
   // `ModuleInfoDeserialized::serialize` in src/js_printer/lib.rs):
   //   table: [offset_width u8][0;3][count u32][(count+1) offsets][pad to even][bytes]
   //   body:  [flags u8][id_width u8][0;2][n_requested u32][n_records u32]
   //          [n_records tag bytes][n_requested tag bytes][string ids @ id_width ...]
-  const ESM_RECORD_BYTE_OFFSET_AT = 78;
-  const ESM_RECORD_BYTE_LENGTH_AT = 86;
-  const ESM_RECORD_HASH_AT = 94;
-  const METADATA_SIZE = 102;
+  const ESM_RECORD_BYTE_OFFSET_AT = 79;
+  const ESM_RECORD_BYTE_LENGTH_AT = 87;
+  const ESM_RECORD_HASH_AT = 95;
+  const METADATA_SIZE = 103;
 
   function corruptModuleRecordStringIndices(file: string): boolean {
     const data = readFileSync(file);

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -622,18 +622,18 @@ test("rejects a cached entry whose sourcemap section header is corrupt", () => {
   // the entry regenerates, not read out of bounds.
   //
   // Cache entry layout (src/jsc/RuntimeTranspilerCache.rs, Metadata::encode):
-  //   0: cache_version u32, 4: module_type u8, 5: output_encoding u8,
-  //   then twelve u64 fields; sourcemap_byte_offset @ 54,
-  //   sourcemap_byte_length @ 62, sourcemap_hash @ 70.
+  //   0: cache_version u32, 4: module_type u8, 5: output_encoding u8, 6: flags u8,
+  //   then twelve u64 fields; sourcemap_byte_offset @ 55,
+  //   sourcemap_byte_length @ 63, sourcemap_hash @ 71.
   // InternalSourceMap header (src/sourcemap/InternalSourceMap.rs):
   //   0: total_len u64, 8: mapping_count u64, 16: input_line_count u64,
   //   24: sync_count u32, 28: stream_offset u32.
-  const SOURCEMAP_BYTE_OFFSET_AT = 54;
-  const SOURCEMAP_BYTE_LENGTH_AT = 62;
+  const SOURCEMAP_BYTE_OFFSET_AT = 55;
+  const SOURCEMAP_BYTE_LENGTH_AT = 63;
 
   function corruptSourceMapHeader(file: string): boolean {
     const data = readFileSync(file);
-    if (data.length < 102) return false;
+    if (data.length < 103) return false;
     const smOff = Number(data.readBigUInt64LE(SOURCEMAP_BYTE_OFFSET_AT));
     const smLen = Number(data.readBigUInt64LE(SOURCEMAP_BYTE_LENGTH_AT));
     if (smLen < 32 || smOff + smLen > data.length) return false;

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1446,6 +1446,24 @@ describe("bun test", () => {
       expect(stderr).toContain("failed later");
       expect(stderr).toContain("1 fail");
     });
+
+    // This arrow is rewritten in this very file, and its toString() text lands in a different
+    // module, so the rewrite must not reference anything from the module it was made in.
+    test("the rewrite survives a Function.toString round-trip into another module", async () => {
+      const fn = () => expect(1).toBe(1);
+      using dir = tempDir("tail-tostring", {
+        "roundtrip.test.ts": `import { test, expect } from "bun:test";\ntest("round-trip", ${fn.toString()});`,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", "roundtrip.test.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain("1 pass");
+      expect(exitCode).toBe(0);
+    });
   });
 
   test("path to a non-test.ts file will work", () => {

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1447,6 +1447,44 @@ describe("bun test", () => {
       expect(stderr).toContain("1 fail");
     });
 
+    // `bun run` and `bun test` transpile the same file to different output now, so they must not
+    // share a transpiler cache entry. The file needs an explicit `bun:test` import (injected
+    // globals already bail out of the cache) and 4KB of source (the cache floor).
+    test("the rewrite is not lost to a transpiler cache entry from bun run", async () => {
+      const contents = [
+        `import { test, expect } from "bun:test";`,
+        `test("tail", () => expect(1).toBe(2));`,
+        `// ${Buffer.alloc(5000, "x").toString()}`,
+      ].join("\n");
+      using dir = tempDir("tail-cache", { "cached.test.ts": contents });
+      const cacheDir = join(String(dir), "cache");
+      mkdirSync(cacheDir);
+      const env = {
+        ...bunEnv,
+        BUN_RUNTIME_TRANSPILER_CACHE_PATH: cacheDir,
+        // Debug builds read the cache but serve from it only with this set.
+        BUN_DEBUG_ENABLE_RESTORE_FROM_TRANSPILER_CACHE: "1",
+      };
+      await using warm = Bun.spawn({
+        cmd: [bunExe(), "run", "cached.test.ts"],
+        env,
+        cwd: String(dir),
+        stdout: "ignore",
+        stderr: "ignore",
+      });
+      await warm.exited;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", "cached.test.ts"],
+        env,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).toMatch(/at <anonymous> \(.*cached\.test\.ts:2:\d+\)/);
+      expect(stderr).toContain("1 fail");
+      expect(exitCode).toBe(1);
+    });
+
     // This arrow is rewritten in this very file, and its toString() text lands in a different
     // module, so the rewrite must not reference anything from the module it was made in.
     test("the rewrite survives a Function.toString round-trip into another module", async () => {

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1489,6 +1489,50 @@ describe("bun test", () => {
       expect(readdirSync(cacheDir).sort()).toEqual(warmEntries);
     });
 
+    // The helper gets `expect` through a re-export, so no import specifier in the helper names
+    // the test framework. The cache entry must still record that `bun test` would rewrite it.
+    test("a helper that gets expect through a re-export reports its line after bun run cached it", async () => {
+      using dir = tempDir("tail-reexport-cache", {
+        "reexport.ts": `export { expect } from "bun:test";`,
+        "util.ts": [
+          `import { expect } from "./reexport.ts";`,
+          `export function check(value: number) { return expect(value).toBe(2); }`,
+          `// ${Buffer.alloc(5000, "x").toString()}`,
+        ].join("\n"),
+        "entry.ts": `import "./util.ts";`,
+        "helper.test.ts": [
+          `import { test } from "bun:test";`,
+          `import { check } from "./util.ts";`,
+          `test("helper", () => { check(1); });`,
+        ].join("\n"),
+      });
+      const cacheDir = join(String(dir), "cache");
+      mkdirSync(cacheDir);
+      const env = {
+        ...bunEnv,
+        BUN_RUNTIME_TRANSPILER_CACHE_PATH: cacheDir,
+        BUN_DEBUG_ENABLE_RESTORE_FROM_TRANSPILER_CACHE: "1",
+      };
+      await using warm = Bun.spawn({
+        cmd: [bunExe(), "run", "entry.ts"],
+        env,
+        cwd: String(dir),
+        stdout: "ignore",
+        stderr: "ignore",
+      });
+      await warm.exited;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", "helper.test.ts"],
+        env,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).toMatch(/at check \(.*util\.ts:2:\d+\)/);
+      expect(stderr).toContain("1 fail");
+      expect(exitCode).toBe(1);
+    });
+
     // This arrow is rewritten in this very file, and its toString() text lands in a different
     // module, so the rewrite must not reference anything from the module it was made in.
     test("the rewrite survives a Function.toString round-trip into another module", async () => {

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1405,6 +1405,49 @@ describe("bun test", () => {
     expect(stderr).toContain("1 pass");
   });
 
+  // A returned matcher call is a proper tail call, which would otherwise leave the failure with no
+  // frame in the file that contains the call.
+  describe("matcher call in tail position", () => {
+    test("a failure reports the line of the matcher call", () => {
+      const stderr = runTest({
+        input: [
+          {
+            filename: "tail.test.ts",
+            contents: [
+              `import { test, expect } from "bun:test";`,
+              `test("expression-bodied callback", () => expect(1).toBe(2));`,
+              `function check(value: number) { return expect(value).toBe(2); }`,
+              `test("helper", () => { check(1); });`,
+              `test("nullish", () => globalThis.nothing ?? expect(1).toBe(2));`,
+            ].join("\n"),
+          },
+        ],
+        expectExitCode: 1,
+      });
+      expect(stderr).toMatch(/at <anonymous> \(.*tail\.test\.ts:2:\d+\)/);
+      expect(stderr).toMatch(/at check \(.*tail\.test\.ts:3:\d+\)/);
+      expect(stderr).toMatch(/at <anonymous> \(.*tail\.test\.ts:5:\d+\)/);
+      expect(stderr).toContain("3 fail");
+    });
+
+    test("the matcher's return value still reaches the runner", () => {
+      const stderr = runTest({
+        input: `
+          import { test, expect } from "bun:test";
+          expect.extend({
+            async toFailLater() {
+              return { pass: false, message: () => "failed later" };
+            },
+          });
+          test("async matcher", () => expect(1).toFailLater());
+        `,
+        expectExitCode: 1,
+      });
+      expect(stderr).toContain("failed later");
+      expect(stderr).toContain("1 fail");
+    });
+  });
+
   test("path to a non-test.ts file will work", () => {
     const stderr = runTest({
       args: ["./index.ts"],

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from "bun";
 import { beforeAll, describe, expect, it, test } from "bun:test";
 import { bunEnv, bunExe, isLinux, isWindows, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { basename, dirname, join, resolve, sep } from "node:path";
 
 describe("bun test", () => {
@@ -1473,6 +1473,8 @@ describe("bun test", () => {
         stderr: "ignore",
       });
       await warm.exited;
+      const warmEntries = readdirSync(cacheDir).sort();
+      expect(warmEntries.length).toBe(1);
       await using proc = Bun.spawn({
         cmd: [bunExe(), "test", "cached.test.ts"],
         env,
@@ -1483,6 +1485,8 @@ describe("bun test", () => {
       expect(stderr).toMatch(/at <anonymous> \(.*cached\.test\.ts:2:\d+\)/);
       expect(stderr).toContain("1 fail");
       expect(exitCode).toBe(1);
+      // The modes use separate cache files, so the bun test run must not evict the bun run entry.
+      expect(readdirSync(cacheDir).sort()).toEqual(warmEntries);
     });
 
     // This arrow is rewritten in this very file, and its toString() text lands in a different

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1520,7 +1520,9 @@ describe("bun test", () => {
         stdout: "ignore",
         stderr: "ignore",
       });
-      await warm.exited;
+      expect(await warm.exited).toBe(0);
+      // util.ts is the only file above the cache floor.
+      expect(readdirSync(cacheDir).length).toBe(1);
       await using proc = Bun.spawn({
         cmd: [bunExe(), "test", "helper.test.ts"],
         env,

--- a/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
@@ -486,6 +486,9 @@ describe("inline snapshots", () => {
     export function wrongFile(value) {
       expect(value).toMatchInlineSnapshot();
     }
+    export function wrongFileTailCall(value) {
+      return expect(value).toMatchInlineSnapshot();
+    }
   `;
   const tester = new InlineSnapshotTester({
     "helper.js": helper_js,
@@ -794,6 +797,145 @@ Date)
       `,
     );
   });
+  // In the tests below the matcher call is a proper tail call (test files are modules, so strict
+  // mode), and the function containing it was invoked by the test runner itself. When the matcher
+  // runs, the frame that held its location is gone and no JS frame is left below it at all.
+  describe("matcher call in tail position", () => {
+    it("expression-bodied test callback", async () => {
+      await tester.test(
+        v => /*js*/ `
+          test("tail call", () => expect("v").toMatchInlineSnapshot(${v("", bad, '`"v"`')}));
+        `,
+      );
+    });
+    it("expression-bodied test callback (toThrowErrorMatchingInlineSnapshot)", async () => {
+      await tester.test(
+        v => /*js*/ `
+          test("tail call", () => expect(() => { throw new Error("boom") }).toThrowErrorMatchingInlineSnapshot(${v("", bad, '`"boom"`')}));
+        `,
+      );
+    });
+    it("inline snapshots inside the function the matcher runs", async () => {
+      // The inner matcher must not disturb the location of the outer, tail-called one.
+      await tester.test(
+        v => /*js*/ `
+          test("nested", () => expect(() => {
+            expect("inner").toMatchInlineSnapshot(${v("", bad, '`"inner"`')});
+            throw new Error("outer");
+          }).toThrowErrorMatchingInlineSnapshot(${v("", bad, '`"outer"`')}));
+        `,
+      );
+    });
+    it("other shapes", async () => {
+      await tester.test(
+        // prettier-ignore
+        v => /*js*/ `
+          test("resolves", () => expect(Promise.resolve("r")).resolves.toMatchInlineSnapshot(${v("", bad, '`"r"`')}));
+          test("return statement", () => { return expect("s").toMatchInlineSnapshot(${v("", bad, '`"s"`')}); });
+          test("only the branch that ran", () => Date.now() ? expect("t").toMatchInlineSnapshot(${v("", bad, '`"t"`')}) : expect("never").toMatchInlineSnapshot());
+          test("last operand of a comma expression", () => (expect("c1").toMatchInlineSnapshot(${v("", bad, '`"c1"`')}), expect("c2").toMatchInlineSnapshot(${v("", bad, '`"c2"`')})));
+          test("right operand of &&", () => Date.now() && expect("and").toMatchInlineSnapshot(${v("", bad, '`"and"`')}));
+          test("right operand of ||", () => globalThis.nothing || expect("or").toMatchInlineSnapshot(${v("", bad, '`"or"`')}));
+          test("right operand of ??", () => globalThis.nothing ?? expect("nullish").toMatchInlineSnapshot(${v("", bad, '`"nullish"`')}));
+          test.each(["e"])("test.each %s", value => expect(value).toMatchInlineSnapshot(${v("", bad, '`"e"`')}));
+          test("name on its own line", () =>
+            expect("n")
+              .toMatchInlineSnapshot(${v("", bad, '`"n"`')}));
+          test("dot on the line before", () => expect("d").
+            toMatchInlineSnapshot(${v("", bad, '`"d"`')}));
+          test("optional chaining", () => expect("o")?.toMatchInlineSnapshot(${v("", bad, '`"o"`')}));
+        `,
+      );
+    });
+    it("helper function in the test file", async () => {
+      await tester.test(
+        v => /*js*/ `
+          function snap(value) {
+            return expect(value).toMatchInlineSnapshot(${v("", bad, '`"h"`')});
+          }
+          function snapThrow(fn) {
+            return expect(fn).toThrowErrorMatchingInlineSnapshot(${v("", bad, '`"thrown"`')});
+          }
+          test("helpers", () => {
+            snap("h");
+            snapThrow(() => { throw new Error("thrown") });
+          });
+        `,
+      );
+    });
+    it("helper function reached through another tail call", async () => {
+      await tester.test(
+        v => /*js*/ `
+          function inner(value) {
+            return expect(value).toMatchInlineSnapshot(${v("", bad, '`"nested"`')});
+          }
+          function outer(value) {
+            return inner(value);
+          }
+          test("nested helpers", () => {
+            outer("nested");
+          });
+        `,
+      );
+    });
+    it("helper function mixed with direct calls", async () => {
+      await tester.test(
+        v => /*js*/ `
+          function snap(value) {
+            return expect(value).toMatchInlineSnapshot(${v("", bad, '`"helper"`')});
+          }
+          test("mixed", () => {
+            expect("before").toMatchInlineSnapshot(${v("", bad, '`"before"`')});
+            snap("helper");
+            expect("after").toMatchInlineSnapshot(${v("", bad, '`"after"`')});
+          });
+        `,
+      );
+    });
+    it("matcher name also appears in the argument", async () => {
+      await tester.test(
+        v => /*js*/ `
+          function snap() {
+            return expect(".toMatchInlineSnapshot(" /* .toMatchInlineSnapshot(\`\`) */).toMatchInlineSnapshot(${v("", bad, '`".toMatchInlineSnapshot("`')});
+          }
+          test("decoy", () => {
+            snap();
+          });
+        `,
+      );
+    });
+    it("helper function called with different values", async () => {
+      // Both calls resolve to the helper's line: the tail-call twin of "should error trying to update the same line twice".
+      await tester.testError(
+        {
+          msg: "error: Failed to update inline snapshot: Multiple inline snapshots on the same line must all have the same value",
+        },
+        /*js*/ `
+          function snap(value) {
+            return expect(value).toMatchInlineSnapshot();
+          }
+          test("conflict", () => {
+            snap("a");
+            snap("b");
+          });
+        `,
+      );
+    });
+    it("helper function in another file is still rejected", async () => {
+      await tester.testError(
+        {
+          msg: "Inline snapshot matchers must be called from the test file",
+        },
+        /*js*/ `
+          import {wrongFileTailCall} from "./helper";
+          test("cases", () => {
+            wrongFileTailCall("interesting");
+          });
+        `,
+      );
+      expect(readFileSync(tester.tmpdir + "/helper.js", "utf-8")).toBe(helper_js);
+    });
+  });
   it("indentation", async () => {
     await tester.test(
       // prettier-ignore
@@ -891,11 +1033,16 @@ test("error snapshots", () => {
     throw undefined; // this one doesn't work in jest because it doesn't think the function threw
   }).toThrowErrorMatchingInlineSnapshot(`undefined`);
   expect(() => {
-    expect(() => {}).toThrowErrorMatchingInlineSnapshot(`undefined`);
+    try {
+      expect(() => {}).toThrowErrorMatchingInlineSnapshot(`undefined`);
+    } catch (e) {
+      (e as Error).message = Bun.stripANSI((e as Error).message);
+      throw e;
+    }
   }).toThrowErrorMatchingInlineSnapshot(`
-"\x1B[2mexpect(\x1B[0m\x1B[31mreceived\x1B[0m\x1B[2m).\x1B[0mtoThrowErrorMatchingInlineSnapshot\x1B[2m(\x1B[0m\x1B[2m)\x1B[0m
+"expect(received).toThrowErrorMatchingInlineSnapshot()
 
-\x1B[1mMatcher error\x1B[0m: Received function did not throw
+Matcher error: Received function did not throw
 "
 `);
 });


### PR DESCRIPTION
Fixes #39685

### Problem
- `test("x", () => expect(v).toMatchInlineSnapshot())` and a helper's `return expect(v).toMatchInlineSnapshot()` fail (`called from file: ""` and `Could not find 'toMatchInlineSnapshot' here`). `test("x", () => expect(1).toBe(2))` fails with no code frame and no `at` line. All three work in Jest.
- A returned call is a proper tail call in a module. JSC drops the frame that contains the call before the matcher runs, so neither the inline snapshot writer (`Expect::inline_snapshot`, a stack walk) nor the error stack can see where the call was written.

### Fix
- `bun test` already transpiles every file it loads with `inject_jest_globals` on. In that mode `s_return` (`src/js_parser/visit/visit_stmt.rs`) rewrites a returned matcher call, which is what an expression-bodied arrow is too, to `[expect(v).toBe(1)][0]`. The call is no longer in tail position, so the frame stays and the stack walk and stack traces work unchanged.
- The rewritten text has no free identifier, so `Function.prototype.toString` output stays runnable in another module (the shell leak test pipes such text into a child script). A rewritten file is not stored in the runtime transpiler cache, and the cache entry metadata now records whether a file uses the test framework (a returned matcher call, found by a detection-only pass under `bun run`, or a test framework import): a `bun test` read rejects, without deleting, a `bun run` entry for such a file, whose output misses the rewrite. Every other file transpiles the same in both modes and the modes keep sharing its entry.
- A matcher call is a method call on an `expect(...)` chain (`.not`, `.resolves`, ...) or a call to either inline snapshot matcher on any receiver. Tail position is followed into `?:` branches and the right operand of `,`, `&&`, `||` and `??`. Code `bun test` does not transpile (`eval`) keeps the old behaviour.
- Verified: `test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts` (`matcher call in tail position`, 10 cases) and `test/cli/test/bun-test.test.ts` (failure location, return value still reaches the runner, a `Function.toString` round-trip into another module, a cache entry written by `bun run`). Both fail on the released binary. Also ran `test/js/bun/test/`, `test/cli/test/`, the source lints, clippy and rustfmt.

### Background
- Proper tail calls: in strict code JSC reuses the caller's frame for a call in tail position, so the callee cannot see its caller. V8 does not implement them, so Jest never hits this.
- `inject_jest_globals`: the parser feature `bun test` turns on for every file. It declares the `bun:test` globals and prepends an import for the ones a file uses. The rewrite reuses the switch.
- Inline snapshot writeback: the matcher queues the position the stack walk reports. The printer starts a source map mapping at every member name, so the remapped position lands on the matcher name whatever is printed in front of the call.

<details><summary>Notes</summary>

**Earlier revision.** This PR first recorded the location when the matcher property was read: a new `onGet` codegen option, a CustomValue property, an expression-info binding and a slot on the runner, about 270 lines. Review of that revision pointed at the transpiler level, which is smaller, also fixes failure locations, and handles the one shape the slot could not (an inline snapshot matcher that runs inside the argument list of another one). #38034 is the same root cause for `mock.module`. A `bun test`-scoped `useTailCalls=false` would fix all of these too, but it makes engine behaviour differ between `bun run` and `bun test` (code that relies on tail calls throws `RangeError` only under `bun test`), and the global version was rejected in #26001, so this PR does not do that.

**Why not capture in `expect()`.** #34978 (closed) and #39722 capture a location on every `expect()` call and then have to find the matcher from there. #39722 searches the file text for the matcher name, which the `matcher name also appears in the argument` case defeats. The rewrite costs nothing at runtime and leaves the matchers alone.

**Checked by hand against the debug build, beyond the tests:** a CommonJS test file, a file that uses the injected globals (both prepended parts), class method and arrow helpers, a non-constant `?:` (a constant one is folded before `s_return` runs), and an inline snapshot matcher running inside another one's argument list.

**`error snapshots` hunk.** The last assertion of that test only held under CI's `FORCE_COLOR=1`, so a piped `bun bd test` of the file failed before this change. The hunk here is #38833 verbatim and disappears on rebase once that lands.

**Not rewritten on purpose:** calls in statement position (not tail calls), `expect(x)["toBe"](1)` (the `requires exactly` tests pin the existing behaviour), and returns in dead code. Returns inside `async` functions and `try` blocks are not tail calls either but are rewritten anyway: the wrapper is harmless there and telling them apart is not worth the code.

**Also run:** `test/js/bun/test/` (1165 pass, 0 fail), `test/cli/test/` (261 pass; `parallel.test.ts` `lazily scales workers` failed once on its 250 ms debug-build timing budget, and its fixtures contain no returned matcher), `test/internal/source-lints/` (160 pass), `cargo clippy -p bun_js_parser`, `cargo fmt --check`, prettier.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/test/bun-test.test.ts, test/cli/run/transpiler-cache.test.ts

<!-- robobun:evidence:end -->


