### PR TITLE
shell_parser: replace break_word_impl's three bools with an AddDelimiter enum

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -97,9 +97,6 @@
 "unchecked_construction:src/runtime/server/mod.rs" = 1
 "unchecked_construction:src/runtime/server/server_body.rs" = 5
 
-[bun_shell_parser]
-"bare_bool_args:src/shell_parser/parse.rs" = 1
-
 [bun_sql_jsc]
 "bare_bool_args:src/sql_jsc/shared/datetime_text.rs" = 1
 "same_match_twice:src/sql_jsc/mysql/protocol/ResultSet.rs" = 1

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -2193,9 +2193,8 @@ enum AddDelimiter {
     No,
     /// Only after text that was pending; nothing is pushed otherwise.
     AfterText,
-    /// Whitespace or an operator ended the word: as `AfterText`, and a word whose last part was
-    /// already pushed as its own token (a closing quote, `$VAR`, `$(cmd)`, `*`, `}`) is delimited
-    /// too.
+    /// Whitespace or an operator ended the word: as `AfterText`, but a word with no text left to
+    /// flush (it ended in a closing quote, `$VAR`, `$(cmd)`, `*` or `}`) is delimited too.
     AfterWord,
 }
 

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -2186,6 +2186,19 @@ pub(crate) enum RedirectDirection {
     In,
 }
 
+/// Whether `Lexer::break_word` follows the text it flushes with a `Token::Delimit`.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum AddDelimiter {
+    /// More of the same word follows (`$VAR`, `*`, `{`, a quote).
+    No,
+    /// Only after text that was pending; nothing is pushed otherwise.
+    AfterText,
+    /// Whitespace or an operator ended the word: as `AfterText`, and a word whose last part was
+    /// already pushed as its own token (a closing quote, `$VAR`, `$(cmd)`, `*`, `}`) is delimited
+    /// too.
+    AfterWord,
+}
+
 #[derive(Clone, Copy)]
 struct BacktrackSnapshot<'bump, const ENCODING: StringEncoding> {
     chars: ShellCharIter<'bump, ENCODING>,
@@ -2397,7 +2410,7 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
             let input = match self.eat() {
                 Some(i) => i,
                 None => {
-                    self.break_word(true)?;
+                    self.break_word(AddDelimiter::AfterText)?;
                     break;
                 }
             };
@@ -2409,7 +2422,7 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
             if char == u32::from(SPECIAL_JS_CHAR) {
                 if self.looks_like_js_string_ref() {
                     if let Some(bunstr) = self.eat_js_string_ref() {
-                        self.break_word(false)?;
+                        self.break_word(AddDelimiter::No)?;
                         self.handle_js_string_ref(bunstr)?;
                         continue;
                     }
@@ -2419,7 +2432,7 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                             self.add_error(b"JS object reference not allowed in double quotes");
                             return Ok(());
                         }
-                        self.break_word(false)?;
+                        self.break_word(AddDelimiter::No)?;
                         self.tokens.push(tok);
                         continue;
                     }
@@ -2451,7 +2464,7 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                                     let p2 = match self.peek() {
                                         Some(p2) => p2,
                                         None => {
-                                            self.break_word(true)?;
+                                            self.break_word(AddDelimiter::AfterText)?;
                                             self.tokens.push(Token::DoubleBracketClose);
                                             fell_through = true;
                                             break 'escaped;
@@ -2466,7 +2479,7 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                                             || c2 == u32::from(b'\n')
                                             || c2 == u32::from(b'\t') =>
                                         {
-                                            self.break_word(true)?;
+                                            self.break_word(AddDelimiter::AfterText)?;
                                             self.tokens.push(Token::DoubleBracketOpen);
                                         }
                                         _ => break 'do_backtrack,
@@ -2495,7 +2508,7 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                                     let p2 = match self.peek() {
                                         Some(p2) => p2,
                                         None => {
-                                            self.break_word(true)?;
+                                            self.break_word(AddDelimiter::AfterText)?;
                                             self.tokens.push(Token::DoubleBracketClose);
                                             fell_through = true;
                                             break 'escaped;
@@ -2517,7 +2530,7 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                                                 | b'>')
                                         ) =>
                                         {
-                                            self.break_word(true)?;
+                                            self.break_word(AddDelimiter::AfterText)?;
                                             self.tokens.push(Token::DoubleBracketClose);
                                         }
                                         _ => break 'do_backtrack,
@@ -2544,7 +2557,7 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                             if !whitespace_preceding {
                                 break 'escaped;
                             }
-                            self.break_word(true)?;
+                            self.break_word(AddDelimiter::AfterText)?;
                             self.eat_comment();
                             fell_through = true;
                         }
@@ -2555,7 +2568,7 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                             {
                                 break 'escaped;
                             }
-                            self.break_word(true)?;
+                            self.break_word(AddDelimiter::AfterText)?;
                             self.tokens.push(Token::Semicolon);
                             fell_through = true;
                         }
