### PR TITLE
install: rename with_alias_of's version parameter and clear its mordant baseline entry

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -18,8 +18,6 @@
 "tuple_wants_struct:src/css/values/color.rs" = 5
 
 [bun_install]
-"always_unwrapped_option:src/install/PackageInstall.rs" = 1
-"arg_named_like_other_param:src/install/PackageManager/PackageJSONEditor.rs" = 3
 "arg_named_like_other_param:src/install/resolution.rs" = 1
 "bare_bool_args:src/install/isolated_install.rs" = 1
 "defaulted_failure:src/install/npm.rs" = 1

--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -52,25 +52,21 @@ fn split_npm_alias(literal: &[u8]) -> Option<(&[u8], &[u8])> {
     ))
 }
 
-/// `version_literal` behind `from`'s `npm:<name>@` (if any), unless it already names a target.
-fn with_alias_of<'a>(
-    arena: &'a bun_alloc::Arena,
-    from: &[u8],
-    version_literal: &'a [u8],
-) -> &'a [u8] {
+/// `version` behind `from`'s `npm:<name>@` (if any), unless it already names a target.
+fn with_alias_of<'a>(arena: &'a bun_alloc::Arena, from: &[u8], version: &'a [u8]) -> &'a [u8] {
     match split_npm_alias(from) {
-        Some((alias, _)) if split_npm_alias(version_literal).is_none() => {
+        Some((alias, _)) if split_npm_alias(version).is_none() => {
             let mut v = Vec::new();
             write!(
                 &mut v,
                 "{}@{}",
                 bstr::BStr::new(alias),
-                bstr::BStr::new(version_literal)
+                bstr::BStr::new(version)
             )
             .expect("infallible: in-memory write");
             arena_str(arena, &v)
         }
-        _ => version_literal,
+        _ => version,
     }
 }
 


### PR DESCRIPTION
### Problem
- `bun run rust:mordant` reports three `arg_named_like_other_param` findings in `src/install/PackageManager/PackageJSONEditor.rs` (lines 520, 744 and 1372 on main), all of the shape `with_alias_of(arena, version_literal, b"latest")`: the `--latest` rewrites in `edit_update_entries`, `edit_catalogs_before_update` and the unresolved-request path of `edit`.
- The helper is declared `with_alias_of(arena, from, version_literal)`: `from` is the literal whose `npm:<name>` alias is kept, the last parameter is the version written behind it. At the three sites the caller's `version_literal` is the existing package.json value, so it is bound to `from` while the callee also has a same-typed parameter called `version_literal`, which is what the lint flags.
- None of the calls is transposed. The existing value supplies the alias and `latest` is the version to put behind it. With the arguments the other way round, `split_npm_alias(b"latest")` is `None` and the helper returns the existing literal unchanged, so `bun update --latest` would stop rewriting anything. The alias cases in `test/cli/install/bun-update.test.ts` and the `--latest` cases in `test/cli/install/catalogs.test.ts` cover the current order.

### Fix
- Rename the callee's last parameter from `version_literal` to `version` (body and doc comment). Call sites are untouched and nothing changes at runtime, so there is no new test.
- `mordant-baseline.toml`, `[bun_install]` section, as `MORDANT_BASELINE_WRITE=1 cargo dylint --all -p bun_install` regenerates it at the current pin:
  - the `arg_named_like_other_param:...PackageJSONEditor.rs = 3` entry goes away (this change);
  - `always_unwrapped_option:src/install/PackageInstall.rs = 1` goes away as well. That entry was carried over by name in #38875, but the `walker: Option<Walker>` field it counted was removed in #38271, so it has been an unused allowance since then. Happy to drop this hunk if the PR should stay strictly scoped.
  - The sections of the other workspace crates the run covers came back identical to main.
- Verification:
  - `cargo dylint --all -p bun_install` with this baseline: without the rename it reports the three sites above (`bun_install 3` in `target/mordant/over-baseline.txt`); with it, nothing over the baseline.
  - `bun bd`, then `bun bd test test/cli/install/bun-update.test.ts -t alias` (10 pass) and `bun bd test test/cli/install/catalogs.test.ts -t latest` (12 pass).

### Background
- `arg_named_like_other_param` is a mordant lint. It fires when a call argument is spelled like a different parameter of the callee than the one it is bound to and the two parameters have the same type, because that is what a swapped call looks like. When the call is right, the fix is a rename so the names stop overlapping; here the overlap came from the callee's parameter name, so that is the one renamed.
- `mordant-baseline.toml` is a ratchet: it records the accepted finding count per (lint, file), and CI only fails on findings above the recorded count. Clearing findings means deleting or lowering the entry, otherwise the allowance would hide new findings of the same lint in that file.
- An npm alias is a package.json value like `"foo": "npm:bar@^1.0.0"`: `bar` is installed under the name `foo`. `with_alias_of` exists so that when bun rewrites the version part of such a value (to `latest` before resolving, or to the resolved range afterwards) the `npm:bar@` prefix survives.
