### PR TITLE
sql: set a cell's column index and kind in one place

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -102,7 +102,6 @@
 
 [bun_sql_jsc]
 "bare_bool_args:src/sql_jsc/shared/datetime_text.rs" = 1
-"same_match_twice:src/sql_jsc/mysql/protocol/ResultSet.rs" = 1
 
 [bun_sys]
 "error_collapsed_to_bool:src/sys/lib.rs" = 4

--- a/src/sql_jsc/mysql/protocol/ResultSet.rs
+++ b/src/sql_jsc/mysql/protocol/ResultSet.rs
@@ -7,7 +7,6 @@ use bun_sql::mysql::protocol::any_mysql_error::AnyMySQLError;
 use bun_sql::mysql::protocol::column_definition41::ColumnFlags;
 use bun_sql::mysql::protocol::encode_int::decode_length_int;
 use bun_sql::mysql::protocol::new_reader::{NewReader, ReaderContext};
-use bun_sql::shared::ColumnIdentifier as NameOrIndex;
 use bun_sql::shared::Data;
 use bun_sql::shared::SQLQueryResultMode;
 
@@ -224,16 +223,10 @@ impl<'a> Row<'a> {
                         self.parse_value_and_set_cell(value, column, &string_data);
                     }
                 }
-                value.index = match column.name_or_index {
-                    // The indexed columns can be out of order.
-                    NameOrIndex::Index(i) => i,
-                    _ => u32::try_from(index).expect("int cast"),
-                };
-                value.is_indexed_column = match column.name_or_index {
-                    NameOrIndex::Duplicate => 2,
-                    NameOrIndex::Index(_) => 1,
-                    NameOrIndex::Name(_) => 0,
-                };
+                value.set_column(
+                    u32::try_from(index).expect("int cast"),
+                    &column.name_or_index,
+                );
             } else {
                 return Err(AnyMySQLError::InvalidResultRow);
             }
@@ -291,16 +284,7 @@ impl<'a> Row<'a> {
                         .unwrap_or(AnyMySQLError::InvalidBinaryValue),
                 })?;
             }
-            value.index = match column.name_or_index {
-                // The indexed columns can be out of order.
-                NameOrIndex::Index(idx) => idx,
-                _ => u32::try_from(i).expect("int cast"),
-            };
-            value.is_indexed_column = match column.name_or_index {
-                NameOrIndex::Duplicate => 2,
-                NameOrIndex::Index(_) => 1,
-                NameOrIndex::Name(_) => 0,
-            };
+            value.set_column(u32::try_from(i).expect("int cast"), &column.name_or_index);
         }
 
         self.values = scopeguard::ScopeGuard::into_inner(cells);

--- a/src/sql_jsc/postgres/DataCell.rs
+++ b/src/sql_jsc/postgres/DataCell.rs
@@ -12,7 +12,6 @@ use bun_sql::shared::sql_query_result_mode::SQLQueryResultMode as PostgresSQLQue
 
 pub(crate) use crate::shared::sql_data_cell::SQLDataCell;
 pub use crate::shared::sql_data_cell::{Array, Flags, Raw, Tag, TypedArray, Value};
-use bun_sql::shared::column_identifier::ColumnIdentifier;
 
 type Result<T, E = AnyPostgresError> = core::result::Result<T, E>;
 
@@ -1272,20 +1271,10 @@ impl<'a> Putter<'a> {
             };
         }
         self.count += 1;
-        cell.index = match &field.name_or_index {
-            // The indexed columns can be out of order.
-            ColumnIdentifier::Index(i) => *i,
-            _ => index,
-        };
-
         // TODO: when duplicate and we know the result will be an object
         // and not a .values() array, we can discard the data
         // immediately.
-        cell.is_indexed_column = match &field.name_or_index {
-            ColumnIdentifier::Duplicate => 2,
-            ColumnIdentifier::Index(_) => 1,
-            ColumnIdentifier::Name(_) => 0,
-        };
+        cell.set_column(index, &field.name_or_index);
         Ok(true)
     }
 

