### PR TITLE
--print: share one body between the entry point promise reactions

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -57,7 +57,6 @@
 "field_valid_only_when:src/runtime/shell/builtin/rm.rs" = 1
 "parallel_vecs:src/runtime/api/html_rewriter.rs" = 1
 "reimplemented_helper:src/runtime/api/bun/Terminal.rs" = 1
-"reimplemented_helper:src/runtime/hw_exports.rs" = 1
 "same_match_twice:src/runtime/api/bun/h2_frame_parser.rs" = 1
 "same_match_twice:src/runtime/cli/pack_command.rs" = 1
 "same_match_twice:src/runtime/cli/update_interactive_command.rs" = 2

--- a/src/runtime/hw_exports.rs
+++ b/src/runtime/hw_exports.rs
@@ -304,11 +304,8 @@ mod sql_hooks {
 
 // ─── entry-point promise reactions (used by `--print`) ───────────────────────
 
-// HOST_EXPORT(Bun__onResolveEntryPointResult)
-pub fn on_resolve_entry_point_result(
-    global: &JSGlobalObject,
-    callframe: &CallFrame,
-) -> bun_jsc::JsResult<JSValue> {
+// A fulfilled value and a rejection reason are printed the same way, as `run_command.rs` does.
+fn print_entry_point_result_and_exit(global: &JSGlobalObject, callframe: &CallFrame) -> ! {
     let result = callframe.argument(0);
     // SAFETY: `vals[..len]` is the single stack `result`; `ctype` is ignored by
     // `message_with_type_and_level` (it always resolves the per-VM console via
@@ -324,7 +321,15 @@ pub fn on_resolve_entry_point_result(
         );
     }
     // SAFETY: bun_vm() never null for a Bun-owned global.
-    bun_core::Global::exit(u32::from(global.bun_vm().as_mut().exit_handler.exit_code));
+    bun_core::Global::exit(u32::from(global.bun_vm().as_mut().exit_handler.exit_code))
+}
+
+// HOST_EXPORT(Bun__onResolveEntryPointResult)
+pub fn on_resolve_entry_point_result(
+    global: &JSGlobalObject,
+    callframe: &CallFrame,
+) -> bun_jsc::JsResult<JSValue> {
+    print_entry_point_result_and_exit(global, callframe)
 }
 
 // HOST_EXPORT(Bun__onRejectEntryPointResult)
@@ -332,22 +337,7 @@ pub fn on_reject_entry_point_result(
     global: &JSGlobalObject,
     callframe: &CallFrame,
 ) -> bun_jsc::JsResult<JSValue> {
-    let result = callframe.argument(0);
-    // SAFETY: `vals[..len]` is the single stack `result`; `ctype` is ignored by
-    // `message_with_type_and_level` (it always resolves the per-VM console via
-    // `vm_console(global)`), so null is fine.
-    unsafe {
-        bun_jsc::ConsoleObject::message_with_type_and_level(
-            core::ptr::null_mut(),
-            bun_jsc::ConsoleObject::MessageType::Log,
-            bun_jsc::ConsoleObject::MessageLevel::Log,
-            global,
-            &raw const result,
-            1,
-        );
-    }
-    // SAFETY: bun_vm() never null for a Bun-owned global.
-    bun_core::Global::exit(u32::from(global.bun_vm().as_mut().exit_handler.exit_code));
+    print_entry_point_result_and_exit(global, callframe)
 }
 
 // ─── bindgenv2 dispatch shims (`bindgen_*_dispatch*`) ────────────────────────

--- a/test/cli/run/run-eval.test.ts
+++ b/test/cli/run/run-eval.test.ts
@@ -176,15 +176,16 @@ describe("--print for cjs/esm", () => {
 });
 
 // An uncaught exception stops the event loop while the printed promise is still
-// pending, so --print has to attach reactions to it. The timer that settles it is
-// created inside the throwing callback, so it cannot fire in the same timer batch
-// as the throw. Fulfillment and rejection are printed the same way; the exit code
-// comes from the uncaught exception.
-describe.concurrent.each([
-  { settle: "resolve", printed: "settled late" },
-  { settle: "reject", printed: "rejected late" },
-])("--print of a promise that $settle()s after the event loop stopped", ({ settle, printed }) => {
-  test(`prints ${JSON.stringify(printed)}`, async () => {
+// pending, so --print attaches reactions to it and polls once more. The settling
+// timer is created inside the throwing callback so it cannot fire in the same
+// batch as the throw; the final poll then sleeps until it is due and the reactions
+// print the value. Skipped on Windows, where the libuv poll can return before the
+// timer is due and the still-pending promise gets printed instead.
+describe.concurrent.skipIf(isWindows)("--print of a promise that settles after the event loop stopped", () => {
+  test.each([
+    { settle: "resolve", printed: "settled late" },
+    { settle: "reject", printed: "rejected late" },
+  ])("$settle() prints the value", async ({ settle, printed }) => {
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
@@ -194,7 +195,12 @@ describe.concurrent.each([
           throw new Error("loop killer");
         }, 1))`,
       ],
-      env: bunEnv,
+      env: {
+        ...bunEnv,
+        // detect_leaks=0: the reactions exit without tearing the VM down, so LSan
+        // reports its still-live state as leaks and aborts the exit.
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
+      },
       stdout: "pipe",
       stderr: "pipe",
     });

--- a/test/cli/run/run-eval.test.ts
+++ b/test/cli/run/run-eval.test.ts
@@ -175,6 +175,36 @@ describe("--print for cjs/esm", () => {
   });
 });
 
+// An uncaught exception stops the event loop while the printed promise is still
+// pending, so --print has to attach reactions to it. The timer that settles it is
+// created inside the throwing callback, so it cannot fire in the same timer batch
+// as the throw. Fulfillment and rejection are printed the same way; the exit code
+// comes from the uncaught exception.
+describe.concurrent.each([
+  { settle: "resolve", printed: "settled late" },
+  { settle: "reject", printed: "rejected late" },
+])("--print of a promise that $settle()s after the event loop stopped", ({ settle, printed }) => {
+  test(`prints ${JSON.stringify(printed)}`, async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "--print",
+        `new Promise((resolve, reject) => setTimeout(() => {
+          setTimeout(() => ${settle}(${JSON.stringify(printed)}), 1);
+          throw new Error("loop killer");
+        }, 1))`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe(`${printed}\n`);
+    expect(stderr).toContain("error: loop killer");
+    expect(exitCode).toBe(1);
+  });
+});
+
 function group(run: (code: string) => SyncSubprocess<"pipe", "inherit">) {
   test("it works", async () => {
     const { stdout } = run('console.log("hello world")');


### PR DESCRIPTION
### Problem
- mordant `reimplemented_helper` on `src/runtime/hw_exports.rs`: `on_reject_entry_point_result` has the same signature and body as `on_resolve_entry_point_result` (print argument 0 with `console.log` formatting, then `Global::exit` with the VM's exit code). A change to one would miss the other.
- The Zig originals (`Bun__onResolveEntryPointResult` / `Bun__onRejectEntryPointResult` in `bun_js.zig`, added in #9407) were identical too, so the port did not lose a reject-specific behavior. Printing both outcomes the same way matches the already-settled branch in `src/runtime/cli/run_command.rs` (`promise.result()` is printed the same way whether the promise fulfilled or rejected), so this is duplication, not a missing behavior.

### Fix
- One private `print_entry_point_result_and_exit` helper; both `HOST_EXPORT` functions are one-line calls to it. No behavior change.
- The two exported symbols stay separate: `ZigGlobalObject.cpp` maps each function pointer to its own `PromiseFunctions` slot, and `run_command.rs` passes both to `then2`.
- `mordant-baseline.toml`: removed the `reimplemented_helper:src/runtime/hw_exports.rs` entry. The one-line wrappers are below the lint's minimum body size, so the site no longer reports.
- Test: `test/cli/run/run-eval.test.ts` gains a case per reaction. An uncaught exception in a timer stops the event loop while the printed promise is still pending, so `--print` attaches these reactions; a timer created inside the throwing callback then fulfills or rejects the promise. Both print the settled value and exit 1 (from the uncaught exception). Passes with this change and with the released binary, as expected for a pure dedupe.
- The test is skipped on Windows (the extra libuv poll can return before the settling timer is due, in which case the still-pending promise is printed and the reactions never run; it flaked that way once in CI) and runs the child with `detect_leaks=0` (the reactions exit without VM teardown, so LSan reports the still-live state as leaks and aborts the child, which also spends about 4s symbolizing; see the details below). Neither caveat is introduced by this change; the reactions simply had no test before.
- Verified: `bun bd test test/cli/run/run-eval.test.ts` (39 pass); the same `--print` scripts produce identical stdout and exit codes on the release binary and the debug build with this change.
- Verified: `bun run rust:mordant` at the pinned revision reports nothing over the baseline with this entry removed (`target/mordant/over-baseline.txt` is not written). As a control, removing the still-valid `abi_type.rs` entry from the baseline makes the same run report exactly that site, so the pass is live on `bun_runtime` and `hw_exports.rs` is clean.

### Background
- `bun --print <expr>` prints the value of the last expression. If that value is a promise, `run_command.rs` prints its settled result. If it is still pending after the event loop has drained, it attaches these two reactions with `then2` and ticks once more; whichever reaction runs prints the value and exits.
- `// HOST_EXPORT(Symbol)` markers in `src/runtime` are scraped by `src/codegen/generate-host-exports.ts`, which emits the `extern "C"` thunks that C++ links against. The marker must sit directly above a `pub fn`, which is why both exported functions remain as thin wrappers rather than one function with two names.

<details>
<summary>Unrelated issue noticed on this path (not changed here)</summary>

Both reactions call `Global::exit` directly, so they skip the `ANY_UNHANDLED` exit-code step, the `process.on("exit")` dispatch, and the VM teardown that `Run::start` performs afterwards. Three visible consequences:

- `bun --print 'Promise.reject(new Error("early")); new Promise(r => setTimeout(() => r(5), 30))'` reports the unhandled rejection and then exits 0, while the same script under `bun -e` exits 1.
- `process.on("exit")` listeners do not run when a reaction prints the value.
- Under LSan (`detect_leaks=1`, as the ASAN CI lanes set), the child aborts at exit with a report for state that the normal exit path frees, e.g. the `Arc<ParsedSourceMap>` created while printing the uncaught exception. The normal `--print` paths (already-settled promise, or a promise that never settles) are clean under the same options.

This predates the port (the Zig code behaved the same) and is shared by both reactions, so it is tracked separately rather than folded into this dedupe. The new test is a ready-made trigger for that fix, which can then drop the `detect_leaks=0` override.



</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/run-eval.test.ts

<!-- robobun:evidence:end -->