### PR TITLE
bun test: fail the test or hook whose done() received an error

### DIFF
--- a/src/runtime/test_runner/DoneCallback.rs
+++ b/src/runtime/test_runner/DoneCallback.rs
@@ -9,10 +9,8 @@ pub struct DoneCallback {
     /// Some = not called yet. None = done already called, no-op.
     pub(crate) r#ref: Option<RefPtr<RefData>>,
     pub(crate) called: bool, // = false
-    /// The file and entry whose callback received this `done`. Set at creation, so
-    /// `done(err)` (and node:test's `t.skip()`/`t.todo()`) can be charged to that entry
-    /// whether `done` fires inside the callback, after it returned (`r#ref` stamped), or
-    /// after the entry already finished (stale `owner`: the runner then rejects it).
+    /// The file and entry this `done` was created for; `done(err)` and node:test's
+    /// `t.skip()`/`t.todo()` are charged to it no matter when they fire.
     pub(crate) buntest_weak: BunTestPtrWeak,
     pub(crate) owner: RefDataValue,
 }

--- a/src/runtime/test_runner/DoneCallback.rs
+++ b/src/runtime/test_runner/DoneCallback.rs
@@ -2,22 +2,34 @@ use bun_jsc::{CallFrame, JSFunction, JSGlobalObject, JSValue, JsClass as _, JsRe
 use bun_core::String as BunString;
 use bun_ptr::RefPtr;
 
-use crate::test_runner::bun_test::{group_begin, BunTest, RefData};
+use crate::test_runner::bun_test::{group_begin, BunTest, BunTestPtrWeak, RefData, RefDataValue};
 
 #[bun_jsc::JsClass(no_construct, no_constructor)] // codegen wires to_js / from_js
 pub struct DoneCallback {
     /// Some = not called yet. None = done already called, no-op.
     pub(crate) r#ref: Option<RefPtr<RefData>>,
     pub(crate) called: bool, // = false
+    /// The file and entry whose callback received this `done`. Set at creation, so
+    /// `done(err)` (and node:test's `t.skip()`/`t.todo()`) can be charged to that entry
+    /// whether `done` fires inside the callback, after it returned (`r#ref` stamped), or
+    /// after the entry already finished (stale `owner`: the runner then rejects it).
+    pub(crate) buntest_weak: BunTestPtrWeak,
+    pub(crate) owner: RefDataValue,
 }
 
 impl DoneCallback {
-    pub(crate) fn create_unbound(global: &JSGlobalObject) -> JSValue {
+    pub(crate) fn create_unbound(
+        global: &JSGlobalObject,
+        buntest_weak: BunTestPtrWeak,
+        owner: RefDataValue,
+    ) -> JSValue {
         let _g = group_begin!();
 
         let done_callback = DoneCallback {
             r#ref: None,
             called: false,
+            buntest_weak,
+            owner,
         };
 
         // `JsClass::to_js` boxes `self` and hands the raw pointer to the JS

--- a/src/runtime/test_runner/DoneCallback.rs
+++ b/src/runtime/test_runner/DoneCallback.rs
@@ -9,8 +9,7 @@ pub struct DoneCallback {
     /// Some = not called yet. None = done already called, no-op.
     pub(crate) r#ref: Option<RefPtr<RefData>>,
     pub(crate) called: bool, // = false
-    /// The file and entry this `done` was created for; `done(err)` and node:test's
-    /// `t.skip()`/`t.todo()` are charged to it no matter when they fire.
+    /// Entry this `done` was created for; `done(err)` and node:test skip/todo are charged to it.
     pub(crate) buntest_weak: BunTestPtrWeak,
     pub(crate) owner: RefDataValue,
 }

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -93,13 +93,6 @@ pub struct Execution {
     /// around `run_test_callback` so code re-entered from a test body (e.g.
     /// spawnSync's wait loop) can read the calling entry's own deadline.
     pub(crate) on_stack_entry: core::cell::Cell<Option<NonNull<ExecutionEntry>>>,
-    /// The (group_index, sequence_index, entry, repeat) for `on_stack_entry`,
-    /// set/restored alongside it. `get_current_state_data()` can't name a
-    /// sequence inside a concurrent group; this can, for code re-entered from
-    /// the microtask drain inside `run_test_callback` (node:test's runtime
-    /// `t.skip()`/`t.todo()` mark lands there before the DoneCallback is
-    /// stamped).
-    pub(crate) on_stack_entry_data: core::cell::Cell<Option<super::bun_test::EntryData>>,
 }
 
 pub struct ConcurrentGroup {
@@ -281,7 +274,6 @@ impl Execution {
             sequences: Box::default(),
             group_index: 0,
             on_stack_entry: core::cell::Cell::new(None),
-            on_stack_entry_data: core::cell::Cell::new(None),
         }
     }
 
@@ -1008,26 +1000,22 @@ fn step_sequence_one(
     if let Some(cb) = next_item.callback.as_ref() {
         group_log::log(format_args!("runSequence queued callback"));
 
-        let entry_data = EntryData {
-            sequence_index,
-            entry: next_item_ptr.as_ptr() as *const (),
-            remaining_repeat_count: sequence.remaining_repeat_count as i64,
-        };
         let callback_data = RefDataValue::Execution {
             group_index: this.group_index,
-            entry_data: Some(entry_data),
+            entry_data: Some(EntryData {
+                sequence_index,
+                entry: next_item_ptr.as_ptr() as *const (),
+                remaining_repeat_count: sequence.remaining_repeat_count as i64,
+            }),
         };
         group_log::log(format_args!("runSequence queued callback: {}", callback_data));
 
         let prev_on_stack = this.on_stack_entry.replace(Some(next_item_ptr));
-        let prev_on_stack_data = this.on_stack_entry_data.replace(Some(entry_data));
         let on_stack_cell = &raw const this.on_stack_entry;
-        let on_stack_data_cell = &raw const this.on_stack_entry_data;
-        // SAFETY: both cells point into `buntest.execution`, which is
+        // SAFETY: `on_stack_cell` points into `buntest.execution`, which is
         // never moved during execution (arena-owned BunTest behind an Rc).
         let _restore = scopeguard::guard((), move |()| unsafe {
             (*on_stack_cell).set(prev_on_stack);
-            (*on_stack_data_cell).set(prev_on_stack_data);
         });
 
         if BunTest::run_test_callback(

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -809,14 +809,10 @@ impl BunTest {
         // SAFETY: `this` is the live `*mut DoneCallback` returned by `from_js`;
         // single-threaded JS VM, GC keeps the wrapper alive for the call frame.
         let first_call = !unsafe { core::mem::replace(&mut (*this).called, true) };
-        // Only the first done() reports its error; a repeated call is a no-op as in Bun 1.2.20
-        // (Jest: "Expected done to be called once, but it was called multiple times.").
+        // Only the first done() reports its error; repeated calls are no-ops (Bun 1.2.20 behavior).
         if first_call && was_error {
-            // done(err) fails the entry this `done` was created for, like a throw or rejection
-            // from the same callback would. Keyed by that entry's own RefDataValue it lands on
-            // the right sequence inside a concurrent group too, and is rejected as stale once
-            // the entry has finished. The generic `uncaught_exception` route attributes by
-            // `get_current_state_data()`, which can do neither.
+            // Key the failure by this `done`'s own entry, not get_current_state_data():
+            // in a concurrent group the "current" entry can be a different test.
             // SAFETY: see above; both fields are read before any JS can run.
             let (buntest, owner) = unsafe { ((*this).buntest_weak.upgrade(), (*this).owner.clone()) };
             match buntest {

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -808,22 +808,27 @@ impl BunTest {
         let was_error = !value.is_empty_or_undefined_or_null();
         // SAFETY: `this` is the live `*mut DoneCallback` returned by `from_js`;
         // single-threaded JS VM, GC keeps the wrapper alive for the call frame.
-        if unsafe { (*this).called } {
-            // in Bun 1.2.20, this is a no-op
-            // in Jest, this is "Expected done to be called once, but it was called multiple times."
-            // Vitest does not support done callbacks
-        } else {
-            // error is only reported for the first done() call
-            if was_error {
-                let _ = global_this.bun_vm().as_mut().uncaught_exception(global_this, value, false);
+        let first_call = !unsafe { core::mem::replace(&mut (*this).called, true) };
+        // Only the first done() reports its error; a repeated call is a no-op as in Bun 1.2.20
+        // (Jest: "Expected done to be called once, but it was called multiple times.").
+        if first_call && was_error {
+            // done(err) fails the entry this `done` was created for, like a throw or rejection
+            // from the same callback would. Keyed by that entry's own RefDataValue it lands on
+            // the right sequence inside a concurrent group too, and is rejected as stale once
+            // the entry has finished. The generic `uncaught_exception` route attributes by
+            // `get_current_state_data()`, which can do neither.
+            // SAFETY: see above; both fields are read before any JS can run.
+            let (buntest, owner) = unsafe { ((*this).buntest_weak.upgrade(), (*this).owner.clone()) };
+            match buntest {
+                Some(strong) => strong.get().on_uncaught_exception(global_this, Some(value), false, &owner),
+                // The file it belongs to is already torn down; report it like any stray error.
+                None => {
+                    let _ = global_this.bun_vm().as_mut().uncaught_exception(global_this, value, false);
+                }
             }
         }
         // SAFETY: see above — `this` is a live `*mut DoneCallback`.
-        let ref_in = unsafe {
-            (*this).called = true;
-            (*this).r#ref.take()
-        };
-        let Some(ref_in) = ref_in else {
+        let Some(ref_in) = (unsafe { (*this).r#ref.take() }) else {
             return Ok(JSValue::UNDEFINED);
         };
 
@@ -1123,7 +1128,7 @@ impl BunTest {
 
         if cfg_done_parameter {
             bun_core::scoped_log!(bun_test_group, "callTestCallback -> appending done callback param: data {}", cfg_data);
-            done_callback = DoneCallback::create_unbound(global_this);
+            done_callback = DoneCallback::create_unbound(global_this, Rc::downgrade(this_strong), cfg_data.clone());
             done_arg = match DoneCallback::bind(done_callback, global_this) {
                 Ok(v) => v,
                 Err(e) => {

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -814,7 +814,7 @@ impl BunTest {
             // Key the failure by this `done`'s own entry, not get_current_state_data():
             // in a concurrent group the "current" entry can be a different test.
             // SAFETY: see above; both fields are read before any JS can run.
-            let (buntest, owner) = unsafe { ((*this).buntest_weak.upgrade(), (*this).owner.clone()) };
+            let (buntest, owner) = unsafe { ((*this).buntest_weak.upgrade(), (*this).owner) };
             match buntest {
                 Some(strong) => strong.get().on_uncaught_exception(global_this, Some(value), false, &owner),
                 // The file it belongs to is already torn down; report it like any stray error.
@@ -1124,7 +1124,7 @@ impl BunTest {
 
         if cfg_done_parameter {
             bun_core::scoped_log!(bun_test_group, "callTestCallback -> appending done callback param: data {}", cfg_data);
-            done_callback = DoneCallback::create_unbound(global_this, Rc::downgrade(this_strong), cfg_data.clone());
+            done_callback = DoneCallback::create_unbound(global_this, Rc::downgrade(this_strong), cfg_data);
             done_arg = match DoneCallback::bind(done_callback, global_this) {
                 Ok(v) => v,
                 Err(e) => {

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -536,19 +536,14 @@ pub(crate) fn js_file_generation(
 
 /// Reached only from `node:test` (`t.skip()` / `t.todo()` at runtime): overrides
 /// the running sequence's result so bun:test reports skip/todo instead of pass.
-/// `done`'s bound `DoneCallback.r#ref.phase` names the intended sequence so a
-/// late call after the watchdog moved on cannot mark the currently-running one.
+/// `done`'s bound `DoneCallback` names the sequence it was created for, so a late
+/// call after the watchdog moved on cannot mark the currently-running one.
 pub(crate) fn js_node_test_mark_result(
     _global: &JSGlobalObject,
     callframe: &CallFrame,
 ) -> JsResult<JSValue> {
     use super::execution::Result as ExecResult;
     let [mode, done] = callframe.arguments_as_array::<2>();
-    let Some(buntest_strong) = bun_test::clone_active_strong() else {
-        return Ok(JSValue::UNDEFINED);
-    };
-    // SAFETY: single-threaded JS VM; the strong is dropped before any re-borrow.
-    let buntest = unsafe { bun_test::buntest_as_mut(&buntest_strong) };
     // `done` is a JSBoundFunction whose bound-this is the DoneCallback wrapper.
     let wrapper = bun_jsc::cpp::Bun__JSBoundFunction__boundThis(done);
     let Some(dcb) = bun_test::DoneCallback::from_js(wrapper) else {
@@ -556,27 +551,20 @@ pub(crate) fn js_node_test_mark_result(
     };
     // SAFETY: `dcb` is the live `*mut DoneCallback` from `from_js`; single-
     // threaded JS VM, GC roots `done` (and its bound-this) for this frame.
-    let (dcb_ref, dcb_called) = unsafe { ((*dcb).r#ref.as_deref(), (*dcb).called) };
-    let bound = match dcb_ref {
-        Some(refdata) => refdata.phase,
-        // `r#ref` unset: `.then()` fired inside run_test_callback's microtask
-        // drain before it stamps the DoneCallback. `get_current_state_data()`
-        // can't name a sequence inside a concurrent group, but
-        // `on_stack_entry_data` holds exactly the `cfg_data` that
-        // `run_test_callback` was invoked with (set/restored around it), so
-        // the mark lands on the right sequence under --concurrent too.
-        None if !dcb_called => match buntest.execution.on_stack_entry_data.get() {
-            Some(entry_data) => bun_test::RefDataValue::Execution {
-                group_index: buntest.execution.group_index,
-                entry_data: Some(entry_data),
-            },
-            None => buntest.get_current_state_data(),
-        },
-        // done() already ran and reported — nothing left to mark.
-        None => return Ok(JSValue::UNDEFINED),
+    let (buntest_strong, owner) = unsafe {
+        if (*dcb).called {
+            // done() already ran and reported — nothing left to mark.
+            return Ok(JSValue::UNDEFINED);
+        }
+        ((*dcb).buntest_weak.upgrade(), (*dcb).owner)
     };
+    let Some(buntest_strong) = buntest_strong else {
+        return Ok(JSValue::UNDEFINED);
+    };
+    // SAFETY: single-threaded JS VM; the strong is dropped before any re-borrow.
+    let buntest = unsafe { bun_test::buntest_as_mut(&buntest_strong) };
     let Some((sequence_ptr, _)) =
-        buntest.execution.get_current_and_valid_execution_sequence(&bound)
+        buntest.execution.get_current_and_valid_execution_sequence(&owner)
     else {
         return Ok(JSValue::UNDEFINED);
     };

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -534,10 +534,9 @@ pub(crate) fn js_file_generation(
     Ok(JSValue::from(generation))
 }
 
-/// Reached only from `node:test` (`t.skip()` / `t.todo()` at runtime): overrides
-/// the running sequence's result so bun:test reports skip/todo instead of pass.
-/// `done`'s bound `DoneCallback` names the sequence it was created for, so a late
-/// call after the watchdog moved on cannot mark the currently-running one.
+/// node:test `t.skip()`/`t.todo()` at runtime: marks the sequence the bound
+/// `DoneCallback` was created for as skip/todo, rejecting late calls whose
+/// sequence already finished.
 pub(crate) fn js_node_test_mark_result(
     _global: &JSGlobalObject,
     callframe: &CallFrame,

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -534,9 +534,7 @@ pub(crate) fn js_file_generation(
     Ok(JSValue::from(generation))
 }
 
-/// node:test `t.skip()`/`t.todo()` at runtime: marks the sequence the bound
-/// `DoneCallback` was created for as skip/todo, rejecting late calls whose
-/// sequence already finished.
+/// node:test `t.skip()`/`t.todo()` at runtime: marks the bound `DoneCallback`'s sequence as skip/todo.
 pub(crate) fn js_node_test_mark_result(
     _global: &JSGlobalObject,
     callframe: &CallFrame,

--- a/test/js/bun/test/test-error-code-done-callback.test.ts
+++ b/test/js/bun/test/test-error-code-done-callback.test.ts
@@ -1,5 +1,5 @@
-import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 import path from "path";
 
 test("verify we print error messages passed to done callbacks", () => {
@@ -80,7 +80,6 @@ test("verify we print error messages passed to done callbacks", () => {
     ^
     error: you should see this(async)
     at <anonymous> (<dir>/test-error-done-callback-fixture.ts:42:14)
-    at <anonymous> (<dir>/test-error-done-callback-fixture.ts:37:3)
     (fail) error done callback (async)
     43 |   });
     44 | });
@@ -111,7 +110,6 @@ test("verify we print error messages passed to done callbacks", () => {
     ^
     error: you should see this(async, nextTick)
     at <anonymous> (<dir>/test-error-done-callback-fixture.ts:60:14)
-    at <anonymous> (<dir>/test-error-done-callback-fixture.ts:54:5)
     (fail) error done callback (async, nextTick)
     62 | });
     63 |
@@ -139,4 +137,144 @@ test("verify we print error messages passed to done callbacks", () => {
     Ran 9 tests across 1 file.
     "
   `);
+});
+
+describe("done(err) fails the test or hook whose done() received it", () => {
+  // Only the lines that show what each error was attributed to, plus the totals.
+  function resultLines(stderr: string) {
+    return normalizeBunSnapshot(stderr)
+      .split("\n")
+      .map(line => line.trim())
+      .filter(line => /^(\((pass|fail)\) |error: |# Unhandled error|\d+ (pass|fail|errors?)$)/.test(line))
+      .join("\n");
+  }
+
+  async function runFixture(source: string, args: string[] = []) {
+    using dir = tempDir("done-err", { "done-err.test.ts": source });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", ...args],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout: normalizeBunSnapshot(stdout), results: resultLines(stderr), exitCode };
+  }
+
+  // `suffix` is "" or ".concurrent". The macrotask case goes last: everything before it
+  // completes while being started, so serial and concurrent runs report in the same order.
+  const fixture = (suffix: string) => `
+    import { it, describe, beforeEach, afterEach } from "bun:test";
+
+    it${suffix}("sync done(err)", done => {
+      done(new Error("sync boom"));
+    });
+    it${suffix}("microtask done(err)", async done => {
+      await 1;
+      done(new Error("microtask boom"));
+    });
+    it${suffix}("done() without an error", done => {
+      done();
+    });
+    it${suffix}.failing("failing test whose done() receives an error", done => {
+      done(new Error("expected boom"));
+    });
+    describe${suffix}("beforeEach", () => {
+      beforeEach(done => {
+        done(new Error("beforeEach boom"));
+      });
+      it("body is skipped", () => {
+        console.log("beforeEach > body ran");
+      });
+    });
+    describe${suffix}("afterEach", () => {
+      afterEach(async done => {
+        await 1;
+        done(new Error("afterEach boom"));
+      });
+      it("test fails", () => {
+        console.log("afterEach > body ran");
+      });
+    });
+    it${suffix}("macrotask done(err)", done => {
+      setTimeout(() => done(new Error("macrotask boom")), 1);
+    });
+  `;
+
+  const expected = {
+    exitCode: 1,
+    stdout: "bun test <version> (<revision>)\nafterEach > body ran",
+    results: [
+      "error: sync boom",
+      "(fail) sync done(err)",
+      "error: microtask boom",
+      "(fail) microtask done(err)",
+      "(pass) done() without an error",
+      "(pass) failing test whose done() receives an error",
+      "error: beforeEach boom",
+      "(fail) beforeEach > body is skipped",
+      "error: afterEach boom",
+      "(fail) afterEach > test fails",
+      "error: macrotask boom",
+      "(fail) macrotask done(err)",
+      "2 pass",
+      "5 fail",
+    ].join("\n"),
+  };
+
+  test.concurrent.each([
+    { name: "serial", suffix: "", args: [] },
+    { name: "bun test --concurrent", suffix: "", args: ["--concurrent"] },
+    { name: "it.concurrent and describe.concurrent", suffix: ".concurrent", args: [] },
+  ])("$name", async ({ suffix, args }) => {
+    expect(await runFixture(fixture(suffix), args)).toEqual(expected);
+  });
+
+  // In each case the "stale" test is already over (timed out, or its body threw before the
+  // runner took charge of its pending done) when its done(err) fires during the second test.
+  test.concurrent.each([
+    {
+      name: "its test timed out",
+      staleTest: `it("stale", done => { fireLater(done, fn => setTimeout(fn, 20)); }, 1);`,
+      staleResult: ["(fail) stale"],
+    },
+    {
+      name: "its test threw after scheduling it on a macrotask",
+      staleTest: `it("stale", done => { fireLater(done, setImmediate); throw new Error("thrown boom"); });`,
+      staleResult: ["error: thrown boom", "(fail) stale"],
+    },
+    {
+      name: "its test threw after scheduling it on a microtask",
+      staleTest: `it("stale", done => { fireLater(done, queueMicrotask); throw new Error("thrown boom"); });`,
+      staleResult: ["error: thrown boom", "(fail) stale"],
+    },
+  ])("a late done(err) is not pinned on the running test when $name", async ({ staleTest, staleResult }) => {
+    const run = await runFixture(`
+      import { it } from "bun:test";
+      const fired = Promise.withResolvers();
+      const fireLater = (done, schedule) =>
+        schedule(() => {
+          done(new Error("late boom"));
+          fired.resolve();
+        });
+      ${staleTest}
+      it("is running when the late done(err) arrives", async () => {
+        await fired.promise;
+      });
+    `);
+    expect(run).toEqual({
+      exitCode: 1,
+      stdout: "bun test <version> (<revision>)",
+      results: [
+        ...staleResult,
+        "# Unhandled error between tests",
+        "error: late boom",
+        "(pass) is running when the late done(err) arrives",
+        "1 pass",
+        "1 fail",
+        "1 error",
+      ].join("\n"),
+    });
+  });
 });

--- a/test/js/bun/test/test-error-code-done-callback.test.ts
+++ b/test/js/bun/test/test-error-code-done-callback.test.ts
@@ -162,10 +162,11 @@ describe("done(err) fails the test or hook whose done() received it", () => {
     return { stdout: normalizeBunSnapshot(stdout), results: resultLines(stderr), exitCode };
   }
 
-  // `suffix` is "" or ".concurrent". The macrotask case goes last: everything before it
-  // completes while being started, so serial and concurrent runs report in the same order.
+  // `suffix` is "" or ".concurrent". Everything up to the macrotask case completes while being
+  // started, so serial and concurrent runs report in the same order. The beforeAll case goes
+  // last so that the tests it skips cannot include any of the other cases.
   const fixture = (suffix: string) => `
-    import { it, describe, beforeEach, afterEach } from "bun:test";
+    import { it, describe, beforeAll, beforeEach, afterEach, afterAll } from "bun:test";
 
     it${suffix}("sync done(err)", done => {
       done(new Error("sync boom"));
@@ -197,14 +198,31 @@ describe("done(err) fails the test or hook whose done() received it", () => {
         console.log("afterEach > body ran");
       });
     });
+    describe${suffix}("afterAll", () => {
+      afterAll(async done => {
+        await 1;
+        done(new Error("afterAll boom"));
+      });
+      it("test passes", () => {
+        console.log("afterAll > body ran");
+      });
+    });
     it${suffix}("macrotask done(err)", done => {
       setTimeout(() => done(new Error("macrotask boom")), 1);
+    });
+    describe${suffix}("beforeAll", () => {
+      beforeAll(done => {
+        done(new Error("beforeAll boom"));
+      });
+      it("body is skipped", () => {
+        console.log("beforeAll > body ran");
+      });
     });
   `;
 
   const expected = {
     exitCode: 1,
-    stdout: "bun test <version> (<revision>)\nafterEach > body ran",
+    stdout: "bun test <version> (<revision>)\nafterEach > body ran\nafterAll > body ran",
     results: [
       "error: sync boom",
       "(fail) sync done(err)",
@@ -216,10 +234,15 @@ describe("done(err) fails the test or hook whose done() received it", () => {
       "(fail) beforeEach > body is skipped",
       "error: afterEach boom",
       "(fail) afterEach > test fails",
+      "(pass) afterAll > test passes",
+      "error: afterAll boom",
+      "(fail) afterAll > (unnamed)",
       "error: macrotask boom",
       "(fail) macrotask done(err)",
-      "2 pass",
-      "5 fail",
+      "error: beforeAll boom",
+      "(fail) beforeAll > (unnamed)",
+      "3 pass",
+      "7 fail",
     ].join("\n"),
   };
 

--- a/test/js/junit-reporter/junit.test.js
+++ b/test/js/junit-reporter/junit.test.js
@@ -608,6 +608,45 @@ describe("junit reporter", () => {
     expect(longPathCase.failure[0]._).toContain(`at fromLongPath (${longPath}:1:`);
     expect(pathCase.failure[0]._).toContain("at fromPath (generated.js:1:");
   });
+
+  it("records done(err) as the failure of its own test case in a concurrent group", async () => {
+    await using tmpDir = tempDir("junit-done-concurrent", {
+      "package.json": "{}",
+      "done.test.js": `
+        import { test } from "bun:test";
+        test.concurrent("sync", done => { done(new Error("sync done boom")); });
+        test.concurrent("async", done => { setTimeout(() => done(new Error("async done boom")), 1); });
+        test.concurrent("ok", done => { done(); });
+      `,
+    });
+
+    const junitPath = join(tmpDir, "junit.xml");
+    await using proc = spawn([bunExe(), "test", "--reporter=junit", "--reporter-outfile", junitPath], {
+      cwd: tmpDir,
+      env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const xmlContent = await file(junitPath).text();
+    const result = await new Promise((resolve, reject) => {
+      xml2js.parseString(xmlContent, { strict: true }, (err, r) => (err ? reject(err) : resolve(r)));
+    });
+    const suite = result.testsuites.testsuite[0];
+    expect(suite.$).toMatchObject({ tests: "3", failures: "2" });
+    expect(
+      suite.testcase.map(tc => ({
+        name: tc.$.name,
+        failure: tc.failure?.map(f => f.$.message),
+      })),
+    ).toEqual([
+      { name: "sync", failure: [expect.stringContaining("sync done boom")] },
+      { name: "ok", failure: undefined },
+      { name: "async", failure: [expect.stringContaining("async done boom")] },
+    ]);
+    expect(exitCode).toBe(1);
+  });
 });
 
 function filterJunitXmlOutput(xmlContent) {

--- a/test/js/node/test_runner/fixtures/30-failing-suite-hooks.js
+++ b/test/js/node/test_runner/fixtures/30-failing-suite-hooks.js
@@ -1,0 +1,20 @@
+// Suite-level before()/after() hooks run as bun:test beforeAll/afterAll hooks
+// that report a failure through their done callback. Node v26.3.0 fails both
+// suites and does not run the body under the failing before().
+const { describe, before, after, test } = require("node:test");
+
+describe("suite whose after() fails", () => {
+  after(() => {
+    throw new Error("suite after() failed");
+  });
+  test("passes on its own", () => {});
+});
+
+describe("suite whose before() fails", () => {
+  before(() => {
+    throw new Error("suite before() failed");
+  });
+  test("must not run", () => {
+    console.log("BODY_RAN_AFTER_FAILED_BEFORE");
+  });
+});

--- a/test/js/node/test_runner/node-test.test.ts
+++ b/test/js/node/test_runner/node-test.test.ts
@@ -88,6 +88,20 @@ describe("node:test", () => {
     });
   });
 
+  test("should fail tests whose hooks, bodies, or inline suite callbacks fail under --concurrent too", async () => {
+    // node:test reports a failure by passing it to bun:test's done callback,
+    // which used to be attributed as an unhandled error between tests (and the
+    // test itself reported as passing) whenever the test ran in a concurrent group.
+    const { exitCode, stdout, stderr } = await runTests(["07-failing-hooks.js"], {}, ["--concurrent"]);
+    expect(stdout).toContain("SUB_BODY_RAN=false");
+    expect(stderr).not.toContain("Unhandled error between tests");
+    expect(stderr).toContain("0 pass");
+    expect({ exitCode, stderr }).toMatchObject({
+      exitCode: 1,
+      stderr: expect.stringContaining("10 fail"),
+    });
+  });
+
   test("should support done callbacks in tests and hooks", async () => {
     const { exitCode, stderr } = await runTests(["10-done-callbacks.js"]);
     expect(stderr).toContain("2 pass");

--- a/test/js/node/test_runner/node-test.test.ts
+++ b/test/js/node/test_runner/node-test.test.ts
@@ -102,6 +102,22 @@ describe("node:test", () => {
     });
   });
 
+  test("should fail a suite whose before() or after() hook fails instead of reporting its tests as passing", async () => {
+    // Suite-level hooks hand their failure to a bun:test beforeAll/afterAll done
+    // callback. It used to be printed as an unhandled error between tests, and
+    // the suite's tests still ran and were reported as passing.
+    const { exitCode, stdout, stderr } = await runTests(["30-failing-suite-hooks.js"]);
+    expect(stdout).not.toContain("BODY_RAN_AFTER_FAILED_BEFORE");
+    expect(stderr).toContain("error: suite after() failed");
+    expect(stderr).toContain("error: suite before() failed");
+    expect(stderr).not.toContain("Unhandled error between tests");
+    expect(stderr).toContain(" 1 pass\n");
+    expect({ exitCode, stderr }).toMatchObject({
+      exitCode: 1,
+      stderr: expect.stringContaining(" 2 fail\n"),
+    });
+  });
+
   test("should support done callbacks in tests and hooks", async () => {
     const { exitCode, stderr } = await runTests(["10-done-callbacks.js"]);
     expect(stderr).toContain("2 pass");


### PR DESCRIPTION
### Problem
- A test that reports its failure with `done(new Error(...))` is printed as `(pass)` when it runs in a concurrent group (`it.concurrent`, `describe.concurrent`, or any test under `bun test --concurrent`). The error is printed as `# Unhandled error between tests` instead, and the summary reads e.g. `4 pass, 0 fail, 4 errors`. The exit code is still 1, but the JUnit report has no `<failure>` for the test, and a `-t` rerun of the test looks green.
- A `beforeAll` / `beforeEach` / `afterEach` / `afterAll` hook calling `done(err)` behaves the same way even serially: the hook is not reported as failed, the dependent tests still run and pass (a failing `beforeEach` / `beforeAll` does not even skip the bodies), the error is counted as unhandled. A hook that throws fails them.
- `it.concurrent.failing("x", done => done(err))` is reported as a failure (the error is not credited to the test, so it "passed").
- `node:test` reports every failure by calling bun:test's done callback, so under `bun test --concurrent` every failing node:test test is reported as passing, and a suite-level `before()` / `after()` hook that throws (reported through a `beforeAll` / `afterAll` done callback) is reported that way even serially.
- Cause: `bun_test_done_callback` (src/runtime/test_runner/bun_test.rs) reports the error through the generic `VirtualMachine::uncaught_exception`, which attributes it with `BunTest::get_current_state_data()`. For a group with more than one sequence that returns `entry_data: None`, and for a hook `jest::on_unhandled_rejection` demotes it to `RefDataValue::Start`; either way `Execution::handle_uncaught_exception` returns `ShowUnhandledErrorBetweenTests` and never marks the sequence failed, so the `add_result` a few lines later completes it as a pass. Serially in a test body it worked only because `get_current_state_data()` happened to resolve to the same test.

### Fix
- `DoneCallback` now records, at creation, the file (`Weak`) and the `RefDataValue` that `run_test_callback` was invoked with; `done(err)` calls `on_uncaught_exception` keyed by that value, which is exactly how a throw or rejection from the same callback is reported (`run_test_callback` / `bun_test_then_or_catch`). The result for a test body, a hook, `test.failing` and JUnit is therefore identical to throwing from that callback, in serial and concurrent groups alike.
- This is correct for every moment `done` can fire: synchronously in the body or in its microtask drain (before the completion ref exists), later from a macrotask (ref stamped), or after the entry already finished. In the last case `get_current_and_valid_execution_sequence` rejects the stale value and the error is reported as `Unhandled error between tests`, like a late rejection already is; previously such a late `done(err)` failed (and completed) whichever test happened to be running.
- Retry attempts of the same test are the one case the stamp cannot tell apart until #38876 lands (it adds a per-attempt generation to this same check): a late `done(err)` from a timed-out attempt is still charged to the attempt running at the time and triggers another retry, as it already is serially on main. In a concurrent group of several tests main happened to report it as an unhandled error (exit 1) and this PR retries there too (exit 0); with #38876 both are rejected as stale. The `retry: 2` fixture posted on #33089 belongs to whichever of the two lands second.
- Completion is unchanged: the error is reported first, then the existing ref / `add_result` / `run_next_tick` path runs exactly once. A side effect is that the next test now starts on the next tick after `done(err)`, as it already did after `done()`; before, the generic path advanced the runner synchronously inside the `done()` call, which is why two stack frames from the previous test's `done()` call disappear from the existing snapshot in `test-error-code-done-callback.test.ts`.
- `node:test`'s runtime `t.skip()` / `t.todo()` mark (`js_node_test_mark_result`) reads the same stamp, which replaces `Execution.on_stack_entry_data` (added for exactly this "done fired before the ref was stamped" case); its existing serial and `--concurrent` tests still pass.
- Not changed: `done(false)` / `done("")` still count as errors, and a second `done()` call is still a no-op (#34041 is about that; it touches the same lines and would report through the same `owner` stamp). An `async` callback that also declares `done` still completes as soon as its promise fulfills (the `Fulfilled` arm of `run_test_callback`), so a `done(err)` it fires later is one of the stale cases above: reported as an unhandled error instead of, as before, failing the next test. Whether such a callback should wait for `done` is a separate question. #33089 (closed in favor of this PR) attributed `done(err)` through the ref as well but fell back to `get_current_state_data()` when the ref is not stamped yet, so the synchronous / microtask concurrent cases above (and node:test under `--concurrent`) stayed broken there; its hook-kind and node:test suite-hook cases are carried here.
- Verified:
  - `test/js/bun/test/test-error-code-done-callback.test.ts`: one fixture (sync, microtask and macrotask `done(err)`, `done()`, `it.failing`, `done(err)` from each of `beforeAll` / `beforeEach` / `afterEach` / `afterAll`) must produce the same per-test results serially, under `--concurrent`, and with `it.concurrent` / `describe.concurrent`; plus three stale-`done(err)` cases (timed out, body threw after scheduling it on a macrotask / microtask) that must not fail the test running at the time. All 7 fail on the current release (`USE_SYSTEM_BUN=1`), pass with `bun bd test`.
  - `test/js/junit-reporter/junit.test.js`: a concurrent group's `done(err)` failures land in their own `<testcase>` (before: `failures="0"`, no `<failure>` elements).
  - `test/js/node/test_runner/node-test.test.ts`: the failing-hooks fixture reports `10 fail` under `--concurrent` too (before: all ten reported as passing, ten unhandled errors).
  - `test/js/node/test_runner/node-test.test.ts` + `fixtures/30-failing-suite-hooks.js`: two suites whose `before()` / `after()` throw report `1 pass, 2 fail` and the body under the failed `before()` does not run (before: `2 pass, 0 fail, 2 errors`, body ran).
  - Also green locally on the debug build: the rest of `test/js/bun/test/` that covers done callbacks, hooks, failing/retry/skip and concurrency, `test/cli/test/bun-test.test.ts`, the rest of `junit.test.js` and `node-test.test.ts`, and the vendored `test/js/node/test/parallel/test-runner-*.js` files run the way `scripts/runner.node.mjs` runs them.

### Background
- Execution model: after collection, a file's tests and hooks are laid out as `ExecutionSequence`s (one test plus its `beforeEach`/`afterEach` entries), grouped into `ConcurrentGroup`s. A serial test is a group of one sequence; consecutive concurrent tests share one group and run interleaved.
- `RefDataValue`: the runner's handle for "this completion belongs to group G, sequence S, entry E, repeat N". `run_test_callback` is invoked with one; the promise `.then`/`.catch` and the done callback hand it back via `add_result`, and `Execution::get_current_and_valid_execution_sequence` refuses it once the sequence has moved on to another entry or completed, which is what makes late completions harmless (telling a retried attempt from its predecessor is #38876).
- `on_uncaught_exception(value, &RefDataValue)` marks that sequence failed (or passed for `test.failing`, skipping the rest of the sequence for a hook) and prints the error as that entry's failure, also recording it for JUnit. With a value it cannot resolve it prints `Unhandled error between tests` and bumps the error counter instead.
- `get_current_state_data()` is the fallback used for genuinely stray errors (an uncaught exception from a timer, an unhandled rejection): it can only point at the single sequence of a serial group, which is why it is the wrong tool for an error whose owner is known.
- The done callback's existing `r#ref` is a refcounted copy of the same `RefDataValue`, but it is only created after the callback returns (so a promise-returning callback and `done()` can agree on who completes the test); a `done(err)` called from the body, from the microtask drain, or after the body threw never sees it, hence the separate stamp taken at creation.

<details><summary>Notes</summary>

Rebase notes: main moved twice under this branch. The two conflicts and their resolutions:

- junit.test.js: main (#39828) and this PR both appended a test at the end of the same describe block. Kept both.
- DoneCallback.rs: main (#40478) gave `RefPtr` a `Drop` impl and deleted the manual `deref()` pattern. This PR's explicit `finalize` and the `scopeguard` release in `bun_test_done_callback` are gone with it: the stamped fields and `r#ref` now release when the box drops. `RefDataValue` also became `Copy` on main (#39570), so the stamp is copied, not cloned.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 10 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/test-error-code-done-callback.test.ts test/js/junit-reporter/junit.test.js test/js/node/test_runner/node-test.test.ts
bun test v1.4.1 (861e9ae04)

test/js/junit-reporter/junit.test.js:
(pass) junit reporter > should generate valid junit xml for passing tests %s [789.46ms]
(pass) junit reporter > should generate valid junit xml for passing tests %s [439.81ms]
[String: "/tmp/junit-comprehensive_BvrVf2"]
(pass) junit reporter > more scenarios [1046.39ms]
(pass) junit reporter > should report only the final result for a retried test [349.21ms]
(pass) junit reporter > produces well-formed XML when test names contain control characters [349.78ms]
(pass) junit reporter > escapes the classname attribute exactly once [354.33ms]
(pass) junit reporter > keeps the test body's error in <failure> when afterEach also throws [331.60ms]
(pass) junit reporter > includes the error type, message and stack in <failure> [331.60ms]
(pass) junit reporter > prints a stack frame whose source is not a file path as-is in <failure> [443.18ms]
632 
... (truncated)

release without fix: 10 FAILED
bun test v1.4.1-canary.1 (861e9ae04)

test/js/junit-reporter/junit.test.js:
(pass) junit reporter > should generate valid junit xml for passing tests %s [15.45ms]
(pass) junit reporter > should generate valid junit xml for passing tests %s [10.05ms]
[String: "/tmp/junit-comprehensive_92NwUC"]
(pass) junit reporter > more scenarios [17.60ms]
(pass) junit reporter > should report only the final result for a retried test [8.35ms]
(pass) junit reporter > produces well-formed XML when test names contain control characters [8.37ms]
(pass) junit reporter > escapes the classname attribute exactly once [7.94ms]
(pass) junit reporter > keeps the test body's error in <failure> when afterEach also throws [7.17ms]
(pass) junit reporter > includes the error type, message and stack in <failure> [7.57ms]
(pass) junit reporter > prints a stack frame whose source is not a file path as-is in <failure> [16.79ms]
632 |     const xmlContent = await file(junitPath).text();
633 |     const result = await new Promise((resolve, reject) => {
634 |       xml2js.parseString(xmlContent, { strict: true }, (err, r) => (err ? reject(err) : resolve(r)));
635 |     });
636 |     const suite = result.
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/test-error-code-done-callback.test.ts test/js/junit-reporter/junit.test.js test/js/node/test_runner/node-test.test.ts
bun test v1.4.1 (861e9ae04)

test/js/junit-reporter/junit.test.js:
(pass) junit reporter > should generate valid junit xml for passing tests %s [675.40ms]
(pass) junit reporter > should generate valid junit xml for passing tests %s [489.84ms]
[String: "/tmp/junit-comprehensive_mtT1mu"]
(pass) junit reporter > more scenarios [980.97ms]
(pass) junit reporter > should report only the final result for a retried test [330.56ms]
(pass) junit reporter > produces well-formed XML when test names contain control characters [328.96ms]
(pass) junit reporter > escapes the classname attribute exactly once [324.53ms]
(pass) junit reporter > keeps the test body's error in <failure> when afterEach also throws [370.34ms]
(pass) junit reporter > includes the error type, message and stack in <failure> [395.63ms]
(pass) junit reporter > prints a stack frame whose source is not a file path as-is in <failure> [441.88ms]
(pass
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     863d0c82b0
  features     baseline

23 deps, 129 codegen, 1172 objects in 672ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (861e9ae04)

Checked 26 installs across 63 packages (no changes) [4.00ms]
[2/1244] gen ErrorCode+*.h
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (861e9ae04)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1244] gen bindgenv2
[5/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (861e9ae04)

Checked 111 installs across 104 packages (no changes) [11.00ms]
[6/1244] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[7/1244] fetch tinycc
[tinycc] up to date
[8/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[9/1216] fetch zlib
[zlib] up to date
[10/1216] gen .bind.ts → GeneratedBindings.cpp
[11/1216] esbuild bun-error

  ../../build/release/codegen/bun-error/index.js       34.9kb
  ../
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/test_runner/DoneCallback.rs            |  13 +-
 src/runtime/test_runner/Execution.rs               |  24 +--
 src/runtime/test_runner/bun_test.rs                |  29 ++--
 src/runtime/test_runner/jest.rs                    |  41 ++---
 .../bun/test/test-error-code-done-callback.test.ts | 169 ++++++++++++++++++++-
 test/js/junit-reporter/junit.test.js               |  39 +++++
 .../test_runner/fixtures/30-failing-suite-hooks.js |  20 +++
 test/js/node/test_runner/node-test.test.ts         |  30 ++++
 8 files changed, 299 insertions(+), 66 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/runtime/test_runner/DoneCallback.rs                       2      3      0
src/runtime/test_runner/Execution.rs                          0      0      0
src/runtime/test_runner/bun_test.rs                           2      2      0
src/runtime/test_runner/jest.rs                               2      3      0
test/js/bun/test/test-error-code-done-callback.test.ts        0      0      0
test/js/junit-reporter/junit.test.js                          2      0      0
…/js/node/test_runner/fixtures/30-failing-suite-hooks.js      0      0      0
test/js/node/test_runner/node-test.test.ts                    0      0      0
```

</details>

**root cause** · written by the author bot

The test runner attributed `done(err)` errors using the shared on-stack entry data at call time, which misattributed failures when the callback fired from a concurrent group, a hook, or after a retry, since the currently executing entry was not necessarily the one that created the callback. The fix stamps each `DoneCallback` at creation with a weak reference to its owning `BunTest` and the `RefDataValue` its entry was invoked with, so `bun_test_done_callback` and node:test result marking route errors to the correct sequence regardless of what is on the stack when the callback runs. If the o…

<!-- robobun:evidence:end -->