@@ -2566,7 +2579,7 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                             {
                                 break 'escaped;
                             }
-                            self.break_word_impl(true, true, false)?;
+                            self.break_word(AddDelimiter::AfterWord)?;
                             self.tokens.push(Token::Newline);
                             fell_through = true;
                         }
@@ -2581,13 +2594,13 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                             if let Some(next) = self.peek() {
                                 if !next.escaped && next.char == u32::from(b'*') {
                                     let _ = self.eat();
-                                    self.break_word(false)?;
+                                    self.break_word(AddDelimiter::No)?;
                                     self.tokens.push(Token::DoubleAsterisk);
                                     fell_through = true;
                                     break 'escaped;
                                 }
                             }
-                            self.break_word(false)?;
+                            self.break_word(AddDelimiter::No)?;
                             self.tokens.push(Token::Asterisk);
                             fell_through = true;
                         }
@@ -2599,7 +2612,7 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                             {
                                 break 'escaped;
                             }
-                            self.break_word(false)?;
+                            self.break_word(AddDelimiter::No)?;
                             self.tokens.push(Token::BraceBegin);
                             fell_through = true;
                         }
@@ -2610,7 +2623,7 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                             {
                                 break 'escaped;
                             }
-                            self.break_word(false)?;
+                            self.break_word(AddDelimiter::No)?;
                             self.tokens.push(Token::Comma);
                             fell_through = true;
                         }
@@ -2621,7 +2634,7 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                             {
                                 break 'escaped;
                             }
-                            self.break_word(false)?;
+                            self.break_word(AddDelimiter::No)?;
                             self.tokens.push(Token::BraceEnd);
                             fell_through = true;
                         }
@@ -2632,7 +2645,7 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                                 break 'escaped;
                             }
                             if self.in_subshell == Some(SubShellKind::Backtick) {
-                                self.break_word_operator()?;
+                                self.break_word(AddDelimiter::AfterWord)?;
                                 if let Some(toktag) = self.last_tok_tag() {
                                     if toktag != TokenTag::Delimit {
                                         self.tokens.push(Token::Delimit);
@@ -2657,20 +2670,20 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                                 escaped: false,
                             });
                             if !peeked.escaped && peeked.char == u32::from(b'(') {
-                                self.break_word(false)?;
+                                self.break_word(AddDelimiter::No)?;
                                 self.eat_subshell(SubShellKind::Dollar)?;
                                 fell_through = true;
                                 break 'escaped;
                             }
 
                             // Handle variable
-                            self.break_word(false)?;
+                            self.break_word(AddDelimiter::No)?;
                             let var_tok = self.eat_var()?;
 
                             match var_tok.len() {
                                 0 => {
                                     self.append_char_to_str_pool(u32::from(b'$'))?;
-                                    self.break_word(false)?;
+                                    self.break_word(AddDelimiter::No)?;
                                 }
                                 1 => 'blk: {
                                     let c = self.strpool[var_tok.start as usize];
@@ -2694,7 +2707,7 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                             {
                                 break 'escaped;
                             }
-                            self.break_word(true)?;
+                            self.break_word(AddDelimiter::AfterText)?;
                             self.eat_subshell(SubShellKind::Normal)?;
                             fell_through = true;
                         }
@@ -2713,7 +2726,7 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                                 break 'escaped;
                             }
 
