### PR TITLE
node:path: name relative()'s buffers by role instead of by position

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -53,7 +53,6 @@
 "arg_named_like_other_param:src/runtime/cli/install_completions_command.rs" = 4
 "arg_named_like_other_param:src/runtime/cli/open.rs" = 1
 "arg_named_like_other_param:src/runtime/cli/pack_command.rs" = 1
-"arg_named_like_other_param:src/runtime/node/path.rs" = 2
 "bare_bool_args:src/runtime/api.rs" = 2
 "bare_bool_args:src/runtime/api/bun/h2_frame_parser.rs" = 1
 "bare_bool_args:src/runtime/bake/dev_server/incremental_graph.rs" = 1
@@ -69,7 +68,6 @@
 "error_collapsed_to_bool:src/runtime/ffi/ffi_body.rs" = 1
 "field_valid_only_when:src/runtime/cli/filter_run.rs" = 1
 "field_valid_only_when:src/runtime/shell/builtin/rm.rs" = 1
-"narrowed_two_ways:src/runtime/node/node_crypto_binding.rs" = 1
 "parallel_vecs:src/runtime/api/html_rewriter.rs" = 1
 "parallel_vecs:src/runtime/bake/dev_server/incremental_graph.rs" = 1
 "reimplemented_helper:src/runtime/api/bun/Terminal.rs" = 1

--- a/src/runtime/node/path.rs
+++ b/src/runtime/node/path.rs
@@ -2396,8 +2396,8 @@ fn relative_posix_t<'a, T: PathCharCwd>(
     from: &[T],
     to: &[T],
     buf: &'a mut [T],
-    buf2: &mut [T],
-    buf3: &mut [T],
+    from_buf: &mut [T],
+    tmp_buf: &mut [T],
 ) -> MaybeSlice<'a, T> {
     // validateString of `from` and `to` are performed in pub fn relative.
     if from == to {
@@ -2405,8 +2405,8 @@ fn relative_posix_t<'a, T: PathCharCwd>(
     }
 
     // Trim leading forward slashes.
-    // Backed by expandable buf2 because fromOrig may be long.
-    let from_orig = resolve_posix_t(&[from], buf2, buf3)?;
+    // Backed by from_buf.
+    let from_orig = resolve_posix_t(&[from], from_buf, tmp_buf)?;
     let from_orig_len = from_orig.len();
     // Backed by buf.
     // Borrowck: resolve into buf, then operate via raw indices.
@@ -2415,7 +2415,7 @@ fn relative_posix_t<'a, T: PathCharCwd>(
     // resolved value.
     let to_orig_len = {
         let (ptr, len) = {
-            let r = resolve_posix_t(&[to], buf, buf3)?;
+            let r = resolve_posix_t(&[to], buf, tmp_buf)?;
             (r.as_ptr(), r.len())
         };
         if ptr != buf.as_ptr() {
@@ -2484,7 +2484,7 @@ fn relative_posix_t<'a, T: PathCharCwd>(
     let mut buf_offset: usize;
     let mut buf_size: usize = 0;
 
-    // Backed by buf3.
+    // Backed by tmp_buf.
     let mut out_len: usize = 0;
     // Add a block to isolate `i`.
     {
@@ -2501,13 +2501,13 @@ fn relative_posix_t<'a, T: PathCharCwd>(
                 if out_len > 0 {
                     buf_offset = buf_size;
                     buf_size += 3;
-                    buf3[buf_offset] = T::from_u8(CHAR_FORWARD_SLASH);
-                    buf3[buf_offset + 1] = T::from_u8(CHAR_DOT);
-                    buf3[buf_offset + 2] = T::from_u8(CHAR_DOT);
+                    tmp_buf[buf_offset] = T::from_u8(CHAR_FORWARD_SLASH);
+                    tmp_buf[buf_offset + 1] = T::from_u8(CHAR_DOT);
+                    tmp_buf[buf_offset + 2] = T::from_u8(CHAR_DOT);
                 } else {
                     buf_size = 2;
-                    buf3[0] = T::from_u8(CHAR_DOT);
-                    buf3[1] = T::from_u8(CHAR_DOT);
+                    tmp_buf[0] = T::from_u8(CHAR_DOT);
+                    tmp_buf[1] = T::from_u8(CHAR_DOT);
                 }
                 out_len = buf_size;
             }
@@ -2530,7 +2530,7 @@ fn relative_posix_t<'a, T: PathCharCwd>(
         buf.copy_within(to_start..to_start + slice_size, buf_offset);
     }
     if out_len > 0 {
-        memmove(&mut buf[0..out_len], &buf3[0..out_len]);
+        memmove(&mut buf[0..out_len], &tmp_buf[0..out_len]);
     }
     buf[buf_size] = T::default();
     Ok(&buf[0..buf_size])
@@ -2542,16 +2542,16 @@ fn relative_windows_t<'a, T: PathCharCwd>(
     from: &[T],
     to: &[T],
     buf: &'a mut [T],
-    buf2: &mut [T],
-    buf3: &mut [T],
+    from_buf: &mut [T],
+    tmp_buf: &mut [T],
 ) -> MaybeSlice<'a, T> {
     // validateString of `from` and `to` are performed in pub fn relative.
     if from == to {
         return Ok(&[]);
     }
 