--- a/src/sql_jsc/shared/SQLDataCell.rs
+++ b/src/sql_jsc/shared/SQLDataCell.rs
@@ -269,18 +269,27 @@ impl SQLDataCell {
     /// the right named/indexed/duplicate flag into `toJS`.
     #[inline]
     pub(crate) fn null_for_column(position: u32, column: &ColumnIdentifier) -> SQLDataCell {
-        SQLDataCell {
-            is_indexed_column: match column {
-                ColumnIdentifier::Duplicate => 2,
-                ColumnIdentifier::Index(_) => 1,
-                ColumnIdentifier::Name(_) => 0,
-            },
-            index: match column {
-                ColumnIdentifier::Index(i) => *i,
-                _ => position,
-            },
-            ..SQLDataCell::default()
-        }
+        let mut cell = SQLDataCell::null();
+        cell.set_column(position, column);
+        cell
+    }
+
+    /// Tags the cell with the column it was decoded for, in the encoding
+    /// SQLClient.cpp's `DataCell` reads: `is_indexed_column` is 0 for a named
+    /// column, 1 for an all-digits name (the object key is that number, not the
+    /// ordinal `position`, so indexed cells can land out of order) and 2 for a
+    /// duplicate, which object-mode results skip.
+    #[inline]
+    pub(crate) fn set_column(&mut self, position: u32, column: &ColumnIdentifier) {
+        self.is_indexed_column = match column {
+            ColumnIdentifier::Duplicate => 2,
+            ColumnIdentifier::Index(_) => 1,
+            ColumnIdentifier::Name(_) => 0,
+        };
+        self.index = match column {
+            ColumnIdentifier::Index(i) => *i,
+            _ => position,
+        };
     }
 
     #[inline]


### PR DESCRIPTION
### Problem
- The mapping from a column's `ColumnIdentifier` to the two cell fields SQLClient.cpp reads (`index`, `is_indexed_column`) was written out four times: `mysql/protocol/ResultSet.rs` (`decode_text` and `decode_binary`), `postgres/DataCell.rs` (`Putter::put_impl`), and `shared/SQLDataCell.rs` (`null_for_column`).
- mordant flags the two copies in `ResultSet.rs` as `same_match_twice` (the entry in `mordant-baseline.toml`); a change to one copy would not reach the others.

### Fix
- Adds `SQLDataCell::set_column(position, &ColumnIdentifier)`, which holds the mapping once; the four sites call it (`null_for_column` is now `null()` + `set_column`).
- Pure refactor: each site sets the same two fields to the same values as before, in the same place in its loop. Net -19 lines.
- Removes the now-stale `same_match_twice:src/sql_jsc/mysql/protocol/ResultSet.rs` baseline entry. The CI mordant job is the check that nothing else moved in the baseline.
- Verified with the debug build against a local MariaDB and Postgres:
  - `test/js/sql/sql-mysql-binary-null-indexed.test.ts`, `sql-mysql-column-name-digits.test.ts`, `sql-mariadb-json.test.ts` (the digit-named column tests cover both MySQL decoders).
  - `test/js/sql/sql.test.ts -t "data row that omits columns"` (covers `null_for_column` and `put_impl` together, with duplicate and digit-named columns).
  - `postgres-datarow-overrun`, `postgres-multi-statement-fields`, `postgres-binary-array-bounds`, `sql-mysql-mediumint`, `sql-mysql-bigint-out-of-range`, `sql-mysql-datetime-roundtrip`: all pass.
  - A probe running the duplicate / digit-named / mixed / NULL-in-indexed / 70-column queries from the suites through objects, `.values()`, `.raw()` and `.simple()` on both drivers produced byte-identical output on this build and on released bun 1.4.0 (the debug build also keeps the `isIndexedColumn`/`isNamedColumn` asserts in SQLClient.cpp live).
- The container-backed matrix in `sql-mysql.test.ts` / `sql.test.ts` needs docker, which this environment does not have; CI runs it.

### Background
- `SQLDataCell` is the `#[repr(C)]` cell both drivers fill per column and hand to `JSC__constructObjectFromDataCell` (SQLClient.cpp) to build the row object.
- `ColumnIdentifier` is how a result column's name is classified when the column list arrives: `Name` (an ordinary key), `Index(n)` (the name is all digits, so the value is stored at array index `n`, which can be out of order and larger than the column count), or `Duplicate` (an earlier occurrence of a repeated name, which object results skip; the last occurrence wins).
- On the cell, `is_indexed_column` carries that classification as 0 / 1 / 2, and `index` is the `Index` number or, otherwise, the column's ordinal position in the row.
