### PR TITLE
run: name the flags passed to configure_env_for_run

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -57,7 +57,6 @@
 "bare_bool_args:src/runtime/api.rs" = 2
 "bare_bool_args:src/runtime/api/bun/h2_frame_parser.rs" = 1
 "bare_bool_args:src/runtime/bake/dev_server/incremental_graph.rs" = 1
-"bare_bool_args:src/runtime/cli/run_command.rs" = 1
 "bare_bool_args:src/runtime/dns_jsc/dns.rs" = 1
 "bare_bool_args:src/runtime/node/types.rs" = 4
 "defaulted_failure:src/runtime/ffi/ffi_body.rs" = 1

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -7,7 +7,7 @@ use bstr::BStr;
 
 use crate::cli::command::ContextData;
 use crate::cli::{self, Command};
-use crate::run_command::RunCommand as Run;
+use crate::run_command::{ConfigureEnvOptions, RunCommand as Run};
 
 use bun_alloc::AllocError;
 use bun_ast::ExprData;
@@ -745,8 +745,15 @@ impl BunxCommand {
         let mut this_transpiler_slot = ::core::mem::MaybeUninit::<Transpiler<'static>>::uninit();
         let mut original_path: Vec<u8> = Vec::new();
 
-        let root_dir_info =
-            Run::configure_env_for_run(ctx, &mut this_transpiler_slot, None, true, true)?;
+        let root_dir_info = Run::configure_env_for_run(
+            ctx,
+            &mut this_transpiler_slot,
+            None,
+            ConfigureEnvOptions {
+                log_errors: true,
+                store_root_fd: true,
+            },
+        )?;
         // SAFETY: `configure_env_for_run` returned `Ok`, so the slot is fully
         // initialized via `MaybeUninit::write`.
         let this_transpiler = unsafe { this_transpiler_slot.assume_init_mut() };

--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -8,7 +8,7 @@ use crate::api::bun::process::SpawnResultExt as _;
 use crate::api::bun::process::{self as spawn, Process, Rusage, SpawnOptions, Status};
 use crate::cli::Command;
 use crate::cli::filter_arg as FilterArg;
-use crate::cli::run_command::RunCommand;
+use crate::cli::run_command::{ConfigureEnvOptions, RunCommand};
 use bun_collections::StringHashMap;
 use bun_core::{Global, Output};
 use bun_core::{ZStr, strings};
@@ -790,7 +790,15 @@ pub(crate) fn run_scripts_with_filter(
     // `RunCommand::configure_env_for_run(...) -> Result<Transpiler, _>`; until then
     // pass `&mut MaybeUninit<Transpiler>` (zeroed() is invalid: Transpiler is not #[repr(C)] POD).
     let mut this_transpiler = core::mem::MaybeUninit::<bun_bundler::Transpiler<'static>>::uninit();
-    let _ = RunCommand::configure_env_for_run(&mut *ctx, &mut this_transpiler, None, true, false)?;
+    let _ = RunCommand::configure_env_for_run(
+        &mut *ctx,
+        &mut this_transpiler,
+        None,
+        ConfigureEnvOptions {
+            log_errors: true,
+            store_root_fd: false,
+        },
+    )?;
     // SAFETY: configure_env_for_run fully initializes the out-param on Ok.
     let mut this_transpiler = unsafe { this_transpiler.assume_init() };
 

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -15,7 +15,7 @@ use bun_paths as path;
 
 use crate::Command;
 use crate::filter_arg as FilterArg;
-use crate::run_command::RunCommand;
+use crate::run_command::{ConfigureEnvOptions, RunCommand};
 
 // `bun.spawn` (Process/Status/SpawnOptions/Rusage/spawnProcess) —
 // lives under crate::api::bun::process.
@@ -878,7 +878,15 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
     // Out-param init pattern.
     let mut this_transpiler_slot =
         ::core::mem::MaybeUninit::<bun_bundler::Transpiler<'static>>::uninit();
-    let _ = RunCommand::configure_env_for_run(ctx, &mut this_transpiler_slot, None, true, false)?;
+    let _ = RunCommand::configure_env_for_run(
+        ctx,
+        &mut this_transpiler_slot,
+        None,
+        ConfigureEnvOptions {
+            log_errors: true,
+            store_root_fd: false,
+        },
+    )?;
     // SAFETY: `configure_env_for_run` fully writes the slot on the success path.
     let this_transpiler = unsafe { this_transpiler_slot.assume_init_mut() };
     let cwd: &[u8] = bun_resolver::fs::FileSystem::get().top_level_dir;

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -25,7 +25,7 @@ use bun_paths::{self as path, PathBuffer, SEP_STR};
 // borrow_subslice/length live on `cow_slice::CowSliceZ`).
 use bun_ptr::cow_slice::CowSlice;
 type CowString = CowSlice<u8>;
-use crate::cli::run_command::RunCommand;
+use crate::cli::run_command::{ConfigureEnvOptions, RunCommand};
 use bun_core::ZBox;
 use bun_core::{ZStr, strings};
 use bun_paths::resolve_path;
@@ -2007,8 +2007,10 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
         &mut *ctx.command_ctx,
         &mut this_transpiler,
         Some(pm_env(ctx.manager)),
-        ctx.manager.options.log_level != LogLevel::Silent,
-        false,
+        ConfigureEnvOptions {
+            log_errors: ctx.manager.options.log_level != LogLevel::Silent,
+            store_root_fd: false,
+        },
     ) {
         if matches!(err, crate::Error::Alloc(_)) {
             return Err(PackError::OutOfMemory);

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -90,6 +90,20 @@ impl Default for ExecCfg {
     }
 }
 
+/// Per-caller knobs for [`RunCommand::configure_env_for_run`] and
+/// [`RunCommand::configure_env_for_run_without_linker`].
+#[derive(Clone, Copy)]
+pub(crate) struct ConfigureEnvOptions {
+    /// Report a current directory that cannot be read on stderr. When `false`
+    /// it is only returned, as [`crate::Error::CouldntReadCurrentDirectory`].
+    pub(crate) log_errors: bool,
+    /// Keep the current directory's fd open on the returned `DirInfo` (only
+    /// that one: the resolver's `store_fd` is turned back off right after),
+    /// for callers that go on to read files through it, like `bunx` resolving
+    /// a package's `bin`.
+    pub(crate) store_root_fd: bool,
+}
+
 pub(crate) struct RunCommand;
 
 impl RunCommand {
@@ -541,10 +555,9 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         ctx: &mut ContextData,
         this_transpiler: &mut ::core::mem::MaybeUninit<Transpiler<'static>>,
         env: Option<*mut DotEnv::Loader>,
-        log_errors: bool,
-        store_root_fd: bool,
+        opts: ConfigureEnvOptions,
     ) -> crate::Result<bun_resolver::DirInfoRef> {
-        Self::configure_env_for_run_impl(ctx, this_transpiler, env, log_errors, store_root_fd, true)
+        Self::configure_env_for_run_impl(ctx, this_transpiler, env, opts, true)
     }
 
     /// Like [`Self::configure_env_for_run`] but does **not** construct the
@@ -555,17 +568,9 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         ctx: &mut ContextData,
         this_transpiler: &mut ::core::mem::MaybeUninit<Transpiler<'static>>,
         env: Option<*mut DotEnv::Loader>,
-        log_errors: bool,
-        store_root_fd: bool,
+        opts: ConfigureEnvOptions,
     ) -> crate::Result<bun_resolver::DirInfoRef> {
-        Self::configure_env_for_run_impl(
-            ctx,
-            this_transpiler,
-            env,
-            log_errors,
-            store_root_fd,
-            false,
-        )
+        Self::configure_env_for_run_impl(ctx, this_transpiler, env, opts, false)
     }
 
     /// `configure_linker()` + `load_tsconfig_json` setup, factored into a
@@ -587,8 +592,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         ctx: &mut ContextData,
         this_transpiler: &mut ::core::mem::MaybeUninit<Transpiler<'static>>,
         env: Option<*mut DotEnv::Loader>,
-        log_errors: bool,
-        store_root_fd: bool,
+        opts: ConfigureEnvOptions,
         with_linker: bool,
     ) -> crate::Result<bun_resolver::DirInfoRef> {
         let args = ctx.args.clone();
@@ -609,7 +613,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
 
         this_transpiler.resolver.care_about_bin_folder = true;
         this_transpiler.resolver.care_about_scripts = true;
-        this_transpiler.resolver.store_fd = store_root_fd;
+        this_transpiler.resolver.store_fd = opts.store_root_fd;
 
         // Bundler-linker + JSX-runtime config: only callers that actually
         // transpile through this `Transpiler` need it. `configure_linker`'s
@@ -625,7 +629,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         let root_dir_info: bun_resolver::DirInfoRef =
             match this_transpiler.resolver.read_dir_info(top_level_dir) {
                 Err(err) => {
-                    if !log_errors {
+                    if !opts.log_errors {
                         return Err(crate::Error::CouldntReadCurrentDirectory);
                     }
                     // SAFETY: `ctx.log` set in `create_context_data` (single-
@@ -2319,8 +2323,10 @@ impl RunCommand {
             ctx,
             this_transpiler,
             None,
-            log_errors,
-            false,
+            ConfigureEnvOptions {
+                log_errors,
+                store_root_fd: false,
+            },
         )?;
         // SAFETY: `configure_env_for_run_without_linker` returned `Ok`, so the
         // slot is fully initialized via `MaybeUninit::write`.


### PR DESCRIPTION
### Problem
- `RunCommand::configure_env_for_run` (and its `_without_linker` twin) take two positional bools, `log_errors` and `store_root_fd`, and three of the four callers pass bare literals for both. At `configure_env_for_run(ctx, &mut slot, None, true, true)` in `bunx_command.rs` nothing says which flag is which, and swapping them compiles.
- This is the one `bare_bool_args` finding mordant has baselined for `src/runtime/cli/run_command.rs`.

### Fix
- Replace the two bools with a `ConfigureEnvOptions { log_errors, store_root_fd }` struct (`run_command.rs`, next to `ExecCfg`, which already gives `exec` its flags this way). Every caller now spells out both fields: `filter_run.rs`, `multi_run.rs`, `bunx_command.rs`, `pack_command.rs`, and the `exec` path inside `run_command.rs`.
- An options struct rather than two enums because two of the callers compute `log_errors` (from `ExecCfg` and from the pack log level) and a struct field takes the value as is.
- The private `configure_env_for_run_impl` keeps its single `with_linker: bool`; the lint only considers functions with two or more bool parameters, and its only callers are the two wrappers directly above it.
- The values each caller passes are unchanged, so this is a pure rename of the arguments; no behavior change.
- The `"bare_bool_args:src/runtime/cli/run_command.rs"` line is removed from `mordant-baseline.toml`.
- Verified: `cargo fmt --all --check`; `bun bd test` on `test/cli/run/run_command.test.ts`, `if-present.test.ts` (the `log_errors: false` path), `multi-run.test.ts`, `filter-workspace.test.ts`, `test/cli/install/bun-run.test.ts`, `bunx.test.ts` (the `store_root_fd: true` caller), `bun-pack.test.ts`. The only failure was `bunx.test.ts` "should set npm_config_user_agent to bun", which fails on main too when run through `bun bd` (the outer `bun run` exports its own `npm_config_user_agent` into the test env; #31928 addresses that) and passes with that variable unset.

### Background
- `configure_env_for_run` builds the process-lifetime `Transpiler` that `bun run`, `bunx`, `bun run --filter`/`--parallel` and `bun pm pack` use to resolve the working directory's `package.json` and seed the `npm_*` environment variables for the script they are about to spawn.
- `log_errors`: when the working directory cannot be read, print the resolver log and an error line; with it off the failure is only returned (used by `bun <script> --if-present` and by `bun pm pack --silent`).
- `store_root_fd`: keep the working directory's fd open on the `DirInfo` the function returns. Only `bunx` wants this, because it later reads the resolved package's `bin` through that fd; the resolver's `store_fd` is switched back off right after the root directory is read, so no other directory keeps an fd.
- mordant is the dylint pack run by `bun run rust:mordant` (pinned in `Cargo.toml`); `mordant-baseline.toml` lists pre-existing findings per lint and file, so fixing one means deleting its line.
