### PR TITLE
websocket: return publish_ctx's app and flags as a struct instead of a tuple

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -89,7 +89,6 @@
 "same_match_twice:src/runtime/shell/builtin/cat.rs" = 1
 "same_match_twice:src/runtime/webcore/Blob.rs" = 2
 "same_match_twice:src/runtime/webcore/Body.rs" = 2
-"tuple_wants_struct:src/runtime/server/ServerWebSocket.rs" = 1
 "tuple_wants_struct:src/runtime/shell/builtin/which.rs" = 1
 "unchecked_construction:src/runtime/api/js_bundle_completion_task.rs" = 1
 "unchecked_construction:src/runtime/cli/pack_command.rs" = 2

--- a/src/runtime/server/ServerWebSocket.rs
+++ b/src/runtime/server/ServerWebSocket.rs
@@ -213,6 +213,15 @@ pub(super) fn blob_payload<'a>(
     Ok(Some(blob.shared_view()))
 }
 
+/// Handler state a `publish*` method reads once up front (`publish_ctx`).
+#[derive(Clone, Copy)]
+struct PublishCtx {
+    /// The server's `uws_app_t*`; `ssl` says which `NewApp<SSL>` it is.
+    app: *mut c_void,
+    ssl: bool,
+    publish_to_self: bool,
+}
+
 impl ServerWebSocket {
     #[inline]
     fn websocket(&self) -> AnyWebSocket {
@@ -253,20 +262,20 @@ impl ServerWebSocket {
     // bool flags — net more code than three small orthogonal helpers.
     // ──────────────────────────────────────────────────────────────────────
 
-    /// `(app, ssl, publish_to_self)` from the handler, or `None` when the
-    /// server has been torn down (`handler.app == None`). The "publish() closed"
-    /// log + `0` return is the caller's responsibility (it varies in nothing,
-    /// but keeping it inline preserves the per-method `scoped_log!` callsite).
+    /// The handler state a publish needs, or `None` when the server has been
+    /// torn down (`handler.app == None`). The "publish() closed" log + `0`
+    /// return is the caller's responsibility (it varies in nothing, but keeping
+    /// it inline preserves the per-method `scoped_log!` callsite).
     #[inline]
-    fn publish_ctx(&self) -> Option<(*mut c_void, bool, bool)> {
+    fn publish_ctx(&self) -> Option<PublishCtx> {
         let handler = self.handler();
         let app = handler.app?;
         let flags = handler.flags;
-        Some((
+        Some(PublishCtx {
             app,
-            flags.contains(HandlerFlags::SSL),
-            flags.contains(HandlerFlags::PUBLISH_TO_SELF),
-        ))
+            ssl: flags.contains(HandlerFlags::SSL),
+            publish_to_self: flags.contains(HandlerFlags::PUBLISH_TO_SELF),
+        })
     }
 
     /// Shared `compress` argument validation for publish*/send*. Preserves the
@@ -295,18 +304,16 @@ impl ServerWebSocket {
     #[inline]
     fn do_publish(
         &self,
-        ssl: bool,
-        app: *mut c_void,
-        publish_to_self: bool,
+        ctx: PublishCtx,
         topic: &[u8],
         buffer: &[u8],
         opcode: Opcode,
         compress: bool,
     ) -> JSValue {
-        let status = if !publish_to_self && !self.is_closed() {
+        let status = if !ctx.publish_to_self && !self.is_closed() {
             self.websocket().publish(topic, buffer, opcode, compress)
         } else {
-            AnyWebSocket::publish_with_options(ssl, app, topic, buffer, opcode, compress)
+            AnyWebSocket::publish_with_options(ctx.ssl, ctx.app, topic, buffer, opcode, compress)
         };
         send_status_to_js(status, buffer.len(), "publish", "bytes")
     }
@@ -829,7 +836,7 @@ impl ServerWebSocket {
             return Err(global_this.throw(format_args!("publish requires at least 1 argument")));
         }
 
-        let Some((app, ssl, publish_to_self)) = self.publish_ctx() else {
+        let Some(ctx) = self.publish_ctx() else {
             bun_output::scoped_log!(WebSocketServer, "publish() closed");
             return Ok(JSValue::js_number(0.0));
         };
@@ -857,27 +864,11 @@ impl ServerWebSocket {
 
         if let Some(array_buffer) = message_value.as_array_buffer(global_this) {
             let buffer = array_buffer.slice();
-            return Ok(self.do_publish(
-                ssl,
-                app,
-                publish_to_self,
-                topic_slice.slice(),
-                buffer,
-                Opcode::Binary,
-                compress,
-            ));
+            return Ok(self.do_publish(ctx, topic_slice.slice(), buffer, Opcode::Binary, compress));
         }
 
         if let Some(slice) = blob_payload(global_this, "publish", message_value)? {
-            let ret = self.do_publish(
-                ssl,
-                app,
-                publish_to_self,
-                topic_slice.slice(),
-                slice,
-                Opcode::Binary,
-                compress,
-            );
+            let ret = self.do_publish(ctx, topic_slice.slice(), slice, Opcode::Binary, compress);
             message_value.ensure_still_alive();
             return Ok(ret);
         }
@@ -888,9 +879,7 @@ impl ServerWebSocket {
             let slice = view.to_slice();
 
             let ret = self.do_publish(
-                ssl,
-                app,
-                publish_to_self,
+                ctx,
                 topic_slice.slice(),
                 slice.slice(),
                 Opcode::Text,
@@ -914,7 +903,7 @@ impl ServerWebSocket {
             return Err(global_this.throw(format_args!("publish requires at least 1 argument")));
         }
 
-        let Some((app, ssl, publish_to_self)) = self.publish_ctx() else {
+        let Some(ctx) = self.publish_ctx() else {
             bun_output::scoped_log!(WebSocketServer, "publish() closed");
             return Ok(JSValue::js_number(0.0));
         };
@@ -942,9 +931,7 @@ impl ServerWebSocket {
         let slice = view.to_slice();
 
         let ret = self.do_publish(
-            ssl,
-            app,
-            publish_to_self,
+            ctx,
             topic_slice.slice(),
             slice.slice(),
             Opcode::Text,
@@ -969,7 +956,7 @@ impl ServerWebSocket {
             );
         }
 
-        let Some((app, ssl, publish_to_self)) = self.publish_ctx() else {
+        let Some(ctx) = self.publish_ctx() else {
             bun_output::scoped_log!(WebSocketServer, "publish() closed");
             return Ok(JSValue::js_number(0.0));
         };
@@ -999,9 +986,7 @@ impl ServerWebSocket {
 
         if let Some(array_buffer) = message_value.as_array_buffer(global_this) {
             return Ok(self.do_publish(
-                ssl,
-                app,
-                publish_to_self,
+                ctx,
                 topic_slice.slice(),
                 array_buffer.slice(),
                 Opcode::Binary,
@@ -1010,15 +995,7 @@ impl ServerWebSocket {
         }
 
         if let Some(slice) = blob_payload(global_this, "publishBinary", message_value)? {
-            let ret = self.do_publish(
-                ssl,
-                app,
-                publish_to_self,
-                topic_slice.slice(),
-                slice,
-                Opcode::Binary,
-                compress,
-            );
+            let ret = self.do_publish(ctx, topic_slice.slice(), slice, Opcode::Binary, compress);
             message_value.ensure_still_alive();
             return Ok(ret);
         }


### PR DESCRIPTION
### Problem
- mordant's `tuple_wants_struct` flags `ServerWebSocket::publish_ctx` in `src/runtime/server/ServerWebSocket.rs`: it returned `Option<(*mut c_void, bool, bool)>`, and all three callers (`publish`, `publish_text`, `publish_binary`) unpacked it as `(app, ssl, publish_to_self)`.
- Each caller then handed the three values back to `do_publish(ssl, app, publish_to_self, ..)` positionally, so the two bools were told apart by position at seven sites (the return, three destructurings, and the `do_publish` parameters at each call). Swapping `ssl` and `publish_to_self` at any of them compiles; the names lived at every call site but not in the type.

### Fix
- Add a file-private `PublishCtx { app, ssl, publish_to_self }` (`Copy`). `publish_ctx` returns `Option<PublishCtx>`, built with named fields from `Handler.app` and `HandlerFlags` exactly as before.
- `do_publish` takes the `PublishCtx` whole instead of the three loose values and reads `ctx.publish_to_self` / `ctx.ssl` / `ctx.app` where it used the parameters. The callers bind `ctx` and pass it through; nothing else in the three methods changes, so the argument checks, error messages and debug logs are untouched. No behavior change, so no new test.
- Delete the cleared `tuple_wants_struct:src/runtime/server/ServerWebSocket.rs` entry from `mordant-baseline.toml`. `bun run rust:mordant:baseline` on this branch drops exactly that line for this file and adds none for `bun_runtime`, so the struct does not trade the finding for another one. The regeneration also drops two entries that are already stale on main and unrelated to this change (`always_unwrapped_option:src/install/PackageInstall.rs`, already removed by #39130, and `narrowed_two_ways:src/runtime/node/node_crypto_binding.rs`, cleared by #37648); both are left alone here.
- Verified:
  - `bun bd` builds.
  - `bun bd test test/js/bun/websocket/websocket-server.test.ts -t 'publish()'`: 24 pass, three runs (covers `publishToSelf` on and off, `publishText`, `publishBinary`, and the backpressure return values).
  - `bun bd test test/js/bun/websocket/websocket-server-stop-retained-ws.test.ts`: 1 pass (the `publish_ctx() == None` path, a socket whose server has been stopped).
  - `bun run rust:mordant` with the baseline entry removed: no findings over the baseline. As a control, the same command on the unmodified `ServerWebSocket.rs` reports `bun_runtime 1`, the `publish_ctx` finding.
  - `cargo clippy -p bun_runtime --no-deps`: clean.
  - In the full `websocket-server.test.ts` run, `send() (benchmark)` and two `publish()` string cases hit their timeouts once under the debug ASAN build; every one of them passes in isolation and each spawns two ASAN child processes, so that is load in the full concurrent file rather than this change.

### Background
- `ws.publish()` on a `ServerWebSocket` is delivered one of two ways. By default it goes through the socket's own uWS handle, which excludes the publishing socket from the fan-out; with `publishToSelf: true` (or once the socket is closed) it goes through the server-wide uWS app instead. That app is a `*mut c_void` the Rust side has to pair with an `ssl` flag, because the TLS and plain servers are two different C++ instantiations (`NewApp<true>` / `NewApp<false>`) and `publish_with_options` picks the cast from the flag. `publish_ctx` is the helper that reads the app pointer and both flags off the server's websocket handler, and returns `None` once the server has been torn down (`app` unset), which the callers turn into a `0` return.
- `mordant-baseline.toml` is the ratchet for the mordant lint pack: it records the per-(lint, file) finding counts that predate the CI job, so CI fails only on new findings. Fixing a site means deleting (or decrementing) its entry.
