### PR TITLE
css: pass SelectorFlags to SelectorBuilder::build instead of three bools

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -13,7 +13,6 @@
 
 [bun_css]
 "arg_named_like_other_param:src/css/rules/mod.rs" = 1
-"bare_bool_args:src/css/selectors/builder.rs" = 1
 "tuple_wants_struct:src/css/css_parser.rs" = 1
 "tuple_wants_struct:src/css/values/color.rs" = 5
 

--- a/src/css/selectors/builder.rs
+++ b/src/css/selectors/builder.rs
@@ -110,23 +110,8 @@ impl<Impl: ValidSelectorImpl> SelectorBuilder<Impl> {
     /// Consumes the builder, producing a Selector.
     ///
     /// *NOTE*: This will free all allocated memory in the builder
-    pub(crate) fn build(
-        &mut self,
-        parsed_pseudo: bool,
-        parsed_slotted: bool,
-        parsed_part: bool,
-    ) -> BuildResult<Impl> {
+    pub(crate) fn build(&mut self, flags: SelectorFlags) -> BuildResult<Impl> {
         let specificity = compute_specificity::<Impl>(self.simple_selectors.slice());
-        let mut flags = SelectorFlags::empty();
-        if parsed_pseudo {
-            flags |= SelectorFlags::HAS_PSEUDO;
-        }
-        if parsed_slotted {
-            flags |= SelectorFlags::HAS_SLOTTED;
-        }
-        if parsed_part {
-            flags |= SelectorFlags::HAS_PART;
-        }
         // `build_with_specificity_and_flags()` drains the contents; `Drop` on
         // `SelectorBuilder` frees the SmallList capacity when the builder goes
         // out of scope.

--- a/src/css/selectors/parser.rs
+++ b/src/css/selectors/parser.rs
@@ -673,11 +673,19 @@ fn parse_selector<Impl: BunSelectorImpl>(
         }
     }
 
-    let has_pseudo_element = state.contains(SelectorParsingState::AFTER_PSEUDO_ELEMENT)
-        || state.contains(SelectorParsingState::AFTER_UNKNOWN_PSEUDO_ELEMENT);
-    let slotted = state.contains(SelectorParsingState::AFTER_SLOTTED);
-    let part = state.contains(SelectorParsingState::AFTER_PART);
-    let result = builder.build(has_pseudo_element, slotted, part);
+    let mut flags = SelectorFlags::empty();
+    if state.contains(SelectorParsingState::AFTER_PSEUDO_ELEMENT)
+        || state.contains(SelectorParsingState::AFTER_UNKNOWN_PSEUDO_ELEMENT)
+    {
+        flags |= SelectorFlags::HAS_PSEUDO;
+    }
+    if state.contains(SelectorParsingState::AFTER_SLOTTED) {
+        flags |= SelectorFlags::HAS_SLOTTED;
+    }
+    if state.contains(SelectorParsingState::AFTER_PART) {
+        flags |= SelectorFlags::HAS_PART;
+    }
+    let result = builder.build(flags);
     Ok(GenericSelector {
         specificity_and_flags: result.specificity_and_flags,
         components: result.components,
@@ -1883,7 +1891,7 @@ impl<Impl: BunSelectorImpl> GenericSelector<Impl> {
         } else {
             builder.push_simple_selector(component);
         }
-        let result = builder.build(false, false, false);
+        let result = builder.build(SelectorFlags::empty());
         Self {
             specificity_and_flags: result.specificity_and_flags,
             components: result.components,


### PR DESCRIPTION
### Problem
- mordant's `bare_bool_args` flags `SelectorBuilder::build` in `src/css/selectors/builder.rs:113`: it takes `parsed_pseudo: bool, parsed_slotted: bool, parsed_part: bool`, and `Selector::from_component_in` calls it as `build(false, false, false)` (`src/css/selectors/parser.rs:1886`), where nothing says which flag is which.
- The three bools exist only to be ORed into a `SelectorFlags` value inside `build()` (`HAS_PSEUDO`, `HAS_SLOTTED`, `HAS_PART`), so the function already had a named representation for its input; the bools were an extra layer in front of it.

### Fix
- `build()` takes the `SelectorFlags` directly. The OR chain moves unchanged into `parse_selector`, the one caller that computes the flags from the parsing state; `from_component_in` passes `SelectorFlags::empty()`. The flags stored on the resulting selector are bit for bit what they were before, so no behavior change and no new test.
- The lint only considers functions with two or more `bool` parameters; `build()` now has none, and nothing else in `builder.rs` qualifies, so the `bare_bool_args:src/css/selectors/builder.rs` entry is removed from `mordant-baseline.toml`. That is the only entry the change clears, so the file was edited by hand rather than regenerated.
- Verified with `bun bd`:
  - `bun bd test test/js/bun/css/`: 2287 pass, 68 skip. The 9 failures are all timeouts of stress tests in this slow debug+ASAN container: the fuzz tests (`css-fuzz.test.ts`, gated `!isCI` with a hardcoded 10s budget), and six expansion-bound tests that pass when rerun with `--timeout 120000`.
  - `bun bd test test/bundler/css/`: 169 pass.
  - `bun bd test test/bundler/esbuild/css.test.ts`: 56 pass (includes `DeduplicateRules`, which compares selectors including these flags).

### Background
- `SelectorBuilder` accumulates the simple selectors and combinators of one selector while it is being parsed; `build()` turns them into the final component list plus a `SpecificityAndFlags` (the computed specificity and a `SelectorFlags` bitset).
- `SelectorFlags` (`bitflags`, defined in `src/css/selectors/parser.rs`) records whether the selector contains a pseudo-element, `::slotted()` or `::part()`. `HAS_PSEUDO` is what `Selector::has_pseudo_element()` reads when deciding whether style rules can be merged; the flags also take part in selector equality and hashing.
- `mordant-baseline.toml` is the ratchet for the mordant lint pack: it records the per-(lint, file) finding counts that predate the job, so CI only fails on new findings. Fixing a site means deleting (or decrementing) its entry.
