### PR TITLE
node:net: emit 'listening' on the next tick so close() from the handler never inherits an accepted connection

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -3573,8 +3573,7 @@ Server.prototype.close = function close(callback) {
   if (this._handle) {
     if (typeof this._handle.stop === "function") {
       this._handle.stop(false);
-      // Node's uv_close() keeps the loop alive one more turn (test-process-beforeexit),
-      // as closeSocketHandle's setImmediate does for sockets.
+      // Node's uv_close() keeps the loop alive for one more turn (test-process-beforeexit); so does this.
       setImmediate(noop);
       // Released here, not on 'close': https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L2434-L2437
       const clusterHandle = this[kClusterHandle];
@@ -3964,9 +3963,7 @@ Server.prototype[kRealListen] = function (
   // Unref the handle if the server was unref'ed prior to listening
   if (this._unref) this.unref();
 
-  // Bun.listen() has already called listen(2). A tick, not a timer, so a close() from
-  // the 'listening' handler runs before the loop accepts anything, as in Node:
-  // https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L2034-L2037
+  // A tick, not a timer, so a close() from 'listening' runs before the loop accepts anything (as in Node).
   process.nextTick(emitListeningNextTick, this);
 };
 

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -3573,6 +3573,12 @@ Server.prototype.close = function close(callback) {
   if (this._handle) {
     if (typeof this._handle.stop === "function") {
       this._handle.stop(false);
+      // stop() closes the listening socket synchronously. In Node the handle's
+      // uv_close() completes on the next loop turn, so the loop counts as alive
+      // until then; this is what re-emits 'beforeExit' after a server is closed
+      // from a 'beforeExit' chain (test-process-beforeexit). Hold the loop for
+      // that one turn the same way closeSocketHandle does for sockets.
+      setImmediate(noop);
       // Released here, not on 'close': https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L2434-L2437
       const clusterHandle = this[kClusterHandle];
       if (clusterHandle) {

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -3573,11 +3573,8 @@ Server.prototype.close = function close(callback) {
   if (this._handle) {
     if (typeof this._handle.stop === "function") {
       this._handle.stop(false);
-      // stop() closes the listening socket synchronously. In Node the handle's
-      // uv_close() completes on the next loop turn, so the loop counts as alive
-      // until then; this is what re-emits 'beforeExit' after a server is closed
-      // from a 'beforeExit' chain (test-process-beforeexit). Hold the loop for
-      // that one turn the same way closeSocketHandle does for sockets.
+      // Node's uv_close() keeps the loop alive one more turn (test-process-beforeexit),
+      // as closeSocketHandle's setImmediate does for sockets.
       setImmediate(noop);
       // Released here, not on 'close': https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L2434-L2437
       const clusterHandle = this[kClusterHandle];
@@ -3967,11 +3964,8 @@ Server.prototype[kRealListen] = function (
   // Unref the handle if the server was unref'ed prior to listening
   if (this._unref) this.unref();
 
-  // Bun.listen() has already bound and called listen(2). Emitting on the next
-  // tick like Node means a server.close() from the 'listening' handler closes
-  // the listening fd before the event loop polls it, so a peer that connected
-  // in between is reset by the kernel instead of being accepted by a server
-  // that is already closing (vite probes free ports with exactly that pattern).
+  // Bun.listen() has already called listen(2). A tick, not a timer, so a close() from
+  // the 'listening' handler runs before the loop accepts anything, as in Node:
   // https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L2034-L2037
   process.nextTick(emitListeningNextTick, this);
 };

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -3961,14 +3961,13 @@ Server.prototype[kRealListen] = function (
   // Unref the handle if the server was unref'ed prior to listening
   if (this._unref) this.unref();
 
-  // We must schedule the emitListeningNextTick() only after the next run of
-  // the event loop's IO queue. Otherwise, the server may not actually be listening
-  // when the 'listening' event is emitted.
-  //
-  // That leads to all sorts of confusion.
-  //
-  // process.nextTick() is not sufficient because it will run before the IO queue.
-  setTimeout(emitListeningNextTick, 1, this);
+  // Bun.listen() has already bound and called listen(2). Emitting on the next
+  // tick like Node means a server.close() from the 'listening' handler closes
+  // the listening fd before the event loop polls it, so a peer that connected
+  // in between is reset by the kernel instead of being accepted by a server
+  // that is already closing (vite probes free ports with exactly that pattern).
+  // https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L2034-L2037
+  process.nextTick(emitListeningNextTick, this);
 };
 
 Server.prototype[EventEmitter.captureRejectionSymbol] = function (err, event, sock) {
@@ -4177,7 +4176,7 @@ Server.prototype[kClusterFauxListen] = function (handle, backlog, path) {
   handle[kClusterOwner] = this;
   handle.listen(backlog || 511);
   if (this._unref) this.unref();
-  setTimeout(emitListeningNextTick, 1, this);
+  process.nextTick(emitListeningNextTick, this);
 };
 
 function onClusterConnection(err, clientHandle) {

--- a/test/js/node/net/node-net-server.test.ts
+++ b/test/js/node/net/node-net-server.test.ts
@@ -227,6 +227,51 @@ describe("net.createServer listen", () => {
       }),
     );
   });
+
+  it("emits 'listening' on the next tick, before the event loop polls", async () => {
+    const server: Server = createServer();
+    const order: string[] = [];
+    server.on("listening", () => order.push("listening"));
+    server.listen(0);
+    process.nextTick(() => order.push("nextTick"));
+    await once(server, "listening");
+    server.close();
+    await once(server, "close");
+    expect(order).toEqual(["listening", "nextTick"]);
+  });
+
+  // How vite, get-port and friends probe for a free port: listen, then close()
+  // from the 'listening' handler. A peer that connects in between must be reset
+  // by the kernel when the listening fd closes, not accepted into the closing
+  // server, whose close() would then wait on a connection nobody is reading.
+  it("close() from 'listening' does not accept a peer that connected in between", async () => {
+    const server: Server = createServer();
+    let accepted = 0;
+    server.on("connection", () => accepted++);
+    server.listen(0, "127.0.0.1");
+
+    // Bun.connect() issues connect(2) synchronously, so the peer is already
+    // sitting in the listen backlog when the 'listening' handler runs.
+    const { port } = server.address() as AddressInfo;
+    const peer = Bun.connect({
+      hostname: "127.0.0.1",
+      port,
+      socket: {
+        data() {},
+        error() {},
+        connectError() {},
+      },
+    }).catch(() => null);
+
+    const { promise: closed, resolve: onClosed } = Promise.withResolvers<void>();
+    server.once("listening", () => {
+      server.close(() => onClosed());
+      peer.then(socket => socket?.end());
+    });
+
+    await closed;
+    expect(accepted).toBe(0);
+  });
 });
 
 describe("net.createServer events", () => {

--- a/test/js/node/net/node-net-server.test.ts
+++ b/test/js/node/net/node-net-server.test.ts
@@ -248,6 +248,8 @@ describe("net.createServer listen", () => {
     const server: Server = createServer();
     let accepted = 0;
     server.on("connection", () => accepted++);
+    const { promise: closed, resolve: onClosed, reject } = Promise.withResolvers<void>();
+    server.on("error", reject);
     server.listen(0, "127.0.0.1");
 
     // Bun.connect() issues connect(2) synchronously, so the peer is already
@@ -263,7 +265,6 @@ describe("net.createServer listen", () => {
       },
     }).catch(() => null);
 
-    const { promise: closed, resolve: onClosed } = Promise.withResolvers<void>();
     server.once("listening", () => {
       server.close(() => onClosed());
       peer.then(socket => socket?.end());
@@ -271,6 +272,42 @@ describe("net.createServer listen", () => {
 
     await closed;
     expect(accepted).toBe(0);
+  });
+
+  // Node's server.close() completes the handle's uv_close() on the next loop
+  // turn, so a server listened and closed from a 'beforeExit' handler brings
+  // the loop back to life once more and 'beforeExit' fires again
+  // (upstream test-process-beforeexit). 'listening' itself is only a nextTick
+  // now, so close() has to hold the loop for that turn on its own.
+  it("closing a server listened from 'beforeExit' re-emits 'beforeExit'", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const net = require("net");
+          process.once("beforeExit", () => {
+            net
+              .createServer()
+              .listen(0)
+              .on("listening", function () {
+                this.close();
+                process.once("beforeExit", () => console.log("beforeExit again"));
+              });
+          });
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // stderr only matters on failure: debug builds may print benign warnings.
+    expect({ stdout, exitCode, failureDetail: exitCode === 0 ? "" : stderr }).toEqual({
+      stdout: "beforeExit again\n",
+      exitCode: 0,
+      failureDetail: "",
+    });
   });
 });
 


### PR DESCRIPTION
### Problem
- `bun --bun vite dev` (vite 8.2.1) intermittently never becomes ready on main: no output, main thread idle in `epoll_wait`, no listening socket. 1.3.14 always comes up. About 1 start in 10 when something polls the port during startup; more often on fewer CPUs.
- The hung process holds exactly one socket: an accepted connection on port 5173 in `CLOSE_WAIT`, and no listener. vite never got past `isPortAvailable()` (`tryListen()` in vite's `http.ts`): `net.createServer().listen(port, host)`, then `server.close(cb)` from the `'listening'` handler. `cb` never fired.
- Cause: `Server.prototype[kRealListen]` (`src/js/node/net.ts:3971` before this change) emitted `'listening'` from `setTimeout(..., 1)`. The event loop therefore polled the new listening socket, and accepted whatever had connected to it (here: the health-check poller), before the `'listening'` handler ran. `close()` then found `_connections > 0` and waited for that connection, which nothing reads. Node emits `'listening'` from `process.nextTick` (`setupListenHandle`, lib/net.js v26.3.0 L2034-L2037), so in Node the listening fd is closed before the loop ever accepts, and the kernel resets the pending peer. Verified: under the same connection hammering, Node reports `accepted=0` every time.
- Why it is new in 1.4: the accept window existed in 1.3.14 too, but back then accepted sockets were created with `allowHalfOpen: false` natively, so the stray connection was torn down as soon as the poller gave up and the close callback fired (vite came up 1-3s late). #31155 gave accepted sockets Node's half-open semantics (a peer FIN with unread data leaves the socket open, as in Node), so the stray connection now lives forever and `close()` never completes.

### Fix
- `kRealListen` and `kClusterFauxListen` emit `'listening'` with `process.nextTick(emitListeningNextTick, this)` instead of a 1ms timer. `Bun.listen()` has already called `listen(2)` when it returns (`Listener::listen` -> `us_socket_group_listen` -> `bsd_create_listen_socket`, all synchronous; `kRealListen` reads the bound port back right after), so the event is not early; `emitListeningNextTick` still skips the emit if the server was closed in between, like Node's `emitListeningNT`. The timer came from 25097cd632 (2023), which replaced #2337's original `nextTick` without a test; the native listen was already synchronous then and nothing in the current suites needs the delay (details in a comment below).
- A `close()` from the handler now runs before the first poll of the listening fd; `us_listen_socket_close` closes the fd synchronously, so connections still in the backlog are reset by the kernel and are never accepted, matching Node.
- `Server.prototype.close()` queues a no-op `setImmediate` when it closes the native listener. In Node the handle's `uv_close()` completes on the next loop turn and the loop counts as alive until then; upstream `test-process-beforeexit` depends on that (a server listened and closed from a `'beforeExit'` handler must make `'beforeExit'` fire again). The 1ms timer used to provide that turn by accident; with `'listening'` on a tick the server is gone before the tick drain returns, so `close()` holds the loop for the turn itself, the same way `closeSocketHandle` already does for sockets. `'close'` itself is still emitted on `nextTick`, so its ordering is unchanged.
- Tests in `test/js/node/net/node-net-server.test.ts`: `'listening'` is ordered before a `nextTick` queued after `listen()`; a peer that `connect(2)`ed into the backlog before the `'listening'` handler closes the server is not accepted; closing a server listened from `'beforeExit'` re-emits `'beforeExit'`. The first two fail on main (`accepted` is 1 there), the third fails with the `nextTick` change alone and passes with the `close()` hold; all three match Node 26.3.0.
- vite repro with 4 `curl` loops hammering port 5173 during startup (forces a connection into the probe window): main release build hangs 3/3 with an empty log, 1.3.14 comes up 3/3 after 1-3s, this branch comes up 3/3.
- `test/js/node/net`, `test/js/node/tls`, `test/js/node/cluster*`, and the upstream `test-net-*`/`test-tls-*`/`test-cluster-*`/`test-process-*`/`test-http2-*` files plus every upstream file mentioning `beforeExit` (787 files, `test-process-beforeexit.js` included): same results as main (the remaining failures here are `localhost` resolution and load timeouts in this container that fail identically on main or pass when run alone).
- `node:http`'s server still emits `'listening'` from a 1ms timer (`_http_server.ts`); it does not have this hang (it serves whatever it accepts), so it is left alone here.

### Background
- `server.close()` in Node stops accepting and emits `'close'` only once every tracked connection has ended; `net.ts` implements this in `_emitCloseIfDrained`, which is re-checked as each accepted socket closes.
- Half-open (`allowHalfOpen`): when the peer sends FIN, a Node socket only auto-ends its own side after the readable side emits `'end'`, which requires buffered data to be consumed. A connection nobody reads therefore stays open after the peer hangs up. That is why the stray accepted connection is permanent in 1.4 and why the fix is to not accept it in the first place.
- Listen backlog: after `listen(2)`, the kernel completes TCP handshakes on its own and queues the connections until the process calls `accept(2)`. Closing the listening fd resets whatever is still queued. Bun only accepts when the event loop polls the fd, so whether user code runs before or after that first poll (`nextTick` vs a timer) decides whether such a connection becomes the server's problem.

<details>
<summary>Repro used</summary>

Minimal (server side of vite's probe, port hammered by `curl` loops from another shell):

```js
const net = require("net");
const server = net.createServer();
let accepted = 0;
server.on("connection", () => accepted++);
server.once("listening", () => server.close(() => console.log("closed, accepted=" + accepted)));
server.listen(5199, "0.0.0.0");
```

main: `accepted connection` x1-4, close callback never fires. 1.3.14: close callback after ~2s (when curl gives up). Node and this branch: closes immediately, `accepted=0`.

Full: `bun create vite app --template react-ts`, then start `bun --bun node_modules/vite/bin/vite.js dev --port 5173 --host 127.0.0.1` while `curl` loops hit the port. main: hangs with an empty log every run; this branch: ready every run.
</details>
