### PR TITLE
linker: name the relative import path locals after the Path fields they fill

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -3,7 +3,6 @@
 "bare_bool_args:src/ast/lib.rs" = 1
 
 [bun_bundler]
-"arg_named_like_other_param:src/bundler/linker.rs" = 1
 "bare_bool_args:src/bundler/Chunk.rs" = 1
 "defaulted_failure:src/bundler/bundle_v2.rs" = 2
 "narrowed_two_ways:src/bundler/bundle_v2.rs" = 1

--- a/src/bundler/linker.rs
+++ b/src/bundler/linker.rs
@@ -632,32 +632,32 @@ impl Linker {
             ImportPathFormat::Relative => {
                 let relative_name = bun_paths::resolve_path::relative(source_dir, source_path);
 
+                let text: &'static [u8];
                 let pretty: &'static [u8];
-                let relative_name_out: &'static [u8];
                 if use_hashed_name {
                     let basepath = PFs::Path::init(source_path);
                     let basename = self.get_hashed_filename(&basepath, None)?;
                     let name = basepath.name();
                     let dir = name.dir_with_trailing_slash();
-                    let mut _pretty: Vec<u8> =
+                    let mut hashed: Vec<u8> =
                         Vec::with_capacity(dir.len() + basename.len() + name.ext.len());
-                    _pretty.extend_from_slice(dir);
-                    _pretty.extend_from_slice(basename);
-                    _pretty.extend_from_slice(name.ext);
-                    pretty = intern(_pretty);
-                    relative_name_out = dupe(relative_name);
+                    hashed.extend_from_slice(dir);
+                    hashed.extend_from_slice(basename);
+                    hashed.extend_from_slice(name.ext);
+                    text = intern(hashed);
+                    pretty = dupe(relative_name);
                 } else {
                     if relative_name.len() > 1
                         && !(relative_name[0] == SEP || relative_name[0] == b'.')
                     {
-                        pretty = dupe(&strings::concat(&[b"./", relative_name]));
+                        text = dupe(&strings::concat(&[b"./", relative_name]));
                     } else {
-                        pretty = dupe(relative_name);
+                        text = dupe(relative_name);
                     }
-                    relative_name_out = pretty;
+                    pretty = text;
                 }
 
-                Ok(PFs::Path::init_with_pretty(pretty, relative_name_out))
+                Ok(PFs::Path::init_with_pretty(text, pretty))
             }
 
             ImportPathFormat::AbsoluteUrl => {


### PR DESCRIPTION
### Problem
- mordant's `arg_named_like_other_param` reports `src/bundler/linker.rs:660`: a local named `pretty` is passed as `init_with_pretty`'s `text` parameter, and `init_with_pretty` also has a `pretty` parameter of the same type, so the call reads like a transposed one. This is the `arg_named_like_other_param:src/bundler/linker.rs` entry in `mordant-baseline.toml`.
- The call is not transposed. `Path::init_with_pretty(text, pretty)` (`src/paths/lib.rs:870`) takes the canonical path first and the display path second, and the `Relative` branch of `generate_import_path` passes the emitted import specifier (`./x.js`) first and the display path second, the same way the `AbsolutePath` branch a few lines up does. The printer emits `import_record.path.text` (`src/js_printer/lib.rs:6155`), so the specifier belongs in `text`. Only the local names were wrong: the value going into `text` was called `pretty`, and the value going into `pretty` was called `relative_name_out`.

### Fix
- Rename the locals after the `Path` fields they fill: `pretty` becomes `text`, `relative_name_out` becomes `pretty`, and the hashed-name buffer `_pretty` becomes `hashed`. Every assignment and the final call keep the same values in the same positions, so there is no behavior change (in the only reachable case, both `link` call sites pass `use_hashed_name = false`, the two values are the same slice anyway).
- Remove the file's `arg_named_like_other_param` entry from `mordant-baseline.toml`.
- No test: a rename has nothing observable to assert, and this branch is not reachable from the CLI or the runtime anyway. `link()` has three callers: `src/runtime/jsc_hooks.rs:3131` and `src/jsc/AsyncModule.rs:1218` both pass `ImportPathFormat::AbsolutePath`, and `src/bundler/transpiler.rs:2909` is guarded by `!self.options.transform_only`, which `Transpiler::transform` (its only entry point, via `bun build --no-bundle`) sets to `true` at `transpiler.rs:2707` before getting there. So the `Relative` branch runs in no test and no user scenario, with or without this change.
- Verified:
  - `cargo check -p bun_bundler` passes.
  - `cargo dylint --all -p bun_bundler` (what `bun run rust:mordant` runs) against the trimmed baseline reports nothing and leaves no `target/mordant/over-baseline.txt`; with `linker.rs` reverted and the same trimmed baseline it reports the line 660 finding as over the baseline, so the rename is what clears it.
  - `bun run rust:mordant:baseline` over the whole workspace also drops this entry. It additionally drops `always_unwrapped_option:src/install/PackageInstall.rs` and `narrowed_two_ways:src/runtime/node/node_crypto_binding.rs`, which were fixed on main by other changes since the baseline was recorded; those are left out of this PR so it stays scoped to the one finding.

### Background
- `bun_paths::fs::Path` carries two strings for one file: `text`, the canonical path the rest of the pipeline (including the printer, when it writes an import specifier back out) uses, and `pretty`, a relative form used for display. `init_with_pretty` is the constructor that sets the two independently.
- `Linker::generate_import_path` rewrites an import record's path for the transpile-only output modes; its `ImportPathFormat::Relative` branch builds the `./`-prefixed relative specifier that would be printed.
- mordant is the advisory Rust lint pack run by `bun run rust:mordant`. `mordant-baseline.toml` is a ratchet of per-(lint, file) counts of pre-existing findings; a fixed finding's entry is deleted so the count cannot grow back.
