### PR TITLE
test(install): serve GitHub tarball fixtures locally in the GHSA-pfwx-36v6-832x and lifecycle script tests

### DIFF
--- a/test/cli/install/GHSA-pfwx-36v6-832x.test.ts
+++ b/test/cli/install/GHSA-pfwx-36v6-832x.test.ts
@@ -1,255 +1,207 @@
-import { file } from "bun";
 import { describe, expect, test } from "bun:test";
-import { rm } from "fs/promises";
-import { bunEnv, bunExe, tempDir } from "harness";
-import { join } from "path";
+import { bunEnv, bunExe, githubTarball, tempDir, textLockfile } from "harness";
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { join } from "node:path";
 
-// Each test uses its own BUN_INSTALL_CACHE_DIR inside the temp dir for full
-// isolation.  This avoids interfering with the global cache or other tests.
-function envWithCache(dir: string) {
-  return { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache") };
+// GHSA-pfwx-36v6-832x: bun.lock records the sha512 of a GitHub dependency's tarball next
+// to its resolved commit, and an install that downloads the tarball again rejects
+// different bytes.
+//
+// `owner/repo#ref` is fetched from `${GITHUB_API_URL}/repos/owner/repo/tarball/ref`, so
+// each test serves the tarball built below from its own local server; nothing in this
+// file talks to api.github.com.
+
+const name = "gh-dep";
+const owner = "gh-owner";
+const repo = "gh-repo";
+const ref = "0badc0d";
+const spec = `${owner}/${repo}#${ref}`;
+// GitHub's tarballs unpack into `<owner>-<repo>-<short sha>`; bun records that directory
+// name in the lockfile as the resolved commit.
+const resolved = `${owner}-${repo}-${ref}`;
+const tarballPath = `/repos/${owner}/${repo}/tarball/${ref}`;
+
+// Pseudo-random bytes (xorshift32) so gzip cannot shrink them.
+function incompressible(bytes: number): Uint8Array {
+  const words = new Uint32Array(bytes / 4);
+  let x = 0x2545f491;
+  for (let i = 0; i < words.length; i++) {
+    x ^= x << 13;
+    x ^= x >>> 17;
+    x ^= x << 5;
+    words[i] = x;
+  }
+  return new Uint8Array(words.buffer);
 }
 
-describe.concurrent("GitHub tarball integrity", () => {
-  test("should store integrity hash in lockfile for GitHub dependencies", async () => {
-    using dir = tempDir("github-integrity", {
-      "package.json": JSON.stringify({
-        name: "test-github-integrity",
-        dependencies: {
-          "is-number": "jonschlinkert/is-number#98e8ff1",
-        },
-      }),
+const tarball = githubTarball(resolved, {
+  "package.json": JSON.stringify({ name, version: "1.0.0" }),
+  "index.js": "module.exports = 1;\n",
+  // The HTTP client reads at most 512 KiB (LIBUS_RECV_BUFFER_LENGTH) per socket read, so a
+  // larger tarball always arrives in several chunks. That is what lets the streaming variant
+  // below commit to streaming extraction on every run instead of falling back to buffering
+  // when the whole body happens to arrive at once.
+  "filler.bin": incompressible(600 * 1024),
+});
+expect(tarball.length).toBeGreaterThan(512 * 1024);
+
+const integrity = `sha512-${createHash("sha512").update(tarball).digest("base64")}`;
+const wrongIntegrity = `sha512-${Buffer.alloc(64).toString("base64")}`;
+const lockedPackage = `${name}@github:${spec}`;
+
+function project(files: Record<string, string> = {}) {
+  return tempDir("github-integrity", {
+    "package.json": JSON.stringify({ name: "app", dependencies: { [name]: spec } }),
+    ...files,
+  });
+}
+
+function lockfileWith(entry: unknown[]) {
+  return textLockfile(1, {
+    workspaces: { "": { name: "app", dependencies: { [name]: spec } } },
+    packages: { [name]: entry },
+  });
+}
+
+async function lockedEntry(dir: string) {
+  const { packages } = Bun.JSONC.parse(await Bun.file(join(dir, "bun.lock")).text()) as {
+    packages: Record<string, unknown[]>;
+  };
+  return packages[name];
+}
+
+// Tarballs smaller than BUN_INSTALL_STREAMING_MIN_SIZE (2 MiB by default) are extracted
+// once the whole body has been buffered; larger ones are streamed into libarchive while
+// they download. The two extractors hash and verify the tarball independently, so every
+// test runs against both. `--verbose` output names the extractor that ran.
+const variants = [
+  { variant: "buffered", variantEnv: {}, extracted: `[${name}] Extract ` },
+  { variant: "streaming", variantEnv: { BUN_INSTALL_STREAMING_MIN_SIZE: "1" }, extracted: `[${name}] Streamed ` },
+];
+
+describe.each(variants)("GitHub tarball integrity ($variant extraction)", ({ variantEnv, extracted }) => {
+  function serveTarball(dir: string) {
+    const requests: string[] = [];
+    const server = Bun.serve({
+      port: 0,
+      fetch(request) {
+        const { pathname } = new URL(request.url);
+        requests.push(pathname);
+        return pathname === tarballPath ? new Response(tarball) : new Response("Not Found", { status: 404 });
+      },
     });
+    return {
+      requests,
+      async install() {
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "install", "--verbose"],
+          cwd: dir,
+          env: {
+            ...bunEnv,
+            ...variantEnv,
+            GITHUB_API_URL: server.url.origin,
+            BUN_INSTALL_CACHE_DIR: join(dir, ".bun-cache"),
+          },
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+        return { stderr, exitCode };
+      },
+      [Symbol.asyncDispose]: () => server.stop(),
+    };
+  }
 
-    const env = envWithCache(dir);
+  test.concurrent("stores the tarball's integrity in the lockfile", async () => {
+    using dir = project();
+    await using github = serveTarball(String(dir));
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "install"],
-      cwd: String(dir),
-      env,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
+    const { stderr, exitCode } = await github.install();
+    expect(stderr).toContain(extracted);
+    expect(stderr).not.toContain("error:");
     expect(stderr).toContain("Saved lockfile");
     expect(exitCode).toBe(0);
 
-    const lockfileContent = await file(join(String(dir), "bun.lock")).text();
-
-    // The lockfile should contain a sha512 integrity hash for the GitHub dependency
-    expect(lockfileContent).toContain("sha512-");
-    // The resolved commit hash should be present
-    expect(lockfileContent).toContain("jonschlinkert-is-number-98e8ff1");
-    // Verify the format: the integrity appears after the resolved commit hash
-    expect(lockfileContent).toMatch(/"jonschlinkert-is-number-98e8ff1",\s*"sha512-/);
+    expect(github.requests).toEqual([tarballPath]);
+    expect(await lockedEntry(String(dir))).toEqual([lockedPackage, {}, resolved, integrity]);
+    expect(existsSync(join(String(dir), "node_modules", name, "index.js"))).toBeTrue();
   });
 
-  test("should verify integrity passes on re-install with matching hash", async () => {
-    using dir = tempDir("github-integrity-match", {
-      "package.json": JSON.stringify({
-        name: "test-github-integrity-match",
-        dependencies: {
-          "is-number": "jonschlinkert/is-number#98e8ff1",
-        },
-      }),
-    });
+  test.concurrent("re-downloading a tarball that matches the locked integrity succeeds", async () => {
+    using dir = project();
+    await using github = serveTarball(String(dir));
 
-    const env = envWithCache(dir);
+    const first = await github.install();
+    expect(first.stderr).not.toContain("error:");
+    expect(first.exitCode).toBe(0);
+    expect(await lockedEntry(String(dir))).toEqual([lockedPackage, {}, resolved, integrity]);
 
-    // First install to generate lockfile with correct integrity
-    await using proc1 = Bun.spawn({
-      cmd: [bunExe(), "install"],
-      cwd: String(dir),
-      env,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-
-    const [stdout1, stderr1, exitCode1] = await Promise.all([proc1.stdout.text(), proc1.stderr.text(), proc1.exited]);
-    expect(stderr1).not.toContain("error:");
-    expect(exitCode1).toBe(0);
-
-    // Read the generated lockfile and extract the integrity hash adjacent to
-    // the GitHub resolved entry to avoid accidentally matching an npm hash.
-    const lockfileContent = await file(join(String(dir), "bun.lock")).text();
-    const integrityMatch = lockfileContent.match(/"jonschlinkert-is-number-98e8ff1",\s*"(sha512-[A-Za-z0-9+/]+=*)"/);
-    expect(integrityMatch).not.toBeNull();
-    const integrityHash = integrityMatch![1];
-
-    // Clear cache and node_modules, then re-install with the same lockfile
     await rm(join(String(dir), ".bun-cache"), { recursive: true, force: true });
     await rm(join(String(dir), "node_modules"), { recursive: true, force: true });
 
-    await using proc2 = Bun.spawn({
-      cmd: [bunExe(), "install"],
-      cwd: String(dir),
-      env,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
+    const second = await github.install();
+    expect(second.stderr).toContain(extracted);
+    expect(second.stderr).not.toContain("error:");
+    expect(second.exitCode).toBe(0);
 
-    const [stdout2, stderr2, exitCode2] = await Promise.all([proc2.stdout.text(), proc2.stderr.text(), proc2.exited]);
-
-    // Should succeed because the integrity matches
-    expect(stderr2).not.toContain("Integrity check failed");
-    expect(exitCode2).toBe(0);
-
-    // Lockfile should still contain the same integrity hash
-    const lockfileContent2 = await file(join(String(dir), "bun.lock")).text();
-    expect(lockfileContent2).toContain(integrityHash);
+    expect(github.requests).toEqual([tarballPath, tarballPath]);
+    expect(await lockedEntry(String(dir))).toEqual([lockedPackage, {}, resolved, integrity]);
+    expect(existsSync(join(String(dir), "node_modules", name, "index.js"))).toBeTrue();
   });
 
-  test("should reject GitHub tarball when integrity check fails", async () => {
-    using dir = tempDir("github-integrity-reject", {
-      "package.json": JSON.stringify({
-        name: "test-github-integrity-reject",
-        dependencies: {
-          "is-number": "jonschlinkert/is-number#98e8ff1",
-        },
-      }),
-      // Pre-create a lockfile with an invalid integrity hash (valid base64, 64 zero bytes)
-      "bun.lock": JSON.stringify({
-        lockfileVersion: 1,
-        configVersion: 1,
-        workspaces: {
-          "": {
-            name: "test-github-integrity-reject",
-            dependencies: {
-              "is-number": "jonschlinkert/is-number#98e8ff1",
-            },
-          },
-        },
-        packages: {
-          "is-number": [
-            "is-number@github:jonschlinkert/is-number#98e8ff1",
-            {},
-            "jonschlinkert-is-number-98e8ff1",
-            "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
-          ],
-        },
-      }),
-    });
+  test.concurrent("rejects a tarball that does not match the locked integrity", async () => {
+    using dir = project({ "bun.lock": lockfileWith([lockedPackage, {}, resolved, wrongIntegrity]) });
+    await using github = serveTarball(String(dir));
 
-    // Fresh per-test cache ensures the tarball must be downloaded from the network
-    const env = envWithCache(dir);
-
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "install"],
-      cwd: String(dir),
-      env,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-    expect(stderr).toContain("Integrity check failed");
+    // Both extractors report the mismatch before they log which one ran, so unlike the
+    // other tests this one cannot check `extracted`; the download is shaped exactly like
+    // theirs, so it goes through the same extractor they prove is in use.
+    const { stderr, exitCode } = await github.install();
+    expect(stderr).toContain(`Integrity check failed for tarball: ${name}`);
     expect(exitCode).not.toBe(0);
+
+    expect(github.requests).toEqual([tarballPath]);
+    expect(existsSync(join(String(dir), "node_modules", name))).toBeFalse();
+    expect(await lockedEntry(String(dir))).toEqual([lockedPackage, {}, resolved, wrongIntegrity]);
   });
 
-  test("should update lockfile with integrity when old format has none", async () => {
-    using dir = tempDir("github-integrity-upgrade", {
-      "package.json": JSON.stringify({
-        name: "test-github-integrity-upgrade",
-        dependencies: {
-          "is-number": "jonschlinkert/is-number#98e8ff1",
-        },
-      }),
-      // Pre-create a lockfile in the old format (no integrity hash)
-      "bun.lock": JSON.stringify({
-        lockfileVersion: 1,
-        configVersion: 1,
-        workspaces: {
-          "": {
-            name: "test-github-integrity-upgrade",
-            dependencies: {
-              "is-number": "jonschlinkert/is-number#98e8ff1",
-            },
-          },
-        },
-        packages: {
-          "is-number": ["is-number@github:jonschlinkert/is-number#98e8ff1", {}, "jonschlinkert-is-number-98e8ff1"],
-        },
-      }),
-    });
+  test.concurrent("adds the integrity to a lockfile written before it was recorded", async () => {
+    using dir = project({ "bun.lock": lockfileWith([lockedPackage, {}, resolved]) });
+    await using github = serveTarball(String(dir));
 
-    // Fresh per-test cache ensures the tarball must be downloaded
-    const env = envWithCache(dir);
-
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "install"],
-      cwd: String(dir),
-      env,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-    // Should succeed without errors
-    expect(stderr).not.toContain("Integrity check failed");
+    const { stderr, exitCode } = await github.install();
+    expect(stderr).toContain(extracted);
     expect(stderr).not.toContain("error:");
-    // The lockfile should be re-saved with the new integrity hash
     expect(stderr).toContain("Saved lockfile");
     expect(exitCode).toBe(0);
 
-    // Verify the lockfile now contains the integrity hash
-    const lockfileContent = await file(join(String(dir), "bun.lock")).text();
-    expect(lockfileContent).toContain("sha512-");
-    expect(lockfileContent).toMatch(/"jonschlinkert-is-number-98e8ff1",\s*"sha512-/);
+    expect(github.requests).toEqual([tarballPath]);
+    expect(await lockedEntry(String(dir))).toEqual([lockedPackage, {}, resolved, integrity]);
+    expect(existsSync(join(String(dir), "node_modules", name, "index.js"))).toBeTrue();
   });
 
-  test("should accept GitHub dependency from cache without re-downloading", async () => {
-    // Use a shared cache dir for both installs so the second is a true cache hit
-    using dir = tempDir("github-integrity-cached", {
-      "package.json": JSON.stringify({
-        name: "test-github-integrity-cached",
-        dependencies: {
-          "is-number": "jonschlinkert/is-number#98e8ff1",
-        },
-      }),
-    });
+  test.concurrent("installs from the cache without downloading when the lockfile has no integrity", async () => {
+    using dir = project();
+    await using github = serveTarball(String(dir));
 
-    const env = envWithCache(dir);
+    const first = await github.install();
+    expect(first.stderr).toContain(extracted);
+    expect(first.stderr).not.toContain("error:");
+    expect(first.exitCode).toBe(0);
 
-    // First install warms the per-test cache
-    await using proc1 = Bun.spawn({
-      cmd: [bunExe(), "install"],
-      cwd: String(dir),
-      env,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-
-    const [stdout1, stderr1, exitCode1] = await Promise.all([proc1.stdout.text(), proc1.stderr.text(), proc1.exited]);
-    expect(stderr1).not.toContain("error:");
-    expect(exitCode1).toBe(0);
-
-    // Remove node_modules but keep the cache
     await rm(join(String(dir), "node_modules"), { recursive: true, force: true });
+    const lockfile = join(String(dir), "bun.lock");
+    await Bun.write(lockfile, (await Bun.file(lockfile).text()).replace(`, "${integrity}"`, ""));
+    expect(await lockedEntry(String(dir))).toEqual([lockedPackage, {}, resolved]);
 
-    // Strip the integrity from the lockfile to simulate an old-format lockfile
-    // that should still work when the cache already has the package
-    const lockfileContent = await file(join(String(dir), "bun.lock")).text();
-    const stripped = lockfileContent.replace(/,\s*"sha512-[^"]*"/, "");
-    await Bun.write(join(String(dir), "bun.lock"), stripped);
+    const second = await github.install();
+    expect(second.stderr).not.toContain(extracted);
+    expect(second.stderr).not.toContain("error:");
+    expect(second.exitCode).toBe(0);
 
-    // Second install should hit the cache and succeed without re-downloading
-    await using proc2 = Bun.spawn({
-      cmd: [bunExe(), "install"],
-      cwd: String(dir),
-      env,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-
-    const [stdout2, stderr2, exitCode2] = await Promise.all([proc2.stdout.text(), proc2.stderr.text(), proc2.exited]);
-
-    // Should succeed without integrity errors (package served from cache)
-    expect(stderr2).not.toContain("Integrity check failed");
-    expect(stderr2).not.toContain("error:");
-    expect(exitCode2).toBe(0);
+    expect(github.requests).toEqual([tarballPath]);
+    expect(existsSync(join(String(dir), "node_modules", name, "index.js"))).toBeTrue();
   });
 });

--- a/test/cli/install/GHSA-pfwx-36v6-832x.test.ts
+++ b/test/cli/install/GHSA-pfwx-36v6-832x.test.ts
@@ -36,7 +36,7 @@ function incompressible(bytes: number): Uint8Array {
   return new Uint8Array(words.buffer);
 }
 
-const tarball = githubTarball(resolved, {
+const tarball = await githubTarball(resolved, {
   "package.json": JSON.stringify({ name, version: "1.0.0" }),
   "index.js": "module.exports = 1;\n",
   // The HTTP client reads at most 512 KiB (LIBUS_RECV_BUFFER_LENGTH) per socket read, so a

--- a/test/cli/install/GHSA-pfwx-36v6-832x.test.ts
+++ b/test/cli/install/GHSA-pfwx-36v6-832x.test.ts
@@ -104,7 +104,7 @@ describe.each(variants)("GitHub tarball integrity ($variant extraction)", ({ var
             GITHUB_API_URL: server.url.origin,
             BUN_INSTALL_CACHE_DIR: join(dir, ".bun-cache"),
           },
-          stdout: "pipe",
+          stdout: "ignore",
           stderr: "pipe",
         });
         const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -6,6 +6,7 @@ import {
   assertManifestsPopulated,
   bunEnv as baseEnv,
   bunExe,
+  githubTarball,
   isLinux,
   isWindows,
   readdirSorted,
@@ -15,14 +16,51 @@ import { join, sep } from "path";
 
 var verdaccio = new VerdaccioRegistry();
 
+// `owner/repo#commit` dependencies are downloaded from `${GITHUB_API_URL}/repos/...`, so
+// the repository below is served by this local server instead of api.github.com.
+const githubOwner = "lifecycle-owner";
+const githubRepo = "lifecycle-install-test";
+const githubCommit = "1234567890abcdef1234567890abcdef12345678";
+const githubDependency = `${githubOwner}/${githubRepo}#${githubCommit}`;
+const githubTarballPath = `/repos/${githubOwner}/${githubRepo}/tarball/${githubCommit}`;
+const githubLifecycleScripts = ["preinstall", "install", "postinstall", "preprepare", "prepare", "postprepare"];
+const githubRepositoryTarball = githubTarball(`${githubOwner}-${githubRepo}-${githubCommit.slice(0, 7)}`, {
+  "package.json": JSON.stringify({
+    name: githubRepo,
+    version: "1.0.0",
+    scripts: Object.fromEntries(githubLifecycleScripts.map(script => [script, `bun ${script}.js`])),
+  }),
+  ...Object.fromEntries(
+    githubLifecycleScripts.map(script => [
+      `${script}.js`,
+      `
+      import { writeFileSync } from "fs";
+      import { join } from "path";
+
+      writeFileSync(join(import.meta.dir, "${script}.txt"), "${script}!");
+      `,
+    ]),
+  ),
+});
+let github: ReturnType<typeof Bun.serve>;
+
 setDefaultTimeout(1000 * 60 * 5);
 
 beforeAll(async () => {
+  github = Bun.serve({
+    port: 0,
+    fetch(request) {
+      return new URL(request.url).pathname === githubTarballPath
+        ? new Response(githubRepositoryTarball)
+        : new Response("Not Found", { status: 404 });
+    },
+  });
   await verdaccio.start();
 });
 
-afterAll(() => {
+afterAll(async () => {
   verdaccio.stop();
+  await github.stop();
 });
 
 function splitErrLines(err: string): string[] {
@@ -1956,7 +1994,11 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
     test("git dependencies also run `preprepare`, `prepare`, and `postprepare` scripts", async () => {
       using ctx = await setupTest();
       const { packageDir, packageJson, env } = ctx;
-      const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
+      const testEnv = {
+        ...env,
+        GITHUB_API_URL: github.url.origin,
+        ...(forceWaiterThread ? { BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : {}),
+      };
 
       await writeFile(
         packageJson,
@@ -1964,7 +2006,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
           name: "foo",
           version: "1.0.0",
           dependencies: {
-            "lifecycle-install-test": "dylan-conway/lifecycle-install-test#3ba6af5b64f2d27456e08df21d750072dffd3eee",
+            "lifecycle-install-test": githubDependency,
           },
         }),
       );
@@ -1986,7 +2028,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       expect(out.replace(/\s*\[[0-9\.]+m?s\]$/m, "").split(/\r?\n/)).toEqual([
         expect.stringContaining("bun install v1."),
         "",
-        "+ lifecycle-install-test@github:dylan-conway/lifecycle-install-test#3ba6af5",
+        `+ lifecycle-install-test@github:${githubOwner}/${githubRepo}#${githubCommit.slice(0, 7)}`,
         "",
         "1 package installed",
         "",
@@ -2009,7 +2051,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
           name: "foo",
           version: "1.0.0",
           dependencies: {
-            "lifecycle-install-test": "dylan-conway/lifecycle-install-test#3ba6af5b64f2d27456e08df21d750072dffd3eee",
+            "lifecycle-install-test": githubDependency,
           },
           trustedDependencies: ["lifecycle-install-test"],
         }),

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -24,7 +24,7 @@ const githubCommit = "1234567890abcdef1234567890abcdef12345678";
 const githubDependency = `${githubOwner}/${githubRepo}#${githubCommit}`;
 const githubTarballPath = `/repos/${githubOwner}/${githubRepo}/tarball/${githubCommit}`;
 const githubLifecycleScripts = ["preinstall", "install", "postinstall", "preprepare", "prepare", "postprepare"];
-const githubRepositoryTarball = githubTarball(`${githubOwner}-${githubRepo}-${githubCommit.slice(0, 7)}`, {
+const githubRepositoryTarball = await githubTarball(`${githubOwner}-${githubRepo}-${githubCommit.slice(0, 7)}`, {
   "package.json": JSON.stringify({
     name: githubRepo,
     version: "1.0.0",

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -2,7 +2,7 @@ import { file, spawn, write } from "bun";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { existsSync, lstatSync, readlinkSync, statSync } from "fs";
 import { mkdir, readlink, rm, symlink } from "fs/promises";
-import { VerdaccioRegistry, bunEnv, bunExe, readdirSorted, runBunInstall, tempDir } from "harness";
+import { VerdaccioRegistry, bunEnv, bunExe, githubTarball, readdirSorted, runBunInstall, tempDir } from "harness";
 import { createRequire } from "module";
 import { dirname, join } from "path";
 
@@ -776,39 +776,10 @@ index 0000000000000000000000000000000000000000..3b18e512dba79e4c8300dd08aeb37f8e
 test("adding and removing a patch for a github dependency in a workspace completes", async () => {
   const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
 
-  // Minimal gzipped tarball shaped like a github codeload tarball: a single
-  // root directory wrapping the package contents.
-  function tarHeader(name: string, size: number, isDir: boolean): Uint8Array {
-    const header = new Uint8Array(512);
-    const encoder = new TextEncoder();
-    header.set(encoder.encode(name), 0);
-    header.set(encoder.encode(isDir ? "0000755 " : "0000644 "), 100);
-    header.set(encoder.encode("0000000 "), 108);
-    header.set(encoder.encode("0000000 "), 116);
-    header.set(encoder.encode(size.toString(8).padStart(11, "0") + " "), 124);
-    header.set(encoder.encode("00000000000 "), 136);
-    header.set(encoder.encode("        "), 148);
-    header[156] = (isDir ? "5" : "0").charCodeAt(0);
-    header.set(encoder.encode("ustar"), 257);
-    header.set(encoder.encode("00"), 263);
-    let checksum = 0;
-    for (const byte of header) checksum += byte;
-    header.set(encoder.encode(checksum.toString(8).padStart(6, "0") + "\0 "), 148);
-    return header;
-  }
-  const blocks: Uint8Array[] = [];
-  blocks.push(tarHeader("testowner-testrepo-aaaaaaa/", 0, true));
-  for (const [name, contents] of [
-    ["package.json", JSON.stringify({ name: "gh-dep", version: "1.0.0" })],
-    ["index.js", 'console.log("original");\n'],
-  ]) {
-    const bytes = new TextEncoder().encode(contents);
-    blocks.push(tarHeader(`testowner-testrepo-aaaaaaa/${name}`, bytes.length, false));
-    blocks.push(bytes);
-    if (bytes.length % 512 !== 0) blocks.push(new Uint8Array(512 - (bytes.length % 512)));
-  }
-  blocks.push(new Uint8Array(1024));
-  const tarball = Bun.gzipSync(Buffer.concat(blocks));
+  const tarball = await githubTarball("testowner-testrepo-aaaaaaa", {
+    "package.json": JSON.stringify({ name: "gh-dep", version: "1.0.0" }),
+    "index.js": 'console.log("original");\n',
+  });
 
   using server = Bun.serve({
     port: 0,

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1880,6 +1880,46 @@ export function textLockfile(version: number, pkgs: any): string {
   });
 }
 
+/**
+ * Builds the gzipped tarball GitHub serves for `/repos/<owner>/<repo>/tarball/<ref>`: one
+ * root directory, which GitHub names `<owner>-<repo>-<short sha>`, with the repository's
+ * files inside it. `bun install` reads the dependency's resolved commit (the lockfile's
+ * third tuple element and the installed `.bun-tag`) from the archive's first entry, so the
+ * root directory entry has to come first; `Bun.Archive` only writes file entries and cannot
+ * produce this layout.
+ *
+ * Serve the bytes from a local server and pass its URL as `GITHUB_API_URL` to install
+ * `owner/repo#ref` dependencies without contacting api.github.com.
+ */
+export function githubTarball(rootDir: string, files: Record<string, string | Uint8Array>): Uint8Array {
+  function header(name: string, size: number, type: "0" | "5"): Buffer {
+    if (Buffer.byteLength(name) > 100) throw new Error(`tar entry name longer than the 100 byte ustar limit: ${name}`);
+    const block = Buffer.alloc(512);
+    block.write(name, 0);
+    block.write(type === "5" ? "0000755\0" : "0000644\0", 100);
+    block.write("0000000\0", 108); // uid
+    block.write("0000000\0", 116); // gid
+    block.write(size.toString(8).padStart(11, "0") + "\0", 124);
+    block.write("00000000000\0", 136); // mtime
+    block.fill(" ", 148, 156); // the checksum is computed with its own field blanked out
+    block.write(type, 156);
+    block.write("ustar\0", 257);
+    block.write("00", 263);
+    let checksum = 0;
+    for (const byte of block) checksum += byte;
+    block.write(checksum.toString(8).padStart(6, "0") + "\0 ", 148);
+    return block;
+  }
+
+  const blocks = [header(`${rootDir}/`, 0, "5")];
+  for (const [path, contents] of Object.entries(files)) {
+    const body = Buffer.from(contents);
+    blocks.push(header(`${rootDir}/${path}`, body.length, "0"), body, Buffer.alloc((512 - (body.length % 512)) % 512));
+  }
+  blocks.push(Buffer.alloc(1024)); // end-of-archive marker
+  return Bun.gzipSync(Buffer.concat(blocks));
+}
+
 export class VerdaccioRegistry {
   port: number;
   process: ChildProcess | undefined;

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1884,40 +1884,16 @@ export function textLockfile(version: number, pkgs: any): string {
  * Builds the gzipped tarball GitHub serves for `/repos/<owner>/<repo>/tarball/<ref>`: one
  * root directory, which GitHub names `<owner>-<repo>-<short sha>`, with the repository's
  * files inside it. `bun install` reads the dependency's resolved commit (the lockfile's
- * third tuple element and the installed `.bun-tag`) from the archive's first entry, so the
- * root directory entry has to come first; `Bun.Archive` only writes file entries and cannot
- * produce this layout.
+ * third tuple element and the installed `.bun-tag`) from the archive's first entry, which
+ * is why the root directory gets an entry of its own ahead of the files.
  *
  * Serve the bytes from a local server and pass its URL as `GITHUB_API_URL` to install
  * `owner/repo#ref` dependencies without contacting api.github.com.
  */
-export function githubTarball(rootDir: string, files: Record<string, string | Uint8Array>): Uint8Array {
-  function header(name: string, size: number, type: "0" | "5"): Buffer {
-    if (Buffer.byteLength(name) > 100) throw new Error(`tar entry name longer than the 100 byte ustar limit: ${name}`);
-    const block = Buffer.alloc(512);
-    block.write(name, 0);
-    block.write(type === "5" ? "0000755\0" : "0000644\0", 100);
-    block.write("0000000\0", 108); // uid
-    block.write("0000000\0", 116); // gid
-    block.write(size.toString(8).padStart(11, "0") + "\0", 124);
-    block.write("00000000000\0", 136); // mtime
-    block.fill(" ", 148, 156); // the checksum is computed with its own field blanked out
-    block.write(type, 156);
-    block.write("ustar\0", 257);
-    block.write("00", 263);
-    let checksum = 0;
-    for (const byte of block) checksum += byte;
-    block.write(checksum.toString(8).padStart(6, "0") + "\0 ", 148);
-    return block;
-  }
-
-  const blocks = [header(`${rootDir}/`, 0, "5")];
-  for (const [path, contents] of Object.entries(files)) {
-    const body = Buffer.from(contents);
-    blocks.push(header(`${rootDir}/${path}`, body.length, "0"), body, Buffer.alloc((512 - (body.length % 512)) % 512));
-  }
-  blocks.push(Buffer.alloc(1024)); // end-of-archive marker
-  return Bun.gzipSync(Buffer.concat(blocks));
+export function githubTarball(rootDir: string, files: Record<string, string | Uint8Array>) {
+  const entries: Record<string, string | Uint8Array> = { [`${rootDir}/`]: "" };
+  for (const [path, contents] of Object.entries(files)) entries[`${rootDir}/${path}`] = contents;
+  return new Bun.Archive(entries, { compress: "gzip" }).bytes();
 }
 
 export class VerdaccioRegistry {


### PR DESCRIPTION
### Problem
- `test/cli/install/GHSA-pfwx-36v6-832x.test.ts` failed 5/5 on build 98240 with `error: GET https://api.github.com/repos/jonschlinkert/is-number/tarball/98e8ff1 - 504`; the same build failed both `git dependencies also run preprepare, prepare, and postprepare scripts` cases in `bun-install-lifecycle-scripts.test.ts` with the same 504 for `dylan-conway/lifecycle-install-test`.
- Both tests install a real repository from api.github.com, so a GitHub outage fails them on every open PR. The GHSA file has done so since #27019 added it; the lifecycle cases predate it.
- What the tests check (the integrity bookkeeping in `src/install/extract_tarball.rs:47-79` and `src/install/TarballStream.rs:1111-1182`, and the prepare scripts of a GitHub dependency) needs a tarball with GitHub's layout, not GitHub itself.

### Fix
- `test/harness.ts`: `githubTarball(rootDir, files)` builds the tarball GitHub returns for `/repos/<owner>/<repo>/tarball/<ref>` with `Bun.Archive`: a `<rootDir>/` entry first, then the files under it. bun takes the resolved commit from the archive's first entry (`src/libarchive/lib.rs:1488-1508`), which is why the root directory needs its own entry; the trailing-slash key is what produces it. `isolated-install.test.ts` carried an inline tar writer for exactly this layout and now uses the helper (net -29 lines there).
- Both failing test files serve such a tarball from a local `Bun.serve` and pass its origin as `GITHUB_API_URL`, which `alloc_github_url` (`src/install/PackageManager/runTasks.rs:1700`) uses in place of `https://api.github.com`. This is the mechanism `isolated-install.test.ts`, `bun-patch.test.ts` and `symlink-path-traversal.test.ts` already use; the dependency specs are fake names, so a test that stopped going through the local server would fail instead of silently reaching GitHub.
- The GHSA tests keep every previous assertion and add what a locally served tarball makes possible: the lockfile entry is compared as a whole against the sha512 of the bytes served, a rejected tarball must not end up in `node_modules` and must not replace the locked hash, and the tarball request count proves the cache-hit case downloads nothing.
- Each GHSA case runs twice, against the buffered extractor and against the streaming one, because the two hash and verify independently and the old test (7.6 KB real tarball, below the 2 MiB streaming threshold) only ever exercised the buffered one. The fixture carries 600 KiB of incompressible filler so it exceeds the HTTP client's 512 KiB read buffer and always arrives in more than one chunk; with `BUN_INSTALL_STREAMING_MIN_SIZE=1` that makes the streaming commit deterministic, and without it the default threshold keeps the buffered path. The `--verbose` lines `[gh-dep] Extract ` / `[gh-dep] Streamed ` assert which extractor ran.
- The lifecycle fixture reproduces the real repository: a `package.json` whose six scripts run `bun <script>.js`, each writing `<script>.txt`, so the `Blocked 6 postinstalls` line, the `#1234567` short-commit output and the six file checks are unchanged apart from the names.
- Verified with `bun bd test` and with outbound network removed (`HTTP_PROXY`/`HTTPS_PROXY` unset in this container, which leaves only loopback): old GHSA file 0/5 pass, new file 10/10; old lifecycle cases 0/2, new cases 2/2; `isolated-install.test.ts` 66/66; the rest of the lifecycle file is unchanged (the three tests that fail here also fail on main in this container, they need `node`/`bun` on `PATH`).

### Background
- `owner/repo#ref` dependencies are downloaded as a tarball from the GitHub API rather than cloned. GitHub's tarballs unpack into a single `<owner>-<repo>-<short sha>` directory; bun records that directory name in the lockfile as the resolved commit (`["dep@github:owner/repo#ref", {}, "owner-repo-sha", "sha512-..."]`) and, since #27019, the sha512 of the tarball bytes after it, so a later install that has to refetch the tarball is checked against it.
- `bun install` has two tarball extractors: bodies below `BUN_INSTALL_STREAMING_MIN_SIZE` are buffered and extracted in one go (`extract_tarball.rs`); larger bodies are fed into libarchive as chunks arrive (`TarballStream.rs`). The decision is made on the first body chunk (`src/install/NetworkTask.rs:223-240`) and needs a 2xx status, a body at least the threshold size, and more data still to come, which is why the fixture has to be larger than one socket read.

### Still reaching GitHub after this PR
- Through the same tarball endpoint, so convertible with this helper: the `should handle GitHub URL ...` cases in `bun-install.test.ts`, the `git dependencies` case in `bun-install-registry.test.ts`, `bun-add.test.ts` (#35149 is open for it with its own builder in `dummy.registry.ts`) and `bunx.test.ts` (#38467, likewise). Those PRs can import this export instead once it lands; the remaining files are left for follow-ups so this one stays a fix for the two files that went red.
- Through `git clone` (`git+https://github.com/...`, SCP-style URLs, `bun create`), which needs a local repository rather than a tarball; #35035 covers the `bun-add.test.ts` instance.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->