### PR TITLE
ast: name BabyString::r#in's parameters for what they are

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -1,5 +1,4 @@
 [bun_ast]
-"arg_named_like_other_param:src/ast/lib.rs" = 1
 "bare_bool_args:src/ast/lib.rs" = 1
 
 [bun_bundler]
@@ -18,7 +17,6 @@
 "tuple_wants_struct:src/css/values/color.rs" = 5
 
 [bun_install]
-"always_unwrapped_option:src/install/PackageInstall.rs" = 1
 "arg_named_like_other_param:src/install/PackageManager/PackageJSONEditor.rs" = 3
 "arg_named_like_other_param:src/install/resolution.rs" = 1
 "bare_bool_args:src/install/isolated_install.rs" = 1
@@ -69,7 +67,6 @@
 "error_collapsed_to_bool:src/runtime/ffi/ffi_body.rs" = 1
 "field_valid_only_when:src/runtime/cli/filter_run.rs" = 1
 "field_valid_only_when:src/runtime/shell/builtin/rm.rs" = 1
-"narrowed_two_ways:src/runtime/node/node_crypto_binding.rs" = 1
 "parallel_vecs:src/runtime/api/html_rewriter.rs" = 1
 "parallel_vecs:src/runtime/bake/dev_server/incremental_graph.rs" = 1
 "reimplemented_helper:src/runtime/api/bun/Terminal.rs" = 1

--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -1077,15 +1077,17 @@ impl BabyString {
         (self.0 >> 16) as u16
     }
 
-    pub fn r#in(parent: &[u8], text: &[u8]) -> BabyString {
+    /// Locates `substring` inside `container` (the string later passed to
+    /// [`BabyString::slice`]) and records its offset and length.
+    pub fn r#in(container: &[u8], substring: &[u8]) -> BabyString {
         // bun_core::strings::index_of deliberately returns None for an empty
-        // needle, but an empty `text` reaches this path via resolve errors for
-        // `import ""`, so short-circuit it here to offset 0.
-        if text.is_empty() {
+        // needle, but an empty `substring` reaches this path via resolve errors
+        // for `import ""`, so short-circuit it here to offset 0.
+        if substring.is_empty() {
             return BabyString::new(0, 0);
         }
-        let off = bun_core::strings::index_of(parent, text).expect("unreachable");
-        BabyString::new(off as u16, text.len() as u16) // @truncate
+        let off = bun_core::strings::index_of(container, substring).expect("unreachable");
+        BabyString::new(off as u16, substring.len() as u16) // @truncate
     }
 
     pub fn slice<'a>(self, container: &'a [u8]) -> &'a [u8] {


### PR DESCRIPTION
### Problem
- mordant's `arg_named_like_other_param` reports `src/ast/lib.rs:1651`, in `Log::add_resolve_error_with_level`: the local `text` is passed as `BabyString::r#in`'s `parent` parameter, and `r#in` also has a parameter named `text` of the same type (`&[u8]`), so the call reads as if its arguments were swapped.
- The call is not swapped. `BabyString::r#in(parent, text)` (`src/ast/lib.rs:1080`) searches for `text` inside `parent` and records the offset and length it found there; the caller wants the specifier located inside the formatted message, which is what `r#in(&text, specifier_arg)` does. The other two callers (`src/jsc/VirtualMachine.rs:4698`, `src/runtime/jsc_hooks.rs:5496`) pass the same order. Only `r#in`'s parameter names are misleading: its `text` is the needle, while every caller's `text` is the haystack.

### Fix
- Rename `r#in`'s parameters to `container` and `substring`. `container` is the name `BabyString::slice` already uses for the same string (a `BabyString` only means something against the string it was built from), and `substring` says what the second argument is. Callers are unchanged. No behavior change: the body is the same code with the names substituted.
- `mordant-baseline.toml` regenerated with `bun run rust:mordant:baseline`. It drops the `arg_named_like_other_param:src/ast/lib.rs` entry this change fixes, plus two entries that were already stale on main because the findings were removed by changes that landed after the baseline was recorded in #38846: `always_unwrapped_option:src/install/PackageInstall.rs` (the `Option<Walker>` removed in #38271) and `narrowed_two_ways:src/runtime/node/node_crypto_binding.rs` (the key length made `usize` in #37648). Happy to drop those two hunks if you would rather keep this to the one line.
- Verified:
  - `bun run rust:mordant` (cargo-dylint 6.0.3, the mordant revision pinned in `Cargo.toml`) over the whole workspace: no findings and no `target/mordant/over-baseline.txt` (the CI gate), both against the baseline on main and against the regenerated one.
  - `bun bd test test/js/bun/resolve/resolve-error.test.ts test/js/node/missing-module.test.js test/js/bun/resolve/import-meta.test.js test/js/bun/resolve/import-meta-resolve.test.mjs test/regression/issue/29264.test.ts`: 71 pass. `resolve-error.test.ts` reads `.specifier` off runtime `ResolveMessage`s and off `Bun.build` logs, which is the value `r#in` computes; `import-meta-resolve.test.mjs` covers the empty-specifier branch.
  - `bun bd test test/js/bun/http/serve.test.ts -t "dev error page"`: 2 pass (the dev error page is the other reader of the stored offset).
- No new test: Rust parameter names are not visible to callers, so no test can tell this change apart from main. The check for it is the `mordant` job in the Rust lints workflow, which runs against the regenerated baseline.

### Background
- `BabyString` (`src/ast/lib.rs`) packs a 16-bit offset and a 16-bit length into a `u32`. A resolve error stores its specifier this way, as a position inside the message's own text, instead of keeping a second copy of the string; `BabyString::r#in` builds it and `BabyString::slice` reads it back (`src/jsc/ResolveMessage.rs`, `src/runtime/server/DevErrorPage.rs`). The method is spelled `r#in` because `in` is a keyword; the name is carried over from the logger this was ported from.
- mordant is the lint pack `bun run rust:mordant` runs in the Rust lints workflow. `mordant-baseline.toml` is a ratchet: per (lint, file) counts of the findings that predate the job, so a PR fails only when it adds one. Fixing a finding means regenerating the file so its entry disappears, which is the second hunk here.

