### PR TITLE
csrf: parse the encoding option in one place

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -71,7 +71,6 @@
 "reimplemented_helper:src/runtime/api/bun/Terminal.rs" = 1
 "reimplemented_helper:src/runtime/hw_exports.rs" = 1
 "same_match_twice:src/runtime/api/bun/h2_frame_parser.rs" = 1
-"same_match_twice:src/runtime/api/csrf_jsc.rs" = 1
 "same_match_twice:src/runtime/bake/production.rs" = 2
 "same_match_twice:src/runtime/cli/pack_command.rs" = 1
 "same_match_twice:src/runtime/cli/publish_command.rs" = 1

--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -71,7 +71,6 @@
 "reimplemented_helper:src/runtime/api/bun/Terminal.rs" = 1
 "reimplemented_helper:src/runtime/hw_exports.rs" = 1
 "same_match_twice:src/runtime/api/bun/h2_frame_parser.rs" = 1
-"same_match_twice:src/runtime/bake/dev_server/mod.rs" = 1
 "same_match_twice:src/runtime/api/csrf_jsc.rs" = 1
 "same_match_twice:src/runtime/bake/production.rs" = 2
 "same_match_twice:src/runtime/cli/pack_command.rs" = 1

--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -77,7 +77,6 @@
 "reimplemented_helper:src/runtime/hw_exports.rs" = 1
 "same_match_twice:src/runtime/api/YAMLObject.rs" = 1
 "same_match_twice:src/runtime/api/bun/h2_frame_parser.rs" = 1
-"same_match_twice:src/runtime/api/csrf_jsc.rs" = 1
 "same_match_twice:src/runtime/bake/dev_server/mod.rs" = 1
 "same_match_twice:src/runtime/bake/production.rs" = 2
 "same_match_twice:src/runtime/cli/pack_command.rs" = 1

--- a/src/runtime/api/csrf_jsc.rs
+++ b/src/runtime/api/csrf_jsc.rs
@@ -48,6 +48,30 @@ fn get_optional_int_u64(
     Ok(Some(num as u64))
 }
 
+/// Reads the optional `encoding` property. Parsed as a Buffer encoding name
+/// ("" selects base64url), of which only the three token formats are accepted.
+fn get_optional_token_format(
+    target: JSValue,
+    global: &JSGlobalObject,
+) -> JsResult<Option<csrf::TokenFormat>> {
+    let Some(value) = target.get(global, "encoding")? else {
+        return Ok(None);
+    };
+    let encoding =
+        NodeEncoding::from_js_with_default_on_empty(value, global, NodeEncoding::Base64url)?;
+    let format = match encoding {
+        Some(NodeEncoding::Base64) => csrf::TokenFormat::Base64,
+        Some(NodeEncoding::Base64url) => csrf::TokenFormat::Base64Url,
+        Some(NodeEncoding::Hex) => csrf::TokenFormat::Hex,
+        _ => {
+            return Err(global.throw_invalid_arguments(format_args!(
+                "Invalid format: must be 'base64', 'base64url', or 'hex'"
+            )));
+        }
+    };
+    Ok(Some(format))
+}
+
 /// JS binding function for generating CSRF tokens
 /// First argument is secret (required), second is options (optional)
 #[bun_jsc::host_fn]
@@ -96,27 +120,8 @@ pub(crate) fn csrf__generate(global: &JSGlobalObject, frame: &CallFrame) -> JsRe
         }
 
         // Extract encoding (optional)
-        if let Some(encoding_js) = options_value.get(global, "encoding")? {
-            let Some(encoding_enum) = NodeEncoding::from_js_with_default_on_empty(
-                encoding_js,
-                global,
-                NodeEncoding::Base64url,
-            )?
-            else {
-                return Err(global.throw_invalid_arguments(format_args!(
-                    "Invalid format: must be 'base64', 'base64url', or 'hex'"
-                )));
-            };
-            encoding = match encoding_enum {
-                NodeEncoding::Base64 => csrf::TokenFormat::Base64,
-                NodeEncoding::Base64url => csrf::TokenFormat::Base64Url,
-                NodeEncoding::Hex => csrf::TokenFormat::Hex,
-                _ => {
-                    return Err(global.throw_invalid_arguments(format_args!(
-                        "Invalid format: must be 'base64', 'base64url', or 'hex'"
-                    )));
-                }
-            };
+        if let Some(format) = get_optional_token_format(options_value, global)? {
+            encoding = format;
         }
 
         if let Some(algorithm_js) = options_value.get(global, "algorithm")? {
@@ -177,10 +182,8 @@ pub(crate) fn csrf__generate(global: &JSGlobalObject, frame: &CallFrame) -> JsRe
         }
     };
 
-    // Encode the token
-    // `csrf::TokenFormat::to_node_encoding()` returns the cycle-broken
-    // `bun_core::NodeEncoding`, not `crate::node::Encoding` (which owns
-    // `encode_with_max_size`). Map locally to the runtime enum instead.
+    // Encode the token. `bun_csrf` sits below `crate::node::Encoding` (which
+    // owns `encode_with_max_size`), so `TokenFormat` is mapped back to it here.
     let node_encoding = match encoding {
         csrf::TokenFormat::Base64 => NodeEncoding::Base64,
         csrf::TokenFormat::Base64Url => NodeEncoding::Base64url,
@@ -251,27 +254,8 @@ pub(crate) fn csrf__verify(global: &JSGlobalObject, frame: &CallFrame) -> JsResu
         }
 
         // Extract encoding (optional)