-    // Backed by expandable buf2 because fromOrig may be long.
-    let from_orig = resolve_windows_t(&[from], buf2, buf3)?;
+    // Backed by from_buf.
+    let from_orig = resolve_windows_t(&[from], from_buf, tmp_buf)?;
     let from_orig_len = from_orig.len();
     // Backed by buf.
     // Borrowck: resolve into buf, then operate via raw indices.
@@ -2560,7 +2560,7 @@ fn relative_windows_t<'a, T: PathCharCwd>(
     // resolved value.
     let to_orig_len = {
         let (ptr, len) = {
-            let r = resolve_windows_t(&[to], buf, buf3)?;
+            let r = resolve_windows_t(&[to], buf, tmp_buf)?;
             (r.as_ptr(), r.len())
         };
         if ptr != buf.as_ptr() {
@@ -2661,7 +2661,7 @@ fn relative_windows_t<'a, T: PathCharCwd>(
     let mut buf_offset: usize;
     let mut buf_size: usize = 0;
 
-    // Backed by buf3.
+    // Backed by tmp_buf.
     let mut out_len: usize = 0;
     // Add a block to isolate `i`.
     {
@@ -2675,13 +2675,13 @@ fn relative_windows_t<'a, T: PathCharCwd>(
                 if out_len > 0 {
                     buf_offset = buf_size;
                     buf_size += 3;
-                    buf3[buf_offset] = T::from_u8(CHAR_BACKWARD_SLASH);
-                    buf3[buf_offset + 1] = T::from_u8(CHAR_DOT);
-                    buf3[buf_offset + 2] = T::from_u8(CHAR_DOT);
+                    tmp_buf[buf_offset] = T::from_u8(CHAR_BACKWARD_SLASH);
+                    tmp_buf[buf_offset + 1] = T::from_u8(CHAR_DOT);
+                    tmp_buf[buf_offset + 2] = T::from_u8(CHAR_DOT);
                 } else {
                     buf_size = 2;
-                    buf3[0] = T::from_u8(CHAR_DOT);
-                    buf3[1] = T::from_u8(CHAR_DOT);
+                    tmp_buf[0] = T::from_u8(CHAR_DOT);
+                    tmp_buf[1] = T::from_u8(CHAR_DOT);
                 }
                 out_len = buf_size;
             }
@@ -2715,7 +2715,7 @@ fn relative_windows_t<'a, T: PathCharCwd>(
             // Use copy_within because toOrig and buf overlap.
             buf.copy_within(to_start..to_start + slice_size, buf_offset);
         }
-        memmove(&mut buf[0..out_len], &buf3[0..out_len]);
+        memmove(&mut buf[0..out_len], &tmp_buf[0..out_len]);
         buf[buf_size] = T::default();
         return Ok(&buf[0..buf_size]);
     }
