### PR TITLE
docs: TOML date/time values in bundles compile to Temporal calls

### DIFF
--- a/docs/bundler/loaders.mdx
+++ b/docs/bundler/loaders.mdx
@@ -148,6 +148,11 @@ var config = {
 config.logLevel;
 ```
 
+<Note>
+  Bun compiles TOML date/time values to `Temporal.*.from()` calls, for every `target`. The runtime that loads the bundle
+  needs a `Temporal` global. See [Date and time values in bundles](/runtime/toml#date-and-time-values-in-bundles).
+</Note>
+
 If you pass a `.toml` file as an entrypoint, Bun converts it to a `.js` module that `export default`s the parsed object.
 
 <CodeGroup>

--- a/docs/runtime/toml.mdx
+++ b/docs/runtime/toml.mdx
@@ -287,6 +287,28 @@ This means:
 - Smaller bundle sizes
 - Tree shaking of unused properties (named imports)
 
+### Date and time values in bundles
+
+Bun compiles each TOML date/time value to a call on the `Temporal` global. The call runs when the bundle loads, for every `target`:
+
+```toml config.toml
+name = "my-app"
+released = 2026-08-15
+```
+
+```js Output
+var config_default = {
+  name: "my-app",
+  released: /* @__PURE__ */ Temporal.PlainDate.from("2026-08-15"),
+};
+```
+
+A runtime without `Temporal` throws `ReferenceError: Temporal is not defined` when it loads the bundle. Bun has `Temporal`. Node.js 24 and earlier do not. To run the bundle on a runtime without `Temporal`, do one of the following:
+
+- Import only the keys you use (`import { name } from "./config.toml"`). Bun tree-shakes the unused keys, including the date/time values.
+- Quote the value in the TOML file (`released = "2026-08-15"`) so Bun emits a string.
+- Import a module that defines `globalThis.Temporal`, such as a Temporal polyfill, before the TOML file. Bun keeps the import order, so the polyfill runs before the date/time calls.
+
 ### Dynamic Imports
 
 You can also dynamically import TOML files:


### PR DESCRIPTION
### Problem
- Since #37018, the TOML loader compiles date/time values to `Temporal.<Class>.from("...")` calls in `bun build` output. The emit does not depend on `target` (`lower_toml_datetimes` is set from the loader alone in `src/js_parser/parse/parse_entry.rs`).
- A bundle built with `--target=node` or `--target=browser` from a TOML file containing a date therefore throws `ReferenceError: Temporal is not defined` at load on a runtime without `Temporal` (Node.js 24 and earlier, for example).
- Neither `docs/runtime/toml.mdx` (Bundler Integration) nor the `toml` entry in `docs/bundler/loaders.mdx` mentioned this; the runtime docs only describe the `Bun.TOML.parse` / import mapping.

### Fix
- `docs/runtime/toml.mdx`: new "Date and time values in bundles" section under Bundler Integration showing the emitted code and the three ways to run such a bundle on a runtime without `Temporal` (named imports so the date keys tree-shake, quoting the value, or importing a module that installs a global `Temporal` ahead of the TOML file).
- `docs/bundler/loaders.mdx`: one note in the `toml` loader entry linking to that section.
- Docs only; no code change. The heading uses plain words so the anchor in the cross-link is unambiguous.
- Every claim was checked against a debug build of main (`88a6398836`):
  - `bun build app.ts --target=browser` and `--target=node` both emit `released: /* @__PURE__ */ Temporal.PlainDate.from("2026-08-15")` for `released = 2026-08-15`.
  - `node out.js` (Node 26, Temporal enabled) prints the date; `node --no-harmony-temporal out.js` throws `ReferenceError: Temporal is not defined`.
  - `import { name } from "./config.toml"` bundles to `var name = "my-app";` with no `Temporal` reference.
  - A module assigning `globalThis.Temporal`, imported before the TOML file, precedes the TOML module in the bundle and the bundle runs under `node --no-harmony-temporal`.
  - `prettier --check` passes on both files.

### Background
- Bun's TOML loader turns a `.toml` file into a JS module whose exports are the parsed document. At runtime (`import` / `Bun.TOML.parse`) date/time values are built as Temporal objects directly. In the bundler the same values have to be expressed as JavaScript source, so the parser rewrites each tagged date/time string into a call on the `Temporal` global; that call runs when the bundle's module-scope code evaluates, which is why the consuming runtime needs `Temporal`.
- Bun enables `Temporal` by default as of 1.4, so this only matters for bundles run elsewhere. The parser rewrite itself (#32953) and the integer range rule are already documented on the same page and in the 1.4 upgrade guide (#36463); this PR only fills the bundler gap.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->