### PR TITLE
bun:ffi: remove ABIType::param_typename, a copy of ABIType::typename

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -73,7 +73,6 @@
 "parallel_vecs:src/runtime/api/html_rewriter.rs" = 1
 "parallel_vecs:src/runtime/bake/dev_server/incremental_graph.rs" = 1
 "reimplemented_helper:src/runtime/api/bun/Terminal.rs" = 1
-"reimplemented_helper:src/runtime/ffi/abi_type.rs" = 1
 "reimplemented_helper:src/runtime/hw_exports.rs" = 1
 "same_match_twice:src/runtime/api/YAMLObject.rs" = 1
 "same_match_twice:src/runtime/api/bun/h2_frame_parser.rs" = 1

--- a/src/runtime/ffi/abi_type.rs
+++ b/src/runtime/ffi/abi_type.rs
@@ -102,8 +102,7 @@ bun_core::comptime_string_map! {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Per-variant string table — single source of truth for the four exhaustive
-// matches that previously lived in typename_label / param_typename_label /
+// Per-variant string table — single source of truth for typename_label /
 // ToCFormatter / ToJSFormatter. Indexed by `self as usize`.
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -224,14 +223,6 @@ impl ABIType {
 
     pub(crate) fn typename_label(self) -> &'static [u8] {
         self.row().c_type
-    }
-
-    pub(crate) fn param_typename(
-        self,
-        writer: &mut impl std::io::Write,
-    ) -> Result<(), crate::Error> {
-        writer.write_all(self.typename_label())?;
-        Ok(())
     }
 }
 

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -2135,7 +2135,7 @@ impl Function {
                 writer.write_all(b", ")?;
             }
             first = false;
-            arg.param_typename(writer)?;
+            arg.typename(writer)?;
             write!(writer, " arg{}", i)?;
         }
         writer.write_all(


### PR DESCRIPTION
### Problem
- `ABIType::param_typename` (src/runtime/ffi/abi_type.rs:229) had the same signature and body as `ABIType::typename` (abi_type.rs:220): both write `self.typename_label()` to the writer. A change to one would silently miss the other. This is the `reimplemented_helper` finding baselined for `abi_type.rs` in `mordant-baseline.toml`.
- The duplication is inherited, not a porting mistake. `paramTypename` was added in #7009 already delegating to `typenameLabel()`, the same as `typename`. The variant that would have differed (`paramTypenameLabel`, which spelled `uint32_t` parameters as `int32_t`) was never called by anything and was dropped as dead code when `ffi.zig` was ported. Large `uint32_t` arguments do not depend on it: `print_source_code` loads every small integer argument as the raw `int64_t` encoding and passes it to a prototype whose parameter type (`uint32_t`) truncates it to the low 32 bits, so the parameter and return positions have always used the same C type name.

### Fix
- Delete `param_typename`; the only caller (`Function::print_source_code` in src/runtime/ffi/ffi_body.rs, the prototype's parameter list) now calls `typename`.
- Remove the `reimplemented_helper:src/runtime/ffi/abi_type.rs` entry from `mordant-baseline.toml` and drop the mention of the never-ported `param_typename_label` from the table comment.
- No behavior change. Verified with the debug build:
  - `viewSource` prototype for a symbol taking all 20 argument types is byte-identical to the one the released `bun` emits (see below).
  - `bun bd test test/js/bun/ffi/ffi.test.js --timeout 120000`: 157 pass (the `--timeout` is only because the exhaustive integer identity tests exceed the 5s default under a debug+ASAN build; CI passes its own larger per-test timeout).
  - `bun bd test test/js/bun/ffi/cc.test.ts test/js/bun/ffi/ffi-viewSource-non-object.test.ts test/js/bun/ffi/ffi-error-messages.test.ts`: 35 pass.
  - The `mordant` workflow runs on this PR since the baseline changed; with the entry removed, it fails if the finding is still reported.
- #38057 (open) adds another `param_typename` caller in `ffi_body.rs`; whichever of the two lands second needs that one call renamed to `typename`.

### Background
- `bun:ffi`'s `cc()` / `dlopen()` fallback path generates a C wrapper per symbol and compiles it with the bundled TinyCC. `print_source_code` emits the prototype of the user's function (`<ret> name(<param> arg0, ...)`) and the wrapper that unpacks `EncodedJSValue`s and calls it; `typename` supplies the `<ret>` and `<param>` spellings from the per-variant `ABI_TABLE`.
- `mordant` is the dylint pack run by `bun run rust:mordant`; `mordant-baseline.toml` holds per-(lint, file) counts of pre-existing findings, and CI fails only on findings above the baseline.

<details>
<summary>Prototype comparison, released bun vs this branch</summary>

```js
import { viewSource } from "bun:ffi";
const types = ["char","int8_t","uint8_t","int16_t","uint16_t","int32_t","uint32_t","int64_t","uint64_t","double","float","bool","ptr","cstring","i64_fast","u64_fast","function","napi_env","napi_value","buffer"];
const [src] = viewSource({ f: { args: types, returns: "uint32_t" } }, false);
```

Both binaries emit:

```c
/* --- The Function To Call */
uint32_t f(char arg0, int8_t arg1, uint8_t arg2, int16_t arg3, uint16_t arg4, int32_t arg5, uint32_t arg6, int64_t arg7, uint64_t arg8, double arg9, float arg10, bool arg11, void* arg12, void* arg13, int64_t arg14, uint64_t arg15, void* arg16, napi_env arg17, napi_value arg18, void* arg19);
```
</details>
