### PR TITLE
css: reject stylesheets of 2 GiB or more instead of aborting on an int cast

### DIFF
--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -2367,6 +2367,27 @@ impl<AtRule> StyleSheet<AtRule> {
     }
 }
 
+/// Longest input `parse_with` / `StyleAttribute::parse` accept.
+///
+/// Byte offsets into the input are stored as `i32` (`bun_ast::Loc` in import
+/// records, CSS-module symbols, `composes` and `PropertyUsage`), and the line
+/// and column numbers derived from them are stored as `i32` too
+/// (`bun_ast::Location` in errors and warnings). The largest such value is
+/// `len + 1`: the column of, or the 1-based line count at, the end of input.
+/// Columns count UTF-16 units, never more than one per byte. Bounding the
+/// length once here is what makes every one of those conversions infallible.
+pub(crate) const MAX_INPUT_LEN: usize = i32::MAX as usize - 1;
+
+fn check_input_len(code: &[u8]) -> Maybe<(), Err<ParserError>> {
+    if code.len() > MAX_INPUT_LEN {
+        return Err(Err {
+            kind: ParserError::input_too_large,
+            loc: None,
+        });
+    }
+    Ok(())
+}
+
 // ── StyleSheet behavior (parse/minify/to_css) ────────────────────────────────
 mod stylesheet_impl {
     use super::*;
@@ -2594,6 +2615,7 @@ mod stylesheet_impl {
             // returned `StyleSheet`.
             // TODO(refactor): re-thread the lifetime through `CssRuleList<'bump, R>`
             // and drop the `'static` bound on `arena`.
+            check_input_len(code)?;
             let mut composes = ComposesMap::default();
             let mut parser_extra = ParserExtra {
                 local_scope: LocalScope::default(),
@@ -2694,6 +2716,7 @@ mod stylesheet_impl {
             // TODO: 'bump lifetime threading — `DeclarationBlock<'static>` in
             // `StyleAttribute` vs `Parser<'a>` here; `arena: &'static Bump`
             // matches the crate-wide erasure (see `parse_with`).
+            check_input_len(code)?;
             let mut parser_extra = ParserExtra {
                 local_scope: LocalScope::default(),
                 symbols: SymbolList::default(),

--- a/src/css/error.rs
+++ b/src/css/error.rs
@@ -74,7 +74,8 @@ impl<T: fmt::Display> Err<T> {
             data: bun_ast::Data {
                 location: match &self.loc {
                     Some(loc) => Some(loc.to_location(source)?),
-                    None => None,
+                    // Errors about the stylesheet as a whole still name the file.
+                    None => bun_ast::Location::init_or_null(Some(source), bun_ast::Range::NONE),
                 },
                 text: text.into(),
             },
@@ -296,6 +297,8 @@ pub enum ParserError {
         expected: Str,
         received: Str,
     },
+    /// The input is longer than [`crate::css_parser::MAX_INPUT_LEN`].
+    input_too_large,
 }
 
 impl fmt::Display for ParserError {
@@ -326,6 +329,7 @@ impl fmt::Display for ParserError {
             Self::unexpected_value { expected, received } => {
                 write!(f, "Expected {}, received {}", bs(*expected), bs(*received))
             }
+            Self::input_too_large => f.write_str("CSS file is too large to parse (2 GiB maximum)"),
         }
     }
 }

--- a/test/js/bun/css/input-too-large.test.ts
+++ b/test/js/bun/css/input-too-large.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { closeSync, openSync, statSync, writeSync } from "node:fs";
+import os from "node:os";
+import { join } from "node:path";
+
+// Every byte offset the CSS parser hands to the rest of bun (import records,
+// CSS module symbols, `composes`) and every line/column in its diagnostics is
+// an i32, so once the tokenizer got past byte 2**31 of a stylesheet the process
+// aborted with `panic: int cast: TryFromIntError(PosOverflow)`. The parser now
+// refuses such input up front with an ordinary build error, before reading it.
+//
+// Each stylesheet here is one comment covering its first 2 GiB followed by a
+// `composes` declaration, a cast site that both the bundler and
+// `bun build --no-bundle` reach (a url() only becomes an import record when
+// bundling). The comment body is all zero bytes, so it costs nothing to
+// produce: untouched pages of a Uint8Array in one case, a hole in a sparse
+// file in the other. Handing it to bun still costs the child 2 GiB of memory,
+// hence the memory gate (the same one fs-oom.test.ts uses for its 2 GiB reads)
+// and the generous timeouts. The tests are deliberately not concurrent, so at
+// most one 2 GiB child exists at a time.
+const TAIL = "*/.a{composes:b}\n";
+const MESSAGE = "CSS file is too large to parse (2 GiB maximum)";
+
+describe.skipIf(os.totalmem() < 10 * 1024 ** 3)("stylesheet of 2 GiB or more", () => {
+  test("Bun.build reports an error naming the file", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const tail = new TextEncoder().encode(${JSON.stringify(TAIL)});
+          const bytes = new Uint8Array(2 ** 31 + tail.length);
+          bytes.set([0x2f, 0x2a]); // "/*"
+          bytes.set(tail, 2 ** 31);
+          const result = await Bun.build({
+            entrypoints: ["/app/big.css"],
+            files: { "/app/big.css": bytes },
+            throw: false,
+          });
+          console.log(JSON.stringify({
+            success: result.success,
+            logs: result.logs.map(log => ({ level: log.level, message: log.message, file: log.position?.file })),
+          }));
+          `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      success: false,
+      logs: [{ level: "error", message: MESSAGE, file: "/app/big.css" }],
+    });
+    expect(exitCode).toBe(0);
+  }, 30_000);
+
+  // Windows only makes a file sparse on request, so seeking past 2 GiB there
+  // would really write 2 GiB of zeros. The bound is the same code on every
+  // platform and the test above already runs there.
+  test.skipIf(isWindows)(
+    "bun build --no-bundle reports an error",
+    async () => {
+      using dir = tempDir("css-too-large", {});
+      const css = join(String(dir), "big.css");
+      const tail = Buffer.from(TAIL);
+      const fd = openSync(css, "w");
+      try {
+        writeSync(fd, Buffer.from("/*"), 0, 2, 0);
+        writeSync(fd, tail, 0, tail.length, 2 ** 31);
+      } finally {
+        closeSync(fd);
+      }
+      expect(statSync(css).size).toBe(2 ** 31 + tail.length);
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build", "--no-bundle", css],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain(`error: ${MESSAGE}`);
+      expect(stdout).toBe("");
+      expect(exitCode).toBe(1);
+    },
+    30_000,
+  );
+});


### PR DESCRIPTION
### Problem
- A `.css` input of 2 GiB or more aborts `bun build`, `Bun.build` and `bun build --no-bundle` with `panic: int cast: TryFromIntError(PosOverflow)` instead of producing a build error.
- bun_css stores byte offsets into the stylesheet as `i32` with an `expect("int cast")`: `add_import_record` for every `url()` / `composes ... from` (src/css/css_parser.rs:3117), `on_import_rule` for `@import` (css_parser.rs:819, after a `u32` cast at 1339), `Composes::parse` (src/css/properties/css_modules.rs:50, reached in any stylesheet since `composes` is an ordinary property), `new_local_identifier` for every class/id of a CSS module (src/css/selectors/parser.rs:1189), and the `composes` property-usage range (css_parser.rs:2094).
- The line and column of a diagnostic go through the same kind of cast: `ErrorLocation::to_location` (src/css/error.rs:190-191), `SourceLocation::to_logger_location` (css_parser.rs:159-160) and the warning path `Log::add_warning_fmt_line_col` (src/ast/lib.rs:1898-1899), and the tokenizer itself keeps columns as `u32` (css_parser.rs:3886, 4180).
- Nothing bounded the input. Both callers, the bundler (src/bundler/ParseTask.rs, `Loader::Css`) and the transpiler's `build_css_output` (src/bundler/transpiler.rs), hand the whole file to `StyleSheet::parse` / `parse_bundler`.

### Fix
- `parse_with` (behind `StyleSheet::parse` and `parse_bundler`) and `StyleAttribute::parse` reject input longer than `MAX_INPUT_LEN = i32::MAX - 1` with a new `ParserError::input_too_large`, which renders as `CSS file is too large to parse (2 GiB maximum)`. Nothing reads the input before the check.
- Why one check is enough: every value the casts above convert is either a byte offset into the input (at most `len`), a length of a slice of it, a column (UTF-16 units, never more than one per byte of the line, plus one) or a 1-based line number (at most one line per byte, plus one). So with `len <= i32::MAX - 1` each of them is at most `i32::MAX`, and the existing casts become the invariants they were written as. The `len + 1` cases (an error at end of input) are why the bound is one below `i32::MAX`.
- The error has no position, so `Err::add_to_logger` now attaches a file-only location for positionless errors (`init_or_null` with `Range::NONE`), the same shape JS diagnostics at `Loc::EMPTY` have. A real line would mean scanning the oversized input for its line text. `bun build` prints `error: CSS file is too large to parse (2 GiB maximum)` / `at <path>/big.css`; `Bun.build({ throw: false })` reports it with `position.file` set. Nothing else produced a positionless error through this path before.
- Same limit and wording as the JSON parser and as #39095, which does this for the JS, TOML, YAML and XML parsers and leaves bun_css to this change (bun_css takes `&[u8]` and has its own error type, so it cannot use that PR's `Source` helper).
- Test: test/js/bun/css/input-too-large.test.ts. Each case feeds a 2 GiB comment followed by `.a{composes:b}` (a cast site both entry points reach) through one of the two callers: `Bun.build` with an in-memory file (zero pages of a `Uint8Array`, so it also runs on Windows) and `bun build --no-bundle` on a sparse file. Gated on 10 GiB of RAM like the 2 GiB cases in fs-oom.test.ts, since the child still holds the 2 GiB it is handed; about 2.5 s per case in a debug build.
- Verified: with the fix, `bun bd test test/js/bun/css/input-too-large.test.ts` passes; without it (`USE_SYSTEM_BUN=1 bun test ...`, 1.4.0) both cases fail with the panic above after tokenizing the 2 GiB.
- Verified: `bun build big.css --outdir out` and `bun build --no-bundle big.css` on a sparse 2 GiB file exit 1 with the error (debug build); they aborted before.
- Verified: test/js/bun/css and test/bundler/css pass with the debug build, except for pre-existing timeouts of tests that do not fit their 5 s / 10 s budget under this debug ASAN build (css-fuzz runs 1000 `Bun.build`s at about 60 ms each; selector-list-error-recovery and the nested-expansion tests spawn children that each spend about 1.7 s loading `bun:internal-for-testing`); CSS parsing itself is unaffected.

### Background
- `bun_ast::Loc` is the byte offset type the whole pipeline uses for positions; it is an `i32`, which is why every parser has a 2 GiB ceiling and why bun_css converts its `usize` positions into it when it builds import records and CSS-module symbols.
- bun_css keeps its own line/column for diagnostics (`SourceLocation`, `u32`, columns counted in UTF-16 code units by adjusting the line start as multi-byte sequences are consumed) and converts them to the logger's `i32` `bun_ast::Location` when an error or warning is reported.
- `Err<T>` is bun_css's error-with-location type; `loc: None` means the error has no position. `Err::add_to_logger` is how the bundler turns one into a log message; `bun build --no-bundle` only formats the message text.
- `Bun.build({ files })` supplies entry points from memory instead of disk; the test uses it so the 2 GiB never has to be written or read, only copied.

<details>
<summary>Repro</summary>

```sh
bun -e '
const fs = require("fs");
const fd = fs.openSync("big.css", "w");
fs.writeSync(fd, Buffer.from("/*"), 0, 2, 0);
const tail = Buffer.from("*/.a{composes:b}\n");
fs.writeSync(fd, tail, 0, tail.length, 2 ** 31);   // sparse: 8 KiB on disk
fs.closeSync(fd);'
bun build ./big.css --outdir out             # before: panic: int cast: TryFromIntError(PosOverflow), exit 134
bun build --no-bundle ./big.css              # before: same panic
```

After:

```
error: CSS file is too large to parse (2 GiB maximum)
    at /tmp/x/big.css
```

A `url()` in place of `composes` aborts the bundler the same way (`add_import_record`); with `--no-bundle` it is rejected earlier because that path parses without an import record list, so the test uses `composes`, which both paths cast.
</details>