-                            self.break_word(true)?;
+                            self.break_word(AddDelimiter::AfterText)?;
                             // Command substitution can be put in a word so need to add delimiter
                             if self.in_subshell == Some(SubShellKind::Dollar) {
                                 if let Some(toktag) = self.last_tok_tag() {
@@ -2742,7 +2755,7 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                             }
                             let snapshot = self.make_snapshot();
                             if let Some(redirect) = self.eat_redirect(input) {
-                                self.break_word(true)?;
+                                self.break_word(AddDelimiter::AfterText)?;
                                 self.tokens.push(Token::Redirect(redirect));
                                 fell_through = true;
                                 break 'escaped;
@@ -2758,7 +2771,7 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                             {
                                 break 'escaped;
                             }
-                            self.break_word_operator()?;
+                            self.break_word(AddDelimiter::AfterWord)?;
 
                             let next = match self.peek() {
                                 Some(n) => n,
@@ -2786,7 +2799,7 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                             {
                                 break 'escaped;
                             }
-                            self.break_word_operator()?;
+                            self.break_word(AddDelimiter::AfterWord)?;
                             let redirect = self.eat_simple_redirect(RedirectDirection::Out);
                             self.tokens.push(Token::Redirect(redirect));
                             fell_through = true;
@@ -2798,7 +2811,7 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                             {
                                 break 'escaped;
                             }
-                            self.break_word_operator()?;
+                            self.break_word(AddDelimiter::AfterWord)?;
                             let redirect = self.eat_simple_redirect(RedirectDirection::In);
                             self.tokens.push(Token::Redirect(redirect));
                             fell_through = true;
@@ -2810,7 +2823,7 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                             {
                                 break 'escaped;
                             }
-                            self.break_word_operator()?;
+                            self.break_word(AddDelimiter::AfterWord)?;
 
                             let next = match self.peek() {
                                 Some(n) => n,
@@ -2842,13 +2855,13 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                         c if c == u32::from(b'\'') => {
                             const _: () = assert!(SPECIAL_CHARS_TABLE.is_set(b'\'' as usize));
                             if self.chars.state == CharState::Single {
-                                self.break_word(false)?;
+                                self.break_word(AddDelimiter::No)?;
                                 self.chars.state = CharState::Normal;
                                 fell_through = true;
                                 break 'escaped;
                             }
                             if self.chars.state == CharState::Normal {
-                                self.break_word(false)?;
+                                self.break_word(AddDelimiter::No)?;
                                 self.chars.state = CharState::Single;
                                 fell_through = true;
                                 break 'escaped;
@@ -2861,10 +2874,10 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                                 break 'escaped;
                             }
                             if self.chars.state == CharState::Normal {
-                                self.break_word(false)?;
+                                self.break_word(AddDelimiter::No)?;
                                 self.chars.state = CharState::Double;
                             } else if self.chars.state == CharState::Double {
-                                self.break_word(false)?;
+                                self.break_word(AddDelimiter::No)?;
                                 self.chars.state = CharState::Normal;
                             }
                             fell_through = true;
@@ -2873,7 +2886,7 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                         c if c == u32::from(b' ') => {
                             const _: () = assert!(SPECIAL_CHARS_TABLE.is_set(b' ' as usize));
                             if self.chars.state == CharState::Normal {
-                                self.break_word_impl(true, true, false)?;
+                                self.break_word(AddDelimiter::AfterWord)?;
                                 fell_through = true;
                                 break 'escaped;
                             }
@@ -2892,7 +2905,7 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
             else if char == u32::from(b'\n') {
                 debug_assert!(input.escaped);
                 if self.chars.state != CharState::Double {
-                    self.break_word_impl(true, true, false)?;
+                    self.break_word(AddDelimiter::AfterWord)?;
                 }
                 continue;
             }
@@ -2941,15 +2954,6 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
         Ok(())
     }
 
-    fn break_word(&mut self, add_delimiter: bool) -> Result<(), LexerError> {
-        self.break_word_impl(add_delimiter, false, false)
-    }
-
-    /// NOTE: this adds a delimiter
-    fn break_word_operator(&mut self) -> Result<(), LexerError> {
-        self.break_word_impl(true, false, true)
-    }
-
     #[inline]
     fn is_immediately_escaped_quote(&self) -> bool {
         (self.chars.state == CharState::Double
@@ -2972,12 +2976,7 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                     .is_some_and(|p| !p.escaped && p.char == u32::from(b'\'')))
     }
 
-    fn break_word_impl(
-        &mut self,
-        add_delimiter: bool,
-        in_normal_space: bool,
-        in_operator: bool,
-    ) -> Result<(), LexerError> {
+    fn break_word(&mut self, add_delimiter: AddDelimiter) -> Result<(), LexerError> {
         let start: u32 = self.word_start;
         let end: u32 = self.j;
         if start != end || self.is_immediately_escaped_quote() {
@@ -2987,10 +2986,10 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                 CharState::Double => Token::DoubleQuotedText(TextRange { start, end }),
             };
             self.tokens.push(tok);
-            if add_delimiter {
+            if add_delimiter != AddDelimiter::No {
                 self.tokens.push(Token::Delimit);
             }
-        } else if (in_normal_space || in_operator)
+        } else if add_delimiter == AddDelimiter::AfterWord
             && !self.tokens.is_empty()
             && match self.tokens[self.tokens.len() - 1].tag() {
                 TokenTag::Var

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -2193,8 +2193,7 @@ enum AddDelimiter {
     No,
     /// Only after text that was pending; nothing is pushed otherwise.
     AfterText,
-    /// Whitespace or an operator ended the word: as `AfterText`, but a word with no text left to
-    /// flush (it ended in a closing quote, `$VAR`, `$(cmd)`, `*` or `}`) is delimited too.
+    /// Whitespace or an operator: delimits the word even when its last part was already pushed.
     AfterWord,
 }
 

--- a/test/js/bun/shell/lex.test.ts
+++ b/test/js/bun/shell/lex.test.ts
@@ -706,6 +706,121 @@ describe("lex shell", () => {
     expect(JSON.parse(result)).toEqual(expected);
   });
 
+  // Where the lexer puts `Delimit` when a word's last part is not plain text
+  // (a variable, a closing quote, a brace group), or when the word is split
+  // into several tokens. Whitespace and operators delimit such a word; `;`
+  // and the end of input do not; the token that splits a word never does.
+  test.each([
+    [
+      "space after a variable",
+      "echo $FOO bar",
+      [
+        { Text: "echo" },
+        { Delimit: {} },
+        { Var: "FOO" },
+        { Delimit: {} },
+        { Text: "bar" },
+        { Delimit: {} },
+        { Eof: {} },
+      ],
+    ],
+    [
+      "newline after a variable",
+      "echo $FOO\nls",
+      [
+        { Text: "echo" },
+        { Delimit: {} },
+        { Var: "FOO" },
+        { Delimit: {} },
+        { Newline: {} },
+        { Text: "ls" },
+        { Delimit: {} },
+        { Eof: {} },
+      ],
+    ],
+    [
+      "escaped newline after a variable",
+      "echo $FOO\\\nls",
+      [
+        { Text: "echo" },
+        { Delimit: {} },
+        { Var: "FOO" },
+        { Delimit: {} },
+        { Text: "ls" },
+        { Delimit: {} },
+        { Eof: {} },
+      ],
+    ],
+    [
+      "operator after a variable",
+      "$FOO|b",
+      [{ Var: "FOO" }, { Delimit: {} }, { Pipe: {} }, { Text: "b" }, { Delimit: {} }, { Eof: {} }],
+    ],
+    [
+      "operator after a space adds no second delimiter",
+      "$FOO | b",
+      [{ Var: "FOO" }, { Delimit: {} }, { Pipe: {} }, { Text: "b" }, { Delimit: {} }, { Eof: {} }],
+    ],
+    [
+      "space after a closing quote",
+      '"a" b',
+      [{ DoubleQuotedText: "a" }, { Delimit: {} }, { Text: "b" }, { Delimit: {} }, { Eof: {} }],
+    ],
+    [
+      "space after a brace group",
+      "{a,b} c",
+      [
+        { BraceBegin: {} },
+        { Text: "a" },
+        { Comma: {} },
+        { Text: "b" },
+        { BraceEnd: {} },
+        { Delimit: {} },
+        { Text: "c" },
+        { Delimit: {} },
+        { Eof: {} },
+      ],
+    ],
+    [
+      "semicolon after a variable",
+      "$FOO;b",
+      [{ Var: "FOO" }, { Semicolon: {} }, { Text: "b" }, { Delimit: {} }, { Eof: {} }],
+    ],
+    [
+      "semicolon after a closing quote",
+      '"a";b',
+      [{ DoubleQuotedText: "a" }, { Semicolon: {} }, { Text: "b" }, { Delimit: {} }, { Eof: {} }],
+    ],
+    [
+      "semicolon after a brace group",
+      "{a,b};c",
+      [
+        { BraceBegin: {} },
+        { Text: "a" },
+        { Comma: {} },
+        { Text: "b" },
+        { BraceEnd: {} },
+        { Semicolon: {} },
+        { Text: "c" },
+        { Delimit: {} },
+        { Eof: {} },
+      ],
+    ],
+    ["end of input after a variable", "$FOO", [{ Var: "FOO" }, { Eof: {} }]],
+    [
+      "variable inside a word",
+      "foo$BAR baz",
+      [{ Text: "foo" }, { Var: "BAR" }, { Delimit: {} }, { Text: "baz" }, { Delimit: {} }, { Eof: {} }],
+    ],
+    [
+      "glob inside a word",
+      "a*b c",
+      [{ Text: "a" }, { Asterisk: {} }, { Text: "b" }, { Delimit: {} }, { Text: "c" }, { Delimit: {} }, { Eof: {} }],
+    ],
+  ])("delimit: %s", (_name, source, expected) => {
+    expect(JSON.parse(lex({ raw: [source] }))).toEqual(expected);
+  });
+
   describe("errors", async () => {
     // This is disallowed because the js object references get turned into special vars: $__bun_0, $__bun_1, etc.
     // this will break things inside of a quote.


### PR DESCRIPTION
### Problem
- `bun run rust:mordant` flags `bare_bool_args` at `src/shell_parser/parse.rs:2975`: `break_word_impl(add_delimiter: bool, in_normal_space: bool, in_operator: bool)`, and all five of its calls pass bare `true`/`false` (`break_word_impl(true, true, false)` at the space and newline sites says nothing about which flag is which).
- The body only ever reads `in_normal_space || in_operator`, so the last two flags are one flag, and no caller passes `add_delimiter = false` together with that flag. Three bools were encoding three cases.

### Fix
- `break_word` now takes `AddDelimiter::{No, AfterText, AfterWord}` directly; `break_word_impl`, the `break_word(bool)` wrapper and `break_word_operator()` are gone. The mapping is mechanical: `break_word(false)` -> `No`, `break_word(true)` -> `AfterText`, `break_word_operator()` and `break_word_impl(true, true, false)` -> `AfterWord` (32 call sites).
- The body is unchanged apart from testing the enum: `add_delimiter != No` where it tested `add_delimiter`, `== AfterWord` where it tested `in_normal_space || in_operator`, so the token stream is the same for every input.
- Drops the crate's only entry (`[bun_shell_parser]`) from `mordant-baseline.toml`, which is what regenerating the baseline produces for this crate.
- Adds a `delimit:` table to `test/js/bun/shell/lex.test.ts` pinning the token streams the three variants stand for: whitespace, newline, escaped newline and operators delimit a word that ended in `$VAR`, a closing quote or `}`; `;` and end of input do not; `$VAR` and `*` inside a word flush the text without a delimiter. The existing tests only covered a few of these placements. The table passes before and after this PR by design: there is no test that can fail without this change, because the change's only claim is that nothing observable moves (the differential run below is the evidence for that, and the dylint run is the evidence that the finding is gone). The table is there so the next change to `break_word` cannot move a delimiter unnoticed.
- Verified:
  - `bun bd test test/js/bun/shell/lex.test.ts test/js/bun/shell/parse.test.ts` (61 pass), `brace.test.ts` plus `shell-seq-condexpr`, `assignments-in-pipeline`, `env.positionals` (90 pass), `bunshell.test.ts` (422 pass; the `subshell > sharp` case timed out once on a cold `bun i` over the network and passes on rerun).
  - Dumped `shellInternals.lex` and `parse` output for 240 snippets covering every `break_word` site (whitespace, newline, escaped newline, every operator, `;`, `(`/`)`, `[[`/`]]`, `#`, fd redirects, `$VAR`, `$(..)`, backticks, quotes, `*`/`**`, braces, interpolated strings and objects) with a build of the parent commit and with this branch: byte-identical, including the seven inputs that throw.
  - `cargo dylint --all -p bun_shell_parser --no-deps` with the baseline entry removed: no findings on this branch; the same command on the parent commit reports the finding, so the entry removal is backed by the lint, not just by hand.
  - A full `bun run rust:mordant:baseline` on this branch produces this file minus two more entries that are already stale on main and unrelated to this change (`narrowed_two_ways:src/runtime/node/node_crypto_binding.rs`, cleared by #37648, and `always_unwrapped_option:src/install/PackageInstall.rs`). Left as they are to keep this PR to its one finding.

### Background
- The shell lexer accumulates the bytes of the current word in a string pool and, whenever it meets something that is not plain word text, calls `break_word` to push the accumulated bytes as a `Text` / `SingleQuotedText` / `DoubleQuotedText` token. A word can consist of several such tokens (`foo$BAR"baz"` is `Text`, `Var`, `DoubleQuotedText`); the parser knows where one word ends and the next begins by a `Delimit` token pushed after the word's last part.
- `AddDelimiter::No` is used when more of the same word follows (a variable, a glob, a brace, a quote), `AfterText` when the text just flushed ends the word, and `AfterWord` at whitespace and operators, where the word may already have ended in a token pushed earlier (`$FOO |`, `"a" b`), so a `Delimit` is pushed after that token too. Those three cases are exactly the flag combinations the old code used.
