### PR TITLE
install: name satisfies_dependency_version's range-side arguments after the dependency

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -18,9 +18,7 @@
 "tuple_wants_struct:src/css/values/color.rs" = 5
 
 [bun_install]
-"always_unwrapped_option:src/install/PackageInstall.rs" = 1
 "arg_named_like_other_param:src/install/PackageManager/PackageJSONEditor.rs" = 3
-"arg_named_like_other_param:src/install/resolution.rs" = 1
 "bare_bool_args:src/install/isolated_install.rs" = 1
 "defaulted_failure:src/install/npm.rs" = 1
 "index_of_other_kind:src/install/isolated_install.rs" = 1

--- a/src/install/resolution.rs
+++ b/src/install/resolution.rs
@@ -17,33 +17,35 @@ use crate::versioned_url::VersionedURLType;
 pub type Resolution = ResolutionType<u64>;
 
 impl Resolution {
-    /// True when this resolution can satisfy `version`: npm ranges by
+    /// True when this resolution can satisfy `dep_version`: npm ranges by
     /// semver, git/github by exact repo equality. Any other kind pairing
     /// (workspace, folder, tarball, dist-tag, …) never satisfies. This is
     /// the comparison the resolver's deferred-peer phase uses to bind peer
     /// edges against already-resolved packages.
     pub(crate) fn satisfies_dependency_version(
         &self,
-        version: &dependency::Version,
-        version_buf: &[u8],
+        dep_version: &dependency::Version,
+        dep_version_buf: &[u8],
         resolution_buf: &[u8],
     ) -> bool {
-        if self.tag == Tag::Npm && version.tag == dependency::VersionTag::Npm {
-            return version.npm().version.satisfies(
+        if self.tag == Tag::Npm && dep_version.tag == dependency::VersionTag::Npm {
+            return dep_version.npm().version.satisfies(
                 self.npm().version,
-                version_buf,
+                dep_version_buf,
                 resolution_buf,
             );
         }
 
-        if self.tag == Tag::Git && version.tag == dependency::VersionTag::Git {
-            return self.git().eql(version.git(), resolution_buf, version_buf);
+        if self.tag == Tag::Git && dep_version.tag == dependency::VersionTag::Git {
+            return self
+                .git()
+                .eql(dep_version.git(), resolution_buf, dep_version_buf);
         }
 
-        if self.tag == Tag::Github && version.tag == dependency::VersionTag::Github {
+        if self.tag == Tag::Github && dep_version.tag == dependency::VersionTag::Github {
             return self
                 .github()
-                .eql(version.github(), resolution_buf, version_buf);
+                .eql(dep_version.github(), resolution_buf, dep_version_buf);
         }
 
         false


### PR DESCRIPTION
### Problem
- mordant's `arg_named_like_other_param` flags `src/install/resolution.rs:34`: `version_buf` is passed as `Group::satisfies`'s `group_buf` parameter, and `satisfies` also has a `version_buf` parameter of the same type (`satisfies(version, group_buf, version_buf)` in `src/semver/SemverQuery.rs:556`).
- The call is not transposed. In `Resolution::satisfies_dependency_version`, `version` is a `dependency::Version` (the declared range, which is the group), so its buffer belongs in `group_buf`; `self` is the resolution holding the concrete version, so `resolution_buf` belongs in `satisfies`'s `version_buf`. The git and github arms agree (`self` is `lhs` with `resolution_buf`, the dependency is `rhs` with its own buffer). The two vocabularies just collide on the word `version`.
- All three callers (`PackageManagerEnqueue.rs:2915`, `:2933`, `lockfile/bun.lock.rs:3414`) pass the same lockfile string buffer in both slots, so a swap would not have been observable there either way.

### Fix
- Rename the parameters to `dep_version` / `dep_version_buf`. `resolution_buf` is unchanged. No behavior change, so no new test.
- Regenerate the `[bun_install]` section of `mordant-baseline.toml` (`MORDANT_BASELINE_WRITE=1 cargo dylint --all -p bun_install --no-deps`). Besides the cleared `arg_named_like_other_param:src/install/resolution.rs` entry, this drops `always_unwrapped_option:src/install/PackageInstall.rs`: the `walker: Option<Walker>` field it counted was removed in #38271, which landed after the baseline was recorded in #38846.
- Verified:
  - `cargo dylint --all -p bun_install --no-deps` (the pinned mordant) with this baseline: no findings. With the rename reverted and the same baseline, it reports exactly the `resolution.rs:34` finding as over the baseline, so the baseline edit and the rename match.
  - `bun bd` builds; the three callers' paths pass on it: `bun bd test test/cli/install/test-dev-peer-dependency-priority.test.ts` (4/4), `test/cli/install/bun-lock.test.ts` (40/40, peer resolution while loading bun.lock), `test/cli/install/bun-install-patch.test.ts` (20/20, patched package lookup).

### Background
- `Group::satisfies(version, group_buf, version_buf)` tests a concrete semver version against a parsed range (the "group"). Both sides store their string pieces (prerelease and build tags) as offsets into a byte buffer, which is why each side passes the buffer that backs it.
- `mordant-baseline.toml` is the ratchet for the mordant lint pack: it records the per-(lint, file) finding counts that predate the job, so CI fails only on new findings. Fixing a site means its entry goes away; entries whose findings were fixed without touching the file (like the `PackageInstall.rs` one) are harmless but stale until the section is regenerated.