-        if let Some(encoding_js) = options_value.get(global, "encoding")? {
-            let Some(encoding_enum) = NodeEncoding::from_js_with_default_on_empty(
-                encoding_js,
-                global,
-                NodeEncoding::Base64url,
-            )?
-            else {
-                return Err(global.throw_invalid_arguments(format_args!(
-                    "Invalid format: must be 'base64', 'base64url', or 'hex'"
-                )));
-            };
-            encoding = match encoding_enum {
-                NodeEncoding::Base64 => csrf::TokenFormat::Base64,
-                NodeEncoding::Base64url => csrf::TokenFormat::Base64Url,
-                NodeEncoding::Hex => csrf::TokenFormat::Hex,
-                _ => {
-                    return Err(global.throw_invalid_arguments(format_args!(
-                        "Invalid format: must be 'base64', 'base64url', or 'hex'"
-                    )));
-                }
-            };
+        if let Some(format) = get_optional_token_format(options_value, global)? {
+            encoding = format;
         }
         if let Some(algorithm_js) = options_value.get(global, "algorithm")? {
             if !algorithm_js.is_string() {

--- a/test/js/bun/util/csrf.test.ts
+++ b/test/js/bun/util/csrf.test.ts
@@ -184,6 +184,23 @@ describe("Bun.CSRF", () => {
     expect(() => CSRF.verify(token, { secret, sessionId: 123 })).toThrow();
   });
 
+  test("rejects encodings that are not token formats", () => {
+    const token = CSRF.generate(secret);
+    const message = "Invalid format: must be 'base64', 'base64url', or 'hex'";
+
+    // Buffer encodings that are not token formats, and names that are not encodings at all
+    for (const encoding of ["utf8", "latin1", "buffer", "bogus"]) {
+      // @ts-expect-error - testing invalid input
+      expect(() => CSRF.generate(secret, { encoding })).toThrow(message);
+      // @ts-expect-error - testing invalid input
+      expect(() => CSRF.verify(token, { secret, encoding })).toThrow(message);
+    }
+
+    // An empty string selects the default (base64url) in both directions
+    // @ts-expect-error - testing invalid input
+    expect(CSRF.verify(CSRF.generate(secret, { encoding: "" }), { secret, encoding: "" })).toBe(true);
+  });
+
   test("handle bad decoding", () => {
     const ambigousSecret = "test-secret";
 


### PR DESCRIPTION
### Problem
- `Bun.CSRF.generate` and `Bun.CSRF.verify` each read the `encoding` option with their own copy of the same code: `get("encoding")`, `Encoding::from_js_with_default_on_empty`, the `Encoding` to `csrf::TokenFormat` match, and the `Invalid format` error (which appeared four times). `src/runtime/api/csrf_jsc.rs:99-120` and `:254-275` before this change.
- mordant's `same_match_twice` reports the second copy; it is the `same_match_twice:src/runtime/api/csrf_jsc.rs` entry in `mordant-baseline.toml`.

### Fix
- One `get_optional_token_format(options, global)` helper in `csrf_jsc.rs`, next to the existing `get_optional_int_u64`, called from both functions at the same point in the option-reading order. The `None` from an unknown encoding name and the non-token encodings share the one error arm, so the message exists once.
- The mapping stays in `csrf_jsc.rs` rather than on an enum: `TokenFormat` lives in `bun_csrf`, which cannot see `crate::node::Encoding`, and this file is `TokenFormat`'s only user. The comment on the reverse mapping (used to encode the token) still named `TokenFormat::to_node_encoding`, removed in #35002; reworded.
- Removed the baseline entry. `bun run rust:mordant` over the workspace is clean with it removed; with the entry removed but the old source restored it reports the one finding at `csrf_jsc.rs:265`, so the entry was this site.
- No behavior change. Compared the release build against this build on the same script covering every rejected encoding (`utf8`, `latin1`, `buffer`, `bogus`, `null`, a number, an object), case-insensitive names, `""`, `undefined`, and the order in which the option properties are read by both functions: identical output.
- Verified with `bun bd test test/js/bun/util/csrf.test.ts` (25 pass). Added one test pinning the error message for both functions and the `""` default, since that path was not covered; it passes before and after, as expected for a refactor.

### Background
- `crate::node::Encoding` is the Buffer encoding enum (`utf8`, `hex`, `base64`, ...). `from_js_with_default_on_empty` parses a JS value as an encoding name, returning the given default for `""` and `None` for names it does not know.
- `csrf::TokenFormat` is the three-variant enum (`Base64`, `Base64Url`, `Hex`) the `bun_csrf` crate encodes and decodes tokens with. The CSRF API accepts the encoding option as a Buffer encoding name and narrows it to a `TokenFormat`, which is the mapping this PR deduplicates.
- mordant is the lint pack run by `bun run rust:mordant`; `mordant-baseline.toml` records the accepted count of findings per (lint, file), and CI fails only on findings above the recorded count, so fixing a finding means deleting its entry.
- #37366 (an 82-file dedup PR stacked on #32022) contains an equivalent helper for this file among many others; when it is rebased, its `csrf_jsc.rs` hunk becomes redundant with this one.
