### PR TITLE
bake: resize the graph trace bits through GraphTraceState::bits

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -18,7 +18,6 @@
 "tuple_wants_struct:src/css/values/color.rs" = 5
 
 [bun_install]
-"always_unwrapped_option:src/install/PackageInstall.rs" = 1
 "arg_named_like_other_param:src/install/PackageManager/PackageJSONEditor.rs" = 3
 "arg_named_like_other_param:src/install/resolution.rs" = 1
 "bare_bool_args:src/install/isolated_install.rs" = 1
@@ -69,7 +68,6 @@
 "error_collapsed_to_bool:src/runtime/ffi/ffi_body.rs" = 1
 "field_valid_only_when:src/runtime/cli/filter_run.rs" = 1
 "field_valid_only_when:src/runtime/shell/builtin/rm.rs" = 1
-"narrowed_two_ways:src/runtime/node/node_crypto_binding.rs" = 1
 "parallel_vecs:src/runtime/api/html_rewriter.rs" = 1
 "parallel_vecs:src/runtime/bake/dev_server/incremental_graph.rs" = 1
 "reimplemented_helper:src/runtime/api/bun/Terminal.rs" = 1
@@ -78,7 +76,6 @@
 "same_match_twice:src/runtime/api/YAMLObject.rs" = 1
 "same_match_twice:src/runtime/api/bun/h2_frame_parser.rs" = 1
 "same_match_twice:src/runtime/api/csrf_jsc.rs" = 1
-"same_match_twice:src/runtime/bake/dev_server/mod.rs" = 1
 "same_match_twice:src/runtime/bake/production.rs" = 2
 "same_match_twice:src/runtime/cli/pack_command.rs" = 1
 "same_match_twice:src/runtime/cli/publish_command.rs" = 1

--- a/src/runtime/bake/dev_server/mod.rs
+++ b/src/runtime/bake/dev_server/mod.rs
@@ -247,10 +247,7 @@ impl GraphTraceState {
     }
 
     pub(crate) fn resize(&mut self, side: Side, new_size: usize) -> Result<(), crate::Error> {
-        let b = match side {
-            Side::Client => &mut self.client_bits,
-            Side::Server => &mut self.server_bits,
-        };
+        let b = self.bits(side);
         if b.unmanaged.bit_length < new_size {
             b.resize(new_size, false)?;
         }


### PR DESCRIPTION
### Problem
- mordant `same_match_twice` finding in `src/runtime/bake/dev_server/mod.rs`: `GraphTraceState::resize` matched on `Side` to pick `client_bits` or `server_bits`, and `GraphTraceState::bits` (a few lines above it) contains the identical match.
- The mapping lived in two places, so adding a side or renaming a field had to be done twice.

### Fix
- `resize` now gets its bit set through `self.bits(side)`. `bits` was already the one place the mapping is written; the mapping selects a `GraphTraceState` field, so it stays a method on that struct rather than moving onto `Side`.
- No behavior change: `bits` returns the same `&mut DynamicBitSet` the inline match produced, and the grow-if-smaller logic after it is untouched.
- `mordant-baseline.toml` regenerated with `bun run rust:mordant:baseline`. Besides this file's `same_match_twice` entry, the regeneration drops two entries whose findings are already gone on main (`always_unwrapped_option` in `src/install/PackageInstall.rs`, `narrowed_two_ways` in `src/runtime/node/node_crypto_binding.rs`), so the baseline matches what mordant reports today.
- Verified:
  - `bun bd test test/bake/dev/css.test.ts` (the only caller of `resize` is the CSS edge attachment path in `incremental_graph.rs`): 15 pass.
  - `bun bd test test/bake/dev/hot.test.ts test/bake/dev/html.test.ts test/bake/dev/esm.test.ts test/bake/dev/incremental-graph-edge-deletion.test.ts`: 39 pass.
  - `bun run rust:mordant` with the baseline entry removed: reports this site on the unfixed source (`target/mordant/over-baseline.txt` = `bun_runtime 1`), reports nothing with this change.

### Background
- `GraphTraceState` holds one bit set per bundle graph side (client, server). The dev server uses it as the visited set while tracing imports through the incremental graph during hot updates.
- mordant is the advisory lint pack run by the `mordant` job in `rust-lints.yml`. `mordant-baseline.toml` records the per-(lint, file) counts of findings that predate the job; a PR fails that job only when it adds findings over the baseline, and removing entries lowers the ratchet once the findings are gone.