@@ -2732,10 +2732,10 @@ fn relative_posix_js_t<T: PathCharCwd>(
     from: &[T],
     to: &[T],
     buf: &mut [T],
-    buf2: &mut [T],
-    buf3: &mut [T],
+    from_buf: &mut [T],
+    tmp_buf: &mut [T],
 ) -> JsResult<JSValue> {
-    match relative_posix_t(from, to, buf, buf2, buf3) {
+    match relative_posix_t(from, to, buf, from_buf, tmp_buf) {
         Ok(r) => create_js_string_t::<T>(global_object, r),
         Err(e) => Ok(e.to_js(global_object)),
     }
@@ -2746,10 +2746,10 @@ fn relative_windows_js_t<T: PathCharCwd>(
     from: &[T],
     to: &[T],
     buf: &mut [T],
-    buf2: &mut [T],
-    buf3: &mut [T],
+    from_buf: &mut [T],
+    tmp_buf: &mut [T],
 ) -> JsResult<JSValue> {
-    match relative_windows_t(from, to, buf, buf2, buf3) {
+    match relative_windows_t(from, to, buf, from_buf, tmp_buf) {
         Ok(r) => create_js_string_t::<T>(global_object, r),
         Err(e) => Ok(e.to_js(global_object)),
     }
@@ -2768,14 +2768,14 @@ fn relative_js_t<T: PathCharCwd>(
     let buf_len =
         ((from.len() + max_path_size::<T>() + 1) * 2 + to.len() + max_path_size::<T>() + 1)
             .max(path_size::<T>());
-    // +1 for null terminator; ×3 for buf/buf2/buf3 carved from one slab.
+    // +1 for null terminator; ×3 for buf/from_buf/tmp_buf carved from one slab.
     let mut scratch = PathScratch::<T>::new(pool, (buf_len + 1) * 3);
     let (buf, rest) = scratch.slice().split_at_mut(buf_len + 1);
-    let (buf2, buf3) = rest.split_at_mut(buf_len + 1);
+    let (from_buf, tmp_buf) = rest.split_at_mut(buf_len + 1);
     if is_windows {
-        relative_windows_js_t(global_object, from, to, buf, buf2, buf3)
+        relative_windows_js_t(global_object, from, to, buf, from_buf, tmp_buf)
     } else {
-        relative_posix_js_t(global_object, from, to, buf, buf2, buf3)
+        relative_posix_js_t(global_object, from, to, buf, from_buf, tmp_buf)
     }
 }
 


### PR DESCRIPTION
### Problem
- `bun run rust:mordant` reports two `arg_named_like_other_param` findings in `src/runtime/node/path.rs`, carried in `mordant-baseline.toml`: `relative_posix_t` and `relative_windows_t` each call `resolve_*_t(&[from], buf2, buf3)`, passing their `buf2` as the callee's `buf` parameter while the callee also has a same-typed parameter named `buf2`, so the call reads like a transposed argument.
- The calls are correct. `relative_*_t` resolves `to` into its own `buf` (which also backs the returned slice), so `from` has to be resolved into a different buffer, and the third buffer is lent to both `resolve_*_t` calls as scratch and then reused to accumulate the `..` segments. Only the positional names (`buf2`, `buf3`) made that look like a mistake.

### Fix
- Rename the second and third buffers of `relative_posix_t`, `relative_windows_t`, their `_js_t` wrappers and `relative_js_t` to `from_buf` and `tmp_buf`, and update the comments that named them. The calls now read `resolve_*_t(&[from], from_buf, tmp_buf)` and `resolve_*_t(&[to], buf, tmp_buf)`. `resolve_posix_t` / `resolve_windows_t` and their other callers are untouched.
- Pure rename, no behavior change.
- `mordant-baseline.toml`: regenerated the `[bun_runtime]` section. This drops the `arg_named_like_other_param:src/runtime/node/path.rs` entry, and also `narrowed_two_ways:src/runtime/node/node_crypto_binding.rs`, whose finding #37648 removed without touching the baseline (it merged a few minutes after #38875 regenerated the file). Happy to drop that second line if this PR should stay strictly scoped.
- Verified:
  - `MORDANT_BASELINE_WRITE=1 cargo dylint --all -p bun_runtime --no-deps` (the `rust:mordant:baseline` script scoped to the one crate this touches; `bun_runtime` has no cargo features, so the crate is compiled the same way as in the workspace run) rewrites `[bun_runtime]` with exactly those two entries removed and nothing added.
  - `bun bd test test/js/node/path/`: 123 pass, 3 skip (Windows-only), 0 fail. `relative.test.js` exercises both `path.posix.relative` and `path.win32.relative`, so both renamed functions run on Linux.

### Background
- mordant is the lint pack `bun run rust:mordant` runs (pinned in `Cargo.toml` under `[workspace.metadata.dylint]`). `mordant-baseline.toml` is a ratchet: per (lint, file) counts of pre-existing findings that CI tolerates, so fixing a site means also deleting its baseline entry, and a stale entry silently absorbs one new finding of that kind in that file.
- `arg_named_like_other_param` fires when an argument is spelled with the name of a callee parameter other than the one it is bound to, and the two parameters share a type (so an actual swap would compile). Renaming the value on either side so the names no longer cross is the intended way to clear a correct call.
