### PR TITLE
transpiler cache: convert the cache file length to i64 once in save

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -38,7 +38,6 @@
 [bun_jsc]
 "bare_bool_args:src/jsc/ZigStackFrame.rs" = 1
 "defaulted_failure:src/jsc/ConsoleObject.rs" = 4
-"narrowed_two_ways:src/jsc/RuntimeTranspilerCache.rs" = 1
 "reimplemented_helper:src/jsc/webcore_types.rs" = 1
 "same_match_twice:src/jsc/VirtualMachine.rs" = 1
 

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -383,8 +383,7 @@ impl Entry {
             let vecs: &[sys::PlatformIoVecConst] = &vecs_buf[0..vecs_i];
 
             let mut position: i64 = 0;
-            let end_position =
-                Metadata::SIZE + output_bytes.len() + sourcemap.len() + esm_record.len();
+            let file_len = Metadata::SIZE + output_bytes.len() + sourcemap.len() + esm_record.len();
 
             #[cfg(debug_assertions)]
             {
@@ -394,22 +393,12 @@ impl Entry {
                     // `uv_buf_t::len` is `ULONG` (u32) on Windows, `usize` on POSIX.
                     total += v.len as usize;
                 }
-                debug_assert!(end_position == total);
+                debug_assert!(file_len == total);
             }
-            debug_assert!(
-                end_position as i64
-                    == i64::try_from(
-                        sourcemap.len() + output_bytes.len() + Metadata::SIZE + esm_record.len()
-                    )
-                    .unwrap()
-            );
 
-            let _ = sys::preallocate_file(
-                tmpfile.fd.cast(),
-                0,
-                i64::try_from(end_position).expect("int cast"),
-            );
-            while (position as usize) < end_position {
+            let end_position = i64::try_from(file_len).expect("int cast");
+            let _ = sys::preallocate_file(tmpfile.fd.cast(), 0, end_position);
+            while position < end_position {
                 let written = sys::pwritev(tmpfile.fd, vecs, position)?;
                 if written == 0 {
                     return Err(crate::CrateError::WriteFailed);


### PR DESCRIPTION
### Problem
- `Entry::save` in `src/jsc/RuntimeTranspilerCache.rs` narrowed the same `usize` byte count (`end_position`) to `i64` two different ways: a bare `end_position as i64` inside a `debug_assert!` (old line 400), and `i64::try_from(end_position).expect("int cast")` for the `preallocate_file` call right after it (old line 410).
- mordant reports this as `narrowed_two_ways`; it is the `narrowed_two_ways:src/jsc/RuntimeTranspilerCache.rs` entry in `mordant-baseline.toml`.
- The `debug_assert!` holding the `as` compared the sum with a checked conversion of the same sum, so it only duplicated the `try_from` on the next line.

### Fix
- The `usize` sum is now `file_len`. The debug block still compares it against the iovec total as `usize`, and it is converted once, with `i64::try_from`, into `end_position: i64`.
- `preallocate_file` and the `pwritev` loop both take that `i64`, so the loop condition compares two `i64`s and the old `position as usize` goes away as well. The duplicate `debug_assert!` is deleted.
- No behavior change: the one `try_from(...).expect("int cast")` is the same check the old code did before `preallocate_file`, and `position` is never negative, so the old `usize` comparison and the new `i64` comparison agree for every length that reaches this code.
- Removed the baseline entry for this file.
- Verified with `bun run rust:mordant:baseline`: the regenerated file no longer contains this entry. It also drops `always_unwrapped_option:src/install/PackageInstall.rs` and `narrowed_two_ways:src/runtime/node/node_crypto_binding.rs`, which were fixed on main separately; those lines are left alone here so this PR stays one finding.
- Verified with `bun run rust:mordant` (bun_jsc rechecked): no warnings and no `target/mordant/over-baseline.txt`.
- Verified with `bun bd test test/cli/run/transpiler-cache.test.ts`: 13 pass.
- No new test: there is no behavior to observe (every input that reaches `save` takes the same path before and after), and `save` is already exercised by the transpiler cache tests above. The check that distinguishes the two versions is mordant itself, which runs on this PR as the `mordant` job in rust-lints.yml with the baseline entry removed.

### Background
- `save` writes one cache file with a single gather write (`pwritev`): a fixed-size metadata header, then the transpiled output, the sourcemap and the serialized ESM record. The lengths are `usize`; `preallocate_file` (fallocate) and the `pwritev` offset take `i64`, which is the only reason the count is narrowed at all.
- mordant is the Rust lint pack CI runs as an advisory ratchet (`bun run rust:mordant`). `mordant-baseline.toml` holds the pre-existing findings per (lint, file); fixing one lets its line be removed.
