### PR TITLE
cli: keep a script's start and end time on its spawned process record

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -67,7 +67,6 @@
 "error_collapsed_to_bool:src/runtime/api/bun/Terminal.rs" = 1
 "error_collapsed_to_bool:src/runtime/api/bun/h2_frame_parser.rs" = 32
 "error_collapsed_to_bool:src/runtime/ffi/ffi_body.rs" = 1
-"field_valid_only_when:src/runtime/cli/filter_run.rs" = 1
 "field_valid_only_when:src/runtime/shell/builtin/rm.rs" = 1
 "narrowed_two_ways:src/runtime/node/node_crypto_binding.rs" = 1
 "parallel_vecs:src/runtime/api/html_rewriter.rs" = 1

--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -44,6 +44,9 @@ struct ProcessInfo {
     // `to_process()` and `set_exit_handler` callers.
     ptr: *mut Process,
     status: Status,
+    start_time: Instant,
+    /// Set together with `status` when the exit arrives.
+    end_time: Option<Instant>,
 }
 
 // `state` is a backref into the owning `State` (which holds `handles: []ProcessHandle`),
@@ -66,9 +69,6 @@ pub(crate) struct ProcessHandle<'a> {
 
     process: Option<ProcessInfo>,
     options: SpawnOptions,
-
-    start_time: Option<Instant>,
-    end_time: Option<Instant>,
 
     remaining_dependencies: usize,
     dependents: Vec<*mut ProcessHandle<'a>>,
@@ -101,7 +101,7 @@ impl<'a> ProcessHandle<'a> {
             handle.config.combined.as_ptr().cast(),
             core::ptr::null(),
         ];
-        handle.start_time = Some(Instant::now());
+        let start_time = Instant::now();
         let spawned: spawn::SpawnProcessResult = 'brk: {
             // Get the envp with the PATH configured
             // There's probably a more optimal way to do this where you have a Vec shared
