### PR TITLE
pack: name the scope and dependency locals in iterate_bundled_deps

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -52,7 +52,6 @@
 [bun_runtime]
 "arg_named_like_other_param:src/runtime/cli/install_completions_command.rs" = 4
 "arg_named_like_other_param:src/runtime/cli/open.rs" = 1
-"arg_named_like_other_param:src/runtime/cli/pack_command.rs" = 1
 "arg_named_like_other_param:src/runtime/node/path.rs" = 2
 "bare_bool_args:src/runtime/api.rs" = 2
 "bare_bool_args:src/runtime/api/bun/h2_frame_parser.rs" = 1

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -889,14 +889,15 @@ fn iterate_bundled_deps(
             continue;
         }
 
-        let _entry_name = entry.name.slice_u8();
+        let entry_name = entry.name.slice_u8();
 
-        if strings::starts_with_char(_entry_name, b'@') {
-            let concat = entry_subpath(b"node_modules", _entry_name)?;
+        if strings::starts_with_char(entry_name, b'@') {
+            let scope_name = entry_name;
+            let scope_subpath = entry_subpath(b"node_modules", scope_name)?;
 
-            let scoped_dir: Dir = match dir_open_dir_z(
+            let scope_dir: Dir = match dir_open_dir_z(
                 root_dir,
-                &concat,
+                &scope_subpath,
                 bun_sys::OpenDirOptions {
                     iterate: true,
                     ..Default::default()
@@ -906,32 +907,32 @@ fn iterate_bundled_deps(
                 Err(_) => continue,
             };
 
-            let mut scoped_iter = DirIterator::iterate(Fd::from_std_dir(&scoped_dir));
-            while let Some(sub_entry) = scoped_iter.next().ok().flatten() {
-                let entry_name = entry_subpath(_entry_name, sub_entry.name.slice_u8())?;
+            let mut scope_iter = DirIterator::iterate(Fd::from_std_dir(&scope_dir));
+            while let Some(scope_entry) = scope_iter.next().ok().flatten() {
+                let dep_name = entry_subpath(scope_name, scope_entry.name.slice_u8())?;
 
                 let Some(dep) = bundled_deps.iter_mut().find(|dep| {
                     debug_assert!(dep.from_root_package_json);
-                    strings::eql_long(entry_name.as_bytes(), &dep.name, true)
+                    strings::eql_long(dep_name.as_bytes(), &dep.name, true)
                 }) else {
                     continue;
                 };
 
-                let entry_subpath_ = entry_subpath(b"node_modules", entry_name.as_bytes())?;
+                let dep_subpath = entry_subpath(b"node_modules", dep_name.as_bytes())?;
 
-                let dedupe_entry = dedupe.get_or_put(entry_subpath_.as_bytes())?;
+                let dedupe_entry = dedupe.get_or_put(dep_subpath.as_bytes())?;
                 dep.was_packed = true;
                 if dedupe_entry.found_existing {
                     // already got to it in `add_bundled_dep` below
                     continue;
                 }
 
-                let subdir = open_subdir(&dir, entry_name.as_bytes(), &entry_subpath_);
+                let subdir = open_subdir(&dir, dep_name.as_bytes(), &dep_subpath);
                 add_bundled_dep(
                     stats,
                     log,
                     root_dir,
-                    DirInfo(subdir, entry_subpath_.as_bytes().into(), 2),
+                    DirInfo(subdir, dep_subpath.as_bytes().into(), 2),
                     &mut bundled_pack_queue,
                     &mut dedupe,
                     &mut additional_bundled_deps,
@@ -939,29 +940,29 @@ fn iterate_bundled_deps(
                 )?;
             }
         } else {
-            let entry_name = _entry_name;
+            let dep_name = entry_name;
             let Some(dep) = bundled_deps.iter_mut().find(|dep| {
                 debug_assert!(dep.from_root_package_json);
-                strings::eql_long(entry_name, &dep.name, true)
+                strings::eql_long(dep_name, &dep.name, true)
             }) else {
                 continue;
             };
 
-            let entry_subpath_ = entry_subpath(b"node_modules", entry_name)?;
+            let dep_subpath = entry_subpath(b"node_modules", dep_name)?;
 
-            let dedupe_entry = dedupe.get_or_put(entry_subpath_.as_bytes())?;
+            let dedupe_entry = dedupe.get_or_put(dep_subpath.as_bytes())?;
             dep.was_packed = true;
             if dedupe_entry.found_existing {
                 // already got to it in `add_bundled_dep` below
                 continue;
             }
 
-            let subdir = open_subdir(&dir, entry_name, &entry_subpath_);
+            let subdir = open_subdir(&dir, dep_name, &dep_subpath);
             add_bundled_dep(
                 stats,
                 log,
                 root_dir,
-                DirInfo(subdir, entry_subpath_.as_bytes().into(), 2),
+                DirInfo(subdir, dep_subpath.as_bytes().into(), 2),
                 &mut bundled_pack_queue,
                 &mut dedupe,
                 &mut additional_bundled_deps,

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -1086,6 +1086,37 @@ describe("bundledDependnecies", () => {
     ]);
   });
 
+  test("scoped names match on scope and name together", async () => {
+    // `bundled` exists unscoped, in @scope and in @other; only the first two are bundled.
+    // @scope/not-bundled shares its scope directory with a bundled dep.
+    const packages = ["bundled", "@scope/bundled", "@scope/not-bundled", "@other/bundled"];
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "pack-bundled-same-name-across-scopes",
+          version: "1.0.0",
+          dependencies: Object.fromEntries(packages.map(name => [name, "1.0.0"])),
+          bundledDependencies: ["@scope/bundled", "bundled"],
+        }),
+      ),
+      ...packages.map(name =>
+        write(join(packageDir, "node_modules", name, "package.json"), JSON.stringify({ name, version: "1.0.0" })),
+      ),
+    ]);
+
+    const { out } = await pack(packageDir, bunEnv);
+    expect(out).toContain("Total files: 3");
+    expect(out).toContain("Bundled deps: 2");
+
+    const tarball = readTarball(join(packageDir, "pack-bundled-same-name-across-scopes-1.0.0.tgz"));
+    expect(tarball.entries).toMatchObject([
+      { "pathname": "package/package.json" },
+      { "pathname": "package/node_modules/@scope/bundled/package.json" },
+      { "pathname": "package/node_modules/bundled/package.json" },
+    ]);
+  });
+
   test("ignore deps that aren't directories", async () => {
     await Promise.all([
       write(


### PR DESCRIPTION
### Problem
- mordant's `arg_named_like_other_param` flags `iterate_bundled_deps` in `src/runtime/cli/pack_command.rs`: `_entry_name` is passed as `entry_subpath`'s `dir_subpath` parameter while the callee also has an `entry_name` parameter of the same type, so the call reads as transposed.
- The call is not transposed. In that branch `_entry_name` is the name of a scope directory under `node_modules` (`@scope`), so it is the directory half of the join, and the result (`@scope/pkg`) is the bundled dependency's name. The code then stored that result in a local called `entry_name`, which is what made the names contradict the callee.
- Checked the release binary before touching anything: with `bundledDependencies: ["@scope/bundled", "bundled"]` and `node_modules/{bundled,@scope/bundled,@scope/not-bundled,@other/bundled}` on disk, `bun pm pack` emits exactly `package/node_modules/@scope/bundled/package.json` and `package/node_modules/bundled/package.json`, which is the correct layout.

### Fix
- Rename the locals to say what they hold: `scope_name` / `scope_subpath` / `scope_dir` for the scope directory, `dep_name` / `dep_subpath` for the bundled dependency, in both the scoped and unscoped branches. No behavior change. The underscore-prefixed name came over from the Zig version, where it worked around the no-shadowing rule.
- Drop the file's `arg_named_like_other_param` line from `mordant-baseline.toml`.
- Add `scoped names match on scope and name together` to `test/cli/install/bun-pack.test.ts`, which pins the layout above. The existing scoped tests only had bundled packages inside the scope, so nothing checked that a non-bundled sibling in the same scope or a same-named package in another scope stays out of the tarball. Because the behavior was already right, this test also passes on the release binary; it documents what the flagged join builds rather than proving a behavior change.
- Verified:
  - `bun bd test test/cli/install/bun-pack.test.ts`: 80 pass.
  - `bun run rust:mordant` from a clean lint target with this baseline: no `target/mordant/over-baseline.txt`.
  - Same run with the source change stashed: `over-baseline.txt` contains `bun_runtime 1`, pointing at this call site.

### Background
- `entry_subpath(dir_subpath, entry_name)` joins a directory subpath and a child name with `/` (just the name when the directory part is empty). `iterate_bundled_deps` also uses it to build a scoped package name, since `@scope/pkg` is the scope directory joined with the package directory.
- `mordant-baseline.toml` is a ratchet: it records the accepted finding count per (lint, file), and the mordant CI job only reports findings above those counts. Fixing a finding means removing its line so the count cannot creep back up.

<details>
<summary>Other baseline lines `bun run rust:mordant:baseline` would drop today</summary>

Regenerating also removes `always_unwrapped_option:src/install/PackageInstall.rs` and `narrowed_two_ways:src/runtime/node/node_crypto_binding.rs`, whose findings were fixed by earlier PRs without a regeneration. They are unrelated to this change, so this PR only removes the `pack_command.rs` line; the two stale lines are harmless until someone regenerates.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-pack.test.ts

<!-- robobun:evidence:end -->