### PR TITLE
yaml: map StringifyError to JsError in one place

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -75,7 +75,6 @@
 "reimplemented_helper:src/runtime/api/bun/Terminal.rs" = 1
 "reimplemented_helper:src/runtime/ffi/abi_type.rs" = 1
 "reimplemented_helper:src/runtime/hw_exports.rs" = 1
-"same_match_twice:src/runtime/api/YAMLObject.rs" = 1
 "same_match_twice:src/runtime/api/bun/h2_frame_parser.rs" = 1
 "same_match_twice:src/runtime/api/csrf_jsc.rs" = 1
 "same_match_twice:src/runtime/bake/dev_server/mod.rs" = 1

--- a/src/runtime/api/YAMLObject.rs
+++ b/src/runtime/api/YAMLObject.rs
@@ -39,21 +39,13 @@ fn stringify(global: &JSGlobalObject, call_frame: &CallFrame) -> JsResult<JSValu
 
     let mut stringifier = Stringifier::init(global, space_value)?;
 
-    if let Err(err) = stringifier.find_anchors_and_aliases(global, value, ValueOrigin::Root) {
-        return match err {
-            StringifyError::OutOfMemory => Err(JsError::OutOfMemory),
-            StringifyError::JsError => Err(JsError::Thrown),
-            StringifyError::StackOverflow => Err(global.throw_stack_overflow()),
-        };
-    }
+    stringifier
+        .find_anchors_and_aliases(global, value, ValueOrigin::Root)
+        .map_err(|err| err.to_js_error(global))?;
 
-    if let Err(err) = stringifier.stringify(global, value) {
-        return match err {
-            StringifyError::OutOfMemory => Err(JsError::OutOfMemory),
-            StringifyError::JsError => Err(JsError::Thrown),
-            StringifyError::StackOverflow => Err(global.throw_stack_overflow()),
-        };
-    }
+    stringifier
+        .stringify(global, value)
+        .map_err(|err| err.to_js_error(global))?;
 
     stringifier.builder.to_string(global)
 }
@@ -172,6 +164,20 @@ impl From<JsError> for StringifyError {
         match e {
             JsError::OutOfMemory => StringifyError::OutOfMemory,
             JsError::Thrown => StringifyError::JsError,
+        }
+    }
+}
+
+impl StringifyError {
+    /// `OutOfMemory` and `JsError` are already JS-shaped (the host-fn wrapper
+    /// throws the former, the latter's exception is pending); only
+    /// `StackOverflow` still has to be thrown here.
+    #[cold]
+    fn to_js_error(self, global: &JSGlobalObject) -> JsError {
+        match self {
+            StringifyError::OutOfMemory => JsError::OutOfMemory,
+            StringifyError::JsError => JsError::Thrown,
+            StringifyError::StackOverflow => global.throw_stack_overflow(),
         }
     }
 }


### PR DESCRIPTION
### Problem
- `YAML.stringify` (src/runtime/api/YAMLObject.rs:42-56) matched on `StringifyError` twice, once after `find_anchors_and_aliases` and once after `stringify`, with identical arms. A change to one copy would miss the other.
- This is the `same_match_twice:src/runtime/api/YAMLObject.rs` entry in `mordant-baseline.toml`.

### Fix
- Add `StringifyError::to_js_error(self, global) -> JsError` holding the one mapping; both call sites become `.map_err(|err| err.to_js_error(global))?`.
- No behavior change: the arms are the same as before (`OutOfMemory` and `JsError` are passed through for the host-fn wrapper, `StackOverflow` throws the range error), only the location moved.
- Remove the now-fixed entry from `mordant-baseline.toml`.
- Verified: `bun bd test test/js/bun/yaml/yaml.test.ts test/regression/issue/23489.test.ts` (644 pass, 18 pre-existing todo, 0 fail). The existing tests cover the thrown-exception and stack-overflow paths (`throws on BigInt`, `handles Proxy that throws`, `handles stack overflow protection`).

### Background
- `StringifyError` is the error type the YAML stringifier's recursive walk returns internally; `JsError` is the runtime-wide two-state error (`Thrown`: an exception is already pending on the VM; `OutOfMemory`: the `host_fn` wrapper throws the OOM error). Only `StackOverflow` needs an actual throw when crossing back into a `JsResult`.
- mordant is the advisory Rust lint pack run by `bun run rust:mordant`; `mordant-baseline.toml` holds per-(lint, file) counts of pre-existing findings, and a fixed finding's entry is deleted so the ratchet tightens.