@@ -185,6 +185,8 @@ impl<'a> ProcessHandle<'a> {
         handle.process = Some(ProcessInfo {
             ptr: process,
             status: Status::Running,
+            start_time,
+            end_time: None,
         });
         // SAFETY: `process` was just allocated by `to_process` (heap::alloc);
         // sole owner until reaped, owner backref set before reap callback can fire.
@@ -271,8 +273,9 @@ bun_spawn::link_impl_ProcessExit! {
     FilterRunHandle for ProcessHandle<'static> => |this| {
         // The Process is never freed; the program exits when all scripts finish.
         on_process_exit(_process, status, _rusage) => {
-            (*this).process.as_mut().unwrap().status = status;
-            (*this).end_time = Some(Instant::now());
+            let info = (*this).process.as_mut().unwrap();
+            info.status = status;
+            info.end_time = Some(Instant::now());
             // Aborted runs finish on exit alone; their pending output is dropped.
             if !(*(*this).state.as_ptr()).aborted {
                 ProcessHandle::drain_and_close_pipes(this);
@@ -566,8 +569,8 @@ impl<'a> State<'a> {
                     }
                     Status::Exited(exited) => {
                         if exited.code == 0 {
-                            if let (Some(start), Some(end)) = (handle.start_time, handle.end_time) {
-                                let duration = end.duration_since(start);
+                            if let Some(end) = proc.end_time {
+                                let duration = end.duration_since(proc.start_time);
                                 let ms = duration.as_nanos() as f64 / 1_000_000.0;
                                 if ms > 1000.0 {
                                     write!(
@@ -1013,8 +1016,6 @@ pub(crate) fn run_scripts_with_filter(
                 stream: true,
                 ..Default::default()
             },
-            start_time: None,
-            end_time: None,
             remaining_dependencies: 0,
             dependents: Vec::new(),
             visit_state: VisitState::Unvisited,

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -107,6 +107,9 @@ struct ProcessSlot {
     /// `PosixSpawnResult::to_process`. Freed via `Process::deref`.
     ptr: *mut Process,
     status: Status,
+    start_time: Instant,
+    /// Set together with `status` when the exit arrives.
+    end_time: Option<Instant>,
 }
 
 pub(crate) struct ProcessHandle<'a> {
@@ -119,9 +122,6 @@ pub(crate) struct ProcessHandle<'a> {
 
     process: Option<ProcessSlot>,
     options: SpawnOptions,
-
-    start_time: Option<Instant>,
-    end_time: Option<Instant>,
 
     /// Set by the `maybe_finish` that counts this script out of
     /// `remaining_scripts`, so a later pipe/exit event or the abort sweep
@@ -155,7 +155,7 @@ impl<'a> ProcessHandle<'a> {
             ptr::null(),
         ];
 
-        self.start_time = Instant::now().into();
+        let start_time = Instant::now();
         let envp;
         let env_ptr = state.env;
         let spawned: SpawnProcessResult = {
@@ -257,6 +257,8 @@ impl<'a> ProcessHandle<'a> {
         self.process = Some(ProcessSlot {
             ptr: process,
             status: Status::Running,
+            start_time,
+            end_time: None,
         });
         // SAFETY: `process` was just allocated by `to_process` (heap::alloc);
         // owner backref set before any reap callback can fire.
@@ -318,8 +320,9 @@ impl<'a> ProcessHandle<'a> {
 bun_spawn::link_impl_ProcessExit! {
     MultiRunHandle for ProcessHandle<'static> => |this| {
         on_process_exit(_process, status, _rusage) => {
-            (*this).process.as_mut().unwrap().status = status;
-            (*this).end_time = Instant::now().into();
+            let slot = (*this).process.as_mut().unwrap();
+            slot.status = status;
+            slot.end_time = Some(Instant::now());
             // Aborted runs finish on exit alone; their pending output is dropped.
             if !(*(*this).state).aborted {
                 ProcessHandle::drain_and_close_pipes(this);
@@ -466,13 +469,14 @@ impl<'a> State<'a> {
         let writer = Output::error_writer();
         self.write_prefix(handle, writer)?;
 
-        match &handle.process.as_ref().unwrap().status {
+        let slot = handle.process.as_ref().unwrap();
+        match &slot.status {
             Status::Exited(exited) => {
                 if exited.code != 0 {
                     writeln!(writer, "Exited with code {}", exited.code)?;
                 } else {
-                    if let (Some(start), Some(end)) = (handle.start_time, handle.end_time) {
-                        let duration = end.duration_since(start);
+                    if let Some(end) = slot.end_time {
+                        let duration = end.duration_since(slot.start_time);
                         let ms = duration.as_nanos() as f64 / 1_000_000.0;
                         if ms > 1000.0 {
                             writeln!(writer, "Done in {:.2}s", ms / 1000.0)?;
@@ -494,7 +498,7 @@ impl<'a> State<'a> {
         }
 
         // Check if we should abort on error
-        let failed = match &handle.process.as_ref().unwrap().status {
+        let failed = match &slot.status {
             Status::Exited(exited) => exited.code != 0,
             Status::Signaled(_) => true,
             _ => true,
@@ -1174,8 +1178,6 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
             stdout_reader: PipeReader::new(false),
             stderr_reader: PipeReader::new(true),
             process: None,
-            start_time: None,
-            end_time: None,
             finished: false,
             remaining_dependencies: 0,
             group_dependents: Vec::new(),

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -648,6 +648,29 @@ describe("bun", () => {
     expect(exitCode).toBe(0);
   });
 
+  // The terminal renderer is TTY-only on Windows (see runElideLinesTest).
+  test.skipIf(isWindows)("terminal output reports how long a successful script took", () => {
+    using dir = tempDir("filter-done-in", {
+      packages: {
+        dep0: {
+          "package.json": JSON.stringify({ name: "dep0", scripts: { script: "exit 0" } }),
+        },
+      },
+      "package.json": JSON.stringify({ name: "ws", workspaces: ["packages/*"] }),
+    });
+
+    const { exitCode, stdout } = spawnSync({
+      cwd: String(dir),
+      cmd: [bunExe(), "run", "--filter", "dep0", "script"],
+      env: { ...bunEnv, FORCE_COLOR: "1", NO_COLOR: "0" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(stdout.toString()).toMatch(/Done in (?:\d+ ms|\d+\.\d{2} s)/);
+    expect(exitCode).toBe(0);
+  });
+
   test("self-referential directory symlink in a workspace does not loop", () => {
     using dir = tempDir("filter-symlink-loop", {
       packages: {


### PR DESCRIPTION
### Problem
- `ProcessHandle.start_time` in `src/runtime/cli/filter_run.rs` (and `end_time` next to it) is an `Option<Instant>` that every handle is built with as `None`, is filled in by `start()` right before `process` becomes `Some`, and is read in exactly one place, inside `if let Some(proc) = &handle.process` (`State::redraw`).
- The field only means something once the script has been spawned, which is the state `process: Some(ProcessInfo)` already represents, so a handle carries two extra nullable fields that nothing ties to that state. This is the `field_valid_only_when` finding recorded for `filter_run.rs` in `mordant-baseline.toml`.
- `src/runtime/cli/multi_run.rs` (`bun run --parallel` / `--sequential`) is a copy of the same structure, with the same two fields on its `ProcessHandle`. It is not in the baseline only because its one read goes through `handle.process.as_ref().unwrap()` instead of an `if let`, which the lint does not follow.

### Fix
- `ProcessInfo` (filter_run) and `ProcessSlot` (multi_run) gain `start_time: Instant` and `end_time: Option<Instant>`; the two `Option<Instant>` fields come off `ProcessHandle`.
- `start()` still takes the timestamp before spawning (as a local) and stores it when it builds the record, so a start time exists exactly when a process does. The exit handler, which already unwraps `process` to store the status, sets `end_time` on the same record.
- The read sites use the record they are already matching on (`proc.end_time` / `proc.start_time`, `slot.*`). Both timestamps are taken at the same points as before, so the `Done in N ms` / `Done in N.NN s` output is unchanged.
- The `field_valid_only_when:src/runtime/cli/filter_run.rs` line is removed from `mordant-baseline.toml`; the rest of the file is unchanged. Both new fields stay quiet under that lint: `start_time` is built from a real value at the only construction site, and `end_time` is written alongside a status that is not one fixed variant.
- Verified with `bun bd test test/cli/run/filter-workspace.test.ts` (79 pass) and `bun bd test test/cli/run/multi-run.test.ts` (121 pass). `multi-run.test.ts` already asserts the `Done in` lines; `filter-workspace.test.ts` did not cover the terminal renderer's timing line, so this adds one test that runs `--filter` with `FORCE_COLOR=1` and checks for `Done in <n> ms` / `<n>.<nn> s` (skipped on Windows, where that renderer needs a real console).

### Background
- `bun run --filter` (`filter_run.rs`) and `bun run --parallel` / `--sequential` (`multi_run.rs`) each build one `ProcessHandle` per script up front, then spawn scripts as their dependencies finish. `handle.process` is `None` until the script is spawned and `Some(record)` afterwards; the record holds the child's `*mut Process` and its exit `Status`, which starts as `Status::Running` and is overwritten by the process exit callback (`link_impl_ProcessExit!`).
- The elapsed time is only printed for scripts that exited with code 0: in filter_run on the terminal renderer's `└─ Done in ...` line, in multi_run on the `label | Done in ...` line on stderr.
- mordant is the Rust lint pack run by the Rust lints workflow; `mordant-baseline.toml` holds the per-(lint, file) counts of findings that predate it, so fixing a finding means deleting its line.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/filter-workspace.test.ts

<!-- robobun:evidence:end -->