### PR TITLE
isolated install: name the entry-hash DFS indices after the table they index

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -23,7 +23,6 @@
 "arg_named_like_other_param:src/install/resolution.rs" = 1
 "bare_bool_args:src/install/isolated_install.rs" = 1
 "defaulted_failure:src/install/npm.rs" = 1
-"index_of_other_kind:src/install/isolated_install.rs" = 1
 "interchangeable_aliases:src/install/lockfile/Tree.rs" = 1
 "same_match_twice:src/install/PackageManager/install_with_manager.rs" = 1
 

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -96,7 +96,8 @@ enum State {
 
 struct StackFrame {
     id: store::entry::Id,
-    dep_idx: u32,
+    /// Position in `id`'s dependency list, not a `DependencyID`.
+    next_dep: u32,
     hasher: Wyhash,
 }
 
@@ -1196,13 +1197,13 @@ pub(crate) fn install_isolated_packages(
             // their own store-path bytes.
             let mut stack: Vec<StackFrame> = Vec::new();
 
-            for _root_id in 0..store.entries.len() {
-                if states[_root_id] != State::Unvisited {
+            for root_entry_idx in 0..store.entries.len() {
+                if states[root_entry_idx] != State::Unvisited {
                     continue;
                 }
                 stack.push(StackFrame {
-                    id: store::entry::Id::from(u32::try_from(_root_id).expect("int cast")),
-                    dep_idx: 0,
+                    id: store::entry::Id::from(u32::try_from(root_entry_idx).expect("int cast")),
+                    next_dep: 0,
                     // Placeholder; reinitialized below before first use when state == Unvisited.
                     hasher: Wyhash::init(0),
                 });
@@ -1212,12 +1213,12 @@ pub(crate) fn install_isolated_packages(
                     // Reshaped for borrowck — re-borrow `top` after each
                     // potential `stack.push()` realloc.
                     let id = stack[top_idx].id;
-                    let idx = id.get() as usize;
+                    let entry_idx = id.get() as usize;
 
-                    if states[idx] == State::Unvisited {
-                        states[idx] = State::InProgress;
+                    if states[entry_idx] == State::Unvisited {
+                        states[entry_idx] = State::InProgress;
 
-                        let node_id = entry_node_ids[idx];
+                        let node_id = entry_node_ids[entry_idx];
                         let pkg_id = node_pkg_ids[node_id.get() as usize];
                         let dep_id = node_dep_ids[node_id.get() as usize];
                         let pkg_res = &pkg_resolutions[pkg_id as usize];
@@ -1292,8 +1293,8 @@ pub(crate) fn install_isolated_packages(
                         };
 
                         if !eligible {
-                            states[idx] = State::Ineligible;
-                            entry_hashes[idx] = 0;
+                            states[entry_idx] = State::Ineligible;
+                            entry_hashes[entry_idx] = 0;
                             stack.pop();
                             continue;
                         }
@@ -1323,32 +1324,32 @@ pub(crate) fn install_isolated_packages(
                             .update(bun_core::bytes_of(&pkg_metas[pkg_id as usize].integrity));
                     }
 
-                    if states[idx] == State::Ineligible {
+                    if states[entry_idx] == State::Ineligible {
                         stack.pop();
                         continue;
                     }
 
-                    let deps = entry_dependencies[idx].slice();
+                    let deps = entry_dependencies[entry_idx].slice();
                     let mut advanced = false;
-                    while (stack[top_idx].dep_idx as usize) < deps.len() {
-                        let dep = &deps[stack[top_idx].dep_idx as usize];
-                        let dep_idx = dep.entry_id.get() as usize;
+                    while (stack[top_idx].next_dep as usize) < deps.len() {
+                        let dep = &deps[stack[top_idx].next_dep as usize];
+                        let dep_entry_idx = dep.entry_id.get() as usize;
                         let dep_name_hash = dependencies[dep.dep_id as usize].name_hash;
-                        match states[dep_idx] {
+                        match states[dep_entry_idx] {
                             State::Done => {
                                 stack[top_idx]
                                     .hasher
                                     .update(bun_core::bytes_of(&dep_name_hash));
                                 stack[top_idx]
                                     .hasher
-                                    .update(bun_core::bytes_of(&entry_hashes[dep_idx]));
+                                    .update(bun_core::bytes_of(&entry_hashes[dep_entry_idx]));
                             }
                             State::Ineligible => {
                                 // A dep that can't live in the global store poisons
                                 // this entry too: its symlink would point at a
                                 // project-local path.
-                                states[idx] = State::Ineligible;
-                                entry_hashes[idx] = 0;
+                                states[entry_idx] = State::Ineligible;
+                                entry_hashes[entry_idx] = 0;
                             }
                             State::InProgress => {
                                 // Cycle back-edge: the dep's hash isn't known yet.
@@ -1363,7 +1364,7 @@ pub(crate) fn install_isolated_packages(
                             State::Unvisited => {
                                 stack.push(StackFrame {
                                     id: dep.entry_id,
-                                    dep_idx: 0,
+                                    next_dep: 0,
                                     // Placeholder; reinitialized on next iteration before use.
                                     hasher: Wyhash::init(0),
                                 });
@@ -1372,24 +1373,24 @@ pub(crate) fn install_isolated_packages(
                                 break;
                             }
                         }
-                        if states[idx] == State::Ineligible {
+                        if states[entry_idx] == State::Ineligible {
                             break;
                         }
-                        stack[top_idx].dep_idx += 1;
+                        stack[top_idx].next_dep += 1;
                     }
 
                     if advanced {
                         continue;
                     }
 
-                    if states[idx] != State::Ineligible {
+                    if states[entry_idx] != State::Ineligible {
                         let mut h = stack[top_idx].hasher.final_();
                         // 0 is the "not eligible" sentinel.
                         if h == 0 {
                             h = 1;
                         }
-                        entry_hashes[idx] = h;
-                        states[idx] = State::Done;
+                        entry_hashes[entry_idx] = h;
+                        states[entry_idx] = State::Done;
                     }
                     stack.pop();
                 }


### PR DESCRIPTION
### Problem
- mordant `index_of_other_kind` in `src/install/isolated_install.rs`: "`states` is indexed by `dep_idx` here. Elsewhere in this function it is indexed by `_root_id` (1 place), and `dep_id` (the same kind as `dep_idx`) indexes `dependencies`. This looks like the wrong table" (`install_isolated_packages`, the `match states[dep_idx]` in the entry-hash DFS).
- `states[dep_idx]` is correct. `states` has one slot per store entry, and that `dep_idx` is `dep.entry_id.get()`, the store entry index of the dependency being visited. The lockfile `DependencyID` (`dep.dep_id`) is the one used to index `dependencies` on the line above.
- The names are what is wrong. Within a few lines `dep_idx` meant two different things (`StackFrame.dep_idx` is the cursor into the entry's dependency list; the local is a store entry index), and earlier in the same file (`build_store`'s workspace loop) `dep_idx` is a `DependencyID`. The root loop variable `_root_id` is a store entry index too, named as if unused.

### Fix
- Rename the three store entry indices in the DFS to `entry_idx`, `root_entry_idx` and `dep_entry_idx`, and the per-frame cursor `StackFrame.dep_idx` to `next_dep`. Every index into `states` / `entry_hashes` / `entry_node_ids` / `entry_dependencies` now says `entry`; nothing index-shaped is called `dep_*` unless it is a `DependencyID`. No behavior change: renames only.
- Not adding an index newtype for the tables: the ids are already newtyped (`store::entry::Id`, a `NewId<Entry>` distinct from `NewId<Node>`), and the per-entry tables are `MultiArrayList` column slices indexed with `id.get() as usize` at roughly 120 sites across this crate. Wrapping this one local scratch table would not stop a crossing on any of its siblings; making the columns typed is a crate-wide change, not this one.
- Drops `index_of_other_kind:src/install/isolated_install.rs` from `mordant-baseline.toml`.
- No test added: renames cannot change what any test observes, so nothing under `test/` can fail before and pass after. The baseline line is the before/after check instead: with it removed, the `mordant` CI job fails on the old names and passes on the new ones (shown below).
- Verified:
  - `cargo dylint --all -p bun_install --no-deps` (the `rust:mordant` command scoped to this crate) with the baseline line removed: reports the finding at `states[dep_idx]` without the rename, nothing with it (output below).
  - `MORDANT_BASELINE_WRITE=1` on this crate regenerates the `[bun_install]` section without this line. It also drops `always_unwrapped_option:src/install/PackageInstall.rs`, which is already stale on main (it disappears with or without this change), so that line is left for a later regenerate rather than folded in here.
  - `cargo check -p bun_install`, `cargo fmt -p bun_install -- --check`.

### Background
- The isolated linker builds a store: one entry per (package, peer set) that gets its own directory under `node_modules/.bun`, with per-entry columns (`entry_hashes`, `entry_node_ids`, `entry_dependencies`) indexed by `store::entry::Id`. Each entry's dependency list holds `DependenciesItem { entry_id, dep_id }`: the store entry the symlink points at, plus the lockfile `DependencyID` that names the alias.
- With the global virtual store enabled, `install_isolated_packages` runs an iterative DFS over entries to compute `entry_hashes`, a hash of each entry's resolved dependency closure used to share store directories across projects. `states` is that DFS's per-entry visit state; `StackFrame` is one entry being visited, and its cursor says how far through the entry's dependency list it is.
- mordant's `index_of_other_kind` reads index kinds off names only (the prefix before `_idx` / `_id`). It flagged `states` because it was indexed under two unrelated kinds (`_root_id`, `dep_idx`) while `dep_id` indexed a table of its own kind; after the rename every index into `states` carries the `entry` kind.

<details>
<summary>mordant output with the baseline line removed</summary>

Without the rename:

```
warning: `states` is indexed by `dep_idx` here. Elsewhere in this function it is indexed by `_root_id` (1 place), and `dep_id` (the same kind as `dep_idx`) indexes `dependencies`. This looks like the wrong table
    --> src/install/isolated_install.rs:1337:31
     |
1337 |                         match states[dep_idx] {
     |                               ^^^^^^^^^^^^^^^
     |
note: `states` indexed the usual way
    --> src/install/isolated_install.rs:1200:20
     |
1200 |                 if states[_root_id] != State::Unvisited {
     |                    ^^^^^^^^^^^^^^^^
     = note: `index_of_other_kind` over the mordant baseline (0 recorded for src/install/isolated_install.rs)

warning: mordant: 1 finding(s) over the baseline in bun_install
```

With the rename: no warnings, `target/mordant/over-baseline.txt` not written.
</details>

